### PR TITLE
Improve support for hlsl extensions

### DIFF
--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -176,6 +176,9 @@ enum {
 // size.
 static unsigned GetReplicatedVectorSize(llvm::CallInst *CI) {
   unsigned commonVectorSize = NO_COMMON_VECTOR_SIZE;
+  Type *RetTy = CI->getType();
+  if (RetTy->isVectorTy())
+    commonVectorSize = RetTy->getVectorNumElements();
   for (unsigned i = 0; i < CI->getNumArgOperands(); ++i) {
     Type *Ty = CI->getArgOperand(i)->getType();
     if (Ty->isVectorTy()) {
@@ -199,14 +202,11 @@ class ReplicatedFunctionTypeTranslator : public FunctionTypeTranslator {
 
     // Result should be vector or void.
     Type *RetTy = CI->getType();
+    if (!RetTy->isVoidTy() && !RetTy->isVectorTy())
+      return nullptr;
+
     if (RetTy->isVectorTy()) {
-      if (RetTy->getVectorNumElements() != commonVectorSize)
-        return nullptr;
       RetTy = RetTy->getVectorElementType();
-    }
-    else {
-      if (!RetTy->isVoidTy())
-        return nullptr;
     }
 
     return RetTy;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -1475,15 +1475,13 @@ static void AddHLSLIntrinsicAttr(FunctionDecl *FD, ASTContext &context,
                               LPCSTR tableName, LPCSTR lowering,
                               const HLSL_INTRINSIC *pIntrinsic) {
   unsigned opcode = (unsigned)pIntrinsic->Op;
-  if (HasUnsignedOpcode(opcode)) {
+  if (HasUnsignedOpcode(opcode) && IsBuiltinTable(tableName)) {
     QualType Ty = FD->getReturnType();
-    if (IsBuiltinTable(tableName)) {
-      IntrinsicOp intrinOp = static_cast<IntrinsicOp>(pIntrinsic->Op);
-      if (pIntrinsic->iOverloadParamIndex != -1) {
-        const FunctionProtoType *FT =
-            FD->getFunctionType()->getAs<FunctionProtoType>();
-        Ty = FT->getParamType(pIntrinsic->iOverloadParamIndex);
-      }
+    IntrinsicOp intrinOp = static_cast<IntrinsicOp>(pIntrinsic->Op);
+    if (pIntrinsic->iOverloadParamIndex != -1) {
+      const FunctionProtoType *FT =
+          FD->getFunctionType()->getAs<FunctionProtoType>();
+      Ty = FT->getParamType(pIntrinsic->iOverloadParamIndex);
     }
 
     // TODO: refine the code for getting element type


### PR DESCRIPTION
This commit improves the support for intrinsics added through
the IDxcIntrinsicTable interface:

    * Only rewrite unsigned opcode for builtin intrinsics
    * Allow replication to work when only vector is return value