### PR TITLE
Improve hctdb use for extension intrinsics

### DIFF
--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -183,6 +183,7 @@ class db_instrhelp_gen:
             "i32": "int32_t",
             "u32": "uint32_t"
             }
+        self.IsDxilOpFuncCallInst = "hlsl::OP::IsDxilOpFuncCallInst"
 
     def print_content(self):
         self.print_header()
@@ -238,7 +239,7 @@ class db_instrhelp_gen:
             print("  operator bool() const {")
             if i.is_dxil_op:
                 op_name = i.fully_qualified_name()
-                print("    return hlsl::OP::IsDxilOpFuncCallInst(Instr, %s);" % op_name)
+                print("    return %s(Instr, %s);" % (self.IsDxilOpFuncCallInst, op_name))
             else:
                 print("    return Instr->getOpcode() == llvm::Instruction::%s;" % i.name)
             print("  }")


### PR DESCRIPTION
Use a variable for the function used to check if an instruction is a dxil
intrinsic call rather than hardcoding the name. Allows us to override the
name if we want to use a different function. Useful for reusing hctdb
to generate code for extension intrinsics.