### PR TITLE
Modify dxc header generator to use unsigned char instead of BYTE

### DIFF
--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -506,7 +506,7 @@ void DxcContext::WriteHeader(IDxcBlobEncoding *pDisassembly, IDxcBlob *pCode,
   {
     std::string s;
     llvm::raw_string_ostream OS(s);
-    OS << "\r\nconst BYTE " << pVariableName << "[] = {";
+    OS << "\r\nconst unsigned char " << pVariableName << "[] = {";
     const uint8_t *pBytes = (const uint8_t *)pCode->GetBufferPointer();
     size_t len = pCode->GetBufferSize();
     s.reserve(100 + len * 6 + (len / 12) * 3); // rough estimate


### PR DESCRIPTION
Hello,
this is a very simple change, but using BYTE as alias type for generated code makes header file not compiling by default, switching to standard unsigned char instead fixes that issues.

Many Thanks
Julien