### PR TITLE
Treat half suffixes as floats

### DIFF
--- a/tools/clang/lib/Lex/LiteralSupport.cpp
+++ b/tools/clang/lib/Lex/LiteralSupport.cpp
@@ -581,6 +581,11 @@ NumericLiteralParser::NumericLiteralParser(StringRef TokSpelling,
     switch (*s) {
     case 'f':      // FP Suffix for "float"
     case 'F':
+// HLSL Change Starts
+// TODO : When we support true half type, these suffixes should be treated differently from f/F
+	case 'h':
+	case 'H':
+// HLSL Change Ends
       if (!isFPConstant) break;  // Error for integer constant.
       if (isFloat || isLong) break; // FF, LF invalid.
       isFloat = true;

--- a/tools/clang/lib/Lex/LiteralSupport.cpp
+++ b/tools/clang/lib/Lex/LiteralSupport.cpp
@@ -583,8 +583,8 @@ NumericLiteralParser::NumericLiteralParser(StringRef TokSpelling,
     case 'F':
 // HLSL Change Starts
 // TODO : When we support true half type, these suffixes should be treated differently from f/F
-	case 'h':
-	case 'H':
+    case 'h':
+    case 'H':
 // HLSL Change Ends
       if (!isFPConstant) break;  // Error for integer constant.
       if (isFloat || isLong) break; // FF, LF invalid.

--- a/tools/clang/test/CodeGenHLSL/literals_Mod.hlsl
+++ b/tools/clang/test/CodeGenHLSL/literals_Mod.hlsl
@@ -49,6 +49,8 @@ float test() :Foo {
   VERIFY_TYPES(uint64_t, overload1(2ULL));
   VERIFY_TYPES(int64_t, overload1(2ll));
   VERIFY_TYPES(int64_t, overload1(2LL));
+  VERIFY_TYPES(half, overload1(1.0h));
+  VERIFY_TYPES(half, overload1(1.0H));
 
   
   // Not ambiguous due to one literal and one specific:
@@ -60,6 +62,9 @@ float test() :Foo {
   VERIFY_TYPES(uint, overload2(2u, 2));
   VERIFY_TYPES(uint, overload2(2, 2ul));
   VERIFY_TYPES(uint, overload2(2ul, 2));
+  // TODO : half is converted to float. Must have overload function with half parameters when true half type is supported.
+  VERIFY_TYPES(half, overload2(1.0h, 1.0));
+  VERIFY_TYPES(half, overload2(1.0, 1.0H));
   
   VERIFY_TYPES(uint64_t, overload2(2, 2ull));
   VERIFY_TYPES(uint64_t, overload2(2ull, 2));
@@ -97,6 +102,8 @@ float test() :Foo {
   VERIFY_TYPES(uint, 2 * 2UL);
   VERIFY_TYPES(int64_t, 2 * 2LL);
   VERIFY_TYPES(uint64_t, 2 * 2ULL);
+  VERIFY_TYPES(half, 1.0 * 2 * 1.5h);
+  VERIFY_TYPES(half, 1.0 * 2 * 1.5H);
 
   // Specific width int forces float to be specific-width
   VERIFY_TYPES(float, 1.5 * 2 * 2L);

--- a/tools/clang/test/CodeGenHLSL/literals_Mod.hlsl
+++ b/tools/clang/test/CodeGenHLSL/literals_Mod.hlsl
@@ -49,8 +49,8 @@ float test() :Foo {
   VERIFY_TYPES(uint64_t, overload1(2ULL));
   VERIFY_TYPES(int64_t, overload1(2ll));
   VERIFY_TYPES(int64_t, overload1(2LL));
-  VERIFY_TYPES(half, overload1(1.0h));
-  VERIFY_TYPES(half, overload1(1.0H));
+  VERIFY_TYPES(float, overload1(1.0h));
+  VERIFY_TYPES(float, overload1(1.0H));
 
   
   // Not ambiguous due to one literal and one specific:
@@ -63,8 +63,8 @@ float test() :Foo {
   VERIFY_TYPES(uint, overload2(2, 2ul));
   VERIFY_TYPES(uint, overload2(2ul, 2));
   // TODO : half is converted to float. Must have overload function with half parameters when true half type is supported.
-  VERIFY_TYPES(half, overload2(1.0h, 1.0));
-  VERIFY_TYPES(half, overload2(1.0, 1.0H));
+  VERIFY_TYPES(float, overload2(1.0h, 1.0));
+  VERIFY_TYPES(float, overload2(1.0, 1.0H));
   
   VERIFY_TYPES(uint64_t, overload2(2, 2ull));
   VERIFY_TYPES(uint64_t, overload2(2ull, 2));
@@ -102,8 +102,8 @@ float test() :Foo {
   VERIFY_TYPES(uint, 2 * 2UL);
   VERIFY_TYPES(int64_t, 2 * 2LL);
   VERIFY_TYPES(uint64_t, 2 * 2ULL);
-  VERIFY_TYPES(half, 1.0 * 2 * 1.5h);
-  VERIFY_TYPES(half, 1.0 * 2 * 1.5H);
+  VERIFY_TYPES(float, 1.0 * 2 * 1.5h);
+  VERIFY_TYPES(float, 1.0 * 2 * 1.5H);
 
   // Specific width int forces float to be specific-width
   VERIFY_TYPES(float, 1.5 * 2 * 2L);


### PR DESCRIPTION
Treat h/H suffixes as f/F as "half" scalar type is converted to "float" type.
This should be changed in the future when we support true half types.