### PR TITLE
Enable Upper Case for Registers

### DIFF
--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -215,7 +215,8 @@ static void ParseRegisterNumberForHLSL(_In_z_ const char *name,
   DXASSERT_NOMSG(diagId != nullptr);
 
   if (*name != 'b' && *name != 'c' && *name != 'i' && *name != 's' &&
-      *name != 't' && *name != 'u') {
+      *name != 't' && *name != 'u' && *name != 'B' && *name != 'C' &&
+	  *name != 'I' && *name != 'S' && *name != 'T' && *name != 'U') {
     *diagId = diag::err_hlsl_unsupported_register_type;
     *registerType = 0;
     *registerNumber = 0;
@@ -250,7 +251,7 @@ void ParsePackSubcomponent(_In_z_ const char* name, _Out_ unsigned* subcomponent
 
   char registerType;
   ParseRegisterNumberForHLSL(name, &registerType, subcomponent, diagId);
-  if (registerType != 'c')
+  if (registerType != 'c' && registerType != 'C')
   {
     *diagId = diag::err_hlsl_unsupported_register_type;
         return;

--- a/tools/clang/lib/Parse/ParseHLSL.cpp
+++ b/tools/clang/lib/Parse/ParseHLSL.cpp
@@ -95,6 +95,21 @@ Decl *Parser::ParseConstBuffer(unsigned Context, SourceLocation &DeclEnd,
   Actions.ActOnStartHLSLBufferView();
   Parser::DeclGroupPtrTy dcl = ParseDeclGroup(PDS, Declarator::FileContext);
 
+  // Check if the register type is valid
+  NamedDecl *namedDecl = cast<NamedDecl>(dcl.get().getSingleDecl());
+  ArrayRef<hlsl::UnusualAnnotation*> annotations = namedDecl->getUnusualAnnotations();
+  for (hlsl::UnusualAnnotation* annotation : annotations) {
+    if (annotation->getKind() == hlsl::UnusualAnnotation::UnusualAnnotationKind::UA_RegisterAssignment) {
+        hlsl::RegisterAssignment *regAssignment = (hlsl::RegisterAssignment *)(annotation);
+        if (isCBuffer && regAssignment->RegisterType != 'b' && regAssignment->RegisterType != 'B') {
+            Diag(namedDecl->getLocation(), diag::err_hlsl_unsupported_cbuffer_register);
+        }
+        else if (!isCBuffer && regAssignment->RegisterType != 't' && regAssignment->RegisterType != 'T') {
+            Diag(namedDecl->getLocation(), diag::err_hlsl_unsupported_tbuffer_register);
+        }
+    }
+  }
+
   Decl *decl = Actions.ActOnHLSLBufferView(getCurScope(), BufferLoc, dcl, isCBuffer);
 
   return decl;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -8281,7 +8281,8 @@ void hlsl::DiagnoseRegisterType(
   case AR_BASIC_MIN16INT:
   case AR_BASIC_MIN16UINT:
     expected = "'b', 'c', or 'i'";
-    isValid = registerType == 'b' || registerType == 'c' || registerType == 'i';
+    isValid = registerType == 'b' || registerType == 'c' || registerType == 'i' ||
+		registerType == 'B' || registerType == 'C' || registerType == 'I';
     break;
 
   case AR_OBJECT_TEXTURE1D:
@@ -8294,7 +8295,8 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_TEXTURE2DMS:
   case AR_OBJECT_TEXTURE2DMS_ARRAY:
     expected = "'t' or 's'";
-    isValid = registerType == 't' || registerType == 's';
+    isValid = registerType == 't' || registerType == 's' ||
+		    registerType == 'T' || registerType == 'S';
     break;
 
   case AR_OBJECT_SAMPLER:
@@ -8304,12 +8306,13 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_SAMPLERCUBE:
   case AR_OBJECT_SAMPLERCOMPARISON:
     expected = "'s' or 't'";
-    isValid = registerType == 's' || registerType == 't';
+    isValid = registerType == 's' || registerType == 't' ||
+		registerType == 'S' || registerType == 'T';
     break;
 
   case AR_OBJECT_BUFFER:
     expected = "'t'";
-    isValid = registerType == 't';
+    isValid = registerType == 't' || registerType == 'T';
     break;
 
   case AR_OBJECT_POINTSTREAM:
@@ -8332,13 +8335,13 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_RWTEXTURE3D:
   case AR_OBJECT_RWBUFFER:
     expected = "'u'";
-    isValid = registerType == 'u';
+    isValid = registerType == 'u' || registerType == 'U';
     break;
 
   case AR_OBJECT_BYTEADDRESS_BUFFER:
   case AR_OBJECT_STRUCTURED_BUFFER:
     expected = "'t'";
-    isValid = registerType == 't';
+    isValid = registerType == 't' || registerType == 'T';
     break;
 
   case AR_OBJECT_CONSUME_STRUCTURED_BUFFER:
@@ -8348,16 +8351,16 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_RWSTRUCTURED_BUFFER_CONSUME:
   case AR_OBJECT_APPEND_STRUCTURED_BUFFER:
     expected = "'u'";
-    isValid = registerType == 'u';
+    isValid = registerType == 'u' || registerType == 'U';
     break;
 
   case AR_OBJECT_CONSTANT_BUFFER:
     expected = "'b'";
-    isValid = registerType == 'b';
+    isValid = registerType == 'b' || registerType == 'B';
     break;
   case AR_OBJECT_TEXTURE_BUFFER:
     expected = "'t'";
-    isValid = registerType == 't';
+    isValid = registerType == 't' || registerType == 'T';
     break;
 
   case AR_OBJECT_ROVBUFFER:
@@ -8369,7 +8372,7 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_ROVTEXTURE2D_ARRAY:
   case AR_OBJECT_ROVTEXTURE3D:
     expected = "'u'";
-    isValid = registerType == 'u';
+    isValid = registerType == 'u' || registerType == 'U';
     break;
 
   case AR_OBJECT_LEGACY_EFFECT:   // Used for all unsupported but ignored legacy effect types
@@ -9596,7 +9599,7 @@ Decl* Sema::ActOnStartHLSLBuffer(
     case hlsl::UnusualAnnotation::UA_RegisterAssignment: {
       hlsl::RegisterAssignment* registerAssignment = cast<hlsl::RegisterAssignment>(*unusualIter);
 
-      if (registerAssignment->RegisterType != expectedRegisterType) {
+      if (registerAssignment->RegisterType != expectedRegisterType && registerAssignment->RegisterType != toupper(expectedRegisterType)) {
         Diag(registerAssignment->Loc, cbuffer ? diag::err_hlsl_unsupported_cbuffer_register : 
                                                 diag::err_hlsl_unsupported_tbuffer_register);
       } else if (registerAssignment->ShaderProfile.size() > 0) {

--- a/tools/clang/test/CodeGenHLSL/uppercase-register1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/uppercase-register1.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK: dx.types.CBufRet
+// CHECK: Texture2D
+// CHECK: SamplerState
+// CHECK: RWStructuredBuffer
+
+struct Foo {
+  float4 g1;
+};
+
+struct Bar {
+  float2 g2;
+  float4 g3;
+};
+
+Texture2D<float4> tex1[10] : register(T0);
+SamplerState Samp : register(S0);
+ConstantBuffer<Foo> buf1[10] : register(B15, space4);
+RWStructuredBuffer<Bar> BarRW : register(U0, space1);
+
+[RootSignature ("DescriptorTable(SRV(t0, numDescriptors=10, space=0))," \
+                "StaticSampler(s0)," \
+                "DescriptorTable(CBV(b15, numDescriptors=15, space=4))," \
+                "UAV(u0, space=1)" \
+)]
+
+
+float4 main(int a : A) : SV_Target {
+  BarRW[0].g2 = buf1[a].g1.xy;
+  BarRW[0].g3 = buf1[a].g1.zyxw;
+  return tex1[0].Gather(Samp, float2(1,1)) + buf1[a].g1.xyzx;
+}

--- a/tools/clang/test/HLSL/packreg.hlsl
+++ b/tools/clang/test/HLSL/packreg.hlsl
@@ -7,20 +7,50 @@ float4 f_conflict : register(c0) : register(c1); // expected-error {{conflicting
 float4 f_no_conflict : register(vs, c0) : register(ps, c1);
 
 // fxc error X3530: invalid register specification, expected 'b' or 'c' binding
-cbuffer MySamplerBuffer : register(s20) // expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3530: invalid register specification, expected 'b' or 'c' binding}}
+cbuffer MySamplerBuffer : register(s20) // expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}}
 {
   float4 MySamplerBuffer_f4;
 }
 
-cbuffer CB1 : register(t1) { float c1; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3530: invalid register specification, expected 'b' or 'c' binding}} */
-cbuffer CB2 : register(c2) { float c2; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3530: invalid register specification, expected 'b' binding}} */
+struct Foo {
+  float g1;
+};
+
+cbuffer CB1 : register(t1) { float c1; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+cbuffer CB2 : register(c2) { float c2; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
 cbuffer CB3 : register(b3) { float c3; }
-cbuffer CB4 : register(u4) { float c4; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3530: invalid register specification, expected 'b' or 'c' binding}} */
+cbuffer CB4 : register(u4) { float c4; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB1 : register(t1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB2 : register(c1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB3 : register(b1);
+ConstantBuffer<Foo> D3D12CB4 : register(u1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+
+cbuffer CB5 : register(T1) { float c5; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+cbuffer CB6 : register(C2) { float c6; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+cbuffer CB7 : register(B3) { float c7; }
+cbuffer CB8 : register(U4) { float c8; }                    /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB5 : register(T1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB6 : register(C1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+ConstantBuffer<Foo> D3D12CB7 : register(B1);
+ConstantBuffer<Foo> D3D12CB8 : register(U1);                /* expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}} */
 
 tbuffer TB11 : register(t11) { float c11; }
-tbuffer TB12 : register(c12) { float c12; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: invalid register specification, expected 't' binding}} */
-tbuffer TB13 : register(b13) { float c13; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: invalid register specification, expected 't' binding}} */
-tbuffer TB14 : register(u14) { float c14; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: invalid register specification, expected 't' binding}} */
+tbuffer TB12 : register(c12) { float c12; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+tbuffer TB13 : register(b13) { float c13; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+tbuffer TB14 : register(u14) { float c14; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB11 : register(t11);
+TextureBuffer<Foo> D3D12TB12 : register(c11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB13 : register(b11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB14 : register(u11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+
+tbuffer TB15 : register(T11) { float c15; }
+tbuffer TB16 : register(C12) { float c16; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+tbuffer TB17 : register(B13) { float c17; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+tbuffer TB18 : register(U14) { float c18; }                 /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB15 : register(T11);
+TextureBuffer<Foo> D3D12TB16 : register(C11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB17 : register(B11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
+TextureBuffer<Foo> D3D12TB18 : register(U11);               /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3591: incorrect bind semantic}} */
 
 // fxc error X4567: maximum cbuffer exceeded. target has 14 slots, manual bind to slot 20 failed
 // We leave this bit of validation to the back-end, as this is presumably target-dependent.
@@ -42,7 +72,7 @@ cbuffer MyDupeBuffer2 : register(b0) : register(b2) // expected-error {{conflict
 }
 
 // fxc error X3530: Buffers may only be bound to one constant offset.
-cbuffer MyDupeBuffer : register(c0) : register(c1) // expected-error {{conflicting register semantics}} expected-error {{invalid register specification, expected 'b' binding}} expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3530: Buffers may only be bound to one constant offset.}} fxc-error {{X3530: invalid register specification, expected 'b' binding}}
+cbuffer MyDupeBuffer : register(c0) : register(c1) // expected-error {{conflicting register semantics}} expected-error {{invalid register specification, expected 'b' binding}} expected-error {{invalid register specification, expected 'b' binding}} fxc-error {{X3591: incorrect bind semantic}}
 {
   float4 Element101 : packoffset(c100) : MY_SEMANTIC : packoffset(c0) : packoffset(c2); // expected-warning {{packoffset is overridden by another packoffset annotation}} fxc-pass {{}}
 }
@@ -76,7 +106,7 @@ tbuffer OtherFloats
 sampler myvar_noparens : register; // expected-error {{expected '(' after 'register'}} fxc-error {{X3000: syntax error: unexpected token ';'}}
 sampler myvar_noclosebracket: register(ps, s[2); ]; // expected-error {{expected ']'}} expected-error {{expected unqualified-id}} expected-note {{to match this '['}} fxc-error {{X3000: syntax error: unexpected token ')'}}
 sampler myvar_norparen: register(ps, s[2]; ); // expected-error {{expected ')'}} expected-error {{expected unqualified-id}} fxc-error {{X3000: syntax error: unexpected token ';'}}
-sampler myVar : register(ps_6_0, s);
+sampler myVar : register(ps_5_0, s);
 /*verify-ast
   VarDecl <col:1, col:9> col:9 myVar 'sampler':'SamplerState'
   `-RegisterAssignment <col:17> register(ps_6_0, s0)
@@ -90,9 +120,9 @@ sampler myVar2_offset : register(vs, s2[8]);
 sampler myVar2_emptyu : register(vs, s2[]); // expected-error {{expected expression}} fxc-error {{X3000: syntax error: unexpected token ']'}}
 sampler myVar_2 : register(vs, s8);
 // fxc error: error X4017: cannot bind the same variable to multiple constants in the same constant bank
-sampler myVar3 : register(ps_6_0, s[0]) : register(vs, s[8]);
+sampler myVar3 : register(ps_5_0, s[0]) : register(vs, s[8]);
 // fxc error X3591: incorrect bind semantic
-sampler myVar4 : register(vs, t0);
+sampler myVar4 : register(vs, t0);          /* fxc-error {{X3591: incorrect bind semantic}} */
 sampler myVar65536 : register(vs, s65536);
 sampler myVar4294967296 : register(vs, s4294967296); // expected-error {{register number should be an integral numeric string}} fxc-pass {{}}
 sampler myVar281474976710656 : register(vs, s281474976710656); // expected-error {{register number should be an integral numeric string}} fxc-pass {{}}
@@ -117,8 +147,12 @@ RWStructuredBuffer<float4> myVar11_rw : register(ps, u);
 sampler myVar12 : register(ps, 3); // expected-error {{expected identifier}} fxc-error {{X3000: syntax error: unexpected integer constant}}
 // fxc error X3000: error X3530: register _ not valid
 sampler myVar13 : register(ps, _); // expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: sampler requires an 's' or 't' register}}
+sampler myVar14 : register(ps, T14);                        /* fxc-error {{X3591: incorrect bind semantic}} */
+sampler myVar15 : register(S15);
+sampler myVar16 : register(ps, A16); // expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: sampler requires an 's' or 't' register}}
+
 // fxc error X3091: packoffset is only allowed in a constant buffer
-sampler myVar14 : packoffset(c0); // expected-error {{packoffset is only allowed in a constant buffer}} fxc-error {{X3091: packoffset is only allowed in a constant buffer}}
+sampler myVar17 : packoffset(c0); // expected-error {{packoffset is only allowed in a constant buffer}} fxc-error {{X3091: packoffset is only allowed in a constant buffer}}
 sampler myVar_s : register(ps, s);
 Texture2D myVar_t : register(ps, t);
 Texture2D myVar_t_1 : register(ps, t[1]);
@@ -126,7 +160,7 @@ Texture2D myVar_t_1_1 : register(ps, t1[1]),
 /*verify-ast
   VarDecl <col:1, col:11> col:11 myVar_t_1_1 'Texture2D':'Texture2D<vector<float, 4> >'
   `-RegisterAssignment <col:25> register(ps, t2)
-  VarDecl <col:1, line:133:3> col:3 myVar_t_2_1 'Texture2D':'Texture2D<vector<float, 4> >'
+  VarDecl <col:1, line:147:3> col:3 myVar_t_2_1 'Texture2D':'Texture2D<vector<float, 4> >'
   |-RegisterAssignment <col:17> register(ps, t3)
   `-RegisterAssignment <col:39> register(vs, t0)
 */
@@ -161,15 +195,20 @@ sampler myVar_s1 : register(ps, s[1], space1);
   `-RegisterAssignment <col:20> register(ps, s1, space1)
 */
 // fxc error X3591: incorrect bind semantic
-sampler myVar_sz : register(ps, s[1], spacez); // expected-error {{space number should be an integral numeric string}} fxc-pass {{}}
+sampler myVar_sz : register(ps, s[1], spacez); // expected-error {{space number should be an integral numeric string}} fxc-error {{X3591: incorrect bind semantic}}
 
 // Legal in fxc due to compatibility mode:
-sampler mySamp_t1 : register(t1);
+sampler mySamp_t1 : register(t1);              /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Buffer buff_t2 : register(t2);
 Buffer buff_s2 : register(s2);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
 Buffer buff_u2 : register(u2);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
 Buffer buff_b2 : register(b2);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
+
+Buffer buff_t3 : register(T3);
+Buffer buff_s3 : register(S3);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
+Buffer buff_u3 : register(U3);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
+Buffer buff_b3 : register(B3);  // expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}}
 
 RasterizerOrderedBuffer<float4> ROVBuff_u1 : register(u1);
 RasterizerOrderedBuffer<float4> ROVBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -177,53 +216,107 @@ RasterizerOrderedBuffer<float4> ROVBuff_f1 : register(f1);    /* expected-error 
 RasterizerOrderedBuffer<float4> ROVBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedBuffer<float4> ROVBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RasterizerOrderedBuffer<float4> ROVBuff_u2 : register(U2);
+RasterizerOrderedBuffer<float4> ROVBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedBuffer<float4> ROVBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedBuffer<float4> ROVBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedBuffer<float4> ROVBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 Texture1D T1D_t1 : register(t1);
 Texture1D T1D_u1 : register(u1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture1D T1D_f1 : register(f1);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture1D T1D_b1 : register(b1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture1D T1D_s1 : register(s1);
+Texture1D T1D_s1 : register(s1);                            /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture1D T1D_t2 : register(T2);
+Texture1D T1D_u2 : register(U2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1D T1D_f2 : register(F2);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1D T1D_b2 : register(B2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1D T1D_s2 : register(S2);                            /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Texture1DArray T1DArray_t1 : register(t1);
 Texture1DArray T1DArray_u1 : register(u1);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture1DArray T1DArray_f1 : register(f1);                  /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture1DArray T1DArray_b1 : register(b1);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture1DArray T1DArray_s1 : register(s1);
+Texture1DArray T1DArray_s1 : register(s1);                  /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture1DArray T1DArray_t2 : register(T2);
+Texture1DArray T1DArray_u2 : register(U2);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1DArray T1DArray_f2 : register(F2);                  /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1DArray T1DArray_b2 : register(B2);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture1DArray T1DArray_s2 : register(S2);                  /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Texture2D T2D_t1 : register(t1);
 Texture2D T2D_u1 : register(u1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2D T2D_f1 : register(f1);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2D T2D_b1 : register(b1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture2D T2D_s1 : register(s1);
+Texture2D T2D_s1 : register(s1);                            /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture2D T2D_t2 : register(T2);
+Texture2D T2D_u2 : register(U2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2D T2D_f2 : register(F2);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2D T2D_b2 : register(B2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2D T2D_s2 : register(S2);                            /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Texture2DMS<float4, 4> T2DMS_t1 : register(t1);
 Texture2DMS<float4, 4> T2DMS_u1 : register(u1);             /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2DMS<float4, 4> T2DMS_f1 : register(f1);             /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2DMS<float4, 4> T2DMS_b1 : register(b1);             /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture2DMS<float4, 4> T2DMS_s1 : register(s1);
+Texture2DMS<float4, 4> T2DMS_s1 : register(s1);             /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture2DMS<float4, 4> T2DMS_t2 : register(T2);
+Texture2DMS<float4, 4> T2DMS_u2 : register(U2);             /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DMS<float4, 4> T2DMS_f2 : register(F2);             /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DMS<float4, 4> T2DMS_b2 : register(B2);             /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DMS<float4, 4> T2DMS_s2 : register(S2);             /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Texture2DArray T2DArray_t1 : register(t1);
 Texture2DArray T2DArray_u1 : register(u1);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2DArray T2DArray_f1 : register(f1);                  /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture2DArray T2DArray_b1 : register(b1);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture2DArray T2DArray_s1 : register(s1);
+Texture2DArray T2DArray_s1 : register(s1);                  /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture2DArray T2DArray_t2 : register(T2);
+Texture2DArray T2DArray_u2 : register(U2);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DArray T2DArray_f2 : register(F2);                  /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DArray T2DArray_b2 : register(B2);                  /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture2DArray T2DArray_s2 : register(S2);                  /* fxc-error {{X3591: incorrect bind semantic}} */
 
 Texture3D T3D_t1 : register(t1);
 Texture3D T3D_u1 : register(u1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture3D T3D_f1 : register(f1);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 Texture3D T3D_b1 : register(b1);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-Texture3D T3D_s1 : register(s1);
+Texture3D T3D_s1 : register(s1);                            /* fxc-error {{X3591: incorrect bind semantic}} */
+
+Texture3D T3D_t2 : register(T2);
+Texture3D T3D_u2 : register(U2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture3D T3D_f2 : register(F2);                            /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture3D T3D_b2 : register(B2);                            /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+Texture3D T3D_s2 : register(S2);                            /* fxc-error {{X3591: incorrect bind semantic}} */
 
 TextureCube TCube_t1 : register(t1);
 TextureCube TCube_u1 : register(u1);                        /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 TextureCube TCube_f1 : register(f1);                        /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 TextureCube TCube_b1 : register(b1);                        /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-TextureCube TCube_s1 : register(s1);
+TextureCube TCube_s1 : register(s1);                        /* fxc-error {{X3591: incorrect bind semantic}} */
+
+TextureCube TCube_t2 : register(T2);
+TextureCube TCube_u2 : register(U2);                        /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCube TCube_f2 : register(F2);                        /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCube TCube_b2 : register(B2);                        /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCube TCube_s2 : register(S2);                        /* fxc-error {{X3591: incorrect bind semantic}} */
 
 TextureCubeArray TCubeArray_t1 : register(t1);
 TextureCubeArray TCubeArray_u1 : register(u1);              /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 TextureCubeArray TCubeArray_f1 : register(f1);              /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
 TextureCubeArray TCubeArray_b1 : register(b1);              /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
-TextureCubeArray TCubeArray_s1 : register(s1);
+TextureCubeArray TCubeArray_s1 : register(s1);              /* fxc-error {{X3591: incorrect bind semantic}} */
+
+TextureCubeArray TCubeArray_t2 : register(T2);
+TextureCubeArray TCubeArray_u2 : register(U2);              /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCubeArray TCubeArray_f2 : register(F2);              /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCubeArray TCubeArray_b2 : register(B2);              /* expected-error {{invalid register specification, expected 't' or 's' binding}} fxc-error {{X3530: texture requires a 't' or 's' register}} */
+TextureCubeArray TCubeArray_s2 : register(S2);              /* fxc-error {{X3591: incorrect bind semantic}} */
 
 RWTexture1D<float4> RWT1D_u1 : register(u1);
 RWTexture1D<float4> RWT1D_t1 : register(t1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -231,11 +324,23 @@ RWTexture1D<float4> RWT1D_f1 : register(f1);                /* expected-error {{
 RWTexture1D<float4> RWT1D_b1 : register(b1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture1D<float4> RWT1D_s1 : register(s1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RWTexture1D<float4> RWT1D_u2 : register(U2);
+RWTexture1D<float4> RWT1D_t2 : register(T2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1D<float4> RWT1D_f2 : register(F2);                /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1D<float4> RWT1D_b2 : register(B2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1D<float4> RWT1D_s2 : register(S2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RWTexture1DArray<float4> RWT1DArray_u1 : register(u1);
 RWTexture1DArray<float4> RWT1DArray_t1 : register(t1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture1DArray<float4> RWT1DArray_f1 : register(f1);      /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture1DArray<float4> RWT1DArray_b1 : register(b1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture1DArray<float4> RWT1DArray_s1 : register(s1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RWTexture1DArray<float4> RWT1DArray_u2 : register(U2);
+RWTexture1DArray<float4> RWT1DArray_t2 : register(T2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1DArray<float4> RWT1DArray_f2 : register(F2);      /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1DArray<float4> RWT1DArray_b2 : register(B2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture1DArray<float4> RWT1DArray_s2 : register(S2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 RWTexture2D<float4> RWT2D_u1 : register(u1);
 RWTexture2D<float4> RWT2D_t1 : register(t1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -243,11 +348,23 @@ RWTexture2D<float4> RWT2D_f1 : register(f1);                /* expected-error {{
 RWTexture2D<float4> RWT2D_b1 : register(b1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture2D<float4> RWT2D_s1 : register(s1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RWTexture2D<float4> RWT2D_u2 : register(U2);
+RWTexture2D<float4> RWT2D_t2 : register(T2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2D<float4> RWT2D_f2 : register(F2);                /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2D<float4> RWT2D_b2 : register(B2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2D<float4> RWT2D_s2 : register(S2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RWTexture2DArray<float4> RWT2DArray_u1 : register(u1);
 RWTexture2DArray<float4> RWT2DArray_t1 : register(t1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture2DArray<float4> RWT2DArray_f1 : register(f1);      /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture2DArray<float4> RWT2DArray_b1 : register(b1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture2DArray<float4> RWT2DArray_s1 : register(s1);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RWTexture2DArray<float4> RWT2DArray_u2 : register(U2);
+RWTexture2DArray<float4> RWT2DArray_t2 : register(T2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2DArray<float4> RWT2DArray_f2 : register(F2);      /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2DArray<float4> RWT2DArray_b2 : register(B2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture2DArray<float4> RWT2DArray_s2 : register(S2);      /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 RWTexture3D<float4> RWT3D_u1 : register(u1);
 RWTexture3D<float4> RWT3D_t1 : register(t1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -255,11 +372,23 @@ RWTexture3D<float4> RWT3D_f1 : register(f1);                /* expected-error {{
 RWTexture3D<float4> RWT3D_b1 : register(b1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWTexture3D<float4> RWT3D_s1 : register(s1);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RWTexture3D<float4> RWT3D_u2 : register(U2);
+RWTexture3D<float4> RWT3D_t2 : register(T2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture3D<float4> RWT3D_f2 : register(F2);                /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture3D<float4> RWT3D_b2 : register(B2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWTexture3D<float4> RWT3D_s2 : register(S2);                /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RasterizerOrderedTexture1D<float4> ROVT1D_u1 : register(u1);
 RasterizerOrderedTexture1D<float4> ROVT1D_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture1D<float4> ROVT1D_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture1D<float4> ROVT1D_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture1D<float4> ROVT1D_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RasterizerOrderedTexture1D<float4> ROVT1D_u2 : register(U2);
+RasterizerOrderedTexture1D<float4> ROVT1D_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1D<float4> ROVT1D_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1D<float4> ROVT1D_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1D<float4> ROVT1D_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 RasterizerOrderedTexture1DArray<float4> ROVT1DArray_u1 : register(u1);
 RasterizerOrderedTexture1DArray<float4> ROVT1DArray_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -267,11 +396,23 @@ RasterizerOrderedTexture1DArray<float4> ROVT1DArray_f1 : register(f1);    /* exp
 RasterizerOrderedTexture1DArray<float4> ROVT1DArray_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture1DArray<float4> ROVT1DArray_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RasterizerOrderedTexture1DArray<float4> ROVT1DArray_u2 : register(U2);
+RasterizerOrderedTexture1DArray<float4> ROVT1DArray_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1DArray<float4> ROVT1DArray_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1DArray<float4> ROVT1DArray_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture1DArray<float4> ROVT1DArray_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RasterizerOrderedTexture2D<float4> ROVT2D_u1 : register(u1);
 RasterizerOrderedTexture2D<float4> ROVT2D_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture2D<float4> ROVT2D_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture2D<float4> ROVT2D_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture2D<float4> ROVT2D_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RasterizerOrderedTexture2D<float4> ROVT2D_u2 : register(U2);
+RasterizerOrderedTexture2D<float4> ROVT2D_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2D<float4> ROVT2D_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2D<float4> ROVT2D_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2D<float4> ROVT2D_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 RasterizerOrderedTexture2DArray<float4> ROVT2DArray_u1 : register(u1);
 RasterizerOrderedTexture2DArray<float4> ROVT2DArray_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -279,11 +420,23 @@ RasterizerOrderedTexture2DArray<float4> ROVT2DArray_f1 : register(f1);    /* exp
 RasterizerOrderedTexture2DArray<float4> ROVT2DArray_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture2DArray<float4> ROVT2DArray_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RasterizerOrderedTexture2DArray<float4> ROVT2DArray_u2 : register(U2);
+RasterizerOrderedTexture2DArray<float4> ROVT2DArray_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2DArray<float4> ROVT2DArray_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2DArray<float4> ROVT2DArray_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture2DArray<float4> ROVT2DArray_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RasterizerOrderedTexture3D<float4> ROVT3D_u1 : register(u1);
 RasterizerOrderedTexture3D<float4> ROVT3D_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture3D<float4> ROVT3D_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture3D<float4> ROVT3D_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedTexture3D<float4> ROVT3D_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RasterizerOrderedTexture3D<float4> ROVT3D_u2 : register(U2);
+RasterizerOrderedTexture3D<float4> ROVT3D_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture3D<float4> ROVT3D_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture3D<float4> ROVT3D_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedTexture3D<float4> ROVT3D_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 ByteAddressBuffer ByteAddressBuff_t1 : register(t1);
 ByteAddressBuffer ByteAddressBuff_u1 : register(u1);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
@@ -291,11 +444,23 @@ ByteAddressBuffer ByteAddressBuff_f1 : register(f1);        /* expected-error {{
 ByteAddressBuffer ByteAddressBuff_b1 : register(b1);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
 ByteAddressBuffer ByteAddressBuff_s1 : register(s1);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
 
+ByteAddressBuffer ByteAddressBuff_t2 : register(T2);
+ByteAddressBuffer ByteAddressBuff_u2 : register(U2);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+ByteAddressBuffer ByteAddressBuff_f2 : register(F2);        /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: buffer requires a 't' register}} */
+ByteAddressBuffer ByteAddressBuff_b2 : register(B2);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+ByteAddressBuffer ByteAddressBuff_s2 : register(S2);        /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+
 RWByteAddressBuffer RWByteAddressBuff_u1 : register(u1);
 RWByteAddressBuffer RWByteAddressBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWByteAddressBuffer RWByteAddressBuff_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWByteAddressBuffer RWByteAddressBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWByteAddressBuffer RWByteAddressBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RWByteAddressBuffer RWByteAddressBuff_u2 : register(U2);
+RWByteAddressBuffer RWByteAddressBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWByteAddressBuffer RWByteAddressBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWByteAddressBuffer RWByteAddressBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWByteAddressBuffer RWByteAddressBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_u1 : register(u1);
 RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -303,11 +468,23 @@ RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_f1 : register(f1);    /* e
 RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_u2 : register(U2);
+RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedByteAddressBuffer ROVByteAddressBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 StructuredBuffer<float4> StructuredBuff_t1 : register(t1);
 StructuredBuffer<float4> StructuredBuff_u1 : register(u1);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
 StructuredBuffer<float4> StructuredBuff_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: buffer requires a 't' register}} */
 StructuredBuffer<float4> StructuredBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
 StructuredBuffer<float4> StructuredBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+
+StructuredBuffer<float4> StructuredBuff_t2 : register(T2);
+StructuredBuffer<float4> StructuredBuff_u2 : register(U2);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+StructuredBuffer<float4> StructuredBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: buffer requires a 't' register}} */
+StructuredBuffer<float4> StructuredBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
+StructuredBuffer<float4> StructuredBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 't' binding}} fxc-error {{X3530: buffer requires a 't' register}} */
 
 RWStructuredBuffer<float4> RWStructuredBuff_u1 : register(u1);
 RWStructuredBuffer<float4> RWStructuredBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -315,11 +492,23 @@ RWStructuredBuffer<float4> RWStructuredBuff_f1 : register(f1);    /* expected-er
 RWStructuredBuffer<float4> RWStructuredBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RWStructuredBuffer<float4> RWStructuredBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+RWStructuredBuffer<float4> RWStructuredBuff_u2 : register(U2);
+RWStructuredBuffer<float4> RWStructuredBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWStructuredBuffer<float4> RWStructuredBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWStructuredBuffer<float4> RWStructuredBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RWStructuredBuffer<float4> RWStructuredBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_u1 : register(u1);
 RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_u2 : register(U2);
+RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+RasterizerOrderedStructuredBuffer<float4> ROVStructuredBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_u1 : register(u1);
 ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
@@ -327,11 +516,23 @@ ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_f1 : register(f1);    /* e
 ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
+ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_u2 : register(U2);
+ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+ConsumeStructuredBuffer<float4> ConsumeStructuredBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
 AppendStructuredBuffer<float4> AppendStructuredBuff_u1 : register(u1);
 AppendStructuredBuffer<float4> AppendStructuredBuff_t1 : register(t1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 AppendStructuredBuffer<float4> AppendStructuredBuff_f1 : register(f1);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
 AppendStructuredBuffer<float4> AppendStructuredBuff_b1 : register(b1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 AppendStructuredBuffer<float4> AppendStructuredBuff_s1 : register(s1);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+
+AppendStructuredBuffer<float4> AppendStructuredBuff_u2 : register(U2);
+AppendStructuredBuffer<float4> AppendStructuredBuff_t2 : register(T2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+AppendStructuredBuffer<float4> AppendStructuredBuff_f2 : register(F2);    /* expected-error {{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}} fxc-error {{X3530: UAV requires a 'u' register}} */
+AppendStructuredBuffer<float4> AppendStructuredBuff_b2 : register(B2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
+AppendStructuredBuffer<float4> AppendStructuredBuff_s2 : register(S2);    /* expected-error {{invalid register specification, expected 'u' binding}} fxc-error {{X3530: UAV requires a 'u' register}} */
 
 cbuffer MyBuffer
 {
@@ -348,6 +549,24 @@ cbuffer MyBuffer
     VarDecl <col:3, col:70> col:70 Element6 'float4':'vector<float, 4>'
     |-ConstantPacking <col:81> packoffset(c12.x)
     `-SemanticDecl <col:99> "MY_SEMANTIC2"
+  */
+}
+
+cbuffer MyBuffer2
+{
+  float4 Element7 : packoffset(C2);
+  float1 Element8 : packoffset(C3);
+  float1 Element9 : packoffset(C3.y);
+  float4 Element10 : packoffset(C20) : packoffset(C20);
+  float4 Element11 : packoffset(C20) : MY_SEMANTIC : packoffset(C21), Element12 : packoffset(C22) : MY_SEMANTIC2; // expected-warning {{packoffset is overridden by another packoffset annotation}} fxc-pass {{}}
+  /*verify-ast
+    VarDecl <col:3, col:10> col:10 Element11 'float4':'vector<float, 4>'
+    |-ConstantPacking <col:22> packoffset(c20.x)
+    |-SemanticDecl <col:40> "MY_SEMANTIC"
+    `-ConstantPacking <col:54> packoffset(c21.x)
+    VarDecl <col:3, col:71> col:71 Element12 'float4':'vector<float, 4>'
+    |-ConstantPacking <col:83> packoffset(c22.x)
+    `-SemanticDecl <col:101> "MY_SEMANTIC2"
   */
 }
 
@@ -374,26 +593,26 @@ cbuffer Parameters : register(b0)
 
 cbuffer cbPerObject : register(b0)
 {
-  float4		g_vObjectColor			: packoffset(c0);
+  float4    g_vObjectColor      : packoffset(c0);
 };
 
 cbuffer cbPerFrame : register(b1)
 {
-  float3		g_vLightDir				: packoffset(c0);
-  float		g_fAmbient : packoffset(c0.w);
+  float3    g_vLightDir       : packoffset(c0);
+  float   g_fAmbient : packoffset(c0.w);
 };
 
 // Nesting case
 cbuffer OuterBuffer : register(b3) {
 /*verify-ast
-  HLSLBufferDecl <col:1, line:406:1> line:390:9 cbuffer OuterBuffer
+  HLSLBufferDecl <col:1, line:602:1> line:586:9 cbuffer OuterBuffer
   |-RegisterAssignment <col:23> register(b3)
-  |-VarDecl <line:401:3, col:9> col:9 used OuterItem0 'float'
-  |-HLSLBufferDecl parent <line:402:3, line:404:3> line:402:11 cbuffer InnerBuffer
+  |-VarDecl <line:597:3, col:9> col:9 used OuterItem0 'float'
+  |-HLSLBufferDecl parent <line:598:3, line:600:3> line:598:11 cbuffer InnerBuffer
   | |-RegisterAssignment <col:25> register(b4)
-  | `-VarDecl <line:403:5, col:11> col:11 used InnerItem0 'float'
-  |-EmptyDecl <line:404:4> col:4
-  `-VarDecl <line:405:3, col:9> col:9 used OuterItem1 'float'
+  | `-VarDecl <line:599:5, col:11> col:11 used InnerItem0 'float'
+  |-EmptyDecl <line:600:4> col:4
+  `-VarDecl <line:601:3, col:9> col:9 used OuterItem1 'float'
 */
   float OuterItem0;
   cbuffer InnerBuffer : register(b4) {
@@ -405,7 +624,7 @@ cbuffer OuterBuffer : register(b3) {
 //--------------------------------------------------------------------------------------
 // Textures and Samplers
 //--------------------------------------------------------------------------------------
-Texture2D	g_txDiffuse : register(t0);
+Texture2D g_txDiffuse : register(t0);
 SamplerState g_samLinear : register(s0);
 
 float2 f2() {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -524,6 +524,7 @@ public:
   TEST_METHOD(CodeGenUintSample)
   TEST_METHOD(CodeGenUmaxObjectAtomic)
   TEST_METHOD(CodeGenUpdateCounter)
+  TEST_METHOD(CodeGenUpperCaseRegister1);
   TEST_METHOD(CodeGenVcmp)
   TEST_METHOD(CodeGenVec_Comp_Arg)
   TEST_METHOD(CodeGenWave)
@@ -2745,6 +2746,10 @@ TEST_F(CompilerTest, CodeGenUmaxObjectAtomic) {
 
 TEST_F(CompilerTest, CodeGenUpdateCounter) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\updateCounter.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenUpperCaseRegister1) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\uppercase-register1.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenVcmp) {

--- a/utils/hct/VerifierHelper.py
+++ b/utils/hct/VerifierHelper.py
@@ -552,8 +552,9 @@ class File(object):
 ##        result = os.system('%s\\clang.exe -cc1 -fsyntax-only -ast-dump %s 1>"%s.ast_dump" 2>"%s.log"' %
         result = os.system('%s\\dxc.exe -ast-dump %s -E main -T ps_5_0 1>"%s.ast_dump" 2>"%s.log"' %
                            (HlslBinDir, self.filename, temp_filename, temp_filename))
-        if result or not os.path.isfile(temp_filename+'.ast_dump'):
-            print 'ast-dump failed and exited with error code %d, see log:\n  %s.log' % (result, temp_filename)
+        # dxc dumps ast even if there exists any syntax error. If there is any error, dxc returns some nonzero errorcode.
+        if not os.path.isfile(temp_filename+'.ast_dump'):
+            print 'ast-dump failed, see log:\n  %s.log' % (temp_filename)
             return
 ##        elif result:
 ##            print 'ast-dump succeeded, but exited with error code %d, see log:\n  %s.log' % (result, temp_filename)

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -45,6 +45,13 @@ if %errorlevel% neq 0 (
   exit /b 1
 )
 
+dxc.exe /T ps_6_0 smoke.hlsl /ast-dump 1>nul
+if %errorlevel% neq 0 (
+  echo Failed - %CD%\dxc.exe /T ps_6_0 smoke.hlsl /ast-dump
+  call :cleanup 2>nul
+  exit /b 1
+)
+
 dxc.exe /T ps_6_0 smoke.hlsl /Dcheck_warning 1>nul 2>smoke.warning.txt
 if %errorlevel% neq 0 (
   echo Failed - %CD%\dxc.exe /T ps_6_0 smoke.hlsl /Dcheck_warning


### PR DESCRIPTION
 - enable upper case for valid registers ('B', 'C', 'I', 'S', 'T', 'U')
 - fix VerifyHelper.py to output ast when expected errors are present
 - fix buffer view register validation check