### PR TITLE
Support Unsigned for shorthand vectors/matrices

### DIFF
--- a/lib/HLSL/DxilCompType.cpp
+++ b/lib/HLSL/DxilCompType.cpp
@@ -281,7 +281,7 @@ const char *CompType::GetName() const {
 
 static const char *s_TypeKindHLSLNames[(unsigned)CompType::Kind::LastEntry] = {
   "unknown",
-  "bool", "min16i", "min16i", "int", "uint", "int64_t", "uint64_t",
+  "bool", "min16i", "min16ui", "int", "uint", "int64_t", "uint64_t",
   "min16f", "float", "double",
   "snorm_min16f", "unorm_min16f", "snorm_float", "unorm_float", "snorm_double", "unorm_double",
 };

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -66,6 +66,8 @@ enum HLSLScalarType {
   HLSLScalarType_uint64,
 };
 
+HLSLScalarType MakeUnsigned(HLSLScalarType T);
+
 static const HLSLScalarType HLSLScalarType_minvalid = HLSLScalarType_bool;
 static const HLSLScalarType HLSLScalarType_max = HLSLScalarType_uint64;
 static const size_t HLSLScalarTypeCount = static_cast<size_t>(HLSLScalarType_max) + 1;

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7227,6 +7227,7 @@ def warn_sync_fetch_and_nand_semantics_change : Warning<
   InGroup<DiagGroup<"sync-fetch-and-nand-semantics-changed">>;
 
 // Type
+def err_sema_invalid_sign_spec : Error<"'%0' cannot be signed or unsigned">;
 def ext_invalid_sign_spec : Extension<"'%0' cannot be signed or unsigned">;
 def warn_receiver_forward_class : Warning<
     "receiver %0 is a forward class and corresponding @interface may not exist">,

--- a/tools/clang/include/clang/Sema/DeclSpec.h
+++ b/tools/clang/include/clang/Sema/DeclSpec.h
@@ -588,15 +588,10 @@ public:
 
   /// \brief Return true if any type-specifier has been found.
   bool hasTypeSpecifier() const {
-    // HLSL Note: snorm and unorm are not, by themselves, good enough to generate a type
-    // (unlike, for example, 'unsigned' in 'unsigned i = 0;').
-    // If they were, the parser would need to be updated, because typedefs will not work
-    // correctly (so, unsigned min16uint foo fails because min16uint isn't a keyword, and
-    // it will try to parse it as the identifier name).
-    return getTypeSpecType() != DeclSpec::TST_unspecified ||
-           getTypeSpecWidth() != DeclSpec::TSW_unspecified ||
-           getTypeSpecComplex() != DeclSpec::TSC_unspecified ||
-           getTypeSpecSign() != DeclSpec::TSS_unspecified;
+      return getTypeSpecType() != DeclSpec::TST_unspecified ||
+            getTypeSpecWidth() != DeclSpec::TSW_unspecified ||
+          getTypeSpecComplex() != DeclSpec::TSC_unspecified;
+           //getTypeSpecSign() != DeclSpec::TSS_unspecified; // HLSL Change - unsigned is not a complete type specifier.
   }
 
   /// \brief Return a bitmask of which flavors of specifiers this

--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -239,4 +239,13 @@ clang::QualType CheckVectorConditional(
 
 }
 
+// This function reads the given declaration TSS and returns the corresponding parsedType with the
+// corresponding type. Replaces the given parsed type with the new type
+clang::ParsedType ApplyTypeSpecSignToParsedType(
+    _In_ clang::Sema* self,
+    _In_ clang::ParsedType &parsedType,
+    _In_ clang::TypeSpecifierSign TSS,
+    _In_ clang::SourceLocation Loc
+);
+
 #endif

--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -241,9 +241,9 @@ clang::QualType CheckVectorConditional(
 
 // This function reads the given declaration TSS and returns the corresponding parsedType with the
 // corresponding type. Replaces the given parsed type with the new type
-clang::ParsedType ApplyTypeSpecSignToParsedType(
+clang::QualType ApplyTypeSpecSignToParsedType(
     _In_ clang::Sema* self,
-    _In_ clang::ParsedType &parsedType,
+    _In_ clang::QualType &type,
     _In_ clang::TypeSpecifierSign TSS,
     _In_ clang::SourceLocation Loc
 );

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -426,4 +426,16 @@ hlsl::ParameterModifier ParamModFromAttrs(llvm::ArrayRef<InheritableAttr *> attr
   return ParameterModifier::FromInOut(isIn, isOut);
 }
 
+HLSLScalarType MakeUnsigned(HLSLScalarType T) {
+    switch (T) {
+    case HLSLScalarType_int:
+        return HLSLScalarType_uint;
+    case HLSLScalarType_int_min16:
+        return HLSLScalarType_uint_min16;
+    case HLSLScalarType_int64:
+        return HLSLScalarType_uint64;
+    }
+    return T;
+}
+
 }

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -3485,9 +3485,10 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
           isConstructorDeclarator(/*Unqualified*/true))
         goto DoneWithDeclSpec;
       // HLSL Change start - modify TypeRep for unsigned vectors/matrix
-      ParsedType newTypeRep = ApplyTypeSpecSignToParsedType(&Actions, TypeRep, DS.getTypeSpecSign(), Loc);
+      QualType qt = TypeRep.get();
+      QualType newType = ApplyTypeSpecSignToParsedType(&Actions, qt, DS.getTypeSpecSign(), Loc);
       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_typename, Loc, PrevSpec,
-                                     DiagID, newTypeRep, Policy);
+                                     DiagID, ParsedType::make(newType), Policy);
       // HLSL Change end
       if (isInvalid)
         break;

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -3484,9 +3484,11 @@ void Parser::ParseDeclarationSpecifiers(DeclSpec &DS,
           Actions.isCurrentClassName(*Tok.getIdentifierInfo(), getCurScope()) &&
           isConstructorDeclarator(/*Unqualified*/true))
         goto DoneWithDeclSpec;
-
+      // HLSL Change start - modify TypeRep for unsigned vectors/matrix
+      ParsedType newTypeRep = ApplyTypeSpecSignToParsedType(&Actions, TypeRep, DS.getTypeSpecSign(), Loc);
       isInvalid = DS.SetTypeSpecType(DeclSpec::TST_typename, Loc, PrevSpec,
-                                     DiagID, TypeRep, Policy);
+                                     DiagID, newTypeRep, Policy);
+      // HLSL Change end
       if (isInvalid)
         break;
 

--- a/tools/clang/lib/Sema/DeclSpec.cpp
+++ b/tools/clang/lib/Sema/DeclSpec.cpp
@@ -1036,6 +1036,10 @@ void DeclSpec::Finish(DiagnosticsEngine &D, Preprocessor &PP, const PrintingPoli
   // signed/unsigned are only valid with int/char/wchar_t.
   if (TypeSpecSign != TSS_unspecified) {
     // HLSL Change starts - signed/unsigned are not complete type specifiers.
+    #if 0
+    if (TypeSpecType == TST_unspecified)
+      TypeSpecType = TST_int;
+    #endif
     // shorthand vectors and matrices can have signed/unsigned specifiers.
     // If other typenames are used with signed/unsigned, it is already diagnosed by hlsl external source
     if (TypeSpecType != TST_int && TypeSpecType != TST_int128 &&

--- a/tools/clang/lib/Sema/DeclSpec.cpp
+++ b/tools/clang/lib/Sema/DeclSpec.cpp
@@ -1035,15 +1035,18 @@ void DeclSpec::Finish(DiagnosticsEngine &D, Preprocessor &PP, const PrintingPoli
 
   // signed/unsigned are only valid with int/char/wchar_t.
   if (TypeSpecSign != TSS_unspecified) {
-    if (TypeSpecType == TST_unspecified)
-      TypeSpecType = TST_int; // unsigned -> unsigned int, signed -> signed int.
-    else if (TypeSpecType != TST_int  && TypeSpecType != TST_int128 &&
-             TypeSpecType != TST_char && TypeSpecType != TST_wchar) {
+    // HLSL Change starts - signed/unsigned are not complete type specifiers.
+    // shorthand vectors and matrices can have signed/unsigned specifiers.
+    // If other typenames are used with signed/unsigned, it is already diagnosed by hlsl external source
+    if (TypeSpecType != TST_int && TypeSpecType != TST_int128 &&
+        TypeSpecType != TST_char && TypeSpecType != TST_wchar &&
+        TypeSpecType != TST_typename) {
       Diag(D, TSSLoc, diag::err_invalid_sign_spec)
         << getSpecifierName((TST)TypeSpecType, Policy);
       // signed double -> double.
       TypeSpecSign = TSS_unspecified;
     }
+    // HLSL Change end
   }
 
   // Validate the width of the type.

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -1388,7 +1388,6 @@ static QualType ConvertDeclSpecToType(TypeProcessingState &state) {
   }
   case DeclSpec::TST_typename: {
     assert(DS.getTypeSpecWidth() == 0 && DS.getTypeSpecComplex() == 0 &&
-           DS.getTypeSpecSign() == 0 &&
            "Can't handle qualifiers on typedef names yet!");
     Result = S.GetTypeFromParser(DS.getRepAsType());
     if (Result.isNull()) {

--- a/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK: uint2
+// CHECK: uint4x4
+
+unsigned int2 a;
+unsigned int4x4 b;
+
+float4 main() : SV_Target 
+{
+  return a.x + b[1][0];
+}

--- a/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
@@ -3,7 +3,7 @@
 // CHECK: uint2
 // CHECK: uint4x4
 // CHECK: uint3x4
-// CHECK: min16i3
+// CHECK: min16ui3
 // CHECK: uint64_t2
 
 unsigned int2 a;

--- a/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unsignedShortHandMatrixVector.hlsl
@@ -2,11 +2,17 @@
 
 // CHECK: uint2
 // CHECK: uint4x4
+// CHECK: uint3x4
+// CHECK: min16i3
+// CHECK: uint64_t2
 
 unsigned int2 a;
 unsigned int4x4 b;
+unsigned dword3x4 c;
+unsigned min16int3 d;
+unsigned int64_t2 e;
 
 float4 main() : SV_Target 
 {
-  return a.x + b[1][0];
+  return a.x + b[1][0] + c[0][3] + d[2];
 }

--- a/tools/clang/test/HLSL/matrix-syntax.hlsl
+++ b/tools/clang/test/HLSL/matrix-syntax.hlsl
@@ -72,7 +72,7 @@ void matrix_unsigned() {
    unsigned bool3x4 boolvector;   /* expected-error {{'bool' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned half4x1 halfvector;   /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned double1x2 doublevector;                           /* expected-error {{'double' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
-   unsigned min12int2x3 min12intvector;                       /* expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min12int2x3 min12intvector;                       /* expected-error {{'min12int' cannot be signed or unsigned}} expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned min16float3x4 min16floatvector;                   /* expected-error {{'min16float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
 
 }

--- a/tools/clang/test/HLSL/matrix-syntax.hlsl
+++ b/tools/clang/test/HLSL/matrix-syntax.hlsl
@@ -60,8 +60,21 @@ void matrix_out_of_bounds() {
 }
 
 void matrix_unsigned() {
-    unsigned int4x2 unsignedMatrix;
-    unsigned float1x4 unsignedFloatMatrix; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned int4x2 intMatrix;
+   unsigned min16int4x3 min16Matrix;
+   unsigned int64_t3x3 int64Matrix;
+   unsigned uint3x4 uintMatrix;
+   unsigned min16uint4x1 min16uintMatrix;
+   unsigned uint64_t2x2 int64uintMatrix;
+   unsigned dword3x2 dwordvector; /* fxc-error {{X3000: unrecognized identifier 'dword3x1'}} */
+   
+   unsigned float2x3 floatMatrix; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned bool3x4 boolvector;   /* expected-error {{'bool' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned half4x1 halfvector;   /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned double1x2 doublevector;                           /* expected-error {{'double' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min12int2x3 min12intvector;                       /* expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min16float3x4 min16floatvector;                   /* expected-error {{'min16float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+
 }
 
 void main() {

--- a/tools/clang/test/HLSL/matrix-syntax.hlsl
+++ b/tools/clang/test/HLSL/matrix-syntax.hlsl
@@ -44,7 +44,8 @@ void abs_in_argument() {
 void matrix_on_demand() {
     float4x4 thematrix;
     float4x4 anotherMatrix;
-    bool2x1 boolMatrix;   
+    bool2x1 boolMatrix;
+    unsigned int4x2 unsignedMatrix;
 }
 
 void abs_on_demand() {
@@ -56,6 +57,11 @@ void matrix_out_of_bounds() {
   matrix<float, 1, 8> matrix_oob_0; // expected-error {{invalid value, valid range is between 1 and 4 inclusive}} fxc-error {{X3053: matrix dimensions must be between 1 and 4}}
   matrix<float, 0, 1> matrix_oob_1; // expected-error {{invalid value, valid range is between 1 and 4 inclusive}} fxc-error {{X3053: matrix dimensions must be between 1 and 4}}
   matrix<float, -1, 1> matrix_oob_2; // expected-error {{invalid value, valid range is between 1 and 4 inclusive}} fxc-error {{X3053: matrix dimensions must be between 1 and 4}}
+}
+
+void matrix_unsigned() {
+    unsigned int4x2 unsignedMatrix;
+    unsigned float1x4 unsignedFloatMatrix; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
 }
 
 void main() {

--- a/tools/clang/test/HLSL/vector-syntax.hlsl
+++ b/tools/clang/test/HLSL/vector-syntax.hlsl
@@ -101,7 +101,7 @@ void vector_unsigned() {
    unsigned bool3 boolvector;   /* expected-error {{'bool' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned half4 halfvector;   /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned double1 doublevector;                           /* expected-error {{'double' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
-   unsigned min12int2 min12intvector;                       /* expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min12int2 min12intvector;                       /* expected-error {{'min12int' cannot be signed or unsigned}} expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
    unsigned min16float3 min16floatvector;                   /* expected-error {{'min16float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
 }
 

--- a/tools/clang/test/HLSL/vector-syntax.hlsl
+++ b/tools/clang/test/HLSL/vector-syntax.hlsl
@@ -88,6 +88,11 @@ void vector_out_of_bounds() {
   vector<float, -1> vector_oob_2; // expected-error {{invalid value, valid range is between 1 and 4 inclusive}} fxc-error {{X3052: vector dimension must be between 1 and 4}}
 }
 
+void vector_unsigned() {
+   unsigned int4x2 intvector;
+   unsigned float2x4 floatvector; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+}
+
 float fn() {
     float4 myvar = float4(1,2,3,4);
     myvar.x = 1.0f;

--- a/tools/clang/test/HLSL/vector-syntax.hlsl
+++ b/tools/clang/test/HLSL/vector-syntax.hlsl
@@ -89,8 +89,20 @@ void vector_out_of_bounds() {
 }
 
 void vector_unsigned() {
-   unsigned int4x2 intvector;
-   unsigned float2x4 floatvector; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned int4 intvector;
+   unsigned min16int4 min16vector;
+   unsigned int64_t3 int64vector;
+   unsigned uint3 uintvector;
+   unsigned min16uint4 min16uintvector;
+   unsigned uint64_t2 int64uintvector;
+   unsigned dword3 dwordvector; /* fxc-error {{X3000: unrecognized identifier 'dword3'}} */
+
+   unsigned float2 floatvector; /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned bool3 boolvector;   /* expected-error {{'bool' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned half4 halfvector;   /* expected-error {{'float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned double1 doublevector;                           /* expected-error {{'double' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min12int2 min12intvector;                       /* expected-warning {{min12int is promoted to min16int}} fxc-error {{X3085: unsigned can not be used with type}} */
+   unsigned min16float3 min16floatvector;                   /* expected-error {{'min16float' cannot be signed or unsigned}} fxc-error {{X3085: unsigned can not be used with type}} */
 }
 
 float fn() {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -526,6 +526,7 @@ public:
   TEST_METHOD(CodeGenUint64_2)
   TEST_METHOD(CodeGenUintSample)
   TEST_METHOD(CodeGenUmaxObjectAtomic)
+  TEST_METHOD(CodeGenUnsignedShortHandMatrixVector)
   TEST_METHOD(CodeGenUpdateCounter)
   TEST_METHOD(CodeGenUpperCaseRegister1);
   TEST_METHOD(CodeGenVcmp)
@@ -2757,6 +2758,10 @@ TEST_F(CompilerTest, CodeGenUintSample) {
 
 TEST_F(CompilerTest, CodeGenUmaxObjectAtomic) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\umaxObjectAtomic.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenUnsignedShortHandMatrixVector) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\unsignedShortHandMatrixVector.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenUpdateCounter) {


### PR DESCRIPTION
1. enable unsigned keyword for int vectors/matrices
   (for example, "unsigned int2" will be converted to  "vector<unsigned int, 2>")
2. disable unsigned keyword as a complete type specifier to be consistent with old compiler.