### PR TITLE
Expand macros in root signature and semantic defines

### DIFF
--- a/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
+++ b/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
@@ -27,9 +27,10 @@ namespace hlsl {
 //  1. You can mark certain defines as "semantic" defines which
 //     will be preserved as metadata in the final DXIL.
 //  2. You can add new HLSL intrinsic functions.
+//  3. You can read a root signature from a custom define.
 //
 // This class provides an interface for generating the DXIL bitcode
-// needed for the two types of extensions above.
+// needed for the types of extensions above.
 //  
 class HLSLExtensionsCodegenHelper {
 public:
@@ -63,6 +64,16 @@ public:
 
   // Get the name to use for the dxil intrinsic function.
   virtual std::string GetIntrinsicName(unsigned opcode) = 0;
+
+  // Struct to hold a root signature that is read from a define.
+  struct CustomRootSignature {
+    std::string RootSignature;
+    unsigned  EncodedSourceLocation;
+    enum Status { NOT_FOUND = 0, FOUND };
+  };
+
+  // Get custom defined root signature.
+  virtual CustomRootSignature::Status GetCustomRootSignature(CustomRootSignature *out) = 0;
 
   // Virtual destructor.
   virtual ~HLSLExtensionsCodegenHelper() {};

--- a/include/dxc/Support/ErrorCodes.h
+++ b/include/dxc/Support/ErrorCodes.h
@@ -92,3 +92,6 @@
 
 // 0X80AA0015 - DXIL container is missing DebugInfo part.
 #define DXC_E_CONTAINER_MISSING_DEBUG                 DXC_MAKE_HRESULT(DXC_SEVERITY_ERROR,FACILITY_DXC,(0x0015))
+
+// 0X80AA0016 - Unexpected failure in macro expansion.
+#define DXC_E_MACRO_EXPANSION_FAILURE                 DXC_MAKE_HRESULT(DXC_SEVERITY_ERROR,FACILITY_DXC,(0x0016))

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -105,6 +105,7 @@ public:
   llvm::StringRef PrivateSource; // OPT_setprivate
   llvm::StringRef RootSignatureSource; // OPT_setrootsignature
   llvm::StringRef VerifyRootSignatureSource; //OPT_verifyrootsignature
+  llvm::StringRef RootSignatureDefine; // OPT_rootsig_define
 
   bool AllResourcesBound; // OPT_all_resources_bound
   bool AstDump; // OPT_ast_dump

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -225,6 +225,8 @@ def hlsl_version : Separate<["-", "/"], "HV">, Group<hlslcomp_Group>, Flags<[Cor
   HelpText<"HLSL version (Only supports 2016 for now)">;
 def no_warnings : Flag<["-", "/"], "no-warnings">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Suppress warnings">;
+def rootsig_define : Separate<["-", "/"], "rootsig-define">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+  HelpText<"Read root signature from a #define">;
 
 //////////////////////////////////////////////////////////////////////////////
 // fxc-based flags that don't match those previously defined.

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -260,6 +260,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.PrivateSource = Args.getLastArgValue(OPT_setprivate);
   opts.RootSignatureSource = Args.getLastArgValue(OPT_setrootsignature);
   opts.VerifyRootSignatureSource = Args.getLastArgValue(OPT_verifyrootsignature);
+  opts.RootSignatureDefine = Args.getLastArgValue(OPT_rootsig_define);
 
   if (!opts.ForceRootSigVer.empty() && opts.ForceRootSigVer != "rootsig_1_0" &&
       opts.ForceRootSigVer != "rootsig_1_1") {

--- a/tools/clang/include/clang/Lex/HLSLMacroExpander.h
+++ b/tools/clang/include/clang/Lex/HLSLMacroExpander.h
@@ -1,0 +1,63 @@
+//===--- HLSLMacroExpander.h - Standalone Macro expansion ------*- C++ -*-===//
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// HLSLMacroExpander.h                                                       //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+//  This file defines utilites for expanding macros after lexing has         //
+//  completed. Normally, macros are expanded as part of the lexing           //
+//  phase and returned in an expanded form directly from the lexer.          //
+//  For hlsl we need to be able to expand macros after the fact to           //
+//  correctly capture semantic defines and root signature defines.           //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+#ifndef LLVM_CLANG_LEX_HLSLMACROEXPANDER_H
+#define LLVM_CLANG_LEX_HLSLMACROEXPANDER_H
+
+#include "clang/Basic/SourceLocation.h"
+
+#include <string>
+#include <utility>
+
+namespace clang {
+  class Preprocessor;
+  class Token;
+  class MacroInfo;
+}
+
+namespace llvm {
+  class StringRef;
+}
+
+namespace hlsl {
+class MacroExpander {
+public:
+  // Options used during macro expansion.
+  enum Option : unsigned {
+    // Strip quotes from string literals. Enables concatenating adjacent
+    // string literals into a single value.
+    STRIP_QUOTES = 1 << 1,
+  };
+
+  // Constructor
+  MacroExpander(clang::Preprocessor &PP, unsigned options = 0);
+
+  // Expand the given macro into the output string.
+  // Returns true if macro was expanded successfully.
+  bool ExpandMacro(clang::MacroInfo *macro, std::string *out);
+
+
+  // Look in the preprocessor for a macro with the provided name.
+  // Return nullptr if the macro could not be found.
+  static clang::MacroInfo *FindMacroInfo(clang::Preprocessor &PP, llvm::StringRef macroName);
+
+private:
+  clang::Preprocessor &PP;
+  clang::FileID m_expansionFileId;
+  bool m_stripQuotes;
+};
+}
+
+#endif // header include guard

--- a/tools/clang/lib/Lex/CMakeLists.txt
+++ b/tools/clang/lib/Lex/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS support)
 add_clang_library(clangLex
   HeaderMap.cpp
   HeaderSearch.cpp
+  HLSLMacroExpander.cpp
   Lexer.cpp
   LiteralSupport.cpp
   MacroArgs.cpp

--- a/tools/clang/lib/Lex/HLSLMacroExpander.cpp
+++ b/tools/clang/lib/Lex/HLSLMacroExpander.cpp
@@ -1,0 +1,169 @@
+//===--- HLSLMacroExpander.cpp - Standalone Macro expansion -----*- C++ -*-===//
+//                                                                            //
+// HLSLMacroExpander.cpp                                                      //
+// Copyright (C) Microsoft Corporation. All rights reserved.                  //
+// This file is distributed under the University of Illinois Open Source      //
+// License. See LICENSE.TXT for details.                                      //
+//===----------------------------------------------------------------------===//
+//
+// This file implements the MacroExpander class.
+//
+//===----------------------------------------------------------------------===//
+#include "clang/Lex/HLSLMacroExpander.h"
+
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Lex/Lexer.h"
+#include "clang/Lex/MacroInfo.h"
+#include "clang/Lex/ModuleMap.h"
+#include "clang/Lex/PPCallbacks.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Lex/PTHLexer.h"
+#include "clang/Lex/PTHManager.h"
+#include "clang/Lex/Token.h"
+#include "clang/Lex/TokenLexer.h"
+#include "llvm/ADT/StringRef.h"
+
+#include "dxc/Support/Global.h"
+using namespace clang;
+using namespace llvm;
+using namespace hlsl;
+
+MacroExpander::MacroExpander(Preprocessor &PP_, unsigned options)
+  : PP(PP_)
+  , m_expansionFileId()
+  , m_stripQuotes(false)
+{
+  if (options & STRIP_QUOTES)
+    m_stripQuotes = true;
+
+  // The preprocess requires a file to be on the lexing stack when we
+  // call ExpandMacro. We add an empty in-memory buffer that we use
+  // just for expanding macros.
+  std::unique_ptr<llvm::MemoryBuffer> SB = llvm::MemoryBuffer::getMemBuffer("", "<hlsl-semantic-defines>");
+  if (!SB) {
+    DXASSERT(false, "Cannot create macro expansion source buffer");
+    throw hlsl::Exception(DXC_E_MACRO_EXPANSION_FAILURE);
+  }
+
+  // Unfortunately, there is no api in the SourceManager to lookup a
+  // previously added file, so we have to add the empty file every time
+  // we expand macros. We could modify source manager to get/set the
+  // macro file id similar to the one we have for getPreambleFileID.
+  // Macros should only be expanded once (if needed for a root signature)
+  // or twice (for semantic defines) so adding an empty file every time
+  // is probably not a big deal.
+  m_expansionFileId = PP.getSourceManager().createFileID(std::move(SB));
+  if (m_expansionFileId.isInvalid()) {
+    DXASSERT(false, "Could not create FileID for macro expnasion?");
+    throw hlsl::Exception(DXC_E_MACRO_EXPANSION_FAILURE);
+  }
+}
+
+// Simple struct to hold a data/length pair.
+struct LiteralData {
+  const char *Data;
+  unsigned Length;
+};
+
+// Get the literal data from a literal token.
+// If stripQuotes flag is true the quotes (and string literal type) will
+// be removed from the data and only the raw string literal value will be
+// returned.
+static LiteralData GetLiteralData(const Token &Tok, bool stripQuotes) {
+  if (!tok::isStringLiteral(Tok.getKind()))
+    return LiteralData{ Tok.getLiteralData(), Tok.getLength() };
+
+  unsigned start_offset = 0;
+  unsigned end_offset = 0;
+  switch (Tok.getKind()) {
+  case tok::string_literal:       start_offset = 1; end_offset = 1;  break; // "foo"
+  case tok::wide_string_literal:  start_offset = 2; end_offset = 1;  break; // L"foo"
+  case tok::utf8_string_literal:  start_offset = 3; end_offset = 1;  break; // u8"foo"
+  case tok::utf16_string_literal: start_offset = 2; end_offset = 1;  break; // u"foo"
+  case tok::utf32_string_literal: start_offset = 2; end_offset = 1;  break; // U"foo"
+  default: break;
+  }
+
+  unsigned length = Tok.getLength() - (start_offset + end_offset);
+  if (length > Tok.getLength()) { // Check for unsigned underflow.
+    DXASSERT(false, "string literal quote count is wrong?");
+    start_offset = 0;
+    length = Tok.getLength();
+  }
+
+  return LiteralData {Tok.getLiteralData() + start_offset, length};
+}
+
+// Print leading spaces if needed by the token.
+// Take care when stripping string literal quoates that we do not add extra
+// spaces to the output.
+static bool ShouldPrintLeadingSpace(const Token &Tok, const Token &PrevTok, bool stripQuotes) {
+  if (!Tok.hasLeadingSpace())
+    return false;
+
+  // Token has leading spaces, but the previous token was a sting literal
+  // and we are stripping quotes to paste the strings together so do not
+  // add a space between the string literal values.
+  if (tok::isStringLiteral(PrevTok.getKind()) && stripQuotes)
+    return false;
+
+  return true;
+}
+
+// Macro expansion implementation.
+// We re-lex the macro using the preprocessors lexer.
+bool MacroExpander::ExpandMacro(MacroInfo *pMacro, std::string *out) {
+  if (!pMacro || !out)
+    return false;
+  MacroInfo &macro = *pMacro;
+
+  // Initialize the token from the macro definition location.
+  Token Tok;
+  bool failed = PP.getRawToken(macro.getDefinitionLoc(), Tok);
+  if (failed)
+    return false;
+
+  // Start the lexing process. Use an outer file to make the preprocessor happy.
+  PP.EnterSourceFile(m_expansionFileId, nullptr, PP.getSourceManager().getLocForStartOfFile(m_expansionFileId));
+  PP.EnterMacro(Tok, macro.getDefinitionEndLoc(), &macro, nullptr);
+  PP.Lex(Tok);
+  llvm::raw_string_ostream OS(*out);
+
+  // Keep track of previous token to print spaces correctly.
+  Token PrevTok;
+  PrevTok.startToken();
+
+  // Lex all the tokens from the macro and add them to the output.
+  while (!Tok.is(tok::eof)) {
+    if (ShouldPrintLeadingSpace(Tok, PrevTok, m_stripQuotes)) {
+      OS << ' ';
+    }
+    if (IdentifierInfo *II = Tok.getIdentifierInfo()) {
+      OS << II->getName();
+    }
+    else if (Tok.isLiteral() && !Tok.needsCleaning() &&
+      Tok.getLiteralData()) {
+      LiteralData literalData = GetLiteralData(Tok, m_stripQuotes);
+      OS.write(literalData.Data, literalData.Length);
+    }
+    else {
+      std::string S = PP.getSpelling(Tok);
+      OS.write(&S[0], S.size());
+    }
+    PrevTok = Tok;
+    PP.Lex(Tok);
+  }
+
+  return true;
+}
+
+// Search for the macro info by the given name.
+MacroInfo *MacroExpander::FindMacroInfo(clang::Preprocessor &PP, StringRef macroName) {
+  // Lookup macro identifier.
+  IdentifierInfo *ii = PP.getIdentifierInfo(macroName);
+  if (!ii)
+    return nullptr;
+
+  // Lookup macro info.
+  return PP.getMacroInfo(ii);
+}

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine1.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define.
+
+#define RS DescriptorTable(SRV(t3))
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine10.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine10.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s | FileCheck %s
+// Test root signature define error: missing descriptor range.
+
+// CHECK: error: validation errors
+// CHECK: Root Signature in DXIL container is not compatible with shader
+#define RS DescriptorTable(SRV(t0))
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine11.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine11.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define overrides root signature attribute.
+// Put an invalid root signature in the attribute and a valid one in the
+// define. If compilation succeeds then the valid root signature was used.
+
+Texture1D<float> tex : register(t3);
+
+#define RS DescriptorTable(SRV(t3))
+[RootSignature("SRV(t0)")]
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine2.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define string
+
+#define RS "DescriptorTable(SRV(t3))"
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine3.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define empty
+
+#define RS 
+
+float main(float i : I) : SV_Target
+{
+  return i;
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine4.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine4.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define empty string
+
+#define RS ""
+
+float main(float i : I) : SV_Target
+{
+  return i;
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine5.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine5.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define concatenated string
+
+#define RS "DescriptorTable" \
+           "(SRV(t3))"
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine6.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine6.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define expanded macro.
+
+#define YYY "DescriptorTable(SRV(t3))"
+#define RS YYY
+           
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine7.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine7.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define expanded macro concatenated string.
+
+#define YYY "DescriptorTable" "(SRV(t3))"
+#define RS YYY
+           
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine8.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine8.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s
+// Test root signature define expanded macro call.
+
+#define YYY(x) DescriptorTable(SRV(x))
+#define RS YYY(t3)
+           
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigDefine9.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigDefine9.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -E main -T ps_6_0 -rootsig-define RS %s | FileCheck %s
+// Test root signature define error: syntax error in root signature.
+
+// CHECK: root signature error - Unexpected token 'XescriptorTable' when parsing root signature
+#define RS XescriptorTable(SRV(x))
+
+Texture1D<float> tex : register(t3);
+float main(float i : I) : SV_Target
+{
+  return tex[i];
+}
+

--- a/tools/clang/test/CodeGenHLSL/rootSigProfile5.hlsl
+++ b/tools/clang/test/CodeGenHLSL/rootSigProfile5.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -E RS -T rootsig_1_0 %s
+// Test root signature compilation from expanded macro.
+
+#define YYY "DescriptorTable" "(SRV(t3))"
+#define RS YYY

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/semantic-defines_gold.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/semantic-defines_gold.hlsl
@@ -1,0 +1,10 @@
+// Rewrite unchanged result:
+int func(int a) {
+  return a;
+}
+
+
+
+// Macros:
+#define SD_FOO 1
+#define SD_ZOO 2

--- a/tools/clang/test/HLSL/rewriter/semantic-defines.hlsl
+++ b/tools/clang/test/HLSL/rewriter/semantic-defines.hlsl
@@ -1,0 +1,8 @@
+#define BAR 1
+#define SD_FOO BAR
+#define SD_ZOO 2
+
+int func(int a)
+{
+  return a;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -597,6 +597,18 @@ public:
   TEST_METHOD(CodeGenRootSigProfile2)
   TEST_METHOD(CodeGenRootSigProfile3)
   TEST_METHOD(CodeGenRootSigProfile4)
+  TEST_METHOD(CodeGenRootSigProfile5)
+  TEST_METHOD(CodeGenRootSigDefine1)
+  TEST_METHOD(CodeGenRootSigDefine2)
+  TEST_METHOD(CodeGenRootSigDefine3)
+  TEST_METHOD(CodeGenRootSigDefine4)
+  TEST_METHOD(CodeGenRootSigDefine5)
+  TEST_METHOD(CodeGenRootSigDefine6)
+  TEST_METHOD(CodeGenRootSigDefine7)
+  TEST_METHOD(CodeGenRootSigDefine8)
+  TEST_METHOD(CodeGenRootSigDefine9)
+  TEST_METHOD(CodeGenRootSigDefine10)
+  TEST_METHOD(CodeGenRootSigDefine11)
   TEST_METHOD(CodeGenCBufferStructArray)
   TEST_METHOD(PreprocessWhenValidThenOK)
   TEST_METHOD(WhenSigMismatchPCFunctionThenFail)
@@ -3052,6 +3064,54 @@ TEST_F(CompilerTest, CodeGenRootSigProfile3) {
 
 TEST_F(CompilerTest, CodeGenRootSigProfile4) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigProfile4.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigProfile5) {
+  CodeGenTest(L"..\\CodeGenHLSL\\rootSigProfile5.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine1) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine1.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine2) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine2.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine3) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine3.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine4) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine4.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine5) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine5.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine6) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine6.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine7) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine7.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine8) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine8.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine9) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine9.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine10) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine10.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenRootSigDefine11) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\rootSigDefine11.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenCBufferStructArray) {

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -395,6 +395,7 @@ public:
   TEST_METHOD(DefineValidationError);
   TEST_METHOD(DefineValidationWarning);
   TEST_METHOD(DefineNoValidatorOk);
+  TEST_METHOD(DefineFromMacro);
   TEST_METHOD(IntrinsicWhenAvailableThenUsed);
   TEST_METHOD(CustomIntrinsicName);
   TEST_METHOD(NoLowering);
@@ -509,6 +510,26 @@ TEST_F(ExtensionTest, DefineNoValidatorOk) {
   c.RegisterSemanticDefine(L"FOO*");
   c.Compile(
     "#define FOO 1\n"
+    "float4 main() : SV_Target {\n"
+    "  return 0;\n"
+    "}\n",
+    { L"/Vd" }, {}
+  );
+
+  std::string disassembly = c.Disassemble();
+  // Check the define is emitted.
+  // #define FOO 1
+  VERIFY_IS_TRUE(
+    disassembly.npos !=
+    disassembly.find("!{!\"FOO\", !\"1\"}"));
+}
+
+TEST_F(ExtensionTest, DefineFromMacro) {
+  Compiler c(m_dllSupport);
+  c.RegisterSemanticDefine(L"FOO*");
+  c.Compile(
+    "#define BAR 1\n"
+    "#define FOO BAR\n"
     "float4 main() : SV_Target {\n"
     "  return 0;\n"
     "}\n",


### PR DESCRIPTION
This commit adds a standalone class for expanding macros and uses it
to for root signature and semantic define processing. Previously,
we were using the raw macro value instead of the expanded value
so something like:

    #define MYRS "DescriptorTable(SRV(t0))"
    #define RS   MYRS

would fail to compile the root signature with an entry point of
RS because it would get a root signature value of MYRS instead
of the expanded value. Similarly, for semantic defines we were
saving the non-expanded value into the bitcode.

This commit also adds a new flag that is used to specify that
the root signature should be read from a #define. So compiling
with `-rootsig-define RS` will read the root signature from
a `#define RS ...` in the source. The -roosig-define flag
takes precedence over a root signature annotation in the souce.