### PR TITLE
Add support for AppVeyor continuous integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DirectX Shader Compiler
 
+[![Build status](https://ci.appveyor.com/api/projects/status/2wsw8t8clpgt1kfm?svg=true)](https://ci.appveyor.com/project/dmpots/directxshadercompiler)
+
 The DirectX Shader Compiler project includes a compiler and related tools used to compile High-Level Shader Language (HLSL) programs into DirectX Intermediate Language (DXIL) representation. Applications that make use of DirectX for graphics, games, and computation can use it to generate shader programs.
 
 For more information, see the [Wiki](https://github.com/Microsoft/DirectXShaderCompiler/wiki).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+platform: x64
+configuration: Debug
+clone_folder: c:\projects\DirectXShaderCompiler
+environment:
+  HLSL_SRC_DIR: c:\projects\DirectXShaderCompiler
+  HLSL_BLD_DIR: c:\projects\DirectXShaderCompiler.bin
+install:
+- ps: c:\projects\DirectXShaderCompiler\utils\appveyor\appveyor_setup.ps1
+build_script:
+- cmd: >-
+    cd %HLSL_SRC_DIR%
+
+    call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+
+    call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017
+test_script:
+- cmd: >-
+    cd %HLSL_SRC_DIR%
+
+    call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+
+    powershell utils\appveyor\appveyor_test.ps1
+
+notifications:
+- provider: GitHubPullRequest
+  on_build_success: true
+  on_build_failure: true
+  on_build_status_changed: true

--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -3,12 +3,23 @@ get_filename_component(VS_PATH32 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Visu
 get_filename_component(VS_PATH64 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\VisualStudio\\14.0;InstallDir]" ABSOLUTE CACHE)
 # VS_PATH32 will be something like C:/Program Files (x86)/Microsoft Visual Studio 14.0/Common7/IDE
 
+# Also look for in vs15 install.
+# TODO: update this to be a non-hardcoded path. Registry keys were removed
+# in vs15 in favor of COM server dlls.
+# https://blogs.msdn.microsoft.com/heaths/2016/09/15/changes-to-visual-studio-15-setup/
+get_filename_component(VS15_C_PATH32 "C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/Common7/IDE" ABSOLUTE CACHE)
+get_filename_component(VS15_P_PATH32 "C:/Program Files (x86)/Microsoft Visual Studio/2017/Professional/Common7/IDE" ABSOLUTE CACHE)
+get_filename_component(VS15_E_PATH32 "C:/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/Common7/IDE" ABSOLUTE CACHE)
+
 # Find the TAEF path, it will typically look something like this.
 # C:\Program Files (x86)\Microsoft Visual Studio 14.0\DIA SDK\include\dia2.h
 find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
           HINTS "${VS_PATH64}/../../DIA SDK/include"
 		  HINTS "${VS_PATH32}/../../DIA SDK/include"
+		  HINTS "${VS15_C_PATH32}/../../DIA SDK/include"
+		  HINTS "${VS15_P_PATH32}/../../DIA SDK/include"
+		  HINTS "${VS15_E_PATH32}/../../DIA SDK/include"
           DOC "path to DIA SDK header files"
           HINTS
           )

--- a/utils/appveyor/appveyor_setup.ps1
+++ b/utils/appveyor/appveyor_setup.ps1
@@ -1,0 +1,11 @@
+# Install the Windows Driver Kit (WDK). Only needed for TAEF.
+$http="https://go.microsoft.com/fwlink/p/?LinkId=526733"
+$path="$env:TEMP\wdk-installer.exe"
+Write-Host "Downloading WDK to $path"
+Invoke-WebRequest $http -OutFile $path
+
+Write-Host "Installing WDK"
+$sw =  [Diagnostics.Stopwatch]::StartNew()
+Start-Process -FilePath $path -Wait -Args "/q /ceip off /features OptionId.WindowsDriverKitComplete"
+$sw.Stop()
+Write-Host ("Installation completed in {0:c}" -f $sw.Elapsed)

--- a/utils/appveyor/appveyor_test.ps1
+++ b/utils/appveyor/appveyor_test.ps1
@@ -1,0 +1,56 @@
+function ConvertTo-AppveyorTestOutcome([string]$taefResult)
+{
+    switch($taefResult) {
+        "Pass"    {"Passed"}
+        "Fail"    {"Failed"}
+        "Skip"    {"Skipped"}
+        "Blocked" {"NotRunnable"}
+        default   {"Inconclusive"}
+    }
+}
+
+function ConvertTo-AppveyorTest([System.Xml.XmlNode] $endTest) {
+    New-Object PSObject -Property @{
+        testName = $endTest.Title
+        testFramework = "TAEF"
+        fileName = "clang-hlsl-tests.dll"
+        outcome = ConvertTo-AppveyorTestOutcome($endTest.Result)
+        durationMilliseconds = ""
+        ErrorMessage = ""
+        ErrorStackTrace = ""
+        StdOut = ""
+        StdErr = ""
+    }
+}
+
+function Get-TaefResults($logfile) {
+    [xml]$results = Get-Content $logfile
+    $endTests = Select-Xml -Xml $results -XPath "/WTT-Logger/EndTest" | ForEach-Object {
+        $test = $_.Node
+        ConvertTo-AppveyorTest($test)
+    }
+    return ,@($endTests)
+}
+
+function Invoke-AppveyorTestsRestMethod($appveyorTests) {
+    $uri = $env:APPVEYOR_API_URL + "/api/tests/batch"
+    $json = ConvertTo-Json $appveyorTests
+    Invoke-RestMethod -Uri $uri -Method Put -Body $json -ContentType "application/json"
+}
+
+function Invoke-TE($logfile) {
+    $testdll = "$env:HLSL_BLD_DIR\Debug\bin\clang-hlsl-tests.dll"
+    $p = Start-Process "te.exe" -Args "$testdll /logOutput:Low /logFile:$logfile /enableWttLogging /p:HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL /labMode /miniDumpOnCrash" -Wait -NoNewWindow -PassThru
+    return $p.ExitCode
+}
+
+$logfile = "$env:HLSL_BLD_DIR\testresults.xml"
+Write-Host "Running taef tests"
+$teExitCode = Invoke-TE $logfile
+Write-Host "Parsing taef tests"
+$testResults = Get-TaefResults $logfile
+Write-Host "Uploading results to AppVeyor"
+Invoke-AppveyorTestsRestMethod $testResults
+Write-Host "Done"
+
+exit $teExitCode

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -39,6 +39,8 @@ if errorlevel 1 (
 if "%BUILD_ARCH%"=="" (
   set BUILD_ARCH=Win32
 )
+
+set BUILD_GENERATOR=Visual Studio 14 2015
 set BUILD_CONFIG=Debug
 set DO_SETUP=1
 set DO_BUILD=1
@@ -86,11 +88,21 @@ if "%1"=="-arm" (
   set BUILD_ARCH=ARM
   shift /1
 )
+if "%1"=="-Debug" (
+  set BUILD_CONFIG=Debug
+  shift /1
+)
+if "%1"=="-Release" (
+  set BUILD_CONFIG=Release
+  shift /1
+)
+if "%1"=="-vs2017" (
+  set BUILD_GENERATOR=Visual Studio 15 2017
+  shift /1
+)
 
-if "%BUILD_ARCH%"=="Win32" (
-  set BUILD_GENERATOR=Visual Studio 14 2015
-) else (
-  set BUILD_GENERATOR=Visual Studio 14 2015 %BUILD_ARCH:x64=Win64%
+if "%BUILD_ARCH%"=="x64" (
+  set BUILD_GENERATOR=%BUILD_GENERATOR% %BUILD_ARCH:x64=Win64%
 )
 
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_ENABLE_ARCMT:BOOL=OFF
@@ -115,6 +127,7 @@ set CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_DEFAULT_TARGET_TRIPLE:STRING=dxil-ms-dx
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_BUILD_EXAMPLES:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_REQUIRES_RTTI:BOOL=ON
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_CL:BOOL=OFF
+set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_SYSTEM_VERSION=10.0.14393.0
 
 rem This parameter is used with vcvarsall to force use of 64-bit build tools
 rem instead of 32-bit tools that run out of memory.
@@ -137,7 +150,7 @@ exit /b 0
 echo Builds HLSL solutions and the product and test binaries for the current
 echo flavor and architecture.
 echo.
-echo hctbuild [-s or -b] [-alldef] [-analyze] [-fv] [-rel] [-arm or -x86 or -x64]
+echo hctbuild [-s or -b] [-alldef] [-analyze] [-fv] [-rel] [-arm or -x86 or -x64] [-Release] [-Debug] [-vs2017]
 echo.
 echo   -s   creates the projects only, without building
 echo   -b   builds the existing project
@@ -152,6 +165,11 @@ echo current BUILD_ARCH=%BUILD_ARCH%.  Override with:
 echo   -x86 targets an x86 build (aka. Win32)
 echo   -x64 targets an x64 build (aka. Win64)
 echo   -arm targets an ARM build
+echo
+echo   AppVeyor Support
+echo   -Release builds release
+echo   -Debug builds debug
+echo   -vs2017 uses Visual Studio 2017 to build
 echo.
 if not "%HLSL_BLD_DIR%"=="" (
   echo The solution file is at %HLSL_BLD_DIR%\LLVM.sln


### PR DESCRIPTION
This commit makes the necessary changes to run the project with AppVeyor
CI. The `appveyor.yml` file contains the configuration settings for the
build. Currently we only build x64-Debug, but we can build the full
x32/x64-Debug/Release matrix by adding a few lines to the config.

The remaining changes are somewhat tied to the specifics of how appveyor
provisions the build machines. The standard VS2015 machines build on
Windows Server 2012. We can build on these machines, but cannot run tests
because we require d3d12.dll which is not available on Windows Server
2012. However, it is present on Windows Server 2016, but appveyor only
provides VS2017 on those machines. So part of the changes are to allow
the compiler to build with VS2017 so we can run tests as part of CI.

The `appveyor_setup.ps1` script installs the WDK as part of the build.
This is the only extra software we need. It is actually installed on the
VS2015 build machines, but not our VS2017 build machines. Perhaps we can
get them to install it by default and then this script can go away.

The `appveyor_test.ps1` script runs the taef tests and then reports the
results to appveyor so they can be displayed on the "Tests" tab.

As a side effect of this work, We can now use the latest cmake (3.7.2) for
our own builds! The key seems to be setting
`-DCMAKE_SYSTEM_VERSION=10.0.14393.0` to ensure that we pick up the
correct SDK.