### PR TITLE
Generate fxc-compatible reflection type info for buffer members

### DIFF
--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -140,6 +140,37 @@ public:
     VERIFY_ARE_EQUAL(pTestDesc->SystemValueType, pBaseDesc->SystemValueType);
   }
 
+  void CompareType(ID3D12ShaderReflectionType *pTest,
+                   ID3D12ShaderReflectionType *pBase)
+  {
+    D3D12_SHADER_TYPE_DESC testDesc, baseDesc;
+    VERIFY_SUCCEEDED(pTest->GetDesc(&testDesc));
+    VERIFY_SUCCEEDED(pBase->GetDesc(&baseDesc));
+
+    VERIFY_ARE_EQUAL(testDesc.Class,    baseDesc.Class);
+    VERIFY_ARE_EQUAL(testDesc.Type,     baseDesc.Type);
+    VERIFY_ARE_EQUAL(testDesc.Rows,     baseDesc.Rows);
+    VERIFY_ARE_EQUAL(testDesc.Columns,  baseDesc.Columns);
+    VERIFY_ARE_EQUAL(testDesc.Elements, baseDesc.Elements);
+    VERIFY_ARE_EQUAL(testDesc.Members,  baseDesc.Members);
+    VERIFY_ARE_EQUAL(testDesc.Offset,   baseDesc.Offset);
+
+    VERIFY_ARE_EQUAL(0, strcmp(testDesc.Name, baseDesc.Name));
+
+    for (UINT i = 0; i < baseDesc.Members; ++i) {
+      ID3D12ShaderReflectionType* testMemberType = pTest->GetMemberTypeByIndex(i);
+      ID3D12ShaderReflectionType* baseMemberType = pBase->GetMemberTypeByIndex(i);
+      VERIFY_IS_NOT_NULL(testMemberType);
+      VERIFY_IS_NOT_NULL(baseMemberType);
+
+      CompareType(testMemberType, baseMemberType);
+
+      LPCSTR testMemberName = pTest->GetMemberTypeName(i);
+      LPCSTR baseMemberName = pBase->GetMemberTypeName(i);
+      VERIFY_ARE_EQUAL(0, strcmp(testMemberName, baseMemberName));
+    }
+  }
+
   typedef HRESULT (__stdcall ID3D12ShaderReflection::*GetParameterDescFn)(UINT, D3D12_SIGNATURE_PARAMETER_DESC*);
 
   void SortNameIdxVector(std::vector<std::tuple<LPCSTR, UINT, UINT>> &value) {
@@ -204,12 +235,17 @@ public:
         VERIFY_ARE_EQUAL(testCB.uFlags, baseCB.uFlags);
 
         llvm::StringMap<D3D12_SHADER_VARIABLE_DESC> variableMap;
+        llvm::StringMap<ID3D12ShaderReflectionType*> variableTypeMap;
         for (UINT vi = 0; vi < testCB.Variables; ++vi) {
           ID3D12ShaderReflectionVariable *pBaseConst;
           D3D12_SHADER_VARIABLE_DESC baseConst;
           pBaseConst = pBaseCB->GetVariableByIndex(vi);
           VERIFY_SUCCEEDED(pBaseConst->GetDesc(&baseConst));
           variableMap[baseConst.Name] = baseConst;
+
+          ID3D12ShaderReflectionType* pBaseType = pBaseConst->GetType();
+          VERIFY_IS_NOT_NULL(pBaseType);
+          variableTypeMap[baseConst.Name] = pBaseType;
         }
         for (UINT vi = 0; vi < testCB.Variables; ++vi) {
           ID3D12ShaderReflectionVariable *pTestConst;
@@ -222,6 +258,12 @@ public:
           VERIFY_ARE_EQUAL(testConst.StartOffset, baseConst.StartOffset);
           // TODO: enalbe size cmp.
           //VERIFY_ARE_EQUAL(testConst.Size, baseConst.Size);
+
+          ID3D12ShaderReflectionType* pTestType = pTestConst->GetType();
+          VERIFY_IS_NOT_NULL(pTestType);
+          VERIFY_ARE_EQUAL(variableTypeMap.count(testConst.Name), 1);
+          ID3D12ShaderReflectionType* pBaseType = variableTypeMap[testConst.Name];
+          CompareType(pTestType, pBaseType);
         }
       }
     }


### PR DESCRIPTION
These changes are to fix issue #134.

The existing code in `DxilContainerReflection.cpp` had two cases where it initialized a `CShaderReflectionType*` variable to null, and then never filled it in (one even had a `TODO` comment). The corresponding code to actually construct a suitable reflection type was also missing.

This change adds a kind of best-effort implementation of that interface. There are cases where the extraction of information from the DXIL is a bit ad hoc, but I expect it to be good enough for many users.

There were existing test cases to verify that the reflection data extracted from DXIL matches that produced by FXC/DXBC, but those tests weren't looking at type information. In order to test the new code, I modified the existing tests to also compare reflection type information (this led to many follow-on bug fixes to my code).

I have confirmed that with the additional checks, these changes allow `DxilContainerTest::ReflectionMatchesDXBC_Checkin` and `*_Full` to pass.

I can rebase this change on top of the `dxil-v1.0` branch and open a new PR if that would be preferred.