### PR TITLE
Lower resource to createHandle at clang code gen.

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -43,6 +43,8 @@ ModulePass *createHLEmitMetadataPass();
 ModulePass *createHLEnsureMetadataPass();
 ModulePass *createDxilEmitMetadataPass();
 ModulePass *createDxilPrecisePropagatePass();
+FunctionPass *createDxilLegalizeResourceUsePass();
+ModulePass *createDxilLegalizeStaticResourceUsePass();
 FunctionPass *createDxilLegalizeSampleOffsetPass();
 FunctionPass *createSimplifyInstPass();
 
@@ -52,6 +54,8 @@ void initializeHLEnsureMetadataPass(llvm::PassRegistry&);
 void initializeHLEmitMetadataPass(llvm::PassRegistry&);
 void initializeDxilEmitMetadataPass(llvm::PassRegistry&);
 void initializeDxilPrecisePropagatePassPass(llvm::PassRegistry&);
+void initializeDxilLegalizeResourceUsePassPass(llvm::PassRegistry&);
+void initializeDxilLegalizeStaticResourceUsePassPass(llvm::PassRegistry&);
 void initializeDxilLegalizeSampleOffsetPassPass(llvm::PassRegistry&);
 void initializeSimplifyInstPass(llvm::PassRegistry&);
 

--- a/include/dxc/HLSL/DxilMetadataHelper.h
+++ b/include/dxc/HLSL/DxilMetadataHelper.h
@@ -172,6 +172,9 @@ public:
   // Control flow hint.
   static const char kDxilControlFlowHintMDName[];
 
+  // Resource attribute.
+  static const char kDxilResourceAttributeMDName[];
+
   // Precise attribute.
   static const char kDxilPreciseAttributeMDName[];
 

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -29,6 +29,7 @@ class LLVMContext;
 class Module;
 class Function;
 class Instruction;
+class CallInst;
 class MDTuple;
 class MDNode;
 class GlobalVariable;
@@ -181,6 +182,12 @@ public:
   void LoadHLMetadata();
   /// Delete any HLDXIR from the specified module.
   static void ClearHLMetadata(llvm::Module &M);
+  /// Create Metadata from a resource.
+  llvm::MDNode *DxilSamplerToMDNode(const DxilSampler &S);
+  llvm::MDNode *DxilSRVToMDNode(const DxilResource &SRV);
+  llvm::MDNode *DxilUAVToMDNode(const DxilResource &UAV);
+  llvm::MDNode *DxilCBufferToMDNode(const DxilCBuffer &CB);
+  DxilResourceBase LoadDxilResourceBaseFromMDNode(llvm::MDNode *MD);
 
   // Type related methods.
   static bool IsStreamOutputPtrType(llvm::Type *Ty);
@@ -198,7 +205,7 @@ public:
 
   // HL code gen.
   template<class BuilderTy>
-  static llvm::Value *EmitHLOperationCall(BuilderTy &Builder,
+  static llvm::CallInst *EmitHLOperationCall(BuilderTy &Builder,
                                           HLOpcodeGroup group, unsigned opcode,
                                           llvm::Type *RetType,
                                           llvm::ArrayRef<llvm::Value *> paramList,
@@ -217,6 +224,9 @@ public:
   static void MarkPreciseAttributeOnPtrWithFunctionCall(llvm::Value *Ptr,
                                                         llvm::Module &M);
   static bool HasPreciseAttribute(llvm::Function *F);
+  // Resource attribute.
+  static void  MarkDxilResourceAttrib(llvm::Function *F, llvm::MDNode *MD);
+  static llvm::MDNode *GetDxilResourceAttrib(llvm::Function *F);
 
   // DXIL type system.
   DxilTypeSystem &GetTypeSystem();

--- a/include/dxc/HLSL/HLOperationLower.h
+++ b/include/dxc/HLSL/HLOperationLower.h
@@ -10,10 +10,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+#include <unordered_set>
 
 namespace llvm {
 class Instruction;
 class Value;
+class LoadInst;
 class Function;
 }
 
@@ -23,7 +25,7 @@ class DxilResourceBase;
 class HLSLExtensionsCodegenHelper;
 
 void TranslateBuiltinOperations(
-    HLModule &HLM,
-    std::unordered_map<llvm::Instruction *, llvm::Value *> &handleMap,
-    HLSLExtensionsCodegenHelper *extCodegenHelper);
+    HLModule &HLM, HLSLExtensionsCodegenHelper *extCodegenHelper,
+    std::unordered_set<llvm::LoadInst *> &UpdateCounterSet,
+    std::unordered_set<llvm::Value *> &NonUniformSet);
 }

--- a/include/dxc/HLSL/HLOperationLowerExtension.h
+++ b/include/dxc/HLSL/HLOperationLowerExtension.h
@@ -39,11 +39,9 @@ namespace hlsl {
       Resource,       // Convert return value to resource return and explode vectors.
     };
 
-    typedef std::unordered_map<llvm::Instruction *, llvm::Value *> HandleMap;
-
     // Create the lowering using the given strategy and custom codegen helper.
-    ExtensionLowering(llvm::StringRef strategy, HLSLExtensionsCodegenHelper *helper, const HandleMap &handleMap, OP& hlslOp);
-    ExtensionLowering(Strategy strategy, HLSLExtensionsCodegenHelper *helper, const HandleMap &handleMap, OP& hlslOp);
+    ExtensionLowering(llvm::StringRef strategy, HLSLExtensionsCodegenHelper *helper, OP& hlslOp);
+    ExtensionLowering(Strategy strategy, HLSLExtensionsCodegenHelper *helper, OP& hlslOp);
 
     // Translate the HL op call to a DXIL op call.
     // Returns a new value if translation was successful.
@@ -69,7 +67,6 @@ namespace hlsl {
   private:
     Strategy m_strategy;
     HLSLExtensionsCodegenHelper *m_helper;
-    const HandleMap &m_handleMap;
     OP &m_hlslOp;
 
     llvm::Value *Unknown(llvm::CallInst *CI);

--- a/include/dxc/HLSL/HLOperations.h
+++ b/include/dxc/HLSL/HLOperations.h
@@ -35,6 +35,7 @@ enum class HLOpcodeGroup {
   HLSubscript,
   HLMatLoadStore,
   HLSelect,
+  HLCreateHandle,
   NumOfHLOps
 };
 
@@ -111,7 +112,7 @@ enum class HLMatLoadStoreOpcode {
 extern const char * const HLPrefix;
 
 HLOpcodeGroup GetHLOpcodeGroup(llvm::Function *F);
-HLOpcodeGroup GetHLOpcodeGroupByName(llvm::Function *F);
+HLOpcodeGroup GetHLOpcodeGroupByName(const llvm::Function *F);
 llvm::StringRef GetHLOpcodeGroupNameByAttr(llvm::Function *F);
 llvm::StringRef GetHLLowerStrategy(llvm::Function *F);
 unsigned  GetHLOpcode(llvm::CallInst *CI);
@@ -320,6 +321,10 @@ const unsigned kGetDimensionsNoMipWidthOpIndex = 2;
 
 // WaveAllEqual.
 const unsigned kWaveAllEqualValueOpIdx = 1;
+
+// CreateHandle.
+const unsigned kCreateHandleResourceOpIdx = 1;
+const unsigned kCreateHandleIndexOpIdx = 2; // Only for array of cbuffer.
 
 } // namespace HLOperandIndex
 

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -76,7 +76,9 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilCondenseResourcesPass(Registry);
     initializeDxilEmitMetadataPass(Registry);
     initializeDxilGenerationPassPass(Registry);
+    initializeDxilLegalizeResourceUsePassPass(Registry);
     initializeDxilLegalizeSampleOffsetPassPass(Registry);
+    initializeDxilLegalizeStaticResourceUsePassPass(Registry);
     initializeDxilPrecisePropagatePassPass(Registry);
     initializeDynamicIndexingVectorToArrayPass(Registry);
     initializeEarlyCSELegacyPassPass(Registry);

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -34,6 +34,8 @@
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
+#include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Transforms/Utils/PromoteMemToReg.h"
 #include <memory>
 #include <unordered_set>
 
@@ -43,144 +45,6 @@ using namespace hlsl;
 // TODO: use hlsl namespace for the most of this file.
 
 namespace {
-
-class LocalResourcePromoter : public LoadAndStorePromoter {
-  AllocaInst *AI;
-  AllocaInst *NewAI;
-  bool        HasUnmappedLd;
-  std::unordered_map<Instruction *, Value *> &handleMap;
-public:
-  LocalResourcePromoter(ArrayRef<Instruction *> Insts, SSAUpdater &S,
-                   std::unordered_map<Instruction *, Value *> &handleMap)
-      : LoadAndStorePromoter(Insts, S), AI(nullptr), handleMap(handleMap),
-        HasUnmappedLd(false) {}
-
-  AllocaInst *run(AllocaInst *AI, const SmallVectorImpl<Instruction *> &Insts) {
-    // Remember which alloca we're promoting (for isInstInList).
-    this->AI = AI;
-    // Only want to add load of resource allocas to handleMap.
-    // But LoadAndStorePromoter::run will remove all load/store and alloca.
-    // So need to clone.
-    // Clone to keep the debug info.
-    NewAI = cast<AllocaInst>(AI->clone());
-    IRBuilder<> Builder(AI);
-    Builder.Insert(NewAI);
-    LoadAndStorePromoter::run(Insts);
-    AI->eraseFromParent();
-    bool allLoadMapped = true;
-    for (User *U : NewAI->users()) {
-      if (LoadInst *LI = dyn_cast<LoadInst>(U)) {
-        if (handleMap.count(LI) == 0) {
-          allLoadMapped = false;
-          break;
-        }
-      }
-    }
-    return allLoadMapped? nullptr : NewAI;
-  }
-
-  bool
-  isInstInList(Instruction *I,
-               const SmallVectorImpl<Instruction *> &Insts) const override {
-    if (LoadInst *LI = dyn_cast<LoadInst>(I))
-      return LI->getOperand(0) == AI;
-    return cast<StoreInst>(I)->getPointerOperand() == AI;
-  }
-
-  void replaceLoadWithValue(LoadInst *LI, Value *V) const override {
-    if (PHINode *phi = dyn_cast<PHINode>(V)) {
-      LI->replaceAllUsesWith(phi);
-      // Add nullptr for phi, will create real handle in
-      // AddCreateHandleForPhiNodeAndSelect.
-      handleMap[phi] = nullptr;
-      return;
-    }
-
-    // Load use go here.
-    // Clone to keep the debug info.
-    Instruction *NewInst = LI->clone();
-    NewInst->replaceUsesOfWith(AI, NewAI);
-    IRBuilder<> Builder(LI);
-    Builder.Insert(NewInst);
-    LI->replaceAllUsesWith(NewInst);
-
-    // Mark handle map.
-    // If cannot find, will return false in run();
-    if (Instruction *I = dyn_cast<Instruction>(V)) {
-      if (handleMap.count(I)) {
-        Instruction *handle = cast<Instruction>(handleMap[I]);
-        // Clone the handle to save debug info of LI.
-        handle = handle->clone();
-        Builder.Insert(handle);
-        handleMap[NewInst] = handle;
-      }
-    }
-  }
-};
-
-class StaticResourcePromoter : public LoadAndStorePromoter {
-  GlobalVariable *GV;
-  bool        HasUnmappedLd;
-  std::unordered_map<Instruction *, Value *> &handleMap;
-public:
-  StaticResourcePromoter(ArrayRef<Instruction *> Insts, SSAUpdater &S,
-                   std::unordered_map<Instruction *, Value *> &handleMap)
-      : LoadAndStorePromoter(Insts, S), GV(nullptr), handleMap(handleMap),
-        HasUnmappedLd(false) {}
-
-  bool run(GlobalVariable *GV, const SmallVectorImpl<Instruction *> &Insts) {
-    // Remember which alloca we're promoting (for isInstInList).
-    this->GV = GV;
-
-    LoadAndStorePromoter::run(Insts);
-
-    bool allLoadMapped = true;
-    for (User *U : GV->users()) {
-      if (LoadInst *LI = dyn_cast<LoadInst>(U)) {
-        if (handleMap.count(LI) == 0) {
-          allLoadMapped = false;
-          break;
-        }
-      }
-    }
-    return allLoadMapped;
-  }
-
-  bool
-  isInstInList(Instruction *I,
-               const SmallVectorImpl<Instruction *> &Insts) const override {
-    if (LoadInst *LI = dyn_cast<LoadInst>(I))
-      return LI->getOperand(0) == GV;
-    return cast<StoreInst>(I)->getPointerOperand() == GV;
-  }
-
-  void replaceLoadWithValue(LoadInst *LI, Value *V) const override {
-    if (PHINode *phi = dyn_cast<PHINode>(V)) {
-      LI->replaceAllUsesWith(phi);
-      // Add nullptr for phi, will create real handle in
-      // AddCreateHandleForPhiNodeAndSelect.
-      handleMap[phi] = nullptr;
-      return;
-    }
-    // Load use go here.
-    // Clone to keep the debug info.
-    Instruction *NewInst = LI->clone();
-    IRBuilder<> Builder(LI);
-    Builder.Insert(NewInst);
-    LI->replaceAllUsesWith(NewInst);
-    // Mark handle map.
-    // If cannot find, will return false in run();
-    if (Instruction *I = dyn_cast<Instruction>(V)) {
-      if (handleMap.count(I)) {
-        Instruction *handle = cast<Instruction>(handleMap[I]);
-        // Clone the handle to save debug info of LI.
-        handle = handle->clone();
-        Builder.Insert(handle);
-        handleMap[NewInst] = handle;
-      }
-    }
-  }
-};
 
 // Collect unused phi of resources and remove them.
 class ResourceRemover : public LoadAndStorePromoter {
@@ -408,29 +272,30 @@ public:
       GenerateDxilPatchConstantLdSt();
     if (SM->IsHS())
       GenerateDxilPatchConstantFunctionInputs();
+    std::unordered_set<LoadInst *> UpdateCounterSet;
+    std::unordered_set<Value *> NonUniformSet;
+
+    GenerateDxilOperations(M, UpdateCounterSet, NonUniformSet);
 
     std::unordered_map<Instruction *, Value *> handleMap;
-    GenerateDxilResourceHandles(handleMap);
-    GenerateDxilCBufferHandles(handleMap);
-
-    // Map local or static global resource to global resource.
-    // Require inline for static global resource.
-    MapLocalDxilResourceHandles(handleMap);
-
-    // Take care phi node of resource.
-    AddCreateHandleForPhiNodeAndSelect(handleMap, m_pHLModule->GetOP());
-
+    GenerateDxilCBufferHandles(NonUniformSet);
     GenerateParamDxilResourceHandles(handleMap);
+    GenerateDxilResourceHandles(UpdateCounterSet, NonUniformSet);
+    AddCreateHandleForPhiNodeAndSelect(m_pHLModule->GetOP());
 
-    GenerateDxilOperations(M, handleMap);
-
-    if (NotOptimized || m_HasDbgInfo) {
-      // For module which not promote mem2reg.
-      // Remove local resource alloca/load/store/phi.
-      Module &M = *m_pHLModule->GetModule();
-      for (Function &F : M.functions()) {
-        if (!F.isDeclaration())
-          RemoveLocalDxilResourceAllocas(&F);
+    // For module which not promote mem2reg.
+    // Remove local resource alloca/load/store/phi.
+    for (auto It = M.begin(); It != M.end();) {
+      Function &F = *(It++);
+      if (!F.isDeclaration()) {
+        RemoveLocalDxilResourceAllocas(&F);
+        if (hlsl::GetHLOpcodeGroupByName(&F) == HLOpcodeGroup::HLCreateHandle) {
+          if (F.user_empty()) {
+            F.eraseFromParent();
+          } else {
+            M.getContext().emitError("Fail to lower createHandle.");
+          }
+        }
       }
     }
 
@@ -469,24 +334,21 @@ private:
   void GenerateClipPlanesForVS(Value *outPosition);
   bool HasClipPlanes();
 
-  void TranslateLocalDxilResourceUses(
-      Function *F, std::vector<GlobalVariable *> &staticResources,
-      std::unordered_map<Instruction *, Value *> &handleMap);
   void RemoveLocalDxilResourceAllocas(Function *F);
-  void MapLocalDxilResourceHandles(
-      std::unordered_map<Instruction *, Value *> &handleMap);
-  void TranslateDxilResourceUses(
-      DxilResourceBase &res,
-      std::unordered_map<Instruction *, Value *> &handleMap);
-  void AddCreateHandleForPhiNodeAndSelect(std::unordered_map<Instruction *, Value *> &handleMap, OP *hlslOP);
-  void GenerateDxilResourceHandles(
-      std::unordered_map<Instruction *, Value *> &handleMap);
+  void
+  TranslateDxilResourceUses(DxilResourceBase &res,
+                            std::unordered_set<LoadInst *> &UpdateCounterSet,
+                            std::unordered_set<Value *> &NonUniformSet);
+  void
+  GenerateDxilResourceHandles(std::unordered_set<LoadInst *> &UpdateCounterSet,
+                              std::unordered_set<Value *> &NonUniformSet);
+  void AddCreateHandleForPhiNodeAndSelect(OP *hlslOP);
   void TranslateParamDxilResourceHandles(Function *F, std::unordered_map<Instruction *, Value *> &handleMap);
   void GenerateParamDxilResourceHandles(
       std::unordered_map<Instruction *, Value *> &handleMap);
   // Generate DXIL cbuffer handles.
-  void GenerateDxilCBufferHandles(
-      std::unordered_map<Instruction *, Value *> &handleMap);
+  void
+  GenerateDxilCBufferHandles(std::unordered_set<Value *> &NonUniformSet);
 
   // Generate DXIL stream output operation.
   void GenerateStreamOutputOperation(Value *streamVal, unsigned streamID);
@@ -494,8 +356,9 @@ private:
   void GenerateStreamOutputOperations();
 
   // change built-in funtion into DXIL operations
-  void GenerateDxilOperations(
-      Module &M, std::unordered_map<Instruction *, Value *> &handleMap);
+  void GenerateDxilOperations(Module &M,
+                              std::unordered_set<LoadInst *> &UpdateCounterSet,
+                              std::unordered_set<Value *> &NonUniformSet);
 
   // Change struct type to legacy layout for cbuf and struct buf.
   void UpdateStructTypeForLegacyLayout();
@@ -1846,192 +1709,16 @@ static Value *SelectOnOperand(Value *Cond, CallInst *CIT, CallInst *CIF,
   return OpSel;
 }
 
-void DxilGenerationPass::AddCreateHandleForPhiNodeAndSelect(std::unordered_map<Instruction *, Value *> &handleMap, OP *hlslOP) {
-  Function *createHandle = hlslOP->GetOpFunc(
-      OP::OpCode::CreateHandle, llvm::Type::getVoidTy(hlslOP->GetCtx()));
-
-  std::unordered_set<PHINode *> objPhiList;
-  std::unordered_set<SelectInst *> objSelectList;
-  for (auto It : handleMap) {
-    Instruction *I = It.first;
-    for (User *U : I->users()) {
-      if (PHINode *phi = dyn_cast<PHINode>(U)) {
-        if (objPhiList.count(phi) == 0)
-          objPhiList.insert(phi);
-      } else if (SelectInst *sel = dyn_cast<SelectInst>(U)) {
-        if (objSelectList.count(sel) == 0)
-          objSelectList.insert(sel);
-      }
-    }
+static void ReplaceResourceUserWithHandle(LoadInst *Res, Value *handle) {
+  for (auto resUser = Res->user_begin(); resUser != Res->user_end();) {
+    CallInst *CI = dyn_cast<CallInst>(*(resUser++));
+    DXASSERT(GetHLOpcodeGroupByName(CI->getCalledFunction()) ==
+                 HLOpcodeGroup::HLCreateHandle,
+             "must be createHandle");
+    CI->replaceAllUsesWith(handle);
+    CI->eraseFromParent();
   }
-
-  // Scan phi list to add resource phi node which all operands are phi nodes.
-  std::vector<PHINode *> objPhiVec(objPhiList.begin(), objPhiList.end());
-  while (!objPhiVec.empty()) {
-    PHINode *phi = objPhiVec.back();
-    objPhiVec.pop_back();
-    unsigned numOperands = phi->getNumOperands();
-    for (unsigned i = 0; i < numOperands; i++) {
-      if (PHINode *nestPhi = dyn_cast<PHINode>(phi->getIncomingValue(i))) {
-        if (objPhiList.count(nestPhi) == 0) {
-          objPhiList.insert(nestPhi);
-          objPhiVec.emplace_back(nestPhi);
-        }
-      }
-    }
-  }
-
-  Value *opArg = hlslOP->GetU32Const((unsigned)OP::OpCode::CreateHandle);
-  Type *resClassTy = Type::getInt8Ty(opArg->getContext());
-  Type *resIDTy = opArg->getType();
-  Type *resAddressTy = opArg->getType();
-  // Phi node object is not uniform
-  Value *isUniformRes = hlslOP->GetI1Const(0);
-
-  // Generate phi for each operands of the createHandle
-  // Then generate createHandle with phi operands.
-  for (PHINode *phi : objPhiList) {
-    IRBuilder<> Builder(phi);
-    unsigned numOperands = phi->getNumOperands();
-    // res class must be same.
-    Value *resClassPhi = Builder.CreatePHI(resClassTy, numOperands);
-    Value *resIDPhi = Builder.CreatePHI(resIDTy, numOperands);
-    Value *resAddressPhi = Builder.CreatePHI(resAddressTy, numOperands);
-
-    IRBuilder<> HandleBuilder(phi->getParent()->getFirstNonPHI());
-    Value *handlePhi = HandleBuilder.CreateCall(createHandle, { opArg, resClassPhi, resIDPhi, resAddressPhi, isUniformRes});
-    handleMap[phi] = handlePhi;
-  }
-
-  // Setup operands for phi operands.
-  for (PHINode *phi : objPhiList) {
-    IRBuilder<> Builder(phi);
-    unsigned numOperands = phi->getNumOperands();
-
-    CallInst *handlePhi = cast<CallInst>(handleMap[phi]);
-
-    PHINode *resClassPhi = cast<PHINode>(handlePhi->getArgOperand(
-        DXIL::OperandIndex::kCreateHandleResClassOpIdx));
-    PHINode *resIDPhi = cast<PHINode>(
-        handlePhi->getArgOperand(DXIL::OperandIndex::kCreateHandleResIDOpIdx));
-    PHINode *resAddressPhi = cast<PHINode>(handlePhi->getArgOperand(
-        DXIL::OperandIndex::kCreateHandleResIndexOpIdx));
-    Value *resClass0 = nullptr;
-    Value *resID0 = nullptr;
-    for (unsigned i = 0; i < numOperands; i++) {
-
-      BasicBlock *BB = phi->getIncomingBlock(i);
-      if (isa<UndefValue>(phi->getOperand(i))) {
-        phi->getContext().emitError(
-            phi, kResourceMapErrorMsg);
-        return;
-      }
-      Instruction *phiOperand = cast<Instruction>(phi->getOperand(i));
-      if (!handleMap.count(phiOperand)) {
-        phi->getContext().emitError(
-            phi, kResourceMapErrorMsg);
-        return;
-      }
-      CallInst *handleI = cast<CallInst>(handleMap[phiOperand]);
-
-      Value *resClassI = handleI->getArgOperand(
-          DXIL::OperandIndex::kCreateHandleResClassOpIdx);
-      resClassPhi->addIncoming(resClassI, BB);
-
-      Value *resIDI =
-          handleI->getArgOperand(DXIL::OperandIndex::kCreateHandleResIDOpIdx);
-      resIDPhi->addIncoming(resIDI, BB);
-      if (i == 0) {
-        resClass0 = resClassI;
-        resID0 = resIDI;
-      } else {
-        if (resClass0 != resClassI)
-          resClass0 = nullptr;
-        if (resID0 != resIDI)
-          resID0 = nullptr;
-      }
-      Value *resAddressI = handleI->getArgOperand(
-          DXIL::OperandIndex::kCreateHandleResIndexOpIdx);
-      resAddressPhi->addIncoming(resAddressI, BB);
-    }
-
-    if (resClass0) {
-      resClassPhi->replaceAllUsesWith(resClass0);
-      resClassPhi->eraseFromParent();
-    }
-    if (resID0) {
-      resIDPhi->replaceAllUsesWith(resID0);
-      resIDPhi->eraseFromParent();
-    }
-  }
-
-  // Merge res class into imm.
-  for (PHINode *phi : objPhiList) {
-    Instruction *phiOperand = cast<Instruction>(phi->getOperand(0));
-    CallInst *handle0 = cast<CallInst>(handleMap[phiOperand]);
-    Value *resClass =
-        handle0->getArgOperand(DXIL::OperandIndex::kCreateHandleResClassOpIdx);
-    Value *immResClass = MergeImmResClass(resClass);
-    handle0->setArgOperand(DXIL::OperandIndex::kCreateHandleResClassOpIdx,
-                           immResClass);
-
-    CallInst *handlePhi = cast<CallInst>(handleMap[phi]);
-
-    if (PHINode *resID = dyn_cast<PHINode>(handlePhi->getArgOperand(
-            DXIL::OperandIndex::kCreateHandleResIDOpIdx))) {
-      unsigned numOperands = resID->getNumOperands();
-      if (numOperands > 0) {
-        Value *resID0 = resID->getIncomingValue(0);
-        for (unsigned i=1;i<numOperands;i++) {
-          if (resID->getIncomingValue(i) != resID0) {
-            resID->getContext().emitError(handle0, kResourceMapErrorMsg);
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  // Drop all ref of the phi to help remove the useless createHandles.
-  for (PHINode *phi : objPhiList) {
-    Value *undefObj = UndefValue::get(phi->getType());
-    unsigned numOperands = phi->getNumOperands();
-    for (unsigned i = 0; i < numOperands; i++) {
-      phi->setIncomingValue(i, undefObj);
-    }
-  }
-
-  // Create sel for each operands of the createHandle.
-  // Generate createHandle with sel operand.
-  // Map createHandle to original sel.
-  for (SelectInst *Sel : objSelectList) {
-    Value *Cond = Sel->getCondition();
-    Value *ValT = Sel->getTrueValue();
-    Value *ValF = Sel->getFalseValue();
-
-    if (!isa<Instruction>(ValT) || !handleMap.count(cast<Instruction>(ValT)) ||
-        !isa<Instruction>(ValF) || !handleMap.count(cast<Instruction>(ValF))) {
-      Sel->getContext().emitError(Sel, kResourceMapErrorMsg);
-      continue;
-    }
-
-    CallInst *handleT = cast<CallInst>(handleMap[cast<Instruction>(ValT)]);
-    CallInst *handleF = cast<CallInst>(handleMap[cast<Instruction>(ValF)]);
-    IRBuilder<> Builder(Sel);
-    Value *ResClass = SelectOnOperand(Cond, handleT, handleF, DXIL::OperandIndex::kCreateHandleResClassOpIdx,
-        Builder);
-    Value *ResID = SelectOnOperand(Cond, handleT, handleF, DXIL::OperandIndex::kCreateHandleResIDOpIdx,
-        Builder);
-
-    if (isa<SelectInst>(ResID) || isa<SelectInst>(ResClass)) {
-      Sel->getContext().emitError(Sel, kResourceMapErrorMsg);
-    }
-    Value *ResAddress = SelectOnOperand(Cond, handleT, handleF, DXIL::OperandIndex::kCreateHandleResIndexOpIdx,
-        Builder);
-
-    Value *handleSel = Builder.CreateCall(createHandle, { opArg, ResClass, ResID, ResAddress, isUniformRes});
-    handleMap[Sel] = handleSel;
-  }
+  Res->eraseFromParent();
 }
 
 static bool IsResourceType(Type *Ty) {
@@ -2047,69 +1734,6 @@ static bool IsResourceType(Type *Ty) {
     DXASSERT(!isResource, "local resource array");
   }
   return isResource;
-}
-
-void DxilGenerationPass::TranslateLocalDxilResourceUses(Function *F, std::vector<GlobalVariable*> &staticResources,
-    std::unordered_map<Instruction *, Value *> &handleMap) {
-  BasicBlock &BB = F->getEntryBlock(); // Get the entry node for the function
-  std::unordered_set<Value *> localResources(staticResources.begin(),
-                                             staticResources.end());
-
-  for (BasicBlock::iterator I = BB.begin(), E = --BB.end(); I != E; ++I)
-    if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) { // Is it an alloca?
-      if (IsResourceType(AI->getAllocatedType())) {
-        localResources.insert(AI);
-      }
-    }
-
-  SSAUpdater SSA;
-  SmallVector<Instruction *, 4> Insts;
-  // Make sure every resource load has mapped to handle.
-  while (!localResources.empty()) {
-    bool bUpdated = false;
-    for (auto it = localResources.begin(); it != localResources.end();) {
-      Value *V = *(it++);
-      bool hasHandleStore = false;
-      // Build list of instructions to promote.
-      for (User *U : V->users()) {
-        Instruction *I = cast<Instruction>(U);
-        if (StoreInst *SI = dyn_cast<StoreInst>(I)) {
-          if (Instruction *resI =
-                  dyn_cast<Instruction>(SI->getValueOperand())) {
-            if (handleMap.count(resI))
-              hasHandleStore = true;
-          }
-        }
-        Insts.emplace_back(I);
-      }
-
-      // No handle here, wait for next round.
-      if (!hasHandleStore) {
-        Insts.clear();
-        continue;
-      }
-
-      bUpdated = true;
-
-      if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
-        AllocaInst *NewAI =
-            LocalResourcePromoter(Insts, SSA, handleMap).run(AI, Insts);
-        localResources.erase(AI);
-        if (NewAI)
-          localResources.insert(NewAI);
-      } else {
-        GlobalVariable *GV = cast<GlobalVariable>(V);
-        if (StaticResourcePromoter(Insts, SSA, handleMap).run(GV, Insts)) {
-          localResources.erase(GV);
-        }
-      }
-      Insts.clear();
-    }
-    if (!bUpdated) {
-      F->getContext().emitError(kResourceMapErrorMsg);
-      break;
-    }
-  }
 }
 
 void DxilGenerationPass::RemoveLocalDxilResourceAllocas(Function *F) {
@@ -2133,23 +1757,6 @@ void DxilGenerationPass::RemoveLocalDxilResourceAllocas(Function *F) {
     ResourceRemover(Insts, SSA).run(AI, Insts);
 
     Insts.clear();
-  }
-}
-
-void DxilGenerationPass::MapLocalDxilResourceHandles(
-    std::unordered_map<Instruction *, Value *> &handleMap) {
-  Module &M = *m_pHLModule->GetModule();
-  std::vector<GlobalVariable*> staticResources;
-  for (auto &GV : M.globals()) {
-    if (GV.getLinkage() == GlobalValue::LinkageTypes::InternalLinkage &&
-        IsResourceType(GV.getType()->getElementType())) {
-      staticResources.emplace_back(&GV);
-    }
-  }
-
-  for (Function &F : M.functions()) {
-    if (!F.isDeclaration())
-      TranslateLocalDxilResourceUses(&F, staticResources, handleMap);
   }
 }
 
@@ -2182,7 +1789,6 @@ void DxilGenerationPass::TranslateParamDxilResourceHandles(Function *F, std::uno
 
       for (User *U : arg.users()) {
         Instruction *I = cast<Instruction>(U);
-
         IRBuilder<> userBuilder(I);
         if (LoadInst *ldInst = dyn_cast<LoadInst>(U)) {
           Value *handleLd = userBuilder.CreateLoad(castToHandle);
@@ -2235,7 +1841,9 @@ void DxilGenerationPass::GenerateParamDxilResourceHandles(
   }
 }
 
-void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::unordered_map<Instruction *, Value *> &handleMap) {
+void DxilGenerationPass::TranslateDxilResourceUses(
+    DxilResourceBase &res, std::unordered_set<LoadInst *> &UpdateCounterSet,
+    std::unordered_set<Value *> &NonUniformSet) {
   OP *hlslOP = m_pHLModule->GetOP();
   Function *createHandle = hlslOP->GetOpFunc(
       OP::OpCode::CreateHandle, llvm::Type::getVoidTy(m_pHLModule->GetCtx()));
@@ -2256,7 +1864,6 @@ void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::u
   Value *resLowerBound = hlslOP->GetU32Const(0);
   // TODO: Set Non-uniform resource bit based on whether index comes from IOP_NonUniformResourceIndex.
   Value *isUniformRes = hlslOP->GetI1Const(0);
-  Value *createHandleArgs[] = {opArg, resClassArg, resIDArg, resLowerBound, isUniformRes};
 
   Value *GV = res.GetGlobalSymbol();
   Module *pM = m_pHLModule->GetModule();
@@ -2274,7 +1881,10 @@ void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::u
   }
 
   bool isResArray = res.GetRangeSize() > 1;
-  std::unordered_map<Function *, Value *> handleMapOnFunction;
+  std::unordered_map<Function *, Instruction *> handleMapOnFunction;
+
+  Value *createHandleArgs[] = {opArg, resClassArg, resIDArg, resLowerBound,
+                               isUniformRes};
 
   for (iplist<Function>::iterator F : pM->getFunctionList()) {
     if (!F->isDeclaration()) {
@@ -2296,10 +1906,16 @@ void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::u
       continue;
 
     if (LoadInst *ldInst = dyn_cast<LoadInst>(user)) {
+      if (UpdateCounterSet.count(ldInst)) {
+        DxilResource *resource = dynamic_cast<DxilResource*>(&res);
+        DXASSERT_NOMSG(resource);
+        DXASSERT_NOMSG(resource->GetClass() == DXIL::ResourceClass::UAV);
+        resource->SetHasCounter(true);
+      }
       Function *userF = ldInst->getParent()->getParent();
       DXASSERT(handleMapOnFunction.count(userF), "must exist");
       Value *handle = handleMapOnFunction[userF];
-      handleMap[ldInst] = handle;
+      ReplaceResourceUserWithHandle(ldInst, handle);
     } else {
       DXASSERT(dyn_cast<GEPOperator>(user) != nullptr,
                "else AddOpcodeParamForIntrinsic in CodeGen did not patch uses "
@@ -2333,6 +1949,13 @@ void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::u
       }
 
       createHandleArgs[DXIL::OperandIndex::kCreateHandleResIndexOpIdx] = idx;
+      if (!NonUniformSet.count(idx))
+        createHandleArgs[DXIL::OperandIndex::kCreateHandleIsUniformOpIdx] =
+            isUniformRes;
+      else
+        createHandleArgs[DXIL::OperandIndex::kCreateHandleIsUniformOpIdx] =
+            hlslOP->GetI1Const(1);
+
       Value *handle = nullptr;
       if (GetElementPtrInst *GEPInst = dyn_cast<GetElementPtrInst>(GEP)) {
         IRBuilder<> Builder = IRBuilder<>(GEPInst);
@@ -2342,37 +1965,278 @@ void DxilGenerationPass::TranslateDxilResourceUses(DxilResourceBase &res, std::u
       for (auto GEPU = GEP->user_begin(), GEPE = GEP->user_end(); GEPU != GEPE; ) {
         // Must be load inst.
         LoadInst *ldInst = cast<LoadInst>(*(GEPU++));
-        if (handle)
-          handleMap[ldInst] = handle;
+        if (UpdateCounterSet.count(ldInst)) {
+          DxilResource *resource = dynamic_cast<DxilResource *>(&res);
+          DXASSERT_NOMSG(resource);
+          DXASSERT_NOMSG(resource->GetClass() == DXIL::ResourceClass::UAV);
+          resource->SetHasCounter(true);
+        }
+        if (handle) {
+          ReplaceResourceUserWithHandle(ldInst, handle);
+        }
         else {
           IRBuilder<> Builder = IRBuilder<>(ldInst);
-          handleMap[ldInst] = Builder.CreateCall(createHandle, createHandleArgs, handleName);
+          Value *localHandle = Builder.CreateCall(createHandle, createHandleArgs, handleName);
+          ReplaceResourceUserWithHandle(ldInst, localHandle);
         }
       }
     }
   }
+  // Erase unused handle.
+  for (auto It : handleMapOnFunction) {
+    Instruction *I = It.second;
+    if (I->user_empty())
+      I->eraseFromParent();
+  }
 }
 
-void DxilGenerationPass::GenerateDxilResourceHandles(std::unordered_map<Instruction *, Value *> &handleMap) {
+void DxilGenerationPass::GenerateDxilResourceHandles(
+    std::unordered_set<LoadInst *> &UpdateCounterSet,
+    std::unordered_set<Value *> &NonUniformSet) {
   // Create sampler handle first, may be used by SRV operations.
   for (size_t i = 0; i < m_pHLModule->GetSamplers().size(); i++) {
     DxilSampler &S = m_pHLModule->GetSampler(i);
-    TranslateDxilResourceUses(S, handleMap);
+    TranslateDxilResourceUses(S, UpdateCounterSet, NonUniformSet);
   }
 
   for (size_t i = 0; i < m_pHLModule->GetSRVs().size(); i++) {
     HLResource &SRV = m_pHLModule->GetSRV(i);
-    TranslateDxilResourceUses(SRV, handleMap);
+    TranslateDxilResourceUses(SRV, UpdateCounterSet, NonUniformSet);
   }
 
   for (size_t i = 0; i < m_pHLModule->GetUAVs().size(); i++) {
     HLResource &UAV = m_pHLModule->GetUAV(i);
-    TranslateDxilResourceUses(UAV, handleMap);
+    TranslateDxilResourceUses(UAV, UpdateCounterSet, NonUniformSet);
   }
 }
 
-void DxilGenerationPass::GenerateDxilCBufferHandles(std::unordered_map<Instruction *, Value *> &handleMap) {
-  // For CBuffer, handle are mapped to CBufferSubscript.
+static void
+AddResourceToSet(Instruction *Res, std::unordered_set<Instruction *> &resSet) {
+  unsigned startOpIdx = 0;
+  // Skip Cond for Select.
+  if (isa<SelectInst>(Res))
+    startOpIdx = 1;
+  else if (!isa<PHINode>(Res))
+    // Only check phi and select here.
+    return;
+
+  // Already add.
+  if (resSet.count(Res))
+    return;
+
+  resSet.insert(Res);
+
+  // Scan operand to add resource node which only used by phi/select.
+  unsigned numOperands = Res->getNumOperands();
+  for (unsigned i = startOpIdx; i < numOperands; i++) {
+    Value *V = Res->getOperand(i);
+    if (Instruction *I = dyn_cast<Instruction>(V)) {
+      AddResourceToSet(I, resSet);
+    }
+  }
+}
+
+// Transform
+//
+//  %g_texture_texture_2d1 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 0, i1 false)
+//  %g_texture_texture_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 2, i1 false)
+//  %13 = select i1 %cmp, %dx.types.Handle %g_texture_texture_2d1, %dx.types.Handle %g_texture_texture_2d
+// Into
+//  %11 = select i1 %cmp, i32 0, i32 2
+//  %12 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 %11, i1 false)
+//
+
+static bool MergeHandleOpWithSameValue(Instruction *HandleOp,
+                                       unsigned startOpIdx,
+                                       unsigned numOperands) {
+  Value *op0 = nullptr;
+  for (unsigned i = startOpIdx; i < numOperands; i++) {
+    Value *op = HandleOp->getOperand(i);
+    if (i == startOpIdx) {
+      op0 = op;
+    } else {
+      if (op0 != op)
+        op0 = nullptr;
+    }
+  }
+  if (op0) {
+    HandleOp->replaceAllUsesWith(op0);
+    return true;
+  }
+  return false;
+}
+
+static void
+UpdateHandleOperands(Instruction *Res,
+                     std::unordered_map<Instruction *, CallInst *> &handleMap,
+                     std::unordered_set<Instruction *> &nonUniformOps) {
+  unsigned numOperands = Res->getNumOperands();
+
+  unsigned startOpIdx = 0;
+  // Skip Cond for Select.
+  if (SelectInst *Sel = dyn_cast<SelectInst>(Res))
+    startOpIdx = 1;
+
+  CallInst *Handle = handleMap[Res];
+
+  Instruction *resClass = cast<Instruction>(
+      Handle->getArgOperand(DXIL::OperandIndex::kCreateHandleResClassOpIdx));
+  Instruction *resID = cast<Instruction>(
+      Handle->getArgOperand(DXIL::OperandIndex::kCreateHandleResIDOpIdx));
+  Instruction *resAddr = cast<Instruction>(
+      Handle->getArgOperand(DXIL::OperandIndex::kCreateHandleResIndexOpIdx));
+
+  for (unsigned i = startOpIdx; i < numOperands; i++) {
+    if (!isa<Instruction>(Res->getOperand(i))) {
+      Res->getContext().emitError(Res, kResourceMapErrorMsg);
+      continue;
+    }
+    Instruction *ResOp = cast<Instruction>(Res->getOperand(i));
+    CallInst *HandleOp = dyn_cast<CallInst>(ResOp);
+
+    if (!HandleOp) {
+      if (handleMap.count(ResOp)) {
+        Res->getContext().emitError(Res, kResourceMapErrorMsg);
+        continue;
+      }
+      HandleOp = handleMap[ResOp];
+    }
+
+    Value *resClassOp =
+        HandleOp->getArgOperand(DXIL::OperandIndex::kCreateHandleResClassOpIdx);
+    Value *resIDOp =
+        HandleOp->getArgOperand(DXIL::OperandIndex::kCreateHandleResIDOpIdx);
+    Value *resAddrOp =
+        HandleOp->getArgOperand(DXIL::OperandIndex::kCreateHandleResIndexOpIdx);
+
+    resClass->setOperand(i, resClassOp);
+    resID->setOperand(i, resIDOp);
+    resAddr->setOperand(i, resAddrOp);
+  }
+
+  if (!MergeHandleOpWithSameValue(resClass, startOpIdx, numOperands))
+    nonUniformOps.insert(resClass);
+  if (!MergeHandleOpWithSameValue(resID, startOpIdx, numOperands))
+    nonUniformOps.insert(resID);
+  MergeHandleOpWithSameValue(resAddr, startOpIdx, numOperands);
+}
+
+void DxilGenerationPass::AddCreateHandleForPhiNodeAndSelect(OP *hlslOP) {
+  Function *createHandle = hlslOP->GetOpFunc(
+      OP::OpCode::CreateHandle, llvm::Type::getVoidTy(hlslOP->GetCtx()));
+
+  std::unordered_set<PHINode *> objPhiList;
+  std::unordered_set<SelectInst *> objSelectList;
+  std::unordered_set<Instruction *> resSelectSet;
+  for (User *U : createHandle->users()) {
+    for (User *HandleU : U->users()) {
+      Instruction *I = cast<Instruction>(HandleU);
+      if (!isa<CallInst>(I))
+        AddResourceToSet(I, resSelectSet);
+    }
+  }
+
+  // Generate Handle inst for Res inst.
+  FunctionType *FT = createHandle->getFunctionType();
+  Value *opArg = hlslOP->GetU32Const((unsigned)OP::OpCode::CreateHandle);
+  Type *resClassTy =
+      FT->getParamType(DXIL::OperandIndex::kCreateHandleResClassOpIdx);
+  Type *resIDTy = FT->getParamType(DXIL::OperandIndex::kCreateHandleResIDOpIdx);
+  Type *resAddrTy =
+      FT->getParamType(DXIL::OperandIndex::kCreateHandleResIndexOpIdx);
+  Value *UndefResClass = UndefValue::get(resClassTy);
+  Value *UndefResID = UndefValue::get(resIDTy);
+  Value *UndefResAddr = UndefValue::get(resAddrTy);
+
+  // phi/select node resource is not uniform
+  Value *nonUniformRes = hlslOP->GetI1Const(1);
+  std::unordered_map<Instruction *, CallInst *> handleMap;
+  for (Instruction *Res : resSelectSet) {
+    unsigned numOperands = Res->getNumOperands();
+    IRBuilder<> Builder(Res);
+
+    unsigned startOpIdx = 0;
+    // Skip Cond for Select.
+    if (SelectInst *Sel = dyn_cast<SelectInst>(Res)) {
+      startOpIdx = 1;
+      Value *Cond = Sel->getCondition();
+
+      Value *resClassSel =
+          Builder.CreateSelect(Cond, UndefResClass, UndefResClass);
+      Value *resIDSel = Builder.CreateSelect(Cond, UndefResID, UndefResID);
+      Value *resAddrSel =
+          Builder.CreateSelect(Cond, UndefResAddr, UndefResAddr);
+
+      CallInst *HandleSel =
+          Builder.CreateCall(createHandle, {opArg, resClassSel, resIDSel,
+                                            resAddrSel, nonUniformRes});
+      handleMap[Res] = HandleSel;
+      Res->replaceAllUsesWith(HandleSel);
+    } else {
+      PHINode *Phi = cast<PHINode>(Res); // res class must be same.
+      PHINode *resClassPhi = Builder.CreatePHI(resClassTy, numOperands);
+      PHINode *resIDPhi = Builder.CreatePHI(resIDTy, numOperands);
+      PHINode *resAddrPhi = Builder.CreatePHI(resAddrTy, numOperands);
+      for (unsigned i = 0; i < numOperands; i++) {
+        BasicBlock *BB = Phi->getIncomingBlock(i);
+        resClassPhi->addIncoming(UndefResClass, BB);
+        resIDPhi->addIncoming(UndefResID, BB);
+        resAddrPhi->addIncoming(UndefResAddr, BB);
+      }
+      IRBuilder<> HandleBuilder(Phi->getParent()->getFirstNonPHI());
+      CallInst *HandlePhi =
+          HandleBuilder.CreateCall(createHandle, {opArg, resClassPhi, resIDPhi,
+                                                  resAddrPhi, nonUniformRes});
+      handleMap[Res] = HandlePhi;
+      Res->replaceAllUsesWith(HandlePhi);
+    }
+  }
+
+  // Update operand for Handle phi/select.
+  std::unordered_set<Instruction *> nonUniformOps;
+  for (Instruction *Res : resSelectSet) {
+    UpdateHandleOperands(Res, handleMap, nonUniformOps);
+  }
+
+  // Merge res class, res id into imm.
+  while (1) {
+    bool bUpdated = false;
+
+    for (auto It = nonUniformOps.begin(); It != nonUniformOps.end();) {
+      Instruction *I = *(It++);
+      unsigned numOperands = I->getNumOperands();
+
+      unsigned startOpIdx = 0;
+      // Skip Cond for Select.
+      if (SelectInst *Sel = dyn_cast<SelectInst>(I))
+        startOpIdx = 1;
+      if (MergeHandleOpWithSameValue(I, startOpIdx, numOperands)) {
+        nonUniformOps.erase(I);
+        bUpdated = true;
+      }
+    }
+
+    if (!bUpdated) {
+      if (!nonUniformOps.empty()) {
+        for (Instruction *I : nonUniformOps) {
+          // Non uniform res class or res id.
+          FT->getContext().emitError(I, kResourceMapErrorMsg);
+        }
+        return;
+      }
+      break;
+    }
+  }
+
+  // Remove useless select/phi.
+  for (Instruction *Res : resSelectSet) {
+    Res->eraseFromParent();
+  }
+}
+
+void DxilGenerationPass::GenerateDxilCBufferHandles(
+    std::unordered_set<Value *> &NonUniformSet) {
+  // For CBuffer, handle are mapped to HLCreateHandle.
   OP *hlslOP = m_pHLModule->GetOP();
   Function *createHandle = hlslOP->GetOpFunc(
       OP::OpCode::CreateHandle, llvm::Type::getVoidTy(m_pHLModule->GetCtx()));
@@ -2382,13 +2246,14 @@ void DxilGenerationPass::GenerateDxilCBufferHandles(std::unordered_map<Instructi
       static_cast<std::underlying_type<DxilResourceBase::Class>::type>(
           DXIL::ResourceClass::CBuffer));
 
-  Value *args[] = { opArg, resClassArg, nullptr, nullptr, hlslOP->GetI1Const(0)};
 
   for (size_t i = 0; i < m_pHLModule->GetCBuffers().size(); i++) {
     DxilCBuffer &CB = m_pHLModule->GetCBuffer(i);
     GlobalVariable *GV = cast<GlobalVariable>(CB.GetGlobalSymbol());
     std::string handleName = std::string(GV->getName()) + "_buffer";
 
+    Value *args[] = {opArg, resClassArg, nullptr, nullptr,
+                     hlslOP->GetI1Const(0)};
     DIVariable *DIV = nullptr;
     DILocation *DL = nullptr;
     if (m_HasDbgInfo) {
@@ -2408,9 +2273,9 @@ void DxilGenerationPass::GenerateDxilCBufferHandles(std::unordered_map<Instructi
 
     if (CB.GetRangeSize() == 1) {
       args[DXIL::OperandIndex::kCreateHandleResIndexOpIdx] = resLowerBound;
-      for (auto U : GV->users()) {
-        // Must CBufferSubscript.
-        CallInst *CI = cast<CallInst>((U));
+      for (auto U = GV->user_begin(); U != GV->user_end(); ) {
+        // Must HLCreateHandle.
+        CallInst *CI = cast<CallInst>(*(U++));
         // Put createHandle to entry block.
         auto InsertPt =
             CI->getParent()->getParent()->getEntryBlock().getFirstInsertionPt();
@@ -2421,14 +2286,15 @@ void DxilGenerationPass::GenerateDxilCBufferHandles(std::unordered_map<Instructi
           // TODO: add debug info.
           //handle->setDebugLoc(DL);
         }
-        handleMap[CI] = handle;
+        CI->replaceAllUsesWith(handle);
+        CI->eraseFromParent();
       }
     } else {
-      for (auto U : GV->users()) {
-        // Must CBufferSubscript.
-        CallInst *CI = cast<CallInst>(U);
+      for (auto U = GV->user_begin(); U != GV->user_end(); ) {
+        // Must HLCreateHandle.
+        CallInst *CI = cast<CallInst>(*(U++));
         IRBuilder<> Builder(CI);
-        Value *CBIndex = CI->getArgOperand(HLOperandIndex::kSubscriptIndexOpIdx);
+        Value *CBIndex = CI->getArgOperand(HLOperandIndex::kCreateHandleIndexOpIdx);
         args[DXIL::OperandIndex::kCreateHandleResIndexOpIdx] =
             CBIndex;
         if (isa<ConstantInt>(CBIndex)) {
@@ -2439,8 +2305,16 @@ void DxilGenerationPass::GenerateDxilCBufferHandles(std::unordered_map<Instructi
                               .getFirstInsertionPt();
           Builder.SetInsertPoint(InsertPt);
         }
+        if (!NonUniformSet.count(CBIndex))
+          args[DXIL::OperandIndex::kCreateHandleIsUniformOpIdx] =
+              hlslOP->GetI1Const(0);
+        else
+          args[DXIL::OperandIndex::kCreateHandleIsUniformOpIdx] =
+              hlslOP->GetI1Const(1);
+
         CallInst *handle = Builder.CreateCall(createHandle, args, handleName);
-        handleMap[CI] = handle;
+        CI->replaceAllUsesWith(handle);
+        CI->eraseFromParent();
       }
     }
   } 
@@ -2535,7 +2409,8 @@ void DxilGenerationPass::GenerateStreamOutputOperations() {
 }
 
 void DxilGenerationPass::GenerateDxilOperations(
-    Module &M, std::unordered_map<Instruction *, Value *> &handleMap) {
+    Module &M, std::unordered_set<LoadInst *> &UpdateCounterSet,
+    std::unordered_set<Value *> &NonUniformSet) {
   // remove all functions except entry function
   Function *entry = m_pHLModule->GetEntryFunction();
   const ShaderModel *pSM = m_pHLModule->GetShaderModel();
@@ -2558,7 +2433,8 @@ void DxilGenerationPass::GenerateDxilOperations(
       func->eraseFromParent();
   }
 
-  TranslateBuiltinOperations(*m_pHLModule, handleMap, m_extensionsCodegenHelper);
+  TranslateBuiltinOperations(*m_pHLModule, m_extensionsCodegenHelper,
+                             UpdateCounterSet, NonUniformSet);
 
   if (pSM->IsGS())
     GenerateStreamOutputOperations();
@@ -2568,7 +2444,7 @@ void DxilGenerationPass::GenerateDxilOperations(
   for (iplist<Function>::iterator F : M.getFunctionList()) {
     if (F->isDeclaration()) {
       hlsl::HLOpcodeGroup group = hlsl::GetHLOpcodeGroupByName(F);
-      if (group != HLOpcodeGroup::NotHL || F->isIntrinsic()) 
+      if (group != HLOpcodeGroup::NotHL || F->isIntrinsic())
         if (F->user_empty())
           deadList.emplace_back(F);
     }
@@ -3163,3 +3039,279 @@ ModulePass *llvm::createDxilPrecisePropagatePass() {
 }
 
 INITIALIZE_PASS(DxilPrecisePropagatePass, "hlsl-dxil-precise", "DXIL precise attribute propagate", false, false)
+
+///////////////////////////////////////////////////////////////////////////////
+// Legalize resource use.
+// Map local or static global resource to global resource.
+// Require inline for static global resource.
+
+namespace {
+
+class DxilLegalizeStaticResourceUsePass : public ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit DxilLegalizeStaticResourceUsePass()
+      : ModulePass(ID) {}
+
+  const char *getPassName() const override {
+    return "DXIL Legalize Static Resource Use";
+  }
+
+  bool runOnModule(Module &M) override {
+    // Promote static global variables.
+    PromoteStaticGlobalResources(M);
+
+    // Transform PHINode/SelectInst on resource into PHINode/SelectInst on
+    // Handle. This will make sure resource only have ld/st/gep use.
+    TransformResourcePHINodeToHandlePHINode(M);
+    return true;
+  }
+
+private:
+  void PromoteStaticGlobalResources(Module &M);
+  void TransformResourcePHINodeToHandlePHINode(Module &M);
+};
+
+char DxilLegalizeStaticResourceUsePass::ID = 0;
+
+class DxilLegalizeResourceUsePass : public FunctionPass {
+  HLModule *m_pHLModule;
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit DxilLegalizeResourceUsePass()
+      : FunctionPass(ID), m_pHLModule(nullptr) {}
+
+  const char *getPassName() const override {
+    return "DXIL Legalize Resource Use";
+  }
+
+  bool runOnFunction(Function &F) override {
+    // Promote local resource first.
+    PromoteLocalResource(F);
+    return true;
+  }
+
+private:
+  void PromoteLocalResource(Function &F);
+};
+
+char DxilLegalizeResourceUsePass::ID = 0;
+
+}
+
+void DxilLegalizeResourceUsePass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<AssumptionCacheTracker>();
+  AU.addRequired<DominatorTreeWrapperPass>();
+  AU.setPreservesAll();
+}
+
+void DxilLegalizeResourceUsePass::PromoteLocalResource(Function &F) {
+  std::vector<AllocaInst *> Allocas;
+  DominatorTree *DT = &getAnalysis<DominatorTreeWrapperPass>().getDomTree();
+  AssumptionCache &AC =
+      getAnalysis<AssumptionCacheTracker>().getAssumptionCache(F);
+
+  BasicBlock &BB = F.getEntryBlock();
+  unsigned allocaSize = 0;
+  while (1) {
+    Allocas.clear();
+
+    // Find allocas that are safe to promote, by looking at all instructions in
+    // the entry node
+    for (BasicBlock::iterator I = BB.begin(), E = --BB.end(); I != E; ++I)
+      if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) { // Is it an alloca?
+        if (IsResourceType(AI->getAllocatedType()))
+          Allocas.push_back(AI);
+      }
+    if (Allocas.empty())
+      break;
+
+    // No update.
+    // Report error and break.
+    if (allocaSize == Allocas.size()) {
+      F.getContext().emitError(kResourceMapErrorMsg);
+      break;
+    }
+    allocaSize = Allocas.size();
+
+    PromoteMemToReg(Allocas, *DT, nullptr, &AC);
+  }
+
+  return;
+}
+
+FunctionPass *llvm::createDxilLegalizeResourceUsePass() {
+  return new DxilLegalizeResourceUsePass();
+}
+
+INITIALIZE_PASS_BEGIN(DxilLegalizeResourceUsePass,
+                      "hlsl-dxil-legalize-resource-use",
+                      "DXIL legalize resource use", false, true)
+INITIALIZE_PASS_DEPENDENCY(AssumptionCacheTracker)
+INITIALIZE_PASS_DEPENDENCY(DominatorTreeWrapperPass)
+INITIALIZE_PASS_END(DxilLegalizeResourceUsePass,
+                    "hlsl-dxil-legalize-resource-use",
+                    "DXIL legalize resource use", false, true)
+
+void DxilLegalizeStaticResourceUsePass::PromoteStaticGlobalResources(
+    Module &M) {
+  std::set<GlobalVariable *> staticResources;
+  for (auto &GV : M.globals()) {
+    if (GV.getLinkage() == GlobalValue::LinkageTypes::InternalLinkage &&
+        IsResourceType(GV.getType()->getElementType())) {
+      staticResources.insert(&GV);
+    }
+  }
+  SSAUpdater SSA;
+  SmallVector<Instruction *, 4> Insts;
+  // Make sure every resource load has mapped to global variable.
+  while (!staticResources.empty()) {
+    bool bUpdated = false;
+    for (auto it = staticResources.begin(); it != staticResources.end();) {
+      GlobalVariable *GV = *(it++);
+      // Build list of instructions to promote.
+      for (User *U : GV->users()) {
+        Instruction *I = cast<Instruction>(U);
+        Insts.emplace_back(I);
+      }
+
+      LoadAndStorePromoter(Insts, SSA).run(Insts);
+      if (GV->user_empty()) {
+        bUpdated = true;
+        staticResources.erase(GV);
+      }
+
+      Insts.clear();
+    }
+    if (!bUpdated) {
+      M.getContext().emitError(kResourceMapErrorMsg);
+      break;
+    }
+  }
+}
+
+void DxilLegalizeStaticResourceUsePass::TransformResourcePHINodeToHandlePHINode(
+    Module &M) {
+  HLModule &HLM = M.GetOrCreateHLModule();
+  OP *hlslOP = HLM.GetOP();
+  Type *HandleTy = hlslOP->GetHandleType();
+
+  std::unordered_set<Instruction *> resSet;
+  // Find all hl create handle which use a phi/select.
+  for (Function &TempF : M.functions()) {
+    if (GetHLOpcodeGroupByName(&TempF) == HLOpcodeGroup::HLCreateHandle) {
+      for (User *U : TempF.users()) {
+        CallInst *CI = cast<CallInst>(U);
+        Value *ResOp =
+            CI->getArgOperand(HLOperandIndex::kCreateHandleResourceOpIdx);
+        if (Instruction *Res = dyn_cast<Instruction>(ResOp))
+          AddResourceToSet(Res, resSet);
+        else if (isa<UndefValue>(ResOp)) {
+          CI->getContext().emitError(CI, kResourceMapErrorMsg);
+          continue;
+        }
+      }
+    }
+  }
+
+  Value *UndefHandle = UndefValue::get(HandleTy);
+
+  // Generate Handle inst for Res inst.
+  std::unordered_map<Instruction *, Value *> resHandleMap;
+  for (Instruction *Res : resSet) {
+    unsigned numOperands = Res->getNumOperands();
+    IRBuilder<> Builder(Res);
+
+    unsigned startOpIdx = 0;
+    // Skip Cond for Select.
+    if (SelectInst *Sel = dyn_cast<SelectInst>(Res)) {
+      startOpIdx = 1;
+      Value *Cond = Sel->getCondition();
+      // Use undef handle to create, will be updated in next loop.
+      Value *Handle = Builder.CreateSelect(Cond, UndefHandle, UndefHandle);
+      resHandleMap[Res] = Handle;
+    } else {
+      PHINode *Phi = cast<PHINode>(Res);
+      PHINode *HandlePhi = Builder.CreatePHI(HandleTy, numOperands);
+      // Use undef handle to create, will be updated in next loop.
+      for (unsigned i = 0; i < numOperands; i++) {
+        BasicBlock *BB = Phi->getIncomingBlock(i);
+        HandlePhi->addIncoming(UndefHandle, BB);
+      }
+      resHandleMap[Res] = HandlePhi;
+    }
+
+    // Generate createHandle for LdInst opreands.
+    for (unsigned i = startOpIdx; i < numOperands; i++) {
+      if (LoadInst *LI = dyn_cast<LoadInst>(Res->getOperand(i))) {
+        if (resHandleMap.count(LI))
+          continue;
+        IRBuilder<> LocalBuilder(LI);
+
+        Instruction *Handle =
+            HLM.EmitHLOperationCall(LocalBuilder, HLOpcodeGroup::HLCreateHandle,
+                                    /*opcode*/ 0, HandleTy, {LI}, M);
+        // No new HL createHandle will be created.
+        // So don't need MarkResourceAttribute here.
+        resHandleMap[LI] = Handle;
+      }
+    }
+  }
+
+  // Update operand for Handle phi/select.
+  for (Instruction *Res : resSet) {
+    unsigned numOperands = Res->getNumOperands();
+
+    unsigned startOpIdx = 0;
+    // Skip Cond for Select.
+    if (SelectInst *Sel = dyn_cast<SelectInst>(Res))
+      startOpIdx = 1;
+
+    Instruction *Handle = cast<Instruction>(resHandleMap[Res]);
+
+    for (unsigned i = startOpIdx; i < numOperands; i++) {
+      if (!isa<Instruction>(Res->getOperand(i))) {
+        Res->getContext().emitError(Res, kResourceMapErrorMsg);
+        continue;
+      }
+      Instruction *ResOp = cast<Instruction>(Res->getOperand(i));
+      if (resHandleMap.count(ResOp) == 0) {
+        Res->getContext().emitError(Res, kResourceMapErrorMsg);
+        continue;
+      }
+      Instruction *HandleOp = cast<Instruction>(resHandleMap[ResOp]);
+      Handle->setOperand(i, HandleOp);
+    }
+  }
+
+  // Replace use of handle with new created handle.
+  for (Instruction *Res : resSet) {
+    Value *Handle = resHandleMap[Res];
+    for (auto U = Res->user_begin(); U != Res->user_end();) {
+      User *ResU = *(U++);
+      if (isa<CallInst>(ResU) && ResU->getType() == HandleTy) {
+        ResU->replaceAllUsesWith(Handle);
+        cast<Instruction>(ResU)->eraseFromParent();
+      }
+    }
+  }
+
+  // Remove the unused phi/select on resource.
+  for (Instruction *Res : resSet) {
+    Res->dropAllReferences();
+  }
+
+  for (Instruction *Res : resSet) {
+    Res->eraseFromParent();
+  }
+}
+
+ModulePass *llvm::createDxilLegalizeStaticResourceUsePass() {
+  return new DxilLegalizeStaticResourceUsePass();
+}
+
+INITIALIZE_PASS(DxilLegalizeStaticResourceUsePass,
+                "hlsl-dxil-legalize-static-resource-use",
+                "DXIL legalize static resource use", false, false)

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -2193,12 +2193,14 @@ void DxilGenerationPass::AddCreateHandleForPhiNodeAndSelect(OP *hlslOP) {
   }
 
   // Update operand for Handle phi/select.
+  // If ResClass or ResID is phi/select, save to nonUniformOps.
   std::unordered_set<Instruction *> nonUniformOps;
   for (Instruction *Res : resSelectSet) {
     UpdateHandleOperands(Res, handleMap, nonUniformOps);
   }
 
-  // Merge res class, res id into imm.
+  // ResClass and ResID must be uniform.
+  // Try to merge res class, res id into imm.
   while (1) {
     bool bUpdated = false;
 

--- a/lib/HLSL/DxilMetadataHelper.cpp
+++ b/lib/HLSL/DxilMetadataHelper.cpp
@@ -44,6 +44,7 @@ const char DxilMDHelper::kDxilTypeSystemMDName[]                      = "dx.type
 const char DxilMDHelper::kDxilTypeSystemHelperVariablePrefix[]        = "dx.typevar.";
 const char DxilMDHelper::kDxilControlFlowHintMDName[]                 = "dx.controlflow.hints";
 const char DxilMDHelper::kDxilPreciseAttributeMDName[]                = "dx.precise";
+const char DxilMDHelper::kDxilResourceAttributeMDName[]               = "dx.resource.attribute";
 const char DxilMDHelper::kDxilValidatorVersionMDName[]                = "dx.valver";
 
 // This named metadata is not valid in final module (should be moved to DxilContainer)

--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -39,6 +39,7 @@ static StringRef HLOpcodeGroupNames[]{
     "subscript",   // HLSubscript,
     "matldst",     // HLMatLoadStore,
     "select",      // HLSelect,
+    "createhandle",// HLCreateHandle,
     "numOfHLDXIL", // NumOfHLOps
 };
 
@@ -53,6 +54,7 @@ static StringRef HLOpcodeGroupFullNames[]{
     "dx.hl.subscript", // HLSubscript,
     "dx.hl.matldst",   // HLMatLoadStore,
     "dx.hl.select",    // HLSelect,
+    "dx.hl.createhandle",  // HLCreateHandle,
     "numOfHLDXIL",     // NumOfHLOps
 };
 
@@ -62,7 +64,12 @@ static HLOpcodeGroup GetHLOpcodeGroupInternal(StringRef group) {
     case 'o': // op
       return HLOpcodeGroup::HLIntrinsic;
     case 'c': // cast
-      return HLOpcodeGroup::HLCast;
+      switch (group[1]) {
+      case 'a': // cast
+        return HLOpcodeGroup::HLCast;
+      case 'r': // createhandle
+        return HLOpcodeGroup::HLCreateHandle;
+      }
     case 'i': // init
       return HLOpcodeGroup::HLInit;
     case 'b': // binaryOp
@@ -83,7 +90,7 @@ static HLOpcodeGroup GetHLOpcodeGroupInternal(StringRef group) {
   return HLOpcodeGroup::NotHL;
 }
 // GetHLOpGroup by function name.
-HLOpcodeGroup GetHLOpcodeGroupByName(Function *F) {
+HLOpcodeGroup GetHLOpcodeGroupByName(const Function *F) {
   StringRef name = F->getName();
 
   if (!name.startswith(HLPrefix)) {
@@ -127,6 +134,7 @@ StringRef GetHLOpcodeGroupName(HLOpcodeGroup op) {
   case HLOpcodeGroup::HLSubscript:
   case HLOpcodeGroup::HLMatLoadStore:
   case HLOpcodeGroup::HLSelect:
+  case HLOpcodeGroup::HLCreateHandle:
     return HLOpcodeGroupNames[static_cast<unsigned>(op)];
   default:
     llvm_unreachable("invalid op");
@@ -144,6 +152,7 @@ StringRef GetHLOpcodeGroupFullName(HLOpcodeGroup op) {
   case HLOpcodeGroup::HLSubscript:
   case HLOpcodeGroup::HLMatLoadStore:
   case HLOpcodeGroup::HLSelect:
+  case HLOpcodeGroup::HLCreateHandle:
     return HLOpcodeGroupFullNames[static_cast<unsigned>(op)];
   default:
     llvm_unreachable("invalid op");
@@ -399,6 +408,11 @@ static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
         matOp == HLMatLoadStoreOpcode::RowMatLoad)
       if (!F->hasFnAttribute(Attribute::ReadOnly))
         F->addFnAttr(Attribute::ReadOnly);
+  } break;
+  case HLOpcodeGroup::HLCreateHandle: {
+    F->addFnAttr(Attribute::ReadNone);
+    F->addFnAttr(Attribute::NoInline);
+    F->setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
   } break;
   }
 }

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -212,6 +212,8 @@ static void addHLSLPasses(bool HLSLHighLevel, bool NoOpt, hlsl::HLSLExtensionsCo
   MPM.add(createSimplifyInstPass());
   MPM.add(createCFGSimplificationPass());
 
+  MPM.add(createDxilLegalizeResourceUsePass());
+  MPM.add(createDxilLegalizeStaticResourceUsePass());
   MPM.add(createDxilGenerationPass(NoOpt, ExtHelper));
 
   MPM.add(createSimplifyInstPass());

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1799,10 +1799,6 @@ void SROA_HLSL::isSafeForScalarRepl(Instruction *I, uint64_t Offset,
                       SI, true /*AllowWholeAccess*/);
       Info.hasALoadOrStore = true;
     } else if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(User)) {
-      HLOpcodeGroup group = GetHLOpcodeGroupByName(II->getCalledFunction());
-      // HL functions are safe for scalar repl.
-      if (group != HLOpcodeGroup::NotHL)
-        return;
       if (II->getIntrinsicID() != Intrinsic::lifetime_start &&
           II->getIntrinsicID() != Intrinsic::lifetime_end)
         return MarkUnsafe(Info, User);

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1799,6 +1799,10 @@ void SROA_HLSL::isSafeForScalarRepl(Instruction *I, uint64_t Offset,
                       SI, true /*AllowWholeAccess*/);
       Info.hasALoadOrStore = true;
     } else if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(User)) {
+      HLOpcodeGroup group = GetHLOpcodeGroupByName(II->getCalledFunction());
+      // HL functions are safe for scalar repl.
+      if (group != HLOpcodeGroup::NotHL)
+        return;
       if (II->getIntrinsicID() != Intrinsic::lifetime_start &&
           II->getIntrinsicID() != Intrinsic::lifetime_end)
         return MarkUnsafe(Info, User);

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -90,6 +90,8 @@ private:
   llvm::DataLayout legacyLayout;
   // decl map to constant id for program
   llvm::DenseMap<HLSLBufferDecl *, uint32_t> constantBufMap;
+  // Map for resource type to resource metadata value.
+  std::unordered_map<llvm::Type *, MDNode*> resMetadataMap;
 
   bool  m_bDebugInfo;
 
@@ -99,6 +101,8 @@ private:
   void AddConstant(VarDecl *constDecl, HLCBuffer &CB);
   uint32_t AddSampler(VarDecl *samplerDecl);
   uint32_t AddUAVSRV(VarDecl *decl, hlsl::DxilResourceBase::Class resClass);
+  bool SetUAVSRV(SourceLocation loc, hlsl::DxilResourceBase::Class resClass,
+                 DxilResource *hlslRes, const RecordDecl *RD);
   uint32_t AddCBuffer(HLSLBufferDecl *D);
   hlsl::DxilResourceBase::Class TypeToClass(clang::QualType Ty);
 
@@ -126,8 +130,6 @@ private:
   void ScanInitList(CodeGenFunction &CGF, InitListExpr *E,
                     SmallVector<Value *, 4> &EltValList,
                     SmallVector<QualType, 4> &EltTyList);
-  // Only scan init list to get the element size;
-  unsigned ScanInitList(InitListExpr *E);
 
   void FlattenAggregatePtrToGepList(CodeGenFunction &CGF, Value *Ptr,
                                     SmallVector<Value *, 4> &idxList,
@@ -998,6 +1000,19 @@ static DxilResource::Kind KeywordToKind(StringRef keyword) {
   return DxilResource::Kind::Invalid;
 }
 
+
+static DxilSampler::SamplerKind KeywordToSamplerKind(const std::string &keyword) {
+  // TODO: refactor for faster search (switch by 1/2/3 first letters, then
+  // compare)
+  if (keyword == "SamplerState")
+    return DxilSampler::SamplerKind::Default;
+
+  if (keyword == "SamplerComparisonState")
+    return DxilSampler::SamplerKind::Comparison;
+
+  return DxilSampler::SamplerKind::Invalid;
+}
+
 void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
   // Add hlsl intrinsic attr
   unsigned intrinsicOpcode;
@@ -1015,19 +1030,46 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
 
       QualType recordTy = MD->getASTContext().getRecordType(RD);
       hlsl::DxilResourceBase::Class resClass = TypeToClass(recordTy);
-
-      llvm::Type *Ty = F->getFunctionType()->params()[0]->getPointerElementType();
-      // Add resource type annotation.
+      llvm::Type *Ty = CGM.getTypes().ConvertType(recordTy);
+      llvm::FunctionType *FT = F->getFunctionType();
+      // Save resource type metadata.
       switch (resClass) {
-      case DXIL::ResourceClass::Sampler:
-        m_pHLModule->AddResourceTypeAnnotation(Ty, DXIL::ResourceClass::Sampler,
-                                               DXIL::ResourceKind::Sampler);
-        break;
-      case DXIL::ResourceClass::UAV:
-      case DXIL::ResourceClass::SRV: {
-        hlsl::DxilResource::Kind kind = KeywordToKind(RD->getName());
-        m_pHLModule->AddResourceTypeAnnotation(Ty, resClass, kind);
+      case DXIL::ResourceClass::UAV: {
+        DxilResource UAV;
+        // TODO: save globalcoherent to variable in EmitHLSLBuiltinCallExpr.
+        SetUAVSRV(FD->getLocation(), resClass, &UAV, RD);
+        // Set global symbol to save type.
+        UAV.SetGlobalSymbol(UndefValue::get(Ty));
+        MDNode * MD = m_pHLModule->DxilUAVToMDNode(UAV);
+        resMetadataMap[Ty] = MD;
       } break;
+      case DXIL::ResourceClass::SRV: {
+        DxilResource SRV;
+        SetUAVSRV(FD->getLocation(), resClass, &SRV, RD);
+        // Set global symbol to save type.
+        SRV.SetGlobalSymbol(UndefValue::get(Ty));
+        MDNode * Meta = m_pHLModule->DxilSRVToMDNode(SRV);
+        resMetadataMap[Ty] = Meta;
+        if (FT->getNumParams() > 1) {
+          QualType paramTy = MD->getParamDecl(0)->getType();
+          // Add sampler type.
+          if (TypeToClass(paramTy) == DXIL::ResourceClass::Sampler) {
+            llvm::Type * Ty = FT->getParamType(1)->getPointerElementType();
+            DxilSampler S;
+            const RecordType *RT = paramTy->getAs<RecordType>();
+            DxilSampler::SamplerKind kind =
+                KeywordToSamplerKind(RT->getDecl()->getName());
+            S.SetSamplerKind(kind);
+            // Set global symbol to save type.
+            S.SetGlobalSymbol(UndefValue::get(Ty));
+            MDNode *MD = m_pHLModule->DxilSamplerToMDNode(S);
+            resMetadataMap[Ty] = MD;
+          }
+        }
+      } break;
+      default:
+        // Skip OutputStream for GS.
+        break;
       }
     }
 
@@ -1876,17 +1918,7 @@ static DxilResourceBase::Class KeywordToClass(const std::string &keyword) {
 
   return DxilResourceBase::Class::Invalid;
 }
-static DxilSampler::SamplerKind KeywordToSamplerKind(const std::string &keyword) {
-  // TODO: refactor for faster search (switch by 1/2/3 first letters, then
-  // compare)
-  if (keyword == "SamplerState")
-    return DxilSampler::SamplerKind::Default;
 
-  if (keyword == "SamplerComparisonState")
-    return DxilSampler::SamplerKind::Comparison;
-
-  return DxilSampler::SamplerKind::Invalid;
-}
 // This should probably be refactored to ASTContextHLSL, and follow types
 // rather than do string comparisons.
 DXIL::ResourceClass
@@ -2036,6 +2068,140 @@ static void CollectScalarTypes(std::vector<QualType> &ScalarTys, QualType Ty) {
   }
 }
 
+bool CGMSHLSLRuntime::SetUAVSRV(SourceLocation loc,
+                                hlsl::DxilResourceBase::Class resClass,
+                                DxilResource *hlslRes, const RecordDecl *RD) {
+  hlsl::DxilResource::Kind kind = KeywordToKind(RD->getName());
+  hlslRes->SetKind(kind);
+
+  // Get the result type from handle field.
+  FieldDecl *FD = *(RD->field_begin());
+  DXASSERT(FD->getName() == "h", "must be handle field");
+  QualType resultTy = FD->getType();
+  // Type annotation for result type of resource.
+  DxilTypeSystem &dxilTypeSys = m_pHLModule->GetTypeSystem();
+  unsigned arrayEltSize = 0;
+  AddTypeAnnotation(QualType(RD->getTypeForDecl(),0), dxilTypeSys, arrayEltSize);
+
+  if (kind == hlsl::DxilResource::Kind::Texture2DMS ||
+      kind == hlsl::DxilResource::Kind::Texture2DMSArray) {
+    const ClassTemplateSpecializationDecl *templateDecl =
+        dyn_cast<ClassTemplateSpecializationDecl>(RD);
+    const clang::TemplateArgument &sampleCountArg =
+        templateDecl->getTemplateArgs()[1];
+    uint32_t sampleCount = sampleCountArg.getAsIntegral().getLimitedValue();
+    hlslRes->SetSampleCount(sampleCount);
+  }
+
+  if (kind != hlsl::DxilResource::Kind::StructuredBuffer) {
+    QualType Ty = resultTy;
+    QualType EltTy = Ty;
+    if (hlsl::IsHLSLVecType(Ty)) {
+      EltTy = hlsl::GetHLSLVecElementType(Ty);
+    } else if (hlsl::IsHLSLMatType(Ty)) {
+      EltTy = hlsl::GetHLSLMatElementType(Ty);
+    } else if (resultTy->isAggregateType()) {
+      // Struct or array in a none-struct resource.
+      std::vector<QualType> ScalarTys;
+      CollectScalarTypes(ScalarTys, resultTy);
+      unsigned size = ScalarTys.size();
+      if (size == 0) {
+        DiagnosticsEngine &Diags = CGM.getDiags();
+        unsigned DiagID = Diags.getCustomDiagID(
+            DiagnosticsEngine::Error,
+            "object's templated type must have at least one element");
+        Diags.Report(loc, DiagID);
+        return false;
+      }
+      if (size > 4) {
+        DiagnosticsEngine &Diags = CGM.getDiags();
+        unsigned DiagID = Diags.getCustomDiagID(
+            DiagnosticsEngine::Error, "elements of typed buffers and textures "
+                                      "must fit in four 32-bit quantities");
+        Diags.Report(loc, DiagID);
+        return false;
+      }
+
+      EltTy = ScalarTys[0];
+      for (QualType ScalarTy : ScalarTys) {
+        if (ScalarTy != EltTy) {
+          DiagnosticsEngine &Diags = CGM.getDiags();
+          unsigned DiagID = Diags.getCustomDiagID(
+              DiagnosticsEngine::Error,
+              "all template type components must have the same type");
+          Diags.Report(loc, DiagID);
+          return false;
+        }
+      }
+    }
+
+    EltTy = EltTy.getCanonicalType();
+    bool bSNorm = false;
+    bool bUNorm = false;
+
+    if (const AttributedType *AT = dyn_cast<AttributedType>(Ty)) {
+      switch (AT->getAttrKind()) {
+      case AttributedType::Kind::attr_hlsl_snorm:
+        bSNorm = true;
+        break;
+      case AttributedType::Kind::attr_hlsl_unorm:
+        bUNorm = true;
+        break;
+      default:
+        // Do nothing
+        break;
+      }
+    }
+
+    if (EltTy->isBuiltinType()) {
+      const BuiltinType *BTy = EltTy->getAs<BuiltinType>();
+      CompType::Kind kind = BuiltinTyToCompTy(BTy, bSNorm, bUNorm);
+      // 64bits types are implemented with u32.
+      if (kind == CompType::Kind::U64 || kind == CompType::Kind::I64 ||
+          kind == CompType::Kind::SNormF64 ||
+          kind == CompType::Kind::UNormF64 || kind == CompType::Kind::F64) {
+        kind = CompType::Kind::U32;
+      }
+      hlslRes->SetCompType(kind);
+    } else {
+      DXASSERT(!bSNorm && !bUNorm, "snorm/unorm on invalid type");
+    }
+  }
+
+  hlslRes->SetROV(RD->getName().startswith("RasterizerOrdered"));
+
+  if (kind == hlsl::DxilResource::Kind::TypedBuffer ||
+      kind == hlsl::DxilResource::Kind::StructuredBuffer) {
+    const ClassTemplateSpecializationDecl *templateDecl =
+        dyn_cast<ClassTemplateSpecializationDecl>(RD);
+
+    const clang::TemplateArgument &retTyArg =
+        templateDecl->getTemplateArgs()[0];
+    llvm::Type *retTy = CGM.getTypes().ConvertType(retTyArg.getAsType());
+
+    uint32_t strideInBytes = legacyLayout.getTypeAllocSize(retTy);
+    hlslRes->SetElementStride(strideInBytes);
+  }
+
+  if (resClass == hlsl::DxilResourceBase::Class::SRV) {
+    if (hlslRes->IsGloballyCoherent()) {
+      DiagnosticsEngine &Diags = CGM.getDiags();
+      unsigned DiagID = Diags.getCustomDiagID(
+          DiagnosticsEngine::Error, "globallycoherent can only be used with "
+                                    "Unordered Access View buffers.");
+      Diags.Report(loc, DiagID);
+      return false;
+    }
+
+    hlslRes->SetRW(false);
+    hlslRes->SetID(m_pHLModule->GetSRVs().size());
+  } else {
+    hlslRes->SetRW(true);
+    hlslRes->SetID(m_pHLModule->GetUAVs().size());
+  }
+  return true;
+}
+
 uint32_t CGMSHLSLRuntime::AddUAVSRV(VarDecl *decl,
                                     hlsl::DxilResourceBase::Class resClass) {
   llvm::GlobalVariable *val =
@@ -2091,138 +2257,16 @@ uint32_t CGMSHLSLRuntime::AddUAVSRV(VarDecl *decl,
   const RecordType *RT = VarTy->getAs<RecordType>();
   RecordDecl *RD = RT->getDecl();
 
-  hlsl::DxilResource::Kind kind = KeywordToKind(RT->getDecl()->getName());
-  hlslRes->SetKind(kind);
-
-  // Get the result type from handle field.
-  FieldDecl *FD = *(RD->field_begin());
-  DXASSERT(FD->getName() == "h", "must be handle field");
-  QualType resultTy = FD->getType();
-  // Type annotation for result type of resource.
-  DxilTypeSystem &dxilTypeSys = m_pHLModule->GetTypeSystem();
-  unsigned arrayEltSize = 0;
-  AddTypeAnnotation(decl->getType(), dxilTypeSys, arrayEltSize);
-
-  if (kind == hlsl::DxilResource::Kind::Texture2DMS ||
-      kind == hlsl::DxilResource::Kind::Texture2DMSArray) {
-    const ClassTemplateSpecializationDecl *templateDecl =
-        dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl());
-    const clang::TemplateArgument &sampleCountArg =
-        templateDecl->getTemplateArgs()[1];
-    uint32_t sampleCount = sampleCountArg.getAsIntegral().getLimitedValue();
-    hlslRes->SetSampleCount(sampleCount);
-  }
-
-  if (kind != hlsl::DxilResource::Kind::StructuredBuffer) {
-    QualType Ty = resultTy;
-    QualType EltTy = Ty;
-    if (hlsl::IsHLSLVecType(Ty)) {
-      EltTy = hlsl::GetHLSLVecElementType(Ty);
-    } else if (hlsl::IsHLSLMatType(Ty)) {
-      EltTy = hlsl::GetHLSLMatElementType(Ty);
-    } else if (resultTy->isAggregateType()) {
-      // Struct or array in a none-struct resource.
-      std::vector<QualType> ScalarTys;
-      CollectScalarTypes(ScalarTys, resultTy);
-      unsigned size = ScalarTys.size();
-      if (size == 0) {
-        DiagnosticsEngine &Diags = CGM.getDiags();
-        unsigned DiagID = Diags.getCustomDiagID(
-            DiagnosticsEngine::Error, "object's templated type must have at least one element");
-        Diags.Report(decl->getLocation(), DiagID);
-        return 0;
-      }
-      if (size > 4) {
-        DiagnosticsEngine &Diags = CGM.getDiags();
-        unsigned DiagID = Diags.getCustomDiagID(
-            DiagnosticsEngine::Error, "elements of typed buffers and textures "
-                                      "must fit in four 32-bit quantities");
-        Diags.Report(decl->getLocation(), DiagID);
-        return 0;
-      }
-
-      EltTy = ScalarTys[0];
-      for (QualType ScalarTy : ScalarTys) {
-        if (ScalarTy != EltTy) {
-          DiagnosticsEngine &Diags = CGM.getDiags();
-          unsigned DiagID = Diags.getCustomDiagID(
-              DiagnosticsEngine::Error,
-              "all template type components must have the same type");
-          Diags.Report(decl->getLocation(), DiagID);
-          return 0;
-        }
-      }
-    }
-
-    EltTy = EltTy.getCanonicalType();
-    bool bSNorm = false;
-    bool bUNorm = false;
-
-    if (const AttributedType *AT = dyn_cast<AttributedType>(Ty)) {
-      switch (AT->getAttrKind()) {
-      case AttributedType::Kind::attr_hlsl_snorm:
-        bSNorm = true;
-        break;
-      case AttributedType::Kind::attr_hlsl_unorm:
-        bUNorm = true;
-        break;
-      default:
-        // Do nothing
-        break;
-      }
-    }
-
-    if (EltTy->isBuiltinType()) {
-      const BuiltinType *BTy = EltTy->getAs<BuiltinType>();
-      CompType::Kind kind = BuiltinTyToCompTy(BTy, bSNorm, bUNorm);
-      // 64bits types are implemented with u32.
-      if (kind == CompType::Kind::U64 ||
-          kind == CompType::Kind::I64 ||
-          kind == CompType::Kind::SNormF64 ||
-          kind == CompType::Kind::UNormF64 ||
-          kind == CompType::Kind::F64) {
-        kind = CompType::Kind::U32;
-      }
-      hlslRes->SetCompType(kind);
-    } else {
-      DXASSERT(!bSNorm && !bUNorm, "snorm/unorm on invalid type");
-    }
-  }
-
   if (decl->hasAttr<HLSLGloballyCoherentAttr>()) {
     hlslRes->SetGloballyCoherent(true);
   }
 
-  hlslRes->SetROV(RT->getDecl()->getName().startswith("RasterizerOrdered"));
-
-  if (kind == hlsl::DxilResource::Kind::TypedBuffer ||
-      kind == hlsl::DxilResource::Kind::StructuredBuffer) {
-    const ClassTemplateSpecializationDecl *templateDecl =
-        dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl());
-
-    const clang::TemplateArgument &retTyArg =
-        templateDecl->getTemplateArgs()[0];
-    llvm::Type *retTy = CGM.getTypes().ConvertType(retTyArg.getAsType());
-
-    uint32_t strideInBytes = legacyLayout.getTypeAllocSize(retTy);
-    hlslRes->SetElementStride(strideInBytes);
-  }
+  if (!SetUAVSRV(decl->getLocation(), resClass, hlslRes.get(), RD))
+    return 0;
 
   if (resClass == hlsl::DxilResourceBase::Class::SRV) {
-    if (hlslRes->IsGloballyCoherent()) {
-      DiagnosticsEngine &Diags = CGM.getDiags();
-      unsigned DiagID = Diags.getCustomDiagID(
-          DiagnosticsEngine::Error, "globallycoherent can only be used with "
-                                    "Unordered Access View buffers.");
-      Diags.Report(decl->getLocation(), DiagID);
-    }
-
-    hlslRes->SetRW(false);
-    hlslRes->SetID(m_pHLModule->GetSRVs().size());
     return m_pHLModule->AddSRV(std::move(hlslRes));
   } else {
-    hlslRes->SetRW(true);
-    hlslRes->SetID(m_pHLModule->GetUAVs().size());
     return m_pHLModule->AddUAV(std::move(hlslRes));
   }
 }
@@ -2272,6 +2316,7 @@ void CGMSHLSLRuntime::AddConstant(VarDecl *constDecl, HLCBuffer &CB) {
   }
 
   llvm::Constant *constVal = CGM.GetAddrOfGlobalVar(constDecl);
+
   bool isGlobalCB = CB.GetID() == globalCBIndex;
   uint32_t offset = 0;
   bool userOffset = false;
@@ -2573,8 +2618,33 @@ void MarkUsedFunctionForConst(Value *V, std::unordered_set<Function*> &usedFunc)
   }
 }
 
+static Function * GetOrCreateHLCreateHandle(HLModule &HLM, llvm::Type *HandleTy,
+    ArrayRef<Value*> paramList, MDNode *MD) {
+  SmallVector<llvm::Type *, 4> paramTyList;
+  for (Value *param : paramList) {
+    paramTyList.emplace_back(param->getType());
+  }
+
+  llvm::FunctionType *funcTy =
+      llvm::FunctionType::get(HandleTy, paramTyList, false);
+  llvm::Module &M = *HLM.GetModule();
+  Function *CreateHandle = GetOrCreateHLFunctionWithBody(M, funcTy, HLOpcodeGroup::HLCreateHandle,
+      /*opcode*/ 0, "");
+  if (CreateHandle->empty()) {
+    // Add body.
+    BasicBlock *BB =
+        BasicBlock::Create(CreateHandle->getContext(), "Entry", CreateHandle);
+    IRBuilder<> Builder(BB);
+    // Just return undef to make a body.
+    Builder.CreateRet(UndefValue::get(HandleTy));
+    // Mark resource attribute.
+    HLM.MarkDxilResourceAttrib(CreateHandle, MD);
+  }
+  return CreateHandle;
+}
+
 static bool CreateCBufferVariable(HLCBuffer &CB,
-    llvm::Module &M) {
+    HLModule &HLM, llvm::Type *HandleTy) {
   bool bUsed = false;
   // Build Struct for CBuffer.
   SmallVector<llvm::Type*, 4> Elements;
@@ -2589,6 +2659,8 @@ static bool CreateCBufferVariable(HLCBuffer &CB,
   // Don't create CBuffer variable for unused cbuffer.
   if (!bUsed)
     return false;
+
+  llvm::Module &M = *HLM.GetModule();
 
   bool isCBArray = CB.GetRangeSize() != 1;
   llvm::GlobalVariable *cbGV = nullptr;
@@ -2634,14 +2706,20 @@ static bool CreateCBufferVariable(HLCBuffer &CB,
 
   llvm::Type *opcodeTy = llvm::Type::getInt32Ty(M.getContext());
   llvm::Type *idxTy = opcodeTy;
+  Constant *zeroIdx = ConstantInt::get(opcodeTy, 0);
+
+  MDNode *MD = HLM.DxilCBufferToMDNode(CB);
+
+  Value *HandleArgs[] = { zeroIdx, cbGV, zeroIdx };
+  Function *CreateHandleFunc = GetOrCreateHLCreateHandle(HLM, HandleTy, HandleArgs, MD);
+
   llvm::FunctionType *SubscriptFuncTy =
-      llvm::FunctionType::get(cbTy, { opcodeTy, cbGV->getType(), idxTy}, false);
+      llvm::FunctionType::get(cbTy, { opcodeTy, HandleTy, idxTy}, false);
 
   Function *subscriptFunc =
       GetOrCreateHLFunction(M, SubscriptFuncTy, HLOpcodeGroup::HLSubscript,
                             (unsigned)HLSubscriptOpcode::CBufferSubscript);
   Constant *opArg = ConstantInt::get(opcodeTy, (unsigned)HLSubscriptOpcode::CBufferSubscript);
-  Constant *zeroIdx = ConstantInt::get(opcodeTy, 0);
   Value *args[] = { opArg, nullptr, zeroIdx };
 
   llvm::LLVMContext &Context = M.getContext();
@@ -2660,83 +2738,99 @@ static bool CreateCBufferVariable(HLCBuffer &CB,
   }
 
   for (Function &F : M.functions()) {
-    if (!F.isDeclaration()) {
-      IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
+    if (F.isDeclaration())
+      continue;
 
-      args[HLOperandIndex::kSubscriptObjectOpIdx] = cbGV;
-      // create HL subscript to make all the use of cbuffer start from it.
-      Instruction *cbSubscript = cast<Instruction>(Builder.CreateCall(subscriptFunc, {args} ));
+    if (GetHLOpcodeGroupByName(&F) != HLOpcodeGroup::NotHL)
+      continue;
 
-      // Replace constant var with GEP pGV
-      for (const std::unique_ptr<DxilResourceBase> &C : CB.GetConstants()) {
-        Value *GV = C->GetGlobalSymbol();
-        if (constUsedFuncList[C->GetID()].count(&F) == 0)
-          continue;
+    IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
 
-        Value *idx = indexArray[C->GetID()];
-        if (!isCBArray) {
-          Instruction *GEP = cast<Instruction>(
-              Builder.CreateInBoundsGEP(cbSubscript, {zero, idx}));
-          // TODO: make sure the debug info is synced to GEP.
-          // GEP->setDebugLoc(GV);
-          ReplaceUseInFunction(GV, GEP, &F, Builder);
-          // Delete if no use in F.
-          if (GEP->user_empty())
-            GEP->eraseFromParent();
-        } else {
-          for (auto U = GV->user_begin(); U != GV->user_end();) {
-            User *user = *(U++);
-            if (user->user_empty())
-              continue;
-            Instruction *I = dyn_cast<Instruction>(user);
-            if (I && I->getParent()->getParent() != &F)
-              continue;
+    // create HL subscript to make all the use of cbuffer start from it.
+    HandleArgs[HLOperandIndex::kCreateHandleResourceOpIdx] = cbGV;
+    CallInst *Handle = Builder.CreateCall(CreateHandleFunc, HandleArgs);
+    args[HLOperandIndex::kSubscriptObjectOpIdx] = Handle;
+    Instruction *cbSubscript =
+        cast<Instruction>(Builder.CreateCall(subscriptFunc, {args}));
 
-            IRBuilder<> *instBuilder = &Builder;
-            unique_ptr<IRBuilder<> > B;
-            if (I) {
-              B = make_unique<IRBuilder<> >(I);
-              instBuilder = B.get();
-            }
+    // Replace constant var with GEP pGV
+    for (const std::unique_ptr<DxilResourceBase> &C : CB.GetConstants()) {
+      Value *GV = C->GetGlobalSymbol();
+      if (constUsedFuncList[C->GetID()].count(&F) == 0)
+        continue;
 
-            GEPOperator *GEPOp = cast<GEPOperator>(user);
-            std::vector<Value *> idxList;
+      Value *idx = indexArray[C->GetID()];
+      if (!isCBArray) {
+        Instruction *GEP = cast<Instruction>(
+            Builder.CreateInBoundsGEP(cbSubscript, {zero, idx}));
+        // TODO: make sure the debug info is synced to GEP.
+        // GEP->setDebugLoc(GV);
+        ReplaceUseInFunction(GV, GEP, &F, Builder);
+        // Delete if no use in F.
+        if (GEP->user_empty())
+          GEP->eraseFromParent();
+      } else {
+        for (auto U = GV->user_begin(); U != GV->user_end();) {
+          User *user = *(U++);
+          if (user->user_empty())
+            continue;
+          Instruction *I = dyn_cast<Instruction>(user);
+          if (I && I->getParent()->getParent() != &F)
+            continue;
 
-            DXASSERT(GEPOp->getNumIndices() >= 1 + cbIndexDepth,
-                        "must indexing ConstantBuffer array");
-            idxList.reserve(GEPOp->getNumIndices() - (cbIndexDepth - 1));
-
-            gep_type_iterator GI = gep_type_begin(*GEPOp), E = gep_type_end(*GEPOp);
-            idxList.push_back(GI.getOperand());
-            // change array index with 0 for struct index.
-            idxList.push_back(zero);
-            GI++;
-            Value *arrayIdx = GI.getOperand();
-            GI++;
-            for (unsigned curIndex = 1; GI != E && curIndex < cbIndexDepth; ++GI, ++curIndex) {
-              arrayIdx = instBuilder->CreateMul(arrayIdx, Builder.getInt32(GI->getArrayNumElements()));
-              arrayIdx = instBuilder->CreateAdd(arrayIdx, GI.getOperand());
-            }
-
-            for (; GI != E; ++GI) {
-              idxList.push_back(GI.getOperand());
-            }
-
-            args[HLOperandIndex::kSubscriptIndexOpIdx] = arrayIdx;
-
-            Instruction *cbSubscript =
-                cast<Instruction>(instBuilder->CreateCall(subscriptFunc, {args}));
-
-            Instruction *NewGEP = cast<Instruction>(
-                instBuilder->CreateInBoundsGEP(cbSubscript, idxList));
-
-            ReplaceUseInFunction(GEPOp, NewGEP, &F, *instBuilder);
+          IRBuilder<> *instBuilder = &Builder;
+          unique_ptr<IRBuilder<>> B;
+          if (I) {
+            B = make_unique<IRBuilder<>>(I);
+            instBuilder = B.get();
           }
+
+          GEPOperator *GEPOp = cast<GEPOperator>(user);
+          std::vector<Value *> idxList;
+
+          DXASSERT(GEPOp->getNumIndices() >= 1 + cbIndexDepth,
+                   "must indexing ConstantBuffer array");
+          idxList.reserve(GEPOp->getNumIndices() - (cbIndexDepth - 1));
+
+          gep_type_iterator GI = gep_type_begin(*GEPOp),
+                            E = gep_type_end(*GEPOp);
+          idxList.push_back(GI.getOperand());
+          // change array index with 0 for struct index.
+          idxList.push_back(zero);
+          GI++;
+          Value *arrayIdx = GI.getOperand();
+          GI++;
+          for (unsigned curIndex = 1; GI != E && curIndex < cbIndexDepth;
+               ++GI, ++curIndex) {
+            arrayIdx = instBuilder->CreateMul(
+                arrayIdx, Builder.getInt32(GI->getArrayNumElements()));
+            arrayIdx = instBuilder->CreateAdd(arrayIdx, GI.getOperand());
+          }
+
+          for (; GI != E; ++GI) {
+            idxList.push_back(GI.getOperand());
+          }
+
+          HandleArgs[HLOperandIndex::kCreateHandleIndexOpIdx] = arrayIdx;
+          CallInst *Handle =
+              instBuilder->CreateCall(CreateHandleFunc, HandleArgs);
+          args[HLOperandIndex::kSubscriptObjectOpIdx] = Handle;
+          args[HLOperandIndex::kSubscriptIndexOpIdx] = arrayIdx;
+
+          Instruction *cbSubscript =
+              cast<Instruction>(instBuilder->CreateCall(subscriptFunc, {args}));
+
+          Instruction *NewGEP = cast<Instruction>(
+              instBuilder->CreateInBoundsGEP(cbSubscript, idxList));
+
+          ReplaceUseInFunction(GEPOp, NewGEP, &F, *instBuilder);
         }
       }
-      // Delete if no use in F.
-      if (cbSubscript->user_empty())
-        cbSubscript->eraseFromParent();
+    }
+    // Delete if no use in F.
+    if (cbSubscript->user_empty()) {
+      cbSubscript->eraseFromParent();
+      Handle->eraseFromParent();
     }
   }
   return true;
@@ -2778,6 +2872,7 @@ static void ConstructCBuffer(
     llvm::Type *CBufferType,
     std::unordered_map<Constant *, DxilFieldAnnotation> &AnnotationMap) {
   DxilTypeSystem &dxilTypeSys = pHLModule->GetTypeSystem();
+  llvm::Type *HandleTy = pHLModule->GetOP()->GetHandleType();
   for (unsigned i = 0; i < pHLModule->GetCBuffers().size(); i++) {
     HLCBuffer &CB = *static_cast<HLCBuffer*>(&(pHLModule->GetCBuffer(i)));
     if (CB.GetConstants().size() == 0) {
@@ -2787,7 +2882,8 @@ static void ConstructCBuffer(
           llvm::GlobalValue::ExternalLinkage, nullptr, CB.GetGlobalName());
       CB.SetGlobalSymbol(pGV);
     } else {
-      bool bCreated = CreateCBufferVariable(CB, *pHLModule->GetModule());
+      bool bCreated =
+          CreateCBufferVariable(CB, *pHLModule, HandleTy);
       if (bCreated)
         ConstructCBufferAnnotation(CB, dxilTypeSys, AnnotationMap);
       else {
@@ -2981,8 +3077,26 @@ static Function *CreateOpFunction(llvm::Module &M, Function *F,
   return opFunc;
 }
 
+static Value *CreateHandleFromResPtr(
+    Value *ResPtr, HLModule &HLM, llvm::Type *HandleTy,
+    std::unordered_map<llvm::Type *, MDNode *> &resMetaMap,
+    IRBuilder<> &Builder) {
+  llvm::Type *objTy = ResPtr->getType()->getPointerElementType();
+  DXASSERT(resMetaMap.count(objTy), "cannot find resource type");
+  MDNode *MD = resMetaMap[objTy];
+  // Load to make sure resource only have Ld/St use so mem2reg could remove
+  // temp resource.
+  Value *ldObj = Builder.CreateLoad(ResPtr);
+  Value *opcode = Builder.getInt32(0);
+  Value *args[] = {opcode, ldObj};
+  Function *CreateHandle = GetOrCreateHLCreateHandle(HLM, HandleTy, args, MD);
+  CallInst *Handle = Builder.CreateCall(CreateHandle, args);
+  return Handle;
+}
+
 static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
-                                       unsigned opcode) {
+                                       unsigned opcode, llvm::Type *HandleTy,
+    std::unordered_map<llvm::Type *, MDNode*> &resMetaMap) {
   llvm::Module &M = *HLM.GetModule();
   llvm::FunctionType *oldFuncTy = F->getFunctionType();
 
@@ -2999,9 +3113,9 @@ static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
       if (HLModule::IsHLSLObjectType(Ty) &&
           // StreamOutput don't need handle.
           !HLModule::IsStreamOutputType(Ty)) {
-        // Use object type directly, not by pointer.
-        // This will make sure temp object variable only used by ld/st.
-        paramTyList[i] = Ty;
+        // Use handle type for object type.
+        // This will make sure temp object variable only used by createHandle.
+        paramTyList[i] = HandleTy;
       }
     }
   }
@@ -3065,8 +3179,8 @@ static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
     }
 
     DXASSERT(resTy, "must find the resource type");
-    // Change object type to resource type.
-    paramTyList[HLOperandIndex::kSubscriptObjectOpIdx] = resTy;
+    // Change object type to handle type.
+    paramTyList[HLOperandIndex::kSubscriptObjectOpIdx] = HandleTy;
     // Change RetTy into pointer of resource reture type.
     RetTy = cast<StructType>(resTy)->getElementType(0)->getPointerTo();
 
@@ -3110,8 +3224,11 @@ static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
       objVal = objGEP->getPointerOperand();
       if (IndexList.size() > 1)
         objVal = Builder.CreateInBoundsGEP(objVal, IndexList);
+
+      Value *Handle =
+          CreateHandleFromResPtr(objVal, HLM, HandleTy, resMetaMap, Builder);
       // Change obj to the resource pointer.
-      opcodeParamList[HLOperandIndex::kSubscriptObjectOpIdx] = objVal;
+      opcodeParamList[HLOperandIndex::kSubscriptObjectOpIdx] = Handle;
 
       // Set idx and mipIdx.
       Value *mipIdx = opcodeParamList[HLOperandIndex::kSubscriptIndexOpIdx];
@@ -3150,7 +3267,9 @@ static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
             Builder.Insert(GEP);
             arg = GEP;
           }
-          opcodeParamList[i] = Builder.CreateLoad(arg);
+          Value *Handle = CreateHandleFromResPtr(arg, HLM, HandleTy,
+                                                 resMetaMap, Builder);
+          opcodeParamList[i] = Handle;
         }
       }
     }
@@ -3176,7 +3295,9 @@ static void AddOpcodeParamForIntrinsic(HLModule &HLM, Function *F,
 }
 
 static void AddOpcodeParamForIntrinsics(HLModule &HLM
-    , std::vector<std::pair<Function *, unsigned>> &intrinsicMap) {
+    , std::vector<std::pair<Function *, unsigned>> &intrinsicMap,
+    std::unordered_map<llvm::Type *, MDNode*> &resMetaMap) {
+  llvm::Type *HandleTy = HLM.GetOP()->GetHandleType();
   for (auto mapIter : intrinsicMap) {
     Function *F = mapIter.first;
     if (F->user_empty()) {
@@ -3186,7 +3307,7 @@ static void AddOpcodeParamForIntrinsics(HLModule &HLM
     }
 
     unsigned opcode = mapIter.second;
-    AddOpcodeParamForIntrinsic(HLM, F, opcode);
+    AddOpcodeParamForIntrinsic(HLM, F, opcode, HandleTy, resMetaMap);
   }
 }
 
@@ -3818,7 +3939,7 @@ void CGMSHLSLRuntime::FinishCodeGen() {
                 EntryFunc->getEntryBlock().getFirstInsertionPt());
 
   // translate opcode into parameter for intrinsic functions
-  AddOpcodeParamForIntrinsics(*m_pHLModule, m_IntrinsicMap);
+  AddOpcodeParamForIntrinsics(*m_pHLModule, m_IntrinsicMap, resMetadataMap);
 
   // Pin entry point and constant buffers, mark everything else internal.
   for (Function &f : m_pHLModule->GetModule()->functions()) {
@@ -3828,7 +3949,9 @@ void CGMSHLSLRuntime::FinishCodeGen() {
     } else {
       f.setLinkage(GlobalValue::LinkageTypes::InternalLinkage);
     }
-
+    // Skip no inline functions.
+    if (f.hasFnAttribute(llvm::Attribute::NoInline))
+      continue;
     // Always inline.
     f.addFnAttr(llvm::Attribute::AlwaysInline);
   }

--- a/tools/clang/test/CodeGenHLSL/bindings1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/bindings1.hlsl
@@ -93,6 +93,11 @@
 // CHECK: ; RWTex1                                UAV     f32          2d      U3             u0     4
 
 // CHECK: %struct.Resources = type { %class.Texture2D, %class.Texture2D.0, %class.Texture2D, %class.Texture2D.0, %class.RWTexture2D, %class.RWTexture2D, %class.RWTexture2D, %class.RWTexture2D, %struct.SamplerComparisonState, %struct.SamplerState, %struct.SamplerComparisonState, %struct.SamplerState, <4 x float> }
+
+// CHECK: %RWTex2_UAV_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 7, i1 false)
+// CHECK: %Tex1_texture_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 0, i1 false)
+// CHECK: %Samp2_sampler = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 3, i32 0, i32 0, i1 false)
+
 // CHECK: %tbuf4_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 8, i32 4, i1 false)
 // CHECK: %tbuf2_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 7, i32 2, i1 false)
 // CHECK: %tbuf3_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 6, i32 6, i1 false)
@@ -103,10 +108,6 @@
 
 // CHECK: %MyCB_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 2, i32 0, i32 11, i1 false)
 // CHECK: %MyTB_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 4, i32 11, i1 false)
-
-// CHECK: %RWTex2_UAV_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 7, i1 false)
-// CHECK: %Tex1_texture_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 0, i1 false)
-// CHECK: %Samp2_sampler = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 3, i32 0, i32 0, i1 false)
 
 // CHECK: %Tex2_texture_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 1, i32 30, i1 false)
 // CHECK: %Tex3_texture_2d = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 2, i32 94, i1 false)

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1208,6 +1208,8 @@ class db_dxil(object):
         add_pass('globaldce', 'GlobalDCE', 'Dead Global Elimination', [])
         add_pass('dynamic-vector-to-array', 'DynamicIndexingVectorToArray', 'Replace dynamic indexing vector with array', [
             {'n':'ReplaceAllVector','t':'ReplaceAllVector','c':1}])
+        add_pass('hlsl-dxil-legalize-resource-use', 'DxilLegalizeResourceUsePass', 'DXIL legalize resource use', [])
+        add_pass('hlsl-dxil-legalize-static-resource-use', 'DxilLegalizeStaticResourceUsePass', 'DXIL legalize static resource use', [])
         add_pass('dxilgen', 'DxilGenerationPass', 'HLSL DXIL Generation', [
             {'n':'NotOptimized','t':'bool','c':1}])
         add_pass('simplify-inst', 'SimplifyInst', 'Simplify Instructions', [])


### PR DESCRIPTION
1. A HL createHandle will have 1 or 2 parameters.
   For  uav/srv/sampler, 1 parameter. 1 is the resource load from resource ptr.
   For cbuffer, 2 parameter. 1 is the same. 2 is for dynamic indexing on array of cbuffers.
   uav/srv/sampler don't have 2 is because all the use of them is on builtin methods. Resource on methods is scalar.
   createHandle function will have metadata to save the resource information like class/kind/type/...

2. Added 2 more passes DxilLegalizeResourceUsePass DxilLegalizeStaticResourceUsePass to remove load/store on local/static resource.
   Also make sure HL createHandle don't have phi operand.

3. For DxilGenerationPass,  Dxil createHandle will be generated after GenerateDxilOperations.
   And HLObjectOperationLowerHelper now get RK/RC from MetadataAsValue argument of HL createHandle.