### PR TITLE
Fix #169 - Bad codegen for firstbithigh/firstbitlow

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -3640,49 +3640,6 @@ static Value * TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp) {
     CI->eraseFromParent();
     return cNan;
   } break;
-  case IntrinsicOp::IOP_firstbithigh: {
-    Value *V = CI->getArgOperand(0);
-    ConstantInt *iV = cast<ConstantInt>(V);
-    APInt v = iV->getValue();
-    Value *firstbit = nullptr;
-    if (v == 0) {
-      firstbit = ConstantInt::get(CI->getType(), -1);
-    } else {
-      bool mask = true;
-      if (v.isNegative())
-        mask = false;
-      unsigned bitWidth = v.getBitWidth();
-      for (int i = bitWidth - 2; i >= 0; i--) {
-        if (v[i] == mask) {
-          firstbit = ConstantInt::get(CI->getType(), bitWidth-1-i);
-          break;
-        }
-      }
-    }
-    CI->replaceAllUsesWith(firstbit);
-    CI->eraseFromParent();
-    return firstbit;
-  } break;
-  case IntrinsicOp::IOP_ufirstbithigh: {
-    Value *V = CI->getArgOperand(0);
-    ConstantInt *iV = cast<ConstantInt>(V);
-    APInt v = iV->getValue();
-    Value *firstbit = nullptr;
-    if (v == 0) {
-      firstbit = ConstantInt::get(CI->getType(), -1);
-    } else {
-      unsigned bitWidth = v.getBitWidth();
-      for (int i = bitWidth - 1; i >= 0; i--) {
-        if (v[i]) {
-          firstbit = ConstantInt::get(CI->getType(), bitWidth-1-i);
-          break;
-        }
-      }
-    }
-    CI->replaceAllUsesWith(firstbit);
-    CI->eraseFromParent();
-    return firstbit;
-  } break;
   default:
     return nullptr;
   }

--- a/tools/clang/test/CodeGenHLSL/firstbitHi.hlsl
+++ b/tools/clang/test/CodeGenHLSL/firstbitHi.hlsl
@@ -2,22 +2,22 @@
 
 // CHECK: FirstbitHi
 // CHECK: sub i32 31
-// CHECK: icmp ne i32
+// CHECK: icmp eq i32 {{.*}}, -1
 // CHECK: select
 // CHECK: i32 -1
 
 // CHECK: FirstbitSHi
 // CHECK: sub i32 31
-// CHECK: icmp ne i32
+// CHECK: icmp eq i32 {{.*}}, -1
 // CHECK: select
 // CHECK: i32 -1
 
-// CHECK: op.bufferStore.i32(i32 69, %dx.types.Handle %outputUAV_UAV_rawbuf, i32 2, i32 undef, i32 26
-// CHECK: op.bufferStore.i32(i32 69, %dx.types.Handle %outputUAV_UAV_rawbuf, i32 3, i32 undef, i32 23
+// CHECK: FirstbitSHi
+// CHECK: FirstbitSHi
 
 // CHECK: dx.op.unaryBits.i64(i32 33, i64
 // CHECK: sub i32 63
-// CHECK: icmp ne i32
+// CHECK: icmp eq i32 {{.*}}, -1
 // CHECK: select
 // CHECK: i32 -1
 

--- a/tools/clang/test/CodeGenHLSL/firstbitLo.hlsl
+++ b/tools/clang/test/CodeGenHLSL/firstbitLo.hlsl
@@ -1,23 +1,14 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
 // CHECK: FirstbitLo
-// CHECK: icmp ne i32
-// CHECK: select
-// CHECK: i32 -1
 
 // CHECK: FirstbitLo
-// CHECK: icmp ne i32
-// CHECK: select
-// CHECK: i32 -1
 
 // CHECK: FirstbitLo
 // CHECK: FirstbitLo
 
 // CHECK: dx.op.unaryBits.i64
 // CHECK: FirstbitLo
-// CHECK: icmp ne i32
-// CHECK: select
-// CHECK: i32 -1
 
 uint a;
 int2 b;

--- a/tools/clang/test/CodeGenHLSL/firstbitshi_const.hlsl
+++ b/tools/clang/test/CodeGenHLSL/firstbitshi_const.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK: FirstbitSHi
+
+[RootSignature("")]
+int main() : SV_Target {
+    return firstbithigh((int)0xffffffff);
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2201,6 +2201,7 @@ TEST_F(CompilerTest, CodeGenFloatToBool) {
 
 TEST_F(CompilerTest, CodeGenFirstbitHi) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\firstbitHi.hlsl");
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\firstbitshi_const.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenFirstbitLo) {


### PR DESCRIPTION
This patch changes codegen for firstbithigh and firstbitlow.

For firstbitlow we do not generate a select on the return value from the
intrinsic. The previous codegen would check if the value is 0 and return -1 if
it was. However, the FirstbitLo intrinsic will return -1 when the input is 0 so
the select is not needed. So regardless of the input value we can take the
result of the intrinsic. This would match the code produced by fxc.

For firstbithi we check the value returned from the intrinsic for -1. If
the value returned is -1 we return -1. We do this for both signed and
unsigned intrinsics. The old codegen would check the input value for
0 and so would produce wrong code when the input value was -1.

We also disable constant folding in the front end for these intrinsics.
There was a bug in the constant folding that would cause a crash and
we are adding constant folding for dxil intrinsics to the optimizer
so we should not need it explicitly in the frontend for these
intrinsics.