### PR TITLE
Fix #180 Select correct device when running ShaderOp tests.

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -298,6 +298,9 @@ public:
       }
       VERIFY_SUCCEEDED(D3D12CreateDevice(hardwareAdapter, FeatureLevelRequired,
                                          IID_PPV_ARGS(&pDevice)));
+      DXGI_ADAPTER_DESC1 AdapterDesc;
+      VERIFY_SUCCEEDED(hardwareAdapter->GetDesc1(&AdapterDesc));
+      LogCommentFmt(L"Using Adapter: %s", AdapterDesc.Description);
     }
     if (pDevice == nullptr)
       return false;
@@ -1840,9 +1843,14 @@ RunShaderOpTest(ID3D12Device *pDevice, dxc::DxcDllSupport &support,
     VERIFY_FAIL(msgWide.m_psz);
   }
 
+  // This won't actually be used since we're supplying the device,
+  // but let's make it consistent.
+  pShaderOp->UseWarpDevice = GetTestParamUseWARP(true);
+
   std::shared_ptr<st::ShaderOpTest> test = std::make_shared<st::ShaderOpTest>();
   test->SetDxcSupport(&support);
   test->SetInitCallback(pInitCallback);
+  test->SetDevice(pDevice);
   test->RunShaderOp(pShaderOp);
 
   std::shared_ptr<ShaderOpTestResult> result =

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -1634,7 +1634,7 @@ TEST_F(ExecutionTest, WaveIntrinsicsInPSTest) {
   {
     MappedData mappedData(pReadCounterBuffer, sizeof(uint32_t));
     appendCount = *((uint32_t *)mappedData.data());
-    LogCommentFmt(L"%u elements in append buffer");
+    LogCommentFmt(L"%u elements in append buffer", appendCount);
   }
 
   {

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -498,9 +498,9 @@ void ShaderOpTest::CreatePipelineState() {
       ShaderOpResource *R = m_pShaderOp->GetResourceByName(m_pShaderOp->RenderTargets[i]);
       GDesc.RTVFormats[i] = R->Desc.Format;
     }
-    GDesc.SampleDesc.Count = 1; // TODO: read from file, set form shader operation; also apply to count
+    GDesc.SampleDesc.Count = 1; // TODO: read from file, set from shader operation; also apply to count
     GDesc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT); // TODO: read from file, set from op
-    GDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT); // TODO: read frm file, set from op
+    GDesc.BlendState = CD3DX12_BLEND_DESC(D3D12_DEFAULT); // TODO: read from file, set from op
 
     // TODO: pending values to set
 #if 0
@@ -1888,10 +1888,10 @@ void ShaderOpParser::ParseResource(IXmlReader *pReader, ShaderOpResource *pResou
           fVal = NAN;
         }
         else if (0 == _wcsicmp(pText, L"-inf")) {
-          fVal = INFINITY;
+          fVal = -(INFINITY);
         }
         else if (0 == _wcsicmp(pText, L"inf") || 0 == _wcsicmp(pText, L"+inf")) {
-          fVal = -(INFINITY);
+          fVal = INFINITY;
         }
         else if (0 == _wcsicmp(pText, L"-denorm")) {
           fVal = -(FLT_MIN / 2);


### PR DESCRIPTION
- Fix #180 Use device passed to RunShaderOpTest()
- Fix reversed inf/-inf and comment typos
- Print adapter being used when hardware adapter selected