### PR TITLE
Move unused global tracing flags into single usage, closes #157.

### DIFF
--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -150,18 +150,6 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 
 #define DXVERIFY_NOMSG(exp) DXASSERT(exp, "")
 
-// This should be improved with global enabled mask rather than a compile-time mask.
-#define DXTRACE_MASK_ENABLED  0
-#define DXTRACE_MASK_APIFS    1
-#define DXTRACE_ENABLED(subsystem) (DXTRACE_MASK_ENABLED & subsystem)
-
-// DXTRACE_FMT formats a debugger trace message if DXTRACE_MASK allows it.
-#define DXTRACE_FMT(subsystem, fmt, ...) do { \
-  if (DXTRACE_ENABLED(subsystem)) OutputDebugFormatA(fmt, __VA_ARGS__); \
-} while (0)
-/// DXTRACE_FMT_APIFS is used by the API-based virtual filesystem.
-#define DXTRACE_FMT_APIFS(fmt, ...) DXTRACE_FMT(DXTRACE_MASK_APIFS, fmt, __VA_ARGS__)
-
 #else
 
 // DXASSERT is disabled in free builds.
@@ -175,9 +163,5 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 
 // DXVERIFY is patterned after NT_VERIFY and will evaluate the expression
 #define DXVERIFY_NOMSG(exp) do { (exp); _Analysis_assume_(exp); } while (0)
-
-// DXTRACE_FMT and the subsystem versions are disabled in free builds.
-#define DXTRACE_FMT(...) (void)(0)
-#define DXTRACE_FMT_APIFS(...) (void)(0)
 
 #endif // DBG

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -41,7 +41,6 @@
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h"
 #include "dxc/HLSL/DxilRootSignature.h"
 
-#ifdef _DEBUG
 #if defined(_MSC_VER)
 #include <io.h>
 #ifndef STDOUT_FILENO
@@ -49,7 +48,6 @@
 #endif
 #ifndef STDERR_FILENO
 # define STDERR_FILENO 2
-#endif
 #endif
 #endif
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -286,6 +286,7 @@ public:
   TEST_METHOD(CompileWhenIncludeSystemMissingThenLoadAttempt)
   TEST_METHOD(CompileWhenIncludeFlagsThenIncludeUsed)
   TEST_METHOD(CompileWhenIncludeMissingThenFail)
+  TEST_METHOD(CompileWhenIncludeHasPathThenOK)
 
   TEST_METHOD(CompileWhenODumpThenPassConfig)
   TEST_METHOD(CompileWhenODumpThenOptimizerMatch)
@@ -1765,6 +1766,38 @@ TEST_F(CompilerTest, CompileWhenIncludeMissingThenFail) {
   HRESULT hr;
   VERIFY_SUCCEEDED(pResult->GetStatus(&hr));
   VERIFY_FAILED(hr);
+}
+
+TEST_F(CompilerTest, CompileWhenIncludeHasPathThenOK) {
+  CComPtr<IDxcCompiler> pCompiler;
+  LPCWSTR Source = L"c:\\temp\\OddIncludes\\main.hlsl";
+  LPCWSTR Args[] = { L"/I", L"c:\\temp" };
+  LPCWSTR ArgsUp[] = { L"/I", L"c:\\Temp" };
+  VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
+  bool useUpValues[] = { false, true };
+  for (bool useUp : useUpValues) {
+    CComPtr<IDxcOperationResult> pResult;
+    CComPtr<IDxcBlobEncoding> pSource;
+#if TEST_ON_DISK
+    CComPtr<IDxcLibrary> pLibrary;
+    VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+    VERIFY_SUCCEEDED(pLibrary->CreateIncludeHandler(&pInclude));
+    VERIFY_SUCCEEDED(pLibrary->CreateBlobFromFile(Source, nullptr, &pSource));
+#else
+    CComPtr<TestIncludeHandler> pInclude;
+    pInclude = new TestIncludeHandler(m_dllSupport);
+    pInclude->CallResults.emplace_back("// Empty");
+    CreateBlobFromText("#include \"include.hlsl\"\r\n"
+                       "float4 main() : SV_Target { return 0; }",
+                       &pSource);
+#endif
+
+    VERIFY_SUCCEEDED(pCompiler->Compile(pSource, Source, L"main",
+      L"ps_6_0", useUp ? ArgsUp : Args, _countof(Args), nullptr, 0, pInclude, &pResult));
+    HRESULT hr;
+    VERIFY_SUCCEEDED(pResult->GetStatus(&hr));
+    VERIFY_SUCCEEDED(hr);
+ }
 }
 
 static const char EmptyCompute[] = "[numthreads(8,8,1)] void main() { }";

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -9,7 +9,10 @@ set TEST_CLANG=1
 set TEST_EXEC=1
 set TEST_CLANG_VERIF=0
 set TEST_EXTRAS=1
-set BUILD_CONFIG=Debug
+
+if "%BUILD_CONFIG%"=="" (
+  set BUILD_CONFIG=Debug
+)
 
 if "%1"=="clean" (
   set TEST_CLEAN=1
@@ -175,7 +178,7 @@ exit /b 0
 :showhelp
 
 echo Usage:
-echo   hcttest [target]
+echo   hcttest [-rel] [-arm or -x86 or -x64] [target]
 echo.
 echo target can be empty or a specific subset.
 echo.
@@ -184,6 +187,13 @@ echo.
 echo 'clang' will only run clang tests.
 echo 'exec' will only run execution tests.
 echo 'v' will run the clang tests that are verified-based.
+echo.
+echo   -rel builds release rather than debug
+echo.
+echo current BUILD_ARCH=%BUILD_ARCH%.  Override with:
+echo   -x86 targets an x86 build (aka. Win32)
+echo   -x64 targets an x64 build (aka. Win64)
+echo   -arm targets an ARM build
 echo.
 echo Use the HCT_EXTRAS environment variable to add hcttest-before and hcttest-after hooks.
 echo.


### PR DESCRIPTION
Normalizes API-provided names to include at least a current-relative
directory, simplifying file lookups. There are still restrictions on
how expressive include handlers enable the virtual file system to be,
these should be documented on the project wiki.

Handle some errors in BeginSourceFile paths where include handlers may
cause early errors, before compilation execution can begin.

Removes the prior scheme for directory handles, where the same handle
would be returned for any parent directory.

Future improvements would be to expand dxc paths before calling into
dxcompiler, and/or to fully implement OS API calls from console apps.