### PR TITLE
Ensure the cached Function->OpCodeClass map is updated

### DIFF
--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -54,6 +54,10 @@ public:
   llvm::Type *GetResRetType(llvm::Type *pOverloadType);
   llvm::Type *GetCBufferRetType(llvm::Type *pOverloadType);
 
+  // Return the opcode class for the given dx.op function.
+  // Caller must ensure that dxilFunction is a valid dxil function.
+  OpCodeClass GetOpClassForDxilFunction(const llvm::Function *dxilFunction);
+
   // LLVM helpers. Perhaps, move to a separate utility class.
   llvm::Constant *GetI1Const(bool v);
   llvm::Constant *GetI8Const(char v);
@@ -102,8 +106,9 @@ private:
     llvm::Function *pOverloads[kNumTypeOverloads];
   };
   OpCodeCacheItem m_OpCodeClassCache[(unsigned)OpCodeClass::NumOpClasses];
-  std::unordered_map<llvm::Function *, OpCodeClass> m_FunctionToOpClass;
+  std::unordered_map<const llvm::Function *, OpCodeClass> m_FunctionToOpClass;
   void RefreshCache(llvm::Module *pModule);
+  void UpdateCache(OpCodeClass opClass, unsigned typeSlot, llvm::Function *F);
 private:
   // Static properties.
   struct OpCodeProperty {

--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -54,9 +54,10 @@ public:
   llvm::Type *GetResRetType(llvm::Type *pOverloadType);
   llvm::Type *GetCBufferRetType(llvm::Type *pOverloadType);
 
-  // Return the opcode class for the given dx.op function.
-  // Caller must ensure that dxilFunction is a valid dxil function.
-  OpCodeClass GetOpClassForDxilFunction(const llvm::Function *dxilFunction);
+  // Try to get the opcode class for a function.
+  // Return true and set `opClass` if the given function is a dxil function.
+  // Return false if the given function is not a dxil function.
+  bool GetOpCodeClass(const llvm::Function *F, OpCodeClass &opClass);
 
   // LLVM helpers. Perhaps, move to a separate utility class.
   llvm::Constant *GetI1Const(bool v);

--- a/include/dxc/HLSL/DxilShaderModel.h
+++ b/include/dxc/HLSL/DxilShaderModel.h
@@ -60,6 +60,9 @@ public:
   static const ShaderModel *Get(Kind Kind, unsigned Major, unsigned Minor);
   static const ShaderModel *GetByName(const char *pszName);
 
+  bool operator==(const ShaderModel &other) const;
+  bool operator!=(const ShaderModel &other) const { return !(*this == other); }
+
 private:
   Kind m_Kind;
   unsigned m_Major;

--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -697,7 +697,7 @@ public:
   void ResetHLModule();
   bool HasDxilModule() const { return TheDxilModule != nullptr; }
   void SetDxilModule(hlsl::DxilModule *pValue) { TheDxilModule = pValue; }
-  hlsl::DxilModule &GetDxilModule() { return *TheDxilModule; }
+  hlsl::DxilModule &GetDxilModule() const { return *TheDxilModule; }
   hlsl::DxilModule &GetOrCreateDxilModule(bool skipInit = false);
   void ResetDxilModule();
   // HLSL Change end

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -526,7 +526,6 @@ HRESULT STDMETHODCALLTYPE DxcOptimizer::RunOptimizer(
     return E_INVALIDARG;
   }
 
-
   legacy::PassManager ModulePasses;
   legacy::FunctionPassManager FunctionPasses(M.get());
   legacy::PassManagerBase *pPassManager = &ModulePasses;

--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -127,7 +127,7 @@ Module *DxilModule::GetModule() const { return m_pModule; }
 OP *DxilModule::GetOP() const { return m_pOP.get(); }
 
 void DxilModule::SetShaderModel(const ShaderModel *pSM) {
-  DXASSERT(m_pSM == nullptr, "shader model must not change for the module");
+  DXASSERT(m_pSM == nullptr || (pSM != nullptr && *m_pSM == *pSM), "shader model must not change for the module");
   m_pSM = pSM;
   m_pMDHelper->SetShaderModel(m_pSM);
   DXIL::ShaderKind shaderKind = pSM->GetKind();

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -727,12 +727,14 @@ void OP::RemoveFunction(Function *F) {
   }
 }
 
-OP::OpCodeClass OP::GetOpClassForDxilFunction(const Function *F) {
+bool OP::GetOpCodeClass(const Function *F, OP::OpCodeClass &opClass) {
   auto iter = m_FunctionToOpClass.find(F);
   if (iter == m_FunctionToOpClass.end()) {
-    throw hlsl::Exception(DXC_E_OPTIMIZATION_FAILED, "should only be called for dxil functions");
+    DXASSERT(!IsDxilOpFunc(F), "dxil function without an opcode class mapping?");
+    return false;
   }
-  return iter->second;
+  opClass = iter->second;
+  return true;
 }
 
 llvm::Type *OP::GetOverloadType(OpCode OpCode, llvm::Function *F) {

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -730,8 +730,7 @@ void OP::RemoveFunction(Function *F) {
 OP::OpCodeClass OP::GetOpClassForDxilFunction(const Function *F) {
   auto iter = m_FunctionToOpClass.find(F);
   if (iter == m_FunctionToOpClass.end()) {
-    DXASSERT(false, "should only be called for dxil functions");
-    return OpCodeClass::NumOpClasses;
+    throw hlsl::Exception(DXC_E_OPTIMIZATION_FAILED, "should only be called for dxil functions");
   }
   return iter->second;
 }

--- a/lib/HLSL/DxilShaderModel.cpp
+++ b/lib/HLSL/DxilShaderModel.cpp
@@ -32,7 +32,7 @@ bool ShaderModel::operator==(const ShaderModel &other) const {
     return m_Kind          == other.m_Kind
         && m_Major         == other.m_Major
         && m_Minor         == other.m_Minor
-        && m_pszName       == other.m_pszName
+        && strcmp(m_pszName,  other.m_pszName) == 0
         && m_NumInputRegs  == other.m_NumInputRegs
         && m_NumOutputRegs == other.m_NumOutputRegs
         && m_bTypedUavs    == other.m_bTypedUavs

--- a/lib/HLSL/DxilShaderModel.cpp
+++ b/lib/HLSL/DxilShaderModel.cpp
@@ -28,6 +28,17 @@ ShaderModel::ShaderModel(Kind Kind, unsigned Major, unsigned Minor, const char *
 , m_NumUAVRegs(NumUAVRegs) {
 }
 
+bool ShaderModel::operator==(const ShaderModel &other) const {
+    return m_Kind          == other.m_Kind
+        && m_Major         == other.m_Major
+        && m_Minor         == other.m_Minor
+        && m_pszName       == other.m_pszName
+        && m_NumInputRegs  == other.m_NumInputRegs
+        && m_NumOutputRegs == other.m_NumOutputRegs
+        && m_bTypedUavs    == other.m_bTypedUavs
+        && m_NumUAVRegs    == other.m_NumUAVRegs;
+}
+
 bool ShaderModel::IsValid() const {
   DXASSERT(IsPS() || IsVS() || IsGS() || IsHS() || IsDS() || IsCS() || m_Kind == Kind::Invalid, "invalid shader model");
   return m_Kind != Kind::Invalid;

--- a/tools/clang/test/HLSL/constprop/bfi.ll
+++ b/tools/clang/test/HLSL/constprop/bfi.ll
@@ -30,16 +30,18 @@ entry:
   %4 = call i32 @dx.op.quaternary.i32(i32 53, i32 0, i32 8, i32 0, i32 15)
   call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %buf_UAV_rawbuf, i32 16, i32 undef, i32 %4, i32 undef, i32 undef, i32 undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
   
-  ; CHECK: @dx.op.bufferStore{{.*}}, i32 2560,
-  %5 = call i64 @dx.op.quaternary.i64(i32 53, i64 4, i64 8, i64 4010, i64 0)
-  %6 = trunc i64 %5 to i32
-  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %buf_UAV_rawbuf, i32 20, i32 undef, i32 %6, i32 undef, i32 undef, i32 undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ; No i64 overloads for bfi in dxil yet.
+  ; xHECK: @dx.op.bufferStore{{.*}}, i32 2560,
+  ;%5 = call i64 @dx.op.quaternary.i64(i32 53, i64 4, i64 8, i64 4010, i64 0)
+  ;%6 = trunc i64 %5 to i32
+  ;call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %buf_UAV_rawbuf, i32 20, i32 undef, i32 %6, i32 undef, i32 undef, i32 undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
   
-  ; CHECK: @dx.op.bufferStore{{.*}}, i32 10,
-  %7 = call i64 @dx.op.quaternary.i64(i32 53, i64 4, i64 32, i64 4010, i64 0)
-  %8 = lshr i64 %7, 32
-  %9 = trunc i64 %8 to i32
-  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %buf_UAV_rawbuf, i32 24, i32 undef, i32 %9, i32 undef, i32 undef, i32 undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ; No i64 overloads for bfi in dxil yet.
+  ; xHECK: @dx.op.bufferStore{{.*}}, i32 10,
+  ;%7 = call i64 @dx.op.quaternary.i64(i32 53, i64 4, i64 32, i64 4010, i64 0)
+  ;%8 = lshr i64 %7, 32
+  ;%9 = trunc i64 %8 to i32
+  ;call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %buf_UAV_rawbuf, i32 24, i32 undef, i32 %9, i32 undef, i32 undef, i32 undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
   
   call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 0)  ; StoreOutput(outputtSigId,rowIndex,colIndex,value)
   ret void


### PR DESCRIPTION
The original goal of this change was to use opcode class for deciding when we
can perform constant folding on a function.

We maintain a mapping from Function* to OpCodeClass inside the OP class.
We wanted to use this map in constant folding to decide if we can constant
fold a function to avoid string comparison on the function names.

However, it turns out that the DxilModule is not always available during
constant folding of dxil calls so we cannot use the map inside of OP. The
change contains a few bug fixes and improvements that came out of trying
to get opcode class working inside constant folding.

  1. Use opcode class in dxil constant folding where possible.
  2. Make sure the opcode cache is refreshed properly.
  3. Remove 64-bit test for bfi.
  4. Add equality comparison for the ShaderModel class.

When switching to use the opcode class for constant folding, we discovered
that our test for 64-bit bfi is invalid. There is no 64-bit overload for
bfi in dxil, so the test we had written was not legal dxil. This change
removes the 64-bit test for bfi constant prop.