### PR TITLE
Move some functions from clang CodeGen to clang AST

### DIFF
--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -24,6 +24,72 @@ using namespace clang;
 
 namespace hlsl {
 
+/// <summary>Try to convert HLSL template vector/matrix type to
+/// ExtVectorType.</summary>
+const clang::ExtVectorType *
+ConvertHLSLVecMatTypeToExtVectorType(const clang::ASTContext &context,
+                                     clang::QualType type) {
+  const Type *Ty = type.getCanonicalType().getTypePtr();
+
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (const ClassTemplateSpecializationDecl *templateDecl =
+            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
+      // TODO: check pointer instead of name
+      if (templateDecl->getName() == "vector") {
+        const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
+        const TemplateArgument &arg0 = argList[0];
+        const TemplateArgument &arg1 = argList[1];
+        QualType elemTy = arg0.getAsType();
+        llvm::APSInt elmSize = arg1.getAsIntegral();
+        return context.getExtVectorType(elemTy, elmSize.getLimitedValue())
+            ->getAs<ExtVectorType>();
+      }
+    }
+  }
+  return nullptr;
+}
+
+bool IsHLSLVecMatType(clang::QualType type) {
+  const Type *Ty = type.getCanonicalType().getTypePtr();
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (const ClassTemplateSpecializationDecl *templateDecl =
+            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
+      if (templateDecl->getName() == "vector") {
+        return true;
+      } else if (templateDecl->getName() == "matrix") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool IsHLSLMatType(clang::QualType type) {
+  const clang::Type *Ty = type.getCanonicalType().getTypePtr();
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (const ClassTemplateSpecializationDecl *templateDecl =
+            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
+      if (templateDecl->getName() == "matrix") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool IsHLSLVecType(clang::QualType type) {
+  const clang::Type *Ty = type.getCanonicalType().getTypePtr();
+  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
+    if (const ClassTemplateSpecializationDecl *templateDecl =
+            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
+      if (templateDecl->getName() == "vector") {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 /// Checks whether the pAttributes indicate a parameter is inout or out; if
 /// inout, pIsIn will be set to true.
 bool IsParamAttributedAsOut(_In_opt_ clang::AttributeList *pAttributes,

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.cpp
@@ -20,85 +20,15 @@
 using namespace clang;
 using namespace CodeGen;
 
-namespace hlsl {
-/// <summary>Try to convert HLSL template vector/matrix type to
-/// ExtVectorType.</summary>
-const clang::ExtVectorType *
-ConvertHLSLVecMatTypeToExtVectorType(const clang::ASTContext &context,
-                                     clang::QualType type) {
-  return CodeGen::CGHLSLRuntime::ConvertHLSLVecMatTypeToExtVectorType(context,
-                                                                      type);
-}
-
-bool IsHLSLVecMatType(clang::QualType type) {
-  return CodeGen::CGHLSLRuntime::IsHLSLVecMatType(type);
-}
-
-bool IsHLSLMatType(clang::QualType type) {
-  const clang::Type *Ty = type.getCanonicalType().getTypePtr();
-  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
-    if (const ClassTemplateSpecializationDecl *templateDecl =
-            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
-      if (templateDecl->getName() == "matrix") {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-bool IsHLSLVecType(clang::QualType type) {
-  const clang::Type *Ty = type.getCanonicalType().getTypePtr();
-  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
-    if (const ClassTemplateSpecializationDecl *templateDecl =
-            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
-      if (templateDecl->getName() == "vector") {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-}
-
 CGHLSLRuntime::~CGHLSLRuntime() {}
 
 bool CGHLSLRuntime::IsHLSLVecMatType(clang::QualType &type) {
-  const Type *Ty = type.getCanonicalType().getTypePtr();
-  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
-    if (const ClassTemplateSpecializationDecl *templateDecl =
-            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
-      if (templateDecl->getName() == "vector") {
-        return true;
-      } else if (templateDecl->getName() == "matrix") {
-        return true;
-      }
-    }
-  }
-  return false;
+  return hlsl::IsHLSLVecMatType(type);
 }
 
 const clang::ExtVectorType *CGHLSLRuntime::ConvertHLSLVecMatTypeToExtVectorType(
     const clang::ASTContext &context, clang::QualType &type) {
-  const Type *Ty = type.getCanonicalType().getTypePtr();
-
-  if (const RecordType *RT = dyn_cast<RecordType>(Ty)) {
-    if (const ClassTemplateSpecializationDecl *templateDecl =
-            dyn_cast<ClassTemplateSpecializationDecl>(RT->getDecl())) {
-      // TODO: check pointer instead of name
-      if (templateDecl->getName() == "vector") {
-        const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
-        const TemplateArgument &arg0 = argList[0];
-        const TemplateArgument &arg1 = argList[1];
-        QualType elemTy = arg0.getAsType();
-        llvm::APSInt elmSize = arg1.getAsIntegral();
-        return context.getExtVectorType(elemTy, elmSize.getLimitedValue())
-            ->getAs<ExtVectorType>();
-      }
-    }
-  }
-  return nullptr;
+  return hlsl::ConvertHLSLVecMatTypeToExtVectorType(context, type);
 }
 
 QualType CGHLSLRuntime::GetHLSLVecMatElementType(QualType type) {


### PR DESCRIPTION
These functions are defined in [`HlslTypes.h`](https://github.com/Microsoft/DirectXShaderCompiler/blob/master/tools/clang/include/clang/AST/HlslTypes.h#L351-L356) in clang AST so they
should have implementations in libclangAST.a.

cc @dneto0 @ehsannas