### PR TITLE
Update default maxcpucount in hctbuild

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -246,7 +246,7 @@ setlocal
 call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %BUILD_TOOLS%
 rem Add /ds for a detailed summary at the end.
 echo Logging to %3\msbuild-log.txt
-MSBuild.exe /nologo /property:Configuration=%1 /property:Platform=%2 /maxcpucount %3\LLVM.sln /consoleloggerparameters:Summary;Verbosity=minimal /fileloggerparameters:LogFile=%3\msbuild-log.txt
+MSBuild.exe /nologo /property:Configuration=%1 /property:Platform=%2 /maxcpucount:2 %3\LLVM.sln /consoleloggerparameters:Summary;Verbosity=minimal /fileloggerparameters:LogFile=%3\msbuild-log.txt
 if NOT "%ERRORLEVEL%"=="0" (
   exit /b 1
 )


### PR DESCRIPTION
Quick fix; we tend to be more constrained by memory than cycles in many build configurations, so ease back a bit.