### PR TITLE
Make sure we are targeting vs2015 for the vs-specific build

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -222,8 +222,12 @@ if "%DO_SETUP%"=="1" (
 if "%DO_BUILD%"=="1" (
   rem Should add support for the non-x86-qualified programfiles.
   echo Building solution files for %2 with %1 configuration.
-  if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
-    call :buildvs_x86dir %1 %2 %3
+  if "%BUILD_GENERATOR%"=="Visual Studio 14 2015" (
+    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
+      call :buildvs_x86dir %1 %2 %3
+    ) else (
+      cmake --build . --config %1
+    )
   ) else (
     cmake --build . --config %1
   )


### PR DESCRIPTION
Otherwise the build will fail when the build generator is vs2017. This
error occurs when you have vs2015 installed but want to build with vs2017.
Without this change the appveyor builds will fail.