### PR TITLE
Adding Execution Tests for ShaderOp Arithmetic operations

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1907,44 +1907,44 @@ ID  Name                          Description
 5   StoreOutput                   stores the value to shader output
 6   FAbs                          returns the absolute value of the input value.
 7   Saturate                      clamps the result of a single or double precision floating point value to [0.0f...1.0f]
-8   IsNaN                         returns the IsNaN
-9   IsInf                         returns the IsInf
-10  IsFinite                      returns the IsFinite
-11  IsNormal                      returns the IsNormal
+8   IsNaN                         IsNaN
+9   IsInf                         IsInf
+10  IsFinite                      IsFinite
+11  IsNormal                      IsNormal
 12  Cos                           returns cosine(theta) for theta in radians.
-13  Sin                           returns the Sin
+13  Sin                           returns sine(theta) for theta in radians.
 14  Tan                           returns the Tan
-15  Acos                          returns the Acos
-16  Asin                          returns the Asin
-17  Atan                          returns the Atan
-18  Hcos                          returns the Hcos
-19  Hsin                          returns the Hsin
-20  Htan                          returns the Htan
-21  Exp                           returns the Exp
-22  Frc                           returns the Frc
-23  Log                           returns the Log
-24  Sqrt                          returns the Sqrt
-25  Rsqrt                         returns the Rsqrt
-26  Round_ne                      returns the Round_ne
-27  Round_ni                      returns the Round_ni
-28  Round_pi                      returns the Round_pi
-29  Round_z                       returns the Round_z
-30  Bfrev                         returns the reverse bit pattern of the input value
-31  Countbits                     returns the Countbits
-32  FirstbitLo                    returns the FirstbitLo
-33  FirstbitHi                    returns src != 0? (BitWidth-1 - FirstbitHi) : -1
-34  FirstbitSHi                   returns src != 0? (BitWidth-1 - FirstbitSHi) : -1
+15  Acos                          Acos
+16  Asin                          Asin
+17  Atan                          Atan
+18  Hcos                          Hcos
+19  Hsin                          Hsin
+20  Htan                          Htan
+21  Exp                           returns component-wise e^exponent
+22  Frc                           Frc
+23  Log                           returns component-wise natural log.
+24  Sqrt                          returns component-wise square root
+25  Rsqrt                         returns component-wise reciprocal square root (1 / sqrt(src))
+26  Round_ne                      floating-point round to integral float.
+27  Round_ni                      floating-point round to integral float.
+28  Round_pi                      floating-point round to integral float.
+29  Round_z                       floating-point round to integral float.
+30  Bfrev                         Bfrev
+31  Countbits                     Countbits
+32  FirstbitLo                    FirstbitLo
+33  FirstbitHi                    FirstbitHi
+34  FirstbitSHi                   FirstbitSHi
 35  FMax                          returns a if a >= b, else b
 36  FMin                          returns a if a < b, else b
-37  IMax                          returns the IMax of the input values
-38  IMin                          returns the IMin of the input values
-39  UMax                          returns the UMax of the input values
+37  IMax                          IMax
+38  IMin                          IMin
+39  UMax                          UMax
 40  UMin                          returns the UMin of the input values
-41  IMul                          returns the IMul of the input values
-42  UMul                          returns the UMul of the input values
-43  UDiv                          returns the UDiv of the input values
-44  UAddc                         returns the UAddc of the input values
-45  USubb                         returns the USubb of the input values
+41  IMul                          there is no way to call this directly in HLSL.
+42  UMul                          UMul
+43  UDiv                          UDiv
+44  UAddc                         UAddc
+45  USubb                         USubb
 46  FMad                          performs a fused multiply add (FMA) of the form a * b + c
 47  Fma                           performs a fused multiply add (FMA) of the form a * b + c
 48  IMad                          performs an integral IMad
@@ -2039,6 +2039,28 @@ ID  Name                          Description
 === ============================= ================================================================================================================
 
 
+Acos
+~~~~
+
+Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1.
+The return value is within the range of -PI/2 to PI/2.
+
+Asin
+~~~~
+
+Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1
+The return value is within the range of -PI/2 to PI/2.
+
+Atan
+~~~~
+
+Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+
+Bfrev
+~~~~~
+
+Reverses the order of the bits, per component.
+
 Cos
 ~~~
 
@@ -2046,11 +2068,25 @@ Theta values can be any IEEE 32-bit floating point values.
 
 The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
 
-
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
-| cos(src) |  NaN | [-1 to +1] |      -0 | -0 | +0 |      +0 | [-1 to +1] |  NaN | NaN |
+| cos(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Countbits
+~~~~~~~~~
+
+Counts the number of bits (per component) in the input integer.
+
+Exp
+~~~
+
+Maximum relative error is e^{-21}
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| exp(src) |  0   | +F         |    1    |  1 |  1 |       1 | +F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 
 FAbs
@@ -2107,6 +2143,157 @@ Denorms are flushed (sign preserved) before comparison, however the result writt
 | NaN  | -inf | b      | +inf | NaN  |
 +------+------+--------+------+------+
 
+FirstbitHi
+~~~~~~~~~~
+
+Gets the location of the first set bit starting from the highest order bit and working downward, per component.
+
+FirstbitLo
+~~~~~~~~~~
+
+Returns the location of the first set bit starting from the lowest order bit and working upward, per component.
+
+FirstbitSHi
+~~~~~~~~~~~
+
+Returns the location of the first set bit of signed integer starting from the lowest order bit and working upward, per component.
+
+Frc
+~~~
+
+component-wise, extract fracitonal component.
+
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src        | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+| frc(src)   | NaN  | [+0,1)     |    +0   | +0 | +0 |      +0 | [+0,1)     | NaN  | NaN |
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Hcos
+~~~~
+
+returns the hyperbolic cosine of the specified value.
+
+Hsin
+~~~~
+
+returns the hyperbolic sine of the specified value.
+
+Htan
+~~~~
+
+returns the hyperbolic tangent of the specified value.
+
+IMax
+~~~~
+
+IMax(a,b) returns a if a >= b, else b
+
+IMin
+~~~~
+
+IMin(a,b) returns a if a < b, else b
+
+IMul
+~~~~
+
+Component-wise multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit (per component) result.
+The low 32 bits (per component) are placed in destLO.  The high 32 bits (per component) are placed in destHI.
+
+Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed.
+
+Optional negate modifier on source operands takes 2's complement before performing arithmetic operation.
+
+IsFinite
+~~~~~~~~
+
+Returns true if x is finite, false otherwise.
+
+IsInf
+~~~~~
+
+Returns true if x is +INF or -INF, false otherwise.
+
+IsNaN
+~~~~~
+
+Returns true if x is NAN or QNAN, false otherwise.
+
+Log
+~~~
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| log(src) |  NaN | NaN        |    -inf |-inf|-inf|    -inf |  F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Round_ne
+~~~~~~~~
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ne rounds towards nearest even. For halfway, it rounds away from zero.
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_ne(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Round_ni
+~~~~~~~~
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ni rounds towards -INF, commonly known as floor().
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_ni(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Round_pi
+~~~~~~~~
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_pi rounds towards +INF, commonly known as ceil().
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_pi(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Round_z
+~~~~~~~
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_z rounds towards zero.
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_z(src) | -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Rsqrt
+~~~~~
+
+Maximum relative error is 2^21.
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src       | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+| rsqrt(src)|  NaN | NaN        |  -inf   |-inf|+inf|  +inf   | +F         | +0   | NaN |
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 Saturate
 ~~~~~~~~
 
@@ -2128,8 +2315,55 @@ The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
-| sin(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
+| sin(src) |  NaN | [-1 to +1] |      -0 | -0 | +0 |      +0 | [-1 to +1] |  NaN | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+Sqrt
+~~~~
+
+Precision is 1 ulp.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| sqrt(src)|  NaN | NaN        |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+UAddc
+~~~~~
+
+Component-wise unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0. \
+The corresponding component in dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
+
+UDiv
+~~~~
+
+Component-wise unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+The results of the divides are the 32-bit quotients (placed in destQUOT) and 32-bit remainders (placed in destREM).
+Divide by zero returns 0xffffffff for both quotient and remainder. Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
+
+UMax
+~~~~
+
+Component-wise unsigned integer maximum. UMax(a,b) = a > b ? a : b
+
+UMin
+~~~~
+
+Component-wise unsigned integer minimum. UMin(a,b) = a < b ? a : b
+
+UMul
+~~~~
+
+Component-wise multiply of 32-bit operands  src0 and src1 (note they are unsigned), producing the correct  full 64-bit (per component) result.
+The low 32 bits (per  component) are placed in destLO. The high 32 bits (per  component) are placed in destHI.
+Either of destHI or destLO may be specified as NULL instead of  specifying a register, in the case high or low 32 bits of the  64-bit result are not needed
+
+USubb
+~~~~~
+
+Component-wise unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
+The corresponding component in dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
 
 .. OPCODES-RST:END
 

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1949,7 +1949,7 @@ ID  Name                           Description
 44  UAddc_                         unsigned add of 32-bit operand with the carry
 45  USubb_                         returns the USubb of the input values
 46  FMad_                          floating point multiply & add
-47  Fma_                           fused multiple-add
+47  Fma_                           fused multiply-add
 48  IMad_                          Signed integer multiply & add
 49  UMad_                          Unsigned integer multiply & add
 50  Msad_                          masked Sum of Absolute Differences.
@@ -2047,13 +2047,31 @@ Acos
 
 The return value is within the range of -PI/2 to PI/2.
 
++----------+------+--------------+---------+------+------+---------+------+-----+
+| src      | -inf | [-1,1]       | -denorm | -0   | +0   | +denorm | +inf | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+| acos(src)|  NaN | (-PI/2,+PI/2)|    PI/2 | PI/2 | PI/2 |    PI/2 |  NaN | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+
 Asin
 ~~~~
 
 The return value is within the range of -PI/2 to PI/2.
 
++----------+------+--------------+---------+------+------+---------+------+-----+
+| src      | -inf | [-1,1]       | -denorm | -0   | +0   | +denorm | +inf | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+| asin(src)|  NaN | (-PI/2,+PI/2)|    0    |  0   |  0   |    0    |  NaN | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+
 Atan
 ~~~~
+
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
+| src      | -inf | -F           | -denorm | -0   | +0   | +denorm | +F            |+inf | NaN |
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
+| atan(src)| -PI/2| (-PI/2,+PI/2)|    0    |  0   |  0   |    0    | (-PI/2,+PI/2) |PI/2 | NaN |
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
 
 Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2
 
@@ -2195,7 +2213,7 @@ Returns the first 0 from the MSB if the number is negative, else the first 1 fro
 Fma
 ~~~
 
-Fused multiple-add. This operation is only defined in double precision.
+Fused multiply-add. This operation is only defined in double precision.
 Fma(a,b,c) = a * b + c
 
 Frc
@@ -2212,15 +2230,33 @@ Hcos
 
 Returns the hyperbolic cosine of the specified value.
 
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| hcos(src)| +inf | (1, +inf)  |      +1 | +1 | +1 |      +1 | (1, +inf)  | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 Hsin
 ~~~~
 
 Returns the hyperbolic sine of the specified value.
 
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| hsin(src)| -inf | -F         |       0 |  0 |  0 |       0 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 Htan
 ~~~~
 
 Returns the hyperbolic tangent of the specified value.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| htan(src)|  NaN | -F         |       0 |  0 |  0 |       0 | +F         |  NaN | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
 
 IMad
 ~~~~

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1923,9 +1923,9 @@ ID  Name                           Description
 18  Hcos_                          returns the hyperbolic cosine of the specified value.
 19  Hsin_                          returns the hyperbolic sine of the specified value.
 20  Htan_                          returns the hyperbolic tangent of the specified value.
-21  Exp_                           returns e^exponent
+21  Exp_                           returns 2^exponent
 22  Frc_                           extract fracitonal component.
-23  Log_                           returns natural log.
+23  Log_                           returns log base 2.
 24  Sqrt_                          returns square root
 25  Rsqrt_                         returns reciprocal square root (1 / sqrt(src)
 26  Round_ne_                      floating-point round to integral float.
@@ -2127,7 +2127,7 @@ Four-dimensional vector dot-product
 Exp
 ~~~
 
-Maximum relative error is e^{-21}
+Returns 2^exponent. Note that hlsl log intrinsic returns the base-e exponent. Maximum relative error is e^-21.
 
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
@@ -2340,6 +2340,8 @@ Loads the value from shader input
 
 Log
 ~~~
+
+Returns log base 2. Note that hlsl log intrinsic returns natural log.
 
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -536,7 +536,7 @@ The classification of behavior for various system values in various signature lo
 
 Each SigPointKind also has a corresponding element allocation (or packing) behavior called PackingKind.  Some SigPointKinds do not result in a signature at all, which corresponds to the packing kind of PackingKind::None.
 
-Signature Points are enumerated as follows in the SigPointKind enum::
+Signature Points are enumerated as follows in the SigPointKind
 
 .. <py>import hctdb_instrhelp</py>
 .. <py::lines('SIGPOINT-RST')>hctdb_instrhelp.get_sigpoint_rst()</py>
@@ -565,7 +565,8 @@ ID SigPoint Related ShaderKind PackingKind    SignatureKind Description
 
 .. SIGPOINT-RST:END
 
-Semantic Interpretations are as follows (SemanticInterpretationKind)::
+Semantic Interpretations are as follows (SemanticInterpretationKind)
+
 
 .. <py>import hctdb_instrhelp</py>
 .. <py::lines('SEMINT-RST')>hctdb_instrhelp.get_sem_interpretation_enum_rst()</py>
@@ -587,7 +588,8 @@ ID Name       Description
 
 .. SEMINT-RST:END
 
-Semantic Interpretations for each SemanticKind at each SigPointKind are as follows::
+Semantic Interpretations for each SemanticKind at each SigPointKind are as follows
+
 
 .. <py>import hctdb_instrhelp</py>
 .. <py::lines('SEMINT-TABLE-RST')>hctdb_instrhelp.get_sem_interpretation_table_rst()</py>
@@ -1829,6 +1831,7 @@ DXIL uses a subset of core LLVM IR instructions that make sense for HLSL, where 
 
 The following LLVM instructions are valid in a DXIL program, with the specified operand types where applicable. The legend for overload types (v)oid, (h)alf, (f)loat, (d)ouble, (1)-bit, (8)-bit, (w)ord, (i)nt, (l)ong.
 
+
 .. <py>import hctdb_instrhelp</py>
 .. <py::lines('INSTR-RST')>hctdb_instrhelp.get_instrs_rst()</py>
 .. INSTR-RST:BEGIN
@@ -1896,170 +1899,179 @@ Opcodes are defined on a dense range and will be provided as enum in a header fi
 .. <py::lines('OPCODES-RST')>hctdb_instrhelp.get_opcodes_rst()</py>
 .. OPCODES-RST:BEGIN
 
-=== ============================= ================================================================================================================
-ID  Name                          Description
-=== ============================= ================================================================================================================
-0   TempRegLoad                   helper load operation
-1   TempRegStore                  helper store operation
-2   MinPrecXRegLoad               helper load operation for minprecision
-3   MinPrecXRegStore              helper store operation for minprecision
-4   LoadInput                     loads the value from shader input
-5   StoreOutput                   stores the value to shader output
-6   FAbs                          returns the absolute value of the input value.
-7   Saturate                      clamps the result of a single or double precision floating point value to [0.0f...1.0f]
-8   IsNaN                         IsNaN
-9   IsInf                         IsInf
-10  IsFinite                      IsFinite
-11  IsNormal                      IsNormal
-12  Cos                           returns cosine(theta) for theta in radians.
-13  Sin                           returns sine(theta) for theta in radians.
-14  Tan                           returns the Tan
-15  Acos                          Acos
-16  Asin                          Asin
-17  Atan                          Atan
-18  Hcos                          Hcos
-19  Hsin                          Hsin
-20  Htan                          Htan
-21  Exp                           returns component-wise e^exponent
-22  Frc                           Frc
-23  Log                           returns component-wise natural log.
-24  Sqrt                          returns component-wise square root
-25  Rsqrt                         returns component-wise reciprocal square root (1 / sqrt(src))
-26  Round_ne                      floating-point round to integral float.
-27  Round_ni                      floating-point round to integral float.
-28  Round_pi                      floating-point round to integral float.
-29  Round_z                       floating-point round to integral float.
-30  Bfrev                         Bfrev
-31  Countbits                     Countbits
-32  FirstbitLo                    FirstbitLo
-33  FirstbitHi                    FirstbitHi
-34  FirstbitSHi                   FirstbitSHi
-35  FMax                          returns a if a >= b, else b
-36  FMin                          returns a if a < b, else b
-37  IMax                          IMax
-38  IMin                          IMin
-39  UMax                          UMax
-40  UMin                          returns the UMin of the input values
-41  IMul                          there is no way to call this directly in HLSL.
-42  UMul                          UMul
-43  UDiv                          UDiv
-44  UAddc                         UAddc
-45  USubb                         USubb
-46  FMad                          performs a fused multiply add (FMA) of the form a * b + c
-47  Fma                           performs a fused multiply add (FMA) of the form a * b + c
-48  IMad                          performs an integral IMad
-49  UMad                          performs an integral UMad
-50  Msad                          performs an integral Msad
-51  Ibfe                          performs an integral Ibfe
-52  Ubfe                          performs an integral Ubfe
-53  Bfi                           given a bit range from the LSB of a number, places that number of bits in another number at any offset
-54  Dot2                          two-dimensional vector dot-product
-55  Dot3                          three-dimensional vector dot-product
-56  Dot4                          four-dimensional vector dot-product
-57  CreateHandle                  creates the handle to a resource
-58  CBufferLoad                   loads a value from a constant buffer resource
-59  CBufferLoadLegacy             loads a value from a constant buffer resource
-60  Sample                        samples a texture
-61  SampleBias                    samples a texture after applying the input bias to the mipmap level
-62  SampleLevel                   samples a texture using a mipmap-level offset
-63  SampleGrad                    samples a texture using a gradient to influence the way the sample location is calculated
-64  SampleCmp                     samples a texture and compares a single component against the specified comparison value
-65  SampleCmpLevelZero            samples a texture and compares a single component against the specified comparison value
-66  TextureLoad                   reads texel data without any filtering or sampling
-67  TextureStore                  reads texel data without any filtering or sampling
-68  BufferLoad                    reads from a TypedBuffer
-69  BufferStore                   writes to a RWTypedBuffer
-70  BufferUpdateCounter           atomically increments/decrements the hidden 32-bit counter stored with a Count or Append UAV
-71  CheckAccessFullyMapped        determines whether all values from a Sample, Gather, or Load operation accessed mapped tiles in a tiled resource
-72  GetDimensions                 gets texture size information
-73  TextureGather                 gathers the four texels that would be used in a bi-linear filtering operation
-74  TextureGatherCmp              same as TextureGather, except this instrution performs comparison on texels, similar to SampleCmp
-75  Texture2DMSGetSamplePosition  gets the position of the specified sample
-76  RenderTargetGetSamplePosition gets the position of the specified sample
-77  RenderTargetGetSampleCount    gets the number of samples for a render target
-78  AtomicBinOp                   performs an atomic operation on two operands
-79  AtomicCompareExchange         atomic compare and exchange to memory
-80  Barrier                       inserts a memory barrier in the shader
-81  CalculateLOD                  calculates the level of detail
-82  Discard                       discard the current pixel
-83  DerivCoarseX                  computes the rate of change of components per stamp
-84  DerivCoarseY                  computes the rate of change of components per stamp
-85  DerivFineX                    computes the rate of change of components per pixel
-86  DerivFineY                    computes the rate of change of components per pixel
-87  EvalSnapped                   evaluates an input attribute at pixel center with an offset
-88  EvalSampleIndex               evaluates an input attribute at a sample location
-89  EvalCentroid                  evaluates an input attribute at pixel center
-90  SampleIndex                   returns the sample index in a sample-frequency pixel shader
-91  Coverage                      returns the coverage mask input in a pixel shader
-92  InnerCoverage                 returns underestimated coverage input from conservative rasterization in a pixel shader
-93  ThreadId                      reads the thread ID
-94  GroupId                       reads the group ID (SV_GroupID)
-95  ThreadIdInGroup               reads the thread ID within the group (SV_GroupThreadID)
-96  FlattenedThreadIdInGroup      provides a flattened index for a given thread within a given group (SV_GroupIndex)
-97  EmitStream                    emits a vertex to a given stream
-98  CutStream                     completes the current primitive topology at the specified stream
-99  EmitThenCutStream             equivalent to an EmitStream followed by a CutStream
-100 GSInstanceID                  GSInstanceID
-101 MakeDouble                    creates a double value
-102 SplitDouble                   splits a double into low and high parts
-103 LoadOutputControlPoint        LoadOutputControlPoint
-104 LoadPatchConstant             LoadPatchConstant
-105 DomainLocation                DomainLocation
-106 StorePatchConstant            StorePatchConstant
-107 OutputControlPointID          OutputControlPointID
-108 PrimitiveID                   PrimitiveID
-109 CycleCounterLegacy            CycleCounterLegacy
-110 WaveIsFirstLane               returns 1 for the first lane in the wave
-111 WaveGetLaneIndex              returns the index of the current lane in the wave
-112 WaveGetLaneCount              returns the number of lanes in the wave
-113 WaveAnyTrue                   returns 1 if any of the lane evaluates the value to true
-114 WaveAllTrue                   returns 1 if all the lanes evaluate the value to true
-115 WaveActiveAllEqual            returns 1 if all the lanes have the same value
-116 WaveActiveBallot              returns a struct with a bit set for each lane where the condition is true
-117 WaveReadLaneAt                returns the value from the specified lane
-118 WaveReadLaneFirst             returns the value from the first lane
-119 WaveActiveOp                  returns the result the operation across waves
-120 WaveActiveBit                 returns the result of the operation across all lanes
-121 WavePrefixOp                  returns the result of the operation on prior lanes
-122 QuadReadLaneAt                reads from a lane in the quad
-123 QuadOp                        returns the result of a quad-level operation
-124 BitcastI16toF16               bitcast between different sizes
-125 BitcastF16toI16               bitcast between different sizes
-126 BitcastI32toF32               bitcast between different sizes
-127 BitcastF32toI32               bitcast between different sizes
-128 BitcastI64toF64               bitcast between different sizes
-129 BitcastF64toI64               bitcast between different sizes
-130 LegacyF32ToF16                legacy fuction to convert float (f32) to half (f16) (this is not related to min-precision)
-131 LegacyF16ToF32                legacy fuction to convert half (f16) to float (f32) (this is not related to min-precision)
-132 LegacyDoubleToFloat           legacy fuction to convert double to float
-133 LegacyDoubleToSInt32          legacy fuction to convert double to int32
-134 LegacyDoubleToUInt32          legacy fuction to convert double to uint32
-135 WaveAllBitCount               returns the count of bits set to 1 across the wave
-136 WavePrefixBitCount            returns the count of bits set to 1 on prior lanes
-=== ============================= ================================================================================================================
+=== ============================== =================================================================================================================
+ID  Name                           Description
+=== ============================== =================================================================================================================
+0   TempRegLoad_                   Helper load operation
+1   TempRegStore_                  Helper store operation
+2   MinPrecXRegLoad_               Helper load operation for minprecision
+3   MinPrecXRegStore_              Helper store operation for minprecision
+4   LoadInput_                     Loads the value from shader input
+5   StoreOutput_                   Stores the value to shader output
+6   FAbs_                          returns the absolute value of the input value.
+7   Saturate_                      clamps the result of a single or double precision floating point value to [0.0f...1.0f]
+8   IsNaN_                         Returns true if x is NAN or QNAN, false otherwise.
+9   IsInf_                         Returns true if x is +INF or -INF, false otherwise.
+10  IsFinite_                      Returns true if x is finite, false otherwise.
+11  IsNormal_                      returns IsNormal
+12  Cos_                           returns cosine(theta) for theta in radians.
+13  Sin_                           returns sine(theta) for theta in radians.
+14  Tan_                           returns tan(theta) for theta in radians.
+15  Acos_                          Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1.
+16  Asin_                          Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
+17  Atan_                          Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+18  Hcos_                          returns the hyperbolic cosine of the specified value.
+19  Hsin_                          returns the hyperbolic sine of the specified value.
+20  Htan_                          returns the hyperbolic tangent of the specified value.
+21  Exp_                           returns e^exponent
+22  Frc_                           extract fracitonal component.
+23  Log_                           returns natural log.
+24  Sqrt_                          returns square root
+25  Rsqrt_                         returns reciprocal square root (1 / sqrt(src)
+26  Round_ne_                      floating-point round to integral float.
+27  Round_ni_                      floating-point round to integral float.
+28  Round_pi_                      floating-point round to integral float.
+29  Round_z_                       floating-point round to integral float.
+30  Bfrev_                         Reverses the order of the bits.
+31  Countbits_                     Counts the number of bits in the input integer.
+32  FirstbitLo_                    Returns the location of the first set bit starting from the lowest order bit and working upward.
+33  FirstbitHi_                    Returns the location of the first set bit starting from the highest order bit and working downward.
+34  FirstbitSHi_                   Returns the location of the first set bit from the highest order bit based on the sign.
+35  FMax_                          returns a if a >= b, else b
+36  FMin_                          returns a if a < b, else b
+37  IMax_                          IMax(a,b) returns a if a > b, else b
+38  IMin_                          IMin(a,b) returns a if a < b, else b
+39  UMax_                          unsigned integer maximum. UMax(a,b) = a > b ? a : b
+40  UMin_                          unsigned integer minimum. UMin(a,b) = a < b ? a : b
+41  IMul_                          multiply of 32-bit operands to produce the correct full 64-bit result.
+42  UMul_                          multiply of 32-bit operands to produce the correct full 64-bit result.
+43  UDiv_                          unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+44  UAddc_                         unsigned add of 32-bit operand with the carry
+45  USubb_                         returns the USubb of the input values
+46  FMad_                          floating point multiply & add
+47  Fma_                           fused multiple-add
+48  IMad_                          Signed integer multiply & add
+49  UMad_                          Unsigned integer multiply & add
+50  Msad_                          masked Sum of Absolute Differences.
+51  Ibfe_                          Integer bitfield extract
+52  Ubfe_                          Unsigned integer bitfield extract
+53  Bfi_                           Given a bit range from the LSB of a number, places that number of bits in another number at any offset
+54  Dot2_                          Two-dimensional vector dot-product
+55  Dot3_                          Three-dimensional vector dot-product
+56  Dot4_                          Four-dimensional vector dot-product
+57  CreateHandle_                  creates the handle to a resource
+58  CBufferLoad_                   loads a value from a constant buffer resource
+59  CBufferLoadLegacy_             loads a value from a constant buffer resource
+60  Sample_                        samples a texture
+61  SampleBias_                    samples a texture after applying the input bias to the mipmap level
+62  SampleLevel_                   samples a texture using a mipmap-level offset
+63  SampleGrad_                    samples a texture using a gradient to influence the way the sample location is calculated
+64  SampleCmp_                     samples a texture and compares a single component against the specified comparison value
+65  SampleCmpLevelZero_            samples a texture and compares a single component against the specified comparison value
+66  TextureLoad_                   reads texel data without any filtering or sampling
+67  TextureStore_                  reads texel data without any filtering or sampling
+68  BufferLoad_                    reads from a TypedBuffer
+69  BufferStore_                   writes to a RWTypedBuffer
+70  BufferUpdateCounter_           atomically increments/decrements the hidden 32-bit counter stored with a Count or Append UAV
+71  CheckAccessFullyMapped_        determines whether all values from a Sample, Gather, or Load operation accessed mapped tiles in a tiled resource
+72  GetDimensions_                 gets texture size information
+73  TextureGather_                 gathers the four texels that would be used in a bi-linear filtering operation
+74  TextureGatherCmp_              same as TextureGather, except this instrution performs comparison on texels, similar to SampleCmp
+75  Texture2DMSGetSamplePosition_  gets the position of the specified sample
+76  RenderTargetGetSamplePosition_ gets the position of the specified sample
+77  RenderTargetGetSampleCount_    gets the number of samples for a render target
+78  AtomicBinOp_                   performs an atomic operation on two operands
+79  AtomicCompareExchange_         atomic compare and exchange to memory
+80  Barrier_                       inserts a memory barrier in the shader
+81  CalculateLOD_                  calculates the level of detail
+82  Discard_                       discard the current pixel
+83  DerivCoarseX_                  computes the rate of change of components per stamp
+84  DerivCoarseY_                  computes the rate of change of components per stamp
+85  DerivFineX_                    computes the rate of change of components per pixel
+86  DerivFineY_                    computes the rate of change of components per pixel
+87  EvalSnapped_                   evaluates an input attribute at pixel center with an offset
+88  EvalSampleIndex_               evaluates an input attribute at a sample location
+89  EvalCentroid_                  evaluates an input attribute at pixel center
+90  SampleIndex_                   returns the sample index in a sample-frequency pixel shader
+91  Coverage_                      returns the coverage mask input in a pixel shader
+92  InnerCoverage_                 returns underestimated coverage input from conservative rasterization in a pixel shader
+93  ThreadId_                      reads the thread ID
+94  GroupId_                       reads the group ID (SV_GroupID)
+95  ThreadIdInGroup_               reads the thread ID within the group (SV_GroupThreadID)
+96  FlattenedThreadIdInGroup_      provides a flattened index for a given thread within a given group (SV_GroupIndex)
+97  EmitStream_                    emits a vertex to a given stream
+98  CutStream_                     completes the current primitive topology at the specified stream
+99  EmitThenCutStream_             equivalent to an EmitStream followed by a CutStream
+100 GSInstanceID_                  GSInstanceID
+101 MakeDouble_                    creates a double value
+102 SplitDouble_                   splits a double into low and high parts
+103 LoadOutputControlPoint_        LoadOutputControlPoint
+104 LoadPatchConstant_             LoadPatchConstant
+105 DomainLocation_                DomainLocation
+106 StorePatchConstant_            StorePatchConstant
+107 OutputControlPointID_          OutputControlPointID
+108 PrimitiveID_                   PrimitiveID
+109 CycleCounterLegacy_            CycleCounterLegacy
+110 WaveIsFirstLane_               returns 1 for the first lane in the wave
+111 WaveGetLaneIndex_              returns the index of the current lane in the wave
+112 WaveGetLaneCount_              returns the number of lanes in the wave
+113 WaveAnyTrue_                   returns 1 if any of the lane evaluates the value to true
+114 WaveAllTrue_                   returns 1 if all the lanes evaluate the value to true
+115 WaveActiveAllEqual_            returns 1 if all the lanes have the same value
+116 WaveActiveBallot_              returns a struct with a bit set for each lane where the condition is true
+117 WaveReadLaneAt_                returns the value from the specified lane
+118 WaveReadLaneFirst_             returns the value from the first lane
+119 WaveActiveOp_                  returns the result the operation across waves
+120 WaveActiveBit_                 returns the result of the operation across all lanes
+121 WavePrefixOp_                  returns the result of the operation on prior lanes
+122 QuadReadLaneAt_                reads from a lane in the quad
+123 QuadOp_                        returns the result of a quad-level operation
+124 BitcastI16toF16_               bitcast between different sizes
+125 BitcastF16toI16_               bitcast between different sizes
+126 BitcastI32toF32_               bitcast between different sizes
+127 BitcastF32toI32_               bitcast between different sizes
+128 BitcastI64toF64_               bitcast between different sizes
+129 BitcastF64toI64_               bitcast between different sizes
+130 LegacyF32ToF16_                legacy fuction to convert float (f32) to half (f16) (this is not related to min-precision)
+131 LegacyF16ToF32_                legacy fuction to convert half (f16) to float (f32) (this is not related to min-precision)
+132 LegacyDoubleToFloat_           legacy fuction to convert double to float
+133 LegacyDoubleToSInt32_          legacy fuction to convert double to int32
+134 LegacyDoubleToUInt32_          legacy fuction to convert double to uint32
+135 WaveAllBitCount_               returns the count of bits set to 1 across the wave
+136 WavePrefixBitCount_            returns the count of bits set to 1 on prior lanes
+=== ============================== =================================================================================================================
 
 
 Acos
 ~~~~
 
-Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1.
 The return value is within the range of -PI/2 to PI/2.
 
 Asin
 ~~~~
 
-Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1
 The return value is within the range of -PI/2 to PI/2.
 
 Atan
 ~~~~
 
-Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2
+
+Bfi
+~~~
+
+Given a bit range from the LSB of a number, place that number of bits in another number at any offset.
+
+dst = Bfi(src0, src1, src2, src3);
+
+The LSB 5 bits of src0 provide the bitfield width (0-31) to take from src2.
+The LSB 5 bits of src1 provide the bitfield offset (0-31) to start replacing bits in the  number read from src3.
+Given width, offset: bitmask = (((1 << width)-1) << offset) & 0xffffffff, dest = ((src2 << offset) & bitmask) | (src3 & ~bitmask)
 
 Bfrev
 ~~~~~
 
-Reverses the order of the bits, per component.
+Reverses the order of the bits. For example given 0x12345678 the result would be 0x1e6a2c48.
 
 Cos
 ~~~
@@ -2077,12 +2089,28 @@ The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
 Countbits
 ~~~~~~~~~
 
-Counts the number of bits (per component) in the input integer.
+Counts the number of bits in the input integer.
+
+Dot2
+~~~~
+
+Two-dimensional vector dot-product
+
+Dot3
+~~~~
+
+Three-dimensional vector dot-product
+
+Dot4
+~~~~
+
+Four-dimensional vector dot-product
 
 Exp
 ~~~
 
 Maximum relative error is e^{-21}
+
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
@@ -2094,6 +2122,12 @@ FAbs
 
 The FAbs instruction takes simply forces the sign of the number(s) on the source operand positive, including on INF values.
 Applying FAbs on NaN preserves NaN, although the particular NaN bit pattern that results is not defined.
+
+FMad
+~~~~
+
+Floating point multiply & add. This operation is not fused for "precise" operations.
+FMad(a,b,c) = a * b + c
 
 FMax
 ~~~~
@@ -2146,63 +2180,102 @@ Denorms are flushed (sign preserved) before comparison, however the result writt
 FirstbitHi
 ~~~~~~~~~~
 
-Gets the location of the first set bit starting from the highest order bit and working downward, per component.
+Returns the integer position of the first bit set in the 32-bit input starting from the MSB. For example, 0x10000000 would return 3. Returns 0xffffffff if no match was found.
 
 FirstbitLo
 ~~~~~~~~~~
 
-Returns the location of the first set bit starting from the lowest order bit and working upward, per component.
+Returns the integer position of the first bit set in the 32-bit input starting from the LSB. For example, 0x00000000 would return 1. Returns 0xffffffff if no match was found.
 
 FirstbitSHi
 ~~~~~~~~~~~
 
-Returns the location of the first set bit of signed integer starting from the lowest order bit and working upward, per component.
+Returns the first 0 from the MSB if the number is negative, else the first 1 from the MSB. Returns 0xffffffff if no match was found.
+
+Fma
+~~~
+
+Fused multiple-add. This operation is only defined in double precision.
+Fma(a,b,c) = a * b + c
 
 Frc
 ~~~
 
-component-wise, extract fracitonal component.
-
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src        | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
-| frc(src)   | NaN  | [+0,1)     |    +0   | +0 | +0 |      +0 | [+0,1)     | NaN  | NaN |
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+------+---------+----+----+---------+--------+------+-----+
+| src          | -inf | -F   | -denorm | -0 | +0 | +denorm | +F     | +inf | NaN |
++--------------+------+------+---------+----+----+---------+--------+------+-----+
+| log(src)     | NaN  |[+0,1)| +0      | +0 | +0 | +0      | [+0,1) | NaN  | NaN |
++--------------+------+------+---------+----+----+---------+--------+------+-----+
 
 Hcos
 ~~~~
 
-returns the hyperbolic cosine of the specified value.
+Returns the hyperbolic cosine of the specified value.
 
 Hsin
 ~~~~
 
-returns the hyperbolic sine of the specified value.
+Returns the hyperbolic sine of the specified value.
 
 Htan
 ~~~~
 
-returns the hyperbolic tangent of the specified value.
+Returns the hyperbolic tangent of the specified value.
+
+IMad
+~~~~
+
+Signed integer multiply & add
+
+IMad(a,b,c) = a * b + c
 
 IMax
 ~~~~
 
-IMax(a,b) returns a if a >= b, else b
+IMax(a,b) returns a if a > b, else b. Optional negate modifier on source operands takes 2's complement before performing operation.
 
 IMin
 ~~~~
 
-IMin(a,b) returns a if a < b, else b
+IMin(a,b) returns a if a < b, else b. Optional negate modifier on source operands takes 2's complement before performing operation.
 
 IMul
 ~~~~
 
-Component-wise multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit (per component) result.
-The low 32 bits (per component) are placed in destLO.  The high 32 bits (per component) are placed in destHI.
+IMul(src0, src1) = destHi, destLo
+multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit result.
+The low 32 bits are placed in destLO. The high 32 bits are placed in destHI.
 
 Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed.
 
 Optional negate modifier on source operands takes 2's complement before performing arithmetic operation.
+
+Ibfe
+~~~~
+
+dest = Ibfe(src0, src1, src2)
+
+Given a range of bits in a number, shift those bits to the LSB and sign extend the MSB of the range.
+
+width : The LSB 5 bits of src0 (0-31).
+
+offset: The LSB 5 bits of src1 (0-31)
+
+.. code:: c
+
+    if( width == 0 )
+    {
+        dest = 0
+    }
+    else if( width + offset < 32 )
+    {
+        shl dest, src2, 32-(width+offset)
+        ishr dest, dest, 32-width
+    }
+    else
+    {
+        ishr dest, src2, offset
+    }
 
 IsFinite
 ~~~~~~~~
@@ -2219,6 +2292,16 @@ IsNaN
 
 Returns true if x is NAN or QNAN, false otherwise.
 
+IsNormal
+~~~~~~~~
+
+Returns IsNormal.
+
+LoadInput
+~~~~~~~~~
+
+Loads the value from shader input
+
 Log
 ~~~
 
@@ -2228,71 +2311,138 @@ Log
 | log(src) |  NaN | NaN        |    -inf |-inf|-inf|    -inf |  F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 
+MinPrecXRegLoad
+~~~~~~~~~~~~~~~
+
+Helper load operation for minprecision
+
+MinPrecXRegStore
+~~~~~~~~~~~~~~~~
+
+Helper store operation for minprecision
+
+Msad
+~~~~
+
+Returns the masked Sum of Absolute Differences.
+
+dest = msad(ref, src, accum)
+
+ref: contains 4 packed 8-bit unsigned integers in 32 bits.
+
+src: contains 4 packed 8-bit unsigned integers in 32 bits.
+
+accum: a 32-bit unsigned integer, providing an existing accumulation.
+
+dest receives the result of the masked SAD operation added to the accumulation value.
+
+.. code:: c
+
+    UINT msad( UINT ref, UINT src, UINT accum )
+    {
+        for (UINT i = 0; i < 4; i++)
+        {
+            BYTE refByte, srcByte, absDiff;
+
+            refByte = (BYTE)(ref >> (i * 8));
+            if (!refByte)
+            {
+                continue;
+            }
+
+            srcByte = (BYTE)(src >> (i * 8));
+            if (refByte >= srcByte)
+            {
+                absDiff = refByte - srcByte;
+            }
+            else
+            {
+                absDiff = srcByte - refByte;
+            }
+
+            // The recommended overflow behavior for MSAD is
+            // to do a 32-bit saturate. This is not
+            // required, however, and wrapping is allowed.
+            // So from an application point of view,
+            // overflow behavior is undefined.
+            if (UINT_MAX - accum < absDiff)
+            {
+                accum = UINT_MAX;
+                break;
+            }
+
+            accum += absDiff;
+        }
+
+        return accum;
+    }
+
 Round_ne
 ~~~~~~~~
 
-Component-wise floating-point round of the values in src,
+Floating-point round of the values in src,
 writing integral floating-point values to dest.
 
 round_ne rounds towards nearest even. For halfway, it rounds away from zero.
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_ne(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_ne(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
 Round_ni
 ~~~~~~~~
 
-Component-wise floating-point round of the values in src,
+Floating-point round of the values in src,
 writing integral floating-point values to dest.
 
 round_ni rounds towards -INF, commonly known as floor().
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_ni(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_ni(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
 Round_pi
 ~~~~~~~~
 
-Component-wise floating-point round of the values in src,
+Floating-point round of the values in src,
 writing integral floating-point values to dest.
 
 round_pi rounds towards +INF, commonly known as ceil().
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_pi(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_pi(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
 Round_z
 ~~~~~~~
 
-Component-wise floating-point round of the values in src,
+Floating-point round of the values in src,
 writing integral floating-point values to dest.
 
 round_z rounds towards zero.
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_z(src) | -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_z(src) | -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
 Rsqrt
 ~~~~~
 
 Maximum relative error is 2^21.
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src       | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
-| rsqrt(src)|  NaN | NaN        |  -inf   |-inf|+inf|  +inf   | +F         | +0   | NaN |
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| rsqrt(src)   | -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
 Saturate
 ~~~~~~~~
@@ -2323,47 +2473,119 @@ Sqrt
 
 Precision is 1 ulp.
 
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| sqrt(src)|  NaN | NaN        |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| sqrt(src)    | NaN  | NaN| -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
+StoreOutput
+~~~~~~~~~~~
+
+Stores the value to shader output
+
+Tan
+~~~
+
+Theta values can be any IEEE 32-bit floating point values.
+
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
+| src      | -inf     | -F             | -denorm | -0 | +0 | +denorm | +F             | +inf | NaN |
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
+| tan(src) | NaN      | [-inf to +inf] | -0      | -0 | +0 | +0      | [-inf to +inf] | NaN  | NaN |
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
+
+TempRegLoad
+~~~~~~~~~~~
+
+Helper load operation
+
+TempRegStore
+~~~~~~~~~~~~
+
+Helper store operation
 
 UAddc
 ~~~~~
 
-Component-wise unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0. \
-The corresponding component in dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
+dest0, dest1 = UAddc(src0, src1)
+
+unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0.
+dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
 
 UDiv
 ~~~~
 
-Component-wise unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+destQUOT, destREM = UDiv(src0, src1);
+
+unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+
 The results of the divides are the 32-bit quotients (placed in destQUOT) and 32-bit remainders (placed in destREM).
-Divide by zero returns 0xffffffff for both quotient and remainder. Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
+
+Divide by zero returns 0xffffffff for both quotient and remainder.
+
+Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
+
+Unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
+dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
+
+UMad
+~~~~
+
+Unsigned integer multiply & add.
+
+Umad(a,b,c) = a * b + c
 
 UMax
 ~~~~
 
-Component-wise unsigned integer maximum. UMax(a,b) = a > b ? a : b
+unsigned integer maximum. UMax(a,b) = a > b ? a : b
 
 UMin
 ~~~~
 
-Component-wise unsigned integer minimum. UMin(a,b) = a < b ? a : b
+unsigned integer minimum. UMin(a,b) = a < b ? a : b
 
 UMul
 ~~~~
 
-Component-wise multiply of 32-bit operands  src0 and src1 (note they are unsigned), producing the correct  full 64-bit (per component) result.
-The low 32 bits (per  component) are placed in destLO. The high 32 bits (per  component) are placed in destHI.
-Either of destHI or destLO may be specified as NULL instead of  specifying a register, in the case high or low 32 bits of the  64-bit result are not needed
+multiply of 32-bit operands src0 and src1 (note they are unsigned), producing the correct full 64-bit result.
+The low 32 bits are placed in destLO. The high 32 bits are placed in destHI.
+Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed
 
 USubb
 ~~~~~
 
-Component-wise unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
-The corresponding component in dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
+dest0, dest1 = USubb(src0, src1)
+
+Ubfe
+~~~~
+
+dest = ubfe(src0, src1, src2)
+
+Given a range of bits in a number, shift those bits to the LSB and set remaining bits to 0.
+
+width : The LSB 5 bits of src0 (0-31).
+
+offset: The LSB 5 bits of src1 (0-31).
+
+Given width, offset:
+
+.. code:: c
+
+    if( width == 0 )
+    {
+        dest = 0
+    }
+    else if( width + offset < 32 )
+    {
+        shl dest, src2, 32-(width+offset)
+        ushr dest, dest, 32-width
+    }
+    else
+    {
+        ushr dest, src2, offset
+    }
 
 .. OPCODES-RST:END
 

--- a/include/dxc/HLSL/DxilConstants.h
+++ b/include/dxc/HLSL/DxilConstants.h
@@ -258,18 +258,18 @@ namespace DXIL {
     FMin = 36, // returns a if a < b, else b
   
     // Binary int with two outputs
-    IMul = 41, // returns the IMul of the input values
-    UDiv = 43, // returns the UDiv of the input values
-    UMul = 42, // returns the UMul of the input values
+    IMul = 41, // multiply of 32-bit operands to produce the correct full 64-bit result.
+    UDiv = 43, // unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+    UMul = 42, // multiply of 32-bit operands to produce the correct full 64-bit result.
   
     // Binary int
-    IMax = 37, // returns the IMax of the input values
-    IMin = 38, // returns the IMin of the input values
-    UMax = 39, // returns the UMax of the input values
-    UMin = 40, // returns the UMin of the input values
+    IMax = 37, // IMax(a,b) returns a if a > b, else b
+    IMin = 38, // IMin(a,b) returns a if a < b, else b
+    UMax = 39, // unsigned integer maximum. UMax(a,b) = a > b ? a : b
+    UMin = 40, // unsigned integer minimum. UMin(a,b) = a < b ? a : b
   
     // Binary uint with carry or borrow
-    UAddc = 44, // returns the UAddc of the input values
+    UAddc = 44, // unsigned add of 32-bit operand with the carry
     USubb = 45, // returns the USubb of the input values
   
     // Bitcasts with different sizes
@@ -294,9 +294,9 @@ namespace DXIL {
     DomainLocation = 105, // DomainLocation
   
     // Dot
-    Dot2 = 54, // two-dimensional vector dot-product
-    Dot3 = 55, // three-dimensional vector dot-product
-    Dot4 = 56, // four-dimensional vector dot-product
+    Dot2 = 54, // Two-dimensional vector dot-product
+    Dot3 = 55, // Three-dimensional vector dot-product
+    Dot4 = 56, // Four-dimensional vector dot-product
   
     // Double precision
     LegacyDoubleToFloat = 132, // legacy fuction to convert double to float
@@ -338,7 +338,7 @@ namespace DXIL {
     SampleIndex = 90, // returns the sample index in a sample-frequency pixel shader
   
     // Quaternary
-    Bfi = 53, // given a bit range from the LSB of a number, places that number of bits in another number at any offset
+    Bfi = 53, // Given a bit range from the LSB of a number, places that number of bits in another number at any offset
   
     // Resources - gather
     TextureGather = 73, // gathers the four texels that would be used in a bi-linear filtering operation
@@ -373,58 +373,58 @@ namespace DXIL {
     Barrier = 80, // inserts a memory barrier in the shader
   
     // Temporary, indexable, input, output registers
-    LoadInput = 4, // loads the value from shader input
-    MinPrecXRegLoad = 2, // helper load operation for minprecision
-    MinPrecXRegStore = 3, // helper store operation for minprecision
-    StoreOutput = 5, // stores the value to shader output
-    TempRegLoad = 0, // helper load operation
-    TempRegStore = 1, // helper store operation
+    LoadInput = 4, // Loads the value from shader input
+    MinPrecXRegLoad = 2, // Helper load operation for minprecision
+    MinPrecXRegStore = 3, // Helper store operation for minprecision
+    StoreOutput = 5, // Stores the value to shader output
+    TempRegLoad = 0, // Helper load operation
+    TempRegStore = 1, // Helper store operation
   
     // Tertiary float
-    FMad = 46, // performs a fused multiply add (FMA) of the form a * b + c
-    Fma = 47, // performs a fused multiply add (FMA) of the form a * b + c
+    FMad = 46, // floating point multiply & add
+    Fma = 47, // fused multiple-add
   
     // Tertiary int
-    IMad = 48, // performs an integral IMad
-    Ibfe = 51, // performs an integral Ibfe
-    Msad = 50, // performs an integral Msad
-    UMad = 49, // performs an integral UMad
-    Ubfe = 52, // performs an integral Ubfe
+    IMad = 48, // Signed integer multiply & add
+    Ibfe = 51, // Integer bitfield extract
+    Msad = 50, // masked Sum of Absolute Differences.
+    UMad = 49, // Unsigned integer multiply & add
+    Ubfe = 52, // Unsigned integer bitfield extract
   
     // Unary float - rounding
-    Round_ne = 26, // returns the Round_ne
-    Round_ni = 27, // returns the Round_ni
-    Round_pi = 28, // returns the Round_pi
-    Round_z = 29, // returns the Round_z
+    Round_ne = 26, // floating-point round to integral float.
+    Round_ni = 27, // floating-point round to integral float.
+    Round_pi = 28, // floating-point round to integral float.
+    Round_z = 29, // floating-point round to integral float.
   
     // Unary float
-    Acos = 15, // returns the Acos
-    Asin = 16, // returns the Asin
-    Atan = 17, // returns the Atan
+    Acos = 15, // Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1.
+    Asin = 16, // Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
+    Atan = 17, // Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
     Cos = 12, // returns cosine(theta) for theta in radians.
-    Exp = 21, // returns the Exp
+    Exp = 21, // returns e^exponent
     FAbs = 6, // returns the absolute value of the input value.
-    Frc = 22, // returns the Frc
-    Hcos = 18, // returns the Hcos
-    Hsin = 19, // returns the Hsin
-    Htan = 20, // returns the Htan
-    IsFinite = 10, // returns the IsFinite
-    IsInf = 9, // returns the IsInf
-    IsNaN = 8, // returns the IsNaN
-    IsNormal = 11, // returns the IsNormal
-    Log = 23, // returns the Log
-    Rsqrt = 25, // returns the Rsqrt
+    Frc = 22, // extract fracitonal component.
+    Hcos = 18, // returns the hyperbolic cosine of the specified value.
+    Hsin = 19, // returns the hyperbolic sine of the specified value.
+    Htan = 20, // returns the hyperbolic tangent of the specified value.
+    IsFinite = 10, // Returns true if x is finite, false otherwise.
+    IsInf = 9, // Returns true if x is +INF or -INF, false otherwise.
+    IsNaN = 8, // Returns true if x is NAN or QNAN, false otherwise.
+    IsNormal = 11, // returns IsNormal
+    Log = 23, // returns natural log.
+    Rsqrt = 25, // returns reciprocal square root (1 / sqrt(src)
     Saturate = 7, // clamps the result of a single or double precision floating point value to [0.0f...1.0f]
-    Sin = 13, // returns the Sin
-    Sqrt = 24, // returns the Sqrt
-    Tan = 14, // returns the Tan
+    Sin = 13, // returns sine(theta) for theta in radians.
+    Sqrt = 24, // returns square root
+    Tan = 14, // returns tan(theta) for theta in radians.
   
     // Unary int
-    Bfrev = 30, // returns the reverse bit pattern of the input value
-    Countbits = 31, // returns the Countbits
-    FirstbitHi = 33, // returns src != 0? (BitWidth-1 - FirstbitHi) : -1
-    FirstbitLo = 32, // returns the FirstbitLo
-    FirstbitSHi = 34, // returns src != 0? (BitWidth-1 - FirstbitSHi) : -1
+    Bfrev = 30, // Reverses the order of the bits.
+    Countbits = 31, // Counts the number of bits in the input integer.
+    FirstbitHi = 33, // Returns the location of the first set bit starting from the highest order bit and working downward.
+    FirstbitLo = 32, // Returns the location of the first set bit starting from the lowest order bit and working upward.
+    FirstbitSHi = 34, // Returns the location of the first set bit from the highest order bit based on the sign.
   
     // Wave
     QuadOp = 123, // returns the result of a quad-level operation

--- a/include/dxc/HLSL/DxilConstants.h
+++ b/include/dxc/HLSL/DxilConstants.h
@@ -402,7 +402,7 @@ namespace DXIL {
     Asin = 16, // Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
     Atan = 17, // Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
     Cos = 12, // returns cosine(theta) for theta in radians.
-    Exp = 21, // returns e^exponent
+    Exp = 21, // returns 2^exponent
     FAbs = 6, // returns the absolute value of the input value.
     Frc = 22, // extract fracitonal component.
     Hcos = 18, // returns the hyperbolic cosine of the specified value.
@@ -412,7 +412,7 @@ namespace DXIL {
     IsInf = 9, // Returns true if x is +INF or -INF, false otherwise.
     IsNaN = 8, // Returns true if x is NAN or QNAN, false otherwise.
     IsNormal = 11, // returns IsNormal
-    Log = 23, // returns natural log.
+    Log = 23, // returns log base 2.
     Rsqrt = 25, // returns reciprocal square root (1 / sqrt(src)
     Saturate = 7, // clamps the result of a single or double precision floating point value to [0.0f...1.0f]
     Sin = 13, // returns sine(theta) for theta in radians.

--- a/include/dxc/HLSL/DxilConstants.h
+++ b/include/dxc/HLSL/DxilConstants.h
@@ -382,7 +382,7 @@ namespace DXIL {
   
     // Tertiary float
     FMad = 46, // floating point multiply & add
-    Fma = 47, // fused multiple-add
+    Fma = 47, // fused multiply-add
   
     // Tertiary int
     IMad = 48, // Signed integer multiply & add

--- a/include/dxc/HLSL/DxilInstructions.h
+++ b/include/dxc/HLSL/DxilInstructions.h
@@ -686,7 +686,7 @@ struct LlvmInst_LandingPad {
   bool isAllowed() const { return false; }
 };
 
-/// This instruction helper load operation
+/// This instruction Helper load operation
 struct DxilInst_TempRegLoad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -704,7 +704,7 @@ struct DxilInst_TempRegLoad {
   llvm::Value *get_index() const { return Instr->getOperand(1); }
 };
 
-/// This instruction helper store operation
+/// This instruction Helper store operation
 struct DxilInst_TempRegStore {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -723,7 +723,7 @@ struct DxilInst_TempRegStore {
   llvm::Value *get_value() const { return Instr->getOperand(2); }
 };
 
-/// This instruction helper load operation for minprecision
+/// This instruction Helper load operation for minprecision
 struct DxilInst_MinPrecXRegLoad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -743,7 +743,7 @@ struct DxilInst_MinPrecXRegLoad {
   llvm::Value *get_component() const { return Instr->getOperand(3); }
 };
 
-/// This instruction helper store operation for minprecision
+/// This instruction Helper store operation for minprecision
 struct DxilInst_MinPrecXRegStore {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -764,7 +764,7 @@ struct DxilInst_MinPrecXRegStore {
   llvm::Value *get_value() const { return Instr->getOperand(4); }
 };
 
-/// This instruction loads the value from shader input
+/// This instruction Loads the value from shader input
 struct DxilInst_LoadInput {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -785,7 +785,7 @@ struct DxilInst_LoadInput {
   llvm::Value *get_gsVertexAxis() const { return Instr->getOperand(4); }
 };
 
-/// This instruction stores the value to shader output
+/// This instruction Stores the value to shader output
 struct DxilInst_StoreOutput {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -842,7 +842,7 @@ struct DxilInst_Saturate {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the IsNaN
+/// This instruction Returns true if x is NAN or QNAN, false otherwise.
 struct DxilInst_IsNaN {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -860,7 +860,7 @@ struct DxilInst_IsNaN {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the IsInf
+/// This instruction Returns true if x is +INF or -INF, false otherwise.
 struct DxilInst_IsInf {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -878,7 +878,7 @@ struct DxilInst_IsInf {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the IsFinite
+/// This instruction Returns true if x is finite, false otherwise.
 struct DxilInst_IsFinite {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -896,7 +896,7 @@ struct DxilInst_IsFinite {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the IsNormal
+/// This instruction returns IsNormal
 struct DxilInst_IsNormal {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -932,7 +932,7 @@ struct DxilInst_Cos {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Sin
+/// This instruction returns sine(theta) for theta in radians.
 struct DxilInst_Sin {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -950,7 +950,7 @@ struct DxilInst_Sin {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Tan
+/// This instruction returns tan(theta) for theta in radians.
 struct DxilInst_Tan {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -968,7 +968,7 @@ struct DxilInst_Tan {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Acos
+/// This instruction Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1.
 struct DxilInst_Acos {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -986,7 +986,7 @@ struct DxilInst_Acos {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Asin
+/// This instruction Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
 struct DxilInst_Asin {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1004,7 +1004,7 @@ struct DxilInst_Asin {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Atan
+/// This instruction Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
 struct DxilInst_Atan {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1022,7 +1022,7 @@ struct DxilInst_Atan {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Hcos
+/// This instruction returns the hyperbolic cosine of the specified value.
 struct DxilInst_Hcos {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1040,7 +1040,7 @@ struct DxilInst_Hcos {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Hsin
+/// This instruction returns the hyperbolic sine of the specified value.
 struct DxilInst_Hsin {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1058,7 +1058,7 @@ struct DxilInst_Hsin {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Htan
+/// This instruction returns the hyperbolic tangent of the specified value.
 struct DxilInst_Htan {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1076,7 +1076,7 @@ struct DxilInst_Htan {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Exp
+/// This instruction returns e^exponent
 struct DxilInst_Exp {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1094,7 +1094,7 @@ struct DxilInst_Exp {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Frc
+/// This instruction extract fracitonal component.
 struct DxilInst_Frc {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1112,7 +1112,7 @@ struct DxilInst_Frc {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Log
+/// This instruction returns natural log.
 struct DxilInst_Log {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1130,7 +1130,7 @@ struct DxilInst_Log {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Sqrt
+/// This instruction returns square root
 struct DxilInst_Sqrt {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1148,7 +1148,7 @@ struct DxilInst_Sqrt {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Rsqrt
+/// This instruction returns reciprocal square root (1 / sqrt(src)
 struct DxilInst_Rsqrt {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1166,7 +1166,7 @@ struct DxilInst_Rsqrt {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Round_ne
+/// This instruction floating-point round to integral float.
 struct DxilInst_Round_ne {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1184,7 +1184,7 @@ struct DxilInst_Round_ne {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Round_ni
+/// This instruction floating-point round to integral float.
 struct DxilInst_Round_ni {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1202,7 +1202,7 @@ struct DxilInst_Round_ni {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Round_pi
+/// This instruction floating-point round to integral float.
 struct DxilInst_Round_pi {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1220,7 +1220,7 @@ struct DxilInst_Round_pi {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Round_z
+/// This instruction floating-point round to integral float.
 struct DxilInst_Round_z {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1238,7 +1238,7 @@ struct DxilInst_Round_z {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the reverse bit pattern of the input value
+/// This instruction Reverses the order of the bits.
 struct DxilInst_Bfrev {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1256,7 +1256,7 @@ struct DxilInst_Bfrev {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the Countbits
+/// This instruction Counts the number of bits in the input integer.
 struct DxilInst_Countbits {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1274,7 +1274,7 @@ struct DxilInst_Countbits {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns the FirstbitLo
+/// This instruction Returns the location of the first set bit starting from the lowest order bit and working upward.
 struct DxilInst_FirstbitLo {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1292,7 +1292,7 @@ struct DxilInst_FirstbitLo {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns src != 0? (BitWidth-1 - FirstbitHi) : -1
+/// This instruction Returns the location of the first set bit starting from the highest order bit and working downward.
 struct DxilInst_FirstbitHi {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1310,7 +1310,7 @@ struct DxilInst_FirstbitHi {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns src != 0? (BitWidth-1 - FirstbitSHi) : -1
+/// This instruction Returns the location of the first set bit from the highest order bit based on the sign.
 struct DxilInst_FirstbitSHi {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1366,7 +1366,7 @@ struct DxilInst_FMin {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the IMax of the input values
+/// This instruction IMax(a,b) returns a if a > b, else b
 struct DxilInst_IMax {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1385,7 +1385,7 @@ struct DxilInst_IMax {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the IMin of the input values
+/// This instruction IMin(a,b) returns a if a < b, else b
 struct DxilInst_IMin {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1404,7 +1404,7 @@ struct DxilInst_IMin {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the UMax of the input values
+/// This instruction unsigned integer maximum. UMax(a,b) = a > b ? a : b
 struct DxilInst_UMax {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1423,7 +1423,7 @@ struct DxilInst_UMax {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the UMin of the input values
+/// This instruction unsigned integer minimum. UMin(a,b) = a < b ? a : b
 struct DxilInst_UMin {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1442,7 +1442,7 @@ struct DxilInst_UMin {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the IMul of the input values
+/// This instruction multiply of 32-bit operands to produce the correct full 64-bit result.
 struct DxilInst_IMul {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1461,7 +1461,7 @@ struct DxilInst_IMul {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the UMul of the input values
+/// This instruction multiply of 32-bit operands to produce the correct full 64-bit result.
 struct DxilInst_UMul {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1480,7 +1480,7 @@ struct DxilInst_UMul {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the UDiv of the input values
+/// This instruction unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
 struct DxilInst_UDiv {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1499,7 +1499,7 @@ struct DxilInst_UDiv {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction returns the UAddc of the input values
+/// This instruction unsigned add of 32-bit operand with the carry
 struct DxilInst_UAddc {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1537,7 +1537,7 @@ struct DxilInst_USubb {
   llvm::Value *get_b() const { return Instr->getOperand(2); }
 };
 
-/// This instruction performs a fused multiply add (FMA) of the form a * b + c
+/// This instruction floating point multiply & add
 struct DxilInst_FMad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1557,7 +1557,7 @@ struct DxilInst_FMad {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs a fused multiply add (FMA) of the form a * b + c
+/// This instruction fused multiple-add
 struct DxilInst_Fma {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1577,7 +1577,7 @@ struct DxilInst_Fma {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs an integral IMad
+/// This instruction Signed integer multiply & add
 struct DxilInst_IMad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1597,7 +1597,7 @@ struct DxilInst_IMad {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs an integral UMad
+/// This instruction Unsigned integer multiply & add
 struct DxilInst_UMad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1617,7 +1617,7 @@ struct DxilInst_UMad {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs an integral Msad
+/// This instruction masked Sum of Absolute Differences.
 struct DxilInst_Msad {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1637,7 +1637,7 @@ struct DxilInst_Msad {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs an integral Ibfe
+/// This instruction Integer bitfield extract
 struct DxilInst_Ibfe {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1657,7 +1657,7 @@ struct DxilInst_Ibfe {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction performs an integral Ubfe
+/// This instruction Unsigned integer bitfield extract
 struct DxilInst_Ubfe {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1677,7 +1677,7 @@ struct DxilInst_Ubfe {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction given a bit range from the LSB of a number, places that number of bits in another number at any offset
+/// This instruction Given a bit range from the LSB of a number, places that number of bits in another number at any offset
 struct DxilInst_Bfi {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1698,7 +1698,7 @@ struct DxilInst_Bfi {
   llvm::Value *get_replaceCount() const { return Instr->getOperand(4); }
 };
 
-/// This instruction two-dimensional vector dot-product
+/// This instruction Two-dimensional vector dot-product
 struct DxilInst_Dot2 {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1719,7 +1719,7 @@ struct DxilInst_Dot2 {
   llvm::Value *get_by() const { return Instr->getOperand(4); }
 };
 
-/// This instruction three-dimensional vector dot-product
+/// This instruction Three-dimensional vector dot-product
 struct DxilInst_Dot3 {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1742,7 +1742,7 @@ struct DxilInst_Dot3 {
   llvm::Value *get_bz() const { return Instr->getOperand(6); }
 };
 
-/// This instruction four-dimensional vector dot-product
+/// This instruction Four-dimensional vector dot-product
 struct DxilInst_Dot4 {
   const llvm::Instruction *Instr;
   // Construction and identification

--- a/include/dxc/HLSL/DxilInstructions.h
+++ b/include/dxc/HLSL/DxilInstructions.h
@@ -1557,7 +1557,7 @@ struct DxilInst_FMad {
   llvm::Value *get_c() const { return Instr->getOperand(3); }
 };
 
-/// This instruction fused multiple-add
+/// This instruction fused multiply-add
 struct DxilInst_Fma {
   const llvm::Instruction *Instr;
   // Construction and identification

--- a/include/dxc/HLSL/DxilInstructions.h
+++ b/include/dxc/HLSL/DxilInstructions.h
@@ -1076,7 +1076,7 @@ struct DxilInst_Htan {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns e^exponent
+/// This instruction returns 2^exponent
 struct DxilInst_Exp {
   const llvm::Instruction *Instr;
   // Construction and identification
@@ -1112,7 +1112,7 @@ struct DxilInst_Frc {
   llvm::Value *get_value() const { return Instr->getOperand(1); }
 };
 
-/// This instruction returns natural log.
+/// This instruction returns log base 2.
 struct DxilInst_Log {
   const llvm::Instruction *Instr;
   // Construction and identification

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -19,31 +19,6 @@
     ]]>
     </Shader>
   </ShaderOp>
-  <ShaderOp Name="MinMax" CS="CS" DispatchX="10" DispatchY="10">
-    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
-    <Resource Name="SPrimitives" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
-    <RootValues>
-      <RootValue Index="0" ResName="SPrimitives" />
-    </RootValues>
-    <Shader Name="CS" Target="cs_6_0">
-      <![CDATA[
-      struct SMinMaxElem {
-        float f_fa;
-        float f_fb;
-        float f_fmin_o;
-        float f_fmax_o;
-      };
-    RWStructuredBuffer<SMinMaxElem> g_buf : register(u0);
-    [numthreads(10,10,1)]
-    void main(uint GI : SV_GroupIndex) {
-      SMinMaxElem l = g_buf[GI];
-      l.f_fmin_o = min(l.f_fa, l.f_fb);
-      l.f_fmax_o = max(l.f_fa, l.f_fb);
-      g_buf[GI] = l;
-    };
-    ]]>
-    </Shader>
-  </ShaderOp>
   <ShaderOp Name="OOB" PS="PS" VS="VS">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), CBV(b0), DescriptorTable(SRV(t0,numDescriptors=2))</RootSignature>
     <Resource Name="CB0" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" TransitionTo="VERTEX_AND_CONSTANT_BUFFER">
@@ -264,6 +239,70 @@
       <![CDATA[
     void main(uint GI : SV_GroupIndex) {};
     ]]>
+    </Shader>
+  </ShaderOp>
+
+  <ShaderOp Name="TertiaryFPOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="STertiaryFPOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="STertiaryFPOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+
+  <ShaderOp Name="TertiaryIntOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="STertiaryIntOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="STertiaryIntOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  <ShaderOp Name="TertiaryUintOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="STertiaryUintOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="STertiaryUintOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+
+  <ShaderOp Name="DotOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SDotOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SDotOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+      void main(uint GI : SV_GroupIndex) {};
+      ]]>
+    </Shader>
+  </ShaderOp>
+
+  <ShaderOp Name="Msad4" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SMsad4" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SMsad4"/>
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+      void main(uint GI : SV_GroupIndex) {};
+      ]]>
     </Shader>
   </ShaderOp>
 

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -194,31 +194,79 @@
       }]]>
     </Shader>
   </ShaderOp>
-  <ShaderOp Name="SinCos" CS="CS" DispatchX="8" DispatchY="8">
+  <ShaderOp Name="UnaryFPOp" CS="CS" DispatchX="8" DispatchY="8">
     <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
-    <Resource Name="SPrimitives" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="SUnaryFPOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
     <RootValues>
-      <RootValue Index="0" ResName="SPrimitives" />
+      <RootValue Index="0" ResName="SUnaryFPOp" />
     </RootValues>
     <Shader Name="CS" Target="cs_6_0">
       <![CDATA[
-      struct SPrimitives {
-        float f_float;
-        float f_float2;
-        float f_float_o;
-        float f_float2_o;
-      };
-    RWStructuredBuffer<SPrimitives> g_buf : register(u0);
-    [numthreads(8,8,1)]
-    void main(uint GI : SV_GroupIndex) {
-      SPrimitives l = g_buf[GI];
-      l.f_float_o = sin(l.f_float);
-      l.f_float2_o = cos(l.f_float2);
-      g_buf[GI] = l;
-    };
+    void main(uint GI : SV_GroupIndex) {};
     ]]>
     </Shader>
   </ShaderOp>
+  <ShaderOp Name="BinaryFPOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SBinaryFPOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SBinaryFPOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  <ShaderOp Name="UnaryIntOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SUnaryIntOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SUnaryIntOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  <ShaderOp Name="UnaryUintOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SUnaryUintOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SUnaryUintOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  <ShaderOp Name="BinaryIntOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SBinaryIntOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SBinaryIntOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  <ShaderOp Name="BinaryUintOp" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SBinaryUintOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SBinaryUintOp" />
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+
   <ShaderOp Name="Triangle" PS="PS" VS="VS">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)</RootSignature>
 

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -35,6 +35,7 @@ add_clang_library(clang-hlsl-tests SHARED
   SystemValueTest.cpp
   ValidationTest.cpp
   VerifierTest.cpp
+  clang-hlsl-tests.rc
   )
 set_target_properties(clang-hlsl-tests PROPERTIES FOLDER "Clang tests")
 

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -80,6 +80,14 @@ inline void LogCommentFmt(_In_z_ _Printf_format_string_ const wchar_t *fmt, ...)
   WEX::Logging::Log::Comment(buf.data());
 }
 
+inline void LogErrorFmt(_In_z_ _Printf_format_string_ const wchar_t *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    std::wstring buf(vFormatToWString(fmt, args));
+    va_end(args);
+    WEX::Logging::Log::Error(buf.data());
+}
+
 inline std::wstring GetPathToHlslDataFile(const wchar_t* relative) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   WEX::Common::String HlslDataDirValue;
@@ -171,6 +179,30 @@ inline bool GetTestParamUseWARP(bool defaultVal) {
   return false;
 }
 
+}
+
+inline bool CompareFloatULP(const float &fsrc, const float &fref, int ULPTolerance) {
+    if (isnan(fsrc)) {
+        return isnan(fref);
+    }
+    if (fsrc == fref) {
+        return true;
+    }
+    int diff = *((DWORD *)&fsrc) - *((DWORD *)&fref);
+    unsigned int uDiff = diff < 0 ? -diff : diff;
+    return uDiff <= (unsigned int)ULPTolerance;
+}
+
+inline bool CompareFloatEpsilon(const float &fsrc, const float &fref, float epsilon) {
+    if (isnan(fsrc)) {
+        return isnan(fref);
+    }
+    return fsrc == fref || fabsf(fsrc - fref) < epsilon;
+}
+
+// Compare using relative error (relative error < 2^{nRelativeExp})
+inline bool CompareFloatRelativeEpsilon(const float &fsrc, const float &fref, int nRelativeExp) {
+    return CompareFloatULP(fsrc, fref, 23 - nRelativeExp);
 }
 
 #define SIMPLE_IUNKNOWN_IMPL1(_IFACE_) \

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -1,0 +1,1902 @@
+<?xml version="1.0"?>
+<Data>
+    <Table Id="UnaryFloatOpTable">
+      <ParameterTypes>
+        <ParameterType Name="Validation.Type">String</ParameterType>
+        <ParameterType Name="Validation.Tolerance">double</ParameterType>
+        <ParameterType Name="Validation.Input" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="sin">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-314.16</Value>
+          <Value>314.16</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>NaN</Value>
+          <Value>-0.0007346401</Value>
+          <Value>0.0007346401</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            [RootSignature("RootFlags(0), UAV(u0)")]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = sin(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="cos">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-314.16</Value>
+          <Value>314.16</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>NaN</Value>
+          <Value>0.99999973015</Value>
+          <Value>0.99999973015</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = cos(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="tan">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-314.16</Value>
+          <Value>314.16</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-0.0</Value>
+          <Value>-0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>NaN</Value>
+          <Value>-0.000735</Value>
+          <Value>0.000735</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = tan(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="Hcos">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>Inf</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>1.0</Value>
+          <Value>Inf</Value>
+          <Value>1.543081</Value>
+          <Value>1.543081</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = cosh(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="Hsin">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>Inf</Value>
+          <Value>1.175201</Value>
+          <Value>-1.175201</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = sinh(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="Htan">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-0.0</Value>
+          <Value>-0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>NaN</Value>
+          <Value>0.761594</Value>
+          <Value>-0.761594</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = tanh(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="acos">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+          <Value>1.5</Value>
+          <Value>-1.5</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>1.570796</Value>
+          <Value>1.570796</Value>
+          <Value>1.570796</Value>
+          <Value>1.570796</Value>
+          <Value>NaN</Value>
+          <Value>0</Value>
+          <Value>3.1415926</Value>
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = acos(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="asin">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+          <Value>1.5</Value>
+          <Value>-1.5</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>NaN</Value>
+          <Value>1.570796</Value>
+          <Value>-1.570796</Value>
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = asin(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="atan">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>-1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>0.785410</Value>
+          <Value>-1.570796</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>0.0</Value>
+          <Value>1.570796</Value>
+          <Value>0.785398163</Value>
+          <Value>-0.785398163</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = atan(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="exp">
+        <Parameter Name="Validation.Type">Relative</Parameter>
+        <Parameter Name="Validation.Tolerance">21</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>10</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>Inf</Value>
+          <Value>0.367879441</Value>
+          <Value>22026.46579</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = exp(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="frc">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>2.718280</Value>
+          <Value>1000.599976</Value>
+          <Value>-7.389</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>NaN</Value>
+          <Value>0</Value>
+          <Value>0.718280</Value>
+          <Value>0.599976</Value>
+          <Value>0.611</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = frac(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="log">
+        <Parameter Name="Validation.Type">Relative</Parameter>
+        <Parameter Name="Validation.Tolerance">21</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>2.718281828</Value>
+          <Value>7.389056</Value>
+          <Value>100</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-Inf</Value>
+          <Value>-Inf</Value>
+          <Value>-Inf</Value>
+          <Value>Inf</Value>
+          <Value>NaN</Value>
+          <Value>1.0</Value>
+          <Value>1.99999998</Value>
+          <Value>4.6051701</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = log(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+      <Row Name="sqrt">
+        <Parameter Name="Validation.Type">ulp</Parameter>
+        <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>2</Value>
+          <Value>16.0</Value>
+          <Value>256.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>Inf</Value>
+          <Value>NaN</Value>
+          <Value>1.41421356237</Value>
+          <Value>4.0</Value>
+          <Value>16.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = sqrt(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="rsqrt">
+        <Parameter Name="Validation.Type">ulp</Parameter>
+        <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>16.0</Value>
+          <Value>256.0</Value>
+          <Value>65536.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-Inf</Value>
+          <Value>Inf</Value>
+          <Value>Inf</Value>
+          <Value>0</Value>
+          <Value>NaN</Value>
+          <Value>0.25</Value>
+          <Value>0.0625</Value>
+          <Value>0.00390625</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = rsqrt(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+       <Row Name="rsqrt">
+        <Parameter Name="Validation.Type">ulp</Parameter>
+        <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>-1</Value>
+          <Value>16.0</Value>
+          <Value>256.0</Value>
+          <Value>65536.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-Inf</Value>
+          <Value>Inf</Value>
+          <Value>Inf</Value>
+          <Value>0</Value>
+          <Value>NaN</Value>
+          <Value>0.25</Value>
+          <Value>0.0625</Value>
+          <Value>0.00390625</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = rsqrt(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="round_ne">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.4</Value>
+          <Value>10.5</Value>
+          <Value>10.6</Value>
+          <Value>11.5</Value>
+          <Value>-10.0</Value>
+          <Value>-10.4</Value>
+          <Value>-10.5</Value>
+          <Value>-10.6</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>11.0</Value>
+          <Value>12.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-11.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = round(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="round_ni">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.4</Value>
+          <Value>10.5</Value>
+          <Value>10.6</Value>
+          <Value>-10.0</Value>
+          <Value>-10.4</Value>
+          <Value>-10.5</Value>
+          <Value>-10.6</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-11.0</Value>
+          <Value>-11.0</Value>
+          <Value>-11.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = floor(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+       </Row>
+
+       <Row Name="round_pi">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.4</Value>
+          <Value>10.5</Value>
+          <Value>10.6</Value>
+          <Value>-10.0</Value>
+          <Value>-10.4</Value>
+          <Value>-10.5</Value>
+          <Value>-10.6</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>11.0</Value>
+          <Value>11.0</Value>
+          <Value>11.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = ceil(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="round_z">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.4</Value>
+          <Value>10.5</Value>
+          <Value>10.6</Value>
+          <Value>-10.0</Value>
+          <Value>-10.4</Value>
+          <Value>-10.5</Value>
+          <Value>-10.6</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-0</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>Inf</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+          <Value>-10.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = trunc(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="IsNaN">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1.0</Value>
+          <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>1</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isnan(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+      <Row Name="IsInf">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1.0</Value>
+          <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isinf(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+      <Row Name="Isfinite">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1.0</Value>
+          <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>1</Value>
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+          <Value>0</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                if (isfinite(l.input))
+                    l.output = 1;
+                else
+                    l.output = 0;
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+
+      <Row Name="FAbs">
+        <Parameter Name="Validation.Type">Epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+          <Value>NaN</Value>
+          <Value>-Inf</Value>
+          <Value>-denorm</Value>
+          <Value>-0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1.0</Value>
+          <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+          <Value>NaN</Value>
+          <Value>Inf</Value>
+          <Value>denorm</Value>
+          <Value>0</Value>
+          <Value>0</Value>
+          <Value>denorm</Value>
+          <Value>Inf</Value>
+          <Value>1</Value>
+          <Value>1</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text"><![CDATA[
+            struct SUnaryFPOp {
+                float input;
+                float output;
+            };
+            RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryFPOp l = g_buf[GI];
+                l.output = abs(l.input);
+                g_buf[GI] = l;
+            }
+           ]]></Parameter>
+      </Row>
+    </Table>
+    <Table Id="BinaryFloatOpTable">
+      <ParameterTypes>
+        <ParameterType Name="Validation.Type">String</ParameterType>
+        <ParameterType Name="Validation.Tolerance">double</ParameterType>
+        <ParameterType Name="Validation.Input1" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.Input2" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.Expected1" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.Expected2" Array="true">String</ParameterType>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="MinMax">
+        <Parameter Name="Validation.Type">epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>NaN</Value>
+            <Value>NaN</Value>
+            <Value>NaN</Value>
+            <Value>NaN</Value>
+            <Value>1.0</Value>
+            <Value>1.0</Value>
+            <Value>-1.0</Value>
+            <Value>-1.0</Value>
+            <Value>1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>inf</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>-inf</Value>
+            <Value>1.0</Value>
+            <Value>-1.0</Value>
+            <Value>-1.0</Value>
+            <Value>-1.0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected2">
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>inf</Value>
+            <Value>-inf</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>NaN</Value>
+            <Value>1.0</Value>
+            <Value>inf</Value>
+            <Value>1.0</Value>
+            <Value>-1.0</Value>
+            <Value>1.0</Value>
+        </Parameter>
+        <Parameter Name="ShaderOp.Name">MinMax</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+            <![CDATA[
+            struct SBinaryFPOp {
+                float input1;
+                float input2;
+                float output1;
+                float output2;
+            };
+            RWStructuredBuffer<SBinaryFPOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryFPOp l = g_buf[GI];
+                l.output1 = min(l.input1, l.input2);
+                l.output2 = max(l.input1, l.input2);
+                g_buf[GI] = l;
+            };
+            ]]>
+        </Parameter>
+      </Row>
+
+    </Table>
+
+    <Table Id="UnaryIntOpTable">
+      <ParameterTypes>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+        <ParameterType Name="Validation.Input" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Expected" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Tolerance">int</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="Bfrev">
+        <Parameter Name="ShaderOp.Name">bfrev</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SUnaryIntOp {
+                int input;
+                int output;
+            };
+            RWStructuredBuffer<SUnaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryIntOp l = g_buf[GI];
+                l.output = reversebits(l.input);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+            <Value>-2147483648</Value>
+            <Value>-65536</Value>
+            <Value>-8</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>8</Value>
+            <Value>65536</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+            <Value>1</Value>
+            <Value>65535</Value>
+            <Value>536870911</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>-2147483648</Value>
+            <Value>268435456</Value>
+            <Value>32768</Value>
+            <Value>-2</Value>
+        </Parameter>
+      </Row>
+
+      <Row Name="FirstbitHi">
+        <Parameter Name="ShaderOp.Name">Firstbithi</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SUnaryIntOp {
+                int input;
+                int output;
+            };
+            RWStructuredBuffer<SUnaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryIntOp l = g_buf[GI];
+                l.output = firstbithigh(l.input);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+            <Value>-2147483648</Value>
+            <Value>-65536</Value>
+            <Value>-8</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>8</Value>
+            <Value>65536</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+            <Value>30</Value>
+            <Value>15</Value>
+            <Value>2</Value>
+            <Value>32</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>3</Value>
+            <Value>16</Value>
+            <Value>30</Value>
+        </Parameter>
+      </Row>
+
+      <Row Name="FirstBitLo">
+        <Parameter Name="ShaderOp.Name">Firstbitlo</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SUnaryIntOp {
+                int input;
+                int output;
+            };
+            RWStructuredBuffer<SUnaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryIntOp l = g_buf[GI];
+                l.output = firstbitlow(l.input);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+            <Value>-2147483648</Value>
+            <Value>-65536</Value>
+            <Value>-8</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>8</Value>
+            <Value>65536</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+            <Value>31</Value>
+            <Value>16</Value>
+            <Value>3</Value>
+            <Value>0</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>3</Value>
+            <Value>16</Value>
+            <Value>0</Value>
+        </Parameter>
+      </Row>
+
+      <Row Name="Countbits">
+        <Parameter Name="ShaderOp.Name">Countbits</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SUnaryIntOp {
+                int input;
+                int output;
+            };
+            RWStructuredBuffer<SUnaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryIntOp l = g_buf[GI];
+                l.output = countbits(l.input);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+            <Value>-2147483648</Value>
+            <Value>-65536</Value>
+            <Value>-8</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>8</Value>
+            <Value>65536</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+            <Value>1</Value>
+            <Value>16</Value>
+            <Value>29</Value>
+            <Value>32</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>1</Value>
+            <Value>1</Value>
+            <Value>31</Value>
+        </Parameter>
+      </Row>
+    </Table>
+
+    <Table Id="UnaryUintOpTable">
+      <ParameterTypes>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+        <ParameterType Name="Validation.Input" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Expected" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Tolerance">int</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="FirstbitHi">
+        <Parameter Name="ShaderOp.Name">Firstbithi</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SUnaryUintOp {
+                uint input;
+                uint output;
+            };
+            RWStructuredBuffer<SUnaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SUnaryUintOp l = g_buf[GI];
+                l.output = firstbithigh(l.input);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input">
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>8</Value>
+            <Value>65536</Value>
+            <Value>2147483647</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected">
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>3</Value>
+            <Value>16</Value>
+            <Value>30</Value>
+            <Value>31</Value>
+        </Parameter>
+      </Row>
+    </Table>
+
+    <Table Id="BinaryIntOpTable">
+      <ParameterTypes>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+        <ParameterType Name="Validation.NumExpected">int</ParameterType>
+        <ParameterType Name="Validation.Input1" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Input2" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Expected1" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Expected2" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Tolerance">int</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="IMax">
+        <Parameter Name="ShaderOp.Name">IMax</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryIntOp {
+                int input1;
+                int input2;
+                int output1; 
+                int output2;
+            };
+            RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryIntOp l = g_buf[GI];
+                l.output1 = max(l.input1, l.input2);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>-2147483648</Value>
+            <Value>-10</Value>
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>2147483647</Value> 
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>-10</Value>
+            <Value>10</Value>
+            <Value>10</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>10</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+      <Row Name="IMin">
+        <Parameter Name="ShaderOp.Name">IMin</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryIntOp {
+                int input1;
+                int input2;
+                int output1; 
+                int output2;
+            };
+            RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryIntOp l = g_buf[GI];
+                l.output1 = min(l.input1, l.input2);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>-2147483648</Value>
+            <Value>-10</Value>
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>2147483647</Value> 
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>-10</Value>
+            <Value>10</Value>
+            <Value>10</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>-2147483648</Value>
+            <Value>-10</Value>
+            <Value>-10</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+      <Row Name="IMul">
+        <Parameter Name="ShaderOp.Name">Mul</Parameter>
+        <Parameter Name="ShaderOp.Description">integer multiplication. Note that this calls llvm "mul" operation and not IMul</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryIntOp {
+                int input1;
+                int input2;
+                int output1; 
+                int output2;
+            };
+            RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryIntOp l = g_buf[GI];
+                l.output1 = l.input1 * l.input2;
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>-2147483648</Value>
+            <Value>-10</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>10</Value>
+            <Value>10000</Value>
+            <Value>2147483647</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>-10</Value>
+            <Value>-10</Value>
+            <Value>10</Value>
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>4</Value>
+            <Value>10001</Value>
+            <Value>0</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0</Value>
+            <Value>100</Value>
+            <Value>-10</Value>
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>40</Value>
+            <Value>100010000</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+    </Table>
+
+    <Table Id="BinaryUintOpTable">
+      <ParameterTypes>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+        <ParameterType Name="Validation.NumExpected">int</ParameterType>
+        <ParameterType Name="Validation.Input1" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Input2" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Expected1" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Expected2" Array="true">unsigned int</ParameterType>
+        <ParameterType Name="Validation.Tolerance">int</ParameterType>
+      </ParameterTypes>
+      <Row Name="UMax">
+        <Parameter Name="ShaderOp.Name">UMax</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryUintOp {
+                uint input1;
+                uint input2;
+                uint output1; 
+                uint output2;
+            };
+            RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryUintOp l = g_buf[GI];
+                l.output1 = max(l.input1, l.input2);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>10000</Value>
+            <Value>2147483647</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>4</Value>
+            <Value>10001</Value>
+            <Value>0</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>10</Value>
+            <Value>10001</Value>
+            <Value>2147483647</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+      <Row Name="UMin">
+        <Parameter Name="ShaderOp.Name">UMin</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryUintOp {
+                uint input1;
+                uint input2;
+                uint output1; 
+                uint output2;
+            };
+            RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryUintOp l = g_buf[GI];
+                l.output1 = min(l.input1, l.input2);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>10</Value>
+            <Value>10000</Value>
+            <Value>2147483647</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>4</Value>
+            <Value>10001</Value>
+            <Value>0</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>4</Value>
+            <Value>10000</Value>
+            <Value>0</Value>
+            <Value>4294967295</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+
+      <Row Name="UMul">
+        <Parameter Name="ShaderOp.Name">Mul</Parameter>
+        <Parameter Name="ShaderOp.Description">integer multiplication. Note that this calls llvm "mul" operation and not IMul</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryUintOp {
+                uint input1;
+                uint input2;
+                uint output1; 
+                uint output2;
+            };
+            RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryUintOp l = g_buf[GI];
+                l.output1 = l.input1 * l.input2;
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>10</Value>
+            <Value>10000</Value>
+            <Value>2147483647</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>4</Value>
+            <Value>10001</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>40</Value>
+            <Value>100010000</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+
+      <Row Name="UDiv">
+        <Parameter Name="ShaderOp.Name">UDiv</Parameter>
+        <Parameter Name="ShaderOp.Description">integer division. Note that this calls llvm "div" and "rem" operations and not UDiv</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryUintOp {
+                uint input1;
+                uint input2;
+                uint output1; 
+                uint output2;
+            };
+            RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryUintOp l = g_buf[GI];
+                l.output1 = l.input1 / l.input2;
+                l.output2 = l.input1 % l.input2;
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Operation.Unsigned">true</Parameter>
+        <Parameter Name="Validation.NumExpected">2</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>1</Value>
+            <Value>1</Value>
+            <Value>10</Value>
+            <Value>10000</Value>
+            <Value>2147483647</Value>
+            <Value>2147483647</Value>
+            <Value>0xffffffff</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>4</Value>
+            <Value>10001</Value>
+            <Value>0</Value>
+            <Value>2147483647</Value>
+            <Value>1</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>0xffffffff</Value>
+            <Value>0</Value>
+            <Value>2</Value>
+            <Value>0</Value>
+            <Value>0xffffffff</Value>
+            <Value>1</Value>
+            <Value>0xffffffff</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected2">
+            <Value>0xffffffff</Value>
+            <Value>1</Value>
+            <Value>2</Value>
+            <Value>10000</Value>
+            <Value>0xffffffff</Value>
+            <Value>0</Value>
+            <Value>0</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+
+       <Row Name="UAddc">
+        <Parameter Name="ShaderOp.Name">UAddc</Parameter>
+        <Parameter Name="ShaderOp.Description">UAddc is called through AddUint64 intrinsic</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct SBinaryUintOp {
+                uint input1;
+                uint input2;
+                uint output1; 
+                uint output2;
+            };
+            RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                SBinaryUintOp l = g_buf[GI];
+                uint2 x = uint2(l.input1, l.input2);
+                uint2 y = AddUint64(x, x);
+                l.output1 = y.x;
+                l.output2 = y.y;
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Operation.Unsigned">true</Parameter>
+        <Parameter Name="Validation.NumExpected">2</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>1</Value>
+            <Value>1</Value>
+            <Value>10000</Value>
+            <Value>0x80000000</Value>
+            <Value>0x7fffffff</Value>
+            <Value>0xffffffff</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>0</Value>
+            <Value>256</Value>
+            <Value>10001</Value>
+            <Value>1</Value>
+            <Value>0x7fffffff</Value>
+            <Value>0x7fffffff</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected1">
+            <Value>2</Value>
+            <Value>2</Value>
+            <Value>20000</Value>
+            <Value>0</Value>
+            <Value>0xfffffffe</Value>
+            <Value>0xfffffffe</Value>
+        </Parameter>
+        <Parameter Name="Validation.Expected2">
+            <Value>0</Value>
+            <Value>512</Value>
+            <Value>20002</Value>
+            <Value>3</Value>
+            <Value>0xfffffffe</Value>
+            <Value>0xffffffff</Value>
+        </Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+      </Row>
+    </Table>
+  </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -6,6 +6,7 @@
         <ParameterType Name="Validation.Tolerance">double</ParameterType>
         <ParameterType Name="Validation.Input" Array="true">String</ParameterType>
         <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
         <ParameterType Name="ShaderOp.Name">String</ParameterType>
         <ParameterType Name="ShaderOp.Target">String</ParameterType>
         <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
@@ -15,6 +16,7 @@
       <Row Name="sin">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -59,6 +61,7 @@
       <Row Name="cos">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -102,6 +105,7 @@
       <Row Name="tan">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -145,6 +149,7 @@
       <Row Name="Hcos">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -188,6 +193,7 @@
       <Row Name="Hsin">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -231,6 +237,7 @@
       <Row Name="Htan">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -274,6 +281,7 @@
       <Row Name="acos">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -321,6 +329,7 @@
       <Row Name="asin">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -368,6 +377,7 @@
       <Row Name="atan">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -411,6 +421,7 @@
       <Row Name="exp">
         <Parameter Name="Validation.Type">Relative</Parameter>
         <Parameter Name="Validation.Tolerance">21</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -454,6 +465,7 @@
       <Row Name="frc">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -501,6 +513,7 @@
       <Row Name="log">
         <Parameter Name="Validation.Type">Relative</Parameter>
         <Parameter Name="Validation.Tolerance">21</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -547,6 +560,7 @@
       <Row Name="sqrt">
         <Parameter Name="Validation.Type">ulp</Parameter>
         <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -594,6 +608,7 @@
       <Row Name="rsqrt">
         <Parameter Name="Validation.Type">ulp</Parameter>
         <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -641,6 +656,7 @@
        <Row Name="rsqrt">
         <Parameter Name="Validation.Type">ulp</Parameter>
         <Parameter Name="Validation.Tolerance">1</Parameter>
+        <Parameter Name="Validation.NumInput">11</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -688,6 +704,7 @@
       <Row Name="round_ne">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">16</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -745,6 +762,7 @@
       <Row Name="round_ni">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">15</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -800,6 +818,7 @@
        <Row Name="round_pi">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">15</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -855,6 +874,7 @@
       <Row Name="round_z">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">15</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -910,6 +930,7 @@
       <Row Name="IsNaN">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -955,6 +976,7 @@
       <Row Name="IsInf">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -1000,6 +1022,7 @@
       <Row Name="Isfinite">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -1046,6 +1069,7 @@
       <Row Name="FAbs">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
           <Value>-Inf</Value>
@@ -1094,6 +1118,7 @@
         <ParameterType Name="Validation.Input2" Array="true">String</ParameterType>
         <ParameterType Name="Validation.Expected1" Array="true">String</ParameterType>
         <ParameterType Name="Validation.Expected2" Array="true">String</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
         <ParameterType Name="ShaderOp.Name">String</ParameterType>
         <ParameterType Name="ShaderOp.Target">String</ParameterType>
         <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
@@ -1103,6 +1128,7 @@
       <Row Name="MinMax">
         <Parameter Name="Validation.Type">epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">17</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>-inf</Value>
             <Value>-inf</Value>
@@ -1202,7 +1228,107 @@
         </Parameter>
       </Row>
 
-    </Table>
+      </Table>
+
+      <Table Id="TertiaryFloatOpTable">
+        <ParameterTypes>
+            <ParameterType Name="Description">String</ParameterType>
+            <ParameterType Name="ShaderOp.Name">String</ParameterType>
+            <ParameterType Name="ShaderOp.Target">String</ParameterType>
+            <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Type">String</ParameterType>
+            <ParameterType Name="Validation.Tolerance">int</ParameterType>
+            <ParameterType Name="Validation.Input1" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Input2" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Input3" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
+        </ParameterTypes>
+
+        <Row Name="FMad">
+            <Parameter Name="ShaderOp.Name">FMad</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+            <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+            <Parameter Name="ShaderOp.Text">
+            <![CDATA[
+                struct STertiaryFloatOp {
+                    float input1;
+                    float input2;
+                    float input3;
+                    float output;
+                };
+                RWStructuredBuffer<STertiaryFloatOp> g_buf : register(u0);
+                [numthreads(8,8,1)]
+                void main(uint GI : SV_GroupIndex) {
+                    STertiaryFloatOp l = g_buf[GI];
+                    l.output = mad(l.input1, l.input2, l.input3);
+                    g_buf[GI] = l;
+                };
+            ]]>
+            </Parameter>
+            <Parameter Name="Validation.Type">epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0.0008</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1.5</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input2">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input3">
+                <Value>NaN</Value>
+                <Value>-Inf</Value>
+                <Value>-denorm</Value>
+                <Value>-0</Value>
+                <Value>0</Value>
+                <Value>denorm</Value>
+                <Value>Inf</Value>
+                <Value>1.0</Value>
+                <Value>-1.0</Value>
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>-5.5</Value>
+            </Parameter>
+
+            <Parameter Name="Validation.Expected">
+                <Value>NaN</Value>
+                <Value>NaN</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>Inf</Value>
+                <Value>2</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>9.5</Value>
+            </Parameter>
+            <Parameter Name="Validation.NumInput">12</Parameter>
+      </Row>
+      </Table>
 
     <Table Id="UnaryIntOpTable">
       <ParameterTypes>
@@ -1213,6 +1339,7 @@
         <ParameterType Name="Validation.Input" Array="true">int</ParameterType>
         <ParameterType Name="Validation.Expected" Array="true">int</ParameterType>
         <ParameterType Name="Validation.Tolerance">int</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
       </ParameterTypes>
 
       <Row Name="Bfrev">
@@ -1236,6 +1363,7 @@
         </Parameter>
 
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
             <Value>-2147483648</Value>
             <Value>-65536</Value>
@@ -1260,7 +1388,7 @@
         </Parameter>
       </Row>
 
-      <Row Name="FirstbitHi">
+      <Row Name="FirstbitSHi">
         <Parameter Name="ShaderOp.Name">Firstbithi</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
@@ -1281,6 +1409,7 @@
         </Parameter>
 
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
             <Value>-2147483648</Value>
             <Value>-65536</Value>
@@ -1296,7 +1425,7 @@
             <Value>30</Value>
             <Value>15</Value>
             <Value>2</Value>
-            <Value>32</Value>
+            <Value>-1</Value>
             <Value>-1</Value>
             <Value>0</Value>
             <Value>3</Value>
@@ -1326,6 +1455,7 @@
         </Parameter>
 
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
             <Value>-2147483648</Value>
             <Value>-65536</Value>
@@ -1371,6 +1501,7 @@
         </Parameter>
 
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
             <Value>-2147483648</Value>
             <Value>-65536</Value>
@@ -1405,6 +1536,7 @@
         <ParameterType Name="Validation.Input" Array="true">unsigned int</ParameterType>
         <ParameterType Name="Validation.Expected" Array="true">unsigned int</ParameterType>
         <ParameterType Name="Validation.Tolerance">int</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
       </ParameterTypes>
 
       <Row Name="FirstbitHi">
@@ -1427,6 +1559,7 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input">
             <Value>0</Value>
             <Value>1</Value>
@@ -1458,6 +1591,7 @@
         <ParameterType Name="Validation.Expected1" Array="true">int</ParameterType>
         <ParameterType Name="Validation.Expected2" Array="true">int</ParameterType>
         <ParameterType Name="Validation.Tolerance">int</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
       </ParameterTypes>
 
       <Row Name="IMax">
@@ -1469,7 +1603,7 @@
             struct SBinaryIntOp {
                 int input1;
                 int input2;
-                int output1; 
+                int output1;
                 int output2;
             };
             RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
@@ -1482,13 +1616,14 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>-2147483648</Value>
             <Value>-10</Value>
             <Value>0</Value>
             <Value>0</Value>
             <Value>10</Value>
-            <Value>2147483647</Value> 
+            <Value>2147483647</Value>
         </Parameter>
         <Parameter Name="Validation.Input2">
             <Value>0</Value>
@@ -1517,7 +1652,7 @@
             struct SBinaryIntOp {
                 int input1;
                 int input2;
-                int output1; 
+                int output1;
                 int output2;
             };
             RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
@@ -1530,13 +1665,14 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>-2147483648</Value>
             <Value>-10</Value>
             <Value>0</Value>
             <Value>0</Value>
             <Value>10</Value>
-            <Value>2147483647</Value> 
+            <Value>2147483647</Value>
         </Parameter>
         <Parameter Name="Validation.Input2">
             <Value>0</Value>
@@ -1566,7 +1702,7 @@
             struct SBinaryIntOp {
                 int input1;
                 int input2;
-                int output1; 
+                int output1;
                 int output2;
             };
             RWStructuredBuffer<SBinaryIntOp> g_buf : register(u0);
@@ -1579,6 +1715,7 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>-2147483648</Value>
             <Value>-10</Value>
@@ -1628,6 +1765,7 @@
         <ParameterType Name="Validation.Expected1" Array="true">unsigned int</ParameterType>
         <ParameterType Name="Validation.Expected2" Array="true">unsigned int</ParameterType>
         <ParameterType Name="Validation.Tolerance">int</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
       </ParameterTypes>
       <Row Name="UMax">
         <Parameter Name="ShaderOp.Name">UMax</Parameter>
@@ -1638,7 +1776,7 @@
             struct SBinaryUintOp {
                 uint input1;
                 uint input2;
-                uint output1; 
+                uint output1;
                 uint output2;
             };
             RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
@@ -1651,6 +1789,7 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>0</Value>
             <Value>0</Value>
@@ -1686,7 +1825,7 @@
             struct SBinaryUintOp {
                 uint input1;
                 uint input2;
-                uint output1; 
+                uint output1;
                 uint output2;
             };
             RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
@@ -1699,6 +1838,7 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>0</Value>
             <Value>0</Value>
@@ -1736,7 +1876,7 @@
             struct SBinaryUintOp {
                 uint input1;
                 uint input2;
-                uint output1; 
+                uint output1;
                 uint output2;
             };
             RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
@@ -1749,6 +1889,7 @@
         ]]>
         </Parameter>
         <Parameter Name="Validation.NumExpected">1</Parameter>
+        <Parameter Name="Validation.NumInput">5</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>0</Value>
             <Value>1</Value>
@@ -1783,7 +1924,7 @@
             struct SBinaryUintOp {
                 uint input1;
                 uint input2;
-                uint output1; 
+                uint output1;
                 uint output2;
             };
             RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
@@ -1798,6 +1939,7 @@
         </Parameter>
         <Parameter Name="Operation.Unsigned">true</Parameter>
         <Parameter Name="Validation.NumExpected">2</Parameter>
+        <Parameter Name="Validation.NumInput">7</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>1</Value>
             <Value>1</Value>
@@ -1847,7 +1989,7 @@
             struct SBinaryUintOp {
                 uint input1;
                 uint input2;
-                uint output1; 
+                uint output1;
                 uint output2;
             };
             RWStructuredBuffer<SBinaryUintOp> g_buf : register(u0);
@@ -1864,6 +2006,7 @@
         </Parameter>
         <Parameter Name="Operation.Unsigned">true</Parameter>
         <Parameter Name="Validation.NumExpected">2</Parameter>
+        <Parameter Name="Validation.NumInput">6</Parameter>
         <Parameter Name="Validation.Input1">
             <Value>1</Value>
             <Value>1</Value>
@@ -1899,4 +2042,350 @@
         <Parameter Name="Validation.Tolerance">0</Parameter>
       </Row>
     </Table>
-  </Data>
+
+    <Table Id="TertiaryIntOpTable">
+      <ParameterTypes>
+        <ParameterType Name="Description">String</ParameterType>
+        <ParameterType Name="ShaderOp.Name">String</ParameterType>
+        <ParameterType Name="ShaderOp.Target">String</ParameterType>
+        <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+        <ParameterType Name="ShaderOp.Text">String</ParameterType>
+        <ParameterType Name="Validation.Type">String</ParameterType>
+        <ParameterType Name="Validation.Tolerance">int</ParameterType>
+        <ParameterType Name="Validation.Input1" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Input2" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Input3" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.Expected" Array="true">int</ParameterType>
+        <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
+      </ParameterTypes>
+
+      <Row Name="IMad">
+        <Parameter Name="ShaderOp.Name">msad4</Parameter>
+        <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+        <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+        <Parameter Name="ShaderOp.Text">
+        <![CDATA[
+            struct STertiaryIntOp {
+                int input1;
+                int input2;
+                int input3;
+                int output;
+            };
+            RWStructuredBuffer<STertiaryIntOp> g_buf : register(u0);
+            [numthreads(8,8,1)]
+            void main(uint GI : SV_GroupIndex) {
+                STertiaryIntOp l = g_buf[GI];
+                l.output = mad(l.input1, l.input2, l.input3);
+                g_buf[GI] = l;
+            };
+        ]]>
+        </Parameter>
+        <Parameter Name="Validation.Type">epsilon</Parameter>
+        <Parameter Name="Validation.Tolerance">0</Parameter>
+        <Parameter Name="Validation.Input1">
+            <Value>-2147483647</Value>
+            <Value>-256</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>2</Value>
+            <Value>16</Value>
+            <Value>2147483647</Value>
+            <Value>1</Value>
+            <Value>-1</Value>
+            <Value>1</Value>
+            <Value>10</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input2">
+            <Value>1</Value>
+            <Value>-256</Value>
+            <Value>-1</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>3</Value>
+            <Value>16</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>-1</Value>
+            <Value>10</Value>
+            <Value>100</Value>
+        </Parameter>
+        <Parameter Name="Validation.Input3">
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>0</Value>
+            <Value>1</Value>
+            <Value>3</Value>
+            <Value>1</Value>
+            <Value>255</Value>
+            <Value>2147483646</Value>
+            <Value>-2147483647</Value>
+            <Value>-10</Value>
+            <Value>-2000</Value>
+        </Parameter>
+
+        <Parameter Name="Validation.Expected">
+            <Value>-2147483647</Value>
+            <Value>65536</Value>
+            <Value>1</Value>
+            <Value>0</Value>
+            <Value>2</Value>
+            <Value>9</Value>
+            <Value>257</Value>
+            <Value>255</Value>
+            <Value>2147483647</Value>
+            <Value>-2147483646</Value>
+            <Value>0</Value>
+            <Value>-1000</Value>
+        </Parameter>
+        <Parameter Name="Validation.NumInput">12</Parameter>
+      </Row>
+      </Table>
+
+      <Table Id="TertiaryUintOpTable">
+        <ParameterTypes>
+            <ParameterType Name="Description">String</ParameterType>
+            <ParameterType Name="ShaderOp.Name">String</ParameterType>
+            <ParameterType Name="ShaderOp.Target">String</ParameterType>
+            <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Type">String</ParameterType>
+            <ParameterType Name="Validation.Tolerance">int</ParameterType>
+            <ParameterType Name="Validation.Input1" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Input2" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Input3" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Expected" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
+        </ParameterTypes>
+
+        <Row Name="UMad">
+            <Parameter Name="ShaderOp.Name">UMad</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+            <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+            <Parameter Name="ShaderOp.Text">
+            <![CDATA[
+                struct STertiaryUintOp {
+                    uint input1;
+                    uint input2;
+                    uint input3;
+                    uint output;
+                };
+                RWStructuredBuffer<STertiaryUintOp> g_buf : register(u0);
+                [numthreads(8,8,1)]
+                void main(uint GI : SV_GroupIndex) {
+                    STertiaryUintOp l = g_buf[GI];
+                    l.output = mad(l.input1, l.input2, l.input3);
+                    g_buf[GI] = l;
+                };
+            ]]>
+            </Parameter>
+            <Parameter Name="Validation.Type">epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>16</Value>
+                <Value>2147483647</Value>
+                <Value>0</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input2">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>16</Value>
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input3">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>15</Value>
+                <Value>0</Value>
+                <Value>10</Value>
+                <Value>10</Value>
+            </Parameter>
+
+            <Parameter Name="Validation.Expected">
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>5</Value>
+                <Value>271</Value>
+                <Value>2147483647</Value>
+                <Value>10</Value>
+                <Value>110</Value>
+            </Parameter>
+            <Parameter Name="Validation.NumInput">7</Parameter>
+      </Row>
+      </Table>
+
+      <Table Id="DotOpTable">
+        <ParameterTypes>
+            <ParameterType Name="Description">String</ParameterType>
+            <ParameterType Name="ShaderOp.Name">String</ParameterType>
+            <ParameterType Name="ShaderOp.Target">String</ParameterType>
+            <ParameterType Name="ShaderOp.EntryPoint">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Type">String</ParameterType>
+            <ParameterType Name="Validation.Tolerance">int</ParameterType>
+            <ParameterType Name="Validation.Input1" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Input2" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.dot2" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.dot3" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.dot4" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
+        </ParameterTypes>
+
+        <Row Name="Dot">
+            <Parameter Name="ShaderOp.Name">Dot</Parameter>
+            <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
+            <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
+            <Parameter Name="ShaderOp.Text">
+            <![CDATA[
+                struct SDotOp {
+                   float4 input1;
+                   float4 input2;
+                   float o_dot2;
+                   float o_dot3;
+                   float o_dot4;
+                };
+                RWStructuredBuffer<SDotOp> g_buf : register(u0);
+                [numthreads(8,8,1)]
+                void main(uint GI : SV_GroupIndex) {
+                    SDotOp l = g_buf[GI];
+                    l.o_dot2 = dot(l.input1.xy, l.input2.xy);
+                    l.o_dot3 = dot(l.input1.xyz, l.input2.xyz);
+                    l.o_dot4 = dot(l.input1.xyzw, l.input2.xyzw);
+                    g_buf[GI] = l;
+                };
+            ]]>
+            </Parameter>
+            <Parameter Name="Validation.Type">epsilon</Parameter>
+            <Parameter Name="Validation.Tolerance">0.008</Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>NaN,NaN,NaN,NaN</Value>
+                <Value>-Inf,-Inf,-Inf,-Inf</Value>
+                <Value>-denorm,-denorm,-denorm,-denorm</Value>
+                <Value>-0,-0,-0,-0</Value>
+                <Value>0,0,0,0</Value>
+                <Value>denorm,denorm,denorm,denorm</Value>
+                <Value>Inf,Inf,Inf,Inf</Value>
+                <Value>1,1,1,1</Value>
+                <Value>-10,0,0,10</Value>
+                <Value>Inf,Inf,Inf,-Inf</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input2">
+                <Value>NaN,NaN,NaN,NaN</Value>
+                <Value>-Inf,-Inf,-Inf,-Inf</Value>
+                <Value>-denorm,-denorm,-denorm,-denorm</Value>
+                <Value>-0,-0,-0,-0</Value>
+                <Value>0,0,0,0</Value>
+                <Value>denorm,denorm,denorm,denorm</Value>
+                <Value>Inf,Inf,Inf,Inf</Value>
+                <Value>1,1,1,1</Value>
+                <Value>10,0,0,10</Value>
+                <Value>Inf,Inf,Inf,Inf</Value>
+            </Parameter>
+            <Parameter Name="Validation.dot2">
+                <Value>NaN</Value>
+                <Value>Inf</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>Inf</Value>
+                <Value>2</Value>
+                <Value>-100</Value>
+                <Value>Inf</Value>
+            </Parameter>
+            <Parameter Name="Validation.dot3">
+                <Value>NaN</Value>
+                <Value>Inf</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>Inf</Value>
+                <Value>3</Value>
+                <Value>-100</Value>
+                <Value>Inf</Value>
+            </Parameter>
+            <Parameter Name="Validation.dot4">
+                <Value>NaN</Value>
+                <Value>Inf</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>Inf</Value>
+                <Value>4</Value>
+                <Value>0</Value>
+                <Value>NaN</Value>
+            </Parameter>
+            <Parameter Name="Validation.NumInput">10</Parameter>
+        </Row>
+      </Table>
+
+      <Table Id="MSad4Table">
+        <ParameterTypes>
+            <ParameterType Name="Description">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Tolerance">int</ParameterType>
+            <ParameterType Name="Validation.Reference" Array="true">unsigned int</ParameterType>
+            <ParameterType Name="Validation.Source" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Accum" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.NumInput">unsigned int</ParameterType>
+        </ParameterTypes>
+        <Row Name="MSad4">
+            <Parameter Name="Description">Msad4 intrinsic calls both Bfi and Msad</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct SMsad4 {
+                        uint ref;
+                        uint2 source;
+                        uint4 accum;
+                        uint4 result;
+                    };
+                    RWStructuredBuffer<SMsad4> g_buf : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        SMsad4 l = g_buf[GI];
+                        l.result = msad4(l.ref, l.source, l.accum);
+                        g_buf[GI] = l;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.Tolerance">0</Parameter>
+            <Parameter Name="Validation.NumInput">4</Parameter>
+            <Parameter Name="Validation.Reference">
+                <Value>0xA100B2C3</Value>
+                <Value>0x00000000</Value>
+                <Value>0xFFFF01C1</Value>
+                <Value>0xFFFFFFFF</Value>
+            </Parameter>
+            <Parameter Name="Validation.Source">
+                <Value>0xD7B0C372, 0x4F57C2A3</Value>
+                <Value>0xFFFFFFFF, 0x00000000</Value>
+                <Value>0x38A03AEF, 0x38194DA3</Value>
+                <Value>0xFFFFFFFF, 0x00000000</Value>
+            </Parameter>
+            <Parameter Name="Validation.Accum">
+                <Value>1,2,3,4</Value>
+                <Value>1,2,3,4</Value>
+                <Value>0,0,0,0</Value>
+                <Value>10,10,10,10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected">
+                <Value>153,6,92,113</Value>
+                <Value>1,2,3,4</Value>
+                <Value>397,585,358,707</Value>
+                <Value>10,265,520,775</Value>
+            </Parameter>
+        </Row>
+       </Table>
+</Data>

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -549,7 +549,7 @@ void ShaderOpTest::CreateResources() {
         memset(values.data(), 0, values.size());
       }
       else if (initByName) {
-        m_InitCallbackFn(R.Name, values);
+        m_InitCallbackFn(R.Name, values, m_pShaderOp);
         if (isBuffer) {
           R.Desc.Width = values.size();
         }

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -230,7 +230,7 @@ struct CommandListRefs {
 // Use this class to run the operation described in a ShaderOp object.
 class ShaderOpTest {
 public:
-  typedef std::function<void(LPCSTR Name, std::vector<BYTE> &Data)> TInitCallbackFn;
+  typedef std::function<void(LPCSTR Name, std::vector<BYTE> &Data, ShaderOp *pShaderOp)> TInitCallbackFn;
   void GetPipelineStats(D3D12_QUERY_DATA_PIPELINE_STATISTICS *pStats);
   void GetReadBackData(LPCSTR pResourceName, MappedData *pData);
   void RunShaderOp(ShaderOp *pShaderOp);

--- a/tools/clang/unittests/HLSL/clang-hlsl-tests.rc
+++ b/tools/clang/unittests/HLSL/clang-hlsl-tests.rc
@@ -1,0 +1,3 @@
+#include <windows.h>
+
+ShaderOpArithTable.xml DATASOURCE_XML "ShaderOpArithTable.xml"

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1082,12 +1082,23 @@ class db_dxil(object):
     def populate_extended_docs(self):
         "Update the documentation with text from external files."
         inst_starter = "* Inst: "
+        block_starter = "* BLOCK-BEGIN"
+        block_end = "* BLOCK-END"
         with open("hctdb_inst_docs.txt") as ops_file:
             inst_name = ""
             inst_doc = ""
             inst_remarks = ""
-            for line in ops_file:
+            is_block = False
+            for idx, line in enumerate(ops_file):
                 if line.startswith("#"): continue
+                if line.startswith(block_starter):
+                    assert is_block == False, "unexpected block begin at line %i" % (idx+1) 
+                    is_block = True
+                    continue
+                if line.startswith(block_end):
+                    assert is_block == True, "unexpected block end at line %i" % (idx+1)
+                    is_block = False
+                    continue
                 if line.startswith(inst_starter):
                     if inst_name:
                         # print(inst_name + " - " + inst_remarks.strip())
@@ -1099,7 +1110,7 @@ class db_dxil(object):
                     inst_name = line[:sep_idx].strip()
                     inst_doc = line[sep_idx+1:].strip()
                 else:
-                    inst_remarks += "\n" + line.strip()
+                    inst_remarks += line if is_block else "\n" + line.strip()
             if inst_name:
                 self.name_idx[inst_name].remarks = inst_remarks.strip()
                     

--- a/utils/hct/hctdb_inst_docs.txt
+++ b/utils/hct/hctdb_inst_docs.txt
@@ -11,20 +11,6 @@
 # h = hctdb.db_dxil()
 # for i in [item.name for item in h.instr if item.is_dxil_op and not item.remarks]: print(i)
 
-* Inst: Cos - returns cosine(theta) for theta in radians.
-
-Theta values can be any IEEE 32-bit floating point values.
-
-The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
-
-
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| cos(src) |  NaN | [-1 to +1] |      -0 | -0 | +0 |      +0 | [-1 to +1] |  NaN | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-
-
 * Inst: FAbs - returns the absolute value of the input value.
 
 The FAbs instruction takes simply forces the sign of the number(s) on the source operand positive, including on INF values.
@@ -86,6 +72,19 @@ where min() and max() in the above expression behave in the way Min and Max beha
 
 Saturate(NaN) returns 0, by the rules for min and max.
 
+
+* Inst: Cos - returns cosine(theta) for theta in radians.
+
+Theta values can be any IEEE 32-bit floating point values.
+
+The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| cos(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 * Inst: Sin - returns sine(theta) for theta in radians.
 
 Theta values can be any IEEE 32-bit floating point values.
@@ -95,6 +94,212 @@ The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
-| sin(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
+| sin(src) |  NaN | [-1 to +1] |      -0 | -0 | +0 |      +0 | [-1 to +1] |  NaN | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 
+* Inst: Exp - returns component-wise e^exponent
+
+Maximum relative error is e^{-21}
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| exp(src) |  0   | +F         |    1    |  1 |  1 |       1 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Frc
+
+component-wise, extract fracitonal component.
+
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src        | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+| frc(src)   | NaN  | [+0,1)     |    +0   | +0 | +0 |      +0 | [+0,1)     | NaN  | NaN |
++------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Log - returns component-wise natural log.
+
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| log(src) |  NaN | NaN        |    -inf |-inf|-inf|    -inf |  F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Sqrt - returns component-wise square root
+
+Precision is 1 ulp.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| sqrt(src)|  NaN | NaN        |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Rsqrt- returns component-wise reciprocal square root (1 / sqrt(src))
+
+Maximum relative error is 2^21.
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src       | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+| rsqrt(src)|  NaN | NaN        |  -inf   |-inf|+inf|  +inf   | +F         | +0   | NaN |
++-----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Round_ne - floating-point round to integral float.
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ne rounds towards nearest even. For halfway, it rounds away from zero.
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_ne(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Round_ni - floating-point round to integral float.
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ni rounds towards -INF, commonly known as floor().
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_ni(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Round_pi - floating-point round to integral float.
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_pi rounds towards +INF, commonly known as ceil().
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_pi(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Round_z - floating-point round to integral float.
+
+Component-wise floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_z rounds towards zero.
+
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+| round_z(src) | -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
++--------------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: IsInf
+
+Returns true if x is +INF or -INF, false otherwise.
+
+* Inst: IsNaN
+
+Returns true if x is NAN or QNAN, false otherwise.
+
+* Inst: IsFinite
+
+Returns true if x is finite, false otherwise.
+
+
+* Inst: Countbits
+
+Counts the number of bits (per component) in the input integer.
+
+* Inst: Bfrev
+
+Reverses the order of the bits, per component.
+
+* Inst: FirstbitHi
+
+Gets the location of the first set bit starting from the highest order bit and working downward, per component.
+
+* Inst: FirstbitLo
+
+Returns the location of the first set bit starting from the lowest order bit and working upward, per component.
+
+* Inst: FirstbitSHi
+
+Returns the location of the first set bit of signed integer starting from the lowest order bit and working upward, per component.
+
+* Inst: IMax
+
+IMax(a,b) returns a if a >= b, else b
+
+* Inst: IMin
+
+IMin(a,b) returns a if a < b, else b
+
+* Inst: IsNormal
+
+* Inst: IMul - there is no way to call this directly in HLSL.
+
+Component-wise multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit (per component) result.
+The low 32 bits (per component) are placed in destLO.  The high 32 bits (per component) are placed in destHI.
+
+Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed.
+
+Optional negate modifier on source operands takes 2's complement before performing arithmetic operation.
+
+* Inst: UMul
+
+Component-wise multiply of 32-bit operands  src0 and src1 (note they are unsigned), producing the correct  full 64-bit (per component) result.
+The low 32 bits (per  component) are placed in destLO. The high 32 bits (per  component) are placed in destHI.
+Either of destHI or destLO may be specified as NULL instead of  specifying a register, in the case high or low 32 bits of the  64-bit result are not needed
+
+* Inst: UDiv
+
+Component-wise unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
+The results of the divides are the 32-bit quotients (placed in destQUOT) and 32-bit remainders (placed in destREM).
+Divide by zero returns 0xffffffff for both quotient and remainder. Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
+
+* Inst: UAddc
+
+Component-wise unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0. \
+The corresponding component in dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
+
+* Inst: USubb
+
+Component-wise unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
+The corresponding component in dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
+
+* Inst: Acos
+
+Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1.
+The return value is within the range of -PI/2 to PI/2.
+
+* Inst: Asin
+
+Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1
+The return value is within the range of -PI/2 to PI/2.
+
+* Inst: Atan
+
+Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+
+* Inst: Hcos
+
+returns the hyperbolic cosine of the specified value.
+
+* Inst: Hsin
+
+returns the hyperbolic sine of the specified value.
+
+* Inst: Htan
+
+returns the hyperbolic tangent of the specified value.
+
+* Inst: UMax
+
+Component-wise unsigned integer maximum. UMax(a,b) = a > b ? a : b
+
+* Inst: UMin
+
+Component-wise unsigned integer minimum. UMin(a,b) = a < b ? a : b

--- a/utils/hct/hctdb_inst_docs.txt
+++ b/utils/hct/hctdb_inst_docs.txt
@@ -11,10 +11,95 @@
 # h = hctdb.db_dxil()
 # for i in [item.name for item in h.instr if item.is_dxil_op and not item.remarks]: print(i)
 
+
+* Inst: Acos - Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1.
+The return value is within the range of -PI/2 to PI/2.
+
+* Inst: Asin - Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
+The return value is within the range of -PI/2 to PI/2.
+
+* Inst: Atan - Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+
+Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2
+
+* Inst: Bfrev - Reverses the order of the bits.
+
+Reverses the order of the bits. For example given 0x12345678 the result would be 0x1e6a2c48.
+
+* Inst: Bfi - Given a bit range from the LSB of a number, places that number of bits in another number at any offset
+
+Given a bit range from the LSB of a number, place that number of bits in another number at any offset.
+
+ dst = Bfi(src0, src1, src2, src3);
+
+ The LSB 5 bits of src0 provide the bitfield width (0-31) to take from src2.
+ The LSB 5 bits of src1 provide the bitfield offset (0-31) to start replacing bits in the  number read from src3.
+ Given width, offset: bitmask = (((1 << width)-1) << offset) & 0xffffffff, dest = ((src2 << offset) & bitmask) | (src3 & ~bitmask)
+
+* Inst: Cos - returns cosine(theta) for theta in radians.
+
+Theta values can be any IEEE 32-bit floating point values.
+
+The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| cos(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: Countbits - Counts the number of bits in the input integer.
+
+Counts the number of bits in the input integer.
+
+* Inst: Dot2 - Two-dimensional vector dot-product
+
+Two-dimensional vector dot-product
+
+* Inst: Dot3 - Three-dimensional vector dot-product
+
+Three-dimensional vector dot-product
+
+* Inst: Dot4 - Four-dimensional vector dot-product
+
+Four-dimensional vector dot-product
+
+* Inst: Exp - returns e^exponent
+
+Maximum relative error is e^{-21}
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| exp(src) |  0   | +F         |    1    |  1 |  1 |       1 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 * Inst: FAbs - returns the absolute value of the input value.
 
 The FAbs instruction takes simply forces the sign of the number(s) on the source operand positive, including on INF values.
 Applying FAbs on NaN preserves NaN, although the particular NaN bit pattern that results is not defined.
+
+* Inst: FirstbitHi - Returns the location of the first set bit starting from the highest order bit and working downward.
+
+Returns the integer position of the first bit set in the 32-bit input starting from the MSB. For example, 0x10000000 would return 3. Returns 0xffffffff if no match was found.
+
+* Inst: FirstbitLo - Returns the location of the first set bit starting from the lowest order bit and working upward.
+
+Returns the integer position of the first bit set in the 32-bit input starting from the LSB. For example, 0x00000000 would return 1. Returns 0xffffffff if no match was found.
+
+* Inst: FirstbitSHi - Returns the location of the first set bit from the highest order bit based on the sign.
+
+Returns the first 0 from the MSB if the number is negative, else the first 1 from the MSB. Returns 0xffffffff if no match was found.
+
+* Inst: Fma - fused multiple-add
+
+Fused multiple-add. This operation is only defined in double precision.
+Fma(a,b,c) = a * b + c
+
+* Inst: FMad - floating point multiply & add
+
+Floating point multiply & add. This operation is not fused for "precise" operations.
+FMad(a,b,c) = a * b + c
 
 * Inst: FMax - returns a if a >= b, else b
 
@@ -62,6 +147,238 @@ Denorms are flushed (sign preserved) before comparison, however the result writt
 | NaN  | -inf | b      | +inf | NaN  |
 +------+------+--------+------+------+
 
+* Inst: Frc - extract fracitonal component.
+
++--------------+------+------+---------+----+----+---------+--------+------+-----+
+| src          | -inf | -F   | -denorm | -0 | +0 | +denorm | +F     | +inf | NaN |
++--------------+------+------+---------+----+----+---------+--------+------+-----+
+| log(src)     | NaN  |[+0,1)| +0      | +0 | +0 | +0      | [+0,1) | NaN  | NaN |
++--------------+------+------+---------+----+----+---------+--------+------+-----+
+
+* Inst: Hcos - returns the hyperbolic cosine of the specified value.
+
+Returns the hyperbolic cosine of the specified value.
+
+* Inst: Hsin - returns the hyperbolic sine of the specified value.
+
+Returns the hyperbolic sine of the specified value.
+
+* Inst: Htan - returns the hyperbolic tangent of the specified value.
+
+Returns the hyperbolic tangent of the specified value.
+
+* Inst: Ibfe - Integer bitfield extract
+
+dest = Ibfe(src0, src1, src2)
+
+Given a range of bits in a number, shift those bits to the LSB and sign extend the MSB of the range.
+
+width : The LSB 5 bits of src0 (0-31).
+
+offset: The LSB 5 bits of src1 (0-31)
+
+* BLOCK-BEGIN
+
+.. code:: c
+
+    if( width == 0 )
+    {
+        dest = 0
+    }
+    else if( width + offset < 32 )
+    {
+        shl dest, src2, 32-(width+offset)
+        ishr dest, dest, 32-width
+    }
+    else
+    {
+        ishr dest, src2, offset
+    }
+
+* BLOCK-END
+
+* Inst: IMad - Signed integer multiply & add
+
+Signed integer multiply & add
+
+IMad(a,b,c) = a * b + c
+
+* Inst: IMax - IMax(a,b) returns a if a > b, else b
+
+IMax(a,b) returns a if a > b, else b. Optional negate modifier on source operands takes 2's complement before performing operation.
+
+* Inst: IMin - IMin(a,b) returns a if a < b, else b
+
+IMin(a,b) returns a if a < b, else b. Optional negate modifier on source operands takes 2's complement before performing operation.
+
+* Inst: IMul - multiply of 32-bit operands to produce the correct full 64-bit result.
+
+IMul(src0, src1) = destHi, destLo
+ multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit result.
+The low 32 bits are placed in destLO. The high 32 bits are placed in destHI.
+
+Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed.
+
+Optional negate modifier on source operands takes 2's complement before performing arithmetic operation.
+
+* Inst: IsFinite - Returns true if x is finite, false otherwise.
+
+Returns true if x is finite, false otherwise.
+
+* Inst: IsInf - Returns true if x is +INF or -INF, false otherwise.
+
+Returns true if x is +INF or -INF, false otherwise.
+
+* Inst: IsNaN - Returns true if x is NAN or QNAN, false otherwise.
+
+Returns true if x is NAN or QNAN, false otherwise.
+
+* Inst: IsNormal - returns IsNormal
+
+Returns IsNormal.
+
+* Inst: Log - returns natural log.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| log(src) |  NaN | NaN        |    -inf |-inf|-inf|    -inf |  F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+* Inst: LoadInput - Loads the value from shader input
+
+Loads the value from shader input
+
+
+* Inst: MinPrecXRegLoad - Helper load operation for minprecision
+
+Helper load operation for minprecision
+
+* Inst: MinPrecXRegStore - Helper store operation for minprecision
+
+Helper store operation for minprecision
+
+* Inst: Msad - masked Sum of Absolute Differences.
+
+Returns the masked Sum of Absolute Differences.
+
+dest = msad(ref, src, accum)
+
+ref: contains 4 packed 8-bit unsigned integers in 32 bits.
+
+src: contains 4 packed 8-bit unsigned integers in 32 bits.
+
+accum: a 32-bit unsigned integer, providing an existing accumulation.
+
+dest receives the result of the masked SAD operation added to the accumulation value.
+
+* BLOCK-BEGIN
+
+.. code:: c
+
+    UINT msad( UINT ref, UINT src, UINT accum )
+    {
+        for (UINT i = 0; i < 4; i++)
+        {
+            BYTE refByte, srcByte, absDiff;
+
+            refByte = (BYTE)(ref >> (i * 8));
+            if (!refByte)
+            {
+                continue;
+            }
+
+            srcByte = (BYTE)(src >> (i * 8));
+            if (refByte >= srcByte)
+            {
+                absDiff = refByte - srcByte;
+            }
+            else
+            {
+                absDiff = srcByte - refByte;
+            }
+
+            // The recommended overflow behavior for MSAD is
+            // to do a 32-bit saturate. This is not
+            // required, however, and wrapping is allowed.
+            // So from an application point of view,
+            // overflow behavior is undefined.
+            if (UINT_MAX - accum < absDiff)
+            {
+                accum = UINT_MAX;
+                break;
+            }
+
+            accum += absDiff;
+        }
+
+        return accum;
+    }
+
+* BLOCK-END
+
+* Inst: Round_ne - floating-point round to integral float.
+
+Floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ne rounds towards nearest even. For halfway, it rounds away from zero.
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_ne(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
+* Inst: Round_ni - floating-point round to integral float.
+
+Floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_ni rounds towards -INF, commonly known as floor().
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_ni(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
+* Inst: Round_pi - floating-point round to integral float.
+
+Floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_pi rounds towards +INF, commonly known as ceil().
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_pi(src)| -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
+* Inst: Round_z - floating-point round to integral float.
+
+Floating-point round of the values in src,
+writing integral floating-point values to dest.
+
+round_z rounds towards zero.
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| round_z(src) | -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
+* Inst: Rsqrt- returns reciprocal square root (1 / sqrt(src)
+
+Maximum relative error is 2^21.
+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| rsqrt(src)   | -inf | -F | -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+
 * Inst: Saturate - clamps the result of a single or double precision floating point value to [0.0f...1.0f]
 
 The Saturate instruction performs the following operation on its input value:
@@ -71,19 +388,6 @@ min(1.0f, max(0.0f, value))
 where min() and max() in the above expression behave in the way Min and Max behave.
 
 Saturate(NaN) returns 0, by the rules for min and max.
-
-
-* Inst: Cos - returns cosine(theta) for theta in radians.
-
-Theta values can be any IEEE 32-bit floating point values.
-
-The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
-
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| cos(src) |  NaN | [-1 to +1] |      +1 | +1 | +1 |      +1 | [-1 to +1] |  NaN | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
 
 * Inst: Sin - returns sine(theta) for theta in radians.
 
@@ -97,209 +401,113 @@ The maximum absolute error is 0.0008 in the interval from -100*Pi to +100*Pi.
 | sin(src) |  NaN | [-1 to +1] |      -0 | -0 | +0 |      +0 | [-1 to +1] |  NaN | NaN |
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 
-* Inst: Exp - returns component-wise e^exponent
-
-Maximum relative error is e^{-21}
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| exp(src) |  0   | +F         |    1    |  1 |  1 |       1 | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-
-* Inst: Frc
-
-component-wise, extract fracitonal component.
-
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src        | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
-| frc(src)   | NaN  | [+0,1)     |    +0   | +0 | +0 |      +0 | [+0,1)     | NaN  | NaN |
-+------------+------+------------+---------+----+----+---------+------------+------+-----+
-
-* Inst: Log - returns component-wise natural log.
-
-
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| log(src) |  NaN | NaN        |    -inf |-inf|-inf|    -inf |  F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-
-* Inst: Sqrt - returns component-wise square root
+* Inst: Sqrt - returns square root
 
 Precision is 1 ulp.
 
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
-| sqrt(src)|  NaN | NaN        |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+----------+------+------------+---------+----+----+---------+------------+------+-----+
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| src          | -inf | -F | -denorm | -0 | +0 | +denorm | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
+| sqrt(src)    | NaN  | NaN| -0      | -0 | +0 | +0      | +F | +inf | NaN |
++--------------+------+----+---------+----+----+---------+----+------+-----+
 
-* Inst: Rsqrt- returns component-wise reciprocal square root (1 / sqrt(src))
+* Inst: StoreOutput - Stores the value to shader output
 
-Maximum relative error is 2^21.
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
-| src       | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
-| rsqrt(src)|  NaN | NaN        |  -inf   |-inf|+inf|  +inf   | +F         | +0   | NaN |
-+-----------+------+------------+---------+----+----+---------+------------+------+-----+
+Stores the value to shader output
 
-* Inst: Round_ne - floating-point round to integral float.
+* Inst: Tan - returns tan(theta) for theta in radians.
 
-Component-wise floating-point round of the values in src,
-writing integral floating-point values to dest.
+Theta values can be any IEEE 32-bit floating point values.
 
-round_ne rounds towards nearest even. For halfway, it rounds away from zero.
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
+| src      | -inf     | -F             | -denorm | -0 | +0 | +denorm | +F             | +inf | NaN |
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
+| tan(src) | NaN      | [-inf to +inf] | -0      | -0 | +0 | +0      | [-inf to +inf] | NaN  | NaN |
++----------+----------+----------------+---------+----+----+---------+----------------+------+-----+
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_ne(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
+* Inst: TempRegLoad - Helper load operation
 
-* Inst: Round_ni - floating-point round to integral float.
+Helper load operation
 
-Component-wise floating-point round of the values in src,
-writing integral floating-point values to dest.
+* Inst: TempRegStore - Helper store operation
 
-round_ni rounds towards -INF, commonly known as floor().
+Helper store operation
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_ni(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
+* Inst: UAddc - unsigned add of 32-bit operand with the carry
 
-* Inst: Round_pi - floating-point round to integral float.
+dest0, dest1 = UAddc(src0, src1)
 
-Component-wise floating-point round of the values in src,
-writing integral floating-point values to dest.
+unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0.
+dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
 
-round_pi rounds towards +INF, commonly known as ceil().
+* Inst: Ubfe - Unsigned integer bitfield extract
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_pi(src)| -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
+dest = ubfe(src0, src1, src2)
 
-* Inst: Round_z - floating-point round to integral float.
+Given a range of bits in a number, shift those bits to the LSB and set remaining bits to 0.
 
-Component-wise floating-point round of the values in src,
-writing integral floating-point values to dest.
+width : The LSB 5 bits of src0 (0-31).
 
-round_z rounds towards zero.
+offset: The LSB 5 bits of src1 (0-31).
 
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| src          | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
-| round_z(src) | -inf | -F         |    -0   | -0 | +0 |      +0 | +F         | +inf | NaN |
-+--------------+------+------------+---------+----+----+---------+------------+------+-----+
+Given width, offset:
 
-* Inst: IsInf
+* BLOCK-BEGIN
 
-Returns true if x is +INF or -INF, false otherwise.
+.. code:: c
 
-* Inst: IsNaN
+    if( width == 0 )
+    {
+        dest = 0
+    }
+    else if( width + offset < 32 )
+    {
+        shl dest, src2, 32-(width+offset)
+        ushr dest, dest, 32-width
+    }
+    else
+    {
+        ushr dest, src2, offset
+    }
 
-Returns true if x is NAN or QNAN, false otherwise.
+* BLOCK-END
 
-* Inst: IsFinite
+* Inst: UDiv - unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
 
-Returns true if x is finite, false otherwise.
+destQUOT, destREM = UDiv(src0, src1);
 
+unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
 
-* Inst: Countbits
-
-Counts the number of bits (per component) in the input integer.
-
-* Inst: Bfrev
-
-Reverses the order of the bits, per component.
-
-* Inst: FirstbitHi
-
-Gets the location of the first set bit starting from the highest order bit and working downward, per component.
-
-* Inst: FirstbitLo
-
-Returns the location of the first set bit starting from the lowest order bit and working upward, per component.
-
-* Inst: FirstbitSHi
-
-Returns the location of the first set bit of signed integer starting from the lowest order bit and working upward, per component.
-
-* Inst: IMax
-
-IMax(a,b) returns a if a >= b, else b
-
-* Inst: IMin
-
-IMin(a,b) returns a if a < b, else b
-
-* Inst: IsNormal
-
-* Inst: IMul - there is no way to call this directly in HLSL.
-
-Component-wise multiply of 32-bit operands src0 and src1 (note they are signed), producing the correct full 64-bit (per component) result.
-The low 32 bits (per component) are placed in destLO.  The high 32 bits (per component) are placed in destHI.
-
-Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed.
-
-Optional negate modifier on source operands takes 2's complement before performing arithmetic operation.
-
-* Inst: UMul
-
-Component-wise multiply of 32-bit operands  src0 and src1 (note they are unsigned), producing the correct  full 64-bit (per component) result.
-The low 32 bits (per  component) are placed in destLO. The high 32 bits (per  component) are placed in destHI.
-Either of destHI or destLO may be specified as NULL instead of  specifying a register, in the case high or low 32 bits of the  64-bit result are not needed
-
-* Inst: UDiv
-
-Component-wise unsigned divide of the 32-bit operand src0 by the 32-bit operand src1.
 The results of the divides are the 32-bit quotients (placed in destQUOT) and 32-bit remainders (placed in destREM).
-Divide by zero returns 0xffffffff for both quotient and remainder. Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
 
-* Inst: UAddc
+Divide by zero returns 0xffffffff for both quotient and remainder.
 
-Component-wise unsigned add of 32-bit operands src0 and src1, placing the LSB part of the 32-bit result in dest0. \
-The corresponding component in dest1 is written with: 1 if a carry is produced, 0 otherwise. Dest1 can be NULL if the carry is not needed
+Either destQUOT or destREM may be specified as NULL instead of specifying a register, in the case the quotient or remainder are not needed.
 
-* Inst: USubb
+Unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
+dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
 
-Component-wise unsigned subtract of 32-bit operands src1 from src0, placing the LSB part of the 32-bit result in dest0.
-The corresponding component in dest1 is written with: 1 if a borrow is produced, 0 otherwise. Dest1 can be NULL if the borrow is not needed
+* Inst: UMad - Unsigned integer multiply & add
 
-* Inst: Acos
+Unsigned integer multiply & add.
 
-Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1.
-The return value is within the range of -PI/2 to PI/2.
+Umad(a,b,c) = a * b + c
 
-* Inst: Asin
+* Inst: UMax - unsigned integer maximum. UMax(a,b) = a > b ? a : b
 
-Returns the arccosine of the specified value. Each component should be a floating-point value within the range of -1 to 1
-The return value is within the range of -PI/2 to PI/2.
+ unsigned integer maximum. UMax(a,b) = a > b ? a : b
 
-* Inst: Atan
+* Inst: UMin - unsigned integer minimum. UMin(a,b) = a < b ? a : b
 
-Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+ unsigned integer minimum. UMin(a,b) = a < b ? a : b
 
-* Inst: Hcos
+* Inst: UMul - multiply of 32-bit operands to produce the correct full 64-bit result.
 
-returns the hyperbolic cosine of the specified value.
+ multiply of 32-bit operands src0 and src1 (note they are unsigned), producing the correct full 64-bit result.
+The low 32 bits are placed in destLO. The high 32 bits are placed in destHI.
+Either of destHI or destLO may be specified as NULL instead of specifying a register, in the case high or low 32 bits of the 64-bit result are not needed
 
-* Inst: Hsin
+* Inst: USubb - unsigned subtract of 32-bit operands with the borrow
 
-returns the hyperbolic sine of the specified value.
+dest0, dest1 = USubb(src0, src1)
 
-* Inst: Htan
-
-returns the hyperbolic tangent of the specified value.
-
-* Inst: UMax
-
-Component-wise unsigned integer maximum. UMax(a,b) = a > b ? a : b
-
-* Inst: UMin
-
-Component-wise unsigned integer minimum. UMin(a,b) = a < b ? a : b

--- a/utils/hct/hctdb_inst_docs.txt
+++ b/utils/hct/hctdb_inst_docs.txt
@@ -15,10 +15,28 @@
 * Inst: Acos - Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1.
 The return value is within the range of -PI/2 to PI/2.
 
++----------+------+--------------+---------+------+------+---------+------+-----+
+| src      | -inf | [-1,1]       | -denorm | -0   | +0   | +denorm | +inf | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+| acos(src)|  NaN | (-PI/2,+PI/2)|    PI/2 | PI/2 | PI/2 |    PI/2 |  NaN | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+
 * Inst: Asin - Returns the arccosine of the specified value. Input should be a floating-point value within the range of -1 to 1
 The return value is within the range of -PI/2 to PI/2.
 
++----------+------+--------------+---------+------+------+---------+------+-----+
+| src      | -inf | [-1,1]       | -denorm | -0   | +0   | +denorm | +inf | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+| asin(src)|  NaN | (-PI/2,+PI/2)|    0    |  0   |  0   |    0    |  NaN | NaN |
++----------+------+--------------+---------+------+------+---------+------+-----+
+
 * Inst: Atan - Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2.
+
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
+| src      | -inf | -F           | -denorm | -0   | +0   | +denorm | +F            |+inf | NaN |
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
+| atan(src)| -PI/2| (-PI/2,+PI/2)|    0    |  0   |  0   |    0    | (-PI/2,+PI/2) |PI/2 | NaN |
++----------+------+--------------+---------+------+------+---------+---------------+-----+-----+
 
 Returns the arctangent of the specified value. The return value is within the range of -PI/2 to PI/2
 
@@ -91,9 +109,9 @@ Returns the integer position of the first bit set in the 32-bit input starting f
 
 Returns the first 0 from the MSB if the number is negative, else the first 1 from the MSB. Returns 0xffffffff if no match was found.
 
-* Inst: Fma - fused multiple-add
+* Inst: Fma - fused multiply-add
 
-Fused multiple-add. This operation is only defined in double precision.
+Fused multiply-add. This operation is only defined in double precision.
 Fma(a,b,c) = a * b + c
 
 * Inst: FMad - floating point multiply & add
@@ -159,13 +177,32 @@ Denorms are flushed (sign preserved) before comparison, however the result writt
 
 Returns the hyperbolic cosine of the specified value.
 
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| hcos(src)| +inf | (1, +inf)  |      +1 | +1 | +1 |      +1 | (1, +inf)  | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
 * Inst: Hsin - returns the hyperbolic sine of the specified value.
 
 Returns the hyperbolic sine of the specified value.
 
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| hsin(src)| -inf | -F         |       0 |  0 |  0 |       0 | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+
+
 * Inst: Htan - returns the hyperbolic tangent of the specified value.
 
 Returns the hyperbolic tangent of the specified value.
+
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
+| htan(src)|  NaN | -F         |       0 |  0 |  0 |       0 | +F         |  NaN | NaN |
++----------+------+------------+---------+----+----+---------+------------+------+-----+
 
 * Inst: Ibfe - Integer bitfield extract
 

--- a/utils/hct/hctdb_inst_docs.txt
+++ b/utils/hct/hctdb_inst_docs.txt
@@ -82,9 +82,9 @@ Three-dimensional vector dot-product
 
 Four-dimensional vector dot-product
 
-* Inst: Exp - returns e^exponent
+* Inst: Exp - returns 2^exponent
 
-Maximum relative error is e^{-21}
+Returns 2^exponent. Note that hlsl log intrinsic returns the base-e exponent. Maximum relative error is e^-21.
 
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |
@@ -274,7 +274,9 @@ Returns true if x is NAN or QNAN, false otherwise.
 
 Returns IsNormal.
 
-* Inst: Log - returns natural log.
+* Inst: Log - returns log base 2.
+
+Returns log base 2. Note that hlsl log intrinsic returns natural log.
 
 +----------+------+------------+---------+----+----+---------+------------+------+-----+
 | src      | -inf | -F         | -denorm | -0 | +0 | +denorm | +F         | +inf | NaN |

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -811,7 +811,7 @@ def get_opcodes_rst():
     rows = []
     rows.append(["ID", "Name", "Description"])
     for i in instrs:
-        rows.append([i.dxil_opid, i.dxil_op, i.doc])
+        rows.append([i.dxil_opid, i.dxil_op + "_", i.doc]) #append _ to enable internal hyperlink on rst files
     result = "\n\n" + format_rst_table(rows) + "\n\n"
     # Add detailed instruction information where available.
     instrs = sorted(instrs, key=lambda v : v.name)


### PR DESCRIPTION
This change is to add execution tests for individual DXIL arithmetic operations. 

1. Using TAEF's data-driven model to group operations by the type/number of operands for each instructions.
2. Updating DXIL.rst for these instructions.
3. Update hctdb.py to enable internal links for DXIL instructions.