### PR TITLE
Improvements to hctgettaef.

### DIFF
--- a/utils/hct/hctgettaef.py
+++ b/utils/hct/hctgettaef.py
@@ -8,10 +8,16 @@ src_dir = os.environ['HLSL_SRC_DIR']
 taef_dir = os.path.join(src_dir, "external", "taef")
 
 if not os.path.isdir(taef_dir):
-  os.mkdir(taef_dir)
+  os.makedirs(taef_dir)
 
-urllib.urlretrieve(url, zipfile_name)
+try:
+  urllib.urlretrieve(url, zipfile_name)
+except:
+  print("Unable to read file with urllib, trying via powershell...")
+  from subprocess import check_call, check_output
+  cmd = "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
+  check_call(['powershell.exe', '-Command', cmd])
+
 z = zipfile.ZipFile(zipfile_name)
 z.extractall(taef_dir)
 z.close()
-

--- a/utils/hct/hctgettaef.py
+++ b/utils/hct/hctgettaef.py
@@ -14,7 +14,7 @@ try:
   urllib.urlretrieve(url, zipfile_name)
 except:
   print("Unable to read file with urllib, trying via powershell...")
-  from subprocess import check_call, check_output
+  from subprocess import check_call
   cmd = "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
   check_call(['powershell.exe', '-Command', cmd])
 


### PR DESCRIPTION
Create all missing directories to target directory as needed.
If urllib.urlretrieve fails, try to download via powershell.