### PR TITLE
Add hooks for constant folding extensions

### DIFF
--- a/include/llvm/Analysis/DxilConstantFolding.h
+++ b/include/llvm/Analysis/DxilConstantFolding.h
@@ -33,9 +33,17 @@ namespace hlsl {
   /// If successful, the constant result is returned, if not, null is returned.
   llvm::Constant *ConstantFoldScalarCall(llvm::StringRef Name, llvm::Type *Ty, llvm::ArrayRef<llvm::Constant *> Operands);
 
+  /// ConstantFoldScalarCallExt
+  /// Hook point for constant folding of extensions.
+  llvm::Constant *ConstantFoldScalarCallExt(llvm::StringRef Name, llvm::Type *Ty, llvm::ArrayRef<llvm::Constant *> Operands);
+
   /// CanConstantFoldCallTo - Return true if we can potentially constant
   /// fold a call to the given function.
   bool CanConstantFoldCallTo(const llvm::Function *F);
+
+  /// CanConstantFoldCallToExt
+  /// Hook point for constant folding of extensions.
+  bool CanConstantFoldCallToExt(const llvm::Function *F);
 }
 
 #endif

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -26,6 +26,7 @@ add_llvm_library(LLVMAnalysis
   DomPrinter.cpp
   DominanceFrontier.cpp
   DxilConstantFolding.cpp
+  DxilConstantFoldingExt.cpp
   IVUsers.cpp
   InstCount.cpp
   InstructionSimplify.cpp

--- a/lib/Analysis/DxilConstantFolding.cpp
+++ b/lib/Analysis/DxilConstantFolding.cpp
@@ -536,7 +536,8 @@ Constant *hlsl::ConstantFoldScalarCall(StringRef Name, Type *Ty, ArrayRef<Consta
       return ConstantFoldIntIntrinsic(opcode, Ty, IntrinsicOperands);
     }
   }
-  return nullptr;
+
+  return hlsl::ConstantFoldScalarCallExt(Name, Ty, RawOperands);
 }
 
 // External entry point to determine if we can constant fold calls to
@@ -570,5 +571,5 @@ bool hlsl::CanConstantFoldCallTo(const Function *F) {
     }
   }
 
-  return false;
+  return hlsl::CanConstantFoldCallToExt(F);
 }

--- a/lib/Analysis/DxilConstantFoldingExt.cpp
+++ b/lib/Analysis/DxilConstantFoldingExt.cpp
@@ -1,0 +1,29 @@
+//===-- DxilConstantFoldingExt.cpp - Hooks for extensions ----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//
+//===----------------------------------------------------------------------===//
+//
+// These are placeholder hooks to support constant folding of extensions.
+// They are defined in a separate file to make it easy to merge changes or link
+// in your own version. There should be no upstream changes to these definitions.
+//
+//===----------------------------------------------------------------------===//
+#include "llvm/Analysis/DxilConstantFolding.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/ArrayRef.h"
+using namespace llvm;
+
+Constant *hlsl::ConstantFoldScalarCallExt(StringRef Name, Type *Ty, ArrayRef<Constant *> RawOperands) {
+  return nullptr;
+}
+
+bool hlsl::CanConstantFoldCallToExt(const Function *F) {
+  return false;
+}


### PR DESCRIPTION
This commit adds placeholder hooks to support constant folding of
extensions.  They are defined in a separate file to make it easy to merge
changes or link in other versions. There should be no upstream changes to
these definitions.