### PR TITLE
Fix initialization order of various class members

### DIFF
--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -57,14 +57,14 @@ HLModule::HLModule(Module *pModule)
     , m_pModule(pModule)
     , m_pEntryFunc(nullptr)
     , m_EntryName("")
-    , m_pSM(nullptr)
-    , m_pOP(llvm::make_unique<OP>(pModule->getContext(), pModule))
-    , m_pTypeSystem(llvm::make_unique<DxilTypeSystem>(pModule))
     , m_pMDHelper(llvm::make_unique<DxilMDHelper>(
           pModule, llvm::make_unique<HLExtraPropertyHelper>(pModule)))
     , m_pDebugInfoFinder(nullptr)
+    , m_pSM(nullptr)
     , m_DxilMajor(1)
-    , m_DxilMinor(0) {
+    , m_DxilMinor(0)
+    , m_pOP(llvm::make_unique<OP>(pModule->getContext(), pModule))
+    , m_pTypeSystem(llvm::make_unique<DxilTypeSystem>(pModule)) {
   DXASSERT_NOMSG(m_pModule != nullptr);
 
   // Pin LLVM dump methods. TODO: make debug-only.

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -42,7 +42,7 @@ struct HLOperationLowerHelper {
 };
 
 HLOperationLowerHelper::HLOperationLowerHelper(HLModule &HLM)
-    : dxilTypeSys(HLM.GetTypeSystem()), hlslOP(*HLM.GetOP()),
+    : hlslOP(*HLM.GetOP()), dxilTypeSys(HLM.GetTypeSystem()),
       legacyDataLayout(HLModule::GetLegacyDataLayoutDesc()) {
   llvm::LLVMContext &Ctx = HLM.GetCtx();
   voidTy = Type::getVoidTy(Ctx);
@@ -2561,7 +2561,7 @@ struct GatherHelper {
 GatherHelper::GatherHelper(
     CallInst *CI, OP::OpCode op, HLObjectOperationLowerHelper *pObjHelper,
     GatherHelper::GatherChannel ch)
-    : opcode(op), hasSampleOffsets(false), special(nullptr) {
+    : opcode(op), special(nullptr), hasSampleOffsets(false) {
   const unsigned thisIdx =
       HLOperandIndex::kHandleOpIdx; // opcode takes arg0, this pointer is arg1.
   const unsigned kSamplerArgIndex = HLOperandIndex::kSampleSamplerArgIndex;
@@ -2757,8 +2757,8 @@ struct ResLoadHelper {
                 Value *h, Value *mip);
   // For double subscript.
   ResLoadHelper(Instruction *ldInst, Value *h, Value *idx, Value *mip)
-      : handle(h), retVal(ldInst), addr(idx), mipLevel(mip),
-        opcode(OP::OpCode::TextureLoad), offset(nullptr), status(nullptr){};
+      : opcode(OP::OpCode::TextureLoad), handle(h), retVal(ldInst), addr(idx),
+        offset(nullptr), status(nullptr), mipLevel(mip) {}
   OP::OpCode opcode;
   Value *handle;
   Value *retVal;
@@ -3249,7 +3249,7 @@ struct AtomicHelper {
 
 // For MOP version of Interlocked*.
 AtomicHelper::AtomicHelper(CallInst *CI, OP::OpCode op, Value *h)
-    : opcode(op), handle(h), originalValue(nullptr), offset(nullptr) {
+    : opcode(op), handle(h), offset(nullptr), originalValue(nullptr) {
   addr = CI->getArgOperand(HLOperandIndex::kObjectInterlockedDestOpIndex);
   if (op == OP::OpCode::AtomicCompareExchange) {
     compareValue = CI->getArgOperand(
@@ -3271,8 +3271,8 @@ AtomicHelper::AtomicHelper(CallInst *CI, OP::OpCode op, Value *h)
 // For IOP version of Interlocked*.
 AtomicHelper::AtomicHelper(CallInst *CI, OP::OpCode op, Value *h, Value *bufIdx,
                            Value *baseOffset)
-    : opcode(op), handle(h), originalValue(nullptr), addr(bufIdx),
-      offset(baseOffset) {
+    : opcode(op), handle(h), addr(bufIdx),
+      offset(baseOffset), originalValue(nullptr) {
   if (op == OP::OpCode::AtomicCompareExchange) {
     compareValue =
         CI->getArgOperand(HLOperandIndex::kInterlockedCmpCompareValueOpIndex);

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -207,18 +207,18 @@ struct RegisterAssignment : public UnusualAnnotation
 {
   /// <summary>Initializes a new RegisterAssignment in invalid state.</summary>
   RegisterAssignment() : UnusualAnnotation(UA_RegisterAssignment),
-    ShaderProfile(),
-    RegisterType(0), RegisterNumber(0), RegisterSpace(0), RegisterOffset(0), IsValid(false)
+    ShaderProfile(), IsValid(false),
+    RegisterType(0), RegisterNumber(0), RegisterSpace(0), RegisterOffset(0)
   {
   }
 
   RegisterAssignment(const RegisterAssignment& other) : UnusualAnnotation(UA_RegisterAssignment, other.Loc),
     ShaderProfile(other.ShaderProfile),
+    IsValid(other.IsValid),
     RegisterType(other.RegisterType),
     RegisterNumber(other.RegisterNumber),
-    RegisterOffset(other.RegisterOffset),
     RegisterSpace(other.RegisterSpace),
-    IsValid(other.IsValid)
+    RegisterOffset(other.RegisterOffset)
   {
   }
 

--- a/tools/clang/include/clang/Frontend/ASTUnit.h
+++ b/tools/clang/include/clang/Frontend/ASTUnit.h
@@ -194,6 +194,7 @@ private:
 
 public:
   hlsl::DxcLangExtensionsHelperApply *HlslLangExtensions; // HLSL Change
+
   class PreambleData {
     const FileEntry *File;
     std::vector<char> Buffer;

--- a/tools/clang/lib/Frontend/ASTUnit.cpp
+++ b/tools/clang/lib/Frontend/ASTUnit.cpp
@@ -222,13 +222,13 @@ ASTUnit::ASTUnit(bool _MainFileIsAST)
     OwnsRemappedFileBuffers(true),
     NumStoredDiagnosticsFromDriver(0),
     PreambleRebuildCounter(0),
+    HlslLangExtensions(nullptr),    // HLSL Change
     NumWarningsInPreamble(0),
     ShouldCacheCodeCompletionResults(false),
     IncludeBriefCommentsInCodeCompletion(false), UserFilesAreVolatile(false),
     CompletionCacheTopLevelHashValue(0),
     PreambleTopLevelHashValue(0),
     CurrentTopLevelHashValue(0),
-    HlslLangExtensions(nullptr),    // HLSL Change
     UnsafeToFree(false) { 
   if (getenv("LIBCLANG_OBJTRACKING"))
     fprintf(stderr, "+++ %u translation units\n", ++ActiveASTUnitObjects);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -1640,7 +1640,7 @@ public:
 
 public:
   UsedIntrinsic(const HLSL_INTRINSIC* intrinsicSource, _In_count_(argCount) QualType* args, size_t argCount)
-    : m_intrinsicSource(intrinsicSource), m_argLength(argCount), m_functionDecl(nullptr)
+    : m_argLength(argCount), m_intrinsicSource(intrinsicSource), m_functionDecl(nullptr)
   {
     std::copy(args, args + argCount, m_args);
   }
@@ -2067,8 +2067,9 @@ private:
     StringRef typeName,
     StringRef functionName,
     unsigned argCount) :
-    _tables(tables), _typeName(typeName), _functionName(functionName), _argCount(argCount),
-    _tableIndex(0), _tableLookupCookie(0), _tableIntrinsic(nullptr), _firstChecked(false)
+    _typeName(typeName), _functionName(functionName), _tables(tables),
+    _tableIntrinsic(nullptr), _tableLookupCookie(0), _tableIndex(0),
+    _argCount(argCount), _firstChecked(false)
   {
   }
 
@@ -2276,8 +2277,9 @@ namespace hlsl {
   public:
     FnReferenceVisitor(FunctionSet &visitedFunctions,
       PendingFunctions &pendingFunctions, CallNodes &callNodes)
-      : m_visitedFunctions(visitedFunctions),
-      m_pendingFunctions(pendingFunctions), m_callNodes(callNodes) {}
+      : m_callNodes(callNodes),
+      m_visitedFunctions(visitedFunctions),
+      m_pendingFunctions(pendingFunctions) {}
 
     void setSourceFn(FunctionDecl *F) {
       F = getFunctionWithBody(F);
@@ -2907,10 +2909,10 @@ private:
 
 public:
   HLSLExternalSource() :
-    m_context(nullptr),
-    m_sema(nullptr),
+    m_matrixTemplateDecl(nullptr),
     m_vectorTemplateDecl(nullptr),
-    m_matrixTemplateDecl(nullptr)
+    m_context(nullptr),
+    m_sema(nullptr)
   {
     memset(m_matrixTypes, 0, sizeof(m_matrixTypes));
     memset(m_matrixShorthandTypes, 0, sizeof(m_matrixShorthandTypes));
@@ -4179,13 +4181,14 @@ private:
     MultiExprArg::iterator CurrentExpr;       // Current expression (advanceable for a list of expressions).
     MultiExprArg::iterator EndExpr;           // STL-style end of expressions.
     FlattenedIterKind IterKind;               // Kind of tracker.
+
     FlattenedTypeTracker(QualType type) : Type(type), Count(0), CurrentExpr(nullptr), IterKind(FK_IncompleteArray) {}
     FlattenedTypeTracker(QualType type, unsigned int count, MultiExprArg::iterator expression) :
         Type(type), Count(count), CurrentExpr(expression), IterKind(FK_Simple) {}
     FlattenedTypeTracker(QualType type, RecordDecl::field_iterator current, RecordDecl::field_iterator end)
-      : Type(type), CurrentField(current), EndField(end), Count(0), CurrentExpr(nullptr), IterKind(FK_Fields) {}
+      : Type(type), Count(0), CurrentField(current), EndField(end), CurrentExpr(nullptr), IterKind(FK_Fields) {}
     FlattenedTypeTracker(MultiExprArg::iterator current, MultiExprArg::iterator end)
-      : CurrentExpr(current), EndExpr(end), Count(0), IterKind(FK_Expressions) {}
+      : Count(0), CurrentExpr(current), EndExpr(end), IterKind(FK_Expressions) {}
 
     /// <summary>Gets the current expression if one is available.</summary>
     Expr* getExprOrNull() const { return CurrentExpr ? *CurrentExpr : nullptr; }
@@ -9005,7 +9008,7 @@ void hlsl::InitializeASTContextForHLSL(ASTContext& context)
 
 /// <summary>Constructs a FlattenedTypeIterator for the specified type.</summary>
 FlattenedTypeIterator::FlattenedTypeIterator(SourceLocation loc, QualType type, HLSLExternalSource& source) :
-  m_source(source), m_typeDepth(0), m_loc(loc), m_draining(false), m_springLoaded(false), m_incompleteCount(0)
+  m_source(source), m_draining(false), m_springLoaded(false), m_incompleteCount(0), m_typeDepth(0), m_loc(loc)
 {
   if (pushTrackerForType(type, nullptr)) {
     considerLeaf();
@@ -9014,7 +9017,7 @@ FlattenedTypeIterator::FlattenedTypeIterator(SourceLocation loc, QualType type, 
 
 /// <summary>Constructs a FlattenedTypeIterator for the specified expressions.</summary>
 FlattenedTypeIterator::FlattenedTypeIterator(SourceLocation loc, MultiExprArg args, HLSLExternalSource& source) :
-  m_source(source), m_typeDepth(0), m_loc(loc), m_draining(false), m_springLoaded(false), m_incompleteCount(0)
+  m_source(source), m_draining(false), m_springLoaded(false), m_incompleteCount(0), m_typeDepth(0), m_loc(loc)
 {
   if (!args.empty()) {
     MultiExprArg::iterator ii = args.begin();
@@ -10142,8 +10145,8 @@ HLSLBufferDecl::HLSLBufferDecl(
     std::vector<hlsl::UnusualAnnotation *> &BufferAttributes,
     SourceLocation LBrace)
     : NamedDecl(Decl::HLSLBuffer, DC, IdLoc, DeclarationName(Id)),
-      DeclContext(Decl::HLSLBuffer), IsCBuffer(cbuffer),
-      IsConstantBufferView(cbufferView), KwLoc(KwLoc), LBraceLoc(LBrace) {
+      DeclContext(Decl::HLSLBuffer), LBraceLoc(LBrace), KwLoc(KwLoc),
+      IsCBuffer(cbuffer), IsConstantBufferView(cbufferView) {
   if (!BufferAttributes.empty()) {
     setUnusualAnnotations(UnusualAnnotation::CopyToASTContextArray(
         getASTContext(), BufferAttributes.data(), BufferAttributes.size()));

--- a/tools/clang/lib/Sema/SemaInit.cpp
+++ b/tools/clang/lib/Sema/SemaInit.cpp
@@ -711,7 +711,7 @@ InitListChecker::InitListChecker(Sema &S, const InitializedEntity &Entity,
                                  const InitializationKind &K,    // HLSL Change - add K
                                  InitListExpr *IL, QualType &T,
                                  bool VerifyOnly)
-  : SemaRef(S), VerifyOnly(VerifyOnly), Kind(K) { // HLSL Change - add Kind
+  : SemaRef(S), Kind(K), VerifyOnly(VerifyOnly) { // HLSL Change - add Kind
   // FIXME: Check that IL isn't already the semantic form of some other
   // InitListExpr. If it is, we'd create a broken AST.
 

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -166,9 +166,10 @@ namespace {
 
   public:
     TypeProcessingState(Sema &sema, Declarator &declarator, Scope* S = nullptr) // HLSL Change: add Scope
-      : sema(sema), declarator(declarator), scope(S), // HLSL Change: add Scope
+      : sema(sema), declarator(declarator),
         chunkIndex(declarator.getNumTypeObjects()),
-        trivial(true), hasSavedAttrs(false) {}
+        trivial(true), hasSavedAttrs(false),
+        scope(S) {} // HLSL Change: add Scope
 
     // HLSL Change: add getScope
     Scope* getScope() const {


### PR DESCRIPTION
This solves compiler warnings given `-Wreorder`.

cc @dneto@ @ehsannas