### PR TITLE
Add default virtual destructors for virtual classes

### DIFF
--- a/include/dxc/HLSL/DxilMetadataHelper.h
+++ b/include/dxc/HLSL/DxilMetadataHelper.h
@@ -219,6 +219,7 @@ public:
   class ExtraPropertyHelper {
   public:
     ExtraPropertyHelper(llvm::Module *pModule);
+    virtual ~ExtraPropertyHelper() {}
 
     virtual void EmitSRVProperties(const DxilResource &SRV, std::vector<llvm::Metadata *> &MDVals) = 0;
     virtual void LoadSRVProperties(const llvm::MDOperand &MDO, DxilResource &SRV) = 0;
@@ -372,6 +373,7 @@ private:
 class DxilExtraPropertyHelper : public DxilMDHelper::ExtraPropertyHelper {
 public:
   DxilExtraPropertyHelper(llvm::Module *pModule);
+  virtual ~DxilExtraPropertyHelper() {}
 
   virtual void EmitSRVProperties(const DxilResource &SRV, std::vector<llvm::Metadata *> &MDVals);
   virtual void LoadSRVProperties(const llvm::MDOperand &MDO, DxilResource &SRV);

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -322,6 +322,7 @@ private:
 class HLExtraPropertyHelper : public DxilExtraPropertyHelper {
 public:
   HLExtraPropertyHelper(llvm::Module *pModule);
+  virtual ~HLExtraPropertyHelper() {}
 
   virtual void EmitSignatureElementProperties(const DxilSignatureElement &SE, std::vector<llvm::Metadata *> &MDVals);
   virtual void LoadSignatureElementProperties(const llvm::MDOperand &MDO, DxilSignatureElement &SE);

--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -87,6 +87,9 @@ public:
 
     ArgumentType(Type *ty, int cnt = 1) : type(ty), count(cnt) {}
   };
+
+  virtual ~FunctionTypeTranslator() {}
+
   virtual Type *TranslateReturnType(CallInst *CI) = 0;
   virtual ArgumentType TranslateArgumentType(Value *OrigArg) = 0;
 };

--- a/tools/clang/include/clang/Frontend/CompilerInstance.h
+++ b/tools/clang/include/clang/Frontend/CompilerInstance.h
@@ -32,6 +32,8 @@ namespace hlsl {
   class DxcLangExtensionsHelper;
   class DxcLangExtensionsHelperApply {
   public:
+    virtual ~DxcLangExtensionsHelperApply() {}
+
     virtual void SetupSema(clang::Sema &S) = 0;
     virtual void SetupPreprocessorOptions(clang::PreprocessorOptions &PPOpts) = 0;
     virtual DxcLangExtensionsHelper *GetDxcLangExtensionsHelper() = 0;


### PR DESCRIPTION
This fixes compiler warnings generated by -Wnon-virtual-dtor.

cc @dneto0 @ehsannas