### PR TITLE
Remove unnecessary const qualifier on return type

### DIFF
--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -74,7 +74,7 @@ public:
   static OpCode GetDxilOpFuncCallInst(const llvm::Instruction *I);
   static const char *GetOpCodeName(OpCode OpCode);
   static const char *GetAtomicOpName(DXIL::AtomicBinOpCode OpCode);
-  static const OpCodeClass GetOpCodeClass(OpCode OpCode);
+  static OpCodeClass GetOpCodeClass(OpCode OpCode);
   static const char *GetOpCodeClassName(OpCode OpCode);
   static bool IsOverloadLegal(OpCode OpCode, llvm::Type *pType);
   static bool CheckOpCodeTable();

--- a/include/dxc/HLSL/DxilTypeSystem.h
+++ b/include/dxc/HLSL/DxilTypeSystem.h
@@ -122,7 +122,7 @@ enum class DxilParamInputQual {
 class DxilParameterAnnotation : public DxilFieldAnnotation {
 public:
   DxilParameterAnnotation();
-  const DxilParamInputQual GetParamInputQual() const;
+  DxilParamInputQual GetParamInputQual() const;
   void SetParamInputQual(DxilParamInputQual qual);
   const std::vector<unsigned> &GetSemanticIndexVec() const;
   void SetSemanticIndexVec(const std::vector<unsigned> &Vec);

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -299,7 +299,7 @@ const char *OP::GetAtomicOpName(DXIL::AtomicBinOpCode OpCode) {
   return AtomicBinOpCodeName[static_cast<unsigned>(OpCode)];
 }
 
-const OP::OpCodeClass OP::GetOpCodeClass(OpCode OpCode) {
+OP::OpCodeClass OP::GetOpCodeClass(OpCode OpCode) {
   DXASSERT(0 <= (unsigned)OpCode && OpCode < OpCode::NumOpCodes, "otherwise caller passed OOB index");
   return m_OpCodeProps[(unsigned)OpCode].OpCodeClass;
 }

--- a/lib/HLSL/DxilTypeSystem.cpp
+++ b/lib/HLSL/DxilTypeSystem.cpp
@@ -99,7 +99,7 @@ DxilParameterAnnotation::DxilParameterAnnotation()
 : m_inputQual(DxilParamInputQual::In), DxilFieldAnnotation() {
 }
 
-const DxilParamInputQual DxilParameterAnnotation::GetParamInputQual() const {
+DxilParamInputQual DxilParameterAnnotation::GetParamInputQual() const {
   return m_inputQual;
 }
 void DxilParameterAnnotation::SetParamInputQual(DxilParamInputQual qual) {


### PR DESCRIPTION
This solves compiler warnings given by -Wignored-qualifiers.

@dneto0 @ehsannas