### PR TITLE
Declare clang::Sema before referencing it

### DIFF
--- a/tools/clang/include/clang/Frontend/CompilerInstance.h
+++ b/tools/clang/include/clang/Frontend/CompilerInstance.h
@@ -27,20 +27,6 @@
 #include <string>
 #include <utility>
 
-// HLSL Change Starts
-namespace hlsl {
-  class DxcLangExtensionsHelper;
-  class DxcLangExtensionsHelperApply {
-  public:
-    virtual ~DxcLangExtensionsHelperApply() {}
-
-    virtual void SetupSema(clang::Sema &S) = 0;
-    virtual void SetupPreprocessorOptions(clang::PreprocessorOptions &PPOpts) = 0;
-    virtual DxcLangExtensionsHelper *GetDxcLangExtensionsHelper() = 0;
-  };
-}
-// HLSL Change Ends
-
 namespace llvm {
 class raw_fd_ostream;
 class Timer;
@@ -63,7 +49,23 @@ class Preprocessor;
 class Sema;
 class SourceManager;
 class TargetInfo;
+}
 
+// HLSL Change Starts
+namespace hlsl {
+  class DxcLangExtensionsHelper;
+  class DxcLangExtensionsHelperApply {
+  public:
+    virtual ~DxcLangExtensionsHelperApply() {}
+
+    virtual void SetupSema(clang::Sema &S) = 0;
+    virtual void SetupPreprocessorOptions(clang::PreprocessorOptions &PPOpts) = 0;
+    virtual DxcLangExtensionsHelper *GetDxcLangExtensionsHelper() = 0;
+  };
+}
+// HLSL Change Ends
+
+namespace clang {
 /// CompilerInstance - Helper class for managing a single instance of the Clang
 /// compiler.
 ///


### PR DESCRIPTION
`DxcLangExtensionsHelperApply` uses `clang::Sema`, which was declared after it.

@dneto0 @ehsannas