### PR TITLE
Fix dbg info for temp variable.

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -286,6 +286,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.OptDump = Args.hasFlag(OPT_Odump, OPT_INVALID, false);
 
   opts.DisableOptimizations = Args.hasFlag(OPT_Od, OPT_INVALID, false);
+  if (opts.DisableOptimizations)
+    opts.OptLevel = 0;
 
   opts.DisableValidation = Args.hasFlag(OPT_VD, OPT_INVALID, false);
 

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -2803,6 +2803,10 @@ Function *StripFunctionParameter(Function *F, DxilModule &DM,
   for (auto &arg : F->args()) {
     if (!arg.user_empty())
       return nullptr;
+    DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(&arg);
+    if (DDI) {
+      DDI->eraseFromParent();
+    }
   }
 
   Function *NewFunc = Function::Create(FT, F->getLinkage(), F->getName());

--- a/tools/clang/lib/CodeGen/CGCall.cpp
+++ b/tools/clang/lib/CodeGen/CGCall.cpp
@@ -2429,6 +2429,18 @@ void CodeGenFunction::EmitFunctionEpilog(const CGFunctionInfo &FI,
   case ABIArgInfo::Direct:
     if (RetAI.getCoerceToType() == ConvertType(RetTy) &&
         RetAI.getDirectOffset() == 0) {
+      // HLSL Change Begin.
+      // If optimization is disabled, just load return value.
+      if (CGM.getCodeGenOpts().DisableLLVMOpts) {
+        // HLSL Change Begins
+        if (hlsl::IsHLSLMatType(RetTy))
+          RV = CGM.getHLSLRuntime().EmitHLSLMatrixLoad(*this, ReturnValue,
+                                                       RetTy);
+        else
+          // HLSL Change Ends
+          RV = Builder.CreateLoad(ReturnValue);
+      } else {
+      // HLSL Change End.
       // The internal return value temp always will have pointer-to-return-type
       // type, just do a load.
 
@@ -2461,6 +2473,7 @@ void CodeGenFunction::EmitFunctionEpilog(const CGFunctionInfo &FI,
           // HLSL Change Ends
           RV = Builder.CreateLoad(ReturnValue);
       }
+      } // HLSL Change
     } else {
       llvm::Value *V = ReturnValue;
       CharUnits Align = getContext().getTypeAlignInChars(RetTy);

--- a/tools/clang/test/CodeGenHLSL/BasicHLSL11_PS2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/BasicHLSL11_PS2.hlsl
@@ -18,13 +18,6 @@
 // Output.d
 // CHECK: llvm.dbg.declare(metadata float* %3
 
-// CHECK: DILocalVariable(tag: DW_TAG_arg_variable, name: "main.Ret"
-// CHECK: DIExpression(DW_OP_bit_piece, 0, 16)
-// CHECK: DIExpression(DW_OP_bit_piece, 16, 4)
-
-// CHECK: DILocalVariable(tag: DW_TAG_arg_variable, name: "Input"
-// CHECK: DIExpression(DW_OP_bit_piece, 0, 12)
-// CHECK: DIExpression(DW_OP_bit_piece, 12, 8)
 // CHECK: DILocalVariable(tag: DW_TAG_auto_variable, name: "vDiffuse"
 // CHECK: DILocalVariable(tag: DW_TAG_auto_variable, name: "fLighting"
 // CHECK: DILocalVariable(tag: DW_TAG_auto_variable, name: "Output"

--- a/tools/clang/test/CodeGenHLSL/BasicHLSL11_PS2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/BasicHLSL11_PS2.hlsl
@@ -9,16 +9,13 @@
 // CHECK: g_txDiffuse_texture_2d
 // CHECK: g_samLinear_sampler
 
-// CHECK: llvm.dbg.declare(metadata <4 x float>* %2
-// CHECK: llvm.dbg.declare(metadata float* %3
-
-// CHECK: llvm.dbg.declare(metadata <3 x float>* %0
-// CHECK: llvm.dbg.declare(metadata <2 x float>* %1
 
 // CHECK: llvm.dbg.declare(metadata [4 x float]* %vDiffuse
 // CHECK: llvm.dbg.declare(metadata float* %fLighting
 
+// Output.c
 // CHECK: llvm.dbg.declare(metadata <4 x float>* %2
+// Output.d
 // CHECK: llvm.dbg.declare(metadata float* %3
 
 // CHECK: DILocalVariable(tag: DW_TAG_arg_variable, name: "main.Ret"

--- a/tools/clang/test/CodeGenHLSL/temp_dbg_info.hlsl
+++ b/tools/clang/test/CodeGenHLSL/temp_dbg_info.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -E main -T ps_6_0 -Od -Zi %s | FileCheck %s
+
+// CHECK: llvm.dbg.declare
+
+float4 main(float4 c : C) : SV_TARGET {
+       float4 a = c;
+       return a;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -553,6 +553,7 @@ public:
   TEST_METHOD(CodeGenSwizzleAtomic)
   TEST_METHOD(CodeGenSwizzleAtomic2)
   TEST_METHOD(CodeGenSwizzleIndexing)
+  TEST_METHOD(CodeGenTempDbgInfo)
   TEST_METHOD(CodeGenTemp1)
   TEST_METHOD(CodeGenTemp2)
   TEST_METHOD(CodeGenTexSubscript)
@@ -3025,6 +3026,10 @@ TEST_F(CompilerTest, CodeGenTemp1) {
 
 TEST_F(CompilerTest, CodeGenTemp2) {
   CodeGenTest(L"..\\CodeGenHLSL\\temp2.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenTempDbgInfo) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\temp_dbg_info.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenTexSubscript) {


### PR DESCRIPTION
1. Remove debug info when strip function parameter from entry function.
2. Set OptLevel to 0 for -Od.
3. If optimization is disabled, always load ReturnValue.