### PR TITLE
Add WaveActiveOp execution test

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -374,7 +374,7 @@
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="WaveIntrinsics" CS="CS" DispatchX="8" DispatchY="8">
+  <ShaderOp Name="WaveIntrinsicsOp" CS="CS" DispatchX="1" DispatchY="1">
     <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
     <Resource Name="SWaveIntrinsicsOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
     <RootValues>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -374,6 +374,19 @@
     </Shader>
   </ShaderOp>
 
+  <ShaderOp Name="WaveIntrinsics" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="SWaveIntrinsicsOp" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SWaveIntrinsicsOp"/>
+    </RootValues>
+    <Shader Name="CS" Target="cs_6_0">
+      <![CDATA[
+      void main(uint GI : SV_GroupIndex) {};
+      ]]>
+    </Shader>
+  </ShaderOp>
+
   <ShaderOp Name="Triangle" PS="PS" VS="VS">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)</RootSignature>
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3807,13 +3807,13 @@ void ExecutionTest::WaveIntrinsicsActiveTest(
       T2 output;
   };
 
-  int NumThreadsX = 8;
-  int NumThreadsY = 12;
-  int NumThreadsZ = 1;
+  unsigned int NumThreadsX = 8;
+  unsigned int NumThreadsY = 12;
+  unsigned int NumThreadsZ = 1;
 
-  static const int ThreadsPerGroup = NumThreadsX * NumThreadsY * NumThreadsZ;
-  static const int DispatchGroupCount = 1;
-  static const int ThreadCount = ThreadsPerGroup * DispatchGroupCount;
+  static const unsigned int ThreadsPerGroup = NumThreadsX * NumThreadsY * NumThreadsZ;
+  static const unsigned int DispatchGroupCount = 1;
+  static const unsigned int ThreadCount = ThreadsPerGroup * DispatchGroupCount;
   CComPtr<IStream> pStream;
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
@@ -3859,7 +3859,7 @@ void ExecutionTest::WaveIntrinsicsActiveTest(
         Data.resize(size);
         PerThreadData *pPrimitives = (PerThreadData*)Data.data();
         // 4 different inputs for each operation test
-        int index = 0;
+        size_t index = 0;
         while (index < ThreadCount) {
           PerThreadData *p = &pPrimitives[index];
           DataArray *IntList = InputList[setIndex];

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -201,11 +201,12 @@ public:
   TEST_METHOD(SaturateTest);
   TEST_METHOD(SignTest);
   TEST_METHOD(Int64Test);
+  TEST_METHOD(WaveIntrinsicsTest);
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(PartialDerivTest);
 
-  BEGIN_TEST_METHOD(WaveIntrinsicsAllIntTest)
-    TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsAllIntTable")
+  BEGIN_TEST_METHOD(WaveIntrinsicsActiveIntTest)
+    TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveIntTable")
   END_TEST_METHOD()
 
   // TAEF data-driven tests.
@@ -1511,13 +1512,10 @@ struct SPrimitives {
 };
 
 std::shared_ptr<ShaderOpTestResult>
-RunShaderOpTest(ID3D12Device *pDevice, dxc::DxcDllSupport &support,
-                IStream *pStream, LPCSTR pName,
-                st::ShaderOpTest::TInitCallbackFn pInitCallback) {
+RunShaderOpTestAfterParse(ID3D12Device *pDevice, dxc::DxcDllSupport &support,
+  IStream *pStream, LPCSTR pName,
+  st::ShaderOpTest::TInitCallbackFn pInitCallback, std::shared_ptr<st::ShaderOpSet> ShaderOpSet) {
   DXASSERT_NOMSG(pStream != nullptr);
-  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
-      std::make_shared<st::ShaderOpSet>();
-  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
   st::ShaderOp *pShaderOp;
   if (pName == nullptr) {
     if (ShaderOpSet->ShaderOps.size() != 1) {
@@ -1557,6 +1555,17 @@ RunShaderOpTest(ID3D12Device *pDevice, dxc::DxcDllSupport &support,
   result->Test = test;
   result->ShaderOp = pShaderOp;
   return result;
+}
+
+std::shared_ptr<ShaderOpTestResult>
+RunShaderOpTest(ID3D12Device *pDevice, dxc::DxcDllSupport &support,
+                IStream *pStream, LPCSTR pName,
+                st::ShaderOpTest::TInitCallbackFn pInitCallback) {
+  DXASSERT_NOMSG(pStream != nullptr);
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+        std::make_shared<st::ShaderOpSet>();
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+  return RunShaderOpTestAfterParse(pDevice, support, pStream, pName, pInitCallback, ShaderOpSet);
 }
 
 static bool isdenorm(float f) {
@@ -1955,6 +1964,7 @@ static TableParameter BinaryUintOpParameters[] = {
     { L"Validation.Expected1", TableParameter::UINT_TABLE, true },
     { L"Validation.Expected2", TableParameter::UINT_TABLE, false },
     { L"Validation.Tolerance", TableParameter::INT, true },
+
     { L"Validation.NumInput", TableParameter::UINT, true },
     { L"Validation.NumExpected", TableParameter::INT, true },
 };
@@ -1997,13 +2007,14 @@ static TableParameter Msad4OpParameters[] = {
     { L"Validation.Expected", TableParameter::STRING_TABLE, true }
 };
 
-static TableParameter WaveIntrinsicsParameters[] = {
+static TableParameter WaveIntrinsicsActiveIntParameters[] = {
+    { L"ShaderOp.Name", TableParameter::STRING, true },
     { L"ShaderOp.Text", TableParameter::STRING, true },
-    { L"Validation.Tolerance", TableParameter::DOUBLE, true },
-    { L"Validaiton.InputType", TableParameter::STRING, true },
-    { L"Validaiton.ExpctedType", TableParameter::STRING, true },
-    { L"Validaiton.Input", TableParameter::STRING_TABLE, true },
-    { L"Validation.Expected", TableParameter::STRING_TABLE, true }
+    { L"Validation.NumInputSet", TableParameter::UINT, true },
+    { L"Validation.InputSet1", TableParameter::INT_TABLE, true },
+    { L"Validation.InputSet2", TableParameter::INT_TABLE, false },
+    { L"Validation.InputSet3", TableParameter::INT_TABLE, false },
+    { L"Validation.InputSet4", TableParameter::INT_TABLE, false }
 };
 
 static HRESULT ParseDataToFloat(PCWSTR str, float &value) {
@@ -2286,7 +2297,7 @@ TEST_F(ExecutionTest, BinaryFloatOpTest) {
     int tableSize = sizeof(BinaryFPOpParameters) / sizeof(TableParameter);
     VERIFY_SUCCEEDED(ParseTableRow(BinaryFPOpParameters, tableSize));
     TableParameterHandler handler(BinaryFPOpParameters, tableSize);
-    
+
     st::ShaderOpShader shader;
 
     CW2A Name(handler.GetTableParamByName(L"ShaderOp.Name")->m_str);
@@ -2527,8 +2538,8 @@ TEST_F(ExecutionTest, UnaryUintOpTest) {
     }
     // Read data from the table
 
-    int tableSize = sizeof(UnaryUintOpParameters) / sizeof(TableParameter); 
-    VERIFY_SUCCEEDED(ParseTableRow(UnaryUintOpParameters, tableSize)); 
+    int tableSize = sizeof(UnaryUintOpParameters) / sizeof(TableParameter);
+    VERIFY_SUCCEEDED(ParseTableRow(UnaryUintOpParameters, tableSize));
     TableParameterHandler handler(UnaryUintOpParameters, tableSize);
 
     st::ShaderOpShader shader;
@@ -2773,7 +2784,6 @@ TEST_F(ExecutionTest, BinaryUintOpTest) {
     size_t tableSize = sizeof(BinaryUintOpParameters) / sizeof(TableParameter);
     VERIFY_SUCCEEDED(ParseTableRow(BinaryUintOpParameters, tableSize));
     TableParameterHandler handler(BinaryUintOpParameters, tableSize);
-    ;
 
     st::ShaderOpShader shader;
 
@@ -3106,251 +3116,632 @@ TEST_F(ExecutionTest, Msad4Test) {
     }
 }
 
-TEST_F(ExecutionTest, WaveIntrinsicsAllIntTest) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-  typedef SUnaryIntOp PerThreadData;
+// Virtual class to compute the expected result given a set of inputs
 
-  int NumThreadsX = 8; 
+template <class T1, class T2>
+class ExpectedCalculator {
+public:
+    virtual T2 computeExpected(std::vector<int> &vec) = 0;
+    virtual ~ExpectedCalculator() {};
+};
+
+template <class T1, class T2>
+class WaveActiveSumCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<int> &vec) {
+    T2 sum = 0;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      sum += vec.at(i);
+    }
+    return sum;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveProductCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 prod = 1;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      prod *= vec.at(i);
+    }
+    return prod;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveCountBitsCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 count = 0;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) > 3) {
+        count++;
+      }
+    }
+    return count;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveMaxCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 maximum = std::numeric_limits<T2>::min();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) > maximum)
+        maximum = vec.at(i);
+    }
+    return maximum;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveMinCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 minimum = std::numeric_limits<T2>::max();
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) < minimum)
+        minimum = vec.at(i);
+    }
+    return minimum;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveBitOrCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 bits = 0x00000000;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) < bits)
+        bits |= vec.at(i);
+    }
+    return bits;
+  }
+};
+
+template <class T1, class T2>
+class WaveActiveBitAndCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 bits = 0xffffffff;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) < bits)
+        bits &= vec.at(i);
+    }
+    return bits;
+  }
+};;
+
+template <class T1, class T2>
+class WaveActiveBitXorCalculator : public ExpectedCalculator<T1, T2> {
+public:
+  T2 computeExpected(std::vector<T1> &vec) {
+    T2 bits = 0x00000000;
+    for (size_t i = 0; i < vec.size(); ++i) {
+      if (vec.at(i) < bits)
+        bits ^= vec.at(i);
+    }
+    return bits;
+  }
+};
+
+template <class T1, class T2>
+struct CalculatorLookupPair {
+    PCWSTR name;
+    ExpectedCalculator<T1,T2> *calculator;
+};
+
+static WaveActiveSumCalculator<int, int> WaveActiveSumCalculatorInt;
+static WaveActiveProductCalculator<int, int> WaveActiveProdCalculatorInt;
+static WaveActiveCountBitsCalculator<int, int> WaveActiveCountBitsCalculatorInt;
+static WaveActiveMaxCalculator<int, int> WaveActiveMaxCalculatorInt;
+static WaveActiveMinCalculator<int, int> WaveActiveMinCalculatorInt;
+static WaveActiveBitOrCalculator<int, int> WaveActiveBitOrCalculatorInt;
+static WaveActiveBitAndCalculator<int, int> WaveActiveBitAndCalculatorInt;
+static WaveActiveBitXorCalculator<int, int> WaveActiveBitXorCalculatorInt;
+
+static CalculatorLookupPair<int, int> WaveIntrinsicsActiveIntCalculatorLookup[] = {
+    { L"WaveActiveSum", &WaveActiveSumCalculatorInt },
+    { L"WaveActiveProduct", &WaveActiveProdCalculatorInt },
+    { L"WaveActiveCountBits", &WaveActiveCountBitsCalculatorInt },
+    { L"WaveActiveMax", &WaveActiveMaxCalculatorInt },
+    { L"WaveActiveMin", &WaveActiveMinCalculatorInt },
+    { L"WaveActiveBitOr", &WaveActiveBitOrCalculatorInt },
+    { L"WaveActiveBitAnd", &WaveActiveBitAndCalculatorInt },
+    { L"WaveActiveBitXor", &WaveActiveBitXorCalculatorInt }
+};
+
+template <class T1, class T2>
+class ExpectedLookupHandler {
+private:
+    size_t m_size;
+    CalculatorLookupPair<T1,T2> *m_table;
+public:
+    ExpectedCalculator<T1, T2> *GetExpectedCalcFunc(PCWSTR name) {
+        for (size_t i = 0; i < m_size; ++i) {
+            if (_wcsicmp(name, m_table[i].name) == 0) {
+                return m_table[i].calculator;
+            }
+        }
+        DXASSERT(false, "Invalid Expected Calculation lookup %s", name);
+        return nullptr;
+    }
+    ExpectedLookupHandler(CalculatorLookupPair<T1, T2> *pTable, size_t size) : m_table(pTable), m_size(size) {}
+};
+
+TEST_F(ExecutionTest, WaveIntrinsicsActiveIntTest) {
+  WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+  // Resource representation for compute shader
+  // firstLaneId is used to group different waves
+  struct PerThreadData {
+      int id;
+      int firstLaneId;
+      int input;
+      int output;
+  };
+
+  int NumThreadsX = 8;
   int NumThreadsY = 8;
   int NumThreadsZ = 1;
 
   static const int ThreadsPerGroup = NumThreadsX * NumThreadsY * NumThreadsZ;
   static const int DispatchGroupCount = 1;
-  static const int count = ThreadsPerGroup * DispatchGroupCount;
+  static const int ThreadCount = ThreadsPerGroup * DispatchGroupCount;
+  CComPtr<IStream> pStream;
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
   CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice))
+  if (!CreateDevice(&pDevice)) {
     return;
-
+  }
   if (!DoesDeviceSupportWaveOps(pDevice)) {
     // Optional feature, so it's correct to not support it if declared as such.
     WEX::Logging::Log::Comment(L"Device does not support wave operations.");
     return;
   }
+  size_t tableSize = sizeof(WaveIntrinsicsActiveIntParameters) / sizeof(TableParameter);
+  VERIFY_SUCCEEDED(ParseTableRow(WaveIntrinsicsActiveIntParameters, tableSize));
+  TableParameterHandler handler(WaveIntrinsicsActiveIntParameters, tableSize);
 
-  size_t tableSize = sizeof(WaveIntrinsicsParameters) / sizeof(TableParameter);
-  VERIFY_SUCCEEDED(ParseTableRow(WaveIntrinsicsParameters, tableSize));
-  TableParameterHandler handler(WaveIntrinsicsParameters, tableSize);
 
-  WEX::TestExecution::TestDataArray<int> *Validation_Input1 =
-    &handler.GetTableParamByName(L"Validation.Input1")->m_intTable;
-  WEX::TestExecution::TestDataArray<int> *Validation_Input2 =
-    &handler.GetTableParamByName(L"Validation.Input2")->m_intTable;
-  WEX::TestExecution::TestDataArray<int> *Validation_Input3 =
-    &handler.GetTableParamByName(L"Validation.Input3")->m_intTable;
-  WEX::TestExecution::TestDataArray<int> *Validation_Input4 =
-    &handler.GetTableParamByName(L"Validation.Input4")->m_intTable;
+  unsigned int numInputSet = handler.GetTableParamByName(L"Validation.NumInputSet")->m_uint;
+
+  // Obtain the list of input lists
+
+  typedef WEX::TestExecution::TestDataArray<int> DataArrayInt;
+  std::vector<DataArrayInt *> InputList;
+  for (unsigned int i = 0;
+      i < numInputSet; ++i) {
+      std::wstring inputName = L"Validation.InputSet";
+      inputName.append(std::to_wstring(i+1));
+      InputList.push_back(&handler.GetTableParamByName(inputName.c_str())->m_intTable);
+  }
 
   CW2A Text(handler.GetTableParamByName(L"ShaderOp.text")->m_str);
 
-  CComPtr<IStream> pStream;
-  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
-  std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
-    pDevice, m_support, pStream, "S",
-    // this callbacked is called when the test
-    // is creating the resource to run the test
-    [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
-    VERIFY_IS_TRUE(0 == _stricmp(Name, ""));
-    size_t size = sizeof(PerThreadData) * count;
-    Data.resize(size);
-    PerThreadData *pPrimitives = (PerThreadData*)Data.data();
-    for (size_t i = 0; i < count; ++i) {
-      PerThreadData *p = &pPrimitives[i];
-     
-      // Parse data from handler. and assign it to p->input and p->output
-    }
-    // use shader from data table
-    pShaderOp->Shaders.at(0).Text = Text.m_psz;
-  });
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet = std::make_shared<st::ShaderOpSet>();
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
 
+  for (size_t testIndex = 0; testIndex < numInputSet; ++testIndex) {
+      std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
+          pDevice, m_support, pStream, "WaveIntrinsicsOp",
+          // this callbacked is called when the test
+          // is creating the resource to run the test
+          [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+          VERIFY_IS_TRUE(0 == _stricmp(Name, "SWaveIntrinsicsOp"));
+          size_t size = sizeof(PerThreadData) * ThreadCount;
+          Data.resize(size);
+          PerThreadData *pPrimitives = (PerThreadData*)Data.data();
+          // 4 different inputs for each operation test
+          int index = 0;
+          while (index < ThreadCount) {
+              PerThreadData *p = &pPrimitives[index];
+              DataArrayInt *IntList = InputList[testIndex];
+              p->id = index;
+              p->input = (*IntList)[index % IntList->GetSize()];
+              index++;
+          }
+          // use shader from data table
+          pShaderOp->Shaders.at(0).Text = Text.m_psz;
+      }, ShaderOpSet);
 
-  std::vector<PerThreadData> values;
-  values.resize(ThreadsPerGroup * DispatchGroupCount);
-  for (size_t i = 0; i < values.size(); ++i) {
-    memset(&values[i], 0, sizeof(PerThreadData));
-    values[i].input = i;
-  }
+      // Check the value
+      MappedData data;
+      test->Test->GetReadBackData("SWaveIntrinsicsOp", &data);
 
-  // Run the compute shader and copy the results back to readable memory.
-  {
-    D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
-    uavDesc.Format = DXGI_FORMAT_UNKNOWN;
-    uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
-    uavDesc.Buffer.FirstElement = 0;
-    uavDesc.Buffer.NumElements = values.size();
-    uavDesc.Buffer.StructureByteStride = sizeof(PerThreadData);
-    uavDesc.Buffer.CounterOffsetInBytes = 0;
-    uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
-    CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle(pUavHeap->GetCPUDescriptorHandleForHeapStart());
-    CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandleGpu(pUavHeap->GetGPUDescriptorHandleForHeapStart());
-    pDevice->CreateUnorderedAccessView(pUavResource, nullptr, &uavDesc, uavHandle);
-    SetDescriptorHeap(pCommandList, pUavHeap);
-    pCommandList->SetComputeRootSignature(pRootSignature);
-    pCommandList->SetComputeRootDescriptorTable(0, uavHandleGpu);
-  }
-  pCommandList->Dispatch(DispatchGroupX, DispatchGroupY, DispatchGroupZ);
-  RecordTransitionBarrier(pCommandList, pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
-  pCommandList->CopyResource(pReadBuffer, pUavResource);
-  pCommandList->Close();
-  ExecuteCommandList(pCommandQueue, pCommandList);
-  WaitForSignal(pCommandQueue, FO);
-  {
-    MappedData mappedData(pReadBuffer, valueSizeInBytes);
-    PerThreadData *pData = (PerThreadData *)mappedData.data();
-    memcpy(values.data(), pData, valueSizeInBytes);
+      PerThreadData *pPrimitives = (PerThreadData*)data.data();
+      WEX::TestExecution::DisableVerifyExceptions dve;
+      // all outputs are equivalent for WaveIntrinsicsActive operations
 
-    // Gather some general data.
-    // The 'firstLaneId' captures a unique number per first-lane per wave.
-    // Counting the number distinct firstLaneIds gives us the number of waves.
-    std::vector<uint32_t> firstLaneIds;
-    for (size_t i = 0; i < values.size(); ++i) {
-      PerThreadData &pts = values[i];
-      uint32_t firstLaneId = pts.firstLaneId;
-      if (!contains(firstLaneIds, firstLaneId)) {
-        firstLaneIds.push_back(firstLaneId);
+      std::vector<int> firstLaneIds;
+      for (size_t i = 0; i < ThreadCount; ++i) {
+          PerThreadData *p = &pPrimitives[i];
+          int firstLaneId = p->firstLaneId;
+          if (!contains(firstLaneIds, firstLaneId)) {
+              firstLaneIds.push_back(firstLaneId);
+          }
       }
-    }
 
-    // Waves should cover 4 threads or more.
-    LogCommentFmt(L"Found %u distinct lane ids: %u", firstLaneIds.size());
-    if (!dxbc) {
-      VERIFY_IS_GREATER_THAN_OR_EQUAL(values.size() / 4, firstLaneIds.size());
-    }
+      std::map<int, std::unique_ptr<std::vector<PerThreadData *>>> waves;
+      for (size_t i = 0; i < firstLaneIds.size(); ++i) {
+          waves[firstLaneIds.at(i)] = std::make_unique<std::vector<PerThreadData*>>(std::vector<PerThreadData*>());
+      }
 
-    // Now, group threads into waves.
-    std::map<uint32_t, std::unique_ptr<std::vector<PerThreadData *> > > waves;
-    for (size_t i = 0; i < firstLaneIds.size(); ++i) {
-      waves[firstLaneIds[i]] = std::make_unique<std::vector<PerThreadData *> >();
-    }
-    for (size_t i = 0; i < values.size(); ++i) {
-      PerThreadData &pts = values[i];
-      std::unique_ptr<std::vector<PerThreadData *> > &wave = waves[pts.firstLaneId];
-      wave->push_back(&pts);
-    }
+      for (size_t i = 0; i < ThreadCount; ++i) {
+          PerThreadData *p= &pPrimitives[i];
+          waves[p->firstLaneId].get()->push_back(p);
+      }
 
-    // Verify that all the wave values are coherent across the wave.
-    for (size_t i = 0; i < values.size(); ++i) {
-      PerThreadData &pts = values[i];
-      std::unique_ptr<std::vector<PerThreadData *> > &wave = waves[pts.firstLaneId];
-      // Sort the lanes by increasing lane ID.
-      struct LaneIdOrderPred {
-        bool operator()(PerThreadData *a, PerThreadData *b) {
-          return a->laneIndex < b->laneIndex;
+      // Calculate expected value of a given wave inputs using ExpectedResultCalculator
+      ExpectedLookupHandler<int, int> expectedHandler(
+          WaveIntrinsicsActiveIntCalculatorLookup,
+          sizeof(WaveIntrinsicsActiveIntCalculatorLookup) /
+              sizeof(CalculatorLookupPair<int, int>));
+      ExpectedCalculator<int, int> *calculator =
+          expectedHandler.GetExpectedCalcFunc(
+              handler.GetTableParamByName(L"ShaderOp.Name")->m_str);
+
+      for (size_t i = 0; i < firstLaneIds.size(); ++i) {
+        std::vector<PerThreadData *> *data = waves[firstLaneIds.at(i)].get();
+        std::vector<int> outputList(data->size());
+        // collect all inputs for given wave and calculate expected
+        std::wstring str = L"Inputs in this wave: ";
+        for (size_t j = 0; j < data->size(); ++j) {
+          outputList.at(j) = (data->at(j)->input);
+          str.append(std::to_wstring(data->at(j)->input));
+          str.append(L" ");
         }
-      };
-      std::sort(wave.get()->begin(), wave.get()->end(), LaneIdOrderPred());
-
-      // Verify some interesting properties of the first lane.
-      uint32_t pfBC, pfSum, pfProd;
-      int32_t i_pfSum, i_pfProd;
-      int32_t i_allMax, i_allMin;
-      {
-        PerThreadData *ptdFirst = wave->front();
-        VERIFY_IS_TRUE(0 != (ptdFirst->flags & 1)); // FirstLane sets this bit.
-        VERIFY_IS_TRUE(0 == ptdFirst->pfBC);
-        VERIFY_IS_TRUE(0 == ptdFirst->pfSum);
-        VERIFY_IS_TRUE(1 == ptdFirst->pfProd);
-        VERIFY_IS_TRUE(0 == ptdFirst->i_pfSum);
-        VERIFY_IS_TRUE(1 == ptdFirst->i_pfProd);
-        pfBC = (ptdFirst->diver > 3) ? 1 : 0;
-        pfSum = ptdFirst->diver;
-        pfProd = ptdFirst->diver;
-        i_pfSum = ptdFirst->i_diver;
-        i_pfProd = ptdFirst->i_diver;
-        i_allMax = i_allMin = ptdFirst->i_diver;
-      }
-
-      // Calculate values which take into consideration all lanes.
-      uint32_t preds = 0;
-      preds |= 1 << 1; // AllTrue starts true, switches to false if needed.
-      preds |= 1 << 2; // AllEqual starts true, switches to false if needed.
-      preds |= 1 << 3; // WaveActiveAllEqual(GTID.z) is always true
-      preds |= 1 << 4; // (WaveActiveAllEqual(WaveReadLaneFirst(diver)) is always true
-      uint32_t ballot[4] = { 0, 0, 0, 0 };
-      int32_t i_allSum = 0, i_allProd = 1;
-      for (size_t n = 0; n < wave->size(); ++n) {
-        std::vector<PerThreadData *> &lanes = *wave.get();
-        // pts.preds |= ((WaveActiveAnyTrue(diver == 1) ? 1 : 0) << 0);
-        if (lanes[n]->diver == 1) preds |= (1 << 0);
-        // pts.preds |= ((WaveActiveAllTrue(diver == 1) ? 1 : 0) << 1);
-        if (lanes[n]->diver != 1) preds &= ~(1 << 1);
-        // pts.preds |= ((WaveActiveAllEqual(diver) ? 1 : 0) << 2);
-        if (lanes[0]->diver != lanes[n]->diver) preds &= ~(1 << 2);
-        // pts.ballot = WaveActiveBallot(diver > 3);\r\n"
-        if (lanes[n]->diver > 3) {
-          // This is the uint4 result layout:
-          // .x -> bits  0 .. 31
-          // .y -> bits 32 .. 63
-          // .z -> bits 64 .. 95
-          // .w -> bits 96 ..127
-          uint32_t component = lanes[n]->laneIndex / 32;
-          uint32_t bit = lanes[n]->laneIndex % 32;
-          ballot[component] |= 1 << bit;
+        int expected = calculator->computeExpected(outputList);
+        LogCommentFmt(str.data());
+        LogCommentFmt(L"Expected : %d", expected);
+        // In a given wave output should be equivalent for WaveActiveOp
+        for (size_t j = 0; j < data->size(); ++j) {
+          VERIFY_ARE_EQUAL(data->at(j)->output, expected);
         }
-        i_allMax = std::max(lanes[n]->i_diver, i_allMax);
-        i_allMin = std::min(lanes[n]->i_diver, i_allMin);
-        i_allProd *= lanes[n]->i_diver;
-        i_allSum += lanes[n]->i_diver;
       }
-
-      for (size_t n = 1; n < wave->size(); ++n) {
-        // 'All' operations are uniform across the wave.
-        std::vector<PerThreadData *> &lanes = *wave.get();
-        VERIFY_IS_TRUE(0 == (lanes[n]->flags & 1)); // non-firstlanes do not set this bit
-        VERIFY_ARE_EQUAL(lanes[0]->allBC, lanes[n]->allBC);
-        VERIFY_ARE_EQUAL(lanes[0]->allSum, lanes[n]->allSum);
-        VERIFY_ARE_EQUAL(lanes[0]->allProd, lanes[n]->allProd);
-        VERIFY_ARE_EQUAL(lanes[0]->allAND, lanes[n]->allAND);
-        VERIFY_ARE_EQUAL(lanes[0]->allOR, lanes[n]->allOR);
-        VERIFY_ARE_EQUAL(lanes[0]->allXOR, lanes[n]->allXOR);
-        VERIFY_ARE_EQUAL(lanes[0]->allMin, lanes[n]->allMin);
-        VERIFY_ARE_EQUAL(lanes[0]->allMax, lanes[n]->allMax);
-        VERIFY_ARE_EQUAL(i_allMax, lanes[n]->i_allMax);
-        VERIFY_ARE_EQUAL(i_allMin, lanes[n]->i_allMin);
-        VERIFY_ARE_EQUAL(i_allProd, lanes[n]->i_allProd);
-        VERIFY_ARE_EQUAL(i_allSum, lanes[n]->i_allSum);
-
-        // first-lane reads and uniform reads are uniform across the wave.
-        VERIFY_ARE_EQUAL(lanes[0]->firstlaneX, lanes[n]->firstlaneX);
-        VERIFY_ARE_EQUAL(lanes[0]->lane1X, lanes[n]->lane1X);
-
-        // the lane count is uniform across the wave.
-        VERIFY_ARE_EQUAL(lanes[0]->laneCount, lanes[n]->laneCount);
-
-        // The predicates are uniform across the wave.
-        VERIFY_ARE_EQUAL(lanes[n]->preds, preds);
-
-        // the lane index is distinct per thread.
-        for (size_t prior = 0; prior < n; ++prior) {
-          VERIFY_ARE_NOT_EQUAL(lanes[prior]->laneIndex, lanes[n]->laneIndex);
-        }
-        // Ballot results are uniform across the wave.
-        VERIFY_ARE_EQUAL(0, memcmp(ballot, lanes[n]->ballot, sizeof(ballot)));
-
-        // Keep running total of prefix calculation. Prefix values are exclusive to
-        // the executing lane.
-        VERIFY_ARE_EQUAL(pfBC, lanes[n]->pfBC);
-        VERIFY_ARE_EQUAL(pfSum, lanes[n]->pfSum);
-        VERIFY_ARE_EQUAL(pfProd, lanes[n]->pfProd);
-        VERIFY_ARE_EQUAL(i_pfSum, lanes[n]->i_pfSum);
-        VERIFY_ARE_EQUAL(i_pfProd, lanes[n]->i_pfProd);
-        pfBC += (lanes[n]->diver > 3) ? 1 : 0;
-        pfSum += lanes[n]->diver;
-        pfProd *= lanes[n]->diver;
-        i_pfSum += lanes[n]->i_diver;
-        i_pfProd *= lanes[n]->i_diver;
-      }
-      // TODO: add divergent branching and verify that the otherwise uniform values properly diverge
-    }
-
-    // Compare each value of each per-thread element.
-    for (size_t i = 0; i < values.size(); ++i) {
-      PerThreadData &pts = values[i];
-      VERIFY_ARE_EQUAL(i, pts.id); // ID is unchanged.
-    }
   }
 }
 
+TEST_F(ExecutionTest, WaveIntrinsicsTest) {
+    WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+    struct PerThreadData {
+        uint32_t id, flags, laneIndex, laneCount, firstLaneId, preds, firstlaneX, lane1X;
+        uint32_t allBC, allSum, allProd, allAND, allOR, allXOR, allMin, allMax;
+        uint32_t pfBC, pfSum, pfProd;
+        uint32_t ballot[4];
+        uint32_t diver;   // divergent value, used in calculation
+        int32_t i_diver;  // divergent value, used in calculation
+        int32_t i_allMax, i_allMin, i_allSum, i_allProd;
+        int32_t i_pfSum, i_pfProd;
+    };
+    static const char pShader[] =
+        WAVE_INTRINSIC_DXBC_GUARD
+        "struct PerThreadData {\r\n"
+        " uint id, flags, laneIndex, laneCount, firstLaneId, preds, firstlaneX, lane1X;\r\n"
+        " uint allBC, allSum, allProd, allAND, allOR, allXOR, allMin, allMax;\r\n"
+        " uint pfBC, pfSum, pfProd;\r\n"
+        " uint4 ballot;\r\n"
+        " uint diver;\r\n"
+        " int i_diver;\r\n"
+        " int i_allMax, i_allMin, i_allSum, i_allProd;\r\n"
+        " int i_pfSum, i_pfProd;\r\n"
+        "};\r\n"
+        "RWStructuredBuffer<PerThreadData> g_sb : register(u0);\r\n"
+        "[numthreads(8,8,1)]\r\n"
+        "void main(uint GI : SV_GroupIndex, uint3 GTID : SV_GroupThreadID) {"
+        "  PerThreadData pts = g_sb[GI];\r\n"
+        "  uint diver = GTID.x + 2;\r\n"
+        "  pts.diver = diver;\r\n"
+        "  pts.flags = 0;\r\n"
+        "  pts.preds = 0;\r\n"
+        "  if (WaveIsFirstLane()) pts.flags |= 1;\r\n"
+        "  pts.laneIndex = WaveGetLaneIndex();\r\n"
+        "  pts.laneCount = WaveGetLaneCount();\r\n"
+        "  pts.firstLaneId = WaveReadLaneFirst(pts.id);\r\n"
+        "  pts.preds |= ((WaveActiveAnyTrue(diver == 1) ? 1 : 0) << 0);\r\n"
+        "  pts.preds |= ((WaveActiveAllTrue(diver == 1) ? 1 : 0) << 1);\r\n"
+        "  pts.preds |= ((WaveActiveAllEqual(diver) ? 1 : 0) << 2);\r\n"
+        "  pts.preds |= ((WaveActiveAllEqual(GTID.z) ? 1 : 0) << 3);\r\n"
+        "  pts.preds |= ((WaveActiveAllEqual(WaveReadLaneFirst(diver)) ? 1 : 0) << 4);\r\n"
+        "  pts.ballot = WaveActiveBallot(diver > 3);\r\n"
+        "  pts.firstlaneX = WaveReadLaneFirst(GTID.x);\r\n"
+        "  pts.lane1X = WaveReadLaneAt(GTID.x, 1);\r\n"
+        "\r\n"
+        "  pts.allBC = WaveActiveCountBits(diver > 3);\r\n"
+        "  pts.allSum = WaveActiveSum(diver);\r\n"
+        "  pts.allProd = WaveActiveProduct(diver);\r\n"
+        "  pts.allAND = WaveActiveBitAnd(diver);\r\n"
+        "  pts.allOR = WaveActiveBitOr(diver);\r\n"
+        "  pts.allXOR = WaveActiveBitXor(diver);\r\n"
+        "  pts.allMin = WaveActiveMin(diver);\r\n"
+        "  pts.allMax = WaveActiveMax(diver);\r\n"
+        "\r\n"
+        "  pts.pfBC = WavePrefixCountBits(diver > 3);\r\n"
+        "  pts.pfSum = WavePrefixSum(diver);\r\n"
+        "  pts.pfProd = WavePrefixProduct(diver);\r\n"
+        "\r\n"
+        "  int i_diver = pts.i_diver;\r\n"
+        "  pts.i_allMax = WaveActiveMax(i_diver);\r\n"
+        "  pts.i_allMin = WaveActiveMin(i_diver);\r\n"
+        "  pts.i_allSum = WaveActiveSum(i_diver);\r\n"
+        "  pts.i_allProd = WaveActiveProduct(i_diver);\r\n"
+        "  pts.i_pfSum = WavePrefixSum(i_diver);\r\n"
+        "  pts.i_pfProd = WavePrefixProduct(i_diver);\r\n"
+        "\r\n"
+        "  g_sb[GI] = pts;\r\n"
+        "}";
+    static const int NumtheadsX = 8;
+    static const int NumtheadsY = 8;
+    static const int NumtheadsZ = 1;
+    static const int ThreadsPerGroup = NumtheadsX * NumtheadsY * NumtheadsZ;
+    static const int DispatchGroupCount = 1;
+
+    CComPtr<ID3D12Device> pDevice;
+    if (!CreateDevice(&pDevice))
+        return;
+
+    if (!DoesDeviceSupportWaveOps(pDevice)) {
+        // Optional feature, so it's correct to not support it if declared as such.
+        WEX::Logging::Log::Comment(L"Device does not support wave operations.");
+        return;
+    }
+
+    std::vector<PerThreadData> values;
+    values.resize(ThreadsPerGroup * DispatchGroupCount);
+    for (size_t i = 0; i < values.size(); ++i) {
+        memset(&values[i], 0, sizeof(PerThreadData));
+        values[i].id = i;
+        values[i].i_diver = (int)i;
+        values[i].i_diver *= (i % 2) ? 1 : -1;
+    }
+
+    static const int DispatchGroupX = 1;
+    static const int DispatchGroupY = 1;
+    static const int DispatchGroupZ = 1;
+
+    CComPtr<ID3D12GraphicsCommandList> pCommandList;
+    CComPtr<ID3D12CommandQueue> pCommandQueue;
+    CComPtr<ID3D12DescriptorHeap> pUavHeap;
+    CComPtr<ID3D12CommandAllocator> pCommandAllocator;
+    UINT uavDescriptorSize;
+    FenceObj FO;
+    bool dxbc = UseDxbc();
+
+    const size_t valueSizeInBytes = values.size() * sizeof(PerThreadData);
+    CreateComputeCommandQueue(pDevice, L"WaveIntrinsicsTest Command Queue", &pCommandQueue);
+    InitFenceObj(pDevice, &FO);
+
+    // Describe and create a UAV descriptor heap.
+    D3D12_DESCRIPTOR_HEAP_DESC heapDesc = {};
+    heapDesc.NumDescriptors = 1;
+    heapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+    heapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+    VERIFY_SUCCEEDED(pDevice->CreateDescriptorHeap(&heapDesc, IID_PPV_ARGS(&pUavHeap)));
+    uavDescriptorSize = pDevice->GetDescriptorHandleIncrementSize(heapDesc.Type);
+
+    // Create root signature.
+    CComPtr<ID3D12RootSignature> pRootSignature;
+    {
+        CD3DX12_DESCRIPTOR_RANGE ranges[1];
+        ranges[0].Init(D3D12_DESCRIPTOR_RANGE_TYPE_UAV, 1, 0, 0, 0);
+
+        CD3DX12_ROOT_PARAMETER rootParameters[1];
+        rootParameters[0].InitAsDescriptorTable(1, &ranges[0], D3D12_SHADER_VISIBILITY_ALL);
+
+        CD3DX12_ROOT_SIGNATURE_DESC rootSignatureDesc;
+        rootSignatureDesc.Init(_countof(rootParameters), rootParameters, 0, nullptr, D3D12_ROOT_SIGNATURE_FLAG_NONE);
+
+        CComPtr<ID3DBlob> signature;
+        CComPtr<ID3DBlob> error;
+        VERIFY_SUCCEEDED(D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, &error));
+        VERIFY_SUCCEEDED(pDevice->CreateRootSignature(0, signature->GetBufferPointer(), signature->GetBufferSize(), IID_PPV_ARGS(&pRootSignature)));
+    }
+
+    // Create pipeline state object.
+    CComPtr<ID3D12PipelineState> pComputeState;
+    CreateComputePSO(pDevice, pRootSignature, pShader, &pComputeState);
+
+    // Create a command allocator and list for compute.
+    VERIFY_SUCCEEDED(pDevice->CreateCommandAllocator(D3D12_COMMAND_LIST_TYPE_COMPUTE, IID_PPV_ARGS(&pCommandAllocator)));
+    VERIFY_SUCCEEDED(pDevice->CreateCommandList(0, D3D12_COMMAND_LIST_TYPE_COMPUTE, pCommandAllocator, pComputeState, IID_PPV_ARGS(&pCommandList)));
+
+    // Set up UAV resource.
+    CComPtr<ID3D12Resource> pUavResource;
+    CComPtr<ID3D12Resource> pReadBuffer;
+    CComPtr<ID3D12Resource> pUploadResource;
+    CreateTestUavs(pDevice, pCommandList, values.data(), valueSizeInBytes, &pUavResource, &pReadBuffer, &pUploadResource);
+
+    // Close the command list and execute it to perform the GPU setup.
+    pCommandList->Close();
+    ExecuteCommandList(pCommandQueue, pCommandList);
+    WaitForSignal(pCommandQueue, FO);
+    VERIFY_SUCCEEDED(pCommandAllocator->Reset());
+    VERIFY_SUCCEEDED(pCommandList->Reset(pCommandAllocator, pComputeState));
+
+    // Run the compute shader and copy the results back to readable memory.
+    {
+        D3D12_UNORDERED_ACCESS_VIEW_DESC uavDesc = {};
+        uavDesc.Format = DXGI_FORMAT_UNKNOWN;
+        uavDesc.ViewDimension = D3D12_UAV_DIMENSION_BUFFER;
+        uavDesc.Buffer.FirstElement = 0;
+        uavDesc.Buffer.NumElements = values.size();
+        uavDesc.Buffer.StructureByteStride = sizeof(PerThreadData);
+        uavDesc.Buffer.CounterOffsetInBytes = 0;
+        uavDesc.Buffer.Flags = D3D12_BUFFER_UAV_FLAG_NONE;
+        CD3DX12_CPU_DESCRIPTOR_HANDLE uavHandle(pUavHeap->GetCPUDescriptorHandleForHeapStart());
+        CD3DX12_GPU_DESCRIPTOR_HANDLE uavHandleGpu(pUavHeap->GetGPUDescriptorHandleForHeapStart());
+        pDevice->CreateUnorderedAccessView(pUavResource, nullptr, &uavDesc, uavHandle);
+        SetDescriptorHeap(pCommandList, pUavHeap);
+        pCommandList->SetComputeRootSignature(pRootSignature);
+        pCommandList->SetComputeRootDescriptorTable(0, uavHandleGpu);
+    }
+    pCommandList->Dispatch(DispatchGroupX, DispatchGroupY, DispatchGroupZ);
+    RecordTransitionBarrier(pCommandList, pUavResource, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_COPY_SOURCE);
+    pCommandList->CopyResource(pReadBuffer, pUavResource);
+    pCommandList->Close();
+    ExecuteCommandList(pCommandQueue, pCommandList);
+    WaitForSignal(pCommandQueue, FO);
+    {
+        MappedData mappedData(pReadBuffer, valueSizeInBytes);
+        PerThreadData *pData = (PerThreadData *)mappedData.data();
+        memcpy(values.data(), pData, valueSizeInBytes);
+
+        // Gather some general data.
+        // The 'firstLaneId' captures a unique number per first-lane per wave.
+        // Counting the number distinct firstLaneIds gives us the number of waves.
+        std::vector<uint32_t> firstLaneIds;
+        for (size_t i = 0; i < values.size(); ++i) {
+            PerThreadData &pts = values[i];
+            uint32_t firstLaneId = pts.firstLaneId;
+            if (!contains(firstLaneIds, firstLaneId)) {
+                firstLaneIds.push_back(firstLaneId);
+            }
+        }
+
+        // Waves should cover 4 threads or more.
+        LogCommentFmt(L"Found %u distinct lane ids: %u", firstLaneIds.size());
+        if (!dxbc) {
+            VERIFY_IS_GREATER_THAN_OR_EQUAL(values.size() / 4, firstLaneIds.size());
+        }
+
+        // Now, group threads into waves.
+        std::map<uint32_t, std::unique_ptr<std::vector<PerThreadData *> > > waves;
+        for (size_t i = 0; i < firstLaneIds.size(); ++i) {
+            waves[firstLaneIds[i]] = std::make_unique<std::vector<PerThreadData *> >();
+        }
+        for (size_t i = 0; i < values.size(); ++i) {
+            PerThreadData &pts = values[i];
+            std::unique_ptr<std::vector<PerThreadData *> > &wave = waves[pts.firstLaneId];
+            wave->push_back(&pts);
+        }
+
+        // Verify that all the wave values are coherent across the wave.
+        for (size_t i = 0; i < values.size(); ++i) {
+            PerThreadData &pts = values[i];
+            std::unique_ptr<std::vector<PerThreadData *> > &wave = waves[pts.firstLaneId];
+            // Sort the lanes by increasing lane ID.
+            struct LaneIdOrderPred {
+                bool operator()(PerThreadData *a, PerThreadData *b) {
+                    return a->laneIndex < b->laneIndex;
+                }
+            };
+            std::sort(wave.get()->begin(), wave.get()->end(), LaneIdOrderPred());
+
+            // Verify some interesting properties of the first lane.
+            uint32_t pfBC, pfSum, pfProd;
+            int32_t i_pfSum, i_pfProd;
+            int32_t i_allMax, i_allMin;
+            {
+                PerThreadData *ptdFirst = wave->front();
+                VERIFY_IS_TRUE(0 != (ptdFirst->flags & 1)); // FirstLane sets this bit.
+                VERIFY_IS_TRUE(0 == ptdFirst->pfBC);
+                VERIFY_IS_TRUE(0 == ptdFirst->pfSum);
+                VERIFY_IS_TRUE(1 == ptdFirst->pfProd);
+                VERIFY_IS_TRUE(0 == ptdFirst->i_pfSum);
+                VERIFY_IS_TRUE(1 == ptdFirst->i_pfProd);
+                pfBC = (ptdFirst->diver > 3) ? 1 : 0;
+                pfSum = ptdFirst->diver;
+                pfProd = ptdFirst->diver;
+                i_pfSum = ptdFirst->i_diver;
+                i_pfProd = ptdFirst->i_diver;
+                i_allMax = i_allMin = ptdFirst->i_diver;
+            }
+
+            // Calculate values which take into consideration all lanes.
+            uint32_t preds = 0;
+            preds |= 1 << 1; // AllTrue starts true, switches to false if needed.
+            preds |= 1 << 2; // AllEqual starts true, switches to false if needed.
+            preds |= 1 << 3; // WaveActiveAllEqual(GTID.z) is always true
+            preds |= 1 << 4; // (WaveActiveAllEqual(WaveReadLaneFirst(diver)) is always true
+            uint32_t ballot[4] = { 0, 0, 0, 0 };
+            int32_t i_allSum = 0, i_allProd = 1;
+            for (size_t n = 0; n < wave->size(); ++n) {
+                std::vector<PerThreadData *> &lanes = *wave.get();
+                // pts.preds |= ((WaveActiveAnyTrue(diver == 1) ? 1 : 0) << 0);
+                if (lanes[n]->diver == 1) preds |= (1 << 0);
+                // pts.preds |= ((WaveActiveAllTrue(diver == 1) ? 1 : 0) << 1);
+                if (lanes[n]->diver != 1) preds &= ~(1 << 1);
+                // pts.preds |= ((WaveActiveAllEqual(diver) ? 1 : 0) << 2);
+                if (lanes[0]->diver != lanes[n]->diver) preds &= ~(1 << 2);
+                // pts.ballot = WaveActiveBallot(diver > 3);\r\n"
+                if (lanes[n]->diver > 3) {
+                    // This is the uint4 result layout:
+                    // .x -> bits  0 .. 31
+                    // .y -> bits 32 .. 63
+                    // .z -> bits 64 .. 95
+                    // .w -> bits 96 ..127
+                    uint32_t component = lanes[n]->laneIndex / 32;
+                    uint32_t bit = lanes[n]->laneIndex % 32;
+                    ballot[component] |= 1 << bit;
+                }
+                i_allMax = std::max(lanes[n]->i_diver, i_allMax);
+                i_allMin = std::min(lanes[n]->i_diver, i_allMin);
+                i_allProd *= lanes[n]->i_diver;
+                i_allSum += lanes[n]->i_diver;
+            }
+
+            for (size_t n = 1; n < wave->size(); ++n) {
+                // 'All' operations are uniform across the wave.
+                std::vector<PerThreadData *> &lanes = *wave.get();
+                VERIFY_IS_TRUE(0 == (lanes[n]->flags & 1)); // non-firstlanes do not set this bit
+                VERIFY_ARE_EQUAL(lanes[0]->allBC, lanes[n]->allBC);
+                VERIFY_ARE_EQUAL(lanes[0]->allSum, lanes[n]->allSum);
+                VERIFY_ARE_EQUAL(lanes[0]->allProd, lanes[n]->allProd);
+                VERIFY_ARE_EQUAL(lanes[0]->allAND, lanes[n]->allAND);
+                VERIFY_ARE_EQUAL(lanes[0]->allOR, lanes[n]->allOR);
+                VERIFY_ARE_EQUAL(lanes[0]->allXOR, lanes[n]->allXOR);
+                VERIFY_ARE_EQUAL(lanes[0]->allMin, lanes[n]->allMin);
+                VERIFY_ARE_EQUAL(lanes[0]->allMax, lanes[n]->allMax);
+                VERIFY_ARE_EQUAL(i_allMax, lanes[n]->i_allMax);
+                VERIFY_ARE_EQUAL(i_allMin, lanes[n]->i_allMin);
+                VERIFY_ARE_EQUAL(i_allProd, lanes[n]->i_allProd);
+                VERIFY_ARE_EQUAL(i_allSum, lanes[n]->i_allSum);
+
+                // first-lane reads and uniform reads are uniform across the wave.
+                VERIFY_ARE_EQUAL(lanes[0]->firstlaneX, lanes[n]->firstlaneX);
+                VERIFY_ARE_EQUAL(lanes[0]->lane1X, lanes[n]->lane1X);
+
+                // the lane count is uniform across the wave.
+                VERIFY_ARE_EQUAL(lanes[0]->laneCount, lanes[n]->laneCount);
+
+                // The predicates are uniform across the wave.
+                VERIFY_ARE_EQUAL(lanes[n]->preds, preds);
+
+                // the lane index is distinct per thread.
+                for (size_t prior = 0; prior < n; ++prior) {
+                    VERIFY_ARE_NOT_EQUAL(lanes[prior]->laneIndex, lanes[n]->laneIndex);
+                }
+                // Ballot results are uniform across the wave.
+                VERIFY_ARE_EQUAL(0, memcmp(ballot, lanes[n]->ballot, sizeof(ballot)));
+
+                // Keep running total of prefix calculation. Prefix values are exclusive to
+                // the executing lane.
+                VERIFY_ARE_EQUAL(pfBC, lanes[n]->pfBC);
+                VERIFY_ARE_EQUAL(pfSum, lanes[n]->pfSum);
+                VERIFY_ARE_EQUAL(pfProd, lanes[n]->pfProd);
+                VERIFY_ARE_EQUAL(i_pfSum, lanes[n]->i_pfSum);
+                VERIFY_ARE_EQUAL(i_pfProd, lanes[n]->i_pfProd);
+                pfBC += (lanes[n]->diver > 3) ? 1 : 0;
+                pfSum += lanes[n]->diver;
+                pfProd *= lanes[n]->diver;
+                i_pfSum += lanes[n]->i_diver;
+                i_pfProd *= lanes[n]->i_diver;
+            }
+            // TODO: add divergent branching and verify that the otherwise uniform values properly diverge
+        }
+
+        // Compare each value of each per-thread element.
+        for (size_t i = 0; i < values.size(); ++i) {
+            PerThreadData &pts = values[i];
+            VERIFY_ARE_EQUAL(i, pts.id); // ID is unchanged.
+        }
+}
+}
 static void WriteReadBackDump(st::ShaderOp *pShaderOp, st::ShaderOpTest *pTest,
                               char **pReadBackDump) {
   std::stringstream str;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -401,7 +401,7 @@ static int MaskEveryThird(int i) {
 // Add more masks when this is resolved
 typedef int(*MaskFunction)(int);
 static MaskFunction MaskFunctionTable[] = {
-  MaskAll
+  MaskAll, MaskEveryOther, MaskEveryThird
 };
 
 template <typename InType, typename OutType>
@@ -460,12 +460,15 @@ public:
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(PartialDerivTest);
 
+  // TODO: Change the priority to 0 once there is a driver that fixes the issue with WaveActive operations
   BEGIN_TEST_METHOD(WaveIntrinsicsActiveIntTest)
     TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveIntTable")
+    TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   BEGIN_TEST_METHOD(WaveIntrinsicsActiveUintTest)
-  TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveUintTable")
+    TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveUintTable")
+    TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   // TAEF data-driven tests.

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -2447,20 +2447,24 @@
 
        </Table>
 
-       <Table Id="WaveIntrinsicAllIntTest">
+       <Table Id="WaveIntrinsicsActiveIntTable">
         <ParameterTypes>
+            <ParameterType Name="ShaderOp.Name">String</ParameterType>
             <ParameterType Name="ShaderOp.Text">String</ParameterType>
-            <ParameterType Name="Validation.Input1" Array="true">int</ParameterType>
-            <ParameterType Name="Validation.Input2" Array="true">int</ParameterType>
-            <ParameterType Name="Validation.Input3" Array="true">int</ParameterType>
-            <ParameterType Name="Validation.Input4" Array="true">int</ParameterType>
-            <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.NumInputSet">unsigned int</ParameterType>
+            <ParameterType Name="Validation.InputSet1" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.InputSet2" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.InputSet3" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.InputSet4" Array="true">int</ParameterType>
         </ParameterTypes>
-        
-        <Row Id="WaveActiveCountBits">
+
+        <Row Name="WaveActiveSum">
+            <Parameter Name="ShaderOp.Name">WaveActiveSum</Parameter>
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
+                        int id;
+                        int firstLaneId;
                         int input;
                         int output;
                     };
@@ -2468,105 +2472,150 @@
                     [numthreads(8,8,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.output = WaveActiveSum(output);
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveSum(pts.input);
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.Input1">
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
                 <Value>1</Value>
-                <Value>0</Value>
-                <Value>-100</Value>
-            </Parameter>
-            <Parameter Name="Validation.Input2">
                 <Value>2</Value>
-                <Value>0</Value>
-                <Value>0</Value>
-            </Parameter>
-            <Parameter Name="Validation.Input3">
                 <Value>3</Value>
-                <Value>0</Value>
-                <Value>10</Value>
-            </Parameter>
-            <Parameter Name="Validation.Input4">
                 <Value>4</Value>
-                <Value>0</Value>
-                <Value>10</Value>
             </Parameter>
-            <Parameter Name="Validation.Expected">
-                <Value>160</Value>
+            <Parameter Name="Validation.InputSet2">
                 <Value>0</Value>
-                <Value>-1280</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>-64</Value>
             </Parameter>
         </Row>
-       </Table>
-
-       <Table Id="WaveIntrinsicAllUintTest">
-        <ParameterType>
-            <ParaemterType Name="ShaderOp.Text">String</ParameterType>
-            <ParameterType Name="Validation.DataType">
-        </ParameterTypes>
-
-        <Row Id="WaveActiveCountBits">
+         <Row Name="WaveActiveProduct">
+            <Parameter Name="ShaderOp.Name">WaveActiveProduct</Parameter>
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
+                        int id;
+                        int firstLaneId;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
                     [numthreads(8,8,1)]
-                    void main(uint GI : SV_GroupIndex, uint3 GTID : SV_GroupThreadID) {
-                    PerThreadData pts = g_sb[GI];
-                    uint diver = GTID.x + 2;
-                    pts.diver = diver;
-                    pts.flags = 0;
-                    pts.preds = 0;
-                    if (WaveIsFirstLane()) pts.flags |= 1;
-                    pts.laneIndex = WaveGetLaneIndex();
-                    pts.laneCount = WaveGetLaneCount();
-                    pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                    pts.preds |= ((WaveActiveAnyTrue(diver == 1) ? 1 : 0) << 0);
-                    pts.preds |= ((WaveActiveAllTrue(diver == 1) ? 1 : 0) << 1);
-                    pts.preds |= ((WaveActiveAllEqual(diver) ? 1 : 0) << 2);
-                    pts.preds |= ((WaveActiveAllEqual(GTID.z) ? 1 : 0) << 3);
-                    pts.preds |= ((WaveActiveAllEqual(WaveReadLaneFirst(diver)) ? 1 : 0) << 4);
-                    pts.ballot = WaveActiveBallot(diver > 3);
-                    pts.firstlaneX = WaveReadLaneFirst(GTID.x);
-                    pts.lane1X = WaveReadLaneAt(GTID.x, 1);
-                    
-                    pts.allBC = WaveActiveCountBits(diver > 3);
-                    pts.allSum = WaveActiveSum(diver);
-                    pts.allProd = WaveActiveProduct(diver);
-                    pts.allAND = WaveActiveBitAnd(diver);
-                    pts.allOR = WaveActiveBitOr(diver);
-                    pts.allXOR = WaveActiveBitXor(diver);
-                    pts.allMin = WaveActiveMin(diver);
-                    pts.allMax = WaveActiveMax(diver);
-                    
-                    pts.pfBC = WavePrefixCountBits(diver > 3);
-                    pts.pfSum = WavePrefixSum(diver);
-                    pts.pfProd = WavePrefixProduct(diver);
-                    
-                    int i_diver = pts.i_diver;
-                    pts.i_allMax = WaveActiveMax(i_diver);
-                    pts.i_allMin = WaveActiveMin(i_diver);
-                    pts.i_allSum = WaveActiveSum(i_diver);
-                    pts.i_allProd = WaveActiveProduct(i_diver);
-                    pts.i_pfSum = WavePrefixSum(i_diver);
-                    pts.i_pfProd = WavePrefixProduct(i_diver);
-                    
-                    g_sb[GI] = pts;
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveProduct(pts.input);
+                        g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.DataType"></Parameter>
-            <Parameter Name="Validation.Input1"></Parameter>
-            <Parameter Name="Validation.Input2"></Parameter>
-            <Parameter Name="Validation.Input3"></Parameter>
-            <Parameter Name="Validation.Input4"></Parameter>
-            <Parameter Name="Validation.Expected"></Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>-64</Value>
+            </Parameter>
         </Row>
-
+        <Row Name="WaveActiveCountBits">
+            <Parameter Name="ShaderOp.Name">WaveActiveCountBits</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveCountBits(pts.input > 3);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>-4</Value>
+                <Value>-64</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>-100</Value>
+                <Value>-1000</Value>
+                <Value>300</Value>
+            </Parameter>
+        </Row>
+        <Row Name="WaveActiveCountBits">
+            <Parameter Name="ShaderOp.Name">WaveActiveCountBits</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveCountBits(pts.input > 3);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>-4</Value>
+                <Value>-64</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>-100</Value>
+                <Value>-1000</Value>
+                <Value>300</Value>
+            </Parameter>
+        </Row>
        </Table>
+
 </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -39,7 +39,7 @@
           <Value>-0.0007346401</Value>
           <Value>0.0007346401</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">sin</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -84,7 +84,7 @@
           <Value>0.99999973015</Value>
           <Value>0.99999973015</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">cos</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -128,7 +128,7 @@
           <Value>-0.000735</Value>
           <Value>0.000735</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">tan</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -172,7 +172,7 @@
           <Value>1.543081</Value>
           <Value>1.543081</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">hcos</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -216,7 +216,7 @@
           <Value>1.175201</Value>
           <Value>-1.175201</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">hsin</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -260,7 +260,7 @@
           <Value>0.761594</Value>
           <Value>-0.761594</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">htan</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -308,7 +308,7 @@
           <Value>NaN</Value>
           <Value>NaN</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">acos</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -356,7 +356,7 @@
           <Value>NaN</Value>
           <Value>NaN</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">asin</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -400,7 +400,7 @@
           <Value>0.785398163</Value>
           <Value>-0.785398163</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">atan</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -444,7 +444,7 @@
           <Value>0.367879441</Value>
           <Value>22026.46579</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">exp</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -492,7 +492,7 @@
           <Value>0.599976</Value>
           <Value>0.611</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">frc</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -540,7 +540,7 @@
           <Value>1.99999998</Value>
           <Value>4.6051701</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">log</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -587,7 +587,7 @@
           <Value>4.0</Value>
           <Value>16.0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">sqrt</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -635,7 +635,7 @@
           <Value>0.0625</Value>
           <Value>0.00390625</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">rsqrt</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -683,7 +683,7 @@
           <Value>0.0625</Value>
           <Value>0.00390625</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">rsqrt</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -741,7 +741,7 @@
           <Value>-10.0</Value>
           <Value>-11.0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">round_ne</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -797,7 +797,7 @@
           <Value>-11.0</Value>
           <Value>-11.0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">round_ni</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -853,7 +853,7 @@
           <Value>-10.0</Value>
           <Value>-10.0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">round_pi</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -909,7 +909,7 @@
           <Value>-10.0</Value>
           <Value>-10.0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">round_z</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -953,7 +953,7 @@
           <Value>0</Value>
           <Value>0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">IsNaN</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -999,7 +999,7 @@
           <Value>0</Value>
           <Value>0</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">IsInf</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -1019,7 +1019,7 @@
             }
            ]]></Parameter>
       </Row>
-      <Row Name="Isfinite">
+      <Row Name="IsFinite">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
         <Parameter Name="Validation.NumInput">9</Parameter>
@@ -1045,7 +1045,7 @@
           <Value>1</Value>
           <Value>1</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">IsFinite</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -1092,7 +1092,7 @@
           <Value>1</Value>
           <Value>1</Value>
         </Parameter>
-        <Parameter Name="ShaderOp.Name">CS</Parameter>
+        <Parameter Name="ShaderOp.Name">FAbs</Parameter>
         <Parameter Name="ShaderOp.Target">cs_6_0</Parameter>
         <Parameter Name="ShaderOp.EntryPoint">main</Parameter>
         <Parameter Name="ShaderOp.Text"><![CDATA[
@@ -2495,6 +2495,7 @@
                 <Value>-64</Value>
             </Parameter>
         </Row>
+
          <Row Name="WaveActiveProduct">
             <Parameter Name="ShaderOp.Name">WaveActiveProduct</Parameter>
             <Parameter Name="ShaderOp.Text">
@@ -2532,48 +2533,7 @@
                 <Value>-64</Value>
             </Parameter>
         </Row>
-        <Row Name="WaveActiveCountBits">
-            <Parameter Name="ShaderOp.Name">WaveActiveCountBits</Parameter>
-            <Parameter Name="ShaderOp.Text">
-                <![CDATA[
-                    struct PerThreadData {
-                        int id;
-                        int firstLaneId;
-                        int input;
-                        int output;
-                    };
-                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
-                    void main(uint GI : SV_GroupIndex) {
-                        PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveCountBits(pts.input > 3);
-                        g_sb[GI] = pts;
-                    }
-                ]]>
-            </Parameter>
-            <Parameter Name="Validation.NumInputSet">4</Parameter>
-            <Parameter Name="Validation.InputSet1">
-                <Value>1</Value>
-                <Value>2</Value>
-                <Value>3</Value>
-                <Value>4</Value>
-            </Parameter>
-            <Parameter Name="Validation.InputSet2">
-                <Value>0</Value>
-            </Parameter>
-            <Parameter Name="Validation.InputSet3">
-                <Value>1</Value>
-                <Value>10</Value>
-                <Value>-4</Value>
-                <Value>-64</Value>
-            </Parameter>
-            <Parameter Name="Validation.InputSet4">
-                <Value>-100</Value>
-                <Value>-1000</Value>
-                <Value>300</Value>
-            </Parameter>
-        </Row>
+
         <Row Name="WaveActiveCountBits">
             <Parameter Name="ShaderOp.Name">WaveActiveCountBits</Parameter>
             <Parameter Name="ShaderOp.Text">
@@ -2709,8 +2669,8 @@
             </Parameter>
         </Row>
 
-        <Row Name="WaveActiveMin">
-            <Parameter Name="ShaderOp.Name">WaveActiveMin</Parameter>
+        <Row Name="WaveActiveAllEqual">
+            <Parameter Name="ShaderOp.Name">WaveActiveAllEqual</Parameter>
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
@@ -2724,12 +2684,249 @@
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
                         pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveAllEqual(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>3</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>-10</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveAnyTrue">
+            <Parameter Name="ShaderOp.Name">WaveActiveAnyTrue</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        bool input;
+                        bool output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveAnyTrue(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveAllTrue">
+            <Parameter Name="ShaderOp.Name">WaveActiveAllTrue</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        bool input;
+                        bool output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveAllTrue(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>1</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+            </Parameter>
+        </Row>
+      </Table>
+
+      <Table Id="WaveIntrinsicsActiveUintTable">
+        <ParameterTypes>
+            <ParameterType Name="ShaderOp.Name">String</ParameterType>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.NumInputSet">unsigned int</ParameterType>
+            <ParameterType Name="Validation.InputSet1" Array="true">unsigned int</ParameterType>
+            <ParameterType Name="Validation.InputSet2" Array="true">unsigned int</ParameterType>
+            <ParameterType Name="Validation.InputSet3" Array="true">unsigned int</ParameterType>
+            <ParameterType Name="Validation.InputSet4" Array="true">unsigned int</ParameterType>
+        </ParameterTypes>
+
+       <Row Name="WaveActiveUSum">
+            <Parameter Name="ShaderOp.Name">WaveActiveUSum</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        uint input;
+                        uint output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveSum(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>64</Value>
+            </Parameter>
+        </Row>
+
+         <Row Name="WaveActiveUProduct">
+            <Parameter Name="ShaderOp.Name">WaveActiveUProduct</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        uint input;
+                        uint output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveProduct(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>64</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveUMax">
+            <Parameter Name="ShaderOp.Name">WaveActiveUMax</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        uint input;
+                        uint output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveMax(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>4</Value>
+                <Value>64</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveUMin">
+            <Parameter Name="ShaderOp.Name">WaveActiveUMin</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        uint input;
+                        uint output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
                         pts.output = WaveActiveMin(pts.input);
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>1</Value>
                 <Value>2</Value>
@@ -2748,13 +2945,8 @@
             <Parameter Name="Validation.InputSet3">
                 <Value>1</Value>
                 <Value>10</Value>
-                <Value>-4</Value>
-                <Value>-64</Value>
-            </Parameter>
-            <Parameter Name="Validation.InputSet4">
-                <Value>-100</Value>
-                <Value>-1000</Value>
-                <Value>300</Value>
+                <Value>4</Value>
+                <Value>64</Value>
             </Parameter>
         </Row>
 
@@ -2765,8 +2957,8 @@
                     struct PerThreadData {
                         int id;
                         int firstLaneId;
-                        int input;
-                        int output;
+                        uint input;
+                        uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
                     [numthreads(8,8,1)]
@@ -2778,7 +2970,7 @@
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>0xf000000</Value>
                 <Value>0x0f00000</Value>
@@ -2797,11 +2989,6 @@
                 <Value>8</Value>
                 <Value>16</Value>
             </Parameter>
-            <Parameter Name="Validation.InputSet4">
-                <Value>0xffffffff</Value>
-                <Value>0x0000ffff</Value>
-                <Value>0xffff0000</Value>
-            </Parameter>
         </Row>
 
         <Row Name="WaveActiveBitAnd">
@@ -2811,8 +2998,8 @@
                     struct PerThreadData {
                         int id;
                         int firstLaneId;
-                        int input;
-                        int output;
+                        uint input;
+                        uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
                     [numthreads(8,8,1)]
@@ -2824,7 +3011,7 @@
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>0xf000000</Value>
                 <Value>0x0f00000</Value>
@@ -2843,11 +3030,6 @@
                 <Value>8</Value>
                 <Value>16</Value>
             </Parameter>
-            <Parameter Name="Validation.InputSet4">
-                <Value>0xffffffff</Value>
-                <Value>0x0000ffff</Value>
-                <Value>0xffff0000</Value>
-            </Parameter>
         </Row>
 
         <Row Name="WaveActiveBitXor">
@@ -2857,8 +3039,8 @@
                     struct PerThreadData {
                         int id;
                         int firstLaneId;
-                        int input;
-                        int output;
+                        uint input;
+                        uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
                     [numthreads(8,8,1)]
@@ -2870,7 +3052,7 @@
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>0xf000000</Value>
                 <Value>0x0f00000</Value>
@@ -2889,12 +3071,6 @@
                 <Value>8</Value>
                 <Value>16</Value>
             </Parameter>
-            <Parameter Name="Validation.InputSet4">
-                <Value>0xffffffff</Value>
-                <Value>0x0000ffff</Value>
-                <Value>0xffff0000</Value>
-            </Parameter>
         </Row>
-       </Table>
-
+    </Table>
 </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -2389,64 +2389,6 @@
         </Row>
        </Table>
 
-       <Table Id="WaveIntrinsicPSTest">
-        <ParameterTypes>
-            <ParameterType Name="ShaderOp.Text">String</ParameterType>
-            <ParameterType Name="Validation.DataType">String</ParameterType>
-            <ParameterType Name="Validation.Input" Array="true">String</ParameterType>
-            <ParameterType Name="Validation.Output" Array="true">String</ParameterType>
-        </ParameterTypes>
-        <Row Name="GetLaneIndex">
-            <Parameter Name="ShaderOp.Text">
-                <![CDATA[
-                         struct PSInput {
-                            float4 position : SV_POSITION;
-                        };
-                        PSInput VSMain(float4 position : POSITION) {
-                            PSInput result;
-                            result.position = position;
-                            return result;
-                        }
-                        typedef uint uint32_t;
-                        uint pos_to_id(float4 pos) { return pos.x * 128 + pos.y; }
-                        struct PerPixelData {
-                            float4 position;
-                            uint32_t id, flags, laneIndex, laneCount, firstLaneId, sum1;
-                            uint32_t id0, id1, id2, id3;
-                            uint32_t acrossX, acrossY, acrossDiag, quadActiveCount;
-                        };
-                        AppendStructuredBuffer<PerPixelData> g_sb : register(u1);
-                        float4 PSMain(PSInput input) : SV_TARGET {
-                            uint one = 1;
-                            PerPixelData d;
-                            d.position = input.position;
-                            d.id = pos_to_id(input.position);
-                            d.flags = 0;
-                            if (WaveIsFirstLane()) d.flags |= 1;
-                            d.laneIndex = WaveGetLaneIndex();
-                            d.laneCount = WaveGetLaneCount();
-                            d.firstLaneId = WaveReadLaneFirst(d.id);
-                            d.sum1 = WaveActiveSum(one);
-                            d.id0 = QuadReadLaneAt(d.id, 0);
-                            d.id1 = QuadReadLaneAt(d.id, 1);
-                            d.id2 = QuadReadLaneAt(d.id, 2);
-                            d.id3 = QuadReadLaneAt(d.id, 3);
-                            d.acrossX = QuadReadAcrossX(d.id);
-                            d.acrossY = QuadReadAcrossY(d.id);
-                            d.acrossDiag = QuadReadAcrossDiagonal(d.id);
-                            d.quadActiveCount = one + QuadReadAcrossX(one) + QuadReadAcrossY(one) + QuadReadAcrossDiagonal(one);
-                            g_sb.Append(d);
-                            return 1;
-                        }
-                ]]>
-            </Parameter>
-            <Parameter Name="Validation.DataType"></Parameter>
-            <Parameter Name="Validation.Input"></Parameter>
-            <Parameter Name="Validation.Output"></Parameter>
-        </Row>
-
-       </Table>
-
        <Table Id="WaveIntrinsicsActiveIntTable">
         <ParameterTypes>
             <ParameterType Name="ShaderOp.Name">String</ParameterType>
@@ -2463,22 +2405,27 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveSum(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveSum(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveSum(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.NumInputSet">1</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>1</Value>
                 <Value>2</Value>
@@ -2501,17 +2448,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveProduct(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveProduct(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveProduct(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2539,17 +2491,19 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveCountBits(pts.input > 3);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveCountBits(pts.input > 3);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2582,17 +2536,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveMax(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveMax(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveMax(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2625,17 +2584,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveMin(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveMin(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveMin(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2674,17 +2638,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         int input;
                         int output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveAllEqual(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveAllEqual(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveAllEqual(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2713,17 +2682,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         bool input;
                         bool output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveAnyTrue(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveAnyTrue(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveAnyTrue(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2740,7 +2714,7 @@
                 <Value>1</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet3">
-                <Value>1</Value>
+                <Value>0</Value>
             </Parameter>
         </Row>
 
@@ -2749,17 +2723,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         bool input;
                         bool output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveAllTrue(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveAllTrue(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveAllTrue(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2797,17 +2776,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveSum(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveSum(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveSum(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2835,17 +2819,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveProduct(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveProduct(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveProduct(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2873,17 +2862,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveMax(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveMax(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveMax(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2911,17 +2905,22 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveMin(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveMin(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveMin(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
@@ -2955,39 +2954,52 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveBitOr(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveBitOr(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveBitOr(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
             <Parameter Name="Validation.InputSet1">
-                <Value>0xf000000</Value>
-                <Value>0x0f00000</Value>
-                <Value>0x00f0000</Value>
-                <Value>0x000f000</Value>
-                <Value>0x0000f00</Value>
-                <Value>0x00000f0</Value>
-                <Value>0x000000f</Value>
+                <Value>0xe0000000</Value>
+                <Value>0x0d000000</Value>
+                <Value>0x00b00000</Value>
+                <Value>0x00070000</Value>
+                <Value>0x0000e000</Value>
+                <Value>0x00000d00</Value>
+                <Value>0x000000b0</Value>
+                <Value>0x00000007</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet2">
-                <Value>0x00000000</Value>
+                <Value>0xedb7edb7</Value>
+                <Value>0xdb7edb7e</Value>
+                <Value>0xb7edb7ed</Value>
+                <Value>0x7edb7edb</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet3">
-                <Value>2</Value>
-                <Value>4</Value>
-                <Value>8</Value>
-                <Value>16</Value>
+                <Value>0x12481248</Value>
+                <Value>0x24812481</Value>
+                <Value>0x48124812</Value>
+                <Value>0x81248124</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0x00000000</Value>
+                <Value>0xffffffff</Value>
             </Parameter>
         </Row>
 
@@ -2996,39 +3008,52 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveBitAnd(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveBitAnd(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveBitAnd(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">3</Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
             <Parameter Name="Validation.InputSet1">
-                <Value>0xf000000</Value>
-                <Value>0x0f00000</Value>
-                <Value>0x00f0000</Value>
-                <Value>0x000f000</Value>
-                <Value>0x0000f00</Value>
-                <Value>0x00000f0</Value>
-                <Value>0x000000f</Value>
+                <Value>0xefffffff</Value>
+                <Value>0xfdffffff</Value>
+                <Value>0xffbfffff</Value>
+                <Value>0xfff7ffff</Value>
+                <Value>0xffffefff</Value>
+                <Value>0xfffffdff</Value>
+                <Value>0xffffffbf</Value>
+                <Value>0xfffffff7</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet2">
-                <Value>0x00000000</Value>
+                <Value>0xedb7edb7</Value>
+                <Value>0xdb7edb7e</Value>
+                <Value>0xb7edb7ed</Value>
+                <Value>0x7edb7edb</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet3">
-                <Value>2</Value>
-                <Value>4</Value>
-                <Value>8</Value>
-                <Value>16</Value>
+                <Value>0x12481248</Value>
+                <Value>0x24812481</Value>
+                <Value>0x48124812</Value>
+                <Value>0x81248124</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0x00000000</Value>
+                <Value>0xffffffff</Value>
             </Parameter>
         </Row>
 
@@ -3037,40 +3062,53 @@
             <Parameter Name="ShaderOp.Text">
                 <![CDATA[
                     struct PerThreadData {
-                        int id;
                         int firstLaneId;
+                        int mask;
                         uint input;
                         uint output;
                     };
                     RWStructuredBuffer<PerThreadData> g_sb : register(u0);
-                    [numthreads(8,8,1)]
+                    [numthreads(8,12,1)]
                     void main(uint GI : SV_GroupIndex) {
                         PerThreadData pts = g_sb[GI];
-                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
-                        pts.output = WaveActiveBitXor(pts.input);
+                        pts.firstLaneId = WaveReadLaneFirst(GI);
+                        if (pts.mask != 0) {
+                            pts.output = WaveActiveBitXor(pts.input);
+                        }
+                        else {
+                            pts.output = WaveActiveBitXor(pts.input);
+                        }
                         g_sb[GI] = pts;
                     }
                 ]]>
             </Parameter>
             <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
-                <Value>0xf000000</Value>
-                <Value>0x0f00000</Value>
-                <Value>0x00f0000</Value>
-                <Value>0x000f000</Value>
-                <Value>0x0000f00</Value>
-                <Value>0x00000f0</Value>
-                <Value>0x000000f</Value>
+                <Value>0xe0000000</Value>
+                <Value>0x0d000000</Value>
+                <Value>0x00b00000</Value>
+                <Value>0x00070000</Value>
+                <Value>0x0000e000</Value>
+                <Value>0x00000d00</Value>
+                <Value>0x000000b0</Value>
+                <Value>0x00000007</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet2">
-                <Value>0x00000000</Value>
+                <Value>0xedb7edb7</Value>
+                <Value>0xdb7edb7e</Value>
+                <Value>0xb7edb7ed</Value>
+                <Value>0x7edb7edb</Value>
             </Parameter>
             <Parameter Name="Validation.InputSet3">
-                <Value>2</Value>
-                <Value>4</Value>
-                <Value>8</Value>
-                <Value>16</Value>
+                <Value>0x12481248</Value>
+                <Value>0x24812481</Value>
+                <Value>0x48124812</Value>
+                <Value>0x81248124</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0x00000000</Value>
+                <Value>0xffffffff</Value>
             </Parameter>
         </Row>
-    </Table>
+    </Table>-->
 </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -2388,4 +2388,185 @@
             </Parameter>
         </Row>
        </Table>
+
+       <Table Id="WaveIntrinsicPSTest">
+        <ParameterTypes>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.DataType">String</ParameterType>
+            <ParameterType Name="Validation.Input" Array="true">String</ParameterType>
+            <ParameterType Name="Validation.Output" Array="true">String</ParameterType>
+        </ParameterTypes>
+        <Row Name="GetLaneIndex">
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                         struct PSInput {
+                            float4 position : SV_POSITION;
+                        };
+                        PSInput VSMain(float4 position : POSITION) {
+                            PSInput result;
+                            result.position = position;
+                            return result;
+                        }
+                        typedef uint uint32_t;
+                        uint pos_to_id(float4 pos) { return pos.x * 128 + pos.y; }
+                        struct PerPixelData {
+                            float4 position;
+                            uint32_t id, flags, laneIndex, laneCount, firstLaneId, sum1;
+                            uint32_t id0, id1, id2, id3;
+                            uint32_t acrossX, acrossY, acrossDiag, quadActiveCount;
+                        };
+                        AppendStructuredBuffer<PerPixelData> g_sb : register(u1);
+                        float4 PSMain(PSInput input) : SV_TARGET {
+                            uint one = 1;
+                            PerPixelData d;
+                            d.position = input.position;
+                            d.id = pos_to_id(input.position);
+                            d.flags = 0;
+                            if (WaveIsFirstLane()) d.flags |= 1;
+                            d.laneIndex = WaveGetLaneIndex();
+                            d.laneCount = WaveGetLaneCount();
+                            d.firstLaneId = WaveReadLaneFirst(d.id);
+                            d.sum1 = WaveActiveSum(one);
+                            d.id0 = QuadReadLaneAt(d.id, 0);
+                            d.id1 = QuadReadLaneAt(d.id, 1);
+                            d.id2 = QuadReadLaneAt(d.id, 2);
+                            d.id3 = QuadReadLaneAt(d.id, 3);
+                            d.acrossX = QuadReadAcrossX(d.id);
+                            d.acrossY = QuadReadAcrossY(d.id);
+                            d.acrossDiag = QuadReadAcrossDiagonal(d.id);
+                            d.quadActiveCount = one + QuadReadAcrossX(one) + QuadReadAcrossY(one) + QuadReadAcrossDiagonal(one);
+                            g_sb.Append(d);
+                            return 1;
+                        }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.DataType"></Parameter>
+            <Parameter Name="Validation.Input"></Parameter>
+            <Parameter Name="Validation.Output"></Parameter>
+        </Row>
+
+       </Table>
+
+       <Table Id="WaveIntrinsicAllIntTest">
+        <ParameterTypes>
+            <ParameterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.Input1" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Input2" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Input3" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Input4" Array="true">int</ParameterType>
+            <ParameterType Name="Validation.Expected" Array="true">String</ParameterType>
+        </ParameterTypes>
+        
+        <Row Id="WaveActiveCountBits">
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.output = WaveActiveSum(output);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.Input1">
+                <Value>1</Value>
+                <Value>0</Value>
+                <Value>-100</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input2">
+                <Value>2</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input3">
+                <Value>3</Value>
+                <Value>0</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Input4">
+                <Value>4</Value>
+                <Value>0</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected">
+                <Value>160</Value>
+                <Value>0</Value>
+                <Value>-1280</Value>
+            </Parameter>
+        </Row>
+       </Table>
+
+       <Table Id="WaveIntrinsicAllUintTest">
+        <ParameterType>
+            <ParaemterType Name="ShaderOp.Text">String</ParameterType>
+            <ParameterType Name="Validation.DataType">
+        </ParameterTypes>
+
+        <Row Id="WaveActiveCountBits">
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex, uint3 GTID : SV_GroupThreadID) {
+                    PerThreadData pts = g_sb[GI];
+                    uint diver = GTID.x + 2;
+                    pts.diver = diver;
+                    pts.flags = 0;
+                    pts.preds = 0;
+                    if (WaveIsFirstLane()) pts.flags |= 1;
+                    pts.laneIndex = WaveGetLaneIndex();
+                    pts.laneCount = WaveGetLaneCount();
+                    pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                    pts.preds |= ((WaveActiveAnyTrue(diver == 1) ? 1 : 0) << 0);
+                    pts.preds |= ((WaveActiveAllTrue(diver == 1) ? 1 : 0) << 1);
+                    pts.preds |= ((WaveActiveAllEqual(diver) ? 1 : 0) << 2);
+                    pts.preds |= ((WaveActiveAllEqual(GTID.z) ? 1 : 0) << 3);
+                    pts.preds |= ((WaveActiveAllEqual(WaveReadLaneFirst(diver)) ? 1 : 0) << 4);
+                    pts.ballot = WaveActiveBallot(diver > 3);
+                    pts.firstlaneX = WaveReadLaneFirst(GTID.x);
+                    pts.lane1X = WaveReadLaneAt(GTID.x, 1);
+                    
+                    pts.allBC = WaveActiveCountBits(diver > 3);
+                    pts.allSum = WaveActiveSum(diver);
+                    pts.allProd = WaveActiveProduct(diver);
+                    pts.allAND = WaveActiveBitAnd(diver);
+                    pts.allOR = WaveActiveBitOr(diver);
+                    pts.allXOR = WaveActiveBitXor(diver);
+                    pts.allMin = WaveActiveMin(diver);
+                    pts.allMax = WaveActiveMax(diver);
+                    
+                    pts.pfBC = WavePrefixCountBits(diver > 3);
+                    pts.pfSum = WavePrefixSum(diver);
+                    pts.pfProd = WavePrefixProduct(diver);
+                    
+                    int i_diver = pts.i_diver;
+                    pts.i_allMax = WaveActiveMax(i_diver);
+                    pts.i_allMin = WaveActiveMin(i_diver);
+                    pts.i_allSum = WaveActiveSum(i_diver);
+                    pts.i_allProd = WaveActiveProduct(i_diver);
+                    pts.i_pfSum = WavePrefixSum(i_diver);
+                    pts.i_pfProd = WavePrefixProduct(i_diver);
+                    
+                    g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.DataType"></Parameter>
+            <Parameter Name="Validation.Input1"></Parameter>
+            <Parameter Name="Validation.Input2"></Parameter>
+            <Parameter Name="Validation.Input3"></Parameter>
+            <Parameter Name="Validation.Input4"></Parameter>
+            <Parameter Name="Validation.Expected"></Parameter>
+        </Row>
+
+       </Table>
 </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -2616,6 +2616,285 @@
                 <Value>300</Value>
             </Parameter>
         </Row>
+
+        <Row Name="WaveActiveMax">
+            <Parameter Name="ShaderOp.Name">WaveActiveMax</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveMax(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>-4</Value>
+                <Value>-64</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>-100</Value>
+                <Value>-1000</Value>
+                <Value>300</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveMin">
+            <Parameter Name="ShaderOp.Name">WaveActiveMin</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveMin(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>5</Value>
+                <Value>6</Value>
+                <Value>7</Value>
+                <Value>8</Value>
+                <Value>9</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>-4</Value>
+                <Value>-64</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>-100</Value>
+                <Value>-1000</Value>
+                <Value>300</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveMin">
+            <Parameter Name="ShaderOp.Name">WaveActiveMin</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveMin(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>1</Value>
+                <Value>2</Value>
+                <Value>3</Value>
+                <Value>4</Value>
+                <Value>5</Value>
+                <Value>6</Value>
+                <Value>7</Value>
+                <Value>8</Value>
+                <Value>9</Value>
+                <Value>10</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>1</Value>
+                <Value>10</Value>
+                <Value>-4</Value>
+                <Value>-64</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>-100</Value>
+                <Value>-1000</Value>
+                <Value>300</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveBitOr">
+            <Parameter Name="ShaderOp.Name">WaveActiveBitOr</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveBitOr(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>0xf000000</Value>
+                <Value>0x0f00000</Value>
+                <Value>0x00f0000</Value>
+                <Value>0x000f000</Value>
+                <Value>0x0000f00</Value>
+                <Value>0x00000f0</Value>
+                <Value>0x000000f</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0x00000000</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>16</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0xffffffff</Value>
+                <Value>0x0000ffff</Value>
+                <Value>0xffff0000</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveBitAnd">
+            <Parameter Name="ShaderOp.Name">WaveActiveBitAnd</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveBitAnd(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>0xf000000</Value>
+                <Value>0x0f00000</Value>
+                <Value>0x00f0000</Value>
+                <Value>0x000f000</Value>
+                <Value>0x0000f00</Value>
+                <Value>0x00000f0</Value>
+                <Value>0x000000f</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0x00000000</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>16</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0xffffffff</Value>
+                <Value>0x0000ffff</Value>
+                <Value>0xffff0000</Value>
+            </Parameter>
+        </Row>
+
+        <Row Name="WaveActiveBitXor">
+            <Parameter Name="ShaderOp.Name">WaveActiveBitXor</Parameter>
+            <Parameter Name="ShaderOp.Text">
+                <![CDATA[
+                    struct PerThreadData {
+                        int id;
+                        int firstLaneId;
+                        int input;
+                        int output;
+                    };
+                    RWStructuredBuffer<PerThreadData> g_sb : register(u0);
+                    [numthreads(8,8,1)]
+                    void main(uint GI : SV_GroupIndex) {
+                        PerThreadData pts = g_sb[GI];
+                        pts.firstLaneId = WaveReadLaneFirst(pts.id);
+                        pts.output = WaveActiveBitXor(pts.input);
+                        g_sb[GI] = pts;
+                    }
+                ]]>
+            </Parameter>
+            <Parameter Name="Validation.NumInputSet">4</Parameter>
+            <Parameter Name="Validation.InputSet1">
+                <Value>0xf000000</Value>
+                <Value>0x0f00000</Value>
+                <Value>0x00f0000</Value>
+                <Value>0x000f000</Value>
+                <Value>0x0000f00</Value>
+                <Value>0x00000f0</Value>
+                <Value>0x000000f</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet2">
+                <Value>0x00000000</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet3">
+                <Value>2</Value>
+                <Value>4</Value>
+                <Value>8</Value>
+                <Value>16</Value>
+            </Parameter>
+            <Parameter Name="Validation.InputSet4">
+                <Value>0xffffffff</Value>
+                <Value>0x0000ffff</Value>
+                <Value>0xffff0000</Value>
+            </Parameter>
+        </Row>
        </Table>
 
 </Data>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -2425,7 +2425,7 @@
                     }
                 ]]>
             </Parameter>
-            <Parameter Name="Validation.NumInputSet">1</Parameter>
+            <Parameter Name="Validation.NumInputSet">3</Parameter>
             <Parameter Name="Validation.InputSet1">
                 <Value>1</Value>
                 <Value>2</Value>
@@ -3110,5 +3110,5 @@
                 <Value>0xffffffff</Value>
             </Parameter>
         </Row>
-    </Table>-->
+    </Table>
 </Data>

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -195,7 +195,7 @@ if "%TEST_EXEC%"=="1" (
 )
 
 if "%TEST_EXEC%"=="1" (
-  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:%TEST_EXEC_FILTER% /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %ADDITIONAL_OPTS%
+  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /select:"@Name='%TEST_EXEC_FILTER%' AND @Priority<2" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %ADDITIONAL_OPTS%
   set RES_EXEC=!ERRORLEVEL!
 )
 


### PR DESCRIPTION
This change adds execution unit tests for WaveActiveOp intrinsics.

For wave operations, there is no guarantee of how many lanes exist in a given wave. The test therefore has to manually compute the expected output by identifying different waves in shaders and group lanes by the waves they belong to. This can be done by providing different id's for each structured resource and call WaveReadLaneFirst() on each shader, and mimic what wave intrinsics to compute expected results.

This change also includes other fixes in ExecutionTests including 1)Have TableParameterHandler to read data driven table parameters and 2) fixing typos

