### PR TITLE
[spirv] Add bare bone code for SPIR-V codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,13 @@ option(HLSL_ENABLE_FIXED_VER "Sets up fixed version information." OFF) # HLSL Ch
 option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) # HLSL Change
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
 
+# SPIRV change starts
+option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." OFF)
+if (${ENABLE_SPIRV_CODEGEN})
+  add_definitions(-DENABLE_SPIRV_CODEGEN)
+endif()
+# SPIRV change ends
+
 include(VersionFromVCS)
 
 option(LLVM_APPEND_VC_REV

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -109,6 +109,7 @@ public:
 
   bool AllResourcesBound; // OPT_all_resources_bound
   bool AstDump; // OPT_ast_dump
+  bool GenSPIRV; // OPT_spirv // SPIRV change
   bool ColorCodeAssembly; // OPT_Cc
   bool CodeGenHighLevel; // OPT_fcgl
   bool DebugInfo; // OPT__SLASH_Zi

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -209,6 +209,8 @@ def _help_question : Flag<["-", "/"], "?">, Flags<[DriverOption]>, Alias<help>;
 
 def ast_dump : Flag<["-", "/"], "ast-dump">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Dumps the parsed Abstract Syntax Tree.">; // should not be core, but handy workaround until explicit API written
+def spirv : Flag<["-"], "spirv">, Flags<[CoreOption, DriverOption, HelpHidden]>, // SPIRV change: temporary solution to support
+  HelpText<"Generates SPIR-V binary code">;                                      // SPIRV change: SPIR-V gen in a command line tool
 def external_lib : Separate<["-", "/"], "external">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,
   HelpText<"External DLL name to load for compiler support">;
 def external_fn : Separate<["-", "/"], "external-fn">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -252,6 +252,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.UseHexLiterals = Args.hasFlag(OPT_Lx, OPT_INVALID);
   opts.Preprocess = Args.getLastArgValue(OPT_P);
   opts.AstDump = Args.hasFlag(OPT_ast_dump, OPT_INVALID, false);
+  opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false); // SPIRV change
   opts.CodeGenHighLevel = Args.hasFlag(OPT_fcgl, OPT_INVALID, false);
   opts.DebugInfo = Args.hasFlag(OPT__SLASH_Zi, OPT_INVALID, false);
   opts.VariableName = Args.getLastArgValue(OPT_Vn);

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVAction.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVAction.h
@@ -1,0 +1,24 @@
+//===-- EmitSPIRVAction.h - FrontendAction for Emitting SPIR-V --*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_EMITSPIRVACTION_H
+#define LLVM_CLANG_SPIRV_EMITSPIRVACTION_H
+
+#include "clang/Frontend/FrontendAction.h"
+
+namespace clang {
+
+class EmitSPIRVAction : public ASTFrontendAction {
+protected:
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef InFile) override;
+};
+
+} // end namespace clang
+
+#endif

--- a/tools/clang/include/clang/SPIRV/SPIRVBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SPIRVBuilder.h
@@ -1,0 +1,26 @@
+//===-- SPIRVBuilder.h - SPIR-V builder --*- C++ -*------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_SPIRVBUILDER_H
+#define LLVM_CLANG_SPIRV_SPIRVBUILDER_H
+
+namespace clang {
+namespace spirv {
+
+class SPIRVBuilder {
+public:
+  SPIRVBuilder() : NextID(0) {}
+
+private:
+  uint32_t NextID;
+};
+
+} // end namespace spirv
+} // end namespace clang
+
+#endif

--- a/tools/clang/lib/CMakeLists.txt
+++ b/tools/clang/lib/CMakeLists.txt
@@ -22,3 +22,4 @@ if(CLANG_ENABLE_STATIC_ANALYZER)
   add_subdirectory(StaticAnalyzer)
 endif()
 add_subdirectory(Format)
+add_subdirectory(SPIRV) # SPIRV change

--- a/tools/clang/lib/CMakeLists.txt
+++ b/tools/clang/lib/CMakeLists.txt
@@ -22,4 +22,8 @@ if(CLANG_ENABLE_STATIC_ANALYZER)
   add_subdirectory(StaticAnalyzer)
 endif()
 add_subdirectory(Format)
-add_subdirectory(SPIRV) # SPIRV change
+# SPIRV change starts
+if (ENABLE_SPIRV_CODEGEN)
+  add_subdirectory(SPIRV)
+endif (ENABLE_SPIRV_CODEGEN)
+# SPIRV change ends

--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+add_clang_library(clangSPIRV
+  EmitSPIRVAction.cpp
+  SPIRVBuilder.cpp
+
+  LINK_LIBS
+  clangAST
+  clangBasic
+  clangFrontend
+  clangLex
+  )

--- a/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
+++ b/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
@@ -1,0 +1,43 @@
+//===--- EmitSPIRVAction.cpp - EmitSPIRVAction implementation -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/EmitSPIRVAction.h"
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/RecordLayout.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/FileManager.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace clang {
+namespace {
+class SPIRVEmitter : public ASTConsumer,
+                     public RecursiveASTVisitor<SPIRVEmitter> {
+public:
+  explicit SPIRVEmitter(raw_ostream *Out) : OutStream(*Out) {}
+
+  void HandleTranslationUnit(ASTContext &Context) override {
+    OutStream << "SPIR-V";
+  }
+
+private:
+  raw_ostream &OutStream;
+};
+}
+
+std::unique_ptr<ASTConsumer>
+EmitSPIRVAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
+  return llvm::make_unique<SPIRVEmitter>(CI.getOutStream());
+}
+} // end namespace clang

--- a/tools/clang/lib/SPIRV/SPIRVBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVBuilder.cpp
@@ -1,0 +1,12 @@
+//===--- SPIRVBuilder.cpp - SPIR-V builder implementation -----------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+namespace clang {
+namespace spirv {} // end namespace spirv
+} // end namespace clang

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -137,7 +137,7 @@ static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
 int DxcContext::ActOnBlob(IDxcBlob *pBlob) {
   int retVal = 0;
   // Text output.
-  if (m_Opts.AstDump || m_Opts.OptDump) {
+  if (m_Opts.AstDump || m_Opts.OptDump || m_Opts.GenSPIRV) { // SPIRV change: add GenSPIRV
     WriteBlobToConsole(pBlob);
     return retVal;
   }

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -137,7 +137,7 @@ static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
 int DxcContext::ActOnBlob(IDxcBlob *pBlob) {
   int retVal = 0;
   // Text output.
-  if (m_Opts.AstDump || m_Opts.OptDump || m_Opts.GenSPIRV) { // SPIRV change: add GenSPIRV
+  if (m_Opts.AstDump || m_Opts.OptDump) {
     WriteBlobToConsole(pBlob);
     return retVal;
   }
@@ -848,6 +848,22 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
       WriteUtf8ToConsoleSizeT(helpString.data(), helpString.size());
       return 0;
     }
+
+    // SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
+    // This ideally should be put in ReadDxcOpts(), but ReadDxcOpts() are called
+    // again in DxcCompilerCompile() with -Fo stripped.
+    if (dxcOpts.GenSPIRV && dxcOpts.OutputObject.empty()) {
+      fprintf(stderr, "-spirv requires -Fo for output object file name.");
+      return 1;
+    }
+#else
+    if (dxcOpts.GenSPIRV) {
+      fprintf(stderr, "SPIR-V codegen not configured via ENABLE_SPIRV_CODEGEN");
+      return 1;
+    }
+#endif
+    // SPIRV change ends
 
     // Apply defaults.
     if (dxcOpts.EntryPoint.empty() && !dxcOpts.RecompileFromBinary) {

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -67,7 +67,6 @@ set(LIBRARIES
   clangLex
   clangTooling
   clangBasic
-  clangSPIRV # SPIRV change
   libclang
   )
 
@@ -84,6 +83,11 @@ set(GENERATED_HEADERS
 
 add_clang_library(dxcompiler SHARED ${SOURCES})
 target_link_libraries(dxcompiler PRIVATE ${LIBRARIES} ${DIASDK_LIBRARIES})
+# SPIRV change starts
+if (ENABLE_SPIRV_CODEGEN)
+  target_link_libraries(dxcompiler PRIVATE clangSPIRV)
+endif (ENABLE_SPIRV_CODEGEN)
+# SPIRV change ends
 add_dependencies(dxcompiler DxcEtw)
 include_directories(AFTER ${LLVM_INCLUDE_DIR}/dxc/Tracing ${DIASDK_INCLUDE_DIRS})
 

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -67,6 +67,7 @@ set(LIBRARIES
   clangLex
   clangTooling
   clangBasic
+  clangSPIRV # SPIRV change
   libclang
   )
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -30,6 +30,7 @@
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/CodeGen/CodeGenAction.h"
+#include "clang/SPIRV/EmitSPIRVAction.h" // SPIRV change
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/Support/Format.h"
@@ -2205,6 +2206,16 @@ public:
           IFT(pContainerStream.QueryInterface(&pOutputBlob));
         }
       }
+      // SPIRV change starts
+      else if (opts.GenSPIRV) {
+          clang::EmitSPIRVAction action;
+          FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);
+          action.BeginSourceFile(compiler, file);
+          action.Execute();
+          action.EndSourceFile();
+          outStream.flush();
+      }
+      // SPIRV change ends
       else {
         llvm::LLVMContext llvmContext;
         EmitBCAction action(&llvmContext);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -30,7 +30,6 @@
 #include "llvm/Bitcode/ReaderWriter.h"
 #include "clang/Frontend/FrontendActions.h"
 #include "clang/CodeGen/CodeGenAction.h"
-#include "clang/SPIRV/EmitSPIRVAction.h" // SPIRV change
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/Support/Format.h"
@@ -41,6 +40,11 @@
 #include "dxc/HLSL/DxilPipelineStateValidation.h"
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h"
 #include "dxc/HLSL/DxilRootSignature.h"
+// SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
+#include "clang/SPIRV/EmitSPIRVAction.h"
+#endif
+// SPIRV change ends
 
 #if defined(_MSC_VER)
 #include <io.h>
@@ -2207,6 +2211,7 @@ public:
         }
       }
       // SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
       else if (opts.GenSPIRV) {
           clang::EmitSPIRVAction action;
           FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);
@@ -2215,6 +2220,7 @@ public:
           action.EndSourceFile();
           outStream.flush();
       }
+#endif
       // SPIRV change ends
       else {
         llvm::LLVMContext llvmContext;

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -113,6 +113,14 @@ if "%BUILD_VS_VER%"=="2015" (
   )
 )
 
+rem Begin SPIRV change
+if "%1"=="-spirv" (
+  echo SPIR-V codegen is enabled.
+  set CMAKE_OPTS=%CMAKE_OPTS% -DENABLE_SPIRV_CODEGEN:BOOL=ON
+  shift /1
+)
+rem End SPIRV change
+
 if "%BUILD_ARCH%"=="x64" (
   set BUILD_GENERATOR=%BUILD_GENERATOR% %BUILD_ARCH:x64=Win64%
 )


### PR DESCRIPTION
* Add `libclangSPIRV` and skeleton `ASTFrontendAction` for SPIR-V
* Add `-spirv` into `dxc` for invoking `EmitSPIRVAction`
* Build SPIR-V codegen conditionally using `ENABLE_SPIRV_CODEGEN`
  in CMake and `-spirv` in `hctbuild`.

For #216

cc @dneto0 @ehsannas