### PR TITLE
Temporalily disabling failing cases: isfinite(NaN) and atan(NaN)

### DIFF
--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -379,7 +379,9 @@
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
         <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
+    <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
+    -->
           <Value>-Inf</Value>
           <Value>-denorm</Value>
           <Value>-0</Value>
@@ -390,7 +392,9 @@
           <Value>-1</Value>
         </Parameter>
         <Parameter Name="Validation.Expected">
+    <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
+    -->
           <Value>-1.570796</Value>
           <Value>0.0</Value>
           <Value>0.0</Value>
@@ -1024,7 +1028,9 @@
         <Parameter Name="Validation.Tolerance">0</Parameter>
         <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
+     <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
+     -->
           <Value>-Inf</Value>
           <Value>-denorm</Value>
           <Value>-0</Value>
@@ -1035,7 +1041,9 @@
           <Value>-1.0</Value>
         </Parameter>
         <Parameter Name="Validation.Expected">
+     <!-- TODO: Uncomment this when WARP is fixed
           <Value>0</Value>
+     -->
           <Value>0</Value>
           <Value>1</Value>
           <Value>1</Value>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -377,7 +377,7 @@
       <Row Name="atan">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
-        <Parameter Name="Validation.NumInput">9</Parameter>
+        <Parameter Name="Validation.NumInput">8</Parameter>
         <Parameter Name="Validation.Input">
     <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
@@ -1026,7 +1026,7 @@
       <Row Name="IsFinite">
         <Parameter Name="Validation.Type">Epsilon</Parameter>
         <Parameter Name="Validation.Tolerance">0</Parameter>
-        <Parameter Name="Validation.NumInput">9</Parameter>
+        <Parameter Name="Validation.NumInput">8</Parameter>
         <Parameter Name="Validation.Input">
      <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>


### PR DESCRIPTION
This change is to prevent hcttest from producing a known execution test failures on WARP.
These should be enabled once WARP is fixed in the future.