### PR TITLE
Bump ValidationVersion to 1.1.

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2780,7 +2780,7 @@ DECL.NOTUSEDEXTERNAL                  External declaration should not be used
 DECL.USEDEXTERNALFUNCTION             External function must be used
 DECL.USEDINTERNAL                     Internal declaration must be used
 FLOW.DEADLOOP                         Loop must have break
-FLOW.FUNCTIONCALL                     Function with parameter is not permitted
+FLOW.FUNCTIONCALL                     Function with parameter is not permitted. This rule only works for DXIL1.0. Later version allow function with parameter except entry function and patch constant function
 FLOW.NORECUSION                       Recursion is not permitted
 FLOW.REDUCIBLE                        Execution flow must be reducible
 INSTR.ALLOWED                         Instructions must be of an allowed type

--- a/include/dxc/HLSL/DxilValidation.h
+++ b/include/dxc/HLSL/DxilValidation.h
@@ -159,7 +159,7 @@ enum class ValidationRule : unsigned {
 
   // Program flow
   FlowDeadLoop, // Loop must have break
-  FlowFunctionCall, // Function with parameter is not permitted
+  FlowFunctionCall, // Function with parameter is not permitted. This rule only works for DXIL1.0. Later version allow function with parameter except entry function and patch constant function
   FlowNoRecusion, // Recursion is not permitted
   FlowReducible, // Execution flow must be reducible
 

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -339,6 +339,7 @@ struct ValidationContext {
   Module &M;
   Module *pDebugModule;
   DxilModule &DxilMod;
+  Type   *HandleTy;
   const DataLayout &DL;
   DiagnosticPrinterRawOStream &DiagPrinter;
   PSExecutionInfo PSExec;
@@ -371,12 +372,17 @@ struct ValidationContext {
         DiagPrinter(DiagPrn), LastRuleEmit((ValidationRule)-1),
         m_bCoverageIn(false), m_bInnerCoverageIn(false) {
     DxilMod.GetDxilVersion(m_DxilMajor, m_DxilMinor);
+    HandleTy = dxilModule.GetOP()->GetHandleType();
     for (unsigned i = 0; i < DXIL::kNumOutputStreams; i++) {
       hasOutputPosition[i] = false;
       OutputPositionMask[i] = 0;
     }
     outputCols.resize(DxilMod.GetOutputSignature().GetElements().size(), 0);
     patchConstCols.resize(DxilMod.GetPatchConstantSignature().GetElements().size(), 0);
+  }
+
+  bool IsDXIL1_1Plus() {
+    return (m_DxilMajor == 1 && m_DxilMinor >= 1) || (m_DxilMajor > 1);
   }
 
   // Provide direct access to the raw_ostream in DiagPrinter.
@@ -657,8 +663,67 @@ static DxilSignatureElement *ValidateSignatureAccess(Instruction *I, DxilSignatu
   return &SE;
 }
 
+static MDNode *GetResourceAttribute(Value *handle, ValidationContext &ValCtx) {
+
+  DxilTypeSystem &typeSys = ValCtx.DxilMod.GetTypeSystem();
+  MDNode *MD = nullptr;
+  if (Argument *Arg = dyn_cast<Argument>(handle)) {
+    Function *F = Arg->getParent();
+    if (DxilFunctionAnnotation *FuncAnnot = typeSys.GetFunctionAnnotation(F)) {
+      DxilParameterAnnotation &ParamAnnot =
+          FuncAnnot->GetParameterAnnotation(Arg->getArgNo());
+      MD = ParamAnnot.GetResourceAttribute();
+    }
+  } else if (LoadInst *LI = dyn_cast<LoadInst>(handle)) {
+    handle = LI->getPointerOperand();
+    for (User *U : handle->users()) {
+      if (CallInst *CI = dyn_cast<CallInst>(U)) {
+        Function *F = CI->getCalledFunction();
+        unsigned ArgNo = 0;
+        for (unsigned i = 0; i < CI->getNumArgOperands(); i++) {
+          if (CI->getArgOperand(i) == handle) {
+            ArgNo = i;
+            break;
+          }
+        }
+        if (DxilFunctionAnnotation *FuncAnnot =
+                typeSys.GetFunctionAnnotation(F)) {
+          DxilParameterAnnotation &ParamAnnot =
+              FuncAnnot->GetParameterAnnotation(ArgNo);
+          MD = ParamAnnot.GetResourceAttribute();
+          break;
+        }
+      }
+    }
+  }
+
+  return MD;
+}
+
+static void GetSamplerKind(Value *handle, DXIL::SamplerKind &Kind,
+                           ValidationContext &ValCtx) {
+  MDNode *MD = GetResourceAttribute(handle, ValCtx);
+
+  if (!MD) {
+    Kind = DXIL::SamplerKind::Invalid;
+    return;
+  }
+
+  DxilSampler S;
+
+  ValCtx.DxilMod.LoadDxilSamplerFromMDNode(MD, S);
+
+  Kind = S.GetSamplerKind();
+}
+
 static DXIL::SamplerKind GetSamplerKind(Value *samplerHandle, ValidationContext &ValCtx) {
   if (!isa<CallInst>(samplerHandle)) {
+    if (ValCtx.IsDXIL1_1Plus()) {
+      DXIL::SamplerKind Kind = DXIL::SamplerKind::Invalid;
+      GetSamplerKind(samplerHandle, Kind, ValCtx);
+      if (Kind != DXIL::SamplerKind::Invalid)
+        return Kind;
+    }
     ValCtx.EmitError(ValidationRule::InstrHandleNotFromCreateHandle);
     return DXIL::SamplerKind::Invalid;
   }
@@ -713,6 +778,26 @@ static DXIL::SamplerKind GetSamplerKind(Value *samplerHandle, ValidationContext 
   return sampler->GetSamplerKind();
 }
 
+static DXIL::ResourceKind
+GetResourceKindAndCompTy(Value *handle, DXIL::ComponentType &CompTy,
+                         DXIL::ResourceClass &ResClass,
+                         ValidationContext &ValCtx) {
+  MDNode *MD = GetResourceAttribute(handle, ValCtx);
+
+  if (!MD)
+    return DXIL::ResourceKind::Invalid;
+  DxilResourceBase R(DxilResourceBase::Class::Invalid);
+  ValCtx.DxilMod.LoadDxilResourceBaseFromMDNode(MD, R);
+  ResClass = R.GetClass();
+  if (ResClass == DXIL::ResourceClass::SRV ||
+      ResClass == DXIL::ResourceClass::UAV) {
+    DxilResource R;
+    ValCtx.DxilMod.LoadDxilResourceFromMDNode(MD, R);
+    CompTy = R.GetCompType().GetKind();
+  }
+  return R.GetKind();
+}
+
 static DXIL::ResourceKind GetResourceKindAndCompTy(Value *handle, DXIL::ComponentType &CompTy, DXIL::ResourceClass &ResClass,
     unsigned &resIndex,
     ValidationContext &ValCtx) {
@@ -720,6 +805,16 @@ static DXIL::ResourceKind GetResourceKindAndCompTy(Value *handle, DXIL::Componen
   ResClass = DXIL::ResourceClass::Invalid;
 
   if (!isa<CallInst>(handle)) {
+    if (ValCtx.IsDXIL1_1Plus()) {
+      // Allow find resource attribute from parameter.
+      DXIL::ResourceKind Kind =
+          GetResourceKindAndCompTy(handle, CompTy, ResClass, ValCtx);
+      if (Kind != DXIL::ResourceKind::Invalid) {
+        // No index for handle from parameter.
+        resIndex = -1;
+        return Kind;
+      }
+    }
     ValCtx.EmitError(ValidationRule::InstrHandleNotFromCreateHandle);
     return DXIL::ResourceKind::Invalid;
   }
@@ -2010,6 +2105,11 @@ static bool ValidateType(Type *Ty, ValidationContext &ValCtx) {
   }
   if (Ty->isStructTy()) {
     bool result = true;
+    if (ValCtx.IsDXIL1_1Plus()) {
+      // Allow alloca handle for out resource parameter.
+      if (Ty == ValCtx.HandleTy)
+        return true;
+    }
     StructType *ST = cast<StructType>(Ty);
 
     StringRef Name = ST->getName();
@@ -2283,6 +2383,8 @@ static void ValidateInstructionMetadata(Instruction *I,
       ValidateLoopMetadata(MD.second, ValCtx);
     } else if (MD.first == LLVMContext::MD_tbaa) {
       ValidateTBAAMetadata(MD.second, ValCtx);
+    } else if (MD.first == LLVMContext::MD_noalias){
+      // Validated in Verifier.cpp.
     } else if (MD.first == LLVMContext::MD_range) {
       // Validated in Verifier.cpp.
     } else {
@@ -2554,10 +2656,15 @@ static void ValidateFunction(Function &F, ValidationContext &ValCtx) {
   if (F.isDeclaration()) {
     ValidateExternalFunction(&F, ValCtx);
   } else {
-    if (!F.arg_empty())
-      ValCtx.EmitFormatError(ValidationRule::FlowFunctionCall,
-                             {F.getName().str()});
-
+    if (!F.arg_empty()) {
+      // For DXIL 1.0, no function is allowed to have parameter.
+      // For later version, only entry function and patch constant function
+      // cannot have parameter.
+      if (!ValCtx.IsDXIL1_1Plus() || &F == ValCtx.DxilMod.GetEntryFunction() ||
+          &F == ValCtx.DxilMod.GetPatchConstantFunction())
+        ValCtx.EmitFormatError(ValidationRule::FlowFunctionCall,
+                               {F.getName().str()});
+    }
     DxilFunctionAnnotation *funcAnnotation =
         ValCtx.DxilMod.GetTypeSystem().GetFunctionAnnotation(&F);
     if (!funcAnnotation) {
@@ -2579,7 +2686,9 @@ static void ValidateFunction(Function &F, ValidationContext &ValCtx) {
           funcAnnotation->GetParameterAnnotation(arg.getArgNo());
 
       if (argTy->isStructTy() && !HLModule::IsStreamOutputType(argTy) &&
-          !paramAnnoation.HasMatrixAnnotation()) {
+          !paramAnnoation.HasMatrixAnnotation() &&
+          // Allow handle type for DXIL1.1 plus.
+          (!ValCtx.IsDXIL1_1Plus() || argTy != ValCtx.HandleTy)) {
         if (arg.hasName())
           ValCtx.EmitFormatError(
               ValidationRule::DeclFnFlattenParam,
@@ -4023,7 +4132,7 @@ static void ValidateUninitializedOutput(ValidationContext &ValCtx) {
 void GetValidationVersion(_Out_ unsigned *pMajor, _Out_ unsigned *pMinor) {
   // Bump these versions after 1.0 to account for additional validation rules.
   *pMajor = 1;
-  *pMinor = 0;
+  *pMinor = 1;
 }
 
 _Use_decl_annotations_ HRESULT

--- a/tools/clang/test/CodeGenHLSL/mat_param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mat_param.hlsl
@@ -1,9 +1,9 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
 
-// CHECK: main
-
-// TODO: check test_inout after disable inline.
-
+// Not inline.
+// CHECK: test_inout
+// float2x2 [2]
+// CHECK: [8 x float]*
 
 struct X {
   float2x2 ma[2];

--- a/tools/clang/test/CodeGenHLSL/mat_param2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mat_param2.hlsl
@@ -1,7 +1,9 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
 
-// CHECK: main
-// TODO: check mat_in after disable inline.
+// Not inlined.
+// CHECK: mat_in
+// float3x3
+// [9 x float]*
 
 row_major float3x3 m;
 

--- a/tools/clang/test/CodeGenHLSL/mat_param3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mat_param3.hlsl
@@ -1,8 +1,13 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
 
-// CHECK: main
 
-// TODO: check test_inout after disable inline.
+// Not inlined.
+// CHECK: test_inout
+// float2x2 [2]
+// CHECK: [8 x float]*
+// float3x3
+// CHECK: [9 x float]*
+
 
 
 struct X {

--- a/tools/clang/test/CodeGenHLSL/resource_param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/resource_param.hlsl
@@ -1,7 +1,9 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
 
-// TODO: check pointer of handle later.
-// CHECK: %dx.types.Handle
+// Function not inlined
+// CHECK: getUav
+// Pointer of handle
+// CHECK: %dx.types.Handle*
 
 RWBuffer<float4> uav1[2];
 RWBuffer<float4> uav2[2];

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -2670,9 +2670,14 @@ public:
     if (Opts.AvoidFlowControl)
       compiler.getCodeGenOpts().UnrollLoops = true;
 
-    // always inline for hlsl
-    compiler.getCodeGenOpts().setInlining(
-        clang::CodeGenOptions::OnlyAlwaysInlining);
+    const hlsl::ShaderModel *SM =
+        hlsl::ShaderModel::GetByName(Opts.TargetProfile.str().c_str());
+    if (SM->IsValid() && !SM->IsSM61Plus()) {
+      // Always inline for hlsl when shader model less than 6.1.
+      compiler.getCodeGenOpts().setInlining(
+          clang::CodeGenOptions::OnlyAlwaysInlining);
+    }
+
 
     compiler.getCodeGenOpts().HLSLExtensionsCodegen = std::make_shared<HLSLExtensionsCodegenHelperImpl>(compiler, m_langExtensionsHelper, Opts.RootSignatureDefine);
   }

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1699,7 +1699,7 @@ class db_dxil(object):
         self.add_valrule("Flow.Reducible", "Execution flow must be reducible")
         self.add_valrule("Flow.NoRecusion", "Recursion is not permitted")
         self.add_valrule("Flow.DeadLoop", "Loop must have break")
-        self.add_valrule_msg("Flow.FunctionCall", "Function with parameter is not permitted", "Function %0 with parameter is not permitted, it should be inlined")
+        self.add_valrule_msg("Flow.FunctionCall", "Function with parameter is not permitted. This rule only works for DXIL1.0. Later version allow function with parameter except entry function and patch constant function", "Function %0 with parameter is not permitted, it should be inlined")
 
         self.add_valrule_msg("Decl.DxilNsReserved", "The DXIL reserved prefixes must only be used by built-in functions and types", "Declaration '%0' uses a reserved prefix")
         self.add_valrule_msg("Decl.DxilFnExtern", "External function must be a DXIL function", "External function '%0' is not a DXIL function")


### PR DESCRIPTION
1. Allow handle pointer type for DXIL1.1.
2. Allow parameter for non-entry function for DXIL1.1.
3. Allow find resource attribute from parameter annotation for DXIL1.1.
4. Not inline when O0 for SM6.1
5. Allow noalias metadata.