### PR TITLE
Lower static global resource and local resource to handle.

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -46,6 +46,7 @@ ModulePass *createDxilLoadMetadataPass();
 ModulePass *createDxilPrecisePropagatePass();
 FunctionPass *createDxilLegalizeResourceUsePass();
 ModulePass *createDxilLegalizeStaticResourceUsePass();
+ModulePass *createDxilLegalizeEvalOperationsPass();
 FunctionPass *createDxilLegalizeSampleOffsetPass();
 FunctionPass *createSimplifyInstPass();
 
@@ -58,6 +59,7 @@ void initializeDxilLoadMetadataPass(llvm::PassRegistry&);
 void initializeDxilPrecisePropagatePassPass(llvm::PassRegistry&);
 void initializeDxilLegalizeResourceUsePassPass(llvm::PassRegistry&);
 void initializeDxilLegalizeStaticResourceUsePassPass(llvm::PassRegistry&);
+void initializeDxilLegalizeEvalOperationsPass(llvm::PassRegistry&);
 void initializeDxilLegalizeSampleOffsetPassPass(llvm::PassRegistry&);
 void initializeSimplifyInstPass(llvm::PassRegistry&);
 

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -198,6 +198,7 @@ public:
   static unsigned
   GetLegacyCBufferFieldElementSize(DxilFieldAnnotation &fieldAnnotation,
                                    llvm::Type *Ty, DxilTypeSystem &typeSys);
+  static llvm::Type *GetArrayEltTy(llvm::Type *Ty);
 
   static bool IsStaticGlobal(llvm::GlobalVariable *GV);
   static bool IsSharedMemoryGlobal(llvm::GlobalVariable *GV);

--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -255,6 +255,7 @@ void initializeSROA_DT_HLSLPass(PassRegistry&);
 void initializeSROA_Parameter_HLSLPass(PassRegistry&);
 void initializeDynamicIndexingVectorToArrayPass(PassRegistry&);
 void initializeMultiDimArrayToOneDimArrayPass(PassRegistry&);
+void initializeResourceToHandlePass(PassRegistry&);
 void initializeSROA_SSAUp_HLSLPass(PassRegistry&);
 void initializeHoistConstantArrayPass(PassRegistry&);
 // HLSL Change Ends

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -134,6 +134,11 @@ void initializeDynamicIndexingVectorToArrayPass(PassRegistry&);
 //
 ModulePass *createMultiDimArrayToOneDimArrayPass();
 void initializeMultiDimArrayToOneDimArrayPass(PassRegistry&);
+//===----------------------------------------------------------------------===//
+// Flatten resource into handle.
+//
+ModulePass *createResourceToHandlePass();
+void initializeResourceToHandlePass(PassRegistry&);
 
 //===----------------------------------------------------------------------===//
 // Hoist a local array initialized with constant values to a global array with

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -124,6 +124,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeReassociatePass(Registry);
     initializeReducibilityAnalysisPass(Registry);
     initializeRegToMemHlslPass(Registry);
+    initializeResourceToHandlePass(Registry);
     initializeRewriteSymbolsPass(Registry);
     initializeSCCPPass(Registry);
     initializeSROAPass(Registry);
@@ -160,7 +161,7 @@ static ArrayRef<LPCSTR> GetPassArgNames(LPCSTR passName) {
   static const LPCSTR ArgPromotionArgs[] = { "maxElements" };
   static const LPCSTR CFGSimplifyPassArgs[] = { "Threshold", "Ftor", "bonus-inst-threshold" };
   static const LPCSTR DxilGenerationPassArgs[] = { "NotOptimized" };
-  static const LPCSTR DynamicIndexingVectorToArrayArgs[] = { "ReplaceAllVector" };
+  static const LPCSTR DynamicIndexingVectorToArrayArgs[] = { "ReplaceAllVectors" };
   static const LPCSTR Float2IntArgs[] = { "float2int-max-integer-bw" };
   static const LPCSTR GVNArgs[] = { "noloads", "enable-pre", "enable-load-pre", "max-recurse-depth" };
   static const LPCSTR JumpThreadingArgs[] = { "Threshold", "jump-threading-threshold" };
@@ -296,7 +297,7 @@ static bool IsPassOptionName(StringRef S) {
     ||  S.equals("MaxHeaderSize")
     ||  S.equals("NotOptimized")
     ||  S.equals("Os")
-    ||  S.equals("ReplaceAllVector")
+    ||  S.equals("ReplaceAllVectors")
     ||  S.equals("RequiresDomTree")
     ||  S.equals("Runtime")
     ||  S.equals("ScalarLoadThreshold")

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -83,6 +83,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilCondenseResourcesPass(Registry);
     initializeDxilEmitMetadataPass(Registry);
     initializeDxilGenerationPassPass(Registry);
+    initializeDxilLegalizeEvalOperationsPass(Registry);
     initializeDxilLegalizeResourceUsePassPass(Registry);
     initializeDxilLegalizeSampleOffsetPassPass(Registry);
     initializeDxilLegalizeStaticResourceUsePassPass(Registry);

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -256,7 +256,6 @@ public:
     // Load up debug information, to cross-reference values and the instructions
     // used to load them.
     m_HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
-    LegalizeEvalOperations(M);
     if (!SM->IsCS()) {
       CreateDxilSignatures();
 
@@ -381,10 +380,6 @@ private:
   // For validation
   std::unordered_map<unsigned, std::unordered_set<unsigned> > m_InputSemanticsUsed,
     m_OutputSemanticsUsed[4], m_PatchConstantSemanticsUsed, m_OtherSemanticsUsed;
-
-  // For EvaluateAttribute operations.
-  void LegalizeEvalOperations(Module &M);
-  void FindAllocasForEvalOperations(Value *f, std::unordered_set<AllocaInst*> &allocas);
 };
 
 class SimplifyInst : public FunctionPass {
@@ -2708,81 +2703,6 @@ void DxilGenerationPass::UpdateStructTypeForLegacyLayout() {
   UpdateStructTypeForLegacyLayoutOnHLM(*m_pHLModule);
 }
 
-// Find allocas for EvaluateAttribute operations
-void DxilGenerationPass::FindAllocasForEvalOperations(
-    Value *val, std::unordered_set<AllocaInst *> &allocas) {
-  Value *CurVal = val;
-  while (!isa<AllocaInst>(CurVal)) {
-    if (CallInst *CI = dyn_cast<CallInst>(CurVal)) {
-      CurVal = CI->getOperand(HLOperandIndex::kUnaryOpSrc0Idx);
-    } else if (InsertElementInst *IE = dyn_cast<InsertElementInst>(CurVal)) {
-      Value *arg0 =
-          IE->getOperand(0); // Could be another insertelement or undef
-      Value *arg1 = IE->getOperand(1);
-      FindAllocasForEvalOperations(arg0, allocas);
-      CurVal = arg1;
-    } else if (ShuffleVectorInst *SV = dyn_cast<ShuffleVectorInst>(CurVal)) {
-      Value *arg0 = SV->getOperand(0);
-      Value *arg1 = SV->getOperand(1);
-      FindAllocasForEvalOperations(
-          arg0, allocas); // Shuffle vector could come from different allocas
-      CurVal = arg1;
-    } else if (ExtractElementInst *EE = dyn_cast<ExtractElementInst>(CurVal)) {
-      CurVal = EE->getOperand(0);
-    } else if (LoadInst *LI = dyn_cast<LoadInst>(CurVal)) {
-      CurVal = LI->getOperand(0);
-    } else {
-      break;
-    }
-  }
-  if (AllocaInst *AI = dyn_cast<AllocaInst>(CurVal)) {
-    allocas.insert(AI);
-  }
-}
-
-// This is needed in order to translate EvaluateAttribute operations that traces
-// back to LoadInput operations during translation stage. Promoting load/store
-// instructions beforehand will allow us to easily trace back to loadInput from
-// function call.
-void DxilGenerationPass::LegalizeEvalOperations(Module &M) {
-  for (Function &F : M.getFunctionList()) {
-    hlsl::HLOpcodeGroup group = hlsl::GetHLOpcodeGroup(&F);
-    if (group != HLOpcodeGroup::NotHL) {
-      std::vector<CallInst *> EvalFunctionCalls;
-      // Find all EvaluateAttribute calls
-      for (User *U : F.users()) {
-        if (CallInst *CI = dyn_cast<CallInst>(U)) {
-          IntrinsicOp evalOp = static_cast<IntrinsicOp>(hlsl::GetHLOpcode(CI));
-          if (evalOp == IntrinsicOp::IOP_EvaluateAttributeAtSample ||
-            evalOp == IntrinsicOp::IOP_EvaluateAttributeCentroid ||
-            evalOp == IntrinsicOp::IOP_EvaluateAttributeSnapped) {
-            EvalFunctionCalls.push_back(CI);
-          }
-        }
-      }
-      if (EvalFunctionCalls.empty()) {
-        continue;
-      }
-      // Start from the call instruction, find all allocas that this call uses.
-      std::unordered_set<AllocaInst *> allocas;
-      for (CallInst *CI : EvalFunctionCalls) {
-        FindAllocasForEvalOperations(CI, allocas);
-      }
-      SSAUpdater SSA;
-      SmallVector<Instruction *, 4> Insts;
-      for (AllocaInst *AI : allocas) {
-        for (User *user : AI->users()) {
-          if (isa<LoadInst>(user) || isa<StoreInst>(user)) {
-            Insts.emplace_back(cast<Instruction>(user));
-          }
-        }
-        LoadAndStorePromoter(Insts, SSA).run(Insts);
-        Insts.clear();
-      }
-    }
-  }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 
 namespace {
@@ -3449,3 +3369,111 @@ ModulePass *llvm::createDxilLegalizeStaticResourceUsePass() {
 INITIALIZE_PASS(DxilLegalizeStaticResourceUsePass,
                 "hlsl-dxil-legalize-static-resource-use",
                 "DXIL legalize static resource use", false, false)
+
+///////////////////////////////////////////////////////////////////////////////
+// Legalize EvalOperations.
+// Make sure src of EvalOperations are from function parameter.
+// This is needed in order to translate EvaluateAttribute operations that traces
+// back to LoadInput operations during translation stage. Promoting load/store
+// instructions beforehand will allow us to easily trace back to loadInput from
+// function call.
+namespace {
+
+class DxilLegalizeEvalOperations : public ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit DxilLegalizeEvalOperations() : ModulePass(ID) {}
+
+  const char *getPassName() const override {
+    return "DXIL Legalize EvalOperations";
+  }
+
+  bool runOnModule(Module &M) override {
+    for (Function &F : M.getFunctionList()) {
+      hlsl::HLOpcodeGroup group = hlsl::GetHLOpcodeGroup(&F);
+      if (group != HLOpcodeGroup::NotHL) {
+        std::vector<CallInst *> EvalFunctionCalls;
+        // Find all EvaluateAttribute calls
+        for (User *U : F.users()) {
+          if (CallInst *CI = dyn_cast<CallInst>(U)) {
+            IntrinsicOp evalOp =
+                static_cast<IntrinsicOp>(hlsl::GetHLOpcode(CI));
+            if (evalOp == IntrinsicOp::IOP_EvaluateAttributeAtSample ||
+                evalOp == IntrinsicOp::IOP_EvaluateAttributeCentroid ||
+                evalOp == IntrinsicOp::IOP_EvaluateAttributeSnapped) {
+              EvalFunctionCalls.push_back(CI);
+            }
+          }
+        }
+        if (EvalFunctionCalls.empty()) {
+          continue;
+        }
+        // Start from the call instruction, find all allocas that this call
+        // uses.
+        std::unordered_set<AllocaInst *> allocas;
+        for (CallInst *CI : EvalFunctionCalls) {
+          FindAllocasForEvalOperations(CI, allocas);
+        }
+        SSAUpdater SSA;
+        SmallVector<Instruction *, 4> Insts;
+        for (AllocaInst *AI : allocas) {
+          for (User *user : AI->users()) {
+            if (isa<LoadInst>(user) || isa<StoreInst>(user)) {
+              Insts.emplace_back(cast<Instruction>(user));
+            }
+          }
+          LoadAndStorePromoter(Insts, SSA).run(Insts);
+          Insts.clear();
+        }
+      }
+    }
+    return true;
+  }
+
+private:
+  void FindAllocasForEvalOperations(Value *val,
+                                    std::unordered_set<AllocaInst *> &allocas);
+};
+
+char DxilLegalizeEvalOperations::ID = 0;
+
+// Find allocas for EvaluateAttribute operations
+void DxilLegalizeEvalOperations::FindAllocasForEvalOperations(
+    Value *val, std::unordered_set<AllocaInst *> &allocas) {
+  Value *CurVal = val;
+  while (!isa<AllocaInst>(CurVal)) {
+    if (CallInst *CI = dyn_cast<CallInst>(CurVal)) {
+      CurVal = CI->getOperand(HLOperandIndex::kUnaryOpSrc0Idx);
+    } else if (InsertElementInst *IE = dyn_cast<InsertElementInst>(CurVal)) {
+      Value *arg0 =
+          IE->getOperand(0); // Could be another insertelement or undef
+      Value *arg1 = IE->getOperand(1);
+      FindAllocasForEvalOperations(arg0, allocas);
+      CurVal = arg1;
+    } else if (ShuffleVectorInst *SV = dyn_cast<ShuffleVectorInst>(CurVal)) {
+      Value *arg0 = SV->getOperand(0);
+      Value *arg1 = SV->getOperand(1);
+      FindAllocasForEvalOperations(
+          arg0, allocas); // Shuffle vector could come from different allocas
+      CurVal = arg1;
+    } else if (ExtractElementInst *EE = dyn_cast<ExtractElementInst>(CurVal)) {
+      CurVal = EE->getOperand(0);
+    } else if (LoadInst *LI = dyn_cast<LoadInst>(CurVal)) {
+      CurVal = LI->getOperand(0);
+    } else {
+      break;
+    }
+  }
+  if (AllocaInst *AI = dyn_cast<AllocaInst>(CurVal)) {
+    allocas.insert(AI);
+  }
+}
+} // namespace
+
+ModulePass *llvm::createDxilLegalizeEvalOperationsPass() {
+  return new DxilLegalizeEvalOperations();
+}
+
+INITIALIZE_PASS(DxilLegalizeEvalOperations,
+                "hlsl-dxil-legalize-eval-operations",
+                "DXIL legalize eval operations", false, false)

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -874,6 +874,15 @@ bool HLModule::IsHLSLObjectType(llvm::Type *Ty) {
   return false;
 }
 
+Type *HLModule::GetArrayEltTy(Type *Ty) {
+  if (isa<PointerType>(Ty))
+    Ty = Ty->getPointerElementType();
+  while (isa<ArrayType>(Ty)) {
+    Ty = Ty->getArrayElementType();
+  }
+  return Ty;
+}
+
 unsigned
 HLModule::GetLegacyCBufferFieldElementSize(DxilFieldAnnotation &fieldAnnotation,
                                            llvm::Type *Ty,

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -2339,6 +2339,10 @@ SampleHelper::SampleHelper(
   samplerHandle = CI->getArgOperand(kSamplerArgIndex);
 
   DXIL::ResourceKind RK = pObjHelper->GetRK(texHandle);
+  if (RK == DXIL::ResourceKind::Invalid) {
+    opcode = DXIL::OpCode::NumOpCodes;
+    return;
+  }
   unsigned coordDimensions = DxilResource::GetNumCoords(RK);
   unsigned offsetDimensions = DxilResource::GetNumOffsets(RK);
 
@@ -2676,6 +2680,10 @@ GatherHelper::GatherHelper(
   samplerHandle = CI->getArgOperand(kSamplerArgIndex);
 
   DXIL::ResourceKind RK = pObjHelper->GetRK(texHandle);
+  if (RK == DXIL::ResourceKind::Invalid) {
+    opcode = DXIL::OpCode::NumOpCodes;
+    return;
+  }
   unsigned coordSize = DxilResource::GetNumCoords(RK);
   unsigned offsetSize = DxilResource::GetNumOffsets(RK);
 

--- a/lib/IR/Pass.cpp
+++ b/lib/IR/Pass.cpp
@@ -320,7 +320,7 @@ bool llvm::GetPassOption(PassOptions &O, StringRef name, StringRef *pValue) {
 bool llvm::GetPassOptionBool(PassOptions &O, llvm::StringRef name, bool *pValue, bool defaultValue) {
   StringRef val;
   if (GetPassOption(O, name, &val)) {
-    *pValue = (name.startswith_lower("t") || name.equals("1"));
+    *pValue = (val.startswith_lower("t") || val.equals("1"));
     return true;
   }
   *pValue = defaultValue;
@@ -329,7 +329,7 @@ bool llvm::GetPassOptionBool(PassOptions &O, llvm::StringRef name, bool *pValue,
 bool llvm::GetPassOptionUnsigned(PassOptions &O, llvm::StringRef name, unsigned *pValue, unsigned defaultValue) {
   StringRef val;
   if (GetPassOption(O, name, &val)) {
-    name.getAsInteger<unsigned>(0, *pValue);
+    val.getAsInteger<unsigned>(0, *pValue);
     return true;
   }
   *pValue = defaultValue;
@@ -338,7 +338,7 @@ bool llvm::GetPassOptionUnsigned(PassOptions &O, llvm::StringRef name, unsigned 
 bool llvm::GetPassOptionInt(PassOptions &O, llvm::StringRef name, int *pValue, int defaultValue) {
   StringRef val;
   if (GetPassOption(O, name, &val)) {
-    name.getAsInteger<int>(0, *pValue);
+    val.getAsInteger<int>(0, *pValue);
     return true;
   }
   *pValue = defaultValue;
@@ -347,7 +347,7 @@ bool llvm::GetPassOptionInt(PassOptions &O, llvm::StringRef name, int *pValue, i
 bool llvm::GetPassOptionUInt32(PassOptions &O, llvm::StringRef name, uint32_t *pValue, uint32_t defaultValue) {
   StringRef val;
   if (GetPassOption(O, name, &val)) {
-    name.getAsInteger<uint32_t>(0, *pValue);
+    val.getAsInteger<uint32_t>(0, *pValue);
     return true;
   }
   *pValue = defaultValue;

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -207,6 +207,12 @@ static void addHLSLPasses(bool HLSLHighLevel, bool NoOpt, hlsl::HLSLExtensionsCo
   MPM.add(createDeadCodeEliminationPass());
   MPM.add(createGlobalDCEPass());
 
+  if (NoOpt) {
+    // If not run mem2reg, try to promote allocas used by EvalOperations.
+    // Do this before change vector to array.
+    MPM.add(createDxilLegalizeEvalOperationsPass());
+  }
+
   // Change dynamic indexing vector to array.
   MPM.add(createDynamicIndexingVectorToArrayPass(NoOpt));
 

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -202,12 +202,18 @@ static void addHLSLPasses(bool HLSLHighLevel, bool NoOpt, hlsl::HLSLExtensionsCo
                                              /*Promote*/ !NoOpt));
 
   MPM.add(createHLMatrixLowerPass());
+  MPM.add(createResourceToHandlePass());
   // DCE should after SROA to remove unused element.
   MPM.add(createDeadCodeEliminationPass());
   MPM.add(createGlobalDCEPass());
 
   // Change dynamic indexing vector to array.
   MPM.add(createDynamicIndexingVectorToArrayPass(NoOpt));
+
+  if (!NoOpt) {
+    // mem2reg
+    MPM.add(createPromoteMemoryToRegisterPass());
+  }
 
   MPM.add(createSimplifyInstPass());
   MPM.add(createCFGSimplificationPass());
@@ -218,11 +224,6 @@ static void addHLSLPasses(bool HLSLHighLevel, bool NoOpt, hlsl::HLSLExtensionsCo
   MPM.add(createDxilLoadMetadataPass()); // Ensure DxilModule is loaded for optimizations.
 
   MPM.add(createSimplifyInstPass());
-
-  if (!NoOpt) {
-    // mem2reg
-    MPM.add(createPromoteMemoryToRegisterPass());
-  }
 
   // Propagate precise attribute.
   MPM.add(createDxilPrecisePropagatePass());

--- a/tools/clang/test/CodeGenHLSL/eval.hlsl
+++ b/tools/clang/test/CodeGenHLSL/eval.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -Od -Zi %s | FileCheck %s
 
 // CHECK: evalCentroid
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1248,7 +1248,7 @@ class db_dxil(object):
         add_pass('die', 'DeadInstElimination', 'Dead Instruction Elimination', [])
         add_pass('globaldce', 'GlobalDCE', 'Dead Global Elimination', [])
         add_pass('dynamic-vector-to-array', 'DynamicIndexingVectorToArray', 'Replace dynamic indexing vector with array', [
-            {'n':'ReplaceAllVector','t':'ReplaceAllVector','c':1}])
+            {'n':'ReplaceAllVectors','t':'bool','c':1}])
         add_pass('hlsl-dxil-legalize-resource-use', 'DxilLegalizeResourceUsePass', 'DXIL legalize resource use', [])
         add_pass('hlsl-dxil-legalize-static-resource-use', 'DxilLegalizeStaticResourceUsePass', 'DXIL legalize static resource use', [])
         add_pass('dxilgen', 'DxilGenerationPass', 'HLSL DXIL Generation', [
@@ -1259,6 +1259,7 @@ class db_dxil(object):
         add_pass('dxil-legalize-sample-offset', 'DxilLegalizeSampleOffsetPass', 'DXIL legalize sample offset', [])
         add_pass('scalarizer', 'Scalarizer', 'Scalarize vector operations', [])
         add_pass('multi-dim-one-dim', 'MultiDimArrayToOneDimArray', 'Flatten multi-dim array into one-dim array', [])
+        add_pass('resource-handle', 'ResourceToHandle', 'Lower resource into handle', [])
         add_pass('hlsl-dxil-condense', 'DxilCondenseResources', 'DXIL Condense Resources', [])
         add_pass('hlsl-dxilemit', 'DxilEmitMetadata', 'HLSL DXIL Metadata Emit', [])
         add_pass('hlsl-dxilload', 'DxilLoadMetadata', 'HLSL DXIL Metadata Load', [])

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1251,6 +1251,7 @@ class db_dxil(object):
             {'n':'ReplaceAllVectors','t':'bool','c':1}])
         add_pass('hlsl-dxil-legalize-resource-use', 'DxilLegalizeResourceUsePass', 'DXIL legalize resource use', [])
         add_pass('hlsl-dxil-legalize-static-resource-use', 'DxilLegalizeStaticResourceUsePass', 'DXIL legalize static resource use', [])
+        add_pass('hlsl-dxil-legalize-eval-operations', 'DxilLegalizeEvalOperations', 'DXIL legalize eval operations', [])
         add_pass('dxilgen', 'DxilGenerationPass', 'HLSL DXIL Generation', [
             {'n':'NotOptimized','t':'bool','c':1}])
         add_pass('simplify-inst', 'SimplifyInst', 'Simplify Instructions', [])


### PR DESCRIPTION
    1. Add ResourceToHandle pass to lower resource to handle.
    2. Don't performPromotion in SROA_HLSL.
    3. Add Option support for DynamicIndexingVectorToArray.
    4. Fix bug in GetPassOption.
    5. Replace GEP ptr, 0 with ptr in DynamicIndexingVectorToArray::ReplaceStaticIndexingOnVector.
    6. Run mem2reg before DxilGenerationPass.
    7. Legalize EvalOperations before change vector to array.