### PR TITLE
[spirv] Add SPIRV-Headers and SPIRV-Tools as external dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ tools/polly
 docs/_build
 # TAEF crash logs.
 WexLogFileOutput/*
+# SPIR-V dependencies.
+external/SPIRV-Headers
+external/SPIRV-Tools
 
 #==============================================================================#
 # Files created in tree by the Go bindings.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,8 @@ if(WITH_POLLY)
   endif()
 endif(WITH_POLLY)
 
+add_subdirectory(external) # SPIRV change
+
 if( LLVM_INCLUDE_TOOLS )
   add_subdirectory(tools)
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Define root location for all external dependencies
+set(DXC_EXTERNAL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}"
+    CACHE STRING "Root location of all external projects")
+
+# Enabling SPIR-V codegen requires SPIRV-Headers for spirv.hpp and
+# SPIRV-Tools for SPIR-V disassembling functionality.
+if (${ENABLE_SPIRV_CODEGEN})
+  set(DXC_SPIRV_HEADERS_DIR "${DXC_EXTERNAL_ROOT_DIR}/SPIRV-Headers"
+      CACHE STRING "Location of SPIRV-Headers source")
+  set(DXC_SPIRV_TOOLS_DIR "${DXC_EXTERNAL_ROOT_DIR}/SPIRV-Tools"
+      CACHE STRING "Location of SPIRV-Tools source")
+
+  if (IS_DIRECTORY ${DXC_SPIRV_HEADERS_DIR})
+    add_subdirectory(${DXC_SPIRV_HEADERS_DIR})
+  endif()
+  if (NOT DEFINED SPIRV-Headers_SOURCE_DIR)
+    message(FATAL_ERROR "SPIRV-Headers was not found - required for SPIR-V codegen")
+  else()
+    set(SPIRV_HEADER_INCLUDE_DIR ${SPIRV-Headers_SOURCE_DIR}/include PARENT_SCOPE)
+  endif()
+
+  if (IS_DIRECTORY ${DXC_SPIRV_TOOLS_DIR})
+    # We only need the library from SPIRV-Tools.
+    set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "Skip building SPIRV-Tools executables")
+    add_subdirectory(${DXC_SPIRV_TOOLS_DIR})
+  endif()
+  if (NOT TARGET SPIRV-Tools)
+    message(FATAL_ERROR "SPIRV-Tools was not found - required for SPIR-V codegen")
+  endif()
+
+  set(SPIRV_DEP_TARGETS
+    SPIRV-Tools
+    SPIRV-Tools-opt
+    spirv-tools-build-version
+    spirv-tools-spv-amd-gcn-shader
+    spirv-tools-vimsyntax
+    install-headers
+    SPIRV-Headers-example
+    SPIRV-Headers-example-1.1
+  )
+
+  # Organize these targets better in Visual Studio
+  foreach(target ${SPIRV_DEP_TARGETS})
+    set_property(TARGET ${target} PROPERTY FOLDER "External dependencies")
+  endforeach()
+endif()


### PR DESCRIPTION
We need SPIRV-Headers for spirv.hpp11 and SPIRV-Tools for SPIR-V
diassembling.

cc @dneto0 @ehsannas