### PR TITLE
Allow two SV_Barycentrics

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2777,6 +2777,7 @@ INSTR.WRITEMASKFORTYPEDUAVSTORE        store on typed uav must write to all four
 INSTR.WRITEMASKMATCHVALUEFORUAVSTORE   uav store write mask must match store value mask, write mask is %0 and store value mask is %1
 META.BARYCENTRICSFLOAT3                only 'float3' type is allowed for SV_Barycentrics.
 META.BARYCENTRICSINTERPOLATION         SV_Barycentrics cannot be used with 'nointerpolation' type
+META.BARYCENTRICSTWOPERSPECTIVES       There can only be up to two input attributes of SV_Barycentrics with different perspective interpolation mode.
 META.BRANCHFLATTEN                     Can't use branch and flatten attributes together
 META.CLIPCULLMAXCOMPONENTS             Combined elements of SV_ClipDistance and SV_CullDistance must fit in 8 components
 META.CLIPCULLMAXROWS                   Combined elements of SV_ClipDistance and SV_CullDistance must fit in two rows.

--- a/include/dxc/HLSL/DxilValidation.h
+++ b/include/dxc/HLSL/DxilValidation.h
@@ -117,6 +117,7 @@ enum class ValidationRule : unsigned {
   // Metadata
   MetaBarycentricsFloat3, // only 'float3' type is allowed for SV_Barycentrics.
   MetaBarycentricsInterpolation, // SV_Barycentrics cannot be used with 'nointerpolation' type
+  MetaBarycentricsTwoPerspectives, // There can only be up to two input attributes of SV_Barycentrics with different perspective interpolation mode.
   MetaBranchFlatten, // Can't use branch and flatten attributes together
   MetaClipCullMaxComponents, // Combined elements of SV_ClipDistance and SV_CullDistance must fit in 8 components
   MetaClipCullMaxRows, // Combined elements of SV_ClipDistance and SV_CullDistance must fit in two rows.

--- a/tools/clang/test/CodeGenHLSL/barycentrics1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/barycentrics1.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T ps_6_1 %s | FileCheck %s
+
+// CHECK: ; SV_Barycentrics
+// CHECK: ; SV_Barycentrics
+// CHECK: ; SV_Barycentrics
+// CHECK: ; SV_Barycentrics
+
+float4 main(float3 bary : SV_Barycentrics, noperspective float3 bary1 : SV_Barycentrics1) : SV_Target
+{
+  float4 vcolor0 = float4(1,0,0,1);
+  float4 vcolor1 = float4(0,1,0,1);
+  float4 vcolor2 = float4(0,0,0,1);
+  float4 vcolorPerspective =  bary.x * vcolor0 + bary.y * vcolor1 + bary.z * vcolor2;
+  float4 vcolorNoPerspectiveCentroid = bary1.x * vcolor0 + bary1.y * vcolor1 + bary1.z * vcolor2;
+  return (vcolorPerspective + vcolorNoPerspectiveCentroid) / 2;
+}

--- a/tools/clang/test/CodeGenHLSL/barycentricsThreeSV.hlsl
+++ b/tools/clang/test/CodeGenHLSL/barycentricsThreeSV.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -E main -T ps_6_1 %s | FileCheck %s
+
+// CHECK: There can only be up to two input attributes of SV_Barycentrics with different perspective interpolation mode.
+
+float4 main(float3 bary : SV_Barycentrics, noperspective float3 bary1 : SV_Barycentrics1, float3 bary2 : SV_Barycentrics2) : SV_Target
+{
+  return 1;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -970,6 +970,8 @@ static void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
     case DxilProgramSigSemantic::FinalLineDensityTessfactor:
       pSysValue = "LINEDEN";
       break;
+    case DxilProgramSigSemantic::Barycentrics:
+      pSysValue = "BARYCEN";
     }
     OS << right_justify(pSysValue, 9);
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -375,6 +375,8 @@ public:
   TEST_METHOD(CodeGenAtomic)
   TEST_METHOD(CodeGenAttributeAtVertex)
   TEST_METHOD(CodeGenBarycentrics)
+  TEST_METHOD(CodeGenBarycentrics1)
+  TEST_METHOD(CodeGenBarycentricsThreeSV)
   TEST_METHOD(CodeGenBinary1)
   TEST_METHOD(CodeGenBoolComb)
   TEST_METHOD(CodeGenBoolSvTarget)
@@ -2231,6 +2233,16 @@ TEST_F(CompilerTest, CodeGenAttributeAtVertex) {
 TEST_F(CompilerTest, CodeGenBarycentrics) {
   if (m_ver.SkipDxil_1_1_Test()) return;
   CodeGenTestCheck(L"..\\CodeGenHLSL\\barycentrics.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenBarycentrics1) {
+  if (m_ver.SkipDxil_1_1_Test()) return;
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\barycentrics1.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenBarycentricsThreeSV) {
+  if (m_ver.SkipDxil_1_1_Test()) return;
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\barycentricsThreeSV.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenBinary1) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -203,6 +203,7 @@ public:
 
   TEST_METHOD(BarycentricFloat4Fail)
   TEST_METHOD(BarycentricNoInterpolationFail)
+  TEST_METHOD(BarycentricSamePerspectiveFail)
   TEST_METHOD(ClipCullMaxComponents)
   TEST_METHOD(ClipCullMaxRows)
   TEST_METHOD(DuplicateSysValue)
@@ -2995,6 +2996,18 @@ TEST_F(ValidationTest, BarycentricFloat4Fail) {
       "float4 main(float4 col : COLOR) : SV_Target { return col; }", "ps_6_1",
       {"!\"COLOR\", i8 9, i8 0"}, {"!\"SV_Barycentrics\", i8 9, i8 28"},
       "only 'float3' type is allowed for SV_Barycentrics.", false);
+}
+
+TEST_F(ValidationTest, BarycentricSamePerspectiveFail) {
+  if (m_ver.SkipDxil_1_1_Test()) return;
+  RewriteAssemblyCheckMsg(
+      "float4 main(float3 bary : SV_Barycentrics, noperspective float3 bary1 : "
+      "SV_Barycentrics1) : SV_Target { return 1; }",
+      "ps_6_1", {"!\"SV_Barycentrics\", i8 9, i8 28, (![0-9]+), i8 4"},
+      {"!\"SV_Barycentrics\", i8 9, i8 28, \\1, i8 2"},
+      "There can only be up to two input attributes of SV_Barycentrics with "
+      "different perspective interpolation mode.",
+      true);
 }
 
 // TODO: reject non-zero padding

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -202,6 +202,7 @@ public:
   TEST_METHOD(AddUint64Odd)
 
   TEST_METHOD(BarycentricFloat4Fail)
+  TEST_METHOD(BarycentricMaxIndexFail)
   TEST_METHOD(BarycentricNoInterpolationFail)
   TEST_METHOD(BarycentricSamePerspectiveFail)
   TEST_METHOD(ClipCullMaxComponents)
@@ -2978,6 +2979,21 @@ TEST_F(ValidationTest, GetAttributeAtVertexInterpFail) {
                           /*bRegex*/ true);
 }
 
+TEST_F(ValidationTest, BarycentricMaxIndexFail) {
+  if (m_ver.SkipDxil_1_1_Test()) return;
+  RewriteAssemblyCheckMsg(
+      "float4 main(float3 bary : SV_Barycentrics, noperspective float3 bary1 : "
+      "SV_Barycentrics1) : SV_Target { return 1; }",
+      "ps_6_1",
+      {"!([0-9]+) = !{i32 0, !\"SV_Barycentrics\", i8 9, i8 28, !([0-9]+), i8 "
+       "2, i32 1, i8 3, i32 -1, i8 -1, null}\n"
+       "!([0-9]+) = !{i32 0}"},
+      {"!\\1 = !{i32 0, !\"SV_Barycentrics\", i8 9, i8 28, !\\2, i8 2, i32 1, "
+       "i8 3, i32 -1, i8 -1, null}\n"
+       "!\\3 = !{i32 2}"},
+      "SV_Barycentrics semantic index exceeds maximum", /*bRegex*/ true);
+}
+
 TEST_F(ValidationTest, BarycentricNoInterpolationFail) {
   if (m_ver.SkipDxil_1_1_Test()) return;
   RewriteAssemblyCheckMsg(
@@ -3009,5 +3025,7 @@ TEST_F(ValidationTest, BarycentricSamePerspectiveFail) {
       "different perspective interpolation mode.",
       true);
 }
+
+
 
 // TODO: reject non-zero padding

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1546,6 +1546,7 @@ class db_dxil(object):
         self.add_valrule("Meta.TextureType", "elements of typed buffers and textures must fit in four 32-bit quantities")
         self.add_valrule("Meta.BarycentricsInterpolation", "SV_Barycentrics cannot be used with 'nointerpolation' type")
         self.add_valrule("Meta.BarycentricsFloat3", "only 'float3' type is allowed for SV_Barycentrics.")
+        self.add_valrule("Meta.BarycentricsTwoPerspectives", "There can only be up to two input attributes of SV_Barycentrics with different perspective interpolation mode.")
 
         self.add_valrule("Instr.Oload", "DXIL intrinsic overload must be valid")
         self.add_valrule_msg("Instr.CallOload", "Call to DXIL intrinsic must match overload signature", "Call to DXIL intrinsic '%0' does not match an allowed overload signature")


### PR DESCRIPTION
Unlike other system value semantics, pixel shader is allowed to declare at most two input attributes with SV_Barycentrics such that one declaration uses perspective interpolation type, while other declaration uses noperspective interpolation type.