### PR TITLE
Generate GEP for DerivedToBase instead of bitcast.

### DIFF
--- a/tools/clang/include/clang/AST/OperationKinds.h
+++ b/tools/clang/include/clang/AST/OperationKinds.h
@@ -311,6 +311,7 @@ enum CastKind {
   CK_HLSLMatrixTruncationCast,
   CK_HLSLVectorToMatrixCast,
   CK_HLSLMatrixToVectorCast,
+  CK_HLSLDerivedToBase,
   // HLSL ComponentConversion (HLSLCC) Casts:
   CK_HLSLCC_IntegralCast,
   CK_HLSLCC_IntegralToBoolean,

--- a/tools/clang/include/clang/Sema/Overload.h
+++ b/tools/clang/include/clang/Sema/Overload.h
@@ -96,6 +96,7 @@ namespace clang {
     ICK_Flat_Conversion,       ///< Flat assignment conversion for HLSL (inline conversion, straddled)
     ICK_HLSLVector_Splat,      ///< HLSLVector/Matrix splat
     ICK_HLSLVector_Truncation, ///< HLSLVector/Matrix truncation
+    ICK_HLSL_Derived_To_Base,  ///< HLSL Derived-to-base
     // HLSL Change Ends
 
     ICK_Num_Conversion_Kinds   ///< The number of conversion kinds

--- a/tools/clang/lib/Sema/SemaExprCXX.cpp
+++ b/tools/clang/lib/Sema/SemaExprCXX.cpp
@@ -3433,6 +3433,7 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
       
   // HLSL Change Starts
   case ICK_Flat_Conversion:
+  case ICK_HLSL_Derived_To_Base:
   case ICK_HLSLVector_Splat:
   case ICK_HLSLVector_Scalar:
   case ICK_HLSLVector_Truncation:

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -140,6 +140,7 @@ ImplicitConversionRank clang::GetConversionRank(ImplicitConversionKind Kind) {
     ICR_Conversion,
     ICR_Conversion,
     ICR_Conversion,
+    ICR_Conversion,
     // HLSL Change Ends
   };
   static_assert(_countof(Rank) == ICK_Num_Conversion_Kinds,
@@ -184,6 +185,7 @@ static const char* GetImplicitConversionName(ImplicitConversionKind Kind) {
     "Flat assignment conversion",
     "HLSLVector/Matrix splat",
     "HLSLVector/Matrix truncation",
+    "HLSL derived to base",
     // HLSL Change Ends
   };
   static_assert(_countof(Name) == ICK_Num_Conversion_Kinds,

--- a/tools/clang/test/CodeGenHLSL/cast7.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast7.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -E main -T ps_6_0 %s -fcgl | FileCheck %s
+
+// Make sure no bitcast to %struct.A*.
+// CHECK-NOT: to %struct.A*
+
+struct A {
+   float a;
+};
+
+struct B : A {
+   float b;
+};
+
+A  ga;
+float2 ib;
+
+float main() : SV_Target
+{
+  B b = {ib};
+  (A)b = ga;
+  return ((A)b).a + b.b;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -387,6 +387,7 @@ public:
   TEST_METHOD(CodeGenCast4)
   TEST_METHOD(CodeGenCast5)
   TEST_METHOD(CodeGenCast6)
+  TEST_METHOD(CodeGenCast7)
   TEST_METHOD(CodeGenCbuf_init_static)
   TEST_METHOD(CodeGenCbufferCopy)
   TEST_METHOD(CodeGenCbufferCopy2)
@@ -2279,6 +2280,10 @@ TEST_F(CompilerTest, CodeGenCast5) {
 
 TEST_F(CompilerTest, CodeGenCast6) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\cast6.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenCast7) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\cast7.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenCbuf_init_static) {


### PR DESCRIPTION
1. Support base in FlattenedTypeIterator.
2. Generate GEP for DerivedToBase except empty struct.