### PR TITLE
[spirv] Add GoogleTest as an external dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,10 @@ option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default buil
 
 # SPIRV change starts
 option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." OFF)
+option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." OFF)
+if (${SPIRV_BUILD_TESTS})
+  set(ENABLE_SPIRV_CODEGEN ON)
+endif()
 if (${ENABLE_SPIRV_CODEGEN})
   add_definitions(-DENABLE_SPIRV_CODEGEN)
 endif()

--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -37,7 +37,7 @@ function(llvm_update_compile_flags name)
       list(APPEND LLVM_COMPILE_FLAGS "/GR-")
     endif ()
   endif()
-  
+
   # HLSL Changes Start
   if (LLVM_ENABLE_EH)
     if (MSVC)
@@ -749,11 +749,12 @@ endfunction(add_llvm_implicit_external_projects)
 
 # Generic support for adding a unittest.
 function(add_unittest test_suite test_name)
-  if( NOT LLVM_BUILD_TESTS )
+  if( NOT LLVM_BUILD_TESTS AND NOT SPIRV_BUILD_TESTS ) # SPIRV change
     set(EXCLUDE_FROM_ALL ON)
   endif()
 
-  include_directories(${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include)
+  include_directories(${DXC_GTEST_DIR}/googletest/include) # SPIRV change
+  include_directories(${DXC_GTEST_DIR}/googlemock/include) # SPIRV change
   if (NOT LLVM_ENABLE_THREADS)
     list(APPEND LLVM_COMPILE_DEFINITIONS GTEST_HAS_PTHREAD=0)
   endif ()
@@ -769,7 +770,7 @@ function(add_unittest test_suite test_name)
   set_output_directory(${test_name} ${outdir} ${outdir})
   target_link_libraries(${test_name}
     gtest
-    gtest_main
+    # gtest_main # SPIRV change
     LLVMSupport # gtest needs it for raw_ostream.
     )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -43,4 +43,18 @@ if (${ENABLE_SPIRV_CODEGEN})
   foreach(target ${SPIRV_DEP_TARGETS})
     set_property(TARGET ${target} PROPERTY FOLDER "External dependencies")
   endforeach()
+
+  # We need GoogleTest for unit and SPIR-V codegen testing.
+  if (${SPIRV_BUILD_TESTS})
+    set(DXC_GTEST_DIR "${DXC_EXTERNAL_ROOT_DIR}/googletest"
+        CACHE STRING "Location of GoogleTest source")
+
+    if (IS_DIRECTORY ${DXC_GTEST_DIR})
+      # Configure googletest
+      include(GTestConfig.cmake)
+    endif()
+    if (NOT TARGET gtest)
+      message(FATAL_ERROR "GoogleTest was not found - required for SPIR-V codegen")
+    endif()
+  endif()
 endif()

--- a/external/GTestConfig.cmake
+++ b/external/GTestConfig.cmake
@@ -1,0 +1,51 @@
+########################################################################
+# Experimental CMake build script for Google Test.
+#
+# Consider this a prototype.  It will change drastically.  For now,
+# this is only for people on the cutting edge.
+#
+# To run the tests for Google Test itself on Linux, use 'make test' or
+# ctest.  You can select which tests to run using 'ctest -R regex'.
+# For more options, run 'ctest --help'.
+########################################################################
+#
+# Project-wide settings
+
+# Where gtest's .h files can be found.
+include_directories(
+  ${DXC_GTEST_DIR}/googletest/include
+  ${DXC_GTEST_DIR}/googletest
+  ${DXC_GTEST_DIR}/googlemock/include
+  ${DXC_GTEST_DIR}/googlemock
+  )
+
+if(WIN32)
+  add_definitions(-DGTEST_OS_WINDOWS=1)
+endif()
+
+if(SUPPORTS_VARIADIC_MACROS_FLAG)
+  add_definitions("-Wno-variadic-macros")
+endif()
+if(SUPPORTS_GNU_ZERO_VARIADIC_MACRO_ARGUMENTS_FLAG)
+  add_definitions("-Wno-gnu-zero-variadic-macro-arguments")
+endif()
+if(CXX_SUPPORTS_COVERED_SWITCH_DEFAULT_FLAG)
+  add_definitions("-Wno-covered-switch-default")
+endif()
+
+set(LLVM_REQUIRES_RTTI 1)
+add_definitions( -DGTEST_HAS_RTTI=0 )
+
+if (NOT LLVM_ENABLE_THREADS)
+  add_definitions( -DGTEST_HAS_PTHREAD=0 )
+endif()
+
+find_library(LLVM_PTHREAD_LIBRARY_PATH pthread)
+if (LLVM_PTHREAD_LIBRARY_PATH)
+  list(APPEND LIBS pthread)
+endif()
+
+add_llvm_library(gtest
+  ${DXC_GTEST_DIR}/googletest/src/gtest-all.cc
+  ${DXC_GTEST_DIR}/googlemock/src/gmock-all.cc
+)

--- a/tools/clang/unittests/CMakeLists.txt
+++ b/tools/clang/unittests/CMakeLists.txt
@@ -41,3 +41,12 @@ if (HLSL_INCLUDE_TESTS)
 endif (HLSL_INCLUDE_TESTS)
 
 # HLSL Change Ends
+
+
+# SPIRV Change Starts
+
+if (SPIRV_BUILD_TESTS)
+  add_subdirectory(SPIRV)
+endif (SPIRV_BUILD_TESTS)
+
+# SPIRV Change Ends

--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  dxcsupport
+  hlsl
+  )
+
+add_clang_unittest(clang-spirv-tests
+  TestMain.cpp
+  )
+
+target_link_libraries(clang-spirv-tests
+  clangCodeGen
+  clangFrontend
+  clangSPIRV
+  )
+
+set_output_directory(clang-spirv-tests ${LLVM_RUNTIME_OUTPUT_INTDIR} ${LLVM_LIBRARY_OUTPUT_INTDIR})

--- a/tools/clang/unittests/SPIRV/TestMain.cpp
+++ b/tools/clang/unittests/SPIRV/TestMain.cpp
@@ -1,0 +1,51 @@
+//===--- utils/unittest/UnitTestMain/TestMain.cpp - unittest driver -------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Signals.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#if defined(_WIN32)
+# include <windows.h>
+# if defined(_MSC_VER)
+#   include <crtdbg.h>
+# endif
+#endif
+
+const char *TestMainArgv0;
+
+int main(int argc, char **argv) {
+  llvm::sys::PrintStackTraceOnErrorSignal(true /* Disable crash reporting */);
+
+  // Initialize both gmock and gtest.
+  testing::InitGoogleMock(&argc, argv);
+
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+
+  // Make it easy for a test to re-execute itself by saving argv[0].
+  TestMainArgv0 = argv[0];
+
+# if defined(_WIN32)
+  // Disable all of the possible ways Windows conspires to make automated
+  // testing impossible.
+  ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#   if defined(_MSC_VER)
+    ::_set_error_mode(_OUT_TO_STDERR);
+    _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#   endif
+# endif
+
+  return RUN_ALL_TESTS();
+}

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -119,6 +119,11 @@ if "%1"=="-spirv" (
   set CMAKE_OPTS=%CMAKE_OPTS% -DENABLE_SPIRV_CODEGEN:BOOL=ON
   shift /1
 )
+if "%1"=="-spirvtest" (
+  echo Building SPIR-V tests is enabled.
+  set CMAKE_OPTS=%CMAKE_OPTS% -DSPIRV_BUILD_TESTS:BOOL=ON
+  shift /1
+)
 rem End SPIRV change
 
 if "%BUILD_ARCH%"=="x64" (


### PR DESCRIPTION
GoogleTest will be used for unit testing and codegen testing for
SPIR-V.

* Added SPIRV_BUILD_TESTS option in CMake to control building
  of SPIR-V tests.
* Added "-spirvtest" into hctbuild to enable it.
* Added "spirv" and "spirv_only" targets for hcttest.

Running `hcttest spirv` will run ALL tests including SPIRV tests.
Running `hcttest spirv_only` will ONLY run SPIRV tests.

The default behavior of hctbuild and hcttest is not changed.