### PR TITLE
Implement Length on Input/OutputPatch objects

### DIFF
--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -35,7 +35,7 @@ static const bool ForConstTrue = true;            // a construct is targeting a 
 static const bool ExplicitConversionFalse = false;// a conversion operation is not the result of an explicit cast
 static const bool InheritedFalse = false;         // template parameter default value is not inherited.
 static const bool ParameterPackFalse = false;     // template parameter is not an ellipsis.
-static const bool TypenameTrue = false;           // 'typename' specified rather than 'class' for a template argument.
+static const bool TypenameFalse = false;          // 'typename' specified rather than 'class' for a template argument.
 static const bool DelayTypeCreationTrue = true;   // delay type creation for a declaration
 static const bool DelayTypeCreationFalse = false; // immediately create a type when the declaration is created
 static const unsigned int NoQuals = 0;            // no qualifiers in effect
@@ -146,7 +146,7 @@ void hlsl::AddHLSLMatrixTemplate(ASTContext& context, ClassTemplateDecl* vectorT
   IdentifierInfo& elementTemplateParamId = context.Idents.get(StringRef("element"), tok::TokenKind::identifier);
   TemplateTypeParmDecl *elementTemplateParamDecl = TemplateTypeParmDecl::Create(
     context, currentDeclContext, NoLoc, NoLoc,
-    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameTrue, ParameterPackFalse);
+    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameFalse, ParameterPackFalse);
   elementTemplateParamDecl->setDefaultArgument(context.getTrivialTypeSourceInfo(context.FloatTy));
   QualType intType = context.IntTy;
   Expr *literalIntFour = IntegerLiteral::Create(
@@ -253,7 +253,7 @@ void hlsl::AddHLSLVectorTemplate(ASTContext& context, ClassTemplateDecl** vector
   IdentifierInfo& elementTemplateParamId = context.Idents.get(StringRef("element"), tok::TokenKind::identifier);
   TemplateTypeParmDecl *elementTemplateParamDecl = TemplateTypeParmDecl::Create(
     context, currentDeclContext, NoLoc, NoLoc,
-    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameTrue, ParameterPackFalse);
+    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameFalse, ParameterPackFalse);
   elementTemplateParamDecl->setDefaultArgument(context.getTrivialTypeSourceInfo(context.FloatTy));
   QualType intType = context.IntTy;
   Expr *literalIntFour = IntegerLiteral::Create(
@@ -261,7 +261,7 @@ void hlsl::AddHLSLVectorTemplate(ASTContext& context, ClassTemplateDecl** vector
   IdentifierInfo& colCountParamId = context.Idents.get(StringRef("element_count"), tok::TokenKind::identifier);
   NonTypeTemplateParmDecl* colCountTemplateParamDecl = NonTypeTemplateParmDecl::Create(
     context, currentDeclContext, NoLoc, NoLoc,
-    FirstTemplateDepth, FirstParamPosition + 2, &colCountParamId, intType, ParameterPackFalse, nullptr);
+    FirstTemplateDepth, FirstParamPosition + 1, &colCountParamId, intType, ParameterPackFalse, nullptr);
   colCountTemplateParamDecl->setDefaultArgument(literalIntFour);
   NamedDecl* templateParameters[] =
   {
@@ -464,8 +464,8 @@ void hlsl::AddStdIsEqualImplementation(clang::ASTContext& context, clang::Sema& 
 
   //  template<typename T, typename U> struct is_same : public false_type {};
   CXXRecordDecl* isSameFalseRecordDecl = CXXRecordDecl::Create(context, TagTypeKind::TTK_Struct, stdNamespace, NoLoc, NoLoc, &isSameId, nullptr, false);
-  TemplateTypeParmDecl* tParam = TemplateTypeParmDecl::Create(context, stdNamespace, NoLoc, NoLoc, FirstTemplateDepth, FirstParamPosition, &tId, TypenameTrue, ParameterPackFalse);
-  TemplateTypeParmDecl* uParam = TemplateTypeParmDecl::Create(context, stdNamespace, NoLoc, NoLoc, FirstTemplateDepth, FirstParamPosition + 1, &vId, TypenameTrue, ParameterPackFalse);
+  TemplateTypeParmDecl* tParam = TemplateTypeParmDecl::Create(context, stdNamespace, NoLoc, NoLoc, FirstTemplateDepth, FirstParamPosition, &tId, TypenameFalse, ParameterPackFalse);
+  TemplateTypeParmDecl* uParam = TemplateTypeParmDecl::Create(context, stdNamespace, NoLoc, NoLoc, FirstTemplateDepth, FirstParamPosition + 1, &vId, TypenameFalse, ParameterPackFalse);
   NamedDecl* falseParams[] = { tParam, uParam };
   TemplateParameterList* falseParamList = TemplateParameterList::Create(context, NoLoc, NoLoc, falseParams, _countof(falseParams), NoLoc);
   ClassTemplateDecl* isSameFalseTemplateDecl = ClassTemplateDecl::Create(context, stdNamespace, NoLoc, DeclarationName(&isSameId), falseParamList, isSameFalseRecordDecl, nullptr);
@@ -521,8 +521,8 @@ void hlsl::AddStdIsEqualImplementation(clang::ASTContext& context, clang::Sema& 
 /// <parm name="templateArgCount">Number of template arguments (one or two).</param>
 /// <parm name="defaultTypeArgValue">If assigned, the default argument for the element template.</param>
 void hlsl::AddTemplateTypeWithHandle(
-  ASTContext& context, 
-  _Outptr_ ClassTemplateDecl** typeDecl, 
+  ASTContext& context,
+  _Outptr_ ClassTemplateDecl** typeDecl,
   _Outptr_ CXXRecordDecl** recordDecl,
   _In_z_ const char* typeName,
   uint8_t templateArgCount, 
@@ -544,8 +544,8 @@ void hlsl::AddTemplateTypeWithHandle(
   IdentifierInfo& elementTemplateParamId = context.Idents.get(StringRef("element"), tok::TokenKind::identifier);
   TemplateTypeParmDecl *elementTemplateParamDecl = TemplateTypeParmDecl::Create(
     context, currentDeclContext, NoLoc, NoLoc,
-    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameTrue, ParameterPackFalse);
-  QualType intType(context.getSizeType().getTypePtr(), NoQuals);
+    FirstTemplateDepth, FirstParamPosition, &elementTemplateParamId, TypenameFalse, ParameterPackFalse);
+  QualType intType = context.IntTy;
 
   if (defaultTypeArgValue != nullptr)
   {
@@ -605,7 +605,17 @@ void hlsl::AddTemplateTypeWithHandle(
     elementType = context.getDependentSizedArrayType(
         elementType, countExpr, ArrayType::ArraySizeModifier::Normal, 0,
         SourceRange());
+
+    // InputPatch and OutputPatch also have a "Length" static const member for the number of control points
+    IdentifierInfo& lengthId = context.Idents.get(StringRef("Length"), tok::TokenKind::identifier);
+    TypeSourceInfo* lengthTypeSource = context.getTrivialTypeSourceInfo(intType.withConst());
+    VarDecl* lengthValueDecl = VarDecl::Create(context, templateRecordDecl, NoLoc, NoLoc, &lengthId,
+      intType.withConst(), lengthTypeSource, SC_Static);
+    lengthValueDecl->setInit(countExpr);
+    lengthValueDecl->setAccess(AS_public);
+    templateRecordDecl->addDecl(lengthValueDecl);
   }
+
   AddHLSLHandleField(context, templateRecordDecl, elementType);
 
   templateRecordDecl->completeDefinition();

--- a/tools/clang/lib/Basic/Targets.cpp
+++ b/tools/clang/lib/Basic/Targets.cpp
@@ -6986,7 +6986,9 @@ public:
   DXILTargetInfo(const llvm::Triple &Triple) : TargetInfo(Triple) {
     BigEndian = false;
     TLSSupported = false;
-    LongWidth = LongAlign = 64;
+    LongWidth = LongAlign = 32;
+    LongDoubleWidth = LongDoubleAlign = 64;
+    LongDoubleFormat = &llvm::APFloat::IEEEdouble;
     BoolWidth = 32;
     // To avoid member for alignment.
     BoolAlign = 8;
@@ -7032,11 +7034,6 @@ class DXIL_32TargetInfo : public DXILTargetInfo {
 
 public:
   DXIL_32TargetInfo(const llvm::Triple &Triple) : DXILTargetInfo(Triple) {
-    LongDoubleWidth = LongDoubleAlign = 64;
-    LongDoubleFormat = &llvm::APFloat::IEEEdouble;
-    BoolWidth = 32;
-    // To avoid member for alignment.
-    BoolAlign = 8;
     // TODO: Update Description for DXIL
     DescriptionString = "e-m:e-p:32:32-i64:64-f80:32-n8:16:32-a:0:32-S32";
   }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -3225,6 +3225,8 @@ public:
       case BuiltinType::UInt: return AR_BASIC_UINT32;
       case BuiltinType::Short: return AR_BASIC_MIN16INT;    // rather than AR_BASIC_INT16
       case BuiltinType::UShort: return AR_BASIC_MIN16UINT;  // rather than AR_BASIC_UINT16
+      case BuiltinType::Long: return AR_BASIC_INT32;
+      case BuiltinType::ULong: return AR_BASIC_UINT32;
       case BuiltinType::LongLong: return AR_BASIC_INT64;
       case BuiltinType::ULongLong: return AR_BASIC_UINT64;
       case BuiltinType::Min12Int: return AR_BASIC_MIN12INT;

--- a/tools/clang/test/CodeGenHLSL/PatchLength1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/PatchLength1.hlsl
@@ -1,0 +1,113 @@
+// RUN: %dxc -E main -T hs_6_0 -Zi %s | FileCheck %s
+
+// CHECK: @dx.op.storePatchConstant.f32(i32 106, i32 0, i32 2, i8 0, float 3.000000e+00)
+// CHECK: @dx.op.storePatchConstant.f32(i32 106, i32 1, i32 0, i8 0, float 3.000000e+00)
+
+//--------------------------------------------------------------------------------------
+// SimpleTessellation.hlsl
+//
+// Advanced Technology Group (ATG)
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//--------------------------------------------------------------------------------------
+
+struct VSSceneIn
+{
+    float3 pos    : POSITION;            
+    float3 norm   : NORMAL;            
+    float2 tex    : TEXCOORD0;            
+};
+
+struct PSSceneIn
+{
+    float4 pos  : SV_Position;
+    float2 tex  : TEXCOORD0;
+    float3 norm : NORMAL;
+
+uint   RTIndex      : SV_RenderTargetArrayIndex;
+};
+
+cbuffer cb0
+{
+    float4x4    g_mWorldViewProj;
+};
+
+Texture2D        g_txDiffuse : register( t0 );
+
+SamplerState    g_sampler : register( s0 );
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Regular VS/PS rendering
+
+PSSceneIn VSSceneMain( VSSceneIn input )
+{
+    PSSceneIn output;
+    
+    output.pos = mul( float4( input.pos, 1.0 ), g_mWorldViewProj );
+    output.tex = input.tex;
+    output.norm = input.norm;
+    
+    return output;
+}
+
+float4 PSSceneMain( PSSceneIn input ) : SV_Target
+{    
+    return g_txDiffuse.Sample( g_sampler, input.tex );
+}
+
+
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Simple forwarding Tessellation shaders
+
+struct HSPerVertexData
+{
+    // This is just the original vertex verbatim. In many real life cases this would be a
+    // control point instead
+    PSSceneIn v;
+};
+
+struct HSPerPatchData
+{
+    // We at least have to specify tess factors per patch
+    // As we're tesselating triangles, there will be 4 tess factors
+    // In real life case this might contain face normal, for example
+	float	edges[ 3 ]	: SV_TessFactor;
+	float	inside		: SV_InsideTessFactor;
+};
+
+float4 HSPerPatchFunc()
+{
+    return 1.8;
+}
+
+HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 3 > points, OutputPatch< HSPerVertexData, 3 > opoints )
+{
+    HSPerPatchData d;
+
+    d.edges[ 0 ] = points[0].tex.x;
+    d.edges[ 1 ] = opoints[1].v.tex.y;
+    d.edges[ 2 ] = points.Length;
+    d.inside = opoints.Length;
+
+    return d;
+}
+
+// hull per-control point shader
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HSPerPatchFunc")]
+[outputcontrolpoints(3)]
+HSPerVertexData main( const uint id : SV_OutputControlPointID,
+                               const InputPatch< PSSceneIn, 3 > points )
+{
+    HSPerVertexData v;
+
+    // Just forward the vertex
+    v.v = points[ id ];
+
+	return v;
+}
+
+

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -803,6 +803,7 @@ public:
   TEST_METHOD(CodeGenRootSigDefine10)
   TEST_METHOD(CodeGenRootSigDefine11)
   TEST_METHOD(CodeGenCBufferStructArray)
+  TEST_METHOD(CodeGenPatchLength)
   TEST_METHOD(PreprocessWhenValidThenOK)
   TEST_METHOD(WhenSigMismatchPCFunctionThenFail)
 
@@ -4198,6 +4199,9 @@ TEST_F(CompilerTest, CodeGenCBufferStructArray) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\cbuffer-structarray.hlsl");
 }
 
+TEST_F(CompilerTest, CodeGenPatchLength) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\PatchLength1.hlsl");
+}
 
 // Dx11 Sample
 


### PR DESCRIPTION
- use IntTy for object template dimension argument.
- Fix name of TypenameTrue to TypenameFalse, since that's what it means.
- Fix index of vector dimension template argument.
- Fix long bit width/align to 32 for DXILTargetInfo