### PR TITLE
Fix bad merge conflict for WaveActiveAllEqual Execution Test

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -363,10 +363,13 @@ struct computeExpected<InType, OutType, ShaderOpKind::WaveActiveAllEqual> {
   OutType operator()(const std::vector<InType> &inputs,
                      const std::vector<int> &masks, int maskValue,
                      unsigned int index) {
-    OutType val = inputs.at(0); // assuming there is always one lane per wave
-    for (size_t i = 1; i < index; ++i) {
-      if (masks.at(i) == maskValue && val != inputs.at(i)) {
-        return 0;
+    const InType *val = nullptr;
+    for (size_t i = 0; i < index; ++i) {
+      if (masks.at(i) == maskValue) {
+        if (val && *val != inputs.at(i)) {
+          return 0;
+        }
+        val = &inputs.at(i);
       }
     }
     return 1;


### PR DESCRIPTION
To resolve bad merge conflict for execution test