### PR TITLE
Code cleanup.

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3813,7 +3813,8 @@ private:
   void replaceCall(Function *F, Function *flatF);
   void createFlattenedFunction(Function *F);
   void createFlattenedFunctionCall(Function *F, Function *flatF, CallInst *CI);
-  void flattenArgument(Function *F, Value *Arg,
+  void
+  flattenArgument(Function *F, Value *Arg, bool bForParam,
                   DxilParameterAnnotation &paramAnnotation,
                   std::vector<Value *> &FlatParamList,
                   std::vector<DxilParameterAnnotation> &FlatRetAnnotationList,
@@ -3911,11 +3912,10 @@ void SROA_Parameter_HLSL::flattenGlobal(GlobalVariable *GV) {
   WorkList.push_back(GV);
   // merge GEP use for global.
   HLModule::MergeGepUse(GV);
-  Function *Entry = m_pHLModule->GetEntryFunction();
   
   DxilTypeSystem &dxilTypeSys = m_pHLModule->GetTypeSystem();
-
-  IRBuilder<> Builder(Entry->getEntryBlock().getFirstInsertionPt());
+  // Only used to create ConstantExpr.
+  IRBuilder<> Builder(m_pHLModule->GetCtx());
   std::vector<Instruction*> deadAllocas;
 
   const DataLayout &DL = GV->getParent()->getDataLayout();
@@ -4817,10 +4817,11 @@ Value *SROA_Parameter_HLSL::castArgumentIfRequired(
 }
 
 void SROA_Parameter_HLSL::flattenArgument(
-    Function *F, Value *Arg, DxilParameterAnnotation &paramAnnotation,
+    Function *F, Value *Arg, bool bForParam,
+    DxilParameterAnnotation &paramAnnotation,
     std::vector<Value *> &FlatParamList,
-    std::vector<DxilParameterAnnotation> &FlatAnnotationList, IRBuilder<> &Builder,
-    DbgDeclareInst *DDI) {
+    std::vector<DxilParameterAnnotation> &FlatAnnotationList,
+    IRBuilder<> &Builder, DbgDeclareInst *DDI) {
   std::deque<Value *> WorkList;
   WorkList.push_back(Arg);
 
@@ -4846,7 +4847,6 @@ void SROA_Parameter_HLSL::flattenArgument(
   const std::string &semantic = paramAnnotation.GetSemanticString();
   bool bSemOverride = !semantic.empty();
 
-  bool bForParam = F == Builder.GetInsertPoint()->getParent()->getParent();
   DxilParamInputQual inputQual = paramAnnotation.GetParamInputQual();
   bool bOut = inputQual == DxilParamInputQual::Out ||
               inputQual == DxilParamInputQual::Inout ||
@@ -5377,6 +5377,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
   
   std::vector<Value *> FlatParamList;
   std::vector<DxilParameterAnnotation> FlatParamAnnotationList;
+  const bool bForParam = true;
   // Add all argument to worklist.
   for (Argument &Arg : F->args()) {
     // merge GEP use for arg.
@@ -5386,7 +5387,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
     DxilParameterAnnotation &paramAnnotation =
         funcAnnotation->GetParameterAnnotation(Arg.getArgNo());
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(&Arg);
-    flattenArgument(F, &Arg, paramAnnotation, FlatParamList,
+    flattenArgument(F, &Arg, bForParam, paramAnnotation, FlatParamList,
                     FlatParamAnnotationList, Builder, DDI);
   }
 
@@ -5440,12 +5441,6 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
                                         HLOpcodeGroup::HLMatLoadStore, opcode,
                                         voidTy, {retValAddr, RetVal}, M);
         }
-        // Clone the return.
-        ReturnInst *NewRet = RetBuilder.CreateRet(RI->getReturnValue());
-        if (RI == InsertPt) {
-          Builder.SetInsertPoint(NewRet);
-        }
-        RI->eraseFromParent();
       }
     }
     // Create a fake store to keep retValAddr so it can be flattened.
@@ -5454,7 +5449,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
     }
 
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(retValAddr);
-    flattenArgument(F, retValAddr, funcAnnotation->GetRetTypeAnnotation(),
+    flattenArgument(F, retValAddr, bForParam, funcAnnotation->GetRetTypeAnnotation(),
                     FlatRetList, FlatRetAnnotationList, Builder, DDI);
   }
 
@@ -5627,6 +5622,7 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
   Type *retType = F->getReturnType();
   std::vector<Value *> FlatRetList;
   std::vector<DxilParameterAnnotation> FlatRetAnnotationList;
+  const bool bForParam = false;
   // Split and change to out parameter.
   if (!retType->isVoidTy()) {
     Value *retValAddr = AllocaBuilder.CreateAlloca(retType);
@@ -5670,9 +5666,10 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
     }
     CI->replaceAllUsesWith(newRetVal);
     // Flat ret val
-    flattenArgument(flatF, retValAddr, funcAnnotation->GetRetTypeAnnotation(),
-                    FlatRetList, FlatRetAnnotationList, AllocaBuilder,
-                    /*DbgDeclareInst*/nullptr);
+    flattenArgument(flatF, retValAddr, bForParam,
+                    funcAnnotation->GetRetTypeAnnotation(), FlatRetList,
+                    FlatRetAnnotationList, AllocaBuilder,
+                    /*DbgDeclareInst*/ nullptr);
   }
 
   std::vector<Value *> args;
@@ -5713,7 +5710,7 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
                  &paramAnnotation);
       }
       arg = tempArg;
-      flattenArgument(flatF, arg, paramAnnotation, FlatParamList,
+      flattenArgument(flatF, arg, bForParam, paramAnnotation, FlatParamList,
                       FlatParamAnnotationList, AllocaBuilder,
                       /*DbgDeclareInst*/ nullptr);
     } else {

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5377,7 +5377,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
   
   std::vector<Value *> FlatParamList;
   std::vector<DxilParameterAnnotation> FlatParamAnnotationList;
-  const bool bForParam = true;
+  const bool bForParamTrue = true;
   // Add all argument to worklist.
   for (Argument &Arg : F->args()) {
     // merge GEP use for arg.
@@ -5387,7 +5387,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
     DxilParameterAnnotation &paramAnnotation =
         funcAnnotation->GetParameterAnnotation(Arg.getArgNo());
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(&Arg);
-    flattenArgument(F, &Arg, bForParam, paramAnnotation, FlatParamList,
+    flattenArgument(F, &Arg, bForParamTrue, paramAnnotation, FlatParamList,
                     FlatParamAnnotationList, Builder, DDI);
   }
 
@@ -5449,7 +5449,7 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
     }
 
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(retValAddr);
-    flattenArgument(F, retValAddr, bForParam, funcAnnotation->GetRetTypeAnnotation(),
+    flattenArgument(F, retValAddr, bForParamTrue, funcAnnotation->GetRetTypeAnnotation(),
                     FlatRetList, FlatRetAnnotationList, Builder, DDI);
   }
 
@@ -5622,7 +5622,7 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
   Type *retType = F->getReturnType();
   std::vector<Value *> FlatRetList;
   std::vector<DxilParameterAnnotation> FlatRetAnnotationList;
-  const bool bForParam = false;
+  const bool bForParamFalse = false;
   // Split and change to out parameter.
   if (!retType->isVoidTy()) {
     Value *retValAddr = AllocaBuilder.CreateAlloca(retType);
@@ -5666,7 +5666,7 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
     }
     CI->replaceAllUsesWith(newRetVal);
     // Flat ret val
-    flattenArgument(flatF, retValAddr, bForParam,
+    flattenArgument(flatF, retValAddr, bForParamFalse,
                     funcAnnotation->GetRetTypeAnnotation(), FlatRetList,
                     FlatRetAnnotationList, AllocaBuilder,
                     /*DbgDeclareInst*/ nullptr);
@@ -5710,7 +5710,7 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
                  &paramAnnotation);
       }
       arg = tempArg;
-      flattenArgument(flatF, arg, bForParam, paramAnnotation, FlatParamList,
+      flattenArgument(flatF, arg, bForParamFalse, paramAnnotation, FlatParamList,
                       FlatParamAnnotationList, AllocaBuilder,
                       /*DbgDeclareInst*/ nullptr);
     } else {

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5449,8 +5449,9 @@ void SROA_Parameter_HLSL::createFlattenedFunction(Function *F) {
     }
 
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(retValAddr);
-    flattenArgument(F, retValAddr, bForParamTrue, funcAnnotation->GetRetTypeAnnotation(),
-                    FlatRetList, FlatRetAnnotationList, Builder, DDI);
+    flattenArgument(F, retValAddr, bForParamTrue,
+                    funcAnnotation->GetRetTypeAnnotation(), FlatRetList,
+                    FlatRetAnnotationList, Builder, DDI);
   }
 
   // Always change return type as parameter.
@@ -5710,8 +5711,8 @@ void SROA_Parameter_HLSL::createFlattenedFunctionCall(Function *F, Function *fla
                  &paramAnnotation);
       }
       arg = tempArg;
-      flattenArgument(flatF, arg, bForParamFalse, paramAnnotation, FlatParamList,
-                      FlatParamAnnotationList, AllocaBuilder,
+      flattenArgument(flatF, arg, bForParamFalse, paramAnnotation,
+                      FlatParamList, FlatParamAnnotationList, AllocaBuilder,
                       /*DbgDeclareInst*/ nullptr);
     } else {
       // Cast vector into array.


### PR DESCRIPTION
1. Don't require entry function for flattenGlobal.
2. Don't check bForParam for flattenArgument.
3. Don't clone and remove return when replace return value with alloca.