### PR TITLE
Add bFinalStage to ViewIDPipelineValidation

### DIFF
--- a/include/dxc/HLSL/DxilPipelineStateValidation.h
+++ b/include/dxc/HLSL/DxilPipelineStateValidation.h
@@ -805,6 +805,7 @@ namespace hlsl {
     };
     virtual ~ViewIDValidator() {}
     virtual Result ValidateStage(const DxilPipelineStateValidation &PSV,
+                                 bool bFinalStage,
                                  unsigned &mismatchElementId) = 0;
   };
 


### PR DESCRIPTION
- bFinalStage indicates a non-PS stage is the final one and validation should be performed on direct outputs, rather than waiting for the next stage to merge outputs with inputs.
- Extra validation for PSV
- Treat tessfactors as dynamically indexed to prevent breaking them up