### PR TITLE
Fix ShaderOpTest parsing and enable tests from warp failures.

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -499,22 +499,18 @@ public:
   // TODO: Change the priority to 0 once there is a driver that fixes the issue with WaveActive operations
   BEGIN_TEST_METHOD(WaveIntrinsicsActiveIntTest)
     TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveIntTable")
-    TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   BEGIN_TEST_METHOD(WaveIntrinsicsActiveUintTest)
     TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsActiveUintTable")
-    TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   BEGIN_TEST_METHOD(WaveIntrinsicsPrefixIntTest)
   TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsPrefixIntTable")
-  TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   BEGIN_TEST_METHOD(WaveIntrinsicsPrefixUintTest)
   TEST_METHOD_PROPERTY(L"DataSource", L"Table:ShaderOpArithTable.xml#WaveIntrinsicsPrefixUintTable")
-  TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
   // TAEF data-driven tests.
   BEGIN_TEST_METHOD(UnaryFloatOpTest)

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -240,31 +240,23 @@
         <Parameter Name="Validation.NumInput">9</Parameter>
         <Parameter Name="Validation.Input">
           <Value>NaN</Value>
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>-Inf</Value>
-    -->
           <Value>-denorm</Value>
           <Value>-0</Value>
           <Value>0</Value>
           <Value>denorm</Value>
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>Inf</Value>
-    -->
           <Value>1</Value>
           <Value>-1</Value>
         </Parameter>
         <Parameter Name="Validation.Expected">
           <Value>NaN</Value>
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>-1</Value>
-    -->
           <Value>-0.0</Value>
           <Value>-0.0</Value>
           <Value>0.0</Value>
           <Value>0.0</Value>
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>1</Value>
-    -->
           <Value>0.761594</Value>
           <Value>-0.761594</Value>
         </Parameter>
@@ -387,9 +379,7 @@
         <Parameter Name="Validation.Tolerance">0.0008</Parameter>
         <Parameter Name="Validation.NumInput">8</Parameter>
         <Parameter Name="Validation.Input">
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
-    -->
           <Value>-Inf</Value>
           <Value>-denorm</Value>
           <Value>-0</Value>
@@ -400,9 +390,7 @@
           <Value>-1</Value>
         </Parameter>
         <Parameter Name="Validation.Expected">
-    <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
-    -->
           <Value>-1.570796</Value>
           <Value>0.0</Value>
           <Value>0.0</Value>
@@ -1036,9 +1024,7 @@
         <Parameter Name="Validation.Tolerance">0</Parameter>
         <Parameter Name="Validation.NumInput">8</Parameter>
         <Parameter Name="Validation.Input">
-     <!-- TODO: Uncomment this when WARP is fixed
           <Value>NaN</Value>
-     -->
           <Value>-Inf</Value>
           <Value>-denorm</Value>
           <Value>-0</Value>
@@ -1049,9 +1035,7 @@
           <Value>-1.0</Value>
         </Parameter>
         <Parameter Name="Validation.Expected">
-     <!-- TODO: Uncomment this when WARP is fixed
           <Value>0</Value>
-     -->
           <Value>0</Value>
           <Value>1</Value>
           <Value>1</Value>

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -1898,7 +1898,7 @@ void ShaderOpParser::ParseResource(IXmlReader *pReader, ShaderOpResource *pResou
         else if (0 == _wcsnicmp(pText, L"inf", 3) || 0 == _wcsnicmp(pText, L"+inf", 4)) {
           fVal = INFINITY;
         }
-        else if (0 == _wcsnicmp(pText, L"-denorm", 6)) {
+        else if (0 == _wcsnicmp(pText, L"-denorm", 7)) {
           fVal = -(FLT_MIN / 2);
         }
         else if (0 == _wcsnicmp(pText, L"denorm", 6)) {

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -1889,19 +1889,19 @@ void ShaderOpParser::ParseResource(IXmlReader *pReader, ShaderOpResource *pResou
         LPCWSTR pEnd = FindByteInitSeparators(pText);
         // Consider looking for prefixes/suffixes to handle bases and types.
         float fVal;
-        if (0 == _wcsicmp(pText, L"nan")) {
+        if (0 == _wcsnicmp(pText, L"nan", 3)) {
           fVal = NAN;
         }
-        else if (0 == _wcsicmp(pText, L"-inf")) {
+        else if (0 == _wcsnicmp(pText, L"-inf", 4)) {
           fVal = -(INFINITY);
         }
-        else if (0 == _wcsicmp(pText, L"inf") || 0 == _wcsicmp(pText, L"+inf")) {
+        else if (0 == _wcsnicmp(pText, L"inf", 3) || 0 == _wcsnicmp(pText, L"+inf", 4)) {
           fVal = INFINITY;
         }
-        else if (0 == _wcsicmp(pText, L"-denorm")) {
+        else if (0 == _wcsnicmp(pText, L"-denorm", 6)) {
           fVal = -(FLT_MIN / 2);
         }
-        else if (0 == _wcsicmp(pText, L"denorm")) {
+        else if (0 == _wcsnicmp(pText, L"denorm", 6)) {
           fVal = (FLT_MIN / 2);
         }
         else {


### PR DESCRIPTION
Restoring default tests as WARP has been fixed for future release.