### PR TITLE
Annotate enum type for field attribute.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -698,6 +698,12 @@ static void ConstructFieldAttributedAnnotation(DxilFieldAnnotation &fieldAnnotat
     CompType::Kind kind = BuiltinTyToCompTy(BTy, bSNorm, bUNorm);
     fieldAnnotation.SetCompType(kind);
   }
+  else if (EltTy->isEnumeralType()) {
+    const EnumType *ETy = EltTy->getAs<EnumType>();
+    QualType type = ETy->getDecl()->getIntegerType();
+    if (const BuiltinType *BTy = dyn_cast<BuiltinType>(type->getCanonicalTypeInternal()))
+        fieldAnnotation.SetCompType(BuiltinTyToCompTy(BTy, bSNorm, bUNorm));
+  }
   else
     DXASSERT(!bSNorm && !bUNorm, "snorm/unorm on invalid type, validate at handleHLSLTypeAttr");
 }

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -4764,7 +4764,7 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
 ///         identifier
 ///
 void Parser::ParseEnumBody(SourceLocation StartLoc, Decl *EnumDecl) {
-  assert(getLangOpts().HLSL && "HLSL does not support enums"); // HLSL Change
+  assert(getLangOpts().HLSL2017 && "HLSL does not support enums before 2017"); // HLSL Change
 
   // Enter the scope of the enum body and start the definition.
   ParseScope EnumScope(this, Scope::DeclScope | Scope::EnumScope);

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -13659,6 +13659,7 @@ EnumConstantDecl *Sema::CheckEnumConstant(EnumDecl *Enum,
       EltTy = Context.DependentTy;
     else {
       SourceLocation ExpLoc;
+      // HLSL Change - check constant expression for enum
       if ((getLangOpts().HLSL2017 || getLangOpts().CPlusPlus11) &&
           Enum->isFixed() && !getLangOpts().MSVCCompat) {
         // C++11 [dcl.enum]p5: If the underlying type is fixed, [...] the

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -13659,8 +13659,8 @@ EnumConstantDecl *Sema::CheckEnumConstant(EnumDecl *Enum,
       EltTy = Context.DependentTy;
     else {
       SourceLocation ExpLoc;
-      if (getLangOpts().CPlusPlus11 && Enum->isFixed() &&
-          !getLangOpts().MSVCCompat) {
+      if ((getLangOpts().HLSL2017 || getLangOpts().CPlusPlus11) &&
+          Enum->isFixed() && !getLangOpts().MSVCCompat) {
         // C++11 [dcl.enum]p5: If the underlying type is fixed, [...] the
         // constant-expression in the enumerator-definition shall be a converted
         // constant expression of the underlying type.

--- a/tools/clang/test/CodeGenHLSL/enum6.hlsl
+++ b/tools/clang/test/CodeGenHLSL/enum6.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -E main -T vs_6_0 -HV 2017 %s | FileCheck %s
+// CHECK: %struct.PSInput = type { <4 x float>, <4 x float>, i16 }
+// CHECK: call void @dx.op.storeOutput.i16(i32 5, i32 2, i32 0, i8 0, i16 3)
+
+enum class E : min16int {
+  E1 = 3,
+  E2
+};
+ 
+struct PSInput {
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+    E e : FOO;
+};
+
+PSInput main(float4 position: POSITION, float4 color: COLOR) {
+    float aspect = 320.0 / 200.0;
+    PSInput result;
+    result.position = position;
+    result.position.y *= aspect;
+    result.color = color;
+    result.e = E::E1;
+    return result;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -434,6 +434,7 @@ public:
   TEST_METHOD(CodeGenEnum3)
   TEST_METHOD(CodeGenEnum4)
   TEST_METHOD(CodeGenEnum5)
+  TEST_METHOD(CodeGenEnum6)
   TEST_METHOD(CodeGenEarlyDepthStencil)
   TEST_METHOD(CodeGenEval)
   TEST_METHOD(CodeGenEvalInvalid)
@@ -2489,6 +2490,10 @@ TEST_F(CompilerTest, CodeGenEnum4) {
 
 TEST_F(CompilerTest, CodeGenEnum5) {
     CodeGenTestCheck(L"..\\CodeGenHLSL\\enum5.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenEnum6) {
+    CodeGenTestCheck(L"..\\CodeGenHLSL\\enum6.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenEarlyDepthStencil) {


### PR DESCRIPTION
This change fixes a bug on HLSL 2017 where the compiler crashes when input/output signature contains enum types.