### PR TITLE
Don't attempt to fault-in HLSL symbols after a fatal error is found.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2997,6 +2997,13 @@ public:
       return false;
     }
 
+    // Currently template instantiation is blocked when a fatal error is
+    // detected. So no faulting-in types at this point, instead we simply
+    // back out.
+    if (this->m_sema->Diags.hasFatalErrorOccurred()) {
+      return false;
+    }
+
     StringRef nameIdentifier = idInfo->getName();
     HLSLScalarType parsedType;
     int rowCount;

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -97,6 +97,7 @@ protected:
   TEST_METHOD(FileWhenSameThenEqual);
   TEST_METHOD(FileWhenNotSameThenNotEqual);
 
+  TEST_METHOD(InclusionWhenMissingThenError);
   TEST_METHOD(InclusionWhenValidThenAvailable);
 
   TEST_METHOD(TUWhenGetFileMissingThenFail);
@@ -151,6 +152,28 @@ TEST_F(DXIntellisenseTest, CursorWhenCBufferRefThenFound) {
   VERIFY_SUCCEEDED(refs.begin()[0]->GetLocation(&loc));
   VERIFY_SUCCEEDED(loc->GetSpellingLocation(nullptr, &line, nullptr, nullptr));
   VERIFY_ARE_EQUAL(2, line);
+}
+
+TEST_F(DXIntellisenseTest, InclusionWhenMissingThenError) {
+  CComPtr<IDxcIntelliSense> isense;
+  CComPtr<IDxcIndex> index;
+  CComPtr<IDxcUnsavedFile> unsaved;
+  CComPtr<IDxcTranslationUnit> TU;
+  CComPtr<IDxcDiagnostic> pDiag;
+  DxcDiagnosticSeverity Severity;
+  const char main_text[] = "error\r\n#include \"missing.hlsl\"\r\nfloat3 g_global;";
+  unsigned diagCount;
+  VERIFY_SUCCEEDED(CompilationResult::DefaultHlslSupport->CreateIntellisense(&isense));
+  VERIFY_SUCCEEDED(isense->CreateIndex(&index));
+  VERIFY_SUCCEEDED(isense->CreateUnsavedFile("file.hlsl", main_text, strlen(main_text), &unsaved));
+  VERIFY_SUCCEEDED(index->ParseTranslationUnit("file.hlsl", nullptr, 0, &unsaved.p, 1,
+    DxcTranslationUnitFlags_UseCallerThread, &TU));
+  VERIFY_SUCCEEDED(TU->GetNumDiagnostics(&diagCount));
+  VERIFY_ARE_EQUAL(1, diagCount);
+  VERIFY_SUCCEEDED(TU->GetDiagnostic(0, &pDiag));
+  VERIFY_SUCCEEDED(pDiag->GetSeverity(&Severity));
+  VERIFY_IS_TRUE(Severity == DxcDiagnosticSeverity::DxcDiagnostic_Error ||
+    Severity == DxcDiagnosticSeverity::DxcDiagnostic_Fatal);
 }
 
 TEST_F(DXIntellisenseTest, InclusionWhenValidThenAvailable) {


### PR DESCRIPTION
Sema::InstantiatingTemplate::InstantiatingTemplate is backing off at
this point, and so the HLSL built-ins that have the expectation of
succeeding are not going to deal well with this case. In the (common)
case of a file missing, it might be interesting to continue, but for
robustness the first fix to be made is to be resilient under these
conditions and simply back out.