### PR TITLE
fixed incorrect message about required cmake 3.7.1, when in fact is required cmake 3.7.2

### DIFF
--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -198,16 +198,23 @@ int DxcContext::ActOnBlob(IDxcBlob *pBlob, IDxcBlob *pDebugBlob, LPCWSTR pDebugB
        m_Opts.ExtractPrivateFile.empty() &&
        m_Opts.VerifyRootSignatureSource.empty() && !m_Opts.ExtractRootSignature);
 
-  bool isRootSigProfile = m_Opts.IsRootSignatureProfile();
-
-  if (!needDisassembly || isRootSigProfile)
+  if (!needDisassembly)
     return retVal;
 
-  CComPtr<IDxcCompiler> pCompiler;
-  IFT(m_dxcSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
-
   CComPtr<IDxcBlobEncoding> pDisassembleResult;
-  IFT(pCompiler->Disassemble(pBlob, &pDisassembleResult));
+
+  if (!m_Opts.IsRootSignatureProfile()) {
+      CComPtr<IDxcCompiler> pCompiler;
+      IFT(m_dxcSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
+      IFT(pCompiler->Disassemble(pBlob, &pDisassembleResult));
+  } else {
+      //make the same behavior as fxc, people may want to embed the root signatures in their code bases.
+      CComPtr<IDxcLibrary> pLibrary;
+      IFT(m_dxcSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
+      std::string Message = "Disassembly failed";
+      IFT(pLibrary->CreateBlobWithEncodingOnHeapCopy((LPBYTE)&Message[0], Message.size(), CP_ACP, &pDisassembleResult));
+  }
+  
   if (!m_Opts.OutputHeader.empty()) {
     llvm::Twine varName = m_Opts.VariableName.empty()
                               ? llvm::Twine("g_", m_Opts.EntryPoint)

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -215,7 +215,7 @@ cmake --version | findstr 3.7.2 1>nul 2>nul
 if "0"=="%ERRORLEVEL%" exit /b 0
 cmake --version | findstr /R 3.6.*MSVC 1>nul 2>nul
 if errorlevel 1 (
-  echo CMake 3.4.3 or 3.7.1 are the currently supported versions for VS 2015 and VS 2017 - your installed cmake is not supported.
+  echo CMake 3.4.3 or 3.7.2 are the currently supported versions for VS 2015 and VS 2017 - your installed cmake is not supported.
   echo See README.md at the root for an explanation of dependencies.
   exit /b 1
 )


### PR DESCRIPTION
When one opens the HLSL console and has installed cmake 3.7.1 he gets a message that cmake version 3.7.1 is required, when in fact 3.7.2 is required
