### PR TITLE
Fix dxc crash on invalid brace-enclosed initializer

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1017,7 +1017,7 @@ def warn_hlsl_effect_sampler_state : Warning <
   "effect sampler_state assignment ignored - effect syntax is deprecated">,
   InGroup< HLSLEffectsSyntax >;
 def warn_hlsl_effect_state_block : Warning <
-  "effect state block ignored - effect syntax is deprecated">,
+  "effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.">,
   InGroup< HLSLEffectsSyntax >;
 def warn_hlsl_effect_technique : Warning <
   "effect technique ignored - effect syntax is deprecated">,

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -2662,8 +2662,11 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
     Diag(Tok.getLocation(), diag::warn_hlsl_effect_state_block);
     ConsumeBrace();
     SkipUntil(tok::r_brace); // skip until '}'
+    // Braces could have been used to initialize an array.
+    // In this case we require users to use braces with the equal sign.
+    // Otherwise, the array will be treated as an uninitialized declaration.
+    Actions.ActOnUninitializedDecl(ThisDecl, TypeContainsAuto);
     // HLSL Change Ends
-
   } else {
     Actions.ActOnUninitializedDecl(ThisDecl, TypeContainsAuto);
   }

--- a/tools/clang/test/HLSL/effects-syntax.hlsl
+++ b/tools/clang/test/HLSL/effects-syntax.hlsl
@@ -182,3 +182,5 @@ int foobar4;
 /*verify-ast
   VarDecl <col:1, col:5> col:5 foobar4 'int'
 */
+int foobar5[] {1, 2, 3};                                        /* expected-error {{definition of variable with array type needs an explicit size or an initializer}} expected-warning {{effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.}} fxc-error {{X3000: syntax error: unexpected integer constant}} */
+int foobar6[4] {1, 2, 3, 4};                                    /* expected-warning {{effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.}} fxc-error {{X3000: syntax error: unexpected integer constant}} */


### PR DESCRIPTION
dxc requres equals sign to use brace-enclosed initializer.