### PR TITLE
Bug fixes for dxil-2017-06

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1017,7 +1017,7 @@ def warn_hlsl_effect_sampler_state : Warning <
   "effect sampler_state assignment ignored - effect syntax is deprecated">,
   InGroup< HLSLEffectsSyntax >;
 def warn_hlsl_effect_state_block : Warning <
-  "effect state block ignored - effect syntax is deprecated">,
+  "effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.">,
   InGroup< HLSLEffectsSyntax >;
 def warn_hlsl_effect_technique : Warning <
   "effect technique ignored - effect syntax is deprecated">,

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -2661,8 +2661,11 @@ Decl *Parser::ParseDeclarationAfterDeclaratorAndAttributes(
     Diag(Tok.getLocation(), diag::warn_hlsl_effect_state_block);
     ConsumeBrace();
     SkipUntil(tok::r_brace); // skip until '}'
+    // Braces could have been used to initialize an array.
+    // In this case we require users to use braces with the equal sign.
+    // Otherwise, the array will be treated as an uninitialized declaration.
+    Actions.ActOnUninitializedDecl(ThisDecl, TypeContainsAuto);
     // HLSL Change Ends
-
   } else {
     Actions.ActOnUninitializedDecl(ThisDecl, TypeContainsAuto);
   }

--- a/tools/clang/lib/Parse/Parser.cpp
+++ b/tools/clang/lib/Parse/Parser.cpp
@@ -758,6 +758,11 @@ Parser::ParseExternalDeclaration(ParsedAttributesWithRange &attrs,
                                               : Sema::PCC_Namespace);
     cutOffParsing();
     return DeclGroupPtrTy();
+  // HLSL Change Starts: Ignore shared keyword for now
+  case tok::kw_shared:
+      ConsumeToken();
+      return ParseExternalDeclaration(attrs);
+  // HLSL Change Ends
   // HLSL Change Starts: Start parsing declaration of cbuffer and tbuffers
   case tok::kw_cbuffer:
   case tok::kw_tbuffer:
@@ -829,7 +834,7 @@ Parser::ParseExternalDeclaration(ParsedAttributesWithRange &attrs,
     if (getLangOpts().HLSL) goto dont_know; // HLSL Change - skip unsupported processing
     ParseMicrosoftIfExistsExternalDeclaration();
     return DeclGroupPtrTy();
-      
+
   default:
   dont_know:
     // We can't tell whether this is a function-definition or declaration yet.

--- a/tools/clang/test/HLSL/effects-syntax.hlsl
+++ b/tools/clang/test/HLSL/effects-syntax.hlsl
@@ -182,3 +182,5 @@ int foobar4;
 /*verify-ast
   VarDecl <col:1, col:5> col:5 foobar4 'int'
 */
+int foobar5[] {1, 2, 3};                                        /* expected-error {{definition of variable with array type needs an explicit size or an initializer}} expected-warning {{effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.}} fxc-error {{X3000: syntax error: unexpected integer constant}} */
+int foobar6[4] {1, 2, 3, 4};                                    /* expected-warning {{effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs.}} fxc-error {{X3000: syntax error: unexpected integer constant}} */

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/shared.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/shared.hlsl
@@ -1,0 +1,22 @@
+// Rewrite unchanged result:
+cbuffer cb0 {
+  const float X;
+}
+;
+tbuffer tb0 {
+  const float Y;
+}
+;
+Buffer<int> g_intBuffer;
+RWByteAddressBuffer g_byteBuffer;
+Texture1D<double> g_tex1d;
+Texture1DArray<int> g_tex1dArray;
+Texture2D<float> g_tex2d;
+Texture2DArray<float> g_tex2dArray;
+Texture2DMS<half> g_texture2dms;
+Texture2DMSArray<float> g_texture2dmsArray;
+float main() : SV_Target {
+  return -X + Y;
+}
+
+

--- a/tools/clang/test/HLSL/rewriter/shared.hlsl
+++ b/tools/clang/test/HLSL/rewriter/shared.hlsl
@@ -1,0 +1,21 @@
+shared cbuffer cb0 {
+    float X;
+};
+
+shared tbuffer tb0 {
+    float Y;
+};
+
+shared Buffer<int> g_intBuffer;
+shared RWByteAddressBuffer g_byteBuffer;
+
+shared Texture1D<double> g_tex1d;
+shared Texture1DArray<int> g_tex1dArray;
+shared Texture2D<float> g_tex2d;
+shared Texture2DArray<float> g_tex2dArray;
+shared Texture2DMS<half> g_texture2dms;
+shared Texture2DMSArray<float> g_texture2dmsArray;
+
+float main() : SV_Target {
+    return -X + Y;
+}

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -56,6 +56,7 @@ public:
   TEST_METHOD(RunMatrixSyntax);
   TEST_METHOD(RunPackReg);
   TEST_METHOD(RunScalarAssignments);
+  TEST_METHOD(RunShared);
   TEST_METHOD(RunStructAssignments);
   TEST_METHOD(RunTemplateChecks);
   TEST_METHOD(RunTypemodsSyntax);
@@ -273,6 +274,10 @@ TEST_F(RewriterTest, RunPackReg) {
 
 TEST_F(RewriterTest, RunScalarAssignments) {
     CheckVerifiesHLSL(L"rewriter\\scalar-assignments_noerr.hlsl", L"rewriter\\correct_rewrites\\scalar-assignments_gold.hlsl");
+}
+
+TEST_F(RewriterTest, RunShared) {
+    CheckVerifiesHLSL(L"rewriter\\shared.hlsl", L"rewriter\\correct_rewrites\\shared.hlsl");
 }
 
 TEST_F(RewriterTest, RunStructAssignments) {


### PR DESCRIPTION
1. Fix dxc crash on invalid brace-enclosed initializer
2. Ignore shared keyword on cbuffer/tbuffer

