### PR TITLE
Fix te discovery from external dir, including x64/amd64 usage.

### DIFF
--- a/cmake/modules/FindTAEF.cmake
+++ b/cmake/modules/FindTAEF.cmake
@@ -51,7 +51,7 @@ set(TAEF_INCLUDE_DIRS ${TAEF_INCLUDE_DIR})
 
 # Prefer the version that supports both x86 and x64, else prefer latest.
 if(EXISTS "${CMAKE_SOURCE_DIR}/external/taef/build/Binaries/amd64/te.exe")
-  set(TAEF_BIN_DIR "${WINDOWS_KIT_10_PATH}/Testing/Runtimes/TAEF")
+  set(TAEF_BIN_DIR "${CMAKE_SOURCE_DIR}/external/taef/build/Binaries")
 elseif(EXISTS "${WINDOWS_KIT_10_PATH}/Testing/Runtimes/TAEF/x86/te.exe"
    AND EXISTS "${WINDOWS_KIT_10_PATH}/Testing/Runtimes/TAEF/x64/te.exe")
   set(TAEF_BIN_DIR "${WINDOWS_KIT_10_PATH}/Testing/Runtimes/TAEF")

--- a/tools/clang/unittests/HLSL/clang-hlsl-tests.vcxproj.user.txt
+++ b/tools/clang/unittests/HLSL/clang-hlsl-tests.vcxproj.user.txt
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <LocalDebuggerCommand>${DOS_TAEF_BIN_DIR}\$(PlatformTarget)\Te.exe</LocalDebuggerCommand>
+    <LocalDebuggerCommand Condition="'$(PlatformTarget)' == 'x64' And Exists('${DOS_TAEF_BIN_DIR}\amd64\Te.exe')">${DOS_TAEF_BIN_DIR}\amd64\Te.exe</LocalDebuggerCommand>
     <LocalDebuggerCommandArguments>$(TargetPath) /inproc /p:"HlslDataDir=${DOS_STYLE_SOURCE_DIR}\..\..\test\HLSL" /name:*</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>


### PR DESCRIPTION
The WDK was used before because it used x64 rather than amd64, like msbuild/VS.
This didn't work when there was no WDK installed and only external TAEF was available.

This fix includes a check for amd64 when x64 msbuild is used, and so external can now be used.