### PR TITLE
Fix Typed UAV Load flag collection

### DIFF
--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -440,8 +440,10 @@ void DxilModule::CollectShaderFlags(ShaderFlags &Flags) {
                   ConstantInt *rangeID = GetArbitraryConstantRangeID(handleCall);
                   if (rangeID) {
                       DxilResource resource = GetUAV(rangeID->getLimitedValue());
-                      if (!IsResourceSingleComponent(resource.GetRetType())) {
-                          hasMulticomponentUAVLoads = true;
+                      if ((resource.IsTypedBuffer() ||
+                           resource.IsAnyTexture()) &&
+                          !IsResourceSingleComponent(resource.GetRetType())) {
+                        hasMulticomponentUAVLoads = true;
                       }
                   }
                 }

--- a/tools/clang/test/CodeGenHLSL/multiUAVLoad7.hlsl
+++ b/tools/clang/test/CodeGenHLSL/multiUAVLoad7.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+
+// CHECK-NOT: Typed UAV Load Additional Formats
+
+struct SUnaryFPOp {
+    float input;
+    float output;
+};
+RWStructuredBuffer<SUnaryFPOp> g_buf : register(u0);
+[numthreads(8,8,1)]
+void main(uint GI : SV_GroupIndex) {
+    SUnaryFPOp l = g_buf[GI];
+    l.output = sin(l.input);
+    g_buf[GI] = l;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -576,6 +576,7 @@ public:
   TEST_METHOD(CodeGenMultiUAVLoad4)
   TEST_METHOD(CodeGenMultiUAVLoad5)
   TEST_METHOD(CodeGenMultiUAVLoad6)
+  TEST_METHOD(CodeGenMultiUAVLoad7)
   TEST_METHOD(CodeGenMultiStream)
   TEST_METHOD(CodeGenMultiStream2)
   TEST_METHOD(CodeGenNeg1)
@@ -3281,6 +3282,11 @@ TEST_F(CompilerTest, CodeGenMultiUAVLoad5) {
 TEST_F(CompilerTest, CodeGenMultiUAVLoad6) {
   if (m_ver.SkipDxil_1_1_Test()) return;
   CodeGenTestCheck(L"..\\CodeGenHLSL\\multiUAVLoad6.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenMultiUAVLoad7) {
+    if (m_ver.SkipDxil_1_1_Test()) return;
+    CodeGenTestCheck(L"..\\CodeGenHLSL\\multiUAVLoad7.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenMultiStream) {


### PR DESCRIPTION
Previous fix on this checked for multi component elements for UAV, but not its resource types. This change checks if UAV Load is of typed buffer or texture and sets the flag accordingly.