### PR TITLE
Look for extra hctdb files in same dir as hctdb scripts

### DIFF
--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -3,6 +3,7 @@
 ###############################################################################
 # DXIL information.                                                           #
 ###############################################################################
+import os
 
 class db_dxil_enum_value(object):
     "A representation for a value in an enumeration type"
@@ -1118,7 +1119,8 @@ class db_dxil(object):
         inst_starter = "* Inst: "
         block_starter = "* BLOCK-BEGIN"
         block_end = "* BLOCK-END"
-        with open("hctdb_inst_docs.txt") as ops_file:
+        thisdir = os.path.dirname(os.path.realpath(__file__))
+        with open(os.path.join(thisdir, "hctdb_inst_docs.txt")) as ops_file:
             inst_name = ""
             inst_doc = ""
             inst_remarks = ""

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -16,7 +16,8 @@ g_db_hlsl = None
 def get_db_hlsl():
     global g_db_hlsl
     if g_db_hlsl is None:
-      with open("gen_intrin_main.txt", "r") as f:
+      thisdir = os.path.dirname(os.path.realpath(__file__))
+      with open(os.path.join(thisdir, "gen_intrin_main.txt"), "r") as f:
         g_db_hlsl = db_hlsl(f)
     return g_db_hlsl
 


### PR DESCRIPTION
Allows the hctdb_instrhelper.py script to be run from outside
utils/hct. No change in generated code.