### PR TITLE
Additional fixes for error handling exposed by OOM testing

### DIFF
--- a/include/llvm/ADT/StringRef.h
+++ b/include/llvm/ADT/StringRef.h
@@ -568,4 +568,24 @@ namespace llvm {
   template <> struct isPodLike<StringRef> { static const bool value = true; };
 }
 
+// HLSL Change Starts
+// StringRef provides an operator string; that trips up the std::pair noexcept specification,
+// which (a) enables the moves constructor (because conversion is allowed), but (b)
+// misclassifies the the construction as nothrow.
+namespace std {
+  template<>
+  struct is_nothrow_constructible <std::string, llvm::StringRef>
+    : std::false_type {
+  };
+  template<>
+  struct is_nothrow_constructible <std::string, llvm::StringRef &>
+    : std::false_type {
+  };
+  template<>
+  struct is_nothrow_constructible <std::string, const llvm::StringRef &>
+    : std::false_type {
+  };
+}
+// HLSL Change Ends
+
 #endif

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2168,9 +2168,12 @@ public:
   }
 
   virtual void *STDMETHODCALLTYPE Realloc(_In_opt_ void *pv, _In_ SIZE_T cb) {
+    SIZE_T priorSize = pv == nullptr ? (SIZE_T)0 : GetSize(pv);
     void *R = Alloc(cb);
     if (!R)
       return nullptr;
+    SIZE_T copySize = std::min(cb, priorSize);
+    memcpy(R, pv, copySize);
     Free(pv);
     return R;
   }

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2238,6 +2238,11 @@ TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
     L"cs_6_0", nullptr, 0, nullptr, 0, nullptr, &pResult));
   allocCount = InstrMalloc.GetAllocCount();
   allocSize = InstrMalloc.GetAllocSize();
+
+  HRESULT hrWithMemory;
+  VERIFY_SUCCEEDED(pResult->GetStatus(&hrWithMemory));
+  VERIFY_SUCCEEDED(hrWithMemory);
+
   pCompiler.Release();
   pResult.Release();
 
@@ -2261,7 +2266,7 @@ TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
 
   // Now, fail each allocation and make sure we get an error.
   for (ULONG i = 0; i <= allocCount; ++i) {
-    LogCommentFmt(L"alloc fail %u", i);
+    // LogCommentFmt(L"alloc fail %u", i);
     bool isLast = i == allocCount;
     InstrMalloc.ResetCounts();
     InstrMalloc.ResetHeap();


### PR DESCRIPTION
In particular, out-of-memory exceptions thrown during string construction in the context of certain move constructors (in this case, and std::pair) would cause the runtime to terminate the process.

The problem is that a noexcept specification was added to some STL move constructors incorrectly, and when the runtime finds such a frame while unwinding, it will invoke std::terminate(). See the comments and static assertions for more details.

A future change will remove debug iterators from Debug builds (the default) and so the out-of-memory tests will be run more regularly; at the time it seems to be of more use finding issues than the iterator checks.