### PR TITLE
dia improvements

### DIFF
--- a/tools/clang/tools/dotnetc/D3DCompiler.cs
+++ b/tools/clang/tools/dotnetc/D3DCompiler.cs
@@ -1,0 +1,43 @@
+﻿///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// D3DCompiler.cs                                                            //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+namespace D3DCompiler
+{
+    using DotNetDxc;
+    using System;
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct D3D_SHADER_MACRO
+    {
+        [MarshalAs(UnmanagedType.LPStr)] string Name;
+        [MarshalAs(UnmanagedType.LPStr)] string Definition;
+    }
+
+    internal static class D3DCompiler
+    {
+        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        public extern static Int32 D3DCompile(
+            [MarshalAs(UnmanagedType.LPStr)] string srcData, int srcDataSize,
+            [MarshalAs(UnmanagedType.LPStr)] string sourceName,
+            [MarshalAs(UnmanagedType.LPArray)] D3D_SHADER_MACRO[] defines,
+            int pInclude,
+            [MarshalAs(UnmanagedType.LPStr)] string entryPoint,
+            [MarshalAs(UnmanagedType.LPStr)] string target,
+            UInt32 Flags1,
+            UInt32 Flags2,
+            out IDxcBlob code, out IDxcBlob errorMsgs);
+
+        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        public extern static Int32 D3DDisassemble(
+            IntPtr ptr, uint ptrSize, uint flags,
+            [MarshalAs(UnmanagedType.LPStr)] string szComments,
+            out IDxcBlob disassembly);
+    }
+}

--- a/tools/clang/tools/dotnetc/DotNetDxc.cs
+++ b/tools/clang/tools/dotnetc/DotNetDxc.cs
@@ -346,9 +346,11 @@ namespace DotNetDxc
     class HlslDxcLib
     {
         private static Guid CLSID_DxcAssembler = new Guid("D728DB68-F903-4F80-94CD-DCCF76EC7151");
+        private static Guid CLSID_DxcDiaDataSource = new Guid("CD1F6B73-2AB0-484D-8EDC-EBE7A43CA09F");
         private static Guid CLSID_DxcIntelliSense = new Guid("3047833c-d1c0-4b8e-9d40-102878605985");
         private static Guid CLSID_DxcRewriter = new Guid("b489b951-e07f-40b3-968d-93e124734da4");
         private static Guid CLSID_DxcCompiler = new Guid("73e22d93-e6ce-47f3-b5bf-f0664f39c1b0");
+        private static Guid CLSID_DxcContainerReflection = new Guid("b9f54489-55b8-400c-ba3a-1675e4728b91");
         private static Guid CLSID_DxcLibrary = new Guid("6245D6AF-66E0-48FD-80B4-4D271796748C");
         private static Guid CLSID_DxcOptimizer = new Guid("AE2CD79F-CC22-453F-9B6B-B124E7A5204C");
         private static Guid CLSID_DxcValidator = new Guid("8CA3E215-F728-4CF3-8CDD-88AF917587A1");
@@ -401,6 +403,25 @@ namespace DotNetDxc
             return (IDxcCompiler)result;
         }
 
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static IDxcContainerReflection CreateDxcContainerReflection()
+        {
+            Guid classId = CLSID_DxcContainerReflection;
+            Guid interfaceId = typeof(IDxcContainerReflection).GUID;
+            object result;
+            DxcCreateInstance(ref classId, ref interfaceId, out result);
+            return (IDxcContainerReflection)result;
+        }
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]
+        public static dia2.IDiaDataSource CreateDxcDiaDataSource()
+        {
+            Guid classId = CLSID_DxcDiaDataSource;
+            Guid interfaceId = typeof(dia2.IDiaDataSource).GUID;
+            object result;
+            DxcCreateInstance(ref classId, ref interfaceId, out result);
+            return (dia2.IDiaDataSource)result;
+        }
 
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static IDxcLibrary CreateDxcLibrary()
@@ -1275,6 +1296,21 @@ namespace DotNetDxc
         IDxcOperationResult Preprocess(IDxcBlob source, string sourceName, string[] arguments, int argCount,
             DXCDefine[] defines, int defineCount, IDxcIncludeHandler includeHandler);
         IDxcBlobEncoding Disassemble(IDxcBlob source);
+    }
+
+    [ComImport]
+    [Guid("d2c21b26-8350-4bdc-976a-331ce6f4c54c")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDxcContainerReflection
+    {
+        void Load(IDxcBlob container);
+        uint GetPartCount();
+        uint GetPartKind(uint idx);
+        IDxcBlob GetPartContent(uint idx);
+        [PreserveSig]
+        int FindFirstPartKind(uint kind, out uint result);
+        [return: MarshalAs(UnmanagedType.Interface, IidParameterIndex = 1)]
+        object GetPartReflection(uint idx, Guid iid);
     }
 
     [ComImport]

--- a/tools/clang/tools/dotnetc/EditorForm.Designer.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.Designer.cs
@@ -70,6 +70,7 @@ namespace MainNs
             this.autoUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bitstreamToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ColorMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.debugInformationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.errorListToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.renderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.outputToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -107,12 +108,12 @@ namespace MainNs
             this.label1 = new System.Windows.Forms.Label();
             this.AvailablePassesBox = new System.Windows.Forms.ListBox();
             this.RewriterOutputTabPage = new System.Windows.Forms.TabPage();
+            this.RewriterOutputTextBox = new System.Windows.Forms.RichTextBox();
             this.TheToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.TopSplitContainer = new System.Windows.Forms.SplitContainer();
             this.OutputTabControl = new System.Windows.Forms.TabControl();
             this.RenderLogTabPage = new System.Windows.Forms.TabPage();
             this.RenderLogBox = new System.Windows.Forms.TextBox();
-            this.RewriterOutputTextBox = new System.Windows.Forms.RichTextBox();
             this.TheStatusStrip.SuspendLayout();
             this.TheMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -138,10 +139,10 @@ namespace MainNs
             this.TheStatusStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.TheStatusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.TheStatusStripLabel});
-            this.TheStatusStrip.Location = new System.Drawing.Point(0, 821);
+            this.TheStatusStrip.Location = new System.Drawing.Point(0, 1032);
             this.TheStatusStrip.Name = "TheStatusStrip";
-            this.TheStatusStrip.Padding = new System.Windows.Forms.Padding(2, 0, 14, 0);
-            this.TheStatusStrip.Size = new System.Drawing.Size(1176, 22);
+            this.TheStatusStrip.Padding = new System.Windows.Forms.Padding(3, 0, 19, 0);
+            this.TheStatusStrip.Size = new System.Drawing.Size(1568, 22);
             this.TheStatusStrip.TabIndex = 0;
             this.TheStatusStrip.Text = "statusStrip1";
             // 
@@ -162,7 +163,8 @@ namespace MainNs
             this.helpToolStripMenuItem});
             this.TheMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.TheMenuStrip.Name = "TheMenuStrip";
-            this.TheMenuStrip.Size = new System.Drawing.Size(1176, 33);
+            this.TheMenuStrip.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
+            this.TheMenuStrip.Size = new System.Drawing.Size(1568, 42);
             this.TheMenuStrip.TabIndex = 1;
             this.TheMenuStrip.Text = "menuStrip1";
             // 
@@ -178,7 +180,7 @@ namespace MainNs
             this.toolStripMenuItem4,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(64, 38);
             this.fileToolStripMenuItem.Text = "&File";
             this.fileToolStripMenuItem.DropDownOpening += new System.EventHandler(this.fileToolStripMenuItem_DropDownOpening);
             // 
@@ -186,7 +188,7 @@ namespace MainNs
             // 
             this.NewToolStripMenuItem.Name = "NewToolStripMenuItem";
             this.NewToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.NewToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.NewToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.NewToolStripMenuItem.Text = "&New";
             this.NewToolStripMenuItem.Click += new System.EventHandler(this.NewToolStripMenuItem_Click);
             // 
@@ -194,7 +196,7 @@ namespace MainNs
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.openToolStripMenuItem.Text = "&Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -202,37 +204,37 @@ namespace MainNs
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.saveToolStripMenuItem.Text = "&Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.saveAsToolStripMenuItem.Text = "Save &As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(214, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(271, 6);
             // 
             // recentFilesToolStripMenuItem
             // 
             this.recentFilesToolStripMenuItem.Name = "recentFilesToolStripMenuItem";
-            this.recentFilesToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.recentFilesToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.recentFilesToolStripMenuItem.Text = "Recent &Files";
             // 
             // toolStripMenuItem4
             // 
             this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(214, 6);
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(271, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.exitToolStripMenuItem.Text = "E&xit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -254,27 +256,27 @@ namespace MainNs
             this.FontGrowToolStripMenuItem,
             this.FontShrinkToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(54, 29);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(67, 38);
             this.editToolStripMenuItem.Text = "&Edit";
             // 
             // undoToolStripMenuItem
             // 
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
             this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.undoToolStripMenuItem.Text = "&Undo";
             this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(293, 6);
             // 
             // cutToolStripMenuItem
             // 
             this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
             this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.cutToolStripMenuItem.Text = "Cu&t";
             this.cutToolStripMenuItem.Click += new System.EventHandler(this.cutToolStripMenuItem_Click);
             // 
@@ -282,7 +284,7 @@ namespace MainNs
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
             this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.copyToolStripMenuItem.Text = "&Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
@@ -290,48 +292,48 @@ namespace MainNs
             // 
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
             this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.pasteToolStripMenuItem.Text = "&Paste";
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
             // 
             // deleteToolStripMenuItem
             // 
             this.deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
-            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.deleteToolStripMenuItem.Text = "&Delete";
             this.deleteToolStripMenuItem.Click += new System.EventHandler(this.deleteToolStripMenuItem_Click);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(293, 6);
             // 
             // selectAllToolStripMenuItem
             // 
             this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
             this.selectAllToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.selectAllToolStripMenuItem.Text = "Select &All";
             this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
             // 
             // toolStripMenuItem3
             // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(293, 6);
             // 
             // findAndReplaceToolStripMenuItem
             // 
             this.findAndReplaceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.quickFindToolStripMenuItem});
             this.findAndReplaceToolStripMenuItem.Name = "findAndReplaceToolStripMenuItem";
-            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.findAndReplaceToolStripMenuItem.Text = "&Find and Replace";
             // 
             // quickFindToolStripMenuItem
             // 
             this.quickFindToolStripMenuItem.Name = "quickFindToolStripMenuItem";
             this.quickFindToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.quickFindToolStripMenuItem.Size = new System.Drawing.Size(240, 30);
+            this.quickFindToolStripMenuItem.Size = new System.Drawing.Size(308, 38);
             this.quickFindToolStripMenuItem.Text = "Quick &Find";
             this.quickFindToolStripMenuItem.Click += new System.EventHandler(this.quickFindToolStripMenuItem_Click);
             // 
@@ -339,14 +341,14 @@ namespace MainNs
             // 
             this.goToToolStripMenuItem.Name = "goToToolStripMenuItem";
             this.goToToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.goToToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.goToToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.goToToolStripMenuItem.Text = "&Go To...";
             this.goToToolStripMenuItem.Click += new System.EventHandler(this.goToToolStripMenuItem_Click);
             // 
             // fileVariablesToolStripMenuItem
             // 
             this.fileVariablesToolStripMenuItem.Name = "fileVariablesToolStripMenuItem";
-            this.fileVariablesToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.fileVariablesToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.fileVariablesToolStripMenuItem.Text = "File &Variables...";
             this.fileVariablesToolStripMenuItem.Click += new System.EventHandler(this.fileVariablesToolStripMenuItem_Click);
             // 
@@ -356,7 +358,7 @@ namespace MainNs
             this.FontGrowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.OemPeriod)));
             this.FontGrowToolStripMenuItem.ShowShortcutKeys = false;
-            this.FontGrowToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.FontGrowToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.FontGrowToolStripMenuItem.Text = "Font G&row";
             this.FontGrowToolStripMenuItem.Click += new System.EventHandler(this.FontGrowToolStripMenuItem_Click);
             // 
@@ -366,7 +368,7 @@ namespace MainNs
             this.FontShrinkToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Oemcomma)));
             this.FontShrinkToolStripMenuItem.ShowShortcutKeys = false;
-            this.FontShrinkToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.FontShrinkToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.FontShrinkToolStripMenuItem.Text = "Font Shrin&k";
             this.FontShrinkToolStripMenuItem.Click += new System.EventHandler(this.FontShrinkToolStripMenuItem_Click);
             // 
@@ -376,52 +378,60 @@ namespace MainNs
             this.autoUpdateToolStripMenuItem,
             this.bitstreamToolStripMenuItem,
             this.ColorMenuItem,
+            this.debugInformationToolStripMenuItem,
             this.errorListToolStripMenuItem,
             this.renderToolStripMenuItem,
             this.outputToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(78, 38);
             this.viewToolStripMenuItem.Text = "&View";
             // 
             // autoUpdateToolStripMenuItem
             // 
             this.autoUpdateToolStripMenuItem.Name = "autoUpdateToolStripMenuItem";
-            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.autoUpdateToolStripMenuItem.Text = "&Auto-Update";
             this.autoUpdateToolStripMenuItem.Click += new System.EventHandler(this.autoUpdateToolStripMenuItem_Click);
             // 
             // bitstreamToolStripMenuItem
             // 
             this.bitstreamToolStripMenuItem.Name = "bitstreamToolStripMenuItem";
-            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.bitstreamToolStripMenuItem.Text = "&Bitstream";
             this.bitstreamToolStripMenuItem.Click += new System.EventHandler(this.bitstreamToolStripMenuItem_Click);
             // 
             // ColorMenuItem
             // 
             this.ColorMenuItem.Name = "ColorMenuItem";
-            this.ColorMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.ColorMenuItem.Size = new System.Drawing.Size(318, 38);
             this.ColorMenuItem.Text = "&Color";
             this.ColorMenuItem.Click += new System.EventHandler(this.colorToolStripMenuItem_Click);
+            // 
+            // debugInformationToolStripMenuItem
+            // 
+            this.debugInformationToolStripMenuItem.Name = "debugInformationToolStripMenuItem";
+            this.debugInformationToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.debugInformationToolStripMenuItem.Text = "&Debug Information";
+            this.debugInformationToolStripMenuItem.Click += new System.EventHandler(this.debugInformationToolStripMenuItem_Click);
             // 
             // errorListToolStripMenuItem
             // 
             this.errorListToolStripMenuItem.Name = "errorListToolStripMenuItem";
-            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.errorListToolStripMenuItem.Text = "Error L&ist";
             this.errorListToolStripMenuItem.Click += new System.EventHandler(this.errorListToolStripMenuItem_Click);
             // 
             // renderToolStripMenuItem
             // 
             this.renderToolStripMenuItem.Name = "renderToolStripMenuItem";
-            this.renderToolStripMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.renderToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.renderToolStripMenuItem.Text = "&Render";
             this.renderToolStripMenuItem.Click += new System.EventHandler(this.renderToolStripMenuItem_Click);
             // 
             // outputToolStripMenuItem
             // 
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
-            this.outputToolStripMenuItem.Size = new System.Drawing.Size(200, 30);
+            this.outputToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.outputToolStripMenuItem.Text = "&Output";
             this.outputToolStripMenuItem.Click += new System.EventHandler(this.outputToolStripMenuItem_Click);
             // 
@@ -431,21 +441,21 @@ namespace MainNs
             this.compileToolStripMenuItem,
             this.exportCompiledObjectToolStripMenuItem});
             this.buildToolStripMenuItem.Name = "buildToolStripMenuItem";
-            this.buildToolStripMenuItem.Size = new System.Drawing.Size(63, 29);
+            this.buildToolStripMenuItem.Size = new System.Drawing.Size(81, 38);
             this.buildToolStripMenuItem.Text = "&Build";
             // 
             // compileToolStripMenuItem
             // 
             this.compileToolStripMenuItem.Name = "compileToolStripMenuItem";
             this.compileToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7)));
-            this.compileToolStripMenuItem.Size = new System.Drawing.Size(286, 30);
+            this.compileToolStripMenuItem.Size = new System.Drawing.Size(368, 38);
             this.compileToolStripMenuItem.Text = "Co&mpile";
             this.compileToolStripMenuItem.Click += new System.EventHandler(this.compileToolStripMenuItem_Click);
             // 
             // exportCompiledObjectToolStripMenuItem
             // 
             this.exportCompiledObjectToolStripMenuItem.Name = "exportCompiledObjectToolStripMenuItem";
-            this.exportCompiledObjectToolStripMenuItem.Size = new System.Drawing.Size(286, 30);
+            this.exportCompiledObjectToolStripMenuItem.Size = new System.Drawing.Size(368, 38);
             this.exportCompiledObjectToolStripMenuItem.Text = "&Export Compiled Object";
             this.exportCompiledObjectToolStripMenuItem.Click += new System.EventHandler(this.exportCompiledObjectToolStripMenuItem_Click);
             // 
@@ -456,27 +466,27 @@ namespace MainNs
             this.rewriterToolStripMenuItem,
             this.rewriteNobodyToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(65, 29);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(82, 38);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.optionsToolStripMenuItem.Text = "&Options...";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // rewriterToolStripMenuItem
             // 
             this.rewriterToolStripMenuItem.Name = "rewriterToolStripMenuItem";
-            this.rewriterToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.rewriterToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.rewriterToolStripMenuItem.Text = "Rewriter";
             this.rewriterToolStripMenuItem.Click += new System.EventHandler(this.rewriterToolStripMenuItem_Click);
             // 
             // rewriteNobodyToolStripMenuItem
             // 
             this.rewriteNobodyToolStripMenuItem.Name = "rewriteNobodyToolStripMenuItem";
-            this.rewriteNobodyToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.rewriteNobodyToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.rewriteNobodyToolStripMenuItem.Text = "RewriteNobody";
             this.rewriteNobodyToolStripMenuItem.Click += new System.EventHandler(this.rewriteNobodyToolStripMenuItem_Click);
             // 
@@ -485,13 +495,13 @@ namespace MainNs
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(77, 38);
             this.helpToolStripMenuItem.Text = "&Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(158, 30);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(194, 38);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -499,6 +509,7 @@ namespace MainNs
             // 
             this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4);
             this.splitContainer1.Name = "splitContainer1";
             // 
             // splitContainer1.Panel1
@@ -508,8 +519,9 @@ namespace MainNs
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.AnalysisTabControl);
-            this.splitContainer1.Size = new System.Drawing.Size(1176, 788);
-            this.splitContainer1.SplitterDistance = 427;
+            this.splitContainer1.Size = new System.Drawing.Size(1568, 990);
+            this.splitContainer1.SplitterDistance = 569;
+            this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 2;
             // 
             // CodeBox
@@ -517,8 +529,9 @@ namespace MainNs
             this.CodeBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.CodeBox.Font = new System.Drawing.Font("Consolas", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.CodeBox.Location = new System.Drawing.Point(0, 0);
+            this.CodeBox.Margin = new System.Windows.Forms.Padding(4);
             this.CodeBox.Name = "CodeBox";
-            this.CodeBox.Size = new System.Drawing.Size(427, 788);
+            this.CodeBox.Size = new System.Drawing.Size(569, 990);
             this.CodeBox.TabIndex = 0;
             this.CodeBox.Text = "";
             this.CodeBox.WordWrap = false;
@@ -533,19 +546,21 @@ namespace MainNs
             this.AnalysisTabControl.Controls.Add(this.RewriterOutputTabPage);
             this.AnalysisTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.AnalysisTabControl.Location = new System.Drawing.Point(0, 0);
+            this.AnalysisTabControl.Margin = new System.Windows.Forms.Padding(4);
             this.AnalysisTabControl.Name = "AnalysisTabControl";
             this.AnalysisTabControl.SelectedIndex = 0;
-            this.AnalysisTabControl.Size = new System.Drawing.Size(745, 788);
+            this.AnalysisTabControl.Size = new System.Drawing.Size(994, 990);
             this.AnalysisTabControl.TabIndex = 0;
             this.AnalysisTabControl.Selecting += new System.Windows.Forms.TabControlCancelEventHandler(this.AnalysisTabControl_Selecting);
             // 
             // DisassemblyTabPage
             // 
             this.DisassemblyTabPage.Controls.Add(this.DisassemblyTextBox);
-            this.DisassemblyTabPage.Location = new System.Drawing.Point(4, 29);
+            this.DisassemblyTabPage.Location = new System.Drawing.Point(8, 39);
+            this.DisassemblyTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.DisassemblyTabPage.Name = "DisassemblyTabPage";
-            this.DisassemblyTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.DisassemblyTabPage.Size = new System.Drawing.Size(737, 755);
+            this.DisassemblyTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.DisassemblyTabPage.Size = new System.Drawing.Size(978, 943);
             this.DisassemblyTabPage.TabIndex = 0;
             this.DisassemblyTabPage.Text = "Disassembly";
             this.DisassemblyTabPage.UseVisualStyleBackColor = true;
@@ -553,10 +568,11 @@ namespace MainNs
             // DisassemblyTextBox
             // 
             this.DisassemblyTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DisassemblyTextBox.Location = new System.Drawing.Point(3, 3);
+            this.DisassemblyTextBox.Location = new System.Drawing.Point(4, 4);
+            this.DisassemblyTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.DisassemblyTextBox.Name = "DisassemblyTextBox";
             this.DisassemblyTextBox.ReadOnly = true;
-            this.DisassemblyTextBox.Size = new System.Drawing.Size(731, 749);
+            this.DisassemblyTextBox.Size = new System.Drawing.Size(970, 935);
             this.DisassemblyTextBox.TabIndex = 0;
             this.DisassemblyTextBox.Text = "";
             this.DisassemblyTextBox.WordWrap = false;
@@ -565,10 +581,11 @@ namespace MainNs
             // ASTTabPage
             // 
             this.ASTTabPage.Controls.Add(this.ASTDumpBox);
-            this.ASTTabPage.Location = new System.Drawing.Point(4, 29);
+            this.ASTTabPage.Location = new System.Drawing.Point(8, 39);
+            this.ASTTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.ASTTabPage.Name = "ASTTabPage";
-            this.ASTTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.ASTTabPage.Size = new System.Drawing.Size(737, 755);
+            this.ASTTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.ASTTabPage.Size = new System.Drawing.Size(978, 945);
             this.ASTTabPage.TabIndex = 1;
             this.ASTTabPage.Text = "AST";
             this.ASTTabPage.UseVisualStyleBackColor = true;
@@ -576,10 +593,11 @@ namespace MainNs
             // ASTDumpBox
             // 
             this.ASTDumpBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ASTDumpBox.Location = new System.Drawing.Point(3, 3);
+            this.ASTDumpBox.Location = new System.Drawing.Point(4, 4);
+            this.ASTDumpBox.Margin = new System.Windows.Forms.Padding(4);
             this.ASTDumpBox.Name = "ASTDumpBox";
             this.ASTDumpBox.ReadOnly = true;
-            this.ASTDumpBox.Size = new System.Drawing.Size(731, 749);
+            this.ASTDumpBox.Size = new System.Drawing.Size(970, 937);
             this.ASTDumpBox.TabIndex = 0;
             this.ASTDumpBox.Text = "";
             // 
@@ -596,10 +614,11 @@ namespace MainNs
             this.OptimizerTabPage.Controls.Add(this.label2);
             this.OptimizerTabPage.Controls.Add(this.label1);
             this.OptimizerTabPage.Controls.Add(this.AvailablePassesBox);
-            this.OptimizerTabPage.Location = new System.Drawing.Point(4, 29);
+            this.OptimizerTabPage.Location = new System.Drawing.Point(8, 39);
+            this.OptimizerTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.OptimizerTabPage.Name = "OptimizerTabPage";
-            this.OptimizerTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.OptimizerTabPage.Size = new System.Drawing.Size(737, 755);
+            this.OptimizerTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.OptimizerTabPage.Size = new System.Drawing.Size(978, 945);
             this.OptimizerTabPage.TabIndex = 2;
             this.OptimizerTabPage.Text = "Optimizer";
             this.OptimizerTabPage.UseVisualStyleBackColor = true;
@@ -608,10 +627,10 @@ namespace MainNs
             // 
             this.PrintAllPassesBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.PrintAllPassesBox.AutoSize = true;
-            this.PrintAllPassesBox.Location = new System.Drawing.Point(10, 624);
-            this.PrintAllPassesBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.PrintAllPassesBox.Location = new System.Drawing.Point(13, 770);
+            this.PrintAllPassesBox.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.PrintAllPassesBox.Name = "PrintAllPassesBox";
-            this.PrintAllPassesBox.Size = new System.Drawing.Size(141, 24);
+            this.PrintAllPassesBox.Size = new System.Drawing.Size(191, 29);
             this.PrintAllPassesBox.TabIndex = 10;
             this.PrintAllPassesBox.Text = "Print all passes";
             this.PrintAllPassesBox.UseVisualStyleBackColor = true;
@@ -619,9 +638,10 @@ namespace MainNs
             // ResetDefaultPassesButton
             // 
             this.ResetDefaultPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.ResetDefaultPassesButton.Location = new System.Drawing.Point(427, 627);
+            this.ResetDefaultPassesButton.Location = new System.Drawing.Point(560, 773);
+            this.ResetDefaultPassesButton.Margin = new System.Windows.Forms.Padding(4);
             this.ResetDefaultPassesButton.Name = "ResetDefaultPassesButton";
-            this.ResetDefaultPassesButton.Size = new System.Drawing.Size(219, 38);
+            this.ResetDefaultPassesButton.Size = new System.Drawing.Size(292, 48);
             this.ResetDefaultPassesButton.TabIndex = 9;
             this.ResetDefaultPassesButton.Text = "Reset Default Passes";
             this.ResetDefaultPassesButton.UseVisualStyleBackColor = true;
@@ -631,10 +651,10 @@ namespace MainNs
             // 
             this.AnalyzeCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.AnalyzeCheckBox.AutoSize = true;
-            this.AnalyzeCheckBox.Location = new System.Drawing.Point(10, 592);
-            this.AnalyzeCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
+            this.AnalyzeCheckBox.Location = new System.Drawing.Point(13, 730);
+            this.AnalyzeCheckBox.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
             this.AnalyzeCheckBox.Name = "AnalyzeCheckBox";
-            this.AnalyzeCheckBox.Size = new System.Drawing.Size(146, 24);
+            this.AnalyzeCheckBox.Size = new System.Drawing.Size(196, 29);
             this.AnalyzeCheckBox.TabIndex = 8;
             this.AnalyzeCheckBox.Text = "Analyze passes";
             this.AnalyzeCheckBox.UseVisualStyleBackColor = true;
@@ -642,9 +662,10 @@ namespace MainNs
             // AddPrintModuleButton
             // 
             this.AddPrintModuleButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.AddPrintModuleButton.Location = new System.Drawing.Point(10, 656);
+            this.AddPrintModuleButton.Location = new System.Drawing.Point(13, 809);
+            this.AddPrintModuleButton.Margin = new System.Windows.Forms.Padding(4);
             this.AddPrintModuleButton.Name = "AddPrintModuleButton";
-            this.AddPrintModuleButton.Size = new System.Drawing.Size(219, 38);
+            this.AddPrintModuleButton.Size = new System.Drawing.Size(292, 48);
             this.AddPrintModuleButton.TabIndex = 7;
             this.AddPrintModuleButton.Text = "Add Print Module";
             this.AddPrintModuleButton.UseVisualStyleBackColor = true;
@@ -653,9 +674,10 @@ namespace MainNs
             // RunPassesButton
             // 
             this.RunPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.RunPassesButton.Location = new System.Drawing.Point(427, 668);
+            this.RunPassesButton.Location = new System.Drawing.Point(560, 825);
+            this.RunPassesButton.Margin = new System.Windows.Forms.Padding(4);
             this.RunPassesButton.Name = "RunPassesButton";
-            this.RunPassesButton.Size = new System.Drawing.Size(219, 38);
+            this.RunPassesButton.Size = new System.Drawing.Size(292, 48);
             this.RunPassesButton.TabIndex = 6;
             this.RunPassesButton.Text = "Run Passes";
             this.RunPassesButton.UseVisualStyleBackColor = true;
@@ -664,9 +686,10 @@ namespace MainNs
             // SelectPassDownButton
             // 
             this.SelectPassDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectPassDownButton.Location = new System.Drawing.Point(537, 579);
+            this.SelectPassDownButton.Location = new System.Drawing.Point(706, 713);
+            this.SelectPassDownButton.Margin = new System.Windows.Forms.Padding(4);
             this.SelectPassDownButton.Name = "SelectPassDownButton";
-            this.SelectPassDownButton.Size = new System.Drawing.Size(110, 38);
+            this.SelectPassDownButton.Size = new System.Drawing.Size(147, 48);
             this.SelectPassDownButton.TabIndex = 5;
             this.SelectPassDownButton.Text = "Swap Down";
             this.SelectPassDownButton.UseVisualStyleBackColor = true;
@@ -675,9 +698,10 @@ namespace MainNs
             // SelectPassUpButton
             // 
             this.SelectPassUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectPassUpButton.Location = new System.Drawing.Point(427, 579);
+            this.SelectPassUpButton.Location = new System.Drawing.Point(560, 713);
+            this.SelectPassUpButton.Margin = new System.Windows.Forms.Padding(4);
             this.SelectPassUpButton.Name = "SelectPassUpButton";
-            this.SelectPassUpButton.Size = new System.Drawing.Size(104, 38);
+            this.SelectPassUpButton.Size = new System.Drawing.Size(139, 48);
             this.SelectPassUpButton.TabIndex = 4;
             this.SelectPassUpButton.Text = "Swap Up";
             this.SelectPassUpButton.UseVisualStyleBackColor = true;
@@ -689,10 +713,11 @@ namespace MainNs
             | System.Windows.Forms.AnchorStyles.Right)));
             this.SelectedPassesBox.ContextMenuStrip = this.PassesContextMenu;
             this.SelectedPassesBox.FormattingEnabled = true;
-            this.SelectedPassesBox.ItemHeight = 20;
-            this.SelectedPassesBox.Location = new System.Drawing.Point(427, 46);
+            this.SelectedPassesBox.ItemHeight = 25;
+            this.SelectedPassesBox.Location = new System.Drawing.Point(560, 58);
+            this.SelectedPassesBox.Margin = new System.Windows.Forms.Padding(4);
             this.SelectedPassesBox.Name = "SelectedPassesBox";
-            this.SelectedPassesBox.Size = new System.Drawing.Size(308, 424);
+            this.SelectedPassesBox.Size = new System.Drawing.Size(409, 504);
             this.SelectedPassesBox.TabIndex = 3;
             this.SelectedPassesBox.DoubleClick += new System.EventHandler(this.SelectedPassesBox_DoubleClick);
             this.SelectedPassesBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.SelectedPassesBox_KeyUp);
@@ -706,31 +731,31 @@ namespace MainNs
             this.copyToolStripMenuItem1,
             this.copyAllToolStripMenuItem});
             this.PassesContextMenu.Name = "PassesContextMenu";
-            this.PassesContextMenu.Size = new System.Drawing.Size(177, 100);
+            this.PassesContextMenu.Size = new System.Drawing.Size(213, 118);
             // 
             // PassPropertiesMenuItem
             // 
             this.PassPropertiesMenuItem.Name = "PassPropertiesMenuItem";
-            this.PassPropertiesMenuItem.Size = new System.Drawing.Size(176, 30);
+            this.PassPropertiesMenuItem.Size = new System.Drawing.Size(212, 36);
             this.PassPropertiesMenuItem.Text = "&Properties...";
             this.PassPropertiesMenuItem.Click += new System.EventHandler(this.PassPropertiesMenuItem_Click);
             // 
             // toolStripMenuItem5
             // 
             this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(173, 6);
+            this.toolStripMenuItem5.Size = new System.Drawing.Size(209, 6);
             // 
             // copyToolStripMenuItem1
             // 
             this.copyToolStripMenuItem1.Name = "copyToolStripMenuItem1";
-            this.copyToolStripMenuItem1.Size = new System.Drawing.Size(176, 30);
+            this.copyToolStripMenuItem1.Size = new System.Drawing.Size(212, 36);
             this.copyToolStripMenuItem1.Text = "&Copy";
             this.copyToolStripMenuItem1.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // copyAllToolStripMenuItem
             // 
             this.copyAllToolStripMenuItem.Name = "copyAllToolStripMenuItem";
-            this.copyAllToolStripMenuItem.Size = new System.Drawing.Size(176, 30);
+            this.copyAllToolStripMenuItem.Size = new System.Drawing.Size(212, 36);
             this.copyAllToolStripMenuItem.Text = "Copy &All";
             this.copyAllToolStripMenuItem.Click += new System.EventHandler(this.copyAllToolStripMenuItem_Click);
             // 
@@ -738,18 +763,20 @@ namespace MainNs
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(423, 12);
+            this.label2.Location = new System.Drawing.Point(554, 15);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(68, 20);
+            this.label2.Size = new System.Drawing.Size(95, 25);
             this.label2.TabIndex = 2;
             this.label2.Text = "&Pipeline:";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 12);
+            this.label1.Location = new System.Drawing.Point(8, 15);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(278, 20);
+            this.label1.Size = new System.Drawing.Size(384, 25);
             this.label1.TabIndex = 1;
             this.label1.Text = "&Available Passes (double-click to add):";
             // 
@@ -759,30 +786,45 @@ namespace MainNs
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.AvailablePassesBox.FormattingEnabled = true;
-            this.AvailablePassesBox.ItemHeight = 20;
-            this.AvailablePassesBox.Location = new System.Drawing.Point(10, 46);
+            this.AvailablePassesBox.ItemHeight = 25;
+            this.AvailablePassesBox.Location = new System.Drawing.Point(13, 58);
+            this.AvailablePassesBox.Margin = new System.Windows.Forms.Padding(4);
             this.AvailablePassesBox.Name = "AvailablePassesBox";
             this.AvailablePassesBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.AvailablePassesBox.Size = new System.Drawing.Size(409, 424);
+            this.AvailablePassesBox.Size = new System.Drawing.Size(534, 504);
             this.AvailablePassesBox.TabIndex = 0;
             this.AvailablePassesBox.DoubleClick += new System.EventHandler(this.AvailablePassesBox_DoubleClick);
             // 
             // RewriterOutputTabPage
             // 
             this.RewriterOutputTabPage.Controls.Add(this.RewriterOutputTextBox);
-            this.RewriterOutputTabPage.Location = new System.Drawing.Point(4, 29);
+            this.RewriterOutputTabPage.Location = new System.Drawing.Point(8, 39);
+            this.RewriterOutputTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.RewriterOutputTabPage.Name = "RewriterOutputTabPage";
-            this.RewriterOutputTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.RewriterOutputTabPage.Size = new System.Drawing.Size(737, 755);
+            this.RewriterOutputTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.RewriterOutputTabPage.Size = new System.Drawing.Size(978, 945);
             this.RewriterOutputTabPage.TabIndex = 3;
             this.RewriterOutputTabPage.Text = "RewriterOutput";
             this.RewriterOutputTabPage.UseVisualStyleBackColor = true;
+            // 
+            // RewriterOutputTextBox
+            // 
+            this.RewriterOutputTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.RewriterOutputTextBox.Location = new System.Drawing.Point(4, 4);
+            this.RewriterOutputTextBox.Margin = new System.Windows.Forms.Padding(4);
+            this.RewriterOutputTextBox.Name = "RewriterOutputTextBox";
+            this.RewriterOutputTextBox.ReadOnly = true;
+            this.RewriterOutputTextBox.Size = new System.Drawing.Size(970, 937);
+            this.RewriterOutputTextBox.TabIndex = 1;
+            this.RewriterOutputTextBox.Text = "";
+            this.RewriterOutputTextBox.WordWrap = false;
             // 
             // TopSplitContainer
             // 
             this.TopSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.TopSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.TopSplitContainer.Location = new System.Drawing.Point(0, 33);
+            this.TopSplitContainer.Location = new System.Drawing.Point(0, 42);
+            this.TopSplitContainer.Margin = new System.Windows.Forms.Padding(4);
             this.TopSplitContainer.Name = "TopSplitContainer";
             this.TopSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -794,9 +836,8 @@ namespace MainNs
             // 
             this.TopSplitContainer.Panel2.Controls.Add(this.OutputTabControl);
             this.TopSplitContainer.Panel2Collapsed = true;
-            this.TopSplitContainer.Size = new System.Drawing.Size(1176, 788);
+            this.TopSplitContainer.Size = new System.Drawing.Size(1568, 990);
             this.TopSplitContainer.SplitterDistance = 477;
-            this.TopSplitContainer.SplitterWidth = 3;
             this.TopSplitContainer.TabIndex = 3;
             // 
             // OutputTabControl
@@ -804,6 +845,7 @@ namespace MainNs
             this.OutputTabControl.Controls.Add(this.RenderLogTabPage);
             this.OutputTabControl.Dock = System.Windows.Forms.DockStyle.Fill;
             this.OutputTabControl.Location = new System.Drawing.Point(0, 0);
+            this.OutputTabControl.Margin = new System.Windows.Forms.Padding(4);
             this.OutputTabControl.Name = "OutputTabControl";
             this.OutputTabControl.SelectedIndex = 0;
             this.OutputTabControl.Size = new System.Drawing.Size(150, 46);
@@ -812,10 +854,11 @@ namespace MainNs
             // RenderLogTabPage
             // 
             this.RenderLogTabPage.Controls.Add(this.RenderLogBox);
-            this.RenderLogTabPage.Location = new System.Drawing.Point(6, 31);
+            this.RenderLogTabPage.Location = new System.Drawing.Point(8, 39);
+            this.RenderLogTabPage.Margin = new System.Windows.Forms.Padding(4);
             this.RenderLogTabPage.Name = "RenderLogTabPage";
-            this.RenderLogTabPage.Padding = new System.Windows.Forms.Padding(3);
-            this.RenderLogTabPage.Size = new System.Drawing.Size(1164, 132);
+            this.RenderLogTabPage.Padding = new System.Windows.Forms.Padding(4);
+            this.RenderLogTabPage.Size = new System.Drawing.Size(1552, 165);
             this.RenderLogTabPage.TabIndex = 0;
             this.RenderLogTabPage.Text = "Render Log";
             this.RenderLogTabPage.UseVisualStyleBackColor = true;
@@ -823,34 +866,25 @@ namespace MainNs
             // RenderLogBox
             // 
             this.RenderLogBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RenderLogBox.Location = new System.Drawing.Point(3, 3);
+            this.RenderLogBox.Location = new System.Drawing.Point(4, 4);
+            this.RenderLogBox.Margin = new System.Windows.Forms.Padding(4);
             this.RenderLogBox.Multiline = true;
             this.RenderLogBox.Name = "RenderLogBox";
             this.RenderLogBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.RenderLogBox.Size = new System.Drawing.Size(1158, 126);
+            this.RenderLogBox.Size = new System.Drawing.Size(1544, 157);
             this.RenderLogBox.TabIndex = 0;
             this.RenderLogBox.WordWrap = false;
             // 
-            // RewriterOutputTextBox
-            // 
-            this.RewriterOutputTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.RewriterOutputTextBox.Location = new System.Drawing.Point(3, 3);
-            this.RewriterOutputTextBox.Name = "RewriterOutputTextBox";
-            this.RewriterOutputTextBox.ReadOnly = true;
-            this.RewriterOutputTextBox.Size = new System.Drawing.Size(731, 749);
-            this.RewriterOutputTextBox.TabIndex = 1;
-            this.RewriterOutputTextBox.Text = "";
-            this.RewriterOutputTextBox.WordWrap = false;
-            // 
             // EditorForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1176, 843);
+            this.ClientSize = new System.Drawing.Size(1568, 1054);
             this.Controls.Add(this.TopSplitContainer);
             this.Controls.Add(this.TheStatusStrip);
             this.Controls.Add(this.TheMenuStrip);
             this.MainMenuStrip = this.TheMenuStrip;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "EditorForm";
             this.Text = "DirectX Compiler Editor";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.EditorForm_FormClosing);
@@ -961,5 +995,6 @@ namespace MainNs
         private System.Windows.Forms.ToolStripMenuItem rewriterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem rewriteNobodyToolStripMenuItem;
         private System.Windows.Forms.RichTextBox RewriterOutputTextBox;
+        private System.Windows.Forms.ToolStripMenuItem debugInformationToolStripMenuItem;
     }
 }

--- a/tools/clang/tools/dotnetc/EditorForm.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.cs
@@ -30,6 +30,7 @@ namespace MainNs
         private IDxcIndex lastIndex;
         private IDxcTranslationUnit lastTU;
         private IDxcBlob selectedShaderBlob;
+        private string selectedShaderBlobTarget;
         private bool passesLoaded = false;
         private bool docModified = false;
         private string docFileName;
@@ -63,6 +64,56 @@ namespace MainNs
         public EditorForm()
         {
             InitializeComponent();
+        }
+
+        internal IDxcBlob SelectedShaderBlob
+        {
+            get { return this.selectedShaderBlob; }
+            set
+            {
+                this.selectedShaderBlob = value;
+                this.selectedShaderBlobTarget = TryGetBlobShaderTarget(this.selectedShaderBlob);
+            }
+        }
+
+        private const uint DFCC_DXIL = 1279875140;
+        private const uint DFCC_SHDR = 1380206675;
+        private const uint DFCC_SHEX = 1480935507;
+        private const uint DFCC_ILDB = 1111772233;
+        private const uint DFCC_SPDB = 1111773267;
+
+        private string TryGetBlobShaderTarget(IDxcBlob blob)
+        {
+            if (blob == null)
+                return null;
+            uint size = blob.GetBufferSize();
+            if (size == 0) return null;
+            unsafe
+            {
+                try
+                {
+                    var reflection = HlslDxcLib.CreateDxcContainerReflection();
+                    reflection.Load(blob);
+                    uint index;
+                    int hr = reflection.FindFirstPartKind(DFCC_DXIL, out index);
+                    if (hr < 0)
+                        hr = reflection.FindFirstPartKind(DFCC_SHEX, out index);
+                    if (hr < 0)
+                        hr = reflection.FindFirstPartKind(DFCC_SHDR, out index);
+                    if (hr < 0)
+                        return null;
+                    unsafe
+                    {
+                        IDxcBlob part = reflection.GetPartContent(index);
+                        UInt32* p = (UInt32 *)part.GetBufferPointer();
+                        return DescribeProgramVersionShort(*p);
+                    }
+                }
+                catch (Exception)
+                {
+                    return null;
+                }
+            }
         }
 
         private void EditorForm_Shown(object sender, EventArgs e)
@@ -311,7 +362,7 @@ namespace MainNs
             string ext = System.IO.Path.GetExtension(this.DocFileName).ToLowerInvariant();
             if (ext == ".cso" || ext == ".fxc")
             {
-                this.selectedShaderBlob = this.Library.CreateBlobFromFile(this.DocFileName, IntPtr.Zero);
+                this.SelectedShaderBlob = this.Library.CreateBlobFromFile(this.DocFileName, IntPtr.Zero);
                 this.DocKind = DocumentKind.CompiledObject;
                 this.DisassembleSelectedShaderBlob();
             }
@@ -341,7 +392,7 @@ namespace MainNs
 
         private void exportCompiledObjectToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (this.selectedShaderBlob == null)
+            if (this.SelectedShaderBlob == null)
             {
                 MessageBox.Show(this, "There is no compiled shader blob available for exporting.");
                 return;
@@ -363,7 +414,7 @@ namespace MainNs
                 if (dialog.ShowDialog(this) != DialogResult.OK)
                     return;
 
-                System.IO.File.WriteAllBytes(dialog.FileName, GetBytesFromBlob(this.selectedShaderBlob));
+                System.IO.File.WriteAllBytes(dialog.FileName, GetBytesFromBlob(this.SelectedShaderBlob));
             }
         }
 
@@ -398,6 +449,17 @@ namespace MainNs
 
         #endregion Menu item handlers.
 
+        private static bool IsDxilTarget(string target)
+        {
+            // ps_6_0
+            // 012345
+            int major;
+            if (target != null && target.Length == 6)
+                if (Int32.TryParse(new string(target[3], 1), out major))
+                    return major >= 6;
+            return false;
+        }
+
         private void CompileDocument()
         {
             this.DisassemblyTextBox.Font = this.CodeBox.Font;
@@ -430,22 +492,55 @@ namespace MainNs
 
             if (localKind == DocumentKind.HlslText)
             {
-                var compiler = HlslDxcLib.CreateDxcCompiler();
                 var source = this.CreateBlobForText(text);
 
                 string fileName = "hlsl.hlsl";
                 HlslFileVariables fileVars = HlslFileVariables.FromText(this.CodeBox.Text);
+                bool isDxil = IsDxilTarget(fileVars.Target);
+                IDxcCompiler compiler = isDxil ? HlslDxcLib.CreateDxcCompiler() : null;
                 {
                     string[] arguments = fileVars.Arguments;
-                    var result = compiler.Compile(source, fileName, fileVars.Entry, fileVars.Target, arguments, arguments.Length, null, 0, library.CreateIncludeHandler());
-                    if (result.GetStatus() == 0)
+                    if (isDxil)
                     {
-                        this.selectedShaderBlob = result.GetResult();
-                        this.DisassembleSelectedShaderBlob();
+                        var result = compiler.Compile(source, fileName, fileVars.Entry, fileVars.Target, arguments, arguments.Length, null, 0, library.CreateIncludeHandler());
+                        if (result.GetStatus() == 0)
+                        {
+                            this.SelectedShaderBlob = result.GetResult();
+                            this.DisassembleSelectedShaderBlob();
+                        }
+                        else
+                        {
+                            this.DisassemblyTextBox.Text = GetStringFromBlob(result.GetErrors());
+                        }
                     }
                     else
                     {
-                        this.DisassemblyTextBox.Text = GetStringFromBlob(result.GetErrors());
+                        IDxcBlob code, errorMsgs;
+                        uint flags = 0;
+                        const uint D3DCOMPILE_DEBUG = 1;
+                        if (fileVars.Arguments.Contains("/Zi")) flags = D3DCOMPILE_DEBUG;
+                        int hr = D3DCompiler.D3DCompiler.D3DCompile(text, text.Length, fileName, null, 0, fileVars.Entry, fileVars.Target, flags, 0, out code, out errorMsgs);
+                        if (hr != 0)
+                        {
+                            if (errorMsgs != null)
+                            {
+                                this.DisassemblyTextBox.Text = GetStringFromBlob(errorMsgs);
+                            }
+                            else
+                            {
+                                this.DisassemblyTextBox.Text = "Compilation filed with 0x" + hr.ToString("x");
+                            }
+                            return;
+                        }
+                        IDxcBlob disassembly;
+                        unsafe
+                        {
+                            IntPtr buf = new IntPtr(code.GetBufferPointer());
+                            hr = D3DCompiler.D3DCompiler.D3DDisassemble(buf, code.GetBufferSize(),
+                                0, null, out disassembly);
+                            this.DisassemblyTextBox.Text = GetStringFromBlob(disassembly);
+                        }
+                        this.SelectedShaderBlob = code;
                     }
                 }
 
@@ -493,7 +588,7 @@ namespace MainNs
                 var result = assembler.AssembleToContainer(source);
                 if (result.GetStatus() == 0)
                 {
-                    this.selectedShaderBlob = result.GetResult();
+                    this.SelectedShaderBlob = result.GetResult();
                     this.DisassembleSelectedShaderBlob();
                     // TODO: run validation on this shader blob
                 }
@@ -615,7 +710,7 @@ namespace MainNs
             var compiler = HlslDxcLib.CreateDxcCompiler();
             try
             {
-                var dis = compiler.Disassemble(this.selectedShaderBlob);
+                var dis = compiler.Disassemble(this.SelectedShaderBlob);
                 string disassemblyText = GetStringFromBlob(dis);
 
                 RichTextBox rtb = this.DisassemblyTextBox;
@@ -2093,7 +2188,7 @@ namespace MainNs
 
         private void bitstreamToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            if (this.selectedShaderBlob == null)
+            if (this.SelectedShaderBlob == null)
             {
                 MessageBox.Show(this, "No shader blob selected. Try compiling a file.");
                 return;
@@ -2102,8 +2197,8 @@ namespace MainNs
             byte[] bytes;
             unsafe
             {
-                char* pBuffer = this.selectedShaderBlob.GetBufferPointer();
-                uint size = this.selectedShaderBlob.GetBufferSize();
+                char* pBuffer = this.SelectedShaderBlob.GetBufferPointer();
+                uint size = this.SelectedShaderBlob.GetBufferSize();
                 bytes = new byte[size];
                 IntPtr ptr = new IntPtr(pBuffer);
                 System.Runtime.InteropServices.Marshal.Copy(ptr, bytes, 0, (int)size);
@@ -2348,8 +2443,18 @@ namespace MainNs
             kind = ((programVersion & 0xffff0000) >> 16);
             major = (programVersion & 0xf0) >> 4;
             minor = (programVersion & 0xf);
-            string[] shaderKinds = "Pixel,Geometry,Hull,Domain,Compute".Split(',');
+            string[] shaderKinds = "Pixel,Vertex,Geometry,Hull,Domain,Compute".Split(',');
             return shaderKinds[kind] + " " + major + "." + minor;
+        }
+
+        private static string DescribeProgramVersionShort(UInt32 programVersion)
+        {
+            uint kind, major, minor;
+            kind = ((programVersion & 0xffff0000) >> 16);
+            major = (programVersion & 0xf0) >> 4;
+            minor = (programVersion & 0xf);
+            string[] shaderKinds = "ps,vs,gs,hs,ds,cs".Split(',');
+            return shaderKinds[kind] + "_" + major + "_" + minor;
         }
 
         private static TreeNode RangeNode(string text)
@@ -2894,6 +2999,65 @@ namespace MainNs
             RewriterOutputTextBox.Text = rewriteText;
             AnalysisTabControl.SelectTab(RewriterOutputTabPage);
         }
+
+        private void debugInformationToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (this.SelectedShaderBlob == null)
+            {
+                MessageBox.Show("Compile or load a shader to view debug information.");
+                return;
+            }
+
+            IDxcBlob debugInfoBlob;
+            dia2.IDiaDataSource dataSource;
+            uint dfcc;
+            IDxcContainerReflection r = HlslDxcLib.CreateDxcContainerReflection();
+            r.Load(this.SelectedShaderBlob);
+            if (IsDxilTarget(this.selectedShaderBlobTarget))
+            {
+                dataSource = HlslDxcLib.CreateDxcDiaDataSource();
+                dfcc = DFCC_ILDB;
+            }
+            else
+            {
+                dataSource = new dia2.DiaDataSource() as dia2.IDiaDataSource;
+                dfcc = DFCC_SPDB;
+            }
+            uint index;
+            int hr = r.FindFirstPartKind(dfcc, out index);
+            if (hr < 0)
+            {
+                MessageBox.Show("Debug information not found in container.");
+                return;
+            }
+            debugInfoBlob = r.GetPartContent(index);
+            try
+            {
+                dataSource.loadDataFromIStream(Library.CreateStreamFromBlobReadOnly(debugInfoBlob));
+                string s = dataSource.get_lastError();
+                if (!String.IsNullOrEmpty(s))
+                {
+                    MessageBox.Show("Failure to load stream: " + s);
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                HandleException(ex);
+                return;
+            }
+            var session = dataSource.openSession();
+            var tables = session.getEnumTables();
+            uint count = tables.get_Count();
+            string output = "Tables:\n";
+            for (uint i = 0; i < count; ++i)
+            {
+                var table = tables.Item(i);
+                output += table.get_name();
+                output += "\n";
+            }
+            this.DisassemblyTextBox.Text = output;
+        }
     }
 
     public static class RichTextBoxExt
@@ -2912,5 +3076,431 @@ namespace MainNs
                 rtb.AppendLine(prefix + lines[i], c);
             }
         }
+    }
+}
+
+namespace dia2
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
+
+    [ComImport]
+    [Guid("e6756135-1e65-4d17-8576-610761398c3c")]
+    class DiaDataSource
+    {
+
+    }
+
+    [ComImport]
+    [Guid("79F1BB5F-B66E-48e5-B6A9-1545C323CA3D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaDataSource
+    {
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_lastError();
+        void loadDataFromPdb(string path);
+        void loadAndValidateDataFromPdb(string path, ref Guid pcsig70, UInt32 sig, UInt32 age);
+        void loadDataForExe(string executable, string searchPath, [MarshalAs(UnmanagedType.IUnknown)] object pCallback);
+        void loadDataFromIStream(IStream pIStream);
+        IDiaSession openSession();
+        // loadDataFromCodeViewInfo
+        // loadDataFromMiscInfo
+    }
+
+    [ComImport]
+    [Guid("2F609EE1-D1C8-4E24-8288-3326BADCD211")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSession
+    {
+        UInt64 get_loadAddress();
+        void put_loadAddress(UInt64 value);
+        IDiaSymbol get_globalScope();
+        IDiaEnumTables getEnumTables();
+        void getSymbolsByAddr();
+        void findChildren();
+        void findChildrenEx();
+        void findChildrenExByAddr();
+        void findChildrenExByVA();
+        void findChildrenExByRVA();
+        void findSymbolByAddr();
+        void findSymbolByRVA();
+        void findSymbolByVA();
+        void findSymbolByToken();
+        void symsAreEquiv();
+        void symbolById();
+        void findSymbolByRVAEx();
+        void findSymbolByVAEx();
+        void findFile();
+        void findFileById();
+        void findLines();
+        void findLinesByAddr();
+        void findLinesByRVA();
+        void findLinesByVA();
+        void findLinesByLinenum();
+        object /*IDiaEnumInjectedSources*/ findInjectedSource(string srcFile);
+        object /*IDiaEnumDebugStreams*/ getEnumDebugStreams();
+        void findInlineFramesByAddr();
+        void findInlineFramesByRVA();
+        void findInlineFramesByVA();
+        void findInlineeLines();
+        void findInlineeLinesByAddr();
+        void findInlineeLinesByRVA();
+        void findInlineeLinesByVA();
+        void findInlineeLinesByLinenum();
+        void findInlineesByName();
+        void findAcceleratorInlineeLinesByLinenum();
+        void findSymbolsForAcceleratorPointerTag();
+        void findSymbolsByRVAForAcceleratorPointerTag();
+        void findAcceleratorInlineesByName();
+        void addressForVA();
+        void addressForRVA();
+        void findILOffsetsByAddr();
+        void findILOffsetsByRVA();
+        void findILOffsetsByVA();
+        void findInputAssemblyFiles();
+        void findInputAssembly();
+        void findInputAssemblyById();
+        void getFuncMDTokenMapSize();
+        void getFuncMDTokenMap();
+        void getTypeMDTokenMapSize();
+        void getTypeMDTokenMap();
+        void getNumberOfFunctionFragments_VA();
+        void getNumberOfFunctionFragments_RVA();
+        void getFunctionFragments_VA();
+        void getFunctionFragments_RVA();
+        object /*IDiaEnumSymbols*/ getExports();
+        object /*IDiaEnumSymbols*/ getHeapAllocationSites();
+        void findInputAssemblyFile();
+    }
+
+    [ComImport]
+    [Guid("cb787b2f-bd6c-4635-ba52-933126bd2dcd")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSymbol
+    {
+        UInt32 get_symIndexId();
+        UInt32 get_symTag();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_name();
+        IDiaSymbol get_lexicalParent();
+        IDiaSymbol get_classParent();
+        IDiaSymbol get_type();
+        UInt32 get_dataKind();
+        UInt32 get_locationType();
+        UInt32 get_addressSection();
+        UInt32 get_addressOffset();
+        UInt32 get_relativeVirtualAddress();
+        UInt64 get_virtualAddress();
+        UInt32 get_registerId();
+        Int32 get_offset();
+        UInt64 get_length();
+        UInt32 get_slot();
+        bool get_volatileType();
+        bool get_constType();
+        bool get_unalignedType();
+        UInt32 get_access();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_libraryName();
+        UInt32 get_platform();
+        UInt32 get_language();
+        bool get_editAndContinueEnabled();
+        UInt32 get_frontEndMajor();
+        UInt32 get_frontEndMinor();
+        UInt32 get_frontEndBuild();
+        UInt32 get_backEndMajor();
+        UInt32 get_backEndMinor();
+        UInt32 get_backEndBuild();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_sourceFileName();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_unused();
+        UInt32 get_thunkOrdinal();
+        Int32 get_thisAdjust();
+        UInt32 get_virtualBaseOffset();
+        bool get_virtual();
+        bool get_intro();
+        bool get_pure();
+        UInt32 get_callingConvention();
+        [return: MarshalAs(UnmanagedType.AsAny)] // VARIANT
+        object get_value();
+        UInt32 get_baseType();
+        UInt32 get_token();
+        UInt32 get_timeStamp();
+        Guid get_guid();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_symbolsFileName();
+        bool get_reference();
+        UInt32 get_count();
+        UInt32 get_bitPosition();
+        IDiaSymbol get_arrayIndexType();
+        bool get_packed();
+        bool get_constructor();
+        bool get_overloadedOperator();
+        bool get_nested();
+        bool get_hasNestedTypes();
+        bool get_hasAssignmentOperator();
+        bool get_hasCastOperator();
+        bool get_scoped();
+        bool get_virtualBaseClass();
+        bool get_indirectVirtualBaseClass();
+        Int32 get_virtualBasePointerOffset();
+        IDiaSymbol get_virtualTableShape();
+        UInt32 get_lexicalParentId();
+        UInt32 get_classParentId();
+        UInt32 get_typeId();
+        UInt32 get_arrayIndexTypeId();
+        UInt32 get_virtualTableShapeId();
+        bool get_code();
+        bool get_function();
+        bool get_managed();
+        bool get_msil();
+        UInt32 get_virtualBaseDispIndex();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_undecoratedName();
+        UInt32 get_age();
+        UInt32 get_signature();
+        bool get_compilerGenerated();
+        bool get_addressTaken();
+        UInt32 get_rank();
+        IDiaSymbol get_lowerBound();
+        IDiaSymbol get_upperBound();
+        UInt32 get_lowerBoundId();
+        UInt32 get_upperBoundId();
+        void get_dataBytes(UInt32 cbData, out UInt32 pcbData, out byte[] pbData);
+        void findChildren();
+        void findChildrenEx();
+        void findChildrenExByAddr();
+        void findChildrenExByVA();
+        void findChildrenExByRVA();
+        UInt32 get_targetSection();
+        UInt32 get_targetOffset();
+        UInt32 get_targetRelativeVirtualAddress();
+        UInt64 get_targetVirtualAddress();
+        UInt32 get_machineType();
+        UInt32 get_oemId();
+        UInt32 get_oemSymbolId();
+        void get_types();
+        void get_typeIds();
+        IDiaSymbol get_objectPointerType();
+        UInt32 get_udtKind();
+        void get_undecoratedNameEx();
+        bool get_noReturn();
+        bool get_customCallingConvention();
+        bool get_noInline();
+        bool get_optimizedCodeDebugInfo();
+        bool get_notReached();
+        bool get_interruptReturn();
+        bool get_farReturn();
+        bool get_isStatic();
+        bool get_hasDebugInfo();
+        bool get_isLTCG();
+        bool get_isDataAligned();
+        bool get_hasSecurityChecks();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_compilerName();
+        bool get_hasAlloca();
+        bool get_hasSetJump();
+        bool get_hasLongJump();
+        bool get_hasInlAsm();
+        bool get_hasEH();
+        bool get_hasSEH();
+        bool get_hasEHa();
+        bool get_isNaked();
+        bool get_isAggregated();
+        bool get_isSplitted();
+        IDiaSymbol get_container();
+        bool get_inlSpec();
+        bool get_noStackOrdering();
+        IDiaSymbol get_virtualBaseTableType();
+        bool get_hasManagedCode();
+        bool get_isHotpatchable();
+        bool get_isCVTCIL();
+        bool get_isMSILNetmodule();
+        bool get_isCTypes();
+        bool get_isStripped();
+        UInt32 get_frontEndQFE();
+        UInt32 get_backEndQFE();
+        bool get_wasInlined();
+        bool get_strictGSCheck();
+        bool get_isCxxReturnUdt();
+        bool get_isConstructorVirtualBase();
+        bool get_RValueReference();
+        IDiaSymbol get_unmodifiedType();
+        bool get_framePointerPresent();
+        bool get_isSafeBuffers();
+        bool get_intrinsic();
+        bool get_sealed();
+        bool get_hfaFloat();
+        bool get_hfaDouble();
+        UInt32 get_liveRangeStartAddressSection();
+        UInt32 get_liveRangeStartAddressOffset();
+        UInt32 get_liveRangeStartRelativeVirtualAddress();
+        UInt32 get_countLiveRanges();
+        UInt64 get_liveRangeLength();
+        UInt32 get_offsetInUdt();
+        UInt32 get_paramBasePointerRegisterId();
+        UInt32 get_localBasePointerRegisterId();
+        bool get_isLocationControlFlowDependent();
+        UInt32 get_stride();
+        UInt32 get_numberOfRows();
+        UInt32 get_numberOfColumns();
+        bool get_isMatrixRowMajor();
+        void get_numericProperties();
+        void get_modifierValues();
+        bool get_isReturnValue();
+        bool get_isOptimizedAway();
+        UInt32 get_builtInKind();
+        UInt32 get_registerType();
+        UInt32 get_baseDataSlot();
+        UInt32 get_baseDataOffset();
+        UInt32 get_textureSlot();
+        UInt32 get_samplerSlot();
+        UInt32 get_uavSlot();
+        UInt32 get_sizeInUdt();
+        UInt32 get_memorySpaceKind();
+        UInt32 get_unmodifiedTypeId();
+        UInt32 get_subTypeId();
+        IDiaSymbol get_subType();
+        UInt32 get_numberOfModifiers();
+        UInt32 get_numberOfRegisterIndices();
+        bool get_isHLSLData();
+        bool get_isPointerToDataMember();
+        bool get_isPointerToMemberFunction();
+        bool get_isSingleInheritance();
+        bool get_isMultipleInheritance();
+        bool get_isVirtualInheritance();
+        bool get_restrictedType();
+        bool get_isPointerBasedOnSymbolValue();
+        IDiaSymbol get_baseSymbol();
+        UInt32 get_baseSymbolId();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_objectFileName();
+        bool get_isAcceleratorGroupSharedLocal();
+        bool get_isAcceleratorPointerTagLiveRange();
+        bool get_isAcceleratorStubFunction();
+        UInt32 get_numberOfAcceleratorPointerTags();
+        bool get_isSdl();
+        bool get_isWinRTPointer();
+        bool get_isRefUdt();
+        bool get_isValueUdt();
+        bool get_isInterfaceUdt();
+        void findInlineFramesByAddr();
+        void findInlineFramesByRVA();
+        void findInlineFramesByVA();
+        void findInlineeLines();
+        void findInlineeLinesByAddr();
+        void findInlineeLinesByRVA();
+        void findInlineeLinesByVA();
+        void findSymbolsForAcceleratorPointerTag();
+        void findSymbolsByRVAForAcceleratorPointerTag();
+        void get_acceleratorPointerTags();
+        void getSrcLineOnTypeDefn();
+        bool get_isPGO();
+        bool get_hasValidPGOCounts();
+        bool get_isOptimizedForSpeed();
+        UInt32 get_PGOEntryCount();
+        UInt32 get_PGOEdgeCount();
+        UInt64 get_PGODynamicInstructionCount();
+        UInt32 get_staticSize();
+        UInt32 get_finalLiveStaticSize();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_phaseName();
+        bool get_hasControlFlowCheck();
+        bool get_constantExport();
+        bool get_dataExport();
+        bool get_privateExport();
+        bool get_noNameExport();
+        bool get_exportHasExplicitlyAssignedOrdinal();
+        bool get_exportIsForwarder();
+        UInt32 get_ordinal();
+        UInt32 get_frameSize();
+        UInt32 get_exceptionHandlerAddressSection();
+        UInt32 get_exceptionHandlerAddressOffset();
+        UInt32 get_exceptionHandlerRelativeVirtualAddress();
+        UInt64 get_exceptionHandlerVirtualAddress();
+        void findInputAssemblyFile();
+        UInt32 get_characteristics();
+        IDiaSymbol get_coffGroup();
+        UInt32 get_bindID();
+        UInt32 get_bindSpace();
+        UInt32 get_bindSlot();
+    }
+
+    [ComImport]
+    [Guid("C65C2B0A-1150-4d7a-AFCC-E05BF3DEE81E")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaEnumTables
+    {
+        void get__NewEnum();
+        UInt32 get_Count();
+        IDiaTable Item(object index);
+        UInt32 Next(UInt32 count,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Interface, SizeParamIndex = 2)]
+            ref IDiaTable[] tables, out UInt32 fetched);
+        void Skip(UInt32 count);
+        void Reset();
+        IDiaEnumTables Clone();
+    }
+
+    [ComImport]
+    [Guid("00000100-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IEnumUnknown
+    {
+        UInt32 Next(UInt32 count,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.IUnknown, SizeParamIndex = 2)]
+            ref object[] tables, out UInt32 fetched);
+        void Skip(UInt32 count);
+        void Reset();
+        IEnumUnknown Clone();
+    }
+
+    [ComImport]
+    [Guid("4A59FB77-ABAC-469b-A30B-9ECC85BFEF14")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaTable : IEnumUnknown
+    {
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        object get__NewEnum();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_name();
+        Int32 get_Count();
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        object Item(UInt32 index);
+    }
+}
+
+namespace D3DCompiler
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
+
+    public struct D3D_SHADER_MACRO
+    {
+        [MarshalAs(UnmanagedType.LPStr)] string Name;
+        [MarshalAs(UnmanagedType.LPStr)] string Definition;
+    }
+
+    internal static class D3DCompiler
+    {
+        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        public extern static Int32 D3DCompile(
+            [MarshalAs(UnmanagedType.LPStr)] string srcData, int srcDataSize,
+            [MarshalAs(UnmanagedType.LPStr)] string sourceName,
+            [MarshalAs(UnmanagedType.LPArray)] D3D_SHADER_MACRO[] defines,
+            int pInclude,
+            [MarshalAs(UnmanagedType.LPStr)] string entryPoint,
+            [MarshalAs(UnmanagedType.LPStr)] string target,
+            UInt32 Flags1,
+            UInt32 Flags2,
+            out IDxcBlob code, out IDxcBlob errorMsgs);
+
+        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
+        public extern static Int32 D3DDisassemble(
+            IntPtr ptr, uint ptrSize, uint flags,
+            [MarshalAs(UnmanagedType.LPStr)] string szComments,
+            out IDxcBlob disassembly);
     }
 }

--- a/tools/clang/tools/dotnetc/EditorForm.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.cs
@@ -43,6 +43,8 @@ namespace MainNs
         private List<DiagnosticDetail> diagnosticDetails;
         private DataGridView diagnosticDetailsGrid;
         private List<PassInfo> passInfos;
+        private TabPage debugInfoTabPage;
+        private RichTextBox debugInfoControl;
         private HlslHost hlslHost = new HlslHost();
 
         internal enum DocumentKind
@@ -510,11 +512,13 @@ namespace MainNs
                         }
                         else
                         {
+                            this.colorizationService.ClearColorization(this.DisassemblyTextBox);
                             this.DisassemblyTextBox.Text = GetStringFromBlob(result.GetErrors());
                         }
                     }
                     else
                     {
+                        this.colorizationService.ClearColorization(this.DisassemblyTextBox);
                         IDxcBlob code, errorMsgs;
                         uint flags = 0;
                         const uint D3DCOMPILE_DEBUG = 1;
@@ -688,16 +692,22 @@ namespace MainNs
         {
             private Dictionary<RichTextBox, RtbColorization> instances = new Dictionary<RichTextBox, RtbColorization>();
 
+            public void ClearColorization(RichTextBox rtb)
+            {
+                SetColorization(rtb, null);
+            }
+
             public void SetColorization(RichTextBox rtb, RtbColorization colorization)
             {
                 RtbColorization existing;
-                if (instances.TryGetValue(rtb, out existing))
+                if (instances.TryGetValue(rtb, out existing) && existing != null)
                 {
                     existing.Stop();
                 }
 
                 instances[rtb] = colorization;
-                colorization.Start();
+                if (colorization != null)
+                    colorization.Start();
             }
         }
 
@@ -3000,6 +3010,27 @@ namespace MainNs
             AnalysisTabControl.SelectTab(RewriterOutputTabPage);
         }
 
+        private IEnumerable<string> EnumerateDiaCandidates()
+        {
+            string progPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+            yield return System.IO.Path.Combine(progPath, @"Microsoft Visual Studio\2017\Community\DIA SDK\bin\amd64\msdia140.dll");
+            yield return System.IO.Path.Combine(progPath, @"Microsoft Visual Studio\2017\Community\Common7\IDE\msdia140.dll");
+            yield return System.IO.Path.Combine(progPath, @"Microsoft Visual Studio\2017\Community\Common7\IDE\msdia120.dll");
+        }
+
+        private string SuggestDiaRegistration()
+        {
+            foreach (string path in EnumerateDiaCandidates())
+            {
+                if (System.IO.File.Exists(path))
+                {
+                    return "Consider registering with this command:\r\n" +
+                        "regsvr32 \"" + path + "\"";
+                }
+            }
+            return null;
+        }
+
         private void debugInformationToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (this.SelectedShaderBlob == null)
@@ -3008,6 +3039,7 @@ namespace MainNs
                 return;
             }
 
+            this.ClearDiaUnimplementedFlags();
             IDxcBlob debugInfoBlob;
             dia2.IDiaDataSource dataSource;
             uint dfcc;
@@ -3020,7 +3052,26 @@ namespace MainNs
             }
             else
             {
-                dataSource = new dia2.DiaDataSource() as dia2.IDiaDataSource;
+                try
+                {
+                    dataSource = new dia2.DiaDataSource() as dia2.IDiaDataSource;
+                }
+                catch (System.Runtime.InteropServices.COMException ce)
+                {
+                    const int REGDB_E_CLASSNOTREG = -2147221164;
+                    if (ce.HResult == REGDB_E_CLASSNOTREG)
+                    {
+                        string suggestion = SuggestDiaRegistration();
+                        string message = "Unable to create dia object.";
+                        if (suggestion != null) message += "\r\n" + suggestion;
+                        MessageBox.Show(this, message);
+                    }
+                    else
+                    {
+                        HandleException(ce);
+                    }
+                    return;
+                }
                 dfcc = DFCC_SPDB;
             }
             uint index;
@@ -3049,14 +3100,202 @@ namespace MainNs
             var session = dataSource.openSession();
             var tables = session.getEnumTables();
             uint count = tables.get_Count();
-            string output = "Tables:\n";
+            StringBuilder output = new StringBuilder();
+            output.AppendLine("* Tables");
+            bool isFirstTable = true;
             for (uint i = 0; i < count; ++i)
             {
                 var table = tables.Item(i);
-                output += table.get_name();
-                output += "\n";
+                if (isFirstTable) isFirstTable = false; else output.AppendLine();
+                output.AppendLine("** " + table.get_name());
+                int itemCount = table.get_Count();
+                output.AppendLine("Record count: " + itemCount);
+                for (int itemIdx = 0; itemIdx < itemCount; itemIdx++)
+                {
+                    object o = table.Item((uint)itemIdx);
+                    if (TryDumpDiaObject(o as dia2.IDiaSymbol, output)) continue;
+                    if (TryDumpDiaObject(o as dia2.IDiaSourceFile, output)) continue;
+                    if (TryDumpDiaObject(o as dia2.IDiaLineNumber, output)) continue;
+                    if (TryDumpDiaObject(o as dia2.IDiaSectionContrib, output)) continue;
+                    if (TryDumpDiaObject(o as dia2.IDiaSegment, output)) continue;
+                }
             }
-            this.DisassemblyTextBox.Text = output;
+
+            if (debugInfoTabPage == null)
+            {
+                this.debugInfoTabPage = new TabPage("Debug Info");
+                this.debugInfoControl = new RichTextBox()
+                {
+                    Dock = DockStyle.Fill,
+                    Font = this.CodeBox.Font,
+                    ReadOnly = true
+                };
+                this.AnalysisTabControl.TabPages.Add(this.debugInfoTabPage);
+                this.debugInfoTabPage.Controls.Add(this.debugInfoControl);
+            }
+            this.debugInfoControl.Text = output.ToString();
+            this.AnalysisTabControl.SelectedTab = this.debugInfoTabPage;
+        }
+
+        private bool TryDumpDiaObject<TIface>(TIface o, StringBuilder sb)
+        {
+            if (o == null) return false;
+            DumpDiaObject(o, sb);
+            return true;
+        }
+
+        private void ClearDiaUnimplementedFlags()
+        {
+            foreach (var item in TypeWriters)
+                foreach (var writer in item.Value)
+                    writer.Unimplemented = false;
+        }
+
+        private void DumpDiaObject<TIface>(TIface o, StringBuilder sb)
+        {
+            Type type = typeof(TIface);
+            bool hasLine = false;
+            List<DiaTypePropertyWriter> writers;
+            if (SymTagEnumValues == null)
+            {
+                SymTagEnumValues = Enum.GetNames(typeof(dia2.SymTagEnum));
+            }
+            if (!TypeWriters.TryGetValue(type, out writers))
+            {
+                writers = new List<DiaTypePropertyWriter>();
+                foreach (System.Reflection.MethodInfo mi in type.GetMethods())
+                {
+                    Func<string, object, StringBuilder, bool> writer;
+                    if (mi.GetParameters().Length > 0)
+                        continue;
+                    string propertyName = mi.Name;
+                    if (!propertyName.StartsWith("get_")) continue;
+                    propertyName = propertyName.Substring(4);
+                    Type returnType = mi.ReturnType;
+                    if (returnType == typeof(string))
+                        writer = WriteDiaValueString;
+                    else if (returnType == typeof(uint) && propertyName == "symTag")
+                        writer = WriteDiaValueSymTag;
+                    else if (returnType == typeof(uint))
+                        writer = WriteDiaValueUInt32;
+                    else if (returnType == typeof(UInt64))
+                        writer = WriteDiaValueUInt64;
+                    else if (returnType == typeof(bool))
+                        writer = WriteDiaValueBool;
+                    else
+                        writer = WriteDiaValueAny;
+                    writers.Add(new DiaTypePropertyWriter()
+                    {
+                        MI = mi,
+                        PropertyName = propertyName,
+                        Writer = writer
+                    });
+                }
+                TypeWriters[type] = writers;
+            }
+            foreach (var writer in writers)
+            {
+                if (writer.Write(o, sb))
+                    hasLine = true;
+            }
+            if (hasLine) sb.AppendLine();
+        }
+
+        private static Dictionary<Type, List<DiaTypePropertyWriter>> TypeWriters = new Dictionary<Type, List<DiaTypePropertyWriter>>();
+        internal static string[] SymTagEnumValues;
+
+        class DiaTypePropertyWriter
+        {
+            public static object[] EmptyParams = new object[0];
+            public bool Unimplemented;
+            public System.Reflection.MethodInfo MI;
+            public string PropertyName;
+            public Func<string, object, StringBuilder, bool> Writer;
+            internal bool Write(object instance, StringBuilder sb)
+            {
+                if (Unimplemented)
+                    return false;
+                try
+                {
+                    object value = MI.Invoke(instance, EmptyParams);
+                    return Writer(PropertyName, value, sb);
+                }
+                catch (System.Reflection.TargetInvocationException tie)
+                {
+                    if (tie.InnerException is NotImplementedException)
+                    {
+                        this.Unimplemented = true;
+                    }
+                    return false;
+                }
+                catch (System.Runtime.InteropServices.COMException)
+                {
+                    return false;
+                }
+            }
+        }
+
+        private static bool WriteDiaValueAny(string propertyName, object propertyValue, StringBuilder sb)
+        {
+            if (null == propertyValue) return false;
+            if (System.Runtime.InteropServices.Marshal.IsComObject(propertyValue)) return false;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.Append(Convert.ToString(propertyValue));
+            sb.AppendLine();
+            return true;
+        }
+
+        private static bool WriteDiaValueSymTag(string propertyName, object propertyValueObj, StringBuilder sb)
+        {
+            uint tag = (uint)propertyValueObj;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.AppendLine(SymTagEnumValues[tag]);
+            return true;
+        }
+
+        private static bool WriteDiaValueBool(string propertyName, object propertyValueObj, StringBuilder sb)
+        {
+            bool propertyValue = (bool)propertyValueObj;
+            if (false == propertyValue) return false;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.Append(propertyValue);
+            sb.AppendLine();
+            return true;
+        }
+
+        private static bool WriteDiaValueUInt32(string propertyName, object propertyValueObj, StringBuilder sb)
+        {
+            uint propertyValue = (uint)propertyValueObj;
+            if (0 == propertyValue) return false;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.Append(propertyValue);
+            sb.AppendLine();
+            return true;
+        }
+
+        private static bool WriteDiaValueUInt64(string propertyName, object propertyValueObj, StringBuilder sb)
+        {
+            UInt64 propertyValue = (UInt64)propertyValueObj;
+            if (0 == propertyValue) return false;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.Append(propertyValue);
+            sb.AppendLine();
+            return true;
+        }
+
+        private static bool WriteDiaValueString(string propertyName, object propertyValueObj, StringBuilder sb)
+        {
+            string propertyValue = (string)propertyValueObj;
+            if (String.IsNullOrEmpty(propertyValue)) return false;
+            sb.Append(propertyName);
+            sb.Append(": ");
+            sb.AppendLine(propertyValue);
+            return true;
         }
     }
 
@@ -3076,431 +3315,5 @@ namespace MainNs
                 rtb.AppendLine(prefix + lines[i], c);
             }
         }
-    }
-}
-
-namespace dia2
-{
-    using System;
-    using System.Runtime.InteropServices;
-    using System.Runtime.InteropServices.ComTypes;
-
-    [ComImport]
-    [Guid("e6756135-1e65-4d17-8576-610761398c3c")]
-    class DiaDataSource
-    {
-
-    }
-
-    [ComImport]
-    [Guid("79F1BB5F-B66E-48e5-B6A9-1545C323CA3D")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IDiaDataSource
-    {
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_lastError();
-        void loadDataFromPdb(string path);
-        void loadAndValidateDataFromPdb(string path, ref Guid pcsig70, UInt32 sig, UInt32 age);
-        void loadDataForExe(string executable, string searchPath, [MarshalAs(UnmanagedType.IUnknown)] object pCallback);
-        void loadDataFromIStream(IStream pIStream);
-        IDiaSession openSession();
-        // loadDataFromCodeViewInfo
-        // loadDataFromMiscInfo
-    }
-
-    [ComImport]
-    [Guid("2F609EE1-D1C8-4E24-8288-3326BADCD211")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IDiaSession
-    {
-        UInt64 get_loadAddress();
-        void put_loadAddress(UInt64 value);
-        IDiaSymbol get_globalScope();
-        IDiaEnumTables getEnumTables();
-        void getSymbolsByAddr();
-        void findChildren();
-        void findChildrenEx();
-        void findChildrenExByAddr();
-        void findChildrenExByVA();
-        void findChildrenExByRVA();
-        void findSymbolByAddr();
-        void findSymbolByRVA();
-        void findSymbolByVA();
-        void findSymbolByToken();
-        void symsAreEquiv();
-        void symbolById();
-        void findSymbolByRVAEx();
-        void findSymbolByVAEx();
-        void findFile();
-        void findFileById();
-        void findLines();
-        void findLinesByAddr();
-        void findLinesByRVA();
-        void findLinesByVA();
-        void findLinesByLinenum();
-        object /*IDiaEnumInjectedSources*/ findInjectedSource(string srcFile);
-        object /*IDiaEnumDebugStreams*/ getEnumDebugStreams();
-        void findInlineFramesByAddr();
-        void findInlineFramesByRVA();
-        void findInlineFramesByVA();
-        void findInlineeLines();
-        void findInlineeLinesByAddr();
-        void findInlineeLinesByRVA();
-        void findInlineeLinesByVA();
-        void findInlineeLinesByLinenum();
-        void findInlineesByName();
-        void findAcceleratorInlineeLinesByLinenum();
-        void findSymbolsForAcceleratorPointerTag();
-        void findSymbolsByRVAForAcceleratorPointerTag();
-        void findAcceleratorInlineesByName();
-        void addressForVA();
-        void addressForRVA();
-        void findILOffsetsByAddr();
-        void findILOffsetsByRVA();
-        void findILOffsetsByVA();
-        void findInputAssemblyFiles();
-        void findInputAssembly();
-        void findInputAssemblyById();
-        void getFuncMDTokenMapSize();
-        void getFuncMDTokenMap();
-        void getTypeMDTokenMapSize();
-        void getTypeMDTokenMap();
-        void getNumberOfFunctionFragments_VA();
-        void getNumberOfFunctionFragments_RVA();
-        void getFunctionFragments_VA();
-        void getFunctionFragments_RVA();
-        object /*IDiaEnumSymbols*/ getExports();
-        object /*IDiaEnumSymbols*/ getHeapAllocationSites();
-        void findInputAssemblyFile();
-    }
-
-    [ComImport]
-    [Guid("cb787b2f-bd6c-4635-ba52-933126bd2dcd")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IDiaSymbol
-    {
-        UInt32 get_symIndexId();
-        UInt32 get_symTag();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_name();
-        IDiaSymbol get_lexicalParent();
-        IDiaSymbol get_classParent();
-        IDiaSymbol get_type();
-        UInt32 get_dataKind();
-        UInt32 get_locationType();
-        UInt32 get_addressSection();
-        UInt32 get_addressOffset();
-        UInt32 get_relativeVirtualAddress();
-        UInt64 get_virtualAddress();
-        UInt32 get_registerId();
-        Int32 get_offset();
-        UInt64 get_length();
-        UInt32 get_slot();
-        bool get_volatileType();
-        bool get_constType();
-        bool get_unalignedType();
-        UInt32 get_access();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_libraryName();
-        UInt32 get_platform();
-        UInt32 get_language();
-        bool get_editAndContinueEnabled();
-        UInt32 get_frontEndMajor();
-        UInt32 get_frontEndMinor();
-        UInt32 get_frontEndBuild();
-        UInt32 get_backEndMajor();
-        UInt32 get_backEndMinor();
-        UInt32 get_backEndBuild();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_sourceFileName();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_unused();
-        UInt32 get_thunkOrdinal();
-        Int32 get_thisAdjust();
-        UInt32 get_virtualBaseOffset();
-        bool get_virtual();
-        bool get_intro();
-        bool get_pure();
-        UInt32 get_callingConvention();
-        [return: MarshalAs(UnmanagedType.AsAny)] // VARIANT
-        object get_value();
-        UInt32 get_baseType();
-        UInt32 get_token();
-        UInt32 get_timeStamp();
-        Guid get_guid();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_symbolsFileName();
-        bool get_reference();
-        UInt32 get_count();
-        UInt32 get_bitPosition();
-        IDiaSymbol get_arrayIndexType();
-        bool get_packed();
-        bool get_constructor();
-        bool get_overloadedOperator();
-        bool get_nested();
-        bool get_hasNestedTypes();
-        bool get_hasAssignmentOperator();
-        bool get_hasCastOperator();
-        bool get_scoped();
-        bool get_virtualBaseClass();
-        bool get_indirectVirtualBaseClass();
-        Int32 get_virtualBasePointerOffset();
-        IDiaSymbol get_virtualTableShape();
-        UInt32 get_lexicalParentId();
-        UInt32 get_classParentId();
-        UInt32 get_typeId();
-        UInt32 get_arrayIndexTypeId();
-        UInt32 get_virtualTableShapeId();
-        bool get_code();
-        bool get_function();
-        bool get_managed();
-        bool get_msil();
-        UInt32 get_virtualBaseDispIndex();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_undecoratedName();
-        UInt32 get_age();
-        UInt32 get_signature();
-        bool get_compilerGenerated();
-        bool get_addressTaken();
-        UInt32 get_rank();
-        IDiaSymbol get_lowerBound();
-        IDiaSymbol get_upperBound();
-        UInt32 get_lowerBoundId();
-        UInt32 get_upperBoundId();
-        void get_dataBytes(UInt32 cbData, out UInt32 pcbData, out byte[] pbData);
-        void findChildren();
-        void findChildrenEx();
-        void findChildrenExByAddr();
-        void findChildrenExByVA();
-        void findChildrenExByRVA();
-        UInt32 get_targetSection();
-        UInt32 get_targetOffset();
-        UInt32 get_targetRelativeVirtualAddress();
-        UInt64 get_targetVirtualAddress();
-        UInt32 get_machineType();
-        UInt32 get_oemId();
-        UInt32 get_oemSymbolId();
-        void get_types();
-        void get_typeIds();
-        IDiaSymbol get_objectPointerType();
-        UInt32 get_udtKind();
-        void get_undecoratedNameEx();
-        bool get_noReturn();
-        bool get_customCallingConvention();
-        bool get_noInline();
-        bool get_optimizedCodeDebugInfo();
-        bool get_notReached();
-        bool get_interruptReturn();
-        bool get_farReturn();
-        bool get_isStatic();
-        bool get_hasDebugInfo();
-        bool get_isLTCG();
-        bool get_isDataAligned();
-        bool get_hasSecurityChecks();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_compilerName();
-        bool get_hasAlloca();
-        bool get_hasSetJump();
-        bool get_hasLongJump();
-        bool get_hasInlAsm();
-        bool get_hasEH();
-        bool get_hasSEH();
-        bool get_hasEHa();
-        bool get_isNaked();
-        bool get_isAggregated();
-        bool get_isSplitted();
-        IDiaSymbol get_container();
-        bool get_inlSpec();
-        bool get_noStackOrdering();
-        IDiaSymbol get_virtualBaseTableType();
-        bool get_hasManagedCode();
-        bool get_isHotpatchable();
-        bool get_isCVTCIL();
-        bool get_isMSILNetmodule();
-        bool get_isCTypes();
-        bool get_isStripped();
-        UInt32 get_frontEndQFE();
-        UInt32 get_backEndQFE();
-        bool get_wasInlined();
-        bool get_strictGSCheck();
-        bool get_isCxxReturnUdt();
-        bool get_isConstructorVirtualBase();
-        bool get_RValueReference();
-        IDiaSymbol get_unmodifiedType();
-        bool get_framePointerPresent();
-        bool get_isSafeBuffers();
-        bool get_intrinsic();
-        bool get_sealed();
-        bool get_hfaFloat();
-        bool get_hfaDouble();
-        UInt32 get_liveRangeStartAddressSection();
-        UInt32 get_liveRangeStartAddressOffset();
-        UInt32 get_liveRangeStartRelativeVirtualAddress();
-        UInt32 get_countLiveRanges();
-        UInt64 get_liveRangeLength();
-        UInt32 get_offsetInUdt();
-        UInt32 get_paramBasePointerRegisterId();
-        UInt32 get_localBasePointerRegisterId();
-        bool get_isLocationControlFlowDependent();
-        UInt32 get_stride();
-        UInt32 get_numberOfRows();
-        UInt32 get_numberOfColumns();
-        bool get_isMatrixRowMajor();
-        void get_numericProperties();
-        void get_modifierValues();
-        bool get_isReturnValue();
-        bool get_isOptimizedAway();
-        UInt32 get_builtInKind();
-        UInt32 get_registerType();
-        UInt32 get_baseDataSlot();
-        UInt32 get_baseDataOffset();
-        UInt32 get_textureSlot();
-        UInt32 get_samplerSlot();
-        UInt32 get_uavSlot();
-        UInt32 get_sizeInUdt();
-        UInt32 get_memorySpaceKind();
-        UInt32 get_unmodifiedTypeId();
-        UInt32 get_subTypeId();
-        IDiaSymbol get_subType();
-        UInt32 get_numberOfModifiers();
-        UInt32 get_numberOfRegisterIndices();
-        bool get_isHLSLData();
-        bool get_isPointerToDataMember();
-        bool get_isPointerToMemberFunction();
-        bool get_isSingleInheritance();
-        bool get_isMultipleInheritance();
-        bool get_isVirtualInheritance();
-        bool get_restrictedType();
-        bool get_isPointerBasedOnSymbolValue();
-        IDiaSymbol get_baseSymbol();
-        UInt32 get_baseSymbolId();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_objectFileName();
-        bool get_isAcceleratorGroupSharedLocal();
-        bool get_isAcceleratorPointerTagLiveRange();
-        bool get_isAcceleratorStubFunction();
-        UInt32 get_numberOfAcceleratorPointerTags();
-        bool get_isSdl();
-        bool get_isWinRTPointer();
-        bool get_isRefUdt();
-        bool get_isValueUdt();
-        bool get_isInterfaceUdt();
-        void findInlineFramesByAddr();
-        void findInlineFramesByRVA();
-        void findInlineFramesByVA();
-        void findInlineeLines();
-        void findInlineeLinesByAddr();
-        void findInlineeLinesByRVA();
-        void findInlineeLinesByVA();
-        void findSymbolsForAcceleratorPointerTag();
-        void findSymbolsByRVAForAcceleratorPointerTag();
-        void get_acceleratorPointerTags();
-        void getSrcLineOnTypeDefn();
-        bool get_isPGO();
-        bool get_hasValidPGOCounts();
-        bool get_isOptimizedForSpeed();
-        UInt32 get_PGOEntryCount();
-        UInt32 get_PGOEdgeCount();
-        UInt64 get_PGODynamicInstructionCount();
-        UInt32 get_staticSize();
-        UInt32 get_finalLiveStaticSize();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_phaseName();
-        bool get_hasControlFlowCheck();
-        bool get_constantExport();
-        bool get_dataExport();
-        bool get_privateExport();
-        bool get_noNameExport();
-        bool get_exportHasExplicitlyAssignedOrdinal();
-        bool get_exportIsForwarder();
-        UInt32 get_ordinal();
-        UInt32 get_frameSize();
-        UInt32 get_exceptionHandlerAddressSection();
-        UInt32 get_exceptionHandlerAddressOffset();
-        UInt32 get_exceptionHandlerRelativeVirtualAddress();
-        UInt64 get_exceptionHandlerVirtualAddress();
-        void findInputAssemblyFile();
-        UInt32 get_characteristics();
-        IDiaSymbol get_coffGroup();
-        UInt32 get_bindID();
-        UInt32 get_bindSpace();
-        UInt32 get_bindSlot();
-    }
-
-    [ComImport]
-    [Guid("C65C2B0A-1150-4d7a-AFCC-E05BF3DEE81E")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IDiaEnumTables
-    {
-        void get__NewEnum();
-        UInt32 get_Count();
-        IDiaTable Item(object index);
-        UInt32 Next(UInt32 count,
-            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Interface, SizeParamIndex = 2)]
-            ref IDiaTable[] tables, out UInt32 fetched);
-        void Skip(UInt32 count);
-        void Reset();
-        IDiaEnumTables Clone();
-    }
-
-    [ComImport]
-    [Guid("00000100-0000-0000-C000-000000000046")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IEnumUnknown
-    {
-        UInt32 Next(UInt32 count,
-            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.IUnknown, SizeParamIndex = 2)]
-            ref object[] tables, out UInt32 fetched);
-        void Skip(UInt32 count);
-        void Reset();
-        IEnumUnknown Clone();
-    }
-
-    [ComImport]
-    [Guid("4A59FB77-ABAC-469b-A30B-9ECC85BFEF14")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    interface IDiaTable : IEnumUnknown
-    {
-        [return: MarshalAs(UnmanagedType.IUnknown)]
-        object get__NewEnum();
-        [return: MarshalAs(UnmanagedType.BStr)]
-        string get_name();
-        Int32 get_Count();
-        [return: MarshalAs(UnmanagedType.IUnknown)]
-        object Item(UInt32 index);
-    }
-}
-
-namespace D3DCompiler
-{
-    using System;
-    using System.Runtime.InteropServices;
-    using System.Runtime.InteropServices.ComTypes;
-
-    public struct D3D_SHADER_MACRO
-    {
-        [MarshalAs(UnmanagedType.LPStr)] string Name;
-        [MarshalAs(UnmanagedType.LPStr)] string Definition;
-    }
-
-    internal static class D3DCompiler
-    {
-        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
-        public extern static Int32 D3DCompile(
-            [MarshalAs(UnmanagedType.LPStr)] string srcData, int srcDataSize,
-            [MarshalAs(UnmanagedType.LPStr)] string sourceName,
-            [MarshalAs(UnmanagedType.LPArray)] D3D_SHADER_MACRO[] defines,
-            int pInclude,
-            [MarshalAs(UnmanagedType.LPStr)] string entryPoint,
-            [MarshalAs(UnmanagedType.LPStr)] string target,
-            UInt32 Flags1,
-            UInt32 Flags2,
-            out IDxcBlob code, out IDxcBlob errorMsgs);
-
-        [DllImport("d3dcompiler_47.dll", CallingConvention = CallingConvention.Winapi, SetLastError = false, CharSet = CharSet.Ansi, ExactSpelling = true)]
-        public extern static Int32 D3DDisassemble(
-            IntPtr ptr, uint ptrSize, uint flags,
-            [MarshalAs(UnmanagedType.LPStr)] string szComments,
-            out IDxcBlob disassembly);
     }
 }

--- a/tools/clang/tools/dotnetc/dia2.cs
+++ b/tools/clang/tools/dotnetc/dia2.cs
@@ -1,0 +1,533 @@
+﻿///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// dia2.cs                                                                   //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+namespace dia2
+{
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Runtime.InteropServices.ComTypes;
+
+    [ComImport]
+    [Guid("e6756135-1e65-4d17-8576-610761398c3c")]
+    class DiaDataSource
+    {
+
+    }
+
+    [ComImport]
+    [Guid("79F1BB5F-B66E-48e5-B6A9-1545C323CA3D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaDataSource
+    {
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_lastError();
+        void loadDataFromPdb(string path);
+        void loadAndValidateDataFromPdb(string path, ref Guid pcsig70, UInt32 sig, UInt32 age);
+        void loadDataForExe(string executable, string searchPath, [MarshalAs(UnmanagedType.IUnknown)] object pCallback);
+        void loadDataFromIStream(IStream pIStream);
+        IDiaSession openSession();
+        // loadDataFromCodeViewInfo
+        // loadDataFromMiscInfo
+    }
+
+    [ComImport]
+    [Guid("2F609EE1-D1C8-4E24-8288-3326BADCD211")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSession
+    {
+        UInt64 get_loadAddress();
+        void put_loadAddress(UInt64 value);
+        IDiaSymbol get_globalScope();
+        IDiaEnumTables getEnumTables();
+        void getSymbolsByAddr();
+        void findChildren();
+        void findChildrenEx();
+        void findChildrenExByAddr();
+        void findChildrenExByVA();
+        void findChildrenExByRVA();
+        void findSymbolByAddr();
+        void findSymbolByRVA();
+        void findSymbolByVA();
+        void findSymbolByToken();
+        void symsAreEquiv();
+        void symbolById();
+        void findSymbolByRVAEx();
+        void findSymbolByVAEx();
+        void findFile();
+        void findFileById();
+        void findLines();
+        void findLinesByAddr();
+        void findLinesByRVA();
+        void findLinesByVA();
+        void findLinesByLinenum();
+        object /*IDiaEnumInjectedSources*/ findInjectedSource(string srcFile);
+        object /*IDiaEnumDebugStreams*/ getEnumDebugStreams();
+        void findInlineFramesByAddr();
+        void findInlineFramesByRVA();
+        void findInlineFramesByVA();
+        void findInlineeLines();
+        void findInlineeLinesByAddr();
+        void findInlineeLinesByRVA();
+        void findInlineeLinesByVA();
+        void findInlineeLinesByLinenum();
+        void findInlineesByName();
+        void findAcceleratorInlineeLinesByLinenum();
+        void findSymbolsForAcceleratorPointerTag();
+        void findSymbolsByRVAForAcceleratorPointerTag();
+        void findAcceleratorInlineesByName();
+        void addressForVA();
+        void addressForRVA();
+        void findILOffsetsByAddr();
+        void findILOffsetsByRVA();
+        void findILOffsetsByVA();
+        void findInputAssemblyFiles();
+        void findInputAssembly();
+        void findInputAssemblyById();
+        void getFuncMDTokenMapSize();
+        void getFuncMDTokenMap();
+        void getTypeMDTokenMapSize();
+        void getTypeMDTokenMap();
+        void getNumberOfFunctionFragments_VA();
+        void getNumberOfFunctionFragments_RVA();
+        void getFunctionFragments_VA();
+        void getFunctionFragments_RVA();
+        object /*IDiaEnumSymbols*/ getExports();
+        object /*IDiaEnumSymbols*/ getHeapAllocationSites();
+        void findInputAssemblyFile();
+    }
+
+    [ComImport]
+    [Guid("cb787b2f-bd6c-4635-ba52-933126bd2dcd")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSymbol
+    {
+        UInt32 get_symIndexId();
+        UInt32 get_symTag();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_name();
+        IDiaSymbol get_lexicalParent();
+        IDiaSymbol get_classParent();
+        IDiaSymbol get_type();
+        UInt32 get_dataKind();
+        UInt32 get_locationType();
+        UInt32 get_addressSection();
+        UInt32 get_addressOffset();
+        UInt32 get_relativeVirtualAddress();
+        UInt64 get_virtualAddress();
+        UInt32 get_registerId();
+        Int32 get_offset();
+        UInt64 get_length();
+        UInt32 get_slot();
+        bool get_volatileType();
+        bool get_constType();
+        bool get_unalignedType();
+        UInt32 get_access();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_libraryName();
+        UInt32 get_platform();
+        UInt32 get_language();
+        bool get_editAndContinueEnabled();
+        UInt32 get_frontEndMajor();
+        UInt32 get_frontEndMinor();
+        UInt32 get_frontEndBuild();
+        UInt32 get_backEndMajor();
+        UInt32 get_backEndMinor();
+        UInt32 get_backEndBuild();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_sourceFileName();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_unused();
+        UInt32 get_thunkOrdinal();
+        Int32 get_thisAdjust();
+        UInt32 get_virtualBaseOffset();
+        bool get_virtual();
+        bool get_intro();
+        bool get_pure();
+        UInt32 get_callingConvention();
+        [return: MarshalAs(UnmanagedType.AsAny)] // VARIANT
+        object get_value();
+        UInt32 get_baseType();
+        UInt32 get_token();
+        UInt32 get_timeStamp();
+        Guid get_guid();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_symbolsFileName();
+        bool get_reference();
+        UInt32 get_count();
+        UInt32 get_bitPosition();
+        IDiaSymbol get_arrayIndexType();
+        bool get_packed();
+        bool get_constructor();
+        bool get_overloadedOperator();
+        bool get_nested();
+        bool get_hasNestedTypes();
+        bool get_hasAssignmentOperator();
+        bool get_hasCastOperator();
+        bool get_scoped();
+        bool get_virtualBaseClass();
+        bool get_indirectVirtualBaseClass();
+        Int32 get_virtualBasePointerOffset();
+        IDiaSymbol get_virtualTableShape();
+        UInt32 get_lexicalParentId();
+        UInt32 get_classParentId();
+        UInt32 get_typeId();
+        UInt32 get_arrayIndexTypeId();
+        UInt32 get_virtualTableShapeId();
+        bool get_code();
+        bool get_function();
+        bool get_managed();
+        bool get_msil();
+        UInt32 get_virtualBaseDispIndex();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_undecoratedName();
+        UInt32 get_age();
+        UInt32 get_signature();
+        bool get_compilerGenerated();
+        bool get_addressTaken();
+        UInt32 get_rank();
+        IDiaSymbol get_lowerBound();
+        IDiaSymbol get_upperBound();
+        UInt32 get_lowerBoundId();
+        UInt32 get_upperBoundId();
+        void get_dataBytes(UInt32 cbData, out UInt32 pcbData, out byte[] pbData);
+        void findChildren();
+        void findChildrenEx();
+        void findChildrenExByAddr();
+        void findChildrenExByVA();
+        void findChildrenExByRVA();
+        UInt32 get_targetSection();
+        UInt32 get_targetOffset();
+        UInt32 get_targetRelativeVirtualAddress();
+        UInt64 get_targetVirtualAddress();
+        UInt32 get_machineType();
+        UInt32 get_oemId();
+        UInt32 get_oemSymbolId();
+        void get_types();
+        void get_typeIds();
+        IDiaSymbol get_objectPointerType();
+        UInt32 get_udtKind();
+        void get_undecoratedNameEx();
+        bool get_noReturn();
+        bool get_customCallingConvention();
+        bool get_noInline();
+        bool get_optimizedCodeDebugInfo();
+        bool get_notReached();
+        bool get_interruptReturn();
+        bool get_farReturn();
+        bool get_isStatic();
+        bool get_hasDebugInfo();
+        bool get_isLTCG();
+        bool get_isDataAligned();
+        bool get_hasSecurityChecks();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_compilerName();
+        bool get_hasAlloca();
+        bool get_hasSetJump();
+        bool get_hasLongJump();
+        bool get_hasInlAsm();
+        bool get_hasEH();
+        bool get_hasSEH();
+        bool get_hasEHa();
+        bool get_isNaked();
+        bool get_isAggregated();
+        bool get_isSplitted();
+        IDiaSymbol get_container();
+        bool get_inlSpec();
+        bool get_noStackOrdering();
+        IDiaSymbol get_virtualBaseTableType();
+        bool get_hasManagedCode();
+        bool get_isHotpatchable();
+        bool get_isCVTCIL();
+        bool get_isMSILNetmodule();
+        bool get_isCTypes();
+        bool get_isStripped();
+        UInt32 get_frontEndQFE();
+        UInt32 get_backEndQFE();
+        bool get_wasInlined();
+        bool get_strictGSCheck();
+        bool get_isCxxReturnUdt();
+        bool get_isConstructorVirtualBase();
+        bool get_RValueReference();
+        IDiaSymbol get_unmodifiedType();
+        bool get_framePointerPresent();
+        bool get_isSafeBuffers();
+        bool get_intrinsic();
+        bool get_sealed();
+        bool get_hfaFloat();
+        bool get_hfaDouble();
+        UInt32 get_liveRangeStartAddressSection();
+        UInt32 get_liveRangeStartAddressOffset();
+        UInt32 get_liveRangeStartRelativeVirtualAddress();
+        UInt32 get_countLiveRanges();
+        UInt64 get_liveRangeLength();
+        UInt32 get_offsetInUdt();
+        UInt32 get_paramBasePointerRegisterId();
+        UInt32 get_localBasePointerRegisterId();
+        bool get_isLocationControlFlowDependent();
+        UInt32 get_stride();
+        UInt32 get_numberOfRows();
+        UInt32 get_numberOfColumns();
+        bool get_isMatrixRowMajor();
+        void get_numericProperties();
+        void get_modifierValues();
+        bool get_isReturnValue();
+        bool get_isOptimizedAway();
+        UInt32 get_builtInKind();
+        UInt32 get_registerType();
+        UInt32 get_baseDataSlot();
+        UInt32 get_baseDataOffset();
+        UInt32 get_textureSlot();
+        UInt32 get_samplerSlot();
+        UInt32 get_uavSlot();
+        UInt32 get_sizeInUdt();
+        UInt32 get_memorySpaceKind();
+        UInt32 get_unmodifiedTypeId();
+        UInt32 get_subTypeId();
+        IDiaSymbol get_subType();
+        UInt32 get_numberOfModifiers();
+        UInt32 get_numberOfRegisterIndices();
+        bool get_isHLSLData();
+        bool get_isPointerToDataMember();
+        bool get_isPointerToMemberFunction();
+        bool get_isSingleInheritance();
+        bool get_isMultipleInheritance();
+        bool get_isVirtualInheritance();
+        bool get_restrictedType();
+        bool get_isPointerBasedOnSymbolValue();
+        IDiaSymbol get_baseSymbol();
+        UInt32 get_baseSymbolId();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_objectFileName();
+        bool get_isAcceleratorGroupSharedLocal();
+        bool get_isAcceleratorPointerTagLiveRange();
+        bool get_isAcceleratorStubFunction();
+        UInt32 get_numberOfAcceleratorPointerTags();
+        bool get_isSdl();
+        bool get_isWinRTPointer();
+        bool get_isRefUdt();
+        bool get_isValueUdt();
+        bool get_isInterfaceUdt();
+        void findInlineFramesByAddr();
+        void findInlineFramesByRVA();
+        void findInlineFramesByVA();
+        void findInlineeLines();
+        void findInlineeLinesByAddr();
+        void findInlineeLinesByRVA();
+        void findInlineeLinesByVA();
+        void findSymbolsForAcceleratorPointerTag();
+        void findSymbolsByRVAForAcceleratorPointerTag();
+        void get_acceleratorPointerTags();
+        void getSrcLineOnTypeDefn();
+        bool get_isPGO();
+        bool get_hasValidPGOCounts();
+        bool get_isOptimizedForSpeed();
+        UInt32 get_PGOEntryCount();
+        UInt32 get_PGOEdgeCount();
+        UInt64 get_PGODynamicInstructionCount();
+        UInt32 get_staticSize();
+        UInt32 get_finalLiveStaticSize();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_phaseName();
+        bool get_hasControlFlowCheck();
+        bool get_constantExport();
+        bool get_dataExport();
+        bool get_privateExport();
+        bool get_noNameExport();
+        bool get_exportHasExplicitlyAssignedOrdinal();
+        bool get_exportIsForwarder();
+        UInt32 get_ordinal();
+        UInt32 get_frameSize();
+        UInt32 get_exceptionHandlerAddressSection();
+        UInt32 get_exceptionHandlerAddressOffset();
+        UInt32 get_exceptionHandlerRelativeVirtualAddress();
+        UInt64 get_exceptionHandlerVirtualAddress();
+        void findInputAssemblyFile();
+        UInt32 get_characteristics();
+        IDiaSymbol get_coffGroup();
+        UInt32 get_bindID();
+        UInt32 get_bindSpace();
+        UInt32 get_bindSlot();
+    }
+
+    [ComImport]
+    [Guid("C65C2B0A-1150-4d7a-AFCC-E05BF3DEE81E")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaEnumTables
+    {
+        void get__NewEnum();
+        UInt32 get_Count();
+        IDiaTable Item(object index);
+        UInt32 Next(UInt32 count,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.Interface, SizeParamIndex = 2)]
+            ref IDiaTable[] tables, out UInt32 fetched);
+        void Skip(UInt32 count);
+        void Reset();
+        IDiaEnumTables Clone();
+    }
+
+    [ComImport]
+    [Guid("B388EB14-BE4D-421d-A8A1-6CF7AB057086")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaLineNumber
+    {
+        IDiaSymbol get_compiland();
+        IDiaSourceFile get_sourceFile();
+        uint get_lineNumber();
+        uint get_lineNumberEnd();
+        uint get_columnNumber();
+        uint get_columnNumberEnd();
+        uint get_addressSection();
+        uint get_addressOffset();
+        uint get_relativeVirtualAddress();
+        UInt64 get_virtualAddress();
+        uint get_length();
+        uint get_sourceFileId();
+        bool get_statement();
+        uint get_compilandId();
+    }
+
+    [ComImport]
+    [Guid("0CF4B60E-35B1-4c6c-BDD8-854B9C8E3857")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSectionContrib
+    {
+        IDiaSymbol get_compiland();
+        uint get_addressSection();
+        uint get_addressOffset();
+        uint get_relativeVirtualAddress();
+        UInt64 get_virtualAddress();
+        uint get_length();
+        bool get_notPaged();
+        bool get_code();
+        bool get_initializedData();
+        bool get_uninitializedData();
+        bool get_remove();
+        bool get_comdat();
+        bool get_discardable();
+        bool get_notCached();
+        bool get_share();
+        bool get_execute();
+        bool get_read();
+        bool get_write();
+        uint get_dataCrc();
+        uint get_relocationsCrc();
+        uint get_compilandId();
+        bool get_code16bit();
+    }
+
+    [ComImport]
+    [Guid("0775B784-C75B-4449-848B-B7BD3159545B")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSegment
+    {
+        uint get_frame();
+        uint get_offset();
+        uint get_length();
+        bool get_read();
+        bool get_write();
+        bool get_execute();
+        uint get_addressSection();
+        uint get_relativeVirtualAddress();
+        UInt64 get_virtualAddress();
+    }
+
+    [ComImport]
+    [Guid("00000100-0000-0000-C000-000000000046")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IEnumUnknown
+    {
+        UInt32 Next(UInt32 count,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.IUnknown, SizeParamIndex = 2)]
+            ref object[] tables, out UInt32 fetched);
+        void Skip(UInt32 count);
+        void Reset();
+        IEnumUnknown Clone();
+    }
+
+    [ComImport]
+    [Guid("A2EF5353-F5A8-4eb3-90D2-CB526ACB3CDD")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaSourceFile
+    {
+        uint get_uniqueId();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_fileName();
+        void /* IDiaEnumSymbols */ get_compilands();
+        [PreserveSig] int get_checksum(uint cbData, out uint pcbData,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeParamIndex = 1)] ref byte[] pbData);
+    }
+
+    [ComImport]
+    [Guid("4A59FB77-ABAC-469b-A30B-9ECC85BFEF14")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    interface IDiaTable // : IEnumUnknown - need to replay vtable
+    {
+        UInt32 Next(UInt32 count,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.IUnknown, SizeParamIndex = 2)]
+            ref object[] tables, out UInt32 fetched);
+        void Skip(UInt32 count);
+        void Reset();
+        IEnumUnknown Clone();
+
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        object get__NewEnum();
+        [return: MarshalAs(UnmanagedType.BStr)]
+        string get_name();
+        Int32 get_Count();
+        [return: MarshalAs(UnmanagedType.IUnknown)]
+        object Item(UInt32 index);
+    }
+
+    enum SymTagEnum
+    {
+        SymTagNull,
+        SymTagExe,
+        SymTagCompiland,
+        SymTagCompilandDetails,
+        SymTagCompilandEnv,
+        SymTagFunction,
+        SymTagBlock,
+        SymTagData,
+        SymTagAnnotation,
+        SymTagLabel,
+        SymTagPublicSymbol,
+        SymTagUDT,
+        SymTagEnum,
+        SymTagFunctionType,
+        SymTagPointerType,
+        SymTagArrayType,
+        SymTagBaseType,
+        SymTagTypedef,
+        SymTagBaseClass,
+        SymTagFriend,
+        SymTagFunctionArgType,
+        SymTagFuncDebugStart,
+        SymTagFuncDebugEnd,
+        SymTagUsingNamespace,
+        SymTagVTableShape,
+        SymTagVTable,
+        SymTagCustom,
+        SymTagThunk,
+        SymTagCustomType,
+        SymTagManagedType,
+        SymTagDimension,
+        SymTagCallSite,
+        SymTagInlineSite,
+        SymTagBaseInterface,
+        SymTagVectorType,
+        SymTagMatrixType,
+        SymTagHLSLType,
+        SymTagCaller,
+        SymTagCallee,
+        SymTagExport,
+        SymTagHeapAllocationSite,
+        SymTagCoffGroup,
+        SymTagMax
+    };
+}

--- a/tools/clang/tools/dotnetc/dndxc.csproj.txt
+++ b/tools/clang/tools/dotnetc/dndxc.csproj.txt
@@ -54,6 +54,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="${DOS_STYLE_SOURCE_DIR}\AsmColorizer.cs" />
+    <Compile Include="${DOS_STYLE_SOURCE_DIR}\D3DCompiler.cs" />
+    <Compile Include="${DOS_STYLE_SOURCE_DIR}\dia2.cs" />
     <Compile Include="${DOS_STYLE_SOURCE_DIR}\DotNetDxc.cs" />
     <Compile Include="${DOS_STYLE_SOURCE_DIR}\BinaryViewControl.cs">
       <SubType>Component</SubType>

--- a/tools/clang/tools/dxcompiler/dxcdia.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdia.cpp
@@ -1964,13 +1964,13 @@ HRESULT CreateDxcDiaTable(DxcDiaSession *pSession, DiaTableKind kind, IDiaTable 
 class DxcDiaDataSource : public IDiaDataSource {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
-    std::shared_ptr<llvm::Module> m_module;
+  std::shared_ptr<llvm::Module> m_module;
   std::shared_ptr<llvm::LLVMContext> m_context;
   std::shared_ptr<llvm::DebugInfoFinder> m_finder;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
 
-    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
     return DoBasicQueryInterface<IDiaDataSource>(this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/dxcompiler/dxcdia.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdia.cpp
@@ -34,6 +34,7 @@
 #include "dxc/Support/dxcapi.impl.h"
 #include <algorithm>
 #include <comdef.h>
+#include "dxcutil.h"
 
 using namespace llvm;
 using namespace clang;
@@ -1998,13 +1999,14 @@ public:
       m_context = std::make_shared<LLVMContext>();
       std::unique_ptr<MemoryBuffer> pBuffer =
           getMemBufferFromStream(pIStream, "data");
-      ErrorOr<std::unique_ptr<llvm::Module>> module =
-          parseBitcodeFile(pBuffer->getMemBufferRef(), *m_context.get());
-      if (!module)
+      std::string DiagStr;
+      std::unique_ptr<llvm::Module> pModule = dxcutil::LoadModuleFromBitcode(
+          pBuffer.get(), *m_context.get(), DiagStr);
+      if (!pModule.get())
         return E_FAIL;
       m_finder = std::make_shared<DebugInfoFinder>();
-      m_finder->processModule(*module.get().get());
-      m_module.reset(module.get().release());
+      m_finder->processModule(*pModule.get());
+      m_module.reset(pModule.release());
     }
     CATCH_CPP_RETURN_HRESULT();
     return S_OK;

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -20,8 +20,11 @@ class DiagnosticsEngine;
 }
 
 namespace llvm {
+class LLVMContext;
+class MemoryBuffer;
 class Module;
 class raw_string_ostream;
+class StringRef;
 class Twine;
 } // namespace llvm
 
@@ -51,5 +54,12 @@ void CreateOperationResultFromOutputs(
     _COM_Outptr_ IDxcOperationResult **ppResult);
 
 bool IsAbsoluteOrCurDirRelative(const llvm::Twine &T);
+
+std::unique_ptr<llvm::Module> LoadModuleFromBitcode(llvm::StringRef BC,
+                                                    llvm::LLVMContext &Ctx,
+                                                    std::string &DiagStr);
+std::unique_ptr<llvm::Module> LoadModuleFromBitcode(llvm::MemoryBuffer *MB,
+                                                    llvm::LLVMContext &Ctx,
+                                                    std::string &DiagStr);
 
 } // namespace dxcutil

--- a/tools/clang/unittests/HLSL/DxcTestUtils.h
+++ b/tools/clang/unittests/HLSL/DxcTestUtils.h
@@ -111,6 +111,12 @@ void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf16ToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf16ToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlobEncoding **ppBlob);
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+                     LPWSTR pTargetProfile, LPCWSTR pArgs,
+                     _Outptr_ IDxcBlob **ppResult);
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+                     LPWSTR pTargetProfile, std::vector<LPCWSTR> &args,
+                     _Outptr_ IDxcBlob **ppResult);
 
 class VersionSupportInfo {
 private:


### PR DESCRIPTION
Fixes failure when bitcode cannot be parsed by the dxc dia data source.
Adds support for ILDB parts to dia (saves the need to skip header in clients).
Adds support to dndxc to dump debug information.
Adds support to dndxc to compile and disassemble d3dcompiler-based shaders.
