### PR TITLE
Bug fixes.

### DIFF
--- a/include/dxc/Support/WinIncludes.h
+++ b/include/dxc/Support/WinIncludes.h
@@ -34,6 +34,11 @@
 #include <intsafe.h>
 #include <ObjIdl.h>
 
+// Support older atlbase.h if needed
+#ifndef _ATL_DECLSPEC_ALLOCATOR
+#define _ATL_DECLSPEC_ALLOCATOR
+#endif
+
 /// Swap two ComPtr classes.
 template <class T> void swap(CComHeapPtr<T> &a, CComHeapPtr<T> &b) {
   T *c(a.m_pData);

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -2229,6 +2229,8 @@ static void SplitCpy(Type *Ty, Value *Dest, Value *Src,
     }
     DxilStructAnnotation *STA = typeSys.GetStructAnnotation(ST);
     DXASSERT(STA, "require annotation here");
+    if (STA->IsEmptyStruct())
+      return;
     for (uint32_t i = 0; i < ST->getNumElements(); i++) {
       llvm::Type *ET = ST->getElementType(i);
 
@@ -5445,10 +5447,10 @@ void SROA_Parameter_HLSL::preprocessArgUsedInCall(Function *F) {
       if (inputQual == DxilParamInputQual::Out ||
           inputQual == DxilParamInputQual::Inout) {
         for (ReturnInst *RI : retList) {
-          IRBuilder<> Builder(RI);
+          IRBuilder<> RetBuilder(RI);
           // copy tmp to arg.
           CallInst *tmpToArg =
-              AllocaBuilder.CreateMemCpy(&arg, TmpArg, size, 0);
+              RetBuilder.CreateMemCpy(&arg, TmpArg, size, 0);
           // Split the memcpy.
           MemcpySplitter::SplitMemCpy(cast<MemCpyInst>(tmpToArg), DL, nullptr,
                                       typeSys);

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_empty_struct_arg.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_empty_struct_arg.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T lib_6_1 %s | FileCheck %s
+
+// Make sure empty struct arg works.
+// CHECK: call void @"\01?test@@YAMUT@@@Z"(float* nonnull %{{.*}})
+
+struct T {
+};
+
+float test(T t);
+
+float test2(T t): SV_Target {
+  return test(t);
+}

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_ret_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_ret_struct.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T lib_6_1 %s | FileCheck %s
+
+// Make sure struct param used as out arg works.
+
+// CHECK: call void @"\01?getT@@YA?AUT@@XZ"
+// CHECK: store
+// CHECK: store
+
+struct T {
+  float a;
+  int   b;
+};
+
+T getT();
+
+T getT2() {
+  return getT();
+}


### PR DESCRIPTION
1. Support empty struct as call arg.
2. Define _ATL_DECLSPEC_ALLOCATOR for older atlbase.h
3. Fix typo in SROA_Parameter_HLSL::preprocessArgUsedInCall for use AllocaBuilder when need RetBuilder.