### PR TITLE
[spirv] Translate operator[] for vector and matrix types

### DIFF
--- a/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
+++ b/tools/clang/lib/SPIRV/EmitSPIRVAction.cpp
@@ -2213,7 +2213,138 @@ public:
     return 0;
   }
 
+  /// Returns true if the given CXXOperatorCallExpr is indexing into a vector or
+  /// matrix using operator[].
+  /// On success, writes the base vector/matrix into *base, and the indices into
+  /// *index0 and *index1, if there are two levels of indexing. If there is only
+  /// one level of indexing, writes the index into *index0 and nullptr into
+  /// *index1.
+  /// Assumes base, index0, and index1 are not nullptr.
+  bool isVecMatIndexing(const CXXOperatorCallExpr *vecIndexExpr,
+                        const Expr **base, const Expr **index0,
+                        const Expr **index1) {
+    // matrix [index0] [index1]         vector [index0]
+    // +--------------+
+    //  vector                     or
+    // +----------------------+         +-------------+
+    //         scalar                        scalar
+
+    // Must be operator[]
+    if (vecIndexExpr->getOperator() != OverloadedOperatorKind::OO_Subscript)
+      return false;
+
+    // Get the base of this outer operator[]
+    const Expr *vecBase = vecIndexExpr->getArg(0);
+    // If the base of the outer operator[] is a vector, try to see if we have
+    // another inner operator[] on a matrix, i.e., two levels of indexing into
+    // the matrix.
+    if (hlsl::IsHLSLVecType(vecBase->getType())) {
+      const auto *matIndexExpr = dyn_cast<CXXOperatorCallExpr>(vecBase);
+
+      if (!matIndexExpr) {
+        // No inner operator[]. So this is just indexing into a vector.
+        *base = vecBase;
+        *index0 = vecIndexExpr->getArg(1);
+        *index1 = nullptr;
+
+        return true;
+      }
+
+      // Must be operator[]
+      if (matIndexExpr->getOperator() != OverloadedOperatorKind::OO_Subscript)
+        return false;
+
+      // Get the base of this inner operator[]
+      const Expr *matBase = matIndexExpr->getArg(0);
+      if (!hlsl::IsHLSLMatType(matBase->getType()))
+        return false;
+
+      *base = matBase;
+      *index0 = matIndexExpr->getArg(1);
+      *index1 = vecIndexExpr->getArg(1);
+
+      return true;
+    }
+
+    // The base of the outside operator[] is not a vector. Try to see whether it
+    // is a matrix. If true, it means we have only one level of indexing.
+    if (hlsl::IsHLSLMatType(vecBase->getType())) {
+      *base = vecBase;
+      *index0 = vecIndexExpr->getArg(1);
+      *index1 = nullptr;
+
+      return true;
+    }
+
+    return false;
+  }
+
+  uint32_t doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr) {
+    { // First try to handle vector/matrix indexing
+      const Expr *baseExpr = nullptr;
+      const Expr *index0Expr = nullptr;
+      const Expr *index1Expr = nullptr;
+
+      if (isVecMatIndexing(expr, &baseExpr, &index0Expr, &index1Expr)) {
+        const auto baseType = baseExpr->getType();
+        llvm::SmallVector<uint32_t, 2> indices;
+
+        if (hlsl::IsHLSLMatType(baseType)) {
+          uint32_t rowCount = 0, colCount = 0;
+          hlsl::GetHLSLMatRowColCount(baseType, rowCount, colCount);
+
+          // Collect indices for this matrix indexing
+          if (rowCount > 1) {
+            indices.push_back(doExpr(index0Expr));
+          }
+          // Evalute index1Expr iff it is not nullptr
+          if (colCount > 1 && index1Expr) {
+            indices.push_back(doExpr(index1Expr));
+          }
+        } else { // Indexing into vector
+          if (hlsl::GetHLSLVecSize(baseType) > 1) {
+            indices.push_back(doExpr(index0Expr));
+          }
+        }
+
+        if (indices.size() == 0) {
+          return doExpr(baseExpr);
+        }
+
+        uint32_t base = doExpr(baseExpr);
+        // If we are indexing into a rvalue, to use OpAccessChain, we first need
+        // to create a local variable to hold the rvalue.
+        //
+        // TODO: We can optimize the codegen by emitting OpCompositeExtract if
+        // all indices are contant integers.
+        if (!baseExpr->isGLValue()) {
+          const uint32_t compositeType = typeTranslator.translateType(baseType);
+          const uint32_t ptrType = theBuilder.getPointerType(
+              compositeType, spv::StorageClass::Function);
+          const uint32_t tempVar =
+              theBuilder.addFnVariable(ptrType, "temp.var");
+          theBuilder.createStore(tempVar, base);
+          base = tempVar;
+        }
+
+        const uint32_t elemType = typeTranslator.translateType(expr->getType());
+        // TODO: select storage type based on the underlying variable
+        const uint32_t ptrType =
+            theBuilder.getPointerType(elemType, spv::StorageClass::Function);
+
+        return theBuilder.createAccessChain(ptrType, base, indices);
+      }
+    }
+
+    emitError("unimplemented C++ operator call: %0") << expr->getOperator();
+    expr->dump();
+    return 0;
+  }
+
   uint32_t doCallExpr(const CallExpr *callExpr) {
+    if (const auto *operatorCall = dyn_cast<CXXOperatorCallExpr>(callExpr))
+      return doCXXOperatorCallExpr(operatorCall);
+
     const FunctionDecl *callee = callExpr->getDirectCallee();
 
     // Intrinsic functions such as 'dot' or 'mul'

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -14,6 +14,11 @@ namespace clang {
 namespace spirv {
 
 uint32_t TypeTranslator::translateType(QualType type) {
+  // Try to translate the canonical type first
+  const auto canonicalType = type.getCanonicalType();
+  if (canonicalType != type)
+    return translateType(canonicalType);
+
   const auto *typePtr = type.getTypePtr();
 
   // Primitive types

--- a/tools/clang/test/CodeGenSPIRV/op.matrix.access.1x1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.matrix.access.1x1.hlsl
@@ -6,7 +6,9 @@ void main() {
     float1x1 mat;
     float3 vec3;
     float2 vec2;
+    float1 vec1;
     float scalar;
+    uint index;
 
     // 1 element (from lvalue)
 // CHECK:      [[load0:%\d+]] = OpLoad %float %mat
@@ -27,4 +29,30 @@ void main() {
     //   invalid format for vector swizzle
     // scalar = (mat + mat)._m00;
     // vec2 = (mat * mat)._11_11;
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load9:%\d+]] = OpLoad %float %mat
+// CHECK-NEXT: OpStore %vec1 [[load9]]
+    vec1 = mat[0]; // Used as rvalue
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load10:%\d+]] = OpLoad %float %vec1
+// CHECK-NEXT: OpStore %mat [[load10]]
+    mat[index] = vec1; // Used as lvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[load11:%\d+]] = OpLoad %float %mat
+// CHECK-NEXT: OpStore %scalar [[load11]]
+    scalar = mat[index][0]; // Used as rvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[load12:%\d+]] = OpLoad %float %scalar
+// CHECK-NEXT: OpStore %mat [[load12]]
+    mat[0][index] = scalar; // Used as lvalue
+
+    // One/two level indexing (from rvalue)
+    // The following statements will trigger errors:
+    //   subscripted value is not an array, matrix, or vector
+    // vec1 = (mat + mat)[0];
+    // scalar = (mat * mat)[0][index];
 }

--- a/tools/clang/test/CodeGenSPIRV/op.matrix.access.1xn.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.matrix.access.1xn.hlsl
@@ -7,6 +7,7 @@ void main() {
     float3 vec3;
     float2 vec2;
     float scalar;
+    uint index;
 
     // 1 element (from lvalue)
 // CHECK:      [[access0:%\d+]] = OpAccessChain %_ptr_Function_float %mat %int_2
@@ -41,4 +42,39 @@ void main() {
     //   invalid format for vector swizzle
     // scalar = (mat + mat)._m02;
     // vec2 = (mat * mat)._11_12;
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load9:%\d+]] = OpLoad %v3float %mat
+// CHECK-NEXT: OpStore %vec3 [[load9]]
+    vec3 = mat[0]; // Used as rvalue
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load10:%\d+]] = OpLoad %v3float %vec3
+// CHECK-NEXT: OpStore %mat [[load10]]
+    mat[index] = vec3; // Used as lvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[access9:%\d+]] = OpAccessChain %_ptr_Function_float %mat %uint_1
+// CHECK-NEXT: [[load11:%\d+]] = OpLoad %float [[access9]]
+// CHECK-NEXT: OpStore %scalar [[load11]]
+    scalar = mat[index][1]; // Used as rvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[load12:%\d+]] = OpLoad %float %scalar
+// CHECK-NEXT: [[index0:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access10:%\d+]] = OpAccessChain %_ptr_Function_float %mat [[index0]]
+// CHECK-NEXT: OpStore [[access10]] [[load12]]
+    mat[0][index] = scalar; // Used as lvalue
+
+    // On level indexing (from rvalue)
+    // For the following case:
+    // vec3 = (mat + mat)[0];
+    // The AST for operator[] is actually accessing into a vector. Both mat will
+    // be implicitly casted (HLSLMatrixToVectorCast) to vector before doing
+    // operator+. So the whole rhs is actually a vector splatting.
+
+    // Two level indexing (from rvalue)
+    // The following statements will trigger errors:
+    //   subscripted value is not an array, matrix, or vector
+    // scalar = (mat * mat)[0][index];
 }

--- a/tools/clang/test/CodeGenSPIRV/op.matrix.access.mx1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.matrix.access.mx1.hlsl
@@ -6,7 +6,9 @@ void main() {
     float3x1 mat;
     float3 vec3;
     float2 vec2;
+    float1 vec1;
     float scalar;
+    uint index;
 
     // 1 element (from lvalue)
 // CHECK:      [[access0:%\d+]] = OpAccessChain %_ptr_Function_float %mat %int_2
@@ -58,4 +60,51 @@ void main() {
     // Codegen: construct a temporary vector first out of (mat * mat) and
     // then extract the value
     vec2 = (mat * mat)._11_21;
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[index0:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access7:%\d+]] = OpAccessChain %_ptr_Function_float %mat [[index0]]
+// CHECK-NEXT: [[load9:%\d+]] = OpLoad %float [[access7]]
+// CHECK-NEXT: OpStore %vec1 [[load9]]
+    vec1 = mat[index]; // Used as rvalue
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load10:%\d+]] = OpLoad %float %vec1
+// CHECK-NEXT: [[access8:%\d+]] = OpAccessChain %_ptr_Function_float %mat %uint_0
+// CHECK-NEXT: OpStore [[access8]] [[load10]]
+    mat[0] = vec1; // Used as lvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[access9:%\d+]] = OpAccessChain %_ptr_Function_float %mat %uint_1
+// CHECK-NEXT: [[load11:%\d+]] = OpLoad %float [[access9]]
+// CHECK-NEXT: OpStore %scalar [[load11]]
+    scalar = mat[1][index]; // Used as rvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[load12:%\d+]] = OpLoad %float %scalar
+// CHECK-NEXT: [[index1:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access10:%\d+]] = OpAccessChain %_ptr_Function_float %mat [[index1]]
+// CHECK-NEXT: OpStore [[access10]] [[load12]]
+    mat[index][0] = scalar; // Used as lvalue
+
+    // On level indexing (from rvalue)
+// CHECK-NEXT: [[load13:%\d+]] = OpLoad %v3float %mat
+// CHECK-NEXT: [[load14:%\d+]] = OpLoad %v3float %mat
+// CHECK-NEXT: [[add:%\d+]] = OpFAdd %v3float [[load13]] [[load14]]
+// CHECK-NEXT: OpStore %temp_var [[add]]
+// CHECK-NEXT: [[access11:%\d+]] = OpAccessChain %_ptr_Function_float %temp_var %uint_0
+// CHECK-NEXT: [[load15:%\d+]] = OpLoad %float [[access11]]
+// CHECK-NEXT: OpStore %vec1 [[load15]]
+    vec1 = (mat + mat)[0];
+
+    // Two level indexing (from rvalue)
+// CHECK-NEXT: [[index2:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[load16:%\d+]] = OpLoad %v3float %mat
+// CHECK-NEXT: [[load17:%\d+]] = OpLoad %v3float %mat
+// CHECK-NEXT: [[mul:%\d+]] = OpFMul %v3float [[load16]] [[load17]]
+// CHECK-NEXT: OpStore %temp_var_0 [[mul]]
+// CHECK-NEXT: [[access12:%\d+]] = OpAccessChain %_ptr_Function_float %temp_var_0 [[index2]]
+// CHECK-NEXT: [[load18:%\d+]] = OpLoad %float [[access12]]
+// CHECK-NEXT: OpStore %scalar [[load18]]
+    scalar = (mat * mat)[index][0];
 }

--- a/tools/clang/test/CodeGenSPIRV/op.matrix.access.mxn.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.matrix.access.mxn.hlsl
@@ -7,6 +7,7 @@ void main() {
     float3 vec3;
     float2 vec2;
     float scalar;
+    uint index;
 
     // 1 element (from lvalue)
 // CHECK:      [[access0:%\d+]] = OpAccessChain %_ptr_Function_float %mat %int_1 %int_2
@@ -55,4 +56,48 @@ void main() {
     // Codegen: construct a temporary matrix first out of (mat * mat) and
     // then extract the value
     vec2 = (mat * mat)._m01_m02;
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[access7:%\d+]] = OpAccessChain %_ptr_Function_v3float %mat %uint_1
+// CHECK-NEXT: [[load4:%\d+]] = OpLoad %v3float [[access7]]
+// CHECK-NEXT: OpStore %vec3 [[load4]]
+    vec3 = mat[1]; // Used as rvalue
+
+    // One level indexing (from lvalue)
+// CHECK-NEXT: [[load5:%\d+]] = OpLoad %v3float %vec3
+// CHECK-NEXT: [[index0:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access8:%\d+]] = OpAccessChain %_ptr_Function_v3float %mat [[index0]]
+// CHECK-NEXT: OpStore [[access8]] [[load5]]
+    mat[index] = vec3; // Used as lvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[index1:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access9:%\d+]] = OpAccessChain %_ptr_Function_float %mat [[index1]] %uint_2
+// CHECK-NEXT: [[load6:%\d+]] = OpLoad %float [[access9]]
+// CHECK-NEXT: OpStore %scalar [[load6]]
+    scalar = mat[index][2]; // Used as rvalue
+
+    // Two level indexing (from lvalue)
+// CHECK-NEXT: [[load7:%\d+]] = OpLoad %float %scalar
+// CHECK-NEXT: [[index2:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access10:%\d+]] = OpAccessChain %_ptr_Function_float %mat %uint_1 [[index2]]
+// CHECK-NEXT: OpStore [[access10]] [[load7]]
+    mat[1][index] = scalar; // Used as lvalue
+
+    // One level indexing (from rvalue)
+// CHECK:      [[cc4:%\d+]] = OpCompositeConstruct %mat2v3float {{%\d+}} {{%\d+}}
+// CHECK-NEXT: OpStore %temp_var [[cc4]]
+// CHECK-NEXT: [[access11:%\d+]] = OpAccessChain %_ptr_Function_v3float %temp_var %uint_0
+// CHECK-NEXT: [[load8:%\d+]] = OpLoad %v3float [[access11]]
+// CHECK-NEXT: OpStore %vec3 [[load8]]
+    vec3 = (mat + mat)[0];
+
+    // Two level indexing (from rvalue)
+// CHECK-NEXT: [[index3:%\d+]] = OpLoad %uint %index
+// CHECK:      [[cc5:%\d+]] = OpCompositeConstruct %mat2v3float {{%\d+}} {{%\d+}}
+// CHECK-NEXT: OpStore %temp_var_0 [[cc5]]
+// CHECK-NEXT: [[access12:%\d+]] = OpAccessChain %_ptr_Function_float %temp_var_0 %uint_0 [[index3]]
+// CHECK-NEXT: [[load9:%\d+]] = OpLoad %float [[access12]]
+// CHECK-NEXT: OpStore %scalar [[load9]]
+    scalar = (mat + mat)[0][index];
 }

--- a/tools/clang/test/CodeGenSPIRV/op.vector.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.access.hlsl
@@ -1,0 +1,69 @@
+// Run: %dxc -T vs_6_0 -E main
+
+void main() {
+// CHECK-LABEL: %bb_entry = OpLabel
+    float4 a;
+    float1 b;
+    float s;
+    uint index;
+
+    // Vector with more than one elements
+// CHECK:      [[access0:%\d+]] = OpAccessChain %_ptr_Function_float %a %uint_0
+// CHECK-NEXT: [[a0:%\d+]] = OpLoad %float [[access0]]
+// CHECK-NEXT: OpStore %s [[a0]]
+    s = a[0];
+// CHECK-NEXT: [[s0:%\d+]] = OpLoad %float %s
+// CHECK-NEXT: [[access1:%\d+]] = OpAccessChain %_ptr_Function_float %a %uint_2
+// CHECK-NEXT:       OpStore [[access1]] [[s0]]
+    a[2] = s;
+
+// CHECK-NEXT: [[index0:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access2:%\d+]] = OpAccessChain %_ptr_Function_float %a [[index0]]
+// CHECK-NEXT: [[a1:%\d+]] = OpLoad %float [[access2]]
+// CHECK-NEXT: OpStore %s [[a1]]
+    s = a[index];
+// CHECK-NEXT: [[s1:%\d+]] = OpLoad %float %s
+// CHECK-NEXT: [[index1:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[access3:%\d+]] = OpAccessChain %_ptr_Function_float %a [[index1]]
+// CHECK-NEXT: OpStore [[access3]] [[s1]]
+    a[index] = s;
+
+    // Vector with one elements
+// CHECK-NEXT: [[b0:%\d+]] = OpLoad %float %b
+// CHECK-NEXT: OpStore %s [[b0]]
+    s = b[0];
+// CHECK-NEXT: [[s2:%\d+]] = OpLoad %float %s
+// CHECK-NEXT: OpStore %b [[s2]]
+    b[0] = s;
+
+// CHECK-NEXT: [[b1:%\d+]] = OpLoad %float %b
+// CHECK-NEXT: OpStore %s [[b1]]
+    s = b[index];
+// CHECK-NEXT: [[s3:%\d+]] = OpLoad %float %s
+// CHECK-NEXT: OpStore %b [[s3]]
+    b[index] = s;
+
+    // From rvalue
+// CHECK-NEXT: [[a2:%\d+]] = OpLoad %v4float %a
+// CHECK-NEXT: [[a3:%\d+]] = OpLoad %v4float %a
+// CHECK-NEXT: [[add:%\d+]] = OpFAdd %v4float [[a2]] [[a3]]
+// CHECK-NEXT: OpStore %temp_var [[add]]
+// CHECK-NEXT: [[access4:%\d+]] = OpAccessChain %_ptr_Function_float %temp_var %uint_0
+// CHECK-NEXT: [[s4:%\d+]] = OpLoad %float [[access4]]
+// CHECK-NEXT: OpStore %s [[s4]]
+    s = (a + a)[0];
+// CHECK-NEXT: [[index2:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[a4:%\d+]] = OpLoad %v4float %a
+// CHECK-NEXT: [[a5:%\d+]] = OpLoad %v4float %a
+// CHECK-NEXT: [[mul:%\d+]] = OpFMul %v4float [[a4]] [[a5]]
+// CHECK-NEXT: OpStore %temp_var_0 [[mul]]
+// CHECK-NEXT: [[access5:%\d+]] = OpAccessChain %_ptr_Function_float %temp_var_0 [[index2]]
+// CHECK-NEXT: [[s5:%\d+]] = OpLoad %float [[access5]]
+// CHECK-NEXT: OpStore %s [[s5]]
+    s = (a * a)[index];
+
+    // The following will trigger frontend errors:
+    //   subscripted value is not an array, matrix, or vector
+    //s = (b + b)[0];
+    //s = (b * b)[index];
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -147,13 +147,14 @@ TEST_F(FileTest, TernaryOpConditionalOp) {
   runFileTest("ternary-op.cond-op.hlsl");
 }
 
-// For vector swizzle operators
+// For vector accessing/swizzling operators
 TEST_F(FileTest, OpVectorSwizzle) { runFileTest("op.vector.swizzle.hlsl"); }
 TEST_F(FileTest, OpVectorSize1Swizzle) {
   runFileTest("op.vector.swizzle.size1.hlsl");
 }
+TEST_F(FileTest, OpVectorAccess) { runFileTest("op.vector.access.hlsl"); }
 
-// For matrix accessing operators
+// For matrix accessing/swizzling operators
 TEST_F(FileTest, OpMatrixAccessMxN) {
   runFileTest("op.matrix.access.mxn.hlsl");
 }


### PR DESCRIPTION
A temporary variable will be created if we are indexing into
a rvalue vector/matrix. This is because we can have variables
as indices, which mandates the use of OpAccessChain. And
OpAccessChain requires a variable that can be loaded or stored.