### PR TITLE
Allow const evaluating vector initializer lists in the frontend

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/cast.vector.splat.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.vector.splat.hlsl
@@ -6,9 +6,10 @@ void main() {
 // CHECK-LABEL: %bb_entry = OpLabel
 
     // From constant
-// CHECK: OpStore %vf4 [[v4f32c]]
+// CHECK: %vf4 = OpVariable %_ptr_Function_v4float Function [[v4f32c]]
     float4 vf4 = 1;
-// CHECK-NEXT: [[v3f32c:%\d+]] = OpCompositeConstruct %v3float %float_2 %float_2 %float_2
+
+// CHECK: [[v3f32c:%\d+]] = OpCompositeConstruct %v3float %float_2 %float_2 %float_2
 // CHECK-NEXT: OpStore %vf3 [[v3f32c]]
     float3 vf3;
     vf3 = float1(2);

--- a/tools/clang/test/CodeGenSPIRV/var.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.hlsl
@@ -16,20 +16,11 @@
 float4 main(float component: COLOR) : SV_TARGET {
 // CHECK-LABEL: %bb_entry = OpLabel
 
-// CHECK-NEXT: %a = OpVariable %_ptr_Function_int Function %int_0
-// CHECK-NEXT: %b = OpVariable %_ptr_Function_int Function
-
-// CHECK-NEXT: %i = OpVariable %_ptr_Function_float Function %float_3
-// CHECK-NEXT: %j = OpVariable %_ptr_Function_float Function
-
-// CHECK-NEXT: %m = OpVariable %_ptr_Function_v4float Function
-// CHECK-NEXT: %n = OpVariable %_ptr_Function_v4float Function
-// CHECK-NEXT: %o = OpVariable %_ptr_Function_v4float Function
-
-// CHECK-NEXT: %p = OpVariable %_ptr_Function_v2int Function [[int2constant]]
-// CHECK-NEXT: %q = OpVariable %_ptr_Function_v3int Function
-
-// CHECK-NEXT: %x = OpVariable %_ptr_Function_uint Function
+// CHECK: %a = OpVariable %_ptr_Function_int Function %int_0
+// CHECK: %i = OpVariable %_ptr_Function_float Function %float_3
+// CHECK: %m = OpVariable %_ptr_Function_v4float Function [[float4constant]]
+// CHECK: %p = OpVariable %_ptr_Function_v2int Function [[int2constant]]
+// CHECK: %x = OpVariable %_ptr_Function_uint Function %uint_1
 
 // Initializer already attached to the var definition
     int a = 0; // From constant
@@ -43,9 +34,8 @@ float4 main(float component: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpStore %j [[component0]]
     float j = component; // From stage variable
 
-// CHECK-NEXT: OpStore %m [[float4constant]]
     float4 m = float4(1.0, 2.0, 3.0, 4.0);  // All components are constants
-// CHECK-NEXT: [[j0:%\d+]] = OpLoad %float %j
+// CHECK: [[j0:%\d+]] = OpLoad %float %j
 // CHECK-NEXT: [[j1:%\d+]] = OpLoad %float %j
 // CHECK-NEXT: [[j2:%\d+]] = OpLoad %float %j
 // CHECK-NEXT: [[j3:%\d+]] = OpLoad %float %j
@@ -65,7 +55,6 @@ float4 main(float component: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpStore %q [[qinit]]
     int3 q = {4, b, a}; // Mixed cases
 
-// CHECK-NEXT: OpStore %x %uint_1
     uint1 x = uint1(1); // Special case: vector of size 1
 
     return o;


### PR DESCRIPTION
Initializer lists in HLSL are very flexible; the front end right
now doesn't handle their const evaluation to the full. This change
only turns on a specific case: intializing vectors.