### PR TITLE
Fix out of bounds memory write in GetResourceBindingDescByName

### DIFF
--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1885,7 +1885,6 @@ _Use_decl_annotations_
 HRESULT DxilShaderReflection::GetResourceBindingDescByName(LPCSTR Name,
   D3D12_SHADER_INPUT_BIND_DESC *pDesc) {
   IFRBOOL(Name != nullptr, E_INVALIDARG);
-  IFR(ZeroMemoryToOut(pDesc));
 
   for (UINT i = 0; i < m_Resources.size(); i++) {
     if (strcmp(m_Resources[i].Name, Name) == 0) {


### PR DESCRIPTION
If reflection version is not D3D12, ZeroMemoryToOut will overwrite
memory outside of the user's pDesc struct, leading to stack or
heap corruption.  I removed ZeroMemoryToOut, since the right amount
of data should be written in each case.