### PR TITLE
[spirv] Converted to generate wrapper for entry function

### DIFF
--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_SPIRV_MODULEBUILDER_H
 
 #include <memory>
+#include <string>
 
 #include "clang/SPIRV/InstBuilder.h"
 #include "clang/SPIRV/SPIRVContext.h"
@@ -216,7 +217,8 @@ public:
   ///
   /// The corresponding pointer type of the given type will be constructed in
   /// this method for the variable itself.
-  uint32_t addStageIOVar(uint32_t type, spv::StorageClass storageClass);
+  uint32_t addStageIOVar(uint32_t type, spv::StorageClass storageClass,
+                         std::string name);
 
   /// \brief Adds a stage builtin variable whose value is of the given type.
   ///

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -327,11 +327,13 @@ uint32_t ModuleBuilder::getGLSLExtInstSet() {
 }
 
 uint32_t ModuleBuilder::addStageIOVar(uint32_t type,
-                                      spv::StorageClass storageClass) {
+                                      spv::StorageClass storageClass,
+                                      std::string name) {
   const uint32_t pointerType = getPointerType(type, storageClass);
   const uint32_t varId = theContext.takeNextId();
   instBuilder.opVariable(pointerType, varId, storageClass, llvm::None).x();
   theModule.addVariable(std::move(constructSite));
+  theModule.addDebugName(varId, name);
   return varId;
 }
 

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -310,6 +310,19 @@ private:
   /// shader model.
   void AddExecutionModeForEntryPoint(uint32_t entryPointId);
 
+  /// \brief Emits a wrapper function for the entry function.
+  ///
+  /// The wrapper function loads the values of all stage input variables and
+  /// creates composites as expected by the source code entry function. It then
+  /// calls the source code entry point and writes out stage output variables
+  /// by extracting sub-values from the return value. In this way, we can handle
+  /// the source code entry point as a normal function.
+  ///
+  /// The wrapper function is also responsible for initializing global static
+  /// variables for some cases.
+  uint32_t emitEntryFunctionWrapper(const FunctionDecl *entryFunction,
+                                    uint32_t entryFuncId);
+
 private:
   /// \brief Returns true iff *all* the case values in the given switch
   /// statement are integer literals. In such cases OpSwitch can be used to

--- a/tools/clang/test/CodeGenSPIRV/break-stmt.mixed.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/break-stmt.mixed.hlsl
@@ -42,8 +42,7 @@ void main() {
 // CHECK-NEXT: OpBranch %for_check
       default:
       // CHECK-NEXT: %for_check = OpLabel
-      // CHECK-NEXT: {{%\d+}} = OpLoad %int %i
-      // CHECK-NEXT: [[i_lt_10:%\d+]] = OpSLessThan %bool %37 %int_10
+      // CHECK:      [[i_lt_10:%\d+]] = OpSLessThan %bool {{%\d+}} %int_10
       // CHECK-NEXT: OpLoopMerge %for_merge %for_continue None
       // CHECK-NEXT: OpBranchConditional [[i_lt_10]] %for_body %for_merge
         for (int i=0; i<10; ++i) {
@@ -79,7 +78,7 @@ void main() {
 
     // CHECK-NEXT: OpBranch %while_merge
     break; // Break the while loop.
-    
+
   // CHECK-NEXT: %while_continue = OpLabel
   // CHECK-NEXT: OpBranch %while_check
   }

--- a/tools/clang/test/CodeGenSPIRV/cf.if.for.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.if.for.hlsl
@@ -1,9 +1,5 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// Stage IO variables
-// CHECK-DAG: [[color:%\d+]] = OpVariable %_ptr_Input_float Input
-// CHECK-DAG: [[target:%\d+]] = OpVariable %_ptr_Output_v4float Output
-
 float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-LABEL: %bb_entry = OpLabel
 
@@ -13,7 +9,7 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: %j = OpVariable %_ptr_Function_int Function %int_0
 // CHECK-NEXT: %k = OpVariable %_ptr_Function_int Function %int_0
 
-// CHECK-NEXT: [[color0:%\d+]] = OpLoad %float [[color]]
+// CHECK-NEXT: [[color0:%\d+]] = OpLoad %float %color
 // CHECK-NEXT: [[lt0:%\d+]] = OpFOrdLessThan %bool [[color0]] %float_0_3
 // CHECK-NEXT: OpSelectionMerge %if_merge None
 // CHECK-NEXT: OpBranchConditional [[lt0]] %if_true %if_merge
@@ -34,15 +30,13 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpBranchConditional [[lt1]] %for_body %for_merge
     for (int i = 0; i < 10; ++i) {
 // CHECK-LABEL: %for_body = OpLabel
-// CHECK-NEXT: [[color1:%\d+]] = OpLoad %float [[color]]
+// CHECK-NEXT: [[color1:%\d+]] = OpLoad %float %color
 // CHECK-NEXT: [[lt2:%\d+]] = OpFOrdLessThan %bool [[color1]] %float_0_5
 // CHECK-NEXT: OpSelectionMerge %if_merge_0 None
 // CHECK-NEXT: OpBranchConditional [[lt2]] %if_true_0 %if_merge_0
         if (color < 0.5) { // if-stmt nested in for-stmt
 // CHECK-LABEL: %if_true_0 = OpLabel
-// CHECK-NEXT: [[val0:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[add1:%\d+]] = OpFAdd %float [[val0]] %float_1
-// CHECK-NEXT: OpStore %val [[add1]]
+// CHECK: OpStore %val
             val = val + 1.;
 // CHECK-NEXT: OpBranch %for_check_0
 
@@ -53,9 +47,7 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpBranchConditional [[lt3]] %for_body_0 %for_merge_0
             for (int j = 0; j < 15; ++j) { // for-stmt deeply nested in if-then
 // CHECK-LABEL: %for_body_0 = OpLabel
-// CHECK-NEXT: [[val1:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[mul2:%\d+]] = OpFMul %float [[val1]] %float_2
-// CHECK-NEXT: OpStore %val [[mul2]]
+// CHECK: OpStore %val
                 val = val * 2.;
 // CHECK-NEXT: OpBranch %for_continue_0
 
@@ -66,24 +58,20 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpBranch %for_check_0
             } // end for (int j
 // CHECK-LABEL: %for_merge_0 = OpLabel
-// CHECK-NEXT: [[val2:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[add3:%\d+]] = OpFAdd %float [[val2]] %float_3
-// CHECK-NEXT: OpStore %val [[add3]]
+// CHECK: OpStore %val
 
             val = val + 3.;
 // CHECK-NEXT: OpBranch %if_merge_0
         }
 // CHECK-LABEL: %if_merge_0 = OpLabel
 
-// CHECK-NEXT: [[color2:%\d+]] = OpLoad %float [[color]]
+// CHECK-NEXT: [[color2:%\d+]] = OpLoad %float %color
 // CHECK-NEXT: [[lt4:%\d+]] = OpFOrdLessThan %bool [[color2]] %float_0_8
 // CHECK-NEXT: OpSelectionMerge %if_merge_1 None
 // CHECK-NEXT: OpBranchConditional [[lt4]] %if_true_1 %if_false
         if (color < 0.8) { // if-stmt following if-stmt
 // CHECK-LABEL: %if_true_1 = OpLabel
-// CHECK-NEXT: [[val3:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[mul4:%\d+]] = OpFMul %float [[val3]] %float_4
-// CHECK-NEXT: OpStore %val [[mul4]]
+// CHECK: OpStore %val
             val = val * 4.;
 // CHECK-NEXT: OpBranch %if_merge_1
         } else {
@@ -97,9 +85,7 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpBranchConditional [[lt5]] %for_body_1 %for_merge_1
             for (int k = 0; k < 20; ++k) { // for-stmt deeply nested in if-else
 // CHECK-LABEL: %for_body_1 = OpLabel
-// CHECK-NEXT: [[val4:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[sub5:%\d+]] = OpFSub %float [[val4]] %float_5
-// CHECK-NEXT: OpStore %val [[sub5]]
+// CHECK: OpStore %val
                 val = val - 5.;
 
 // CHECK-NEXT: [[val5:%\d+]] = OpLoad %float %val
@@ -108,9 +94,7 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-NEXT: OpBranchConditional [[lt6]] %if_true_2 %if_merge_2
                 if (val < 0.) { // deeply nested if-stmt
 // CHECK-LABEL: %if_true_2 = OpLabel
-// CHECK-NEXT: [[val6:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[add100:%\d+]] = OpFAdd %float [[val6]] %float_100
-// CHECK-NEXT: OpStore %val [[add100]]
+// CHECK: OpStore %val
                     val = val + 100.;
 // CHECK-NEXT: OpBranch %if_merge_2
                 }
@@ -138,27 +122,19 @@ float4 main(float color: COLOR) : SV_TARGET {
 // CHECK-LABEL: %for_merge = OpLabel
 
     // if-stmt following for-stmt
-// CHECK-NEXT: [[color3:%\d+]] = OpLoad %float [[color]]
+// CHECK-NEXT: [[color3:%\d+]] = OpLoad %float %color
 // CHECK-NEXT: [[lt7:%\d+]] = OpFOrdLessThan %bool [[color3]] %float_0_9
 // CHECK-NEXT: OpSelectionMerge %if_merge_3 None
 // CHECK-NEXT: OpBranchConditional [[lt7]] %if_true_3 %if_merge_3
     if (color < 0.9) {
 // CHECK-LABEL: %if_true_3 = OpLabel
-// CHECK-NEXT: [[val7:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[add6:%\d+]] = OpFAdd %float [[val7]] %float_6
-// CHECK-NEXT: OpStore %val [[add6]]
+// CHECK: OpStore %val
         val = val + 6.;
 // CHECK-NEXT: OpBranch %if_merge_3
     }
 // CHECK-LABEL: %if_merge_3 = OpLabel
 
-// CHECK-NEXT: [[comp0:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[comp1:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[comp2:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[comp3:%\d+]] = OpLoad %float %val
-// CHECK-NEXT: [[ret:%\d+]] = OpCompositeConstruct %v4float [[comp0]] [[comp1]] [[comp2]] [[comp3]]
-// CHECK-NEXT: OpStore [[target]] [[ret]]
-// CHECK-NEXT: OpReturn
+// CHECK: OpReturnValue
     return float4(val, val, val, val);
 // CHECK-NEXT: OpFunctionEnd
 }

--- a/tools/clang/test/CodeGenSPIRV/constant-ps.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/constant-ps.hlsl2spv
@@ -8,28 +8,36 @@ float4 main(): SV_TARGET
 // ; SPIR-V
 // ; Version: 1.0
 // ; Generator: Google spiregg; 0
-// ; Bound: 14
+// ; Bound: 18
 // ; Schema: 0
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint Fragment %main "main" %4
+// OpEntryPoint Fragment %main "main" %out_var_SV_Target
 // OpExecutionMode %main OriginUpperLeft
 // OpName %main "main"
+// OpName %out_var_SV_Target "out.var.SV_Target"
+// OpName %src_main "src.main"
 // OpName %bb_entry "bb.entry"
-// OpDecorate %4 Location 0
+// OpDecorate %out_var_SV_Target Location 0
+// %void = OpTypeVoid
+// %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
-// %void = OpTypeVoid
-// %6 = OpTypeFunction %void
+// %11 = OpTypeFunction %v4float
 // %float_1 = OpConstant %float 1
 // %float_2 = OpConstant %float 2
 // %float_3_5 = OpConstant %float 3.5
 // %float_4_7 = OpConstant %float 4.7
-// %13 = OpConstantComposite %v4float %float_1 %float_2 %float_3_5 %float_4_7
-// %4 = OpVariable %_ptr_Output_v4float Output
-// %main = OpFunction %void None %6
-// %bb_entry = OpLabel
-// OpStore %4 %13
+// %17 = OpConstantComposite %v4float %float_1 %float_2 %float_3_5 %float_4_7
+// %out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+// %main = OpFunction %void None %3
+// %5 = OpLabel
+// %8 = OpFunctionCall %v4float %src_main
+// OpStore %out_var_SV_Target %8
 // OpReturn
+// OpFunctionEnd
+// %src_main = OpFunction %v4float None %11
+// %bb_entry = OpLabel
+// OpReturnValue %17
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/empty-void-main.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/empty-void-main.hlsl2spv
@@ -8,17 +8,23 @@ void main()
 // ; SPIR-V
 // ; Version: 1.0
 // ; Generator: Google spiregg; 0
-// ; Bound: 5
+// ; Bound: 8
 // ; Schema: 0
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
 // OpEntryPoint Fragment %main "main"
 // OpExecutionMode %main OriginUpperLeft
 // OpName %main "main"
+// OpName %src_main "src.main"
 // OpName %bb_entry "bb.entry"
 // %void = OpTypeVoid
-// %2 = OpTypeFunction %void
-// %main = OpFunction %void None %2
+// %3 = OpTypeFunction %void
+// %main = OpFunction %void None %3
+// %5 = OpLabel
+// %6 = OpFunctionCall %void %src_main
+// OpReturn
+// OpFunctionEnd
+// %src_main = OpFunction %void None %3
 // %bb_entry = OpLabel
 // OpReturn
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
@@ -9,27 +9,43 @@ float4 main(float4 input: COLOR): SV_TARGET
 // ; SPIR-V
 // ; Version: 1.0
 // ; Generator: Google spiregg; 0
-// ; Bound: 12
+// ; Bound: 20
 // ; Schema: 0
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint Fragment %main "main" %4 %6
+// OpEntryPoint Fragment %main "main" %in_var_COLOR %out_var_SV_Target
 // OpExecutionMode %main OriginUpperLeft
 // OpName %main "main"
+// OpName %in_var_COLOR "in.var.COLOR"
+// OpName %param_var_input "param.var.input"
+// OpName %out_var_SV_Target "out.var.SV_Target"
+// OpName %src_main "src.main"
+// OpName %input "input"
 // OpName %bb_entry "bb.entry"
-// OpDecorate %4 Location 0
-// OpDecorate %6 Location 0
+// OpDecorate %in_var_COLOR Location 0
+// OpDecorate %out_var_SV_Target Location 0
+// %void = OpTypeVoid
+// %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
-// %_ptr_Output_v4float = OpTypePointer Output %v4float
 // %_ptr_Input_v4float = OpTypePointer Input %v4float
-// %void = OpTypeVoid
-// %8 = OpTypeFunction %void
-// %4 = OpVariable %_ptr_Output_v4float Output
-// %6 = OpVariable %_ptr_Input_v4float Input
-// %main = OpFunction %void None %8
-// %bb_entry = OpLabel
-// %11 = OpLoad %v4float %6
-// OpStore %4 %11
+// %_ptr_Function_v4float = OpTypePointer Function %v4float
+// %_ptr_Output_v4float = OpTypePointer Output %v4float
+// %16 = OpTypeFunction %v4float %_ptr_Function_v4float
+// %in_var_COLOR = OpVariable %_ptr_Input_v4float Input
+// %out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
+// %main = OpFunction %void None %3
+// %5 = OpLabel
+// %param_var_input = OpVariable %_ptr_Function_v4float Function
+// %10 = OpLoad %v4float %in_var_COLOR
+// OpStore %param_var_input %10
+// %13 = OpFunctionCall %v4float %src_main %param_var_input
+// OpStore %out_var_SV_Target %13
 // OpReturn
+// OpFunctionEnd
+// %src_main = OpFunction %v4float None %16
+// %input = OpFunctionParameter %_ptr_Function_v4float
+// %bb_entry = OpLabel
+// %19 = OpLoad %v4float %input
+// OpReturnValue %19
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
@@ -17,51 +17,72 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // ; SPIR-V
 // ; Version: 1.0
 // ; Generator: Google spiregg; 0
-// ; Bound: 28
+// ; Bound: 37
 // ; Schema: 0
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint Vertex %VSmain "VSmain" %gl_Position %5 %7 %8
+// OpEntryPoint Vertex %VSmain "VSmain" %in_var_POSITION %in_var_COLOR %gl_Position %out_var_COLOR
 // OpName %VSmain "VSmain"
-// OpName %bb_entry "bb.entry"
+// OpName %in_var_POSITION "in.var.POSITION"
+// OpName %param_var_position "param.var.position"
+// OpName %in_var_COLOR "in.var.COLOR"
+// OpName %param_var_color "param.var.color"
 // OpName %PSInput "PSInput"
 // OpMemberName %PSInput 0 "position"
 // OpMemberName %PSInput 1 "color"
+// OpName %out_var_COLOR "out.var.COLOR"
+// OpName %src_VSmain "src.VSmain"
+// OpName %position "position"
+// OpName %color "color"
+// OpName %bb_entry "bb.entry"
 // OpName %result "result"
 // OpDecorate %gl_Position BuiltIn Position
-// OpDecorate %5 Location 0
-// OpDecorate %7 Location 0
-// OpDecorate %8 Location 1
+// OpDecorate %in_var_POSITION Location 0
+// OpDecorate %in_var_COLOR Location 1
+// OpDecorate %out_var_COLOR Location 0
 // %int = OpTypeInt 32 1
+// %void = OpTypeVoid
+// %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
-// %_ptr_Output_v4float = OpTypePointer Output %v4float
 // %_ptr_Input_v4float = OpTypePointer Input %v4float
-// %void = OpTypeVoid
-// %10 = OpTypeFunction %void
-// %PSInput = OpTypeStruct %v4float %v4float
-// %_ptr_Function_PSInput = OpTypePointer Function %PSInput
 // %_ptr_Function_v4float = OpTypePointer Function %v4float
+// %PSInput = OpTypeStruct %v4float %v4float
+// %_ptr_Output_v4float = OpTypePointer Output %v4float
+// %23 = OpTypeFunction %PSInput %_ptr_Function_v4float %_ptr_Function_v4float
+// %_ptr_Function_PSInput = OpTypePointer Function %PSInput
 // %int_0 = OpConstant %int 0
 // %int_1 = OpConstant %int 1
+// %in_var_POSITION = OpVariable %_ptr_Input_v4float Input
+// %in_var_COLOR = OpVariable %_ptr_Input_v4float Input
 // %gl_Position = OpVariable %_ptr_Output_v4float Output
-// %5 = OpVariable %_ptr_Output_v4float Output
-// %7 = OpVariable %_ptr_Input_v4float Input
-// %8 = OpVariable %_ptr_Input_v4float Input
-// %VSmain = OpFunction %void None %10
+// %out_var_COLOR = OpVariable %_ptr_Output_v4float Output
+// %VSmain = OpFunction %void None %3
+// %5 = OpLabel
+// %param_var_position = OpVariable %_ptr_Function_v4float Function
+// %param_var_color = OpVariable %_ptr_Function_v4float Function
+// %10 = OpLoad %v4float %in_var_POSITION
+// OpStore %param_var_position %10
+// %14 = OpLoad %v4float %in_var_COLOR
+// OpStore %param_var_color %14
+// %17 = OpFunctionCall %PSInput %src_VSmain %param_var_position %param_var_color
+// %18 = OpCompositeExtract %v4float %17 0
+// OpStore %gl_Position %18
+// %21 = OpCompositeExtract %v4float %17 1
+// OpStore %out_var_COLOR %21
+// OpReturn
+// OpFunctionEnd
+// %src_VSmain = OpFunction %PSInput None %23
+// %position = OpFunctionParameter %_ptr_Function_v4float
+// %color = OpFunctionParameter %_ptr_Function_v4float
 // %bb_entry = OpLabel
 // %result = OpVariable %_ptr_Function_PSInput Function
-// %16 = OpLoad %v4float %7
-// %20 = OpAccessChain %_ptr_Function_v4float %result %int_0
-// OpStore %20 %16
-// %21 = OpLoad %v4float %8
-// %23 = OpAccessChain %_ptr_Function_v4float %result %int_1
-// OpStore %23 %21
-// %24 = OpAccessChain %_ptr_Function_v4float %result %int_0
-// %25 = OpLoad %v4float %24
-// OpStore %gl_Position %25
-// %26 = OpAccessChain %_ptr_Function_v4float %result %int_1
-// %27 = OpLoad %v4float %26
-// OpStore %5 %27
-// OpReturn
+// %29 = OpLoad %v4float %position
+// %32 = OpAccessChain %_ptr_Function_v4float %result %int_0
+// OpStore %32 %29
+// %33 = OpLoad %v4float %color
+// %35 = OpAccessChain %_ptr_Function_v4float %result %int_1
+// OpStore %35 %33
+// %36 = OpLoad %PSInput %result
+// OpReturnValue %36
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.hlsl
@@ -1,16 +1,16 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK: OpEntryPoint Vertex %main "main" [[out:%\d+]] [[a:%\d+]] [[b:%\d+]] [[c:%\d+]]
+// CHECK: OpEntryPoint Vertex %main "main" %in_var_AAA %in_var_B %in_var_CC %out_var_DDDD
 
-// CHECK: OpDecorate [[out]] Location 0
-// CHECK: OpDecorate [[a]] Location 0
-// CHECK: OpDecorate [[b]] Location 1
-// CHECK: OpDecorate [[c]] Location 2
+// CHECK: OpDecorate %in_var_AAA Location 0
+// CHECK: OpDecorate %in_var_B Location 1
+// CHECK: OpDecorate %in_var_CC Location 2
+// CHECK: OpDecorate %out_var_DDDD Location 0
 
-// CHECK: [[out]] = OpVariable %_ptr_Output_float Output
-// CHECK: [[a]] = OpVariable %_ptr_Input_v4float Input
-// CHECK: [[b]] = OpVariable %_ptr_Input_int Input
-// CHECK: [[c]] = OpVariable %_ptr_Input_mat2v3float Input
+// CHECK: %in_var_AAA = OpVariable %_ptr_Input_v4float Input
+// CHECK: %in_var_B = OpVariable %_ptr_Input_int Input
+// CHECK: %in_var_CC = OpVariable %_ptr_Input_mat2v3float Input
+// CHECK: %out_var_DDDD = OpVariable %_ptr_Output_float Output
 
 float main(float4 a: AAA, int b: B, float2x3 c: CC) : DDDD {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/semantic.depth.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.depth.ps.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK:                 OpEntryPoint Fragment %main "main" %gl_FragDepth {{%\d+}}
+// CHECK:                 OpEntryPoint Fragment %main "main" %in_var_A %gl_FragDepth
 
 // CHECK:                 OpDecorate %gl_FragDepth BuiltIn FragDepth
 

--- a/tools/clang/test/CodeGenSPIRV/semantic.instance-id.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.instance-id.ps.hlsl
@@ -1,10 +1,10 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK:             OpEntryPoint Fragment %main "main" {{%\d+}} [[input:%\d+]]
+// CHECK:             OpEntryPoint Fragment %main "main" %in_var_SV_InstanceID %out_var_SV_Target
 
-// CHECK:             OpDecorate [[input]] Location 0
+// CHECK:             OpDecorate %in_var_SV_InstanceID Location 0
 
-// CHECK: [[input]] = OpVariable %_ptr_Input_int Input
+// CHECK: %in_var_SV_InstanceID = OpVariable %_ptr_Input_int Input
 
 float4 main(int input: SV_InstanceID) : SV_Target {
     return input;

--- a/tools/clang/test/CodeGenSPIRV/semantic.instance-id.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.instance-id.vs.hlsl
@@ -1,12 +1,12 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK:                     OpEntryPoint Vertex %main "main" [[output:%\d+]] %gl_InstanceIndex
+// CHECK:                     OpEntryPoint Vertex %main "main" %gl_InstanceIndex %out_var_SV_InstanceID
 
 // CHECK:                     OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
-// CHECK:                     OpDecorate [[output]] Location 0
+// CHECK:                     OpDecorate %out_var_SV_InstanceID Location 0
 
-// CHECK:        [[output]] = OpVariable %_ptr_Output_int Output
 // CHECK: %gl_InstanceIndex = OpVariable %_ptr_Input_int Input
+// CHECK: %out_var_SV_InstanceID = OpVariable %_ptr_Output_int Output
 
 int main(int input: SV_InstanceID) : SV_InstanceID {
     return input;

--- a/tools/clang/test/CodeGenSPIRV/semantic.position.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.position.ps.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK:                 OpEntryPoint Fragment %main "main" {{%\d+}} %gl_FragCoord
+// CHECK:                 OpEntryPoint Fragment %main "main" %gl_FragCoord %out_var_SV_Target
 
 // CHECK:                 OpDecorate %gl_FragCoord BuiltIn FragCoord
 

--- a/tools/clang/test/CodeGenSPIRV/semantic.position.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.position.vs.hlsl
@@ -1,12 +1,12 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK:                OpEntryPoint Vertex %main "main" %gl_Position [[input:%\d+]]
+// CHECK:                OpEntryPoint Vertex %main "main" %in_var_SV_Position %gl_Position
 
 // CHECK:                OpDecorate %gl_Position BuiltIn Position
-// CHECK:                OpDecorate [[input]] Location 0
+// CHECK:                OpDecorate %in_var_SV_Position Location 0
 
+// CHECK: %in_var_SV_Position = OpVariable %_ptr_Input_v4float Input
 // CHECK: %gl_Position = OpVariable %_ptr_Output_v4float Output
-// CHECK:    [[input]] = OpVariable %_ptr_Input_v4float Input
 
 float4 main(float4 input: SV_Position) : SV_Position {
     return input;

--- a/tools/clang/test/CodeGenSPIRV/semantic.target.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.target.ps.hlsl
@@ -1,10 +1,10 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK:              OpEntryPoint Fragment %main "main" [[target:%\d+]] {{%\d+}}
+// CHECK:              OpEntryPoint Fragment %main "main" %in_var_A %out_var_SV_Target
 
-// CHECK:              OpDecorate [[target]] Location 0
+// CHECK:              OpDecorate %out_var_SV_Target Location 0
 
-// CHECK: [[target]] = OpVariable %_ptr_Output_v4float Output
+// CHECK: %out_var_SV_Target = OpVariable %_ptr_Output_v4float Output
 
 float4 main(float4 input: A) : SV_Target {
     return input;

--- a/tools/clang/test/CodeGenSPIRV/semantic.vertex-id.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.vertex-id.vs.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK:                   OpEntryPoint Vertex %main "main" {{%\d+}} %gl_VertexIndex
+// CHECK:                   OpEntryPoint Vertex %main "main" %gl_VertexIndex %out_var_A
 
 // CHECK:                   OpDecorate %gl_VertexIndex BuiltIn VertexIndex
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.entry-function.wrapper.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.entry-function.wrapper.hlsl
@@ -1,0 +1,51 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    bool a : A;
+    uint2 b: B;
+    float2x3 c: C;
+};
+
+struct T {
+    S x;
+    int y: D;
+};
+
+// CHECK:       %in_var_A = OpVariable %_ptr_Input_bool Input
+// CHECK-NEXT:  %in_var_B = OpVariable %_ptr_Input_v2uint Input
+// CHECK-NEXT:  %in_var_C = OpVariable %_ptr_Input_mat2v3float Input
+// CHECK-NEXT:  %in_var_D = OpVariable %_ptr_Input_int Input
+
+// CHECK-NEXT: %out_var_A = OpVariable %_ptr_Output_bool Output
+// CHECK-NEXT: %out_var_B = OpVariable %_ptr_Output_v2uint Output
+// CHECK-NEXT: %out_var_C = OpVariable %_ptr_Output_mat2v3float Output
+// CHECK-NEXT: %out_var_D = OpVariable %_ptr_Output_int Output
+
+// CHECK-NEXT:        %main = OpFunction %void None {{%\d+}}
+// CHECK-NEXT:     {{%\d+}} = OpLabel
+
+// CHECK-NEXT: %param_var_input = OpVariable %_ptr_Function_T Function
+// CHECK-NEXT: [[inA:%\d+]] = OpLoad %bool %in_var_A
+// CHECK-NEXT: [[inB:%\d+]] = OpLoad %v2uint %in_var_B
+// CHECK-NEXT: [[inC:%\d+]] = OpLoad %mat2v3float %in_var_C
+// CHECK-NEXT: [[inS:%\d+]] = OpCompositeConstruct %S [[inA]] [[inB]] [[inC]]
+// CHECK-NEXT: [[inD:%\d+]] = OpLoad %int %in_var_D
+// CHECK-NEXT: [[inT:%\d+]] = OpCompositeConstruct %T [[inS]] [[inD]]
+// CHECK-NEXT:                OpStore %param_var_input [[inT]]
+
+// CHECK-NEXT:  [[ret:%\d+]] = OpFunctionCall %T %src_main %param_var_input
+// CHECK-NEXT: [[outS:%\d+]] = OpCompositeExtract %S [[ret]] 0
+// CHECK-NEXT: [[outA:%\d+]] = OpCompositeExtract %bool [[outS]] 0
+// CHECK-NEXT:                 OpStore %out_var_A [[outA]]
+// CHECK-NEXT: [[outB:%\d+]] = OpCompositeExtract %v2uint [[outS]] 1
+// CHECK-NEXT:                 OpStore %out_var_B [[outB]]
+// CHECK-NEXT: [[outC:%\d+]] = OpCompositeExtract %mat2v3float [[outS]] 2
+// CHECK-NEXT:                 OpStore %out_var_C [[outC]]
+// CHECK-NEXT: [[outD:%\d+]] = OpCompositeExtract %int [[ret]] 1
+// CHECK-NEXT:                 OpStore %out_var_D [[outD]]
+
+// CHECK-NEXT:                 OpReturn
+// CHECK-NEXT:                 OpFunctionEnd
+T main(T input) {
+    return input;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.storage-class.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.storage-class.hlsl
@@ -5,20 +5,23 @@ struct VSOut {
     float4 out2: D;
 };
 
-static float4 sgVar; // Private
+static float4 sgVar; // Privte
 
-// CHECK: [[input:%\d+]] = OpVariable %_ptr_Input_v4float Input
+// Note: The entry function in the source code is treated as a normal function.
+// Another wrapper function take care of handling stage input/output variables.
+// and calling the source code entry function. So there are no Input/Ouput
+// storage class involved in the following.
 
-VSOut main(float4 input: A /* Input */, uint index: B /* Input */) {
+VSOut main(float4 input: A /* Function */, uint index: B /* Function */) {
     static float4 slVar; // Private
 
     VSOut ret; // Function
 
-// CHECK:      {{%\d+}} = OpAccessChain %_ptr_Input_float [[input]] {{%\d+}}
-// CHECK:      {{%\d+}} = OpAccessChain %_ptr_Private_float %sgVar {{%\d+}}
-// CHECK:      {{%\d+}} = OpAccessChain %_ptr_Private_float %slVar {{%\d+}}
+// CHECK:      OpAccessChain %_ptr_Function_float %input
+// CHECK:      OpAccessChain %_ptr_Private_float %sgVar
+// CHECK:      OpAccessChain %_ptr_Private_float %slVar
 // CHECK:      [[lhs:%\d+]] = OpAccessChain %_ptr_Function_v4float %ret %int_0
-// CHECK-NEXT: {{%\d+}} = OpAccessChain %_ptr_Function_float [[lhs]] {{%\d+}}
+// CHECK-NEXT: OpAccessChain %_ptr_Function_float [[lhs]]
     ret.out1[index] = input[index] + sgVar[index] + slVar[index];
 
     return ret;

--- a/tools/clang/test/CodeGenSPIRV/var.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.hlsl
@@ -4,9 +4,6 @@
 // CHECK: [[float4constant:%\d+]] = OpConstantComposite %v4float %float_1 %float_2 %float_3 %float_4
 // CHECK: [[int2constant:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 
-// Stage IO variables
-// CHECK: [[component:%\d+]] = OpVariable %_ptr_Input_float Input
-
 float4 main(float component: COLOR) : SV_TARGET {
 // CHECK-LABEL: %bb_entry = OpLabel
 
@@ -24,7 +21,7 @@ float4 main(float component: COLOR) : SV_TARGET {
 
 // Initializer already attached to the var definition
     float i = 1. + 2.;   // From const expr
-// CHECK-NEXT: [[component0:%\d+]] = OpLoad %float [[component]]
+// CHECK-NEXT: [[component0:%\d+]] = OpLoad %float %component
 // CHECK-NEXT: OpStore %j [[component0]]
     float j = component; // From stage variable
 

--- a/tools/clang/test/CodeGenSPIRV/var.init.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.struct.hlsl
@@ -80,7 +80,7 @@ void main() {
 // CHECK-NEXT: [[n:%\d+]] = OpBitcast %int [[s2bv]]
 
 // CHECK-NEXT: [[s2c:%\d+]] = OpAccessChain %_ptr_Function_mat2v2float %s2 %int_2
-// CHECK-NEXT: [[o:%\d+]] = OpLoad %mat2v2float %65
+// CHECK-NEXT: [[o:%\d+]] = OpLoad %mat2v2float [[s2c]]
 
 // CHECK-NEXT: {{%\d+}} = OpCompositeConstruct %T [[h]] [[i]] [[j]] [[k]] [[l]] [[m]] [[n]] [[o]]
     T t = {s1,          // Decomposing struct

--- a/tools/clang/test/CodeGenSPIRV/var.static.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.static.hlsl
@@ -15,22 +15,23 @@ static bool3 gb;
 // InitListHandler.
 static float2x2 gc = {1, 2, 3, 4};
 
-// CHECK: [[input:%\d+]] = OpVariable %_ptr_Input_int Input
-
 // CHECK: %a = OpVariable %_ptr_Private_uint Private %uint_5
 // CHECK: %b = OpVariable %_ptr_Private_v4float Private [[v4f0]]
 // CHECK: %c = OpVariable %_ptr_Private_int Private
 
 // CHECK: %init_done_c = OpVariable %_ptr_Private_bool Private %false
 
-int main(int input: A) : B {
-// CHECK-LABEL: %bb_entry = OpLabel
-
-    // initialization of gc
+    // initialization of gc appears at the beginning of the entry function wrapper
+// CHECK-LABEL: OpLabel
 // CHECK:      [[v2f12:%\d+]] = OpCompositeConstruct %v2float %float_1 %float_2
 // CHECK-NEXT: [[v2f34:%\d+]] = OpCompositeConstruct %v2float %float_3 %float_4
 // CHECK-NEXT: [[mat1234:%\d+]] = OpCompositeConstruct %mat2v2float [[v2f12]] [[v2f34]]
 // CHECK-NEXT: OpStore %gc [[mat1234]]
+// CHECK:      OpFunctionCall %int %src_main
+// CHECK-LABEL: OpFunctionEnd
+
+int main(int input: A) : B {
+// CHECK-LABEL: %bb_entry = OpLabel
 
     static uint a = 5;    // const init
     static float4 b;      // no init
@@ -39,7 +40,7 @@ int main(int input: A) : B {
 // CHECK-NEXT: OpSelectionMerge %if_merge None
 // CHECK-NEXT: OpBranchConditional [[initdonec]] %if_true %if_merge
 // CHECK-NEXT: %if_true = OpLabel
-// CHECK-NEXT: [[initc:%\d+]] = OpLoad %int [[input]]
+// CHECK-NEXT: [[initc:%\d+]] = OpLoad %int %input
 // CHECK-NEXT: OpStore %c [[initc]]
 // CHECK-NEXT: OpStore %init_done_c %true
 // CHECK-NEXT: OpBranch %if_merge

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -312,5 +312,8 @@ TEST_F(FileTest, IntrinsicsAtan) { runFileTest("intrinsics.atan.hlsl"); }
 
 // SPIR-V specific
 TEST_F(FileTest, SpirvStorageClass) { runFileTest("spirv.storage-class.hlsl"); }
+TEST_F(FileTest, SpirvEntryFunctionWrapper) {
+  runFileTest("spirv.entry-function.wrapper.hlsl");
+}
 
 } // namespace


### PR DESCRIPTION
Previously for an entry function, we decompose its parameters and
return value and create stage input/output/builtin variables from
them directly. This is fine for simple shaders, but it will have
problems for shaders using structs to group stage variables.
Accessing paramters and return values (using operator. and return)
needs special handling for entry functions, which is nasty.

With the wrapper function, we can handle entry functions just like
normal functions. Stage variable handling are all done in the
wrapper funtion.