### PR TITLE
[spirv] Turn on C++11 attributes and support [[vk::location(X)]]

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -232,6 +232,7 @@ def MicrosoftExt : LangOpt<"MicrosoftExt">;
 def Borland : LangOpt<"Borland">;
 def CUDA : LangOpt<"CUDA">;
 def COnly : LangOpt<"CPlusPlus", 1>;
+def SPIRV : LangOpt<"SPIRV">; // SPIRV Change
 
 // Defines targets for target-specific attributes. The list of strings should
 // specify architectures for which the target applies, based off the ArchType
@@ -851,6 +852,18 @@ def HLSLShader : InheritableAttr {
 }
 
 // HLSL Change Ends
+
+// SPIRV Change Starts
+
+def VKLocation : InheritableAttr {
+  let Spellings = [CXX11<"vk", "location">];
+  let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;
+  let Args = [IntArgument<"Number">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+// SPIRV Change Ends
 
 def C11NoReturn : InheritableAttr {
   let Spellings = [Keyword<"_Noreturn">];

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -158,6 +158,8 @@ public:
   bool IsHLSLLibrary;
   bool NoMinPrecision; // use strict precision, not min precision.
   // MS Change Ends
+
+  bool SPIRV = false;  // SPIRV Change
   
   bool isSignedOverflowDefined() const {
     return getSignedOverflowBehavior() == SOB_Defined;

--- a/tools/clang/include/clang/Parse/Parser.h
+++ b/tools/clang/include/clang/Parse/Parser.h
@@ -2132,7 +2132,9 @@ private:
   IdentifierLoc *ParseIdentifierLoc();
 
   void MaybeParseCXX11Attributes(Declarator &D) {
-    if (getLangOpts().CPlusPlus11 && isCXX11AttributeSpecifier()) {
+    if ((getLangOpts().CPlusPlus11 ||
+         getLangOpts().HLSL) && // HLSL change
+        isCXX11AttributeSpecifier()) {
       ParsedAttributesWithRange attrs(AttrFactory);
       SourceLocation endLoc;
       ParseCXX11Attributes(attrs, &endLoc);
@@ -2141,7 +2143,9 @@ private:
   }
   void MaybeParseCXX11Attributes(ParsedAttributes &attrs,
                                  SourceLocation *endLoc = nullptr) {
-    if (getLangOpts().CPlusPlus11 && isCXX11AttributeSpecifier()) {
+    if ((getLangOpts().CPlusPlus11 ||
+         getLangOpts().HLSL) && // HLSL change
+        isCXX11AttributeSpecifier()) {
       ParsedAttributesWithRange attrsWithRange(AttrFactory);
       ParseCXX11Attributes(attrsWithRange, endLoc);
       attrs.takeAllFrom(attrsWithRange);
@@ -2150,7 +2154,8 @@ private:
   void MaybeParseCXX11Attributes(ParsedAttributesWithRange &attrs,
                                  SourceLocation *endLoc = nullptr,
                                  bool OuterMightBeMessageSend = false) {
-    if (getLangOpts().CPlusPlus11 &&
+    if ((getLangOpts().CPlusPlus11 ||
+         getLangOpts().HLSL) && // HLSL change
         isCXX11AttributeSpecifier(false, OuterMightBeMessageSend))
       ParseCXX11Attributes(attrs, endLoc);
   }

--- a/tools/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/tools/clang/lib/Parse/ParseDeclCXX.cpp
@@ -3817,7 +3817,6 @@ bool Parser::ParseCXX11AttributeArgs(IdentifierInfo *AttrName,
 ///         identifier
 void Parser::ParseCXX11AttributeSpecifier(ParsedAttributes &attrs,
                                           SourceLocation *endLoc) {
-  assert(!getLangOpts().HLSL && "unreachable code in HLSL, no parsing of C++11-style attributes"); // HLSL Change
   if (Tok.is(tok::kw_alignas)) {
     Diag(Tok.getLocation(), diag::warn_cxx98_compat_alignas);
     ParseAlignmentSpecifier(attrs, endLoc);
@@ -3898,7 +3897,7 @@ void Parser::ParseCXX11AttributeSpecifier(ParsedAttributes &attrs,
 ///       attribute-specifier-seq[opt] attribute-specifier
 void Parser::ParseCXX11Attributes(ParsedAttributesWithRange &attrs,
                                   SourceLocation *endLoc) {
-  assert(getLangOpts().CPlusPlus11);
+  assert(getLangOpts().CPlusPlus11 || getLangOpts().HLSL); // HLSL Change
 
   SourceLocation StartLoc = Tok.getLocation(), Loc;
   if (!endLoc)

--- a/tools/clang/lib/Parse/ParseTentative.cpp
+++ b/tools/clang/lib/Parse/ParseTentative.cpp
@@ -498,12 +498,6 @@ bool Parser::isCXXTypeId(TentativeCXXTypeIdContext Context, bool &isAmbiguous) {
 Parser::CXX11AttributeKind
 Parser::isCXX11AttributeSpecifier(bool Disambiguate,
                                   bool OuterMightBeMessageSend) {
-  // HLSL Change Starts
-  if (getLangOpts().HLSL) {
-    return CAK_NotAttributeSpecifier;
-  }
-  // HLSL Change Ends
-
   if (Tok.is(tok::kw_alignas))
     return CAK_AttributeSpecifier;
 

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -182,7 +182,8 @@ void SPIRVEmitter::HandleTranslationUnit(ASTContext &context) {
   AddExecutionModeForEntryPoint(entryFunctionId);
 
   // Add Location decorations to stage input/output variables.
-  declIdMapper.finalizeStageIOLocations();
+  if (!declIdMapper.decorateStageIOLocations())
+    return;
 
   // Output the constructed module.
   std::vector<uint32_t> m = theBuilder.takeModule();

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10146,7 +10146,7 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
 	  break;
   default:
     Handled = false;
-    return;
+    break;  // SPIRV Change: was return;
   }
 
   if (declAttr != nullptr)
@@ -10157,7 +10157,29 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     // The attribute has been set but will have no effect. Validation will emit a diagnostic
     // and prevent code generation.
     ValidateAttributeTargetIsFunction(S, D, A);
+
+    return; // SPIRV Change
   }
+
+  // SPIRV Change Starts
+  Handled = true;
+  switch (A.getKind())
+  {
+  case AttributeList::AT_VKLocation:
+	  declAttr = ::new (S.Context) VKLocationAttr(A.getRange(), S.Context,
+		  ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+	  break;
+  default:
+    Handled = false;
+    return;
+  }
+
+  if (declAttr != nullptr)
+  {
+    DXASSERT_NOMSG(Handled);
+    D->addAttr(declAttr);
+  }
+  // SPIRV Change Ends
 }
 
 /// <summary>Processes an attribute for a statement.</summary>

--- a/tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
@@ -22,8 +22,8 @@ float4 main(float4 input: COLOR): SV_Target
 // OpName %out_var_SV_Target "out.var.SV_Target"
 // OpName %src_main "src.main"
 // OpName %input "input"
-// OpDecorate %out_var_SV_Target Location 0
 // OpDecorate %in_var_COLOR Location 0
+// OpDecorate %out_var_SV_Target Location 0
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32

--- a/tools/clang/test/CodeGenSPIRV/vk.location.exp-in.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.exp-in.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    [[vk::location(2)]] int    a: A; // In nested struct --- A -> 2
+};
+
+struct T {
+    [[vk::location(1)]] float4 b: B; // In struct --- B -> 1
+                        S      s;
+};
+
+struct U {
+                        float4 c: C;
+};
+
+float main([[vk::location(0)]] in  uint   m: M, // On function parameter --- M -> 0
+                                   T      t,
+                               out float  n: N,
+                               out U      u,
+
+                               out float4 pos: SV_Position
+          ) : R {
+    return 1.0;
+}
+
+// Explicit assignment
+// CHECK: OpDecorate %in_var_M Location 0
+// CHECK: OpDecorate %in_var_B Location 1
+// CHECK: OpDecorate %in_var_A Location 2
+
+// Alphabetical assignment
+// CHECK: OpDecorate %out_var_C Location 0
+// CHECK: OpDecorate %out_var_N Location 1
+// CHECK: OpDecorate %out_var_R Location 2

--- a/tools/clang/test/CodeGenSPIRV/vk.location.exp-out.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.exp-out.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+                        int    a: A;
+};
+
+struct T {
+                        float4 b: B;
+                        S      s;
+};
+
+struct U {
+    [[vk::location(1)]] float4 c: C; // In struct --- C -> 1
+};
+
+[[vk::location(2)]]                  // On function return --- R -> 2
+float main(                    in  uint   m: M,
+                                   T      t,
+           [[vk::location(0)]] out float  n: N, // On function parameter --- N -> 0
+                               out U      u,
+
+                               out float4 pos: SV_Position
+          ) : R {
+    return 1.0;
+}
+
+// Alphabetical assignment
+// CHECK: OpDecorate %in_var_A Location 0
+// CHECK: OpDecorate %in_var_B Location 1
+// CHECK: OpDecorate %in_var_M Location 2
+
+// Explicit assignment
+// CHECK: OpDecorate %out_var_R Location 2
+// CHECK: OpDecorate %out_var_N Location 0
+// CHECK: OpDecorate %out_var_C Location 1
+

--- a/tools/clang/test/CodeGenSPIRV/vk.location.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.hlsl
@@ -1,0 +1,35 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    [[vk::location(2)]] int    a: A; // In nested struct --- A -> 2
+};
+
+struct T {
+    [[vk::location(1)]] float4 b: B; // In struct --- B -> 1
+                        S      s;
+};
+
+struct U {
+    [[vk::location(1)]] float4 c: C; // In struct --- C -> 1
+};
+
+[[vk::location(2)]]                  // On function return --- R -> 2
+float main([[vk::location(0)]] in  uint   m: M, // On function parameter --- M -> 0
+                                   T      t,
+           [[vk::location(0)]] out float  n: N, // On function parameter --- N -> 0
+                               out U      u,
+
+                               out float4 pos: SV_Position
+          ) : R {
+    return 1.0;
+}
+
+// Explicit assignment
+// CHECK: OpDecorate %in_var_M Location 0
+// CHECK: OpDecorate %in_var_B Location 1
+// CHECK: OpDecorate %in_var_A Location 2
+
+// Explicit assignment
+// CHECK: OpDecorate %out_var_R Location 2
+// CHECK: OpDecorate %out_var_N Location 0
+// CHECK: OpDecorate %out_var_C Location 1

--- a/tools/clang/test/CodeGenSPIRV/vk.location.large.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.large.hlsl
@@ -1,0 +1,6 @@
+// Run: %dxc -T vs_6_0 -E main
+
+[[vk::location(123456)]]
+float main() : A { return 1.0; }
+
+// CHECK: 3:3: error: stage output location #123456 too large

--- a/tools/clang/test/CodeGenSPIRV/vk.location.mixed.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.mixed.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T vs_6_0 -E main
+
+float main(
+    [[vk::location(5)]] int   a: A,
+                        float b: B
+) : R { return 1.0; }
+
+// CHECK:      error: partial explicit stage input location assignment via
+// CHECK-SAME: vk::location(X)
+// CHECK-SAME: unsupported

--- a/tools/clang/test/CodeGenSPIRV/vk.location.reassign.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.reassign.hlsl
@@ -1,0 +1,33 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    [[vk::location(3)]] float a : A;  // error
+    [[vk::location(3)]] float b : B;  // error
+};
+
+struct T {
+    [[vk::location(3)]] float i : A;  // error
+    [[vk::location(3)]] float j : B;  // error
+};
+
+[[vk::location(3)]]                   // first use
+float main(
+    [[vk::location(3)]]     float m : M,  // first use
+    [[vk::location(3)]]     float n : N,  // error
+                            S     s,
+
+    [[vk::location(3)]] out float x : X,  // error
+    [[vk::location(3)]] out float y : Y,  // error
+                        out T     t
+) : R {
+    return 1.0;
+}
+
+// CHECK: 16:7: error: stage input location #3 already assigned
+// CHECK: 4:7: error: stage input location #3 already assigned
+// CHECK: 5:7: error: stage input location #3 already assigned
+
+// CHECK: 19:7: error: stage output location #3 already assigned
+// CHECK: 20:7: error: stage output location #3 already assigned
+// CHECK: 9:7: error: stage output location #3 already assigned
+// CHECK: 10:7: error: stage output location #3 already assigned

--- a/tools/clang/test/HLSL/cxx11-attributes.hlsl
+++ b/tools/clang/test/HLSL/cxx11-attributes.hlsl
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+
+struct S {
+    [[vk::location(1)]] // expected-warning {{'location' attribute ignored}}
+    float a: A;
+};
+
+[[maybe_unused]] // expected-warning {{unknown attribute 'maybe_unused' ignored}}
+float main([[scope::attr(0, "str")]] // expected-warning {{unknown attribute 'attr' ignored}}
+           float m: B,
+           S s) : C {
+    return m + s.a;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -789,6 +789,12 @@ public:
 
     compiler.getLangOpts().NoMinPrecision = Opts.NoMinPrecision;
 
+// SPIRV change starts
+#ifdef ENABLE_SPIRV_CODEGEN
+    compiler.getLangOpts().SPIRV = Opts.GenSPIRV;
+#endif
+// SPIRV change ends
+
     if (Opts.WarningAsError)
       compiler.getDiagnostics().setWarningsAsErrors(true);
 

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -40,6 +40,7 @@ public:
   TEST_METHOD(RunConstAssign);
   TEST_METHOD(RunConstDefault);
   TEST_METHOD(RunCppErrors);
+  TEST_METHOD(RunCXX11Attributes);
   TEST_METHOD(RunEnums);
   TEST_METHOD(RunFunctions);
   TEST_METHOD(RunIndexingOperator);
@@ -161,6 +162,10 @@ TEST_F(VerifierTest, RunConstDefault) {
 
 TEST_F(VerifierTest, RunCppErrors) {
   CheckVerifiesHLSL(L"cpp-errors.hlsl");
+}
+
+TEST_F(VerifierTest, RunCXX11Attributes) {
+  CheckVerifiesHLSL(L"cxx11-attributes.hlsl");
 }
 
 TEST_F(VerifierTest, RunEnums) {

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -350,5 +350,21 @@ TEST_F(FileTest, SpirvEntryFunctionWrapper) {
 TEST_F(FileTest, SpirvEntryFunctionInOut) {
   runFileTest("spirv.entry-function.inout.hlsl");
 }
+TEST_F(FileTest, VulkanLocation) { runFileTest("vk.location.hlsl"); }
+TEST_F(FileTest, VulkanLocationInputExplicitOutputImplicit) {
+  runFileTest("vk.location.exp-in.hlsl");
+}
+TEST_F(FileTest, VulkanLocationInputImplicitOutputExplicit) {
+  runFileTest("vk.location.exp-out.hlsl");
+}
+TEST_F(FileTest, VulkanLocationTooLarge) {
+  runFileTest("vk.location.large.hlsl", /*expectSuccess*/ false);
+}
+TEST_F(FileTest, VulkanLocationReassigned) {
+  runFileTest("vk.location.reassign.hlsl", /*expectSuccess*/ false);
+}
+TEST_F(FileTest, VulkanLocationPartiallyAssigned) {
+  runFileTest("vk.location.mixed.hlsl", /*expectSuccess*/ false);
+}
 
 } // namespace

--- a/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/tools/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -1924,7 +1924,20 @@ static void GenerateHasAttrSpellingStringSwitch(
     } else if (Variety == "CXX11")
       // C++11 mode should be checked against LangOpts, which is presumed to be
       // present in the caller.
+    {  // SPIRV Change
       Test = "LangOpts.CPlusPlus11";
+
+      // SPIRV Change Begins
+      // Allow C++11 attribute specifiers in HLSL when they are of the
+      // vk namespace
+      std::vector<FlattenedSpelling> Spellings = GetFlattenedSpellings(*Attr);
+      for (const auto &S : Spellings)
+        if (S.nameSpace() == "vk") {
+          Test = "(LangOpts.HLSL || LangOpts.CPlusPlus11)";
+          break;
+        }
+    }
+    // SPIRV Change Ends
 
     std::string TestStr =
         !Test.empty() ? Test + " ? " + llvm::itostr(Version) + " : 0" : "1";


### PR DESCRIPTION
This commit turns on C++11 attributes for HLSL globally. C++11
attributes will be parsed where they are allowed in C++11.
However, they will just result in an warning of ignored attribute,
without any semantic impact for the general DXIL CodeGen.

For SPIR-V CodeGen, C++11 attributes within the vk namespace will
be interpreted and converted to semantic AST nodes.