### PR TITLE
Support half type for constant buffer. 

### DIFF
--- a/include/dxc/HLSL/DxilCompType.h
+++ b/include/dxc/HLSL/DxilCompType.h
@@ -63,6 +63,7 @@ public:
   bool IsSNorm() const;
   bool IsUNorm() const;
   bool Is64Bit() const;
+  bool Is16Bit() const;
 
   /// For min-precision types, returns upconverted (base) type.
   CompType GetBaseCompType() const;

--- a/include/dxc/HLSL/DxilContainer.h
+++ b/include/dxc/HLSL/DxilContainer.h
@@ -105,8 +105,9 @@ static const uint64_t ShaderFeatureInfo_WaveOps = 0x4000;
 static const uint64_t ShaderFeatureInfo_Int64Ops = 0x8000;
 static const uint64_t ShaderFeatureInfo_ViewID = 0x10000;
 static const uint64_t ShaderFeatureInfo_Barycentrics = 0x20000;
+static const uint64_t ShaderFeatureInfo_UseStrictHalf = 0x40000;
 
-static const unsigned ShaderFeatureInfoCount = 18;
+static const unsigned ShaderFeatureInfoCount = 19;
 
 struct DxilShaderFeatureInfo {
   uint64_t FeatureFlags;

--- a/include/dxc/HLSL/DxilModule.h
+++ b/include/dxc/HLSL/DxilModule.h
@@ -275,6 +275,9 @@ public:
     void SetBarycentrics(bool flag) { m_bBarycentrics = flag; }
     bool GetBarycentrics() const { return m_bBarycentrics; }
 
+    void SetUseStrictHalf(bool flag) { m_bUseStrictHalf = flag; }
+    bool GetUseStrictHalf() const { return m_bUseStrictHalf; }
+
     static uint64_t GetShaderFlagsRawForCollection(); // some flags are collected (eg use 64-bit), some provided (eg allow refactoring)
     uint64_t GetShaderFlagsRaw() const;
     void SetShaderFlagsRaw(uint64_t data);
@@ -310,7 +313,9 @@ public:
     unsigned m_bViewID : 1;           // SHADER_FEATURE_VIEWID
     unsigned m_bBarycentrics : 1;     // SHADER_FEATURE_BARYCENTRICS
 
-    unsigned m_align0 : 9;        // align to 32 bit.
+    unsigned m_bUseStrictHalf : 1; // TODO: comment corresponding shader feature enum name
+
+    unsigned m_align0 : 8;        // align to 32 bit.
     uint32_t m_align1;            // align to 64 bit.
   };
 

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -59,7 +59,8 @@ struct HLOptions {
   unsigned bLegacyCBufferLoad      : 1;
   unsigned PackingStrategy         : 2;
   static_assert((unsigned)DXIL::PackingStrategy::Invalid < 4, "otherwise 2 bits is not enough to store PackingStrategy");
-  unsigned unused                  : 25;
+  unsigned bUseStrictHalf          : 1;
+  unsigned unused                  : 24;
 };
 
 /// Use this class to manipulate HLDXIR of a shader.

--- a/lib/HLSL/DxilCompType.cpp
+++ b/lib/HLSL/DxilCompType.cpp
@@ -155,6 +155,19 @@ bool CompType::Is64Bit() const {
   }
 }
 
+bool CompType::Is16Bit() const {
+  switch (m_Kind) {
+  case DXIL::ComponentType::F16:
+  case DXIL::ComponentType::I16:
+  case DXIL::ComponentType::SNormF16:
+  case DXIL::ComponentType::UNormF16:
+  case DXIL::ComponentType::U16:
+    return true;
+  default:
+    return false;
+  }
+}
+
 CompType CompType::GetBaseCompType() const {
   switch (m_Kind) {
   case Kind::I1:        return CompType(Kind::I1);

--- a/lib/HLSL/DxilCompType.cpp
+++ b/lib/HLSL/DxilCompType.cpp
@@ -298,7 +298,7 @@ const char *CompType::GetName() const {
 static const char *s_TypeKindHLSLNames[(unsigned)CompType::Kind::LastEntry] = {
   "unknown",
   "bool", "min16i", "min16ui", "int", "uint", "int64_t", "uint64_t",
-  "min16f", "float", "double",
+  "half", "float", "double",
   "snorm_min16f", "unorm_min16f", "snorm_float", "unorm_float", "snorm_double", "unorm_double",
 };
 

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -177,6 +177,8 @@ void InitDxilModuleFromHLModule(HLModule &H, DxilModule &M, DxilEntrySignature *
   //bool m_bEnableMSAD;
   //M.m_ShaderFlags.SetAllResourcesBound(H.GetHLOptions().bAllResourcesBound);
 
+  M.m_ShaderFlags.SetUseStrictHalf(H.GetHLOptions().bUseStrictHalf);
+
   if (FnProps)
     M.SetShaderProperties(FnProps);
 

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -940,15 +940,22 @@ Type *OP::GetCBufferRetType(Type *pOverloadType) {
   if (m_pCBufferRetType[TypeSlot] == nullptr) {
     string TypeName("dx.types.CBufRet.");
     TypeName += GetOverloadTypeName(TypeSlot);
-    if (!pOverloadType->isDoubleTy()) {
-      Type *FieldTypes[4] = { pOverloadType, pOverloadType, pOverloadType, pOverloadType };
-      m_pCBufferRetType[TypeSlot] = GetOrCreateStructType(m_Ctx, FieldTypes, TypeName, m_pModule);
-    } else {
+    if (pOverloadType->isDoubleTy()) {
       Type *FieldTypes[2] = { pOverloadType, pOverloadType };
       m_pCBufferRetType[TypeSlot] = GetOrCreateStructType(m_Ctx, FieldTypes, TypeName, m_pModule);
     }
+    else if (pOverloadType->isHalfTy()) {
+      Type *FieldTypes[8] = {
+          pOverloadType, pOverloadType, pOverloadType, pOverloadType,
+          pOverloadType, pOverloadType, pOverloadType, pOverloadType,
+      };
+      m_pCBufferRetType[TypeSlot] = GetOrCreateStructType(m_Ctx, FieldTypes, TypeName, m_pModule);
+    }
+    else {
+      Type *FieldTypes[4] = { pOverloadType, pOverloadType, pOverloadType, pOverloadType };
+      m_pCBufferRetType[TypeSlot] = GetOrCreateStructType(m_Ctx, FieldTypes, TypeName, m_pModule);
+    }
   }
-
   return m_pCBufferRetType[TypeSlot];
 }
 

--- a/lib/HLSL/DxilUtil.cpp
+++ b/lib/HLSL/DxilUtil.cpp
@@ -40,7 +40,8 @@ GetLegacyCBufferFieldElementSize(DxilFieldAnnotation &fieldAnnotation,
   }
 
   // Bytes.
-  unsigned compSize = fieldAnnotation.GetCompType().Is64Bit()?8:4;
+  CompType compType = fieldAnnotation.GetCompType();
+  unsigned compSize = compType.Is64Bit() ? 8 : compType.Is16Bit() ? 2 : 4;
   unsigned fieldSize = compSize;
   if (Ty->isVectorTy()) {
     fieldSize *= Ty->getVectorNumElements();

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1999,7 +1999,8 @@ static bool IsDxilBuiltinStructType(StructType *ST, hlsl::OP *hlslOP) {
   unsigned EltNum = ST->getNumElements();
   switch (EltNum) {
   case 2:
-  case 4: {
+  case 4:
+  case 8: { // 2 for doubles, 8 for halfs.
     Type *EltTy = ST->getElementType(0);
     return ST == hlslOP->GetCBufferRetType(EltTy);
   } break;

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -4787,15 +4787,18 @@ Value *GenerateCBLoadLegacy(Value *handle, Value *legacyIdx,
                             unsigned channelOffset, Type *EltTy,
                             unsigned vecSize, OP *hlslOP,
                             IRBuilder<> &Builder) {
-  DXASSERT((channelOffset + vecSize) <= 4, "legacy cbuffer don't across 16 bytes register.");
   Constant *OpArg = hlslOP->GetU32Const((unsigned)OP::OpCode::CBufferLoadLegacy);
 
   Type *i1Ty = Type::getInt1Ty(EltTy->getContext());
   Type *doubleTy = Type::getDoubleTy(EltTy->getContext());
   Type *i64Ty = Type::getInt64Ty(EltTy->getContext());
+  Type *halfTy = Type::getHalfTy(EltTy->getContext());
+
   bool isBool = EltTy == i1Ty;
   bool is64 = (EltTy == doubleTy) | (EltTy == i64Ty);
-  bool isNormal = !isBool && !is64;
+  bool is16 = (EltTy == halfTy);
+  bool isNormal = !isBool && !is64 && !is16;
+  DXASSERT(is16 || (channelOffset + vecSize) <= 4, "legacy cbuffer don't across 16 bytes register.");
   if (isNormal) {
     Function *CBLoad = hlslOP->GetOpFunc(OP::OpCode::CBufferLoadLegacy, EltTy);
     Value *loadLegacy = Builder.CreateCall(CBLoad, {OpArg, handle, legacyIdx});
@@ -4805,9 +4808,20 @@ Value *GenerateCBLoadLegacy(Value *handle, Value *legacyIdx,
       Result = Builder.CreateInsertElement(Result, NewElt, i);
     }
     return Result;
-  } else if (is64) {
+  } else if (is16) {
     Function *CBLoad = hlslOP->GetOpFunc(OP::OpCode::CBufferLoadLegacy, EltTy);
     Value *loadLegacy = Builder.CreateCall(CBLoad, {OpArg, handle, legacyIdx});
+    Value *Result = UndefValue::get(VectorType::get(EltTy, vecSize));
+    // index aligned by 2 bytes not 4 bytes
+    channelOffset *= 2;
+    for (unsigned i = 0; i < vecSize; ++i) {
+      Value *NewElt = Builder.CreateExtractValue(loadLegacy, channelOffset + i);
+      Result = Builder.CreateInsertElement(Result, NewElt, i);
+    }
+    return Result;
+  } else if (is64) {
+    Function *CBLoad = hlslOP->GetOpFunc(OP::OpCode::CBufferLoadLegacy, EltTy);
+    Value *loadLegacy = Builder.CreateCall(CBLoad, { OpArg, handle, legacyIdx });
     Value *Result = UndefValue::get(VectorType::get(EltTy, vecSize));
     unsigned smallVecSize = 2;
     if (vecSize < smallVecSize)

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -311,7 +311,7 @@ void clang::CompileRootSignature(
 //
 CGMSHLSLRuntime::CGMSHLSLRuntime(CodeGenModule &CGM)
     : CGHLSLRuntime(CGM), Context(CGM.getLLVMContext()), EntryFunc(nullptr),
-      TheModule(CGM.getModule()), legacyLayout(HLModule::GetLegacyDataLayoutDesc()),
+      TheModule(CGM.getModule()), legacyLayout(HLModule::GetLegacyDataLayoutDesc(), CGM.getLangOpts().NoMinPrecision),
       CBufferType(
           llvm::StructType::create(TheModule.getContext(), "ConstantBuffer")) {
   const hlsl::ShaderModel *SM =
@@ -348,6 +348,7 @@ CGMSHLSLRuntime::CGMSHLSLRuntime(CodeGenModule &CGM)
   opts.bLegacyCBufferLoad = !CGM.getCodeGenOpts().HLSLNotUseLegacyCBufLoad;
   opts.bAllResourcesBound = CGM.getCodeGenOpts().HLSLAllResourcesBound;
   opts.PackingStrategy = CGM.getCodeGenOpts().HLSLSignaturePackingStrategy;
+
   m_pHLModule->SetHLOptions(opts);
 
   m_pHLModule->SetValidatorVersion(CGM.getCodeGenOpts().HLSLValidatorMajorVer, CGM.getCodeGenOpts().HLSLValidatorMinorVer);
@@ -385,6 +386,7 @@ CGMSHLSLRuntime::CGMSHLSLRuntime(CodeGenModule &CGM)
 
   // set Float Denorm Mode
   m_pHLModule->SetFPDenormMode(CGM.getCodeGenOpts().HLSLFlushFPDenorm);
+
 }
 
 bool CGMSHLSLRuntime::IsHlslObjectType(llvm::Type *Ty) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -349,6 +349,8 @@ CGMSHLSLRuntime::CGMSHLSLRuntime(CodeGenModule &CGM)
   opts.bAllResourcesBound = CGM.getCodeGenOpts().HLSLAllResourcesBound;
   opts.PackingStrategy = CGM.getCodeGenOpts().HLSLSignaturePackingStrategy;
 
+  opts.bUseStrictHalf = CGM.getLangOpts().NoMinPrecision;
+
   m_pHLModule->SetHLOptions(opts);
 
   m_pHLModule->SetValidatorVersion(CGM.getCodeGenOpts().HLSLValidatorMajorVer, CGM.getCodeGenOpts().HLSLValidatorMinorVer);

--- a/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
@@ -56,4 +56,4 @@ cbuffer Foo {
 
 float4 main() : SV_Target {
   return h1 + f3.x + h2.x + h2.y + f3_1.z + f2.x + h4.x + h4.y + h4.z + h4.w + h2_1.x + h2_1.y + h3.x + h3.y + h3.z + d1;
-}}
+}

--- a/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
@@ -1,19 +1,20 @@
 // RUN: %dxc -E main -T ps_6_0 -no-min-precision %s | FileCheck %s
 
+// CHECK: Strict half
 // CHECK: cbuffer Foo
 // CHECK: {
 // CHECK:   struct dx.alignment.legacy.Foo
 // CHECK:   {
-// CHECK:       min16f h1;                                    ; Offset:    0
-// CHECK:       float3 f3;                                    ; Offset:    4
-// CHECK:       min16f2 h2;                                   ; Offset:   16
-// CHECK:       float3 f3_1;                                  ; Offset:   20
-// CHECK:       float2 f2;                                    ; Offset:   32
-// CHECK:       min16f4 h4;                                   ; Offset:   40
-// CHECK:       min16f2 h2_1;                                 ; Offset:   48
-// CHECK:       min16f3 h3;                                   ; Offset:   52
-// CHECK:       double d1;                                    ; Offset:   64
-// CHECK:   } Foo                                             ; Offset:    0 Size:    72
+// CHECK:       half h1;                                    ; Offset:    0
+// CHECK:       float3 f3;                                  ; Offset:    4
+// CHECK:       half2 h2;                                   ; Offset:   16
+// CHECK:       float3 f3_1;                                ; Offset:   20
+// CHECK:       float2 f2;                                  ; Offset:   32
+// CHECK:       half4 h4;                                   ; Offset:   40
+// CHECK:       half2 h2_1;                                 ; Offset:   48
+// CHECK:       half3 h3;                                   ; Offset:   52
+// CHECK:       double d1;                                  ; Offset:   64
+// CHECK:   } Foo                                           ; Offset:    0 Size:    72
 // CHECK: }
 
 // CHECK: %Foo_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 2, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)

--- a/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
@@ -1,0 +1,59 @@
+// RUN: %dxc -E main -T ps_6_0 -no-min-precision %s | FileCheck %s
+
+// CHECK: cbuffer Foo
+// CHECK: {
+// CHECK:   struct dx.alignment.legacy.Foo
+// CHECK:   {
+// CHECK:       min16f h1;                                    ; Offset:    0
+// CHECK:       float3 f3;                                    ; Offset:    4
+// CHECK:       min16f2 h2;                                   ; Offset:   16
+// CHECK:       float3 f3_1;                                  ; Offset:   20
+// CHECK:       float2 f2;                                    ; Offset:   32
+// CHECK:       min16f4 h4;                                   ; Offset:   40
+// CHECK:       min16f2 h2_1;                                 ; Offset:   48
+// CHECK:       min16f3 h3;                                   ; Offset:   52
+// CHECK:       double d1;                                    ; Offset:   64
+// CHECK:   } Foo                                             ; Offset:    0 Size:    72
+// CHECK: }
+
+// CHECK: %Foo_buffer = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 2, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f16 @dx.op.cbufferLoadLegacy.f16(i32 59, %dx.types.Handle %Foo_buffer, i32 0)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 0
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %Foo_buffer, i32 0)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f32 {{%[0-9]+}}, 1
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f16 @dx.op.cbufferLoadLegacy.f16(i32 59, %dx.types.Handle %Foo_buffer, i32 1)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 0
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 1
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %Foo_buffer, i32 1)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f32 {{%[0-9]+}}, 3
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %Foo_buffer, i32 2)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f32 {{%[0-9]+}}, 0
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f16 @dx.op.cbufferLoadLegacy.f16(i32 59, %dx.types.Handle %Foo_buffer, i32 2)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 4
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 5
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 6
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 7
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f16 @dx.op.cbufferLoadLegacy.f16(i32 59, %dx.types.Handle %Foo_buffer, i32 3)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 0
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 1
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 2
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 3
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f16 {{%[0-9]+}}, 4
+// CHECK: {{%[0-9]+}} = call %dx.types.CBufRet.f64 @dx.op.cbufferLoadLegacy.f64(i32 59, %dx.types.Handle %Foo_buffer, i32 4)  ; CBufferLoadLegacy(handle,regIndex)
+// CHECK: {{%[0-9]+}} = extractvalue %dx.types.CBufRet.f64 {{%[0-9]+}}, 0
+
+cbuffer Foo {
+  half h1;
+  float3 f3;
+  half2 h2;
+  float3 f3_1;
+  float2 f2;
+  half4 h4;
+  half2 h2_1;
+  half3 h3;
+  double d1;
+}
+
+float4 main() : SV_Target {
+  return h1 + f3.x + h2.x + h2.y + f3_1.z + f2.x + h4.x + h4.y + h4.z + h4.w + h2_1.x + h2_1.y + h3.x + h3.y + h3.z + d1;
+}}

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -313,6 +313,7 @@ PCSTR g_pFeatureInfoNames[] = {
     "64-Bit integer",
     "View Instancing",
     "Barycentrics",
+    "Strict half"
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount, "g_pFeatureInfoNames needs to be updated");
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -481,6 +481,7 @@ public:
   TEST_METHOD(CodeGenCbuffer6_51)
   TEST_METHOD(CodeGenCbufferAlloc)
   TEST_METHOD(CodeGenCbufferAllocLegacy)
+  TEST_METHOD(CodeGenCbufferHalf)
   TEST_METHOD(CodeGenCbufferInLoop)
   TEST_METHOD(CodeGenClass)
   TEST_METHOD(CodeGenClip)
@@ -2974,6 +2975,10 @@ TEST_F(CompilerTest, CodeGenCbufferAlloc) {
 
 TEST_F(CompilerTest, CodeGenCbufferAllocLegacy) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\cbufferAlloc_legacy.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenCbufferHalf) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\cbufferHalf.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenCbufferInLoop) {


### PR DESCRIPTION
For fp16 constant buffer resources, we are still repsecting DWORD alignment with 4 dwords for each row. 
For half2, we will pack them into one dword. For half or half3, we will pad them so that memory layout still aligns with dword.
For fp16 buffer load, CBufRet type will have 8 halfs so that we can extract values with index 0-7.
