### PR TITLE
[spirv] Support texture and sampler types

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -189,10 +189,35 @@ User-defined types
 are type aliases introduced by typedef. No new types are introduced and we can
 rely on Clang to resolve to the original types.
 
-Samplers and textures
-+++++++++++++++++++++
+Samplers
+++++++++
 
-[TODO]
+All `sampler types <https://msdn.microsoft.com/en-us/library/windows/desktop/bb509644(v=vs.85).aspx>`_
+will be translated into SPIR-V ``OpTypeSampler``.
+
+SPIR-V ``OpTypeSampler`` is an opaque type that cannot be parameterized;
+therefore state assignments on sampler types is not supported (yet).
+
+Textures
+++++++++
+
+`Texture types <https://msdn.microsoft.com/en-us/library/windows/desktop/bb509700(v=vs.85).aspx>`_
+are translated into SPIR-V ``OpTypeImage``, with parameters:
+
+====================   ==== ===== ======= == ======= ============
+HLSL Texture Type      Dim  Depth Arrayed MS Sampled Image Format
+====================   ==== ===== ======= == ======= ============
+``Texture1D``          1D    0       0    0    1       Unknown
+``Texture2D``          2D    0       0    0    1       Unknown
+``Texture3D``          3D    0       0    0    1       Unknown
+``TextureCube``        Cube  0       0    0    1       Unknown
+``Texture1DArray``     1D    0       1    0    1       Unknown
+``Texture2DArray``     2D    0       1    0    1       Unknown
+``TextureCubeArray``   3D    0       1    0    1       Unknown
+====================   ==== ===== ======= == ======= ============
+
+The meanings of the headers in the above table is explained in ``OpTypeImage``
+of the SPIR-V spec.
 
 Buffers
 +++++++

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -226,13 +226,14 @@ public:
   uint32_t addStageBuiltinVar(uint32_t type, spv::StorageClass storageClass,
                               spv::BuiltIn);
 
-  /// \brief Adds a file/module visible variable. This variable will have
-  /// Private storage class.
+  /// \brief Adds a module variable. This variable should not have the Function
+  /// storage class.
   ///
   /// The corresponding pointer type of the given type will be constructed in
   /// this method for the variable itself.
-  uint32_t addFileVar(uint32_t valueType, llvm::StringRef name = "",
-                      llvm::Optional<uint32_t> init = llvm::None);
+  uint32_t addModuleVar(uint32_t valueType, spv::StorageClass storageClass,
+                        llvm::StringRef name = "",
+                        llvm::Optional<uint32_t> init = llvm::None);
 
   /// \brief Decorates the given target <result-id> with the given location.
   void decorateLocation(uint32_t targetId, uint32_t location);
@@ -257,6 +258,8 @@ public:
   uint32_t getArrayType(uint32_t elemType, uint32_t count);
   uint32_t getFunctionType(uint32_t returnType,
                            llvm::ArrayRef<uint32_t> paramTypes);
+  uint32_t getImageType(uint32_t sampledType, spv::Dim, bool isArray);
+  uint32_t getSamplerType();
 
   // === Constant ===
   uint32_t getConstantBool(bool value);

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -26,8 +26,9 @@ namespace spirv {
 /// DiagnosticEngine passed into the constructor.
 class TypeTranslator {
 public:
-  TypeTranslator(ModuleBuilder &builder, DiagnosticsEngine &diag)
-      : theBuilder(builder), diags(diag) {}
+  TypeTranslator(ASTContext &context, ModuleBuilder &builder,
+                 DiagnosticsEngine &diag)
+      : astContext(context), theBuilder(builder), diags(diag) {}
 
   /// \brief Generates the corresponding SPIR-V type for the given Clang
   /// frontend type and returns the type's <result-id>. On failure, reports
@@ -101,7 +102,12 @@ private:
     return diags.Report(diagId);
   }
 
+  /// \brief Translates the given HLSL resource type into its SPIR-V
+  /// instructions and returns the <result-id>. Returns 0 on failure.
+  uint32_t translateResourceType(QualType type);
+
 private:
+  ASTContext &astContext;
   ModuleBuilder &theBuilder;
   DiagnosticsEngine &diags;
 };

--- a/tools/clang/test/CodeGenSPIRV/type.sampler.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.sampler.hlsl
@@ -1,0 +1,15 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: %type_sampler = OpTypeSampler
+// CHECK: %_ptr_UniformConstant_type_sampler = OpTypePointer UniformConstant %type_sampler
+
+// CHECK: %s1 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+SamplerState           s1 : register(s1);
+// CHECK: %s2 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+SamplerComparisonState s2 : register(s2);
+// CHECK: %s3 = OpVariable %_ptr_UniformConstant_type_sampler UniformConstant
+sampler                s3 : register(s3);
+
+void main() {
+// CHECK-LABEL: %main = OpFunction
+}

--- a/tools/clang/test/CodeGenSPIRV/type.texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.texture.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpCapability Sampled1D
+
+// CHECK: %type_1d_image = OpTypeImage %float 1D 0 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_1d_image = OpTypePointer UniformConstant %type_1d_image
+
+// CHECK: %type_2d_image = OpTypeImage %int 2D 0 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+
+// CHECK: %type_3d_image = OpTypeImage %uint 3D 0 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_3d_image = OpTypePointer UniformConstant %type_3d_image
+
+// CHECK: %type_cube_image = OpTypeImage %float Cube 0 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_cube_image = OpTypePointer UniformConstant %type_cube_image
+
+// CHECK: %type_1d_image_array = OpTypeImage %float 1D 0 1 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_1d_image_array = OpTypePointer UniformConstant %type_1d_image_array
+
+// CHECK: %type_2d_image_array = OpTypeImage %int 2D 0 1 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_2d_image_array = OpTypePointer UniformConstant %type_2d_image_array
+
+// CHECK: %type_cube_image_array = OpTypeImage %float Cube 0 1 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_cube_image_array = OpTypePointer UniformConstant %type_cube_image_array
+
+// CHECK: %t1 = OpVariable %_ptr_UniformConstant_type_1d_image UniformConstant
+Texture1D   <float4> t1 : register(t1);
+// CHECK: %t2 = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+Texture2D   <int4>   t2 : register(t2);
+// CHECK: %t3 = OpVariable %_ptr_UniformConstant_type_3d_image UniformConstant
+Texture3D   <uint4>  t3 : register(t3);
+// CHECK: %t4 = OpVariable %_ptr_UniformConstant_type_cube_image UniformConstant
+TextureCube <float4> t4 : register(t4);
+
+
+// CHECK: %t5 = OpVariable %_ptr_UniformConstant_type_1d_image_array UniformConstant
+Texture1DArray   <float4> t5 : register(t5);
+// CHECK: %t6 = OpVariable %_ptr_UniformConstant_type_2d_image_array UniformConstant
+Texture2DArray   <int4>   t6 : register(t6);
+// CHECK: %t7 = OpVariable %_ptr_UniformConstant_type_cube_image_array UniformConstant
+TextureCubeArray <float4> t7 : register(t7);
+
+void main() {
+// CHECK-LABEL: %main = OpFunction
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -41,6 +41,8 @@ TEST_F(FileTest, MatrixTypes) { runFileTest("type.matrix.hlsl"); }
 TEST_F(FileTest, StructTypes) { runFileTest("type.struct.hlsl"); }
 TEST_F(FileTest, ArrayTypes) { runFileTest("type.array.hlsl"); }
 TEST_F(FileTest, TypedefTypes) { runFileTest("type.typedef.hlsl"); }
+TEST_F(FileTest, SamplerTypes) { runFileTest("type.sampler.hlsl"); }
+TEST_F(FileTest, TextureTypes) { runFileTest("type.texture.hlsl"); }
 
 // For constants
 TEST_F(FileTest, ScalarConstants) { runFileTest("constant.scalar.hlsl"); }


### PR DESCRIPTION
This commit add support for the following types:
* Texture1D, Texture2D, Texture3D, TextureCube
* Texture1DArray, Texture2DArray, TextureCubeArray
* SamplerState, SamplerComparisonState, sampler

Buffer, Texture2DMS, and Texture2DMSArray is not supported yet,
also setting sampler states.

Texture types will be translated OpTypeImage, and sampler types
will be translated into OpTypeSampler.