### PR TITLE
[spirv] Support six texture methods

### DIFF
--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -144,6 +144,31 @@ public:
   uint32_t createBinaryOp(spv::Op op, uint32_t resultType, uint32_t lhs,
                           uint32_t rhs);
 
+  /// \brief Creates SPIR-V instructions for sampling the given image.
+  ///
+  /// If lod or grad is given a non-zero value, *ExplicitLod variants of
+  /// OpImageSample* will be generated; otherwise, *ImplicitLod variant will
+  /// be generated.
+  ///
+  /// If bias, lod, or grad is given a non-zero value, an additional image
+  /// operands, Bias, Lod, or Grad, will be attached to the current instruction,
+  /// respectively.
+  uint32_t createImageSample(uint32_t texelType, uint32_t imageType,
+                             uint32_t image, uint32_t sampler,
+                             uint32_t coordinate, uint32_t bias, uint32_t lod,
+                             std::pair<uint32_t, uint32_t> grad,
+                             uint32_t offset);
+
+  /// \brief Creates SPIR-V instructions for fetching the given image.
+  uint32_t createImageFetch(uint32_t texelType, uint32_t image,
+                            uint32_t coordinate, uint32_t lod, uint32_t offset);
+
+  /// \brief Creates SPIR-V instructions for sampling the given image.
+  uint32_t createImageGather(uint32_t texelType, uint32_t imageType,
+                             uint32_t image, uint32_t sampler,
+                             uint32_t coordinate, uint32_t component,
+                             uint32_t offset);
+
   /// \brief Creates a select operation with the given values for true and false
   /// cases and returns the <result-id> for the result.
   uint32_t createSelect(uint32_t resultType, uint32_t condition,
@@ -260,6 +285,7 @@ public:
                            llvm::ArrayRef<uint32_t> paramTypes);
   uint32_t getImageType(uint32_t sampledType, spv::Dim, bool isArray);
   uint32_t getSamplerType();
+  uint32_t getSampledImageType(uint32_t imageType);
 
   // === Constant ===
   uint32_t getConstantBool(bool value);

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -91,18 +91,13 @@ private:
   uint32_t doCastExpr(const CastExpr *expr);
   uint32_t doCompoundAssignOperator(const CompoundAssignOperator *expr);
   uint32_t doConditionalOperator(const ConditionalOperator *expr);
+  uint32_t doCXXMemberCallExpr(const CXXMemberCallExpr *expr);
   uint32_t doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr);
   uint32_t doExtMatrixElementExpr(const ExtMatrixElementExpr *expr);
   uint32_t doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr);
   uint32_t doInitListExpr(const InitListExpr *expr);
   uint32_t doMemberExpr(const MemberExpr *expr);
   uint32_t doUnaryOperator(const UnaryOperator *expr);
-
-private:
-  /// Translates the return statement into its SPIR-V equivalent. Also generates
-  /// necessary instructions for the entry function ensuring that the signature
-  /// matches the SPIR-V requirements.
-  void processReturnStmt(const ReturnStmt *stmt);
 
 private:
   /// Translates the given frontend binary operator into its SPIR-V equivalent
@@ -170,6 +165,11 @@ private:
   /// nullptr, writes true to it if the generated instruction is a constant.
   uint32_t createVectorSplat(const Expr *scalarExpr, uint32_t size,
                              bool *resultIsConstant = nullptr);
+
+  /// Splits the given vector into the last element and the rest (as a new
+  /// vector).
+  void splitVecLastElement(QualType vecType, uint32_t vec, uint32_t *residual,
+                           uint32_t *lastElement);
 
   /// Translates a floatN * float multiplication into SPIR-V instructions and
   /// returns the <result-id>. Returns 0 if the given binary operation is not

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather.hlsl
@@ -1,0 +1,27 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+Texture2DArray   <float4> t2 : register(t2);
+TextureCubeArray <float4> t4 : register(t4);
+// .Gather() does not support Texture1DArray.
+
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_0_4
+
+float4 main(float3 location: A) : SV_Target {
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT:        [[loc:%\d+]] = OpLoad %v3float %location
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageGather %v4float [[sampledImg]] [[loc]] %int_0
+    float4 val2 = t2.Gather(gSampler, location);
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image_array %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageGather %v4float [[sampledImg]] [[v4fc]] %int_0
+    float4 val4 = t4.Gather(gSampler, float4(0.1, 0.2, 0.3, 0.4));
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.array.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.load.hlsl
@@ -1,0 +1,29 @@
+// Run: %dxc -T ps_6_0 -E main
+
+Texture1DArray <float4> t1 : register(t1);
+Texture2DArray <float4> t2 : register(t2);
+// .Load() does not support TextureCubeArray.
+
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_1 %int_2 %int_3
+
+float4 main(int4 location: A) : SV_Target {
+
+// CHECK:         [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
+// CHECK-NEXT: [[coord:%\d+]] = OpVectorShuffle %v2int [[v3ic]] [[v3ic]] 0 1
+// CHECK-NEXT:   [[lod:%\d+]] = OpCompositeExtract %int [[v3ic]] 2
+// CHECK-NEXT:       {{%\d+}} = OpImageFetch %v4float [[t1]] [[coord]] Lod|ConstOffset [[lod]] %int_10
+    float4 val1 = t1.Load(int3(1, 2, 3), 10);
+
+// CHECK:         [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[loc:%\d+]] = OpLoad %v4int %location
+// CHECK-NEXT: [[coord:%\d+]] = OpVectorShuffle %v3int [[loc]] [[loc]] 0 1 2
+// CHECK-NEXT:   [[lod:%\d+]] = OpCompositeExtract %int [[loc]] 3
+// CHECK-NEXT:       {{%\d+}} = OpImageFetch %v4float [[t2]] [[coord]] Lod [[lod]]
+    float4 val2 = t2.Load(location);
+
+    return 1.0;
+}
+
+
+
+

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1DArray   <float4> t1 : register(t1);
+Texture2DArray   <float4> t2 : register(t2);
+TextureCubeArray <float4> t3 : register(t3);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v2fc]] Bias|ConstOffset %float_0_5 %int_1
+    float4 val1 = t1.SampleBias(gSampler, float2(0.1, 1), 0.5, 1);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]] Bias %float_0_5
+    float4 val2 = t2.SampleBias(gSampler, float3(0.1, 0.2, 1), 0.5);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_cube_image_array %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v4fc]] Bias %float_0_5
+    float4 val3 = t3.SampleBias(gSampler, float4(0.1, 0.2, 0.3, 1), 0.5);
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
@@ -1,0 +1,43 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1DArray   <float4> t1 : register(t1);
+Texture2DArray   <float4> t2 : register(t2);
+TextureCubeArray <float4> t3 : register(t3);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image
+
+// CHECK: [[v2f_0_1:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_1
+// CHECK: [[v3f_0_1:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_1 %float_0_1
+// CHECK: [[v2f_0_2:%\d+]] = OpConstantComposite %v2float %float_0_2 %float_0_2
+// CHECK: [[v2f_0_3:%\d+]] = OpConstantComposite %v2float %float_0_3 %float_0_3
+// CHECK: [[v4f_0_1:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_1 %float_0_1 %float_0_1
+// CHECK: [[v3f_0_2:%\d+]] = OpConstantComposite %v3float %float_0_2 %float_0_2 %float_0_2
+// CHECK: [[v3f_0_3:%\d+]] = OpConstantComposite %v3float %float_0_3 %float_0_3 %float_0_3
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v2f_0_1]] Grad|ConstOffset %float_0_2 %float_0_3 %int_1
+    float4 val1 = t1.SampleGrad(gSampler, float2(0.1, 0.1), 0.2, 0.3, 1);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3f_0_1]] Grad [[v2f_0_2]] [[v2f_0_3]]
+    float4 val2 = t2.SampleGrad(gSampler, float3(0.1, 0.1, 0.1), float2(0.2, 0.2), float2(0.3, 0.3));
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_cube_image_array %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v4f_0_1]] Grad [[v3f_0_2]] [[v3f_0_3]]
+    float4 val3 = t3.SampleGrad(gSampler, float4(0.1, 0.1, 0.1, 0.1), float3(0.2, 0.2, 0.2), float3(0.3, 0.3, 0.3));
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1DArray   <float4> t1 : register(t1);
+Texture2DArray   <float4> t2 : register(t2);
+TextureCubeArray <float4> t3 : register(t3);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v2fc]] Lod|ConstOffset %float_10 %int_1
+    float4 val1 = t1.SampleLevel(gSampler, float2(0.1, 1), 10, 1);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3fc]] Lod %float_20
+    float4 val2 = t2.SampleLevel(gSampler, float3(0.1, 0.2, 1), 20);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_cube_image_array %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v4fc]] Lod %float_30
+    float4 val3 = t3.SampleLevel(gSampler, float4(0.1, 0.2, 0.3, 1), 30);
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1DArray   <float4> t1 : register(t1);
+Texture2DArray   <float4> t2 : register(t2);
+TextureCubeArray <float4> t3 : register(t3);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v2fc]] ConstOffset %int_1
+    float4 val1 = t1.Sample(gSampler, float2(0.1, 1), 1);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image_array %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]]
+    float4 val2 = t2.Sample(gSampler, float3(0.1, 0.2, 1));
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_cube_image_array %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v4fc]]
+    float4 val3 = t3.Sample(gSampler, float4(0.1, 0.2, 0.3, 1));
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.gather.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather.hlsl
@@ -1,0 +1,28 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+Texture2D   <float4> t2 : register(t2);
+TextureCube <float4> t4 : register(t4);
+// .Gather() does not support Texture1D and Texture3D.
+
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
+float4 main(float2 location: A) : SV_Target {
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT:        [[loc:%\d+]] = OpLoad %v2float %location
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageGather %v4float [[sampledImg]] [[loc]] %int_0 ConstOffset [[v2ic]]
+    float4 val2 = t2.Gather(gSampler, location, int2(1, 2));
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageGather %v4float [[sampledImg]] [[v3fc]] %int_0
+    float4 val4 = t4.Gather(gSampler, float3(0.1, 0.2, 0.3));
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.load.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T ps_6_0 -E main
+
+Texture1D <float4> t1 : register(t1);
+Texture2D <float4> t2 : register(t2);
+Texture3D <float4> t3 : register(t3);
+// .Load() does not support TextureCube.
+
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
+// CHECK: [[v4ic:%\d+]] = OpConstantComposite %v4int %int_1 %int_2 %int_3 %int_4
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+float4 main(int3 location: A) : SV_Target {
+
+// CHECK:         [[t1:%\d+]] = OpLoad %type_1d_image %t1
+// CHECK-NEXT: [[coord:%\d+]] = OpCompositeExtract %int [[v2ic]] 0
+// CHECK-NEXT:   [[lod:%\d+]] = OpCompositeExtract %int [[v2ic]] 1
+// CHECK-NEXT:       {{%\d+}} = OpImageFetch %v4float [[t1]] [[coord]] Lod|ConstOffset [[lod]] %int_1
+    float4 val1 = t1.Load(int2(1, 2), 1);
+
+// CHECK:         [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[loc:%\d+]] = OpLoad %v3int %location
+// CHECK-NEXT: [[coord:%\d+]] = OpVectorShuffle %v2int [[loc]] [[loc]] 0 1
+// CHECK-NEXT:   [[lod:%\d+]] = OpCompositeExtract %int [[loc]] 2
+// CHECK-NEXT:       {{%\d+}} = OpImageFetch %v4float [[t2]] [[coord]] Lod [[lod]]
+    float4 val2 = t2.Load(location);
+
+// CHECK:         [[t3:%\d+]] = OpLoad %type_3d_image %t3
+// CHECK-NEXT: [[coord:%\d+]] = OpVectorShuffle %v3int [[v4ic]] [[v4ic]] 0 1 2
+// CHECK-NEXT:   [[lod:%\d+]] = OpCompositeExtract %int [[v4ic]] 3
+// CHECK-NEXT:       {{%\d+}} = OpImageFetch %v4float [[t3]] [[coord]] Lod|ConstOffset [[lod]] [[v3ic]]
+    float4 val3 = t3.Load(int4(1, 2, 3, 4), 3);
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
@@ -1,0 +1,50 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1D   <float4> t1 : register(t1);
+Texture2D   <float4> t2 : register(t2);
+Texture3D   <float4> t3 : register(t3);
+TextureCube <float4> t4 : register(t4);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
+// CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_0_1 Bias %float_0_5
+    float4 val1 = t1.SampleBias(gSampler, 0.1, 0.5);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v2fc]] Bias|ConstOffset %float_0_5 [[v2ic]]
+    float4 val2 = t2.SampleBias(gSampler, float2(0.1, 0.2), 0.5, 2);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_3d_image %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]] Bias|ConstOffset %float_0_5 [[v3ic]]
+    float4 val3 = t3.SampleBias(gSampler, float3(0.1, 0.2, 0.3), 0.5, 3);
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_2 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]] Bias %float_0_5
+    float4 val4 = t4.SampleBias(gSampler, float3(0.1, 0.2, 0.3), 0.5);
+
+    return 1.0;
+}
+
+

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
@@ -1,0 +1,52 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1D   <float4> t1 : register(t1);
+Texture2D   <float4> t2 : register(t2);
+Texture3D   <float4> t3 : register(t3);
+TextureCube <float4> t4 : register(t4);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
+// CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
+
+// CHECK: [[v2f_0_1:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_1
+// CHECK: [[v2f_0_2:%\d+]] = OpConstantComposite %v2float %float_0_2 %float_0_2
+// CHECK: [[v2f_0_3:%\d+]] = OpConstantComposite %v2float %float_0_3 %float_0_3
+// CHECK: [[v2i_2:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+// CHECK: [[v3f_0_1:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_1 %float_0_1
+// CHECK: [[v3f_0_2:%\d+]] = OpConstantComposite %v3float %float_0_2 %float_0_2 %float_0_2
+// CHECK: [[v3f_0_3:%\d+]] = OpConstantComposite %v3float %float_0_3 %float_0_3 %float_0_3
+// CHECK: [[v3i_3:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] %float_0_1 Grad %float_0_2 %float_0_3
+    float4 val1 = t1.SampleGrad(gSampler, 0.1, 0.2, 0.3);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v2f_0_1]] Grad|ConstOffset [[v2f_0_2]] [[v2f_0_3]] [[v2i_2]]
+    float4 val2 = t2.SampleGrad(gSampler, float2(0.1, 0.1), float2(0.2, 0.2), float2(0.3, 0.3), 2);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_3d_image %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3f_0_1]] Grad|ConstOffset [[v3f_0_2]] [[v3f_0_3]] [[v3i_3]]
+    float4 val3 = t3.SampleGrad(gSampler, float3(0.1, 0.1, 0.1), float3(0.2, 0.2, 0.2), float3(0.3, 0.3, 0.3), 3);
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_2 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3f_0_1]] Grad [[v3f_0_2]] [[v3f_0_3]]
+    float4 val4 = t4.SampleGrad(gSampler, float3(0.1, 0.1, 0.1), float3(0.2, 0.2, 0.2), float3(0.3, 0.3, 0.3));
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
@@ -1,0 +1,48 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1D   <float4> t1 : register(t1);
+Texture2D   <float4> t2 : register(t2);
+Texture3D   <float4> t3 : register(t3);
+TextureCube <float4> t4 : register(t4);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
+// CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] %float_0_1 Lod %float_10
+    float4 val1 = t1.SampleLevel(gSampler, 0.1, 10);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v2fc]] Lod|ConstOffset %float_10 [[v2ic]]
+    float4 val2 = t2.SampleLevel(gSampler, float2(0.1, 0.2), 10, 2);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_3d_image %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3fc]] Lod|ConstOffset %float_10 [[v3ic]]
+    float4 val3 = t3.SampleLevel(gSampler, float3(0.1, 0.2, 0.3), 10, 3);
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_2 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleExplicitLod %v4float [[sampledImg]] [[v3fc]] Lod %float_10
+    float4 val4 = t4.SampleLevel(gSampler, float3(0.1, 0.2, 0.3), 10);
+
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
@@ -1,0 +1,48 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState gSampler : register(s1);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1D   <float4> t1 : register(t1);
+Texture2D   <float4> t2 : register(t2);
+Texture3D   <float4> t3 : register(t3);
+TextureCube <float4> t4 : register(t4);
+
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
+// CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
+
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+float4 main() : SV_Target {
+// CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image [[t1]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_0_1
+    float4 val1 = t1.Sample(gSampler, 0.1);
+
+// CHECK:              [[t2:%\d+]] = OpLoad %type_2d_image %t2
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_0 [[t2]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v2fc]] ConstOffset [[v2ic]]
+    float4 val2 = t2.Sample(gSampler, float2(0.1, 0.2), 2);
+
+// CHECK:              [[t3:%\d+]] = OpLoad %type_3d_image %t3
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]] ConstOffset [[v3ic]]
+    float4 val3 = t3.Sample(gSampler, float3(0.1, 0.2, 0.3), 3);
+
+// CHECK:              [[t4:%\d+]] = OpLoad %type_cube_image %t4
+// CHECK-NEXT:   [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_2 [[t4]] [[gSampler]]
+// CHECK-NEXT:            {{%\d+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] [[v3fc]]
+    float4 val4 = t4.Sample(gSampler, float3(0.1, 0.2, 0.3));
+
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -293,6 +293,32 @@ TEST_F(FileTest, SemanticDuplication) {
   runFileTest("semantic.duplication.hlsl", /*expectSuccess*/ false);
 }
 
+// For texture methods
+TEST_F(FileTest, TextureSample) { runFileTest("texture.sample.hlsl"); }
+TEST_F(FileTest, TextureArraySample) {
+  runFileTest("texture.array.sample.hlsl");
+}
+TEST_F(FileTest, TextureLoad) { runFileTest("texture.load.hlsl"); }
+TEST_F(FileTest, TextureArrayLoad) { runFileTest("texture.array.load.hlsl"); }
+TEST_F(FileTest, TextureGather) { runFileTest("texture.gather.hlsl"); }
+TEST_F(FileTest, TextureArrayGather) {
+  runFileTest("texture.array.gather.hlsl");
+}
+TEST_F(FileTest, TextureSampleLevel) {
+  runFileTest("texture.sample-level.hlsl");
+}
+TEST_F(FileTest, TextureArraySampleLevel) {
+  runFileTest("texture.array.sample-level.hlsl");
+}
+TEST_F(FileTest, TextureSampleBias) { runFileTest("texture.sample-bias.hlsl"); }
+TEST_F(FileTest, TextureArraySampleBias) {
+  runFileTest("texture.array.sample-bias.hlsl");
+}
+TEST_F(FileTest, TextureSampleGrad) { runFileTest("texture.sample-grad.hlsl"); }
+TEST_F(FileTest, TextureArraySampleGrad) {
+  runFileTest("texture.array.sample-grad.hlsl");
+}
+
 // For intrinsic functions
 TEST_F(FileTest, IntrinsicsDot) { runFileTest("intrinsics.dot.hlsl"); }
 TEST_F(FileTest, IntrinsicsMul) { runFileTest("intrinsics.mul.hlsl"); }


### PR DESCRIPTION
This commit add support for the following methods on textures:
* .Sample()
* .SampleLevel()
* .SampleGrad()
* .SampleBias()
* .Load()
* .Gather()