### PR TITLE
[spirv] Support setting resource binding numbers

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -54,7 +54,7 @@ For example, to specify the layout of Vulkan resources:
 
 .. code:: hlsl
 
-  [[vk::set(X), vk::binding(Y)]]
+  [[vk::binding(X, Y)]]
   tbuffer TbufOne {
     [[vk::offset(Z)]]
     float4 field;
@@ -70,9 +70,12 @@ For example, to specify the layout of Vulkan resources:
 
 The namespace ``vk`` will be used for all Vulkan attributes:
 
-- ``location(X)``: For specifying the location number on stage input/outuput
-  variables. Allowed on function parameters, function returns, and struct
-  fields.
+- ``location(X)``: For specifying the location (``X``) numbers for stage
+  input/output variables. Allowed on function parameters, function returns,
+  and struct fields.
+- ``binding(X[, Y]): For specifying the descriptor set (``Y``) and binding
+  (``X``) numbers for resource variables. The descriptor set (``Y``) is
+  optional; if missing, it will be 0. Allowed on global variables.
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will
@@ -378,6 +381,38 @@ flattening all structs if structs are used as function parameters or returns.
 
 There is an exception to the above rule for SV_Target[N]. It will always be
 mapped to ``Location`` number N.
+
+HLSL register and Vulkan binding
+++++++++++++++++++++++++++++++++
+
+In shaders for DirectX, resources are accessed via registers; while in shaders
+for Vulkan, it is done via descriptor set and binding numbers. The developer
+can explicitly annotate variables in HLSL to specify descriptor set and binding
+numbers, or leave it to the compiler to derive implicitly from registers.
+The explicit way has precedence over the implicit way. However, a mix of both
+way is not allowed (yet).
+
+Explicit descriptor set and binding number assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``[[vk::binding(X[, Y])]]`` can be attached to global variables to specify the
+descriptor set ``Y`` and binding ``X``. The descriptor set number is optional;
+if missing, it will be zero.
+
+Implicit descriptor set and binding number assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Without explicit annotations, the compiler will try to deduce descriptor set and
+binding numbers in the following way:
+
+If there is ``:register(xX, spaceY)`` specified for the given global variable,
+the corresponding resource will be assigned to descriptor set ``Y`` and binding
+number ``X``, regardless the resource type `x`. (Note that this can cause
+reassignment of the same set and binding number pair. TODO)
+
+If there is no register specification, the corresponding resource will be
+assigned to the next available binding number, starting from 0, in descriptor
+set #0.
 
 HLSL expressions
 ----------------

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -863,6 +863,14 @@ def VKLocation : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKBinding : InheritableAttr {
+  let Spellings = [CXX11<"vk", "binding">];
+  let Subjects = SubjectList<[GlobalVar], ErrorDiag, "ExpectedVariable">;
+  let Args = [IntArgument<"Binding">, DefaultIntArgument<"Set", 0>];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 // SPIRV Change Ends
 
 def C11NoReturn : InheritableAttr {

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -238,6 +238,11 @@ public:
   /// \brief Decorates the given target <result-id> with the given location.
   void decorateLocation(uint32_t targetId, uint32_t location);
 
+  /// \brief Decorates the given target <result-id> with the given descriptor
+  /// set and binding number.
+  void decorateDSetBinding(uint32_t targetId, uint32_t setNumber,
+                           uint32_t bindingNumber);
+
   /// \brief Decorates the given target <result-id> with the given decoration
   /// (without additional parameters).
   void decorate(uint32_t targetId, spv::Decoration);

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -355,6 +355,15 @@ uint32_t ModuleBuilder::addModuleVar(uint32_t type, spv::StorageClass sc,
   return varId;
 }
 
+void ModuleBuilder::decorateDSetBinding(uint32_t targetId, uint32_t setNumber,
+                                        uint32_t bindingNumber) {
+  const auto *d = Decoration::getDescriptorSet(theContext, setNumber);
+  theModule.addDecoration(*d, targetId);
+
+  d = Decoration::getBinding(theContext, bindingNumber);
+  theModule.addDecoration(*d, targetId);
+}
+
 void ModuleBuilder::decorateLocation(uint32_t targetId, uint32_t location) {
   const Decoration *d =
       Decoration::getLocation(theContext, location, llvm::None);

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -185,6 +185,10 @@ void SPIRVEmitter::HandleTranslationUnit(ASTContext &context) {
   if (!declIdMapper.decorateStageIOLocations())
     return;
 
+  // Add descriptor set and binding decorations to resource variables.
+  if (!declIdMapper.decorateResourceBindings())
+    return;
+
   // Output the constructed module.
   std::vector<uint32_t> m = theBuilder.takeModule();
   theCompilerInstance.getOutStream()->write(

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10166,9 +10166,14 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
   switch (A.getKind())
   {
   case AttributeList::AT_VKLocation:
-	  declAttr = ::new (S.Context) VKLocationAttr(A.getRange(), S.Context,
-		  ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
-	  break;
+    declAttr = ::new (S.Context) VKLocationAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+    break;
+  case AttributeList::AT_VKBinding:
+    declAttr = ::new (S.Context) VKBindingAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), ValidateAttributeIntArg(S, A, 1),
+      A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
@@ -1,0 +1,24 @@
+// Run: %dxc -T ps_6_0 -E main
+
+[[vk::binding(1)]]
+SamplerState sampler1      : register(s1, space1);
+
+[[vk::binding(3, 1)]]
+SamplerState sampler2      : register(s2);
+
+[[vk::binding(1)]] // duplicate
+Texture2D<float4> texture1;
+
+[[vk::binding(3, 1)]] // duplicate
+Texture3D<float4> texture2 : register(t0, space0);
+
+[[vk::binding(3, 1)]] // duplicate
+Texture3D<float4> texture3 : register(t0, space0);
+
+float4 main() : SV_Target {
+    return 1.0;
+}
+
+// CHECK: :9:3: error: resource binding #1 in descriptor set #0 already assigned
+// CHECK: :12:3: error: resource binding #3 in descriptor set #1 already assigned
+// CHECK: :15:3: error: resource binding #3 in descriptor set #1 already assigned

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -1,0 +1,25 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK:      OpDecorate %sampler1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler1 Binding 0
+[[vk::binding(0)]]
+SamplerState sampler1      : register(s1, space1);
+
+// CHECK:      OpDecorate %sampler2 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %sampler2 Binding 3
+[[vk::binding(3, 1)]]
+SamplerState sampler2      : register(s2);
+
+// CHECK:      OpDecorate %texture1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %texture1 Binding 5
+[[vk::binding(5)]]
+Texture2D<float4> texture1;
+
+// CHECK:      OpDecorate %texture2 DescriptorSet 2
+// CHECK-NEXT: OpDecorate %texture2 Binding 2
+[[vk::binding(2, 2)]]
+Texture3D<float4> texture2 : register(t0, space0);
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
@@ -1,0 +1,22 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK:      OpDecorate %sampler1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler1 Binding 0
+SamplerState sampler1;
+
+// CHECK:      OpDecorate %texture1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %texture1 Binding 1
+Texture2D<float4> texture1;
+
+// CHECK:      OpDecorate %texture2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %texture2 Binding 2
+Texture3D<float4> texture2;
+
+// CHECK:      OpDecorate %sampler2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler2 Binding 3
+SamplerState sampler2;
+
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK:      OpDecorate %sampler1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler1 Binding 1
+SamplerState sampler1: register(s1);
+
+// CHECK:      OpDecorate %sampler2 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %sampler2 Binding 2
+SamplerState sampler2 : register(s2, space1);
+
+// Note: overlapping set # and binding # for now.
+// CHECK:      OpDecorate %texture1 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %texture1 Binding 2
+Texture2D<float4> texture1: register(t2, space1);
+
+// Note: overlapping set # and binding # for now.
+// CHECK:      OpDecorate %texture2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %texture2 Binding 1
+Texture3D<float4> texture2: register(t1);
+
+// Note: using the next available binding #
+// CHECK:      OpDecorate %sampler3 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler3 Binding 0
+SamplerState sampler3;
+
+// Note: using the next available binding #
+// CHECK:      OpDecorate %sampler4 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sampler4 Binding 2
+SamplerState sampler4;
+
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -346,12 +346,14 @@ TEST_F(FileTest, IntrinsicsAtan) { runFileTest("intrinsics.atan.hlsl"); }
 
 // Vulkan/SPIR-V specific
 TEST_F(FileTest, SpirvStorageClass) { runFileTest("spirv.storage-class.hlsl"); }
+
 TEST_F(FileTest, SpirvEntryFunctionWrapper) {
   runFileTest("spirv.entry-function.wrapper.hlsl");
 }
 TEST_F(FileTest, SpirvEntryFunctionInOut) {
   runFileTest("spirv.entry-function.inout.hlsl");
 }
+
 TEST_F(FileTest, VulkanLocation) { runFileTest("vk.location.hlsl"); }
 TEST_F(FileTest, VulkanLocationInputExplicitOutputImplicit) {
   runFileTest("vk.location.exp-in.hlsl");
@@ -368,11 +370,28 @@ TEST_F(FileTest, VulkanLocationReassigned) {
 TEST_F(FileTest, VulkanLocationPartiallyAssigned) {
   runFileTest("vk.location.mixed.hlsl", /*expectSuccess*/ false);
 }
+
 TEST_F(FileTest, SpirvInterpolation) {
   runFileTest("spirv.interpolation.hlsl");
 }
 TEST_F(FileTest, SpirvInterpolationError) {
   runFileTest("spirv.interpolation.error.hlsl", /*expectSuccess*/ false);
+}
+
+TEST_F(FileTest, VulkanExplicitBinding) {
+  // Resource binding from [[vk::binding()]]
+  runFileTest("vk.binding.explicit.hlsl");
+}
+TEST_F(FileTest, VulkanImplicitBinding) {
+  // Resource binding from neither [[vk::binding()]] or :register()
+  runFileTest("vk.binding.implicit.hlsl");
+}
+TEST_F(FileTest, VulkanRegisterBinding) {
+  // Resource binding from :register()
+  runFileTest("vk.binding.register.hlsl");
+}
+TEST_F(FileTest, VulkanExplicitBindingReassigned) {
+  runFileTest("vk.binding.explicit.error.hlsl", /*expectSuccess*/ false);
 }
 
 } // namespace


### PR DESCRIPTION
This commit add support for resource binding number assignment via
both the explicit and the implicit way.

The explicit way:

[[vk::binding(X[, Y])]] is introduced, with X denoting the binding
number and the optional Y denoting the set number. If Y is missing,
the set number will be set to 0. This attribute can only be attached
to variables.

The implicit way:

register(xX, spaceY) will be used to deduce the correct set and
binding number for a given resource. X will be used as the binding
number and Y will be used as the set number. Right now we do not
consider the resource type x, which means binding numbers can
overlap given the same X and Y but not x. That is to be addressed
later.