### PR TITLE
[spirv] Add support for (RW)StructuredBuffer

### DIFF
--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -289,6 +289,8 @@ public:
                          Type::DecorationSet decorations = {});
   uint32_t getArrayType(uint32_t elemType, uint32_t count,
                         Type::DecorationSet decorations = {});
+  uint32_t getRuntimeArrayType(uint32_t elemType,
+                               Type::DecorationSet decorations = {});
   uint32_t getFunctionType(uint32_t returnType,
                            llvm::ArrayRef<uint32_t> paramTypes);
   uint32_t getImageType(uint32_t sampledType, spv::Dim, uint32_t depth,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -146,7 +146,7 @@ public:
                          llvm::Optional<uint32_t> init);
 
   /// \brief Creates an external-visible variable and returns its <result-id>.
-  uint32_t createExternVar(uint32_t varType, const VarDecl *var);
+  uint32_t createExternVar(const VarDecl *var);
 
   /// \brief Creates a cbuffer/tbuffer from the given decl.
   ///

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -613,6 +613,14 @@ uint32_t ModuleBuilder::getArrayType(uint32_t elemType, uint32_t count,
   return typeId;
 }
 
+uint32_t ModuleBuilder::getRuntimeArrayType(uint32_t elemType,
+                                            Type::DecorationSet decorations) {
+  const Type *type = Type::getRuntimeArray(theContext, elemType, decorations);
+  const uint32_t typeId = theContext.getResultIdForType(type);
+  theModule.addType(type, typeId);
+  return typeId;
+}
+
 uint32_t ModuleBuilder::getFunctionType(uint32_t returnType,
                                         llvm::ArrayRef<uint32_t> paramTypes) {
   const Type *type = Type::getFunction(theContext, returnType, paramTypes);

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -135,24 +135,6 @@ private:
   ///   the original vector, no shuffling needed).
   bool isVectorShuffle(const Expr *expr);
 
-  /// Returns true if the given CXXOperatorCallExpr is indexing into a vector or
-  /// matrix using operator[].
-  /// On success, writes the base vector/matrix into *base, and the indices into
-  /// *index0 and *index1, if there are two levels of indexing. If there is only
-  /// one level of indexing, writes the index into *index0 and nullptr into
-  /// *index1.
-  ///
-  /// matrix [index0] [index1]         vector [index0]
-  /// +-------------+
-  ///  vector                     or
-  /// +----------------------+         +-------------+
-  ///         scalar                        scalar
-  ///
-  /// Assumes base, index0, and index1 are not nullptr.
-  bool isVecMatIndexing(const CXXOperatorCallExpr *vecIndexExpr,
-                        const Expr **base, const Expr **index0,
-                        const Expr **index1);
-
   /// \brief Returns true if the given CXXOperatorCallExpr is indexing into a
   /// Buffer/RWBuffer using operator[].
   /// On success, writes the base buffer into *base if base is not nullptr, and
@@ -221,8 +203,8 @@ private:
                                  const BinaryOperatorKind opcode);
 
   /// Collects all indices (SPIR-V constant values) from consecutive MemberExprs
-  /// or ArraySubscriptExprs and writes into indices. Returns the real base
-  /// (the first Expr that is not a MemberExpr or ArraySubscriptExpr).
+  /// or ArraySubscriptExprs or operator[] calls and writes into indices.
+  /// Returns the real base.
   const Expr *
   collectArrayStructIndices(const Expr *expr,
                             llvm::SmallVectorImpl<uint32_t> *indices);
@@ -437,6 +419,10 @@ private:
   /// given location. The type of the loaded element matches the type in the
   /// declaration for the (RW)Buffer object.
   uint32_t processBufferLoad(const Expr *object, const Expr *address);
+
+  /// \brief Generates an OpAccessChain instruction for the given
+  /// (RW)StructuredBuffer.Load() method call.
+  uint32_t processStructuredBufferLoad(const CXXMemberCallExpr *expr);
 
 private:
   /// \brief Wrapper method to create an error message and report it

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -34,7 +34,7 @@ inline void roundToPow2(uint32_t *val, uint32_t pow2) {
 }
 } // anonymous namespace
 
-uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
+uint32_t TypeTranslator::translateType(QualType type, LayoutRule rule,
                                        bool isRowMajor) {
   // We can only apply row_major to matrices or arrays of matrices.
   if (isRowMajor)
@@ -43,7 +43,7 @@ uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
   // Try to translate the canonical type first
   const auto canonicalType = type.getCanonicalType();
   if (canonicalType != type)
-    return translateType(canonicalType, decorateLayout, isRowMajor);
+    return translateType(canonicalType, rule, isRowMajor);
 
   // Primitive types
   {
@@ -70,7 +70,7 @@ uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
 
   // Typedefs
   if (const auto *typedefType = type->getAs<TypedefType>())
-    return translateType(typedefType->desugar(), decorateLayout, isRowMajor);
+    return translateType(typedefType->desugar(), rule, isRowMajor);
 
   // Reference types
   if (const auto *refType = type->getAs<ReferenceType>()) {
@@ -80,7 +80,7 @@ uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
     // We already pass function arguments via pointers to tempoary local
     // variables. So it should be fine to drop the pointer type and treat it
     // as the underlying pointee type here.
-    return translateType(refType->getPointeeType(), decorateLayout, isRowMajor);
+    return translateType(refType->getPointeeType(), rule, isRowMajor);
   }
 
   // In AST, vector/matrix types are TypedefType of TemplateSpecializationType.
@@ -126,21 +126,21 @@ uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
     // (ClassTemplateSpecializationDecl is a subclass of CXXRecordDecl, which is
     // then a subclass of RecordDecl.) So we need to check them before checking
     // the general struct type.
-    if (const auto id = translateResourceType(type))
+    if (const auto id = translateResourceType(type, rule))
       return id;
 
     // Collect all fields' types and names.
     llvm::SmallVector<uint32_t, 4> fieldTypes;
     llvm::SmallVector<llvm::StringRef, 4> fieldNames;
     for (const auto *field : decl->fields()) {
-      fieldTypes.push_back(translateType(field->getType(), decorateLayout,
+      fieldTypes.push_back(translateType(field->getType(), rule,
                                          field->hasAttr<HLSLRowMajorAttr>()));
       fieldNames.push_back(field->getName());
     }
 
     llvm::SmallVector<const Decoration *, 4> decorations;
-    if (decorateLayout) {
-      decorations = getLayoutDecorations(decl);
+    if (rule != LayoutRule::Void) {
+      decorations = getLayoutDecorations(decl, rule);
     }
 
     return theBuilder.getStructType(fieldTypes, decl->getName(), fieldNames,
@@ -149,15 +149,15 @@ uint32_t TypeTranslator::translateType(QualType type, bool decorateLayout,
 
   if (const auto *arrayType = astContext.getAsConstantArrayType(type)) {
     const uint32_t elemType =
-        translateType(arrayType->getElementType(), decorateLayout, isRowMajor);
+        translateType(arrayType->getElementType(), rule, isRowMajor);
     // TODO: handle extra large array size?
     const auto size =
         static_cast<uint32_t>(arrayType->getSize().getZExtValue());
 
     llvm::SmallVector<const Decoration *, 4> decorations;
-    if (decorateLayout) {
+    if (rule != LayoutRule::Void) {
       uint32_t stride = 0;
-      (void)getAlignmentAndSize(type, &stride, isRowMajor);
+      (void)getAlignmentAndSize(type, rule, isRowMajor, &stride);
       decorations.push_back(
           Decoration::getArrayStride(*theBuilder.getSPIRVContext(), stride));
     }
@@ -362,7 +362,7 @@ uint32_t TypeTranslator::getComponentVectorType(QualType matrixType) {
 }
 
 llvm::SmallVector<const Decoration *, 4>
-TypeTranslator::getLayoutDecorations(const DeclContext *decl) {
+TypeTranslator::getLayoutDecorations(const DeclContext *decl, LayoutRule rule) {
   const auto spirvContext = theBuilder.getSPIRVContext();
   llvm::SmallVector<const Decoration *, 4> decorations;
   uint32_t offset = 0, index = 0;
@@ -379,7 +379,7 @@ TypeTranslator::getLayoutDecorations(const DeclContext *decl) {
 
     uint32_t memberAlignment = 0, memberSize = 0, stride = 0;
     std::tie(memberAlignment, memberSize) =
-        getAlignmentAndSize(fieldType, &stride, isRowMajor);
+        getAlignmentAndSize(fieldType, rule, isRowMajor, &stride);
 
     // Each structure-type member must have an Offset Decoration.
     roundToPow2(&offset, memberAlignment);
@@ -398,7 +398,7 @@ TypeTranslator::getLayoutDecorations(const DeclContext *decl) {
     if (isMxNMatrix(fieldType)) {
       memberAlignment = memberSize = stride = 0;
       std::tie(memberAlignment, memberSize) =
-          getAlignmentAndSize(fieldType, &stride, isRowMajor);
+          getAlignmentAndSize(fieldType, rule, isRowMajor, &stride);
 
       decorations.push_back(
           Decoration::getMatrixStride(*spirvContext, stride, index));
@@ -421,7 +421,7 @@ TypeTranslator::getLayoutDecorations(const DeclContext *decl) {
   return decorations;
 }
 
-uint32_t TypeTranslator::translateResourceType(QualType type) {
+uint32_t TypeTranslator::translateResourceType(QualType type, LayoutRule rule) {
   const auto *recordType = type->getAs<RecordType>();
   assert(recordType);
   const llvm::StringRef name = recordType->getDecl()->getName();
@@ -451,6 +451,33 @@ uint32_t TypeTranslator::translateResourceType(QualType type) {
   // Sampler types
   if (name == "SamplerState" || name == "SamplerComparisonState") {
     return theBuilder.getSamplerType();
+  }
+
+  if (name == "StructuredBuffer" || name == "RWStructuredBuffer") {
+    auto &context = *theBuilder.getSPIRVContext();
+    // StructureBuffer<S> will be translated into an OpTypeStruct with one
+    // field, which is an OpTypeRuntimeArray of OpTypeStruct (S).
+
+    const auto s = hlsl::GetHLSLResourceResultType(type);
+    const uint32_t structType = translateType(s, rule);
+    const auto structName = s->getAs<RecordType>()->getDecl()->getName();
+
+    llvm::SmallVector<const Decoration *, 4> decorations;
+    // The stride for the runtime array is the size of S.
+    uint32_t size = 0, stride = 0;
+    std::tie(std::ignore, size) =
+        getAlignmentAndSize(s, rule, /*isRowMajor*/ false, &stride);
+    decorations.push_back(Decoration::getArrayStride(context, size));
+    const uint32_t raType =
+        theBuilder.getRuntimeArrayType(structType, decorations);
+
+    decorations.clear();
+    decorations.push_back(Decoration::getOffset(context, 0, 0));
+    if (!name.startswith("RW"))
+      decorations.push_back(Decoration::getNonWritable(context, 0));
+    decorations.push_back(Decoration::getBufferBlock(context));
+    const std::string typeName = "type." + name.str() + "." + structName.str();
+    return theBuilder.getStructType(raType, typeName, {}, decorations);
   }
 
   // ByteAddressBuffer types.
@@ -503,8 +530,8 @@ TypeTranslator::translateSampledTypeToImageFormat(QualType sampledType) {
 }
 
 std::pair<uint32_t, uint32_t>
-TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
-                                    const bool isRowMajor) {
+TypeTranslator::getAlignmentAndSize(QualType type, LayoutRule rule,
+                                    const bool isRowMajor, uint32_t *stride) {
   // std140 layout rules:
 
   // 1. If the member is a scalar consuming N basic machine units, the base
@@ -555,10 +582,11 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
   //     are laid out in order, according to rule (9).
   const auto canonicalType = type.getCanonicalType();
   if (canonicalType != type)
-    return getAlignmentAndSize(canonicalType, stride, isRowMajor);
+    return getAlignmentAndSize(canonicalType, rule, isRowMajor, stride);
 
   if (const auto *typedefType = type->getAs<TypedefType>())
-    return getAlignmentAndSize(typedefType->desugar(), stride, isRowMajor);
+    return getAlignmentAndSize(typedefType->desugar(), rule, isRowMajor,
+                               stride);
 
   { // Rule 1
     QualType ty = {};
@@ -585,7 +613,7 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
     if (isVectorType(type, &elemType, &elemCount)) {
       uint32_t size = 0;
       std::tie(std::ignore, size) =
-          getAlignmentAndSize(elemType, stride, isRowMajor);
+          getAlignmentAndSize(elemType, rule, isRowMajor, stride);
 
       return {(elemCount == 3 ? 4 : elemCount) * size, elemCount * size};
     }
@@ -597,7 +625,7 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
     if (isMxNMatrix(type, &elemType, &rowCount, &colCount)) {
       uint32_t alignment = 0, size = 0;
       std::tie(alignment, std::ignore) =
-          getAlignmentAndSize(elemType, stride, isRowMajor);
+          getAlignmentAndSize(elemType, rule, isRowMajor, stride);
 
       // Matrices are treated as arrays of vectors:
       // The base alignment and array stride are set to match the base alignment
@@ -605,7 +633,9 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
       // up to the base alignment of a vec4.
       const uint32_t vecStorageSize = isRowMajor ? colCount : rowCount;
       alignment *= (vecStorageSize == 3 ? 4 : vecStorageSize);
-      roundToPow2(&alignment, kStd140Vec4Alignment);
+      if (rule == LayoutRule::GLSLStd140) {
+        roundToPow2(&alignment, kStd140Vec4Alignment);
+      }
       *stride = alignment;
       size = (isRowMajor ? rowCount : colCount) * alignment;
 
@@ -621,7 +651,7 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
     for (const auto *field : structType->getDecl()->fields()) {
       uint32_t memberAlignment = 0, memberSize = 0;
       std::tie(memberAlignment, memberSize) = getAlignmentAndSize(
-          field->getType(), stride, field->hasAttr<HLSLRowMajorAttr>());
+          field->getType(), rule, field->hasAttr<HLSLRowMajorAttr>(), stride);
 
       // The base alignment of the structure is N, where N is the largest
       // base alignment value of any of its members...
@@ -630,8 +660,10 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
       structSize += memberSize;
     }
 
-    // ... and rounded up to the base alignment of a vec4.
-    roundToPow2(&maxAlignment, kStd140Vec4Alignment);
+    if (rule == LayoutRule::GLSLStd140) {
+      // ... and rounded up to the base alignment of a vec4.
+      roundToPow2(&maxAlignment, kStd140Vec4Alignment);
+    }
     // The base offset of the member following the sub-structure is rounded up
     // to the next multiple of the base alignment of the structure.
     roundToPow2(&structSize, maxAlignment);
@@ -641,13 +673,15 @@ TypeTranslator::getAlignmentAndSize(QualType type, uint32_t *stride,
   // Rule 4, 6, 8, and 10
   if (const auto *arrayType = astContext.getAsConstantArrayType(type)) {
     uint32_t alignment = 0, size = 0;
-    std::tie(alignment, size) =
-        getAlignmentAndSize(arrayType->getElementType(), stride, isRowMajor);
+    std::tie(alignment, size) = getAlignmentAndSize(arrayType->getElementType(),
+                                                    rule, isRowMajor, stride);
 
-    // The base alignment and array stride are set to match the base alignment
-    // of a single array element, according to rules 1, 2, and 3, and rounded
-    // up to the base alignment of a vec4.
-    roundToPow2(&alignment, kStd140Vec4Alignment);
+    if (rule == LayoutRule::GLSLStd140) {
+      // The base alignment and array stride are set to match the base alignment
+      // of a single array element, according to rules 1, 2, and 3, and rounded
+      // up to the base alignment of a vec4.
+      roundToPow2(&alignment, kStd140Vec4Alignment);
+    }
     // Need to round size up considering stride for scalar types
     roundToPow2(&size, alignment);
     *stride = size; // Use size instead of alignment here for Rule 10

--- a/tools/clang/test/CodeGenSPIRV/method.structured-buffer.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.structured-buffer.load.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct SBuffer {
+    float4   f1;
+    float2x3 f2[3];
+};
+
+  StructuredBuffer<SBuffer> mySBuffer1;
+RWStructuredBuffer<SBuffer> mySBuffer2;
+
+float4 main(int index: A) : SV_Target {
+    // b1 and b2's type does not need layout decorations. So it's a different
+    // SBuffer definition.
+// XXXXX-NOT:  OpMemberDecorate %SBuffer_0 0 Offset 0
+// XXXXX:      %_ptr_Function_SBuffer_0 = OpTypePointer Function %SBuffer_0
+
+// XXXXX:      %b1 = OpVariable %_ptr_Function_SBuffer_0 Function
+// XXXXX-NEXT: %b2 = OpVariable %_ptr_Function_SBuffer_0 Function
+
+// TODO: wrong codegen right now: missing load the value from sb1 & sb2
+// TODO: need to make sure we have %SBuffer (not %SBuffer_0) as the loaded type
+// XXXXX:      [[index:%\d+]] = OpLoad %int %index
+// XXXXX:      [[sb1:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer1 %int_0 [[index]]
+// XXXXX:      {{%\d+}} = OpLoad %SBuffer [[sb1]]
+// XXXXX:      [[sb2:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer2 %int_0 %int_0
+// XXXXX:      {{%\d+}} = OpLoad %SBuffer [[sb2]]
+    //SBuffer b1 = mySBuffer1.Load(index);
+    //SBuffer b2;
+    //b2 = mySBuffer2.Load(0);
+
+// CHECK:      [[f1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %mySBuffer1 %int_0 %int_5 %int_0
+// CHECK-NEXT: [[x:%\d+]] = OpAccessChain %_ptr_Uniform_float [[f1]] %int_0
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[x]]
+
+// CHECK:      [[index:%\d+]] = OpLoad %int %index
+// CHECK-NEXT: [[f012:%\d+]] = OpAccessChain %_ptr_Uniform_float %mySBuffer2 %int_0 [[index]] %int_1 %int_0 %uint_1 %uint_2
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[f012]]
+    return mySBuffer1.Load(5).f1.x + mySBuffer2.Load(index).f2[0][1][2];
+}

--- a/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
@@ -35,8 +35,7 @@ float main(float val: A, uint index: B) : C {
 // CHECK-NEXT:  [[res:%\d+]] = OpVectorShuffle %v4float [[vec4]] [[vec2]] 0 1 5 4
 // CHECK-NEXT:                 OpStore [[ptr0]] [[res]]
     vecvar[3].ab = val;
-// CHECK-NEXT: [[ptr1:%\d+]] = OpAccessChain %_ptr_Function_v4float %vecvar %int_2
-// CHECK-NEXT: [[ptr2:%\d+]] = OpAccessChain %_ptr_Function_float [[ptr1]] %uint_1
+// CHECK-NEXT: [[ptr2:%\d+]] = OpAccessChain %_ptr_Function_float %vecvar %int_2 %uint_1
 // CHECK-NEXT: [[load:%\d+]] = OpLoad %float [[ptr2]]
 // CHECK-NEXT:                 OpStore %r [[load]]
     r = vecvar[2][1];
@@ -51,8 +50,7 @@ float main(float val: A, uint index: B) : C {
 // CHECK-NEXT: [[ptr2:%\d+]] = OpAccessChain %_ptr_Function_float [[ptr0]] %int_1 %int_2
 // CHECK-NEXT:                 OpStore [[ptr2]] [[val1]]
     matvar[2]._12_23 = val;
-// CHECK-NEXT: [[ptr3:%\d+]] = OpAccessChain %_ptr_Function_mat2v3float %matvar %int_0
-// CHECK-NEXT: [[ptr4:%\d+]] = OpAccessChain %_ptr_Function_float [[ptr3]] %uint_1 %uint_2
+// CHECK-NEXT: [[ptr4:%\d+]] = OpAccessChain %_ptr_Function_float %matvar %int_0 %uint_1 %uint_2
 // CHECK-NEXT: [[load:%\d+]] = OpLoad %float [[ptr4]]
 // CHECK-NEXT:                 OpStore %r [[load]]
     r = matvar[0][1][2];

--- a/tools/clang/test/CodeGenSPIRV/op.constant-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.constant-buffer.access.hlsl
@@ -23,8 +23,7 @@ float main() : A {
 // CHECK-NEXT: [[b0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[b]] %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[b0]]
 
-// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v4float %MyCbuffer %int_2
-// CHECK-NEXT: [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float [[c]] %uint_1 %uint_2
+// CHECK:      [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float %MyCbuffer %int_2 %uint_1 %uint_2
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[c12]]
 
 // CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_float %MyCbuffer %int_3 %int_0

--- a/tools/clang/test/CodeGenSPIRV/op.rw-structured-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.rw-structured-buffer.access.hlsl
@@ -1,0 +1,46 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float  f;
+};
+
+struct T {
+    float    a;
+    float2   b[2];
+    float3x4 c[3];
+    S        s[2];
+    float    t[4];
+};
+
+
+RWStructuredBuffer<T> MySbuffer;
+
+void main(uint index: A) {
+// CHECK:      [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_2 %int_2 %int_2 %uint_1 %uint_2
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[c12]]
+
+// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_3 %int_3 %int_0 %int_0
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[s]]
+    float val = MySbuffer[2].c[2][1][2] + MySbuffer[3].s[0].f;
+
+// CHECK:       [[val:%\d+]] = OpLoad %float %val
+// CHECK-NEXT:  [[index:%\d+]] = OpLoad %uint %index
+
+// CHECK-NEXT:  [[t3:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 [[index]] %int_4 %int_3
+// CHECK-NEXT:  OpStore [[t3]] [[val]]
+
+// CHECK:       [[f:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_3 %int_3 %int_0 %int_0
+// CHECK-NEXT:  OpStore [[f]] [[val]]
+
+// CHECK-NEXT:  [[c212:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_2 %int_2 %int_2 %uint_1 %uint_2
+// CHECK-NEXT:  OpStore [[c212]] [[val]]
+
+// CHECK-NEXT:  [[b1:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %MySbuffer %int_0 %uint_1 %int_1 %int_1
+// CHECK-NEXT:  [[x:%\d+]] = OpAccessChain %_ptr_Uniform_float [[b1]] %int_0
+// CHECK-NEXT:  OpStore [[x]] [[val]]
+
+// CHECK-NEXT:  [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_0 %int_0
+// CHECK-NEXT:  OpStore [[a]] [[val]]
+    MySbuffer[0].a = MySbuffer[1].b[1].x = MySbuffer[2].c[2][1][2] =
+    MySbuffer[3].s[0].f = MySbuffer[index].t[3] = val;
+}

--- a/tools/clang/test/CodeGenSPIRV/op.struct.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.struct.access.hlsl
@@ -21,8 +21,7 @@ void main() {
 // CHECK-NEXT: {{%\d+}} = OpLoad %bool [[a]]
     bool v2 = t.i.a;
 
-// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Function_v2uint %t %int_1 %int_1
-// CHECK-NEXT: [[b0:%\d+]] = OpAccessChain %_ptr_Function_uint [[b]] %uint_0
+// CHECK:      [[b0:%\d+]] = OpAccessChain %_ptr_Function_uint %t %int_1 %int_1 %uint_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %uint [[b0]]
     uint v3 = t.i.b[0];
 // CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Function_v2uint %t %int_1 %int_1
@@ -36,8 +35,7 @@ void main() {
 // CHECK-NEXT: [[c11v:%\d+]] = OpLoad %float [[c11p]]
 // CHECK-NEXT: {{%\d+}} = OpCompositeConstruct %v2float [[c00v]] [[c11v]]
     float2 v5 = t.i.c._11_22;
-// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Function_mat2v3float %t %int_1 %int_2
-// CHECK-NEXT: [[c1:%\d+]] = OpAccessChain %_ptr_Function_v3float [[c]] %uint_1
+// CHECK:      [[c1:%\d+]] = OpAccessChain %_ptr_Function_v3float %t %int_1 %int_2 %uint_1
 // CHECK-NEXT: {{%\d+}} = OpLoad %v3float [[c1]]
     float3 v6 = t.i.c[1];
 
@@ -48,8 +46,7 @@ void main() {
 // CHECK-NEXT: OpStore [[a]] {{%\d+}}
     t.i.a = v2;
 
-// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Function_v2uint %t %int_1 %int_1
-// CHECK-NEXT: [[b1:%\d+]] = OpAccessChain %_ptr_Function_uint [[b]] %uint_1
+// CHECK:      [[b1:%\d+]] = OpAccessChain %_ptr_Function_uint %t %int_1 %int_1 %uint_1
 // CHECK-NEXT: OpStore [[b1]] {{%\d+}}
     t.i.b[1] = v3;
 // CHECK:      [[v4:%\d+]] = OpLoad %v2uint %v4
@@ -68,8 +65,7 @@ void main() {
 // CHECK-NEXT: [[c00:%\d+]] = OpAccessChain %_ptr_Function_float [[c]] %int_0 %int_0
 // CHECK-NEXT: OpStore [[c00]] [[v51]]
     t.i.c._22_11 = v5;
-// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Function_mat2v3float %t %int_1 %int_2
-// CHECK-NEXT: [[c0:%\d+]] = OpAccessChain %_ptr_Function_v3float [[c]] %uint_0
+// CHECK:      [[c0:%\d+]] = OpAccessChain %_ptr_Function_v3float %t %int_1 %int_2 %uint_0
 // CHECK-NEXT: OpStore [[c0]] {{%\d+}}
     t.i.c[0] = v6;
 }

--- a/tools/clang/test/CodeGenSPIRV/op.structured-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.structured-buffer.access.hlsl
@@ -1,0 +1,37 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float  f;
+};
+
+struct T {
+    float    a;
+    float2   b[2];
+    float3x4 c[3];
+    S        s[2];
+    float    t[4];
+};
+
+
+StructuredBuffer<T> MySbuffer;
+
+float4 main(uint index: A) : SV_Target {
+// CHECK:      [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_0 %int_0
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[a]]
+
+// CHECK:      [[b1:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %MySbuffer %int_0 %uint_1 %int_1 %int_1
+// CHECK-NEXT: [[x:%\d+]] = OpAccessChain %_ptr_Uniform_float [[b1]] %int_0
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[x]]
+
+// CHECK:      [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_2 %int_2 %int_2 %uint_1 %uint_2
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[c12]]
+
+// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_3 %int_3 %int_0 %int_0
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[s]]
+
+// CHECK:      [[index:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT: [[t:%\d+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 [[index]] %int_4 %int_3
+// CHECK-NEXT: {{%\d+}} = OpLoad %float [[t]]
+    return MySbuffer[0].a + MySbuffer[1].b[1].x + MySbuffer[2].c[2][1][2] +
+           MySbuffer[3].s[0].f + MySbuffer[index].t[3];
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.storage-class.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.storage-class.hlsl
@@ -20,8 +20,7 @@ VSOut main(float4 input: A /* Function */, uint index: B /* Function */) {
 // CHECK:      OpAccessChain %_ptr_Function_float %input
 // CHECK:      OpAccessChain %_ptr_Private_float %sgVar
 // CHECK:      OpAccessChain %_ptr_Private_float %slVar
-// CHECK:      [[lhs:%\d+]] = OpAccessChain %_ptr_Function_v4float %ret %int_0
-// CHECK-NEXT: OpAccessChain %_ptr_Function_float [[lhs]]
+// CHECK:      OpAccessChain %_ptr_Function_float %ret %int_0 {{%\d+}}
     ret.out1[index] = input[index] + sgVar[index] + slVar[index];
 
     return ret;

--- a/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
@@ -1,0 +1,48 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpName %type_StructuredBuffer_S "type.StructuredBuffer.S"
+// CHECK: OpName %type_StructuredBuffer_T "type.StructuredBuffer.T"
+
+// CHECK: OpName %type_RWStructuredBuffer_S "type.RWStructuredBuffer.S"
+// CHECK: OpName %type_RWStructuredBuffer_T "type.RWStructuredBuffer.T"
+
+// CHECK: %S = OpTypeStruct %float %v3float %mat2v3float
+// CHECK: %_runtimearr_S = OpTypeRuntimeArray %S
+// CHECK: %type_StructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_StructuredBuffer_S = OpTypePointer Uniform %type_StructuredBuffer_S
+struct S {
+    float    a;
+    float3   b;
+    float2x3 c;
+};
+
+// CHECK: %T = OpTypeStruct %_arr_float_uint_3 %_arr_v3float_uint_4 %_arr_S_uint_3 %_arr_mat3v2float_uint_4
+// CHECK: %_runtimearr_T = OpTypeRuntimeArray %T
+// CHECK: %type_StructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK: %_ptr_Uniform_type_StructuredBuffer_T = OpTypePointer Uniform %type_StructuredBuffer_T
+
+// CHECK: %type_RWStructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_S = OpTypePointer Uniform %type_RWStructuredBuffer_S
+
+// CHECK: %type_RWStructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK: %_ptr_Uniform_type_RWStructuredBuffer_T = OpTypePointer Uniform %type_RWStructuredBuffer_T
+struct T {
+    float    a[3];
+    float3   b[4];
+    S        c[3];
+    float3x2 d[4];
+};
+
+// CHECK: %mySBuffer1 = OpVariable %_ptr_Uniform_type_StructuredBuffer_S Uniform
+StructuredBuffer<S> mySBuffer1 : register(t1);
+// CHECK: %mySBuffer2 = OpVariable %_ptr_Uniform_type_StructuredBuffer_T Uniform
+StructuredBuffer<T> mySBuffer2 : register(t2);
+
+// CHECK: %mySBuffer3 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
+RWStructuredBuffer<S> mySBuffer3 : register(u1);
+// CHECK: %mySBuffer4 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
+RWStructuredBuffer<T> mySBuffer4 : register(u2);
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -33,6 +33,19 @@ RWBuffer<float4> myRWBuffer : register(u0, space1);
 // TODO: support [[vk::binding()]] on cbuffer
 // TODO: support [[vk::binding()]] on ConstantBuffer
 
+struct S {
+    float f;
+};
+
+// CHECK:      OpDecorate %sbuffer1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sbuffer1 Binding 3
+[[vk::binding(3)]]
+  StructuredBuffer<S> sbuffer1 : register(t5);
+// CHECK:      OpDecorate %sbuffer2 DescriptorSet 3
+// CHECK-NEXT: OpDecorate %sbuffer2 Binding 2
+[[vk::binding(2, 3)]]
+RWStructuredBuffer<S> sbuffer2 : register(u6);
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
@@ -38,6 +38,13 @@ struct S {
 // CHECK-NEXT: OpDecorate %myCbuffer2 Binding 7
 ConstantBuffer<S> myCbuffer2;
 
+// CHECK:      OpDecorate %sbuffer1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sbuffer1 Binding 8
+  StructuredBuffer<S> sbuffer1;
+// CHECK:      OpDecorate %sbuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sbuffer2 Binding 9
+RWStructuredBuffer<S> sbuffer2;
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -54,6 +54,13 @@ ConstantBuffer<S> myCbuffer2 : register(b2, space2);
 // CHECK-NEXT: OpDecorate %myCbuffer3 Binding 2
 ConstantBuffer<S> myCbuffer3 : register(b2, space3);
 
+// CHECK:      OpDecorate %sbuffer1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %sbuffer1 Binding 5
+  StructuredBuffer<S> sbuffer1 : register(t5);
+// CHECK:      OpDecorate %sbuffer2 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %sbuffer2 Binding 6
+RWStructuredBuffer<S> sbuffer2 : register(u6, space1);
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.nested.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.nested.std430.hlsl
@@ -1,0 +1,92 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// Deep nested array of matrices
+// Depp nested majorness
+struct R {                         // Alignment    Offset  Size                              Next
+    row_major    float2x3 rf1[3];  // 16(vec4)  -> 0     + 3(array) * stride(2 * 16(vec4)) = 96
+    column_major float2x3 rf2[4];  // 8(vec2)   -> 96    + 4(array) * stride(3 * 8(vec2))  = 192
+                 float2x3 rf3[2];  // 8(vec2)   -> 192   + 2(array) * stride(3 * 8(vec2))  = 240
+                 int      rf4;     // 4         -> 240   + 4                               = 244
+};                                 // 16(max)                                                256 (244 round up to R alignment)
+
+// Array of scalars, vectors, matrices, and structs
+struct S {                         // Alignment   Offset  Size                              Next
+    float3       sf1[3];           // 16(vec4) -> 0     + 3(array) * 16(vec4)             = 48
+    float        sf2[3];           // 4        -> 48    + 3(array) * 4                    = 60
+    R            sf3[4];           // 16       -> 64    + 4(array) * stride(256)          = 1088
+    row_major    float3x2 sf4[2];  // 8(vec2)  -> 1088  + 2(array) * stride(3 * 8(vec2))  = 1136
+    column_major float3x2 sf5[3];  // 16(vec4) -> 1136  + 3(array) * stride(2 * 16(vec4)) = 1232
+                 float3x2 sf6[4];  // 16(vec4) -> 1232  + 4(array) * stride(2 * 16(vec4)) = 1360
+                 float    sf7;     // 4        -> 1360  + 4                               = 1364
+};                                 // 16(max)                                               1376 (1364 round up to S alignment)
+
+struct T {        // Alignment    Offset  Size              Next
+    R    tf1[2];  // 16        -> 0     + 2(array) * 256  = 512
+    S    tf2[3];  // 16        -> 512   + 3(array) * 1376 = 4640
+    uint tf3;     // 4         -> 4640  + 4               = 4644
+};                // 16(max)                                4656 (4640 round up to T alignment)
+
+struct SBuffer {  // Alignment   Offset   Size                 Next
+    T    t[2];       // 16       -> 0      + 2(array) * 4656 = 9312
+    bool z;          // 4        -> 9312
+};
+
+RWStructuredBuffer<SBuffer> MySBuffer;
+
+// CHECK:      OpDecorate %_arr_mat2v3float_uint_3 ArrayStride 32
+// CHECK:      OpDecorate %_arr_mat2v3float_uint_4 ArrayStride 24
+// CHECK:      OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 24
+
+// CHECK:      OpMemberDecorate %R 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %R 0 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %R 0 ColMajor
+// CHECK-NEXT: OpMemberDecorate %R 1 Offset 96
+// CHECK-NEXT: OpMemberDecorate %R 1 MatrixStride 8
+// CHECK-NEXT: OpMemberDecorate %R 1 RowMajor
+// CHECK-NEXT: OpMemberDecorate %R 2 Offset 192
+// CHECK-NEXT: OpMemberDecorate %R 2 MatrixStride 8
+// CHECK-NEXT: OpMemberDecorate %R 2 RowMajor
+// CHECK-NEXT: OpMemberDecorate %R 3 Offset 240
+
+// CHECK:      OpDecorate %_arr_R_uint_2 ArrayStride 256
+// CHECK:      OpDecorate %_arr_v3float_uint_3 ArrayStride 16
+// CHECK:      OpDecorate %_arr_float_uint_3 ArrayStride 4
+// CHECK:      OpDecorate %_arr_R_uint_4 ArrayStride 256
+
+// CHECK:      OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 24
+// CHECK:      OpDecorate %_arr_mat3v2float_uint_3 ArrayStride 32
+// CHECK:      OpDecorate %_arr_mat3v2float_uint_4 ArrayStride 32
+
+// CHECK:      OpMemberDecorate %S 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %S 1 Offset 48
+// CHECK-NEXT: OpMemberDecorate %S 2 Offset 64
+// CHECK-NEXT: OpMemberDecorate %S 3 Offset 1088
+// CHECK-NEXT: OpMemberDecorate %S 3 MatrixStride 8
+// CHECK-NEXT: OpMemberDecorate %S 3 ColMajor
+// CHECK-NEXT: OpMemberDecorate %S 4 Offset 1136
+// CHECK-NEXT: OpMemberDecorate %S 4 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %S 4 RowMajor
+// CHECK-NEXT: OpMemberDecorate %S 5 Offset 1232
+// CHECK-NEXT: OpMemberDecorate %S 5 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %S 5 RowMajor
+// CHECK-NEXT: OpMemberDecorate %S 6 Offset 1360
+
+// CHECK:      OpDecorate %_arr_S_uint_3 ArrayStride 1376
+
+// CHECK:      OpMemberDecorate %T 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %T 1 Offset 512
+// CHECK-NEXT: OpMemberDecorate %T 2 Offset 4640
+
+// CHECK:      OpDecorate %_arr_T_uint_2 ArrayStride 4656
+
+// CHECK-NEXT: OpMemberDecorate %SBuffer 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %SBuffer 1 Offset 9312
+
+// CHECK:      OpDecorate %_runtimearr_SBuffer ArrayStride 9328
+
+// CHECK:      OpMemberDecorate %type_RWStructuredBuffer_SBuffer 0 Offset 0
+// CHECK-NEXT: OpDecorate %type_RWStructuredBuffer_SBuffer BufferBlock
+
+float4 main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
@@ -1,0 +1,85 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct R {     // Alignment       Offset     Size       Next
+    float2 rf; // 8(vec2)      -> 0        + 8(vec2)  = 8
+};             // 8               8          8
+
+struct S {      // Alignment    Offset                                Size        Next
+    R      sf1; // 8         -> 0                                   + 8         = 8
+    float  sf2; // 4         -> 8                                   + 4         = 12
+    float3 sf3; // 16(vec4)  -> 16 (12 round up to vec4 alignment)  + 12(vec3)  = 28
+    float  sf4; // 4         -> 28                                  + 4         = 32
+};              // 16(max)                                                        32
+
+struct T {           // Alignment     Offset                               Size              = Next
+    int      tf1;    // 4          -> 0                                  + 4                 = 4
+    R        tf2[3]; // 8          -> 8                                  + 3 * stride(8)     = 32
+    float3x2 tf3;    // 16(vec4)   -> 32 (32 round up to vec4 alignment) + 2 * stride(vec4)  = 64
+    S        tf4;    // 16         -> 64 (64 round up to S alignment)    + 32                = 96
+    float    tf5;    // 4          -> 96                                 + 4                 = 100
+};                   // 16(max)                                                                112(100 round up to T max alignment)
+
+struct SBuffer {              // Alignment   Offset                                 Size                     Next
+                 bool     a;     // 4        -> 0                                    +     4                  = 4
+                 uint1    b;     // 4        -> 4                                    +     4                  = 8
+                 float3   c;     // 16(vec4) -> 16 (8 round up to vec4 alignment)    + 3 * 4                  = 28
+    row_major    float2x3 d;     // 16(vec4) -> 32 (28 round up to vec4 alignment)   + 2 * stride(vec4)       = 64
+    column_major float2x3 e;     // 16(vec4) -> 64 (64 round up to vec2 alignment)   + 3 * stride(vec2)       = 88
+                 float2x1 f;     // 8(vec2)  -> 88 (88 round up to vec2 aligment)    + 2 * 4                  = 96
+    row_major    float2x3 g[3];  // 16(vec4) -> 96 (96 round up to vec4 alignment)   + 3 * 2 * stride(vec4)   = 192
+    column_major float2x2 h[4];  // 16(vec4) -> 192 (192 round up to vec2 alignment) + 4 * 2 * stride(vec2)   = 256
+                 T        t;     // 16       -> 256 (352 round up to T alignment)    + 112                    = 368
+                 float    z;     // 4        -> 368
+
+};
+
+StructuredBuffer<SBuffer> MySBuffer;
+
+// CHECK:      OpDecorate %_arr_mat2v3float_uint_3 ArrayStride 32
+// CHECK:      OpDecorate %_arr_mat2v2float_uint_4 ArrayStride 16
+
+// CHECK:      OpMemberDecorate %R 0 Offset 0
+
+// CHECK:      OpDecorate %_arr_R_uint_3 ArrayStride 8
+
+// CHECK:      OpMemberDecorate %S 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %S 1 Offset 8
+// CHECK-NEXT: OpMemberDecorate %S 2 Offset 16
+// CHECK-NEXT: OpMemberDecorate %S 3 Offset 28
+
+// CHECK:      OpMemberDecorate %T 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %T 1 Offset 8
+// CHECK-NEXT: OpMemberDecorate %T 2 Offset 32
+// CHECK-NEXT: OpMemberDecorate %T 2 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %T 2 RowMajor
+// CHECK-NEXT: OpMemberDecorate %T 3 Offset 64
+// CHECK-NEXT: OpMemberDecorate %T 4 Offset 96
+
+// CHECK:      OpMemberDecorate %SBuffer 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %SBuffer 1 Offset 4
+// CHECK-NEXT: OpMemberDecorate %SBuffer 2 Offset 16
+// CHECK-NEXT: OpMemberDecorate %SBuffer 3 Offset 32
+// CHECK-NEXT: OpMemberDecorate %SBuffer 3 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %SBuffer 3 ColMajor
+// CHECK-NEXT: OpMemberDecorate %SBuffer 4 Offset 64
+// CHECK-NEXT: OpMemberDecorate %SBuffer 4 MatrixStride 8
+// CHECK-NEXT: OpMemberDecorate %SBuffer 4 RowMajor
+// CHECK-NEXT: OpMemberDecorate %SBuffer 5 Offset 88
+// CHECK-NEXT: OpMemberDecorate %SBuffer 6 Offset 96
+// CHECK-NEXT: OpMemberDecorate %SBuffer 6 MatrixStride 16
+// CHECK-NEXT: OpMemberDecorate %SBuffer 6 ColMajor
+// CHECK-NEXT: OpMemberDecorate %SBuffer 7 Offset 192
+// CHECK-NEXT: OpMemberDecorate %SBuffer 7 MatrixStride 8
+// CHECK-NEXT: OpMemberDecorate %SBuffer 7 RowMajor
+// CHECK-NEXT: OpMemberDecorate %SBuffer 8 Offset 256
+// CHECK-NEXT: OpMemberDecorate %SBuffer 9 Offset 368
+
+// CHECK:      OpDecorate %_runtimearr_SBuffer ArrayStride 384
+
+// CHECK:      OpMemberDecorate %type_StructuredBuffer_SBuffer 0 Offset 0
+// CHECK-NEXT: OpMemberDecorate %type_StructuredBuffer_SBuffer 0 NonWritable
+// CHECK-NEXT: OpDecorate %type_StructuredBuffer_SBuffer BufferBlock
+
+float main() : SV_Target {
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -52,6 +52,9 @@ TEST_F(FileTest, CBufferType) { runFileTest("type.cbuffer.hlsl"); }
 TEST_F(FileTest, ConstantBufferType) {
   runFileTest("type.constant-buffer.hlsl");
 }
+TEST_F(FileTest, StructuredBufferType) {
+  runFileTest("type.structured-buffer.hlsl");
+}
 TEST_F(FileTest, ByteAddressBufferTypes) {
   runFileTest("type.byte-address-buffer.hlsl");
 }
@@ -198,13 +201,19 @@ TEST_F(FileTest, OpMatrixAccess1x1) {
 // For struct & array accessing operator
 TEST_F(FileTest, OpStructAccess) { runFileTest("op.struct.access.hlsl"); }
 TEST_F(FileTest, OpArrayAccess) { runFileTest("op.array.access.hlsl"); }
+
+// For buffer accessing operator
+TEST_F(FileTest, OpBufferAccess) { runFileTest("op.buffer.access.hlsl"); }
 TEST_F(FileTest, OpCBufferAccess) { runFileTest("op.cbuffer.access.hlsl"); }
 TEST_F(FileTest, OpConstantBufferAccess) {
   runFileTest("op.constant-buffer.access.hlsl");
 }
-
-// For Buffer/RWBuffer accessing operator
-TEST_F(FileTest, OpBufferAccess) { runFileTest("op.buffer.access.hlsl"); }
+TEST_F(FileTest, OpStructuredBufferAccess) {
+  runFileTest("op.structured-buffer.access.hlsl");
+}
+TEST_F(FileTest, OpRWStructuredBufferAccess) {
+  runFileTest("op.rw-structured-buffer.access.hlsl");
+}
 
 // For casting
 TEST_F(FileTest, CastNoOp) { runFileTest("cast.no-op.hlsl"); }
@@ -344,6 +353,9 @@ TEST_F(FileTest, TextureArraySampleGrad) {
   runFileTest("texture.array.sample-grad.hlsl");
 }
 
+TEST_F(FileTest, StructuredBufferLoad) {
+  runFileTest("method.structured-buffer.load.hlsl");
+}
 // For ByteAddressBuffer methods
 TEST_F(FileTest, ByteAddressBufferLoad) {
   runFileTest("method.byte-address-buffer.load.hlsl");
@@ -468,6 +480,12 @@ TEST_F(FileTest, VulkanLayoutCBufferStd140) {
 }
 TEST_F(FileTest, VulkanLayoutCBufferNestedStd140) {
   runFileTest("vk.layout.cbuffer.nested.std140.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutSBufferStd430) {
+  runFileTest("vk.layout.sbuffer.std430.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutSBufferNestedStd430) {
+  runFileTest("vk.layout.sbuffer.nested.std430.hlsl");
 }
 
 } // namespace


### PR DESCRIPTION
* Supported (RW)StructuredBuffer types
* Supported accessing elements in (RW)StructuredBuffer
* Supported the Load() method
* Supported std430 layout

Also optimized OpAccessChain CodeGen. This is necessary right
now because otherwise we will have pointers to intermediate
composite objects like structs and arrays. Structs/arrays are
different types with and without layout decorations. To have the
correct struct/array pointer type for OpAccessChain, we need to
always pass in the correct layout rules when translating the
types, which is not easy. Optimizing intermediate OpAccessChain
away solves the problem because scalar/vector/matrix types are
unique given the same parameter.