### PR TITLE
[spirv] Support assigning to objects of composite types

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -177,9 +177,11 @@ public:
   struct DeclSpirvInfo {
     uint32_t resultId;
     spv::StorageClass storageClass;
+    /// Layout rule for this decl.
+    LayoutRule layoutRule = LayoutRule::Void;
     /// Value >= 0 means that this decl is a VarDecl inside a cbuffer/tbuffer
     /// and this is the index; value < 0 means this is just a standalone decl.
-    int indexInCTBuffer;
+    int indexInCTBuffer = -1;
   };
 
   /// \brief Returns the SPIR-V information for the given decl.
@@ -196,9 +198,12 @@ public:
   /// returns a newly assigned <result-id> for it.
   uint32_t getOrRegisterFnResultId(const FunctionDecl *fn);
 
-  /// Returns the storage class for the given expression. The expression is
-  /// expected to be an lvalue. Otherwise this method may panic.
-  spv::StorageClass resolveStorageClass(const Expr *expr) const;
+  /// Returns the storage class for the given expression. If rule is not
+  /// nullptr, also writes the layout rule into it.
+  /// The expression is expected to be an lvalue. Otherwise this method may
+  /// panic.
+  spv::StorageClass resolveStorageInfo(const Expr *expr,
+                                       LayoutRule *rule = nullptr) const;
   spv::StorageClass resolveStorageClass(const Decl *decl) const;
 
   /// \brief Returns all defined stage (builtin/input/ouput) variables in this

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -371,10 +371,8 @@ uint32_t SPIRVEmitter::doExpr(const Expr *expr) {
 
 uint32_t SPIRVEmitter::loadIfGLValue(const Expr *expr) {
   const uint32_t result = doExpr(expr);
-  if (expr->isGLValue()) {
-    const uint32_t baseTyId = typeTranslator.translateType(expr->getType());
-    return theBuilder.createLoad(baseTyId, result);
-  }
+  if (expr->isGLValue())
+    return theBuilder.createLoad(getType(expr), result);
 
   return result;
 }
@@ -516,7 +514,10 @@ void SPIRVEmitter::doVarDecl(const VarDecl *decl) {
           toInitGloalVars.push_back(decl);
         }
       } else {
-        theBuilder.createStore(varId, doExpr(decl->getInit()));
+        LayoutRule rhsLayout = LayoutRule::Void;
+        (void)declIdMapper.resolveStorageInfo(decl->getInit(), &rhsLayout);
+        storeValue(varId, loadIfGLValue(decl->getInit()), decl->getType(),
+                   spv::StorageClass::Function, LayoutRule::Void, rhsLayout);
       }
     }
   } else {
@@ -1040,9 +1041,10 @@ uint32_t SPIRVEmitter::doArraySubscriptExpr(const ArraySubscriptExpr *expr) {
   llvm::SmallVector<uint32_t, 4> indices;
   const auto *base = collectArrayStructIndices(expr, &indices);
 
-  const uint32_t ptrType =
-      theBuilder.getPointerType(typeTranslator.translateType(expr->getType()),
-                                declIdMapper.resolveStorageClass(base));
+  LayoutRule rule = LayoutRule::Void;
+  const auto sc = declIdMapper.resolveStorageInfo(base, &rule);
+  const uint32_t ptrType = theBuilder.getPointerType(
+      typeTranslator.translateType(expr->getType(), rule), sc);
 
   return theBuilder.createAccessChain(ptrType, doExpr(base), indices);
 }
@@ -1052,8 +1054,12 @@ uint32_t SPIRVEmitter::doBinaryOperator(const BinaryOperator *expr) {
 
   // Handle assignment first since we need to evaluate rhs before lhs.
   // For other binary operations, we need to evaluate lhs before rhs.
-  if (opcode == BO_Assign)
-    return processAssignment(expr->getLHS(), doExpr(expr->getRHS()), false);
+  if (opcode == BO_Assign) {
+    LayoutRule rhsLayout = LayoutRule::Void;
+    (void)declIdMapper.resolveStorageInfo(expr->getRHS(), &rhsLayout);
+    return processAssignment(expr->getLHS(), loadIfGLValue(expr->getRHS()),
+                             false, /*lhsPtr*/ 0, rhsLayout);
+  }
 
   // Try to optimize floatMxN * float and floatN * float case
   if (opcode == BO_Mul) {
@@ -1165,8 +1171,7 @@ uint32_t SPIRVEmitter::doCastExpr(const CastExpr *expr) {
 
     // Using lvalue as rvalue means we need to OpLoad the contents from
     // the parameter/variable first.
-    const uint32_t resultType = typeTranslator.translateType(toType);
-    return theBuilder.createLoad(resultType, fromValue);
+    return theBuilder.createLoad(getType(expr), fromValue);
   }
   case CastKind::CK_NoOp:
     return doExpr(subExpr);
@@ -1416,7 +1421,7 @@ uint32_t SPIRVEmitter::processByteAddressBufferLoadStore(
   // the address.
   const uint32_t uintTypeId = theBuilder.getUint32Type();
   const uint32_t ptrType = theBuilder.getPointerType(
-      uintTypeId, declIdMapper.resolveStorageClass(object));
+      uintTypeId, declIdMapper.resolveStorageInfo(object));
   const uint32_t constUint0 = theBuilder.getConstantUint32(0);
 
   if (doStore) {
@@ -1478,7 +1483,7 @@ SPIRVEmitter::processStructuredBufferLoad(const CXXMemberCallExpr *expr) {
       hlsl::GetHLSLResourceResultType(buffer->getType());
   const uint32_t ptrType = theBuilder.getPointerType(
       typeTranslator.translateType(structType, LayoutRule::GLSLStd430),
-      declIdMapper.resolveStorageClass(buffer));
+      declIdMapper.resolveStorageInfo(buffer));
 
   const uint32_t zero = theBuilder.getConstantInt32(0);
   const uint32_t index = doExpr(expr->getArg(0));
@@ -1715,9 +1720,10 @@ uint32_t SPIRVEmitter::doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr) {
     base = tempVar;
   }
 
-  const uint32_t ptrType =
-      theBuilder.getPointerType(typeTranslator.translateType(expr->getType()),
-                                declIdMapper.resolveStorageClass(baseExpr));
+  LayoutRule rule = LayoutRule::Void;
+  const auto sc = declIdMapper.resolveStorageInfo(baseExpr, &rule);
+  const uint32_t ptrType = theBuilder.getPointerType(
+      typeTranslator.translateType(expr->getType(), rule), sc);
 
   return theBuilder.createAccessChain(ptrType, base, indices);
 }
@@ -1756,7 +1762,7 @@ SPIRVEmitter::doExtMatrixElementExpr(const ExtMatrixElementExpr *expr) {
         indices[i] = theBuilder.getConstantInt32(indices[i]);
 
       const uint32_t ptrType = theBuilder.getPointerType(
-          elemType, declIdMapper.resolveStorageClass(baseExpr));
+          elemType, declIdMapper.resolveStorageInfo(baseExpr));
       if (!indices.empty()) {
         // Load the element via access chain
         elem = theBuilder.createAccessChain(ptrType, base, indices);
@@ -1815,7 +1821,7 @@ SPIRVEmitter::doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr) {
     // v.xyyz to turn a lvalue v into rvalue.
     if (expr->getBase()->isGLValue()) { // E.g., v.x;
       const uint32_t ptrType = theBuilder.getPointerType(
-          type, declIdMapper.resolveStorageClass(baseExpr));
+          type, declIdMapper.resolveStorageInfo(baseExpr));
       const uint32_t index = theBuilder.getConstantInt32(accessor.Swz0);
       // We need a lvalue here. Do not try to load.
       return theBuilder.createAccessChain(ptrType, doExpr(baseExpr), {index});
@@ -1866,9 +1872,10 @@ uint32_t SPIRVEmitter::doMemberExpr(const MemberExpr *expr) {
   llvm::SmallVector<uint32_t, 4> indices;
   const Expr *base = collectArrayStructIndices(expr, &indices);
 
-  const uint32_t ptrType =
-      theBuilder.getPointerType(typeTranslator.translateType(expr->getType()),
-                                declIdMapper.resolveStorageClass(base));
+  LayoutRule rule = LayoutRule::Void;
+  const auto sc = declIdMapper.resolveStorageInfo(base, &rule);
+  const uint32_t ptrType = theBuilder.getPointerType(
+      typeTranslator.translateType(expr->getType(), rule), sc);
 
   return theBuilder.createAccessChain(ptrType, doExpr(base), indices);
 }
@@ -1933,6 +1940,12 @@ uint32_t SPIRVEmitter::doUnaryOperator(const UnaryOperator *expr) {
       << expr->getOpcodeStr(opcode);
   expr->dump();
   return 0;
+}
+
+uint32_t SPIRVEmitter::getType(const Expr *expr) {
+  LayoutRule rule = LayoutRule::Void;
+  (void)declIdMapper.resolveStorageInfo(expr, &rule);
+  return typeTranslator.translateType(expr->getType(), rule);
 }
 
 spv::Op SPIRVEmitter::translateOp(BinaryOperator::Opcode op, QualType type) {
@@ -2057,8 +2070,9 @@ case BO_##kind : {                                                             \
 }
 
 uint32_t SPIRVEmitter::processAssignment(const Expr *lhs, const uint32_t rhs,
-                                         bool isCompoundAssignment,
-                                         uint32_t lhsPtr) {
+                                         const bool isCompoundAssignment,
+                                         uint32_t lhsPtr,
+                                         LayoutRule rhsLayout) {
   // Assigning to vector swizzling should be handled differently.
   if (const uint32_t result = tryToAssignToVectorElements(lhs, rhs)) {
     return result;
@@ -2073,13 +2087,75 @@ uint32_t SPIRVEmitter::processAssignment(const Expr *lhs, const uint32_t rhs,
   }
 
   // Normal assignment procedure
-  if (lhsPtr == 0)
+  if (!lhsPtr)
     lhsPtr = doExpr(lhs);
 
-  theBuilder.createStore(lhsPtr, rhs);
+  LayoutRule lhsLayout = LayoutRule::Void;
+  const auto lhsSc = declIdMapper.resolveStorageInfo(lhs, &lhsLayout);
+  storeValue(lhsPtr, rhs, lhs->getType(), lhsSc, lhsLayout, rhsLayout);
+
   // Plain assignment returns a rvalue, while compound assignment returns
   // lvalue.
   return isCompoundAssignment ? lhsPtr : rhs;
+}
+
+void SPIRVEmitter::storeValue(const uint32_t lhsPtr, const uint32_t rhsVal,
+                              const QualType valType,
+                              const spv::StorageClass lhsSc,
+                              const LayoutRule lhsLayout,
+                              const LayoutRule rhsLayout) {
+  // If lhs and rhs has the same memory layout, we should be safe to load
+  // from rhs and directly store into lhs and avoid decomposing rhs.
+  // TODO: is this optimization always correct?
+  if (lhsLayout == rhsLayout || typeTranslator.isScalarType(valType) ||
+      typeTranslator.isVectorType(valType) ||
+      typeTranslator.isMxNMatrix(valType)) {
+    theBuilder.createStore(lhsPtr, rhsVal);
+  } else if (const auto *recordType = valType->getAs<RecordType>()) {
+    uint32_t index = 0;
+    for (const auto *decl : recordType->getDecl()->decls()) {
+      // Implicit generated struct declarations should be ignored.
+      if (isa<CXXRecordDecl>(decl) && decl->isImplicit())
+        continue;
+
+      const auto *field = cast<FieldDecl>(decl);
+      assert(field);
+
+      const auto subRhsValType =
+          typeTranslator.translateType(field->getType(), rhsLayout);
+      const auto subRhsVal =
+          theBuilder.createCompositeExtract(subRhsValType, rhsVal, {index});
+      const auto subLhsPtrType = theBuilder.getPointerType(
+          typeTranslator.translateType(field->getType(), lhsLayout), lhsSc);
+      const auto subLhsPtr = theBuilder.createAccessChain(
+          subLhsPtrType, lhsPtr, {theBuilder.getConstantUint32(index)});
+
+      storeValue(subLhsPtr, subRhsVal, field->getType(), lhsSc, lhsLayout,
+                 rhsLayout);
+      ++index;
+    }
+  } else if (const auto *arrayType =
+                 astContext.getAsConstantArrayType(valType)) {
+    const auto elemType = arrayType->getElementType();
+    // TODO: handle extra large array size?
+    const auto size =
+        static_cast<uint32_t>(arrayType->getSize().getZExtValue());
+
+    for (uint32_t i = 0; i < size; ++i) {
+      const auto subRhsValType =
+          typeTranslator.translateType(elemType, rhsLayout);
+      const auto subRhsVal =
+          theBuilder.createCompositeExtract(subRhsValType, rhsVal, {i});
+      const auto subLhsPtrType = theBuilder.getPointerType(
+          typeTranslator.translateType(elemType, lhsLayout), lhsSc);
+      const auto subLhsPtr = theBuilder.createAccessChain(
+          subLhsPtrType, lhsPtr, {theBuilder.getConstantUint32(i)});
+
+      storeValue(subLhsPtr, subRhsVal, elemType, lhsSc, lhsLayout, rhsLayout);
+    }
+  } else {
+    emitError("storing value of type %0 unimplemented") << valType;
+  }
 }
 
 uint32_t SPIRVEmitter::processBinaryOp(const Expr *lhs, const Expr *rhs,
@@ -2517,8 +2593,8 @@ uint32_t SPIRVEmitter::tryToAssignToVectorElements(const Expr *lhs,
 }
 
 uint32_t SPIRVEmitter::tryToAssignToRWBuffer(const Expr *lhs, uint32_t rhs) {
-  const Expr* baseExpr = nullptr;
-  const Expr* indexExpr = nullptr;
+  const Expr *baseExpr = nullptr;
+  const Expr *indexExpr = nullptr;
   if (isBufferIndexing(dyn_cast<CXXOperatorCallExpr>(lhs), &baseExpr,
                        &indexExpr)) {
     const uint32_t locId = doExpr(indexExpr);
@@ -2572,7 +2648,7 @@ uint32_t SPIRVEmitter::tryToAssignToMatrixElements(const Expr *lhs,
       rhsElem = theBuilder.createCompositeExtract(elemTypeId, rhs, {i});
 
     const uint32_t ptrType = theBuilder.getPointerType(
-        elemTypeId, declIdMapper.resolveStorageClass(baseMat));
+        elemTypeId, declIdMapper.resolveStorageInfo(baseMat));
 
     // If the lhs is actually a matrix of size 1x1, we don't need the access
     // chain. base is already the dest pointer.

--- a/tools/clang/test/CodeGenSPIRV/binary-op.assign.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.assign.composite.hlsl
@@ -1,0 +1,101 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct SubBuffer {
+    float    a[1];
+    float2   b[1];
+    float2x3 c[1];
+};
+
+struct BufferType {
+    float     a;
+    float3    b;
+    float3x2  c;
+    SubBuffer d[1];
+};
+
+RWStructuredBuffer<BufferType> sbuf;  // %BufferType                     & %SubBuffer
+    ConstantBuffer<BufferType> cbuf;  // %type_ConstantBuffer_BufferType & %SubBuffer_0
+
+void main(uint index: A) {
+    // Same storage class
+
+// CHECK:      [[sbuf0:%\d+]] = OpAccessChain %_ptr_Uniform_BufferType %sbuf %int_0 %uint_0
+// CHECK-NEXT: [[val:%\d+]] = OpLoad %BufferType [[sbuf0]]
+// CHECK-NEXT: [[sbuf8:%\d+]] = OpAccessChain %_ptr_Uniform_BufferType %sbuf %int_0 %uint_8
+// CHECK-NEXT: OpStore [[sbuf8]] [[val]]
+    sbuf[8] = sbuf[0];
+
+    // Different storage class
+
+
+// CHECK-NEXT: [[lbuf:%\d+]] = OpLoad %BufferType_0 %lbuf
+// CHECK-NEXT: [[sbuf5:%\d+]] = OpAccessChain %_ptr_Uniform_BufferType %sbuf %int_0 %uint_5
+
+    // sbuf[5].a <- lbuf.a
+// CHECK-NEXT: [[val:%\d+]] = OpCompositeExtract %float [[lbuf]] 0
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_float [[sbuf5]] %uint_0
+// CHECK-NEXT: OpStore [[ptr]] [[val]]
+
+    // sbuf[5].b <- lbuf.b
+// CHECK-NEXT: [[val:%\d+]] = OpCompositeExtract %v3float [[lbuf]] 1
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_v3float [[sbuf5]] %uint_1
+// CHECK-NEXT: OpStore [[ptr]] [[val]]
+
+    // sbuf[5].c <- lbuf.c
+// CHECK-NEXT: [[val:%\d+]] = OpCompositeExtract %mat3v2float [[lbuf]] 2
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v2float [[sbuf5]] %uint_2
+// CHECK-NEXT: OpStore [[ptr]] [[val]]
+
+// CHECK-NEXT: [[lbuf_d:%\d+]] = OpCompositeExtract %_arr_SubBuffer_1_uint_1 [[lbuf]] 3
+// CHECK-NEXT: [[sbuf_d:%\d+]] = OpAccessChain %_ptr_Uniform__arr_SubBuffer_uint_1 [[sbuf5]] %uint_3
+// CHECK-NEXT: [[lbuf_d0:%\d+]] = OpCompositeExtract %SubBuffer_1 [[lbuf_d]] 0
+// CHECK-NEXT: [[sbuf_d0:%\d+]] = OpAccessChain %_ptr_Uniform_SubBuffer [[sbuf_d]] %uint_0
+
+    // sbuf[5].d[0].a[0] <- lbuf.a[0]
+// CHECK-NEXT: [[lbuf_d0_a:%\d+]] = OpCompositeExtract %_arr_float_uint_1_1 [[lbuf_d0]] 0
+// CHECK-NEXT: [[sbuf_d0_a:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_1 [[sbuf_d0]] %uint_0
+// CHECK-NEXT: [[lbuf_d0_a0:%\d+]] = OpCompositeExtract %float [[lbuf_d0_a]] 0
+// CHECK-NEXT: [[sbuf_d0_a0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[sbuf_d0_a]] %uint_0
+// CHECK-NEXT: OpStore [[sbuf_d0_a0]] [[lbuf_d0_a0]]
+
+    // sbuf[5].d[0].b[0] <- lbuf.b[0]
+// CHECK-NEXT: [[lbuf_d0_b:%\d+]] = OpCompositeExtract %_arr_v2float_uint_1_1 [[lbuf_d0]] 1
+// CHECK-NEXT: [[sbuf_d0_b:%\d+]] = OpAccessChain %_ptr_Uniform__arr_v2float_uint_1 [[sbuf_d0]] %uint_1
+// CHECK-NEXT: [[lbuf_d0_b0:%\d+]] = OpCompositeExtract %v2float [[lbuf_d0_b]] 0
+// CHECK-NEXT: [[sbuf_d0_b0:%\d+]] = OpAccessChain %_ptr_Uniform_v2float [[sbuf_d0_b]] %uint_0
+// CHECK-NEXT: OpStore [[sbuf_d0_b0]] [[lbuf_d0_b0]]
+
+    // sbuf[5].d[0].c[0] <- lbuf.c[0]
+// CHECK-NEXT: [[lbuf_d0_c:%\d+]] = OpCompositeExtract %_arr_mat2v3float_uint_1_1 [[lbuf_d0]] 2
+// CHECK-NEXT: [[sbuf_d0_c:%\d+]] = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_1 [[sbuf_d0]] %uint_2
+// CHECK-NEXT: [[lbuf_d0_c0:%\d+]] = OpCompositeExtract %mat2v3float [[lbuf_d0_c]] 0
+// CHECK-NEXT: [[sbuf_d0_c0:%\d+]] = OpAccessChain %_ptr_Uniform_mat2v3float [[sbuf_d0_c]] %uint_0
+// CHECK-NEXT: OpStore [[sbuf_d0_c0]] [[lbuf_d0_c0]]
+    BufferType lbuf;                  // %BufferType_0                   & %SubBuffer_1
+    sbuf[5]  = lbuf;             // %BufferType <- %BufferType_0
+
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_SubBuffer_0 %cbuf %int_3 %int_0
+// CHECK-NEXT: [[cbuf_d0:%\d+]] = OpLoad %SubBuffer_0 [[ptr]]
+
+    // sub.a[0] <- cbuf.d[0].a[0]
+// CHECK-NEXT: [[cbuf_d0_a:%\d+]] = OpCompositeExtract %_arr_float_uint_1_0 [[cbuf_d0]] 0
+// CHECK-NEXT: [[sub_a:%\d+]] = OpAccessChain %_ptr_Function__arr_float_uint_1_1 %sub %uint_0
+// CHECK-NEXT: [[cbuf_d0_a0:%\d+]] = OpCompositeExtract %float [[cbuf_d0_a]] 0
+// CHECK-NEXT: [[sub_a0:%\d+]] = OpAccessChain %_ptr_Function_float [[sub_a]] %uint_0
+// CHECK-NEXT: OpStore [[sub_a0]] [[cbuf_d0_a0]]
+
+    // sub.b[0] <- cbuf.d[0].b[0]
+// CHECK-NEXT: [[cbuf_d0_b:%\d+]] = OpCompositeExtract %_arr_v2float_uint_1_0 [[cbuf_d0]] 1
+// CHECK-NEXT: [[sub_b:%\d+]] = OpAccessChain %_ptr_Function__arr_v2float_uint_1_1 %sub %uint_1
+// CHECK-NEXT: [[cbuf_d0_b0:%\d+]] = OpCompositeExtract %v2float [[cbuf_d0_b]] 0
+// CHECK-NEXT: [[sub_b0:%\d+]] = OpAccessChain %_ptr_Function_v2float [[sub_b]] %uint_0
+// CHECK-NEXT: OpStore [[sub_b0]] [[cbuf_d0_b0]]
+
+    // sub.c[0] <- cbuf.d[0].c[0]
+// CHECK-NEXT: [[cbuf_d0_c:%\d+]] = OpCompositeExtract %_arr_mat2v3float_uint_1_0 [[cbuf_d0]] 2
+// CHECK-NEXT: [[sub_c:%\d+]] = OpAccessChain %_ptr_Function__arr_mat2v3float_uint_1_1 %sub %uint_2
+// CHECK-NEXT: [[cbuf_d0_c0:%\d+]] = OpCompositeExtract %mat2v3float [[cbuf_d0_c]] 0
+// CHECK-NEXT: [[sub_c0:%\d+]] = OpAccessChain %_ptr_Function_mat2v3float [[sub_c]] %uint_0
+// CHECK-NEXT: OpStore [[sub_c0]] [[cbuf_d0_c0]]
+    SubBuffer sub = cbuf.d[0];        // %SubBuffer_1 <- %SubBuffer_0
+}

--- a/tools/clang/test/CodeGenSPIRV/method.structured-buffer.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.structured-buffer.load.hlsl
@@ -11,22 +11,20 @@ RWStructuredBuffer<SBuffer> mySBuffer2;
 float4 main(int index: A) : SV_Target {
     // b1 and b2's type does not need layout decorations. So it's a different
     // SBuffer definition.
-// XXXXX-NOT:  OpMemberDecorate %SBuffer_0 0 Offset 0
-// XXXXX:      %_ptr_Function_SBuffer_0 = OpTypePointer Function %SBuffer_0
+// CHECK-NOT:  OpMemberDecorate %SBuffer_0 0 Offset 0
+// CHECK:      %_ptr_Function_SBuffer_0 = OpTypePointer Function %SBuffer_0
 
-// XXXXX:      %b1 = OpVariable %_ptr_Function_SBuffer_0 Function
-// XXXXX-NEXT: %b2 = OpVariable %_ptr_Function_SBuffer_0 Function
+// CHECK:      %b1 = OpVariable %_ptr_Function_SBuffer_0 Function
+// CHECK-NEXT: %b2 = OpVariable %_ptr_Function_SBuffer_0 Function
 
-// TODO: wrong codegen right now: missing load the value from sb1 & sb2
-// TODO: need to make sure we have %SBuffer (not %SBuffer_0) as the loaded type
-// XXXXX:      [[index:%\d+]] = OpLoad %int %index
-// XXXXX:      [[sb1:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer1 %int_0 [[index]]
-// XXXXX:      {{%\d+}} = OpLoad %SBuffer [[sb1]]
-// XXXXX:      [[sb2:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer2 %int_0 %int_0
-// XXXXX:      {{%\d+}} = OpLoad %SBuffer [[sb2]]
-    //SBuffer b1 = mySBuffer1.Load(index);
-    //SBuffer b2;
-    //b2 = mySBuffer2.Load(0);
+// CHECK:      [[index:%\d+]] = OpLoad %int %index
+// CHECK:      [[sb1:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer1 %int_0 [[index]]
+// CHECK:      {{%\d+}} = OpLoad %SBuffer [[sb1]]
+// CHECK:      [[sb2:%\d+]] = OpAccessChain %_ptr_Uniform_SBuffer %mySBuffer2 %int_0 %int_0
+// CHECK:      {{%\d+}} = OpLoad %SBuffer [[sb2]]
+    SBuffer b1 = mySBuffer1.Load(index);
+    SBuffer b2;
+    b2 = mySBuffer2.Load(0);
 
 // CHECK:      [[f1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %mySBuffer1 %int_0 %int_5 %int_0
 // CHECK-NEXT: [[x:%\d+]] = OpAccessChain %_ptr_Uniform_float [[f1]] %int_0

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -111,6 +111,9 @@ TEST_F(FileTest, UnaryOpLogicalNot) {
 
 // For assignments
 TEST_F(FileTest, BinaryOpAssign) { runFileTest("binary-op.assign.hlsl"); }
+TEST_F(FileTest, BinaryOpAssignComposite) {
+  runFileTest("binary-op.assign.composite.hlsl");
+}
 
 // For arithmetic binary operators
 TEST_F(FileTest, BinaryOpScalarArithmetic) {


### PR DESCRIPTION
For these objects, if the lhs and rhs are of different storage
class, we may need to do the assignment recursively at the
non-composite level since OpStore requires that the pointer's
type operand must be the same as the type of object.