### PR TITLE
[spirv] Support {Append|Consume}StructuredBuffer

### DIFF
--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -144,11 +144,11 @@ public:
   uint32_t createBinaryOp(spv::Op op, uint32_t resultType, uint32_t lhs,
                           uint32_t rhs);
 
-  /// \brief Creates an OpAtomicIAdd instruction with the given SPIR-V opcode.
-  /// Returns the <result-id> for the result.
-  uint32_t createAtomicIAdd(uint32_t resultType, uint32_t orignalValuePtr,
-                            uint32_t scopeId, uint32_t memorySemanticsId,
-                            uint32_t valueToAdd);
+  /// \brief Creates an OpAtomicIAdd or OpAtomicISub instruction with the given
+  /// parameters. Returns the <result-id> for the result.
+  uint32_t createAtomicIAddSub(uint32_t resultType, uint32_t orignalValuePtr,
+                               uint32_t scopeId, uint32_t memorySemanticsId,
+                               uint32_t valueToOp, bool isAdd);
 
   /// \brief Creates SPIR-V instructions for sampling the given image.
   ///

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -144,6 +144,12 @@ public:
   uint32_t createBinaryOp(spv::Op op, uint32_t resultType, uint32_t lhs,
                           uint32_t rhs);
 
+  /// \brief Creates an OpAtomicIAdd instruction with the given SPIR-V opcode.
+  /// Returns the <result-id> for the result.
+  uint32_t createAtomicIAdd(uint32_t resultType, uint32_t orignalValuePtr,
+                            uint32_t scopeId, uint32_t memorySemanticsId,
+                            uint32_t valueToAdd);
+
   /// \brief Creates SPIR-V instructions for sampling the given image.
   ///
   /// If lod or grad is given a non-zero value, *ExplicitLod variants of

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -198,6 +198,10 @@ public:
   /// returns a newly assigned <result-id> for it.
   uint32_t getOrRegisterFnResultId(const FunctionDecl *fn);
 
+  /// \brief Returns the associated counter's <result-id> for the given
+  /// {Append|Consume}StructuredBuffer variable.
+  uint32_t getCounterId(const VarDecl *decl);
+
   /// Returns the storage class for the given expression. If rule is not
   /// nullptr, also writes the layout rule into it.
   /// The expression is expected to be an lvalue. Otherwise this method may
@@ -290,6 +294,8 @@ private:
   llvm::SmallVector<StageVar, 8> stageVars;
   /// Vector of all defined resource variables.
   llvm::SmallVector<ResourceVar, 8> resourceVars;
+  /// Mapping from {Append|Consume}StructuredBuffers to their counter variables
+  llvm::DenseMap<const NamedDecl *, uint32_t> counterVars;
 };
 
 DeclResultIdMapper::DeclResultIdMapper(const hlsl::ShaderModel &model,

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -210,6 +210,21 @@ uint32_t ModuleBuilder::createBinaryOp(spv::Op op, uint32_t resultType,
   return id;
 }
 
+uint32_t ModuleBuilder::createAtomicIAdd(uint32_t resultType,
+                                         uint32_t orignalValuePtr,
+                                         uint32_t scopeId,
+                                         uint32_t memorySemanticsId,
+                                         uint32_t valueToAdd) {
+  assert(insertPoint && "null insert point");
+  const uint32_t id = theContext.takeNextId();
+  instBuilder
+      .opAtomicIAdd(resultType, id, orignalValuePtr, scopeId, memorySemanticsId,
+                    valueToAdd)
+      .x();
+  insertPoint->appendInstruction(std::move(constructSite));
+  return id;
+}
+
 spv::ImageOperandsMask ModuleBuilder::composeImageOperandsMask(
     uint32_t bias, uint32_t lod, const std::pair<uint32_t, uint32_t> &grad,
     uint32_t constOffset, uint32_t varOffset,

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -210,17 +210,20 @@ uint32_t ModuleBuilder::createBinaryOp(spv::Op op, uint32_t resultType,
   return id;
 }
 
-uint32_t ModuleBuilder::createAtomicIAdd(uint32_t resultType,
-                                         uint32_t orignalValuePtr,
-                                         uint32_t scopeId,
-                                         uint32_t memorySemanticsId,
-                                         uint32_t valueToAdd) {
+uint32_t ModuleBuilder::createAtomicIAddSub(uint32_t resultType,
+                                            uint32_t orignalValuePtr,
+                                            uint32_t scopeId,
+                                            uint32_t memorySemanticsId,
+                                            uint32_t valueToOp, bool isAdd) {
   assert(insertPoint && "null insert point");
   const uint32_t id = theContext.takeNextId();
-  instBuilder
-      .opAtomicIAdd(resultType, id, orignalValuePtr, scopeId, memorySemanticsId,
-                    valueToAdd)
-      .x();
+  if (isAdd)
+    instBuilder.opAtomicIAdd(resultType, id, orignalValuePtr, scopeId,
+                             memorySemanticsId, valueToOp);
+  else
+    instBuilder.opAtomicISub(resultType, id, orignalValuePtr, scopeId,
+                             memorySemanticsId, valueToOp);
+  instBuilder.x();
   insertPoint->appendInstruction(std::move(constructSite));
   return id;
 }

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -1528,16 +1528,15 @@ SPIRVEmitter::processACSBufferAppendConsume(const CXXMemberCallExpr *expr) {
   uint32_t index = 0;
   if (isAppend) {
     // For append, we add one to the counter.
-    index = theBuilder.createAtomicIAdd(u32Type, counterPtr, one, zero, one);
+    index = theBuilder.createAtomicIAddSub(u32Type, counterPtr, one, zero, one,
+                                           /*isAdd=*/true);
   } else {
     // For consume, we substract one from the counter. Note that OpAtomicIAdd
     // returns the value before the addition; so we need to do substraction
     // again with OpAtomicIAdd's return value.
-    const uint32_t negOne = theBuilder.getConstantInt32(-1);
-    const auto prevIndex =
-        theBuilder.createAtomicIAdd(u32Type, counterPtr, one, zero, negOne);
-    index =
-        theBuilder.createBinaryOp(spv::Op::OpIAdd, u32Type, prevIndex, negOne);
+    const auto prevIndex = theBuilder.createAtomicIAddSub(
+        u32Type, counterPtr, one, zero, one, /*isAdd=*/false);
+    index = theBuilder.createBinaryOp(spv::Op::OpISub, u32Type, prevIndex, one);
   }
 
   LayoutRule lhsLayout = LayoutRule::Void;

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -106,6 +106,9 @@ private:
   /// the type with correct layout decorations.
   uint32_t getType(const Expr *expr);
 
+  /// Returns the proper pointer type for the given expr. Similar to the above.
+  uint32_t getPointerType(const Expr *expr);
+
   /// Translates the given frontend binary operator into its SPIR-V equivalent
   /// taking consideration of the operand type.
   spv::Op translateOp(BinaryOperator::Opcode op, QualType type);
@@ -440,6 +443,11 @@ private:
   /// \brief Generates an OpAccessChain instruction for the given
   /// (RW)StructuredBuffer.Load() method call.
   uint32_t processStructuredBufferLoad(const CXXMemberCallExpr *expr);
+
+  /// \brief Generates SPIR-V instructions for the .Append()/.Consume() call on
+  /// the given {Append|Consume}StructuredBuffer. Returns the <result-id> of
+  /// the loaded value for .Consume; returns zero for .Append().
+  uint32_t processACSBufferAppendConsume(const CXXMemberCallExpr *expr);
 
 private:
   /// \brief Wrapper method to create an error message and report it

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -54,6 +54,11 @@ public:
                          LayoutRule layoutRule = LayoutRule::Void,
                          bool isRowMajor = false);
 
+  /// \brief Generates the SPIR-V type for the counter associated with a
+  /// {Append|Consume}StructuredBuffer: an OpTypeStruct with a single 32-bit
+  /// integer value. This type will be decorated with BufferBlock.
+  uint32_t getACSBufferCounter();
+
   /// \brief Returns true if the given type is the HLSL ByteAddressBufferType.
   bool isByteAddressBuffer(QualType type);
 
@@ -166,6 +171,9 @@ private:
   /// \bried For the given sampled type, returns the corresponding image format
   /// that can be used to create an image object.
   spv::ImageFormat translateSampledTypeToImageFormat(QualType type);
+
+  /// \brief Returns a string name for the given type.
+  static std::string getName(QualType type);
 
 private:
   ASTContext &astContext;

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
@@ -1,0 +1,40 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float    a;
+    float3   b;
+    float2x3 c;
+};
+
+AppendStructuredBuffer<float4> buffer1;
+AppendStructuredBuffer<S>      buffer2;
+
+void main(float4 vec: A) {
+// CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
+// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %uint_1
+// CHECK-NEXT: [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 [[index]]
+// CHECK-NEXT: [[vec:%\d+]] = OpLoad %v4float %vec
+// CHECK-NEXT: OpStore [[buffer1]] [[vec]]
+    buffer1.Append(vec);
+
+    S s; // Will use a separate S type without layout decorations
+
+// CHECK-NEXT: [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer2 %uint_0
+// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %uint_1
+
+// CHECK-NEXT: [[buffer2:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffer2 %uint_0 [[index]]
+// CHECK-NEXT: [[s:%\d+]] = OpLoad %S_0 %s
+
+// CHECK-NEXT: [[s0:%\d+]] = OpCompositeExtract %float [[s]] 0
+// CHECK-NEXT: [[buffer20:%\d+]] = OpAccessChain %_ptr_Uniform_float [[buffer2]] %uint_0
+// CHECK-NEXT: OpStore [[buffer20]] [[s0]]
+
+// CHECK-NEXT: [[s1:%\d+]] = OpCompositeExtract %v3float [[s]] 1
+// CHECK-NEXT: [[buffer21:%\d+]] = OpAccessChain %_ptr_Uniform_v3float [[buffer2]] %uint_1
+// CHECK-NEXT: OpStore [[buffer21]] [[s1]]
+
+// CHECK-NEXT: [[s2:%\d+]] = OpCompositeExtract %mat2v3float [[s]] 2
+// CHECK-NEXT: [[buffer22:%\d+]] = OpAccessChain %_ptr_Uniform_mat2v3float [[buffer2]] %uint_2
+// CHECK-NEXT: OpStore [[buffer22]] [[s2]]
+    buffer2.Append(s);
+}

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
@@ -1,0 +1,44 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float    a;
+    float3   b;
+    float2x3 c;
+};
+
+ConsumeStructuredBuffer<float4> buffer1;
+ConsumeStructuredBuffer<S>      buffer2;
+
+float4 main() : A {
+// CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %int_n1
+// CHECK-NEXT: [[index:%\d+]] = OpIAdd %uint [[prev]] %int_n1
+// CHECK-NEXT: [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 [[index]]
+// CHECK-NEXT: [[val:%\d+]] = OpLoad %v4float [[buffer1]]
+// CHECK-NEXT: OpStore %v [[val]]
+    float4 v = buffer1.Consume();
+
+    S s; // Will use a separate S type without layout decorations
+
+// CHECK-NEXT: [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer2 %uint_0
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %int_n1
+// CHECK-NEXT: [[index:%\d+]] = OpIAdd %uint [[prev]] %int_n1
+
+// CHECK-NEXT: [[buffer2:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffer2 %uint_0 [[index]]
+// CHECK-NEXT: [[val:%\d+]] = OpLoad %S [[buffer2]]
+
+// CHECK-NEXT: [[buffer20:%\d+]] = OpCompositeExtract %float [[val]] 0
+// CHECK-NEXT: [[s0:%\d+]] = OpAccessChain %_ptr_Function_float %s %uint_0
+// CHECK-NEXT: OpStore [[s0]] [[buffer20]]
+
+// CHECK-NEXT: [[buffer21:%\d+]] = OpCompositeExtract %v3float [[val]] 1
+// CHECK-NEXT: [[s1:%\d+]] = OpAccessChain %_ptr_Function_v3float %s %uint_1
+// CHECK-NEXT: OpStore [[s1]] [[buffer21]]
+
+// CHECK-NEXT: [[buffer22:%\d+]] = OpCompositeExtract %mat2v3float [[val]] 2
+// CHECK-NEXT: [[s2:%\d+]] = OpAccessChain %_ptr_Function_mat2v3float %s %uint_2
+// CHECK-NEXT: OpStore [[s2]] [[buffer22]]
+    s = buffer2.Consume();
+
+    return v;
+}

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
@@ -11,8 +11,8 @@ ConsumeStructuredBuffer<S>      buffer2;
 
 float4 main() : A {
 // CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
-// CHECK-NEXT: [[prev:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %int_n1
-// CHECK-NEXT: [[index:%\d+]] = OpIAdd %uint [[prev]] %int_n1
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %uint [[counter]] %uint_1 %uint_0 %uint_1
+// CHECK-NEXT: [[index:%\d+]] = OpISub %uint [[prev]] %uint_1
 // CHECK-NEXT: [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 [[index]]
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %v4float [[buffer1]]
 // CHECK-NEXT: OpStore %v [[val]]
@@ -21,8 +21,8 @@ float4 main() : A {
     S s; // Will use a separate S type without layout decorations
 
 // CHECK-NEXT: [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer2 %uint_0
-// CHECK-NEXT: [[prev:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %int_n1
-// CHECK-NEXT: [[index:%\d+]] = OpIAdd %uint [[prev]] %int_n1
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %uint [[counter]] %uint_1 %uint_0 %uint_1
+// CHECK-NEXT: [[index:%\d+]] = OpISub %uint [[prev]] %uint_1
 
 // CHECK-NEXT: [[buffer2:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffer2 %uint_0 [[index]]
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %S [[buffer2]]

--- a/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpName %type_AppendStructuredBuffer_v4float "type.AppendStructuredBuffer.v4float"
+// CHECK: OpName %buffer1 "buffer1"
+
+// CHECK: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
+// CHECK: OpName %counter_var_buffer1 "counter.var.buffer1"
+
+// CHECK: OpName %type_AppendStructuredBuffer_S "type.AppendStructuredBuffer.S"
+// CHECK: OpName %buffer2 "buffer2"
+
+// CHECK: OpName %counter_var_buffer2 "counter.var.buffer2"
+
+// CHECK: %type_AppendStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
+// CHECK: %_ptr_Uniform_type_AppendStructuredBuffer_v4float = OpTypePointer Uniform %type_AppendStructuredBuffer_v4float
+
+// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
+// CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
+
+// CHECK: %type_AppendStructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_AppendStructuredBuffer_S = OpTypePointer Uniform %type_AppendStructuredBuffer_S
+
+// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_v4float Uniform
+// CHECK: %counter_var_buffer1 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+AppendStructuredBuffer<float4> buffer1;
+
+struct S {
+    float a;
+    float3 b;
+    float2x3 c;
+};
+
+// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_AppendStructuredBuffer_S Uniform
+// CHECK: %counter_var_buffer2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+AppendStructuredBuffer<S> buffer2;
+
+float main() : A {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpName %type_ConsumeStructuredBuffer_v4float "type.ConsumeStructuredBuffer.v4float"
+// CHECK: OpName %buffer1 "buffer1"
+
+// CHECK: OpName %type_ACSBuffer_counter "type.ACSBuffer.counter"
+// CHECK: OpName %counter_var_buffer1 "counter.var.buffer1"
+
+// CHECK: OpName %type_ConsumeStructuredBuffer_S "type.ConsumeStructuredBuffer.S"
+// CHECK: OpName %buffer2 "buffer2"
+
+// CHECK: OpName %counter_var_buffer2 "counter.var.buffer2"
+
+// CHECK: %type_ConsumeStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
+// CHECK: %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float = OpTypePointer Uniform %type_ConsumeStructuredBuffer_v4float
+
+// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
+// CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
+
+// CHECK: %type_ConsumeStructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_ConsumeStructuredBuffer_S = OpTypePointer Uniform %type_ConsumeStructuredBuffer_S
+
+// CHECK: %buffer1 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_v4float Uniform
+// CHECK: %counter_var_buffer1 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+ConsumeStructuredBuffer<float4> buffer1;
+
+struct S {
+    float a;
+    float3 b;
+    float2x3 c;
+};
+
+// CHECK: %buffer2 = OpVariable %_ptr_Uniform_type_ConsumeStructuredBuffer_S Uniform
+// CHECK: %counter_var_buffer2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+ConsumeStructuredBuffer<S> buffer2;
+
+float main() : A {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -46,6 +46,9 @@ struct S {
 [[vk::binding(2, 3)]]
 RWStructuredBuffer<S> sbuffer2 : register(u6);
 
+// TODO: support [[vk::binding()]] on AppendStructuredBuffer
+// TODO: support [[vk::binding()]] on ConsumeStructuredBuffer
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
@@ -45,6 +45,18 @@ ConstantBuffer<S> myCbuffer2;
 // CHECK-NEXT: OpDecorate %sbuffer2 Binding 9
 RWStructuredBuffer<S> sbuffer2;
 
+// CHECK:      OpDecorate %abuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %abuffer Binding 10
+// CHECK-NEXT: OpDecorate %counter_var_abuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 11
+AppendStructuredBuffer<S> abuffer;
+
+// CHECK:      OpDecorate %csbuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %csbuffer Binding 12
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 13
+ConsumeStructuredBuffer<S> csbuffer;
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -61,6 +61,20 @@ ConstantBuffer<S> myCbuffer3 : register(b2, space3);
 // CHECK-NEXT: OpDecorate %sbuffer2 Binding 6
 RWStructuredBuffer<S> sbuffer2 : register(u6, space1);
 
+    // The counter variable will use the next unassigned number
+// CHECK:      OpDecorate %abuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %abuffer Binding 5
+// CHECK-NEXT: OpDecorate %counter_var_abuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 4
+AppendStructuredBuffer<S> abuffer : register(u5);
+
+    // The counter variable will use the next unassigned number
+// CHECK:      OpDecorate %csbuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %csbuffer Binding 7
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 6
+ConsumeStructuredBuffer<S> csbuffer : register(u7);
+
 float4 main() : SV_Target {
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.asbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.asbuffer.std430.hlsl
@@ -1,0 +1,52 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate %_arr_float_uint_2 ArrayStride 4
+// CHECK: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
+// CHECK: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
+// CHECK: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
+
+// CHECK: OpMemberDecorate %S 0 Offset 0
+// CHECK: OpMemberDecorate %S 1 Offset 16
+// CHECK: OpMemberDecorate %S 2 Offset 48
+// CHECK: OpMemberDecorate %S 2 MatrixStride 16
+// CHECK: OpMemberDecorate %S 2 ColMajor
+// CHECK: OpMemberDecorate %S 3 Offset 112
+// CHECK: OpMemberDecorate %S 3 MatrixStride 8
+// CHECK: OpMemberDecorate %S 3 RowMajor
+// CHECK: OpMemberDecorate %S 4 Offset 160
+// CHECK: OpMemberDecorate %S 4 MatrixStride 8
+// CHECK: OpMemberDecorate %S 4 RowMajor
+// CHECK: OpMemberDecorate %S 5 Offset 208
+
+// CHECK: OpDecorate %_arr_S_uint_2 ArrayStride 224
+
+// CHECK: OpMemberDecorate %T 0 Offset 0
+// CHECK: OpMemberDecorate %T 1 Offset 448
+
+// CHECK: OpDecorate %_runtimearr_T ArrayStride 464
+
+// CHECK: OpMemberDecorate %type_AppendStructuredBuffer_T 0 Offset 0
+// CHECK: OpDecorate %type_AppendStructuredBuffer_T BufferBlock
+
+// CHECK: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
+// CHECK: OpDecorate %type_ACSBuffer_counter BufferBlock
+struct S {
+                 float    a[2];
+                 float3   b[2];
+    row_major    float2x3 c[2];
+    column_major float2x3 d[2];
+                 float2x3 e[2];
+                 int      f;
+};
+
+struct T {
+    S    s[2];
+    uint t;
+};
+
+AppendStructuredBuffer<T> buffer2;
+
+float main() : A {
+    return 1.0;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.csbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.csbuffer.std430.hlsl
@@ -1,0 +1,51 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate %_arr_float_uint_2 ArrayStride 4
+// CHECK: OpDecorate %_arr_v3float_uint_2 ArrayStride 16
+// CHECK: OpDecorate %_arr_mat2v3float_uint_2 ArrayStride 32
+// CHECK: OpDecorate %_arr_mat2v3float_uint_2_0 ArrayStride 24
+
+// CHECK: OpMemberDecorate %S 0 Offset 0
+// CHECK: OpMemberDecorate %S 1 Offset 16
+// CHECK: OpMemberDecorate %S 2 Offset 48
+// CHECK: OpMemberDecorate %S 2 MatrixStride 16
+// CHECK: OpMemberDecorate %S 2 ColMajor
+// CHECK: OpMemberDecorate %S 3 Offset 112
+// CHECK: OpMemberDecorate %S 3 MatrixStride 8
+// CHECK: OpMemberDecorate %S 3 RowMajor
+// CHECK: OpMemberDecorate %S 4 Offset 160
+// CHECK: OpMemberDecorate %S 4 MatrixStride 8
+// CHECK: OpMemberDecorate %S 4 RowMajor
+// CHECK: OpMemberDecorate %S 5 Offset 208
+
+// CHECK: OpDecorate %_arr_S_uint_2 ArrayStride 224
+
+// CHECK: OpMemberDecorate %T 0 Offset 0
+// CHECK: OpMemberDecorate %T 1 Offset 448
+
+// CHECK: OpDecorate %_runtimearr_T ArrayStride 464
+
+// CHECK: OpMemberDecorate %type_ConsumeStructuredBuffer_T 0 Offset 0
+// CHECK: OpDecorate %type_ConsumeStructuredBuffer_T BufferBlock
+
+// CHECK: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
+// CHECK: OpDecorate %type_ACSBuffer_counter BufferBlock
+struct S {
+                 float    a[2];
+                 float3   b[2];
+    row_major    float2x3 c[2];
+    column_major float2x3 d[2];
+                 float2x3 e[2];
+                 int      f;
+};
+
+struct T {
+    S    s[2];
+    uint t;
+};
+
+ConsumeStructuredBuffer<T> buffer2;
+
+float main() : A {
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -56,6 +56,12 @@ TEST_F(FileTest, ConstantBufferType) {
 TEST_F(FileTest, StructuredBufferType) {
   runFileTest("type.structured-buffer.hlsl");
 }
+TEST_F(FileTest, AppendStructuredBufferType) {
+  runFileTest("type.append-structured-buffer.hlsl");
+}
+TEST_F(FileTest, ConsumeStructuredBufferType) {
+  runFileTest("type.consume-structured-buffer.hlsl");
+}
 TEST_F(FileTest, ByteAddressBufferTypes) {
   runFileTest("type.byte-address-buffer.hlsl");
 }
@@ -360,6 +366,12 @@ TEST_F(FileTest, TextureArraySampleGrad) {
 TEST_F(FileTest, StructuredBufferLoad) {
   runFileTest("method.structured-buffer.load.hlsl");
 }
+TEST_F(FileTest, AppendStructuredBufferAppend) {
+  runFileTest("method.append-structured-buffer.append.hlsl");
+}
+TEST_F(FileTest, ConsumeStructuredBufferConsume) {
+  runFileTest("method.consume-structured-buffer.consume.hlsl");
+}
 // For ByteAddressBuffer methods
 TEST_F(FileTest, ByteAddressBufferLoad) {
   runFileTest("method.byte-address-buffer.load.hlsl");
@@ -491,6 +503,12 @@ TEST_F(FileTest, VulkanLayoutSBufferStd430) {
 }
 TEST_F(FileTest, VulkanLayoutSBufferNestedStd430) {
   runFileTest("vk.layout.sbuffer.nested.std430.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutAppendSBufferStd430) {
+  runFileTest("vk.layout.asbuffer.std430.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutConsumeSBufferStd430) {
+  runFileTest("vk.layout.csbuffer.std430.hlsl");
 }
 
 } // namespace


### PR DESCRIPTION
* Supported the `{Append|Consume}StructureBuffer` type
* Supported `.Append()` and `.Consume()`

`{Append|Consume}StructureBuffer<S>` is implemented as `OpTypeStruct`
with an `OpTypeRuntimeArray` of `S`. And each such array will have
an associated counter, whose type is `OpTypeStruct` of 32-bit integer.
The index for `.Append()`/`.Conume()` is fetched by doing atomic
operations on the associated counter.