### PR TITLE
Upload artifacts in Appveyor Artifacts page

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,31 +1,33 @@
 version: 1.0.{build}
+
 image: Visual Studio 2017
 platform: x64
 configuration: Debug
+
 clone_folder: c:\projects\DirectXShaderCompiler
+clone_depth: 1
+
 environment:
   HLSL_SRC_DIR: c:\projects\DirectXShaderCompiler
-  HLSL_BLD_DIR: c:\projects\DirectXShaderCompiler.bin
+  HLSL_BLD_DIR: c:\projects\DirectXShaderCompiler\build
+
 install:
 - ps: c:\projects\DirectXShaderCompiler\utils\appveyor\appveyor_setup.ps1
 - git submodule update --init --recursive
+
+before_build:
+- cmd: call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+
 build_script:
-- cmd: >-
-    cd %HLSL_SRC_DIR%
+- cmd: call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017 -spirvtest
 
-    call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
-
-    call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017 -spirvtest
 test_script:
-- cmd: >-
-    cd %HLSL_SRC_DIR%
-
-    call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
-
-    powershell utils\appveyor\appveyor_test.ps1
-# Running SPIR-V tests
-- cmd: >-
-    %HLSL_BLD_DIR%\%CONFIGURATION%\bin\clang-spirv-tests.exe --spirv-test-root %HLSL_SRC_DIR%\tools\clang\test\CodeGenSPIRV
+- cmd: powershell utils\appveyor\appveyor_test.ps1
+- cmd: call utils\hct\hcttest spirv_only
+    
+artifacts:
+- path: build\$(configuration)\bin\*.dll
+- path: build\$(configuration)\bin\*.exe
 
 notifications:
 - provider: GitHubPullRequest


### PR DESCRIPTION
This pull request enables uploading build artifacts to Appveyor Artifacts
page. I've tried out this pull request and it works. You can check it [here](https://ci.appveyor.com/project/antiagainst/directxshadercompiler/build/1.0.504/artifacts).

With this, devs can just directly download the latest build from Appveyor
instead of building by themselves.

All `.exe` and `.dll` in the `build` directly are uploaded. We can revisit
the list later if necessary.

Also made a few other changes to the script:
* Change Git clone depth to 1
* Removed duplicated env setting commands (the default CD is already
  source repo root)