### PR TITLE
Fix the support for -O4

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -327,7 +327,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     }
   }
 
-  if (Arg *A = Args.getLastArg(OPT_O0, OPT_O1, OPT_O2, OPT_O3)) {
+  if (Arg *A = Args.getLastArg(OPT_O0, OPT_O1, OPT_O2, OPT_O3, OPT_O4)) {
     if (A->getOption().matches(OPT_O0))
       opts.OptLevel = 0;
     if (A->getOption().matches(OPT_O1))
@@ -336,6 +336,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       opts.OptLevel = 2;
     if (A->getOption().matches(OPT_O3))
       opts.OptLevel = 3;
+    if (A->getOption().matches(OPT_O4))
+      opts.OptLevel = 4;
   }
   else
     opts.OptLevel = 3;

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.def
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.def
@@ -93,7 +93,9 @@ CODEGENOPT(NoZeroInitializedInBSS , 1, 0) ///< -fno-zero-initialized-in-bss.
 ENUM_CODEGENOPT(ObjCDispatchMethod, ObjCDispatchMethodKind, 2, Legacy) 
 CODEGENOPT(OmitLeafFramePointer , 1, 0) ///< Set when -momit-leaf-frame-pointer is
                                         ///< enabled.
-VALUE_CODEGENOPT(OptimizationLevel, 2, 0) ///< The -O[0-3] option specified.
+// HLSL Change Starts - 2 bits -> 4 bits, -O[0-3] -> -O[0-4]
+VALUE_CODEGENOPT(OptimizationLevel, 4, 0) ///< The -O[0-4] option specified.
+// HLSL Change Ends
 VALUE_CODEGENOPT(OptimizeSize, 2, 0) ///< If -Os (==1) or -Oz (==2) is specified.
 
 CODEGENOPT(ProfileInstrGenerate , 1, 0) ///< Instrument code to generate


### PR DESCRIPTION
LLVM/Clang originally only supports upto -O3. So only two bits are
allocated for storing the level. We are supporting -O[0-4] instead,
so need to enlarge the storage to avoid treating -O4 as -O0.