### PR TITLE
[spirv] Add support explicit binding for CTBuffer

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -865,7 +865,7 @@ def VKLocation : InheritableAttr {
 
 def VKBinding : InheritableAttr {
   let Spellings = [CXX11<"vk", "binding">];
-  let Subjects = SubjectList<[GlobalVar], ErrorDiag, "ExpectedVariable">;
+  let Subjects = SubjectList<[GlobalVar, HLSLBuffer], ErrorDiag, "ExpectedVariable">;
   let Args = [IntArgument<"Binding">, DefaultIntArgument<"Set", 0>];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
@@ -1421,7 +1421,7 @@ def Overloadable : Attr {
   let Documentation = [OverloadableDocs];
 }
 
-def Override : InheritableAttr { 
+def Override : InheritableAttr {
   let Spellings = [Keyword<"override">];
   let SemaHandler = 0;
   let Documentation = [Undocumented];
@@ -1488,7 +1488,7 @@ def ReqdWorkGroupSize : InheritableAttr {
 
 def WorkGroupSizeHint :  InheritableAttr {
   let Spellings = [GNU<"work_group_size_hint">];
-  let Args = [UnsignedArgument<"XDim">, 
+  let Args = [UnsignedArgument<"XDim">,
               UnsignedArgument<"YDim">,
               UnsignedArgument<"ZDim">];
   let Subjects = SubjectList<[Function], ErrorDiag>;

--- a/tools/clang/include/clang/Parse/Parser.h
+++ b/tools/clang/include/clang/Parse/Parser.h
@@ -2377,9 +2377,9 @@ private:
 
   // HLSL Change Starts
   Decl *ParseCTBuffer(unsigned Context, SourceLocation &DeclEnd,
-    SourceLocation InlineLoc = SourceLocation());
+    ParsedAttributesWithRange &attrs, SourceLocation InlineLoc = SourceLocation());
   Decl *ParseConstBuffer(unsigned Context, SourceLocation &DeclEnd,
-    SourceLocation InlineLoc = SourceLocation());
+    ParsedAttributesWithRange &attrs, SourceLocation InlineLoc = SourceLocation());
   // HLSL Change Ends
 
   Decl *ParseNamespace(unsigned Context, SourceLocation &DeclEnd,

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -1922,13 +1922,11 @@ Parser::DeclGroupPtrTy Parser::ParseDeclaration(unsigned Context,
   // HLSL Change Starts
   case tok::kw_cbuffer:
   case tok::kw_tbuffer:
-    ProhibitAttributes(attrs);
-    SingleDecl = ParseCTBuffer(Context, DeclEnd);
+    SingleDecl = ParseCTBuffer(Context, DeclEnd, attrs);
     break;
   case tok::kw_ConstantBuffer:
   case tok::kw_TextureBuffer:
-    ProhibitAttributes(attrs);
-    SingleDecl = ParseConstBuffer(Context, DeclEnd);
+    SingleDecl = ParseConstBuffer(Context, DeclEnd, attrs);
     break;
   // HLSL Change Ends
   case tok::kw_namespace:

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -30,12 +30,21 @@ Buffer<int> myBuffer : register(t1, space0);
 [[vk::binding(4, 1)]]
 RWBuffer<float4> myRWBuffer : register(u0, space1);
 
-// TODO: support [[vk::binding()]] on cbuffer
-// TODO: support [[vk::binding()]] on ConstantBuffer
+// CHECK: OpDecorate %var_myCBuffer DescriptorSet 3
+// CHECK-NEXT: OpDecorate %var_myCBuffer Binding 10
+[[vk::binding(10, 3)]]
+cbuffer myCBuffer : register(b5, space1) {
+    float cbfield;
+};
 
 struct S {
     float f;
 };
+
+// CHECK: OpDecorate %myConstantBuffer DescriptorSet 3
+// CHECK-NEXT: OpDecorate %myConstantBuffer Binding 5
+[[vk::binding(5, 3)]]
+ConstantBuffer<S> myConstantBuffer: register(b1, space1);
 
 // CHECK:      OpDecorate %sbuffer1 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %sbuffer1 Binding 3

--- a/tools/clang/test/HLSL/cxx11-attributes.hlsl
+++ b/tools/clang/test/HLSL/cxx11-attributes.hlsl
@@ -1,9 +1,17 @@
 // RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
 
+[[vk::binding(4, 3)]] // expected-warning {{'binding' attribute ignored}}
+cbuffer myCBuffer {
+    float cbfield;
+};
+
 struct S {
     [[vk::location(1)]] // expected-warning {{'location' attribute ignored}}
     float a: A;
 };
+
+[[vk::binding(5, 3)]] // expected-warning {{'binding' attribute ignored}}
+ConstantBuffer<S> myConstantBuffer;
 
 [[maybe_unused]] // expected-warning {{unknown attribute 'maybe_unused' ignored}}
 float main([[scope::attr(0, "str")]] // expected-warning {{unknown attribute 'attr' ignored}}


### PR DESCRIPTION
This commit adds support for explicit binding assignment in
cbuffer/tbuffer/ConstantBuffer/TextureBuffer.