### PR TITLE
Update version to 2017 10

### DIFF
--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -960,14 +960,14 @@ function(hlsl_update_product_ver RC_INTERNAL_NAME)
                  "RC_COMPANY_NAME=\"Microsoft(r) Corporation\""
                  "RC_VERSION_FIELD_1=0"
                  "RC_VERSION_FIELD_2=2017"
-                 "RC_VERSION_FIELD_3=6"
+                 "RC_VERSION_FIELD_3=10"
                  "RC_VERSION_FIELD_4=0"
-                 "RC_FILE_VERSION=\"0.2017.6.0\""
+                 "RC_FILE_VERSION=\"0.2017.10.0\""
                  "RC_FILE_DESCRIPTION=\"DirectX Compiler - Out Of Band\""
                  "RC_INTERNAL_NAME=\"${RC_INTERNAL_NAME}\""
                  "RC_COPYRIGHT=\"(c) Microsoft Corporation. All rights reserved.\""
                  "RC_PRODUCT_NAME=\"Microsoft(r) DirectX for Windows(r) - Out Of Band\""
-                 "RC_PRODUCT_VERSION=\"0.2017.6.0\"")
+                 "RC_PRODUCT_VERSION=\"0.2017.10.0\"")
   endif (HLSL_ENABLE_FIXED_VER)
 endfunction(hlsl_update_product_ver)
 # HLSL Change Ends

--- a/tools/clang/lib/Basic/CMakeLists.txt
+++ b/tools/clang/lib/Basic/CMakeLists.txt
@@ -32,7 +32,7 @@ set(get_svn_script "${LLVM_MAIN_SRC_DIR}/cmake/modules/GetSVN.cmake")
 
 # HLSL Change Starts
 if (HLSL_ENABLE_FIXED_VER)
-  add_definitions(/DHLSL_FIXED_VER="dxcoob 2017.6")
+  add_definitions(/DHLSL_FIXED_VER="dxcoob 2017.10")
 endif (HLSL_ENABLE_FIXED_VER)
 # HLSL Change Ends
 


### PR DESCRIPTION
Updating dxcompiler file version and llvm.ident version to 2017 10 for new release. 