### PR TITLE
Fix Windows SDK check in dxexp.cpp

### DIFF
--- a/tools/dxexp/dxexp.cpp
+++ b/tools/dxexp/dxexp.cpp
@@ -44,7 +44,7 @@ static HRESULT AtlCheck(HRESULT hr) {
 }
 
 // Not defined in Creators Update version of d3d12.h:
-#ifndef D3D12_FEATURE_DATA_D3D12_OPTIONS3
+#if WDK_NTDDI_VERSION <= NTDDI_WIN10_RS2
 #define D3D_SHADER_MODEL_6_1 ((D3D_SHADER_MODEL)0x61)
 #define D3D12_FEATURE_D3D12_OPTIONS3 ((D3D12_FEATURE)21)
 typedef


### PR DESCRIPTION
dxexp.cpp tries to define some types if they are not found in
the SDK. However, we cannot use #ifndef to test whether a type
is defined or not. Use WDK_NTDDI_VERSION instead to do the
check instead.

d3d12.h in Windows SDK 10.0.16299.0 defined the types we want in
dxexp.cpp, but the one in Windows SDK 10.0.15063.0 does not.
WDK_NTDDI_VERSION is set to NTDDI_WIN10_RS3 for the former, and
NTDDI_WIN10_RS2 for the later.