### PR TITLE
PIX Debugger: Specify undefined values for unused arguments...

### DIFF
--- a/tools/clang/test/HLSL/pix/DebugBasic.hlsl
+++ b/tools/clang/test/HLSL/pix/DebugBasic.hlsl
@@ -20,7 +20,7 @@
 // CHECK: %MaskedForUAVLimit = and i32 %UAVIncResult, 983039
 // CHECK: %MultipliedForInterest = mul i32 %MaskedForUAVLimit, %OffsetMultiplicand
 // CHECK: %AddedForInterest = add i32 %MultipliedForInterest, %OffsetAddend
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest, i32 0, i32 0, i32 0, i32 0, i32 0, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest, i32 undef, i32 0, i32 undef, i32 undef, i32 undef, i8 1)
 
 
 [RootSignature("")]

--- a/tools/clang/test/HLSL/pix/DebugFlowControl.hlsl
+++ b/tools/clang/test/HLSL/pix/DebugFlowControl.hlsl
@@ -8,7 +8,7 @@
 // CHECK:  %MaskedForUAVLimit16 = and i32 %UAVIncResult15, 983039
 // CHECK:  %MultipliedForInterest17 = mul i32 %MaskedForUAVLimit16, %OffsetMultiplicand
 // CHECK:  %AddedForInterest18 = add i32 %MultipliedForInterest17, %OffsetAddend
-// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest18, i32 0, i32 64257, i32 0, i32 0, i32 0, i8 1)
+// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest18, i32 undef, i32 64257, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK:  switch i32
 // CHECK:    i32 0, label 
 // CHECK:    i32 32, label


### PR DESCRIPTION
These values were upsetting a particular IHV's driver.
It's much happier when undefined values are passed for the unused ones.
(Also deleted an unused/unnecessary scope inside runOnModule.)
