### PR TITLE
[spirv] Add support for four register number shifting options

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -655,23 +655,24 @@ Explicit binding number assignment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``[[vk::binding(X[, Y])]]`` can be attached to global variables to specify the
-descriptor set ``Y`` and binding ``X``. The descriptor set number is optional;
-if missing, it will be zero.
+descriptor set as ``Y`` and binding number as ``X``. The descriptor set number
+is optional; if missing, it will be zero.
 
 Implicit binding number assignment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Without explicit annotations, the compiler will try to deduce descriptor set and
-binding numbers in the following way:
+Without explicit annotations, the compiler will try to deduce descriptor sets
+and binding numbers in the following way:
 
 If there is ``:register(xX, spaceY)`` specified for the given global variable,
 the corresponding resource will be assigned to descriptor set ``Y`` and binding
-number ``X``, regardless the register type ``x``. Note that this will cause
+number ``X``, regardless of the register type ``x``. Note that this will cause
 binding number collision if, say, two resources are of different register
 type but the same register number. To solve this problem, four command-line
 options, ``-fvk-b-shift M N``, ``-fvk-s-shift M N``, ``-fvk-t-shift M N``, and
-``-fvk-u-shift M N``, are provided to shift all binding numbers in space ``M``
-of register type ``b``, ``s``, ``t``, and ``u`` by ``N``, respectively.
+``-fvk-u-shift M N``, are provided to shift by ``N`` all binding numbers
+inferred for register type ``b``, ``s``, ``t``, and ``u`` in space ``M``,
+respectively.
 
 If there is no register specification, the corresponding resource will be
 assigned to the next available binding number, starting from 0, in descriptor
@@ -1788,14 +1789,14 @@ codegen for Vulkan:
 - ``-fvk-b-shift M N``: Shifts by ``N`` the inferred binding numbers for all
   resources in b-type registers of space ``M``. Specifically, for a resouce
   attached with ``:register(bX, spaceM)`` but not ``[vk::binding(...)]``,
-  sets its Vulkan binding set to ``M`` and binding number to ``X + N``. If you
-  need to shift the inferred binding numbers for more than one space, provide
-  more than one such option. If more than one such option is provided for the
-  same space, the last one takes effect. See `HLSL register and Vulkan binding`_
-  for explanation and examples.
+  sets its Vulkan descriptor set to ``M`` and binding number to ``X + N``. If
+  you need to shift the inferred binding numbers for more than one space,
+  provide more than one such option. If more than one such option is provided
+  for the same space, the last one takes effect. See `HLSL register and Vulkan
+  binding`_ for explanation and examples.
 - ``-fvk-t-shift M N``, similar to ``-fvk-b-shift``, but for t-type registers.
 - ``-fvk-s-shift M N``, similar to ``-fvk-b-shift``, but for s-type registers.
 - ``-fvk-u-shift M N``, similar to ``-fvk-b-shift``, but for u-type registers.
-- ``-fvk-stage-io-order={alpha|decl}``: Sets the stage input/output variable
+- ``-fvk-stage-io-order={alpha|decl}``: Assigns the stage input/output variable
   location number according to alphabetical order or declaration order. See
   `HLSL semantic and Vulkan Location`_ for more details.

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -669,8 +669,8 @@ the corresponding resource will be assigned to descriptor set ``Y`` and binding
 number ``X``, regardless of the register type ``x``. Note that this will cause
 binding number collision if, say, two resources are of different register
 type but the same register number. To solve this problem, four command-line
-options, ``-fvk-b-shift M N``, ``-fvk-s-shift M N``, ``-fvk-t-shift M N``, and
-``-fvk-u-shift M N``, are provided to shift by ``N`` all binding numbers
+options, ``-fvk-b-shift N M``, ``-fvk-s-shift N M``, ``-fvk-t-shift N M``, and
+``-fvk-u-shift N M``, are provided to shift by ``N`` all binding numbers
 inferred for register type ``b``, ``s``, ``t``, and ``u`` in space ``M``,
 respectively.
 
@@ -687,7 +687,7 @@ In summary, the compiler essentially assigns binding numbers in three passes.
   annotation.
 - Then the compiler processes all remaining declarations with
   ``:register(xX, spaceY)`` annotation, by applying the shift passed in using
-  command-line option ``-fvk-{b|s|t|u}-shift M N``, if provided.
+  command-line option ``-fvk-{b|s|t|u}-shift N M``, if provided.
 - Finally, the compiler assigns next available binding numbers to the rest in
   the declaration order.
 
@@ -1786,7 +1786,7 @@ The following command line options are added into ``dxc`` to support SPIR-V
 codegen for Vulkan:
 
 - ``-spirv``: Generates SPIR-V code.
-- ``-fvk-b-shift M N``: Shifts by ``N`` the inferred binding numbers for all
+- ``-fvk-b-shift N M``: Shifts by ``N`` the inferred binding numbers for all
   resources in b-type registers of space ``M``. Specifically, for a resouce
   attached with ``:register(bX, spaceM)`` but not ``[vk::binding(...)]``,
   sets its Vulkan descriptor set to ``M`` and binding number to ``X + N``. If
@@ -1794,9 +1794,9 @@ codegen for Vulkan:
   provide more than one such option. If more than one such option is provided
   for the same space, the last one takes effect. See `HLSL register and Vulkan
   binding`_ for explanation and examples.
-- ``-fvk-t-shift M N``, similar to ``-fvk-b-shift``, but for t-type registers.
-- ``-fvk-s-shift M N``, similar to ``-fvk-b-shift``, but for s-type registers.
-- ``-fvk-u-shift M N``, similar to ``-fvk-b-shift``, but for u-type registers.
+- ``-fvk-t-shift N M``, similar to ``-fvk-b-shift``, but for t-type registers.
+- ``-fvk-s-shift N M``, similar to ``-fvk-b-shift``, but for s-type registers.
+- ``-fvk-u-shift N M``, similar to ``-fvk-b-shift``, but for u-type registers.
 - ``-fvk-stage-io-order={alpha|decl}``: Assigns the stage input/output variable
   location number according to alphabetical order or declaration order. See
   `HLSL semantic and Vulkan Location`_ for more details.

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -160,7 +160,11 @@ public:
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
   bool GenSPIRV; // OPT_spirv
-  llvm::StringRef VkStageIoOrder;
+  llvm::StringRef VkStageIoOrder; // OPT_fvk_stage_io_order
+  uint32_t VkBShift; // OPT_fvk_b_shift
+  uint32_t VkTShift; // OPT_fvk_t_shift
+  uint32_t VkSShift; // OPT_fvk_s_shift
+  uint32_t VkUShift; // OPT_fvk_u_shift
 #endif
   // SPIRV Change Ends
 };

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -161,10 +161,10 @@ public:
 #ifdef ENABLE_SPIRV_CODEGEN
   bool GenSPIRV; // OPT_spirv
   llvm::StringRef VkStageIoOrder; // OPT_fvk_stage_io_order
-  uint32_t VkBShift; // OPT_fvk_b_shift
-  uint32_t VkTShift; // OPT_fvk_t_shift
-  uint32_t VkSShift; // OPT_fvk_s_shift
-  uint32_t VkUShift; // OPT_fvk_u_shift
+  llvm::SmallVector<uint32_t, 4> VkBShift; // OPT_fvk_b_shift
+  llvm::SmallVector<uint32_t, 4> VkTShift; // OPT_fvk_t_shift
+  llvm::SmallVector<uint32_t, 4> VkSShift; // OPT_fvk_s_shift
+  llvm::SmallVector<uint32_t, 4> VkUShift; // OPT_fvk_u_shift
 #endif
   // SPIRV Change Ends
 };

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -235,17 +235,17 @@ def ignore_line_directives : Flag<["-", "/"], "ignore-line-directives">, HelpTex
 
 // SPIRV Change Starts
 def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Generate SPIR-V binary code">;
+  HelpText<"Generate SPIR-V code">;
 def fvk_stage_io_order_EQ : Joined<["-"], "fvk-stage-io-order=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Specify Vulkan stage I/O location assignment order">;
-def fvk_b_shift : MultiArg<["-"], "fvk-b-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Specify the register number shift for b-type register">;
-def fvk_t_shift : MultiArg<["-"], "fvk-t-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Specify the register number shift for t-type register">;
-def fvk_s_shift : MultiArg<["-"], "fvk-s-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Specify the register number shift for s-type register">;
-def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Specify the register number shift for u-type register">;
+def fvk_b_shift : MultiArg<["-"], "fvk-b-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify Vulkan binding number shift for b-type register">;
+def fvk_t_shift : MultiArg<["-"], "fvk-t-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify Vulkan binding number shift for t-type register">;
+def fvk_s_shift : MultiArg<["-"], "fvk-s-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify Vulkan binding number shift for s-type register">;
+def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify Vulkan binding number shift for u-type register">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -238,13 +238,13 @@ def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverO
   HelpText<"Generate SPIR-V binary code">;
 def fvk_stage_io_order_EQ : Joined<["-"], "fvk-stage-io-order=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Specify Vulkan stage I/O location assignment order">;
-def fvk_b_shift_EQ : Joined<["-"], "fvk-b-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_b_shift : MultiArg<["-"], "fvk-b-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify the register number shift for b-type register">;
-def fvk_t_shift_EQ : Joined<["-"], "fvk-t-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_t_shift : MultiArg<["-"], "fvk-t-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify the register number shift for t-type register">;
-def fvk_s_shift_EQ : Joined<["-"], "fvk-s-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_s_shift : MultiArg<["-"], "fvk-s-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify the register number shift for s-type register">;
-def fvk_u_shift_EQ : Joined<["-"], "fvk-u-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify the register number shift for u-type register">;
 // SPIRV Change Ends
 

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -238,13 +238,13 @@ def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverO
   HelpText<"Generate SPIR-V code">;
 def fvk_stage_io_order_EQ : Joined<["-"], "fvk-stage-io-order=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Specify Vulkan stage I/O location assignment order">;
-def fvk_b_shift : MultiArg<["-"], "fvk-b-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_b_shift : MultiArg<["-"], "fvk-b-shift", 2>, MetaVarName<"<shift> <space>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify Vulkan binding number shift for b-type register">;
-def fvk_t_shift : MultiArg<["-"], "fvk-t-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_t_shift : MultiArg<["-"], "fvk-t-shift", 2>, MetaVarName<"<shift> <space>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify Vulkan binding number shift for t-type register">;
-def fvk_s_shift : MultiArg<["-"], "fvk-s-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_s_shift : MultiArg<["-"], "fvk-s-shift", 2>, MetaVarName<"<shift> <space>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify Vulkan binding number shift for s-type register">;
-def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, MetaVarName<"<space> <shift>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, MetaVarName<"<shift> <space>">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify Vulkan binding number shift for u-type register">;
 // SPIRV Change Ends
 

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -234,10 +234,18 @@ def no_min_precision: Flag<["-", "/"], "no-min-precision">, Flags<[CoreOption, D
 def ignore_line_directives : Flag<["-", "/"], "ignore-line-directives">, HelpText<"Ignore line directives">, Flags<[CoreOption]>, Group<hlslcomp_Group>;
 
 // SPIRV Change Starts
-def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
+def spirv : Flag<["-"], "spirv">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Generate SPIR-V binary code">;
 def fvk_stage_io_order_EQ : Joined<["-"], "fvk-stage-io-order=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Specify Vulkan stage I/O location assignment order">;
+def fvk_b_shift_EQ : Joined<["-"], "fvk-b-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify the register number shift for b-type register">;
+def fvk_t_shift_EQ : Joined<["-"], "fvk-t-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify the register number shift for t-type register">;
+def fvk_s_shift_EQ : Joined<["-"], "fvk-s-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify the register number shift for s-type register">;
+def fvk_u_shift_EQ : Joined<["-"], "fvk-u-shift=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify the register number shift for u-type register">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -444,15 +444,42 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
   opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
+
+  const llvm::StringRef bShift = Args.getLastArgValue(OPT_fvk_b_shift_EQ, "0");
+  if (bShift.getAsInteger(10, opts.VkBShift)) {
+    errors << "invalid b-type register number shift: " << bShift;
+    return 1;
+  }
+  const llvm::StringRef tShift = Args.getLastArgValue(OPT_fvk_t_shift_EQ, "0");
+  if (tShift.getAsInteger(10, opts.VkTShift)) {
+    errors << "invalid t-type register number shift: " << tShift;
+    return 1;
+  }
+  const llvm::StringRef sShift = Args.getLastArgValue(OPT_fvk_s_shift_EQ, "0");
+  if (sShift.getAsInteger(10, opts.VkSShift)) {
+    errors << "invalid s-type register number shift: " << sShift;
+    return 1;
+  }
+  const llvm::StringRef uShift = Args.getLastArgValue(OPT_fvk_u_shift_EQ, "0");
+  if (uShift.getAsInteger(10, opts.VkUShift)) {
+    errors << "invalid u-type register number shift: " << uShift;
+    return 1;
+  }
+
   opts.VkStageIoOrder = Args.getLastArgValue(OPT_fvk_stage_io_order_EQ, "decl");
   if (opts.VkStageIoOrder != "alpha" && opts.VkStageIoOrder != "decl") {
-    errors << "Unknown Vulkan stage I/O location assignment order : "
+    errors << "unknown Vulkan stage I/O location assignment order: "
            << opts.VkStageIoOrder;
     return 1;
   }
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
-      !Args.getLastArgValue(OPT_fvk_stage_io_order_EQ).empty()) {
+      !Args.getLastArgValue(OPT_fvk_stage_io_order_EQ).empty() ||
+      !Args.getLastArgValue(OPT_fvk_b_shift_EQ).empty() ||
+      !Args.getLastArgValue(OPT_fvk_t_shift_EQ).empty() ||
+      !Args.getLastArgValue(OPT_fvk_s_shift_EQ).empty() ||
+      !Args.getLastArgValue(OPT_fvk_u_shift_EQ).empty()
+      ) {
     errors << "SPIR-V CodeGen not available. "
               "Please recompile with -DENABLE_SPIRV_CODEGEN=ON.";
     return 1;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -443,11 +443,16 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
-  opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
+  const bool genSpirv = opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
 
   // Collects the arguments for -fvk-{b|s|t|u}-shift.
-  const auto handleVkShiftArgs = [&Args, &errors](
+  const auto handleVkShiftArgs = [genSpirv, &Args, &errors](
       OptSpecifier id, const char* name, llvm::SmallVectorImpl<uint32_t>* shifts) {
+    if (!genSpirv) {
+      errors << "-fvk-" << name << "-shift requires -spirv";
+      return false;
+    }
+
     const auto values = Args.getAllArgValues(id);
 
     shifts->clear();

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -448,12 +448,12 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   // Collects the arguments for -fvk-{b|s|t|u}-shift.
   const auto handleVkShiftArgs = [genSpirv, &Args, &errors](
       OptSpecifier id, const char* name, llvm::SmallVectorImpl<uint32_t>* shifts) {
-    if (!genSpirv) {
+    const auto values = Args.getAllArgValues(id);
+
+    if (!genSpirv && !values.empty()) {
       errors << "-fvk-" << name << "-shift requires -spirv";
       return false;
     }
-
-    const auto values = Args.getAllArgValues(id);
 
     shifts->clear();
     for (const auto& val : values) {

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -15,6 +15,10 @@ namespace clang {
 /// Structs for controlling behaviors of SPIR-V codegen.
 struct EmitSPIRVOptions {
   llvm::StringRef stageIoOrder;
+  uint32_t bShift;
+  uint32_t tShift;
+  uint32_t sShift;
+  uint32_t uShift;
 };
 } // end namespace clang
 

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -9,16 +9,17 @@
 #ifndef LLVM_CLANG_SPIRV_EMITSPIRVOPTIONS_H
 #define LLVM_CLANG_SPIRV_EMITSPIRVOPTIONS_H
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace clang {
 /// Structs for controlling behaviors of SPIR-V codegen.
 struct EmitSPIRVOptions {
   llvm::StringRef stageIoOrder;
-  uint32_t bShift;
-  uint32_t tShift;
-  uint32_t sShift;
-  uint32_t uShift;
+  llvm::SmallVector<uint32_t, 4> bShift;
+  llvm::SmallVector<uint32_t, 4> tShift;
+  llvm::SmallVector<uint32_t, 4> sShift;
+  llvm::SmallVector<uint32_t, 4> uShift;
 };
 } // end namespace clang
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -474,7 +474,7 @@ public:
       : masterShift(0) {
     assert(shifts.size() % 2 == 0);
     for (uint32_t i = 0; i < shifts.size(); i += 2)
-      perSetShift[shifts[i]] = shifts[i + 1];
+      perSetShift[shifts[i + 1]] = shifts[i];
   }
 
   /// Returns the shift amount for the given set.

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -465,6 +465,32 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
   return true;
 }
 
+namespace {
+/// A class for maintaining the binding number shift requested for descriptor
+/// sets.
+class BindingShiftMapper {
+public:
+  explicit BindingShiftMapper(const llvm::SmallVectorImpl<uint32_t> &shifts)
+      : masterShift(0) {
+    assert(shifts.size() % 2 == 0);
+    for (uint32_t i = 0; i < shifts.size(); i += 2)
+      perSetShift[shifts[i]] = shifts[i + 1];
+  }
+
+  /// Returns the shift amount for the given set.
+  uint32_t getShiftForSet(uint32_t set) const {
+    const auto found = perSetShift.find(set);
+    if (found != perSetShift.end())
+      return found->second;
+    return masterShift;
+  }
+
+private:
+  uint32_t masterShift; /// Shift amount applies to all sets.
+  llvm::DenseMap<uint32_t, uint32_t> perSetShift;
+};
+}
+
 bool DeclResultIdMapper::decorateResourceBindings() {
   BindingSet bindingSet;
   bool noError = true;
@@ -486,6 +512,11 @@ bool DeclResultIdMapper::decorateResourceBindings() {
       }
     }
 
+  BindingShiftMapper bShiftMapper(spirvOptions.bShift);
+  BindingShiftMapper tShiftMapper(spirvOptions.tShift);
+  BindingShiftMapper sShiftMapper(spirvOptions.sShift);
+  BindingShiftMapper uShiftMapper(spirvOptions.uShift);
+
   // Process variables with register(...) binding assignment
   for (const auto &var : resourceVars)
     if (const auto *reg = var.getRegister())
@@ -494,16 +525,16 @@ bool DeclResultIdMapper::decorateResourceBindings() {
         uint32_t binding = reg->RegisterNumber;
         switch (reg->RegisterType) {
         case 'b':
-          binding += spirvOptions.bShift;
+          binding += bShiftMapper.getShiftForSet(set);
           break;
         case 't':
-          binding += spirvOptions.tShift;
+          binding += tShiftMapper.getShiftForSet(set);
           break;
         case 's':
-          binding += spirvOptions.sShift;
+          binding += sShiftMapper.getShiftForSet(set);
           break;
         case 'u':
-          binding += spirvOptions.uShift;
+          binding += uShiftMapper.getShiftForSet(set);
           break;
         case 'c':
           // For setting packing offset. Does not affect binding.

--- a/tools/clang/test/CodeGenSPIRV/passthru-cs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-cs.hlsl2spv
@@ -8,7 +8,7 @@
 //--------------------------------------------------------------------------------------
 
 ByteAddressBuffer Buffer0 : register(t0);
-RWByteAddressBuffer BufferOut : register(u0);
+RWByteAddressBuffer BufferOut : register(u1);
 
 [numthreads(1, 1, 1)]
 void main( uint3 DTid : SV_DispatchThreadID )
@@ -47,7 +47,7 @@ void main( uint3 DTid : SV_DispatchThreadID )
 // OpDecorate %Buffer0 DescriptorSet 0
 // OpDecorate %Buffer0 Binding 0
 // OpDecorate %BufferOut DescriptorSet 0
-// OpDecorate %BufferOut Binding 0
+// OpDecorate %BufferOut Binding 1
 // %uint = OpTypeInt 32 0
 // %int = OpTypeInt 32 1
 // %_runtimearr_uint = OpTypeRuntimeArray %uint

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-alpha.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2DArray<float4> t2f4 : register(t1);
 Texture2DArray<uint4>  t2u4 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-blue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-blue.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2DArray<float4> t2f4 : register(t1);
 Texture2DArray<int3>   t2i3 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp-red.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture2DArray<float4> t2f4 : register(t1);
 Texture2DArray<uint>   t2u1 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture2DArray<float4> t1 : register(t1);
 Texture2DArray<float2> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-green.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-green.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2DArray<float4> t2f4 : register(t1);
 Texture2DArray<uint2>  t2u2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-red.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2DArray<float4> t2f4 : register(t1);
 Texture2DArray<uint>   t2u1 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp-level-zero.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp-level-zero.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture1DArray   <float4> t1 : register(t1);
 Texture2DArray   <float3> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture1DArray   <float4> t1 : register(t1);
 Texture2DArray   <float3> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-alpha.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2D<float4> t2f4 : register(t1);
 Texture2D<int4>   t2i4 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-blue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-blue.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2D<float4> t2f4 : register(t1);
 Texture2D<uint3>  t2u3 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-red.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture2D<float4> t2f4 : register(t1);
 Texture2D<uint>   t2u1 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture2D<float4> t1 : register(t1);
 Texture2D<float2> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-green.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-green.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2D<float4> t2f4 : register(t1);
 Texture2D<uint2>  t2u2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-red.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 Texture2D<float4> t2f4 : register(t1);
 Texture2D<uint>   t2u1 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-cmp-level-zero.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-cmp-level-zero.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture1D   <float4> t1 : register(t1);
 Texture2D   <float2> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-cmp.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerComparisonState gSampler : register(s1);
+SamplerComparisonState gSampler : register(s5);
 
 Texture1D   <float4> t1 : register(t1);
 Texture2D   <float2> t2 : register(t2);

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
-SamplerState gSampler : register(s1);
+SamplerState gSampler : register(s5);
 
 // Note: The front end forbids sampling from non-floating-point texture formats.
 

--- a/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
@@ -39,9 +39,9 @@ StructuredBuffer<S> mySBuffer1 : register(t1);
 StructuredBuffer<T> mySBuffer2 : register(t2);
 
 // CHECK: %mySBuffer3 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
-RWStructuredBuffer<S> mySBuffer3 : register(u1);
+RWStructuredBuffer<S> mySBuffer3 : register(u3);
 // CHECK: %mySBuffer4 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
-RWStructuredBuffer<T> mySBuffer4 : register(u2);
+RWStructuredBuffer<T> mySBuffer4 : register(u4);
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 0 2 -fvk-t-shift 0 2 -fvk-s-shift 0 3 -fvk-u-shift 0 3
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 2 0 -fvk-t-shift 2 0 -fvk-s-shift 3 0 -fvk-u-shift 3 0
 
 struct S {
     float4 f;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-b-shift=2 -fvk-t-shift=2 -fvk-s-shift=3 -fvk-u-shift=3
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 0 2 -fvk-t-shift 0 2 -fvk-s-shift 0 3 -fvk-u-shift 0 3
 
 struct S {
     float4 f;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
@@ -1,0 +1,29 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift=2 -fvk-t-shift=2 -fvk-s-shift=3 -fvk-u-shift=3
+
+struct S {
+    float4 f;
+};
+
+[[vk::binding(2)]]
+ConstantBuffer<S> cbuffer3;
+
+ConstantBuffer<S> cbuffer1 : register(b0); // Collision with cbuffer3 after shift
+
+Texture2D<float4> texture1: register(t0, space1);
+Texture2D<float4> texture2: register(t0); // Collision with cbuffer3 after shift
+
+SamplerState sampler1: register(s0);
+SamplerState sampler2: register(s0, space2);
+
+RWBuffer<float4> rwbuffer1 : register(u0, space3);
+RWBuffer<float4> rwbuffer2 : register(u0); // Collision with sampler1 after shift
+
+float4 main() : SV_Target {
+    return cbuffer1.f;
+}
+
+//CHECK: :10:30: error: resource binding #2 in descriptor set #0 already assigned
+
+//CHECK: :13:29: error: resource binding #2 in descriptor set #0 already assigned
+
+//CHECK: :19:30: error: resource binding #3 in descriptor set #0 already assigned

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 0 100 -fvk-b-shift 2 200 -fvk-t-shift 0 200 -fvk-t-shift 1 300 -fvk-t-shift 0 400 -fvk-s-shift 0 500 -fvk-s-shift 2 600 -fvk-u-shift 0 700 -fvk-u-shift 3 800
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 100 0 -fvk-b-shift 200 2 -fvk-t-shift 200 0 -fvk-t-shift 300 1 -fvk-t-shift 400 0 -fvk-s-shift 500 0 -fvk-s-shift 600 2 -fvk-u-shift 700 0 -fvk-u-shift 800 3
 
 // Tests that we can set shift for more than one sets of the same register type
 // Tests that we can override shift for the same set

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
@@ -1,4 +1,7 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-b-shift=100 -fvk-t-shift=200 -fvk-s-shift=300 -fvk-u-shift=400
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift 0 100 -fvk-b-shift 2 200 -fvk-t-shift 0 200 -fvk-t-shift 1 300 -fvk-t-shift 0 400 -fvk-s-shift 0 500 -fvk-s-shift 2 600 -fvk-u-shift 0 700 -fvk-u-shift 3 800
+
+// Tests that we can set shift for more than one sets of the same register type
+// Tests that we can override shift for the same set
 
 struct S {
     float4 f;
@@ -9,34 +12,34 @@ struct S {
 // CHECK: OpDecorate %cbuffer3 DescriptorSet 0
 // CHECK: OpDecorate %cbuffer3 Binding 42
 [[vk::binding(42)]]
-ConstantBuffer<S> cbuffer3;
+ConstantBuffer<S> cbuffer3 : register(b10, space2);
 
 // CHECK: OpDecorate %cbuffer1 DescriptorSet 0
 // CHECK: OpDecorate %cbuffer1 Binding 100
 ConstantBuffer<S> cbuffer1 : register(b0);
 // CHECK: OpDecorate %cbuffer2 DescriptorSet 2
-// CHECK: OpDecorate %cbuffer2 Binding 100
+// CHECK: OpDecorate %cbuffer2 Binding 200
 ConstantBuffer<S> cbuffer2 : register(b0, space2);
 
 // CHECK: OpDecorate %texture1 DescriptorSet 1
-// CHECK: OpDecorate %texture1 Binding 201
+// CHECK: OpDecorate %texture1 Binding 301
 Texture2D<float4> texture1: register(t1, space1);
 // CHECK: OpDecorate %texture2 DescriptorSet 0
-// CHECK: OpDecorate %texture2 Binding 201
+// CHECK: OpDecorate %texture2 Binding 401
 Texture2D<float4> texture2: register(t1);
 
 // CHECK: OpDecorate %sampler1 DescriptorSet 0
-// CHECK: OpDecorate %sampler1 Binding 300
+// CHECK: OpDecorate %sampler1 Binding 500
 // CHECK: OpDecorate %sampler2 DescriptorSet 2
-// CHECK: OpDecorate %sampler2 Binding 300
+// CHECK: OpDecorate %sampler2 Binding 600
 SamplerState sampler1: register(s0);
 SamplerState sampler2: register(s0, space2);
 
 // CHECK: OpDecorate %rwbuffer1 DescriptorSet 3
-// CHECK: OpDecorate %rwbuffer1 Binding 403
+// CHECK: OpDecorate %rwbuffer1 Binding 803
 RWBuffer<float4> rwbuffer1 : register(u3, space3);
 // CHECK: OpDecorate %rwbuffer2 DescriptorSet 0
-// CHECK: OpDecorate %rwbuffer2 Binding 403
+// CHECK: OpDecorate %rwbuffer2 Binding 703
 RWBuffer<float4> rwbuffer2 : register(u3);
 
 // Lacking binding assignment is unaffacted.

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.hlsl
@@ -1,0 +1,53 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-b-shift=100 -fvk-t-shift=200 -fvk-s-shift=300 -fvk-u-shift=400
+
+struct S {
+    float4 f;
+};
+
+// Explicit binding assignment is unaffected.
+
+// CHECK: OpDecorate %cbuffer3 DescriptorSet 0
+// CHECK: OpDecorate %cbuffer3 Binding 42
+[[vk::binding(42)]]
+ConstantBuffer<S> cbuffer3;
+
+// CHECK: OpDecorate %cbuffer1 DescriptorSet 0
+// CHECK: OpDecorate %cbuffer1 Binding 100
+ConstantBuffer<S> cbuffer1 : register(b0);
+// CHECK: OpDecorate %cbuffer2 DescriptorSet 2
+// CHECK: OpDecorate %cbuffer2 Binding 100
+ConstantBuffer<S> cbuffer2 : register(b0, space2);
+
+// CHECK: OpDecorate %texture1 DescriptorSet 1
+// CHECK: OpDecorate %texture1 Binding 201
+Texture2D<float4> texture1: register(t1, space1);
+// CHECK: OpDecorate %texture2 DescriptorSet 0
+// CHECK: OpDecorate %texture2 Binding 201
+Texture2D<float4> texture2: register(t1);
+
+// CHECK: OpDecorate %sampler1 DescriptorSet 0
+// CHECK: OpDecorate %sampler1 Binding 300
+// CHECK: OpDecorate %sampler2 DescriptorSet 2
+// CHECK: OpDecorate %sampler2 Binding 300
+SamplerState sampler1: register(s0);
+SamplerState sampler2: register(s0, space2);
+
+// CHECK: OpDecorate %rwbuffer1 DescriptorSet 3
+// CHECK: OpDecorate %rwbuffer1 Binding 403
+RWBuffer<float4> rwbuffer1 : register(u3, space3);
+// CHECK: OpDecorate %rwbuffer2 DescriptorSet 0
+// CHECK: OpDecorate %rwbuffer2 Binding 403
+RWBuffer<float4> rwbuffer2 : register(u3);
+
+// Lacking binding assignment is unaffacted.
+
+// CHECK: OpDecorate %cbuffer4 DescriptorSet 0
+// CHECK: OpDecorate %cbuffer4 Binding 0
+ConstantBuffer<S> cbuffer4;
+// CHECK: OpDecorate %cbuffer5 DescriptorSet 0
+// CHECK: OpDecorate %cbuffer5 Binding 1
+ConstantBuffer<S> cbuffer5;
+
+float4 main() : SV_Target {
+    return cbuffer1.f;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float4 f;
+};
+
+ConstantBuffer<S>     myCbuffer1 : register(b0);
+ConstantBuffer<S>     myCbuffer2 : register(b0, space1);
+
+RWStructuredBuffer<S> mySBuffer1 : register(u0);         // duplicate
+RWStructuredBuffer<S> mySBuffer2 : register(u0, space1); // duplicate
+RWStructuredBuffer<S> mySBuffer3 : register(u0, space2);
+
+float4 main() : SV_Target {
+    return 1.0;
+}
+
+// CHECK: :10:36: error: resource binding #0 in descriptor set #0 already assigned
+// CHECK: :11:36: error: resource binding #0 in descriptor set #1 already assigned

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -8,15 +8,13 @@ SamplerState sampler1: register(s1);
 // CHECK-NEXT: OpDecorate %sampler2 Binding 2
 SamplerState sampler2 : register(s2, space1);
 
-// Note: overlapping set # and binding # for now.
 // CHECK:      OpDecorate %texture1 DescriptorSet 1
-// CHECK-NEXT: OpDecorate %texture1 Binding 2
-Texture2D<float4> texture1: register(t2, space1);
+// CHECK-NEXT: OpDecorate %texture1 Binding 20
+Texture2D<float4> texture1: register(t20, space1);
 
-// Note: overlapping set # and binding # for now.
 // CHECK:      OpDecorate %texture2 DescriptorSet 0
-// CHECK-NEXT: OpDecorate %texture2 Binding 1
-Texture3D<float4> texture2: register(t1);
+// CHECK-NEXT: OpDecorate %texture2 Binding 10
+Texture3D<float4> texture2: register(t10);
 
 SamplerState sampler3;
 
@@ -57,8 +55,8 @@ RWStructuredBuffer<S> sbuffer2 : register(u6, space1);
 
     // The counter variable will use the next unassigned number
 // CHECK:      OpDecorate %abuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %abuffer Binding 5
-AppendStructuredBuffer<S> abuffer : register(u5);
+// CHECK-NEXT: OpDecorate %abuffer Binding 55
+AppendStructuredBuffer<S> abuffer : register(u55);
 
     // The counter variable will use the next unassigned number
 // CHECK:      OpDecorate %csbuffer DescriptorSet 0

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -464,6 +464,10 @@ public:
       else if (opts.GenSPIRV) {
           clang::EmitSPIRVOptions spirvOpts;
           spirvOpts.stageIoOrder = opts.VkStageIoOrder;
+          spirvOpts.bShift = opts.VkBShift;
+          spirvOpts.tShift = opts.VkTShift;
+          spirvOpts.sShift = opts.VkSShift;
+          spirvOpts.uShift = opts.VkUShift;
           clang::EmitSPIRVAction action(spirvOpts);
           FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);
           action.BeginSourceFile(compiler, file);

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -692,8 +692,19 @@ TEST_F(FileTest, VulkanRegisterBinding) {
   // Resource binding from :register()
   runFileTest("vk.binding.register.hlsl");
 }
+TEST_F(FileTest, VulkanRegisterBindingShift) {
+  // Resource binding from :register() and with shift specified via
+  // command line option
+  runFileTest("vk.binding.cl.hlsl");
+}
 TEST_F(FileTest, VulkanExplicitBindingReassigned) {
   runFileTest("vk.binding.explicit.error.hlsl", /*expectSuccess*/ false);
+}
+TEST_F(FileTest, VulkanRegisterBindingReassigned) {
+  runFileTest("vk.binding.register.error.hlsl", /*expectSuccess*/ false);
+}
+TEST_F(FileTest, VulkanRegisterBindingShiftReassigned) {
+  runFileTest("vk.binding.cl.error.hlsl", /*expectSuccess*/ false);
 }
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -34,7 +34,7 @@ private:
 
   std::string targetProfile;             ///< Target profile (argument of -T)
   std::string entryPoint;                ///< Entry point name (argument of -E)
-  std::string restArgs;                  ///< All the other arguments
+  std::vector<std::string> restArgs;     ///< All the other arguments
   std::string inputFilePath;             ///< Path to the input test file
   std::vector<uint32_t> generatedBinary; ///< The generated SPIR-V Binary
   std::string checkCommands;             ///< CHECK commands that verify output

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -39,7 +39,7 @@ bool validateSpirvBinary(std::vector<uint32_t> &binary);
 /// Returns true on success, and false otherwise.
 bool processRunCommandArgs(const llvm::StringRef runCommandLine,
                            std::string *targetProfile, std::string *entryPoint,
-                           std::string *restArgs);
+                           std::vector<std::string> *restArgs);
 
 /// \brief Converts an IDxcBlob into a vector of 32-bit unsigned integers which
 /// is returned via the 'binaryWords' argument.
@@ -58,7 +58,7 @@ std::string getAbsPathOfInputDataFile(const llvm::StringRef filename);
 bool runCompilerWithSpirvGeneration(const llvm::StringRef inputFilePath,
                                     const llvm::StringRef entryPoint,
                                     const llvm::StringRef targetProfile,
-                                    const llvm::StringRef restArgs,
+                                    const std::vector<std::string> &restArgs,
                                     std::vector<uint32_t> *generatedBinary,
                                     std::string *errorMessages);
 

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
@@ -58,7 +58,7 @@ private:
 
   std::string targetProfile;             ///< Target profile (argument of -T)
   std::string entryPoint;                ///< Entry point name (argument of -E)
-  std::string restArgs;                  ///< All the other arguments
+  std::vector<std::string> restArgs;     ///< All the other arguments
   std::string inputFilePath;             ///< Path to the input test file
   std::vector<uint32_t> generatedBinary; ///< The generated SPIR-V Binary
   std::string expectedSpirvAsm;          ///< Expected SPIR-V parsed from input


### PR DESCRIPTION
Added the following four command line options to shift register
number for Vulkan:

* -fvk-b-shift
* -fvk-t-shift
* -fvk-s-shift
* -fvk-u-shift

These options are used to avoid assigning the same binding
number to more than one resources.