### PR TITLE
[spirv] Allow the same binding number for combined image sampler

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -678,6 +678,13 @@ If there is no register specification, the corresponding resource will be
 assigned to the next available binding number, starting from 0, in descriptor
 set #0.
 
+Error checking
+~~~~~~~~~~~~~~
+
+Trying to reuse the same binding number of the same descriptor set results in
+a compiler error, unless we have exactly two resources and one is an image and
+the other is a sampler. This is to support the Vulkan combined image sampler.
+
 Summary
 ~~~~~~~
 
@@ -704,7 +711,7 @@ As an example, for the following code:
   [[vk::binding(3)]]
   RWBuffer<float4> rwbuffer1 : register(u5, space2);
 
-If we compile with ``-fvk-t-shift 0 10 -fvk-t-shift 1 20``:
+If we compile with ``-fvk-t-shift 10 0 -fvk-t-shift 20 1``:
 
 - ``rwbuffer1`` will take binding #3 in set #0, since explicit binding
   assignment has precedence over the rest.

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -85,16 +85,31 @@ private:
 
 class ResourceVar {
 public:
-  ResourceVar(uint32_t id, const hlsl::RegisterAssignment *r,
+  /// The category of this resource.
+  ///
+  /// We only care about Vulkan image and sampler types here, since they can be
+  /// bundled together as a combined image sampler which takes the same binding
+  /// number. The compiler should allow this case.
+  ///
+  /// Numbers are assigned to make bit check easiser.
+  enum class Category : uint32_t {
+    Image = 1,
+    Sampler = 2,
+    Other = 3,
+  };
+
+  ResourceVar(uint32_t id, Category cat, const hlsl::RegisterAssignment *r,
               const VKBindingAttr *b)
-      : varId(id), reg(r), binding(b) {}
+      : varId(id), category(cat), reg(r), binding(b) {}
 
   uint32_t getSpirvId() const { return varId; }
+  Category getCategory() const { return category; }
   const hlsl::RegisterAssignment *getRegister() const { return reg; }
   const VKBindingAttr *getBinding() const { return binding; }
 
 private:
   uint32_t varId;                      ///< <result-id>
+  Category category;                   ///< Resource category
   const hlsl::RegisterAssignment *reg; ///< HLSL register assignment
   const VKBindingAttr *binding;        ///< Vulkan binding assignment
 };

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -402,6 +402,15 @@ bool TypeTranslator::isTextureMS(QualType type) {
   return false;
 }
 
+bool TypeTranslator::isSampler(QualType type) {
+  if (const auto *rt = type->getAs<RecordType>()) {
+    const auto name = rt->getDecl()->getName();
+    if (name == "SamplerState" || name == "SamplerComparisonState")
+      return true;
+  }
+  return false;
+}
+
 bool TypeTranslator::isVectorType(QualType type, QualType *elemType,
                                   uint32_t *elemCount) {
   bool isVec = false;

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -85,6 +85,9 @@ public:
   /// \brief Returns true if the given type is an HLSL RWTexture type.
   static bool isRWTexture(QualType);
 
+  /// \brief Returns true if the given type is an HLSL sampler type.
+  static bool isSampler(QualType);
+
   /// \brief Returns true if the given type is an HLSL OutputPatch type.
   static bool isOutputPatch(QualType);
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
@@ -6,19 +6,36 @@ SamplerState sampler1      : register(s1, space1);
 [[vk::binding(3, 1)]]
 SamplerState sampler2      : register(s2);
 
-[[vk::binding(1)]] // duplicate
+[[vk::binding(1)]] // reuse - allowed for combined image sampler
 Texture2D<float4> texture1;
 
-[[vk::binding(3, 1)]] // duplicate
+[[vk::binding(3, 1)]] // reuse - allowed for combined image sampler
 Texture3D<float4> texture2 : register(t0, space0);
 
-[[vk::binding(3, 1)]] // duplicate
+[[vk::binding(3, 1)]] // reuse - disallowed
 Texture3D<float4> texture3 : register(t0, space0);
+
+[[vk::binding(1)]] // reuse - disallowed
+SamplerState sampler3      : register(s1, space1);
+
+struct S { float f; };
+
+[[vk::binding(5)]]
+StructuredBuffer<S> buf1;
+
+[[vk::binding(5)]] // reuse - disallowed
+SamplerState sampler4;
+
+[[vk::binding(5)]] // reuse - disallowed
+Texture2D<float4> texture4;
 
 float4 main() : SV_Target {
     return 1.0;
 }
 
-// CHECK: :9:3: error: resource binding #1 in descriptor set #0 already assigned
-// CHECK: :12:3: error: resource binding #3 in descriptor set #1 already assigned
+// CHECK-NOT:  :9:{{%\d+}}: error: resource binding #1 in descriptor set #0 already assigned
+// CHECK-NOT: :12:{{%\d+}}: error: resource binding #3 in descriptor set #1 already assigned
 // CHECK: :15:3: error: resource binding #3 in descriptor set #1 already assigned
+// CHECK: :18:3: error: resource binding #1 in descriptor set #0 already assigned
+// CHECK: :26:3: error: resource binding #5 in descriptor set #0 already assigned
+// CHECK: :29:3: error: resource binding #5 in descriptor set #0 already assigned

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
@@ -7,9 +7,16 @@ struct S {
 ConstantBuffer<S>     myCbuffer1 : register(b0);
 ConstantBuffer<S>     myCbuffer2 : register(b0, space1);
 
-RWStructuredBuffer<S> mySBuffer1 : register(u0);         // duplicate
-RWStructuredBuffer<S> mySBuffer2 : register(u0, space1); // duplicate
+RWStructuredBuffer<S> mySBuffer1 : register(u0);         // reuse - disallowed
+RWStructuredBuffer<S> mySBuffer2 : register(u0, space1); // reuse - disallowed
 RWStructuredBuffer<S> mySBuffer3 : register(u0, space2);
+
+SamplerState mySampler1 : register(s5, space1);
+Texture2D    myTexture1 : register(t5, space1); // reuse - allowed
+
+Texture2D    myTexture2 : register(t6, space6);
+[[vk::binding(6, 6)]] // reuse - allowed
+SamplerState mySampler2;
 
 float4 main() : SV_Target {
     return 1.0;
@@ -17,3 +24,5 @@ float4 main() : SV_Target {
 
 // CHECK: :10:36: error: resource binding #0 in descriptor set #0 already assigned
 // CHECK: :11:36: error: resource binding #0 in descriptor set #1 already assigned
+// CHECK-NOT: :15:{{%\d+}}: error: resource binding #5 in descriptor set #1 already assigned
+// CHECK-NOT: :18:{{%\d+}}: error: resource binding #6 in descriptor set #6 already assigned


### PR DESCRIPTION
Vulkan combined image sampler is logically considered a sampled
image and a sampler bound together.