### PR TITLE
[spirv] Add support for [[vk::counter_binding(X)]]

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -70,6 +70,9 @@ The namespace ``vk`` will be used for all Vulkan attributes:
 - ``binding(X[, Y])``: For specifying the descriptor set (``Y``) and binding
   (``X``) numbers for resource variables. The descriptor set (``Y``) is
   optional; if missing, it will be set to 0. Allowed on global variables.
+- ``counter_binding(X)``: For specifying the binding number (``X``) for the
+  associated counter for RW/Append/Consume structured buffer. The descriptor
+  set number for the associated counter is always the same as the main resource.
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will
@@ -365,6 +368,11 @@ will be translated into
   ; Variable
   %myCbuffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_T Uniform
 
+If ``.IncrementCounter()`` or ``.DecrementCounter()`` is used in the source
+code, an additional associated counter variable will be created for manipulating
+the counter. The counter variable will be of ``OpTypeStruct`` type, which only
+contains a 32-bit integer. The counter variable takes its own binding number.
+
 ``AppendStructuredBuffer`` and ``ConsumeStructuredBuffer``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -656,7 +664,11 @@ Explicit binding number assignment
 
 ``[[vk::binding(X[, Y])]]`` can be attached to global variables to specify the
 descriptor set as ``Y`` and binding number as ``X``. The descriptor set number
-is optional; if missing, it will be zero.
+is optional; if missing, it will be zero. RW/append/consume structured buffers
+have associated counters, which will occupy their own Vulkan descriptors.
+``[vk::counter_binding(Z)]`` can be attached to a RW/append/consume structured
+buffers to specify the binding number for the associated counter to ``Z``. Note
+that the set number of the counter is always the same as the main buffer.
 
 Implicit binding number assignment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -865,8 +865,24 @@ def VKLocation : InheritableAttr {
 
 def VKBinding : InheritableAttr {
   let Spellings = [CXX11<"vk", "binding">];
-  let Subjects = SubjectList<[GlobalVar, HLSLBuffer], ErrorDiag, "ExpectedVariable">;
+  let Subjects = SubjectList<[GlobalVar, HLSLBuffer], ErrorDiag, "ExpectedGlobalVarOrCTBuffer">;
   let Args = [IntArgument<"Binding">, DefaultIntArgument<"Set", 0>];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+// StructuredBuffer types that can have associated counters.
+def CounterStructuredBuffer : SubsetSubject<
+    Var,
+    [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
+      (S->getType()->getAs<RecordType>()->getDecl()->getName() == "RWStructuredBuffer" ||
+       S->getType()->getAs<RecordType>()->getDecl()->getName() == "AppendStructuredBuffer" ||
+       S->getType()->getAs<RecordType>()->getDecl()->getName() == "ConsumeStructuredBuffer")}]>;
+
+def VKCounterBinding : InheritableAttr {
+  let Spellings = [CXX11<"vk", "counter_binding">];
+  let Subjects = SubjectList<[CounterStructuredBuffer], ErrorDiag, "ExpectedCounterStructuredBuffer">;
+  let Args = [IntArgument<"Binding">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2325,6 +2325,10 @@ def warn_attribute_wrong_decl_type : Warning<
   "variables, functions and classes|Objective-C protocols|"
   "functions and global variables|structs, unions, and typedefs|structs and typedefs|"
   "interface or protocol declarations|kernel functions|"
+  // SPIRV Change Starts
+  "global variables, cbuffers, and tbuffers|"
+  "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
+  // SPIRV Change Ends
   // HLSL Change Starts - add 3 more enum values
   "varibales and parameters|functions, parameters, and fields|"
   "functions, variables, parameters, fields, and types}1">,

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -855,6 +855,10 @@ enum AttributeDeclKind {
   ExpectedStructOrTypedef,
   ExpectedObjectiveCInterfaceOrProtocol,
   ExpectedKernelFunction
+  // SPIRV Change Begins
+  ,ExpectedGlobalVarOrCTBuffer
+  ,ExpectedCounterStructuredBuffer
+  // SPIRV Change Ends
   // HLSL Change Begins - add attribute decl combinations
   ,ExpectedVariableOrParam,
   ExpectedFunctionOrParamOrField,

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -570,6 +570,10 @@ private:
   /// (RW)StructuredBuffer.Load() method call.
   SpirvEvalInfo processStructuredBufferLoad(const CXXMemberCallExpr *expr);
 
+  /// \brief Increments or decrements the counter for RW/Append/Consume
+  /// structured buffer.
+  uint32_t incDecRWACSBufferCounter(const CXXMemberCallExpr *, bool isInc);
+
   /// \brief Loads numWords 32-bit unsigned integers or stores numWords 32-bit
   /// unsigned integers (based on the doStore parameter) to the given
   /// ByteAddressBuffer. Loading is allowed from a ByteAddressBuffer or

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10178,6 +10178,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
       ValidateAttributeIntArg(S, A), ValidateAttributeIntArg(S, A, 1),
       A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKCounterBinding:
+    declAttr = ::new (S.Context) VKCounterBindingAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
@@ -11,7 +11,7 @@ AppendStructuredBuffer<S>      buffer2;
 
 void main(float4 vec: A) {
 // CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
-// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %uint_1
+// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %int [[counter]] %uint_1 %uint_0 %int_1
 // CHECK-NEXT: [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 [[index]]
 // CHECK-NEXT: [[vec:%\d+]] = OpLoad %v4float %vec
 // CHECK-NEXT: OpStore [[buffer1]] [[vec]]
@@ -20,7 +20,7 @@ void main(float4 vec: A) {
     S s; // Will use a separate S type without layout decorations
 
 // CHECK-NEXT: [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer2 %uint_0
-// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %uint [[counter]] %uint_1 %uint_0 %uint_1
+// CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %int [[counter]] %uint_1 %uint_0 %int_1
 
 // CHECK-NEXT: [[buffer2:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffer2 %uint_0 [[index]]
 // CHECK-NEXT: [[s:%\d+]] = OpLoad %S_0 %s

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.consume.hlsl
@@ -11,8 +11,8 @@ ConsumeStructuredBuffer<S>      buffer2;
 
 float4 main() : A {
 // CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
-// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %uint [[counter]] %uint_1 %uint_0 %uint_1
-// CHECK-NEXT: [[index:%\d+]] = OpISub %uint [[prev]] %uint_1
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %int [[counter]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT: [[index:%\d+]] = OpISub %int [[prev]] %int_1
 // CHECK-NEXT: [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 [[index]]
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %v4float [[buffer1]]
 // CHECK-NEXT: OpStore %v [[val]]
@@ -21,8 +21,8 @@ float4 main() : A {
     S s; // Will use a separate S type without layout decorations
 
 // CHECK-NEXT: [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer2 %uint_0
-// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %uint [[counter]] %uint_1 %uint_0 %uint_1
-// CHECK-NEXT: [[index:%\d+]] = OpISub %uint [[prev]] %uint_1
+// CHECK-NEXT: [[prev:%\d+]] = OpAtomicISub %int [[counter]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT: [[index:%\d+]] = OpISub %int [[prev]] %int_1
 
 // CHECK-NEXT: [[buffer2:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffer2 %uint_0 [[index]]
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %S [[buffer2]]

--- a/tools/clang/test/CodeGenSPIRV/method.rw-structured-buffer.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.rw-structured-buffer.counter.hlsl
@@ -1,0 +1,33 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float4 f;
+};
+
+// CHECK: OpMemberDecorate %type_ACSBuffer_counter 0 Offset 0
+// CHECK: OpDecorate %type_ACSBuffer_counter BufferBlock
+
+// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
+
+// CHECK: %counter_var_wCounter1 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+// CHECK: %counter_var_wCounter2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
+RWStructuredBuffer<S> wCounter1;
+RWStructuredBuffer<S> wCounter2;
+// CHECK-NOT: %counter_var_woCounter
+RWStructuredBuffer<S> woCounter;
+
+float4 main() : SV_Target {
+// CHECK:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_wCounter1 %uint_0
+// CHECK-NEXT: [[pre1:%\d+]] = OpAtomicIAdd %int [[ptr1]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT: [[val1:%\d+]] = OpBitcast %uint [[pre1]]
+// CHECK-NEXT:                 OpStore %a [[val1]]
+    uint a = wCounter1.IncrementCounter();
+// CHECK:      [[ptr2:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_wCounter2 %uint_0
+// CHECK-NEXT: [[pre2:%\d+]] = OpAtomicISub %int [[ptr2]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT: [[cnt2:%\d+]] = OpISub %int [[pre2]] %int_1
+// CHECK-NEXT: [[val2:%\d+]] = OpBitcast %uint [[cnt2]]
+// CHECK-NEXT:                 OpStore %b [[val2]]
+    uint b = wCounter2.DecrementCounter();
+
+    return woCounter[0].f + float4(a, b, 0, 0);
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.error.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    [[vk::binding(5)]] // error
+    float4 f;
+    [[vk::counter_binding(11)]] // error
+    float4 g;
+};
+
+[[vk::counter_binding(3)]] // error
+SamplerState mySampler;
+[[vk::counter_binding(4)]] // error
+Texture2D    myTexture;
+[[vk::counter_binding(5)]] // error
+StructuredBuffer<S> mySBuffer;
+
+[[vk::location(5)]] // error
+ConsumeStructuredBuffer<S> myCSBuffer;
+
+[[vk::location(12)]] // error
+cbuffer myCBuffer {
+    float field;
+}
+
+[[vk::binding(10)]] // error
+float4 main([[vk::binding(15)]] float4 a: A // error
+           ) : SV_Target {
+ return 1.0;
+}
+
+// CHECK:   :4:7: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers
+// CHECK:   :6:7: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
+// CHECK:  :10:3: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
+// CHECK:  :12:3: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
+// CHECK:  :14:3: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
+// CHECK:  :17:3: error: 'location' attribute only applies to functions, parameters, and fields
+// CHECK:  :20:3: error: 'location' attribute only applies to functions, parameters, and fields
+// CHECK: :26:15: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers
+// CHECK:  :25:3: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
@@ -1,0 +1,64 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float4 f;
+};
+
+// vk::binding + vk::counter_binding
+[[vk::binding(5, 3), vk::counter_binding(10)]]
+RWStructuredBuffer<S> mySBuffer1;
+// CHECK:      OpDecorate %mySBuffer1 DescriptorSet 3
+// CHECK-NEXT: OpDecorate %mySBuffer1 Binding 5
+
+// :register + vk::counter_binding
+[[vk::counter_binding(20)]]
+AppendStructuredBuffer<S> myASBuffer1 : register(u1, space1);
+// CHECK:      OpDecorate %counter_var_myASBuffer1 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %counter_var_myASBuffer1 Binding 20
+
+// none + vk::counter_binding
+[[vk::counter_binding(2)]]
+ConsumeStructuredBuffer<S> myCSBuffer1;
+// CHECK:      OpDecorate %counter_var_myCSBuffer1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_myCSBuffer1 Binding 2
+
+// vk::binding + none
+[[vk::binding(1)]]
+RWStructuredBuffer<S> mySBuffer2;
+// CHECK:      OpDecorate %mySBuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %mySBuffer2 Binding 1
+
+// CHECK:      OpDecorate %counter_var_mySBuffer1 DescriptorSet 3
+// CHECK-NEXT: OpDecorate %counter_var_mySBuffer1 Binding 10
+
+// CHECK-NEXT: OpDecorate %myASBuffer1 DescriptorSet 1
+// CHECK-NEXT: OpDecorate %myASBuffer1 Binding 1
+
+// :register + none
+AppendStructuredBuffer<S> myASBuffer2 : register(u3, space2);
+// CHECK-NEXT: OpDecorate %myASBuffer2 DescriptorSet 2
+// CHECK-NEXT: OpDecorate %myASBuffer2 Binding 3
+
+// CHECK-NEXT: OpDecorate %myCSBuffer1 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %myCSBuffer1 Binding 0
+
+// CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 DescriptorSet 2
+// CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 Binding 0
+
+// none + none
+ConsumeStructuredBuffer<S> myCSBuffer2;
+// CHECK-NEXT: OpDecorate %myCSBuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %myCSBuffer2 Binding 3
+
+// CHECK-NEXT: OpDecorate %counter_var_myCSBuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_myCSBuffer2 Binding 4
+
+// CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 Binding 5
+
+float4 main() : SV_Target {
+    uint a = mySBuffer1.IncrementCounter();
+    uint b = mySBuffer2.DecrementCounter();
+
+    return  a + b;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -56,19 +56,19 @@ ConstantBuffer<S> myConstantBuffer: register(b1, space1);
 RWStructuredBuffer<S> sbuffer2 : register(u6);
 
 // CHECK:      OpDecorate %asbuffer DescriptorSet 1
-// CHECK-NEXT: OpDecorate %asbuffer Binding 20
+// CHECK-NEXT: OpDecorate %asbuffer Binding 1
 // CHECK-NEXT: OpDecorate %csbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %csbuffer Binding 21
-// CHECK-NEXT: OpDecorate %counter_var_asbuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_asbuffer Binding 1
-// CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 4
-[[vk::binding(20, 1)]]
+// CHECK-NEXT: OpDecorate %counter_var_asbuffer DescriptorSet 1
+// CHECK-NEXT: OpDecorate %counter_var_asbuffer Binding 0
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 1
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 2
+[[vk::binding(1, 1)]]
 AppendStructuredBuffer<S> asbuffer : register(u10);
-// Next available "hole": binding #1 in set #0
+// Next available "hole" in set #1: binding #0
 [[vk::binding(21, 1)]]
 ConsumeStructuredBuffer<S> csbuffer : register(u11);
-// Next available "hole": binding #4 in set #0
+// Next available "hole" in set #1: binding #2
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -489,6 +489,9 @@ TEST_F(FileTest, StructuredBufferLoad) {
 TEST_F(FileTest, StructuredBufferGetDimensions) {
   runFileTest("method.structured-buffer.get-dimensions.hlsl");
 }
+TEST_F(FileTest, RWStructuredBufferIncDecCounter) {
+  runFileTest("method.rw-structured-buffer.counter.hlsl");
+}
 TEST_F(FileTest, AppendStructuredBufferAppend) {
   runFileTest("method.append-structured-buffer.append.hlsl");
 }
@@ -687,6 +690,17 @@ TEST_F(FileTest, SpirvEntryFunctionInOut) {
   runFileTest("spirv.entry-function.inout.hlsl");
 }
 
+TEST_F(FileTest, SpirvInterpolation) {
+  runFileTest("spirv.interpolation.hlsl");
+}
+TEST_F(FileTest, SpirvInterpolationError) {
+  runFileTest("spirv.interpolation.error.hlsl", /*expectSuccess*/ false);
+}
+
+TEST_F(FileTest, VulkanAttributeErrors) {
+  runFileTest("vk.attribute.error.hlsl", /*expectSuccess*/ false);
+}
+
 TEST_F(FileTest, VulkanLocation) { runFileTest("vk.location.hlsl"); }
 TEST_F(FileTest, VulkanLocationInputExplicitOutputImplicit) {
   runFileTest("vk.location.exp-in.hlsl");
@@ -702,13 +716,6 @@ TEST_F(FileTest, VulkanLocationReassigned) {
 }
 TEST_F(FileTest, VulkanLocationPartiallyAssigned) {
   runFileTest("vk.location.mixed.hlsl", /*expectSuccess*/ false);
-}
-
-TEST_F(FileTest, SpirvInterpolation) {
-  runFileTest("spirv.interpolation.hlsl");
-}
-TEST_F(FileTest, SpirvInterpolationError) {
-  runFileTest("spirv.interpolation.error.hlsl", /*expectSuccess*/ false);
 }
 
 TEST_F(FileTest, VulkanExplicitBinding) {
@@ -737,6 +744,12 @@ TEST_F(FileTest, VulkanRegisterBindingReassigned) {
 TEST_F(FileTest, VulkanRegisterBindingShiftReassigned) {
   runFileTest("vk.binding.cl.error.hlsl", /*expectSuccess*/ false);
 }
+TEST_F(FileTest, VulkanStructuredBufferCounter) {
+  // [[vk::counter_binding()]] for RWStructuredBuffer, AppendStructuredBuffer,
+  // and ConsumeStructuredBuffer
+  runFileTest("vk.binding.counter.hlsl");
+}
+
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");
 }


### PR DESCRIPTION
A new attribute [[vk::counter_binding(X)]] can be used to specify
the binding number for associated counters for RW/append/consume
structured buffers.

Also added support for .IncrementCounter() and .DecrementCounter()
for RWStructuredBuffer.

Also fixed the type error of OpAtomicI{Add|Sub}.