### PR TITLE
PIX pixel-cost visualizer: Fix byte offset, simplify ReEmitDxilResources

### DIFF
--- a/lib/HLSL/DxilAddPixelHitInstrumentation.cpp
+++ b/lib/HLSL/DxilAddPixelHitInstrumentation.cpp
@@ -143,6 +143,7 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
     pUAV->SetLowerBound(0);
     pUAV->SetRangeSize(1);
     pUAV->SetKind(DXIL::ResourceKind::RawBuffer);
+    pUAV->SetRW(true);
 
     auto pAnnotation = DM.GetTypeSystem().GetStructAnnotation(UAVStructTy);
     if (pAnnotation == nullptr)
@@ -247,7 +248,7 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
           {
             Function* LoadWeight = HlslOP->GetOpFunc(OP::OpCode::BufferLoad, Type::getInt32Ty(Ctx));
             Constant* LoadWeightOpcode = HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferLoad);
-            Constant* OffsetIntoUAV = HlslOP->GetU32Const(NumPixels * 2);
+            Constant* OffsetIntoUAV = HlslOP->GetU32Const(NumPixels * 2 * 4);
             auto WeightStruct = Builder.CreateCall(LoadWeight, {
               LoadWeightOpcode, // i32 opcode
               HandleForUAV,     // %dx.types.Handle, ; resource handle

--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -1394,6 +1394,7 @@ MDTuple *DxilModule::EmitDxilResources() {
 
 void DxilModule::ReEmitDxilResources() {
   ClearDxilMetadata(*m_pModule);
+  m_pViewIdState->Compute();
   EmitDxilMetadata();
 }
 

--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -1393,23 +1393,8 @@ MDTuple *DxilModule::EmitDxilResources() {
 }
 
 void DxilModule::ReEmitDxilResources() {
-  MDTuple *pNewResource = EmitDxilResources();
-  m_pMDHelper->UpdateDxilResources(pNewResource);
-  m_pMDHelper->EmitDxilTypeSystem(GetTypeSystem(), m_LLVMUsed);
-  const llvm::NamedMDNode *pEntries = m_pMDHelper->GetDxilEntryPoints();
-  IFTBOOL(pEntries->getNumOperands() == 1, DXC_E_INCORRECT_DXIL_METADATA);
-
-  Function *pEntryFunc;
-  string EntryName;
-  const llvm::MDOperand *pSignatures, *pResources, *pProperties;
-  m_pMDHelper->GetDxilEntryPoint(pEntries->getOperand(0), pEntryFunc, EntryName, pSignatures, pResources, pProperties);
-
-  MDTuple *pMDSignatures = m_pMDHelper->EmitDxilSignatures(*m_EntrySignature);
-  MDTuple *pMDProperties = EmitDxilShaderProperties();
-  MDTuple *pEntry = m_pMDHelper->EmitDxilEntryPointTuple(pEntryFunc, EntryName, pMDSignatures, pNewResource, pMDProperties);
-  vector<MDNode *> Entries;
-  Entries.emplace_back(pEntry);
-  m_pMDHelper->UpdateDxilEntryPoints(Entries);
+  ClearDxilMetadata(*m_pModule);
+  EmitDxilMetadata();
 }
 
 void DxilModule::LoadDxilResources(const llvm::MDOperand &MDO) {

--- a/tools/clang/test/HLSL/pix/pixelCounterAddPixelCost.hlsl
+++ b/tools/clang/test/HLSL/pix/pixelCounterAddPixelCost.hlsl
@@ -4,7 +4,7 @@
 // CHECK: %UAVIncResult = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 0, i32 %ByteIndex, i32 undef, i32 undef, i32 1)
 
 // Check for pixel cost instructions:
-// CHECK: %WeightStruct = call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %PIX_CountUAV_Handle, i32 128, i32 undef)
+// CHECK: %WeightStruct = call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %PIX_CountUAV_Handle, i32 512, i32 undef)
 // CHECK: %Weight = extractvalue %dx.types.ResRet.i32 %WeightStruct, 0
 // CHECK: %OffsetByteIndex = add i32 %ByteIndex, 256
 // CHECK: %UAVIncResult2 = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 0, i32 %OffsetByteIndex, i32 undef, i32 undef, i32 %Weight)


### PR DESCRIPTION
Update pixel cost visualizer: this should be a byte offset, so multiply by sizeof(dword)
Set UAV to r/w (matching usage used by other PIX UAVs in other passes)
Replaced ReEmitDxilResources with clear-and-emit. 

