### PR TITLE
[spirv] Add check for Patch decoration in interface tests

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -96,9 +96,9 @@ hlsl::DxilParamInputQual deduceParamQual(const DeclaratorDecl *decl,
 /// shader model.
 const hlsl::SigPoint *deduceSigPoint(const DeclaratorDecl *decl, bool asInput,
                                      const hlsl::ShaderModel::Kind kind,
-                                     bool isPatchConstant) {
+                                     bool forPCF) {
   return hlsl::SigPoint::GetSigPoint(hlsl::SigPointFromInputQual(
-      deduceParamQual(decl, asInput), kind, isPatchConstant));
+      deduceParamQual(decl, asInput), kind, forPCF));
 }
 
 /// Returns the type of the given decl. If the given decl is a FunctionDecl,
@@ -113,7 +113,7 @@ inline QualType getTypeOrFnRetType(const DeclaratorDecl *decl) {
 
 bool DeclResultIdMapper::createStageOutputVar(const DeclaratorDecl *decl,
                                               uint32_t storedValue,
-                                              bool isPatchConstant) {
+                                              bool forPCF) {
   QualType type = getTypeOrFnRetType(decl);
 
   // Output stream types (PointStream, LineStream, TriangleStream) are
@@ -121,8 +121,8 @@ bool DeclResultIdMapper::createStageOutputVar(const DeclaratorDecl *decl,
   if (hlsl::IsHLSLStreamOutputType(type))
     type = hlsl::GetHLSLResourceResultType(type);
 
-  const auto *sigPoint = deduceSigPoint(decl, /*asInput=*/false,
-                                        shaderModel.GetKind(), isPatchConstant);
+  const auto *sigPoint =
+      deduceSigPoint(decl, /*asInput=*/false, shaderModel.GetKind(), forPCF);
 
   // HS output variables are created using the other overload. For the rest,
   // none of them should be created as arrays.
@@ -149,7 +149,7 @@ bool DeclResultIdMapper::createStageOutputVar(const DeclaratorDecl *decl,
 
 bool DeclResultIdMapper::createStageInputVar(const ParmVarDecl *paramDecl,
                                              uint32_t *loadedValue,
-                                             bool isPatchConstant) {
+                                             bool forPCF) {
   uint32_t arraySize = 0;
   QualType type = paramDecl->getType();
 
@@ -164,7 +164,7 @@ bool DeclResultIdMapper::createStageInputVar(const ParmVarDecl *paramDecl,
   }
 
   const auto *sigPoint = deduceSigPoint(paramDecl, /*asInput=*/true,
-                                        shaderModel.GetKind(), isPatchConstant);
+                                        shaderModel.GetKind(), forPCF);
 
   return createStageVars(paramDecl, sigPoint, /*asInput=*/true, type, arraySize,
                          llvm::None, loadedValue, "in.var");

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -147,12 +147,13 @@ public:
   /// attached to the given function's parameter or return value and returns
   /// true on success. SPIR-V instructions will also be generated to update the
   /// contents of the output variables by extracting sub-values from the given
-  /// storedValue.
+  /// storedValue. forPCF should be set to true for handling decls in patch
+  /// constant function.
   ///
   /// Note that the control point stage output variable of HS should be created
   /// by the other overload.
   bool createStageOutputVar(const DeclaratorDecl *decl, uint32_t storedValue,
-                            bool isPatchConstant);
+                            bool forPCF);
   /// \brief Overload for handling HS control point stage ouput variable.
   bool createStageOutputVar(const DeclaratorDecl *decl, uint32_t arraySize,
                             uint32_t invocationId, uint32_t storedValue);
@@ -160,9 +161,10 @@ public:
   /// \brief Creates the stage input variables by parsing the semantics attached
   /// to the given function's parameter and returns true on success. SPIR-V
   /// instructions will also be generated to load the contents from the input
-  /// variables and composite them into one and write to *loadedValue.
+  /// variables and composite them into one and write to *loadedValue. forPCF
+  /// should be set to true for handling decls in patch constant function.
   bool createStageInputVar(const ParmVarDecl *paramDecl, uint32_t *loadedValue,
-                           bool isPatchConstant);
+                           bool forPCF);
 
   /// \brief Creates a function-scope paramter in the current function and
   /// returns its <result-id>.

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -5798,7 +5798,7 @@ bool SPIRVEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
             outputControlPointIdVal, primitiveIdVar, hullMainInputPatchParam))
       return false;
   } else {
-    if (!declIdMapper.createStageOutputVar(decl, retVal, /*isPC*/ false))
+    if (!declIdMapper.createStageOutputVar(decl, retVal, /*forPCF*/ false))
       return false;
   }
 
@@ -5914,7 +5914,7 @@ bool SPIRVEmitter::processHullEntryPointOutputAndPatchConstFunc(
         std::string tempVarName = "param.var." + param->getNameAsString();
         const uint32_t tempVar = theBuilder.addFnVar(typeId, tempVarName);
         uint32_t loadedValue = 0;
-        declIdMapper.createStageInputVar(param, &loadedValue, /*isPC*/ true);
+        declIdMapper.createStageInputVar(param, &loadedValue, /*forPCF*/ true);
         theBuilder.createStore(tempVar, loadedValue);
         primitiveId = tempVar;
       }
@@ -5924,7 +5924,7 @@ bool SPIRVEmitter::processHullEntryPointOutputAndPatchConstFunc(
   const uint32_t pcfResultId =
       theBuilder.createFunctionCall(pcfRetType, pcfId, {pcfParams});
   if (!declIdMapper.createStageOutputVar(patchConstFunc, pcfResultId,
-                                         /*isPC*/ true))
+                                         /*forPCF*/ true))
     return false;
 
   theBuilder.createBranch(mergeBB);

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
@@ -71,8 +71,12 @@ struct DsOut {
 // CHECK: OpDecorate %type_gl_PerVertex_0 Block
 
 // CHECK: OpDecorate %gl_TessCoord BuiltIn TessCoord
+// CHECK: OpDecorate %gl_TessCoord Patch
 // CHECK: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
+// CHECK: OpDecorate %gl_TessLevelOuter Patch
 // CHECK: OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
+// CHECK: OpDecorate %gl_TessLevelInner Patch
+// CHECK: OpDecorate %in_var_FOO Patch
 // CHECK: OpDecorate %in_var_TEXCOORD Location 0
 // CHECK: OpDecorate %in_var_BAR Location 1
 // CHECK: OpDecorate %in_var_FOO Location 2

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
@@ -73,8 +73,11 @@ struct HsPcfOut
 // CHECK: OpDecorate %gl_InvocationID BuiltIn InvocationId
 // CHECK: OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
 // CHECK: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
+// CHECK: OpDecorate %gl_TessLevelOuter Patch
 // CHECK: OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
-
+// CHECK: OpDecorate %gl_TessLevelInner Patch
+// CHECK: OpDecorate %out_var_TEXCOORD Patch
+// CHECK: OpDecorate %out_var_WEIGHT Patch
 // CHECK: OpDecorate %in_var_BAZ Location 0
 // CHECK: OpDecorate %out_var_FOO Location 0
 // CHECK: OpDecorate %out_var_BAR Location 1


### PR DESCRIPTION
Also make parameter names clear that they are for patch constant
function (PCF), not generally patch constant, which also involves
some domain shader inputs.