### PR TITLE
[spirv] Add support for [[vk::push_constant]]

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -152,13 +152,35 @@ Shader Stage Input Output
 
 More details in the `gl_PerVertex`_ section.
 
+Vulkan specific features
+------------------------
+
+We try to implement Vulkan specific features using the most intuitive and
+non-intrusive ways in HLSL, which means we will prefer native language
+constructs when possible. If that is inadequate, we then consider attaching
+`Vulkan specific attributes`_ to them, or introducing new syntax.
+
+Descriptor sets
+~~~~~~~~~~~~~~~
+
+To specify which Vulkan descriptor a particular resource binds to, use the
+``[[vk::binding(X[, Y])]]`` attribute.
+
+Push constants
+~~~~~~~~~~~~~~
+
+Vulkan push constant blocks are represented using normal global variables of
+struct types in HLSL. The variables (not the underlying struct types) should be
+annotated with the ``[[vk::push_constant]]`` attribute.
+
+Please note as per the requirements of Vulkan, "there must be no more than one
+push constant block statically used per shader entry point."
+
 Vulkan specific attributes
 --------------------------
 
-To provide additional information required by Vulkan in HLSL, we need to extend
-the syntax of HLSL.
 `C++ attribute specifier sequence <http://en.cppreference.com/w/cpp/language/attributes>`_
-is a non-intrusive way of achieving such purpose.
+is a non-intrusive way of providing Vulkan specific information in HLSL.
 
 The namespace ``vk`` will be used for all Vulkan attributes:
 
@@ -171,6 +193,9 @@ The namespace ``vk`` will be used for all Vulkan attributes:
 - ``counter_binding(X)``: For specifying the binding number (``X``) for the
   associated counter for RW/Append/Consume structured buffer. The descriptor
   set number for the associated counter is always the same as the main resource.
+- ``push_constant``: For marking a variable as the push constant block. Allowed
+  on global variables of struct type. At most one variable can be marked as
+  ``push_constant`` in a shader.
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -879,7 +879,7 @@ def VKBinding : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
-// StructuredBuffer types that can have associated counters.
+// StructuredBuffer types that can have associated counters
 def CounterStructuredBuffer : SubsetSubject<
     Var,
     [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
@@ -891,6 +891,17 @@ def VKCounterBinding : InheritableAttr {
   let Spellings = [CXX11<"vk", "counter_binding">];
   let Subjects = SubjectList<[CounterStructuredBuffer], ErrorDiag, "ExpectedCounterStructuredBuffer">;
   let Args = [IntArgument<"Binding">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+// Global variables that are of struct type
+def StructGlobalVar : SubsetSubject<Var, [{S->hasGlobalStorage() && S->getType()->isStructureType()}]>;
+
+def VKPushConstant : InheritableAttr {
+  let Spellings = [CXX11<"vk", "push_constant">];
+  let Subjects = SubjectList<[StructGlobalVar], ErrorDiag, "ExpectedStructGlobalVar">;
+  let Args = [];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2326,6 +2326,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "functions and global variables|structs, unions, and typedefs|structs and typedefs|"
   "interface or protocol declarations|kernel functions|"
   // SPIRV Change Starts
+  "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   // SPIRV Change Ends

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -856,6 +856,7 @@ enum AttributeDeclKind {
   ExpectedObjectiveCInterfaceOrProtocol,
   ExpectedKernelFunction
   // SPIRV Change Begins
+  ,ExpectedStructGlobalVar
   ,ExpectedGlobalVarOrCTBuffer
   ,ExpectedCounterStructuredBuffer
   // SPIRV Change Ends

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10222,6 +10222,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     declAttr = ::new (S.Context) VKCounterBindingAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKPushConstant:
+    declAttr = ::new (S.Context) VKPushConstantAttr(A.getRange(), S.Context,
+      A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.error.hlsl
@@ -28,6 +28,20 @@ float4 main([[vk::binding(15)]] float4 a: A // error
  return 1.0;
 }
 
+struct T {
+    [[vk::push_constant]] // error
+    float4 f;
+};
+
+[[vk::push_constant]] // error
+float foo([[vk::push_constant]] int param) // error
+{
+    return param;
+}
+
+[[vk::push_constant(5)]]
+T pcs;
+
 // CHECK:   :4:7: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers
 // CHECK:   :6:7: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
 // CHECK:  :10:3: error: 'counter_binding' attribute only applies to RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers
@@ -37,3 +51,7 @@ float4 main([[vk::binding(15)]] float4 a: A // error
 // CHECK:  :20:3: error: 'location' attribute only applies to functions, parameters, and fields
 // CHECK: :26:15: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers
 // CHECK:  :25:3: error: 'binding' attribute only applies to global variables, cbuffers, and tbuffers
+// CHECK:  :32:7: error: 'push_constant' attribute only applies to global variables of struct type
+// CHECK: :37:13: error: 'push_constant' attribute only applies to global variables of struct type
+// CHECK:  :36:3: error: 'push_constant' attribute only applies to global variables of struct type
+// CHECK:  :42:3: error: 'push_constant' attribute takes no arguments

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
@@ -1,0 +1,35 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate %_arr_v2float_uint_3 ArrayStride 8
+// CHECK: OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 32
+
+// CHECK: OpMemberDecorate %T 0 Offset 0
+// CHECK: OpMemberDecorate %T 1 Offset 32
+// CHECK: OpMemberDecorate %T 1 MatrixStride 16
+// CHECK: OpMemberDecorate %T 1 RowMajor
+struct T {
+                 float2   f1[3];
+    column_major float3x2 f2[2];
+};
+
+// CHECK: OpMemberDecorate %type_PushConstant_S 0 Offset 0
+// CHECK: OpMemberDecorate %type_PushConstant_S 1 Offset 16
+// CHECK: OpMemberDecorate %type_PushConstant_S 2 Offset 32
+// CHECK: OpMemberDecorate %type_PushConstant_S 3 Offset 128
+// CHECK: OpMemberDecorate %type_PushConstant_S 3 MatrixStride 16
+// CHECK: OpMemberDecorate %type_PushConstant_S 3 ColMajor
+
+// CHECK: OpDecorate %type_PushConstant_S Block
+struct S {
+              float    f1;
+              float3   f2;
+              T        f4;
+    row_major float2x3 f3;
+};
+
+[[vk::push_constant]]
+S pcs;
+
+float main() : A {
+    return pcs.f1;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.hlsl
@@ -1,0 +1,38 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct T {
+    float2 val[3];
+};
+
+// CHECK: OpName %type_PushConstant_S "type.PushConstant.S"
+// CHECK: OpMemberName %type_PushConstant_S 0 "f1"
+// CHECK: OpMemberName %type_PushConstant_S 1 "f2"
+// CHECK: OpMemberName %type_PushConstant_S 2 "f3"
+// CHECK: OpMemberName %type_PushConstant_S 3 "f4"
+
+// CHECK: %type_PushConstant_S = OpTypeStruct %float %v3float %mat2v3float %T
+struct S {
+    float    f1;
+    float3   f2;
+    float2x3 f3;
+    T        f4;
+};
+// CHECK: %_ptr_PushConstant_type_PushConstant_S = OpTypePointer PushConstant %type_PushConstant_S
+
+// CHECK: %pcs = OpVariable %_ptr_PushConstant_type_PushConstant_S PushConstant
+[[vk::push_constant]]
+S pcs;
+
+float main() : A {
+    return
+// CHECK:     {{%\d+}} = OpAccessChain %_ptr_PushConstant_float %pcs %int_0
+        pcs.f1 +
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_PushConstant_v3float %pcs %int_1
+// CHECK:     {{%\d+}} = OpAccessChain %_ptr_PushConstant_float [[ptr]] %int_2
+        pcs.f2.z +
+// CHECK:     {{%\d+}} = OpAccessChain %_ptr_PushConstant_float %pcs %int_2 %uint_1 %uint_2
+        pcs.f3[1][2] +
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_PushConstant_v2float %pcs %int_3 %int_0 %int_2
+// CHECK:     {{%\d+}} = OpAccessChain %_ptr_PushConstant_float [[ptr]] %int_1
+        pcs.f4.val[2].y;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -847,6 +847,8 @@ TEST_F(FileTest, VulkanStructuredBufferCounter) {
   runFileTest("vk.binding.counter.hlsl");
 }
 
+TEST_F(FileTest, VulkanPushConstant) { runFileTest("vk.push-constant.hlsl"); }
+
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");
 }
@@ -873,6 +875,10 @@ TEST_F(FileTest, VulkanLayoutTBufferStd430) {
 }
 TEST_F(FileTest, VulkanLayoutTextureBufferStd430) {
   runFileTest("vk.layout.texture-buffer.std430.hlsl");
+}
+
+TEST_F(FileTest, VulkanLayoutPushConstantStd430) {
+  runFileTest("vk.layout.push-constant.std430.hlsl");
 }
 
 // HS: for different Patch Constant Functions


### PR DESCRIPTION
[[vk::push_constant]] can be attached to a global variable of
struct type to put that variable in the PushConstant storage
class.

PushConstant should be of OpTypeStruct type with std430 layout.