### PR TITLE
[spirv] Emit unsupported error for some intrinsics

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2200,3 +2200,31 @@ codegen for Vulkan:
 - ``-fvk-stage-io-order={alpha|decl}``: Assigns the stage input/output variable
   location number according to alphabetical order or declaration order. See
   `HLSL semantic and Vulkan Location`_ for more details.
+
+Unsupported HLSL Features
+=========================
+
+The following HLSL language features are not supported in SPIR-V codegen,
+either because of no Vulkan equivalents at the moment, or because of deprecation.
+
+* Literal/immediate sampler state: deprecated feature. The compiler will
+  emit a warning and ignore it.
+* ``abort()`` intrinsic function: no Vulkan equivalent. The compiler will emit
+  an error.
+* ``GetRenderTargetSampleCount()`` intrinsic function: no Vulkan equivalent.
+  (Its GLSL counterpart is ``gl_NumSamples``, which is not available in GLSL for
+  Vulkan.) The compiler will emit an error.
+* ``GetRenderTargetSamplePosition()`` intrinsic function: no Vulkan equivalent.
+  (``gl_SamplePosition`` provides similar functionality but it's only for the
+  sample currently being processed.) The compiler will emit an error.
+* ``tex*()`` intrinsic functions: deprecated features. The compiler will
+  emit errors.
+* ``.GatherCmpGreen()``, ``.GatherCmpBlue()``, ``.GatherCmpAlpha()`` intrinsic
+  method: no Vulkan equivalent. (SPIR-V ``OpImageDrefGather`` instruction does
+  not take component as input.) The compiler will emit an error.
+* ``.CalculateLevelOfDetailUnclamped()`` intrinsic method: no Vulkan equivalent.
+  (SPIR-V ``OpImageQueryLod`` returns the clamped LOD in Vulkan.) The compiler
+  will emit an error.
+* ``.GetSamplePosition()`` intrinsic method: no Vulkan equivalent.
+  (``gl_SamplePosition`` provides similar functionality but it's only for the
+  sample currently being processed.) The compiler will emit an error.

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.abort.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.abort.hlsl
@@ -1,0 +1,7 @@
+// Run: %dxc -T ps_6_0 -E main
+
+void main() {
+    abort();
+}
+
+// CHECK: :4:5: error: no equivalent for abort intrinsic function in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-render-target-sample-count.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-render-target-sample-count.hlsl
@@ -1,0 +1,7 @@
+// Run: %dxc -T ps_6_0 -E main
+
+void main() {
+    uint a = GetRenderTargetSampleCount();
+}
+
+// CHECK: :4:14: error: no equivalent for GetRenderTargetSampleCount intrinsic function in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-render-target-sample-position.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-render-target-sample-position.hlsl
@@ -1,0 +1,7 @@
+// Run: %dxc -T ps_6_0 -E main
+
+void main() {
+    uint a = GetRenderTargetSamplePosition(2);
+}
+
+// CHECK: :4:14: error: no equivalent for GetRenderTargetSamplePosition intrinsic function in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/texture.calculate-lod-unclamped.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.calculate-lod-unclamped.hlsl
@@ -1,0 +1,13 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState ss : register(s2);
+
+Texture1D        <float>  t1;
+
+void main() {
+  float x = 0.5;
+
+  float lod1 = t1.CalculateLevelOfDetailUnclamped(ss, x);
+}
+
+// CHECK: :10:19: error: no equivalent for CalculateLevelOfDetailUnclamped intrinsic method in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-alpha.hlsl
@@ -1,0 +1,11 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerComparisonState gSampler : register(s5);
+
+Texture2D<float4> myTexture : register(t1);
+
+float4 main(float2 location: A, float comparator: B) : SV_Target {
+    return myTexture.GatherCmpAlpha(gSampler, location, comparator, int2(1, 2));
+}
+
+// CHECK: :8:22: error: no equivalent for GatherCmpAlpha intrinsic method in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-blue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-blue.hlsl
@@ -1,0 +1,11 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerComparisonState gSampler : register(s5);
+
+Texture2D<float4> gTexture : register(t1);
+
+float4 main(float2 location: A, float comparator: B) : SV_Target {
+    return gTexture.GatherCmpBlue(gSampler, location, comparator, int2(1, 2));
+}
+
+// CHECK: :8:21: error: no equivalent for GatherCmpBlue intrinsic method in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-green.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp-green.hlsl
@@ -1,0 +1,11 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerComparisonState gSampler : register(s5);
+
+Texture2D<float4> myTexture : register(t1);
+
+float4 main(float2 location: A, float comparator: B) : SV_Target {
+    return myTexture.GatherCmpGreen(gSampler, location, comparator, int2(1, 2));
+}
+
+// CHECK: :8:22: error: no equivalent for GatherCmpGreen intrinsic method in Vulkan

--- a/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
@@ -1,0 +1,9 @@
+// Run: %dxc -T ps_6_0 -E main
+
+Texture2DMS       <float> myTexture;
+
+void main() {
+  float2 ret = myTexture.GetSamplePosition(2);
+}
+
+// CHECK: :6:26: error: no equivalent for GetSamplePosition intrinsic method in Vulkan

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -488,8 +488,14 @@ TEST_F(FileTest, TextureArrayLoad) { runFileTest("texture.array.load.hlsl"); }
 TEST_F(FileTest, TextureGetDimensions) {
   runFileTest("texture.get-dimensions.hlsl");
 }
+TEST_F(FileTest, TextureGetSamplePosition) {
+  runFileTest("texture.get-sample-position.hlsl", Expect::Failure);
+}
 TEST_F(FileTest, TextureCalculateLevelOfDetail) {
   runFileTest("texture.calculate-lod.hlsl");
+}
+TEST_F(FileTest, TextureCalculateLevelOfDetailUnclamped) {
+  runFileTest("texture.calculate-lod-unclamped.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, TextureGather) { runFileTest("texture.gather.hlsl"); }
 TEST_F(FileTest, TextureArrayGather) {
@@ -524,6 +530,15 @@ TEST_F(FileTest, TextureGatherCmpRed) {
 }
 TEST_F(FileTest, TextureArrayGatherCmpRed) {
   runFileTest("texture.array.gather-cmp-red.hlsl");
+}
+TEST_F(FileTest, TextureArrayGatherCmpGreen) {
+  runFileTest("texture.gather-cmp-green.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, TextureArrayGatherCmpBlue) {
+  runFileTest("texture.gather-cmp-blue.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, TextureArrayGatherCmpAlpha) {
+  runFileTest("texture.gather-cmp-alpha.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, TextureSampleLevel) {
   runFileTest("texture.sample-level.hlsl");
@@ -742,6 +757,19 @@ TEST_F(FileTest, IntrinsicsAsin) { runFileTest("intrinsics.asin.hlsl"); }
 TEST_F(FileTest, IntrinsicsAcos) { runFileTest("intrinsics.acos.hlsl"); }
 TEST_F(FileTest, IntrinsicsAtan) { runFileTest("intrinsics.atan.hlsl"); }
 TEST_F(FileTest, IntrinsicsAtan2) { runFileTest("intrinsics.atan2.hlsl"); }
+
+// Unspported intrinsic functions
+TEST_F(FileTest, IntrinsicsAbort) {
+  runFileTest("intrinsics.abort.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, IntrinsicsGetRenderTargetSampleCount) {
+  runFileTest("intrinsics.get-render-target-sample-count.hlsl",
+              Expect::Failure);
+}
+TEST_F(FileTest, IntrinsicsGetRenderTargetSamplePosition) {
+  runFileTest("intrinsics.get-render-target-sample-position.hlsl",
+              Expect::Failure);
+}
 
 // For attributes
 TEST_F(FileTest, AttributeNumThreads) {


### PR DESCRIPTION
* abort
* GetRenderTargetSampleCount
* GetRenderTargetSamplePosition
* GatherCmpGreen
* GatherCmpBlue
* GatherCmpAlpha
* GetSamplePosition
* CalculateLevelOfDetailUnclamped