### PR TITLE
[spirv] Add mechanism for Vulkan-specific builtins

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -160,8 +160,8 @@ non-intrusive ways in HLSL, which means we will prefer native language
 constructs when possible. If that is inadequate, we then consider attaching
 `Vulkan specific attributes`_ to them, or introducing new syntax.
 
-Descriptor sets
-~~~~~~~~~~~~~~~
+Descriptors
+~~~~~~~~~~~
 
 To specify which Vulkan descriptor a particular resource binds to, use the
 ``[[vk::binding(X[, Y])]]`` attribute.
@@ -175,6 +175,19 @@ annotated with the ``[[vk::push_constant]]`` attribute.
 
 Please note as per the requirements of Vulkan, "there must be no more than one
 push constant block statically used per shader entry point."
+
+Builtin variables
+~~~~~~~~~~~~~~~~~
+
+Some of the Vulkan builtin variables have no equivalents in native HLSL
+language. To support them, ``[[vk::builtin("<builtin>")]]`` is introduced.
+Right now only two ``<builtin>`` are supported:
+
+* ``PointSize``: The GLSL equivalent is ``gl_PointSize``.
+* ``HelperInvocation``: The GLSL equivalent is ``gl_HelperInvocation``.
+
+Please see Vulkan spec. `14.6. Built-In Variables <https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#interfaces-builtin-variables>`_
+for detailed explanation of these builtins.
 
 Vulkan specific attributes
 --------------------------
@@ -196,6 +209,9 @@ The namespace ``vk`` will be used for all Vulkan attributes:
 - ``push_constant``: For marking a variable as the push constant block. Allowed
   on global variables of struct type. At most one variable can be marked as
   ``push_constant`` in a shader.
+- ``builtin("X")``: For specifying an entity should be translated into a certain
+  Vulkan builtin variable. Allowed on function parameters, function returns,
+  and struct fields.
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -863,6 +863,14 @@ def HLSLExperimental : InheritableAttr {
 
 // SPIRV Change Starts
 
+def VKBuiltIn : InheritableAttr {
+  let Spellings = [CXX11<"vk", "builtin">];
+  let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;
+  let Args = [StringArgument<"BuiltIn">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 def VKLocation : InheritableAttr {
   let Spellings = [CXX11<"vk", "location">];
   let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -37,11 +37,14 @@ class StageVar {
 public:
   inline StageVar(const hlsl::SigPoint *sig, llvm::StringRef semaStr,
                   const hlsl::Semantic *sema, llvm::StringRef semaName,
-                  uint32_t semaIndex, uint32_t type)
+                  uint32_t semaIndex, const VKBuiltInAttr *builtin,
+                  uint32_t type)
       : sigPoint(sig), semanticStr(semaStr), semantic(sema),
-        semanticName(semaName), semanticIndex(semaIndex), typeId(type),
-        valueId(0), isBuiltin(false), storageClass(spv::StorageClass::Max),
-        location(nullptr) {}
+        semanticName(semaName), semanticIndex(semaIndex), builtinAttr(builtin),
+        typeId(type), valueId(0), isBuiltin(false),
+        storageClass(spv::StorageClass::Max), location(nullptr) {
+    isBuiltin = builtinAttr != nullptr;
+  }
 
   const hlsl::SigPoint *getSigPoint() const { return sigPoint; }
   const hlsl::Semantic *getSemantic() const { return semantic; }
@@ -50,6 +53,8 @@ public:
 
   uint32_t getSpirvId() const { return valueId; }
   void setSpirvId(uint32_t id) { valueId = id; }
+
+  const VKBuiltInAttr *getBuiltInAttr() const { return builtinAttr; }
 
   std::string getSemanticStr() const;
   uint32_t getSemanticIndex() const { return semanticIndex; }
@@ -75,6 +80,8 @@ private:
   llvm::StringRef semanticName;
   /// HLSL semantic index.
   uint32_t semanticIndex;
+  /// SPIR-V BuiltIn attribute.
+  const VKBuiltInAttr *builtinAttr;
   /// SPIR-V <type-id>.
   uint32_t typeId;
   /// SPIR-V <result-id>.

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -443,7 +443,8 @@ bool GlPerVertex::tryToAccessPointSize(hlsl::SigPoint::Kind sigPointKind,
 }
 
 uint32_t GlPerVertex::readPositionOrPointSize(bool isPosition) const {
-  assert(inIsGrouped); // We do not handle stand-alone Position builtin here.
+  // We do not handle stand-alone Position/PointSize builtin here.
+  assert(inIsGrouped);
 
   // The PointSize builtin is always of float type.
   // The Position builtin is always of float4 type.
@@ -456,7 +457,7 @@ uint32_t GlPerVertex::readPositionOrPointSize(bool isPosition) const {
 
   if (inArraySize == 0) {
     // The input builtin block is a single block. Only need one index to
-    // locate the Position builtin.
+    // locate the Position/PointSize builtin.
     const uint32_t ptr =
         theBuilder.createAccessChain(ptrType, inBlockVar, {fieldIndex});
     return theBuilder.createLoad(fieldType, ptr);
@@ -469,13 +470,13 @@ uint32_t GlPerVertex::readPositionOrPointSize(bool isPosition) const {
   for (uint32_t i = 0; i < inArraySize; ++i) {
     const uint32_t arrayIndex = theBuilder.getConstantUint32(i);
     // Get pointer into the array of structs. We need two indices to locate
-    // the Position builtin now: the first one is the array index, and the
-    // second one is the struct index.
+    // the Position/PointSize builtin now: the first one is the array index,
+    // and the second one is the struct index.
     const uint32_t ptr = theBuilder.createAccessChain(ptrType, inBlockVar,
                                                       {arrayIndex, fieldIndex});
     elements.push_back(theBuilder.createLoad(fieldType, ptr));
   }
-  // Construct a new array of float4 for the Position builtins
+  // Construct a new array of float4/float for the Position/PointSize builtins
   const uint32_t arrayType = theBuilder.getArrayType(
       fieldType, theBuilder.getConstantUint32(inArraySize));
   return theBuilder.createCompositeConstruct(arrayType, elements);
@@ -625,7 +626,8 @@ bool GlPerVertex::readField(hlsl::Semantic::Kind semanticKind,
 void GlPerVertex::writePositionOrPointSize(
     bool isPosition, llvm::Optional<uint32_t> invocationId,
     uint32_t value) const {
-  assert(outIsGrouped); // We do not handle stand-alone Position builtin here.
+  // We do not handle stand-alone Position/PointSize builtin here.
+  assert(outIsGrouped);
 
   // The Position builtin is always of float4 type.
   // The PointSize builtin is always of float type.
@@ -638,7 +640,7 @@ void GlPerVertex::writePositionOrPointSize(
 
   if (outArraySize == 0) {
     // The input builtin block is a single block. Only need one index to
-    // locate the Position builtin.
+    // locate the Position/PointSize builtin.
     const uint32_t ptr =
         theBuilder.createAccessChain(ptrType, outBlockVar, {fieldIndex});
     theBuilder.createStore(ptr, value);
@@ -655,8 +657,8 @@ void GlPerVertex::writePositionOrPointSize(
 
   const uint32_t arrayIndex = invocationId.getValue();
   // Get pointer into the array of structs. We need two indices to locate
-  // the Position builtin now: the first one is the array index, and the
-  // second one is the struct index.
+  // the Position/PointSize builtin now: the first one is the array index,
+  // and the second one is the struct index.
   const uint32_t ptr = theBuilder.createAccessChain(ptrType, outBlockVar,
                                                     {arrayIndex, fieldIndex});
   theBuilder.createStore(ptr, value);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10351,6 +10351,11 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
   Handled = true;
   switch (A.getKind())
   {
+  case AttributeList::AT_VKBuiltIn:
+    declAttr = ::new (S.Context) VKBuiltInAttr(A.getRange(), S.Context,
+      ValidateAttributeStringArg(S, A, "PointSize,HelperInvocation"),
+      A.getAttributeSpellingListIndex());
+    break;
   case AttributeList::AT_VKLocation:
     declAttr = ::new (S.Context) VKLocationAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());

--- a/tools/clang/test/CodeGenSPIRV/spirv.builtin.helper-invocation.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.builtin.helper-invocation.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK:      OpEntryPoint Fragment
+// CHECK-SAME: %gl_HelperInvocation
+
+// CHECK:      OpDecorate %gl_HelperInvocation BuiltIn HelperInvocation
+
+// CHECK:      %gl_HelperInvocation = OpVariable %_ptr_Input_bool Input
+
+float4 main([[vk::builtin("HelperInvocation")]] bool isHI : HI) : SV_Target {
+// CHECK:      [[val:%\d+]] = OpLoad %bool %gl_HelperInvocation
+// CHECK-NEXT: OpStore %param_var_isHI [[val]]
+    float ret = 1.0;
+
+    if (isHI) ret = 2.0;
+
+    return ret;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.gs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.gs.hlsl
@@ -9,12 +9,18 @@ struct GsPerVertexIn {
     float3 clip2 : SV_ClipDistance2; // Builtin ClipDistance
     float2 clip0 : SV_ClipDistance0; // Builtin ClipDistance
     float3 foo   : FOO;              // Input variable
+
+    [[vk::builtin("PointSize")]]
+    float ptSize : PSIZE;            // Builtin PointSize
 };
 
 struct GsInnerOut {
     float4 pos   : SV_Position;      // Builtion Position
     float2 foo   : FOO;              // Output variable
     float2 cull3 : SV_CullDistance3; // Builtin CullDistance
+
+    [[vk::builtin("PointSize")]]
+    float ptSize : PSIZE;            // Builtin PointSize
 };
 
 struct GsPerVertexOut {
@@ -29,7 +35,7 @@ struct GsPerVertexOut {
 // Input  variable: FOO, BAR
 // Output variable: FOO, BAR
 
-// CHECK: OpEntryPoint Geometry %main "main" %gl_PerVertexIn %gl_ClipDistance %gl_CullDistance %in_var_BAR %in_var_FOO %gl_Position %out_var_FOO %out_var_BAR
+// CHECK: OpEntryPoint Geometry %main "main" %gl_PerVertexIn %gl_ClipDistance %gl_CullDistance %in_var_BAR %in_var_FOO %gl_Position %out_var_FOO %gl_PointSize %out_var_BAR
 
 // CHECK: OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
 // CHECK: OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
@@ -40,6 +46,7 @@ struct GsPerVertexOut {
 // CHECK: OpDecorate %gl_ClipDistance BuiltIn ClipDistance
 // CHECK: OpDecorate %gl_CullDistance BuiltIn CullDistance
 // CHECK: OpDecorate %gl_Position BuiltIn Position
+// CHECK: OpDecorate %gl_PointSize BuiltIn PointSize
 
 // CHECK: OpDecorate %in_var_BAR Location 0
 // CHECK: OpDecorate %in_var_FOO Location 1
@@ -61,6 +68,7 @@ struct GsPerVertexOut {
 // CHECK: %in_var_FOO = OpVariable %_ptr_Input__arr_v3float_uint_2 Input
 // CHECK: %gl_Position = OpVariable %_ptr_Output_v4float Output
 // CHECK: %out_var_FOO = OpVariable %_ptr_Output_v2float Output
+// CHECK: %gl_PointSize = OpVariable %_ptr_Output_float Output
 // CHECK: %out_var_BAR = OpVariable %_ptr_Output_v4float Output
 
 [maxvertexcount(2)]
@@ -128,16 +136,25 @@ void main(in    line float2                     bar   [2] : BAR,
 
 // CHECK-NEXT:   [[inFooArr:%\d+]] = OpLoad %_arr_v3float_uint_2 %in_var_FOO
 
+// Compose an array for GsPerVertexIn::ptSize
+// CHECK-NEXT:      [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_1
+// CHECK-NEXT:      [[val0:%\d+]] = OpLoad %float [[ptr0]]
+// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_1
+// CHECK-NEXT:      [[val1:%\d+]] = OpLoad %float [[ptr1]]
+// CHECK-NEXT: [[inPtSzArr:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 [[val0]] [[val1]]
+
 // CHECK-NEXT:      [[val0:%\d+]] = OpCompositeExtract %v4float [[inPosArr]] 0
 // CHECK-NEXT:      [[val1:%\d+]] = OpCompositeExtract %v3float [[inClip2Arr]] 0
 // CHECK-NEXT:      [[val2:%\d+]] = OpCompositeExtract %v2float [[inClip0Arr]] 0
 // CHECK-NEXT:      [[val3:%\d+]] = OpCompositeExtract %v3float [[inFooArr]] 0
-// CHECK-NEXT:   [[inData0:%\d+]] = OpCompositeConstruct %GsPerVertexIn [[val0]] [[val1]] [[val2]] [[val3]]
+// CHECK-NEXT:      [[val4:%\d+]] = OpCompositeExtract %float [[inPtSzArr]] 0
+// CHECK-NEXT:   [[inData0:%\d+]] = OpCompositeConstruct %GsPerVertexIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]]
 // CHECK-NEXT:      [[val0:%\d+]] = OpCompositeExtract %v4float [[inPosArr]] 1
 // CHECK-NEXT:      [[val1:%\d+]] = OpCompositeExtract %v3float [[inClip2Arr]] 1
 // CHECK-NEXT:      [[val2:%\d+]] = OpCompositeExtract %v2float [[inClip0Arr]] 1
 // CHECK-NEXT:      [[val3:%\d+]] = OpCompositeExtract %v3float [[inFooArr]] 1
-// CHECK-NEXT:   [[inData1:%\d+]] = OpCompositeConstruct %GsPerVertexIn [[val0]] [[val1]] [[val2]] [[val3]]
+// CHECK-NEXT:      [[val4:%\d+]] = OpCompositeExtract %float [[inPtSzArr]] 1
+// CHECK-NEXT:   [[inData1:%\d+]] = OpCompositeConstruct %GsPerVertexIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]]
 
 // CHECK-NEXT:    [[inData:%\d+]] = OpCompositeConstruct %_arr_GsPerVertexIn_uint_2 [[inData0]] [[inData1]]
 // CHECK-NEXT:                      OpStore %param_var_inData [[inData]]

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
@@ -16,12 +16,18 @@ struct HsCpIn
     float3 cull3   : SV_CullDistance3; // Builtin CullDistance
 
     float3 baz     : BAZ;              // Input variable
+
+    [[vk::builtin("PointSize")]]
+    float  ptSize  : PSIZE;            // Builtin PointSize
 };
 
 struct CpInner2 {
     float1 clip8   : SV_ClipDistance8; // Builtin ClipDistance
     float2 cull6   : SV_CullDistance6; // Builtin CullDistance
     float3 foo     : FOO;              // Output variable
+
+    [[vk::builtin("PointSize")]]
+    float  ptSize  : PSIZE;            // Builtin PointSize
 };
 
 struct CpInner1 {
@@ -203,6 +209,13 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 
 // CHECK-NEXT:   [[inBazArr:%\d+]] = OpLoad %_arr_v3float_uint_2 %in_var_BAZ
 
+// Read gl_PerVertex[].gl_PointSize[] to compose a new array for HsCpIn::ptSize
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_1
+// CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_1
+// CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
+// CHECK-NEXT:  [[inPtSzArr:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 [[val0]] [[val1]]
+
 // Compose a temporary HsCpIn value out of the temporary arrays constructed before
 // CHECK-NEXT:       [[val0:%\d+]] = OpCompositeExtract %v4float [[inPosArr]] 0
 // CHECK-NEXT:       [[val1:%\d+]] = OpCompositeExtract %v2float [[inClip0Arr]] 0
@@ -210,7 +223,8 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 // CHECK-NEXT:       [[val3:%\d+]] = OpCompositeExtract %float [[inClip2Arr]] 0
 // CHECK-NEXT:       [[val4:%\d+]] = OpCompositeExtract %v3float [[inCull3Arr]] 0
 // CHECK-NEXT:       [[val5:%\d+]] = OpCompositeExtract %v3float [[inBazArr]] 0
-// CHECK-NEXT:    [[hscpin0:%\d+]] = OpCompositeConstruct %HsCpIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]] [[val5]]
+// CHECK-NEXT:       [[val6:%\d+]] = OpCompositeExtract %float [[inPtSzArr]] 0
+// CHECK-NEXT:    [[hscpin0:%\d+]] = OpCompositeConstruct %HsCpIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]] [[val5]] [[val6]]
 
 // Compose a temporary HsCpIn value out of the temporary arrays constructed before
 // CHECK-NEXT:       [[val0:%\d+]] = OpCompositeExtract %v4float [[inPosArr]] 1
@@ -219,7 +233,8 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 // CHECK-NEXT:       [[val3:%\d+]] = OpCompositeExtract %float [[inClip2Arr]] 1
 // CHECK-NEXT:       [[val4:%\d+]] = OpCompositeExtract %v3float [[inCull3Arr]] 1
 // CHECK-NEXT:       [[val5:%\d+]] = OpCompositeExtract %v3float [[inBazArr]] 1
-// CHECK-NEXT:    [[hscpin1:%\d+]] = OpCompositeConstruct %HsCpIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]] [[val5]]
+// CHECK-NEXT:       [[val6:%\d+]] = OpCompositeExtract %float [[inPtSzArr]] 1
+// CHECK-NEXT:    [[hscpin1:%\d+]] = OpCompositeConstruct %HsCpIn [[val0]] [[val1]] [[val2]] [[val3]] [[val4]] [[val5]] [[val6]]
 
 // Populate the temporary variables for function call
 
@@ -272,6 +287,11 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 // CHECK-NEXT:        [[foo:%\d+]] = OpCompositeExtract %v3float [[outInner2]] 2
 // CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v3float %out_var_FOO [[invoId]]
 // CHECK-NEXT:                       OpStore [[ptr]] [[foo]]
+
+// Write out HsCpOut::CpInner1::CpInner2::PointSize to gl_PerVertex[].gl_PointSize
+// CHECK-NEXT:     [[ptSize:%\d+]] = OpCompositeExtract %float [[outInner2]] 3
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_1
+// CHECK-NEXT:                       OpStore [[ptr]] [[ptSize]]
 
 // Write out HsCpOut::CpInner1::clip6 to gl_PerVertex[].gl_ClipDistance
 // CHECK-NEXT:      [[clip6:%\d+]] = OpCompositeExtract %float [[outInner1]] 2

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
@@ -45,16 +45,17 @@ struct VSOut {
   InnerStruct s;
 };
 
-void main(out VSOut  vsOut,
-          out   float3 clipdis0 : SV_ClipDistance0, // -> BuiltIn ClipDistance in gl_PerVertex
-          inout float4 coord    : TEXCOORD,         // -> Input & output variable
-          out   float  culldis5 : SV_CullDistance5, // -> BuiltIn CullDistance in gl_PerVertex
-          out   float  culldis3 : SV_CullDistance3, // -> BuiltIn CullDistance in gl_PerVertex
-          out   float  culldis6 : SV_CullDistance6, // -> BuiltIn CullDistance in gl_PerVertex
-          in    float4 inPos    : SV_Position,      // -> Input variable
-          in    float2 inClip   : SV_ClipDistance,  // -> Input variable
-          in    float3 inCull   : SV_CullDistance0  // -> Input variable
-         ) {
+[[vk::builtin("PointSize")]]
+float main(out VSOut  vsOut,
+           out   float3 clipdis0 : SV_ClipDistance0, // -> BuiltIn ClipDistance in gl_PerVertex
+           inout float4 coord    : TEXCOORD,         // -> Input & output variable
+           out   float  culldis5 : SV_CullDistance5, // -> BuiltIn CullDistance in gl_PerVertex
+           out   float  culldis3 : SV_CullDistance3, // -> BuiltIn CullDistance in gl_PerVertex
+           out   float  culldis6 : SV_CullDistance6, // -> BuiltIn CullDistance in gl_PerVertex
+           in    float4 inPos    : SV_Position,      // -> Input variable
+           in    float2 inClip   : SV_ClipDistance,  // -> Input variable
+           in    float3 inCull   : SV_CullDistance0  // -> Input variable
+         ) : PSize {                                 // -> Builtin PointSize
     vsOut    = (VSOut)0;
     clipdis0 = 1.;
     coord    = 2.;
@@ -62,6 +63,8 @@ void main(out VSOut  vsOut,
     culldis3 = 4.;
     culldis6 = 5.;
     inPos    = 6.;
+
+    return 7.;
 
 // Layout of ClipDistance array:
 //   clipdis0: 3 floats, offset 0
@@ -81,7 +84,10 @@ void main(out VSOut  vsOut,
 // CHECK-NEXT:   [[inCull:%\d+]] = OpLoad %v3float %in_var_SV_CullDistance0
 // CHECK-NEXT:                     OpStore %param_var_inCull [[inCull]]
 
-// CHECK-NEXT: OpFunctionCall %void %src_main
+// CHECK-NEXT:   [[ptSize:%\d+]] = OpFunctionCall %float %src_main
+
+// CHECK-NEXT:      [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_1
+// CHECK-NEXT:                     OpStore [[ptr]] [[ptSize]]
 
 // Write out COLOR
 // CHECK-NEXT:    [[vsOut:%\d+]] = OpLoad %VSOut %param_var_vsOut

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -936,6 +936,10 @@ TEST_F(FileTest, SpirvEntryFunctionInOut) {
   runFileTest("spirv.entry-function.inout.hlsl");
 }
 
+TEST_F(FileTest, SpirvBuiltInHelperInvocation) {
+  runFileTest("spirv.builtin.helper-invocation.hlsl");
+}
+
 // For shader stage input/output interface
 // For semantic SV_Position, SV_ClipDistance, SV_CullDistance
 TEST_F(FileTest, SpirvStageIOInterfaceVS) {


### PR DESCRIPTION
[[vk::builtin("...")]] is introduced to support Vulkan-specific
builtins.

There are two supported in this commit:

* gl_PointSize
* gl_HelperInvocation

Validating the usages of these two builtins is left for anther
commit.