### PR TITLE
[spirv] Validate vk::push_constant usage

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -239,6 +239,10 @@ private:
                             llvm::SmallVectorImpl<uint32_t> *indices);
 
 private:
+  /// Validates that vk::* attributes are used correctly.
+  void validateVKAttributes(const Decl *decl);
+
+private:
   /// Processes the given expr, casts the result into the given bool (vector)
   /// type and returns the <result-id> of the casted value.
   uint32_t castToBool(uint32_t value, QualType fromType, QualType toType);
@@ -672,6 +676,15 @@ private:
     return diags.Report(loc, diagId);
   }
 
+  /// \brief Wrapper method to create a note message and report it
+  /// in the diagnostic engine associated with this consumer
+  template <unsigned N>
+  DiagnosticBuilder emitNote(const char (&message)[N], SourceLocation loc) {
+    const auto diagId =
+        diags.getCustomDiagID(clang::DiagnosticsEngine::Note, message);
+    return diags.Report(loc, diagId);
+  }
+
 private:
   CompilerInstance &theCompilerInstance;
   ASTContext &astContext;
@@ -702,6 +715,10 @@ private:
   const FunctionDecl *curFunction;
   /// The SPIR-V function parameter for the current this object.
   uint32_t curThis;
+
+  /// The source location of a push constant block we have previously seen.
+  /// Invalid means no push constant blocks defined thus far.
+  SourceLocation seenPushConstantAt;
 
   /// Whether the translated SPIR-V binary needs legalization.
   ///

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.invalid.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.invalid.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float f;
+};
+
+[[vk::push_constant, vk::binding(5)]]
+S pcs;
+
+float main() : A {
+    return 1.0;
+}
+
+// CHECK: :7:3: error: 'push_constant' attribute cannot be used together with 'binding' attribute

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.multiple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.multiple.hlsl
@@ -1,0 +1,24 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float4 f;
+};
+
+[[vk::push_constant]]
+S pcs1;
+
+[[vk::push_constant]] // error
+S pcs2;
+
+[[vk::push_constant]] // error
+S pcs3;
+
+float main() : A {
+    return 1.0;
+}
+
+// CHECK: :10:3: error: cannot have more than one push constant block
+// CHECK: :7:3: note: push constant block previously defined here
+
+// CHECK: :13:3: error: cannot have more than one push constant block
+// CHECK: :7:3: note: push constant block previously defined here

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -862,6 +862,9 @@ TEST_F(FileTest, SpirvInterpolationError) {
 TEST_F(FileTest, VulkanAttributeErrors) {
   runFileTest("vk.attribute.error.hlsl", FileTest::Expect::Failure);
 }
+TEST_F(FileTest, VulkanAttributeInvalidUsages) {
+  runFileTest("vk.attribute.invalid.hlsl", FileTest::Expect::Failure);
+}
 
 // Vulkan specific
 TEST_F(FileTest, VulkanLocation) { runFileTest("vk.location.hlsl"); }
@@ -914,6 +917,9 @@ TEST_F(FileTest, VulkanStructuredBufferCounter) {
 }
 
 TEST_F(FileTest, VulkanPushConstant) { runFileTest("vk.push-constant.hlsl"); }
+TEST_F(FileTest, VulkanMultiplePushConstant) {
+  runFileTest("vk.push-constant.multiple.hlsl", FileTest::Expect::Failure);
+}
 
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");


### PR DESCRIPTION
Attaching vk::push_constant and vk::binding to the same global
variable is disallowed.