### PR TITLE
[spirv] Emit note for the intial use location of bindings

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -291,6 +291,15 @@ private:
     return diags.Report(loc, diagId);
   }
 
+  /// \brief Wrapper method to create a note message and report it
+  /// in the diagnostic engine associated with this consumer.
+  template <unsigned N>
+  DiagnosticBuilder emitNote(const char (&message)[N], SourceLocation loc) {
+    const auto diagId =
+        diags.getCustomDiagID(clang::DiagnosticsEngine::Note, message);
+    return diags.Report(loc, diagId);
+  }
+
   /// \brief Checks whether some semantic is used more than once and returns
   /// true if no such cases. Returns false otherwise.
   bool checkSemanticDuplication(bool forInput);

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.error.hlsl
@@ -23,6 +23,7 @@ float4 main() : SV_Target {
 }
 
 //CHECK: :10:30: error: resource binding #2 in descriptor set #0 already assigned
+//CHECK:   :7:3: note: binding number previously assigned here
 
 //CHECK: :13:29: error: resource binding #2 in descriptor set #0 already assigned
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.error.hlsl
@@ -36,6 +36,7 @@ float4 main() : SV_Target {
 // CHECK-NOT:  :9:{{%\d+}}: error: resource binding #1 in descriptor set #0 already assigned
 // CHECK-NOT: :12:{{%\d+}}: error: resource binding #3 in descriptor set #1 already assigned
 // CHECK: :15:3: error: resource binding #3 in descriptor set #1 already assigned
+// CHECK: :12:3: note: binding number previously assigned here
 // CHECK: :18:3: error: resource binding #1 in descriptor set #0 already assigned
 // CHECK: :26:3: error: resource binding #5 in descriptor set #0 already assigned
 // CHECK: :29:3: error: resource binding #5 in descriptor set #0 already assigned

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.error.hlsl
@@ -23,6 +23,7 @@ float4 main() : SV_Target {
 }
 
 // CHECK: :10:36: error: resource binding #0 in descriptor set #0 already assigned
+// CHECK:  :7:36: note: binding number previously assigned here
 // CHECK: :11:36: error: resource binding #0 in descriptor set #1 already assigned
 // CHECK-NOT: :15:{{%\d+}}: error: resource binding #5 in descriptor set #1 already assigned
 // CHECK-NOT: :18:{{%\d+}}: error: resource binding #6 in descriptor set #6 already assigned


### PR DESCRIPTION
This makes it easier for the devs to see with which a binding
numbers is conflicting.