### PR TITLE
[spirv] Allow samplers and textures in initializer list

### DIFF
--- a/tools/clang/lib/SPIRV/InitListHandler.h
+++ b/tools/clang/lib/SPIRV/InitListHandler.h
@@ -125,6 +125,7 @@ private:
                                    uint32_t colCount, SourceLocation);
   uint32_t createInitForStructType(QualType type);
   uint32_t createInitForConstantArrayType(QualType type, SourceLocation);
+  uint32_t createInitForSamplerImageType(QualType type, SourceLocation);
 
 private:
   SPIRVEmitter &theEmitter;

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -620,8 +620,12 @@ TypeTranslator::getLayoutDecorations(const DeclContext *decl, LayoutRule rule) {
 }
 
 uint32_t TypeTranslator::translateResourceType(QualType type, LayoutRule rule) {
+  // Resource types are either represented like C struct or C++ class in the
+  // AST. Samplers are represented like C struct, so isStructureType() will
+  // return true for it; textures are represented like C++ class, so
+  // isClassType() will return true for it.
+
   const auto *recordType = type->getAs<RecordType>();
-  assert(recordType);
   const llvm::StringRef name = recordType->getDecl()->getName();
 
   // TODO: avoid string comparison once hlsl::IsHLSLResouceType() does that.

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -625,7 +625,10 @@ uint32_t TypeTranslator::translateResourceType(QualType type, LayoutRule rule) {
   // return true for it; textures are represented like C++ class, so
   // isClassType() will return true for it.
 
+  assert(type->isStructureOrClassType());
+
   const auto *recordType = type->getAs<RecordType>();
+  assert(recordType);
   const llvm::StringRef name = recordType->getDecl()->getName();
 
   // TODO: avoid string comparison once hlsl::IsHLSLResouceType() does that.

--- a/tools/clang/test/CodeGenSPIRV/var.init.opaque.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.opaque.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct Inner {
+    Texture3D    t;
+};
+
+struct Combined1 {
+    Inner        others;
+    SamplerState s1;
+    Texture2D    t1;
+    Texture2D    t2;
+    SamplerState s2;
+};
+
+struct Combined2 {
+    Texture3D    t;
+    SamplerState s;
+};
+
+Texture3D    gTex3D;
+SamplerState gSampler;
+Texture2D    gTex2D;
+
+float main() : A {
+
+// CHECK:      [[tex3d:%\d+]] = OpLoad %type_3d_image %gTex3D
+// CHECK-NEXT: [[sampl:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[comb2:%\d+]] = OpCompositeConstruct %Combined2 [[tex3d]] [[sampl]]
+// CHECK-NEXT:                  OpStore %comb2 [[comb2]]
+    Combined2 comb2 = {gTex3D, gSampler};
+
+// CHECK-NEXT:   [[ptr:%\d+]] = OpAccessChain %_ptr_Function_type_3d_image %comb2 %int_0
+// CHECK-NEXT: [[tex3d:%\d+]] = OpLoad %type_3d_image [[ptr]]
+// CHECK-NEXT: [[inner:%\d+]] = OpCompositeConstruct %Inner [[tex3d]]
+// CHECK-NEXT:   [[ptr:%\d+]] = OpAccessChain %_ptr_Function_type_sampler %comb2 %int_1
+// CHECK-NEXT: [[sampl1:%\d+]] = OpLoad %type_sampler [[ptr]]
+// CHECK-NEXT: [[tex2d1:%\d+]] = OpLoad %type_2d_image %gTex2D
+// CHECK-NEXT: [[tex2d2:%\d+]] = OpLoad %type_2d_image %gTex2D
+// CHECK-NEXT: [[sampl2:%\d+]] = OpLoad %type_sampler %gSampler
+// CHECK-NEXT: [[comb1:%\d+]] = OpCompositeConstruct %Combined1 [[inner]] [[sampl1]] [[tex2d1]] [[tex2d2]] [[sampl2]]
+// CHECK-NEXT:                  OpStore %comb1 [[comb1]]
+    Combined1 comb1 = {comb2, {gTex2D, gTex2D}, gSampler};
+
+    return 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -97,6 +97,7 @@ TEST_F(FileTest, VarInitCbuffer) {
 TEST_F(FileTest, VarInitTbuffer) {
   runFileTest("var.init.tbuffer.hlsl", FileTest::Expect::Warning);
 }
+TEST_F(FileTest, VarInitOpaque) { runFileTest("var.init.opaque.hlsl"); }
 TEST_F(FileTest, StaticVar) { runFileTest("var.static.hlsl"); }
 
 // For prefix/postfix increment/decrement


### PR DESCRIPTION
Samplers, (RW)Buffers, and (RW)Textures are translated into SPIR-V
opaque types OpTypeSampler and OpTypeImage. Putting them in init
list will result in illegal SPIR-V. But we still allow it in the
CodeGen. Relying on SPIRV-Tools opt to correct them.