### PR TITLE
[spirv] Fix location mismatches between HS and DS

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -654,7 +654,13 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
     }
   }
 
-  if (spirvOptions.stageIoOrder == "alpha") {
+  // If alphabetical ordering was requested, sort by semantic string.
+  // Since HS includes 2 sets of outputs (patch-constant output and
+  // OutputPatch), running into location mismatches between HS and DS is very
+  // likely. In order to avoid location mismatches between HS and DS, use
+  // alphabetical ordering.
+  if (spirvOptions.stageIoOrder == "alpha" ||
+      (!forInput && shaderModel.IsHS()) || (forInput && shaderModel.IsDS())) {
     // Sort stage input/output variables alphabetically
     std::sort(vars.begin(), vars.end(),
               [](const StageVar *a, const StageVar *b) {

--- a/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
@@ -105,12 +105,12 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // OpDecorate %in_var_TANWEIGHTS Patch
 // OpDecorate %gl_TessCoord BuiltIn TessCoord
 // OpDecorate %gl_TessCoord Patch
-// OpDecorate %in_var_TANGENT Location 0
-// OpDecorate %in_var_TEXCOORD Location 1
+// OpDecorate %in_var_BEZIERPOS Location 0
+// OpDecorate %in_var_TANGENT Location 1
 // OpDecorate %in_var_TANUCORNER Location 2
 // OpDecorate %in_var_TANVCORNER Location 3
 // OpDecorate %in_var_TANWEIGHTS Location 4
-// OpDecorate %in_var_BEZIERPOS Location 5
+// OpDecorate %in_var_TEXCOORD Location 5
 // OpDecorate %out_var_NORMAL Location 0
 // OpDecorate %out_var_TEXCOORD Location 1
 // OpDecorate %out_var_TANGENT Location 2

--- a/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
@@ -129,10 +129,10 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // OpDecorate %in_var_TANGENT Location 2
 // OpDecorate %out_var_BEZIERPOS Location 0
 // OpDecorate %out_var_TANGENT Location 1
-// OpDecorate %out_var_TEXCOORD Location 2
-// OpDecorate %out_var_TANUCORNER Location 3
-// OpDecorate %out_var_TANVCORNER Location 4
-// OpDecorate %out_var_TANWEIGHTS Location 5
+// OpDecorate %out_var_TANUCORNER Location 2
+// OpDecorate %out_var_TANVCORNER Location 3
+// OpDecorate %out_var_TANWEIGHTS Location 4
+// OpDecorate %out_var_TEXCOORD Location 5
 // %uint = OpTypeInt 32 0
 // %int = OpTypeInt 32 1
 // %void = OpTypeVoid

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
@@ -81,9 +81,9 @@ struct DsOut {
 // CHECK: OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
 // CHECK: OpDecorate %gl_TessLevelInner Patch
 // CHECK: OpDecorate %in_var_FOO Patch
-// CHECK: OpDecorate %in_var_TEXCOORD Location 0
-// CHECK: OpDecorate %in_var_BAR Location 1
-// CHECK: OpDecorate %in_var_FOO Location 2
+// CHECK: OpDecorate %in_var_BAR Location 0
+// CHECK: OpDecorate %in_var_FOO Location 1
+// CHECK: OpDecorate %in_var_TEXCOORD Location 2
 // CHECK: OpDecorate %out_var_FOO Location 0
 // CHECK: OpDecorate %out_var_BAR Location 1
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
@@ -81,8 +81,8 @@ struct HsPcfOut
 // CHECK: OpDecorate %out_var_TEXCOORD Patch
 // CHECK: OpDecorate %out_var_WEIGHT Patch
 // CHECK: OpDecorate %in_var_BAZ Location 0
-// CHECK: OpDecorate %out_var_FOO Location 0
-// CHECK: OpDecorate %out_var_BAR Location 1
+// CHECK: OpDecorate %out_var_BAR Location 0
+// CHECK: OpDecorate %out_var_FOO Location 1
 // CHECK: OpDecorate %out_var_TEXCOORD Location 2
 // CHECK: OpDecorate %out_var_WEIGHT Location 3
 


### PR DESCRIPTION
Uses location assignments in alphabetical order for HS outputs and DS
inputs. This will make the interface matching for these two stages
robust.