### PR TITLE
[spirv] Use SpirvEvalInfo to convey lvalue/rvalue

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -94,7 +94,7 @@ private:
   SpirvEvalInfo doCallExpr(const CallExpr *callExpr);
   SpirvEvalInfo doCastExpr(const CastExpr *expr);
   SpirvEvalInfo doCompoundAssignOperator(const CompoundAssignOperator *expr);
-  uint32_t doConditionalOperator(const ConditionalOperator *expr);
+  SpirvEvalInfo doConditionalOperator(const ConditionalOperator *expr);
   SpirvEvalInfo doCXXMemberCallExpr(const CXXMemberCallExpr *expr);
   SpirvEvalInfo doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr);
   SpirvEvalInfo doExtMatrixElementExpr(const ExtMatrixElementExpr *expr);
@@ -110,7 +110,7 @@ private:
 
   /// Generates SPIR-V instructions for the given normal (non-intrinsic and
   /// non-operator) standalone or member function call.
-  uint32_t processCall(const CallExpr *expr);
+  SpirvEvalInfo processCall(const CallExpr *expr);
 
   /// Generates the necessary instructions for assigning rhs to lhs. If lhsPtr
   /// is not zero, it will be used as the pointer from lhs instead of evaluating
@@ -218,7 +218,7 @@ private:
   /// matrixVal should be the loaded value of the matrix. actOnEachVector takes
   /// three parameters for the current vector: the index, the <type-id>, and
   /// the value. It returns the <result-id> of the processed vector.
-  uint32_t processEachVectorInMatrix(
+  SpirvEvalInfo processEachVectorInMatrix(
       const Expr *matrix, const uint32_t matrixVal,
       llvm::function_ref<uint32_t(uint32_t, uint32_t, uint32_t)>
           actOnEachVector);
@@ -259,7 +259,7 @@ private:
 
 private:
   /// Processes HLSL instrinsic functions.
-  uint32_t processIntrinsicCallExpr(const CallExpr *);
+  SpirvEvalInfo processIntrinsicCallExpr(const CallExpr *);
 
   /// Processes the 'clip' intrinsic function. Discards the current pixel if the
   /// specified value is less than zero.
@@ -570,9 +570,10 @@ private:
   /// \brief Loads one element from the given Buffer/RWBuffer/Texture object at
   /// the given location. The type of the loaded element matches the type in the
   /// declaration for the Buffer/Texture object.
-  uint32_t processBufferTextureLoad(const Expr *object, uint32_t location,
-                                    uint32_t constOffset = 0,
-                                    uint32_t varOffst = 0, uint32_t lod = 0);
+  SpirvEvalInfo processBufferTextureLoad(const Expr *object, uint32_t location,
+                                         uint32_t constOffset = 0,
+                                         uint32_t varOffst = 0,
+                                         uint32_t lod = 0);
 
   /// \brief Processes .Sample() and .Gather() method calls for texture objects.
   uint32_t processTextureSampleGather(const CXXMemberCallExpr *expr,
@@ -625,8 +626,9 @@ private:
   /// ByteAddressBuffer. Loading is allowed from a ByteAddressBuffer or
   /// RWByteAddressBuffer. Storing is allowed only to RWByteAddressBuffer.
   /// Panics if it is not the case.
-  uint32_t processByteAddressBufferLoadStore(const CXXMemberCallExpr *,
-                                             uint32_t numWords, bool doStore);
+  SpirvEvalInfo processByteAddressBufferLoadStore(const CXXMemberCallExpr *,
+                                                  uint32_t numWords,
+                                                  bool doStore);
 
   /// \brief Processes the GetDimensions intrinsic function call on a
   /// (RW)ByteAddressBuffer by querying the image in the given expr.

--- a/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.buffer-access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.buffer-access.hlsl
@@ -1,0 +1,37 @@
+// Run: %dxc -T ps_6_0 -E main
+
+Buffer<float>  myBuffer1;
+Buffer<float3> myBuffer3;
+
+float4 main(in float4 pos : SV_Position) : SV_Target0
+{
+    uint index = (uint)pos.x;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image %myBuffer1
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}}
+// CHECK-NEXT:   [[val:%\d+]] = OpCompositeExtract %float [[fetch]] 0
+// CHECK-NEXT:                  OpStore %a [[val]]
+    float  a = myBuffer1[index].x;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image %myBuffer1
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}}
+// CHECK-NEXT:    [[ex:%\d+]] = OpCompositeExtract %float [[fetch]] 0
+// CHECK-NEXT:   [[val:%\d+]] = OpCompositeConstruct %v2float [[ex]] [[ex]]
+// CHECK-NEXT:                  OpStore %b [[val]]
+    float2 b = myBuffer1[index].xx;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_0 %myBuffer3
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}}
+// CHECK-NEXT:   [[val:%\d+]] = OpVectorShuffle %v3float [[fetch]] [[fetch]] 0 1 2
+// CHECK-NEXT:       OpStore %c [[val]]
+    float3 c = myBuffer3[index].xyz;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_0 %myBuffer3
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}}
+// CHECK-NEXT:   [[val:%\d+]] = OpVectorShuffle %v3float [[fetch]] [[fetch]] 0 1 2
+// CHECK-NEXT:     [[d:%\d+]] = OpVectorShuffle %v4float [[val]] [[val]] 1 1 0 2
+// CHECK-NEXT:                  OpStore %d [[d]]
+    float4 d = myBuffer3[index].yyxz;
+
+    return float4(c, a) + d + float4(b, b);
+}

--- a/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.hlsl
@@ -125,10 +125,8 @@ void main() {
 // CHECK-NEXT: OpStore %v4f2 [[v24]]
     v4f2.wzyx.abgr.xywz.rgab = v4f1.xyzw.xyzw.rgab.rgab; // from original vector to original vector
 
-    // Note that we cannot generate OpAccessChain for v4f1 since v4f1.xzyx is
-    // already not a lvalue!
-// CHECK-NEXT: [[v24:%\d+]] = OpLoad %v4float %v4f1
-// CHECK-NEXT: [[ce1:%\d+]] = OpCompositeExtract %float [[v24]] 2
+// CHECK-NEXT: [[v24:%\d+]] = OpAccessChain %_ptr_Function_float %v4f1 %int_2
+// CHECK-NEXT: [[ce1:%\d+]] = OpLoad %float [[v24]]
 // CHECK-NEXT: [[ac4:%\d+]] = OpAccessChain %_ptr_Function_float %v4f2 %int_1
 // CHECK-NEXT: OpStore [[ac4]] [[ce1]]
     v4f2.wzyx.zy.x = v4f1.xzyx.y.x; // from one element (rvalue) to one element (lvalue)

--- a/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.texture-access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.texture-access.hlsl
@@ -1,0 +1,33 @@
+// Run: %dxc -T ps_6_0 -E main
+
+Texture2D<float4> myTexture;
+
+float4 main(in float4 pos : SV_Position) : SV_Target0
+{
+    int2 coord = (int2)pos.xy;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_2d_image %myTexture
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}} Lod %uint_0
+// CHECK-NEXT:   [[val:%\d+]] = OpCompositeExtract %float [[fetch]] 2
+// CHECK-NEXT:                  OpStore %a [[val]]
+    float  a = myTexture[coord].z;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_2d_image %myTexture
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}} Lod %uint_0
+// CHECK-NEXT:   [[val:%\d+]] = OpVectorShuffle %v2float [[fetch]] [[fetch]] 1 0
+// CHECK-NEXT:                  OpStore %b [[val]]
+    float2 b = myTexture[coord].yx;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_2d_image %myTexture
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}} Lod %uint_0
+// CHECK-NEXT:   [[val:%\d+]] = OpVectorShuffle %v3float [[fetch]] [[fetch]] 2 3 0
+// CHECK-NEXT:       OpStore %c [[val]]
+    float3 c = myTexture[coord].zwx;
+
+// CHECK:        [[img:%\d+]] = OpLoad %type_2d_image %myTexture
+// CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] {{%\d+}} Lod %uint_0
+// CHECK-NEXT:                  OpStore %d [[fetch]]
+    float4 d = myTexture[coord].xyzw;
+
+    return float4(c, a) + d + float4(b, b);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -219,6 +219,12 @@ TEST_F(FileTest, OpVectorSwizzle) { runFileTest("op.vector.swizzle.hlsl"); }
 TEST_F(FileTest, OpVectorSwizzle1) {
   runFileTest("op.vector.swizzle.size1.hlsl");
 }
+TEST_F(FileTest, OpVectorSwizzleAfterBufferAccess) {
+  runFileTest("op.vector.swizzle.buffer-access.hlsl");
+}
+TEST_F(FileTest, OpVectorSwizzleAfterTextureAccess) {
+  runFileTest("op.vector.swizzle.texture-access.hlsl");
+}
 TEST_F(FileTest, OpVectorAccess) { runFileTest("op.vector.access.hlsl"); }
 
 // For matrix accessing/swizzling operators


### PR DESCRIPTION
Previously we reply on Expr::isGLValue() to check whether an
expression is lvalue. That requires lots of ad-hoc fixes in
the CodeGen for missing/wrong lvalue/rvalue.

Now we use SpirvEvalInfo to calculate the lvalueness together
with the <result-id>. It is much cleaner.

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/819