### PR TITLE
[spirv] Use .getAs<>() instead of cast<>() for RecordType

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1102,7 +1102,7 @@ bool DeclResultIdMapper::createStageVars(
     return false;
   }
 
-  const auto *structDecl = cast<RecordType>(type.getTypePtr())->getDecl();
+  const auto *structDecl = type->getAs<RecordType>()->getDecl();
 
   if (asInput) {
     // If this decl translates into multiple stage input variables, we need to
@@ -1226,7 +1226,7 @@ bool DeclResultIdMapper::writeBackOutputStream(const ValueDecl *decl,
     return false;
   }
 
-  const auto *structDecl = cast<RecordType>(type.getTypePtr())->getDecl();
+  const auto *structDecl = type->getAs<RecordType>()->getDecl();
 
   // Write out each field
   for (const auto *field : structDecl->fields()) {

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -159,8 +159,7 @@ bool GlPerVertex::doClipCullDistanceDecl(const DeclaratorDecl *decl,
 
   if (!getStageVarSemantic(decl, &semanticStr, &semantic, &semanticIndex)) {
     if (baseType->isStructureType()) {
-      const auto *structDecl =
-          cast<RecordType>(baseType.getTypePtr())->getDecl();
+      const auto *structDecl = baseType->getAs<RecordType>()->getDecl();
       // Go through each field to see if there is any usage of
       // SV_ClipDistance/SV_CullDistance.
       for (const auto *field : structDecl->fields()) {


### PR DESCRIPTION
cast<RecordType>(T.getTypePtr()) cannot handle cases in which
T is typedef of some struct type.