### PR TITLE
Container clipboard and XML serialization

### DIFF
--- a/tools/clang/tools/dotnetc/EditorForm.Designer.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.Designer.cs
@@ -123,6 +123,7 @@ namespace MainNs
             this.RenderLogTabPage = new System.Windows.Forms.TabPage();
             this.RenderLogBox = new System.Windows.Forms.TextBox();
             this.RewriterOutputTextBox = new System.Windows.Forms.RichTextBox();
+            this.bitstreamFromClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.TheStatusStrip.SuspendLayout();
             this.TheMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -173,7 +174,7 @@ namespace MainNs
             this.helpToolStripMenuItem});
             this.TheMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.TheMenuStrip.Name = "TheMenuStrip";
-            this.TheMenuStrip.Size = new System.Drawing.Size(1302, 40);
+            this.TheMenuStrip.Size = new System.Drawing.Size(1302, 42);
             this.TheMenuStrip.TabIndex = 1;
             this.TheMenuStrip.Text = "menuStrip1";
             // 
@@ -189,7 +190,7 @@ namespace MainNs
             this.toolStripMenuItem4,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(64, 36);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(64, 38);
             this.fileToolStripMenuItem.Text = "&File";
             this.fileToolStripMenuItem.DropDownOpening += new System.EventHandler(this.fileToolStripMenuItem_DropDownOpening);
             // 
@@ -265,7 +266,7 @@ namespace MainNs
             this.FontGrowToolStripMenuItem,
             this.FontShrinkToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(67, 36);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(67, 38);
             this.editToolStripMenuItem.Text = "&Edit";
             // 
             // undoToolStripMenuItem
@@ -386,61 +387,62 @@ namespace MainNs
             this.viewToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.autoUpdateToolStripMenuItem,
             this.bitstreamToolStripMenuItem,
+            this.bitstreamFromClipboardToolStripMenuItem,
             this.ColorMenuItem,
             this.debugInformationToolStripMenuItem,
             this.errorListToolStripMenuItem,
             this.renderToolStripMenuItem,
             this.outputToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(78, 36);
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(78, 38);
             this.viewToolStripMenuItem.Text = "&View";
             // 
             // autoUpdateToolStripMenuItem
             // 
             this.autoUpdateToolStripMenuItem.Name = "autoUpdateToolStripMenuItem";
-            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.autoUpdateToolStripMenuItem.Text = "&Auto-Update";
             this.autoUpdateToolStripMenuItem.Click += new System.EventHandler(this.autoUpdateToolStripMenuItem_Click);
             // 
             // bitstreamToolStripMenuItem
             // 
             this.bitstreamToolStripMenuItem.Name = "bitstreamToolStripMenuItem";
-            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.bitstreamToolStripMenuItem.Text = "&Bitstream";
             this.bitstreamToolStripMenuItem.Click += new System.EventHandler(this.bitstreamToolStripMenuItem_Click);
             // 
             // ColorMenuItem
             // 
             this.ColorMenuItem.Name = "ColorMenuItem";
-            this.ColorMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.ColorMenuItem.Size = new System.Drawing.Size(378, 38);
             this.ColorMenuItem.Text = "&Color";
             this.ColorMenuItem.Click += new System.EventHandler(this.colorToolStripMenuItem_Click);
             // 
             // debugInformationToolStripMenuItem
             // 
             this.debugInformationToolStripMenuItem.Name = "debugInformationToolStripMenuItem";
-            this.debugInformationToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.debugInformationToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.debugInformationToolStripMenuItem.Text = "&Debug Information";
             this.debugInformationToolStripMenuItem.Click += new System.EventHandler(this.debugInformationToolStripMenuItem_Click);
             // 
             // errorListToolStripMenuItem
             // 
             this.errorListToolStripMenuItem.Name = "errorListToolStripMenuItem";
-            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.errorListToolStripMenuItem.Text = "Error L&ist";
             this.errorListToolStripMenuItem.Click += new System.EventHandler(this.errorListToolStripMenuItem_Click);
             // 
             // renderToolStripMenuItem
             // 
             this.renderToolStripMenuItem.Name = "renderToolStripMenuItem";
-            this.renderToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.renderToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.renderToolStripMenuItem.Text = "&Render";
             this.renderToolStripMenuItem.Click += new System.EventHandler(this.renderToolStripMenuItem_Click);
             // 
             // outputToolStripMenuItem
             // 
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
-            this.outputToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
+            this.outputToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
             this.outputToolStripMenuItem.Text = "&Output";
             this.outputToolStripMenuItem.Click += new System.EventHandler(this.outputToolStripMenuItem_Click);
             // 
@@ -450,7 +452,7 @@ namespace MainNs
             this.compileToolStripMenuItem,
             this.exportCompiledObjectToolStripMenuItem});
             this.buildToolStripMenuItem.Name = "buildToolStripMenuItem";
-            this.buildToolStripMenuItem.Size = new System.Drawing.Size(81, 36);
+            this.buildToolStripMenuItem.Size = new System.Drawing.Size(81, 38);
             this.buildToolStripMenuItem.Text = "&Build";
             // 
             // compileToolStripMenuItem
@@ -475,7 +477,7 @@ namespace MainNs
             this.rewriterToolStripMenuItem,
             this.rewriteNobodyToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(82, 36);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(82, 38);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // optionsToolStripMenuItem
@@ -504,7 +506,7 @@ namespace MainNs
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(77, 36);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(77, 38);
             this.helpToolStripMenuItem.Text = "&Help";
             // 
             // aboutToolStripMenuItem
@@ -528,7 +530,7 @@ namespace MainNs
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.AnalysisTabControl);
-            this.splitContainer1.Size = new System.Drawing.Size(1302, 373);
+            this.splitContainer1.Size = new System.Drawing.Size(1302, 371);
             this.splitContainer1.SplitterDistance = 470;
             this.splitContainer1.TabIndex = 2;
             // 
@@ -539,7 +541,7 @@ namespace MainNs
             this.CodeBox.Location = new System.Drawing.Point(0, 0);
             this.CodeBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.CodeBox.Name = "CodeBox";
-            this.CodeBox.Size = new System.Drawing.Size(470, 373);
+            this.CodeBox.Size = new System.Drawing.Size(470, 371);
             this.CodeBox.TabIndex = 0;
             this.CodeBox.Text = "";
             this.CodeBox.WordWrap = false;
@@ -557,7 +559,7 @@ namespace MainNs
             this.AnalysisTabControl.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.AnalysisTabControl.Name = "AnalysisTabControl";
             this.AnalysisTabControl.SelectedIndex = 0;
-            this.AnalysisTabControl.Size = new System.Drawing.Size(828, 373);
+            this.AnalysisTabControl.Size = new System.Drawing.Size(828, 371);
             this.AnalysisTabControl.TabIndex = 0;
             this.AnalysisTabControl.Selecting += new System.Windows.Forms.TabControlCancelEventHandler(this.AnalysisTabControl_Selecting);
             // 
@@ -572,7 +574,7 @@ namespace MainNs
             this.CompilationTabPage.Controls.Add(this.label4);
             this.CompilationTabPage.Location = new System.Drawing.Point(8, 42);
             this.CompilationTabPage.Name = "CompilationTabPage";
-            this.CompilationTabPage.Size = new System.Drawing.Size(812, 323);
+            this.CompilationTabPage.Size = new System.Drawing.Size(812, 321);
             this.CompilationTabPage.TabIndex = 3;
             this.CompilationTabPage.Text = "Compilation";
             this.CompilationTabPage.UseVisualStyleBackColor = true;
@@ -928,7 +930,7 @@ namespace MainNs
             // 
             this.TopSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.TopSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.TopSplitContainer.Location = new System.Drawing.Point(0, 40);
+            this.TopSplitContainer.Location = new System.Drawing.Point(0, 42);
             this.TopSplitContainer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.TopSplitContainer.Name = "TopSplitContainer";
             this.TopSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
@@ -942,7 +944,7 @@ namespace MainNs
             this.TopSplitContainer.Panel2.Controls.Add(this.OutputTabControl);
             this.TopSplitContainer.Panel2Collapsed = true;
             this.TopSplitContainer.Panel2MinSize = 75;
-            this.TopSplitContainer.Size = new System.Drawing.Size(1302, 373);
+            this.TopSplitContainer.Size = new System.Drawing.Size(1302, 371);
             this.TopSplitContainer.SplitterDistance = 25;
             this.TopSplitContainer.SplitterWidth = 3;
             this.TopSplitContainer.TabIndex = 3;
@@ -993,6 +995,13 @@ namespace MainNs
             this.RewriterOutputTextBox.TabIndex = 1;
             this.RewriterOutputTextBox.Text = "";
             this.RewriterOutputTextBox.WordWrap = false;
+            // 
+            // bitstreamFromClipboardToolStripMenuItem
+            // 
+            this.bitstreamFromClipboardToolStripMenuItem.Name = "bitstreamFromClipboardToolStripMenuItem";
+            this.bitstreamFromClipboardToolStripMenuItem.Size = new System.Drawing.Size(378, 38);
+            this.bitstreamFromClipboardToolStripMenuItem.Text = "Bitstream from clipboard";
+            this.bitstreamFromClipboardToolStripMenuItem.Click += new System.EventHandler(this.bitstreamFromClipboardToolStripMenuItem_Click);
             // 
             // EditorForm
             // 
@@ -1126,5 +1135,6 @@ namespace MainNs
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.TabPage CompilationTabPage;
+        private System.Windows.Forms.ToolStripMenuItem bitstreamFromClipboardToolStripMenuItem;
     }
 }

--- a/tools/clang/tools/dotnetc/EditorForm.Designer.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.Designer.cs
@@ -86,6 +86,14 @@ namespace MainNs
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.CodeBox = new System.Windows.Forms.RichTextBox();
             this.AnalysisTabControl = new System.Windows.Forms.TabControl();
+            this.CompilationTabPage = new System.Windows.Forms.TabPage();
+            this.btnCompile = new System.Windows.Forms.Button();
+            this.tbOptions = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
+            this.cbProfile = new System.Windows.Forms.ComboBox();
+            this.label5 = new System.Windows.Forms.Label();
+            this.tbEntry = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
             this.DisassemblyTabPage = new System.Windows.Forms.TabPage();
             this.DisassemblyTextBox = new System.Windows.Forms.RichTextBox();
             this.ASTTabPage = new System.Windows.Forms.TabPage();
@@ -111,16 +119,6 @@ namespace MainNs
             this.AvailablePassesBox = new System.Windows.Forms.ListBox();
             this.TheToolTip = new System.Windows.Forms.ToolTip(this.components);
             this.TopSplitContainer = new System.Windows.Forms.SplitContainer();
-            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.tbOptions = new System.Windows.Forms.TextBox();
-            this.cbProfile = new System.Windows.Forms.ComboBox();
-            this.tbEntry = new System.Windows.Forms.TextBox();
-            this.label4 = new System.Windows.Forms.Label();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label6 = new System.Windows.Forms.Label();
-            this.btnCompile = new System.Windows.Forms.Button();
-            this.label3 = new System.Windows.Forms.Label();
             this.OutputTabControl = new System.Windows.Forms.TabControl();
             this.RenderLogTabPage = new System.Windows.Forms.TabPage();
             this.RenderLogBox = new System.Windows.Forms.TextBox();
@@ -132,6 +130,7 @@ namespace MainNs
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.AnalysisTabControl.SuspendLayout();
+            this.CompilationTabPage.SuspendLayout();
             this.DisassemblyTabPage.SuspendLayout();
             this.ASTTabPage.SuspendLayout();
             this.OptimizerTabPage.SuspendLayout();
@@ -140,11 +139,6 @@ namespace MainNs
             this.TopSplitContainer.Panel1.SuspendLayout();
             this.TopSplitContainer.Panel2.SuspendLayout();
             this.TopSplitContainer.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
-            this.splitContainer2.Panel1.SuspendLayout();
-            this.splitContainer2.Panel2.SuspendLayout();
-            this.splitContainer2.SuspendLayout();
-            this.tableLayoutPanel1.SuspendLayout();
             this.OutputTabControl.SuspendLayout();
             this.RenderLogTabPage.SuspendLayout();
             this.SuspendLayout();
@@ -154,17 +148,18 @@ namespace MainNs
             this.TheStatusStrip.ImageScalingSize = new System.Drawing.Size(24, 24);
             this.TheStatusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.TheStatusStripLabel});
-            this.TheStatusStrip.Location = new System.Drawing.Point(0, 428);
+            this.TheStatusStrip.Location = new System.Drawing.Point(0, 413);
             this.TheStatusStrip.Name = "TheStatusStrip";
             this.TheStatusStrip.Padding = new System.Windows.Forms.Padding(4, 0, 16, 0);
-            this.TheStatusStrip.Size = new System.Drawing.Size(1302, 22);
+            this.TheStatusStrip.Size = new System.Drawing.Size(1302, 37);
             this.TheStatusStrip.TabIndex = 0;
             this.TheStatusStrip.Text = "statusStrip1";
             // 
             // TheStatusStripLabel
             // 
             this.TheStatusStripLabel.Name = "TheStatusStripLabel";
-            this.TheStatusStripLabel.Size = new System.Drawing.Size(0, 17);
+            this.TheStatusStripLabel.Size = new System.Drawing.Size(84, 32);
+            this.TheStatusStripLabel.Text = "Ready.";
             // 
             // TheMenuStrip
             // 
@@ -178,7 +173,7 @@ namespace MainNs
             this.helpToolStripMenuItem});
             this.TheMenuStrip.Location = new System.Drawing.Point(0, 0);
             this.TheMenuStrip.Name = "TheMenuStrip";
-            this.TheMenuStrip.Size = new System.Drawing.Size(1302, 33);
+            this.TheMenuStrip.Size = new System.Drawing.Size(1302, 40);
             this.TheMenuStrip.TabIndex = 1;
             this.TheMenuStrip.Text = "menuStrip1";
             // 
@@ -194,7 +189,7 @@ namespace MainNs
             this.toolStripMenuItem4,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(50, 29);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(64, 36);
             this.fileToolStripMenuItem.Text = "&File";
             this.fileToolStripMenuItem.DropDownOpening += new System.EventHandler(this.fileToolStripMenuItem_DropDownOpening);
             // 
@@ -202,7 +197,7 @@ namespace MainNs
             // 
             this.NewToolStripMenuItem.Name = "NewToolStripMenuItem";
             this.NewToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.NewToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.NewToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.NewToolStripMenuItem.Text = "&New";
             this.NewToolStripMenuItem.Click += new System.EventHandler(this.NewToolStripMenuItem_Click);
             // 
@@ -210,7 +205,7 @@ namespace MainNs
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.openToolStripMenuItem.Text = "&Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -218,37 +213,37 @@ namespace MainNs
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.saveToolStripMenuItem.Text = "&Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.saveAsToolStripMenuItem.Text = "Save &As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // toolStripSeparator1
             // 
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(214, 6);
+            this.toolStripSeparator1.Size = new System.Drawing.Size(271, 6);
             // 
             // recentFilesToolStripMenuItem
             // 
             this.recentFilesToolStripMenuItem.Name = "recentFilesToolStripMenuItem";
-            this.recentFilesToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.recentFilesToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.recentFilesToolStripMenuItem.Text = "Recent &Files";
             // 
             // toolStripMenuItem4
             // 
             this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(214, 6);
+            this.toolStripMenuItem4.Size = new System.Drawing.Size(271, 6);
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(217, 30);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(274, 38);
             this.exitToolStripMenuItem.Text = "E&xit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
             // 
@@ -270,27 +265,27 @@ namespace MainNs
             this.FontGrowToolStripMenuItem,
             this.FontShrinkToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(54, 29);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(67, 36);
             this.editToolStripMenuItem.Text = "&Edit";
             // 
             // undoToolStripMenuItem
             // 
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
             this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.undoToolStripMenuItem.Text = "&Undo";
             this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(293, 6);
             // 
             // cutToolStripMenuItem
             // 
             this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
             this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.cutToolStripMenuItem.Text = "Cu&t";
             this.cutToolStripMenuItem.Click += new System.EventHandler(this.cutToolStripMenuItem_Click);
             // 
@@ -298,7 +293,7 @@ namespace MainNs
             // 
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
             this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.copyToolStripMenuItem.Text = "&Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
@@ -306,48 +301,48 @@ namespace MainNs
             // 
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
             this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.pasteToolStripMenuItem.Text = "&Paste";
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
             // 
             // deleteToolStripMenuItem
             // 
             this.deleteToolStripMenuItem.Name = "deleteToolStripMenuItem";
-            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.deleteToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.deleteToolStripMenuItem.Text = "&Delete";
             this.deleteToolStripMenuItem.Click += new System.EventHandler(this.deleteToolStripMenuItem_Click);
             // 
             // toolStripMenuItem2
             // 
             this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem2.Size = new System.Drawing.Size(293, 6);
             // 
             // selectAllToolStripMenuItem
             // 
             this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
             this.selectAllToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.A)));
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.selectAllToolStripMenuItem.Text = "Select &All";
             this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
             // 
             // toolStripMenuItem3
             // 
             this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(227, 6);
+            this.toolStripMenuItem3.Size = new System.Drawing.Size(293, 6);
             // 
             // findAndReplaceToolStripMenuItem
             // 
             this.findAndReplaceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.quickFindToolStripMenuItem});
             this.findAndReplaceToolStripMenuItem.Name = "findAndReplaceToolStripMenuItem";
-            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.findAndReplaceToolStripMenuItem.Text = "&Find and Replace";
             // 
             // quickFindToolStripMenuItem
             // 
             this.quickFindToolStripMenuItem.Name = "quickFindToolStripMenuItem";
             this.quickFindToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.quickFindToolStripMenuItem.Size = new System.Drawing.Size(240, 30);
+            this.quickFindToolStripMenuItem.Size = new System.Drawing.Size(308, 38);
             this.quickFindToolStripMenuItem.Text = "Quick &Find";
             this.quickFindToolStripMenuItem.Click += new System.EventHandler(this.quickFindToolStripMenuItem_Click);
             // 
@@ -355,14 +350,14 @@ namespace MainNs
             // 
             this.goToToolStripMenuItem.Name = "goToToolStripMenuItem";
             this.goToToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.G)));
-            this.goToToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.goToToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.goToToolStripMenuItem.Text = "&Go To...";
             this.goToToolStripMenuItem.Click += new System.EventHandler(this.goToToolStripMenuItem_Click);
             // 
             // fileVariablesToolStripMenuItem
             // 
             this.fileVariablesToolStripMenuItem.Name = "fileVariablesToolStripMenuItem";
-            this.fileVariablesToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.fileVariablesToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.fileVariablesToolStripMenuItem.Text = "File &Variables...";
             this.fileVariablesToolStripMenuItem.Click += new System.EventHandler(this.fileVariablesToolStripMenuItem_Click);
             // 
@@ -372,7 +367,7 @@ namespace MainNs
             this.FontGrowToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.OemPeriod)));
             this.FontGrowToolStripMenuItem.ShowShortcutKeys = false;
-            this.FontGrowToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.FontGrowToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.FontGrowToolStripMenuItem.Text = "Font G&row";
             this.FontGrowToolStripMenuItem.Click += new System.EventHandler(this.FontGrowToolStripMenuItem_Click);
             // 
@@ -382,7 +377,7 @@ namespace MainNs
             this.FontShrinkToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
             | System.Windows.Forms.Keys.Oemcomma)));
             this.FontShrinkToolStripMenuItem.ShowShortcutKeys = false;
-            this.FontShrinkToolStripMenuItem.Size = new System.Drawing.Size(230, 30);
+            this.FontShrinkToolStripMenuItem.Size = new System.Drawing.Size(296, 38);
             this.FontShrinkToolStripMenuItem.Text = "Font Shrin&k";
             this.FontShrinkToolStripMenuItem.Click += new System.EventHandler(this.FontShrinkToolStripMenuItem_Click);
             // 
@@ -397,55 +392,55 @@ namespace MainNs
             this.renderToolStripMenuItem,
             this.outputToolStripMenuItem});
             this.viewToolStripMenuItem.Name = "viewToolStripMenuItem";
-            this.viewToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
+            this.viewToolStripMenuItem.Size = new System.Drawing.Size(78, 36);
             this.viewToolStripMenuItem.Text = "&View";
             // 
             // autoUpdateToolStripMenuItem
             // 
             this.autoUpdateToolStripMenuItem.Name = "autoUpdateToolStripMenuItem";
-            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.autoUpdateToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.autoUpdateToolStripMenuItem.Text = "&Auto-Update";
             this.autoUpdateToolStripMenuItem.Click += new System.EventHandler(this.autoUpdateToolStripMenuItem_Click);
             // 
             // bitstreamToolStripMenuItem
             // 
             this.bitstreamToolStripMenuItem.Name = "bitstreamToolStripMenuItem";
-            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.bitstreamToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.bitstreamToolStripMenuItem.Text = "&Bitstream";
             this.bitstreamToolStripMenuItem.Click += new System.EventHandler(this.bitstreamToolStripMenuItem_Click);
             // 
             // ColorMenuItem
             // 
             this.ColorMenuItem.Name = "ColorMenuItem";
-            this.ColorMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.ColorMenuItem.Size = new System.Drawing.Size(318, 38);
             this.ColorMenuItem.Text = "&Color";
             this.ColorMenuItem.Click += new System.EventHandler(this.colorToolStripMenuItem_Click);
             // 
             // debugInformationToolStripMenuItem
             // 
             this.debugInformationToolStripMenuItem.Name = "debugInformationToolStripMenuItem";
-            this.debugInformationToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.debugInformationToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.debugInformationToolStripMenuItem.Text = "&Debug Information";
             this.debugInformationToolStripMenuItem.Click += new System.EventHandler(this.debugInformationToolStripMenuItem_Click);
             // 
             // errorListToolStripMenuItem
             // 
             this.errorListToolStripMenuItem.Name = "errorListToolStripMenuItem";
-            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.errorListToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.errorListToolStripMenuItem.Text = "Error L&ist";
             this.errorListToolStripMenuItem.Click += new System.EventHandler(this.errorListToolStripMenuItem_Click);
             // 
             // renderToolStripMenuItem
             // 
             this.renderToolStripMenuItem.Name = "renderToolStripMenuItem";
-            this.renderToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.renderToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.renderToolStripMenuItem.Text = "&Render";
             this.renderToolStripMenuItem.Click += new System.EventHandler(this.renderToolStripMenuItem_Click);
             // 
             // outputToolStripMenuItem
             // 
             this.outputToolStripMenuItem.Name = "outputToolStripMenuItem";
-            this.outputToolStripMenuItem.Size = new System.Drawing.Size(249, 30);
+            this.outputToolStripMenuItem.Size = new System.Drawing.Size(318, 38);
             this.outputToolStripMenuItem.Text = "&Output";
             this.outputToolStripMenuItem.Click += new System.EventHandler(this.outputToolStripMenuItem_Click);
             // 
@@ -455,21 +450,21 @@ namespace MainNs
             this.compileToolStripMenuItem,
             this.exportCompiledObjectToolStripMenuItem});
             this.buildToolStripMenuItem.Name = "buildToolStripMenuItem";
-            this.buildToolStripMenuItem.Size = new System.Drawing.Size(63, 29);
+            this.buildToolStripMenuItem.Size = new System.Drawing.Size(81, 36);
             this.buildToolStripMenuItem.Text = "&Build";
             // 
             // compileToolStripMenuItem
             // 
             this.compileToolStripMenuItem.Name = "compileToolStripMenuItem";
             this.compileToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7)));
-            this.compileToolStripMenuItem.Size = new System.Drawing.Size(286, 30);
+            this.compileToolStripMenuItem.Size = new System.Drawing.Size(368, 38);
             this.compileToolStripMenuItem.Text = "Co&mpile";
             this.compileToolStripMenuItem.Click += new System.EventHandler(this.compileToolStripMenuItem_Click);
             // 
             // exportCompiledObjectToolStripMenuItem
             // 
             this.exportCompiledObjectToolStripMenuItem.Name = "exportCompiledObjectToolStripMenuItem";
-            this.exportCompiledObjectToolStripMenuItem.Size = new System.Drawing.Size(286, 30);
+            this.exportCompiledObjectToolStripMenuItem.Size = new System.Drawing.Size(368, 38);
             this.exportCompiledObjectToolStripMenuItem.Text = "&Export Compiled Object";
             this.exportCompiledObjectToolStripMenuItem.Click += new System.EventHandler(this.exportCompiledObjectToolStripMenuItem_Click);
             // 
@@ -480,27 +475,27 @@ namespace MainNs
             this.rewriterToolStripMenuItem,
             this.rewriteNobodyToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(65, 29);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(82, 36);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // optionsToolStripMenuItem
             // 
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.optionsToolStripMenuItem.Text = "&Options...";
             this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsToolStripMenuItem_Click);
             // 
             // rewriterToolStripMenuItem
             // 
             this.rewriterToolStripMenuItem.Name = "rewriterToolStripMenuItem";
-            this.rewriterToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.rewriterToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.rewriterToolStripMenuItem.Text = "Rewriter";
             this.rewriterToolStripMenuItem.Click += new System.EventHandler(this.rewriterToolStripMenuItem_Click);
             // 
             // rewriteNobodyToolStripMenuItem
             // 
             this.rewriteNobodyToolStripMenuItem.Name = "rewriteNobodyToolStripMenuItem";
-            this.rewriteNobodyToolStripMenuItem.Size = new System.Drawing.Size(219, 30);
+            this.rewriteNobodyToolStripMenuItem.Size = new System.Drawing.Size(278, 38);
             this.rewriteNobodyToolStripMenuItem.Text = "RewriteNobody";
             this.rewriteNobodyToolStripMenuItem.Click += new System.EventHandler(this.rewriteNobodyToolStripMenuItem_Click);
             // 
@@ -509,13 +504,13 @@ namespace MainNs
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(61, 29);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(77, 36);
             this.helpToolStripMenuItem.Text = "&Help";
             // 
             // aboutToolStripMenuItem
             // 
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(158, 30);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(194, 38);
             this.aboutToolStripMenuItem.Text = "&About...";
             this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
             // 
@@ -533,7 +528,7 @@ namespace MainNs
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.AnalysisTabControl);
-            this.splitContainer1.Size = new System.Drawing.Size(1302, 306);
+            this.splitContainer1.Size = new System.Drawing.Size(1302, 373);
             this.splitContainer1.SplitterDistance = 470;
             this.splitContainer1.TabIndex = 2;
             // 
@@ -544,7 +539,7 @@ namespace MainNs
             this.CodeBox.Location = new System.Drawing.Point(0, 0);
             this.CodeBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.CodeBox.Name = "CodeBox";
-            this.CodeBox.Size = new System.Drawing.Size(470, 306);
+            this.CodeBox.Size = new System.Drawing.Size(470, 373);
             this.CodeBox.TabIndex = 0;
             this.CodeBox.Text = "";
             this.CodeBox.WordWrap = false;
@@ -553,6 +548,7 @@ namespace MainNs
             // 
             // AnalysisTabControl
             // 
+            this.AnalysisTabControl.Controls.Add(this.CompilationTabPage);
             this.AnalysisTabControl.Controls.Add(this.DisassemblyTabPage);
             this.AnalysisTabControl.Controls.Add(this.ASTTabPage);
             this.AnalysisTabControl.Controls.Add(this.OptimizerTabPage);
@@ -561,345 +557,55 @@ namespace MainNs
             this.AnalysisTabControl.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.AnalysisTabControl.Name = "AnalysisTabControl";
             this.AnalysisTabControl.SelectedIndex = 0;
-            this.AnalysisTabControl.Size = new System.Drawing.Size(828, 306);
+            this.AnalysisTabControl.Size = new System.Drawing.Size(828, 373);
             this.AnalysisTabControl.TabIndex = 0;
             this.AnalysisTabControl.Selecting += new System.Windows.Forms.TabControlCancelEventHandler(this.AnalysisTabControl_Selecting);
             // 
-            // DisassemblyTabPage
+            // CompilationTabPage
             // 
-            this.DisassemblyTabPage.Controls.Add(this.DisassemblyTextBox);
-            this.DisassemblyTabPage.Location = new System.Drawing.Point(4, 31);
-            this.DisassemblyTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.DisassemblyTabPage.Name = "DisassemblyTabPage";
-            this.DisassemblyTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.DisassemblyTabPage.Size = new System.Drawing.Size(820, 271);
-            this.DisassemblyTabPage.TabIndex = 0;
-            this.DisassemblyTabPage.Text = "Disassembly";
-            this.DisassemblyTabPage.UseVisualStyleBackColor = true;
+            this.CompilationTabPage.Controls.Add(this.btnCompile);
+            this.CompilationTabPage.Controls.Add(this.tbOptions);
+            this.CompilationTabPage.Controls.Add(this.label6);
+            this.CompilationTabPage.Controls.Add(this.cbProfile);
+            this.CompilationTabPage.Controls.Add(this.label5);
+            this.CompilationTabPage.Controls.Add(this.tbEntry);
+            this.CompilationTabPage.Controls.Add(this.label4);
+            this.CompilationTabPage.Location = new System.Drawing.Point(8, 42);
+            this.CompilationTabPage.Name = "CompilationTabPage";
+            this.CompilationTabPage.Size = new System.Drawing.Size(812, 323);
+            this.CompilationTabPage.TabIndex = 3;
+            this.CompilationTabPage.Text = "Compilation";
+            this.CompilationTabPage.UseVisualStyleBackColor = true;
             // 
-            // DisassemblyTextBox
+            // btnCompile
             // 
-            this.DisassemblyTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.DisassemblyTextBox.Location = new System.Drawing.Point(4, 3);
-            this.DisassemblyTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.DisassemblyTextBox.Name = "DisassemblyTextBox";
-            this.DisassemblyTextBox.ReadOnly = true;
-            this.DisassemblyTextBox.Size = new System.Drawing.Size(812, 265);
-            this.DisassemblyTextBox.TabIndex = 0;
-            this.DisassemblyTextBox.Text = "";
-            this.DisassemblyTextBox.WordWrap = false;
-            this.DisassemblyTextBox.SelectionChanged += new System.EventHandler(this.DisassemblyTextBox_SelectionChanged);
-            // 
-            // ASTTabPage
-            // 
-            this.ASTTabPage.Controls.Add(this.ASTDumpBox);
-            this.ASTTabPage.Location = new System.Drawing.Point(4, 29);
-            this.ASTTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ASTTabPage.Name = "ASTTabPage";
-            this.ASTTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ASTTabPage.Size = new System.Drawing.Size(820, 273);
-            this.ASTTabPage.TabIndex = 1;
-            this.ASTTabPage.Text = "AST";
-            this.ASTTabPage.UseVisualStyleBackColor = true;
-            // 
-            // ASTDumpBox
-            // 
-            this.ASTDumpBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ASTDumpBox.Location = new System.Drawing.Point(4, 3);
-            this.ASTDumpBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ASTDumpBox.Name = "ASTDumpBox";
-            this.ASTDumpBox.ReadOnly = true;
-            this.ASTDumpBox.Size = new System.Drawing.Size(812, 267);
-            this.ASTDumpBox.TabIndex = 0;
-            this.ASTDumpBox.Text = "";
-            // 
-            // OptimizerTabPage
-            // 
-            this.OptimizerTabPage.Controls.Add(this.InteractiveEditorButton);
-            this.OptimizerTabPage.Controls.Add(this.ResetDefaultPassesButton);
-            this.OptimizerTabPage.Controls.Add(this.AnalyzeCheckBox);
-            this.OptimizerTabPage.Controls.Add(this.AddPrintModuleButton);
-            this.OptimizerTabPage.Controls.Add(this.RunPassesButton);
-            this.OptimizerTabPage.Controls.Add(this.SelectPassDownButton);
-            this.OptimizerTabPage.Controls.Add(this.SelectPassUpButton);
-            this.OptimizerTabPage.Controls.Add(this.SelectedPassesBox);
-            this.OptimizerTabPage.Controls.Add(this.label2);
-            this.OptimizerTabPage.Controls.Add(this.label1);
-            this.OptimizerTabPage.Controls.Add(this.AvailablePassesBox);
-            this.OptimizerTabPage.Location = new System.Drawing.Point(4, 29);
-            this.OptimizerTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.OptimizerTabPage.Name = "OptimizerTabPage";
-            this.OptimizerTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.OptimizerTabPage.Size = new System.Drawing.Size(820, 273);
-            this.OptimizerTabPage.TabIndex = 2;
-            this.OptimizerTabPage.Text = "Optimizer";
-            this.OptimizerTabPage.UseVisualStyleBackColor = true;
-            // 
-            // InteractiveEditorButton
-            // 
-            this.InteractiveEditorButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.InteractiveEditorButton.Location = new System.Drawing.Point(473, 193);
-            this.InteractiveEditorButton.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
-            this.InteractiveEditorButton.Name = "InteractiveEditorButton";
-            this.InteractiveEditorButton.Size = new System.Drawing.Size(244, 38);
-            this.InteractiveEditorButton.TabIndex = 11;
-            this.InteractiveEditorButton.Text = "Interactive Editor...";
-            this.InteractiveEditorButton.UseVisualStyleBackColor = true;
-            this.InteractiveEditorButton.Click += new System.EventHandler(this.InteractiveEditorButton_Click);
-            // 
-            // ResetDefaultPassesButton
-            // 
-            this.ResetDefaultPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.ResetDefaultPassesButton.Location = new System.Drawing.Point(473, 101);
-            this.ResetDefaultPassesButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ResetDefaultPassesButton.Name = "ResetDefaultPassesButton";
-            this.ResetDefaultPassesButton.Size = new System.Drawing.Size(244, 42);
-            this.ResetDefaultPassesButton.TabIndex = 9;
-            this.ResetDefaultPassesButton.Text = "Reset Default Passes";
-            this.ResetDefaultPassesButton.UseVisualStyleBackColor = true;
-            this.ResetDefaultPassesButton.Click += new System.EventHandler(this.ResetDefaultPassesButton_Click);
-            // 
-            // AnalyzeCheckBox
-            // 
-            this.AnalyzeCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.AnalyzeCheckBox.AutoSize = true;
-            this.AnalyzeCheckBox.Location = new System.Drawing.Point(10, 51);
-            this.AnalyzeCheckBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
-            this.AnalyzeCheckBox.Name = "AnalyzeCheckBox";
-            this.AnalyzeCheckBox.Size = new System.Drawing.Size(176, 26);
-            this.AnalyzeCheckBox.TabIndex = 8;
-            this.AnalyzeCheckBox.Text = "Analyze passes";
-            this.AnalyzeCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // AddPrintModuleButton
-            // 
-            this.AddPrintModuleButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.AddPrintModuleButton.Location = new System.Drawing.Point(6, 85);
-            this.AddPrintModuleButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.AddPrintModuleButton.Name = "AddPrintModuleButton";
-            this.AddPrintModuleButton.Size = new System.Drawing.Size(244, 42);
-            this.AddPrintModuleButton.TabIndex = 7;
-            this.AddPrintModuleButton.Text = "Add Print Module";
-            this.AddPrintModuleButton.UseVisualStyleBackColor = true;
-            this.AddPrintModuleButton.Click += new System.EventHandler(this.AddPrintModuleButton_Click);
-            // 
-            // RunPassesButton
-            // 
-            this.RunPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.RunPassesButton.Location = new System.Drawing.Point(473, 145);
-            this.RunPassesButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.RunPassesButton.Name = "RunPassesButton";
-            this.RunPassesButton.Size = new System.Drawing.Size(244, 42);
-            this.RunPassesButton.TabIndex = 6;
-            this.RunPassesButton.Text = "Run Passes";
-            this.RunPassesButton.UseVisualStyleBackColor = true;
-            this.RunPassesButton.Click += new System.EventHandler(this.RunPassesButton_Click);
-            // 
-            // SelectPassDownButton
-            // 
-            this.SelectPassDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectPassDownButton.Location = new System.Drawing.Point(595, 48);
-            this.SelectPassDownButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.SelectPassDownButton.Name = "SelectPassDownButton";
-            this.SelectPassDownButton.Size = new System.Drawing.Size(124, 42);
-            this.SelectPassDownButton.TabIndex = 5;
-            this.SelectPassDownButton.Text = "Swap Down";
-            this.SelectPassDownButton.UseVisualStyleBackColor = true;
-            this.SelectPassDownButton.Click += new System.EventHandler(this.SelectPassDownButton_Click);
-            // 
-            // SelectPassUpButton
-            // 
-            this.SelectPassUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectPassUpButton.Location = new System.Drawing.Point(473, 48);
-            this.SelectPassUpButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.SelectPassUpButton.Name = "SelectPassUpButton";
-            this.SelectPassUpButton.Size = new System.Drawing.Size(116, 42);
-            this.SelectPassUpButton.TabIndex = 4;
-            this.SelectPassUpButton.Text = "Swap Up";
-            this.SelectPassUpButton.UseVisualStyleBackColor = true;
-            this.SelectPassUpButton.Click += new System.EventHandler(this.SelectPassUpButton_Click);
-            // 
-            // SelectedPassesBox
-            // 
-            this.SelectedPassesBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.SelectedPassesBox.ContextMenuStrip = this.PassesContextMenu;
-            this.SelectedPassesBox.FormattingEnabled = true;
-            this.SelectedPassesBox.ItemHeight = 22;
-            this.SelectedPassesBox.Location = new System.Drawing.Point(473, 51);
-            this.SelectedPassesBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.SelectedPassesBox.Name = "SelectedPassesBox";
-            this.SelectedPassesBox.Size = new System.Drawing.Size(340, 4);
-            this.SelectedPassesBox.TabIndex = 3;
-            this.SelectedPassesBox.DoubleClick += new System.EventHandler(this.SelectedPassesBox_DoubleClick);
-            this.SelectedPassesBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.SelectedPassesBox_KeyUp);
-            // 
-            // PassesContextMenu
-            // 
-            this.PassesContextMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
-            this.PassesContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.PassPropertiesMenuItem,
-            this.toolStripMenuItem5,
-            this.copyToolStripMenuItem1,
-            this.copyAllToolStripMenuItem,
-            this.PastePassesMenuItem,
-            this.DeleteAllPassesMenuItem});
-            this.PassesContextMenu.Name = "PassesContextMenu";
-            this.PassesContextMenu.Size = new System.Drawing.Size(177, 160);
-            // 
-            // PassPropertiesMenuItem
-            // 
-            this.PassPropertiesMenuItem.Name = "PassPropertiesMenuItem";
-            this.PassPropertiesMenuItem.Size = new System.Drawing.Size(176, 30);
-            this.PassPropertiesMenuItem.Text = "P&roperties...";
-            this.PassPropertiesMenuItem.Click += new System.EventHandler(this.PassPropertiesMenuItem_Click);
-            // 
-            // toolStripMenuItem5
-            // 
-            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(173, 6);
-            // 
-            // copyToolStripMenuItem1
-            // 
-            this.copyToolStripMenuItem1.Name = "copyToolStripMenuItem1";
-            this.copyToolStripMenuItem1.Size = new System.Drawing.Size(176, 30);
-            this.copyToolStripMenuItem1.Text = "&Copy";
-            this.copyToolStripMenuItem1.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
-            // 
-            // copyAllToolStripMenuItem
-            // 
-            this.copyAllToolStripMenuItem.Name = "copyAllToolStripMenuItem";
-            this.copyAllToolStripMenuItem.Size = new System.Drawing.Size(176, 30);
-            this.copyAllToolStripMenuItem.Text = "Copy &All";
-            this.copyAllToolStripMenuItem.Click += new System.EventHandler(this.copyAllToolStripMenuItem_Click);
-            // 
-            // PastePassesMenuItem
-            // 
-            this.PastePassesMenuItem.Name = "PastePassesMenuItem";
-            this.PastePassesMenuItem.Size = new System.Drawing.Size(176, 30);
-            this.PastePassesMenuItem.Text = "&Paste";
-            this.PastePassesMenuItem.Click += new System.EventHandler(this.PastePassesMenuItem_Click);
-            // 
-            // DeleteAllPassesMenuItem
-            // 
-            this.DeleteAllPassesMenuItem.Name = "DeleteAllPassesMenuItem";
-            this.DeleteAllPassesMenuItem.Size = new System.Drawing.Size(176, 30);
-            this.DeleteAllPassesMenuItem.Text = "Delete All";
-            this.DeleteAllPassesMenuItem.Click += new System.EventHandler(this.DeleteAllPassesMenuItem_Click);
-            // 
-            // label2
-            // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(467, 12);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(100, 22);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "&Pipeline:";
-            // 
-            // label1
-            // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 12);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(400, 22);
-            this.label1.TabIndex = 1;
-            this.label1.Text = "&Available Passes (double-click to add):";
-            // 
-            // AvailablePassesBox
-            // 
-            this.AvailablePassesBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.AvailablePassesBox.FormattingEnabled = true;
-            this.AvailablePassesBox.ItemHeight = 22;
-            this.AvailablePassesBox.Location = new System.Drawing.Point(10, 51);
-            this.AvailablePassesBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.AvailablePassesBox.Name = "AvailablePassesBox";
-            this.AvailablePassesBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.AvailablePassesBox.Size = new System.Drawing.Size(451, 4);
-            this.AvailablePassesBox.TabIndex = 0;
-            this.AvailablePassesBox.DoubleClick += new System.EventHandler(this.AvailablePassesBox_DoubleClick);
-            // 
-            // TopSplitContainer
-            // 
-            this.TopSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.TopSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.TopSplitContainer.Location = new System.Drawing.Point(0, 33);
-            this.TopSplitContainer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.TopSplitContainer.Name = "TopSplitContainer";
-            this.TopSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // TopSplitContainer.Panel1
-            // 
-            this.TopSplitContainer.Panel1.Controls.Add(this.splitContainer2);
-            // 
-            // TopSplitContainer.Panel2
-            // 
-            this.TopSplitContainer.Panel2.Controls.Add(this.OutputTabControl);
-            this.TopSplitContainer.Panel2Collapsed = true;
-            this.TopSplitContainer.Size = new System.Drawing.Size(1302, 395);
-            this.TopSplitContainer.SplitterDistance = 370;
-            this.TopSplitContainer.SplitterWidth = 3;
-            this.TopSplitContainer.TabIndex = 3;
-            // 
-            // splitContainer2
-            // 
-            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.splitContainer2.Name = "splitContainer2";
-            this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer2.Panel1
-            // 
-            this.splitContainer2.Panel1.Controls.Add(this.splitContainer1);
-            // 
-            // splitContainer2.Panel2
-            // 
-            this.splitContainer2.Panel2.Controls.Add(this.tableLayoutPanel1);
-            this.splitContainer2.Panel2.Controls.Add(this.label3);
-            this.splitContainer2.Panel2MinSize = 50;
-            this.splitContainer2.Size = new System.Drawing.Size(1302, 395);
-            this.splitContainer2.SplitterDistance = 306;
-            this.splitContainer2.SplitterWidth = 5;
-            this.splitContainer2.TabIndex = 3;
-            // 
-            // tableLayoutPanel1
-            // 
-            this.tableLayoutPanel1.AutoSize = true;
-            this.tableLayoutPanel1.ColumnCount = 4;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 622F));
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 208F));
-            this.tableLayoutPanel1.Controls.Add(this.tbOptions, 2, 1);
-            this.tableLayoutPanel1.Controls.Add(this.cbProfile, 1, 1);
-            this.tableLayoutPanel1.Controls.Add(this.tbEntry, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.label4, 0, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label5, 1, 0);
-            this.tableLayoutPanel1.Controls.Add(this.label6, 2, 0);
-            this.tableLayoutPanel1.Controls.Add(this.btnCompile, 3, 0);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(1302, 84);
-            this.tableLayoutPanel1.TabIndex = 3;
+            this.btnCompile.AutoSize = true;
+            this.btnCompile.Location = new System.Drawing.Point(293, 28);
+            this.btnCompile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.btnCompile.Name = "btnCompile";
+            this.btnCompile.Size = new System.Drawing.Size(243, 77);
+            this.btnCompile.TabIndex = 2;
+            this.btnCompile.Text = "Compile (Ctrl+F7)";
+            this.btnCompile.UseVisualStyleBackColor = true;
+            this.btnCompile.Click += new System.EventHandler(this.compileToolStripMenuItem_Click);
             // 
             // tbOptions
             // 
-            this.tbOptions.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tbOptions.Location = new System.Drawing.Point(476, 28);
+            this.tbOptions.Location = new System.Drawing.Point(9, 168);
             this.tbOptions.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tbOptions.Name = "tbOptions";
-            this.tbOptions.Size = new System.Drawing.Size(614, 29);
+            this.tbOptions.Size = new System.Drawing.Size(614, 36);
             this.tbOptions.TabIndex = 3;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(4, 137);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(116, 28);
+            this.label6.TabIndex = 7;
+            this.label6.Text = "Options:";
             // 
             // cbProfile
             // 
@@ -925,19 +631,28 @@ namespace MainNs
             "ds_6_2",
             "lib_6_1",
             "lib_6_2"});
-            this.cbProfile.Location = new System.Drawing.Point(240, 28);
+            this.cbProfile.Location = new System.Drawing.Point(9, 98);
             this.cbProfile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.cbProfile.Name = "cbProfile";
-            this.cbProfile.Size = new System.Drawing.Size(217, 30);
+            this.cbProfile.Size = new System.Drawing.Size(217, 36);
             this.cbProfile.TabIndex = 0;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(4, 67);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(181, 28);
+            this.label5.TabIndex = 6;
+            this.label5.Text = "Shader Model:";
             // 
             // tbEntry
             // 
-            this.tbEntry.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tbEntry.Location = new System.Drawing.Point(4, 28);
+            this.tbEntry.Location = new System.Drawing.Point(9, 28);
             this.tbEntry.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tbEntry.Name = "tbEntry";
-            this.tbEntry.Size = new System.Drawing.Size(228, 29);
+            this.tbEntry.Size = new System.Drawing.Size(228, 36);
             this.tbEntry.TabIndex = 4;
             this.tbEntry.Text = "main";
             // 
@@ -947,53 +662,290 @@ namespace MainNs
             this.label4.Location = new System.Drawing.Point(4, 0);
             this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(70, 22);
+            this.label4.Size = new System.Drawing.Size(90, 28);
             this.label4.TabIndex = 5;
             this.label4.Text = "Entry:";
             // 
-            // label5
+            // DisassemblyTabPage
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(240, 0);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(130, 22);
-            this.label5.TabIndex = 6;
-            this.label5.Text = "ShaderModel:";
+            this.DisassemblyTabPage.Controls.Add(this.DisassemblyTextBox);
+            this.DisassemblyTabPage.Location = new System.Drawing.Point(8, 39);
+            this.DisassemblyTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.DisassemblyTabPage.Name = "DisassemblyTabPage";
+            this.DisassemblyTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.DisassemblyTabPage.Size = new System.Drawing.Size(812, 326);
+            this.DisassemblyTabPage.TabIndex = 0;
+            this.DisassemblyTabPage.Text = "Disassembly";
+            this.DisassemblyTabPage.UseVisualStyleBackColor = true;
             // 
-            // label6
+            // DisassemblyTextBox
             // 
-            this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(476, 0);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(90, 22);
-            this.label6.TabIndex = 7;
-            this.label6.Text = "Options:";
+            this.DisassemblyTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.DisassemblyTextBox.Location = new System.Drawing.Point(4, 3);
+            this.DisassemblyTextBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.DisassemblyTextBox.Name = "DisassemblyTextBox";
+            this.DisassemblyTextBox.ReadOnly = true;
+            this.DisassemblyTextBox.Size = new System.Drawing.Size(804, 320);
+            this.DisassemblyTextBox.TabIndex = 0;
+            this.DisassemblyTextBox.Text = "";
+            this.DisassemblyTextBox.WordWrap = false;
+            this.DisassemblyTextBox.SelectionChanged += new System.EventHandler(this.DisassemblyTextBox_SelectionChanged);
             // 
-            // btnCompile
+            // ASTTabPage
             // 
-            this.btnCompile.AutoSize = true;
-            this.btnCompile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.btnCompile.Location = new System.Drawing.Point(1098, 3);
-            this.btnCompile.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.btnCompile.Name = "btnCompile";
-            this.tableLayoutPanel1.SetRowSpan(this.btnCompile, 2);
-            this.btnCompile.Size = new System.Drawing.Size(200, 78);
-            this.btnCompile.TabIndex = 2;
-            this.btnCompile.Text = "Compile";
-            this.btnCompile.UseVisualStyleBackColor = true;
-            this.btnCompile.Click += new System.EventHandler(this.compileToolStripMenuItem_Click);
+            this.ASTTabPage.Controls.Add(this.ASTDumpBox);
+            this.ASTTabPage.Location = new System.Drawing.Point(8, 39);
+            this.ASTTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.ASTTabPage.Name = "ASTTabPage";
+            this.ASTTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.ASTTabPage.Size = new System.Drawing.Size(812, 326);
+            this.ASTTabPage.TabIndex = 1;
+            this.ASTTabPage.Text = "AST";
+            this.ASTTabPage.UseVisualStyleBackColor = true;
             // 
-            // label3
+            // ASTDumpBox
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(82, 23);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(120, 22);
-            this.label3.TabIndex = 1;
-            this.label3.Text = "ShaderModel";
+            this.ASTDumpBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ASTDumpBox.Location = new System.Drawing.Point(4, 3);
+            this.ASTDumpBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.ASTDumpBox.Name = "ASTDumpBox";
+            this.ASTDumpBox.ReadOnly = true;
+            this.ASTDumpBox.Size = new System.Drawing.Size(804, 320);
+            this.ASTDumpBox.TabIndex = 0;
+            this.ASTDumpBox.Text = "";
+            // 
+            // OptimizerTabPage
+            // 
+            this.OptimizerTabPage.Controls.Add(this.InteractiveEditorButton);
+            this.OptimizerTabPage.Controls.Add(this.ResetDefaultPassesButton);
+            this.OptimizerTabPage.Controls.Add(this.AnalyzeCheckBox);
+            this.OptimizerTabPage.Controls.Add(this.AddPrintModuleButton);
+            this.OptimizerTabPage.Controls.Add(this.RunPassesButton);
+            this.OptimizerTabPage.Controls.Add(this.SelectPassDownButton);
+            this.OptimizerTabPage.Controls.Add(this.SelectPassUpButton);
+            this.OptimizerTabPage.Controls.Add(this.SelectedPassesBox);
+            this.OptimizerTabPage.Controls.Add(this.label2);
+            this.OptimizerTabPage.Controls.Add(this.label1);
+            this.OptimizerTabPage.Controls.Add(this.AvailablePassesBox);
+            this.OptimizerTabPage.Location = new System.Drawing.Point(8, 39);
+            this.OptimizerTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.OptimizerTabPage.Name = "OptimizerTabPage";
+            this.OptimizerTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.OptimizerTabPage.Size = new System.Drawing.Size(812, 326);
+            this.OptimizerTabPage.TabIndex = 2;
+            this.OptimizerTabPage.Text = "Optimizer";
+            this.OptimizerTabPage.UseVisualStyleBackColor = true;
+            // 
+            // InteractiveEditorButton
+            // 
+            this.InteractiveEditorButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.InteractiveEditorButton.Location = new System.Drawing.Point(465, 246);
+            this.InteractiveEditorButton.Margin = new System.Windows.Forms.Padding(5, 6, 5, 6);
+            this.InteractiveEditorButton.Name = "InteractiveEditorButton";
+            this.InteractiveEditorButton.Size = new System.Drawing.Size(244, 38);
+            this.InteractiveEditorButton.TabIndex = 11;
+            this.InteractiveEditorButton.Text = "Interactive Editor...";
+            this.InteractiveEditorButton.UseVisualStyleBackColor = true;
+            this.InteractiveEditorButton.Click += new System.EventHandler(this.InteractiveEditorButton_Click);
+            // 
+            // ResetDefaultPassesButton
+            // 
+            this.ResetDefaultPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.ResetDefaultPassesButton.Location = new System.Drawing.Point(465, 154);
+            this.ResetDefaultPassesButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.ResetDefaultPassesButton.Name = "ResetDefaultPassesButton";
+            this.ResetDefaultPassesButton.Size = new System.Drawing.Size(244, 42);
+            this.ResetDefaultPassesButton.TabIndex = 9;
+            this.ResetDefaultPassesButton.Text = "Reset Default Passes";
+            this.ResetDefaultPassesButton.UseVisualStyleBackColor = true;
+            this.ResetDefaultPassesButton.Click += new System.EventHandler(this.ResetDefaultPassesButton_Click);
+            // 
+            // AnalyzeCheckBox
+            // 
+            this.AnalyzeCheckBox.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.AnalyzeCheckBox.AutoSize = true;
+            this.AnalyzeCheckBox.Location = new System.Drawing.Point(10, 98);
+            this.AnalyzeCheckBox.Margin = new System.Windows.Forms.Padding(4, 6, 4, 6);
+            this.AnalyzeCheckBox.Name = "AnalyzeCheckBox";
+            this.AnalyzeCheckBox.Size = new System.Drawing.Size(226, 32);
+            this.AnalyzeCheckBox.TabIndex = 8;
+            this.AnalyzeCheckBox.Text = "Analyze passes";
+            this.AnalyzeCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // AddPrintModuleButton
+            // 
+            this.AddPrintModuleButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.AddPrintModuleButton.Location = new System.Drawing.Point(6, 138);
+            this.AddPrintModuleButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.AddPrintModuleButton.Name = "AddPrintModuleButton";
+            this.AddPrintModuleButton.Size = new System.Drawing.Size(244, 42);
+            this.AddPrintModuleButton.TabIndex = 7;
+            this.AddPrintModuleButton.Text = "Add Print Module";
+            this.AddPrintModuleButton.UseVisualStyleBackColor = true;
+            this.AddPrintModuleButton.Click += new System.EventHandler(this.AddPrintModuleButton_Click);
+            // 
+            // RunPassesButton
+            // 
+            this.RunPassesButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.RunPassesButton.Location = new System.Drawing.Point(465, 198);
+            this.RunPassesButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.RunPassesButton.Name = "RunPassesButton";
+            this.RunPassesButton.Size = new System.Drawing.Size(244, 42);
+            this.RunPassesButton.TabIndex = 6;
+            this.RunPassesButton.Text = "Run Passes";
+            this.RunPassesButton.UseVisualStyleBackColor = true;
+            this.RunPassesButton.Click += new System.EventHandler(this.RunPassesButton_Click);
+            // 
+            // SelectPassDownButton
+            // 
+            this.SelectPassDownButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.SelectPassDownButton.Location = new System.Drawing.Point(587, 101);
+            this.SelectPassDownButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.SelectPassDownButton.Name = "SelectPassDownButton";
+            this.SelectPassDownButton.Size = new System.Drawing.Size(124, 42);
+            this.SelectPassDownButton.TabIndex = 5;
+            this.SelectPassDownButton.Text = "Swap Down";
+            this.SelectPassDownButton.UseVisualStyleBackColor = true;
+            this.SelectPassDownButton.Click += new System.EventHandler(this.SelectPassDownButton_Click);
+            // 
+            // SelectPassUpButton
+            // 
+            this.SelectPassUpButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.SelectPassUpButton.Location = new System.Drawing.Point(465, 101);
+            this.SelectPassUpButton.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.SelectPassUpButton.Name = "SelectPassUpButton";
+            this.SelectPassUpButton.Size = new System.Drawing.Size(116, 42);
+            this.SelectPassUpButton.TabIndex = 4;
+            this.SelectPassUpButton.Text = "Swap Up";
+            this.SelectPassUpButton.UseVisualStyleBackColor = true;
+            this.SelectPassUpButton.Click += new System.EventHandler(this.SelectPassUpButton_Click);
+            // 
+            // SelectedPassesBox
+            // 
+            this.SelectedPassesBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.SelectedPassesBox.ContextMenuStrip = this.PassesContextMenu;
+            this.SelectedPassesBox.FormattingEnabled = true;
+            this.SelectedPassesBox.ItemHeight = 28;
+            this.SelectedPassesBox.Location = new System.Drawing.Point(465, 51);
+            this.SelectedPassesBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.SelectedPassesBox.Name = "SelectedPassesBox";
+            this.SelectedPassesBox.Size = new System.Drawing.Size(340, 88);
+            this.SelectedPassesBox.TabIndex = 3;
+            this.SelectedPassesBox.DoubleClick += new System.EventHandler(this.SelectedPassesBox_DoubleClick);
+            this.SelectedPassesBox.KeyUp += new System.Windows.Forms.KeyEventHandler(this.SelectedPassesBox_KeyUp);
+            // 
+            // PassesContextMenu
+            // 
+            this.PassesContextMenu.ImageScalingSize = new System.Drawing.Size(32, 32);
+            this.PassesContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.PassPropertiesMenuItem,
+            this.toolStripMenuItem5,
+            this.copyToolStripMenuItem1,
+            this.copyAllToolStripMenuItem,
+            this.PastePassesMenuItem,
+            this.DeleteAllPassesMenuItem});
+            this.PassesContextMenu.Name = "PassesContextMenu";
+            this.PassesContextMenu.Size = new System.Drawing.Size(213, 190);
+            // 
+            // PassPropertiesMenuItem
+            // 
+            this.PassPropertiesMenuItem.Name = "PassPropertiesMenuItem";
+            this.PassPropertiesMenuItem.Size = new System.Drawing.Size(212, 36);
+            this.PassPropertiesMenuItem.Text = "P&roperties...";
+            this.PassPropertiesMenuItem.Click += new System.EventHandler(this.PassPropertiesMenuItem_Click);
+            // 
+            // toolStripMenuItem5
+            // 
+            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
+            this.toolStripMenuItem5.Size = new System.Drawing.Size(209, 6);
+            // 
+            // copyToolStripMenuItem1
+            // 
+            this.copyToolStripMenuItem1.Name = "copyToolStripMenuItem1";
+            this.copyToolStripMenuItem1.Size = new System.Drawing.Size(212, 36);
+            this.copyToolStripMenuItem1.Text = "&Copy";
+            this.copyToolStripMenuItem1.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
+            // 
+            // copyAllToolStripMenuItem
+            // 
+            this.copyAllToolStripMenuItem.Name = "copyAllToolStripMenuItem";
+            this.copyAllToolStripMenuItem.Size = new System.Drawing.Size(212, 36);
+            this.copyAllToolStripMenuItem.Text = "Copy &All";
+            this.copyAllToolStripMenuItem.Click += new System.EventHandler(this.copyAllToolStripMenuItem_Click);
+            // 
+            // PastePassesMenuItem
+            // 
+            this.PastePassesMenuItem.Name = "PastePassesMenuItem";
+            this.PastePassesMenuItem.Size = new System.Drawing.Size(212, 36);
+            this.PastePassesMenuItem.Text = "&Paste";
+            this.PastePassesMenuItem.Click += new System.EventHandler(this.PastePassesMenuItem_Click);
+            // 
+            // DeleteAllPassesMenuItem
+            // 
+            this.DeleteAllPassesMenuItem.Name = "DeleteAllPassesMenuItem";
+            this.DeleteAllPassesMenuItem.Size = new System.Drawing.Size(212, 36);
+            this.DeleteAllPassesMenuItem.Text = "Delete All";
+            this.DeleteAllPassesMenuItem.Click += new System.EventHandler(this.DeleteAllPassesMenuItem_Click);
+            // 
+            // label2
+            // 
+            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(459, 12);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(129, 28);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "&Pipeline:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(6, 12);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(519, 28);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "&Available Passes (double-click to add):";
+            // 
+            // AvailablePassesBox
+            // 
+            this.AvailablePassesBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.AvailablePassesBox.FormattingEnabled = true;
+            this.AvailablePassesBox.ItemHeight = 28;
+            this.AvailablePassesBox.Location = new System.Drawing.Point(10, 51);
+            this.AvailablePassesBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.AvailablePassesBox.Name = "AvailablePassesBox";
+            this.AvailablePassesBox.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            this.AvailablePassesBox.Size = new System.Drawing.Size(443, 88);
+            this.AvailablePassesBox.TabIndex = 0;
+            this.AvailablePassesBox.DoubleClick += new System.EventHandler(this.AvailablePassesBox_DoubleClick);
+            // 
+            // TopSplitContainer
+            // 
+            this.TopSplitContainer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.TopSplitContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            this.TopSplitContainer.Location = new System.Drawing.Point(0, 40);
+            this.TopSplitContainer.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.TopSplitContainer.Name = "TopSplitContainer";
+            this.TopSplitContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // TopSplitContainer.Panel1
+            // 
+            this.TopSplitContainer.Panel1.Controls.Add(this.splitContainer1);
+            // 
+            // TopSplitContainer.Panel2
+            // 
+            this.TopSplitContainer.Panel2.Controls.Add(this.OutputTabControl);
+            this.TopSplitContainer.Panel2Collapsed = true;
+            this.TopSplitContainer.Panel2MinSize = 75;
+            this.TopSplitContainer.Size = new System.Drawing.Size(1302, 373);
+            this.TopSplitContainer.SplitterDistance = 25;
+            this.TopSplitContainer.SplitterWidth = 3;
+            this.TopSplitContainer.TabIndex = 3;
             // 
             // OutputTabControl
             // 
@@ -1009,11 +961,11 @@ namespace MainNs
             // RenderLogTabPage
             // 
             this.RenderLogTabPage.Controls.Add(this.RenderLogBox);
-            this.RenderLogTabPage.Location = new System.Drawing.Point(6, 33);
+            this.RenderLogTabPage.Location = new System.Drawing.Point(8, 42);
             this.RenderLogTabPage.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.RenderLogTabPage.Name = "RenderLogTabPage";
             this.RenderLogTabPage.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.RenderLogTabPage.Size = new System.Drawing.Size(1294, 144);
+            this.RenderLogTabPage.Size = new System.Drawing.Size(134, 0);
             this.RenderLogTabPage.TabIndex = 0;
             this.RenderLogTabPage.Text = "Render Log";
             this.RenderLogTabPage.UseVisualStyleBackColor = true;
@@ -1026,7 +978,7 @@ namespace MainNs
             this.RenderLogBox.Multiline = true;
             this.RenderLogBox.Name = "RenderLogBox";
             this.RenderLogBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.RenderLogBox.Size = new System.Drawing.Size(1286, 138);
+            this.RenderLogBox.Size = new System.Drawing.Size(126, 0);
             this.RenderLogBox.TabIndex = 0;
             this.RenderLogBox.WordWrap = false;
             // 
@@ -1044,7 +996,7 @@ namespace MainNs
             // 
             // EditorForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 22F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(13F, 28F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1302, 450);
             this.Controls.Add(this.TopSplitContainer);
@@ -1068,6 +1020,8 @@ namespace MainNs
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
             this.AnalysisTabControl.ResumeLayout(false);
+            this.CompilationTabPage.ResumeLayout(false);
+            this.CompilationTabPage.PerformLayout();
             this.DisassemblyTabPage.ResumeLayout(false);
             this.ASTTabPage.ResumeLayout(false);
             this.OptimizerTabPage.ResumeLayout(false);
@@ -1077,13 +1031,6 @@ namespace MainNs
             this.TopSplitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.TopSplitContainer)).EndInit();
             this.TopSplitContainer.ResumeLayout(false);
-            this.splitContainer2.Panel1.ResumeLayout(false);
-            this.splitContainer2.Panel2.ResumeLayout(false);
-            this.splitContainer2.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
-            this.splitContainer2.ResumeLayout(false);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            this.tableLayoutPanel1.PerformLayout();
             this.OutputTabControl.ResumeLayout(false);
             this.RenderLogTabPage.ResumeLayout(false);
             this.RenderLogTabPage.PerformLayout();
@@ -1171,15 +1118,13 @@ namespace MainNs
         private System.Windows.Forms.ToolStripMenuItem PastePassesMenuItem;
         private System.Windows.Forms.ToolStripMenuItem DeleteAllPassesMenuItem;
         private System.Windows.Forms.Button InteractiveEditorButton;
-        private System.Windows.Forms.SplitContainer splitContainer2;
         private System.Windows.Forms.ComboBox cbProfile;
-        private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Button btnCompile;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TextBox tbOptions;
         private System.Windows.Forms.TextBox tbEntry;
         private System.Windows.Forms.Label label4;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.TabPage CompilationTabPage;
     }
 }

--- a/tools/clang/tools/dotnetc/EditorForm.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.cs
@@ -1226,7 +1226,16 @@ namespace MainNs
             RichTextBox rtb = this.DeepActiveControl as RichTextBox;
             if (rtb != null)
             {
-                rtb.Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
+                // Handle the container format.
+                if (Clipboard.ContainsData(ContainerData.DataFormat.Name))
+                {
+                    object o = Clipboard.GetData(ContainerData.DataFormat.Name);
+                    rtb.SelectedText = ContainerData.DataObjectToString(o);
+                }
+                else
+                {
+                    rtb.Paste(DataFormats.GetFormat(DataFormats.UnicodeText));
+                }
                 return;
             }
             TextBoxBase tb = this.ActiveControl as TextBoxBase;
@@ -2096,16 +2105,23 @@ namespace MainNs
                 return;
             }
 
-            byte[] bytes;
-            unsafe
+            DisplayBitstream(ContainerData.BlobToBytes(this.SelectedShaderBlob), "Bitstream Viewer - Selected Shader");
+        }
+
+        private void bitstreamFromClipboardToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (!Clipboard.ContainsData(ContainerData.DataFormat.Name))
             {
-                char* pBuffer = this.SelectedShaderBlob.GetBufferPointer();
-                uint size = this.SelectedShaderBlob.GetBufferSize();
-                bytes = new byte[size];
-                IntPtr ptr = new IntPtr(pBuffer);
-                System.Runtime.InteropServices.Marshal.Copy(ptr, bytes, 0, (int)size);
+                MessageBox.Show(this, "No shader blob on clipboard. Try pasting from the optimizer view.");
+                return;
             }
 
+            DisplayBitstream(ContainerData.DataObjectToBytes(Clipboard.GetData(ContainerData.DataFormat.Name)),
+                "Bitstream Viewer - Clipboard");
+        }
+
+        private void DisplayBitstream(byte[] bytes, string title)
+        {
             StatusBar statusBar = new StatusBar();
             statusBar.Dock = DockStyle.Bottom;
 
@@ -2155,7 +2171,7 @@ namespace MainNs
             container.Dock = DockStyle.Fill;
 
             Form form = new Form();
-            form.Text = "Bitstream Viewer";
+            form.Text = title;
             form.Controls.Add(container);
             form.Controls.Add(statusBar);
             binaryView.Bytes = bytes;

--- a/tools/clang/tools/dotnetc/EditorForm.cs
+++ b/tools/clang/tools/dotnetc/EditorForm.cs
@@ -187,6 +187,7 @@ namespace MainNs
         private void compileToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.CompileDocument();
+            this.AnalysisTabControl.SelectedTab = this.DisassemblyTabPage;
         }
 
         private void errorListToolStripMenuItem_Click(object sender, EventArgs e)

--- a/tools/clang/tools/dotnetc/EditorModels.cs
+++ b/tools/clang/tools/dotnetc/EditorModels.cs
@@ -304,4 +304,47 @@ namespace MainNs
 
         #endregion Private methods.
     }
+
+    class ContainerData
+    {
+        public static System.Windows.Forms.DataFormats.Format DataFormat =
+            System.Windows.Forms.DataFormats.GetFormat("DXBC");
+
+        public static string BlobToBase64(IDxcBlob blob)
+        {
+            return System.Convert.ToBase64String(BlobToBytes(blob));
+        }
+
+        public static byte[] BlobToBytes(IDxcBlob blob)
+        {
+            byte[] bytes;
+            unsafe
+            {
+                char* pBuffer = blob.GetBufferPointer();
+                uint size = blob.GetBufferSize();
+                bytes = new byte[size];
+                IntPtr ptr = new IntPtr(pBuffer);
+                System.Runtime.InteropServices.Marshal.Copy(ptr, bytes, 0, (int)size);
+            }
+            return bytes;
+        }
+
+        public static byte[] DataObjectToBytes(object data)
+        {
+            System.IO.Stream stream = data as System.IO.Stream;
+            if (stream == null)
+                return null;
+            byte[] bytes = new byte[stream.Length];
+            stream.Read(bytes, 0, (int)stream.Length);
+            return bytes;
+        }
+
+        public static string DataObjectToString(object data)
+        {
+            byte[] bytes = DataObjectToBytes(data);
+            if (bytes == null)
+                return "";
+            return System.Convert.ToBase64String(bytes);
+        }
+    }
 }

--- a/tools/clang/tools/dotnetc/HlslHost.cs
+++ b/tools/clang/tools/dotnetc/HlslHost.cs
@@ -5,7 +5,7 @@
 // This file is distributed under the University of Illinois Open Source     //
 // License. See LICENSE.TXT for details.                                     //
 //                                                                           //
-// Provides support for working with an out-of-process rendering host.      //
+// Provides support for working with an out-of-process rendering host.       //
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/tools/clang/tools/dotnetc/OptEditorForm.Designer.cs
+++ b/tools/clang/tools/dotnetc/OptEditorForm.Designer.cs
@@ -37,6 +37,7 @@
             this.DiffButton = new System.Windows.Forms.RadioButton();
             this.RightButton = new System.Windows.Forms.RadioButton();
             this.ApplyChangesButton = new System.Windows.Forms.Button();
+            this.CopyContainerButton = new System.Windows.Forms.Button();
             this.LogBox = new System.Windows.Forms.RichTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.TopContainer)).BeginInit();
             this.TopContainer.Panel1.SuspendLayout();
@@ -53,6 +54,7 @@
             // 
             this.TopContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.TopContainer.Location = new System.Drawing.Point(0, 0);
+            this.TopContainer.Margin = new System.Windows.Forms.Padding(6);
             this.TopContainer.Name = "TopContainer";
             // 
             // TopContainer.Panel1
@@ -62,17 +64,20 @@
             // TopContainer.Panel2
             // 
             this.TopContainer.Panel2.Controls.Add(this.WorkContainer);
-            this.TopContainer.Size = new System.Drawing.Size(697, 469);
-            this.TopContainer.SplitterDistance = 232;
+            this.TopContainer.Size = new System.Drawing.Size(1394, 902);
+            this.TopContainer.SplitterDistance = 464;
+            this.TopContainer.SplitterWidth = 8;
             this.TopContainer.TabIndex = 0;
             // 
             // PassesListBox
             // 
             this.PassesListBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.PassesListBox.FormattingEnabled = true;
+            this.PassesListBox.ItemHeight = 25;
             this.PassesListBox.Location = new System.Drawing.Point(0, 0);
+            this.PassesListBox.Margin = new System.Windows.Forms.Padding(6);
             this.PassesListBox.Name = "PassesListBox";
-            this.PassesListBox.Size = new System.Drawing.Size(232, 469);
+            this.PassesListBox.Size = new System.Drawing.Size(464, 902);
             this.PassesListBox.TabIndex = 0;
             this.PassesListBox.SelectedIndexChanged += new System.EventHandler(this.PassesListBox_SelectedIndexChanged);
             // 
@@ -81,6 +86,7 @@
             this.WorkContainer.Dock = System.Windows.Forms.DockStyle.Fill;
             this.WorkContainer.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
             this.WorkContainer.Location = new System.Drawing.Point(0, 0);
+            this.WorkContainer.Margin = new System.Windows.Forms.Padding(6);
             this.WorkContainer.Name = "WorkContainer";
             this.WorkContainer.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
@@ -92,16 +98,18 @@
             // WorkContainer.Panel2
             // 
             this.WorkContainer.Panel2.Controls.Add(this.LogBox);
-            this.WorkContainer.Size = new System.Drawing.Size(461, 469);
-            this.WorkContainer.SplitterDistance = 400;
+            this.WorkContainer.Size = new System.Drawing.Size(922, 902);
+            this.WorkContainer.SplitterDistance = 825;
+            this.WorkContainer.SplitterWidth = 8;
             this.WorkContainer.TabIndex = 0;
             // 
             // CodeBox
             // 
             this.CodeBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.CodeBox.Location = new System.Drawing.Point(0, 29);
+            this.CodeBox.Location = new System.Drawing.Point(0, 56);
+            this.CodeBox.Margin = new System.Windows.Forms.Padding(6);
             this.CodeBox.Name = "CodeBox";
-            this.CodeBox.Size = new System.Drawing.Size(461, 371);
+            this.CodeBox.Size = new System.Drawing.Size(922, 769);
             this.CodeBox.TabIndex = 1;
             this.CodeBox.Text = "";
             this.CodeBox.SelectionChanged += new System.EventHandler(this.CodeBox_SelectionChanged);
@@ -115,18 +123,21 @@
             this.flowLayoutPanel1.Controls.Add(this.DiffButton);
             this.flowLayoutPanel1.Controls.Add(this.RightButton);
             this.flowLayoutPanel1.Controls.Add(this.ApplyChangesButton);
+            this.flowLayoutPanel1.Controls.Add(this.CopyContainerButton);
             this.flowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.flowLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(6);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(461, 29);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(922, 56);
             this.flowLayoutPanel1.TabIndex = 0;
             // 
             // LeftButton
             // 
             this.LeftButton.AutoSize = true;
-            this.LeftButton.Location = new System.Drawing.Point(3, 3);
+            this.LeftButton.Location = new System.Drawing.Point(6, 6);
+            this.LeftButton.Margin = new System.Windows.Forms.Padding(6);
             this.LeftButton.Name = "LeftButton";
-            this.LeftButton.Size = new System.Drawing.Size(43, 17);
+            this.LeftButton.Size = new System.Drawing.Size(79, 29);
             this.LeftButton.TabIndex = 0;
             this.LeftButton.Text = "Left";
             this.LeftButton.UseVisualStyleBackColor = true;
@@ -136,9 +147,10 @@
             // 
             this.DiffButton.AutoSize = true;
             this.DiffButton.Checked = true;
-            this.DiffButton.Location = new System.Drawing.Point(52, 3);
+            this.DiffButton.Location = new System.Drawing.Point(97, 6);
+            this.DiffButton.Margin = new System.Windows.Forms.Padding(6);
             this.DiffButton.Name = "DiffButton";
-            this.DiffButton.Size = new System.Drawing.Size(41, 17);
+            this.DiffButton.Size = new System.Drawing.Size(75, 29);
             this.DiffButton.TabIndex = 1;
             this.DiffButton.TabStop = true;
             this.DiffButton.Text = "Diff";
@@ -148,9 +160,10 @@
             // RightButton
             // 
             this.RightButton.AutoSize = true;
-            this.RightButton.Location = new System.Drawing.Point(99, 3);
+            this.RightButton.Location = new System.Drawing.Point(184, 6);
+            this.RightButton.Margin = new System.Windows.Forms.Padding(6);
             this.RightButton.Name = "RightButton";
-            this.RightButton.Size = new System.Drawing.Size(50, 17);
+            this.RightButton.Size = new System.Drawing.Size(93, 29);
             this.RightButton.TabIndex = 2;
             this.RightButton.Text = "Right";
             this.RightButton.UseVisualStyleBackColor = true;
@@ -159,29 +172,43 @@
             // ApplyChangesButton
             // 
             this.ApplyChangesButton.Enabled = false;
-            this.ApplyChangesButton.Location = new System.Drawing.Point(155, 3);
+            this.ApplyChangesButton.Location = new System.Drawing.Point(289, 6);
+            this.ApplyChangesButton.Margin = new System.Windows.Forms.Padding(6);
             this.ApplyChangesButton.Name = "ApplyChangesButton";
-            this.ApplyChangesButton.Size = new System.Drawing.Size(98, 23);
+            this.ApplyChangesButton.Size = new System.Drawing.Size(196, 44);
             this.ApplyChangesButton.TabIndex = 3;
             this.ApplyChangesButton.Text = "Apply Changes";
             this.ApplyChangesButton.UseVisualStyleBackColor = true;
             this.ApplyChangesButton.Click += new System.EventHandler(this.ApplyChangesButton_Click);
             // 
+            // CopyContainerButton
+            // 
+            this.CopyContainerButton.Location = new System.Drawing.Point(497, 6);
+            this.CopyContainerButton.Margin = new System.Windows.Forms.Padding(6);
+            this.CopyContainerButton.Name = "CopyContainerButton";
+            this.CopyContainerButton.Size = new System.Drawing.Size(196, 44);
+            this.CopyContainerButton.TabIndex = 4;
+            this.CopyContainerButton.Text = "Copy Container";
+            this.CopyContainerButton.UseVisualStyleBackColor = true;
+            this.CopyContainerButton.Click += new System.EventHandler(this.CopyContainerButton_Click);
+            // 
             // LogBox
             // 
             this.LogBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.LogBox.Location = new System.Drawing.Point(0, 0);
+            this.LogBox.Margin = new System.Windows.Forms.Padding(6);
             this.LogBox.Name = "LogBox";
-            this.LogBox.Size = new System.Drawing.Size(461, 65);
+            this.LogBox.Size = new System.Drawing.Size(922, 69);
             this.LogBox.TabIndex = 0;
             this.LogBox.Text = "";
             // 
             // OptEditorForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(697, 469);
+            this.ClientSize = new System.Drawing.Size(1394, 902);
             this.Controls.Add(this.TopContainer);
+            this.Margin = new System.Windows.Forms.Padding(6);
             this.Name = "OptEditorForm";
             this.Text = "Optimizer Editor";
             this.Load += new System.EventHandler(this.OptEditorForm_Load);
@@ -212,5 +239,6 @@
         private System.Windows.Forms.Button ApplyChangesButton;
         private System.Windows.Forms.RichTextBox CodeBox;
         private System.Windows.Forms.RichTextBox LogBox;
+        private System.Windows.Forms.Button CopyContainerButton;
     }
 }

--- a/tools/clang/tools/dotnetc/OptEditorForm.cs
+++ b/tools/clang/tools/dotnetc/OptEditorForm.cs
@@ -140,6 +140,32 @@ namespace MainNs
         {
             EditorForm.HandleCodeSelectionChanged(this.CodeBox, null);
         }
+
+        private void CopyContainerButton_Click(object sender, EventArgs e)
+        {
+            // The intent is to copy compiled code (possibly customized) into the
+            // clipboard so it can be pasted into an XML file to be run interactively.
+
+            var text = this.CodeBox.Text;
+            var source = EditorForm.CreateBlobForText(this.Library, text);
+            var assembler = HlslDxcLib.CreateDxcAssembler();
+            var assembleResult = assembler.AssembleToContainer(source);
+            if (assembleResult.GetStatus() < 0)
+            {
+                var errors = assembleResult.GetErrors();
+                MessageBox.Show(EditorForm.GetStringFromBlob(this.Library, errors));
+                return;
+            }
+            var container = assembleResult.GetResult();
+
+            // Now copy that to the clipboard.
+            var bytes = ContainerData.BlobToBytes(container);
+            var stream = new System.IO.MemoryStream(bytes);
+            var dataObj = new DataObject();
+            dataObj.SetData(ContainerData.DataFormat.Name, stream);
+            dataObj.SetText(text);
+            Clipboard.SetDataObject(dataObj, true);
+        }
     }
 
     public class TextSection

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -154,6 +154,7 @@ public:
   LPCSTR  Text;       // HLSL Shader Text.
   LPCSTR  Arguments;  // Command line Arguments.
   LPCSTR  Defines;    // HLSL Defines.
+  BOOL    Compiled;   // Whether text is a base64-encoded value.
 };
 
 // Use this class to represent a value in the root signature.


### PR DESCRIPTION
Adds a clipboard format to copy containers from optimizer and paste them encoded in shader ops and render them.
Adds a command to view the bitcode on the clipboard.
Adds a tab page for compilation options.
Relays out some of the UI on the main form to allow the render output pane to be visible again.
Some more text work missing, but this should help render output scenarios.
