### PR TITLE
Increased MaxIncludeFiles limit & filed issue #866

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -123,7 +123,7 @@ const DxcArgsHandle OutputHandle(SpecialValue::Output);
 /// Max number of included files (1:1 to their directories) or search directories.
 /// If programs include more than a handful, DxcArgsFileSystem will need to do better than linear scans.
 /// If this is fired, ERROR_OUT_OF_STRUCTURES will be returned by an attempt to open a file.
-static const size_t MaxIncludedFiles = 200;
+static const size_t MaxIncludedFiles = 1000;
 
 bool IsAbsoluteOrCurDirRelativeW(LPCWSTR Path) {
   if (!Path || !Path[0]) return FALSE;


### PR DESCRIPTION
I am hitting the max include file count limit on some workloads. I'm increasing the limit a bit to get unblocked. I have filed issue #866 to follow up with a data-structure and/or algo update to avoid having this limit.