### PR TITLE
[spirv] Fix type mismatch when loading Constant/Texture Buffer

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -366,6 +366,9 @@ uint32_t DeclResultIdMapper::createVarOfExplicitLayoutStruct(
   const uint32_t structType =
       theBuilder.getStructType(fieldTypes, typeName, fieldNames, decorations);
 
+  // Register the <type-id> for this decl
+  ctBufferPCTypeIds[decl] = structType;
+
   const auto sc = usageKind == ContextUsageKind::PushConstant
                       ? spv::StorageClass::PushConstant
                       : spv::StorageClass::Uniform;
@@ -474,6 +477,13 @@ uint32_t DeclResultIdMapper::createCounterVar(const ValueDecl *decl) {
                             decl->getAttr<VKBindingAttr>(),
                             decl->getAttr<VKCounterBindingAttr>(), true);
   return counterVars[decl] = counterId;
+}
+
+uint32_t
+DeclResultIdMapper::getCTBufferPushConstantTypeId(const DeclContext *decl) {
+  const auto found = ctBufferPCTypeIds.find(decl);
+  assert(found != ctBufferPCTypeIds.end());
+  return found->second;
 }
 
 std::vector<uint32_t> DeclResultIdMapper::collectStageVars() const {

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -263,6 +263,19 @@ public:
   /// {RW|Append|Consume}StructuredBuffer variable.
   uint32_t getOrCreateCounterId(const ValueDecl *decl);
 
+  /// \brief Returns the <type-id> for the given cbuffer, tbuffer,
+  /// ConstantBuffer, TextureBuffer, or push constant block.
+  ///
+  /// Note: we need this method because constant/texture buffers and push
+  /// constant blocks are all represented as normal struct types upon which
+  /// they are parameterized. That is different from structured buffers,
+  /// for which we can tell they are not normal structs by investigating
+  /// the name. But for constant/texture buffers and push constant blocks,
+  /// we need to have the additional Block/BufferBlock decoration to keep
+  /// type consistent. Normal translation path for structs via TypeTranslator
+  /// won't attach Block/BufferBlock decoration.
+  uint32_t getCTBufferPushConstantTypeId(const DeclContext *decl);
+
   /// \brief Returns all defined stage (builtin/input/ouput) variables in this
   /// mapper.
   std::vector<uint32_t> collectStageVars() const;
@@ -454,6 +467,10 @@ private:
   /// Mapping from {RW|Append|Consume}StructuredBuffers to their
   /// counter variables
   llvm::DenseMap<const NamedDecl *, uint32_t> counterVars;
+
+  /// Mapping from cbuffer/tbuffer/ConstantBuffer/TextureBufer/push-constant
+  /// to the <type-id>
+  llvm::DenseMap<const DeclContext *, uint32_t> ctBufferPCTypeIds;
 
 public:
   /// The gl_PerVertex structs for both input and output

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -119,12 +119,14 @@ private:
   /// lhs again.
   SpirvEvalInfo processAssignment(const Expr *lhs, const SpirvEvalInfo &rhs,
                                   bool isCompoundAssignment,
-                                  SpirvEvalInfo lhsPtr = 0);
+                                  SpirvEvalInfo lhsPtr = 0,
+                                  const Expr *rhsExpr = nullptr);
 
   /// Generates SPIR-V instructions to store rhsVal into lhsPtr. This will be
-  /// recursive if valType is a composite type.
+  /// recursive if lhsValType is a composite type. rhsExpr will be used as a
+  /// reference to adjust the CodeGen if not nullptr.
   void storeValue(const SpirvEvalInfo &lhsPtr, const SpirvEvalInfo &rhsVal,
-                  QualType valType);
+                  QualType lhsValType, const Expr *rhsExpr = nullptr);
 
   /// Generates the necessary instructions for conducting the given binary
   /// operation on lhs and rhs. If lhsResultId is not nullptr, the evaluated

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
@@ -10,7 +10,7 @@
 
 // CHECK:     OpMemberDecorate %type_ConstantBuffer_S 0 Offset 0
 // CHECK:     OpMemberDecorate %S 0 Offset 0
-// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S_0 0 Offset 0
 
 // CHECK:     %type_ConstantBuffer_S = OpTypeStruct %v4float
 // CHECK:     %S = OpTypeStruct %v4float

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
@@ -1,0 +1,67 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// Note: The following is invalid SPIR-V code.
+//
+// * The assignment ignores storage class (and thus layout) difference.
+
+// %type_ConstantBuffer_S is the type for myCBuffer. With layout decoration.
+// %S is the type for myASBuffer elements. With layout decoration.
+// %S_0 is the type for function local variables. Without layout decoration.
+
+// CHECK:     OpMemberDecorate %type_ConstantBuffer_S 0 Offset 0
+// CHECK:     OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+
+// CHECK:     %type_ConstantBuffer_S = OpTypeStruct %v4float
+// CHECK:     %S = OpTypeStruct %v4float
+// CHECK:     %S_0 = OpTypeStruct %v4float
+struct S {
+    float4 f;
+};
+
+// CHECK: %myCBuffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_S Uniform
+ConstantBuffer<S>         myCBuffer;
+AppendStructuredBuffer<S> myASBuffer;
+
+S retStuff();
+
+float4 doStuff(S buffer) {
+    return buffer.f;
+}
+
+float4 main(in float4 pos : SV_Position) : SV_Target
+{
+// CHECK:      [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %buffer1 [[val]]
+    S buffer1 = myCBuffer;
+
+// CHECK:      [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %buffer2 [[val]]
+    S buffer2;
+    buffer2 = myCBuffer;
+
+// CHECK:      [[val:%\d+]] = OpFunctionCall %S_0 %retStuff
+// CHECK-NEXT:                OpStore %buffer3 [[val]]
+    S buffer3;
+    buffer3 = retStuff();
+
+// Write out each component recursively
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %myASBuffer %uint_0 {{%\d+}}
+// CHECK-NEXT: [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
+// CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[val]] 0
+// CHECK-NEXT: [[adr:%\d+]] = OpAccessChain %_ptr_Uniform_v4float [[ptr]] %uint_0
+// CHECK-NEXT:                OpStore [[adr]] [[vec]]
+    myASBuffer.Append(myCBuffer);
+
+// CHECK:      [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %param_var_buffer [[val]]
+    return doStuff(myCBuffer);
+}
+
+S retStuff() {
+// CHECK:      [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %temp_var_ret [[val]]
+// CHECK-NEXT: [[ret:%\d+]] = OpLoad %S_0 %temp_var_ret
+// CHECK-NEXT:                OpReturnValue [[ret]]
+    return myCBuffer;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.hlsl
@@ -18,9 +18,6 @@ struct ResourceBundle {
     RWBuffer<float3>           rwbuf;
     Texture2D<float>           tex2d;
     RWTexture2D<float4>        rwtex2d;
-    // The frontend does not allow ConstantBuffers and TextureBuffers to be in a struct.
-    //ConstantBuffer<T>          cbuf;
-    //TextureBuffer<T>           tbuf;
     StructuredBuffer<T>        sbuf;
     RWStructuredBuffer<T>      rwsbuf;
     AppendStructuredBuffer<T>  asbuf;
@@ -34,8 +31,6 @@ Buffer<float3>             g_buf;
 RWBuffer<float3>           g_rwbuf;
 Texture2D<float>           g_tex2d;
 RWTexture2D<float4>        g_rwtex2d;
-//ConstantBuffer<T>          g_cbuf;
-//TextureBuffer<T>           g_tbuf;
 StructuredBuffer<T>        g_sbuf;
 RWStructuredBuffer<T>      g_rwsbuf;
 AppendStructuredBuffer<T>  g_asbuf;
@@ -70,9 +65,6 @@ void main() {
 // CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Function_type_2d_image_0 %b %int_4
 // CHECK-NEXT:                OpStore [[ptr]] [[val]]
     b.rwtex2d = g_rwtex2d;
-
-    //b.cbuf    = g_cbuf;
-    //b.tbuf    = g_tbuf;
 
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %type_StructuredBuffer_T %g_sbuf
 // CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Function_type_StructuredBuffer_T_0 %b %int_5

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
@@ -1,0 +1,65 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// Note: The following is invalid SPIR-V code.
+//
+// * The assignment ignores storage class (and thus layout) difference.
+
+// %type_TextureBuffer_S is the type for myCBuffer. With layout decoration.
+// %S is the type for myASBuffer elements. With layout decoration.
+// %S_0 is the type for function local variables. Without layout decoration.
+
+// CHECK:     OpMemberDecorate %type_TextureBuffer_S 0 Offset 0
+// CHECK:     OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+
+// CHECK:     %type_TextureBuffer_S = OpTypeStruct %v4float
+// CHECK:     %S = OpTypeStruct %v4float
+// CHECK:     %S_0 = OpTypeStruct %v4float
+struct S {
+    float4 f;
+};
+
+// CHECK: %myCBuffer = OpVariable %_ptr_Uniform_type_TextureBuffer_S Uniform
+TextureBuffer<S>         myCBuffer;
+AppendStructuredBuffer<S> myASBuffer;
+
+S retStuff();
+
+float4 doStuff(S buffer) {
+    return buffer.f;
+}
+
+float4 main(in float4 pos : SV_Position) : SV_Target
+{
+// CHECK:      [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %buffer1 [[val]]
+    S buffer1 = myCBuffer;
+
+// CHECK:      [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %buffer2 [[val]]
+    S buffer2;
+    buffer2 = myCBuffer;
+
+// CHECK:      [[val:%\d+]] = OpFunctionCall %S_0 %retStuff
+// CHECK-NEXT:                OpStore %buffer3 [[val]]
+    S buffer3;
+    buffer3 = retStuff();
+
+// The underlying struct type has the same layout. Can write out as a whole.
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %myASBuffer %uint_0 {{%\d+}}
+// CHECK-NEXT: [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore [[ptr]] [[val]]
+    myASBuffer.Append(myCBuffer);
+
+// CHECK:      [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %param_var_buffer [[val]]
+    return doStuff(myCBuffer);
+}
+
+S retStuff() {
+// CHECK:      [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myCBuffer
+// CHECK-NEXT:                OpStore %temp_var_ret [[val]]
+// CHECK-NEXT: [[ret:%\d+]] = OpLoad %S_0 %temp_var_ret
+// CHECK-NEXT:                OpReturnValue [[ret]]
+    return myCBuffer;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
@@ -10,7 +10,7 @@
 
 // CHECK:     OpMemberDecorate %type_TextureBuffer_S 0 Offset 0
 // CHECK:     OpMemberDecorate %S 0 Offset 0
-// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S_0 0 Offset 0
 
 // CHECK:     %type_TextureBuffer_S = OpTypeStruct %v4float
 // CHECK:     %S = OpTypeStruct %v4float

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -139,11 +139,6 @@ TEST_F(FileTest, BinaryOpAssign) { runFileTest("binary-op.assign.hlsl"); }
 TEST_F(FileTest, BinaryOpAssignComposite) {
   runFileTest("binary-op.assign.composite.hlsl");
 }
-TEST_F(FileTest, BinaryOpAssignResource) {
-  runFileTest("binary-op.assign.resource.hlsl", Expect::Success,
-              // It generates invalid SPIR-V code right now.
-              /*runValidation=*/false);
-}
 
 // For comma binary operator
 TEST_F(FileTest, BinaryOpComma) { runFileTest("binary-op.comma.hlsl"); }
@@ -957,6 +952,22 @@ TEST_F(FileTest, SpirvInterpolation) {
 }
 TEST_F(FileTest, SpirvInterpolationError) {
   runFileTest("spirv.interpolation.error.hlsl", FileTest::Expect::Failure);
+}
+
+TEST_F(FileTest, SpirvLegalizationStructuredBuffer) {
+  runFileTest("spirv.legal.sbuffer.hlsl", Expect::Success,
+              // The generated SPIR-V needs legalization.
+              /*runValidation=*/false);
+}
+TEST_F(FileTest, SpirvLegalizationConstantBuffer) {
+  runFileTest("spirv.legal.cbuffer.hlsl", Expect::Success,
+              // The generated SPIR-V needs legalization.
+              /*runValidation=*/false);
+}
+TEST_F(FileTest, SpirvLegalizationTextureBuffer) {
+  runFileTest("spirv.legal.tbuffer.hlsl", Expect::Success,
+              // The generated SPIR-V needs legalization.
+              /*runValidation=*/false);
 }
 
 TEST_F(FileTest, VulkanAttributeErrors) {


### PR DESCRIPTION
ConstantBuffer/TextureBuffer are rerepresented the same as normal
structs upon which they are parameterized. So, using the normal
translation path via TypeTranslator, we have no way to tell whether
a struct is indeed just a normal struct or a Constant/Texture
buffer. Thus, we cannot apply the Block/BufferBlock decoration
appropriately. This causes type mismatch for OpLoad instructions.