### PR TITLE
[spirv] Fix structured buffer .GetDimensions()

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -1998,7 +1998,7 @@ SPIRVEmitter::doConditionalOperator(const ConditionalOperator *expr) {
 uint32_t SPIRVEmitter::processByteAddressBufferStructuredBufferGetDimensions(
     const CXXMemberCallExpr *expr) {
   const auto *object = expr->getImplicitObjectArgument();
-  const auto objectId = loadIfGLValue(object);
+  const auto objectId = doExpr(object);
   const auto type = object->getType();
   const bool isByteAddressBuffer = TypeTranslator::isByteAddressBuffer(type) ||
                                    TypeTranslator::isRWByteAddressBuffer(type);

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
@@ -10,9 +10,8 @@ AppendStructuredBuffer<S> buffer;
 
 void main() {
   uint numStructs, stride;
-  
-// CHECK:      [[buf:%\d+]] = OpLoad %type_AppendStructuredBuffer_S %buffer
-// CHECK-NEXT: [[len:%\d+]] = OpArrayLength %uint [[buf]] 0
+
+// CHECK:      [[len:%\d+]] = OpArrayLength %uint %buffer 0
 // CHECK-NEXT: OpStore %numStructs [[len]]
 // CHECK-NEXT: OpStore %stride %uint_64
   buffer.GetDimensions(numStructs, stride);

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.get-dimensions.hlsl
@@ -6,14 +6,12 @@ RWByteAddressBuffer b2;
 void main() {
   uint dim;
 
-// CHECK:             [[b1:%\d+]] = OpLoad %type_ByteAddressBuffer %b1
-// CHECK-NEXT:      [[dim1:%\d+]] = OpArrayLength %uint [[b1]] 0
+// CHECK:           [[dim1:%\d+]] = OpArrayLength %uint %b1 0
 // CHECK-NEXT: [[numBytes1:%\d+]] = OpIMul %uint [[dim1]] %uint_4
 // CHECK-NEXT:                      OpStore %dim [[numBytes1]]
   b1.GetDimensions(dim);
 
-// CHECK:             [[b2:%\d+]] = OpLoad %type_RWByteAddressBuffer %b2
-// CHECK-NEXT:      [[dim2:%\d+]] = OpArrayLength %uint [[b2]] 0
+// CHECK:           [[dim2:%\d+]] = OpArrayLength %uint %b2 0
 // CHECK-NEXT: [[numBytes2:%\d+]] = OpIMul %uint [[dim2]] %uint_4
 // CHECK-NEXT:                      OpStore %dim [[numBytes2]]
   b2.GetDimensions(dim);

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
@@ -10,9 +10,8 @@ ConsumeStructuredBuffer<S> buffer;
 
 void main() {
   uint numStructs, stride;
-  
-// CHECK:      [[buf:%\d+]] = OpLoad %type_ConsumeStructuredBuffer_S %buffer
-// CHECK-NEXT: [[len:%\d+]] = OpArrayLength %uint [[buf]] 0
+
+// CHECK:      [[len:%\d+]] = OpArrayLength %uint %buffer 0
 // CHECK-NEXT: OpStore %numStructs [[len]]
 // CHECK-NEXT: OpStore %stride %uint_64
   buffer.GetDimensions(numStructs, stride);

--- a/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
@@ -11,14 +11,12 @@ RWStructuredBuffer<SBuffer> mySBuffer2;
 void main() {
   uint numStructs, stride;
 
-// CHECK:       [[sb1:%\d+]] = OpLoad %type_StructuredBuffer_SBuffer %mySBuffer1
-// CHECK-NEXT: [[len1:%\d+]] = OpArrayLength %uint [[sb1]] 0
+// CHECK:      [[len1:%\d+]] = OpArrayLength %uint %mySBuffer1 0
 // CHECK-NEXT:                 OpStore %numStructs [[len1]]
 // CHECK-NEXT:                 OpStore %stride %uint_96
   mySBuffer1.GetDimensions(numStructs, stride);
 
-// CHECK:       [[sb2:%\d+]] = OpLoad %type_RWStructuredBuffer_SBuffer %mySBuffer2
-// CHECK-NEXT: [[len2:%\d+]] = OpArrayLength %uint [[sb2]] 0
+// CHECK:      [[len2:%\d+]] = OpArrayLength %uint %mySBuffer2 0
 // CHECK-NEXT:                 OpStore %numStructs [[len2]]
 // CHECK-NEXT:                 OpStore %stride %uint_96
   mySBuffer2.GetDimensions(numStructs, stride);


### PR DESCRIPTION
OpArrayLength takes a pointer to an OpTypeStruct whose last member
is a run-time array, not a loaded struct value.