### PR TITLE
[spirv] warn {row|col}_major on standalone matrix.

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2335,3 +2335,6 @@ either because of no Vulkan equivalents at the moment, or because of deprecation
   ``RWByteAddressBuffer`` are not represented as image types in SPIR-V, using the
   output unsigned integer ``status`` argument in their ``Load*`` methods is not
   supported. Using these methods with the ``status`` argument will cause a compiler error.
+* Applying ``row_major`` or ``column_major`` attributes to a stand-alone matrix will be
+  ignored by the compiler because ``RowMajor`` and ``ColMajor`` decorations in SPIR-V are
+  only allowed to be applied to members of structures. A warning will be issued by the compiler.

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -834,6 +834,16 @@ void SPIRVEmitter::doRecordDecl(const RecordDecl *recordDecl) {
 void SPIRVEmitter::doVarDecl(const VarDecl *decl) {
   validateVKAttributes(decl);
 
+  if (decl->hasAttr<HLSLRowMajorAttr>()) {
+    emitWarning("row_major attribute for stand-alone matrix is not supported",
+                decl->getLocation());
+  }
+  if (decl->hasAttr<HLSLColumnMajorAttr>()) {
+    emitWarning(
+        "column_major attribute for stand-alone matrix is not supported",
+        decl->getLocation());
+  }
+
   if (decl->hasAttr<VKPushConstantAttr>()) {
     // This is a VarDecl for PushConstant block.
     (void)declIdMapper.createPushConstant(decl);

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -836,12 +836,12 @@ void SPIRVEmitter::doVarDecl(const VarDecl *decl) {
 
   if (decl->hasAttr<HLSLRowMajorAttr>()) {
     emitWarning("row_major attribute for stand-alone matrix is not supported",
-                decl->getLocation());
+                decl->getAttr<HLSLRowMajorAttr>()->getLocation());
   }
   if (decl->hasAttr<HLSLColumnMajorAttr>()) {
     emitWarning(
         "column_major attribute for stand-alone matrix is not supported",
-        decl->getLocation());
+        decl->getAttr<HLSLColumnMajorAttr>()->getLocation());
   }
 
   if (decl->hasAttr<VKPushConstantAttr>()) {

--- a/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: warning: row_major attribute for stand-alone matrix is not supported
+row_major float2x3 grMajorMat;
+// CHECK: warning: column_major attribute for stand-alone matrix is not supported
+column_major float2x3 gcMajorMat;
+
+// CHECK: warning: row_major attribute for stand-alone matrix is not supported
+static row_major float2x3 gsrMajorMat;
+// CHECK: warning: column_major attribute for stand-alone matrix is not supported
+static column_major float2x3 gscMajorMat;
+
+void main() {
+  // CHECK: warning: row_major attribute for stand-alone matrix is not supported
+  row_major float2x3 rMajorMat;
+  // CHECK: warning: column_major attribute for stand-alone matrix is not supported
+  column_major float2x3 cMajorMat;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
@@ -1,18 +1,18 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK: 4:20: warning: row_major attribute for stand-alone matrix is not supported
+// CHECK: 4:1: warning: row_major attribute for stand-alone matrix is not supported
 row_major float2x3 grMajorMat;
-// CHECK: 6:23: warning: column_major attribute for stand-alone matrix is not supported
+// CHECK: 6:1: warning: column_major attribute for stand-alone matrix is not supported
 column_major float2x3 gcMajorMat;
 
-// CHECK: 9:27: warning: row_major attribute for stand-alone matrix is not supported
+// CHECK: 9:8: warning: row_major attribute for stand-alone matrix is not supported
 static row_major float2x3 gsrMajorMat;
-// CHECK: 11:30: warning: column_major attribute for stand-alone matrix is not supported
+// CHECK: 11:8: warning: column_major attribute for stand-alone matrix is not supported
 static column_major float2x3 gscMajorMat;
 
 void main() {
-  // CHECK: 15:22: warning: row_major attribute for stand-alone matrix is not supported
+  // CHECK: 15:3: warning: row_major attribute for stand-alone matrix is not supported
   row_major float2x3 rMajorMat;
-  // CHECK: 17:25: warning: column_major attribute for stand-alone matrix is not supported
+  // CHECK: 17:3: warning: column_major attribute for stand-alone matrix is not supported
   column_major float2x3 cMajorMat;
 }

--- a/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.hlsl
@@ -1,18 +1,18 @@
 // Run: %dxc -T ps_6_0 -E main
 
-// CHECK: warning: row_major attribute for stand-alone matrix is not supported
+// CHECK: 4:20: warning: row_major attribute for stand-alone matrix is not supported
 row_major float2x3 grMajorMat;
-// CHECK: warning: column_major attribute for stand-alone matrix is not supported
+// CHECK: 6:23: warning: column_major attribute for stand-alone matrix is not supported
 column_major float2x3 gcMajorMat;
 
-// CHECK: warning: row_major attribute for stand-alone matrix is not supported
+// CHECK: 9:27: warning: row_major attribute for stand-alone matrix is not supported
 static row_major float2x3 gsrMajorMat;
-// CHECK: warning: column_major attribute for stand-alone matrix is not supported
+// CHECK: 11:30: warning: column_major attribute for stand-alone matrix is not supported
 static column_major float2x3 gscMajorMat;
 
 void main() {
-  // CHECK: warning: row_major attribute for stand-alone matrix is not supported
+  // CHECK: 15:22: warning: row_major attribute for stand-alone matrix is not supported
   row_major float2x3 rMajorMat;
-  // CHECK: warning: column_major attribute for stand-alone matrix is not supported
+  // CHECK: 17:25: warning: column_major attribute for stand-alone matrix is not supported
   column_major float2x3 cMajorMat;
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -45,6 +45,9 @@ TEST_F(WholeFileTest, EmptyStructInterfaceVS) {
 TEST_F(FileTest, ScalarTypes) { runFileTest("type.scalar.hlsl"); }
 TEST_F(FileTest, VectorTypes) { runFileTest("type.vector.hlsl"); }
 TEST_F(FileTest, MatrixTypes) { runFileTest("type.matrix.hlsl"); }
+TEST_F(FileTest, MatrixTypesMajorness) {
+  runFileTest("type.matrix.majorness.hlsl", FileTest::Expect::Warning);
+}
 TEST_F(FileTest, StructTypes) { runFileTest("type.struct.hlsl"); }
 TEST_F(FileTest, ClassTypes) { runFileTest("type.class.hlsl"); }
 TEST_F(FileTest, ArrayTypes) { runFileTest("type.array.hlsl"); }


### PR DESCRIPTION
According to the SPIR-V Spec on decorations:
> RowMajor
> Applies only to a member of a structure type. 
>
> ColMajor
> Applies only to a member of a structure type. 

We currently do add these decorations for struct members. For now we will emit a warning if they are used on stand-alone matrices. We could consider fixing this via creating a struct with 1 matrix inside in the future.