### PR TITLE
[spirv] Test atomic intrinsics on primitive types in CS

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.cs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.cs.hlsl
@@ -1,0 +1,59 @@
+// Run: %dxc -T cs_6_0 -E main
+
+groupshared int dest_i;
+groupshared uint dest_u;
+
+void main()
+{
+  uint original_u_val;
+  int original_i_val;
+
+  int   val1;
+  int   val2;
+
+  //////////////////////////////////////////////////////////////////////////
+  ///////      Test all Interlocked* functions on primitive types     //////
+  ///////                Only int and uint are allowd                 //////
+  //////////////////////////////////////////////////////////////////////////
+
+// CHECK:      [[val1_27:%\d+]] = OpLoad %int %val1
+// CHECK-NEXT: [[iadd27:%\d+]] = OpAtomicIAdd %int %dest_i %uint_1 %uint_0 [[val1_27]]
+// CHECK-NEXT:                   OpStore %original_i_val [[iadd27]]
+  InterlockedAdd(dest_i, val1, original_i_val);
+
+// CHECK:      [[and28:%\d+]] = OpAtomicAnd %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK-NEXT:                  OpStore %original_u_val [[and28]]
+  InterlockedAnd(dest_u, 10,  original_u_val);
+
+// CHECK:       [[uint10:%\d+]] = OpBitcast %int %uint_10
+// CHECK-NEXT: [[asmax29:%\d+]] = OpAtomicSMax %int %dest_i %uint_1 %uint_0 [[uint10]]
+// CHECK-NEXT:                    OpStore %original_i_val [[asmax29]]
+  InterlockedMax(dest_i, 10,  original_i_val);
+
+// CHECK:      [[umin30:%\d+]] = OpAtomicUMin %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK-NEXT:                   OpStore %original_u_val [[umin30]]
+  InterlockedMin(dest_u, 10,  original_u_val);
+
+// CHECK:      [[val2_31:%\d+]] = OpLoad %int %val2
+// CHECK-NEXT:   [[or31:%\d+]] = OpAtomicOr %int %dest_i %uint_1 %uint_0 [[val2_31]]
+// CHECK-NEXT:                   OpStore %original_i_val [[or31]]
+  InterlockedOr (dest_i, val2, original_i_val);
+
+// CHECK:      [[xor32:%\d+]] = OpAtomicXor %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK-NEXT:                  OpStore %original_u_val [[xor32]]
+  InterlockedXor(dest_u, 10,  original_u_val);
+
+// CHECK:      [[val1_33:%\d+]] = OpLoad %int %val1
+// CHECK-NEXT: [[val2_33:%\d+]] = OpLoad %int %val2
+// CHECK-NEXT:        {{%\d+}} = OpAtomicCompareExchange %int %dest_i %uint_1 %uint_0 %uint_0 [[val2_33]] [[val1_33]]
+  InterlockedCompareStore(dest_i, val1, val2);
+
+// CHECK:      [[ace34:%\d+]] = OpAtomicCompareExchange %uint %dest_u %uint_1 %uint_0 %uint_0 %uint_20 %uint_15
+// CHECK-NEXT:                  OpStore %original_u_val [[ace34]]
+  InterlockedCompareExchange(dest_u, 15, 20, original_u_val);
+
+// CHECK:      [[val2_35:%\d+]] = OpLoad %int %val2
+// CHECK-NEXT:  [[ace35:%\d+]] = OpAtomicExchange %int %dest_i %uint_1 %uint_0 [[val2_35]]
+// CHECK-NEXT:                   OpStore %original_i_val [[ace35]]
+  InterlockedExchange(dest_i, val2, original_i_val);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.ps.hlsl
@@ -246,51 +246,5 @@ void main()
 // CHECK-NEXT:   [[add:%\d+]] = OpAtomicIAdd %uint [[ptr]] %uint_1 %uint_0 [[u1]]
 // CHECK-NEXT:                  OpStore %out_u1 [[add]]
   InterlockedAdd(g_tRWBuffU[u1], u1, out_u1);
-
-  //////////////////////////////////////////////////////////////////////////
-  ///////      Test all Interlocked* functions on primitive types     //////
-  ///////                Only int and uint are allowd                 //////
-  //////////////////////////////////////////////////////////////////////////
-
-// CHECK:      [[i1b_27:%\d+]] = OpLoad %int %i1b
-// CHECK-NEXT: [[iadd27:%\d+]] = OpAtomicIAdd %int %i1 %uint_1 %uint_0 [[i1b_27]]
-// CHECK-NEXT:                   OpStore %out_i1 [[iadd27]]
-  InterlockedAdd(i1, i1b, out_i1);
-
-// CHECK:      [[and28:%\d+]] = OpAtomicAnd %uint %u1 %uint_1 %uint_0 %uint_10
-// CHECK-NEXT:                  OpStore %out_u1 [[and28]]
-  InterlockedAnd(u1, 10,  out_u1);
-
-// CHECK:       [[uint10:%\d+]] = OpBitcast %int %uint_10
-// CHECK-NEXT: [[asmax29:%\d+]] = OpAtomicSMax %int %i1 %uint_1 %uint_0 [[uint10]]
-// CHECK-NEXT:                    OpStore %out_i1 [[asmax29]]
-  InterlockedMax(i1, 10,  out_i1);
-
-// CHECK:      [[umin30:%\d+]] = OpAtomicUMin %uint %u1 %uint_1 %uint_0 %uint_10
-// CHECK-NEXT:                   OpStore %out_u1 [[umin30]]
-  InterlockedMin(u1, 10,  out_u1);
-
-// CHECK:      [[i1c_31:%\d+]] = OpLoad %int %i1c
-// CHECK-NEXT:   [[or31:%\d+]] = OpAtomicOr %int %i1 %uint_1 %uint_0 [[i1c_31]]
-// CHECK-NEXT:                   OpStore %out_i1 [[or31]]
-  InterlockedOr (i1, i1c, out_i1);
-
-// CHECK:      [[xor32:%\d+]] = OpAtomicXor %uint %u1 %uint_1 %uint_0 %uint_10
-// CHECK-NEXT:                  OpStore %out_u1 [[xor32]]
-  InterlockedXor(u1, 10,  out_u1);
-
-// CHECK:      [[i1b_33:%\d+]] = OpLoad %int %i1b
-// CHECK-NEXT: [[i1c_33:%\d+]] = OpLoad %int %i1c
-// CHECK-NEXT:        {{%\d+}} = OpAtomicCompareExchange %int %i1 %uint_1 %uint_0 %uint_0 [[i1c_33]] [[i1b_33]]
-  InterlockedCompareStore(i1, i1b, i1c);
-
-// CHECK:      [[ace34:%\d+]] = OpAtomicCompareExchange %uint %u1 %uint_1 %uint_0 %uint_0 %uint_20 %uint_15
-// CHECK-NEXT:                  OpStore %out_u1 [[ace34]]
-  InterlockedCompareExchange(u1, 15, 20, out_u1);
-
-// CHECK:      [[i1c_35:%\d+]] = OpLoad %int %i1c
-// CHECK-NEXT:  [[ace35:%\d+]] = OpAtomicExchange %int %i1 %uint_1 %uint_0 [[i1c_35]]
-// CHECK-NEXT:                   OpStore %out_i1 [[ace35]]
-  InterlockedExchange(i1, i1c, out_i1);
 }
 

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -774,8 +774,11 @@ TEST_F(FileTest, IntrinsicsGroupMemoryBarrierWithGroupSync) {
 TEST_F(FileTest, IntrinsicsIsFinite) {
   runFileTest("intrinsics.isfinite.hlsl");
 }
-TEST_F(FileTest, IntrinsicsInterlockedMethods) {
-  runFileTest("intrinsics.interlocked-methods.hlsl");
+TEST_F(FileTest, IntrinsicsInterlockedMethodsPS) {
+  runFileTest("intrinsics.interlocked-methods.ps.hlsl");
+}
+TEST_F(FileTest, IntrinsicsInterlockedMethodsCS) {
+  runFileTest("intrinsics.interlocked-methods.cs.hlsl");
 }
 TEST_F(FileTest, IntrinsicsIsInf) { runFileTest("intrinsics.isinf.hlsl"); }
 TEST_F(FileTest, IntrinsicsIsNan) { runFileTest("intrinsics.isnan.hlsl"); }


### PR DESCRIPTION
Interlocked*() can only be performed on int or uint typed resources
and shared memory variables.