### PR TITLE
[spirv] Emit warning for packoffset

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2349,3 +2349,7 @@ either because of no Vulkan equivalents at the moment, or because of deprecation
 * The Hull shader ``partitioning`` attribute may not have the ``pow2`` value. The compiler
   will emit an error. Other attribute values are supported and described in the
   `Hull Entry Point Attributes`_ section.
+* ``cbuffer``/``tbuffer`` member initializer: no Vulkan equivalent. The compiler
+  will emit an warning and ignore it.
+* ``:packoffset()``: Not supported right now. The compiler will emit an warning
+  and ignore it.

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T vs_6_0 -E main
+
+cbuffer MyCBuffer {
+    float4 data1;
+    float4 data2 : packoffset(c1);
+    float  data3 : packoffset(c2.y);
+}
+
+float4 main() : A {
+    return data1 + data2 + data3;
+}
+
+// CHECK: :5:20: warning: packoffset ignored since not supported
+// CHECK: :6:20: warning: packoffset ignored since not supported

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1091,6 +1091,10 @@ TEST_F(FileTest, VulkanLayoutPushConstantStd430) {
   runFileTest("vk.layout.push-constant.std430.hlsl");
 }
 
+TEST_F(FileTest, VulkanLayoutCBufferPackOffset) {
+  runFileTest("vk.layout.cbuffer.packoffset.hlsl", Expect::Warning);
+}
+
 // HS: for different Patch Constant Functions
 TEST_F(FileTest, HullShaderPCFVoid) { runFileTest("hs.pcf.void.hlsl"); }
 TEST_F(FileTest, HullShaderPCFTakesInputPatch) {


### PR DESCRIPTION
We do not support packoffset right now. Emit warning and ignore it.