### PR TITLE
[spirv] Use temporary variable for method call on static variable

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -253,7 +253,7 @@ private:
   /// Returns the <result-id> of the variable.
   uint32_t SPIRVEmitter::createTemporaryVar(QualType varType,
                                             llvm::StringRef varName,
-                                            uint32_t initValue);
+                                            const SpirvEvalInfo &initValue);
 
   /// Collects all indices (SPIR-V constant values) from consecutive MemberExprs
   /// or ArraySubscriptExprs or operator[] calls and writes into indices.

--- a/tools/clang/test/CodeGenSPIRV/oo.method.on-static-var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.method.on-static-var.hlsl
@@ -1,0 +1,20 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float val;
+
+    float getVal() { return val; }
+};
+
+static S gSVar = {4.2};
+
+float main() : A {
+// CHECK:      %temp_var_S = OpVariable %_ptr_Function_S Function
+
+// CHECK:       [[s:%\d+]] = OpLoad %S %gSVar
+// CHECK-NEXT:               OpStore %temp_var_S [[s]]
+// CHECK-NEXT:    {{%\d+}} = OpFunctionCall %float %S_getVal %temp_var_S
+// CHECK-NEXT:  [[s:%\d+]] = OpLoad %S %temp_var_S
+// CHECK-NEXT:               OpStore %gSVar [[s]]
+    return gSVar.getVal();
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -397,6 +397,9 @@ TEST_F(FileTest, ClassStaticMember) {
 TEST_F(FileTest, StaticMemberInitializer) {
   runFileTest("oo.static.member.init.hlsl");
 }
+TEST_F(FileTest, MethodCallOnStaticVar) {
+  runFileTest("oo.method.on-static-var.hlsl");
+}
 
 // For semantics
 // SV_Position, SV_ClipDistance, and SV_CullDistance are covered in


### PR DESCRIPTION
Static variables are in the Private storage class but all methods
are generated to take pointers of the Function storage class. So
to call a method on a static variable, we need first create a
temporary variable initialized with the contents of the static
variable. After the method call, we also need to write the contents
back to the static variable in case there are side effects.