### PR TITLE
[spirv] Fix array of non-matrix with -Zpr

### DIFF
--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -690,8 +690,14 @@ bool TypeTranslator::isMxNMatrix(QualType type, QualType *elemType,
 bool TypeTranslator::isRowMajorMatrix(QualType type, const Decl *decl) const {
   if (!isMxNMatrix(type) && !type->isArrayType())
     return false;
+
+  if (const auto *arrayType = astContext.getAsConstantArrayType(type))
+    if (!isMxNMatrix(arrayType->getElementType()))
+      return false;
+
   if (!decl)
     return spirvOptions.defaultRowMajor;
+
   return decl->hasAttr<HLSLRowMajorAttr>() ||
          !decl->hasAttr<HLSLColumnMajorAttr>() && spirvOptions.defaultRowMajor;
 }

--- a/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.zpr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.matrix.majorness.zpr.hlsl
@@ -21,7 +21,7 @@ cbuffer MyCBuffer {
 }
 
 struct T {
-               float    f;
+               float    f[2]; // Make sure that arrays of non-matrices work
 // CHECK: OpMemberDecorate %T 1 ColMajor
                float2x3 mat1;
 // CHECK: OpMemberDecorate %T 2 ColMajor


### PR DESCRIPTION
Previously we will return defaultRowMajor as long as the type
is an array. That will hit an assertion failure in translateType()
for arrays of non-matrices.

Also refreshed SPIRV-Tools