### PR TITLE
[spirv] Fix lvalue/rvalue handling

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -874,10 +874,6 @@ void SPIRVEmitter::doDeclStmt(const DeclStmt *declStmt) {
     doDecl(decl);
 }
 
-SpirvEvalInfo SPIRVEmitter::loadIfGLValue(const Expr *expr) {
-  return loadIfGLValue(expr, doExpr(expr));
-}
-
 } // end namespace spirv
 } // end namespace clang
 

--- a/tools/clang/lib/SPIRV/SpirvEvalInfo.h
+++ b/tools/clang/lib/SPIRV/SpirvEvalInfo.h
@@ -88,7 +88,7 @@ public:
   inline SpirvEvalInfo &setLayoutRule(LayoutRule rule);
   LayoutRule getLayoutRule() const { return layoutRule; }
 
-  inline SpirvEvalInfo &setRValue();
+  inline SpirvEvalInfo &setRValue(bool rvalue = true);
   bool isRValue() const { return isRValue_; }
 
   inline SpirvEvalInfo &setConstant();
@@ -148,8 +148,8 @@ SpirvEvalInfo &SpirvEvalInfo::setLayoutRule(LayoutRule rule) {
   return *this;
 }
 
-SpirvEvalInfo &SpirvEvalInfo::setRValue() {
-  isRValue_ = true;
+SpirvEvalInfo &SpirvEvalInfo::setRValue(bool rvalue) {
+  isRValue_ = rvalue;
   return *this;
 }
 


### PR DESCRIPTION
* Loading the pointer from an alias variable turns the evaluation
  info into lavalue again.
* loadIfGLValue() should suppress the immediate LValueToRValue
  implicit cast.