### PR TITLE
[spirv] Legalization: associated counter in structs

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -691,6 +691,14 @@ private:
   /// Note: legalization specific code
   bool tryToAssignCounterVar(const DeclaratorDecl *dstDecl,
                              const Expr *srcExpr);
+  bool tryToAssignCounterVar(const Expr *dstExpr, const Expr *srcExpr);
+
+  /// Returns the counter variable's information associated with the entity
+  /// represented by the given decl.
+  ///
+  /// This method only handles final alias structured buffers, which means
+  /// AssocCounter#1 and AssocCounter#2.
+  const CounterIdAliasPair *getFinalACSBufferCounter(const Expr *decl);
 
   /// \brief Loads numWords 32-bit unsigned integers or stores numWords 32-bit
   /// unsigned integers (based on the doStore parameter) to the given

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.struct.hlsl
@@ -1,0 +1,207 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct Bundle {
+      RWStructuredBuffer<float> rw;
+  AppendStructuredBuffer<float> append;
+ ConsumeStructuredBuffer<float> consume;
+};
+
+struct TwoBundle {
+    Bundle b1;
+    Bundle b2;
+};
+
+struct Wrapper {
+    TwoBundle b;
+};
+
+      RWStructuredBuffer<float> globalRWSBuffer;
+  AppendStructuredBuffer<float> globalASBuffer;
+ ConsumeStructuredBuffer<float> globalCSBuffer;
+
+Bundle  CreateBundle();
+Wrapper CreateWrapper();
+Wrapper ReturnWrapper(Wrapper wrapper);
+
+// Static variable
+static Bundle  staticBundle  = CreateBundle();
+static Wrapper staticWrapper = CreateWrapper();
+
+// CHECK: %counter_var_staticBundle_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticBundle_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticBundle_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_staticWrapper_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticWrapper_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticWrapper_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticWrapper_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticWrapper_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_staticWrapper_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_CreateBundle_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateBundle_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateBundle_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_CreateWrapper_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateWrapper_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateWrapper_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateWrapper_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateWrapper_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_CreateWrapper_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_localWrapper_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_localWrapper_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_localWrapper_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_localWrapper_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_localWrapper_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_localWrapper_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_wrapper_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_wrapper_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_wrapper_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_wrapper_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_wrapper_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_wrapper_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_ReturnWrapper_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_ReturnWrapper_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_ReturnWrapper_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_ReturnWrapper_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_ReturnWrapper_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_ReturnWrapper_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_b_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_b_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_b_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK: %counter_var_w_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_w_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_w_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_w_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_w_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_w_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// CHECK-LABEL: %main = OpFunction
+
+    // Assign to static variable
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_CreateBundle_0
+// CHECK-NEXT:                OpStore %counter_var_staticBundle_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_CreateBundle_1
+// CHECK-NEXT:                OpStore %counter_var_staticBundle_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_CreateBundle_2
+// CHECK-NEXT:                OpStore %counter_var_staticBundle_2 [[src]]
+
+// CHECK-LABEL: %src_main = OpFunction
+float main() : VALUE {
+    // Assign to the parameter
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_0_0
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_0_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_0_1
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_0_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_0_2
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_0_2 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_1_0
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_1_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_1_1
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_1_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticWrapper_0_1_2
+// CHECK-NEXT:                OpStore %counter_var_wrapper_0_1_2 [[src]]
+    // Make the call
+// CHECK:          {{%\d+}} = OpFunctionCall %Wrapper %ReturnWrapper %param_var_wrapper
+    // Assign to the return value
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_0_0
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_0_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_0_1
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_0_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_0_2
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_0_2 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_1_0
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_1_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_1_1
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_1_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_1_2
+// CHECK-NEXT:                OpStore %counter_var_localWrapper_0_1_2 [[src]]
+    Wrapper localWrapper = ReturnWrapper(staticWrapper);
+
+// CHECK:      [[cnt:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_0
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_int [[cnt]] %uint_0
+// CHECK-NEXT:     {{%\d+}} = OpAtomicIAdd %int [[ptr]] %uint_1 %uint_0 %int_1
+    localWrapper.b.b1.rw.IncrementCounter();
+// CHECK:      [[cnt:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_1
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_int [[cnt]] %uint_0
+// CHECK-NEXT: [[add:%\d+]] = OpAtomicIAdd %int [[ptr]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT:     {{%\d+}} = OpAccessChain %_ptr_Uniform_float {{%\d+}} %uint_0 [[add]]
+    localWrapper.b.b2.append.Append(5.0);
+
+// CHECK:      [[cnt:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_ReturnWrapper_0_0_2
+// CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_int [[cnt]] %uint_0
+// CHECK-NEXT: [[sub:%\d+]] = OpAtomicISub %int [[ptr]] %uint_1 %uint_0 %int_1
+// CHECK-NEXT: [[pre:%\d+]] = OpISub %int [[sub]] %int_1
+// CHECK-NEXT:     {{%\d+}} = OpAccessChain %_ptr_Uniform_float {{%\d+}} %uint_0 [[pre]]
+    return ReturnWrapper(staticWrapper).b.b1.consume.Consume();
+}
+
+// CHECK-LABEL: %CreateBundle = OpFunction
+Bundle CreateBundle() {
+    Bundle b;
+    // Assign to final struct fields who have associated counters
+// CHECK: OpStore %counter_var_b_0 %counter_var_globalRWSBuffer
+    b.rw      = globalRWSBuffer;
+// CHECK: OpStore %counter_var_b_1 %counter_var_globalASBuffer
+    b.append  = globalASBuffer;
+// CHECK: OpStore %counter_var_b_2 %counter_var_globalCSBuffer
+    b.consume = globalCSBuffer;
+
+    // Assign from local variable
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_b_0
+// CHECK-NEXT:                OpStore %counter_var_CreateBundle_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_b_1
+// CHECK-NEXT:                OpStore %counter_var_CreateBundle_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_b_2
+// CHECK-NEXT:                OpStore %counter_var_CreateBundle_2 [[src]]
+    return b;
+}
+
+// CHECK-LABEL: %CreateWrapper = OpFunction
+Wrapper CreateWrapper() {
+    Wrapper w;
+
+    // Assign from final struct fields who have associated counters
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticBundle_0
+// CHECK-NEXT:                OpStore %counter_var_w_0_0_0 [[src]]
+    w.b.b1.rw      = staticBundle.rw;
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticBundle_1
+// CHECK-NEXT:                OpStore %counter_var_w_0_0_1 [[src]]
+    w.b.b1.append  = staticBundle.append;
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_staticBundle_2
+// CHECK-NEXT:                OpStore %counter_var_w_0_0_2 [[src]]
+    w.b.b1.consume = staticBundle.consume;
+
+    // TODO:
+
+    // Assign to intermediate structs whose fields have associated counters
+    //w.b.b2         = staticBundle;
+
+    // Assign from intermediate structs whose fields have associated counters
+    //staticBundle   = w.b.b1;
+
+    return w;
+}
+
+// CHECK-LABEL: %ReturnWrapper = OpFunction
+Wrapper ReturnWrapper(Wrapper wrapper) {
+    // Assign from parameter
+// CHECK:      [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_0_0
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_0_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_0_1
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_0_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_0_2
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_0_2 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_1_0
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_1_0 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_1_1
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_1_1 [[src]]
+// CHECK-NEXT: [[src:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_wrapper_0_1_2
+// CHECK-NEXT:                OpStore %counter_var_ReturnWrapper_0_1_2 [[src]]
+    return wrapper;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.hlsl
@@ -84,15 +84,10 @@ float4 main() : SV_Target {
     int index = c.getT().getSBuffer2()[42];
 
 // CHECK:      [[val:%\d+]] = OpLoad %Combine %c
-// CHECK-NEXT:                OpStore %param_var_comb [[val]]
+// CHECK:                     OpStore %param_var_comb [[val]]
     return foo(c);
 }
 float4 foo(Combine comb) {
-    // TODO: add support for associated counters of struct fields
-    // comb.s.append.Append(float4(1, 2, 3, 4));
-    // float4 val = comb.s.consume.Consume();
-    // comb.t.rw[5].a = 4.2;
-
 // CHECK:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Function__ptr_Uniform_type_ByteAddressBuffer %comb %int_2
 // CHECK-NEXT: [[ptr2:%\d+]] = OpLoad %_ptr_Uniform_type_ByteAddressBuffer [[ptr1]]
 // CHECK-NEXT:  [[idx:%\d+]] = OpShiftRightLogical %uint %uint_5 %uint_2

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1005,6 +1005,10 @@ TEST_F(FileTest, SpirvLegalizationStructuredBufferCounter) {
   runFileTest("spirv.legal.sbuffer.counter.hlsl", Expect::Success,
               /*runValidation=*/true, /*relaxLogicalPointer=*/true);
 }
+TEST_F(FileTest, SpirvLegalizationStructuredBufferCounterInStruct) {
+  runFileTest("spirv.legal.sbuffer.counter.struct.hlsl", Expect::Success,
+              /*runValidation=*/true, /*relaxLogicalPointer=*/true);
+}
 TEST_F(FileTest, SpirvLegalizationStructuredBufferInStruct) {
   runFileTest("spirv.legal.sbuffer.struct.hlsl", Expect::Success,
               /*runValidation=*/true, /*relaxLogicalPointer=*/true);


### PR DESCRIPTION
For structs containing RW/Append/Consume structured buffers, to
properly track aliasing and use the correct associated counter
for each buffer after legalization, we need to create temporary
counter variables for all struct fields that are RW/Append/Consume
structured buffers and assign them accordingly if the corresponding
buffer field is updated.

Because of structs, now we have four forms an alias RW/Append/
Consume structured buffer can be in:

* 1 (AssocCounter#1). A stand-alone variable,
* 2 (AssocCounter#2). A struct field,
* 3 (AssocCounter#3). A struct containing alias fields,
* 4 (AssocCounter#4). A nested struct containing alias fields.

For AssocBuffer#3 and AssocBuffer#4, it means we need to update all
fields' associated counters.

This commit only handles the first three forms.