### PR TITLE
[spirv] Legalization: associated counters in implicit objects

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -595,8 +595,10 @@ uint32_t DeclResultIdMapper::getOrRegisterFnResultId(const FunctionDecl *fn) {
 }
 
 const CounterIdAliasPair *DeclResultIdMapper::getCounterIdAliasPair(
-    const DeclaratorDecl *decl,
-    const llvm::SmallVector<uint32_t, 4> *indices) const {
+    const DeclaratorDecl *decl, const llvm::SmallVector<uint32_t, 4> *indices) {
+  if (!decl)
+    return nullptr;
+
   if (indices) {
     // Indices are provided. Walk through the fields of the decl.
     const auto counter = fieldCounterVars.find(decl);
@@ -608,11 +610,12 @@ const CounterIdAliasPair *DeclResultIdMapper::getCounterIdAliasPair(
     if (counter != counterVars.end())
       return &counter->second;
   }
+
   return nullptr;
 }
 
 const CounterVarFields *
-DeclResultIdMapper::getCounterVarFields(const DeclaratorDecl *decl) const {
+DeclResultIdMapper::getCounterVarFields(const DeclaratorDecl *decl) {
   if (!decl)
     return nullptr;
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -283,10 +283,11 @@ public:
   uint32_t createFnParam(const ParmVarDecl *param);
 
   /// \brief Creates the counter variable associated with the given param.
-  /// This is meant to be used for forward-declared functions.
+  /// This is meant to be used for forward-declared functions and this objects
+  /// of methods.
   ///
   /// Note: legalization specific code
-  inline void createFnParamCounterVar(const ParmVarDecl *param);
+  inline void createFnParamCounterVar(const VarDecl *param);
 
   /// \brief Creates a function-scope variable in the current function and
   /// returns its <result-id>.
@@ -383,12 +384,12 @@ public:
   /// if the given decl has no associated counter variable created.
   const CounterIdAliasPair *getCounterIdAliasPair(
       const DeclaratorDecl *decl,
-      const llvm::SmallVector<uint32_t, 4> *indices = nullptr) const;
+      const llvm::SmallVector<uint32_t, 4> *indices = nullptr);
 
   /// \brief Returns all the associated counters for the given decl. The decl is
   /// expected to be a struct containing alias RW/Append/Consume structured
   /// buffers. Returns nullptr if it does not.
-  const CounterVarFields *getCounterVarFields(const DeclaratorDecl *decl) const;
+  const CounterVarFields *getCounterVarFields(const DeclaratorDecl *decl);
 
   /// \brief Returns the <type-id> for the given cbuffer, tbuffer,
   /// ConstantBuffer, TextureBuffer, or push constant block.
@@ -717,8 +718,8 @@ bool DeclResultIdMapper::isInputStorageClass(const StageVar &v) {
          spv::StorageClass::Input;
 }
 
-void DeclResultIdMapper::createFnParamCounterVar(const ParmVarDecl *param) {
-  return createCounterVarForDecl(param);
+void DeclResultIdMapper::createFnParamCounterVar(const VarDecl *param) {
+  createCounterVarForDecl(param);
 }
 
 void DeclResultIdMapper::createFieldCounterVars(const DeclaratorDecl *decl) {

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -698,7 +698,16 @@ private:
   ///
   /// This method only handles final alias structured buffers, which means
   /// AssocCounter#1 and AssocCounter#2.
-  const CounterIdAliasPair *getFinalACSBufferCounter(const Expr *decl);
+  const CounterIdAliasPair *getFinalACSBufferCounter(const Expr *expr);
+  /// This method handles AssocCounter#3 and AssocCounter#4.
+  const CounterVarFields *
+  getIntermediateACSBufferCounter(const Expr *expr,
+                                  llvm::SmallVector<uint32_t, 4> *indices);
+
+  /// Gets or creates an ImplicitParamDecl to represent the implicit object
+  /// parameter of the given method.
+  const ImplicitParamDecl *
+  getOrCreateDeclForMethodObject(const CXXMethodDecl *method);
 
   /// \brief Loads numWords 32-bit unsigned integers or stores numWords 32-bit
   /// unsigned integers (based on the doStore parameter) to the given
@@ -842,6 +851,17 @@ private:
   ///
   /// Note: legalization specific code
   bool needsLegalization;
+
+  /// Mapping from methods to the decls to represent their implicit object
+  /// parameters
+  ///
+  /// We need this map because that we need to update the associated counters on
+  /// the implicit object when invoking method calls. The ImplicitParamDecl
+  /// mapped to serves as a key to find the associated counters in
+  /// DeclResultIdMapper.
+  ///
+  /// Note: legalization specific code
+  llvm::DenseMap<const CXXMethodDecl *, const ImplicitParamDecl *> thisDecls;
 
   /// Global variables that should be initialized once at the begining of the
   /// entry function.

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
@@ -1,0 +1,114 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct Bundle {
+      RWStructuredBuffer<float> rw;
+  AppendStructuredBuffer<float> append;
+ ConsumeStructuredBuffer<float> consume;
+};
+
+// Counter variables for the this object of getCSBuffer()
+// CHECK: %counter_var_getCSBuffer_this_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getCSBuffer_this_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getCSBuffer_this_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getCSBuffer_this_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getCSBuffer_this_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getCSBuffer_this_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// Counter variables for the this object of getASBuffer()
+// CHECK: %counter_var_getASBuffer_this_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getASBuffer_this_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getASBuffer_this_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getASBuffer_this_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getASBuffer_this_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getASBuffer_this_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+// Counter variables for the this object of getRWSBuffer()
+// CHECK: %counter_var_getRWSBuffer_this_0_0_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getRWSBuffer_this_0_0_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getRWSBuffer_this_0_0_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getRWSBuffer_this_0_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getRWSBuffer_this_0_1_1 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_getRWSBuffer_this_0_1_2 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+
+struct TwoBundle {
+    Bundle b1;
+    Bundle b2;
+
+    // Checks at the end of the file
+    ConsumeStructuredBuffer<float> getCSBuffer() { return b1.consume; }
+};
+
+struct Wrapper {
+    TwoBundle b;
+
+    // Checks at the end of the file
+    AppendStructuredBuffer<float> getASBuffer() { return b.b1.append; }
+
+    // Checks at the end of the file
+    RWStructuredBuffer<float> getRWSBuffer() { return b.b2.rw; }
+};
+
+// CHECK-LABLE: %src_main = OpFunction
+float main() : VVV {
+    TwoBundle localBundle;
+    Wrapper   localWrapper;
+
+// CHECK:      [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_0_0
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_0_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_0_1
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_0_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_0_2
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_0_2 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_1_0
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_1_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_1_1
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_1_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_1_2
+// CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_1_2 [[counter]]
+// CHECK-NEXT:                    OpFunctionCall %_ptr_Uniform_type_RWStructuredBuffer_float %TwoBundle_getCSBuffer %localBundle
+    float value = localBundle.getCSBuffer().Consume();
+
+// CHECK:      [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_0
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_0_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_1
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_0_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_2
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_0_2 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_0
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_1_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_1
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_1_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_2
+// CHECK-NEXT:                    OpStore %counter_var_getASBuffer_this_0_1_2 [[counter]]
+// CHECK-NEXT:                    OpFunctionCall %_ptr_Uniform_type_RWStructuredBuffer_float %Wrapper_getASBuffer %localWrapper
+    localWrapper.getASBuffer().Append(4.2);
+
+// CHECK:      [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_0
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_0_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_1
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_0_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_0_2
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_0_2 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_0
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_1_0 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_1
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_1_1 [[counter]]
+// CHECK-NEXT: [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localWrapper_0_1_2
+// CHECK-NEXT:                    OpStore %counter_var_getRWSBuffer_this_0_1_2 [[counter]]
+// CHECK-NEXT:                    OpFunctionCall %_ptr_Uniform_type_RWStructuredBuffer_float %Wrapper_getRWSBuffer %localWrapper
+    RWStructuredBuffer<float> localRWSBuffer = localWrapper.getRWSBuffer();
+
+    return localRWSBuffer[5];
+}
+
+// CHECK-LABEL: %TwoBundle_getCSBuffer = OpFunction
+// CHECK:             [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_getCSBuffer_this_0_2
+// CHECK-NEXT:                           OpStore %counter_var_getCSBuffer [[counter]]
+
+// CHECK-LABEL: %Wrapper_getASBuffer = OpFunction
+// CHECK:           [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_getASBuffer_this_0_0_1
+// CHECK-NEXT:                         OpStore %counter_var_getASBuffer [[counter]]
+
+// CHECK-LABEL: %Wrapper_getRWSBuffer = OpFunction
+// CHECK:            [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_getRWSBuffer_this_0_1_0
+// CHECK-NEXT:                          OpStore %counter_var_getRWSBuffer [[counter]]

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1006,7 +1006,13 @@ TEST_F(FileTest, SpirvLegalizationStructuredBufferCounter) {
               /*runValidation=*/true, /*relaxLogicalPointer=*/true);
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferCounterInStruct) {
+  // Tests using struct/class having associated counters
   runFileTest("spirv.legal.sbuffer.counter.struct.hlsl", Expect::Success,
+              /*runValidation=*/true, /*relaxLogicalPointer=*/true);
+}
+TEST_F(FileTest, SpirvLegalizationStructuredBufferCounterInMethod) {
+  // Tests using methods whose enclosing struct/class having associated counters
+  runFileTest("spirv.legal.sbuffer.counter.method.hlsl", Expect::Success,
               /*runValidation=*/true, /*relaxLogicalPointer=*/true);
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferInStruct) {


### PR DESCRIPTION
An implicit object is translated into the first argument to the
method call. If the implicit object is of struct type and its
fields have associated counters, we need to assign its associated
counters accordingly like other normal arguments.

For each such method, we generate associated counters for its
implicit object. At a call site, we assign the associated counters
from the real object to the ones associated with the method implict
object.