### PR TITLE
[spirv] Add support for .GetSamplePosition()

### DIFF
--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -212,6 +212,13 @@ uint32_t ModuleBuilder::createUnaryOp(spv::Op op, uint32_t resultType,
   const uint32_t id = theContext.takeNextId();
   instBuilder.unaryOp(op, resultType, id, operand).x();
   insertPoint->appendInstruction(std::move(constructSite));
+  switch (op) {
+  case spv::Op::OpImageQuerySize:
+  case spv::Op::OpImageQueryLevels:
+  case spv::Op::OpImageQuerySamples:
+    requireCapability(spv::Capability::ImageQuery);
+    break;
+  }
   return id;
 }
 
@@ -221,6 +228,12 @@ uint32_t ModuleBuilder::createBinaryOp(spv::Op op, uint32_t resultType,
   const uint32_t id = theContext.takeNextId();
   instBuilder.binaryOp(op, resultType, id, lhs, rhs).x();
   insertPoint->appendInstruction(std::move(constructSite));
+  switch (op) {
+  case spv::Op::OpImageQueryLod:
+  case spv::Op::OpImageQuerySizeLod:
+    requireCapability(spv::Capability::ImageQuery);
+    break;
+  }
   return id;
 }
 

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -3080,7 +3080,9 @@ uint32_t SPIRVEmitter::emitGetSamplePosition(const uint32_t sampleCount,
 
     const std::string varName =
         "var.GetSamplePosition.data." + std::to_string(len);
-    return theBuilder.addFnVar(arrType, varName, val);
+    const auto var = theBuilder.addFnVar(arrType, varName);
+    theBuilder.createStore(var, val);
+    return var;
   };
 
   const uint32_t pos2Arr = createArray(pos2, 2);

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -728,6 +728,10 @@ private:
   uint32_t processRWByteAddressBufferAtomicMethods(hlsl::IntrinsicOp opcode,
                                                    const CXXMemberCallExpr *);
 
+  /// \brief Processes the GetSamplePosition intrinsic method call on a
+  /// Texture2DMS(Array).
+  uint32_t processGetSamplePosition(const CXXMemberCallExpr *);
+
   /// \brief Generates SPIR-V instructions for the .Append()/.Consume() call on
   /// the given {Append|Consume}StructuredBuffer. Returns the <result-id> of
   /// the loaded value for .Consume; returns zero for .Append().
@@ -739,6 +743,10 @@ private:
   /// \brief Generates SPIR-V instructions to end emitting the current
   /// primitive in GS.
   uint32_t processStreamOutputRestart(const CXXMemberCallExpr *expr);
+
+  /// \brief Emulates GetSamplePosition() for standard sample settings, i.e.,
+  /// with 1, 2, 4, 8, or 16 samples. Returns float2(0) for other cases.
+  uint32_t emitGetSamplePosition(uint32_t sampleCount, uint32_t sampleIndex);
 
 private:
   /// \brief Takes a vector of size 4, and returns a vector of size 1 or 2 or 3

--- a/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
@@ -43,15 +43,20 @@ Texture2DMS       <float> myTexture;
 // CHECK:     [[zero:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
 
 void main(int index : INDEX) {
-// CHECK:  %var_GetSamplePosition_data_2 = OpVariable %_ptr_Function__arr_v2float_uint_2 Function [[pos2]]
-// CHECK:  %var_GetSamplePosition_data_4 = OpVariable %_ptr_Function__arr_v2float_uint_4 Function [[pos4]]
-// CHECK:  %var_GetSamplePosition_data_8 = OpVariable %_ptr_Function__arr_v2float_uint_8 Function [[pos8]]
-// CHECK: %var_GetSamplePosition_data_16 = OpVariable %_ptr_Function__arr_v2float_uint_16 Function [[pos16]]
+// CHECK:  %var_GetSamplePosition_data_2 = OpVariable %_ptr_Function__arr_v2float_uint_2 Function
+// CHECK:  %var_GetSamplePosition_data_4 = OpVariable %_ptr_Function__arr_v2float_uint_4 Function
+// CHECK:  %var_GetSamplePosition_data_8 = OpVariable %_ptr_Function__arr_v2float_uint_8 Function
+// CHECK: %var_GetSamplePosition_data_16 = OpVariable %_ptr_Function__arr_v2float_uint_16 Function
 // CHECK:  %var_GetSamplePosition_result = OpVariable %_ptr_Function_v2float Function
 
 // CHECK:        [[tex:%\d+]] = OpLoad %type_2d_image %myTexture
 // CHECK-NEXT: [[count:%\d+]] = OpImageQuerySamples %uint [[tex]]
 // CHECK-NEXT: [[index:%\d+]] = OpLoad %int %index
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_2 %34
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_4 %47
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_8 %68
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_16 %91
+
 // CHECK-NEXT:   [[eq2:%\d+]] = OpIEqual %bool [[count]] %uint_2
 // CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge2 None
 // CHECK-NEXT:                  OpBranchConditional [[eq2]] %if_GetSamplePosition_then2 %if_GetSamplePosition_else2

--- a/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
@@ -2,8 +2,111 @@
 
 Texture2DMS       <float> myTexture;
 
-void main() {
-  float2 ret = myTexture.GetSamplePosition(2);
-}
+// CHECK:   [[pos2_0:%\d+]] = OpConstantComposite %v2float %float_0_25 %float_0_25
+// CHECK:   [[pos2_1:%\d+]] = OpConstantComposite %v2float %float_n0_25 %float_n0_25
+// CHECK:     [[pos2:%\d+]] = OpConstantComposite %_arr_v2float_uint_2 [[pos2_0]] [[pos2_1]]
 
-// CHECK: :6:26: error: no equivalent for GetSamplePosition intrinsic method in Vulkan
+// CHECK:   [[pos4_0:%\d+]] = OpConstantComposite %v2float %float_n0_125 %float_n0_375
+// CHECK:   [[pos4_1:%\d+]] = OpConstantComposite %v2float %float_0_375 %float_n0_125
+// CHECK:   [[pos4_2:%\d+]] = OpConstantComposite %v2float %float_n0_375 %float_0_125
+// CHECK:   [[pos4_3:%\d+]] = OpConstantComposite %v2float %float_0_125 %float_0_375
+// CHECK:     [[pos4:%\d+]] = OpConstantComposite %_arr_v2float_uint_4 [[pos4_0]] [[pos4_1]] [[pos4_2]] [[pos4_3]]
+
+// CHECK:   [[pos8_0:%\d+]] = OpConstantComposite %v2float %float_0_0625 %float_n0_1875
+// CHECK:   [[pos8_1:%\d+]] = OpConstantComposite %v2float %float_n0_0625 %float_0_1875
+// CHECK:   [[pos8_2:%\d+]] = OpConstantComposite %v2float %float_0_3125 %float_0_0625
+// CHECK:   [[pos8_3:%\d+]] = OpConstantComposite %v2float %float_n0_1875 %float_n0_3125
+// CHECK:   [[pos8_4:%\d+]] = OpConstantComposite %v2float %float_n0_3125 %float_0_3125
+// CHECK:   [[pos8_5:%\d+]] = OpConstantComposite %v2float %float_n0_4375 %float_n0_0625
+// CHECK:   [[pos8_6:%\d+]] = OpConstantComposite %v2float %float_0_1875 %float_0_4375
+// CHECK:   [[pos8_7:%\d+]] = OpConstantComposite %v2float %float_0_4375 %float_n0_4375
+// CHECK:     [[pos8:%\d+]] = OpConstantComposite %_arr_v2float_uint_8 [[pos8_0]] [[pos8_1]] [[pos8_2]] [[pos8_3]] [[pos8_4]] [[pos8_5]] [[pos8_6]] [[pos8_7]]
+
+// CHECK: [[pos16_00:%\d+]] = OpConstantComposite %v2float %float_0_0625 %float_0_0625
+// CHECK: [[pos16_01:%\d+]] = OpConstantComposite %v2float %float_n0_0625 %float_n0_1875
+// CHECK: [[pos16_02:%\d+]] = OpConstantComposite %v2float %float_n0_1875 %float_0_125
+// CHECK: [[pos16_03:%\d+]] = OpConstantComposite %v2float %float_0_25 %float_n0_0625
+// CHECK: [[pos16_04:%\d+]] = OpConstantComposite %v2float %float_n0_3125 %float_n0_125
+// CHECK: [[pos16_05:%\d+]] = OpConstantComposite %v2float %float_0_125 %float_0_3125
+// CHECK: [[pos16_06:%\d+]] = OpConstantComposite %v2float %float_0_3125 %float_0_1875
+// CHECK: [[pos16_07:%\d+]] = OpConstantComposite %v2float %float_0_1875 %float_n0_3125
+// CHECK: [[pos16_08:%\d+]] = OpConstantComposite %v2float %float_n0_125 %float_0_375
+// CHECK: [[pos16_09:%\d+]] = OpConstantComposite %v2float %float_0 %float_n0_4375
+// CHECK: [[pos16_10:%\d+]] = OpConstantComposite %v2float %float_n0_25 %float_n0_375
+// CHECK: [[pos16_11:%\d+]] = OpConstantComposite %v2float %float_n0_375 %float_0_25
+// CHECK: [[pos16_12:%\d+]] = OpConstantComposite %v2float %float_n0_5 %float_0
+// CHECK: [[pos16_13:%\d+]] = OpConstantComposite %v2float %float_0_4375 %float_n0_25
+// CHECK: [[pos16_14:%\d+]] = OpConstantComposite %v2float %float_0_375 %float_0_4375
+// CHECK: [[pos16_15:%\d+]] = OpConstantComposite %v2float %float_n0_4375 %float_n0_5
+// CHECK:    [[pos16:%\d+]] = OpConstantComposite %_arr_v2float_uint_16 [[pos16_00]] [[pos16_01]] [[pos16_02]] [[pos16_03]] [[pos16_04]] [[pos16_05]] [[pos16_06]] [[pos16_07]] [[pos16_08]] [[pos16_09]] [[pos16_10]] [[pos16_11]] [[pos16_12]] [[pos16_13]] [[pos16_14]] [[pos16_15]]
+
+// CHECK:     [[zero:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
+
+void main(int index : INDEX) {
+// CHECK:  %var_GetSamplePosition_data_2 = OpVariable %_ptr_Function__arr_v2float_uint_2 Function [[pos2]]
+// CHECK:  %var_GetSamplePosition_data_4 = OpVariable %_ptr_Function__arr_v2float_uint_4 Function [[pos4]]
+// CHECK:  %var_GetSamplePosition_data_8 = OpVariable %_ptr_Function__arr_v2float_uint_8 Function [[pos8]]
+// CHECK: %var_GetSamplePosition_data_16 = OpVariable %_ptr_Function__arr_v2float_uint_16 Function [[pos16]]
+// CHECK:  %var_GetSamplePosition_result = OpVariable %_ptr_Function_v2float Function
+
+// CHECK:        [[tex:%\d+]] = OpLoad %type_2d_image %myTexture
+// CHECK-NEXT: [[count:%\d+]] = OpImageQuerySamples %uint [[tex]]
+// CHECK-NEXT: [[index:%\d+]] = OpLoad %int %index
+// CHECK-NEXT:   [[eq2:%\d+]] = OpIEqual %bool [[count]] %uint_2
+// CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge2 None
+// CHECK-NEXT:                  OpBranchConditional [[eq2]] %if_GetSamplePosition_then2 %if_GetSamplePosition_else2
+
+// CHECK-NEXT: %if_GetSamplePosition_then2 = OpLabel
+// CHECK-NEXT:    [[ac:%\d+]] = OpAccessChain %_ptr_Function_v2float %var_GetSamplePosition_data_2 [[index]]
+// CHECK-NEXT:   [[val:%\d+]] = OpLoad %v2float [[ac]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_result [[val]]
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge2
+
+// CHECK-NEXT: %if_GetSamplePosition_else2 = OpLabel
+// CHECK-NEXT:   [[eq4:%\d+]] = OpIEqual %bool [[count]] %uint_4
+// CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge4 None
+// CHECK-NEXT:                  OpBranchConditional [[eq4]] %if_GetSamplePosition_then4 %if_GetSamplePosition_else4
+
+// CHECK-NEXT: %if_GetSamplePosition_then4 = OpLabel
+// CHECK-NEXT:    [[ac:%\d+]] = OpAccessChain %_ptr_Function_v2float %var_GetSamplePosition_data_4 [[index]]
+// CHECK-NEXT:   [[val:%\d+]] = OpLoad %v2float [[ac]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_result [[val]]
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge4
+
+// CHECK-NEXT: %if_GetSamplePosition_else4 = OpLabel
+// CHECK-NEXT:   [[eq8:%\d+]] = OpIEqual %bool [[count]] %uint_8
+// CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge8 None
+// CHECK-NEXT:                  OpBranchConditional [[eq8]] %if_GetSamplePosition_then8 %if_GetSamplePosition_else8
+
+// CHECK-NEXT: %if_GetSamplePosition_then8 = OpLabel
+// CHECK-NEXT:    [[ac:%\d+]] = OpAccessChain %_ptr_Function_v2float %var_GetSamplePosition_data_8 [[index]]
+// CHECK-NEXT:   [[val:%\d+]] = OpLoad %v2float [[ac]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_result [[val]]
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge8
+
+// CHECK-NEXT: %if_GetSamplePosition_else8 = OpLabel
+// CHECK-NEXT:  [[eq16:%\d+]] = OpIEqual %bool [[count]] %uint_16
+// CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge16 None
+// CHECK-NEXT:                  OpBranchConditional [[eq16]] %if_GetSamplePosition_then16 %if_GetSamplePosition_else16
+
+// CHECK-NEXT: %if_GetSamplePosition_then16 = OpLabel
+// CHECK-NEXT:    [[ac:%\d+]] = OpAccessChain %_ptr_Function_v2float %var_GetSamplePosition_data_16 [[index]]
+// CHECK-NEXT:   [[val:%\d+]] = OpLoad %v2float [[ac]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_result [[val]]
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge16
+
+// CHECK-NEXT: %if_GetSamplePosition_else16 = OpLabel
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_result [[zero]]
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge16
+
+// CHECK-NEXT: %if_GetSamplePosition_merge16 = OpLabel
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge8
+// CHECK-NEXT: %if_GetSamplePosition_merge8 = OpLabel
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge4
+// CHECK-NEXT: %if_GetSamplePosition_merge4 = OpLabel
+// CHECK-NEXT:                  OpBranch %if_GetSamplePosition_merge2
+// CHECK-NEXT: %if_GetSamplePosition_merge2 = OpLabel
+// CHECK-NEXT:   [[val:%\d+]] = OpLoad %v2float %var_GetSamplePosition_result
+// CHECK-NEXT:                  OpStore %ret [[val]]
+  float2 ret = myTexture.GetSamplePosition(index);
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.get-sample-position.hlsl
@@ -52,10 +52,10 @@ void main(int index : INDEX) {
 // CHECK:        [[tex:%\d+]] = OpLoad %type_2d_image %myTexture
 // CHECK-NEXT: [[count:%\d+]] = OpImageQuerySamples %uint [[tex]]
 // CHECK-NEXT: [[index:%\d+]] = OpLoad %int %index
-// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_2 %34
-// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_4 %47
-// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_8 %68
-// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_16 %91
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_2 [[pos2]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_4 [[pos4]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_8 [[pos8]]
+// CHECK-NEXT:                  OpStore %var_GetSamplePosition_data_16 [[pos16]]
 
 // CHECK-NEXT:   [[eq2:%\d+]] = OpIEqual %bool [[count]] %uint_2
 // CHECK-NEXT:                  OpSelectionMerge %if_GetSamplePosition_merge2 None

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -592,7 +592,7 @@ TEST_F(FileTest, TextureGetDimensions) {
   runFileTest("texture.get-dimensions.hlsl");
 }
 TEST_F(FileTest, TextureGetSamplePosition) {
-  runFileTest("texture.get-sample-position.hlsl", Expect::Failure);
+  runFileTest("texture.get-sample-position.hlsl");
 }
 TEST_F(FileTest, TextureCalculateLevelOfDetail) {
   runFileTest("texture.calculate-lod.hlsl");


### PR DESCRIPTION
This only supports .GetSamplePosition() for standard sample
positions, i.e., sample count is 1, 2, 4, 8, or 16. For other
cases, the method will just return float2(0, 0).