### PR TITLE
[spirv] Add initial support for specialization constant

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -176,6 +176,18 @@ annotated with the ``[[vk::push_constant]]`` attribute.
 Please note as per the requirements of Vulkan, "there must be no more than one
 push constant block statically used per shader entry point."
 
+Specialization constants
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+To use Vulkan specialization constants, annotate global constants with the
+``[[vk::constant_id(X)]]`` attribute. For example,
+
+.. code:: hlsl
+
+  [[vk::constant_id(1)]] const bool  specConstBool  = true;
+  [[vk::constant_id(2)]] const int   specConstInt   = 42;
+  [[vk::constant_id(3)]] const float specConstFloat = 1.5;
+
 Builtin variables
 ~~~~~~~~~~~~~~~~~
 
@@ -209,6 +221,8 @@ The namespace ``vk`` will be used for all Vulkan attributes:
 - ``push_constant``: For marking a variable as the push constant block. Allowed
   on global variables of struct type. At most one variable can be marked as
   ``push_constant`` in a shader.
+- ``constant_id``: For marking a global constant as a specialization constant.
+  Allowed on global variables of boolean/integer/float types.
 - ``builtin("X")``: For specifying an entity should be translated into a certain
   Vulkan builtin variable. Allowed on function parameters, function returns,
   and struct fields.

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -936,6 +936,17 @@ def VKInputAttachmentIndex : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+// Global variables that are of scalar type
+def ScalarGlobalVar : SubsetSubject<Var, [{S->hasGlobalStorage() && S->getType()->isScalarType()}]>;
+
+def VKConstantId : InheritableAttr {
+  let Spellings = [CXX11<"vk", "constant_id">];
+  let Subjects = SubjectList<[ScalarGlobalVar], ErrorDiag, "ExpectedScalarGlobalVar">;
+  let Args = [IntArgument<"SpecConstId">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 // SPIRV Change Ends
 
 def C11NoReturn : InheritableAttr {

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2327,6 +2327,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "interface or protocol declarations|kernel functions|"
   // SPIRV Change Starts
   "fields|"
+  "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"

--- a/tools/clang/include/clang/SPIRV/InstBuilder.h
+++ b/tools/clang/include/clang/SPIRV/InstBuilder.h
@@ -882,10 +882,15 @@ public:
                        uint32_t operand);
   InstBuilder &binaryOp(spv::Op op, uint32_t result_type, uint32_t result_id,
                         uint32_t lhs, uint32_t rhs);
+  InstBuilder &specConstantBinaryOp(spv::Op op, uint32_t result_type,
+                                    uint32_t result_id, uint32_t lhs,
+                                    uint32_t rhs);
 
   // Methods for building constants.
   InstBuilder &opConstant(uint32_t result_type, uint32_t result_id,
                           uint32_t value);
+  InstBuilder &opSpecConstant(uint32_t result_type, uint32_t result_id,
+                              uint32_t value);
 
   // All-in-one method for creating different types of OpImageSample*.
   InstBuilder &

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -151,6 +151,8 @@ public:
   /// the <result-id> for the result.
   uint32_t createBinaryOp(spv::Op op, uint32_t resultType, uint32_t lhs,
                           uint32_t rhs);
+  uint32_t createSpecConstantBinaryOp(spv::Op op, uint32_t resultType,
+                                      uint32_t lhs, uint32_t rhs);
 
   /// \brief Creates an atomic instruction with the given parameters.
   /// Returns the <result-id> for the result.
@@ -357,6 +359,9 @@ public:
   void decorateDSetBinding(uint32_t targetId, uint32_t setNumber,
                            uint32_t bindingNumber);
 
+  /// \brief Decorates the given target <result-id> with the given SpecId.
+  void decorateSpecId(uint32_t targetId, uint32_t specId);
+
   /// \brief Decorates the given target <result-id> with the given decoration
   /// (without additional parameters).
   void decorate(uint32_t targetId, spv::Decoration);
@@ -400,15 +405,15 @@ public:
   uint32_t getSparseResidencyStructType(uint32_t type);
 
   // === Constant ===
-  uint32_t getConstantBool(bool value);
+  uint32_t getConstantBool(bool value, bool isSpecConst = false);
   uint32_t getConstantInt16(int16_t value);
-  uint32_t getConstantInt32(int32_t value);
+  uint32_t getConstantInt32(int32_t value, bool isSpecConst = false);
   uint32_t getConstantInt64(int64_t value);
   uint32_t getConstantUint16(uint16_t value);
-  uint32_t getConstantUint32(uint32_t value);
+  uint32_t getConstantUint32(uint32_t value, bool isSpecConst = false);
   uint32_t getConstantUint64(uint64_t value);
   uint32_t getConstantFloat16(int16_t value);
-  uint32_t getConstantFloat32(float value);
+  uint32_t getConstantFloat32(float value, bool isSpecConst = false);
   uint32_t getConstantFloat64(double value);
   uint32_t getConstantComposite(uint32_t typeId,
                                 llvm::ArrayRef<uint32_t> constituents);

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -857,6 +857,7 @@ enum AttributeDeclKind {
   ExpectedKernelFunction
   // SPIRV Change Begins
   ,ExpectedField
+  ,ExpectedScalarGlobalVar
   ,ExpectedStructGlobalVar
   ,ExpectedGlobalVarOrCTBuffer
   ,ExpectedCounterStructuredBuffer

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -283,7 +283,7 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
   return nullptr;
 }
 
-SpirvEvalInfo DeclResultIdMapper::getDeclResultId(const ValueDecl *decl,
+SpirvEvalInfo DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
                                                   bool checkRegistered) {
   if (const auto *info = getDeclSpirvInfo(decl))
     if (info->indexInCTBuffer >= 0) {
@@ -624,6 +624,11 @@ DeclResultIdMapper::getCounterVarFields(const DeclaratorDecl *decl) {
     return &found->second;
 
   return nullptr;
+}
+
+void DeclResultIdMapper::registerSpecConstant(const VarDecl *decl,
+                                              uint32_t specConstant) {
+  astDecls[decl].info.setResultId(specConstant).setRValue().setSpecConstant();
 }
 
 void DeclResultIdMapper::createCounterVar(

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -369,13 +369,17 @@ public:
   ///
   /// This method will emit a fatal error if checkRegistered is true and the
   /// decl is not registered.
-  SpirvEvalInfo getDeclResultId(const ValueDecl *decl,
+  SpirvEvalInfo getDeclEvalInfo(const ValueDecl *decl,
                                 bool checkRegistered = true);
 
   /// \brief Returns the <result-id> for the given function if already
   /// registered; otherwise, treats the given function as a normal decl and
   /// returns a newly assigned <result-id> for it.
   uint32_t getOrRegisterFnResultId(const FunctionDecl *fn);
+
+  /// Registers that the given decl should be translated into the given spec
+  /// constant.
+  void registerSpecConstant(const VarDecl *decl, uint32_t specConstant);
 
   /// \brief Returns the associated counter's (<result-id>, is-alias-or-not)
   /// pair for the given {RW|Append|Consume}StructuredBuffer variable.

--- a/tools/clang/lib/SPIRV/InstBuilderManual.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderManual.cpp
@@ -64,6 +64,27 @@ InstBuilder &InstBuilder::binaryOp(spv::Op op, uint32_t result_type,
   return *this;
 }
 
+InstBuilder &InstBuilder::specConstantBinaryOp(spv::Op op, uint32_t result_type,
+                                               uint32_t result_id, uint32_t lhs,
+                                               uint32_t rhs) {
+  if (!TheInst.empty()) {
+    TheStatus = Status::NestedInst;
+    return *this;
+  }
+
+  // TODO: check op range
+
+  TheInst.reserve(6);
+  TheInst.emplace_back(static_cast<uint32_t>(spv::Op::OpSpecConstantOp));
+  TheInst.emplace_back(result_type);
+  TheInst.emplace_back(result_id);
+  TheInst.emplace_back(static_cast<uint32_t>(op));
+  TheInst.emplace_back(lhs);
+  TheInst.emplace_back(rhs);
+
+  return *this;
+}
+
 InstBuilder &InstBuilder::opConstant(uint32_t resultType, uint32_t resultId,
                                      uint32_t value) {
   if (!TheInst.empty()) {
@@ -130,6 +151,22 @@ InstBuilder &InstBuilder::opImageFetchRead(
     const auto &val = image_operands.getValue();
     encodeImageOperands(val);
   }
+
+  return *this;
+}
+
+InstBuilder &InstBuilder::opSpecConstant(uint32_t resultType, uint32_t resultId,
+                                         uint32_t value) {
+  if (!TheInst.empty()) {
+    TheStatus = Status::NestedInst;
+    return *this;
+  }
+
+  TheInst.reserve(4);
+  TheInst.emplace_back(static_cast<uint32_t>(spv::Op::OpSpecConstant));
+  TheInst.emplace_back(resultType);
+  TheInst.emplace_back(resultId);
+  TheInst.emplace_back(value);
 
   return *this;
 }

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -11,6 +11,7 @@
 
 #include "TypeTranslator.h"
 #include "spirv/unified1//spirv.hpp11"
+#include "clang/SPIRV/BitwiseCast.h"
 #include "clang/SPIRV/InstBuilder.h"
 #include "llvm/llvm_assert/assert.h"
 
@@ -234,6 +235,15 @@ uint32_t ModuleBuilder::createBinaryOp(spv::Op op, uint32_t resultType,
     requireCapability(spv::Capability::ImageQuery);
     break;
   }
+  return id;
+}
+
+uint32_t ModuleBuilder::createSpecConstantBinaryOp(spv::Op op,
+                                                   uint32_t resultType,
+                                                   uint32_t lhs, uint32_t rhs) {
+  const uint32_t id = theContext.takeNextId();
+  instBuilder.specConstantBinaryOp(op, resultType, id, lhs, rhs).x();
+  theModule.addVariable(std::move(constructSite));
   return id;
 }
 
@@ -768,6 +778,11 @@ void ModuleBuilder::decorateLocation(uint32_t targetId, uint32_t location) {
   theModule.addDecoration(d, targetId);
 }
 
+void ModuleBuilder::decorateSpecId(uint32_t targetId, uint32_t specId) {
+  const Decoration *d = Decoration::getSpecId(theContext, specId);
+  theModule.addDecoration(d, targetId);
+}
+
 void ModuleBuilder::decorate(uint32_t targetId, spv::Decoration decoration) {
   const Decoration *d = nullptr;
   switch (decoration) {
@@ -1063,7 +1078,19 @@ uint32_t ModuleBuilder::getByteAddressBufferType(bool isRW) {
   return typeId;
 }
 
-uint32_t ModuleBuilder::getConstantBool(bool value) {
+uint32_t ModuleBuilder::getConstantBool(bool value, bool isSpecConst) {
+  if (isSpecConst) {
+    const uint32_t constId = theContext.takeNextId();
+    if (value) {
+      instBuilder.opSpecConstantTrue(getBoolType(), constId).x();
+    } else {
+      instBuilder.opSpecConstantFalse(getBoolType(), constId).x();
+    }
+
+    theModule.addVariable(std::move(constructSite));
+    return constId;
+  }
+
   const uint32_t typeId = getBoolType();
   const Constant *constant = value ? Constant::getTrue(theContext, typeId)
                                    : Constant::getFalse(theContext, typeId);
@@ -1084,17 +1111,40 @@ uint32_t ModuleBuilder::getConstantBool(bool value) {
     return constId;                                                            \
   }
 
+#define IMPL_GET_PRIMITIVE_CONST_SPEC_CONST(builderTy, cppTy)                  \
+                                                                               \
+  uint32_t ModuleBuilder::getConstant##builderTy(cppTy value,                  \
+                                                 bool isSpecConst) {           \
+    if (isSpecConst) {                                                         \
+      const uint32_t constId = theContext.takeNextId();                        \
+      instBuilder                                                              \
+          .opSpecConstant(get##builderTy##Type(), constId,                     \
+                          cast::BitwiseCast<uint32_t>(value))                  \
+          .x();                                                                \
+      theModule.addVariable(std::move(constructSite));                         \
+      return constId;                                                          \
+    }                                                                          \
+                                                                               \
+    const uint32_t typeId = get##builderTy##Type();                            \
+    const Constant *constant =                                                 \
+        Constant::get##builderTy(theContext, typeId, value);                   \
+    const uint32_t constId = theContext.getResultIdForConstant(constant);      \
+    theModule.addConstant(constant, constId);                                  \
+    return constId;                                                            \
+  }
+
 IMPL_GET_PRIMITIVE_CONST(Int16, int16_t)
-IMPL_GET_PRIMITIVE_CONST(Int32, int32_t)
+IMPL_GET_PRIMITIVE_CONST_SPEC_CONST(Int32, int32_t)
 IMPL_GET_PRIMITIVE_CONST(Uint16, uint16_t)
-IMPL_GET_PRIMITIVE_CONST(Uint32, uint32_t)
+IMPL_GET_PRIMITIVE_CONST_SPEC_CONST(Uint32, uint32_t)
 IMPL_GET_PRIMITIVE_CONST(Float16, int16_t)
-IMPL_GET_PRIMITIVE_CONST(Float32, float)
+IMPL_GET_PRIMITIVE_CONST_SPEC_CONST(Float32, float)
 IMPL_GET_PRIMITIVE_CONST(Float64, double)
 IMPL_GET_PRIMITIVE_CONST(Int64, int64_t)
 IMPL_GET_PRIMITIVE_CONST(Uint64, uint64_t)
 
-#undef IMPL_GET_PRIMITIVE_VALUE
+#undef IMPL_GET_PRIMITIVE_CONST
+#undef IMPL_GET_PRIMITIVE_CONST_SPEC_CONST
 
 uint32_t
 ModuleBuilder::getConstantComposite(uint32_t typeId,

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -7578,7 +7578,8 @@ uint32_t SPIRVEmitter::translateAPFloat(llvm::APFloat floatValue,
       emitError(
           "evaluating float literal %0 at a lower bitwidth loses information",
           {})
-          // Converting from 32/64-bit to 16-bit won't lose information.
+          // Converting from 16bit to 32/64-bit won't lose information.
+          // So only 32/64-bit values can reach here.
           << std::to_string(valueBitwidth == 32
                                 ? originalValue.convertToFloat()
                                 : originalValue.convertToDouble());

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -243,6 +243,9 @@ private:
       llvm::function_ref<uint32_t(uint32_t, uint32_t, uint32_t)>
           actOnEachVector);
 
+  /// Translates the given varDecl into a spec constant.
+  void createSpecConstant(const VarDecl *varDecl);
+
   /// Generates the necessary instructions for conducting the given binary
   /// operation on lhs and rhs.
   ///
@@ -844,6 +847,10 @@ private:
   /// The source location of a push constant block we have previously seen.
   /// Invalid means no push constant blocks defined thus far.
   SourceLocation seenPushConstantAt;
+
+  /// Indicates whether the current emitter is in specialization constant mode:
+  /// all 32-bit scalar constants will be translated into OpSpecConstant.
+  bool isSpecConstantMode;
 
   /// Whether the translated SPIR-V binary needs legalization.
   ///

--- a/tools/clang/lib/SPIRV/SpirvEvalInfo.h
+++ b/tools/clang/lib/SPIRV/SpirvEvalInfo.h
@@ -94,6 +94,9 @@ public:
   inline SpirvEvalInfo &setConstant();
   bool isConstant() const { return isConstant_; }
 
+  inline SpirvEvalInfo &setSpecConstant();
+  bool isSpecConstant() const { return isSpecConstant_; }
+
   inline SpirvEvalInfo &setRelaxedPrecision();
   bool isRelaxedPrecision() const { return isRelaxedPrecision_; }
 
@@ -114,6 +117,7 @@ private:
 
   bool isRValue_;
   bool isConstant_;
+  bool isSpecConstant_;
   bool isRelaxedPrecision_;
 };
 
@@ -155,6 +159,12 @@ SpirvEvalInfo &SpirvEvalInfo::setRValue(bool rvalue) {
 
 SpirvEvalInfo &SpirvEvalInfo::setConstant() {
   isConstant_ = true;
+  return *this;
+}
+
+SpirvEvalInfo &SpirvEvalInfo::setSpecConstant() {
+  // Specialization constant is also a kind of constant.
+  isConstant_ = isSpecConstant_ = true;
   return *this;
 }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10470,6 +10470,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
         A.getRange(), S.Context, ValidateAttributeIntArg(S, A),
         A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKConstantId:
+    declAttr = ::new (S.Context) VKConstantIdAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.hlsl
@@ -1,0 +1,29 @@
+// Run: %dxc -T vs_6_0 -E main
+
+[[vk::constant_id(0)]]
+const bool sc0 = true;
+
+[[vk::constant_id(1)]]
+const bool sc1 = sc0; // error
+
+[[vk::constant_id(2)]]
+const double sc2 = 42; // error
+
+[[vk::constant_id(3)]]
+const int sc3; // error
+
+[[vk::constant_id(4)]]
+const int sc4 = sc3 + sc3; // error
+
+[[vk::constant_id(5)]]
+static const int sc5 = 1; // error
+
+float main() : A {
+    return 1.0;
+}
+
+// CHECK:  :7:18: error: unsupported specialization constant initializer
+// CHECK:  :10:1: error: unsupported specialization constant type
+// CHECK: :13:11: error: missing default value for specialization constant
+// CHECK: :16:17: error: unsupported specialization constant initializer
+// CHECK: :19:18: error: specialization constant must be externally visible

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.init.hlsl
@@ -1,0 +1,63 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate [[b0:%\d+]] SpecId 0
+// CHECK: OpDecorate [[b1:%\d+]] SpecId 1
+// CHECK: OpDecorate [[b2:%\d+]] SpecId 2
+
+// CHECK: OpDecorate [[i0:%\d+]] SpecId 10
+// CHECK: OpDecorate [[i1:%\d+]] SpecId 11
+// CHECK: OpDecorate [[i2:%\d+]] SpecId 12
+// CHECK: OpDecorate [[i3:%\d+]] SpecId 13
+
+// CHECK: OpDecorate [[u0:%\d+]] SpecId 20
+
+// CHECK: OpDecorate [[f0:%\d+]] SpecId 30
+// CHECK: OpDecorate [[f1:%\d+]] SpecId 31
+// CHECK: OpDecorate [[f2:%\d+]] SpecId 32
+// CHECK: OpDecorate [[f3:%\d+]] SpecId 33
+
+// CHECK: [[b0]] = OpSpecConstantTrue %bool
+[[vk::constant_id(0)]]
+bool b0 = true;
+// CHECK: [[b1]] = OpSpecConstantFalse %bool
+[[vk::constant_id(1)]]
+bool b1 = 0;
+// CHECK: [[b2]] = OpSpecConstantTrue %bool
+[[vk::constant_id(2)]]
+bool b2 = 1.5;
+
+
+// CHECK:  [[i0]] = OpSpecConstant %int 42
+[[vk::constant_id(10)]]
+int i0 = 42;
+// CHECK:  [[i1]] = OpSpecConstant %int -42
+[[vk::constant_id(11)]]
+int i1 = -42;
+// CHECK:  [[i2]] = OpSpecConstant %int 1
+[[vk::constant_id(12)]]
+int i2 = (true);
+// CHECK:  [[i3]] = OpSpecConstant %int 2
+[[vk::constant_id(13)]]
+int i3 = 2.5;
+
+// CHECK: [[u0]] = OpSpecConstant %uint 56
+[[vk::constant_id(20)]]
+uint uintConst1 = 56;
+
+// CHECK: [[f0]] = OpSpecConstant %float 4.2
+[[vk::constant_id(30)]]
+float f0 = (4.2);
+// CHECK: [[f1]] = OpSpecConstant %float -4.2
+[[vk::constant_id(31)]]
+float f1 = -4.2;
+// CHECK: [[f2]] = OpSpecConstant %float 1
+[[vk::constant_id(32)]]
+float f2 = true;
+// CHECK: [[f3]] = OpSpecConstant %float 20
+[[vk::constant_id(33)]]
+float f3 = 20;
+
+
+float main() : A {
+    return 1.0;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.usage.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.usage.hlsl
@@ -1,0 +1,24 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate [[sc:%\d+]] SpecId 10
+[[vk::constant_id(10)]]
+// CHECK: [[sc]] = OpSpecConstant %int 12
+const int specConst = 12;
+
+// TODO: The frontend parsing hits assertion failures saying cannot evaluating
+// as constant int for the following usages.
+/*
+cbuffer Data {
+    float4 pos[specConst];
+    float4 tex[specConst + 5];
+};
+*/
+
+// CHECK: [[add:%\d+]] = OpSpecConstantOp %int IAdd [[sc]] %int_3
+static const int val = specConst + 3;
+
+// CHECK-LABEL:  %main = OpFunction
+// CHECK:                OpStore %val [[add]]
+void main() {
+
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1115,6 +1115,16 @@ TEST_F(FileTest, VulkanMultiplePushConstant) {
   runFileTest("vk.push-constant.multiple.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, VulkanSpecConstantInit) {
+  runFileTest("vk.spec-constant.init.hlsl");
+}
+TEST_F(FileTest, VulkanSpecConstantUsage) {
+  runFileTest("vk.spec-constant.usage.hlsl");
+}
+TEST_F(FileTest, VulkanSpecConstantError) {
+  runFileTest("vk.spec-constant.error.hlsl", Expect::Failure);
+}
+
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");
 }


### PR DESCRIPTION
This commit add support for generating OpSpecConstant* instructions
with SpecId decorations. Spec constants are only allowed to be of
scalar boolean/integer/float types. Using spec constant as the array
size does not work at the moment.