### PR TITLE
Fixes #823 - Compile crashes if pSourceName if nullptr/empty

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -309,6 +309,7 @@ public:
     CComPtr<AbstractMemoryStream> pOutputStream;
     CHeapPtr<wchar_t> DebugBlobName;
     DxcEtw_DXCompilerCompile_Start();
+    pSourceName = (pSourceName && *pSourceName) ? pSourceName : L"hlsl.hlsl"; // declared optional, so pick a default
     DxcThreadMalloc TM(m_pMalloc);
     IFC(hlsl::DxcGetBlobAsUtf8(pSource, &utf8Source));
 


### PR DESCRIPTION
Code had a (reasonable) assumption that sources have names, but the
entry point wasn't verifying that. For compat with prior compilers and
the annotation, we choose to support it. Unlikely other implementations,
the name is a simple hard-coded one, instead of varying, to allow for
easier deduping when the output is checked (name is in debug section).