### PR TITLE
[spirv] Remove spec constants from Constant class

### DIFF
--- a/tools/clang/include/clang/SPIRV/Structure.h
+++ b/tools/clang/include/clang/SPIRV/Structure.h
@@ -518,9 +518,6 @@ void SPIRVModule::addType(const Type *type, uint32_t resultId) {
 
 void SPIRVModule::addConstant(const Constant *constant, uint32_t resultId) {
   constants.insert(std::make_pair(constant, resultId));
-  for (const Decoration *d : constant->getDecorations()) {
-    addDecoration(d, resultId);
-  }
 };
 
 void SPIRVModule::addVariable(Instruction &&var) {

--- a/tools/clang/lib/SPIRV/Constant.cpp
+++ b/tools/clang/lib/SPIRV/Constant.cpp
@@ -40,54 +40,49 @@ uint32_t signExtendTo32Bits(int16_t value) {
   }
   return clang::spirv::cast::BitwiseCast<uint32_t, two16Bits>(result);
 }
-}
+} // namespace
 
 namespace clang {
 namespace spirv {
 
-Constant::Constant(spv::Op op, uint32_t type, llvm::ArrayRef<uint32_t> arg,
-                   DecorationSet decs)
-    : opcode(op), typeId(type), args(arg) {
-  decorations = llvm::SetVector<const Decoration *>(decs.begin(), decs.end());
-}
+Constant::Constant(spv::Op op, uint32_t type, llvm::ArrayRef<uint32_t> arg)
+    : opcode(op), typeId(type), args(arg.begin(), arg.end()) {}
 
 const Constant *Constant::getUniqueConstant(SPIRVContext &context,
                                             const Constant &c) {
   return context.registerConstant(c);
 }
 
-const Constant *Constant::getTrue(SPIRVContext &ctx, uint32_t type_id,
-                                  DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpConstantTrue, type_id, {}, dec);
+const Constant *Constant::getTrue(SPIRVContext &ctx, uint32_t type_id) {
+  Constant c = Constant(spv::Op::OpConstantTrue, type_id, {});
   return getUniqueConstant(ctx, c);
 }
 
-const Constant *Constant::getFalse(SPIRVContext &ctx, uint32_t type_id,
-                                   DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpConstantFalse, type_id, {}, dec);
+const Constant *Constant::getFalse(SPIRVContext &ctx, uint32_t type_id) {
+  Constant c = Constant(spv::Op::OpConstantFalse, type_id, {});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getFloat16(SPIRVContext &ctx, uint32_t type_id,
-                                     int16_t value, DecorationSet dec) {
+                                     int16_t value) {
   // According to the SPIR-V Spec:
   // When the type's bit width is less than 32-bits, the literal's value appears
   // in the low-order bits of the word, and the high-order bits must be 0 for a
   // floating-point type.
-  Constant c = Constant(spv::Op::OpConstant, type_id,
-                        {zeroExtendTo32Bits(value)}, dec);
+  Constant c =
+      Constant(spv::Op::OpConstant, type_id, {zeroExtendTo32Bits(value)});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getFloat32(SPIRVContext &ctx, uint32_t type_id,
-                                     float value, DecorationSet dec) {
+                                     float value) {
   Constant c = Constant(spv::Op::OpConstant, type_id,
-                        {cast::BitwiseCast<uint32_t, float>(value)}, dec);
+                        {cast::BitwiseCast<uint32_t, float>(value)});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getFloat64(SPIRVContext &ctx, uint32_t type_id,
-                                     double value, DecorationSet dec) {
+                                     double value) {
   // TODO: The ordering of the 2 words depends on the endian-ness of the host
   // machine.
   struct wideFloat {
@@ -96,136 +91,88 @@ const Constant *Constant::getFloat64(SPIRVContext &ctx, uint32_t type_id,
   };
   wideFloat words = cast::BitwiseCast<wideFloat, double>(value);
   Constant c =
-      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1}, dec);
+      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getUint16(SPIRVContext &ctx, uint32_t type_id,
-                                    uint16_t value, DecorationSet dec) {
+                                    uint16_t value) {
   // According to the SPIR-V Spec:
   // When the type's bit width is less than 32-bits, the literal's value appears
   // in the low-order bits of the word, and the high-order bits must be 0 for an
   // integer type with Signedness of 0.
-  Constant c = Constant(spv::Op::OpConstant, type_id,
-                        {zeroExtendTo32Bits(value)}, dec);
+  Constant c =
+      Constant(spv::Op::OpConstant, type_id, {zeroExtendTo32Bits(value)});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getUint32(SPIRVContext &ctx, uint32_t type_id,
-                                    uint32_t value, DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpConstant, type_id, {value}, dec);
+                                    uint32_t value) {
+  Constant c = Constant(spv::Op::OpConstant, type_id, {value});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getUint64(SPIRVContext &ctx, uint32_t type_id,
-                                    uint64_t value, DecorationSet dec) {
+                                    uint64_t value) {
   struct wideInt {
     uint32_t word0;
     uint32_t word1;
   };
   wideInt words = cast::BitwiseCast<wideInt, uint64_t>(value);
   Constant c =
-      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1}, dec);
+      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getInt16(SPIRVContext &ctx, uint32_t type_id,
-                                    int16_t value, DecorationSet dec) {
+                                   int16_t value) {
   // According to the SPIR-V Spec:
   // When the type's bit width is less than 32-bits, the literal's value appears
   // in the low-order bits of the word, and the high-order bits must be
   // sign-extended for integers with Signedness of 1.
-  Constant c = Constant(spv::Op::OpConstant, type_id,
-                        {signExtendTo32Bits(value)}, dec);
+  Constant c =
+      Constant(spv::Op::OpConstant, type_id, {signExtendTo32Bits(value)});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getInt32(SPIRVContext &ctx, uint32_t type_id,
-                                   int32_t value, DecorationSet dec) {
+                                   int32_t value) {
   Constant c = Constant(spv::Op::OpConstant, type_id,
-                        {cast::BitwiseCast<uint32_t, int32_t>(value)}, dec);
+                        {cast::BitwiseCast<uint32_t, int32_t>(value)});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getInt64(SPIRVContext &ctx, uint32_t type_id,
-                                   int64_t value, DecorationSet dec) {
+                                   int64_t value) {
   struct wideInt {
     uint32_t word0;
     uint32_t word1;
   };
   wideInt words = cast::BitwiseCast<wideInt, int64_t>(value);
   Constant c =
-      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1}, dec);
+      Constant(spv::Op::OpConstant, type_id, {words.word0, words.word1});
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getComposite(SPIRVContext &ctx, uint32_t type_id,
-                                       llvm::ArrayRef<uint32_t> constituents,
-                                       DecorationSet dec) {
-  Constant c =
-      Constant(spv::Op::OpConstantComposite, type_id, constituents, dec);
+                                       llvm::ArrayRef<uint32_t> constituents) {
+  Constant c = Constant(spv::Op::OpConstantComposite, type_id, constituents);
   return getUniqueConstant(ctx, c);
 }
 
 const Constant *Constant::getSampler(SPIRVContext &ctx, uint32_t type_id,
                                      spv::SamplerAddressingMode sam,
-                                     uint32_t param, spv::SamplerFilterMode sfm,
-                                     DecorationSet dec) {
-  Constant c = Constant(
-      spv::Op::OpConstantSampler, type_id,
-      {static_cast<uint32_t>(sam), param, static_cast<uint32_t>(sfm)}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getNull(SPIRVContext &ctx, uint32_t type_id,
-                                  DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpConstantNull, type_id, {}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getSpecTrue(SPIRVContext &ctx, uint32_t type_id,
-                                      DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpSpecConstantTrue, type_id, {}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getSpecFalse(SPIRVContext &ctx, uint32_t type_id,
-                                       DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpSpecConstantFalse, type_id, {}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getSpecFloat32(SPIRVContext &ctx, uint32_t type_id,
-                                         float value, DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpSpecConstant, type_id,
-                        {cast::BitwiseCast<uint32_t, float>(value)}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getSpecUint32(SPIRVContext &ctx, uint32_t type_id,
-                                        uint32_t value, DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpSpecConstant, type_id, {value}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *Constant::getSpecInt32(SPIRVContext &ctx, uint32_t type_id,
-                                       int32_t value, DecorationSet dec) {
-  Constant c = Constant(spv::Op::OpSpecConstant, type_id,
-                        {cast::BitwiseCast<uint32_t, int32_t>(value)}, dec);
-  return getUniqueConstant(ctx, c);
-}
-
-const Constant *
-Constant::getSpecComposite(SPIRVContext &ctx, uint32_t type_id,
-                           llvm::ArrayRef<uint32_t> constituents,
-                           DecorationSet dec) {
+                                     uint32_t param,
+                                     spv::SamplerFilterMode sfm) {
   Constant c =
-      Constant(spv::Op::OpSpecConstantComposite, type_id, constituents, dec);
+      Constant(spv::Op::OpConstantSampler, type_id,
+               {static_cast<uint32_t>(sam), param, static_cast<uint32_t>(sfm)});
   return getUniqueConstant(ctx, c);
 }
 
-bool Constant::hasDecoration(const Decoration *d) const {
-  return decorations.count(d);
+const Constant *Constant::getNull(SPIRVContext &ctx, uint32_t type_id) {
+  Constant c = Constant(spv::Op::OpConstantNull, type_id, {});
+  return getUniqueConstant(ctx, c);
 }
 
 bool Constant::isBoolean() const {

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -1094,7 +1094,7 @@ IMPL_GET_PRIMITIVE_CONST(Float64, double)
 IMPL_GET_PRIMITIVE_CONST(Int64, int64_t)
 IMPL_GET_PRIMITIVE_CONST(Uint64, uint64_t)
 
-#undef IMPL_GET_PRIMITIVE_VALUE
+#undef IMPL_GET_PRIMITIVE_CONST
 
 uint32_t
 ModuleBuilder::getConstantComposite(uint32_t typeId,

--- a/tools/clang/unittests/SPIRV/ConstantTest.cpp
+++ b/tools/clang/unittests/SPIRV/ConstantTest.cpp
@@ -8,17 +8,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVTestUtils.h"
+
 #include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
 #include "clang/SPIRV/BitwiseCast.h"
 #include "clang/SPIRV/Constant.h"
 #include "clang/SPIRV/SPIRVContext.h"
-#include "gtest/gtest.h"
 
 using namespace clang::spirv;
 
 namespace {
-using ::testing::ElementsAre;
 using ::testing::ContainerEq;
+using ::testing::ElementsAre;
 
 TEST(Constant, True) {
   SPIRVContext ctx;
@@ -82,184 +84,6 @@ TEST(Constant, Null) {
   const auto result = c->withResultId(9);
   const auto expected = constructInst(spv::Op::OpConstantNull, {8, 9});
   EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecTrue) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecTrue(ctx, 2);
-  const auto result = c->withResultId(3);
-  const auto expected = constructInst(spv::Op::OpSpecConstantTrue, {2, 3});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecFalse) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecFalse(ctx, 2);
-  const auto result = c->withResultId(3);
-  const auto expected = constructInst(spv::Op::OpSpecConstantFalse, {2, 3});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecUint32) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecUint32(ctx, 2, 7u);
-  const auto result = c->withResultId(3);
-  const auto expected = constructInst(spv::Op::OpSpecConstant, {2, 3, 7u});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecInt32) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecInt32(ctx, 2, -7);
-  const auto result = c->withResultId(3);
-  const auto expected =
-      constructInst(spv::Op::OpSpecConstant, {2, 3, 0xFFFFFFF9});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecFloat32) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecFloat32(ctx, 2, 7.0);
-  const auto result = c->withResultId(3);
-  const auto expected = constructInst(
-      spv::Op::OpSpecConstant, {2, 3, cast::BitwiseCast<uint32_t, float>(7.0)});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, SpecComposite) {
-  SPIRVContext ctx;
-  const Constant *c = Constant::getSpecComposite(ctx, 8, {4, 5, 6, 7});
-  const auto result = c->withResultId(9);
-  const auto expected =
-      constructInst(spv::Op::OpSpecConstantComposite, {8, 9, 4, 5, 6, 7});
-  EXPECT_THAT(result, ContainerEq(expected));
-}
-TEST(Constant, DecoratedTrue) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getTrue(ctx, 2, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstantTrue);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_TRUE(c->getArgs().empty());
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedFalse) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getFalse(ctx, 2, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstantFalse);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_TRUE(c->getArgs().empty());
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedUint32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getUint32(ctx, 2, 7u, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(), ElementsAre(7u));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedInt32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getInt32(ctx, 2, -7, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(), ElementsAre(0xFFFFFFF9));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedFloat32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getFloat32(ctx, 2, 7.0f, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(),
-              ElementsAre(cast::BitwiseCast<uint32_t, float>(7.0)));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedComposite) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getComposite(ctx, 8, {4, 5, 6, 7}, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstantComposite);
-  EXPECT_EQ(c->getTypeId(), 8);
-  EXPECT_THAT(c->getArgs(), ElementsAre(4, 5, 6, 7));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSampler) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c =
-      Constant::getSampler(ctx, 8, spv::SamplerAddressingMode::Repeat, 1,
-                           spv::SamplerFilterMode::Linear, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstantSampler);
-  EXPECT_EQ(c->getTypeId(), 8);
-  EXPECT_THAT(
-      c->getArgs(),
-      ElementsAre(static_cast<uint32_t>(spv::SamplerAddressingMode::Repeat), 1,
-                  static_cast<uint32_t>(spv::SamplerFilterMode::Linear)));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedNull) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getNull(ctx, 2, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpConstantNull);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_TRUE(c->getArgs().empty());
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecTrue) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecTrue(ctx, 2, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstantTrue);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_TRUE(c->getArgs().empty());
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecFalse) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecFalse(ctx, 2, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstantFalse);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_TRUE(c->getArgs().empty());
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecUint32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecUint32(ctx, 2, 7u, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(), ElementsAre(7u));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecInt32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecInt32(ctx, 2, -7, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(), ElementsAre(0xFFFFFFF9));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecFloat32) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecFloat32(ctx, 2, 7.0f, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstant);
-  EXPECT_EQ(c->getTypeId(), 2);
-  EXPECT_THAT(c->getArgs(),
-              ElementsAre(cast::BitwiseCast<uint32_t, float>(7.0)));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
-}
-TEST(Constant, DecoratedSpecComposite) {
-  SPIRVContext ctx;
-  const Decoration *d = Decoration::getSpecId(ctx, 5);
-  const Constant *c = Constant::getSpecComposite(ctx, 8, {4, 5, 6, 7}, {d});
-  EXPECT_EQ(c->getOpcode(), spv::Op::OpSpecConstantComposite);
-  EXPECT_EQ(c->getTypeId(), 8);
-  EXPECT_THAT(c->getArgs(), ElementsAre(4, 5, 6, 7));
-  EXPECT_THAT(c->getDecorations(), ElementsAre(d));
 }
 
 TEST(Constant, ConstantsWithSameBitPatternButDifferentTypeIdAreNotEqual) {


### PR DESCRIPTION
Specialization constants are more like variables. Unlike normal
constants, we cannot unify spec constants, even if two of them
have exactly the same arguments. Neither can we replace a spec
constant with its default value (initializer) or folding exprs
containing spec constants.

We can use the SpecId decoration to distinguish spec constants
with the same arguments, but the problem is that not all spec
constants have SpecId decorations. Only those explicitly marked
in the source code have, derived ones do not.

Also, we cannot decorate normal constants. So we can remove the
decoration member in the Constant class.