### PR TITLE
[spirv] Comine type and constant in SPIRVModule

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
@@ -115,11 +115,11 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // OpDecorate %out_var_TEXCOORD Location 1
 // OpDecorate %out_var_TANGENT Location 2
 // OpDecorate %out_var_BITANGENT Location 3
-// %uint = OpTypeInt 32 0
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
+// %uint = OpTypeInt 32 0
 // %uint_1 = OpConstant %uint 1
 // %_arr_float_uint_1 = OpTypeArray %float %uint_1
 // %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
@@ -150,9 +150,9 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // %_ptr_Output_v3float = OpTypePointer Output %v3float
 // %_ptr_Output_v2float = OpTypePointer Output %v2float
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
+// %uint_0 = OpConstant %uint 0
 // %85 = OpTypeFunction %DS_OUTPUT %_ptr_Function_HS_CONSTANT_DATA_OUTPUT %_ptr_Function_v2float %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_4
 // %_ptr_Function_DS_OUTPUT = OpTypePointer Function %DS_OUTPUT
-// %uint_0 = OpConstant %uint 0
 // %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_4 Input
 // %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output
 // %gl_TessLevelOuter = OpVariable %_ptr_Input__arr_float_uint_4 Input

--- a/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
@@ -133,12 +133,11 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // OpDecorate %out_var_TANVCORNER Location 3
 // OpDecorate %out_var_TANWEIGHTS Location 4
 // OpDecorate %out_var_TEXCOORD Location 5
-// %uint = OpTypeInt 32 0
-// %int = OpTypeInt 32 1
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
+// %uint = OpTypeInt 32 0
 // %uint_1 = OpConstant %uint 1
 // %_arr_float_uint_1 = OpTypeArray %float %uint_1
 // %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
@@ -160,10 +159,11 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %BEZIER_CONTROL_POINT = OpTypeStruct %v3float
 // %_ptr_Output__arr_v3float_uint_3 = OpTypePointer Output %_arr_v3float_uint_3
 // %_ptr_Output_v3float = OpTypePointer Output %v3float
+// %uint_0 = OpConstant %uint 0
+// %uint_2 = OpConstant %uint 2
 // %bool = OpTypeBool
 // %uint_4 = OpConstant %uint 4
 // %_arr_float_uint_4 = OpTypeArray %float %uint_4
-// %uint_2 = OpConstant %uint 2
 // %_arr_float_uint_2 = OpTypeArray %float %uint_2
 // %_arr_v3float_uint_4 = OpTypeArray %v3float %uint_4
 // %_arr_v2float_uint_4 = OpTypeArray %v2float %uint_4
@@ -175,14 +175,10 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
 // %95 = OpTypeFunction %HS_CONSTANT_DATA_OUTPUT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint
 // %_ptr_Function_HS_CONSTANT_DATA_OUTPUT = OpTypePointer Function %HS_CONSTANT_DATA_OUTPUT
-// %_ptr_Function_float = OpTypePointer Function %float
-// %120 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
-// %_ptr_Function_VS_CONTROL_POINT_OUTPUT = OpTypePointer Function %VS_CONTROL_POINT_OUTPUT
-// %_ptr_Function_BEZIER_CONTROL_POINT = OpTypePointer Function %BEZIER_CONTROL_POINT
-// %_ptr_Function_v3float = OpTypePointer Function %v3float
-// %uint_0 = OpConstant %uint 0
 // %float_1 = OpConstant %float 1
+// %int = OpTypeInt 32 1
 // %int_0 = OpConstant %int 0
+// %_ptr_Function_float = OpTypePointer Function %float
 // %float_2 = OpConstant %float 2
 // %int_1 = OpConstant %int 1
 // %float_3 = OpConstant %float 3
@@ -191,6 +187,10 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %int_3 = OpConstant %int 3
 // %float_5 = OpConstant %float 5
 // %float_6 = OpConstant %float 6
+// %120 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
+// %_ptr_Function_VS_CONTROL_POINT_OUTPUT = OpTypePointer Function %VS_CONTROL_POINT_OUTPUT
+// %_ptr_Function_BEZIER_CONTROL_POINT = OpTypePointer Function %BEZIER_CONTROL_POINT
+// %_ptr_Function_v3float = OpTypePointer Function %v3float
 // %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_3 Input
 // %gl_PerVertexOut = OpVariable %_ptr_Output__arr_type_gl_PerVertex_uint_3 Output
 // %in_var_WORLDPOS = OpVariable %_ptr_Input__arr_v3float_uint_3 Input

--- a/tools/clang/test/CodeGenSPIRV/constant.scalar.16bit.enabled.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/constant.scalar.16bit.enabled.hlsl
@@ -32,11 +32,9 @@
 // CHECK-NOT: OpDecorate %c_int16_n16 RelaxedPrecision
 // CHECK-NOT: OpDecorate %c_int16_16 RelaxedPrecision
 
-// CHECK: %short = OpTypeInt 16 1
-// CHECK: %ushort = OpTypeInt 16 0
+void main() {
 // CHECK: %half = OpTypeFloat 16
 
-void main() {
 // CHECK: %half_0x1_2p_0 = OpConstant %half 0x1.2p+0
   half       c_half = 1.125;
 // CHECK: %half_0x1_ep_3 = OpConstant %half 0x1.ep+3
@@ -46,10 +44,15 @@ void main() {
 // CHECK: %half_0x1_8p_0 = OpConstant %half 0x1.8p+0
   float16_t  c_float16t = 1.5;
 
+// CHECK: %short = OpTypeInt 16 1
+
 // CHECK: %short_n3 = OpConstant %short -3
   min16int   c_min16int_n3 = -3;
 // CHECK: %short_3 = OpConstant %short 3
   min16int   c_min16int_3 = 3;
+
+// CHECK: %ushort = OpTypeInt 16 0
+
 // CHECK: %ushort_5 = OpConstant %ushort 5
   min16uint  c_min16uint_5 = 5;
 
@@ -58,7 +61,7 @@ void main() {
 // CHECK: %short_9 = OpConstant %short 9
   min12int   c_min12int_9 = 9;
 // It seems that min12uint is still not supported by the front-end.
-// XXXXX: %short_12 = OpConstant %short 12 
+// XXXXX: %short_12 = OpConstant %short 12
 //  min12uint   c_min12uint = 12;
 
 // CHECK: %ushort_16 = OpConstant %ushort 16

--- a/tools/clang/test/CodeGenSPIRV/constant.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/constant.vector.hlsl
@@ -3,13 +3,10 @@
 void main() {
 // CHECK: %int_1 = OpConstant %int 1
     int1 c_int1 = int1(1);
-// CHECK-NEXT: %int_2 = OpConstant %int 2
-// CHECK-NEXT: {{%\d+}} = OpConstantComposite %v2int %int_1 %int_2
+// CHECK: {{%\d+}} = OpConstantComposite %v2int %int_1 %int_2
     int2 c_int2 = int2(1, 2);
-// CHECK-NEXT: %int_3 = OpConstant %int 3
-// CHECK-NEXT: {{%\d+}} = OpConstantComposite %v3int %int_1 %int_2 %int_3
+// CHECK: {{%\d+}} = OpConstantComposite %v3int %int_1 %int_2 %int_3
     int3 c_int3 = int3(1, 2, 3);
-// CHECK-NEXT: %int_4 = OpConstant %int 4
-// CHECK-NEXT: {{%\d+}} = OpConstantComposite %v4int %int_1 %int_2 %int_3 %int_4
+// CHECK: {{%\d+}} = OpConstantComposite %v4int %int_1 %int_2 %int_3 %int_4
     int4 c_int4 = int4(1, 2, 3, 4);
 }

--- a/tools/clang/test/CodeGenSPIRV/empty-struct-interface.vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/empty-struct-interface.vs.hlsl2spv
@@ -30,11 +30,11 @@ VSOut main(VSIn input)
 // OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
 // OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
 // OpDecorate %type_gl_PerVertex Block
-// %uint = OpTypeInt 32 0
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
+// %uint = OpTypeInt 32 0
 // %uint_1 = OpConstant %uint 1
 // %_arr_float_uint_1 = OpTypeArray %float %uint_1
 // %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.all.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.all.hlsl
@@ -4,11 +4,11 @@
 // The 'all' function can only operate on int, bool, float,
 // vector of these scalars, and matrix of these scalars.
 
-// CHECK:      [[v4int_0:%\d+]] = OpConstantComposite %v4int %int_0 %int_0 %int_0 %int_0
-// CHECK-NEXT: [[v4uint_0:%\d+]] = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
-// CHECK-NEXT: [[v4float_0:%\d+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
-// CHECK-NEXT: [[v3float_0:%\d+]] = OpConstantComposite %v3float %float_0 %float_0 %float_0
-// CHECK-NEXT: [[v2float_0:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
+// CHECK:   [[v4int_0:%\d+]] = OpConstantComposite %v4int %int_0 %int_0 %int_0 %int_0
+// CHECK:  [[v4uint_0:%\d+]] = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+// CHECK: [[v4float_0:%\d+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+// CHECK: [[v3float_0:%\d+]] = OpConstantComposite %v3float %float_0 %float_0 %float_0
+// CHECK: [[v2float_0:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
 
 void main() {
     bool result;

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.any.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.any.hlsl
@@ -4,11 +4,11 @@
 // The 'any' function can only operate on int, bool, float,
 // vector of these scalars, and matrix of these scalars.
 
-// CHECK:      [[v4int_0:%\d+]] = OpConstantComposite %v4int %int_0 %int_0 %int_0 %int_0
-// CHECK-NEXT: [[v4uint_0:%\d+]] = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
-// CHECK-NEXT: [[v4float_0:%\d+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
-// CHECK-NEXT: [[v3float_0:%\d+]] = OpConstantComposite %v3float %float_0 %float_0 %float_0
-// CHECK-NEXT: [[v2float_0:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
+// CHECK:   [[v4int_0:%\d+]] = OpConstantComposite %v4int %int_0 %int_0 %int_0 %int_0
+// CHECK:  [[v4uint_0:%\d+]] = OpConstantComposite %v4uint %uint_0 %uint_0 %uint_0 %uint_0
+// CHECK: [[v4float_0:%\d+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+// CHECK: [[v3float_0:%\d+]] = OpConstantComposite %v3float %float_0 %float_0 %float_0
+// CHECK: [[v2float_0:%\d+]] = OpConstantComposite %v2float %float_0 %float_0
 
 void main() {
     bool result;

--- a/tools/clang/test/CodeGenSPIRV/passthru-cs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-cs.hlsl2spv
@@ -49,7 +49,6 @@ void main( uint3 DTid : SV_DispatchThreadID )
 // OpDecorate %BufferOut DescriptorSet 0
 // OpDecorate %BufferOut Binding 1
 // %uint = OpTypeInt 32 0
-// %int = OpTypeInt 32 1
 // %_runtimearr_uint = OpTypeRuntimeArray %uint
 // %type_ByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 // %_ptr_Uniform_type_ByteAddressBuffer = OpTypePointer Uniform %type_ByteAddressBuffer
@@ -62,10 +61,11 @@ void main( uint3 DTid : SV_DispatchThreadID )
 // %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 // %21 = OpTypeFunction %void %_ptr_Function_v3uint
 // %_ptr_Function_uint = OpTypePointer Function %uint
-// %_ptr_Uniform_uint = OpTypePointer Uniform %uint
+// %int = OpTypeInt 32 1
 // %int_0 = OpConstant %int 0
 // %uint_4 = OpConstant %uint 4
 // %uint_2 = OpConstant %uint 2
+// %_ptr_Uniform_uint = OpTypePointer Uniform %uint
 // %uint_0 = OpConstant %uint 0
 // %Buffer0 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
 // %BufferOut = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform

--- a/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
@@ -46,12 +46,11 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // OpDecorate %in_var_POSITION Location 0
 // OpDecorate %in_var_COLOR Location 1
 // OpDecorate %out_var_COLOR Location 0
-// %uint = OpTypeInt 32 0
-// %int = OpTypeInt 32 1
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
+// %uint = OpTypeInt 32 0
 // %uint_1 = OpConstant %uint 1
 // %_arr_float_uint_1 = OpTypeArray %float %uint_1
 // %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
@@ -60,9 +59,10 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // %_ptr_Input_v4float = OpTypePointer Input %v4float
 // %PSInput = OpTypeStruct %v4float %v4float
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
+// %uint_0 = OpConstant %uint 0
 // %30 = OpTypeFunction %PSInput %_ptr_Function_v4float %_ptr_Function_v4float
 // %_ptr_Function_PSInput = OpTypePointer Function %PSInput
-// %uint_0 = OpConstant %uint 0
+// %int = OpTypeInt 32 1
 // %int_0 = OpConstant %int 0
 // %int_1 = OpConstant %int 1
 // %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-alpha.hlsl
@@ -9,13 +9,14 @@ TextureCubeArray<uint4> tCubeArray : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv4f_1_5:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
 
 float4 main(float3 location: A) : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-blue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-blue.hlsl
@@ -9,15 +9,17 @@ TextureCubeArray<uint4> tCubeArray : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4uint
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
+
 // CHECK: [[cv4f_1_5:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4uint
 
 float4 main(float3 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image_array %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp-red.hlsl
@@ -9,15 +9,17 @@ TextureCubeArray<int4> tCubeArray : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv4f_1_5:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float3 location: A, float comparator: B) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image_array %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-cmp.hlsl
@@ -8,10 +8,11 @@ Texture2DArray<float>  t3 : register(t3);
 TextureCubeArray<float>t4 : register(t4);
 // .GatherCmp() does not support Texture1DArray.
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
 // CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
+
 // CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
 
 float4 main(float3 location: A, float comparator: B, int2 offset: C) : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-green.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-green.hlsl
@@ -9,15 +9,17 @@ TextureCubeArray<int4> tCubeArray : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv4f_1_5:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float3 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image_array %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather-red.hlsl
@@ -9,15 +9,17 @@ TextureCubeArray<int4> tCubeArray : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv4f_1_5:%\d+]] = OpConstantComposite %v4float %float_1_5 %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float3 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image_array %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.array.gather.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.gather.hlsl
@@ -11,10 +11,10 @@ TextureCubeArray <float>  t8 : register(t8);
 // CHECK: OpCapability ImageGatherExtended
 // CHECK: OpCapability SparseResidency
 
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_0_4
+
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
 // CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4float
-
-// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_0_4
 
 float4 main(float3 location: A, int2 offset: B) : SV_Target {
 

--- a/tools/clang/test/CodeGenSPIRV/texture.array.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.load.hlsl
@@ -6,9 +6,10 @@ Texture2DArray <float4> t2 : register(t2);
 
 // CHECK: OpCapability SparseResidency
 
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_1 %int_2 %int_3
+
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
-// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_1 %int_2 %int_3
 // CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 
 float4 main(int4 location: A) : SV_Target {
@@ -47,6 +48,6 @@ float4 main(int4 location: A) : SV_Target {
 // CHECK-NEXT:      [[result:%\d+]] = OpCompositeExtract %v4float [[structResult]] 1
 // CHECK-NEXT:                        OpStore %val4 [[result]]
     float4 val4 = t2.Load(location, int2(1, 2), status);
-    
+
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-bias.hlsl
@@ -14,15 +14,17 @@ TextureCubeArray <float3> t5 : register(t5);
 // CHECK: OpCapability MinLod
 // CHECK: OpCapability SparseResidency
 
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
-// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 
 float4 main(int2 offset : A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
@@ -69,7 +71,7 @@ float4 main(int2 offset : A) : SV_Target {
 // CHECK-NEXT:       [[result:%\d+]] = OpCompositeExtract %v4float [[structResult]] 1
 // CHECK-NEXT:                         OpStore %val6 [[result]]
     float4 val6 = t1.SampleBias(gSampler, float2(0.1, 1), 0.5, 1, clamp, status);
-    
+
 // CHECK:                [[t3:%\d+]] = OpLoad %type_cube_image_array %t3
 // CHECK-NEXT:     [[gSampler:%\d+]] = OpLoad %type_sampler %gSampler
 // CHECK-NEXT:   [[sampledImg:%\d+]] = OpSampledImage %type_sampled_image_1 [[t3]] [[gSampler]]

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp-level-zero.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp-level-zero.hlsl
@@ -8,11 +8,11 @@ TextureCubeArray <float>  t3 : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
-
 // CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
 // CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
 
 float4 main(int2 offset: A, float comparator: B) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-cmp.hlsl
@@ -9,11 +9,11 @@ TextureCubeArray <float>  t3 : register(t3);
 // CHECK: OpCapability MinLod
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
-
 // CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
 // CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
 
 float4 main(int2 offset: A, float comparator: B) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1
@@ -79,6 +79,6 @@ float4 main(int2 offset: A, float comparator: B) : SV_Target {
 // CHECK-NEXT:       [[result:%\d+]] = OpCompositeExtract %float [[structResult]] 1
 // CHECK-NEXT:                         OpStore %val7 [[result]]
     float val7 = t3.SampleCmp(gSampler, float4(0.1, 0.2, 0.3, 1), comparator, /*clamp*/ 1.5, status);
-    
+
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-grad.hlsl
@@ -15,19 +15,20 @@ TextureCubeArray <float2> t5 : register(t5);
 // CHECK: OpCapability MinLod
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
-// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
-// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image
-
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
 // CHECK: [[v2f_0_1:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_1
+// CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+
 // CHECK: [[v3f_0_1:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_1 %float_0_1
 // CHECK: [[v2f_0_2:%\d+]] = OpConstantComposite %v2float %float_0_2 %float_0_2
 // CHECK: [[v2f_0_3:%\d+]] = OpConstantComposite %v2float %float_0_3 %float_0_3
+// CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+
 // CHECK: [[v4f_0_1:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_1 %float_0_1 %float_0_1
 // CHECK: [[v3f_0_2:%\d+]] = OpConstantComposite %v3float %float_0_2 %float_0_2 %float_0_2
 // CHECK: [[v3f_0_3:%\d+]] = OpConstantComposite %v3float %float_0_3 %float_0_3 %float_0_3
+// CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
 float4 main(int2 offset : A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample-level.hlsl
@@ -13,15 +13,16 @@ TextureCubeArray <float3> t5 : register(t5);
 // CHECK: OpCapability ImageGatherExtended
 // CHECK: OpCapability SparseResidency
 
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
-// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 
 float4 main(int2 offset : A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.array.sample.hlsl
@@ -13,15 +13,16 @@ TextureCubeArray <float3> t5 : register(t5);
 // CHECK: OpCapability MinLod
 // CHECK: OpCapability SparseResidency
 
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image_array
+
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image_array
+
+// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_cube_image_array
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_1
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_1
-// CHECK: [[v4fc:%\d+]] = OpConstantComposite %v4float %float_0_1 %float_0_2 %float_0_3 %float_1
 
 float4 main() : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image_array %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-alpha.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-alpha.hlsl
@@ -9,15 +9,17 @@ TextureCube<uint4> tCube : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4uint
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
+
 // CHECK: [[cv3f_1_5:%\d+]] = OpConstantComposite %v3float %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4uint
 
 float4 main(float2 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-blue.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-blue.hlsl
@@ -9,15 +9,18 @@ TextureCube<int4> tCube : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv3f_1_5:%\d+]] = OpConstantComposite %v3float %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float2 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-cmp.hlsl
@@ -8,10 +8,11 @@ Texture2D<float>  t3 : register(t3);
 TextureCube<float>t4 : register(t4);
 // .GatherCmp() does not support Texture1D and Texture3D.
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
 // CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
+
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_1_5 %float_1_5 %float_1_5
 
 float4 main(float2 location: A, float comparator: B, int2 offset: C) : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-green.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-green.hlsl
@@ -9,15 +9,17 @@ TextureCube<int4> tCube : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
-
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
+
 // CHECK: [[cv3f_1_5:%\d+]] = OpConstantComposite %v3float %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float2 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.gather-red.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather-red.hlsl
@@ -9,15 +9,18 @@ TextureCube<int4> tCube : register(t3);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 // CHECK:      [[c12:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK:      [[c34:%\d+]] = OpConstantComposite %v2int %int_3 %int_4
 // CHECK:      [[c56:%\d+]] = OpConstantComposite %v2int %int_5 %int_6
 // CHECK:      [[c78:%\d+]] = OpConstantComposite %v2int %int_7 %int_8
 // CHECK:    [[c1to8:%\d+]] = OpConstantComposite %_arr_v2int_uint_4 [[c12]] [[c34]] [[c56]] [[c78]]
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4uint
+
 // CHECK: [[cv3f_1_5:%\d+]] = OpConstantComposite %v3float %float_1_5 %float_1_5 %float_1_5
+
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
 
 float4 main(float2 location: A) : SV_Target {
 // CHECK:            [[t2f4:%\d+]] = OpLoad %type_2d_image %t2f4

--- a/tools/clang/test/CodeGenSPIRV/texture.gather.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.gather.hlsl
@@ -10,11 +10,11 @@ TextureCube <float>  t8 : register(t8);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4float
-
 // CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4int
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4float
 
 float4 main(float2 location: A) : SV_Target {
 

--- a/tools/clang/test/CodeGenSPIRV/texture.load.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.load.hlsl
@@ -15,13 +15,13 @@ Texture2DMSArray<float3> t8 : register(t8);
 // CHECK: OpCapability ImageGatherExtended
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
-// CHECK: %SparseResidencyStruct_1 = OpTypeStruct %uint %v4uint
-
 // CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_1 %int_2
 // CHECK: [[v4ic:%\d+]] = OpConstantComposite %v4int %int_1 %int_2 %int_3 %int_4
 // CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
+// CHECK: %SparseResidencyStruct_0 = OpTypeStruct %uint %v4int
+// CHECK: %SparseResidencyStruct_1 = OpTypeStruct %uint %v4uint
 
 float4 main(int3 location: A, int offset: B) : SV_Target {
     uint status;
@@ -155,6 +155,6 @@ float4 main(int3 location: A, int offset: B) : SV_Target {
 // CHECK-NEXT:      [[result:%\d+]] = OpVectorShuffle %v3float [[v4result]] [[v4result]] 0 1 2
 // CHECK-NEXT:                        OpStore %val18 [[result]]
     float3 val18 = t8.Load(pos3, sampleIndex, int2(1,2), status);
-    
+
     return 1.0;
 }

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-bias.hlsl
@@ -16,15 +16,16 @@ Texture3D   <float2> t6 : register(t6);
 // CHECK: OpCapability SparseResidency
 
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
 // CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
-
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
-// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
 
 float4 main(int3 offset: A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-cmp-level-zero.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-cmp-level-zero.hlsl
@@ -9,10 +9,10 @@ TextureCube <float>  t4 : register(t4);
 
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
-
 // CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
 
 float4 main(int2 offset: A, float comparator: B) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-cmp.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-cmp.hlsl
@@ -10,10 +10,10 @@ TextureCube <float>  t4 : register(t4);
 // CHECK: OpCapability MinLod
 // CHECK: OpCapability SparseResidency
 
-// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
-
 // CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
 // CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
+// CHECK: %SparseResidencyStruct = OpTypeStruct %uint %float
 
 float4 main(int2 offset: A, float comparator: B) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-grad.hlsl
@@ -16,19 +16,21 @@ Texture2D   <float2> t6 : register(t6);
 // CHECK: OpCapability SparseResidency
 
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: [[v2f_0_1:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_1
+// CHECK: [[v2f_0_2:%\d+]] = OpConstantComposite %v2float %float_0_2 %float_0_2
+// CHECK: [[v2f_0_3:%\d+]] = OpConstantComposite %v2float %float_0_3 %float_0_3
+
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: [[v3f_0_1:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_1 %float_0_1
+// CHECK: [[v3f_0_2:%\d+]] = OpConstantComposite %v3float %float_0_2 %float_0_2 %float_0_2
+// CHECK: [[v3f_0_3:%\d+]] = OpConstantComposite %v3float %float_0_3 %float_0_3 %float_0_3
+// CHECK:   [[v3i_3:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
 // CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
-// CHECK: [[v2f_0_1:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_1
-// CHECK: [[v2f_0_2:%\d+]] = OpConstantComposite %v2float %float_0_2 %float_0_2
-// CHECK: [[v2f_0_3:%\d+]] = OpConstantComposite %v2float %float_0_3 %float_0_3
-// CHECK: [[v3f_0_1:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_1 %float_0_1
-// CHECK: [[v3f_0_2:%\d+]] = OpConstantComposite %v3float %float_0_2 %float_0_2 %float_0_2
-// CHECK: [[v3f_0_3:%\d+]] = OpConstantComposite %v3float %float_0_3 %float_0_3 %float_0_3
-// CHECK: [[v3i_3:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
 
 float4 main(int2 offset : A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-level.hlsl
@@ -15,15 +15,17 @@ TextureCube <float2> t6 : register(t6);
 // CHECK: OpCapability SparseResidency
 
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
+
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
 // CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
-// CHECK: [[v2ic:%\d+]] = OpConstantComposite %v2int %int_2 %int_2
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
 
 float4 main(int3 offset: A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.hlsl
@@ -16,15 +16,17 @@ TextureCube <float3> t6 : register(t6);
 // CHECK: OpCapability SparseResidency
 
 // CHECK: %type_sampled_image = OpTypeSampledImage %type_1d_image
+// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
+
 // CHECK: %type_sampled_image_0 = OpTypeSampledImage %type_2d_image
+// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
+// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
+
 // CHECK: %type_sampled_image_1 = OpTypeSampledImage %type_3d_image
 // CHECK: %type_sampled_image_2 = OpTypeSampledImage %type_cube_image
 
 // CHECK: %SparseResidencyStruct = OpTypeStruct %uint %v4float
 
-// CHECK: [[v2fc:%\d+]] = OpConstantComposite %v2float %float_0_1 %float_0_2
-// CHECK: [[v3fc:%\d+]] = OpConstantComposite %v3float %float_0_1 %float_0_2 %float_0_3
-// CHECK: [[v3ic:%\d+]] = OpConstantComposite %v3int %int_3 %int_3 %int_3
 
 float4 main(int2 offset: A) : SV_Target {
 // CHECK:              [[t1:%\d+]] = OpLoad %type_1d_image %t1

--- a/tools/clang/unittests/SPIRV/StructureTest.cpp
+++ b/tools/clang/unittests/SPIRV/StructureTest.cpp
@@ -276,11 +276,11 @@ TEST(Structure, TakeModuleWithArrayAndConstantDependency) {
   sib.inst(
       spv::Op::OpDecorate,
       {secondArrId, static_cast<uint32_t>(spv::Decoration::ArrayStride), 4});
-  // Now the expected order: int64, int32, void, float, constant(8), array
-  sib.inst(spv::Op::OpTypeInt, {i64Id, 64, 1});
-  sib.inst(spv::Op::OpTypeInt, {i32Id, 32, 1});
+  // Now the expected order: void, float, int64, int32, constant(8), array
   sib.inst(spv::Op::OpTypeVoid, {voidId});
   sib.inst(spv::Op::OpTypeFloat, {f32Id, 32});
+  sib.inst(spv::Op::OpTypeInt, {i64Id, 64, 1});
+  sib.inst(spv::Op::OpTypeInt, {i32Id, 32, 1});
   sib.inst(spv::Op::OpConstant, {i32Id, constantId, 8});
   sib.inst(spv::Op::OpTypeArray, {arrId, i32Id, constantId});
   sib.inst(spv::Op::OpTypeArray, {secondArrId, i32Id, constantId});


### PR DESCRIPTION
Types and constants are interdependent. Previously we use different
members for storing them, which requires hacks to output types
and constants in the correct order to satisfy their dependencies.
However, with specialization constants, things will be more
complicated. Using the same member to store all of them solves
the problem naturally.