### PR TITLE
[spirv] Handle vector<literal int/float, 1> in type hints

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -4041,7 +4041,8 @@ SPIRVEmitter::doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr) {
   }
 
   if (baseSize == 1) {
-    // Selecting one element from a size-1 vector. Construct the vector.
+    // Selecting more than one element from a size-1 vector, for example,
+    // <scalar>.xx. Construct the vector.
     auto info = loadIfGLValue(baseExpr);
     llvm::SmallVector<uint32_t, 4> components(accessorSize, info);
     return info

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -144,10 +144,9 @@ bool TypeTranslator::LiteralTypeHint::isLiteralType(QualType type) {
       type->isSpecificBuiltinType(BuiltinType::LitFloat))
     return true;
 
-  // For cases such as 'vector<literal int, 2>'
-  QualType elemType = {};
-  if (isVectorType(type, &elemType))
-    return isLiteralType(elemType);
+  // For cases such as 'vector<literal int, 2>' or 'vector<literal float, 1>'
+  if (hlsl::IsHLSLVecType(type))
+    return isLiteralType(hlsl::GetHLSLVecElementType(type));
 
   return false;
 }

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -260,10 +260,11 @@ public:
   QualType getIntendedLiteralType(QualType type);
 
 public:
-  // A RAII class for maintaining the intendedLiteralTypes stack.
-  // Instantiating an object of this class ensures that as long as the
-  // object lives, the hint lives in the TypeTranslator, and once the object is
-  // destroyed, the hint is automatically removed from the stack.
+  /// A RAII class for maintaining the intendedLiteralTypes stack.
+  ///
+  /// Instantiating an object of this class ensures that as long as the
+  /// object lives, the hint lives in the TypeTranslator, and once the object is
+  /// destroyed, the hint is automatically removed from the stack.
   class LiteralTypeHint {
   public:
     LiteralTypeHint(TypeTranslator &t, QualType ty);

--- a/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.const-scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.const-scalar.hlsl
@@ -4,7 +4,7 @@
 // CHECK: [[v4f25:%\d+]] = OpConstantComposite %v4float %float_2_5 %float_2_5 %float_2_5 %float_2_5
 // CHECK:  [[v4f0:%\d+]] = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
 
-float4 main() : SV_Target {
+float4 main(float input: INPUT) : SV_Target {
 
 // CHECK: OpStore %a [[v4f1]]
   float4 a = (1).xxxx;
@@ -14,6 +14,13 @@ float4 main() : SV_Target {
 
 // CHECK: OpStore %c [[v4f0]]
   float4 c = (false).xxxx;
+
+// CHECK:       [[cc:%\d+]] = OpCompositeConstruct %v2float %float_0 %float_0
+// CHECK-NEXT: [[cc0:%\d+]] = OpCompositeExtract %float [[cc]] 0
+// CHECK-NEXT: [[cc1:%\d+]] = OpCompositeExtract %float [[cc]] 1
+// CHECK-NEXT: [[rhs:%\d+]] = OpCompositeConstruct %v4float {{%\d+}} {{%\d+}} [[cc0]] [[cc1]]
+// CHECK-NEXT:                OpStore %d [[rhs]]
+  float4 d = float4(input, input, 0.0.xx);
 
 // CHECK: OpReturnValue [[v4f0]]
   return 0.0.xxxx;


### PR DESCRIPTION
isVectorType() only returns true for real vectors with more than
one element.