### PR TITLE
[spirv] Fix neglecting majorness on cbuffer/tbuffer members

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -296,7 +296,7 @@ SpirvEvalInfo DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
           cast<VarDecl>(decl)->getType(),
           // We need to set decorateLayout here to avoid creating SPIR-V
           // instructions for the current type without decorations.
-          info->info.getLayoutRule());
+          info->info.getLayoutRule(), info->isRowMajor);
 
       const uint32_t elemId = theBuilder.createAccessChain(
           theBuilder.getPointerType(varType, info->info.getStorageClass()),
@@ -516,12 +516,14 @@ uint32_t DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
       continue;
 
     const auto *varDecl = cast<VarDecl>(subDecl);
+    const bool isRowMajor =
+        typeTranslator.isRowMajorMatrix(varDecl->getType(), varDecl);
     astDecls[varDecl] = {SpirvEvalInfo(bufferVar)
                              .setStorageClass(spv::StorageClass::Uniform)
                              .setLayoutRule(decl->isCBuffer()
                                                 ? LayoutRule::GLSLStd140
                                                 : LayoutRule::GLSLStd430),
-                         index++};
+                         index++, isRowMajor};
   }
   resourceVars.emplace_back(
       bufferVar, ResourceVar::Category::Other, getResourceBinding(decl),

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -347,8 +347,8 @@ private:
     /// Default constructor to satisfy DenseMap
     DeclSpirvInfo() : info(0), indexInCTBuffer(-1) {}
 
-    DeclSpirvInfo(const SpirvEvalInfo &info_, int index = -1)
-        : info(info_), indexInCTBuffer(index) {}
+    DeclSpirvInfo(const SpirvEvalInfo &info_, int index = -1, bool row = false)
+        : info(info_), indexInCTBuffer(index), isRowMajor(row) {}
 
     /// Implicit conversion to SpirvEvalInfo.
     operator SpirvEvalInfo() const { return info; }
@@ -357,6 +357,8 @@ private:
     /// Value >= 0 means that this decl is a VarDecl inside a cbuffer/tbuffer
     /// and this is the index; value < 0 means this is just a standalone decl.
     int indexInCTBuffer;
+    /// Whether this decl should be row major.
+    bool isRowMajor;
   };
 
   /// \brief Returns the SPIR-V information for the given decl.

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
@@ -3,6 +3,10 @@
 // CHECK: OpDecorate %_arr_mat2v3float_uint_5 ArrayStride 32
 // CHECK: OpDecorate %_arr_mat2v3float_uint_5_0 ArrayStride 48
 
+// CHECK: OpMemberDecorate %type_MyCBuffer 0 ColMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 1 RowMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 2 RowMajor
+
 // CHECK: %type_MyCBuffer = OpTypeStruct %_arr_mat2v3float_uint_5 %_arr_mat2v3float_uint_5_0 %_arr_mat2v3float_uint_5_0
 cbuffer MyCBuffer {
     row_major    float2x3 matrices1[5];

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
@@ -1,0 +1,21 @@
+// Run: %dxc -T vs_6_0 -E main -Zpc
+
+// CHECK: OpDecorate %_arr_mat2v3float_uint_5 ArrayStride 32
+// CHECK: OpDecorate %_arr_mat2v3float_uint_5_0 ArrayStride 48
+
+// CHECK: %type_MyCBuffer = OpTypeStruct %_arr_mat2v3float_uint_5 %_arr_mat2v3float_uint_5_0 %_arr_mat2v3float_uint_5_0
+cbuffer MyCBuffer {
+    row_major    float2x3 matrices1[5];
+    column_major float2x3 matrices2[5];
+                 float2x3 matrices3[5];
+}
+
+void main() {
+    // Check that the result types for access chains are correct
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_0
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_1
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_2
+    float2x3 m1 = matrices1[1];
+    float2x3 m2 = matrices2[2];
+    float2x3 m3 = matrices3[3];
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
@@ -3,6 +3,10 @@
 // CHECK: OpDecorate %_arr_mat2v3float_uint_5 ArrayStride 32
 // CHECK: OpDecorate %_arr_mat2v3float_uint_5_0 ArrayStride 48
 
+// CHECK: OpMemberDecorate %type_MyCBuffer 0 ColMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 1 RowMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 2 ColMajor
+
 // CHECK: %type_MyCBuffer = OpTypeStruct %_arr_mat2v3float_uint_5 %_arr_mat2v3float_uint_5_0 %_arr_mat2v3float_uint_5
 cbuffer MyCBuffer {
     row_major    float2x3 matrices1[5];

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
@@ -1,0 +1,21 @@
+// Run: %dxc -T vs_6_0 -E main -Zpr
+
+// CHECK: OpDecorate %_arr_mat2v3float_uint_5 ArrayStride 32
+// CHECK: OpDecorate %_arr_mat2v3float_uint_5_0 ArrayStride 48
+
+// CHECK: %type_MyCBuffer = OpTypeStruct %_arr_mat2v3float_uint_5 %_arr_mat2v3float_uint_5_0 %_arr_mat2v3float_uint_5
+cbuffer MyCBuffer {
+    row_major    float2x3 matrices1[5];
+    column_major float2x3 matrices2[5];
+                 float2x3 matrices3[5];
+}
+
+void main() {
+    // Check that the result types for access chains are correct
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_0
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_1
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_2
+    float2x3 m1 = matrices1[1];
+    float2x3 m2 = matrices2[2];
+    float2x3 m3 = matrices3[3];
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1126,6 +1126,12 @@ TEST_F(FileTest, VulkanSpecConstantError) {
   runFileTest("vk.spec-constant.error.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, VulkanLayoutCBufferMatrixZpr) {
+  runFileTest("vk.layout.cbuffer.zpr.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutCBufferMatrixZpc) {
+  runFileTest("vk.layout.cbuffer.zpc.hlsl");
+}
 TEST_F(FileTest, VulkanLayoutCBufferStd140) {
   runFileTest("vk.layout.cbuffer.std140.hlsl");
 }


### PR DESCRIPTION
cbuffers/tbuffers are handled differently than other resource types
becuase their members do not need to be qualified when using.
That is, their members are distinct entities. However, in SPIR-V,
we need to generate one single entity to hold them all for all
members in a cbuffer/tbuffer.

Previously we didn't record the marjorness annotated on each member,
which results in returning the wrong types for members.