### PR TITLE
[spirv] FloatConversion for structs with one single member

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.struct.hlsl
@@ -1,0 +1,25 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// Compositing a struct by casting from its single member
+
+struct S {
+    float4 val;
+};
+
+struct T {
+    S val;
+};
+
+float4 main(float4 a: A) : SV_Target {
+// CHECK:      [[a:%\d+]] = OpLoad %v4float %a
+// CHECK-NEXT: [[s:%\d+]] = OpCompositeConstruct %S [[a]]
+// CHECK-NEXT:              OpStore %s [[s]]
+    S s = (S)a;
+
+// CHECK:      [[s:%\d+]] = OpLoad %S %s
+// CHECK-NEXT: [[t:%\d+]] = OpCompositeConstruct %T [[s]]
+// CHECK-NEXT:              OpStore %t [[t]]
+    T t = (T)s;
+
+    return s.val + t.val.val;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -317,6 +317,9 @@ TEST_F(FileTest, CastImplicit2LiteralInt) {
 TEST_F(FileTest, CastImplicitFlatConversion) {
   runFileTest("cast.flat-conversion.implicit.hlsl");
 }
+TEST_F(FileTest, CastFlatConversionStruct) {
+  runFileTest("cast.flat-conversion.struct.hlsl");
+}
 TEST_F(FileTest, CastExplicitVecToMat) {
   runFileTest("cast.vec-to-mat.explicit.hlsl");
 }


### PR DESCRIPTION
For a struct `T` with only one member of type `S`, `(T)<an-instance-of-S>`
is allowed and will be interpreted as constructing an instance of
`T` using the instance of `S` as its member.