### PR TITLE
[spirv] Accept array types for PS stage input variables

### DIFF
--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -840,8 +840,13 @@ bool TypeTranslator::isSameType(QualType type1, QualType type2) {
 
 QualType TypeTranslator::getElementType(QualType type) {
   QualType elemType = {};
-  (void)(isScalarType(type, &elemType) || isVectorType(type, &elemType) ||
-         isMxNMatrix(type, &elemType));
+  if (isScalarType(type, &elemType) || isVectorType(type, &elemType) ||
+      isMxNMatrix(type, &elemType)) {
+  } else if (const auto *arrType = astContext.getAsConstantArrayType(type)) {
+    elemType = arrType->getElementType();
+  } else {
+    assert(false && "unhandled type");
+  }
   return elemType;
 }
 

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -201,8 +201,8 @@ public:
   /// \brief Returns a string name for the given type.
   static std::string getName(QualType type);
 
-  /// \brief Returns the the element type for the given scalar/vector/matrix
-  /// type. Returns empty QualType for other cases.
+  /// \brief Returns the the element type for the given scalar, vector, matrix,
+  /// or array type. Returns empty QualType for other cases.
   QualType getElementType(QualType type);
 
   /// \brief Generates the corresponding SPIR-V vector type for the given Clang

--- a/tools/clang/test/CodeGenSPIRV/spirv.interpolation.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interpolation.hlsl
@@ -32,6 +32,9 @@ struct PSInput {
                        bool  bool_a: BOOLA;
 // CHECK: OpDecorate %in_var_BOOLD Flat
   nointerpolation      bool3 bool_d: BOOLD;
+
+// CHECK: OpDecorate %in_var_FPH Flat
+  nointerpolation      float4 fp_h[1]: FPH;
 };
 
 float4 main(                     PSInput input,


### PR DESCRIPTION
We need to check the element types of PS input variables to
properly apply interpolation decorations. Previously the method
used to query element type does not support array types, which
caused an assertion eventually.