### PR TITLE
Carry BasePath within CK_HLSLDerivedToBase casts

### DIFF
--- a/tools/clang/test/HLSL/derived-to-base.hlsl
+++ b/tools/clang/test/HLSL/derived-to-base.hlsl
@@ -1,0 +1,62 @@
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+
+struct Base {
+    float4 a;
+    float4 b;
+};
+
+struct Derived : Base {
+    float4 b;
+    float4 c;
+};
+
+struct DerivedAgain : Derived {
+    float4 c;
+    float4 d;
+};
+
+float main() : A {
+    DerivedAgain da1, da2;
+
+    (Derived)da1 = (Derived)da2;
+    /*verify-ast
+      BinaryOperator <col:5, col:29> 'Derived' '='
+      |-CStyleCastExpr <col:5, col:14> 'Derived' lvalue <NoOp>
+      | `-ImplicitCastExpr <col:14> 'Derived' lvalue <HLSLDerivedToBase (Derived)>
+      |   `-DeclRefExpr <col:14> 'DerivedAgain' lvalue Var 'da1' 'DerivedAgain'
+      `-ImplicitCastExpr <col:20, col:29> 'Derived' <LValueToRValue>
+        `-CStyleCastExpr <col:20, col:29> 'Derived' lvalue <NoOp>
+          `-ImplicitCastExpr <col:29> 'Derived' lvalue <HLSLDerivedToBase (Derived)>
+            `-DeclRefExpr <col:29> 'DerivedAgain' lvalue Var 'da2' 'DerivedAgain'
+    */
+
+    (Base)da1    = (Base)da2;
+    /*verify-ast
+      BinaryOperator <col:5, col:26> 'Base' '='
+      |-CStyleCastExpr <col:5, col:11> 'Base' lvalue <NoOp>
+      | `-ImplicitCastExpr <col:11> 'Base' lvalue <HLSLDerivedToBase (Derived -> Base)>
+      |   `-DeclRefExpr <col:11> 'DerivedAgain' lvalue Var 'da1' 'DerivedAgain'
+      `-ImplicitCastExpr <col:20, col:26> 'Base' <LValueToRValue>
+        `-CStyleCastExpr <col:20, col:26> 'Base' lvalue <NoOp>
+          `-ImplicitCastExpr <col:26> 'Base' lvalue <HLSLDerivedToBase (Derived -> Base)>
+            `-DeclRefExpr <col:26> 'DerivedAgain' lvalue Var 'da2' 'DerivedAgain'
+    */
+
+    Derived d;
+
+    (Base)d      = (Base)da2;
+    /*verify-ast
+      BinaryOperator <col:5, col:26> 'Base' '='
+      |-CStyleCastExpr <col:5, col:11> 'Base' lvalue <NoOp>
+      | `-ImplicitCastExpr <col:11> 'Base' lvalue <HLSLDerivedToBase (Base)>
+      |   `-DeclRefExpr <col:11> 'Derived' lvalue Var 'd' 'Derived'
+      `-ImplicitCastExpr <col:20, col:26> 'Base' <LValueToRValue>
+        `-CStyleCastExpr <col:20, col:26> 'Base' lvalue <NoOp>
+          `-ImplicitCastExpr <col:26> 'Base' lvalue <HLSLDerivedToBase (Derived -> Base)>
+            `-DeclRefExpr <col:26> 'DerivedAgain' lvalue Var 'da2' 'DerivedAgain'
+    */
+
+    da1          = (DerivedAgain)d; // expected-error {{cannot convert from 'Derived' to 'DerivedAgain'}}
+
+    return 1.0;
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -68,6 +68,7 @@ public:
   TEST_METHOD(RunTypemodsSyntax);
   TEST_METHOD(RunSemantics);
   TEST_METHOD(RunImplicitCasts);
+  TEST_METHOD(RunDerivedToBaseCasts);
   TEST_METHOD(RunLiterals);
   TEST_METHOD(RunEffectsSyntax);
   TEST_METHOD(RunVectorConditional);
@@ -275,6 +276,10 @@ TEST_F(VerifierTest, RunSemantics) {
 
 TEST_F(VerifierTest, RunImplicitCasts) {
   CheckVerifiesHLSL(L"implicit-casts.hlsl");
+}
+
+TEST_F(VerifierTest, RunDerivedToBaseCasts) {
+  CheckVerifiesHLSL(L"derived-to-base.hlsl");
 }
 
 TEST_F(VerifierTest, RunLiterals) {


### PR DESCRIPTION
This will enable us to trace back the whole base chain.