### PR TITLE
[spirv] Avoid getting constant zero for static resources

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/var.static.resource.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.static.resource.hlsl
@@ -1,0 +1,24 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// No inline initializer
+
+// CHECK: %sRWTex = OpVariable %_ptr_Private_type_2d_image Private
+// CHECK: %lRWTex = OpVariable %_ptr_Private_type_2d_image Private
+
+static RWTexture2D<float4> sRWTex;
+
+// No OpStore
+
+// CHECK-LABEL:    %main = OpFunction
+// CHECK-NEXT:             OpLabel
+// CHECK-NEXT:             OpFunctionCall %void %src_main
+// CHECK-NEXT:             OpReturn
+// CHECK-NEXT:             OpFunctionEnd
+
+// CHECK:     %src_main = OpFunction
+// CHECK-NEXT:             OpLabel
+// CHECK-NEXT:             OpReturn
+// CHECK-NEXT:             OpFunctionEnd
+void main() {
+    static RWTexture2D<float4> lRWTex;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -120,6 +120,9 @@ TEST_F(FileTest, VarInitCrossStorageClass) {
   runFileTest("var.init.cross-storage-class.hlsl");
 }
 TEST_F(FileTest, StaticVar) { runFileTest("var.static.hlsl"); }
+TEST_F(FileTest, UninitStaticResourceVar) {
+  runFileTest("var.static.resource.hlsl");
+}
 TEST_F(FileTest, GlobalMatrixVar) { runFileTest("var.global-mat.hlsl"); }
 
 // For prefix/postfix increment/decrement


### PR DESCRIPTION
For static resources not explicitly initialized, we cannot initialize
them since there are no meaningful zero values. Just do nothing.

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/1055