### PR TITLE
Fix denorm tests and sm support

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3222,7 +3222,7 @@ static void VerifyOutputWithExpectedValueFloat(
   }
 }
 
-static bool VerifyOutputWithExpectedValueFloatBool(
+static bool CompareOutputWithExpectedValueFloat(
     float output, float ref, LPCWSTR type, double tolerance,
     hlsl::DXIL::Float32DenormMode mode = hlsl::DXIL::Float32DenormMode::Any) {
   if (_wcsicmp(type, L"Relative") == 0) {
@@ -4843,9 +4843,9 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
          L"%6.8f, expected = %6.8f(%x) or %6.8f(%x)",
          i, p->input1, p->input2, p->output1, val1, *(int *)&val1, val2, *(int *)&val2);
        VERIFY_IS_TRUE(
-           VerifyOutputWithExpectedValueFloatBool(
+           CompareOutputWithExpectedValueFloat(
                p->output1, val1, Validation_Type, Validation_Tolerance, mode) ||
-           VerifyOutputWithExpectedValueFloatBool(
+           CompareOutputWithExpectedValueFloat(
                p->output1, val2, Validation_Type, Validation_Tolerance, mode));
     }
     else {
@@ -4889,7 +4889,7 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
 
   std::vector<WEX::Common::String> *Validation_Expected1 =
     &(handler.GetTableParamByName(L"Validation.Expected1")->m_StringTable);
-
+  
   // two expected outputs for any mode
   std::vector<WEX::Common::String> *Validation_Expected2 =
     &(handler.GetTableParamByName(L"Validation.Expected2")->m_StringTable);
@@ -4957,9 +4957,9 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
             L"%6.8f, expected = %6.8f(%x) or %6.8f(%x)",
             i, p->input1, p->input2, p->input3, p->output, val1, *(int *)&val1, val2, *(int *)&val2);
         VERIFY_IS_TRUE(
-            VerifyOutputWithExpectedValueFloatBool(
+            CompareOutputWithExpectedValueFloat(
                 p->output, val1, Validation_Type, Validation_Tolerance, mode) ||
-            VerifyOutputWithExpectedValueFloatBool(
+            CompareOutputWithExpectedValueFloat(
                 p->output, val2, Validation_Type, Validation_Tolerance, mode));
     }
     else {

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -360,7 +360,14 @@ public:
     D3D_SHADER_MODEL_6_1 = 0x61,
     D3D_SHADER_MODEL_6_2 = 0x62
   } D3D_SHADER_MODEL;
+
+#if WDK_NTDDI_VERSION == NTDDI_WIN10_RS2
+  static const D3D_SHADER_MODEL HIGHEST_SHADER_MODEL = D3D_SHADER_MODEL_6_0;
+#elif WDK_NTDDI_VERSION == NTDDI_WIN10_RS3
+  static const D3D_SHADER_MODEL HIGHEST_SHADER_MODEL = D3D_SHADER_MODEL_6_1;
+#else
   static const D3D_SHADER_MODEL HIGHEST_SHADER_MODEL = D3D_SHADER_MODEL_6_2;
+#endif
 
   dxc::DxcDllSupport m_support;
   VersionSupportInfo m_ver;
@@ -435,7 +442,12 @@ public:
 
   bool CreateDevice(_COM_Outptr_ ID3D12Device **ppDevice,
                     D3D_SHADER_MODEL testModel = D3D_SHADER_MODEL_6_0) {
-    DXASSERT_NOMSG(testModel <= HIGHEST_SHADER_MODEL);
+    if (testModel > HIGHEST_SHADER_MODEL) {
+      UINT minor = testModel & 0x0f;
+      LogCommentFmt(L"Installed SDK does not support "
+          L"shader model 6.%1u", minor);
+      return false;
+    }
     const D3D_FEATURE_LEVEL FeatureLevelRequired = D3D_FEATURE_LEVEL_11_0;
     CComPtr<IDXGIFactory4> factory;
     CComPtr<ID3D12Device> pDevice;
@@ -2837,6 +2849,7 @@ static TableParameter DenormTertiaryFPOpParameters[] = {
     { L"Validation.Input2", TableParameter::STRING_TABLE, true },
     { L"Validation.Input3", TableParameter::STRING_TABLE, true },
     { L"Validation.Expected1", TableParameter::STRING_TABLE, true },
+    { L"Validation.Expected2", TableParameter::STRING_TABLE, false },
     { L"Validation.Type", TableParameter::STRING, true },
     { L"Validation.Tolerance", TableParameter::DOUBLE, true },
 };
@@ -3206,6 +3219,21 @@ static void VerifyOutputWithExpectedValueFloat(
     VERIFY_IS_TRUE(CompareFloatULP(output, ref, (int)tolerance, mode));
   } else {
     LogErrorFmt(L"Failed to read comparison type %S", type);
+  }
+}
+
+static bool VerifyOutputWithExpectedValueFloatBool(
+    float output, float ref, LPCWSTR type, double tolerance,
+    hlsl::DXIL::Float32DenormMode mode = hlsl::DXIL::Float32DenormMode::Any) {
+  if (_wcsicmp(type, L"Relative") == 0) {
+    return CompareFloatRelativeEpsilon(output, ref, (int)tolerance, mode);
+  } else if (_wcsicmp(type, L"Epsilon") == 0) {
+    return CompareFloatEpsilon(output, ref, (float)tolerance, mode);
+  } else if (_wcsicmp(type, L"ULP") == 0) {
+    return CompareFloatULP(output, ref, (int)tolerance, mode);
+  } else {
+    LogErrorFmt(L"Failed to read comparison type %S", type);
+    return false;
   }
 }
 
@@ -4750,6 +4778,9 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
 
   std::vector<WEX::Common::String> *Validation_Expected1 =
     &(handler.GetTableParamByName(L"Validation.Expected1")->m_StringTable);
+  // two expected outputs for any mode
+  std::vector<WEX::Common::String> *Validation_Expected2 =
+    &(handler.GetTableParamByName(L"Validation.Expected2")->m_StringTable);
 
   LPCWSTR Validation_Type = handler.GetTableParamByName(L"Validation.Type")->m_str;
   double Validation_Tolerance = handler.GetTableParamByName(L"Validation.Tolerance")->m_double;
@@ -4763,7 +4794,10 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
   else if (strcmp(Arguments.m_psz, "-denorm ftz") == 0) {
     mode = Float32DenormMode::FTZ;
   }
-
+  if (mode == Float32DenormMode::Any) {
+    DXASSERT(Validation_Expected2->size() == Validation_Expected1->size(),
+             "must have same number of expected values");
+  }
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
     pDevice, m_support, pStream, "BinaryFPOp",
     // this callbacked is called when the test
@@ -4796,17 +4830,34 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
   SBinaryFPOp *pPrimitives = (SBinaryFPOp *)data.data();
   WEX::TestExecution::DisableVerifyExceptions dve;
 
-
   for (unsigned i = 0; i < count; ++i) {
     SBinaryFPOp *p = &pPrimitives[i];
-    LPCWSTR str1 = (*Validation_Expected1)[i % Validation_Expected1->size()];
-    float val1;
-    VERIFY_SUCCEEDED(ParseDataToFloat(str1, val1));
-    LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, output1 = "
-      L"%6.8f, expected1 = %6.8f",
-      i, p->input1, p->input2, p->output1, val1);
-    VerifyOutputWithExpectedValueFloat(p->output1, val1, Validation_Type,
-      Validation_Tolerance, mode);
+    if (mode == Float32DenormMode::Any) {
+       LPCWSTR str1 = (*Validation_Expected1)[i % Validation_Expected1->size()];
+       LPCWSTR str2 = (*Validation_Expected2)[i % Validation_Expected2->size()];
+       float val1;
+       float val2;
+       VERIFY_SUCCEEDED(ParseDataToFloat(str1, val1));
+       VERIFY_SUCCEEDED(ParseDataToFloat(str2, val2));
+       LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, output = "
+         L"%6.8f, expected = %6.8f(%x) or %6.8f(%x)",
+         i, p->input1, p->input2, p->output1, val1, *(int *)&val1, val2, *(int *)&val2);
+       VERIFY_IS_TRUE(
+           VerifyOutputWithExpectedValueFloatBool(
+               p->output1, val1, Validation_Type, Validation_Tolerance, mode) ||
+           VerifyOutputWithExpectedValueFloatBool(
+               p->output1, val2, Validation_Type, Validation_Tolerance, mode));
+    }
+    else {
+       LPCWSTR str1 = (*Validation_Expected1)[i % Validation_Expected1->size()];
+       float val1;
+       VERIFY_SUCCEEDED(ParseDataToFloat(str1, val1));
+       LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, output = "
+         L"%6.8f, expected = %6.8f(%a)",
+         i, p->input1, p->input2, p->output1, val1, *(int *)&val1);
+       VerifyOutputWithExpectedValueFloat(p->output1, val1, Validation_Type,
+          Validation_Tolerance, mode);
+    }
   }
 }
 
@@ -4836,9 +4887,12 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
   std::vector<WEX::Common::String> *Validation_Input3 =
     &(handler.GetTableParamByName(L"Validation.Input3")->m_StringTable);
 
-  std::vector<WEX::Common::String> *Validation_Expected =
+  std::vector<WEX::Common::String> *Validation_Expected1 =
     &(handler.GetTableParamByName(L"Validation.Expected1")->m_StringTable);
 
+  // two expected outputs for any mode
+  std::vector<WEX::Common::String> *Validation_Expected2 =
+    &(handler.GetTableParamByName(L"Validation.Expected2")->m_StringTable);
   LPCWSTR Validation_Type = handler.GetTableParamByName(L"Validation.Type")->m_str;
   double Validation_Tolerance = handler.GetTableParamByName(L"Validation.Tolerance")->m_double;
   size_t count = Validation_Input1->size();
@@ -4851,7 +4905,10 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
   else if (strcmp(Arguments.m_psz, "-denorm ftz") == 0) {
     mode = Float32DenormMode::FTZ;
   }
-
+  if (mode == Float32DenormMode::Any) {
+    DXASSERT(Validation_Expected2->size() == Validation_Expected1->size(),
+      "must have same number of expected values");
+  }
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
     pDevice, m_support, pStream, "TertiaryFPOp",
     // this callbacked is called when the test
@@ -4889,14 +4946,32 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
 
   for (unsigned i = 0; i < count; ++i) {
     STertiaryFPOp *p = &pPrimitives[i];
-    LPCWSTR str = (*Validation_Expected)[i % Validation_Expected->size()];
-    float val;
-    VERIFY_SUCCEEDED(ParseDataToFloat(str, val));
-    LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, input3 = %6.8f, output1 = "
-      L"%6.8f, expected = %6.8f",
-      i, p->input1, p->input2, p->input3, p->output, val);
-    VerifyOutputWithExpectedValueFloat(p->output, val, Validation_Type,
-      Validation_Tolerance);
+    if (mode == Float32DenormMode::Any) {
+        LPCWSTR str1 = (*Validation_Expected1)[i % Validation_Expected1->size()];
+        LPCWSTR str2 = (*Validation_Expected2)[i % Validation_Expected2->size()];
+        float val1;
+        float val2;
+        VERIFY_SUCCEEDED(ParseDataToFloat(str1, val1));
+        VERIFY_SUCCEEDED(ParseDataToFloat(str2, val2));
+        LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, input3 = %6.8f, output = "
+            L"%6.8f, expected = %6.8f(%x) or %6.8f(%x)",
+            i, p->input1, p->input2, p->input3, p->output, val1, *(int *)&val1, val2, *(int *)&val2);
+        VERIFY_IS_TRUE(
+            VerifyOutputWithExpectedValueFloatBool(
+                p->output, val1, Validation_Type, Validation_Tolerance, mode) ||
+            VerifyOutputWithExpectedValueFloatBool(
+                p->output, val2, Validation_Type, Validation_Tolerance, mode));
+    }
+    else {
+        LPCWSTR str1 = (*Validation_Expected1)[i % Validation_Expected1->size()];
+        float val1;
+        VERIFY_SUCCEEDED(ParseDataToFloat(str1, val1));
+        LogCommentFmt(L"element #%u, input1 = %6.8f, input2 = %6.8f, input3 = %6.8f, output = "
+            L"%6.8f, expected = %6.8f(%a)",
+            i, p->input1, p->input2, p->input3, p->output, val1, *(int *)&val1);
+        VerifyOutputWithExpectedValueFloat(p->output, val1, Validation_Type,
+            Validation_Tolerance, mode);
+    }
   }
 }
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -71,6 +71,7 @@ static const GUID D3D12ExperimentalShaderModelsID = { /* 76f5573e-f13a-40f5-b297
 using namespace DirectX;
 using namespace hlsl_test;
 
+
 template <typename TSequence, typename T>
 static bool contains(TSequence s, const T &val) {
   return std::cend(s) != std::find(std::cbegin(s), std::cend(s), val);
@@ -359,8 +360,9 @@ public:
     D3D_SHADER_MODEL_6_1 = 0x61,
     D3D_SHADER_MODEL_6_2 = 0x62
   } D3D_SHADER_MODEL;
+  static const D3D_SHADER_MODEL HIGHEST_SHADER_MODEL = D3D_SHADER_MODEL_6_2;
 
- dxc::DxcDllSupport m_support;
+  dxc::DxcDllSupport m_support;
   VersionSupportInfo m_ver;
   bool m_ExperimentalModeEnabled = false;
 
@@ -433,6 +435,7 @@ public:
 
   bool CreateDevice(_COM_Outptr_ ID3D12Device **ppDevice,
                     D3D_SHADER_MODEL testModel = D3D_SHADER_MODEL_6_0) {
+    DXASSERT_NOMSG(testModel <= HIGHEST_SHADER_MODEL);
     const D3D_FEATURE_LEVEL FeatureLevelRequired = D3D_FEATURE_LEVEL_11_0;
     CComPtr<IDXGIFactory4> factory;
     CComPtr<ID3D12Device> pDevice;
@@ -477,10 +480,10 @@ public:
       } D3D12_FEATURE_DATA_SHADER_MODEL;
       const UINT D3D12_FEATURE_SHADER_MODEL = 7;
       D3D12_FEATURE_DATA_SHADER_MODEL SMData;
-      SMData.HighestShaderModel = D3D_SHADER_MODEL_6_0;
+      SMData.HighestShaderModel = HIGHEST_SHADER_MODEL;
       VERIFY_SUCCEEDED(pDevice->CheckFeatureSupport(
         (D3D12_FEATURE)D3D12_FEATURE_SHADER_MODEL, &SMData, sizeof(SMData)));
-      if (SMData.HighestShaderModel != testModel) {
+      if (SMData.HighestShaderModel < testModel) {
         UINT minor = testModel & 0x0f;
         LogCommentFmt(L"The selected device does not support "
                       L"shader model 6.%1u", minor);

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -5777,6 +5777,7 @@
             <ParameterType Array="true" Name="Validation.Input1">String</ParameterType>
             <ParameterType Array="true" Name="Validation.Input2">String</ParameterType>
             <ParameterType Array="true" Name="Validation.Expected1">String</ParameterType>
+            <ParameterType Array="true" Name="Validation.Expected2">String</ParameterType>
         </ParameterTypes>
         <Row Name="FDivDenormFTZ">
             <Parameter Name="Validation.Type">ulp</Parameter>
@@ -5809,7 +5810,7 @@
             </Parameter>
             <Parameter Name="Validation.Expected1">
                 <Value>0</Value>
-                <Value>1</Value>
+                <Value>NaN</Value>
                 <Value>0</Value>
                 <Value>0</Value>
             </Parameter>
@@ -5846,9 +5847,15 @@
             </Parameter>
             <Parameter Name="Validation.Expected1">
                 <Value>0x00FC0000</Value>
-                <Value>0</Value>
+                <Value>0x00400000</Value>
                 <Value>0</Value>
                 <Value>0x00700000</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected2">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm any</Parameter>
         </Row>
@@ -5890,6 +5897,13 @@
                 <Value>0x01960000</Value>
                 <Value>0x32400000</Value>
             </Parameter>
+            <Parameter Name="Validation.Expected2">
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+            </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm any</Parameter>
         </Row>
         <Row Name="FDivDenormAny">
@@ -5926,6 +5940,12 @@
                 <Value>1</Value>
                 <Value>0x00404040</Value>
                 <Value>0x00400000</Value>
+            </Parameter>
+            <Parameter Name="Validation.Expected2">
+                <Value>0</Value>
+                <Value>NaN</Value>
+                <Value>0</Value>
+                <Value>0</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm any</Parameter>
         </Row>
@@ -5964,8 +5984,8 @@
                 <Value>0</Value>
                 <Value>0</Value>
                 <Value>0</Value>
-                <Value>0x01960000</Value>
-                <Value>0x32400000</Value>
+                <Value>0</Value>
+                <Value>0</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm ftz</Parameter>
         </Row>
@@ -5999,7 +6019,7 @@
                 <Value>0x800E0000</Value>
             </Parameter>
             <Parameter Name="Validation.Expected1">
-                <Value>0x00FC0000</Value>
+                <Value>0</Value>
                 <Value>0</Value>
                 <Value>0</Value>
                 <Value>0</Value>
@@ -6074,7 +6094,7 @@
             </Parameter>
             <Parameter Name="Validation.Expected1">
                 <Value>0x0</Value>
-                <Value>0x00FE0000</Value>
+                <Value>0</Value>
                 <Value>0</Value>
                 <Value>0</Value>
             </Parameter>
@@ -6152,6 +6172,12 @@
                 <Value>0x007F0000</Value>
                 <Value>0x007A0000</Value>
             </Parameter>
+            <Parameter Name="Validation.Expected2">
+                <Value>0x0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+                <Value>0</Value>
+            </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm any</Parameter>
         </Row>
         <Row Name="FAddDenormPreserve">
@@ -6185,7 +6211,7 @@
             </Parameter>
             <Parameter Name="Validation.Expected1">
                 <Value>0x00FC0000</Value>
-                <Value>0</Value>
+                <Value>0x00400000</Value>
                 <Value>0</Value>
                 <Value>0x00700000</Value>
             </Parameter>
@@ -6243,6 +6269,7 @@
             <ParameterType Array="true" Name="Validation.Input2">String</ParameterType>
             <ParameterType Array="true" Name="Validation.Input3">String</ParameterType>
             <ParameterType Array="true" Name="Validation.Expected1">String</ParameterType>
+            <ParameterType Array="true" Name="Validation.Expected2">String</ParameterType>
         </ParameterTypes>
         <Row Name="FMadDenormPreserve">
             <Parameter Name="Validation.Type">ulp</Parameter>
@@ -6320,6 +6347,11 @@
                 <Value>0x80700000</Value>
                 <Value>0x01380000</Value>
             </Parameter>
+            <Parameter Name="Validation.Expected2">
+                <Value>0</Value>
+                <Value>0x00800000</Value>
+                <Value>0x00800000</Value>
+            </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm any</Parameter>
         </Row>
         <Row Name="FMadDenormFTZ">
@@ -6356,8 +6388,8 @@
             </Parameter>
             <Parameter Name="Validation.Expected1">
                 <Value>0</Value>
-                <Value>0</Value>
-                <Value>0x01380000</Value>
+                <Value>0x00800000</Value>
+                <Value>0x00800000</Value>
             </Parameter>
             <Parameter Name="ShaderOp.Arguments">-denorm ftz</Parameter>
         </Row>

--- a/utils/hct/hctdb_test.py
+++ b/utils/hct/hctdb_test.py
@@ -110,7 +110,7 @@ def add_test_case_denorm(test_name, inst_names, validation_type, validation_tole
                   output_lists_preserve, shader_target, shader_text, shader_arguments="-denorm preserve")
     # we can expect the same output for "any" and "preserve" mode. We should make sure that for validation zero are accepted outputs for denormal outputs.
     add_test_case(test_name + "Any", inst_names, validation_type, validation_tolerance, input_lists,
-                  output_lists_preserve, shader_target, shader_text, shader_arguments="-denorm any")
+                  output_lists_preserve + output_lists_ftz, shader_target, shader_text, shader_arguments="-denorm any")
 
 
 g_shader_texts = {
@@ -793,22 +793,22 @@ def add_test_cases():
     # Denorm Binary Float
     add_test_case_denorm('FAddDenorm', ['FAdd'], 'ulp', 1,
     [['0x007E0000', '0x00200000', '0x007E0000', '0x007E0000'],['0x007E0000','0x00200000', '0x807E0000', '0x800E0000']],
-    [['0x00FC0000','0', '0', '0']],
-    [['0x00FC0000','0', '0', '0x00700000']],
+    [['0','0', '0', '0']],
+    [['0x00FC0000','0x00400000', '0', '0x00700000']],
     'cs_6_2', get_shader_text("binary float", "+"))
     add_test_case_denorm('FSubDenorm', ['FSub'], 'ulp', 1,
     [['0x007E0000', '0x007F0000', '0x00FF0000', '0x007A0000'],['0x007E0000', '0x807F0000', '0x00800000', '0']],
-    [['0x0', '0x00FE0000', '0', '0']],
+    [['0x0', '0', '0', '0']],
     [['0x0', '0x00FE0000', '0x007F0000', '0x007A0000']],
     'cs_6_2', get_shader_text("binary float", "-"))
     add_test_case_denorm('FDivDenorm', ['FDiv'], 'ulp', 1,
     [['0x007F0000', '0x007F0000', '0x40000000', '0x00800000'],['1', '0x007F0000', '0x7F7F0000', '0x40000000']],
-    [['0', '1', '0', '0']],
+    [['0', 'NaN', '0', '0']],
     [['0x007F0000', '1', '0x00404040', '0x00400000']],
     'cs_6_2', get_shader_text("binary float", "/"))
     add_test_case_denorm('FMulDenorm', ['FMul'], 'ulp', 1,
     [['0x00000300', '0x007F0000', '0x007F0000', '0x001E0000', '0x00000300'],['128', '1', '0x007F0000', '20', '0x78000000']],
-    [['0', '0', '0', '0x01960000', '0x32400000']],
+    [['0', '0', '0', '0', '0']],
     [['0x00018000','0x007F0000', '0', '0x01960000', '0x32400000']],
     'cs_6_2', get_shader_text("binary float", "*"))
     # Tertiary Float
@@ -840,7 +840,7 @@ def add_test_cases():
     [['0x80780000', '0x80780000', '0x00780000'],
      ['1', '2', '2'],
      ['0x80780000', '0x00800000', '0x00800000']],
-    [['0', '0', '0x01380000']],
+    [['0', '0x00800000', '0x00800000']],
      [['0x80780000', '0x80700000', '0x01380000']],
                   'cs_6_2', get_shader_text("tertiary float", "mad"))
 
@@ -1528,12 +1528,12 @@ def generate_table_for_taef():
             ET.SubElement(
                 root, "Table", attrib={
                     "Id": "DenormBinaryFloatOpTable"
-                }), 2, 1)
+                }), 2, 2) # 2 sets of expected values for any mode
         generate_parameter_types(
             ET.SubElement(
                 root, "Table", attrib={
                     "Id": "DenormTertiaryFloatOpTable"
-                }), 3, 1)
+                }), 3, 2)
 
         for case in g_test_cases.values():
             cur_inst = case.insts[0]


### PR DESCRIPTION
Fixing device support for > SM 6.0 and updating dxexp
Also fixing the following tests:
    ExecutionTest::DenormBinaryFloatOpTest#FDivDenormFTZ
    ExecutionTest::DenormBinaryFloatOpTest#FAddDenormAny
    ExecutionTest::DenormBinaryFloatOpTest#FMulDenormAny
    ExecutionTest::DenormBinaryFloatOpTest#FDivDenormAny
    ExecutionTest::DenormBinaryFloatOpTest#FMulDenormFTZ
    ExecutionTest::DenormBinaryFloatOpTest#FAddDenormFTZ
    ExecutionTest::DenormBinaryFloatOpTest#FSubDenormFTZ
    ExecutionTest::DenormBinaryFloatOpTest#FSubDenormAny
    ExecutionTest::DenormTertiaryFloatOpTest#FMadDenormAny
    ExecutionTest::DenormTertiaryFloatOpTest#FMadDenormFTZ
