### PR TITLE
[spirv] Add support for NonUniformResourceIndex

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -1679,6 +1679,22 @@ HLSL Intrinsic Function   GLSL Extended Instruction
 ``trunc``               ``Trunc``
 ======================= ===================================
 
+Emulating using SPIR-V functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``NonUniformResourceIndex`` is emulated using a SPIR-V function corresponding
+to the following HLSL source code:
+
+.. code:: hlsl
+
+  uint NonUniformResourceIndex(uint index) {
+    while (true)
+      if (WaveReadLaneFirst(index) == index)
+        return index;
+
+    return 0; // Unreachable
+  }
+
 HLSL OO features
 ================
 

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -303,6 +303,9 @@ public:
   /// \brief Creates an OpEndPrimitive instruction.
   void createEndPrimitive();
 
+  /// \brief Creates an OpSubgroupFirstInvocationKHR instruciton.
+  uint32_t createSubgroupFirstInvocation(uint32_t resultType, uint32_t value);
+
   // === SPIR-V Module Structure ===
 
   inline void requireCapability(spv::Capability);

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -705,6 +705,18 @@ void ModuleBuilder::createEndPrimitive() {
   insertPoint->appendInstruction(std::move(constructSite));
 }
 
+uint32_t ModuleBuilder::createSubgroupFirstInvocation(uint32_t resultType,
+                                                      uint32_t value) {
+  assert(insertPoint && "null insert point");
+  addExtension("SPV_KHR_shader_ballot");
+  requireCapability(spv::Capability::SubgroupBallotKHR);
+
+  uint32_t resultId = theContext.takeNextId();
+  instBuilder.opSubgroupFirstInvocationKHR(resultType, resultId, value).x();
+  insertPoint->appendInstruction(std::move(constructSite));
+  return resultId;
+}
+
 void ModuleBuilder::addExecutionMode(uint32_t entryPointId,
                                      spv::ExecutionMode em,
                                      llvm::ArrayRef<uint32_t> params) {

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -789,9 +789,15 @@ private:
   /// primitive in GS.
   uint32_t processStreamOutputRestart(const CXXMemberCallExpr *expr);
 
+  /// \brief Generates SPIR-V instructions to call NonUniformResourceIndex.
+  uint32_t processNonUniformResourceIndex(const CallExpr *expr);
+
   /// \brief Emulates GetSamplePosition() for standard sample settings, i.e.,
   /// with 1, 2, 4, 8, or 16 samples. Returns float2(0) for other cases.
   uint32_t emitGetSamplePosition(uint32_t sampleCount, uint32_t sampleIndex);
+
+  /// \brief Emits the function to emulate NonUniformResourceIndex.
+  void emitNonUniformResourceIndex(uint32_t functionId);
 
 private:
   /// \brief Takes a vector of size 4, and returns a vector of size 1 or 2 or 3
@@ -953,6 +959,11 @@ private:
   /// This is the Patch Constant Function. This function is not explicitly
   /// called from the entry point function.
   FunctionDecl *patchConstFunc;
+
+  /// The <result-id> for the function emulating NonUniformResourceIndex.
+  /// 0 means NonUniformResourceIndex is not used in thes source code so that
+  /// we don't need to emit the emulating function.
+  uint32_t nonUniformResourceIndexFnId;
 };
 
 void SPIRVEmitter::doDeclStmt(const DeclStmt *declStmt) {

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.non-uniform-resource-index.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.non-uniform-resource-index.hlsl
@@ -1,0 +1,40 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpCapability SubgroupBallotKHR
+// CHECK: OpExtension "SPV_KHR_shader_ballot"
+
+// CHECK: [[fnType:%\d+]] = OpTypeFunction %uint %_ptr_Function_uint
+
+Texture2D gTex[5];
+SamplerState gSamp;
+
+float4 main(uint id : ID) : SV_Target {
+// CHECK: OpFunctionCall %uint %fn_NonUniformResourceIndex
+    return gTex[NonUniformResourceIndex(id)].Sample(gSamp, float2(1., 2.)) +
+    // Make sure we are calling the same function
+// CHECK: OpFunctionCall %uint %fn_NonUniformResourceIndex
+           gTex[NonUniformResourceIndex(id)].Sample(gSamp, float2(3., 4.));
+}
+
+// CHECK:      %fn_NonUniformResourceIndex = OpFunction %uint None [[fnType]]
+// CHECK-NEXT:          %index = OpFunctionParameter %_ptr_Function_uint
+// CHECK-NEXT:     %bb_entry_0 = OpLabel
+// CHECK-NEXT:                   OpBranch %while_check
+// CHECK-NEXT:    %while_check = OpLabel
+// CHECK-NEXT:                   OpLoopMerge %while_merge %while_continue None
+// CHECK-NEXT:                   OpBranchConditional %true %while_body %while_merge
+// CHECK-NEXT:     %while_body = OpLabel
+// CHECK-NEXT:  [[index:%\d+]] = OpLoad %uint %index
+// CHECK-NEXT:    [[ret:%\d+]] = OpSubgroupFirstInvocationKHR %uint [[index]]
+// CHECK-NEXT:     [[eq:%\d+]] = OpIEqual %bool [[ret]] [[index]]
+// CHECK-NEXT:                   OpSelectionMerge %if_merge None
+// CHECK-NEXT:                   OpBranchConditional [[eq]] %if_true %if_merge
+// CHECK-NEXT:        %if_true = OpLabel
+// CHECK-NEXT:                   OpReturnValue [[index]]
+// CHECK-NEXT:       %if_merge = OpLabel
+// CHECK-NEXT:                   OpBranch %while_continue
+// CHECK-NEXT: %while_continue = OpLabel
+// CHECK-NEXT:                   OpBranch %while_check
+// CHECK-NEXT:    %while_merge = OpLabel
+// CHECK-NEXT:                   OpReturnValue %uint_0
+// CHECK-NEXT:                   OpFunctionEnd

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -902,6 +902,9 @@ TEST_F(FileTest, IntrinsicsGetRenderTargetSamplePosition) {
   runFileTest("intrinsics.get-render-target-sample-position.hlsl",
               Expect::Failure);
 }
+TEST_F(FileTest, IntrinsicsNonUniformResourceIndex) {
+  runFileTest("intrinsics.non-uniform-resource-index.hlsl");
+}
 
 // For attributes
 TEST_F(FileTest, AttributeNumThreads) {


### PR DESCRIPTION
We emulate the functionality of NonUniformResourceIndex with
the following source code:

```hlsl
uint NonUniformResourceIndex(uint index) {
  while (true)
    if (WaveReadLaneFirst(index) == index)
      return index;

  return 0; // Unreachable
}
```