### PR TITLE
[spirv] Remove the "var." prefix on cbuffer/tbuffer names

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -555,9 +555,8 @@ uint32_t DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
   const auto usageKind =
       decl->isCBuffer() ? ContextUsageKind::CBuffer : ContextUsageKind::TBuffer;
   const std::string structName = "type." + decl->getName().str();
-  const std::string varName = "var." + decl->getName().str();
-  const uint32_t bufferVar =
-      createVarOfExplicitLayoutStruct(decl, usageKind, structName, varName);
+  const uint32_t bufferVar = createVarOfExplicitLayoutStruct(
+      decl, usageKind, structName, decl->getName());
 
   // We still register all VarDecls seperately here. All the VarDecls are
   // mapped to the <result-id> of the buffer object, which means when querying

--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.no-op.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.no-op.hlsl
@@ -15,7 +15,7 @@ struct T {
 float4 main() : SV_Target {
     T t;
 
-// CHECK:        [[gscalars_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_1 %var_Data %int_0
+// CHECK:        [[gscalars_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_1 %Data %int_0
 // CHECK-NEXT:   [[gscalars_val:%\d+]] = OpLoad %_arr_float_uint_1 [[gscalars_ptr]]
 // CHECK-NEXT:    [[scalars_ptr:%\d+]] = OpAccessChain %_ptr_Function__arr_float_uint_1_0 %t %int_0
 // CHECK-NEXT:      [[gscalars0:%\d+]] = OpCompositeExtract %float [[gscalars_val]] 0
@@ -23,7 +23,7 @@ float4 main() : SV_Target {
 // CHECK-NEXT:                           OpStore [[scalars0_ptr]] [[gscalars0]]
     t.scalars = gScalars;
 
-// CHECK-NEXT: [[gvecs_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_2 %var_Data %int_1
+// CHECK-NEXT: [[gvecs_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_v4float_uint_2 %Data %int_1
 // CHECK-NEXT: [[gvecs_val:%\d+]] = OpLoad %_arr_v4float_uint_2 [[gvecs_ptr]]
 // CHECK-NEXT:  [[vecs_ptr:%\d+]] = OpAccessChain %_ptr_Function__arr_v4float_uint_2_0 %t %int_1
 // CHECK-NEXT:    [[gvecs0:%\d+]] = OpCompositeExtract %v4float [[gvecs_val]] 0
@@ -34,7 +34,7 @@ float4 main() : SV_Target {
 // CHECK-NEXT:                      OpStore [[vecs1_ptr]] [[gvecs1]]
     t.vecs    = gVecs;
 
-// CHECK-NEXT: [[gmats_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_1 %var_Data %int_2
+// CHECK-NEXT: [[gmats_ptr:%\d+]] = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_1 %Data %int_2
 // CHECK-NEXT: [[gmats_val:%\d+]] = OpLoad %_arr_mat2v3float_uint_1 [[gmats_ptr]]
 // CHECK-NEXT:  [[mats_ptr:%\d+]] = OpAccessChain %_ptr_Function__arr_mat2v3float_uint_1_0 %t %int_2
 // CHECK-NEXT:    [[gmats0:%\d+]] = OpCompositeExtract %mat2v3float [[gmats_val]] 0

--- a/tools/clang/test/CodeGenSPIRV/fn.ctbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.ctbuffer.hlsl
@@ -27,7 +27,7 @@ tbuffer MyTBuffer {
 float4 main() : SV_Target {
 // %S vs %S_0: need destruction and construction
 // CHECK:         %temp_var_S = OpVariable %_ptr_Function_S_0 Function
-// CHECK:       [[tb_s:%\d+]] = OpAccessChain %_ptr_Uniform_S %var_MyTBuffer %int_1
+// CHECK:       [[tb_s:%\d+]] = OpAccessChain %_ptr_Uniform_S %MyTBuffer %int_1
 // CHECK-NEXT:     [[s:%\d+]] = OpLoad %S [[tb_s]]
 // CHECK-NEXT: [[s_val:%\d+]] = OpCompositeExtract %v3float [[s]] 0
 // CHECK-NEXT:   [[ptr:%\d+]] = OpAccessChain %_ptr_Function_v3float %temp_var_S %uint_0
@@ -37,11 +37,11 @@ float4 main() : SV_Target {
 }
 
 // CHECK:      %get_cb_val = OpFunction %v4float None {{%\d+}}
-// CHECK:         {{%\d+}} = OpAccessChain %_ptr_Uniform_v4float %var_MyCBuffer %int_0
+// CHECK:         {{%\d+}} = OpAccessChain %_ptr_Uniform_v4float %MyCBuffer %int_0
 
 // CHECK:     %S_get_s_val = OpFunction %v3float None {{%\d+}}
 // CHECK-NEXT: %param_this = OpFunctionParameter %_ptr_Function_S_0
 // CHECK:         {{%\d+}} = OpAccessChain %_ptr_Function_v3float %param_this %int_0
 
 // CHECK:      %get_tb_val = OpFunction %float None {{%\d+}}
-// CHECK:         {{%\d+}} = OpAccessChain %_ptr_Uniform_float %var_MyTBuffer %int_0
+// CHECK:         {{%\d+}} = OpAccessChain %_ptr_Uniform_float %MyTBuffer %int_0

--- a/tools/clang/test/CodeGenSPIRV/op.cbuffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.cbuffer.access.hlsl
@@ -13,22 +13,22 @@ cbuffer MyCbuffer : register(b1) {
 };
 
 float main() : A {
-// CHECK:      [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %var_MyCbuffer %int_0
+// CHECK:      [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %MyCbuffer %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[a]]
 
-// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %var_MyCbuffer %int_1
+// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %MyCbuffer %int_1
 // CHECK-NEXT: [[b0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[b]] %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[b0]]
 
-// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v4float %var_MyCbuffer %int_2
+// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v4float %MyCbuffer %int_2
 // CHECK-NEXT: [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float [[c]] %uint_1 %uint_2
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[c12]]
 
-// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_S %var_MyCbuffer %int_3
+// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_S %MyCbuffer %int_3
 // CHECK-NEXT: [[s0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[s]] %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[s0]]
 
-// CHECK:      [[t:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %var_MyCbuffer %int_4
+// CHECK:      [[t:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyCbuffer %int_4
 // CHECK-NEXT: [[t3:%\d+]] = OpAccessChain %_ptr_Uniform_float [[t]] %int_3
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[t3]]
     return a + b.x + c[1][2] + s.f + t[3];

--- a/tools/clang/test/CodeGenSPIRV/op.tbuffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.tbuffer.access.hlsl
@@ -13,22 +13,22 @@ tbuffer MyTbuffer : register(t0) {
 };
 
 float main() : A {
-// CHECK:      [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %var_MyTbuffer %int_0
+// CHECK:      [[a:%\d+]] = OpAccessChain %_ptr_Uniform_float %MyTbuffer %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[a]]
 
-// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %var_MyTbuffer %int_1
+// CHECK:      [[b:%\d+]] = OpAccessChain %_ptr_Uniform_v2float %MyTbuffer %int_1
 // CHECK-NEXT: [[b0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[b]] %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[b0]]
 
-// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v4float %var_MyTbuffer %int_2
+// CHECK:      [[c:%\d+]] = OpAccessChain %_ptr_Uniform_mat3v4float %MyTbuffer %int_2
 // CHECK-NEXT: [[c12:%\d+]] = OpAccessChain %_ptr_Uniform_float [[c]] %uint_1 %uint_2
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[c12]]
 
-// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_S %var_MyTbuffer %int_3
+// CHECK:      [[s:%\d+]] = OpAccessChain %_ptr_Uniform_S %MyTbuffer %int_3
 // CHECK-NEXT: [[s0:%\d+]] = OpAccessChain %_ptr_Uniform_float [[s]] %int_0
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[s0]]
 
-// CHECK:      [[t:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %var_MyTbuffer %int_4
+// CHECK:      [[t:%\d+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyTbuffer %int_4
 // CHECK-NEXT: [[t3:%\d+]] = OpAccessChain %_ptr_Uniform_float [[t]] %int_3
 // CHECK-NEXT: {{%\d+}} = OpLoad %float [[t3]]
     return a + b.x + c[1][2] + s.f + t[3];

--- a/tools/clang/test/CodeGenSPIRV/type.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.cbuffer.hlsl
@@ -8,13 +8,13 @@
 // CHECK-NEXT: OpMemberName %type_MyCbuffer 4 "s"
 // CHECK-NEXT: OpMemberName %type_MyCbuffer 5 "t"
 
-// CHECK:      OpName %var_MyCbuffer "var.MyCbuffer"
+// CHECK:      OpName %MyCbuffer "MyCbuffer"
 
 // CHECK:      OpName %type_AnotherCBuffer "type.AnotherCBuffer"
 // CHECK-NEXT: OpMemberName %type_AnotherCBuffer 0 "m"
 // CHECK-NEXT: OpMemberName %type_AnotherCBuffer 1 "n"
 
-// CHECK:      OpName %var_AnotherCBuffer "var.AnotherCBuffer"
+// CHECK:      OpName %AnotherCBuffer "AnotherCBuffer"
 
 struct S {
     float  f1;
@@ -39,8 +39,8 @@ cbuffer AnotherCBuffer : register(b2) {
 
 // CHECK: %type_AnotherCBuffer = OpTypeStruct %v3float %v4float
 
-// CHECK: %var_MyCbuffer = OpVariable %_ptr_Uniform_type_MyCbuffer Uniform
-// CHECK: %var_AnotherCBuffer = OpVariable %_ptr_Uniform_type_AnotherCBuffer Uniform
+// CHECK: %MyCbuffer = OpVariable %_ptr_Uniform_type_MyCbuffer Uniform
+// CHECK: %AnotherCBuffer = OpVariable %_ptr_Uniform_type_AnotherCBuffer Uniform
 
 void main() {
 }

--- a/tools/clang/test/CodeGenSPIRV/type.tbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.tbuffer.hlsl
@@ -8,13 +8,13 @@
 // CHECK-NEXT: OpMemberName %type_MyTbuffer 4 "s"
 // CHECK-NEXT: OpMemberName %type_MyTbuffer 5 "t"
 
-// CHECK:      OpName %var_MyTbuffer "var.MyTbuffer"
+// CHECK:      OpName %MyTbuffer "MyTbuffer"
 
 // CHECK:      OpName %type_AnotherTbuffer "type.AnotherTbuffer"
 // CHECK-NEXT: OpMemberName %type_AnotherTbuffer 0 "m"
 // CHECK-NEXT: OpMemberName %type_AnotherTbuffer 1 "n"
 
-// CHECK:      OpName %var_AnotherTbuffer "var.AnotherTbuffer"
+// CHECK:      OpName %AnotherTbuffer "AnotherTbuffer"
 
 struct S {
     float  f1;
@@ -39,8 +39,8 @@ tbuffer AnotherTbuffer : register(t2) {
 
 // CHECK: %type_AnotherTbuffer = OpTypeStruct %v3float %v4float
 
-// CHECK: %var_MyTbuffer = OpVariable %_ptr_Uniform_type_MyTbuffer Uniform
-// CHECK: %var_AnotherTbuffer = OpVariable %_ptr_Uniform_type_AnotherTbuffer Uniform
+// CHECK: %MyTbuffer = OpVariable %_ptr_Uniform_type_MyTbuffer Uniform
+// CHECK: %AnotherTbuffer = OpVariable %_ptr_Uniform_type_AnotherTbuffer Uniform
 
 void main() {
 }

--- a/tools/clang/test/CodeGenSPIRV/var.init.cross-storage-class.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.cross-storage-class.hlsl
@@ -16,7 +16,7 @@ cbuffer Constants {
 
 // CHECK-LABEL:           %main = OpFunction
 
-// CHECK:          [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %var_Constants %int_0
+// CHECK:          [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %Constants %int_0
 // CHECK-NEXT: [[uniform:%\d+]] = OpLoad %S [[ptr]]
 // CHECK-NEXT:     [[vec:%\d+]] = OpCompositeExtract %v4float [[uniform]] 0
 // CHECK-NEXT:     [[ptr:%\d+]] = OpAccessChain %_ptr_Private_v4float %private_struct %uint_0
@@ -39,7 +39,7 @@ S main()
 float4 foo()
 // CHECK-LABEL:            %foo = OpFunction
 {
-// CHECK:          [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %var_Constants %int_0
+// CHECK:          [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %Constants %int_0
 // CHECK-NEXT: [[uniform:%\d+]] = OpLoad %S [[ptr]]
 // CHECK-NEXT:     [[vec:%\d+]] = OpCompositeExtract %v4float [[uniform]] 0
 // CHECK-NEXT:     [[ptr:%\d+]] = OpAccessChain %_ptr_Private_v4float %fn_private_struct %uint_0

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -30,8 +30,8 @@ Buffer<int> myBuffer : register(t1, space0);
 [[vk::binding(4, 1)]]
 RWBuffer<float4> myRWBuffer : register(u0, space1);
 
-// CHECK: OpDecorate %var_myCBuffer DescriptorSet 3
-// CHECK-NEXT: OpDecorate %var_myCBuffer Binding 10
+// CHECK: OpDecorate %myCBuffer DescriptorSet 3
+// CHECK-NEXT: OpDecorate %myCBuffer Binding 10
 [[vk::binding(10, 3)]]
 cbuffer myCBuffer : register(b5, space1) {
     float cbfield;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
@@ -16,8 +16,8 @@ Texture3D<float4> texture2;
 // CHECK-NEXT: OpDecorate %sampler2 Binding 3
 SamplerState sampler2;
 
-// CHECK:      OpDecorate %var_myCbuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %var_myCbuffer Binding 4
+// CHECK:      OpDecorate %myCbuffer DescriptorSet 0
+// CHECK-NEXT: OpDecorate %myCbuffer Binding 4
 cbuffer myCbuffer {
     float4 stuff;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -20,8 +20,8 @@ SamplerState sampler3;
 
 SamplerState sampler4;
 
-// CHECK:      OpDecorate %var_myCbuffer DescriptorSet 3
-// CHECK-NEXT: OpDecorate %var_myCbuffer Binding 1
+// CHECK:      OpDecorate %myCbuffer DescriptorSet 3
+// CHECK-NEXT: OpDecorate %myCbuffer Binding 1
 cbuffer myCbuffer : register(b1, space3) {
     float4 stuff;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.cloption.ignore-unused-resources.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.cloption.ignore-unused-resources.hlsl
@@ -20,12 +20,12 @@ Texture2D gTex2D2;
 Texture2D gTex2D3;
 Texture2D gTex2D4;
 
-// CHECK-NOT: %var_gCBuffer1 = OpVariable
+// CHECK-NOT: %gCBuffer1 = OpVariable
 cbuffer gCBuffer1 {
     float4 cb_f;
 };
 
-// CHECK:     %var_gTBuffer1 = OpVariable
+// CHECK:     %gTBuffer1 = OpVariable
 tbuffer gTBuffer1 {
     float4 tb_f;
 };

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpc.hlsl
@@ -16,9 +16,9 @@ cbuffer MyCBuffer {
 
 void main() {
     // Check that the result types for access chains are correct
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_0
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_1
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_2
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %MyCBuffer %int_0
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %MyCBuffer %int_1
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %MyCBuffer %int_2
     float2x3 m1 = matrices1[1];
     float2x3 m2 = matrices2[2];
     float2x3 m3 = matrices3[3];

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.zpr.hlsl
@@ -16,9 +16,9 @@ cbuffer MyCBuffer {
 
 void main() {
     // Check that the result types for access chains are correct
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_0
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %var_MyCBuffer %int_1
-// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %var_MyCBuffer %int_2
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %MyCBuffer %int_0
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5_0 %MyCBuffer %int_1
+// CHECK: {{%\d+}} = OpAccessChain %_ptr_Uniform__arr_mat2v3float_uint_5 %MyCBuffer %int_2
     float2x3 m1 = matrices1[1];
     float2x3 m2 = matrices2[2];
     float2x3 m3 = matrices3[3];


### PR DESCRIPTION
This will help reflection libraries to do their work.