### PR TITLE
Silence unusued variable warning when building without asserts

### DIFF
--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -1207,7 +1207,9 @@ void HLMatrixLowerPass::TranslateMatMajorCast(CallInst *matInst,
     unsigned srcCol, srcRow;
     Type *srcTy = GetMatrixInfo(matInst->getType(), srcCol, srcRow);
     DXASSERT(srcTy == castTy, "type must match");
-    DXASSERT(castCol == srcRow && castRow == srcCol, "col row must match");
+	(void)castTy;
+	(void)srcTy;
+	DXASSERT(castCol == srcRow && castRow == srcCol, "col row must match");
     col = srcCol;
     row = srcRow;
   }

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -1206,9 +1206,7 @@ void HLMatrixLowerPass::TranslateMatMajorCast(CallInst *matInst,
     Type *castTy = GetMatrixInfo(castInst->getType(), castCol, castRow);
     unsigned srcCol, srcRow;
     Type *srcTy = GetMatrixInfo(matInst->getType(), srcCol, srcRow);
-    DXASSERT(srcTy == castTy, "type must match");
-    (void)castTy;
-    (void)srcTy;
+    DXASSERT_LOCALVAR((castTy, srcTy), srcTy == castTy, "type must match");
     DXASSERT(castCol == srcRow && castRow == srcCol, "col row must match");
     col = srcCol;
     row = srcRow;

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -1207,9 +1207,9 @@ void HLMatrixLowerPass::TranslateMatMajorCast(CallInst *matInst,
     unsigned srcCol, srcRow;
     Type *srcTy = GetMatrixInfo(matInst->getType(), srcCol, srcRow);
     DXASSERT(srcTy == castTy, "type must match");
-	(void)castTy;
-	(void)srcTy;
-	DXASSERT(castCol == srcRow && castRow == srcCol, "col row must match");
+    (void)castTy;
+    (void)srcTy;
+    DXASSERT(castCol == srcRow && castRow == srcCol, "col row must match");
     col = srcCol;
     row = srcRow;
   }


### PR DESCRIPTION
Building without asserts enabled fails the build due to unused variable warning.