### PR TITLE
[spirv] Implement relaxed layout for vector types

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -162,6 +162,7 @@ public:
   bool GenSPIRV; // OPT_spirv
   bool VkIgnoreUnusedResources; // OPT_fvk_ignore_used_resources
   bool VkInvertY; // OPT_fvk_invert_y
+  bool VkUseGlslLayout; // OPT_fvk_use_glsl_layout
   llvm::StringRef VkStageIoOrder; // OPT_fvk_stage_io_order
   llvm::SmallVector<uint32_t, 4> VkBShift; // OPT_fvk_b_shift
   llvm::SmallVector<uint32_t, 4> VkTShift; // OPT_fvk_t_shift

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -250,6 +250,8 @@ def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, MetaVarName<"<shift> <space
   HelpText<"Specify Vulkan binding number shift for u-type register">;
 def fvk_invert_y: Flag<["-"], "fvk-invert-y">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Invert SV_Position.y in VS/DS/GS to accommodate Vulkan's coordinate system">;
+def fvk_use_glsl_layout: Flag<["-"], "fvk-use-glsl-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Use conventional GLSL std140/std430 layout for resources">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -483,6 +483,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 #ifdef ENABLE_SPIRV_CODEGEN
   const bool genSpirv = opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
   opts.VkInvertY = Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false);
+  opts.VkUseGlslLayout = Args.hasFlag(OPT_fvk_use_glsl_layout, OPT_INVALID, false);
   opts.VkIgnoreUnusedResources = Args.hasFlag(OPT_fvk_ignore_unused_resources, OPT_INVALID, false);
 
   // Collects the arguments for -fvk-{b|s|t|u}-shift.
@@ -522,6 +523,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fvk_use_glsl_layout, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_ignore_unused_resources, OPT_INVALID, false) ||
       !Args.getLastArgValue(OPT_fvk_stage_io_order_EQ).empty() ||
       !Args.getLastArgValue(OPT_fvk_b_shift).empty() ||

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -20,6 +20,7 @@ struct EmitSPIRVOptions {
   bool defaultRowMajor;
   bool disableValidation;
   bool invertY;
+  bool useGlslLayout;
   bool ignoreUnusedResources;
   bool enable16BitTypes;
   llvm::StringRef stageIoOrder;

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -1347,23 +1347,25 @@ void TypeTranslator::alignUsingHLSLRelaxedLayout(QualType fieldType,
                                                  uint32_t *currentOffset) {
   bool fieldIsVecType = false;
 
-  // Adjust according to HLSL relaxed layout rules.
-  // Aligning vectors as their element types so that we can pack a float
-  // and a float3 tightly together.
-  QualType vecElemType = {};
-  if (fieldIsVecType = isVectorType(fieldType, &vecElemType)) {
-    uint32_t scalarAlignment = 0;
-    std::tie(scalarAlignment, std::ignore) =
-        getAlignmentAndSize(vecElemType, LayoutRule::Void, false, nullptr);
-    if (scalarAlignment <= 4)
-      *fieldAlignment = scalarAlignment;
+  if (!spirvOptions.useGlslLayout) {
+    // Adjust according to HLSL relaxed layout rules.
+    // Aligning vectors as their element types so that we can pack a float
+    // and a float3 tightly together.
+    QualType vecElemType = {};
+    if (fieldIsVecType = isVectorType(fieldType, &vecElemType)) {
+      uint32_t scalarAlignment = 0;
+      std::tie(scalarAlignment, std::ignore) =
+          getAlignmentAndSize(vecElemType, LayoutRule::Void, false, nullptr);
+      if (scalarAlignment <= 4)
+        *fieldAlignment = scalarAlignment;
+    }
   }
 
   roundToPow2(currentOffset, *fieldAlignment);
 
   // Adjust according to HLSL relaxed layout rules.
   // Bump to 4-component vector alignment if there is a bad straddle
-  if (fieldIsVecType &&
+  if (!spirvOptions.useGlslLayout && fieldIsVecType &&
       improperStraddle(fieldType, fieldSize, *currentOffset)) {
     *fieldAlignment = kStd140Vec4Alignment;
     roundToPow2(currentOffset, *fieldAlignment);

--- a/tools/clang/lib/SPIRV/TypeTranslator.h
+++ b/tools/clang/lib/SPIRV/TypeTranslator.h
@@ -261,9 +261,18 @@ private:
   /// instructions and returns the <result-id>. Returns 0 on failure.
   uint32_t translateResourceType(QualType type, LayoutRule rule);
 
-  /// \bried For the given sampled type, returns the corresponding image format
+  /// \brief For the given sampled type, returns the corresponding image format
   /// that can be used to create an image object.
   spv::ImageFormat translateSampledTypeToImageFormat(QualType type);
+
+  /// \brief Aligns currentOffset properly to allow packing vectors in the HLSL
+  /// way: using the element type's alignment as the vector alignment, as long
+  /// as there is no improper straddle.
+  /// fieldSize and fieldAlignment are the original size and alignment
+  /// calculated without considering the HLSL vector relaxed rule.
+  void alignUsingHLSLRelaxedLayout(QualType fieldType, uint32_t fieldSize,
+                                   uint32_t *fieldAlignment,
+                                   uint32_t *currentOffset);
 
 public:
   /// \brief Returns the alignment and size in bytes for the given type

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main
+// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
 
 struct S {
     float a;

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main
+// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
 
 struct S {
     float a;

--- a/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main
+// Run: %dxc -T ps_6_0 -E main -fvk-use-glsl-layout
 
 struct SBuffer {
   float4   f1;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.std140.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.std140.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main
+// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
 
 struct R {     // Alignment                           Offset     Size       Next
     float2 rf; // 8(vec2)                          -> 0        + 8(vec2)  = 8

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main
+// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
 
 // CHECK: OpDecorate %_arr_v2float_uint_3 ArrayStride 8
 // CHECK: OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 32

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main
+// Run: %dxc -T ps_6_0 -E main -fvk-use-glsl-layout
 
 struct R {     // Alignment       Offset     Size       Next
     float2 rf; // 8(vec2)      -> 0        + 8(vec2)  = 8

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.vector.relaxed.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.vector.relaxed.hlsl
@@ -1,0 +1,124 @@
+// Run: %dxc -T ps_6_0 -E main
+
+    // For ConstantBuffer & cbuffer
+// CHECK: OpMemberDecorate %S 0 Offset 0
+// CHECK: OpMemberDecorate %S 1 Offset 4
+// CHECK: OpMemberDecorate %S 2 Offset 16
+// CHECK: OpMemberDecorate %S 3 Offset 28
+// CHECK: OpMemberDecorate %S 4 Offset 32
+// CHECK: OpMemberDecorate %S 5 Offset 36
+// CHECK: OpMemberDecorate %S 6 Offset 44
+// CHECK: OpMemberDecorate %S 7 Offset 48
+// CHECK: OpMemberDecorate %S 8 Offset 56
+// CHECK: OpMemberDecorate %S 9 Offset 64
+// CHECK: OpMemberDecorate %S 10 Offset 80
+// CHECK: OpMemberDecorate %S 11 Offset 92
+// CHECK: OpMemberDecorate %S 12 Offset 96
+// CHECK: OpMemberDecorate %S 13 Offset 112
+// CHECK: OpMemberDecorate %S 14 Offset 128
+// CHECK: OpMemberDecorate %S 15 Offset 140
+// CHECK: OpMemberDecorate %S 16 Offset 144
+// CHECK: OpMemberDecorate %S 17 Offset 160
+// CHECK: OpMemberDecorate %S 18 Offset 176
+// CHECK: OpMemberDecorate %S 19 Offset 192
+// CHECK: OpMemberDecorate %S 20 Offset 208
+// CHECK: OpMemberDecorate %S 21 Offset 240
+// CHECK: OpMemberDecorate %S 22 Offset 272
+// CHECK: OpMemberDecorate %S 23 Offset 304
+
+    // For StructuredBuffer & tbuffer
+// CHECK: OpMemberDecorate %S_0 0 Offset 0
+// CHECK: OpMemberDecorate %S_0 1 Offset 4
+// CHECK: OpMemberDecorate %S_0 2 Offset 16
+// CHECK: OpMemberDecorate %S_0 3 Offset 28
+// CHECK: OpMemberDecorate %S_0 4 Offset 32
+// CHECK: OpMemberDecorate %S_0 5 Offset 36
+// CHECK: OpMemberDecorate %S_0 6 Offset 44
+// CHECK: OpMemberDecorate %S_0 7 Offset 48
+// CHECK: OpMemberDecorate %S_0 8 Offset 56
+// CHECK: OpMemberDecorate %S_0 9 Offset 64
+// CHECK: OpMemberDecorate %S_0 10 Offset 80
+// CHECK: OpMemberDecorate %S_0 11 Offset 92
+// CHECK: OpMemberDecorate %S_0 12 Offset 96
+// CHECK: OpMemberDecorate %S_0 13 Offset 112
+// CHECK: OpMemberDecorate %S_0 14 Offset 128
+// CHECK: OpMemberDecorate %S_0 15 Offset 140
+// CHECK: OpMemberDecorate %S_0 16 Offset 144
+// CHECK: OpMemberDecorate %S_0 17 Offset 160
+// CHECK: OpMemberDecorate %S_0 18 Offset 176
+// CHECK: OpMemberDecorate %S_0 19 Offset 192
+// CHECK: OpMemberDecorate %S_0 20 Offset 196
+// CHECK: OpMemberDecorate %S_0 21 Offset 208
+// CHECK: OpMemberDecorate %S_0 22 Offset 240
+// CHECK: OpMemberDecorate %S_0 23 Offset 272
+
+// CHECK: OpDecorate %_runtimearr_T ArrayStride 288
+
+// CHECK:     %type_ConstantBuffer_T = OpTypeStruct %S
+// CHECK:                         %T = OpTypeStruct %S_0
+// CHECK:   %type_StructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK: %type_RWStructuredBuffer_T = OpTypeStruct %_runtimearr_T
+// CHECK:              %type_TBuffer = OpTypeStruct %S_0
+
+// CHECK:   %MyCBuffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_T Uniform
+// CHECK:   %MySBuffer = OpVariable %_ptr_Uniform_type_StructuredBuffer_T Uniform
+// CHECK: %MyRWSBuffer = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
+// CHECK:     %CBuffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_T Uniform
+// CHECK:     %TBuffer = OpVariable %_ptr_Uniform_type_TBuffer Uniform
+
+struct S {
+    float  f0;
+    float3 f1;
+
+    float3 f2;
+    float1 f3;
+
+    float  f4;
+    float2 f5;
+    float1 f6;
+
+    float2 f7;
+    float2 f8;
+
+    float2 f9;
+    float3 f10;
+    float  f11;
+
+    float1 f12;
+    float4 f13;
+    float3 f14;
+    float  f15;
+
+    float1 f16[1];
+    float3 f17[1];
+
+    float3 f18[1];
+    float  f19[1];
+
+    float1 f20[2];
+    float3 f21[2];
+
+    float3 f22[2];
+    float  f23[2];
+};
+
+struct T {
+    S s;
+};
+
+
+    ConstantBuffer<T> MyCBuffer;
+  StructuredBuffer<T> MySBuffer;
+RWStructuredBuffer<T> MyRWSBuffer;
+
+cbuffer CBuffer {
+    S CB_s;
+};
+
+tbuffer TBuffer {
+    S TB_s;
+};
+
+float4 main() : SV_Target {
+    return MyCBuffer.s.f0 + MySBuffer[0].s.f4 + CB_s.f11 + TB_s.f15;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -469,6 +469,7 @@ public:
           spirvOpts.codeGenHighLevel = opts.CodeGenHighLevel;
           spirvOpts.disableValidation = opts.DisableValidation;
           spirvOpts.invertY = opts.VkInvertY;
+          spirvOpts.useGlslLayout = opts.VkUseGlslLayout;
           spirvOpts.ignoreUnusedResources = opts.VkIgnoreUnusedResources;
           spirvOpts.defaultRowMajor = opts.DefaultRowMajor;
           spirvOpts.stageIoOrder = opts.VkStageIoOrder;

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1217,6 +1217,11 @@ TEST_F(FileTest, VulkanLayout64BitTypesStd430) {
 TEST_F(FileTest, VulkanLayout64BitTypesStd140) {
   runFileTest("vk.layout.64bit-types.std140.hlsl");
 }
+TEST_F(FileTest, VulkanLayoutVectorRelaxedLayout) {
+  // Allows vectors to be aligned according to their element types, if not
+  // causing improper straddle
+  runFileTest("vk.layout.vector.relaxed.hlsl");
+}
 
 TEST_F(FileTest, VulkanLayoutPushConstantStd430) {
   runFileTest("vk.layout.push-constant.std430.hlsl");


### PR DESCRIPTION
Based on GLSL std140/std430 layout rules, relaxed layout allows
using vector's element type's alignment as the vector types's
alignment, so that we can pack a float value and a float3 value
tightly. This is the default right now.

Also add an option, `-fvk-use-glsl-layout`, to turn off the relaxed
layout for vectors and use conventional GLSL std140/std430 layout
rules.