### PR TITLE
[spirv] Support 64bit types during resource calculation

### DIFF
--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -1207,6 +1207,10 @@ TypeTranslator::getAlignmentAndSize(QualType type, LayoutRule rule,
         case BuiltinType::UInt:
         case BuiltinType::Float:
           return {4, 4};
+        case BuiltinType::Double:
+        case BuiltinType::LongLong:
+        case BuiltinType::ULongLong:
+          return {8, 8};
         default:
           emitError("primitive type %0 unimplemented")
               << builtinType->getTypeClassName();

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.64bit-types.std140.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.64bit-types.std140.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate %_arr_double_uint_3 ArrayStride 16
+// CHECK: OpDecorate %_arr_mat2v3double_uint_2 ArrayStride 64
+// CHECK: OpDecorate %_arr_v2long_uint_1 ArrayStride 16
+
+// CHECK: OpMemberDecorate %type_MyCBuffer 0 Offset 0
+// CHECK: OpMemberDecorate %type_MyCBuffer 1 Offset 8
+// CHECK: OpMemberDecorate %type_MyCBuffer 2 Offset 16
+// CHECK: OpMemberDecorate %type_MyCBuffer 3 Offset 64
+// CHECK: OpMemberDecorate %type_MyCBuffer 4 Offset 96
+// CHECK: OpMemberDecorate %type_MyCBuffer 5 Offset 128
+// CHECK: OpMemberDecorate %type_MyCBuffer 5 MatrixStride 32
+// CHECK: OpMemberDecorate %type_MyCBuffer 5 RowMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 6 Offset 192
+// CHECK: OpMemberDecorate %type_MyCBuffer 7 Offset 208
+// CHECK: OpMemberDecorate %type_MyCBuffer 8 Offset 224
+// CHECK: OpMemberDecorate %type_MyCBuffer 8 MatrixStride 32
+// CHECK: OpMemberDecorate %type_MyCBuffer 8 ColMajor
+// CHECK: OpMemberDecorate %type_MyCBuffer 9 Offset 352
+
+
+cbuffer MyCBuffer{               // Alignment | Offset + Size                 = Next
+              float     f1;      // 0         | 0        4                      4
+              uint64_t  f2;      // 8         | 8        8                      16
+              double    f3[3];   // 16        | 16       16 (stride) * 3        64
+              float     f4;      // 4         | 64       4                      68
+              int64_t3  f5;      // 32        | 96       8 * 3                  120
+              double3x2 f6;      // 32        | 128      32 * 2                 192    // SPIR-V RowMajor
+              double2x1 f7;      // 16        | 192      16                     208
+              float     f8;      // 4         | 208      4                      212
+    row_major double2x3 f9[2];   // 32        | 224      32 * 4                 352    // SPIR-V ColMajor
+              int64_t2  f10[1];  // 16        | 352      16 (stride)            368
+};                               // 32 (max)                                    384
+
+void main() { }

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.64bit-types.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.64bit-types.std430.hlsl
@@ -1,0 +1,39 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: OpDecorate %_arr_double_uint_3 ArrayStride 8
+// CHECK: OpDecorate %_arr_mat2v3double_uint_2 ArrayStride 64
+// CHECK: OpDecorate %_arr_v2long_uint_1 ArrayStride 16
+
+// CHECK: OpMemberDecorate %S 0 Offset 0
+// CHECK: OpMemberDecorate %S 1 Offset 8
+// CHECK: OpMemberDecorate %S 2 Offset 16
+// CHECK: OpMemberDecorate %S 3 Offset 40
+// CHECK: OpMemberDecorate %S 4 Offset 64
+// CHECK: OpMemberDecorate %S 5 Offset 96
+// CHECK: OpMemberDecorate %S 5 MatrixStride 32
+// CHECK: OpMemberDecorate %S 5 RowMajor
+// CHECK: OpMemberDecorate %S 6 Offset 160
+// CHECK: OpMemberDecorate %S 7 Offset 176
+// CHECK: OpMemberDecorate %S 8 Offset 192
+// CHECK: OpMemberDecorate %S 8 MatrixStride 32
+// CHECK: OpMemberDecorate %S 8 ColMajor
+// CHECK: OpMemberDecorate %S 9 Offset 320
+
+// CHECK: OpDecorate %_runtimearr_S ArrayStride 352
+
+struct S {                       // Alignment | Offset + Size       = Next
+              float     f1;      // 0         | 0        4            4
+              uint64_t  f2;      // 8         | 8        8            16
+              double    f3[3];   // 8         | 16       8 * 3        40
+              float     f4;      // 4         | 40       4            44
+              int64_t3  f5;      // 32        | 64       8 * 3        88
+              double3x2 f6;      // 32        | 96       32 * 2       160    // SPIR-V RowMajor
+              double2x1 f7;      // 16        | 160      16           176
+              float     f8;      // 4         | 176      4            180
+    row_major double2x3 f9[2];   // 32        | 192      32 * 4       320    // SPIR-V ColMajor
+              int64_t2  f10[1];  // 16        | 320      16           336
+};                               // 32 (max)                          352
+
+StructuredBuffer<S> MySBuffer;
+
+void main() { }

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1190,6 +1190,12 @@ TEST_F(FileTest, VulkanLayoutTBufferStd430) {
 TEST_F(FileTest, VulkanLayoutTextureBufferStd430) {
   runFileTest("vk.layout.texture-buffer.std430.hlsl");
 }
+TEST_F(FileTest, VulkanLayout64BitTypesStd430) {
+  runFileTest("vk.layout.64bit-types.std430.hlsl");
+}
+TEST_F(FileTest, VulkanLayout64BitTypesStd140) {
+  runFileTest("vk.layout.64bit-types.std140.hlsl");
+}
 
 TEST_F(FileTest, VulkanLayoutPushConstantStd430) {
   runFileTest("vk.layout.push-constant.std430.hlsl");


### PR DESCRIPTION
Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/1094