### PR TITLE
[spirv] Do not assign descriptors to Workgroup variables

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.hlsl
@@ -5,6 +5,12 @@ struct S {
     float3 f2;
 };
 
+// CHECK-NOT: OpDecorate %a DescriptorSet
+// CHECK-NOT: OpDecorate %b DescriptorSet
+// CHECK-NOT: OpDecorate %c DescriptorSet
+// CHECK-NOT: OpDecorate %d DescriptorSet
+// CHECK-NOT: OpDecorate %s DescriptorSet
+
 // CHECK: %a = OpVariable %_ptr_Workgroup_float Workgroup
 groupshared              float    a;
 // CHECK: %b = OpVariable %_ptr_Workgroup_v3float Workgroup


### PR DESCRIPTION
Also fix missing row-major-ness for external matrices that need
struct wrapping.