### PR TITLE
[spirv] Fix type mismatch for compound assignment

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -148,12 +148,20 @@ private:
                   QualType lhsValType);
 
   /// Generates the necessary instructions for conducting the given binary
-  /// operation on lhs and rhs. If lhsResultId is not nullptr, the evaluated
-  /// pointer from lhs during the process will be written into it. If
-  /// mandateGenOpcode is not spv::Op::Max, it will used as the SPIR-V opcode
-  /// instead of deducing from Clang frontend opcode.
+  /// operation on lhs and rhs.
+  ///
+  /// computationType is the type for LHS and RHS when doing computation, while
+  /// resultType is the type of the whole binary operation. They can be
+  /// different for compound assignments like <some-int-value> *=
+  /// <some-float-value>, where computationType is float and resultType is int.
+  ///
+  /// If lhsResultId is not nullptr, the evaluated pointer from lhs during the
+  /// process will be written into it. If mandateGenOpcode is not spv::Op::Max,
+  /// it will used as the SPIR-V opcode instead of deducing from Clang frontend
+  /// opcode.
   SpirvEvalInfo processBinaryOp(const Expr *lhs, const Expr *rhs,
-                                BinaryOperatorKind opcode, QualType resultType,
+                                BinaryOperatorKind opcode,
+                                QualType computationType, QualType resultType,
                                 SourceRange, SpirvEvalInfo *lhsInfo = nullptr,
                                 spv::Op mandateGenOpcode = spv::Op::Max);
 

--- a/tools/clang/test/CodeGenSPIRV/binary-op.arith-assign.mixed.form.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.arith-assign.mixed.form.hlsl
@@ -1,8 +1,6 @@
 // Run: %dxc -T vs_6_0 -E main
 
 void main() {
-// CHECK-LABEL: %bb_entry = OpLabel
-
     float4 a;
     float s;
 

--- a/tools/clang/test/CodeGenSPIRV/binary-op.arith-assign.mixed.type.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.arith-assign.mixed.type.hlsl
@@ -1,0 +1,26 @@
+// Run: %dxc -T vs_6_0 -E main
+
+void main() {
+    uint uVal;
+    bool bVal;
+
+    float fVal;
+    int iVal;
+
+    // No conversion of lhs
+// CHECK:      [[b_bool:%\d+]] = OpLoad %bool %bVal
+// CHECK-NEXT: [[b_uint:%\d+]] = OpSelect %uint [[b_bool]] %uint_1 %uint_0
+// CHECK-NEXT: [[u_uint:%\d+]] = OpLoad %uint %uVal
+// CHECK-NEXT:    [[add:%\d+]] = OpIAdd %uint [[u_uint]] [[b_uint]]
+// CHECK-NEXT:                   OpStore %uVal [[add]]
+    uVal += bVal;
+
+    // Convert lhs to the type of rhs, do computation, and then convert back
+// CHECK:        [[f_float:%\d+]] = OpLoad %float %fVal
+// CHECK-NEXT:     [[i_int:%\d+]] = OpLoad %int %iVal
+// CHECK-NEXT:   [[i_float:%\d+]] = OpConvertSToF %float [[i_int]]
+// CHECK-NEXT: [[mul_float:%\d+]] = OpFMul %float [[i_float]] [[f_float]]
+// CHECK-NEXT:   [[mul_int:%\d+]] = OpConvertFToS %int [[mul_float]]
+// CHECK-NEXT:                      OpStore %iVal [[mul_int]]
+    iVal *= fVal;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -194,8 +194,13 @@ TEST_F(FileTest, BinaryOpVectorArithAssign) {
 TEST_F(FileTest, BinaryOpMatrixArithAssign) {
   runFileTest("binary-op.arith-assign.matrix.hlsl");
 }
-TEST_F(FileTest, BinaryOpMixedArithAssign) {
-  runFileTest("binary-op.arith-assign.mixed.hlsl");
+TEST_F(FileTest, BinaryOpMixedFormArithAssign) {
+  // Test mixing scalar/vector/matrix/etc.
+  runFileTest("binary-op.arith-assign.mixed.form.hlsl");
+}
+TEST_F(FileTest, BinaryOpMixedTypeArithAssign) {
+  // Test mixing float/int/uint/bool/etc.
+  runFileTest("binary-op.arith-assign.mixed.type.hlsl");
 }
 
 // For bitwise binary operators


### PR DESCRIPTION
Compound assignments don't have the proper AST nodes to implicitly
casting LHS and RHS to the same type. But it has an API called
getComputationLHSType() to tell us what the LHS are expected to
convert to when doing the computation. We need to take into
consideration of that information when CodeGen'ing compound
assignments.