### PR TITLE
Modified hctgettaef.py to use tls1.2 when requesting files files github.

### DIFF
--- a/utils/hct/hctgettaef.py
+++ b/utils/hct/hctgettaef.py
@@ -1,5 +1,6 @@
 import urllib
 import os
+import ssl
 import zipfile
 
 url = "https://github.com/Microsoft/WinObjC/raw/develop/deps/prebuilt/nuget/taef.redist.wlk.1.0.170206001-nativetargets.nupkg"
@@ -11,11 +12,17 @@ if not os.path.isdir(taef_dir):
   os.makedirs(taef_dir)
 
 try:
-  urllib.urlretrieve(url, zipfile_name)
+  ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+  response = urllib.urlopen(url, context=ctx)
+  f = open(zipfile_name, 'wb')
+  f.write(response.read())
+  f.close()
 except:
   print("Unable to read file with urllib, trying via powershell...")
   from subprocess import check_call
-  cmd = "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
+  cmd = ""
+  cmd += "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;"
+  cmd += "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
   check_call(['powershell.exe', '-Command', cmd])
 
 z = zipfile.ZipFile(zipfile_name)


### PR DESCRIPTION
Default TLS1.0 now fails to retrieve files with Github's new change:
https://developer.github.com/changes/2018-02-01-weak-crypto-removal-notice/