### PR TITLE
  Fix anonymous struct cbuffer

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1900,7 +1900,7 @@ void CGMSHLSLRuntime::addResource(Decl *D) {
     if (VD->hasInit() && resClass != DXIL::ResourceClass::Invalid)
       return;
     // skip static global.
-    if (!VD->isExternallyVisible()) {
+    if (!VD->hasExternalFormalLinkage()) {
       if (VD->hasInit() && VD->getType().isConstQualified()) {
         Expr* InitExp = VD->getInit();
         GlobalVariable *GV = cast<GlobalVariable>(CGM.GetAddrOfGlobalVar(VD));

--- a/tools/clang/test/CodeGenHLSL/quick-test/anon_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/anon_struct.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T ps_6_0 -E main %s | FileCheck %s
+
+// CHECK: %"$Globals" = type { %struct.anon }
+// CHECK: @dx.op.cbufferLoadLegacy
+
+struct {
+    int X;
+} CB;
+
+float main(int N : A, int C : B) : SV_TARGET {
+    return CB.X;
+}


### PR DESCRIPTION
Anonymous structures were not added to $Globals because they are
not externally visible.