### PR TITLE
[spirv] Cull RHS of shift operations

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -1315,6 +1315,10 @@ corresponding SPIR-V opcodes according to the following table.
 | ``>>`` | ``OpShiftRightArithmetic``  | ``OpShiftRightLogical``       |
 +--------+-----------------------------+-------------------------------+
 
+Note that for ``<<``/``>>``, the right hand side will be culled: only the ``n``
+- 1 least significant bits are considered, where ``n`` is the bitwidth of the
+left hand side.
+
 Comparison operators
 --------------------
 

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -490,6 +490,11 @@ private:
   /// one will be a vector of size N.
   uint32_t getMatElemValueOne(QualType type);
 
+  /// Returns a SPIR-V constant equal to the bitwdith of the given type minus
+  /// one. The returned constant has the same component count and bitwidth as
+  /// the given type.
+  uint32_t getMaskForBitwidthValue(QualType type);
+
 private:
   /// \brief Performs a FlatConversion implicit cast. Fills an instance of the
   /// given type with initializer <result-id>. The initializer is of type

--- a/tools/clang/lib/SPIRV/TypeTranslator.cpp
+++ b/tools/clang/lib/SPIRV/TypeTranslator.cpp
@@ -380,10 +380,7 @@ uint32_t TypeTranslator::getElementSpirvBitwidth(QualType type) {
     case BuiltinType::Min12Int:
     case BuiltinType::Half:
     case BuiltinType::Min10Float: {
-      if (spirvOptions.enable16BitTypes)
-        return 16;
-      else
-        return 32;
+      return spirvOptions.enable16BitTypes ? 16 : 32;
     }
     case BuiltinType::LitFloat: {
       // First try to see if there are any hints about how this literal type
@@ -394,10 +391,7 @@ uint32_t TypeTranslator::getElementSpirvBitwidth(QualType type) {
 
       const auto &semantics = astContext.getFloatTypeSemantics(type);
       const auto bitwidth = llvm::APFloat::getSizeInBits(semantics);
-      if (bitwidth <= 32)
-        return 32;
-      else
-        return 64;
+      return bitwidth <= 32 ? 32 : 64;
     }
     case BuiltinType::LitInt: {
       // First try to see if there are any hints about how this literal type

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.scalar.hlsl
@@ -37,26 +37,4 @@ void main() {
 // CHECK-NEXT: [[xor1:%\d+]] = OpBitwiseXor %uint [[j2]] [[i2]]
 // CHECK-NEXT: OpStore %j [[xor1]]
     j ^= i;
-
-// CHECK-NEXT: [[a3:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b3:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[shl0:%\d+]] = OpShiftLeftLogical %int [[b3]] [[a3]]
-// CHECK-NEXT: OpStore %b [[shl0]]
-    b <<= a;
-// CHECK-NEXT: [[i3:%\d+]] = OpLoad %uint %i
-// CHECK-NEXT: [[j3:%\d+]] = OpLoad %uint %j
-// CHECK-NEXT: [[shl1:%\d+]] = OpShiftLeftLogical %uint [[j3]] [[i3]]
-// CHECK-NEXT: OpStore %j [[shl1]]
-    j <<= i;
-
-// CHECK-NEXT: [[a4:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b4:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[shr0:%\d+]] = OpShiftRightArithmetic %int [[b4]] [[a4]]
-// CHECK-NEXT: OpStore %b [[shr0]]
-    b >>= a;
-// CHECK-NEXT: [[i4:%\d+]] = OpLoad %uint %i
-// CHECK-NEXT: [[j4:%\d+]] = OpLoad %uint %j
-// CHECK-NEXT: [[shr1:%\d+]] = OpShiftRightLogical %uint [[j4]] [[i4]]
-// CHECK-NEXT: OpStore %j [[shr1]]
-    j >>= i;
 }

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.shift-left.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.shift-left.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T ps_6_2 -E main -enable-16bit-types
+
+// CHECK: [[v2c31:%\d+]] = OpConstantComposite %v2uint %uint_31 %uint_31
+// CHECK: [[v3c63:%\d+]] = OpConstantComposite %v3ulong %ulong_63 %ulong_63 %ulong_63
+// CHECK: [[v4c15:%\d+]] = OpConstantComposite %v4ushort %ushort_15 %ushort_15 %ushort_15 %ushort_15
+void main() {
+    int       a, b;
+    uint2     d, e;
+
+    int64_t3  g, h;
+    uint64_t  j, k;
+
+    int16_t   m, n;
+    uint16_t4 p, q;
+
+// CHECK:        [[b:%\d+]] = OpLoad %int %b
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %int [[b]] %uint_31
+// CHECK-NEXT:                OpShiftLeftLogical %int {{%\d+}} [[rhs]]
+    a <<= b;
+
+// CHECK:        [[e:%\d+]] = OpLoad %v2uint %e
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v2uint [[e]] [[v2c31]]
+// CHECK-NEXT:                OpShiftLeftLogical %v2uint {{%\d+}} [[rhs]]
+    d <<= e;
+
+// CHECK:        [[h:%\d+]] = OpLoad %v3long %h
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%\d+}} [[rhs]]
+    g <<= h;
+
+// CHECK:        [[k:%\d+]] = OpLoad %ulong %k
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%\d+}} [[rhs]]
+    j <<= k;
+
+// CHECK:        [[n:%\d+]] = OpLoad %short %n
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %short [[n]] %ushort_15
+// CHECK-NEXT:                OpShiftLeftLogical %short {{%\d+}} [[rhs]]
+    m <<= n;
+
+// CHECK:        [[q:%\d+]] = OpLoad %v4ushort %q
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%\d+}} [[rhs]]
+    p <<= q;
+}

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.shift-right.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.shift-right.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T ps_6_2 -E main -enable-16bit-types
+
+// CHECK: [[v2c31:%\d+]] = OpConstantComposite %v2uint %uint_31 %uint_31
+// CHECK: [[v3c63:%\d+]] = OpConstantComposite %v3ulong %ulong_63 %ulong_63 %ulong_63
+// CHECK: [[v4c15:%\d+]] = OpConstantComposite %v4ushort %ushort_15 %ushort_15 %ushort_15 %ushort_15
+void main() {
+    int       a, b;
+    uint2     d, e;
+
+    int64_t3  g, h;
+    uint64_t  j, k;
+
+    int16_t   m, n;
+    uint16_t4 p, q;
+
+// CHECK:        [[b:%\d+]] = OpLoad %int %b
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %int [[b]] %uint_31
+// CHECK-NEXT:                OpShiftRightArithmetic %int {{%\d+}} [[rhs]]
+    a >>= b;
+
+// CHECK:        [[e:%\d+]] = OpLoad %v2uint %e
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v2uint [[e]] [[v2c31]]
+// CHECK-NEXT:                OpShiftRightLogical %v2uint {{%\d+}} [[rhs]]
+    d >>= e;
+
+// CHECK:        [[h:%\d+]] = OpLoad %v3long %h
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%\d+}} [[rhs]]
+    g >>= h;
+
+// CHECK:        [[k:%\d+]] = OpLoad %ulong %k
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftRightLogical %ulong {{%\d+}} [[rhs]]
+    j >>= k;
+
+// CHECK:        [[n:%\d+]] = OpLoad %short %n
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %short [[n]] %ushort_15
+// CHECK-NEXT:                OpShiftRightArithmetic %short {{%\d+}} [[rhs]]
+    m >>= n;
+
+// CHECK:        [[q:%\d+]] = OpLoad %v4ushort %q
+// CHECK:      [[rhs:%\d+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%\d+}} [[rhs]]
+    p >>= q;
+}

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise-assign.vector.hlsl
@@ -38,26 +38,4 @@ void main() {
 // CHECK-NEXT: [[xor1:%\d+]] = OpBitwiseXor %v2uint [[j2]] [[i2]]
 // CHECK-NEXT: OpStore %j [[xor1]]
     j ^= i;
-
-// CHECK-NEXT: [[a3:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b3:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[shl0:%\d+]] = OpShiftLeftLogical %int [[b3]] [[a3]]
-// CHECK-NEXT: OpStore %b [[shl0]]
-    b <<= a;
-// CHECK-NEXT: [[i3:%\d+]] = OpLoad %v2uint %i
-// CHECK-NEXT: [[j3:%\d+]] = OpLoad %v2uint %j
-// CHECK-NEXT: [[shl1:%\d+]] = OpShiftLeftLogical %v2uint [[j3]] [[i3]]
-// CHECK-NEXT: OpStore %j [[shl1]]
-    j <<= i;
-
-// CHECK-NEXT: [[a4:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b4:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[shr0:%\d+]] = OpShiftRightArithmetic %int [[b4]] [[a4]]
-// CHECK-NEXT: OpStore %b [[shr0]]
-    b >>= a;
-// CHECK-NEXT: [[i4:%\d+]] = OpLoad %v2uint %i
-// CHECK-NEXT: [[j4:%\d+]] = OpLoad %v2uint %j
-// CHECK-NEXT: [[shr1:%\d+]] = OpShiftRightLogical %v2uint [[j4]] [[i4]]
-// CHECK-NEXT: OpStore %j [[shr1]]
-    j >>= i;
 }

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.scalar.hlsl
@@ -42,28 +42,6 @@ void main() {
 // CHECK-NEXT: OpStore %k [[k2]]
     k = i ^ j;
 
-// CHECK-NEXT: [[a3:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b3:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[c3:%\d+]] = OpShiftLeftLogical %int [[a3]] [[b3]]
-// CHECK-NEXT: OpStore %c [[c3]]
-    c = a << b;
-// CHECK-NEXT: [[i3:%\d+]] = OpLoad %uint %i
-// CHECK-NEXT: [[j3:%\d+]] = OpLoad %uint %j
-// CHECK-NEXT: [[k3:%\d+]] = OpShiftLeftLogical %uint [[i3]] [[j3]]
-// CHECK-NEXT: OpStore %k [[k3]]
-    k = i << j;
-
-// CHECK-NEXT: [[a4:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b4:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[c4:%\d+]] = OpShiftRightArithmetic %int [[a4]] [[b4]]
-// CHECK-NEXT: OpStore %c [[c4]]
-    c = a >> b;
-// CHECK-NEXT: [[i4:%\d+]] = OpLoad %uint %i
-// CHECK-NEXT: [[j4:%\d+]] = OpLoad %uint %j
-// CHECK-NEXT: [[k4:%\d+]] = OpShiftRightLogical %uint [[i4]] [[j4]]
-// CHECK-NEXT: OpStore %k [[k4]]
-    k = i >> j;
-
 // CHECK-NEXT: [[a5:%\d+]] = OpLoad %int %a
 // CHECK-NEXT: [[b5:%\d+]] = OpNot %int [[a5]]
 // CHECK-NEXT: OpStore %b [[b5]]

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.shift-left.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.shift-left.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T ps_6_2 -E main -enable-16bit-types
+
+// CHECK: [[v2c31:%\d+]] = OpConstantComposite %v2uint %uint_31 %uint_31
+// CHECK: [[v3c63:%\d+]] = OpConstantComposite %v3ulong %ulong_63 %ulong_63 %ulong_63
+// CHECK: [[v4c15:%\d+]] = OpConstantComposite %v4ushort %ushort_15 %ushort_15 %ushort_15 %ushort_15
+void main() {
+    int       a, b, c;
+    uint2     d, e, f;
+
+    int64_t3  g, h, i;
+    uint64_t  j, k, l;
+
+    int16_t   m, n, o;
+    uint16_t4 p, q, r;
+
+// CHECK:        [[b:%\d+]] = OpLoad %int %b
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %int [[b]] %uint_31
+// CHECK-NEXT:                OpShiftLeftLogical %int {{%\d+}} [[rhs]]
+    c = a << b;
+
+// CHECK:        [[e:%\d+]] = OpLoad %v2uint %e
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v2uint [[e]] [[v2c31]]
+// CHECK-NEXT:                OpShiftLeftLogical %v2uint {{%\d+}} [[rhs]]
+    f = d << e;
+
+// CHECK:        [[h:%\d+]] = OpLoad %v3long %h
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%\d+}} [[rhs]]
+    i = g << h;
+
+// CHECK:        [[k:%\d+]] = OpLoad %ulong %k
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%\d+}} [[rhs]]
+    l = j << k;
+
+// CHECK:        [[n:%\d+]] = OpLoad %short %n
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %short [[n]] %ushort_15
+// CHECK-NEXT:                OpShiftLeftLogical %short {{%\d+}} [[rhs]]
+    o = m << n;
+
+// CHECK:        [[q:%\d+]] = OpLoad %v4ushort %q
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%\d+}} [[rhs]]
+    r = p << q;
+}

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.shift-right.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.shift-right.hlsl
@@ -1,0 +1,45 @@
+// Run: %dxc -T ps_6_2 -E main -enable-16bit-types
+
+// CHECK: [[v2c31:%\d+]] = OpConstantComposite %v2uint %uint_31 %uint_31
+// CHECK: [[v3c63:%\d+]] = OpConstantComposite %v3ulong %ulong_63 %ulong_63 %ulong_63
+// CHECK: [[v4c15:%\d+]] = OpConstantComposite %v4ushort %ushort_15 %ushort_15 %ushort_15 %ushort_15
+void main() {
+    int       a, b, c;
+    uint2     d, e, f;
+
+    int64_t3  g, h, i;
+    uint64_t  j, k, l;
+
+    int16_t   m, n, o;
+    uint16_t4 p, q, r;
+
+// CHECK:        [[b:%\d+]] = OpLoad %int %b
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %int [[b]] %uint_31
+// CHECK-NEXT:                OpShiftRightArithmetic %int {{%\d+}} [[rhs]]
+    c = a >> b;
+
+// CHECK:        [[e:%\d+]] = OpLoad %v2uint %e
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v2uint [[e]] [[v2c31]]
+// CHECK-NEXT:                OpShiftRightLogical %v2uint {{%\d+}} [[rhs]]
+    f = d >> e;
+
+// CHECK:        [[h:%\d+]] = OpLoad %v3long %h
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%\d+}} [[rhs]]
+    i = g >> h;
+
+// CHECK:        [[k:%\d+]] = OpLoad %ulong %k
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftRightLogical %ulong {{%\d+}} [[rhs]]
+    l = j >> k;
+
+// CHECK:        [[n:%\d+]] = OpLoad %short %n
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %short [[n]] %ushort_15
+// CHECK-NEXT:                OpShiftRightArithmetic %short {{%\d+}} [[rhs]]
+    o = m >> n;
+
+// CHECK:        [[q:%\d+]] = OpLoad %v4ushort %q
+// CHECK-NEXT: [[rhs:%\d+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%\d+}} [[rhs]]
+    r = p >> q;
+}

--- a/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.bitwise.vector.hlsl
@@ -39,28 +39,6 @@ void main() {
 // CHECK-NEXT: OpStore %k [[k2]]
     k = i ^ j;
 
-// CHECK-NEXT: [[a3:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b3:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[c3:%\d+]] = OpShiftLeftLogical %int [[a3]] [[b3]]
-// CHECK-NEXT: OpStore %c [[c3]]
-    c = a << b;
-// CHECK-NEXT: [[i3:%\d+]] = OpLoad %v3uint %i
-// CHECK-NEXT: [[j3:%\d+]] = OpLoad %v3uint %j
-// CHECK-NEXT: [[k3:%\d+]] = OpShiftLeftLogical %v3uint [[i3]] [[j3]]
-// CHECK-NEXT: OpStore %k [[k3]]
-    k = i << j;
-
-// CHECK-NEXT: [[a4:%\d+]] = OpLoad %int %a
-// CHECK-NEXT: [[b4:%\d+]] = OpLoad %int %b
-// CHECK-NEXT: [[c4:%\d+]] = OpShiftRightArithmetic %int [[a4]] [[b4]]
-// CHECK-NEXT: OpStore %c [[c4]]
-    c = a >> b;
-// CHECK-NEXT: [[i4:%\d+]] = OpLoad %v3uint %i
-// CHECK-NEXT: [[j4:%\d+]] = OpLoad %v3uint %j
-// CHECK-NEXT: [[k4:%\d+]] = OpShiftRightLogical %v3uint [[i4]] [[j4]]
-// CHECK-NEXT: OpStore %k [[k4]]
-    k = i >> j;
-
 // CHECK-NEXT: [[a5:%\d+]] = OpLoad %int %a
 // CHECK-NEXT: [[b5:%\d+]] = OpNot %int [[a5]]
 // CHECK-NEXT: OpStore %b [[b5]]

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -213,6 +213,12 @@ TEST_F(FileTest, BinaryOpScalarBitwise) {
 TEST_F(FileTest, BinaryOpVectorBitwise) {
   runFileTest("binary-op.bitwise.vector.hlsl");
 }
+TEST_F(FileTest, BinaryOpBitwiseShiftLeft) {
+  runFileTest("binary-op.bitwise.shift-left.hlsl");
+}
+TEST_F(FileTest, BinaryOpBitwiseShiftRight) {
+  runFileTest("binary-op.bitwise.shift-right.hlsl");
+}
 
 // For bitwise assignments
 TEST_F(FileTest, BinaryOpScalarBitwiseAssign) {
@@ -220,6 +226,12 @@ TEST_F(FileTest, BinaryOpScalarBitwiseAssign) {
 }
 TEST_F(FileTest, BinaryOpVectorBitwiseAssign) {
   runFileTest("binary-op.bitwise-assign.vector.hlsl");
+}
+TEST_F(FileTest, BinaryOpBitwiseAssignShiftLeft) {
+  runFileTest("binary-op.bitwise-assign.shift-left.hlsl");
+}
+TEST_F(FileTest, BinaryOpBitwiseAssignShiftRight) {
+  runFileTest("binary-op.bitwise-assign.shift-right.hlsl");
 }
 
 // For comparison operators


### PR DESCRIPTION
In SPIR-V, if shifting a value by an amount that is greater than
the value's bitwidth, the result is undefined.

FXC and DXC/DXIL performs a bitwise and over the RHS of the shift
operation to only consider its (n - 1) least significant bits,
where n is the bitwidth of LHS.