### PR TITLE
Fix checking LoadInput for GetAttributeAtVertex for no Opt

### DIFF
--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -1776,7 +1776,8 @@ public:
                 static_cast<IntrinsicOp>(hlsl::GetHLOpcode(CI));
             if (evalOp == IntrinsicOp::IOP_EvaluateAttributeAtSample ||
                 evalOp == IntrinsicOp::IOP_EvaluateAttributeCentroid ||
-                evalOp == IntrinsicOp::IOP_EvaluateAttributeSnapped) {
+                evalOp == IntrinsicOp::IOP_EvaluateAttributeSnapped ||
+                evalOp == IntrinsicOp::IOP_GetAttributeAtVertex) {
               EvalFunctionCalls.push_back(CI);
             }
           }

--- a/tools/clang/test/CodeGenHLSL/attributeAtVertexNoOpt.hlsl
+++ b/tools/clang/test/CodeGenHLSL/attributeAtVertexNoOpt.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
+
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 0, i8 0)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 1, i8 0)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 2, i8 0)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 0, i8 1)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 1, i8 1)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 2, i8 1)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 0, i8 2)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 1, i8 2)
+// CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 2, i8 2)
+
+struct PSInput
+{
+    float4 position : SV_POSITION;
+    nointerpolation float3 color : COLOR;
+};
+RWByteAddressBuffer outputUAV : register(u0);
+cbuffer constants : register(b0)
+{
+    float4 g_constants;
+}
+float4 main(PSInput input) : SV_TARGET
+{
+    uint cmp = (uint)(g_constants[0]);
+
+    float colorAtV0 = GetAttributeAtVertex(input.color, 0)[cmp];
+    float colorAtV1 = GetAttributeAtVertex(input.color, 1)[cmp];
+    float colorAtV2 = GetAttributeAtVertex(input.color, 2)[cmp];
+    outputUAV.Store(0, asuint(colorAtV0));
+    outputUAV.Store(4, asuint(colorAtV1));
+    outputUAV.Store(8, asuint(colorAtV2));
+
+    return 1.0;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -476,6 +476,7 @@ public:
   TEST_METHOD(CodeGenAtomic)
   TEST_METHOD(CodeGenAtomic2)
   TEST_METHOD(CodeGenAttributeAtVertex)
+  TEST_METHOD(CodeGenAttributeAtVertexNoOpt)
   TEST_METHOD(CodeGenBarycentrics)
   TEST_METHOD(CodeGenBarycentrics1)
   TEST_METHOD(CodeGenBarycentricsThreeSV)
@@ -3190,6 +3191,11 @@ TEST_F(CompilerTest, CodeGenAtomic2) {
 TEST_F(CompilerTest, CodeGenAttributeAtVertex) {
   if (m_ver.SkipDxilVersion(1,1)) return;
   CodeGenTestCheck(L"..\\CodeGenHLSL\\attributeAtVertex.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenAttributeAtVertexNoOpt) {
+  if (m_ver.SkipDxilVersion(1,1)) return;
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\attributeAtVertexNoOpt.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenBarycentrics) {


### PR DESCRIPTION
This change is to fix LoadInput check for GetAttributeAtVertex call with no optimization. Currently it was emitting wrong error message with no codegen. 