### PR TITLE
Add 'implicit truncation of vector type' warning

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -7750,8 +7750,12 @@ Expr* HLSLExternalSource::CastExprToTypeNumeric(Expr* expr, QualType type)
 
   if (expr->getType() != type) {
     StandardConversionSequence standard;
-    if (CanConvert(SourceLocation(), expr, type, /*explicitConversion*/false, nullptr, &standard) &&
-        (standard.First != ICK_Identity || !standard.isIdentityConversion())) {
+    TYPE_CONVERSION_REMARKS remarks;
+    if (CanConvert(SourceLocation(), expr, type, /*explicitConversion*/false, &remarks, &standard) &&
+      (standard.First != ICK_Identity || !standard.isIdentityConversion())) {
+      if ((remarks & TYPE_CONVERSION_ELT_TRUNCATION) != 0) {
+        m_sema->Diag(expr->getExprLoc(), diag::warn_hlsl_implicit_vector_truncation);
+      }
       ExprResult result = m_sema->PerformImplicitConversion(expr, type, standard, Sema::AA_Casting, Sema::CCK_ImplicitConversion);
       if (result.isUsable()) {
         return result.get();

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -7752,7 +7752,7 @@ Expr* HLSLExternalSource::CastExprToTypeNumeric(Expr* expr, QualType type)
     StandardConversionSequence standard;
     TYPE_CONVERSION_REMARKS remarks;
     if (CanConvert(SourceLocation(), expr, type, /*explicitConversion*/false, &remarks, &standard) &&
-      (standard.First != ICK_Identity || !standard.isIdentityConversion())) {
+        (standard.First != ICK_Identity || !standard.isIdentityConversion())) {
       if ((remarks & TYPE_CONVERSION_ELT_TRUNCATION) != 0) {
         m_sema->Diag(expr->getExprLoc(), diag::warn_hlsl_implicit_vector_truncation);
       }

--- a/tools/clang/test/CodeGenHLSL/quick-test/vector-matrix-binops.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/vector-matrix-binops.hlsl
@@ -1,12 +1,18 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
 
-// CHECK: vector-matrix-binops.hlsl:24:14: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:31:16: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:36:24: error: type mismatch
-// CHECK: vector-matrix-binops.hlsl:37:27: error: type mismatch
-// CHECK: vector-matrix-binops.hlsl:39:14: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:52:27: error: type mismatch
-// CHECK: vector-matrix-binops.hlsl:53:27: error: type mismatch
+// CHECK: vector-matrix-binops.hlsl:29:26: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:30:21: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:30:14: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:35:23: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:36:29: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:37:23: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:37:16: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:42:24: error: type mismatch
+// CHECK: vector-matrix-binops.hlsl:43:27: error: type mismatch
+// CHECK: vector-matrix-binops.hlsl:44:26: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:45:14: warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl:58:27: error: type mismatch
+// CHECK: vector-matrix-binops.hlsl:59:27: error: type mismatch
 
 void main() {
 

--- a/tools/clang/test/HLSL/implicit-casts.hlsl
+++ b/tools/clang/test/HLSL/implicit-casts.hlsl
@@ -662,10 +662,8 @@ float4 test(): SV_Target {
               `-DeclRefExpr <col:30> 'float4':'vector<float, 4>' lvalue Var 'f4' 'float4':'vector<float, 4>'
   */
 
-  f4 = i3x1 * f4;                               /* expected-error {{cannot convert from 'matrix<float, 3, 1>' to 'float4'}} fxc-error {{X3017: cannot implicitly convert from 'const float3x1' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
-
-  // TODO: We seem to be missing the vector truncation warning in this case
-  f3 = i3x1 * f4;                   /* fxc-warning {{X3206: implicit truncation of vector type}} */
+  f4 = i3x1 * f4;                               /* expected-error {{cannot convert from 'matrix<float, 3, 1>' to 'float4'}} expected-warning {{implicit truncation of vector type}} fxc-error {{X3017: cannot implicitly convert from 'const float3x1' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
+  f3 = i3x1 * f4;                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   /*verify-ast
     BinaryOperator <col:3, col:15> 'float3':'vector<float, 3>' '='
     |-DeclRefExpr <col:3> 'float3':'vector<float, 3>' lvalue Var 'f3' 'float3':'vector<float, 3>'

--- a/tools/clang/test/HLSL/uint4_add3.hlsl
+++ b/tools/clang/test/HLSL/uint4_add3.hlsl
@@ -11,6 +11,6 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   float4 b = a;
   b += a.xyz;         /* expected-error {{cannot convert from 'vector<float, 3>' to 'float4'}} fxc-error {{X3017: cannot implicitly convert from 'const float3' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
   float4 d = 0;
-  d = b+c;            /* expected-error {{cannot convert from 'vector<float, 3>' to 'float4'}} fxc-error {{X3017: cannot implicitly convert from 'const float3' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
+  d = b+c;            /* expected-error {{cannot convert from 'vector<float, 3>' to 'float4'}} expected-warning {{implicit truncation of vector type}} fxc-error {{X3017: cannot implicitly convert from 'const float3' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
   return b + d;
 }

--- a/tools/clang/test/HLSL/vector-conditional.hlsl
+++ b/tools/clang/test/HLSL/vector-conditional.hlsl
@@ -121,8 +121,7 @@ float4 main(float4 v0 : TEXCOORD) : SV_Target
         `-FloatingLiteral <col:20> 'float' 1.000000e+00
   */
 
-  // TODO: Should be a vector truncation warning here
-  acc.xy += b4.xy ? v0.xy : (v0 + 1.0F);                    /* fxc-warning {{X3206: implicit truncation of vector type}} */
+  acc.xy += b4.xy ? v0.xy : (v0 + 1.0F);                    /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   /*verify-ast
     CompoundAssignOperator <col:3, col:39> 'vector<float, 2>':'vector<float, 2>' lvalue vectorcomponent '+=' ComputeLHSTy='vector<float, 2>' ComputeResultTy='vector<float, 2>'
     |-HLSLVectorElementExpr <col:3, col:7> 'vector<float, 2>':'vector<float, 2>' lvalue vectorcomponent xy
@@ -146,7 +145,7 @@ float4 main(float4 v0 : TEXCOORD) : SV_Target
   acc += b4 ? v0.xy : 1.0F;                                 /* expected-error {{conditional operator condition and result dimensions mismatch.}} fxc-error {{X3017: cannot implicitly convert from 'float2' to 'float4'}} */
   acc += b4 ? v0.xy : (v0 + 1.0F);                          /* expected-error {{conditional operator condition and result dimensions mismatch.}} fxc-error {{X3017: cannot implicitly convert from 'float2' to 'const float4'}} */
   acc += b4.xy ? v0 : (v0 + 1.0F);                          /* expected-error {{conditional operator condition and result dimensions mismatch.}} fxc-error {{X3020: dimension of conditional does not match value}} */
-  acc += b4.xy ? v0 : (v0.xy + 1.0F);                       /* expected-error {{cannot convert from 'vector<float, 2>' to 'float4'}} fxc-error {{X3017: cannot implicitly convert from 'const float2' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
+  acc += b4.xy ? v0 : (v0.xy + 1.0F);                       /* expected-error {{cannot convert from 'vector<float, 2>' to 'float4'}} expected-warning {{implicit truncation of vector type}} fxc-error {{X3017: cannot implicitly convert from 'const float2' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
 
   // lit float/int
   acc += b4 ? v0 : 1.1;


### PR DESCRIPTION
There was no warning when the truncation happened
due to a binary operation.

Fixes #1159
