### PR TITLE
Fixes failures in two execution tests that used SRVs

### DIFF
--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -120,6 +120,7 @@ public:
   LPCSTR  Kind;         // One of UAV,SRV,CBV
   // Other fields to customize mapping can be added here.
   D3D12_SHADER_RESOURCE_VIEW_DESC   SrvDesc;
+  bool                              SrvDescPresent;
   D3D12_UNORDERED_ACCESS_VIEW_DESC  UavDesc;
 };
 


### PR DESCRIPTION
Longform explanation:
Views/descriptors over resources may specify some non-default properties.

The prior implementation was trying to check values and infer whether
they had been set or were forcibly needed. For starters, this wasn't
always properly initialized, so results were not consistent. Guessing
at this point is a bad idea in any case, so the new implementation
keeps track of whether anything was in fact specified (and if so, values
should have been initialized by the reader, although that is still WIP
for some cases).