### PR TITLE
Allow void in function parameter list

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7488,8 +7488,6 @@ def err_hlsl_objectintemplateargument : Error<
   "%0 is an object and cannot be used as a type parameter">;
 def err_hlsl_packoffset_requires_cbuffer : Error<
   "packoffset is only allowed in a constant buffer">;
-def err_hlsl_param_typedef_of_void : Error< // Patterned after err_param_typedef_of_void
-  "empty parameter list defined with a %select{typedef|type alias}0 of 'void' not allowed%select{ in HLSL|}0">;
 def err_hlsl_register_semantics_conflicting : Error<
   "conflicting register semantics">;
 def err_hlsl_register_or_offset_bind_not_valid: Error<

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -148,7 +148,7 @@ public:
 
 #endif
 
-  // MS Change Starts
+  // HLSL Change Starts
   unsigned HLSLVersion;  // Only supported for IntelliSense scenarios.
   std::string HLSLEntryFunction;
   std::string HLSLProfile;
@@ -156,7 +156,7 @@ public:
   unsigned RootSigMinor;
   bool IsHLSLLibrary;
   bool UseMinPrecision; // use min precision, not native precision.
-  // MS Change Ends
+  // HLSL Change Ends
 
   bool SPIRV = false;  // SPIRV Change
   

--- a/tools/clang/lib/AST/ASTDumper.cpp
+++ b/tools/clang/lib/AST/ASTDumper.cpp
@@ -1045,14 +1045,14 @@ void ASTDumper::dumpHLSLUnusualAnnotations(const ArrayRef<hlsl::UnusualAnnotatio
 // HLSL Change Ends
 
 void ASTDumper::dumpDecl(const Decl *D) {
-  // MS Change Starts: Don't display decls with invalid SourceLocations.
+  // HLSL Change Starts: Don't display decls with invalid SourceLocations.
   if (D && D->getDeclContext() &&
       D->getDeclContext()->getDeclKind() == Decl::Kind::TranslationUnit &&
       D->getSourceRange().isInvalid())
   {
     return;
   }
-  // MS Change Ends
+  // HLSL Change Ends
 
   dumpChild([=] {
     if (!D) {

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -6458,11 +6458,11 @@ void Parser::ParseFunctionDeclarator(Declarator &D,
 bool Parser::ParseRefQualifier(bool &RefQualifierIsLValueRef,
                                SourceLocation &RefQualifierLoc) {
   if (Tok.isOneOf(tok::amp, tok::ampamp)) {
-    // MS Change Starts
+    // HLSL Change Starts
     if (getLangOpts().HLSL) {
       Diag(Tok, diag::err_hlsl_unsupported_construct) << "reference qualifiers on functions";
     } else
-    // MS Change Ends
+    // HLSL Change Ends
     Diag(Tok, getLangOpts().CPlusPlus11 ?
          diag::warn_cxx98_compat_ref_qualifier :
          diag::ext_ref_qualifier);

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -7640,20 +7640,6 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
           NewFD->setInvalidDecl();
       }
     }
-
-    // HLSL Change Starts - error on typedef or type alias of void parameter
-    if (getLangOpts().HLSL && FTI.NumParams && FTIHasSingleVoidParameter(FTI)) {
-      ParmVarDecl *Param = cast<ParmVarDecl>(FTI.Params[0].Param);
-      bool IsTypeAlias = false;
-      if (const TypedefType *TT = Param->getType()->getAs<TypedefType>())
-        IsTypeAlias = isa<TypeAliasDecl>(TT->getDecl());
-      else if (const TemplateSpecializationType *TST =
-                 Param->getType()->getAs<TemplateSpecializationType>())
-        IsTypeAlias = TST->isTypeAlias();
-      Diag(Param->getLocation(), diag::err_hlsl_param_typedef_of_void) << IsTypeAlias;
-    }
-    // HLSL Change Ends
-
   } else if (const FunctionProtoType *FT = R->getAs<FunctionProtoType>()) {
     // When we're declaring a function with a typedef, typeof, etc as in the
     // following example, we'll need to synthesize (unnamed)

--- a/tools/clang/test/CodeGenHLSL/quick-test/void-param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/void-param.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
+
+// CHECK-NOT: error: empty parameter list defined with a typedef of 'void' not allowed in HLSL
+// CHECK: void-param.hlsl:12:16: error: argument may not have 'void' type
+// CHECK: void-param.hlsl:14:16: error: pointers are unsupported in HLSL
+// CHECK: void-param.hlsl:16:10: error: 'void' as parameter must not have type qualifiers
+// CHECK: void-param.hlsl:18:10: error: 'void' must be the first and only parameter if specified
+// CHECK: void-param.hlsl:20:17: error: variadic arguments is unsupported in HLSL
+// CHECK: void-param.hlsl:20:10: error: 'void' must be the first and only parameter if specified
+// CHECK: void-param.hlsl:22:10: error: 'void' must be the first and only parameter if specified
+
+void foo2(void a) {}
+
+void foo2(void *p) {}
+
+void foo3(const void) {}
+
+void foo4(float a, void) {}
+
+void foo5(void, ...) {}
+
+void foo6(void, float a) {}
+
+void foo1(void) {}
+
+float4 main() : SV_TARGET {
+ return 0;
+}

--- a/tools/clang/test/HLSL/cpp-errors.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors.hlsl
@@ -238,7 +238,7 @@ int fn_template(T t)
 
 int template; // expected-error {{'template' is a reserved keyword in HLSL}} expected-error {{expected unqualified-id}}
 
-int get_value(VOID_TYPE) { // expected-error {{empty parameter list defined with a typedef of 'void' not allowed in HLSL}}
+int get_value(VOID_TYPE) {
   return 1;
 }
 


### PR DESCRIPTION
We should support void in an empty parameter list. There are shaders that use this syntax and the old compiler supports it as well.

Fixes #1064