### PR TITLE
[spirv] Add -fspv-target-env command line option.

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2652,6 +2652,9 @@ codegen for Vulkan:
 - ``-fspv-reflect``: Emits additional SPIR-V instructions to aid reflection.
 - ``-fspv-extension=<extension>``: Only allows using ``<extension>`` in CodeGen.
   If you want to allow multiple extensions, provide more than one such option.
+- ``-fspv-target-env=<env>``: Specifies the target environment for this compilation.
+  The current valid options are ``vulkan1.0`` and ``vulkan1.1``. If no target
+  environment is provided, ``vulkan1.0`` is used as default.
 
 Unsupported HLSL Features
 =========================

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -171,6 +171,7 @@ public:
   llvm::SmallVector<uint32_t, 4> VkSShift; // OPT_fvk_s_shift
   llvm::SmallVector<uint32_t, 4> VkUShift; // OPT_fvk_u_shift
   llvm::SmallVector<llvm::StringRef, 4> SpvExtensions; // OPT_fspv_extension
+  llvm::StringRef SpvTargetEnv;                        // OPT_fvk_stage_io_order
 #endif
   // SPIRV Change Ends
 };

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -171,7 +171,7 @@ public:
   llvm::SmallVector<uint32_t, 4> VkSShift; // OPT_fvk_s_shift
   llvm::SmallVector<uint32_t, 4> VkUShift; // OPT_fvk_u_shift
   llvm::SmallVector<llvm::StringRef, 4> SpvExtensions; // OPT_fspv_extension
-  llvm::StringRef SpvTargetEnv;                        // OPT_fvk_stage_io_order
+  llvm::StringRef SpvTargetEnv;                        // OPT_fspv_target_env
 #endif
   // SPIRV Change Ends
 };

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -257,7 +257,7 @@ def fspv_reflect: Flag<["-"], "fspv-reflect">, Group<spirv_Group>, Flags<[CoreOp
 def fspv_extension_EQ : Joined<["-"], "fspv-extension=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify SPIR-V extension permitted to use">;
 def fspv_target_env_EQ : Joined<["-"], "fspv-target-env=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Specify the target Vulkan environment">;
+  HelpText<"Specify the target environment: vulkan1.0 (default) or vulkan1.1">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -256,6 +256,8 @@ def fspv_reflect: Flag<["-"], "fspv-reflect">, Group<spirv_Group>, Flags<[CoreOp
   HelpText<"Emit additional SPIR-V instructions to aid reflection">;
 def fspv_extension_EQ : Joined<["-"], "fspv-extension=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify SPIR-V extension permitted to use">;
+def fspv_target_env_EQ : Joined<["-"], "fspv-target-env=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Specify the target Vulkan environment">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -526,6 +526,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   for (const Arg *A : Args.filtered(OPT_fspv_extension_EQ)) {
     opts.SpvExtensions.push_back(A->getValue());
   }
+
+  opts.SpvTargetEnv = Args.getLastArgValue(OPT_fspv_target_env_EQ, "vulkan1.0");
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false) ||
@@ -534,6 +536,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fvk_ignore_unused_resources, OPT_INVALID, false) ||
       !Args.getLastArgValue(OPT_fvk_stage_io_order_EQ).empty() ||
       !Args.getLastArgValue(OPT_fspv_extension_EQ).empty() ||
+      !Args.getLastArgValue(OPT_fspv_target_env_EQ).empty() ||
       !Args.getLastArgValue(OPT_fvk_b_shift).empty() ||
       !Args.getLastArgValue(OPT_fvk_t_shift).empty() ||
       !Args.getLastArgValue(OPT_fvk_s_shift).empty() ||

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -30,6 +30,7 @@ struct EmitSPIRVOptions {
   llvm::SmallVector<uint32_t, 4> sShift;
   llvm::SmallVector<uint32_t, 4> uShift;
   llvm::SmallVector<llvm::StringRef, 4> allowedExtensions;
+  llvm::StringRef targetEnv;
 };
 } // end namespace clang
 

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -45,7 +45,7 @@ enum class Extension {
 /// The class for handling SPIR-V version and extension requests.
 class FeatureManager {
 public:
-  explicit FeatureManager(DiagnosticsEngine &de, const EmitSPIRVOptions &);
+  FeatureManager(DiagnosticsEngine &de, const EmitSPIRVOptions &);
 
   /// Allows the given extension to be used in CodeGen.
   bool allowExtension(llvm::StringRef);
@@ -73,7 +73,7 @@ public:
   /// Returns the target environment corresponding to the target environment
   /// that was specified as command line option. If no option is specified, the
   /// default (Vulkan 1.0) is returned.
-  inline spv_target_env getTargetEnv() { return targetEnv; }
+  spv_target_env getTargetEnv() const { return targetEnv; }
 
   /// Returns true if the given extension is not part of the core of the target
   /// environment.

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -501,8 +501,6 @@ void ModuleBuilder::setMemoryModel(spv::MemoryModel mm) {
   theModule.setMemoryModel(mm);
 }
 
-void ModuleBuilder::useSpirv1p3() { theModule.setVersion(0x00010300); }
-
 void ModuleBuilder::requireCapability(spv::Capability cap) {
   if (cap != spv::Capability::Max)
     theModule.addCapability(cap);

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -35,8 +35,7 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
     targetEnv = SPV_ENV_VULKAN_1_1;
   else {
     emitError("unknown SPIR-V target environment '%0'", {}) << opts.targetEnv;
-    emitNote("allowed options are:\n%0\n%1", {}) << "vulkan1.0"
-                                                 << "vulkan1.1";
+    emitNote("allowed options are:\n vulkan1.0\n vulkan1.1", {});
   }
 }
 
@@ -76,7 +75,7 @@ bool FeatureManager::requestTargetEnv(spv_target_env requestedEnv,
   if (targetEnv == SPV_ENV_VULKAN_1_0 && requestedEnv == SPV_ENV_VULKAN_1_1) {
     emitError("Vulkan 1.1 is required for %0 but not permitted to use", srcLoc)
         << target;
-    emitNote("please specify your target environment via command line option",
+    emitNote("please specify your target environment via command line option -fspv-target-env=",
              {});
     return false;
   }

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -6189,7 +6189,7 @@ SpirvEvalInfo SPIRVEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     retVal = processIntrinsicF32ToF16(callExpr);
     break;
   case hlsl::IntrinsicOp::IOP_WaveGetLaneCount: {
-    featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1, "Wave Operation",
+    featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1, "WaveGetLaneCount",
                                     callExpr->getExprLoc());
     const uint32_t retType =
         typeTranslator.translateType(callExpr->getCallReturnType(astContext));
@@ -6198,7 +6198,7 @@ SpirvEvalInfo SPIRVEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     retVal = theBuilder.createLoad(retType, varId);
   } break;
   case hlsl::IntrinsicOp::IOP_WaveGetLaneIndex: {
-    featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1, "Wave Operation",
+    featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1, "WaveGetLaneIndex",
                                     callExpr->getExprLoc());
     const uint32_t retType =
         typeTranslator.translateType(callExpr->getCallReturnType(astContext));

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.h
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.h
@@ -955,9 +955,6 @@ private:
   /// Note: legalization specific code
   bool needsLegalization;
 
-  /// Indicates whether we should generate SPIR-V 1.3 instead of 1.0.
-  bool needsSpirv1p3;
-
   /// Mapping from methods to the decls to represent their implicit object
   /// parameters
   ///

--- a/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-diagonal.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-diagonal.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-x.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-x.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-y.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-y.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.quad-read-lane-at.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.quad-read-lane-at.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-true.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-true.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-any-true.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-any-true.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-ballot.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-ballot.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-and.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // Note: WaveActiveBitAnd() only accepts unsigned interger scalars/vectors.
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-or.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // Note: WaveActiveBitOr() only accepts unsigned interger scalars/vectors.
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-xor.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-bit-xor.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // Note: WaveActiveBitXor() only accepts unsigned interger scalars/vectors.
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-count-bits.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-count-bits.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-max.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-max.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-min.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-min.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-product.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-product.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-sum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-sum.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-get-lane-count.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-get-lane-count.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-get-lane-index.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-get-lane-index.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-is-first-lane.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-is-first-lane.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-op.no-target-env.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-op.no-target-env.error.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T cs_6_0 -E main
+
+RWStructuredBuffer<uint> values;
+[numthreads(32, 1, 1)]
+void main(uint3 id: SV_DispatchThreadID) {
+    values[id.x] = WaveIsFirstLane();
+}
+
+// CHECK: 6:20: error: Vulkan 1.1 is required for Wave Operation but not permitted to use
+// CHECK: note: please specify your target environment via command line option

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-op.target-vulkan1.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-op.target-vulkan1.error.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.0
+
+RWStructuredBuffer<uint> values;
+[numthreads(32, 1, 1)]
+void main(uint3 id: SV_DispatchThreadID) {
+    values[id.x] = WaveIsFirstLane();
+}
+
+// CHECK: 6:20: error: Vulkan 1.1 is required for Wave Operation but not permitted to use
+// CHECK: note: please specify your target environment via command line option

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-count-bits.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-count-bits.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-product.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-product.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-sum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-prefix-sum.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-read-lane-at.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-read-lane-at.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-read-lane-first.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-read-lane-first.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave.builtin.no-dup.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave.builtin.no-dup.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // Some wave ops translates into SPIR-V builtin variables.
 // Test that we are not generating duplicated builtins for multiple calls of

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -479,6 +479,7 @@ public:
           spirvOpts.sShift = opts.VkSShift;
           spirvOpts.uShift = opts.VkUShift;
           spirvOpts.allowedExtensions = opts.SpvExtensions;
+          spirvOpts.targetEnv = opts.SpvTargetEnv;
           spirvOpts.enable16BitTypes = opts.Enable16BitTypes;
           clang::EmitSPIRVAction action(spirvOpts);
           FrontendInputFile file(utf8SourceName.m_psz, IK_HLSL);

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1131,6 +1131,14 @@ TEST_F(FileTest, SM6QuadReadLaneAt) {
   runFileTest("sm6.quad-read-lane-at.hlsl");
 }
 
+// Test error on using wave ops on Vulkan 1.0 target environment.
+TEST_F(FileTest, WaveOpVulkan1Error) {
+  runFileTest("sm6.wave-op.target-vulkan1.error.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, WaveOpNoTargetEnvError) {
+  runFileTest("sm6.wave-op.no-target-env.error.hlsl", Expect::Failure);
+}
+
 // SPIR-V specific
 TEST_F(FileTest, SpirvStorageClass) { runFileTest("spirv.storage-class.hlsl"); }
 


### PR DESCRIPTION
The valid values for this option currently are:
vulkan1.0
vulkan1.1

If no target environment is specified, vulkan1.0 is used as default.