### PR TITLE
[spirv] Rename -fvk-use-glsl-layout to -fvk-use-gl-layout

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -163,7 +163,7 @@ public:
   bool GenSPIRV;                           // OPT_spirv
   bool VkIgnoreUnusedResources;            // OPT_fvk_ignore_used_resources
   bool VkInvertY;                          // OPT_fvk_invert_y
-  bool VkUseGlslLayout;                    // OPT_fvk_use_glsl_layout
+  bool VkUseGlLayout;                      // OPT_fvk_use_gl_layout
   bool VkUseDxLayout;                      // OPT_fvk_use_dx_layout
   bool SpvEnableReflect;                   // OPT_fspv_reflect
   llvm::StringRef VkStageIoOrder;          // OPT_fvk_stage_io_order

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -250,8 +250,8 @@ def fvk_u_shift : MultiArg<["-"], "fvk-u-shift", 2>, MetaVarName<"<shift> <space
   HelpText<"Specify Vulkan binding number shift for u-type register">;
 def fvk_invert_y: Flag<["-"], "fvk-invert-y">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Invert SV_Position.y in VS/DS/GS to accommodate Vulkan's coordinate system">;
-def fvk_use_glsl_layout: Flag<["-"], "fvk-use-glsl-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
-  HelpText<"Use conventional GLSL std140/std430 memory layout for Vulkan resources">;
+def fvk_use_gl_layout: Flag<["-"], "fvk-use-gl-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Use strict OpenGL std140/std430 memory layout for Vulkan resources">;
 def fvk_use_dx_layout: Flag<["-"], "fvk-use-dx-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Use DirectX memory layout for Vulkan resources">;
 def fspv_reflect: Flag<["-"], "fspv-reflect">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -484,7 +484,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 #ifdef ENABLE_SPIRV_CODEGEN
   const bool genSpirv = opts.GenSPIRV = Args.hasFlag(OPT_spirv, OPT_INVALID, false);
   opts.VkInvertY = Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false);
-  opts.VkUseGlslLayout = Args.hasFlag(OPT_fvk_use_glsl_layout, OPT_INVALID, false);
+  opts.VkUseGlLayout = Args.hasFlag(OPT_fvk_use_gl_layout, OPT_INVALID, false);
   opts.VkUseDxLayout = Args.hasFlag(OPT_fvk_use_dx_layout, OPT_INVALID, false);
   opts.SpvEnableReflect = Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false);
   opts.VkIgnoreUnusedResources = Args.hasFlag(OPT_fvk_ignore_unused_resources, OPT_INVALID, false);
@@ -532,7 +532,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false) ||
-      Args.hasFlag(OPT_fvk_use_glsl_layout, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fvk_use_gl_layout, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_use_dx_layout, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_ignore_unused_resources, OPT_INVALID, false) ||

--- a/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
+++ b/tools/clang/include/clang/SPIRV/EmitSPIRVOptions.h
@@ -33,7 +33,7 @@ struct EmitSPIRVOptions {
   bool defaultRowMajor;
   bool disableValidation;
   bool invertY;
-  bool useGlslLayout;
+  bool useGlLayout;
   bool useDxLayout;
   bool ignoreUnusedResources;
   bool enable16BitTypes;

--- a/tools/clang/lib/SPIRV/EmitSPIRVOptions.cpp
+++ b/tools/clang/lib/SPIRV/EmitSPIRVOptions.cpp
@@ -15,7 +15,7 @@ void EmitSPIRVOptions::Initialize() {
     cBufferLayoutRule = spirv::LayoutRule::FxcCTBuffer;
     tBufferLayoutRule = spirv::LayoutRule::FxcCTBuffer;
     sBufferLayoutRule = spirv::LayoutRule::FxcSBuffer;
-  } else if (useGlslLayout) {
+  } else if (useGlLayout) {
     cBufferLayoutRule = spirv::LayoutRule::GLSLStd140;
     tBufferLayoutRule = spirv::LayoutRule::GLSLStd430;
     sBufferLayoutRule = spirv::LayoutRule::GLSLStd430;

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -533,8 +533,8 @@ SPIRVEmitter::SPIRVEmitter(CompilerInstance &ci, EmitSPIRVOptions &options)
       !shaderModel.IsGS())
     emitError("-fvk-invert-y can only be used in VS/DS/GS", {});
 
-  if (options.useGlslLayout && options.useDxLayout)
-    emitError("cannot specify both -fvk-use-dx-layout and -fvk-use-glsl-layout",
+  if (options.useGlLayout && options.useDxLayout)
+    emitError("cannot specify both -fvk-use-dx-layout and -fvk-use-gl-layout",
               {});
 
   options.Initialize();

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T vs_6_0 -E main -fvk-use-gl-layout
 
 struct S {
     float a;

--- a/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.consume-structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T vs_6_0 -E main -fvk-use-gl-layout
 
 struct S {
     float a;

--- a/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.structured-buffer.get-dimensions.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T ps_6_0 -E main -fvk-use-gl-layout
 
 struct SBuffer {
   float4   f1;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.std140.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.std140.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T vs_6_0 -E main -fvk-use-gl-layout
 
 struct R {     // Alignment                           Offset     Size       Next
     float2 rf; // 8(vec2)                          -> 0        + 8(vec2)  = 8

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.push-constant.std430.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T vs_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T vs_6_0 -E main -fvk-use-gl-layout
 
 // CHECK: OpDecorate %_arr_v2float_uint_3 ArrayStride 8
 // CHECK: OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 32

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.sbuffer.std430.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -fvk-use-glsl-layout
+// Run: %dxc -T ps_6_0 -E main -fvk-use-gl-layout
 
 struct R {     // Alignment       Offset     Size       Next
     float2 rf; // 8(vec2)      -> 0        + 8(vec2)  = 8

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -469,7 +469,7 @@ public:
           spirvOpts.codeGenHighLevel = opts.CodeGenHighLevel;
           spirvOpts.disableValidation = opts.DisableValidation;
           spirvOpts.invertY = opts.VkInvertY;
-          spirvOpts.useGlslLayout = opts.VkUseGlslLayout;
+          spirvOpts.useGlLayout = opts.VkUseGlLayout;
           spirvOpts.useDxLayout = opts.VkUseDxLayout;
           spirvOpts.enableReflect = opts.SpvEnableReflect;
           spirvOpts.ignoreUnusedResources = opts.VkIgnoreUnusedResources;


### PR DESCRIPTION
GLSL as a shading language does not define the layout rules for
std140/std430; the OpenGL graphics environment defines that.

This is also more consistent with -fvk-use-dx-layout.