### PR TITLE
[spirv] Reduce messages printed when testing

### DIFF
--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -157,11 +157,10 @@ bool runCompilerWithSpirvGeneration(const llvm::StringRef inputFilePath,
     // Get compilation results.
     IFT(pResult->GetStatus(&resultStatus));
 
-    // Get diagnostics string and print warnings and errors to stderr.
+    // Get diagnostics string.
     IFT(pResult->GetErrorBuffer(&pErrorBuffer));
     const std::string diagnostics((char *)pErrorBuffer->GetBufferPointer(),
                                   pErrorBuffer->GetBufferSize());
-    fprintf(stderr, "%s\n", diagnostics.c_str());
     *errorMessages = diagnostics;
 
     if (SUCCEEDED(resultStatus)) {


### PR DESCRIPTION
* Stop outputting warning/error messages in tests

They were useful initially; but as we become more and more
mature and having more and more tests, they are just flooding
the output.

* Stop outputting info for successful tests