### PR TITLE
[spirv] Stop emitting SPV_GOOGLE_decorate_string

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -38,7 +38,6 @@ enum class Extension {
   EXT_shader_stencil_export,
   AMD_gpu_shader_half_float,
   AMD_shader_explicit_vertex_parameter,
-  GOOGLE_decorate_string,
   GOOGLE_hlsl_functionality1,
   Unknown,
 };

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -61,9 +61,6 @@ bool FeatureManager::allowExtension(llvm::StringRef name) {
   }
 
   allowedExtensions.set(static_cast<unsigned>(symbol));
-  if (symbol == Extension::GOOGLE_hlsl_functionality1)
-    allowedExtensions.set(
-        static_cast<unsigned>(Extension::GOOGLE_decorate_string));
 
   return true;
 }
@@ -109,7 +106,6 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
             Extension::AMD_gpu_shader_half_float)
       .Case("SPV_AMD_shader_explicit_vertex_parameter",
             Extension::AMD_shader_explicit_vertex_parameter)
-      .Case("SPV_GOOGLE_decorate_string", Extension::GOOGLE_decorate_string)
       .Case("SPV_GOOGLE_hlsl_functionality1",
             Extension::GOOGLE_hlsl_functionality1)
       .Default(Extension::Unknown);
@@ -133,8 +129,6 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_AMD_gpu_shader_half_float";
   case Extension::AMD_shader_explicit_vertex_parameter:
     return "SPV_AMD_shader_explicit_vertex_parameter";
-  case Extension::GOOGLE_decorate_string:
-    return "SPV_GOOGLE_decorate_string";
   case Extension::GOOGLE_hlsl_functionality1:
     return "SPV_GOOGLE_hlsl_functionality1";
   default:

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -845,7 +845,6 @@ void ModuleBuilder::decorateHlslSemantic(uint32_t targetId,
                                          llvm::StringRef semantic,
                                          llvm::Optional<uint32_t> memberIdx) {
   if (allowReflect) {
-    addExtension(Extension::GOOGLE_decorate_string, "SPIR-V reflection", {});
     addExtension(Extension::GOOGLE_hlsl_functionality1, "SPIR-V reflection",
                  {});
     theModule.addDecoration(

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
@@ -4,7 +4,6 @@
 // CHECK: OpCapability CullDistance
 // CHECK: OpCapability Tessellation
 
-// CHECK: OpExtension "SPV_GOOGLE_decorate_string"
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
 // HS PCF output

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.gs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.gs.hlsl
@@ -4,7 +4,6 @@
 // CHECK: OpCapability CullDistance
 // CHECK: OpCapability Geometry
 
-// CHECK: OpExtension "SPV_GOOGLE_decorate_string"
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
 struct GsPerVertexIn {

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
@@ -6,7 +6,6 @@
 // CHECK: OpCapability CullDistance
 // CHECK: OpCapability Tessellation
 
-// CHECK: OpExtension "SPV_GOOGLE_decorate_string"
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
 // Input control point

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.hlsl
@@ -3,7 +3,6 @@
 // CHECK: OpCapability ClipDistance
 // CHECK: OpCapability CullDistance
 
-// CHECK: OpExtension "SPV_GOOGLE_decorate_string"
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
 struct Inner {

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
@@ -3,7 +3,6 @@
 // CHECK: OpCapability ClipDistance
 // CHECK: OpCapability CullDistance
 
-// CHECK: OpExtension "SPV_GOOGLE_decorate_string"
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
 // CHECK: OpEntryPoint Vertex %main "main" %gl_PerVertexOut %in_var_TEXCOORD %in_var_SV_Position %in_var_SV_ClipDistance %in_var_SV_CullDistance0 %out_var_COLOR %out_var_TEXCOORD


### PR DESCRIPTION
Its functionality is subsumed by SPV_GOOGLE_hlsl_functionality1.

See https://github.com/KhronosGroup/SPIRV-Registry/pull/4