### PR TITLE
Better memcpy propagation.

### DIFF
--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -1264,7 +1264,7 @@ Value *TranslateAtan2(CallInst *CI, IntrinsicOp IOP, OP::OpCode opcode,
   Constant *halfPi = ConstantFP::get(Ty->getScalarType(), M_PI / 2);
   Constant *negHalfPi = ConstantFP::get(Ty->getScalarType(), -M_PI / 2);
   Constant *zero = ConstantFP::get(Ty->getScalarType(), 0);
-  if (Ty != Ty->getScalarType()) {
+  if (Ty->isVectorTy()) {
     unsigned vecSize = Ty->getVectorNumElements();
     pi = ConstantVector::getSplat(vecSize, pi);
     halfPi = ConstantVector::getSplat(vecSize, halfPi);

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -701,9 +701,9 @@ void collectInputOutputAccessInfo(
     Value *GV, Constant *constZero,
     std::vector<InputOutputAccessInfo> &accessInfoList, bool hasVertexID,
     bool bInput, bool bRowMajor) {
-  auto User = GV->user_begin();
-  auto UserE = GV->user_end();
-  for (; User != UserE;) {
+  // merge GEP use for input output.
+  HLModule::MergeGepUse(GV);
+  for (auto User = GV->user_begin(); User != GV->user_end();) {
     Value *I = *(User++);
     if (LoadInst *ldInst = dyn_cast<LoadInst>(I)) {
       if (bInput) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2921,6 +2921,9 @@ static bool CreateCBufferVariable(HLCBuffer &CB,
     if (cbSubscript->user_empty()) {
       cbSubscript->eraseFromParent();
       Handle->eraseFromParent();
+    } else {
+      // merge GEP use for cbSubscript.
+      HLModule::MergeGepUse(cbSubscript);
     }
   }
   return true;
@@ -4299,7 +4302,7 @@ void CGMSHLSLRuntime::FinishCodeGen() {
     if (f.hasFnAttribute(llvm::Attribute::NoInline))
       continue;
     // Always inline for used functions.
-    if (!f.user_empty())
+    if (!f.user_empty() && !f.isDeclaration())
       f.addFnAttr(llvm::Attribute::AlwaysInline);
   }
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+
+
+// Make sure initialize static global inside user function can still be propagated.
+// CHECK-NOT: alloca
+
+struct A {
+  float4 x[25];
+};
+
+A a;
+
+static A a2;
+
+void set(A aa) {
+   aa = a;
+}
+
+float4 main(uint l:L) : SV_Target {
+  set(a2);
+  return a2.x[l];
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy2.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -E main -T ps_6_0 -Zi %s | FileCheck %s
+
+
+// Make sure debug info works for flattened alloca.
+// CHECK:call void @llvm.dbg.declare(metadata [2 x float]* %a2.1, 
+
+struct X {
+   float a;
+   int b;
+};
+
+struct A {
+  X x[25];
+  float y[2];
+};
+
+A a;
+float b;
+
+void set(A aa) {
+   aa = a;
+   aa.y[0] = b;
+   aa.y[1] = 3;
+}
+
+float4 main(uint l:L) : SV_Target {
+  A a2;
+  set(a2);
+  return a2.x[l].a + a2.y[l];
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy3.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// Make sure initialize static global inside user function can still be propagated.
+// CHECK-NOT: alloca
+
+// Make sure cbuffer is used.
+// CHECK: call %dx.types.CBufRet.f32 @dx.op.cbufferLoad
+
+// Make sure use of zero initializer get zero.
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.000000e+00)
+
+struct A {
+  float4 x[25];
+};
+
+A a;
+
+static A a2;
+
+void set(A aa) {
+   aa = a;
+}
+
+float2 main(uint l:L) : SV_Target {
+  float m = a2.x[l].x;
+  set(a2);
+  return float2(a2.x[l].x,m);
+}


### PR DESCRIPTION
1. MergeGepUse for cbuffer and temp gep created when flatten.
2. When flatten alloca, always keep order by size of type.
   So we can make sure big alloca flattened first, then small alloca can easier remove memcpy.
3. For global variable which has zero init value, ignore it if the initializer not used.
4. In ResourceToHandle::ReplaceResourceWithHandle only assert when has user.
5. MergeGepUse for input output in collectInputOutputAccessInfo.