### PR TITLE
[spirv] Add support for dual-source blending

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -275,6 +275,8 @@ The namespace ``vk`` will be used for all Vulkan attributes:
 - ``builtin("X")``: For specifying an entity should be translated into a certain
   Vulkan builtin variable. Allowed on function parameters, function returns,
   and struct fields.
+- ``index(X)``: For specifying the index at a specific pixel shader output
+  location. Used for dual-source blending.
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -879,6 +879,14 @@ def VKLocation : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKIndex : InheritableAttr {
+  let Spellings = [CXX11<"vk", "index">];
+  let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;
+  let Args = [IntArgument<"Number">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 def VKBinding : InheritableAttr {
   let Spellings = [CXX11<"vk", "binding">];
   let Subjects = SubjectList<[GlobalVar, HLSLBuffer], ErrorDiag, "ExpectedGlobalVarOrCTBuffer">;

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -375,6 +375,9 @@ public:
   /// \brief Decorates the given target <result-id> with the given location.
   void decorateLocation(uint32_t targetId, uint32_t location);
 
+  /// \brief Decorates the given target <result-id> with the given index.
+  void decorateIndex(uint32_t targetId, uint32_t index);
+
   /// \brief Decorates the given target <result-id> with the given descriptor
   /// set and binding number.
   void decorateDSetBinding(uint32_t targetId, uint32_t setNumber,

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -859,6 +859,11 @@ void ModuleBuilder::decorateLocation(uint32_t targetId, uint32_t location) {
   theModule.addDecoration(d, targetId);
 }
 
+void ModuleBuilder::decorateIndex(uint32_t targetId, uint32_t index) {
+  const Decoration *d = Decoration::getIndex(theContext, index);
+  theModule.addDecoration(d, targetId);
+}
+
 void ModuleBuilder::decorateSpecId(uint32_t targetId, uint32_t specId) {
   const Decoration *d = Decoration::getSpecId(theContext, specId);
   theModule.addDecoration(d, targetId);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10483,6 +10483,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     declAttr = ::new (S.Context) VKLocationAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKIndex:
+    declAttr = ::new (S.Context) VKIndexAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+    break;
   case AttributeList::AT_VKBinding:
     declAttr = ::new (S.Context) VKBindingAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), ValidateAttributeIntArg(S, A, 1),

--- a/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.error1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.error1.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct PSOut {
+    [[vk::location(1), vk::index(5)]] float4 a: SV_Target0;
+    [[vk::location(0), vk::index(1)]] float4 b: SV_Target1;
+};
+
+PSOut main() {
+    PSOut o = (PSOut)0;
+    return o;
+}
+
+// CHECK: :4:7: error: dual-source blending should use vk::location 0
+// CHECK: :4:24: error: dual-source blending only accepts 0 or 1 as vk::index

--- a/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.error2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.error2.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T vs_6_0 -E main
+
+int main(
+    [[vk::index(1)]] int a : A
+) : B {
+    return a;
+}
+
+// CHECK: :4:7: error: vk::index only allowed in pixel shader
+// CHECK: :4:7: error: vk::index should be used together with vk::location for dual-source blending

--- a/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.target.dual-blend.hlsl
@@ -1,0 +1,16 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpDecorate %out_var_SV_Target0 Location 0
+// CHECK: OpDecorate %out_var_SV_Target0 Index 0
+// CHECK: OpDecorate %out_var_SV_Target1 Location 0
+// CHECK: OpDecorate %out_var_SV_Target1 Index 1
+
+struct PSOut {
+    [[vk::location(0), vk::index(0)]] float4 a: SV_Target0;
+    [[vk::location(0), vk::index(1)]] float4 b: SV_Target1;
+};
+
+PSOut main() {
+    PSOut o = (PSOut)0;
+    return o;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -482,6 +482,15 @@ TEST_F(FileTest, SemanticInstanceIDPS) {
   runFileTest("semantic.instance-id.ps.hlsl");
 }
 TEST_F(FileTest, SemanticTargetPS) { runFileTest("semantic.target.ps.hlsl"); }
+TEST_F(FileTest, SemanticTargetDualBlend) {
+  runFileTest("semantic.target.dual-blend.hlsl");
+}
+TEST_F(FileTest, SemanticTargetDualBlendError1) {
+  runFileTest("semantic.target.dual-blend.error1.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, SemanticTargetDualBlendError2) {
+  runFileTest("semantic.target.dual-blend.error2.hlsl", Expect::Failure);
+}
 TEST_F(FileTest, SemanticDepthPS) { runFileTest("semantic.depth.ps.hlsl"); }
 TEST_F(FileTest, SemanticDepthGreaterEqualPS) {
   runFileTest("semantic.depth-greater-equal.ps.hlsl");
@@ -1443,9 +1452,7 @@ TEST_F(FileTest, NonFpColMajorError) {
 TEST_F(FileTest, NamespaceFunctions) {
   runFileTest("namespace.functions.hlsl");
 }
-TEST_F(FileTest, NamespaceGlobals) {
-  runFileTest("namespace.globals.hlsl");
-}
+TEST_F(FileTest, NamespaceGlobals) { runFileTest("namespace.globals.hlsl"); }
 TEST_F(FileTest, NamespaceResources) {
   runFileTest("namespace.resources.hlsl");
 }


### PR DESCRIPTION
In HLSL, dual-source color blending is enabled only via API;
the shader needs no special marks: it only writes SV_Target0
& SV_Target1 like normal.

But in Vulkan, to enable dual-source blending, the shader need
to mark the two participating output variables with Index = 0
and Index = 1, respectively.

So we introduce a new attribute, vk::index(), to let developers
to specify the index of an output variable so dual-source
blending can be enabled.

See Vulkan spec "26.1.2. Dual-Source Blending".