### PR TITLE
Fix variable langopts compile with semicolon

### DIFF
--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1277,7 +1277,7 @@ void CompilerInvocation::setLangDefaults(LangOptions &Opts, InputKind IK,
     Opts.NativeHalfType = 1;
   }
 
-  Opts.HLSL = IK == IK_HLSL || LangStd == LangStandard::lang_hlsl // HLSL Change: Langstandard for HLSL
+  Opts.HLSL = IK == IK_HLSL || LangStd == LangStandard::lang_hlsl; // HLSL Change: Langstandard for HLSL
 
   Opts.CUDA = IK == IK_CUDA || IK == IK_PreprocessedCuda ||
               LangStd == LangStandard::lang_cuda;


### PR DESCRIPTION
A missing semicolon in an HLSL change made the admittedly underused
MS_SUPPORT_VARIABLE_LANGOPTS defined build fail. This adds it.
Simple change. Literally one character.