### PR TITLE
Minor fixes that will make compilers happier.

### DIFF
--- a/include/dxc/Support/FileIOHelper.h
+++ b/include/dxc/Support/FileIOHelper.h
@@ -53,7 +53,7 @@ public:
   }
 
   explicit CDxcTMHeapPtr(_In_ T* pData) throw() :
-    CDxcTMHeapPtr<T, CDxcThreadMallocAllocator>(pData)
+    CHeapPtr<T, CDxcThreadMallocAllocator>(pData)
   {
   }
 };


### PR DESCRIPTION
CDxcTMHeapPtr templated with 2 classes does not exist.

A code block has also been moved so that the caller function knows about
the existence of the callee function. Previous code order is not allowed
by some compilers.