### PR TITLE
[spirv] Convert to use stand-alone variables for gl_PerVertex

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -120,7 +120,7 @@ decorated by the ``Position``, ``ClipDistance``, ``CullDistance`` builtin,
 and two of them are decorated by the ``Location`` decoration. (Note that
 ``clip0`` and ``clip1`` are concatenated, also ``cull0`` and ``cull1``.
 The ``ClipDistance`` and ``CullDistance`` builtins are special and explained
-in the `gl_PerVertex`_ section.)
+in the `ClipDistance & CullDistance`_ section.)
 
 Flattening is infective because of Vulkan interface matching rules. If we
 flatten a struct in the output of a previous stage, which may create multiple
@@ -132,25 +132,6 @@ stages, which means we need to flatten all shader stage interfaces. For
 hull/domain/geometry shader, their inputs/outputs have an additional arrayness.
 So if we are seeing an array of structs in these shaders, we need to flatten
 them into arrays of its fields.
-
-Lastly, to satisfy the type requirements on builtins, after flattening, the
-variables decorated with ``Position``, ``ClipDistance``, and ``CullDistance``
-builtins are grouped into struct, like ``gl_PerVertex`` for certain shader stage
-interface:
-
-============ ===== ======
-Shader Stage Input Output
-============ ===== ======
-    VS         X     G
-    HS         G     G
-    DS         G     G
-    GS         G     S
-    PS         S     X
-============ ===== ======
-
-(``X``: Not applicable, ``G``: Grouped, ``S``: separated)
-
-More details in the `gl_PerVertex`_ section.
 
 Vulkan specific features
 ------------------------
@@ -1226,22 +1207,8 @@ flattening all structs if structs are used as function parameters or returns.
 There is an exception to the above rule for SV_Target[N]. It will always be
 mapped to ``Location`` number N.
 
-``gl_PerVertex``
-~~~~~~~~~~~~~~~~
-
-Variables annotated with ``SV_Position``, ``SV_ClipDistanceX``, and
-``SV_CullDistanceX`` are mapped into fields of a ``gl_PerVertex`` struct:
-
-.. code:: hlsl
-
-    struct gl_PerVertex {
-        float4 gl_Position;       // SPIR-V BuiltIn Position
-        float  gl_PointSize;      // No HLSL equivalent
-        float  gl_ClipDistance[]; // SPIR-V BuiltIn ClipDistance
-        float  gl_CullDistance[]; // SPIR-V BuiltIn CullDistance
-    };
-
-This mimics how these builtins are handled in GLSL.
+``ClipDistance & CullDistance``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Variables decorated with ``SV_ClipDistanceX`` can be float or vector of float
 type. To map them into one float array in the struct, we firstly sort them

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -431,6 +431,9 @@ public:
   bool writeBackOutputStream(const NamedDecl *decl, QualType type,
                              uint32_t value);
 
+  /// \brief Inverts SV_Position.y is requested.
+  uint32_t invertYIfRequested(uint32_t position);
+
   /// \brief Decorates all stage input and output variables with proper
   /// location and returns true on success.
   ///
@@ -742,7 +745,7 @@ DeclResultIdMapper::DeclResultIdMapper(const hlsl::ShaderModel &model,
       astContext(context), diags(context.getDiagnostics()),
       typeTranslator(translator), featureManager(features), entryFunctionId(0),
       laneCountBuiltinId(0), laneIndexBuiltinId(0), needsLegalization(false),
-      glPerVertex(model, context, builder, typeTranslator, options.invertY) {}
+      glPerVertex(model, context, builder, typeTranslator) {}
 
 bool DeclResultIdMapper::decorateStageIOLocations() {
   // Try both input and output even if input location assignment failed

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -18,11 +18,8 @@ namespace clang {
 namespace spirv {
 
 namespace {
-constexpr uint32_t gPositionIndex = 0;
-constexpr uint32_t gPointSizeIndex = 1;
-constexpr uint32_t gClipDistanceIndex = 2;
-constexpr uint32_t gCullDistanceIndex = 3;
-constexpr uint32_t gGlPerVertexSize = 4;
+constexpr uint32_t gClipDistanceIndex = 0;
+constexpr uint32_t gCullDistanceIndex = 1;
 
 /// \brief Returns true if the given decl has a semantic string attached and
 /// writes the info to *semanticStr, *semantic, and *semanticIndex.
@@ -63,80 +60,49 @@ inline bool hasGSPrimitiveTypeQualifier(const DeclaratorDecl *decl) {
 } // anonymous namespace
 
 GlPerVertex::GlPerVertex(const hlsl::ShaderModel &sm, ASTContext &context,
-                         ModuleBuilder &builder, TypeTranslator &translator,
-                         bool negateY)
+                         ModuleBuilder &builder, TypeTranslator &translator)
     : shaderModel(sm), astContext(context), theBuilder(builder),
-      typeTranslator(translator), invertY(negateY), inIsGrouped(true),
-      outIsGrouped(true), inBlockVar(0), outBlockVar(0), inClipVar(0),
-      inCullVar(0), outClipVar(0), outCullVar(0), inArraySize(0),
-      outArraySize(0), inClipArraySize(1), outClipArraySize(1),
-      inCullArraySize(1), outCullArraySize(1), inSemanticStrs(4, ""),
-      outSemanticStrs(4, "") {}
+      typeTranslator(translator), inClipVar(0), inCullVar(0), outClipVar(0),
+      outCullVar(0), inArraySize(0), outArraySize(0), inClipArraySize(1),
+      outClipArraySize(1), inCullArraySize(1), outCullArraySize(1),
+      inSemanticStrs(2, ""), outSemanticStrs(2, "") {}
 
 void GlPerVertex::generateVars(uint32_t inArrayLen, uint32_t outArrayLen) {
-  // Calling this method twice is an internal error.
-  assert(inBlockVar == 0);
-  assert(outBlockVar == 0);
-
   inArraySize = inArrayLen;
   outArraySize = outArrayLen;
 
-  switch (shaderModel.GetKind()) {
-  case hlsl::ShaderModel::Kind::Vertex:
-    outBlockVar = createBlockVar(/*asInput=*/false, 0);
-    break;
-  case hlsl::ShaderModel::Kind::Hull:
-    inBlockVar = createBlockVar(/*asInput=*/true, inArraySize);
-    outBlockVar = createBlockVar(/*asInput=*/false, outArraySize);
-    break;
-  case hlsl::ShaderModel::Kind::Domain:
-    inBlockVar = createBlockVar(/*asInput=*/true, inArraySize);
-    outBlockVar = createBlockVar(/*asInput=*/false, 0);
-    break;
-  case hlsl::ShaderModel::Kind::Geometry:
-    inBlockVar = createBlockVar(/*asInput=*/true, inArraySize);
-    if (!outClipType.empty())
-      outClipVar = createClipDistanceVar(/*asInput=*/false, outClipArraySize);
-    if (!outCullType.empty())
-      outCullVar = createCullDistanceVar(/*asInput=*/false, outCullArraySize);
-    outIsGrouped = false;
-    break;
-  case hlsl::ShaderModel::Kind::Pixel:
-    if (!inClipType.empty())
-      inClipVar = createClipDistanceVar(/*asInput=*/true, inClipArraySize);
-    if (!inCullType.empty())
-      inCullVar = createCullDistanceVar(/*asInput=*/true, inCullArraySize);
-    inIsGrouped = false;
-    break;
-  }
+  if (!inClipType.empty())
+    inClipVar = createClipCullDistanceVar(/*asInput=*/true, /*isClip=*/true,
+                                          inClipArraySize);
+  if (!inCullType.empty())
+    inCullVar = createClipCullDistanceVar(/*asInput=*/true, /*isClip=*/false,
+                                          inCullArraySize);
+  if (!outClipType.empty())
+    outClipVar = createClipCullDistanceVar(/*asInput=*/false, /*isClip=*/true,
+                                           outClipArraySize);
+  if (!outCullType.empty())
+    outCullVar = createClipCullDistanceVar(/*asInput=*/false, /*isClip=*/false,
+                                           outCullArraySize);
 }
 
-llvm::SmallVector<uint32_t, 4> GlPerVertex::getStageInVars() const {
-  llvm::SmallVector<uint32_t, 4> vars;
-  if (inIsGrouped) {
-    if (inBlockVar)
-      vars.push_back(inBlockVar);
-  } else {
-    if (inClipVar)
-      vars.push_back(inClipVar);
-    if (inCullVar)
-      vars.push_back(inCullVar);
-  }
+llvm::SmallVector<uint32_t, 2> GlPerVertex::getStageInVars() const {
+  llvm::SmallVector<uint32_t, 2> vars;
+
+  if (inClipVar)
+    vars.push_back(inClipVar);
+  if (inCullVar)
+    vars.push_back(inCullVar);
 
   return vars;
 }
 
-llvm::SmallVector<uint32_t, 4> GlPerVertex::getStageOutVars() const {
-  llvm::SmallVector<uint32_t, 4> vars;
-  if (outIsGrouped) {
-    if (outBlockVar)
-      vars.push_back(outBlockVar);
-  } else {
-    if (outClipVar)
-      vars.push_back(outClipVar);
-    if (outCullVar)
-      vars.push_back(outCullVar);
-  }
+llvm::SmallVector<uint32_t, 2> GlPerVertex::getStageOutVars() const {
+  llvm::SmallVector<uint32_t, 2> vars;
+
+  if (outClipVar)
+    vars.push_back(outClipVar);
+  if (outCullVar)
+    vars.push_back(outCullVar);
 
   return vars;
 }
@@ -214,12 +180,9 @@ bool GlPerVertex::doGlPerVertexFacts(const DeclaratorDecl *decl,
   uint32_t *blockArraySize = asInput ? &inArraySize : &outArraySize;
   bool isCull = false;
   auto *semanticStrs = asInput ? &inSemanticStrs : &outSemanticStrs;
-  auto index = gGlPerVertexSize; // The index of this semantic in gl_PerVertex
+  uint32_t index = kSemanticStrCount;
 
   switch (semantic->GetKind()) {
-  case hlsl::Semantic::Kind::Position:
-    index = gPositionIndex;
-    break;
   case hlsl::Semantic::Kind::ClipDistance:
     typeMap = asInput ? &inClipType : &outClipType;
     index = gClipDistanceIndex;
@@ -231,15 +194,9 @@ bool GlPerVertex::doGlPerVertexFacts(const DeclaratorDecl *decl,
     break;
   }
 
-  // PointSize does not have corresponding SV semantic; it uses
-  // [[vk::builtin("PointSize")]] instead.
-  if (const auto *builtinAttr = decl->getAttr<VKBuiltInAttr>())
-    if (builtinAttr->getBuiltIn() == "PointSize")
-      index = gPointSizeIndex;
-
   // Remember the semantic strings provided by the developer so that we can
   // emit OpDecorate* instructions properly for them
-  if (index < gGlPerVertexSize) {
+  if (index < kSemanticStrCount) {
     if ((*semanticStrs)[index].empty())
       (*semanticStrs)[index] = semanticStr;
     // We can have multiple ClipDistance/CullDistance semantics mapping to the
@@ -353,70 +310,27 @@ void GlPerVertex::calculateClipCullDistanceArraySize() {
   updateSizeAndOffset(outCullType, &outCullOffset, &outCullArraySize);
 }
 
-uint32_t GlPerVertex::createBlockVar(bool asInput, uint32_t arraySize) {
-  const llvm::StringRef typeName = "type.gl_PerVertex";
-  spv::StorageClass sc = spv::StorageClass::Input;
-  llvm::StringRef varName = "gl_PerVertexIn";
-  auto *semanticStrs = &inSemanticStrs;
-  uint32_t clipSize = inClipArraySize;
-  uint32_t cullSize = inCullArraySize;
-
-  if (!asInput) {
-    sc = spv::StorageClass::Output;
-    varName = "gl_PerVertexOut";
-    semanticStrs = &outSemanticStrs;
-    clipSize = outClipArraySize;
-    cullSize = outCullArraySize;
-  }
-
-  uint32_t typeId = typeTranslator.getGlPerVertexStruct(
-      clipSize, cullSize, typeName, *semanticStrs);
-
-  // Handle the extra arrayness over the block
-  if (arraySize != 0) {
-    const uint32_t arraySizeId = theBuilder.getConstantUint32(arraySize);
-    typeId = theBuilder.getArrayType(typeId, arraySizeId);
-  }
-
-  return theBuilder.addStageIOVar(typeId, sc, varName);
-}
-
-uint32_t GlPerVertex::createPositionVar(bool asInput) {
-  const uint32_t type = theBuilder.getVecType(theBuilder.getFloat32Type(), 4);
-  const spv::StorageClass sc =
-      asInput ? spv::StorageClass::Input : spv::StorageClass::Output;
-  // Special handling here. Requesting Position for input means we are in
-  // PS, which should use FragCoord instead of Position.
-  assert(asInput ? shaderModel.IsPS() : true);
-  const spv::BuiltIn builtin =
-      asInput ? spv::BuiltIn::FragCoord : spv::BuiltIn::Position;
-
-  return theBuilder.addStageBuiltinVar(type, sc, builtin);
-}
-
-uint32_t GlPerVertex::createClipDistanceVar(bool asInput, uint32_t arraySize) {
-  const uint32_t type = theBuilder.getArrayType(
+uint32_t GlPerVertex::createClipCullDistanceVar(bool asInput, bool isClip,
+                                                uint32_t arraySize) {
+  uint32_t type = theBuilder.getArrayType(
       theBuilder.getFloat32Type(), theBuilder.getConstantUint32(arraySize));
+  if (asInput && inArraySize != 0) {
+    type = theBuilder.getArrayType(type,
+                                   theBuilder.getConstantUint32(inArraySize));
+  } else if (!asInput && outArraySize != 0) {
+    type = theBuilder.getArrayType(type,
+                                   theBuilder.getConstantUint32(outArraySize));
+  }
+
   spv::StorageClass sc =
       asInput ? spv::StorageClass::Input : spv::StorageClass::Output;
 
-  auto id = theBuilder.addStageBuiltinVar(type, sc, spv::BuiltIn::ClipDistance);
-  theBuilder.decorateHlslSemantic(
-      id, asInput ? inSemanticStrs[gClipDistanceIndex]
-                  : outSemanticStrs[gClipDistanceIndex]);
-  return id;
-}
-
-uint32_t GlPerVertex::createCullDistanceVar(bool asInput, uint32_t arraySize) {
-  const uint32_t type = theBuilder.getArrayType(
-      theBuilder.getFloat32Type(), theBuilder.getConstantUint32(arraySize));
-  spv::StorageClass sc =
-      asInput ? spv::StorageClass::Input : spv::StorageClass::Output;
-
-  auto id = theBuilder.addStageBuiltinVar(type, sc, spv::BuiltIn::CullDistance);
-  theBuilder.decorateHlslSemantic(
-      id, asInput ? inSemanticStrs[gCullDistanceIndex]
-                  : outSemanticStrs[gCullDistanceIndex]);
+  auto id = theBuilder.addStageBuiltinVar(type, sc,
+                                          isClip ? spv::BuiltIn::ClipDistance
+                                                 : spv::BuiltIn::CullDistance);
+  const auto index = isClip ? gClipDistanceIndex : gCullDistanceIndex;
+  theBuilder.decorateHlslSemantic(id, asInput ? inSemanticStrs[index]
+                                              : outSemanticStrs[index]);
   return id;
 }
 
@@ -430,7 +344,6 @@ bool GlPerVertex::tryToAccess(hlsl::SigPoint::Kind sigPointKind,
                                  : true);
 
   switch (semanticKind) {
-  case hlsl::Semantic::Kind::Position:
   case hlsl::Semantic::Kind::ClipDistance:
   case hlsl::Semantic::Kind::CullDistance:
     // gl_PerVertex only cares about these builtins.
@@ -441,24 +354,12 @@ bool GlPerVertex::tryToAccess(hlsl::SigPoint::Kind sigPointKind,
 
   switch (sigPointKind) {
   case hlsl::SigPoint::Kind::PSIn:
-    // We don't handle stand-alone Position builtin in this class.
-    if (semanticKind == hlsl::Semantic::Kind::Position)
-      return false; // Fall back to the normal path
-
-    // Fall through
-
   case hlsl::SigPoint::Kind::HSCPIn:
   case hlsl::SigPoint::Kind::DSCPIn:
   case hlsl::SigPoint::Kind::GSVIn:
     return readField(semanticKind, semanticIndex, value);
 
   case hlsl::SigPoint::Kind::GSOut:
-    // We don't handle stand-alone Position builtin in this class.
-    if (semanticKind == hlsl::Semantic::Kind::Position)
-      return false; // Fall back to the normal path
-
-    // Fall through
-
   case hlsl::SigPoint::Kind::VSOut:
   case hlsl::SigPoint::Kind::HSCPOut:
   case hlsl::SigPoint::Kind::DSOut:
@@ -471,68 +372,9 @@ bool GlPerVertex::tryToAccess(hlsl::SigPoint::Kind sigPointKind,
   return false;
 }
 
-bool GlPerVertex::tryToAccessPointSize(hlsl::SigPoint::Kind sigPointKind,
-                                       llvm::Optional<uint32_t> invocation,
-                                       uint32_t *value, bool noWriteBack) {
-  switch (sigPointKind) {
-  case hlsl::SigPoint::Kind::HSCPIn:
-  case hlsl::SigPoint::Kind::DSCPIn:
-  case hlsl::SigPoint::Kind::GSVIn:
-    *value = readPositionOrPointSize(/*isPosition=*/false);
-    return true;
-  case hlsl::SigPoint::Kind::VSOut:
-  case hlsl::SigPoint::Kind::HSCPOut:
-  case hlsl::SigPoint::Kind::DSOut:
-    writePositionOrPointSize(/*isPosition=*/false, invocation, *value);
-    return true;
-  }
-
-  return false; // Fall back to normal path: GSOut
-}
-
-uint32_t GlPerVertex::readPositionOrPointSize(bool isPosition) const {
-  // We do not handle stand-alone Position/PointSize builtin here.
-  assert(inIsGrouped);
-
-  // The PointSize builtin is always of float type.
-  // The Position builtin is always of float4 type.
-  const uint32_t f32Type = theBuilder.getFloat32Type();
-  const uint32_t fieldType =
-      isPosition ? theBuilder.getVecType(f32Type, 4) : f32Type;
-  const uint32_t ptrType =
-      theBuilder.getPointerType(fieldType, spv::StorageClass::Input);
-  const uint32_t fieldIndex = theBuilder.getConstantUint32(isPosition ? 0 : 1);
-
-  if (inArraySize == 0) {
-    // The input builtin block is a single block. Only need one index to
-    // locate the Position/PointSize builtin.
-    const uint32_t ptr =
-        theBuilder.createAccessChain(ptrType, inBlockVar, {fieldIndex});
-    return theBuilder.createLoad(fieldType, ptr);
-  }
-
-  // The input builtin block is an array of blocks, which means we need to
-  // read an array of float4 from an array of structs.
-
-  llvm::SmallVector<uint32_t, 8> elements;
-  for (uint32_t i = 0; i < inArraySize; ++i) {
-    const uint32_t arrayIndex = theBuilder.getConstantUint32(i);
-    // Get pointer into the array of structs. We need two indices to locate
-    // the Position/PointSize builtin now: the first one is the array index,
-    // and the second one is the struct index.
-    const uint32_t ptr = theBuilder.createAccessChain(ptrType, inBlockVar,
-                                                      {arrayIndex, fieldIndex});
-    elements.push_back(theBuilder.createLoad(fieldType, ptr));
-  }
-  // Construct a new array of float4/float for the Position/PointSize builtins
-  const uint32_t arrayType = theBuilder.getArrayType(
-      fieldType, theBuilder.getConstantUint32(inArraySize));
-  return theBuilder.createCompositeConstruct(arrayType, elements);
-}
-
 uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
                                               QualType asType) const {
-  const uint32_t clipCullIndex = isClip ? 2 : 3;
+  const uint32_t clipCullVar = isClip ? inClipVar : inCullVar;
 
   // The ClipDistance/CullDistance is always an float array. We are accessing
   // it using pointers, which should be of pointer to float type.
@@ -541,25 +383,16 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
       theBuilder.getPointerType(f32Type, spv::StorageClass::Input);
 
   if (inArraySize == 0) {
-    // The input builtin block is a single block. Only need two indices to
-    // locate the array segment for this SV_ClipDistance/SV_CullDistance
-    // variable: one is the index in the gl_PerVertex struct, the other is
-    // the start offset within the float array.
+    // The input builtin does not have extra arrayness. Only need one index
+    // to locate the array segment for this SV_ClipDistance/SV_CullDistance
+    // variable: the start offset within the float array.
     QualType elemType = {};
     uint32_t count = {};
 
     if (TypeTranslator::isScalarType(asType)) {
       const uint32_t offsetId = theBuilder.getConstantUint32(offset);
-      uint32_t ptr = 0;
-
-      if (inIsGrouped) {
-        ptr = theBuilder.createAccessChain(
-            ptrType, inBlockVar,
-            {theBuilder.getConstantUint32(clipCullIndex), offsetId});
-      } else {
-        ptr = theBuilder.createAccessChain(
-            ptrType, clipCullIndex == 2 ? inClipVar : inCullVar, {offsetId});
-      }
+      const uint32_t ptr =
+          theBuilder.createAccessChain(ptrType, clipCullVar, {offsetId});
       return theBuilder.createLoad(f32Type, ptr);
     }
 
@@ -570,16 +403,8 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
       for (uint32_t i = 0; i < count; ++i) {
         // Read elements sequentially from the float array
         const uint32_t offsetId = theBuilder.getConstantUint32(offset + i);
-        uint32_t ptr = 0;
-
-        if (inIsGrouped) {
-          ptr = theBuilder.createAccessChain(
-              ptrType, inBlockVar,
-              {theBuilder.getConstantUint32(clipCullIndex), offsetId});
-        } else {
-          ptr = theBuilder.createAccessChain(
-              ptrType, clipCullIndex == 2 ? inClipVar : inCullVar, {offsetId});
-        }
+        const uint32_t ptr =
+            theBuilder.createAccessChain(ptrType, clipCullVar, {offsetId});
         elements.push_back(theBuilder.createLoad(f32Type, ptr));
       }
       return theBuilder.createCompositeConstruct(
@@ -597,8 +422,6 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
   // for indexing into the gl_PerVertex struct, and the third one for reading
   // the correct element in the float array for ClipDistance/CullDistance.
 
-  assert(inIsGrouped); // Separated builtins won't have the extra arrayness.
-
   llvm::SmallVector<uint32_t, 8> arrayElements;
   QualType elemType = {};
   uint32_t count = {};
@@ -609,9 +432,8 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
     arrayType = theBuilder.getArrayType(f32Type, arraySize);
     for (uint32_t i = 0; i < inArraySize; ++i) {
       const uint32_t ptr = theBuilder.createAccessChain(
-          ptrType, inBlockVar,
+          ptrType, clipCullVar,
           {theBuilder.getConstantUint32(i), // Block array index
-           theBuilder.getConstantUint32(clipCullIndex),
            theBuilder.getConstantUint32(offset)});
       arrayElements.push_back(theBuilder.createLoad(f32Type, ptr));
     }
@@ -623,9 +445,9 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
       llvm::SmallVector<uint32_t, 4> vecElements;
       for (uint32_t j = 0; j < count; ++j) {
         const uint32_t ptr = theBuilder.createAccessChain(
-            ptrType, inBlockVar,
-            {theBuilder.getConstantUint32(i), // Block array index
-             theBuilder.getConstantUint32(clipCullIndex),
+            ptrType, clipCullVar,
+            // Block array index
+            {theBuilder.getConstantUint32(i),
              // Read elements sequentially from the float array
              theBuilder.getConstantUint32(offset + j)});
         vecElements.push_back(theBuilder.createLoad(f32Type, ptr));
@@ -644,9 +466,6 @@ uint32_t GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
 bool GlPerVertex::readField(hlsl::Semantic::Kind semanticKind,
                             uint32_t semanticIndex, uint32_t *value) {
   switch (semanticKind) {
-  case hlsl::Semantic::Kind::Position:
-    *value = readPositionOrPointSize(/*isPosition=*/true);
-    return true;
   case hlsl::Semantic::Kind::ClipDistance: {
     const auto offsetIter = inClipOffset.find(semanticIndex);
     const auto typeIter = inClipType.find(semanticIndex);
@@ -671,62 +490,10 @@ bool GlPerVertex::readField(hlsl::Semantic::Kind semanticKind,
   return false;
 }
 
-void GlPerVertex::writePositionOrPointSize(
-    bool isPosition, llvm::Optional<uint32_t> invocationId, uint32_t value) {
-  // We do not handle stand-alone Position/PointSize builtin here.
-  assert(outIsGrouped);
-
-  // The Position builtin is always of float4 type.
-  // The PointSize builtin is always of float type.
-  const uint32_t f32Type = theBuilder.getFloat32Type();
-  const uint32_t fieldType =
-      isPosition ? theBuilder.getVecType(f32Type, 4) : f32Type;
-  const uint32_t ptrType =
-      theBuilder.getPointerType(fieldType, spv::StorageClass::Output);
-  const uint32_t fieldIndex = theBuilder.getConstantUint32(isPosition ? 0 : 1);
-
-  if (outArraySize == 0) {
-    // The input builtin block is a single block. Only need one index to
-    // locate the Position/PointSize builtin.
-    const uint32_t ptr =
-        theBuilder.createAccessChain(ptrType, outBlockVar, {fieldIndex});
-
-    if (isPosition && invertY) {
-      if (shaderModel.IsVS() || shaderModel.IsDS()) {
-        const auto oldY =
-            theBuilder.createCompositeExtract(f32Type, value, {1});
-        const auto newY =
-            theBuilder.createUnaryOp(spv::Op::OpFNegate, f32Type, oldY);
-        value = theBuilder.createCompositeInsert(fieldType, value, {1}, newY);
-      }
-    }
-
-    theBuilder.createStore(ptr, value);
-    return;
-  }
-
-  // Writing to an array only happens in HSCPOut.
-  assert(shaderModel.IsHS());
-  // And we are only writing to the array element with InvocationId as index.
-  assert(invocationId.hasValue());
-
-  // The input builtin block is an array of blocks, which means we need to
-  // to write a float4 to each gl_PerVertex in the array.
-
-  const uint32_t arrayIndex = invocationId.getValue();
-  // Get pointer into the array of structs. We need two indices to locate
-  // the Position/PointSize builtin now: the first one is the array index,
-  // and the second one is the struct index.
-  const uint32_t ptr = theBuilder.createAccessChain(ptrType, outBlockVar,
-                                                    {arrayIndex, fieldIndex});
-
-  theBuilder.createStore(ptr, value);
-}
-
 void GlPerVertex::writeClipCullArrayFromType(
     llvm::Optional<uint32_t> invocationId, bool isClip, uint32_t offset,
     QualType fromType, uint32_t fromValue) const {
-  const uint32_t clipCullIndex = isClip ? 2 : 3;
+  const uint32_t clipCullVar = isClip ? outClipVar : outCullVar;
 
   // The ClipDistance/CullDistance is always an float array. We are accessing
   // it using pointers, which should be of pointer to float type.
@@ -735,25 +502,16 @@ void GlPerVertex::writeClipCullArrayFromType(
       theBuilder.getPointerType(f32Type, spv::StorageClass::Output);
 
   if (outArraySize == 0) {
-    // The input builtin block is a single block. Only need two indices to
-    // locate the array segment for this SV_ClipDistance/SV_CullDistance
-    // variable: one is the index in the gl_PerVertex struct, the other is
-    // the start offset within the float array.
+    // The output builtin does not have extra arrayness. Only need one index
+    // to locate the array segment for this SV_ClipDistance/SV_CullDistance
+    // variable: the start offset within the float array.
     QualType elemType = {};
     uint32_t count = {};
 
     if (TypeTranslator::isScalarType(fromType)) {
       const uint32_t offsetId = theBuilder.getConstantUint32(offset);
-      uint32_t ptr = 0;
-
-      if (outIsGrouped) {
-        ptr = theBuilder.createAccessChain(
-            ptrType, outBlockVar,
-            {theBuilder.getConstantUint32(clipCullIndex), offsetId});
-      } else {
-        ptr = theBuilder.createAccessChain(
-            ptrType, clipCullIndex == 2 ? outClipVar : outCullVar, {offsetId});
-      }
+      const uint32_t ptr =
+          theBuilder.createAccessChain(ptrType, clipCullVar, {offsetId});
       theBuilder.createStore(ptr, fromValue);
       return;
     }
@@ -764,17 +522,8 @@ void GlPerVertex::writeClipCullArrayFromType(
       for (uint32_t i = 0; i < count; ++i) {
         // Write elements sequentially into the float array
         const uint32_t offsetId = theBuilder.getConstantUint32(offset + i);
-        uint32_t ptr = 0;
-
-        if (outIsGrouped) {
-          ptr = theBuilder.createAccessChain(
-              ptrType, outBlockVar,
-              {theBuilder.getConstantUint32(clipCullIndex), offsetId});
-        } else {
-          ptr = theBuilder.createAccessChain(
-              ptrType, clipCullIndex == 2 ? outClipVar : outCullVar,
-              {offsetId});
-        }
+        const uint32_t ptr =
+            theBuilder.createAccessChain(ptrType, clipCullVar, {offsetId});
         const uint32_t subValue =
             theBuilder.createCompositeExtract(f32Type, fromValue, {i});
         theBuilder.createStore(ptr, subValue);
@@ -786,8 +535,6 @@ void GlPerVertex::writeClipCullArrayFromType(
                      "float case sneaked in");
     return;
   }
-
-  assert(outIsGrouped); // Separated builtins won't have the extra arrayness.
 
   // Writing to an array only happens in HSCPOut.
   assert(shaderModel.IsHS());
@@ -806,11 +553,10 @@ void GlPerVertex::writeClipCullArrayFromType(
   uint32_t count = {};
 
   if (TypeTranslator::isScalarType(fromType)) {
-    const uint32_t ptr = theBuilder.createAccessChain(
-        ptrType, outBlockVar,
-        {arrayIndex, // Block array index
-         theBuilder.getConstantUint32(clipCullIndex),
-         theBuilder.getConstantUint32(offset)});
+    const uint32_t ptr =
+        theBuilder.createAccessChain(ptrType, clipCullVar,
+                                     {arrayIndex, // Block array index
+                                      theBuilder.getConstantUint32(offset)});
     theBuilder.createStore(ptr, fromValue);
     return;
   }
@@ -819,9 +565,9 @@ void GlPerVertex::writeClipCullArrayFromType(
     // For each gl_PerVertex block, we need to write a vector into it.
     for (uint32_t i = 0; i < count; ++i) {
       const uint32_t ptr = theBuilder.createAccessChain(
-          ptrType, outBlockVar,
-          {arrayIndex, // Block array index
-           theBuilder.getConstantUint32(clipCullIndex),
+          ptrType, clipCullVar,
+          // Block array index
+          {arrayIndex,
            // Write elements sequentially into the float array
            theBuilder.getConstantUint32(offset + i)});
       const uint32_t subValue =
@@ -855,9 +601,6 @@ bool GlPerVertex::writeField(hlsl::Semantic::Kind semanticKind,
   // The interesting shader stage is HS. We need the InvocationID to write
   // out the value to the correct array element.
   switch (semanticKind) {
-  case hlsl::Semantic::Kind::Position:
-    writePositionOrPointSize(/*isPosition=*/true, invocationId, *value);
-    return true;
   case hlsl::Semantic::Kind::ClipDistance: {
     const auto offsetIter = outClipOffset.find(semanticIndex);
     const auto typeIter = outClipType.find(semanticIndex);

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -23,20 +23,8 @@
 namespace clang {
 namespace spirv {
 
-/// The class for representing special gl_PerVertex builtin interface block.
-/// The Position, PointSize, ClipDistance, and CullDistance builtin should
-/// be handled by this class, except for
-/// * Position builtin used in GS output and PS input,
-/// * PointSize builtin used in GS output.
-///
-/// Although the Vulkan spec does not require this directly, it seems the only
-/// way to avoid violating the spec is to group the Position, ClipDistance, and
-/// CullDistance builtins together into a struct. That's also how GLSL handles
-/// these builtins. In GLSL, this struct is called gl_PerVertex.
-///
-/// This struct should appear as the entry point parameters but it should not
-/// have location assignment. We can have two such blocks at most: one for
-/// input, one for output.
+/// The class for handling ClipDistance and CullDistance builtin variables that
+/// belong to gl_PerVertex.
 ///
 /// Reading/writing of the ClipDistance/CullDistance builtin is not as
 /// straightforward as other builtins. This is because in HLSL, we can have
@@ -57,19 +45,18 @@ namespace spirv {
 class GlPerVertex {
 public:
   GlPerVertex(const hlsl::ShaderModel &sm, ASTContext &context,
-              ModuleBuilder &builder, TypeTranslator &translator, bool negateY);
+              ModuleBuilder &builder, TypeTranslator &translator);
 
   /// Records a declaration of SV_ClipDistance/SV_CullDistance so later
   /// we can caculate the ClipDistance/CullDistance array layout.
-  /// Also records the semantic strings provided for the builtins in
-  /// gl_PerVertex.
+  /// Also records the semantic strings provided for them.
   bool recordGlPerVertexDeclFacts(const DeclaratorDecl *decl, bool asInput);
 
   /// Calculates the layout for ClipDistance/CullDistance arrays.
   void calculateClipCullDistanceArraySize();
 
-  /// Emits SPIR-V code for the input and/or ouput gl_PerVertex builtin
-  /// interface blocks. If inputArrayLength is not zero, the input gl_PerVertex
+  /// Emits SPIR-V code for the input and/or ouput ClipDistance/CullDistance
+  /// builtin variables. If inputArrayLength is not zero, the input variable
   /// will have an additional arrayness of the given size. Similarly for
   /// outputArrayLength.
   ///
@@ -78,9 +65,9 @@ public:
   void generateVars(uint32_t inputArrayLength, uint32_t outputArrayLength);
 
   /// Returns the <result-id>s for stage input variables.
-  llvm::SmallVector<uint32_t, 4> getStageInVars() const;
+  llvm::SmallVector<uint32_t, 2> getStageInVars() const;
   /// Returns the <result-id>s for stage output variables.
-  llvm::SmallVector<uint32_t, 4> getStageOutVars() const;
+  llvm::SmallVector<uint32_t, 2> getStageOutVars() const;
 
   /// Requires the ClipDistance/CullDistance capability if we've seen
   /// definition of SV_ClipDistance/SV_CullDistance.
@@ -98,16 +85,11 @@ public:
   /// accesses the element at the invocation offset in the gl_PerVeterx array.
   ///
   /// Emits SPIR-V instructions and returns true if we are accessing builtins
-  /// belonging to gl_PerVertex. Does nothing and returns true if we are
-  /// accessing builtins not in gl_PerVertex. Returns false if errors occurs.
+  /// that are ClipDistance or CullDistance. Does nothing and returns true if
+  /// accessing builtins for others. Returns false if errors occurs.
   bool tryToAccess(hlsl::SigPoint::Kind sigPoint, hlsl::Semantic::Kind,
                    uint32_t semanticIndex, llvm::Optional<uint32_t> invocation,
                    uint32_t *value, bool noWriteBack);
-
-  /// Similar to tryToAccess, but only used for the PointSize builtin.
-  bool tryToAccessPointSize(hlsl::SigPoint::Kind sigPoint,
-                            llvm::Optional<uint32_t> invocation,
-                            uint32_t *value, bool noWriteBack);
 
 private:
   template <unsigned N>
@@ -117,19 +99,10 @@ private:
     return astContext.getDiagnostics().Report(loc, diagId);
   }
 
-  /// Creates a gl_PerVertex interface block variable. If arraySize is not zero,
-  /// The created variable will be an array of gl_PerVertex of the given size.
-  /// Otherwise, it will just be a plain struct.
-  uint32_t createBlockVar(bool asInput, uint32_t arraySize);
-  /// Creates a stand-alone Position builtin variable.
-  uint32_t createPositionVar(bool asInput);
-  /// Creates a stand-alone ClipDistance builtin variable.
-  uint32_t createClipDistanceVar(bool asInput, uint32_t arraySize);
-  /// Creates a stand-alone CullDistance builtin variable.
-  uint32_t createCullDistanceVar(bool asInput, uint32_t arraySize);
+  /// Creates a stand-alone ClipDistance/CullDistance builtin variable.
+  uint32_t createClipCullDistanceVar(bool asInput, bool isClip,
+                                     uint32_t arraySize);
 
-  /// Emits SPIR-V instructions for reading the Position/PointSize builtin.
-  uint32_t readPositionOrPointSize(bool isPosition) const;
   /// Emits SPIR-V instructions for reading the data starting from offset in
   /// the ClipDistance/CullDistance builtin. The data read will be transformed
   /// into the given type asType.
@@ -139,10 +112,6 @@ private:
   bool readField(hlsl::Semantic::Kind semanticKind, uint32_t semanticIndex,
                  uint32_t *value);
 
-  /// Emits SPIR-V instructions for writing the Position/PointSize builtin.
-  void writePositionOrPointSize(bool isPosition,
-                                llvm::Optional<uint32_t> invocationId,
-                                uint32_t value);
   /// Emits SPIR-V instructions for writing data into the ClipDistance/
   /// CullDistance builtin starting from offset. The value to be written is
   /// fromValue, whose type is fromType. Necessary transformations will be
@@ -167,41 +136,14 @@ private:
   ModuleBuilder &theBuilder;
   TypeTranslator &typeTranslator;
 
-  /// Indicates whether to invert SV_Position.y to accommodate Vulkan's
-  /// coordinate system
-  bool invertY;
-
-  /// We can have Position, ClipDistance, and CullDistance either grouped (G)
-  /// into the gl_PerVertex struct, or separated (S) as stand-alone variables.
-  /// The following table shows for each shader stage, which one is used:
-  ///
-  /// ===== ===== ======
-  /// Stage Input Output
-  /// ===== ===== ======
-  ///  VS     X     G
-  ///  HS     G     G
-  ///  DS     G     G
-  ///  GS     G     S
-  ///  PS     S     X
-  /// ===== ===== ======
-  ///
-  /// Note that when we use separated variables, there is no extra arrayness.
-  ///
-  /// So depending on the shader stage, we may use one of the following set
-  /// of variables to store <result-id>s of the variables:
-
-  /// Indicates which set of variables are used.
-  bool inIsGrouped, outIsGrouped;
-  /// Input/output gl_PerVertex block variable if grouped.
-  uint32_t inBlockVar, outBlockVar;
-  /// Input/output ClipDistance/CullDistance variable if separated.
+  /// Input/output ClipDistance/CullDistance variable.
   uint32_t inClipVar, inCullVar;
   uint32_t outClipVar, outCullVar;
 
-  /// The array size for the input/output gl_PerVertex block variabe.
+  /// The array size for the input/output gl_PerVertex block member variables.
   /// HS input and output, DS input, GS input has an additional level of
   /// arrayness. The array size is stored in this variable. Zero means
-  /// the corresponding variable is a plain struct, not an array.
+  /// the corresponding variable does not need extra arrayness.
   uint32_t inArraySize, outArraySize;
   /// The array size of input/output ClipDistance/CullDistance float arrays.
   /// This is not the array size of the whole gl_PerVertex struct.
@@ -218,10 +160,12 @@ private:
   SemanticIndexToArrayOffsetMap inClipOffset, outClipOffset;
   SemanticIndexToArrayOffsetMap inCullOffset, outCullOffset;
 
+  enum { kSemanticStrCount = 2 };
+
   /// Keeps track of the semantic strings provided in the source code for the
   /// builtins in gl_PerVertex.
-  llvm::SmallVector<std::string, 4> inSemanticStrs;
-  llvm::SmallVector<std::string, 4> outSemanticStrs;
+  llvm::SmallVector<std::string, kSemanticStrCount> inSemanticStrs;
+  llvm::SmallVector<std::string, kSemanticStrCount> outSemanticStrs;
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -9244,8 +9244,8 @@ bool SPIRVEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   declIdMapper.glPerVertex.calculateClipCullDistanceArraySize();
 
   if (!shaderModel.IsCS()) {
-    // Generate the gl_PerVertex structs or stand-alone builtins of
-    // Position, ClipDistance, and CullDistance.
+    // Generate stand-alone builtins of Position, ClipDistance, and
+    // CullDistance, which belongs to gl_PerVertex.
     declIdMapper.glPerVertex.generateVars(inputArraySize, outputArraySize);
   }
 

--- a/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.domain.hlsl2spv
@@ -48,15 +48,12 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // CHECK-WHOLE-SPIR-V:
 // OpCapability Tessellation
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint TessellationEvaluation %BezierEvalDS "BezierEvalDS" %gl_PerVertexIn %gl_PerVertexOut %gl_TessLevelOuter %gl_TessLevelInner %in_var_TANGENT %in_var_TEXCOORD %in_var_TANUCORNER %in_var_TANVCORNER %in_var_TANWEIGHTS %gl_TessCoord %in_var_BEZIERPOS %out_var_NORMAL %out_var_TEXCOORD %out_var_TANGENT %out_var_BITANGENT
+// OpEntryPoint TessellationEvaluation %BezierEvalDS "BezierEvalDS" %gl_TessLevelOuter %gl_TessLevelInner %in_var_TANGENT %in_var_TEXCOORD %in_var_TANUCORNER %in_var_TANVCORNER %in_var_TANWEIGHTS %gl_TessCoord %in_var_BEZIERPOS %out_var_NORMAL %out_var_TEXCOORD %out_var_TANGENT %out_var_BITANGENT %gl_Position
 // OpExecutionMode %BezierEvalDS Quads
 // OpSource HLSL 600
 // OpName %bb_entry "bb.entry"
 // OpName %src_BezierEvalDS "src.BezierEvalDS"
 // OpName %BezierEvalDS "BezierEvalDS"
-// OpName %type_gl_PerVertex "type.gl_PerVertex"
-// OpName %gl_PerVertexIn "gl_PerVertexIn"
-// OpName %gl_PerVertexOut "gl_PerVertexOut"
 // OpName %HS_CONSTANT_DATA_OUTPUT "HS_CONSTANT_DATA_OUTPUT"
 // OpMemberName %HS_CONSTANT_DATA_OUTPUT 0 "Edges"
 // OpMemberName %HS_CONSTANT_DATA_OUTPUT 1 "Inside"
@@ -90,11 +87,6 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // OpName %UV "UV"
 // OpName %bezpatch "bezpatch"
 // OpName %Output "Output"
-// OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// OpDecorate %type_gl_PerVertex Block
 // OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
 // OpDecorate %gl_TessLevelOuter Patch
 // OpDecorate %gl_TessLevelInner BuiltIn TessLevelInner
@@ -106,6 +98,7 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // OpDecorate %in_var_TANWEIGHTS Patch
 // OpDecorate %gl_TessCoord BuiltIn TessCoord
 // OpDecorate %gl_TessCoord Patch
+// OpDecorate %gl_Position BuiltIn Position
 // OpDecorate %in_var_BEZIERPOS Location 0
 // OpDecorate %in_var_TANGENT Location 1
 // OpDecorate %in_var_TANUCORNER Location 5
@@ -119,15 +112,8 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
-// %v4float = OpTypeVector %float 4
 // %uint = OpTypeInt 32 0
-// %uint_1 = OpConstant %uint 1
-// %_arr_float_uint_1 = OpTypeArray %float %uint_1
-// %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
 // %uint_4 = OpConstant %uint 4
-// %_arr_type_gl_PerVertex_uint_4 = OpTypeArray %type_gl_PerVertex %uint_4
-// %_ptr_Input__arr_type_gl_PerVertex_uint_4 = OpTypePointer Input %_arr_type_gl_PerVertex_uint_4
-// %_ptr_Output_type_gl_PerVertex = OpTypePointer Output %type_gl_PerVertex
 // %_arr_float_uint_4 = OpTypeArray %float %uint_4
 // %uint_2 = OpConstant %uint 2
 // %_arr_float_uint_2 = OpTypeArray %float %uint_2
@@ -135,6 +121,7 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // %_arr_v3float_uint_4 = OpTypeArray %v3float %uint_4
 // %v2float = OpTypeVector %float 2
 // %_arr_v2float_uint_4 = OpTypeArray %v2float %uint_4
+// %v4float = OpTypeVector %float 4
 // %HS_CONSTANT_DATA_OUTPUT = OpTypeStruct %_arr_float_uint_4 %_arr_float_uint_2 %_arr_v3float_uint_4 %_arr_v2float_uint_4 %_arr_v3float_uint_4 %_arr_v3float_uint_4 %v4float
 // %_ptr_Function_HS_CONSTANT_DATA_OUTPUT = OpTypePointer Function %HS_CONSTANT_DATA_OUTPUT
 // %_ptr_Input__arr_float_uint_4 = OpTypePointer Input %_arr_float_uint_4
@@ -151,11 +138,8 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // %_ptr_Output_v3float = OpTypePointer Output %v3float
 // %_ptr_Output_v2float = OpTypePointer Output %v2float
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
-// %uint_0 = OpConstant %uint 0
-// %85 = OpTypeFunction %DS_OUTPUT %_ptr_Function_HS_CONSTANT_DATA_OUTPUT %_ptr_Function_v2float %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_4
+// %76 = OpTypeFunction %DS_OUTPUT %_ptr_Function_HS_CONSTANT_DATA_OUTPUT %_ptr_Function_v2float %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_4
 // %_ptr_Function_DS_OUTPUT = OpTypePointer Function %DS_OUTPUT
-// %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_4 Input
-// %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output
 // %gl_TessLevelOuter = OpVariable %_ptr_Input__arr_float_uint_4 Input
 // %gl_TessLevelInner = OpVariable %_ptr_Input__arr_float_uint_2 Input
 // %in_var_TANGENT = OpVariable %_ptr_Input__arr_v3float_uint_4 Input
@@ -169,54 +153,54 @@ DS_OUTPUT BezierEvalDS( HS_CONSTANT_DATA_OUTPUT input,
 // %out_var_TEXCOORD = OpVariable %_ptr_Output_v2float Output
 // %out_var_TANGENT = OpVariable %_ptr_Output_v3float Output
 // %out_var_BITANGENT = OpVariable %_ptr_Output_v3float Output
+// %gl_Position = OpVariable %_ptr_Output_v4float Output
 // %BezierEvalDS = OpFunction %void None %3
-// %17 = OpLabel
+// %5 = OpLabel
 // %param_var_input = OpVariable %_ptr_Function_HS_CONSTANT_DATA_OUTPUT Function
 // %param_var_UV = OpVariable %_ptr_Function_v2float Function
 // %param_var_bezpatch = OpVariable %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_4 Function
-// %30 = OpLoad %_arr_float_uint_4 %gl_TessLevelOuter
-// %33 = OpLoad %_arr_float_uint_2 %gl_TessLevelInner
-// %36 = OpLoad %_arr_v3float_uint_4 %in_var_TANGENT
-// %39 = OpLoad %_arr_v2float_uint_4 %in_var_TEXCOORD
-// %41 = OpLoad %_arr_v3float_uint_4 %in_var_TANUCORNER
-// %43 = OpLoad %_arr_v3float_uint_4 %in_var_TANVCORNER
-// %46 = OpLoad %v4float %in_var_TANWEIGHTS
-// %47 = OpCompositeConstruct %HS_CONSTANT_DATA_OUTPUT %30 %33 %36 %39 %41 %43 %46
-// OpStore %param_var_input %47
-// %52 = OpLoad %v3float %gl_TessCoord
-// %53 = OpVectorShuffle %v2float %52 %52 0 1
-// OpStore %param_var_UV %53
-// %59 = OpLoad %_arr_v3float_uint_4 %in_var_BEZIERPOS
-// %60 = OpCompositeExtract %v3float %59 0
-// %61 = OpCompositeConstruct %BEZIER_CONTROL_POINT %60
-// %62 = OpCompositeExtract %v3float %59 1
-// %63 = OpCompositeConstruct %BEZIER_CONTROL_POINT %62
-// %64 = OpCompositeExtract %v3float %59 2
-// %65 = OpCompositeConstruct %BEZIER_CONTROL_POINT %64
-// %66 = OpCompositeExtract %v3float %59 3
-// %67 = OpCompositeConstruct %BEZIER_CONTROL_POINT %66
-// %68 = OpCompositeConstruct %_arr_BEZIER_CONTROL_POINT_uint_4 %61 %63 %65 %67
-// OpStore %param_var_bezpatch %68
-// %70 = OpFunctionCall %DS_OUTPUT %src_BezierEvalDS %param_var_input %param_var_UV %param_var_bezpatch
-// %71 = OpCompositeExtract %v3float %70 0
-// OpStore %out_var_NORMAL %71
-// %74 = OpCompositeExtract %v2float %70 1
-// OpStore %out_var_TEXCOORD %74
-// %77 = OpCompositeExtract %v3float %70 2
-// OpStore %out_var_TANGENT %77
-// %79 = OpCompositeExtract %v3float %70 3
-// OpStore %out_var_BITANGENT %79
-// %81 = OpCompositeExtract %v4float %70 4
-// %84 = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
-// OpStore %84 %81
+// %22 = OpLoad %_arr_float_uint_4 %gl_TessLevelOuter
+// %25 = OpLoad %_arr_float_uint_2 %gl_TessLevelInner
+// %28 = OpLoad %_arr_v3float_uint_4 %in_var_TANGENT
+// %31 = OpLoad %_arr_v2float_uint_4 %in_var_TEXCOORD
+// %33 = OpLoad %_arr_v3float_uint_4 %in_var_TANUCORNER
+// %35 = OpLoad %_arr_v3float_uint_4 %in_var_TANVCORNER
+// %38 = OpLoad %v4float %in_var_TANWEIGHTS
+// %39 = OpCompositeConstruct %HS_CONSTANT_DATA_OUTPUT %22 %25 %28 %31 %33 %35 %38
+// OpStore %param_var_input %39
+// %44 = OpLoad %v3float %gl_TessCoord
+// %45 = OpVectorShuffle %v2float %44 %44 0 1
+// OpStore %param_var_UV %45
+// %51 = OpLoad %_arr_v3float_uint_4 %in_var_BEZIERPOS
+// %52 = OpCompositeExtract %v3float %51 0
+// %53 = OpCompositeConstruct %BEZIER_CONTROL_POINT %52
+// %54 = OpCompositeExtract %v3float %51 1
+// %55 = OpCompositeConstruct %BEZIER_CONTROL_POINT %54
+// %56 = OpCompositeExtract %v3float %51 2
+// %57 = OpCompositeConstruct %BEZIER_CONTROL_POINT %56
+// %58 = OpCompositeExtract %v3float %51 3
+// %59 = OpCompositeConstruct %BEZIER_CONTROL_POINT %58
+// %60 = OpCompositeConstruct %_arr_BEZIER_CONTROL_POINT_uint_4 %53 %55 %57 %59
+// OpStore %param_var_bezpatch %60
+// %62 = OpFunctionCall %DS_OUTPUT %src_BezierEvalDS %param_var_input %param_var_UV %param_var_bezpatch
+// %63 = OpCompositeExtract %v3float %62 0
+// OpStore %out_var_NORMAL %63
+// %66 = OpCompositeExtract %v2float %62 1
+// OpStore %out_var_TEXCOORD %66
+// %69 = OpCompositeExtract %v3float %62 2
+// OpStore %out_var_TANGENT %69
+// %71 = OpCompositeExtract %v3float %62 3
+// OpStore %out_var_BITANGENT %71
+// %73 = OpCompositeExtract %v4float %62 4
+// OpStore %gl_Position %73
 // OpReturn
 // OpFunctionEnd
-// %src_BezierEvalDS = OpFunction %DS_OUTPUT None %85
+// %src_BezierEvalDS = OpFunction %DS_OUTPUT None %76
 // %input = OpFunctionParameter %_ptr_Function_HS_CONSTANT_DATA_OUTPUT
 // %UV = OpFunctionParameter %_ptr_Function_v2float
 // %bezpatch = OpFunctionParameter %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_4
 // %bb_entry = OpLabel
 // %Output = OpVariable %_ptr_Function_DS_OUTPUT Function
-// %92 = OpLoad %DS_OUTPUT %Output
-// OpReturnValue %92
+// %83 = OpLoad %DS_OUTPUT %Output
+// OpReturnValue %83
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
@@ -59,7 +59,7 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // CHECK-WHOLE-SPIR-V:
 // OpCapability Tessellation
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint TessellationControl %SubDToBezierHS "SubDToBezierHS" %gl_PerVertexIn %gl_PerVertexOut %in_var_WORLDPOS %in_var_TEXCOORD0 %in_var_TANGENT %gl_InvocationID %gl_PrimitiveID %out_var_BEZIERPOS %gl_TessLevelOuter %gl_TessLevelInner %out_var_TANGENT %out_var_TEXCOORD %out_var_TANUCORNER %out_var_TANVCORNER %out_var_TANWEIGHTS
+// OpEntryPoint TessellationControl %SubDToBezierHS "SubDToBezierHS" %in_var_WORLDPOS %in_var_TEXCOORD0 %in_var_TANGENT %gl_InvocationID %gl_PrimitiveID %out_var_BEZIERPOS %gl_TessLevelOuter %gl_TessLevelInner %out_var_TANGENT %out_var_TEXCOORD %out_var_TANUCORNER %out_var_TANVCORNER %out_var_TANWEIGHTS
 // OpExecutionMode %SubDToBezierHS Quads
 // OpExecutionMode %SubDToBezierHS SpacingFractionalOdd
 // OpExecutionMode %SubDToBezierHS VertexOrderCcw
@@ -71,9 +71,6 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // OpName %bb_entry_0 "bb.entry"
 // OpName %src_SubDToBezierHS "src.SubDToBezierHS"
 // OpName %SubDToBezierHS "SubDToBezierHS"
-// OpName %type_gl_PerVertex "type.gl_PerVertex"
-// OpName %gl_PerVertexIn "gl_PerVertexIn"
-// OpName %gl_PerVertexOut "gl_PerVertexOut"
 // OpName %VS_CONTROL_POINT_OUTPUT "VS_CONTROL_POINT_OUTPUT"
 // OpMemberName %VS_CONTROL_POINT_OUTPUT 0 "vPosition"
 // OpMemberName %VS_CONTROL_POINT_OUTPUT 1 "vUV"
@@ -109,11 +106,6 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // OpName %PatchID_0 "PatchID"
 // OpName %vsOutput "vsOutput"
 // OpName %result "result"
-// OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// OpDecorate %type_gl_PerVertex Block
 // OpDecorate %gl_InvocationID BuiltIn InvocationId
 // OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
 // OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
@@ -137,18 +129,11 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
-// %v4float = OpTypeVector %float 4
-// %uint = OpTypeInt 32 0
-// %uint_1 = OpConstant %uint 1
-// %_arr_float_uint_1 = OpTypeArray %float %uint_1
-// %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
-// %uint_3 = OpConstant %uint 3
-// %_arr_type_gl_PerVertex_uint_3 = OpTypeArray %type_gl_PerVertex %uint_3
-// %_ptr_Input__arr_type_gl_PerVertex_uint_3 = OpTypePointer Input %_arr_type_gl_PerVertex_uint_3
-// %_ptr_Output__arr_type_gl_PerVertex_uint_3 = OpTypePointer Output %_arr_type_gl_PerVertex_uint_3
 // %v3float = OpTypeVector %float 3
 // %v2float = OpTypeVector %float 2
 // %VS_CONTROL_POINT_OUTPUT = OpTypeStruct %v3float %v2float %v3float
+// %uint = OpTypeInt 32 0
+// %uint_3 = OpConstant %uint 3
 // %_arr_VS_CONTROL_POINT_OUTPUT_uint_3 = OpTypeArray %VS_CONTROL_POINT_OUTPUT %uint_3
 // %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 = OpTypePointer Function %_arr_VS_CONTROL_POINT_OUTPUT_uint_3
 // %_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
@@ -168,13 +153,14 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %_arr_float_uint_2 = OpTypeArray %float %uint_2
 // %_arr_v3float_uint_4 = OpTypeArray %v3float %uint_4
 // %_arr_v2float_uint_4 = OpTypeArray %v2float %uint_4
+// %v4float = OpTypeVector %float 4
 // %HS_CONSTANT_DATA_OUTPUT = OpTypeStruct %_arr_float_uint_4 %_arr_float_uint_2 %_arr_v3float_uint_4 %_arr_v2float_uint_4 %_arr_v3float_uint_4 %_arr_v3float_uint_4 %v4float
 // %_ptr_Output__arr_float_uint_4 = OpTypePointer Output %_arr_float_uint_4
 // %_ptr_Output__arr_float_uint_2 = OpTypePointer Output %_arr_float_uint_2
 // %_ptr_Output__arr_v3float_uint_4 = OpTypePointer Output %_arr_v3float_uint_4
 // %_ptr_Output__arr_v2float_uint_4 = OpTypePointer Output %_arr_v2float_uint_4
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
-// %95 = OpTypeFunction %HS_CONSTANT_DATA_OUTPUT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint
+// %87 = OpTypeFunction %HS_CONSTANT_DATA_OUTPUT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint
 // %_ptr_Function_HS_CONSTANT_DATA_OUTPUT = OpTypePointer Function %HS_CONSTANT_DATA_OUTPUT
 // %float_1 = OpConstant %float 1
 // %int = OpTypeInt 32 1
@@ -188,12 +174,10 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %int_3 = OpConstant %int 3
 // %float_5 = OpConstant %float 5
 // %float_6 = OpConstant %float 6
-// %120 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
+// %112 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
 // %_ptr_Function_VS_CONTROL_POINT_OUTPUT = OpTypePointer Function %VS_CONTROL_POINT_OUTPUT
 // %_ptr_Function_BEZIER_CONTROL_POINT = OpTypePointer Function %BEZIER_CONTROL_POINT
 // %_ptr_Function_v3float = OpTypePointer Function %v3float
-// %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_3 Input
-// %gl_PerVertexOut = OpVariable %_ptr_Output__arr_type_gl_PerVertex_uint_3 Output
 // %in_var_WORLDPOS = OpVariable %_ptr_Input__arr_v3float_uint_3 Input
 // %in_var_TEXCOORD0 = OpVariable %_ptr_Input__arr_v2float_uint_3 Input
 // %in_var_TANGENT = OpVariable %_ptr_Input__arr_v3float_uint_3 Input
@@ -208,90 +192,90 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // %out_var_TANVCORNER = OpVariable %_ptr_Output__arr_v3float_uint_4 Output
 // %out_var_TANWEIGHTS = OpVariable %_ptr_Output_v4float Output
 // %SubDToBezierHS = OpFunction %void None %3
-// %17 = OpLabel
+// %5 = OpLabel
 // %param_var_ip = OpVariable %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 Function
 // %param_var_cpid = OpVariable %_ptr_Function_uint Function
 // %param_var_PatchID = OpVariable %_ptr_Function_uint Function
-// %27 = OpLoad %_arr_v3float_uint_3 %in_var_WORLDPOS
-// %31 = OpLoad %_arr_v2float_uint_3 %in_var_TEXCOORD0
-// %33 = OpLoad %_arr_v3float_uint_3 %in_var_TANGENT
-// %34 = OpCompositeExtract %v3float %27 0
-// %35 = OpCompositeExtract %v2float %31 0
-// %36 = OpCompositeExtract %v3float %33 0
-// %37 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %34 %35 %36
-// %38 = OpCompositeExtract %v3float %27 1
-// %39 = OpCompositeExtract %v2float %31 1
-// %40 = OpCompositeExtract %v3float %33 1
-// %41 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %38 %39 %40
-// %42 = OpCompositeExtract %v3float %27 2
-// %43 = OpCompositeExtract %v2float %31 2
-// %44 = OpCompositeExtract %v3float %33 2
-// %45 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %42 %43 %44
-// %46 = OpCompositeConstruct %_arr_VS_CONTROL_POINT_OUTPUT_uint_3 %37 %41 %45
-// OpStore %param_var_ip %46
-// %51 = OpLoad %uint %gl_InvocationID
-// OpStore %param_var_cpid %51
-// %54 = OpLoad %uint %gl_PrimitiveID
-// OpStore %param_var_PatchID %54
-// %56 = OpFunctionCall %BEZIER_CONTROL_POINT %src_SubDToBezierHS %param_var_ip %param_var_cpid %param_var_PatchID
-// %57 = OpCompositeExtract %v3float %56 0
-// %61 = OpAccessChain %_ptr_Output_v3float %out_var_BEZIERPOS %51
-// OpStore %61 %57
+// %18 = OpLoad %_arr_v3float_uint_3 %in_var_WORLDPOS
+// %22 = OpLoad %_arr_v2float_uint_3 %in_var_TEXCOORD0
+// %24 = OpLoad %_arr_v3float_uint_3 %in_var_TANGENT
+// %25 = OpCompositeExtract %v3float %18 0
+// %26 = OpCompositeExtract %v2float %22 0
+// %27 = OpCompositeExtract %v3float %24 0
+// %28 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %25 %26 %27
+// %29 = OpCompositeExtract %v3float %18 1
+// %30 = OpCompositeExtract %v2float %22 1
+// %31 = OpCompositeExtract %v3float %24 1
+// %32 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %29 %30 %31
+// %33 = OpCompositeExtract %v3float %18 2
+// %34 = OpCompositeExtract %v2float %22 2
+// %35 = OpCompositeExtract %v3float %24 2
+// %36 = OpCompositeConstruct %VS_CONTROL_POINT_OUTPUT %33 %34 %35
+// %37 = OpCompositeConstruct %_arr_VS_CONTROL_POINT_OUTPUT_uint_3 %28 %32 %36
+// OpStore %param_var_ip %37
+// %42 = OpLoad %uint %gl_InvocationID
+// OpStore %param_var_cpid %42
+// %45 = OpLoad %uint %gl_PrimitiveID
+// OpStore %param_var_PatchID %45
+// %47 = OpFunctionCall %BEZIER_CONTROL_POINT %src_SubDToBezierHS %param_var_ip %param_var_cpid %param_var_PatchID
+// %48 = OpCompositeExtract %v3float %47 0
+// %52 = OpAccessChain %_ptr_Output_v3float %out_var_BEZIERPOS %42
+// OpStore %52 %48
 // OpControlBarrier %uint_2 %uint_4 %uint_0
-// %66 = OpIEqual %bool %51 %uint_0
+// %57 = OpIEqual %bool %42 %uint_0
 // OpSelectionMerge %if_merge None
-// OpBranchConditional %66 %if_true %if_merge
+// OpBranchConditional %57 %if_true %if_merge
 // %if_true = OpLabel
-// %75 = OpFunctionCall %HS_CONSTANT_DATA_OUTPUT %SubDToBezierConstantsHS %param_var_ip %param_var_PatchID
-// %76 = OpCompositeExtract %_arr_float_uint_4 %75 0
-// OpStore %gl_TessLevelOuter %76
-// %79 = OpCompositeExtract %_arr_float_uint_2 %75 1
-// OpStore %gl_TessLevelInner %79
-// %82 = OpCompositeExtract %_arr_v3float_uint_4 %75 2
-// OpStore %out_var_TANGENT %82
-// %85 = OpCompositeExtract %_arr_v2float_uint_4 %75 3
-// OpStore %out_var_TEXCOORD %85
-// %88 = OpCompositeExtract %_arr_v3float_uint_4 %75 4
-// OpStore %out_var_TANUCORNER %88
-// %90 = OpCompositeExtract %_arr_v3float_uint_4 %75 5
-// OpStore %out_var_TANVCORNER %90
-// %92 = OpCompositeExtract %v4float %75 6
-// OpStore %out_var_TANWEIGHTS %92
+// %67 = OpFunctionCall %HS_CONSTANT_DATA_OUTPUT %SubDToBezierConstantsHS %param_var_ip %param_var_PatchID
+// %68 = OpCompositeExtract %_arr_float_uint_4 %67 0
+// OpStore %gl_TessLevelOuter %68
+// %71 = OpCompositeExtract %_arr_float_uint_2 %67 1
+// OpStore %gl_TessLevelInner %71
+// %74 = OpCompositeExtract %_arr_v3float_uint_4 %67 2
+// OpStore %out_var_TANGENT %74
+// %77 = OpCompositeExtract %_arr_v2float_uint_4 %67 3
+// OpStore %out_var_TEXCOORD %77
+// %80 = OpCompositeExtract %_arr_v3float_uint_4 %67 4
+// OpStore %out_var_TANUCORNER %80
+// %82 = OpCompositeExtract %_arr_v3float_uint_4 %67 5
+// OpStore %out_var_TANVCORNER %82
+// %84 = OpCompositeExtract %v4float %67 6
+// OpStore %out_var_TANWEIGHTS %84
 // OpBranch %if_merge
 // %if_merge = OpLabel
 // OpReturn
 // OpFunctionEnd
-// %SubDToBezierConstantsHS = OpFunction %HS_CONSTANT_DATA_OUTPUT None %95
+// %SubDToBezierConstantsHS = OpFunction %HS_CONSTANT_DATA_OUTPUT None %87
 // %ip = OpFunctionParameter %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3
 // %PatchID = OpFunctionParameter %_ptr_Function_uint
 // %bb_entry = OpLabel
 // %Output = OpVariable %_ptr_Function_HS_CONSTANT_DATA_OUTPUT Function
-// %105 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_0
-// OpStore %105 %float_1
-// %108 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_1
-// OpStore %108 %float_2
-// %111 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_2
-// OpStore %111 %float_3
-// %114 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_3
-// OpStore %114 %float_4
-// %116 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_0
-// OpStore %116 %float_5
-// %118 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_1
-// OpStore %118 %float_6
-// %119 = OpLoad %HS_CONSTANT_DATA_OUTPUT %Output
-// OpReturnValue %119
+// %97 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_0
+// OpStore %97 %float_1
+// %100 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_1
+// OpStore %100 %float_2
+// %103 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_2
+// OpStore %103 %float_3
+// %106 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_3
+// OpStore %106 %float_4
+// %108 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_0
+// OpStore %108 %float_5
+// %110 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_1
+// OpStore %110 %float_6
+// %111 = OpLoad %HS_CONSTANT_DATA_OUTPUT %Output
+// OpReturnValue %111
 // OpFunctionEnd
-// %src_SubDToBezierHS = OpFunction %BEZIER_CONTROL_POINT None %120
+// %src_SubDToBezierHS = OpFunction %BEZIER_CONTROL_POINT None %112
 // %ip_0 = OpFunctionParameter %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3
 // %cpid = OpFunctionParameter %_ptr_Function_uint
 // %PatchID_0 = OpFunctionParameter %_ptr_Function_uint
 // %bb_entry_0 = OpLabel
 // %vsOutput = OpVariable %_ptr_Function_VS_CONTROL_POINT_OUTPUT Function
 // %result = OpVariable %_ptr_Function_BEZIER_CONTROL_POINT Function
-// %130 = OpAccessChain %_ptr_Function_v3float %vsOutput %int_0
-// %131 = OpLoad %v3float %130
-// %132 = OpAccessChain %_ptr_Function_v3float %result %int_0
-// OpStore %132 %131
-// %133 = OpLoad %BEZIER_CONTROL_POINT %result
-// OpReturnValue %133
+// %122 = OpAccessChain %_ptr_Function_v3float %vsOutput %int_0
+// %123 = OpLoad %v3float %122
+// %124 = OpAccessChain %_ptr_Function_v3float %result %int_0
+// OpStore %124 %123
+// %125 = OpLoad %BEZIER_CONTROL_POINT %result
+// OpReturnValue %125
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/empty-struct-interface.vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/empty-struct-interface.vs.hlsl2spv
@@ -15,47 +15,32 @@ VSOut main(VSIn input)
 // CHECK-WHOLE-SPIR-V:
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint Vertex %main "main" %gl_PerVertexOut
+// OpEntryPoint Vertex %main "main"
 // OpSource HLSL 600
 // OpName %bb_entry "bb.entry"
 // OpName %src_main "src.main"
 // OpName %main "main"
-// OpName %type_gl_PerVertex "type.gl_PerVertex"
-// OpName %gl_PerVertexOut "gl_PerVertexOut"
 // OpName %VSIn "VSIn"
 // OpName %param_var_input "param.var.input"
 // OpName %input "input"
 // OpName %result "result"
-// OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// OpDecorate %type_gl_PerVertex Block
 // %void = OpTypeVoid
 // %3 = OpTypeFunction %void
-// %float = OpTypeFloat 32
-// %v4float = OpTypeVector %float 4
-// %uint = OpTypeInt 32 0
-// %uint_1 = OpConstant %uint 1
-// %_arr_float_uint_1 = OpTypeArray %float %uint_1
-// %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
-// %_ptr_Output_type_gl_PerVertex = OpTypePointer Output %type_gl_PerVertex
 // %VSIn = OpTypeStruct
 // %_ptr_Function_VSIn = OpTypePointer Function %VSIn
-// %19 = OpTypeFunction %VSIn %_ptr_Function_VSIn
-// %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output
+// %11 = OpTypeFunction %VSIn %_ptr_Function_VSIn
 // %main = OpFunction %void None %3
-// %13 = OpLabel
+// %5 = OpLabel
 // %param_var_input = OpVariable %_ptr_Function_VSIn Function
-// %17 = OpCompositeConstruct %VSIn
-// OpStore %param_var_input %17
-// %18 = OpFunctionCall %VSIn %src_main %param_var_input
+// %9 = OpCompositeConstruct %VSIn
+// OpStore %param_var_input %9
+// %10 = OpFunctionCall %VSIn %src_main %param_var_input
 // OpReturn
 // OpFunctionEnd
-// %src_main = OpFunction %VSIn None %19
+// %src_main = OpFunction %VSIn None %11
 // %input = OpFunctionParameter %_ptr_Function_VSIn
 // %bb_entry = OpLabel
 // %result = OpVariable %_ptr_Function_VSIn Function
-// %23 = OpLoad %VSIn %result
-// OpReturnValue %23
+// %15 = OpLoad %VSIn %result
+// OpReturnValue %15
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
@@ -13,7 +13,7 @@ float4 main() : C {
 // CHECK-NEXT:                OpImageWrite [[buf]] %uint_5 [[a]]
 // CHECK-NEXT:   [[b:%\d+]] = OpLoad %v3float %param_var_b
 // CHECK-NEXT: [[tex:%\d+]] = OpLoad %type_2d_image %MyRWTexture
-// CHECK-NEXT:                OpImageWrite [[tex]] %36 [[b]]
+// CHECK-NEXT:                OpImageWrite [[tex]] {{%\d+}} [[b]]
     foo(MyRWBuffer[5], MyRWTexture[uint2(6, 7)]);
 
     float4 val;

--- a/tools/clang/test/CodeGenSPIRV/gs.emit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/gs.emit.hlsl
@@ -28,7 +28,7 @@ void main(in    line float2 foo[2] : FOO,
 // Write back to stage output variables
 // CHECK-NEXT: [[vertex:%\d+]] = OpLoad %GsPerVertexOut %vertex
 // CHECK-NEXT:    [[pos:%\d+]] = OpCompositeExtract %v4float [[vertex]] 0
-// CHECK-NEXT:                   OpStore %gl_Position [[pos]]
+// CHECK-NEXT:                   OpStore %gl_Position_0 [[pos]]
 // CHECK-NEXT:    [[foo:%\d+]] = OpCompositeExtract %v3float [[vertex]] 1
 // CHECK-NEXT:                   OpStore %out_var_FOO [[foo]]
 // CHECK-NEXT:      [[s:%\d+]] = OpCompositeExtract %GsInnerOut [[vertex]] 2
@@ -41,7 +41,7 @@ void main(in    line float2 foo[2] : FOO,
 // Write back to stage output variables
 // CHECK-NEXT: [[vertex:%\d+]] = OpLoad %GsPerVertexOut %vertex
 // CHECK-NEXT:    [[pos:%\d+]] = OpCompositeExtract %v4float [[vertex]] 0
-// CHECK-NEXT:                   OpStore %gl_Position [[pos]]
+// CHECK-NEXT:                   OpStore %gl_Position_0 [[pos]]
 // CHECK-NEXT:    [[foo:%\d+]] = OpCompositeExtract %v3float [[vertex]] 1
 // CHECK-NEXT:                   OpStore %out_var_FOO [[foo]]
 // CHECK-NEXT:      [[s:%\d+]] = OpCompositeExtract %GsInnerOut [[vertex]] 2

--- a/tools/clang/test/CodeGenSPIRV/oo.inheritance.stage-io.gs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.inheritance.stage-io.gs.hlsl
@@ -19,11 +19,7 @@ struct Derived : Base {
 
 // CHECK-NEXT:     [[a_arr:%\d+]] = OpLoad %_arr_v4float_uint_2 %in_var_AAA
 
-// CHECK-NEXT:  [[pos0_ptr:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_0 %uint_0
-// CHECK-NEXT:      [[pos0:%\d+]] = OpLoad %v4float [[pos0_ptr]]
-// CHECK-NEXT:  [[pos1_ptr:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_1 %uint_0
-// CHECK-NEXT:      [[pos1:%\d+]] = OpLoad %v4float [[pos1_ptr]]
-// CHECK-NEXT:   [[pos_arr:%\d+]] = OpCompositeConstruct %_arr_v4float_uint_2 [[pos0]] [[pos1]]
+// CHECK-NEXT:   [[pos_arr:%\d+]] = OpLoad %_arr_v4float_uint_2 %gl_Position
 
 // CHECK-NEXT:    [[empty0:%\d+]] = OpCompositeExtract %Empty [[empty_arr]] 0
 // CHECK-NEXT:        [[a0:%\d+]] = OpCompositeExtract %v4float [[a_arr]] 0
@@ -66,7 +62,7 @@ void main(in    line Derived             inData[2],
 // CHECK-NEXT:                      OpStore %out_var_AAA [[a]]
 
 // CHECK-NEXT:       [[pos:%\d+]] = OpCompositeExtract %v4float [[base]] 2
-// CHECK-NEXT:                      OpStore %gl_Position [[pos]]
+// CHECK-NEXT:                      OpStore %gl_Position_0 [[pos]]
 
 // CHECK-NEXT:         [[b:%\d+]] = OpCompositeExtract %v4float [[inData0]] 1
 // CHECK-NEXT:                      OpStore %out_var_BBB [[b]]

--- a/tools/clang/test/CodeGenSPIRV/oo.inheritance.stage-io.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.inheritance.stage-io.vs.hlsl
@@ -56,8 +56,7 @@ void main(in Derived input, out Derived output) {
 // CHECK-NEXT:                 OpStore %out_var_MMM [[m]]
 
 // CHECK-NEXT:  [[pos:%\d+]] = OpCompositeExtract %v4float [[base]] 3
-// CHECK-NEXT:  [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
-// CHECK-NEXT:                 OpStore [[ptr]] [[pos]]
+// CHECK-NEXT:                 OpStore %gl_Position [[pos]]
 
 // CHECK-NEXT:    [[t:%\d+]] = OpCompositeExtract %T [[drv]] 1
 // CHECK-NEXT:    [[n:%\d+]] = OpCompositeExtract %v3float [[t]] 0

--- a/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/passthru-vs.hlsl2spv
@@ -1,11 +1,11 @@
-// Run: %dxc -T vs_6_0 -E VSmain
+// Run: %dxc -T vs_6_0 -E main
 
 struct PSInput {
   float4 position : SV_Position;
   float4 color : COLOR;
 };
 
-PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
+PSInput main(float4 position: POSITION, float4 color: COLOR) {
   PSInput result;
   result.position = position;
   result.color = color;
@@ -17,17 +17,15 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // ; SPIR-V
 // ; Version: 1.0
 // ; Generator: Google spiregg; 0
-// ; Bound: 44
+// ; Bound: 37
 // ; Schema: 0
 // OpCapability Shader
 // OpMemoryModel Logical GLSL450
-// OpEntryPoint Vertex %VSmain "VSmain" %gl_PerVertexOut %in_var_POSITION %in_var_COLOR %out_var_COLOR
+// OpEntryPoint Vertex %main "main" %in_var_POSITION %in_var_COLOR %gl_Position %out_var_COLOR
 // OpSource HLSL 600
 // OpName %bb_entry "bb.entry"
-// OpName %src_VSmain "src.VSmain"
-// OpName %VSmain "VSmain"
-// OpName %type_gl_PerVertex "type.gl_PerVertex"
-// OpName %gl_PerVertexOut "gl_PerVertexOut"
+// OpName %src_main "src.main"
+// OpName %main "main"
 // OpName %param_var_position "param.var.position"
 // OpName %in_var_POSITION "in.var.POSITION"
 // OpName %param_var_color "param.var.color"
@@ -39,11 +37,7 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // OpName %position "position"
 // OpName %color "color"
 // OpName %result "result"
-// OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// OpDecorate %type_gl_PerVertex Block
+// OpDecorate %gl_Position BuiltIn Position
 // OpDecorate %in_var_POSITION Location 0
 // OpDecorate %in_var_COLOR Location 1
 // OpDecorate %out_var_COLOR Location 0
@@ -51,52 +45,45 @@ PSInput VSmain(float4 position: POSITION, float4 color: COLOR) {
 // %3 = OpTypeFunction %void
 // %float = OpTypeFloat 32
 // %v4float = OpTypeVector %float 4
-// %uint = OpTypeInt 32 0
-// %uint_1 = OpConstant %uint 1
-// %_arr_float_uint_1 = OpTypeArray %float %uint_1
-// %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_1 %_arr_float_uint_1
-// %_ptr_Output_type_gl_PerVertex = OpTypePointer Output %type_gl_PerVertex
 // %_ptr_Function_v4float = OpTypePointer Function %v4float
 // %_ptr_Input_v4float = OpTypePointer Input %v4float
 // %PSInput = OpTypeStruct %v4float %v4float
 // %_ptr_Output_v4float = OpTypePointer Output %v4float
-// %uint_0 = OpConstant %uint 0
-// %30 = OpTypeFunction %PSInput %_ptr_Function_v4float %_ptr_Function_v4float
+// %23 = OpTypeFunction %PSInput %_ptr_Function_v4float %_ptr_Function_v4float
 // %_ptr_Function_PSInput = OpTypePointer Function %PSInput
 // %int = OpTypeInt 32 1
 // %int_0 = OpConstant %int 0
 // %int_1 = OpConstant %int 1
-// %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output
 // %in_var_POSITION = OpVariable %_ptr_Input_v4float Input
 // %in_var_COLOR = OpVariable %_ptr_Input_v4float Input
+// %gl_Position = OpVariable %_ptr_Output_v4float Output
 // %out_var_COLOR = OpVariable %_ptr_Output_v4float Output
-// %VSmain = OpFunction %void None %3
-// %13 = OpLabel
+// %main = OpFunction %void None %3
+// %5 = OpLabel
 // %param_var_position = OpVariable %_ptr_Function_v4float Function
 // %param_var_color = OpVariable %_ptr_Function_v4float Function
-// %18 = OpLoad %v4float %in_var_POSITION
-// OpStore %param_var_position %18
-// %21 = OpLoad %v4float %in_var_COLOR
-// OpStore %param_var_color %21
-// %23 = OpFunctionCall %PSInput %src_VSmain %param_var_position %param_var_color
-// %24 = OpCompositeExtract %v4float %23 0
-// %27 = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
-// OpStore %27 %24
-// %28 = OpCompositeExtract %v4float %23 1
-// OpStore %out_var_COLOR %28
+// %12 = OpLoad %v4float %in_var_POSITION
+// OpStore %param_var_position %12
+// %15 = OpLoad %v4float %in_var_COLOR
+// OpStore %param_var_color %15
+// %17 = OpFunctionCall %PSInput %src_main %param_var_position %param_var_color
+// %18 = OpCompositeExtract %v4float %17 0
+// OpStore %gl_Position %18
+// %21 = OpCompositeExtract %v4float %17 1
+// OpStore %out_var_COLOR %21
 // OpReturn
 // OpFunctionEnd
-// %src_VSmain = OpFunction %PSInput None %30
+// %src_main = OpFunction %PSInput None %23
 // %position = OpFunctionParameter %_ptr_Function_v4float
 // %color = OpFunctionParameter %_ptr_Function_v4float
 // %bb_entry = OpLabel
 // %result = OpVariable %_ptr_Function_PSInput Function
-// %36 = OpLoad %v4float %position
-// %39 = OpAccessChain %_ptr_Function_v4float %result %int_0
-// OpStore %39 %36
-// %40 = OpLoad %v4float %color
-// %42 = OpAccessChain %_ptr_Function_v4float %result %int_1
-// OpStore %42 %40
-// %43 = OpLoad %PSInput %result
-// OpReturnValue %43
+// %29 = OpLoad %v4float %position
+// %32 = OpAccessChain %_ptr_Function_v4float %result %int_0
+// OpStore %32 %29
+// %33 = OpLoad %v4float %color
+// %35 = OpAccessChain %_ptr_Function_v4float %result %int_1
+// OpStore %35 %33
+// %36 = OpLoad %PSInput %result
+// OpReturnValue %36
 // OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.arbitrary.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK: OpEntryPoint Vertex %main "main" %gl_PerVertexOut %in_var_AAA %in_var_B %in_var_CC %out_var_DDDD
+// CHECK: OpEntryPoint Vertex %main "main" %in_var_AAA %in_var_B %in_var_CC %out_var_DDDD
 
 // CHECK: OpDecorate %in_var_AAA Location 0
 // CHECK: OpDecorate %in_var_B Location 1

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ds.hlsl
@@ -58,40 +58,31 @@ struct DsOut {
   InnerPerVertexOut s;
 };
 
-// Per-vertex    input  builtin : gl_PerVertex (Position, ClipDistance, CullDistance)
-// Per-vertex    output builtin : gl_PerVertex (Position, ClipDistance, CullDistance)
+// Per-vertex    input  builtin : Position, PointSize, ClipDistance, CullDistance
+// Per-vertex    output builtin : Position, PointSize, ClipDistance, CullDistance
 // Per-vertex    input  variable: TEXCOORD, BAR
 // Per-vertex    output variable: FOO, BAR
 
 // Per-primitive input builtin  : TessLevelInner, TessLevelOuter, TessCoord (SV_DomainLocation)
 // Per-primitive input variable : FOO
 
-// CHECK: OpEntryPoint TessellationEvaluation %main "main" %gl_PerVertexIn %gl_PerVertexOut %in_var_TEXCOORD %in_var_BAR %gl_TessCoord %gl_TessLevelOuter %gl_TessLevelInner %in_var_FOO %out_var_FOO %out_var_BAR
+// CHECK: OpEntryPoint TessellationEvaluation %main "main" %gl_ClipDistance %gl_CullDistance %gl_ClipDistance_0 %gl_CullDistance_0 %gl_Position %in_var_TEXCOORD %in_var_BAR %gl_PointSize %gl_TessCoord %gl_TessLevelOuter %gl_TessLevelInner %in_var_FOO %gl_Position_0 %out_var_FOO %out_var_BAR %gl_PointSize_0
 
-// CHECK: OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// CHECK: OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// CHECK: OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// CHECK: OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// CHECK: OpDecorate %type_gl_PerVertex Block
+// CHECK: OpDecorate %gl_ClipDistance BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance HlslSemanticGOOGLE "SV_CullDistance"
+// CHECK: OpDecorate %gl_ClipDistance_0 BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance_0 HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance_0 BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance_0 HlslSemanticGOOGLE "SV_CullDistance"
 
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 0 HlslSemanticGOOGLE "SV_Position"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 1 HlslSemanticGOOGLE "PSIZE"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 2 HlslSemanticGOOGLE "SV_ClipDistance"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 3 HlslSemanticGOOGLE "SV_CullDistance"
-
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 0 BuiltIn Position
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 1 BuiltIn PointSize
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 2 BuiltIn ClipDistance
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 3 BuiltIn CullDistance
-// CHECK: OpDecorate %type_gl_PerVertex_0 Block
-
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 0 HlslSemanticGOOGLE "SV_Position"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 1 HlslSemanticGOOGLE "PSIZE"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 2 HlslSemanticGOOGLE "SV_ClipDistance"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 3 HlslSemanticGOOGLE "SV_CullDistance"
-
+// CHECK: OpDecorate %gl_Position BuiltIn Position
+// CHECK: OpDecorateStringGOOGLE %gl_Position HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %in_var_TEXCOORD HlslSemanticGOOGLE "TEXCOORD"
 // CHECK: OpDecorateStringGOOGLE %in_var_BAR HlslSemanticGOOGLE "BAR"
+// CHECK: OpDecorate %gl_PointSize BuiltIn PointSize
+// CHECK: OpDecorateStringGOOGLE %gl_PointSize HlslSemanticGOOGLE "PSIZE"
 // CHECK: OpDecorate %gl_TessCoord BuiltIn TessCoord
 // CHECK: OpDecorateStringGOOGLE %gl_TessCoord HlslSemanticGOOGLE "SV_DomainLocation"
 // CHECK: OpDecorate %gl_TessCoord Patch
@@ -103,8 +94,13 @@ struct DsOut {
 // CHECK: OpDecorate %gl_TessLevelInner Patch
 // CHECK: OpDecorateStringGOOGLE %in_var_FOO HlslSemanticGOOGLE "FOO"
 // CHECK: OpDecorate %in_var_FOO Patch
+
+// CHECK: OpDecorate %gl_Position_0 BuiltIn Position
+// CHECK: OpDecorateStringGOOGLE %gl_Position_0 HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %out_var_FOO HlslSemanticGOOGLE "FOO"
 // CHECK: OpDecorateStringGOOGLE %out_var_BAR HlslSemanticGOOGLE "BAR"
+// CHECK: OpDecorate %gl_PointSize_0 BuiltIn PointSize
+// CHECK: OpDecorateStringGOOGLE %gl_PointSize_0 HlslSemanticGOOGLE "PSIZE"
 // CHECK: OpDecorate %in_var_BAR Location 0
 // CHECK: OpDecorate %in_var_FOO Location 1
 // CHECK: OpDecorate %in_var_TEXCOORD Location 2
@@ -113,22 +109,28 @@ struct DsOut {
 
 // Input : clip0 + clip3 : 2 floats
 // Input : cull2 + cull3 : 6 floats
-// CHECK: %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_2 %_arr_float_uint_6
 
 // Output: clip0 + clip5 : 4 floats
 // Output: cull3 + cull4 : 4 floats
-// CHECK: %type_gl_PerVertex_0 = OpTypeStruct %v4float %float %_arr_float_uint_4 %_arr_float_uint_4
 
-// CHECK:    %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_3 Input
-// CHECK:   %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex_0 Output
+// CHECK:   %gl_ClipDistance = OpVariable %_ptr_Input__arr__arr_float_uint_2_uint_3 Input
+// CHECK:   %gl_CullDistance = OpVariable %_ptr_Input__arr__arr_float_uint_6_uint_3 Input
+// CHECK: %gl_ClipDistance_0 = OpVariable %_ptr_Output__arr_float_uint_4 Output
+// CHECK: %gl_CullDistance_0 = OpVariable %_ptr_Output__arr_float_uint_4 Output
+
+// CHECK:       %gl_Position = OpVariable %_ptr_Input__arr_v4float_uint_3 Input
 // CHECK:   %in_var_TEXCOORD = OpVariable %_ptr_Input__arr_v4float_uint_3 Input
 // CHECK:        %in_var_BAR = OpVariable %_ptr_Input__arr_v2float_uint_3 Input
+// CHECK:      %gl_PointSize = OpVariable %_ptr_Input__arr_float_uint_3 Input
 // CHECK:      %gl_TessCoord = OpVariable %_ptr_Input_v3float Input
 // CHECK: %gl_TessLevelOuter = OpVariable %_ptr_Input__arr_float_uint_4 Input
 // CHECK: %gl_TessLevelInner = OpVariable %_ptr_Input__arr_float_uint_2 Input
 // CHECK:        %in_var_FOO = OpVariable %_ptr_Input_v3float Input
+
+// CHECK:     %gl_Position_0 = OpVariable %_ptr_Output_v4float Output
 // CHECK:       %out_var_FOO = OpVariable %_ptr_Output_v3float Output
 // CHECK:       %out_var_BAR = OpVariable %_ptr_Output_v4float Output
+// CHECK:    %gl_PointSize_0 = OpVariable %_ptr_Output_float Output
 
 [domain("quad")]
 DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
@@ -155,82 +157,70 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 //   cull3: 2 floats, offset 0
 //   cull4: 2 floats, offset 2
 
-// Read gl_PerVertex[0].gl_ClipDistance and compose patch[0].cull3 (SV_CullDistance3)
-// CHECK:              [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_2
+// Read gl_CullDistance[0] and compose patch[0].cull3 (SV_CullDistance3)
+// CHECK:              [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_2
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_3
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_3
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_4
+// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_4
 // CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
-// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_5
+// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_5
 // CHECK-NEXT:         [[val3:%\d+]] = OpLoad %float [[ptr3]]
 // CHECK-NEXT:  [[patch0cull3:%\d+]] = OpCompositeConstruct %v4float [[val0]] [[val1]] [[val2]] [[val3]]
 
-// Read gl_PerVertex[1].gl_ClipDistance and compose patch[1].cull3 (SV_CullDistance3)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_2
+// Read gl_CullDistance[1] and compose patch[1].cull3 (SV_CullDistance3)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_2
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_3
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_3
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_4
+// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_4
 // CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
-// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_5
+// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_5
 // CHECK-NEXT:         [[val3:%\d+]] = OpLoad %float [[ptr3]]
 // CHECK-NEXT:  [[patch1cull3:%\d+]] = OpCompositeConstruct %v4float [[val0]] [[val1]] [[val2]] [[val3]]
 
-// Read gl_PerVertex[2].gl_ClipDistance and compose patch[2].cull3 (SV_CullDistance3)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_2
+// Read gl_CullDistance[2] and compose patch[2].cull3 (SV_CullDistance3)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_2
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_3
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_3
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_4
+// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_4
 // CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
-// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_5
+// CHECK-NEXT:         [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_5
 // CHECK-NEXT:         [[val3:%\d+]] = OpLoad %float [[ptr3]]
 // CHECK-NEXT:  [[patch2cull3:%\d+]] = OpCompositeConstruct %v4float [[val0]] [[val1]] [[val2]] [[val3]]
 
 // Compose an array of input SV_CullDistance3 for later use
 // CHECK-NEXT:   [[inCull3Arr:%\d+]] = OpCompositeConstruct %_arr_v4float_uint_3 [[patch0cull3]] [[patch1cull3]] [[patch2cull3]]
 
-// Read gl_PerVertex[0].gl_Position as patch[0].s.pos (SV_Position)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_0 %uint_0
-// CHECK-NEXT:         [[val0:%\d+]] = OpLoad %v4float [[ptr0]]
+// Read gl_Position
+// CHECK-NEXT:     [[inPosArr:%\d+]] = OpLoad %_arr_v4float_uint_3 %gl_Position
 
-// Read gl_PerVertex[1].gl_Position as patch[1].s.pos (SV_Position)
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_1 %uint_0
-// CHECK-NEXT:         [[val1:%\d+]] = OpLoad %v4float [[ptr1]]
-
-// Read gl_PerVertex[2].gl_Position as patch[2].s.pos (SV_Position)
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_2 %uint_0
-// CHECK-NEXT:         [[val2:%\d+]] = OpLoad %v4float [[ptr2]]
-
-// Compose an array of input SV_Position for later use
-// CHECK-NEXT:     [[inPosArr:%\d+]] = OpCompositeConstruct %_arr_v4float_uint_3 [[val0]] [[val1]] [[val2]]
-
-// Read gl_PerVertex[0].gl_ClipDistance as patch[0].s.clip0 (SV_ClipDistance0)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_2 %uint_0
+// Read gl_ClipDistance[0] as patch[0].s.clip0 (SV_ClipDistance0)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0 %uint_0
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
 
-// Read gl_PerVertex[1].gl_ClipDistance as patch[1].s.clip0 (SV_ClipDistance0)
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_2 %uint_0
+// Read gl_ClipDistance[1] as patch[1].s.clip0 (SV_ClipDistance0)
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1 %uint_0
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
 
-// Read gl_PerVertex[2].gl_ClipDistance as patch[2].s.clip0 (SV_ClipDistance0)
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_2 %uint_0
+// Read gl_ClipDistance[2] as patch[2].s.clip0 (SV_ClipDistance0)
+// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_2 %uint_0
 // CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
 
 // Compose an array of input SV_ClipDistance0 for later use
 // CHECK-NEXT:   [[inClip0Arr:%\d+]] = OpCompositeConstruct %_arr_float_uint_3 [[val0]] [[val1]] [[val2]]
 
-// Read gl_PerVertex[0].gl_ClipDistance as patch[0].s.s.clip3 (SV_ClipDistance3)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_2 %uint_1
+// Read gl_ClipDistance[0] as patch[0].s.s.clip3 (SV_ClipDistance3)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0 %uint_1
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
 
-// Read gl_PerVertex[1].gl_ClipDistance as patch[1].s.s.clip3 (SV_ClipDistance3)
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_2 %uint_1
+// Read gl_ClipDistance[1] as patch[1].s.s.clip3 (SV_ClipDistance3)
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1 %uint_1
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
 
-// Read gl_PerVertex[2].gl_ClipDistance as patch[2].s.s.clip3 (SV_ClipDistance3)
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_2 %uint_1
+// Read gl_ClipDistance[2] as patch[2].s.s.clip3 (SV_ClipDistance3)
+// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_2 %uint_1
 // CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
 
 // Compose an array of input SV_ClipDistance3 for later use
@@ -255,24 +245,24 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 // Compose an array of input Inner2PerVertexIn for later use
 // CHECK-NEXT:   [[inIn2PVArr:%\d+]] = OpCompositeConstruct %_arr_Inner2PerVertexIn_uint_3 [[val0]] [[val1]] [[val2]]
 
-// Read gl_PerVertex[0].gl_CullDistance as patch[0].s.cull2 (SV_CullDistance2)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_0
+// Read gl_CullDistance[0] as patch[0].s.cull2 (SV_CullDistance2)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_0
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_1
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_1
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT:  [[patch0cull2:%\d+]] = OpCompositeConstruct %v2float [[val0]] [[val1]]
 
-// Read gl_PerVertex[1].gl_CullDistance as patch[1].s.cull2 (SV_CullDistance2)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_0
+// Read gl_CullDistance[1] as patch[1].s.cull2 (SV_CullDistance2)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_0
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_1
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_1
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT:  [[patch1cull2:%\d+]] = OpCompositeConstruct %v2float [[val0]] [[val1]]
 
-// Read gl_PerVertex[2].gl_CullDistance as patch[2].s.cull2 (SV_CullDistance2)
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_0
+// Read gl_CullDistance[2] as patch[2].s.cull2 (SV_CullDistance2)
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_0
 // CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_3 %uint_1
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_2 %uint_1
 // CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT:  [[patch2cull2:%\d+]] = OpCompositeConstruct %v2float [[val0]] [[val1]]
 
@@ -304,14 +294,8 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 
 // CHECK-NEXT:     [[inBarArr:%\d+]] = OpLoad %_arr_v2float_uint_3 %in_var_BAR
 
-// Compose an array of input PointSize for later use
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_1
-// CHECK-NEXT:         [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_1
-// CHECK-NEXT:         [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:         [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_2 %uint_1
-// CHECK-NEXT:         [[val2:%\d+]] = OpLoad %float [[ptr2]]
-// CHECK-NEXT:  [[inPtSizeArr:%\d+]] = OpCompositeConstruct %_arr_float_uint_3 [[val0]] [[val1]] [[val2]]
+// Read gl_PointSize
+// CHECK-NEXT:  [[inPtSizeArr:%\d+]] = OpLoad %_arr_float_uint_3 %gl_PointSize
 
 // Decompose temporary arrays created before to compose PerVertexIn
 
@@ -354,8 +338,7 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 
 // Decompose DsOut and write out output SV_Position
 // CHECK-NEXT:       [[outPos:%\d+]] = OpCompositeExtract %v4float [[ret]] 0
-// CHECK-NEXT:          [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
-// CHECK-NEXT:                         OpStore [[ptr]] [[outPos]]
+// CHECK-NEXT:                         OpStore %gl_Position_0 [[outPos]]
 
 // CHECK-NEXT:      [[outInPV:%\d+]] = OpCompositeExtract %InnerPerVertexOut [[ret]] 1
 // CHECK-NEXT:     [[outIn2PV:%\d+]] = OpCompositeExtract %Inner2PerVertexOut [[outInPV]] 0
@@ -366,24 +349,24 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 
 // Decompose Inner2PerVertexOut and write out DsOut.s.s.cull3 (SV_CullDistance3) at offset 0
 // CHECK-NEXT:        [[cull3:%\d+]] = OpCompositeExtract %v2float [[outIn2PV]] 1
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_0
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_0
 // CHECK-NEXT:         [[val0:%\d+]] = OpCompositeExtract %float [[cull3]] 0
 // CHECK-NEXT:                         OpStore [[ptr0]] [[val0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_1
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_1
 // CHECK-NEXT:         [[val1:%\d+]] = OpCompositeExtract %float [[cull3]] 1
 // CHECK-NEXT:                         OpStore [[ptr1]] [[val1]]
 
 // Decompose Inner2PerVertexOut and write out DsOut.s.s.clip0 (SV_ClipDistance0) at offset 0
 // CHECK-NEXT:        [[clip0:%\d+]] = OpCompositeExtract %float [[outIn2PV]] 2
-// CHECK-NEXT:          [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_0
+// CHECK-NEXT:          [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_0
 // CHECK-NEXT:                         OpStore [[ptr]] [[clip0]]
 
 // Decompose InnerPerVertexOut and write out DsOut.s.cull4 (SV_CullDistance4) at offset 2
 // CHECK-NEXT:        [[cull4:%\d+]] = OpCompositeExtract %v2float [[outInPV]] 1
-// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_2
+// CHECK-NEXT:         [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_2
 // CHECK-NEXT:         [[val0:%\d+]] = OpCompositeExtract %float [[cull4]] 0
 // CHECK-NEXT:                         OpStore [[ptr0]] [[val0]]
-// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_3
+// CHECK-NEXT:         [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_3
 // CHECK-NEXT:         [[val1:%\d+]] = OpCompositeExtract %float [[cull4]] 1
 // CHECK-NEXT:                         OpStore [[ptr1]] [[val1]]
 
@@ -393,18 +376,17 @@ DsOut main(    const OutputPatch<PerVertexIn, 3> patch,
 
 // Decompose InnerPerVertexOut and write out DsOut.s.ptSize (PointSize)
 // CHECK-NEXT:       [[ptSize:%\d+]] = OpCompositeExtract %float [[outInPV]] 3
-// CHECK-NEXT:          [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_1
-// CHECK-NEXT:                         OpStore [[ptr]] [[ptSize]]
+// CHECK-NEXT:                         OpStore %gl_PointSize_0 [[ptSize]]
 
 // Write out clip5 (SV_ClipDistance5) at offset 1
 // CHECK-NEXT: [[clip5:%\d+]] = OpLoad %v3float %param_var_clip5
-// CHECK-NEXT:  [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_1
+// CHECK-NEXT:  [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_1
 // CHECK-NEXT:  [[val0:%\d+]] = OpCompositeExtract %float [[clip5]] 0
 // CHECK-NEXT:                  OpStore [[ptr0]] [[val0]]
-// CHECK-NEXT:  [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_2
+// CHECK-NEXT:  [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_2
 // CHECK-NEXT:  [[val1:%\d+]] = OpCompositeExtract %float [[clip5]] 1
 // CHECK-NEXT:                  OpStore [[ptr1]] [[val1]]
-// CHECK-NEXT:  [[ptr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_3
+// CHECK-NEXT:  [[ptr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_3
 // CHECK-NEXT:  [[val2:%\d+]] = OpCompositeExtract %float [[clip5]] 2
 // CHECK-NEXT:                  OpStore [[ptr2]] [[val2]]
 }

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.hs.hlsl
@@ -57,8 +57,8 @@ struct HsPcfOut
   float4 weight      : WEIGHT;
 };
 
-// Per-vertex    input  builtin : gl_PerVertex (Position, ClipDistance, CullDistance), InvocationID
-// Per-vertex    output builtin : gl_PerVertex (Position, ClipDistance, CullDistance)
+// Per-vertex    input  builtin : Position, PointSize, ClipDistance, CullDistance, InvocationID
+// Per-vertex    output builtin : Position, PointSize, ClipDistance, CullDistance
 // Per-vertex    input  variable: BAZ
 // Per-vertex    output variable: FOO, BAR
 
@@ -66,36 +66,32 @@ struct HsPcfOut
 // Per-primitive output builtin : TessLevelInner, TessLevelOuter
 // Per-primitive output variable: TEXCOORD, WEIGHT
 
-// CHECK: OpEntryPoint TessellationControl %main "main" %gl_PerVertexIn %gl_PerVertexOut %in_var_BAZ %gl_InvocationID %gl_PrimitiveID %out_var_FOO %out_var_BAR %gl_TessLevelOuter %gl_TessLevelInner %out_var_TEXCOORD %out_var_WEIGHT
+// CHECK: OpEntryPoint TessellationControl %main "main" %gl_ClipDistance %gl_CullDistance %gl_ClipDistance_0 %gl_CullDistance_0 %gl_Position %in_var_BAZ %gl_PointSize %gl_InvocationID %gl_PrimitiveID %gl_Position_0 %out_var_FOO %gl_PointSize_0 %out_var_BAR %gl_TessLevelOuter %gl_TessLevelInner %out_var_TEXCOORD %out_var_WEIGHT
 
-// CHECK: OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// CHECK: OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// CHECK: OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// CHECK: OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// CHECK: OpDecorate %type_gl_PerVertex Block
+// CHECK: OpDecorate %gl_ClipDistance BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance HlslSemanticGOOGLE "SV_CullDistance"
+// CHECK: OpDecorate %gl_ClipDistance_0 BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance_0 HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance_0 BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance_0 HlslSemanticGOOGLE "SV_CullDistance"
 
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 0 HlslSemanticGOOGLE "SV_Position"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 1 HlslSemanticGOOGLE "PSIZE"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 2 HlslSemanticGOOGLE "SV_ClipDistance"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 3 HlslSemanticGOOGLE "SV_CullDistance"
-
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 0 BuiltIn Position
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 1 BuiltIn PointSize
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 2 BuiltIn ClipDistance
-// CHECK: OpMemberDecorate %type_gl_PerVertex_0 3 BuiltIn CullDistance
-// CHECK: OpDecorate %type_gl_PerVertex_0 Block
-
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 0 HlslSemanticGOOGLE "SV_Position"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 1 HlslSemanticGOOGLE "PSIZE"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 2 HlslSemanticGOOGLE "SV_ClipDistance"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex_0 3 HlslSemanticGOOGLE "SV_CullDistance"
-
+// CHECK: OpDecorate %gl_Position BuiltIn Position
+// CHECK: OpDecorateStringGOOGLE %gl_Position HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %in_var_BAZ HlslSemanticGOOGLE "BAZ"
+// CHECK: OpDecorate %gl_PointSize BuiltIn PointSize
+// CHECK: OpDecorateStringGOOGLE %gl_PointSize HlslSemanticGOOGLE "PSIZE"
 // CHECK: OpDecorate %gl_InvocationID BuiltIn InvocationId
 // CHECK: OpDecorateStringGOOGLE %gl_InvocationID HlslSemanticGOOGLE "SV_OutputControlPointID"
 // CHECK: OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
 // CHECK: OpDecorateStringGOOGLE %gl_PrimitiveID HlslSemanticGOOGLE "SV_PrimitiveID"
+
+// CHECK: OpDecorate %gl_Position_0 BuiltIn Position
+// CHECK: OpDecorateStringGOOGLE %gl_Position_0 HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %out_var_FOO HlslSemanticGOOGLE "FOO"
+// CHECK: OpDecorate %gl_PointSize_0 BuiltIn PointSize
+// CHECK: OpDecorateStringGOOGLE %gl_PointSize_0 HlslSemanticGOOGLE "PSIZE"
 // CHECK: OpDecorateStringGOOGLE %out_var_BAR HlslSemanticGOOGLE "BAR"
 // CHECK: OpDecorate %gl_TessLevelOuter BuiltIn TessLevelOuter
 // CHECK: OpDecorateStringGOOGLE %gl_TessLevelOuter HlslSemanticGOOGLE "SV_TessFactor"
@@ -115,19 +111,24 @@ struct HsPcfOut
 
 // Input : clip0 + clip2         : 3 floats
 // Input : cull3 + cull5         : 4 floats
-// CHECK:   %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_3 %_arr_float_uint_4
 
 // Output: clip6 + clip7 + clip8 : 3 floats
 // Output: cull6 + cull9         : 5 floats
-// CHECK: %type_gl_PerVertex_0 = OpTypeStruct %v4float %float %_arr_float_uint_3 %_arr_float_uint_5
 
-// CHECK:    %gl_PerVertexIn = OpVariable %_ptr_Input__arr_type_gl_PerVertex_uint_2 Input
-// CHECK:   %gl_PerVertexOut = OpVariable %_ptr_Output__arr_type_gl_PerVertex_0_uint_2 Output
+// CHECK:   %gl_ClipDistance = OpVariable %_ptr_Input__arr__arr_float_uint_3_uint_2 Input
+// CHECK:   %gl_CullDistance = OpVariable %_ptr_Input__arr__arr_float_uint_4_uint_2 Input
+// CHECK: %gl_ClipDistance_0 = OpVariable %_ptr_Output__arr__arr_float_uint_3_uint_2 Output
+// CHECK: %gl_CullDistance_0 = OpVariable %_ptr_Output__arr__arr_float_uint_5_uint_2 Output
 
+// CHECK:       %gl_Position = OpVariable %_ptr_Input__arr_v4float_uint_2 Input
 // CHECK:        %in_var_BAZ = OpVariable %_ptr_Input__arr_v3float_uint_2 Input
+// CHECK:      %gl_PointSize = OpVariable %_ptr_Input__arr_float_uint_2 Input
 // CHECK:   %gl_InvocationID = OpVariable %_ptr_Input_uint Input
 // CHECK:    %gl_PrimitiveID = OpVariable %_ptr_Input_uint Input
+
+// CHECK:     %gl_Position_0 = OpVariable %_ptr_Output__arr_v4float_uint_2 Output
 // CHECK:       %out_var_FOO = OpVariable %_ptr_Output__arr_v3float_uint_2 Output
+// CHECK:    %gl_PointSize_0 = OpVariable %_ptr_Output__arr_float_uint_2 Output
 // CHECK:       %out_var_BAR = OpVariable %_ptr_Output__arr_v4float_uint_2 Output
 // CHECK: %gl_TessLevelOuter = OpVariable %_ptr_Output__arr_float_uint_4 Output
 // CHECK: %gl_TessLevelInner = OpVariable %_ptr_Output__arr_float_uint_2 Output
@@ -168,61 +169,57 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
     output = (HsCpOut)0;
     return output;
 
-// Read gl_PerVertex[].gl_Postion and compose a new array for HsCpIn::pos
+// Read gl_Postion for HsCpIn::pos
 
-// CHECK:           [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_0 %uint_0
-// CHECK-NEXT:      [[val0:%\d+]] = OpLoad %v4float [[ptr0]]
-// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_v4float %gl_PerVertexIn %uint_1 %uint_0
-// CHECK-NEXT:      [[val1:%\d+]] = OpLoad %v4float [[ptr1]]
-// CHECK-NEXT:  [[inPosArr:%\d+]] = OpCompositeConstruct %_arr_v4float_uint_2 [[val0]] [[val1]]
+// CHECK:       [[inPosArr:%\d+]] = OpLoad %_arr_v4float_uint_2 %gl_Position
 
-// Read gl_PerVertex[].gl_ClipDistance[] to compose a new array for HsCpIn::clip0
+// Read gl_ClipDistance[] to compose a new array for HsCpIn::clip0
 
-// CHECK-NEXT:      [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_2 %uint_0
+// CHECK-NEXT:      [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0 %uint_0
 // CHECK-NEXT:      [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_2 %uint_1
+// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0 %uint_1
 // CHECK-NEXT:      [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT:    [[clip00:%\d+]] = OpCompositeConstruct %v2float [[val0]] [[val1]]
 
-// CHECK-NEXT:      [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_2 %uint_0
+// CHECK-NEXT:      [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1 %uint_0
 // CHECK-NEXT:      [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_2 %uint_1
+// CHECK-NEXT:      [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1 %uint_1
 // CHECK-NEXT:      [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT:    [[clip01:%\d+]] = OpCompositeConstruct %v2float [[val0]] [[val1]]
 
 // CHECK-NEXT: [[inClip0Arr:%\d+]] = OpCompositeConstruct %_arr_v2float_uint_2 [[clip00]] [[clip01]]
 
-// Read gl_PerVertex[].gl_CullDistance[] to compose a new array for HsCpIn::cull5
+// Read gl_CullDistance[] to compose a new array for HsCpIn::cull5
 
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_3
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_3
 // CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_3
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_3
 // CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT: [[inCull5Arr:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 [[val0]] [[val1]]
 
-// Read gl_PerVertex[].gl_ClipDistance[] to compose a new array for HsCpIn::clip2
+// Read gl_ClipDistance[] to compose a new array for HsCpIn::clip2
 
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_2 %uint_2
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0 %uint_2
 // CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_2 %uint_2
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1 %uint_2
 // CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
 // CHECK-NEXT: [[inClip2Arr:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 [[val0]] [[val1]]
 
-// Read gl_PerVertex[].gl_CullDistance[] to compose a new array for HsCpIn::cull3
+// Read gl_CullDistance[] to compose a new array for HsCpIn::cull3
 
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_0
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_0
 // CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_1
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_1
 // CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_3 %uint_2
+// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_0 %uint_2
 // CHECK-NEXT:       [[val2:%\d+]] = OpLoad %float [[ptr2]]
 // CHECK-NEXT:     [[cull30:%\d+]] = OpCompositeConstruct %v3float [[val0]] [[val1]] [[val2]]
 
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_0
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_0
 // CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_1
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_1
 // CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_3 %uint_2
+// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_CullDistance %uint_1 %uint_2
 // CHECK-NEXT:       [[val2:%\d+]] = OpLoad %float [[ptr2]]
 // CHECK-NEXT:     [[cull31:%\d+]] = OpCompositeConstruct %v3float [[val0]] [[val1]] [[val2]]
 
@@ -230,12 +227,8 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 
 // CHECK-NEXT:   [[inBazArr:%\d+]] = OpLoad %_arr_v3float_uint_2 %in_var_BAZ
 
-// Read gl_PerVertex[].gl_PointSize[] to compose a new array for HsCpIn::ptSize
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_0 %uint_1
-// CHECK-NEXT:       [[val0:%\d+]] = OpLoad %float [[ptr0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_PerVertexIn %uint_1 %uint_1
-// CHECK-NEXT:       [[val1:%\d+]] = OpLoad %float [[ptr1]]
-// CHECK-NEXT:  [[inPtSzArr:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 [[val0]] [[val1]]
+// Read gl_PointSize[] for HsCpIn::ptSize
+// CHECK-NEXT:  [[inPtSzArr:%\d+]] = OpLoad %_arr_float_uint_2 %gl_PointSize
 
 // Compose a temporary HsCpIn value out of the temporary arrays constructed before
 // CHECK-NEXT:       [[val0:%\d+]] = OpCompositeExtract %v4float [[inPosArr]] 0
@@ -270,37 +263,37 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 
 // CHECK-NEXT:        [[ret:%\d+]] = OpFunctionCall %HsCpOut %src_main %param_var_patch %param_var_cpId %param_var_patchId
 
-// Write out HsCpOut::cull9 into gl_PerVertex[].gl_CullDistance[]
+// Write out HsCpOut::cull9 into gl_CullDistance[]
 // CHECK-NEXT:      [[cull9:%\d+]] = OpCompositeExtract %v3float [[ret]] 0
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_3 %uint_2
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 [[invoId]] %uint_2
 // CHECK-NEXT:       [[val0:%\d+]] = OpCompositeExtract %float [[cull9]] 0
 // CHECK-NEXT:                       OpStore [[ptr0]] [[val0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_3 %uint_3
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 [[invoId]] %uint_3
 // CHECK-NEXT:       [[val1:%\d+]] = OpCompositeExtract %float [[cull9]] 1
 // CHECK-NEXT:                       OpStore [[ptr1]] [[val1]]
-// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_3 %uint_4
+// CHECK-NEXT:       [[ptr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 [[invoId]] %uint_4
 // CHECK-NEXT:       [[val2:%\d+]] = OpCompositeExtract %float [[cull9]] 2
 // CHECK-NEXT:                       OpStore [[ptr2]] [[val2]]
 
 // CHECK-NEXT:  [[outInner1:%\d+]] = OpCompositeExtract %CpInner1 [[ret]] 1
 
-// Write out HsCpOut::CpInner1::pos to gl_PerVertex[].gl_Position
+// Write out HsCpOut::CpInner1::pos to gl_Position
 // CHECK-NEXT:     [[outPos:%\d+]] = OpCompositeExtract %v4float [[outInner1]] 0
-// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut [[invoId]] %uint_0
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_Position_0 [[invoId]]
 // CHECK-NEXT:                      OpStore [[ptr]] [[outPos:%\d+]]
 
-// Write out HsCpOut::CpInner1::CpInner2::clip8 to gl_PerVertex[].gl_ClipDistance
+// Write out HsCpOut::CpInner1::CpInner2::clip8 to gl_ClipDistance
 // CHECK-NEXT:  [[outInner2:%\d+]] = OpCompositeExtract %CpInner2 [[outInner1]] 1
 // CHECK-NEXT:   [[outClip8:%\d+]] = OpCompositeExtract %float [[outInner2]] 0
-// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_2 %uint_2
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 [[invoId]] %uint_2
 // CHECK-NEXT:                       OpStore [[ptr]] [[outClip8]]
 
-// Write out HsCpOut::CpInner1::CpInner2::cull6 to gl_PerVertex[].gl_CullDistance
+// Write out HsCpOut::CpInner1::CpInner2::cull6 to gl_CullDistance
 // CHECK-NEXT:   [[outCull6:%\d+]] = OpCompositeExtract %v2float [[outInner2]] 1
-// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_3 %uint_0
+// CHECK-NEXT:       [[ptr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 [[invoId]] %uint_0
 // CHECK-NEXT:       [[val0:%\d+]] = OpCompositeExtract %float [[outCull6]] 0
 // CHECK-NEXT:                       OpStore [[ptr0]] [[val0]]
-// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_3 %uint_1
+// CHECK-NEXT:       [[ptr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 [[invoId]] %uint_1
 // CHECK-NEXT:       [[val1:%\d+]] = OpCompositeExtract %float [[outCull6]] 1
 // CHECK-NEXT:                       OpStore [[ptr1]] [[val1]]
 
@@ -309,14 +302,14 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 // CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v3float %out_var_FOO [[invoId]]
 // CHECK-NEXT:                       OpStore [[ptr]] [[foo]]
 
-// Write out HsCpOut::CpInner1::CpInner2::PointSize to gl_PerVertex[].gl_PointSize
+// Write out HsCpOut::CpInner1::CpInner2::PointSize to gl_PointSize
 // CHECK-NEXT:     [[ptSize:%\d+]] = OpCompositeExtract %float [[outInner2]] 3
-// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_1
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PointSize_0 [[invoId]]
 // CHECK-NEXT:                       OpStore [[ptr]] [[ptSize]]
 
-// Write out HsCpOut::CpInner1::clip6 to gl_PerVertex[].gl_ClipDistance
+// Write out HsCpOut::CpInner1::clip6 to gl_ClipDistance
 // CHECK-NEXT:      [[clip6:%\d+]] = OpCompositeExtract %float [[outInner1]] 2
-// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_2 %uint_0
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 [[invoId]] %uint_0
 // CHECK-NEXT:                       OpStore [[ptr]] [[clip6]]
 
 // Write out HsCpOut::CpInner1::bar to out_var_BAR
@@ -324,9 +317,9 @@ HsCpOut main(InputPatch<HsCpIn, NumOutPoints> patch, uint cpId : SV_OutputContro
 // CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %out_var_BAR [[invoId]]
 // CHECK-NEXT:                       OpStore [[ptr]] [[bar]]
 
-// Write out HsCpOut::clip7 to gl_PerVertex[].gl_ClipDistance
+// Write out HsCpOut::clip7 to gl_ClipDistance
 // CHECK-NEXT:      [[clip7:%\d+]] = OpCompositeExtract %float [[ret]] 2
-// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut [[invoId]] %uint_2 %uint_1
+// CHECK-NEXT:        [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 [[invoId]] %uint_1
 // CHECK-NEXT:                       OpStore [[ptr]] [[clip7]]
 
 // Call PCF

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.hlsl
@@ -5,24 +5,26 @@
 
 // CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
 
-// CHECK: OpEntryPoint Vertex %main "main" %gl_PerVertexOut %in_var_TEXCOORD %in_var_SV_Position %in_var_SV_ClipDistance %in_var_SV_CullDistance0 %out_var_COLOR %out_var_TEXCOORD
+// CHECK: OpEntryPoint Vertex %main "main" %gl_ClipDistance %gl_CullDistance %gl_ClipDistance_0 %gl_CullDistance_0 %in_var_TEXCOORD %in_var_SV_Position %in_var_SV_ClipDistance %in_var_SV_CullDistance0 %gl_PointSize %out_var_COLOR %gl_Position %out_var_TEXCOORD
 
-// CHECK: OpMemberDecorate %type_gl_PerVertex 0 BuiltIn Position
-// CHECK: OpMemberDecorate %type_gl_PerVertex 1 BuiltIn PointSize
-// CHECK: OpMemberDecorate %type_gl_PerVertex 2 BuiltIn ClipDistance
-// CHECK: OpMemberDecorate %type_gl_PerVertex 3 BuiltIn CullDistance
-// CHECK: OpDecorate %type_gl_PerVertex Block
-
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 0 HlslSemanticGOOGLE "SV_Position"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 1 HlslSemanticGOOGLE "PSize"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 2 HlslSemanticGOOGLE "SV_ClipDistance"
-// CHECK: OpMemberDecorateStringGOOGLE %type_gl_PerVertex 3 HlslSemanticGOOGLE "SV_CullDistance"
+// CHECK: OpDecorate %gl_ClipDistance BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance HlslSemanticGOOGLE "SV_CullDistance0"
+// CHECK: OpDecorate %gl_ClipDistance_0 BuiltIn ClipDistance
+// CHECK: OpDecorateStringGOOGLE %gl_ClipDistance_0 HlslSemanticGOOGLE "SV_ClipDistance"
+// CHECK: OpDecorate %gl_CullDistance_0 BuiltIn CullDistance
+// CHECK: OpDecorateStringGOOGLE %gl_CullDistance_0 HlslSemanticGOOGLE "SV_CullDistance"
 
 // CHECK: OpDecorateStringGOOGLE %in_var_TEXCOORD HlslSemanticGOOGLE "TEXCOORD"
 // CHECK: OpDecorateStringGOOGLE %in_var_SV_Position HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %in_var_SV_ClipDistance HlslSemanticGOOGLE "SV_ClipDistance"
 // CHECK: OpDecorateStringGOOGLE %in_var_SV_CullDistance0 HlslSemanticGOOGLE "SV_CullDistance0"
+// CHECK: OpDecorate %gl_PointSize BuiltIn PointSize
+// CHECK: OpDecorateStringGOOGLE %gl_PointSize HlslSemanticGOOGLE "PSize"
 // CHECK: OpDecorateStringGOOGLE %out_var_COLOR HlslSemanticGOOGLE "COLOR"
+// CHECK: OpDecorate %gl_Position BuiltIn Position
+// CHECK: OpDecorateStringGOOGLE %gl_Position HlslSemanticGOOGLE "SV_Position"
 // CHECK: OpDecorateStringGOOGLE %out_var_TEXCOORD HlslSemanticGOOGLE "TEXCOORD"
 
 // CHECK: OpDecorate %in_var_TEXCOORD Location 0
@@ -34,15 +36,20 @@
 
 //     clipdis0 + clipdis1            : 5 floats
 //     culldis3 + culldis5 + culldis6 : 3 floats
-// CHECK: %type_gl_PerVertex = OpTypeStruct %v4float %float %_arr_float_uint_5 %_arr_float_uint_3
 
-// CHECK: %gl_PerVertexOut = OpVariable %_ptr_Output_type_gl_PerVertex Output
+// CHECK: %gl_ClipDistance = OpVariable %_ptr_Input__arr_float_uint_2 Input
+// CHECK: %gl_CullDistance = OpVariable %_ptr_Input__arr_float_uint_3 Input
+// CHECK: %gl_ClipDistance_0 = OpVariable %_ptr_Output__arr_float_uint_5 Output
+// CHECK: %gl_CullDistance_0 = OpVariable %_ptr_Output__arr_float_uint_3 Output
 
 // CHECK: %in_var_TEXCOORD = OpVariable %_ptr_Input_v4float Input
 // CHECK: %in_var_SV_Position = OpVariable %_ptr_Input_v4float Input
 // CHECK: %in_var_SV_ClipDistance = OpVariable %_ptr_Input_v2float Input
 // CHECK: %in_var_SV_CullDistance0 = OpVariable %_ptr_Input_v3float Input
+// CHECK: %gl_PointSize = OpVariable %_ptr_Output_float Output
+
 // CHECK: %out_var_COLOR = OpVariable %_ptr_Output_v4float Output
+// CHECK: %gl_Position = OpVariable %_ptr_Output_v4float Output
 // CHECK: %out_var_TEXCOORD = OpVariable %_ptr_Output_v4float Output
 
 struct InnerInnerStruct {
@@ -100,8 +107,7 @@ float main(out VSOut  vsOut,
 
 // CHECK-NEXT:   [[ptSize:%\d+]] = OpFunctionCall %float %src_main
 
-// CHECK-NEXT:      [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_1
-// CHECK-NEXT:                     OpStore [[ptr]] [[ptSize]]
+// CHECK-NEXT:                     OpStore %gl_PointSize [[ptSize]]
 
 // Write out COLOR
 // CHECK-NEXT:    [[vsOut:%\d+]] = OpLoad %VSOut %param_var_vsOut
@@ -112,10 +118,10 @@ float main(out VSOut  vsOut,
 
 // Write out SV_ClipDistance1
 // CHECK-NEXT:    [[clip1:%\d+]] = OpCompositeExtract %v2float [[innerS]] 0
-// CHECK-NEXT: [[clipArr3:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_3
+// CHECK-NEXT: [[clipArr3:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_3
 // CHECK-NEXT:   [[clip10:%\d+]] = OpCompositeExtract %float [[clip1]] 0
 // CHECK-NEXT:                     OpStore [[clipArr3]] [[clip10]]
-// CHECK-NEXT: [[clipArr4:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_4
+// CHECK-NEXT: [[clipArr4:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_4
 // CHECK-NEXT:   [[clip11:%\d+]] = OpCompositeExtract %float [[clip1]] 1
 // CHECK-NEXT:                     OpStore [[clipArr4]] [[clip11]]
 
@@ -123,18 +129,17 @@ float main(out VSOut  vsOut,
 
 // Write out SV_Position
 // CHECK-NEXT:     [[pos:%\d+]] = OpCompositeExtract %v4float [[inner2S]] 0
-// CHECK-NEXT:  [[outPos:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
-// CHECK-NEXT:       OpStore [[outPos]] [[pos]]
+// CHECK-NEXT:                    OpStore %gl_Position [[pos]]
 
 // Write out SV_ClipDistance0
 // CHECK-NEXT:    [[clip0:%\d+]] = OpLoad %v3float %param_var_clipdis0
-// CHECK-NEXT: [[clipArr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_0
+// CHECK-NEXT: [[clipArr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_0
 // CHECK-NEXT:   [[clip00:%\d+]] = OpCompositeExtract %float [[clip0]] 0
 // CHECK-NEXT:                     OpStore [[clipArr0]] [[clip00]]
-// CHECK-NEXT: [[clipArr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_1
+// CHECK-NEXT: [[clipArr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_1
 // CHECK-NEXT:   [[clip01:%\d+]] = OpCompositeExtract %float [[clip0]] 1
 // CHECK-NEXT:                     OpStore [[clipArr1]] [[clip01]]
-// CHECK-NEXT: [[clipArr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_2 %uint_2
+// CHECK-NEXT: [[clipArr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance_0 %uint_2
 // CHECK-NEXT:   [[clip02:%\d+]] = OpCompositeExtract %float [[clip0]] 2
 // CHECK-NEXT:                     OpStore [[clipArr2]] [[clip02]]
 
@@ -144,16 +149,16 @@ float main(out VSOut  vsOut,
 
 // Write out SV_CullDistance5
 // CHECK-NEXT:    [[cull5:%\d+]] = OpLoad %float %param_var_culldis5
-// CHECK-NEXT: [[cullArr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_1
+// CHECK-NEXT: [[cullArr1:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_1
 // CHECK-NEXT:                     OpStore [[cullArr1]] [[cull5]]
 
 // Write out SV_CullDistance3
 // CHECK-NEXT:    [[cull3:%\d+]] = OpLoad %float %param_var_culldis3
-// CHECK-NEXT: [[cullArr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_0
+// CHECK-NEXT: [[cullArr0:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_0
 // CHECK-NEXT:                     OpStore [[cullArr0]] [[cull3]]
 
 // Write out SV_CullDistance6
 // CHECK-NEXT:    [[cull6:%\d+]] = OpLoad %float %param_var_culldis6
-// CHECK-NEXT: [[cullArr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_PerVertexOut %uint_3 %uint_2
+// CHECK-NEXT: [[cullArr2:%\d+]] = OpAccessChain %_ptr_Output_float %gl_CullDistance_0 %uint_2
 // CHECK-NEXT:                     OpStore [[cullArr2]] [[cull6]]
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.ds.hlsl
@@ -26,8 +26,7 @@ DsCpOut main(OutputPatch<DsCpIn, 3> patch,
 
 // CHECK:      [[call:%\d+]] = OpFunctionCall %DsCpIn %src_main %param_var_patch %param_var_pcfData
 // CHECK-NEXT:  [[val:%\d+]] = OpCompositeExtract %v4float [[call]] 0
-// CHECK-NEXT:  [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
 // CHECK-NEXT: [[oldY:%\d+]] = OpCompositeExtract %float [[val]] 1
 // CHECK-NEXT: [[newY:%\d+]] = OpFNegate %float [[oldY]]
 // CHECK-NEXT:  [[pos:%\d+]] = OpCompositeInsert %v4float [[newY]] [[val]] 1
-// CHECK-NEXT:                 OpStore [[ptr]] [[pos]]
+// CHECK-NEXT:                 OpStore %gl_Position_0 [[pos]]

--- a/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.gs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.gs.hlsl
@@ -21,7 +21,7 @@ void main(in    line GsVIn              inData[2],
 // CHECK-NEXT: [[oldY:%\d+]] = OpCompositeExtract %float [[val]] 1
 // CHECK-NEXT: [[newY:%\d+]] = OpFNegate %float [[oldY]]
 // CHECK-NEXT:  [[pos:%\d+]] = OpCompositeInsert %v4float [[newY]] [[val]] 1
-// CHECK-NEXT:                 OpStore %gl_Position [[pos]]
+// CHECK-NEXT:                 OpStore %gl_Position_0 [[pos]]
     outData.Append(vertex);
 
     outData.RestartStrip();

--- a/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.cloption.invert-y.vs.hlsl
@@ -5,8 +5,7 @@ float4 main(float4 a : A) : SV_Position {
 }
 
 // CHECK:         [[a:%\d+]] = OpFunctionCall %v4float %src_main %param_var_a
-// CHECK-NEXT:  [[ptr:%\d+]] = OpAccessChain %_ptr_Output_v4float %gl_PerVertexOut %uint_0
 // CHECK-NEXT: [[oldY:%\d+]] = OpCompositeExtract %float [[a]] 1
 // CHECK-NEXT: [[newY:%\d+]] = OpFNegate %float [[oldY]]
 // CHECK-NEXT:  [[pos:%\d+]] = OpCompositeInsert %v4float [[newY]] [[a]] 1
-// CHECK-NEXT:                 OpStore [[ptr]] [[pos]]
+// CHECK-NEXT:                 OpStore %gl_Position [[pos]]


### PR DESCRIPTION
It's actually a spec reading issue that it seems we cannot
have stand-alone variables for Position, PointSize, ClipDistance,
or CullDistance in HS/DS/GS.

Removed all code regarding Position and PointSize from GlPerVertex.
We still need to keep GlPerVertex aroudn to handle ClipDistance
and CullDistance though.