### PR TITLE
Match throws and use standard string exception

### DIFF
--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4814,7 +4814,7 @@ void report_fatal_error_handler(void *user_datam, const std::string &reason,
   BitcodeDiagnosticInfo BDI(std::error_code(EINVAL, std::system_category()),
                             DiagnosticSeverity::DS_Error, reason);
   data->DiagnosticHandler(BDI);
-  throw std::exception("Invalid bitcode");
+  throw std::runtime_error("Invalid bitcode");
 }
 // HLSL Change Ends
 

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -80,7 +80,7 @@ static HeapMalloc g_HeapMalloc;
 
 namespace hlsl {
 
-IMalloc *GetGlobalHeapMalloc() {
+IMalloc *GetGlobalHeapMalloc() throw() {
   return &g_HeapMalloc;
 }
 
@@ -141,7 +141,7 @@ void WriteBinaryFile(LPCWSTR pFileName, const void *pData, DWORD DataSize) {
 }
 
 _Use_decl_annotations_
-UINT32 DxcCodePageFromBytes(const char *bytes, size_t byteLen) {
+UINT32 DxcCodePageFromBytes(const char *bytes, size_t byteLen) throw() {
   UINT32 codePage;
   if (byteLen >= 4) {
     // Now try to use the BOM to check for Unicode encodings
@@ -321,7 +321,7 @@ static HRESULT CodePageBufferToUtf16(UINT32 codePage, LPCVOID bufferPointer,
 
 _Use_decl_annotations_
 HRESULT DxcCreateBlobFromBlob(
-    IDxcBlob *pBlob, UINT32 offset, UINT32 length, IDxcBlob **ppResult) {
+    IDxcBlob *pBlob, UINT32 offset, UINT32 length, IDxcBlob **ppResult) throw() {
   if (pBlob == nullptr || ppResult == nullptr) {
     return E_POINTER;
   }
@@ -347,7 +347,7 @@ HRESULT DxcCreateBlobFromBlob(
 
 _Use_decl_annotations_
 HRESULT
-DxcCreateBlobOnHeap(LPCVOID pData, UINT32 size, IDxcBlob **ppResult) {
+DxcCreateBlobOnHeap(LPCVOID pData, UINT32 size, IDxcBlob **ppResult) throw() {
   if (pData == nullptr || ppResult == nullptr) {
     return E_POINTER;
   }
@@ -362,7 +362,7 @@ DxcCreateBlobOnHeap(LPCVOID pData, UINT32 size, IDxcBlob **ppResult) {
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobOnHeapCopy(_In_bytecount_(size) LPCVOID pData, UINT32 size,
-                        _COM_Outptr_ IDxcBlob **ppResult) {
+                        _COM_Outptr_ IDxcBlob **ppResult) throw() {
   if (pData == nullptr || ppResult == nullptr) {
     return E_POINTER;
   }
@@ -415,7 +415,7 @@ DxcCreateBlobFromFile(IMalloc *pMalloc, LPCWSTR pFileName, UINT32 *pCodePage,
 
 _Use_decl_annotations_
 HRESULT DxcCreateBlobFromFile(LPCWSTR pFileName, UINT32 *pCodePage,
-                              IDxcBlobEncoding **ppBlobEncoding) {
+                              IDxcBlobEncoding **ppBlobEncoding) throw() {
   CComPtr<IMalloc> pMalloc;
   IFR(CoGetMalloc(1, &pMalloc));
   return DxcCreateBlobFromFile(pMalloc, pFileName, pCodePage, ppBlobEncoding);
@@ -424,7 +424,7 @@ HRESULT DxcCreateBlobFromFile(LPCWSTR pFileName, UINT32 *pCodePage,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingSet(IMalloc *pMalloc, IDxcBlob *pBlob, UINT32 codePage,
-                             IDxcBlobEncoding **ppBlobEncoding) {
+                             IDxcBlobEncoding **ppBlobEncoding) throw() {
   DXASSERT_NOMSG(pMalloc != nullptr);
   DXASSERT_NOMSG(pBlob != nullptr);
   DXASSERT_NOMSG(ppBlobEncoding != nullptr);
@@ -442,7 +442,7 @@ DxcCreateBlobWithEncodingSet(IMalloc *pMalloc, IDxcBlob *pBlob, UINT32 codePage,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingSet(IDxcBlob *pBlob, UINT32 codePage,
-                             IDxcBlobEncoding **ppBlobEncoding) {
+                             IDxcBlobEncoding **ppBlobEncoding) throw() {
   return DxcCreateBlobWithEncodingSet(DxcGetThreadMallocNoRef(), pBlob,
                                       codePage, ppBlobEncoding);
 }
@@ -450,7 +450,7 @@ DxcCreateBlobWithEncodingSet(IDxcBlob *pBlob, UINT32 codePage,
 _Use_decl_annotations_
 HRESULT DxcCreateBlobWithEncodingFromPinned(LPCVOID pText, UINT32 size,
                                             UINT32 codePage,
-                                            IDxcBlobEncoding **pBlobEncoding) {
+                                            IDxcBlobEncoding **pBlobEncoding) throw() {
   *pBlobEncoding = nullptr;
 
   InternalDxcBlobEncoding *internalEncoding;
@@ -467,7 +467,7 @@ _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingFromStream(IStream *pStream, bool newInstanceAlways,
                                     UINT32 codePage,
-                                    IDxcBlobEncoding **ppBlobEncoding) {
+                                    IDxcBlobEncoding **ppBlobEncoding) throw() {
   *ppBlobEncoding = nullptr;
   if (pStream == nullptr) {
     return S_OK;
@@ -496,7 +496,7 @@ DxcCreateBlobWithEncodingFromStream(IStream *pStream, bool newInstanceAlways,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingOnHeap(LPCVOID pText, UINT32 size, UINT32 codePage,
-                                IDxcBlobEncoding **pBlobEncoding) {
+                                IDxcBlobEncoding **pBlobEncoding) throw() {
   *pBlobEncoding = nullptr;
 
   InternalDxcBlobEncoding *internalEncoding;
@@ -511,7 +511,7 @@ DxcCreateBlobWithEncodingOnHeap(LPCVOID pText, UINT32 size, UINT32 codePage,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingOnHeapCopy(LPCVOID pText, UINT32 size, UINT32 codePage,
-  IDxcBlobEncoding **pBlobEncoding) {
+  IDxcBlobEncoding **pBlobEncoding) throw() {
   *pBlobEncoding = nullptr;
 
   CDxcMallocHeapPtr<char> heapCopy(DxcGetThreadMallocNoRef());
@@ -532,7 +532,7 @@ DxcCreateBlobWithEncodingOnHeapCopy(LPCVOID pText, UINT32 size, UINT32 codePage,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingOnMalloc(LPCVOID pText, IMalloc *pIMalloc, UINT32 size, UINT32 codePage,
-  IDxcBlobEncoding **pBlobEncoding) {
+  IDxcBlobEncoding **pBlobEncoding) throw() {
 
   *pBlobEncoding = nullptr;
   InternalDxcBlobEncoding* internalEncoding;
@@ -546,7 +546,7 @@ DxcCreateBlobWithEncodingOnMalloc(LPCVOID pText, IMalloc *pIMalloc, UINT32 size,
 _Use_decl_annotations_
 HRESULT
 DxcCreateBlobWithEncodingOnMallocCopy(IMalloc *pIMalloc, LPCVOID pText, UINT32 size, UINT32 codePage,
-  IDxcBlobEncoding **ppBlobEncoding) {
+  IDxcBlobEncoding **ppBlobEncoding) throw() {
   *ppBlobEncoding = nullptr;
   void *pData = pIMalloc->Alloc(size);
   if (pData == nullptr)
@@ -562,7 +562,7 @@ DxcCreateBlobWithEncodingOnMallocCopy(IMalloc *pIMalloc, LPCVOID pText, UINT32 s
 
 
 _Use_decl_annotations_
-HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) {
+HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) throw() {
   *pBlobEncoding = nullptr;
 
   HRESULT hr;
@@ -654,7 +654,7 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) {
 
 HRESULT
 DxcGetBlobAsUtf8NullTerm(_In_ IDxcBlob *pBlob,
-                         _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) {
+                         _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) throw() {
   *ppBlobEncoding = nullptr;
 
   HRESULT hr;
@@ -700,7 +700,7 @@ DxcGetBlobAsUtf8NullTerm(_In_ IDxcBlob *pBlob,
 }
 
 _Use_decl_annotations_
-HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobEncoding **pBlobEncoding) {
+HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobEncoding **pBlobEncoding) throw() {
   *pBlobEncoding = nullptr;
 
   HRESULT hr;
@@ -815,22 +815,26 @@ public:
   }
 
   // AbstractMemoryStream implementation.
-  LPBYTE GetPtr() override {
+  LPBYTE GetPtr() throw() override {
     return m_pMemory;
   }
 
-  ULONG GetPtrSize() override {
+  ULONG GetPtrSize() throw() override {
     return m_size;
   }
 
-  LPBYTE Detach() override {
+  LPBYTE Detach() throw() override {
     LPBYTE result = m_pMemory;
     m_pMemory = nullptr;
     Reset();
     return result;
   }
 
-  HRESULT Reserve(ULONG targetSize) override {
+  UINT64 GetPosition() throw() override {
+    return m_offset;
+  }
+
+  HRESULT Reserve(ULONG targetSize) throw() override {
     if (m_pMemory == nullptr) {
       m_pMemory = (LPBYTE)m_pMalloc->Alloc(targetSize);
       if (m_pMemory == nullptr) {
@@ -856,9 +860,6 @@ public:
   }
   SIZE_T STDMETHODCALLTYPE GetBufferSize(void) override {
     return m_size;
-  }
-  UINT64 GetPosition() override {
-    return m_offset;
   }
 
   // ISequentialStream implementation.
@@ -1096,7 +1097,7 @@ public:
   }
 };
 
-HRESULT CreateMemoryStream(_In_ IMalloc *pMalloc, _COM_Outptr_ AbstractMemoryStream** ppResult) {
+HRESULT CreateMemoryStream(_In_ IMalloc *pMalloc, _COM_Outptr_ AbstractMemoryStream** ppResult) throw() {
   if (pMalloc == nullptr || ppResult == nullptr) {
     return E_POINTER;
   }
@@ -1106,7 +1107,7 @@ HRESULT CreateMemoryStream(_In_ IMalloc *pMalloc, _COM_Outptr_ AbstractMemoryStr
   return (*ppResult == nullptr) ? E_OUTOFMEMORY : S_OK;
 }
 
-HRESULT CreateReadOnlyBlobStream(_In_ IDxcBlob *pSource, _COM_Outptr_ IStream** ppResult) {
+HRESULT CreateReadOnlyBlobStream(_In_ IDxcBlob *pSource, _COM_Outptr_ IStream** ppResult) throw() {
   if (pSource == nullptr || ppResult == nullptr) {
     return E_POINTER;
   }

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -32,7 +32,7 @@ IMalloc *DxcGetThreadMallocNoRef() throw();
 _Ret_maybenull_ _Post_writable_byte_size_(nBytes) void *DxcThreadAlloc(size_t nBytes) throw();
 void DxcThreadFree(void *) throw();
 
-HRESULT DxcInitThreadMalloc() {
+HRESULT DxcInitThreadMalloc() throw() {
   DXASSERT(g_ThreadMallocTlsIndex == 0, "else InitThreadMalloc already called");
   DXASSERT(g_pDefaultMalloc == nullptr, "else InitThreadMalloc already called");
 
@@ -51,7 +51,7 @@ HRESULT DxcInitThreadMalloc() {
   return S_OK;
 }
 
-void DxcCleanupThreadMalloc() {
+void DxcCleanupThreadMalloc() throw() {
   if (g_ThreadMallocTlsIndex) {
     TlsFree(g_ThreadMallocTlsIndex);
     g_ThreadMallocTlsIndex = 0;
@@ -61,26 +61,26 @@ void DxcCleanupThreadMalloc() {
   }
 }
 
-IMalloc *DxcGetThreadMallocNoRef() {
+IMalloc *DxcGetThreadMallocNoRef() throw() {
   DXASSERT(g_ThreadMallocTlsIndex != 0, "else prior to DxcInitThreadMalloc or after DxcCleanupThreadMalloc");
   return reinterpret_cast<IMalloc *>(TlsGetValue(g_ThreadMallocTlsIndex));
 }
-void DxcClearThreadMalloc() {
+void DxcClearThreadMalloc() throw() {
   DXASSERT(g_ThreadMallocTlsIndex != 0, "else prior to DxcInitThreadMalloc or after DxcCleanupThreadMalloc");
   IMalloc *pMalloc = DxcGetThreadMallocNoRef();
   DXVERIFY_NOMSG(TlsSetValue(g_ThreadMallocTlsIndex, nullptr));
   pMalloc->Release();
 }
-void DxcSetThreadMalloc(IMalloc *pMalloc) {
+void DxcSetThreadMalloc(IMalloc *pMalloc) throw() {
   DXASSERT(g_ThreadMallocTlsIndex != 0, "else prior to DxcInitThreadMalloc or after DxcCleanupThreadMalloc");
   DXASSERT(DxcGetThreadMallocNoRef() == nullptr, "else nested allocation invoked");
   DXVERIFY_NOMSG(TlsSetValue(g_ThreadMallocTlsIndex, pMalloc));
   pMalloc->AddRef();
 }
-void DxcSetThreadMallocOrDefault(IMalloc *pMalloc) {
+void DxcSetThreadMallocOrDefault(IMalloc *pMalloc) throw() {
   DxcSetThreadMalloc(pMalloc ? pMalloc : g_pDefaultMalloc);
 }
-IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) {
+IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) throw() {
   DXASSERT(g_ThreadMallocTlsIndex != 0, "else prior to DxcInitThreadMalloc or after DxcCleanupThreadMalloc");
   IMalloc *pPrior = DxcGetThreadMallocNoRef();
   if (ppPrior) {
@@ -89,6 +89,6 @@ IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) {
   DXVERIFY_NOMSG(TlsSetValue(g_ThreadMallocTlsIndex, pMalloc));
   return pMalloc;
 }
-IMalloc *DxcSwapThreadMallocOrDefault(IMalloc *pMallocOrNull, IMalloc **ppPrior) {
+IMalloc *DxcSwapThreadMallocOrDefault(IMalloc *pMallocOrNull, IMalloc **ppPrior) throw() {
   return DxcSwapThreadMalloc(pMallocOrNull ? pMallocOrNull : g_pDefaultMalloc, ppPrior);
 }

--- a/lib/MSSupport/MSFileSystemImpl.cpp
+++ b/lib/MSSupport/MSFileSystemImpl.cpp
@@ -90,96 +90,96 @@ MSFileSystemForDisk::MSFileSystemForDisk()
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::FindNextFileW(HANDLE hFindFile, LPWIN32_FIND_DATAW lpFindFileData)
+BOOL MSFileSystemForDisk::FindNextFileW(HANDLE hFindFile, LPWIN32_FIND_DATAW lpFindFileData) throw()
 {
   return ::FindNextFileW(hFindFile, lpFindFileData);
 }
 
 _Use_decl_annotations_
-HANDLE MSFileSystemForDisk::FindFirstFileW(LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData)
+HANDLE MSFileSystemForDisk::FindFirstFileW(LPCWSTR lpFileName, LPWIN32_FIND_DATAW lpFindFileData) throw()
 {
   return ::FindFirstFileW(lpFileName, lpFindFileData);
 }
 
-void MSFileSystemForDisk::FindClose(HANDLE findHandle)
+void MSFileSystemForDisk::FindClose(HANDLE findHandle) throw()
 {
   ::FindClose(findHandle);
 }
 
 _Use_decl_annotations_
-HANDLE MSFileSystemForDisk::CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes)
+HANDLE MSFileSystemForDisk::CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes) throw()
 {
   return ::CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, nullptr, dwCreationDisposition, dwFlagsAndAttributes, nullptr);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::SetFileTime(HANDLE hFile, _In_opt_ const FILETIME *lpCreationTime, _In_opt_ const FILETIME *lpLastAccessTime, _In_opt_ const FILETIME *lpLastWriteTime)
+BOOL MSFileSystemForDisk::SetFileTime(HANDLE hFile, _In_opt_ const FILETIME *lpCreationTime, _In_opt_ const FILETIME *lpLastAccessTime, _In_opt_ const FILETIME *lpLastWriteTime) throw()
 {
   return ::SetFileTime(hFile, lpCreationTime, lpLastAccessTime, lpLastWriteTime);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::GetFileInformationByHandle(HANDLE hFile, LPBY_HANDLE_FILE_INFORMATION lpFileInformation)
+BOOL MSFileSystemForDisk::GetFileInformationByHandle(HANDLE hFile, LPBY_HANDLE_FILE_INFORMATION lpFileInformation) throw()
 {
   return ::GetFileInformationByHandle(hFile, lpFileInformation);
 }
 
 _Use_decl_annotations_
-DWORD MSFileSystemForDisk::GetFileType(HANDLE hFile)
+DWORD MSFileSystemForDisk::GetFileType(HANDLE hFile) throw()
 {
   return ::GetFileType(hFile);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::CreateHardLinkW(LPCWSTR lpFileName, LPCWSTR lpExistingFileName)
+BOOL MSFileSystemForDisk::CreateHardLinkW(LPCWSTR lpFileName, LPCWSTR lpExistingFileName) throw()
 {
   return ::CreateHardLinkW(lpFileName, lpExistingFileName, nullptr);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::MoveFileExW(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName, DWORD dwFlags)
+BOOL MSFileSystemForDisk::MoveFileExW(LPCWSTR lpExistingFileName, LPCWSTR lpNewFileName, DWORD dwFlags) throw()
 {
   return ::MoveFileExW(lpExistingFileName, lpNewFileName, dwFlags);
 }
 
 _Use_decl_annotations_
-DWORD MSFileSystemForDisk::GetFileAttributesW(LPCWSTR lpFileName)
+DWORD MSFileSystemForDisk::GetFileAttributesW(LPCWSTR lpFileName) throw()
 {
   return ::GetFileAttributesW(lpFileName);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::CloseHandle(HANDLE hObject)
+BOOL MSFileSystemForDisk::CloseHandle(HANDLE hObject) throw()
 {
   return ::CloseHandle(hObject);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::DeleteFileW(LPCWSTR lpFileName)
+BOOL MSFileSystemForDisk::DeleteFileW(LPCWSTR lpFileName) throw()
 {
   return ::DeleteFileW(lpFileName);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::RemoveDirectoryW(LPCWSTR lpFileName)
+BOOL MSFileSystemForDisk::RemoveDirectoryW(LPCWSTR lpFileName) throw()
 {
   return ::RemoveDirectoryW(lpFileName);
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::CreateDirectoryW(LPCWSTR lpPathName)
+BOOL MSFileSystemForDisk::CreateDirectoryW(LPCWSTR lpPathName) throw()
 {
   return ::CreateDirectoryW(lpPathName, nullptr);
 }
 
 _Use_decl_annotations_
-DWORD MSFileSystemForDisk::GetCurrentDirectoryW(DWORD nBufferLength,  LPWSTR lpBuffer)
+DWORD MSFileSystemForDisk::GetCurrentDirectoryW(DWORD nBufferLength,  LPWSTR lpBuffer) throw()
 {
   return ::GetCurrentDirectoryW(nBufferLength, lpBuffer);
 }
 
 _Use_decl_annotations_
-DWORD MSFileSystemForDisk::GetMainModuleFileNameW(LPWSTR lpFilename, DWORD nSize)
+DWORD MSFileSystemForDisk::GetMainModuleFileNameW(LPWSTR lpFilename, DWORD nSize) throw()
 {
   // Add some code to ensure that the result is null terminated.
   if (nSize <= 1)
@@ -195,7 +195,7 @@ DWORD MSFileSystemForDisk::GetMainModuleFileNameW(LPWSTR lpFilename, DWORD nSize
 }
 
 _Use_decl_annotations_
-DWORD MSFileSystemForDisk::GetTempPathW(DWORD nBufferLength, LPWSTR lpBuffer)
+DWORD MSFileSystemForDisk::GetTempPathW(DWORD nBufferLength, LPWSTR lpBuffer) throw()
 {
   return ::GetTempPathW(nBufferLength, lpBuffer);
 }
@@ -212,30 +212,30 @@ namespace {
 }
 
 _Use_decl_annotations_
-BOOLEAN MSFileSystemForDisk::CreateSymbolicLinkW(LPCWSTR lpSymlinkFileName, LPCWSTR lpTargetFileName, DWORD dwFlags)
+BOOLEAN MSFileSystemForDisk::CreateSymbolicLinkW(LPCWSTR lpSymlinkFileName, LPCWSTR lpTargetFileName, DWORD dwFlags) throw()
 {
   return create_symbolic_link_api(lpSymlinkFileName, lpTargetFileName, dwFlags);
 }
 
-bool MSFileSystemForDisk::SupportsCreateSymbolicLink()
+bool MSFileSystemForDisk::SupportsCreateSymbolicLink() throw()
 {
   return create_symbolic_link_api != nullptr;
 }
 
 _Use_decl_annotations_
-BOOL MSFileSystemForDisk::ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead, _Out_opt_ LPDWORD lpNumberOfBytesRead)
+BOOL MSFileSystemForDisk::ReadFile(HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead, _Out_opt_ LPDWORD lpNumberOfBytesRead) throw()
 {
   return ::ReadFile(hFile, lpBuffer, nNumberOfBytesToRead, lpNumberOfBytesRead, nullptr);
 }
 
 _Use_decl_annotations_
-HANDLE MSFileSystemForDisk::CreateFileMappingW(HANDLE hFile, DWORD flProtect, DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow)
+HANDLE MSFileSystemForDisk::CreateFileMappingW(HANDLE hFile, DWORD flProtect, DWORD dwMaximumSizeHigh, DWORD dwMaximumSizeLow) throw()
 {
   return ::CreateFileMappingW(hFile, nullptr, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, nullptr);
 }
 
 _Use_decl_annotations_
-LPVOID MSFileSystemForDisk::MapViewOfFile(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap)
+LPVOID MSFileSystemForDisk::MapViewOfFile(HANDLE hFileMappingObject, DWORD dwDesiredAccess, DWORD dwFileOffsetHigh, DWORD dwFileOffsetLow, SIZE_T dwNumberOfBytesToMap) throw()
 {
   return ::MapViewOfFile(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
 }
@@ -246,13 +246,13 @@ BOOL MSFileSystemForDisk::UnmapViewOfFile(LPCVOID lpBaseAddress) throw()
   return ::UnmapViewOfFile(lpBaseAddress);
 }
 
-bool MSFileSystemForDisk::FileDescriptorIsDisplayed(int fd)
+bool MSFileSystemForDisk::FileDescriptorIsDisplayed(int fd) throw()
 {
   DWORD Mode;  // Unused
   return (GetConsoleMode((HANDLE)_get_osfhandle(fd), &Mode) != 0);
 }
 
-unsigned MSFileSystemForDisk::GetColumnCount(DWORD nStdHandle)
+unsigned MSFileSystemForDisk::GetColumnCount(DWORD nStdHandle) throw()
 {
   unsigned Columns = 0;
   CONSOLE_SCREEN_BUFFER_INFO csbi;
@@ -269,43 +269,43 @@ unsigned MSFileSystemForDisk::GetConsoleOutputTextAttributes() throw()
   return 0;
 }
 
-void MSFileSystemForDisk::SetConsoleOutputTextAttributes(unsigned attributes)
+void MSFileSystemForDisk::SetConsoleOutputTextAttributes(unsigned attributes) throw()
 {
   ::SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), attributes);
 }
 
-void MSFileSystemForDisk::ResetConsoleOutputTextAttributes()
+void MSFileSystemForDisk::ResetConsoleOutputTextAttributes() throw()
 {
   ::SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), _defaultAttributes);
 }
 
-int MSFileSystemForDisk::open_osfhandle(intptr_t osfhandle, int flags)
+int MSFileSystemForDisk::open_osfhandle(intptr_t osfhandle, int flags) throw()
 {
   return ::_open_osfhandle(osfhandle, flags);
 }
 
-intptr_t MSFileSystemForDisk::get_osfhandle(int fd)
+intptr_t MSFileSystemForDisk::get_osfhandle(int fd) throw()
 {
   return ::_get_osfhandle(fd);
 }
 
-int MSFileSystemForDisk::close(int fd)
+int MSFileSystemForDisk::close(int fd) throw()
 {
   return ::_close(fd);
 }
 
-long MSFileSystemForDisk::lseek(int fd, long offset, int origin)
+long MSFileSystemForDisk::lseek(int fd, long offset, int origin) throw()
 {
   return ::_lseek(fd, offset, origin);
 }
 
-int MSFileSystemForDisk::setmode(int fd, int mode)
+int MSFileSystemForDisk::setmode(int fd, int mode) throw()
 {
   return ::_setmode(fd, mode);
 }
 
 _Use_decl_annotations_
-errno_t MSFileSystemForDisk::resize_file(LPCWSTR path, uint64_t size)
+errno_t MSFileSystemForDisk::resize_file(LPCWSTR path, uint64_t size) throw()
 {
   int fd = ::_wopen(path, O_BINARY | _O_RDWR, S_IWRITE);
   if (fd == -1)
@@ -320,13 +320,13 @@ errno_t MSFileSystemForDisk::resize_file(LPCWSTR path, uint64_t size)
 }
 
 _Use_decl_annotations_
-int MSFileSystemForDisk::Read(int fd, void* buffer, unsigned int count)
+int MSFileSystemForDisk::Read(int fd, void* buffer, unsigned int count) throw()
 {
   return ::_read(fd, buffer, count);
 }
 
 _Use_decl_annotations_
-int MSFileSystemForDisk::Write(int fd, const void* buffer, unsigned int count)
+int MSFileSystemForDisk::Write(int fd, const void* buffer, unsigned int count) throw()
 {
   return ::_write(fd, buffer, count);
 }
@@ -338,7 +338,7 @@ int MSFileSystemForDisk::Write(int fd, const void* buffer, unsigned int count)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Externally visible functions.
 
-HRESULT CreateMSFileSystemForDisk(_COM_Outptr_ ::llvm::sys::fs::MSFileSystem** pResult)
+HRESULT CreateMSFileSystemForDisk(_COM_Outptr_ ::llvm::sys::fs::MSFileSystem** pResult) throw()
 {
   *pResult = new (std::nothrow) ::llvm::sys::fs::MSFileSystemForDisk();
   return (*pResult != nullptr) ? S_OK : E_OUTOFMEMORY;

--- a/tools/clang/lib/Frontend/CompilerInstance.cpp
+++ b/tools/clang/lib/Frontend/CompilerInstance.cpp
@@ -596,7 +596,7 @@ void CompilerInstance::clearOutputFiles(bool EraseFiles) {
   }
   OutputFiles.clear();
   NonSeekStream.reset();
-  if (errorsFound) throw std::exception("errors when processing output"); // HLSL Change
+  if (errorsFound) throw std::runtime_error("errors when processing output"); // HLSL Change
 }
 
 raw_pwrite_stream *

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -568,7 +568,7 @@ public:
     SetLastError(ERROR_NOT_CAPABLE);
     return FALSE;
   }
-  DWORD GetTempPathW(DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) override {
+  DWORD GetTempPathW(DWORD nBufferLength, _Out_writes_to_opt_(nBufferLength, return +1) LPWSTR lpBuffer) throw() override {
     SetLastError(ERROR_NOT_CAPABLE);
     return FALSE;
   }

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -362,6 +362,6 @@ public:
   HRESULT STDMETHODCALLTYPE GetKind(_Out_ DxcTypeKind* pResult) override;
 };
 
-HRESULT CreateDxcIntelliSense(_In_ REFIID riid, _Out_ LPVOID* ppv);
+HRESULT CreateDxcIntelliSense(_In_ REFIID riid, _Out_ LPVOID* ppv) throw();
 
 #endif


### PR DESCRIPTION
Some compilers require function prototypes and bodies to match with
throw() attributes. This corrects them.

Additionally, it replaces thrown std::exceptions with a string
parameter with runtime_errors, which can take a string on any
system.

Finally, as an incidental change, I moved GetPosition in 
FileIOHelper.cpp to its proper place with the rest of the 
AbstractMemoryStream implementation instead of grouping it 
with the IDxcBlob implementation

Nonfunctional change. 
Just inching toward cross platform compatibility