### PR TITLE
Turn off warnings on MSVC include search rules

### DIFF
--- a/tools/clang/lib/Lex/HeaderSearch.cpp
+++ b/tools/clang/lib/Lex/HeaderSearch.cpp
@@ -564,7 +564,9 @@ static bool checkMSVCHeaderSearch(DiagnosticsEngine &Diags,
                                   const FileEntry *MSFE, const FileEntry *FE,
                                   SourceLocation IncludeLoc) {
   if (MSFE && FE != MSFE) {
+#if 0  // HLSL Change - turn off warnings of MSVC search rules
     Diags.Report(IncludeLoc, diag::ext_pp_include_search_ms) << MSFE->getName();
+#endif // HLSL Change
     return true;
   }
   return false;


### PR DESCRIPTION
This turns off warnings on non-portable MSVC include search
rules completely.

If we are trying to migrate to the C++ default behavior for
include file resolution for the long run, then maybe it makes
more sense to still have this warning and use a command-line
option to get the old behavior like what we've done for
macro expansion.

Let me know if you prefer the later. I'd happy to change.