### PR TITLE
[spirv] Support storing to values of reference types

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -4812,7 +4812,9 @@ SpirvEvalInfo SPIRVEmitter::processAssignment(const Expr *lhs,
 
 void SPIRVEmitter::storeValue(const SpirvEvalInfo &lhsPtr,
                               const SpirvEvalInfo &rhsVal,
-                              const QualType lhsValType) {
+                              QualType lhsValType) {
+  if (const auto *refType = lhsValType->getAs<ReferenceType>())
+    lhsValType = refType->getPointeeType();
 
   QualType matElemType = {};
   const bool lhsIsMat = typeTranslator.isMxNMatrix(lhsValType, &matElemType);

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.storage-class.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.storage-class.hlsl
@@ -1,0 +1,30 @@
+// Run: %dxc -T vs_6_0 -E main
+
+RWStructuredBuffer<float> Data;
+
+void foo(in float a, inout float b, out float c) {
+    b += a;
+    c = a + b;
+}
+
+void main(float input : INPUT) {
+// CHECK: %param_var_a = OpVariable %_ptr_Function_float Function
+// CHECK: %param_var_b = OpVariable %_ptr_Function_float Function
+// CHECK: %param_var_c = OpVariable %_ptr_Function_float Function
+
+// CHECK: [[val:%\d+]] = OpLoad %float %input
+// CHECK:                OpStore %param_var_a [[val]]
+// CHECK:  [[p0:%\d+]] = OpAccessChain %_ptr_Uniform_float %Data %int_0 %uint_0
+// CHECK: [[val:%\d+]] = OpLoad %float [[p0]]
+// CHECK:                OpStore %param_var_b [[val]]
+// CHECK:  [[p1:%\d+]] = OpAccessChain %_ptr_Uniform_float %Data %int_0 %uint_1
+// CHECK: [[val:%\d+]] = OpLoad %float [[p1]]
+// CHECK:                OpStore %param_var_c [[val]]
+
+// CHECK:                OpFunctionCall %void %foo %param_var_a %param_var_b %param_var_c
+    foo(input, Data[0], Data[1]);
+// CHECK: [[val:%\d+]] = OpLoad %float %param_var_b
+// CHECK:                OpStore [[p0]] [[val]]
+// CHECK: [[val:%\d+]] = OpLoad %float %param_var_c
+// CHECK:                OpStore [[p1]] [[val]]
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -436,6 +436,9 @@ TEST_F(FileTest, FunctionInOutParam) { runFileTest("fn.param.inout.hlsl"); }
 TEST_F(FileTest, FunctionInOutParamVector) {
   runFileTest("fn.param.inout.vector.hlsl");
 }
+TEST_F(FileTest, FunctionInOutParamDiffStorageClass) {
+  runFileTest("fn.param.inout.storage-class.hlsl");
+}
 TEST_F(FileTest, FunctionFowardDeclaration) {
   runFileTest("fn.foward-declaration.hlsl");
 }


### PR DESCRIPTION
AST will use reference types for function parameters that are
marked as out or inout.