### PR TITLE
Make correct/consistent #include capitalization

### DIFF
--- a/lib/Analysis/DxilConstantFolding.cpp
+++ b/lib/Analysis/DxilConstantFolding.cpp
@@ -35,7 +35,7 @@
 #include <algorithm>
 #include <functional>
 
-#include "dxc/HLSL/Dxil.h"
+#include "dxc/HLSL/DXIL.h"
 
 using namespace llvm;
 using namespace hlsl;

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -11,7 +11,7 @@
 
 #include "dxc/HLSL/DxilValidation.h"
 #include "dxc/HLSL/DxilGenerationPass.h"
-#include "dxc/HLSL/DXILOperations.h"
+#include "dxc/HLSL/DxilOperations.h"
 #include "dxc/HLSL/DxilModule.h"
 #include "dxc/HLSL/DxilShaderModel.h"
 #include "dxc/HLSL/DxilContainer.h"

--- a/lib/Transforms/IPO/GlobalDCE.cpp
+++ b/lib/Transforms/IPO/GlobalDCE.cpp
@@ -27,7 +27,7 @@
 #include <unordered_map>
 #include "dxc/HLSL/HLModule.h" // HLSL Change
 #include "dxc/HLSL/DxilModule.h" // HLSL Change
-#include "dxc/HLSL/DXILOperations.h" // HLSL Change
+#include "dxc/HLSL/DxilOperations.h" // HLSL Change
 #include "dxc/HLSL/DxilInstructions.h" // HLSL Change
 using namespace llvm;
 

--- a/tools/clang/unittests/HLSL/FileCheckForTest.cpp
+++ b/tools/clang/unittests/HLSL/FileCheckForTest.cpp
@@ -36,7 +36,7 @@
 #include <vector>
 
 // HLSL Change
-#include <dxc/support/WinIncludes.h>
+#include <dxc/Support/WinIncludes.h>
 #include "llvm/Support/MSFileSystem.h"
 #include "DxcTestUtils.h"
 // End HLSL Change

--- a/tools/dxexp/dxexp.cpp
+++ b/tools/dxexp/dxexp.cpp
@@ -13,7 +13,7 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 
-#include <Windows.h>
+#include <windows.h>
 #include <dxgi1_4.h>
 #include <d3d12.h>
 #include <atlbase.h>

--- a/tools/llvm-pdbdump/llvm-pdbdump.cpp
+++ b/tools/llvm-pdbdump/llvm-pdbdump.cpp
@@ -44,7 +44,7 @@
 #include "llvm/Support/Signals.h"
 
 #if defined(HAVE_DIA_SDK)
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 using namespace llvm;

--- a/tools/llvm-symbolizer/LLVMSymbolize.cpp
+++ b/tools/llvm-symbolizer/LLVMSymbolize.cpp
@@ -31,8 +31,8 @@
 #include <stdlib.h>
 
 #if defined(_MSC_VER)
-#include <Windows.h>
-#include <DbgHelp.h>
+#include <windows.h>
+#include <dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")
 #endif
 

--- a/utils/KillTheDoctor/KillTheDoctor.cpp
+++ b/utils/KillTheDoctor/KillTheDoctor.cpp
@@ -52,9 +52,9 @@
 #include <system_error>
 
 // These includes must be last.
-#include <Windows.h>
-#include <WinError.h>
-#include <Dbghelp.h>
+#include <windows.h>
+#include <winerror.h>
+#include <dbghelp.h>
 #include <psapi.h>
 
 using namespace llvm;


### PR DESCRIPTION
Several #included files were capitalized incorrectly in the case of
files pertaining to the project, or inconsistently in the case of
Windows headers which are typically only relevant where capitalization
doesn't matter. In spite of that, consistent capitalization can be
useful for cross-platform stubbing purposes.

This corrects capitalization of a few Dxil* headers and forces
capitalization of Windows-specific headers to be consistent with
the overwhelming majority of other instances.

No functional change, just cross-platform facilitation