### PR TITLE
Unknown variable in SpanAllocator::Find

### DIFF
--- a/include/dxc/HLSL/DxilSpanAllocator.h
+++ b/include/dxc/HLSL/DxilSpanAllocator.h
@@ -58,7 +58,7 @@ public:
     auto next = m_Spans.lower_bound(Span(nullptr, pos, end));
     if (next == m_Spans.end() || end < next->start)
       return true;  // it fits here
-    return Find(size, result.first, pos, align);
+    return Find(size, next, pos, align);
   }
 
   // allocate element size in first available space, returns false on failure


### PR DESCRIPTION
MSVC is very forgiving of crimes committed in templated functions
and methods of templated classes that never actually get instantiated.
Consequently, the fact that the public variant of Find in SpanAllocator
referenced an unknown variable, seemingly as a copy paste error
was left unnoticed. Other compilers are not so magnanimous.

The call to the private version of Find() takes an iterator as a starting
location to search for a place to put a span of the given size. The
public Find() searches through the known spans to find the one just
past the range requested by the current pos and size. If it reaches
the end, then the span can be placed at the end safely. If it
fits before some other span, overlap needs to be checked. If the
new span would overlap its neighbor, another location is needed.
It makes sense to start looking for that location after the end
of the neighbor whose span you just treaded on. So passing the
next iterator into the private Find() makes sense.