### PR TITLE
[linux-port] Use standard int literal suffixes

### DIFF
--- a/include/dxc/dxcapi.internal.h
+++ b/include/dxc/dxcapi.internal.h
@@ -22,11 +22,11 @@ typedef interface ID3D10Blob ID3D10Blob;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Intrinsic definitions.
-#define AR_QUAL_IN             0x0000000000000010UI64
-#define AR_QUAL_OUT            0x0000000000000020UI64
-#define AR_QUAL_CONST          0x0000000000000200UI64
-#define AR_QUAL_ROWMAJOR       0x0000000000000400UI64
-#define AR_QUAL_COLMAJOR       0x0000000000000800UI64
+#define AR_QUAL_IN             0x0000000000000010ULL
+#define AR_QUAL_OUT            0x0000000000000020ULL
+#define AR_QUAL_CONST          0x0000000000000200ULL
+#define AR_QUAL_ROWMAJOR       0x0000000000000400ULL
+#define AR_QUAL_COLMAJOR       0x0000000000000800ULL
 
 #define AR_QUAL_IN_OUT (AR_QUAL_IN | AR_QUAL_OUT)
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4006,7 +4006,7 @@ public:
   /// <param name="RHS">Right hand side.</param>
   /// <param name="QuestionLoc">Location of question mark in operator.</param>
   /// <returns>Result type of vector conditional expression.</returns>
-  clang::QualType HLSLExternalSource::CheckVectorConditional(
+  clang::QualType CheckVectorConditional(
     _In_ ExprResult &Cond,
     _In_ ExprResult &LHS,
     _In_ ExprResult &RHS,
@@ -6163,7 +6163,7 @@ UINT64 HLSLExternalSource::ScoreCast(QualType pLType, QualType pRType)
   }
 
 #define SCORE_COND(shift, cond) { \
-  if (cond) uScore += 1UI64 << (SCORE_MIN_SHIFT + SCORE_PARAM_SHIFT * shift); }
+  if (cond) uScore += 1ULL << (SCORE_MIN_SHIFT + SCORE_PARAM_SHIFT * shift); }
   SCORE_COND(0, uRSize < uLSize);
   SCORE_COND(1, bLPromo);
   SCORE_COND(2, bRPromo);


### PR DESCRIPTION
Replaces -i64 suffixes with -LL which are said to be equivalent by
MSDN. Both should result in 64 bit behavior.

Additionally, I dropped a superfluous repetition of the class name
on the inlined CheckVectorConditional method of HLSLExternalSource. 
By all rights, it should be its own change, but it gets lonely so it came
along for the ride. The repeated class name made some compilers
unhappy and losing it doesn't bother anyone.