### PR TITLE
[linux-port] Fix template ambiguities

### DIFF
--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -925,8 +925,8 @@ void DxilModule::LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S) {
 template <typename TResource>
 static void RemoveResources(std::vector<std::unique_ptr<TResource>> &vec,
                     std::unordered_set<unsigned> &immResID) {
-  for (std::vector<std::unique_ptr<TResource>>::iterator p = vec.begin(); p != vec.end();) {
-    std::vector<std::unique_ptr<TResource>>::iterator c = p++;
+  for (auto p = vec.begin(); p != vec.end();) {
+    auto c = p++;
     if (immResID.count((*c)->GetID()) == 0) {
       p = vec.erase(c);
     }

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3628,7 +3628,7 @@ static void ValidateSignature(ValidationContext &ValCtx, const DxilSignature &S,
 
     // Semantic index overlap check, keyed by name.
     std::string nameUpper(E->GetName());
-    std::transform(nameUpper.begin(), nameUpper.end(), nameUpper.begin(), toupper);
+    std::transform(nameUpper.begin(), nameUpper.end(), nameUpper.begin(), ::toupper);
     unordered_set<unsigned> &semIdxSet = semanticIndexMap[streamId][nameUpper];
     for (unsigned semIdx : E->GetSemanticIndexVec()) {
       if (semIdxSet.count(semIdx) > 0) {


### PR DESCRIPTION
Templated iterators often have a dependent scope, which annoys
some compilers because they can't tell if the typename evaluates
to a type or a variable name. This adds typename keywords to
remove the ambiguity in removeResources.

Additionally, the std toupper function can't be found for the sake
of the templated call to std::transform in ValidateSignature
function. By adding :: to clarify it, the template can be evaluated.