### PR TITLE
[linux-port] Resolve ternary type ambiguities

### DIFF
--- a/lib/Transforms/IPO/Inliner.cpp
+++ b/lib/Transforms/IPO/Inliner.cpp
@@ -83,7 +83,7 @@ Inliner::Inliner(char &ID)
 
 Inliner::Inliner(char &ID, int Threshold, bool InsertLifetime)
   : CallGraphSCCPass(ID), InlineThreshold(InlineLimit.getNumOccurrences() > 0 ?
-                                          InlineLimit : Threshold),
+                                          unsigned(InlineLimit) : Threshold),
     InsertLifetime(InsertLifetime) {}
 
 /// For this class, we declare that we require and preserve the call graph.

--- a/lib/Transforms/Scalar/LoopUnrollPass.cpp
+++ b/lib/Transforms/Scalar/LoopUnrollPass.cpp
@@ -101,13 +101,13 @@ namespace {
   public:
     static char ID; // Pass ID, replacement for typeid
     LoopUnroll(int T = -1, int C = -1, int P = -1, int R = -1) : LoopPass(ID) {
-      CurrentThreshold = (T == -1) ? UnrollThreshold : unsigned(T);
+      CurrentThreshold = (T == -1) ? unsigned(UnrollThreshold) : unsigned(T);
       CurrentPercentDynamicCostSavedThreshold =
           UnrollPercentDynamicCostSavedThreshold;
       CurrentDynamicCostSavingsDiscount = UnrollDynamicCostSavingsDiscount;
-      CurrentCount = (C == -1) ? UnrollCount : unsigned(C);
-      CurrentAllowPartial = (P == -1) ? UnrollAllowPartial : (bool)P;
-      CurrentRuntime = (R == -1) ? UnrollRuntime : (bool)R;
+      CurrentCount = (C == -1) ? unsigned(UnrollCount) : unsigned(C);
+      CurrentAllowPartial = (P == -1) ? (bool)UnrollAllowPartial : (bool)P;
+      CurrentRuntime = (R == -1) ? (bool)UnrollRuntime : (bool)R;
 
       UserThreshold = (T != -1) || (UnrollThreshold.getNumOccurrences() > 0);
       UserPercentDynamicCostSavedThreshold =


### PR DESCRIPTION
A few ternary operators took different types in the second and
third position, which some compilers refuse to resolve. By casting
the third operand to the type of the assigned variable and make
it match the second operand.