### PR TITLE
[linux-port] avoid initialization-crossing gotos

### DIFF
--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -83,6 +83,8 @@ void RootSignatureTokenizer::ReadNextToken(uint32_t BufferIdx)
     char *pBuffer = m_TokenStrings[BufferIdx];
     Token &T = m_Tokens[BufferIdx];
     bool bFloat = false;
+    bool bKW = false;
+    char c = 0;
 
     EatSpace();
 
@@ -185,7 +187,7 @@ void RootSignatureTokenizer::ReadNextToken(uint32_t BufferIdx)
     //
     // Classify token
     //
-    char c = pBuffer[0];
+    c = pBuffer[0];
 
     // Delimiters
     switch(c)
@@ -245,7 +247,6 @@ void RootSignatureTokenizer::ReadNextToken(uint32_t BufferIdx)
     // Keyword
 #define KW(__name)  ToKeyword(pBuffer, T, #__name, Token::Type::__name)
 
-    bool bKW = false;
     // Case-incensitive
     switch(toupper(c))
     {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -7262,6 +7262,9 @@ bool HLSLExternalSource::CanConvert(
   _Out_opt_ TYPE_CONVERSION_REMARKS* remarks,
   _Inout_opt_ StandardConversionSequence* standard)
 {
+  bool bCheckElt = false;
+  UINT uTSize, uSSize;
+
   DXASSERT_NOMSG(sourceExpr != nullptr);
   DXASSERT_NOMSG(!target.isNull());
 
@@ -7320,8 +7323,8 @@ bool HLSLExternalSource::CanConvert(
   CollectInfo(target, &TargetInfo);
   CollectInfo(source, &SourceInfo);
 
-  UINT uTSize = TargetInfo.uTotalElts;
-  UINT uSSize = SourceInfo.uTotalElts;
+  uTSize = TargetInfo.uTotalElts;
+  uSSize = SourceInfo.uTotalElts;
 
   // TODO: TYPE_CONVERSION_BY_REFERENCE does not seem possible here
   // are we missing cases?
@@ -7440,7 +7443,6 @@ bool HLSLExternalSource::CanConvert(
   // 5. The result of a matrix and a vector is similar to #4.
   //
 
-  bool bCheckElt = false;
 
   switch (TargetInfo.ShapeKind) {
   case AR_TOBJ_BASIC:


### PR DESCRIPTION
There are a few error-handling goto operators that cross
initialization of variables involved in the standard correct
operation. This introduces the risk of undefined behavior should
the code at the label jumped to use those uninitialized variables.