### PR TITLE
[spirv] File names are case sensitive.

### DIFF
--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -12,7 +12,7 @@
 #include <algorithm>
 #include <sstream>
 
-#include "SpirvTestOptions.h"
+#include "SPIRVTestOptions.h"
 #include "gtest/gtest.h"
 
 namespace clang {


### PR DESCRIPTION
Fixes Linux compiler error.