### PR TITLE
Change llvm.dbg.contents into dx.source.contents.

### DIFF
--- a/include/dxc/HLSL/DxilMetadataHelper.h
+++ b/include/dxc/HLSL/DxilMetadataHelper.h
@@ -81,6 +81,12 @@ public:
   // ViewId state.
   static const char kDxilViewIdStateMDName[];
 
+  // Source info.
+  static const char kDxilSourceContentsMDName[];
+  static const char kDxilSourceDefinesMDName[];
+  static const char kDxilSourceMainFileNameMDName[];
+  static const char kDxilSourceArgsMDName[];
+
   // Function props.
   static const char kDxilFunctionPropertiesMDName[];
   static const char kDxilEntrySignaturesMDName[];

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -159,6 +159,8 @@ MainArgs::MainArgs(llvm::ArrayRef<llvm::StringRef> args) {
 MainArgs& MainArgs::operator=(const MainArgs &other) {
   Utf8StringVector.clear();
   Utf8CharPtrVector.clear();
+  Utf8StringVector.reserve(other.Utf8StringVector.size());
+  Utf8CharPtrVector.reserve(other.Utf8StringVector.size());
   for (const std::string &str : other.Utf8StringVector) {
     Utf8StringVector.emplace_back(str);
     Utf8CharPtrVector.push_back(Utf8StringVector.back().data());

--- a/lib/HLSL/DxilMetadataHelper.cpp
+++ b/lib/HLSL/DxilMetadataHelper.cpp
@@ -57,7 +57,12 @@ const char DxilMDHelper::kDxilViewIdStateMDName[]                     = "dx.view
 const char DxilMDHelper::kDxilFunctionPropertiesMDName[]              = "dx.func.props";
 const char DxilMDHelper::kDxilEntrySignaturesMDName[]                 = "dx.func.signatures";
 
-static std::array<const char *, 7> DxilMDNames = {
+const char DxilMDHelper::kDxilSourceContentsMDName[]                  = "dx.source.contents";
+const char DxilMDHelper::kDxilSourceDefinesMDName[]                   = "dx.source.defines";
+const char DxilMDHelper::kDxilSourceMainFileNameMDName[]              = "dx.source.mainFileName";
+const char DxilMDHelper::kDxilSourceArgsMDName[]                      = "dx.source.args";
+
+static std::array<const char *, 11> DxilMDNames = {
   DxilMDHelper::kDxilVersionMDName,
   DxilMDHelper::kDxilShaderModelMDName,
   DxilMDHelper::kDxilEntryPointsMDName,
@@ -65,6 +70,10 @@ static std::array<const char *, 7> DxilMDNames = {
   DxilMDHelper::kDxilTypeSystemMDName,
   DxilMDHelper::kDxilValidatorVersionMDName,
   DxilMDHelper::kDxilViewIdStateMDName,
+  DxilMDHelper::kDxilSourceContentsMDName,
+  DxilMDHelper::kDxilSourceDefinesMDName,
+  DxilMDHelper::kDxilSourceMainFileNameMDName,
+  DxilMDHelper::kDxilSourceArgsMDName,
 };
 
 DxilMDHelper::DxilMDHelper(Module *pModule, std::unique_ptr<ExtraPropertyHelper> EPH)

--- a/lib/HLSL/DxilMetadataHelper.cpp
+++ b/lib/HLSL/DxilMetadataHelper.cpp
@@ -62,7 +62,7 @@ const char DxilMDHelper::kDxilSourceDefinesMDName[]                   = "dx.sour
 const char DxilMDHelper::kDxilSourceMainFileNameMDName[]              = "dx.source.mainFileName";
 const char DxilMDHelper::kDxilSourceArgsMDName[]                      = "dx.source.args";
 
-static std::array<const char *, 11> DxilMDNames = {
+static std::array<const char *, 7> DxilMDNames = {
   DxilMDHelper::kDxilVersionMDName,
   DxilMDHelper::kDxilShaderModelMDName,
   DxilMDHelper::kDxilEntryPointsMDName,
@@ -70,10 +70,6 @@ static std::array<const char *, 11> DxilMDNames = {
   DxilMDHelper::kDxilTypeSystemMDName,
   DxilMDHelper::kDxilValidatorVersionMDName,
   DxilMDHelper::kDxilViewIdStateMDName,
-  DxilMDHelper::kDxilSourceContentsMDName,
-  DxilMDHelper::kDxilSourceDefinesMDName,
-  DxilMDHelper::kDxilSourceMainFileNameMDName,
-  DxilMDHelper::kDxilSourceArgsMDName,
 };
 
 DxilMDHelper::DxilMDHelper(Module *pModule, std::unique_ptr<ExtraPropertyHelper> EPH)

--- a/lib/HLSL/DxilModule.cpp
+++ b/lib/HLSL/DxilModule.cpp
@@ -1681,6 +1681,23 @@ void DxilModule::StripDebugRelatedCode() {
       }
     }
   }
+  // Remove dx.source metadata.
+  if (NamedMDNode *contents = m_pModule->getNamedMetadata(
+          DxilMDHelper::kDxilSourceContentsMDName)) {
+    contents->eraseFromParent();
+  }
+  if (NamedMDNode *defines =
+          m_pModule->getNamedMetadata(DxilMDHelper::kDxilSourceDefinesMDName)) {
+    defines->eraseFromParent();
+  }
+  if (NamedMDNode *mainFileName = m_pModule->getNamedMetadata(
+          DxilMDHelper::kDxilSourceMainFileNameMDName)) {
+    mainFileName->eraseFromParent();
+  }
+  if (NamedMDNode *arguments =
+          m_pModule->getNamedMetadata(DxilMDHelper::kDxilSourceArgsMDName)) {
+    arguments->eraseFromParent();
+  }
 }
 DebugInfoFinder &DxilModule::GetOrCreateDebugInfoFinder() {
   if (m_pDebugInfoFinder == nullptr) {

--- a/tools/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/tools/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -25,6 +25,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include <memory>
+#include "dxc/HLSL/DxilMetadataHelper.h" // HLSL Change - dx source info
 using namespace clang;
 
 namespace {
@@ -222,7 +223,8 @@ namespace {
              it != end; ++it) {
           if (it->first->isValid() && !it->second->IsSystemFile) {
             if (pContents == nullptr) {
-              pContents = M->getOrInsertNamedMetadata("llvm.dbg.contents");
+              pContents = M->getOrInsertNamedMetadata(
+                  hlsl::DxilMDHelper::kDxilSourceContentsMDName);
             }
             llvm::MDTuple *pFileInfo = llvm::MDNode::get(
                 LLVMCtx,
@@ -234,7 +236,8 @@ namespace {
         }
 
         // Add Defines to Debug Info
-        llvm::NamedMDNode *pDefines = M->getOrInsertNamedMetadata("llvm.dbg.defines");
+        llvm::NamedMDNode *pDefines = M->getOrInsertNamedMetadata(
+            hlsl::DxilMDHelper::kDxilSourceDefinesMDName);
         std::vector<llvm::Metadata *> vecDefines;
         vecDefines.resize(CodeGenOpts.HLSLDefines.size());
         std::transform(CodeGenOpts.HLSLDefines.begin(), CodeGenOpts.HLSLDefines.end(),
@@ -243,13 +246,15 @@ namespace {
         pDefines->addOperand(pDefinesInfo);
 
         // Add main file name to debug info
-        llvm::NamedMDNode *pSourceFilename = M->getOrInsertNamedMetadata("llvm.dbg.mainFileName");
+        llvm::NamedMDNode *pSourceFilename = M->getOrInsertNamedMetadata(
+            hlsl::DxilMDHelper::kDxilSourceMainFileNameMDName);
         llvm::MDTuple *pFileName = llvm::MDNode::get(
           LLVMCtx, llvm::MDString::get(LLVMCtx, CodeGenOpts.MainFileName));
         pSourceFilename->addOperand(pFileName);
 
         // Pass in any other arguments to debug info
-        llvm::NamedMDNode *pArgs = M->getOrInsertNamedMetadata("llvm.dbg.args");
+        llvm::NamedMDNode *pArgs = M->getOrInsertNamedMetadata(
+            hlsl::DxilMDHelper::kDxilSourceArgsMDName);
         std::vector<llvm::Metadata *> vecArguments;
         vecArguments.resize(CodeGenOpts.HLSLArguments.size());
         std::transform(CodeGenOpts.HLSLArguments.begin(), CodeGenOpts.HLSLArguments.end(),

--- a/tools/clang/test/CodeGenHLSL/share_mem_dbg.hlsl
+++ b/tools/clang/test/CodeGenHLSL/share_mem_dbg.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -Zi -Od %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -Zi -Od -DDefineA -DDefineB=0 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: groupId
@@ -6,12 +6,25 @@
 // CHECK: flattenedThreadIdInGroup
 // CHECK: addrspace(3)
 
+// Make sure source info exist.
+// CHECK: !dx.source.contents
+// CHECK: !dx.source.defines
+// CHECK: !dx.source.mainFileName
+// CHECK: !dx.source.args
+
 // CHECK: DIGlobalVariable(name: "dataC.1.0"
 // CHECK: DIDerivedType(tag: DW_TAG_member, name: ".1.0"
 // CHECK: DIGlobalVariable(name: "dataC.1.1"
 // CHECK: DIDerivedType(tag: DW_TAG_member, name: ".1.1"
 // CHECK: DIGlobalVariable(name: "dataC.0
 // CHECK: DIDerivedType(tag: DW_TAG_member, name: ".0"
+
+// Make sure source info contents exist.
+// CHECK: share_mem_dbg.hlsl", !"// RUN: %dxc
+// CHECK: !{!"DefineA=1", !"DefineB=0"}
+// CHECK: share_mem_dbg.hlsl"}
+// CHECK: !{!"-E", !"main", !"-T", !"cs_6_0", !"-Zi", !"-Od", !"-D", !"DefineA", !"-D", !"DefineB=0"}
+
 
 struct S {
   column_major float2x2 d;

--- a/tools/clang/tools/dxcompiler/dxcdia.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdia.cpp
@@ -23,6 +23,7 @@
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/HLSL/DxilContainer.h"
 #include "dxc/HLSL/DxilShaderModel.h"
+#include "dxc/HLSL/DxilMetadataHelper.h"
 #include "dxc/HLSL/DxilModule.h"
 #include "dxc/HLSL/DxilUtil.h"
 #include "dxc/Support/Global.h"
@@ -175,10 +176,14 @@ public:
     m_dxilModule->LoadDxilMetadata();
 
     // Get file contents.
-    m_contents = m_module->getNamedMetadata("llvm.dbg.contents");
-    m_defines = m_module->getNamedMetadata("llvm.dbg.defines");
-    m_mainFileName = m_module->getNamedMetadata("llvm.dbg.mainFileName");
-    m_arguments = m_module->getNamedMetadata("llvm.dbg.args");
+    m_contents =
+        m_module->getNamedMetadata(DxilMDHelper::kDxilSourceContentsMDName);
+    m_defines =
+        m_module->getNamedMetadata(DxilMDHelper::kDxilSourceDefinesMDName);
+    m_mainFileName =
+        m_module->getNamedMetadata(DxilMDHelper::kDxilSourceMainFileNameMDName);
+    m_arguments =
+        m_module->getNamedMetadata(DxilMDHelper::kDxilSourceArgsMDName);
     // Build up a linear list of instructions. The index will be used as the
     // RVA. Debug instructions are ommitted from this enumeration.
     for (const Function &fn : m_module->functions()) {

--- a/tools/clang/tools/dxcompiler/dxcdia.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdia.cpp
@@ -178,12 +178,24 @@ public:
     // Get file contents.
     m_contents =
         m_module->getNamedMetadata(DxilMDHelper::kDxilSourceContentsMDName);
+    if (!m_contents)
+      m_contents = m_module->getNamedMetadata("llvm.dbg.contents");
+
     m_defines =
         m_module->getNamedMetadata(DxilMDHelper::kDxilSourceDefinesMDName);
+    if (!m_defines)
+      m_defines = m_module->getNamedMetadata("llvm.dbg.defines");
+
     m_mainFileName =
         m_module->getNamedMetadata(DxilMDHelper::kDxilSourceMainFileNameMDName);
+    if (!m_mainFileName)
+      m_mainFileName = m_module->getNamedMetadata("llvm.dbg.mainFileName");
+
     m_arguments =
         m_module->getNamedMetadata(DxilMDHelper::kDxilSourceArgsMDName);
+    if (!m_arguments)
+      m_arguments = m_module->getNamedMetadata("llvm.dbg.args");
+
     // Build up a linear list of instructions. The index will be used as the
     // RVA. Debug instructions are ommitted from this enumeration.
     for (const Function &fn : m_module->functions()) {

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -285,7 +285,12 @@ void PrintDxilSignature(LPCSTR pName, const DxilSignature &Signature,
     OS << comment << " ";
 
     OS << left_justify(sigElt->GetName(), 20);
-    OS << ' ' << format("%5u", sigElt->GetSemanticIndexVec()[0]);
+    auto &indexVec = sigElt->GetSemanticIndexVec();
+    unsigned index = 0;
+    if (!indexVec.empty()) {
+      index = sigElt->GetSemanticIndexVec()[0];
+    }
+    OS << ' ' << format("%5u", index);
     sigElt->GetInterpolationMode()->GetName();
     OS << ' ' << right_justify(sigElt->GetInterpolationMode()->GetName(), 22);
     OS << "   ";


### PR DESCRIPTION
1. Change llvm.dbg.contents into dx.source.contents.
2. Fix crash when SemanticIndexVec is empty.
3. Fix case Utf8StringVector is reallocated in MainArgs::operator=(const MainArgs &other).