### PR TITLE
[spirv] Support ViewportIndex & Layer in VS and DS

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -37,6 +37,7 @@ enum class Extension {
   EXT_descriptor_indexing,
   EXT_fragment_fully_covered,
   EXT_shader_stencil_export,
+  EXT_shader_viewport_index_layer,
   AMD_gpu_shader_half_float,
   AMD_shader_explicit_vertex_parameter,
   GOOGLE_hlsl_functionality1,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2168,15 +2168,22 @@ uint32_t DeclResultIdMapper::createSpirvStageVar(StageVar *stageVar,
   case hlsl::Semantic::Kind::RenderTargetArrayIndex: {
     switch (sigPointKind) {
     case hlsl::SigPoint::Kind::VSIn:
-    case hlsl::SigPoint::Kind::VSOut:
     case hlsl::SigPoint::Kind::HSCPIn:
     case hlsl::SigPoint::Kind::HSCPOut:
     case hlsl::SigPoint::Kind::PCOut:
     case hlsl::SigPoint::Kind::DSIn:
     case hlsl::SigPoint::Kind::DSCPIn:
-    case hlsl::SigPoint::Kind::DSOut:
     case hlsl::SigPoint::Kind::GSVIn:
       return theBuilder.addStageIOVar(type, sc, name.str());
+    case hlsl::SigPoint::Kind::VSOut:
+    case hlsl::SigPoint::Kind::DSOut:
+      theBuilder.addExtension(Extension::EXT_shader_viewport_index_layer,
+                              "SV_RenderTargetArrayIndex", srcLoc);
+      theBuilder.requireCapability(
+          spv::Capability::ShaderViewportIndexLayerEXT);
+
+      stageVar->setIsSpirvBuiltin();
+      return theBuilder.addStageBuiltinVar(type, sc, BuiltIn::Layer);
     case hlsl::SigPoint::Kind::GSOut:
     case hlsl::SigPoint::Kind::PSIn:
       theBuilder.requireCapability(spv::Capability::Geometry);
@@ -2194,15 +2201,22 @@ uint32_t DeclResultIdMapper::createSpirvStageVar(StageVar *stageVar,
   case hlsl::Semantic::Kind::ViewPortArrayIndex: {
     switch (sigPointKind) {
     case hlsl::SigPoint::Kind::VSIn:
-    case hlsl::SigPoint::Kind::VSOut:
     case hlsl::SigPoint::Kind::HSCPIn:
     case hlsl::SigPoint::Kind::HSCPOut:
     case hlsl::SigPoint::Kind::PCOut:
     case hlsl::SigPoint::Kind::DSIn:
     case hlsl::SigPoint::Kind::DSCPIn:
-    case hlsl::SigPoint::Kind::DSOut:
     case hlsl::SigPoint::Kind::GSVIn:
       return theBuilder.addStageIOVar(type, sc, name.str());
+    case hlsl::SigPoint::Kind::VSOut:
+    case hlsl::SigPoint::Kind::DSOut:
+      theBuilder.addExtension(Extension::EXT_shader_viewport_index_layer,
+                              "SV_ViewPortArrayIndex", srcLoc);
+      theBuilder.requireCapability(
+          spv::Capability::ShaderViewportIndexLayerEXT);
+
+      stageVar->setIsSpirvBuiltin();
+      return theBuilder.addStageBuiltinVar(type, sc, BuiltIn::ViewportIndex);
     case hlsl::SigPoint::Kind::GSOut:
     case hlsl::SigPoint::Kind::PSIn:
       theBuilder.requireCapability(spv::Capability::MultiViewport);

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -100,12 +100,13 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_KHR_multiview", Extension::KHR_multiview)
       .Case("SPV_KHR_shader_draw_parameters",
             Extension::KHR_shader_draw_parameters)
-      .Case("SPV_EXT_descriptor_indexing",
-            Extension::EXT_descriptor_indexing)
+      .Case("SPV_EXT_descriptor_indexing", Extension::EXT_descriptor_indexing)
       .Case("SPV_EXT_fragment_fully_covered",
             Extension::EXT_fragment_fully_covered)
       .Case("SPV_EXT_shader_stencil_export",
             Extension::EXT_shader_stencil_export)
+      .Case("SPV_EXT_shader_viewport_index_layer",
+            Extension::EXT_shader_viewport_index_layer)
       .Case("SPV_AMD_gpu_shader_half_float",
             Extension::AMD_gpu_shader_half_float)
       .Case("SPV_AMD_shader_explicit_vertex_parameter",
@@ -133,6 +134,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_EXT_fragment_fully_covered";
   case Extension::EXT_shader_stencil_export:
     return "SPV_EXT_shader_stencil_export";
+  case Extension::EXT_shader_viewport_index_layer:
+    return "SPV_EXT_shader_viewport_index_layer";
   case Extension::AMD_gpu_shader_half_float:
     return "SPV_AMD_gpu_shader_half_float";
   case Extension::AMD_shader_explicit_vertex_parameter:

--- a/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index.ds.hlsl
@@ -17,19 +17,21 @@ struct DsCpOut {
   uint   index              : SV_RenderTargetArrayIndex;
 };
 
+// CHECK:      OpCapability ShaderViewportIndexLayerEXT
+// CHECK:      OpExtension "SPV_EXT_shader_viewport_index_layer"
+
 // CHECK:      OpEntryPoint TessellationEvaluation %main "main"
 // CHECK-SAME: %in_var_SV_RenderTargetArrayIndex
 // CHECK-SAME: %in_var_SV_RenderTargetArrayIndex_0
-// CHECK-SAME: %out_var_SV_RenderTargetArrayIndex
+// CHECK-SAME: %gl_Layer
 
-
+// CHECK:      OpDecorate %gl_Layer BuiltIn Layer
 // CHECK:      OpDecorate %in_var_SV_RenderTargetArrayIndex Location 0
 // CHECK:      OpDecorate %in_var_SV_RenderTargetArrayIndex_0 Location 1
-// CHECK:      OpDecorate %out_var_SV_RenderTargetArrayIndex Location 0
 
 // CHECK:      %in_var_SV_RenderTargetArrayIndex = OpVariable %_ptr_Input__arr_uint_uint_3 Input
 // CHECK:      %in_var_SV_RenderTargetArrayIndex_0 = OpVariable %_ptr_Input_uint Input
-// CHECK:      %out_var_SV_RenderTargetArrayIndex = OpVariable %_ptr_Output_uint Output
+// CHECK:      %gl_Layer = OpVariable %_ptr_Output_uint Output
 
 [domain("quad")]
 DsCpOut main(OutputPatch<DsCpIn, 3> patch, HsPcfOut pcfData) {

--- a/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index.vs.hlsl
@@ -1,14 +1,17 @@
 // Run: %dxc -T vs_6_0 -E main
 
+// CHECK:      OpCapability ShaderViewportIndexLayerEXT
+// CHECK:      OpExtension "SPV_EXT_shader_viewport_index_layer"
+
 // CHECK:      OpEntryPoint Vertex %main "main"
 // CHECK-SAME: %in_var_SV_RenderTargetArrayIndex
-// CHECK-SMAE: %out_var_SV_RenderTargetArrayIndex
+// CHECK-SMAE: %gl_Layer
 
+// CHECK:      OpDecorate %gl_Layer BuiltIn Layer
 // CHECK:      OpDecorate %in_var_SV_RenderTargetArrayIndex Location 0
-// CHECK:      OpDecorate %out_var_SV_RenderTargetArrayIndex Location 0
 
 // CHECK:      %in_var_SV_RenderTargetArrayIndex = OpVariable %_ptr_Input_uint Input
-// CHECK:      %out_var_SV_RenderTargetArrayIndex = OpVariable %_ptr_Output_uint Output
+// CHECK:      %gl_Layer = OpVariable %_ptr_Output_uint Output
 
 uint main(uint input: SV_RenderTargetArrayIndex) : SV_RenderTargetArrayIndex {
     return input;

--- a/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.ds.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.ds.hlsl
@@ -20,16 +20,15 @@ struct DsCpOut {
 // CHECK:      OpEntryPoint TessellationEvaluation %main "main"
 // CHECK-SAME: %in_var_SV_ViewportArrayIndex
 // CHECK-SAME: %in_var_SV_ViewportArrayIndex_0
-// CHECK-SAME: %out_var_SV_ViewportArrayIndex
+// CHECK-SAME: %gl_ViewportIndex
 
-
+// CHECK:      OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
 // CHECK:      OpDecorate %in_var_SV_ViewportArrayIndex Location 0
 // CHECK:      OpDecorate %in_var_SV_ViewportArrayIndex_0 Location 1
-// CHECK:      OpDecorate %out_var_SV_ViewportArrayIndex Location 0
 
 // CHECK:      %in_var_SV_ViewportArrayIndex = OpVariable %_ptr_Input__arr_uint_uint_3 Input
 // CHECK:      %in_var_SV_ViewportArrayIndex_0 = OpVariable %_ptr_Input_uint Input
-// CHECK:      %out_var_SV_ViewportArrayIndex = OpVariable %_ptr_Output_uint Output
+// CHECK:      %gl_ViewportIndex = OpVariable %_ptr_Output_uint Output
 
 [domain("quad")]
 DsCpOut main(OutputPatch<DsCpIn, 3> patch, HsPcfOut pcfData) {

--- a/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.vs.hlsl
@@ -1,14 +1,17 @@
 // Run: %dxc -T vs_6_0 -E main
 
+// CHECK:      OpCapability ShaderViewportIndexLayerEXT
+// CHECK:      OpExtension "SPV_EXT_shader_viewport_index_layer"
+
 // CHECK:      OpEntryPoint Vertex %main "main"
 // CHECK-SAME: %in_var_SV_ViewportArrayIndex
-// CHECK-SMAE: %out_var_SV_ViewportArrayIndex
+// CHECK-SMAE: %gl_ViewportIndex
 
+// CHECK:      OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
 // CHECK:      OpDecorate %in_var_SV_ViewportArrayIndex Location 0
-// CHECK:      OpDecorate %out_var_SV_ViewportArrayIndex Location 0
 
 // CHECK:      %in_var_SV_ViewportArrayIndex = OpVariable %_ptr_Input_uint Input
-// CHECK:      %out_var_SV_ViewportArrayIndex = OpVariable %_ptr_Output_uint Output
+// CHECK:      %gl_ViewportIndex = OpVariable %_ptr_Output_uint Output
 
 uint main(uint input: SV_ViewportArrayIndex) : SV_ViewportArrayIndex {
     return input;


### PR DESCRIPTION
Using SV_RenderTargetArrayIndex (translated into Layer builtin)
and SV_ViewportArrayIndex (translated into ViewportIndex builtin)
in VS and DS output requires the SPV_EXT_shader_viewport_index_layer
extension.