### PR TITLE
[spirv] Avoid creating temporary variables for local variables

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.hlsl
@@ -11,36 +11,18 @@ float fnInOut(uniform float a, in float b, out float c, inout float d, inout Pix
 }
 
 float main(float val: A) : B {
-// CHECK-LABEL: %src_main = OpFunction
     float m, n;
     Pixel p;
 
 // CHECK:      %param_var_a = OpVariable %_ptr_Function_float Function
 // CHECK-NEXT: %param_var_b = OpVariable %_ptr_Function_float Function
-// CHECK-NEXT: %param_var_c = OpVariable %_ptr_Function_float Function
-// CHECK-NEXT: %param_var_d = OpVariable %_ptr_Function_float Function
-// CHECK-NEXT: %param_var_e = OpVariable %_ptr_Function_Pixel Function
 
 // CHECK-NEXT:                OpStore %param_var_a %float_5
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %float %val
 // CHECK-NEXT:                OpStore %param_var_b [[val]]
-// CHECK-NEXT:   [[m:%\d+]] = OpLoad %float %m
-// CHECK-NEXT:                OpStore %param_var_c [[m]]
-// CHECK-NEXT:   [[n:%\d+]] = OpLoad %float %n
-// CHECK-NEXT:                OpStore %param_var_d [[n]]
-// CHECK-NEXT:   [[p:%\d+]] = OpLoad %Pixel %p
-// CHECK-NEXT:                OpStore %param_var_e [[p]]
 
-// CHECK-NEXT: [[ret:%\d+]] = OpFunctionCall %float %fnInOut %param_var_a %param_var_b %param_var_c %param_var_d
-
-// CHECK-NEXT:   [[c:%\d+]] = OpLoad %float %param_var_c
-// CHECK-NEXT:                OpStore %m [[c]]
-// CHECK-NEXT:   [[d:%\d+]] = OpLoad %float %param_var_d
-// CHECK-NEXT:                OpStore %n [[d]]
-// CHECK-NEXT:   [[e:%\d+]] = OpLoad %Pixel %param_var_e
-// CHECK-NEXT:                OpStore %p [[e]]
+// CHECK-NEXT: [[ret:%\d+]] = OpFunctionCall %float %fnInOut %param_var_a %param_var_b %m %n %p
 
 // CHECK-NEXT:                OpReturnValue [[ret]]
     return fnInOut(5., val, m, n, p);
-// CHECK-NEXT: OpFunctionEnd
 }

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.no-copy.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.no-copy.hlsl
@@ -1,0 +1,37 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct S {
+    float4 val;
+};
+
+void foo(
+    out   int      a,
+    inout uint2    b,
+    out   float2x3 c,
+    inout S        d,
+    out   float    e[4]
+) {
+    a = 0;
+    b = 1;
+    c = 2.0;
+    d.val = 3.0;
+    e[0] = 4.0;
+}
+
+void main() {
+    int      a;
+    uint2    b;
+    float2x3 c;
+    S        d;
+    float    e[4];
+
+// CHECK: %a = OpVariable %_ptr_Function_int Function
+// CHECK: %b = OpVariable %_ptr_Function_v2uint Function
+// CHECK: %c = OpVariable %_ptr_Function_mat2v3float Function
+// CHECK: %d = OpVariable %_ptr_Function_S Function
+// CHECK: %e = OpVariable %_ptr_Function__arr_float_uint_4 Function
+
+// CHECK:      OpFunctionCall %void %foo %a %b %c %d %e
+
+    foo(a, b, c, d, e);
+}

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
@@ -18,9 +18,7 @@ float4 main() : C {
 
     float4 val;
 // CHECK:    [[z_ptr:%\d+]] = OpAccessChain %_ptr_Function_float %val %int_2
-// CHECK:          {{%\d+}} = OpFunctionCall %void %bar %param_var_x %param_var_y %param_var_z %param_var_w
-// CHECK-NEXT:   [[x:%\d+]] = OpLoad %v4float %param_var_x
-// CHECK-NEXT:                OpStore %val [[x]]
+// CHECK:          {{%\d+}} = OpFunctionCall %void %bar %val %param_var_y %param_var_z %param_var_w
 // CHECK-NEXT:   [[y:%\d+]] = OpLoad %v3float %param_var_y
 // CHECK-NEXT: [[old:%\d+]] = OpLoad %v4float %val
     // Write to val.zwx:

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -435,12 +435,20 @@ TEST_F(FileTest, ControlFlowConditionalOp) { runFileTest("cf.cond-op.hlsl"); }
 // For functions
 TEST_F(FileTest, FunctionCall) { runFileTest("fn.call.hlsl"); }
 TEST_F(FileTest, FunctionDefaultArg) { runFileTest("fn.default-arg.hlsl"); }
-TEST_F(FileTest, FunctionInOutParam) { runFileTest("fn.param.inout.hlsl"); }
+TEST_F(FileTest, FunctionInOutParam) {
+  // Tests using uniform/in/out/inout annotations on function parameters
+  runFileTest("fn.param.inout.hlsl");
+}
 TEST_F(FileTest, FunctionInOutParamVector) {
   runFileTest("fn.param.inout.vector.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamDiffStorageClass) {
   runFileTest("fn.param.inout.storage-class.hlsl");
+}
+TEST_F(FileTest, FunctionInOutParamNoNeedToCopy) {
+  // Tests that referencing function scope variables as a whole with out/inout
+  // annotation does not create temporary variables
+  runFileTest("fn.param.inout.no-copy.hlsl");
 }
 TEST_F(FileTest, FunctionFowardDeclaration) {
   runFileTest("fn.foward-declaration.hlsl");


### PR DESCRIPTION
When calling functions with arguments that references local
variables as a whole and annotated with out/inout, we don't
need to create temporary variables for them again. Just pass
the pointers to the original local variables.