### PR TITLE
[appveyor] Disable CompileWhenNoMemThenOOM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,12 @@ option(HLSL_ENABLE_FIXED_VER "Sets up fixed version information." OFF) # HLSL Ch
 option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) # HLSL Change
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
 
+# HLSL Change Starts - set flag for Appveyor CI
+if ( $ENV{CI} AND $ENV{APPVEYOR} )
+  set(DXC_ON_APPVEYOR_CI ON)
+endif()
+# HLSL Change ends
+
 # SPIRV change starts
 option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." OFF)
 option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default buil
 
 # HLSL Change Starts - set flag for Appveyor CI
 if ( $ENV{CI} AND $ENV{APPVEYOR} )
-  set(DXC_ON_APPVEYOR_CI ON)
+  add_definitions(-DDXC_ON_APPVEYOR_CI)
 endif()
 # HLSL Change ends
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -417,7 +417,9 @@ public:
   TEST_METHOD(CompileWhenODumpThenOptimizerMatch)
   TEST_METHOD(CompileWhenVdThenProducesDxilContainer)
 
+#ifndef DXC_ON_APPVEYOR_CI
   TEST_METHOD(CompileWhenNoMemThenOOM)
+#endif // DXC_ON_APPVEYOR_CI
   TEST_METHOD(CompileWhenShaderModelMismatchAttributeThenFail)
   TEST_METHOD(CompileBadHlslThenFail)
   TEST_METHOD(CompileLegacyShaderModelThenFail)
@@ -2694,6 +2696,7 @@ public:
   virtual void STDMETHODCALLTYPE HeapMinimize(void) {}
 };
 
+#ifndef DXC_ON_APPVEYOR_CI
 TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
@@ -2781,6 +2784,7 @@ TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
     VERIFY_ARE_EQUAL(initialRefCount, InstrMalloc.GetRefCount());
   }
 }
+#endif // DXC_ON_APPVEYOR_CI
 
 TEST_F(CompilerTest, CompileWhenShaderModelMismatchAttributeThenFail) {
   CComPtr<IDxcCompiler> pCompiler;


### PR DESCRIPTION
Suddenly the `CompileWhenNoMemThenOOM` test started to fail
even for a pull request that is trivial and does not touch the source
code (e.g., #1294). And we cannot reproduce this failure locally.
It's likely an Appveyor infrastructure issue; they updated a few things
[yesterday](https://www.appveyor.com/updates/2018/05/16/).

I temporary disabled this test on Appveyor CI for now to unblock
other work. A following up PR to try to revert this PR and fix the issue.