### PR TITLE
[linux-port] Fix DiagnosticPrinter use of std::hex

### DIFF
--- a/include/llvm/IR/DiagnosticPrinter.h
+++ b/include/llvm/IR/DiagnosticPrinter.h
@@ -55,6 +55,8 @@ public:
 
   // Other types.
   virtual DiagnosticPrinter &operator<<(const SMDiagnostic &Diag) = 0;
+  virtual DiagnosticPrinter &
+  operator<<(std::ios_base &(*iomanip)(std::ios_base &)) = 0; // HLSL Change
 };
 
 /// \brief Basic diagnostic printer that uses an underlying raw_ostream.
@@ -88,6 +90,8 @@ public:
 
   // Other types.
   DiagnosticPrinter &operator<<(const SMDiagnostic &Diag) override;
+  DiagnosticPrinter &operator<<(
+      std::ios_base &(*iomanip)(std::ios_base &)) override; // HLSL Change
 };
 } // End namespace llvm
 

--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -60,6 +60,10 @@ private:
   /// this buffer.
   char *OutBufStart, *OutBufEnd, *OutBufCur;
 
+  /// The base in which numbers will be written. default is 10. 8 and 16 are
+  /// also possible.
+  int writeBase;  // HLSL Change
+
   enum BufferKind {
     Unbuffered = 0,
     InternalBuffer,
@@ -84,6 +88,7 @@ public:
       : BufferMode(unbuffered ? Unbuffered : InternalBuffer) {
     // Start out ready to flush.
     OutBufStart = OutBufEnd = OutBufCur = nullptr;
+    writeBase = 10; // HLSL Change
   }
 
   virtual ~raw_ostream();
@@ -213,6 +218,9 @@ public:
   /// Output \p N in hexadecimal, without any prefix or padding.
   raw_ostream &write_hex(unsigned long long N);
 
+  /// Output \p N in writeBase, without any prefix or padding.
+  raw_ostream &write_base(unsigned long long N); // HLSL Change
+
   /// Output \p Str, turning '\\', '\t', '\n', '"', and anything that doesn't
   /// satisfy std::isprint into an escape sequence.
   raw_ostream &write_escaped(StringRef Str, bool UseHexEscapes = false);
@@ -228,7 +236,10 @@ public:
   
   // Formatted output, see the formatHex() function in Support/Format.h.
   raw_ostream &operator<<(const FormattedNumber &);
-  
+
+  raw_ostream &
+  operator<<(std::ios_base &(*iomanip)(std::ios_base &)); // HLSL Change
+
   /// indent - Insert 'NumSpaces' spaces.
   raw_ostream &indent(unsigned NumSpaces);
 
@@ -402,7 +413,7 @@ public:
 
   /// Manually flush the stream and close the file. Note that this does not call
   /// fsync.
-  void close();
+  void close() override;
 
   bool supportsSeeking() { return SupportsSeeking; }
 

--- a/lib/IR/DiagnosticPrinter.cpp
+++ b/lib/IR/DiagnosticPrinter.cpp
@@ -96,6 +96,14 @@ DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Twine &Str) {
   return *this;
 }
 
+// HLSL Change Starts
+DiagnosticPrinter &DiagnosticPrinterRawOStream::
+operator<<(std::ios_base &(*iomanip)(std::ios_base &)) {
+  Stream << iomanip;
+  return *this;
+}
+// HLSL Change Ends.
+
 // IR related types.
 DiagnosticPrinter &DiagnosticPrinterRawOStream::operator<<(const Value &V) {
   Stream << V.getName();


### PR DESCRIPTION
DiagnosticPrinter doesn't support io manipulators like std::hex,
in spite of that, they were included in some invocations of it. MSVC
seemed to allow this because it interpretted std::hex as a void
pointer, which is supported.

This adds support of std::hex and similar manipulators by adding an
overloaded operator<< that takes the type of std::hex and its friends
and sets a base number which is used when the base is not 10 to print
numbers in the specified base, which can only be 8 or 16 according to
what is passed in.

Also while I was changing things in raw_ostream.h I added a
missing override keyword that produced a lot of warnings on clang.