### PR TITLE
[linux-port] Compile improvements (helps gcc).

### DIFF
--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -131,7 +131,7 @@ private:
   struct OpCodeProperty {
     OpCode OpCode;
     const char *pOpCodeName;
-    OpCodeClass OpCodeClass;
+    OpCodeClass opCodeClass;
     const char *pOpCodeClassName;
     bool bAllowOverload[kNumTypeOverloads];   // void, h,f,d, i1, i8,i16,i32,i64
     llvm::Attribute::AttrKind FuncAttr;

--- a/lib/HLSL/DxilDebugInstrumentation.cpp
+++ b/lib/HLSL/DxilDebugInstrumentation.cpp
@@ -158,7 +158,7 @@ private:
       unsigned PrimitiveId;
       unsigned InstanceId;
     } GeometryShader;
-  } m_Parameters = { 0,0,0 };
+  } m_Parameters = { {0,0,0} };
 
   union SystemValueIndices {
     struct PixelShaderParameters {

--- a/lib/HLSL/DxilShaderModel.cpp
+++ b/lib/HLSL/DxilShaderModel.cpp
@@ -85,19 +85,19 @@ const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
 
 const ShaderModel *ShaderModel::GetByName(const char *pszName) {
   // [ps|vs|gs|hs|ds|cs]_[major]_[minor]
-  Kind Kind;
+  Kind kind;
   switch (pszName[0]) {
-  case 'p':   Kind = Kind::Pixel;     break;
-  case 'v':   Kind = Kind::Vertex;    break;
-  case 'g':   Kind = Kind::Geometry;  break;
-  case 'h':   Kind = Kind::Hull;      break;
-  case 'd':   Kind = Kind::Domain;    break;
-  case 'c':   Kind = Kind::Compute;   break;
-  case 'l':   Kind = Kind::Library;   break;
+  case 'p':   kind = Kind::Pixel;     break;
+  case 'v':   kind = Kind::Vertex;    break;
+  case 'g':   kind = Kind::Geometry;  break;
+  case 'h':   kind = Kind::Hull;      break;
+  case 'd':   kind = Kind::Domain;    break;
+  case 'c':   kind = Kind::Compute;   break;
+  case 'l':   kind = Kind::Library;   break;
   default:    return GetInvalid();
   }
   unsigned Idx = 3;
-  if (Kind != Kind::Library) {
+  if (kind != Kind::Library) {
     if (pszName[1] != 's' || pszName[2] != '_')
       return GetInvalid();
   } else {
@@ -137,7 +137,7 @@ const ShaderModel *ShaderModel::GetByName(const char *pszName) {
   if (pszName[Idx++] != 0)
     return GetInvalid();
 
-  return Get(Kind, Major, Minor);
+  return Get(kind, Major, Minor);
 }
 
 void ShaderModel::GetDxilVersion(unsigned &DxilMajor, unsigned &DxilMinor) const {


### PR DESCRIPTION
GCC5 has a few limitations that later versions do not. The
most pervasive issue is the confusion of scoped operators on enum
names when the name of the enum is shared with a local variable.

The only other issue concerns intialization of a union containing
structs and how many curly braces is enough.