### PR TITLE
[linux-port] More compile improvement (helps GCC).

### DIFF
--- a/include/dxc/HLSL/DxilOperations.h
+++ b/include/dxc/HLSL/DxilOperations.h
@@ -129,7 +129,7 @@ private:
 private:
   // Static properties.
   struct OpCodeProperty {
-    OpCode OpCode;
+    OpCode opCode;
     const char *pOpCodeName;
     OpCodeClass opCodeClass;
     const char *pOpCodeClassName;

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -347,7 +347,7 @@ bool OP::IsOverloadLegal(OpCode opCode, Type *pType) {
 
 bool OP::CheckOpCodeTable() {
   for (unsigned i = 0; i < (unsigned)OpCode::NumOpCodes; i++) {
-    if ((unsigned)m_OpCodeProps[i].OpCode != i)
+    if ((unsigned)m_OpCodeProps[i].opCode != i)
       return false;
   }
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3662,10 +3662,10 @@ struct PointerStatus {
         AccessingFunction(nullptr), HasMultipleAccessingFunctions(false),
         Size(size) {}
   void MarkAsStored() {
-    storedType = PointerStatus::StoredType::Stored;
+    storedType = StoredType::Stored;
     StoredOnceValue = nullptr;
   }
-  void MarkAsLoaded() { loadedType = PointerStatus::LoadedType::Loaded; }
+  void MarkAsLoaded() { loadedType = LoadedType::Loaded; }
 };
 
 void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
@@ -3696,8 +3696,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
         }
         if (MC->getRawDest() == V) {
           if (bFullCopy &&
-              PS.storedType == PointerStatus::StoredType::NotStored) {
-            PS.storedType = PointerStatus::StoredType::MemcopyDestOnce;
+              PS.storedType == StoredType::NotStored) {
+            PS.storedType = StoredType::MemcopyDestOnce;
             PS.StoringMemcpy = MI;
           } else {
             PS.MarkAsStored();
@@ -3705,8 +3705,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
           }
         } else if (MC->getRawSource() == V) {
           if (bFullCopy &&
-              PS.loadedType == PointerStatus::LoadedType::NotLoaded) {
-            PS.loadedType = PointerStatus::LoadedType::MemcopySrcOnce;
+              PS.loadedType == LoadedType::NotLoaded) {
+            PS.loadedType = LoadedType::MemcopySrcOnce;
             PS.LoadingMemcpy = MI;
           } else {
             PS.MarkAsLoaded();
@@ -3732,8 +3732,8 @@ void PointerStatus::analyzePointer(const Value *V, PointerStatus &PS,
     } else if (const StoreInst *SI = dyn_cast<StoreInst>(U)) {
       Value *V = SI->getOperand(0);
 
-      if (PS.storedType == PointerStatus::StoredType::NotStored) {
-        PS.storedType = PointerStatus::StoredType::StoredOnce;
+      if (PS.storedType == StoredType::NotStored) {
+        PS.storedType = StoredType::StoredOnce;
         PS.StoredOnceValue = V;
       } else {
         PS.MarkAsStored();

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -202,10 +202,12 @@ static void addAddDiscriminatorsPass(const PassManagerBuilder &Builder,
   PM.add(createAddDiscriminatorsPass());
 }
 
+#ifdef MS_ENABLE_OBJCARC // HLSL Change
 static void addBoundsCheckingPass(const PassManagerBuilder &Builder,
                                     legacy::PassManagerBase &PM) {
   PM.add(createBoundsCheckingPass());
 }
+#endif // MS_ENABLE_OBJCARC // HLSL Change
 
 #ifdef MS_ENABLE_INSTR // HLSL Change
 

--- a/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -183,10 +183,12 @@ CodeGenModule::CodeGenModule(ASTContext &C, const HeaderSearchOptions &HSO,
 }
 
 CodeGenModule::~CodeGenModule() {
+#if 0 // HLSL Change - no ObjC, OpenCL, OpenMP, or CUDA support
   delete ObjCRuntime;
   delete OpenCLRuntime;
   delete OpenMPRuntime;
   delete CUDARuntime;
+#endif // HLSL Change
   delete HLSLRuntime;  // HLSL Change
   TheTargetCodeGenInfo.reset(nullptr); // HLSL Change
   delete TBAA;
@@ -3252,7 +3254,7 @@ void CodeGenModule::EmitObjCPropertyImplementations(const
                                  const_cast<ObjCImplementationDecl *>(D), PID);
     }
   }
-#endif 0 // HLSL Change - no ObjC support
+#endif // HLSL Change - no ObjC support
 }
 
 static bool needsDestructMethod(ObjCImplementationDecl *impl) {


### PR DESCRIPTION
GCC has what seems to me to be a bug where it disapproves of the members
of a member struct of class OP having the same name as a type imported
by "using". It's the only compiler with the issue and I don't see any real
conflict, but it's easier to placate it than to fix GCC. GCC
claims its ambiguous. Making the member variables lowercase fixes
this neatly.

Removed some PointerStatus:: prefixes from references within the
class itself which upsets GCC.

HLSL changes excluded Transforms/Instrumentation directory entirely
including BoundsChecking. However it didn't excluder one reference
to a function declared there in BackendUtil that fails to link on GCC.
The function that references the missing BoundsChecking function
is static and not used anywhere with current settings. So it's not
considered a symbol to be linked by MSVC or clang, but GCC insists.