### PR TITLE
Add rawbufferstore to shader access tracking

### DIFF
--- a/lib/HLSL/DxilShaderAccessTracking.cpp
+++ b/lib/HLSL/DxilShaderAccessTracking.cpp
@@ -461,11 +461,12 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
       { DXIL::OpCode::TextureGather         , ShaderAccessFlags::Read   , true , f32i32 }, // todo: SM6: f16f32i16i32 },
       { DXIL::OpCode::TextureGatherCmp      , ShaderAccessFlags::Read   , false, f32i32 }, // todo: SM6: f16f32i16i32 },
       { DXIL::OpCode::BufferLoad            , ShaderAccessFlags::Read   , false, f32i32 },
-      { DXIL::OpCode::RawBufferLoad         , ShaderAccessFlags::Read   , false, f32i32 },
+      { DXIL::OpCode::RawBufferLoad         , ShaderAccessFlags::Read   , false, f16f32i16i32 },
       { DXIL::OpCode::BufferStore           , ShaderAccessFlags::Write  , false, f32i32 },
       { DXIL::OpCode::BufferUpdateCounter   , ShaderAccessFlags::Counter, false, voidType },
       { DXIL::OpCode::AtomicBinOp           , ShaderAccessFlags::Write  , false, i32 },
       { DXIL::OpCode::AtomicCompareExchange , ShaderAccessFlags::Write  , false, i32 },
+      { DXIL::OpCode::RawBufferStore        , ShaderAccessFlags::Write  , false, f16f32i16i32 },
     };
 
     for (const auto & raFunction : raFunctions) {

--- a/tools/clang/test/HLSL/pix/AccessTracking.hlsl
+++ b/tools/clang/test/HLSL/pix/AccessTracking.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -ECSMain -Tcs_6_0 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=S0:1:1i1;U0:2:10i0;.. | %FileCheck %s
+// RUN: %dxc -ECSMain -Tcs_6_2 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=S0:1:1i1;U0:2:10i0;.. | %FileCheck %s
 
 // Check we added the UAV:
 // CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
@@ -11,8 +11,8 @@
 // CHECK: slotIndex = mul i32
 
 // Check for udpate of UAV:
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32
-
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %bufferArray_UAV_rawbuf, i32 0, i32
+// CHECKL %UAVOrResult1 = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2
 
 ByteAddressBuffer inBuffer : register(t0);
 RWByteAddressBuffer bufferArray[] : register(u0);


### PR DESCRIPTION
Pretty easy one. Add RawBufferStore operand, update RawBufferLoad's overloads for SM_6_2, and tweak the test to cover it.