### PR TITLE
[linux-port] Introduce Windows "adapter" headers.

### DIFF
--- a/include/dxc/HLSL/DxilContainer.h
+++ b/include/dxc/HLSL/DxilContainer.h
@@ -18,6 +18,7 @@
 #include <iterator>
 #include <functional>
 #include "dxc/HLSL/DxilConstants.h"
+#include "dxc/Support/WinAdapter.h"
 
 struct IDxcContainerReflection;
 namespace llvm { class Module; }

--- a/include/dxc/HLSL/DxilRootSignature.h
+++ b/include/dxc/HLSL/DxilRootSignature.h
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+#include "dxc/Support/WinAdapter.h"
+
 struct IDxcBlob;
 struct IDxcBlobEncoding;
 

--- a/include/dxc/HLSL/DxilSignatureElement.h
+++ b/include/dxc/HLSL/DxilSignatureElement.h
@@ -18,7 +18,7 @@
 #include "dxc/HLSL/DxilSignatureAllocator.h"
 #include <string>
 #include <vector>
-
+#include <limits.h>
 
 namespace hlsl {
 

--- a/include/dxc/HLSL/DxilValidation.h
+++ b/include/dxc/HLSL/DxilValidation.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include "dxc/Support/Global.h"
 #include "dxc/HLSL/DxilConstants.h"
+#include "dxc/Support/WinAdapter.h"
 
 namespace llvm {
 class Module;

--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#ifdef _WIN32
 // Redeclare some macros to not depend on winerror.h
 #define DXC_FAILED(hr) (((HRESULT)(hr)) < 0)
 #ifndef _HRESULT_DEFINED
@@ -21,10 +22,12 @@ typedef long HRESULT;
 typedef _Return_type_success_(return >= 0) long HRESULT;
 #endif // _Return_type_success_
 #endif // !_HRESULT_DEFINED
+#endif // _WIN32
 
 #include <stdarg.h>
 #include <system_error>
 #include "dxc/Support/exception.h"
+#include "dxc/Support/WinAdapter.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 // Memory allocation support.

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -1,0 +1,453 @@
+//===- WinAdapter.h - Windows Adapter for non-Windows platforms -*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines Windows-specific types, macros, and SAL annotations used
+// in the codebase for non-Windows platforms.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_WIN_ADAPTER_H
+#define LLVM_SUPPORT_WIN_ADAPTER_H
+
+#ifndef _WIN32
+
+#ifdef __cplusplus
+#include <atomic>
+#include <cassert>
+#include <climits>
+#include <cstring>
+#include <cwchar>
+#include <fstream>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
+#include <vector>
+#endif // __cplusplus
+
+//===----------------------------------------------------------------------===//
+//
+//                             Begin: Macro Definitions
+//
+//===----------------------------------------------------------------------===//
+#define C_ASSERT(expr) static_assert((expr), "")
+#define ATLASSERT assert
+
+#define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
+
+#define _countof(a) (sizeof(a) / sizeof(*(a)))
+
+#define __declspec(x)
+
+#define uuid(id)
+
+#define STDMETHODCALLTYPE
+#define STDAPI extern "C" HRESULT STDAPICALLTYPE
+#define STDAPI_(type) extern "C" type STDAPICALLTYPE
+#define STDMETHODIMP HRESULT STDMETHODCALLTYPE
+#define STDMETHODIMP_(type) type STDMETHODCALLTYPE
+
+#define UNREFERENCED_PARAMETER(P) (void)(P)
+
+#define RtlEqualMemory(Destination, Source, Length)                            \
+  (!memcmp((Destination), (Source), (Length)))
+#define RtlMoveMemory(Destination, Source, Length)                             \
+  memmove((Destination), (Source), (Length))
+#define RtlCopyMemory(Destination, Source, Length)                             \
+  memcpy((Destination), (Source), (Length))
+#define RtlFillMemory(Destination, Length, Fill)                               \
+  memset((Destination), (Fill), (Length))
+#define RtlZeroMemory(Destination, Length) memset((Destination), 0, (Length))
+#define MoveMemory RtlMoveMemory
+#define CopyMemory RtlCopyMemory
+#define FillMemory RtlFillMemory
+#define ZeroMemory RtlZeroMemory
+
+#define FALSE 0
+#define TRUE 1
+
+#define REGDB_E_CLASSNOTREG 1
+
+// We ignore the code page completely on Linux.
+#define GetConsoleOutputCP() 0
+
+#define _HRESULT_TYPEDEF_(_sc) ((HRESULT)_sc)
+#define DISP_E_BADINDEX _HRESULT_TYPEDEF_(0x8002000BL)
+
+// This is an unsafe conversion. If needed, we can later implement a safe
+// conversion that throws exceptions for overflow cases.
+#define UIntToInt(uint_arg, int_ptr_arg) *int_ptr_arg = uint_arg
+
+#define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)
+
+// Use errno to implement {Get|Set}LastError
+#define GetLastError() errno
+#define SetLastError(ERR) errno = ERR
+
+// Map these errors to equivalent errnos.
+#define ERROR_SUCCESS 0L
+#define ERROR_OUT_OF_STRUCTURES ENOMEM
+#define ERROR_UNHANDLED_EXCEPTION EINTR
+#define ERROR_NOT_FOUND ENOTSUP
+#define ERROR_NOT_CAPABLE EPERM
+#define ERROR_FILE_NOT_FOUND ENOENT
+#define ERROR_IO_DEVICE EIO
+#define ERROR_INVALID_HANDLE EBADF
+
+// Used by HRESULT <--> WIN32 error code conversion
+#define SEVERITY_ERROR 1
+#define FACILITY_WIN32 7
+#define HRESULT_CODE(hr) ((hr)&0xFFFF)
+#define MAKE_HRESULT(severity, facility, code)                                 \
+  ((HRESULT)(((unsigned long)(severity) << 31) |                               \
+             ((unsigned long)(facility) << 16) | ((unsigned long)(code))))
+
+#define FILE_TYPE_UNKNOWN 0x0000
+#define FILE_TYPE_DISK 0x0001
+#define FILE_TYPE_CHAR 0x0002
+#define FILE_TYPE_PIPE 0x0003
+#define FILE_TYPE_REMOTE 0x8000
+
+#define FILE_ATTRIBUTE_NORMAL 0x00000080
+#define FILE_ATTRIBUTE_DIRECTORY 0x00000010
+#define INVALID_FILE_ATTRIBUTES ((DWORD)-1)
+
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+// STGTY ENUMS
+#define STGTY_STORAGE 1
+#define STGTY_STREAM 2
+#define STGTY_LOCKBYTES 3
+#define STGTY_PROPERTY 4
+
+// Storage errors
+#define STG_E_INVALIDFUNCTION 1L
+#define STG_E_ACCESSDENIED 2L
+
+#define STREAM_SEEK_SET 0
+#define STREAM_SEEK_CUR 1
+#define STREAM_SEEK_END 2
+
+#define HEAP_NO_SERIALIZE 1
+
+#define MB_ERR_INVALID_CHARS 0x00000008 // error for invalid chars
+
+#define _atoi64 atoll
+#define sprintf_s snprintf
+#define _strdup strdup
+#define vsprintf_s vsprintf
+#define strcat_s strcat
+
+#define OutputDebugStringW(msg) fputws(msg, stderr)
+
+#define OutputDebugStringA(msg) fputs(msg, stderr)
+#define OutputDebugFormatA(...) fprintf(stderr, __VA_ARGS__)
+
+// Event Tracing for Windows (ETW) provides application programmers the ability
+// to start and stop event tracing sessions, instrument an application to
+// provide trace events, and consume trace events.
+#define DxcEtw_DXCompilerCreateInstance_Start()
+#define DxcEtw_DXCompilerCreateInstance_Stop(hr)
+#define DxcEtw_DXCompilerCompile_Start()
+#define DxcEtw_DXCompilerCompile_Stop(hr)
+#define DxcEtw_DXCompilerDisassemble_Start()
+#define DxcEtw_DXCompilerDisassemble_Stop(hr)
+#define DxcEtw_DXCompilerPreprocess_Start()
+#define DxcEtw_DXCompilerPreprocess_Stop(hr)
+#define DxcEtw_DxcValidation_Start()
+#define DxcEtw_DxcValidation_Stop(hr)
+
+#define UInt32Add UIntAdd
+#define Int32ToUInt32 IntToUInt
+
+//===--------------------- HRESULT Related Macros -------------------------===//
+
+#define S_OK ((HRESULT)0L)
+#define S_FALSE ((HRESULT)1L)
+
+#define E_ABORT (HRESULT)0x80004004
+#define E_ACCESSDENIED (HRESULT)0x80070005
+#define E_FAIL (HRESULT)0x80004005
+#define E_HANDLE (HRESULT)0x80070006
+#define E_INVALIDARG (HRESULT)0x80070057
+#define E_NOINTERFACE (HRESULT)0x80004002
+#define E_NOTIMPL (HRESULT)0x80004001
+#define E_OUTOFMEMORY (HRESULT)0x8007000E
+#define E_POINTER (HRESULT)0x80004003
+#define E_UNEXPECTED (HRESULT)0x8000FFFF
+
+#define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
+#define FAILED(hr) (((HRESULT)(hr)) < 0)
+#define DXC_FAILED(hr) (((HRESULT)(hr)) < 0)
+
+#define HRESULT_FROM_WIN32(x)                                                  \
+  (HRESULT)(x) <= 0 ? (HRESULT)(x)                                             \
+                    : (HRESULT)(((x)&0x0000FFFF) | (7 << 16) | 0x80000000)
+
+//===----------------------------------------------------------------------===//
+//
+//                         Begin: Disable SAL Annotations
+//
+//===----------------------------------------------------------------------===//
+#define _In_
+#define _In_z_
+#define _In_opt_
+#define _In_opt_count_(size)
+#define _In_opt_z_
+#define _In_reads_(size)
+#define _In_reads_bytes_(size)
+#define _In_reads_bytes_opt_(size)
+#define _In_reads_opt_(size)
+#define _In_reads_to_ptr_(ptr)
+#define _In_count_(size)
+#define _In_range_(lb, ub)
+#define _In_bytecount_(size)
+#define _In_NLS_string_(size)
+#define __in_bcount(size)
+
+#define _Out_
+#define _Out_bytecap_(nbytes)
+#define _Out_writes_to_opt_(a, b)
+#define _Outptr_
+#define _Outptr_opt_
+#define _Outptr_opt_result_z_
+#define _Out_opt_
+#define _Out_writes_(size)
+#define _Out_write_bytes_(size)
+#define _Out_writes_z_(size)
+#define _Out_writes_all_(size)
+#define _Out_writes_bytes_(size)
+#define _Outref_result_buffer_(size)
+#define _Outptr_result_buffer_(size)
+#define _Out_cap_(size)
+#define _Out_cap_x_(size)
+#define _Out_range_(lb, ub)
+#define _Outptr_result_z_
+#define _Outptr_result_buffer_maybenull_(ptr)
+#define _Outptr_result_maybenull_
+#define _Outptr_result_nullonfailure_
+
+#define __out_ecount_part(a, b)
+
+#define _Inout_
+#define _Inout_z_
+#define _Inout_opt_
+#define _Inout_cap_(size)
+#define _Inout_count_(size)
+#define _Inout_count_c_(size)
+#define _Inout_opt_count_c_(size)
+#define _Inout_bytecount_c_(size)
+#define _Inout_opt_bytecount_c_(size)
+
+#define _Ret_maybenull_
+#define _Ret_notnull_
+#define _Ret_opt_
+
+#define _Use_decl_annotations_
+#define _Analysis_assume_(expr)
+#define _Analysis_assume_nullterminated_(x)
+#define _Success_(expr)
+
+#define __inexpressible_readableTo(size)
+#define __inexpressible_writableTo(size)
+
+#define _Printf_format_string_
+#define _Null_terminated_
+#define __fallthrough
+
+#define _Field_size_(size)
+#define _Field_size_full_(size)
+#define _Field_size_opt_(size)
+#define _Post_writable_byte_size_(size)
+#define _Post_readable_byte_size_(size)
+#define __drv_allocatesMem(mem)
+
+#define _COM_Outptr_
+#define _COM_Outptr_opt_
+#define _COM_Outptr_result_maybenull_
+
+#define _Null_
+#define _Notnull_
+#define _Maybenull_
+
+#define _Outptr_result_bytebuffer_(size)
+
+#define __debugbreak()
+
+// GCC produces erros on calling convention attributes.
+#ifdef __GNUC__
+#define __cdecl
+#define __CRTDECL
+#define __stdcall
+#define __vectorcall
+#define __thiscall
+#define __fastcall
+#define __clrcall
+#endif // __GNUC__
+
+//===----------------------------------------------------------------------===//
+//
+//                             Begin: Type Definitions
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __cplusplus
+
+typedef unsigned char BYTE;
+typedef unsigned char *LPBYTE;
+
+typedef BYTE BOOLEAN;
+typedef BOOLEAN *PBOOLEAN;
+
+typedef bool BOOL;
+typedef BOOL *LPBOOL;
+
+typedef int INT;
+typedef long LONG;
+typedef unsigned int UINT;
+typedef unsigned long ULONG;
+typedef long long LONGLONG;
+typedef long long LONG_PTR;
+typedef unsigned long long ULONGLONG;
+
+typedef uint16_t WORD;
+typedef uint32_t DWORD;
+typedef DWORD *LPDWORD;
+
+typedef uint32_t UINT32;
+typedef uint64_t UINT64;
+
+typedef signed char INT8, *PINT8;
+typedef signed int INT32, *PINT32;
+
+typedef size_t SIZE_T;
+typedef const char *LPCSTR;
+typedef const char *PCSTR;
+
+typedef int errno_t;
+
+typedef wchar_t WCHAR;
+typedef wchar_t *LPWSTR;
+typedef wchar_t *PWCHAR;
+typedef const wchar_t *LPCWSTR;
+typedef const wchar_t *PCWSTR;
+
+typedef WCHAR OLECHAR;
+typedef OLECHAR *BSTR;
+typedef OLECHAR *LPOLESTR;
+typedef char *LPSTR;
+
+typedef void *LPVOID;
+typedef const void *LPCVOID;
+
+typedef std::nullptr_t nullptr_t;
+
+typedef signed int HRESULT;
+
+//===--------------------- Handle Types -----------------------------------===//
+
+typedef void *HANDLE;
+
+#define DECLARE_HANDLE(name)                                                   \
+  struct name##__ {                                                            \
+    int unused;                                                                \
+  };                                                                           \
+  typedef struct name##__ *name
+DECLARE_HANDLE(HINSTANCE);
+
+typedef void *HMODULE;
+
+#define STD_INPUT_HANDLE ((DWORD)-10)
+#define STD_OUTPUT_HANDLE ((DWORD)-11)
+#define STD_ERROR_HANDLE ((DWORD)-12)
+
+//===--------------------- Struct Types -----------------------------------===//
+
+typedef struct _FILETIME {
+  DWORD dwLowDateTime;
+  DWORD dwHighDateTime;
+} FILETIME, *PFILETIME, *LPFILETIME;
+
+typedef struct _BY_HANDLE_FILE_INFORMATION {
+  DWORD dwFileAttributes;
+  FILETIME ftCreationTime;
+  FILETIME ftLastAccessTime;
+  FILETIME ftLastWriteTime;
+  DWORD dwVolumeSerialNumber;
+  DWORD nFileSizeHigh;
+  DWORD nFileSizeLow;
+  DWORD nNumberOfLinks;
+  DWORD nFileIndexHigh;
+  DWORD nFileIndexLow;
+} BY_HANDLE_FILE_INFORMATION, *PBY_HANDLE_FILE_INFORMATION,
+    *LPBY_HANDLE_FILE_INFORMATION;
+
+typedef struct _WIN32_FIND_DATAW {
+  DWORD dwFileAttributes;
+  FILETIME ftCreationTime;
+  FILETIME ftLastAccessTime;
+  FILETIME ftLastWriteTime;
+  DWORD nFileSizeHigh;
+  DWORD nFileSizeLow;
+  DWORD dwReserved0;
+  DWORD dwReserved1;
+  WCHAR cFileName[260];
+  WCHAR cAlternateFileName[14];
+} WIN32_FIND_DATAW, *PWIN32_FIND_DATAW, *LPWIN32_FIND_DATAW;
+
+typedef union _LARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    DWORD HighPart;
+  } u;
+  LONGLONG QuadPart;
+} LARGE_INTEGER;
+
+typedef LARGE_INTEGER *PLARGE_INTEGER;
+
+typedef union _ULARGE_INTEGER {
+  struct {
+    DWORD LowPart;
+    DWORD HighPart;
+  } u;
+  ULONGLONG QuadPart;
+} ULARGE_INTEGER;
+
+typedef ULARGE_INTEGER *PULARGE_INTEGER;
+
+typedef struct tagSTATSTG {
+  LPOLESTR pwcsName;
+  DWORD type;
+  ULARGE_INTEGER cbSize;
+  FILETIME mtime;
+  FILETIME ctime;
+  FILETIME atime;
+  DWORD grfMode;
+  DWORD grfLocksSupported;
+  CLSID clsid;
+  DWORD grfStateBits;
+  DWORD reserved;
+} STATSTG;
+
+enum tagSTATFLAG {
+  STATFLAG_DEFAULT = 0,
+  STATFLAG_NONAME = 1,
+  STATFLAG_NOOPEN = 2
+};
+
+// TODO: More definitions will be added here.
+
+#endif // __cplusplus
+
+#endif // _WIN32
+
+#endif // LLVM_SUPPORT_WIN_ADAPTER_H

--- a/include/dxc/Support/exception.h
+++ b/include/dxc/Support/exception.h
@@ -11,9 +11,9 @@
 #pragma once
 
 #include "dxc/Support/ErrorCodes.h"
+#include "dxc/Support/WinAdapter.h"
 #include <exception>
 #include <string>
-
 
 namespace hlsl
 {

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -17,6 +17,10 @@
 #define DXC_API_IMPORT __declspec(dllimport)
 #endif
 
+#ifndef _WIN32
+#include "dxc/Support/WinAdapter.h"
+#endif
+
 struct IMalloc;
 struct IDxcIncludeHandler;
 

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -12,6 +12,8 @@
 #ifndef __DXC_ISENSE__
 #define __DXC_ISENSE__
 
+#include "dxc/Support/WinAdapter.h"
+
 typedef enum DxcGlobalOptions
 {
   DxcGlobalOpt_None = 0x0,

--- a/include/llvm-c/Core.h
+++ b/include/llvm-c/Core.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_C_CORE_H
 #define LLVM_C_CORE_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm-c/Support.h"
 
 #ifdef __cplusplus

--- a/include/llvm-c/Disassembler.h
+++ b/include/llvm-c/Disassembler.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_C_DISASSEMBLER_H
 #define LLVM_C_DISASSEMBLER_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/Support/DataTypes.h"
 #include <stddef.h>
 

--- a/include/llvm/ADT/STLExtras.h
+++ b/include/llvm/ADT/STLExtras.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_ADT_STLEXTRAS_H
 #define LLVM_ADT_STLEXTRAS_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/Support/Compiler.h"
 #include <algorithm> // for std::all_of
 #include <cassert>

--- a/include/llvm/Analysis/ConstantFolding.h
+++ b/include/llvm/Analysis/ConstantFolding.h
@@ -20,6 +20,8 @@
 #ifndef LLVM_ANALYSIS_CONSTANTFOLDING_H
 #define LLVM_ANALYSIS_CONSTANTFOLDING_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
+
 namespace llvm {
   class Constant;
   class ConstantFP;

--- a/include/llvm/MC/MCStreamer.h
+++ b/include/llvm/MC/MCStreamer.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_MC_MCSTREAMER_H
 #define LLVM_MC_MCSTREAMER_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/MC/MCDirectives.h"

--- a/include/llvm/Support/ConvertUTF.h
+++ b/include/llvm/Support/ConvertUTF.h
@@ -180,6 +180,7 @@ unsigned getNumBytesForUTF8(UTF8 firstByte);
 /*************************************************************************/
 /* Below are LLVM-specific wrappers of the functions above. */
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/include/llvm/Support/FileSystem.h
+++ b/include/llvm/Support/FileSystem.h
@@ -27,6 +27,7 @@
 #ifndef LLVM_SUPPORT_FILESYSTEM_H
 #define LLVM_SUPPORT_FILESYSTEM_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"

--- a/include/llvm/Support/Format.h
+++ b/include/llvm/Support/Format.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_SUPPORT_FORMAT_H
 #define LLVM_SUPPORT_FORMAT_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DataTypes.h"

--- a/include/llvm/Support/MathExtras.h
+++ b/include/llvm/Support/MathExtras.h
@@ -14,6 +14,7 @@
 #ifndef LLVM_SUPPORT_MATHEXTRAS_H
 #define LLVM_SUPPORT_MATHEXTRAS_H
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <cassert>

--- a/include/llvm/TableGen/Main.h
+++ b/include/llvm/TableGen/Main.h
@@ -14,7 +14,13 @@
 #ifndef LLVM_TABLEGEN_MAIN_H
 #define LLVM_TABLEGEN_MAIN_H
 
-#include <sal.h>  // HLSL Change - SAL
+// HLSL Change Begins
+#ifdef _WIN32
+#include <sal.h>
+#else
+#include "dxc/Support/WinAdapter.h"
+#endif
+// HLSL Change Ends
 
 namespace llvm {
 

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -9,13 +9,13 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/Support/Global.h"
+#ifdef _WIN32
 #include <specstrings.h>
-#include "dxc/Support/Unicode.h"
+#endif
 #include <string>
-
+#include "dxc/Support/Global.h"
+#include "dxc/Support/Unicode.h"
 #include "dxc/Support/WinIncludes.h"
-
 
 namespace Unicode {
 

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -10,7 +10,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/Support/Global.h"
+#ifdef _WIN32
 #include <specstrings.h>
+#endif
 
 #include "dxc/Support/WinIncludes.h"
 #include "llvm/Support/ThreadLocal.h"

--- a/lib/HLSL/DxilShaderAccessTracking.cpp
+++ b/lib/HLSL/DxilShaderAccessTracking.cpp
@@ -22,7 +22,9 @@
 #include "llvm/Transforms/Utils/Local.h"
 #include <deque>
 
+#ifdef _WIN32
 #include <winerror.h>
+#endif
 
 using namespace llvm;
 using namespace hlsl;

--- a/lib/HLSL/DxilShaderModel.cpp
+++ b/lib/HLSL/DxilShaderModel.cpp
@@ -7,6 +7,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include <limits.h>
+
 #include "dxc/HLSL/DxilShaderModel.h"
 #include "dxc/HLSL/DxilSemantic.h"
 #include "dxc/Support/Global.h"

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -15,6 +15,7 @@
 #include "dxc/HLSL/HLModule.h"
 #include "dxc/HLSL/DxilTypeSystem.h"
 #include "dxc/HLSL/DxilRootSignature.h"
+#include "dxc/Support/WinAdapter.h"
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/Constants.h"

--- a/lib/HLSL/WaveSensitivityAnalysis.cpp
+++ b/lib/HLSL/WaveSensitivityAnalysis.cpp
@@ -31,7 +31,9 @@
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
 #include "llvm/ADT/BitVector.h"
+#ifdef _WIN32
 #include <winerror.h>
+#endif
 #include "llvm/Support/raw_ostream.h"
 #include <unordered_set>
 

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -61,7 +61,9 @@ void LLVMShutdown() {
 }
 
 // HLSL Change: use ISO _strdup rather than strdup, which compiled but fails to link
+#ifdef _MSC_VER
 #define strdup _strdup
+#endif
 
 /*===-- Error handling ----------------------------------------------------===*/
 

--- a/lib/MSSupport/MSFileSystemImpl.cpp
+++ b/lib/MSSupport/MSFileSystemImpl.cpp
@@ -10,17 +10,24 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/Support/WinIncludes.h"
 #include <fcntl.h>
+
+#ifdef _WIN32
 #include <io.h>
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <errno.h>
-
-#include "llvm/Support/MSFileSystem.h"
-
 #include <new>
+
+#include "dxc/Support/WinIncludes.h"
+#include "dxc/Support/WinAdapter.h"
+#include "llvm/Support/MSFileSystem.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Externally visible functions.

--- a/lib/Support/ConvertUTFWrapper.cpp
+++ b/lib/Support/ConvertUTFWrapper.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include "llvm/Support/ConvertUTF.h"
 #include "llvm/Support/SwapByteOrder.h"
 #include <string>

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -29,7 +29,9 @@
 #include <cassert>
 #include <cstdlib>
 
+#ifdef _WIN32
 #include "windows.h"  // HLSL Change
+#endif
 
 #if defined(HAVE_UNISTD_H)
 # include <unistd.h>

--- a/lib/Support/Program.cpp
+++ b/lib/Support/Program.cpp
@@ -23,7 +23,7 @@ using namespace sys;
 //===          independent code.
 //===----------------------------------------------------------------------===//
 
-#ifdef MSFT_SUPPORTS_CHILD_PROCESSES
+#if defined(MSFT_SUPPORTS_CHILD_PROCESSES) || defined(LLVM_ON_UNIX)
 
 static bool Execute(ProcessInfo &PI, StringRef Program, const char **args,
                     const char **env, const StringRef **Redirects,

--- a/lib/Support/Windows/MSFileSystem.inc.cpp
+++ b/lib/Support/Windows/MSFileSystem.inc.cpp
@@ -14,7 +14,9 @@
 #define NOMINMAX
 #include "WindowsSupport.h"
 #include <fcntl.h>
+#ifdef _WIN32
 #include <io.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <system_error>

--- a/lib/Support/regerror.c
+++ b/lib/Support/regerror.c
@@ -45,6 +45,8 @@
 
 #include "regutils.h"
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
+
 #ifdef _MSC_VER
 #define snprintf _snprintf
 #endif

--- a/lib/Support/regex_impl.h
+++ b/lib/Support/regex_impl.h
@@ -38,7 +38,9 @@
 #ifndef _REGEX_H_
 #define	_REGEX_H_
 
+#include "dxc/Support/WinAdapter.h" // HLSL Change
 #include <sys/types.h>
+
 typedef off_t llvm_regoff_t;
 typedef struct {
   llvm_regoff_t rm_so;		/* start of match */

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -19,8 +19,9 @@
 #include "clang/AST/Type.h"             // needs QualType
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
-#include "llvm/Support/Casting.h"
 #include "dxc/HLSL/DxilConstants.h"
+#include "dxc/Support/WinAdapter.h"
+#include "llvm/Support/Casting.h"
 
 namespace clang {
   class ASTContext;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -32,12 +32,14 @@
 #include "clang/Sema/SemaHLSL.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
+#include "dxc/Support/WinAdapter.h"
 #include "dxc/dxcapi.internal.h"
 #include "dxc/HlslIntrinsicOp.h"
 #include "gen_intrin_main_tables_15.h"
 #include "dxc/HLSL/HLOperations.h"
 #include "dxc/HLSL/DxilShaderModel.h"
 #include <array>
+#include <float.h>
 
 enum ArBasicKind {
   AR_BASIC_BOOL,

--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -57,8 +57,10 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/MemoryBuffer.h"
+#ifdef _WIN32
 #include <dia2.h>
 #include <comdef.h>
+#endif
 #include <algorithm>
 #include <unordered_map>
 

--- a/tools/clang/tools/dxcompiler/dxcdia.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdia.cpp
@@ -27,7 +27,9 @@
 #include "dxc/HLSL/DxilModule.h"
 #include "dxc/HLSL/DxilUtil.h"
 #include "dxc/Support/Global.h"
+#ifdef _WIN32
 #include "dia2.h"
+#endif
 
 #include "dxc/dxcapi.internal.h"
 
@@ -40,7 +42,9 @@
 #include "dxc/Support/dxcapi.impl.h"
 #include <algorithm>
 #include <array>
+#ifdef _WIN32
 #include <comdef.h>
+#endif
 #include "dxcutil.h"
 
 using namespace llvm;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -49,7 +49,9 @@
 #include "dxc/Support/dxcapi.impl.h"
 #include "dxc/Support/DxcLangExtensionsHelper.h"
 #include "dxc/Support/HLSLOptions.h"
+#ifdef _WIN32
 #include "dxcetw.h"
+#endif
 #include "dxillib.h"
 #include <algorithm>
 

--- a/tools/clang/tools/dxcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcompiler/dxcvalidator.cpp
@@ -24,7 +24,10 @@
 #include "dxc/Support/FileIOHelper.h"
 #include "dxc/Support/dxcapi.impl.h"
 #include "dxc/HLSL/DxilRootSignature.h"
+
+#ifdef _WIN32
 #include "dxcetw.h"
+#endif
 
 using namespace llvm;
 using namespace hlsl;

--- a/tools/clang/tools/dxcompiler/dxillib.h
+++ b/tools/clang/tools/dxcompiler/dxillib.h
@@ -13,8 +13,8 @@
 #ifndef __DXC_DXILLIB__
 #define __DXC_DXILLIB__
 
+#include "dxc/Support/WinAdapter.h"
 #include "dxc/Support/WinIncludes.h"
-
 
 // Initialize Dxil library. 
 HRESULT DxilLibInitialize();

--- a/tools/clang/utils/TableGen/TableGen.cpp
+++ b/tools/clang/utils/TableGen/TableGen.cpp
@@ -20,8 +20,11 @@
 #include "llvm/TableGen/Record.h"
 
 // HLSL Change Starts
+#ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
+#endif
+
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
 // HLSL Change Ends

--- a/utils/TableGen/TableGen.cpp
+++ b/utils/TableGen/TableGen.cpp
@@ -21,8 +21,11 @@
 #include "llvm/TableGen/SetTheory.h"
 
 // HLSL Change Starts
+#ifdef _WIN32
 #define NOMINMAX
 #include <windows.h>
+#endif
+
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
 // HLSL Change Ends


### PR DESCRIPTION
In this CL, we have introduced three new header files.

* WinSAL.h disables SAL annotations for non-Windows platforms.

* WinMacros.h defines some Windows-specifc macros that are not defined on
other platforms. This will enable compilation of usages of these macros.

* WinTypes.h defines Windows-specific types that are used throughout the
codebase for non-Windows platforms. This file is currently not complete.
As we go forward, we will add more classes/structs/type definitions to
this file for specific purposes.

The contents of these files are completely disabled (#ifdef'd away) for
Windows, and do not affect Windows compilation in any way.

For the most part, this is our way of enabling compilation of the
codebase on non-Windows platforms without making invasive changes
to the existing cpp files, and without hindering any future development.

Moreover, I have added the #include of these files for all the locations
that will need it for successful Linux compilation.