### PR TITLE
[linux-port] Fix preprocessor warnings

### DIFF
--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -9,8 +9,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
 #include "dxc/HLSL/HLOperations.h"
 #include "dxc/HlslIntrinsicOp.h"
 #include "llvm/IR/Function.h"

--- a/tools/clang/lib/CodeGen/CGClass.cpp
+++ b/tools/clang/lib/CodeGen/CGClass.cpp
@@ -1458,7 +1458,7 @@ void CodeGenFunction::EmitDestructorBody(FunctionArgList &Args) {
                             /*Delegating=*/false, LoadCXXThis());
       break;
     }
-#endif 1 // HLSL Change - no support for exception handling
+#endif // HLSL Change - no support for exception handling
     // Fallthrough: act like we're in the base variant.
 
   case Dtor_Base:

--- a/tools/clang/lib/Frontend/FrontendAction.cpp
+++ b/tools/clang/lib/Frontend/FrontendAction.cpp
@@ -369,7 +369,7 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
       if (!CI.getASTContext().getExternalSource())
         goto failure;
     }
-#endif 0 // HLSL Change Ends - no support for AST serialization
+#endif // HLSL Change Ends - no support for AST serialization
 
     CI.setASTConsumer(std::move(Consumer));
     if (!CI.hasASTConsumer())

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -1355,7 +1355,7 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
       }
     }
   }
-#endif 0 // HLSL Change - no format string support
+#endif // HLSL Change - no format string support
   if (FDecl || Proto) {
     CheckNonNullArguments(*this, FDecl, Proto, Args, Loc);
 

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -9,8 +9,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/HLSL/DxilContainer.h"
 #include "dxc/Support/Global.h"

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -9,8 +9,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#pragma once
-
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/HLSL/DxilContainer.h"
 #include "dxc/Support/Global.h"


### PR DESCRIPTION
Remove pragma once from source files. It has no meaning in a source
file unless it's used as a header, which, fortunately, none of
these are.
Fixes 3 clang and 3 gcc warnings.

Remove trailing tokens after #endifs. Common result from copy,
paste, and slightly alter the beginning #if line to keep the
comments after consistent.
Fixes 3 clang and 3 gcc warnings.