### PR TITLE
[linux-port] Dummy access to unused variables

### DIFF
--- a/lib/HLSL/ComputeViewIdState.cpp
+++ b/lib/HLSL/ComputeViewIdState.cpp
@@ -516,7 +516,7 @@ void DxilViewIdState::CollectPhiCFValuesContributingToOutputRec(PHINode *pPhi,
     BasicBlock *pBB = pPhi->getIncomingBlock(i);
     DomTreeNodeBase<BasicBlock> *pDomNode = pFuncInfo->pDomTree->getNode(pBB);
     auto it = DomTreeMarkers.emplace(pDomNode, pValue);
-    DXASSERT_NOMSG(it.second || it.first->second == pValue); it;
+    DXASSERT_NOMSG(it.second || it.first->second == pValue); (void)it;
   }
   // Mark the dominator tree with "definition" values, walking up to the parent.
   for (unsigned i = 0; i < pPhi->getNumOperands(); i++) {

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -556,6 +556,7 @@ void DxilGenerationPass::TranslateDxilResourceUses(
         if (m_HasDbgInfo) {
           // TODO: set debug info.
           //Builder.SetCurrentDebugLocation(DL);
+          (void)(DL);
         }
         handleMapOnFunction[F] = Builder.CreateCall(createHandle, createHandleArgs, handleName);
       }
@@ -954,6 +955,7 @@ void DxilGenerationPass::GenerateDxilCBufferHandles(
         if (m_HasDbgInfo) {
           // TODO: add debug info.
           //handle->setDebugLoc(DL);
+          (void)(DL);
         }
         CI->replaceAllUsesWith(handle);
         CI->eraseFromParent();

--- a/lib/HLSL/DxilOperations.cpp
+++ b/lib/HLSL/DxilOperations.cpp
@@ -492,7 +492,7 @@ void OP::RefreshCache() {
       OpCode OpCode = OP::GetDxilOpFuncCallInst(CI);
       Type *pOverloadType = OP::GetOverloadType(OpCode, &F);
       Function *OpFunc = GetOpFunc(OpCode, pOverloadType);
-      (OpFunc);
+      (void)(OpFunc);
       DXASSERT_NOMSG(OpFunc == &F);
     }
   }
@@ -525,8 +525,8 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   Type *pI8 = Type::getInt8Ty(m_Ctx);
   Type *pI16 = Type::getInt16Ty(m_Ctx);
   Type *pI32 = Type::getInt32Ty(m_Ctx);
-  Type *pPI32 = Type::getInt32PtrTy(m_Ctx); (pPI32); // Currently unused.
-  Type *pI64 = Type::getInt64Ty(m_Ctx); (pI64); // Currently unused.
+  Type *pPI32 = Type::getInt32PtrTy(m_Ctx); (void)(pPI32); // Currently unused.
+  Type *pI64 = Type::getInt64Ty(m_Ctx); (void)(pI64); // Currently unused.
   Type *pF16 = Type::getHalfTy(m_Ctx);
   Type *pF32 = Type::getFloatTy(m_Ctx);
   Type *pPF32 = Type::getFloatPtrTy(m_Ctx);

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -2183,7 +2183,7 @@ static bool IsValueMinPrec(DxilModule &DxilMod, Value *V) {
   DXASSERT(DxilMod.GetGlobalFlags() & DXIL::kEnableMinPrecision,
            "else caller didn't check - currently this path should never be hit "
            "otherwise");
-  (DxilMod);
+  (void)(DxilMod);
   Type *Ty = V->getType();
   if (Ty->isIntegerTy()) {
     return 16 == Ty->getIntegerBitWidth();

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -505,8 +505,8 @@ void replaceStWithStOutput(Function *stOutput, StoreInst *stInst,
     Value *colIdx = Builder.getInt8(0);
     ArrayType *AT = cast<ArrayType>(val->getType());
     Value *args[] = {OpArg, outputID, idx, colIdx, /*val*/ nullptr};
-    args;
-    AT;
+    (void)args;
+    (void)AT;
   }
 }
 
@@ -618,7 +618,7 @@ void replaceDirectInputParameter(Value *param, Function *loadInput,
     param->replaceAllUsesWith(input);
   } else if (HLMatrixLower::IsMatrixType(Ty)) {
     Value *colIdx = hlslOP->GetU8Const(0);
-    colIdx;
+    (void)colIdx;
     DXASSERT(param->hasOneUse(),
              "matrix arg should only has one use as matrix to vec");
     CallInst *CI = cast<CallInst>(param->user_back());

--- a/tools/clang/include/clang/Frontend/CompilerInstance.h
+++ b/tools/clang/include/clang/Frontend/CompilerInstance.h
@@ -274,7 +274,7 @@ public:
   /// \brief Set the flag indicating whether we should (re)build the global
   /// module index.
   void setBuildGlobalModuleIndex(bool Build) {
-    (Build);// BuildGlobalModuleIndex = Build; // HLSL Change - no support for modules
+    (void)(Build);// BuildGlobalModuleIndex = Build; // HLSL Change - no support for modules
   }
 
   /// }

--- a/tools/clang/lib/AST/Decl.cpp
+++ b/tools/clang/lib/AST/Decl.cpp
@@ -1337,7 +1337,7 @@ public:
     // static can follow an extern, so we can have two decls with different
     // linkages.
     const LangOptions &Opts = D->getASTContext().getLangOpts();
-    (Opts); // HLSL Change - this only has static consts referenced
+    (void)(Opts); // HLSL Change - this only has static consts referenced
     if (!Opts.CPlusPlus || Opts.MicrosoftExt)
       return LV;
 
@@ -2066,7 +2066,7 @@ void VarDecl::setInit(Expr *I) {
 
 bool VarDecl::isUsableInConstantExpressions(ASTContext &C) const {
   const LangOptions &Lang = C.getLangOpts();
-  (Lang); // HLSL Change - this object is only accessed through static consts
+  (void)(Lang); // HLSL Change - this object is only accessed through static consts
 
   if (!Lang.CPlusPlus)
     return false;

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -1323,7 +1323,7 @@ void Sema::checkCall(NamedDecl *FDecl, const FunctionProtoType *Proto,
     return;
 
 #if 1 // HLSL Change - no format string support
-  (IsMemberFunction); (CallType); (Range);
+  (void)(IsMemberFunction); (void)(CallType); (void)(Range);
 #else
   // Printf and scanf checking.
   llvm::SmallBitVector CheckedVarArgs;

--- a/tools/clang/lib/Sema/SemaDeclObjC.cpp
+++ b/tools/clang/lib/Sema/SemaDeclObjC.cpp
@@ -3502,10 +3502,10 @@ Sema::ObjCContainerKind Sema::getObjCContainerKind() const {
 Decl *Sema::ActOnAtEnd(Scope *S, SourceRange AtEnd, ArrayRef<Decl *> allMethods,
                        ArrayRef<DeclGroupPtrTy> allTUVars) {
 #if 1 // HLSL Change Starts
-  (S);
-  (AtEnd);
-  (allMethods);
-  (allTUVars);
+  (void)(S);
+  (void)(AtEnd);
+  (void)(allMethods);
+  (void)(allTUVars);
   return nullptr;
 #else
   if (getObjCContainerKind() == Sema::OCK_None)

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -3633,7 +3633,7 @@ public:
   QualType NewQualifiedType(UINT64 qwUsages, QualType type)
   {
     // NOTE: NewQualifiedType does quite a bit more in the prior compiler
-    (qwUsages);
+    (void)(qwUsages);
     return type;
   }
 


### PR DESCRIPTION
Simply including a variable as the entirity of an expression is
insufficient to silence warnings for gcc and clang. The variable
is not reported as unused, which is the intent, but the expression
result is reported in a warning as unused. By casting that
expression as (void), both warnings are silenced.
Fixes 110 clang and 40 gcc warnings.