### PR TITLE
[linux-port] Casts for compares and assigns

### DIFF
--- a/lib/DxcSupport/Global.cpp
+++ b/lib/DxcSupport/Global.cpp
@@ -23,4 +23,4 @@ void CheckLLVMErrorCode(const std::error_code &ec) {
   }
 }
 
-static_assert(DXC_E_OVERLAPPING_SEMANTICS == 0x80AA0001, "Sanity check for DXC errors failed");
+static_assert(unsigned(DXC_E_OVERLAPPING_SEMANTICS) == 0x80AA0001, "Sanity check for DXC errors failed");

--- a/lib/HLSL/DxilAddPixelHitInstrumentation.cpp
+++ b/lib/HLSL/DxilAddPixelHitInstrumentation.cpp
@@ -125,7 +125,7 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
 
     ID = DM.AddUAV(std::move(pUAV));
 
-    assert(ID == UAVResourceHandle);
+    assert((unsigned)ID == UAVResourceHandle);
 
     // Create handle for the newly-added UAV
     Function* CreateHandleOpFunc = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));

--- a/lib/HLSL/DxilRootSignature.cpp
+++ b/lib/HLSL/DxilRootSignature.cpp
@@ -140,7 +140,7 @@ SimpleSerializer::~SimpleSerializer() {
     m_pSegment = pSegment->pNext;
 
     if (pSegment->bOwner) {
-      delete pSegment->pData;
+      delete[] (char*)pSegment->pData;
     }
 
     delete pSegment;
@@ -201,7 +201,7 @@ HRESULT SimpleSerializer::ReserveBlock(void **ppData, unsigned cbSize,
 
 Cleanup:
   if (FAILED(hr)) {
-    delete[] pClonedData;
+    delete[] (char*)pClonedData;
     delete pSegment;
   }
   return hr;

--- a/lib/HLSL/DxilShaderAccessTracking.cpp
+++ b/lib/HLSL/DxilShaderAccessTracking.cpp
@@ -414,7 +414,7 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
 
       ID = DM.AddUAV(std::move(pUAV));
 
-      assert(ID == UAVResourceHandle);
+      assert((unsigned)ID == UAVResourceHandle);
 
       // Create handle for the newly-added UAV
       Function* CreateHandleOpFunc = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));

--- a/lib/HLSL/PauseResumePasses.cpp
+++ b/lib/HLSL/PauseResumePasses.cpp
@@ -47,8 +47,8 @@ void SetPauseResumePasses(Module &M, StringRef pause, StringRef resume) {
   LLVMContext &Ctx = M.getContext();
   NamedMDNode *N = M.getOrInsertNamedMetadata(kPauseResumeMDName);
   Metadata *MDs[kPauseResumeNumFields];
-  MDs[kPauseResumePassNameToPause] = MDString::get(Ctx, pause);
-  MDs[kPauseResumePassNameToResume] = MDString::get(Ctx, resume);
+  MDs[(int)kPauseResumePassNameToPause] = MDString::get(Ctx, pause);
+  MDs[(int)kPauseResumePassNameToResume] = MDString::get(Ctx, resume);
   if (N->getNumOperands() == 0)
     N->addOperand(MDNode::get(Ctx, MDs));
   else

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -989,7 +989,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
       const auto attrLoc = attr->getLocation(); // Attr source code location
       const auto idx = var.getIndexAttr() ? var.getIndexAttr()->getNumber() : 0;
 
-      if (loc >= LocationSet::kMaxLoc) {
+      if ((const unsigned)loc >= LocationSet::kMaxLoc) {
         emitError("stage %select{output|input}0 location #%1 too large",
                   attrLoc)
             << forInput << loc;

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -208,7 +208,7 @@ bool GlPerVertex::doGlPerVertexFacts(const DeclaratorDecl *decl,
       (*semanticStrs)[index] = "SV_CullDistance";
   }
 
-  if (index < gClipDistanceIndex || index > gCullDistanceIndex) {
+  if (index > gCullDistanceIndex) {
     // Annotated with something other than SV_ClipDistance or SV_CullDistance.
     // We don't care about such cases.
     return true;

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -9739,7 +9739,7 @@ void SPIRVEmitter::processSwitchStmtUsingIfStmts(const SwitchStmt *switchStmt) {
     // Accumulate all non-case/default/break statements as the body for the
     // current case.
     std::vector<Stmt *> statements;
-    for (int i = curCaseIndex + 1;
+    for (unsigned i = curCaseIndex + 1;
          i < flatSwitch.size() && !isa<BreakStmt>(flatSwitch[i]); ++i) {
       if (!isa<CaseStmt>(flatSwitch[i]) && !isa<DefaultStmt>(flatSwitch[i]))
         statements.push_back(const_cast<Stmt *>(flatSwitch[i]));

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2476,9 +2476,9 @@ namespace hlsl {
     void dump() const {
       OutputDebugStringW(L"Call Nodes:\r\n");
       for (auto &node : m_callNodes) {
-        OutputDebugFormatA("%s [%p]:\r\n", node.first->getName().str().c_str(), node.first);
+        OutputDebugFormatA("%s [%p]:\r\n", node.first->getName().str().c_str(), (void*)node.first);
         for (auto callee : node.second.CalleeFns) {
-          OutputDebugFormatA("    %s [%p]\r\n", callee->getName().str().c_str(), callee);
+          OutputDebugFormatA("    %s [%p]\r\n", callee->getName().str().c_str(), (void*)callee);
         }
       }
     }
@@ -2948,7 +2948,7 @@ private:
     TypeSourceInfo *float4TypeSourceInfo = m_context->getTrivialTypeSourceInfo(float4Type, NoLoc);
     m_objectTypeLazyInitMask = 0;
     unsigned effectKindIndex = 0;
-    for (int i = 0; i < _countof(g_ArBasicKindsAsTypes); i++)
+    for (unsigned i = 0; i < _countof(g_ArBasicKindsAsTypes); i++)
     {
       ArBasicKind kind = g_ArBasicKindsAsTypes[i];
       if (kind == AR_OBJECT_WAVE) { // wave objects are currently unused
@@ -2996,7 +2996,7 @@ private:
       // Create decls for each deprecated effect object type:
       unsigned effectObjBase = _countof(g_ArBasicKindsAsTypes);
       // TypeSourceInfo* effectObjTypeSource = m_context->getTrivialTypeSourceInfo(GetBasicKindType(AR_OBJECT_LEGACY_EFFECT));
-      for (int i = 0; i < _countof(g_DeprecatedEffectObjectNames); i++) {
+      for (unsigned i = 0; i < _countof(g_DeprecatedEffectObjectNames); i++) {
         IdentifierInfo& idInfo = m_context->Idents.get(StringRef(g_DeprecatedEffectObjectNames[i]), tok::TokenKind::identifier);
         //TypedefDecl* effectObjDecl = TypedefDecl::Create(*m_context, currentDeclContext, NoLoc, NoLoc, &idInfo, effectObjTypeSource);
         CXXRecordDecl *effectObjDecl = CXXRecordDecl::Create(*m_context, TagTypeKind::TTK_Struct, currentDeclContext, NoLoc, NoLoc, &idInfo);
@@ -3026,8 +3026,7 @@ private:
 
   clang::TypedefDecl *LookupMatrixShorthandType(HLSLScalarType scalarType, UINT rowCount, UINT colCount) {
     DXASSERT_NOMSG(scalarType != HLSLScalarType::HLSLScalarType_unknown &&
-                   rowCount >= 0 && rowCount <= 4 && colCount >= 0 &&
-                   colCount <= 4);
+                   rowCount <= 4 && colCount <= 4);
     TypedefDecl *qts =
         m_matrixShorthandTypes[scalarType][rowCount - 1][colCount - 1];
     if (qts == nullptr) {
@@ -3041,7 +3040,7 @@ private:
 
   clang::TypedefDecl *LookupVectorShorthandType(HLSLScalarType scalarType, UINT colCount) {
     DXASSERT_NOMSG(scalarType != HLSLScalarType::HLSLScalarType_unknown &&
-                   colCount >= 0 && colCount <= 4);
+                   colCount <= 4);
     TypedefDecl *qts = m_vectorTypedefs[scalarType][colCount - 1];
     if (qts == nullptr) {
       QualType type = LookupVectorType(scalarType, colCount);
@@ -3458,13 +3457,12 @@ public:
     DXASSERT_NOMSG(table != nullptr);
 
     // Function intrinsics are added on-demand, objects get template methods.
-    for (int i = 0; i < _countof(g_ArBasicKindsAsTypes); i++) {
+    for (unsigned i = 0; i < _countof(g_ArBasicKindsAsTypes); i++) {
       // Grab information already processed by AddObjectTypes.
       ArBasicKind kind = g_ArBasicKindsAsTypes[i];
       const char *typeName = g_ArBasicTypeNames[kind];
       uint8_t templateArgCount = g_ArBasicKindsTemplateCount[i];
-      DXASSERT(0 <= templateArgCount && templateArgCount <= 2,
-        "otherwise a new case has been added");
+      DXASSERT(templateArgCount <= 2, "otherwise a new case has been added");
       int startDepth = (templateArgCount == 0) ? 0 : 1;
       CXXRecordDecl *recordDecl = m_objectTypeDecls[i];
       if (recordDecl == nullptr) {

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -97,7 +97,7 @@ void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
     if (pSig->Mask & DxilProgramSigMaskW)
       Mask[3] = 'w';
 
-    if (pSig->Register == -1) {
+    if (pSig->Register == (unsigned)-1) {
       OS << "    N/A";
       if (!_stricmp(pSemanticName, "SV_Depth"))
         OS << "   oDepth";
@@ -242,7 +242,7 @@ void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
     if (rwMask & DxilProgramSigMaskW)
       Mask[3] = 'w';
 
-    if (pSig->Register == -1)
+    if (pSig->Register == (unsigned)-1)
       OS << (rwMask ? "    YES" : "     NO");
     else
       OS << "   " << Mask[0] << Mask[1] << Mask[2] << Mask[3];


### PR DESCRIPTION
Various comparisons produce warnings because the values differ in
signedness. This either changes the type of one of the parameters
or else it casts one. This includes adding casts to all of the
defined return error values. Which is more than was needed, but
consistent with some existing values anyway.
Fixes 11 clang and 12 gcc warnings.

Eliminate a few greater than or equal comparisons of unsigned
values which are always true. The most aggressive of this is
the exclusion of a function that has become a no-op because of
HLSL initialization of a key variable that had some invalid
comparisons because of the same const value.
Fixes 4 clang and 7 gcc warnings.

Additionally casts a few parameters to the proper type to silence
warnings about confusing or problem casts. This includes printing
functions, array indices, and deletes of void pointers. The latter
of which might have caused problems.
Fixes 6 clang 6 gcc warnings.

One incidental change that silences a warning about security for
using a string variable as the format for printf. Since it just
outputs the string, fputs is more appropriate anyway. Also
directed to stderr as more appropriate for debug info.