### PR TITLE
[linux-port] disable covered-switch-default warning

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -394,7 +394,7 @@ elseif( LLVM_COMPILER_IS_GCC_COMPATIBLE )
     endif()
 
     append_if(LLVM_ENABLE_PEDANTIC "-pedantic -Wno-long-long" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG)
+    # add_flag_if_supported("-Wcovered-switch-default" COVERED_SWITCH_DEFAULT_FLAG) # HLSL Change
     append_if(USE_NO_UNINITIALIZED "-Wno-uninitialized" CMAKE_CXX_FLAGS)
     append_if(USE_NO_MAYBE_UNINITIALIZED "-Wno-maybe-uninitialized" CMAKE_CXX_FLAGS)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,9 +21,6 @@ if (${ENABLE_SPIRV_CODEGEN})
 
   if (IS_DIRECTORY ${DXC_SPIRV_TOOLS_DIR})
     # We only need the library from SPIRV-Tools.
-    if (NOT WIN32)
-      add_compile_options(-Wno-covered-switch-default)
-    endif()
     set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "Skip building SPIRV-Tools executables")
     set(SPIRV_TOOLS_EXTRA_DEFINITIONS /D_ITERATOR_DEBUG_LEVEL=0)
     add_subdirectory(${DXC_SPIRV_TOOLS_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Defaults in switch statments can mask warnings that might
indicate that a new enum value was added and corresponding changes
to a switch statement that relies on that enum are missed. For this
reason, clang reports when switch statements that fully define case
statements for all possible enum values contain default: statements.

However, this is a warning of a potential problem that might arise
from future changes to the code rather than anything that might be
wrong now. Additionally, while unlikely that an enum switch might
be presented with a value that isn't valid for that enum, it isn't
impossible. So rather than respect this warning, we will silence it.
It's not included by default. LLVM wanted it. We don't, so it's
removed. This makes the earlier external cmake change unnecessary.
Ignores 34 clang warnings