### PR TITLE
[linux-port] Remove/dummy unused class components

### DIFF
--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -208,7 +208,7 @@ class DxilGenerationPass : public ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilGenerationPass(bool NoOpt = false)
-      : ModulePass(ID), m_pHLModule(nullptr), NotOptimized(NoOpt), m_extensionsCodegenHelper(nullptr) {}
+      : ModulePass(ID), m_pHLModule(nullptr), m_extensionsCodegenHelper(nullptr), NotOptimized(NoOpt) {}
 
   const char *getPassName() const override { return "DXIL Generator"; }
 
@@ -300,6 +300,8 @@ public:
     // Remove debug code when not debug info.
     if (!m_HasDbgInfo)
       DxilMod.StripDebugRelatedCode();
+
+    (void)NotOptimized; // Dummy out unused member to silence warnings
 
     return true;
   }
@@ -1328,11 +1330,9 @@ INITIALIZE_PASS(HLEnsureMetadata, "hlsl-hlensure", "HLSL High-Level Metadata Ens
 
 namespace {
 class DxilPrecisePropagatePass : public ModulePass {
-  HLModule *m_pHLModule;
-
 public:
   static char ID; // Pass identification, replacement for typeid
-  explicit DxilPrecisePropagatePass() : ModulePass(ID), m_pHLModule(nullptr) {}
+  explicit DxilPrecisePropagatePass() : ModulePass(ID) {}
 
   const char *getPassName() const override { return "DXIL Precise Propagate"; }
 
@@ -1571,13 +1571,12 @@ private:
 char DxilLegalizeStaticResourceUsePass::ID = 0;
 
 class DxilLegalizeResourceUsePass : public FunctionPass {
-  HLModule *m_pHLModule;
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilLegalizeResourceUsePass()
-      : FunctionPass(ID), m_pHLModule(nullptr) {}
+      : FunctionPass(ID) {}
 
   const char *getPassName() const override {
     return "DXIL Legalize Resource Use";

--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -41,8 +41,7 @@ DEFINE_ENUM_FLAG_OPERATORS(DxilRootDescriptorFlags)
 DEFINE_ENUM_FLAG_OPERATORS(DxilDescriptorRangeFlags)
 
 RootSignatureTokenizer::RootSignatureTokenizer(const char *pStr, size_t len)
-  : m_pOrigStr(pStr)
-  , m_pStrPos(pStr)
+  : m_pStrPos(pStr)
   , m_pEndPos(pStr + len)
 {
     m_TokenBufferIdx = 0;
@@ -50,8 +49,7 @@ RootSignatureTokenizer::RootSignatureTokenizer(const char *pStr, size_t len)
 }
 
 RootSignatureTokenizer::RootSignatureTokenizer(const char *pStr)
-  : m_pOrigStr(pStr)
-  , m_pStrPos(pStr)
+  : m_pStrPos(pStr)
   , m_pEndPos(pStr + strlen(pStr))
 {
   m_TokenBufferIdx = 0;

--- a/tools/clang/lib/Parse/HLSLRootSignature.h
+++ b/tools/clang/lib/Parse/HLSLRootSignature.h
@@ -193,7 +193,6 @@ public:
     Token PeekToken();
 
 private:
-    const char *m_pOrigStr;
     const char *m_pStrPos;
     const char *m_pEndPos;
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -627,7 +627,6 @@ private:
   DiagnosticsEngine &diags;
 
   TypeTranslator &typeTranslator;
-  FeatureManager &featureManager;
 
   uint32_t entryFunctionId;
 
@@ -745,7 +744,7 @@ DeclResultIdMapper::DeclResultIdMapper(const hlsl::ShaderModel &model,
                                        const EmitSPIRVOptions &options)
     : shaderModel(model), theBuilder(builder), spirvOptions(options),
       astContext(context), diags(context.getDiagnostics()),
-      typeTranslator(translator), featureManager(features), entryFunctionId(0),
+      typeTranslator(translator), entryFunctionId(0),
       laneCountBuiltinId(0), laneIndexBuiltinId(0), needsLegalization(false),
       glPerVertex(model, context, builder, typeTranslator) {}
 

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -62,7 +62,7 @@ inline bool hasGSPrimitiveTypeQualifier(const DeclaratorDecl *decl) {
 GlPerVertex::GlPerVertex(const hlsl::ShaderModel &sm, ASTContext &context,
                          ModuleBuilder &builder, TypeTranslator &translator)
     : shaderModel(sm), astContext(context), theBuilder(builder),
-      typeTranslator(translator), inClipVar(0), inCullVar(0), outClipVar(0),
+      inClipVar(0), inCullVar(0), outClipVar(0),
       outCullVar(0), inArraySize(0), outArraySize(0), inClipArraySize(1),
       outClipArraySize(1), inCullArraySize(1), outCullArraySize(1),
       inSemanticStrs(2, ""), outSemanticStrs(2, "") {}

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -134,7 +134,6 @@ private:
   const hlsl::ShaderModel &shaderModel;
   ASTContext &astContext;
   ModuleBuilder &theBuilder;
-  TypeTranslator &typeTranslator;
 
   /// Input/output ClipDistance/CullDistance variable.
   uint32_t inClipVar, inCullVar;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -632,7 +632,6 @@ public:
 
       IFT(CreateMemoryStream(m_pMalloc, &pOutputStream));
 
-      const llvm::opt::OptTable *table = ::options::getHlslOptTable();
       int argCountInt;
       IFT(UIntToInt(argCount, &argCountInt));
       hlsl::options::MainArgs mainArgs(argCountInt, pArguments, 0);


### PR DESCRIPTION
Clang is smart enough to detect when a class member function or
variable is not used and emits a warning for that case. This
removes all such members as well as any corresponding parameters
and other variables that might have been used to initialize such.
Fixes 8 clang warnings.

NotOptimized in DxilGenerationPass echoed in places that made us
think that it might be needed at some point in spite of not being
used now. So it gets a dummy reference instead of being removed.