### PR TITLE
[linux-port] Cross-platform critical section

### DIFF
--- a/tools/clang/tools/dxcompiler/dxillib.cpp
+++ b/tools/clang/tools/dxcompiler/dxillib.cpp
@@ -12,17 +12,19 @@
 #include "dxillib.h"
 #include "dxc/Support/Global.h" // For DXASSERT
 #include "dxc/Support/dxcapi.use.h"
+#include "llvm/Support/Mutex.h"
 
 using namespace dxc;
 
 static DxcDllSupport g_DllSupport;
 static HRESULT g_DllLibResult = S_OK;
-static CRITICAL_SECTION cs;
+
+static llvm::sys::Mutex *cs = nullptr;
 
 // Check if we can successfully get IDxcValidator from dxil.dll
 // This function is to prevent multiple attempts to load dxil.dll 
 HRESULT DxilLibInitialize() {
-  InitializeCriticalSection(&cs);
+  cs = new llvm::sys::Mutex;
   return S_OK;
 }
 
@@ -37,7 +39,8 @@ HRESULT DxilLibCleanup(DxilLibCleanUpType type) {
   else {
     hr = E_INVALIDARG;
   }
-  DeleteCriticalSection(&cs);
+  delete cs;
+  cs = nullptr;
   return hr;
 }
 
@@ -45,14 +48,19 @@ HRESULT DxilLibCleanup(DxilLibCleanUpType type) {
 // If we fail to load dxil.dll, set g_DllLibResult to E_FAIL so that we don't
 // have multiple attempts to load dxil.dll
 bool DxilLibIsEnabled() {
-  EnterCriticalSection(&cs);
+#if LLVM_ON_WIN32
+  cs->lock();
   if (SUCCEEDED(g_DllLibResult)) {
     if (!g_DllSupport.IsEnabled()) {
       g_DllLibResult = g_DllSupport.InitializeForDll(L"dxil.dll", "DxcCreateInstance");
     }
   }
-  LeaveCriticalSection(&cs);
+  cs->unlock();
   return SUCCEEDED(g_DllLibResult);
+#else
+  g_DllLibResult = (HRESULT)-1;
+  return false;
+#endif
 }
 
 
@@ -60,9 +68,9 @@ HRESULT DxilLibCreateInstance(_In_ REFCLSID rclsid, _In_ REFIID riid, _In_ IUnkn
   DXASSERT_NOMSG(ppInterface != nullptr);
   HRESULT hr = E_FAIL;
   if (DxilLibIsEnabled()) {
-    EnterCriticalSection(&cs);
+    cs->lock();
     hr = g_DllSupport.CreateInstance(rclsid, riid, ppInterface);
-    LeaveCriticalSection(&cs);
+    cs->unlock();
   }
   return hr;
 }


### PR DESCRIPTION
InitializeCriticalSection, DeleteCriticalSection, EnterCriticalSection,
and LeaveCriticalSection serve to create a mutual exclusion section of
code, but they are stubbed out currently for non-win platforms.

There is multi-platform support for the same functionality in LLVM
in the form of SmartMutex. This switches from the Windows specific
to the abstraction, allowing the same code to work on other platforms.