### PR TITLE
[spirv] Add support for [[vk::set(X)]]

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -150,6 +150,9 @@ To specify which Vulkan descriptor a particular resource binds to, use the
 Alternatively, to specify both Vulkan binding numbers and descriptor sets use
 the ``[[vk::binding(X[, Y])]]`` attribute.
 
+Only one of ``[[vk::set(X)]]`` or ``[[vk::binding(X[, Y])]]`` may be specified
+for the same variable.
+
 Subpass inputs
 ~~~~~~~~~~~~~~
 
@@ -1298,12 +1301,12 @@ In summary, the compiler essentially assigns binding numbers in four passes.
 
 - Firstly it handles all declarations with explicit ``[[vk::binding(X[, Y])]]``
   annotation.
-- Secondly it handles all declarations with explicit ``[[vk::set(X)]]``
-  annotation, assigning the next available binding number in the specified
-  descriptor set.
 - Then the compiler processes all remaining declarations with
   ``:register(xX, spaceY)`` annotation, by applying the shift passed in using
   command-line option ``-fvk-{b|s|t|u}-shift N M``, if provided.
+- Then it handles all declarations with explicit ``[[vk::set(X)]]``
+  annotation, assigning the next available binding number in the specified
+  descriptor set.
 - Finally, the compiler assigns next available binding numbers to the rest in
   the declaration order.
 
@@ -1326,12 +1329,12 @@ If we compile with ``-fvk-t-shift 10 0 -fvk-t-shift 20 1``:
 
 - ``rwbuffer1`` will take binding #3 in set #0, since explicit binding
   assignment has precedence over the rest.
-- ``sampler1`` will take binding 0 in set #1, since that's the next available
-  binding number in set #1.
 - ``cbuffer1`` will take binding #0 in set #0, since that's what deduced from
   the register assignment, and there is no shift requested from command line.
 - ``texture1`` will take binding #10 in set #0, and ``texture2`` will take
   binding #21 in set #1, since we requested an 10 shift on t-type registers.
+- ``sampler1`` will take binding 0 in set #1, since that's the next available
+  binding number in set #1.
 - ``sampler2`` will take binding 1 in set #0, since that's the next available
   binding number in set #0.
 

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -895,6 +895,14 @@ def VKBinding : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKSet : InheritableAttr {
+  let Spellings = [CXX11<"vk", "set">];
+  let Subjects = SubjectList<[GlobalVar, HLSLBuffer], ErrorDiag, "ExpectedGlobalVarOrCTBuffer">;
+  let Args = [IntArgument<"Set">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 // StructuredBuffer types that can have associated counters
 def CounterStructuredBuffer : SubsetSubject<
     Var,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -432,8 +432,9 @@ SpirvEvalInfo DeclResultIdMapper::createExternVar(const VarDecl *var) {
   const auto *bindingAttr = var->getAttr<VKBindingAttr>();
   const auto *counterBindingAttr = var->getAttr<VKCounterBindingAttr>();
   const auto *setAttr = var->getAttr<VKSetAttr>();
+  SourceLocation loc = var->getLocation();
 
-  resourceVars.emplace_back(id, regAttr, bindingAttr, counterBindingAttr, setAttr);
+  resourceVars.emplace_back(id, loc, regAttr, bindingAttr, counterBindingAttr, setAttr);
 
   if (const auto *inputAttachment = var->getAttr<VKInputAttachmentIndexAttr>())
     theBuilder.decorateInputAttachmentIndex(id, inputAttachment->getIndex());
@@ -591,7 +592,8 @@ uint32_t DeclResultIdMapper::createCTBuffer(const HLSLBufferDecl *decl) {
                                              : spirvOptions.tBufferLayoutRule);
     astDecls[varDecl].indexInCTBuffer = index++;
   }
-  resourceVars.emplace_back(bufferVar, getResourceBinding(decl),
+  resourceVars.emplace_back(bufferVar, decl->getLocation(),
+			    getResourceBinding(decl),
                             decl->getAttr<VKBindingAttr>(),
                             decl->getAttr<VKCounterBindingAttr>(),
                             decl->getAttr<VKSetAttr>());
@@ -640,7 +642,8 @@ uint32_t DeclResultIdMapper::createCTBuffer(const VarDecl *decl) {
           .setStorageClass(spv::StorageClass::Uniform)
           .setLayoutRule(context->isCBuffer() ? spirvOptions.cBufferLayoutRule
                                               : spirvOptions.tBufferLayoutRule);
-  resourceVars.emplace_back(bufferVar, getResourceBinding(context),
+  resourceVars.emplace_back(bufferVar, decl->getLocation(),
+			    getResourceBinding(context),
                             decl->getAttr<VKBindingAttr>(),
                             decl->getAttr<VKCounterBindingAttr>(),
                             decl->getAttr<VKSetAttr>());
@@ -678,7 +681,8 @@ void DeclResultIdMapper::createGlobalsCBuffer(const VarDecl *var) {
       context, /*arraySize*/ 0, ContextUsageKind::Globals, "type.$Globals",
       "$Globals");
 
-  resourceVars.emplace_back(globals, nullptr, nullptr, nullptr, nullptr);
+  SourceLocation noLoc;
+  resourceVars.emplace_back(globals, noLoc, nullptr, nullptr, nullptr, nullptr);
 
   uint32_t index = 0;
   for (const auto *decl : typeTranslator.collectDeclsInDeclContext(context))
@@ -792,7 +796,8 @@ void DeclResultIdMapper::createCounterVar(
   if (!isAlias) {
     // Non-alias counter variables should be put in to resourceVars so that
     // descriptors can be allocated for them.
-    resourceVars.emplace_back(counterId, getResourceBinding(decl),
+    resourceVars.emplace_back(counterId, decl->getLocation(),
+			      getResourceBinding(decl),
                               decl->getAttr<VKBindingAttr>(),
                               decl->getAttr<VKCounterBindingAttr>(),
                               decl->getAttr<VKSetAttr>(), true);
@@ -1101,8 +1106,8 @@ private:
 bool DeclResultIdMapper::decorateResourceBindings() {
   // For normal resource, we support 4 approaches of setting binding numbers:
   // - m1: [[vk::binding(...)]]
-  // - m2: [[vk::set(...)]]
-  // - m3: :register(...)
+  // - m2: :register(...)
+  // - m3: [[vk::set(...)]]
   // - m4: None
   //
   // For associated counters, we support 2 approaches:
@@ -1139,25 +1144,19 @@ bool DeclResultIdMapper::decorateResourceBindings() {
           set = vkBinding->getSet();
         else if (const auto *reg = var.getRegister())
           set = reg->RegisterSpace;
+	else if (const auto *vkSet = var.getSet())
+          set = vkSet->getSet();
 
         tryToDecorate(var.getSpirvId(), set, vkCBinding->getBinding());
       }
     } else {
       if (const auto *vkBinding = var.getBinding()) {
+	if (const auto *vkSet = var.getSet()) {
+	  emitError("Invalid inclusion of vk::set with vk::binding", var.getLocation());
+	}
         // Process m1
         tryToDecorate(var.getSpirvId(), vkBinding->getSet(),
                       vkBinding->getBinding());
-      }
-    }
-  }
-
-  for (const auto &var : resourceVars) {
-    if (!var.isCounter() && !var.getBinding()) {
-      if (const auto *vkSet = var.getSet()) {
-        // Process m2
-        uint32_t set = vkSet->getSet();
-        theBuilder.decorateDSetBinding(var.getSpirvId(), set,
-                                       bindingSet.useNextBinding(set));
       }
     }
   }
@@ -1167,9 +1166,9 @@ bool DeclResultIdMapper::decorateResourceBindings() {
   BindingShiftMapper sShiftMapper(spirvOptions.sShift);
   BindingShiftMapper uShiftMapper(spirvOptions.uShift);
 
-  // Process m3
+  // Process m2
   for (const auto &var : resourceVars)
-    if (!var.isCounter() && !var.getBinding() && !var.getSet())
+    if (!var.isCounter() && !var.getBinding())
       if (const auto *reg = var.getRegister()) {
         const uint32_t set = reg->RegisterSpace;
         uint32_t binding = reg->RegisterNumber;
@@ -1196,6 +1195,17 @@ bool DeclResultIdMapper::decorateResourceBindings() {
         tryToDecorate(var.getSpirvId(), set, binding);
       }
 
+  // Process m3
+  for (const auto &var : resourceVars) {
+    if (!var.isCounter() && !var.getBinding() && !var.getRegister()) {
+      if (const auto *vkSet = var.getSet()) {
+        uint32_t set = vkSet->getSet();
+        theBuilder.decorateDSetBinding(var.getSpirvId(), set,
+                                       bindingSet.useNextBinding(set));
+      }
+    }
+  }
+
   for (const auto &var : resourceVars) {
     if (var.isCounter()) {
       if (!var.getCounterBinding()) {
@@ -1203,10 +1213,10 @@ bool DeclResultIdMapper::decorateResourceBindings() {
         uint32_t set = 0;
         if (const auto *vkBinding = var.getBinding())
           set = vkBinding->getSet();
-	else if (const auto *vkSet = var.getSet())
-          set = vkSet->getSet();
         else if (const auto *reg = var.getRegister())
           set = reg->RegisterSpace;
+	else if (const auto *vkSet = var.getSet())
+          set = vkSet->getSet();
 
         theBuilder.decorateDSetBinding(var.getSpirvId(), set,
                                        bindingSet.useNextBinding(set));

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -112,13 +112,14 @@ private:
 
 class ResourceVar {
 public:
-  ResourceVar(uint32_t id, const hlsl::RegisterAssignment *r,
+  ResourceVar(uint32_t id, const SourceLocation l, const hlsl::RegisterAssignment *r,
               const VKBindingAttr *b, const VKCounterBindingAttr *cb,
               const VKSetAttr *s, bool counter = false)
-      : varId(id), reg(r), binding(b), counterBinding(cb), set(s),
+      : varId(id), loc(l), reg(r), binding(b), counterBinding(cb), set(s),
         isCounterVar(counter) {}
 
   uint32_t getSpirvId() const { return varId; }
+  const SourceLocation getLocation() const { return loc; }
   const hlsl::RegisterAssignment *getRegister() const { return reg; }
   const VKBindingAttr *getBinding() const { return binding; }
   const VKSetAttr *getSet() const { return set; }
@@ -127,8 +128,10 @@ public:
     return counterBinding;
   }
 
+
 private:
   uint32_t varId;                             ///< <result-id>
+  const SourceLocation loc;                   ///< Vulkan Location
   const hlsl::RegisterAssignment *reg;        ///< HLSL register assignment
   const VKBindingAttr *binding;               ///< Vulkan binding assignment
   const VKCounterBindingAttr *counterBinding; ///< Vulkan counter binding

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -114,13 +114,14 @@ class ResourceVar {
 public:
   ResourceVar(uint32_t id, const hlsl::RegisterAssignment *r,
               const VKBindingAttr *b, const VKCounterBindingAttr *cb,
-              bool counter = false)
-      : varId(id), reg(r), binding(b), counterBinding(cb),
+              const VKSetAttr *s, bool counter = false)
+      : varId(id), reg(r), binding(b), counterBinding(cb), set(s),
         isCounterVar(counter) {}
 
   uint32_t getSpirvId() const { return varId; }
   const hlsl::RegisterAssignment *getRegister() const { return reg; }
   const VKBindingAttr *getBinding() const { return binding; }
+  const VKSetAttr *getSet() const { return set; }
   bool isCounter() const { return isCounterVar; }
   const VKCounterBindingAttr *getCounterBinding() const {
     return counterBinding;
@@ -131,6 +132,7 @@ private:
   const hlsl::RegisterAssignment *reg;        ///< HLSL register assignment
   const VKBindingAttr *binding;               ///< Vulkan binding assignment
   const VKCounterBindingAttr *counterBinding; ///< Vulkan counter binding
+  const VKSetAttr *set;                       ///< Vulkan set assignment
   bool isCounterVar;                          ///< Couter variable or not
 };
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10525,6 +10525,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
       ValidateAttributeIntArg(S, A), ValidateAttributeIntArg(S, A, 1),
       A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKSet:
+    declAttr = ::new (S.Context) VKSetAttr(A.getRange(), S.Context,
+      ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
+    break;
   case AttributeList::AT_VKCounterBinding:
     declAttr = ::new (S.Context) VKCounterBindingAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
@@ -13,17 +13,17 @@ RWStructuredBuffer<S> mySBuffer1;
 // CHECK:      OpDecorate %counter_var_mySBuffer1 DescriptorSet 3
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer1 Binding 10
 
-// vk::set + vk::counter_binding
-[[vk::set(4), vk::counter_binding(15)]]
-AppendStructuredBuffer<S> myASBufferS1;
-// CHECK:      OpDecorate %counter_var_myASBufferS1 DescriptorSet 4
-// CHECK-NEXT: OpDecorate %counter_var_myASBufferS1 Binding 15
-
 // :register + vk::counter_binding
 [[vk::counter_binding(20)]]
 AppendStructuredBuffer<S> myASBuffer1 : register(u1, space1);
 // CHECK:      OpDecorate %counter_var_myASBuffer1 DescriptorSet 1
 // CHECK-NEXT: OpDecorate %counter_var_myASBuffer1 Binding 20
+
+// vk::set + vk::counter_binding
+[[vk::set(4), vk::counter_binding(15)]]
+AppendStructuredBuffer<S> myASBufferS1;
+// CHECK:      OpDecorate %counter_var_myASBufferS1 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS1 Binding 15
 
 // none + vk::counter_binding
 [[vk::counter_binding(2)]]
@@ -37,14 +37,6 @@ RWStructuredBuffer<S> mySBuffer2;
 // CHECK:      OpDecorate %mySBuffer2 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %mySBuffer2 Binding 1
 
-// CHECK-NEXT: OpDecorate %myASBufferS1 DescriptorSet 4
-// CHECK-NEXT: OpDecorate %myASBufferS1 Binding 0
-
-// vk::set + none
-[[vk::set(4)]]
-AppendStructuredBuffer<S> myASBufferS2;
-// CHECK-NEXT: OpDecorate %myASBufferS2 DescriptorSet 4
-// CHECK-NEXT: OpDecorate %myASBufferS2 Binding 1
 
 // CHECK-NEXT: OpDecorate %myASBuffer1 DescriptorSet 1
 // CHECK-NEXT: OpDecorate %myASBuffer1 Binding 1
@@ -54,17 +46,26 @@ AppendStructuredBuffer<S> myASBuffer2 : register(u3, space2);
 // CHECK-NEXT: OpDecorate %myASBuffer2 DescriptorSet 2
 // CHECK-NEXT: OpDecorate %myASBuffer2 Binding 3
 
+// CHECK-NEXT: OpDecorate %myASBufferS1 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %myASBufferS1 Binding 0
+
+// vk::set + none
+[[vk::set(4)]]
+AppendStructuredBuffer<S> myASBufferS2;
+// CHECK-NEXT: OpDecorate %myASBufferS2 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %myASBufferS2 Binding 1
+
 // CHECK-NEXT: OpDecorate %myCSBuffer1 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %myCSBuffer1 Binding 0
 
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 Binding 3
 
-// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 DescriptorSet 4
-// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 Binding 2
-
 // CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 DescriptorSet 2
 // CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 Binding 0
+
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 Binding 2
 
 // none + none
 ConsumeStructuredBuffer<S> myCSBuffer2;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
@@ -13,6 +13,12 @@ RWStructuredBuffer<S> mySBuffer1;
 // CHECK:      OpDecorate %counter_var_mySBuffer1 DescriptorSet 3
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer1 Binding 10
 
+// vk::set + vk::counter_binding
+[[vk::set(4), vk::counter_binding(15)]]
+AppendStructuredBuffer<S> myASBufferS1;
+// CHECK:      OpDecorate %counter_var_myASBufferS1 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS1 Binding 15
+
 // :register + vk::counter_binding
 [[vk::counter_binding(20)]]
 AppendStructuredBuffer<S> myASBuffer1 : register(u1, space1);
@@ -31,6 +37,15 @@ RWStructuredBuffer<S> mySBuffer2;
 // CHECK:      OpDecorate %mySBuffer2 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %mySBuffer2 Binding 1
 
+// CHECK-NEXT: OpDecorate %myASBufferS1 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %myASBufferS1 Binding 0
+
+// vk::set + none
+[[vk::set(4)]]
+AppendStructuredBuffer<S> myASBufferS2;
+// CHECK-NEXT: OpDecorate %myASBufferS2 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %myASBufferS2 Binding 1
+
 // CHECK-NEXT: OpDecorate %myASBuffer1 DescriptorSet 1
 // CHECK-NEXT: OpDecorate %myASBuffer1 Binding 1
 
@@ -44,6 +59,9 @@ AppendStructuredBuffer<S> myASBuffer2 : register(u3, space2);
 
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 Binding 3
+
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 DescriptorSet 4
+// CHECK-NEXT: OpDecorate %counter_var_myASBufferS2 Binding 2
 
 // CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 DescriptorSet 2
 // CHECK-NEXT: OpDecorate %counter_var_myASBuffer2 Binding 0

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -59,7 +59,28 @@ RWStructuredBuffer<S> sbuffer2 : register(u6);
 // CHECK-NEXT: OpDecorate %asbuffer Binding 1
 // CHECK-NEXT: OpDecorate %csbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %csbuffer Binding 21
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 DescriptorSet 3
+
+// CHECK:      OpDecorate %samplerA DescriptorSet 0
+// CHECK-NEXT: OpDecorate %samplerA Binding 1
+[[vk::set(0)]]
+SamplerState samplerA      : register(s1, space1);
+// CHECK:      OpDecorate %samplerB DescriptorSet 0
+// CHECK-NEXT: OpDecorate %samplerB Binding 4
+[[vk::set(0)]]
+SamplerState samplerB      : register(s2, space1);
+// CHECK:      OpDecorate %samplerC DescriptorSet 2
+// CHECK-NEXT: OpDecorate %samplerC Binding 0
+[[vk::set(2)]]
+SamplerState samplerC      : register(s3, space2);
+// CHECK:      OpDecorate %samplerD DescriptorSet 2
+// CHECK-NEXT: OpDecorate %samplerD Binding 1
+[[vk::set(2)]]
+SamplerState samplerD      : register(s7, space0);
+// CHECK:      OpDecorate %samplerE DescriptorSet 2
+// CHECK-NEXT: OpDecorate %samplerE Binding 4
+[[vk::set(2)]]
+SamplerState samplerE      : register(s0, space0);
+// CHECK: OpDecorate %counter_var_sbuffer2 DescriptorSet 3
 // CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 0
 // CHECK-NEXT: OpDecorate %counter_var_asbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %counter_var_asbuffer Binding 0

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -60,26 +60,26 @@ RWStructuredBuffer<S> sbuffer2 : register(u6);
 // CHECK-NEXT: OpDecorate %csbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %csbuffer Binding 21
 
-// CHECK:      OpDecorate %samplerA DescriptorSet 0
-// CHECK-NEXT: OpDecorate %samplerA Binding 1
+// CHECK:      OpDecorate %samplerA DescriptorSet 1
+// CHECK-NEXT: OpDecorate %samplerA Binding 7
 [[vk::set(0)]]
-SamplerState samplerA      : register(s1, space1);
-// CHECK:      OpDecorate %samplerB DescriptorSet 0
-// CHECK-NEXT: OpDecorate %samplerB Binding 4
+SamplerState samplerA      : register(s7, space1);
+// CHECK:      OpDecorate %samplerB DescriptorSet 1
+// CHECK-NEXT: OpDecorate %samplerB Binding 8
 [[vk::set(0)]]
-SamplerState samplerB      : register(s2, space1);
+SamplerState samplerB      : register(s8, space1);
 // CHECK:      OpDecorate %samplerC DescriptorSet 2
 // CHECK-NEXT: OpDecorate %samplerC Binding 0
 [[vk::set(2)]]
-SamplerState samplerC      : register(s3, space2);
+SamplerState samplerC;
 // CHECK:      OpDecorate %samplerD DescriptorSet 2
 // CHECK-NEXT: OpDecorate %samplerD Binding 1
 [[vk::set(2)]]
-SamplerState samplerD      : register(s7, space0);
+SamplerState samplerD;
 // CHECK:      OpDecorate %samplerE DescriptorSet 2
 // CHECK-NEXT: OpDecorate %samplerE Binding 4
 [[vk::set(2)]]
-SamplerState samplerE      : register(s0, space0);
+SamplerState samplerE;
 // CHECK: OpDecorate %counter_var_sbuffer2 DescriptorSet 3
 // CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 0
 // CHECK-NEXT: OpDecorate %counter_var_asbuffer DescriptorSet 1

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
@@ -49,39 +49,39 @@ RWStructuredBuffer<S> impBindVsRegImpCt : register(u9, space4);
 // CHECK:      OpDecorate %impBindVsRegImpCt DescriptorSet 0
 // CHECK-NEXT: OpDecorate %impBindVsRegImpCt Binding 12
 
-// vk::set > :register explicit counter (counter part)
+// :register > vk::set explicit counter (counter part)
 [[vk::set(3), vk::counter_binding(2)]]
-ConsumeStructuredBuffer<S> setVsRegExCt;
-// CHECK:      OpDecorate %counter_var_setVsRegExCt DescriptorSet 3
+ConsumeStructuredBuffer<S> setVsRegExCt :register(u9, space6);
+// CHECK:      OpDecorate %counter_var_setVsRegExCt DescriptorSet 6
 // CHECK-NEXT: OpDecorate %counter_var_setVsRegExCt Binding 2
 
-// vk::set > :register explicit counter (main part)
-// CHECK-NEXT: OpDecorate %setVsRegExCt DescriptorSet 3
-// CHECK-NEXT: OpDecorate %setVsRegExCt Binding 0
+// :register > vk::set explicit counter (main part)
+// CHECK-NEXT: OpDecorate %setVsRegExCt DescriptorSet 6
+// CHECK-NEXT: OpDecorate %setVsRegExCt Binding 9
 
-// vk::set > :register
+// :register > vk::set
 [[vk::set(1)]]
 Buffer<int> SetVsReg : register(t2, space3);
-// CHECK:      OpDecorate %SetVsReg DescriptorSet 1
-// CHECK-NEXT: OpDecorate %SetVsReg Binding 0
+// CHECK:      OpDecorate %SetVsReg DescriptorSet 3
+// CHECK-NEXT: OpDecorate %SetVsReg Binding 2
 
-// vk::set > :register implicit counter (main part)
+// :register > vk::set implicit counter (main part)
 [[vk::set(3)]]
 AppendStructuredBuffer<S> setVsRegImpCt : register(u6, space2);
-// CHECK-NEXT: OpDecorate %setVsRegImpCt DescriptorSet 3
-// CHECK-NEXT: OpDecorate %setVsRegImpCt Binding 1
+// CHECK-NEXT: OpDecorate %setVsRegImpCt DescriptorSet 2
+// CHECK-NEXT: OpDecorate %setVsRegImpCt Binding 6
 
 // explicit set vk::binding > :register implicit counter (counter part)
 // CHECK:      OpDecorate %counter_var_exBindVsRegImpCt DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegImpCt Binding 3
+// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegImpCt Binding 0
 
 // implicit set vk::binding > :register implicit counter (counter part)
 // CHECK:      OpDecorate %counter_var_impBindVsRegImpCt DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_impBindVsRegImpCt Binding 0
 
-// vk::set > :register implicit counter (counter part)
-// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt Binding 5
+// :register > vk::set implicit counter (counter part)
+// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt DescriptorSet 2
+// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt Binding 0
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
@@ -4,8 +4,8 @@ struct S {
     float4 f;
 };
 
-// Verify that descriptor set-indicating override per: vk::binding > :register
-// using variations on these and vk::counter_binding
+// Verify that descriptor set-indicating override per: vk::binding > :register and
+// :register > vk::set, using variations on these and vk::counter_binding
 
 // explicit set vk::binding > :register
 [[vk::binding(5, 4)]]
@@ -49,13 +49,39 @@ RWStructuredBuffer<S> impBindVsRegImpCt : register(u9, space4);
 // CHECK:      OpDecorate %impBindVsRegImpCt DescriptorSet 0
 // CHECK-NEXT: OpDecorate %impBindVsRegImpCt Binding 12
 
+// vk::set > :register explicit counter (counter part)
+[[vk::set(3), vk::counter_binding(2)]]
+ConsumeStructuredBuffer<S> setVsRegExCt;
+// CHECK:      OpDecorate %counter_var_setVsRegExCt DescriptorSet 3
+// CHECK-NEXT: OpDecorate %counter_var_setVsRegExCt Binding 2
+
+// vk::set > :register explicit counter (main part)
+// CHECK-NEXT: OpDecorate %setVsRegExCt DescriptorSet 3
+// CHECK-NEXT: OpDecorate %setVsRegExCt Binding 0
+
+// vk::set > :register
+[[vk::set(1)]]
+Buffer<int> SetVsReg : register(t2, space3);
+// CHECK:      OpDecorate %SetVsReg DescriptorSet 1
+// CHECK-NEXT: OpDecorate %SetVsReg Binding 0
+
+// vk::set > :register implicit counter (main part)
+[[vk::set(3)]]
+AppendStructuredBuffer<S> setVsRegImpCt : register(u6, space2);
+// CHECK-NEXT: OpDecorate %setVsRegImpCt DescriptorSet 3
+// CHECK-NEXT: OpDecorate %setVsRegImpCt Binding 1
+
 // explicit set vk::binding > :register implicit counter (counter part)
 // CHECK:      OpDecorate %counter_var_exBindVsRegImpCt DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegImpCt Binding 0
+// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegImpCt Binding 3
 
 // implicit set vk::binding > :register implicit counter (counter part)
 // CHECK:      OpDecorate %counter_var_impBindVsRegImpCt DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_impBindVsRegImpCt Binding 0
+
+// vk::set > :register implicit counter (counter part)
+// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt DescriptorSet 3
+// CHECK-NEXT: OpDecorate %counter_var_setVsRegImpCt Binding 5
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.setbinding.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.setbinding.hlsl
@@ -1,0 +1,99 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct S {
+    float4 f;
+};
+
+// vk::binding w/vk::set w/:register
+[[vk::binding(1, 0), vk::set(2)]]
+SamplerState bindVsSetVsReg      : register(s3, space4);
+// CHECK:      9:14: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/vk::binding w/:register
+[[vk::set(2), vk::binding(1, 0)]]
+SamplerState setVsBindVsReg      : register(s3, space4);
+// CHECK:      14:14: error: Invalid inclusion of vk::set with vk::binding
+
+// explicit vk::binding w/vk::set
+[[vk::binding(6,5), vk::set(7)]]
+Texture2D<float4> ExBindVsSet;
+// CHECK:      19:19: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/explicit vk::binding
+[[vk::set(7), vk::binding(6,5)]]
+Texture2D<float4> SetVsExBind;
+// CHECK:      24:19: error: Invalid inclusion of vk::set with vk::binding
+
+// implicit vk::binding w/vk::set
+[[vk::binding(7), vk::set(9)]]
+Texture3D<float4> ImpBindVsSet;
+// CHECK:      29:19: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/implicit vk::binding
+[[vk::set(9), vk::binding(7)]]
+Texture3D<float4> SetVsImpBind;
+// CHECK:      34:19: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::binding w/vk::set w/:register explicit counter
+[[vk::binding(2, 1), vk::set(2), vk::counter_binding(3)]]
+RWStructuredBuffer<S> BindVsSetVsRegExCt : register(u3, space4);
+// CHECK:      39:23: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::binding w/vk::set w/:register explicit counter
+[[vk::set(2), vk::binding(2, 1), vk::counter_binding(3)]]
+RWStructuredBuffer<S> setVsBindVsRegExCt : register(u3, space4);
+// CHECK:      44:23: error: Invalid inclusion of vk::set with vk::binding
+
+// explicit vk::binding w/vk::set explicit counter
+[[vk::binding(5, 6), vk::set(7), vk::counter_binding(3)]]
+AppendStructuredBuffer<S> ExBindVsSetExCt;
+// CHECK:      49:27: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/explicit vk::binding explicit counter
+[[vk::set(7), vk::binding(5, 6), vk::counter_binding(3)]]
+AppendStructuredBuffer<S> SetVsExBindExCt;
+// CHECK:      54:27: error: Invalid inclusion of vk::set with vk::binding
+
+// implicit vk::binding w/vk::set explicit counter
+[[vk::binding(9), vk::set(11), vk::counter_binding(10)]]
+ConsumeStructuredBuffer<S> impBindVsSetExCt;
+// CHECK:      59:28: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/implicit vk::binding explicit counter
+[[vk::set(11), vk::binding(9), vk::counter_binding(10)]]
+ConsumeStructuredBuffer<S> setVsImpBindExCt;
+// CHECK:      64:28: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::binding w/vk::set w/:register implicit counter (main part)
+[[vk::binding(5, 3), vk::set(4)]]
+RWStructuredBuffer<S> bindVsSetVsRegImpCt : register(u9, space2);
+// CHECK:      69:23: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/vk::binding w/:register implicit counter (main part)
+[[vk::set(4), vk::binding(5, 3)]]
+RWStructuredBuffer<S> setVsBindVsRegImpCt : register(u9, space2);
+// CHECK:      74:23: error: Invalid inclusion of vk::set with vk::binding
+
+// explicit vk::binding w/vk::set implicit counter (main part)
+[[vk::binding(4), vk::set(6)]]
+AppendStructuredBuffer<S> exBindVsSetImpCt;
+// CHECK:      79:27: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/explicit vk::binding implicit counter (main part)
+[[vk::set(6), vk::binding(4)]]
+AppendStructuredBuffer<S> setVsExBindImpCt;
+// CHECK:      84:27: error: Invalid inclusion of vk::set with vk::binding
+
+// implicit vk::binding w/vk::set implicit counter (main part)
+[[vk::binding(11), vk::set(7)]]
+AppendStructuredBuffer<S> impBindVsSetImpCt;
+// CHECK:      89:27: error: Invalid inclusion of vk::set with vk::binding
+
+// vk::set w/implicit vk::binding implicit counter (main part)
+[[vk::set(7), vk::binding(11)]]
+AppendStructuredBuffer<S> SetVsImpBindImpCt;
+// CHECK:      94:27: error: Invalid inclusion of vk::set with vk::binding
+
+float4 main() : SV_Target {
+    return  1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1341,7 +1341,7 @@ TEST_F(FileTest, VulkanImplicitBinding) {
   runFileTest("vk.binding.implicit.hlsl");
 }
 TEST_F(FileTest, VulkanPrecedenceBinding) {
-  // Bindings from vk::binding and :register competing for dominance
+  // Bindings from vk::binding, :register, and vk::set competing for dominance
   runFileTest("vk.binding.precedence.hlsl");
 }
 TEST_F(FileTest, VulkanRegisterBinding) {
@@ -1362,6 +1362,10 @@ TEST_F(FileTest, VulkanStructuredBufferCounter) {
   // [[vk::counter_binding()]] for RWStructuredBuffer, AppendStructuredBuffer,
   // and ConsumeStructuredBuffer
   runFileTest("vk.binding.counter.hlsl");
+}
+TEST_F(FileTest, VulkanSetBindingErrors) {
+  // Combine vk::set and vk::binding in various erroneous ways.
+  runFileTest("vk.binding.setbinding.hlsl", Expect::Failure);
 }
 
 TEST_F(FileTest, VulkanPushConstant) { runFileTest("vk.push-constant.hlsl"); }


### PR DESCRIPTION
A new attribute [[vk::set(X)]] can be used to specify the descriptor
set of a resource variable, leaving the binding index to be
determined automatically based on what's available.

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/1340