### PR TITLE
[spirv] Append must load pointers first

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -3474,7 +3474,12 @@ SPIRVEmitter::processACSBufferAppendConsume(const CXXMemberCallExpr *expr) {
 
   if (isAppend) {
     // Write out the value
-    storeValue(bufferInfo, doExpr(expr->getArg(0)), bufferElemTy);
+    auto arg0 = doExpr(expr->getArg(0));
+    if(!arg0.isRValue()) {
+      arg0.setResultId(theBuilder.createLoad(
+          typeTranslator.translateType(bufferElemTy), arg0));
+    }
+    storeValue(bufferInfo, arg0, bufferElemTy);
     return 0;
   } else {
     // Note that we are returning a pointer (lvalue) here inorder to further

--- a/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.append-structured-buffer.append.hlsl
@@ -9,6 +9,9 @@ struct S {
 AppendStructuredBuffer<float4> buffer1;
 AppendStructuredBuffer<S>      buffer2;
 
+// Use this to test appending a consumed value.
+ConsumeStructuredBuffer<float4> buffer3;
+
 void main(float4 vec: A) {
 // CHECK:      [[counter:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_buffer1 %uint_0
 // CHECK-NEXT: [[index:%\d+]] = OpAtomicIAdd %int [[counter]] %uint_1 %uint_0 %int_1
@@ -32,4 +35,10 @@ void main(float4 vec: A) {
 // CHECK-NEXT: [[val:%\d+]] = OpCompositeConstruct %S [[s_a]] [[s_b]] [[s_c]]
 // CHECK-NEXT: OpStore [[buffer2]] [[val]]
     buffer2.Append(s);
+
+// CHECK:           [[buffer1:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer1 %uint_0 {{%\d+}}
+// CHECK:      [[consumed_ptr:%\d+]] = OpAccessChain %_ptr_Uniform_v4float %buffer3 %uint_0 {{%\d+}}
+// CHECK-NEXT:     [[consumed:%\d+]] = OpLoad %v4float [[consumed_ptr]]
+// CHECK-NEXT:                         OpStore [[buffer1]] [[consumed]]
+    buffer1.Append(buffer3.Consume());
 }


### PR DESCRIPTION
The AppendStructuredBuffer's Append method was not checking for lvalues.