### PR TITLE
[linux-port] Add missing case statements

### DIFF
--- a/lib/HLSL/DxilContainerAssembler.cpp
+++ b/lib/HLSL/DxilContainerAssembler.cpp
@@ -55,6 +55,9 @@ static DxilProgramSigSemantic KindToSystemValue(Semantic::Kind kind, DXIL::Tesse
       return DxilProgramSigSemantic::FinalTriEdgeTessfactor;
     case DXIL::TessellatorDomain::Quad:
       return DxilProgramSigSemantic::FinalQuadEdgeTessfactor;
+    default:
+      // No other valid TesselatorDomain options.
+      return DxilProgramSigSemantic::Undefined;
     }
   }
   case Semantic::Kind::InsideTessFactor: {
@@ -66,6 +69,9 @@ static DxilProgramSigSemantic KindToSystemValue(Semantic::Kind kind, DXIL::Tesse
       return DxilProgramSigSemantic::FinalTriInsideTessfactor;
     case DXIL::TessellatorDomain::Quad:
       return DxilProgramSigSemantic::FinalQuadInsideTessfactor;
+    default:
+      // No other valid DxilProgramSigSemantic options.
+      return DxilProgramSigSemantic::Undefined;
     }
   }
   case Semantic::Kind::Invalid:
@@ -296,6 +302,8 @@ DxilPartWriter *hlsl::NewProgramSignatureWriter(const DxilModule &M, DXIL::Signa
         M.GetPatchConstantSignature(), M.GetTessellatorDomain(),
         /*IsInput*/ M.GetShaderModel()->IsDS(),
         /*UseMinPrecision*/!M.m_ShaderFlags.GetUseNativeLowPrecision());
+  case DXIL::SignatureKind::Invalid:
+    return nullptr;
   }
   return nullptr;
 }
@@ -579,6 +587,11 @@ public:
         }
         break;
       }
+    case ShaderModel::Kind::Compute:
+    case ShaderModel::Kind::Library:
+    case ShaderModel::Kind::Invalid:
+      // Compute, Library, and Invalide not relevant to PSVRuntimeInfo0
+      break;
     }
 
     // Set resource binding information

--- a/lib/HLSL/DxilConvergent.cpp
+++ b/lib/HLSL/DxilConvergent.cpp
@@ -181,6 +181,9 @@ Value *DxilConvergentMark::FindConvergentOperand(Instruction *I) {
       case IntrinsicOp::MOP_GatherGreen:
       case IntrinsicOp::MOP_GatherRed:
         return CI->getArgOperand(HLOperandIndex::kGatherCoordArgIndex);
+      default:
+        // No other ops have convergent operands.
+        break;
       }
     }
   }

--- a/lib/HLSL/DxilDebugInstrumentation.cpp
+++ b/lib/HLSL/DxilDebugInstrumentation.cpp
@@ -691,6 +691,9 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC, Instruction
   case Type::TypeID::FunctionTyID:
   case Type::TypeID::ArrayTyID:
   case Type::TypeID::VectorTyID:
+  case Type::TypeID::X86_FP80TyID:
+  case Type::TypeID::X86_MMXTyID:
+  case Type::TypeID::PPC_FP128TyID:
     assert(false);
   }
 

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -789,6 +789,12 @@ void HLMatrixLowerPass::lowerToVec(Instruction *matInst) {
     case HLOpcodeGroup::HLSubscript: {
       vecInst = MatSubscriptToVec(CI);
     } break;
+    case HLOpcodeGroup::NotHL:
+    case HLOpcodeGroup::HLExtIntrinsic:
+    case HLOpcodeGroup::HLCreateHandle:
+    case HLOpcodeGroup::NumOfHLOps:
+      // Not matrix instructions
+      break;
     }
   } else if (AllocaInst *AI = dyn_cast<AllocaInst>(matInst)) {
     Type *Ty = AI->getAllocatedType();
@@ -841,6 +847,12 @@ void HLMatrixLowerPass::TrivialMatUnOpReplace(CallInst *matInst,
   case HLUnaryOpcode::PostDec:
   case HLUnaryOpcode::PreDec:
     vecUseInst->setOperand(0, vecInst);
+    break;
+  case HLUnaryOpcode::Invalid:
+  case HLUnaryOpcode::Plus:
+  case HLUnaryOpcode::Minus:
+  case HLUnaryOpcode::NumOfUO:
+    // No VecInst replacements for these.
     break;
   }
 }
@@ -2089,6 +2101,12 @@ void HLMatrixLowerPass::replaceMatWithVec(Instruction *matInst,
         DXASSERT(!isa<AllocaInst>(matInst), "array of matrix init should lowered in StoreInitListToDestPtr at CGHLSLMS.cpp");
         TranslateMatInit(useCall);
       } break;
+      case HLOpcodeGroup::NotHL:
+      case HLOpcodeGroup::HLExtIntrinsic:
+      case HLOpcodeGroup::HLCreateHandle:
+      case HLOpcodeGroup::NumOfHLOps:
+      // No vector equivalents for these ops.
+	break;
       }
     } else if (dyn_cast<BitCastInst>(useInst)) {
       // Just replace the src with vec version.

--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -168,9 +168,13 @@ llvm::StringRef GetHLOpcodeName(HLUnaryOpcode Op) {
   case HLUnaryOpcode::Minus:   return "-";
   case HLUnaryOpcode::Not:     return "~";
   case HLUnaryOpcode::LNot:    return "!";
+  case HLUnaryOpcode::Invalid:
+  case HLUnaryOpcode::NumOfUO:
+    // Invalid Unary Ops
+    break;
   }
   llvm_unreachable("Unknown unary operator");
-  
+
 }
 
 llvm::StringRef GetHLOpcodeName(HLBinaryOpcode Op) {
@@ -200,6 +204,10 @@ llvm::StringRef GetHLOpcodeName(HLBinaryOpcode Op) {
   case HLBinaryOpcode::Or:        return "|";
   case HLBinaryOpcode::LAnd:      return "&&";
   case HLBinaryOpcode::LOr:       return "||";
+  case HLBinaryOpcode::Invalid:
+  case HLBinaryOpcode::NumOfBO:
+    // Invalid Binary Ops
+    break;
   }
 
   llvm_unreachable("Invalid OpCode!");
@@ -425,6 +433,13 @@ static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
     F->addFnAttr(Attribute::NoInline);
     F->setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
   } break;
+  case HLOpcodeGroup::NotHL:
+  case HLOpcodeGroup::HLExtIntrinsic:
+  case HLOpcodeGroup::HLIntrinsic:
+  case HLOpcodeGroup::HLSelect:
+  case HLOpcodeGroup::NumOfHLOps:
+    // No default attributes for these opcodes.
+    break;
   }
 }
 

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -54,9 +54,16 @@ unsigned UpateSemanticAndInterpMode(StringRef &semName,
     case InterpolationMode::Kind::Linear:
       mode = InterpolationMode::Kind::LinearNoperspective;
       break;
-    case InterpolationMode::Kind::Constant: {
+    case InterpolationMode::Kind::Constant:
+    case InterpolationMode::Kind::Undefined:
+    case InterpolationMode::Kind::Invalid: {
       Context.emitError("invalid interpolation mode for SV_Position");
     } break;
+    case InterpolationMode::Kind::LinearNoperspective:
+    case InterpolationMode::Kind::LinearNoperspectiveCentroid:
+    case InterpolationMode::Kind::LinearNoperspectiveSample:
+      // Already Noperspective modes.
+      break;
     }
   }
   return semIndex;
@@ -676,6 +683,9 @@ void replaceDirectInputParameter(Value *param, Function *loadInput,
       CI->replaceAllUsesWith(newVec);
       CI->eraseFromParent();
     } break;
+    default:
+      // Only matrix to vector casts are valid.
+      break;
     }
   } else {
     DXASSERT(0, "invalid type for direct input");

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5263,7 +5263,7 @@ Value *SROA_Parameter_HLSL::castArgumentIfRequired(
             // Set arg to CI again.
             RowMat->setArgOperand(HLOperandIndex::kUnaryOpSrc0Idx, CI);
           } break;
-          case HLMatLoadStoreOpcode::RowMatStore:
+          case HLMatLoadStoreOpcode::RowMatStore: {
             // Update matrix function opcode to col major version.
             Value *rowOpArg = ConstantInt::get(
                 opcodeTy,
@@ -5275,6 +5275,10 @@ Value *SROA_Parameter_HLSL::castArgumentIfRequired(
                 Builder, HLOpcodeGroup::HLCast,
                 (unsigned)HLCastOpcode::RowMatrixToColMatrix, Ty, {Mat}, M);
             CI->setArgOperand(HLOperandIndex::kMatStoreValOpIdx, RowMat);
+          } break;
+          case HLMatLoadStoreOpcode::ColMatLoad:
+          case HLMatLoadStoreOpcode::ColMatStore:
+            // Only row matrices can be converted to col matrices.
             break;
           }
         }

--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -4618,6 +4618,8 @@ QualType ASTContext::getFloatingTypeOfSizeWithinDomain(QualType Size,
     case FloatRank:      return FloatComplexTy;
     case DoubleRank:     return DoubleComplexTy;
     case LongDoubleRank: return LongDoubleComplexTy;
+    case LitFloatRank:   llvm_unreachable("Complex LitFloat is not supported");  // HLSL Change
+    case Min10FloatRank: llvm_unreachable("Complex Min10Float is not supported"); // HLSL Change
     }
   }
 
@@ -5457,6 +5459,13 @@ static char getObjCEncodingForPrimitiveKind(const ASTContext *C,
     case BuiltinType::KIND:
 #include "clang/AST/BuiltinTypes.def"
       llvm_unreachable("invalid builtin type for @encode");
+    // HLSL Change Start
+    case BuiltinType::Min12Int:
+    case BuiltinType::Min10Float:
+    case BuiltinType::LitInt:
+    case BuiltinType::LitFloat:
+      llvm_unreachable("@encoding HLSL primitive type");
+    // HLSL Change Ends
     }
     llvm_unreachable("invalid BuiltinType::Kind value");
 }

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -1139,13 +1139,11 @@ UnusualAnnotation* hlsl::UnusualAnnotation::CopyToASTContext(ASTContext& Context
 
 static bool HasTessFactorSemantic(const ValueDecl *decl) {
   for (const UnusualAnnotation *it : decl->getUnusualAnnotations()) {
-    switch (it->getKind()) {
-    case UnusualAnnotation::UA_SemanticDecl: {
+    if (it->getKind() == UnusualAnnotation::UA_SemanticDecl) {
       const SemanticDecl *sd = cast<SemanticDecl>(it);
       const Semantic *pSemantic = Semantic::GetByName(sd->SemanticName);
       if (pSemantic && pSemantic->GetKind() == Semantic::Kind::TessFactor)
         return true;
-    }
     }
   }
   return false;

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -460,6 +460,9 @@ bool IsParamAttributedAsOut(clang::AttributeList *pAttributes, bool *pIsIn) {
       outFound = true;
       inFound = true;
       break;
+    default:
+      // Ignore the majority of attributes that don't have in/out characteristics
+      break;
     }
     pAttributes = pAttributes->getNext();
   }
@@ -502,6 +505,9 @@ HLSLScalarType MakeUnsigned(HLSLScalarType T) {
         return HLSLScalarType_uint64;
     case HLSLScalarType_int16:
         return HLSLScalarType_uint16;
+    default:
+        // Only signed int types are relevant.
+        break;
     }
     return T;
 }

--- a/tools/clang/lib/AST/ItaniumMangle.cpp
+++ b/tools/clang/lib/AST/ItaniumMangle.cpp
@@ -2039,6 +2039,12 @@ void CXXNameMangler::mangleType(const BuiltinType *T) {
   case BuiltinType::OCLImage3d: Out << "11ocl_image3d"; break;
   case BuiltinType::OCLSampler: Out << "11ocl_sampler"; break;
   case BuiltinType::OCLEvent: Out << "9ocl_event"; break;
+    // HLSL Change starts
+  case BuiltinType::Min12Int: Out << "min21_int"; break;
+  case BuiltinType::LitInt: Out << "lit_int"; break;
+  case BuiltinType::LitFloat: Out << "lit_float"; break;
+  case BuiltinType::Min10Float: Out << "min10_float"; break;
+    // HLSL Change ends
   }
 }
 

--- a/tools/clang/lib/AST/TypePrinter.cpp
+++ b/tools/clang/lib/AST/TypePrinter.cpp
@@ -1152,6 +1152,9 @@ void TypePrinter::printAttributedBefore(const AttributedType *T,
     case AttributedType::attr_hlsl_column_major: OS << "column_major "; break;
     case AttributedType::attr_hlsl_unorm: OS << "unorm "; break;
     case AttributedType::attr_hlsl_snorm: OS << "snorm "; break;
+    default:
+      // Only HLSL attribute types are covered.
+      break;
     }
   }
   // HLSL Change Ends

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -449,6 +449,24 @@ llvm::DIType *CGDebugInfo::CreateType(const BuiltinType *BT) {
         CGM.getContext().getTypeAlign(BT), llvm::dwarf::DW_ATE_unsigned);
   case BuiltinType::OCLEvent:
     return getOrCreateStructPtrType("opencl_event_t", OCLEventDITy);
+#else
+  case BuiltinType::ObjCClass:
+  case BuiltinType::ObjCId:
+  case BuiltinType::ObjCSel:
+  case BuiltinType::OCLImage1d:
+  case BuiltinType::OCLImage1dArray:
+  case BuiltinType::OCLImage1dBuffer:
+  case BuiltinType::OCLImage2d:
+  case BuiltinType::OCLImage2dArray:
+  case BuiltinType::OCLImage3d:
+  case BuiltinType::OCLSampler:
+  case BuiltinType::OCLEvent:
+    llvm_unreachable("No ObjC or OpenCL support");
+  case BuiltinType::Min12Int:
+  case BuiltinType::LitInt:
+  case BuiltinType::Min10Float:
+  case BuiltinType::LitFloat:
+    llvm_unreachable("Unsupported HLSL types");
 #endif // HLSL Change - no ObjC or OpenCL support
 
   case BuiltinType::UChar:
@@ -2133,6 +2151,11 @@ llvm::DIType *CGDebugInfo::CreateTypeNode(QualType Ty, llvm::DIFile *Unit) {
     return CreateType(cast<ObjCObjectType>(Ty), Unit);
   case Type::ObjCInterface:
     return CreateType(cast<ObjCInterfaceType>(Ty), Unit);
+#else
+  case Type::ObjCObjectPointer:
+  case Type::ObjCObject:
+  case Type::ObjCInterface:
+    llvm_unreachable("No ObjC Support");
 #endif // HLSL Change - no ObjC support
   case Type::Builtin:
     return CreateType(cast<BuiltinType>(Ty));
@@ -2148,6 +2171,9 @@ llvm::DIType *CGDebugInfo::CreateTypeNode(QualType Ty, llvm::DIFile *Unit) {
 #if 0 // HLSL Change - no block support
   case Type::BlockPointer:
     return CreateType(cast<BlockPointerType>(Ty), Unit);
+#else
+  case Type::BlockPointer:
+    llvm_unreachable("No Block Support");
 #endif // HLSL Change - no block support
   case Type::Typedef:
     return CreateType(cast<TypedefType>(Ty), Unit);

--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -92,6 +92,7 @@ void CodeGenFunction::EmitDecl(const Decl &D) {
   case Decl::Import:
   case Decl::OMPThreadPrivate:
   case Decl::Empty:
+  case Decl::HLSLBuffer: // HLSL Change
     // None of these decls require codegen support.
     return;
 

--- a/tools/clang/lib/CodeGen/CGExpr.cpp
+++ b/tools/clang/lib/CodeGen/CGExpr.cpp
@@ -3486,6 +3486,17 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
     llvm::Value *GEP = Builder.CreateInBoundsGEP(This, IdxList);
     return MakeAddrLValue(GEP, ToType);
   }
+  case CK_HLSLMatrixSplat:
+  case CK_HLSLMatrixToScalarCast:
+  case CK_HLSLMatrixTruncationCast:
+  case CK_HLSLMatrixToVectorCast:
+    // Matrices should be handled above.
+  case CK_HLSLVectorToMatrixCast:
+  case CK_HLSLCC_IntegralCast:
+  case CK_HLSLCC_IntegralToBoolean:
+  case CK_HLSLCC_FloatingToBoolean:
+  case CK_HLSLCC_FloatingCast:
+    llvm_unreachable("Unhandled HLSL lvalue cast");
   // HLSL Change Ends
   case CK_ZeroToOCLEvent:
     llvm_unreachable("NULL to OpenCL event lvalue cast is not valid");

--- a/tools/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/tools/clang/lib/CodeGen/CGExprComplex.cpp
@@ -484,6 +484,24 @@ ComplexPairTy ComplexExprEmitter::EmitCast(CastKind CK, Expr *Op,
   case CK_BuiltinFnToFnPtr:
   case CK_ZeroToOCLEvent:
   case CK_AddressSpaceConversion:
+  // HLSL Change Start
+  case CK_FlatConversion:
+  case CK_HLSLVectorSplat:
+  case CK_HLSLMatrixSplat:
+  case CK_HLSLVectorToScalarCast:
+  case CK_HLSLMatrixToScalarCast:
+  case CK_HLSLVectorTruncationCast:
+  case CK_HLSLMatrixTruncationCast:
+  case CK_HLSLVectorToMatrixCast:
+  case CK_HLSLMatrixToVectorCast:
+  case CK_HLSLDerivedToBase:
+  case CK_HLSLCC_IntegralCast:
+  case CK_HLSLCC_IntegralToBoolean:
+  case CK_HLSLCC_IntegralToFloating:
+  case CK_HLSLCC_FloatingToIntegral:
+  case CK_HLSLCC_FloatingToBoolean:
+  case CK_HLSLCC_FloatingCast:
+  // HLSL Change End
     llvm_unreachable("invalid cast kind for complex value");
 
   case CK_FloatingRealToComplex:

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -708,6 +708,9 @@ static CompType::Kind BuiltinTyToCompTy(const BuiltinType *BTy, bool bSNorm,
   case BuiltinType::Bool:
     kind = CompType::Kind::I1;
     break;
+  default:
+    // Other types not used by HLSL.
+    break;
   }
   return kind;
 }
@@ -1454,6 +1457,10 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
     case ShaderModel::Kind::Pixel:
       DXASSERT(funcProps->shaderKind == SM->GetKind(),
                "attribute profile not match entry function profile");
+      break;
+    case ShaderModel::Kind::Library:
+    case ShaderModel::Kind::Invalid:
+      // Non-shader stage shadermodels don't have entry points.
       break;
     }
   }

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -137,7 +137,10 @@ void CodeGenFunction::EmitStmt(const Stmt *S) {
   case Stmt::ReturnStmtClass:   EmitReturnStmt(cast<ReturnStmt>(*S));     break;
 
   case Stmt::SwitchStmtClass:   EmitSwitchStmt(cast<SwitchStmt>(*S));     break;
-#if 0 // HLSL Change - no support for assembler, captures, ObjC, exception handling, for-range, openmp
+#if 1 // HLSL Change - no support for assembler, captures, ObjC, exception handling, for-range, openmp
+  default:
+    break;
+#else
   case Stmt::GCCAsmStmtClass:   // Intentional fall-through.
   case Stmt::MSAsmStmtClass:    EmitAsmStmt(cast<AsmStmt>(*S));           break;
   case Stmt::CapturedStmtClass: {

--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -2368,6 +2368,12 @@ static bool TypeInfoIsInStandardLibrary(const BuiltinType *Ty) {
     case BuiltinType::ObjCClass:
     case BuiltinType::ObjCSel:
       llvm_unreachable("FIXME: Objective-C types are unsupported!");
+    case BuiltinType::Min12Int:
+    case BuiltinType::LitInt:
+    case BuiltinType::Min10Float:
+    case BuiltinType::LitFloat:
+      llvm_unreachable("FIXME: HLSL types are unsupported!");
+      break;
   }
 
   llvm_unreachable("Invalid BuiltinType Kind!");

--- a/tools/clang/lib/Frontend/FrontendActions.cpp
+++ b/tools/clang/lib/Frontend/FrontendActions.cpp
@@ -785,6 +785,7 @@ void PrintPreambleAction::ExecuteAction() {
   case IK_PreprocessedObjCXX:
   case IK_AST:
   case IK_LLVM_IR:
+  case IK_HLSL: // HLSL Change
     // We can't do anything with these.
     return;
   }

--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -1052,6 +1052,9 @@ HRESULT RootSignatureParser::ParseRegister(TokenType::Type RegType, uint32_t & R
         case TokenType::SReg:
             IFC(Error(ERR_RS_INCORRECT_REGISTER_TYPE, "Incorrect register type '%s' in Sampler/StaticSampler (expected s#)", Token.GetStr()));
             break;
+        default:
+          // Only Register types are relevant.
+	  break;
         }
     }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1335,6 +1335,9 @@ bool DeclResultIdMapper::createStageVars(const hlsl::SigPoint *sigPoint,
           hlsl::IsHLSLVecType(type) ? hlsl::GetHLSLVecElementType(type) : type);
       typeId = theBuilder.getVecType(srcVecElemTypeId, 3);
       break;
+    default:
+      // Only the semantic kinds mentioned above are handled.
+      break;
     }
 
     // Handle the extra arrayness
@@ -1862,6 +1865,9 @@ uint32_t DeclResultIdMapper::getBuiltinVar(spv::BuiltIn builtIn) {
   case spv::BuiltIn::SubgroupLocalInvocationId:
     laneIndexBuiltinId = varId;
     break;
+  default:
+    // Only relevant to subgroup builtins.
+    break;
   }
 
   return varId;
@@ -1910,6 +1916,9 @@ uint32_t DeclResultIdMapper::createSpirvStageVar(StageVar *stageVar,
       theBuilder.addExtension(Extension::KHR_device_group,
                               stageVar->getSemanticStr(), srcLoc);
       theBuilder.requireCapability(spv::Capability::DeviceGroup);
+      break;
+    default:
+      // Just seeking builtins requiring extensions. The rest can be ignored.
       break;
     }
 

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -185,6 +185,10 @@ bool FeatureManager::isExtensionRequiredForTargetEnv(Extension ext) {
     case Extension::KHR_multiview:
     case Extension::KHR_shader_draw_parameters:
       required = false;
+      break;
+    default:
+      // Only 1.1 extensions can be suppressed.
+      required = true;
     }
   }
 

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -192,6 +192,9 @@ bool GlPerVertex::doGlPerVertexFacts(const DeclaratorDecl *decl,
     isCull = true;
     index = gCullDistanceIndex;
     break;
+  default:
+    // Only Cull or Clip apply.
+    break;
   }
 
   // Remember the semantic strings provided by the developer so that we can
@@ -367,6 +370,9 @@ bool GlPerVertex::tryToAccess(hlsl::SigPoint::Kind sigPointKind,
       return true;
 
     return writeField(semanticKind, semanticIndex, invocationId, value);
+  default:
+    // Only interfaces that involve gl_PerVertex are needed.
+    break;
   }
 
   return false;
@@ -486,6 +492,9 @@ bool GlPerVertex::readField(hlsl::Semantic::Kind semanticKind,
                                      typeIter->second);
     return true;
   }
+  default:
+    // Only Cull or Clip apply.
+    break;
   }
   return false;
 }
@@ -621,6 +630,9 @@ bool GlPerVertex::writeField(hlsl::Semantic::Kind semanticKind,
                                offsetIter->second, typeIter->second, *value);
     return true;
   }
+  default:
+    // Only Cull or Clip apply.
+    break;
   }
   return false;
 }

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -224,6 +224,9 @@ uint32_t ModuleBuilder::createUnaryOp(spv::Op op, uint32_t resultType,
   case spv::Op::OpImageQuerySamples:
     requireCapability(spv::Capability::ImageQuery);
     break;
+  default:
+    // Only checking for ImageQueries, the other Ops can be ignored.
+    break;
   }
   return id;
 }
@@ -238,6 +241,9 @@ uint32_t ModuleBuilder::createBinaryOp(spv::Op op, uint32_t resultType,
   case spv::Op::OpImageQueryLod:
   case spv::Op::OpImageQuerySizeLod:
     requireCapability(spv::Capability::ImageQuery);
+    break;
+  default:
+    // Only checking for ImageQueries, the other Ops can be ignored.
     break;
   }
   return id;
@@ -1097,6 +1103,10 @@ uint32_t ModuleBuilder::getImageType(uint32_t sampledType, spv::Dim dim,
   case spv::ImageFormat::R16ui:
   case spv::ImageFormat::R8ui:
     requireCapability(spv::Capability::StorageImageExtendedFormats);
+    break;
+  default:
+    // Only image formats requiring extended formats are relevant. The rest just pass through.
+    break;
   }
 
   if (dim == spv::Dim::Dim1D) {

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -286,6 +286,9 @@ spv::Op translateAtomicHlslOpcodeToSpirvOpcode(hlsl::IntrinsicOp opcode) {
   case IntrinsicOp::IOP_InterlockedExchange:
   case IntrinsicOp::MOP_InterlockedExchange:
     return Op::OpAtomicExchange;
+  default:
+    // Only atomic opcodes are relevant.
+    break;
   }
 
   assert(false && "unimplemented hlsl intrinsic opcode");
@@ -329,6 +332,9 @@ bool isAcceptedSpecConstantBinaryOp(spv::Op op) {
   case spv::Op::OpUGreaterThanEqual:
   case spv::Op::OpSGreaterThanEqual:
     return true;
+  default:
+    // Accepted binary opcodes return true. Anything else is false.
+    return false;
   }
   return false;
 }
@@ -510,6 +516,9 @@ spv::Capability getCapabilityForGroupNonUniform(spv::Op opcode) {
   case spv::Op::OpGroupNonUniformQuadBroadcast:
   case spv::Op::OpGroupNonUniformQuadSwap:
     return spv::Capability::GroupNonUniformQuad;
+  default:
+    assert(false && "unhandled opcode");
+    break;
   }
   assert(false && "unhandled opcode");
   return spv::Capability::Max;
@@ -5194,6 +5203,12 @@ SpirvEvalInfo SPIRVEmitter::processBinaryOp(const Expr *lhs, const Expr *rhs,
   }
   case BO_Assign:
     llvm_unreachable("assignment should not be handled here");
+    break;
+  case BO_PtrMemD:
+  case BO_PtrMemI:
+  case BO_Comma:
+    // Unimplemented
+    break;
   }
 
   emitError("binary operator '%0' unimplemented", lhs->getExprLoc())
@@ -7017,6 +7032,9 @@ spv::Op SPIRVEmitter::translateWaveOp(hlsl::IntrinsicOp op, QualType type,
     WAVE_OP_CASE_SINT_UINT_FLOAT(ActiveMax, SMax, UMax, FMax);
     WAVE_OP_CASE_SINT_UINT_FLOAT(ActiveUMin, SMin, UMin, FMin);
     WAVE_OP_CASE_SINT_UINT_FLOAT(ActiveMin, SMin, UMin, FMin);
+  default:
+    // Only Simple Wave Ops are handled here.
+    break;
   }
 #undef WAVE_OP_CASE_INT_FLOAT
 #undef WAVE_OP_CASE_INT
@@ -8442,6 +8460,10 @@ uint32_t SPIRVEmitter::processIntrinsicUsingSpirvInst(
     case spv::Op::OpFwidthFine:
     case spv::Op::OpFwidthCoarse:
       needsLegalization = true;
+      break;
+    default:
+      // Only the given opcodes need legalization. Anything else should preserve previous.
+      break;
     }
 
   const uint32_t returnType = typeTranslator.translateType(callExpr->getType());

--- a/tools/clang/lib/Sema/DeclSpec.cpp
+++ b/tools/clang/lib/Sema/DeclSpec.cpp
@@ -309,6 +309,10 @@ bool Declarator::isDeclarationOfFunction() const {
     case TST_unspecified:
     case TST_void:
     case TST_wchar:
+    // HLSL Change Starts
+    case TST_min10float:
+    case TST_min12int:
+    // HLSL Change Ends
       return false;
 
     case TST_decltype_auto:

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2164,8 +2164,10 @@ bool TemplateHasDefaultType(ArBasicKind kind)
 #endif // ENABLE_SPIRV_CODEGEN
   // SPIRV change ends
     return true;
+  default:
+    // Objects with default types return true. Everything else is false.
+    return false;
   }
-  return false;
 }
 
 /// <summary>
@@ -3443,6 +3445,9 @@ public:
       case BuiltinType::Min10Float: return AR_BASIC_MIN10FLOAT;
       case BuiltinType::LitFloat: return AR_BASIC_LITERAL_FLOAT;
       case BuiltinType::LitInt: return AR_BASIC_LITERAL_INT;
+      default:
+        // Only builtin types that have basickind equivalents.
+        break;
       }
     }
     if (const EnumType *ET = dyn_cast<EnumType>(type)) {
@@ -4732,6 +4737,9 @@ static bool CombineObjectTypes(ArBasicKind Target, _In_ ArBasicKind Source,
       return true;
     }
     break;
+  default:
+    // Not a combinable target.
+    break;
   }
 
   AssignOpt(AR_BASIC_UNKNOWN, pCombined);
@@ -5778,6 +5786,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
     case AR_BASIC_FLOAT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
@@ -5785,12 +5795,16 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_FLOAT32:
     case AR_BASIC_FLOAT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_FLOAT32:
     switch (leftKind) {
     case AR_BASIC_FLOAT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_MIN10FLOAT:
@@ -5801,6 +5815,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
     case AR_BASIC_FLOAT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_MIN16FLOAT:
@@ -5810,6 +5826,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
     case AR_BASIC_FLOAT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
 
@@ -5824,6 +5842,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_UINT32:
     case AR_BASIC_UINT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_INT16:
@@ -5835,6 +5855,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_UINT32:
     case AR_BASIC_UINT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_INT32:
@@ -5844,6 +5866,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_INT64:
     case AR_BASIC_UINT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_MIN12INT:
@@ -5852,6 +5876,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_INT32:
     case AR_BASIC_INT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_MIN16INT:
@@ -5859,6 +5885,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_INT32:
     case AR_BASIC_INT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   case AR_BASIC_MIN16UINT:
@@ -5866,6 +5894,8 @@ bool HLSLExternalSource::IsPromotion(ArBasicKind leftKind, ArBasicKind rightKind
     case AR_BASIC_UINT32:
     case AR_BASIC_UINT64:
       return true;
+    default:
+      return false; // No other type is a promotion.
     }
     break;
   }
@@ -5896,6 +5926,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_UINT32:
     case AR_BASIC_UINT64:
       return false;
+    default:
+      break; // No other valid cast types
     }
     break;
 
@@ -5905,6 +5937,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_UINT8:
       return false;
+    default:
+      break; // No other valid cast types
     }
     break;
 
@@ -5914,6 +5948,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_UINT16:
       return false;
+    default:
+      break; // No other valid cast types
     }
     break;
 
@@ -5923,6 +5959,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_UINT32:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5932,6 +5970,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_UINT64:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5941,6 +5981,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_INT8:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5950,6 +5992,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_INT16:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5959,6 +6003,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_INT32:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5968,6 +6014,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_LITERAL_INT:
     case AR_BASIC_INT64:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5979,6 +6027,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
     case AR_BASIC_FLOAT64:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5986,6 +6036,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     switch (rightKind) {
     case AR_BASIC_LITERAL_FLOAT:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -5993,6 +6045,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     switch (rightKind) {
     case AR_BASIC_LITERAL_FLOAT:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -6000,6 +6054,8 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     switch (rightKind) {
     case AR_BASIC_LITERAL_FLOAT:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
 
@@ -6007,8 +6063,12 @@ bool HLSLExternalSource::IsCast(ArBasicKind leftKind, ArBasicKind rightKind) {
     switch (rightKind) {
     case AR_BASIC_LITERAL_FLOAT:
       return false;
+    default:
+      break; // No other valid cast types.
     }
     break;
+  default:
+    break; // No other relevant targets.
   }
 
   return true;
@@ -6037,6 +6097,8 @@ bool HLSLExternalSource::IsIntCast(ArBasicKind leftKind, ArBasicKind rightKind) 
     case AR_BASIC_UINT32:
     case AR_BASIC_UINT64:
       return false;
+    default:
+      break; // No other valid conversions
     }
     break;
 
@@ -6051,6 +6113,8 @@ bool HLSLExternalSource::IsIntCast(ArBasicKind leftKind, ArBasicKind rightKind) 
     switch (rightKind) {
     case AR_BASIC_LITERAL_INT:
       return false;
+    default:
+      break; // No other valid conversions
     }
     break;
 
@@ -6062,6 +6126,8 @@ bool HLSLExternalSource::IsIntCast(ArBasicKind leftKind, ArBasicKind rightKind) 
     case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
     case AR_BASIC_FLOAT64:
       return false;
+    default:
+      break; // No other valid conversions
     }
     break;
 
@@ -6072,7 +6138,12 @@ bool HLSLExternalSource::IsIntCast(ArBasicKind leftKind, ArBasicKind rightKind) 
     switch (rightKind) {
     case AR_BASIC_LITERAL_FLOAT:
       return false;
+    default:
+      break; // No other valid conversions
     }
+    break;
+  default:
+    // No other relevant targets
     break;
   }
 
@@ -6989,6 +7060,9 @@ static clang::CastKind ImplicitConversionKindToCastKind(
     else if (IS_BASIC_AINT(FromKind) && IS_BASIC_BOOL(ToKind))
       return CK_IntegralToBoolean;
     break;
+  default:
+    // Only covers implicit conversions with cast kind equivalents.
+    return CK_Invalid;
   }
   return CK_Invalid;
 }
@@ -7006,6 +7080,9 @@ static clang::CastKind ConvertToComponentCastKind(clang::CastKind CK) {
     return CK_HLSLCC_FloatingToBoolean;
   case CK_IntegralToBoolean:
     return CK_HLSLCC_IntegralToBoolean;
+  default:
+    // Only HLSLCC castkinds are relevant. Ignore the rest.
+    return CK_Invalid;
   }
   return CK_Invalid;
 }
@@ -7213,6 +7290,9 @@ void HLSLExternalSource::GetConversionForm(
       pTypeInfo->ShapeKind = AR_TOBJ_BASIC;
     }
     break;
+  default:
+    // Only convertable shapekinds are relevant.
+    break;
   }
 }
 
@@ -7381,21 +7461,8 @@ bool HLSLExternalSource::CanConvert(
           goto lSuccess;
         }
         break;
-      }
-    }
-
-    if (const BuiltinType *BT = source->getAs<BuiltinType>()) {
-      BuiltinType::Kind kind = BT->getKind();
-      switch (kind) {
-      case BuiltinType::Kind::UInt:
-      case BuiltinType::Kind::Int:
-      case BuiltinType::Kind::Float:
-      case BuiltinType::Kind::LitFloat:
-      case BuiltinType::Kind::LitInt:
-        if (explicitConversion) {
-          Second = ICK_Flat_Conversion;
-          goto lSuccess;
-        }
+      default:
+        // Only flat conversion kinds are relevant.
         break;
       }
     }
@@ -7468,6 +7535,9 @@ bool HLSLExternalSource::CanConvert(
     case AR_TOBJ_INTERFACE:
     case AR_TOBJ_POINTER:
       return false;
+    default:
+      // Only valid conversion source types are handled.
+      break;
     }
 
     bCheckElt = true;
@@ -7522,6 +7592,9 @@ bool HLSLExternalSource::CanConvert(
     case AR_TOBJ_INTERFACE:
     case AR_TOBJ_POINTER:
       return false;
+    default:
+      // Only valid conversion source types are handled.
+      break;
     }
 
     bCheckElt = true;
@@ -7577,6 +7650,9 @@ bool HLSLExternalSource::CanConvert(
     case AR_TOBJ_INTERFACE:
     case AR_TOBJ_POINTER:
       return false;
+    default:
+      // Only valid conversion source types are handled.
+      break;
     }
 
     bCheckElt = true;
@@ -7697,6 +7773,9 @@ lSuccess:
         case ICK_HLSLVector_Splat:
           standard->First = ICK_Lvalue_To_Rvalue;
           break;
+        default:
+          // Only flat and splat conversions handled.
+          break;
         }
         switch (ComponentConversion)
         {
@@ -7707,6 +7786,9 @@ lSuccess:
         case ICK_Floating_Integral:
         case ICK_Boolean_Conversion:
           standard->First = ICK_Lvalue_To_Rvalue;
+          break;
+        default:
+          // Only potential assignments above covered.
           break;
         }
       }
@@ -7958,6 +8040,9 @@ void HLSLExternalSource::CheckBinOpForHLSL(
     // In the HLSL case these cases don't apply or simply aren't surfaced.
     ResultTy = RHS.get()->getType();
     return;
+  default:
+    // Only assign and comma operations handled.
+    break;
   }
 
   // Leave this diagnostic for last to emulate fxc behavior.
@@ -8158,6 +8243,9 @@ QualType HLSLExternalSource::CheckUnaryOpForHLSL(
   case UO_Deref:
     m_sema->Diag(OpLoc, diag::err_hlsl_unsupported_operator);
     return QualType();
+  default:
+    // Only * and & covered.
+    break;
   }
 
   Expr* expr = InputExpr.get();
@@ -8601,6 +8689,9 @@ void HLSLExternalSource::DiagnoseAssignmentResultForHLSL(
   case AR_BASIC_MIN10FLOAT:
     warnAboutNarrowing = (src == AR_BASIC_INT32 || src == AR_BASIC_UINT32 || src == AR_BASIC_FLOAT32 || src == AR_BASIC_FLOAT64);
     break;
+  default:
+    // No other destination types result in narrowing.
+    break;
   }
 
   // fxc errors looked like this:
@@ -8701,6 +8792,9 @@ void GetFloatLimits(ArBasicKind basicKind, double* minValue, double* maxValue)
   case AR_BASIC_FLOAT32_PARTIAL_PRECISION:
   case AR_BASIC_FLOAT32: *minValue = -(FLT_MIN); *maxValue = FLT_MAX; return;
   case AR_BASIC_FLOAT64: *minValue = -(DBL_MIN); *maxValue = DBL_MAX; return;
+  default:
+    // No other float types.
+    break;
   }
 
   DXASSERT(false, "unreachable");
@@ -8720,6 +8814,9 @@ void GetUnsignedLimit(ArBasicKind basicKind, uint64_t* maxValue)
   case AR_BASIC_UINT16: *maxValue = UINT16_MAX; return;
   case AR_BASIC_UINT32: *maxValue = UINT32_MAX; return;
   case AR_BASIC_UINT64: *maxValue = UINT64_MAX; return;
+  default:
+    // No other unsigned int types.
+    break;
   }
 
   DXASSERT(false, "unreachable");
@@ -8740,6 +8837,9 @@ void GetSignedLimits(ArBasicKind basicKind, int64_t* minValue, int64_t* maxValue
   case AR_BASIC_INT16: *minValue = INT16_MIN; *maxValue = INT16_MAX; return;
   case AR_BASIC_INT32: *minValue = INT32_MIN; *maxValue = INT32_MAX; return;
   case AR_BASIC_INT64: *minValue = INT64_MIN; *maxValue = INT64_MAX; return;
+  default:
+    // No other signed int types.
+    break;
   }
 
   DXASSERT(false, "unreachable");
@@ -9127,6 +9227,8 @@ void hlsl::DiagnoseRegisterType(
   case AR_OBJECT_LEGACY_EFFECT:   // Used for all unsupported but ignored legacy effect types
     isWarning = true;
     break;                        // So we don't care what you tried to bind it to
+  default: // Other types have no associated registers.
+    break;
   }
 
   // fxc is inconsistent as to when it reports an error and when it ignores invalid bind semantics, so emit
@@ -11107,6 +11209,9 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
         }
         pCentroid = pAttr;
         break;
+      default:
+        // Only relevant to the four attribs included in this block.
+        break;
       }
       break;
 
@@ -11741,7 +11846,19 @@ bool hlsl::IsHLSLAttr(clang::attr::Kind AttrKind) {
   case clang::attr::HLSLTriangleAdj:
   case clang::attr::HLSLGloballyCoherent:
   case clang::attr::NoInline:
+  case clang::attr::VKBinding:
+  case clang::attr::VKBuiltIn:
+  case clang::attr::VKConstantId:
+  case clang::attr::VKCounterBinding:
+  case clang::attr::VKIndex:
+  case clang::attr::VKInputAttachmentIndex:
+  case clang::attr::VKLocation:
+  case clang::attr::VKOffset:
+  case clang::attr::VKPushConstant:
     return true;
+  default:
+    // Only HLSL/VK Attributes return true. Only used for printPretty(), which doesn't support them.
+    break;
   }
   
   return false;

--- a/tools/clang/lib/Sema/SemaTemplateVariadic.cpp
+++ b/tools/clang/lib/Sema/SemaTemplateVariadic.cpp
@@ -740,6 +740,10 @@ bool Sema::containsUnexpandedParameterPacks(Declarator &D) {
   case TST_decltype_auto:
   case TST_unknown_anytype:
   case TST_error:
+  // HLSL Change Start
+  case TST_min10float:
+  case TST_min12int:
+  // HLSL Change End
     break;
   }
 

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -5725,8 +5725,10 @@ static bool isHLSLTypeAttr(AttributeList::Kind Kind) {
   case AttributeList::AT_HLSLSnorm:
   case AttributeList::AT_HLSLUnorm:
     return true;
+  default:
+    // Only meant to catch attr handled by handleHLSLTypeAttr, ignore the rest
+    return false;
   }
-  return false;
 }
 
 static bool handleHLSLTypeAttr(TypeProcessingState &State,

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -191,6 +191,9 @@ void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
       break;
     case DxilProgramSigSemantic::Barycentrics:
       pSysValue = "BARYCEN";
+      break;
+    case DxilProgramSigSemantic::Undefined:
+      break;
     }
     OS << right_justify(pSysValue, 9);
 
@@ -222,6 +225,8 @@ void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
       break;
     case DxilProgramSigCompType::Float64:
       pFormat = "double";
+      break;
+    case DxilProgramSigCompType::Unknown:
       break;
     }
 
@@ -361,6 +366,8 @@ void PrintResourceFormat(DxilResourceBase &res, unsigned alignment,
       OS << right_justify(compName, alignment);
       break;
     }
+  case DxilResource::Class::Invalid:
+    break;
   }
 }
 
@@ -401,6 +408,8 @@ void PrintResourceDim(DxilResourceBase &res, unsigned alignment,
       OS << right_justify(res.GetResDimName(), alignment);
       break;
     }
+    break;
+  case DxilResourceBase::Class::Invalid:
     break;
   }
 }
@@ -587,6 +596,9 @@ void PrintTypeAndName(llvm::Type *Ty, DxilFieldAnnotation &annotation,
     case MatrixOrientation::ColumnMajor:
       Stream << "column_major ";
       break;
+    case MatrixOrientation::Undefined:
+    case MatrixOrientation::LastEntry:
+      break;
     }
     Stream << compTyName << Matrix.Rows << "x" << Matrix.Cols;
   } else if (Ty->isVectorTy())
@@ -631,6 +643,9 @@ void PrintFieldLayout(llvm::Type *Ty, DxilFieldAnnotation &annotation,
         break;
       case MatrixOrientation::ColumnMajor:
         arraySize /= Matrix.Cols;
+        break;
+      case MatrixOrientation::Undefined:
+      case MatrixOrientation::LastEntry:
         break;
       }
       if (EltTy->isVectorTy()) {
@@ -1230,6 +1245,11 @@ void PrintPipelineStateValidationRuntimeInfo(const char *pBuffer,
     OS << comment << " DepthOutput=" << (bool)pInfo->PS.DepthOutput << "\n";
     OS << comment << " SampleFrequency=" << (bool)pInfo->PS.SampleFrequency
        << "\n";
+    break;
+  case DXIL::ShaderKind::Compute:
+  case DXIL::ShaderKind::Library:
+  case DXIL::ShaderKind::Invalid:
+    // Nothing to print for these shader kinds.
     break;
   }
 

--- a/tools/clang/tools/libclang/CIndex.cpp
+++ b/tools/clang/tools/libclang/CIndex.cpp
@@ -5326,6 +5326,8 @@ CXCursor clang_getCursorDefinition(CXCursor C) {
     if (NamedDecl *Friend = cast<FriendTemplateDecl>(D)->getFriendDecl())
       return clang_getCursorDefinition(MakeCXCursor(Friend, TU));
     return clang_getNullCursor();
+  case Decl::HLSLBuffer: // HLSL Change
+    return clang_getNullCursor(); // HLSL Change
   }
 
   return clang_getNullCursor();

--- a/tools/clang/tools/libclang/CXCursor.cpp
+++ b/tools/clang/tools/libclang/CXCursor.cpp
@@ -107,6 +107,7 @@ CXCursor cxcursor::MakeCXCursor(const Stmt *S, const Decl *Parent,
   
   switch (S->getStmtClass()) {
   case Stmt::NoStmtClass:
+  case Stmt::DiscardStmtClass: // HLSL Change
     break;
   
   case Stmt::CaseStmtClass:


### PR DESCRIPTION
When switching over an enum value, the ideal is to include a case
for every possibly value. Where possible, that's what this change
does to silence warnings and also to provide space to properly
handle every possible input and throw a warning should a new one
be added. In some cases, it's not practical to list every input.
In these cases, putting a default that doesn't change the behavior,
but let's the compiler know that the behavior is intended.
Fixes 133 clang and 8108(!) gcc warnings.