### PR TITLE
Fix warning on windows release builds (#243)

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -7257,8 +7257,7 @@ void ResourceToHandle::ReplaceResourceWithHandle(Value *ResPtr,
       // Remove resource Store.
       SI->eraseFromParent();
     } else {
-      if (!U->user_empty() || !isa<GEPOperator>(U))
-        DXASSERT(0, "invalid operation on resource");
+      DXASSERT(U->user_empty() && isa<GEPOperator>(U), "invalid operation on resource");
     }
   }
 }


### PR DESCRIPTION
A persistent and occasionally confusing warning is produced on
Windows release builds because of a conditional expression that only
contains an assert. On a release build, this amounts to nothing but
a semicolon, which produces the warning.

This folds the conditional into the previously explicit assert so
it is included or excluded entirely regardless of build type.