### PR TITLE
[appveyor] Clone the whole history

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ platform: x64
 configuration: Release
 
 clone_folder: c:\projects\DirectXShaderCompiler
-clone_depth: 1
 
 environment:
   HLSL_SRC_DIR: c:\projects\DirectXShaderCompiler


### PR DESCRIPTION
Right now we have a mechanism to version rolling build. It depends
on the Git history and will count number of commits. So we need
the full history.