### PR TITLE
Correct min21_int typo in ItaniumMangle

### DIFF
--- a/tools/clang/lib/AST/ItaniumMangle.cpp
+++ b/tools/clang/lib/AST/ItaniumMangle.cpp
@@ -2040,7 +2040,7 @@ void CXXNameMangler::mangleType(const BuiltinType *T) {
   case BuiltinType::OCLSampler: Out << "11ocl_sampler"; break;
   case BuiltinType::OCLEvent: Out << "9ocl_event"; break;
     // HLSL Change starts
-  case BuiltinType::Min12Int: Out << "min21_int"; break;
+  case BuiltinType::Min12Int: Out << "min12_int"; break;
   case BuiltinType::LitInt: Out << "lit_int"; break;
   case BuiltinType::LitFloat: Out << "lit_float"; break;
   case BuiltinType::Min10Float: Out << "min10_float"; break;


### PR DESCRIPTION
Determines what the type is represented as in function name mangling.
Just as easy to get it right. Simple typo fix.

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/1368