### PR TITLE
[linux-port] Enable some code. Disable some code.

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -186,6 +186,7 @@ public:
 
   MainArgs() = default;
   MainArgs(int argc, const wchar_t **argv, int skipArgCount = 1);
+  MainArgs(int argc, const char **argv, int skipArgCount = 1);
   MainArgs(llvm::ArrayRef<llvm::StringRef> args);
   MainArgs& operator=(const MainArgs &other);
   llvm::ArrayRef<const char *> getArrayRef() const {

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -134,8 +134,8 @@ typedef enum DxcDiagnosticDisplayOptions
   // Display the category name associated with this diagnostic, if any.
   DxcDiagnostic_DisplayCategoryName = 0x20,
 
-	// Display the severity of the diagnostic message.
-	DxcDiagnostic_DisplaySeverity = 0x200
+  // Display the severity of the diagnostic message.
+  DxcDiagnostic_DisplaySeverity = 0x200
 } DxcDiagnosticDisplayOptions;
 
 typedef enum DxcTranslationUnitFlags

--- a/include/llvm/PassRegistry.h
+++ b/include/llvm/PassRegistry.h
@@ -39,7 +39,10 @@ struct PassRegistrationListener;
 /// threads simultaneously, you will need to use a separate PassRegistry on
 /// each thread.
 class PassRegistry {
-  //mutable sys::SmartRWMutex<true> Lock; // HLSL Change - no lock needed
+  #ifndef LLVM_ON_WIN32
+  // HLSL Change - no lock needed for Windows, as it will use its own mechanism defined in PassRegistry.cpp.
+  mutable sys::SmartRWMutex<true> Lock;
+  #endif
 
   /// PassInfoMap - Keep track of the PassInfo object for each registered pass.
   typedef DenseMap<const void *, const PassInfo *> MapType;

--- a/include/llvm/Support/Mutex.h
+++ b/include/llvm/Support/Mutex.h
@@ -71,10 +71,10 @@ namespace llvm
     /// @{
     private:
 #if defined(LLVM_ENABLE_THREADS) && LLVM_ENABLE_THREADS != 0
-#if 0 // HLSL Change
-      void* data_; ///< We don't know what the data will be
-#else
+#if LLVM_ON_WIN32 // HLSL Change
       char data_[sizeof(void*) == 8 ? 40 : 24]; // C_ASSERT this is CRITICAL_SECTION-sized
+#else
+      void* data_; ///< We don't know what the data will be
 #endif // HLSL Change
 #endif
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -147,6 +147,17 @@ MainArgs::MainArgs(int argc, const wchar_t **argv, int skipArgCount) {
   }
 }
 
+MainArgs::MainArgs(int argc, const char **argv, int skipArgCount) {
+  if (argc > skipArgCount) {
+    Utf8StringVector.reserve(argc - skipArgCount);
+    Utf8CharPtrVector.reserve(argc - skipArgCount);
+    for (int i = skipArgCount; i < argc; ++i) {
+      Utf8StringVector.emplace_back(argv[i]);
+      Utf8CharPtrVector.push_back(Utf8StringVector.back().data());
+    }
+  }
+}
+
 MainArgs::MainArgs(llvm::ArrayRef<llvm::StringRef> args) {
   Utf8StringVector.reserve(args.size());
   Utf8CharPtrVector.reserve(args.size());

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -13,6 +13,7 @@
 #include "dxc/Support/dxcapi.use.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/Unicode.h"
+#include "dxc/Support/WinFunctions.h"
 
 namespace dxc {
 
@@ -36,6 +37,12 @@ static std::string GetWin32ErrorMessage(DWORD err) {
     return std::string(formattedMsg);
   }
   return std::string();
+}
+#else
+static std::string GetWin32ErrorMessage(DWORD err) {
+  // Since we use errno for handling messages, we use strerror to get the error
+  // message.
+  return std::string(std::strerror(err));
 }
 #endif // _WIN32
 
@@ -160,7 +167,7 @@ void WriteUtf8ToConsoleSizeT(_In_opt_count_(charCount) const char *pText,
     return;
   }
 
-  int charCountInt;
+  int charCountInt = 0;
   IFT(SizeTToInt(charCount, &charCountInt));
   WriteUtf8ToConsole(pText, charCountInt, streamType);
 }

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -87,7 +87,7 @@ void llvm::report_fatal_error(const Twine &Reason, bool GenCrashDiag) {
     handlerData = ErrorHandlerUserData;
   }
 
-#if 0 // HLSL Change - unwind if necessary, but don't terminate the process
+#ifndef LLVM_ON_WIN32 // HLSL Change - unwind if necessary, but don't terminate the process
   if (handler) {
     handler(handlerData, Reason.str(), GenCrashDiag);
   } else {
@@ -98,7 +98,7 @@ void llvm::report_fatal_error(const Twine &Reason, bool GenCrashDiag) {
     raw_svector_ostream OS(Buffer);
     OS << "LLVM ERROR: " << Reason << "\n";
     StringRef MessageStr = OS.str();
-    ssize_t written = ::_write(2, MessageStr.data(), MessageStr.size());
+    ssize_t written = ::write(2, MessageStr.data(), MessageStr.size());
     (void)written; // If something went wrong, we deliberately just give up.
   }
 
@@ -127,7 +127,7 @@ void llvm::llvm_unreachable_internal(const char *msg, const char *file,
   if (file)
     dbgs() << " at " << file << ":" << line;
   dbgs() << "!\n";
-#if 0 // HLSL Change - unwind if necessary, but don't terminate the process
+#ifndef LLVM_ON_WIN32 // HLSL Change - unwind if necessary, but don't terminate the process
   abort();
 #else
   RaiseException(STATUS_LLVM_UNREACHABLE, 0, 0, 0);

--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -8,6 +8,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "assert.h"
+
+#ifdef _WIN32
+
 #include "windows.h"
 #include "dxc/Support/Global.h"
 
@@ -18,3 +21,13 @@ void llvm_assert(_In_z_ const char *_Message,
   OutputDebugFormatA("Error: assert(%s)\nFile:\n%s(%d)\nFunc:\t%s\n", _Message, _File, _Line, _Function);
   RaiseException(STATUS_LLVM_ASSERT, 0, 0, 0);
 }
+
+#else
+
+#include <assert.h>
+
+void llvm_assert(const char* message, const char*, unsigned) {
+  assert(false && message);
+}
+
+#endif

--- a/tools/clang/include/clang/Frontend/FrontendActions.h
+++ b/tools/clang/include/clang/Frontend/FrontendActions.h
@@ -137,6 +137,7 @@ public:
   bool hasCodeCompletionSupport() const override { return true; }
 };
 
+#if 0 // HLSL change - no support for modules or PCH
 /// \brief Dump information about the given module file, to be used for
 /// basic debugging and discovery.
 class DumpModuleInfoAction : public ASTFrontendAction {
@@ -162,6 +163,7 @@ protected:
 public:
   bool hasCodeCompletionSupport() const override { return false; }
 };
+#endif // HLSL changes
 
 /**
  * \brief Frontend action adaptor that merges ASTs together.

--- a/tools/clang/lib/Frontend/FrontendActions.cpp
+++ b/tools/clang/lib/Frontend/FrontendActions.cpp
@@ -408,6 +408,7 @@ SyntaxOnlyAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
   return llvm::make_unique<ASTConsumer>();
 }
 
+#if 0 // HLSL Change Starts - no support for modules or PCH
 std::unique_ptr<ASTConsumer>
 DumpModuleInfoAction::CreateASTConsumer(CompilerInstance &CI,
                                         StringRef InFile) {
@@ -418,8 +419,6 @@ std::unique_ptr<ASTConsumer>
 VerifyPCHAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
   return llvm::make_unique<ASTConsumer>();
 }
-
-#if 0 // HLSL Change Starts - no support for modules or PCH
 
 void VerifyPCHAction::ExecuteAction() {
   CompilerInstance &CI = getCompilerInstance();

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -37,6 +37,7 @@ namespace {
 #endif
 #endif
 
+#ifdef _WIN32
 #ifdef DBG
 
 // This should be improved with global enabled mask rather than a compile-time mask.
@@ -56,6 +57,10 @@ namespace {
 #define DXTRACE_FMT_APIFS(...)
 
 #endif // DBG
+#else  // _WIN32
+#define DXTRACE_FMT_APIFS(...)
+#endif // _WIN32
+
 
 
 enum class HandleKind {
@@ -137,6 +142,13 @@ bool IsAbsoluteOrCurDirRelativeW(LPCWSTR Path) {
   if (Path[0] == L'\\') {
     return Path[1] == L'\\';
   }
+
+  #ifndef _WIN32
+  // Absolute paths on unix systems start with '/'
+  if (Path[0] == L'/') {
+    return TRUE;
+  }
+  #endif
 
   //
   // NOTE: there are a number of cases we don't handle, as they don't play well with the simple
@@ -470,7 +482,6 @@ public:
       lpFileInformation->nFileIndexHigh = 1;
       return TRUE;
     }
-
     SetLastError(ERROR_INVALID_HANDLE);
     return FALSE;
   }

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -100,7 +100,7 @@ static void raw_string_ostream_to_CoString(raw_string_ostream &o, _Outptr_result
   *pResult = (LPSTR)CoTaskMemAlloc(s.size() + 1);
   if (*pResult == nullptr) 
     throw std::bad_alloc();
-  strcpy_s(*pResult, s.size() + 1, s.c_str());
+  strncpy(*pResult, s.c_str(), s.size() + 1);
 }
 
 static
@@ -574,7 +574,6 @@ public:
       ::llvm::sys::fs::MSFileSystem* msfPtr;
       IFT(CreateMSFileSystemForDisk(&msfPtr));
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
-
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
@@ -617,7 +616,6 @@ public:
       ::llvm::sys::fs::MSFileSystem* msfPtr;
       IFT(CreateMSFileSystemForDisk(&msfPtr));
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
-
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
@@ -666,7 +664,6 @@ public:
     try {
       dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(utf8Source, pSourceName, pIncludeHandler);
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
-
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
@@ -698,7 +695,7 @@ public:
       defineStr += "#define ";
       defineStr += utf8Name;
       defineStr += " ";
-      defineStr += utf8Value ? utf8Value : "1";
+      defineStr += utf8Value ? utf8Value.m_psz : "1";
       defineStr += "\n";
     }
 


### PR DESCRIPTION
Some code originally in llvm/clang was commented out, and was replaced
with Windows-specific implementation. In this change we bring back some
of those.

Also disabled some code that is not relevant any more.

And a few minor improvements towards cross-platform compilation.