### PR TITLE
[linux-port] Enable cross-platform interfaces.

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -17,11 +17,16 @@
 #define DXC_API_IMPORT __declspec(dllimport)
 #endif
 
-#ifndef _WIN32
+#ifdef _WIN32
+#define DECLARE_CROSS_PLATFORM_UUIDOF(T)
+#define DEFINE_CROSS_PLATFORM_UUIDOF(T)
+#else
+#include <dlfcn.h>
 #include "dxc/Support/WinAdapter.h"
 #endif
 
 struct IMalloc;
+
 struct IDxcIncludeHandler;
 
 /// <summary>
@@ -71,12 +76,19 @@ typedef HRESULT(__stdcall *DxcCreateInstance2Proc)(
 /// <remarks>
 /// While this function is similar to CoCreateInstance, there is no COM involvement.
 /// </remarks>
+
+#ifndef _MSC_VER
+extern "C"
+#endif
 DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
   _In_ REFCLSID   rclsid,
   _In_ REFIID     riid,
   _Out_ LPVOID*   ppv
   );
 
+#ifndef _MSC_VER
+extern "C"
+#endif
 DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
   _In_ IMalloc    *pMalloc,
   _In_ REFCLSID   rclsid,
@@ -91,6 +103,8 @@ IDxcBlob : public IUnknown {
 public:
   virtual LPVOID STDMETHODCALLTYPE GetBufferPointer(void) = 0;
   virtual SIZE_T STDMETHODCALLTYPE GetBufferSize(void) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcBlob)
 };
 
 struct __declspec(uuid("7241d424-2646-4191-97c0-98e96e42fc68"))
@@ -98,6 +112,8 @@ IDxcBlobEncoding : public IDxcBlob {
 public:
   virtual HRESULT STDMETHODCALLTYPE GetEncoding(_Out_ BOOL *pKnown,
                                                 _Out_ UINT32 *pCodePage) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcBlobEncoding)
 };
 
 struct __declspec(uuid("e5204dc7-d18c-4c3c-bdfb-851673980fe7"))
@@ -125,6 +141,8 @@ IDxcLibrary : public IUnknown {
       _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
       _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcLibrary)
 };
 
 struct __declspec(uuid("CEDB484A-D4E9-445A-B991-CA21CA157DC2"))
@@ -132,6 +150,8 @@ IDxcOperationResult : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetStatus(_Out_ HRESULT *pStatus) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetResult(_COM_Outptr_result_maybenull_ IDxcBlob **pResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetErrorBuffer(_COM_Outptr_result_maybenull_ IDxcBlobEncoding **pErrors) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcOperationResult)
 };
 
 struct __declspec(uuid("7f61fc7d-950d-467f-b3e3-3c02fb49187c"))
@@ -140,6 +160,8 @@ IDxcIncludeHandler : public IUnknown {
     _In_ LPCWSTR pFilename,                                   // Candidate filename.
     _COM_Outptr_result_maybenull_ IDxcBlob **ppIncludeSource  // Resultant source object for included file, nullptr if not found.
     ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcIncludeHandler)
 };
 
 struct DxcDefine {
@@ -180,6 +202,8 @@ IDxcCompiler : public IUnknown {
     _In_ IDxcBlob *pSource,                         // Program to disassemble.
     _COM_Outptr_ IDxcBlobEncoding **ppDisassembly   // Disassembly text.
     ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcCompiler)
 };
 
 struct __declspec(uuid("A005A9D9-B8BB-4594-B5C9-0E633BEC4D37"))
@@ -199,6 +223,8 @@ IDxcCompiler2 : public IDxcCompiler {
     _Outptr_opt_result_z_ LPWSTR *ppDebugBlobName,// Suggested file name for debug blob.
     _COM_Outptr_opt_ IDxcBlob **ppDebugBlob       // Debug blob
   ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcCompiler2)
 };
 
 struct __declspec(uuid("F1B5BE2A-62DD-4327-A1C2-42AC1E1E78E6"))
@@ -224,6 +250,8 @@ public:
       _COM_Outptr_ IDxcOperationResult *
           *ppResult // Linker output status, buffer, and errors
   ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcLinker)
 };
 
 static const UINT32 DxcValidatorFlags_Default = 0;
@@ -240,6 +268,8 @@ IDxcValidator : public IUnknown {
     _In_ UINT32 Flags,                            // Validation flags.
     _COM_Outptr_ IDxcOperationResult **ppResult   // Validation output status, buffer, and errors
     ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcValidator)
 };
 
 struct __declspec(uuid("334b1f50-2292-4b35-99a1-25588d8c17fe"))
@@ -248,6 +278,8 @@ IDxcContainerBuilder : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE AddPart(_In_ UINT32 fourCC, _In_ IDxcBlob *pSource) = 0;      // Part to add to the container
   virtual HRESULT STDMETHODCALLTYPE RemovePart(_In_ UINT32 fourCC) = 0;                           // Remove the part with fourCC
   virtual HRESULT STDMETHODCALLTYPE SerializeContainer(_Out_ IDxcOperationResult **ppResult) = 0; // Builds a container of the given container builder state
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder)
 };
 
 struct __declspec(uuid("091f7a26-1c1f-4948-904b-e6e3a8a771d5"))
@@ -257,6 +289,8 @@ IDxcAssembler : public IUnknown {
     _In_ IDxcBlob *pShader,                       // Shader to assemble.
     _COM_Outptr_ IDxcOperationResult **ppResult   // Assembly output status, buffer, and errors
     ) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcAssembler)
 };
 
 struct __declspec(uuid("d2c21b26-8350-4bdc-976a-331ce6f4c54c"))
@@ -267,6 +301,8 @@ IDxcContainerReflection : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetPartContent(UINT32 idx, _COM_Outptr_ IDxcBlob **ppResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE FindFirstPartKind(UINT32 kind, _Out_ UINT32 *pResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetPartReflection(UINT32 idx, REFIID iid, void **ppvObject) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcContainerReflection)
 };
 
 struct __declspec(uuid("AE2CD79F-CC22-453F-9B6B-B124E7A5204C"))
@@ -276,6 +312,8 @@ IDxcOptimizerPass : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetOptionArgCount(_Out_ UINT32 *pCount) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetOptionArgName(UINT32 argIndex, _COM_Outptr_ LPWSTR *ppResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetOptionArgDescription(UINT32 argIndex, _COM_Outptr_ LPWSTR *ppResult) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcOptimizerPass)
 };
 
 struct __declspec(uuid("25740E2E-9CBA-401B-9119-4FB42F39F270"))
@@ -286,6 +324,8 @@ IDxcOptimizer : public IUnknown {
     _In_count_(optionCount) LPCWSTR *ppOptions, UINT32 optionCount,
     _COM_Outptr_ IDxcBlob **pOutputModule,
     _COM_Outptr_opt_ IDxcBlobEncoding **ppOutputText) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcOptimizer)
 };
 
 static const UINT32 DxcVersionInfoFlags_None = 0;
@@ -296,15 +336,27 @@ struct __declspec(uuid("b04f5b50-2059-4f12-a8ff-a1e0cde1cc7e"))
 IDxcVersionInfo : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetVersion(_Out_ UINT32 *pMajor, _Out_ UINT32 *pMinor) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetFlags(_Out_ UINT32 *pFlags) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcVersionInfo)
 };
 
 struct __declspec(uuid("fb6904c4-42f0-4b62-9c46-983af7da7c83"))
 IDxcVersionInfo2 : public IDxcVersionInfo {
   virtual HRESULT STDMETHODCALLTYPE GetCommitInfo(_Out_ UINT32 *pCommitCount, _Out_ char **pCommitHash) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcVersionInfo2)
 };
 
+// Note: __declspec(selectany) requires 'extern'
+// On Linux __declspec(selectany) is removed and using 'extern' results in link error.
+#ifdef _MSC_VER
+#define EXTERN extern
+#else
+#define EXTERN
+#endif
+
 // {73e22d93-e6ce-47f3-b5bf-f0664f39c1b0}
-__declspec(selectany) extern const CLSID CLSID_DxcCompiler = {
+__declspec(selectany) EXTERN const CLSID CLSID_DxcCompiler = {
   0x73e22d93,
   0xe6ce,
   0x47f3,
@@ -312,7 +364,7 @@ __declspec(selectany) extern const CLSID CLSID_DxcCompiler = {
 };
 
 // {EF6A8087-B0EA-4D56-9E45-D07E1A8B7806}
-__declspec(selectany) extern const GUID CLSID_DxcLinker = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcLinker = {
     0xef6a8087,
     0xb0ea,
     0x4d56,
@@ -320,7 +372,7 @@ __declspec(selectany) extern const GUID CLSID_DxcLinker = {
 };
 
 // {CD1F6B73-2AB0-484D-8EDC-EBE7A43CA09F}
-__declspec(selectany) extern const CLSID CLSID_DxcDiaDataSource = {
+__declspec(selectany) EXTERN const CLSID CLSID_DxcDiaDataSource = {
   0xcd1f6b73,
   0x2ab0,
   0x484d,
@@ -328,7 +380,7 @@ __declspec(selectany) extern const CLSID CLSID_DxcDiaDataSource = {
 };
 
 // {6245D6AF-66E0-48FD-80B4-4D271796748C}
-__declspec(selectany) extern const GUID CLSID_DxcLibrary = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcLibrary = {
   0x6245d6af,
   0x66e0,
   0x48fd,
@@ -336,7 +388,7 @@ __declspec(selectany) extern const GUID CLSID_DxcLibrary = {
 };
 
 // {8CA3E215-F728-4CF3-8CDD-88AF917587A1}
-__declspec(selectany) extern const GUID CLSID_DxcValidator = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcValidator = {
   0x8ca3e215,
   0xf728,
   0x4cf3,
@@ -344,7 +396,7 @@ __declspec(selectany) extern const GUID CLSID_DxcValidator = {
 };
 
 // {D728DB68-F903-4F80-94CD-DCCF76EC7151}
-__declspec(selectany) extern const GUID CLSID_DxcAssembler = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcAssembler = {
   0xd728db68,
   0xf903,
   0x4f80,
@@ -352,7 +404,7 @@ __declspec(selectany) extern const GUID CLSID_DxcAssembler = {
 };
 
 // {b9f54489-55b8-400c-ba3a-1675e4728b91}
-__declspec(selectany) extern const GUID CLSID_DxcContainerReflection = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcContainerReflection = {
   0xb9f54489,
   0x55b8,
   0x400c,
@@ -360,7 +412,7 @@ __declspec(selectany) extern const GUID CLSID_DxcContainerReflection = {
 };
 
 // {AE2CD79F-CC22-453F-9B6B-B124E7A5204C}
-__declspec(selectany) extern const GUID CLSID_DxcOptimizer = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcOptimizer = {
     0xae2cd79f,
     0xcc22,
     0x453f,
@@ -368,7 +420,7 @@ __declspec(selectany) extern const GUID CLSID_DxcOptimizer = {
 };
 
 // {94134294-411f-4574-b4d0-8741e25240d2}
-__declspec(selectany) extern const GUID CLSID_DxcContainerBuilder = {
+__declspec(selectany) EXTERN const GUID CLSID_DxcContainerBuilder = {
   0x94134294,
   0x411f,
   0x4574,  

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -762,8 +762,15 @@ IDxcUnsavedFile : public IUnknown
 // Fun fact: 'extern' is required because const is by default static in C++, so
 // CLSID_DxcIntelliSense is not visible externally (this is OK in C, since const is
 // not by default static in C)
+
+#ifdef _MSC_VER
+#define EXTERN extern
+#else
+#define EXTERN
+#endif
+
 __declspec(selectany)
-extern const CLSID CLSID_DxcIntelliSense = { /* 3047833c-d1c0-4b8e-9d40-102878605985 */
+EXTERN const CLSID CLSID_DxcIntelliSense = { /* 3047833c-d1c0-4b8e-9d40-102878605985 */
     0x3047833c,
     0xd1c0,
     0x4b8e,

--- a/include/dxc/dxctools.h
+++ b/include/dxc/dxctools.h
@@ -47,10 +47,17 @@ IDxcRewriter : public IUnknown {
                                                      _In_ UINT32  rewriteOption,
                                                      _COM_Outptr_ IDxcOperationResult **ppResult) = 0;
 
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcRewriter)
 };
 
+#ifdef _MSC_VER
+#define EXTERN extern
+#else
+#define EXTERN
+#endif
+
 __declspec(selectany)
-extern const CLSID CLSID_DxcRewriter = { /* b489b951-e07f-40b3-968d-93e124734da4 */
+EXTERN const CLSID CLSID_DxcRewriter = { /* b489b951-e07f-40b3-968d-93e124734da4 */
   0xb489b951,
   0xe07f,
   0x40b3,

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -31,9 +31,6 @@
 #ifdef LLVM_ON_WIN32
 #include "d3d12shader.h" // for compatibility
 #include "d3d11shader.h" // for compatibility
-#endif
-
-#ifdef LLVM_ON_WIN32
 
 const GUID IID_ID3D11ShaderReflection_43 = {
     0x0a233719,

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -28,8 +28,13 @@
 
 #include "dxc/dxcapi.h"
 
+#ifdef LLVM_ON_WIN32
 #include "d3d12shader.h" // for compatibility
 #include "d3d11shader.h" // for compatibility
+#endif
+
+#ifdef LLVM_ON_WIN32
+
 const GUID IID_ID3D11ShaderReflection_43 = {
     0x0a233719,
     0x3960,
@@ -1950,3 +1955,9 @@ UINT64 DxilShaderReflection::GetRequiresFlags() {
   if (features & ShaderFeatureInfo_ViewportAndRTArrayIndexFromAnyShaderFeedingRasterizer) result |= D3D_SHADER_REQUIRES_VIEWPORT_AND_RT_ARRAY_INDEX_FROM_ANY_SHADER_FEEDING_RASTERIZER;
   return result;
 }
+
+#else
+void hlsl::CreateDxcContainerReflection(IDxcContainerReflection **ppResult) {
+  *ppResult = nullptr;
+}
+#endif // LLVM_ON_WIN32

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -16,9 +16,28 @@
 #include "dxc/dxcisense.h"
 #include "dxc/dxctools.h"
 #include "dxc/Support/Global.h"
+#ifdef _WIN32
 #include "dxcetw.h"
+#endif
 #include "dxillib.h"
 #include <memory>
+
+// Initialize the UUID for the interfaces.
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcLibrary)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcBlobEncoding)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcOperationResult)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcAssembler)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcBlob)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcIncludeHandler)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcCompiler)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcCompiler2)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcVersionInfo)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcVersionInfo2)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcValidator)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcOptimizerPass)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcOptimizer)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcRewriter)
 
 HRESULT CreateDxcCompiler(_In_ REFIID riid, _Out_ LPVOID *ppv);
 HRESULT CreateDxcDiaDataSource(_In_ REFIID riid, _Out_ LPVOID *ppv);
@@ -53,13 +72,7 @@ static HRESULT ThreadMallocDxcCreateInstance(
                   _Out_ LPVOID   *ppv) {
   HRESULT hr = S_OK;
   *ppv = nullptr;
-  if (IsEqualCLSID(rclsid, CLSID_DxcIntelliSense)) {
-    hr = CreateDxcIntelliSense(riid, ppv);
-  }
-  else if (IsEqualCLSID(rclsid, CLSID_DxcRewriter)) {
-    hr = CreateDxcRewriter(riid, ppv);
-  }
-  else if (IsEqualCLSID(rclsid, CLSID_DxcCompiler)) {
+  if (IsEqualCLSID(rclsid, CLSID_DxcCompiler)) {
     hr = CreateDxcCompiler(riid, ppv);
   }
   else if (IsEqualCLSID(rclsid, CLSID_DxcLibrary)) {
@@ -78,6 +91,14 @@ static HRESULT ThreadMallocDxcCreateInstance(
   else if (IsEqualCLSID(rclsid, CLSID_DxcOptimizer)) {
     hr = CreateDxcOptimizer(riid, ppv);
   }
+// Note: The following targets are not yet enabled for non-Windows platforms.
+#ifdef _WIN32
+  else if (IsEqualCLSID(rclsid, CLSID_DxcIntelliSense)) {
+    hr = CreateDxcIntelliSense(riid, ppv);
+  }
+  else if (IsEqualCLSID(rclsid, CLSID_DxcRewriter)) {
+    hr = CreateDxcRewriter(riid, ppv);
+  }
   else if (IsEqualCLSID(rclsid, CLSID_DxcDiaDataSource)) {
     hr = CreateDxcDiaDataSource(riid, ppv);
   }
@@ -90,6 +111,7 @@ static HRESULT ThreadMallocDxcCreateInstance(
   else if (IsEqualCLSID(rclsid, CLSID_DxcContainerBuilder)) {
     hr = CreateDxcContainerBuilder(riid, ppv);
   }
+#endif
   else {
     hr = REGDB_E_CLASSNOTREG;
   }


### PR DESCRIPTION
As described #1342, this change makes it possible for interfaces to
compile on other platforms, without making any intrusive changes.