### PR TITLE
[linux-port] Fix gcc6.4 alpine(and others) compile

### DIFF
--- a/include/llvm/Analysis/TargetLibraryInfo.def
+++ b/include/llvm/Analysis/TargetLibraryInfo.def
@@ -431,9 +431,11 @@ TLI_DEFINE_STRING_INTERNAL("fmodl")
 /// FILE *fopen(const char *filename, const char *mode);
 TLI_DEFINE_ENUM_INTERNAL(fopen)
 TLI_DEFINE_STRING_INTERNAL("fopen")
+#if 0 // HLSL Change Starts - Exclude potentially duplicate 64bit versions
 /// FILE *fopen64(const char *filename, const char *opentype)
 TLI_DEFINE_ENUM_INTERNAL(fopen64)
 TLI_DEFINE_STRING_INTERNAL("fopen64")
+#endif // HLSL Change Ends
 /// int fprintf(FILE *stream, const char *format, ...);
 TLI_DEFINE_ENUM_INTERNAL(fprintf)
 TLI_DEFINE_STRING_INTERNAL("fprintf")
@@ -467,9 +469,11 @@ TLI_DEFINE_STRING_INTERNAL("fseek")
 /// int fseeko(FILE *stream, off_t offset, int whence);
 TLI_DEFINE_ENUM_INTERNAL(fseeko)
 TLI_DEFINE_STRING_INTERNAL("fseeko")
+#if 0 // HLSL Change Starts - Exclude potentially duplicate 64bit versions
 /// int fseeko64(FILE *stream, off64_t offset, int whence)
 TLI_DEFINE_ENUM_INTERNAL(fseeko64)
 TLI_DEFINE_STRING_INTERNAL("fseeko64")
+#endif // HLSL Change Ends
 /// int fsetpos(FILE *stream, const fpos_t *pos);
 TLI_DEFINE_ENUM_INTERNAL(fsetpos)
 TLI_DEFINE_STRING_INTERNAL("fsetpos")
@@ -491,9 +495,11 @@ TLI_DEFINE_STRING_INTERNAL("ftell")
 /// off_t ftello(FILE *stream);
 TLI_DEFINE_ENUM_INTERNAL(ftello)
 TLI_DEFINE_STRING_INTERNAL("ftello")
+#if 0 // HLSL Change Starts - Exclude potentially duplicate 64bit versions
 /// off64_t ftello64(FILE *stream)
 TLI_DEFINE_ENUM_INTERNAL(ftello64)
 TLI_DEFINE_STRING_INTERNAL("ftello64")
+#endif // HLSL Change Ends
 /// int ftrylockfile(FILE *file);
 TLI_DEFINE_ENUM_INTERNAL(ftrylockfile)
 TLI_DEFINE_STRING_INTERNAL("ftrylockfile")
@@ -955,9 +961,11 @@ TLI_DEFINE_STRING_INTERNAL("times")
 /// FILE *tmpfile(void);
 TLI_DEFINE_ENUM_INTERNAL(tmpfile)
 TLI_DEFINE_STRING_INTERNAL("tmpfile")
+#if 0 // HLSL Change Starts - Exclude potentially duplicate 64bit versions
 /// FILE *tmpfile64(void)
 TLI_DEFINE_ENUM_INTERNAL(tmpfile64)
 TLI_DEFINE_STRING_INTERNAL("tmpfile64")
+#endif // HLSL Change Ends
 /// int toascii(int c);
 TLI_DEFINE_ENUM_INTERNAL(toascii)
 TLI_DEFINE_STRING_INTERNAL("toascii")

--- a/lib/Analysis/TargetLibraryInfo.cpp
+++ b/lib/Analysis/TargetLibraryInfo.cpp
@@ -350,16 +350,16 @@ static void initialize(TargetLibraryInfoImpl &TLI, const Triple &T,
     TLI.setUnavailable(LibFunc::under_IO_getc);
     TLI.setUnavailable(LibFunc::under_IO_putc);
     TLI.setUnavailable(LibFunc::memalign);
-    TLI.setUnavailable(LibFunc::fopen64);
-    TLI.setUnavailable(LibFunc::fseeko64);
+    //TLI.setUnavailable(LibFunc::fopen64); // HLSL Change - duplicate 64bit versions
+    //TLI.setUnavailable(LibFunc::fseeko64); // HLSL Change - duplicate 64bit versions
     TLI.setUnavailable(LibFunc::fstat64);
     TLI.setUnavailable(LibFunc::fstatvfs64);
-    TLI.setUnavailable(LibFunc::ftello64);
+    //TLI.setUnavailable(LibFunc::ftello64); // HLSL Change - duplicate 64bit versions
     TLI.setUnavailable(LibFunc::lstat64);
     TLI.setUnavailable(LibFunc::open64);
     TLI.setUnavailable(LibFunc::stat64);
     TLI.setUnavailable(LibFunc::statvfs64);
-    TLI.setUnavailable(LibFunc::tmpfile64);
+    //TLI.setUnavailable(LibFunc::tmpfile64); // HLSL Change - duplicate 64bit versions
   }
 
   TLI.addVectorizableFunctionsFromVecLib(ClVectorLibrary);

--- a/lib/Transforms/IPO/FunctionAttrs.cpp
+++ b/lib/Transforms/IPO/FunctionAttrs.cpp
@@ -1627,6 +1627,7 @@ bool FunctionAttrs::inferPrototypeAttributes(Function &F) {
     setOnlyReadsMemory(F, 1);
     setOnlyReadsMemory(F, 2);
     break;
+#if 0 // HLSL Change Starts - Exclude potentially duplicate 64bit versions
   case LibFunc::fopen64:
     if (FTy->getNumParams() != 2 ||
         !FTy->getReturnType()->isPointerTy() ||
@@ -1653,6 +1654,7 @@ bool FunctionAttrs::inferPrototypeAttributes(Function &F) {
     setDoesNotThrow(F);
     setDoesNotAlias(F, 0);
     break;
+#endif // HLSL Change Ends - Exclude potentially duplicate 64bit versions
   case LibFunc::fstat64:
   case LibFunc::fstatvfs64:
     if (FTy->getNumParams() != 2 || !FTy->getParamType(1)->isPointerTy())


### PR DESCRIPTION
Alpine Linux and probably several others, define fopen64, fseeko64,
ftello64, and tmpfile64 to their 32 bit equivalents in system
headers. This results in duplicates in areas of the code that
include 32 bit and 64 bit references to this. Since HLSL doesn't
have any of these functions anyway, we can safely exclude them.