### PR TITLE
[linux-port] Use cross-platform dynamic lib load

### DIFF
--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -28,7 +28,7 @@ if( NOT MSVC )
 endif( NOT MSVC )
 
 # HLSL Change - add ignored sources
-set(HLSL_IGNORE_SOURCES DynamicLibrary.cpp PluginLoader.cpp)
+set(HLSL_IGNORE_SOURCES PluginLoader.cpp)
 
 add_llvm_library(LLVMSupport
   APFloat.cpp
@@ -52,6 +52,7 @@ add_llvm_library(LLVMSupport
   DeltaAlgorithm.cpp
   DAGDeltaAlgorithm.cpp
   Dwarf.cpp
+  DynamicLibrary.cpp
   ErrorHandling.cpp
   FileUtilities.cpp
   FileOutputBuffer.cpp

--- a/tools/clang/tools/dxcompiler/dxillib.cpp
+++ b/tools/clang/tools/dxcompiler/dxillib.cpp
@@ -25,6 +25,11 @@ static llvm::sys::Mutex *cs = nullptr;
 // This function is to prevent multiple attempts to load dxil.dll 
 HRESULT DxilLibInitialize() {
   cs = new llvm::sys::Mutex;
+#if LLVM_ON_WIN32
+  cs->lock();
+  g_DllLibResult = g_DllSupport.InitializeForDll(L"dxil.dll", "DxcCreateInstance");
+  cs->unlock();
+#endif
   return S_OK;
 }
 


### PR DESCRIPTION
LLVM includes a DynamicLibrary class that works on multiple platforms
Rather than ifdefing between dlopen for non-Windows and LoadLibraryW
on Windows, using this class allows us to abstract platform differences
while using the same code.

Changed DxilLibInitialize to attempt to initialize dxil.dll so the
smart mutex inside the dynamic library object uses the same IMalloc
as the other ManagedStatic objects so they can all be freed in order.