### PR TITLE
[spirv] Update SPIRV-Tools for not merging resource types

### DIFF
--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -240,6 +240,8 @@ bool spirvToolsValidate(spv_target_env env, std::vector<uint32_t> *module,
 
   spvtools::ValidatorOptions options;
   options.SetRelaxLogicalPointer(relaxLogicalPointer);
+  // TODO: Fix the following to enable validating layout.
+  options.SetRelaxBlockLayout(true);
 
   return tools.Validate(module->data(), module->size(), options);
 }

--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -38,6 +38,8 @@ bool validateSpirvBinary(spv_target_env env, std::vector<uint32_t> &binary,
                          bool relaxLogicalPointer) {
   spvtools::ValidatorOptions options;
   options.SetRelaxLogicalPointer(relaxLogicalPointer);
+  // TODO: Fix the following to enable validating layout.
+  options.SetRelaxBlockLayout(true);
   spvtools::SpirvTools spirvTools(env);
   spirvTools.SetMessageConsumer(
       [](spv_message_level_t, const char *, const spv_position_t &,


### PR DESCRIPTION
Keeping the original struct type is important for some reflection
workflows.

The validation check for layout is alo included. But we disable
it for now and will re-enable it after fixing all the failures.

Fixes https://github.com/Microsoft/DirectXShaderCompiler/issues/1364