### PR TITLE
[spirv] Do not build tests by default and hook up with ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,10 +103,10 @@ option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." OFF)
 # Enable SPIR-V CodeGen for Linux by default.
 if(NOT WIN32)
   set(ENABLE_SPIRV_CODEGEN ON)
-  set(SPIRV_BUILD_TESTS ON)
 endif()
 
 if (${SPIRV_BUILD_TESTS})
+  enable_testing()
   set(ENABLE_SPIRV_CODEGEN ON)
 endif()
 if (${ENABLE_SPIRV_CODEGEN})

--- a/docs/DxcOnUnix.rst
+++ b/docs/DxcOnUnix.rst
@@ -130,11 +130,14 @@ You can follow these steps to build and run the SPIR-V CodeGen tests:
 
   cd <dxc-build-dir>
   # Use SPIRV_BUILD_TESTS flag to enable building these tests.
-  cmake <dxc-src-dir> -GNinja -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release $(cat <dxc-src-dir>/utils/cmake-predefined-config-params)
-  # Build all targets. Includes 'dxc' and 'clang-spirv-tests'.
+  cmake <dxc-src-dir> \
+    $(cat <dxc-src-dir>/utils/cmake-predefined-config-params) \
+    -DCMAKE_BUILD_TYPE=Release -DSPIRV_BUILD_TESTS=ON \
+    -GNinja
+  # Build all targets. Includes 'dxc' and tests.
   ninja
   # Run all tests
-  <dxc-build-dir>/bin/clang-spirv-tests --spirv-test-root <dxc-src-dir>/tools/clang/test/CodeGenSPIRV/
+  ctest
 
 
 As described in the `Known Issues`_ section above, you currently need to

--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -40,3 +40,7 @@ target_include_directories(clang-spirv-tests
 
 set_output_directory(clang-spirv-tests
   ${LLVM_RUNTIME_OUTPUT_INTDIR} ${LLVM_LIBRARY_OUTPUT_INTDIR})
+
+add_test(NAME test-spirv-codegen
+  COMMAND clang-spirv-tests --spirv-test-root
+          ${PROJECT_SOURCE_DIR}/tools/clang/test/CodeGenSPIRV)


### PR DESCRIPTION
This way we can just run ctest to invoke the tests, instead of
remembering the binary and its parameters.