### PR TITLE
Fix lambda captures in dxilcontainer serializer

### DIFF
--- a/lib/HLSL/DxilContainerAssembler.cpp
+++ b/lib/HLSL/DxilContainerAssembler.cpp
@@ -883,6 +883,10 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
 
   // If we have debug information present, serialize it to a debug part, then use the stripped version as the canonical program version.
   CComPtr<AbstractMemoryStream> pProgramStream = pInputProgramStream;
+  const uint32_t DebugInfoNameHashLen = 32;   // 32 chars of MD5
+  const uint32_t DebugInfoNameSuffix = 4;     // '.lld'
+  const uint32_t DebugInfoNameNullAndPad = 4; // '\0\0\0\0'
+  CComPtr<AbstractMemoryStream> pHashStream;
   if (HasDebugInfo(*pModule->GetModule())) {
     uint32_t debugInUInt32, debugPaddingBytes;
     GetPaddedProgramPartSize(pInputProgramStream, debugInUInt32, debugPaddingBytes);
@@ -902,16 +906,12 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
     WriteBitcodeToFile(pModule->GetModule(), outStream, true);
 
     if (Flags & SerializeDxilFlags::IncludeDebugNamePart) {
-      CComPtr<AbstractMemoryStream> pHashStream;
       // If the debug name should be specific to the sources, base the name on the debug
       // bitcode, which will include the source references, line numbers, etc. Otherwise,
       // do it exclusively on the target shader bitcode.
       pHashStream = (int)(Flags & SerializeDxilFlags::DebugNameDependOnSource)
                         ? CComPtr<AbstractMemoryStream>(pModuleBitcode)
                         : CComPtr<AbstractMemoryStream>(pProgramStream);
-      const uint32_t DebugInfoNameHashLen = 32;   // 32 chars of MD5
-      const uint32_t DebugInfoNameSuffix = 4;     // '.lld'
-      const uint32_t DebugInfoNameNullAndPad = 4; // '\0\0\0\0'
       const uint32_t DebugInfoContentLen =
           sizeof(DxilShaderDebugName) + DebugInfoNameHashLen +
           DebugInfoNameSuffix + DebugInfoNameNullAndPad;


### PR DESCRIPTION
A lambda function relied on captured variables after they went out
of scope. The result on Linux was access to random data. The effect
varies randomly just as returning a point to a variable that goes
out of scope might.