### PR TITLE
[linux-port] Correct char convert size in/out

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -111,6 +111,8 @@
 #define ERROR_IO_DEVICE EIO
 #define ERROR_INVALID_HANDLE EBADF
 #define ERROR_ARITHMETIC_OVERFLOW EOVERFLOW
+#define ERROR_INSUFFICIENT_BUFFER ENOBUFS
+#define ERROR_INVALID_PARAMETER EINVAL
 
 // Used by HRESULT <--> WIN32 error code conversion
 #define SEVERITY_ERROR 1
@@ -841,7 +843,7 @@ public:
       return;
     }
 
-    int len = wcslen(psz) * 4;
+    int len = (wcslen(psz) + 1) * 4;
     m_psz = new char[len];
     std::wcstombs(m_psz, psz, len);
   }


### PR DESCRIPTION
MultiByteToWideChar and WideCharToMultiByte were returning -1 on
failure, which caused failures to be ignored. When successful, they
were returning the number of characters converted excluding the
terminating null character because that's what the std:: functions
used for the implementation do. Both are inconsistent with the
original Windows implementations.

Simply adding one to the return value works in all cases save those
where the number of characters converted was limited by the parameter
In this case, the number of characters converted doesn't include
the terminating null. So no addition is warrented.

Added addition errors in keeping with the function descriptions.

The CW2A conversion class left out the terminating null character
when calculating the max size of the converted string.