### PR TITLE
[linux-port] Handle register number limits

### DIFF
--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -229,12 +229,14 @@ static void ParseRegisterNumberForHLSL(_In_z_ const char *name,
   // It's valid to omit the register name.
   if (*name) {
     char *nameEnd;
+    unsigned long num;
     errno = 0;
-    *registerNumber = strtoul(name, &nameEnd, 10);
-    if (*nameEnd != '\0' || errno == ERANGE) {
+    num = strtoul(name, &nameEnd, 10);
+    if (*nameEnd != '\0' || errno == ERANGE || num > UINT32_MAX) {
       *diagId = diag::err_hlsl_unsupported_register_number;
       return;
     }
+    *registerNumber = num;
   } else {
     *registerNumber = 0;
   }


### PR DESCRIPTION
Like on other platforms, on Windows, strtoul is limited to the size
long. However, long on windows is 32, on linux, it's 64. So Linux
happily converts a string that requires more than 32 bits.
However, it is returned into a variable that is only 32 bits.

In order to keep Linux behavior consistent with Windows, and for
lack of a strtou function, strtoul is still called, but overflow
of 32 bits is detected and reported as an error, making Verifier-
Test happy.