### PR TITLE
Initialize all bits in IncludedFileIndexToHandle

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -83,12 +83,25 @@ struct HandleBits {
 };
 struct DxcArgsHandle {
   DxcArgsHandle(HANDLE h) : Handle(h) {}
-  DxcArgsHandle(unsigned fileIndex)
-    : Bits{ fileIndex, 0, (unsigned)HandleKind::File } {}
-  DxcArgsHandle(HandleKind HK, unsigned fileIndex, unsigned dirLength)
-    : Bits{ fileIndex, dirLength, (unsigned)HK} {}
-  DxcArgsHandle(SpecialValue V)
-      : Bits{(unsigned)V, 0, (unsigned)HandleKind::Special} {}
+  DxcArgsHandle(unsigned fileIndex) {
+    Handle = 0;
+    Bits.Offset = fileIndex;
+    Bits.Length = 0;
+    Bits.Kind = (unsigned)HandleKind::File;
+  }
+  DxcArgsHandle(HandleKind HK, unsigned fileIndex, unsigned dirLength) {
+    Handle = 0;
+    Bits.Offset = fileIndex;
+    Bits.Length = dirLength;
+    Bits.Kind = (unsigned)HK;
+  }
+  DxcArgsHandle(SpecialValue V) {
+    Handle = 0;
+    Bits.Offset = (unsigned)V;
+    Bits.Length = 0;
+    Bits.Kind = (unsigned)HandleKind::Special;;
+  }
+
   union {
     HANDLE Handle;
     HandleBits Bits;


### PR DESCRIPTION
Included file HANDLEs are generated using the type, the file index
and some representation of the directory. Since they are not real
files on a real filesystem, they don't have genuine handles.
This conversion is performed using a union containing the above
values and a HANDLE object, which is returned after these are assigned
However, the size of the above values is far less than that of the
HANDLE, which leaves many bits uninitialized, containing random
values.

By initializing the handle to 0, then the capital-B "Bits" values,
no small-b bits are left uninitialized.