### PR TITLE
[linux-port] Win adapter changes for HLSL tests

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -50,11 +50,15 @@
 #define HeapFree(hHeap, dwFlags, voidPtr) free(voidPtr)
 #define HeapCreate(flags, nBytes, maxSize) malloc(nBytes)
 
+#define SysFreeString free
+#define SysAllocStringLen(ptr, size) (wchar_t*)realloc(ptr, (size + 1)*sizeof(wchar_t))
+
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #define _countof(a) (sizeof(a) / sizeof(*(a)))
 
 #define __declspec(x)
+#define DECLSPEC_SELECTANY
 
 #define uuid(id)
 
@@ -171,8 +175,15 @@
 #define _atoi64 atoll
 #define sprintf_s snprintf
 #define _strdup strdup
+
 #define vsprintf_s vsprintf
 #define strcat_s strcat
+#define strcpy_s(dst, n, src) strncpy(dst, src, n)
+#define _vscwprintf vwprintf
+#define vswprintf_s vswprintf
+#define swprintf_s swprintf
+
+#define StringCchCopyW(dst, n, src) wcsncpy(dst, src, n)
 
 #define OutputDebugStringW(msg) fputws(msg, stderr)
 
@@ -243,6 +254,7 @@
 
 #define _Out_
 #define _Out_bytecap_(nbytes)
+#define _Out_writes_to_(a, b)
 #define _Out_writes_to_opt_(a, b)
 #define _Outptr_
 #define _Outptr_opt_
@@ -717,6 +729,7 @@ public:
   }
   int GetSize() { return this->size(); }
   T *GetData() { return this->data(); }
+  void RemoveAll() { this->clear(); }
 };
 
 template <class T, class Allocator = CAllocator> class CHeapPtrBase {

--- a/include/dxc/Support/WinFunctions.h
+++ b/include/dxc/Support/WinFunctions.h
@@ -19,12 +19,18 @@
 
 #include "dxc/Support/WinAdapter.h"
 
+HRESULT StringCchCopyEx(LPSTR pszDest, size_t cchDest, LPCSTR pszSrc,
+                        LPSTR *ppszDestEnd, size_t *pcchRemaining, DWORD dwFlags);
 HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format, ...);
 HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult);
 HRESULT IntToUInt(int in, UINT *out);
 HRESULT SizeTToInt(size_t in, INT *out);
 HRESULT UInt32Mult(UINT a, UINT b, UINT *out);
 int _stricmp(const char *str1, const char *str2);
+int _wcsicmp(const wchar_t *str1, const wchar_t *str2);
+int _wcsnicmp(const wchar_t *str1, const wchar_t *str2, size_t n);
+int wsprintf(wchar_t *wcs, const wchar_t *fmt, ...);
+unsigned char _BitScanForward(unsigned long * Index, unsigned long Mask);
 HRESULT CoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);
 
 HANDLE CreateFile2(_In_ LPCWSTR lpFileName, _In_ DWORD dwDesiredAccess,

--- a/lib/DxcSupport/WinFunctions.cpp
+++ b/lib/DxcSupport/WinFunctions.cpp
@@ -116,7 +116,7 @@ int _wcsicmp(const wchar_t *str1, const wchar_t *str2) {
 
 int _wcsnicmp(const wchar_t *str1, const wchar_t *str2, size_t n) {
   size_t i = 0;
-  for (; str1[i] && str2[i]; ++i) {
+  for (; i < n && str1[i] && str2[i]; ++i) {
     int d = std::towlower(str1[i]) - std::towlower(str2[i]);
     if (d != 0)
       return d;


### PR DESCRIPTION
A number of Windows-specific features are present in the HLSL tests
as well as driver features that had to be enabled to get those tests
running, notably intellisense classes.

This change adds to the existing WinAdapter and WinFunctions files
to include the features needed for these additions to compiler and tests.
They cover a lot of ground, but mostly consist of memory allocation
and string changes, because you can never have enough ways to
allocate memory and manipulate strings.

An incidental change is to the existing CreateFileW implementation
to retry a file if the error indicated it was interrupted. This was
taken from the LLVM Path.inc implementation for Unix.