### PR TITLE
[linux-port] Enable intellisense classes for Unix

### DIFF
--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -12,6 +12,7 @@
 #ifndef __DXC_ISENSE__
 #define __DXC_ISENSE__
 
+#include "dxc/dxcapi.h"
 #include "dxc/Support/WinAdapter.h"
 
 typedef enum DxcGlobalOptions
@@ -663,6 +664,8 @@ IDxcIntelliSense : public IUnknown
     _Out_ DxcDiagnosticDisplayOptions* pValue) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetDefaultEditingTUOptions(_Out_ DxcTranslationUnitFlags* pValue) = 0;
   virtual HRESULT STDMETHODCALLTYPE CreateUnsavedFile(_In_ LPCSTR fileName, _In_ LPCSTR contents, unsigned contentLength, _Outptr_result_nullonfailure_ IDxcUnsavedFile** pResult) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcIntelliSense)
 };
 
 struct __declspec(uuid("937824a0-7f5a-4815-9ba7-7fc0424f4173"))

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1957,4 +1957,6 @@ UINT64 DxilShaderReflection::GetRequiresFlags() {
 void hlsl::CreateDxcContainerReflection(IDxcContainerReflection **ppResult) {
   *ppResult = nullptr;
 }
+
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcContainerReflection)
 #endif // LLVM_ON_WIN32

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -38,6 +38,8 @@ DEFINE_CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder)
 DEFINE_CROSS_PLATFORM_UUIDOF(IDxcOptimizerPass)
 DEFINE_CROSS_PLATFORM_UUIDOF(IDxcOptimizer)
 DEFINE_CROSS_PLATFORM_UUIDOF(IDxcRewriter)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcIntelliSense)
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcLinker)
 
 HRESULT CreateDxcCompiler(_In_ REFIID riid, _Out_ LPVOID *ppv);
 HRESULT CreateDxcDiaDataSource(_In_ REFIID riid, _Out_ LPVOID *ppv);
@@ -91,11 +93,11 @@ static HRESULT ThreadMallocDxcCreateInstance(
   else if (IsEqualCLSID(rclsid, CLSID_DxcOptimizer)) {
     hr = CreateDxcOptimizer(riid, ppv);
   }
-// Note: The following targets are not yet enabled for non-Windows platforms.
-#ifdef _WIN32
   else if (IsEqualCLSID(rclsid, CLSID_DxcIntelliSense)) {
     hr = CreateDxcIntelliSense(riid, ppv);
   }
+// Note: The following targets are not yet enabled for non-Windows platforms.
+#ifdef _WIN32
   else if (IsEqualCLSID(rclsid, CLSID_DxcRewriter)) {
     hr = CreateDxcRewriter(riid, ppv);
   }

--- a/tools/clang/tools/libclang/CMakeLists.txt
+++ b/tools/clang/tools/libclang/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SOURCES
   IndexTypeSourceInfo.cpp
   Indexing.cpp
   IndexingContext.cpp
+  dxcisenseimpl.cpp # HLSL Change
   dxcrewriteunused.cpp # HLSL Change
 
   ADDITIONAL_HEADERS
@@ -86,7 +87,6 @@ set(SOURCES
 
 set (HLSL_IGNORE_SOURCES
   BuildSystem.cpp
-  dxcisenseimpl.cpp # HLSL Change
 )
 endif(WIN32)
 

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/Host.h"
 #include "clang/Sema/SemaHLSL.h"
 
+#include "dxc/Support/WinFunctions.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/Global.h"
 #include "dxcisenseimpl.h"


### PR DESCRIPTION
Several HLSL tests, notably VerifierTest, require intellisense classes
To get these working on Unix platforms, we need to add support.
This involves mostly exposing the instance creation, the UUID, and
adding the right headers. 

Additionally adds definitions of a couple UUIDs that were declared
but previously not defined. These are also useful for HLSL tests.