### PR TITLE
[linux-port] restore mistakenly removed sysallocs

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -45,6 +45,9 @@
 #define CoTaskMemAlloc malloc
 #define CoTaskMemFree free
 
+#define SysFreeString free
+#define SysAllocStringLen(ptr, size) (wchar_t*)realloc(ptr, (size + 1)*sizeof(wchar_t))
+
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
 
 #define _countof(a) (sizeof(a) / sizeof(*(a)))


### PR DESCRIPTION
In rebasing the heap change, I mistakenly removed the sysallocstringlen
and sysfreestring functions. This restores them.