### PR TITLE
Remove unneeded object files from HLSL tests

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -10,13 +10,6 @@ set( LLVM_LINK_COMPONENTS
   support
   mssupport
   dxcsupport
-  hlsl
-  option
-  bitreader
-  bitwriter
-  analysis
-  ipa
-  irreader
   )
 
 if(WIN32)


### PR DESCRIPTION
There are several object files that get included in the dynamic
library as well as the executable binary that is linked to it.
This is probably inadvertent and for many linkers, it doesn't cause
much of a problem, it just includes two copies of various variables
and functions. One set is used, the other is wasted. The executable
is a bit larger as a result, but there are no other consequences.

However, for some linkers, this is a problem particularly where
addresses of static variables are concerned. Some of these can be
resolved at compile time and so they are explicitly affixed to one
set of static variables. However, the linker might redirect later
runtime references to the other set. In this case, the result was
an infinite loop in optimization passes that kept looking for needed
analysis passes. Never finding one matching the UUID that it expected
because it was drawn from the wrong set, it kept trying to schedule
them, which used a method that successfully identified the already
existing pass and so no scheduling occurred, but the loop over needed
analysis passes was restarted and the process started over.

There's a fairly obvious workaround to this, but the root problem
really is the duplicate inclusion which may cause little damage
but grants no benefit I'm aware of. This change removes the unneeded
object files relating to passes from the executable. It runs on all
supported platforms.