### PR TITLE
[linux-port] Fix conflict with /U arg and files

### DIFF
--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1910,10 +1910,17 @@ bool CompilerInvocation::CreateFromArgs(CompilerInvocation &Res,
   // where we have a dxc-based command-line. We choose to accept additional
   // options even if they don't get applied.
   const unsigned IncludedFlagsBitmask = 0;
+#ifdef _WIN32
+  const unsigned ExcludedFlagsBitmask = 0;
+#else
+  // Exception: Exclude cl.exe like arguments that can trip up Unix systems
+  const unsigned ExcludedFlagsBitmask = options::CLOption;
+#endif
+  // End HLSL Change
   unsigned MissingArgIndex, MissingArgCount;
   InputArgList Args =
       Opts->ParseArgs(llvm::makeArrayRef(ArgBegin, ArgEnd), MissingArgIndex,
-                      MissingArgCount, IncludedFlagsBitmask);
+                      MissingArgCount, IncludedFlagsBitmask, ExcludedFlagsBitmask);
 
   // Check for missing argument error.
   if (MissingArgCount) {


### PR DESCRIPTION
Due to the format that Windows arguments take, files on Unix systems
can sometimes be mistaken for them. A notable example of this is a
file from a directory starting with /U because it will look to the
arg processor exactly like the undefine-macro argument. Because of
this, the VerifierTest might seem to hang because, seeming to have
no input file, it falls back to reading stdin.

The dxc binary avoids this by using a completely different set of
options that doesn't include any of these. clang itself uses
inclusion and exclusion flags that determine on which systems and
under what circumstances / arguments are allowed.

CompilerInvocation::CreateFromArgs was altered to not take any of
these bitfields for the sake of the HLSL tests. I've made a slight
alteration to that to exclude the cl.exe style arguments using the
exclusion bitfield.