### PR TITLE
[linux-port] Enable AllocatorTest for Unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,3 +75,4 @@ script:
   - ./bin/dxc -T ps_6_0 -Fo passthru-ps.spv ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv -spirv
   - cmp passthru-ps.spv ../tools/clang/test/CodeGenSPIRV/passthru-ps.spv
   - ./bin/clang-spirv-tests --spirv-test-root ../tools/clang/test/CodeGenSPIRV/
+  - ./bin/clang-hlsl-tests --HlslDataDir $PWD/../tools/clang/test/CodeGenSPIRV/

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,4 +75,4 @@ script:
   - ./bin/dxc -T ps_6_0 -Fo passthru-ps.spv ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv -spirv
   - cmp passthru-ps.spv ../tools/clang/test/CodeGenSPIRV/passthru-ps.spv
   - ./bin/clang-spirv-tests --spirv-test-root ../tools/clang/test/CodeGenSPIRV/
-  - ./bin/clang-hlsl-tests --HlslDataDir $PWD/../tools/clang/test/CodeGenSPIRV/
+  - ./bin/clang-hlsl-tests --HlslDataDir $PWD/../tools/clang/test/HLSL/

--- a/tools/clang/unittests/HLSL/AllocatorTest.cpp
+++ b/tools/clang/unittests/HLSL/AllocatorTest.cpp
@@ -9,7 +9,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/Support/WinIncludes.h"
+#ifdef _WIN32
 #include "WexTestClass.h"
+#endif
 #include "HlslTestUtils.h"
 
 #include "dxc/HLSL/DxilSpanAllocator.h"
@@ -318,7 +320,8 @@ struct Scenario {
     }
     //   one = two = random
     if (maxIdx > 2) {
-      unsigned one = std::min(1 + (randGen() % (maxIdx - 2)), maxIdx);
+      unsigned randIdx = 1 + (randGen() % (maxIdx - 2));
+      unsigned one = std::min(randIdx, maxIdx);
       pairs.insert(Test(one, one));
     }
     //   one = two = last - 1
@@ -343,18 +346,22 @@ struct Scenario {
     }
     //   one = first, two = random
     if (maxIdx > 3) {
-      unsigned two = std::min(1 + (randGen() % (maxIdx - 2)), maxIdx);
+      unsigned randIdx = 1 + (randGen() % (maxIdx - 2));
+      unsigned two = std::min(randIdx, maxIdx);
       pairs.insert(Test(0, two));
     }
     //   one = random, two = random
     if (maxIdx > 4) {
-      unsigned one = std::min(1 + (randGen() % (maxIdx - 3)), maxIdx);
-      unsigned two = std::min(one + 1 + (randGen() % (maxIdx - (one + 1))), maxIdx);
+      unsigned randIdx = 1 + (randGen() % (maxIdx - 3));
+      unsigned one = std::min(randIdx, maxIdx);
+      randIdx = one + 1 + (randGen() % (maxIdx - (one + 1)));
+      unsigned two = std::min(randIdx, maxIdx);
       pairs.insert(Test(one, two));
     }
     //   one = random, two = last
     if (maxIdx > 3) {
-      unsigned one = std::min(1 + (randGen() % (maxIdx - 2)), maxIdx);
+      unsigned randIdx = 1 + (randGen() % (maxIdx - 2));
+      unsigned one = std::min(randIdx, maxIdx);
       pairs.insert(Test(one, maxIdx));
     }
     //   one = second, two = last-1
@@ -522,7 +529,12 @@ struct Scenario {
 };
 
 // The test fixture.
+#ifdef _WIN32
 class AllocatorTest {
+#else
+class AllocatorTest : public ::testing::Test {
+protected:
+#endif
   std::vector<Scenario> m_Scenarios;
 public:
   BEGIN_TEST_CLASS(AllocatorTest)

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -53,7 +53,6 @@ add_clang_library(clang-hlsl-tests SHARED
   )
 else (WIN32)
 set(HLSL_IGNORE_SOURCES
-  AllocatorTest.cpp
   CompilerTest.cpp
   DxilContainerTest.cpp
   DxilModuleTest.cpp
@@ -76,6 +75,7 @@ set(HLSL_IGNORE_SOURCES
   )
 
 add_clang_unittest(clang-hlsl-tests
+  AllocatorTest.cpp
   DxcTestUtils.cpp
   HLSLTestOptions.cpp
   TestMain.cpp

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -124,3 +124,7 @@ file(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" DOS_STYLE_SOURCE_DIR)
 file(TO_NATIVE_PATH "${TAEF_BIN_DIR}" DOS_TAEF_BIN_DIR)
 configure_file(clang-hlsl-tests.vcxproj.user.txt clang-hlsl-tests.vcxproj.user)
 endif(WIN32)
+
+add_test(NAME test-hlsl-codegen
+  COMMAND clang-hlsl-tests --HlslDataDir
+          ${PROJECT_SOURCE_DIR}/tools/clang/test/HLSL)


### PR DESCRIPTION
Enable gtest support and create temp variable to pass to std::min
by reference as it does on Linux.

Also enables clang-hlsl-tests for travis as it will now be running
something useful