### PR TITLE
Remove unneeded object files from HLSL tests

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(DiaSDK REQUIRED) # Used for constants and declarations.
 find_package(D3D12 REQUIRED) # Used for ExecutionTest.cpp.
 ENDif(WIN32)
 
+if(WIN32)
 set( LLVM_LINK_COMPONENTS
   support
   mssupport
@@ -19,7 +20,6 @@ set( LLVM_LINK_COMPONENTS
   irreader
   )
 
-if(WIN32)
 set(HLSL_IGNORE_SOURCES
   TestMain.cpp
   HLSLTestOptions.cpp
@@ -52,6 +52,12 @@ add_clang_library(clang-hlsl-tests SHARED
   clang-hlsl-tests.rc
   )
 else (WIN32)
+set( LLVM_LINK_COMPONENTS
+  support
+  mssupport
+  dxcsupport
+  )
+
 set(HLSL_IGNORE_SOURCES
   CompilerTest.cpp
   DxilContainerTest.cpp


### PR DESCRIPTION
There are several object files that get included in the dynamic
library as well as the executable binary that is linked to it.
This is probably due to the limited way that the Windows linker
exposes symbols. Regardless, the duplicate inclusion doesn't cause
much of a problem, it just includes two copies of various variables
and functions. One set is used, the other is wasted. The executable
is a bit larger as a result, but there are no other consequences.

However, for some linkers in some cases, this is a problem. Of
particular concern are cases where where addresses of static
variables are used as identifiers. Each compilation unit, will have
its own set of static symbols. Where the call begins and possibly
some compiler optimizations will determine which static variable's
address is used. If the call ends several levels lower comparing to
the address of a different static variable, there will be a mismatch
that can result in failures ore infinite loops.

Specifically, the compiler uses passes for various purposes that are
all identified by the address of a static variable in the class that
represents that pass. If the code in question is only included once
in a compilation in a single library or a single executable, that
causes no problems, but static variables are by definition not as
"global" as the "G" in GUUID might suggest. They are limited to their
compulation unit. So when a given pass requires scheduling a new
pass to collect the analysis information required, The pass gets
scheduled, but when the pass's dependency check loop is restarted,
the scheduled pass is not found due to this mismatch, so it tries
to schedule it again and again ad infinitum.

To resolve this issue would require either changing the way GUUIDs
are manufactured, which I've done in another change that sprawled
over the entire compiler and was successful. Arguably, another tack
is to remove the duplicate inclusions where they can cause problems.
Being far less invasive, this seemed more appropriate for this change.