### PR TITLE
[spirv] Embed preprocessed source code when -Zi

### DIFF
--- a/tools/clang/include/clang/SPIRV/InstBuilder.h
+++ b/tools/clang/include/clang/SPIRV/InstBuilder.h
@@ -94,7 +94,7 @@ public:
   // Instruction building methods.
   InstBuilder &opNop();
   InstBuilder &opUndef(uint32_t result_type, uint32_t result_id);
-  InstBuilder &opSourceContinued(std::string continued_source);
+  InstBuilder &opSourceContinued(llvm::StringRef continued_source);
   InstBuilder &opSource(spv::SourceLanguage source_language, uint32_t version,
                         llvm::Optional<uint32_t> file,
                         llvm::Optional<llvm::StringRef> source);

--- a/tools/clang/include/clang/SPIRV/InstBuilder.h
+++ b/tools/clang/include/clang/SPIRV/InstBuilder.h
@@ -23,6 +23,7 @@
 #include "spirv/unified1/spirv.hpp11"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace clang {
 namespace spirv {
@@ -96,7 +97,7 @@ public:
   InstBuilder &opSourceContinued(std::string continued_source);
   InstBuilder &opSource(spv::SourceLanguage source_language, uint32_t version,
                         llvm::Optional<uint32_t> file,
-                        llvm::Optional<std::string> source);
+                        llvm::Optional<llvm::StringRef> source);
   InstBuilder &opSourceExtension(std::string extension);
   InstBuilder &opName(uint32_t target, std::string name);
   InstBuilder &opMemberName(uint32_t type, uint32_t member, std::string name);
@@ -1092,7 +1093,7 @@ private:
   void encodeMemoryAccess(spv::MemoryAccessMask value);
   void encodeExecutionMode(spv::ExecutionMode value);
   void encodeDecoration(spv::Decoration value);
-  void encodeString(std::string value);
+  void encodeString(llvm::StringRef value);
 
   WordConsumer TheConsumer;
   std::vector<uint32_t> TheInst;       ///< The instruction under construction.

--- a/tools/clang/include/clang/SPIRV/ModuleBuilder.h
+++ b/tools/clang/include/clang/SPIRV/ModuleBuilder.h
@@ -341,6 +341,8 @@ public:
   /// \brief Sets the source file name and the <result-id> for the OpString for
   /// the file name.
   inline void setSourceFileName(uint32_t id, std::string name);
+  /// \brief Sets the main source file content.
+  inline void setSourceFileContent(llvm::StringRef content);
 
   /// \brief Adds an execution mode to the module under construction.
   void addExecutionMode(uint32_t entryPointId, spv::ExecutionMode em,
@@ -551,6 +553,10 @@ void ModuleBuilder::setShaderModelVersion(uint32_t major, uint32_t minor) {
 
 void ModuleBuilder::setSourceFileName(uint32_t id, std::string name) {
   theModule.setSourceFileName(id, std::move(name));
+}
+
+void ModuleBuilder::setSourceFileContent(llvm::StringRef content) {
+  theModule.setSourceFileContent(content);
 }
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/Structure.h
+++ b/tools/clang/include/clang/SPIRV/Structure.h
@@ -308,6 +308,7 @@ public:
   inline void addExecutionMode(Instruction &&);
   inline void setShaderModelVersion(uint32_t);
   inline void setSourceFileName(uint32_t id, std::string name);
+  inline void setSourceFileContent(llvm::StringRef content);
   // TODO: source code debug information
   inline void addDebugName(uint32_t targetId, llvm::StringRef name,
                            llvm::Optional<uint32_t> memberIndex = llvm::None);
@@ -341,6 +342,7 @@ private:
   uint32_t shaderModelVersion;
   uint32_t sourceFileNameId; // The <result-id> for the OpString for file name
   std::string sourceFileName;
+  llvm::StringRef sourceFileContent;
   // TODO: source code debug information
   std::set<DebugName> debugNames;
   llvm::SetVector<std::pair<uint32_t, const Decoration *>> decorations;
@@ -501,6 +503,10 @@ void SPIRVModule::setShaderModelVersion(uint32_t version) {
 void SPIRVModule::setSourceFileName(uint32_t id, std::string name) {
   sourceFileNameId = id;
   sourceFileName = std::move(name);
+}
+
+void SPIRVModule::setSourceFileContent(llvm::StringRef content) {
+  sourceFileContent = content;
 }
 
 void SPIRVModule::addDebugName(uint32_t targetId, llvm::StringRef name,

--- a/tools/clang/lib/SPIRV/InstBuilderAuto.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderAuto.cpp
@@ -132,7 +132,7 @@ InstBuilder &InstBuilder::opSourceContinued(std::string continued_source) {
 InstBuilder &InstBuilder::opSource(spv::SourceLanguage source_language,
                                    uint32_t version,
                                    llvm::Optional<uint32_t> file,
-                                   llvm::Optional<std::string> source) {
+                                   llvm::Optional<llvm::StringRef> source) {
   if (!TheInst.empty()) {
     TheStatus = Status::NestedInst;
     return *this;

--- a/tools/clang/lib/SPIRV/InstBuilderAuto.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderAuto.cpp
@@ -116,7 +116,7 @@ InstBuilder &InstBuilder::opUndef(uint32_t result_type, uint32_t result_id) {
   return *this;
 }
 
-InstBuilder &InstBuilder::opSourceContinued(std::string continued_source) {
+InstBuilder &InstBuilder::opSourceContinued(llvm::StringRef continued_source) {
   if (!TheInst.empty()) {
     TheStatus = Status::NestedInst;
     return *this;

--- a/tools/clang/lib/SPIRV/InstBuilderManual.cpp
+++ b/tools/clang/lib/SPIRV/InstBuilderManual.cpp
@@ -234,7 +234,7 @@ InstBuilder &InstBuilder::opSpecConstant(uint32_t resultType, uint32_t resultId,
   return *this;
 }
 
-void InstBuilder::encodeString(std::string value) {
+void InstBuilder::encodeString(llvm::StringRef value) {
   const auto &words = string::encodeSPIRVString(value);
   TheInst.insert(TheInst.end(), words.begin(), words.end());
 }

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -610,9 +610,18 @@ SPIRVEmitter::SPIRVEmitter(CompilerInstance &ci, EmitSPIRVOptions &options)
 
   // Set debug info
   const auto &inputFiles = ci.getFrontendOpts().Inputs;
-  if (options.enableDebugInfo && !inputFiles.empty())
+  if (options.enableDebugInfo && !inputFiles.empty()) {
+    // File name
     theBuilder.setSourceFileName(theContext.takeNextId(),
                                  inputFiles.front().getFile().str());
+
+    // Source code
+    const auto &sm = ci.getSourceManager();
+    const llvm::MemoryBuffer *mainFile =
+        sm.getBuffer(sm.getMainFileID(), SourceLocation());
+    theBuilder.setSourceFileContent(
+        StringRef(mainFile->getBufferStart(), mainFile->getBufferSize()));
+  }
 }
 
 void SPIRVEmitter::HandleTranslationUnit(ASTContext &context) {

--- a/tools/clang/lib/SPIRV/Structure.cpp
+++ b/tools/clang/lib/SPIRV/Structure.cpp
@@ -289,9 +289,14 @@ void SPIRVModule::take(InstBuilder *builder) {
       fileName = sourceFileNameId;
     }
 
+    llvm::Optional<llvm::StringRef> srcCode;
+    if (!sourceFileContent.empty()) {
+      srcCode = llvm::Optional<llvm::StringRef>(sourceFileContent);
+    }
+
     builder
         ->opSource(spv::SourceLanguage::HLSL, shaderModelVersion, fileName,
-                   llvm::None)
+                   srcCode)
         .x();
   }
 

--- a/tools/clang/lib/SPIRV/Structure.cpp
+++ b/tools/clang/lib/SPIRV/Structure.cpp
@@ -17,6 +17,32 @@ namespace spirv {
 namespace {
 constexpr uint32_t kGeneratorNumber = 14;
 constexpr uint32_t kToolVersion = 0;
+
+/// Chops the given original string into multiple smaller ones to make sure they
+/// can be encoded in a sequence of OpSourceContinued instructions following an
+/// OpSource instruction.
+void chopString(llvm::StringRef original,
+                llvm::SmallVectorImpl<llvm::StringRef> *chopped) {
+  const uint32_t maxCharInOpSource = 0xFFFFu - 5u; // Minus operands and nul
+  const uint32_t maxCharInContinue = 0xFFFFu - 2u; // Minus opcode and nul
+
+  chopped->clear();
+  if (original.size() > maxCharInOpSource) {
+    chopped->push_back(llvm::StringRef(original.data(), maxCharInOpSource));
+    original = llvm::StringRef(original.data() + maxCharInOpSource,
+                               original.size() - maxCharInOpSource);
+    while (original.size() > maxCharInContinue) {
+      chopped->push_back(llvm::StringRef(original.data(), maxCharInContinue));
+      original = llvm::StringRef(original.data() + maxCharInContinue,
+                                 original.size() - maxCharInContinue);
+    }
+    if (!original.empty()) {
+      chopped->push_back(original);
+    }
+  } else if (!original.empty()) {
+    chopped->push_back(original);
+  }
+}
 } // namespace
 
 // === Instruction implementations ===
@@ -289,15 +315,21 @@ void SPIRVModule::take(InstBuilder *builder) {
       fileName = sourceFileNameId;
     }
 
-    llvm::Optional<llvm::StringRef> srcCode;
-    if (!sourceFileContent.empty()) {
-      srcCode = llvm::Optional<llvm::StringRef>(sourceFileContent);
+    llvm::SmallVector<llvm::StringRef, 2> choppedSrcCode;
+    llvm::Optional<llvm::StringRef> firstSnippet;
+    chopString(sourceFileContent, &choppedSrcCode);
+    if (!choppedSrcCode.empty()) {
+      firstSnippet = llvm::Optional<llvm::StringRef>(choppedSrcCode.front());
     }
 
     builder
         ->opSource(spv::SourceLanguage::HLSL, shaderModelVersion, fileName,
-                   srcCode)
+                   firstSnippet)
         .x();
+
+    for (uint32_t i = 1; i < choppedSrcCode.size(); ++i) {
+      builder->opSourceContinued(choppedSrcCode[i]).x();
+    }
   }
 
   // BasicBlock debug names should be emitted only for blocks that are

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.hlsl
@@ -4,6 +4,13 @@
 // CHECK-SAME: spirv.debug.opsource.hlsl
 // CHECK:      OpSource HLSL 610 [[str]]
 
+// Make sure we have #line directive emitted by the preprocessor
+// CHECK-SAME: #line 1
+
+// Make sure we have the original source code
+// CHECK:      numthreads(8, 1, 1)
+// CHECK-NEXT: void main()
+
 [numthreads(8, 1, 1)]
 void main() {
 }

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -331,6 +331,8 @@ public:
     DxcThreadMalloc TM(m_pMalloc);
 
     try {
+      IFT(CreateMemoryStream(m_pMalloc, &pOutputStream));
+
       // Parse command-line options into DxcOpts
       int argCountInt;
       IFT(UIntToInt(argCount, &argCountInt));
@@ -377,7 +379,6 @@ public:
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
-      IFT(CreateMemoryStream(m_pMalloc, &pOutputStream));
       IFT(pOutputStream.QueryInterface(&pOutputBlob));
 
       if (opts.DisplayIncludeProcess)


### PR DESCRIPTION
Preprocessed source code could be quite useful for developers
to have a functionality-equivalent shader that they want to
debug.