### PR TITLE
Disable loop idiom pass which may break dxil

### DIFF
--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -392,7 +392,10 @@ void PassManagerBuilder::populateModulePassManager(
   //MPM.add(createLoopUnswitchPass(SizeLevel || OptLevel < 3)); // HLSL Change - may move barrier inside divergent if.
   MPM.add(createInstructionCombiningPass());
   MPM.add(createIndVarSimplifyPass());        // Canonicalize indvars
-  MPM.add(createLoopIdiomPass());             // Recognize idioms like memset.
+  // HLSL Change Begins
+  // Don't allow loop idiom pass which may insert memset/memcpy thereby breaking the dxil
+  //MPM.add(createLoopIdiomPass());             // Recognize idioms like memset.
+  // HLSL Change Ends
   MPM.add(createLoopDeletionPass());          // Delete dead loops
   if (EnableLoopInterchange) {
     MPM.add(createLoopInterchangePass()); // Interchange loops

--- a/tools/clang/test/CodeGenHLSL/quick-test/enable-partial-unroll-test01.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/enable-partial-unroll-test01.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// CHECK: define void @main()
+// CHECK: entry
+
+#define MAX_INDEX 5
+
+groupshared float g_Array[2][(MAX_INDEX * MAX_INDEX)];
+
+[RootSignature("")] float4 main(uint GroupIndex
+                                : A) : SV_Target {
+  uint idx;
+  float l_Array[(MAX_INDEX * MAX_INDEX)] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+  for (idx = 0; idx < (MAX_INDEX * MAX_INDEX); idx++) {
+    g_Array[GroupIndex][idx] = l_Array[idx];
+  }
+
+  return float4(g_Array[GroupIndex][0], g_Array[GroupIndex][1], g_Array[GroupIndex][2], g_Array[GroupIndex][3]);
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/enable-partial-unroll-test02.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/enable-partial-unroll-test02.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// CHECK: define void @main()
+// CHECK: entry
+
+#define MAX_INDEX 14
+
+groupshared float g_Array[2][(MAX_INDEX * MAX_INDEX)];
+
+[RootSignature("")] float4 main(uint GroupIndex
+                                : A) : SV_Target {
+  uint idx;
+  for (idx = 0; idx < (MAX_INDEX * MAX_INDEX); idx++) {
+    g_Array[GroupIndex][idx] = 0.0f;
+  }
+
+  return float4(g_Array[GroupIndex][0], g_Array[GroupIndex][1], g_Array[GroupIndex][2], g_Array[GroupIndex][3]);
+}


### PR DESCRIPTION
The loop-idiom pass identifies idioms such as memset/memcpy in a loop and replace those idioms with llvm intrinsic such as `llvm.memset` / `llvm.memcpy` which breaks the DXIL. This change disables the loop-idiom pass.