### PR TITLE
Always move allocas to entry block

### DIFF
--- a/tools/clang/test/CodeGenHLSL/quick-test/alloca-non-entry-basic-block.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/alloca-non-entry-basic-block.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// CHECK: define void @main()
+// CHECK: entry
+
+float2 foo() {
+  return float2(1.0f, -1.0f);
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  for (int c = 0; c < 2; ++c) {
+    if (foo()[c] >= 1.0f) {
+      return foo()[c];
+    }
+  }
+  return 1.0f;
+}


### PR DESCRIPTION
In `HLPreprocess` pass, we assume that allocas could be present in non-entry block only when during inlining `stacksave` / `stackstore` are inserted. However, there could be other cases where allocas could be present in non-entry blocks. This change always tries to move allocas in the non-entry blocks.