### PR TITLE
[linux-port] Enable OptimizerTest for Unix

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -69,7 +69,6 @@ set(HLSL_IGNORE_SOURCES
   FunctionTest.cpp
   LinkerTest.cpp
   MSFileSysTest.cpp
-  OptimizerTest.cpp
   OptionsTest.cpp
   RewriterTest.cpp
   ShaderOpTest.cpp
@@ -83,6 +82,7 @@ add_clang_unittest(clang-hlsl-tests
   DXIsenseTest.cpp
   HLSLTestOptions.cpp
   Objects.cpp
+  OptimizerTest.cpp
   TestMain.cpp
   VerifierTest.cpp
   )

--- a/tools/clang/unittests/HLSL/OptimizerTest.cpp
+++ b/tools/clang/unittests/HLSL/OptimizerTest.cpp
@@ -25,7 +25,6 @@
 #include "dxc/dxcapi.h"
 
 #include "HLSLTestData.h"
-#include "WexTestClass.h"
 #include "HlslTestUtils.h"
 #include "DxcTestUtils.h"
 
@@ -48,7 +47,11 @@ using namespace hlsl_test;
 ///////////////////////////////////////////////////////////////////////////////
 // Optimizer test cases.
 
+#ifdef _WIN32
 class OptimizerTest {
+#else
+class OptimizerTest : public ::testing::Test {
+#endif
 public:
   BEGIN_TEST_CLASS(OptimizerTest)
     TEST_CLASS_PROPERTY(L"Parallel", L"true")
@@ -155,8 +158,8 @@ void OptimizerTest::OptimizerWhenSliceNThenOK(int optLevel, LPCWSTR pText, LPCWS
   VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &pOptimizer));
 
   // Create the target program with a single invocation.
-  wchar_t OptArg[4];
-  wsprintf(OptArg, L"/O%i", optLevel);
+  wchar_t OptArg[4] = L"/O0";
+  OptArg[2] = L'0' + optLevel;
   Utf16ToBlob(m_dllSupport, pText, &pSource);
   LPCWSTR args[] = { L"/Vd", OptArg };
   VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",


### PR DESCRIPTION
Add gtest support. Eliminate wsprintf, since there is not a simple
alternative on Linux (to its discredit). It was overkill for just
appending a single numerical digit to two characters anyway.