### PR TITLE
[linux-port] HLSL test unsigned compare warnings

### DIFF
--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1357,7 +1357,7 @@ public:
     VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDisassembleBlob));
 
     std::string disassembleString(BlobToUtf8(pDisassembleBlob));
-    VERIFY_ARE_NOT_EQUAL(0, disassembleString.size());
+    VERIFY_ARE_NOT_EQUAL(0U, disassembleString.size());
   }
 
   void CodeGenTestCheckFullPath(LPCWSTR fullPath) {
@@ -1838,7 +1838,7 @@ TEST_F(CompilerTest, CompileWhenIncorrectThenFails) {
   CComPtr<IDxcBlobEncoding> pErrorBuffer;
   VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrorBuffer));
   std::string errorString(BlobToUtf8(pErrorBuffer));
-  VERIFY_ARE_NOT_EQUAL(0, errorString.size());
+  VERIFY_ARE_NOT_EQUAL(0U, errorString.size());
   // Useful for examining actual error message:
   // CA2W errorStringW(errorString.c_str(), CP_UTF8);
   // WEX::Logging::Log::Comment(errorStringW.m_psz);
@@ -1866,7 +1866,7 @@ TEST_F(CompilerTest, CompileWhenWorksThenDisassembleWorks) {
   VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDisassembleBlob));
 
   std::string disassembleString(BlobToUtf8(pDisassembleBlob));
-  VERIFY_ARE_NOT_EQUAL(0, disassembleString.size());
+  VERIFY_ARE_NOT_EQUAL(0U, disassembleString.size());
   // Useful for examining disassembly:
   // CA2W disassembleStringW(disassembleString.c_str(), CP_UTF8);
   // WEX::Logging::Log::Comment(disassembleStringW.m_psz);

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -153,10 +153,10 @@ TEST_F(DXIntellisenseTest, CursorWhenCBufferRefThenFound) {
   ExpectCursorAt(c.TU, 4, 1, DxcCursor_DeclRefExpr, &varRefCursor);
   VERIFY_SUCCEEDED(c.TU->GetFile(CompilationResult::getDefaultFileName(), &file));
   VERIFY_SUCCEEDED(varRefCursor->FindReferencesInFile(file, 0, 4, refs.size_ref(), refs.data_ref()));
-  VERIFY_ARE_EQUAL(2, refs.size());
+  VERIFY_ARE_EQUAL(2U, refs.size());
   VERIFY_SUCCEEDED(refs.begin()[0]->GetLocation(&loc));
   VERIFY_SUCCEEDED(loc->GetSpellingLocation(nullptr, &line, nullptr, nullptr));
-  VERIFY_ARE_EQUAL(2, line);
+  VERIFY_ARE_EQUAL(2U, line);
 }
 
 TEST_F(DXIntellisenseTest, InclusionWhenMissingThenError) {
@@ -174,7 +174,7 @@ TEST_F(DXIntellisenseTest, InclusionWhenMissingThenError) {
   VERIFY_SUCCEEDED(index->ParseTranslationUnit("file.hlsl", nullptr, 0, &unsaved.p, 1,
     DxcTranslationUnitFlags_UseCallerThread, &TU));
   VERIFY_SUCCEEDED(TU->GetNumDiagnostics(&diagCount));
-  VERIFY_ARE_EQUAL(1, diagCount);
+  VERIFY_ARE_EQUAL(1U, diagCount);
   VERIFY_SUCCEEDED(TU->GetDiagnostic(0, &pDiag));
   VERIFY_SUCCEEDED(pDiag->GetSeverity(&Severity));
   VERIFY_IS_TRUE(Severity == DxcDiagnosticSeverity::DxcDiagnostic_Error ||
@@ -199,9 +199,9 @@ TEST_F(DXIntellisenseTest, InclusionWhenValidThenAvailable) {
   VERIFY_SUCCEEDED(index->ParseTranslationUnit("file.hlsl", nullptr, 0, &unsaved[0].p, 2,
     DxcTranslationUnitFlags_UseCallerThread, &TU));
   VERIFY_SUCCEEDED(TU->GetNumDiagnostics(&diagCount));
-  VERIFY_ARE_EQUAL(0, diagCount);
+  VERIFY_ARE_EQUAL(0U, diagCount);
   VERIFY_SUCCEEDED(TU->GetInclusionList(inclusions.size_ref(), inclusions.data_ref()));
-  VERIFY_ARE_EQUAL(2, inclusions.size());
+  VERIFY_ARE_EQUAL(2U, inclusions.size());
   for (IDxcInclusion * i : inclusions) {
     CComPtr<IDxcFile> file;
     CComHeapPtr<char> fileName;
@@ -263,7 +263,7 @@ TEST_F(DXIntellisenseTest, TUWhenRegionInactiveMissingThenCountIsZero) {
   IDxcSourceRange** results;
   VERIFY_SUCCEEDED(result.TU->GetFile("filename.hlsl", &file));
   VERIFY_SUCCEEDED(result.TU->GetSkippedRanges(file.p, &resultCount, &results));
-  VERIFY_ARE_EQUAL(0, resultCount);
+  VERIFY_ARE_EQUAL(0U, resultCount);
   VERIFY_IS_NULL(results);
 }
 
@@ -285,15 +285,15 @@ TEST_F(DXIntellisenseTest, TUWhenRegionInactiveThenEndIsBeforeElseHash) {
   VERIFY_SUCCEEDED(result.TU->GetSkippedRanges(file.p, &resultCount, &results));
 
   ::WEX::TestExecution::DisableVerifyExceptions disable;
-  VERIFY_ARE_EQUAL(1, resultCount);
+  VERIFY_ARE_EQUAL(1U, resultCount);
   for (unsigned i = 0; i < resultCount; ++i)
   {
     CComPtr<IDxcSourceLocation> endLoc;
     VERIFY_SUCCEEDED(results[i]->GetEnd(&endLoc));
     unsigned line, col, offset;
     VERIFY_SUCCEEDED(endLoc->GetSpellingLocation(nullptr, &line, &col, &offset));
-    VERIFY_ARE_EQUAL(3, line);
-    VERIFY_ARE_EQUAL(1, col);
+    VERIFY_ARE_EQUAL(3U, line);
+    VERIFY_ARE_EQUAL(1U, col);
     results[i]->Release();
   }
   CoTaskMemFree(results);
@@ -315,15 +315,15 @@ TEST_F(DXIntellisenseTest, TUWhenRegionInactiveThenEndIsBeforeEndifHash) {
   VERIFY_SUCCEEDED(result.TU->GetSkippedRanges(file.p, &resultCount, &results));
 
   ::WEX::TestExecution::DisableVerifyExceptions disable;
-  VERIFY_ARE_EQUAL(1, resultCount);
+  VERIFY_ARE_EQUAL(1U, resultCount);
   for (unsigned i = 0; i < resultCount; ++i)
   {
     CComPtr<IDxcSourceLocation> endLoc;
     VERIFY_SUCCEEDED(results[i]->GetEnd(&endLoc));
     unsigned line, col, offset;
     VERIFY_SUCCEEDED(endLoc->GetSpellingLocation(nullptr, &line, &col, &offset));
-    VERIFY_ARE_EQUAL(3, line);
-    VERIFY_ARE_EQUAL(1, col);
+    VERIFY_ARE_EQUAL(3U, line);
+    VERIFY_ARE_EQUAL(1U, col);
     results[i]->Release();
   }
   CoTaskMemFree(results);
@@ -347,15 +347,15 @@ TEST_F(DXIntellisenseTest, TUWhenRegionInactiveThenStartIsAtIfdefEol) {
   VERIFY_SUCCEEDED(result.TU->GetSkippedRanges(file.p, &resultCount, &results));
 
   ::WEX::TestExecution::DisableVerifyExceptions disable;
-  VERIFY_ARE_EQUAL(1, resultCount);
+  VERIFY_ARE_EQUAL(1U, resultCount);
   for (unsigned i = 0; i < resultCount; ++i)
   {
     CComPtr<IDxcSourceLocation> startLoc;
     VERIFY_SUCCEEDED(results[i]->GetStart(&startLoc));
     unsigned line, col, offset;
     VERIFY_SUCCEEDED(startLoc->GetSpellingLocation(nullptr, &line, &col, &offset));
-    VERIFY_ARE_EQUAL(1, line);
-    VERIFY_ARE_EQUAL(24, col);
+    VERIFY_ARE_EQUAL(1U, line);
+    VERIFY_ARE_EQUAL(24U, col);
     results[i]->Release();
   }
   CoTaskMemFree(results);
@@ -416,7 +416,7 @@ TEST_F(DXIntellisenseTest, TUWhenUnsaveFileThenOK) {
     // No errors expected.
     unsigned numDiagnostics;
     VERIFY_SUCCEEDED(tu->GetNumDiagnostics(&numDiagnostics));
-    VERIFY_ARE_EQUAL(0, numDiagnostics);
+    VERIFY_ARE_EQUAL(0U, numDiagnostics);
 
     CComPtr<IDxcCursor> tuCursor;
     CComInterfaceArray<IDxcCursor> cursors;
@@ -668,9 +668,9 @@ TEST_F(DXIntellisenseTest, CursorWhenReferenceThenDefinitionAvailable)
   
   VERIFY_SUCCEEDED(defCursor->GetLocation(&defLocation));
   VERIFY_SUCCEEDED(defLocation->GetSpellingLocation(&defFile, &line, &col, &offset));
-  VERIFY_ARE_EQUAL(1, line);
-  VERIFY_ARE_EQUAL(5, col); // Points to 'myfunc'
-  VERIFY_ARE_EQUAL(4, offset); // Offset is zero-based
+  VERIFY_ARE_EQUAL(1U, line);
+  VERIFY_ARE_EQUAL(5U, col); // Points to 'myfunc'
+  VERIFY_ARE_EQUAL(4U, offset); // Offset is zero-based
 }
 
 TEST_F(DXIntellisenseTest,CursorWhenFindAtBodyCallThenMatch)

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -672,7 +672,7 @@ TEST_F(DxilContainerTest, CompileWhenOKThenIncludesFeatureInfo) {
                            hlsl::DxilPartIsType(hlsl::DFCC_FeatureInfo));
   VERIFY_ARE_NOT_EQUAL(hlsl::end(pHeader), pPartIter);
   VERIFY_ARE_EQUAL(sizeof(uint64_t), (*pPartIter)->PartSize);
-  VERIFY_ARE_EQUAL(0, *(uint64_t *)hlsl::GetDxilPartData(*pPartIter));
+  VERIFY_ARE_EQUAL(0U, *(const uint64_t *)hlsl::GetDxilPartData(*pPartIter));
 }
 
 TEST_F(DxilContainerTest, DisassemblyWhenBCInvalidThenFails) {
@@ -808,7 +808,7 @@ TEST_F(DxilContainerTest, DisassemblyWhenValidThenOK) {
   VERIFY_SUCCEEDED(pResult->GetResult(&pProgram));
   VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDisassembly));
   std::string disassembleString(BlobToUtf8(pDisassembly));
-  VERIFY_ARE_NOT_EQUAL(0, disassembleString.size());
+  VERIFY_ARE_NOT_EQUAL(0U, disassembleString.size());
 }
 
 class HlslFileVariables {

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -213,22 +213,22 @@ TEST_F(OptionsTest, ReadOptionsWhenDefinesThenInit) {
 
   std::unique_ptr<DxcOpts> o;
   o = ReadOptsTest(ArgsNoDefinesArr, DxrFlags);
-  EXPECT_EQ(0, o->Defines.size());
+  EXPECT_EQ(0U, o->Defines.size());
   
   o = ReadOptsTest(ArgsOneDefineArr, DxrFlags);
-  EXPECT_EQ(1, o->Defines.size());
+  EXPECT_EQ(1U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_STREQW(L"1", o->Defines.data()[0].Value);
 
   o = ReadOptsTest(ArgsTwoDefinesArr, DxrFlags);
-  EXPECT_EQ(2, o->Defines.size());
+  EXPECT_EQ(2U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_STREQW(L"1", o->Defines.data()[0].Value);
   EXPECT_STREQW(L"NAME2", o->Defines.data()[1].Name);
   EXPECT_STREQW(L"2", o->Defines.data()[1].Value);
 
   o = ReadOptsTest(ArgsEmptyDefineArr, DxrFlags);
-  EXPECT_EQ(1, o->Defines.size());
+  EXPECT_EQ(1U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_EQ(nullptr, o->Defines.data()[0].Value);
 }
@@ -292,7 +292,7 @@ TEST_F(OptionsTest, CopyOptionsWhenSingleThenOK) {
       table->ParseArgs(ArgsNoDefines, missingIndex, missingArgCount, DxcFlags);
   std::vector<std::wstring> outArgs;
   CopyArgsToWStrings(args, DxcFlags, outArgs);
-  EXPECT_EQ(4, outArgs.size()); // -unknown and hlsl.hlsl are missing
+  EXPECT_EQ(4U, outArgs.size()); // -unknown and hlsl.hlsl are missing
   VERIFY_ARE_NOT_EQUAL(outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"/T")));
   VERIFY_ARE_NOT_EQUAL(outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"ps_6_0")));
   VERIFY_ARE_NOT_EQUAL(outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"/E")));


### PR DESCRIPTION
There are a lot of compares between unsigned variables and literal
integers in HLSL tests that produce a long list of warnings on
Unix platforms.

This appends a -U suffix to the literals to silence the warnings