### PR TITLE
Fix random ordering of disassembly

### DIFF
--- a/lib/HLSL/DxilContainerAssembler.cpp
+++ b/lib/HLSL/DxilContainerAssembler.cpp
@@ -135,8 +135,10 @@ struct sort_second {
 struct sort_sig {
   bool operator()(const DxilProgramSignatureElement &a,
                   const DxilProgramSignatureElement &b) {
-    return (a.Stream < b.Stream) |
-           ((a.Stream == b.Stream) & (a.Register < b.Register));
+    return (a.Stream < b.Stream) ||
+           ((a.Stream == b.Stream) && (a.Register < b.Register)) ||
+           ((a.Stream == b.Stream) && (a.Register == b.Register) &&
+            (a.SemanticName < b.SemanticName));
   }
 };
 

--- a/lib/HLSL/DxilPreserveAllOutputs.cpp
+++ b/lib/HLSL/DxilPreserveAllOutputs.cpp
@@ -197,7 +197,7 @@ public:
 
 private:
   typedef std::vector<OutputWrite> OutputVec;
-  typedef std::unordered_map<unsigned, OutputElement>  OutputMap;
+  typedef std::map<unsigned, OutputElement>  OutputMap;
   OutputVec collectOutputStores(Function &F);
   OutputMap generateOutputMap(const OutputVec &calls, DxilModule &DM);
   void createTempAllocas(OutputMap &map, IRBuilder<> &builder);


### PR DESCRIPTION
Due to iterating through an unordered_map, and sorting a vector
using a comparison that didn't handle ties completely, some
disassembly outputs were in implementation-dependent order in spite
of tests depending on a certain order.