### PR TITLE
[linux-port] Misc HLSL test warnings

### DIFF
--- a/tools/clang/unittests/HLSL/CompilationResult.h
+++ b/tools/clang/unittests/HLSL/CompilationResult.h
@@ -149,8 +149,8 @@ public:
     IsenseSupport(support),
     Intellisense(isense),
     Index(index),
-    TU(tu),
-    NumErrorDiagnostics(0)
+    NumErrorDiagnostics(0),
+    TU(tu)
   {
     if (tu) {
       IFE(tu->GetNumDiagnostics(&NumDiagnostics));
@@ -224,7 +224,6 @@ public:
     CComPtr<IDxcIndex> tuIndex;
     CComPtr<IDxcTranslationUnit> tu;
     const char *fileName = getDefaultFileName();
-    const int DisplayDiagnosticsToStdErrFalse = 0;
     if (textLen == 0) textLen = strlen(text);
 
     IFE(isense->CreateIndex(&tuIndex));
@@ -267,7 +266,6 @@ public:
     IFE(support->CreateIntellisense(&isense));
     CComPtr<IDxcIndex> tuIndex;
     CComPtr<IDxcTranslationUnit> tu;
-    const int DisplayDiagnosticsToStdErrFalse = 0;
     const char* commandLineArgs[32];
     unsigned commandLineArgsCount = 0;
     char* nextArg = arguments;

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1417,11 +1417,11 @@ public:
     }
   }
 
-  std::string VerifyCompileFailed(LPCSTR pText, LPWSTR pTargetProfile, LPCSTR pErrorMsg) {
+  std::string VerifyCompileFailed(LPCSTR pText, LPCWSTR pTargetProfile, LPCSTR pErrorMsg) {
     return VerifyCompileFailed(pText, pTargetProfile, pErrorMsg, L"main");
   }
 
-  std::string VerifyCompileFailed(LPCSTR pText, LPWSTR pTargetProfile, LPCSTR pErrorMsg, LPCWSTR pEntryPoint) {
+  std::string VerifyCompileFailed(LPCSTR pText, LPCWSTR pTargetProfile, LPCSTR pErrorMsg, LPCWSTR pEntryPoint) {
     CComPtr<IDxcCompiler> pCompiler;
     CComPtr<IDxcOperationResult> pResult;
     CComPtr<IDxcBlobEncoding> pSource;

--- a/tools/clang/unittests/HLSL/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSL/FileCheckerTest.cpp
@@ -65,8 +65,8 @@ static string trim(string value) {
       Command(command), Arguments(arguments), CommandFileName(commandFileName) { }
     FileRunCommandPart::FileRunCommandPart(FileRunCommandPart && other) :
       Command(std::move(other.Command)),
-      CommandFileName(other.CommandFileName),
       Arguments(std::move(other.Arguments)),
+      CommandFileName(other.CommandFileName),
       RunResult(other.RunResult),
       StdOut(std::move(other.StdOut)),
       StdErr(std::move(other.StdErr)) { }

--- a/tools/clang/unittests/HLSL/FunctionTest.cpp
+++ b/tools/clang/unittests/HLSL/FunctionTest.cpp
@@ -13,7 +13,6 @@
 #include <memory>
 #include <vector>
 #include <string>
-#include <strstream>
 #include "CompilationResult.h"
 #include "HLSLTestData.h"
 
@@ -139,7 +138,7 @@ TEST_F(FunctionTest, AllowedStorageClass) {
 TEST_F(FunctionTest, AllowedInParamUsesClass) {
   const char* fragments[] =  { "f", "1.0f" };
   for (const auto &iop : InOutParameterModifierData) {
-    for (int i = 0; i < _countof(fragments); i++) {
+    for (unsigned i = 0; i < _countof(fragments); i++) {
       char program[256];
       sprintf_s(program, _countof(program),
               "float ps(%s float o) { return o; }\n"

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -275,9 +275,6 @@ inline uint16_t ConvertFloat32ToFloat16(float val) {
 
   static const uint32_t SignMask = 0x8000;
 
-  // Maximum f32 value representable in f16 format
-  static const uint32_t Max16in32 = 0x477fe000;
-
   // Minimum f32 value representable in f16 format without denormalizing
   static const uint32_t Min16in32 = 0x38800000;
 
@@ -298,12 +295,12 @@ inline uint16_t ConvertFloat32ToFloat16(float val) {
   Bits Abs;
   Abs.u_bits = bits.u_bits ^ sign;
 
-  bool isLessThanNormal = Abs.f_bits < *(float*)&Min16in32;
+  bool isLessThanNormal = Abs.f_bits < *(const float*)&Min16in32;
   bool isInfOrNaN = Abs.u_bits > Max32;
 
   if (isLessThanNormal) {
     // Compute Denormal result
-    return (uint16_t)(Abs.f_bits * *(float*)(&DenormalRatio)) | (sign >> 16);
+    return (uint16_t)(Abs.f_bits * *(const float*)(&DenormalRatio)) | (sign >> 16);
   }
   else if (isInfOrNaN) {
     // Compute Inf or Nan result
@@ -372,7 +369,7 @@ inline bool CompareFloatULP(const float &fsrc, const float &fref,
   }
   // For FTZ or Preserve mode, we should get the expected number within
   // ULPTolerance for any operations.
-  int diff = *((DWORD *)&fsrc) - *((DWORD *)&fref);
+  int diff = *((const DWORD *)&fsrc) - *((const DWORD *)&fref);
   unsigned int uDiff = diff < 0 ? -diff : diff;
   return uDiff <= (unsigned int)ULPTolerance;
 }


### PR DESCRIPTION
Compiling HLSL tests on Unix produces a long list of warnings that
obfuscate the results of the build and ambiguates the intent.

This includes reordering the constructor initialization lists to
match the actual initialization order, removing unused variables,
changing pointer parameters to const to avoid casts that remove
the const qualifier when the value pointed to is not altered anyway,
removes deprecated and unused header, changes type to match
comparison, casts a few pointers to const when passed in, removes
unused functions.