### PR TITLE
[linux-port] Enable FunctionTest on Unix

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -64,7 +64,6 @@ set(HLSL_IGNORE_SOURCES
   DxilModuleTest.cpp
   ExecutionTest.cpp
   ExtensionTest.cpp
-  FunctionTest.cpp
   LinkerTest.cpp
   MSFileSysTest.cpp
   OptionsTest.cpp
@@ -79,6 +78,7 @@ add_clang_unittest(clang-hlsl-tests
   DXIsenseTest.cpp
   FileCheckerTest.cpp
   FileCheckForTest.cpp
+  FunctionTest.cpp
   HLSLTestOptions.cpp
   Objects.cpp
   OptimizerTest.cpp

--- a/tools/clang/unittests/HLSL/FunctionTest.cpp
+++ b/tools/clang/unittests/HLSL/FunctionTest.cpp
@@ -18,14 +18,16 @@
 #include "HLSLTestData.h"
 
 #undef _read
-#include "WexTestClass.h"
 #include "HlslTestUtils.h"
 #include "DxcTestUtils.h"
 #include "dxc/Support/Global.h"
 #include "dxc/HLSL/DxilContainer.h"
 
-class FunctionTest
-{
+#ifdef _WIN32
+class FunctionTest {
+#else
+class FunctionTest : public ::testing::Test {
+#endif
 public:
   BEGIN_TEST_CLASS(FunctionTest)
     TEST_CLASS_PROPERTY(L"Parallel", L"true")
@@ -98,6 +100,7 @@ public:
       CComPtr<IDxcBlob> pContainer;
 
       VERIFY_SUCCEEDED(pResult->GetResult(&pContainer));
+#ifdef _WIN32 // No reflection support
       VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcContainerReflection, &pReflection));
       VERIFY_SUCCEEDED(pReflection->Load(pContainer));
       UINT count;
@@ -112,6 +115,7 @@ public:
         }
       }
       VERIFY_IS_TRUE(found);
+#endif // _WIN32 - No reflection support
     }
   }
 
@@ -154,6 +158,7 @@ TEST_F(FunctionTest, AllowedInParamUsesClass) {
 }
 
 TEST_F(FunctionTest, ParseRootSignature) {
+#ifdef _WIN32 // - dxil.dll can only be found on Windows
   struct AutoModule {
     HMODULE m_module;
     AutoModule(const wchar_t *pName) {
@@ -165,6 +170,7 @@ TEST_F(FunctionTest, ParseRootSignature) {
     }
   };
   AutoModule dxilAM(L"dxil.dll"); // Pin this if available to avoid reloading on each compile.
+#endif // _WIN32 - dxil.dll can only be found on Windows
 
   VERIFY_SUCCEEDED(m_support.Initialize());
 


### PR DESCRIPTION
Exclude reflection and dxil.dll portions that are unsupported or
unneeded.