### PR TITLE
[linux-port] DxilContainer/ModuleTest on Unix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,8 @@ branches:
 
 addons:
   apt:
-    packages: ninja-build 'libstdc++-5-dev'
+    sources: ubuntu-toolchain-r-test
+    packages: ninja-build libstdc++-5-dev
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ branches:
 
 addons:
   apt:
-    packages: ninja-build libstdc++6
+    packages: ninja-build 'libstdc++-5-dev'
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ branches:
 
 addons:
   apt:
-    packages: ninja-build libstdc++5-dev
+    packages: ninja-build libstdc++6
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,7 @@ branches:
 
 addons:
   apt:
-    packages:
-      - ninja-build libstdc++-5-dev
+    packages: ninja-build libstdc++-5
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ branches:
 
 addons:
   apt:
-    packages: ninja-build libstdc++-5
+    packages: ninja-build libstdc++5
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ branches:
 
 addons:
   apt:
-    packages: ninja-build libstdc++5
+    packages: ninja-build libstdc++5-dev
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ branches:
 addons:
   apt:
     packages:
-      - ninja-build
+      - ninja-build libstdc++-5-dev
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja; fi

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -60,8 +60,6 @@ set( LLVM_LINK_COMPONENTS
 
 set(HLSL_IGNORE_SOURCES
   CompilerTest.cpp
-  DxilContainerTest.cpp
-  DxilModuleTest.cpp
   ExecutionTest.cpp
   ExtensionTest.cpp
   FunctionTest.cpp
@@ -76,6 +74,8 @@ set(HLSL_IGNORE_SOURCES
 add_clang_unittest(clang-hlsl-tests
   AllocatorTest.cpp
   DxcTestUtils.cpp
+  DxilContainerTest.cpp
+  DxilModuleTest.cpp
   DXIsenseTest.cpp
   FileCheckerTest.cpp
   FileCheckForTest.cpp

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -13,6 +13,11 @@
 #define UNICODE
 #endif
 
+#ifdef __APPLE__
+// Workaround for ambiguous wcsstr on Mac
+#define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
+#endif
+
 #include <memory>
 #include <vector>
 #include <string>

--- a/tools/clang/unittests/HLSL/DxilModuleTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilModuleTest.cpp
@@ -8,7 +8,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "CompilationResult.h"
-#include "WexTestClass.h"
 #include "HlslTestUtils.h"
 #include "DxcTestUtils.h"
 #include "dxc/Support/microcom.h"
@@ -24,7 +23,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/ErrorOr.h"
-#include "llvm/BitCode/ReaderWriter.h"
+#include "llvm/Bitcode/ReaderWriter.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/InstIterator.h"
 
@@ -34,7 +33,11 @@ using namespace llvm;
 ///////////////////////////////////////////////////////////////////////////////
 // DxilModule unit tests.
 
+#ifdef _WIN32
 class DxilModuleTest {
+#else
+class DxilModuleTest : public ::testing::Test {
+#endif
 public:
   BEGIN_TEST_CLASS(DxilModuleTest)
     TEST_CLASS_PROPERTY(L"Parallel", L"true")


### PR DESCRIPTION
Mostly just excluding portions that require reflection allows this
test to run with the usual corralling of header files behine a WIN32
ifdef and adding the gtest inheritence for non-win.
Change an include file capitalization so it can be found on case
sensitive filesystems.