### PR TITLE
Change CreateBlobWithEncodingFromPinned argument to LPCVOID; silence lost const warnings

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -125,7 +125,7 @@ IDxcLibrary : public IUnknown {
     LPCWSTR pFileName, _In_opt_ UINT32* codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
   virtual HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingFromPinned(
-    LPBYTE pText, UINT32 size, UINT32 codePage,
+    _In_bytecount_(size) LPCVOID pText, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
   virtual HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingOnHeapCopy(
        _In_bytecount_(size) LPCVOID pText, UINT32 size, UINT32 codePage,

--- a/tools/clang/tools/dxcompiler/dxclibrary.cpp
+++ b/tools/clang/tools/dxcompiler/dxclibrary.cpp
@@ -77,7 +77,7 @@ public:
   }
 
   HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingFromPinned(
-    LPBYTE pText, UINT32 size, UINT32 codePage,
+    _In_bytecount_(size) LPCVOID pText, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override {
     DxcThreadMalloc TM(m_pMalloc);
     return ::hlsl::DxcCreateBlobWithEncodingFromPinned(pText, size, codePage, pBlobEncoding);

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -985,7 +985,7 @@ public:
                         UINT32 codePage, _Outptr_ IDxcBlobEncoding **ppBlob) {
     CComPtr<IDxcLibrary> library;
     IFT(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &library));
-    IFT(library->CreateBlobWithEncodingFromPinned((LPBYTE)data, size, codePage,
+    IFT(library->CreateBlobWithEncodingFromPinned(data, size, codePage,
                                                   ppBlob));
   }
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -402,7 +402,7 @@ public:
     HRESULT resultCode;
     VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcCompiler, &pCompiler));
     VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned((LPBYTE)pText, strlen(pText), CP_UTF8, &pTextBlob));
+    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(pText, strlen(pText), CP_UTF8, &pTextBlob));
     VERIFY_SUCCEEDED(pCompiler->Compile(pTextBlob, L"hlsl.hlsl", pEntryPoint, pTargetProfile, nullptr, 0, nullptr, 0, nullptr, &pResult));
     VERIFY_SUCCEEDED(pResult->GetStatus(&resultCode));
     if (FAILED(resultCode)) {

--- a/tools/clang/unittests/HLSL/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSL/FileCheckerTest.cpp
@@ -340,7 +340,7 @@ static string trim(string value) {
         CComPtr<IDxcAssembler> pAssembler;
         IFT(DllSupport->CreateInstance(CLSID_DxcAssembler, &pAssembler));
         IFT(pLibrary->CreateBlobWithEncodingFromPinned(
-            (LPBYTE)Prior->StdOut.c_str(), Prior->StdOut.size(), CP_UTF8,
+            Prior->StdOut.c_str(), Prior->StdOut.size(), CP_UTF8,
             &pSource));
       }
 

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -109,7 +109,7 @@ public:
                         UINT32 codePage, _In_ IDxcBlobEncoding **ppBlob) {
     CComPtr<IDxcLibrary> library;
     IFT(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &library));
-    IFT(library->CreateBlobWithEncodingFromPinned((LPBYTE)data, size, codePage,
+    IFT(library->CreateBlobWithEncodingFromPinned(data, size, codePage,
                                                   ppBlob));
   }
 
@@ -172,7 +172,7 @@ public:
       IFT(mapping.MapFile(file));
       CComPtr<IDxcLibrary> library;
       IFT(support.CreateInstance(CLSID_DxcLibrary, &library));
-      IFT(library->CreateBlobWithEncodingFromPinned((LPBYTE)mapping.GetData(),
+      IFT(library->CreateBlobWithEncodingFromPinned(mapping.GetData(),
                                                     mapping.GetMappingSize(),
                                                     CP_UTF8, &BlobEncoding));
     }

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -696,7 +696,7 @@ void ShaderOpTest::CreateShaders() {
       HRESULT resultCode;
       CHECK_HR(m_pDxcSupport->CreateInstance(CLSID_DxcLibrary, &pLibrary));
       CHECK_HR(pLibrary->CreateBlobWithEncodingFromPinned(
-          (LPBYTE)pText, (UINT32)strlen(pText), CP_UTF8, &pTextBlob));
+          pText, (UINT32)strlen(pText), CP_UTF8, &pTextBlob));
       CHECK_HR(m_pDxcSupport->CreateInstance(CLSID_DxcCompiler, &pCompiler));
       CHECK_HR(pCompiler->Compile(pTextBlob, nameW, entryPointW, targetW,
                                   (LPCWSTR *)argumentsWList.data(), argumentsWList.size(),

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -279,7 +279,7 @@ public:
     CComPtr<IDxcLibrary> pLibrary;
     CComPtr<IDxcBlobEncoding> pBlobEncoding; // Encoding doesn't actually matter, it's binary.
     VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned((LPBYTE)pBlob, blobSize, CP_UTF8, &pBlobEncoding));
+    VERIFY_SUCCEEDED(pLibrary->CreateBlobWithEncodingFromPinned(pBlob, blobSize, CP_UTF8, &pBlobEncoding));
     CheckValidationMsgs(pBlobEncoding, pErrorMsgs, bRegex);
   }
 


### PR DESCRIPTION
CreateBlobWithEncodingFromPinned is unlike any of the other
CreateBlob* functions in that its pText argument is a non-const
byte pointer. All the others use const void pointer for this
same parameter. Because the parameter is not const, in many cases
const pointers need to have their const qualifier cast off to be
used for this parameter in spite of the fact that the next level
call passes it to a const pointer. This produces a bunch of
warnings in places where its used.

By changing the variable to const void, there is less unnecessary
casting, fewer warnings, no change in behavior, and a clearer
external indication of the way it is used by the function from the
prototype.