### PR TITLE
[linux-port] Enable extensiontest for Unix

### DIFF
--- a/include/dxc/dxcapi.internal.h
+++ b/include/dxc/dxcapi.internal.h
@@ -171,6 +171,8 @@ public:
   virtual HRESULT STDMETHODCALLTYPE SetSemanticDefineValidator(_In_ IDxcSemanticDefineValidator* pValidator) = 0;
   /// <summary>Sets the name for the root metadata node used in DXIL to hold the semantic defines.</summary>
   virtual HRESULT STDMETHODCALLTYPE SetSemanticDefineMetaDataName(LPCSTR name) = 0;
+
+  DECLARE_CROSS_PLATFORM_UUIDOF(IDxcLangExtensions)
 };
 
 struct __declspec(uuid("454b764f-3549-475b-958c-a7a6fcd05fbc"))

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -64,6 +64,8 @@ using namespace clang;
 using namespace hlsl;
 using std::string;
 
+DEFINE_CROSS_PLATFORM_UUIDOF(IDxcLangExtensions)
+
 // This declaration is used for the locally-linked validator.
 HRESULT CreateDxcValidator(_In_ REFIID riid, _Out_ LPVOID *ppv);
 

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -63,7 +63,6 @@ set(HLSL_IGNORE_SOURCES
   DxilContainerTest.cpp
   DxilModuleTest.cpp
   ExecutionTest.cpp
-  ExtensionTest.cpp
   LinkerTest.cpp
   MSFileSysTest.cpp
   OptionsTest.cpp
@@ -75,6 +74,7 @@ add_clang_unittest(clang-hlsl-tests
   AllocatorTest.cpp
   DxcTestUtils.cpp
   DXIsenseTest.cpp
+  ExtensionTest.cpp
   FileCheckerTest.cpp
   FileCheckForTest.cpp
   FunctionTest.cpp

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -8,7 +8,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "CompilationResult.h"
-#include "WexTestClass.h"
 #include "HlslTestUtils.h"
 #include "DxcTestUtils.h"
 #include "dxc/Support/microcom.h"
@@ -149,7 +148,7 @@ Intrinsic BufferIntrinsics[] = {
 
 class IntrinsicTable {
 public:
-  IntrinsicTable(wchar_t *ns, Intrinsic *begin, Intrinsic *end)
+  IntrinsicTable(const wchar_t *ns, Intrinsic *begin, Intrinsic *end)
     :  m_namespace(ns), m_begin(begin), m_end(end)
   { }
 
@@ -209,7 +208,7 @@ private:
 
 class TestIntrinsicTable : public IDxcIntrinsicTable {
 private:
-  DXC_MICROCOM_REF_FIELD(m_dwRef);
+  DXC_MICROCOM_REF_FIELD(m_dwRef)
   std::vector<IntrinsicTable> m_tables;
 public:
   TestIntrinsicTable() : m_dwRef(0) { 
@@ -307,7 +306,7 @@ public:
 // the correct type (integer, string, etc).
 class TestSemanticDefineValidator : public IDxcSemanticDefineValidator {
 private:
-  DXC_MICROCOM_REF_FIELD(m_dwRef);
+  DXC_MICROCOM_REF_FIELD(m_dwRef)
   std::vector<std::string> m_errorDefines;
   std::vector<std::string> m_warningDefines;
 public:
@@ -322,7 +321,7 @@ public:
     return DoBasicQueryInterface<IDxcSemanticDefineValidator>(this, iid, ppvObject);
   }
 
-  virtual HRESULT STDMETHODCALLTYPE GetSemanticDefineWarningsAndErrors(LPCSTR pName, LPCSTR pValue, IDxcBlobEncoding **ppWarningBlob, IDxcBlobEncoding **ppErrorBlob) {
+  virtual HRESULT STDMETHODCALLTYPE GetSemanticDefineWarningsAndErrors(LPCSTR pName, LPCSTR pValue, IDxcBlobEncoding **ppWarningBlob, IDxcBlobEncoding **ppErrorBlob) override {
     if (!pName || !pValue || !ppWarningBlob || !ppErrorBlob)
       return E_FAIL;
 
@@ -413,7 +412,11 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 // Extension unit tests.
 
+#ifdef _WIN32
 class ExtensionTest {
+#else
+class ExtensionTest : public ::testing::Test {
+#endif
 public:
   BEGIN_TEST_CLASS(ExtensionTest)
     TEST_CLASS_PROPERTY(L"Parallel", L"true")


### PR DESCRIPTION
Enable the UUID for IDxcLangExtensions so its interface can be
properly queried. Sundry const, semicolon, and override warning
eliminating changes that might have been included in the larger
corresponding changes had this test not been an afterthought.