### PR TITLE
[linux-port] Better match Windows char conversion

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -839,15 +839,19 @@ public:
 #define CP_ACP 0
 #define CP_UTF8 65001 // UTF-8 translation.
 
+// Convert Windows codepage value to locale string
+const char *CPToLocale(uint32_t CodePage);
+
 // The t_nBufferLength parameter is part of the published interface, but not
 // used here.
 template <int t_nBufferLength = 128> class CW2AEX {
 public:
   CW2AEX(LPCWSTR psz, UINT nCodePage = CP_UTF8) {
-    if (nCodePage != CP_UTF8) {
-      // Current Implementation only supports CP_UTF8
-      assert(false && "CW2AEX implementation for Linux does not handle "
-                      "non-UTF8 code pages");
+    const char *locale = CPToLocale(nCodePage);
+    if (locale == nullptr) {
+      // Current Implementation only supports CP_UTF8, and CP_ACP
+      assert(false && "CW2AEX implementation for Linux only handles "
+                      "UTF8 and ACP code pages");
       return;
     }
 
@@ -856,9 +860,11 @@ public:
       return;
     }
 
+    locale = setlocale(LC_ALL, locale);
     int len = (wcslen(psz) + 1) * 4;
     m_psz = new char[len];
     std::wcstombs(m_psz, psz, len);
+    setlocale(LC_ALL, locale);
   }
 
   ~CW2AEX() { delete[] m_psz; }
@@ -874,10 +880,11 @@ typedef CW2AEX<> CW2A;
 template <int t_nBufferLength = 128> class CA2WEX {
 public:
   CA2WEX(LPCSTR psz, UINT nCodePage = CP_UTF8) {
-    if (nCodePage != CP_UTF8) {
-      // Current Implementation only supports CP_UTF8
-      assert(false && "CA2WEX implementation for Linux does not handle "
-                      "non-UTF8 code pages");
+    const char *locale = CPToLocale(nCodePage);
+    if (locale == nullptr) {
+      // Current Implementation only supports CP_UTF8, and CP_ACP
+      assert(false && "CA2WEX implementation for Linux only handles "
+                      "UTF8 and ACP code pages");
       return;
     }
 
@@ -886,9 +893,11 @@ public:
       return;
     }
 
+    locale = setlocale(LC_ALL, locale);
     int len = strlen(psz) + 1;
     m_psz = new wchar_t[len];
     std::mbstowcs(m_psz, psz, len);
+    setlocale(LC_ALL, locale);
   }
 
   ~CA2WEX() { delete[] m_psz; }

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -50,6 +50,20 @@ void *CAllocator::Reallocate(void *p, size_t nBytes) throw() {
 void *CAllocator::Allocate(size_t nBytes) throw() { return malloc(nBytes); }
 void CAllocator::Free(void *p) throw() { free(p); }
 
+//===---------------------- Char converstion ------------------------------===//
+
+const char *CPToLocale(uint32_t CodePage) {
+  static const char *utf8 = "en_US.utf8";
+  static const char *iso88591 = "en_US.iso88591";
+  if (CodePage == CP_UTF8) {
+    return utf8;
+  } else if (CodePage == CP_ACP) {
+    // Experimentation suggests that ACP is expected to be ISO-8859-1
+    return iso88591;
+  }
+  return nullptr;
+}
+
 //===--------------------------- CHandle -------------------------------===//
 
 CHandle::CHandle(HANDLE h) { m_h = h; }

--- a/tools/clang/test/CodeGenHLSL/quick-test/assignCast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/assignCast.hlsl
@@ -8,7 +8,7 @@
 // CHECK: uitofp i32 {{.*}} to float
 
 float main(float4 a : A, float b : B) : SV_Target {
-  uint c = b;
+  uint c = b;
   c += a;
   return c;
 }


### PR DESCRIPTION
Windows char conversion functions differ from the std methods in
a few ways. Windows ignores null terminators when lengths are
provided, length limits represent character lengths not byte sizes,
the current linux implementation ignores codepages, but the files
used in many HLSL tests are in iso 8859-1 not utf8. So some
differentiation is needed.

This solves all but one of the above problems. To limit conversion
by source characters instead of solely the size of the output
buffer, where necessary, a temporary buffer is created to hold the
source string that corresponds to the provided character length and
a null terminator is appended to make the std:: conversion stop there.
If there is a null terminator there already, this is skipped for
performance purposes. Such is often the case.

To respect the codepage parameter, it is converted to the corresponding
locale string and setlocale is used to temporarily set the locale
accordingly and set it back afterwards.

The aspect that is missed is that the Windows conversion functions
will happily blow past a null terminating character if the length
specified encompasses it. This is rare enough in general, and unlikely
in the way these functions are used in the source base.

corrects one errant non-breaking space character that found its way
into an HLSL file that the std:: conversion choked on. It didn't seem
to serve any purpose anyway.