### PR TITLE
Pretend 11on12's DXBC->DXIL converter had supplied semantic index 0 for system values

### DIFF
--- a/lib/HLSL/DxilContainerAssembler.cpp
+++ b/lib/HLSL/DxilContainerAssembler.cpp
@@ -373,8 +373,12 @@ private:
       E.SemanticName = 0;
     }
     // Search index buffer for matching semantic index sequence
-    DXASSERT_NOMSG(SE.GetRows() == SE.GetSemanticIndexVec().size());
-    auto &SemIdx = SE.GetSemanticIndexVec();
+    auto SemIdx = SE.GetSemanticIndexVec();
+    if (SemIdx.empty()) {
+      // the 11on12 DXBC->DXIL converter can produce no semantic indices for
+      // system values. Fake up a vector of (probably one) zeroes:
+      SemIdx.assign(static_cast<size_t>(SE.GetRows()), 0);
+    }
     bool match = false;
     for (uint32_t offset = 0; offset + SE.GetRows() - 1 < m_SemanticIndexBuffer.size(); offset++) {
       match = true;


### PR DESCRIPTION
Under PIX, when assembling a container for a modified shader, DxilPSVWriter:: SetPSVSigElement hits an assert that the provided semantic index vector is not of the expected size. In fact, the vector is empty. The 11on12 DXBC->DXIL converter appears to supply this empty vector for system values, such as, as in this case, SV_Depth. Providing a 0 as the semantic index, which is of course a reasonable value, is enough to make this code happy and PIX can proceed to assemble its modified shader.