### PR TITLE
Use std::atomic.

### DIFF
--- a/include/dxc/Support/microcom.h
+++ b/include/dxc/Support/microcom.h
@@ -77,7 +77,7 @@ public:
 };
 
 #define DXC_MICROCOM_REF_FIELD(m_dwRef)                                        \
-  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = 0;
+  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = {0};
 #define DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                      \
   ULONG STDMETHODCALLTYPE AddRef() override {                                  \
     return (ULONG)++m_dwRef;                                                   \
@@ -107,7 +107,7 @@ void DxcCallDestructor(T *obj) {
 // The "TM" version keep an IMalloc field that, if not null, indicate
 // ownership of 'this' and of any allocations used during release.
 #define DXC_MICROCOM_TM_REF_FIELDS()                                           \
-  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = 0;                       \
+  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = {0};                     \
   CComPtr<IMalloc> m_pMalloc;
 
 #define DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()                                  \

--- a/include/dxc/Support/microcom.h
+++ b/include/dxc/Support/microcom.h
@@ -12,6 +12,7 @@
 #ifndef __DXC_MICROCOM__
 #define __DXC_MICROCOM__
 
+#include <atomic>
 #include "llvm/Support/Atomic.h"
 
 template <typename TIface>
@@ -76,15 +77,15 @@ public:
 };
 
 #define DXC_MICROCOM_REF_FIELD(m_dwRef)                                        \
-  volatile llvm::sys::cas_flag m_dwRef = 0;
+  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = 0;
 #define DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                      \
   ULONG STDMETHODCALLTYPE AddRef() override {                                  \
-    return (ULONG)llvm::sys::AtomicIncrement(&m_dwRef);                        \
+    return (ULONG)++m_dwRef;                                                   \
   }
 #define DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)                              \
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                            \
   ULONG STDMETHODCALLTYPE Release() override {                                 \
-    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);                \
+    ULONG result = (ULONG)--m_dwRef;                                           \
     if (result == 0)                                                           \
       delete this;                                                             \
     return result;                                                             \
@@ -106,13 +107,13 @@ void DxcCallDestructor(T *obj) {
 // The "TM" version keep an IMalloc field that, if not null, indicate
 // ownership of 'this' and of any allocations used during release.
 #define DXC_MICROCOM_TM_REF_FIELDS()                                           \
-  volatile llvm::sys::cas_flag m_dwRef = 0;                                    \
+  volatile std::atomic<llvm::sys::cas_flag> m_dwRef = 0;                       \
   CComPtr<IMalloc> m_pMalloc;
 
 #define DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()                                  \
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                            \
   ULONG STDMETHODCALLTYPE Release() override {                                 \
-    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);                \
+    ULONG result = (ULONG)--m_dwRef;                                           \
     if (result == 0) {                                                         \
       CComPtr<IMalloc> pTmp(m_pMalloc);                                        \
       DxcThreadMalloc M(pTmp);                                                 \

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -184,7 +184,7 @@ public:
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)
   ULONG STDMETHODCALLTYPE Release() override {
     // Because blobs are also used by tests and utilities, we avoid using TLS.
-    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
+    ULONG result = (ULONG)--m_dwRef;
     if (result == 0) {
       CComPtr<IMalloc> pTmp(m_pMalloc);
       this->~InternalDxcBlobEncoding();
@@ -776,7 +776,7 @@ public:
   ULONG STDMETHODCALLTYPE Release() override {
     // Because memory streams are also used by tests and utilities,
     // we avoid using TLS.
-    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef);
+    ULONG result = (ULONG)--m_dwRef;
     if (result == 0) {
       CComPtr<IMalloc> pTmp(m_pMalloc);
       this->~MemoryStream();

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <sstream>
 #include <fstream>
+#include <atomic>
 #ifdef _WIN32
 #include <dxgiformat.h>
 #include "WexTestClass.h"
@@ -508,11 +509,11 @@ inline UINT GetByteSizeForFormat(DXGI_FORMAT value) {
 #endif
 
 #define SIMPLE_IUNKNOWN_IMPL1(_IFACE_) \
-  private: volatile llvm::sys::cas_flag m_dwRef; \
+  private: volatile std::atomic<llvm::sys::cas_flag> m_dwRef; \
   public:\
-  ULONG STDMETHODCALLTYPE AddRef() { return (ULONG)llvm::sys::AtomicIncrement(&m_dwRef); } \
+  ULONG STDMETHODCALLTYPE AddRef() { return (ULONG)++m_dwRef; } \
   ULONG STDMETHODCALLTYPE Release() { \
-    ULONG result = (ULONG)llvm::sys::AtomicDecrement(&m_dwRef); \
+    ULONG result = (ULONG)--m_dwRef; \
     if (result == 0) delete this; \
     return result; \
   } \


### PR DESCRIPTION
llvm::sys::Atomic* was removed in upstream llvm.