### PR TITLE
[spirv] Emit Git commit info when debug information requested

### DIFF
--- a/tools/clang/include/clang/Basic/Version.h
+++ b/tools/clang/include/clang/Basic/Version.h
@@ -77,6 +77,15 @@ namespace clang {
   /// for use in the CPP __VERSION__ macro, which includes the clang version
   /// number, the repository version, and the vendor tag.
   std::string getClangFullCPPVersion();
+
+  // HLSL Change Starts
+#ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
+  /// \brief Returns the number of Git commits in current branch.
+  uint32_t getGitCommitCount();
+  /// \brief Returns the hash of the current Git commit.
+  const char *getGitCommitHash();
+#endif // SUPPORT_QUERY_GIT_COMMIT_INFO
+  // HLSL Change Ends
 }
 
 #endif // LLVM_CLANG_BASIC_VERSION_H

--- a/tools/clang/include/clang/SPIRV/Structure.h
+++ b/tools/clang/include/clang/SPIRV/Structure.h
@@ -293,7 +293,7 @@ public:
   /// destructive; the module will be consumed and cleared after calling it.
   void take(InstBuilder *builder);
 
-  inline void setVersion(uint32_t version);
+  inline void useVulkan1p1();
   /// \brief Sets the id bound to the given bound.
   inline void setBound(uint32_t newBound);
 
@@ -328,6 +328,7 @@ public:
   inline uint32_t getExtInstSetId(llvm::StringRef setName);
 
 private:
+  bool isVulkan1p1;
   Header header; ///< SPIR-V module header.
   llvm::SetVector<spv::Capability> capabilities;
   llvm::SetVector<std::string> extensions;
@@ -453,10 +454,13 @@ TypeIdPair::TypeIdPair(const Type &ty, uint32_t id) : type(ty), resultId(id) {}
 // === Module inline implementations ===
 
 SPIRVModule::SPIRVModule()
-    : addressingModel(llvm::None), memoryModel(llvm::None),
+    : isVulkan1p1(false), addressingModel(llvm::None), memoryModel(llvm::None),
       shaderModelVersion(0), sourceFileNameId(0) {}
 
-void SPIRVModule::setVersion(uint32_t version) { header.version = version; }
+void SPIRVModule::useVulkan1p1() {
+  isVulkan1p1 = true;
+  header.version = 0x00010300u;
+}
 void SPIRVModule::setBound(uint32_t newBound) { header.bound = newBound; }
 
 void SPIRVModule::addCapability(spv::Capability cap) {

--- a/tools/clang/lib/Basic/CMakeLists.txt
+++ b/tools/clang/lib/Basic/CMakeLists.txt
@@ -90,3 +90,25 @@ add_clang_library(clangBasic
   ${version_inc}
   )
 
+# HLSL Change Starts
+if ( HLSL_SUPPORT_QUERY_GIT_COMMIT_INFO )
+  set(GIT_COMMIT_INFO_FILE ${CMAKE_CURRENT_BINARY_DIR}/GitCommitInfo.inc)
+  set(GET_GIT_COMMIT_SCRIPT ${PROJECT_SOURCE_DIR}/utils/GetCommitInfo.py)
+  add_custom_command(
+    OUTPUT  ${GIT_COMMIT_INFO_FILE}
+    COMMAND ${PYTHON_EXECUTABLE} ${GET_GIT_COMMIT_SCRIPT}
+            ${PROJECT_SOURCE_DIR} ${GIT_COMMIT_INFO_FILE}
+    DEPENDS ${GET_GIT_COMMIT_SCRIPT} GIT_COMMIT_INFO_ALWAYS_REBUILD
+    COMMENT "Collect Git commit info for versioning"
+  )
+  add_custom_target(
+    GIT_COMMIT_INFO_ALWAYS_REBUILD
+    ${CMAKE_COMMAND} -E touch ${GET_GIT_COMMIT_SCRIPT}
+    COMMENT "Touch GetCommitInfo.py to trigger rebuild"
+  )
+  set_property(TARGET GIT_COMMIT_INFO_ALWAYS_REBUILD
+    PROPERTY FOLDER "Utils")
+  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/Version.cpp
+    PROPERTIES OBJECT_DEPENDS "${GIT_COMMIT_INFO_FILE}")
+endif()
+# HLSL Change Ends

--- a/tools/clang/lib/Basic/Version.cpp
+++ b/tools/clang/lib/Basic/Version.cpp
@@ -180,4 +180,12 @@ std::string getClangFullCPPVersion() {
 #endif // HLSL Change Ends
 }
 
+// HLSL Change Starts
+#ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
+#include "GitCommitInfo.inc"
+uint32_t getGitCommitCount() { return kGitCommitCount; }
+const char *getGitCommitHash() { return kGitCommitHash; }
+#endif // SUPPORT_QUERY_GIT_COMMIT_INFO
+// HLSL Change Ends
+
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/ModuleBuilder.cpp
+++ b/tools/clang/lib/SPIRV/ModuleBuilder.cpp
@@ -28,7 +28,7 @@ ModuleBuilder::ModuleBuilder(SPIRVContext *C, FeatureManager *features,
 
   // Set the SPIR-V version if needed.
   if (featureManager && featureManager->getTargetEnv() == SPV_ENV_VULKAN_1_1)
-    theModule.setVersion(0x00010300);
+    theModule.useVulkan1p1();
 }
 
 std::vector<uint32_t> ModuleBuilder::takeModule() {

--- a/tools/clang/lib/SPIRV/Structure.cpp
+++ b/tools/clang/lib/SPIRV/Structure.cpp
@@ -11,6 +11,15 @@
 
 #include "BlockReadableOrder.h"
 
+#ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
+#include "clang/Basic/Version.h"
+#else
+namespace clang {
+uint32_t getGitCommitCount() { return 0; }
+const char *getGitCommitHash() { return "<unknown-hash>"; }
+} // namespace clang
+#endif // SUPPORT_QUERY_GIT_COMMIT_INFO
+
 namespace clang {
 namespace spirv {
 
@@ -351,6 +360,16 @@ void SPIRVModule::take(InstBuilder *builder) {
     } else {
       builder->opName(inst.targetId, std::move(inst.name)).x();
     }
+  }
+
+  if (isVulkan1p1) {
+    std::string commitHash =
+        std::string("dxc-commit-hash: ") + clang::getGitCommitHash();
+    builder->opModuleProcessed(commitHash).x();
+
+    std::string commitCount = std::string("dxc-commit-count: ") +
+                              std::to_string(clang::getGitCommitCount());
+    builder->opModuleProcessed(commitCount).x();
   }
 
   for (const auto &idDecorPair : decorations) {

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.commit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.commit.hlsl
@@ -1,0 +1,6 @@
+// Run: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -Zi
+
+// CHECK: OpModuleProcessed "dxc-commit-hash: {{\w+}}"
+// CHECK: OpModuleProcessed "dxc-commit-count: {{\d+}}"
+
+void main() { }

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -125,29 +125,6 @@ else ()
   include_directories(AFTER ${LLVM_INCLUDE_DIR}/dxc/Tracing)
 endif (WIN32)
 
-if ( HLSL_SUPPORT_QUERY_GIT_COMMIT_INFO )
-  set(GIT_COMMIT_INFO_FILE ${CMAKE_CURRENT_BINARY_DIR}/GitCommitInfo.inc)
-  set(GET_GIT_COMMIT_SCRIPT ${PROJECT_SOURCE_DIR}/utils/GetCommitInfo.py)
-  add_custom_command(
-    OUTPUT  ${GIT_COMMIT_INFO_FILE}
-    COMMAND ${PYTHON_EXECUTABLE} ${GET_GIT_COMMIT_SCRIPT}
-            ${PROJECT_SOURCE_DIR} ${GIT_COMMIT_INFO_FILE}
-    DEPENDS ${GET_GIT_COMMIT_SCRIPT} GIT_COMMIT_INFO_ALWAYS_REBUILD
-    COMMENT "Collect Git commit info for versioning"
-  )
-  add_custom_target(
-    GIT_COMMIT_INFO_ALWAYS_REBUILD
-    ${CMAKE_COMMAND} -E touch ${GET_GIT_COMMIT_SCRIPT}
-    COMMENT "Touch GetCommitInfo.py to trigger rebuild"
-  )
-  set_property(TARGET GIT_COMMIT_INFO_ALWAYS_REBUILD
-    PROPERTY FOLDER "Utils")
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/dxcompilerobj.cpp
-    PROPERTIES OBJECT_DEPENDS "${GIT_COMMIT_INFO_FILE}")
-  set_source_files_properties(${CMAKE_CURRENT_SOURCE_DIR}/dxcvalidator.cpp
-    PROPERTIES OBJECT_DEPENDS "${GIT_COMMIT_INFO_FILE}")
-endif()
-
 set_target_properties(dxcompiler
   PROPERTIES
   OUTPUT_NAME "dxcompiler"

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -54,7 +54,7 @@
 // SPIRV change ends
 
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
-#include "GitCommitInfo.inc" // Auto generated file containing Git commit info
+#include "clang/Basic/Version.h"
 #endif // SUPPORT_QUERY_GIT_COMMIT_INFO
 
 #define CP_UTF16 1200
@@ -961,13 +961,13 @@ public:
     if (pCommitCount == nullptr || pCommitHash == nullptr)
       return E_INVALIDARG;
 
-    char *const hash = (char *)CoTaskMemAlloc(ARRAYSIZE(kGitCommitHash) + 1);
+    char *const hash = (char *)CoTaskMemAlloc(8 + 1); // 8 is guaranteed by utils/GetCommitInfo.py
     if (hash == nullptr)
       return E_OUTOFMEMORY;
-    std::strcpy(hash, kGitCommitHash);
+    std::strcpy(hash, getGitCommitHash());
 
     *pCommitHash = hash;
-    *pCommitCount = kGitCommitCount;
+    *pCommitCount = getGitCommitCount();
 
     return S_OK;
   }

--- a/tools/clang/tools/dxcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcompiler/dxcvalidator.cpp
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
-#include "GitCommitInfo.inc" // Auto generated file containing Git commit info
+#include "clang/Basic/Version.h"
 #endif // SUPPORT_QUERY_GIT_COMMIT_INFO
 
 using namespace llvm;
@@ -177,13 +177,13 @@ HRESULT STDMETHODCALLTYPE DxcValidator::GetCommitInfo(
   if (pCommitCount == nullptr || pCommitHash == nullptr)
     return E_INVALIDARG;
 
-  char *const hash = (char *)CoTaskMemAlloc(ARRAYSIZE(kGitCommitHash) + 1);
+  char *const hash = (char *)CoTaskMemAlloc(8 + 1); // 8 is guaranteed by utils/GetCommitInfo.py
   if (hash == nullptr)
     return E_OUTOFMEMORY;
-  std::strcpy(hash, kGitCommitHash);
+  std::strcpy(hash, clang::getGitCommitHash());
 
   *pCommitHash = hash;
-  *pCommitCount = kGitCommitCount;
+  *pCommitCount = clang::getGitCommitCount();
 
   return S_OK;
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1345,6 +1345,11 @@ TEST_F(FileTest, SpirvDebugOpLine) {
   runFileTest("spirv.debug.opline.hlsl");
 }
 
+TEST_F(FileTest, SpirvDebugDxcCommitInfo) {
+  useVulkan1p1();
+  runFileTest("spirv.debug.commit.hlsl");
+}
+
 TEST_F(FileTest, VulkanAttributeErrors) {
   runFileTest("vk.attribute.error.hlsl", Expect::Failure);
 }

--- a/utils/GetCommitInfo.py
+++ b/utils/GetCommitInfo.py
@@ -6,7 +6,7 @@ import subprocess
 
 def git_get_commit_hash():
     return subprocess.check_output(
-        ['git', 'rev-parse', '--short', 'HEAD']).decode('ascii').strip()
+        ['git', 'rev-parse', '--short=8', 'HEAD']).decode('ascii').strip()
 
 
 def git_get_commit_count():


### PR DESCRIPTION
If targeting Vulkan 1.1 & requesting debug information with -Zi,
two new OpModuleProcessed instruction will be emitted to contain
"dxc-commit-hash" & "dxc-commit-count".