### PR TITLE
Implement Length property on constant arrays (FXC regression)

### DIFF
--- a/tools/clang/include/clang/AST/Stmt.h
+++ b/tools/clang/include/clang/AST/Stmt.h
@@ -205,7 +205,7 @@ protected:
     friend class UnaryExprOrTypeTraitExpr;
     unsigned : NumExprBits;
 
-    unsigned Kind : 2;
+    unsigned Kind : 3;   // HLSL Change
     unsigned IsType : 1; // true if operand is a type, false if an expression.
   };
 

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7654,6 +7654,8 @@ def err_hlsl_func_in_func_decl : Error<
    "function declaration is not allowed in function parameters">;
 def err_hlsl_unsupported_keyword_for_version : Error<
    "%0 is only allowed for HLSL %1 and above.">;
+def err_hlsl_unsupported_for_version_lower : Error<
+   "%0 is only allowed for HLSL %1 and lower.">;
 def err_hlsl_unsupported_keyword_for_min_precision : Error<
    "%0 is only supported with -enable-16bit-types option">;
 def err_hlsl_intrinsic_template_arg_unsupported: Error<

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -149,7 +149,7 @@ public:
 #endif
 
   // HLSL Change Starts
-  unsigned HLSLVersion;  // Only supported for IntelliSense scenarios.
+  unsigned HLSLVersion; 
   std::string HLSLEntryFunction;
   std::string HLSLProfile;
   unsigned RootSigMajor;

--- a/tools/clang/include/clang/Basic/TypeTraits.h
+++ b/tools/clang/include/clang/Basic/TypeTraits.h
@@ -94,6 +94,7 @@ namespace clang {
     UETT_AlignOf,
     UETT_VecStep,
     UETT_OpenMPRequiredSimdAlign,
+    UETT_ArrayLength,    // HLSL Change
   };
 }
 

--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -150,6 +150,15 @@ bool LookupVectorMemberExprForHLSL(
   clang::SourceLocation MemberLoc,
   _Inout_ clang::ExprResult* result);
 
+bool LookupArrayMemberExprForHLSL(
+  clang::Sema* self,
+  clang::Expr& BaseExpr,
+  clang::DeclarationName MemberName,
+  bool IsArrow,
+  clang::SourceLocation OpLoc,
+  clang::SourceLocation MemberLoc,
+  _Inout_ clang::ExprResult* result);
+
 clang::ExprResult MaybeConvertScalarToVector(
   _In_ clang::Sema* Self,
   _In_ clang::Expr* E);

--- a/tools/clang/lib/AST/ASTDumper.cpp
+++ b/tools/clang/lib/AST/ASTDumper.cpp
@@ -1971,8 +1971,10 @@ void ASTDumper::VisitUnaryExprOrTypeTraitExpr(
   case UETT_OpenMPRequiredSimdAlign:
     OS << " __builtin_omp_required_simd_align";
     break;
+  // HLSL Change Begins
   case UETT_ArrayLength:
     OS << " Length";
+  // HLSLC Change Ends
   }
   if (Node->isArgumentType())
     dumpType(Node->getArgumentType());

--- a/tools/clang/lib/AST/ASTDumper.cpp
+++ b/tools/clang/lib/AST/ASTDumper.cpp
@@ -1971,6 +1971,8 @@ void ASTDumper::VisitUnaryExprOrTypeTraitExpr(
   case UETT_OpenMPRequiredSimdAlign:
     OS << " __builtin_omp_required_simd_align";
     break;
+  case UETT_ArrayLength:
+    OS << " Length";
   }
   if (Node->isArgumentType())
     dumpType(Node->getArgumentType());

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -7496,6 +7496,13 @@ bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
                     Info.Ctx.getOpenMPDefaultSimdAlign(E->getArgumentType()))
             .getQuantity(),
         E);
+
+  case UETT_ArrayLength: {
+    QualType SrcTy = E->getTypeOfArgument();
+    assert(isa<ConstantArrayType>(SrcTy));
+    const ConstantArrayType *CAT = cast<ConstantArrayType>(SrcTy);
+    return Success(CAT->getSize(), E);
+  }
   }
 
   llvm_unreachable("unknown expr/type trait");

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -7497,12 +7497,14 @@ bool IntExprEvaluator::VisitUnaryExprOrTypeTraitExpr(
             .getQuantity(),
         E);
 
+  // HLSL Change Begins
   case UETT_ArrayLength: {
     QualType SrcTy = E->getTypeOfArgument();
     assert(isa<ConstantArrayType>(SrcTy));
     const ConstantArrayType *CAT = cast<ConstantArrayType>(SrcTy);
     return Success(CAT->getSize(), E);
   }
+  // HLSL Change Ends
   }
 
   llvm_unreachable("unknown expr/type trait");

--- a/tools/clang/lib/AST/ItaniumMangle.cpp
+++ b/tools/clang/lib/AST/ItaniumMangle.cpp
@@ -3063,6 +3063,7 @@ recurse:
       Diags.Report(DiagID);
       return; 
     }
+    // HLSL Change Begins
     case UETT_ArrayLength: {
       DiagnosticsEngine & Diags = Context.getDiags();
       unsigned DiagID = Diags.getCustomDiagID(
@@ -3071,6 +3072,7 @@ recurse:
       Diags.Report(DiagID);
       return;
     }
+    // HLSL Change Begins
     }
     if (SAE->isArgumentType()) {
       Out << 't';

--- a/tools/clang/lib/AST/ItaniumMangle.cpp
+++ b/tools/clang/lib/AST/ItaniumMangle.cpp
@@ -3055,13 +3055,22 @@ recurse:
       Diags.Report(DiagID);
       return;
     }
-    case UETT_OpenMPRequiredSimdAlign:
+    case UETT_OpenMPRequiredSimdAlign: {
       DiagnosticsEngine &Diags = Context.getDiags();
       unsigned DiagID = Diags.getCustomDiagID(
           DiagnosticsEngine::Error,
           "cannot yet mangle __builtin_omp_required_simd_align expression");
       Diags.Report(DiagID);
+      return; 
+    }
+    case UETT_ArrayLength: {
+      DiagnosticsEngine & Diags = Context.getDiags();
+      unsigned DiagID = Diags.getCustomDiagID(
+        DiagnosticsEngine::Error,
+        "cannot yet mangle .Length expression");
+      Diags.Report(DiagID);
       return;
+    }
     }
     if (SAE->isArgumentType()) {
       Out << 't';

--- a/tools/clang/lib/AST/StmtPrinter.cpp
+++ b/tools/clang/lib/AST/StmtPrinter.cpp
@@ -1265,32 +1265,38 @@ void StmtPrinter::VisitOffsetOfExpr(OffsetOfExpr *Node) {
 }
 
 void StmtPrinter::VisitUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *Node){
-  switch(Node->getKind()) {
-  case UETT_SizeOf:
-    OS << "sizeof";
-    break;
-  case UETT_AlignOf:
-    if (Policy.LangOpts.CPlusPlus)
-      OS << "alignof";
-    else if (Policy.LangOpts.C11)
-      OS << "_Alignof";
-    else
-      OS << "__alignof";
-    break;
-  case UETT_VecStep:
-    OS << "vec_step";
-    break;
-  case UETT_OpenMPRequiredSimdAlign:
-    OS << "__builtin_omp_required_simd_align";
-    break;
-  }
-  if (Node->isArgumentType()) {
-    OS << '(';
-    Node->getArgumentType().print(OS, Policy);
-    OS << ')';
-  } else {
-    OS << " ";
+  if (Node->getKind() == UETT_ArrayLength) {
     PrintExpr(Node->getArgumentExpr());
+    OS << ".Length";
+  }
+  else {
+    switch(Node->getKind()) {
+    case UETT_SizeOf:
+      OS << "sizeof";
+      break;
+    case UETT_AlignOf:
+      if (Policy.LangOpts.CPlusPlus)
+        OS << "alignof";
+      else if (Policy.LangOpts.C11)
+        OS << "_Alignof";
+      else
+        OS << "__alignof";
+      break;
+    case UETT_VecStep:
+      OS << "vec_step";
+      break;
+    case UETT_OpenMPRequiredSimdAlign:
+      OS << "__builtin_omp_required_simd_align";
+      break;
+    }
+    if (Node->isArgumentType()) {
+      OS << '(';
+      Node->getArgumentType().print(OS, Policy);
+      OS << ')';
+    } else {
+      OS << " ";
+      PrintExpr(Node->getArgumentExpr());
+    }
   }
 }
 

--- a/tools/clang/lib/AST/StmtPrinter.cpp
+++ b/tools/clang/lib/AST/StmtPrinter.cpp
@@ -1265,38 +1265,39 @@ void StmtPrinter::VisitOffsetOfExpr(OffsetOfExpr *Node) {
 }
 
 void StmtPrinter::VisitUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *Node){
+  // HLSL Change Begin
   if (Node->getKind() == UETT_ArrayLength) {
     PrintExpr(Node->getArgumentExpr());
     OS << ".Length";
+    return;
   }
-  else {
-    switch(Node->getKind()) {
-    case UETT_SizeOf:
-      OS << "sizeof";
-      break;
-    case UETT_AlignOf:
-      if (Policy.LangOpts.CPlusPlus)
-        OS << "alignof";
-      else if (Policy.LangOpts.C11)
-        OS << "_Alignof";
-      else
-        OS << "__alignof";
-      break;
-    case UETT_VecStep:
-      OS << "vec_step";
-      break;
-    case UETT_OpenMPRequiredSimdAlign:
-      OS << "__builtin_omp_required_simd_align";
-      break;
-    }
-    if (Node->isArgumentType()) {
-      OS << '(';
-      Node->getArgumentType().print(OS, Policy);
-      OS << ')';
-    } else {
-      OS << " ";
-      PrintExpr(Node->getArgumentExpr());
-    }
+  // HLSL Change Ends
+  switch(Node->getKind()) {
+  case UETT_SizeOf:
+    OS << "sizeof";
+    break;
+  case UETT_AlignOf:
+    if (Policy.LangOpts.CPlusPlus)
+      OS << "alignof";
+    else if (Policy.LangOpts.C11)
+      OS << "_Alignof";
+    else
+      OS << "__alignof";
+    break;
+  case UETT_VecStep:
+    OS << "vec_step";
+    break;
+  case UETT_OpenMPRequiredSimdAlign:
+    OS << "__builtin_omp_required_simd_align";
+    break;
+  }
+  if (Node->isArgumentType()) {
+    OS << '(';
+    Node->getArgumentType().print(OS, Policy);
+    OS << ')';
+  } else {
+    OS << " ";
+    PrintExpr(Node->getArgumentExpr());
   }
 }
 

--- a/tools/clang/lib/Basic/LangOptions.cpp
+++ b/tools/clang/lib/Basic/LangOptions.cpp
@@ -24,7 +24,8 @@ using namespace clang;
 #endif // MS_SUPPORT_VARIABLE_LANGOPTS
 #endif // LLVM_ON_UNIX
 
-LangOptions::LangOptions() {
+LangOptions::LangOptions() 
+    : HLSLVersion(2018) {
 #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 #define LANGOPT(Name, Bits, Default, Description) Name = Default;
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Description) set##Name(Default);

--- a/tools/clang/lib/Sema/SemaExprMember.cpp
+++ b/tools/clang/lib/Sema/SemaExprMember.cpp
@@ -1248,6 +1248,13 @@ static ExprResult LookupMemberExpr(Sema &S, LookupResult &R,
       return vectorResult;
     }
   }
+  {
+    ExprResult arrayResult;
+    if (S.getLangOpts().HLSL &&
+      hlsl::LookupArrayMemberExprForHLSL(&S, *BaseExpr.get(), MemberName, IsArrow, OpLoc, MemberLoc, &arrayResult)) {
+      return arrayResult;
+    }
+  }
   // HLSL Change Ends
 
   // Handle field access to simple records.

--- a/tools/clang/test/HLSL/array-length.hlsl
+++ b/tools/clang/test/HLSL/array-length.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify -HV 2016  %s
 
 float4 planes1[8];
 float4 planes2[3+2]; 

--- a/tools/clang/test/HLSL/array-length.hlsl
+++ b/tools/clang/test/HLSL/array-length.hlsl
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+
+float4 planes1[8];
+float4 planes2[3+2]; 
+
+struct S {
+    float4 planes[2]; 
+};
+
+[RootSignature("CBV(b0, space=0, visibility=SHADER_VISIBILITY_ALL)")]
+float main(S s:POSITION) : SV_Target {
+    float4 planes3[] = {{ 1.0, 2.0, 3.0, 4.0 }};
+    
+    int total = planes1.Length;	// expected-warning {{Length is deprecated}}
+    total += planes2.Length;  	// expected-warning {{Length is deprecated}}
+    total += planes3.Length;    // expected-warning {{Length is deprecated}}
+    total += s.planes.Length;   // expected-warning {{Length is deprecated}}
+
+    return total;
+}

--- a/tools/clang/test/HLSL/rewriter/array-length-rw.hlsl
+++ b/tools/clang/test/HLSL/rewriter/array-length-rw.hlsl
@@ -1,0 +1,10 @@
+float4 planes[8];
+
+[RootSignature("CBV(b0, space=0, visibility=SHADER_VISIBILITY_ALL)")]
+float main(POSITION) : SV_Target {
+    float4 x = float4(1.0, 1.0, 1.0, 1.0);
+    for (uint i = 0; i < planes.Length; ++i) {
+        x = x + planes[i];
+    }
+    return x.x;
+}

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/array-length-rw_gold.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/array-length-rw_gold.hlsl
@@ -1,0 +1,12 @@
+// Rewrite unchanged result:
+const float4 planes[8];
+[RootSignature(CBV(b0, space=0, visibility=SHADER_VISIBILITY_ALL))]
+float main(int) {
+  float4 x = float4(1., 1., 1., 1.);
+  for (uint i = 0; i < planes.Length; ++i) {
+    x = x + planes[i];
+  }
+  return x.x;
+}
+
+

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -52,6 +52,7 @@ public:
     TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 
+  TEST_METHOD(RunArrayLength);
   TEST_METHOD(RunAttributes);
   TEST_METHOD(RunAnonymousStruct);
   TEST_METHOD(RunCppErrors);
@@ -287,6 +288,10 @@ public:
     return CompareGold(rewriteText, GetPathToHlslDataFile(goldPath).c_str());
   }
 };
+
+TEST_F(RewriterTest, RunArrayLength) {
+  CheckVerifiesHLSL(L"rewriter\\array-length-rw.hlsl", L"rewriter\\correct_rewrites\\array-length-rw_gold.hlsl");
+}
 
 TEST_F(RewriterTest, RunAttributes) {
     CheckVerifiesHLSL(L"rewriter\\attributes_noerr.hlsl", L"rewriter\\correct_rewrites\\attributes_gold.hlsl");

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -52,7 +52,8 @@ public:
     TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 
-  TEST_METHOD(RunArrayLength);
+  //TODO: Enable this tests with -HV 2016 once we have a way to change HLSL version
+  //TEST_METHOD(RunArrayLength);
   TEST_METHOD(RunAttributes);
   TEST_METHOD(RunAnonymousStruct);
   TEST_METHOD(RunCppErrors);
@@ -289,9 +290,10 @@ public:
   }
 };
 
-TEST_F(RewriterTest, RunArrayLength) {
-  CheckVerifiesHLSL(L"rewriter\\array-length-rw.hlsl", L"rewriter\\correct_rewrites\\array-length-rw_gold.hlsl");
-}
+//TODO: Enable this tests with -HV 2016 once we have a way to change HLSL version
+// TEST_F(RewriterTest, RunArrayLength) {
+//  CheckVerifiesHLSL(L"rewriter\\array-length-rw.hlsl", L"rewriter\\correct_rewrites\\array-length-rw_gold.hlsl");
+//}
 
 TEST_F(RewriterTest, RunAttributes) {
     CheckVerifiesHLSL(L"rewriter\\attributes_noerr.hlsl", L"rewriter\\correct_rewrites\\attributes_gold.hlsl");

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -36,6 +36,7 @@ public:
     TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 
+  TEST_METHOD(RunArrayLength)
   TEST_METHOD(RunAttributes)
   TEST_METHOD(RunConstExpr)
   TEST_METHOD(RunConstAssign)
@@ -131,6 +132,10 @@ public:
     CheckVerifies(hlsl_test::GetPathToHlslDataFile(name).c_str());
   }
 };
+
+TEST_F(VerifierTest, RunArrayLength) {
+  CheckVerifiesHLSL(L"array-length.hlsl");
+}
 
 TEST_F(VerifierTest, RunAttributes) {
   CheckVerifiesHLSL(L"attributes.hlsl");


### PR DESCRIPTION
The FXC compiler supports Length property on arrays. This change adds it
to the DXC compiler for backwards compatibility. However, it is marked
obsolete and will be removed in future versions of HLSL.