### PR TITLE
[spirv] Stop emitting commit count

### DIFF
--- a/tools/clang/lib/SPIRV/Structure.cpp
+++ b/tools/clang/lib/SPIRV/Structure.cpp
@@ -379,10 +379,6 @@ void SPIRVModule::take(InstBuilder *builder) {
         std::string("dxc-commit-hash: ") + clang::getGitCommitHash();
     builder->opModuleProcessed(commitHash).x();
 
-    std::string commitCount = std::string("dxc-commit-count: ") +
-                              std::to_string(clang::getGitCommitCount());
-    builder->opModuleProcessed(commitCount).x();
-
     // Emit OpModuleProcessed to indicate the command line options that were
     // used to generate this module.
     if (!spirvOptions.clOptions.empty()) {

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.commit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.commit.hlsl
@@ -1,6 +1,5 @@
 // Run: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -Zi
 
 // CHECK: OpModuleProcessed "dxc-commit-hash: {{\w+}}"
-// CHECK: OpModuleProcessed "dxc-commit-count: {{\d+}}"
 
 void main() { }


### PR DESCRIPTION
The commit hash should suffice to pinpoint in Git history.