### PR TITLE
[linux-port] Do not use llvm DynamicLibrary in dxcapi.use.h

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -13,27 +13,40 @@
 #define __DXCAPI_USE_H__
 
 #include "dxc/dxcapi.h"
-#include "llvm/Support/DynamicLibrary.h"
 
 namespace dxc {
 
 // Helper class to dynamically load the dxcompiler or a compatible libraries.
 class DxcDllSupport {
 protected:
-  using DynamicLibrary = llvm::sys::DynamicLibrary;
-  DynamicLibrary m_dll;
+  HMODULE m_dll;
   DxcCreateInstanceProc m_createFn;
   DxcCreateInstance2Proc m_createFn2;
 
+  #ifndef _WIN32
+  void FreeLibrary(void* handle) {
+    ::dlclose(handle);
+  }
+  HMODULE LoadLibraryW(LPCWSTR name) {
+    char nameStr[256];
+    std::wcstombs(nameStr, name, 256);
+    return ::dlopen(nameStr, RTLD_LAZY);
+  }
+  HMODULE GetProcAddress(HMODULE dll, LPCSTR fnName) {
+    return ::dlsym(dll, fnName);
+  }
+  #endif
+
   HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
-    if (m_dll.isValid()) return S_OK;
-    m_dll = DynamicLibrary::getPermanentLibrary(CW2A(dllName));
-    if (!m_dll.isValid()) return HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND);
-    m_createFn = (DxcCreateInstanceProc)m_dll.getAddressOfSymbol(fnName);
+    if (m_dll != nullptr) return S_OK;
+    m_dll = LoadLibraryW(dllName);
+    if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
+    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
 
     if (m_createFn == nullptr) {
       HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-      m_dll = DynamicLibrary();
+      FreeLibrary(m_dll);
+      m_dll = nullptr;
       return hr;
     }
 
@@ -45,18 +58,18 @@ protected:
       memcpy(fnName2, fnName, s);
       fnName2[s] = '2';
       fnName2[s + 1] = '\0';
-      m_createFn2 = (DxcCreateInstance2Proc)m_dll.getAddressOfSymbol(fnName2);
+      m_createFn2 = (DxcCreateInstance2Proc)GetProcAddress(m_dll, fnName2);
     }
 
     return S_OK;
   }
 
 public:
-  DxcDllSupport() : m_dll(), m_createFn(nullptr), m_createFn2(nullptr) {
+  DxcDllSupport() : m_dll(nullptr), m_createFn(nullptr), m_createFn2(nullptr) {
   }
 
   DxcDllSupport(DxcDllSupport&& other) {
-    m_dll = other.m_dll; other.m_dll = DynamicLibrary();
+    m_dll = other.m_dll; other.m_dll = nullptr;
     m_createFn = other.m_createFn; other.m_createFn = nullptr;
     m_createFn2 = other.m_createFn2; other.m_createFn2 = nullptr;
   }
@@ -86,7 +99,7 @@ public:
 
   HRESULT CreateInstance(REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
     if (pResult == nullptr) return E_POINTER;
-    if (!m_dll.isValid()) return E_FAIL;
+    if (m_dll == nullptr) return E_FAIL;
     HRESULT hr = m_createFn(clsid, riid, (LPVOID*)pResult);
     return hr;
   }
@@ -98,7 +111,7 @@ public:
 
   HRESULT CreateInstance2(IMalloc *pMalloc, REFCLSID clsid, REFIID riid, _Outptr_ IUnknown **pResult) {
     if (pResult == nullptr) return E_POINTER;
-    if (!m_dll.isValid()) return E_FAIL;
+    if (m_dll == nullptr) return E_FAIL;
     if (m_createFn2 == nullptr) return E_FAIL;
     HRESULT hr = m_createFn2(pMalloc, clsid, riid, (LPVOID*)pResult);
     return hr;
@@ -109,20 +122,21 @@ public:
   }
 
   bool IsEnabled() const {
-    return m_dll.isValid();
+    return m_dll != nullptr;
   }
 
   void Cleanup() {
-    if (m_dll.isValid()) {
+    if (m_dll != nullptr) {
       m_createFn = nullptr;
       m_createFn2 = nullptr;
-      m_dll = DynamicLibrary();
+      FreeLibrary(m_dll);
+      m_dll = nullptr;
     }
   }
 
-  DynamicLibrary Detach() {
-    DynamicLibrary module = m_dll;
-    m_dll = DynamicLibrary();
+  HMODULE Detach() {
+    HMODULE module = m_dll;
+    m_dll = nullptr;
     return module;
   }
 };

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -23,29 +23,32 @@ protected:
   DxcCreateInstanceProc m_createFn;
   DxcCreateInstance2Proc m_createFn2;
 
-  #ifndef _WIN32
-  void FreeLibrary(void* handle) {
-    ::dlclose(handle);
-  }
-  HMODULE LoadLibraryW(LPCWSTR name) {
-    char nameStr[256];
-    std::wcstombs(nameStr, name, 256);
-    return ::dlopen(nameStr, RTLD_LAZY);
-  }
-  HMODULE GetProcAddress(HMODULE dll, LPCSTR fnName) {
-    return ::dlsym(dll, fnName);
-  }
-  #endif
-
   HRESULT InitializeInternal(LPCWSTR dllName, LPCSTR fnName) {
     if (m_dll != nullptr) return S_OK;
+
+#ifdef _WIN32
     m_dll = LoadLibraryW(dllName);
+#else
+    char nameStr[256];
+    std::wcstombs(nameStr, dllName, 256);
+    m_dll = ::dlopen(nameStr, RTLD_LAZY);
+#endif
+
     if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
+
+#ifdef _WIN32
     m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
+#else
+    m_createFn = (DxcCreateInstanceProc)::dlsym(m_dll, fnName);
+#endif
 
     if (m_createFn == nullptr) {
       HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+#ifdef _WIN32
       FreeLibrary(m_dll);
+#else
+      ::dlclose(m_dll);
+#endif
       m_dll = nullptr;
       return hr;
     }
@@ -58,7 +61,11 @@ protected:
       memcpy(fnName2, fnName, s);
       fnName2[s] = '2';
       fnName2[s + 1] = '\0';
+#ifdef _WIN32
       m_createFn2 = (DxcCreateInstance2Proc)GetProcAddress(m_dll, fnName2);
+#else
+      m_createFn2 = (DxcCreateInstance2Proc)::dlsym(m_dll, fnName2);
+#endif
     }
 
     return S_OK;
@@ -129,7 +136,11 @@ public:
     if (m_dll != nullptr) {
       m_createFn = nullptr;
       m_createFn2 = nullptr;
+#ifdef _WIN32
       FreeLibrary(m_dll);
+#else
+      ::dlclose(m_dll);
+#endif
       m_dll = nullptr;
     }
   }

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -28,7 +28,7 @@ if( NOT MSVC )
 endif( NOT MSVC )
 
 # HLSL Change - add ignored sources
-set(HLSL_IGNORE_SOURCES PluginLoader.cpp)
+set(HLSL_IGNORE_SOURCES DynamicLibrary.cpp PluginLoader.cpp)
 
 add_llvm_library(LLVMSupport
   APFloat.cpp
@@ -52,7 +52,6 @@ add_llvm_library(LLVMSupport
   DeltaAlgorithm.cpp
   DAGDeltaAlgorithm.cpp
   Dwarf.cpp
-  DynamicLibrary.cpp
   ErrorHandling.cpp
   FileUtilities.cpp
   FileOutputBuffer.cpp


### PR DESCRIPTION
Fixes #1525 

This CL changes dxcapi.use.h back to what it was before the Linux-port work. It does, however, add a snippet into it to redirect FreeLibrary to dlcose, LoadLibraryW to dlopen, and GetProcAddress to dlsym for non-Windows platforms.