### PR TITLE
Exclude certain globals when enabling them for write in /Gec mode

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -4312,7 +4312,10 @@ static void CreateWriteEnabledStaticGlobals(llvm::Module *M,
                                             llvm::Function *EF) {
   std::vector<GlobalVariable *> worklist;
   for (GlobalVariable &GV : M->globals()) {
-    if (!GV.isConstant() && GV.getLinkage() != GlobalValue::InternalLinkage) {
+    if (!GV.isConstant() && GV.getLinkage() != GlobalValue::InternalLinkage &&
+        // skip globals which are HLSL objects or group shared
+        !HLModule::IsHLSLObjectType(GV.getType()->getPointerElementType()) &&
+        !dxilutil::IsSharedMemoryGlobal(&GV)) {
       if (GlobalHasStoreUser(&GV))
         worklist.emplace_back(&GV);
       // TODO: Ensure that constant globals aren't using initializer

--- a/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test05.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test05.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T ps_6_0 /Gec -HV 2016 > %s | FileCheck %s
+
+// CHECK: define void @main()
+// CHECK: ret void
+
+RWTexture2D<float3> Color : register(u0);
+groupshared uint PixelCountH;
+
+uint main( uint2 a : A, float3 b : B ) : SV_Target
+{
+ Color[a] = b; 
+ PixelCountH = Color[a].x * 1;
+ return PixelCountH;
+}


### PR DESCRIPTION
Exclude certain globals which are either HLSL objects or group shared when enabling them for write in /Gec mode.