### PR TITLE
Propagate EnableBackCompatMode flag in DxcRewriter

### DIFF
--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -129,6 +129,7 @@ void SetupCompilerForRewrite(CompilerInstance &compiler,
   compiler.getDiagnostics().setIgnoreAllWarnings(!opts.OutputWarnings);
   compiler.getLangOpts().HLSLVersion = (unsigned)opts.HLSLVersion;
   compiler.getLangOpts().UseMinPrecision = !opts.Enable16BitTypes;
+  compiler.getLangOpts().EnableBackCompatMode = opts.EnableBackCompatMode;
 
   PreprocessorOptions &PPOpts = compiler.getPreprocessorOpts();
   if (rewrite != nullptr) {


### PR DESCRIPTION
Fixes failing RewriterTests

The EnableBackCompatMode flag was not initialized when the compiler was used via DxcRewriter. The flag is new and has been introduced shortly after the DxcRewriter change PR. The tests failures were caused by unfortunate merge timing of the two changes.