### PR TITLE
Fix lit function

### DIFF
--- a/tools/clang/test/CodeGenHLSL/quick-test/lit-function.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/lit-function.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T ps_6_0 -E main  %s | FileCheck %s
+
+// Verify lit function defined as lit(ambient, diffuse, specular, 1) where:
+// ambient = 1.
+// diffuse = ((n l) < 0) ? 0 : n l.
+// specular = ((n l) < 0) || ((n h) < 0) ? 0 : ((n h) ^ m).
+
+// CHECK: fcmp
+// CHECK: select
+// CHECK: fcmp
+// CHECK: or
+// CHECK: Log
+// CHECK: fmul
+// CHECK: Exp
+// CHECK: select
+
+float4 main(float a : A, float b : B, float c : C) : SV_Target
+{
+  return lit(a, b, c);
+}


### PR DESCRIPTION
There was a bug in [lit function](https://docs.microsoft.com/en-us/windows/desktop/direct3dhlsl/dx-graphics-hlsl-lit) where specular uses mul (`*`) operator instead of power (`^`) operator. Correct expression for specular is: `((n l) < 0) || ((n h) < 0) ? 0 : ((n h) ^ m)`.