### PR TITLE
[linux-port] Add definition of strnicmp for Linux.

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -172,6 +172,7 @@
 #define _atoi64 atoll
 #define sprintf_s snprintf
 #define _strdup strdup
+#define _strnicmp strnicmp
 
 #define vsprintf_s vsprintf
 #define strcat_s strcat

--- a/include/dxc/Support/WinFunctions.h
+++ b/include/dxc/Support/WinFunctions.h
@@ -26,6 +26,8 @@ HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult);
 HRESULT IntToUInt(int in, UINT *out);
 HRESULT SizeTToInt(size_t in, INT *out);
 HRESULT UInt32Mult(UINT a, UINT b, UINT *out);
+
+int strnicmp(const char *str1, const char *str2, size_t count);
 int _stricmp(const char *str1, const char *str2);
 int _wcsicmp(const wchar_t *str1, const wchar_t *str2);
 int _wcsnicmp(const wchar_t *str1, const wchar_t *str2, size_t n);

--- a/lib/DxcSupport/WinFunctions.cpp
+++ b/lib/DxcSupport/WinFunctions.cpp
@@ -98,6 +98,23 @@ HRESULT UInt32Mult(UINT a, UINT b, UINT *out) {
   return S_OK;
 }
 
+int strnicmp(const char *str1, const char *str2, size_t count) {
+  size_t i = 0;
+  for (; i < count && str1[i] && str2[i]; ++i) {
+    int d = std::tolower(str1[i]) - std::tolower(str2[i]);
+    if (d != 0)
+      return d;
+  }
+
+  if (i == count) {
+    // All 'count' characters matched.
+    return 0;
+  }
+
+  // str1 or str2 reached NULL before 'count' characters were compared.
+  return str1[i] - str2[i];
+}
+
 int _stricmp(const char *str1, const char *str2) {
   size_t i = 0;
   for (; str1[i] && str2[i]; ++i) {

--- a/lib/HLSL/DxilTypeSystem.cpp
+++ b/lib/HLSL/DxilTypeSystem.cpp
@@ -11,6 +11,7 @@
 #include "dxc/HLSL/DxilModule.h"
 #include "dxc/HLSL/HLModule.h"
 #include "dxc/Support/Global.h"
+#include "dxc/Support/WinFunctions.h"
 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/LLVMContext.h"


### PR DESCRIPTION
Usage of strnicmp was recently added to the code base, and causes the
Linux builds to fail. This fixes it.