### PR TITLE
Fix fallback compiler to ensure raytracing samples' compatibility with 6_3 under fallback layer

### DIFF
--- a/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
@@ -265,7 +265,9 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::RenameAndLink(
         }
 
         // Link all the modules together into a single into library
-        int valMajor = 1, valMinor = 2; // TODO: Where to get these values?
+        unsigned int valMajor = 0, valMinor = 0;
+        dxcutil::GetValidatorVersion(&valMajor, &valMinor);
+
         std::unique_ptr<Module> M;
         {
             DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);
@@ -470,7 +472,8 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Link(
             shaderNames[i] = ws2s(pShaderNames[i]);
 
         // Link all the modules together into a single into library
-        int valMajor = 1, valMinor = 2; // TODO: Where to get these values?
+        unsigned int valMajor = 0, valMinor = 0;
+        dxcutil::GetValidatorVersion(&valMajor, &valMinor);
         std::unique_ptr<Module> M;
         {
             DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);
@@ -635,7 +638,8 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Compile(
       shaderNames[i] = ws2s(pShaderNames[i]);
 
     // Link all the modules together into a single into library
-    int valMajor = 1, valMinor = 3; // TODO: Where to get these values?
+    unsigned int valMajor = 0, valMinor = 0;
+    dxcutil::GetValidatorVersion(&valMajor, &valMinor);
     std::unique_ptr<Module> M;
     {
     DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);

--- a/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
@@ -635,7 +635,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Compile(
       shaderNames[i] = ws2s(pShaderNames[i]);
 
     // Link all the modules together into a single into library
-    int valMajor = 1, valMinor = 2; // TODO: Where to get these values?
+    int valMajor = 1, valMinor = 3; // TODO: Where to get these values?
     std::unique_ptr<Module> M;
     {
     DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);

--- a/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
@@ -283,7 +283,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::RenameAndLink(
             }
 
             dxilutil::ExportMap exportMap;
-            M = pLinker->Link("", "lib_6_1", exportMap);
+            M = pLinker->Link("", "lib_6_3", exportMap);
             if (m_debugOutput)
             {
                 saveModuleToAsmFile(M.get(), "combined.ll");
@@ -310,7 +310,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::RenameAndLink(
         DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);
         pLinker->RegisterLib("M", std::move(M), nullptr);
         pLinker->AttachLib("M");
-        auto profile = "lib_6_1";
+        auto profile = "lib_6_3";
         M = pLinker->Link(StringRef(), profile, exportMap);
         bool hasErrors = DiagContext.HasErrors();
 
@@ -489,7 +489,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Link(
             }
 
             dxilutil::ExportMap exportMap;
-            M = pLinker->Link("", "lib_6_1", exportMap);
+            M = pLinker->Link("", "lib_6_3", exportMap);
             if (m_debugOutput)
             {
                 saveModuleToAsmFile(M.get(), "combined.ll");
@@ -711,7 +711,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Compile(
     DxilLinker* pLinker = DxilLinker::CreateLinker(context, valMajor, valMinor);
     pLinker->RegisterLib("M", std::move(M), nullptr);
     pLinker->AttachLib("M");
-    auto profile = "lib_6_1";
+    auto profile = "lib_6_3";
     M = pLinker->Link(StringRef(), profile, exportMap);
     bool hasErrors = DiagContext.HasErrors();
 

--- a/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
@@ -651,7 +651,7 @@ HRESULT STDMETHODCALLTYPE DxcDxrFallbackCompiler::Compile(
     }
 
     dxilutil::ExportMap exportMap;
-    M = pLinker->Link("", "lib_6_1", exportMap);
+    M = pLinker->Link("", "lib_6_3", exportMap);
     if (m_debugOutput)
     {
         saveModuleToAsmFile(M.get(), "combined.ll");

--- a/tools/clang/unittests/DxrFallback/test_DxrFallback.cpp
+++ b/tools/clang/unittests/DxrFallback/test_DxrFallback.cpp
@@ -170,7 +170,7 @@ public:
     {
       CComPtr<IDxcBlob> pInput;
       LPCWSTR args[] = { L"-O3" };
-      CompileToDxilFromFile(m_dxcSupport, s2ws(m_path + filename).c_str(), L"", L"lib_6_1", args, _countof(args), nullptr, 0, &pInput);
+      CompileToDxilFromFile(m_dxcSupport, s2ws(m_path + filename).c_str(), L"", L"lib_6_3", args, _countof(args), nullptr, 0, &pInput);
       m_inputBlobs.push_back(pInput);
       m_inputBlobPtrs.push_back(pInput);
     }


### PR DESCRIPTION
In the interest of getting RS5 DXR compatibility the raytracing samples were upgraded to target shader model 6_3. This, unfortunately, broke the fallback layer. Fixing the fallback layer requires adjusting the fallback compiler to target 6_3. 

This change has been tested+verified working with the fallback layer on all samples on develop-dxr-rs5-preview.

Once this change is in, the plan is for a build of it to be available in a release on the [samples releases page](https://github.com/Microsoft/DirectX-Graphics-Samples/releases).