### PR TITLE
Fix dependencies for DxrFallback.

### DIFF
--- a/lib/DxrFallback/CMakeLists.txt
+++ b/lib/DxrFallback/CMakeLists.txt
@@ -11,4 +11,4 @@ add_llvm_library(LLVMDxrFallback
   StateFunctionTransform.h
 )
 
-add_dependencies(LLVMDxrFallback intrinscs_gen)
+add_dependencies(LLVMDxrFallback intrinsics_gen)


### PR DESCRIPTION
The dependency for this library had a typo, which failed
to add intrinsics_gen as a dependency, leading to spuirous
failures when building with high leveles of concurrency.