### PR TITLE
Replacing recursive Value::MergeUseLists implementation with an iterative one

### DIFF
--- a/include/llvm/IR/Value.h
+++ b/include/llvm/IR/Value.h
@@ -494,6 +494,9 @@ private:
   template <class Compare>
   static Use *mergeUseLists(Use *L, Use *R, Compare Cmp) {
     Use *Merged;
+
+    // HLSL Change Begins. Copied from LLVM Version 8.0.0.
+    // MergeUseListsImpl(L, R, &Merged, Cmp);
     Use **Next = &Merged;
 
     while (true) {
@@ -515,9 +518,18 @@ private:
         L = L->Next;
       }
     }
+    // HLSL Change Ends.
 
     return Merged;
   }
+  
+  /// \brief Tail-recursive helper for \a mergeUseLists().
+  ///
+  /// \param[out] Next the first element in the list.
+  // HLSL Change Begins.
+  //template <class Compare>
+  //static void mergeUseListsImpl(Use *L, Use *R, Use **Next, Compare Cmp);
+  // HLSL Change Ends.
 
 protected:
   unsigned short getSubclassDataFromValue() const { return SubclassData; }
@@ -601,6 +613,29 @@ template <class Compare> void Value::sortUseList(Compare Cmp) {
     Prev = &I->Next;
   }
 }
+
+// HLSL Change Begins.
+/*
+template <class Compare>
+void Value::mergeUseListsImpl(Use *L, Use *R, Use **Next, Compare Cmp) {
+  if (!L) {
+    *Next = R;
+    return;
+  }
+  if (!R) {
+    *Next = L;
+    return;
+  }
+  if (Cmp(*R, *L)) {
+    *Next = R;
+    mergeUseListsImpl(L, R->Next, &R->Next, Cmp);
+    return;
+  }
+  *Next = L;
+  mergeUseListsImpl(L->Next, R, &L->Next, Cmp);
+}
+*/
+// HLSL Change Ends.
 
 // isa - Provide some specializations of isa so that we don't have to include
 // the subtype header files to test to see if the value is a subclass...

--- a/include/llvm/IR/Value.h
+++ b/include/llvm/IR/Value.h
@@ -494,15 +494,30 @@ private:
   template <class Compare>
   static Use *mergeUseLists(Use *L, Use *R, Compare Cmp) {
     Use *Merged;
-    mergeUseListsImpl(L, R, &Merged, Cmp);
+    Use **Next = &Merged;
+
+    while (true) {
+      if (!L) {
+        *Next = R;
+        break;
+      }
+      if (!R) {
+        *Next = L;
+        break;
+      }
+      if (Cmp(*R, *L)) {
+        *Next = R;
+        Next = &R->Next;
+        R = R->Next;
+      } else {
+        *Next = L;
+        Next = &L->Next;
+        L = L->Next;
+      }
+    }
+
     return Merged;
   }
-
-  /// \brief Tail-recursive helper for \a mergeUseLists().
-  ///
-  /// \param[out] Next the first element in the list.
-  template <class Compare>
-  static void mergeUseListsImpl(Use *L, Use *R, Use **Next, Compare Cmp);
 
 protected:
   unsigned short getSubclassDataFromValue() const { return SubclassData; }
@@ -585,25 +600,6 @@ template <class Compare> void Value::sortUseList(Compare Cmp) {
     I->setPrev(Prev);
     Prev = &I->Next;
   }
-}
-
-template <class Compare>
-void Value::mergeUseListsImpl(Use *L, Use *R, Use **Next, Compare Cmp) {
-  if (!L) {
-    *Next = R;
-    return;
-  }
-  if (!R) {
-    *Next = L;
-    return;
-  }
-  if (Cmp(*R, *L)) {
-    *Next = R;
-    mergeUseListsImpl(L, R->Next, &R->Next, Cmp);
-    return;
-  }
-  *Next = L;
-  mergeUseListsImpl(L->Next, R, &L->Next, Cmp);
 }
 
 // isa - Provide some specializations of isa so that we don't have to include


### PR DESCRIPTION
Replacing the tail-recursive function Value::MergeUseLists with an iterative version (used in LLVM  version 8.0.0)

The tail recursive version of the function was causing stack overflow in a large
shader.