### PR TITLE
Properly clean up resources involved in unused convergent values.

### DIFF
--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -597,7 +597,8 @@ void PassManagerBuilder::populateModulePassManager(
     MPM.add(createDxilConvergentClearPass());
     MPM.add(createDeadCodeEliminationPass()); // DCE needed after clearing convergent
                                               // before CreateHandleForLib so no
-                                              // unused resources get added declared.
+                                              // unused resources get re-added to
+                                              // DxilModule.
     MPM.add(createMultiDimArrayToOneDimArrayPass());
     MPM.add(createDxilLowerCreateHandleForLibPass());
     MPM.add(createDxilTranslateRawBuffer());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -595,9 +595,9 @@ void PassManagerBuilder::populateModulePassManager(
   // HLSL Change Begins.
   if (!HLSLHighLevel) {
     MPM.add(createDxilConvergentClearPass());
-    MPM.add(createDeadCodeEliminationPass()); // DCE needed after clearing convergent
-                                              // before CreateHandleForLib so no
-                                              // unused resources get re-added to
+    MPM.add(createDeadCodeEliminationPass()); // DCE needed after clearing convergence
+                                              // annotations before CreateHandleForLib
+                                              // so no unused resources get re-added to
                                               // DxilModule.
     MPM.add(createMultiDimArrayToOneDimArrayPass());
     MPM.add(createDxilLowerCreateHandleForLibPass());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -595,6 +595,9 @@ void PassManagerBuilder::populateModulePassManager(
   // HLSL Change Begins.
   if (!HLSLHighLevel) {
     MPM.add(createDxilConvergentClearPass());
+    MPM.add(createDeadCodeEliminationPass()); // DCE needed after clearing convergent
+                                              // before CreateHandleForLib so no
+                                              // unused resources get added declared.
     MPM.add(createMultiDimArrayToOneDimArrayPass());
     MPM.add(createDxilLowerCreateHandleForLibPass());
     MPM.add(createDxilTranslateRawBuffer());

--- a/tools/clang/test/CodeGenHLSL/quick-test/resource_cleanup.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/resource_cleanup.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc /O3 /Tps_6_0 /Emain > %s | FileCheck %s
+
+// Make sure only one cbuffer is emitted for the final
+// dxil.
+
+// CHECK-NOT: cb1 
+
+cbuffer BAR {
+  float bar;
+}
+cbuffer FOO {
+  float foo;
+}
+
+Texture2D tex0;
+SamplerState samp0;
+
+float main(float2 a : A) : SV_Target {
+  tex0.Sample(samp0, a+float2(bar,-bar));
+  return foo;
+}


### PR DESCRIPTION
Convergence annotations prevent unused instructions from being removed. Currently, resources used by of those instructions get added to the final DXIL since the instructions don't get removed until after the resources are finalized.

This change adds a DCE after removing convergence annotations and before generating final resources so no unused resources make it to the final DXIL.