### PR TITLE
Report error for mismatched types in initialization lists

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4632,7 +4632,7 @@ public:
 
     /// <summary>Whether the elements can be converted and the sequences have the same length.</summary>
     bool IsConvertibleAndEqualLength() const {
-      return LeftCount == RightCount;
+      return CanConvertElements && LeftCount == RightCount;
     }
 
     /// <summary>Whether the elements can be converted but the left-hand sequence is longer.</summary>
@@ -4642,6 +4642,10 @@ public:
 
     bool IsRightLonger() const {
       return RightCount > LeftCount;
+    }
+
+    bool IsEqualLength() const {
+      return LeftCount == RightCount;
     }
   };
 
@@ -6559,10 +6563,15 @@ void HLSLExternalSource::InitializeInitSequenceForHLSL(
         diagLocation = Entity.getDiagLoc();
       }
 
-      m_sema->Diag(diagLocation,
-        diag::err_vector_incorrect_num_initializers)
-        << (comparisonResult.RightCount < comparisonResult.LeftCount)
-        << comparisonResult.LeftCount << comparisonResult.RightCount;
+      if (comparisonResult.IsEqualLength()) {
+        m_sema->Diag(diagLocation, diag::err_hlsl_type_mismatch);
+      }
+      else {
+        m_sema->Diag(diagLocation,
+          diag::err_vector_incorrect_num_initializers)
+          << (comparisonResult.RightCount < comparisonResult.LeftCount)
+          << comparisonResult.LeftCount << comparisonResult.RightCount;
+      }
       SilenceSequenceDiagnostics(initSequence);
     }
   }

--- a/tools/clang/test/HLSL/matrix-assignments.hlsl
+++ b/tools/clang/test/HLSL/matrix-assignments.hlsl
@@ -144,6 +144,10 @@ float4 main() : SV_Target {
           `-FloatingLiteral <col:51> 'float' 1.500000e+00
   */
 
+// Initialization list with invalid types
+  Texture2D t;
+  int2x2 i22_list_type_mismatch = { 1, t, 3, 4 };             /* expected-error {{type mismatch}} fxc-pass {{}} */
+
   float2x3 val[2];
 
   fn1(val);

--- a/tools/clang/test/HLSL/vector-assignments.hlsl
+++ b/tools/clang/test/HLSL/vector-assignments.hlsl
@@ -44,6 +44,10 @@ float3 f3_f2_f = { f2_all, 0.1f };
 // fxc error: error X3017: 'f3_f2_f_f': initializer does not match type
 float3 f3_f2_f_f = { f2_all, 0.1f, 0.2f }; // expected-error {{too many elements in vector initialization (expected 3 elements, have 4)}} fxc-error {{X3017: 'f3_f2_f_f': initializer does not match type}}
 
+// Initialization list with invalid types.
+Texture2D t;
+float2 f2err = { t, 0.1f };                /* expected-error {{type mismatch}} fxc-pass {{}} */
+
 // Constructor with wrong element count fails.
 // fxc error: error X3014: incorrect number of arguments to numeric-type constructor
 float2 f2c = float2(); // expected-error {{'float2' cannot have an explicit empty initializer}} fxc-error {{X3014: incorrect number of arguments to numeric-type constructor}}


### PR DESCRIPTION
The compiler did not report an error when an element in initialization list could not be converted to a target element type. It went though the conversion checks but never reported an error on the clang level. The compiler then crashed in code gen. This commit fixes that.