### PR TITLE
Add Subobjects to compiler front end

### DIFF
--- a/include/dxc/DXIL/DxilSubobject.h
+++ b/include/dxc/DXIL/DxilSubobject.h
@@ -44,7 +44,8 @@ public:
 
 
   bool GetStateObjectConfig(uint32_t &Flags) const;
-  bool GetRootSignature(bool local, const void * &Data, uint32_t &Size) const;
+  bool GetRootSignature(bool local, const void * &Data, uint32_t &Size, 
+                        const char **pText = nullptr) const;
   bool GetSubobjectToExportsAssociation(llvm::StringRef &Subobject,
                                         const char * const * &Exports,
                                         uint32_t &NumExports) const;
@@ -73,6 +74,7 @@ private:
   struct RootSignature_t {
     uint32_t Size;
     const void *Data;
+    const char *Text; // can be null
   };
   struct SubobjectToExportsAssociation_t {
     const char *Subobject;
@@ -135,10 +137,11 @@ public:
   DxilSubobject &CreateRootSignature(llvm::StringRef Name,
                                      bool local,
                                      const void *Data,
-                                     uint32_t Size);
+                                     uint32_t Size,
+                                     llvm::StringRef *pText = nullptr);
   DxilSubobject &CreateSubobjectToExportsAssociation(
     llvm::StringRef Name,
-    llvm::StringRef Subobject, const char * const *Exports, uint32_t NumExports);
+    llvm::StringRef Subobject, llvm::StringRef *Exports, uint32_t NumExports);
   DxilSubobject &CreateRaytracingShaderConfig(
     llvm::StringRef Name,
     uint32_t MaxPayloadSizeInBytes,

--- a/lib/DxilContainer/DxilContainerReader.cpp
+++ b/lib/DxilContainer/DxilContainerReader.cpp
@@ -41,7 +41,7 @@ void LoadSubobjectsFromRDAT(DxilSubobjects &subobjects, RDAT::SubobjectTableRead
     }
     case DXIL::SubobjectKind::SubobjectToExportsAssociation: {
       uint32_t NumExports = reader.GetSubobjectToExportsAssociation_NumExports();
-      std::vector<const char*> Exports;
+      std::vector<StringRef> Exports;
       Exports.resize(NumExports);
       for (unsigned i = 0; i < NumExports; ++i) {
         Exports[i] = reader.GetSubobjectToExportsAssociation_Export(i);

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -315,6 +315,7 @@ void AddRecordTypeWithHandle(
 
 void AddRayFlags(clang::ASTContext& context);
 void AddHitKinds(clang::ASTContext& context);
+void AddStateObjectFlags(clang::ASTContext& context);
 
 /// <summary>Adds the implementation for std::is_equal.</summary>
 void AddStdIsEqualImplementation(clang::ASTContext& context, clang::Sema& sema);
@@ -387,6 +388,9 @@ clang::QualType GetHLSLInputPatchElementType(clang::QualType type);
 unsigned GetHLSLInputPatchCount(clang::QualType type);
 clang::QualType GetHLSLOutputPatchElementType(clang::QualType type);
 unsigned GetHLSLOutputPatchCount(clang::QualType type);
+
+bool IsHLSLSubobjectType(clang::QualType type);
+bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind);
 
 bool IsArrayConstantStringType(const clang::QualType type);
 bool IsPointerStringType(const clang::QualType type);

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7161,8 +7161,8 @@ def err_first_argument_to_cwsc_pdtor_call : Error<
 def err_second_argument_to_cwsc_not_pointer : Error<
   "second argument to __builtin_call_with_static_chain must be of pointer type">;
 
-def err_vector_incorrect_num_initializers : Error<
-  "%select{too many|too few}0 elements in vector initialization (expected %1 element%s1, have %2)">;
+def err_incorrect_num_initializers : Error<
+  "%select{too many|too few}0 elements in %select{vector|subobject}1 initialization (expected %2 element%s2, have %3)">;
 def err_altivec_empty_initializer : Error<"expected initializer">;
 
 def err_invalid_neon_type_code : Error<
@@ -7650,8 +7650,12 @@ def warn_hlsl_effect_object : Warning <
 def warn_hlsl_unused_call : Warning<
   "ignoring return value of function that only reads data">,
   InGroup<UnusedValue>;
-def err_hlsl_string_not_global : Error<
-   "string declaration may only appear in global scope">;
+def err_hlsl_object_not_global : Error<
+   "%select{subobject|string}0 declaration may only appear in global scope">;
+def err_hlsl_object_extern_not_supported : Error<
+   "%select{subobject|string}0 cannot be declared with 'extern' storage specifier">;
+def err_hlsl_object_missing_initializer : Error<
+   "%select{subobject|string}0 declaration needs to be initialized">;
 def err_hlsl_func_in_func_decl : Error<
    "function declaration is not allowed in function parameters">;
 def err_hlsl_unsupported_keyword_for_version : Error<

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -556,6 +556,14 @@ void hlsl::AddHitKinds(ASTContext& context) {
   AddConstUInt(context, curDC, StringRef("HIT_KIND_TRIANGLE_BACK_FACE"), (unsigned)DXIL::HitKind::TriangleBackFace);
 }
 
+/// <summary> Adds a constant integers for state object flags </summary>
+void hlsl::AddStateObjectFlags(ASTContext& context) {
+  DeclContext *curDC = context.getTranslationUnitDecl();
+ 
+  AddConstUInt(context, curDC, StringRef("STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS"), (unsigned)DXIL::StateObjectFlags::AllowLocalDependenciesOnExternalDefinitions);
+  AddConstUInt(context, curDC, StringRef("STATE_OBJECT_FLAGS_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS"), (unsigned)DXIL::StateObjectFlags::AllowExternalDependenciesOnLocalDefinitions);
+}
+
 static
 Expr* IntConstantAsBoolExpr(clang::Sema& sema, uint64_t value)
 {

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -501,6 +501,35 @@ bool IsHLSLResourceType(clang::QualType type) {
   return false;
 }
 
+bool IsHLSLSubobjectType(clang::QualType type) {
+  DXIL::SubobjectKind kind;
+  return GetHLSLSubobjectKind(type, kind);
+}
+
+bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind) {
+  type = type.getCanonicalType();
+  if (const RecordType *RT = type->getAs<RecordType>()) {
+    StringRef name = RT->getDecl()->getName();
+    switch (name.size()) {
+    case 17:
+      return name == "StateObjectConfig" ? (subobjectKind = DXIL::SubobjectKind::StateObjectConfig, true) : false;
+    case 18:
+      return name == "LocalRootSignature" ? (subobjectKind = DXIL::SubobjectKind::LocalRootSignature, true) : false;
+    case 19:
+      return name == "GlobalRootSignature" ? (subobjectKind = DXIL::SubobjectKind::GlobalRootSignature, true) : false;
+    case 29:
+      return name == "SubobjectToExportsAssociation" ? (subobjectKind = DXIL::SubobjectKind::SubobjectToExportsAssociation, true) : false;
+    case 22:
+      return name == "RaytracingShaderConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingShaderConfig, true) : false;
+    case 24:
+      return name == "RaytracingPipelineConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingPipelineConfig, true) : false;
+    case 8:
+      return name == "HitGroup" ? (subobjectKind = DXIL::SubobjectKind::HitGroup, true) : false;
+    }
+  }
+  return false;
+}
+
 QualType GetHLSLResourceResultType(QualType type) {
   type = type.getCanonicalType();
   const RecordType *RT = cast<RecordType>(type);

--- a/tools/clang/lib/AST/TypePrinter.cpp
+++ b/tools/clang/lib/AST/TypePrinter.cpp
@@ -152,13 +152,20 @@ void TypePrinter::print(const Type *T, Qualifiers Quals, raw_ostream &OS,
 
   // HLSL Change Starts
   // Print 'char *' as 'string' and 'const char *' as 'const string'
-  if (Policy.LangOpts.HLSL && T->isPointerType()) {
-    QualType Pointee = T->getPointeeType();
-    if (const BuiltinType* BIT = Pointee->getAs<BuiltinType>()) {
-      if (BIT->getKind() == BuiltinType::Char_S) {
+  if (Policy.LangOpts.HLSL) {
+    if (T->isPointerType()) {
+      QualType Pointee = T->getPointeeType();
+      if (Pointee->isSpecificBuiltinType(BuiltinType::Char_S)) {
         Quals = Pointee.getQualifiers();
         Quals.print(OS, Policy, /*appendSpaceIfNonEmpty=*/true);
         OS << "string";
+        return;
+      }
+    }
+    else if (T->isConstantArrayType()) {
+      const Type *pElemType = T->getArrayElementTypeNoTypeQual();
+      if (pElemType->isSpecificBuiltinType(BuiltinType::Char_S)) {
+        OS << "literal string";
         return;
       }
     }

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -55,6 +55,7 @@ public:
   virtual ~CGHLSLRuntime();
 
   virtual void addResource(Decl *D) = 0;
+  virtual void addSubobject(Decl *D) = 0;
   virtual void FinishCodeGen() = 0;
   virtual RValue EmitHLSLBuiltinCallExpr(CodeGenFunction &CGF,
                                          const FunctionDecl *FD,
@@ -117,11 +118,7 @@ public:
   virtual void AddHLSLFunctionInfo(llvm::Function *, const FunctionDecl *FD) = 0;
   virtual void EmitHLSLFunctionProlog(llvm::Function *, const FunctionDecl *FD) = 0;
 
-  virtual void AddGlobalStringDecl(const clang::VarDecl *D, llvm::GlobalVariable *GV) = 0;
-  virtual void AddGlobalStringConstant(llvm::GlobalVariable *GV) = 0;
-
-  virtual bool IsHlslObjectType(llvm::Type *Ty) = 0;
-
+  
   virtual void AddControlFlowHint(CodeGenFunction &CGF, const Stmt &S, llvm::TerminatorInst *TI, llvm::ArrayRef<const Attr *> Attrs) = 0;
 
   virtual void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D, llvm::Value *V) = 0;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -30,6 +30,7 @@
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
 #include "clang/Sema/SemaHLSL.h"
+#include "clang/Sema/SemaHLSL.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinAdapter.h"
@@ -187,6 +188,15 @@ enum ArBasicKind {
   AR_OBJECT_ACCELARATION_STRUCT,
   AR_OBJECT_USER_DEFINED_TYPE,
   AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES,
+
+  // subobjects
+  AR_OBJECT_STATE_OBJECT_CONFIG,
+  AR_OBJECT_GLOBAL_ROOT_SIGNATURE,
+  AR_OBJECT_LOCAL_ROOT_SIGNATURE,
+  AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC,
+  AR_OBJECT_RAYTRACING_SHADER_CONFIG,
+  AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
+  AR_OBJECT_HIT_GROUP,
 
   AR_BASIC_MAXIMUM_COUNT
 };
@@ -454,6 +464,16 @@ const UINT g_uBasicKindProps[] =
   LICOMPTYPE_ACCELERATION_STRUCT,   // AR_OBJECT_ACCELARATION_STRUCT
   LICOMPTYPE_USER_DEFINED_TYPE,      // AR_OBJECT_USER_DEFINED_TYPE
   0,      // AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES
+
+  // subobjects
+  0,      //AR_OBJECT_STATE_OBJECT_CONFIG,
+  0,      //AR_OBJECT_GLOBAL_ROOT_SIGNATURE,
+  0,      //AR_OBJECT_LOCAL_ROOT_SIGNATURE,
+  0,      //AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC,
+  0,      //AR_OBJECT_RAYTRACING_SHADER_CONFIG,
+  0,      //AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
+  0,      //AR_OBJECT_HIT_GROUP,
+    
   // AR_BASIC_MAXIMUM_COUNT
 };
 
@@ -1255,6 +1275,15 @@ const ArBasicKind g_ArBasicKindsAsTypes[] =
   AR_OBJECT_RAY_DESC,
   AR_OBJECT_ACCELARATION_STRUCT,
   AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES,
+
+  // subobjects
+  AR_OBJECT_STATE_OBJECT_CONFIG,
+  AR_OBJECT_GLOBAL_ROOT_SIGNATURE,
+  AR_OBJECT_LOCAL_ROOT_SIGNATURE,
+  AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC,
+  AR_OBJECT_RAYTRACING_SHADER_CONFIG,
+  AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
+  AR_OBJECT_HIT_GROUP,
 };
 
 // Count of template arguments for basic kind of objects that look like templates (one or more type arguments).
@@ -1325,6 +1354,14 @@ const uint8_t g_ArBasicKindsTemplateCount[] =
   0, // AR_OBJECT_RAY_DESC
   0, // AR_OBJECT_ACCELARATION_STRUCT
   0, // AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES
+
+  0, // AR_OBJECT_STATE_OBJECT_CONFIG,
+  0, // AR_OBJECT_GLOBAL_ROOT_SIGNATURE,
+  0, // AR_OBJECT_LOCAL_ROOT_SIGNATURE,
+  0, // AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC,
+  0, // AR_OBJECT_RAYTRACING_SHADER_CONFIG,
+  0, // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
+  0, // AR_OBJECT_HIT_GROUP,
 };
 
 C_ASSERT(_countof(g_ArBasicKindsAsTypes) == _countof(g_ArBasicKindsTemplateCount));
@@ -1405,6 +1442,14 @@ const SubscriptOperatorRecord g_ArBasicKindsSubscripts[] =
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAY_DESC
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_ACCELARATION_STRUCT
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES
+
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_STATE_OBJECT_CONFIG,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_GLOBAL_ROOT_SIGNATURE,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_LOCAL_ROOT_SIGNATURE,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAYTRACING_SHADER_CONFIG,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_HIT_GROUP,
 };
 
 C_ASSERT(_countof(g_ArBasicKindsAsTypes) == _countof(g_ArBasicKindsSubscripts));
@@ -1507,7 +1552,16 @@ const char* g_ArBasicTypeNames[] =
   "RayDesc",
   "RaytracingAccelerationStructure",
   "user defined type",
-  "BuiltInTriangleIntersectionAttributes"
+  "BuiltInTriangleIntersectionAttributes",
+
+  // subobjects
+  "StateObjectConfig",
+  "GlobalRootSignature",
+  "LocalRootSignature",
+  "SubobjectToExportsAssociation", 
+  "RaytracingShaderConfig",
+  "RaytracingPipelineConfig",
+  "HitGroup",
 };
 
 C_ASSERT(_countof(g_ArBasicTypeNames) == AR_BASIC_MAXIMUM_COUNT);
@@ -2327,9 +2381,8 @@ static void AddHLSLSubscriptAttr(Decl *D, ASTContext &context, HLSubscriptOpcode
   D->addAttr(HLSLIntrinsicAttr::CreateImplicit(context, group, "", static_cast<unsigned>(opcode)));
 }
 
-static void CreateSimpleField(clang::ASTContext &context,
-                              CXXRecordDecl *recordDecl, StringRef Name,
-                              QualType Ty) {
+static void CreateSimpleField(clang::ASTContext &context, CXXRecordDecl *recordDecl, StringRef Name,
+                              QualType Ty, AccessSpecifier access = AccessSpecifier::AS_public) {
   IdentifierInfo &fieldId =
       context.Idents.get(Name, tok::TokenKind::identifier);
   TypeSourceInfo *filedTypeSource = context.getTrivialTypeSourceInfo(Ty, NoLoc);
@@ -2339,7 +2392,7 @@ static void CreateSimpleField(clang::ASTContext &context,
   FieldDecl *fieldDecl =
       FieldDecl::Create(context, recordDecl, NoLoc, NoLoc, &fieldId, Ty,
                         filedTypeSource, nullptr, MutableFalse, initStyle);
-  fieldDecl->setAccess(AccessSpecifier::AS_public);
+  fieldDecl->setAccess(access);
   fieldDecl->setImplicit(true);
 
   recordDecl->addDecl(fieldDecl);
@@ -2398,6 +2451,97 @@ static CXXRecordDecl *AddBuiltInTriangleIntersectionAttributes(ASTContext& conte
     attributesDecl->setImplicit(true);
     curDC->addDecl(attributesDecl);
     return attributesDecl;
+}
+
+//
+// Subobjects
+
+static CXXRecordDecl *StartSubobjectDecl(ASTContext& context, const char *name) {
+  IdentifierInfo &id = context.Idents.get(StringRef(name), tok::TokenKind::identifier);
+  CXXRecordDecl *decl = CXXRecordDecl::Create( context, TagTypeKind::TTK_Struct, 
+    context.getTranslationUnitDecl(), NoLoc, NoLoc, &id, nullptr, DelayTypeCreationTrue);
+  decl->startDefinition();
+  return decl;
+}
+
+void FinishSubobjectDecl(ASTContext& context, CXXRecordDecl *decl) {
+  decl->completeDefinition();
+  context.getTranslationUnitDecl()->addDecl(decl);
+  decl->setImplicit(true);
+}
+
+// struct StateObjectConfig 
+// {
+//   uint32_t Flags;
+// };
+static CXXRecordDecl *CreateSubobjectStateObjectConfig(ASTContext& context) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, "StateObjectConfig");
+  CreateSimpleField(context, decl, "Flags", context.UnsignedIntTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
+// struct GlobalRootSignature
+// {
+//   string signature;
+// };
+static CXXRecordDecl *CreateSubobjectRootSignature(ASTContext& context, bool global) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, global ? "GlobalRootSignature" : "LocalRootSignature");
+  CreateSimpleField(context, decl, "Data", context.HLSLStringTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
+// struct SubobjectToExportsAssociation 
+// {
+//   string Subobject;
+//   string Exports;
+// };
+static CXXRecordDecl *CreateSubobjectSubobjectToExportsAssoc(ASTContext& context) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, "SubobjectToExportsAssociation");
+  CreateSimpleField(context, decl, "Subobject", context.HLSLStringTy, AccessSpecifier::AS_private);
+  CreateSimpleField(context, decl, "Exports",   context.HLSLStringTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
+// struct RaytracingShaderConfig 
+// {
+//   uint32_t MaxPayloadSizeInBytes;
+//   uint32_t MaxAttributeSizeInBytes;
+// };
+static CXXRecordDecl *CreateSubobjectRaytracingShaderConfig(ASTContext& context) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, "RaytracingShaderConfig");
+  CreateSimpleField(context, decl, "MaxPayloadSizeInBytes",   context.UnsignedIntTy, AccessSpecifier::AS_private);
+  CreateSimpleField(context, decl, "MaxAttributeSizeInBytes", context.UnsignedIntTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
+// struct RaytracingPipelineConfig 
+// {
+//   uint32_t MaxTraceRecursionDepth;
+// };
+static CXXRecordDecl *CreateSubobjectRaytracingPipelineConfig(ASTContext& context) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, "RaytracingPipelineConfig"); 
+  CreateSimpleField(context, decl, "MaxTraceRecursionDepth", context.UnsignedIntTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
+// struct HitGroup
+// {
+//   string intersection;
+//   string anyhit;
+//   string closesthit;
+// };
+static CXXRecordDecl *CreateSubobjectHitGroup(ASTContext& context) {
+  CXXRecordDecl *decl = StartSubobjectDecl(context, "HitGroup");
+  CreateSimpleField(context, decl, "Intersection", context.HLSLStringTy, AccessSpecifier::AS_private);
+  CreateSimpleField(context, decl, "AnyHit",       context.HLSLStringTy, AccessSpecifier::AS_private);
+  CreateSimpleField(context, decl, "ClosestHit",   context.HLSLStringTy, AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
 }
 
 //
@@ -3024,8 +3168,33 @@ private:
       } else if (kind == AR_OBJECT_TRIANGLE_INTERSECTION_ATTRIBUTES) {
         QualType float2Type = LookupVectorType(HLSLScalarType::HLSLScalarType_float, 2);
         recordDecl = AddBuiltInTriangleIntersectionAttributes(*m_context, float2Type);
-      } else
-      if (templateArgCount == 0)
+      } else if (IsSubobjectBasicKind(kind)) {
+        switch (kind) {
+        case AR_OBJECT_STATE_OBJECT_CONFIG:
+          recordDecl = CreateSubobjectStateObjectConfig(*m_context);
+          break;
+        case AR_OBJECT_GLOBAL_ROOT_SIGNATURE:
+          recordDecl = CreateSubobjectRootSignature(*m_context, true);
+          break;
+        case AR_OBJECT_LOCAL_ROOT_SIGNATURE:
+          recordDecl = CreateSubobjectRootSignature(*m_context, false);
+          break;
+        case AR_OBJECT_SUBOBJECT_TO_EXPORTS_ASSOC:
+          recordDecl = CreateSubobjectSubobjectToExportsAssoc(*m_context);
+          break;
+          break;
+        case AR_OBJECT_RAYTRACING_SHADER_CONFIG:
+          recordDecl = CreateSubobjectRaytracingShaderConfig(*m_context);
+          break;
+        case AR_OBJECT_RAYTRACING_PIPELINE_CONFIG:
+          recordDecl = CreateSubobjectRaytracingPipelineConfig(*m_context);
+          break;
+        case AR_OBJECT_HIT_GROUP:
+          recordDecl = CreateSubobjectHitGroup(*m_context);
+          break;
+        }
+      }
+      else if (templateArgCount == 0)
       {
         AddRecordTypeWithHandle(*m_context, &recordDecl, typeName);
         DXASSERT(recordDecl != nullptr, "AddRecordTypeWithHandle failed to return the object declaration");
@@ -3214,6 +3383,14 @@ public:
     }
     DXASSERT_NOMSG(m_hlslStringTypedef != nullptr);
     return m_hlslStringTypedef;
+  }
+
+  static bool IsSubobjectBasicKind(ArBasicKind kind) {
+    return kind >= AR_OBJECT_STATE_OBJECT_CONFIG && kind <= AR_OBJECT_HIT_GROUP;
+  }
+
+  bool IsSubobjectType(QualType type) {
+    return IsSubobjectBasicKind(GetTypeElementKind(type));
   }
 
   void WarnMinPrecision(HLSLScalarType type, SourceLocation loc) {
@@ -3943,6 +4120,7 @@ public:
     // Initializing built in integers for ray tracing
     AddRayFlags(*m_context);
     AddHitKinds(*m_context);
+    AddStateObjectFlags(*m_context);
 
     return true;
   }
@@ -6568,8 +6746,9 @@ void HLSLExternalSource::InitializeInitSequenceForHLSL(
       }
       else {
         m_sema->Diag(diagLocation,
-          diag::err_vector_incorrect_num_initializers)
+          diag::err_incorrect_num_initializers)
           << (comparisonResult.RightCount < comparisonResult.LeftCount)
+          << IsSubobjectType(destType)
           << comparisonResult.LeftCount << comparisonResult.RightCount;
       }
       SilenceSequenceDiagnostics(initSequence);
@@ -10066,10 +10245,22 @@ bool FlattenedTypeIterator::pushTrackerForType(QualType type, MultiExprArg::iter
       GetHLSLVecSize(type), nullptr));
     return true;
   case ArTypeObjectKind::AR_TOBJ_OBJECT: {
-    // Object have no sub-types.
-    m_typeTrackers.push_back(FlattenedTypeIterator::FlattenedTypeTracker(
+    if (m_source.IsSubobjectType(type)) {
+      // subobjects are initialized with initialization lists
+      recordType = type->getAsStructureType();
+      fi = recordType->getDecl()->field_begin();
+      fe = recordType->getDecl()->field_end();
+
+      m_typeTrackers.push_back(
+          FlattenedTypeIterator::FlattenedTypeTracker(type, fi, fe));
+      return true;
+    }
+    else {
+      // Object have no sub-types.
+      m_typeTrackers.push_back(FlattenedTypeIterator::FlattenedTypeTracker(
         type.getCanonicalType(), 1, expression));
-    return true;
+      return true;
+    }
   }
   case ArTypeObjectKind::AR_TOBJ_STRING: {
     // Strings have no sub-types.
@@ -11193,6 +11384,7 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
   // case of a function (or method).
   QualType qt = TInfo->getType();
   const Type* pType = qt.getTypePtrOrNull();
+  HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(this);
 
   // Early checks - these are not simple attribution errors, but constructs that
   // are fundamentally unsupported,
@@ -11214,14 +11406,18 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
     }
   }
 
-  // diagnose string declarations
-  if (hlsl::IsStringType(qt) && !D.isInvalidType()) {
+  // String and subobject declarations are supported only as top level global variables.
+  // Const and static modifiers are implied - add them if missing.
+  if ((hlsl::IsStringType(qt) || hlslSource->IsSubobjectType(qt)) && !D.isInvalidType()) {
     // string are supported only as top level global variables
     if (!DC->isTranslationUnit()) {
-      Diag(D.getLocStart(), diag::err_hlsl_string_not_global);
+      Diag(D.getLocStart(), diag::err_hlsl_object_not_global) << (int)hlsl::IsStringType(qt);
       result = false;
     }
-    // const and static modifiers are implied - add them if missing
+    if (isExtern) {
+      Diag(D.getLocStart(), diag::err_hlsl_object_extern_not_supported) << (int)hlsl::IsStringType(qt);
+      result = false;
+    }
     const char *PrevSpec = nullptr;
     unsigned DiagID = 0;
     if (!isStatic) {
@@ -11269,7 +11465,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
       return false;
     }
     // Add methods if not ready.
-    HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(this);
     hlslSource->AddHLSLObjectMethodsIfNotReady(qt);
   } else if (qt->isArrayType()) {
     QualType eltQt(qt->getArrayElementTypeNoTypeQual(), 0);
@@ -11278,7 +11473,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
 
     if (hlsl::IsObjectType(this, eltQt, &bDeprecatedEffectObject)) {
       // Add methods if not ready.
-      HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(this);
       hlslSource->AddHLSLObjectMethodsIfNotReady(eltQt);
     }
   }
@@ -11315,7 +11509,6 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC,
     }
   }
 
-  HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(this);
   ArBasicKind basicKind = hlslSource->GetTypeElementKind(qt);
 
   if (hasSignSpec) {

--- a/tools/clang/lib/Sema/SemaInit.cpp
+++ b/tools/clang/lib/Sema/SemaInit.cpp
@@ -1507,10 +1507,12 @@ void InitListChecker::CheckVectorType(const InitializedEntity &Entity,
 
   // OpenCL requires all elements to be initialized.
   if (numEltsInit != maxElements && !extraElementsAllowed) {  // HLSL Change
-    if (!VerifyOnly)
+    if (!VerifyOnly) {
+      static const unsigned selectVectorIdx = 0;
       SemaRef.Diag(IList->getLocStart(),
-                   diag::err_vector_incorrect_num_initializers)
-        << (numEltsInit < maxElements) << maxElements << numEltsInit;
+                   diag::err_incorrect_num_initializers)
+        << (numEltsInit < maxElements) << selectVectorIdx << maxElements << numEltsInit;
+      }
     hadError = true;
   }
 }

--- a/tools/clang/test/HLSL/scalar-assignments-exact-precision.hlsl
+++ b/tools/clang/test/HLSL/scalar-assignments-exact-precision.hlsl
@@ -12,7 +12,7 @@ snorm bool sb;         // expected-error {{snorm and unorm qualifier can only be
 
 // Used to generate this undesirable error:
 // cannot initialize a variable of type 'min16float' (aka 'half') with an lvalue of type 'const char [4]'
-min16float foobar = "foo"; // expected-error {{cannot initialize a variable of type 'min16float' with an lvalue of type 'const char [4]'}} expected-warning {{min16float is promoted to float16_t}} fxc-error {{X3017: cannot implicitly convert from 'const string' to 'min16float'}}
+min16float foobar = "foo"; // expected-error {{cannot initialize a variable of type 'min16float' with an lvalue of type 'literal string'}} expected-warning {{min16float is promoted to float16_t}} fxc-error {{X3017: cannot implicitly convert from 'const string' to 'min16float'}}
 
 /*
 (let (

--- a/tools/clang/test/HLSL/scalar-assignments.hlsl
+++ b/tools/clang/test/HLSL/scalar-assignments.hlsl
@@ -12,7 +12,7 @@ snorm bool sb;         // expected-error {{snorm and unorm qualifier can only be
 
 // Used to generate this undesirable error:
 // cannot initialize a variable of type 'min16float' (aka 'half') with an lvalue of type 'const char [4]'
-min16float foobar = "foo"; // expected-error {{cannot initialize a variable of type 'min16float' with an lvalue of type 'const char [4]'}} fxc-error {{X3017: cannot implicitly convert from 'const string' to 'min16float'}}
+min16float foobar = "foo"; // expected-error {{cannot initialize a variable of type 'min16float' with an lvalue of type 'literal string'}} fxc-error {{X3017: cannot implicitly convert from 'const string' to 'min16float'}}
 
 /*
 (let (

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -650,14 +650,17 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
       bLocalRS = true;
       __fallthrough;
     case DXIL::SubobjectKind::GlobalRootSignature: {
+      const char *Text = nullptr;
       const void *Data = nullptr;
       uint32_t Size = 0;
-      if (!obj.GetRootSignature(bLocalRS, Data, Size)) {
+      if (!obj.GetRootSignature(bLocalRS, Data, Size, &Text)) {
         OS << "<error getting subobject>";
         break;
       }
-      // TODO: Deserialize root signature?
       OS << "<" << Size << " bytes>";
+      if (Text && Text[0]) {
+        OS << ", \"" << Text << "\"";
+      }
       break;
     }
     case DXIL::SubobjectKind::SubobjectToExportsAssociation: {
@@ -671,7 +674,7 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
       OS << "\"" << Subobject << "\", { ";
       if (Exports) {
         for (unsigned i = 0; i < NumExports; ++i) {
-          OS << "\"" << Exports[i] << "\"" << (i ? ", " : "");
+          OS << (i ? ", " : "") << "\"" << Exports[i] << "\"";
         }
       }
       OS << " } ";
@@ -714,6 +717,7 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
     }
     OS << " };\n";
   }
+  OS << comment << "\n";
 }
 
 void PrintStructLayout(StructType *ST, DxilTypeSystem &typeSys,


### PR DESCRIPTION
- Add HLSL subobject classes to clang and enable their initialization via initialization lists
- Translate declared subobjects and add them to DXIL module
- Fix bugs in subobject metadata serialization and disasm
- Preserve original input string in root signature subobject
- Remove unused IsHlslObjectType method from CGHLSLRuntime
- Remove unnecessary collection of global strings in CGHLSLRuntime
- Change type printer to report 'literal string' for constant char arrays

Subobject tests coming soon.