### PR TITLE
Fix lower memcpy for nested struct with single element

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -4142,7 +4142,6 @@ bool SROA_Helper::LowerMemcpy(Value *V, DxilFieldAnnotation *annotation,
         // Only remove one level bitcast generated from inline.
         if (BitCastOperator *BC = dyn_cast<BitCastOperator>(Dest))
           Dest = BC->getOperand(0);
-
         // For GEP, the ptr could have other GEP read/write.
         // Only scan one GEP is not enough.
         // And resource ptr should not be replaced.

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1556,7 +1556,7 @@ bool SROA_HLSL::performScalarRepl(Function &F, DxilTypeSystem &typeSys) {
     auto sz0 = DL.getTypeAllocSize(a0ty);
     auto sz1 = DL.getTypeAllocSize(a1ty);
     if (sz0 == sz1 && (isUnitSzStruct0 || isUnitSzStruct1))
-      return !(getNestedLevelInStruct(a0ty) > getNestedLevelInStruct(a1ty));;
+      return getNestedLevelInStruct(a0ty) < getNestedLevelInStruct(a1ty);
     return sz0 < sz1;
   };
   std::priority_queue<AllocaInst *, std::vector<AllocaInst *>,

--- a/tools/clang/test/CodeGenHLSL/quick-test/lower-memcpy-gep-test.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/lower-memcpy-gep-test.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc /Tps_6_2 /Eps_main /Zpc /O3 /Zi > %s | FileCheck %s
+// CHECK: define void @main()
+// CHECK: entry
+
+struct MyStruct1 
+{     
+    float var [ 1 ] ; 
+} ; 
+
+struct MyStruct2 
+{ 
+    MyStruct1 internal [ 1 ] ; 
+} ; 
+
+void ps_main ( ) 
+{ 
+    MyStruct1 mystruct1 [ 1 ] ;
+    MyStruct2 mystruct2 ;
+    mystruct2.internal = mystruct1 ;
+} 


### PR DESCRIPTION
Allow lower memcpy if gep is only used for memcpy's dest address