### PR TITLE
Fixed failure on including empty files, and added test.

### DIFF
--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -589,8 +589,9 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IDxcBlobEncoding **pBlobEncoding) thro
     codePage = DxcCodePageFromBytes((const char *)pBlob->GetBufferPointer(), blobLen);
   }
 
-  if (codePage == CP_UTF8) {
+  if (codePage == CP_UTF8 || blobLen == 0) {
     // Reuse the underlying blob but create an object with the encoding known.
+    // Empty blobs are encoding-agnostic, so we can consider them UTF-8 and avoid useless conversion.
     InternalDxcBlobEncoding* internalEncoding;
     hr = InternalDxcBlobEncoding::CreateFromBlob(pBlob, DxcGetThreadMallocNoRef(), true, CP_UTF8, &internalEncoding);
     if (SUCCEEDED(hr)) {

--- a/tools/clang/unittests/HLSL/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/DxcTestUtils.cpp
@@ -248,12 +248,22 @@ void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal,
                                                 ppBlob));
 }
 
-void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val,
-                _Outptr_ IDxcBlobEncoding **ppBlob) {
+void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val,
+                           UINT32 codePage, _Outptr_ IDxcBlobEncoding **ppBlob) {
   CComPtr<IDxcLibrary> library;
   IFT(dllSupport.CreateInstance(CLSID_DxcLibrary, &library));
-  IFT(library->CreateBlobWithEncodingOnHeapCopy(val.data(), val.size(), CP_UTF8,
-                                                ppBlob));
+  IFT(library->CreateBlobWithEncodingOnHeapCopy(val.data(), val.size(),
+                                                codePage, ppBlob));
+}
+
+void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val,
+                           UINT32 codePage, _Outptr_ IDxcBlob **ppBlob) {
+  MultiByteStringToBlob(dllSupport, val, codePage, (IDxcBlobEncoding **)ppBlob);
+}
+
+void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val,
+                _Outptr_ IDxcBlobEncoding **ppBlob) {
+  MultiByteStringToBlob(dllSupport, val, CP_UTF8, ppBlob);
 }
 
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val,

--- a/tools/clang/unittests/HLSL/DxcTestUtils.h
+++ b/tools/clang/unittests/HLSL/DxcTestUtils.h
@@ -118,6 +118,8 @@ bool CheckNotMsgs(const LPCSTR pText, size_t TextCount, const LPCSTR *pErrorMsgs
 void GetDxilPart(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgram, IDxcBlob **pDxilPart);
 std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgram);
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
+void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
+void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);


### PR DESCRIPTION
- Prevent needless conversion of empty file to UTF-16, failing due to unexpected file size.
- Add validating test.

Addresses #861 