### PR TITLE
Fix remaining HLModule/DxilModule dependencies from llvm::Module, etc.

### DIFF
--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -690,23 +690,24 @@ public:
 /// @}
 
   // HLSL Change start
-  typedef void (*RemoveFunctionCallback)(llvm::Module*, llvm::Function*);
-  RemoveFunctionCallback   pHLModuleRemoveFunction = nullptr;
-  RemoveFunctionCallback pDxilModuleRemoveFunction = nullptr;
-  void RemoveFunctionHook(llvm::Function* F) {
-    if   (pHLModuleRemoveFunction)   (*pHLModuleRemoveFunction)(this, F);
-    if (pDxilModuleRemoveFunction) (*pDxilModuleRemoveFunction)(this, F);
+  typedef void (*RemoveGlobalCallback)(llvm::Module*, llvm::GlobalObject*);
+  typedef void(*ResetModuleCallback)(llvm::Module*);
+  RemoveGlobalCallback pfnRemoveGlobal = nullptr;
+  void CallRemoveGlobalHook(llvm::GlobalObject* G) {
+    if (pfnRemoveGlobal) (*pfnRemoveGlobal)(this, G);
   }
   bool HasHLModule() const { return TheHLModule != nullptr; }
   void SetHLModule(hlsl::HLModule *pValue) { TheHLModule = pValue; }
   hlsl::HLModule &GetHLModule() { return *TheHLModule; }
   hlsl::HLModule &GetOrCreateHLModule(bool skipInit = false);
-  void ResetHLModule();
+  ResetModuleCallback pfnResetHLModule = nullptr;
+  void ResetHLModule() { if (pfnResetHLModule) (*pfnResetHLModule)(this); }
   bool HasDxilModule() const { return TheDxilModule != nullptr; }
   void SetDxilModule(hlsl::DxilModule *pValue) { TheDxilModule = pValue; }
   hlsl::DxilModule &GetDxilModule() const { return *TheDxilModule; }
   hlsl::DxilModule &GetOrCreateDxilModule(bool skipInit = false);
-  void ResetDxilModule();
+  ResetModuleCallback pfnResetDxilModule = nullptr;
+  void ResetDxilModule() { if (pfnResetDxilModule) (*pfnResetDxilModule)(this); }
   // HLSL Change end
 };
 

--- a/lib/IR/Function.cpp
+++ b/lib/IR/Function.cpp
@@ -235,12 +235,12 @@ Type *Function::getReturnType() const {
 }
 
 void Function::removeFromParent() {
-  getParent()->RemoveFunctionHook(this); // HLSL Change
+  getParent()->CallRemoveGlobalHook(this); // HLSL Change
   getParent()->getFunctionList().remove(this);
 }
 
 void Function::eraseFromParent() {
-  getParent()->RemoveFunctionHook(this); // HLSL Change
+  getParent()->CallRemoveGlobalHook(this); // HLSL Change
   getParent()->getFunctionList().erase(this);
 }
 

--- a/lib/IR/Globals.cpp
+++ b/lib/IR/Globals.cpp
@@ -19,7 +19,6 @@
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Module.h"
-#include "dxc/HLSL/HLModule.h" // HLSL Change
 #include "llvm/IR/Operator.h"
 #include "llvm/Support/ErrorHandling.h"
 using namespace llvm;
@@ -189,12 +188,12 @@ void GlobalVariable::setParent(Module *parent) {
 }
 
 void GlobalVariable::removeFromParent() {
-  if (getParent()->HasHLModule()) getParent()->GetHLModule().RemoveGlobal(this);
+  getParent()->CallRemoveGlobalHook(this);  // HLSL Change
   getParent()->getGlobalList().remove(this);
 }
 
 void GlobalVariable::eraseFromParent() {
-  if (getParent()->HasHLModule()) getParent()->GetHLModule().RemoveGlobal(this);
+  getParent()->CallRemoveGlobalHook(this);  // HLSL Change
   getParent()->getGlobalList().erase(this);
 }
 


### PR DESCRIPTION
- Use one callback for global removal - Function and GlobalValue use this
- Share callback for HLModule and DxilModule, transfer is handled by
  setting callback on construction and checking pointer before clearing