### PR TITLE
Remove unsupported /O4 option from help text.

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -96,8 +96,6 @@ def O2 : Flag<["-", "/"], "O2">, Group<hlsloptz_Group>, Flags<[CoreOption]>,
     HelpText<"Optimization Level 2">;
 def O3 : Flag<["-", "/"], "O3">, Group<hlsloptz_Group>, Flags<[CoreOption]>,
     HelpText<"Optimization Level 3 (Default)">;
-def O4 : Flag<["-", "/"], "O4">, Group<hlsloptz_Group>, Flags<[CoreOption]>,
-    HelpText<"Optimization Level 4">;
 def Odump : Flag<["-", "/"], "Odump">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
     HelpText<"Print the optimizer commands.">;
 def Qunused_arguments : Flag<["-"], "Qunused-arguments">, Group<hlslcore_Group>, Flags<[CoreOption]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -696,7 +696,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       errors << "-Oconfig should not be specified more than once";
       return 1;
     }
-    if (Args.getLastArg(OPT_O0, OPT_O1, OPT_O2, OPT_O3, OPT_O4)) {
+    if (Args.getLastArg(OPT_O0, OPT_O1, OPT_O2, OPT_O3)) {
       errors << "-Oconfig should not be used together with -O";
       return 1;
     }

--- a/tools/clang/test/CodeGenHLSL/quick-test/MinimalTraverseShaderLib-pp.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/MinimalTraverseShaderLib-pp.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_3 -Zi -HV 2017 -O4 -Zpr -default-linkage external %s | FileCheck %s
+// RUN: %dxc -T lib_6_3 -Zi -HV 2017 -O3 -Zpr -default-linkage external %s | FileCheck %s
 
 // CHECK: define void @"\01?Fallback_TraceRay
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.with-O4.cl.oconfig.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.with-O4.cl.oconfig.hlsl
@@ -1,5 +1,0 @@
-// Run: %dxc -T ps_6_0 -E main -O4 -Oconfig=--loop-unroll
-
-void main() {}
-
-// CHECK: -Oconfig should not be used together with -O

--- a/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSPIRVTest.cpp
@@ -1265,9 +1265,6 @@ TEST_F(FileTest, SpirvOptOconfigAndO2) {
 TEST_F(FileTest, SpirvOptOconfigAndO3) {
   runFileTest("spirv.opt.with-O3.cl.oconfig.hlsl", Expect::Failure);
 }
-TEST_F(FileTest, SpirvOptOconfigAndO4) {
-  runFileTest("spirv.opt.with-O4.cl.oconfig.hlsl", Expect::Failure);
-}
 TEST_F(FileTest, SpirvOptOconfigInvalidFlag) {
   runFileTest("spirv.opt.invalid-flag.cl.oconfig.hlsl", Expect::Failure);
 }


### PR DESCRIPTION
This was a merely cosmetic issue, /O4 is unrecognized and ignored by the compiler.

Fixes #661