### PR TITLE
Added support for custom include paths when compiling with /P

### DIFF
--- a/tools/clang/tools/dxc/dxc.cpp
+++ b/tools/clang/tools/dxc/dxc.cpp
@@ -873,6 +873,14 @@ void DxcContext::Preprocess() {
   if (m_Opts.LegacyMacroExpansion)
     args.push_back(L"-flegacy-macro-expansion");
 
+  std::vector<std::wstring> includePath;
+  for (const llvm::opt::Arg *A : m_Opts.Args.filtered(hlsl::options::OPT_I))
+    includePath.emplace_back(Unicode::UTF8ToUTF16StringOrThrow(A->getValue()));
+  for (const std::wstring &directory : includePath) {
+    args.emplace_back(L"-I");
+    args.emplace_back(directory.c_str()); // The strings are kept alive in the includePath vector
+  }
+
   ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
   IFT(CreateInstance(CLSID_DxcCompiler, &pCompiler));
   IFT(pCompiler->Preprocess(pSource, StringRefUtf16(m_Opts.InputFile), args.data(), args.size(), m_Opts.Defines.data(), m_Opts.Defines.size(), pIncludeHandler, &pPreprocessResult));

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -602,6 +602,13 @@ if %errorlevel% neq 0 (
   exit /b 1
 )
 
+dxc.exe -P include-main.hlsl.pp -I inc subfolder\include-main.hlsl >nul
+if %errorlevel% neq 0 (
+  echo Failed to preprocess subfolder\include-main.hlsl
+  call :cleanup 2>nul
+  exit /b 1
+)
+
 rem SPIR-V Change Starts
 echo Smoke test for SPIR-V CodeGen ...
 set spirv_smoke_success=0
@@ -649,6 +656,7 @@ del %CD%\smoke.opt.ll
 del %CD%\smoke.opt.prn.txt
 del %CD%\smoke.rebuilt-container.cso
 del %CD%\smoke.rebuilt-container2.cso
+del %CD%\include-main.hlsl.pp
 rem SPIR-V Change Starts
 del %CD%\smoke.spirv.log
 rem SPIR-V Change Ends


### PR DESCRIPTION
The include paths were not piped as preprocessor command args.

Fixes #1636