### PR TITLE
Fixed [unroll] being interpreted as [unroll(1)].

### DIFF
--- a/tools/clang/lib/CodeGen/CGLoopInfo.h
+++ b/tools/clang/lib/CodeGen/CGLoopInfo.h
@@ -52,9 +52,12 @@ struct LoopAttributes {
   unsigned VectorizerUnroll;
 
   // HLSL Change Begins.
-  /// \brief hlsl [loop] attribute
-  bool     HlslLoop;
-  /// \brief hlsl [unroll] attribute
+  /// \brief hlsl loop unrolling policy based on [loop] and [unroll] attributes
+  enum HlslUnrollPolicyEnum { HlslAllowUnroll, HlslDisableUnroll, HlslForceUnroll };
+
+  /// \brief hlsl unrolling policy
+  HlslUnrollPolicyEnum HlslUnrollPolicy;
+  /// \brief argument to hlsl [unroll] attribute, 0 = full unroll
   unsigned HlslUnrollCount;
   // HLSL Change Ends.
 };
@@ -130,9 +133,14 @@ public:
 
   // HLSL Change Begins
   /// \brief Set the hlsl unroll count for the next loop pushed.
-  void setHlslUnrollCount(unsigned U) { StagedAttrs.HlslUnrollCount = U; }
+  void setHlslUnroll(unsigned U) {
+    StagedAttrs.HlslUnrollPolicy = LoopAttributes::HlslForceUnroll;
+    StagedAttrs.HlslUnrollCount = U;
+  }
   /// \brief Set the hlsl loop for the next loop pushed.
-  void setHlslLoop(bool Enable = true) { StagedAttrs.HlslLoop = Enable; }
+  void setHlslLoop() {
+    StagedAttrs.HlslUnrollPolicy = LoopAttributes::HlslDisableUnroll;
+  }
   // HLSL Chagne Ends
 
 private:

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10427,8 +10427,8 @@ static Attr* HandleClipPlanes(Sema& S, const AttributeList &A)
 static Attr* HandleUnrollAttribute(Sema& S, const AttributeList &Attr)
 {
   int argValue = ValidateAttributeIntArg(S, Attr);
-  // Default value is 1.
-  if (Attr.getNumArgs() == 0) argValue = 1;
+  // Default value is 0 (full unroll).
+  if (Attr.getNumArgs() == 0) argValue = 0;
   return ::new (S.Context) HLSLUnrollAttr(Attr.getRange(), S.Context,
     argValue, Attr.getAttributeSpellingListIndex());
 }
@@ -12045,7 +12045,10 @@ void hlsl::CustomPrintHLSLAttr(const clang::Attr *A, llvm::raw_ostream &Out, con
     Attr * noconst = const_cast<Attr*>(A);
     HLSLUnrollAttr *ACast = static_cast<HLSLUnrollAttr*>(noconst);
     Indent(Indentation, Out);
-    Out << "[unroll(" << ACast->getCount() << ")]\n";
+    if (ACast->getCount() == 0)
+      Out << "[unroll]\n";
+    else
+      Out << "[unroll(" << ACast->getCount() << ")]\n";
     break;
   }
   

--- a/tools/clang/test/HLSL/rewriter/attributes_noerr.hlsl
+++ b/tools/clang/test/HLSL/rewriter/attributes_noerr.hlsl
@@ -19,6 +19,33 @@
 //  return 0;
 //}
 
+int unroll_noarg() {
+  int result = 2;
+  
+  [unroll]
+  for (int i = 0; i < 100; i++) result++;
+  
+  return result;
+}
+
+int unroll_zero() {
+  int result = 2;
+  
+  [unroll(0)]
+  for (int i = 0; i < 100; i++) result++;
+  
+  return result;
+}
+
+int unroll_one() {
+  int result = 2;
+  
+  [unroll(1)]
+  for (int i = 0; i < 100; i++) result++;
+  
+  return result;
+}
+
 int short_unroll() {
   int result = 2;
   

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/attributes_gold.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/attributes_gold.hlsl
@@ -1,4 +1,31 @@
 // Rewrite unchanged result:
+int unroll_noarg() {
+  int result = 2;
+  [unroll]
+  for (int i = 0; i < 100; i++) 
+    result++;
+  return result;
+}
+
+
+int unroll_zero() {
+  int result = 2;
+  [unroll]
+  for (int i = 0; i < 100; i++) 
+    result++;
+  return result;
+}
+
+
+int unroll_one() {
+  int result = 2;
+  [unroll(1)]
+  for (int i = 0; i < 100; i++) 
+    result++;
+  return result;
+}
+
+
 int short_unroll() {
   int result = 2;
   [unroll(2)]


### PR DESCRIPTION
DXC internally used an unroll count of zero to represent no unrolling, so it encoded `[unroll]` as an unroll count of 1 to not lose the information. However, in HLSL the former represents full unrolling while the latter represents generating only the first iteration of the loop. This change ensures that we can internally distinguish between `[unroll]` and `[unroll(1)]`, by making `[unroll]` equivalent to `[unroll(0)]`, like FXC does. Modified a rewriter test to verify this (we can't test codegen yet due to #1534).

Fixes #1533 