### PR TITLE
Fix memory allocation issues

### DIFF
--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -116,6 +116,7 @@ DxilModule::DxilModule(Module *pModule)
 {
 
   DXASSERT_NOMSG(m_pModule != nullptr);
+  m_pModule->pfnResetDxilModule = &DxilModule_ResetModule;
   m_pModule->pfnRemoveGlobal = &DxilModule_RemoveGlobal;
 
 #if defined(_DEBUG) || defined(DBG)

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -116,8 +116,8 @@ DxilModule::DxilModule(Module *pModule)
 {
 
   DXASSERT_NOMSG(m_pModule != nullptr);
-  m_pModule->pfnResetDxilModule = &DxilModule_ResetModule;
   m_pModule->pfnRemoveGlobal = &DxilModule_RemoveGlobal;
+  m_pModule->pfnResetDxilModule = &DxilModule_ResetModule;
 
 #if defined(_DEBUG) || defined(DBG)
   // Pin LLVM dump methods.

--- a/tools/clang/include/clang/Parse/Parser.h
+++ b/tools/clang/include/clang/Parse/Parser.h
@@ -169,7 +169,8 @@ class Parser : public CodeCompletionHandler {
   std::unique_ptr<PragmaHandler> LoopHintHandler;
   std::unique_ptr<PragmaHandler> UnrollHintHandler;
   std::unique_ptr<PragmaHandler> NoUnrollHintHandler;
-  std::unique_ptr<PragmaHandler> PackMatrixHandler; // HLSL Change -packmatrix.
+
+  PragmaHandler *pPackMatrixHandler = nullptr; // // HLSL Change -packmatrix
 
   std::unique_ptr<CommentHandler> CommentSemaHandler;
 

--- a/tools/clang/lib/Parse/ParsePragma.cpp
+++ b/tools/clang/lib/Parse/ParsePragma.cpp
@@ -251,8 +251,10 @@ void Parser::initializePragmaHandlers() {
   } // HLSL Change, matching HLSL check to remove pragma processing
   else {
     // HLSL Change Begin - packmatrix.
-    PackMatrixHandler.reset(new PragmaPackMatrixHandler(Actions));
-    PP.AddPragmaHandler(PackMatrixHandler.get());
+    // The pointer ownership goes to PP, which deletes it in its destructor
+    // unless it is removed & deleted via resetPragmaHandlers
+    pPackMatrixHandler = new PragmaPackMatrixHandler(Actions);
+    PP.AddPragmaHandler(pPackMatrixHandler); 
     // HLSL Change End.
   }
 }
@@ -328,8 +330,9 @@ void Parser::resetPragmaHandlers() {
   } // HLSL Change - close conditional for skipping pragmas
   else {
     // HLSL Change Begin - packmatrix.
-    PP.RemovePragmaHandler(PackMatrixHandler.get());
-    PackMatrixHandler.reset();
+    PP.RemovePragmaHandler(pPackMatrixHandler);
+    delete pPackMatrixHandler;
+    pPackMatrixHandler = nullptr;
     // HLSL Change End.
   }
 }

--- a/tools/clang/lib/Parse/ParsePragma.cpp
+++ b/tools/clang/lib/Parse/ParsePragma.cpp
@@ -253,8 +253,9 @@ void Parser::initializePragmaHandlers() {
     // HLSL Change Begin - packmatrix.
     // The pointer ownership goes to PP, which deletes it in its destructor
     // unless it is removed & deleted via resetPragmaHandlers
-    pPackMatrixHandler = new PragmaPackMatrixHandler(Actions);
-    PP.AddPragmaHandler(pPackMatrixHandler); 
+    std::unique_ptr<PragmaHandler> pHandler(new PragmaPackMatrixHandler(Actions));
+    PP.AddPragmaHandler(pHandler.get());
+    pPackMatrixHandler = pHandler.release();
     // HLSL Change End.
   }
 }


### PR DESCRIPTION
- DxilModule was not freed
- PragmaMatrixHandler was freed twice when the compiler execution was aborted prematurely by an exception
- Improve diagnostic tracing in CompilerTest::CompileWhenNoMemThenOOM