### PR TITLE
HitGroup subobject changes

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1157,6 +1157,7 @@ namespace DXIL {
     HitGroup                          = 11,
     NumKinds // aka D3D12_STATE_SUBOBJECT_TYPE_MAX_VALID
   };
+
   inline bool IsValidSubobjectKind(SubobjectKind kind) {
     return (kind < SubobjectKind::NumKinds &&
       ( kind <= SubobjectKind::LocalRootSignature ||
@@ -1168,6 +1169,16 @@ namespace DXIL {
     AllowExternalDependenciesOnLocalDefinitions = 0x2,
     ValidMask = 0x3,
   };
+
+  enum class HitGroupType : uint32_t {
+    Triangle = 0x0,
+    ProceduralPrimitive = 0x1,
+    LastEntry,
+  };
+
+  inline bool IsValidHitGroupType(HitGroupType type) {
+    return (type >= HitGroupType::Triangle && type < HitGroupType::LastEntry);
+  }
 
   extern const char* kLegacyLayoutString;
   extern const char* kNewLayoutString;

--- a/include/dxc/DXIL/DxilSubobject.h
+++ b/include/dxc/DXIL/DxilSubobject.h
@@ -50,7 +50,8 @@ public:
   bool GetRaytracingShaderConfig(uint32_t &MaxPayloadSizeInBytes,
                                  uint32_t &MaxAttributeSizeInBytes) const;
   bool GetRaytracingPipelineConfig(uint32_t &MaxTraceRecursionDepth) const;
-  bool GetHitGroup(llvm::StringRef &AnyHit,
+  bool GetHitGroup(DXIL::HitGroupType &hitGroupType,
+                   llvm::StringRef &AnyHit,
                    llvm::StringRef &ClosestHit,
                    llvm::StringRef &Intersection) const;
 
@@ -86,6 +87,7 @@ private:
     uint32_t MaxTraceRecursionDepth;
   };
   struct HitGroup_t {
+    DXIL::HitGroupType Type;
     const char *AnyHit;
     const char *ClosestHit;
     const char *Intersection;
@@ -147,7 +149,8 @@ public:
   DxilSubobject &CreateRaytracingPipelineConfig(
     llvm::StringRef Name,
     uint32_t MaxTraceRecursionDepth);
-  DxilSubobject &CreateHitGroup(llvm::StringRef Name,
+  DxilSubobject &CreateHitGroup(llvm::StringRef Name, 
+                                DXIL::HitGroupType hitGroupType,
                                 llvm::StringRef AnyHit,
                                 llvm::StringRef ClosestHit,
                                 llvm::StringRef Intersection);

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -212,6 +212,7 @@ struct RuntimeDataSubobjectInfo {
     uint32_t MaxTraceRecursionDepth;
   };
   struct HitGroup_t {
+    uint32_t Type;
     // each is a string table offset for the shader name
     // 0 points to empty name, indicating no shader.
     uint32_t AnyHit;
@@ -532,6 +533,10 @@ public:
   }
 
   // HitGroup
+  DXIL::HitGroupType GetHitGroup_Type() const {
+    return (GetKind() == DXIL::SubobjectKind::HitGroup) ?
+      (DXIL::HitGroupType)m_SubobjectInfo->HitGroup.Type : (DXIL::HitGroupType)(-1);
+  }
   const char *GetHitGroup_Intersection() const {
     return (GetKind() == DXIL::SubobjectKind::HitGroup) ?
       m_Context->pStringTableReader->Get(m_SubobjectInfo->HitGroup.Intersection) : "";
@@ -643,6 +648,7 @@ struct DxilSubobjectDesc {
     uint32_t MaxTraceRecursionDepth;
   };
   struct HitGroup_t {
+    uint32_t Type;  // DXIL::HitGroupType / D3D12_HIT_GROUP_TYPE
     LPCWSTR AnyHit;
     LPCWSTR ClosestHit;
     LPCWSTR Intersection;

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -1412,8 +1412,10 @@ Metadata *DxilMDHelper::EmitSubobject(const DxilSubobject &obj) {
   }
   case DXIL::SubobjectKind::HitGroup: {
     llvm::StringRef Intersection, AnyHit, ClosestHit;
-    IFTBOOL(obj.GetHitGroup(Intersection, AnyHit, ClosestHit),
+    DXIL::HitGroupType hgType;
+    IFTBOOL(obj.GetHitGroup(hgType, Intersection, AnyHit, ClosestHit),
       DXC_E_INCORRECT_DXIL_METADATA);
+    Args.emplace_back(Uint32ToConstMD((uint32_t)hgType));
     Args.emplace_back(MDString::get(m_Ctx, Intersection));
     Args.emplace_back(MDString::get(m_Ctx, AnyHit));
     Args.emplace_back(MDString::get(m_Ctx, ClosestHit));
@@ -1481,10 +1483,11 @@ void DxilMDHelper::LoadSubobject(const llvm::MDNode &MD, DxilSubobjects &Subobje
     break;
   }
   case DXIL::SubobjectKind::HitGroup: {
+    uint32_t hgType = ConstMDToUint32(MD.getOperand(i++));
     StringRef Intersection(StringMDToStringRef(MD.getOperand(i++)));
     StringRef AnyHit(StringMDToStringRef(MD.getOperand(i++)));
     StringRef ClosestHit(StringMDToStringRef(MD.getOperand(i++)));
-    Subobjects.CreateHitGroup(name, AnyHit, ClosestHit, Intersection);
+    Subobjects.CreateHitGroup(name, (DXIL::HitGroupType)hgType, AnyHit, ClosestHit, Intersection);
     break;
   }
   default:

--- a/lib/DXIL/DxilSubobject.cpp
+++ b/lib/DXIL/DxilSubobject.cpp
@@ -71,6 +71,7 @@ void DxilSubobject::CopyUnionedContents(const DxilSubobject &other) {
     RaytracingPipelineConfig.MaxTraceRecursionDepth = other.RaytracingPipelineConfig.MaxTraceRecursionDepth;
     break;
   case Kind::HitGroup:
+    HitGroup.Type = other.HitGroup.Type;
     HitGroup.AnyHit = other.HitGroup.AnyHit;
     HitGroup.ClosestHit = other.HitGroup.ClosestHit;
     HitGroup.Intersection = other.HitGroup.Intersection;
@@ -160,10 +161,12 @@ bool DxilSubobject::GetRaytracingPipelineConfig(
 }
 
 // HitGroup
-bool DxilSubobject::GetHitGroup(llvm::StringRef &AnyHit,
+bool DxilSubobject::GetHitGroup(DXIL::HitGroupType &hitGroupType, 
+                                llvm::StringRef &AnyHit,
                                 llvm::StringRef &ClosestHit,
                                 llvm::StringRef &Intersection) const {
   if (m_Kind == Kind::HitGroup) {
+    hitGroupType = HitGroup.Type;
     AnyHit = HitGroup.AnyHit;
     ClosestHit = HitGroup.ClosestHit;
     Intersection = HitGroup.Intersection;
@@ -291,6 +294,7 @@ DxilSubobject &DxilSubobjects::CreateRaytracingPipelineConfig(
 }
 
 DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
+                                              DXIL::HitGroupType hitGroupType,
                                               llvm::StringRef AnyHit,
                                               llvm::StringRef ClosestHit,
                                               llvm::StringRef Intersection) {
@@ -298,6 +302,7 @@ DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
   AnyHit = GetSubobjectString(AnyHit);
   ClosestHit = GetSubobjectString(ClosestHit);
   Intersection = GetSubobjectString(Intersection);
+  obj.HitGroup.Type = hitGroupType;
   obj.HitGroup.AnyHit = AnyHit.data();
   obj.HitGroup.ClosestHit = ClosestHit.data();
   obj.HitGroup.Intersection = Intersection.data();

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1243,10 +1243,12 @@ private:
           info.RaytracingPipelineConfig.MaxTraceRecursionDepth);
         break;
       case DXIL::SubobjectKind::HitGroup:
+        HitGroupType hgType;
         StringRef AnyHit;
         StringRef ClosestHit;
         StringRef Intersection;
-        obj.GetHitGroup(AnyHit, ClosestHit, Intersection);
+        obj.GetHitGroup(hgType, AnyHit, ClosestHit, Intersection);
+        info.HitGroup.Type = (uint32_t)hgType;
         info.HitGroup.AnyHit = m_pStringBufferPart->Insert(AnyHit);
         info.HitGroup.ClosestHit = m_pStringBufferPart->Insert(ClosestHit);
         info.HitGroup.Intersection = m_pStringBufferPart->Insert(Intersection);

--- a/lib/DxilContainer/DxilContainerReader.cpp
+++ b/lib/DxilContainer/DxilContainerReader.cpp
@@ -62,6 +62,7 @@ void LoadSubobjectsFromRDAT(DxilSubobjects &subobjects, RDAT::SubobjectTableRead
       break;
     case DXIL::SubobjectKind::HitGroup:
       subobjects.CreateHitGroup(reader.GetName(),
+        reader.GetHitGroup_Type(),
         reader.GetHitGroup_AnyHit(),
         reader.GetHitGroup_ClosestHit(),
         reader.GetHitGroup_Intersection());

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -390,7 +390,8 @@ clang::QualType GetHLSLOutputPatchElementType(clang::QualType type);
 unsigned GetHLSLOutputPatchCount(clang::QualType type);
 
 bool IsHLSLSubobjectType(clang::QualType type);
-bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind);
+bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind, 
+                          DXIL::HitGroupType &ghType);
 
 bool IsArrayConstantStringType(const clang::QualType type);
 bool IsPointerStringType(const clang::QualType type);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -503,10 +503,12 @@ bool IsHLSLResourceType(clang::QualType type) {
 
 bool IsHLSLSubobjectType(clang::QualType type) {
   DXIL::SubobjectKind kind;
-  return GetHLSLSubobjectKind(type, kind);
+  DXIL::HitGroupType hgType;
+  return GetHLSLSubobjectKind(type, kind, hgType);
 }
 
-bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind) {
+bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind, DXIL::HitGroupType &hgType) {
+  hgType = (DXIL::HitGroupType)(-1);
   type = type.getCanonicalType();
   if (const RecordType *RT = type->getAs<RecordType>()) {
     StringRef name = RT->getDecl()->getName();
@@ -523,8 +525,20 @@ bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKi
       return name == "RaytracingShaderConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingShaderConfig, true) : false;
     case 24:
       return name == "RaytracingPipelineConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingPipelineConfig, true) : false;
-    case 8:
-      return name == "HitGroup" ? (subobjectKind = DXIL::SubobjectKind::HitGroup, true) : false;
+    case 16:
+      if (name == "TriangleHitGroup") {
+        subobjectKind = DXIL::SubobjectKind::HitGroup;
+        hgType = DXIL::HitGroupType::Triangle;
+        return true;
+      }
+      return false;
+    case 27:
+      if (name == "ProceduralPrimitiveHitGroup") {
+        subobjectKind = DXIL::SubobjectKind::HitGroup;
+        hgType = DXIL::HitGroupType::ProceduralPrimitive;
+        return true;
+      }
+      return false;
     }
   }
   return false;

--- a/tools/clang/test/CodeGenHLSL/quick-test/subobjects.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/subobjects.hlsl
@@ -7,7 +7,8 @@
 // CHECK: ; SubobjectToExportsAssociation sea2 = { "grs", { }  };
 // CHECK: ; RaytracingShaderConfig rsc = { MaxPayloadSizeInBytes = 128, MaxAttributeSizeInBytes = 64 };
 // CHECK: ; RaytracingPipelineConfig rpc = { MaxTraceRecursionDepth = 512 };
-// CHECK: ; HitGroup hitGt = { anyhit = "a", closesthit = "b", intersection = "c" };
+// CHECK: ; HitGroup trHitGt = { HitGroupType = Triangle, Anyhit = "a", Closesthit = "b", Intersection = "" };
+// CHECK: ; HitGroup ppHitGt = { HitGroupType = ProceduralPrimitive, Anyhit = "a", Closesthit = "b", Intersection = "c" };
 
 GlobalRootSignature grs = {"CBV(b0)"};
 StateObjectConfig soc = { STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS };
@@ -16,7 +17,8 @@ SubobjectToExportsAssociation sea = { "grs", "a;b;foo;c" };
 SubobjectToExportsAssociation sea2 = { "grs", ";" };
 RaytracingShaderConfig rsc = { 128, 64 };
 RaytracingPipelineConfig rpc = { 512 };
-HitGroup hitGt = { "a", "b", "c"};
+TriangleHitGroup trHitGt = { "a", "b" };
+ProceduralPrimitiveHitGroup ppHitGt = { "a", "b", "c"};
 
 int main(int i : INDEX) : SV_Target {
   return 1;

--- a/tools/clang/test/HLSL/subobjects-syntax.hlsl
+++ b/tools/clang/test/HLSL/subobjects-syntax.hlsl
@@ -66,24 +66,38 @@ RaytracingShaderConfig rsc2_7 = "foo";                      /* expected-error {{
 RaytracingShaderConfig rsc2_8 = 128;                        /* expected-error {{cannot initialize a variable of type 'RaytracingShaderConfig' with an rvalue of type 'literal int'}} */
 
 RaytracingPipelineConfig rpc1_1 = { 512 };
-RaytracingPipelineConfig rpc1_2 = { 512f };                 /* expected-error {{invalid digit 'f' in decimal constant}} */
+RaytracingPipelineConfig rpc1_2 = { 512.15f };                 /* expected-warning {{implicit conversion from 'float' to 'unsigned int' changes value from 512.15002 to 512}} */
 
 RaytracingPipelineConfig rpc2_2 = { 512, 128 };             /* expected-error {{too many elements in subobject initialization (expected 1 element, have 2)}} */
 RaytracingPipelineConfig rpc2_3 = 512;                      /* expected-error {{cannot initialize a variable of type 'RaytracingPipelineConfig' with an rvalue of type 'literal int'}} */
 RaytracingPipelineConfig rpc2_4 = 51.1f;                    /* expected-error {{cannot initialize a variable of type 'RaytracingPipelineConfig' with an rvalue of type 'float'}} */
 RaytracingPipelineConfig rpc2_5 = "foo";                    /* expected-error {{cannot initialize a variable of type 'RaytracingPipelineConfig' with an lvalue of type 'literal string'}} */
 
-HitGroup hitGt1_1 = { "a", "b", "c"};
-HitGroup hitGt1_2 = { s1, s2, s3 };
-HitGroup hitGt1_3 = { "", "", "" };
+TriangleHitGroup trHitGt1_1 = { "a", "b" };
+TriangleHitGroup trHitGt1_2 = { s1, s2 };
+TriangleHitGroup trHitGt1_3 = { "", "" };
 
-HitGroup hitGt2_2 = { "a", "b"};                            /* expected-error {{too few elements in subobject initialization (expected 3 elements, have 2)}} */
-HitGroup hitGt2_3 = { "a", "b", 10 };                       /* expected-error {{type mismatch}} */
-HitGroup hitGt2_4 = { 1, 2, 3 };                            /* expected-error {{type mismatch}} */
-HitGroup hitGt2_5 = "foo";                                  /* expected-error {{cannot initialize a variable of type 'HitGroup' with an lvalue of type 'literal string'}} */
-HitGroup hitGt2_6 = 115;                                    /* expected-error {{cannot initialize a variable of type 'HitGroup' with an rvalue of type 'literal int'}} */
-HitGroup hitGt2_7 = s2;                                     /* expected-error {{cannot initialize a variable of type 'HitGroup' with an lvalue of type 'string'}} */
-HitGroup hitGt2_8 = { s1, "", s4 };
+TriangleHitGroup trHitGt2_2 = { "a", "b", "c"};               /* expected-error {{too many elements in subobject initialization (expected 2 elements, have 3)}} */
+TriangleHitGroup trHitGt2_3 = { "a", 10 };                    /* expected-error {{type mismatch}} */
+TriangleHitGroup trHitGt2_4 = { 1, 2 };                       /* expected-error {{type mismatch}} */
+TriangleHitGroup trHitGt2_5 = "foo";                          /* expected-error {{cannot initialize a variable of type 'TriangleHitGroup' with an lvalue of type 'literal string'}} */
+TriangleHitGroup trHitGt2_6 = 115;                            /* expected-error {{cannot initialize a variable of type 'TriangleHitGroup' with an rvalue of type 'literal int'}} */
+TriangleHitGroup trHitGt2_7 = s2;                             /* expected-error {{cannot initialize a variable of type 'TriangleHitGroup' with an lvalue of type 'string'}} */
+
+ProceduralPrimitiveHitGroup ppHitGt1_1 = { "a", "b", "c"};
+ProceduralPrimitiveHitGroup ppHitGt1_2 = { s1, s2, s3 };
+ProceduralPrimitiveHitGroup ppHitGt1_3 = { "", "", "c" };
+
+ProceduralPrimitiveHitGroup ppHitGt2_2 = { "a", "b"};         /* expected-error {{too few elements in subobject initialization (expected 3 elements, have 2)}} */
+ProceduralPrimitiveHitGroup ppHitGt2_3 = { "a", "b", 10 };    /* expected-error {{type mismatch}} */
+ProceduralPrimitiveHitGroup ppHitGt2_4 = { 1, 2, 3 };         /* expected-error {{type mismatch}} */
+ProceduralPrimitiveHitGroup ppHitGt2_5 = "foo";               /* expected-error {{cannot initialize a variable of type 'ProceduralPrimitiveHitGroup' with an lvalue of type 'literal string'}} */
+ProceduralPrimitiveHitGroup ppHitGt2_6 = 115;                 /* expected-error {{cannot initialize a variable of type 'ProceduralPrimitiveHitGroup' with an rvalue of type 'literal int'}} */
+ProceduralPrimitiveHitGroup ppHitGt2_7 = s2;                  /* expected-error {{cannot initialize a variable of type 'ProceduralPrimitiveHitGroup' with an lvalue of type 'string'}} */
+
+TriangleHitGroup trHitGt2_8 = { s1, s4 };
+ProceduralPrimitiveHitGroup ppHitGt2_8 = { s1, "", s4 };
+ProceduralPrimitiveHitGroup ppHitGt2_9 = { "a", "b", ""};
 
 int main(int i : INDEX) : SV_Target {
   return 1;

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -601,6 +601,16 @@ static const char *FlagToString(DXIL::StateObjectFlags Flag) {
   return "<invalid StateObjectFlag>";
 }
 
+static const char *HitGroupTypeToString(DXIL::HitGroupType type) {
+  switch (type) {
+  case DXIL::HitGroupType::Triangle:
+    return "Triangle";
+  case DXIL::HitGroupType::ProceduralPrimitive:
+    return "ProceduralPrimitive";
+  }
+  return "<invalid HitGroupType>";
+}
+
 template <typename _T>
 void PrintFlags(raw_string_ostream &OS, uint32_t Flags) {
   if (!Flags) {
@@ -702,16 +712,18 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
       break;
     }
     case DXIL::SubobjectKind::HitGroup: {
+      HitGroupType hgType;
       StringRef AnyHit;
       StringRef ClosestHit;
       StringRef Intersection;
-      if (!obj.GetHitGroup(AnyHit, ClosestHit, Intersection)) {
+      if (!obj.GetHitGroup(hgType, AnyHit, ClosestHit, Intersection)) {
         OS << "<error getting subobject>";
         break;
       }
-      OS << "anyhit = \"" << AnyHit
-         << "\", closesthit = \"" << ClosestHit
-         << "\", intersection = \"" << Intersection << "\"";
+      OS << "HitGroupType = " << HitGroupTypeToString(hgType) 
+         << ", Anyhit = \"" << AnyHit
+         << "\", Closesthit = \"" << ClosestHit
+         << "\", Intersection = \"" << Intersection << "\"";
       break;
     }
     }

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -5954,13 +5954,17 @@ TEST_F(CompilerTest, SubobjectCodeGenErrors) {
     { "SubobjectToExportsAssociation sea;", "1:1: error: subobject needs to be initialized" },
     { "RaytracingShaderConfig rsc;",        "1:1: error: subobject needs to be initialized" },
     { "RaytracingPipelineConfig rpc;",      "1:1: error: subobject needs to be initialized" },
-    { "HitGroup hitGt;",                    "1:1: error: subobject needs to be initialized" },
+    { "TriangleHitGroup hitGt;",            "1:1: error: subobject needs to be initialized" },
+    { "ProceduralPrimitiveHitGroup hitGt;", "1:1: error: subobject needs to be initialized" },
     { "GlobalRootSignature grs2 = {\"\"};", "1:29: error: empty string not expected here" },
     { "LocalRootSignature lrs2 = {\"\"};",  "1:28: error: empty string not expected here" },
     { "SubobjectToExportsAssociation sea2 = { \"\", \"x\" };", "1:40: error: empty string not expected here" },
     { "SubobjectToExportsAssociation sea3 = { \"x\", \"\" };", "1:45: error: empty string not expected here" },
     { "string s; SubobjectToExportsAssociation sea4 = { \"x\", s };", "1:55: error: cannot convert to constant string" },
-    { "extern int v; RaytracingPipelineConfig rpc2 = { v + 16 };", "1:49: error: cannot convert to constant unsigned int" }
+    { "extern int v; RaytracingPipelineConfig rpc2 = { v + 16 };", "1:49: error: cannot convert to constant unsigned int" },
+    { "string s; TriangleHitGroup trHitGt2_8 = { s, \"foo\" };", "1:43: error: cannot convert to constant string" },
+    { "string s; ProceduralPrimitiveHitGroup ppHitGt2_8 = { s, \"\", s };", "1:54: error: cannot convert to constant string" },
+    { "ProceduralPrimitiveHitGroup ppHitGt2_9 = { \"a\", \"b\", \"\"};", "1:54: error: empty string not expected here" }
   };
 
   for (unsigned i = 0; i < _countof(testCases); i++) {


### PR DESCRIPTION
- Replace HitGroup subobject by TriangleHitGroup and ProcedurePrimitiveHitGroup
- Add internal HitGroupType enum that maps to D3D12_HIT_GROUP_TYPE
- Add corresponding HitGroupType field to metadata, RDAT and reflection