### PR TITLE
Support for cmake from VS Professional/Enterprise; update TAEF comments and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Before you build, you will need to have some additional software installed. This
 
 After cloning the project, you can set up a build environment shortcut by double-clicking the `utils\hct\hctshortcut.js` file. This will create a shortcut on your desktop with a default configuration.
 
-Tests are built using the TAEF framework. Unless you have the Windows Driver Kit installed, you should run the script at `utils\hct\hctgettaef.py` from your build environment before you start building to download and unzip it as an external dependency. You should only need to do this once.
+Tests are built using the TAEF framework which is a part of Windows Driver Kit and is integrated with Visual Studio 2017. It should be already installed with Visual Studio 2017. In case it is not, download and install Windows Driver Kit.
 
 To build, run this command on the HLSL Console.
 

--- a/utils/hct/hctgettaef.py
+++ b/utils/hct/hctgettaef.py
@@ -1,30 +1,33 @@
-import urllib
-import os
-import ssl
-import zipfile
+print "hctgetatef.py is no longer supported."
+print "TAEF framework should be installed as part of Windows Driver Kit that is integrated with Visual Studio 2017."
 
-url = "https://github.com/Microsoft/WinObjC/raw/develop/deps/prebuilt/nuget/taef.redist.wlk.1.0.170206001-nativetargets.nupkg"
-zipfile_name = os.path.join(os.environ['TEMP'], "taef.redist.wlk.1.0.170206001-nativetargets.nupkg.zip")
-src_dir = os.environ['HLSL_SRC_DIR']
-taef_dir = os.path.join(src_dir, "external", "taef")
+# import urllib
+# import os
+# import ssl
+# import zipfile
 
-if not os.path.isdir(taef_dir):
-  os.makedirs(taef_dir)
+# url = "https://github.com/Microsoft/WinObjC/raw/develop/deps/prebuilt/nuget/taef.redist.wlk.1.0.170206001-nativetargets.nupkg"
+# zipfile_name = os.path.join(os.environ['TEMP'], "taef.redist.wlk.1.0.170206001-nativetargets.nupkg.zip")
+# src_dir = os.environ['HLSL_SRC_DIR']
+# taef_dir = os.path.join(src_dir, "external", "taef")
 
-try:
-  ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-  response = urllib.urlopen(url, context=ctx)
-  f = open(zipfile_name, 'wb')
-  f.write(response.read())
-  f.close()
-except:
-  print("Unable to read file with urllib, trying via powershell...")
-  from subprocess import check_call
-  cmd = ""
-  cmd += "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;"
-  cmd += "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
-  check_call(['powershell.exe', '-Command', cmd])
+# if not os.path.isdir(taef_dir):
+#   os.makedirs(taef_dir)
 
-z = zipfile.ZipFile(zipfile_name)
-z.extractall(taef_dir)
-z.close()
+# try:
+#   ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+#   response = urllib.urlopen(url, context=ctx)
+#   f = open(zipfile_name, 'wb')
+#   f.write(response.read())
+#   f.close()
+# except:
+#   print("Unable to read file with urllib, trying via powershell...")
+#   from subprocess import check_call
+#   cmd = ""
+#   cmd += "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;"
+#   cmd += "(new-object System.Net.WebClient).DownloadFile('" + url + "', '" + zipfile_name + "')"
+#   check_call(['powershell.exe', '-Command', cmd])
+
+# z = zipfile.ZipFile(zipfile_name)
+# z.extractall(taef_dir)
+# z.close()

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -124,6 +124,16 @@ if "%ERRORLEVEL%"=="0" (
   echo Path adjusted to include cmake from Visual Studio 2017 Community
   exit /b 0
 )
+call :ifexistaddpath "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+if "%ERRORLEVEL%"=="0" (
+  echo Path adjusted to include cmake from Visual Studio 2017 Professional
+  exit /b 0
+)
+call :ifexistaddpath "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+if "%ERRORLEVEL%"=="0" (
+  echo Path adjusted to include cmake from Visual Studio 2017 Enterprise
+  exit /b 0
+)
 if errorlevel 1 if exist "%programfiles%\CMake\bin" set path=%path%;%programfiles%\CMake\bin
 if errorlevel 1 if exist "%programfiles(x86)%\CMake\bin" set path=%path%;%programfiles(x86)%\CMake\bin
 where cmake.exe 1>nul 2>nul
@@ -246,7 +256,7 @@ cmake --version | findstr 3.9.0-MSVC 1>nul 2>nul
 if "0"=="%ERRORLEVEL%" exit /b 0
 cmake --version | findstr 3.11.2 1>nul 2>nul
 if "0"=="%ERRORLEVEL%" exit /b 0
-cmake --version | findstr /R 3.6.*MSVC 1>nul 2>nul
+cmake --version | findstr /R 3.*MSVC 1>nul 2>nul
 if errorlevel 1 (
   echo CMake 3.4.3, 3.7.2, 3.9.0 or 3.11.2 are the currently supported versions for VS 2015 and VS 2017 - your installed cmake is not supported.
   echo See README.md at the root for an explanation of dependencies.


### PR DESCRIPTION
Update hctstart.cmd to be able to find CMake from Visual Studio Professional and Enterprise.

TAEF: hctgettaef.py script stopped working because of external dependency. Since TAEF seems to be installed by default in Microsoft Driver Kit as part of Visual Studio 2017 setup, I've changed the script to just refer to that instead. Also changed the setup instructions on the GitHub main page to mention this.

