### PR TITLE
Set default floating-point environment at compiler boundaries

### DIFF
--- a/tools/clang/test/CodeGenHLSL/fpexcept.hlsl
+++ b/tools/clang/test/CodeGenHLSL/fpexcept.hlsl
@@ -1,0 +1,7 @@
+// RUN: %dxc -E main -T ps_6_0 %s
+
+float3 main() : SV_Target
+{
+    // Some calls known to cause floating point exceptions when evaluated
+    return float3(pow(0.0f, 0.0f), pow(-1.0f, 0.5f), pow(0.0f, -1.0f));
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3423,7 +3423,9 @@ struct FPEnableExceptionsScope
   }
   ~FPEnableExceptionsScope() {
     unsigned int newValue;
-    _controlfp_s(&newValue, previousValue, _MCW_EM);
+    errno_t error = _controlfp_s(&newValue, previousValue, _MCW_EM);
+    DXASSERT(error == 0, "Failed to restore floating-point environment.");
+    (void)error;
   }
 #endif
 };

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <sstream>
 #include <algorithm>
+#include <cfloat>
 #include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/dxcapi.h"
@@ -372,6 +373,7 @@ public:
   TEST_METHOD(CodeGenExternRes)
   TEST_METHOD(CodeGenExpandTrig)
   TEST_METHOD(CodeGenFloatCast)
+  TEST_METHOD(CodeGenFloatingPointEnvironment)
   TEST_METHOD(CodeGenFloatToBool)
   TEST_METHOD(CodeGenFirstbitHi)
   TEST_METHOD(CodeGenFirstbitLo)
@@ -3409,6 +3411,26 @@ TEST_F(CompilerTest, CodeGenExpandTrig) {
 
 TEST_F(CompilerTest, CodeGenFloatCast) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\float_cast.hlsl");
+}
+
+struct FPEnableExceptionsScope
+{
+  // _controlfp_s is non-standard and <cfenv> doesn't have a function to enable exceptions
+#ifdef _WIN32
+  unsigned int previousValue;
+  FPEnableExceptionsScope() {
+    VERIFY_IS_TRUE(_controlfp_s(&previousValue, 0, _MCW_EM) == 0); // _MCW_EM == 0 means enable all exceptions
+  }
+  ~FPEnableExceptionsScope() {
+    unsigned int newValue;
+    _controlfp_s(&newValue, previousValue, _MCW_EM);
+  }
+#endif
+};
+
+TEST_F(CompilerTest, CodeGenFloatingPointEnvironment) {
+  FPEnableExceptionsScope fpEnableExceptions;
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\fpexcept.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenFloatToBool) {


### PR DESCRIPTION
We were crashing while constant folding in `CGHLSLMS.TryEvalIntrinsic` when libc functions cause floating-point exceptions and the compiler caller had enabled floating-point exceptions.

I really wanted to use the standard `<cfenv>` header, but `feholdexceptions` and `fesetround` somehow had no impact on the floating-point environment, as seen by checking the x87/xmm registers before and after, so I had to use non-standard `_controlfp_s`, which makes this fix Windows-specific.

Fixes #1607 