### PR TITLE
Fix Validation for RDAT and other issues with Subobjects

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -147,10 +147,10 @@ public:
   // Includes: vs/hs/ds/gs/ps/cs as well as the patch constant function.
   bool IsEntryThatUsesSignatures(const llvm::Function *F) const ;
 
-  // Remove Root Signature from module metadata
-  void StripRootSignatureFromMetadata();
-  // Remove Subobjects from module metadata
-  void StripSubobjectsFromMetadata();
+  // Remove Root Signature from module metadata, return true if changed
+  bool StripRootSignatureFromMetadata();
+  // Remove Subobjects from module metadata, return true if changed
+  bool StripSubobjectsFromMetadata();
   // Update validator version metadata to current setting
   void UpdateValidatorVersionMetadata();
 

--- a/include/dxc/DxilContainer/DxilContainerReader.h
+++ b/include/dxc/DxilContainer/DxilContainerReader.h
@@ -18,7 +18,7 @@ namespace RDAT {
   class SubobjectTableReader;
 }
 
-void LoadSubobjectsFromRDAT(DxilSubobjects &subobjects,
+bool LoadSubobjectsFromRDAT(DxilSubobjects &subobjects,
   RDAT::SubobjectTableReader *pSubobjectTableReader);
 
 } // namespace hlsl

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -583,7 +583,7 @@ private:
 
 public:
   DxilRuntimeData();
-  DxilRuntimeData(const char *ptr, size_t size);
+  DxilRuntimeData(const void *ptr, size_t size);
   // initializing reader from RDAT. return true if no error has occured.
   bool InitFromRDAT(const void *pRDAT, size_t size);
   // read prerelease data:

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -91,7 +91,7 @@ public:
 
 DxilRuntimeData::DxilRuntimeData() : DxilRuntimeData(nullptr, 0) {}
 
-DxilRuntimeData::DxilRuntimeData(const char *ptr, size_t size)
+DxilRuntimeData::DxilRuntimeData(const void *ptr, size_t size)
     : m_TableCount(0), m_StringReader(), m_IndexTableReader(), m_RawBytesReader(),
       m_ResourceTableReader(), m_FunctionTableReader(),
       m_SubobjectTableReader(), m_Context() {
@@ -342,6 +342,9 @@ const DxilLibraryDesc DxilRuntimeReflection_impl::GetLibraryReflection() {
     reflection.NumFunctions =
         m_RuntimeData.GetFunctionTableReader()->GetNumFunctions();
     reflection.pFunction = m_Functions.data();
+    reflection.NumSubobjects =
+        m_RuntimeData.GetSubobjectTableReader()->GetCount();
+    reflection.pSubobjects = m_Subobjects.data();
   }
   return reflection;
 }

--- a/lib/Analysis/ReducibilityAnalysis.cpp
+++ b/lib/Analysis/ReducibilityAnalysis.cpp
@@ -50,10 +50,10 @@ public:
 
   ReducibilityAnalysis()
       : FunctionPass(ID), m_Action(IrreducibilityAction::ThrowException),
-        m_bReducible(false) {}
+        m_bReducible(true) {}
 
   explicit ReducibilityAnalysis(IrreducibilityAction Action)
-      : FunctionPass(ID), m_Action(Action), m_bReducible(false) {}
+      : FunctionPass(ID), m_Action(Action), m_bReducible(true) {}
 
   virtual bool runOnFunction(Function &F);
 

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1011,11 +1011,13 @@ bool DxilModule::IsEntryThatUsesSignatures(const llvm::Function *F) const {
   return IsPatchConstantShader(F);
 }
 
-void DxilModule::StripRootSignatureFromMetadata() {
+bool DxilModule::StripRootSignatureFromMetadata() {
   NamedMDNode *pRootSignatureNamedMD = GetModule()->getNamedMetadata(DxilMDHelper::kDxilRootSignatureMDName);
   if (pRootSignatureNamedMD) {
     GetModule()->eraseNamedMetadata(pRootSignatureNamedMD);
+    return true;
   }
+  return false;
 }
 
 DxilSubobjects *DxilModule::GetSubobjects() {
@@ -1031,11 +1033,13 @@ void DxilModule::ResetSubobjects(DxilSubobjects *subobjects) {
   m_pSubobjects.reset(subobjects);
 }
 
-void DxilModule::StripSubobjectsFromMetadata() {
+bool DxilModule::StripSubobjectsFromMetadata() {
   NamedMDNode *pSubobjectsNamedMD = GetModule()->getNamedMetadata(DxilMDHelper::kDxilSubobjectsMDName);
   if (pSubobjectsNamedMD) {
     GetModule()->eraseNamedMetadata(pSubobjectsNamedMD);
+    return true;
   }
+  return false;
 }
 
 void DxilModule::UpdateValidatorVersionMetadata() {

--- a/lib/DXIL/DxilSubobject.cpp
+++ b/lib/DXIL/DxilSubobject.cpp
@@ -311,8 +311,8 @@ DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
 
 DxilSubobject &DxilSubobjects::CreateSubobject(Kind kind, llvm::StringRef Name) {
   Name = GetSubobjectString(Name);
-  DXASSERT(FindSubobject(Name) == nullptr,
-    "otherwise, name collision between subobjects");
+  IFTBOOLMSG(FindSubobject(Name) == nullptr, DXC_E_GENERAL_INTERNAL_ERROR, "Subobject name collision");
+  IFTBOOLMSG(!Name.empty(), DXC_E_GENERAL_INTERNAL_ERROR, "Empty Subobject name");
   std::unique_ptr<DxilSubobject> ptr(new DxilSubobject(*this, kind, Name));
   DxilSubobject &ref = *ptr;
   m_Subobjects[Name] = std::move(ptr);

--- a/lib/DxilContainer/DxilContainerReader.cpp
+++ b/lib/DxilContainer/DxilContainerReader.cpp
@@ -18,57 +18,66 @@
 
 namespace hlsl {
 
-void LoadSubobjectsFromRDAT(DxilSubobjects &subobjects, RDAT::SubobjectTableReader *pSubobjectTableReader) {
+bool LoadSubobjectsFromRDAT(DxilSubobjects &subobjects, RDAT::SubobjectTableReader *pSubobjectTableReader) {
   if (!pSubobjectTableReader)
-    return;
+    return false;
+  bool result = true;
   for (unsigned i = 0; i < pSubobjectTableReader->GetCount(); ++i) {
-    auto reader = pSubobjectTableReader->GetItem(i);
-    DXIL::SubobjectKind kind = reader.GetKind();
-    bool bLocalRS = false;
-    switch (kind) {
-    case DXIL::SubobjectKind::StateObjectConfig:
-      subobjects.CreateStateObjectConfig(reader.GetName(),
-        reader.GetStateObjectConfig_Flags());
-      break;
-    case DXIL::SubobjectKind::LocalRootSignature:
-      bLocalRS = true;
-    case DXIL::SubobjectKind::GlobalRootSignature: {
-      const void *pOutBytes;
-      uint32_t OutSizeInBytes;
-      reader.GetRootSignature(&pOutBytes, &OutSizeInBytes);
-      subobjects.CreateRootSignature(reader.GetName(), bLocalRS, pOutBytes, OutSizeInBytes);
-      break;
-    }
-    case DXIL::SubobjectKind::SubobjectToExportsAssociation: {
-      uint32_t NumExports = reader.GetSubobjectToExportsAssociation_NumExports();
-      std::vector<llvm::StringRef> Exports;
-      Exports.resize(NumExports);
-      for (unsigned i = 0; i < NumExports; ++i) {
-        Exports[i] = reader.GetSubobjectToExportsAssociation_Export(i);
-      }
-      subobjects.CreateSubobjectToExportsAssociation(reader.GetName(),
-        reader.GetSubobjectToExportsAssociation_Subobject(),
-        Exports.data(), NumExports);
-      break;
-    }
-    case DXIL::SubobjectKind::RaytracingShaderConfig:
-      subobjects.CreateRaytracingShaderConfig(reader.GetName(),
-        reader.GetRaytracingShaderConfig_MaxPayloadSizeInBytes(),
-        reader.GetRaytracingShaderConfig_MaxAttributeSizeInBytes());
-      break;
-    case DXIL::SubobjectKind::RaytracingPipelineConfig:
-      subobjects.CreateRaytracingPipelineConfig(reader.GetName(),
-        reader.GetRaytracingPipelineConfig_MaxTraceRecursionDepth());
-      break;
-    case DXIL::SubobjectKind::HitGroup:
-      subobjects.CreateHitGroup(reader.GetName(),
-        reader.GetHitGroup_Type(),
-        reader.GetHitGroup_AnyHit(),
-        reader.GetHitGroup_ClosestHit(),
-        reader.GetHitGroup_Intersection());
+    try {
+      auto reader = pSubobjectTableReader->GetItem(i);
+      DXIL::SubobjectKind kind = reader.GetKind();
+      bool bLocalRS = false;
+      switch (kind) {
+      case DXIL::SubobjectKind::StateObjectConfig:
+        subobjects.CreateStateObjectConfig(reader.GetName(),
+          reader.GetStateObjectConfig_Flags());
         break;
+      case DXIL::SubobjectKind::LocalRootSignature:
+        bLocalRS = true;
+      case DXIL::SubobjectKind::GlobalRootSignature: {
+        const void *pOutBytes;
+        uint32_t OutSizeInBytes;
+        if (!reader.GetRootSignature(&pOutBytes, &OutSizeInBytes)) {
+          result = false;
+          continue;
+        }
+        subobjects.CreateRootSignature(reader.GetName(), bLocalRS, pOutBytes, OutSizeInBytes);
+        break;
+      }
+      case DXIL::SubobjectKind::SubobjectToExportsAssociation: {
+        uint32_t NumExports = reader.GetSubobjectToExportsAssociation_NumExports();
+        std::vector<llvm::StringRef> Exports;
+        Exports.resize(NumExports);
+        for (unsigned i = 0; i < NumExports; ++i) {
+          Exports[i] = reader.GetSubobjectToExportsAssociation_Export(i);
+        }
+        subobjects.CreateSubobjectToExportsAssociation(reader.GetName(),
+          reader.GetSubobjectToExportsAssociation_Subobject(),
+          Exports.data(), NumExports);
+        break;
+      }
+      case DXIL::SubobjectKind::RaytracingShaderConfig:
+        subobjects.CreateRaytracingShaderConfig(reader.GetName(),
+          reader.GetRaytracingShaderConfig_MaxPayloadSizeInBytes(),
+          reader.GetRaytracingShaderConfig_MaxAttributeSizeInBytes());
+        break;
+      case DXIL::SubobjectKind::RaytracingPipelineConfig:
+        subobjects.CreateRaytracingPipelineConfig(reader.GetName(),
+          reader.GetRaytracingPipelineConfig_MaxTraceRecursionDepth());
+        break;
+      case DXIL::SubobjectKind::HitGroup:
+        subobjects.CreateHitGroup(reader.GetName(),
+          reader.GetHitGroup_Type(),
+          reader.GetHitGroup_AnyHit(),
+          reader.GetHitGroup_ClosestHit(),
+          reader.GetHitGroup_Intersection());
+          break;
+      }
+    } catch (hlsl::Exception &) {
+      result = false;
     }
   }
+  return result;
 }
 
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/subobjects.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/subobjects.hlsl
@@ -1,10 +1,11 @@
-// RUN: %dxc -T lib_6_4 -Vd %s | FileCheck %s
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
 
 // CHECK: ; GlobalRootSignature grs = { <48 bytes> };
 // CHECK: ; StateObjectConfig soc = { STATE_OBJECT_FLAG_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITIONS };
 // CHECK: ; LocalRootSignature lrs = { <48 bytes> };
 // CHECK: ; SubobjectToExportsAssociation sea = { "grs", { "a", "b", "foo", "c" }  };
 // CHECK: ; SubobjectToExportsAssociation sea2 = { "grs", { }  };
+// CHECK: ; SubobjectToExportsAssociation sea3 = { "grs", { }  };
 // CHECK: ; RaytracingShaderConfig rsc = { MaxPayloadSizeInBytes = 128, MaxAttributeSizeInBytes = 64 };
 // CHECK: ; RaytracingPipelineConfig rpc = { MaxTraceRecursionDepth = 512 };
 // CHECK: ; HitGroup trHitGt = { HitGroupType = Triangle, Anyhit = "a", Closesthit = "b", Intersection = "" };
@@ -14,7 +15,9 @@ GlobalRootSignature grs = {"CBV(b0)"};
 StateObjectConfig soc = { STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS };
 LocalRootSignature lrs = {"UAV(u0, visibility = SHADER_VISIBILITY_GEOMETRY), RootFlags(LOCAL_ROOT_SIGNATURE)"};
 SubobjectToExportsAssociation sea = { "grs", "a;b;foo;c" };
+// Empty association is well-defined: it creates a default association
 SubobjectToExportsAssociation sea2 = { "grs", ";" };
+SubobjectToExportsAssociation sea3 = { "grs", "" };
 RaytracingShaderConfig rsc = { 128, 64 };
 RaytracingPipelineConfig rpc = { 512 };
 TriangleHitGroup trHitGt = { "a", "b" };

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -1578,7 +1578,9 @@ HRESULT Disassemble(IDxcBlob *pProgram, raw_string_ostream &Stream) {
       if (RDAT::SubobjectTableReader *pSubobjectTableReader =
         runtimeData.GetSubobjectTableReader()) {
         dxilModule.ResetSubobjects(new DxilSubobjects());
-        LoadSubobjectsFromRDAT(*dxilModule.GetSubobjects(), pSubobjectTableReader);
+        if (!LoadSubobjectsFromRDAT(*dxilModule.GetSubobjects(), pSubobjectTableReader)) {
+          Stream << "; error occurred while loading Subobjects from RDAT.\n";
+        }
       }
     }
     if (dxilModule.GetSubobjects()) {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -5983,7 +5983,6 @@ TEST_F(CompilerTest, SubobjectCodeGenErrors) {
     { "GlobalRootSignature grs2 = {\"\"};", "1:29: error: empty string not expected here" },
     { "LocalRootSignature lrs2 = {\"\"};",  "1:28: error: empty string not expected here" },
     { "SubobjectToExportsAssociation sea2 = { \"\", \"x\" };", "1:40: error: empty string not expected here" },
-    { "SubobjectToExportsAssociation sea3 = { \"x\", \"\" };", "1:45: error: empty string not expected here" },
     { "string s; SubobjectToExportsAssociation sea4 = { \"x\", s };", "1:55: error: cannot convert to constant string" },
     { "extern int v; RaytracingPipelineConfig rpc2 = { v + 16 };", "1:49: error: cannot convert to constant unsigned int" },
     { "string s; TriangleHitGroup trHitGt2_8 = { s, \"foo\" };", "1:43: error: cannot convert to constant string" },


### PR DESCRIPTION
- re-serialize module when changed by removing either subobjects or
  root signature metadata
- improve error detection/handling for loading/creating subobjects
- load subobjects from RDAT if not in DxilModule for RDAT comparison
- fix subobjects missing from desc in DxilRuntimeReflection
- default ReducibilityAnalysis to pass so it doesn't fail when no
  functions are present
- report error on subobject if validator (< 1.4) will not accept
  them, so they will not be captured
- container validation for required/disallowed parts for libraries