### PR TITLE
Fix crash when assigning to global matrix in compat mode

### DIFF
--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -2470,21 +2470,14 @@ void HLMatrixLowerPass::runOnGlobal(GlobalVariable *GV) {
 
     for (auto U = GV->user_begin(); U != GV->user_end();) {
       Value *user = *(U++);
-      if (CallInst *CI = dyn_cast<CallInst>(user)) {
-        HLOpcodeGroup group = GetHLOpcodeGroupByName(CI->getCalledFunction());
-        if (group == HLOpcodeGroup::HLMatLoadStore) {
-          TranslateMatLoadStoreOnGlobal(GV, arrayMat, CI);
-        }
-        else {
-          DXASSERT(group == HLOpcodeGroup::HLSubscript, "Must be subscript operation");
-          TranslateMatSubscriptOnGlobalPtr(CI, arrayMat);
-        }
+      CallInst *CI = cast<CallInst>(user);
+      HLOpcodeGroup group = GetHLOpcodeGroupByName(CI->getCalledFunction());
+      if (group == HLOpcodeGroup::HLMatLoadStore) {
+        TranslateMatLoadStoreOnGlobal(GV, arrayMat, CI);
       }
       else {
-        // Apparently someone generates unused GEP operators
-        GEPOperator *GEPOp = cast<GEPOperator>(user);
-        DXASSERT(GEPOp->use_empty(), "Unhandled GEP operator global matrix user.");
-        (void)GEPOp;
+        DXASSERT(group == HLOpcodeGroup::HLSubscript, "Must be subscript operation");
+        TranslateMatSubscriptOnGlobalPtr(CI, arrayMat);
       }
     }
     GV->removeDeadConstantUsers();

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -1794,12 +1794,11 @@ void HLMatrixLowerPass::TranslateMatSubscriptOnGlobalPtr(
   // Cannot generate vector pointer
   // Replace all uses with scalar pointers.
   if (!matSubInst->getType()->getPointerElementType()->isVectorTy()) {
-    DXASSERT(idxList.size() == 1, "Expected a single matrix subscript index if the result is not a vector");
+    DXASSERT(idxList.size() == 1, "Expected a single matrix element index if the result is not a vector");
     Value *Ptr =
       subBuilder.CreateInBoundsGEP(vecPtr, { zeroIdx, idxList[0] });
     matSubInst->replaceAllUsesWith(Ptr);
-  }
-  else {
+  } else {
     // Split the use of CI with Ptrs.
     for (auto U = matSubInst->user_begin(); U != matSubInst->user_end();) {
       Instruction *subsUser = cast<Instruction>(*(U++));

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -3808,7 +3808,9 @@ static void SimplifyBitCast(BitCastOperator *BC, SmallInstSet &deadInsts) {
 
   FromTy = FromTy->getPointerElementType();
   ToTy = ToTy->getPointerElementType();
+
   // Take care case like %2 = bitcast %struct.T* %1 to <1 x float>*.
+  bool GEPCreated = false;
   if (FromTy->isStructTy()) {
     IRBuilder<> Builder(FromTy->getContext());
     if (Instruction *I = dyn_cast<Instruction>(BC))
@@ -3822,6 +3824,7 @@ static void SimplifyBitCast(BitCastOperator *BC, SmallInstSet &deadInsts) {
     }
     std::vector<Value *> idxList(nestLevel, zeroIdx);
     Ptr = Builder.CreateGEP(Ptr, idxList);
+    GEPCreated = true;
   }
 
   for (User *U : BC->users()) {
@@ -3848,6 +3851,14 @@ static void SimplifyBitCast(BitCastOperator *BC, SmallInstSet &deadInsts) {
     } else {
       DXASSERT(0, "not support yet");
     }
+  }
+
+  // We created a GEP instruction but didn't end up consuming it, so delete it.
+  if (GEPCreated && Ptr->use_empty()) {
+    if (GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(Ptr))
+      GEP->eraseFromParent();
+    else
+      cast<Constant>(Ptr)->destroyConstant();
   }
 }
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
@@ -58,6 +58,7 @@ float4 main(uint a : A) : SV_Target {
          g_v +
          float4(g_m[0][0], g_m[0][1], g_m[1][0], g_m[1][1]) +
          float4(g_m_rm[0][0], g_m_rm[0][1], g_m_rm[1][0], g_m_rm[1][1]) +
+         float4(g_m2._11, g_m2._12, g_m2._21_22) +
          float4(g_a[0], g_a[1], g_a[2], g_a[3]) +
          float4(g_a2d[0][0], g_a2d[0][1], g_a2d[1][0], g_a2d[1][1]) +
          float4(g_ma[0][0][0], g_ma[1][0][1], g_ma[2][1][0], g_ma[3][1][1]);

--- a/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
@@ -24,11 +24,13 @@ float4 main(uint a : A) : SV_Target {
   for (uint i = 0; i < 2; i++)
     for (uint j = 0; j < 2; j++)
       g_m[i][j] = a + i + j;
+  g_m._12 = 42;
       
   // update global row_major matrix
   for (uint i = 0; i < 2; i++)
     for (uint j = 0; j < 2; j++)
       g_m_rm[i][j] = a + i + j;
+  g_m_rm._12 = 42;
 
   // update global boolean
   g_b = true;

--- a/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
@@ -8,6 +8,7 @@ float g_s;
 float4 g_v = float4(1.0, -1.0, 0.0, 1.0);
 int2x2 g_m;
 row_major int2x2 g_m_rm;
+int2x2 g_m2;
 bool g_b = false;
 int g_a[5];
 int g_a2d[3][2];
@@ -24,13 +25,16 @@ float4 main(uint a : A) : SV_Target {
   for (uint i = 0; i < 2; i++)
     for (uint j = 0; j < 2; j++)
       g_m[i][j] = a + i + j;
-  g_m._12 = 42;
       
   // update global row_major matrix
   for (uint i = 0; i < 2; i++)
     for (uint j = 0; j < 2; j++)
       g_m_rm[i][j] = a + i + j;
-  g_m_rm._12 = 42;
+
+  // update global matrix through element access
+  g_m2._11 = a;
+  g_m2._12_21 = float2(a, a + 1);
+  g_m2._21_22 = a + 3;
 
   // update global boolean
   g_b = true;

--- a/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/global-var-write-test01.hlsl
@@ -6,41 +6,53 @@
 
 float g_s;
 float4 g_v = float4(1.0, -1.0, 0.0, 1.0);
-// TODO: writing to a global matrix currently causes the compiler to crash. fix it.
-// int2x2 g_m;
+int2x2 g_m;
+row_major int2x2 g_m_rm;
 bool g_b = false;
 int g_a[5];
 int g_a2d[3][2];
-float4 main(uint a
-            : A) : SV_Target {
+int2x2 g_ma[4];
+
+float4 main(uint a : A) : SV_Target {
   // update global scalar
   g_s = a;
 
   // update global vector
   g_v = float4(a + 1, a + 2, a + 3, a + 4);
 
-  /*
   // update global matrix
   for (uint i = 0; i < 2; i++)
     for (uint j = 0; j < 2; j++)
       g_m[i][j] = a + i + j;
-  */
+      
+  // update global row_major matrix
+  for (uint i = 0; i < 2; i++)
+    for (uint j = 0; j < 2; j++)
+      g_m_rm[i][j] = a + i + j;
+
+  // update global boolean
+  g_b = true;
+
+  // update global array
+  for (uint i = 0; i < 5; i++)
+    g_a[i] = a + i;
   
   // update global 2d array
   for (uint i = 0; i < 3; i++)
     for (uint j = 0; j < 2; j++)
       g_a2d[i][j] = a + i + j;
 
-  // update global array
-  for (uint i = 0; i < 5; i++)
-    g_a[i] = a + i;
-
-  // update global boolean
-  g_b = true;
+  // update global matrix array
+  for (uint i = 0; i < 4; i++)
+    for (uint j = 0; j < 2; j++)
+      for (uint k = 0; k < 2; k++)
+        g_ma[i][j][k] = a + i + j;
 
   return float4(g_s, g_s, g_s, g_s) +
          g_v +
-         // float4(g_m[0][0], g_m[0][1], g_m[1][0], g_m[1][1]) +
+         float4(g_m[0][0], g_m[0][1], g_m[1][0], g_m[1][1]) +
+         float4(g_m_rm[0][0], g_m_rm[0][1], g_m_rm[1][0], g_m_rm[1][1]) +
+         float4(g_a[0], g_a[1], g_a[2], g_a[3]) +
          float4(g_a2d[0][0], g_a2d[0][1], g_a2d[1][0], g_a2d[1][1]) +
-         float4(g_a[0], g_a[1], g_a[2], g_a[3]);
+         float4(g_ma[0][0][0], g_ma[1][0][1], g_ma[2][1][0], g_ma[3][1][1]);
 }


### PR DESCRIPTION
- An earlier bitcast would create an unused GEP instruction referencing the matrix, which the matrix lowering code couldn't handle. Removed that GEP.
- `float1x1` was special-cased as if we lowered it to `[1 x float]`, but that's not the case, it gets lowered to `[1 x <1 x float>]`, so the more general code applies.

Fixes #1530