### PR TITLE
Fix subobject raw bytes storage; don't point into RDAT for reflection

### DIFF
--- a/include/dxc/DXIL/DxilSubobject.h
+++ b/include/dxc/DXIL/DxilSubobject.h
@@ -120,9 +120,9 @@ public:
   DxilSubobjects &operator=(const DxilSubobjects &other) = delete;
 
   // Add/find string in owned subobject strings, returning canonical ptr
-  llvm::StringRef GetSubobjectString(llvm::StringRef value);
+  llvm::StringRef InternString(llvm::StringRef value);
   // Add/find raw bytes, returning canonical ptr
-  const void *GetRawBytes(const void *ptr, size_t size);
+  const void *InternRawBytes(const void *ptr, size_t size);
   DxilSubobject *FindSubobject(llvm::StringRef name);
   void RemoveSubobject(llvm::StringRef name);
   DxilSubobject &CloneSubobject(const DxilSubobject &Subobject, llvm::StringRef Name);

--- a/include/dxc/DXIL/DxilSubobject.h
+++ b/include/dxc/DXIL/DxilSubobject.h
@@ -108,8 +108,7 @@ private:
 class DxilSubobjects {
 public:
   typedef std::pair<std::unique_ptr<char[]>, size_t> StoredBytes;
-  typedef llvm::MapVector< llvm::StringRef, StoredBytes > StringStorage;
-  typedef llvm::MapVector< const void*, StoredBytes > RawBytesStorage;
+  typedef llvm::MapVector< llvm::StringRef, StoredBytes > BytesStorage;
   typedef llvm::MapVector< llvm::StringRef, std::unique_ptr<DxilSubobject> > SubobjectStorage;
   using Kind = DXIL::SubobjectKind;
 
@@ -158,8 +157,7 @@ public:
 private:
   DxilSubobject &CreateSubobject(Kind kind, llvm::StringRef Name);
 
-  StringStorage m_StringStorage;
-  RawBytesStorage m_RawBytesStorage;
+  BytesStorage m_BytesStorage;
   SubobjectStorage m_Subobjects;
 };
 

--- a/lib/DXIL/DxilSubobject.cpp
+++ b/lib/DXIL/DxilSubobject.cpp
@@ -22,7 +22,7 @@ namespace hlsl {
 DxilSubobject::DxilSubobject(DxilSubobject &&other)
   : m_Owner(other.m_Owner),
     m_Kind(other.m_Kind),
-    m_Name(m_Owner.GetSubobjectString(other.m_Name)),
+    m_Name(m_Owner.InternString(other.m_Name)),
     m_Exports(std::move(other.m_Exports))
 {
   DXASSERT_NOMSG(DXIL::IsValidSubobjectKind(m_Kind));
@@ -32,7 +32,7 @@ DxilSubobject::DxilSubobject(DxilSubobject &&other)
 DxilSubobject::DxilSubobject(DxilSubobjects &owner, Kind kind, llvm::StringRef name)
   : m_Owner(owner),
     m_Kind(kind),
-    m_Name(m_Owner.GetSubobjectString(name)),
+    m_Name(m_Owner.InternString(name)),
     m_Exports()
 {
   DXASSERT_NOMSG(DXIL::IsValidSubobjectKind(m_Kind));
@@ -81,17 +81,17 @@ void DxilSubobject::CopyUnionedContents(const DxilSubobject &other) {
 
 void DxilSubobject::InternStrings() {
   // Transfer strings if necessary
-  m_Name = m_Owner.GetSubobjectString(m_Name).data();
+  m_Name = m_Owner.InternString(m_Name).data();
   switch (m_Kind) {
   case Kind::SubobjectToExportsAssociation:
-    SubobjectToExportsAssociation.Subobject = m_Owner.GetSubobjectString(SubobjectToExportsAssociation.Subobject).data();
+    SubobjectToExportsAssociation.Subobject = m_Owner.InternString(SubobjectToExportsAssociation.Subobject).data();
     for (auto &ptr : m_Exports)
-      ptr = m_Owner.GetSubobjectString(ptr).data();
+      ptr = m_Owner.InternString(ptr).data();
     break;
   case Kind::HitGroup:
-    HitGroup.AnyHit = m_Owner.GetSubobjectString(HitGroup.AnyHit).data();
-    HitGroup.ClosestHit = m_Owner.GetSubobjectString(HitGroup.ClosestHit).data();
-    HitGroup.Intersection = m_Owner.GetSubobjectString(HitGroup.Intersection).data();
+    HitGroup.AnyHit = m_Owner.InternString(HitGroup.AnyHit).data();
+    HitGroup.ClosestHit = m_Owner.InternString(HitGroup.ClosestHit).data();
+    HitGroup.Intersection = m_Owner.InternString(HitGroup.Intersection).data();
     break;
   default:
     break;
@@ -187,7 +187,7 @@ DxilSubobjects::DxilSubobjects(DxilSubobjects &&other)
 DxilSubobjects::~DxilSubobjects() {}
 
 
-llvm::StringRef DxilSubobjects::GetSubobjectString(llvm::StringRef value) {
+llvm::StringRef DxilSubobjects::InternString(llvm::StringRef value) {
   auto it = m_BytesStorage.find(value);
   if (it != m_BytesStorage.end())
     return it->first;
@@ -201,7 +201,7 @@ llvm::StringRef DxilSubobjects::GetSubobjectString(llvm::StringRef value) {
   return key;
 }
 
-const void *DxilSubobjects::GetRawBytes(const void *ptr, size_t size) {
+const void *DxilSubobjects::InternRawBytes(const void *ptr, size_t size) {
   auto it = m_BytesStorage.find(llvm::StringRef((const char *)ptr, size));
   if (it != m_BytesStorage.end())
     return it->first.data();
@@ -228,7 +228,7 @@ void DxilSubobjects::RemoveSubobject(llvm::StringRef name) {
 
 DxilSubobject &DxilSubobjects::CloneSubobject(
     const DxilSubobject &Subobject, llvm::StringRef Name) {
-  Name = GetSubobjectString(Name);
+  Name = InternString(Name);
   DXASSERT(FindSubobject(Name) == nullptr,
     "otherwise, name collision between subobjects");
   std::unique_ptr<DxilSubobject> ptr(new DxilSubobject(*this, Subobject, Name));
@@ -250,9 +250,9 @@ DxilSubobject &DxilSubobjects::CreateStateObjectConfig(
 DxilSubobject &DxilSubobjects::CreateRootSignature(
     llvm::StringRef Name, bool local, const void *Data, uint32_t Size, llvm::StringRef *pText /*= nullptr*/) {
   auto &obj = CreateSubobject(local ? Kind::LocalRootSignature : Kind::GlobalRootSignature, Name);
-  obj.RootSignature.Data = GetRawBytes(Data, Size);
+  obj.RootSignature.Data = InternRawBytes(Data, Size);
   obj.RootSignature.Size = Size;
-  obj.RootSignature.Text = (pText ? GetSubobjectString(*pText).data() : nullptr);
+  obj.RootSignature.Text = (pText ? InternString(*pText).data() : nullptr);
   return obj;
 }
 
@@ -262,10 +262,10 @@ DxilSubobject &DxilSubobjects::CreateSubobjectToExportsAssociation(
     llvm::StringRef *Exports,
     uint32_t NumExports) {
   auto &obj = CreateSubobject(Kind::SubobjectToExportsAssociation, Name);
-  Subobject = GetSubobjectString(Subobject);
+  Subobject = InternString(Subobject);
   obj.SubobjectToExportsAssociation.Subobject = Subobject.data();
   for (unsigned i = 0; i < NumExports; i++) {
-    obj.m_Exports.emplace_back(GetSubobjectString(Exports[i]).data());
+    obj.m_Exports.emplace_back(InternString(Exports[i]).data());
   }
   return obj;
 }
@@ -294,9 +294,9 @@ DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
                                               llvm::StringRef ClosestHit,
                                               llvm::StringRef Intersection) {
   auto &obj = CreateSubobject(Kind::HitGroup, Name);
-  AnyHit = GetSubobjectString(AnyHit);
-  ClosestHit = GetSubobjectString(ClosestHit);
-  Intersection = GetSubobjectString(Intersection);
+  AnyHit = InternString(AnyHit);
+  ClosestHit = InternString(ClosestHit);
+  Intersection = InternString(Intersection);
   obj.HitGroup.Type = hitGroupType;
   obj.HitGroup.AnyHit = AnyHit.data();
   obj.HitGroup.ClosestHit = ClosestHit.data();
@@ -305,7 +305,7 @@ DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
 }
 
 DxilSubobject &DxilSubobjects::CreateSubobject(Kind kind, llvm::StringRef Name) {
-  Name = GetSubobjectString(Name);
+  Name = InternString(Name);
   IFTBOOLMSG(FindSubobject(Name) == nullptr, DXC_E_GENERAL_INTERNAL_ERROR, "Subobject name collision");
   IFTBOOLMSG(!Name.empty(), DXC_E_GENERAL_INTERNAL_ERROR, "Empty Subobject name");
   std::unique_ptr<DxilSubobject> ptr(new DxilSubobject(*this, kind, Name));


### PR DESCRIPTION
DxilSubobject:
- combine string and raw bytes storage in m_BytesStorage
- use StringRef as key, since memcmp is used with explicit length

DxilRuntimeReflection:
- add m_BytesMap for local unique copy of raw bytes in RDAT
  to prevent pointing into RDAT blob for root sig
- clean up some insertion patterns