### PR TITLE
Fixed crash when static methods are used.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1549,12 +1549,14 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
   unsigned ParmIdx = 0;
 
   if (const CXXMethodDecl *MethodDecl = dyn_cast<CXXMethodDecl>(FD)) {
-    QualType ThisTy = MethodDecl->getThisType(FD->getASTContext());
-    DxilParameterAnnotation &paramAnnotation =
-        FuncAnnotation->GetParameterAnnotation(ArgNo++);
-    // Construct annoation for this pointer.
-    ConstructFieldAttributedAnnotation(paramAnnotation, ThisTy,
-                                       bDefaultRowMajor);
+    if (MethodDecl->isInstance()) {
+      QualType ThisTy = MethodDecl->getThisType(FD->getASTContext());
+      DxilParameterAnnotation &paramAnnotation =
+          FuncAnnotation->GetParameterAnnotation(ArgNo++);
+      // Construct annoation for this pointer.
+      ConstructFieldAttributedAnnotation(paramAnnotation, ThisTy,
+                                         bDefaultRowMajor);
+    }
   }
 
   // Ret Info

--- a/tools/clang/test/CodeGenHLSL/quick-test/static_method.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/static_method.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK: @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+
+struct Helper
+{
+    static float GetValue() { return 1; }
+};
+
+float main() : SV_Target
+{
+    return Helper::GetValue();
+}


### PR DESCRIPTION
We were unconditionally trying to manipulate the `this` pointer.
Also added a simple test.

Fixes #1711 