### PR TITLE
Fix assert following reflection changes.

### DIFF
--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -563,8 +563,9 @@ void DxilModule::SetOutputControlPointCount(unsigned NumOCPs) {
 }
 
 DXIL::TessellatorPartitioning DxilModule::GetTessellatorPartitioning() const {
-  DXASSERT(m_DxilEntryPropsMap.size() == 1 && m_pSM->IsHS(),
-           "only works for HS profile");
+  if (!m_pSM->IsHS())
+    return DXIL::TessellatorPartitioning::Undefined;
+  DXASSERT(m_DxilEntryPropsMap.size() == 1, "should have one entry prop");
   DxilFunctionProps &props = m_DxilEntryPropsMap.begin()->second->props;
   DXASSERT(props.IsHS(), "Must be HS profile");
   return props.ShaderProps.HS.partition;


### PR DESCRIPTION
`DxilModule::GetTessellatorPartitioning` didn't follow the model of other methods of returning `Undefined` when it does not apply to the shader stage and would assert.

Introduced by pull request #1704 