### PR TITLE
Fix implicit unique_ptr to bool conversion error when compiling with GCC.

### DIFF
--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -99,7 +99,7 @@ public:
   explicit ValueMap(const ExtraData &Data, unsigned NumInitBuckets = 64)
       : Map(NumInitBuckets), Data(Data) {}
 
-  bool hasMD() const { return static_cast<bool>(MDMap); } // HLSL Change
+  bool hasMD() const { return bool(MDMap); }
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);

--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -99,7 +99,7 @@ public:
   explicit ValueMap(const ExtraData &Data, unsigned NumInitBuckets = 64)
       : Map(NumInitBuckets), Data(Data) {}
 
-  bool hasMD() const { return MDMap; }
+  bool hasMD() const { return static_cast<bool>(MDMap); } // HLSL Change
   MDMapT &MD() {
     if (!MDMap)
       MDMap.reset(new MDMapT);


### PR DESCRIPTION
The function is not actually used so VC++ lazily avoids reporting an error, but GCC does.
Mimicked the fix in the official LLVM repo and omitted `// HLSL Change` to simplify merging:
https://github.com/llvm-mirror/llvm/commit/81361659c523e6cef9cd66046334fe46619b9c00#diff-6daed8fde4789051cc55875ce87080b4
Fixes #1692 