### PR TITLE
Fix row_major being lost through typedefs.

### DIFF
--- a/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_preserved_with_typedef.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_preserved_with_typedef.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// If column major, the CBuffer will have a size of 8 bytes, if row major it should be 20
+// CHECK: CBuf ; Offset: 0 Size: 20
+
+typedef row_major float2x1 rmf2x1;
+cbuffer CBuf { rmf2x1 mat; }
+float main() : SV_Target { return mat._11; }


### PR DESCRIPTION
The code attempted to cast a `QualType` to an `AttributedType`, which would fail if it was in fact a `TypedefType`. Better use the existing helper function we have.

Fixes #1647 