### PR TITLE
Mark built-in types as 'final' to prevent inheritance.

### DIFF
--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -334,6 +334,7 @@ void hlsl::AddHLSLMatrixTemplate(ASTContext& context, ClassTemplateDecl* vectorT
     context, currentDeclContext, NoLoc, DeclarationName(&matrixId),
     templateParameterList, templateRecordDecl, nullptr);
   templateRecordDecl->setDescribedClassTemplate(classTemplateDecl);
+  templateRecordDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
 
   // Requesting the class name specialization will fault in required types.
   QualType T = classTemplateDecl->getInjectedClassNameSpecialization();
@@ -436,6 +437,7 @@ void hlsl::AddHLSLVectorTemplate(ASTContext& context, ClassTemplateDecl** vector
     context, currentDeclContext, NoLoc, DeclarationName(&vectorId),
     templateParameterList, templateRecordDecl, nullptr);
   templateRecordDecl->setDescribedClassTemplate(classTemplateDecl);
+  templateRecordDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
 
   // Requesting the class name specialization will fault in required types.
   QualType T = classTemplateDecl->getInjectedClassNameSpecialization();
@@ -503,6 +505,7 @@ void hlsl::AddRecordTypeWithHandle(ASTContext& context, _Outptr_ CXXRecordDecl**
     context, TagDecl::TagKind::TTK_Struct, currentDeclContext, NoLoc, NoLoc, &newTypeId, nullptr);
   newDecl->setLexicalDeclContext(currentDeclContext);
   newDecl->setFreeStanding();
+  newDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
   newDecl->startDefinition();
   AddHLSLHandleField(context, newDecl, QualType(GetHLSLObjectHandleType(context)));
   currentDeclContext->addDecl(newDecl);
@@ -788,6 +791,7 @@ void hlsl::AddTemplateTypeWithHandle(
     context, currentDeclContext, NoLoc, DeclarationName(&typeId),
     templateParameterList, templateRecordDecl, nullptr);
   templateRecordDecl->setDescribedClassTemplate(classTemplateDecl);
+  templateRecordDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
   
   // Requesting the class name specialization will fault in required types.
   QualType T = classTemplateDecl->getInjectedClassNameSpecialization();

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2420,6 +2420,7 @@ static CXXRecordDecl *CreateRayDescStruct(clang::ASTContext &context,
   CXXRecordDecl *rayDescDecl = CXXRecordDecl::Create(
       context, TagTypeKind::TTK_Struct, currentDeclContext, NoLoc, NoLoc,
       &rayDesc, nullptr, DelayTypeCreationTrue);
+  rayDescDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
   rayDescDecl->startDefinition();
 
   QualType floatTy = context.FloatTy;
@@ -2451,6 +2452,7 @@ static CXXRecordDecl *AddBuiltInTriangleIntersectionAttributes(ASTContext& conte
     CXXRecordDecl *attributesDecl = CXXRecordDecl::Create(
         context, TagTypeKind::TTK_Struct, curDC, NoLoc, NoLoc,
         &attributesId, nullptr, DelayTypeCreationTrue);
+    attributesDecl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
     attributesDecl->startDefinition();
     // float2 barycentrics;
     CreateSimpleField(context, attributesDecl, "barycentrics", baryType);
@@ -2467,6 +2469,7 @@ static CXXRecordDecl *StartSubobjectDecl(ASTContext& context, const char *name) 
   IdentifierInfo &id = context.Idents.get(StringRef(name), tok::TokenKind::identifier);
   CXXRecordDecl *decl = CXXRecordDecl::Create( context, TagTypeKind::TTK_Struct, 
     context.getTranslationUnitDecl(), NoLoc, NoLoc, &id, nullptr, DelayTypeCreationTrue);
+  decl->addAttr(FinalAttr::CreateImplicit(context, FinalAttr::Keyword_final));
   decl->startDefinition();
   return decl;
 }

--- a/tools/clang/test/CodeGenHLSL/quick-test/builtin_types_no_inheritance.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/builtin_types_no_inheritance.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -T ps_6_0 -E main %s | FileCheck %s
+
+// CHECK: error: base 'vector' is marked 'final'
+// CHECK: error: base 'matrix' is marked 'final'
+// CHECK: error: base 'Texture3D' is marked 'final'
+// CHECK: error: base 'ByteAddressBuffer' is marked 'final'
+// CHECK: error: base 'SamplerState' is marked 'final'
+// CHECK: error: base 'TriangleStream' is marked 'final'
+// CHECK: error: base 'InputPatch' is marked 'final'
+// CHECK: error: base 'OutputPatch' is marked 'final'
+// CHECK: error: base 'RayDesc' is marked 'final'
+// CHECK: error: base 'BuiltInTriangleIntersectionAttributes' is marked 'final'
+// CHECK: error: base 'RaytracingAccelerationStructure' is marked 'final'
+// CHECK: error: base 'GlobalRootSignature' is marked 'final'
+
+struct F2 : float2 {};
+struct F4x4 : float4x4 {};
+struct Tex3D : Texture3D<float> {};
+struct BABuf : ByteAddressBuffer {};
+struct Samp : SamplerState {};
+
+struct Vertex { float3 pos : POSITION; };
+struct GSTS : TriangleStream<Vertex> {};
+struct HSIP : InputPatch<Vertex, 16> {};
+struct HSOP : OutputPatch<Vertex, 16> {};
+
+struct RD : RayDesc {};
+struct BITIA : BuiltInTriangleIntersectionAttributes {};
+struct RTAS : RaytracingAccelerationStructure {};
+struct GRS : GlobalRootSignature {};
+
+float main() : SV_Target { return 0; }


### PR DESCRIPTION
Fixes #1721 