### PR TITLE
Change in-memory representation of bool vectors to use i32's

### DIFF
--- a/include/dxc/HLSL/HLMatrixLowerHelper.h
+++ b/include/dxc/HLSL/HLMatrixLowerHelper.h
@@ -31,17 +31,27 @@ bool IsMatrixType(llvm::Type *Ty);
 DxilFieldAnnotation *FindAnnotationFromMatUser(llvm::Value *Mat,
                                                DxilTypeSystem &typeSys);
 // Translate matrix type to vector type.
-llvm::Type *LowerMatrixType(llvm::Type *Ty);
+llvm::Type *LowerMatrixType(llvm::Type *Ty, bool forMem = false);
 // TODO: use type annotation.
 llvm::Type *GetMatrixInfo(llvm::Type *Ty, unsigned &col, unsigned &row);
 // TODO: use type annotation.
 bool IsMatrixArrayPointer(llvm::Type *Ty);
 // Translate matrix array pointer type to vector array pointer type.
-llvm::Type *LowerMatrixArrayPointer(llvm::Type *Ty);
+llvm::Type *LowerMatrixArrayPointer(llvm::Type *Ty, bool forMem = false);
 
 llvm::Value *BuildVector(llvm::Type *EltTy, unsigned size,
                          llvm::ArrayRef<llvm::Value *> elts,
                          llvm::IRBuilder<> &Builder);
+
+llvm::Value *VecMatrixMemToReg(llvm::Value *VecVal, llvm::Type *MatType,
+                               llvm::IRBuilder<> &Builder);
+llvm::Value *VecMatrixRegToMem(llvm::Value* VecVal, llvm::Type *MatType,
+                               llvm::IRBuilder<> &Builder);
+llvm::Instruction *CreateVecMatrixLoad(llvm::Value *VecPtr,
+                                       llvm::Type *MatType, llvm::IRBuilder<> &Builder);
+llvm::Instruction *CreateVecMatrixStore(llvm::Value* VecVal, llvm::Value *VecPtr,
+                                        llvm::Type *MatType, llvm::IRBuilder<> &Builder);
+
 // For case like mat[i][j].
 // IdxList is [i][0], [i][1], [i][2],[i][3].
 // Idx is j.

--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -1568,7 +1568,8 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
     // Vector align to its element.
     if (getLangOpts().HLSL) {
       Align = EltInfo.Align;
-      Width = Align * VT->getNumElements();
+      if (Align > Width)
+        Width = Align * VT->getNumElements();
     }
     // HLSL Change Ends.
     // If the alignment is not a power of 2, round up to the next power of 2.

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -3877,6 +3877,15 @@ static Value *CastLdValue(Value *Ptr, llvm::Type *FromTy, llvm::Type *ToTy, IRBu
       // Change scalar into vec1.
       Value *Vec1 = UndefValue::get(ToTy);
       return Builder.CreateInsertElement(Vec1, V, (uint64_t)0);
+    } else if (vecSize == 1 && FromTy->isIntegerTy()
+      && ToTy->getVectorElementType()->isIntegerTy(1)) {
+      // load(bitcast i32* to <1 x i1>*)
+      // Rewrite to
+      // insertelement(icmp ne (load i32*), 0)
+      Value *IntV = Builder.CreateLoad(Ptr);
+      Value *BoolV = Builder.CreateICmpNE(IntV, ConstantInt::get(IntV->getType(), 0), "tobool");
+      Value *Vec1 = UndefValue::get(ToTy);
+      return Builder.CreateInsertElement(Vec1, BoolV, (uint64_t)0);
     } else if (FromTy->isVectorTy() && vecSize == 1) {
       Value *V = Builder.CreateLoad(Ptr);
       // VectorTrunc
@@ -5507,15 +5516,20 @@ static void AddMissingCastOpsInInitList(SmallVector<Value *, 4> &elts, SmallVect
 
 static void StoreInitListToDestPtr(Value *DestPtr,
                                    SmallVector<Value *, 4> &elts, unsigned &idx,
-                                   QualType Type, CodeGenTypes &Types, bool bDefaultRowMajor,
-                                   CGBuilderTy &Builder, llvm::Module &M) {
+                                   QualType Type, bool bDefaultRowMajor,
+                                   CodeGenFunction &CGF, llvm::Module &M) {
+  CodeGenTypes &Types = CGF.getTypes();
+  CGBuilderTy &Builder = CGF.Builder;
+
   llvm::Type *Ty = DestPtr->getType()->getPointerElementType();
   llvm::Type *i32Ty = llvm::Type::getInt32Ty(Ty->getContext());
 
   if (Ty->isVectorTy()) {
-    Value *Result = UndefValue::get(Ty);
-    for (unsigned i = 0; i < Ty->getVectorNumElements(); i++)
+    llvm::Type *RegTy = CGF.ConvertType(Type);
+    Value *Result = UndefValue::get(RegTy);
+    for (unsigned i = 0; i < RegTy->getVectorNumElements(); i++)
       Result = Builder.CreateInsertElement(Result, elts[idx + i], i);
+    Result = CGF.EmitToMemory(Result, Type);
     Builder.CreateStore(Result, DestPtr);
     idx += Ty->getVectorNumElements();
   } else if (HLMatrixLower::IsMatrixType(Ty)) {
@@ -5580,8 +5594,8 @@ static void StoreInitListToDestPtr(Value *DestPtr,
             unsigned i = RL.getNonVirtualBaseLLVMFieldNo(BaseDecl);
             Constant *gepIdx = ConstantInt::get(i32Ty, i);
             Value *GEP = Builder.CreateInBoundsGEP(DestPtr, {zero, gepIdx});
-            StoreInitListToDestPtr(GEP, elts, idx, parentTy, Types,
-                                   bDefaultRowMajor, Builder, M);
+            StoreInitListToDestPtr(GEP, elts, idx, parentTy,
+                                   bDefaultRowMajor, CGF, M);
           }
         }
       }
@@ -5589,8 +5603,8 @@ static void StoreInitListToDestPtr(Value *DestPtr,
         unsigned i = RL.getLLVMFieldNo(field);
         Constant *gepIdx = ConstantInt::get(i32Ty, i);
         Value *GEP = Builder.CreateInBoundsGEP(DestPtr, {zero, gepIdx});
-        StoreInitListToDestPtr(GEP, elts, idx, field->getType(), Types,
-                               bDefaultRowMajor, Builder, M);
+        StoreInitListToDestPtr(GEP, elts, idx, field->getType(),
+                               bDefaultRowMajor, CGF, M);
       }
     }
   } else if (Ty->isArrayTy()) {
@@ -5599,8 +5613,8 @@ static void StoreInitListToDestPtr(Value *DestPtr,
     for (unsigned i = 0; i < Ty->getArrayNumElements(); i++) {
       Constant *gepIdx = ConstantInt::get(i32Ty, i);
       Value *GEP = Builder.CreateInBoundsGEP(DestPtr, {zero, gepIdx});
-      StoreInitListToDestPtr(GEP, elts, idx, EltType, Types, bDefaultRowMajor,
-                             Builder, M);
+      StoreInitListToDestPtr(GEP, elts, idx, EltType, bDefaultRowMajor,
+                             CGF, M);
     }
   } else {
     DXASSERT(Ty->isSingleValueType(), "invalid type");
@@ -5780,8 +5794,8 @@ Value *CGMSHLSLRuntime::EmitHLSLInitListExpr(CodeGenFunction &CGF, InitListExpr 
     ParamList.append(EltValList.begin(), EltValList.end());
     idx = 0;
     bool bDefaultRowMajor = m_pHLModule->GetHLOptions().bDefaultRowMajor;
-    StoreInitListToDestPtr(DestPtr, EltValList, idx, ResultTy, CGF.getTypes(),
-                           bDefaultRowMajor, CGF.Builder, TheModule);
+    StoreInitListToDestPtr(DestPtr, EltValList, idx, ResultTy,
+                           bDefaultRowMajor, CGF, TheModule);
     return nullptr;
   }
 
@@ -7116,15 +7130,10 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
     BasicBlock *InsertBlock = CGF.Builder.GetInsertBlock();
     Function *F = InsertBlock->getParent();
 
-    if (ParamTy->isBooleanType()) {
-      // Create i32 for bool.
-      ParamTy = CGM.getContext().IntTy;
-    }
     // Make sure the alloca is in entry block to stop inline create stacksave.
     IRBuilder<> AllocaBuilder(dxilutil::FindAllocaInsertionPt(F));
-    tmpArgAddr = AllocaBuilder.CreateAlloca(CGF.ConvertType(ParamTy));
+    tmpArgAddr = AllocaBuilder.CreateAlloca(CGF.ConvertTypeForMem(ParamTy));
 
-      
     // add it to local decl map
     TmpArgMap(tmpArg, tmpArgAddr);
 
@@ -7202,6 +7211,8 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionCopyBack(
           outVal = CGF.Builder.CreateLoad(tmpArgAddr);
         else
           outVal = EmitHLSLMatrixLoad(CGF, tmpArgAddr, ParamTy);
+
+        outVal = CGF.EmitFromMemory(outVal, ParamTy);
 
         llvm::Type *ToTy = CGF.ConvertType(ArgTy);
         llvm::Type *FromTy = outVal->getType();

--- a/tools/clang/test/CodeGenHLSL/RValSubscript.hlsl
+++ b/tools/clang/test/CodeGenHLSL/RValSubscript.hlsl
@@ -5,7 +5,7 @@
 // CHECK: i32 5)
 // CHECK: extractvalue
 // CHECK: , 2
-// CHECK: icmp eq
+// CHECK: icmp ne
 // CHECK 0
 
 // For (x4 < 3)[1]
@@ -47,7 +47,7 @@
 // CHECK: fcmp fast oeq
 // CHECK: fcmp fast oeq
 // CHECK: fcmp fast oeq
-// CHECK: alloca [16 x i1]
+// CHECK: alloca [16 x i32]
 
 
 float4x4 xt;

--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_loadbuf_storebuf_memrepr.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_loadbuf_storebuf_memrepr.hlsl
@@ -1,0 +1,110 @@
+// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+
+// Ensure that bools are converted from/to their mem representation when loaded/stored in buffers
+
+// Constant buffer loads
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: extractvalue %dx.types.CBufRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+
+// Structured buffer loads
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: icmp ne i32 {{.*}}, 0
+
+// Structured buffer stores
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: call void @dx.op.bufferStore.i32
+  
+
+struct AllTheBools
+{
+    bool2x2 m;
+    bool2 v;
+    bool s;
+    bool2x2 ma[2];
+    bool2 va[2];
+    bool sa[2];
+};
+
+ConstantBuffer<AllTheBools> cb;
+StructuredBuffer<AllTheBools> sb;
+RWStructuredBuffer<AllTheBools> rwsb;
+
+float main(int i : I) : SV_Target
+{
+    float result = 0;
+
+    // Constant buffer loads
+    if (cb.m._22 && cb.v.y && cb.s
+        && cb.ma[1]._22 && cb.va[1].y && cb.sa[1])
+    {
+        result++;
+    }
+    
+    // Structured buffer loads
+    if (sb[0].m._22 && sb[0].v.y && sb[0].s
+        && sb[0].ma[1]._22 && sb[0].va[1].y && sb[0].sa[1])
+    {
+        result++;
+    }
+
+    // Structured buffer stores
+    if (result >= 1.0f)
+    {
+        rwsb[0].m._22 = i == 42;
+        rwsb[0].v.y = i == 42;
+        rwsb[0].s = i == 42;
+        rwsb[0].ma[1]._22 = i == 42;
+        rwsb[0].va[1].y = i == 42;
+        rwsb[0].sa[1] = i == 42;
+    }
+
+    return 0;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_memrepr.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_memrepr.hlsl
@@ -1,0 +1,52 @@
+// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+
+// Ensure that bools are converted from/to their memory representation when loaded/stored
+
+// Local variables should never be i1s
+// CHECK-not: alloca {{.*}}i1
+
+// Test stores
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+// CHECK: icmp eq i32 {{.*}}, 42
+// CHECK: zext i1 {{.*}} to i32
+// CHECK: store i32
+
+// Test loads
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: load i32
+// CHECK: icmp ne i32 {{.*}}, 0
+
+float main(int i : I) : SV_Target
+{
+    bool s = i == 42;
+    bool1 v = i == 42;
+    bool1x1 m = i == 42;
+    bool sa[1] = { i == 42 };
+    bool1 va[1] = { i == 42 };
+    bool1x1 ma[1] = { i == 42 };
+
+    return s && v.x && m._11 && sa[0] && va[0].x && ma[0]._11 ? 1.0f : 2.0f;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_scalar_swizzle.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_scalar_swizzle.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+
+// This is mostly a regression test for a bug where a bitcast
+// from i32* to i1* was emitted.
+
+// CHECK: alloca i32
+// CHECK: alloca [2 x i32]
+// CHECK-NOT: bitcast
+
+float main() : SV_Target
+{
+    bool b = true;
+    bool2 b2 = b.xx;
+    return 0;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_stress.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_stress.hlsl
@@ -1,0 +1,54 @@
+// RUN: %dxc -E main -T vs_6_0 -O0 %s
+
+// Regression test for compiler crashes in complex bool cases
+
+struct AllTheBools
+{
+    bool b : B;
+    bool ba2[2] :BA2;
+    bool1 b1 : B1;
+    bool3 b3 : B3;
+    bool3 b3a2[2] : B3A2;
+    bool1x1 b1x1 : B1X1;
+    bool2x3 b2x3 : B2X3;
+    row_major bool2x3 rmb2x3 : RMB2X3;
+    bool2x3 b2x3a2[2] : B2X3A2;
+};
+
+ConstantBuffer<AllTheBools> cb;
+StructuredBuffer<AllTheBools> sb;
+
+void not(in out bool value) { value = !value; }
+
+void not(in out bool2 value)
+{
+  value = !value;
+  not(value.x);
+  not(value.y);
+}
+
+void not(in out bool3 value)
+{
+  not(value.xz);
+  not(value.y);
+}
+
+AllTheBools main(AllTheBools input, float f : F)
+{
+    AllTheBools output;
+    output.b = input.b ? cb.b : sb[0].b;
+    output.ba2[1] = input.b;
+    output.ba2[0] = input.ba2[1];
+    output.b1 = input.b3.y;
+    output.b3 = input.b.xxx;
+    output.b3a2 = sb[0].b3a2;
+    if (sb[0].b) return cb;
+
+    output.b1x1 = cb.b2x3._22;
+    output.b2x3 = bool2x3(sb[0].b3, bool3(f > 2, input.b, false));
+    output.rmb2x3 = input.b2x3;
+    not(output.rmb2x3[0]);
+    output.b2x3a2[1] = cb.b2x3;
+    output.b2x3a2[0] = input.b2x3;
+    return output;
+}


### PR DESCRIPTION
This change fixes an inconsistency between scalar and vector bools, where the formers were stored as `i32`s in memory while the latter remained `<n x i1>`s. This lead to a number of crashes in more complex bool scenarios.

The solution is to extend Clang's strategy for scalar bools to vector of bools. Clang relies on three key functions to deal with differences between register and memory type representations which are special-cased for bools and now also for bool vectors. Several HLSL code additions did not properly leverage those functions, and this was addressed wherever possible, in some cases removing the need for special cases for bools.

To deal with matrices, a similar concept of register/memory representation was introduced in the matrix lowering code and the lowering passes were updated accordingly.

Vector changes (clang codegen):
- Change in-memory type of bool vectors to <n x i32> (`CodeGenTypes::ConvertTypeForMem` + `CodeGenFunction::EmitToMemory/EmitFromMemory`)
- Fix some HLSL-specific code additions not using `EmitToMemory/EmitFromMemory`
- Fix improper vector type size calculations in `ASTContext::getTypeInfoImpl`

Matrix changes (HL matrix lower passes):
- Introduce the concept of mem vs reg lowered matrix types and conversion helpers

Test changes:
- Added a test for bool reg/mem conversion when loading/storing locals
- Added a test for bool reg/mem conversion when loading from/storing to buffers
- Added a bool stress test which used to blow up the compiler in all kinds of ways

Further work could eliminate many of the `i1` special cases in the codebase in favor of always properly converting between reg and mem representations

Fixes #1700 
Related to #1740 