### PR TITLE
Fix CompileWhenNoMemThenOOM  test failure

### DIFF
--- a/tools/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/tools/clang/lib/Basic/DiagnosticIDs.cpp
@@ -278,7 +278,12 @@ namespace clang {
 
       unsigned getOrCreateDiagID(DiagnosticIDs::Level L, StringRef Message,
                                  DiagnosticIDs &Diags) {
-        DiagDesc D(L, Message);
+        // HLSL Change Starts
+        // ".str()" is a workaround for a bug in VC++'s STL where std::pair<T,U>::pair<T2,U2>(T2&&,U2&&)
+        // may cause a conversion operator from U2 to U to be invoked within a noexcept function.
+        // This would cause a call std::terminate if we ran out of memory and throw std::bad_alloc
+        DiagDesc D(L, Message.str());
+        // HLSL Change Ends
         // Check to see if it already exists.
         std::map<DiagDesc, unsigned>::iterator I = DiagIDs.lower_bound(D);
         if (I != DiagIDs.end() && I->first == D)

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -231,9 +231,7 @@ public:
   TEST_METHOD(CompileWhenODumpThenOptimizerMatch)
   TEST_METHOD(CompileWhenVdThenProducesDxilContainer)
 
-#ifndef DXC_ON_APPVEYOR_CI
   TEST_METHOD(CompileWhenNoMemThenOOM)
-#endif // DXC_ON_APPVEYOR_CI
   TEST_METHOD(CompileWhenShaderModelMismatchAttributeThenFail)
   TEST_METHOD(CompileBadHlslThenFail)
   TEST_METHOD(CompileLegacyShaderModelThenFail)
@@ -2580,7 +2578,6 @@ public:
   }
 };
 
-#ifndef DXC_ON_APPVEYOR_CI
 TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
@@ -2678,7 +2675,6 @@ TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
     VERIFY_ARE_EQUAL(initialRefCount, InstrMalloc.GetRefCount());
   }
 }
-#endif // DXC_ON_APPVEYOR_CI
 
 TEST_F(CompilerTest, CompileWhenShaderModelMismatchAttributeThenFail) {
   CComPtr<IDxcCompiler> pCompiler;


### PR DESCRIPTION
I got bothered by always hitting this failure and investigated. It turns out that this is a regression in the VC++ STL implementation, but there's a simple workaround. See code comments for description. I'm following up with the compiler guys to report it. I've also re-enabled the appveyor test.

Fixes #1464 