### PR TITLE
Fix invalid CmpEQ(%bool,0) for converting bools

### DIFF
--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_matrix_cbuflegacy_conversion.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_matrix_cbuflegacy_conversion.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+
+struct Struct { bool2x2 mat; };
+ConstantBuffer<Struct> cb;
+bool2x2 main() : B { return cb.mat; }

--- a/tools/clang/test/CodeGenHLSL/quick-test/bool_matrix_conversion.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/bool_matrix_conversion.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: icmp ne i32 {{.*}}, 0
+// CHECK: fcmp fast one float {{.*}}, 0.000000e+00
+// CHECK: fcmp fast one float {{.*}}, 0.000000e+00
+// CHECK: fcmp fast one float {{.*}}, 0.000000e+00
+// CHECK: fcmp fast one float {{.*}}, 0.000000e+00
+
+struct Input
+{
+    int2x2 i : I;
+    float2x2 f : F;
+};
+
+struct Output
+{
+    bool2x2 i : I;
+    bool2x2 f : F;
+};
+
+Output main(Input input)
+{
+    Output output;
+    output.i = (bool2x2)input.i;
+    output.f = (bool2x2)input.f;
+    return output;
+}


### PR DESCRIPTION
The matrix lowering code special-cased bools and converted from i32s using `CmpEQ(%bool,0)` instead of `CmpNE(%bool,0)` in a few places. This change fixes it, where possible by leveraging `MemToReg` to remove the special cases.

Fixes #1740