### PR TITLE
Explicit assign the symbol visibility

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -511,7 +511,7 @@ public:                                                                        \
 private:                                                                       \
   static const char T##_ID;
 
-#define DEFINE_CROSS_PLATFORM_UUIDOF(T) const char T::T##_ID = '\0';
+#define DEFINE_CROSS_PLATFORM_UUIDOF(T) __attribute__((visibility("default"))) const char T::T##_ID = '\0';
 #define __uuidof(T) T::uuidof()
 #define IID_PPV_ARGS(ppType)                                                   \
   (**(ppType)).uuidof(), reinterpret_cast<void **>(ppType)

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -13,8 +13,18 @@
 #ifndef __DXC_API__
 #define __DXC_API__
 
-#ifndef DXC_API_IMPORT
-#define DXC_API_IMPORT __declspec(dllimport)
+#ifdef _WIN32
+#define DXC_SYMBOL_IMPORT __declspec(dllimport)
+#define DXC_SYMBOL_EXPORT __declspec(dllexport)
+#else
+#define DXC_SYMBOL_IMPORT __attribute__((visibility("default")))
+#define DXC_SYMBOL_EXPORT __attribute__((visibility("default")))
+#endif
+
+#ifdef BUILDING_DXC_DLL
+#define DXC_API DXC_SYMBOL_EXPORT
+#else
+#define DXC_API DXC_SYMBOL_IMPORT
 #endif
 
 #ifdef _WIN32
@@ -80,7 +90,7 @@ typedef HRESULT(__stdcall *DxcCreateInstance2Proc)(
 #ifndef _MSC_VER
 extern "C"
 #endif
-DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
+DXC_API HRESULT __stdcall DxcCreateInstance(
   _In_ REFCLSID   rclsid,
   _In_ REFIID     riid,
   _Out_ LPVOID*   ppv
@@ -89,7 +99,7 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
 #ifndef _MSC_VER
 extern "C"
 #endif
-DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
+DXC_API HRESULT __stdcall DxcCreateInstance2(
   _In_ IMalloc    *pMalloc,
   _In_ REFCLSID   rclsid,
   _In_ REFIID     riid,

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -11,7 +11,7 @@
 
 #include "dxc/Support/WinIncludes.h"
 
-#define DXC_API_IMPORT __declspec(dllexport)
+#define BUILDING_DXC_DLL
 
 #include "dxc/dxcisense.h"
 #include "dxc/dxctools.h"
@@ -121,7 +121,7 @@ static HRESULT ThreadMallocDxcCreateInstance(
   return hr;
 }
 
-DXC_API_IMPORT HRESULT __stdcall
+DXC_API HRESULT __stdcall
 DxcCreateInstance(
   _In_ REFCLSID   rclsid,
   _In_ REFIID     riid,
@@ -138,7 +138,7 @@ DxcCreateInstance(
   return hr;
 }
 
-DXC_API_IMPORT HRESULT __stdcall
+DXC_API HRESULT __stdcall
 DxcCreateInstance2(
   _In_ IMalloc    *pMalloc,
   _In_ REFCLSID   rclsid,

--- a/tools/clang/tools/dxrfallbackcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcapi.cpp
@@ -11,7 +11,7 @@
 
 #include "dxc/Support/WinIncludes.h"
 
-#define DXC_API_IMPORT __declspec(dllexport)
+#define BUILDING_DXC_DLL
 
 #include "dxc/dxctools.h"
 #include "dxc/Support/Global.h"
@@ -37,7 +37,7 @@ static HRESULT ThreadMallocDxcCreateInstance(
   return hr;
 }
 
-DXC_API_IMPORT HRESULT __stdcall
+DXC_API HRESULT __stdcall
 DxcCreateDxrFallbackCompiler(
   _In_ REFCLSID   rclsid,
   _In_ REFIID     riid,


### PR DESCRIPTION
This modification is based on https://gcc.gnu.org/wiki/Visibility. In this change, export entries are explicitly marked as default visibility. If put -fvisibility=hidden to CXXFLAGS, dxcompiler binary size reduces for ~25%.