### PR TITLE
Add rawBufferLoad/rawBufferStore tests for the compute pipeline

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -583,17 +583,181 @@
   </ShaderOp>
 
   <ShaderOp Name="ComputeRawBufferLdStI32" CS="CS">
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_SINT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="4" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="4" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="4" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="4" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_2">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
   </ShaderOp>>
+  
   <ShaderOp Name="ComputeRawBufferLdStFloat" CS="CS">
-  </ShaderOp>>
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="160" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="480" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32_FLOAT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="4" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="4" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="4" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="4" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_2">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
+  
   <ShaderOp Name="ComputeRawBufferLdStI64" CS="CS">
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="8" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="8" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="8" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="8" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_3">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
   </ShaderOp>>
   <ShaderOp Name="ComputeRawBufferLdStDouble" CS="CS">
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="320" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="960" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R32G32_SINT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="8" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="8" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="8" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="8" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_3">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
   </ShaderOp>>
   <ShaderOp Name="ComputeRawBufferLdStI16" CS="CS">
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_SINT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_SINT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="2" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="2" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="2" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="2" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_2" Arguments="/enable-16bit-types">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
   </ShaderOp>>
   <ShaderOp Name="ComputeRawBufferLdStHalf" CS="CS">
-  </ShaderOp>>
+    <RootSignature>RootFlags(0), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="80" InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_FLOAT" ReadBack="true" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" Format="R16_FLOAT" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' NumElements="10" StructureByteStride="2" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="10" StructureByteStride="2" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' NumElements="30" StructureByteStride="2" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="30" StructureByteStride="2" />
+    </DescriptorHeap>
+    <Shader Name="CS" Target="cs_6_2" Arguments="/enable-16bit-types">
+      <![CDATA[
+    void main(uint GI : SV_GroupIndex) {};
+    ]]>
+    </Shader>
+  </ShaderOp>
   
   <ShaderOp Name="GraphicsRawBufferLdStI32" PS="PS" VS="VS">
   </ShaderOp>


### PR DESCRIPTION
Covers:
- SRV (Load) and UAV buffers (Load, Store)
- declared in root signature as root values and in a descriptor table
- used as [RW]ByteAddressBuffer and [RW]StructuredBuffer
- data types half, float, double, int16_t, int32_t, int64_t,
- scalar type + vectors with 2 to 4 elements

The 16-bit type tests are temporarily disabled because of a bug in WARP
(set to Priority 2 and not run by hcttest).

The 64-bit type tests are disabled the same way until WARP supports shader
model 6.3.