### PR TITLE
Fix debug info for arguments in EmitParmDecl during CodeGen

### DIFF
--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -1865,11 +1865,7 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, llvm::Value *Arg,
   if (CGDebugInfo *DI = getDebugInfo()) {
     if (CGM.getCodeGenOpts().getDebugInfo()
           >= CodeGenOptions::LimitedDebugInfo) {
-      // HLSL Change Begins.
-      // Use the Arg directly instead of DeclPtr for HLSL.
-      // The DeclPtr will be promoted in later pass.
-      DI->EmitDeclareOfArgVariable(&D, Arg, ArgNo, Builder);
-      // HLSL Change Ends.
+      DI->EmitDeclareOfArgVariable(&D, DeclPtr, ArgNo, Builder);
     }
   }
 


### PR DESCRIPTION
Fixes #1705

- Declare of arg variable would point to non-pointer value, which was not
  legal llvm.
- This change fixes that, but SROA_HLSL will be unable to find the arg's
  debug info in certain cases.  That code has to be changed anyways,
  so that fix needs to come in a later change.