### PR TITLE
Fix use-after-free due to by-value Twine parameters.

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -69,8 +69,8 @@ namespace dxilutil {
                              llvm::Function *PatchConstantFunc, bool IsLib);
   void EmitErrorOnInstruction(llvm::Instruction *I, llvm::StringRef Msg);
   void EmitResMappingError(llvm::Instruction *Res);
-  std::string FormatMessageAtLocation(const llvm::DebugLoc &DL, llvm::Twine Msg);
-  llvm::Twine FormatMessageWithoutLocation(llvm::Twine Msg);
+  std::string FormatMessageAtLocation(const llvm::DebugLoc &DL, const llvm::Twine& Msg);
+  llvm::Twine FormatMessageWithoutLocation(const llvm::Twine& Msg);
   // Simple demangle just support case "\01?name@" pattern.
   llvm::StringRef DemangleFunctionName(llvm::StringRef name);
   // ReplaceFunctionName replaces the undecorated portion of originalName with undecorated newName

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -229,7 +229,7 @@ static bool EmitErrorOnInstructionFollowPhiSelect(
   return false;
 }
 
-std::string FormatMessageAtLocation(const DebugLoc &DL, Twine Msg) {
+std::string FormatMessageAtLocation(const DebugLoc &DL, const Twine& Msg) {
   std::string locString;
   raw_string_ostream os(locString);
   DL.print(os);
@@ -237,8 +237,8 @@ std::string FormatMessageAtLocation(const DebugLoc &DL, Twine Msg) {
   return os.str();
 }
 
-Twine FormatMessageWithoutLocation(Twine Msg) {
-  return Twine(Msg) + " Use /Zi for source location.";
+Twine FormatMessageWithoutLocation(const Twine& Msg) {
+  return Msg + " Use /Zi for source location.";
 }
 
 void EmitErrorOnInstruction(Instruction *I, StringRef Msg) {


### PR DESCRIPTION
`llvm::Twine`s are dangerous. When concatenated, they store a pointer to their operands to defer the actual string concatenation as long as possible. Hence every `Twine` being concatenated must be kept alive. `FormatMessageWithoutLocation` took a twine by value, concatenated, and returned the result. This means that the concatenation pointed to the by-value argument, which gets destroyed when the function returns.