### PR TITLE
Improve handling of semantics through SROA

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -72,25 +72,6 @@ STATISTIC(NumAdjusted, "Number of scalar allocas adjusted to allow promotion");
 
 namespace {
 
-  // When replacing aggregates by scalars,
-  // the first scalar will preserve the original semantic,
-  // and the subsequent ones will temporarily use this value.
-  // We then run a pass to fix the semantics and properly renumber them
-  // once the aggregate has been fully expanded.
-  // 
-  // For example:
-  // struct Foo { float a; float b; };
-  // void main(Foo foo : TEXCOORD0, float bar : TEXCOORD0)
-  //
-  // Will be expanded to
-  // void main(float a : TEXCOORD0, float b : *, float bar : TEXCOORD0)
-  //
-  // And then fixed up to
-  // void main(float a : TEXCOORD0, float b : TEXCOORD1, float bar : TEXCOORD0)
-  //
-  // (which will later on fail validation due to duplicate semantics).
-  constexpr const char *ContinuedPseudoSemantic = "*";
-
 class SROA_Helper {
 public:
   // Split V into AllocaInsts with Builder and save the new AllocaInsts into Elts.
@@ -4451,6 +4432,25 @@ private:
   std::unordered_set<Value *> castRowMajorParamMap;
   bool m_HasDbgInfo;
 };
+
+// When replacing aggregates by its scalar elements,
+// the first element will preserve the original semantic,
+// and the subsequent ones will temporarily use this value.
+// We then run a pass to fix the semantics and properly renumber them
+// once the aggregate has been fully expanded.
+// 
+// For example:
+// struct Foo { float a; float b; };
+// void main(Foo foo : TEXCOORD0, float bar : TEXCOORD0)
+//
+// Will be expanded to
+// void main(float a : TEXCOORD0, float b : *, float bar : TEXCOORD0)
+//
+// And then fixed up to
+// void main(float a : TEXCOORD0, float b : TEXCOORD1, float bar : TEXCOORD0)
+//
+// (which will later on fail validation due to duplicate semantics).
+constexpr const char *ContinuedPseudoSemantic = "*";
 }
 
 char SROA_Parameter_HLSL::ID = 0;

--- a/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_0 -E main -WX %s | FileCheck %s
+
+// CHECK: semantic 'COLOR0' on struct field will be ignored
+
+struct Input
+{
+    float a;
+    float b : COLOR0;
+};
+
+float main(Input input : TEXCOORD0) : SV_Target
+{
+    return 1;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning.hlsl
@@ -1,11 +1,11 @@
 // RUN: %dxc -T ps_6_0 -E main -WX %s | FileCheck %s
 
-// CHECK: semantic 'COLOR0' on struct field will be ignored
+// CHECK: semantic 'NORMAL0' on field overridden by function or enclosing type
 
 struct Input
 {
     float a;
-    float b : COLOR0;
+    float b : NORMAL0;
 };
 
 float main(Input input : TEXCOORD0) : SV_Target

--- a/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning_return_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/semantics_conflict_warning_return_struct.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc -T ps_6_0 -E main -WX %s | FileCheck %s
+
+// CHECK: semantic 'COLOR0' on field overridden by function or enclosing type
+
+struct Output
+{
+    float a;
+    float b : COLOR0;
+};
+
+Output main() : SV_Target
+{
+    Output output;
+    output.a = 1;
+    output.b = 2;
+    return output;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/semantics_duplicate_param_error.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/semantics_duplicate_param_error.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T ps_6_0 -E main %s | FileCheck %s
+
+// Tests that we prevent multiple inputs/outputs from having the same semantics.
+
+// CHECK: validation errors
+// CHECK: Semantic 'TEXCOORD' overlap at 0
+
+float main(float u : TEXCOORD0, float v : TEXCOORD0) : SV_Target { return 1; }

--- a/tools/clang/test/CodeGenHLSL/quick-test/semantics_duplicate_struct_error.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/semantics_duplicate_struct_error.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T ps_6_0 -E main %s | FileCheck %s
+
+// Tests that we prevent multiple inputs/outputs from having the same semantics.
+// Also serves as a regresion test for an SROA crash in the struct case.
+
+// CHECK: validation errors
+// CHECK: Semantic 'TEXCOORD' overlap at 0
+
+struct Texcoords
+{
+    float u : TEXCOORD0;
+    float v : TEXCOORD0;
+};
+
+float main(Texcoords texcoords) : SV_Target
+{
+    return 1;
+}


### PR DESCRIPTION
This mainly fixes a crash with this code:

```
struct Input { float a : TEXCOORD0; float b : TEXCOORD0; };
float main(Input input) : SV_Target { return 1; }
```

The crash happened because of our strategy for handling this:

```
struct Input { float a; float b; };
float main(Input input : TEXCOORD0) : SV_Target { return 1; }
```

When expanding `Input`, we would label every field with the original semantic, so we would end up with two parameters annotated `TEXCOORD0`, we would then run a pass on all adjacent `TEXCOORD0` parameters and change them to properly number them. However, this couldn't detect the situation in my original snippet, where we have two 'TEXCOORD0' in a row that are not the expansion of a struct marked with that semantic. It incorrectly attempted to renumber `b` in a way that ended up crashing.

The solution is to change the strategy: when expanding a struct marked with a semantic, only the first field is now emitted with that same semantic, and all subsequent ones get assigned a dummy semantic '*'. Once the parameter expansion completes, we do a pass and renumber all '*' semantics based on their preceding legit semantic. Since '*' is not a valid semantic, we can't get confused with other fields having the same semantic.

I also added a warning for this case:
```
struct Input { float a : NORMAL0; };
float main(Input input : TEXCOORD0) : SV_Target { return 1; }
```

Fixes #1771
Fixes #1774