### PR TITLE
Fixed crash with #pragma pack_matrix followed by explicit orientation

### DIFF
--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -4304,7 +4304,8 @@ static TypeSourceInfo *GetFullTypeForDeclarator(TypeProcessingState &state,
 
 // HLSL changes begin
 bool Sema::GetAttributedTypeWithMatrixPackingInfo(QualType& T, QualType *RetTy) {
-  if (getLangOpts().HLSL && hlsl::IsHLSLMatType(T)) {
+  bool isRowMajorAttributed;
+  if (getLangOpts().HLSL && hlsl::IsHLSLMatType(T) && !hlsl::HasHLSLMatOrientation(T, &isRowMajorAttributed)) {
     if (PackMatrixColMajorPragmaOn || PackMatrixRowMajorPragmaOn) {
       *RetTy = Context.getAttributedType(
         PackMatrixRowMajorPragmaOn

--- a/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_overrides.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_overrides.hlsl
@@ -1,0 +1,38 @@
+// RUN: %dxc /T vs_6_0 /E main /Zpr %s | FileCheck %s | XFail GitHub #1788
+
+// Test effective matrix orientations with every combination
+// of default and explicit matrix orientations.
+
+struct S1 { column_major int2x2 mat; };
+struct S2 { int2x2 mat; }; // Default to row_major from /Zpr
+
+#pragma pack_matrix(column_major)
+struct S3 { row_major int2x2 mat; };
+struct S4 { int2x2 mat; }; // Default to column_major from #pragma
+
+#pragma pack_matrix(row_major)
+struct S5 { column_major int2x2 mat; };
+struct S6 { int2x2 mat; }; // Default to row_major from #pragma
+
+RWStructuredBuffer<S1> sb1;
+RWStructuredBuffer<S2> sb2;
+RWStructuredBuffer<S3> sb3;
+RWStructuredBuffer<S4> sb4;
+RWStructuredBuffer<S5> sb5;
+RWStructuredBuffer<S6> sb6;
+
+void main()
+{
+    // CHECK: i32 11, i32 21, i32 12, i32 22
+    sb1[0].mat = int2x2(11, 12, 21, 22);
+    // CHECK: i32 11, i32 12, i32 21, i32 22
+    sb2[0].mat = int2x2(11, 12, 21, 22);
+    // CHECK: i32 11, i32 12, i32 21, i32 22
+    sb3[0].mat = int2x2(11, 12, 21, 22);
+    // CHECK: i32 11, i32 21, i32 12, i32 22
+    sb4[0].mat = int2x2(11, 12, 21, 22);
+    // CHECK: i32 11, i32 21, i32 12, i32 22
+    sb5[0].mat = int2x2(11, 12, 21, 22);
+    // CHECK: i32 11, i32 12, i32 21, i32 22
+    sb6[0].mat = int2x2(11, 12, 21, 22);
+}


### PR DESCRIPTION
Thanks to Vishal for the fix!

I'm submitting an XFail'ing test for another bug that would previously crash due to this issue, so it works as a regression test at the same time (XFail won't make a crashing test succeed).

Fixes #1787