### PR TITLE
[linux-port] Fix gcc build error.

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5360,7 +5360,7 @@ Value *SROA_Parameter_HLSL::castArgumentIfRequired(
 }
 
 struct AnnotatedValue {
-  Value *Value;
+  llvm::Value *Value;
   DxilFieldAnnotation Annotation;
 };
 


### PR DESCRIPTION
There's some discussion on this issue here:
http://www.cplusplus.com/forum/general/171799/

Clang builds (on Linux and macOS) were not broken. only gcc.