### PR TITLE
Add rawBufferLoad/rawBufferStore tests for the graphics pipeline

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -666,18 +666,183 @@
     </Shader>
   </ShaderOp>>
 
-  <ShaderOp Name="GraphicsRawBufferLdStI32" PS="PS" VS="VS">
+  <ShaderOp Name="GraphicsRawBufferLdSt32Bit" PS="PS" VS="VS">
+    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="40"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="40"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="40"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="40"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="120" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="120" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="120" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="120" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="VBuffer" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" Topology="TRIANGLELIST">
+      { { -1.0f, 1.0f,  0.0f } },
+      { {  1.0f, 1.0f,  0.0f } },
+      { { -1.0f, -1.0f, 0.0f } },
+
+      { { -1.0f, -1.0f, 0.0f } },
+      { {  1.0f,  1.0f, 0.0f } },
+      { {  1.0f, -1.0f, 0.0f } }
+    </Resource>
+    <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_UINT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' Flags='RAW' NumElements="10" Format="R32_TYPELESS" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="1" StructureByteStride="40" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' Flags='RAW' NumElements="30" Format="R32_TYPELESS" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="1" StructureByteStride="120" />
+    </DescriptorHeap>
+    <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
+      <Descriptor Name="RTarget" Kind="RTV"/>
+    </DescriptorHeap>
+    <InputElements>
+      <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
+    </InputElements>
+    <RenderTargets>
+      <RenderTarget Name="RTarget"/>
+    </RenderTargets>
+    <Shader Name="VS" Target="vs_6_2">
+      <![CDATA[
+        struct PSInput {
+          float4 pos : SV_POSITION;
+        };
+        PSInput main(float3 pos : POSITION) {
+          PSInput r;
+          r.pos = float4(pos, 1); 
+          return r;
+        }
+      ]]>
+    </Shader>
+    <Shader Name="PS" Target="ps_6_2">
+      <![CDATA[// Shader source code will be set at runtime]]>
+    </Shader>
   </ShaderOp>
-  <ShaderOp Name="GraphicsRawBufferLdStFloat" PS="PS" VS="VS">
+  
+  <ShaderOp Name="GraphicsRawBufferLdSt64Bit" PS="PS" VS="VS">
+    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="80"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="80"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="80"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="80"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="240" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="VBuffer" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" Topology="TRIANGLELIST">
+      { { -1.0f, 1.0f,  0.0f } },
+      { {  1.0f, 1.0f,  0.0f } },
+      { { -1.0f, -1.0f, 0.0f } },
+
+      { { -1.0f, -1.0f, 0.0f } },
+      { {  1.0f,  1.0f, 0.0f } },
+      { {  1.0f, -1.0f, 0.0f } }
+    </Resource>
+    <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_UINT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' Flags='RAW' NumElements="20" Format="R32_TYPELESS" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="1" StructureByteStride="80" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' Flags='RAW' NumElements="60" Format="R32_TYPELESS" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="1" StructureByteStride="240" />
+    </DescriptorHeap>
+    <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
+      <Descriptor Name="RTarget" Kind="RTV"/>
+    </DescriptorHeap>
+    <InputElements>
+      <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
+    </InputElements>
+    <RenderTargets>
+      <RenderTarget Name="RTarget"/>
+    </RenderTargets>
+    <Shader Name="VS" Target="vs_6_2">
+      <![CDATA[
+        struct PSInput {
+          float4 pos : SV_POSITION;
+        };
+        PSInput main(float3 pos : POSITION) {
+          PSInput r;
+          r.pos = float4(pos, 1); 
+          return r;
+        }
+      ]]>
+    </Shader>
+    <Shader Name="PS" Target="ps_6_2">
+      <![CDATA[// Shader source code will be set at runtime]]>
+    </Shader>
   </ShaderOp>
-  <ShaderOp Name="GraphicsRawBufferLdStI64" PS="PS" VS="VS">
+
+  <ShaderOp Name="GraphicsRawBufferLdSt16Bit" PS="PS" VS="VS">
+    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), SRV(t0), SRV(t1), UAV(u0), UAV(u1), DescriptorTable(SRV(t2,numDescriptors=2), UAV(u2,numDescriptors=2))</RootSignature>
+    <Resource Name="SRVBuffer0" Dimension="BUFFER" Width="20"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer1" Dimension="BUFFER" Width="20"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="SRVBuffer2" Dimension="BUFFER" Width="20"  InitialResourceState="COPY_DEST" Init="ByName" Format="R32_TYPELESS"/>
+    <Resource Name="SRVBuffer3" Dimension="BUFFER" Width="20"  InitialResourceState="COPY_DEST" Init="ByName" />
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="60" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer1" Dimension="BUFFER" Width="60" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="UAVBuffer2" Dimension="BUFFER" Width="60" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" Format="R32_TYPELESS" />
+    <Resource Name="UAVBuffer3" Dimension="BUFFER" Width="60" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ByName" ReadBack="true" />
+    <Resource Name="VBuffer" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" Topology="TRIANGLELIST">
+      { { -1.0f, 1.0f,  0.0f } },
+      { {  1.0f, 1.0f,  0.0f } },
+      { { -1.0f, -1.0f, 0.0f } },
+
+      { { -1.0f, -1.0f, 0.0f } },
+      { {  1.0f,  1.0f, 0.0f } },
+      { {  1.0f, -1.0f, 0.0f } }
+    </Resource>
+    <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_UINT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="SRVBuffer0" />
+      <RootValue Index="1" ResName="SRVBuffer1" />
+      <RootValue Index="2" ResName="UAVBuffer0" />
+      <RootValue Index="3" ResName="UAVBuffer1" />
+      <RootValue Index="4" HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='SRVBuffer2' Kind='SRV' ResName='SRVBuffer2' Flags='RAW' NumElements="5" Format="R32_TYPELESS" />
+      <Descriptor Name='SRVBuffer3' Kind='SRV' ResName='SRVBuffer3' NumElements="1" StructureByteStride="20" />
+      <Descriptor Name='UAVBuffer2' Kind='UAV' ResName='UAVBuffer2' Flags='RAW' NumElements="15" Format="R32_TYPELESS" />
+      <Descriptor Name='UAVBuffer3' Kind='UAV' ResName='UAVBuffer3' NumElements="1" StructureByteStride="60" />
+    </DescriptorHeap>
+    <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
+      <Descriptor Name="RTarget" Kind="RTV"/>
+    </DescriptorHeap>
+    <InputElements>
+      <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
+    </InputElements>
+    <RenderTargets>
+      <RenderTarget Name="RTarget"/>
+    </RenderTargets>
+    <Shader Name="VS" Target="vs_6_2">
+      <![CDATA[
+        struct PSInput {
+          float4 pos : SV_POSITION;
+        };
+        PSInput main(float3 pos : POSITION) {
+          PSInput r;
+          r.pos = float4(pos, 1); 
+          return r;
+        }
+      ]]>
+    </Shader>
+    <Shader Name="PS" Target="ps_6_2">
+      <![CDATA[// Shader source code will be set at runtime]]>
+    </Shader>
   </ShaderOp>
-  <ShaderOp Name="GraphicsRawBufferLdStDouble" PS="PS" VS="VS">
-  </ShaderOp>
-  <ShaderOp Name="GraphicsRawBufferLdSt16" PS="PS" VS="VS">
-  </ShaderOp>
-  <ShaderOp Name="GraphicsRawBufferLdStHalf" PS="PS" VS="VS">
-  </ShaderOp>
+
   <!--
   TODO: Dynamically index into tables
   -->

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -6156,7 +6156,7 @@ void ExecutionTest::RunComputeRawBufferLdStTest(D3D_SHADER_MODEL shaderModel, Ra
      VERIFY_IS_TRUE(((0 == strncmp(Name, "SRVBuffer", 9)) || (0 == strncmp(Name, "UAVBuffer", 9))) &&
                     (Name[9] >= '0' && Name[9] <= '3'));
      pShaderOp->Shaders.at(0).Arguments = compilerOptions;
-     pShaderOp->Shaders.at(1).Text = rawBufferTestShaderText;
+     pShaderOp->Shaders.at(0).Text = rawBufferTestShaderText;
 
      VERIFY_IS_TRUE(sizeof(RawBufferLdStTestData<Ty>) <= Data.size());
      RawBufferLdStTestData<Ty> *pInData = (RawBufferLdStTestData<Ty>*)Data.data();


### PR DESCRIPTION
Covers:
- SRV (Load) and UAV buffers (Load, Store)
- declared in root signature as root values and in a descriptor table
- used as [RW]ByteAddressBuffer and [RW]StructuredBuffer
- data types half, float, double, int16_t, int32_t, int64_t,
- scalar type + vectors with 2 to 4 elements

The 16-bit type tests are temporarily disabled because of a bug in WARP
(set to Priority 2 and not run by hcttest).