### PR TITLE
Fixed matrices being returned after a store with the wrong orientation

### DIFF
--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -1122,7 +1122,7 @@ void CodeGenFunction::EmitReturnStmt(const ReturnStmt &S) {
     case TEK_Scalar:
       // HLSL Change Begins.
       if (hlsl::IsHLSLMatType(RV->getType())) {
-        CGM.getHLSLRuntime().EmitHLSLMatrixStore(*this, EmitScalarExpr(RV), ReturnValue, RV->getType());
+        CGM.getHLSLRuntime().EmitHLSLMatrixStore(*this, EmitScalarExpr(RV), ReturnValue, FnRetTy);
       } else
         // HLSL Change Ends.
         Builder.CreateStore(EmitScalarExpr(RV), ReturnValue);

--- a/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_output_return.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_output_return.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T vs_6_0 /E main %s | FileCheck %s | XFail GitHub #1790
+// RUN: %dxc /T vs_6_0 /E main %s | FileCheck %s
 
 // Test that outputting a matrix value through a return statement
 // correctly takes the return parameter orientation into account.

--- a/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_transpose_in_function.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/matrix_orientation_transpose_in_function.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T vs_6_0 /E main > %s | FileCheck %s | XFail GitHub #1781
+// RUN: %dxc /T vs_6_0 /E main > %s | FileCheck %s
 
 // Regression test for a bug where the transpose isn't performed,
 // or is performed twice, when wrapped in its own function.


### PR DESCRIPTION
When storing to the clang-generated temporary variable for the return value, use the matrix type from the return type, not from the return value (which is irrelevant), as to store with the proper orientation.

Fixes #1781 
Fixes #1790 