### PR TITLE
Add a test suite for casting between type shapes

### DIFF
--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_scalar.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_scalar.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int array[] = { 1 };
+    return (int)array;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_struct.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+struct S { int x, y; };
+S main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 1, i32 0, i8 0, i32 2)
+    int array[] = { 1, 2 };
+    return (S)array;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/array_to_vector.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1795
+
+int2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 2)
+    int array[] = { 1, 2 };
+    return (int2)array;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_array.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_array.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1808
+
+typedef int i4[4];
+i4 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 11)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 1, i8 0, i32 12)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 2, i8 0, i32 21)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 3, i8 0, i32 22)
+    int2x2 m = int2x2(11, 12, 21, 22);
+    return (i4)m;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_array_return_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_array_return_vector.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+typedef int i4[4];
+int4 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 11)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 12)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 2, i32 21)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 3, i32 22)
+    int2x2 m = int2x2(11, 12, 21, 22);
+    i4 a = (i4)m;
+    return int4(a[0], a[1], a[2], a[3]); // Workaround for GitHub #1808 - DXC doesn't support array return types
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_scalar.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_scalar.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 11)
+    int1x1 m = int1x1(11);
+    return (int)m;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_struct.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+struct S { int a, b, c, d; };
+S main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 11)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 1, i32 0, i8 0, i32 12)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 2, i32 0, i8 0, i32 21)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 3, i32 0, i8 0, i32 22)
+    int2x2 m = int2x2(11, 12, 21, 22);
+    return (S)m;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/matrix_to_vector.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int4 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 11)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 12)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 2, i32 21)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 3, i32 22)
+    int2x2 m = int2x2(11, 12, 21, 22);
+    return (int4)m;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_array.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_array.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1808
+
+typedef int i1[1];
+i1 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int v = 1;
+    return (i1)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_array_return_scalar.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_array_return_scalar.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+typedef int i1[1];
+int main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int v = 1;
+    i1 a = (i1)v;
+    return a[0]; // Workaround for GitHub #1808 - DXC doesn't support array return types
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_matrix.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_matrix.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int1x2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int v = 1;
+    return (int1x2)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_struct.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+struct S { int x; };
+S main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int v = 1;
+    return (S)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/scalar_to_vector.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int1 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int v = 1;
+    return (int1)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_array.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_array.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1808
+
+struct S { int x, y; };
+typedef int i2[2];
+i2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 1, i8 0, i32 2)
+    S s = { 1, 2 };
+    return (i2)s;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_array_return_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_array_return_vector.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+struct S { int x, y; };
+typedef int i2[2];
+int2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 2)
+    S s = { 1, 2 };
+    i2 a = (i2)s;
+    return int2(a[0], a[1]); // Workaround for GitHub #1808 - DXC doesn't support array return types
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/struct_to_vector.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1795
+
+struct S { int x, y; };
+int2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 2)
+    S s = { 1, 2 };
+    return (int2)s;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_array.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_array.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #1808
+
+typedef int i2[2];
+i2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 1, i8 0, i32 2)
+    int2 v = int2(1, 2);
+    return (i2)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_array_return_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_array_return_vector.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+typedef int i2[2];
+int2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 2)
+    int2 v = int2(1, 2);
+    i2 a = (i2)v;
+    return int2(a[0], a[1]); // Workaround for GitHub #1808 - DXC doesn't support array return types
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_matrix.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_matrix.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+row_major int2x2 main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 2)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 1, i8 0, i32 3)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 1, i8 1, i32 4)
+    int4 v = int4(1, 2, 3, 4);
+    return (int2x2)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_scalar.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_scalar.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+int main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    int1 v = int1(1);
+    return (int)v;
+}

--- a/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cast_between_type_shapes/vector_to_struct.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+struct S { int x, y; };
+S main() : OUT
+{
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: @dx.op.storeOutput.i32(i32 5, i32 1, i32 0, i8 0, i32 2)
+    int2 v = int2(1, 2);
+    return (S)v;
+}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -302,6 +302,7 @@ public:
   TEST_METHOD(CodeGenCalcLod2DArray)
   TEST_METHOD(CodeGenCall1)
   TEST_METHOD(CodeGenCall3)
+  TEST_METHOD(CodeGenCastBetweenTypeShapes)
   TEST_METHOD(CodeGenCast1)
   TEST_METHOD(CodeGenCast2)
   TEST_METHOD(CodeGenCast3)
@@ -3145,6 +3146,10 @@ TEST_F(CompilerTest, CodeGenCall1) {
 
 TEST_F(CompilerTest, CodeGenCall3) {
   CodeGenTest(L"..\\CodeGenHLSL\\call3.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenCastBetweenTypeShapes) {
+  CodeGenTestCheckBatchDir(L"..\\CodeGenHLSL\\cast_between_type_shapes");
 }
 
 TEST_F(CompilerTest, CodeGenCast1) {


### PR DESCRIPTION
Adds tests for all combination of explicit casts between scalar, vector, matrix, array and struct types.

- To-array tests are XFail'ed because of #1808, so I added a variant that doesn't try to directly return the array.
- Array-to-matrix, struct-to-matrix and struct-to-scalar are not included because they crash the compiler (#1799)
- Array-to-vector and struct-to-vector are XFail'ed because of #1795