### PR TITLE
Change diagnostics output file/line format to MSVC's.

### DIFF
--- a/tools/clang/lib/Frontend/TextDiagnostic.cpp
+++ b/tools/clang/lib/Frontend/TextDiagnostic.cpp
@@ -819,7 +819,7 @@ void TextDiagnostic::emitDiagnosticLoc(SourceLocation Loc, PresumedLoc PLoc,
   switch (DiagOpts->getFormat()) {
   case DiagnosticOptions::Clang:
   case DiagnosticOptions::Vi:    OS << ':';    break;
-  case DiagnosticOptions::MSVC:  OS << ") : "; break;
+  case DiagnosticOptions::MSVC:  OS << ") :"; break;
   }
 
   if (DiagOpts->ShowSourceRanges && !Ranges.empty()) {

--- a/tools/clang/test/CodeGenHLSL/SimpleHs10.hlsl
+++ b/tools/clang/test/CodeGenHLSL/SimpleHs10.hlsl
@@ -4,7 +4,7 @@
 // message.
 
 // CHECK: Multiple overloads of patchconstantfunc HSPerPatchFunc.
-// CHECK: 87:16: note: This overload was selected
+// CHECK: (87,16) : note: This overload was selected
 
 //--------------------------------------------------------------------------------------
 // SimpleTessellation.hlsl

--- a/tools/clang/test/CodeGenHLSL/attributes-gs-no-inout-main.hlsl
+++ b/tools/clang/test/CodeGenHLSL/attributes-gs-no-inout-main.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
 
-// CHECK: 18:11: error: stream-output object must be an inout parameter
+// CHECK: error: stream-output object must be an inout parameter
 
 struct GsOut {
     float4 pos : SV_Position;

--- a/tools/clang/test/CodeGenHLSL/attributes-gs-no-inout-other.hlsl
+++ b/tools/clang/test/CodeGenHLSL/attributes-gs-no-inout-other.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
 
-// CHECK: 10:10: error: stream-output object must be an inout parameter
+// CHECK: error: stream-output object must be an inout parameter
 
 struct GsOut {
     float4 pos : SV_Position;

--- a/tools/clang/test/CodeGenHLSL/attributes-gs-no-maxvertexcount.hlsl
+++ b/tools/clang/test/CodeGenHLSL/attributes-gs-no-maxvertexcount.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
 
-// CHECK: :16:6: error: GS entry point must have the maxvertexcount attribute
+// CHECK: error: GS entry point must have the maxvertexcount attribute
 
 struct GsOut {
     float4 pos : SV_Position;

--- a/tools/clang/test/CodeGenHLSL/attributes-hs-no-pcf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/attributes-hs-no-pcf.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T hs_6_0 %s | FileCheck %s
 
-// CHECK: :32:9: error: HS entry point must have the patchconstantfunc attribute
+// CHECK: error: HS entry point must have the patchconstantfunc attribute
 
 #define NumOutPoints 2
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/line_directive.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/line_directive.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 2> %s | FileCheck %s
 
 // #line directive should be honored
-// CHECK: renamed.hlsl:42
+// CHECK: renamed.hlsl(42,
 
 float4 main() : SV_Target
 {

--- a/tools/clang/test/CodeGenHLSL/quick-test/vector-matrix-binops.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/vector-matrix-binops.hlsl
@@ -1,18 +1,18 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
 
-// CHECK: vector-matrix-binops.hlsl:29:26: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:30:21: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:30:14: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:35:23: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:36:29: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:37:23: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:37:16: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:42:26: error: cannot convert from 'float4x4' to 'float4'
-// CHECK: vector-matrix-binops.hlsl:43:29: error: cannot convert from 'float4' to 'float4x4'
-// CHECK: vector-matrix-binops.hlsl:44:26: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:45:21: warning: implicit truncation of vector type
-// CHECK: vector-matrix-binops.hlsl:58:29: error: cannot convert from 'float3x2' to 'float2x3'
-// CHECK: vector-matrix-binops.hlsl:59:29: error: cannot convert from 'float2x3' to 'float1x4'
+// CHECK: vector-matrix-binops.hlsl(29,26) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(30,21) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(30,14) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(35,23) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(36,29) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(37,23) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(37,16) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(42,26) : error: cannot convert from 'float4x4' to 'float4'
+// CHECK: vector-matrix-binops.hlsl(43,29) : error: cannot convert from 'float4' to 'float4x4'
+// CHECK: vector-matrix-binops.hlsl(44,26) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(45,21) : warning: implicit truncation of vector type
+// CHECK: vector-matrix-binops.hlsl(58,29) : error: cannot convert from 'float3x2' to 'float2x3'
+// CHECK: vector-matrix-binops.hlsl(59,29) : error: cannot convert from 'float2x3' to 'float1x4'
 
 void main() {
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/void-param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/void-param.hlsl
@@ -1,13 +1,13 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
 
 // CHECK-NOT: error: empty parameter list defined with a typedef of 'void' not allowed in HLSL
-// CHECK: void-param.hlsl:12:16: error: argument may not have 'void' type
-// CHECK: void-param.hlsl:14:16: error: pointers are unsupported in HLSL
-// CHECK: void-param.hlsl:16:10: error: 'void' as parameter must not have type qualifiers
-// CHECK: void-param.hlsl:18:10: error: 'void' must be the first and only parameter if specified
-// CHECK: void-param.hlsl:20:17: error: variadic arguments is unsupported in HLSL
-// CHECK: void-param.hlsl:20:10: error: 'void' must be the first and only parameter if specified
-// CHECK: void-param.hlsl:22:10: error: 'void' must be the first and only parameter if specified
+// CHECK: void-param.hlsl(12,16) : error: argument may not have 'void' type
+// CHECK: void-param.hlsl(14,16) : error: pointers are unsupported in HLSL
+// CHECK: void-param.hlsl(16,10) : error: 'void' as parameter must not have type qualifiers
+// CHECK: void-param.hlsl(18,10) : error: 'void' must be the first and only parameter if specified
+// CHECK: void-param.hlsl(20,17) : error: variadic arguments is unsupported in HLSL
+// CHECK: void-param.hlsl(20,10) : error: 'void' must be the first and only parameter if specified
+// CHECK: void-param.hlsl(22,10) : error: 'void' must be the first and only parameter if specified
 
 void foo2(void a) {}
 

--- a/tools/clang/test/CodeGenHLSL/space-only-register.hlsl
+++ b/tools/clang/test/CodeGenHLSL/space-only-register.hlsl
@@ -1,34 +1,34 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
-// CHECK: :4:40: error: missing register type and number
+// CHECK: (4,40) : error: missing register type and number
 Buffer<float4> MyBuffer     : register(space1);
-// CHECK: :6:40: error: missing register type and number
+// CHECK: (6,40) : error: missing register type and number
 Texture2D<float4> MyTexture : register(space1);
 
-// CHECK: :9:30: error: missing register type and number
+// CHECK: (9,30) : error: missing register type and number
 cbuffer MyCbuffer : register(space2) {
     float4 CB_a;
 }
 
-// CHECK: :14:30: error: missing register type and number
+// CHECK: (14,30) : error: missing register type and number
 tbuffer MyTbuffer : register(space2) {
     float4 TB_a;
 }
 
 struct S { float4 val; };
 
-// CHECK: :21:41: error: missing register type and number
+// CHECK: (21,41) : error: missing register type and number
 ConstantBuffer<S> MyCbuffer2 : register(space3);
-// CHECK: :23:41: error: missing register type and number
+// CHECK: (23,41) : error: missing register type and number
 TextureBuffer<S>  MyTbuffer2 : register(space3);
 
-// CHECK: :26:50: error: missing register type and number
+// CHECK: (26,50) : error: missing register type and number
 StructuredBuffer<S>        MySbuffer1 : register(space4);
-// CHECK: :28:50: error: missing register type and number
+// CHECK: (28,50) : error: missing register type and number
 RWStructuredBuffer<S>      MySbuffer2 : register(space4);
-// CHECK: :30:50: error: missing register type and number
+// CHECK: (30,50) : error: missing register type and number
 AppendStructuredBuffer<S>  MySbuffer3 : register(space4);
-// CHECK: :32:50: error: missing register type and number
+// CHECK: (32,50) : error: missing register type and number
 ConsumeStructuredBuffer<S> MySbuffer4 : register(space4);
 
 float4 main() : SV_Target {

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -825,6 +825,7 @@ public:
     compiler.createDiagnostics(diagPrinter, false);
     // don't output warning to stderr/file if "/no-warnings" is present.
     compiler.getDiagnostics().setIgnoreAllWarnings(!Opts.OutputWarnings);
+    compiler.getDiagnostics().getDiagnosticOptions().setFormat(TextDiagnosticFormat::MSVC);
     compiler.createFileManager();
     compiler.createSourceManager(compiler.getFileManager());
     compiler.setTarget(

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -5974,22 +5974,22 @@ TEST_F(CompilerTest, SubobjectCodeGenErrors) {
     const char *expectedError;
   };
   SubobjectErrorTestCase testCases[] = {
-    { "GlobalRootSignature grs;",           "1:1: error: subobject needs to be initialized" },
-    { "StateObjectConfig soc;",             "1:1: error: subobject needs to be initialized" },
-    { "LocalRootSignature lrs;",            "1:1: error: subobject needs to be initialized" },
-    { "SubobjectToExportsAssociation sea;", "1:1: error: subobject needs to be initialized" },
-    { "RaytracingShaderConfig rsc;",        "1:1: error: subobject needs to be initialized" },
-    { "RaytracingPipelineConfig rpc;",      "1:1: error: subobject needs to be initialized" },
-    { "TriangleHitGroup hitGt;",            "1:1: error: subobject needs to be initialized" },
-    { "ProceduralPrimitiveHitGroup hitGt;", "1:1: error: subobject needs to be initialized" },
-    { "GlobalRootSignature grs2 = {\"\"};", "1:29: error: empty string not expected here" },
-    { "LocalRootSignature lrs2 = {\"\"};",  "1:28: error: empty string not expected here" },
-    { "SubobjectToExportsAssociation sea2 = { \"\", \"x\" };", "1:40: error: empty string not expected here" },
-    { "string s; SubobjectToExportsAssociation sea4 = { \"x\", s };", "1:55: error: cannot convert to constant string" },
-    { "extern int v; RaytracingPipelineConfig rpc2 = { v + 16 };", "1:49: error: cannot convert to constant unsigned int" },
-    { "string s; TriangleHitGroup trHitGt2_8 = { s, \"foo\" };", "1:43: error: cannot convert to constant string" },
-    { "string s; ProceduralPrimitiveHitGroup ppHitGt2_8 = { s, \"\", s };", "1:54: error: cannot convert to constant string" },
-    { "ProceduralPrimitiveHitGroup ppHitGt2_9 = { \"a\", \"b\", \"\"};", "1:54: error: empty string not expected here" }
+    { "GlobalRootSignature grs;",           "(1,1) : error: subobject needs to be initialized" },
+    { "StateObjectConfig soc;",             "(1,1) : error: subobject needs to be initialized" },
+    { "LocalRootSignature lrs;",            "(1,1) : error: subobject needs to be initialized" },
+    { "SubobjectToExportsAssociation sea;", "(1,1) : error: subobject needs to be initialized" },
+    { "RaytracingShaderConfig rsc;",        "(1,1) : error: subobject needs to be initialized" },
+    { "RaytracingPipelineConfig rpc;",      "(1,1) : error: subobject needs to be initialized" },
+    { "TriangleHitGroup hitGt;",            "(1,1) : error: subobject needs to be initialized" },
+    { "ProceduralPrimitiveHitGroup hitGt;", "(1,1) : error: subobject needs to be initialized" },
+    { "GlobalRootSignature grs2 = {\"\"};", "(1,29) : error: empty string not expected here" },
+    { "LocalRootSignature lrs2 = {\"\"};",  "(1,28) : error: empty string not expected here" },
+    { "SubobjectToExportsAssociation sea2 = { \"\", \"x\" };", "(1,40) : error: empty string not expected here" },
+    { "string s; SubobjectToExportsAssociation sea4 = { \"x\", s };", "(1,55) : error: cannot convert to constant string" },
+    { "extern int v; RaytracingPipelineConfig rpc2 = { v + 16 };", "(1,49) : error: cannot convert to constant unsigned int" },
+    { "string s; TriangleHitGroup trHitGt2_8 = { s, \"foo\" };", "(1,43) : error: cannot convert to constant string" },
+    { "string s; ProceduralPrimitiveHitGroup ppHitGt2_8 = { s, \"\", s };", "(1,54) : error: cannot convert to constant string" },
+    { "ProceduralPrimitiveHitGroup ppHitGt2_9 = { \"a\", \"b\", \"\"};", "(1,54) : error: empty string not expected here" }
   };
 
   for (unsigned i = 0; i < _countof(testCases); i++) {

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -510,7 +510,7 @@ TEST_F(ExtensionTest, DefineValidationError) {
   // Check that the error message is for the validation failure.
   VERIFY_IS_TRUE(
     errors.npos !=
-    errors.find("hlsl.hlsl:1:9: error: bad define: FOO"));
+    errors.find("hlsl.hlsl(1,9) : error: bad define: FOO"));
 }
 
 TEST_F(ExtensionTest, DefineValidationWarning) {
@@ -529,7 +529,7 @@ TEST_F(ExtensionTest, DefineValidationWarning) {
   // Check that the error message is for the validation failure.
   VERIFY_IS_TRUE(
     errors.npos !=
-    errors.find("hlsl.hlsl:1:9: warning: bad define: FOO"));
+    errors.find("hlsl.hlsl(1,9) : warning: bad define: FOO"));
 
   // Check the define is still emitted.
   std::string disassembly = c.Disassemble();


### PR DESCRIPTION
Microsoft build tools expect msbuild-compatible error messages. This merely change

```
main.hlsl:3:3: error: void function 'foo' should not return a value
  return 2;
  ^      ~
```

to:

```
main.hlsl(3,3) :  error: void function 'foo' should not return a value
  return 2;
  ^      ~
```

But it makes our error messages compatible with PIX.

See https://docs.microsoft.com/en-us/cpp/ide/formatting-the-output-of-a-custom-build-step-or-build-event