### PR TITLE
Fixed double-delete when SROA'ing OutputStream.Append with multiple structs

### DIFF
--- a/tools/clang/test/CodeGenHLSL/quick-test/streamout_multiple_aggregates.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/streamout_multiple_aggregates.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
+
+// Regression test for GitHub #1812
+// "Crash when using multiple nested structs in GS"
+// Due to multiple SROA passes processing the same original Append intrinsic,
+// and redundantly queuing it for deletion.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float 0.000000e+00)
+
+struct Inner1 { float t : A; };
+struct Inner2 { float t : B; };
+struct Outer { Inner1 i1; Inner2 i2; };
+
+[maxvertexcount(1)]
+void main(point Outer input[1], inout PointStream<Outer> output)
+{
+    Outer o = (Outer)0;
+    output.Append(o);
+}


### PR DESCRIPTION
When SROA'ing this pattern: `append(struct1, struct2)`, we would generate `append(float, struct2)` when processing `struct1` and add the original call to the list of dead instructions, but it would still be a user of `struct2`, so we would process it a second time when generating the final `append(float, float)`. Not only is this a double-delete, but it's also an `O(n^2)` algorithm. Fixed by `undef`'ing all operands of the original `append` after processing it so that we don't visit it again.

Fixes #1812 