### PR TITLE
Added a test suite for the HLMatrixLower pass

### DIFF
--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/array_load_store.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/array_load_store.ll
@@ -1,0 +1,54 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; row/col load/stores should not incur vector shuffling
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.2.2*)
+declare %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.2.2*, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca [2 x <4 x i32>]
+  %alloca = alloca [2 x %class.matrix.int.2.2], align 4
+  
+  ; CHECK: %[[gep0:.*]] = getelementptr inbounds [2 x <4 x i32>], [2 x <4 x i32>]* %[[alloca]], i32 0, i32 0
+  %gep0 = getelementptr inbounds [2 x %class.matrix.int.2.2], [2 x %class.matrix.int.2.2]* %alloca, i32 0, i32 0
+  
+  ; CHECK: %[[gep1:.*]] = getelementptr inbounds [2 x <4 x i32>], [2 x <4 x i32>]* %[[alloca]], i32 0, i32 1
+  %gep1 = getelementptr inbounds [2 x %class.matrix.int.2.2], [2 x %class.matrix.int.2.2]* %alloca, i32 0, i32 1
+  
+  ; CHECK: %[[load:.*]] = load <4 x i32>, <4 x i32>* %[[gep0]]
+  %load = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %gep0)
+  
+  ; CHECK: store <4 x i32> %[[load]], <4 x i32>* %[[gep1]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 1, %class.matrix.int.2.2* %gep1, %class.matrix.int.2.2 %load)
+  
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/binary_opcode.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/binary_opcode.ll
@@ -1,0 +1,52 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering of matrix binary operators with different operands
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.2.2*)
+declare %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.2.2*, %class.matrix.int.2.2)
+declare %class.matrix.int.2.2 @"dx.hl.binop"(i32, %class.matrix.int.2.2, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca1:.*]] = alloca <4 x i32>
+  %alloca1 = alloca %class.matrix.int.2.2, align 4
+  ; CHECK: %[[alloca2:.*]] = alloca <4 x i32>
+  %alloca2 = alloca %class.matrix.int.2.2, align 4
+  ; CHECK: %[[load1:.*]] = load <4 x i32>, <4 x i32>* %[[alloca1]]
+  %load1 = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %alloca1)
+  ; CHECK: %[[load2:.*]] = load <4 x i32>, <4 x i32>* %[[alloca2]]
+  %load2 = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %alloca2)
+  ; CHECK: %[[sub:.*]] = sub <4 x i32> %[[load1]], %[[load2]]
+  %add = call %class.matrix.int.2.2 @"dx.hl.binop"(i32 5, %class.matrix.int.2.2 %load1, %class.matrix.int.2.2 %load2)
+  ; CHECK: store <4 x i32> %[[sub]], <4 x i32>* %[[alloca1]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.2.2* %alloca1, %class.matrix.int.2.2 %add)
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/binary_opcode_same_operand.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/binary_opcode_same_operand.ll
@@ -1,0 +1,48 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering of matrix binary operators with the same operand
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.2.2*)
+declare %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.2.2*, %class.matrix.int.2.2)
+declare %class.matrix.int.2.2 @"dx.hl.binop"(i32, %class.matrix.int.2.2, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <4 x i32>
+  %alloca = alloca %class.matrix.int.2.2, align 4
+  ; CHECK: %[[load:.*]] = load <4 x i32>, <4 x i32>* %[[alloca]]
+  %load = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %alloca)
+  ; CHECK: %[[add:.*]] = add <4 x i32> %[[load]], %[[load]]
+  %add = call %class.matrix.int.2.2 @"dx.hl.binop"(i32 4, %class.matrix.int.2.2 %load, %class.matrix.int.2.2 %load)
+  ; CHECK: store <4 x i32> %[[add]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %add)
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/load_store_orientations.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/load_store_orientations.ll
@@ -1,0 +1,64 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; row/col load/stores should not incur vector shuffling
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.2.2*)
+declare %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.2.2*, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <4 x i32>
+  %alloca = alloca %class.matrix.int.2.2, align 4
+  
+  ; CHECK: %[[rowLoad:.*]] = load <4 x i32>, <4 x i32>* %[[alloca]]
+  %rowLoad = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %alloca)
+  
+  ; CHECK: %[[colLoad:.*]] = load <4 x i32>, <4 x i32>* %[[alloca]]
+  %colLoad = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 0, %class.matrix.int.2.2* %alloca)
+
+  ; rowStore(rowLoad)
+  ; CHECK: store <4 x i32> %[[rowLoad]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %rowLoad)
+
+  ; rowStore(colLoad)
+  ; CHECK: store <4 x i32> %[[colLoad]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %colLoad)
+  
+  ; colStore(rowLoad)
+  ; CHECK: store <4 x i32> %[[rowLoad]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 1, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %rowLoad)
+  
+  ; colStore(colLoad)
+  ; CHECK: store <4 x i32> %[[colLoad]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 1, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %colLoad)
+  
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/orientation_cast.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/orientation_cast.ll
@@ -1,0 +1,57 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering matrix orientation casts
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.3.2 = type { [3 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.3.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.3.2*)
+declare %class.matrix.int.3.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.3.2*, %class.matrix.int.3.2)
+declare %class.matrix.int.3.2 @"dx.hl.cast"(i32, %class.matrix.int.3.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <6 x i32>
+  %alloca = alloca %class.matrix.int.3.2, align 4
+  ; CHECK: %[[load:.*]] = load <6 x i32>, <6 x i32>* %[[alloca]]
+  %load = call %class.matrix.int.3.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.3.2* %alloca)
+  
+  ; <11, 12, 21, 22, 31, 32> to <11, 21, 31, 12, 22, 32>
+  ; CHECK: %[[rowToCol:.*]] = shufflevector <6 x i32> %[[load]], <6 x i32> %[[load]], <6 x i32> <i32 0, i32 2, i32 4, i32 1, i32 3, i32 5>
+  %rowToCol = call %class.matrix.int.3.2 @"dx.hl.cast"(i32 7, %class.matrix.int.3.2 %load) ; RowMatrixToColMatrix
+  ; CHECK: store <6 x i32> %[[rowToCol]], <6 x i32>* %[[alloca]]
+  call %class.matrix.int.3.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.3.2* %alloca, %class.matrix.int.3.2 %rowToCol)
+
+  ; <11, 12, 21, 22, 31, 32> to <11, 22, 12, 31, 21, 32>
+  ; CHECK: %[[colToRow:.*]] = shufflevector <6 x i32> %[[load]], <6 x i32> %[[load]], <6 x i32> <i32 0, i32 3, i32 1, i32 4, i32 2, i32 5>
+  %colToRow = call %class.matrix.int.3.2 @"dx.hl.cast"(i32 6, %class.matrix.int.3.2 %load) ; ColMatrixToRowMatrix
+  ; CHECK: store <6 x i32> %[[colToRow]], <6 x i32>* %[[alloca]]
+  call %class.matrix.int.3.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.3.2* %alloca, %class.matrix.int.3.2 %colToRow)
+
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/subscript_element.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/subscript_element.ll
@@ -1,0 +1,55 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering of matrix element subscripts (m3x3._12_21)
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.3.3 = type { [3 x <3 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare <2 x i32>* @"dx.hl.subscript.elem"(i32, %class.matrix.int.3.3*, <2 x i32>)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <9 x i32>
+  %alloca = alloca %class.matrix.int.3.3, align 4
+
+  ; CHECK: %[[load1:.*]] = load <9 x i32>, <9 x i32>* %[[alloca]]
+  ; CHECK: %[[elems13:.*]] = shufflevector <9 x i32> %[[load1]], <9 x i32> %[[load1]], <2 x i32> <i32 1, i32 3>
+  %rowElems13Ptr = call <2 x i32>* @"dx.hl.subscript.elem"(i32 4, %class.matrix.int.3.3* %alloca, <2 x i32> <i32 1, i32 3>) ; RowMatElement
+  %elems = load <2 x i32>, <2 x i32>* %rowElems13Ptr
+
+  ; CHECK: %[[load2:.*]] = load <9 x i32>, <9 x i32>* %[[alloca]]
+  ; CHECK: %[[elem1:.*]] = extractelement <2 x i32> %[[elems13]], i64 0
+  ; CHECK: %[[vecWithElem1:.*]] = insertelement <9 x i32> %[[load2]], i32 %[[elem1]], i64 1
+  ; CHECK: %[[elem3:.*]] = extractelement <2 x i32> %[[elems13]], i64 1
+  ; CHECK: %[[vecWithElems13:.*]] = insertelement <9 x i32> %[[vecWithElem1]], i32 %[[elem3]], i64 3
+  ; CHECK: store <9 x i32> %[[vecWithElems13]], <9 x i32>* %[[alloca]]
+  %colElems13Ptr = call <2 x i32>* @"dx.hl.subscript.elem"(i32 3, %class.matrix.int.3.3* %alloca, <2 x i32> <i32 1, i32 3>) ; ColMatElement
+  store <2 x i32> %elems, <2 x i32>* %colElems13Ptr
+
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/subscript_index.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/subscript_index.ll
@@ -1,0 +1,57 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering of matrix element indexing (m3x3[1])
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.3.3 = type { [3 x <3 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare <3 x i32>* @"dx.hl.subscript.idx"(i32, %class.matrix.int.3.3*, i32, i32, i32)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <9 x i32>
+  %alloca = alloca %class.matrix.int.3.3, align 4
+
+  ; CHECK: %[[load1:.*]] = load <9 x i32>, <9 x i32>* %[[alloca]]
+  ; CHECK: %[[elems147:.*]] = shufflevector <9 x i32> %[[load1]], <9 x i32> %[[load1]], <3 x i32> <i32 1, i32 4, i32 7>
+  %rowElems147Ptr = call <3 x i32>* @"dx.hl.subscript.idx"(i32 2, %class.matrix.int.3.3* %alloca, i32 1, i32 4, i32 7) ; RowMatSubscript
+  %elems = load <3 x i32>, <3 x i32>* %rowElems147Ptr
+
+  ; CHECK: %[[load2:.*]] = load <9 x i32>, <9 x i32>* %[[alloca]]
+  ; CHECK: %[[elem1:.*]] = extractelement <3 x i32> %[[elems147]], i64 0
+  ; CHECK: %[[vecWithElem1:.*]] = insertelement <9 x i32> %[[load2]], i32 %[[elem1]], i32 1
+  ; CHECK: %[[elem4:.*]] = extractelement <3 x i32> %[[elems147]], i64 1
+  ; CHECK: %[[vecWithElems14:.*]] = insertelement <9 x i32> %[[vecWithElem1]], i32 %[[elem4]], i32 4
+  ; CHECK: %[[elem7:.*]] = extractelement <3 x i32> %[[elems147]], i64 2
+  ; CHECK: %[[vecWithElems147:.*]] = insertelement <9 x i32> %[[vecWithElems14]], i32 %[[elem7]], i32 7
+  ; CHECK: store <9 x i32> %[[vecWithElems147]], <9 x i32>* %[[alloca]]
+  %colElems147Ptr = call <3 x i32>* @"dx.hl.subscript.idx"(i32 1, %class.matrix.int.3.3* %alloca, i32 1, i32 4, i32 7) ; ColMatSubscript
+  store <3 x i32> %elems, <3 x i32>* %colElems147Ptr
+
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/to_vector.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/to_vector.ll
@@ -1,0 +1,48 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering matrix to vector casts
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.init.matrix"(i32, i32, i32, i32, i32)
+declare <4 x i32> @"dx.hl.cast"(i32, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[vec0:.*]] = insertelement <4 x i32> undef, i32 11, i32 0
+  ; CHECK: %[[vec1:.*]] = insertelement <4 x i32> %[[vec0]], i32 12, i32 1
+  ; CHECK: %[[vec2:.*]] = insertelement <4 x i32> %[[vec1]], i32 21, i32 2
+  ; CHECK: %[[vec3:.*]] = insertelement <4 x i32> %[[vec2]], i32 22, i32 3
+  %mat = call %class.matrix.int.2.2 @"dx.hl.init.matrix"(i32 0, i32 11, i32 12, i32 21, i32 22)
+  %calMatToVec = call <4 x i32> @"dx.hl.cast"(i32 4, %class.matrix.int.2.2 %mat) ; colMatToVec
+  %rowMatToVec = call <4 x i32> @"dx.hl.cast"(i32 5, %class.matrix.int.2.2 %mat) ; rowMatToVec
+  ; CHECK: = add <4 x i32> %[[vec3]], %[[vec3]]
+  %sum = add <4 x i32> %calMatToVec, %rowMatToVec
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/test/CodeGenHLSL/hlmatrixlower/unary_opcode.ll
+++ b/tools/clang/test/CodeGenHLSL/hlmatrixlower/unary_opcode.ll
@@ -1,0 +1,48 @@
+; RUN: %opt %s -hlmatrixlower -S | FileCheck %s
+
+; Test lowering of matrix unary operators
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%ConstantBuffer = type opaque
+%class.matrix.int.2.2 = type { [2 x <2 x i32>] }
+@"$Globals" = external constant %ConstantBuffer
+
+declare %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32, %class.matrix.int.2.2*)
+declare %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32, %class.matrix.int.2.2*, %class.matrix.int.2.2)
+declare %class.matrix.int.2.2 @"dx.hl.unop.-"(i32, %class.matrix.int.2.2)
+
+; Function Attrs: nounwind
+; CHECK: define void @main()
+define void @main() {
+entry:
+  ; CHECK: %[[alloca:.*]] = alloca <4 x i32>
+  %alloca = alloca %class.matrix.int.2.2, align 4
+  ; CHECK: %[[load:.*]] = load <4 x i32>, <4 x i32>* %[[alloca]]
+  %load = call %class.matrix.int.2.2 @"dx.hl.matldst.load"(i32 2, %class.matrix.int.2.2* %alloca)
+  ; CHECK: %[[sub:.*]] = sub <4 x i32> zeroinitializer, %[[load]]
+  %neg = call %class.matrix.int.2.2 @"dx.hl.unop.-"(i32 6, %class.matrix.int.2.2 %load)
+  ; CHECK: store <4 x i32> %[[sub]], <4 x i32>* %[[alloca]]
+  call %class.matrix.int.2.2 @"dx.hl.matldst.store"(i32 3, %class.matrix.int.2.2* %alloca, %class.matrix.int.2.2 %neg)
+  ; CHECK: ret void
+  ret void
+}
+
+!dx.version = !{!2}
+!dx.shaderModel = !{!4}
+!dx.entryPoints = !{!9}
+!dx.fnprops = !{!13}
+!dx.options = !{!14, !15}
+!dx.resource.type.annotation = !{!8}
+
+!2 = !{i32 1, i32 0}
+!4 = !{!"vs", i32 6, i32 0}
+!8 = !{}
+!9 = !{void ()* @main, !"main", null, !10, null}
+!10 = !{null, null, !11, null}
+!11 = !{!12}
+!12 = !{i32 0, %ConstantBuffer* @"$Globals", !"$Globals", i32 0, i32 -1, i32 1, i32 0, null}
+!13 = !{void ()* @main, i32 1}
+!14 = !{i32 144}
+!15 = !{i32 -1}

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -955,6 +955,7 @@ public:
   TEST_METHOD(Unroll)
   TEST_METHOD(QuickTest)
   TEST_METHOD(QuickLlTest)
+  TEST_METHOD(MatrixLowerTestSuite)
   BEGIN_TEST_METHOD(SingleFileCheckTest)
     TEST_METHOD_PROPERTY(L"Ignore", L"true")
   END_TEST_METHOD()
@@ -6037,6 +6038,10 @@ TEST_F(CompilerTest, QuickTest) {
 
 TEST_F(CompilerTest, QuickLlTest) {
 	CodeGenTestCheckBatchDir(L"..\\CodeGenHLSL\\quick-ll-test");
+}
+
+TEST_F(CompilerTest, MatrixLowerTestSuite) {
+  CodeGenTestCheckBatchDir(L"..\\CodeGenHLSL\\hlmatrixlower");
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
Also cleaned up lowered code for matrix element/subscript to avoid unnecessary alloca and insertvectors instead of shufflevector.

This was motivated by the talks of rewriting this pass and fundamental bugs it may exhibit, although my simple tests haven't succeeded in uncovering them.