### PR TITLE
Re-enable failures for linux and OSX travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,6 @@ matrix:
           sources: ubuntu-toolchain-r-test
           packages: ninja-build g++-5
       env: DXC_BUILD_TYPE=Release
-  allow_failures:
-    - os: linux
-    - os: osx
 
 cache:
   apt: true


### PR DESCRIPTION
We let a few build breaks in due to this lately, and it looks like there's agreement that we should flip this on again.