### PR TITLE
Do not try to use EvalBinaryIntrinsic for min/max with integer type arguments.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -4228,12 +4228,16 @@ static Value * TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp) {
   case IntrinsicOp::IOP_max: {
     auto maxF = [](float a, float b) -> float { return a > b ? a:b; };
     auto maxD = [](double a, double b) -> double { return a > b ? a:b; };
+    if (CI->getArgOperand(0)->getType()->getScalarType()->isIntegerTy())
+      return nullptr;
     return EvalBinaryIntrinsic(CI, maxF, maxD);
   } break;
   case IntrinsicOp::IOP_min: {
     auto minF = [](float a, float b) -> float { return a < b ? a:b; };
     auto minD = [](double a, double b) -> double { return a < b ? a:b; };
-    return EvalBinaryIntrinsic(CI, minF, minD);
+    if (CI->getArgOperand(0)->getType()->getScalarType()->isIntegerTy())
+      return nullptr;
+	return EvalBinaryIntrinsic(CI, minF, minD);
   } break;
   case IntrinsicOp::IOP_rcp: {
     auto rcpF = [](float v) -> float { return 1.0 / v; };

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -4239,7 +4239,7 @@ static Value * TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp) {
     // Handled in DXIL constant folding
     if (CI->getArgOperand(0)->getType()->getScalarType()->isIntegerTy())
       return nullptr;
-	return EvalBinaryIntrinsic(CI, minF, minD);
+    return EvalBinaryIntrinsic(CI, minF, minD);
   } break;
   case IntrinsicOp::IOP_rcp: {
     auto rcpF = [](float v) -> float { return 1.0 / v; };

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -4228,6 +4228,7 @@ static Value * TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp) {
   case IntrinsicOp::IOP_max: {
     auto maxF = [](float a, float b) -> float { return a > b ? a:b; };
     auto maxD = [](double a, double b) -> double { return a > b ? a:b; };
+    // Handled in DXIL constant folding
     if (CI->getArgOperand(0)->getType()->getScalarType()->isIntegerTy())
       return nullptr;
     return EvalBinaryIntrinsic(CI, maxF, maxD);
@@ -4235,6 +4236,7 @@ static Value * TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp) {
   case IntrinsicOp::IOP_min: {
     auto minF = [](float a, float b) -> float { return a < b ? a:b; };
     auto minD = [](double a, double b) -> double { return a < b ? a:b; };
+    // Handled in DXIL constant folding
     if (CI->getArgOperand(0)->getType()->getScalarType()->isIntegerTy())
       return nullptr;
 	return EvalBinaryIntrinsic(CI, minF, minD);

--- a/tools/clang/test/CodeGenHLSL/max_min_literal.hlsl
+++ b/tools/clang/test/CodeGenHLSL/max_min_literal.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK-NOT: FMax
+// CHECK-NOT: FMin
+// CHECK-NOT: IMax
+// CHECK-NOT: IMin
+// CHECK-NOT: UMax
+// CHECK-NOT: UMin
+
+
+#define FA float4(0.0f, 1.0f, 2.0f, 3.0f)
+#define FB float4(4.0f, 5.0f, 6.0f, 7.0f)
+#define IA int4(0, 1, 2, 3)
+#define IB int4(4, 5, 6, 7)
+#define UA uint4(0, 1, 2, 3)
+#define UB uint4(4, 5, 6, 7)
+
+
+float4 main(float4 a : A) : SV_TARGET
+{
+  return max(FA,FB) + min(FA,FB) + max(IA,IB) + min(IA,IB) + max(UA,UB) + min(UA,UB);
+}
+

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -485,6 +485,7 @@ public:
   TEST_METHOD(CodeGenMatSubscript6)
   TEST_METHOD(CodeGenMatSubscript7)
   TEST_METHOD(CodeGenMaxMin)
+  TEST_METHOD(CodeGenMaxMinLiteral)
   TEST_METHOD(CodeGenMinprec1)
   TEST_METHOD(CodeGenMinprec2)
   TEST_METHOD(CodeGenMinprec3)
@@ -3908,6 +3909,10 @@ TEST_F(CompilerTest, CodeGenMatSubscript7) {
 
 TEST_F(CompilerTest, CodeGenMaxMin) {
   CodeGenTestCheck(L"..\\CodeGenHLSL\\max_min.hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenMaxMinLiteral) {
+  CodeGenTestCheck(L"..\\CodeGenHLSL\\max_min_literal.hlsl");
 }
 
 TEST_F(CompilerTest, CodeGenMinprec1) {


### PR DESCRIPTION
`EvalBinaryIntrinsic` does not support functions with integer arguments, and since min/max do support ints this causes a crash.
The min/max expressions are still evaluated at compile time before optimization even when not handled in `TryEvalIntrinsic`, the same is true for other functions, such as sign(int), which do not appear at all here.

Fixes #1822