### PR TITLE
Implement FileCheck -check-prefix for DXC tests.

### DIFF
--- a/tools/clang/test/CodeGenHLSL/Include.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Include.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | StdErrCheck %s
+// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | FileCheck -input=stderr %s
 
 
 

--- a/tools/clang/test/CodeGenHLSL/SimpleHs10.hlsl
+++ b/tools/clang/test/CodeGenHLSL/SimpleHs10.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T hs_6_0  %s 2>&1 | StdErrCheck %s
+// RUN: %dxc -E main -T hs_6_0  %s 2>&1 | FileCheck -input=stderr %s
 
 // Same as SimpleHS11.hlsl, except that we only verify StdErr for the warning
 // message.

--- a/tools/clang/test/CodeGenHLSL/quick-test/FileCheck_prefix.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/FileCheck_prefix.hlsl
@@ -1,0 +1,6 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck -check-prefix=FOO %s
+
+// CHECK: this should be ignored
+// FOO: main
+
+void main() {}

--- a/tools/clang/unittests/HLSL/DxcTestUtils.h
+++ b/tools/clang/unittests/HLSL/DxcTestUtils.h
@@ -55,21 +55,12 @@ public:
 };
 
 class FileRunCommandPart {
-private:
-  void RunFileChecker(const FileRunCommandPart *Prior);
-  void RunStdErrChecker(const FileRunCommandPart *Prior);
-  void RunDxc(const FileRunCommandPart *Prior);
-  void RunDxv(const FileRunCommandPart *Prior);
-  void RunOpt(const FileRunCommandPart *Prior);
-  void RunD3DReflect(const FileRunCommandPart *Prior);
-  void RunTee(const FileRunCommandPart *Prior);
-  void RunXFail(const FileRunCommandPart *Prior);
 public:
-  FileRunCommandPart(const FileRunCommandPart&) = default;
   FileRunCommandPart(const std::string &command, const std::string &arguments, LPCWSTR commandFileName);
-  FileRunCommandPart(FileRunCommandPart && other);
+  FileRunCommandPart(const FileRunCommandPart&) = default;
+  FileRunCommandPart(FileRunCommandPart&&) = default;
   
-  void Run(const FileRunCommandPart *Prior);
+  void Run(dxc::DxcDllSupport &DllSupport, const FileRunCommandPart *Prior);
   
   void ReadOptsForDxc(hlsl::options::MainArgs &argStrings, hlsl::options::DxcOpts &Opts);
 
@@ -77,13 +68,20 @@ public:
   std::string Arguments;    // Arguments to command
   LPCWSTR CommandFileName;  // File name replacement for %s
 
-  dxc::DxcDllSupport *DllSupport; // DLL support to use for Run().
-
   // These fields are set after an invocation to Run().
   CComPtr<IDxcOperationResult> OpResult;  // The operation result, if any.
   int RunResult;                          // The exit code for the operation.
   std::string StdOut;                     // Standard output text.
   std::string StdErr;                     // Standard error text.
+
+private:
+  void RunFileChecker(const FileRunCommandPart *Prior);
+  void RunDxc(dxc::DxcDllSupport &DllSupport, const FileRunCommandPart *Prior);
+  void RunDxv(dxc::DxcDllSupport &DllSupport, const FileRunCommandPart *Prior);
+  void RunOpt(dxc::DxcDllSupport &DllSupport, const FileRunCommandPart *Prior);
+  void RunD3DReflect(dxc::DxcDllSupport &DllSupport, const FileRunCommandPart *Prior);
+  void RunTee(const FileRunCommandPart *Prior);
+  void RunXFail(const FileRunCommandPart *Prior);
 };
 
 void ParseCommandParts(LPCSTR commands, LPCWSTR fileName, std::vector<FileRunCommandPart> &parts);


### PR DESCRIPTION
This is not useful yet because we only support one // RUN: line, but that's next on my list!
Also cleans that code up a bit.
Also adds an -input=stderr option, just for the sake of removing the duplicated code from StdErrCheck, which is only used by two tests.