### PR TITLE
Support directory paths with hcttest file-check.

### DIFF
--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -19,8 +19,8 @@ set TEST_CLANG_FILTER= /select: "@Priority<1"
 set TEST_EXEC_FILTER=ExecutionTest::*
 set LOG_FILTER=/logOutput:LowWithConsoleBuffering
 set TEST_COMPAT_SUITE=0
-set COMPAT_SUIT_PATH=
-set TEST_SINGLE_FILE_CHECK=0
+set MANUAL_FILE_CHECK_PATH=
+set TEST_MANUAL_FILE_CHECK=0
 set SINGLE_FILE_CHECK_NAME=0
 
 rem Begin SPIRV change
@@ -78,15 +78,10 @@ if "%1"=="-clean" (
   set TEST_CLANG=1
   set TEST_CLANG_FILTER= /name:%2
   shift /1
-) else if "%1"=="compat-suite" (
-  set TEST_ALL=0
-  set TEST_COMPAT_SUITE=1
-  set COMPAT_SUIT_PATH= /p:"SuitePath=%~2"
-  shift /1
 ) else if "%1"=="file-check" (
   set TEST_ALL=0
-  set TEST_SINGLE_FILE_CHECK=1
-  set COMPAT_SUIT_PATH= /p:"InputFile=%~2"
+  set TEST_MANUAL_FILE_CHECK=1
+  set MANUAL_FILE_CHECK_PATH=%~2
   shift /1
 ) else if "%1"=="v" (
   set TEST_ALL=0
@@ -281,13 +276,8 @@ if exist "%HCT_EXTRAS%\hcttest-after.cmd" (
   set RES_HCTTEST_AFTER=!ERRORLEVEL!
 )
 
-if "%TEST_SINGLE_FILE_CHECK%"=="1" (
-  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:CompilerTest::SingleFileCheckTest /runIgnoredTests %COMPAT_SUIT_PATH%
-  set RES_EXEC=!ERRORLEVEL!
-)
-
-if "%TEST_COMPAT_SUITE%"=="1" (
-  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:CompilerTest::ShaderCompatSuite %COMPAT_SUIT_PATH%
+if "%TEST_MANUAL_FILE_CHECK%"=="1" (
+  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:CompilerTest::ManualFileCheckTest /runIgnoredTests /p:"InputPath=%MANUAL_FILE_CHECK_PATH%"
   set RES_EXEC=!ERRORLEVEL!
 )
 


### PR DESCRIPTION
The `ShaderCompatSuite` and `Unroll` tests randomly supported being used to batch run file-check on directories. This change rather updates `hcttest file-check` to support directories as well as individual files.