### PR TITLE
Re-ignore OSX travis build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
           sources: ubuntu-toolchain-r-test
           packages: ninja-build g++-5
       env: DXC_BUILD_TYPE=Release
+  allow_failures:
+    - os: osx
 
 cache:
   apt: true


### PR DESCRIPTION
Since enabling the OSX Travis builds, they have been failing for infrastructure reasons on most pull requests. We are not in a position to investigate this, I believe Google only depends on the Linux builds, and in any case those already cover GCC and Clang, so that should be good enough to ensure new code changes work on other compilers.

(of course we welcome anyone able to fix and re-enable the OSX runs!)