### PR TITLE
Fix conversions not always honoring LValue-to-RValue

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -8046,10 +8046,11 @@ bool HLSLExternalSource::CanConvert(
   // Cannot cast function type.
   if (source->isFunctionType())
     return false;
-  // Convert to an r-value to begin with.
-  bool needsLValueToRValue = sourceExpr->isLValue() &&
-    !target->isLValueReferenceType() && 
-    IsConversionToLessOrEqualElements(source, target, explicitConversion);
+
+  // Convert to an r-value to begin with, with an exception for strings
+  // since they are not first-class values and we want to preserve them as literals.
+  bool needsLValueToRValue = sourceExpr->isLValue() && !target->isLValueReferenceType()
+    && sourceExpr->getStmtClass() != Expr::StringLiteralClass;
 
   bool targetRef = target->isReferenceType();
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/implicit_numerical_shape_conversions.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/implicit_numerical_shape_conversions.hlsl
@@ -39,21 +39,21 @@ void main()
     // CHECK: i32 11,
     output.Append(last_of_s(m1x1));
     // NCHECK: i32 11,
-    // output.Append(last_of_s(m2x2)); // GitHub #1845
+    // output.Append(last_of_s(m2x2)); // Crashes, tracked by GitHub #1845
 
     // ICK_HLSLVector_Conversion (vector/matrix, element-preserving)
-    // NCHECK: i32 12,
-    // output.Append(last_of_v2(m1x2)); // Crashes, tracked by GitHub #1844
-    // NCHECK: i32 21,
-    // output.Append(last_of_v2(m2x1)); // Crashes, tracked by GitHub #1844
-    // NCHECK: i32 22,
-    // output.Append(last_of_v4(m2x2)); // Crashes, tracked by GitHub #1844
-    // NCHECK: i32 -2,
-    // output.Append(last_of_m1x2(v2)); // Crashes, tracked by GitHub #1844
-    // NCHECK: i32 -2,
-    // output.Append(last_of_m2x1(v2)); // Crashes, tracked by GitHub #1844
-    // NCHECK: i32 -4,
-    // output.Append(last_of_m2x2(v4)); // Crashes, tracked by GitHub #1844
+    // CHECK: i32 12,
+    output.Append(last_of_v2(m1x2));
+    // CHECK: i32 21,
+    output.Append(last_of_v2(m2x1));
+    // CHECK: i32 22,
+    output.Append(last_of_v4(m2x2));
+    // CHECK: i32 -2,
+    output.Append(last_of_m1x2(v2));
+    // CHECK: i32 -2,
+    output.Append(last_of_m2x1(v2));
+    // CHECK: i32 -4,
+    output.Append(last_of_m2x2(v4));
 
     // ICK_HLSLVector_Splat (single element duplicated)
     // CHECK: i32 42,

--- a/tools/clang/test/CodeGenHLSL/quick-test/implicit_numerical_shape_conversions.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/implicit_numerical_shape_conversions.hlsl
@@ -38,8 +38,8 @@ void main()
     output.Append(last_of_s(v2));
     // CHECK: i32 11,
     output.Append(last_of_s(m1x1));
-    // NCHECK: i32 11,
-    // output.Append(last_of_s(m2x2)); // Crashes, tracked by GitHub #1845
+    // CHECK: i32 11,
+    output.Append(last_of_s(m2x2));
 
     // ICK_HLSLVector_Conversion (vector/matrix, element-preserving)
     // CHECK: i32 12,
@@ -74,10 +74,10 @@ void main()
     output.Append(last_of_v1(v2));
     // CHECK: i32 -2,
     output.Append(last_of_v2(v3));
-    // NCHECK: i32 11,
-    // output.Append(last_of_v1(m2x2)); // Crashes, tracked by GitHub #1845
-    // NCHECK: i32 11,
-    // output.Append(last_of_m1x1(m2x2)); // Crashes, tracked by GitHub #1845
+    // CHECK: i32 11,
+    output.Append(last_of_v1(m2x2));
+    // CHECK: i32 11,
+    output.Append(last_of_m1x1(m2x2));
     // CHECK: i32 12,
     output.Append(last_of_m1x2(m2x2));
     // CHECK: i32 21,

--- a/tools/clang/test/HLSL/binop-dims.hlsl
+++ b/tools/clang/test/HLSL/binop-dims.hlsl
@@ -7,12 +7,6 @@
 // we use -Wno-unused-value because we generate some no-op expressions to yield errors
 // without also putting them in a static assertion
 
-// TODO: Fix LValue casting to match fxc.
-// Currently certain LValue casts will crash CodeGen,
-// so an error has been placed here instead for now.
-// Need to look for the following expected error and fix in the future:
-//    cannot truncate lvalue vector/matrix
-
 /*<py>
 import re
 rxComments = re.compile(r'(//.*|/\*.*?\*\/)')
@@ -135,36 +129,36 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   f1 += (float1)m1x1;
   f1 = f1 + m2x1;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m2x1;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m2x1;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m2x1;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m2x1;
+  f1 += (float1)m2x1;
   f1 = f1 + m4x1;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m4x1;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m4x1;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m4x1;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m4x1;
+  f1 += (float1)m4x1;
   f1 = f1 + m1x2;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m1x2;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m1x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m1x2;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m1x2;
+  f1 += (float1)m1x2;
   f1 = f1 + m2x2;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m2x2;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m2x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m2x2;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m2x2;
+  f1 += (float1)m2x2;
   f1 = f1 + m4x2;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m4x2;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m4x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m4x2;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m4x2;
+  f1 += (float1)m4x2;
   f1 = f1 + m1x4;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m1x4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m1x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m1x4;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m1x4;
+  f1 += (float1)m1x4;
   f1 = f1 + m2x4;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m2x4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m2x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m2x4;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m2x4;
+  f1 += (float1)m2x4;
   f1 = f1 + m4x4;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f1 += m4x4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f1 = f1 + (float1)m4x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f1 += (float1)m4x4;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f1 = f1 + (float1)m4x4;
+  f1 += (float1)m4x4;
   f2 = f2 + f;
   f2 += f;
   f2 = f2 + (float2)f;
@@ -191,8 +185,8 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   f2 += (float2)m2x1;
   f2 = f2 + m4x1;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f2 += m4x1;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f2 = f2 + (float2)m4x1;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f2 += (float2)m4x1;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f2 = f2 + (float2)m4x1;
+  f2 += (float2)m4x1;
   f2 = f2 + m1x2;
   f2 += m1x2;
   f2 = f2 + (float2)m1x2;
@@ -207,8 +201,8 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   f2 += (float2)m4x2;                                       /* expected-error {{cannot convert from 'float4x2' to 'float2'}} fxc-error {{X3017: cannot convert from 'float4x2' to 'float2'}} */
   f2 = f2 + m1x4;                                           /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f2 += m1x4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  f2 = f2 + (float2)m1x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  f2 += (float2)m1x4;                                       /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  f2 = f2 + (float2)m1x4;
+  f2 += (float2)m1x4;
   f2 = f2 + m2x4;                                           /* expected-error {{cannot convert from 'float2x4' to 'float2'}} fxc-error {{X3020: type mismatch}} */
   f2 += m2x4;                                               /* expected-error {{cannot convert from 'float2x4' to 'float2'}} fxc-error {{X3020: type mismatch}} */
   f2 = f2 + (float2)m2x4;                                   /* expected-error {{cannot convert from 'float2x4' to 'float2'}} fxc-error {{X3017: cannot convert from 'float2x4' to 'float2'}} */
@@ -291,36 +285,36 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   m1x1 += (float1x1)m1x1;
   m1x1 = m1x1 + m2x1;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m2x1;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m2x1;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m2x1;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m2x1;
+  m1x1 += (float1x1)m2x1;
   m1x1 = m1x1 + m4x1;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m4x1;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m4x1;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m4x1;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m4x1;
+  m1x1 += (float1x1)m4x1;
   m1x1 = m1x1 + m1x2;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m1x2;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m1x2;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m1x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m1x2;
+  m1x1 += (float1x1)m1x2;
   m1x1 = m1x1 + m2x2;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m2x2;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m2x2;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m2x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m2x2;
+  m1x1 += (float1x1)m2x2;
   m1x1 = m1x1 + m4x2;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m4x2;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m4x2;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m4x2;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m4x2;
+  m1x1 += (float1x1)m4x2;
   m1x1 = m1x1 + m1x4;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m1x4;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m1x4;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m1x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m1x4;
+  m1x1 += (float1x1)m1x4;
   m1x1 = m1x1 + m2x4;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m2x4;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m2x4;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m2x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m2x4;
+  m1x1 += (float1x1)m2x4;
   m1x1 = m1x1 + m4x4;                                       /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x1 += m4x4;                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x1 = m1x1 + (float1x1)m4x4;                             /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x1 += (float1x1)m4x4;                                   /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x1 = m1x1 + (float1x1)m4x4;
+  m1x1 += (float1x1)m4x4;
   m2x1 = m2x1 + f;
   m2x1 += f;
   m2x1 = m2x1 + (float2x1)f;
@@ -335,8 +329,8 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   m2x1 += (float2x1)f2;
   m2x1 = m2x1 + f4;                                         /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m2x1 += f4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m2x1 = m2x1 + (float2x1)f4;                               /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m2x1 += (float2x1)f4;                                     /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m2x1 = m2x1 + (float2x1)f4;
+  m2x1 += (float2x1)f4;
   m2x1 = m2x1 + m1x1;
   m2x1 += m1x1;
   m2x1 = m2x1 + (float2x1)m1x1;
@@ -439,8 +433,8 @@ float4 main(float4 a : A, float3 c :C) : SV_TARGET {
   m1x2 += (float1x2)f2;
   m1x2 = m1x2 + f4;                                         /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   m1x2 += f4;                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
-  m1x2 = m1x2 + (float1x2)f4;                               /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
-  m1x2 += (float1x2)f4;                                     /* expected-error {{cannot truncate lvalue vector/matrix}} fxc-pass {{}} */
+  m1x2 = m1x2 + (float1x2)f4;
+  m1x2 += (float1x2)f4;
   m1x2 = m1x2 + m1x1;
   m1x2 += m1x1;
   m1x2 = m1x2 + (float1x2)m1x1;


### PR DESCRIPTION
There was a bogus condition that made this dependent on whether we were truncating vectors/matrices, so later code would unexpectedly get an LValue (llvm pointer) instead of an RValue (llvm value) and crash. Coincidentally it also made strings work... ugh.

Fixes #1844 and #1845