### PR TITLE
Fix name clashes between the entrypoint and same-named functions in different scopes

### DIFF
--- a/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -612,11 +612,14 @@ StringRef CodeGenModule::getMangledName(GlobalDecl GD) {
 
   const auto *ND = cast<NamedDecl>(GD.getDecl());
   // HLSL Change Starts
+  // Entry point doesn't get mangled
   if (ND->getKind() == Decl::Function &&
-      ND->getNameAsString() == CodeGenOpts.HLSLEntryFunction) {
+    ND->getDeclContext()->getDeclKind() == Decl::Kind::TranslationUnit &&
+    ND->getNameAsString() == CodeGenOpts.HLSLEntryFunction) {
     return CodeGenOpts.HLSLEntryFunction;
   }
   // HLSL Change Ends
+
   SmallString<256> Buffer;
   StringRef Str;
   if (getCXXABI().getMangleContext().shouldMangleDeclName(ND)) {

--- a/tools/clang/test/CodeGenHLSL/quick-test/entrypoint_name_clash_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/entrypoint_name_clash_regression.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc /T vs_6_0 /E main %s | FileCheck %s
+
+// Regression test for a bug where any function named
+// like the entry point would get the same mangling,
+// regardless of its scope, causing a name clash (GitHub #1848).
+
+// CHECK: define void @main()
+
+namespace foo { void main() {} }
+struct bar { static void main() {} };
+void main() { foo::main(); bar::main(); }

--- a/tools/clang/test/CodeGenHLSL/quick-test/entrypoint_not_in_global_namespace_error.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/entrypoint_not_in_global_namespace_error.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc /T vs_6_0 /E main %s | FileCheck %s
+
+// Test that the entry point must be in the global namespace.
+
+// CHECK: error: missing entry point definition
+
+namespace foo { void main() {} }
+struct bar { static void main() {} };


### PR DESCRIPTION
The name mangling logic has a special case to preserve the entry point name intact, but it would also apply to functions in different scopes that had the same name as the entry point.

Fixes #1848