### PR TITLE
[DxilPIXPasses] Assigns unique ID to each instruction.

### DIFF
--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -72,6 +72,12 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
   if (OSOverride != nullptr) {
     *OSOverride << "\nBegin - dxil values to virtual register mapping\n";
   }
+
+  std::uint32_t InstNum = 0;
+  for (llvm::Instruction &I : llvm::inst_range(m_DM->GetEntryFunction())) {
+    pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, ++InstNum);
+  }
+
   for (llvm::Instruction &I : llvm::inst_range(m_DM->GetEntryFunction())) {
     AnnotateValues(&I);
   }

--- a/lib/DxilPIXPasses/DxilPIXVirtualRegisters.h
+++ b/lib/DxilPIXPasses/DxilPIXVirtualRegisters.h
@@ -22,6 +22,14 @@ class Value;
 }  // namespace llvm
 
 namespace pix_dxil {
+namespace PixDxilInstNum {
+static constexpr char MDName[] = "pix-dxil-inst-num";
+static constexpr uint32_t ID = 3;
+
+void AddMD(llvm::LLVMContext &Ctx, llvm::Instruction *pI, std::uint32_t InstNum);
+bool FromInst(llvm::Instruction *pI, std::uint32_t *pInstNum);
+}  // namespace PixDxilInstNum
+
 namespace PixDxilReg {
 static constexpr char MDName[] = "pix-dxil-reg";
 static constexpr uint32_t ID = 0;

--- a/tools/clang/test/CodeGenHLSL/pix/DebugFlowControl.hlsl
+++ b/tools/clang/test/CodeGenHLSL/pix/DebugFlowControl.hlsl
@@ -8,7 +8,7 @@
 // CHECK:  %MaskedForUAVLimit3 = and i32 %UAVIncResult2, 983039
 // CHECK:  %MultipliedForInterest4 = mul i32 %MaskedForUAVLimit3, %OffsetMultiplicand
 // CHECK:  %AddedForInterest5 = add i32 %MultipliedForInterest4, %OffsetAddend
-// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5, i32 undef, i32 64770, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5, i32 undef, i32 64771, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK:  switch i32
 // CHECK:    i32 0, label 
 // CHECK:    i32 32, label

--- a/tools/clang/tools/dxcompiler/dxcassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcassembler.cpp
@@ -130,8 +130,11 @@ HRESULT STDMETHODCALLTYPE DxcAssembler::AssembleToContainer(
     outStream.flush();
 
     CComPtr<IDxcBlob> pResultBlob;
+    static constexpr hlsl::SerializeDxilFlags flags = static_cast<hlsl::SerializeDxilFlags>(
+        static_cast<uint32_t>(SerializeDxilFlags::IncludeDebugNamePart) |
+        static_cast<uint32_t>(SerializeDxilFlags::IncludeDebugInfoPart));
     dxcutil::AssembleToContainer(std::move(M), pResultBlob,
-                                         TM.p, SerializeDxilFlags::IncludeDebugNamePart,
+                                         TM.p, flags,
                                          pOutputStream);
 
     IFT(DxcOperationResult::CreateFromResultErrorStatus(pResultBlob, nullptr, S_OK, ppResult));


### PR DESCRIPTION
This PR modifies the DxilAnnotateWithVirtualRegister pass to also annotate
each instruction in the DXIL module with a unique ID. This ID can then be
used by trace debuggers to uniquely identify an instruction in DXIL module.

This PR also modifies the DxilDebugInstrumentation pass to output this
unique ID on each entry in the debug trace. The debug trace is also expanded
to include the Value Ordinal (i.e., the virtual register modified by the
instruction).

Finally, this PR bundles a small bugfix to the dxassembler. The bug prevented
the DxcAssembler to add the debug DXIL to the container it assembles.