### PR TITLE
Fixed a crash on unused matrix inputs

### DIFF
--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -633,8 +633,7 @@ void replaceDirectInputParameter(Value *param, Function *loadInput,
         GenerateLdInput(loadInput, args, Builder, zero, bCast, EltTy);
     param->replaceAllUsesWith(input);
   } else if (dxilutil::IsHLSLMatrixType(Ty)) {
-    Value *colIdx = hlslOP->GetU8Const(0);
-    (void)colIdx;
+    if (param->use_empty()) return;
     DXASSERT(param->hasOneUse(),
              "matrix arg should only has one use as matrix to vec");
     CallInst *CI = cast<CallInst>(param->user_back());

--- a/tools/clang/test/CodeGenHLSL/declarations/functions/entrypoints/unused_matrix_input_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/declarations/functions/entrypoints/unused_matrix_input_regression.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc /T vs_6_2 /E main %s | FileCheck %s
+
+// Regression test for GitHub #1947, where matrix input parameters were expected to have
+// exactly one use in HLSignatureLower, instead of zero or one, leading to a crash.
+
+// CHECK: ret void
+
+void main(int2x2 mat : IN) {}


### PR DESCRIPTION
HLMatrixLower asserted that all matrix parameters had a single use, instead of also allowing them to be unused.

Fixes #1947