### PR TITLE
Fix some argument passing and groupshared bad codegen and crashes - on 19h1-rel

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -104,6 +104,7 @@ namespace dxilutil {
   void PrintDiagnosticHandler(const llvm::DiagnosticInfo &DI, void *Context);
   // Returns true if type contains HLSL Object type (resource)
   bool ContainsHLSLObjectType(llvm::Type *Ty);
+  bool IsHLSLResourceType(llvm::Type *Ty);
   bool IsHLSLObjectType(llvm::Type *Ty);
   bool IsHLSLMatrixType(llvm::Type *Ty);
   bool IsSplat(llvm::ConstantDataVector *cdv);

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -396,29 +396,15 @@ llvm::Instruction *FirstNonAllocaInsertionPt(llvm::Function* F) {
   return SkipAllocas(FindAllocaInsertionPt(F));
 }
 
-bool IsHLSLObjectType(llvm::Type *Ty) {
+bool IsHLSLResourceType(llvm::Type *Ty) {
   if (llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty)) {
     StringRef name = ST->getName();
-    // TODO: don't check names.
-    if (name.startswith("dx.types.wave_t"))
-      return true;
-
-    if (name.endswith("_slice_type"))
-      return false;
-
     name = name.ltrim("class.");
     name = name.ltrim("struct.");
 
     if (name == "SamplerState")
       return true;
     if (name == "SamplerComparisonState")
-      return true;
-
-    if (name.startswith("TriangleStream<"))
-      return true;
-    if (name.startswith("PointStream<"))
-      return true;
-    if (name.startswith("LineStream<"))
       return true;
 
     if (name.startswith("AppendStructuredBuffer<"))
@@ -441,23 +427,53 @@ bool IsHLSLObjectType(llvm::Type *Ty) {
       return true;
     if (name.startswith("StructuredBuffer<"))
       return true;
-    if (name.startswith("Texture1D<"))
+
+    if (name.startswith("Texture")) {
+      name = name.ltrim("Texture");
+      if (name.startswith("1D<"))
+        return true;
+      if (name.startswith("1DArray<"))
+        return true;
+      if (name.startswith("2D<"))
+        return true;
+      if (name.startswith("2DArray<"))
+        return true;
+      if (name.startswith("3D<"))
+        return true;
+      if (name.startswith("Cube<"))
+        return true;
+      if (name.startswith("CubeArray<"))
+        return true;
+      if (name.startswith("2DMS<"))
+        return true;
+      if (name.startswith("2DMSArray<"))
+        return true;
+    }
+  }
+  return false;
+}
+
+bool IsHLSLObjectType(llvm::Type *Ty) {
+  if (llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty)) {
+    StringRef name = ST->getName();
+    // TODO: don't check names.
+    if (name.startswith("dx.types.wave_t"))
       return true;
-    if (name.startswith("Texture1DArray<"))
+
+    if (name.endswith("_slice_type"))
+      return false;
+
+    if (IsHLSLResourceType(Ty))
       return true;
-    if (name.startswith("Texture2D<"))
+
+    name = name.ltrim("class.");
+    name = name.ltrim("struct.");
+
+    if (name.startswith("TriangleStream<"))
       return true;
-    if (name.startswith("Texture2DArray<"))
+    if (name.startswith("PointStream<"))
       return true;
-    if (name.startswith("Texture3D<"))
-      return true;
-    if (name.startswith("TextureCube<"))
-      return true;
-    if (name.startswith("TextureCubeArray<"))
-      return true;
-    if (name.startswith("Texture2DMS<"))
-      return true;
-    if (name.startswith("Texture2DMSArray<"))
+    if (name.startswith("LineStream<"))
       return true;
   }
   return false;

--- a/tools/clang/lib/CodeGen/CGClass.cpp
+++ b/tools/clang/lib/CodeGen/CGClass.cpp
@@ -171,7 +171,8 @@ llvm::Value *CodeGenFunction::GetAddressOfBaseClass(
 
   // Get the base pointer type.
   llvm::Type *BasePtrTy =
-    ConvertType((PathEnd[-1])->getType())->getPointerTo();
+    ConvertType((PathEnd[-1])->getType())->getPointerTo(
+      Value->getType()->getPointerAddressSpace()); // HLSL Change: match address space
 
   QualType DerivedTy = getContext().getRecordType(Derived);
   CharUnits DerivedAlign = getContext().getTypeAlignInChars(DerivedTy);

--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -1795,7 +1795,7 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, llvm::Value *Arg,
   }
 
   LValue lv = MakeAddrLValue(DeclPtr, Ty, Align);
-  if (IsScalar) {
+  if (!getLangOpts().HLSL && IsScalar) {  // HLSL Change: not ObjC
     Qualifiers qs = Ty.getQualifiers();
     if (Qualifiers::ObjCLifetime lt = qs.getObjCLifetime()) {
       // We honor __attribute__((ns_consumed)) for types with lifetime.

--- a/tools/clang/lib/CodeGen/CGExpr.cpp
+++ b/tools/clang/lib/CodeGen/CGExpr.cpp
@@ -3298,10 +3298,8 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
         FromTy->getPointerElementType(), RetTy->getPointerAddressSpace());
       assert(ConvertedFromTy == RetTy &&
              "otherwise, more than just address space changing in one step");
-      llvm::Value *cast = llvm::UndefValue::get(RetTy);
-      if (ConvertedFromTy == RetTy) {
-        cast = Builder.CreateAddrSpaceCast(FromValue, ConvertedFromTy);
-      }
+      llvm::Value *cast =
+          Builder.CreateAddrSpaceCast(FromValue, ConvertedFromTy);
       return MakeAddrLValue(cast, ToType);
     }
     llvm::Value *cast = CGM.getHLSLRuntime().EmitHLSLMatrixOperationCall(*this, E, RetTy, { LV.getAddress() });

--- a/tools/clang/lib/CodeGen/CGExpr.cpp
+++ b/tools/clang/lib/CodeGen/CGExpr.cpp
@@ -3285,10 +3285,25 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
     LValue LV = EmitLValue(E->getSubExpr());
     QualType ToType = getContext().getLValueReferenceType(E->getType());
 
+    llvm::Value *FromValue = LV.getAddress();
+    llvm::Type *FromTy = FromValue->getType();
     llvm::Type *RetTy = ConvertType(ToType);
     // type not changed, LValueToRValue, CStyleCast may go this path
-    if (LV.getAddress()->getType() == RetTy)
+    if (FromTy == RetTy) {
       return LV;
+    // If only address space changed, add address space cast
+    }
+    if (FromTy->getPointerAddressSpace() != RetTy->getPointerAddressSpace()) {
+      llvm::Type *ConvertedFromTy = llvm::PointerType::get(
+        FromTy->getPointerElementType(), RetTy->getPointerAddressSpace());
+      assert(ConvertedFromTy == RetTy &&
+             "otherwise, more than just address space changing in one step");
+      llvm::Value *cast = llvm::UndefValue::get(RetTy);
+      if (ConvertedFromTy == RetTy) {
+        cast = Builder.CreateAddrSpaceCast(FromValue, ConvertedFromTy);
+      }
+      return MakeAddrLValue(cast, ToType);
+    }
     llvm::Value *cast = CGM.getHLSLRuntime().EmitHLSLMatrixOperationCall(*this, E, RetTy, { LV.getAddress() });
     return MakeAddrLValue(cast, ToType);
   }

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -7010,8 +7010,6 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
     const ParmVarDecl *Param = FD->getParamDecl(i);
     const Expr *Arg = E->getArg(i+ArgsToSkip);
     QualType ParamTy = Param->getType().getNonReferenceType();
-    RValue argRV; // emit this if aggregate arg on in-only param
-    LValue argLV; // otherwise, we may emit this
     bool isObject = dxilutil::IsHLSLObjectType(CGF.ConvertTypeForMem(ParamTy));
     bool isAggregateType = !isObject &&
       (ParamTy->isArrayType() || ParamTy->isRecordType()) &&
@@ -7079,6 +7077,8 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
     // FIXME: This will not emit in correct argument order with the other
     //        arguments. This should be integrated into
     //        CodeGenFunction::EmitCallArg if possible.
+    RValue argRV; // emit this if aggregate arg on in-only param
+    LValue argLV; // otherwise, we may emit this
     llvm::Value *argAddr = nullptr;
     QualType argType = Arg->getType();
     CharUnits argAlignment;

--- a/tools/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1811,11 +1811,6 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
 
     // Make sure the result is of the correct type.
     if (Entry->getType()->getAddressSpace() != Ty->getAddressSpace()) {
-      // HLSL Change Begins
-      // TODO: do we put address space in type?
-      if (LangOpts.HLSL) return Entry;
-      else
-      // HLSL Change Ends
       return llvm::ConstantExpr::getAddrSpaceCast(Entry, Ty);
     }
 
@@ -1869,7 +1864,7 @@ CodeGenModule::GetOrCreateLLVMGlobal(StringRef MangledName,
       GV->setSection(".cp.rodata");
   }
 
-  if (AddrSpace != Ty->getAddressSpace() && !LangOpts.HLSL) // HLSL Change -TODO: do we put address space in type?
+  if (AddrSpace != Ty->getAddressSpace())
     return llvm::ConstantExpr::getAddrSpaceCast(GV, Ty);
 
 

--- a/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SPIRVEmitter.cpp
@@ -6813,7 +6813,7 @@ SPIRVEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
   const uint32_t zero = theBuilder.getConstantUint32(0);
   const uint32_t scope = theBuilder.getConstantUint32(1); // Device
   const auto *dest = expr->getArg(0);
-  const auto baseType = dest->getType();
+  const auto baseType = dest->getType()->getCanonicalTypeUnqualified();
 
   if (!baseType->isIntegerType()) {
     emitError("can only perform atomic operations on scalar integer values",

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10806,6 +10806,9 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
   case AttributeList::AT_HLSLGroupShared:
     declAttr = ::new (S.Context) HLSLGroupSharedAttr(A.getRange(), S.Context,
       A.getAttributeSpellingListIndex());
+    if (VarDecl *VD = dyn_cast<VarDecl>(D)) {
+      VD->setType(S.Context.getAddrSpaceQualType(VD->getType(), DXIL::kTGSMAddrSpace));
+    }
     break;
   case AttributeList::AT_HLSLUniform:
     declAttr = ::new (S.Context) HLSLUniformAttr(A.getRange(), S.Context,

--- a/tools/clang/test/CodeGenHLSL/quick-test/empty_struct3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/empty_struct3.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Make sure nest empty struct works.
+// CHECK: main
+
+struct KillerStruct {};
+
+struct InnerStruct {
+  KillerStruct s;
+};
+
+struct OuterStruct {
+  InnerStruct s;
+};
+
+class Derived : OuterStruct {
+  InnerStruct s2;
+};
+
+cbuffer Params_cbuffer : register(b0) {
+  Derived constants[2][3];
+};
+
+float4 foo(Derived s) { return (float4)0; }
+
+float4 main(float4 pos : POSITION) : SV_POSITION {
+  return foo(constants[1][2]);
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/empty_struct3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/empty_struct3.hlsl
@@ -1,6 +1,7 @@
 // RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
 
-// Make sure nest empty struct works.
+// Make sure nested empty struct works.  Also test related paths such as
+// derived, multi-dim array in constant buffer, and argument passing.
 // CHECK: main
 
 struct KillerStruct {};
@@ -23,6 +24,6 @@ cbuffer Params_cbuffer : register(b0) {
 
 float4 foo(Derived s) { return (float4)0; }
 
-float4 main(float4 pos : POSITION) : SV_POSITION {
+float4 main() : SV_POSITION {
   return foo(constants[1][2]);
 }

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
@@ -1,16 +1,25 @@
 // RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
 
+// This tests cast of derived to base when derived is groupshared.
+// Different use cases can hit different code paths, hence the variety of
+// uses here:
+//    - calling base method
+//    - vector element assignment on base member
+//    - casting to base and passing to function
+// The barrier and write to RWBuf prevents optimizations from eliminating
+// groupshared use, considering this dead-code, or detecting a race condition.
+
 // CHECK: @[[gs0:.+]] = addrspace(3) global i32 undef
 // CHECK: @[[gs1:.+]] = addrspace(3) global i32 undef
 // CHECK: @[[gs2:.+]] = addrspace(3) global i32 undef
-// CHECK: store i32 1, i32 addrspace(3)* @[[gs0:.+]], align 4
-// CHECK: store i32 2, i32 addrspace(3)* @[[gs1:.+]], align 4
-// CHECK: store i32 3, i32 addrspace(3)* @[[gs2:.+]], align 4
+// CHECK: store i32 1, i32 addrspace(3)* @[[gs0]], align 4
+// CHECK: store i32 2, i32 addrspace(3)* @[[gs1]], align 4
+// CHECK: store i32 3, i32 addrspace(3)* @[[gs2]], align 4
 
-// CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.0", align 4
-// CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.1", align 4
-// CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.2", align 4
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %RWBuf_UAV_rawbuf, i32 %mul, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
+// CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs0]], align 4
+// CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs1]], align 4
+// CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs2]], align 4
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{.+}}, i32 %mul, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
 
 
 class Base {

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
@@ -19,7 +19,7 @@
 // CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs0]], align 4
 // CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs1]], align 4
 // CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs2]], align 4
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{.+}}, i32 %mul, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{.+}}, i32 %{{.+}}, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
 
 
 class Base {

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
@@ -1,0 +1,41 @@
+// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+
+// CHECK: @[[gs0:.+]] = addrspace(3) global i32 undef
+// CHECK: @[[gs1:.+]] = addrspace(3) global i32 undef
+// CHECK: @[[gs2:.+]] = addrspace(3) global i32 undef
+// CHECK: store i32 1, i32 addrspace(3)* @[[gs0:.+]], align 4
+// CHECK: store i32 2, i32 addrspace(3)* @[[gs1:.+]], align 4
+// CHECK: store i32 3, i32 addrspace(3)* @[[gs2:.+]], align 4
+
+// CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.0", align 4
+// CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.1", align 4
+// CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* @"\01?gs_derived@@3VDerived@@A.0.0.2", align 4
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %RWBuf_UAV_rawbuf, i32 %mul, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
+
+
+class Base {
+  uint3 u;
+  void set_u_y(uint value) { u.y = value; }
+};
+class Derived : Base {
+  float bar;
+};
+
+groupshared Derived gs_derived;
+RWByteAddressBuffer RWBuf;
+
+void UpdateBase_z(inout Base b, uint value) {
+  b.u.z = value;
+}
+
+[numthreads(2, 1, 1)]
+void main(uint3 groupThreadID: SV_GroupThreadID) {
+  if (groupThreadID.x == 0) {
+    gs_derived.u.x = 1;
+    gs_derived.set_u_y(2);
+    UpdateBase_z((Base)gs_derived, 3);
+  }
+  GroupMemoryBarrierWithGroupSync();
+  uint addr = groupThreadID.x * 4;
+  RWBuf.Store3(addr, gs_derived.u);
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-member-matrix-subscript-col.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-member-matrix-subscript-col.hlsl
@@ -1,0 +1,49 @@
+// RUN: %dxc -E main -T cs_6_0 -Zpc %s | FileCheck %s
+
+// CHECK: %[[cb0:[^ ]+]] = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %{{.*}}, i32 0)
+// CHECK: %[[cb0x:[^ ]+]] = extractvalue %dx.types.CBufRet.f32 %[[cb0]], 0
+// CHECK: store float %[[cb0x]], float addrspace(3)* getelementptr inbounds ([16 x float], [16 x float] addrspace(3)* @[[obj:[^,]+]], i32 0, i32 0), align 16
+
+// CHECK: %[[cb1:[^ ]+]] = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %{{.*}}, i32 1)
+// CHECK: %[[cb1x:[^ ]+]] = extractvalue %dx.types.CBufRet.f32 %[[cb1]], 0
+// CHECK: store float %[[cb1x]], float addrspace(3)* getelementptr inbounds ([16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 1), align 4
+
+// CHECK: %[[_25:[^ ]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 %{{.+}}
+// CHECK: %[[_26:[^ ]+]] = load float, float addrspace(3)* %[[_25]], align 4
+// CHECK: %[[_27:[^ ]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 %{{.+}}
+// CHECK: %[[_28:[^ ]+]] = load float, float addrspace(3)* %[[_27]], align 4
+
+// CHECK: %[[_33:[^ ]+]] = bitcast float %[[_26]] to i32
+// CHECK: %[[_34:[^ ]+]] = bitcast float %[[_28]] to i32
+
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{[^,]+}}, i32 %{{.+}}, i32 undef, i32 %[[_33]], i32 %[[_34]], i32 %{{.+}}, i32 %{{.+}}, i8 15)
+
+float4 rows[4];
+
+void set_row(inout float4 row, uint i) {
+  row = rows[i];
+}
+
+class Obj {
+  float4x4 mat;
+  void set() {
+    set_row(mat[0], 0);
+    set_row(mat[1], 1);
+    set_row(mat[2], 2);
+    set_row(mat[3], 3);
+  }
+};
+
+RWByteAddressBuffer RWBuf;
+groupshared Obj obj;
+
+[numthreads(4, 1, 1)]
+void main(uint3 groupThreadID: SV_GroupThreadID) {
+  if (groupThreadID.x == 0) {
+    obj.set();
+  }
+  GroupMemoryBarrierWithGroupSync();
+  float4 row = obj.mat[groupThreadID.x];
+  uint addr = groupThreadID.x * 4;
+  RWBuf.Store4(addr, uint4(asuint(row.x), asuint(row.y), asuint(row.z), asuint(row.w)));
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-member-matrix-subscript.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-member-matrix-subscript.hlsl
@@ -1,0 +1,48 @@
+// RUN: %dxc -E main -T cs_6_0 -Zpr %s | FileCheck %s
+
+// CHECK: %[[cb0:[^ ]+]] = call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %{{.*}}, i32 0)
+// CHECK: %[[cb0x:[^ ]+]] = extractvalue %dx.types.CBufRet.f32 %[[cb0]], 0
+// CHECK: %[[cb0y:[^ ]+]] = extractvalue %dx.types.CBufRet.f32 %[[cb0]], 1
+
+// CHECK: store float %[[cb0x]], float addrspace(3)* getelementptr inbounds ([16 x float], [16 x float] addrspace(3)* @[[obj:[^,]+]], i32 0, i32 0), align 16
+// CHECK: store float %[[cb0y]], float addrspace(3)* getelementptr inbounds ([16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 1), align 4
+
+// CHECK: %[[_25:[^ ]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 %{{.+}}
+// CHECK: %[[_26:[^ ]+]] = load float, float addrspace(3)* %[[_25]], align 16
+// CHECK: %[[_27:[^ ]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @[[obj]], i32 0, i32 %{{.+}}
+// CHECK: %[[_28:[^ ]+]] = load float, float addrspace(3)* %[[_27]], align 4
+
+// CHECK: %[[_33:[^ ]+]] = bitcast float %[[_26]] to i32
+// CHECK: %[[_34:[^ ]+]] = bitcast float %[[_28]] to i32
+
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{.*}}, i32 %{{.+}}, i32 undef, i32 %[[_33]], i32 %[[_34]], i32 %{{.+}}, i32 %{{.+}}, i8 15)
+
+float4 rows[4];
+
+void set_row(inout float4 row, uint i) {
+  row = rows[i];
+}
+
+class Obj {
+  float4x4 mat;
+  void set() {
+    set_row(mat[0], 0);
+    set_row(mat[1], 1);
+    set_row(mat[2], 2);
+    set_row(mat[3], 3);
+  }
+};
+
+RWByteAddressBuffer RWBuf;
+groupshared Obj obj;
+
+[numthreads(4, 1, 1)]
+void main(uint3 groupThreadID: SV_GroupThreadID) {
+  if (groupThreadID.x == 0) {
+    obj.set();
+  }
+  GroupMemoryBarrierWithGroupSync();
+  float4 row = obj.mat[groupThreadID.x];
+  uint addr = groupThreadID.x * 4;
+  RWBuf.Store4(addr, uint4(asuint(row.x), asuint(row.y), asuint(row.z), asuint(row.w)));
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/static_global_copy3.hlsl
@@ -17,7 +17,7 @@ A a;
 
 static A a2;
 
-void set(A aa) {
+void set(out A aa) {
    aa = a;
 }
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/struct_param_in_mod.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/struct_param_in_mod.hlsl
@@ -1,32 +1,16 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
-// Verify fixes for:
-// Bug 1: extra calls to MulPayload due to LValue emit for function call and skipping arg replacement when deemed unnecessary
-// Bug 2: local modification to the payload structure in MullPayload leaks to calling function
+// Verify that modificaion of in-only struct parameter does not modify
+// the value passed in by the caller.
 
-// CHECK-DAG: [[p2x:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 2, i32 0, i8 0,
-// CHECK-DAG: [[p2y:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 2, i32 0, i8 1,
-// CHECK-DAG: [[p2z:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 2, i32 0, i8 2,
-// CHECK-DAG: [[p1x:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 0,
-// CHECK-DAG: [[p1y:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 1,
-// CHECK-DAG: [[p1z:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 2,
-// CHECK-DAG: [[inputx:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0,
-// CHECK-DAG: [[inputy:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1,
-// CHECK-DAG: [[p1x_:%[^ ]*]] = fmul fast float [[inputx]], [[p1x]]
-// CHECK-DAG: [[p1y_:%[^ ]*]] = fmul fast float [[inputx]], [[p1y]]
-// CHECK-DAG: [[p1z_:%[^ ]*]] = fmul fast float [[inputx]], [[p1z]]
-// CHECK-DAG: [[p2x_:%[^ ]*]] = fmul fast float [[inputy]], [[p2x]]
-// CHECK-DAG: [[p2y_:%[^ ]*]] = fmul fast float [[inputy]], [[p2y]]
-// CHECK-DAG: [[p2z_:%[^ ]*]] = fmul fast float [[inputy]], [[p2z]]
-// CHECK-DAG: [[retx:%[^ ]*]] = fadd fast float [[p2x_]], [[p1x_]]
-// CHECK-DAG: [[rety:%[^ ]*]] = fadd fast float [[p2y_]], [[p1y_]]
-// CHECK-DAG: [[retz:%[^ ]*]] = fadd fast float [[p2z_]], [[p1z_]]
-// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float [[retx]])
-// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float [[rety]])
-// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float [[retz]])
+// CHECK-DAG: [[f:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 0,
+// CHECK-DAG: [[p:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0,
+// CHECK-DAG: [[o1:%[^ ]*]] = fmul fast float [[p]], [[f]]
+// CHECK-DAG: [[ret:%[^ ]*]] = fadd fast float [[o1]], [[p]]
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float [[ret]])
 
 struct PayloadStruct {
-  float3 Color;
+  float Color;
 };
 
 PayloadStruct MulPayload(in PayloadStruct Payload, in float x)
@@ -35,17 +19,10 @@ PayloadStruct MulPayload(in PayloadStruct Payload, in float x)
   return Payload;
 }
 
-PayloadStruct AddPayload(in PayloadStruct Payload0, in PayloadStruct Payload1)
-{
-  Payload0.Color += Payload1.Color;
-  return Payload0;
-}
+void main(PayloadStruct p : Payload,
+          float f : INPUT,
+          out PayloadStruct o : SV_Target) {
 
-void main(float2 input : INPUT,
-          PayloadStruct FirstPayload : FirstPayload,
-          PayloadStruct SecondPayload : SecondPayload,
-          out PayloadStruct OutputPayload : SV_Target) {
-
-  OutputPayload = AddPayload(MulPayload(FirstPayload, input.x),
-                             MulPayload(SecondPayload, input.y));
+  o = MulPayload(p, f);
+  o.Color += p.Color;
 }

--- a/tools/clang/test/CodeGenHLSL/quick-test/struct_param_in_mod2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/struct_param_in_mod2.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// Verify fixes for:
+// Bug 1: extra calls to MulPayload due to LValue emit for function call and skipping arg replacement when deemed unnecessary
+// Bug 2: local modification to the payload structure in MullPayload leaks to calling function
+
+// CHECK-DAG: [[p1x:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 0,
+// CHECK-DAG: [[p1y:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 1,
+// CHECK-DAG: [[p1z:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 1, i32 0, i8 2,
+// CHECK-DAG: [[inputx:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0,
+// CHECK-DAG: [[inputy:%[^ ]*]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1,
+// CHECK-DAG: [[add_inputxy:%[^ ]*]] = fadd fast float [[inputy]], [[inputx]]
+// CHECK-DAG: [[retx:%[^ ]*]] = fmul fast float [[add_inputxy]], [[p1x]]
+// CHECK-DAG: [[rety:%[^ ]*]] = fmul fast float [[add_inputxy]], [[p1y]]
+// CHECK-DAG: [[retz:%[^ ]*]] = fmul fast float [[add_inputxy]], [[p1z]]
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float [[retx]])
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float [[rety]])
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float [[retz]])
+
+struct PayloadStruct {
+  float3 Color;
+};
+
+PayloadStruct MulPayload(in PayloadStruct Payload, in float x)
+{
+  Payload.Color *= x;
+  return Payload;
+}
+
+PayloadStruct AddPayload(in PayloadStruct Payload0, in PayloadStruct Payload1)
+{
+  Payload0.Color += Payload1.Color;
+  return Payload0;
+}
+
+void main(float2 input : INPUT,
+          PayloadStruct FirstPayload : FirstPayload,
+          out PayloadStruct OutputPayload : SV_Target) {
+
+  OutputPayload = AddPayload(MulPayload(FirstPayload, input.x),
+                             MulPayload(FirstPayload, input.y));
+}

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_arg_flatten.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_arg_flatten.hlsl
@@ -1,7 +1,8 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure function call on external function has correct type.
-// CHECK: call float @"\01?test_extern@@YAMUT@@Y01U1@U1@AIAV?$matrix@M$01$01@@@Z"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* nonnull {{.*}}, %class.matrix.float.2.2* dereferenceable(16) {{.*}})
+// CHECK: call float @"\01?test_extern@@YAMUT@@Y01U1@U1@AIAV?$matrix@M$01$01@@@Z"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* {{.*}}, %class.matrix.float.2.2* dereferenceable(16) {{.*}})
+
 struct T {
   float a;
   float b;

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_arg_flatten3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_arg_flatten3.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure function call on external function has correct type.
 
-// CHECK: call float @"\01?test_extern@@YAMUT@@@Z"(%struct.T* nonnull %tmp) #2
+// CHECK: call float @"\01?test_extern@@YAMUT@@@Z"(%struct.T* nonnull {{.*}}) #2
 
 struct T {
   float a;

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_empty_struct_arg.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/lib_arg_flatten/lib_empty_struct_arg.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// Make sure empty struct arg works.
-// CHECK: call float @"\01?test@@YAMUT@@@Z"(%struct.T* %t)
+// Make sure empty struct arg is replaced with undef.
+// CHECK: call float @"\01?test@@YAMUT@@@Z"(%struct.T* undef)
 
 struct T {
 };


### PR DESCRIPTION
fixes #1551, fixes #1896, fixes #1902

- set address space for groupshared QualType and fix downstream effects

Fix:
- double LValue expression emit for in aggregate arguments
- in agg param modifying caller's value instead of copy
- groupshared matrix support in HLMatrixLower
- groupshared base class member access
- groupshared matrix member casting in class method

Still in need of more fixes and tests:
- incomplete array and auto dimensions from initializer