### PR TITLE
Fix SROA not lowering all uses of values

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3376,14 +3376,13 @@ void SROA_Helper::RewriteForScalarRepl(Value *V, IRBuilder<> &Builder) {
   Use* PrevUse = nullptr;
   while (!V->use_empty()) {
     Use &TheUse = *V->use_begin();
+
     DXASSERT_LOCALVAR(PrevUse, &TheUse != PrevUse,
-      "Infinite loop while SROA'ing value, value use isn't getting eliminated.");
+      "Infinite loop while SROA'ing value, use isn't getting eliminated.");
     PrevUse = &TheUse;
 
     // Each of these must either call ->eraseFromParent()
     // or null out the use of V so that we make progress.
-    // Unfortunately we can hardly assert that this has happened
-    // because in the ->eraseFromParent() case, we can't access the user anymore.
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(TheUse.getUser())) {
       RewriteForConstExpr(CE, Builder);
     }

--- a/tools/clang/test/CodeGenHLSL/passes/sroa_hlsl/groupshared_array_struct_matrix_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/passes/sroa_hlsl/groupshared_array_struct_matrix_regression.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
+
+// Regression test for GitHub #1631, where SROA would generate more uses
+// of a value while processing it (due to expanding a memcpy) and fail
+// to process the new uses. This caused global structs of matrices to reach HLMatrixLower,
+// which couldn't handle them and would unexpectedly leave matrix intrinsics untouched.
+// Compilation would then fail with "error: Fail to lower matrix load/store."
+
+// CHECK: ret void
+
+struct S { int1x1 x, y; };
+groupshared S gs[1];
+void f(S s[1]) {}
+void main() { f(gs); }


### PR DESCRIPTION
The original bug is that `HLOperationLower` encounters a leftover unlowered matrix and reports an error. The problem isn't that `HLMatrixLower` isn't doing its job, but rather that SROA is failing to lower a specific pattern of groupshared array of structs containing matrices. The reason is that we iterate over all of the uses of the value to be SROA'd to replace them, but in some specific cases, we might end up expanding a memcpy into its constituents, which would add new uses of the value we're trying to replace while were iterating upon its uses. New uses are presumably added to the head of the use list because we never end up visiting them as we complete the iteration, and so we leave references to the unlowered value.

The fix is to change the iteration over all uses loop to a simple `while (!V->use_empty()) process V->use_begin();`. This required a few cascading changes to ensure that all code paths within the loop would indeed either delete the user or set the use target to undef so that we don't end up with an infinite loop (for which I've also added an assert).

Fixes #1631 