### PR TITLE
Update tests to reflect new fixes in master

### DIFF
--- a/tools/clang/test/CodeGenHLSL/crashes/derived_to_base_argument_conversion.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/derived_to_base_argument_conversion.hlsl
@@ -1,8 +1,0 @@
-// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
-
-// Repro of GitHub #1843
-
-struct Base {};
-struct Derived : Base { int a; };
-void f(Base b) {}
-void main() { Derived d; f(d); }

--- a/tools/clang/test/CodeGenHLSL/crashes/matrix_to_aggregate_conversion.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/matrix_to_aggregate_conversion.hlsl
@@ -1,7 +1,0 @@
-// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
-
-// Repro of GitHub #1799
-
-typedef int ix4[4];
-void f(ix4) {}
-void main() { f((ix4)int2x2(1,2,3,4)); }

--- a/tools/clang/test/CodeGenHLSL/crashes/run_all.cmd
+++ b/tools/clang/test/CodeGenHLSL/crashes/run_all.cmd
@@ -1,5 +1,5 @@
 @echo off
 rem We can't run the whole directory at once because crashes stop execution.
-for /f "usebackq delims=|" %%f in (`dir /b "%~dp0"`) do (
+for /f "usebackq delims=|" %%f in (`dir /b "%~dp0\*.hlsl"`) do (
     %HLSL_SRC_DIR%\utils\hct\hcttest.cmd file-check "%~dp0\%%f"
 )

--- a/tools/clang/test/CodeGenHLSL/crashes/static_const_struct_bool_matrix_subscript.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/static_const_struct_bool_matrix_subscript.hlsl
@@ -1,9 +1,0 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
-
-// Repro of GitHub #1881
-
-bool main() : OUT
-{
-    static const struct { bool2x2 x; } sm = { false, true, false, true };
-    return sm.x._11;
-}

--- a/tools/clang/test/CodeGenHLSL/crashes/struct_truncation_cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/struct_truncation_cast.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
+
+// Repro of GitHub #1970
+
+struct S2 { int a, b; };
+struct S3 { int a, b, c; };
+void main()
+{
+    S3 s;
+    (S2)s;
+}

--- a/tools/clang/test/CodeGenHLSL/declarations/bool_representation/const_init_list_no_crash.hlsl
+++ b/tools/clang/test/CodeGenHLSL/declarations/bool_representation/const_init_list_no_crash.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
 
 // Regression test for bools in constant initialization lists crashing
-// due to a mismatch between register and memory representations (GitHub #1880)
+// due to a mismatch between register and memory representations (GitHub #1880, #1881)
 
 // CHECK: ret void
 
@@ -32,9 +32,8 @@ bool main() : OUT
     static const bool ab_s[] = { sb, sv, sm };
 
     // Reference everything to ensure they get codegen'd
-    // Bool matrix accesses crash due to GitHub #1881
-    return b && v.x /* && m._11 */
-        && ab[0] && av[0].x /* && am[0]._11 */
-        && sb.x && sv.x /* && sm.x._11 */
+    return b && v.x && m._11
+        && ab[0] && av[0].x && am[0]._11
+        && sb.x && sv.x && sm.x._11
         && ab_b[0] && ab_v[0] && ab_m[0] && ab_a[0] && ab_s[0];
 }

--- a/tools/clang/test/CodeGenHLSL/declarations/groupshared/this_ptr_address_space.hlsl
+++ b/tools/clang/test/CodeGenHLSL/declarations/groupshared/this_ptr_address_space.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
+
+// Test that the address space of the this pointer is honored
+// when accessing data members or calling member functions.
+// Also a regression test for GitHub #1957
+
+struct Foo { int x; int getX() { return x; } };
+int i, j;
+
+// CHECK: @[[gs:.*]] = addrspace(3) global [2 x i32] undef
+groupshared Foo foo[2];
+
+int4 main() : OUT
+{
+  return int4(
+    // getelementptr & addrspacecast constant expressions
+    // CHECK: load i32, i32 addrspace(3)* getelementptr inbounds ([2 x i32], [2 x i32] addrspace(3)* @[[gs]], i32 0, i32 0)
+    foo[0].x, 
+    // CHECK: load i32, i32 addrspace(3)* getelementptr inbounds ([2 x i32], [2 x i32] addrspace(3)* @[[gs]], i32 0, i32 1)
+    foo[1].getX(),
+
+    // getelementptr & addrspacecast instructions
+    // CHECK: %[[gep:.*]] = getelementptr [2 x i32], [2 x i32] addrspace(3)* @[[gs]], i32 0, i32 %{{.*}}
+    // CHECK: load i32, i32 addrspace(3)* %[[gep]]
+    foo[i].x,
+    // CHECK: %[[gep:.*]] = getelementptr [2 x i32], [2 x i32] addrspace(3)* @[[gs]], i32 0, i32 %{{.*}}
+    // CHECK: load i32, i32 addrspace(3)* %[[gep]]
+    foo[j].getX()); 
+}

--- a/tools/clang/test/CodeGenHLSL/expressions/argument_passing/aggregates_by_value_semantics.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/argument_passing/aggregates_by_value_semantics.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -E main -T vs_6_0 -no-warnings %s | FileCheck %s
+
+// Tests that pass-by-value/copy-in semantics are respected
+// with aggregate types (arrays and structs).
+
+struct S { int f; };
+void set_elem(int a[1]) { a[0] = 42; }
+void set_field(S s) { s.f = 42; }
+int2 main() : OUT
+{
+    int a[1] = { 1 };
+    set_elem(a);
+    S s = { 1 };
+    set_field(s);
+
+    // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+    // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 1)
+    return int2(a[0], s.f);
+}

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
@@ -197,7 +197,7 @@ void main()
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
     output_s1((S1)a2);
-    // DXC crashes (GitHub #1799)
+    // DXC crashes (GitHub #1970)
     // FXC: l(1,0,0,0)
     // output_s1((S1)s2);
     
@@ -440,7 +440,7 @@ void main()
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_s2((S2)a4);
-    // DXC crashes (GitHub #1799)
+    // DXC crashes (GitHub #1970)
     // FXC: l(1,2,0,0)
     // output_s2((S2)s4);
 }

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
@@ -117,15 +117,15 @@ void main()
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
     output_a1((A1)v1);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(11,0,0,0)
-    // output_a1((A1)m1x1);
+    output_a1((A1)m1x1);
     // DXC rejects (GitHub #1862)
     // FXC: l(1,0,0,0)
     // output_a1(s1); 
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
-    // output_a1((A1)s1);
+    output_a1((A1)s1);
 
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
@@ -133,9 +133,9 @@ void main()
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
     output_s1((S1)v1);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(11,0,0,0)
-    // output_s1((S1)m1x1);
+    output_s1((S1)m1x1);
     // DXC rejects (GitHub #1862)
     // FXC: l(1,0,0,0)
     // output_s1(a1);
@@ -190,9 +190,9 @@ void main()
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
     output_a1((A1)a2);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
-    // output_a1((A1)s2);
+    output_a1((A1)s2);
 
     // DXC: i32 1, i32 0, i32 0, i32 0, i8 15)
     // FXC: l(1,0,0,0)
@@ -298,34 +298,34 @@ void main()
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_a2((A2)v2);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 12, i32 0, i32 0, i8 15)
     // FXC: l(11,12,0,0)
-    // output_a2((A2)m1x2);
-    // DXC crashes (GitHub #1799)
+    output_a2((A2)m1x2);
+    // DXC: i32 11, i32 21, i32 0, i32 0, i8 15)
     // FXC: l(11,21,0,0)
-    // output_a2((A2)m2x1);
-    // DXC crashes (GitHub #1799)
+    output_a2((A2)m2x1);
+    // DXC: i32 11, i32 12, i32 21, i32 22, i8 15)
     // FXC: l(11,12,21,22)
-    // output_a4((A4)m2x2);
+    output_a4((A4)m2x2);
     // DXC rejects (GitHub #1862)
     // FXC: l(1,2,0,0)
     // output_a2(s2);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
-    // output_a2((A2)s2);
+    output_a2((A2)s2);
 
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_s2((S2)v2);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 12, i32 0, i32 0, i8 15)
     // FXC: l(11,12,0,0)
-    // output_s2((S2)m1x2);
-    // DXC crashes (GitHub #1799)
+    output_s2((S2)m1x2);
+    // DXC: i32 11, i32 21, i32 0, i32 0, i8 15)
     // FXC: l(11,21,0,0)
-    // output_s2((S2)m2x1);
-    // DXC crashes (GitHub #1799)
+    output_s2((S2)m2x1);
+    // DXC: i32 11, i32 12, i32 21, i32 22, i8 15)
     // FXC: l(11,12,21,22)
-    // output_s4((S4)m2x2);
+    output_s4((S4)m2x2);
     // DXC rejects (GitHub #1862)
     // FXC: l(1,2,0,0)
     // output_s2(a2);
@@ -403,38 +403,38 @@ void main()
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_a2((A2)v4);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 12, i32 0, i32 0, i8 15)
     // FXC: l(11,12,0,0)
-    // output_a2((A2)m1x3);
-    // DXC crashes (GitHub #1799)
+    output_a2((A2)m1x3);
+    // DXC: i32 11, i32 21, i32 0, i32 0, i8 15)
     // FXC: l(11,21,0,0)
-    // output_a2((A2)m3x1);
-    // DXC crashes (GitHub #1799)
+    output_a2((A2)m3x1);
+    // DXC accepts (GitHub #1865)
     // FXC rejects with error X3017: cannot convert from 'int2x2' to 'typedef int[2]'
     // output_a2((A2)m2x2);
-    // DXC crashes (GitHub #1799)
+    // DXC accepts (GitHub #1865)
     // FXC rejects with error X3017: cannot convert from 'int3x3' to 'typedef int[2]'
     // output_a2((A2)m3x3);
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_a2((A2)a4);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
-    // output_a2((A2)s4);
+    output_a2((A2)s4);
 
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)
     // FXC: l(1,2,0,0)
     output_s2((S2)v4);
-    // DXC crashes (GitHub #1799)
+    // DXC: i32 11, i32 12, i32 0, i32 0, i8 15)
     // FXC: l(11,12,0,0)
-    // output_s2((S2)m1x3);
-    // DXC crashes (GitHub #1799)
+    output_s2((S2)m1x3);
+    // DXC: i32 11, i32 21, i32 0, i32 0, i8 15)
     // FXC: l(11,21,0,0)
-    // output_s2((S2)m3x1);
-    // DXC crashes (GitHub #1799)
+    output_s2((S2)m3x1);
+    // DXC accepts (GitHub #1865)
     // FXC rejects with error X3017: cannot convert from 'int2x2' to 'struct S2'
     // output_s2((S2)m2x2);
-    // DXC crashes (GitHub #1799)
+    // DXC accepts (GitHub #1865)
     // FXC rejects with error X3017: cannot convert from 'int3x3' to 'struct S2'
     // output_s2((S2)m3x3);
     // DXC: i32 1, i32 2, i32 0, i32 0, i8 15)

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/derived_to_base_argument.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/derived_to_base_argument.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
+
+// Regression test for GitHub #1843, where derived-to-base
+// conversions would cause a crash while emitting arguments,
+// probably due to lvalue/rvalue handling while casting.
+
+// CHECK: ret void
+
+struct Base {};
+struct Derived : Base { int a; };
+void f(Base b) {}
+void main() { Derived d; f(d); }


### PR DESCRIPTION
Fixes #1835, #1881, #1799 (remaining crash tracked by #1970), removing crash repros
Adds a test for #1843, #1957, and a crash repro for #1970