### PR TITLE
Reorg test coverage for cast between structs of identical layout.

### DIFF
--- a/tools/clang/test/CodeGenHLSL/crashes/equivalent_struct_argument_conversion.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/equivalent_struct_argument_conversion.hlsl
@@ -1,8 +1,0 @@
-// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
-
-// Repro of GitHub #1842
-
-struct S1 { int a, b; };
-struct S2 { int a, b; };
-void foo(S2 s) {}
-void main() { S1 s; foo(s); }

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/explicit_cast_as_out_param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/explicit_cast_as_out_param.hlsl
@@ -1,4 +1,6 @@
 // RUN: %dxc /Tvs_6_0 /Emain %s | FileCheck %s
+// Test explicit cast between structs of identical layout where
+// the destination struct is marked as out param.
 
 // o1.f1 = input.f1
 // CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/explicit_cast_as_return_val.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/explicit_cast_as_return_val.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc /Tps_6_0 /Emain %s | FileCheck %s
 // github issue #1684
+// Test explicit cast between structs of identical layouts.
+
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_func_param.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_func_param.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// github issue #1842
+// Test implicit cast scenario between structs of identical layout
+// when struct is passed as a function parameter. This test 
+// simply checks if this program compiles successfully w/o crashing.
+
+// CHECK: main
+
+struct S1 { int a, b; };
+struct S2 { int a, b; };
+void foo(S2 s) {}
+void main() { S1 s; foo(s); }

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_func_param_user_scenario.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_func_param_user_scenario.hlsl
@@ -1,0 +1,54 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// github issue #1725
+// Test implicit cast scenario between structs of identical layout
+// which would crash as reported by a user.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 0.000000e+00)
+  
+struct BUFF
+{
+    float4 rt0 : SV_Target0;
+};
+
+struct VSOUT_A
+{
+    float4 hclip : SV_Position;
+    float3 wp : WORLD_POSITION;
+};
+
+struct VSOUT_B
+{
+    VSOUT_A position;
+    float3 normal : NORMAL;
+};
+
+struct VSOUT_C
+{
+    VSOUT_A position;
+    float3 normal : NORMAL;
+};
+
+float3 getNormal(in VSOUT_B vsout)
+{
+    return vsout.normal;
+}
+
+struct VSOUT_D
+{
+    VSOUT_C standard;
+};
+
+void foo(in VSOUT_A stdP)
+{
+    (stdP) = (stdP);
+}
+
+BUFF main(VSOUT_D input)
+{
+    foo(input.standard.position);        // comment out and it will compile fine
+    float3 N = getNormal( input.standard ); // comment this out and it will compile fine    
+    return (BUFF)0;
+}

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_streamout_append.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/identical_layout_structs/implicit_cast_as_streamout_append.hlsl
@@ -56,24 +56,7 @@ void main(inout TriangleStream<GSOutPSIn> stream)
     tri[2].clr = float4(17, 18, 19, 20);
     tri[2].pos = float4(21, 22, 23, 24);
     
-//#define WORKAROUND
-#if !defined(WORKAROUND)
     stream.Append(tri[0]);
     stream.Append(tri[1]);
     stream.Append(tri[2]);
-#else
-    GSOutPSIn t0;
-        t0.clr = tri[0].clr;
-        t0.pos = tri[0].pos;
-    GSOutPSIn t1;
-        t1.clr = tri[1].clr;
-        t1.pos = tri[1].pos;
-    GSOutPSIn t2;
-        t2.clr = tri[2].clr;
-        t2.pos = tri[2].pos;
-
-    stream.Append(t0);
-    stream.Append(t1);
-    stream.Append(t2);
-#endif
 }


### PR DESCRIPTION
It turns out that latest `master` fixes #1725 and #1842. Nevertheless, this PR adds the respective failing scenarios as tests. It also reorganizes existing tests to bring together all tests involving cast between structs of identical layout.