### PR TITLE
Fix non-decimal integer literals being truncated to 32 bits if not suffixed by LL

### DIFF
--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -3398,8 +3398,7 @@ ExprResult Sema::ActOnNumericConstant(const Token &Tok, Scope *UDLScope) {
     QualType Ty;
     unsigned Width = 64;
     llvm::APInt ResultVal(Width, 0);
-    if (!Literal.isLong && !Literal.isLongLong &&
-        !Literal.isUnsigned && Literal.getRadix() == 10) {
+    if (!Literal.isLong && !Literal.isLongLong && !Literal.isUnsigned) {
       // in HLSL, unspecific literal ints are LitIntTy, using 64-bit
       Ty = Context.LitIntTy;
       if (Literal.GetIntegerValue(ResultVal)) {

--- a/tools/clang/test/CodeGenHLSL/expressions/64bit_integer_literals.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/64bit_integer_literals.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T vs_6_3 %s | FileCheck %s
+
+// Regression test for GitHub #1973, where the value of literals
+// were implicitly truncated to 32 bits if not suffixed with LL.
+
+RWStructuredBuffer<uint64_t4> buf;
+void main()
+{
+  // CHECK: call void @dx.op.rawBufferStore.i64
+  // CHECK: i64 4294967296, i64 4294967296, i64 4294967296, i64 4294967296, i8 15
+  buf[0] = uint64_t4(
+    4294967296, // 2^32
+    0x100000000, // 2^32
+    040000000000, // 2^32
+    0b100000000000000000000000000000000); // 2^32
+}

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/numerical_const_init_list.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/numerical_const_init_list.hlsl
@@ -68,7 +68,7 @@ void main() {
     
     // To float
     // CHECK: float 1.000000e+00, float -1.000000e+00, float 0x41F0000000000000, float -1.000000e+00, i8
-    // CHECK: float 6.553500e+04, float -1.000000e+00, float 0x41F0000000000000, float -1.500000e+00, i8
+    // CHECK: float 6.553500e+04, float -1.000000e+00, float 0x43F0000000000000, float -1.500000e+00, i8
     // CHECK: float -1.500000e+00, float -1.500000e+00, float 0.000000e+00, float 0.000000e+00, i8
     static const float f[] = {
         true, // UIToFP

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/intrinsic-examples_gold.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/intrinsic-examples_gold.hlsl
@@ -26,13 +26,13 @@ VS_OUT FontVertexShader(VS_IN In) {
   Out.Position.x = In.Pos.x;
   Out.Position.y = In.Pos.y;
   Out.Diffuse = Color;
-  uint texX = (In.TexAndChannelSelector.x >> 0) & 65535U;
-  uint texY = (In.TexAndChannelSelector.x >> 16) & 65535U;
+  uint texX = (In.TexAndChannelSelector.x >> 0) & 65535;
+  uint texY = (In.TexAndChannelSelector.x >> 16) & 65535;
   Out.TexCoord0 = float2(texX, texY) * TexScale;
-  Out.ChannelSelector.w = (0 != (In.TexAndChannelSelector.y & 61440U)) ? 1 : 0;
-  Out.ChannelSelector.x = (0 != (In.TexAndChannelSelector.y & 3840U)) ? 1 : 0;
-  Out.ChannelSelector.y = (0 != (In.TexAndChannelSelector.y & 240U)) ? 1 : 0;
-  Out.ChannelSelector.z = (0 != (In.TexAndChannelSelector.y & 15U)) ? 1 : 0;
+  Out.ChannelSelector.w = (0 != (In.TexAndChannelSelector.y & 61440)) ? 1 : 0;
+  Out.ChannelSelector.x = (0 != (In.TexAndChannelSelector.y & 3840)) ? 1 : 0;
+  Out.ChannelSelector.y = (0 != (In.TexAndChannelSelector.y & 240)) ? 1 : 0;
+  Out.ChannelSelector.z = (0 != (In.TexAndChannelSelector.y & 15)) ? 1 : 0;
   return Out;
 }
 

--- a/tools/clang/test/HLSL/subobjects-syntax.hlsl
+++ b/tools/clang/test/HLSL/subobjects-syntax.hlsl
@@ -19,7 +19,7 @@ StateObjectConfig soc1_4 = { 1 };
 StateObjectConfig soc1_5 = { 0.1f };                        /* expected-warning {{implicit conversion from 'float' to 'unsigned int' changes value from 0.1 to 0}} */
 
 StateObjectConfig soc2_2 = STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS;    /* expected-error {{cannot initialize a variable of type 'StateObjectConfig' with an lvalue of type 'const unsigned int'}} */
-StateObjectConfig soc2_3 = 0x1;                             /* expected-error {{cannot initialize a variable of type 'StateObjectConfig' with an rvalue of type 'unsigned int'}} */
+StateObjectConfig soc2_3 = 0x1;                             /* expected-error {{cannot initialize a variable of type 'StateObjectConfig' with an rvalue of type 'literal int'}} */
 StateObjectConfig soc2_4 = "none";                          /* expected-error {{cannot initialize a variable of type 'StateObjectConfig' with an lvalue of type 'literal string'}} */
 StateObjectConfig soc2_5 = { STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS, STATE_OBJECT_FLAGS_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS };    /* expected-error {{too many elements in subobject initialization (expected 1 element, have 2)}} */
 StateObjectConfig soc2_6 = { 0x1, 0x2 };                    /* expected-error {{too many elements in subobject initialization (expected 1 element, have 2)}} */


### PR DESCRIPTION
One consequence of this fix is that 0x/0b/0 literals are now considered of the literal int type instead of some unsigned integral type, hence some rewriter output changes.

Fixes #1973