### PR TITLE
Fix vec1/mat1x1 to aggregate type splats and a crash

### DIFF
--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/between_type_shapes.hlsl
@@ -229,22 +229,22 @@ void main()
     // DXC: i32 1, i32 1, i32 0, i32 0, i8 15)
     // FXC: l(1,1,0,0)
     output_a2((A2)i);
-    // DXC rejects (GitHub #1863)
+    // DXC: i32 1, i32 1, i32 0, i32 0, i8 15)
     // FXC: l(1,1,0,0)
-    // output_a2((A2)v1);
-    // DXC rejects (GitHub #1863)
+    output_a2((A2)v1);
+    // DXC: i32 11, i32 11, i32 0, i32 0, i8 15)
     // FXC: l(11,11,0,0)
-    // output_a2((A2)m1x1);
+    output_a2((A2)m1x1);
 
     // DXC: i32 1, i32 1, i32 0, i32 0, i8 15)
     // FXC: l(1,1,0,0)
     output_s2((S2)i);
-    // DXC rejects (GitHub #1863)
+    // DXC: i32 1, i32 1, i32 0, i32 0, i8 15)
     // FXC: l(1,1,0,0)
-    // output_s2((S2)v1);
-    // DXC rejects (GitHub #1863)
+    output_s2((S2)v1);
+    // DXC: i32 11, i32 11, i32 0, i32 0, i8 15)
     // FXC: l(11,11,0,0)
-    // output_s2((S2)m1x1);
+    output_s2((S2)m1x1);
     
     // DXC: 8888
     output_separator();

--- a/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/to_aggregate_ignored.hlsl
+++ b/tools/clang/test/CodeGenHLSL/expressions/conversions_and_casts/to_aggregate_ignored.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T vs_6_2 %s | FileCheck %s
+
+// Regression test for GitHub #1978, where converting to an aggregate type
+// and ignoring the result would cause a crash, because clang would not
+// allocate an AggValueSlot, and so our destination pointer would be nullptr.
+
+// CHECK: ret void
+
+struct S { int f; };
+void main()
+{
+  (S)0;
+  (int[1])0;
+}

--- a/tools/clang/test/HLSL/conversions-between-type-shapes.hlsl
+++ b/tools/clang/test/HLSL/conversions-between-type-shapes.hlsl
@@ -153,18 +153,18 @@ void main()
     to_a2(i);                                               /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int' to 'typedef int[2]'}} */
     (A2)i;
     to_a2(v1);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int1' to 'typedef int[2]'}} */
-    (A2)v1;                                                 /* expected-error {{cannot convert from 'int1' to 'A2' (aka 'int [2]')}} fxc-pass {{}} */
+    (A2)v1;
     to_a2(m1x1);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int1' to 'typedef int[2]'}} */
-    (A2)m1x1;                                               /* expected-error {{cannot convert from 'int1x1' to 'A2' (aka 'int [2]')}} fxc-pass {{}} */
+    (A2)m1x1;
     (A2)a1;                                                 /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'A2' (aka 'int [2]')}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'typedef int[2]'}} */
     (A2)s1;                                                 /* expected-error {{cannot convert from 'S1' to 'A2' (aka 'int [2]')}} fxc-error {{X3017: cannot convert from 'struct S1' to 'typedef int[2]'}} */
 
     to_s2(i);                                               /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int' to 'struct S2'}} */
     (S2)i;
     to_s2(v1);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int1' to 'struct S2'}} */
-    (S2)v1;                                                 /* expected-error {{cannot convert from 'int1' to 'S2'}} fxc-pass {{}} */
+    (S2)v1;
     to_s2(m1x1);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int1' to 'struct S2'}} */
-    (S2)m1x1;                                               /* expected-error {{cannot convert from 'int1x1' to 'S2'}} fxc-pass {{}} */
+    (S2)m1x1;
     (S2)a1;                                                 /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'S2'}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'struct S2'}} */
     (S2)s1;                                                 /* expected-error {{cannot convert from 'S1' to 'S2'}} fxc-error {{X3017: cannot convert from 'struct S1' to 'struct S2'}} */
 


### PR DESCRIPTION
FXC treats scalars, vector1s and matrix1x1s the same, at least as far as conversions go. We allowed splats from scalars to aggregates, but not from vector1s or matrix1x1s.

Also fixes a bug where we would crash on conversions to aggregates where the result was ignored, because clang wouldn't allocate an `AggValueSlot` and we didn't handle the destination pointer being `nullptr`.

Fixes #1863 and #1978