### PR TITLE
Add a test for recursion in structure members failing validation

### DIFF
--- a/tools/clang/test/CodeGenHLSL/declarations/functions/recursion/lib_struct_member_unconditional.hlsl
+++ b/tools/clang/test/CodeGenHLSL/declarations/functions/recursion/lib_struct_member_unconditional.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T lib_6_3 -exports main %s | FileCheck %s
+
+// Regression test for GitHub #1943, where recursive struct member functions
+// would crash the compiler.
+
+// The SCCP pass replaces the recursive call with an undef value,
+// which is why validation fails with a non-obvious error.
+
+// CHECK: validation errors
+// CHECK: Instructions should not read uninitialized value
+
+struct S
+{
+  int func() { return func(); }
+};
+
+int main() : OUT
+{
+  S s;
+  return s.func();
+}


### PR DESCRIPTION
This was reported as a bug by @simontaylor81, but stopped repro'ing only a few commits later, probably as part of the various fixes we merged back into master, so I'm just adding a regression test and calling it good.

Fixes #1943