### PR TITLE
Fix a cmake warning of policy CMP0023 in dxclib

### DIFF
--- a/tools/clang/tools/dxc/dxclib/CMakeLists.txt
+++ b/tools/clang/tools/dxc/dxclib/CMakeLists.txt
@@ -11,7 +11,7 @@ add_clang_library(dxclib
   )
 
 if(ENABLE_SPIRV_CODEGEN)
-  target_link_libraries(dxclib SPIRV-Tools)
+  target_link_libraries(dxclib PRIVATE SPIRV-Tools)
 endif()
 
 if (WIN32)


### PR DESCRIPTION
Add PUBLIC to dxclib to fix the warning.