### PR TITLE
[spirv] decouple argument scope from call-by-value decision

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2060,8 +2060,10 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
       // getObject().objectMethod();
       // Also, any parameter passed to the member function must be of Function
       // storage class.
-      needsTempVar = objInstr->isRValue() ||
-                     objInstr->getStorageClass() != spv::StorageClass::Function;
+      needsTempVar =
+          objInstr->isRValue() ||
+          (objInstr->getStorageClass() != spv::StorageClass::Function &&
+           objInstr->getStorageClass() != spv::StorageClass::Workgroup);
 
       if (needsTempVar) {
         args.push_back(createTemporaryVar(

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2096,8 +2096,10 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
                                              arg->getLocStart());
     }
 
-    if (argInfo && argInfo->getStorageClass() == spv::StorageClass::Function &&
-        canActAsOutParmVar(param) &&
+    if (argInfo &&
+        ((argInfo->getStorageClass() == spv::StorageClass::Function &&
+          canActAsOutParmVar(param)) ||
+         argInfo->getStorageClass() == spv::StorageClass::Workgroup) &&
         paramTypeMatchesArgType(param->getType(), arg->getType())) {
       vars.push_back(argInfo);
       isTempVar.push_back(false);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2069,10 +2069,10 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
       // Also, any parameter passed to the member function must be of Function
       // storage class.
       if (objInstr->isRValue()) {
-        args.push_back(
-            createTemporaryVar(objectType, getAstTypeName(objectType),
-                               // May need to load to use as initializer
-                               loadIfGLValue(object, objInstr)));
+        args.push_back(createTemporaryVar(
+            objectType, getAstTypeName(objectType),
+            // May need to load to use as initializer
+            loadIfGLValue(object, objInstr), object->getLocStart()));
       } else {
         // Based on SPIR-V spec, function parameter must always be in Function
         // scope. If we pass a non-function scope argument, we need
@@ -2200,8 +2200,8 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
     const uint32_t index = i + isNonStaticMemberCall;
     if (isTempVar[index] && canActAsOutParmVar(param)) {
       const auto *arg = callExpr->getArg(i);
-      SpirvInstruction *value =
-          spvBuilder.createLoad(param->getType(), vars[index]);
+      SpirvInstruction *value = spvBuilder.createLoad(
+          param->getType(), vars[index], arg->getLocStart());
 
       // Now we want to assign 'value' to arg. But first, in rare cases when
       // using 'out' or 'inout' where the parameter and argument have a type

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1056,9 +1056,9 @@ private:
   /// Note: legalization specific code
   bool needsLegalization;
 
-  /// Whether the translated SPIR-V binary passes --relax-logical-pointer option
-  /// to spirv-val because of illegal function parameter scope.
-  bool relaxLogicalPointerForFunctionParam;
+  /// Whether the translated SPIR-V binary passes --before-hlsl-legalization
+  /// option to spirv-val because of illegal function parameter scope.
+  bool beforeHlslLegalization;
 
   /// Mapping from methods to the decls to represent their implicit object
   /// parameters

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1056,6 +1056,10 @@ private:
   /// Note: legalization specific code
   bool needsLegalization;
 
+  /// Whether the translated SPIR-V binary passes --relax-logical-pointer option
+  /// to spirv-val because of illegal function parameter scope.
+  bool relaxLogicalPointerForFunctionParam;
+
   /// Mapping from methods to the decls to represent their implicit object
   /// parameters
   ///

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
@@ -1,13 +1,42 @@
-// Run: %dxc -T cs_6_0 -E main -Vd
+// Run: %dxc -T cs_6_0 -E main
 
-// CHECK: %foo = OpVariable %_ptr_Workgroup__arr__arr_int_uint_10_uint_10 Workgroup
-groupshared int foo[10][10];
+// CHECK: %A = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_int Uniform
+RWStructuredBuffer<int> A;
 
-int bar(int arg[10][10]) {
-  return arg[0][0];
+// CHECK: %B = OpVariable %_ptr_Private_int Private
+static int B;
+
+// CHECK: %C = OpVariable %_ptr_Workgroup_int Workgroup
+groupshared int C;
+
+// CHECK: %D = OpVariable %_ptr_Workgroup__arr_int_uint_10 Workgroup
+groupshared int D[10];
+
+int foo(int x, int y, int z, int w[10], int v) {
+  return x | y | z | w[0] | v;
 }
 
 void main() {
-  // CHECK: [[callBar:%\d+]] = OpFunctionCall %int %bar %foo
-  int a = bar(foo);
+// CHECK: %E = OpVariable %_ptr_Function_int Function
+  int E;
+
+// CHECK:      %param_var_x = OpVariable %_ptr_Function_int Function
+// CHECK-NEXT: %param_var_y = OpVariable %_ptr_Function_int Function
+// CHECK-NEXT: %param_var_z = OpVariable %_ptr_Function_int Function
+// CHECK-NEXT: %param_var_w = OpVariable %_ptr_Function__arr_int_uint_10 Function
+// CHECK-NEXT: %param_var_v = OpVariable %_ptr_Function_int Function
+
+
+// CHECK:      [[A:%\d+]] = OpLoad %int {{%\d+}}
+// CHECK-NEXT:              OpStore %param_var_x [[A]]
+// CHECK-NEXT: [[B:%\d+]] = OpLoad %int %B
+// CHECK-NEXT:              OpStore %param_var_y [[B]]
+// CHECK-NEXT: [[C:%\d+]] = OpLoad %int %C
+// CHECK-NEXT:              OpStore %param_var_z [[C]]
+// CHECK-NEXT: [[D:%\d+]] = OpLoad %_arr_int_uint_10 %D
+// CHECK-NEXT:              OpStore %param_var_w [[D]]
+// CHECK-NEXT: [[E:%\d+]] = OpLoad %int %E
+// CHECK-NEXT:              OpStore %param_var_v [[E]]
+// CHECK-NEXT:   {{%\d+}} = OpFunctionCall %int %foo %param_var_x %param_var_y %param_var_z %param_var_w %param_var_v
+  A[0] = foo(A[0], B, C, D, E);
 }

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
@@ -3,13 +3,11 @@
 // CHECK: %foo = OpVariable %_ptr_Workgroup__arr__arr_int_uint_10_uint_10 Workgroup
 groupshared int foo[10][10];
 
-int bar(int arg[10][10])
-{
-    return arg[0][0];
+int bar(int arg[10][10]) {
+  return arg[0][0];
 }
 
-void main()
-{
-// CHECK: [[callBar:%\d+]] = OpFunctionCall %int %bar %foo
-    int a = bar(foo);
+void main() {
+  // CHECK: [[callBar:%\d+]] = OpFunctionCall %int %bar %foo
+  int a = bar(foo);
 }

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.hlsl
@@ -1,0 +1,15 @@
+// Run: %dxc -T cs_6_0 -E main -Vd
+
+// CHECK: %foo = OpVariable %_ptr_Workgroup__arr__arr_int_uint_10_uint_10 Workgroup
+groupshared int foo[10][10];
+
+int bar(int arg[10][10])
+{
+    return arg[0][0];
+}
+
+void main()
+{
+// CHECK: [[callBar:%\d+]] = OpFunctionCall %int %bar %foo
+    int a = bar(foo);
+}

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.out.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.out.hlsl
@@ -29,7 +29,6 @@ void main() {
 // CHECK: %E = OpVariable %_ptr_Function_int Function
   int E;
 
-// CHECK:      %param_var_x = OpVariable %_ptr_Function_int Function
 // CHECK:        [[A:%\d+]] = OpAccessChain %_ptr_Uniform_int %A %int_0 %uint_0
 // CHECK-NEXT:     {{%\d+}} = OpFunctionCall %void %foo [[A]] %B %C %D %E
   foo(A[0], B, C, D, E);

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.out.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.function-param.out.hlsl
@@ -1,0 +1,37 @@
+// Run: %dxc -T cs_6_0 -E main
+
+struct S {
+  int a;
+  float b;
+};
+
+void foo(out int x, out int y, out int z, out S w, out int v) {
+  x = 1;
+  y = x << 1;
+  z = x << 2;
+  w.a = x << 3;
+  v = x << 4;
+}
+
+// CHECK: %A = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_int Uniform
+RWStructuredBuffer<int> A;
+
+// CHECK: %B = OpVariable %_ptr_Private_int Private
+static int B;
+
+// CHECK: %C = OpVariable %_ptr_Workgroup_int Workgroup
+groupshared int C;
+
+// CHECK: %D = OpVariable %_ptr_Workgroup_S Workgroup
+groupshared S D;
+
+void main() {
+// CHECK: %E = OpVariable %_ptr_Function_int Function
+  int E;
+
+// CHECK:      %param_var_x = OpVariable %_ptr_Function_int Function
+// CHECK:        [[A:%\d+]] = OpAccessChain %_ptr_Uniform_int %A %int_0 %uint_0
+// CHECK-NEXT:     {{%\d+}} = OpFunctionCall %void %foo [[A]] %B %C %D %E
+  foo(A[0], B, C, D, E);
+  A[0] = A[0] | B | C | D.a | E;
+}

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.struct-function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.struct-function.hlsl
@@ -1,16 +1,47 @@
-// Run: %dxc -T cs_6_0 -E main -Vd
+// Run: %dxc -T cs_6_0 -E main
 
-struct foo {
-  int bar[10][10];
-  int baz() {
-    return bar[0][0];
+struct S {
+  int a;
+  float b;
+
+  void foo(S x, inout S y, out S z, S w) {
+    a = 1;
+    x.a = a << 1;
+    y.a = x.a << 1;
+    z.a = x.a << 2;
+    w.a = x.a << 3;
   }
 };
 
-// CHECK: %a = OpVariable %_ptr_Workgroup_foo Workgroup
-groupshared foo a;
+// CHECK: %A = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
+RWStructuredBuffer<S> A;
+
+// CHECK: %B = OpVariable %_ptr_Private_S Private
+static S B;
+
+// CHECK: %C = OpVariable %_ptr_Workgroup_S Workgroup
+groupshared S C;
+
+// CHECK: %D = OpVariable %_ptr_Workgroup_S Workgroup
+groupshared S D;
 
 void main() {
-// CHECK: [[callBaz:%\d+]] = OpFunctionCall %int %foo_baz %a
-  int b = a.baz();
+// CHECK: %E = OpVariable %_ptr_Function_S Function
+  S E;
+
+// CHECK: %param_var_x = OpVariable %_ptr_Function_S Function
+// CHECK: %param_var_w = OpVariable %_ptr_Function_S Function
+
+// CHECK:        [[A:%\d+]] = OpAccessChain %_ptr_Uniform_S_0 %A %int_0 %uint_0
+// CHECK-NEXT: [[A_0:%\d+]] = OpLoad %S_0 [[A]]
+// CHECK-NEXT:   [[a:%\d+]] = OpCompositeExtract %int [[A_0]] 0
+// CHECK-NEXT:   [[b:%\d+]] = OpCompositeExtract %float [[A_0]] 1
+// CHECK-NEXT: [[A_0:%\d+]] = OpCompositeConstruct %S [[a]] [[b]]
+// CHECK-NEXT:                OpStore %param_var_x [[A_0]]
+// CHECK-NEXT:   [[E:%\d+]] = OpLoad %S %E
+// CHECK-NEXT:                OpStore %param_var_w [[E]]
+// CHECK-NEXT:     {{%\d+}} = OpFunctionCall %void %S_foo %D %param_var_x %B %C %param_var_w
+  D.foo(A[0], B, C, E);
+
+  A[0].a = A[0].a | B.a | C.a | D.a;
 }

--- a/tools/clang/test/CodeGenSPIRV/cs.groupshared.struct-function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cs.groupshared.struct-function.hlsl
@@ -1,0 +1,16 @@
+// Run: %dxc -T cs_6_0 -E main -Vd
+
+struct foo {
+  int bar[10][10];
+  int baz() {
+    return bar[0][0];
+  }
+};
+
+// CHECK: %a = OpVariable %_ptr_Workgroup_foo Workgroup
+groupshared foo a;
+
+void main() {
+// CHECK: [[callBaz:%\d+]] = OpFunctionCall %int %foo_baz %a
+  int b = a.baz();
+}

--- a/tools/clang/test/CodeGenSPIRV/decoration.no-contraction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.no-contraction.hlsl
@@ -92,7 +92,7 @@ precise float func3(float e, float f, float g, float h) {
 // CHECK-NEXT:                        OpLoad %float %g_1
 // CHECK-NEXT:                        OpLoad %float %h_1
 // CHECK-NEXT:    [[func3_g_mul_h]] = OpFMul %float
-// CHECK-NEXT: [[func3_ef_plus_gh]] = OpFAdd %float %162 %165
+// CHECK-NEXT: [[func3_ef_plus_gh]] = OpFAdd %float [[func3_e_mul_f]] [[func3_g_mul_h]]
   float result = (e*f) + (g*h); // precise because it's the function return value.
   return result;
 }

--- a/tools/clang/test/CodeGenSPIRV/fn.call.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.call.hlsl
@@ -40,10 +40,10 @@ void main() {
 // CHECK-NEXT: [[call2:%\d+]] = OpFunctionCall %int %fnTwoParm [[twoParam1]] [[twoParam2]]
     fnTwoParm(v, v);  // Pass in variable; ignore return value
 
-// CHECK-NEXT: OpStore [[nestedParam2]] %int_1
-// CHECK-NEXT: [[call3:%\d+]] = OpFunctionCall %int %fnOneParm [[nestedParam2]]
-// CHECK-NEXT: OpStore [[nestedParam1]] [[call3]]
-// CHECK-NEXT: [[call4:%\d+]] = OpFunctionCall %int %fnCallOthers [[nestedParam1]]
+// CHECK-NEXT: OpStore [[nestedParam1]] %int_1
+// CHECK-NEXT: [[call3:%\d+]] = OpFunctionCall %int %fnOneParm [[nestedParam1]]
+// CHECK-NEXT: OpStore [[nestedParam2]] [[call3]]
+// CHECK-NEXT: [[call4:%\d+]] = OpFunctionCall %int %fnCallOthers [[nestedParam2]]
 // CHECK-NEXT: OpReturn
 // CHECK-NEXT: OpFunctionEnd
     fnCallOthers(fnOneParm(1)); // Nested function calls

--- a/tools/clang/test/CodeGenSPIRV/fn.ctbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.ctbuffer.hlsl
@@ -26,13 +26,8 @@ tbuffer MyTBuffer {
 
 float4 main() : SV_Target {
 // %S vs %S_0: need destruction and construction
-// CHECK:         %temp_var_S = OpVariable %_ptr_Function_S_0 Function
 // CHECK:       [[tb_s:%\d+]] = OpAccessChain %_ptr_Uniform_S %MyTBuffer %int_1
-// CHECK-NEXT:     [[s:%\d+]] = OpLoad %S [[tb_s]]
-// CHECK-NEXT: [[s_val:%\d+]] = OpCompositeExtract %v3float [[s]] 0
-// CHECK-NEXT:   [[tmp:%\d+]] = OpCompositeConstruct %S_0 [[s_val]]
-// CHECK-NEXT:                  OpStore %temp_var_S [[tmp]]
-// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %v3float %S_get_s_val %temp_var_S
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %v3float %S_get_s_val [[tb_s]]
     return get_cb_val() + float4(tb_s.get_s_val(), 0.) * get_tb_val();
 }
 

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.storage-class.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.storage-class.hlsl
@@ -9,22 +9,12 @@ void foo(in float a, inout float b, out float c) {
 
 void main(float input : INPUT) {
 // CHECK: %param_var_a = OpVariable %_ptr_Function_float Function
-// CHECK: %param_var_b = OpVariable %_ptr_Function_float Function
-// CHECK: %param_var_c = OpVariable %_ptr_Function_float Function
 
 // CHECK: [[val:%\d+]] = OpLoad %float %input
 // CHECK:                OpStore %param_var_a [[val]]
 // CHECK:  [[p0:%\d+]] = OpAccessChain %_ptr_Uniform_float %Data %int_0 %uint_0
-// CHECK: [[val:%\d+]] = OpLoad %float [[p0]]
-// CHECK:                OpStore %param_var_b [[val]]
 // CHECK:  [[p1:%\d+]] = OpAccessChain %_ptr_Uniform_float %Data %int_0 %uint_1
-// CHECK: [[val:%\d+]] = OpLoad %float [[p1]]
-// CHECK:                OpStore %param_var_c [[val]]
 
-// CHECK:                OpFunctionCall %void %foo %param_var_a %param_var_b %param_var_c
+// CHECK:                OpFunctionCall %void %foo %param_var_a [[p0]] [[p1]]
     foo(input, Data[0], Data[1]);
-// CHECK: [[val:%\d+]] = OpLoad %float %param_var_b
-// CHECK:                OpStore [[p0]] [[val]]
-// CHECK: [[val:%\d+]] = OpLoad %float %param_var_c
-// CHECK:                OpStore [[p1]] [[val]]
 }

--- a/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.inout.vector.hlsl
@@ -18,7 +18,7 @@ float4 main() : C {
 
     float4 val;
 // CHECK:    [[z_ptr:%\d+]] = OpAccessChain %_ptr_Function_float %val %int_2
-// CHECK:          {{%\d+}} = OpFunctionCall %void %bar %val %param_var_y %param_var_z %param_var_w
+// CHECK:          {{%\d+}} = OpFunctionCall %void %bar %val %param_var_y %param_var_z [[z_ptr]]
 // CHECK-NEXT:   [[y:%\d+]] = OpLoad %v3float %param_var_y
 // CHECK-NEXT: [[old:%\d+]] = OpLoad %v4float %val
     // Write to val.zwx:
@@ -37,8 +37,6 @@ float4 main() : C {
 // CHECK-NEXT: [[old:%\d+]] = OpLoad %v4float %val
 // CHECK-NEXT: [[new:%\d+]] = OpVectorShuffle %v4float [[old]] [[z]] 4 5 2 3
 // CHECK-NEXT:                OpStore %val [[new]]
-// CHECK-NEXT:   [[w:%\d+]] = OpLoad %float %param_var_w
-// CHECK-NEXT:                OpStore [[z_ptr]] [[w]]
     bar(val, val.zwx, val.xy, val.z);
 
     return MyRWBuffer[0];

--- a/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
@@ -1,0 +1,104 @@
+struct R {
+  int a;
+  void incr() { ++a; }
+};
+
+// CHECK: %rwsb = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_R Uniform
+RWStructuredBuffer<R> rwsb;
+
+struct S {
+  int a;
+  void incr() { ++a; }
+};
+
+// CHECK: %gs = OpVariable %_ptr_Workgroup_S Workgroup
+groupshared S gs;
+
+// CHECK: %st = OpVariable %_ptr_Private_S Private
+static S st;
+
+void decr(inout R foo) {
+  foo.a--;
+};
+
+void decr2(inout S foo) {
+  foo.a--;
+};
+
+void int_decr(out int foo) {
+  ++foo;
+}
+
+// CHECK: %gsarr = OpVariable %_ptr_Workgroup__arr_S_uint_10 Workgroup
+groupshared S gsarr[10];
+
+// CHECK: %starr = OpVariable %_ptr_Private__arr_S_uint_10 Private
+static S starr[10];
+
+void main() {
+// CHECK:    %fn = OpVariable %_ptr_Function_S Function
+  S fn;
+
+// CHECK: %fnarr = OpVariable %_ptr_Function__arr_S_uint_10 Function
+  S fnarr[10];
+
+// CHECK:   %arr = OpVariable %_ptr_Function__arr_int_uint_10 Function
+  int arr[10];
+
+// CHECK:      [[rwsb:%\d+]] = OpAccessChain %_ptr_Uniform_R %rwsb %int_0 %uint_0
+// CHECK-NEXT:      {{%\d+}} = OpFunctionCall %void %R_incr [[rwsb]]
+  rwsb[0].incr();
+
+// CHECK: OpFunctionCall %void %S_incr %gs
+  gs.incr();
+
+// CHECK: OpFunctionCall %void %S_incr %st
+  st.incr();
+
+// CHECK: OpFunctionCall %void %S_incr %fn
+  fn.incr();
+
+// CHECK:      [[rwsb:%\d+]] = OpAccessChain %_ptr_Uniform_R %rwsb %int_0 %uint_0
+// CHECK-NEXT:      {{%\d+}} = OpFunctionCall %void %decr [[rwsb]]
+  decr(rwsb[0]);
+
+// CHECK: OpFunctionCall %void %decr2 %gs
+  decr2(gs);
+
+// CHECK: OpFunctionCall %void %decr2 %st
+  decr2(st);
+
+// CHECK: OpFunctionCall %void %decr2 %fn
+  decr2(fn);
+
+// CHECK:      [[gsarr:%\d+]] = OpAccessChain %_ptr_Workgroup_S %gsarr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %S_incr [[gsarr]]
+  gsarr[0].incr();
+
+// CHECK:      [[starr:%\d+]] = OpAccessChain %_ptr_Private_S %starr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %S_incr [[starr]]
+  starr[0].incr();
+
+// CHECK:      [[fnarr:%\d+]] = OpAccessChain %_ptr_Function_S %fnarr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %S_incr [[fnarr]]
+  fnarr[0].incr();
+
+// CHECK:      [[gsarr:%\d+]] = OpAccessChain %_ptr_Workgroup_S %gsarr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %decr2 [[gsarr]]
+  decr2(gsarr[0]);
+
+// CHECK:      [[starr:%\d+]] = OpAccessChain %_ptr_Private_S %starr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %decr2 [[starr]]
+  decr2(starr[0]);
+
+// CHECK:      [[fnarr:%\d+]] = OpAccessChain %_ptr_Function_S %fnarr %int_0
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %decr2 [[fnarr]]
+  decr2(fnarr[0]);
+
+// CHECK:        [[arr:%\d+]] = OpAccessChain %_ptr_Function_int %arr %int_0
+// CHECK-NEXT: [[arr_0:%\d+]] = OpLoad %int [[arr]]
+// CHECK-NEXT: [[arr_0:%\d+]] = OpIAdd %int [[arr_0]] %int_1
+// CHECK-NEXT:                  OpStore [[arr]] [[arr_0]]
+// CHECK-NEXT:       {{%\d+}} = OpFunctionCall %void %int_decr [[arr]]
+  int_decr(++arr[0]);
+}

--- a/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
@@ -1,3 +1,5 @@
+// Run: %dxc -T ps_6_0 -E main
+
 struct R {
   int a;
   void incr() { ++a; }

--- a/tools/clang/test/CodeGenSPIRV/oo.method.on-static-var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.method.on-static-var.hlsl
@@ -9,12 +9,7 @@ struct S {
 static S gSVar = {4.2};
 
 float main() : A {
-// CHECK:      %temp_var_S = OpVariable %_ptr_Function_S Function
-
-// CHECK:       [[s:%\d+]] = OpLoad %S %gSVar
-// CHECK-NEXT:               OpStore %temp_var_S [[s]]
-// CHECK-NEXT:    {{%\d+}} = OpFunctionCall %float %S_getVal %temp_var_S
-// CHECK-NEXT:  [[s:%\d+]] = OpLoad %S %temp_var_S
-// CHECK-NEXT:               OpStore %gSVar [[s]]
+// CHECK:      [[ret:%\d+]] = OpFunctionCall %float %S_getVal %gSVar
+// CHECK-NEXT:                OpReturnValue [[ret]]
     return gSVar.getVal();
 }

--- a/tools/clang/test/CodeGenSPIRV/oo.struct.method.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.struct.method.hlsl
@@ -104,16 +104,8 @@ float main() : A {
 // CHECK-NEXT:        {{%\d+}} = OpFunctionCall %float %S_fn_ref %temp_var_S
   float f2 = foo().get_S().fn_ref();
 
-// CHECK:         [[uniformPtr:%\d+]] = OpAccessChain %_ptr_Uniform_R %rwsb %int_0 %uint_0
-// CHECK-NEXT:   [[originalObj:%\d+]] = OpLoad %R [[uniformPtr]]
-// CHECK-NEXT:        [[member:%\d+]] = OpCompositeExtract %int [[originalObj]] 0
-// CHECK-NEXT:       [[tempVar:%\d+]] = OpCompositeConstruct %R_0 [[member]]
-// CHECK-NEXT:                          OpStore %temp_var_R [[tempVar]]
-// CHECK-NEXT:                          OpFunctionCall %void %R_incr %temp_var_R
-// CHECK-NEXT:       [[tempVar:%\d+]] = OpLoad %R_0 %temp_var_R
-// CHECK-NEXT: [[tempVarMember:%\d+]] = OpCompositeExtract %int [[tempVar]] 0
-// CHECK-NEXT:          [[newR:%\d+]] = OpCompositeConstruct %R [[tempVarMember]]
-// CHECK-NEXT:                          OpStore [[uniformPtr]] [[newR]]
+// CHECK:      [[rwsb_0:%\d+]] = OpAccessChain %_ptr_Uniform_R %rwsb %int_0 %uint_0
+// CHECK-NEXT:                   OpFunctionCall %void %R_incr [[rwsb_0]]
   rwsb[0].incr();
 
   return f1;

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1782,6 +1782,9 @@ TEST_F(FileTest, GeometryShaderEmit) { runFileTest("gs.emit.hlsl"); }
 TEST_F(FileTest, ComputeShaderGroupShared) {
   runFileTest("cs.groupshared.hlsl");
 }
+TEST_F(FileTest, ComputeShaderGroupSharedFunctionParam) {
+  runFileTest("cs.groupshared.function-param.hlsl", Expect::Success, false);
+}
 
 // === Legalization examples ===
 

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -501,6 +501,9 @@ TEST_F(FileTest, FunctionInOutParamVector) {
 TEST_F(FileTest, FunctionInOutParamDiffStorageClass) {
   runFileTest("fn.param.inout.storage-class.hlsl");
 }
+TEST_F(FileTest, FunctionInOutParamIsomorphism) {
+  runFileTest("fn.param.inout.isomorphism.hlsl");
+}
 TEST_F(FileTest, FunctionInOutParamNoNeedToCopy) {
   // Tests that referencing function scope variables as a whole with out/inout
   // annotation does not create temporary variables
@@ -538,6 +541,7 @@ TEST_F(FileTest, StaticMemberInitializer) {
   runFileTest("oo.static.member.init.hlsl");
 }
 TEST_F(FileTest, MethodCallOnStaticVar) {
+  setRelaxLogicalPointer();
   runFileTest("oo.method.on-static-var.hlsl");
 }
 TEST_F(FileTest, Inheritance) { runFileTest("oo.inheritance.hlsl"); }
@@ -1785,6 +1789,10 @@ TEST_F(FileTest, ComputeShaderGroupShared) {
 TEST_F(FileTest, ComputeShaderGroupSharedFunctionParam) {
   setRelaxLogicalPointer();
   runFileTest("cs.groupshared.function-param.hlsl");
+}
+TEST_F(FileTest, ComputeShaderGroupSharedFunctionParamOut) {
+  setRelaxLogicalPointer();
+  runFileTest("cs.groupshared.function-param.out.hlsl");
 }
 TEST_F(FileTest, ComputeShaderGroupSharedStructFunction) {
   setRelaxLogicalPointer();

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1785,6 +1785,9 @@ TEST_F(FileTest, ComputeShaderGroupShared) {
 TEST_F(FileTest, ComputeShaderGroupSharedFunctionParam) {
   runFileTest("cs.groupshared.function-param.hlsl", Expect::Success, false);
 }
+TEST_F(FileTest, ComputeShaderGroupSharedStructFunction) {
+  runFileTest("cs.groupshared.struct-function.hlsl", Expect::Success, false);
+}
 
 // === Legalization examples ===
 

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1783,10 +1783,12 @@ TEST_F(FileTest, ComputeShaderGroupShared) {
   runFileTest("cs.groupshared.hlsl");
 }
 TEST_F(FileTest, ComputeShaderGroupSharedFunctionParam) {
-  runFileTest("cs.groupshared.function-param.hlsl", Expect::Success, false);
+  setRelaxLogicalPointer();
+  runFileTest("cs.groupshared.function-param.hlsl");
 }
 TEST_F(FileTest, ComputeShaderGroupSharedStructFunction) {
-  runFileTest("cs.groupshared.struct-function.hlsl", Expect::Success, false);
+  setRelaxLogicalPointer();
+  runFileTest("cs.groupshared.struct-function.hlsl");
 }
 
 // === Legalization examples ===

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -496,9 +496,11 @@ TEST_F(FileTest, FunctionInOutParam) {
   runFileTest("fn.param.inout.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamVector) {
+  setRelaxLogicalPointer();
   runFileTest("fn.param.inout.vector.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamDiffStorageClass) {
+  setRelaxLogicalPointer();
   runFileTest("fn.param.inout.storage-class.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamIsomorphism) {
@@ -1930,6 +1932,7 @@ TEST_F(FileTest, DecorationRelaxedPrecisionImage) {
 
 // For NoContraction decorations
 TEST_F(FileTest, DecorationNoContraction) {
+  setRelaxLogicalPointer();
   runFileTest("decoration.no-contraction.hlsl");
 }
 TEST_F(FileTest, DecorationNoContractionVariableReuse) {

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -88,7 +88,7 @@ TEST_F(FileTest, StructuredBufferType) {
   runFileTest("type.structured-buffer.hlsl");
 }
 TEST_F(FileTest, StructuredByteBufferArray) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("type.structured-buffer.array.hlsl");
 }
 TEST_F(FileTest, StructuredByteBufferArrayError) {
@@ -496,15 +496,16 @@ TEST_F(FileTest, FunctionInOutParam) {
   runFileTest("fn.param.inout.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamVector) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("fn.param.inout.vector.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamDiffStorageClass) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("fn.param.inout.storage-class.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamIsomorphism) {
-  runFileTest("fn.param.inout.isomorphism.hlsl");
+  setBeforeHLSLLegalization();
+  runFileTest("fn.param.isomorphism.hlsl");
 }
 TEST_F(FileTest, FunctionInOutParamNoNeedToCopy) {
   // Tests that referencing function scope variables as a whole with out/inout
@@ -522,15 +523,18 @@ TEST_F(FileTest, FunctionInOutParamTypeMismatch) {
 TEST_F(FileTest, FunctionFowardDeclaration) {
   runFileTest("fn.foward-declaration.hlsl");
 }
-TEST_F(FileTest, FunctionInCTBuffer) { runFileTest("fn.ctbuffer.hlsl"); }
+TEST_F(FileTest, FunctionInCTBuffer) {
+  setBeforeHLSLLegalization();
+  runFileTest("fn.ctbuffer.hlsl");
+}
 
 // For OO features
 TEST_F(FileTest, StructMethodCall) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("oo.struct.method.hlsl");
 }
 TEST_F(FileTest, ClassMethodCall) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("oo.class.method.hlsl");
 }
 TEST_F(FileTest, StructStaticMember) {
@@ -543,7 +547,7 @@ TEST_F(FileTest, StaticMemberInitializer) {
   runFileTest("oo.static.member.init.hlsl");
 }
 TEST_F(FileTest, MethodCallOnStaticVar) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("oo.method.on-static-var.hlsl");
 }
 TEST_F(FileTest, Inheritance) { runFileTest("oo.inheritance.hlsl"); }
@@ -1372,34 +1376,34 @@ TEST_F(FileTest, SpirvLegalizationOpaqueStruct) {
   runFileTest("spirv.legal.opaque-struct.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferUsage) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.usage.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferMethods) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.methods.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferCounter) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.counter.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferCounterInStruct) {
   // Tests using struct/class having associated counters
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.counter.struct.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferCounterInMethod) {
   // Tests using methods whose enclosing struct/class having associated counters
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.counter.method.hlsl");
 }
 TEST_F(FileTest,
        SpirvLegalizationCounterVarAssignAcrossDifferentNestedStructLevel) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.counter.nested-struct.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferInStruct) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.struct.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationConstantBuffer) {
@@ -1793,11 +1797,11 @@ TEST_F(FileTest, ComputeShaderGroupSharedFunctionParam) {
   runFileTest("cs.groupshared.function-param.hlsl");
 }
 TEST_F(FileTest, ComputeShaderGroupSharedFunctionParamOut) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("cs.groupshared.function-param.out.hlsl");
 }
 TEST_F(FileTest, ComputeShaderGroupSharedStructFunction) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("cs.groupshared.struct-function.hlsl");
 }
 
@@ -1932,7 +1936,7 @@ TEST_F(FileTest, DecorationRelaxedPrecisionImage) {
 
 // For NoContraction decorations
 TEST_F(FileTest, DecorationNoContraction) {
-  setRelaxLogicalPointer();
+  setBeforeHLSLLegalization();
   runFileTest("decoration.no-contraction.hlsl");
 }
 TEST_F(FileTest, DecorationNoContractionVariableReuse) {

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -62,7 +62,7 @@ bool FileTest::parseInputFile() {
 
 void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
                            bool runValidation) {
-  if (relaxLogicalPointer)
+  if (relaxLogicalPointer || beforeHLSLLegalization)
     assert(runValidation);
 
   inputFilePath = utils::getAbsPathOfInputDataFile(filename);
@@ -102,9 +102,9 @@ void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
     ASSERT_EQ(result.status(), effcee::Result::Status::Ok);
 
     if (runValidation)
-      EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
-                                             relaxLogicalPointer, glLayout,
-                                             dxLayout, scalarLayout));
+      EXPECT_TRUE(utils::validateSpirvBinary(
+          targetEnv, generatedBinary, relaxLogicalPointer,
+          beforeHLSLLegalization, glLayout, dxLayout, scalarLayout));
   } else if (expect == Expect::Warning) {
     ASSERT_TRUE(compileOk);
 
@@ -128,9 +128,9 @@ void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
     ASSERT_EQ(result.status(), effcee::Result::Status::Ok);
 
     if (runValidation)
-      EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
-                                             relaxLogicalPointer, glLayout,
-                                             dxLayout, scalarLayout));
+      EXPECT_TRUE(utils::validateSpirvBinary(
+          targetEnv, generatedBinary, relaxLogicalPointer,
+          beforeHLSLLegalization, glLayout, dxLayout, scalarLayout));
   } else if (expect == Expect::Failure) {
     ASSERT_FALSE(compileOk);
 
@@ -157,8 +157,8 @@ void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
 
     std::string valMessages;
     EXPECT_FALSE(utils::validateSpirvBinary(
-        targetEnv, generatedBinary, relaxLogicalPointer, glLayout, dxLayout,
-        scalarLayout, &valMessages));
+        targetEnv, generatedBinary, relaxLogicalPointer, beforeHLSLLegalization,
+        glLayout, dxLayout, scalarLayout, &valMessages));
     auto options = effcee::Options()
                        .SetChecksName(filename.str())
                        .SetInputName("<val-message>");

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -29,10 +29,11 @@ public:
 
   FileTest()
       : targetEnv(SPV_ENV_VULKAN_1_0), relaxLogicalPointer(false),
-        glLayout(false), dxLayout(false) {}
+        beforeHLSLLegalization(false), glLayout(false), dxLayout(false) {}
 
   void useVulkan1p1() { targetEnv = SPV_ENV_VULKAN_1_1; }
   void setRelaxLogicalPointer() { relaxLogicalPointer = true; }
+  void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
   void setGlLayout() { glLayout = true; }
   void setDxLayout() { dxLayout = true; }
   void setScalarLayout() { scalarLayout = true; }
@@ -54,6 +55,7 @@ private:
   std::string generatedSpirvAsm;         ///< Disassembled binary (SPIR-V code)
   spv_target_env targetEnv;              ///< Environment to validate against
   bool relaxLogicalPointer;
+  bool beforeHLSLLegalization;
   bool glLayout;
   bool dxLayout;
   bool scalarLayout;

--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -35,10 +35,12 @@ bool disassembleSpirvBinary(std::vector<uint32_t> &binary,
 }
 
 bool validateSpirvBinary(spv_target_env env, std::vector<uint32_t> &binary,
-                         bool relaxLogicalPointer, bool glLayout, bool dxLayout,
-                         bool scalarLayout, std::string *message) {
+                         bool relaxLogicalPointer, bool beforeHlslLegalization,
+                         bool glLayout, bool dxLayout, bool scalarLayout,
+                         std::string *message) {
   spvtools::ValidatorOptions options;
   options.SetRelaxLogicalPointer(relaxLogicalPointer);
+  options.SetBeforeHlslLegalization(beforeHlslLegalization);
   if (dxLayout || scalarLayout) {
     options.SetSkipBlockLayout(true);
   } else if (glLayout) {

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -33,8 +33,9 @@ bool disassembleSpirvBinary(std::vector<uint32_t> &binary,
 /// \brief Runs the SPIR-V Tools validation on the given SPIR-V binary.
 /// Returns true if validation is successful; false otherwise.
 bool validateSpirvBinary(spv_target_env, std::vector<uint32_t> &binary,
-                         bool relaxLogicalPointer, bool glLayout, bool dxLayout,
-                         bool scalarLayout, std::string *message = nullptr);
+                         bool relaxLogicalPointer, bool beforeHlslLegalization,
+                         bool glLayout, bool dxLayout, bool scalarLayout,
+                         std::string *message = nullptr);
 
 /// \brief Parses the Target Profile and Entry Point from the Run command
 /// Returns the target profile, entry point, and the rest via arguments.

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
@@ -109,8 +109,8 @@ void WholeFileTest::runWholeFileTest(llvm::StringRef filename,
   if (runSpirvValidation) {
     EXPECT_TRUE(utils::validateSpirvBinary(
         targetEnv, generatedBinary,
-        /*relaxLogicalPointer=*/false, /*glLayout=*/false, /*dxLayout=*/false,
-        /*scalarLayout=*/false));
+        /*relaxLogicalPointer=*/false, /*beforeHlslLegalization=*/false,
+        /*glLayout=*/false, /*dxLayout=*/false, /*scalarLayout=*/false));
   }
 }
 


### PR DESCRIPTION
Previously, when passing a variable whose scope is not Function,
DXC creates a temporal variable with Function scope and copies
the value of the variable to the temporal one. It produces legal
SPIR-V code but it causes unnecessary loads / stores if the
function is inlined by spirv-opt.

This commit decouples argument scope from call-by-value
decision to avoid creation/load/store of temporal variables.
This generates illegal SPIR-V code but spirv-opt HLSL
legalization handles it.

Related to #1977