### PR TITLE
Map CompType::Kind::I1 to DxilProgramSigCompType::UIn32

### DIFF
--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -101,6 +101,7 @@ static DxilProgramSigSemantic KindToSystemValue(Semantic::Kind kind, DXIL::Tesse
 static DxilProgramSigCompType CompTypeToSigCompType(hlsl::CompType value) {
   switch (value.GetKind()) {
   case CompType::Kind::I32: return DxilProgramSigCompType::SInt32;
+  case CompType::Kind::I1: __fallthrough;
   case CompType::Kind::U32: return DxilProgramSigCompType::UInt32;
   case CompType::Kind::F32: return DxilProgramSigCompType::Float32;
   case CompType::Kind::I16: return DxilProgramSigCompType::SInt16;
@@ -110,7 +111,6 @@ static DxilProgramSigCompType CompTypeToSigCompType(hlsl::CompType value) {
   case CompType::Kind::F16: return DxilProgramSigCompType::Float16;
   case CompType::Kind::F64: return DxilProgramSigCompType::Float64;
   case CompType::Kind::Invalid: __fallthrough;
-  case CompType::Kind::I1: __fallthrough;
   default:
     return DxilProgramSigCompType::Unknown;
   }

--- a/tools/clang/test/CodeGenHLSL/quick-test/sig-bool-as-uint.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/sig-bool-as-uint.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// make sure bool maps to uint in signature
+// CHECK: ; BOOL                     0   x           0     NONE    uint
+
+float4 main(bool b : BOOL) : SV_Target
+{
+	return b ? 1.0 : 0.0;
+}


### PR DESCRIPTION
Fix bool mapping to unknown component type in shader signature that can cause PSO signature validation error.
Fixes #1993.