### PR TITLE
[spirv] Clean up extension & capability management.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -9,7 +9,6 @@
 #ifndef LLVM_CLANG_SPIRV_SPIRVBUILDER_H
 #define LLVM_CLANG_SPIRV_SPIRVBUILDER_H
 
-#include "clang/SPIRV/FeatureManager.h"
 #include "clang/SPIRV/SpirvContext.h"
 #include "clang/SPIRV/SpirvBasicBlock.h"
 #include "clang/SPIRV/SpirvFunction.h"
@@ -32,9 +31,10 @@ namespace spirv {
 /// Call `getModule()` to get the SPIR-V words after finishing building the
 /// module.
 class SpirvBuilder {
+  friend class CapabilityVisitor;
+
 public:
-  SpirvBuilder(ASTContext &ac, SpirvContext &c, FeatureManager *,
-               const SpirvCodeGenOptions &);
+  SpirvBuilder(ASTContext &ac, SpirvContext &c, const SpirvCodeGenOptions &);
   ~SpirvBuilder() = default;
 
   // Forbid copy construction and assignment
@@ -427,9 +427,6 @@ public:
                         SourceLocation loc);
 
   // === SPIR-V Module Structure ===
-
-  inline void requireCapability(spv::Capability, SourceLocation loc = {});
-
   inline void setMemoryModel(spv::AddressingModel, spv::MemoryModel);
 
   /// \brief Adds an entry point for the module under construction. We only
@@ -449,10 +446,6 @@ public:
   inline void addExecutionMode(SpirvFunction *entryPoint, spv::ExecutionMode em,
                                llvm::ArrayRef<uint32_t> params,
                                SourceLocation loc = {});
-
-  /// \brief Adds an extension to the module under construction for translating
-  /// the given target at the given source location.
-  void addExtension(Extension, llvm::StringRef target, SourceLocation);
 
   /// \brief Adds an OpModuleProcessed instruction to the module under
   /// construction.
@@ -570,6 +563,19 @@ public:
 public:
   std::vector<uint32_t> takeModule();
 
+
+protected:
+  /// Only friend classes are allowed to add capability/extension to the module
+  /// under construction.
+
+  /// \brief Adds the given capability to the module under construction due to
+  /// the feature used at the given source location.
+  inline void requireCapability(spv::Capability, SourceLocation loc = {});
+
+  /// \brief Adds an extension to the module under construction for translating
+  /// the given target at the given source location.
+  inline void requireExtension(llvm::StringRef extension, SourceLocation);
+
 private:
   /// \brief Returns the composed ImageOperandsMask from non-zero parameters
   /// and pushes non-zero parameters to *orderedParams in the expected order.
@@ -595,11 +601,7 @@ private:
   /// the entry block.
   std::vector<SpirvBasicBlock *> basicBlocks;
 
-  FeatureManager *featureManager; ///< SPIR-V version/extension manager.
   const SpirvCodeGenOptions &spirvOptions; ///< Command line options.
-
-  llvm::SetVector<spv::Capability> existingCapabilities;
-  llvm::SetVector<Extension> existingExtensions;
 
   /// A struct containing information regarding a builtin variable.
   struct BuiltInVarInfo {
@@ -614,14 +616,11 @@ private:
 };
 
 void SpirvBuilder::requireCapability(spv::Capability cap, SourceLocation loc) {
-  if (cap != spv::Capability::Max) {
-    // No need to create a new capability nor add it to the module if it has
-    // already been added.
-    if (existingCapabilities.insert(cap)) {
-      auto *capability = new (context) SpirvCapability(loc, cap);
-      module->addCapability(capability);
-    }
-  }
+  module->addCapability(new (context) SpirvCapability(loc, cap));
+}
+
+void SpirvBuilder::requireExtension(llvm::StringRef ext, SourceLocation loc) {
+  module->addExtension(new (context) SpirvExtension(loc, ext));
 }
 
 void SpirvBuilder::setMemoryModel(spv::AddressingModel addrModel,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2492,10 +2492,8 @@ SpirvVariable *DeclResultIdMapper::createSpirvStageVar(
     return spvBuilder.addStageBuiltinVar(type, sc, BuiltIn::FragStencilRefEXT,
                                          srcLoc);
   }
-  // According to DXIL spec, the ViewID SV can only be used by PSIn.
+  // According to DXIL spec, the Barycentrics SV can only be used by PSIn.
   case hlsl::Semantic::Kind::Barycentrics: {
-    spvBuilder.addExtension(Extension::AMD_shader_explicit_vertex_parameter,
-                            stageVar->getSemanticStr(), srcLoc);
     stageVar->setIsSpirvBuiltin();
 
     // Selecting the correct builtin according to interpolation mode

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -481,7 +481,7 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
       spirvOptions(ci.getCodeGenOpts().SpirvOptions),
       entryFunctionName(ci.getCodeGenOpts().HLSLEntryFunction), spvContext(),
       featureManager(diags, spirvOptions),
-      spvBuilder(astContext, spvContext, &featureManager, spirvOptions),
+      spvBuilder(astContext, spvContext, spirvOptions),
       declIdMapper(astContext, spvContext, spvBuilder, *this, featureManager,
                    spirvOptions),
       entryFunction(nullptr), curFunction(nullptr), curThis(nullptr),
@@ -9416,8 +9416,6 @@ void SpirvEmitter::processPixelShaderAttributes(const FunctionDecl *decl) {
                                 decl->getLocation());
   }
   if (decl->getAttr<VKPostDepthCoverageAttr>()) {
-    spvBuilder.addExtension(Extension::KHR_post_depth_coverage,
-                            "[[vk::post_depth_coverage]]", decl->getLocation());
     spvBuilder.addExecutionMode(entryFunction,
                                 spv::ExecutionMode::PostDepthCoverage, {},
                                 decl->getLocation());

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -88,7 +88,17 @@ void SpirvModule::addFunction(SpirvFunction *fn) {
 
 void SpirvModule::addCapability(SpirvCapability *cap) {
   assert(cap && "cannot add null capability to the module");
-  capabilities.push_back(cap);
+  // Only add the capability to the module if it is not already added.
+  // Due to the small number of capabilities, this should not be too expensive.
+  const spv::Capability capability = cap->getCapability();
+  auto found =
+      std::find_if(capabilities.begin(), capabilities.end(),
+                   [capability](SpirvCapability *existingCapability) {
+                     return capability == existingCapability->getCapability();
+                   });
+  if (found == capabilities.end()) {
+    capabilities.push_back(cap);
+  }
 }
 
 void SpirvModule::setMemoryModel(SpirvMemoryModel *model) {
@@ -108,7 +118,17 @@ void SpirvModule::addExecutionMode(SpirvExecutionMode *em) {
 
 void SpirvModule::addExtension(SpirvExtension *ext) {
   assert(ext && "cannot add null extension");
-  extensions.push_back(ext);
+  // Only add the extension to the module if it is not already added.
+  // Due to the small number of extensions, this should not be too expensive.
+  const auto extName = ext->getExtensionName();
+  auto found =
+      std::find_if(extensions.begin(), extensions.end(),
+                   [&extName](SpirvExtension *existingExtension) {
+                     return extName == existingExtension->getExtensionName();
+                   });
+  if (found == extensions.end()) {
+    extensions.push_back(ext);
+  }
 }
 
 void SpirvModule::addExtInstSet(SpirvExtInstImport *set) {


### PR DESCRIPTION
The is a cleanup for the way we add extensions (and capabilities) to the SPIR-V module in memory.

We should only be adding extensions and capabilities in one pass over the SPIR-V IMR. With this PR, CapabilityVisitor is **the only** class that is adding capabilities and extensions. Since CapabilityVisitor is figuring out the extensions&capabilities to add, it should be the one that communicates with FeatureManager. So I've removed FeatureManager from SpirvBuilder.

SpirvBuilder was also keeping a separate set of existing capabilities and extensions to avoid duplicates. This was bad. SpirvModule already has a list of these, and it should be the one making sure there are no duplicates.