### PR TITLE
[spirv] Set assignment for second param of modf()

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7183,7 +7183,6 @@ SpirvInstruction *SpirvEmitter::processIntrinsicModf(const CallExpr *callExpr) {
   const auto ipType = ipArg->getType();
   const auto returnType = callExpr->getType();
   auto *argInstr = doExpr(arg);
-  auto *ipInstr = doExpr(ipArg);
 
   // For scalar and vector argument types.
   {
@@ -7201,7 +7200,7 @@ SpirvInstruction *SpirvEmitter::processIntrinsicModf(const CallExpr *callExpr) {
       // This will do nothing if the input number (x) and the ip are both of the
       // same type. Otherwise, it will convert the ip into int as necessary.
       ip = castToInt(ip, argType, ipType, arg->getExprLoc());
-      spvBuilder.createStore(ipInstr, ip);
+      processAssignment(ipArg, ip, false, nullptr);
       return spvBuilder.createCompositeExtract(argType, modf, {0});
     }
   }
@@ -7234,7 +7233,7 @@ SpirvInstruction *SpirvEmitter::processIntrinsicModf(const CallExpr *callExpr) {
       // case we need to cast manually.
       if (!hlsl::GetHLSLMatElementType(ipType)->isFloatingType())
         ip = castToInt(ip, argType, ipType, ipArg->getExprLoc());
-      spvBuilder.createStore(ipInstr, ip);
+      processAssignment(ipArg, ip, false, nullptr);
       return spvBuilder.createCompositeConstruct(returnType, fracs);
     }
   }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.modf.swizzle.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.modf.swizzle.hlsl
@@ -1,0 +1,12 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: [[glsl:%\d+]] = OpExtInstImport "GLSL.std.450"
+
+void main() {
+// CHECK:      [[swizzle:%\d+]] = OpLoad %v3int %v3i
+// CHECK-NEXT:  [[vector:%\d+]] = OpVectorShuffle %v3int [[swizzle]] {{%\d+}} 3 4 2
+// CHECK-NEXT:                    OpStore %v3i [[vector]]
+  float2 v2f;
+  int3 v3i = 0;
+  modf(v2f, v3i.xy);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -974,6 +974,7 @@ TEST_F(FileTest, IntrinsicsLog2) { runFileTest("intrinsics.log2.hlsl"); }
 TEST_F(FileTest, IntrinsicsMin) { runFileTest("intrinsics.min.hlsl"); }
 TEST_F(FileTest, IntrinsicsLit) { runFileTest("intrinsics.lit.hlsl"); }
 TEST_F(FileTest, IntrinsicsModf) { runFileTest("intrinsics.modf.hlsl"); }
+TEST_F(FileTest, IntrinsicsModfWithSwizzling) { runFileTest("intrinsics.modf.swizzle.hlsl"); }
 TEST_F(FileTest, IntrinsicsMad) { runFileTest("intrinsics.mad.hlsl"); }
 TEST_F(FileTest, IntrinsicsMax) { runFileTest("intrinsics.max.hlsl"); }
 TEST_F(FileTest, IntrinsicsMsad4) { runFileTest("intrinsics.msad4.hlsl"); }


### PR DESCRIPTION
The second parameter of modf() intrinsic is an output. This CL
assumes modf() has assignment expression for the second parameter.

Fixes #1741