### PR TITLE
[spirv] Fix handling of literals for constants.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1044,9 +1044,6 @@ private:
 
 class SpirvConstantComposite : public SpirvConstant {
 public:
-  SpirvConstantComposite(const SpirvType *type,
-                         llvm::ArrayRef<SpirvConstant *> constituents,
-                         bool isSpecConst = false);
   SpirvConstantComposite(QualType type,
                          llvm::ArrayRef<SpirvConstant *> constituents,
                          bool isSpecConst = false);

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -104,9 +104,7 @@ private:
   std::vector<SpirvDecoration *> decorations;
   std::vector<SpirvConstant *> constants;
   std::vector<SpirvVariable *> variables;
-
-  // Shader logic instructions
-  llvm::SetVector<SpirvFunction *> functions;
+  std::vector<SpirvFunction *> functions;
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -294,12 +294,15 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
           return spvContext.getUIntType(use16Bit ? 16 : 32);
 
         // All literal types should have been lowered to concrete types before
-        // LowerTypeVisitor is invoked. We should error out if we encounter a
-        // literal type.
+        // LowerTypeVisitor is invoked. However, if there are unused literals,
+        // they will still have 'literal' type when we get to this point. Use
+        // 32-bit width by default for these cases.
+        // Example:
+        // void main() { 1.0; 1; }
         case BuiltinType::LitInt:
-          return spvContext.getUIntType(64);
+          return spvContext.getUIntType(32);
         case BuiltinType::LitFloat: {
-          return spvContext.getFloatType(64);
+          return spvContext.getFloatType(32);
 
         default:
           emitError("primitive type %0 unimplemented", srcLoc)

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -428,15 +428,6 @@ bool SpirvConstantFloat::operator==(const SpirvConstantFloat &that) const {
 }
 
 SpirvConstantComposite::SpirvConstantComposite(
-    const SpirvType *type, llvm::ArrayRef<SpirvConstant *> constituentsVec,
-    bool isSpecConst)
-    : SpirvConstant(IK_ConstantComposite,
-                    isSpecConst ? spv::Op::OpSpecConstantComposite
-                                : spv::Op::OpConstantComposite,
-                    type),
-      constituents(constituentsVec.begin(), constituentsVec.end()) {}
-
-SpirvConstantComposite::SpirvConstantComposite(
     QualType type, llvm::ArrayRef<SpirvConstant *> constituentsVec,
     bool isSpecConst)
     : SpirvConstant(IK_ConstantComposite,

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -35,7 +35,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
 
     // Our transformations do not cross function bounaries, therefore the order
     // of visiting functions is not important.
-    for (auto fn : functions) {
+    for (auto iter = functions.rbegin(); iter != functions.rend(); ++iter) {
+      auto *fn = *iter;
       if (!fn->invokeVisitor(visitor, reverseOrder))
         return false;
     }
@@ -162,7 +163,7 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
 
 void SpirvModule::addFunction(SpirvFunction *fn) {
   assert(fn && "cannot add null function to the module");
-  functions.insert(fn);
+  functions.push_back(fn);
 }
 
 void SpirvModule::addCapability(SpirvCapability *cap) {

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -30,51 +30,129 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
   if (!visitor->visit(this, Visitor::Phase::Init))
     return false;
 
-  for (auto *cap : capabilities)
-    if (!cap->invokeVisitor(visitor))
+  if (reverseOrder) {
+    // Reverse order of a SPIR-V module.
+
+    // Our transformations do not cross function bounaries, therefore the order
+    // of visiting functions is not important.
+    for (auto fn : functions) {
+      if (!fn->invokeVisitor(visitor, reverseOrder))
+        return false;
+    }
+
+    for (auto iter = variables.rbegin(); iter != variables.rend(); ++iter) {
+      auto *var = *iter;
+      if (!var->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = constants.rbegin(); iter != constants.rend(); ++iter) {
+      auto *constant = *iter;
+      if (!constant->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = decorations.rbegin(); iter != decorations.rend(); ++iter) {
+      auto *decoration = *iter;
+      if (!decoration->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = moduleProcesses.rbegin(); iter != moduleProcesses.rend();
+         ++iter) {
+      auto *moduleProcess = *iter;
+      if (!moduleProcess->invokeVisitor(visitor))
+        return false;
+    }
+
+    if (debugSource)
+      if (!debugSource->invokeVisitor(visitor))
+        return false;
+
+    for (auto iter = executionModes.rbegin(); iter != executionModes.rend();
+         ++iter) {
+      auto *execMode = *iter;
+      if (!execMode->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = entryPoints.rbegin(); iter != entryPoints.rend(); ++iter) {
+      auto *entryPoint = *iter;
+      if (!entryPoint->invokeVisitor(visitor))
+        return false;
+    }
+
+    if (!memoryModel->invokeVisitor(visitor))
       return false;
 
-  for (auto ext : extensions)
-    if (!ext->invokeVisitor(visitor))
+    for (auto iter = extInstSets.rbegin(); iter != extInstSets.rend(); ++iter) {
+      auto *extInstSet = *iter;
+      if (!extInstSet->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = extensions.rbegin(); iter != extensions.rend(); ++iter) {
+      auto *extension = *iter;
+      if (!extension->invokeVisitor(visitor))
+        return false;
+    }
+
+    for (auto iter = capabilities.rbegin(); iter != capabilities.rend();
+         ++iter) {
+      auto *capability = *iter;
+      if (!capability->invokeVisitor(visitor))
+        return false;
+    }
+  }
+  // Traverse the regular order of a SPIR-V module.
+  else {
+    for (auto *cap : capabilities)
+      if (!cap->invokeVisitor(visitor))
+        return false;
+
+    for (auto ext : extensions)
+      if (!ext->invokeVisitor(visitor))
+        return false;
+
+    for (auto extInstSet : extInstSets)
+      if (!extInstSet->invokeVisitor(visitor))
+        return false;
+
+    if (!memoryModel->invokeVisitor(visitor))
       return false;
 
-  for (auto extInstSet : extInstSets)
-    if (!extInstSet->invokeVisitor(visitor))
-      return false;
+    for (auto entryPoint : entryPoints)
+      if (!entryPoint->invokeVisitor(visitor))
+        return false;
 
-  if (!memoryModel->invokeVisitor(visitor))
-    return false;
+    for (auto execMode : executionModes)
+      if (!execMode->invokeVisitor(visitor))
+        return false;
 
-  for (auto entryPoint : entryPoints)
-    if (!entryPoint->invokeVisitor(visitor))
-      return false;
+    if (debugSource)
+      if (!debugSource->invokeVisitor(visitor))
+        return false;
 
-  for (auto execMode : executionModes)
-    if (!execMode->invokeVisitor(visitor))
-      return false;
+    for (auto moduleProcess : moduleProcesses)
+      if (!moduleProcess->invokeVisitor(visitor))
+        return false;
 
-  if (debugSource)
-    if (!debugSource->invokeVisitor(visitor))
-      return false;
+    for (auto decoration : decorations)
+      if (!decoration->invokeVisitor(visitor))
+        return false;
 
-  for (auto moduleProcess : moduleProcesses)
-    if (!moduleProcess->invokeVisitor(visitor))
-      return false;
+    for (auto constant : constants)
+      if (!constant->invokeVisitor(visitor))
+        return false;
 
-  for (auto decoration : decorations)
-    if (!decoration->invokeVisitor(visitor))
-      return false;
+    for (auto var : variables)
+      if (!var->invokeVisitor(visitor))
+        return false;
 
-  for (auto constant : constants)
-    constant->invokeVisitor(visitor);
-
-  for (auto var : variables)
-    if (!var->invokeVisitor(visitor))
-      return false;
-
-  for (auto fn : functions)
-    if (!fn->invokeVisitor(visitor, reverseOrder))
-      return false;
+    for (auto fn : functions)
+      if (!fn->invokeVisitor(visitor, reverseOrder))
+        return false;
+  }
 
   if (!visitor->visit(this, Visitor::Phase::Done))
     return false;

--- a/tools/clang/test/CodeGenSPIRV/literal.constant-composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/literal.constant-composite.hlsl
@@ -1,0 +1,11 @@
+// Run: %dxc -T ps_6_0 -E main
+
+float func(float3 i) { return i.x; }
+
+float4 main(float1 i : TEXCOORD0) : SV_Target {
+// CHECK: OpConstantComposite %v3float %float_1 %float_2 %float_3
+// CHECK: OpConstantComposite %v3float %float_0 %float_0 %float_0
+// CHECK: OpConstantComposite %v3float %float_0_5 %float_0_5 %float_0_5
+  return func((float3(1, 2, 3) * i) > 0 ? 0.5 : 0);
+}
+

--- a/tools/clang/test/CodeGenSPIRV/literal.unused.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/literal.unused.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// Unused literals should not be evaluated at 64-bit width.
+// Their usage should not result in Int64 or Float64 capabilities.
+
+// CHECK-NOT: OpCapability Int64
+// CHECK-NOT: OpCapability Float64
+
+float4 main() : SV_Target {
+
+// CHECK: %uint_0 = OpConstant %uint 0
+  0;
+// CHECK: %float_0 = OpConstant %float 0
+  0.0;
+
+  return 0;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/literal.vec-times-scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/literal.vec-times-scalar.hlsl
@@ -1,0 +1,11 @@
+// Run: %dxc -T ps_6_0 -E main
+
+float func(float3 i) { return i.x; }
+
+float4 main(float1 i : TEXCOORD0) : SV_Target {
+// CHECK: [[vec123:%\d+]] = OpConstantComposite %v3float %float_1 %float_2 %float_3
+// CHECK: [[select:%\d+]] = OpSelect %float {{%\d+}} %float_0_5 %float_0
+// CHECK:                   OpVectorTimesScalar %v3float [[vec123]] [[select]]
+  return func(float3(1, 2, 3) * (i > 0 ? 0.5 : 0));
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -127,6 +127,15 @@ TEST_F(FileTest, MatrixConstants) { runFileTest("constant.matrix.hlsl"); }
 TEST_F(FileTest, StructConstants) { runFileTest("constant.struct.hlsl"); }
 TEST_F(FileTest, ArrayConstants) { runFileTest("constant.array.hlsl"); }
 
+// For literals
+TEST_F(FileTest, UnusedLiterals) { runFileTest("literal.unused.hlsl"); }
+TEST_F(FileTest, LiteralConstantComposite) {
+  runFileTest("literal.constant-composite.hlsl");
+}
+TEST_F(FileTest, LiteralVecTimesScalar) {
+  runFileTest("literal.vec-times-scalar.hlsl");
+}
+
 // For variables
 TEST_F(FileTest, VarInitScalarVector) { runFileTest("var.init.hlsl"); }
 TEST_F(FileTest, VarInitMatrixMxN) { runFileTest("var.init.matrix.mxn.hlsl"); }
@@ -486,7 +495,6 @@ TEST_F(FileTest, FunctionParamUnsizedArray) {
   // Unsized ararys as function params are not supported.
   runFileTest("fn.param.unsized-array.hlsl", Expect::Failure);
 }
-
 
 TEST_F(FileTest, FunctionFowardDeclaration) {
   runFileTest("fn.foward-declaration.hlsl");
@@ -1814,9 +1822,7 @@ TEST_F(FileTest, RayTracingNVAnyHit) {
 TEST_F(FileTest, RayTracingNVClosestHit) {
   runFileTest("raytracing.nv.closesthit.hlsl");
 }
-TEST_F(FileTest, RayTracingNVMiss) {
-  runFileTest("raytracing.nv.miss.hlsl");
-}
+TEST_F(FileTest, RayTracingNVMiss) { runFileTest("raytracing.nv.miss.hlsl"); }
 TEST_F(FileTest, RayTracingNVCallable) {
   runFileTest("raytracing.nv.callable.hlsl");
 }


### PR DESCRIPTION
Deducing literal types works by traversing the SPIR-V module in the
reverse order. We were only performing the reverse oreder within
functions, but we should have also reversed the order for SPIR-V
instructions that lay outside of functions. For example: constants,
constant composites, etc.

Before this fix, constants were visited before functions, and therefore
if they had a literal type, it wouldn't be deduced properly.