### PR TITLE
[spirv] (Spec)ConstantComposite are handled by SpirvConstant classes.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -109,11 +109,11 @@ public:
   /// \brief Creates a composite construct instruction with the given
   /// <result-type> and constituents and returns the pointer of the
   /// composite instruction.
-  SpirvComposite *
+  SpirvCompositeConstruct *
   createCompositeConstruct(QualType resultType,
                            llvm::ArrayRef<SpirvInstruction *> constituents,
                            SourceLocation loc = {});
-  SpirvComposite *
+  SpirvCompositeConstruct *
   createCompositeConstruct(const SpirvType *resultType,
                            llvm::ArrayRef<SpirvInstruction *> constituents,
                            SourceLocation loc = {});

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -82,17 +82,17 @@ public:
     // Normal instruction kinds
     // In alphabetical order
 
-    IK_AccessChain,      // OpAccessChain
-    IK_Atomic,           // OpAtomic*
-    IK_Barrier,          // Op*Barrier
-    IK_BinaryOp,         // Binary operations
-    IK_BitFieldExtract,  // OpBitFieldExtract
-    IK_BitFieldInsert,   // OpBitFieldInsert
-    IK_Composite,        // Op*Composite
-    IK_CompositeExtract, // OpCompositeExtract
-    IK_CompositeInsert,  // OpCompositeInsert
-    IK_ExtInst,          // OpExtInst
-    IK_FunctionCall,     // OpFunctionCall
+    IK_AccessChain,        // OpAccessChain
+    IK_Atomic,             // OpAtomic*
+    IK_Barrier,            // Op*Barrier
+    IK_BinaryOp,           // Binary operations
+    IK_BitFieldExtract,    // OpBitFieldExtract
+    IK_BitFieldInsert,     // OpBitFieldInsert
+    IK_CompositeConstruct, // OpCompositeConstruct
+    IK_CompositeExtract,   // OpCompositeExtract
+    IK_CompositeInsert,    // OpCompositeInsert
+    IK_ExtInst,            // OpExtInst
+    IK_FunctionCall,       // OpFunctionCall
 
     IK_EndPrimitive, // OpEndPrimitive
     IK_EmitVertex,   // OpEmitVertex
@@ -1081,29 +1081,19 @@ public:
   bool operator==(const SpirvConstantNull &that) const;
 };
 
-/// \brief Composition instructions
-///
-/// This class includes OpConstantComposite, OpSpecConstantComposite,
-/// and OpCompositeConstruct.
-class SpirvComposite : public SpirvInstruction {
+/// \brief OpCompositeConstruct instruction
+class SpirvCompositeConstruct : public SpirvInstruction {
 public:
-  SpirvComposite(QualType resultType, SourceLocation loc,
-                 llvm::ArrayRef<SpirvInstruction *> constituentsVec,
-                 bool isConstant = false, bool isSpecConstant = false);
+  SpirvCompositeConstruct(QualType resultType, SourceLocation loc,
+                          llvm::ArrayRef<SpirvInstruction *> constituentsVec);
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
-    return inst->getKind() == IK_Composite;
+    return inst->getKind() == IK_CompositeConstruct;
   }
 
-  DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvComposite)
+  DECLARE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeConstruct)
 
-  bool isConstantComposite() const {
-    return getopcode() == spv::Op::OpConstantComposite;
-  }
-  bool isSpecConstantComposite() const {
-    return getopcode() == spv::Op::OpSpecConstantComposite;
-  }
   llvm::ArrayRef<SpirvInstruction *> getConstituents() const {
     return consituents;
   }

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -90,7 +90,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvConstantFloat)
   DEFINE_VISIT_METHOD(SpirvConstantComposite)
   DEFINE_VISIT_METHOD(SpirvConstantNull)
-  DEFINE_VISIT_METHOD(SpirvComposite)
+  DEFINE_VISIT_METHOD(SpirvCompositeConstruct)
   DEFINE_VISIT_METHOD(SpirvCompositeExtract)
   DEFINE_VISIT_METHOD(SpirvCompositeInsert)
   DEFINE_VISIT_METHOD(SpirvEmitVertex)

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -628,7 +628,7 @@ bool EmitVisitor::visit(SpirvConstantNull *inst) {
   return true;
 }
 
-bool EmitVisitor::visit(SpirvComposite *inst) {
+bool EmitVisitor::visit(SpirvCompositeConstruct *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -231,7 +231,7 @@ public:
   bool visit(SpirvConstantFloat *);
   bool visit(SpirvConstantComposite *);
   bool visit(SpirvConstantNull *);
-  bool visit(SpirvComposite *);
+  bool visit(SpirvCompositeConstruct *);
   bool visit(SpirvCompositeExtract *);
   bool visit(SpirvCompositeInsert *);
   bool visit(SpirvExtInst *);

--- a/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
@@ -317,7 +317,7 @@ bool LiteralTypeVisitor::visit(SpirvConstantComposite *inst) {
   return true;
 }
 
-bool LiteralTypeVisitor::visit(SpirvComposite *inst) {
+bool LiteralTypeVisitor::visit(SpirvCompositeConstruct *inst) {
   const auto resultType = inst->getAstResultType();
   updateTypeForCompositeMembers(resultType, inst->getConstituents());
   return true;

--- a/tools/clang/lib/SPIRV/LiteralTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LiteralTypeVisitor.h
@@ -36,7 +36,7 @@ public:
   bool visit(SpirvNonUniformBinaryOp *);
   bool visit(SpirvStore *);
   bool visit(SpirvConstantComposite *);
-  bool visit(SpirvComposite *);
+  bool visit(SpirvCompositeConstruct *);
   bool visit(SpirvCompositeExtract *);
   bool visit(SpirvAccessChain *);
   bool visit(SpirvExtInst *);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -105,12 +105,12 @@ void SpirvBuilder::setContinueTarget(SpirvBasicBlock *continueLabel) {
   insertPoint->setContinueTarget(continueLabel);
 }
 
-SpirvComposite *SpirvBuilder::createCompositeConstruct(
+SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
     QualType resultType, llvm::ArrayRef<SpirvInstruction *> constituents,
     SourceLocation loc) {
   assert(insertPoint && "null insert point");
   auto *instruction =
-      new (context) SpirvComposite(resultType, loc, constituents);
+      new (context) SpirvCompositeConstruct(resultType, loc, constituents);
   insertPoint->addInstruction(instruction);
   if (!constituents.empty()) {
     instruction->setLayoutRule(constituents[0]->getLayoutRule());
@@ -118,12 +118,12 @@ SpirvComposite *SpirvBuilder::createCompositeConstruct(
   return instruction;
 }
 
-SpirvComposite *SpirvBuilder::createCompositeConstruct(
+SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
     const SpirvType *resultType,
     llvm::ArrayRef<SpirvInstruction *> constituents, SourceLocation loc) {
   assert(insertPoint && "null insert point");
   auto *instruction =
-      new (context) SpirvComposite(/*QualType*/ {}, loc, constituents);
+      new (context) SpirvCompositeConstruct(/*QualType*/ {}, loc, constituents);
   instruction->setResultType(resultType);
   if (!constituents.empty()) {
     instruction->setLayoutRule(constituents[0]->getLayoutRule());

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -58,7 +58,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantInteger)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantFloat)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantComposite)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvConstantNull)
-DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvComposite)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeConstruct)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeExtract)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvCompositeInsert)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvEmitVertex)
@@ -355,15 +355,10 @@ SpirvBitFieldInsert::SpirvBitFieldInsert(QualType resultType,
                     loc, baseInst, offsetInst, countInst),
       insert(insertInst) {}
 
-SpirvComposite::SpirvComposite(
+SpirvCompositeConstruct::SpirvCompositeConstruct(
     QualType resultType, SourceLocation loc,
-    llvm::ArrayRef<SpirvInstruction *> constituentsVec, bool isConstant,
-    bool isSpecConstant)
-    : SpirvInstruction(IK_Composite,
-                       isSpecConstant
-                           ? spv::Op::OpSpecConstantComposite
-                           : isConstant ? spv::Op::OpConstantComposite
-                                        : spv::Op::OpCompositeConstruct,
+    llvm::ArrayRef<SpirvInstruction *> constituentsVec)
+    : SpirvInstruction(IK_CompositeConstruct, spv::Op::OpCompositeConstruct,
                        resultType, loc),
       consituents(constituentsVec.begin(), constituentsVec.end()) {}
 


### PR DESCRIPTION
Cleanup for better naming:
This is mainly just renaming the `SpirvComposite` class to `SpirvCompositeConstruct`. Also, the OpConstantComposite and OpSpecConstantComposite are handled by `SpirvConstantComposite` class. so removed any reference to these inside the `SpirvComposite` class.