### PR TITLE
Removing child loops of successfully unrolled loops from queue

### DIFF
--- a/tools/clang/test/CodeGenHLSL/unroll/intact_child_loops.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unroll/intact_child_loops.hlsl
@@ -2,6 +2,7 @@
 // CHECK: @main
 
 // Test case for when an unrolled loop has a child loop that's not unrolled.
+// regression test for GitHub #2006
 
 void main()
 {

--- a/tools/clang/test/CodeGenHLSL/unroll/intact_child_loops.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unroll/intact_child_loops.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// CHECK: @main
+
+// Test case for when an unrolled loop has a child loop that's not unrolled.
+
+void main()
+{
+  for (int i = 0; i < 1; i++)
+    [unroll]
+    for (int j = 0; j < 1; j++)
+      for (int k = 0; k < 1; k++)
+        ;
+}

--- a/tools/clang/test/CodeGenHLSL/unroll/nested3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unroll/nested3.hlsl
@@ -46,15 +46,18 @@ float main(float3 a : A, float3 b : B) : SV_Target {
 
   float ret = 0;
   [unroll]
-  for (uint i = 0; i < 4; i++) {
+  for (uint l = 0; l < 4; l++) {
+    [unroll]
+    for (uint i = 0; i < 4; i++) {
 
-    [loop]
-    for (uint j = 0; j < 4; j++) {
-      ret += routine(j);
-      ret++;
+      [loop]
+      for (uint j = 0; j < 4; j++) {
+        ret += routine(j);
+        ret++;
+      }
+
+      ret--;
     }
-
-    ret--;
   }
 
   return ret;

--- a/tools/clang/test/CodeGenHLSL/unroll/nested3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/unroll/nested3.hlsl
@@ -46,7 +46,7 @@ float main(float3 a : A, float3 b : B) : SV_Target {
 
   float ret = 0;
   [unroll]
-  for (uint l = 0; l < 4; l++) {
+  for (uint l = 0; l < 1; l++) {
     [unroll]
     for (uint i = 0; i < 4; i++) {
 


### PR DESCRIPTION
Fixes #2006