### PR TITLE
Allow creation of new instances of hlsl option table

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -203,6 +203,9 @@ public:
   operator LPCWSTR() const { return m_value.size() ? m_value.data() : nullptr; }
 };
 
+/// Create a copy of the HLSL opt table
+llvm::opt::OptTable *CreateNewOptTable();
+
 /// Reads all options from the given argument strings, populates opts, and
 /// validates reporting errors and warnings.
 int ReadDxcOpts(const llvm::opt::OptTable *optionTable, unsigned flagsToInclude,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -45,6 +45,10 @@ namespace {
       : OptTable(HlslInfoTable, llvm::array_lengthof(HlslInfoTable)) {}
   };
 
+  HlslOptTable *CreateHlslOptTable() {
+    return new (std::nothrow) HlslOptTable();
+  }
+
 }
 
 static HlslOptTable *g_HlslOptTable;
@@ -55,7 +59,7 @@ static HlslOptTable *g_HlslOptTable;
 
 std::error_code hlsl::options::initHlslOptTable() {
   DXASSERT(g_HlslOptTable == nullptr, "else double-init");
-  g_HlslOptTable = new (std::nothrow) HlslOptTable();
+  g_HlslOptTable = CreateHlslOptTable();
   if (g_HlslOptTable == nullptr)
     return std::error_code(E_OUTOFMEMORY, std::system_category());
   return std::error_code();
@@ -273,6 +277,11 @@ static bool handleVkShiftArgs(const InputArgList &args, OptSpecifier id,
 
 namespace hlsl {
 namespace options {
+
+/// Create a copy of the HLSL opt table
+OptTable *CreateNewOptTable() {
+  return CreateHlslOptTable();
+}
 
 /// Reads all options from the given argument strings, populates opts, and
 /// validates reporting errors and warnings.


### PR DESCRIPTION
Allow users of the option library to create instances of the HLSL OptTable to parse the arguments without having to rely on a single static instance of the OptTable.