### PR TITLE
[spirv] Use llvm::ilist to store instructions in BB.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
@@ -15,11 +15,21 @@
 #include "clang/SPIRV/SpirvInstruction.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
 
 namespace clang {
 namespace spirv {
 
 class SpirvVisitor;
+
+class SpirvInstructionNode : public llvm::ilist_node<SpirvInstructionNode> {
+public:
+  SpirvInstructionNode() : instruction(nullptr) {}
+  SpirvInstructionNode(SpirvInstruction *instr) : instruction(instr) {}
+
+  SpirvInstruction *instruction;
+};
 
 /// The class representing a SPIR-V basic block in memory.
 class SpirvBasicBlock {
@@ -85,7 +95,7 @@ private:
   std::string labelName; ///< The label's debug name
 
   /// Instructions belonging to this basic block.
-  std::vector<SpirvInstruction *> instructions;
+  llvm::ilist<SpirvInstructionNode> instructions;
 
   /// Successors to this basic block.
   llvm::SmallVector<SpirvBasicBlock *, 2> successors;

--- a/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
@@ -18,7 +18,8 @@ SpirvBasicBlock::SpirvBasicBlock(llvm::StringRef name)
       continueTarget(nullptr) {}
 
 bool SpirvBasicBlock::hasTerminator() const {
-  return !instructions.empty() && isa<SpirvTerminator>(instructions.back());
+  return !instructions.empty() &&
+         isa<SpirvTerminator>(instructions.back().instruction);
 }
 
 bool SpirvBasicBlock::invokeVisitor(Visitor *visitor,
@@ -28,9 +29,9 @@ bool SpirvBasicBlock::invokeVisitor(Visitor *visitor,
     return false;
 
   if (reverseOrder) {
-    for (auto inst = instructions.rbegin(); inst != instructions.rend();
-         ++inst) {
-      if (!(*inst)->invokeVisitor(visitor))
+    for (auto iter = instructions.rbegin(); iter != instructions.rend();
+         ++iter) {
+      if (!iter->instruction->invokeVisitor(visitor))
         return false;
     }
     // If a basic block is the first basic block of a function, it should
@@ -47,9 +48,10 @@ bool SpirvBasicBlock::invokeVisitor(Visitor *visitor,
         if (!var->invokeVisitor(visitor))
           return false;
 
-    for (auto *inst : instructions)
-      if (!inst->invokeVisitor(visitor))
+    for (auto iter = instructions.begin(); iter != instructions.end(); ++iter) {
+      if (!iter->instruction->invokeVisitor(visitor))
         return false;
+    }
   }
 
   if (!visitor->visit(this, Visitor::Phase::Done))

--- a/tools/clang/unittests/SPIRV/SpirvBasicBlockTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvBasicBlockTest.cpp
@@ -24,7 +24,7 @@ TEST(SpirvBasicBlockTest, CheckName) {
 TEST(SpirvBasicBlockTest, CheckResultId) {
   SpirvBasicBlock bb("myBasicBlock");
   bb.setResultId(5);
-  EXPECT_EQ(bb.getResultId(), 5);
+  EXPECT_EQ(bb.getResultId(), 5u);
 }
 
 TEST(SpirvBasicBlockTest, CheckMergeTarget) {


### PR DESCRIPTION
This PR changes the container for instructions inside a basic block.

Instead of a vector, we are going to use a linked list (doubly-linked). We can simply use `llvm::ilist`. This will help when we want to make changes to the SPIR-V module in memory.