### PR TITLE
Fix crash lowering GlobalVariable when scope is DINamespace

### DIFF
--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -1182,35 +1182,26 @@ static void AddDIGlobalVariable(DIBuilder &Builder, DIGlobalVariable *LocDIGV,
       LocDIGV->getScope(), Name, GV->getName(), LocDIGV->getFile(),
       LocDIGV->getLine(), DITy, false, GV);
 
-  DICompileUnit *DICU = dyn_cast<DICompileUnit>(LocDIGV->getScope());
-  if (!DICU) {
-    DISubprogram *DIS = dyn_cast<DISubprogram>(LocDIGV->getScope());
-    if (DIS) {
-      // Find the DICU which has this Subprogram.
-      NamedMDNode *CompileUnits = GV->getParent()->getNamedMetadata("llvm.dbg.cu");
-      DXASSERT_NOMSG(CompileUnits);
-      for (unsigned I = 0, E = CompileUnits->getNumOperands(); I != E; ++I) {
-        auto *CU = cast<DICompileUnit>(CompileUnits->getOperand(I));
-        DXASSERT(CU , "Expected valid compile unit");
-
-        for (DISubprogram *SP : CU->getSubprograms()) {
-          if (SP == DIS) {
-            DICU = CU;
-            break;
-          }
-        }
-      }
-    }
+  DICompileUnit *DICU = nullptr;
+  std::vector<Metadata *> AllGVs;
+  std::vector<Metadata *>::iterator locIt;
+  for (auto itDICU : DbgInfoFinder.compile_units()) {
+    MDTuple *GTuple = cast_or_null<MDTuple>(itDICU->getRawGlobalVariables());
+    if (!GTuple)
+      continue;
+    AllGVs.assign(GTuple->operands().begin(), GTuple->operands().end());
+    locIt = std::find(AllGVs.begin(), AllGVs.end(), LocDIGV);
+    if (locIt == AllGVs.end())
+      continue;
+    DICU = itDICU;
+    break;
   }
   DXASSERT_NOMSG(DICU);
+  if (!DICU)
+    return;
+
   // Add global to CU.
-  auto *GlobalVariables = DICU->getRawGlobalVariables();
-  DXASSERT_NOMSG(GlobalVariables);
-  MDTuple *GTuple = cast<MDTuple>(GlobalVariables);
-  std::vector<Metadata *> AllGVs(GTuple->operands().begin(),
-                                 GTuple->operands().end());
   if (removeLocDIGV) {
-    auto locIt = std::find(AllGVs.begin(), AllGVs.end(), LocDIGV);
     AllGVs.erase(locIt);
   }
   AllGVs.emplace_back(EltDIGV);

--- a/tools/clang/test/CodeGenHLSL/quick-test/namespace-global-debug.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/namespace-global-debug.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi -Od %s | FileCheck %s
+
+// CHECK: sc_Arr2D@foo{{.*}} = internal constant [9 x float] [float
+
+namespace foo
+{
+  static const float a = 0.27901;
+  static const float b = 0.44198;
+  static const float c = -0.27901;
+  static const float sc_Arr2D[3][3] =
+  {
+      { a * a, a * b, a * c },
+      { b * a, b * b, b * c },
+      { c * a, c * b, c * c },
+  };
+}
+
+float main(int i : IN) : OUT {
+  return foo::sc_Arr2D[i / 3][i % 3];
+}


### PR DESCRIPTION
- Change algorithm to no longer assume that getScope() returns either
  DICompileUnit or DISubprogram, searching for the global var in each
  compile unit until found instead.