### PR TITLE
Fix bogus DIFile debug metadata

### DIFF
--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -321,15 +321,17 @@ void CGDebugInfo::CreateCompileUnit() {
   // the file name itself with no path information. This file name may have had
   // a relative path, so we look into the actual file entry for the main
   // file to determine the real absolute path for the file.
-  std::string MainFileDir;
-  if (const FileEntry *MainFile = SM.getFileEntryForID(SM.getMainFileID())) {
-    MainFileDir = MainFile->getDir()->getName();
-    if (MainFileDir != ".") {
-      llvm::SmallString<1024> MainFileDirSS(MainFileDir);
-      llvm::sys::path::append(MainFileDirSS, MainFileName);
-      MainFileName = MainFileDirSS.str();
+  if (!llvm::sys::path::is_absolute(MainFileName)) { // HLSL Change: we put the full path in -main-file-name
+    std::string MainFileDir;
+    if (const FileEntry *MainFile = SM.getFileEntryForID(SM.getMainFileID())) {
+      MainFileDir = MainFile->getDir()->getName();
+      if (MainFileDir != ".") {
+        llvm::SmallString<1024> MainFileDirSS(MainFileDir);
+        llvm::sys::path::append(MainFileDirSS, MainFileName);
+        MainFileName = MainFileDirSS.str();
+      }
     }
-  }
+  } // HLSL Change
 
   // Save filename string.
   StringRef Filename = internString(MainFileName);

--- a/tools/clang/test/CodeGenHLSL/debug/duplicate_difile_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/duplicate_difile_regression.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi %s | FileCheck %s
+
+// Regression test for a bug where two !DIFile debug metadata
+// entries were created for the same file when a full path was passed in
+// the command line, the first of which bogusly having the directory part twice:
+// !DIFile(filename: "E:\5CdirE:\5Cdir\5Cfile.hlsl", directory: "")
+// !DIFile(filename: "E:\5Cdir\5Cfile.hlsl", directory: "")
+
+// Ensure we have only one DIFile and it has a path with a single drive component
+// Note that we have to be careful not to match the "!DIFile" strings in the CHECK
+// statements below, since the source code for this test will be preserved in a
+// metadata element.
+
+// CHECK: !{{[0-9]+}} = !DIFile(filename: "{{[^:]*}}:{{[^:]*}}"
+// CHECK-NOT: !{{[0-9]+}} = !DIFile(
+
+Texture2D tex; // This is necessary for the second, non-bogus !DIFile
+void main() {}


### PR DESCRIPTION
When compiling with debug info and passing in a full path, we ended up with a bogus `!DIFile` metadata entry where the path had the drive and directory components twice before the filename. Other code would compute the correct path and create a second `!DIFile` metadata entry.

Apparently we're misusing `CodeGenOptions::MainFileName`, because it should not contain a full path but, due to other code of ours, it seems like a riskier change to fix that because we depend on it in `CodeGeneratorImpl::HandleTranslationUnit`.