### PR TITLE
Fix bugs discovered by temporarily enabling debug iterators

### DIFF
--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -1594,6 +1594,10 @@ StructType *UpdateStructTypeForLegacyLayout(StructType *ST, bool IsCBuf,
   DxilStructAnnotation *SA = TypeSys.GetStructAnnotation(ST);
   DXASSERT(SA, "must have annotation for struct type");
 
+  if (SA->IsEmptyStruct()) {
+    return ST;
+  }
+
   for (unsigned i = 0; i < fieldsCount; i++) {
     Type *EltTy = ST->getElementType(i);
     Type *UpdatedTy = UpdateFieldTypeForLegacyLayout(

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -624,6 +624,7 @@ bool CleanupSharedMemoryAddrSpaceCast(Module &M) {
                                valueMap)) {
         bConverged = false;
         bChanged = true;
+        break;
       }
       if (PHI->use_empty()) {
         phiReplacements.erase(PHI);

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -231,7 +231,10 @@ public:
   TEST_METHOD(CompileWhenODumpThenOptimizerMatch)
   TEST_METHOD(CompileWhenVdThenProducesDxilContainer)
 
+#if _ITERATOR_DEBUG_LEVEL==0 
+  // CompileWhenNoMemThenOOM can properly detect leaks only when debug iterators are disabled
   TEST_METHOD(CompileWhenNoMemThenOOM)
+#endif
   TEST_METHOD(CompileWhenShaderModelMismatchAttributeThenFail)
   TEST_METHOD(CompileBadHlslThenFail)
   TEST_METHOD(CompileLegacyShaderModelThenFail)
@@ -1958,6 +1961,8 @@ public:
   }
 };
 
+#if _ITERATOR_DEBUG_LEVEL==0
+// CompileWhenNoMemThenOOM can properly detect leaks only when debug iterators are disabled
 TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
@@ -2055,6 +2060,7 @@ TEST_F(CompilerTest, CompileWhenNoMemThenOOM) {
     VERIFY_ARE_EQUAL(initialRefCount, InstrMalloc.GetRefCount());
   }
 }
+#endif
 
 TEST_F(CompilerTest, CompileWhenShaderModelMismatchAttributeThenFail) {
   CComPtr<IDxcCompiler> pCompiler;


### PR DESCRIPTION
Disable CompileWhenNoMemThenOOM when debug iterators are enabled

Note that debug iterators are still disabled in the build by default.
We will do internal runs with debug iterators on to catch these bugs
sooner, but we do not want to enable them by default because it blocks
the OOF memory handling tests CompileWhenNoMemThenOOM.