### PR TITLE
Debug info support for local arrays of aggregates

### DIFF
--- a/tools/clang/test/CodeGenHLSL/debug/_readme.txt
+++ b/tools/clang/test/CodeGenHLSL/debug/_readme.txt
@@ -13,11 +13,10 @@ The current workaround is to include the following in your test to explicitly ma
 the quoted source file:
 
   // Exclude quoted source file (see readme)
-  // CHECK: {{!"[^"]*\\0A[^"]*"}}
+  // CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 
 This will match a metadata string containing \0A (newline), which should only appear
 in the quoted source file. It will not match itself in the quoted source file because
-the regex won't match itself, and even less the escaped version of itself.
-
-Note that if you see a failure on that line, it means that something else before that
-CHECK failed to match.
+the regex won't match itself, and even less the escaped version of itself. We use
+CHECK-LABEL such that CHECKs above that line cannot match in or past the quoted source
+file, which improves error messages.

--- a/tools/clang/test/CodeGenHLSL/debug/duplicate_difile_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/duplicate_difile_regression.hlsl
@@ -16,7 +16,7 @@
 // CHECK-NOT: !DIFile(
 
 // Exclude quoted source file (see readme)
-// CHECK: {{!"[^"]*\\0A[^"]*"}}
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 
 Texture2D tex; // This is necessary for the second, non-bogus !DIFile
 void main() {}

--- a/tools/clang/test/CodeGenHLSL/debug/locals/array_of_aggregates_nested.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/array_of_aggregates_nested.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi -Od %s | FileCheck %s
+
+// Test that debug information is correct for nested array of aggregates,
+// where SROA wreaks havok by breaking the initial variable element contiguity.
+
+// CHECK-DAG: %[[xx:.*]] = alloca [2 x i32]
+// CHECK-DAG: %[[xy:.*]] = alloca [2 x i32]
+// CHECK-DAG: %[[y:.*]] = alloca [4 x float]
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xx]], i64 0, metadata ![[divar:.*]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xx]], i64 32, metadata ![[divar]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xy]], i64 0, metadata ![[divar]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xy]], i64 32, metadata ![[divar]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [4 x float]* %[[y]], i64 0, metadata ![[divar]], metadata ![[yexp0:.*]])
+// CHECK-DAG: call void @llvm.dbg.value(metadata [4 x float]* %[[y]], i64 64, metadata ![[divar]], metadata ![[yexp1:.*]])
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[divar]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "val"
+// i32 pieces
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 128, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 160, 32)
+// float pieces
+// CHECK-DAG: ![[yexp0]] = !DIExpression(DW_OP_bit_piece, 64, 64)
+// CHECK-DAG: ![[yexp1]] = !DIExpression(DW_OP_bit_piece, 192, 64)
+
+typedef struct { int2 x; float y[2]; } type[2];
+
+int main(int input : IN) : OUT
+{
+    type val = (type)input;
+    return val[0].x.x;
+}

--- a/tools/clang/test/CodeGenHLSL/debug/locals/array_of_structs.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/array_of_structs.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi -Od %s | FileCheck %s
+
+// Test that debug information is correct for arrays of structs,
+// which get SROA'ed into per-element arrays, breaking the original
+// contiguousness between struct elements.
+
+// CHECK-DAG: %[[ints:.*]] = alloca [2 x i32]
+// CHECK-DAG: %[[floats:.*]] = alloca [2 x float]
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[ints]], i64 0, metadata ![[divar:.*]], metadata ![[expr0:.*]])
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[ints]], i64 32, metadata ![[divar]], metadata ![[expr2:.*]])
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x float]* %[[floats]], i64 0, metadata ![[divar]], metadata ![[expr1:.*]])
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x float]* %[[floats]], i64 32, metadata ![[divar]], metadata ![[expr3:.*]])
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[divar]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "val"
+// CHECK-DAG: ![[expr0]] = !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK-DAG: ![[expr1]] = !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: ![[expr2]] = !DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK-DAG: ![[expr3]] = !DIExpression(DW_OP_bit_piece, 96, 32)
+
+typedef struct { int x; float y; } type[2];
+
+int main(int input : IN) : OUT
+{
+    type val = (type)input;
+    return val[0].x;
+}

--- a/tools/clang/test/CodeGenHLSL/debug/locals/array_of_vectors.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/array_of_vectors.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi -Od %s | FileCheck %s
+
+// Test that debug information is correct for arrays of vectors,
+// which get SROA'ed into per-element arrays, breaking the original
+// contiguousness between vector elements.
+
+// CHECK-DAG: %[[xs:.*]] = alloca [2 x i32]
+// CHECK-DAG: %[[ys:.*]] = alloca [2 x i32]
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xs]], i64 0, metadata ![[divar:.*]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[xs]], i64 32, metadata ![[divar]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[ys]], i64 0, metadata ![[divar]], metadata !{{.*}})
+// CHECK-DAG: call void @llvm.dbg.value(metadata [2 x i32]* %[[ys]], i64 32, metadata ![[divar]], metadata !{{.*}})
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[divar]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "val"
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 64, 32)
+// CHECK-DAG: !DIExpression(DW_OP_bit_piece, 96, 32)
+
+int main(int input : IN) : OUT
+{
+    int2 val[2] = (int2[2])input;
+    return val[0].x;
+}

--- a/tools/clang/test/CodeGenHLSL/debug/locals/multi_dim_array.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/multi_dim_array.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi -Od %s | FileCheck %s
+
+// Test that flattening array dimensions preserves debug information.
+
+// CHECK: alloca [1 x i32]
+// Should have a debug value or declare
+// CHECK: call void @llvm.dbg.
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK: !DILocalVariable(tag: DW_TAG_auto_variable, name: "x"
+// CHECK: !DIExpression()
+
+int main() : OUT
+{
+  int x[1][1] = { 0 };
+  return x[0][0];
+}

--- a/tools/clang/test/CodeGenHLSL/debug/locals/structuredbuffer_load.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/structuredbuffer_load.hlsl
@@ -11,7 +11,7 @@
 // CHECK: call void @dx.op.storeOutput.i32
 
 // Exclude quoted source file (see readme)
-// CHECK: {{!"[^"]*\\0A[^"]*"}}
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 
 StructuredBuffer<int2> buf;
 int2 main() : OUT

--- a/tools/clang/test/CodeGenHLSL/debug/locals/texture_load.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/texture_load.hlsl
@@ -15,7 +15,7 @@
 // CHECK: call void @dx.op.storeOutput.f32
 
 // Exclude quoted source file (see readme)
-// CHECK: {{!"[^"]*\\0A[^"]*"}}
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 
 Texture1D<float4> tex;
 float4 main() : SV_Target

--- a/tools/clang/test/CodeGenHLSL/debug/locals/texture_sample.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/texture_sample.hlsl
@@ -15,7 +15,7 @@
 // CHECK: call void @dx.op.storeOutput.f32
 
 // Exclude quoted source file (see readme)
-// CHECK: {{!"[^"]*\\0A[^"]*"}}
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 
 sampler samp;
 Texture2D<float4> tex;

--- a/tools/clang/test/CodeGenHLSL/debug/nested_struct_arg.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/nested_struct_arg.hlsl
@@ -3,6 +3,9 @@
 // Make sure all elements of the struct in an arg (even when there are nested
 // structs) are at distinct offsets.
 
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
 // CHECK-DAG: DW_OP_bit_piece
 
 

--- a/tools/clang/test/CodeGenHLSL/debug/vector_members.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/vector_members.hlsl
@@ -2,8 +2,11 @@
 
 // Test that the debug info for HLSL vectors exposes per-component fields.
 
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "int2"
-// CHECK: !DICompositeType(tag: DW_TAG_class_type, name: "vector<int, 2>", {{.*}}, size: 64, align: 32
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "x", {{.*}}, size: 32, align: 32
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "y", {{.*}}, size: 32, align: 32, offset: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int2"
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "vector<int, 2>", {{.*}}, size: 64, align: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "x", {{.*}}, size: 32, align: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "y", {{.*}}, size: 32, align: 32, offset: 32
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 int2 main(int2 v : IN) : OUT { return v; }

--- a/tools/clang/test/CodeGenHLSL/debug/vector_members_bool.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/vector_members_bool.hlsl
@@ -3,8 +3,11 @@
 // Test that the debug info for HLSL bool vectors exposes per-component fields
 // in the memory representation of bools (32-bits)
 
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "bool2"
-// CHECK: !DICompositeType(tag: DW_TAG_class_type, name: "vector<bool, 2>", {{.*}}, size: 64, align: 32
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "x", {{.*}}, size: 32, align: 32
-// CHECK: !DIDerivedType(tag: DW_TAG_member, name: "y", {{.*}}, size: 32, align: 32, offset: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "bool2"
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "vector<bool, 2>", {{.*}}, size: 64, align: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "x", {{.*}}, size: 32, align: 32
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "y", {{.*}}, size: 32, align: 32, offset: 32
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
 bool2 main(bool2 v : IN) : OUT { return v; }


### PR DESCRIPTION
Representing debug info for arrays of aggregates (structs or vectors) is complex because SROA turns them into separate per-element arrays which don't represent a contiguous range of the original user variable.

This implementation proposal uses multiple `@llvm.dbg.value` intrinsics on a single SROA-generated array of aggregate elements alloca when necessary to encode the non-contiguity. The "Offset" parameter of that intrinsic is used to indicate what part of the element alloca array is concerned by the associated DIExpression. In the DIExpression, `DW_OP_bit_piece` is used to indicate to what part of the original user variable the value maps.

There is no support for globals or parameters at this time. Parameters should be similar but it's not clear whether globals can be supported in the same way.