### PR TITLE
Fix debug info generated by scalarizer.

### DIFF
--- a/tools/clang/test/CodeGenHLSL/debug/locals/scalarized_vector.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/locals/scalarized_vector.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi %s | FileCheck %s
+
+// Test that the vector scalarizer preserves debug information.
+
+// CHECK: %[[x:.*]] = add i32
+// CHECK: %[[y:.*]] = add i32
+// CHECK-DAG: call void @llvm.dbg.value(metadata i32 %[[x]], i64 0, metadata ![[vec:.*]], metadata ![[xexp:.*]]), !dbg !46
+// CHECK-DAG: call void @llvm.dbg.value(metadata i32 %[[y]], i64 0, metadata ![[vec]], metadata ![[yexp:.*]]), !dbg !46
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[vec]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "vec"
+// CHECK-DAG: ![[xexp]] = !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK-DAG: ![[yexp]] = !DIExpression(DW_OP_bit_piece, 32, 32)
+
+int2 main(int2 a : A, int2 b : B) : OUT
+{
+    int2 vec = a + b;
+    return vec;
+}


### PR DESCRIPTION
Fixes some bugs with how the scalarizer emitted debug info:

- It wrongly emitted a non-zero Offset argument, which would cause the intrinsic to get discarded by newer LLVM versions which removed that parameter. (and the offset value it emitted wasn't even correct).
- It didn't take into account the offset of any existing bit piece expressions on the vector.