### PR TITLE
Disable SROA of vectors

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1637,7 +1637,7 @@ bool SROA_HLSL::performScalarRepl(Function &F, DxilTypeSystem &typeSys) {
       bool hasPrecise = HLModule::HasPreciseAttributeWithMetadata(AI);
 
       bool SROAed = SROA_Helper::DoScalarReplacement(
-          AI, Elts, Builder, /*bFlatVector*/ true, hasPrecise, typeSys, DL,
+          AI, Elts, Builder, /*bFlatVector*/ false, hasPrecise, typeSys, DL,
           DeadInsts);
 
       if (SROAed) {
@@ -4706,12 +4706,7 @@ void SROA_Parameter_HLSL::flattenGlobal(GlobalVariable *GV) {
     }
 
     // Flat Global vector if no dynamic vector indexing.
-    bool bFlatVector = !hasDynamicVectorIndexing(EltGV);
-
-    // Disable scalarization of groupshared vector arrays
-    if (GV->getType()->getAddressSpace() == DXIL::kTGSMAddrSpace &&
-        Ty->isArrayTy())
-      bFlatVector = false;
+    bool bFlatVector = false;
 
     std::vector<Value *> Elts;
     bool SROAed = SROA_Helper::DoScalarReplacement(

--- a/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/groupshared-base-cast.hlsl
@@ -9,16 +9,14 @@
 // The barrier and write to RWBuf prevents optimizations from eliminating
 // groupshared use, considering this dead-code, or detecting a race condition.
 
-// CHECK: @[[gs0:.+]] = addrspace(3) global i32 undef
-// CHECK: @[[gs1:.+]] = addrspace(3) global i32 undef
-// CHECK: @[[gs2:.+]] = addrspace(3) global i32 undef
-// CHECK: store i32 1, i32 addrspace(3)* @[[gs0]], align 4
-// CHECK: store i32 2, i32 addrspace(3)* @[[gs1]], align 4
-// CHECK: store i32 3, i32 addrspace(3)* @[[gs2]], align 4
+// CHECK: @[[gs:.+]] = addrspace(3) global [3 x i32] undef
+// CHECK: store i32 1, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 0), align 4
+// CHECK: store i32 2, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 1), align 4
+// CHECK: store i32 3, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 2), align 4
 
-// CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs0]], align 4
-// CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs1]], align 4
-// CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* @[[gs2]], align 4
+// CHECK: %[[l0:[^ ]+]] = load i32, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 0), align 4
+// CHECK: %[[l1:[^ ]+]] = load i32, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 1), align 4
+// CHECK: %[[l2:[^ ]+]] = load i32, i32 addrspace(3)* getelementptr inbounds ([3 x i32], [3 x i32] addrspace(3)* @[[gs]], i32 0, i32 2), align 4
 // CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %{{.+}}, i32 %{{.+}}, i32 undef, i32 %[[l0]], i32 %[[l1]], i32 %[[l2]], i32 undef, i8 7)
 
 

--- a/tools/clang/test/CodeGenHLSL/quick-test/staticGlobals.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/staticGlobals.hlsl
@@ -2,10 +2,6 @@
 
 // TODO: create execution test.
 
-// CHECK: [3 x float] [float 5.000000e+00, float 0.000000e+00, float 0.000000e+00]
-// CHECK: [3 x float] [float 6.000000e+00, float 0.000000e+00, float 0.000000e+00]
-// CHECK: [3 x float] [float 7.000000e+00, float 0.000000e+00, float 0.000000e+00]
-// CHECK: [3 x float] [float 8.000000e+00, float 0.000000e+00, float 0.000000e+00]
 // CHECK: [4 x float] [float 5.000000e+00, float 6.000000e+00, float 7.000000e+00, float 8.000000e+00]
 // CHECK: [16 x float] [float 1.500000e+01, float 1.500000e+01, float 1.500000e+01, float 1.500000e+01, float 1.600000e+01, float 1.600000e+01, float 1.600000e+01, float 1.600000e+01, float 1.700000e+01, float 1.700000e+01, float 1.700000e+01, float 1.700000e+01, float 1.800000e+01, float 1.800000e+01, float 1.800000e+01, float 1.800000e+01]
 // CHECK: [16 x float] [float 0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00, float 0.000000e+00, float 1.000000e+00, float 2.000000e+00, float 3.000000e+00]

--- a/tools/clang/test/CodeGenHLSL/quick-test/staticGlobals3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/staticGlobals3.hlsl
@@ -1,20 +1,13 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
 
-// t3.b.x
-// CHECK: [3 x float] [float 0.000000e+00, float 2.500000e+01, float 0.000000e+00]
-// t3.b.y
-// CHECK: [3 x float] [float 0.000000e+00, float 2.600000e+01, float 0.000000e+00]
-// t3.c.x
-// CHECK: constant [3 x i32] [i32 0, i32 27, i32 0]
-// t3.c.y
-// CHECK: [3 x i32] [i32 0, i32 28, i32 0]
+// t3.b
+// CHECK: [6 x float] [float 0.000000e+00, float 0.000000e+00, float 2.500000e+01, float 2.600000e+01, float 0.000000e+00, float 0.000000e+00]
+// t3.c
+// CHECK: constant [6 x i32] [i32 0, i32 0, i32 27, i32 28, i32 0, i32 0]
 // t3.a
-
 // CHECK: [12 x float] [float 5.000000e+00, float 7.000000e+00, float 6.000000e+00, float 8.000000e+00, float 2.500000e+01, float 2.700000e+01, float 2.600000e+01, float 2.800000e+01, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00]
-
 // t3.t
-
 // CHECK: [24 x float] [float 2.500000e+01, float 2.700000e+01, float 2.600000e+01, float 2.800000e+01, float 2.500000e+01, float 2.700000e+01, float 2.600000e+01, float 2.800000e+01, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 3.000000e+00, float 5.000000e+00, float 7.000000e+00, float 6.000000e+00, float 8.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 0.000000e+00, float 5.000000e+00, float 7.000000e+00, float 6.000000e+00, float 8.000000e+00]
 
 

--- a/tools/clang/test/CodeGenHLSL/shader-compat-suite/static_imm.hlsl
+++ b/tools/clang/test/CodeGenHLSL/shader-compat-suite/static_imm.hlsl
@@ -1,8 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
 // Make sure create constant for static array.
-// CHECK: constant [3 x float] [float 0.000000e+00, float 0x3FF1B22D20000000, float -2.800000e+01]
-// CHECK: constant [3 x float] [float 0x3FF4A3D700000000, float 0x4046666660000000, float 0x3FB99999A0000000]
+// CHECK: constant [6 x float] [float 0.000000e+00, float 0x3FF4A3D700000000, float 0x3FF1B22D20000000, float 0x4046666660000000, float -2.800000e+01, float 0x3FB99999A0000000]
 
 static const float2 t[ 3 ]=
 	{

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1415,8 +1415,8 @@ TEST_F(ValidationTest, UnusedMetadata) {
 
 TEST_F(ValidationTest, MemoryOutOfBound) {
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\targetArray.hlsl", "ps_6_0",
-                          "getelementptr [4 x float], [4 x float]* %7, i32 0, i32 3",
-                          "getelementptr [4 x float], [4 x float]* %7, i32 0, i32 10",
+                          "getelementptr [8 x float], [8 x float]* %5, i32 0, i32 3",
+                          "getelementptr [8 x float], [8 x float]* %5, i32 0, i32 10",
                           "Access to out-of-bounds memory is disallowed");
 }
 


### PR DESCRIPTION
Other passes break vectors down into arrays or scalars, but SROA does it in a funny way where it converts arrays of vectors into one array per vector component, changing the data locality. This is an experiment to see what happens if we stop doing that, and it wasn't so bad!

This change would improve debug information for vectors and preserve a bit more info since arrays of vectors will be broken down into arrays of arrays, that could be use for a future array dimension rotation pass.

The small numbers of tests impacted by this is either a good sign that the impact is minimal or a bad sign that our test coverage is lacking.

Thoughts? Should we do this?