### PR TITLE
Adjust debug info handling options for better sanity

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -93,6 +93,7 @@ public:
 
   llvm::StringRef AssemblyCode; // OPT_Fc
   llvm::StringRef DebugFile;    // OPT_Fd
+  llvm::StringRef PDBAltPath;   // OPT_pdb_alt_path
   llvm::StringRef EntryPoint;   // OPT_entrypoint
   llvm::StringRef ExternalFn;   // OPT_external_fn
   llvm::StringRef ExternalLib;  // OPT_external_lib
@@ -166,6 +167,13 @@ public:
 
   bool IsRootSignatureProfile();
   bool IsLibraryProfile();
+
+  // Helpers to clarify interpretation of flags for behavior in implementation
+  bool IsDebugInfoEnabled();    // Zi || Fd
+  bool EmbedDebugInfo();        // Zi && !Fd && !Qstrip_debug
+  bool EmbedPDBName();          // Zi || Fd || pdb_alt_path
+  bool DebugFileIsDirectory();  // Fd ends in '\\'
+  llvm::StringRef GetPDBName(); // pdb_alt_path or Fd
 
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -330,7 +330,12 @@ def Fc : JoinedOrSeparate<["-", "/"], "Fc">, MetaVarName<"<file>">, HelpText<"Ou
 //def Fx : JoinedOrSeparate<["-", "/"], "Fx">, MetaVarName<"<file>">, HelpText<"Output assembly code and hex listing file">;
 def Fh : JoinedOrSeparate<["-", "/"], "Fh">, MetaVarName<"<file>">, HelpText<"Output header file containing object code">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 def Fe : JoinedOrSeparate<["-", "/"], "Fe">, MetaVarName<"<file>">, HelpText<"Output warnings and errors to the given file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
-def Fd : JoinedOrSeparate<["-", "/"], "Fd">, MetaVarName<"<file>">, HelpText<"Write debug information to the given file or directory; trail \\ to auto-generate and imply Qstrip_priv">, Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
+def Fd : JoinedOrSeparate<["-", "/"], "Fd">, MetaVarName<"<file>">,
+  HelpText<"Write debug information to the given file, or automatically named file in directory when ending in '\\'; implies Zi and Qstrip_debug">,
+  Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
+def pdb_alt_path : JoinedOrSeparate<["-", "/"], "pdb-alt-path">,
+  MetaVarName<"<file>">, HelpText<"Embed this PDB path in the binary instead of the path written to by Fd">,
+  Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
 def Vn : JoinedOrSeparate<["-", "/"], "Vn">, MetaVarName<"<name>">, HelpText<"Use <name> as variable name in header file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 def Cc : Flag<["-", "/"], "Cc">, HelpText<"Output color coded assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;
 def Ni : Flag<["-", "/"], "Ni">, HelpText<"Output instruction numbers in assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;

--- a/tools/clang/tools/libclang/CMakeLists.txt
+++ b/tools/clang/tools/libclang/CMakeLists.txt
@@ -184,6 +184,8 @@ if(ENABLE_SHARED)
 endif()
 endif() # HLSL Change
 
+add_dependencies(libclang TablegenHLSLOptions)  # HLSL Change
+
 # HLSL Change Starts
 # add_clang_library(${LIBCLANG_STATIC_TARGET_NAME} STATIC ${SOURCES})
 # target_link_libraries(${LIBCLANG_STATIC_TARGET_NAME} ${LIBS})

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -235,12 +235,6 @@ int DxcContext::ActOnBlob(IDxcBlob *pBlob, IDxcBlob *pDebugBlob,
 
   // Extract and write the PDB/debug information.
   if (!m_Opts.DebugFile.empty()) {
-    IFTBOOLMSG(m_Opts.DebugInfo, E_INVALIDARG,
-               "/Fd specified, but no Debug Info was "
-               "found in the shader, please use the "
-               "/Zi switch to generate debug "
-               "information compiling this shader.");
-
     if (pDebugBlob != nullptr) {
       IFTBOOLMSG(pDebugBlobName && *pDebugBlobName, E_INVALIDARG,
                  "/Fd was specified but no debug name was produced");


### PR DESCRIPTION
- -Fd implies -Zi and -Qstrip_debug
- Debug name is based on -Fd, unless path ends with '\', meaning you
  want auto-naming and writing under the specified directory
- -pdb-alt-path overrides debug name in shader blob from default name
  based on -Fd argument.  Not compatible with auto-naming
- -Zi used without -Fd implies embedding debug info, unless -Qstrip_debug
  is used.  In this scenario, we still add the debug name, which is the
  auto-name, unless -pdb-alt-path is supplied.
- If not embedding debug info, we don't put it in the container in the
  first place.

- Also fixed missing dependency on table gen options from libclang