### PR TITLE
[spirv] Remove createBinaryOp API which uses SpirvType.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -188,9 +188,7 @@ public:
   SpirvBinaryOp *createBinaryOp(spv::Op op, QualType resultType,
                                 SpirvInstruction *lhs, SpirvInstruction *rhs,
                                 SourceLocation loc = {});
-  SpirvBinaryOp *createBinaryOp(spv::Op op, const SpirvType *,
-                                SpirvInstruction *lhs, SpirvInstruction *rhs,
-                                SourceLocation loc = {});
+
   SpirvSpecConstantBinaryOp *
   createSpecConstantBinaryOp(spv::Op op, QualType resultType,
                              SpirvInstruction *lhs, SpirvInstruction *rhs,

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -308,20 +308,6 @@ SpirvBinaryOp *SpirvBuilder::createBinaryOp(spv::Op op, QualType resultType,
   return instruction;
 }
 
-SpirvBinaryOp *SpirvBuilder::createBinaryOp(spv::Op op,
-                                            const SpirvType *resultType,
-                                            SpirvInstruction *lhs,
-                                            SpirvInstruction *rhs,
-                                            SourceLocation loc) {
-  assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvBinaryOp(op, /*QualType*/ {}, loc, lhs, rhs);
-  instruction->setResultType(resultType);
-  instruction->setNonUniform(lhs->isNonUniform() || rhs->isNonUniform());
-  insertPoint->addInstruction(instruction);
-  return instruction;
-}
-
 SpirvSpecConstantBinaryOp *SpirvBuilder::createSpecConstantBinaryOp(
     spv::Op op, QualType resultType, SpirvInstruction *lhs,
     SpirvInstruction *rhs, SourceLocation loc) {


### PR DESCRIPTION
All usages of `createBinaryOp` overload have already been removed. This change removes the function itself.