### PR TITLE
Fix compiler crash on using incomplete types

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -10245,15 +10245,19 @@ bool FlattenedTypeIterator::pushTrackerForType(QualType type, MultiExprArg::iter
 
     if (CXXRecordDecl *cxxRecordDecl =
             dyn_cast<CXXRecordDecl>(recordType->getDecl())) {
-      CXXRecordDecl::base_class_iterator bi, be;
-      bi = cxxRecordDecl->bases_begin();
-      be = cxxRecordDecl->bases_end();
-      if (bi != be) {
-        // Add type tracker for base.
-        // Add base after child to make sure base considered first.
-        m_typeTrackers.push_back(
+      // We'll error elsewhere if the record has no definition,
+      // just don't attempt to use it.
+      if (cxxRecordDecl->hasDefinition()) {
+        CXXRecordDecl::base_class_iterator bi, be;
+        bi = cxxRecordDecl->bases_begin();
+        be = cxxRecordDecl->bases_end();
+        if (bi != be) {
+          // Add type tracker for base.
+          // Add base after child to make sure base considered first.
+          m_typeTrackers.push_back(
             FlattenedTypeIterator::FlattenedTypeTracker(type, bi, be));
-        bAddTracker = true;
+          bAddTracker = true;
+        }
       }
     }
     return bAddTracker;

--- a/tools/clang/test/HLSL/incomplete-type.hlsl
+++ b/tools/clang/test/HLSL/incomplete-type.hlsl
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -verify -verify-ignore-unexpected=note %s
+
+// Tests that the compiler is well-behaved with regard to uses of incomplete types.
+// Regression test for GitHub #2058, which crashed in this case.
+
+struct S;
+ConstantBuffer<S> CB; // expected-error {{variable has incomplete type 'S'}}
+S func( // expected-error {{incomplete result type 'S' in function definition}}
+  S param) // expected-error {{variable has incomplete type 'S'}}
+{
+  S local; // expected-error {{variable has incomplete type 'S'}}
+  return (S)0; // expected-error {{'S' is an incomplete type}}
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -47,6 +47,7 @@ public:
   TEST_METHOD(RunCXX11Attributes)
   TEST_METHOD(RunEnums)
   TEST_METHOD(RunFunctions)
+  TEST_METHOD(RunIncompleteType)
   TEST_METHOD(RunIndexingOperator)
   TEST_METHOD(RunIntrinsicExamples)
   TEST_METHOD(RunMatrixAssignments)
@@ -187,6 +188,10 @@ TEST_F(VerifierTest, RunEnums) {
 
 TEST_F(VerifierTest, RunFunctions) {
   CheckVerifiesHLSL(L"functions.hlsl");
+}
+
+TEST_F(VerifierTest, RunIncompleteType) {
+  CheckVerifiesHLSL(L"incomplete-type.hlsl");
 }
 
 TEST_F(VerifierTest, RunIndexingOperator) {


### PR DESCRIPTION
Using a forward declared type without a definition may well be illegal, but it shouldn't crash the compiler.

Fixes #2058