### PR TITLE
Fix SROA leaving some llvm.dbg.declare(undef) behind

### DIFF
--- a/lib/Transforms/Scalar/SROA.cpp
+++ b/lib/Transforms/Scalar/SROA.cpp
@@ -4446,6 +4446,17 @@ void SROA::deleteDeadInstructions(
     Instruction *I = DeadInsts.pop_back_val();
     DEBUG(dbgs() << "Deleting dead instruction: " << *I << "\n");
 
+    // HLSL Change Begins
+    // If the instruction is an alloca, find the possible dbg.declare connected
+    // to it, and remove it too. We must do this before calling RAUW or we will
+    // not be able to find it.
+    if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) {
+      DeletedAllocas.insert(AI);
+      if (DbgDeclareInst *DbgDecl = FindAllocaDbgDeclare(AI))
+        DbgDecl->eraseFromParent();
+    }
+    // HLSL Change Ends
+
     I->replaceAllUsesWith(UndefValue::get(I->getType()));
 
     for (Use &Operand : I->operands())
@@ -4455,12 +4466,6 @@ void SROA::deleteDeadInstructions(
         if (isInstructionTriviallyDead(U))
           DeadInsts.insert(U);
       }
-
-    if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) {
-      DeletedAllocas.insert(AI);
-      if (DbgDeclareInst *DbgDecl = FindAllocaDbgDeclare(AI))
-        DbgDecl->eraseFromParent();
-    }
 
     ++NumDeleted;
     I->eraseFromParent();

--- a/lib/Transforms/Scalar/SROA.cpp
+++ b/lib/Transforms/Scalar/SROA.cpp
@@ -4467,6 +4467,14 @@ void SROA::deleteDeadInstructions(
           DeadInsts.insert(U);
       }
 
+#if 0 // HLSL Change - blocked moved before replaceAllUsesWith
+    if (AllocaInst *AI = dyn_cast<AllocaInst>(I)) {
+      DeletedAllocas.insert(AI);
+      if (DbgDeclareInst *DbgDecl = FindAllocaDbgDeclare(AI))
+        DbgDecl->eraseFromParent();
+    }
+#endif // HLSL Change
+
     ++NumDeleted;
     I->eraseFromParent();
   }


### PR DESCRIPTION
All uses of dead instructions are replaced by `undef` before we have a case for AllocaInst and try to find any `llvm.dbg.declare` intrinsic, so we never find them.

This was fixed in a later LLVM version, see: https://github.com/llvm-mirror/llvm/commit/0e1ce271574ac0f9097000a08f13736c45352ced