### PR TITLE
Improve debug type information for resources.

### DIFF
--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -1513,9 +1513,16 @@ TypeInfo ASTContext::getTypeInfoImpl(const Type *T) const {
   bool AlignIsRequired = false;
   // HLSL Change Starts
   if (getLangOpts().HLSL) {
+    QualType QualTy(T, 0);
     if (const ExtVectorType *Ty =
-            hlsl::ConvertHLSLVecMatTypeToExtVectorType(*this, QualType(T, 0))) {
+            hlsl::ConvertHLSLVecMatTypeToExtVectorType(*this, QualTy)) {
       T = Ty;
+    }
+    else if (hlsl::IsHLSLResourceType(QualTy) || hlsl::IsHLSLStreamOutputType(QualTy)) {
+      // Lie that those are pointer-sized.
+      // We don't know how big they will be on the target architecture.
+      // And the fields we stuff into those structures are irrelevant.
+      T = getIntPtrType().getTypePtr();
     }
   }
   // HLSL Change Ends

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1024,6 +1024,10 @@ void CGDebugInfo::CollectRecordFields(
 }
 
 // HLSL Change Begins
+// Hook to allow us to lie about the contents of some HLSL types in the debug info,
+// by exposing clean members rather than our implementation detail internals.
+// Note that the debug size of types is not based on the fields reported here,
+// but rather on ASTContext::getTypeSize, so they should be consistent.
 bool CGDebugInfo::TryCollectHLSLRecordElements(const RecordType *Ty,
     llvm::DICompositeType *DITy,
     SmallVectorImpl<llvm::Metadata *> &Elements) {
@@ -1044,6 +1048,10 @@ bool CGDebugInfo::TryCollectHLSLRecordElements(const RecordType *Ty,
       Elements.emplace_back(FieldType);
     }
 
+    return true;
+  }
+  else if (hlsl::IsHLSLResourceType(QualTy) || hlsl::IsHLSLStreamOutputType(QualTy)) {
+    // Should appear as having no members rather than exposing our internal handles.
     return true;
   }
 

--- a/tools/clang/test/CodeGenHLSL/debug/types/resources.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/types/resources.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -T ps_6_0 -E main -Zi %s | FileCheck %s
+
+// Test the definitions for resource types in debug metadata.
+// Resource types should be pointer-sized and not contain members.
+
+// CHECK-DAG: ![[empty:.*]] = !{}
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "Texture2D<vector<float, 2> >",{{.*}} size: 32, align: 32, elements: ![[empty]]
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "SamplerState",{{.*}} size: 32, align: 32, elements: ![[empty]]
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "Buffer<vector<float, 2> >",{{.*}} size: 32, align: 32, elements: ![[empty]]
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_structure_type, name: "ByteAddressBuffer",{{.*}} size: 32, align: 32, elements: ![[empty]]
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "StructuredBuffer<vector<float, 2> >",{{.*}} size: 32, align: 32, elements: ![[empty]]
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+Texture2D<float2> tex;
+SamplerState samp;
+Buffer<float2> buf;
+ByteAddressBuffer bytebuf;
+StructuredBuffer<float2> structbuf;
+
+float main() : SV_Target
+{
+  // Use every resource so it makes it to the debug info
+  return tex.Sample(samp, 0).x + buf[0] + bytebuf.Load(0) + structbuf[0].x;
+}


### PR DESCRIPTION
Two changes in here:

- Hide the resource members in the debug information as they are internal implementation details.
- Force the size of resources to be reported as 32 bits (`sizeof(intptr)`). It's not useful for resources to have a size based on the internal fields we stick in there, it's more useful for backends to be able to expect a fixed resource size, even though what they end up generating might be bigger.

The latter change seems a little riskier, but none of the tests were impacted.