### PR TITLE
 [spirv] Use QualType in constant instruction constructors

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1069,7 +1069,6 @@ private:
 
 class SpirvConstantNull : public SpirvConstant {
 public:
-  SpirvConstantNull(const SpirvType *type);
   SpirvConstantNull(QualType type);
 
   bool invokeVisitor(Visitor *v) override;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -987,7 +987,7 @@ protected:
 
 class SpirvConstantBoolean : public SpirvConstant {
 public:
-  SpirvConstantBoolean(const BoolType *type, bool value,
+  SpirvConstantBoolean(QualType type, bool value,
                        bool isSpecConst = false);
 
   // For LLVM-style RTTI

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1015,9 +1015,8 @@ SpirvConstant *SpirvBuilder::getConstantFloat(QualType type,
 
 SpirvConstant *SpirvBuilder::getConstantBool(bool value, bool specConst) {
   // We do not care about making unique constants at this point.
-  auto *boolConst = new (context)
-      SpirvConstantBoolean(context.getBoolType(), value, specConst);
-  boolConst->setAstResultType(astContext.BoolTy);
+  auto *boolConst =
+      new (context) SpirvConstantBoolean(astContext.BoolTy, value, specConst);
   module->addConstant(boolConst);
   return boolConst;
 }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -418,7 +418,7 @@ bool SpirvConstant::isSpecConstant() const {
          opcode == spv::Op::OpSpecConstantComposite;
 }
 
-SpirvConstantBoolean::SpirvConstantBoolean(const BoolType *type, bool val,
+SpirvConstantBoolean::SpirvConstantBoolean(QualType type, bool val,
                                            bool isSpecConst)
     : SpirvConstant(IK_ConstantBoolean,
                     val ? (isSpecConst ? spv::Op::OpSpecConstantTrue

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -470,15 +470,12 @@ SpirvConstantComposite::SpirvConstantComposite(
                     type),
       constituents(constituentsVec.begin(), constituentsVec.end()) {}
 
-SpirvConstantNull::SpirvConstantNull(const SpirvType *type)
-    : SpirvConstant(IK_ConstantNull, spv::Op::OpConstantNull, type) {}
-
 SpirvConstantNull::SpirvConstantNull(QualType type)
     : SpirvConstant(IK_ConstantNull, spv::Op::OpConstantNull, type) {}
 
 bool SpirvConstantNull::operator==(const SpirvConstantNull &that) const {
-  // QualType may contain 'literal type'. We can only compare the SPIR-V types.
-  return opcode == that.opcode && resultType == that.resultType;
+  return opcode == that.opcode && resultType == that.resultType &&
+         astResultType == that.astResultType;
 }
 
 SpirvCompositeExtract::SpirvCompositeExtract(QualType resultType,

--- a/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
@@ -104,9 +104,9 @@ TEST_F(SpirvConstantTest, CheckOperatorEqualOnFloat) {
 }
 
 TEST_F(SpirvConstantTest, CheckOperatorEqualOnNull) {
-  SpirvContext ctx;
-  SpirvConstantNull constant1(ctx.getSIntType(32));
-  SpirvConstantNull constant2(ctx.getSIntType(32));
+  clang::ASTContext &astContext = getAstContext();
+  SpirvConstantNull constant1(astContext.IntTy);
+  SpirvConstantNull constant2(astContext.IntTy);
   EXPECT_TRUE(constant1 == constant2);
 }
 
@@ -163,9 +163,9 @@ TEST_F(SpirvConstantTest, CheckOperatorEqualOnInt4) {
 }
 
 TEST_F(SpirvConstantTest, CheckOperatorEqualOnNull2) {
-  SpirvContext ctx;
-  SpirvConstantNull constant1(ctx.getSIntType(32));
-  SpirvConstantNull constant2(ctx.getUIntType(32));
+  clang::ASTContext &astContext = getAstContext();
+  SpirvConstantNull constant1(astContext.IntTy);
+  SpirvConstantNull constant2(astContext.UnsignedIntTy);
   EXPECT_FALSE(constant1 == constant2);
 }
 

--- a/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvConstantTest.cpp
@@ -17,16 +17,16 @@ namespace {
 class SpirvConstantTest : public SpirvTestBase {};
 
 TEST_F(SpirvConstantTest, BoolFalse) {
-  SpirvContext ctx;
+  clang::ASTContext &astContext = getAstContext();
   const bool val = false;
-  SpirvConstantBoolean constant(ctx.getBoolType(), val);
+  SpirvConstantBoolean constant(astContext.BoolTy, val);
   EXPECT_EQ(val, constant.getValue());
 }
 
 TEST_F(SpirvConstantTest, BoolTrue) {
-  SpirvContext ctx;
+  clang::ASTContext &astContext = getAstContext();
   const bool val = true;
-  SpirvConstantBoolean constant(ctx.getBoolType(), val);
+  SpirvConstantBoolean constant(astContext.BoolTy, val);
   EXPECT_EQ(val, constant.getValue());
 }
 
@@ -80,10 +80,10 @@ TEST_F(SpirvConstantTest, Float32) {
 }
 
 TEST_F(SpirvConstantTest, CheckOperatorEqualOnBool) {
-  SpirvContext ctx;
+  clang::ASTContext &astContext = getAstContext();
   const bool val = true;
-  SpirvConstantBoolean constant1(ctx.getBoolType(), val);
-  SpirvConstantBoolean constant2(ctx.getBoolType(), val);
+  SpirvConstantBoolean constant1(astContext.BoolTy, val);
+  SpirvConstantBoolean constant2(astContext.BoolTy, val);
   EXPECT_TRUE(constant1 == constant2);
 }
 
@@ -111,9 +111,9 @@ TEST_F(SpirvConstantTest, CheckOperatorEqualOnNull) {
 }
 
 TEST_F(SpirvConstantTest, CheckOperatorEqualOnBool2) {
-  SpirvContext ctx;
-  SpirvConstantBoolean constant1(ctx.getBoolType(), true);
-  SpirvConstantBoolean constant2(ctx.getBoolType(), false);
+  clang::ASTContext &astContext = getAstContext();
+  SpirvConstantBoolean constant1(astContext.BoolTy, true);
+  SpirvConstantBoolean constant2(astContext.BoolTy, false);
   EXPECT_FALSE(constant1 == constant2);
 }
 
@@ -170,9 +170,9 @@ TEST_F(SpirvConstantTest, CheckOperatorEqualOnNull2) {
 }
 
 TEST_F(SpirvConstantTest, BoolConstNotEqualSpecConst) {
-  SpirvContext ctx;
-  SpirvConstantBoolean constant1(ctx.getBoolType(), true, /*SpecConst*/ true);
-  SpirvConstantBoolean constant2(ctx.getBoolType(), false, /*SpecConst*/ false);
+  clang::ASTContext &astContext = getAstContext();
+  SpirvConstantBoolean constant1(astContext.BoolTy, true, /*SpecConst*/ true);
+  SpirvConstantBoolean constant2(astContext.BoolTy, false, /*SpecConst*/ false);
   EXPECT_FALSE(constant1 == constant2);
 }
 


### PR DESCRIPTION
Finishes switching all constant instruction constructors to use QualType rather than SpirvType.