### PR TITLE
Add tests for debug info of half and double types (16 and 64-bit).

### DIFF
--- a/tools/clang/test/CodeGenHLSL/debug/types/double.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/types/double.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -E main -T vs_6_0 -Zi %s | FileCheck %s
+
+// Test that debug information for doubles (64-bit type) is preserved.
+
+// CHECK: %[[bufret:.*]] = call %dx.types.CBufRet.f64 @dx.op.cbufferLoadLegacy.f64
+// CHECK: %[[d:.*]] = extractvalue %dx.types.CBufRet.f64 %[[bufret]], 0
+// CHECK: call void @llvm.dbg.value(metadata double %[[d]], i64 0, metadata ![[divar:.*]], metadata ![[diexpr:.*]])
+
+// CHECK: !DIBasicType(name: "double", size: 64, align: 64, encoding: DW_ATE_float)
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[divar]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "d"
+// CHECK-DAG: ![[diexpr]] = !DIExpression()
+
+double cb_d;
+float main() : OUT
+{
+    double d = cb_d;
+    return (float)d;
+}

--- a/tools/clang/test/CodeGenHLSL/debug/types/half.hlsl
+++ b/tools/clang/test/CodeGenHLSL/debug/types/half.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -Zi %s | FileCheck %s
+
+// Test that debug information for half floats (16-bit type) is preserved.
+
+// CHECK: %[[bufret:.*]] = call %dx.types.CBufRet.f16.8 @dx.op.cbufferLoadLegacy.f16
+// CHECK: %[[h:.*]] = extractvalue %dx.types.CBufRet.f16.8 %[[bufret]], 0
+// CHECK: call void @llvm.dbg.value(metadata half %[[h]], i64 0, metadata ![[divar:.*]], metadata ![[diexpr:.*]])
+
+// CHECK: !DIBasicType(name: "half", size: 16, align: 16, encoding: DW_ATE_float)
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+// CHECK-DAG: ![[divar]] = !DILocalVariable(tag: DW_TAG_auto_variable, name: "h"
+// CHECK-DAG: ![[diexpr]] = !DIExpression()
+
+half cb_h;
+float main() : OUT
+{
+    half h = cb_h;
+    return (float)h;
+}


### PR DESCRIPTION
Those are pretty trivial tests but we should have coverage for those cases.