### PR TITLE
Make the array out of bounds error conditional on the HLSL version.

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7441,7 +7441,7 @@ def err_opencl_constant_no_init : Error<
 // HLSL Change Starts
 let CategoryName = "HLSL Issue" in {
 def err_hlsl_array_element_index_out_of_bounds: Error<
-  "array element index '%0' is out of bounds">;
+  "array index %0 is out of bounds">;
 def err_hlsl_attribute_expects_string_literal: Error<
   "attribute %0 must have a string literal argument">;
 def err_hlsl_attribute_expects_string_literal_from_list: Error<

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -8469,7 +8469,7 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     }
 
     // HLSL Change Starts
-    if (getLangOpts().HLSL) {
+    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > 2016) {
       DiagRuntimeBehavior(BaseExpr->getLocStart(), BaseExpr,
         PDiag(diag::err_hlsl_array_element_index_out_of_bounds) << index.toString(10, true));
     }
@@ -8488,7 +8488,7 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     } // HLSL Change
   } else {
     // HLSL Change Starts
-    if (getLangOpts().HLSL) {
+    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > 2016) {
       DiagRuntimeBehavior(BaseExpr->getLocStart(), BaseExpr,
         PDiag(diag::err_hlsl_array_element_index_out_of_bounds) << index.toString(10, true));
     }

--- a/tools/clang/test/HLSL/array-index-out-of-bounds-HV-2016.hlsl
+++ b/tools/clang/test/HLSL/array-index-out-of-bounds-HV-2016.hlsl
@@ -1,0 +1,12 @@
+// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -HV 2016 -verify -verify-ignore-unexpected=note %s
+
+void dead()
+{
+    int array[2];
+    array[-1] = 0;                                          /* expected-warning {{array index -1 is before the beginning of the array}} fxc-pass */
+    array[0] = 0;
+    array[1] = 0;
+    array[2] = 0;                                           /* expected-warning {{array index 2 is past the end of the array (which contains 2 elements)}} fxc-pass */
+}
+
+void main() {}

--- a/tools/clang/test/HLSL/array-index-out-of-bounds.hlsl
+++ b/tools/clang/test/HLSL/array-index-out-of-bounds.hlsl
@@ -3,8 +3,8 @@
 void main()
 {
     int array[2];
-    array[-1] = 0;                                          /* expected-error {{array element index '-1' is out of bounds}} fxc-error {{X3504: array index out of bounds}} */
+    array[-1] = 0;                                          /* expected-error {{array index -1 is out of bounds}} fxc-error {{X3504: array index out of bounds}} */
     array[0] = 0;
     array[1] = 0;
-    array[2] = 0;                                           /* expected-error {{array element index '2' is out of bounds}} fxc-error {{X3504: array index out of bounds}} */
+    array[2] = 0;                                           /* expected-error {{array index 2 is out of bounds}} fxc-error {{X3504: array index out of bounds}} */
 }

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -139,6 +139,7 @@ public:
 
 TEST_F(VerifierTest, RunArrayIndexOutOfBounds) {
   CheckVerifiesHLSL(L"array-index-out-of-bounds.hlsl");
+  CheckVerifiesHLSL(L"array-index-out-of-bounds-HV-2016.hlsl");
 }
 
 TEST_F(VerifierTest, RunArrayLength) {


### PR DESCRIPTION
#1931 added this error, but it was later found to be a breaking change from FXC as FXC would only produce the error if the out-of-bounds error was in a function being referenced somewhere. This change makes the error conditional on the HLSL version for backwards compatibility. With `-HV 2016`, it is only a warning.