### PR TITLE
Fix an assert on cbuffer loads of bool vectors

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -98,7 +98,7 @@ namespace dxilutil {
                                       unsigned numOperands);
   bool SimplifyTrivialPHIs(llvm::BasicBlock *BB);
   void MigrateDebugValue(llvm::Value *Old, llvm::Value *New);
-  void ScatterDebugValueToVectorElements(llvm::Value *Val);
+  void TryScatterDebugValueToVectorElements(llvm::Value *Val);
   std::unique_ptr<llvm::Module> LoadModuleFromBitcode(llvm::StringRef BC,
     llvm::LLVMContext &Ctx, std::string &DiagStr);
   std::unique_ptr<llvm::Module> LoadModuleFromBitcode(llvm::MemoryBuffer *MB,

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -363,8 +363,9 @@ void MigrateDebugValue(Value *Old, Value *New) {
 // If we just keep the debug info on the recomposed vector,
 // we will lose it when we break it apart again during later
 // optimization stages.
-void ScatterDebugValueToVectorElements(Value *Val) {
-  DXASSERT(isa<InsertElementInst>(Val), "Should be a newly gathered vector.");
+void TryScatterDebugValueToVectorElements(Value *Val) {
+  if (!isa<InsertElementInst>(Val) || !Val->getType()->isVectorTy()) return;
+
   DbgValueInst *VecDbgValInst = FindDbgValueInst(Val);
   if (VecDbgValInst == nullptr) return;
 

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -5500,7 +5500,7 @@ void TranslateCBAddressUserLegacy(Instruction *user, Value *handle,
       Value *newLd = TranslateConstBufMatLdLegacy(
         MatTy, handle, legacyIdx, colMajor, hlslOP, /*memElemRepr*/false, DL, Builder);
       CI->replaceAllUsesWith(newLd);
-      dxilutil::ScatterDebugValueToVectorElements(newLd);
+      dxilutil::TryScatterDebugValueToVectorElements(newLd);
       CI->eraseFromParent();
     } else if (group == HLOpcodeGroup::HLSubscript) {
       HLSubscriptOpcode subOp = static_cast<HLSubscriptOpcode>(opcode);
@@ -5669,7 +5669,7 @@ void TranslateCBAddressUserLegacy(Instruction *user, Value *handle,
                                    hlslOP, Builder);
 
     ldInst->replaceAllUsesWith(newLd);
-    if (Ty->isVectorTy()) dxilutil::ScatterDebugValueToVectorElements(newLd);
+    dxilutil::TryScatterDebugValueToVectorElements(newLd);
     ldInst->eraseFromParent();
   } else if (BitCastInst *BCI = dyn_cast<BitCastInst>(user)) {
     for (auto it = BCI->user_begin(); it != BCI->user_end(); ) {

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -630,7 +630,7 @@ void replaceDirectInputParameter(Value *param, Function *loadInput,
     param->replaceAllUsesWith(newVec);
 
     // THe individual loadInputs are the authoritative source of values for the vector.
-    dxilutil::ScatterDebugValueToVectorElements(newVec);
+    dxilutil::TryScatterDebugValueToVectorElements(newVec);
   } else if (!Ty->isArrayTy() && !HLMatrixType::isa(Ty)) {
     DXASSERT(cols == 1, "only support scalar here");
     Value *colIdx = hlslOP->GetU8Const(0);


### PR DESCRIPTION
After loading a vector from a cbuffer, we attempt moving the debug info upstream, to the individually loaded elements, assuming that they got converted into a vector by a sequence of `insertelement` instructions. This is not the case for bool vectors, because the `insertelement` sequence will be followed by a mem-to-reg conversion. Made the code more resilient to such unexpected patterns (better to lose debug info than to crash compilation).