### PR TITLE
Preserve snorm/unorm on resource template args

### DIFF
--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/assign_different_error.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/assign_different_error.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail
+
+// Test that assignments between resources of different
+// snorm/unorm qualifiers are reported as errors.
+
+// CHECK-NOT: @dx.op.bufferLoad.f32
+
+Buffer<snorm float> buf_snorm;
+
+float main() : OUT
+{
+  Buffer<unorm float> buf_unorm = buf_snorm; // FXC: error X3017: cannot implicitly convert from 'const Buffer<snorm float>' to 'Buffer<unorm float>'
+  return buf_unorm.Load(0);
+}

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/assign_different_error.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/assign_different_error.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s | XFail GitHub #2106
 
 // Test that assignments between resources of different
 // snorm/unorm qualifiers are reported as errors.

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/global_struct_field.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/global_struct_field.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+// Test that snorm/unorm is preserved in the DXIL metadata for
+// resources declared as fields of global structures.
+
+// With an SRV and textures (9 = float, 13 = snorm float, 14 = unorm float)
+// CHECK-DAG: !{i32 0, %{{.*}}* undef, !{{.*}}, i32 0, i32 0, i32 1, i32 1, i32 0, ![[bs:.*]]}
+// CHECK-DAG: ![[bs]] = !{i32 0, i32 13}
+struct { Texture1D<snorm float> tex_snorm; } globals;
+
+float main() : OUT
+{
+  return globals.tex_snorm.Load(0);
+}

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/srv_uav.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/srv_uav.hlsl
@@ -2,7 +2,7 @@
 
 // Test that snorm/unorm is preserved in the DXIL metadata.
 
-// With an SRV and textures
+// With an SRV and textures (9 = float, 13 = snorm float, 14 = unorm float)
 // CHECK-DAG: !{i32 0, %{{.*}}* undef, !{{.*}}, i32 0, i32 0, i32 1, i32 1, i32 0, ![[bf:.*]]}
 // CHECK-DAG: ![[bf]] = !{i32 0, i32 9}
 // CHECK-DAG: !{i32 1, %{{.*}}* undef, !{{.*}}, i32 0, i32 1, i32 1, i32 1, i32 0, ![[bs:.*]]}
@@ -13,7 +13,7 @@ Texture1D<float> tex_float;
 Texture1D<snorm float> tex_snorm;
 Texture1D<unorm float> tex_unorm;
 
-// With a UAV and buffers
+// With a UAV and buffers (9 = float, 13 = snorm float, 14 = unorm float)
 // CHECK-DAG: !{i32 0, %{{.*}}* undef, !{{.*}}, i32 0, i32 0, i32 1, i32 10, i1 false, i1 false, i1 false, ![[rwbf:.*]]}
 // CHECK-DAG: ![[rwbf]] = !{i32 0, i32 9}
 // CHECK-DAG: !{i32 1, %{{.*}}* undef, !{{.*}}, i32 0, i32 1, i32 1, i32 10, i1 false, i1 false, i1 false, ![[rwbs:.*]]}

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/srv_uav.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/norm_floats/srv_uav.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+// Test that snorm/unorm is preserved in the DXIL metadata.
+
+// With an SRV and textures
+// CHECK-DAG: !{i32 0, %{{.*}}* undef, !{{.*}}, i32 0, i32 0, i32 1, i32 1, i32 0, ![[bf:.*]]}
+// CHECK-DAG: ![[bf]] = !{i32 0, i32 9}
+// CHECK-DAG: !{i32 1, %{{.*}}* undef, !{{.*}}, i32 0, i32 1, i32 1, i32 1, i32 0, ![[bs:.*]]}
+// CHECK-DAG: ![[bs]] = !{i32 0, i32 13}
+// CHECK-DAG: !{i32 2, %{{.*}}* undef, !{{.*}}, i32 0, i32 2, i32 1, i32 1, i32 0, ![[bu:.*]]}
+// CHECK-DAG: ![[bu]] = !{i32 0, i32 14}
+Texture1D<float> tex_float;
+Texture1D<snorm float> tex_snorm;
+Texture1D<unorm float> tex_unorm;
+
+// With a UAV and buffers
+// CHECK-DAG: !{i32 0, %{{.*}}* undef, !{{.*}}, i32 0, i32 0, i32 1, i32 10, i1 false, i1 false, i1 false, ![[rwbf:.*]]}
+// CHECK-DAG: ![[rwbf]] = !{i32 0, i32 9}
+// CHECK-DAG: !{i32 1, %{{.*}}* undef, !{{.*}}, i32 0, i32 1, i32 1, i32 10, i1 false, i1 false, i1 false, ![[rwbs:.*]]}
+// CHECK-DAG: ![[rwbs]] = !{i32 0, i32 13}
+// CHECK-DAG: !{i32 2, %{{.*}}* undef, !{{.*}}, i32 0, i32 2, i32 1, i32 10, i1 false, i1 false, i1 false, ![[rwbu:.*]]}
+// CHECK-DAG: ![[rwbu]] = !{i32 0, i32 14}
+RWBuffer<float> rwbuf_float;
+RWBuffer<snorm float> rwbuf_snorm;
+RWBuffer<unorm float> rwbuf_unorm;
+
+float main() : OUT
+{
+  return tex_float.Load(0) + tex_snorm.Load(0) + tex_unorm.Load(0)
+    + rwbuf_float.Load(0) + rwbuf_snorm.Load(0) + rwbuf_unorm.Load(0);
+}


### PR DESCRIPTION
This is a partial solution to preserving `snorm` and `unorm` for `Buffer` and other resource types. In the clang type system, the canonical type of `Buffer<snorm float>` is a `RecordType` for the template specialization, which is `Buffer<float>`, so the information is lost. However, the type of the variable itself has a sugar node of type `TemplateSpecializationType` which provides the exact type arguments that were provided to the template class to select its specialization. Hence we can retrieve the information if we have access to the `VarDecl`'s type.

This is a partial solution, because the `snorm`/`unorm` is still not encoded in the canonical type of the variable, which means that it is still legal to assign resources that differ between their use of the attribute. However, it should unblock the use of the feature with backends that consume this metadata.

Fixes #1722
Filed #2106