### PR TITLE
Allow clip/cull elements to be declared as array [2]

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -651,6 +651,7 @@ ID Name       Description
 6  Target     Special handling for SV_Target
 7  TessFactor Special handling for tessellation factors
 8  Shadow     Shadow element must be added to a signature for compatibility
+8  ClipCull   Special packing rules for SV_ClipDistance or SV_CullDistance
 == ========== =============================================================
 
 .. SEMINT-RST:END
@@ -662,40 +663,40 @@ Semantic Interpretations for each SemanticKind at each SigPointKind are as follo
 .. <py::lines('SEMINT-TABLE-RST')>hctdb_instrhelp.get_sem_interpretation_table_rst()</py>
 .. SEMINT-TABLE-RST:BEGIN
 
-====================== ============ ====== ============ ============ ====== ======= ========== ============ ====== ====== ====== ============ ====== ============= ============= ========
-Semantic               VSIn         VSOut  PCIn         HSIn         HSCPIn HSCPOut PCOut      DSIn         DSCPIn DSOut  GSVIn  GSIn         GSOut  PSIn          PSOut         CSIn
-====================== ============ ====== ============ ============ ====== ======= ========== ============ ====== ====== ====== ============ ====== ============= ============= ========
-Arbitrary              Arb          Arb    NA           NA           Arb    Arb     Arb        Arb          Arb    Arb    Arb    NA           Arb    Arb           NA            NA
-VertexID               SV           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NA
-InstanceID             SV           Arb    NA           NA           Arb    Arb     NA         NA           Arb    Arb    Arb    NA           Arb    Arb           NA            NA
-Position               Arb          SV     NA           NA           SV     SV      Arb        Arb          SV     SV     SV     NA           SV     SV            NA            NA
-RenderTargetArrayIndex Arb          SV     NA           NA           SV     SV      Arb        Arb          SV     SV     SV     NA           SV     SV            NA            NA
-ViewPortArrayIndex     Arb          SV     NA           NA           SV     SV      Arb        Arb          SV     SV     SV     NA           SV     SV            NA            NA
-ClipDistance           Arb          SV     NA           NA           SV     SV      Arb        Arb          SV     SV     SV     NA           SV     SV            NA            NA
-CullDistance           Arb          SV     NA           NA           SV     SV      Arb        Arb          SV     SV     SV     NA           SV     SV            NA            NA
-OutputControlPointID   NA           NA     NA           NotInSig     NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NA
-DomainLocation         NA           NA     NA           NA           NA     NA      NA         NotInSig     NA     NA     NA     NA           NA     NA            NA            NA
-PrimitiveID            NA           NA     NotInSig     NotInSig     NA     NA      NA         NotInSig     NA     NA     NA     Shadow       SGV    SGV           NA            NA
-GSInstanceID           NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NotInSig     NA     NA            NA            NA
-SampleIndex            NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     Shadow _41    NA            NA
-IsFrontFace            NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           SGV    SGV           NA            NA
-Coverage               NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NotInSig _50  NotPacked _41 NA
-InnerCoverage          NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NotInSig _50  NA            NA
-Target                 NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            Target        NA
-Depth                  NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NotPacked     NA
-DepthLessEqual         NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NotPacked _50 NA
-DepthGreaterEqual      NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NotPacked _50 NA
-StencilRef             NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NotPacked _50 NA
-DispatchThreadID       NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NotInSig
-GroupID                NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NotInSig
-GroupIndex             NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NotInSig
-GroupThreadID          NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NA            NA            NotInSig
-TessFactor             NA           NA     NA           NA           NA     NA      TessFactor TessFactor   NA     NA     NA     NA           NA     NA            NA            NA
-InsideTessFactor       NA           NA     NA           NA           NA     NA      TessFactor TessFactor   NA     NA     NA     NA           NA     NA            NA            NA
-ViewID                 NotInSig _61 NA     NotInSig _61 NotInSig _61 NA     NA      NA         NotInSig _61 NA     NA     NA     NotInSig _61 NA     NotInSig _61  NA            NA
-Barycentrics           NA           NA     NA           NA           NA     NA      NA         NA           NA     NA     NA     NA           NA     NotPacked _61 NA            NA
-ShadingRate            NA           SV _64 NA           NA           SV _64 SV _64  NA         NA           SV _64 SV _64 SV _64 NA           SV _64 SV _64        NA            NA
-====================== ============ ====== ============ ============ ====== ======= ========== ============ ====== ====== ====== ============ ====== ============= ============= ========
+====================== ============ ======== ============ ============ ======== ======== ========== ============ ======== ======== ======== ============ ======== ============= ============= ========
+Semantic               VSIn         VSOut    PCIn         HSIn         HSCPIn   HSCPOut  PCOut      DSIn         DSCPIn   DSOut    GSVIn    GSIn         GSOut    PSIn          PSOut         CSIn
+====================== ============ ======== ============ ============ ======== ======== ========== ============ ======== ======== ======== ============ ======== ============= ============= ========
+Arbitrary              Arb          Arb      NA           NA           Arb      Arb      Arb        Arb          Arb      Arb      Arb      NA           Arb      Arb           NA            NA
+VertexID               SV           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NA
+InstanceID             SV           Arb      NA           NA           Arb      Arb      NA         NA           Arb      Arb      Arb      NA           Arb      Arb           NA            NA
+Position               Arb          SV       NA           NA           SV       SV       Arb        Arb          SV       SV       SV       NA           SV       SV            NA            NA
+RenderTargetArrayIndex Arb          SV       NA           NA           SV       SV       Arb        Arb          SV       SV       SV       NA           SV       SV            NA            NA
+ViewPortArrayIndex     Arb          SV       NA           NA           SV       SV       Arb        Arb          SV       SV       SV       NA           SV       SV            NA            NA
+ClipDistance           Arb          ClipCull NA           NA           ClipCull ClipCull Arb        Arb          ClipCull ClipCull ClipCull NA           ClipCull ClipCull      NA            NA
+CullDistance           Arb          ClipCull NA           NA           ClipCull ClipCull Arb        Arb          ClipCull ClipCull ClipCull NA           ClipCull ClipCull      NA            NA
+OutputControlPointID   NA           NA       NA           NotInSig     NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NA
+DomainLocation         NA           NA       NA           NA           NA       NA       NA         NotInSig     NA       NA       NA       NA           NA       NA            NA            NA
+PrimitiveID            NA           NA       NotInSig     NotInSig     NA       NA       NA         NotInSig     NA       NA       NA       Shadow       SGV      SGV           NA            NA
+GSInstanceID           NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NotInSig     NA       NA            NA            NA
+SampleIndex            NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       Shadow _41    NA            NA
+IsFrontFace            NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           SGV      SGV           NA            NA
+Coverage               NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NotInSig _50  NotPacked _41 NA
+InnerCoverage          NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NotInSig _50  NA            NA
+Target                 NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            Target        NA
+Depth                  NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NotPacked     NA
+DepthLessEqual         NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NotPacked _50 NA
+DepthGreaterEqual      NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NotPacked _50 NA
+StencilRef             NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NotPacked _50 NA
+DispatchThreadID       NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NotInSig
+GroupID                NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NotInSig
+GroupIndex             NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NotInSig
+GroupThreadID          NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NotInSig
+TessFactor             NA           NA       NA           NA           NA       NA       TessFactor TessFactor   NA       NA       NA       NA           NA       NA            NA            NA
+InsideTessFactor       NA           NA       NA           NA           NA       NA       TessFactor TessFactor   NA       NA       NA       NA           NA       NA            NA            NA
+ViewID                 NotInSig _61 NA       NotInSig _61 NotInSig _61 NA       NA       NA         NotInSig _61 NA       NA       NA       NotInSig _61 NA       NotInSig _61  NA            NA
+Barycentrics           NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NotPacked _61 NA            NA
+ShadingRate            NA           SV _64   NA           NA           SV _64   SV _64   NA         NA           SV _64   SV _64   SV _64   NA           SV _64   SV _64        NA            NA
+====================== ============ ======== ============ ============ ======== ======== ========== ============ ======== ======== ======== ============ ======== ============= ============= ========
 
 .. SEMINT-TABLE-RST:END
 

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -212,6 +212,7 @@ namespace DXIL {
     Target, // Special handling for SV_Target
     TessFactor, // Special handling for tessellation factors
     Shadow, // Shadow element must be added to a signature for compatibility
+    ClipCull, // Special packing rules for SV_ClipDistance or SV_CullDistance
     Invalid,
   };
   // SemanticInterpretationKind-ENUM:END

--- a/include/dxc/DXIL/DxilSigPoint.inl
+++ b/include/dxc/DXIL/DxilSigPoint.inl
@@ -49,38 +49,38 @@ const SigPoint SigPoint::ms_SigPoints[kNumSigPointRecords] = {
 
 // <py::lines('INTERPRETATION-TABLE')>hctdb_instrhelp.get_interpretation_table()</py>
 // INTERPRETATION-TABLE:BEGIN
-//   Semantic,               VSIn,         VSOut,  PCIn,         HSIn,         HSCPIn, HSCPOut, PCOut,      DSIn,         DSCPIn, DSOut,  GSVIn,  GSIn,         GSOut,  PSIn,          PSOut,         CSIn
+//   Semantic,               VSIn,         VSOut,    PCIn,         HSIn,         HSCPIn,   HSCPOut,  PCOut,      DSIn,         DSCPIn,   DSOut,    GSVIn,    GSIn,         GSOut,    PSIn,          PSOut,         CSIn
 #define DO_INTERPRETATION_TABLE(ROW) \
-  ROW(Arbitrary,              Arb,          Arb,    NA,           NA,           Arb,    Arb,     Arb,        Arb,          Arb,    Arb,    Arb,    NA,           Arb,    Arb,           NA,            NA) \
-  ROW(VertexID,               SV,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NA) \
-  ROW(InstanceID,             SV,           Arb,    NA,           NA,           Arb,    Arb,     NA,         NA,           Arb,    Arb,    Arb,    NA,           Arb,    Arb,           NA,            NA) \
-  ROW(Position,               Arb,          SV,     NA,           NA,           SV,     SV,      Arb,        Arb,          SV,     SV,     SV,     NA,           SV,     SV,            NA,            NA) \
-  ROW(RenderTargetArrayIndex, Arb,          SV,     NA,           NA,           SV,     SV,      Arb,        Arb,          SV,     SV,     SV,     NA,           SV,     SV,            NA,            NA) \
-  ROW(ViewPortArrayIndex,     Arb,          SV,     NA,           NA,           SV,     SV,      Arb,        Arb,          SV,     SV,     SV,     NA,           SV,     SV,            NA,            NA) \
-  ROW(ClipDistance,           Arb,          SV,     NA,           NA,           SV,     SV,      Arb,        Arb,          SV,     SV,     SV,     NA,           SV,     SV,            NA,            NA) \
-  ROW(CullDistance,           Arb,          SV,     NA,           NA,           SV,     SV,      Arb,        Arb,          SV,     SV,     SV,     NA,           SV,     SV,            NA,            NA) \
-  ROW(OutputControlPointID,   NA,           NA,     NA,           NotInSig,     NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NA) \
-  ROW(DomainLocation,         NA,           NA,     NA,           NA,           NA,     NA,      NA,         NotInSig,     NA,     NA,     NA,     NA,           NA,     NA,            NA,            NA) \
-  ROW(PrimitiveID,            NA,           NA,     NotInSig,     NotInSig,     NA,     NA,      NA,         NotInSig,     NA,     NA,     NA,     Shadow,       SGV,    SGV,           NA,            NA) \
-  ROW(GSInstanceID,           NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NotInSig,     NA,     NA,            NA,            NA) \
-  ROW(SampleIndex,            NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     Shadow _41,    NA,            NA) \
-  ROW(IsFrontFace,            NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           SGV,    SGV,           NA,            NA) \
-  ROW(Coverage,               NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NotInSig _50,  NotPacked _41, NA) \
-  ROW(InnerCoverage,          NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NotInSig _50,  NA,            NA) \
-  ROW(Target,                 NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            Target,        NA) \
-  ROW(Depth,                  NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NotPacked,     NA) \
-  ROW(DepthLessEqual,         NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NotPacked _50, NA) \
-  ROW(DepthGreaterEqual,      NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NotPacked _50, NA) \
-  ROW(StencilRef,             NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NotPacked _50, NA) \
-  ROW(DispatchThreadID,       NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NotInSig) \
-  ROW(GroupID,                NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NotInSig) \
-  ROW(GroupIndex,             NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NotInSig) \
-  ROW(GroupThreadID,          NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NA,            NA,            NotInSig) \
-  ROW(TessFactor,             NA,           NA,     NA,           NA,           NA,     NA,      TessFactor, TessFactor,   NA,     NA,     NA,     NA,           NA,     NA,            NA,            NA) \
-  ROW(InsideTessFactor,       NA,           NA,     NA,           NA,           NA,     NA,      TessFactor, TessFactor,   NA,     NA,     NA,     NA,           NA,     NA,            NA,            NA) \
-  ROW(ViewID,                 NotInSig _61, NA,     NotInSig _61, NotInSig _61, NA,     NA,      NA,         NotInSig _61, NA,     NA,     NA,     NotInSig _61, NA,     NotInSig _61,  NA,            NA) \
-  ROW(Barycentrics,           NA,           NA,     NA,           NA,           NA,     NA,      NA,         NA,           NA,     NA,     NA,     NA,           NA,     NotPacked _61, NA,            NA) \
-  ROW(ShadingRate,            NA,           SV _64, NA,           NA,           SV _64, SV _64,  NA,         NA,           SV _64, SV _64, SV _64, NA,           SV _64, SV _64,        NA,            NA)
+  ROW(Arbitrary,              Arb,          Arb,      NA,           NA,           Arb,      Arb,      Arb,        Arb,          Arb,      Arb,      Arb,      NA,           Arb,      Arb,           NA,            NA) \
+  ROW(VertexID,               SV,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA) \
+  ROW(InstanceID,             SV,           Arb,      NA,           NA,           Arb,      Arb,      NA,         NA,           Arb,      Arb,      Arb,      NA,           Arb,      Arb,           NA,            NA) \
+  ROW(Position,               Arb,          SV,       NA,           NA,           SV,       SV,       Arb,        Arb,          SV,       SV,       SV,       NA,           SV,       SV,            NA,            NA) \
+  ROW(RenderTargetArrayIndex, Arb,          SV,       NA,           NA,           SV,       SV,       Arb,        Arb,          SV,       SV,       SV,       NA,           SV,       SV,            NA,            NA) \
+  ROW(ViewPortArrayIndex,     Arb,          SV,       NA,           NA,           SV,       SV,       Arb,        Arb,          SV,       SV,       SV,       NA,           SV,       SV,            NA,            NA) \
+  ROW(ClipDistance,           Arb,          ClipCull, NA,           NA,           ClipCull, ClipCull, Arb,        Arb,          ClipCull, ClipCull, ClipCull, NA,           ClipCull, ClipCull,      NA,            NA) \
+  ROW(CullDistance,           Arb,          ClipCull, NA,           NA,           ClipCull, ClipCull, Arb,        Arb,          ClipCull, ClipCull, ClipCull, NA,           ClipCull, ClipCull,      NA,            NA) \
+  ROW(OutputControlPointID,   NA,           NA,       NA,           NotInSig,     NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA) \
+  ROW(DomainLocation,         NA,           NA,       NA,           NA,           NA,       NA,       NA,         NotInSig,     NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA) \
+  ROW(PrimitiveID,            NA,           NA,       NotInSig,     NotInSig,     NA,       NA,       NA,         NotInSig,     NA,       NA,       NA,       Shadow,       SGV,      SGV,           NA,            NA) \
+  ROW(GSInstanceID,           NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NotInSig,     NA,       NA,            NA,            NA) \
+  ROW(SampleIndex,            NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       Shadow _41,    NA,            NA) \
+  ROW(IsFrontFace,            NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           SGV,      SGV,           NA,            NA) \
+  ROW(Coverage,               NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NotInSig _50,  NotPacked _41, NA) \
+  ROW(InnerCoverage,          NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NotInSig _50,  NA,            NA) \
+  ROW(Target,                 NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            Target,        NA) \
+  ROW(Depth,                  NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NotPacked,     NA) \
+  ROW(DepthLessEqual,         NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NotPacked _50, NA) \
+  ROW(DepthGreaterEqual,      NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NotPacked _50, NA) \
+  ROW(StencilRef,             NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NotPacked _50, NA) \
+  ROW(DispatchThreadID,       NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NotInSig) \
+  ROW(GroupID,                NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NotInSig) \
+  ROW(GroupIndex,             NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NotInSig) \
+  ROW(GroupThreadID,          NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NotInSig) \
+  ROW(TessFactor,             NA,           NA,       NA,           NA,           NA,       NA,       TessFactor, TessFactor,   NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA) \
+  ROW(InsideTessFactor,       NA,           NA,       NA,           NA,           NA,       NA,       TessFactor, TessFactor,   NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA) \
+  ROW(ViewID,                 NotInSig _61, NA,       NotInSig _61, NotInSig _61, NA,       NA,       NA,         NotInSig _61, NA,       NA,       NA,       NotInSig _61, NA,       NotInSig _61,  NA,            NA) \
+  ROW(Barycentrics,           NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NotPacked _61, NA,            NA) \
+  ROW(ShadingRate,            NA,           SV _64,   NA,           NA,           SV _64,   SV _64,   NA,         NA,           SV _64,   SV _64,   SV _64,   NA,           SV _64,   SV _64,        NA,            NA)
 // INTERPRETATION-TABLE:END
 
 const VersionedSemanticInterpretation SigPoint::ms_SemanticInterpretationTable[(unsigned)DXIL::SemanticKind::Invalid][(unsigned)SigPoint::Kind::Invalid] = {

--- a/include/dxc/HLSL/DxilSignatureAllocator.h
+++ b/include/dxc/HLSL/DxilSignatureAllocator.h
@@ -131,6 +131,10 @@ public:
   ConflictType DetectColConflict(const PackElement *SE, unsigned row, unsigned col);
   void PlaceElement(const PackElement *SE, unsigned row, unsigned col);
 
+  // FindNext/PackNext return found/packed location + element rows if found,
+  // otherwise, they return 0.
+  unsigned FindNext(unsigned &foundRow, unsigned &foundCol,
+                    PackElement* SE, unsigned startRow, unsigned numRows, unsigned startCol = 0);
   unsigned PackNext(PackElement* SE, unsigned startRow, unsigned numRows, unsigned startCol = 0);
 
   // Simple greedy in-order packer used by PackOptimized

--- a/include/dxc/HLSL/DxilSignatureAllocator.h
+++ b/include/dxc/HLSL/DxilSignatureAllocator.h
@@ -82,6 +82,7 @@ public:
   static const uint8_t kEFSGV = 1 << 2;
   static const uint8_t kEFSV = 1 << 3;
   static const uint8_t kEFTessFactor = 1 << 4;
+  static const uint8_t kEFClipCull = 1 << 5;
   static const uint8_t kEFConflictsWithIndexed = kEFSGV | kEFSV;
   static uint8_t GetElementFlags(const PackElement *SE);
 

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -4125,7 +4125,8 @@ static void ValidateSignatureElement(DxilSignatureElement &SE,
     }
     // Maximum rows is 1 for system values other than Target
     // with the exception of tessfactors, which are validated in CheckPatchConstantSemantic
-    if (!bIsTessfactor && SE.GetRows() > 1) {
+    // and ClipDistance/CullDistance, which have other custom constraints.
+    if (!bIsTessfactor && !bIsClipCull && SE.GetRows() > 1) {
       ValCtx.EmitSignatureError(&SE, ValidationRule::MetaSystemValueRows);
     }
   }
@@ -4307,7 +4308,8 @@ static void ValidateSignature(ValidationContext &ValCtx, const DxilSignature &S,
     case DXIL::SemanticKind::ClipDistance:
     case DXIL::SemanticKind::CullDistance:
       // Validate max 8 components across 2 rows (registers)
-      clipcullRowSet[streamId].insert(E->GetStartRow());
+      for (unsigned rowIdx = 0; rowIdx < E->GetRows(); rowIdx++)
+        clipcullRowSet[streamId].insert(E->GetStartRow() + rowIdx);
       if (clipcullRowSet[streamId].size() > 2) {
         ValCtx.EmitError(ValidationRule::MetaClipCullMaxRows);
       }

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -326,6 +326,7 @@ void HLSignatureLower::ProcessArgument(Function *func,
     case DXIL::SemanticInterpretationKind::Target:
     case DXIL::SemanticInterpretationKind::TessFactor:
     case DXIL::SemanticInterpretationKind::NotPacked:
+    case DXIL::SemanticInterpretationKind::ClipCull:
       // Will be replaced with load/store intrinsics in
       // GenerateDxilInputsOutputs
       break;

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_optimized %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_ClipDistance          1    yz         1  CLIPDST   float    yz
+// CHECK-NEXT: ; SV_CullDistance          0      w        1  CULLDST   float      w
+// CHECK-NEXT: ; BeforeClipCull           0   x           1     NONE   float   x
+// CHECK-NEXT: ; SV_ClipDistance          0      w        2  CLIPDST   float      w
+// CHECK-NEXT: ; SV_CullDistance          1   xyz         2  CULLDST   float   xyz
+
+struct VS_OUT {
+  float3 first : First;
+  float clip0 : SV_ClipDistance0;
+  float3 cull1 : SV_CullDistance1;
+  float cull0 : SV_CullDistance0;
+  float2 clip1 : SV_ClipDistance1;
+  float withFirst : WithFirst;          // packs with First
+  float afterClipCull : BeforeClipCull; // packed before clip/cull in same row
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt2.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_optimized %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_CullDistance          0      w        1  CULLDST   float      w
+// CHECK-NEXT: ; SV_ClipDistance          1    yz         1  CLIPDST   float    yz
+// CHECK-NEXT: ; BeforeClipCull           0   x           1     NONE   float   x
+// CHECK-NEXT: ; SV_ClipDistance          0   x           2  CLIPDST   float   x
+// CHECK-NEXT: ; SV_ClipDistance          2    yz         2  CLIPDST   float    yz
+
+struct VS_OUT {
+  float3 first : First;
+  float cull0 : SV_CullDistance0;
+  float clip0 : SV_ClipDistance0;
+  float2 clip1[2] : SV_ClipDistance1;
+  float withFirst : WithFirst;          // packs with First
+  float afterClipCull : BeforeClipCull; // packed before clip/cull in same row
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull-opt3.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_optimized %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_CullDistance          0      w        1  CULLDST   float      w
+// CHECK-NEXT: ; SV_CullDistance          1     z         1  CULLDST   float     z
+// CHECK-NEXT: ; SV_ClipDistance          1    y          1  CLIPDST   float    y
+// CHECK-NEXT: ; BeforeClipCull           0   x           1     NONE   float   x
+// CHECK-NEXT: ; SV_CullDistance          2     z         2  CULLDST   float     z
+// CHECK-NEXT: ; SV_ClipDistance          0   x           2  CLIPDST   float   x
+// CHECK-NEXT: ; SV_ClipDistance          2    y          2  CLIPDST   float    y
+// CHECK-NEXT: ; SV_ClipDistance          3      w        2  CLIPDST   float      w
+
+struct VS_OUT {
+  float3 first : First;
+  float cull0 : SV_CullDistance0;
+  float clip0 : SV_ClipDistance0;
+  float clip1[2] : SV_ClipDistance1;
+  float cull1[2] : SV_CullDistance1;
+  float clip3 : SV_ClipDistance3;
+  float withFirst : WithFirst;          // packs with First
+  float afterClipCull : BeforeClipCull; // packed before clip/cull in same row
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_prefix_stable %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_ClipDistance          0   x           1  CLIPDST   float   x
+// CHECK-NEXT: ; SV_CullDistance          1    yzw        1  CULLDST   float    yzw
+// CHECK-NEXT: ; SV_ClipDistance          1    yz         2  CLIPDST   float    yz
+// CHECK-NEXT: ; SV_CullDistance          0   x           2  CULLDST   float   x
+// CHECK-NEXT: ; AfterClipCull            0   x           3     NONE   float   x
+
+struct VS_OUT {
+  float3 first : First;
+  // Clip/Cull reserves row
+  float clip0 : SV_ClipDistance0;
+  float3 cull1 : SV_CullDistance1;
+  float cull0 : SV_CullDistance0;
+  float2 clip1 : SV_ClipDistance1;
+  float withFirst : WithFirst;          // packs with First
+  float afterClipCull : AfterClipCull;  // cannot pack after clip/cull in same row
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull2.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_prefix_stable %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_ClipDistance          0   x           1  CLIPDST   float   x
+// CHECK-NEXT: ; SV_ClipDistance          1      w        1  CLIPDST   float      w
+// CHECK-NEXT: ; SV_CullDistance          1    yz         1  CULLDST   float    yz
+// CHECK-NEXT: ; SV_CullDistance          2    yz         2  CULLDST   float    yz
+// CHECK-NEXT: ; AfterClipCull            0   x           3     NONE   float   x
+
+struct VS_OUT {
+  float3 first : First;
+  // Clip/Cull reserves row
+  float clip0 : SV_ClipDistance0;
+  float2 cull1[2] : SV_CullDistance1;
+  float clip1 : SV_ClipDistance1;
+  float withFirst : WithFirst;          // packs with First
+  float afterClipCull : AfterClipCull;  // cannot pack after clip/cull in same row
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/quick-test/pack-clip-cull3.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -E main -T vs_6_0 -pack_prefix_stable %s | FileCheck %s
+
+// CHECK:      ; Output signature:
+// CHECK:      ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; First                    0   xyz         0     NONE   float   xyz
+// CHECK-NEXT: ; WithFirst                0      w        0     NONE   float      w
+// CHECK-NEXT: ; SV_ClipDistance          0   x           1  CLIPDST   float   x
+// CHECK-NEXT: ; SV_ClipDistance          1      w        1  CLIPDST   float      w
+// CHECK-NEXT: ; SV_CullDistance          1    yz         1  CULLDST   float    yz
+// CHECK-NEXT: ; SV_ClipDistance          2      w        2  CLIPDST   float      w
+// CHECK-NEXT: ; SV_CullDistance          2    yz         2  CULLDST   float    yz
+// CHECK-NEXT: ; AfterClipCull            0   x           3     NONE   float   x
+
+struct VS_OUT {
+  float3 first : First;
+  // Clip/Cull reserves row
+  float clip0 : SV_ClipDistance0;
+  float2 cull1[2] : SV_CullDistance1;   // array works
+  float clip1[2] : SV_ClipDistance1;    // second array works without conflict
+  float withFirst : WithFirst;          // packs with First
+  // AfterClipCull looks like it could pack before clip/cull elements on row 2,
+  // but prefix-stable reserves rows for clip/cull, so it will not pack there.
+  float afterClipCull : AfterClipCull;
+};
+
+
+VS_OUT main() {
+	return (VS_OUT)1.0F;
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1789,6 +1789,7 @@ class db_dxil(object):
             (6, "Target", "Special handling for SV_Target"),
             (7, "TessFactor", "Special handling for tessellation factors"),
             (8, "Shadow", "Shadow element must be added to a signature for compatibility"),
+            (8, "ClipCull", "Special packing rules for SV_ClipDistance or SV_CullDistance"),
             (9, "Invalid", ""),
             ])
         self.enums.append(SemanticInterpretationKind)
@@ -1802,8 +1803,8 @@ class db_dxil(object):
             Position,Arb,SV,NA,NA,SV,SV,Arb,Arb,SV,SV,SV,NA,SV,SV,NA,NA
             RenderTargetArrayIndex,Arb,SV,NA,NA,SV,SV,Arb,Arb,SV,SV,SV,NA,SV,SV,NA,NA
             ViewPortArrayIndex,Arb,SV,NA,NA,SV,SV,Arb,Arb,SV,SV,SV,NA,SV,SV,NA,NA
-            ClipDistance,Arb,SV,NA,NA,SV,SV,Arb,Arb,SV,SV,SV,NA,SV,SV,NA,NA
-            CullDistance,Arb,SV,NA,NA,SV,SV,Arb,Arb,SV,SV,SV,NA,SV,SV,NA,NA
+            ClipDistance,Arb,ClipCull,NA,NA,ClipCull,ClipCull,Arb,Arb,ClipCull,ClipCull,ClipCull,NA,ClipCull,ClipCull,NA,NA
+            CullDistance,Arb,ClipCull,NA,NA,ClipCull,ClipCull,Arb,Arb,ClipCull,ClipCull,ClipCull,NA,ClipCull,ClipCull,NA,NA
             OutputControlPointID,NA,NA,NA,NotInSig,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA
             DomainLocation,NA,NA,NA,NA,NA,NA,NA,NotInSig,NA,NA,NA,NA,NA,NA,NA,NA
             PrimitiveID,NA,NA,NotInSig,NotInSig,NA,NA,NA,NotInSig,NA,NA,NA,Shadow,SGV,SGV,NA,NA


### PR DESCRIPTION
- This approach fixes validation and packing to handle this case.
- fix some issues found in packing related to rowsUsed result from Pack
  functions.  Make these return 0 on failure, instead of startRow.
- Split PackNext into FindNext and PackNext that uses it for greater
  flexibility.
- ensure reserved rows adjacent when multi-row clip/cull element found
  and rows already allocated.
- clean/fix up clip/cull allocation code