### PR TITLE
[spirv] fix no-op matrix type cast bug

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -104,6 +104,10 @@ bool canTreatAsSameScalarType(QualType type1, QualType type2);
 /// regardless of constness and literalness.
 bool isSameScalarOrVecType(QualType type1, QualType type2);
 
+/// \brief Returns true if the two types are the same scalar or vector or matrix
+/// type, regardless of constness and literalness.
+bool isSameScalarOrVecMatType(QualType type1, QualType type2);
+
 /// \brief Returns true if the two types are the same type, regardless of
 /// constness and literalness.
 bool isSameType(const ASTContext &, QualType type1, QualType type2);

--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -104,10 +104,6 @@ bool canTreatAsSameScalarType(QualType type1, QualType type2);
 /// regardless of constness and literalness.
 bool isSameScalarOrVecType(QualType type1, QualType type2);
 
-/// \brief Returns true if the two types are the same scalar or vector or matrix
-/// type, regardless of constness and literalness.
-bool isSameScalarOrVecMatType(QualType type1, QualType type2);
-
 /// \brief Returns true if the two types are the same type, regardless of
 /// constness and literalness.
 bool isSameType(const ASTContext &, QualType type1, QualType type2);

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -624,6 +624,22 @@ bool isSameScalarOrVecType(QualType type1, QualType type2) {
   return false;
 }
 
+bool isSameScalarOrVecMatType(QualType type1, QualType type2) {
+  if (isSameScalarOrVecType(type1, type2))
+    return true;
+
+  { // Matrix types
+    QualType elemType1 = {}, elemType2 = {};
+    uint32_t row1 = 0, row2 = 0, col1 = 0, col2 = 0;
+    if (isMxNMatrix(type1, &elemType1, &row1, &col1) &&
+        isMxNMatrix(type2, &elemType2, &row2, &col2))
+      return row1 == row2 && col1 == col2 &&
+             canTreatAsSameScalarType(elemType1, elemType2);
+  }
+
+  return false;
+}
+
 bool isSameType(const ASTContext &astContext, QualType type1, QualType type2) {
   if (isSameScalarOrVecType(type1, type2))
     return true;

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -624,22 +624,6 @@ bool isSameScalarOrVecType(QualType type1, QualType type2) {
   return false;
 }
 
-bool isSameScalarOrVecMatType(QualType type1, QualType type2) {
-  if (isSameScalarOrVecType(type1, type2))
-    return true;
-
-  { // Matrix types
-    QualType elemType1 = {}, elemType2 = {};
-    uint32_t row1 = 0, row2 = 0, col1 = 0, col2 = 0;
-    if (isMxNMatrix(type1, &elemType1, &row1, &col1) &&
-        isMxNMatrix(type2, &elemType2, &row2, &col2))
-      return row1 == row2 && col1 == col2 &&
-             canTreatAsSameScalarType(elemType1, elemType2);
-  }
-
-  return false;
-}
-
 bool isSameType(const ASTContext &astContext, QualType type1, QualType type2) {
   if (isSameScalarOrVecType(type1, type2))
     return true;

--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -308,16 +308,28 @@ InitListHandler::createInitForMatrixType(QualType matrixType,
 
     auto *init = initializers.back();
 
-    if (hlsl::IsHLSLMatType(init->getAstResultType())) {
-      uint32_t initRowCount = 0, initColCount = 0;
-      hlsl::GetHLSLMatRowColCount(init->getAstResultType(), initRowCount,
-                                  initColCount);
-
+    QualType initElemType;
+    uint32_t initRowCount = 0, initColCount = 0;
+    if (isMxNMatrix(init->getAstResultType(), &initElemType, &initRowCount,
+                    &initColCount)) {
       if (rowCount == initRowCount && colCount == initColCount) {
         initializers.pop_back();
         // TODO: We only support FP matrices now. Do type cast here after
         // adding more matrix types.
-        return init;
+        if (isSameScalarOrVecType(initElemType, elemType))
+          return init;
+
+        const QualType initVecType =
+            astContext.getExtVectorType(initElemType, colCount);
+        llvm::SmallVector<SpirvInstruction *, 4> vectors;
+        for (uint32_t i = 0; i < rowCount; ++i) {
+          auto *inst =
+              spvBuilder.createCompositeExtract(initVecType, init, {i});
+          const auto vecType = astContext.getExtVectorType(elemType, colCount);
+          vectors.push_back(
+              theEmitter.castToType(inst, initVecType, vecType, srcLoc));
+        }
+        return spvBuilder.createCompositeConstruct(matrixType, vectors);
       }
     }
   }

--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -312,9 +312,6 @@ InitListHandler::createInitForMatrixType(QualType matrixType,
       uint32_t initRowCount = 0, initColCount = 0;
       hlsl::GetHLSLMatRowColCount(init->getAstResultType(), initRowCount,
                                   initColCount);
-      const QualType initElemType =
-          hlsl::GetHLSLMatElementType(init->getAstResultType());
-
       if (rowCount == initRowCount && colCount == initColCount) {
         initializers.pop_back();
         return theEmitter.castToType(init, init->getAstResultType(), matrixType,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -945,17 +945,17 @@ bool SpirvEmitter::loadIfAliasVarRef(const Expr *varExpr,
 SpirvInstruction *SpirvEmitter::castToType(SpirvInstruction *value,
                                            QualType fromType, QualType toType,
                                            SourceLocation srcLoc) {
-  if (isFloatOrVecOfFloatType(toType))
+  if (isFloatOrVecMatOfFloatType(toType))
     return castToFloat(value, fromType, toType, srcLoc);
 
   // Order matters here. Bool (vector) values will also be considered as uint
   // (vector) values. So given a bool (vector) argument, isUintOrVecOfUintType()
   // will also return true. We need to check bool before uint. The opposite is
   // not true.
-  if (isBoolOrVecOfBoolType(toType))
+  if (isBoolOrVecMatOfBoolType(toType))
     return castToBool(value, fromType, toType);
 
-  if (isSintOrVecOfSintType(toType) || isUintOrVecOfUintType(toType))
+  if (isSintOrVecMatOfSintType(toType) || isUintOrVecMatOfUintType(toType))
     return castToInt(value, fromType, toType, srcLoc);
 
   emitError("casting to type %0 unimplemented", {}) << toType;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -6117,7 +6117,7 @@ SpirvInstruction *SpirvEmitter::turnIntoElementPtr(
 SpirvInstruction *SpirvEmitter::castToBool(SpirvInstruction *fromVal,
                                            QualType fromType,
                                            QualType toBoolType) {
-  if (isSameScalarOrVecType(fromType, toBoolType))
+  if (isSameScalarOrVecMatType(fromType, toBoolType))
     return fromVal;
 
   { // Special case handling for converting to a matrix of booleans.
@@ -6147,7 +6147,7 @@ SpirvInstruction *SpirvEmitter::castToBool(SpirvInstruction *fromVal,
 SpirvInstruction *SpirvEmitter::castToInt(SpirvInstruction *fromVal,
                                           QualType fromType, QualType toIntType,
                                           SourceLocation srcLoc) {
-  if (isSameScalarOrVecType(fromType, toIntType))
+  if (isSameScalarOrVecMatType(fromType, toIntType))
     return fromVal;
 
   if (isBoolOrVecOfBoolType(fromType)) {
@@ -6254,7 +6254,7 @@ SpirvInstruction *SpirvEmitter::castToFloat(SpirvInstruction *fromVal,
                                             QualType fromType,
                                             QualType toFloatType,
                                             SourceLocation srcLoc) {
-  if (isSameScalarOrVecType(fromType, toFloatType))
+  if (isSameScalarOrVecMatType(fromType, toFloatType))
     return fromVal;
 
   if (isBoolOrVecOfBoolType(fromType)) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -6117,7 +6117,7 @@ SpirvInstruction *SpirvEmitter::turnIntoElementPtr(
 SpirvInstruction *SpirvEmitter::castToBool(SpirvInstruction *fromVal,
                                            QualType fromType,
                                            QualType toBoolType) {
-  if (isSameScalarOrVecMatType(fromType, toBoolType))
+  if (isSameType(astContext, fromType, toBoolType))
     return fromVal;
 
   { // Special case handling for converting to a matrix of booleans.
@@ -6147,7 +6147,7 @@ SpirvInstruction *SpirvEmitter::castToBool(SpirvInstruction *fromVal,
 SpirvInstruction *SpirvEmitter::castToInt(SpirvInstruction *fromVal,
                                           QualType fromType, QualType toIntType,
                                           SourceLocation srcLoc) {
-  if (isSameScalarOrVecMatType(fromType, toIntType))
+  if (isSameType(astContext, fromType, toIntType))
     return fromVal;
 
   if (isBoolOrVecOfBoolType(fromType)) {
@@ -6254,7 +6254,7 @@ SpirvInstruction *SpirvEmitter::castToFloat(SpirvInstruction *fromVal,
                                             QualType fromType,
                                             QualType toFloatType,
                                             SourceLocation srcLoc) {
-  if (isSameScalarOrVecMatType(fromType, toFloatType))
+  if (isSameType(astContext, fromType, toFloatType))
     return fromVal;
 
   if (isBoolOrVecOfBoolType(fromType)) {

--- a/tools/clang/test/CodeGenSPIRV/cast.no-op.matrix.float-to-int.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.no-op.matrix.float-to-int.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T ps_6_0 -E main
+
+void main() {
+  float2x2 a;
+  int4 b;
+
+// CHECK:        [[a:%\d+]] = OpLoad %mat2v2float %a
+// CHECK-NEXT: [[a_0:%\d+]] = OpCompositeExtract %v2float [[a]] 0
+// CHECK-NEXT: [[a_0:%\d+]] = OpConvertFToS %v2int [[a_0]]
+// CHECK-NEXT: [[a_1:%\d+]] = OpCompositeExtract %v2float [[a]] 1
+// CHECK-NEXT: [[a_1:%\d+]] = OpConvertFToS %v2int [[a_1]]
+// CHECK-NEXT:   [[a:%\d+]] = OpCompositeConstruct %_arr_v2int_uint_2 [[a_0]] [[a_1]]
+  b.zw = mul(int2x2(a), b.yx);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -382,6 +382,9 @@ TEST_F(FileTest, OpTextureSampleAccess) {
 
 // For casting
 TEST_F(FileTest, CastNoOp) { runFileTest("cast.no-op.hlsl"); }
+TEST_F(FileTest, CastNoOpMatrixFloatToInt) {
+  runFileTest("cast.no-op.matrix.float-to-int.hlsl");
+}
 TEST_F(FileTest, CastImplicit2Bool) { runFileTest("cast.2bool.implicit.hlsl"); }
 TEST_F(FileTest, CastExplicit2Bool) { runFileTest("cast.2bool.explicit.hlsl"); }
 TEST_F(FileTest, CastImplicit2SInt) { runFileTest("cast.2sint.implicit.hlsl"); }


### PR DESCRIPTION
Type cast float2x2 to int2x2 causes a validation error when emitting
SPIR-V. This CL fixes it by adding type conversion in InitListHandler.