### PR TITLE
Fix allocator mismatch with CompileWithDebug output string

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -342,7 +342,7 @@ public:
     HRESULT hr = S_OK;
     CComPtr<IDxcBlobEncoding> utf8Source;
     CComPtr<AbstractMemoryStream> pOutputStream;
-    CHeapPtr<wchar_t> DebugBlobName;
+    CComHeapPtr<wchar_t> DebugBlobName;
 
     DxcEtw_DXCompilerCompile_Start();
     pSourceName = (pSourceName && *pSourceName) ? pSourceName : L"hlsl.hlsl"; // declared optional, so pick a default


### PR DESCRIPTION
We declare `CHeapPtr<wchar_t> DebugBlobName;`, where `CHeapPtr` uses the `CCRTAllocator` by default, but initialize it with: `Unicode::UTF8BufferToUTF16ComHeap(pDebugName, &DebugBlobName)`, which uses `CComHeapPtr<wchar_t> p;`

If we don't hit any exceptions, things are fine because we end up doing: `*ppDebugBlobName = DebugBlobName.Detach();` , so the destructor will be a no-op.