### PR TITLE
Add -Qembed_debug, don't embed debug info by default

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -150,6 +150,7 @@ public:
   bool DisplayIncludeProcess = false; // OPT__vi
   bool RecompileFromBinary = false; // OPT _Recompile (Recompiling the DXBC binary file not .hlsl file)
   bool StripDebug = false; // OPT Qstrip_debug
+  bool EmbedDebug = false; // OPT Qembed_debug
   bool StripRootSignature = false; // OPT_Qstrip_rootsignature
   bool StripPrivate = false; // OPT_Qstrip_priv
   bool StripReflection = false; // OPT_Qstrip_reflect
@@ -166,6 +167,13 @@ public:
 
   bool IsRootSignatureProfile();
   bool IsLibraryProfile();
+
+  // Helpers to clarify interpretation of flags for behavior in implementation
+  bool IsDebugInfoEnabled();    // Zi
+  bool EmbedDebugInfo();        // Qembed_debug
+  bool EmbedPDBName();          // Zi or Fd
+  bool DebugFileIsDirectory();  // Fd ends in '\\'
+  llvm::StringRef GetPDBName(); // Fd name
 
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -330,7 +330,9 @@ def Fc : JoinedOrSeparate<["-", "/"], "Fc">, MetaVarName<"<file>">, HelpText<"Ou
 //def Fx : JoinedOrSeparate<["-", "/"], "Fx">, MetaVarName<"<file>">, HelpText<"Output assembly code and hex listing file">;
 def Fh : JoinedOrSeparate<["-", "/"], "Fh">, MetaVarName<"<file>">, HelpText<"Output header file containing object code">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 def Fe : JoinedOrSeparate<["-", "/"], "Fe">, MetaVarName<"<file>">, HelpText<"Output warnings and errors to the given file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
-def Fd : JoinedOrSeparate<["-", "/"], "Fd">, MetaVarName<"<file>">, HelpText<"Write debug information to the given file or directory; trail \\ to auto-generate and imply Qstrip_priv">, Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
+def Fd : JoinedOrSeparate<["-", "/"], "Fd">, MetaVarName<"<file>">,
+  HelpText<"Write debug information to the given file, or automatically named file in directory when ending in '\\'">,
+  Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
 def Vn : JoinedOrSeparate<["-", "/"], "Vn">, MetaVarName<"<name>">, HelpText<"Use <name> as variable name in header file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 def Cc : Flag<["-", "/"], "Cc">, HelpText<"Output color coded assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;
 def Ni : Flag<["-", "/"], "Ni">, HelpText<"Output instruction numbers in assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;
@@ -349,6 +351,8 @@ def Qstrip_reflect : Flag<["-", "/"], "Qstrip_reflect">, Flags<[DriverOption]>, 
   HelpText<"Strip reflection data from shader bytecode  (must be used with /Fo <file>)">;
 def Qstrip_debug : Flag<["-", "/"], "Qstrip_debug">, Flags<[CoreOption]>, Group<hlslutil_Group>,
   HelpText<"Strip debug information from 4_0+ shader bytecode  (must be used with /Fo <file>)">;
+def Qembed_debug : Flag<["-", "/"], "Qembed_debug">, Flags<[CoreOption]>, Group<hlslutil_Group>,
+  HelpText<"Embed PDB in shader container (must be used with /Zi)">;
 def Qstrip_priv : Flag<["-", "/"], "Qstrip_priv">, Flags<[DriverOption]>, Group<hlslutil_Group>,
   HelpText<"Strip private data from shader bytecode  (must be used with /Fo <file>)">;
 

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1565,10 +1565,6 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
 
   // If we have debug information present, serialize it to a debug part, then use the stripped version as the canonical program version.
   CComPtr<AbstractMemoryStream> pProgramStream = pInputProgramStream;
-  const uint32_t DebugInfoNameHashLen = 32;   // 32 chars of MD5
-  const uint32_t DebugInfoNameSuffix = 4;     // '.lld'
-  const uint32_t DebugInfoNameNullAndPad = 4; // '\0\0\0\0'
-  CComPtr<AbstractMemoryStream> pHashStream;
   if (HasDebugInfo(*pModule->GetModule())) {
     uint32_t debugInUInt32, debugPaddingBytes;
     GetPaddedProgramPartSize(pInputProgramStream, debugInUInt32, debugPaddingBytes);
@@ -1586,63 +1582,56 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
     IFT(CreateMemoryStream(DxcGetThreadMallocNoRef(), &pProgramStream));
     raw_stream_ostream outStream(pProgramStream.p);
     WriteBitcodeToFile(pModule->GetModule(), outStream, true);
+  } else {
+    // If no debug info, clear DebugNameDependOnSource
+    // (it's default, and this scenario can happen)
+    Flags &= ~SerializeDxilFlags::DebugNameDependOnSource;
+  }
 
-    if (Flags & SerializeDxilFlags::IncludeDebugNamePart) {
+  // Serialize debug name if requested.
+  CComPtr<AbstractMemoryStream> pHashStream;
+  std::string DebugNameStr; // Used if constructing name based on hash
+  if (Flags & SerializeDxilFlags::IncludeDebugNamePart) {
+    if (DebugName.empty()) {
       // If the debug name should be specific to the sources, base the name on the debug
       // bitcode, which will include the source references, line numbers, etc. Otherwise,
       // do it exclusively on the target shader bitcode.
-
       pHashStream = (int)(Flags & SerializeDxilFlags::DebugNameDependOnSource)
-                        ? CComPtr<AbstractMemoryStream>(pModuleBitcode)
-                        : CComPtr<AbstractMemoryStream>(pProgramStream);
+                      ? CComPtr<AbstractMemoryStream>(pModuleBitcode)
+                      : CComPtr<AbstractMemoryStream>(pProgramStream);
 
-      // Use user specified debug name if a) it's given and b) it's not a path
-      bool UseDebugName = DebugName.size() && !DebugName.endswith(llvm::StringRef("\\"));
-
-      // Calculate the length of the name
-      const uint32_t NameLen = UseDebugName ? 
-        DebugName.size() :
-        DebugInfoNameHashLen +  DebugInfoNameSuffix;
-
-      // Calculate the size of the blob part.
-      const uint32_t DebugInfoContentLen =
-          sizeof(DxilShaderDebugName) + NameLen + DebugInfoNameNullAndPad;
-
-      writer.AddPart(DFCC_ShaderDebugName, DebugInfoContentLen,
-        [DebugInfoNameSuffix, DebugInfoNameHashLen, UseDebugName, DebugName, pHashStream]
-        (AbstractMemoryStream *pStream)
-      {
-        DxilShaderDebugName NameContent;
-        NameContent.Flags = 0;
-
-        if (UseDebugName) {
-          NameContent.NameLength = DebugName.size();
-          IFT(WriteStreamValue(pStream, NameContent));
-
-          ULONG cbWritten;
-          IFT(pStream->Write(DebugName.begin(), DebugName.size(), &cbWritten));
-          const char Pad[] = { '\0','\0','\0','\0' };
-          IFT(pStream->Write(Pad, _countof(Pad), &cbWritten));
-        }
-        else {
-          NameContent.NameLength = DebugInfoNameHashLen + DebugInfoNameSuffix;
-          IFT(WriteStreamValue(pStream, NameContent));
-
-          ArrayRef<uint8_t> Data((uint8_t *)pHashStream->GetPtr(), pHashStream->GetPtrSize());
-          llvm::MD5 md5;
-          llvm::MD5::MD5Result md5Result;
-          SmallString<32> Hash;
-          md5.update(Data);
-          md5.final(md5Result);
-          md5.stringifyResult(md5Result, Hash);
-
-          ULONG cbWritten;
-          IFT(pStream->Write(Hash.data(), Hash.size(), &cbWritten));
-          const char SuffixAndPad[] = { '.','l','l','d','\0','\0','\0','\0' };
-          IFT(pStream->Write(SuffixAndPad, _countof(SuffixAndPad), &cbWritten));
-        }
-      });
+      ArrayRef<uint8_t> Data((uint8_t *)pHashStream->GetPtr(), pHashStream->GetPtrSize());
+      llvm::MD5 md5;
+      llvm::MD5::MD5Result md5Result;
+      SmallString<32> Hash;
+      md5.update(Data);
+      md5.final(md5Result);
+      md5.stringifyResult(md5Result, Hash);
+      DebugNameStr += Hash;
+      DebugNameStr += ".lld";
+      DebugName = DebugNameStr;
     }
+
+    // Calculate the size of the blob part.
+    const uint32_t DebugInfoContentLen = PSVALIGN4(
+        sizeof(DxilShaderDebugName) + DebugName.size() + 1); // 1 for null
+
+    writer.AddPart(DFCC_ShaderDebugName, DebugInfoContentLen,
+      [DebugName]
+      (AbstractMemoryStream *pStream)
+    {
+      DxilShaderDebugName NameContent;
+      NameContent.Flags = 0;
+      NameContent.NameLength = DebugName.size();
+      IFT(WriteStreamValue(pStream, NameContent));
+
+      ULONG cbWritten;
+      IFT(pStream->Write(DebugName.begin(), DebugName.size(), &cbWritten));
+      const char Pad[] = { '\0','\0','\0','\0' };
+      // Always writes at least one null to align size
+      unsigned padLen = (4 - ((sizeof(DxilShaderDebugName) + cbWritten) & 0x3));
+      IFT(pStream->Write(Pad, padLen, &cbWritten));
+    });
   }
 
   // Compute padded bitcode size.

--- a/tools/clang/tools/dxc/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxc/dxclib/dxc.cpp
@@ -150,7 +150,10 @@ public:
   }
 
   int  Compile();
-  void Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary, IDxcCompiler *pCompiler, std::vector<LPCWSTR> &args, IDxcOperationResult **pCompileResult);
+  void Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary,
+                 IDxcCompiler *pCompiler, std::vector<LPCWSTR> &args,
+                 std::wstring &outputPDBPath, CComPtr<IDxcBlob> &pDebugBlob,
+                 IDxcOperationResult **pCompileResult);
   int DumpBinary();
   void Preprocess();
   void GetCompilerVersionInfo(llvm::raw_string_ostream &OS);
@@ -223,13 +226,12 @@ int DxcContext::ActOnBlob(IDxcBlob *pBlob, IDxcBlob *pDebugBlob, LPCWSTR pDebugB
       "found in the shader, please use the "
       "/Zi switch to generate debug "
       "information compiling this shader.");
-
     if (pDebugBlob != nullptr) {
       IFTBOOLMSG(pDebugBlobName && *pDebugBlobName, E_INVALIDARG,
         "/Fd was specified but no debug name was produced");
       WriteBlobToFile(pDebugBlob, pDebugBlobName);
-    }
-    else {
+    } else {
+      // Note: This is for load from binary case
       WritePartToFile(pBlob, hlsl::DFCC_ShaderDebugInfoDXIL, m_Opts.DebugFile);
     }
   }
@@ -542,7 +544,11 @@ public:
   }
 };
 
-void DxcContext::Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary, IDxcCompiler *pCompiler, std::vector<LPCWSTR> &args, IDxcOperationResult **ppCompileResult) {
+void DxcContext::Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary,
+                           IDxcCompiler *pCompiler, std::vector<LPCWSTR> &args,
+                           std::wstring &outputPDBPath,
+                           CComPtr<IDxcBlob> &pDebugBlob,
+                           IDxcOperationResult **ppCompileResult) {
 // Recompile currently only supported on Windows
 #ifdef _WIN32
   CComPtr<IDxcBlob> pTargetBlob;
@@ -689,11 +695,28 @@ void DxcContext::Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary, IDxcCompile
   }
 
   CComPtr<IDxcOperationResult> pResult;
-  IFT(pCompiler->Compile(pCompileSource, pMainFileName,
-    StringRefUtf16(EntryPoint),
-    StringRefUtf16(TargetProfile), ConcatArgs.data(),
-    ConcatArgs.size(), ConcatDefines.data(),
-    ConcatDefines.size(), pIncludeHandler, &pResult));
+
+  if (!m_Opts.DebugFile.empty()) {
+    CComPtr<IDxcCompiler2> pCompiler2;
+    CComHeapPtr<WCHAR> pDebugName;
+    Unicode::UTF8ToUTF16String(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
+    IFT(pCompiler->QueryInterface(&pCompiler2));
+    IFT(pCompiler2->CompileWithDebug(
+        pCompileSource, pMainFileName, StringRefUtf16(EntryPoint),
+        StringRefUtf16(TargetProfile), ConcatArgs.data(), ConcatArgs.size(),
+        ConcatDefines.data(), ConcatDefines.size(), pIncludeHandler, &pResult,
+        &pDebugName, &pDebugBlob));
+    if (pDebugName.m_pData && m_Opts.DebugFileIsDirectory()) {
+      outputPDBPath += pDebugName.m_pData;
+    }
+  } else {
+    IFT(pCompiler->Compile(pCompileSource, pMainFileName,
+      StringRefUtf16(EntryPoint),
+      StringRefUtf16(TargetProfile), ConcatArgs.data(),
+      ConcatArgs.size(), ConcatDefines.data(),
+      ConcatDefines.size(), pIncludeHandler, &pResult));
+  }
+
   *ppCompileResult = pResult.Detach();
 #else
   assert(false && "Recompile is currently only supported on Windows.");
@@ -705,7 +728,7 @@ int DxcContext::Compile() {
   CComPtr<IDxcCompiler> pCompiler;
   CComPtr<IDxcOperationResult> pCompileResult;
   CComPtr<IDxcBlob> pDebugBlob;
-  std::wstring debugName;
+  std::wstring outputPDBPath;
   {
     CComPtr<IDxcBlobEncoding> pSource;
 
@@ -727,9 +750,9 @@ int DxcContext::Compile() {
     IFTARG(pSource->GetBufferSize() >= 4);
 
     if (m_Opts.RecompileFromBinary) {
-      Recompile(pSource, pLibrary, pCompiler, args, &pCompileResult);
-    }
-    else {
+      Recompile(pSource, pLibrary, pCompiler, args, outputPDBPath, pDebugBlob,
+                &pCompileResult);
+    } else {
       CComPtr<IDxcIncludeHandler> pIncludeHandler;
       IFT(pLibrary->CreateIncludeHandler(&pIncludeHandler));
 
@@ -744,10 +767,10 @@ int DxcContext::Compile() {
         }
       }
 
-      if (!m_Opts.DebugFile.empty() && m_Opts.DebugFile.endswith(llvm::StringRef("\\"))) {
-        args.push_back(L"/Qstrip_debug"); // implied
+      if (!m_Opts.DebugFile.empty()) {
         CComPtr<IDxcCompiler2> pCompiler2;
         CComHeapPtr<WCHAR> pDebugName;
+        Unicode::UTF8ToUTF16String(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
         IFT(pCompiler.QueryInterface(&pCompiler2));
         IFT(pCompiler2->CompileWithDebug(
             pSource, StringRefUtf16(m_Opts.InputFile),
@@ -755,9 +778,8 @@ int DxcContext::Compile() {
             args.data(), args.size(), m_Opts.Defines.data(),
             m_Opts.Defines.size(), pIncludeHandler, &pCompileResult,
             &pDebugName, &pDebugBlob));
-        if (pDebugName.m_pData) {
-          Unicode::UTF8ToUTF16String(m_Opts.DebugFile.str().c_str(), &debugName);
-          debugName += pDebugName.m_pData;
+        if (pDebugName.m_pData && m_Opts.DebugFileIsDirectory()) {
+          outputPDBPath += pDebugName.m_pData;
         }
       } else {
         IFT(pCompiler->Compile(pSource, StringRefUtf16(m_Opts.InputFile),
@@ -766,6 +788,13 @@ int DxcContext::Compile() {
           args.size(), m_Opts.Defines.data(),
           m_Opts.Defines.size(), pIncludeHandler, &pCompileResult));
       }
+    }
+
+    // When compiling we don't embed debug info if options don't ask for it.
+    // If user specified /Qstrip_debug, remove from m_Opts now so we don't
+    // try to modify the container to strip debug info that isn't there.
+    if (!m_Opts.EmbedDebugInfo()) {
+      m_Opts.StripDebug = false;
     }
   }
 
@@ -786,7 +815,7 @@ int DxcContext::Compile() {
     pCompiler.Release();
     pCompileResult.Release();
     if (pProgram.p != nullptr) {
-      ActOnBlob(pProgram.p, pDebugBlob, debugName.c_str());
+      ActOnBlob(pProgram.p, pDebugBlob, outputPDBPath.c_str());
     }
   }
   return status;

--- a/tools/clang/tools/dxcompiler/dxcassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcassembler.cpp
@@ -32,6 +32,17 @@ using namespace hlsl;
 // This declaration is used for the locally-linked validator.
 HRESULT CreateDxcValidator(_In_ REFIID riid, _Out_ LPVOID *ppv);
 
+static bool HasDebugInfo(const Module &M) {
+  for (Module::const_named_metadata_iterator NMI = M.named_metadata_begin(),
+                                             NME = M.named_metadata_end();
+       NMI != NME; ++NMI) {
+    if (NMI->getName().startswith("llvm.dbg.")) {
+      return true;
+    }
+  }
+  return false;
+}
+
 class DxcAssembler : public IDxcAssembler {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()      
@@ -130,9 +141,12 @@ HRESULT STDMETHODCALLTYPE DxcAssembler::AssembleToContainer(
     outStream.flush();
 
     CComPtr<IDxcBlob> pResultBlob;
-    static constexpr hlsl::SerializeDxilFlags flags = static_cast<hlsl::SerializeDxilFlags>(
-        static_cast<uint32_t>(SerializeDxilFlags::IncludeDebugNamePart) |
-        static_cast<uint32_t>(SerializeDxilFlags::IncludeDebugInfoPart));
+    hlsl::SerializeDxilFlags flags = hlsl::SerializeDxilFlags::None;
+    if (HasDebugInfo(*M)) {
+      flags |= SerializeDxilFlags::IncludeDebugInfoPart;
+      flags |= SerializeDxilFlags::IncludeDebugNamePart;
+      flags |= SerializeDxilFlags::DebugNameDependOnSource;
+    }
     dxcutil::AssembleToContainer(std::move(M), pResultBlob,
                                          TM.p, flags,
                                          pOutputStream);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -576,10 +576,13 @@ public:
         if (opts.EmbedPDBName()) {
           SerializeFlags |= SerializeDxilFlags::IncludeDebugNamePart;
         }
-        // If -Qembed_debug specified, or if there is no output pointer
-        // for the debug blob (such as when called by Compile()),
-        // embed the debug info.
-        if (opts.EmbedDebugInfo() || (opts.DebugInfo && !ppDebugBlob)) {
+        // If -Qembed_debug specified, embed the debug info.
+        // Or, if there is no output pointer for the debug blob (such as when called by Compile()),
+        // embed the debug info and emit a note.
+        if (opts.EmbedDebugInfo()) {
+          SerializeFlags |= SerializeDxilFlags::IncludeDebugInfoPart;
+        } else if (opts.DebugInfo && !ppDebugBlob) {
+          w << "warning: no output provided for debug - embedding PDB in shader container.  Use -Qembed_debug to silence this warning.\n";
           SerializeFlags |= SerializeDxilFlags::IncludeDebugInfoPart;
         }
         if (opts.DebugNameForSource) {

--- a/tools/clang/tools/libclang/CMakeLists.txt
+++ b/tools/clang/tools/libclang/CMakeLists.txt
@@ -184,6 +184,8 @@ if(ENABLE_SHARED)
 endif()
 endif() # HLSL Change
 
+add_dependencies(libclang TablegenHLSLOptions)  # HLSL Change
+
 # HLSL Change Starts
 # add_clang_library(${LIBCLANG_STATIC_TARGET_NAME} STATIC ${SOURCES})
 # target_link_libraries(${LIBCLANG_STATIC_TARGET_NAME} ${LIBS})

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -830,7 +830,7 @@ public:
 
     VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
     CreateBlobFromText(hlsl, &pSource);
-    LPCWSTR args[] = { L"/Zi" };
+    LPCWSTR args[] = { L"/Zi", L"/Qembed_debug" };
     VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
       L"ps_6_0", args, _countof(args), nullptr, 0, nullptr, &pResult));
     VERIFY_SUCCEEDED(pResult->GetResult(&pProgram));
@@ -1255,7 +1255,7 @@ TEST_F(CompilerTest, CompileWhenDebugWorksThenStripDebug) {
                      "  return local;\r\n"
                      "}",
                      &pSource);
-  LPCWSTR args[] = {L"/Zi"};
+  LPCWSTR args[] = {L"/Zi", L"/Qembed_debug"};
 
   VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
                                       L"ps_6_0", args, _countof(args), nullptr,
@@ -1352,7 +1352,7 @@ TEST_F(CompilerTest, CompileThenAddCustomDebugName) {
     "}",
     &pSource);
 
-  LPCWSTR args[] = { L"/Zi", L"/Zss" };
+  LPCWSTR args[] = { L"/Zi", L"/Qembed_debug", L"/Zss" };
 
   VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
     L"ps_6_0", args, _countof(args), nullptr, 0,
@@ -2266,8 +2266,11 @@ static void CompileTestAndLoadDia(dxc::DxcDllSupport &dllSupport, IDiaDataSource
   CComPtr<IDxcLibrary> pLib;
   CComPtr<IDxcContainerReflection> pReflection;
   UINT32 index;
+  std::vector<LPCWSTR> args;
+  args.push_back(L"/Zi");
+  args.push_back(L"/Qembed_debug");
 
-  VerifyCompileOK(dllSupport, EmptyCompute, L"cs_6_0", L"/Zi", &pContainer);
+  VerifyCompileOK(dllSupport, EmptyCompute, L"cs_6_0", args, &pContainer);
   VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcLibrary, &pLib));
   VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcContainerReflection, &pReflection));
   VERIFY_SUCCEEDED(pReflection->Load(pContainer));

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -522,9 +522,9 @@ bool DxilContainerTest::InitSupport() {
 TEST_F(DxilContainerTest, CompileWhenDebugSourceThenSourceMatters) {
   char program1[] = "float4 main() : SV_Target { return 0; }";
   char program2[] = "  float4 main() : SV_Target { return 0; }  ";
-  LPCWSTR Zi[] = { L"/Zi" };
-  LPCWSTR ZiZss[] = { L"/Zi", L"/Zss" };
-  LPCWSTR ZiZsb[] = { L"/Zi", L"/Zsb" };
+  LPCWSTR Zi[] = { L"/Zi", L"/Qembed_debug" };
+  LPCWSTR ZiZss[] = { L"/Zi", L"/Qembed_debug", L"/Zss" };
+  LPCWSTR ZiZsb[] = { L"/Zi", L"/Qembed_debug", L"/Zsb" };
   
   // No debug info, no debug name...
   std::string noName = CompileToDebugName(program1, L"main", L"ps_6_0", nullptr, 0);
@@ -1497,11 +1497,12 @@ TEST_F(DxilContainerTest, DxilContainerUnitTest) {
   CComPtr<IDxcOperationResult> pResult;
   std::vector<LPCWSTR> arguments;
   arguments.emplace_back(L"/Zi");
+  arguments.emplace_back(L"/Qembed_debug");
   
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
   CreateBlobFromText("float4 main() : SV_Target { return 0; }", &pSource);
   // Test DxilContainer with ShaderDebugInfoDXIL
-  VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"hlsl.hlsl", L"main", L"ps_6_0", arguments.data(), 1, nullptr, 0, nullptr, &pResult));
+  VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"hlsl.hlsl", L"main", L"ps_6_0", arguments.data(), arguments.size(), nullptr, 0, nullptr, &pResult));
   VERIFY_SUCCEEDED(pResult->GetResult(&pProgram));
   
   const hlsl::DxilContainerHeader *pHeader = static_cast<const hlsl::DxilContainerHeader *> (pProgram->GetBufferPointer());


### PR DESCRIPTION
- New -Qembed_debug is required to embed PDB in shader container
- -Zi used without -Qembed_debug will not embed debug info by
  default unless there's no separate debug output location, in which
  case it embeds and issues a warning.  This is the case when using
  the Compile() method.
- In dxc and CompileWithDebug() -Fd implies -Qstrip_debug
- Debug name is based on -Fd, unless path ends with '\', meaning you
  want auto-naming and file written under the specified directory
- Debug name always embedded when debug info used, or -Fd used
- -Fd without -Zi just embeds debug name for CompileWithDebug(),
  still error with dxc, since it can't write to your file.
- If not embedding debug info, it doesn't get written to the container,
  only to be stripped out again.
- Fix padding for alignment in DebugName part.
- Default to DebugNameForBinary instead of DebugNameForSource if no
  DebugInfo enabled

- Also fixed missing dependency on table gen options from libclang