### PR TITLE
Remove malloc usages in favor of operator new

### DIFF
--- a/include/llvm/ADT/SmallVector.h
+++ b/include/llvm/ADT/SmallVector.h
@@ -248,7 +248,7 @@ void SmallVectorTemplateBase<T, isPodLike>::grow(size_t MinSize) {
   size_t NewCapacity = size_t(NextPowerOf2(CurCapacity+2));
   if (NewCapacity < MinSize)
     NewCapacity = MinSize;
-  T *NewElts = static_cast<T*>(malloc(NewCapacity*sizeof(T)));
+  T *NewElts = (T*)new char[NewCapacity*sizeof(T)]; // HLSL Change: Use overridable operator new
 
   // Move the elements over.
   this->uninitialized_move(this->begin(), this->end(), NewElts);
@@ -258,7 +258,7 @@ void SmallVectorTemplateBase<T, isPodLike>::grow(size_t MinSize) {
 
   // If this wasn't grown from the inline copy, deallocate the old space.
   if (!this->isSmall())
-    free(this->begin());
+    delete[] (char*)this->begin(); // HLSL Change: Use overridable operator delete
 
   this->setEnd(NewElts+CurSize);
   this->BeginX = NewElts;
@@ -364,7 +364,7 @@ public:
 
     // If this wasn't grown from the inline copy, deallocate the old space.
     if (!this->isSmall())
-      free(this->begin());
+      delete[] (char*)this->begin(); // HLSL Change: Use overridable operator delete
   }
 
 
@@ -784,7 +784,7 @@ SmallVectorImpl<T> &SmallVectorImpl<T>::operator=(SmallVectorImpl<T> &&RHS) {
   // If the RHS isn't small, clear this vector and then steal its buffer.
   if (!RHS.isSmall()) {
     this->destroy_range(this->begin(), this->end());
-    if (!this->isSmall()) free(this->begin());
+    if (!this->isSmall()) delete[] (char*)this->begin(); // HLSL Change: Use overridable operator delete
     this->BeginX = RHS.BeginX;
     this->EndX = RHS.EndX;
     this->CapacityX = RHS.CapacityX;

--- a/lib/CodeGen/LiveIntervalUnion.cpp
+++ b/lib/CodeGen/LiveIntervalUnion.cpp
@@ -189,7 +189,7 @@ void LiveIntervalUnion::Array::init(LiveIntervalUnion::Allocator &Alloc,
   clear();
   Size = NSize;
   LIUs = static_cast<LiveIntervalUnion*>(
-    malloc(sizeof(LiveIntervalUnion)*NSize));
+    new char[sizeof(LiveIntervalUnion)*NSize]); // HLSL Change: Use overridable operator new
   for (unsigned i = 0; i != Size; ++i)
     new(LIUs + i) LiveIntervalUnion(Alloc);
 }
@@ -199,7 +199,7 @@ void LiveIntervalUnion::Array::clear() {
     return;
   for (unsigned i = 0; i != Size; ++i)
     LIUs[i].~LiveIntervalUnion();
-  free(LIUs);
+  delete[] static_cast<char*>(LIUs); // HLSL Change: Use overridable operator delete
   Size =  0;
   LIUs = nullptr;
 }

--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -1883,6 +1883,7 @@ void FunctionPass::assignPassManager(PMStack &PMS,
 
     // [1] Create new Function Pass Manager
     FPP = new FPPassManager();
+    std::unique_ptr<FPPassManager> NewFPP(FPP); // HLSL Change
     FPP->populateInheritedAnalysis(PMS);
 
     // [2] Set up new manager's top level manager
@@ -1891,6 +1892,7 @@ void FunctionPass::assignPassManager(PMStack &PMS,
 
     // [3] Assign manager to manage this new manager. This may create
     // and push new managers into PMS
+    NewFPP.release(); // HLSL Change: assignPassManager transfers ownership of 'this'...
     FPP->assignPassManager(PMS, PMD->getPassManagerType());
 
     // [4] Push new manager into PMS

--- a/lib/Support/SmallVector.cpp
+++ b/lib/Support/SmallVector.cpp
@@ -25,13 +25,17 @@ void SmallVectorBase::grow_pod(void *FirstEl, size_t MinSizeInBytes,
 
   void *NewElts;
   if (BeginX == FirstEl) {
-    NewElts = malloc(NewCapacityInBytes);
+    NewElts = new char[NewCapacityInBytes]; // HLSL Change: Use overridable operator new
 
     // Copy the elements over.  No need to run dtors on PODs.
     memcpy(NewElts, this->BeginX, CurSizeBytes);
   } else {
     // If this wasn't grown from the inline copy, grow the allocated space.
-    NewElts = realloc(this->BeginX, NewCapacityInBytes);
+    // HLSL Change Begins: Use overridable operator new
+    NewElts = new char[NewCapacityInBytes];
+    memcpy(NewElts, this->BeginX, CurSizeBytes);
+    delete[] (char*)this->BeginX;
+    // HLSL Change Ends
   }
   assert(NewElts && "Out of memory");
 


### PR DESCRIPTION
In a few places, llvm uses `malloc` instead of `operator new`, especially with collections that want to avoid calling constructors. In those cases, the allocation won't go through our custom allocator and will crash rather than throw on out-of-memory conditions. This fixes the biggest offenders.