### PR TITLE
Fix a crash on xvalue passed as an argument

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -7086,7 +7086,7 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
       continue;
     }
 
-    if (!Param->isModifierOut() && !RValOnRef) {
+    if (!Param->isModifierOut() && !RValOnRef && Arg->isRValue()) {
       // No need to copy arg to in-only param for hlsl intrinsic.
       if (const FunctionDecl *Callee = E->getDirectCallee()) {
         if (Callee->hasAttr<HLSLIntrinsicAttr>())

--- a/tools/clang/test/CodeGenHLSL/batch/expressions/argument_passing/xvalue_to_prvalue.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/expressions/argument_passing/xvalue_to_prvalue.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Regression test for a crash when an expression classified
+// as an xvalue by clang is used as an argument to a function
+// expecting a prvalue.
+
+// StructuredBuffer::Load() returns a struct type by value
+// rather than by reference like StructuredBuffer::operator[].
+// A struct returned by value is considered an xvalue so it can be moved,
+
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: call void @dx.op.bufferStore.i32
+
+struct S { int x; };
+StructuredBuffer<S> structbuf;
+AppendStructuredBuffer<S> appbuf;
+void main() { appbuf.Append(structbuf.Load(0)); }


### PR DESCRIPTION
This is an okay fix, but I think the real issue here is that it makes no sense that we're using rvalue references to mean const lvalue references. I filed a follow-up bug: #2153

Fixes #2152 