### PR TITLE
RValue references no more!

### DIFF
--- a/tools/clang/test/CodeGenHLSL/batch/expressions/argument_passing/xvalue_to_rvalue_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/expressions/argument_passing/xvalue_to_rvalue_regression.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Regression test for a crash because some intrinsics like StructuredBuffer::Load()
+// used to return rvalue references, which classified as an xvalue by clang
+// and misbehaved when used as an argument to a function expecting a prvalue.
+
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32
+// CHECK: extractvalue %dx.types.ResRet.i32
+// CHECK: call void @dx.op.bufferStore.i32
+
+struct S { int x; };
+StructuredBuffer<S> structbuf;
+AppendStructuredBuffer<S> appbuf;
+void main() { appbuf.Append(structbuf.Load(0)); }

--- a/tools/clang/test/CodeGenSPIRV/type.append.consume-structured-buffer.cast.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append.consume-structured-buffer.cast.hlsl
@@ -60,6 +60,8 @@ void main() {
 // CHECK:       [[p_5:%\d+]] = OpAccessChain %_ptr_Uniform_struct_with_bool %consume_struct_with_bool %uint_0 {{%\d+}}
 // CHECK-NEXT:  [[p_6:%\d+]] = OpAccessChain %_ptr_Uniform_uint [[p_5]] %int_3
 // CHECK-NEXT:  [[i_5:%\d+]] = OpLoad %uint [[p_6]]
+// CHECK-NEXT: [[bi_5:%\d+]] = OpINotEqual %bool [[i_5]] %uint_0
+// CHECK-NEXT:  [[i_5:%\d+]] = OpSelect %uint [[bi_5]] %uint_1 %uint_0
 // CHECK-NEXT:                 OpStore [[p_4]] [[i_5]]
   append_bool.Append(consume_struct_with_bool.Consume().elem_bool);
 
@@ -146,6 +148,8 @@ void main() {
 // CHECK:       [[p_19:%\d+]] = OpAccessChain %_ptr_Uniform_struct_with_bool %consume_struct_with_bool %uint_0 {{%\d+}}
 // CHECK-NEXT:  [[p_20:%\d+]] = OpAccessChain %_ptr_Uniform_v2uint [[p_19]] %int_0
 // CHECK-NEXT: [[vu_20:%\d+]] = OpLoad %v2uint [[p_20]]
+// CHECK-NEXT: [[vb_20:%\d+]] = OpINotEqual %v2bool [[vu_20]] {{%\d+}}
+// CHECK-NEXT: [[vu_20:%\d+]] = OpSelect %v2uint [[vb_20]] {{%\d+}} {{%\d+}}
 // CHECK-NEXT:                  OpStore {{%\d+}} [[vu_20]]
   append_v2bool.Append(consume_struct_with_bool.Consume().elem_v2bool);
 
@@ -259,6 +263,8 @@ void main() {
 
 // CHECK:       [[p_41:%\d+]] = OpAccessChain %_ptr_Uniform_uint {{%\d+}} %int_0
 // CHECK-NEXT:  [[i_41:%\d+]] = OpLoad %uint [[p_41]]
+// CHECK-NEXT:  [[b_41:%\d+]] = OpINotEqual %bool [[i_41]] %uint_0
+// CHECK-NEXT:  [[i_41:%\d+]] = OpSelect %uint [[b_41]] %uint_1 %uint_0
 // CHECK-NEXT:                  OpStore {{%\d+}} [[i_41]]
   append_bool.Append(consume_struct_with_bool.Consume().elem_v2bool.x);
 


### PR DESCRIPTION
In a few places, we used rvalue references as if they meant read-only references, which is not at all their semantics. This change ensures that we never deal with rvalue references, which in any case have no place in HLSL and only introduce weird edge cases, but only with const and non-const lvalue references.

Fixes #2153
Fixes #2152