### PR TITLE
Bug fixes and minor changes to ExecutionTest

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -496,7 +496,6 @@
     </RenderTargets>
 
     <Shader Name="VS" Target="vs_6_2" Arguments="/enable-16bit-types">
-    <!--<Shader Name="VS" Target="vs_6_0"> -->
     <![CDATA[
     struct PSInput {
       half4 position : SV_POSITION;
@@ -514,7 +513,6 @@
     </Shader>
 
     <Shader Name="PS" Target="ps_6_2" Arguments="/enable-16bit-types">
-    <!--<Shader Name="PS" Target="ps_6_0">-->
     <![CDATA[
     struct PSInput {
       half4 position : SV_POSITION;
@@ -566,8 +564,8 @@
          result.position = position;
          return result;
         }
-        float4 PSMain(PSInput input) : SV_TARGET {
-         return float4(first, second, third, fourth);
+        half4 PSMain(PSInput input) : SV_TARGET {
+         return half4(first, second, third, fourth);
         }
       ]]>
     </Shader>

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -1010,9 +1010,7 @@ public:
     CComPtr<IDxcLibrary> pLibrary;
     CComPtr<IDxcBlobEncoding> pBlob;
     CComPtr<IStream> pStream;
-
     std::wstring path = GetPathToHlslDataFile(relativePath);
-
     VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcLibrary, &pLibrary));
     VERIFY_SUCCEEDED(pLibrary->CreateBlobFromFile(path.c_str(), nullptr, &pBlob));
     VERIFY_SUCCEEDED(pLibrary->CreateStreamFromBlobReadOnly(pBlob, &pStream));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -1010,7 +1010,11 @@ public:
     CComPtr<IDxcLibrary> pLibrary;
     CComPtr<IDxcBlobEncoding> pBlob;
     CComPtr<IStream> pStream;
+#ifdef _HLK_CONF
+    std::wstring path = GetPathToHLKDataFile(relativePath);
+#else
     std::wstring path = GetPathToHlslDataFile(relativePath);
+#endif
     VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcLibrary, &pLibrary));
     VERIFY_SUCCEEDED(pLibrary->CreateBlobFromFile(path.c_str(), nullptr, &pBlob));
     VERIFY_SUCCEEDED(pLibrary->CreateStreamFromBlobReadOnly(pBlob, &pStream));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -10,6 +10,8 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#define HLSLDATAFILEPARAM L"HlslDataDir"
+
 #include <algorithm>
 #include <memory>
 #include <vector>
@@ -1010,11 +1012,9 @@ public:
     CComPtr<IDxcLibrary> pLibrary;
     CComPtr<IDxcBlobEncoding> pBlob;
     CComPtr<IStream> pStream;
-#ifdef _HLK_CONF
-    std::wstring path = GetPathToHLKDataFile(relativePath);
-#else
+
     std::wstring path = GetPathToHlslDataFile(relativePath);
-#endif
+
     VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcLibrary, &pLibrary));
     VERIFY_SUCCEEDED(pLibrary->CreateBlobFromFile(path.c_str(), nullptr, &pBlob));
     VERIFY_SUCCEEDED(pLibrary->CreateStreamFromBlobReadOnly(pBlob, &pStream));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -10,8 +10,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#define HLSLDATAFILEPARAM L"HlslDataDir"
-
 #include <algorithm>
 #include <memory>
 #include <vector>

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -240,7 +240,7 @@ inline bool isdenorm(float f) {
 }
 
 inline float ifdenorm_flushf(float a) {
-  return isdenorm(a) ? (float)_copysign(0.0f, a) : a;
+  return isdenorm(a) ? (float)copysign(0.0f, a) : a;
 }
 
 #endif // FP_SUBNORMAL

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -21,6 +21,10 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/DXIL/DxilConstants.h" // DenormMode
 
+#ifndef HLSLDATAFILEPARAM
+#define HLSLDATAFILEPARAM L"HlslDataDir"
+#endif
+
 // If TAEF verify macros are available, use them to alias other legacy
 // comparison macros that don't have a direct translation.
 //
@@ -115,7 +119,7 @@ inline void LogErrorFmt(_In_z_ _Printf_format_string_ const wchar_t *fmt, ...) {
 inline std::wstring GetPathToHlslDataFile(const wchar_t* relative) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   WEX::Common::String HlslDataDirValue;
-  ASSERT_HRESULT_SUCCEEDED(WEX::TestExecution::RuntimeParameters::TryGetValue(L"HlslDataDir", HlslDataDirValue));
+  ASSERT_HRESULT_SUCCEEDED(WEX::TestExecution::RuntimeParameters::TryGetValue(HLSLDATAFILEPARAM, HlslDataDirValue));
 
   wchar_t envPath[MAX_PATH];
   wchar_t expanded[MAX_PATH];
@@ -232,33 +236,29 @@ inline float ifdenorm_flushf(float a) {
   return isdenorm(a) ? copysign(0.0f, a) : a;
 }
 
-inline bool ifdenorm_flushf_eq(float a, float b) {
-  return ifdenorm_flushf(a) == ifdenorm_flushf(b);
-}
-
-inline bool ifdenorm_flushf_eq_or_nans(float a, float b) {
-  if (std::isnan(a) && std::isnan(b)) return true;
-  return ifdenorm_flushf(a) == ifdenorm_flushf(b);
-}
-
 #else
 
 inline bool isdenorm(float f) {
   return (std::numeric_limits<float>::denorm_min() <= f && f < std::numeric_limits<float>::min()) ||
-         (-std::numeric_limits<float>::min() <= f && f < -std::numeric_limits<float>::denorm_min());
+         (-std::numeric_limits<float>::min() < f && f <= -std::numeric_limits<float>::denorm_min());
 }
+
 inline bool isinf(float f) {
   static const INT32 Max32 = 0x7f7FFFFF;
   UINT n = *(UINT*)&f;
   UINT abs = n & 0x7FFFFFFF;
   return abs > Max32;
 }
+
 inline int signbit(float f) {
   return copysign(1.0, (double)f) == 1.0 ? 0 : 1; // A non-zero value if the sign of f is negative.
 }
+
 inline float ifdenorm_flushf(float a) {
   return isdenorm(a) ? (float)_copysign(0.0f, a) : a;
 }
+
+#endif // FP_SUBNORMAL
 
 inline bool ifdenorm_flushf_eq(float a, float b) {
   return ifdenorm_flushf(a) == ifdenorm_flushf(b);
@@ -268,8 +268,6 @@ inline bool ifdenorm_flushf_eq_or_nans(float a, float b) {
   if (std::isnan(a) && std::isnan(b)) return true;
   return ifdenorm_flushf(a) == ifdenorm_flushf(b);
 }
-
-#endif // FP_SUBNORMAL
 
 static const uint16_t Float16NaN = 0xff80;
 static const uint16_t Float16PosInf = 0x7c00;

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <fstream>
 #include <atomic>
+#include <cmath>
 #ifdef _WIN32
 #include <dxgiformat.h>
 #include "WexTestClass.h"

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -228,10 +228,6 @@ inline bool isdenorm(float f) {
   return FP_SUBNORMAL == std::fpclassify(f);
 }
 
-inline bool isdenorm(double d) {
-  return FP_SUBNORMAL == std::fpclassify(d);
-}
-
 inline float ifdenorm_flushf(float a) {
   return isdenorm(a) ? copysign(0.0f, a) : a;
 }
@@ -243,17 +239,6 @@ inline bool isdenorm(float f) {
          (-std::numeric_limits<float>::min() < f && f <= -std::numeric_limits<float>::denorm_min());
 }
 
-inline bool isinf(float f) {
-  static const INT32 Max32 = 0x7f7FFFFF;
-  UINT n = *(UINT*)&f;
-  UINT abs = n & 0x7FFFFFFF;
-  return abs > Max32;
-}
-
-inline int signbit(float f) {
-  return copysign(1.0, (double)f) == 1.0 ? 0 : 1; // A non-zero value if the sign of f is negative.
-}
-
 inline float ifdenorm_flushf(float a) {
   return isdenorm(a) ? (float)_copysign(0.0f, a) : a;
 }
@@ -261,11 +246,6 @@ inline float ifdenorm_flushf(float a) {
 #endif // FP_SUBNORMAL
 
 inline bool ifdenorm_flushf_eq(float a, float b) {
-  return ifdenorm_flushf(a) == ifdenorm_flushf(b);
-}
-
-inline bool ifdenorm_flushf_eq_or_nans(float a, float b) {
-  if (std::isnan(a) && std::isnan(b)) return true;
   return ifdenorm_flushf(a) == ifdenorm_flushf(b);
 }
 

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -203,22 +203,17 @@ inline bool GetTestParamBool(LPCWSTR name) {
 }
 
 inline bool GetTestParamUseWARP(bool defaultVal) {
-#ifdef _HLK_CONF
-    UNREFERENCED_PARAMETER(defaultVal);
-    return false;
-#else
-    WEX::Common::String AdapterValue;
-    if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
-          L"Adapter", AdapterValue))) {
-      return defaultVal;
-    }
-    if ((defaultVal && AdapterValue.IsEmpty()) ||
-        AdapterValue.CompareNoCase(L"WARP") == 0) {
-      return true;
-    }
-    return false;
-#endif // _HLK_CONF
+  WEX::Common::String AdapterValue;
+  if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(
+        L"Adapter", AdapterValue))) {
+    return defaultVal;
   }
+  if ((defaultVal && AdapterValue.IsEmpty()) ||
+      AdapterValue.CompareNoCase(L"WARP") == 0) {
+    return true;
+  }
+  return false;
+}
 
 }
 
@@ -228,10 +223,6 @@ inline bool isdenorm(float f) {
   return FP_SUBNORMAL == std::fpclassify(f);
 }
 
-inline float ifdenorm_flushf(float a) {
-  return isdenorm(a) ? copysign(0.0f, a) : a;
-}
-
 #else
 
 inline bool isdenorm(float f) {
@@ -239,11 +230,11 @@ inline bool isdenorm(float f) {
          (-std::numeric_limits<float>::min() < f && f <= -std::numeric_limits<float>::denorm_min());
 }
 
-inline float ifdenorm_flushf(float a) {
-  return isdenorm(a) ? (float)copysign(0.0f, a) : a;
-}
-
 #endif // FP_SUBNORMAL
+
+inline float ifdenorm_flushf(float a) {
+  return isdenorm(a) ? copysign(0.0f, a) : a;
+}
 
 inline bool ifdenorm_flushf_eq(float a, float b) {
   return ifdenorm_flushf(a) == ifdenorm_flushf(b);

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -699,7 +699,7 @@ void ShaderOpTest::CreateShaders() {
           pText, (UINT32)strlen(pText), CP_UTF8, &pTextBlob));
       CHECK_HR(m_pDxcSupport->CreateInstance(CLSID_DxcCompiler, &pCompiler));
       CHECK_HR(pCompiler->Compile(pTextBlob, nameW, entryPointW, targetW,
-                                  (LPCWSTR *)argumentsWList.data(), argumentsWList.size(),
+                                  (LPCWSTR *)argumentsWList.data(), (UINT32)argumentsWList.size(),
                                   nullptr, 0,
                                   nullptr, &pResult));
       CHECK_HR(pResult->GetStatus(&resultCode));
@@ -717,7 +717,9 @@ void ShaderOpTest::CreateShaders() {
       CHECK_HR(pResult->GetResult(&pCode));
       CComPtr<IDxcBlobEncoding> pBlob;
       CHECK_HR(pCompiler->Disassemble((IDxcBlob *)pCode, (IDxcBlobEncoding **)&pBlob));
-      dxc::WriteUtf8ToConsoleSizeT((char *)pBlob->GetBufferPointer(), pBlob->GetBufferSize());
+      CComPtr<IDxcBlobEncoding> pUtf16Blob;
+      pLibrary->GetBlobAsUtf16(pBlob, &pUtf16Blob);
+      hlsl_test::LogCommentFmt(L"%*s", (int)pUtf16Blob->GetBufferSize() / 2, (LPCWSTR)pUtf16Blob->GetBufferPointer());
 #endif
     } else {
       CComPtr<ID3DBlob> pError;
@@ -1429,7 +1431,7 @@ static HRESULT ReadAttrEnumT(IXmlReader *pReader, LPCWSTR pAttrName, ParserEnumK
   }
   LPCWSTR pText;
   CHECK_HR(pReader->GetValue(&pText, nullptr));
-  if (pStripPrefix && *pStripPrefix && _wcsnicmp(pAttrName, pText, wcslen(pStripPrefix)) == 0)
+  if (pStripPrefix && *pStripPrefix && _wcsnicmp(pStripPrefix, pText, wcslen(pStripPrefix)) == 0)
     pText += wcslen(pStripPrefix);
   CHECK_HR(GetEnumValueT(pText, K, pValue));
   CHECK_HR(pReader->MoveToElement());


### PR DESCRIPTION
Fixes 2 test bugs and a few razzle build warnings
Removes HlslTestUtils.h dependency on llvm/Support/Atomic.h
Brings it in sync with the HLK version of the tests