### PR TITLE
Fix issues with -Qstrip_reflect and -Qstrip_debug

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -121,6 +121,7 @@ public:
   DxilSignature &GetPatchConstantSignature();
   const DxilSignature &GetPatchConstantSignature() const;
   const std::vector<uint8_t> &GetSerializedRootSignature() const;
+  std::vector<uint8_t> &GetSerializedRootSignature();
 
   bool HasDxilEntrySignature(const llvm::Function *F) const;
   DxilEntrySignature &GetDxilEntrySignature(const llvm::Function *F);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -945,6 +945,10 @@ const std::vector<uint8_t> &DxilModule::GetSerializedRootSignature() const {
   return m_SerializedRootSignature;
 }
 
+std::vector<uint8_t> &DxilModule::GetSerializedRootSignature() {
+  return m_SerializedRootSignature;
+}
+
 // Entry props.
 bool DxilModule::HasDxilEntrySignature(const llvm::Function *F) const {
   return m_DxilEntryPropsMap.find(F) != m_DxilEntryPropsMap.end();

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -581,7 +581,7 @@ public:
         // embed the debug info and emit a note.
         if (opts.EmbedDebugInfo()) {
           SerializeFlags |= SerializeDxilFlags::IncludeDebugInfoPart;
-        } else if (opts.DebugInfo && !ppDebugBlob) {
+        } else if (!opts.StripDebug && opts.DebugInfo && !ppDebugBlob) {
           w << "warning: no output provided for debug - embedding PDB in shader container.  Use -Qembed_debug to silence this warning.\n";
           SerializeFlags |= SerializeDxilFlags::IncludeDebugInfoPart;
         }


### PR DESCRIPTION
-Qstrip_reflect would reserialize the root signature, leading to
validation failure #2162.  Fixed by moving root sig to writer to clear
from module and prevent re-serialization to metadata.

Fixed -Qstrip_debug with -Zi and no output location still embeding
debug module.

Fixes #2162.