### PR TITLE
Fix double-delete when failing to load llvm bitcode

### DIFF
--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4775,7 +4775,7 @@ getLazyBitcodeModuleImpl(std::unique_ptr<MemoryBuffer> &&Buffer,
   // Get the buffer identifier before we transfer the ownership to the bitcode reader,
   // this is ugly but safe as long as it keeps the buffer, and hence identifier string, alive.
   const char* BufferIdentifier = Buffer->getBufferIdentifier();
-  std::unique_ptr<BitcodeReader> R = std::make_unique<BitcodeReader>(
+  std::unique_ptr<BitcodeReader> R = make_unique<BitcodeReader>(
     std::move(Buffer), Context, DiagnosticHandler);
 
   ErrorOr<std::unique_ptr<Module>> Ret =
@@ -4799,7 +4799,7 @@ ErrorOr<std::unique_ptr<Module>> llvm::getStreamedBitcodeModule(
     StringRef Name, std::unique_ptr<DataStreamer> Streamer,
     LLVMContext &Context, DiagnosticHandlerFunction DiagnosticHandler) {
   std::unique_ptr<Module> M = make_unique<Module>(Name, Context);
-  std::unique_ptr<BitcodeReader> R = std::make_unique<BitcodeReader>(Context, DiagnosticHandler); // HLSL Change: unique_ptr
+  std::unique_ptr<BitcodeReader> R = make_unique<BitcodeReader>(Context, DiagnosticHandler); // HLSL Change: unique_ptr
 
   return getBitcodeModuleImpl(std::move(Streamer), Name, std::move(R), Context, false, // HLSL Change: std::move
                               false);

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4775,7 +4775,7 @@ getLazyBitcodeModuleImpl(std::unique_ptr<MemoryBuffer> &&Buffer,
   // Get the buffer identifier before we transfer the ownership to the bitcode reader,
   // this is ugly but safe as long as it keeps the buffer, and hence identifier string, alive.
   const char* BufferIdentifier = Buffer->getBufferIdentifier();
-  std::unique_ptr<BitcodeReader> R = make_unique<BitcodeReader>(
+  std::unique_ptr<BitcodeReader> R = llvm::make_unique<BitcodeReader>(
     std::move(Buffer), Context, DiagnosticHandler);
 
   ErrorOr<std::unique_ptr<Module>> Ret =
@@ -4799,7 +4799,7 @@ ErrorOr<std::unique_ptr<Module>> llvm::getStreamedBitcodeModule(
     StringRef Name, std::unique_ptr<DataStreamer> Streamer,
     LLVMContext &Context, DiagnosticHandlerFunction DiagnosticHandler) {
   std::unique_ptr<Module> M = make_unique<Module>(Name, Context);
-  std::unique_ptr<BitcodeReader> R = make_unique<BitcodeReader>(Context, DiagnosticHandler); // HLSL Change: unique_ptr
+  std::unique_ptr<BitcodeReader> R = llvm::make_unique<BitcodeReader>(Context, DiagnosticHandler); // HLSL Change: unique_ptr
 
   return getBitcodeModuleImpl(std::move(Streamer), Name, std::move(R), Context, false, // HLSL Change: std::move
                               false);

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -4741,24 +4741,19 @@ getBitcodeModuleImpl(std::unique_ptr<DataStreamer> Streamer, StringRef Name,
   M->setMaterializer(R);
   // HLSL Change End
 
-  auto cleanupOnError = [&](std::error_code EC) {
-    R->releaseBuffer(); // Never take ownership on error.
-    return EC;
-  };
-
   // Delay parsing Metadata if ShouldLazyLoadMetadata is true.
   if (std::error_code EC = R->parseBitcodeInto(std::move(Streamer), M.get(),
                                                ShouldLazyLoadMetadata))
-    return cleanupOnError(EC);
+    return EC; // HLSL Change: Correct memory management of BitcodeReader.buffer
 
   if (MaterializeAll) {
     // Read in the entire module, and destroy the BitcodeReader.
     if (std::error_code EC = M->materializeAllPermanently())
-      return cleanupOnError(EC);
+      return EC; // HLSL Change: Correct memory management of BitcodeReader.buffer
   } else {
     // Resolve forward references from blockaddresses.
     if (std::error_code EC = R->materializeForwardReferencedFunctions())
-      return cleanupOnError(EC);
+      return EC; // HLSL Change: Correct memory management of BitcodeReader.buffer
   }
   return std::move(M);
 }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -258,6 +258,8 @@ public:
 
   TEST_METHOD(SpaceOnlyRegisterFail)
 
+  TEST_METHOD(WhenDisassembleInvalidBlobThenFail)
+
   dxc::DxcDllSupport m_dllSupport;
   VersionSupportInfo m_ver;
 
@@ -3056,6 +3058,23 @@ float4 main(uint vid : SV_ViewID, float3 In[31] : INPUT) : SV_Target \
 TEST_F(ValidationTest, SpaceOnlyRegisterFail) {
   TestCheck(L"..\\CodeGenHLSL\\space-only-register.hlsl");
 }
+
+// Regression test for a double-delete when failing to parse bitcode.
+TEST_F(ValidationTest, WhenDisassembleInvalidBlobThenFail) {
+  if (!m_dllSupport.IsEnabled()) {
+    VERIFY_SUCCEEDED(m_dllSupport.Initialize());
+  }
+
+  CComPtr<IDxcBlobEncoding> pInvalidBitcode;
+  Utf8ToBlob(m_dllSupport, "This text is certainly not bitcode", &pInvalidBitcode);
+
+  CComPtr<IDxcCompiler> pCompiler;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
+
+  CComPtr<IDxcBlobEncoding> pDisassembly;
+  VERIFY_FAILED(pCompiler->Disassemble(pInvalidBitcode, &pDisassembly));
+}
+
 
 TEST_F(ValidationTest, GSMainMissingAttributeFail) {
   TestCheck(L"..\\CodeGenHLSL\\attributes-gs-no-inout-main.hlsl");


### PR DESCRIPTION
We added an exception when the bitcode reader reports an error, however the code higher up in the call stack isn't fully exception-safe and it turns out that two unique_ptrs over the same `MemoryBuffer` are alive at the same time, hence the double-delete and, more often than not, crash.

Tested manually by running `dxc /dumpbin` and forcing an exception to happen. Also later on added a test.