### PR TITLE
Add TablegenHLSLOptions dependency to dxclib

### DIFF
--- a/tools/clang/tools/dxc/dxclib/CMakeLists.txt
+++ b/tools/clang/tools/dxc/dxclib/CMakeLists.txt
@@ -18,3 +18,4 @@ if (WIN32)
   include_directories(AFTER ${DIASDK_INCLUDE_DIRS})
 endif (WIN32)
 
+add_dependencies(dxclib TablegenHLSLOptions)


### PR DESCRIPTION
Fixes build break on parallel builds