### PR TITLE
Added missing semicolon in struct layout output

### DIFF
--- a/tools/clang/test/CodeGenHLSL/batch/declarations/matrix_pack/preserved_with_typedef.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/matrix_pack/preserved_with_typedef.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
 // If column major, the CBuffer will have a size of 8 bytes, if row major it should be 20
-// CHECK: CBuf ; Offset: 0 Size: 20
+// CHECK: CBuf; ; Offset: 0 Size: 20
 
 typedef row_major float2x1 rmf2x1;
 cbuffer CBuf { rmf2x1 mat; }

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/resources/structured_buffers/layout.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/resources/structured_buffers/layout.hlsl
@@ -3,16 +3,28 @@
 // Tests the printed layout of structured buffers.
 
 // CHECK: int2 a; ; Offset: 0
-// CHECK: int b[2]; ; Offset: 8
-// CHECK: int2 c; ; Offset: 16
-// CHECK: int2 d; ; Offset: 24
+// CHECK: struct
+// CHECK: {
+// CHECK:   int b[2]; ; Offset: 8
+// CHECK:   int2 c; ; Offset: 16
+// CHECK:   int2 d; ; Offset: 24
+// CHECK: } s; ; Offset: 8
+// CHECK: struct
+// CHECK: {
+// CHECK: } _; ; Offset: 32
 // CHECK: int e; ; Offset: 32
 // CHECK: Size: 36
 
 // CHECK: int2 a; ; Offset: 0
-// CHECK: int b[2]; ; Offset: 8
-// CHECK: int2 c; ; Offset: 16
-// CHECK: int2 d; ; Offset: 24
+// CHECK: struct
+// CHECK: {
+// CHECK:   int b[2]; ; Offset: 8
+// CHECK:   int2 c; ; Offset: 16
+// CHECK:   int2 d; ; Offset: 24
+// CHECK: } s; ; Offset: 8
+// CHECK: struct
+// CHECK: {
+// CHECK: } _; ; Offset: 32
 // CHECK: int e; ; Offset: 32
 // CHECK: Size: 36
 
@@ -25,6 +37,7 @@ struct Struct
         int2 c;
         int2 d;
     } s;
+    struct {} _;
     int e;
 };
 

--- a/tools/clang/test/CodeGenHLSL/batch/misc/bindings1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/misc/bindings1.hlsl
@@ -10,7 +10,7 @@
 // CHECK: ;       float4 f2;                                    ; Offset:  112
 // CHECK: ;       float fa[15];                                 ; Offset:  128
 // CHECK: ;
-// CHECK: ;   } MyCB                                            ; Offset:    0 Size:   356
+// CHECK: ;   } MyCB;                                           ; Offset:    0 Size:   356
 // CHECK: ;
 // CHECK: ; }
 
@@ -26,10 +26,10 @@
 // CHECK: ;           float4 f;                                 ; Offset:    0
 // CHECK: ;           int4 i;                                   ; Offset:   16
 // CHECK: ;
-// CHECK: ;       } buf2                                        ; Offset:    0
+// CHECK: ;       } buf2;                                       ; Offset:    0
 // CHECK: ;
 // CHECK: ;
-// CHECK: ;   } buf2                                            ; Offset:    0 Size:    32
+// CHECK: ;   } buf2;                                           ; Offset:    0 Size:    32
 // CHECK: ;
 // CHECK: ; }
 
@@ -42,7 +42,7 @@
 // CHECK: ;       float f3;                                     ; Offset:    0
 // CHECK: ;       float4 f4;                                    ; Offset:   16
 // CHECK: ;
-// CHECK: ;   } MyTB                                            ; Offset:    0 Size:    32
+// CHECK: ;   } MyTB;                                           ; Offset:    0 Size:    32
 // CHECK: ;
 // CHECK: ; }
 
@@ -58,10 +58,10 @@
 // CHECK: ;           float4 f;                                 ; Offset:    0
 // CHECK: ;           int4 i;                                   ; Offset:   16
 // CHECK: ;
-// CHECK: ;       } tbuf1                                       ; Offset:    0
+// CHECK: ;       } tbuf1;                                      ; Offset:    0
 // CHECK: ;
 // CHECK: ;
-// CHECK: ;   } tbuf1                                           ; Offset:    0 Size:    32
+// CHECK: ;   } tbuf1;                                          ; Offset:    0 Size:    32
 // CHECK: ;
 // CHECK: ; }
 

--- a/tools/clang/test/CodeGenHLSL/batch/misc/cbuffer5.51.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/misc/cbuffer5.51.hlsl
@@ -13,10 +13,10 @@
 // CHECK: ;
 // CHECK: ;           float4 g1[16];                            ; Offset:    0
 // CHECK: ;
-// CHECK: ;       } buf1                                        ; Offset:    0
+// CHECK: ;       } buf1;                                       ; Offset:    0
 // CHECK: ;
 // CHECK: ;
-// CHECK: ;   } buf1                                            ; Offset:    0 Size:  256
+// CHECK: ;   } buf1;                                           ; Offset:    0 Size:  256
 // CHECK: ;
 // CHECK: ; }
 // CHECK: ;
@@ -34,13 +34,13 @@
 // CHECK: ;
 // CHECK: ;               float4 g1[16];                        ; Offset:    0
 // CHECK: ;
-// CHECK: ;           } foo                                     ; Offset:    0
+// CHECK: ;           } foo;                                    ; Offset:    0
 // CHECK: ;
 // CHECK: ;           uint3 idx[16];                            ; Offset:  256
 // CHECK: ;
-// CHECK: ;       } buf2                                        ; Offset:    0
+// CHECK: ;       } buf2;                                       ; Offset:    0
 // CHECK: ;
-// CHECK: ;   } buf2                                            ; Offset:    0 Size: 508
+// CHECK: ;   } buf2;                                           ; Offset:    0 Size: 508
 // CHECK: ;
 // CHECK: ; }
 // CHECK: ;

--- a/tools/clang/test/CodeGenHLSL/batch/misc/cbuffer6.51.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/misc/cbuffer6.51.hlsl
@@ -13,10 +13,10 @@
 // CHECK: ;
 // CHECK: ;           float4 g1[16];                            ; Offset:    0
 // CHECK: ;
-// CHECK: ;       } buf1                                        ; Offset:    0
+// CHECK: ;       } buf1;                                       ; Offset:    0
 // CHECK: ;
 // CHECK: ;
-// CHECK: ;   } buf1                                            ; Offset:    0 Size:  256
+// CHECK: ;   } buf1;                                           ; Offset:    0 Size:  256
 // CHECK: ;
 // CHECK: ; }
 // CHECK: ;
@@ -34,13 +34,13 @@
 // CHECK: ;
 // CHECK: ;               float4 g1[16];                        ; Offset:    0
 // CHECK: ;
-// CHECK: ;           } foo                                     ; Offset:    0
+// CHECK: ;           } foo;                                    ; Offset:    0
 // CHECK: ;
 // CHECK: ;           uint3 idx[16];                            ; Offset:  256
 // CHECK: ;
-// CHECK: ;       } buf2                                        ; Offset:    0
+// CHECK: ;       } buf2;                                       ; Offset:    0
 // CHECK: ;
-// CHECK: ;   } buf2                                            ; Offset:    0 Size: 508
+// CHECK: ;   } buf2;                                           ; Offset:    0 Size: 508
 // CHECK: ;
 // CHECK: ; }
 // CHECK: ;

--- a/tools/clang/test/CodeGenHLSL/batch/misc/cbufferMinPrec.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/misc/cbufferMinPrec.hlsl
@@ -14,7 +14,7 @@
 // CHECK:       min16float2 h2_1;                             ; Offset:   80
 // CHECK:       min16float3 h3;                               ; Offset:   96
 // CHECK:       double d1;                                    ; Offset:  112
-// CHECK:   } Foo                                             ; Offset:    0 Size:   120
+// CHECK:   } Foo;                                            ; Offset:    0 Size:   120
 // CHECK: }
 
 // CHECK: %dx.types.CBufRet.f16 = type { half, half, half, half }

--- a/tools/clang/test/CodeGenHLSL/cbufferHalf-struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferHalf-struct.hlsl
@@ -21,7 +21,7 @@
 // CHECK:       int i1;                                     ; Offset:   80
 // CHECK:       double d2;                                  ; Offset:   88
 
-// CHECK:   } f                                             ; Offset:    0 Size:    96
+// CHECK:   } f;                                            ; Offset:    0 Size:    96
 
 struct Foo {
   half h1;
@@ -74,7 +74,7 @@ struct Foo {
 // CHECK:       half h22;                                   ; Offset:   76
 // CHECK:       half h23;                                   ; Offset:   78
 
-// CHECK:   } b                                             ; Offset:    0 Size:    80
+// CHECK:   } b;                                            ; Offset:    0 Size:    80
 
 struct Bar {
   half h1;

--- a/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferHalf.hlsl
@@ -22,7 +22,7 @@
 
 // CHECK:       int f_i1;                                     ; Offset:   80
 // CHECK:       double f_d2;                                  ; Offset:   88
-// CHECK:   } Foo                                             ; Offset:    0 Size:    96
+// CHECK:   } Foo;                                            ; Offset:    0 Size:    96
 // CHECK: }
 
 cbuffer Foo {
@@ -77,7 +77,7 @@ cbuffer Foo {
 // CHECK:       half b_h22;                                   ; Offset:   76
 // CHECK:       half b_h23;                                   ; Offset:   78
 
-// CHECK:   } Bar                                             ; Offset:    0 Size:    80
+// CHECK:   } Bar;                                            ; Offset:    0 Size:    80
 // CHECK: }
 
 cbuffer Bar {

--- a/tools/clang/test/CodeGenHLSL/cbufferInt16-struct.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferInt16-struct.hlsl
@@ -21,7 +21,7 @@
 // CHECK:       int i1;                                   ; Offset:   80
 // CHECK:       double d2;                                ; Offset:   88
 
-// CHECK:   } f                                           ; Offset:    0 Size:    96
+// CHECK:   } f;                                          ; Offset:    0 Size:    96
 
 struct Foo {
   int16_t h1;
@@ -74,7 +74,7 @@ struct Foo {
 // CHECK:       uint16_t h22;                                  ; Offset:   76
 // CHECK:       int16_t h23;                                   ; Offset:   78
 
-// CHECK:   } b                                             ; Offset:    0 Size:    80
+// CHECK:   } b;                                            ; Offset:    0 Size:    80
 
 struct Bar {
   int16_t h1;

--- a/tools/clang/test/CodeGenHLSL/cbufferInt16.hlsl
+++ b/tools/clang/test/CodeGenHLSL/cbufferInt16.hlsl
@@ -22,7 +22,7 @@
 
 // CHECK:       int f_i1;                                   ; Offset:   80
 // CHECK:       double f_d2;                                ; Offset:   88
-// CHECK:   } Foo                                           ; Offset:    0 Size:    96
+// CHECK:   } Foo;                                          ; Offset:    0 Size:    96
 // CHECK: }
 
 cbuffer Foo {
@@ -77,7 +77,7 @@ cbuffer Foo {
 // CHECK:       int16_t b_h22;                                   ; Offset:   76
 // CHECK:       int16_t b_h23;                                   ; Offset:   78
 
-// CHECK:   } Bar                                             ; Offset:    0 Size:    80
+// CHECK:   } Bar;                                               ; Offset:    0 Size:    80
 // CHECK: }
 
 cbuffer Bar {

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -856,9 +856,9 @@ void PrintStructLayout(StructType *ST, DxilTypeSystem &typeSys, const DataLayout
 
   if (!annotation) {
     if (!sizeOfStruct) {
-      (OS << comment).indent(indent) << "/* empty struct */\n";
+      (OS << comment).indent(fieldIndent) << "/* empty struct */\n";
     } else {
-      (OS << comment).indent(indent) << "[" << sizeOfStruct << " x i8] (type annotation not present)\n";
+      (OS << comment).indent(fieldIndent) << "[" << sizeOfStruct << " x i8] (type annotation not present)\n";
     }
   } else {
     for (unsigned i = 0; i < ST->getNumElements(); i++) {
@@ -877,12 +877,12 @@ void PrintStructLayout(StructType *ST, DxilTypeSystem &typeSys, const DataLayout
   }
   (OS << comment).indent(indent) << "\n";
   // The 2 in offsetIndent-indent-2 is for "} ".
-  (OS << comment).indent(indent)
-      << "} " << left_justify(varName, offsetIndent - 2);
+  std::string varNameAndSemicolon = varName;
+  varNameAndSemicolon += ';';
+  (OS << comment).indent(indent) << "} " << left_justify(varNameAndSemicolon, offsetIndent - 2);
   OS << comment << " Offset:" << right_justify(std::to_string(offset), 5);
   if (sizeOfStruct)
     OS << " Size: " << right_justify(std::to_string(sizeOfStruct), 5);
-  ;
   OS << "\n";
 
   OS << comment << "\n";
@@ -928,7 +928,7 @@ void PrintStructBufferDefinition(DxilResource *buf,
       OS << comment << "   [" << DL.getTypeAllocSize(ST)
          << " x i8] (type annotation not present)\n";
     } else {
-      PrintStructLayout(ST, typeSys, &DL, OS, comment, "$Element;",
+      PrintStructLayout(ST, typeSys, &DL, OS, comment, "$Element",
                         /*offset*/ 0, /*indent*/ 3, offsetIndent,
                         DL.getTypeAllocSize(ST));
     }


### PR DESCRIPTION
We printed:
```
struct structName
{
  int fieldName;
} fieldName // No semicolon
```