### PR TITLE
Add TablegenHLSLOptions dependency to dxcompiler

### DIFF
--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -114,6 +114,7 @@ set(GENERATED_HEADERS
   )
 
 add_clang_library(dxcompiler SHARED ${SOURCES})
+add_dependencies(dxcompiler TablegenHLSLOptions) 
 if (WIN32)
   # No DxcEtw on non-Windows platforms.
   add_dependencies(dxcompiler DxcEtw)


### PR DESCRIPTION
Fixes build break in parallel builds