### PR TITLE
Fixed a validation failure with stripping reflect with library shaders.

### DIFF
--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1434,10 +1434,12 @@ void DxilModule::StripReflection() {
 
 
   // Resource
-  StripResourcesReflection(m_CBuffers);
-  StripResourcesReflection(m_UAVs);
-  StripResourcesReflection(m_SRVs);
-  StripResourcesReflection(m_Samplers);
+  if (!GetShaderModel()->IsLib()) {
+    StripResourcesReflection(m_CBuffers);
+    StripResourcesReflection(m_UAVs);
+    StripResourcesReflection(m_SRVs);
+    StripResourcesReflection(m_Samplers);
+  }
 
   // Unused global.
   SmallVector<GlobalVariable *,2> UnusedGlobals;

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1531,11 +1531,6 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
 
   bool bMetadataStripped = false;
 
-  if (Flags & SerializeDxilFlags::StripReflectionFromDxilPart) {
-    pModule->StripReflection();
-    bMetadataStripped = true;
-  }
-
   if (pModule->GetShaderModel()->IsLib()) {
     DXASSERT(pModule->GetSerializedRootSignature().empty(),
              "otherwise, library has root signature outside subobject definitions");
@@ -1590,6 +1585,11 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
     // If no debug info, clear DebugNameDependOnSource
     // (it's default, and this scenario can happen)
     Flags &= ~SerializeDxilFlags::DebugNameDependOnSource;
+  }
+
+  if (Flags & SerializeDxilFlags::StripReflectionFromDxilPart) {
+    pModule->StripReflection();
+    bModuleStripped = true;
   }
 
   // If debug info or reflection was stripped, re-serialize the module.

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1530,11 +1530,10 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
   DXASSERT_NOMSG(pModule->GetSerializedRootSignature().empty());
 
   bool bMetadataStripped = false;
-  bool bModuleStripped = false;
 
   if (Flags & SerializeDxilFlags::StripReflectionFromDxilPart) {
     pModule->StripReflection();
-    bModuleStripped = true;
+    bMetadataStripped = true;
   }
 
   if (pModule->GetShaderModel()->IsLib()) {
@@ -1571,6 +1570,7 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
     WriteBitcodeToFile(pModule->GetModule(), outStream, true);
   }
 
+  bool bModuleStripped = false;
   // If we have debug information present, serialize it to a debug part, then use the stripped version as the canonical program version.
   CComPtr<AbstractMemoryStream> pProgramStream = pInputProgramStream;
   bool bHasDebugInfo = HasDebugInfo(*pModule->GetModule());

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1570,9 +1570,9 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
     WriteBitcodeToFile(pModule->GetModule(), outStream, true);
   }
 
-  bool bModuleStripped = false;
   // If we have debug information present, serialize it to a debug part, then use the stripped version as the canonical program version.
   CComPtr<AbstractMemoryStream> pProgramStream = pInputProgramStream;
+  bool bModuleStripped = false;
   bool bHasDebugInfo = HasDebugInfo(*pModule->GetModule());
   if (bHasDebugInfo) {
     uint32_t debugInUInt32, debugPaddingBytes;

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1530,7 +1530,6 @@ void hlsl::SerializeDxilContainerForModule(DxilModule *pModule,
   DXASSERT_NOMSG(pModule->GetSerializedRootSignature().empty());
 
   bool bMetadataStripped = false;
-
   if (pModule->GetShaderModel()->IsLib()) {
     DXASSERT(pModule->GetSerializedRootSignature().empty(),
              "otherwise, library has root signature outside subobject definitions");

--- a/tools/clang/test/CodeGenHLSL/batch/compiler_options/Qstrip_reflect_lib.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/compiler_options/Qstrip_reflect_lib.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T lib_6_3 %s /Qstrip_reflect | FileCheck %s
+
+// Check that validation doesn't complain about RDAT mismatch with resources
+// because names are now gone.
+
+// CHECK: @main
+
+Texture2D tex0;
+Texture2D tex1;
+Texture2D tex2;
+
+SamplerState samp0;
+SamplerState samp1;
+SamplerState samp2;
+
+[shader("pixel")]
+float4 main(float2 uv : TEXCOORD) : SV_Target  {
+  return
+    tex0.Sample(samp0, uv) +
+    tex1.Sample(samp1, uv) +
+    tex2.Sample(samp2, uv);
+} 

--- a/tools/clang/test/CodeGenHLSL/batch/compiler_options/Qstrip_reflect_subobj.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/compiler_options/Qstrip_reflect_subobj.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T lib_6_3 -Qstrip_reflect %s | FileCheck %s
+
+// CHECK: ; GlobalRootSignature grs = { <48 bytes> };
+// CHECK: ; StateObjectConfig soc = { STATE_OBJECT_FLAG_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITIONS };
+// CHECK: ; LocalRootSignature lrs = { <48 bytes> };
+// CHECK: ; SubobjectToExportsAssociation sea = { "grs", { "a", "b", "foo", "c" }  };
+// CHECK: ; SubobjectToExportsAssociation sea2 = { "grs", { }  };
+// CHECK: ; SubobjectToExportsAssociation sea3 = { "grs", { }  };
+// CHECK: ; RaytracingShaderConfig rsc = { MaxPayloadSizeInBytes = 128, MaxAttributeSizeInBytes = 64 };
+// CHECK: ; RaytracingPipelineConfig rpc = { MaxTraceRecursionDepth = 512 };
+// CHECK: ; HitGroup trHitGt = { HitGroupType = Triangle, Anyhit = "a", Closesthit = "b", Intersection = "" };
+// CHECK: ; HitGroup ppHitGt = { HitGroupType = ProceduralPrimitive, Anyhit = "a", Closesthit = "b", Intersection = "c" };
+
+GlobalRootSignature grs = {"CBV(b0)"};
+StateObjectConfig soc = { STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS };
+LocalRootSignature lrs = {"UAV(u0, visibility = SHADER_VISIBILITY_GEOMETRY), RootFlags(LOCAL_ROOT_SIGNATURE)"};
+SubobjectToExportsAssociation sea = { "grs", "a;b;foo;c" };
+// Empty association is well-defined: it creates a default association
+SubobjectToExportsAssociation sea2 = { "grs", ";" };
+SubobjectToExportsAssociation sea3 = { "grs", "" };
+RaytracingShaderConfig rsc = { 128, 64 };
+RaytracingPipelineConfig rpc = { 512 };
+TriangleHitGroup trHitGt = { "a", "b" };
+ProceduralPrimitiveHitGroup ppHitGt = { "a", "b", "c"};
+
+int main(int i : INDEX) : SV_Target {
+  return 1;
+}


### PR DESCRIPTION
Make sure submodule doesn't get re-emitted into metadata.
Strip reflect *BEFORE* writing RDAT, so that the names don't get put into RDAT and fail validation.
Debug info doesn't actually need any value names, as all the names are strings in the debug metadata.
