### PR TITLE
Fixed a bug where necessary code gets deleted with library shaders.

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -342,6 +342,7 @@ private:
   // Helpers.
   template<typename T> unsigned AddResource(std::vector<std::unique_ptr<T> > &Vec, std::unique_ptr<T> pRes);
   void LoadDxilSignature(const llvm::MDTuple *pSigTuple, DxilSignature &Sig, bool bInput);
+  void RemoveGlobalResourcesUsers();
 
   // properties from HLModule preserved as ShaderFlags
   bool m_bDisableOptimizations;

--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -342,7 +342,6 @@ private:
   // Helpers.
   template<typename T> unsigned AddResource(std::vector<std::unique_ptr<T> > &Vec, std::unique_ptr<T> pRes);
   void LoadDxilSignature(const llvm::MDTuple *pSigTuple, DxilSignature &Sig, bool bInput);
-  void RemoveGlobalResourcesUsers();
 
   // properties from HLModule preserved as ShaderFlags
   bool m_bDisableOptimizations;

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1498,8 +1498,15 @@ void DxilModule::LoadDxilResources(const llvm::MDOperand &MDO) {
   }
 }
 
-void DxilModule::StripDebugRelatedCode() {
+void DxilModule::RemoveGlobalResourcesUsers() {
   // Remove all users of global resources.
+  //
+  // Only do this when shader is not a library. This making the assumption that
+  // there would be no variables of resources, but it's not true for library
+  // shaders.
+  if (GetShaderModel()->IsLib())
+    return;
+
   for (GlobalVariable &GV : m_pModule->globals()) {
     if (GV.hasInternalLinkage())
       continue;
@@ -1547,6 +1554,11 @@ void DxilModule::StripDebugRelatedCode() {
       }
     }
   }
+}
+
+void DxilModule::StripDebugRelatedCode() {
+  RemoveGlobalResourcesUsers();
+
   // Remove dx.source metadata.
   if (NamedMDNode *contents = m_pModule->getNamedMetadata(
           DxilMDHelper::kDxilSourceContentsMDName)) {


### PR DESCRIPTION
Deleted some old code where we manually delete users of resource GV's while stripping debug modules. This is normally unnecessary but harmless, because we are guaranteed to have reduced all resource variables, and any failure to do so would result in a validation failure. However, library shaders *can* have resource variables. Removing the instructions here would result in incorrect code.