### PR TITLE
Switch from deprecated FindPythonInterp module to FindPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,7 +397,7 @@ set(TARGET_TRIPLE "${LLVM_DEFAULT_TARGET_TRIPLE}")
 include(HandleLLVMOptions)
 
 # Verify that we can find a Python 3 interpreter and force cmake to use it.
-find_package(PythonInterp 3 REQUIRED)
+find_package(Python 3 REQUIRED)
 
 ######
 # LLVMBuild Integration


### PR DESCRIPTION
PR #2187 broke the cmake build for me because I had Python 2 installed in addition to Python 3.  It only finds Python 2, even when Python 3 is on the path.

It seems that the `FindPythonInterp` module was deprecated in favor of `FindPython`.
```
# .. deprecated:: 3.12
#
#   Use :module:`FindPython3`, :module:`FindPython2` or :module:`FindPython` instead.
```

So I replaced `find_package(PythonInterp 3 REQUIRED)` with `find_package(Python 3 REQUIRED)`, and it found the right Python and worked.

Any objections?