### PR TITLE
Add shader hash blob part

### DIFF
--- a/include/dxc/DxilContainer/DxilContainer.h
+++ b/include/dxc/DxilContainer/DxilContainer.h
@@ -40,6 +40,17 @@ struct DxilContainerHash {
   uint8_t Digest[DxilContainerHashSize];
 };
 
+enum class DxilShaderHashFlags : uint32_t {
+  None = 0,           // No flags defined.
+  IncludesSource = 1, // This flag indicates that the shader hash was computed
+                      // taking into account source information (-Zss)
+};
+
+typedef struct DxilShaderHash {
+  uint32_t Flags; // DxilShaderHashFlags
+  uint8_t Digest[DxilContainerHashSize];
+} DxcShaderHash;
+
 struct DxilContainerVersion {
   uint16_t Major;
   uint16_t Minor;
@@ -83,6 +94,7 @@ enum DxilFourCC {
   DFCC_DXIL                     = DXIL_FOURCC('D', 'X', 'I', 'L'),
   DFCC_PipelineStateValidation  = DXIL_FOURCC('P', 'S', 'V', '0'),
   DFCC_RuntimeData              = DXIL_FOURCC('R', 'D', 'A', 'T'),
+  DFCC_ShaderHash               = DXIL_FOURCC('H', 'A', 'S', 'H'),
 };
 
 #undef DXIL_FOURCC

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -638,14 +638,15 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     return 1;
   }
 
-  if (!opts.DebugNameForBinary && !opts.DebugNameForSource) {
-    if (opts.DebugInfo)
-      opts.DebugNameForSource = true;
-    else
-      opts.DebugNameForBinary = true;
-  }
-  else if (opts.DebugNameForBinary && opts.DebugNameForSource) {
+  if (opts.DebugInfo && !opts.DebugNameForBinary && !opts.DebugNameForSource) {
+    opts.DebugNameForBinary = true;
+  } else if (opts.DebugNameForBinary && opts.DebugNameForSource) {
     errors << "Cannot specify both /Zss and /Zsb";
+    return 1;
+  }
+
+  if (opts.DebugNameForSource && !opts.DebugInfo) {
+    errors << "/Zss requires debug info (/Zi)";
     return 1;
   }
 

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -5091,7 +5091,8 @@ void GetValidationVersion(_Out_ unsigned *pMajor, _Out_ unsigned *pMinor) {
   // - packed u8x4/i8x4 dot with accumulate to i32
   // - half dot2 with accumulate to float
   // 1.5 adds:
-  // TODO: Fill this in.
+  // - WaveMatch, WaveMultiPrefixOp, WaveMultiPrefixBitCount
+  // - HASH container part support
   *pMajor = 1;
   *pMinor = 5;
 }
@@ -5409,6 +5410,12 @@ HRESULT ValidateDxilContainerParts(llvm::Module *pModule,
     case DFCC_ShaderDebugInfoDXIL:
     case DFCC_ShaderDebugName:
       continue;
+
+    case DFCC_ShaderHash:
+      if (pPart->PartSize != sizeof(DxilShaderHash)) {
+        ValCtx.EmitFormatError(ValidationRule::ContainerPartInvalid, { szFourCC });
+      }
+      break;
 
     // Runtime Data (RDAT) for libraries
     case DFCC_RuntimeData:

--- a/tools/clang/test/CodeGenHLSL/container/ShaderHash.hlsl
+++ b/tools/clang/test/CodeGenHLSL/container/ShaderHash.hlsl
@@ -1,0 +1,7 @@
+// RUN: %dxc -E main -T vs_6_0 %s -Zsb | FileCheck %s
+
+// CHECK: ; shader hash: 9f3f8b8ebb42a9707866c758265145c5
+
+float4 main() : SV_Position {
+  return 1.0;
+}

--- a/tools/clang/test/CodeGenHLSL/container/ShaderHash.hlsl
+++ b/tools/clang/test/CodeGenHLSL/container/ShaderHash.hlsl
@@ -1,7 +1,0 @@
-// RUN: %dxc -E main -T vs_6_0 %s -Zsb | FileCheck %s
-
-// CHECK: ; shader hash: 9f3f8b8ebb42a9707866c758265145c5
-
-float4 main() : SV_Position {
-  return 1.0;
-}

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -1511,6 +1511,19 @@ HRESULT Disassemble(IDxcBlob *pProgram, raw_string_ostream &Stream) {
     }
 
     it = std::find_if(begin(pContainer), end(pContainer),
+      DxilPartIsType(DFCC_ShaderHash));
+    if (it != end(pContainer)) {
+      const DxilShaderHash *pHashContent =
+        reinterpret_cast<const DxilShaderHash *>(GetDxilPartData(*it));
+      Stream << "; shader hash: ";
+      for (int i = 0; i < 16; ++i)
+        Stream << format("%.2x", pHashContent->Digest[i]);
+      if (pHashContent->Flags & (uint32_t)DxilShaderHashFlags::IncludesSource)
+        Stream << " (includes source)";
+      Stream << "\n";
+    }
+
+    it = std::find_if(begin(pContainer), end(pContainer),
                       DxilPartIsType(DFCC_DXIL));
     if (it == end(pContainer)) {
       return DXC_E_CONTAINER_MISSING_DXIL;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -586,7 +586,12 @@ public:
           SerializeFlags |= SerializeDxilFlags::IncludeDebugInfoPart;
         }
         if (opts.DebugNameForSource) {
+          // Implies name part
+          SerializeFlags |= SerializeDxilFlags::IncludeDebugNamePart;
           SerializeFlags |= SerializeDxilFlags::DebugNameDependOnSource;
+        } else if (opts.DebugNameForBinary) {
+          // Implies name part
+          SerializeFlags |= SerializeDxilFlags::IncludeDebugNamePart;
         }
         if (opts.StripReflection) {
           SerializeFlags |= SerializeDxilFlags::StripReflectionFromDxilPart;

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -422,7 +422,7 @@ public:
     if (hrVer == E_NOINTERFACE) return false;
     VERIFY_SUCCEEDED(hrVer);
     VERIFY_SUCCEEDED(pVersionInfo->GetVersion(&Major, &Minor));
-    return Major == 1 && (Minor >= 1);
+    return !(Major == 1 && Minor < 1);
   }
 
   bool DoesValidatorSupportShaderHash() {
@@ -432,7 +432,7 @@ public:
     if (hrVer == E_NOINTERFACE) return false;
     VERIFY_SUCCEEDED(hrVer);
     VERIFY_SUCCEEDED(pVersionInfo->GetVersion(&Major, &Minor));
-    return Major == 1 && (Minor >= 5);
+    return !(Major == 1 && Minor < 5);
   }
 
   std::string CompileToDebugName(LPCSTR program, LPCWSTR entryPoint,


### PR DESCRIPTION
Includes minor behavior changes regarding debug name/hashing:
1. Default to hashing shader module rather than debug module, so separate compilation for debug version can match by default, without having to include special flags.
2. Produce debug name and hash when using -Zsb, even without -Zi or -Fd