### PR TITLE
Hide Unix symbols by default

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -189,7 +189,7 @@ if( LLVM_ENABLE_PIC )
       # MinGW warns if -fvisibility-inlines-hidden is used.
     else()
       check_cxx_compiler_flag("-fvisibility-inlines-hidden" SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG)
-      append_if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG "-fvisibility-inlines-hidden" CMAKE_CXX_FLAGS)
+      append_if(SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG "-fvisibility-inlines-hidden -fvisibility=hidden" CMAKE_CXX_FLAGS)
     endif()
   endif()
 endif()

--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -54,16 +54,10 @@ void DxcClearThreadMalloc() throw();
 // Used to retrieve the current invocation's allocator or perform an alloc/free/realloc.
 IMalloc *DxcGetThreadMallocNoRef() throw();
 
-#if defined(LLVM_ON_UNIX)
-#define DXC_HIDDEN_LINKAGE __attribute__(( visibility("hidden") ))
-#else  // LLVM_ON_UNIX
-#define DXC_HIDDEN_LINKAGE
-#endif  // LLVM_ON_UNIX
-
 class DxcThreadMalloc {
 public:
-  explicit DXC_HIDDEN_LINKAGE DxcThreadMalloc(IMalloc *pMallocOrNull) throw();
-  DXC_HIDDEN_LINKAGE ~DxcThreadMalloc();
+  explicit DxcThreadMalloc(IMalloc *pMallocOrNull) throw();
+  ~DxcThreadMalloc();
 
   IMalloc *GetInstalledAllocator() const { return p; }
 

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -509,9 +509,9 @@ public:                                                                        \
   static REFIID uuidof() { return static_cast<REFIID>(&T##_ID); }              \
                                                                                \
 private:                                                                       \
-  static const char T##_ID;
+   __attribute__ ((visibility ("default"))) static const char T##_ID;
 
-#define DEFINE_CROSS_PLATFORM_UUIDOF(T) const char T::T##_ID = '\0';
+#define DEFINE_CROSS_PLATFORM_UUIDOF(T) __attribute__ ((visibility ("default"))) const char T::T##_ID = '\0';
 #define __uuidof(T) T::uuidof()
 #define IID_PPV_ARGS(ppType)                                                   \
   (**(ppType)).uuidof(), reinterpret_cast<void **>(ppType)

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -13,8 +13,14 @@
 #ifndef __DXC_API__
 #define __DXC_API__
 
+#ifdef _WIN32
 #ifndef DXC_API_IMPORT
 #define DXC_API_IMPORT __declspec(dllimport)
+#endif
+#else
+#ifndef DXC_API_IMPORT
+#define DXC_API_IMPORT __attribute__ ((visibility ("default")))
+#endif
 #endif
 
 #ifdef _WIN32

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -50,10 +50,6 @@ namespace {
 
 static HlslOptTable *g_HlslOptTable;
 
-#ifndef _WIN32
-#pragma GCC visibility push(hidden)
-#endif
-
 std::error_code hlsl::options::initHlslOptTable() {
   DXASSERT(g_HlslOptTable == nullptr, "else double-init");
   g_HlslOptTable = new (std::nothrow) HlslOptTable();
@@ -70,10 +66,6 @@ void hlsl::options::cleanupHlslOptTable() {
 const OptTable * hlsl::options::getHlslOptTable() {
   return g_HlslOptTable;
 }
-
-#ifndef _WIN32
-#pragma GCC visibility pop
-#endif
 
 void DxcDefines::push_back(llvm::StringRef value) {
   // Skip empty defines.

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -80,10 +80,10 @@ static IMalloc *DxcSwapThreadMalloc(IMalloc *pMalloc, IMalloc **ppPrior) throw()
   return pMalloc;
 }
 
-DXC_HIDDEN_LINKAGE DxcThreadMalloc::DxcThreadMalloc(IMalloc *pMallocOrNull) throw() {
+DxcThreadMalloc::DxcThreadMalloc(IMalloc *pMallocOrNull) throw() {
     p = DxcSwapThreadMalloc(pMallocOrNull ? pMallocOrNull : g_pDefaultMalloc, &pPrior);
 }
 
-DXC_HIDDEN_LINKAGE DxcThreadMalloc::~DxcThreadMalloc() {
+DxcThreadMalloc::~DxcThreadMalloc() {
     DxcSwapThreadMalloc(pPrior, nullptr);
 }

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -22,10 +22,6 @@
 static llvm::sys::ThreadLocal<IMalloc> *g_ThreadMallocTls;
 static IMalloc *g_pDefaultMalloc;
 
-#ifndef _WIN32
-#pragma GCC visibility push(hidden)
-#endif
-
 HRESULT DxcInitThreadMalloc() throw() {
   DXASSERT(g_pDefaultMalloc == nullptr, "else InitThreadMalloc already called");
 
@@ -91,7 +87,3 @@ DXC_HIDDEN_LINKAGE DxcThreadMalloc::DxcThreadMalloc(IMalloc *pMallocOrNull) thro
 DXC_HIDDEN_LINKAGE DxcThreadMalloc::~DxcThreadMalloc() {
     DxcSwapThreadMalloc(pPrior, nullptr);
 }
-
-#ifndef _WIN32
-#pragma GCC visibility pop
-#endif

--- a/tools/clang/lib/CodeGen/CMakeLists.txt
+++ b/tools/clang/lib/CodeGen/CMakeLists.txt
@@ -5,6 +5,8 @@ set(LLVM_LINK_COMPONENTS
   BitReader
   BitWriter
   Core
+  DXIL
+  DxilRootSignature
   IPO
   IRReader
   InstCombine

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -11,7 +11,11 @@
 
 #include "dxc/Support/WinIncludes.h"
 
+#ifdef _WIN32
 #define DXC_API_IMPORT __declspec(dllexport)
+#else
+#define DXC_API_IMPORT __attribute__ ((visibility ("default")))
+#endif
 
 #include "dxc/dxcisense.h"
 #include "dxc/dxctools.h"

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -4,9 +4,8 @@ if(WIN32)
 find_package(TAEF REQUIRED)
 find_package(DiaSDK REQUIRED) # Used for constants and declarations.
 find_package(D3D12 REQUIRED) # Used for ExecutionTest.cpp.
-ENDif(WIN32)
+endif(WIN32)
 
-if(WIN32)
 set( LLVM_LINK_COMPONENTS
   support
   mssupport
@@ -23,6 +22,7 @@ set( LLVM_LINK_COMPONENTS
   irreader
   )
 
+if(WIN32)
 set(HLSL_IGNORE_SOURCES
   TestMain.cpp
   HLSLTestOptions.cpp
@@ -56,12 +56,6 @@ add_clang_library(clang-hlsl-tests SHARED
   clang-hlsl-tests.rc
   )
 else (WIN32)
-set( LLVM_LINK_COMPONENTS
-  support
-  mssupport
-  dxcsupport
-  )
-
 set(HLSL_IGNORE_SOURCES
   ExecutionTest.cpp
   LinkerTest.cpp


### PR DESCRIPTION
Using the -fvisibility=hidden by default only exposes symbols that have
the __attribute__((visibility("default"))) attribute applied to them.
There are only a couple of functions that are meant to be exposed from
libdxcompiler. To expose the proper functions, the macros used to create
the UUIDs for class types are redefined with the attribute and
DXC_API_IMPORT is defined with the attribute above for non-windows
platforms.

Since we're hiding everything now, the portions that were explicitly
hidden to make MacOS work are removed.

This exposed a number of missing dependencies of libraries and unit
tests. Namely clang-hlsl-tests, clang-spirv-tests, and libclangCodeGen.

Resolves #2203