### PR TITLE
[spirv] Add OpName for specialization constants.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -6056,6 +6056,7 @@ void SpirvEmitter::createSpecConstant(const VarDecl *varDecl) {
       specConstant, varDecl->getAttr<VKConstantIdAttr>()->getSpecConstId(),
       varDecl->getLocation());
 
+  specConstant->setDebugName(varDecl->getName());
   declIdMapper.registerSpecConstant(varDecl, specConstant);
 }
 

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.init.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.init.hlsl
@@ -1,59 +1,59 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK: OpDecorate [[b0:%\d+]] SpecId 0
-// CHECK: OpDecorate [[b1:%\d+]] SpecId 1
-// CHECK: OpDecorate [[b2:%\d+]] SpecId 2
+// CHECK: OpDecorate %b0 SpecId 0
+// CHECK: OpDecorate %b1 SpecId 1
+// CHECK: OpDecorate %b2 SpecId 2
 
-// CHECK: OpDecorate [[i0:%\d+]] SpecId 10
-// CHECK: OpDecorate [[i1:%\d+]] SpecId 11
-// CHECK: OpDecorate [[i2:%\d+]] SpecId 12
-// CHECK: OpDecorate [[i3:%\d+]] SpecId 13
+// CHECK: OpDecorate %i0 SpecId 10
+// CHECK: OpDecorate %i1 SpecId 11
+// CHECK: OpDecorate %i2 SpecId 12
+// CHECK: OpDecorate %i3 SpecId 13
 
-// CHECK: OpDecorate [[u0:%\d+]] SpecId 20
+// CHECK: OpDecorate %u0 SpecId 20
 
-// CHECK: OpDecorate [[f0:%\d+]] SpecId 30
-// CHECK: OpDecorate [[f1:%\d+]] SpecId 31
-// CHECK: OpDecorate [[f2:%\d+]] SpecId 32
-// CHECK: OpDecorate [[f3:%\d+]] SpecId 33
+// CHECK: OpDecorate %f0 SpecId 30
+// CHECK: OpDecorate %f1 SpecId 31
+// CHECK: OpDecorate %f2 SpecId 32
+// CHECK: OpDecorate %f3 SpecId 33
 
-// CHECK: [[b0]] = OpSpecConstantTrue %bool
+// CHECK: %b0 = OpSpecConstantTrue %bool
 [[vk::constant_id(0)]]
 bool b0 = true;
-// CHECK: [[b1]] = OpSpecConstantFalse %bool
+// CHECK: %b1 = OpSpecConstantFalse %bool
 [[vk::constant_id(1)]]
 bool b1 = 0;
-// CHECK: [[b2]] = OpSpecConstantTrue %bool
+// CHECK: %b2 = OpSpecConstantTrue %bool
 [[vk::constant_id(2)]]
 bool b2 = 1.5;
 
 
-// CHECK:  [[i0]] = OpSpecConstant %int 42
+// CHECK:  %i0 = OpSpecConstant %int 42
 [[vk::constant_id(10)]]
 int i0 = 42;
-// CHECK:  [[i1]] = OpSpecConstant %int -42
+// CHECK:  %i1 = OpSpecConstant %int -42
 [[vk::constant_id(11)]]
 int i1 = -42;
-// CHECK:  [[i2]] = OpSpecConstant %int 1
+// CHECK:  %i2 = OpSpecConstant %int 1
 [[vk::constant_id(12)]]
 int i2 = (true);
-// CHECK:  [[i3]] = OpSpecConstant %int 2
+// CHECK:  %i3 = OpSpecConstant %int 2
 [[vk::constant_id(13)]]
 int i3 = 2.5;
 
-// CHECK: [[u0]] = OpSpecConstant %uint 56
+// CHECK: %u0 = OpSpecConstant %uint 56
 [[vk::constant_id(20)]]
-uint uintConst1 = 56;
+uint u0 = 56;
 
-// CHECK: [[f0]] = OpSpecConstant %float 4.5
+// CHECK: %f0 = OpSpecConstant %float 4.5
 [[vk::constant_id(30)]]
 float f0 = (4.5);
-// CHECK: [[f1]] = OpSpecConstant %float -4.5
+// CHECK: %f1 = OpSpecConstant %float -4.5
 [[vk::constant_id(31)]]
 float f1 = -4.5;
-// CHECK: [[f2]] = OpSpecConstant %float 1
+// CHECK: %f2 = OpSpecConstant %float 1
 [[vk::constant_id(32)]]
 float f2 = true;
-// CHECK: [[f3]] = OpSpecConstant %float 20
+// CHECK: %f3 = OpSpecConstant %float 20
 [[vk::constant_id(33)]]
 float f3 = 20;
 

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.usage.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.usage.hlsl
@@ -1,8 +1,8 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK: OpDecorate [[sc:%\d+]] SpecId 10
+// CHECK: OpDecorate %specConst SpecId 10
 [[vk::constant_id(10)]]
-// CHECK: [[sc]] = OpSpecConstant %int 12
+// CHECK: %specConst = OpSpecConstant %int 12
 const int specConst = 12;
 
 // TODO: The frontend parsing hits assertion failures saying cannot evaluating
@@ -14,7 +14,7 @@ cbuffer Data {
 };
 */
 
-// CHECK: [[add:%\d+]] = OpSpecConstantOp %int IAdd [[sc]] %int_3
+// CHECK: [[add:%\d+]] = OpSpecConstantOp %int IAdd %specConst %int_3
 static const int val = specConst + 3;
 
 // CHECK-LABEL:  %main = OpFunction


### PR DESCRIPTION
Fixes #2214 