### PR TITLE
[spirv] Add missing enum under SpirvVariable class.

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -455,7 +455,8 @@ public:
     TBuffer = 1,
     PushConstant = 2,
     Globals = 3,
-    None = 4
+    ShaderRecordBufferNV = 4,
+    None = 5
   };
 
   SpirvVariable(QualType resultType, SourceLocation loc, spv::StorageClass sc,


### PR DESCRIPTION
@ehsannas for this minor review

sparmarNV pointed out that i missed updating this enum and is not consistent with DeclResultIdMapper.h
It seems to me this is actually never used and suspect this is some vestigial remains during V2 transition.
I am updating this to keep it consistent and avoid confusion.
I can remove ContextUsageKind from SpirvVariable if that is right thing to do.

Thanks