### PR TITLE
Expose code completion API

### DIFF
--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -807,22 +807,23 @@ IDxcUnsavedFile : public IUnknown
 struct __declspec(uuid("1E06466A-FD8B-45F3-A78F-8A3F76EBB552"))
 IDxcCodeCompleteResults : public IUnknown
 {
-  virtual HRESULT STDMETHODCALLTYPE GetNumResults(_Out_ unsigned *pResult) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetResultAt(unsigned index, _Outptr_result_nullonfailure_ IDxcCompletionResult **pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetNumResults(_Out_ unsigned* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetResultAt(unsigned index, _Outptr_result_nullonfailure_ IDxcCompletionResult** pResult) = 0;
 };
 
 struct __declspec(uuid("943C0588-22D0-4784-86FC-701F802AC2B6"))
 IDxcCompletionResult : public IUnknown
 {
-  virtual HRESULT STDMETHODCALLTYPE GetCursorKind(_Out_ DxcCursorKind *pResult) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetCompletionString(_Outptr_result_nullonfailure_ IDxcCompletionString **pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCursorKind(_Out_ DxcCursorKind* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCompletionString(_Outptr_result_nullonfailure_ IDxcCompletionString** pResult) = 0;
 };
 
 struct __declspec(uuid("06B51E0F-A605-4C69-A110-CD6E14B58EEC"))
 IDxcCompletionString : public IUnknown
 {
-  virtual HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned *pResult) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetCompletionChunkKind(unsigned chunkNumber, _Out_ DxcCompletionChunkKind *pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCompletionChunkKind(unsigned chunkNumber, _Out_ DxcCompletionChunkKind* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCompletionChunkText(unsigned chunkNumber, _Out_ LPSTR* pResult) = 0;
 };
 
 // Fun fact: 'extern' is required because const is by default static in C++, so

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -564,6 +564,39 @@ enum DxcCursorKindFlags
   DxcCursorKind_Unexposed = 0x100,
 };
 
+enum DxcCodeCompleteFlags
+{
+  DxcCodeCompleteFlags_None = 0,
+  DxcCodeCompleteFlags_IncludeMacros = 0x1,
+  DxcCodeCompleteFlags_IncludeCodePatterns = 0x2,
+  DxcCodeCompleteFlags_IncludeBriefComments = 0x4,
+};
+
+enum DxcCompletionChunkKind
+{
+  DxcCompletionChunk_Optional = 0,
+  DxcCompletionChunk_TypedText = 1,
+  DxcCompletionChunk_Text = 2,
+  DxcCompletionChunk_Placeholder = 3,
+  DxcCompletionChunk_Informative = 4,
+  DxcCompletionChunk_CurrentParameter = 5,
+  DxcCompletionChunk_LeftParen = 6,
+  DxcCompletionChunk_RightParen = 7,
+  DxcCompletionChunk_LeftBracket = 8,
+  DxcCompletionChunk_RightBracket = 9,
+  DxcCompletionChunk_LeftBrace = 10,
+  DxcCompletionChunk_RightBrace = 11,
+  DxcCompletionChunk_LeftAngle = 12,
+  DxcCompletionChunk_RightAngle = 13,
+  DxcCompletionChunk_Comma = 14,
+  DxcCompletionChunk_ResultType = 15,
+  DxcCompletionChunk_Colon = 16,
+  DxcCompletionChunk_SemiColon = 17,
+  DxcCompletionChunk_Equal = 18,
+  DxcCompletionChunk_HorizontalSpace = 19,
+  DxcCompletionChunk_VerticalSpace = 20,
+};
+
 struct IDxcCursor;
 struct IDxcDiagnostic;
 struct IDxcFile;
@@ -576,6 +609,9 @@ struct IDxcToken;
 struct IDxcTranslationUnit;
 struct IDxcType;
 struct IDxcUnsavedFile;
+struct IDxcCodeCompleteResults;
+struct IDxcCompletionResult;
+struct IDxcCompletionString;
 
 struct __declspec(uuid("1467b985-288d-4d2a-80c1-ef89c42c40bc"))
 IDxcCursor : public IUnknown
@@ -744,6 +780,11 @@ IDxcTranslationUnit : public IUnknown
     _Out_ unsigned* errorLength,
     _Out_ BSTR* errorMessage) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetInclusionList(_Out_ unsigned* pResultCount, _Outptr_result_buffer_(*pResultCount) IDxcInclusion*** pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE CodeCompleteAt(
+      _In_ char *fileName, unsigned line, unsigned column,
+      _In_ IDxcUnsavedFile** pUnsavedFiles, unsigned numUnsavedFiles,
+      _In_ DxcCodeCompleteFlags options,
+      _Outptr_result_nullonfailure_ IDxcCodeCompleteResults **pResult) = 0;
 };
 
 struct __declspec(uuid("2ec912fd-b144-4a15-ad0d-1c5439c81e46"))
@@ -760,6 +801,28 @@ IDxcUnsavedFile : public IUnknown
   virtual HRESULT STDMETHODCALLTYPE GetFileName(_Outptr_result_z_ LPSTR* pFileName) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetContents(_Outptr_result_z_ LPSTR* pContents) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetLength(_Out_ unsigned* pLength) = 0;
+};
+
+
+struct __declspec(uuid("1E06466A-FD8B-45F3-A78F-8A3F76EBB552"))
+IDxcCodeCompleteResults : public IUnknown
+{
+  virtual HRESULT STDMETHODCALLTYPE GetNumResults(_Out_ unsigned *pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetResultAt(unsigned index, _Outptr_result_nullonfailure_ IDxcCompletionResult **pResult) = 0;
+};
+
+struct __declspec(uuid("943C0588-22D0-4784-86FC-701F802AC2B6"))
+IDxcCompletionResult : public IUnknown
+{
+  virtual HRESULT STDMETHODCALLTYPE GetCursorKind(_Out_ DxcCursorKind *pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCompletionString(_Outptr_result_nullonfailure_ IDxcCompletionString **pResult) = 0;
+};
+
+struct __declspec(uuid("06B51E0F-A605-4C69-A110-CD6E14B58EEC"))
+IDxcCompletionString : public IUnknown
+{
+  virtual HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned *pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetCompletionChunkKind(unsigned chunkNumber, _Out_ DxcCompletionChunkKind *pResult) = 0;
 };
 
 // Fun fact: 'extern' is required because const is by default static in C++, so

--- a/tools/clang/lib/Frontend/ASTUnit.cpp
+++ b/tools/clang/lib/Frontend/ASTUnit.cpp
@@ -48,6 +48,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include "clang/Frontend/VerifyDiagnosticConsumer.h"  // HLSL Change
+#include "llvm/Support/ManagedStatic.h" // HLSL Change
 using namespace clang;
 
 using llvm::TimeRecord;
@@ -104,28 +105,12 @@ static llvm::sys::SmartMutex<false> &getOnDiskMutex() {
   return M;
 }
 
-static void __cdecl cleanupOnDiskMapAtExit(); // HLSL Change - __cdecl
-
+// HLSL Change: use ManagedStatic
 typedef llvm::DenseMap<const ASTUnit *,
                        std::unique_ptr<OnDiskData>> OnDiskDataMap;
 static OnDiskDataMap &getOnDiskDataMap() {
-  static OnDiskDataMap M;
-  static bool hasRegisteredAtExit = false;
-  if (!hasRegisteredAtExit) {
-    hasRegisteredAtExit = true;
-    atexit(cleanupOnDiskMapAtExit);
-  }
-  return M;
-}
-
-static void __cdecl cleanupOnDiskMapAtExit() {  // HLSL Change - __cdecl
-  // Use the mutex because there can be an alive thread destroying an ASTUnit.
-  llvm::MutexGuard Guard(getOnDiskMutex());
-  for (const auto &I : getOnDiskDataMap()) {
-    // We don't worry about freeing the memory associated with OnDiskDataMap.
-    // All we care about is erasing stale files.
-    I.second->Cleanup();
-  }
+  static llvm::ManagedStatic<OnDiskDataMap> M;
+  return *M;
 }
 
 static OnDiskData &getOnDiskData(const ASTUnit *AU) {

--- a/tools/clang/tools/libclang/CIndexCodeCompletion.cpp
+++ b/tools/clang/tools/libclang/CIndexCodeCompletion.cpp
@@ -825,7 +825,8 @@ CXCodeCompleteResults *clang_codeCompleteAt(CXTranslationUnit TU,
     complete_column, llvm::makeArrayRef(unsaved_files, num_unsaved_files),
     options, nullptr};
 
-  if (getenv("LIBCLANG_NOTHREADS")) {
+  // HLSL Change - Force code completion to run on current thread.
+  if (true || getenv("LIBCLANG_NOTHREADS")) {
     clang_codeCompleteAt_Impl(&CCAI);
     return CCAI.result;
   }

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1920,6 +1920,7 @@ DxcCodeCompleteResults::DxcCodeCompleteResults()
 
 DxcCodeCompleteResults::~DxcCodeCompleteResults()
 {
+	clang_disposeCodeCompleteResults(&m_ccr);
 }
 
 void DxcCodeCompleteResults::Initialize(const CXCodeCompleteResults& ccr)
@@ -2034,6 +2035,14 @@ HRESULT DxcCompletionString::GetCompletionChunkKind(unsigned chunkNumber, DxcCom
   if (pResult == nullptr) return E_POINTER;
   *pResult = (DxcCompletionChunkKind)clang_getCompletionChunkKind(m_cs, chunkNumber);
   return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCompletionString::GetCompletionChunkText(unsigned chunkNumber, LPSTR* pResult)
+{
+	if (pResult == nullptr) return E_POINTER;
+	DxcThreadMalloc TM(m_pMalloc);
+	return CXStringToAnsiAndDispose(clang_getCompletionChunkText(m_cs, chunkNumber), pResult);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1823,6 +1823,36 @@ HRESULT DxcTranslationUnit::GetInclusionList(unsigned *pResultCount,
   return S_OK;
 }
 
+_Use_decl_annotations_
+HRESULT DxcTranslationUnit::CodeCompleteAt(
+	char *fileName, unsigned line, unsigned column,
+	IDxcUnsavedFile **pUnsavedFiles, unsigned numUnsavedFiles,
+	DxcCodeCompleteFlags options, IDxcCodeCompleteResults **pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+
+  DxcThreadMalloc TM(m_pMalloc);
+
+  CXUnsavedFile *files;
+  HRESULT hr = SetupUnsavedFiles(pUnsavedFiles, numUnsavedFiles, &files);
+  if (FAILED(hr))
+    return hr;
+
+  CXCodeCompleteResults *results = clang_codeCompleteAt(
+      m_tu, fileName, line, column, files, numUnsavedFiles, options);
+
+  if (results == nullptr) return E_FAIL;
+  *pResult = nullptr;
+  DxcCodeCompleteResults *newValue =
+      new (std::nothrow) DxcCodeCompleteResults();
+  if (newValue == nullptr)
+    return E_OUTOFMEMORY;
+  newValue->Initialize(*results);
+  newValue->AddRef();
+  *pResult = newValue;
+  return S_OK;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 DxcType::DxcType()
@@ -1878,6 +1908,131 @@ HRESULT DxcType::GetKind(DxcTypeKind* pResult)
 {
   if (pResult == nullptr) return E_POINTER;
   *pResult = (DxcTypeKind)m_type.kind;
+  return S_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+DxcCodeCompleteResults::DxcCodeCompleteResults()
+{
+  m_pMalloc = DxcGetThreadMallocNoRef();
+}
+
+DxcCodeCompleteResults::~DxcCodeCompleteResults()
+{
+}
+
+void DxcCodeCompleteResults::Initialize(const CXCodeCompleteResults& ccr)
+{
+  m_ccr = ccr;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCodeCompleteResults::GetNumResults(unsigned *pResult)
+{
+  if (pResult == nullptr)
+    return E_POINTER;
+
+  DxcThreadMalloc TM(m_pMalloc);
+
+  *pResult = m_ccr.NumResults;
+  return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCodeCompleteResults::GetResultAt(
+  unsigned index,
+  IDxcCompletionResult **pResult)
+{
+  if (pResult == nullptr)
+    return E_POINTER;
+
+  DxcThreadMalloc TM(m_pMalloc);
+
+  CXCompletionResult result = m_ccr.Results[index];
+
+  *pResult = nullptr;
+  DxcCompletionResult *newValue = new (std::nothrow) DxcCompletionResult();
+  if (newValue == nullptr)
+    return E_OUTOFMEMORY;
+  newValue->Initialize(result);
+  newValue->AddRef();
+  *pResult = newValue;
+
+  return S_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+DxcCompletionResult::DxcCompletionResult()
+{
+  m_pMalloc = DxcGetThreadMallocNoRef();
+}
+
+DxcCompletionResult::~DxcCompletionResult()
+{
+}
+
+void DxcCompletionResult::Initialize(const CXCompletionResult &cr)
+{
+  m_cr = cr;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCompletionResult::GetCursorKind(DxcCursorKind *pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+  *pResult = (DxcCursorKind)m_cr.CursorKind;
+  return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCompletionResult::GetCompletionString(IDxcCompletionString **pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+
+  DxcThreadMalloc TM(m_pMalloc);
+
+  *pResult = nullptr;
+  DxcCompletionString *newValue = new (std::nothrow) DxcCompletionString();
+  if (newValue == nullptr)
+    return E_OUTOFMEMORY;
+  newValue->Initialize(m_cr.CompletionString);
+  newValue->AddRef();
+  *pResult = newValue;
+
+  return S_OK;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+DxcCompletionString::DxcCompletionString()
+{
+  m_pMalloc = DxcGetThreadMallocNoRef();
+}
+
+DxcCompletionString::~DxcCompletionString()
+{
+}
+
+void DxcCompletionString::Initialize(const CXCompletionString &cs)
+{
+  m_cs = cs;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCompletionString::GetNumCompletionChunks(unsigned *pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+  *pResult = clang_getNumCompletionChunks(m_cs);
+  return S_OK;
+}
+
+_Use_decl_annotations_
+HRESULT DxcCompletionString::GetCompletionChunkKind(unsigned chunkNumber, DxcCompletionChunkKind *pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+  *pResult = (DxcCompletionChunkKind)clang_getCompletionChunkKind(m_cs, chunkNumber);
   return S_OK;
 }
 
@@ -2052,3 +2207,27 @@ C_ASSERT((int)DxcCursor_FirstExtraDecl == (int)CXCursor_FirstExtraDecl);
 C_ASSERT((int)DxcCursor_LastExtraDecl == (int)CXCursor_LastExtraDecl);
 
 C_ASSERT((int)DxcTranslationUnitFlags_UseCallerThread == (int)CXTranslationUnit_UseCallerThread);
+
+C_ASSERT((int)DxcCodeCompleteFlags_IncludeMacros == (int)CXCodeComplete_IncludeMacros);
+C_ASSERT((int)DxcCodeCompleteFlags_IncludeCodePatterns == (int)CXCodeComplete_IncludeCodePatterns);
+C_ASSERT((int)DxcCodeCompleteFlags_IncludeBriefComments == (int)CXCodeComplete_IncludeBriefComments);
+
+C_ASSERT((int)DxcCompletionChunk_Optional == (int)CXCompletionChunk_Optional);
+C_ASSERT((int)DxcCompletionChunk_TypedText == (int)CXCompletionChunk_TypedText);
+C_ASSERT((int)DxcCompletionChunk_Text == (int)CXCompletionChunk_Text);
+C_ASSERT((int)DxcCompletionChunk_Placeholder == (int)CXCompletionChunk_Placeholder);
+C_ASSERT((int)DxcCompletionChunk_Informative == (int)CXCompletionChunk_Informative);
+C_ASSERT((int)DxcCompletionChunk_CurrentParameter == (int)CXCompletionChunk_CurrentParameter);
+C_ASSERT((int)DxcCompletionChunk_LeftParen == (int)CXCompletionChunk_LeftParen);
+C_ASSERT((int)DxcCompletionChunk_RightParen == (int)CXCompletionChunk_RightParen);
+C_ASSERT((int)DxcCompletionChunk_LeftBracket == (int)CXCompletionChunk_LeftBracket);
+C_ASSERT((int)DxcCompletionChunk_RightBracket == (int)CXCompletionChunk_RightBracket);
+C_ASSERT((int)DxcCompletionChunk_LeftBrace == (int)CXCompletionChunk_LeftBrace);
+C_ASSERT((int)DxcCompletionChunk_RightBrace == (int)CXCompletionChunk_RightBrace);
+C_ASSERT((int)DxcCompletionChunk_Comma == (int)CXCompletionChunk_Comma);
+C_ASSERT((int)DxcCompletionChunk_ResultType == (int)CXCompletionChunk_ResultType);
+C_ASSERT((int)DxcCompletionChunk_Colon == (int)CXCompletionChunk_Colon);
+C_ASSERT((int)DxcCompletionChunk_SemiColon == (int)CXCompletionChunk_SemiColon);
+C_ASSERT((int)DxcCompletionChunk_Equal == (int)CXCompletionChunk_Equal);
+C_ASSERT((int)DxcCompletionChunk_HorizontalSpace == (int)CXCompletionChunk_HorizontalSpace);
+C_ASSERT((int)DxcCompletionChunk_VerticalSpace == (int)CXCompletionChunk_VerticalSpace);

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1841,12 +1841,17 @@ HRESULT DxcTranslationUnit::CodeCompleteAt(
   CXCodeCompleteResults *results = clang_codeCompleteAt(
       m_tu, fileName, line, column, files, numUnsavedFiles, options);
 
+  CleanupUnsavedFiles(files, numUnsavedFiles);
+
   if (results == nullptr) return E_FAIL;
   *pResult = nullptr;
   DxcCodeCompleteResults *newValue =
       new (std::nothrow) DxcCodeCompleteResults();
   if (newValue == nullptr)
-    return E_OUTOFMEMORY;
+  {
+	  clang_disposeCodeCompleteResults(results);
+	  return E_OUTOFMEMORY;
+  }
   newValue->Initialize(results);
   newValue->AddRef();
   *pResult = newValue;

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1847,7 +1847,7 @@ HRESULT DxcTranslationUnit::CodeCompleteAt(
       new (std::nothrow) DxcCodeCompleteResults();
   if (newValue == nullptr)
     return E_OUTOFMEMORY;
-  newValue->Initialize(*results);
+  newValue->Initialize(results);
   newValue->AddRef();
   *pResult = newValue;
   return S_OK;
@@ -1920,10 +1920,10 @@ DxcCodeCompleteResults::DxcCodeCompleteResults()
 
 DxcCodeCompleteResults::~DxcCodeCompleteResults()
 {
-	clang_disposeCodeCompleteResults(&m_ccr);
+	clang_disposeCodeCompleteResults(m_ccr);
 }
 
-void DxcCodeCompleteResults::Initialize(const CXCodeCompleteResults& ccr)
+void DxcCodeCompleteResults::Initialize(CXCodeCompleteResults* ccr)
 {
   m_ccr = ccr;
 }
@@ -1936,7 +1936,7 @@ HRESULT DxcCodeCompleteResults::GetNumResults(unsigned *pResult)
 
   DxcThreadMalloc TM(m_pMalloc);
 
-  *pResult = m_ccr.NumResults;
+  *pResult = m_ccr->NumResults;
   return S_OK;
 }
 
@@ -1950,7 +1950,7 @@ HRESULT DxcCodeCompleteResults::GetResultAt(
 
   DxcThreadMalloc TM(m_pMalloc);
 
-  CXCompletionResult result = m_ccr.Results[index];
+  CXCompletionResult result = m_ccr->Results[index];
 
   *pResult = nullptr;
   DxcCompletionResult *newValue = new (std::nothrow) DxcCompletionResult();

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -338,6 +338,12 @@ public:
       _Out_ unsigned* errorLength,
       _Out_ BSTR* errorMessage) override;
     HRESULT STDMETHODCALLTYPE GetInclusionList(_Out_ unsigned* pResultCount, _Outptr_result_buffer_(*pResultCount) IDxcInclusion*** pResult) override;
+    HRESULT STDMETHODCALLTYPE CodeCompleteAt(
+      _In_ char *fileName, unsigned line, unsigned column,
+      _In_ IDxcUnsavedFile** pUnsavedFiles, unsigned numUnsavedFiles,
+      _In_ DxcCodeCompleteFlags options,
+      _Outptr_result_nullonfailure_ IDxcCodeCompleteResults **pResult)
+      override;
 };
 
 class DxcType : public IDxcType
@@ -360,6 +366,66 @@ public:
   HRESULT STDMETHODCALLTYPE GetSpelling(_Outptr_result_maybenull_ LPSTR* pResult) override;
   HRESULT STDMETHODCALLTYPE IsEqualTo(_In_ IDxcType* other, _Out_ BOOL* pResult) override;
   HRESULT STDMETHODCALLTYPE GetKind(_Out_ DxcTypeKind* pResult) override;
+};
+
+class DxcCodeCompleteResults : public IDxcCodeCompleteResults
+{
+private:
+  DXC_MICROCOM_TM_REF_FIELDS()
+  CXCodeCompleteResults m_ccr;
+public:
+  DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
+    return DoBasicQueryInterface<IDxcCodeCompleteResults>(this, iid, ppvObject);
+  }
+
+  DxcCodeCompleteResults();
+  ~DxcCodeCompleteResults();
+  void Initialize(const CXCodeCompleteResults& ccr);
+
+  HRESULT STDMETHODCALLTYPE GetNumResults(_Out_ unsigned *pResult) override;
+  HRESULT STDMETHODCALLTYPE GetResultAt(unsigned index, _Outptr_result_nullonfailure_ IDxcCompletionResult **pResult) override;
+};
+
+class DxcCompletionResult : public IDxcCompletionResult
+{
+private:
+  DXC_MICROCOM_TM_REF_FIELDS()
+  CXCompletionResult m_cr;
+public:
+  DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
+    return DoBasicQueryInterface<IDxcCompletionResult>(this, iid, ppvObject);
+  }
+
+  DxcCompletionResult();
+  ~DxcCompletionResult();
+  void Initialize(const CXCompletionResult& cr);
+
+  HRESULT STDMETHODCALLTYPE GetCursorKind(_Out_ DxcCursorKind *pResult) override;
+  HRESULT STDMETHODCALLTYPE GetCompletionString(_Outptr_result_nullonfailure_ IDxcCompletionString **pResult) override;
+};
+
+class DxcCompletionString : public IDxcCompletionString
+{
+private:
+  DXC_MICROCOM_TM_REF_FIELDS()
+  CXCompletionString m_cs;
+public:
+  DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
+    return DoBasicQueryInterface<IDxcCompletionString>(this, iid, ppvObject);
+  }
+
+  DxcCompletionString();
+  ~DxcCompletionString();
+  void Initialize(const CXCompletionString& cs);
+
+  HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned *pResult) override;
+  HRESULT STDMETHODCALLTYPE GetCompletionChunkKind(unsigned chunkNumber, _Out_ DxcCompletionChunkKind *pResult) override;
 };
 
 HRESULT CreateDxcIntelliSense(_In_ REFIID riid, _Out_ LPVOID* ppv) throw();

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -426,6 +426,7 @@ public:
 
   HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned *pResult) override;
   HRESULT STDMETHODCALLTYPE GetCompletionChunkKind(unsigned chunkNumber, _Out_ DxcCompletionChunkKind *pResult) override;
+  HRESULT STDMETHODCALLTYPE GetCompletionChunkText(unsigned chunkNumber, _Out_ LPSTR* pResult) override;
 };
 
 HRESULT CreateDxcIntelliSense(_In_ REFIID riid, _Out_ LPVOID* ppv) throw();

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -372,7 +372,7 @@ class DxcCodeCompleteResults : public IDxcCodeCompleteResults
 {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
-  CXCodeCompleteResults m_ccr;
+  CXCodeCompleteResults* m_ccr;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
@@ -382,7 +382,7 @@ public:
 
   DxcCodeCompleteResults();
   ~DxcCodeCompleteResults();
-  void Initialize(const CXCodeCompleteResults& ccr);
+  void Initialize(CXCodeCompleteResults* ccr);
 
   HRESULT STDMETHODCALLTYPE GetNumResults(_Out_ unsigned *pResult) override;
   HRESULT STDMETHODCALLTYPE GetResultAt(unsigned index, _Outptr_result_nullonfailure_ IDxcCompletionResult **pResult) override;

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -805,7 +805,7 @@ TEST_F(DXIntellisenseTest, CompletionWhenResultsAvailable)
   VERIFY_SUCCEEDED(result.TU->CodeCompleteAt(fileName, 2, 1, &unsavedFile.p, 1, DxcCodeCompleteFlags_None, &codeCompleteResults));
   unsigned numResults;
   VERIFY_SUCCEEDED(codeCompleteResults->GetNumResults(&numResults));
-  VERIFY_ARE_EQUAL(102, numResults);
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(numResults, 1);
   CComPtr<IDxcCompletionResult> completionResult;
   VERIFY_SUCCEEDED(codeCompleteResults->GetResultAt(0, &completionResult));
   DxcCursorKind completionResultCursorKind;

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -805,7 +805,7 @@ TEST_F(DXIntellisenseTest, CompletionWhenResultsAvailable)
   VERIFY_SUCCEEDED(result.TU->CodeCompleteAt(fileName, 2, 1, &unsavedFile.p, 1, DxcCodeCompleteFlags_None, &codeCompleteResults));
   unsigned numResults;
   VERIFY_SUCCEEDED(codeCompleteResults->GetNumResults(&numResults));
-  VERIFY_IS_GREATER_THAN_OR_EQUAL(numResults, 1);
+  VERIFY_IS_GREATER_THAN_OR_EQUAL(numResults, 1u);
   CComPtr<IDxcCompletionResult> completionResult;
   VERIFY_SUCCEEDED(codeCompleteResults->GetResultAt(0, &completionResult));
   DxcCursorKind completionResultCursorKind;

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -120,6 +120,8 @@ protected:
   TEST_METHOD(QualifiedNameVariable)
 
   TEST_METHOD(TypeWhenICEThenEval)
+
+  TEST_METHOD(CompletionWhenResultsAvailable)
 };
 
 bool DXIntellisenseTest::DXIntellisenseTestClassSetup() {
@@ -787,4 +789,19 @@ TEST_F(DXIntellisenseTest, TypeWhenICEThenEval)
   CComHeapPtr<char> name;
   VERIFY_SUCCEEDED(typeCursor->GetSpelling(&name));
   VERIFY_ARE_EQUAL_STR("const float [2]", name); // global variables converted to const by default
+}
+
+TEST_F(DXIntellisenseTest, CompletionWhenResultsAvailable)
+{
+  char program[] = "floa";
+  CompilationResult result(CompilationResult::CreateForProgram(program, _countof(program)));
+  VERIFY_ARE_EQUAL(false, result.ParseSucceeded());
+  char* fileName = "filename.hlsl";
+  CComPtr<IDxcUnsavedFile> unsavedFile;
+  IFE(TrivialDxcUnsavedFile::Create(fileName, program, &unsavedFile));
+  CComPtr<IDxcCodeCompleteResults> codeCompleteResults;
+  VERIFY_SUCCEEDED(result.TU->CodeCompleteAt(fileName, 1, 1, &unsavedFile.p, 1, DxcCodeCompleteFlags_None, &codeCompleteResults));
+  unsigned numResults;
+  VERIFY_SUCCEEDED(codeCompleteResults->GetNumResults(&numResults));
+  VERIFY_ARE_EQUAL(1, numResults);
 }

--- a/tools/clang/unittests/HLSL/WEXAdapter.h
+++ b/tools/clang/unittests/HLSL/WEXAdapter.h
@@ -59,6 +59,8 @@
 #define VERIFY_IS_NOT_NULL_2(expr, msg) EXPECT_NE(nullptr, (expr)) << msg
 #define VERIFY_IS_NOT_NULL(...) MACRO_N(VERIFY_IS_NOT_NULL_, __VA_ARGS__)
 
+#define VERIFY_IS_GREATER_THAN_OR_EQUAL(greater, less) EXPECT_GE(greater, less)
+
 #define VERIFY_WIN32_BOOL_SUCCEEDED_1(expr) EXPECT_TRUE(expr)
 #define VERIFY_WIN32_BOOL_SUCCEEDED_2(expr, msg) EXPECT_TRUE(expr) << msg
 #define VERIFY_WIN32_BOOL_SUCCEEDED(...) MACRO_N(VERIFY_WIN32_BOOL_SUCCEEDED_, __VA_ARGS__)


### PR DESCRIPTION
I've made a start on extending the existing IntelliSense support by exposing code completion APIs.

There's still a lot to do, but I've hit an early obstacle, which I'm hoping somebody more experienced with the codebase can maybe help me with!

I've added a new `DXIntellisenseTest` test called `CompletionWhenResultsAvailable`. This test calls `DxcTranslationUnit::CodeCompleteAt`, which eventually crashes on this line in `DXCompiler.cpp` because `DxcGetThreadMallocNoRef()` returns a `nullptr`:

``` cpp
return DxcGetThreadMallocNoRef()->Alloc(size);
```

I've looked at the other functions in `DxcTranslationUnit`, and I think I'm doing the same thing they are with this code:

``` cpp
DxcThreadMalloc TM(m_pMalloc);
```

What am I missing?