### PR TITLE
[spirv] Cleanups related to handling of storage classes

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -114,10 +114,6 @@ public:
   createCompositeConstruct(QualType resultType,
                            llvm::ArrayRef<SpirvInstruction *> constituents,
                            SourceLocation loc);
-  SpirvCompositeConstruct *
-  createCompositeConstruct(const SpirvType *resultType,
-                           llvm::ArrayRef<SpirvInstruction *> constituents,
-                           SourceLocation loc);
 
   /// \brief Creates a composite extract instruction. The given composite is
   /// indexed using the given literal indexes to obtain the resulting element.

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -167,12 +167,11 @@ public:
   /// \brief Creates an access chain instruction to retrieve the element from
   /// the given base by walking through the given indexes. Returns the
   /// instruction pointer for the pointer to the element.
+  /// Note: The given 'resultType' should be the underlying value type, not the
+  /// pointer type. The type lowering pass automatically adds pointerness and
+  /// proper storage class (based on the access base) to the result type.
   SpirvAccessChain *
   createAccessChain(QualType resultType, SpirvInstruction *base,
-                    llvm::ArrayRef<SpirvInstruction *> indexes,
-                    SourceLocation loc);
-  SpirvAccessChain *
-  createAccessChain(const SpirvType *resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
                     SourceLocation loc);
 

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -399,7 +399,7 @@ SpirvInstruction *GlPerVertex::readClipCullArrayAsType(
 
   // The ClipDistance/CullDistance is always an float array. We are accessing
   // it using pointers, which should be of pointer to float type.
-  const FloatType *f32Type = spvContext.getFloatType(32);
+  const QualType f32Type = astContext.FloatTy;
 
   if (inArraySize == 0) {
     // The input builtin does not have extra arrayness. Only need one index
@@ -411,9 +411,9 @@ SpirvInstruction *GlPerVertex::readClipCullArrayAsType(
     if (isScalarType(asType)) {
       auto *spirvConstant = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                                       llvm::APInt(32, offset));
-      auto *ptr = spvBuilder.createAccessChain(astContext.FloatTy, clipCullVar,
+      auto *ptr = spvBuilder.createAccessChain(f32Type, clipCullVar,
                                                {spirvConstant}, loc);
-      return spvBuilder.createLoad(astContext.FloatTy, ptr, loc);
+      return spvBuilder.createLoad(f32Type, ptr, loc);
     }
 
     if (isVectorType(asType, &elemType, &count)) {
@@ -424,12 +424,12 @@ SpirvInstruction *GlPerVertex::readClipCullArrayAsType(
         // Read elements sequentially from the float array
         auto *spirvConstant = spvBuilder.getConstantInt(
             astContext.UnsignedIntTy, llvm::APInt(32, offset + i));
-        auto *ptr = spvBuilder.createAccessChain(
-            astContext.FloatTy, clipCullVar, {spirvConstant}, loc);
-        elements.push_back(spvBuilder.createLoad(astContext.FloatTy, ptr, loc));
+        auto *ptr = spvBuilder.createAccessChain(f32Type, clipCullVar,
+                                                 {spirvConstant}, loc);
+        elements.push_back(spvBuilder.createLoad(f32Type, ptr, loc));
       }
       return spvBuilder.createCompositeConstruct(
-          spvContext.getVectorType(f32Type, count), elements, loc);
+          astContext.getExtVectorType(f32Type, count), elements, loc);
     }
 
     llvm_unreachable("SV_ClipDistance/SV_CullDistance not float or vector of "
@@ -446,33 +446,32 @@ SpirvInstruction *GlPerVertex::readClipCullArrayAsType(
   llvm::SmallVector<SpirvInstruction *, 8> arrayElements;
   QualType elemType = {};
   uint32_t count = {};
-  const ArrayType *arrayType = nullptr;
+  QualType arrayType = {};
 
   if (isScalarType(asType)) {
-    arrayType = spvContext.getArrayType(f32Type, inArraySize,
-                                        /*ArrayStride*/ llvm::None);
+    arrayType = astContext.getConstantArrayType(
+        f32Type, llvm::APInt(32, inArraySize), clang::ArrayType::Normal, 0);
     for (uint32_t i = 0; i < inArraySize; ++i) {
       auto *ptr = spvBuilder.createAccessChain(
-          astContext.FloatTy, clipCullVar,
+          f32Type, clipCullVar,
           {spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                      llvm::APInt(32, i)), // Block array index
            spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                      llvm::APInt(32, offset))},
           loc);
-      arrayElements.push_back(
-          spvBuilder.createLoad(astContext.FloatTy, ptr, loc));
+      arrayElements.push_back(spvBuilder.createLoad(f32Type, ptr, loc));
     }
   } else if (isVectorType(asType, &elemType, &count)) {
-    arrayType =
-        spvContext.getArrayType(spvContext.getVectorType(f32Type, count),
-                                inArraySize, /*ArrayStride*/ llvm::None);
+    arrayType = astContext.getConstantArrayType(
+        astContext.getExtVectorType(f32Type, count),
+        llvm::APInt(32, inArraySize), clang::ArrayType::Normal, 0);
 
     for (uint32_t i = 0; i < inArraySize; ++i) {
       // For each gl_PerVertex block, we need to read a vector from it.
       llvm::SmallVector<SpirvInstruction *, 4> vecElements;
       for (uint32_t j = 0; j < count; ++j) {
         auto *ptr = spvBuilder.createAccessChain(
-            astContext.FloatTy, clipCullVar,
+            f32Type, clipCullVar,
             // Block array index
             {spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                        llvm::APInt(32, i)),
@@ -480,11 +479,10 @@ SpirvInstruction *GlPerVertex::readClipCullArrayAsType(
              spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                        llvm::APInt(32, offset + j))},
             loc);
-        vecElements.push_back(
-            spvBuilder.createLoad(astContext.FloatTy, ptr, loc));
+        vecElements.push_back(spvBuilder.createLoad(f32Type, ptr, loc));
       }
       arrayElements.push_back(spvBuilder.createCompositeConstruct(
-          spvContext.getVectorType(f32Type, count), vecElements, loc));
+          astContext.getExtVectorType(f32Type, count), vecElements, loc));
     }
   } else {
     llvm_unreachable("SV_ClipDistance/SV_CullDistance not float or vector of "
@@ -534,7 +532,7 @@ void GlPerVertex::writeClipCullArrayFromType(
 
   // The ClipDistance/CullDistance is always an float array. We are accessing
   // it using pointers, which should be of pointer to float type.
-  const FloatType *f32Type = spvContext.getFloatType(32);
+  const QualType f32Type = astContext.FloatTy;
 
   if (outArraySize == 0) {
     // The output builtin does not have extra arrayness. Only need one index
@@ -546,8 +544,8 @@ void GlPerVertex::writeClipCullArrayFromType(
     if (isScalarType(fromType)) {
       auto *constant = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                                  llvm::APInt(32, offset));
-      auto *ptr = spvBuilder.createAccessChain(astContext.FloatTy, clipCullVar,
-                                               {constant}, loc);
+      auto *ptr =
+          spvBuilder.createAccessChain(f32Type, clipCullVar, {constant}, loc);
       spvBuilder.createStore(ptr, fromValue, loc);
       return;
     }
@@ -559,10 +557,10 @@ void GlPerVertex::writeClipCullArrayFromType(
         // Write elements sequentially into the float array
         auto *constant = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                                    llvm::APInt(32, offset + i));
-        auto *ptr = spvBuilder.createAccessChain(astContext.FloatTy,
-                                                 clipCullVar, {constant}, loc);
-        auto *subValue = spvBuilder.createCompositeExtract(astContext.FloatTy,
-                                                           fromValue, {i}, loc);
+        auto *ptr =
+            spvBuilder.createAccessChain(f32Type, clipCullVar, {constant}, loc);
+        auto *subValue =
+            spvBuilder.createCompositeExtract(f32Type, fromValue, {i}, loc);
         spvBuilder.createStore(ptr, subValue, loc);
       }
       return;
@@ -591,7 +589,7 @@ void GlPerVertex::writeClipCullArrayFromType(
 
   if (isScalarType(fromType)) {
     auto *ptr = spvBuilder.createAccessChain(
-        astContext.FloatTy, clipCullVar,
+        f32Type, clipCullVar,
         {arrayIndex, spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                                llvm::APInt(32, offset))},
         loc);
@@ -603,7 +601,7 @@ void GlPerVertex::writeClipCullArrayFromType(
     // For each gl_PerVertex block, we need to write a vector into it.
     for (uint32_t i = 0; i < count; ++i) {
       auto *ptr = spvBuilder.createAccessChain(
-          astContext.FloatTy, clipCullVar,
+          f32Type, clipCullVar,
           // Block array index
           {arrayIndex,
            // Write elements sequentially into the float array
@@ -611,8 +609,8 @@ void GlPerVertex::writeClipCullArrayFromType(
                                      llvm::APInt(32, offset + i))},
           loc);
 
-      auto *subValue = spvBuilder.createCompositeExtract(astContext.FloatTy,
-                                                         fromValue, {i}, loc);
+      auto *subValue =
+          spvBuilder.createCompositeExtract(f32Type, fromValue, {i}, loc);
       spvBuilder.createStore(ptr, subValue, loc);
     }
     return;

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -91,6 +91,15 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
     instr->setResultType(pointerType);
     break;
   }
+  // Access chains must have a pointer type. The storage class for the pointer
+  // is the same as the storage class of the access base.
+  case spv::Op::OpAccessChain: {
+    const auto *pointerType = spvContext.getPointerType(
+        resultType,
+        cast<SpirvAccessChain>(instr)->getBase()->getStorageClass());
+    instr->setResultType(pointerType);
+    break;
+  }
   // OpImageTexelPointer's result type must be a pointer with image storage
   // class.
   case spv::Op::OpImageTexelPointer: {

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -198,6 +198,17 @@ SpirvLoad *SpirvBuilder::createLoad(const SpirvType *resultType,
   auto *instruction = new (context) SpirvLoad(/*QualType*/ {}, loc, pointer);
   instruction->setResultType(resultType);
   instruction->setStorageClass(pointer->getStorageClass());
+  // Special case for legalization. We could have point-to-pointer types.
+  // For example:
+  //
+  // %var = OpVariable %_ptr_Private__ptr_Uniform_type_X Private
+  // %1 = OpLoad %_ptr_Uniform_type_X %var
+  //
+  // Loading from %var should result in Uniform storage class, not Private.
+  if (const auto *ptrType = dyn_cast<SpirvPointerType>(resultType)) {
+    instruction->setStorageClass(ptrType->getStorageClass());
+  }
+
   instruction->setLayoutRule(pointer->getLayoutRule());
   instruction->setNonUniform(pointer->isNonUniform());
   instruction->setRValue(true);
@@ -243,31 +254,6 @@ SpirvBuilder::createAccessChain(QualType resultType, SpirvInstruction *base,
   assert(insertPoint && "null insert point");
   auto *instruction =
       new (context) SpirvAccessChain(resultType, loc, base, indexes);
-  instruction->setStorageClass(base->getStorageClass());
-  instruction->setLayoutRule(base->getLayoutRule());
-  bool isNonUniform = base->isNonUniform();
-  for (auto *index : indexes)
-    isNonUniform = isNonUniform || index->isNonUniform();
-  instruction->setNonUniform(isNonUniform);
-  instruction->setContainsAliasComponent(base->containsAliasComponent());
-
-  // If doing an access chain into a structured or byte address buffer, make
-  // sure the layout rule is sBufferLayoutRule.
-  if (base->hasAstResultType() &&
-      isAKindOfStructuredOrByteBuffer(base->getAstResultType()))
-    instruction->setLayoutRule(spirvOptions.sBufferLayoutRule);
-
-  insertPoint->addInstruction(instruction);
-  return instruction;
-}
-
-SpirvAccessChain *SpirvBuilder::createAccessChain(
-    const SpirvType *resultType, SpirvInstruction *base,
-    llvm::ArrayRef<SpirvInstruction *> indexes, SourceLocation loc) {
-  assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvAccessChain(/*QualType*/ {}, loc, base, indexes);
-  instruction->setResultType(resultType);
   instruction->setStorageClass(base->getStorageClass());
   instruction->setLayoutRule(base->getLayoutRule());
   bool isNonUniform = base->isNonUniform();

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -120,20 +120,6 @@ SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
   return instruction;
 }
 
-SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
-    const SpirvType *resultType,
-    llvm::ArrayRef<SpirvInstruction *> constituents, SourceLocation loc) {
-  assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvCompositeConstruct(/*QualType*/ {}, loc, constituents);
-  instruction->setResultType(resultType);
-  if (!constituents.empty()) {
-    instruction->setLayoutRule(constituents[0]->getLayoutRule());
-  }
-  insertPoint->addInstruction(instruction);
-  return instruction;
-}
-
 SpirvCompositeExtract *SpirvBuilder::createCompositeExtract(
     QualType resultType, SpirvInstruction *composite,
     llvm::ArrayRef<uint32_t> indexes, SourceLocation loc) {


### PR DESCRIPTION
This change results in better handling of storage classes. This is useful for when we want to implement the templated Load/Store for (RW)ByteAddressBuffers.