### PR TITLE
Add IDxcSourceLocation::GetPresumedLocation

### DIFF
--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -723,16 +723,16 @@ struct __declspec(uuid("8e7ddf1c-d7d3-4d69-b286-85fccba1e0cf"))
 IDxcSourceLocation : public IUnknown
 {
   virtual HRESULT STDMETHODCALLTYPE IsEqualTo(_In_ IDxcSourceLocation* other, _Out_ BOOL* pResult) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetSpellingLocation(
-    _Outptr_opt_ IDxcFile** pFile,
-    _Out_opt_ unsigned* pLine,
-    _Out_opt_ unsigned* pCol,
-    _Out_opt_ unsigned* pOffset) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetPresumedLocation(
     _Outptr_opt_ LPSTR* pFilename,
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol) = 0;
   virtual HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetSpellingLocation(
+    _Outptr_opt_ IDxcFile** pFile,
+    _Out_opt_ unsigned* pLine,
+    _Out_opt_ unsigned* pCol,
+    _Out_opt_ unsigned* pOffset) = 0;
 };
 
 struct __declspec(uuid("f1359b36-a53f-4e81-b514-b6b84122a13f"))

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -728,6 +728,10 @@ IDxcSourceLocation : public IUnknown
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetPresumedLocation(
+	  _Outptr_opt_ LPSTR* pFilename,
+	  _Out_opt_ unsigned* pLine,
+	  _Out_opt_ unsigned* pCol) = 0;
   virtual HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) = 0;
 };
 

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -723,16 +723,16 @@ struct __declspec(uuid("8e7ddf1c-d7d3-4d69-b286-85fccba1e0cf"))
 IDxcSourceLocation : public IUnknown
 {
   virtual HRESULT STDMETHODCALLTYPE IsEqualTo(_In_ IDxcSourceLocation* other, _Out_ BOOL* pResult) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetPresumedLocation(
-    _Outptr_opt_ LPSTR* pFilename,
-    _Out_opt_ unsigned* pLine,
-    _Out_opt_ unsigned* pCol) = 0;
-  virtual HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetSpellingLocation(
     _Outptr_opt_ IDxcFile** pFile,
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) = 0;
+  virtual HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetPresumedLocation(
+    _Outptr_opt_ LPSTR* pFilename,
+    _Out_opt_ unsigned* pLine,
+    _Out_opt_ unsigned* pCol) = 0;
 };
 
 struct __declspec(uuid("f1359b36-a53f-4e81-b514-b6b84122a13f"))

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -729,9 +729,9 @@ IDxcSourceLocation : public IUnknown
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetPresumedLocation(
-	  _Outptr_opt_ LPSTR* pFilename,
-	  _Out_opt_ unsigned* pLine,
-	  _Out_opt_ unsigned* pCol) = 0;
+    _Outptr_opt_ LPSTR* pFilename,
+    _Out_opt_ unsigned* pLine,
+    _Out_opt_ unsigned* pCol) = 0;
   virtual HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) = 0;
 };
 

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1341,6 +1341,26 @@ HRESULT DxcSourceLocation::GetSpellingLocation(
   return S_OK;
 }
 
+HRESULT DxcSourceLocation::GetPresumedLocation(
+	_Outptr_opt_ LPSTR* pFilename,
+	_Out_opt_ unsigned* pLine,
+	_Out_opt_ unsigned* pCol)
+{
+	DxcThreadMalloc TM(m_pMalloc);
+
+	CXString filename;
+	unsigned line, col;
+	clang_getPresumedLocation(m_location, &filename, &line, &col);
+	if (pFilename != nullptr)
+	{
+		HRESULT hr = CXStringToAnsiAndDispose(filename, pFilename);
+		if (FAILED(hr)) return hr;
+	}
+	if (pLine) *pLine = line;
+	if (pCol) *pCol = col;
+	return S_OK;
+}
+
 HRESULT DxcSourceLocation::IsNull(_Out_ BOOL* pResult)
 {
   if (pResult == nullptr) return E_POINTER;

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1341,6 +1341,14 @@ HRESULT DxcSourceLocation::GetSpellingLocation(
   return S_OK;
 }
 
+HRESULT DxcSourceLocation::IsNull(_Out_ BOOL* pResult)
+{
+  if (pResult == nullptr) return E_POINTER;
+  CXSourceLocation nullLocation = clang_getNullLocation();
+  *pResult = 0 !=clang_equalLocations(nullLocation, m_location);
+  return S_OK;
+}
+
 HRESULT DxcSourceLocation::GetPresumedLocation(
   _Outptr_opt_ LPSTR* pFilename,
   _Out_opt_ unsigned* pLine,
@@ -1358,14 +1366,6 @@ HRESULT DxcSourceLocation::GetPresumedLocation(
   }
   if (pLine) *pLine = line;
   if (pCol) *pCol = col;
-  return S_OK;
-}
-
-HRESULT DxcSourceLocation::IsNull(_Out_ BOOL* pResult)
-{
-  if (pResult == nullptr) return E_POINTER;
-  CXSourceLocation nullLocation = clang_getNullLocation();
-  *pResult = 0 !=clang_equalLocations(nullLocation, m_location);
   return S_OK;
 }
 

--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -1342,23 +1342,23 @@ HRESULT DxcSourceLocation::GetSpellingLocation(
 }
 
 HRESULT DxcSourceLocation::GetPresumedLocation(
-	_Outptr_opt_ LPSTR* pFilename,
-	_Out_opt_ unsigned* pLine,
-	_Out_opt_ unsigned* pCol)
+  _Outptr_opt_ LPSTR* pFilename,
+  _Out_opt_ unsigned* pLine,
+  _Out_opt_ unsigned* pCol)
 {
-	DxcThreadMalloc TM(m_pMalloc);
-
-	CXString filename;
-	unsigned line, col;
-	clang_getPresumedLocation(m_location, &filename, &line, &col);
-	if (pFilename != nullptr)
-	{
-		HRESULT hr = CXStringToAnsiAndDispose(filename, pFilename);
-		if (FAILED(hr)) return hr;
-	}
-	if (pLine) *pLine = line;
-	if (pCol) *pCol = col;
-	return S_OK;
+  DxcThreadMalloc TM(m_pMalloc);
+  
+  CXString filename;
+  unsigned line, col;
+  clang_getPresumedLocation(m_location, &filename, &line, &col);
+  if (pFilename != nullptr)
+  {
+    HRESULT hr = CXStringToAnsiAndDispose(filename, pFilename);
+    if (FAILED(hr)) return hr;
+  }
+  if (pLine) *pLine = line;
+  if (pCol) *pCol = col;
+  return S_OK;
 }
 
 HRESULT DxcSourceLocation::IsNull(_Out_ BOOL* pResult)

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -244,9 +244,9 @@ public:
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) override;
   HRESULT STDMETHODCALLTYPE GetPresumedLocation(
-	  _Outptr_opt_ LPSTR* pFilename,
-	  _Out_opt_ unsigned* pLine,
-	  _Out_opt_ unsigned* pCol) override;
+    _Outptr_opt_ LPSTR* pFilename,
+    _Out_opt_ unsigned* pLine,
+    _Out_opt_ unsigned* pCol) override;
   HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) override;
 };
 

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -243,11 +243,11 @@ public:
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) override;
+  HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) override;
   HRESULT STDMETHODCALLTYPE GetPresumedLocation(
     _Outptr_opt_ LPSTR* pFilename,
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol) override;
-  HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) override;
 };
 
 class DxcSourceRange : public IDxcSourceRange

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -243,6 +243,10 @@ public:
     _Out_opt_ unsigned* pLine,
     _Out_opt_ unsigned* pCol,
     _Out_opt_ unsigned* pOffset) override;
+  HRESULT STDMETHODCALLTYPE GetPresumedLocation(
+	  _Outptr_opt_ LPSTR* pFilename,
+	  _Out_opt_ unsigned* pLine,
+	  _Out_opt_ unsigned* pCol) override;
   HRESULT STDMETHODCALLTYPE IsNull(_Out_ BOOL* pResult) override;
 };
 


### PR DESCRIPTION
Add `IDxcSourceLocation::GetPresumedLocation` as a wrapper for `clang_getPresumedLocation`.

This is important for (e.g.) showing errors in the correct location in IDEs when the `#line` directive is used, primarily in generated code.