### PR TITLE
[spirv] same variable for legalization and before-hlsl-legal

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -671,7 +671,7 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
   if (!spirvOptions.disableValidation) {
     std::string messages;
     if (!spirvToolsValidate(targetEnv, spirvOptions,
-                            beforeHlslLegalization ||
+                            needsLegalization ||
                                 declIdMapper.requiresLegalization(),
                             &m, &messages)) {
       emitFatalError("generated SPIR-V is invalid: %0", {}) << messages;


### PR DESCRIPTION
We should have the same decision for HLSL legalization of spirv-opt
and --before-hlsl-legalization option of spirv-val.