### PR TITLE
Loop count for all trivial form loops. Mem2Reg only when necessary.

### DIFF
--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -261,6 +261,7 @@ void initializeResourceToHandlePass(PassRegistry&);
 void initializeSROA_SSAUp_HLSLPass(PassRegistry&);
 void initializeHoistConstantArrayPass(PassRegistry&);
 void initializeDxilLoopUnrollPass(PassRegistry&);
+void initializeDxilConditionalMem2RegPass(PassRegistry&);
 void initializeDxilFixConstArrayInitializerPass(PassRegistry&);
 // HLSL Change Ends
 void initializeScalarEvolutionAliasAnalysisPass(PassRegistry&);

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -134,6 +134,9 @@ void initializeSROA_Parameter_HLSLPass(PassRegistry&);
 Pass *createDxilFixConstArrayInitializerPass();
 void initializeDxilFixConstArrayInitializerPass(PassRegistry&);
 
+Pass *createDxilConditionalMem2RegPass(bool NoOpt);
+void initializeDxilConditionalMem2RegPass(PassRegistry&);
+
 Pass *createDxilLoopUnrollPass(unsigned MaxIterationAttempt);
 void initializeDxilLoopUnrollPass(PassRegistry&);
 //===----------------------------------------------------------------------===//

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -87,6 +87,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilAllocateResourcesForLibPass(Registry);
     initializeDxilCleanupAddrSpaceCastPass(Registry);
     initializeDxilCondenseResourcesPass(Registry);
+    initializeDxilConditionalMem2RegPass(Registry);
     initializeDxilConvergentClearPass(Registry);
     initializeDxilConvergentMarkPass(Registry);
     initializeDxilDeadFunctionEliminationPass(Registry);
@@ -190,6 +191,7 @@ static ArrayRef<LPCSTR> GetPassArgNames(LPCSTR passName) {
   static const LPCSTR ArgPromotionArgs[] = { "maxElements" };
   static const LPCSTR CFGSimplifyPassArgs[] = { "Threshold", "Ftor", "bonus-inst-threshold" };
   static const LPCSTR DxilAddPixelHitInstrumentationArgs[] = { "force-early-z", "add-pixel-cost", "rt-width", "sv-position-index", "num-pixels" };
+  static const LPCSTR DxilConditionalMem2RegArgs[] = { "NoOpt" };
   static const LPCSTR DxilDebugInstrumentationArgs[] = { "UAVSize", "parameter0", "parameter1", "parameter2" };
   static const LPCSTR DxilGenerationPassArgs[] = { "NotOptimized" };
   static const LPCSTR DxilOutputColorBecomesConstantArgs[] = { "mod-mode", "constant-red", "constant-green", "constant-blue", "constant-alpha" };
@@ -223,6 +225,7 @@ static ArrayRef<LPCSTR> GetPassArgNames(LPCSTR passName) {
   if (strcmp(passName, "argpromotion") == 0) return ArrayRef<LPCSTR>(ArgPromotionArgs, _countof(ArgPromotionArgs));
   if (strcmp(passName, "simplifycfg") == 0) return ArrayRef<LPCSTR>(CFGSimplifyPassArgs, _countof(CFGSimplifyPassArgs));
   if (strcmp(passName, "hlsl-dxil-add-pixel-hit-instrmentation") == 0) return ArrayRef<LPCSTR>(DxilAddPixelHitInstrumentationArgs, _countof(DxilAddPixelHitInstrumentationArgs));
+  if (strcmp(passName, "dxil-cond-mem2reg") == 0) return ArrayRef<LPCSTR>(DxilConditionalMem2RegArgs, _countof(DxilConditionalMem2RegArgs));
   if (strcmp(passName, "hlsl-dxil-debug-instrumentation") == 0) return ArrayRef<LPCSTR>(DxilDebugInstrumentationArgs, _countof(DxilDebugInstrumentationArgs));
   if (strcmp(passName, "dxilgen") == 0) return ArrayRef<LPCSTR>(DxilGenerationPassArgs, _countof(DxilGenerationPassArgs));
   if (strcmp(passName, "hlsl-dxil-constantColor") == 0) return ArrayRef<LPCSTR>(DxilOutputColorBecomesConstantArgs, _countof(DxilOutputColorBecomesConstantArgs));
@@ -263,6 +266,7 @@ static ArrayRef<LPCSTR> GetPassArgDescriptions(LPCSTR passName) {
   static const LPCSTR ArgPromotionArgs[] = { "None" };
   static const LPCSTR CFGSimplifyPassArgs[] = { "None", "None", "Control the number of bonus instructions (default = 1)" };
   static const LPCSTR DxilAddPixelHitInstrumentationArgs[] = { "None", "None", "None", "None", "None" };
+  static const LPCSTR DxilConditionalMem2RegArgs[] = { "None" };
   static const LPCSTR DxilDebugInstrumentationArgs[] = { "None", "None", "None", "None" };
   static const LPCSTR DxilGenerationPassArgs[] = { "None" };
   static const LPCSTR DxilOutputColorBecomesConstantArgs[] = { "None", "None", "None", "None", "None" };
@@ -296,6 +300,7 @@ static ArrayRef<LPCSTR> GetPassArgDescriptions(LPCSTR passName) {
   if (strcmp(passName, "argpromotion") == 0) return ArrayRef<LPCSTR>(ArgPromotionArgs, _countof(ArgPromotionArgs));
   if (strcmp(passName, "simplifycfg") == 0) return ArrayRef<LPCSTR>(CFGSimplifyPassArgs, _countof(CFGSimplifyPassArgs));
   if (strcmp(passName, "hlsl-dxil-add-pixel-hit-instrmentation") == 0) return ArrayRef<LPCSTR>(DxilAddPixelHitInstrumentationArgs, _countof(DxilAddPixelHitInstrumentationArgs));
+  if (strcmp(passName, "dxil-cond-mem2reg") == 0) return ArrayRef<LPCSTR>(DxilConditionalMem2RegArgs, _countof(DxilConditionalMem2RegArgs));
   if (strcmp(passName, "hlsl-dxil-debug-instrumentation") == 0) return ArrayRef<LPCSTR>(DxilDebugInstrumentationArgs, _countof(DxilDebugInstrumentationArgs));
   if (strcmp(passName, "dxilgen") == 0) return ArrayRef<LPCSTR>(DxilGenerationPassArgs, _countof(DxilGenerationPassArgs));
   if (strcmp(passName, "hlsl-dxil-constantColor") == 0) return ArrayRef<LPCSTR>(DxilOutputColorBecomesConstantArgs, _countof(DxilOutputColorBecomesConstantArgs));
@@ -340,6 +345,7 @@ static bool IsPassOptionName(StringRef S) {
     ||  S.equals("InlineThreshold")
     ||  S.equals("InsertLifetime")
     ||  S.equals("MaxHeaderSize")
+    ||  S.equals("NoOpt")
     ||  S.equals("NotOptimized")
     ||  S.equals("Os")
     ||  S.equals("ReplaceAllVectors")

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -252,10 +252,12 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   // Change dynamic indexing vector to array.
   MPM.add(createDynamicIndexingVectorToArrayPass(NoOpt));
 
-  if (!NoOpt) {
-    // mem2reg
-    MPM.add(createPromoteMemoryToRegisterPass());
+  // mem2reg
+  // Special Mem2Reg pass that only happens if optimization is
+  // enabled or loop unroll is needed.
+  MPM.add(createDxilConditionalMem2RegPass(NoOpt));
 
+  if (!NoOpt) {
     MPM.add(createDxilConvergentMarkPass());
   }
 
@@ -269,7 +271,7 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   // Needs to happen before resources are lowered and before HL
   // module is gone.
   MPM.add(createLoopRotatePass());
-  MPM.add(createDxilLoopUnrollPass(/*MaxIterationAttempt*/ 128));
+  MPM.add(createDxilLoopUnrollPass(1024));
 
   // Default unroll pass. This is purely for optimizing loops without
   // attributes.

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/precise/matrix.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/precise/matrix.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s | XFail GitHub #2080
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
 
 // Test that precise modifier on a matrix has an effect.
 

--- a/tools/clang/test/CodeGenHLSL/batch/unroll/big_step.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/unroll/big_step.hlsl
@@ -1,0 +1,38 @@
+// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// CHECK: @main
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK-NOT: @dx.op.unary.f32(i32 13
+
+// Confirm that loops with greater than 1 step should be able to be unrolled
+
+[RootSignature("")]
+float main(float y : Y) : SV_Target {
+  float x = 0;
+
+  static const uint kLoopCount = 512;
+
+  [unroll]
+  for (uint i = 0; i < kLoopCount; i += 32) {
+    x = sin(x * x + y);
+  }
+  return x;
+}

--- a/tools/clang/test/CodeGenHLSL/batch/unroll/big_step_non_trivial.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/unroll/big_step_non_trivial.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// CHECK: @main
+
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+// CHECK: @dx.op.unary.f32(i32 13
+
+// CHECK-NOT: @dx.op.unary.f32(i32 13
+
+// Confirm that loops with fairly complex exit conditions
+// should be able to be unrolled
+
+[RootSignature("")]
+float main(float y : Y) : SV_Target {
+  float x = 0;
+
+  static const uint kLoopCount = 512;
+
+  int j = 10;
+  [unroll]
+  for (uint i = 0; i < kLoopCount && j > 2; i += 16) {
+    x = sin(x * x + y);
+    i -= 8;
+    j -= 1;
+  }
+  return x;
+}

--- a/tools/clang/test/CodeGenHLSL/batch/unroll/fail.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/unroll/fail.hlsl
@@ -1,5 +1,6 @@
 // RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
 // CHECK-DAG: Could not unroll loop.
+// CHECK-DAG: -HV 2016
 // CHECK-NOT: @main
 
 // Check that the compilation fails due to unable to

--- a/tools/clang/test/CodeGenHLSL/batch/unroll/large_count.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/unroll/large_count.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
-// CHECK: Could not unroll loop
-// CHECK: To give an explicit unroll bound, use unroll(n)
-// CHECK-NOT: @main
+// CHECK: @main
+
+// Confirm that simple loops should be able to be unrolled
 
 [RootSignature("")]
 float main(float y : Y) : SV_Target {

--- a/tools/clang/test/CodeGenHLSL/batch/unroll/warning.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/unroll/warning.hlsl
@@ -1,7 +1,9 @@
-// RUN: %dxc -HV 2016 -Od -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc /HV 2016 -Od -E main -T ps_6_0 %s | FileCheck %s
 // CHECK-DAG: warning: Could not unroll loop.
+// CHECK-NOT: -HV 2016
 // CHECK-NOT: @main
 
+// Check that the warning doesn't mention HV 2016
 // Check that the compilation fails due to unable to
 // find the loop bound.
 

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1525,6 +1525,9 @@ class db_dxil(object):
             {'n':'force-ssa-updater', 'i':'ForceSSAUpdater', 't':'bool', 'd':'Force the pass to not use DomTree and mem2reg, insteadforming SSA values through the SSAUpdater infrastructure.'},
             {'n':'sroa-random-shuffle-slices', 'i':'SROARandomShuffleSlices', 't':'bool', 'd':'Enable randomly shuffling the slices to help uncover instability in their order.'},
             {'n':'sroa-strict-inbounds', 'i':'SROAStrictInbounds', 't':'bool', 'd':'Experiment with completely strict handling of inbounds GEPs.'}])
+        add_pass("dxil-cond-mem2reg", "DxilConditionalMem2Reg", "Dxil Conditional Mem2Reg", [
+                {'n':'NoOpt', 't':'bool', 'c':1},
+            ])
         add_pass('scalarrepl', 'SROA_DT', 'Scalar Replacement of Aggregates (DT)', [
             {'n':'Threshold', 't':'int', 'c':1},
             {'n':'StructMemberThreshold', 't':'int', 'c':1},


### PR DESCRIPTION
Using Scalar Evolution to figure out trivial loop trip count, but it needs Mem2reg to have been done, so we can't just run promote allocas as part of the unroll pass.

This change adds a pass to conditionally run m2r on functions that have loops that need to be unrolled when Od option is used. 