### PR TITLE
Fix PDB generation to not require embedded hash inside DxilContainer

### DIFF
--- a/include/dxc/DXIL/DxilPDB.h
+++ b/include/dxc/DXIL/DxilPDB.h
@@ -10,6 +10,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/Support/WinIncludes.h"
+#include "llvm/ADT/ArrayRef.h"
 
 struct IDxcBlob;
 struct IStream;
@@ -19,6 +20,6 @@ namespace hlsl {
 namespace pdb {
 
   HRESULT LoadDataFromStream(IMalloc *pMalloc, IStream *pIStream, IDxcBlob **pOutContainer);
-  HRESULT WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, const BYTE HashData[16], IDxcBlob **ppOutBlob);
+  HRESULT WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, llvm::ArrayRef<BYTE> HashData, IDxcBlob **ppOutBlob);
 }
 }

--- a/include/dxc/DXIL/DxilPDB.h
+++ b/include/dxc/DXIL/DxilPDB.h
@@ -19,6 +19,6 @@ namespace hlsl {
 namespace pdb {
 
   HRESULT LoadDataFromStream(IMalloc *pMalloc, IStream *pIStream, IDxcBlob **pOutContainer);
-  HRESULT WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, IDxcBlob **ppOutBlob); 
+  HRESULT WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, const BYTE HashData[16], IDxcBlob **ppOutBlob);
 }
 }

--- a/include/dxc/DxilContainer/DxilContainerAssembler.h
+++ b/include/dxc/DxilContainer/DxilContainerAssembler.h
@@ -50,7 +50,8 @@ void SerializeDxilContainerForModule(hlsl::DxilModule *pModule,
                                      AbstractMemoryStream *pModuleBitcode,
                                      AbstractMemoryStream *pStream,
                                      llvm::StringRef DebugName,
-                                     SerializeDxilFlags Flags);
+                                     SerializeDxilFlags Flags,
+                                     DxilShaderHash *pShaderHashOut = nullptr);
 void SerializeDxilContainerForRootSignature(hlsl::RootSignatureHandle *pRootSigHandle,
                                      AbstractMemoryStream *pStream);
 

--- a/lib/DXIL/DxilPDB.cpp
+++ b/lib/DXIL/DxilPDB.cpp
@@ -266,6 +266,7 @@ SmallVector<char, 0> WritePdbStream(ArrayRef<BYTE> Hash) {
   Header.Version = (uint32_t)PdbStreamVersion::VC70;
   Header.Age = 1;
   Header.Signature = 0;
+  DXASSERT_NOMSG(Hash.size() == sizeof(Header.UniqueId));
   memcpy(Header.UniqueId, Hash.data(), std::min(Hash.size(), sizeof(Header.UniqueId)));
 
   SmallVector<char, 0> Result;
@@ -291,11 +292,11 @@ SmallVector<char, 0> WritePdbStream(ArrayRef<BYTE> Hash) {
   return Result;
 }
 
-HRESULT hlsl::pdb::WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, const BYTE HashData[16], IDxcBlob **ppOutBlob) {
+HRESULT hlsl::pdb::WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, ArrayRef<BYTE> HashData, IDxcBlob **ppOutBlob) {
   if (!hlsl::IsValidDxilContainer((hlsl::DxilContainerHeader *)pContainer->GetBufferPointer(), pContainer->GetBufferSize()))
     return E_FAIL;
 
-  SmallVector<char, 0> PdbStream = WritePdbStream({ HashData, HashData + sizeof(HashData) });
+  SmallVector<char, 0> PdbStream = WritePdbStream(HashData);
 
   MSFWriter Writer;
   Writer.AddEmptyStream();     // Old Directory

--- a/lib/DXIL/DxilPDB.cpp
+++ b/lib/DXIL/DxilPDB.cpp
@@ -291,33 +291,11 @@ SmallVector<char, 0> WritePdbStream(ArrayRef<BYTE> Hash) {
   return Result;
 }
 
-static HRESULT FindShaderHash(IDxcBlob *pContainer, BYTE *pDigest, UINT32 uCapacity, UINT32 *pBytesWritten) {
+HRESULT hlsl::pdb::WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, const BYTE HashData[16], IDxcBlob **ppOutBlob) {
   if (!hlsl::IsValidDxilContainer((hlsl::DxilContainerHeader *)pContainer->GetBufferPointer(), pContainer->GetBufferSize()))
     return E_FAIL;
 
-  hlsl::DxilContainerHeader *DxilHeader = (hlsl::DxilContainerHeader *)pContainer->GetBufferPointer();
-  for (unsigned i = 0; i < DxilHeader->PartCount; i++) {
-    hlsl::DxilPartHeader *PartHeader = GetDxilContainerPart(DxilHeader, i);
-    if (PartHeader->PartFourCC == hlsl::DFCC_ShaderHash) {
-      hlsl::DxilShaderHash *HashHeader = (hlsl::DxilShaderHash *)(PartHeader+1);
-      if (sizeof(HashHeader->Digest) > uCapacity)
-        return E_FAIL;
-      memcpy(pDigest, HashHeader->Digest, sizeof(HashHeader->Digest));
-      *pBytesWritten = sizeof(HashHeader->Digest);
-      return S_OK;
-    }
-  }
-  return E_FAIL;
-}
-
-HRESULT hlsl::pdb::WriteDxilPDB(IMalloc *pMalloc, IDxcBlob *pContainer, IDxcBlob **ppOutBlob) {
-  if (!hlsl::IsValidDxilContainer((hlsl::DxilContainerHeader *)pContainer->GetBufferPointer(), pContainer->GetBufferSize()))
-    return E_FAIL;
-
-  BYTE HashData[16];
-  UINT32 uHashSize = 0;
-  IFR(FindShaderHash(pContainer, HashData, sizeof(HashData), &uHashSize));
-  SmallVector<char, 0> PdbStream = WritePdbStream({ HashData, HashData+uHashSize });
+  SmallVector<char, 0> PdbStream = WritePdbStream({ HashData, HashData + sizeof(HashData) });
 
   MSFWriter Writer;
   Writer.AddEmptyStream();     // Old Directory

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -30,6 +30,7 @@ class Twine;
 
 namespace hlsl {
 enum class SerializeDxilFlags : uint32_t;
+struct DxilShaderHash;
 class AbstractMemoryStream;
 namespace options {
 class MainArgs;
@@ -42,13 +43,14 @@ HRESULT ValidateAndAssembleToContainer(
     std::unique_ptr<llvm::Module> pM, CComPtr<IDxcBlob> &pOutputContainerBlob,
     IMalloc *pMalloc, hlsl::SerializeDxilFlags SerializeFlags,
     CComPtr<hlsl::AbstractMemoryStream> &pModuleBitcode, bool bDebugInfo, llvm::StringRef DebugName,
-    clang::DiagnosticsEngine &Diag);
+    clang::DiagnosticsEngine &Diag, hlsl::DxilShaderHash *pShaderHashOut = nullptr);
 void GetValidatorVersion(unsigned *pMajor, unsigned *pMinor);
 void AssembleToContainer(std::unique_ptr<llvm::Module> pM,
                          CComPtr<IDxcBlob> &pOutputContainerBlob,
                          IMalloc *pMalloc,
                          hlsl::SerializeDxilFlags SerializeFlags,
-                         CComPtr<hlsl::AbstractMemoryStream> &pModuleBitcode);
+                         CComPtr<hlsl::AbstractMemoryStream> &pModuleBitcode,
+                         hlsl::DxilShaderHash *pShaderHashOut = nullptr);
 HRESULT Disassemble(IDxcBlob *pProgram, llvm::raw_string_ostream &Stream);
 void ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
                          hlsl::options::DxcOpts &opts,


### PR DESCRIPTION
This would break when official DXIL.dll was used, since it would exclude
the shader hash part that the validator wouldn't recognize, and is not
required for a valid shader.  This prevented shader signing for the
output of newer compiler versions.