### PR TITLE
Fix memcpy mishandling in parameter SROA

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -4791,7 +4791,11 @@ void SROA_Parameter_HLSL::flattenArgument(
     // Do not skip unused parameter.
     Value *V = AV.Value;
     DxilFieldAnnotation &annotation = AV.Annotation;
-    const bool bAllowReplace = !bOut;
+
+    // We can never replace memcpy for arguments because they have an implicit
+    // first memcpy that happens from argument passing, and pointer analysis
+    // will not reveal that, especially if we've done a first SROA pass on V.
+    const bool bAllowReplace = false;
     SROA_Helper::LowerMemcpy(V, &annotation, dxilTypeSys, DL, bAllowReplace);
 
     // Now is safe to create the IRBuilders.

--- a/tools/clang/test/CodeGenHLSL/batch/passes/sroa_hlsl/memcpy_nested_input.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/passes/sroa_hlsl/memcpy_nested_input.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Regression test for GitHub #2277, where parameter SROA
+// would misbehave on memcpys and end up causing an undef
+// value to be returned.
+
+struct Inner { int x, y; };
+struct Outer { Inner inner; };
+void bug(inout Inner inner) {}
+int main(Outer outer : IN) : OUT
+{
+  // CHECK: loadInput
+  // CHECK: storeOutput
+  bug(outer.inner);
+  return outer.inner.x;
+}


### PR DESCRIPTION
`LowerMemcpy` tries to see if a variable is only written to by a single memcpy. There is a special case for `llvm::Argument`s, since arguments have an implicit first write for their initialization in addition to whatever memcpy they might have. During parameter SROA, aggregate arguments get broken down into their constituing elements as plateholder `AllocaInst`s, and at the end of the pass they'll get promoted back into `llvm::Argument`s of the SROA'd function. In the intermediate steps, however, a test for `isa<Argument>` will fail to detect that an `AllocaInst` is a placeholder for a future argument, and so its implicit initialization will not be taken into account. This would cause a bad `ReplaceMemcpy`, yielding reads from uninitialized locals, causing undefs and all of that fun stuff.

Fixes #2277