### PR TITLE
Support non-int32 types with SV_***ID semantics

### DIFF
--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -1160,8 +1160,8 @@ void HLSignatureLower::GenerateDxilCSInputs() {
 
     Constant *OpArg = hlslOP->GetU32Const((unsigned)opcode);
     Type *NumTy = arg.getType();
-    if (NumTy->isPointerTy())
-      NumTy = NumTy->getPointerElementType();
+    DXASSERT(!NumTy->isPointerTy(), "Unexpected byref value for CS SV_***ID semantic.");
+    DXASSERT(NumTy->getScalarType()->isIntegerTy(), "Unexpected non-integer value for CS SV_***ID semantic.");
 
     // Always use the i32 overload of those intrinsics, and then cast as needed
     Function *dxilFunc = hlslOP->GetOpFunc(opcode, Builder.getInt32Ty());

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_int16.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_int16.hlsl
@@ -1,9 +1,9 @@
 // RUN: %dxc -E main -T cs_6_2 -enable-16bit-types %s | FileCheck %s
 
-// Check that compute shader SV_***ID parameters can have non-32bit integer types.
+// Check that compute shader SV_***ID parameters can have 16-bit integer types.
 // Regression test for GitHub issue #2268
 
-StructuredBuffer<uint3> buf;
+RWStructuredBuffer<uint3> buf;
 
 [numthreads(1, 1, 1)]
 void main(uint16_t3 tid : SV_DispatchThreadID)

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_min12int.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_min12int.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+
+// Check that compute shader SV_***ID parameters can have min-integer types.
+// Regression test for GitHub issue #2268
+
+RWStructuredBuffer<uint3> buf;
+
+[numthreads(1, 1, 1)]
+void main(min12int3 tid : SV_DispatchThreadID)
+{
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 0)
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 1)
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 2)
+    // Truncation honors uint16_t type
+    // CHECK: shl i32 %{{.*}}, 16
+    // CHECK: ashr exact i32 %{{.*}}, 16
+    // CHECK: shl i32 %{{.*}}, 16
+    // CHECK: ashr exact i32 %{{.*}}, 16
+    // CHECK: shl i32 %{{.*}}, 16
+    // CHECK: ashr exact i32 %{{.*}}, 16
+    // CHECK: call void @dx.op.bufferStore.i32
+    buf[0] = tid;
+}

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_not_int32.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/cs_sv_id_not_int32.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -E main -T cs_6_2 -enable-16bit-types %s | FileCheck %s
+
+// Check that compute shader SV_***ID parameters can have non-32bit integer types.
+// Regression test for GitHub issue #2268
+
+StructuredBuffer<uint3> buf;
+
+[numthreads(1, 1, 1)]
+void main(uint16_t3 tid : SV_DispatchThreadID)
+{
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 0)
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 1)
+    // CHECK: call i32 @dx.op.threadId.i32(i32 93, i32 2)
+    // Truncation honors uint16_t type
+    // CHECK: and i32 {{.*}}, 65535
+    // CHECK: and i32 {{.*}}, 65535
+    // CHECK: and i32 {{.*}}, 65535
+    // CHECK: call void @dx.op.rawBufferStore.i32
+    buf[0] = tid;
+}

--- a/tools/clang/test/CodeGenHLSL/crashes/float_cs_sv_semantic.hlsl
+++ b/tools/clang/test/CodeGenHLSL/crashes/float_cs_sv_semantic.hlsl
@@ -1,0 +1,6 @@
+// RUN: %dxc -E main -T cs_6_2 %s | FileCheck %s
+
+// Repro of GitHub #2299
+
+[numthreads(1, 1, 1)]
+void main(float3 tid : SV_DispatchThreadID) {}


### PR DESCRIPTION
It seemed overkill to request backends to support a `@dx.op.threadId.i16` intrinsic so I'm always calling the `i32` version and then truncating or zextending to the final type.

Fixes #2268