### PR TITLE
Fix memcpy size calculation in ScalarReplAggregatesHLSL::ReplaceMemcpy

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3346,9 +3346,7 @@ static void ReplaceMemcpy(Value *V, Value *Src, MemCpyInst *MC,
         const DataLayout &DL = SrcBCI->getModule()->getDataLayout();
         unsigned SrcSize = DL.getTypeAllocSize(
             SrcBCI->getOperand(0)->getType()->getPointerElementType());
-        unsigned MemcpySize =
-            cast<ConstantInt>(MC->getLength())->getZExtValue() *
-            MC->getAlignment();
+        unsigned MemcpySize = cast<ConstantInt>(MC->getLength())->getZExtValue();
         if (SrcSize != MemcpySize) {
           DXASSERT(0, "Cannot handle partial memcpy");
           return;

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1506,7 +1506,7 @@ static void EltMemCpy(Type *Ty, Value *Dest, Value *Src,
   Value *DestGEP = CreateMergedGEP(Dest, idxList, Builder);
   Value *SrcGEP = CreateMergedGEP(Src, idxList, Builder);
   unsigned size = DL.getTypeAllocSize(Ty);
-  Builder.CreateMemCpy(DestGEP, SrcGEP, size, size);
+  Builder.CreateMemCpy(DestGEP, SrcGEP, size, /* Align */ 1);
 }
 
 static bool IsMemCpyTy(Type *Ty, DxilTypeSystem &typeSys) {


### PR DESCRIPTION
Multiplying by the alignment made no sense, and there are cases where it is not 1.