### PR TITLE
Improve validation error message formatting

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -700,14 +700,12 @@ struct ValidationContext {
       }
       LastRuleEmit = Rule;
       LastDebugLocEmit = L;
-
-      L.print(DiagStream());
-      DiagPrinter << ' ';
-      return true;
     }
+
     BasicBlock *BB = I->getParent();
     Function *F = BB->getParent();
 
+    // Print instruction
     std::string InstrStr;
     raw_string_ostream InstrStream(InstrStr);
     I->print(InstrStream);
@@ -716,6 +714,7 @@ struct ValidationContext {
     InstrStrRef = InstrStrRef.ltrim(); // Ignore indentation
     DiagPrinter << "at '" << InstrStrRef << "'";
 
+    // ... parent block name
     DiagPrinter << " in block '";
     if (!BB->getName().empty()) {
       DiagPrinter << BB->getName();
@@ -727,12 +726,22 @@ struct ValidationContext {
         if (BB == &(*i)) {
           break;
         }
+        idx++;
       }
       DiagPrinter << "#" << idx;
     }
     DiagPrinter << "'";
 
-    DiagPrinter << " of function '" << *F << "': ";
+    // ... function name
+    DiagPrinter << " of function '" << F->getName() << "'";
+    
+    if (L) {
+      DiagPrinter << " (";
+      L.print(DiagStream());
+      DiagPrinter << ')';
+    }
+
+    DiagPrinter << ": ";
     return true;
   }
 

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -702,10 +702,19 @@ struct ValidationContext {
       LastDebugLocEmit = L;
     }
 
+    // Print the error header matched by IDE regexes
+    DiagPrinter << "error: ";
+
+    // Print the debug location, if any, as matched by IDE regexes
+    if (L) {
+      L.print(DiagStream());
+      DiagPrinter << ": ";
+    }
+
     BasicBlock *BB = I->getParent();
     Function *F = BB->getParent();
 
-    // Print instruction
+    // Printthe instruction
     std::string InstrStr;
     raw_string_ostream InstrStream(InstrStr);
     I->print(InstrStream);
@@ -714,7 +723,7 @@ struct ValidationContext {
     InstrStrRef = InstrStrRef.ltrim(); // Ignore indentation
     DiagPrinter << "at '" << InstrStrRef << "'";
 
-    // ... parent block name
+    // Print the parent block name
     DiagPrinter << " in block '";
     if (!BB->getName().empty()) {
       DiagPrinter << BB->getName();
@@ -732,16 +741,10 @@ struct ValidationContext {
     }
     DiagPrinter << "'";
 
-    // ... function name
-    DiagPrinter << " of function '" << F->getName() << "'";
-    
-    if (L) {
-      DiagPrinter << " (";
-      L.print(DiagStream());
-      DiagPrinter << ')';
-    }
+    // Print the function name
+    DiagPrinter << " of function '" << F->getName() << "': ";
 
-    DiagPrinter << ": ";
+    // Parent will print the message
     return true;
   }
 

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -708,8 +708,15 @@ struct ValidationContext {
     BasicBlock *BB = I->getParent();
     Function *F = BB->getParent();
 
-    DiagPrinter << "at " << I;
-    DiagPrinter << " inside block ";
+    std::string InstrStr;
+    raw_string_ostream InstrStream(InstrStr);
+    I->print(InstrStream);
+    InstrStream.flush();
+    StringRef InstrStrRef = InstrStr;
+    InstrStrRef = InstrStrRef.ltrim(); // Ignore indentation
+    DiagPrinter << "at '" << InstrStrRef << "'";
+
+    DiagPrinter << " in block '";
     if (!BB->getName().empty()) {
       DiagPrinter << BB->getName();
     }
@@ -723,7 +730,9 @@ struct ValidationContext {
       }
       DiagPrinter << "#" << idx;
     }
-    DiagPrinter << " of function " << *F << ' ';
+    DiagPrinter << "'";
+
+    DiagPrinter << " of function '" << *F << "': ";
     return true;
   }
 


### PR DESCRIPTION
Compare:
```
error: validation errors
at 'call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %buf_texture_structbuf, i32 0, i32 0, float 3.000000e+00, float undef, float undef, float undef, i8 1)' in block 'entry' of function 'main' (E:\Sandbox\playground.hlsl:3:22): store should on uav resource.
```
to the previous
```
error: validation errors
at 0x1236957db30 inside block #0 of function main store should on uav resource.
```