### PR TITLE
[spirv] Support for ByteAddressBuffer.Load<T>

### DIFF
--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -16,6 +16,7 @@ add_clang_library(clangSPIRV
   LiteralTypeVisitor.cpp
   LowerTypeVisitor.cpp
   PreciseVisitor.cpp
+  RawBufferMethods.cpp
   RelaxedPrecisionVisitor.cpp
   SpirvBasicBlock.cpp
   SpirvBuilder.cpp

--- a/tools/clang/lib/SPIRV/RawBufferMethods.cpp
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.cpp
@@ -1,0 +1,511 @@
+//===---- RawBufferMethods.cpp ---- Raw Buffer Methods ----------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//===----------------------------------------------------------------------===//
+
+#include "RawBufferMethods.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/CharUnits.h"
+#include "clang/AST/RecordLayout.h"
+#include "clang/SPIRV/AstTypeProbe.h"
+#include "clang/SPIRV/SpirvBuilder.h"
+#include "clang/SPIRV/SpirvInstruction.h"
+
+namespace clang {
+namespace spirv {
+
+SpirvInstruction *RawBufferHandler::load16BitsAtBitOffset0(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target16BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 0);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  // The underlying element type of the ByteAddressBuffer is uint. So we
+  // need to load 32-bits at the very least.
+  auto *loadPtr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                               {constUint0, index}, loc);
+  result = spvBuilder.createLoad(astContext.UnsignedIntTy, loadPtr, loc);
+  // Only need to mask the lowest 16 bits of the loaded 32-bit uint.
+  // OpUConvert can perform truncation in this case.
+  result = spvBuilder.createUnaryOp(spv::Op::OpUConvert,
+                                    astContext.UnsignedShortTy, result, loc);
+  result = theEmitter.castToType(result, astContext.UnsignedShortTy,
+                                 target16BitType, loc);
+  result->setRValue();
+
+  // Now that a 16-bit load at bit-offset 0 has been performed, the next load
+  // should be done at *the same base index* at bit-offset 16.
+  bitOffset = (bitOffset + 16) % 32;
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::load32BitsAtBitOffset0(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target32BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 0);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  // Only need to perform one 32-bit uint load.
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+  auto *loadPtr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                               {constUint0, index}, loc);
+  result = spvBuilder.createLoad(astContext.UnsignedIntTy, loadPtr, loc);
+  result = theEmitter.castToType(result, astContext.UnsignedIntTy,
+                                 target32BitType, loc);
+  result->setRValue();
+  // Now that a 32-bit load at bit-offset 0 has been performed, the next load
+  // should be done at *the next base index* at bit-offset 0.
+  bitOffset = (bitOffset + 32) % 32;
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::load64BitsAtBitOffset0(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target64BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 0);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  SpirvInstruction *ptr = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+  auto *constUint32 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 32));
+
+  // Need to perform two 32-bit uint loads and construct a 64-bit value.
+
+  // Load the first 32-bit uint (word0).
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *word0 =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+  // Increment the base index
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+  // Load the second 32-bit uint (word1).
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *word1 =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Convert both word0 and word1 to 64-bit uints.
+  word0 = spvBuilder.createUnaryOp(spv::Op::OpUConvert,
+                                   astContext.UnsignedLongLongTy, word0, loc);
+  word1 = spvBuilder.createUnaryOp(spv::Op::OpUConvert,
+                                   astContext.UnsignedLongLongTy, word1, loc);
+
+  // Shift word1 to the left by 32 bits.
+  word1 = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
+                                    astContext.UnsignedLongLongTy, word1,
+                                    constUint32, loc);
+
+  // BitwiseOr word0 and word1.
+  result = spvBuilder.createBinaryOp(
+      spv::Op::OpBitwiseOr, astContext.UnsignedLongLongTy, word0, word1, loc);
+
+  result = theEmitter.castToType(result, astContext.UnsignedLongLongTy,
+                                 target64BitType, loc);
+  result->setRValue();
+  // Now that a 64-bit load at bit-offset 0 has been performed, the next load
+  // should be done at *the base index + 2* at bit-offset 0. The index has
+  // already been incremented once. Need to increment it once more.
+  bitOffset = (bitOffset + 64) % 32;
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::load16BitsAtBitOffset16(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target16BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 16);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+  auto *constUint16 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 16));
+
+  // The underlying element type of the ByteAddressBuffer is uint. So we
+  // need to load 32-bits at the very least.
+  auto *ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                           {constUint0, index}, loc);
+  result = spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+  result = spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical,
+                                     astContext.UnsignedIntTy, result,
+                                     constUint16, loc);
+  result = spvBuilder.createUnaryOp(spv::Op::OpUConvert,
+                                    astContext.UnsignedShortTy, result, loc);
+  result = theEmitter.castToType(result, astContext.UnsignedShortTy,
+                                 target16BitType, loc);
+  result->setRValue();
+
+  // Now that a 16-bit load at bit-offset 16 has been performed, the next load
+  // should be done at *the next base index* at bit-offset 0.
+  bitOffset = (bitOffset + 16) % 32;
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::load32BitsAtBitOffset16(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target32BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 16);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  SpirvInstruction *ptr = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+  auto *constUint16 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 16));
+
+  // The underlying element type of the ByteAddressBuffer is uint. Since the
+  // bitOffset is not zero, we need to perform two load operations.
+
+  // Load the first 32-bit uint. Only its 16 MSBs matter.
+  // The 16 MSBs of the loaded value becomes the 16 LSBs of the result.
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *lsb =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Right shift by 16 bits leaves the upper 16 bits as 0.
+  lsb = spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical,
+                                  astContext.UnsignedIntTy, lsb, constUint16,
+                                  loc);
+
+  // Increment the base index
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+
+  // Load the second 32-bit uint. Only its 16 LSBs matter.
+  // The 16 LSBs of the loaded value becomes the 16 MSBs of the result.
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *msb =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Left shift by 16 bits leaves the lower 16 bits as 0.
+  msb = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
+                                  astContext.UnsignedIntTy, msb, constUint16,
+                                  loc);
+
+  // Bitwise Or the MSBs and LSBs to get the resulting 32-bit value.
+  result = spvBuilder.createBinaryOp(spv::Op::OpBitwiseOr,
+                                     astContext.UnsignedIntTy, lsb, msb, loc);
+
+  result = theEmitter.castToType(result, astContext.UnsignedIntTy,
+                                 target32BitType, loc);
+  result->setRValue();
+
+  // Now that a 32-bit load at bit-offset 16 has been performed, the next load
+  // should be done at *the next base index* at bit-offset 16.
+  // The base index has already been incremented.
+  bitOffset = (bitOffset + 32) % 32;
+
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::load64BitsAtBitOffset16(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    QualType target64BitType, uint32_t &bitOffset) {
+  assert(bitOffset == 16);
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  SpirvInstruction *ptr = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+  auto *constUint16 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 16));
+  auto *constUint48 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 48));
+
+  // The underlying element type of the ByteAddressBuffer is uint. Since the
+  // bitOffset is 16, we need to perform three load operations.
+  // Use 16 bits from the first load, all the 32 bits from the second load, and
+  // 16 bits from the third load.
+
+  // Load the first 32-bit uint. Only its 16 MSBs matter.
+  // Right shift by 16 bits leaves the upper 16 bits as 0.
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *first16 =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Incremenet the index and load a 32-bit uint.
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *middle32 =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Incremenet the index and load a 32-bit uint. Only its 16 LSBs matter.
+  index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                    index, constUint1, loc);
+  ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
+                                     {constUint0, index}, loc);
+  SpirvInstruction *last16 =
+      spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc);
+
+  // Convert all parts to 64 bits
+  first16 = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedLongLongTy, first16, loc);
+  middle32 = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedLongLongTy, middle32, loc);
+  last16 = spvBuilder.createUnaryOp(spv::Op::OpUConvert,
+                                    astContext.UnsignedLongLongTy, last16, loc);
+
+  // Perform: (first16 >> 16) | (middle32 << 16) | (last16 << 48)
+  first16 = spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical,
+                                      astContext.UnsignedLongLongTy, first16,
+                                      constUint16, loc);
+  middle32 = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
+                                       astContext.UnsignedLongLongTy, middle32,
+                                       constUint16, loc);
+  last16 = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
+                                     astContext.UnsignedLongLongTy, last16,
+                                     constUint48, loc);
+
+  result = spvBuilder.createBinaryOp(spv::Op::OpBitwiseOr,
+                                     astContext.UnsignedLongLongTy, first16,
+                                     middle32, loc);
+  result = spvBuilder.createBinaryOp(
+      spv::Op::OpBitwiseOr, astContext.UnsignedLongLongTy, result, last16, loc);
+
+  result = theEmitter.castToType(result, astContext.UnsignedLongLongTy,
+                                 target64BitType, loc);
+  result->setRValue();
+
+  // Now that a 64-bit load at bit-offset 16 has been performed, the next load
+  // should be done at *the base index + 2* at bit-offset 16.
+  // The base index has already been incremented twice.
+  bitOffset = (bitOffset + 64) % 32;
+
+  return result;
+}
+
+SpirvInstruction *RawBufferHandler::processTemplatedLoadFromBuffer(
+    SpirvInstruction *buffer, SpirvInstruction *&index,
+    const QualType targetType, uint32_t &bitOffset) {
+  const auto loc = buffer->getSourceLocation();
+  SpirvInstruction *result = nullptr;
+  auto *constUint0 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
+  auto *constUint1 =
+      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
+
+  // TODO: If 8-bit types are to be supported in the future, we should also
+  // add code to support bitOffset 8 and 24.
+  assert(bitOffset == 0 || bitOffset == 16);
+
+  // Scalar types
+  if (isScalarType(targetType)) {
+    auto loadWidth = getElementSpirvBitwidth(
+        astContext, targetType, theEmitter.getSpirvOptions().enable16BitTypes);
+    switch (bitOffset) {
+    case 0: {
+      switch (loadWidth) {
+      case 16:
+        return load16BitsAtBitOffset0(buffer, index, targetType, bitOffset);
+        break;
+      case 32:
+        return load32BitsAtBitOffset0(buffer, index, targetType, bitOffset);
+        break;
+      case 64:
+        return load64BitsAtBitOffset0(buffer, index, targetType, bitOffset);
+        break;
+      default:
+        theEmitter.emitError(
+            "templated load of ByteAddressBuffer is only implemented for "
+            "16, 32, and 64-bit types",
+            loc);
+        return nullptr;
+      }
+      break;
+    }
+    case 16: {
+      switch (loadWidth) {
+      case 16:
+        return load16BitsAtBitOffset16(buffer, index, targetType, bitOffset);
+        break;
+      case 32:
+        return load32BitsAtBitOffset16(buffer, index, targetType, bitOffset);
+        break;
+      case 64:
+        return load64BitsAtBitOffset16(buffer, index, targetType, bitOffset);
+        break;
+      default:
+        theEmitter.emitError(
+            "templated load of ByteAddressBuffer is only implemented for "
+            "16, 32, and 64-bit types",
+            loc);
+        return nullptr;
+      }
+      break;
+    }
+    default:
+      theEmitter.emitError(
+          "templated load of ByteAddressBuffer is only implemented for "
+          "16, 32, and 64-bit types",
+          loc);
+      return nullptr;
+    }
+  }
+
+  // Vector types
+  {
+    QualType elemType = {};
+    uint32_t elemCount = 0;
+    if (isVectorType(targetType, &elemType, &elemCount)) {
+      llvm::SmallVector<SpirvInstruction *, 4> loadedElems;
+      for (uint32_t i = 0; i < elemCount; ++i) {
+        loadedElems.push_back(
+            processTemplatedLoadFromBuffer(buffer, index, elemType, bitOffset));
+      }
+      result =
+          spvBuilder.createCompositeConstruct(targetType, loadedElems, loc);
+      result->setRValue();
+      return result;
+    }
+  }
+
+  // Array types
+  {
+    QualType elemType = {};
+    uint32_t elemCount = 0;
+    if (const auto *arrType = astContext.getAsConstantArrayType(targetType)) {
+      elemCount = static_cast<uint32_t>(arrType->getSize().getZExtValue());
+      elemType = arrType->getElementType();
+      llvm::SmallVector<SpirvInstruction *, 4> loadedElems;
+      for (uint32_t i = 0; i < elemCount; ++i) {
+        loadedElems.push_back(
+            processTemplatedLoadFromBuffer(buffer, index, elemType, bitOffset));
+      }
+      result =
+          spvBuilder.createCompositeConstruct(targetType, loadedElems, loc);
+      result->setRValue();
+      return result;
+    }
+  }
+
+  // Matrix types
+  {
+    QualType elemType = {};
+    uint32_t numRows = 0, numCols = 0;
+    if (isMxNMatrix(targetType, &elemType, &numRows, &numCols)) {
+      llvm::SmallVector<SpirvInstruction *, 4> loadedElems;
+      llvm::SmallVector<SpirvInstruction *, 4> loadedRows;
+      for (uint32_t i = 0; i < numRows; ++i) {
+        for (uint32_t j = 0; j < numCols; ++j) {
+          // TODO: This is currently doing a row_major matrix load. We must
+          // investigate whether we also need to implement it for column_major.
+          loadedElems.push_back(processTemplatedLoadFromBuffer(
+              buffer, index, elemType, bitOffset));
+        }
+        const auto rowType = astContext.getExtVectorType(elemType, numCols);
+        loadedRows.push_back(
+            spvBuilder.createCompositeConstruct(rowType, loadedElems, loc));
+        loadedElems.clear();
+      }
+      result = spvBuilder.createCompositeConstruct(targetType, loadedRows, loc);
+      result->setRValue();
+      return result;
+    }
+  }
+
+  // Struct types
+  // The "natural" layout for structure types dictates that structs are
+  // aligned like their field with the largest alignment.
+  // As a result, there might exist some padding after some struct members.
+  if (const auto *structType = targetType->getAs<RecordType>()) {
+    const auto *decl = structType->getDecl();
+    assert(bitOffset == 0);
+    const auto &layout = astContext.getASTRecordLayout(decl);
+    SpirvInstruction *originalIndex = index;
+    uint32_t originalBitOffset = bitOffset;
+    llvm::SmallVector<SpirvInstruction *, 4> loadedElems;
+    uint32_t structAlignment = 0;
+    uint32_t structSize = static_cast<uint32_t>(layout.getSize().getQuantity());
+    uint32_t fieldIndex = 0;
+    for (const auto *field : decl->fields()) {
+      CharUnits alignment;
+      std::tie(std::ignore, alignment) = astContext.getTypeInfoInChars(
+          field->getType()->getUnqualifiedDesugaredType());
+      structAlignment = std::max(
+          structAlignment, static_cast<uint32_t>(alignment.getQuantity()));
+
+      assert(fieldIndex < layout.getFieldCount());
+      uint32_t fieldOffsetInBytes = static_cast<uint32_t>(
+          astContext.toCharUnitsFromBits(layout.getFieldOffset(fieldIndex++))
+              .getQuantity());
+      if (fieldOffsetInBytes != 0) {
+        // Divide the fieldOffset by 4 to figure out how much to increment the
+        // index into the buffer (increment occurs by 32-bit words since the
+        // underlying type is an array of uints).
+        // The remainder by four tells us the *byte offset* (then multiply by 8
+        // to get bit offset).
+        auto wordOffset = fieldOffsetInBytes / 4;
+        bitOffset = (fieldOffsetInBytes % 4) * 8;
+        index = spvBuilder.createBinaryOp(
+            spv::Op::OpIAdd, astContext.UnsignedIntTy, originalIndex,
+            spvBuilder.getConstantInt(astContext.UnsignedIntTy,
+                                      llvm::APInt(32, wordOffset)),
+            loc);
+      }
+      loadedElems.push_back(processTemplatedLoadFromBuffer(
+          buffer, index, field->getType(), bitOffset));
+    }
+
+    // After we're done with loading the entire struct, we need to update the
+    // index and bitOffset (in case we are loading an array of structs).
+    //
+    // Example: struct alignment = 8. struct size = 34 bytes
+    // (34 / 8) = 4 full words
+    // (34 % 8) = 2 > 0, therefore need to move to the next aligned address
+    // So the starting byte offset after loading the entire struct is:
+    // 8 * (4 + 1) = 40
+    assert(structAlignment != 0);
+    uint32_t newByteOffset =
+        structAlignment * ((structSize / structAlignment) +
+                           (structSize % structAlignment > 0 ? 1 : 0));
+    uint32_t newWordOffset = newByteOffset / 4;
+    index = spvBuilder.createBinaryOp(
+        spv::Op::OpIAdd, astContext.UnsignedIntTy, originalIndex,
+        spvBuilder.getConstantInt(astContext.UnsignedIntTy,
+                                  llvm::APInt(32, newWordOffset)),
+        loc);
+
+    // New bitOffset should be zero because after loading the struct, we will
+    // be loading at the next aligned address.
+    bitOffset = 0;
+    result = spvBuilder.createCompositeConstruct(targetType, loadedElems, loc);
+    result->setRValue();
+    return result;
+  }
+
+  llvm_unreachable("templated buffer load unimplemented for type");
+}
+
+} // namespace spirv
+} // namespace clang

--- a/tools/clang/lib/SPIRV/RawBufferMethods.h
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.h
@@ -1,0 +1,81 @@
+//===------ RawBufferMethods.h ---- Raw Buffer Methods ----------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_RAWBUFFERMETHODS_H
+#define LLVM_CLANG_SPIRV_RAWBUFFERMETHODS_H
+
+class ASTContext;
+class SpirvBuilder;
+class SpirvInstruction;
+
+#include "SpirvEmitter.h"
+
+namespace clang {
+namespace spirv {
+
+class RawBufferHandler {
+public:
+  RawBufferHandler(SpirvEmitter &emitter)
+      : theEmitter(emitter), astContext(emitter.getASTContext()),
+        spvBuilder(emitter.getSpirvBuilder()) {}
+
+  /// \brief Performs (RW)ByteAddressBuffer.Load<T>(address).
+  /// (RW)ByteAddressBuffers are represented as structs with only one member
+  /// which is a runtime array in SPIR-V. This method works by loading one or
+  /// more uints, and performing necessary casts and composite constructions
+  /// to build the 'targetType'. The 'offset' parameter can be used for finer
+  /// grained load of bitwidths smaller than 32-bits. Example: targetType =
+  /// uint16_t, address=0, offset=0
+  ///                 --> Load the first 16-bit uint starting at address 0.
+  /// targetType = uint16_t, address=0, offset=16
+  ///                 --> Load the second 16-bit uint starting at address 0.
+  SpirvInstruction *processTemplatedLoadFromBuffer(SpirvInstruction *buffer,
+                                                   SpirvInstruction *&index,
+                                                   const QualType targetType,
+                                                   uint32_t &bitOffset);
+
+private:
+  SpirvInstruction *load16BitsAtBitOffset0(SpirvInstruction *buffer,
+                                           SpirvInstruction *&index,
+                                           QualType target16BitType,
+                                           uint32_t &bitOffset);
+
+  SpirvInstruction *load32BitsAtBitOffset0(SpirvInstruction *buffer,
+                                           SpirvInstruction *&index,
+                                           QualType target32BitType,
+                                           uint32_t &bitOffset);
+
+  SpirvInstruction *load64BitsAtBitOffset0(SpirvInstruction *buffer,
+                                           SpirvInstruction *&index,
+                                           QualType target64BitType,
+                                           uint32_t &bitOffset);
+
+  SpirvInstruction *load16BitsAtBitOffset16(SpirvInstruction *buffer,
+                                            SpirvInstruction *&index,
+                                            QualType target16BitType,
+                                            uint32_t &bitOffset);
+
+  SpirvInstruction *load32BitsAtBitOffset16(SpirvInstruction *buffer,
+                                            SpirvInstruction *&index,
+                                            QualType target32BitType,
+                                            uint32_t &bitOffset);
+
+  SpirvInstruction *load64BitsAtBitOffset16(SpirvInstruction *buffer,
+                                            SpirvInstruction *&index,
+                                            QualType target64BitType,
+                                            uint32_t &bitOffset);
+
+private:
+  SpirvEmitter &theEmitter;
+  const ASTContext &astContext;
+  SpirvBuilder &spvBuilder;
+};
+
+} // namespace spirv
+} // namespace clang
+
+#endif // LLVM_CLANG_SPIRV_RAWBUFFERMETHODS_H

--- a/tools/clang/lib/SPIRV/RawBufferMethods.h
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.h
@@ -70,6 +70,18 @@ private:
                                             uint32_t &bitOffset);
 
 private:
+  /// \brief Performs an OpBitCast from |fromType| to |toType| on the given
+  /// instruction.
+  ///
+  /// If the |toType| is a boolean type, it performs a regular type cast.
+  ///
+  /// If the |fromType| and |toType| are the same, does not thing and returns
+  /// the given instruction
+  SpirvInstruction *bitCastToNumericalOrBool(SpirvInstruction *instr,
+                                             QualType fromType, QualType toType,
+                                             SourceLocation loc);
+
+private:
   SpirvEmitter &theEmitter;
   const ASTContext &astContext;
   SpirvBuilder &spvBuilder;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -52,6 +52,7 @@ public:
   SpirvBuilder &getSpirvBuilder() { return spvBuilder; }
   DiagnosticsEngine &getDiagnosticsEngine() { return diags; }
   CompilerInstance &getCompilerInstance() { return theCompilerInstance; }
+  SpirvCodeGenOptions &getSpirvOptions() { return spirvOptions; }
 
   void doDecl(const Decl *decl);
   void doStmt(const Stmt *stmt, llvm::ArrayRef<const Attr *> attrs = {});
@@ -946,7 +947,7 @@ private:
                               const clang::FunctionDecl *,
                               bool isEntryFunction);
 
-private:
+public:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.
   template <unsigned N>

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.matrix.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.matrix.hlsl
@@ -71,7 +71,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:         [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
 // CHECK: [[word1_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
 // CHECK:          [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[word1_ulong_shifted]]
-// CHECK:                [[val0:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+// CHECK:                [[val0:%\d+]] = OpBitcast %double [[val0_ulong]]
 // CHECK:             [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
 // CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
 // CHECK:               [[word2:%\d+]] = OpLoad %uint [[ptr]]
@@ -82,7 +82,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:         [[word3_ulong:%\d+]] = OpUConvert %ulong [[word3]]
 // CHECK: [[word3_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word3_ulong]] %uint_32
 // CHECK:          [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[word2_ulong]] [[word3_ulong_shifted]]
-// CHECK:                [[val1:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+// CHECK:                [[val1:%\d+]] = OpBitcast %double [[val1_ulong]]
 // CHECK:             [[index_4:%\d+]] = OpIAdd %uint [[index_3]] %uint_1
 // CHECK:                [[row0:%\d+]] = OpCompositeConstruct %v2double [[val0]] [[val1]]
 // CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
@@ -94,7 +94,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:         [[word5_ulong:%\d+]] = OpUConvert %ulong [[word5]]
 // CHECK: [[word5_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word5_ulong]] %uint_32
 // CHECK:          [[val2_ulong:%\d+]] = OpBitwiseOr %ulong [[word4_ulong]] [[word5_ulong_shifted]]
-// CHECK:                [[val2:%\d+]] = OpConvertUToF %double [[val2_ulong]]
+// CHECK:                [[val2:%\d+]] = OpBitcast %double [[val2_ulong]]
 // CHECK:             [[index_6:%\d+]] = OpIAdd %uint [[index_5]] %uint_1
 // CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_6]]
 // CHECK:               [[word6:%\d+]] = OpLoad %uint [[ptr]]
@@ -105,7 +105,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:         [[word7_ulong:%\d+]] = OpUConvert %ulong [[word7]]
 // CHECK: [[word7_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word7_ulong]] %uint_32
 // CHECK:          [[val3_ulong:%\d+]] = OpBitwiseOr %ulong [[word6_ulong]] [[word7_ulong_shifted]]
-// CHECK:                [[val3:%\d+]] = OpConvertUToF %double [[val3_ulong]]
+// CHECK:                [[val3:%\d+]] = OpBitcast %double [[val3_ulong]]
 // CHECK:                [[row1:%\d+]] = OpCompositeConstruct %v2double [[val2]] [[val3]]
 // CHECK:              [[matrix:%\d+]] = OpCompositeConstruct %mat2v2double [[row0]] [[row1]]
 // CHECK:                                OpStore %f64 [[matrix]]

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.matrix.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.matrix.hlsl
@@ -1,0 +1,155 @@
+// Run: %dxc -T cs_6_2 -E main -enable-16bit-types
+
+ByteAddressBuffer buf;
+
+[numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadId)
+{
+// ********* 16-bit matrix ********************
+
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index:%\d+]]
+// CHECK:         [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val0:%\d+]] = OpUConvert %ushort [[word0]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index]]
+// CHECK:         [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[shifted_word0:%\d+]] = OpShiftRightLogical %uint [[word0]] %uint_16
+// CHECK:          [[val1:%\d+]] = OpUConvert %ushort [[shifted_word0]]
+// CHECK:       [[index_1:%\d+]] = OpIAdd %uint [[index]] %uint_1
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:         [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val2:%\d+]] = OpUConvert %ushort [[word1]]
+// CHECK:          [[row0:%\d+]] = OpCompositeConstruct %v3ushort [[val0]] [[val1]] [[val2]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:         [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[shifted_word1:%\d+]] = OpShiftRightLogical %uint [[word1]] %uint_16
+// CHECK:          [[val3:%\d+]] = OpUConvert %ushort [[shifted_word1:%\d+]]
+// CHECK:       [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:         [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val4:%\d+]] = OpUConvert %ushort [[word2:%\d+]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:         [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[shifted_word2:%\d+]] = OpShiftRightLogical %uint [[word2]] %uint_16
+// CHECK:          [[val5:%\d+]] = OpUConvert %ushort [[shifted_word2:%\d+]]
+// CHECK:          [[row1:%\d+]] = OpCompositeConstruct %v3ushort [[val3]] [[val4]] [[val5]]
+// CHECK:        [[matrix:%\d+]] = OpCompositeConstruct %_arr_v3ushort_uint_2 [[row0]] [[row1]]
+// CHECK:                          OpStore %u16 [[matrix]]
+  uint16_t2x3 u16 = buf.Load<uint16_t2x3>(tid.x);
+
+
+// ********* 32-bit matrix ********************
+
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:  [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:   [[val0:%\d+]] = OpBitcast %int [[word0]]
+// CHECK:[[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:  [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:   [[val1:%\d+]] = OpBitcast %int [[word1:%\d+]]
+// CHECK:[[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:   [[row0:%\d+]] = OpCompositeConstruct %v2int [[val0]] [[val1]]
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:  [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:   [[val2:%\d+]] = OpBitcast %int [[word2]]
+// CHECK:[[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:  [[word3:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:   [[val3:%\d+]] = OpBitcast %int [[word3]]
+// CHECK:   [[row1:%\d+]] = OpCompositeConstruct %v2int [[val2]] [[val3]]
+// CHECK: [[matrix:%\d+]] = OpCompositeConstruct %_arr_v2int_uint_2 [[row0]] [[row1]]
+// CHECK:                   OpStore %i [[matrix]]
+  int2x2 i = buf.Load<int2x2>(tid.x);
+
+// ********* 64-bit matrix ********************
+
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:               [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:             [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:               [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[word0_ulong:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:         [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK: [[word1_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
+// CHECK:          [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[word1_ulong_shifted]]
+// CHECK:                [[val0:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+// CHECK:             [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:               [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:             [[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:               [[word3:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[word2_ulong:%\d+]] = OpUConvert %ulong [[word2]]
+// CHECK:         [[word3_ulong:%\d+]] = OpUConvert %ulong [[word3]]
+// CHECK: [[word3_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word3_ulong]] %uint_32
+// CHECK:          [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[word2_ulong]] [[word3_ulong_shifted]]
+// CHECK:                [[val1:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+// CHECK:             [[index_4:%\d+]] = OpIAdd %uint [[index_3]] %uint_1
+// CHECK:                [[row0:%\d+]] = OpCompositeConstruct %v2double [[val0]] [[val1]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
+// CHECK:               [[word4:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:             [[index_5:%\d+]] = OpIAdd %uint [[index_4]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_5]]
+// CHECK:               [[word5:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[word4_ulong:%\d+]] = OpUConvert %ulong [[word4]]
+// CHECK:         [[word5_ulong:%\d+]] = OpUConvert %ulong [[word5]]
+// CHECK: [[word5_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word5_ulong]] %uint_32
+// CHECK:          [[val2_ulong:%\d+]] = OpBitwiseOr %ulong [[word4_ulong]] [[word5_ulong_shifted]]
+// CHECK:                [[val2:%\d+]] = OpConvertUToF %double [[val2_ulong]]
+// CHECK:             [[index_6:%\d+]] = OpIAdd %uint [[index_5]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_6]]
+// CHECK:               [[word6:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:             [[index_7:%\d+]] = OpIAdd %uint [[index_6]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_7]]
+// CHECK:               [[word7:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[word6_ulong:%\d+]] = OpUConvert %ulong [[word6]]
+// CHECK:         [[word7_ulong:%\d+]] = OpUConvert %ulong [[word7]]
+// CHECK: [[word7_ulong_shifted:%\d+]] = OpShiftLeftLogical %ulong [[word7_ulong]] %uint_32
+// CHECK:          [[val3_ulong:%\d+]] = OpBitwiseOr %ulong [[word6_ulong]] [[word7_ulong_shifted]]
+// CHECK:                [[val3:%\d+]] = OpConvertUToF %double [[val3_ulong]]
+// CHECK:                [[row1:%\d+]] = OpCompositeConstruct %v2double [[val2]] [[val3]]
+// CHECK:              [[matrix:%\d+]] = OpCompositeConstruct %mat2v2double [[row0]] [[row1]]
+// CHECK:                                OpStore %f64 [[matrix]]
+  float64_t2x2 f64 = buf.Load<float64_t2x2>(tid.x);
+
+// ********* array of matrices ********************
+
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0]]
+// CHECK:             [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:                [[row1:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:             [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:             [[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:                [[row2:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:            [[matrix_1:%\d+]] = OpCompositeConstruct %mat2v3half [[row1]] [[row2]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:             [[index_4:%\d+]] = OpIAdd %uint [[index_3]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
+// CHECK:                [[row1:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
+// CHECK:             [[index_5:%\d+]] = OpIAdd %uint [[index_4]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_5]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_5]]
+// CHECK:             [[index_6:%\d+]] = OpIAdd %uint [[index_5]] %uint_1
+// CHECK:                [[row2:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:            [[matrix_2:%\d+]] = OpCompositeConstruct %mat2v3half [[row1]] [[row2]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_6]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_6]]
+// CHECK:             [[index_7:%\d+]] = OpIAdd %uint [[index_6]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_7]]
+// CHECK:                [[row1:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_7]]
+// CHECK:             [[index_8:%\d+]] = OpIAdd %uint [[index_7]] %uint_1
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_8]]
+// CHECK:                 [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_8]]
+// CHECK:                [[row2:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:            [[matrix_3:%\d+]] = OpCompositeConstruct %mat2v3half [[row1]] [[row2]]
+// CHECK:        [[matrix_array:%\d+]] = OpCompositeConstruct %_arr_mat2v3half_uint_3 [[matrix_1]] [[matrix_2]] [[matrix_3]]
+// CHECK:                                OpStore %matVec [[matrix_array]]
+  float16_t2x3 matVec[3] = buf.Load<float16_t2x3[3]>(tid.x);
+}
+

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.scalar.hlsl
@@ -22,7 +22,7 @@ ByteAddressBuffer buf;
   // CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
   // CHECK:   [[uint:%\d+]] = OpLoad %uint [[ptr]]
   // CHECK: [[ushort:%\d+]] = OpUConvert %ushort [[uint]]
-  // CHECK:   [[half:%\d+]] = OpConvertUToF %half [[ushort]]
+  // CHECK:   [[half:%\d+]] = OpBitcast %half [[ushort]]
   // CHECK:                   OpStore %f16 [[half]]
   float16_t f16 = buf.Load<float16_t>(tid.x);
 
@@ -41,7 +41,7 @@ ByteAddressBuffer buf;
 
   // CHECK:   [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
   // CHECK:  [[uint:%\d+]] = OpLoad %uint [[ptr]]
-  // CHECK: [[float:%\d+]] = OpConvertUToF %float [[uint]]
+  // CHECK: [[float:%\d+]] = OpBitcast %float [[uint]]
   // CHECK:                  OpStore %f [[float]]
   float f = buf.Load<float>(tid.x);
 
@@ -87,7 +87,7 @@ ByteAddressBuffer buf;
 // CHECK:        [[word1Long:%\d+]] = OpUConvert %ulong [[word1]]
 // CHECK: [[shiftedWord1Long:%\d+]] = OpShiftLeftLogical %ulong [[word1Long]] %uint_32
 // CHECK:        [[val_ulong:%\d+]] = OpBitwiseOr %ulong [[word0Long]] [[shiftedWord1Long]]
-// CHECK:       [[val_double:%\d+]] = OpConvertUToF %double [[val_ulong]]
+// CHECK:       [[val_double:%\d+]] = OpBitcast %double [[val_ulong]]
 // CHECK:                             OpStore %f64 [[val_double]]
   double f64 = buf.Load<double>(tid.x);
 
@@ -128,7 +128,7 @@ ByteAddressBuffer buf;
 // CHECK:         [[val0_word1_ulong:%\d+]] = OpUConvert %ulong [[val0_word1_uint]]
 // CHECK: [[shifted_val0_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[val0_word1_ulong]] %uint_32
 // CHECK:               [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[val0_word0_ulong]] [[shifted_val0_word1_ulong]]
-// CHECK:              [[val0_double:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+// CHECK:              [[val0_double:%\d+]] = OpBitcast %double [[val0_ulong]]
 //
 // CHECK:                   [[addr_2:%\d+]] = OpIAdd %uint [[addr_1]] %uint_1
 // CHECK:                      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr_2]]
@@ -140,7 +140,7 @@ ByteAddressBuffer buf;
 // CHECK:         [[val1_word1_ulong:%\d+]] = OpUConvert %ulong [[val1_word1_uint]]
 // CHECK: [[shifted_val1_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[val1_word1_ulong]] %uint_32
 // CHECK:               [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[val1_word0_ulong]] [[shifted_val1_word1_ulong]]
-// CHECK:              [[val1_double:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+// CHECK:              [[val1_double:%\d+]] = OpBitcast %double [[val1_ulong]]
 //
 // CHECK:                     [[fArr:%\d+]] = OpCompositeConstruct %_arr_double_uint_2 [[val0_double]] [[val1_double]]
 // CHECK:                                     OpStore %fArr [[fArr]]

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.scalar.hlsl
@@ -1,0 +1,149 @@
+// Run: %dxc -T cs_6_2 -E main -enable-16bit-types
+
+ByteAddressBuffer buf;
+
+[numthreads(64, 1, 1)] void main(uint3 tid
+                                 : SV_DispatchThreadId) {
+  // ********* 16-bit scalar ********************
+
+  // CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK:   [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[ushort:%\d+]] = OpUConvert %ushort [[uint]]
+  // CHECK:                   OpStore %u16 [[ushort]]
+  uint16_t u16 = buf.Load<uint16_t>(tid.x);
+
+  // CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK:   [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[ushort:%\d+]] = OpUConvert %ushort [[uint]]
+  // CHECK:  [[short:%\d+]] = OpBitcast %short [[ushort]]
+  // CHECK:                   OpStore %i16 [[short]]
+  int16_t i16 = buf.Load<int16_t>(tid.x);
+
+  // CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK:   [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[ushort:%\d+]] = OpUConvert %ushort [[uint]]
+  // CHECK:   [[half:%\d+]] = OpConvertUToF %half [[ushort]]
+  // CHECK:                   OpStore %f16 [[half]]
+  float16_t f16 = buf.Load<float16_t>(tid.x);
+
+  // ********* 32-bit scalar ********************
+
+  // CHECK:  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK: [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK:                 OpStore %u [[uint]]
+  uint u = buf.Load<uint>(tid.x);
+
+  // CHECK:  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK: [[uint:%\d+]] = OpLoad %uint [[ptr:%\d+]]
+  // CHECK:  [[int:%\d+]] = OpBitcast %int [[uint]]
+  // CHECK:                 OpStore %i [[int]]
+  int i = buf.Load<int>(tid.x);
+
+  // CHECK:   [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK:  [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[float:%\d+]] = OpConvertUToF %float [[uint]]
+  // CHECK:                  OpStore %f [[float]]
+  float f = buf.Load<float>(tid.x);
+
+  // CHECK:  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 {{%\d+}}
+  // CHECK: [[uint:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[bool:%\d+]] = OpINotEqual %bool [[uint]] %uint_0
+  // CHECK:                 OpStore %b [[bool]]
+  bool b = buf.Load<bool>(tid.x);
+
+  // ********* 64-bit scalar ********************
+
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr:%\d+]]
+// CHECK:            [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[newAddr:%\d+]] = OpIAdd %uint [[addr]] %uint_1
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[newAddr]]
+// CHECK:            [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:       [[word0ULong:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:       [[word1ULong:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK:[[shiftedWord1ULong:%\d+]] = OpShiftLeftLogical %ulong [[word1ULong]] %uint_32
+// CHECK:              [[val:%\d+]] = OpBitwiseOr %ulong [[word0ULong]] [[shiftedWord1ULong]]
+// CHECK:                             OpStore %u64 [[val]]
+  uint64_t u64 = buf.Load<uint64_t>(tid.x);
+
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr:%\d+]]
+// CHECK:            [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[newAddr:%\d+]] = OpIAdd %uint [[addr]] %uint_1
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[newAddr]]
+// CHECK:            [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:        [[word0Long:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:        [[word1Long:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK: [[shiftedWord1Long:%\d+]] = OpShiftLeftLogical %ulong [[word1Long]] %uint_32
+// CHECK:        [[val_ulong:%\d+]] = OpBitwiseOr %ulong [[word0Long]] [[shiftedWord1Long]]
+// CHECK:         [[val_long:%\d+]] = OpBitcast %long [[val_ulong]]
+// CHECK:                             OpStore %i64 [[val_long]]
+  int64_t i64 = buf.Load<int64_t>(tid.x);
+
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr:%\d+]]
+// CHECK:            [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[newAddr:%\d+]] = OpIAdd %uint [[addr]] %uint_1
+// CHECK:              [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[newAddr]]
+// CHECK:            [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:        [[word0Long:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:        [[word1Long:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK: [[shiftedWord1Long:%\d+]] = OpShiftLeftLogical %ulong [[word1Long]] %uint_32
+// CHECK:        [[val_ulong:%\d+]] = OpBitwiseOr %ulong [[word0Long]] [[shiftedWord1Long]]
+// CHECK:       [[val_double:%\d+]] = OpConvertUToF %double [[val_ulong]]
+// CHECK:                             OpStore %f64 [[val_double]]
+  double f64 = buf.Load<double>(tid.x);
+
+  // ********* array of scalars *****************
+
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr:%\d+]]
+// CHECK:    [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:     [[val0:%\d+]] = OpUConvert %ushort [[word0]]
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr]]
+// CHECK:    [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[val1uint:%\d+]] = OpShiftRightLogical %uint [[word0]] %uint_16
+// CHECK:     [[val1:%\d+]] = OpUConvert %ushort [[val1uint]]
+// CHECK:  [[newAddr:%\d+]] = OpIAdd %uint [[addr]] %uint_1
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[newAddr]]
+// CHECK:    [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:     [[val2:%\d+]] = OpUConvert %ushort [[word1]]
+// CHECK:     [[uArr:%\d+]] = OpCompositeConstruct %_arr_ushort_uint_3 [[val0]] [[val1]] [[val2]]
+// CHECK:                     OpStore %uArr [[uArr]]
+  uint16_t uArr[3] = buf.Load<uint16_t[3]>(tid.x);
+
+// CHECK:       [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr:%\d+]]
+// CHECK: [[val0_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val0:%\d+]] = OpBitcast %int %174
+// CHECK:   [[newAddr:%\d+]] = OpIAdd %uint [[addr]] %uint_1
+// CHECK:       [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[newAddr]]
+// CHECK: [[val1_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val1:%\d+]] = OpBitcast %int [[val1_uint]]
+// CHECK:      [[iArr:%\d+]] = OpCompositeConstruct %_arr_int_uint_2 [[val0]] [[val1]]
+// CHECK:                      OpStore %iArr [[iArr]]
+  int iArr[2] = buf.Load<int[2]>(tid.x);
+
+// CHECK:                      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr_0:%\d+]]
+// CHECK:          [[val0_word0_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:                   [[addr_1:%\d+]] = OpIAdd %uint [[addr_0]] %uint_1
+// CHECK:                      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr_1]]
+// CHECK:          [[val0_word1_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[val0_word0_ulong:%\d+]] = OpUConvert %ulong [[val0_word0_uint]]
+// CHECK:         [[val0_word1_ulong:%\d+]] = OpUConvert %ulong [[val0_word1_uint]]
+// CHECK: [[shifted_val0_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[val0_word1_ulong]] %uint_32
+// CHECK:               [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[val0_word0_ulong]] [[shifted_val0_word1_ulong]]
+// CHECK:              [[val0_double:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+//
+// CHECK:                   [[addr_2:%\d+]] = OpIAdd %uint [[addr_1]] %uint_1
+// CHECK:                      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr_2]]
+// CHECK:          [[val1_word0_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:                   [[addr_3:%\d+]] = OpIAdd %uint [[addr_2]] %uint_1
+// CHECK:                      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[addr_3]]
+// CHECK:          [[val1_word1_uint:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:         [[val1_word0_ulong:%\d+]] = OpUConvert %ulong [[val1_word0_uint]]
+// CHECK:         [[val1_word1_ulong:%\d+]] = OpUConvert %ulong [[val1_word1_uint]]
+// CHECK: [[shifted_val1_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[val1_word1_ulong]] %uint_32
+// CHECK:               [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[val1_word0_ulong]] [[shifted_val1_word1_ulong]]
+// CHECK:              [[val1_double:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+//
+// CHECK:                     [[fArr:%\d+]] = OpCompositeConstruct %_arr_double_uint_2 [[val0_double]] [[val1_double]]
+// CHECK:                                     OpStore %fArr [[fArr]]
+  double fArr[2] = buf.Load<double[2]>(tid.x);
+}
+

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.struct.hlsl
@@ -1,0 +1,170 @@
+// Run: %dxc -T cs_6_2 -E main -enable-16bit-types
+
+ByteAddressBuffer buf;
+RWByteAddressBuffer buf2;
+
+struct S {
+  float16_t3 a[3];
+  float b;
+  double c;
+  float16_t d;
+};
+
+[numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadId) {
+  S sArr[2] = buf.Load<S[2]>(tid.x);
+}
+
+// Here is the DXIL output with the load offsets:
+//
+// define void @main() {
+//   COMMENT: Load at address tid.x (offset = 0):
+//   %RawBufferLoad36 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %1, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 6 (offset = 6 bytes):
+//   %5 = add i32 %1, 6
+//   %RawBufferLoad35 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %5, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 12 (offset = 12 bytes):
+//   %9 = add i32 %1, 12
+//   %RawBufferLoad = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %9, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 20 (offset = 20 bytes):
+//   %13 = add i32 %1, 20
+//   %RawBufferLoad45 = call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %13, i32 undef, i8 1, i32 4)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 24 (offset = 24 bytes):
+//   %15 = add i32 %1, 24
+//   %16 = call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %15, i32 undef, i8 3, i32 8)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 32 (offset = 32 bytes):
+//   %20 = add i32 %1, 32
+//   %RawBufferLoad43 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %20, i32 undef, i8 1, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: The load of the first struct in sArr has finished.
+//   COMMENT: Padding must be applied until we reach the struct alignment.
+//   COMMENT: The second struct in sArr starts at offset 40.
+//   COMMENT: Load at address tid.x + 40 (offset = 40 bytes):
+//   %22 = add i32 %1, 40
+//   %RawBufferLoad39 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %22, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 46 (offset = 46 bytes):
+//   %26 = add i32 %1, 46
+//   %RawBufferLoad38 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %26, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 52 (offset = 52 bytes):
+//   %30 = add i32 %1, 52
+//   %RawBufferLoad37 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %30, i32 undef, i8 7, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 60 (offset = 60 bytes):
+//   %34 = add i32 %1, 60
+//   %RawBufferLoad42 = call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %34, i32 undef, i8 1, i32 4)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 64 (offset = 64 bytes):
+//   %36 = add i32 %1, 64
+//   %37 = call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %36, i32 undef, i8 3, i32 8)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+//   COMMENT: Load at address tid.x + 72 (offset = 72 bytes):
+//   %41 = add i32 %1, 72
+//   %RawBufferLoad40 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %buf_texture_rawbuf, i32 %41, i32 undef, i8 1, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+//   ...
+// }
+
+
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK: [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:   [[aVec0:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK: [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK: [[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:   [[aVec1:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK: [[index_4:%\d+]] = OpIAdd %uint [[index_3]] %uint_1
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
+// CHECK:   [[aVec2:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:       [[a:%\d+]] = OpCompositeConstruct %_arr_v3half_uint_3 [[aVec0]] [[aVec1]] [[aVec2]]
+//
+// COMMENT: Going to start loading 'b'. Must start at byte offset 20
+// COMMENT: 20 byte offset is equivalent to 5 words offset (32-bit words).
+// COMMENT: 'b' is 32-bit wide, so it will consume 1 word.
+//
+// CHECK: [[index_5:%\d+]] = OpIAdd %uint [[index_0]] %uint_5
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_5]]
+//
+// COMMENT: Going to start loading 'c'. Must start at byte offset 24
+// COMMENT: 24 byte offset is equivalent to 6 words offset (32-bit words).
+// COMMENT: 'c' is 64-bit wide, so it will consume 2 words.
+//
+// CHECK: [[index_6:%\d+]] = OpIAdd %uint [[index_0]] %uint_6
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_6]]
+// CHECK: [[index_7:%\d+]] = OpIAdd %uint [[index_6]] %uint_1
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_7]]
+//
+// COMMENT: Going to start loading 'd'. Must start at byte offset 32.
+// COMMENT: 32 byte offset is equivalent to 8 words offset (32-bit words).
+// COMMENT: 'd' is 16-bit wide, so it will consume half of one word.
+//
+// CHECK: [[index_8:%\d+]] = OpIAdd %uint [[index_0]] %uint_8
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_8]]
+// CHECK: [[index_10:%\d+]] = OpIAdd %uint [[index_0]] %uint_10
+// CHECK: [[s_0:%\d+]] = OpCompositeConstruct %S
+//
+// COMMENT: Going to start loading the second struct in sArr.
+// COMMENT: The structure is 8-byte aligned (due to the existence of 'double')
+// COMMENT: The last struct in the array ended at offset 34.
+// COMMENT: We need to add padding up to offset 40 (to be 8-byte aligned).
+// COMMENT: 40 byte offset is equivalent to 10 words offset (32-bit words).
+//
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_10]]
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_10]]
+// CHECK: [[index_11:%\d+]] = OpIAdd %uint [[index_10]] %uint_1
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_11]]
+// CHECK:    [[aVec0:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_11]]
+// CHECK: [[index_12:%\d+]] = OpIAdd %uint [[index_11]] %uint_1
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_12]]
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_12]]
+// CHECK: [[index_13:%\d+]] = OpIAdd %uint [[index_12]] %uint_1
+// CHECK:    [[aVec1:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_13]]
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_13]]
+// CHECK: [[index_14:%\d+]] = OpIAdd %uint [[index_13]] %uint_1
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_14]]
+// CHECK:    [[aVec2:%\d+]] = OpCompositeConstruct %v3half
+// CHECK:        [[a:%\d+]] = OpCompositeConstruct %_arr_v3half_uint_3 [[aVec0]] [[aVec1]] [[aVec2]]
+//
+// COMMENT: Similar to the load of the first struct, member 'b' is at offset 20
+// COMMENT: from the beginning of the struct. The second struct starts at offset 40
+// COMMENT: Therefore the second struct's 'b' starts at offset 60.
+// COMMENT: 60 byte offset is equivalent to 15 words offset (32-bit words).
+//
+// CHECK: [[index_15:%\d+]] = OpIAdd %uint [[index_10]] %uint_5
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_15]]
+//
+// COMMENT: member 'c' must start at offset 40 + 24 = 64
+// COMMENT: 64 byte offset is equivalent to 16 words offset (32-bit words).
+// COMMENT: 'c' is 64-bit wide, so it will consume 2 words.
+//
+// CHECK: [[index_16:%\d+]] = OpIAdd %uint [[index_10]] %uint_6
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_16]]
+// CHECK: [[index_17:%\d+]] = OpIAdd %uint [[index_16]] %uint_1
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_17]]
+//
+// COMMENT: member 'd' must start at offset 40 + 32 = 72
+// COMMENT: 72 byte offset is equivalent to 18 words offset (32-bit words).
+// COMMENT: 'c' is 16-bit wide, so it will consume half of one word.
+//
+// CHECK: [[index_18:%\d+]] = OpIAdd %uint [[index_10]] %uint_8
+// CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_18]]
+//
+// COMMENT: Construct sArr[2]
+//
+// CHECK:                     OpCompositeConstruct %S
+// CHECK:                     OpCompositeConstruct %_arr_S_uint_2
+// CHECK:                     OpStore %sArr {{%\d+}}
+

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.vector.hlsl
@@ -1,0 +1,120 @@
+// Run: %dxc -T cs_6_2 -E main -enable-16bit-types
+
+ByteAddressBuffer buf;
+
+[numthreads(64, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadId)
+{
+// ********* 16-bit vector ********************
+// CHECK:       [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:     [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val0:%\d+]] = OpUConvert %ushort [[word0]]
+// CHECK:       [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0]]
+// CHECK:     [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[val1_uint:%\d+]] = OpShiftRightLogical %uint [[word0]] %uint_16
+// CHECK:      [[val1:%\d+]] = OpUConvert %ushort [[val1_uint]]
+// CHECK:   [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:       [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:     [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:      [[val2:%\d+]] = OpUConvert %ushort [[word1]]
+// CHECK:      [[uVec:%\d+]] = OpCompositeConstruct %v3ushort [[val0]] [[val1]] [[val2]]
+// CHECK:                      OpStore %u16 [[uVec]]
+  uint16_t3 u16 = buf.Load<uint16_t3>(tid.x);
+
+
+// ********* 32-bit vector ********************
+
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:   [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:    [[val0:%\d+]] = OpBitcast %int [[word0]]
+// CHECK: [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:   [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:    [[val1:%\d+]] = OpBitcast %int [[word1]]
+// CHECK:    [[iVec:%\d+]] = OpCompositeConstruct %v2int [[val0]] [[val1]]
+// CHECK:                    OpStore %i [[iVec]]
+  int2 i = buf.Load<int2>(tid.x);
+
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:   [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:    [[val0:%\d+]] = OpINotEqual %bool [[word0]] %uint_0
+// CHECK: [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:     [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:   [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:    [[val1:%\d+]] = OpINotEqual %bool [[word1]] %uint_0
+// CHECK:    [[bVec:%\d+]] = OpCompositeConstruct %v2bool [[val0]] [[val1]]
+// CHECK:                    OpStore %b [[bVec]]
+  bool2 b = buf.Load<bool2>(tid.x);
+
+// ********* 64-bit vector ********************
+
+// CHECK:                  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:                [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:              [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:                  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:                [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[word0_ulong:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:          [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK:  [[shifted_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
+// CHECK:           [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[shifted_word1_ulong]]
+// CHECK:                 [[val0:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+// CHECK:              [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:                  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:                [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:              [[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:                  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:                [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[word0_ulong:%\d+]] = OpUConvert %ulong [[word0]]
+// CHECK:          [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
+// CHECK:  [[shifted_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
+// CHECK:           [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[shifted_word1_ulong]]
+// CHECK:                 [[val1:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+// CHECK:                 [[fVec:%\d+]] = OpCompositeConstruct %v2double [[val0]] [[val1]]
+// CHECK:                                 OpStore %f64 [[fVec]]
+  float64_t2 f64 = buf.Load<float64_t2>(tid.x);
+
+// ********* array of vectors ********************
+
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_0:%\d+]]
+// CHECK:         [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val0:%\d+]] = OpUConvert %ushort [[word0]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 %117
+// CHECK:         [[word0:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[word0_shifted:%\d+]] = OpShiftRightLogical %uint [[word0]] %uint_16
+// CHECK:          [[val1:%\d+]] = OpUConvert %ushort [[word0_shifted]]
+// CHECK:       [[index_1:%\d+]] = OpIAdd %uint [[index_0]] %uint_1
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:         [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val2:%\d+]] = OpUConvert %ushort [[word1]]
+// CHECK:          [[vec0:%\d+]] = OpCompositeConstruct %v3ushort [[val0]] [[val1]] [[val2]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_1]]
+// CHECK:         [[word1:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[word1_shifted:%\d+]] = OpShiftRightLogical %uint [[word1]] %uint_16
+// CHECK:          [[val3:%\d+]] = OpUConvert %ushort [[word1_shifted:%\d+]]
+// CHECK:       [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:         [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val4:%\d+]] = OpUConvert %ushort [[word2]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
+// CHECK:         [[word2:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[shifted_word2:%\d+]] = OpShiftRightLogical %uint [[word2]] %uint_16
+// CHECK:          [[val5:%\d+]] = OpUConvert %ushort [[shifted_word2]]
+// CHECK:       [[index_3:%\d+]] = OpIAdd %uint [[index_2]] %uint_1
+// CHECK:          [[vec1:%\d+]] = OpCompositeConstruct %v3ushort [[val3]] [[val4]] [[val5]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:         [[word3:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val6:%\d+]] = OpUConvert %ushort [[word3]]
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_3]]
+// CHECK:         [[word3:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK: [[shifted_word3:%\d+]] = OpShiftRightLogical %uint [[word3]] %uint_16
+// CHECK:          [[val7:%\d+]] = OpUConvert %ushort [[shifted_word3]]
+// CHECK:       [[index_4:%\d+]] = OpIAdd %uint [[index_3]] %uint_1
+// CHECK:           [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_4]]
+// CHECK:         [[word4:%\d+]] = OpLoad %uint [[ptr]]
+// CHECK:          [[val8:%\d+]] = OpUConvert %ushort [[word4]]
+// CHECK:          [[vec2:%\d+]] = OpCompositeConstruct %v3ushort [[val6]] [[val7]] [[val8]]
+// CHECK:        [[vecArr:%\d+]] = OpCompositeConstruct %_arr_v3ushort_uint_3 [[vec0]] [[vec1]] [[vec2]]
+// CHECK:                          OpStore %uVec [[vecArr]]
+  uint16_t3 uVec[3] = buf.Load<uint16_t3[3]>(tid.x);
+}
+

--- a/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.vector.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.byte-address-buffer.templated-load.vector.hlsl
@@ -57,7 +57,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:          [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
 // CHECK:  [[shifted_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
 // CHECK:           [[val0_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[shifted_word1_ulong]]
-// CHECK:                 [[val0:%\d+]] = OpConvertUToF %double [[val0_ulong]]
+// CHECK:                 [[val0:%\d+]] = OpBitcast %double [[val0_ulong]]
 // CHECK:              [[index_2:%\d+]] = OpIAdd %uint [[index_1]] %uint_1
 // CHECK:                  [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %buf %uint_0 [[index_2]]
 // CHECK:                [[word0:%\d+]] = OpLoad %uint [[ptr]]
@@ -68,7 +68,7 @@ void main(uint3 tid : SV_DispatchThreadId)
 // CHECK:          [[word1_ulong:%\d+]] = OpUConvert %ulong [[word1]]
 // CHECK:  [[shifted_word1_ulong:%\d+]] = OpShiftLeftLogical %ulong [[word1_ulong]] %uint_32
 // CHECK:           [[val1_ulong:%\d+]] = OpBitwiseOr %ulong [[word0_ulong]] [[shifted_word1_ulong]]
-// CHECK:                 [[val1:%\d+]] = OpConvertUToF %double [[val1_ulong]]
+// CHECK:                 [[val1:%\d+]] = OpBitcast %double [[val1_ulong]]
 // CHECK:                 [[fVec:%\d+]] = OpCompositeConstruct %v2double [[val0]] [[val1]]
 // CHECK:                                 OpStore %f64 [[fVec]]
   float64_t2 f64 = buf.Load<float64_t2>(tid.x);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -878,6 +878,18 @@ TEST_F(FileTest, ConsumeStructuredBufferGetDimensions) {
 TEST_F(FileTest, ByteAddressBufferLoad) {
   runFileTest("method.byte-address-buffer.load.hlsl");
 }
+TEST_F(FileTest, ByteAddressBufferTemplatedLoadScalar) {
+  runFileTest("method.byte-address-buffer.templated-load.scalar.hlsl");
+}
+TEST_F(FileTest, ByteAddressBufferTemplatedLoadVector) {
+  runFileTest("method.byte-address-buffer.templated-load.vector.hlsl");
+}
+TEST_F(FileTest, ByteAddressBufferTemplatedLoadMatrix) {
+  runFileTest("method.byte-address-buffer.templated-load.matrix.hlsl");
+}
+TEST_F(FileTest, ByteAddressBufferTemplatedLoadStruct) {
+  runFileTest("method.byte-address-buffer.templated-load.struct.hlsl");
+}
 TEST_F(FileTest, ByteAddressBufferStore) {
   runFileTest("method.byte-address-buffer.store.hlsl");
 }


### PR DESCRIPTION
In SPIR-V, ByteAddressBuffers are represented as structures with 1 member: a RuntimeArray of 32-bit uints.

In order to perform templated Load on a raw buffer (e.g. `buf.Load<T>`), we'll need to perform one or more 32-bit uint loads and construct the target type (`T`). The target type is only allowed to be numerical types, boolean types, structures containing them, or arrays of any of these.

This is only the `Load` side of things. The support for templated `Store` is not yet implemented.