### PR TITLE
DxilDia bugfixes:

### DIFF
--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -98,7 +98,11 @@ void dxil_dia::Session::Init(
   }
 
   // Initialize symbols
-  m_symsMgr.Init(this);
+  try {
+      m_symsMgr.Init(this);
+  } catch (const hlsl::Exception &) {
+      m_symsMgr = std::move(dxil_dia::SymbolManager());
+  }
 }
 
 HRESULT dxil_dia::Session::getSourceFileIdByName(

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -1737,10 +1737,10 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariables() {
   llvm::Function *DbgDeclare = llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
   for (llvm::Value *U : DbgDeclare->users()) {
     auto *CI = llvm::dyn_cast<llvm::CallInst>(U);
-    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(CI->getDebugLoc()->getScope());
+    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(CI->getDebugLoc()->getInlinedAtScope());
     auto SymIt = m_ScopeToSym.find(LS);
     if (SymIt == m_ScopeToSym.end()) {
-      continue;
+      return E_FAIL;
     }
 
     auto *LocalNameMetadata = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1));

--- a/lib/DxilDia/DxilDiaSymbolManager.h
+++ b/lib/DxilDia/DxilDiaSymbolManager.h
@@ -60,6 +60,8 @@ public:
 
 
   SymbolManager();
+  SymbolManager(SymbolManager&&) = default;
+  SymbolManager &operator =(SymbolManager &&) = default;
   ~SymbolManager();
 
   void Init(Session *pSes);


### PR DESCRIPTION
1) avoids leaking exceptions during symbol initialization
2) returns E_FAIL when the scope for a local variable is not found
3) uses getInlinedAtScope when searching for the local variable's scopes.