### PR TITLE
Add RaytracingPipelineConfig1 subobject to DXR

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1249,8 +1249,8 @@ namespace DXIL {
     UseNativeLowPrecision
   };
 
-  // Corresponds to HIT_FLAG_* in HLSL
-  enum class RayFlag : uint8_t {
+  // Corresponds to RAY_FLAG_* in HLSL
+  enum class RayFlag : uint32_t {
     None = 0x00,
     ForceOpaque = 0x01,
     ForceNonOpaque = 0x02,
@@ -1260,6 +1260,8 @@ namespace DXIL {
     CullFrontFacingTriangles = 0x20,
     CullOpaque = 0x40,
     CullNonOpaque = 0x80,
+    SkipTriangles = 0x100,
+    SkipProceduralPrimitives = 0x200,
   };
 
   // Corresponds to HIT_KIND_* in HLSL
@@ -1316,6 +1318,7 @@ namespace DXIL {
     RaytracingShaderConfig            = 9,
     RaytracingPipelineConfig          = 10,
     HitGroup                          = 11,
+    RaytracingPipelineConfig1         = 12,
     NumKinds // aka D3D12_STATE_SUBOBJECT_TYPE_MAX_VALID
   };
 
@@ -1336,7 +1339,13 @@ namespace DXIL {
     ProceduralPrimitive = 0x1,
     LastEntry,
   };
-
+  
+  enum class RaytracingPipelineFlags : uint32_t {
+    SkipTriangles = 0x100,
+    SkipProceduralPrimitives = 0x200,
+    ValidMask = 0x300,
+  };
+  
   enum class CommittedStatus : uint32_t {
     CommittedNothing = 0,
     CommittedTriangleHit = 1,

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1341,6 +1341,7 @@ namespace DXIL {
   };
   
   enum class RaytracingPipelineFlags : uint32_t {
+    None = 0x0,
     SkipTriangles = 0x100,
     SkipProceduralPrimitives = 0x200,
     ValidMask = 0x300,

--- a/include/dxc/DXIL/DxilSubobject.h
+++ b/include/dxc/DXIL/DxilSubobject.h
@@ -50,6 +50,7 @@ public:
   bool GetRaytracingShaderConfig(uint32_t &MaxPayloadSizeInBytes,
                                  uint32_t &MaxAttributeSizeInBytes) const;
   bool GetRaytracingPipelineConfig(uint32_t &MaxTraceRecursionDepth) const;
+  bool GetRaytracingPipelineConfig1(uint32_t &MaxTraceRecursionDepth, uint32_t &Flags) const;
   bool GetHitGroup(DXIL::HitGroupType &hitGroupType,
                    llvm::StringRef &AnyHit,
                    llvm::StringRef &ClosestHit,
@@ -86,6 +87,10 @@ private:
   struct RaytracingPipelineConfig_t {
     uint32_t MaxTraceRecursionDepth;
   };
+  struct RaytracingPipelineConfig1_t {
+    uint32_t MaxTraceRecursionDepth;
+    uint32_t Flags; // DXIL::RaytracingPipelineFlags
+  };
   struct HitGroup_t {
     DXIL::HitGroupType Type;
     const char *AnyHit;
@@ -100,6 +105,7 @@ private:
     RaytracingShaderConfig_t RaytracingShaderConfig;
     RaytracingPipelineConfig_t RaytracingPipelineConfig;
     HitGroup_t HitGroup;
+    RaytracingPipelineConfig1_t RaytracingPipelineConfig1;
   };
 
   friend class DxilSubobjects;
@@ -148,6 +154,10 @@ public:
   DxilSubobject &CreateRaytracingPipelineConfig(
     llvm::StringRef Name,
     uint32_t MaxTraceRecursionDepth);
+  DxilSubobject &CreateRaytracingPipelineConfig1(
+    llvm::StringRef Name,
+    uint32_t MaxTraceRecursionDepth,
+    uint32_t Flags);
   DxilSubobject &CreateHitGroup(llvm::StringRef Name, 
                                 DXIL::HitGroupType hitGroupType,
                                 llvm::StringRef AnyHit,

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -219,6 +219,10 @@ struct RuntimeDataSubobjectInfo {
     uint32_t ClosestHit;
     uint32_t Intersection;
   };
+  struct RaytracingPipelineConfig1_t {
+    uint32_t MaxTraceRecursionDepth;
+    uint32_t Flags;
+  };
 
   union {
     StateObjectConfig_t StateObjectConfig;
@@ -227,6 +231,7 @@ struct RuntimeDataSubobjectInfo {
     RaytracingShaderConfig_t RaytracingShaderConfig;
     RaytracingPipelineConfig_t RaytracingPipelineConfig;
     HitGroup_t HitGroup;
+    RaytracingPipelineConfig1_t RaytracingPipelineConfig1;
   };
 };
 
@@ -532,6 +537,17 @@ public:
       m_SubobjectInfo->RaytracingPipelineConfig.MaxTraceRecursionDepth : 0;
   }
 
+  // RaytracingPipelineConfig1
+  uint32_t GetRaytracingPipelineConfig1_MaxTraceRecursionDepth() const {
+    return (GetKind() == DXIL::SubobjectKind::RaytracingPipelineConfig1) ?
+      m_SubobjectInfo->RaytracingPipelineConfig1.MaxTraceRecursionDepth : 0;
+  }
+
+  uint32_t GetRaytracingPipelineConfig1_Flags() const {
+    return (GetKind() == DXIL::SubobjectKind::RaytracingPipelineConfig1) ?
+      m_SubobjectInfo->RaytracingPipelineConfig1.Flags : (uint32_t)0;
+  }
+
   // HitGroup
   DXIL::HitGroupType GetHitGroup_Type() const {
     return (GetKind() == DXIL::SubobjectKind::HitGroup) ?
@@ -653,6 +669,11 @@ struct DxilSubobjectDesc {
     LPCWSTR Intersection;
   };
 
+  struct RaytracingPipelineConfig1_t {
+    uint32_t MaxTraceRecursionDepth;
+    uint32_t Flags; // DXIL::RaytracingPipelineFlags / D3D12_RAYTRACING_PIPELINE_FLAGS
+  };
+
   union {
     StateObjectConfig_t StateObjectConfig;
     RootSignature_t RootSignature;    // GlobalRootSignature or LocalRootSignature
@@ -660,6 +681,7 @@ struct DxilSubobjectDesc {
     RaytracingShaderConfig_t RaytracingShaderConfig;
     RaytracingPipelineConfig_t RaytracingPipelineConfig;
     HitGroup_t HitGroup;
+    RaytracingPipelineConfig1_t RaytracingPipelineConfig1;
   };
 };
 

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -515,6 +515,10 @@ DxilSubobjectDesc *DxilRuntimeReflection_impl::AddSubobject(const SubobjectReade
     subobject.HitGroup.AnyHit = GetWideString(subobjectReader.GetHitGroup_AnyHit());
     subobject.HitGroup.ClosestHit = GetWideString(subobjectReader.GetHitGroup_ClosestHit());
     break;
+  case DXIL::SubobjectKind::RaytracingPipelineConfig1:
+    subobject.RaytracingPipelineConfig1.MaxTraceRecursionDepth = subobjectReader.GetRaytracingPipelineConfig1_MaxTraceRecursionDepth();
+    subobject.RaytracingPipelineConfig1.Flags = subobjectReader.GetRaytracingPipelineConfig1_Flags();
+    break;
   default:
     // Ignore contents of unrecognized subobject type (forward-compat)
     break;

--- a/lib/DXIL/DxilSubobject.cpp
+++ b/lib/DXIL/DxilSubobject.cpp
@@ -76,6 +76,10 @@ void DxilSubobject::CopyUnionedContents(const DxilSubobject &other) {
     HitGroup.ClosestHit = other.HitGroup.ClosestHit;
     HitGroup.Intersection = other.HitGroup.Intersection;
     break;
+  case Kind::RaytracingPipelineConfig1:
+    RaytracingPipelineConfig1.MaxTraceRecursionDepth = other.RaytracingPipelineConfig1.MaxTraceRecursionDepth;
+    RaytracingPipelineConfig1.Flags = other.RaytracingPipelineConfig1.Flags;
+    break;
   default:
     DXASSERT(0, "invalid kind");
     break;
@@ -178,7 +182,17 @@ bool DxilSubobject::GetHitGroup(DXIL::HitGroupType &hitGroupType,
   return false;
 }
 
-
+// RaytracingPipelineConfig1
+bool DxilSubobject::GetRaytracingPipelineConfig1(
+    uint32_t &MaxTraceRecursionDepth, uint32_t &Flags) const {
+  if (m_Kind == Kind::RaytracingPipelineConfig1) {
+    MaxTraceRecursionDepth = RaytracingPipelineConfig1.MaxTraceRecursionDepth;
+    Flags = RaytracingPipelineConfig1.Flags;
+    return true;
+  }
+  return false;
+}
+ 
 DxilSubobjects::DxilSubobjects()
   : m_BytesStorage()
   , m_Subobjects()
@@ -304,6 +318,16 @@ DxilSubobject &DxilSubobjects::CreateHitGroup(llvm::StringRef Name,
   obj.HitGroup.AnyHit = AnyHit.data();
   obj.HitGroup.ClosestHit = ClosestHit.data();
   obj.HitGroup.Intersection = Intersection.data();
+  return obj;
+}
+
+DxilSubobject &DxilSubobjects::CreateRaytracingPipelineConfig1(
+    llvm::StringRef Name, uint32_t MaxTraceRecursionDepth, uint32_t Flags) {
+  auto &obj = CreateSubobject(Kind::RaytracingPipelineConfig1, Name);
+  obj.RaytracingPipelineConfig1.MaxTraceRecursionDepth = MaxTraceRecursionDepth;
+  DXASSERT_NOMSG(
+      0 == ((~(uint32_t)DXIL::RaytracingPipelineFlags::ValidMask) & Flags));
+  obj.RaytracingPipelineConfig1.Flags = Flags;
   return obj;
 }
 

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1288,6 +1288,7 @@ private:
           info.RaytracingPipelineConfig.MaxTraceRecursionDepth);
         break;
       case DXIL::SubobjectKind::HitGroup:
+      {
         HitGroupType hgType;
         StringRef AnyHit;
         StringRef ClosestHit;
@@ -1297,6 +1298,12 @@ private:
         info.HitGroup.AnyHit = m_pStringBufferPart->Insert(AnyHit);
         info.HitGroup.ClosestHit = m_pStringBufferPart->Insert(ClosestHit);
         info.HitGroup.Intersection = m_pStringBufferPart->Insert(Intersection);
+        break;
+      }
+      case DXIL::SubobjectKind::RaytracingPipelineConfig1:
+        obj.GetRaytracingPipelineConfig1(
+            info.RaytracingPipelineConfig1.MaxTraceRecursionDepth,
+            info.RaytracingPipelineConfig1.Flags);
         break;
       }
       m_pSubobjectTable->Insert(info);

--- a/lib/DxilContainer/DxilContainerReader.cpp
+++ b/lib/DxilContainer/DxilContainerReader.cpp
@@ -72,6 +72,12 @@ bool LoadSubobjectsFromRDAT(DxilSubobjects &subobjects, RDAT::SubobjectTableRead
           reader.GetHitGroup_ClosestHit(),
           reader.GetHitGroup_Intersection());
           break;
+      case DXIL::SubobjectKind::RaytracingPipelineConfig1:
+        subobjects.CreateRaytracingPipelineConfig1(
+            reader.GetName(),
+            reader.GetRaytracingPipelineConfig1_MaxTraceRecursionDepth(),
+            reader.GetRaytracingPipelineConfig1_Flags());
+        break;
       }
     } catch (hlsl::Exception &) {
       result = false;

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -305,6 +305,7 @@ void AddRecordTypeWithHandle(
 void AddRayFlags(clang::ASTContext& context);
 void AddHitKinds(clang::ASTContext& context);
 void AddStateObjectFlags(clang::ASTContext& context);
+void AddRaytracingPipelineFlags(clang::ASTContext &context);
 void AddCommittedStatus(clang::ASTContext& context);
 void AddCandidateType(clang::ASTContext& context);
 

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -581,6 +581,7 @@ void hlsl::AddStateObjectFlags(ASTContext& context) {
 void hlsl::AddRaytracingPipelineFlags(ASTContext& context) {
   DeclContext *curDC = context.getTranslationUnitDecl();
  
+  AddConstUInt(context, curDC, StringRef("RAYTRACING_PIPELINE_FLAG_NONE"), (unsigned)DXIL::RaytracingPipelineFlags::None);
   AddConstUInt(context, curDC, StringRef("RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES"), (unsigned)DXIL::RaytracingPipelineFlags::SkipTriangles);
   AddConstUInt(context, curDC, StringRef("RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES"), (unsigned)DXIL::RaytracingPipelineFlags::SkipProceduralPrimitives);
 }

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -556,6 +556,8 @@ void hlsl::AddRayFlags(ASTContext& context) {
   AddConstUInt(context, curDC, StringRef("RAY_FLAG_CULL_FRONT_FACING_TRIANGLES"), (unsigned)DXIL::RayFlag::CullFrontFacingTriangles);
   AddConstUInt(context, curDC, StringRef("RAY_FLAG_CULL_OPAQUE"), (unsigned)DXIL::RayFlag::CullOpaque);
   AddConstUInt(context, curDC, StringRef("RAY_FLAG_CULL_NON_OPAQUE"), (unsigned)DXIL::RayFlag::CullNonOpaque);
+  AddConstUInt(context, curDC, StringRef("RAY_FLAG_SKIP_TRIANGLES"), (unsigned)DXIL::RayFlag::SkipTriangles);
+  AddConstUInt(context, curDC, StringRef("RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES"), (unsigned)DXIL::RayFlag::SkipProceduralPrimitives);
 }
 
 /// <summary> Adds a constant integers for hit kinds </summary>
@@ -573,6 +575,14 @@ void hlsl::AddStateObjectFlags(ASTContext& context) {
  
   AddConstUInt(context, curDC, StringRef("STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS"), (unsigned)DXIL::StateObjectFlags::AllowLocalDependenciesOnExternalDefinitions);
   AddConstUInt(context, curDC, StringRef("STATE_OBJECT_FLAGS_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS"), (unsigned)DXIL::StateObjectFlags::AllowExternalDependenciesOnLocalDefinitions);
+}
+
+/// <summary> Adds a constant integers for raytracing pipeline flags </summary>
+void hlsl::AddRaytracingPipelineFlags(ASTContext& context) {
+  DeclContext *curDC = context.getTranslationUnitDecl();
+ 
+  AddConstUInt(context, curDC, StringRef("RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES"), (unsigned)DXIL::RaytracingPipelineFlags::SkipTriangles);
+  AddConstUInt(context, curDC, StringRef("RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES"), (unsigned)DXIL::RaytracingPipelineFlags::SkipProceduralPrimitives);
 }
 
 /// <summary> Adds const integers for committed status </summary>

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -564,6 +564,8 @@ bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKi
       return name == "RaytracingShaderConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingShaderConfig, true) : false;
     case 24:
       return name == "RaytracingPipelineConfig" ? (subobjectKind = DXIL::SubobjectKind::RaytracingPipelineConfig, true) : false;
+    case 25:
+      return name == "RaytracingPipelineConfig1" ? (subobjectKind = DXIL::SubobjectKind::RaytracingPipelineConfig1, true) : false;
     case 16:
       if (name == "TriangleHitGroup") {
         subobjectKind = DXIL::SubobjectKind::HitGroup;

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2811,6 +2811,19 @@ void CGMSHLSLRuntime::CreateSubobject(DXIL::SubobjectKind kind, const StringRef 
       }
       break;
     }
+    case DXIL::SubobjectKind::RaytracingPipelineConfig1: {
+      DXASSERT_NOMSG(argCount == 2);
+      uint32_t maxTraceRecursionDepth;
+      uint32_t raytracingPipelineFlags;
+      if (!GetAsConstantUInt32(args[0], &maxTraceRecursionDepth))
+        return;
+
+      if (!GetAsConstantUInt32(args[1], &raytracingPipelineFlags))
+        return;
+
+      subobjects->CreateRaytracingPipelineConfig1(name, maxTraceRecursionDepth, raytracingPipelineFlags);
+      break;
+    }
     default:
       llvm_unreachable("unknown SubobjectKind");
       break;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -203,6 +203,7 @@ enum ArBasicKind {
   AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
   AR_OBJECT_TRIANGLE_HIT_GROUP,
   AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP,
+  AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1,
 
   // RayQuery
   AR_OBJECT_RAY_QUERY,
@@ -489,6 +490,7 @@ const UINT g_uBasicKindProps[] =
   0,      //AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
   0,      //AR_OBJECT_TRIANGLE_HIT_GROUP,
   0,      //AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP,
+  0,      //AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1,
 
   0,      //AR_OBJECT_RAY_QUERY,
 
@@ -1323,6 +1325,7 @@ const ArBasicKind g_ArBasicKindsAsTypes[] =
   AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
   AR_OBJECT_TRIANGLE_HIT_GROUP,
   AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP,
+  AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1,
 
   AR_OBJECT_RAY_QUERY
 };
@@ -1409,6 +1412,7 @@ const uint8_t g_ArBasicKindsTemplateCount[] =
   0, // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
   0, // AR_OBJECT_TRIANGLE_HIT_GROUP,
   0, // AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP,
+  0, // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1,
 
   1, // AR_OBJECT_RAY_QUERY,
 };
@@ -1505,6 +1509,7 @@ const SubscriptOperatorRecord g_ArBasicKindsSubscripts[] =
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG,
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_TRIANGLE_HIT_GROUP,
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP,
+  { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1,
 
   { 0, MipsFalse, SampleFalse },  // AR_OBJECT_RAY_QUERY,
 };
@@ -1625,6 +1630,7 @@ const char* g_ArBasicTypeNames[] =
   "RaytracingPipelineConfig",
   "TriangleHitGroup",
   "ProceduralPrimitiveHitGroup",
+  "RaytracingPipelineConfig1",
 
   "RayQuery"
 };
@@ -2613,6 +2619,23 @@ static CXXRecordDecl *CreateSubobjectRaytracingPipelineConfig(ASTContext& contex
   return decl;
 }
 
+// struct RaytracingPipelineConfig1
+// {
+//   uint32_t MaxTraceRecursionDepth;
+//   uint32_t Flags;
+// };
+static CXXRecordDecl *
+CreateSubobjectRaytracingPipelineConfig1(ASTContext &context) {
+  CXXRecordDecl *decl =
+      StartSubobjectDecl(context, "RaytracingPipelineConfig1");
+  CreateSimpleField(context, decl, "MaxTraceRecursionDepth",
+                    context.UnsignedIntTy, AccessSpecifier::AS_private);
+  CreateSimpleField(context, decl, "Flags", context.UnsignedIntTy,
+                    AccessSpecifier::AS_private);
+  FinishSubobjectDecl(context, decl);
+  return decl;
+}
+
 // struct TriangleHitGroup
 // {
 //   string AnyHit;
@@ -3290,6 +3313,9 @@ private:
         case AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP:
           recordDecl = CreateSubobjectProceduralPrimitiveHitGroup(*m_context);
           break;
+        case AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1:
+          recordDecl = CreateSubobjectRaytracingPipelineConfig1(*m_context);
+          break;
         }
       } else if (kind == AR_OBJECT_RAY_QUERY) {
         ClassTemplateDecl* typeDecl = nullptr;
@@ -3490,7 +3516,7 @@ public:
   }
 
   static bool IsSubobjectBasicKind(ArBasicKind kind) {
-    return kind >= AR_OBJECT_STATE_OBJECT_CONFIG && kind <= AR_OBJECT_PROCEDURAL_PRIMITIVE_HIT_GROUP;
+    return kind >= AR_OBJECT_STATE_OBJECT_CONFIG && kind <= AR_OBJECT_RAYTRACING_PIPELINE_CONFIG1;
   }
 
   bool IsSubobjectType(QualType type) {
@@ -4240,6 +4266,7 @@ public:
     AddRayFlags(*m_context);
     AddHitKinds(*m_context);
     AddStateObjectFlags(*m_context);
+    AddRaytracingPipelineFlags(*m_context);
     AddCommittedStatus(*m_context);
     AddCandidateType(*m_context);
 

--- a/tools/clang/test/CodeGenHLSL/batch/shader_stages/raytracing/subobjects_raytracingPipelineConfig1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/shader_stages/raytracing/subobjects_raytracingPipelineConfig1.hlsl
@@ -9,6 +9,7 @@
 // CHECK: ; RaytracingShaderConfig rsc = { MaxPayloadSizeInBytes = 128, MaxAttributeSizeInBytes = 64 };
 // CHECK: ; RaytracingPipelineConfig1 rpc = { MaxTraceRecursionDepth = 32, Flags = RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES };
 // CHECK: ; SubobjectToExportsAssociation sea4 = { "rpc", { }  };
+// CHECK: ; RaytracingPipelineConfig1 rpc2 = { MaxTraceRecursionDepth = 32, Flags = 0 };
 // CHECK: ; HitGroup trHitGt = { HitGroupType = Triangle, Anyhit = "a", Closesthit = "b", Intersection = "" };
 // CHECK: ; HitGroup ppHitGt = { HitGroupType = ProceduralPrimitive, Anyhit = "a", Closesthit = "b", Intersection = "c" };
 
@@ -22,6 +23,7 @@ SubobjectToExportsAssociation sea3 = { "grs", "" };
 RaytracingShaderConfig rsc = { 128, 64 };
 RaytracingPipelineConfig1 rpc = { 32, RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES };
 SubobjectToExportsAssociation sea4 = {"rpc", ";"};
+RaytracingPipelineConfig1 rpc2 = {32, RAYTRACING_PIPELINE_FLAG_NONE };
 TriangleHitGroup trHitGt = {"a", "b"};
 ProceduralPrimitiveHitGroup ppHitGt = { "a", "b", "c"};
 

--- a/tools/clang/test/CodeGenHLSL/batch/shader_stages/raytracing/subobjects_raytracingPipelineConfig1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/shader_stages/raytracing/subobjects_raytracingPipelineConfig1.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// CHECK: ; GlobalRootSignature grs = { <48 bytes> };
+// CHECK: ; StateObjectConfig soc = { STATE_OBJECT_FLAG_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITIONS };
+// CHECK: ; LocalRootSignature lrs = { <48 bytes> };
+// CHECK: ; SubobjectToExportsAssociation sea = { "grs", { "a", "b", "foo", "c" }  };
+// CHECK: ; SubobjectToExportsAssociation sea2 = { "grs", { }  };
+// CHECK: ; SubobjectToExportsAssociation sea3 = { "grs", { }  };
+// CHECK: ; RaytracingShaderConfig rsc = { MaxPayloadSizeInBytes = 128, MaxAttributeSizeInBytes = 64 };
+// CHECK: ; RaytracingPipelineConfig1 rpc = { MaxTraceRecursionDepth = 32, Flags = RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES };
+// CHECK: ; SubobjectToExportsAssociation sea4 = { "rpc", { }  };
+// CHECK: ; HitGroup trHitGt = { HitGroupType = Triangle, Anyhit = "a", Closesthit = "b", Intersection = "" };
+// CHECK: ; HitGroup ppHitGt = { HitGroupType = ProceduralPrimitive, Anyhit = "a", Closesthit = "b", Intersection = "c" };
+
+GlobalRootSignature grs = {"CBV(b0)"};
+StateObjectConfig soc = { STATE_OBJECT_FLAGS_ALLOW_LOCAL_DEPENDENCIES_ON_EXTERNAL_DEFINITONS };
+LocalRootSignature lrs = {"UAV(u0, visibility = SHADER_VISIBILITY_GEOMETRY), RootFlags(LOCAL_ROOT_SIGNATURE)"};
+SubobjectToExportsAssociation sea = { "grs", "a;b;foo;c" };
+// Empty association is well-defined: it creates a default association
+SubobjectToExportsAssociation sea2 = { "grs", ";" };
+SubobjectToExportsAssociation sea3 = { "grs", "" };
+RaytracingShaderConfig rsc = { 128, 64 };
+RaytracingPipelineConfig1 rpc = { 32, RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES };
+SubobjectToExportsAssociation sea4 = {"rpc", ";"};
+TriangleHitGroup trHitGt = {"a", "b"};
+ProceduralPrimitiveHitGroup ppHitGt = { "a", "b", "c"};
+
+int main(int i : INDEX) : SV_Target {
+  return 1;
+}

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -598,6 +598,7 @@ static const char *SubobjectKindToString(DXIL::SubobjectKind kind) {
   case DXIL::SubobjectKind::RaytracingShaderConfig: return "RaytracingShaderConfig";
   case DXIL::SubobjectKind::RaytracingPipelineConfig: return "RaytracingPipelineConfig";
   case DXIL::SubobjectKind::HitGroup: return "HitGroup";
+  case DXIL::SubobjectKind::RaytracingPipelineConfig1: return "RaytracingPipelineConfig1";
   }
   return "<invalid kind>";
 }
@@ -610,6 +611,16 @@ static const char *FlagToString(DXIL::StateObjectFlags Flag) {
     return "STATE_OBJECT_FLAG_ALLOW_EXTERNAL_DEPENDENCIES_ON_LOCAL_DEFINITIONS";
   }
   return "<invalid StateObjectFlag>";
+}
+
+static const char *FlagToString(DXIL::RaytracingPipelineFlags Flag) {
+  switch (Flag) {
+  case DXIL::RaytracingPipelineFlags::SkipTriangles:
+    return "RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES";
+  case DXIL::RaytracingPipelineFlags::SkipProceduralPrimitives:
+    return "RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES";
+  }
+  return "<invalid RaytracingPipelineFlags>";
 }
 
 static const char *HitGroupTypeToString(DXIL::HitGroupType type) {
@@ -735,6 +746,17 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
          << ", Anyhit = \"" << AnyHit
          << "\", Closesthit = \"" << ClosestHit
          << "\", Intersection = \"" << Intersection << "\"";
+      break;
+    }
+    case DXIL::SubobjectKind::RaytracingPipelineConfig1: {
+      uint32_t MaxTraceRecursionDepth;
+      uint32_t Flags;
+      if (!obj.GetRaytracingPipelineConfig1(MaxTraceRecursionDepth, Flags)) {
+        OS << "<error getting subobject>";
+        break;
+      }
+      OS << "MaxTraceRecursionDepth = " << MaxTraceRecursionDepth;
+      PrintFlags<DXIL::RaytracingPipelineFlags>(OS, Flags);
       break;
     }
     }

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -756,6 +756,7 @@ void PrintSubobjects(const DxilSubobjects &subobjects,
         break;
       }
       OS << "MaxTraceRecursionDepth = " << MaxTraceRecursionDepth;
+      OS << ", Flags = ";
       PrintFlags<DXIL::RaytracingPipelineFlags>(OS, Flags);
       break;
     }

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -615,6 +615,8 @@ static const char *FlagToString(DXIL::StateObjectFlags Flag) {
 
 static const char *FlagToString(DXIL::RaytracingPipelineFlags Flag) {
   switch (Flag) {
+  case DXIL::RaytracingPipelineFlags::None:
+    return "RAYTRACING_PIPELINE_FLAG_NONE";
   case DXIL::RaytracingPipelineFlags::SkipTriangles:
     return "RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES";
   case DXIL::RaytracingPipelineFlags::SkipProceduralPrimitives:

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2753,6 +2753,7 @@ TEST_F(CompilerTest, SubobjectCodeGenErrors) {
     { "SubobjectToExportsAssociation sea;", "1:1: error: subobject needs to be initialized" },
     { "RaytracingShaderConfig rsc;",        "1:1: error: subobject needs to be initialized" },
     { "RaytracingPipelineConfig rpc;",      "1:1: error: subobject needs to be initialized" },
+    { "RaytracingPipelineConfig1 rpc1;",    "1:1: error: subobject needs to be initialized" },
     { "TriangleHitGroup hitGt;",            "1:1: error: subobject needs to be initialized" },
     { "ProceduralPrimitiveHitGroup hitGt;", "1:1: error: subobject needs to be initialized" },
     { "GlobalRootSignature grs2 = {\"\"};", "1:29: error: empty string not expected here" },


### PR DESCRIPTION
This adds support for the HLSL DXR subobject type RaytracingPipelineConfig1 {uint MaxTraceRecursionDepth, uint Flags}. This extends the existing RaytracingPipelineConfig subobject, adding the Flags field. This is valid for DXR 1.1 devices (which the runtime enforces).

The API definition for the subobject is below (flags shown below match what can be specified in HLSL by omitting the D3D12_ prefix.

typedef enum D3D12_RAYTRACING_PIPELINE_FLAGS
{
D3D12_RAYTRACING_PIPELINE_FLAG_NONE = 0x0,
D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_TRIANGLES = 0x100,
D3D12_RAYTRACING_PIPELINE_FLAG_SKIP_PROCEDURAL_PRIMITIVES = 0x200,
D3D12_RAYTRACING_PIPELINE_FLAG_VALID_MASK = 0x300, ;internal
} D3D12_RAYTRACING_PIPELINE_FLAGS;

typedef struct D3D12_RAYTRACING_PIPELINE_CONFIG1
{
UINT MaxTraceRecursionDepth;
D3D12_RAYTRACING_PIPELINE_FLAGS Flags;
} D3D12_RAYTRACING_PIPELINE_CONFIG1;