### PR TITLE
Support nested struct in IsTypeMatchForMemcpy

### DIFF
--- a/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1160,8 +1160,14 @@ Instruction *InstCombiner::visitAdd(BinaryOperator &I) {
     return ReplaceInstUsesWith(I, V);
 
   // A+B --> A|B iff A and B have no bits set in common.
-  if (haveNoCommonBitsSet(LHS, RHS, DL, AC, &I, DT))
+  // HLSL Change Begin - disable A+B -> A|B for i32.
+  bool bIsI32 = false;
+  if (IntegerType *IT = dyn_cast<IntegerType>(I.getType())) {
+    bIsI32 = IT->getBitWidth() == 32;
+  }
+  if (haveNoCommonBitsSet(LHS, RHS, DL, AC, &I, DT) && !bIsI32)
     return BinaryOperator::CreateOr(LHS, RHS);
+  // HLSL Change End.
 
   if (Constant *CRHS = dyn_cast<Constant>(RHS)) {
     Value *X;

--- a/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1160,14 +1160,8 @@ Instruction *InstCombiner::visitAdd(BinaryOperator &I) {
     return ReplaceInstUsesWith(I, V);
 
   // A+B --> A|B iff A and B have no bits set in common.
-  // HLSL Change Begin - disable A+B -> A|B for i32.
-  bool bIsI32 = false;
-  if (IntegerType *IT = dyn_cast<IntegerType>(I.getType())) {
-    bIsI32 = IT->getBitWidth() == 32;
-  }
-  if (haveNoCommonBitsSet(LHS, RHS, DL, AC, &I, DT) && !bIsI32)
+  if (haveNoCommonBitsSet(LHS, RHS, DL, AC, &I, DT))
     return BinaryOperator::CreateOr(LHS, RHS);
-  // HLSL Change End.
 
   if (Constant *CRHS = dyn_cast<Constant>(RHS)) {
     Value *X;

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -7078,6 +7078,17 @@ static bool IsStructWithSameElementType(llvm::StructType *ST, llvm::Type *Ty) {
     if (StructType *EltSt = dyn_cast<StructType>(EltTy)) {
       if (!IsStructWithSameElementType(EltSt, Ty))
         return false;
+    } else if (llvm::ArrayType *AT = dyn_cast<llvm::ArrayType>(EltTy)) {
+      llvm::Type *ArrayEltTy = dxilutil::GetArrayEltTy(AT);
+      if (ArrayEltTy == Ty) {
+        continue;
+      } else if (StructType *EltSt = dyn_cast<StructType>(EltTy)) {
+        if (!IsStructWithSameElementType(EltSt, Ty))
+          return false;
+      } else {
+        return false;
+      }
+
     } else if (EltTy != Ty)
       return false;
   }

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2402,6 +2402,10 @@ void CGMSHLSLRuntime::addResource(Decl *D) {
           staticConstGlobalInitMap[InitExp] = GV;
         }
       }
+      // Add type annotation for static global variable.
+      DxilTypeSystem &typeSys = m_pHLModule->GetTypeSystem();
+      unsigned arrayEltSize = 0;
+      AddTypeAnnotation(VD->getType(), typeSys, arrayEltSize);
       return;
     }
 
@@ -7067,6 +7071,19 @@ void CGMSHLSLRuntime::EmitHLSLAggregateCopy(CodeGenFunction &CGF, llvm::Value *S
     SmallVector<Value *, 4> idxList;
     EmitHLSLAggregateCopy(CGF, SrcPtr, DestPtr, idxList, Ty, Ty, SrcPtr->getType());
 }
+
+// Make sure all element type of struct is same type.
+static bool IsStructWithSameElementType(llvm::StructType *ST, llvm::Type *Ty) {
+  for (llvm::Type *EltTy : ST->elements()) {
+    if (StructType *EltSt = dyn_cast<StructType>(EltTy)) {
+      if (!IsStructWithSameElementType(EltSt, Ty))
+        return false;
+    } else if (EltTy != Ty)
+      return false;
+  }
+  return true;
+}
+
 // To memcpy, need element type match.
 // For struct type, the layout should match in cbuffer layout.
 // struct { float2 x; float3 y; } will not match struct { float3 x; float2 y; }.
@@ -7097,11 +7114,8 @@ static bool IsTypeMatchForMemcpy(llvm::Type *SrcTy, llvm::Type *DestTy) {
       return false;
     if (Ty->getVectorNumElements() != 4)
       return false;
-    for (llvm::Type *EltTy : ST->elements()) {
-      if (EltTy != Ty)
-        return false;
-    }
-    return true;
+
+    return IsStructWithSameElementType(ST, Ty);
   }
 }
 

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
@@ -5,9 +5,6 @@
 // Test that no variable initializers are emitted, especially for cbuffers globals.
 // CHECK-NOT: {{.*}} = constant
 
-// Check the offset calculate.
-// CHECK: add {{.+}}, 2
-
 
 float4 cb[4*4];
 

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -E main -T ps_6_0 > %s | FileCheck %s
+
+// Make sure cast to nest struct works.
+
+// Test that no variable initializers are emitted, especially for cbuffers globals.
+// CHECK-NOT: {{.*}} = constant
+
+// Check the offset calculate.
+// CHECK: add {{.+}}, 2
+
+
+float4 cb[4*4];
+
+struct N {
+  float4 b;
+  float4 c;
+};
+
+struct A {
+  float4 a;
+  N      n;
+  float4 d;
+};
+
+static const A a[4] = cb;
+
+
+float4 main(int i:I) : SV_Target {
+  return a[i].n.c + cb[i];
+}

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/globals/array_cast.hlsl
@@ -4,9 +4,11 @@
 
 // Test that no variable initializers are emitted, especially for cbuffers globals.
 // CHECK-NOT: {{.*}} = constant
+// Check the offset calculate.
+// CHECK: mul i32 {{.+}}, 5
+// CHECK: add i32 {{.+}}, 2
 
-
-float4 cb[4*4];
+float4 cb[5*4];
 
 struct N {
   float4 b;
@@ -16,12 +18,12 @@ struct N {
 struct A {
   float4 a;
   N      n;
-  float4 d;
+  float4 d[2];
 };
 
 static const A a[4] = cb;
 
 
 float4 main(int i:I) : SV_Target {
-  return a[i].n.c + cb[i];
+  return a[i].n.c + cb[i] + a[i+1].d[i%2];
 }


### PR DESCRIPTION
Add TypeAnnotation for static global and support nested struct in IsTypeMatchForMemcpy.

Also skip A+B --> A|B on i32.