### PR TITLE
Remove globalopt dependency on the name of the entrypoint

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -79,6 +79,7 @@ public:
   llvm::Function *GetPatchConstantFunction();
   const llvm::Function *GetPatchConstantFunction() const;
   void SetPatchConstantFunction(llvm::Function *pFunc);
+  bool IsEntryOrPatchConstantFunction(const llvm::Function* pFunc) const;
 
   // Flags.
   unsigned GetGlobalFlags() const;

--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -698,7 +698,7 @@ public:
   }
   bool HasHLModule() const { return TheHLModule != nullptr; }
   void SetHLModule(hlsl::HLModule *pValue) { TheHLModule = pValue; }
-  hlsl::HLModule &GetHLModule() { return *TheHLModule; }
+  hlsl::HLModule &GetHLModule() const { return *TheHLModule; }
   hlsl::HLModule &GetOrCreateHLModule(bool skipInit = false);
   ResetModuleCallback pfnResetHLModule = nullptr;
   void ResetHLModule() { if (pfnResetHLModule) (*pfnResetHLModule)(this); }

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -275,6 +275,10 @@ void DxilModule::SetPatchConstantFunction(llvm::Function *patchConstantFunc) {
   }
 }
 
+bool DxilModule::IsEntryOrPatchConstantFunction(const llvm::Function* pFunc) const {
+  return pFunc == GetEntryFunction() || pFunc == GetPatchConstantFunction();
+}
+
 unsigned DxilModule::GetGlobalFlags() const {
   unsigned Flags = m_ShaderFlags.GetGlobalFlags();
   return Flags;

--- a/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/lib/Transforms/IPO/GlobalOpt.cpp
@@ -1728,6 +1728,8 @@ bool GlobalOpt::ProcessInternalGlobal(GlobalVariable *GV,
                                       Module::global_iterator &GVI,
                                       const GlobalStatus &GS) {
   auto &DL = GV->getParent()->getDataLayout();
+
+#if 0 // HLSL Change - Don't special case for the name "main"
   // If this is a first class global and has only one accessing function
   // and this function is main (which we know is not recursive), we replace
   // the global with a local alloca in this function.
@@ -1757,6 +1759,7 @@ bool GlobalOpt::ProcessInternalGlobal(GlobalVariable *GV,
     ++NumLocalized;
     return true;
   }
+#endif // HLSL Change
 
   // If the global is never loaded (but may be stored to), it is dead.
   // Delete it now.

--- a/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s
+
+// Regression test for #2318, where the globalopt had behavior
+// conditional on the name of the main function.
+
+static uint g[1] = { 0 };
+uint main() : OUT
+{
+  // CHECK: load i32
+  // CHECK: add i32
+  // CHECK: store i32
+  g[0]++;
+  // CHECK: call void @dx.op.storeOutput.i32
+  return g[0];
+}

--- a/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main.hlsl
@@ -6,10 +6,9 @@
 static uint g[1] = { 0 };
 uint main() : OUT
 {
-  // CHECK: load i32
-  // CHECK: add i32
-  // CHECK: store i32
+  // CHECK-NOT: load i32
+  // CHECK-NOT: store i32
   g[0]++;
-  // CHECK: call void @dx.op.storeOutput.i32
+  // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
   return g[0];
 }

--- a/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main2.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T vs_6_0 -E main2 %s | FileCheck %s
+
+// Regression test for #2318, where the globalopt had behavior
+// conditional on the name of the main function.
+
+static uint g[1] = { 0 };
+uint main2() : OUT
+{
+  // CHECK: load i32
+  // CHECK: add i32
+  // CHECK: store i32
+  g[0]++;
+  // CHECK: call void @dx.op.storeOutput.i32
+  return g[0];
+}

--- a/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/passes/globalopt/entrypoint_name_invariant_main2.hlsl
@@ -6,10 +6,9 @@
 static uint g[1] = { 0 };
 uint main2() : OUT
 {
-  // CHECK: load i32
-  // CHECK: add i32
-  // CHECK: store i32
+  // CHECK-NOT: load i32
+  // CHECK-NOT: store i32
   g[0]++;
-  // CHECK: call void @dx.op.storeOutput.i32
+  // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
   return g[0];
 }


### PR DESCRIPTION
GlobalOpt has an explicit test for a function called "main" (eww...) to enable an optimization. This updates the test to match the entry point, independent of its name.

Fixes #2350