### PR TITLE
Fix crash with mesh shader output signatures

### DIFF
--- a/lib/HLSL/ComputeViewIdStateBuilder.cpp
+++ b/lib/HLSL/ComputeViewIdStateBuilder.cpp
@@ -427,7 +427,7 @@ void DxilViewIdStateBuilder::CollectValuesContributingToOutputs(EntryInfo &Entry
       GetUnsignedVal(SO.get_colIndex(), &col);
       GetUnsignedVal(SO.get_rowIndex(), (uint32_t*)&startRow);
     } else if (DxilInst_StoreVertexOutput SVO = DxilInst_StoreVertexOutput(CI)) {
-      pDxilSig = &m_pModule->GetPatchConstOrPrimSignature();
+      pDxilSig = &m_pModule->GetOutputSignature();
       pContributingValue = SVO.get_value();
       GetUnsignedVal(SVO.get_outputSigId(), &id);
       GetUnsignedVal(SVO.get_colIndex(), &col);

--- a/tools/clang/test/CodeGenHLSL/mesh/vertices_sig_bigger_than_primitives_sig_regression.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh/vertices_sig_bigger_than_primitives_sig_regression.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -E main -T ms_6_5 %s | FileCheck %s
+
+// Regression test for a crash where the primitive signature was used when looking
+// up vertex output signatures, so if the vertices struct had more signature elements
+// than the primitives struct, it would crash
+
+// CHECK: @main
+
+struct Vertex { float4 pos : SV_POSITION; };
+struct Primitive {};
+
+[outputtopology("point")]
+[numthreads(2,2,1)]
+void main(
+    out vertices Vertex verts[1],
+    out primitives Primitive prims[1],
+    out indices uint3 idx[1])
+{
+     verts = (Vertex[1])0;
+     SetMeshOutputCounts(0, 0);
+}


### PR DESCRIPTION
The primitive signature was being used with `vertexStoreOutput` instructions. It would crash if the vertex signature was bigger than the primitive signature.