### PR TITLE
PIX: Change shader access tracking pass to use non-atomic stores

### DIFF
--- a/tools/clang/test/CodeGenHLSL/batch/pix/AccessTracking.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/pix/AccessTracking.hlsl
@@ -7,11 +7,12 @@
 // CHECK: CompareWithSlotLimit = icmp uge i32
 // CHECK: CompareWithSlotLimitAsUint = zext i1 %CompareWithSlotLimit to i32
 // CHECK: IsInBounds = sub i32 1, %CompareWithSlotLimitAsUint
-// CHECK: SlotOffset = add i32
+// CHECK: SlotDwordOffset = add i32
+// CHECK: SlotByteOffset = mul i32
 // CHECK: slotIndex = mul i32
 
 // Check for udpate of UAV:
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 
 
 ByteAddressBuffer inBuffer : register(t0);

--- a/tools/clang/test/CodeGenHLSL/batch/pix/rawBufferStore.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/pix/rawBufferStore.hlsl
@@ -2,24 +2,24 @@
 
 // Check that the expected PIX UAV read-tracking is emitted (the atomicBinOp "|= 1") followed by the expected raw read:
 
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16
 
 // Now the writes with atomicBinOp "|=2":
 
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 2)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.f32
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 2)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.i32
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 2)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.f16
-// CHECK: call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_CountUAV_Handle, i32 2, i32 8, i32 undef, i32 undef, i32 2)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.i16
 
 struct S


### PR DESCRIPTION
(Turns out the original implementation with atomic ORs was very good at inducing TDRs on otherwise-functional shaders.)
This change uses three times the UAV memory to write a single DWORD per access type using BufferStore, rather than to set a single bit using AtomicOr. The resultant less-interlocky instrumented shaders no longer TDR. Repro case in PIX bug # 22725204
