### PR TITLE
Add mesh shader support to RootSignature parsing/validation and fix PSV

### DIFF
--- a/include/dxc/DxilRootSignature/DxilRootSignature.h
+++ b/include/dxc/DxilRootSignature/DxilRootSignature.h
@@ -77,7 +77,8 @@ enum class DxilDescriptorRangeType : unsigned {
   SRV = 0,
   UAV = 1,
   CBV = 2,
-  Sampler = 3
+  Sampler = 3,
+  MaxValue = 3
 };
 enum class DxilRootDescriptorFlags : unsigned {
   None = 0,
@@ -106,15 +107,18 @@ enum class DxilRootSignatureFlags : uint32_t {
   DenyPixelShaderRootAccess = 0x20,
   AllowStreamOutput = 0x40,
   LocalRootSignature = 0x80,
+  DenyAmplificationShaderRootAccess = 0x100,
+  DenyMeshShaderRootAccess = 0x200,
   AllowLowTierReservedHwCbLimit = 0x80000000,
-  ValidFlags = 0x800000ff
+  ValidFlags = 0x800003ff
 };
 enum class DxilRootParameterType {
   DescriptorTable = 0,
   Constants32Bit = 1,
   CBV = 2,
   SRV = 3,
-  UAV = 4
+  UAV = 4,
+  MaxValue = 4
 };
 enum class DxilFilter {
   // TODO: make these names consistent with code convention
@@ -161,7 +165,10 @@ enum class DxilShaderVisibility {
   Hull = 2,
   Domain = 3,
   Geometry = 4,
-  Pixel = 5
+  Pixel = 5,
+  Amplification = 6,
+  Mesh = 7,
+  MaxValue = 7
 };
 enum class DxilStaticBorderColor {
   TransparentBlack = 0,

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -452,8 +452,12 @@ public:
     unsigned ValMajor, ValMinor;
     m_Module.GetValidatorVersion(ValMajor, ValMinor);
     // Allow PSVVersion to be upgraded
-    if (m_PSVInitInfo.PSVVersion < 1 && (ValMajor > 1 || (ValMajor == 1 && ValMinor >= 1)))
+    if (ValMajor == 0 && ValMinor == 0) {
+      // Validation disabled upgrades to maximum PSVVersion
+      m_PSVInitInfo.PSVVersion = MAX_PSV_VERSION;
+    } else if (m_PSVInitInfo.PSVVersion < 1 && (ValMajor > 1 || (ValMajor == 1 && ValMinor >= 1))) {
       m_PSVInitInfo.PSVVersion = 1;
+    }
 
     const ShaderModel *SM = m_Module.GetShaderModel();
     UINT uCBuffers = m_Module.GetCBuffers().size();
@@ -610,7 +614,7 @@ public:
     case ShaderModel::Kind::Mesh: {
       pInfo->MS.MaxOutputVertices = (UINT)m_Module.GetMaxOutputVertices();
       pInfo->MS.MaxOutputPrimitives = (UINT)m_Module.GetMaxOutputPrimitives();
-      pInfo1->MeshOutputTopology = (UINT)m_Module.GetMeshOutputTopology();
+      pInfo1->MS1.MeshOutputTopology = (UINT)m_Module.GetMeshOutputTopology();
       Module *mod = m_Module.GetModule();
       const DataLayout &DL = mod->getDataLayout();
       unsigned totalByteSize = 0;

--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -287,6 +287,8 @@ void RootSignatureTokenizer::ReadNextToken(uint32_t BufferIdx)
               KW(DENY_DOMAIN_SHADER_ROOT_ACCESS) || 
               KW(DENY_GEOMETRY_SHADER_ROOT_ACCESS) || 
               KW(DENY_PIXEL_SHADER_ROOT_ACCESS) ||
+              KW(DENY_AMPLIFICATION_SHADER_ROOT_ACCESS) ||
+              KW(DENY_MESH_SHADER_ROOT_ACCESS) ||
               KW(DESCRIPTORS_VOLATILE) ||
               KW(DATA_VOLATILE) ||
               KW(DATA_STATIC) ||
@@ -360,6 +362,7 @@ void RootSignatureTokenizer::ReadNextToken(uint32_t BufferIdx)
               KW(SHADER_VISIBILITY_ALL)      ||  KW(SHADER_VISIBILITY_VERTEX) || 
               KW(SHADER_VISIBILITY_HULL)     || KW(SHADER_VISIBILITY_DOMAIN)  ||
               KW(SHADER_VISIBILITY_GEOMETRY) || KW(SHADER_VISIBILITY_PIXEL) ||
+              KW(SHADER_VISIBILITY_AMPLIFICATION) || KW(SHADER_VISIBILITY_MESH) ||
               KW(STATIC_BORDER_COLOR_TRANSPARENT_BLACK) ||
               KW(STATIC_BORDER_COLOR_OPAQUE_BLACK) ||
               KW(STATIC_BORDER_COLOR_OPAQUE_WHITE);
@@ -678,6 +681,8 @@ HRESULT RootSignatureParser::ParseRootSignatureFlags(DxilRootSignatureFlags & Fl
     //  DENY_DOMAIN_SHADER_ROOT_ACCESS
     //  DENY_GEOMETRY_SHADER_ROOT_ACCESS
     //  DENY_PIXEL_SHADER_ROOT_ACCESS
+    //  DENY_AMPLIFICATION_SHADER_ROOT_ACCESS
+    //  DENY_MESH_SHADER_ROOT_ACCESS
     //  ALLOW_STREAM_OUTPUT
     //  LOCAL_ROOT_SIGNATURE
 
@@ -723,6 +728,12 @@ HRESULT RootSignatureParser::ParseRootSignatureFlags(DxilRootSignatureFlags & Fl
                 break;
             case TokenType::DENY_PIXEL_SHADER_ROOT_ACCESS:
                 Flags |= DxilRootSignatureFlags::DenyPixelShaderRootAccess;
+                break;
+            case TokenType::DENY_AMPLIFICATION_SHADER_ROOT_ACCESS:
+                Flags |= DxilRootSignatureFlags::DenyAmplificationShaderRootAccess;
+                break;
+            case TokenType::DENY_MESH_SHADER_ROOT_ACCESS:
+                Flags |= DxilRootSignatureFlags::DenyMeshShaderRootAccess;
                 break;
             case TokenType::ALLOW_STREAM_OUTPUT:
                 Flags |= DxilRootSignatureFlags::AllowStreamOutput;
@@ -1290,6 +1301,8 @@ HRESULT RootSignatureParser::ParseVisibility(DxilShaderVisibility & Vis)
     case TokenType::SHADER_VISIBILITY_DOMAIN:   Vis = DxilShaderVisibility::Domain;   break;
     case TokenType::SHADER_VISIBILITY_GEOMETRY: Vis = DxilShaderVisibility::Geometry; break;
     case TokenType::SHADER_VISIBILITY_PIXEL:    Vis = DxilShaderVisibility::Pixel;    break;
+    case TokenType::SHADER_VISIBILITY_AMPLIFICATION:  Vis = DxilShaderVisibility::Amplification;  break;
+    case TokenType::SHADER_VISIBILITY_MESH:     Vis = DxilShaderVisibility::Mesh;     break;
     default:
         IFC(Error(ERR_RS_UNEXPECTED_TOKEN, 
                  "Unexpected visibility value: '%s'.", Token.GetStr()));

--- a/tools/clang/lib/Parse/HLSLRootSignature.h
+++ b/tools/clang/lib/Parse/HLSLRootSignature.h
@@ -69,6 +69,8 @@ public:
             SHADER_VISIBILITY_DOMAIN,
             SHADER_VISIBILITY_GEOMETRY,
             SHADER_VISIBILITY_PIXEL,
+            SHADER_VISIBILITY_AMPLIFICATION,
+            SHADER_VISIBILITY_MESH,
 
             // Root signature flags
             RootFlags,
@@ -78,6 +80,8 @@ public:
             DENY_DOMAIN_SHADER_ROOT_ACCESS,
             DENY_GEOMETRY_SHADER_ROOT_ACCESS,
             DENY_PIXEL_SHADER_ROOT_ACCESS,
+            DENY_AMPLIFICATION_SHADER_ROOT_ACCESS,
+            DENY_MESH_SHADER_ROOT_ACCESS,
             ALLOW_STREAM_OUTPUT,
             LOCAL_ROOT_SIGNATURE,
 

--- a/tools/clang/test/CodeGenHLSL/mesh/mesh-rootsig.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh/mesh-rootsig.hlsl
@@ -1,0 +1,78 @@
+// RUN: %dxc -E main -T ms_6_5 %s | FileCheck %s
+
+// CHECK: dx.op.getMeshPayload.struct.MeshPayload
+// CHECK: dx.op.setMeshOutputCounts(i32 168, i32 30, i32 10)
+// CHECK: dx.op.emitIndices
+// CHECK: dx.op.storeVertexOutput
+// CHECK: dx.op.storePrimitiveOutput
+
+#define MAX_VERT 30
+#define MAX_PRIM 10
+#define NUM_THREADS 32
+struct MeshPerVertex {
+    float4 position : SV_Position;
+    float4 color : COLOR;
+};
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+    float malnor : MALNOR;
+    float alnorm : ALNORM;
+    float ormaln : ORMALN;
+    int4 layer0 : LAYER0;
+    int2 layer1 : LAYER1;
+};
+
+struct MeshPayload {
+    float normal;
+    float malnor;
+    float alnorm;
+    float ormaln;
+    int layer[6];
+};
+
+groupshared float gsMem[MAX_PRIM];
+
+cbuffer CB1 : register(b1, space2)
+{
+  uint idx;
+}
+
+[RootSignature("CBV(b1, space=2, visibility=SHADER_VISIBILITY_MESH)")]
+[numthreads(NUM_THREADS, 1, 1)]
+[outputtopology("triangle")]
+void main(
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in payload MeshPayload mpl,
+            in uint tig : SV_GroupIndex,
+            in uint vid : SV_ViewID
+         )
+{
+    SetMeshOutputCounts(MAX_VERT, MAX_PRIM);
+    if (tig < MAX_PRIM) {
+      uint3 indices = (tig * 3) + uint3(0, 1, 2);
+      primIndices[tig] = indices;
+      MeshPerPrimitive op;
+      op.normal = mpl.normal;
+      gsMem[tig] = op.normal;
+      op.malnor = gsMem[(tig + idx) % MAX_PRIM];
+      op.alnorm = mpl.alnorm;
+      op.ormaln = mpl.ormaln;
+      op.layer0 = int4(mpl.layer[0], mpl.layer[1], mpl.layer[2], mpl.layer[3]);
+      op.layer1 = int2(mpl.layer[4], mpl.layer[5]);
+      prims[tig] = op;
+    }
+    if (tig < MAX_VERT) {
+      MeshPerVertex ov;
+      if (vid % 2) {
+          ov.position = float4(0.0, 1.0, 2.0, 3.0);
+          ov.color = float4(4.0, 5.0, 6.0, 7.0);
+      } else {
+          ov.position = float4(10.0, 11.0, 12.0, 13.0);
+          ov.color = float4(14.0, 15.0, 16.0, 17.0);
+      }
+      verts[tig] = ov;
+    }
+}


### PR DESCRIPTION
- Fix PSV so MS output topology doesn't overlap SigInputVectors
- Fix PSV version code to use latest when validation disabled