### PR TITLE
Remove lambda parameter shadow

### DIFF
--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -6933,7 +6933,7 @@ void TranslateStructBufSubscriptUser(
     }
 
     if (ldInst) {
-      auto LdElement = [=, &Builder](Value *offset, IRBuilder<> &Builder) -> Value * {
+      auto LdElement = [=](Value *offset, IRBuilder<> &Builder) -> Value * {
         unsigned numComponents = 0;
         if (VectorType *VTy = dyn_cast<VectorType>(Ty)) {
           numComponents = VTy->getNumElements();


### PR DESCRIPTION
Later versions of clang fail to compile a lambda function that includes
a parameter that shadows an explicit capture. Such a one was introduced
to HLOperationLower recently. This preserves the existing behavior while
removing the shadow.