### PR TITLE
flesh out SV_CullPrimitive support 

### DIFF
--- a/include/dxc/DxilContainer/DxilContainer.h
+++ b/include/dxc/DxilContainer/DxilContainer.h
@@ -156,6 +156,7 @@ enum class DxilProgramSigSemantic : uint32_t {
   FinalLineDensityTessfactor = 16,
   Barycentrics = 23,
   ShadingRate = 24,
+  CullPrimitive = 25,
   Target = 64,
   Depth = 65,
   Coverage = 66,

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -57,6 +57,7 @@ static DxilProgramSigSemantic KindToSystemValue(Semantic::Kind kind, DXIL::Tesse
   case Semantic::Kind::CullDistance: return DxilProgramSigSemantic::CullDistance;
   case Semantic::Kind::Barycentrics: return DxilProgramSigSemantic::Barycentrics;
   case Semantic::Kind::ShadingRate: return DxilProgramSigSemantic::ShadingRate;
+  case Semantic::Kind::CullPrimitive: return DxilProgramSigSemantic::CullPrimitive;
   case Semantic::Kind::TessFactor: {
     switch (domain) {
     case DXIL::TessellatorDomain::IsoLine:

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1721,6 +1721,11 @@ D3D_NAME SemanticToSystemValueType(const Semantic *S, DXIL::TessellatorDomain do
     default:
     return D3D_NAME_UNDEFINED;
     }
+  case Semantic::Kind::ShadingRate:
+    return D3D_NAME_SHADINGRATE;
+  case Semantic::Kind::CullPrimitive:
+#define D3D_NAME_CULL_PRIMITIVE 25
+    return (D3D_NAME)D3D_NAME_CULL_PRIMITIVE;
   }
   case Semantic::Kind::InsideTessFactor:
     switch (domain) {

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1722,7 +1722,8 @@ D3D_NAME SemanticToSystemValueType(const Semantic *S, DXIL::TessellatorDomain do
     return D3D_NAME_UNDEFINED;
     }
   case Semantic::Kind::ShadingRate:
-    return D3D_NAME_SHADINGRATE;
+#define D3D_NAME_CULL_SHADINGRATE 24
+    return (D3D_NAME)D3D_NAME_SHADINGRATE;
   case Semantic::Kind::CullPrimitive:
 #define D3D_NAME_CULL_PRIMITIVE 25
     return (D3D_NAME)D3D_NAME_CULL_PRIMITIVE;

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -38,10 +38,6 @@
 #include "d3d12shader.h" // for compatibility
 #include "d3d11shader.h" // for compatibility
 
-// These will be defined in a future version of the Windows SDK, locally defining for now:
-#define D3D_NAME_CULL_SHADINGRATE 24
-#define D3D_NAME_CULL_PRIMITIVE 25
-
 const GUID IID_ID3D11ShaderReflection_43 = {
     0x0a233719,
     0x3960,
@@ -1726,9 +1722,9 @@ D3D_NAME SemanticToSystemValueType(const Semantic *S, DXIL::TessellatorDomain do
     return D3D_NAME_UNDEFINED;
     }
   case Semantic::Kind::ShadingRate:
-    return (D3D_NAME)D3D_NAME_SHADINGRATE;
+    return (D3D_NAME)DxilProgramSigSemantic::ShadingRate;
   case Semantic::Kind::CullPrimitive:
-    return (D3D_NAME)D3D_NAME_CULL_PRIMITIVE;
+    return (D3D_NAME)DxilProgramSigSemantic::CullPrimitive;
   }
   case Semantic::Kind::InsideTessFactor:
     switch (domain) {

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -38,6 +38,10 @@
 #include "d3d12shader.h" // for compatibility
 #include "d3d11shader.h" // for compatibility
 
+// These will be defined in a future version of the Windows SDK, locally defining for now:
+#define D3D_NAME_CULL_SHADINGRATE 24
+#define D3D_NAME_CULL_PRIMITIVE 25
+
 const GUID IID_ID3D11ShaderReflection_43 = {
     0x0a233719,
     0x3960,
@@ -1722,10 +1726,8 @@ D3D_NAME SemanticToSystemValueType(const Semantic *S, DXIL::TessellatorDomain do
     return D3D_NAME_UNDEFINED;
     }
   case Semantic::Kind::ShadingRate:
-#define D3D_NAME_CULL_SHADINGRATE 24
     return (D3D_NAME)D3D_NAME_SHADINGRATE;
   case Semantic::Kind::CullPrimitive:
-#define D3D_NAME_CULL_PRIMITIVE 25
     return (D3D_NAME)D3D_NAME_CULL_PRIMITIVE;
   }
   case Semantic::Kind::InsideTessFactor:

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -4407,6 +4407,12 @@ static void ValidateSignatureElement(DxilSignatureElement &SE,
                              {SE.GetSemantic()->GetName(), "uint"});
     }
     break;
+  case DXIL::SemanticKind::CullPrimitive: {
+    if (!(compBool && compWidth == 1) || SE.GetCols() != 1) {
+      ValCtx.EmitFormatError(ValidationRule::MetaSemanticCompType,
+                             {SE.GetSemantic()->GetName(), "bool"});
+    }
+  } break;
   case DXIL::SemanticKind::TessFactor:
   case DXIL::SemanticKind::InsideTessFactor:
     // NOTE: the size check is at CheckPatchConstantSemantic.

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/misc/shadingrate1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/misc/shadingrate1.hlsl
@@ -3,7 +3,7 @@
 // CHECK:       ; Note: shader requires additional functionality:
 // CHECK-NEXT:  ;       Shading Rate
 // CHECK:       ; Input signature:
-// CHECK:       ; SV_ShadingRate           0   x           1     NONE    uint
+// CHECK:       ; SV_ShadingRate           0   x           1SHDINGRATE    uint
 // CHECK:       ; Output signature:
 // CHECK:       ; Input signature:
 // CHECK:       ; SV_ShadingRate           0        nointerpolation

--- a/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/misc/shadingrate2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/declarations/functions/entrypoints/semantics/misc/shadingrate2.hlsl
@@ -4,7 +4,7 @@
 // CHECK-NEXT:  ;       Shading Rate
 // CHECK:       ; Input signature:
 // CHECK:       ; Output signature:
-// CHECK:       ; SV_ShadingRate           0   x           1     NONE    uint
+// CHECK:       ; SV_ShadingRate           0   x           1SHDINGRATE    uint
 // CHECK:       ; Input signature:
 // CHECK:       ; Output signature:
 // CHECK:       ; SV_ShadingRate           0        nointerpolation

--- a/tools/clang/test/CodeGenHLSL/mesh/mesh.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh/mesh.hlsl
@@ -5,6 +5,7 @@
 // CHECK: dx.op.emitIndices
 // CHECK: dx.op.storeVertexOutput
 // CHECK: dx.op.storePrimitiveOutput
+// CHECK: !"cullPrimitive", i32 3, i32 100, i32 4, !"SV_CullPrimitive", i32 7, i32 1}
 
 #define MAX_VERT 32
 #define MAX_PRIM 16
@@ -20,6 +21,7 @@ struct MeshPerPrimitive {
     float alnorm : ALNORM;
     float ormaln : ORMALN;
     int layer[6] : LAYER;
+    bool cullPrimitive : SV_CullPrimitive;
 };
 
 struct MeshPayload {
@@ -71,6 +73,7 @@ void main(
       op.layer[3] = mpl.layer[3];
       op.layer[4] = mpl.layer[4];
       op.layer[5] = mpl.layer[5];
+      op.cullPrimitive = false;
       gsMem[tig / 3] = op.normal;
       prims[tig / 3] = op;
     }

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -192,6 +192,12 @@ void PrintSignature(LPCSTR pName, const DxilProgramSignature *pSignature,
     case DxilProgramSigSemantic::Barycentrics:
       pSysValue = "BARYCEN";
       break;
+    case DxilProgramSigSemantic::ShadingRate:
+      pSysValue = "SHDINGRATE";
+      break;
+    case DxilProgramSigSemantic::CullPrimitive:
+      pSysValue = "CULLPRIM";
+      break;
     case DxilProgramSigSemantic::Undefined:
       break;
     }


### PR DESCRIPTION
(and fill in some missing SV_ShadingRate entries)

One part of the change depends on an enum value being added to d3dcommon.h, which I have staged in the OS.   For now I just locally #defined the value D3D_NAME_CULL_PRIMITIVE in dxilcontainerreflection.cpp.  Advice on how to get this #define removed and d3dcommon.h updated?  Need to wait until public SDK has been updated?