### PR TITLE
Fix a few sources of nondeterminism in the dxil linker

### DIFF
--- a/include/dxc/HLSL/DxilExportMap.h
+++ b/include/dxc/HLSL/DxilExportMap.h
@@ -20,8 +20,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
 
 namespace llvm {
 class Function;
@@ -34,7 +33,7 @@ namespace dxilutil {
   public:
     typedef std::unordered_set<std::string> StringStore;
     typedef std::set<llvm::StringRef> NameSet;
-    typedef llvm::DenseMap< llvm::Function*, NameSet > RenameMap;
+    typedef llvm::MapVector< llvm::Function*, NameSet > RenameMap;
     typedef llvm::StringMap< llvm::StringSet<> > ExportMapByString;
     typedef ExportMapByString::iterator iterator;
     typedef ExportMapByString::const_iterator const_iterator;


### PR DESCRIPTION
Always the same culprit: iterating over a pointer-keyed map/set. There are more issues remaining because I'm still seeing my linked dxil module have unpredictible function orderings, but hopefully this part of the code should be good now.