### PR TITLE
Enable build without git enlistment

### DIFF
--- a/utils/GetCommitInfo.py
+++ b/utils/GetCommitInfo.py
@@ -5,13 +5,19 @@ import subprocess
 
 
 def git_get_commit_hash():
-    return subprocess.check_output(
-        ['git', 'rev-parse', '--short=8', 'HEAD']).decode('ascii').strip()
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-parse', '--short=8', 'HEAD']).decode('ascii').strip()
+    except subprocess.CalledProcessError:
+        return "00000000"
 
 
 def git_get_commit_count():
-    return subprocess.check_output(
-        ['git', 'rev-list', '--count', 'HEAD']).decode('ascii').strip()
+    try:
+        return subprocess.check_output(
+            ['git', 'rev-list', '--count', 'HEAD']).decode('ascii').strip()
+    except subprocess.CalledProcessError:
+        return 0
 
 
 def compose_commit_namespace(git_count, git_hash):

--- a/utils/version/gen_version.py
+++ b/utils/version/gen_version.py
@@ -36,14 +36,23 @@ def get_output_of(cmd):
     return output.decode('ASCII').strip()
 
 def get_last_commit_sha():
-    return get_output_of([ "git", "describe", "--always", "--dirty" ])
+    try:
+        return get_output_of([ "git", "describe", "--always", "--dirty" ])
+    except subprocess.CalledProcessError:
+        return "00000000"
 
 def get_current_branch():
-    return get_output_of([ "git", "rev-parse", "--abbrev-ref", "HEAD" ])
+    try:
+        return get_output_of([ "git", "rev-parse", "--abbrev-ref", "HEAD" ])
+    except subprocess.CalledProcessError:
+        return "private"
 
 def get_commit_count(sha):
-    return get_output_of([ "git", "rev-list", "--count", sha ])
-
+    try:
+        return get_output_of([ "git", "rev-list", "--count", sha ])
+    except subprocess.CalledProcessError:
+        return 0
+    
 def read_latest_release_info():
     latest_release_file = os.path.join(os.path.dirname(os.path.abspath( __file__)), "latest-release.json")
     with open(latest_release_file, 'r') as f:


### PR DESCRIPTION
Adds exception handling around git invocations to supply replacement values when building outside of git enlistment.

Fixes #2364