### PR TITLE
Adding test fixes and more support for SM6.5 WaveMultiPrefix functions

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -6174,14 +6174,14 @@ static T GetWaveMultiPrefixInitialAccumValue(LPCWSTR testName) {
   } else if (_wcsicmp(testName, L"WaveMultiPrefixSum") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixUSum") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixBitOr") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0 ||
+             _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixBitXor") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0 ||
+             _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixCountBits") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
     return static_cast<T>(0);
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitAnd") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
     return static_cast<T>(-1);
   } else {
     return static_cast<T>(0);
@@ -6197,16 +6197,16 @@ std::function<T(T, T)> GetWaveMultiPrefixReferenceFunction(LPCWSTR testName) {
              _wcsicmp(testName, L"WaveMultiPrefixUSum") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs + rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitAnd") == 0 ||
-			       _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs & rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitOr") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs | rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitXor") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs ^ rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixCountBits") == 0 ||
-	           _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
+             _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
     // For CountBits, each lane contributes a boolean value. The test input is
     // a zero or non-zero integer. If the input is a non-zero value then the
     // condition is true, thus we contribute one to the bit count.
@@ -6337,7 +6337,7 @@ ExecutionTest::WaveIntrinsicsMultiPrefixOpTest(TableParameter *pParameterList,
 
         LogCommentFmt(L"%08X  %08X  %08X  %08X  %08X  %08X", data->laneId, data->mask, data->key, data->value, data->result, accum);
 
-		VERIFY_IS_TRUE(accum == data->result);
+        VERIFY_IS_TRUE(accum == data->result);
       }
       LogCommentFmt(L"\n");
     }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -6174,14 +6174,14 @@ static T GetWaveMultiPrefixInitialAccumValue(LPCWSTR testName) {
   } else if (_wcsicmp(testName, L"WaveMultiPrefixSum") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixUSum") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixBitOr") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0 ||
+	           _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixBitXor") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0 ||
+	           _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0 ||
              _wcsicmp(testName, L"WaveMultiPrefixCountBits") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
+	           _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
     return static_cast<T>(0);
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitAnd") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
+	           _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
     return static_cast<T>(-1);
   } else {
     return static_cast<T>(0);
@@ -6197,20 +6197,20 @@ std::function<T(T, T)> GetWaveMultiPrefixReferenceFunction(LPCWSTR testName) {
              _wcsicmp(testName, L"WaveMultiPrefixUSum") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs + rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitAnd") == 0 ||
-			 _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
+			       _wcsicmp(testName, L"WaveMultiPrefixUBitAnd") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs & rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitOr") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0) {
+	           _wcsicmp(testName, L"WaveMultiPrefixUBitOr") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs | rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixBitXor") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0) {
+	           _wcsicmp(testName, L"WaveMultiPrefixUBitXor") == 0) {
     return [] (T lhs, T rhs) -> T { return lhs ^ rhs; };
   } else if (_wcsicmp(testName, L"WaveMultiPrefixCountBits") == 0 ||
-	         _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
+	           _wcsicmp(testName, L"WaveMultiPrefixUCountBits") == 0) {
     // For CountBits, each lane contributes a boolean value. The test input is
-    // an integer, so convert to a boolean by computing (input > 10) If this
-    // condition is true, we contribute one to the bit count.
-    return [] (T lhs, T rhs) -> T { return lhs + (rhs > 10 ? 1 : 0); };
+    // a zero or non-zero integer. If the input is a non-zero value then the
+    // condition is true, thus we contribute one to the bit count.
+    return [] (T lhs, T rhs) -> T { return lhs + (rhs ? 1 : 0); };
   } else {
     return [] (T lhs, T rhs) -> T { return 0; };
   }

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -6130,10 +6130,10 @@
                     data.laneId = WaveGetLaneIndex();
                     if (data.mask != 0) {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value, mask);
                     } else {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value, mask);
                     }
                     g_buffer[id] = data;
                 }</Parameter>
@@ -6145,16 +6145,16 @@
                 <Value>4</Value>
             </Parameter>
             <Parameter Name="Validation.Values">
-                <Value>10</Value>
+                <Value>0</Value>
                 <Value>42</Value>
-                <Value>1</Value>
+                <Value>0</Value>
                 <Value>64</Value>
                 <Value>11</Value>
                 <Value>76</Value>
                 <Value>90</Value>
                 <Value>111</Value>
-                <Value>9</Value>
-                <Value>6</Value>
+                <Value>0</Value>
+                <Value>0</Value>
                 <Value>79</Value>
                 <Value>34</Value>
             </Parameter>
@@ -6618,10 +6618,10 @@
                     data.laneId = WaveGetLaneIndex();
                     if (data.mask != 0) {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value, mask);
                     } else {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value, mask);
                     }
                     g_buffer[id] = data;
                 }</Parameter>
@@ -6633,16 +6633,16 @@
                 <Value>4</Value>
             </Parameter>
             <Parameter Name="Validation.Values">
-                <Value>10</Value>
+                <Value>0</Value>
                 <Value>42</Value>
-                <Value>1</Value>
+                <Value>0</Value>
                 <Value>64</Value>
                 <Value>11</Value>
                 <Value>76</Value>
                 <Value>90</Value>
                 <Value>111</Value>
-                <Value>9</Value>
-                <Value>6</Value>
+                <Value>0</Value>
+                <Value>0</Value>
                 <Value>79</Value>
                 <Value>34</Value>
             </Parameter>

--- a/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
+++ b/tools/clang/unittests/HLSL/ShaderOpArithTable.xml
@@ -6130,10 +6130,10 @@
                     data.laneId = WaveGetLaneIndex();
                     if (data.mask != 0) {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
                     } else {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
                     }
                     g_buffer[id] = data;
                 }</Parameter>
@@ -6618,10 +6618,10 @@
                     data.laneId = WaveGetLaneIndex();
                     if (data.mask != 0) {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
                     } else {
                         uint4 mask = WaveMatch(data.key);
-                        data.result = WaveMultiPrefixCountBits(data.value, mask);
+                        data.result = WaveMultiPrefixCountBits(data.value > 10, mask);
                     }
                     g_buffer[id] = data;
                 }</Parameter>

--- a/utils/hct/hctdb_test.py
+++ b/utils/hct/hctdb_test.py
@@ -1393,7 +1393,7 @@ def add_test_cases():
          [['0', '3', '1', '5', '4'], ['10', '42', '1', '64', '11', '76', '90', '111', '9', '6', '79', '34']], [],
         'cs_6_5', get_shader_text("wave op multi prefix int", "WaveMultiPrefixProduct"))
     add_test_case('WaveMultiPrefixCountBits', ['WaveMultiPrefixOp'], 'Epsilon', 0,
-         [['0', '3', '1', '5', '4'], ['10', '42', '1', '64', '11', '76', '90', '111', '9', '6', '79', '34']], [],
+         [['0', '3', '1', '5', '4'], ['0', '42', '0', '64', '11', '76', '90', '111', '0', '0', '79', '34']], [],
         'cs_6_5', get_shader_text("wave op multi prefix int", "WaveMultiPrefixCountBits"))
 
     add_test_case('WaveMultiPrefixUBitAnd', ['WaveMultiPrefixOp'], 'Epsilon', 0,
@@ -1412,7 +1412,7 @@ def add_test_cases():
          [['0', '3', '1', '5', '4'], ['10', '42', '1', '64', '11', '76', '90', '111', '9', '6', '79', '34']], [],
         'cs_6_5', get_shader_text("wave op multi prefix uint", "WaveMultiPrefixProduct"))
     add_test_case('WaveMultiPrefixUCountBits', ['WaveMultiPrefixOp'], 'Epsilon', 0,
-         [['0', '3', '1', '5', '4'], ['10', '42', '1', '64', '11', '76', '90', '111', '9', '6', '79', '34']], [],
+         [['0', '3', '1', '5', '4'], ['0', '42', '0', '64', '11', '76', '90', '111', '0', '0', '79', '34']], [],
         'cs_6_5', get_shader_text("wave op multi prefix uint", "WaveMultiPrefixCountBits"))
 
 


### PR DESCRIPTION
1)	Ensure wave lane-id’s are sorted when accumulating result
2)	Fix made for HLSL in ShaderOpArithTable.xml to ensure the input aligns with what is being tested
3)	Added support for the “UBit” version for all of these tests.