### PR TITLE
Enable clang warnings for uninitialized variables/structs

### DIFF
--- a/tools/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/tools/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2006,6 +2006,18 @@ AnalysisBasedWarnings::IssueWarnings(sema::AnalysisBasedWarnings::Policy P,
     Analyzer.run(AC);
   }
 
+  // HLSL changes begin
+  // Enable diagnostics related ti uninitialized variables
+  if (S.getLangOpts().HLSL) {
+    Diags.setSeverity(diag::warn_uninit_var, diag::Severity::Warning,
+                      D->getLocStart());
+    Diags.setSeverity(diag::warn_sometimes_uninit_var, diag::Severity::Warning,
+                      D->getLocStart());
+    Diags.setSeverity(diag::warn_maybe_uninit_var, diag::Severity::Warning,
+                      D->getLocStart());
+  }
+  // HLSL changes end
+
   if (!Diags.isIgnored(diag::warn_uninit_var, D->getLocStart()) ||
       !Diags.isIgnored(diag::warn_sometimes_uninit_var, D->getLocStart()) ||
       !Diags.isIgnored(diag::warn_maybe_uninit_var, D->getLocStart())) {

--- a/tools/clang/lib/Sema/AnalysisBasedWarnings.cpp
+++ b/tools/clang/lib/Sema/AnalysisBasedWarnings.cpp
@@ -2007,7 +2007,7 @@ AnalysisBasedWarnings::IssueWarnings(sema::AnalysisBasedWarnings::Policy P,
   }
 
   // HLSL changes begin
-  // Enable diagnostics related ti uninitialized variables
+  // Enable diagnostics related to uninitialized variables
   if (S.getLangOpts().HLSL) {
     Diags.setSeverity(diag::warn_uninit_var, diag::Severity::Warning,
                       D->getLocStart());

--- a/tools/clang/test/HLSL/matrix-syntax-exact-precision.hlsl
+++ b/tools/clang/test/HLSL/matrix-syntax-exact-precision.hlsl
@@ -7,17 +7,17 @@
 matrix m;
 
 void abs_without_using_result() {
-    matrix<float, 4, 4> mymatrix;
-    abs(mymatrix);            /* expected-warning {{ignoring return value of function declared with const attribute}} fxc-pass {{}} */
+    matrix<float, 4, 4> mymatrix; /* expected-note {{variable 'mymatrix' is declared here}} fxc-pass {{}} */
+    abs(mymatrix);            /* expected-warning {{ignoring return value of function declared with const attribute}} expected-warning {{variable 'mymatrix' is uninitialized when used here}} fxc-pass {{}} */
 
-    matrix<float, 1, 4> mymatrix2;
-    abs(mymatrix2);           /* expected-warning {{ignoring return value of function declared with const attribute}} fxc-pass {{}} */
+    matrix<float, 1, 4> mymatrix2;/* expected-note {{variable 'mymatrix2' is declared here}} fxc-pass {{}} */
+    abs(mymatrix2);           /* expected-warning {{ignoring return value of function declared with const attribute}} expected-warning{{variable 'mymatrix2' is uninitialized when used here}} fxc-pass {{}} */
 }
 
 void abs_with_assignment() {
-    matrix<float, 4, 4> mymatrix;
+    matrix<float, 4, 4> mymatrix;/* expected-note {{variable 'mymatrix' is declared here}} fxc-pass {{}} */
     matrix<float, 4, 4> absMatrix;
-    absMatrix = abs(mymatrix);
+    absMatrix = abs(mymatrix); /* expected-warning{{variable 'mymatrix' is uninitialized when used here}} fxc-pass{{}} */
 }
 
 matrix<float, 4, 4> abs_for_result(matrix<float, 4, 4> value) {
@@ -27,8 +27,8 @@ matrix<float, 4, 4> abs_for_result(matrix<float, 4, 4> value) {
 void fn_use_matrix(matrix<float, 4, 4> value) { }
 
 void abs_in_argument() {
-    matrix<float, 4, 4> mymatrix;
-    fn_use_matrix(abs(mymatrix));
+    matrix<float, 4, 4> mymatrix;/* expected-note {{variable 'mymatrix' is declared here}} fxc-pass {{}} */
+    fn_use_matrix(abs(mymatrix)); /* expected-warning{{variable 'mymatrix' is uninitialized when used here}} fxc-pass{{}} */
     /*verify-ast
       CallExpr <col:5, col:32> 'void'
       |-ImplicitCastExpr <col:5> 'void (*)(matrix<float, 4, 4>)' <FunctionToPointerDecay>
@@ -49,8 +49,8 @@ void matrix_on_demand() {
 }
 
 void abs_on_demand() {
-   float1x2 f12;
-   float1x2 result = abs(f12);
+   float1x2 f12;/* expected-note {{variable 'f12' is declared here}} fxc-pass {{}} */
+   float1x2 result = abs(f12); /* expected-warning{{variable 'f12' is uninitialized when used here}} fxc-pass{{}} */
 }
 
 void matrix_out_of_bounds() {

--- a/tools/clang/test/HLSL/matrix-syntax.hlsl
+++ b/tools/clang/test/HLSL/matrix-syntax.hlsl
@@ -7,17 +7,17 @@
 matrix m;
 
 void abs_without_using_result() {
-    matrix<float, 4, 4> mymatrix;
-    abs(mymatrix);            /* expected-warning {{ignoring return value of function declared with const attribute}} fxc-pass {{}} */
+    matrix<float, 4, 4> mymatrix; /* expected-note {{variable 'mymatrix' is declared here}} */
+    abs(mymatrix);            /* expected-warning {{ignoring return value of function declared with const attribute}} expected-warning {{variable 'mymatrix' is uninitialized when used here}} fxc-pass {{}} */
 
-    matrix<float, 1, 4> mymatrix2;
-    abs(mymatrix2);           /* expected-warning {{ignoring return value of function declared with const attribute}} fxc-pass {{}} */
+    matrix<float, 1, 4> mymatrix2; /* expected-note {{variable 'mymatrix2' is declared here}} */
+    abs(mymatrix2);           /* expected-warning {{ignoring return value of function declared with const attribute}} expected-warning {{variable 'mymatrix2' is uninitialized when used here}} fxc-pass {{}} */
 }
 
 void abs_with_assignment() {
-    matrix<float, 4, 4> mymatrix;
+    matrix<float, 4, 4> mymatrix; /* expected-note {{variable 'mymatrix' is declared here}} */
     matrix<float, 4, 4> absMatrix;
-    absMatrix = abs(mymatrix);
+    absMatrix = abs(mymatrix); /* expected-warning {{variable 'mymatrix' is uninitialized when used here}} fxc-pass {{}} */
 }
 
 matrix<float, 4, 4> abs_for_result(matrix<float, 4, 4> value) {
@@ -27,8 +27,8 @@ matrix<float, 4, 4> abs_for_result(matrix<float, 4, 4> value) {
 void fn_use_matrix(matrix<float, 4, 4> value) { }
 
 void abs_in_argument() {
-    matrix<float, 4, 4> mymatrix;
-    fn_use_matrix(abs(mymatrix));
+    matrix<float, 4, 4> mymatrix; /* expected-note {{variable 'mymatrix' is declared here}} */
+    fn_use_matrix(abs(mymatrix)); /* expected-warning {{variable 'mymatrix' is uninitialized when used here}} fxc-pass {{}}*/
     /*verify-ast
       CallExpr <col:5, col:32> 'void'
       |-ImplicitCastExpr <col:5> 'void (*)(matrix<float, 4, 4>)' <FunctionToPointerDecay>
@@ -49,8 +49,8 @@ void matrix_on_demand() {
 }
 
 void abs_on_demand() {
-   float1x2 f12;
-   float1x2 result = abs(f12);
+   float1x2 f12; /* expected-note {{variable 'f12' is declared here}} */
+   float1x2 result = abs(f12); /* expected-warning {{variable 'f12' is uninitialized when used here}} fxc-pass {{}}*/
 }
 
 void matrix_out_of_bounds() {

--- a/tools/clang/test/HLSL/uninitialized-warnings.hlsl
+++ b/tools/clang/test/HLSL/uninitialized-warnings.hlsl
@@ -1,0 +1,55 @@
+// RUN: %clang_cc1 -verify %s
+
+// This file contains scenarios to test warnings are generated when uninitialized
+// variables or structs are used.
+
+struct MyStruct
+{
+ float a;
+ int b;
+};
+
+cbuffer MyCBuf
+{
+	float c;
+}
+
+uint uninitvar()
+{
+	uint sum; /* expected-note {{initialize the variable 'sum' to silence this warning}} */
+    sum++; /* expected-warning {{variable 'sum' is uninitialized when used here}} */
+	return sum;
+}
+
+uint uninitvarself()
+{
+	uint sum = sum; /* expected-warning {{variable 'sum' is uninitialized when used within its own initialization}} */
+	return sum;
+}
+
+uint mayuninit(uint i)
+{
+	uint s; /* expected-note {{initialize the variable 's' to silence this warning}} */
+	if(i > 10) /* expected-warning {{variable 's' is used uninitialized whenever 'if' condition is false}} expected-note {{remove the 'if' if its condition is always true}} */
+	{
+		s = 10;
+	}
+	return s; /* expected-note {{uninitialized use occurs here}} */
+}
+
+uint uninit2(uint s)
+{
+	s = s << 4;
+	return s;
+}
+
+void main(uint i : IN){
+	uint s; /* expected-note {{initialize the variable 's' to silence this warning}} */
+	(void) uninit2(s); /* expected-warning {{variable 's' is uninitialized when used here}} */
+	(void) uninitvar();
+	(void) uninitvarself();
+	MyStruct val1,val2; /* expected-note {{initialize the variable 'val1' to silence this warning}} */
+	val2 = val1; /* expected-warning {{variable 'val1' is uninitialized when used here}} */
+	mayuninit(i);
+	float d = c;
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -87,6 +87,7 @@ public:
   TEST_METHOD(RunBadInclude)
   TEST_METHOD(RunWave)
   TEST_METHOD(RunBinopDims)
+  TEST_METHOD(RunUninitWarnings)
 
   void CheckVerifies(const wchar_t* path) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
@@ -352,4 +353,8 @@ TEST_F(VerifierTest, RunWave) {
 
 TEST_F(VerifierTest, RunBinopDims) {
   CheckVerifiesHLSL(L"binop-dims.hlsl");
+}
+
+TEST_F(VerifierTest, RunUninitWarnings) {
+    CheckVerifiesHLSL(L"uninitialized-warnings.hlsl");
 }


### PR DESCRIPTION
As listed in issue #2419, unlike DXC, FXC has some support for generating diagnostic for uninitialized variables/structs (which is rather inconsistent). For example, FXC generates error for uninitialized variables, but only warns for uninitialized structs. Also, FXC fails to generate any warning when variables "may" be uninitialized (e.g., when initialized conditionally). This PR enables Clang warning for uninitialized variables/structs which produces much better diagnostic than FXC. 

Fixes #2419