### PR TITLE
Add Fdd option to specify debug output dir

### DIFF
--- a/docs/SourceLevelDebuggingHLSL.rst
+++ b/docs/SourceLevelDebuggingHLSL.rst
@@ -83,10 +83,12 @@ The most common use cases are as follows.
 
 * Build debug information and extract it to an auto-generated external
   file. In this case, /Zi and /Fd should both be used, and the /Fd value
-  should end in a trailing backslash when using dxc, naming the target
-  directory in which to place the file. /Zss is the default, but /Zsb can be
-  used to deduplicate files. When using /Fd with a directory name,
-  /Qstrip_debug is implied.
+  should end in a trailing directory separator (backslash on Windows) when
+  using dxc, naming the target directory in which to place the file.
+  Alternately, /Fdd can be used to name the target directory omitting the
+  trailing separator. /Zss is the default, but /Zsb can be used to
+  deduplicate files. When using /Fd with a directory name, /Qstrip_debug is
+  implied.
 
 A less common use case is to specify an explicit name for the external
 file. In this case, the command-line should include /Zi, /Fd with a specific

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -93,6 +93,7 @@ public:
 
   llvm::StringRef AssemblyCode; // OPT_Fc
   llvm::StringRef DebugFile;    // OPT_Fd
+  llvm::StringRef DebugDir;     // OPT_Fdd
   llvm::StringRef EntryPoint;   // OPT_entrypoint
   llvm::StringRef ExternalFn;   // OPT_external_fn
   llvm::StringRef ExternalLib;  // OPT_external_lib

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -339,6 +339,9 @@ def Fe : JoinedOrSeparate<["-", "/"], "Fe">, MetaVarName<"<file>">, HelpText<"Ou
 def Fd : JoinedOrSeparate<["-", "/"], "Fd">, MetaVarName<"<file>">,
   HelpText<"Write debug information to the given file, or automatically named file in directory when ending in '\\'">,
   Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
+def Fdd : JoinedOrSeparate<["-", "/"], "Fdd">, MetaVarName<"<dir>">,
+  HelpText<"Write debug information to an automatically named file in given directory">,
+  Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
 def Vn : JoinedOrSeparate<["-", "/"], "Vn">, MetaVarName<"<name>">, HelpText<"Use <name> as variable name in header file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 def Cc : Flag<["-", "/"], "Cc">, HelpText<"Output color coded assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;
 def Ni : Flag<["-", "/"], "Ni">, HelpText<"Output instruction numbers in assembly listings">, Group<hlslcomp_Group>, Flags<[DriverOption]>;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -155,7 +155,7 @@ bool DxcOpts::DebugFileIsDirectory() {
 }
 
 llvm::StringRef DxcOpts::GetPDBName() {
-  if (!DebugFileIsDirectory())
+  if (!DebugFileIsDirectory() && DebugDir.empty())
     return DebugFile;
   return llvm::StringRef();
 }
@@ -283,7 +283,7 @@ static bool handleVkShiftArgs(const InputArgList &args, OptSpecifier id,
     return false;
   }
   return true;
-};
+}
 #endif
 // SPIRV Change Ends
 
@@ -420,8 +420,14 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   // AssemblyCodeHex not supported (Fx)
   // OutputLibrary not supported (Fl)
+  if (Arg *A = Args.getLastArg(OPT_Fd, OPT_Fdd)) {
+      opts.DebugFile = A->getValue();
+      if (A->getOption().matches(OPT_Fdd))
+          opts.DebugDir = A->getValue();
+  } else {
+    opts.DebugFile =  "";
+  }
   opts.AssemblyCode = Args.getLastArgValue(OPT_Fc);
-  opts.DebugFile = Args.getLastArgValue(OPT_Fd);
   opts.ExtractPrivateFile = Args.getLastArgValue(OPT_getprivate);
   opts.Enable16BitTypes = Args.hasFlag(OPT_enable_16bit_types, OPT_INVALID, false);
   opts.OutputObject = Args.getLastArgValue(OPT_Fo);


### PR DESCRIPTION
Because the /Fd option requires a backslash on Windows to specify a
directory, if this argument needs to be quoted, the closing quotation
mark is escaped, which confuses the arguments provided.

The /Fdd option explicitly specifies the directory to output the
automatically named debug files to without the need for a trailing
separator character.

The implementation reuses the significance of the DebugFile member,
while adding a DebugDir member that indicates that DebugFile contains
a directory name that needs to have both the platform-appropriate
separator and the generated debug file name appended to it.

Resolves #2427