### PR TITLE
Fix the compiling problem on VS2019.2

### DIFF
--- a/utils/TableGen/AsmWriterEmitter.cpp
+++ b/utils/TableGen/AsmWriterEmitter.cpp
@@ -763,7 +763,7 @@ static unsigned CountNumOperands(StringRef AsmString, unsigned Variant) {
 namespace {
 struct AliasPriorityComparator {
   typedef std::pair<CodeGenInstAlias *, int> ValueType;
-  bool operator()(const ValueType &LHS, const ValueType &RHS) {
+  bool operator()(const ValueType &LHS, const ValueType &RHS) const {
     if (LHS.second ==  RHS.second) {
       // We don't actually care about the order, but for consistency it
       // shouldn't depend on pointer comparisons.


### PR DESCRIPTION
The comparator in std::set is restrict to const since VS2019.2. The operator() of it need to be const to avoid a C3848 error.