### PR TITLE
[spirv] Add '--fspv-preserve-bindings' command line option

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -283,6 +283,8 @@ def fspv_target_env_EQ : Joined<["-"], "fspv-target-env=">, Group<spirv_Group>, 
   HelpText<"Specify the target environment: vulkan1.0 (default) or vulkan1.1">;
 def fspv_flatten_resource_arrays: Flag<["-"], "fspv-flatten-resource-arrays">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Flatten arrays of resources so each array element takes one binding number">;
+def fspv_preserve_bindings: Flag<["-"], "fspv-preserve-bindings">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Make the optimizer keep bindings, even when they are unused.">;
 def Wno_vk_ignored_features : Joined<["-"], "Wno-vk-ignored-features">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Do not emit warnings for ingored features resulting from no Vulkan support">;
 def Wno_vk_emulated_features : Joined<["-"], "Wno-vk-emulated-features">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -54,6 +54,7 @@ struct SpirvCodeGenOptions {
   bool useGlLayout;
   bool useScalarLayout;
   bool flattenResourceArrays;
+  bool preserveBindings;
   SpirvLayoutRule cBufferLayoutRule;
   SpirvLayoutRule sBufferLayoutRule;
   SpirvLayoutRule tBufferLayoutRule;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -719,6 +719,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.noWarnEmulatedFeatures = Args.hasFlag(OPT_Wno_vk_emulated_features, OPT_INVALID, false);
   opts.SpirvOptions.flattenResourceArrays =
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false);
+  opts.SpirvOptions.preserveBindings =
+      Args.hasFlag(OPT_fspv_preserve_bindings, OPT_INVALID, false);
 
   if (!handleVkShiftArgs(Args, OPT_fvk_b_shift, "b", &opts.SpirvOptions.bShift, errors) ||
       !handleVkShiftArgs(Args, OPT_fvk_t_shift, "t", &opts.SpirvOptions.tShift, errors) ||
@@ -794,6 +796,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fvk_use_dx_layout, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_use_scalar_layout, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_flatten_resource_arrays, OPT_INVALID, false) ||
+      Args.hasFlag(OPT_fspv_preserve_bindings, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fspv_reflect, OPT_INVALID, false) ||
       Args.hasFlag(OPT_Wno_vk_ignored_features, OPT_INVALID, false) ||
       Args.hasFlag(OPT_Wno_vk_emulated_features, OPT_INVALID, false) ||

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -175,6 +175,7 @@ bool spirvToolsOptimize(spv_target_env env, std::vector<uint32_t> *module,
 
   spvtools::OptimizerOptions options;
   options.set_run_validator(false);
+  options.set_preserve_bindings(spirvOptions.preserveBindings);
 
   if (spirvOptions.optConfig.empty()) {
     optimizer.RegisterPerformancePasses();


### PR DESCRIPTION
On the C++ code side, we bind resources based on reflection data. If some code tries to bind a resource that is not part of the reflection data, it is considered an error and the game asserts which forces `DebugBreak`.

When doing shader development, our pipeline compile and reload shaders live. Doing some modifications to the shader code can temporarily make a binding unused.

In the case where a binding is unused, we want to output a warning saying a specific resource is not used. And only display that warning once.

However, the optimizer currently removes unused bindings and triggers the error/assert every time something is bound to the shader (once to many times per frame) instead of showing only a warning once, which is very annoying.

This is why I added this `--fspv-preserve-bindings` as a option in order to correctly know if a resource is really absent or if it is just unused.

Consider the simple sample code :
```
struct VSOutput
{
	float4 Tint : COLOR0;
};

struct InstanceData
{
	float4 Color;
};
StructuredBuffer<InstanceData> InstanceDataSB;

VSOutput VS(uint aInstanceID : SV_InstanceID)
{
	VSOutput vertexOutput;

	vertexOutput.Tint = InstanceDataSB[aInstanceID].Color;
	vertexOutput.Tint = float4(1.0f, 0.0f, 0.0f, 0.0f); // Testing a specific color

	return vertexOutput;
}
```

A line that was added to test something when we output a specific color :
`vertexOutput.Tint = float4(1.0f, 0.0f, 0.0f, 0.0f); // Testing a specific color`

InstanceDataSB stop being used and the problem happens.