### PR TITLE
Add support for check prefixes and multiple RUN lines in file checker

### DIFF
--- a/tools/clang/test/CodeGenHLSL/batch/expressions/intrinsics/misc/abs1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/batch/expressions/intrinsics/misc/abs1.hlsl
@@ -1,4 +1,4 @@
-﻿// RUN: %dxc -E main -T ps_6_0 -fcgl %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -fcgl %s | FileCheck %s
 
 // CHECK: main
 // After lowering, these would turn into multiple abs calls rather than a 4 x float

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <cmath>
 #include <vector>
+#include <algorithm>
 #ifdef _WIN32
 #include <dxgiformat.h>
 #include "WexTestClass.h"
@@ -203,14 +204,14 @@ inline std::vector<std::string> GetRunLines(const LPCWSTR name) {
 
   std::vector<std::string> runlines;
   std::string line;
-  constexpr unsigned runlinesize = 300;
+  constexpr size_t runlinesize = 300;
   while (std::getline(infile, line)) {
     auto lineelems = strtok(line);
     if (!HasRunLine(line))
       continue;
     char runline[runlinesize];
     memset(runline, 0, runlinesize);
-    memcpy(runline, line.c_str(), runlinesize);
+    memcpy(runline, line.c_str(), min(runlinesize, line.size()));
     runlines.emplace_back(runline);
   }
   return runlines;

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <atomic>
 #include <cmath>
+#include <vector>
 #ifdef _WIN32
 #include <dxgiformat.h>
 #include "WexTestClass.h"
@@ -21,6 +22,8 @@
 #endif
 #include "dxc/Support/Unicode.h"
 #include "dxc/DXIL/DxilConstants.h" // DenormMode
+
+using namespace std;
 
 #ifndef HLSLDATAFILEPARAM
 #define HLSLDATAFILEPARAM L"HlslDataDir"
@@ -73,6 +76,43 @@
 #define EXPECT_EQ(expected, actual) VERIFY_ARE_EQUAL(expected, actual)
 #endif 
 #endif // VERIFY_ARE_EQUAL
+
+static constexpr char whitespaceChars[] = " \t\r\n";
+
+static std::string strltrim(const std::string &value) {
+  size_t first = value.find_first_not_of(whitespaceChars);
+  return first == string::npos ? value : value.substr(first);
+}
+
+static std::string strrtrim(const std::string &value) {
+  size_t last = value.find_last_not_of(whitespaceChars);
+  return last == string::npos ? value : value.substr(0, last + 1);
+}
+
+static std::string strtrim(const std::string &value) {
+  return strltrim(strrtrim(value));
+}
+
+static bool strstartswith(const std::string& value, const char* pattern) {
+  for (size_t i = 0; ; ++i) {
+    if (pattern[i] == '\0') return true;
+    if (i == value.size() || value[i] != pattern[i]) return false;
+  }
+}
+
+static std::vector<std::string> strtok(const std::string &value, const char *delimiters = whitespaceChars) {
+  size_t searchOffset = 0;
+  std::vector<std::string> tokens;
+  while (searchOffset != value.size()) {
+    size_t tokenStartIndex = value.find_first_not_of(delimiters, searchOffset);
+    if (tokenStartIndex == std::string::npos) break;
+    size_t tokenEndIndex = value.find_first_of(delimiters, tokenStartIndex);
+    if (tokenEndIndex == std::string::npos) tokenEndIndex = value.size();
+    tokens.emplace_back(value.substr(tokenStartIndex, tokenEndIndex - tokenStartIndex));
+    searchOffset = tokenEndIndex;
+  }
+  return tokens;
+}
 
 namespace hlsl_test {
 
@@ -136,6 +176,44 @@ inline bool PathLooksAbsolute(LPCWSTR name) {
 #else
   return name && *name && (*name == L'/');
 #endif
+}
+
+static bool HasRunLine(std::string &line) {
+  const char *delimiters = " ;/";
+  auto lineelems = strtok(line, delimiters);
+  return !lineelems.empty() &&
+    lineelems.front().compare("RUN:") == 0;
+}
+
+inline std::vector<std::string> GetRunLines(const LPCWSTR name) {
+  const std::wstring path = PathLooksAbsolute(name)
+    ? std::wstring(name)
+    : hlsl_test::GetPathToHlslDataFile(name);
+#ifdef _WIN32
+  std::ifstream infile(path);
+#else
+  std::ifstream infile((CW2A(path.c_str())));
+#endif
+  if (infile.bad()) {
+    std::wstring errMsg(L"Unable to read file ");
+    errMsg += path;
+    WEX::Logging::Log::Error(errMsg.c_str());
+    VERIFY_FAIL();
+  }
+
+  std::vector<std::string> runlines;
+  std::string line;
+  constexpr unsigned runlinesize = 300;
+  while (std::getline(infile, line)) {
+    auto lineelems = strtok(line);
+    if (!HasRunLine(line))
+      continue;
+    char runline[runlinesize];
+    memset(runline, 0, runlinesize);
+    memcpy(runline, line.c_str(), runlinesize);
+    runlines.emplace_back(runline);
+  }
+  return runlines;
 }
 
 inline std::string GetFirstLine(LPCWSTR name) {

--- a/tools/clang/unittests/HLSL/HlslTestUtils.h
+++ b/tools/clang/unittests/HLSL/HlslTestUtils.h
@@ -206,7 +206,6 @@ inline std::vector<std::string> GetRunLines(const LPCWSTR name) {
   std::string line;
   constexpr size_t runlinesize = 300;
   while (std::getline(infile, line)) {
-    auto lineelems = strtok(line);
     if (!HasRunLine(line))
       continue;
     char runline[runlinesize];


### PR DESCRIPTION
- Add support for multiple `RUN:` lines in test files. This should help reduce the number of test files we have as multiple closely related scenarios can be tested in a single test file.

- Add support for multiple check prefixes using a new option `-check-prefixes` passed to `FileCheck`.

- Examples:

```
// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s -check-prefixes=CHK1,CHK3
// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types %s | FileCheck %s -check-prefix=CHK2

```
