### PR TITLE
Remove array dimension limitation (1 <= dimension <= 65536)

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7525,8 +7525,6 @@ def err_hlsl_type_mismatch : Error<
   "type mismatch">;
 def err_hlsl_unsupported_array_equality_op: Error<
   "equality operators cannot be used with array types">;
-def err_hlsl_unsupported_array_size: Error<
-  "array dimension must be between 1 and 65536">;
 def err_hlsl_unsupported_incomplete_array: Error<
   "array dimensions of struct/class members must be explicit">;
 def err_hlsl_unsupported_bool_lvalue_op : Error<

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -2093,12 +2093,6 @@ QualType Sema::BuildArrayType(QualType T, ArrayType::ArraySizeModifier ASM,
           << ArraySize->getSourceRange();
       return QualType();
     }
-    // HLSL Change Starts
-    // Always report zero-sized arrays as errors as well as > 65536
-    if (getLangOpts().HLSL && (ConstVal == 0 || ConstVal.getLimitedValue() > 65536)) {
-      Diag(ArraySize->getLocStart(), diag::err_hlsl_unsupported_array_size);
-    } else
-    // HLSL Change Ends
     if (ConstVal == 0) {
       // GCC accepts zero sized static arrays. We allow them when
       // we're not in a SFINAE context.

--- a/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
@@ -644,7 +644,9 @@ int;
 // expected-warning@321 {{declaration does not declare anything}}
 
 float4 plain(float4 param4 /* : FOO */) /*: FOO */{
-  int i[0]; // expected-error {{array dimension must be between 1 and 65536}}
+  // fxc error X3059: array dimension must be between 1 and 65536
+  // dxc no longer produces this error - it doesn't have the limitation, and other limits should be enforced elsewhere.
+  int i[0]; // fxc-error {{X3059: array dimension must be between 1 and 65536}}
   const j; // expected-error {{HLSL requires a type specifier for all declarations}}
   long long ll; // expected-error {{'long' is a reserved keyword in HLSL}} expected-error {{'long' is a reserved keyword in HLSL}} expected-error {{HLSL requires a type specifier for all declarations}}
   return is_supported();

--- a/tools/clang/test/HLSL/cpp-errors.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors.hlsl
@@ -644,7 +644,9 @@ int;
 // expected-warning@321 {{declaration does not declare anything}}
 
 float4 plain(float4 param4 /* : FOO */) /*: FOO */{
-  int i[0]; // expected-error {{array dimension must be between 1 and 65536}}
+  // fxc error X3059: array dimension must be between 1 and 65536
+  // dxc no longer produces this error - it doesn't have the limitation, and other limits should be enforced elsewhere.
+  int i[0]; // fxc-error {{X3059: array dimension must be between 1 and 65536}}
   const j; // expected-error {{HLSL requires a type specifier for all declarations}}
   long long ll; // expected-error {{'long' is a reserved keyword in HLSL}} expected-error {{'long' is a reserved keyword in HLSL}} expected-error {{HLSL requires a type specifier for all declarations}}
   return is_supported();

--- a/tools/clang/test/HLSL/indexing-operator.hlsl
+++ b/tools/clang/test/HLSL/indexing-operator.hlsl
@@ -519,11 +519,12 @@ void my_subscripts()
   int2x2 i22;
 
   // fxc error X3059: array dimension must be between 1 and 65536
-  int ai0[0]; // expected-error {{array dimension must be between 1 and 65536}} fxc-error {{X3059: array dimension must be between 1 and 65536}}
+  // dxc no longer produces this error - it doesn't have the limitation, and other limits should be enforced elsewhere.
+  int ai0[0]; // fxc-error {{X3059: array dimension must be between 1 and 65536}}
+  int ai65537[65537]; // fxc-error {{X3059: array dimension must be between 1 and 65536}}
+
   int ai1[1];
   int ai65536[65536];
-  // fxc error X3059: array dimension must be between 1 and 65536
-  int ai65537[65537]; // expected-error {{array dimension must be between 1 and 65536}} fxc-error {{X3059: array dimension must be between 1 and 65536}}
 
   // fxc error X3121: array, matrix, vector, or indexable object type expected in index expression
   i[0] = 1; // expected-error {{subscripted value is not an array, matrix, or vector}} fxc-error {{X3121: array, matrix, vector, or indexable object type expected in index expression}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/array/large_resource_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/array/large_resource_array.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK: ; tex                               texture     f32          2d      T0             t0 99999
+
+Texture2D<float4> tex[99999];
+
+float4 main(uint i : I) : SV_TARGET
+{
+  return tex[i][uint2(0,0)];
+}


### PR DESCRIPTION
- This restriction from fxc is not needed for dxc
- It was being applied to resource arrays in dxc, but not in fxc.