### PR TITLE
Enable non-C VS installs

### DIFF
--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -6,7 +6,11 @@ get_filename_component(VS_PATH64 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Mi
 # Also look for in vs15 or vs16 install.
 set(PROGRAMFILES_X86 "ProgramFiles(x86)")
 set(VS_PATH32 "$ENV{${PROGRAMFILES_X86}}/Microsoft Visual Studio")
+get_filename_component(VS15_C_PATH32 "${VS_PATH32}/2017/Community/Common7/IDE" ABSOLUTE CACHE)
+get_filename_component(VS15_P_PATH32 "${VS_PATH32}/2017/Professional/Common7/IDE" ABSOLUTE CACHE)
+get_filename_component(VS15_E_PATH32 "${VS_PATH32}/2017/Enterprise/Common7/IDE" ABSOLUTE CACHE)
 
+# Starting in VS 15.2, vswhere is included.
 # Unclear what the right component to search for is, might be Microsoft.VisualStudio.Component.VC.DiagnosticTools
 # (although the friendly name of that is C++ profiling tools).  The toolset is the most likely target.
 execute_process(
@@ -23,6 +27,9 @@ execute_process(
 find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
           HINTS "${VSWHERE_LATEST}/DIA SDK/include"
+          HINTS "${VS15_C_PATH32}/../../DIA SDK/include" 
+          HINTS "${VS15_P_PATH32}/../../DIA SDK/include"
+          HINTS "${VS15_E_PATH32}/../../DIA SDK/include"
           HINTS "${VS_PATH64}/../../DIA SDK/include"
           HINTS "${VS_PATH32}/../../DIA SDK/include"
           DOC "path to DIA SDK header files"

--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -6,12 +6,15 @@ get_filename_component(VS_PATH64 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Mi
 # Also look for in vs15 or vs16 install.
 set(PROGRAMFILES_X86 "ProgramFiles(x86)")
 set(VS_PATH32 "$ENV{${PROGRAMFILES_X86}}/Microsoft Visual Studio")
-get_filename_component(VS16_C_PATH32 "${VS_PATH32}/2019/Community/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS16_P_PATH32 "${VS_PATH32}/2019/Professional/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS16_E_PATH32 "${VS_PATH32}/2019/Enterprise/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS15_C_PATH32 "${VS_PATH32}/2017/Community/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS15_P_PATH32 "${VS_PATH32}/2017/Professional/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS15_E_PATH32 "${VS_PATH32}/2017/Enterprise/Common7/IDE" ABSOLUTE CACHE)
+
+# Unclear what the right component to search for is, might be Microsoft.VisualStudio.Component.VC.DiagnosticTools
+# (although the friendly name of that is C++ profiling tools).  The toolset is the most likely target.
+execute_process(
+  COMMAND "${VS_PATH32}/Installer/vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+  OUTPUT_VARIABLE VSWHERE_LATEST
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
 # Find the DIA SDK path, it will typically look something like this.
 # C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\DIA SDK\include
@@ -19,16 +22,10 @@ get_filename_component(VS15_E_PATH32 "${VS_PATH32}/2017/Enterprise/Common7/IDE" 
 # C:\Program Files (x86)\Microsoft Visual Studio 14.0\DIA SDK\include
 find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
-          HINTS "${VS16_C_PATH32}/../../DIA SDK/include" 
-          HINTS "${VS16_P_PATH32}/../../DIA SDK/include"
-          HINTS "${VS16_E_PATH32}/../../DIA SDK/include"
-          HINTS "${VS15_C_PATH32}/../../DIA SDK/include" 
-          HINTS "${VS15_P_PATH32}/../../DIA SDK/include"
-          HINTS "${VS15_E_PATH32}/../../DIA SDK/include"
+          HINTS "${VSWHERE_LATEST}/DIA SDK/include"
           HINTS "${VS_PATH64}/../../DIA SDK/include"
           HINTS "${VS_PATH32}/../../DIA SDK/include"
           DOC "path to DIA SDK header files"
-          HINTS
           )
 
 if (CMAKE_GENERATOR MATCHES "Visual Studio.*Win64" )

--- a/utils/TableGen/AsmWriterEmitter.cpp
+++ b/utils/TableGen/AsmWriterEmitter.cpp
@@ -763,7 +763,7 @@ static unsigned CountNumOperands(StringRef AsmString, unsigned Variant) {
 namespace {
 struct AliasPriorityComparator {
   typedef std::pair<CodeGenInstAlias *, int> ValueType;
-  bool operator()(const ValueType &LHS, const ValueType &RHS) {
+  bool operator()(const ValueType &LHS, const ValueType &RHS) const {
     if (LHS.second ==  RHS.second) {
       // We don't actually care about the order, but for consistency it
       // shouldn't depend on pointer comparisons.


### PR DESCRIPTION
Use vswhere when possible to locate the VS install.  This enables VS to be found when it isn't on the C drive.
  - Also mark a function const as 2019's STL doesn't like putting it in a map if it isn't.