### PR TITLE
[spirv] spirv-val scalar-block-layout for dx/scalar layout

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -210,7 +210,7 @@ bool spirvToolsValidate(spv_target_env env, const SpirvCodeGenOptions &opts,
   // VK: relaxed block layout rules
   // DX: Skip block layout rules
   if (opts.useScalarLayout || opts.useDxLayout) {
-    options.SetSkipBlockLayout(true);
+    options.SetScalarBlockLayout(true);
   } else if (opts.useGlLayout) {
     // spirv-val by default checks this.
   } else {


### PR DESCRIPTION
If -fvk-use-dx-layout or -fvk-use-scalar-layout option is given,
we use dx or scalar memory layout that must follow
scalarBlockLayout feature of Vulkan memory layout rule. This commit
lets dx/scalar layout use SPIR-V validator with
--scalar-block-layout option.

Fixes #2408 