### PR TITLE
Fix call to OptTable::PrintHelp

### DIFF
--- a/tools/clang/lib/Driver/Driver.cpp
+++ b/tools/clang/lib/Driver/Driver.cpp
@@ -746,7 +746,7 @@ void Driver::PrintHelp(bool ShowHidden) const {
   if (!ShowHidden)
     ExcludedFlagsBitmask |= HelpHidden;
 
-  getOpts().PrintHelp(llvm::outs(), Name.c_str(), DriverTitle.c_str(),
+  getOpts().PrintHelp(llvm::outs(), Name.c_str(), DriverTitle.c_str(), "",
                       IncludedFlagsBitmask, ExcludedFlagsBitmask);
 }
 

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -900,7 +900,7 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
     if (dxcOpts.ShowHelp) {
       std::string helpString;
       llvm::raw_string_ostream helpStream(helpString);
-      optionTable->PrintHelp(helpStream, "dxc_bach.exe", "HLSL Compiler", "");
+      optionTable->PrintHelp(helpStream, "dxc_batch.exe", "HLSL Compiler", "");
       helpStream << "multi-thread";
       helpStream.flush();
       dxc::WriteUtf8ToConsoleSizeT(helpString.data(), helpString.size());


### PR DESCRIPTION
The call to `OptTable::PrintHelp` in Driver.cpp takes 6 arguments.
https://github.com/microsoft/DirectXShaderCompiler/blob/c25c44dabf9c18269966ccf9d82b99b956b73faa/include/llvm/Option/OptTable.h#L166-L168 