### PR TITLE
Fix a crash when no identifier name provided for constant buffer

### DIFF
--- a/tools/clang/lib/Parse/ParseHLSL.cpp
+++ b/tools/clang/lib/Parse/ParseHLSL.cpp
@@ -102,6 +102,12 @@ Decl *Parser::ParseConstBuffer(unsigned Context, SourceLocation &DeclEnd,
   Actions.ActOnStartHLSLBufferView();
   Parser::DeclGroupPtrTy dcl = ParseDeclGroup(PDS, Declarator::FileContext);
 
+  // If parsing of decl group fails, then decl group must have been illformed. Bail out!
+  // Note that we don't have to generate any diagnostics here as it was already
+  // generated previously in ParseDirectDeclarator().
+  if (!dcl)
+    return nullptr;
+
   // Check if the register type is valid
   NamedDecl *namedDecl = cast<NamedDecl>(dcl.get().getSingleDecl());
   ArrayRef<hlsl::UnusualAnnotation*> annotations = namedDecl->getUnusualAnnotations();

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/missing_identifier_name_objects.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/missing_identifier_name_objects.hlsl
@@ -1,0 +1,34 @@
+
+// This test checks that when identifier name is missing for various object types,
+// dxcompiler generates error and no crashes are observed.
+
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+// CHECK: error: expected unqualified-id
+
+struct S
+{
+    float foo;
+};
+
+Buffer<float4> : register(b0);
+ByteAddressBuffer : register(b0);
+Texture2D<float4> : register(t0);
+ConstantBuffer<S> : register(b0);
+StructuredBuffer<S> : register(b0);
+RWTexture1D<float4> : register(b0);
+RWBuffer<float2> : register(b0);
+TextureCube<float4> : register(b0);
+TextureCubeArray<float4> : register(b0);
+RWStructuredBuffer<int1x1> : register(b0);
+
+void main() {}


### PR DESCRIPTION
Fix a crash when no identifier name is provided to ConstantBuffer decl.

Fixes #2471