### PR TITLE
Fix the HLSL_VERSION_LOCATION when build DXC in a parent project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 
 option(HLSL_EMBED_VERSION "If set, embeds version information in the binaries." ON) # HLSL Change
 # HLSL Change - Directory with version.inc file used for the build (generated or copied from HLSL_FIXED_VERSION_LOCATION)
-set(HLSL_VERSION_LOCATION ${CMAKE_BINARY_DIR}\\utils\\version) 
+set(HLSL_VERSION_LOCATION ${CMAKE_CURRENT_BINARY_DIR}\\utils\\version)
 option(HLSL_OFFICIAL_BUILD "If set, embeds official version in the binaries (based on the latest release version)" OFF) # HLSL Change
 option(HLSL_ENABLE_FIXED_VER "Reads version information from a file." OFF) # HLSL Change
 
@@ -89,7 +89,7 @@ if (HLSL_ENABLE_FIXED_VER)
   set(HLSL_EMBED_VERSION ON)
   if (NOT DEFINED HLSL_FIXED_VERSION_LOCATION)
     # HLSL Change - Directory with fixed version.inc file
-    set(HLSL_FIXED_VERSION_LOCATION  ${CMAKE_SOURCE_DIR}\\utils\\version) 
+    set(HLSL_FIXED_VERSION_LOCATION  ${CMAKE_CURRENT_SOURCE_DIR}\\utils\\version)
   endif()
 endif()
 


### PR DESCRIPTION
When put DXC into a parent project, the CMAKE_BINARY_DIR and CMAKE_SOURCE_DIR are the paths of the parent project, makes HLSL_VERSION_LOCATION a wrong path. Change them to CMAKE_CURRENT_BINARY_DIR and CMAKE_CURRENT_SOURCE_DIR to locate the DXC's paths.