### PR TITLE
[spirv] spirv-val scalar-block-layout for unittests

### DIFF
--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -41,7 +41,7 @@ bool validateSpirvBinary(spv_target_env env, std::vector<uint32_t> &binary,
   spvtools::ValidatorOptions options;
   options.SetBeforeHlslLegalization(beforeHlslLegalization);
   if (dxLayout || scalarLayout) {
-    options.SetSkipBlockLayout(true);
+    options.SetScalarBlockLayout(true);
   } else if (glLayout) {
     // The default for spirv-val.
   } else {


### PR DESCRIPTION
This is a follow up commit of #2473 that uses scalar-block-layout
spirv-val option for dx/scalar layout. I forgot to apply the same
thing for unittests.