### PR TITLE
[spirv] Invariant position flag

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -339,6 +339,8 @@ def fvk_use_dx_position_w: Flag<["-"], "fvk-use-dx-position-w">, Group<spirv_Gro
   HelpText<"Reciprocate SV_Position.w after reading from stage input in PS to accommodate the difference between Vulkan and DirectX">;
 def fvk_support_nonzero_base_instance: Flag<["-"], "fvk-support-nonzero-base-instance">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Follow Vulkan spec to use gl_BaseInstance as the first vertex instance, which makes SV_InstanceID = gl_InstanceIndex - gl_BaseInstance (without this option, SV_InstanceID = gl_InstanceIndex)">;
+def fvk_invariant_position: Flag<["-"], "fvk-invariant-position">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Apply the invariant decorator to interpolators with the SV_Position semantic.">;
 def fvk_use_gl_layout: Flag<["-"], "fvk-use-gl-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Use strict OpenGL std140/std430 memory layout for Vulkan resources">;
 def fvk_use_dx_layout: Flag<["-"], "fvk-use-dx-layout">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -52,6 +52,7 @@ struct SpirvCodeGenOptions {
   bool enableReflect;
   bool invertY; // Additive inverse
   bool invertW; // Multiplicative inverse
+  bool invariantPosition;
   bool noWarnEmulatedFeatures;
   bool noWarnIgnoredFeatures;
   bool useDxLayout;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -953,6 +953,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.invertW = Args.hasFlag(OPT_fvk_use_dx_position_w, OPT_INVALID, false);
   opts.SpirvOptions.supportNonzeroBaseInstance =
       Args.hasFlag(OPT_fvk_support_nonzero_base_instance, OPT_INVALID, false);
+  opts.SpirvOptions.invariantPosition = Args.hasFlag(OPT_fvk_invariant_position, OPT_INVALID, false);
   opts.SpirvOptions.useGlLayout = Args.hasFlag(OPT_fvk_use_gl_layout, OPT_INVALID, false);
   opts.SpirvOptions.useDxLayout = Args.hasFlag(OPT_fvk_use_dx_layout, OPT_INVALID, false);
   opts.SpirvOptions.useScalarLayout = Args.hasFlag(OPT_fvk_use_scalar_layout, OPT_INVALID, false);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1348,6 +1348,14 @@ SpirvVariable *SpirvBuilder::addStageBuiltinVar(QualType type,
       loc, var, spv::Decoration::BuiltIn, {static_cast<uint32_t>(builtin)});
   mod->addDecoration(decor);
 
+  // If the setting is enabled, Position is additionally decorated with Invariant.
+  if (spirvOptions.invariantPosition && builtin == spv::BuiltIn::Position)
+  {
+    auto *invariantDecor = new (context) SpirvDecoration(
+        loc, var, spv::Decoration::Invariant);
+    module->addDecoration(invariantDecor);
+  }
+
   // Add variable to cache.
   builtinVars.emplace_back(storageClass, builtin, var);
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1353,7 +1353,7 @@ SpirvVariable *SpirvBuilder::addStageBuiltinVar(QualType type,
   {
     auto *invariantDecor = new (context) SpirvDecoration(
         loc, var, spv::Decoration::Invariant);
-    module->addDecoration(invariantDecor);
+    mod->addDecoration(invariantDecor);
   }
 
   // Add variable to cache.


### PR DESCRIPTION
Hi, this change adds a new flag `-fvk-invariant-position`, which addresses an issue when transcoding to MSL via SPIRV-Cross.

When forward rendering using a depth prepass, if the SV_Position export of the prepass and lit shaders are optimized differently by the compiler then depth fighting can result. 

MSL v2.1+ supports a `[[position, invariant]]` semantic which forces the compiler to avoid optimizations which could introduce this problem, and SPIRV-Cross emits this semantic when it detects the `Invariant` decorator on `gl_Position`. However, DXC never emits the `Invariant` decorator.

This flag causes the `Invariant` decorator to be automatically added to `gl_Position`, fixing the problem.

Another approach I considered was to use the presence of the `precise` flag on the position export as an indicator that invariance is desired. This would open it up to other exports, although that would require further work in SPIRV-Cross. 

In our shaders, we simply assign clip space position to a `precise` temporary before assigning to `SV_Position` and that is sufficient, but I don't think it would be straightforward to expose that to MSL, and this seemed like the more appropriate fix.