### PR TITLE
Reflection: Remove code preventing more than one SV_ClipDistance

### DIFF
--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1834,16 +1834,8 @@ static uint8_t NegMask(uint8_t V) {
 void DxilShaderReflection::CreateReflectionObjectsForSignature(
   const DxilSignature &Sig,
   std::vector<D3D12_SIGNATURE_PARAMETER_DESC> &Descs) {
-  bool clipDistanceSeen = false;
   for (auto && SigElem : Sig.GetElements()) {
     D3D12_SIGNATURE_PARAMETER_DESC Desc;
-
-    // TODO: why do we have multiple SV_ClipDistance elements?
-    if (SigElem->GetSemantic()->GetKind() == DXIL::SemanticKind::ClipDistance) {
-      if (clipDistanceSeen) continue;
-      clipDistanceSeen = true;
-    }
-
     Desc.ComponentType = CompTypeToRegisterComponentType(SigElem->GetCompType());
     Desc.Mask = SigElem->GetColsAsMask();
     // D3D11_43 does not have MinPrecison.

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/clip-dist-refl.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/clip-dist-refl.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -E MainVp -T vs_6_0 %s | %D3DReflect %s | FileCheck %s
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK: OutputParameters: 2
+
+void MainVp (out float4 rw_sv_clipdistance : SV_ClipDistance,
+             out float4 rw_sv_clipdistance1 : SV_ClipDistance1)
+{
+   rw_sv_clipdistance = float4(0.0, 0.0, 0.0, 0.0);
+   rw_sv_clipdistance1 = float4(0.0, 0.0, 0.0, 0.0);
+}


### PR DESCRIPTION
No idea why this was here, but it was very old (predates GitHub repo),
and no tests failed when I removed it, so I think it's fine to remove.

Fixes #2540.