### PR TITLE
PIX DIA: Use min/max RVA of variable's uses as live range

### DIFF
--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -1797,8 +1797,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
   //     if scope not in end_of_scope:
   //       end_of_scope[scope] = rva(I)
   //     if I is dbg.declare:
-  //       live_range[symbol of I] = SymbolManager.LiveRange[FirstUseRVA,
-  //       end_of_scope[scope]]
+  //       live_range[symbol of I] = SymbolManager.LiveRange[FirstUseRVA, end_of_scope[scope]]
   llvm::Module *M = &m_Session.ModuleRef();
   m_SymToLR.clear();
   const auto &Instrs = m_Session.InstructionsRef();

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -39,42 +39,42 @@ namespace hlsl_symbols {
 
 // HLSL Symbol Hierarchy
 // ---- ------ ---------
-//
+// 
 //                                  +---------------+
-//                                  | Program (EXE) | Global Scope
+//                                  | Program (EXE) |                                   Global Scope
 //                                  +------+--------+
 //                                         |
 //                                +--------^-----------+
-//                                | Compiland (Shader) | Compilation Unit
+//                                | Compiland (Shader) |                                Compilation Unit
 //                                +--------+-----------+
 //                                         |
 //      +------------+------------+--------+-------+------------+--------------+
-//      |            |            |        |       |            |              |
-// +----^----+   +---^---+   +----^---+    |   +---^---+   +----^----+
-// +-----^-----+ | Details |   | Flags |   | Target |    |   | Entry |   |
-// Defines |   | Arguments |  Synthetic Symbols
-// +---------+   +-------+   +--------+    |   +-------+   +---------+
-// +-----------+
+//      |            |            |        |       |            |              |        
+// +----^----+   +---^---+   +----^---+    |   +---^---+   +----^----+   +-----^-----+
+// | Details |   | Flags |   | Target |    |   | Entry |   | Defines |   | Arguments |  Synthetic Symbols
+// +---------+   +-------+   +--------+    |   +-------+   +---------+   +-----------+
 //                                         |
 //                                         |
 //       +---------------+------------+----+-----+-------------+-----------+
-//       |               |            |          |             |           |
+//       |               |            |          |             |           | 
 // +-----^-----+   +-----^-----+   +--^--+   +---^--+      +---^--+     +--^--+
-// | Function0 |   | Function1 |   | ... |   | UDT0 |      | UDT1 |     | ... |
-// Source Symbols
+// | Function0 |   | Function1 |   | ... |   | UDT0 |      | UDT1 |     | ... |         Source Symbols
 // +-----+-----+   +-----+-----+   +-----+   +---+--+      +---+--+     +-----+
 //       |               |                       |             |
 //  +----^----+     +----^----+             +----^----+   +----^----+
 //  | Locals0 |     | Locals1 |             | Fields0 |   | Fields1 |
 //  +---------+     +---------+             +---------+   +---------+
 
-static const std::string &DxilEntryName(Session *pSession);
+static const std::string & DxilEntryName(Session *pSession);
 
-template <
-    typename S, typename... C,
-    typename = typename std::enable_if<!std::is_same<Symbol, S>::value>::type>
-HRESULT AllocAndInit(IMalloc *pMalloc, Session *pSession, DWORD dwIndex,
-                     DWORD dwSymTag, S **ppSymbol, C... ctorArgs) {
+template <typename S, typename... C, typename = typename std::enable_if<!std::is_same<Symbol, S>::value>::type>
+HRESULT AllocAndInit(
+  IMalloc *pMalloc,
+  Session *pSession,
+  DWORD dwIndex,
+  DWORD dwSymTag,
+  S **ppSymbol,
+  C... ctorArgs) {
   *ppSymbol = S::Alloc(pMalloc, ctorArgs...);
   if (*ppSymbol == nullptr) {
     return E_OUTOFMEMORY;
@@ -84,26 +84,29 @@ HRESULT AllocAndInit(IMalloc *pMalloc, Session *pSession, DWORD dwIndex,
   return S_OK;
 }
 
-template <typename T, typename R> T *dyn_cast_to_ditype(R ref) {
-  return llvm::dyn_cast<T>((llvm::Metadata *)ref);
+template <typename T, typename R>
+T *dyn_cast_to_ditype(R ref) {
+  return llvm::dyn_cast<T>((llvm::Metadata *) ref);
 }
 
-template <typename T, typename R> T *dyn_cast_to_ditype_or_null(R ref) {
-  return llvm::dyn_cast_or_null<T>((llvm::Metadata *)ref);
+template <typename T, typename R>
+T *dyn_cast_to_ditype_or_null(R ref) {
+  return llvm::dyn_cast_or_null<T>((llvm::Metadata *) ref);
 }
 
-template <typename N> struct DISymbol : public Symbol {
+template <typename N>
+struct DISymbol : public Symbol {
   DISymbol(IMalloc *M, N Node) : Symbol(M), m_pNode(Node) {}
 
   N m_pNode;
 };
 
-template <typename N> struct TypedSymbol : public DISymbol<N> {
-  TypedSymbol(IMalloc *M, N Node, DWORD dwTypeID, llvm::DIType *Type)
-      : DISymbol(M, Node), m_dwTypeID(dwTypeID), m_pType(Type) {}
+template <typename N>
+struct TypedSymbol : public DISymbol<N> {
+  TypedSymbol(IMalloc *M, N Node, DWORD dwTypeID, llvm::DIType *Type) : DISymbol(M, Node), m_dwTypeID(dwTypeID), m_pType(Type) {}
 
   STDMETHODIMP get_type(
-      /* [retval][out] */ IDiaSymbol **ppRetVal) override {
+    /* [retval][out] */ IDiaSymbol **ppRetVal) override {
     if (ppRetVal == nullptr) {
       return E_INVALIDARG;
     }
@@ -134,42 +137,40 @@ struct GlobalScopeSymbol : public Symbol {
 namespace symbol_factory {
 class GlobalScope final : public SymbolManager::SymbolFactory {
 public:
-  GlobalScope(DWORD ID, DWORD ParentID)
-      : SymbolManager::SymbolFactory(ID, ParentID) {}
+    GlobalScope(DWORD ID, DWORD ParentID)
+        : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    return hlsl_symbols::GlobalScopeSymbol::Create(pMalloc, pSession, ppRet);
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        return hlsl_symbols::GlobalScopeSymbol::Create(pMalloc, pSession, ppRet);
+    }
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct CompilandSymbol : public DISymbol<llvm::DICompileUnit *> {
   DXC_MICROCOM_TM_ALLOC(CompilandSymbol)
-  explicit CompilandSymbol(IMalloc *M, llvm::DICompileUnit *CU)
-      : DISymbol<llvm::DICompileUnit *>(M, CU) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession,
-                        llvm::DICompileUnit *CU, Symbol **ppSym);
+  explicit CompilandSymbol(IMalloc *M, llvm::DICompileUnit *CU) : DISymbol<llvm::DICompileUnit *>(M, CU) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, llvm::DICompileUnit *CU, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class Compiland final : public SymbolManager::SymbolFactory {
 public:
-  Compiland(DWORD ID, DWORD ParentID, llvm::DICompileUnit *CU)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_CU(CU) {}
+    Compiland(DWORD ID, DWORD ParentID, llvm::DICompileUnit *CU)
+        : SymbolManager::SymbolFactory(ID, ParentID), m_CU(CU) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(hlsl_symbols::CompilandSymbol::Create(pMalloc, pSession, m_CU, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(hlsl_symbols::CompilandSymbol::Create(pMalloc, pSession, m_CU, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 
 private:
-  llvm::DICompileUnit *m_CU;
+    llvm::DICompileUnit *m_CU;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct CompilandDetailsSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(CompilandDetailsSymbol)
@@ -190,14 +191,14 @@ struct CompilandDetailsSymbol : public Symbol {
 // be static (thus requiring the explicit <this> parameter) so that
 // DEFINE_SIMPLE_GETTER can use decltype(name(nullptr)) in order to
 // define the property parameter type.
-#define DEFINE_SIMPLE_GETTER(name)                                             \
-  STDMETHODIMP get_##name(decltype(name(nullptr)) *pValue) override {          \
-    if (pValue == nullptr) {                                                   \
-      return E_INVALIDARG;                                                     \
-    }                                                                          \
-    *pValue = name(this);                                                      \
-    return S_OK;                                                               \
-  }
+#define DEFINE_SIMPLE_GETTER(name)                                        \
+    STDMETHODIMP get_ ## name(decltype(name(nullptr)) *pValue) override { \
+      if (pValue == nullptr) {                                            \
+        return E_INVALIDARG;                                              \
+      }                                                                   \
+      *pValue = name(this);                                               \
+      return S_OK;                                                        \
+    }
 
   static constexpr DWORD platform(CompilandDetailsSymbol *) { return 256; }
   static constexpr DWORD language(CompilandDetailsSymbol *) { return 16; }
@@ -227,121 +228,107 @@ struct CompilandDetailsSymbol : public Symbol {
 namespace symbol_factory {
 class CompilandDetails final : public SymbolManager::SymbolFactory {
 public:
-  CompilandDetails(DWORD ID, DWORD ParentID)
-      : SymbolManager::SymbolFactory(ID, ParentID) {}
+    CompilandDetails(DWORD ID, DWORD ParentID)
+        : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(hlsl_symbols::CompilandDetailsSymbol::Create(pMalloc, pSession, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(hlsl_symbols::CompilandDetailsSymbol::Create(pMalloc, pSession, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct CompilandEnvSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(CompilandEnvSymbol)
   explicit CompilandEnvSymbol(IMalloc *M) : Symbol(M) {}
-  static HRESULT CreateFlags(IMalloc *pMalloc, Session *pSession,
-                             Symbol **ppSym);
-  static HRESULT CreateTarget(IMalloc *pMalloc, Session *pSession,
-                              Symbol **ppSym);
-  static HRESULT CreateEntry(IMalloc *pMalloc, Session *pSession,
-                             Symbol **ppSym);
-  static HRESULT CreateDefines(IMalloc *pMalloc, Session *pSession,
-                               Symbol **pSym);
-  static HRESULT CreateArguments(IMalloc *pMalloc, Session *pSession,
-                                 Symbol **ppSym);
+  static HRESULT CreateFlags(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
+  static HRESULT CreateTarget(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
+  static HRESULT CreateEntry(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
+  static HRESULT CreateDefines(IMalloc *pMalloc, Session *pSession, Symbol **pSym);
+  static HRESULT CreateArguments(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 using CompilandEnvCreateFn = HRESULT(IMalloc *, Session *, Symbol **);
-template <CompilandEnvCreateFn C>
+template<CompilandEnvCreateFn C>
 class CompilandEnv final : public SymbolManager::SymbolFactory {
 public:
-  CompilandEnv(DWORD ID, DWORD ParentID)
-      : SymbolManager::SymbolFactory(ID, ParentID) {}
+    CompilandEnv(DWORD ID, DWORD ParentID)
+        : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(C(pMalloc, pSession, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(C(pMalloc, pSession, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct FunctionSymbol : public TypedSymbol<llvm::DISubprogram *> {
   DXC_MICROCOM_TM_ALLOC(FunctionSymbol)
-  FunctionSymbol(IMalloc *M, llvm::DISubprogram *Node, DWORD dwTypeID,
-                 llvm::DIType *Type)
-      : TypedSymbol<llvm::DISubprogram *>(M, Node, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
-                        llvm::DISubprogram *Node, DWORD dwTypeID,
-                        llvm::DIType *Type, Symbol **ppSym);
+  FunctionSymbol(IMalloc *M, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DISubprogram *>(M, Node, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class Function final : public SymbolManager::SymbolFactory {
 public:
-  Function(DWORD ID, DWORD ParentID, llvm::DISubprogram *Node, DWORD TypeID)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_TypeID(TypeID) {}
+    Function(DWORD ID, DWORD ParentID, llvm::DISubprogram *Node, DWORD TypeID)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_TypeID(TypeID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(FunctionSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
-                               m_Node->getType(), ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(FunctionSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Node->getType(), ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+        return S_OK;
+    }
 
 private:
-  llvm::DISubprogram *m_Node;
-  DWORD m_TypeID;
+    llvm::DISubprogram *m_Node;
+    DWORD m_TypeID;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct FunctionBlockSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(FunctionBlockSymbol)
   explicit FunctionBlockSymbol(IMalloc *M) : Symbol(M) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
-                        Symbol **ppSym);
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class FunctionBlock final : public SymbolManager::SymbolFactory {
 public:
-  FunctionBlock(DWORD ID, DWORD ParentID)
-      : SymbolManager::SymbolFactory(ID, ParentID) {}
+    FunctionBlock(DWORD ID, DWORD ParentID)
+        : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(FunctionBlockSymbol::Create(pMalloc, pSession, m_ID, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(FunctionBlockSymbol::Create(pMalloc, pSession, m_ID, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct TypeSymbol : public DISymbol<llvm::DIType *> {
   using LazySymbolName = std::function<HRESULT(Session *, std::string *)>;
   DXC_MICROCOM_TM_ALLOC(TypeSymbol)
-  TypeSymbol(IMalloc *M, llvm::DIType *Node, LazySymbolName LazySymbolName)
-      : DISymbol<llvm::DIType *>(M, Node), m_lazySymbolName(LazySymbolName) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
-                        DWORD dwID, DWORD st, llvm::DIType *Node,
-                        LazySymbolName LazySymbolName, Symbol **ppSym);
+  TypeSymbol(IMalloc *M, llvm::DIType *Node, LazySymbolName LazySymbolName) : DISymbol<llvm::DIType *>(M, Node), m_lazySymbolName(LazySymbolName) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st, llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym);
   STDMETHODIMP get_name(
-      /* [retval][out] */ BSTR *pRetVal) override;
+    /* [retval][out] */ BSTR *pRetVal) override;
   STDMETHODIMP get_baseType(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_length(
-      /* [retval][out] */ ULONGLONG *pRetVal) override;
+    /* [retval][out] */ ULONGLONG *pRetVal) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 
@@ -351,36 +338,31 @@ struct TypeSymbol : public DISymbol<llvm::DIType *> {
 namespace symbol_factory {
 class Type final : public SymbolManager::SymbolFactory {
 public:
-  Type(DWORD ID, DWORD ParentID, DWORD st, llvm::DIType *Node,
-       TypeSymbol::LazySymbolName LazySymbolName)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_st(st), m_Node(Node),
-        m_LazySymbolName(LazySymbolName) {}
+    Type(DWORD ID, DWORD ParentID, DWORD st, llvm::DIType *Node, TypeSymbol::LazySymbolName LazySymbolName)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_st(st), m_Node(Node), m_LazySymbolName(LazySymbolName) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(TypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_st, m_Node,
-                           m_LazySymbolName, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(TypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_st, m_Node, m_LazySymbolName, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 
 private:
-  DWORD m_st;
-  llvm::DIType *m_Node;
-  TypeSymbol::LazySymbolName m_LazySymbolName;
+    DWORD m_st;
+    llvm::DIType *m_Node;
+    TypeSymbol::LazySymbolName m_LazySymbolName;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct TypedefTypeSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(TypedefTypeSymbol)
-  TypedefTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwBaseTypeID)
-      : TypeSymbol(M, Node, nullptr), m_dwBaseTypeID(dwBaseTypeID) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
-                        DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID,
-                        Symbol **ppSym);
+  TypedefTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwBaseTypeID) : TypeSymbol(M, Node, nullptr), m_dwBaseTypeID(dwBaseTypeID) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym);
 
   STDMETHODIMP get_type(
-      /* [retval][out] */ IDiaSymbol **ppRetVal) override;
+    /* [retval][out] */ IDiaSymbol **ppRetVal) override;
 
   const DWORD m_dwBaseTypeID;
 };
@@ -388,39 +370,33 @@ struct TypedefTypeSymbol : public TypeSymbol {
 namespace symbol_factory {
 class TypedefType final : public SymbolManager::SymbolFactory {
 public:
-  TypedefType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD BaseTypeID)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_BaseTypeID(BaseTypeID) {}
+    TypedefType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD BaseTypeID)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_BaseTypeID(BaseTypeID) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(TypedefTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
-                                  m_BaseTypeID, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(TypedefTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_BaseTypeID, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+        return S_OK;
+    }
 
 private:
-  llvm::DIType *m_Node;
-  DWORD m_BaseTypeID;
+    llvm::DIType *m_Node;
+    DWORD m_BaseTypeID;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct VectorTypeSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(VectorTypeSymbol)
-  VectorTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwElemTyID,
-                   std::uint32_t NumElts)
-      : TypeSymbol(M, Node, nullptr), m_ElemTyID(dwElemTyID),
-        m_NumElts(NumElts) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
-                        DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID,
-                        std::uint32_t NumElts, Symbol **ppSym);
+  VectorTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts) : TypeSymbol(M, Node, nullptr), m_ElemTyID(dwElemTyID), m_NumElts(NumElts) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts, Symbol **ppSym);
 
   STDMETHODIMP get_count(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_type(
-      /* [retval][out] */ IDiaSymbol **ppRetVal) override;
+    /* [retval][out] */ IDiaSymbol **ppRetVal) override;
 
   std::uint32_t m_ElemTyID;
   std::uint32_t m_NumElts;
@@ -429,121 +405,101 @@ struct VectorTypeSymbol : public TypeSymbol {
 namespace symbol_factory {
 class VectorType final : public SymbolManager::SymbolFactory {
 public:
-  VectorType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD ElemTyID,
-             std::uint32_t NumElts)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_ElemTyID(ElemTyID), m_NumElts(NumElts) {}
+    VectorType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD ElemTyID, std::uint32_t NumElts)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_ElemTyID(ElemTyID), m_NumElts(NumElts) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(VectorTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
-                                 m_ElemTyID, m_NumElts, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(VectorTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_ElemTyID, m_NumElts, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+        return S_OK;
+    }
 
 private:
-  llvm::DIType *m_Node;
-  DWORD m_ElemTyID;
-  std::uint32_t m_NumElts;
+    llvm::DIType *m_Node;
+    DWORD m_ElemTyID;
+    std::uint32_t m_NumElts;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct UDTSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(UDTSymbol)
-  UDTSymbol(IMalloc *M, llvm::DICompositeType *Node, LazySymbolName LazyName)
-      : TypeSymbol(M, Node, LazyName) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
-                        DWORD dwID, llvm::DICompositeType *Node,
-                        LazySymbolName LazySymbolName, Symbol **ppSym);
+  UDTSymbol(IMalloc *M, llvm::DICompositeType *Node, LazySymbolName LazyName) : TypeSymbol(M, Node, LazyName) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DICompositeType *Node, LazySymbolName LazySymbolName, Symbol **ppSym);
 };
 
 namespace symbol_factory {
 class UDT final : public SymbolManager::SymbolFactory {
 public:
-  UDT(DWORD ID, DWORD ParentID, llvm::DICompositeType *Node,
-      TypeSymbol::LazySymbolName LazySymbolName)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_LazySymbolName(LazySymbolName) {}
+    UDT(DWORD ID, DWORD ParentID, llvm::DICompositeType *Node, TypeSymbol::LazySymbolName LazySymbolName)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_LazySymbolName(LazySymbolName) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(UDTSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
-                          m_LazySymbolName, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(UDTSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_LazySymbolName, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        return S_OK;
+    }
 
 private:
-  llvm::DICompositeType *m_Node;
-  TypeSymbol::LazySymbolName m_LazySymbolName;
+    llvm::DICompositeType *m_Node;
+    TypeSymbol::LazySymbolName m_LazySymbolName;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct GlobalVariableSymbol : public TypedSymbol<llvm::DIGlobalVariable *> {
   DXC_MICROCOM_TM_ALLOC(GlobalVariableSymbol)
-  GlobalVariableSymbol(IMalloc *M, llvm::DIGlobalVariable *GV, DWORD dwTypeID,
-                       llvm::DIType *Type)
-      : TypedSymbol<llvm::DIGlobalVariable *>(M, GV, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
-                        llvm::DIGlobalVariable *GV, DWORD dwTypeID,
-                        llvm::DIType *Type, Symbol **ppSym);
+  GlobalVariableSymbol(IMalloc *M, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DIGlobalVariable *>(M, GV, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class GlobalVariable final : public SymbolManager::SymbolFactory {
 public:
-  GlobalVariable(DWORD ID, DWORD ParentID, llvm::DIGlobalVariable *GV,
-                 DWORD TypeID, llvm::DIType *Type)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_GV(GV), m_TypeID(TypeID),
-        m_Type(Type) {}
+    GlobalVariable(DWORD ID, DWORD ParentID, llvm::DIGlobalVariable *GV, DWORD TypeID, llvm::DIType *Type)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_GV(GV), m_TypeID(TypeID), m_Type(Type) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(GlobalVariableSymbol::Create(pMalloc, pSession, m_ID, m_GV, m_TypeID,
-                                     m_Type, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str()));
-    (*ppRet)->SetIsHLSLData(true);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(GlobalVariableSymbol::Create(pMalloc, pSession, m_ID, m_GV, m_TypeID, m_Type, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str()));
+        (*ppRet)->SetIsHLSLData(true);
+        return S_OK;
+    }
 
 private:
-  llvm::DIGlobalVariable *m_GV;
-  DWORD m_TypeID;
-  llvm::DIType *m_Type;
+    llvm::DIGlobalVariable *m_GV;
+    DWORD m_TypeID;
+    llvm::DIType *m_Type;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct LocalVariableSymbol : public TypedSymbol<llvm::DIVariable *> {
   DXC_MICROCOM_TM_ALLOC(LocalVariableSymbol)
-  LocalVariableSymbol(IMalloc *M, llvm::DIVariable *Node, DWORD dwTypeID,
-                      llvm::DIType *Type, DWORD dwOffsetInUDT,
-                      DWORD dwDxilRegNum)
-      : TypedSymbol<llvm::DIVariable *>(M, Node, dwTypeID, Type),
-        m_dwOffsetInUDT(dwOffsetInUDT), m_dwDxilRegNum(dwDxilRegNum) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
-                        llvm::DIVariable *Node, DWORD dwTypeID,
-                        llvm::DIType *Type, DWORD dwOffsetInUDT,
-                        DWORD m_dwDxilRegNum, Symbol **ppSym);
+  LocalVariableSymbol(IMalloc *M, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum) : TypedSymbol<llvm::DIVariable *>(M, Node, dwTypeID, Type), m_dwOffsetInUDT(dwOffsetInUDT), m_dwDxilRegNum(dwDxilRegNum) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD m_dwDxilRegNum, Symbol **ppSym);
   STDMETHODIMP get_locationType(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_isAggregated(
-      /* [retval][out] */ BOOL *pRetVal) override;
+    /* [retval][out] */ BOOL *pRetVal) override;
   STDMETHODIMP get_registerType(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_offsetInUdt(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_sizeInUdt(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_numberOfRegisterIndices(
-      /* [retval][out] */ DWORD *pRetVal) override;
+    /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_numericProperties(
-      /* [in] */ DWORD cnt,
-      /* [out] */ DWORD *pcnt,
-      /* [size_is][out] */ DWORD *pProperties) override;
+    /* [in] */ DWORD cnt,
+    /* [out] */ DWORD *pcnt,
+    /* [size_is][out] */ DWORD *pProperties) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 
@@ -574,44 +530,33 @@ private:
 
 class LocalVariable final : public SymbolManager::SymbolFactory {
 public:
-  LocalVariable(DWORD ID, DWORD ParentID, llvm::DIVariable *Node, DWORD TypeID,
-                llvm::DIType *Type, std::shared_ptr<LocalVarInfo> VI)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_TypeID(TypeID), m_Type(Type), m_VI(VI) {}
+    LocalVariable(DWORD ID, DWORD ParentID, llvm::DIVariable *Node, DWORD TypeID, llvm::DIType *Type, std::shared_ptr<LocalVarInfo> VI)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_TypeID(TypeID), m_Type(Type), m_VI(VI) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(LocalVariableSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
-                                    m_Type, m_VI->GetOffsetInUDT(),
-                                    m_VI->GetDxilRegister(), ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-    (*ppRet)->SetDataKind(m_Node->getTag() == llvm::dwarf::DW_TAG_arg_variable
-                              ? DataIsParam
-                              : DataIsLocal);
-    return S_OK;
-  }
-
-  llvm::DIVariable *Node() const { return m_Node; }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(LocalVariableSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Type, m_VI->GetOffsetInUDT(), m_VI->GetDxilRegister(), ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+        (*ppRet)->SetDataKind(m_Node->getTag() == llvm::dwarf::DW_TAG_arg_variable ? DataIsParam : DataIsLocal);
+        return S_OK;
+    }
 
 private:
-  llvm::DIVariable *m_Node;
-  DWORD m_TypeID;
-  llvm::DIType *m_Type;
-  std::shared_ptr<LocalVarInfo> m_VI;
+    llvm::DIVariable *m_Node;
+    DWORD m_TypeID;
+    llvm::DIType *m_Type;
+    std::shared_ptr<LocalVarInfo> m_VI;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 struct UDTFieldSymbol : public TypedSymbol<llvm::DIDerivedType *> {
   DXC_MICROCOM_TM_ALLOC(UDTFieldSymbol)
-  UDTFieldSymbol(IMalloc *M, llvm::DIDerivedType *Node, DWORD dwTypeID,
-                 llvm::DIType *Type)
-      : TypedSymbol<llvm::DIDerivedType *>(M, Node, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
-                        llvm::DIDerivedType *Node, DWORD dwTypeID,
-                        llvm::DIType *Type, Symbol **ppSym);
+  UDTFieldSymbol(IMalloc *M, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DIDerivedType *>(M, Node, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
   STDMETHODIMP get_offset(
-      /* [retval][out] */ LONG *pRetVal) override;
+    /* [retval][out] */ LONG *pRetVal) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
@@ -619,33 +564,29 @@ struct UDTFieldSymbol : public TypedSymbol<llvm::DIDerivedType *> {
 namespace symbol_factory {
 class UDTField final : public SymbolManager::SymbolFactory {
 public:
-  UDTField(DWORD ID, DWORD ParentID, llvm::DIDerivedType *Node, DWORD TypeID,
-           llvm::DIType *Type)
-      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
-        m_TypeID(TypeID), m_Type(Type) {}
+    UDTField(DWORD ID, DWORD ParentID, llvm::DIDerivedType *Node, DWORD TypeID, llvm::DIType *Type)
+        : SymbolManager::SymbolFactory(ID, ParentID),
+          m_Node(Node), m_TypeID(TypeID), m_Type(Type) {}
 
-  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-    IMalloc *pMalloc = pSession->GetMallocNoRef();
-    IFR(UDTFieldSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
-                               m_Type, ppRet));
-    (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-    (*ppRet)->SetDataKind(m_Node->isStaticMember() ? DataIsStaticLocal
-                                                   : DataIsMember);
-    return S_OK;
-  }
+    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+        IMalloc *pMalloc = pSession->GetMallocNoRef();
+        IFR(UDTFieldSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Type, ppRet));
+        (*ppRet)->SetLexicalParent(m_ParentID);
+        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+        (*ppRet)->SetDataKind(m_Node->isStaticMember() ? DataIsStaticLocal : DataIsMember);
+        return S_OK;
+    }
 
 private:
-  llvm::DIDerivedType *m_Node;
-  DWORD m_TypeID;
-  llvm::DIType *m_Type;
+    llvm::DIDerivedType *m_Node;
+    DWORD m_TypeID;
+    llvm::DIType *m_Type;
 };
-} // namespace symbol_factory
+}  // namespace symbol_factory
 
 class SymbolManagerInit {
 public:
-  using SymbolCtor =
-      std::function<HRESULT(Session *pSession, DWORD ID, Symbol **ppSym)>;
+  using SymbolCtor = std::function<HRESULT(Session *pSession, DWORD ID, Symbol **ppSym)>;
 
   using LazySymbolName = TypeSymbol::LazySymbolName;
 
@@ -670,8 +611,7 @@ public:
     std::vector<llvm::DIType *> m_Layout;
     DWORD m_dwCurrentSizeInBytes = 0;
   };
-  using TypeToInfoMap =
-      llvm::DenseMap<llvm::DIType *, std::unique_ptr<TypeInfo>>;
+  using TypeToInfoMap = llvm::DenseMap<llvm::DIType *, std::unique_ptr<TypeInfo> >;
 
   // Because of the way the VarToID map is constructed, the
   // vector<LocalVarInfo> may need to grow. The Symbol Constructor for local
@@ -687,23 +627,22 @@ public:
   using UDTFieldToIDMap = llvm::DenseMap<llvm::DIDerivedType *, DWORD>;
 
   SymbolManagerInit(
-      Session *pSession,
-      std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
-      SymbolManager::ScopeToIDMap *pScopeToSym,
-      SymbolManager::IDToLiveRangeMap *pSymToLR);
+    Session *pSession,
+    std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
+    SymbolManager::ScopeToIDMap *pScopeToSym,
+    SymbolManager::IDToLiveRangeMap *pSymToLR);
 
   template <typename Factory, typename... Args>
-  HRESULT AddSymbol(DWORD dwParentID, DWORD *pNewSymID, Args &&... args) {
-    if (dwParentID > m_SymCtors.size()) {
-      return E_FAIL;
-    }
+  HRESULT AddSymbol(DWORD dwParentID, DWORD *pNewSymID, Args&&... args) {
+      if (dwParentID > m_SymCtors.size()) {
+          return E_FAIL;
+      }
 
-    const DWORD dwNewSymID = m_SymCtors.size() + 1;
-    m_SymCtors.emplace_back(std::unique_ptr<Factory>(
-        new Factory(dwNewSymID, dwParentID, std::forward<Args>(args)...)));
-    *pNewSymID = dwNewSymID;
-    IFR(AddParent(dwParentID));
-    return S_OK;
+      const DWORD dwNewSymID = m_SymCtors.size() + 1;
+      m_SymCtors.emplace_back(std::unique_ptr<Factory>(new Factory(dwNewSymID, dwParentID, std::forward<Args>(args)...)));
+      *pNewSymID = dwNewSymID;
+      IFR(AddParent(dwParentID));
+      return S_OK;
   }
 
   HRESULT CreateFunctionsForAllCUs();
@@ -713,50 +652,40 @@ public:
   HRESULT IsDbgDeclareCall(llvm::Module *M, const llvm::Instruction *I,
                            DWORD *pReg, DWORD *pRegSize,
                            llvm::DILocalVariable **LV, uint64_t *pStartOffset,
-                           uint64_t *pEndOffset, dxil_dia::Session::RVA *pLowestUserRVA,
-                           dxil_dia::Session::RVA *pHighestUserRVA );
+                           uint64_t *pEndOffset,
+                           dxil_dia::Session::RVA *pLowestUserRVA,
+                           dxil_dia::Session::RVA *pHighestUserRVA);
   HRESULT GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum,
                                 DWORD *pRegSize);
-  HRESULT PopulateParentToChildrenIDMap(
-      SymbolManager::ParentToChildrenMap *pParentToChildren);
+  HRESULT PopulateParentToChildrenIDMap(SymbolManager::ParentToChildrenMap *pParentToChildren);
 
 private:
   HRESULT GetTypeInfo(llvm::DIType *T, TypeInfo **TI);
 
-  template <typename Factory, typename... Args>
-  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID,
-                  Args &&... args) {
-    IFR(AddSymbol<Factory>(dwParentID, pNewSymID, std::forward<Args>(args)...));
-    if (!m_TypeToInfo
-             .insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID)))
-             .second) {
-      return E_FAIL;
-    }
-    return S_OK;
+  template<typename Factory, typename... Args>
+  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID, Args&&... args) {
+      IFR(AddSymbol<Factory>(dwParentID, pNewSymID, std::forward<Args>(args)...));
+      if (!m_TypeToInfo.insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID))).second) {
+          return E_FAIL;
+      }
+      return S_OK;
   }
 
   HRESULT AddParent(DWORD dwParentIndex);
-  HRESULT CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS,
-                                           DWORD *pNewSymID);
+  HRESULT CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS, DWORD *pNewSymID);
   HRESULT CreateFunctionBlockForInstruction(llvm::Instruction *I);
   HRESULT CreateFunctionBlocksForFunction(llvm::Function *F);
   HRESULT CreateFunctionsForCU(llvm::DICompileUnit *CU);
   HRESULT CreateGlobalVariablesForCU(llvm::DICompileUnit *CU);
   HRESULT GetScopeID(llvm::DIScope *S, DWORD *pScopeID);
   HRESULT CreateType(llvm::DIType *T, DWORD *pNewTypeID);
-  HRESULT CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST,
-                               DWORD *pNewTypeID);
-  HRESULT CreateBasicType(DWORD dwParentID, llvm::DIBasicType *VT,
-                          DWORD *pNewTypeID);
-  HRESULT CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT,
-                              DWORD *pNewTypeID);
+  HRESULT CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID);
+  HRESULT CreateBasicType(DWORD dwParentID, llvm::DIBasicType *VT, DWORD *pNewTypeID);
+  HRESULT CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID);
   HRESULT CreateHLSLType(llvm::DICompositeType *T, DWORD *pNewTypeID);
-  HRESULT IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID,
-                           std::uint32_t *pElemCnt);
-  HRESULT CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID,
-                               std::uint32_t pElemCnt, DWORD *pNewTypeID);
-  HRESULT HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT,
-                            DWORD *pNewTypeID);
+  HRESULT IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt);
+  HRESULT CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt, DWORD *pNewTypeID);
+  HRESULT HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID);
   HRESULT CreateLocalVariable(DWORD dwParentID, llvm::DILocalVariable *LV);
   HRESULT GetTypeLayout(llvm::DIType *Ty, std::vector<DWORD> *pRet);
   HRESULT CreateUDTField(DWORD dwParentID, llvm::DIDerivedType *Field);
@@ -796,13 +725,14 @@ private:
   UDTScope BeginUDTScope(TypeInfo *pNext) {
     return UDTScope(&m_pCurUDT, pNext);
   }
+
 };
 
-} // namespace hlsl_symbols
-} // namespace dxil_dia
+}  // namespace hlsl_symbols
+}  // namespace dxil_dia
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -812,17 +742,13 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
     const DWORD SizeInBits = BT->getSizeInBits();
     switch (BT->getEncoding()) {
     case llvm::dwarf::DW_ATE_boolean:
-      *pRetVal = btBool;
-      break;
+      *pRetVal = btBool; break;
     case llvm::dwarf::DW_ATE_unsigned:
-      *pRetVal = btUInt;
-      break;
+      *pRetVal = btUInt; break;
     case llvm::dwarf::DW_ATE_signed:
-      *pRetVal = btInt;
-      break;
+      *pRetVal = btInt; break;
     case llvm::dwarf::DW_ATE_float:
-      *pRetVal = btFloat;
-      break;
+      *pRetVal = btFloat; break;
     }
   }
 
@@ -830,7 +756,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_length(
-    /* [retval][out] */ ULONGLONG *pRetVal) {
+  /* [retval][out] */ ULONGLONG *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -845,103 +771,75 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_length(
   return S_OK;
 }
 
-static const std::string &
-dxil_dia::hlsl_symbols::DxilEntryName(Session *pSession) {
+static const std::string &dxil_dia::hlsl_symbols::DxilEntryName(Session *pSession) {
   return pSession->DxilModuleRef().GetEntryFunctionName();
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::Create(IMalloc *pMalloc,
-                                                          Session *pSession,
-                                                          Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslProgramId, SymTagExe,
-                   (GlobalScopeSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::Create(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslProgramId, SymTagExe, (GlobalScopeSymbol**)ppSym));
   (*ppSym)->SetName(L"HLSL");
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::Create(IMalloc *pMalloc,
-                                                        Session *pSession,
-                                                        llvm::DICompileUnit *CU,
-                                                        Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandId, SymTagCompiland,
-                   (CompilandSymbol **)ppSym, CU));
+HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::Create(IMalloc *pMalloc, Session *pSession, llvm::DICompileUnit *CU, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandId, SymTagCompiland, (CompilandSymbol**)ppSym, CU));
   (*ppSym)->SetName(L"main");
   if (pSession->MainFileName()) {
-    llvm::StringRef strRef =
-        llvm::dyn_cast<llvm::MDString>(
-            pSession->MainFileName()->getOperand(0)->getOperand(0))
-            ->getString();
-    std::string str(strRef.begin(),
-                    strRef.size()); // To make sure str is null terminated
-    (*ppSym)->SetSourceFileName(
-        _bstr_t(Unicode::UTF8ToUTF16StringOrThrow(str.data()).c_str()));
+    llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(pSession->MainFileName()->getOperand(0)->getOperand(0))->getString();
+    std::string str(strRef.begin(), strRef.size()); // To make sure str is null terminated
+    (*ppSym)->SetSourceFileName(_bstr_t(Unicode::UTF8ToUTF16StringOrThrow(str.data()).c_str()));
   }
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandDetailsId,
-                   SymTagCompilandDetails, (CompilandDetailsSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::Create(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandDetailsId, SymTagCompilandDetails, (CompilandDetailsSymbol**)ppSym));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateFlags(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvFlagsId,
-                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateFlags(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvFlagsId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
   (*ppSym)->SetName(L"hlslFlags");
   (*ppSym)->SetValue(pSession->DxilModuleRef().GetGlobalFlags());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateTarget(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvTargetId,
-                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateTarget(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvTargetId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
   (*ppSym)->SetName(L"hlslTarget");
   (*ppSym)->SetValue(pSession->DxilModuleRef().GetShaderModel()->GetName());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateEntry(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvEntryId,
-                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateEntry(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvEntryId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
   (*ppSym)->SetName(L"hlslEntry");
   (*ppSym)->SetValue(DxilEntryName(pSession).c_str());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvDefinesId,
-                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvDefinesId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
   (*ppSym)->SetName(L"hlslDefines");
   llvm::MDNode *definesNode = pSession->Defines()->getOperand(0);
-  // Construct a double null terminated string for defines with L"\0" as a
-  // delimiter
+  // Construct a double null terminated string for defines with L"\0" as a delimiter
   CComBSTR pBSTR;
-  for (llvm::MDNode::op_iterator it = definesNode->op_begin();
-       it != definesNode->op_end(); ++it) {
+  for (llvm::MDNode::op_iterator it = definesNode->op_begin(); it != definesNode->op_end(); ++it) {
     llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(*it)->getString();
     std::string str(strRef.begin(), strRef.size());
     CA2W cv(str.c_str());
@@ -956,17 +854,14 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(
-    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvArgumentsId,
-                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvArgumentsId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
   (*ppSym)->SetName(L"hlslArguments");
   auto Arguments = pSession->Arguments()->getOperand(0);
   auto NumArguments = Arguments->getNumOperands();
   std::string args;
   for (unsigned i = 0; i < NumArguments; ++i) {
-    llvm::StringRef strRef =
-        llvm::dyn_cast<llvm::MDString>(Arguments->getOperand(i))->getString();
+    llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(Arguments->getOperand(i))->getString();
     if (!args.empty())
       args.push_back(' ');
     args = args + strRef.str();
@@ -975,49 +870,36 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node,
-    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagFunction,
-                   (FunctionSymbol **)ppSym, Node, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagFunction, (FunctionSymbol**)ppSym, Node, dwTypeID, Type));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::Create(IMalloc *pMalloc,
-                                                            Session *pSession,
-                                                            DWORD dwID,
-                                                            Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagBlock,
-                   (FunctionBlockSymbol **)ppSym));
+HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagBlock, (FunctionBlockSymbol**)ppSym));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypeSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st,
-    llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, st, (TypeSymbol **)ppSym, Node,
-                   LazySymbolName));
+HRESULT dxil_dia::hlsl_symbols::TypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st, llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, st, (TypeSymbol**)ppSym, Node, LazySymbolName));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_name(
-    /* [retval][out] */ BSTR *pRetVal) {
+  /* [retval][out] */ BSTR *pRetVal) {
   DxcThreadMalloc TM(m_pSession->GetMallocNoRef());
   if (m_lazySymbolName != nullptr) {
     DXASSERT(!this->HasName(), "Setting type name multiple times.");
@@ -1029,22 +911,17 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_name(
   return Symbol::get_name(pRetVal);
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypeSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::TypeSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::VectorTypeSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID,
-    llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts,
-    Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagVectorType,
-                   (VectorTypeSymbol **)ppSym, Node, dwElemTyID, NumElts));
+HRESULT dxil_dia::hlsl_symbols::VectorTypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagVectorType, (VectorTypeSymbol**)ppSym, Node, dwElemTyID, NumElts));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_count(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1054,7 +931,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_count(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_type(
-    /* [retval][out] */ IDiaSymbol **ppRetVal) {
+  /* [retval][out] */ IDiaSymbol **ppRetVal) {
   if (ppRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1067,27 +944,18 @@ STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_type(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTSymbol::Create(IMalloc *pMalloc,
-                                                  Session *pSession,
-                                                  DWORD dwParentID, DWORD dwID,
-                                                  llvm::DICompositeType *Node,
-                                                  LazySymbolName LazySymbolName,
-                                                  Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagUDT, (UDTSymbol **)ppSym,
-                   Node, LazySymbolName));
+HRESULT dxil_dia::hlsl_symbols::UDTSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DICompositeType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagUDT, (UDTSymbol**)ppSym, Node, LazySymbolName));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypedefTypeSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID,
-    llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagTypedef,
-                   (TypedefTypeSymbol **)ppSym, Node, dwBaseTypeID));
+HRESULT dxil_dia::hlsl_symbols::TypedefTypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagTypedef, (TypedefTypeSymbol**)ppSym, Node, dwBaseTypeID));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypedefTypeSymbol::get_type(
-    /* [retval][out] */ IDiaSymbol **ppRetVal) {
+  /* [retval][out] */ IDiaSymbol **ppRetVal) {
   if (ppRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1100,32 +968,23 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypedefTypeSymbol::get_type(
   return S_FALSE;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV,
-    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
-                   (GlobalVariableSymbol **)ppSym, GV, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (GlobalVariableSymbol**)ppSym, GV, dwTypeID, Type));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node,
-    DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum,
-    Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
-                   (LocalVariableSymbol **)ppSym, Node, dwTypeID, Type,
-                   dwOffsetInUDT, dwDxilRegNum));
+HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (LocalVariableSymbol**)ppSym, Node, dwTypeID, Type, dwOffsetInUDT, dwDxilRegNum));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_locationType(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1135,7 +994,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_locationType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_isAggregated(
-    /* [retval][out] */ BOOL *pRetVal) {
+  /* [retval][out] */ BOOL *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1145,7 +1004,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_isAggregated(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_registerType(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1156,7 +1015,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_registerType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_offsetInUdt(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1166,20 +1025,19 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_offsetInUdt(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_sizeInUdt(
-    /* [retval][out] */ DWORD *pRetVal) {
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
 
   static constexpr DWORD kBitsPerByte = 8;
-  // auto *DT = llvm::cast<llvm::DIDerivedType>(m_pType);
-  *pRetVal = 4; // DT->getSizeInBits() / kBitsPerByte;
+  //auto *DT = llvm::cast<llvm::DIDerivedType>(m_pType);
+  *pRetVal = 4; //DT->getSizeInBits() / kBitsPerByte;
   return S_OK;
 }
 
-STDMETHODIMP
-dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIndices(
-    /* [retval][out] */ DWORD *pRetVal) {
+STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIndices(
+  /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1189,9 +1047,9 @@ dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIndices(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numericProperties(
-    /* [in] */ DWORD cnt,
-    /* [out] */ DWORD *pcnt,
-    /* [size_is][out] */ DWORD *pProperties) {
+  /* [in] */ DWORD cnt,
+  /* [out] */ DWORD *pcnt,
+  /* [size_is][out] */ DWORD *pProperties) {
   if (pcnt == nullptr || pProperties == nullptr || cnt != 1) {
     return E_INVALIDARG;
   }
@@ -1201,22 +1059,18 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numericProperties(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::Create(
-    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node,
-    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
-                   (UDTFieldSymbol **)ppSym, Node, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (UDTFieldSymbol**)ppSym, Node, dwTypeID, Type));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::UDTFieldSymbol::get_offset(
-    /* [retval][out] */ LONG *pRetVal) {
+  /* [retval][out] */ LONG *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1226,8 +1080,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::UDTFieldSymbol::get_offset(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::GetChildren(
-    std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
@@ -1237,31 +1090,31 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::SymbolManagerInit(
     std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
     SymbolManager::ScopeToIDMap *pScopeToSym,
     SymbolManager::IDToLiveRangeMap *pSymToLR)
-    : m_Session(*pSession), m_SymCtors(*pSymCtors), m_ScopeToSym(*pScopeToSym),
-      m_SymToLR(*pSymToLR) {
+  : m_Session(*pSession),
+    m_SymCtors(*pSymCtors),
+    m_ScopeToSym(*pScopeToSym),
+    m_SymToLR(*pSymToLR) {
   DXASSERT_ARGS(m_Parent.size() == m_SymCtors.size(),
                 "parent and symbol array size mismatch: %d vs %d",
-                m_Parent.size(), m_SymCtors.size());
+                m_Parent.size(),
+                m_SymCtors.size());
 }
 
-void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::Embed(
-    const TypeInfo &TI) {
+void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::Embed(const TypeInfo &TI) {
   for (const auto &E : TI.GetLayout()) {
     m_Layout.emplace_back(E);
   }
   m_dwCurrentSizeInBytes += TI.m_dwCurrentSizeInBytes;
 }
 
-void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::AddBasicType(
-    llvm::DIBasicType *BT) {
+void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::AddBasicType(llvm::DIBasicType *BT) {
   m_Layout.emplace_back(BT);
 
   static constexpr DWORD kNumBitsPerByte = 8;
   m_dwCurrentSizeInBytes += BT->getSizeInBits() / kNumBitsPerByte;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T,
-                                                               TypeInfo **TI) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T, TypeInfo **TI) {
   auto tyInfoIt = m_TypeToInfo.find(T);
   if (tyInfoIt == m_TypeToInfo.end()) {
     return E_FAIL;
@@ -1271,15 +1124,12 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T,
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::AddParent(DWORD dwParentIndex) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::AddParent(DWORD dwParentIndex) {
   m_Parent.emplace_back(dwParentIndex);
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalScope(
-    llvm::DILocalScope *LS, DWORD *pNewSymID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS, DWORD *pNewSymID) {
   if (LS == nullptr) {
     return E_FAIL;
   }
@@ -1315,9 +1165,7 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalScope(
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruction(
-    llvm::Instruction *I) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruction(llvm::Instruction *I) {
   const llvm::DebugLoc &DL = I->getDebugLoc();
   if (!DL) {
     return S_OK;
@@ -1344,9 +1192,7 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruction(
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFunction(
-    llvm::Function *F) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFunction(llvm::Function *F) {
   for (llvm::BasicBlock &BB : *F) {
     for (llvm::Instruction &I : BB) {
       IFR(CreateFunctionBlockForInstruction(&I));
@@ -1356,17 +1202,14 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFunction(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(
-    llvm::DICompileUnit *CU) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(llvm::DICompileUnit *CU) {
   bool FoundFunctions = false;
   for (llvm::DISubprogram *SubProgram : CU->getSubprograms()) {
     DWORD dwNewFunID;
-    const DWORD dwParentID =
-        SubProgram->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
+    const DWORD dwParentID = SubProgram->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
     DWORD dwSubprogramTypeID;
     IFR(CreateType(SubProgram->getType(), &dwSubprogramTypeID));
-    IFR(AddSymbol<symbol_factory::Function>(dwParentID, &dwNewFunID, SubProgram,
-                                            dwSubprogramTypeID));
+    IFR(AddSymbol<symbol_factory::Function>(dwParentID, &dwNewFunID, SubProgram, dwSubprogramTypeID));
     m_ScopeToSym.insert(std::make_pair(SubProgram, dwNewFunID));
 
     if (llvm::Function *F = SubProgram->getFunction()) {
@@ -1377,8 +1220,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(
 
   if (!FoundFunctions) {
     // This works around an old bug in dxcompiler whose effects are still
-    // sometimes present in PIX users' traces. (The bug was that the
-    // subprogram(s) weren't pointing to their contained function.)
+    // sometimes present in PIX users' traces. (The bug was that the subprogram(s)
+    // weren't pointing to their contained function.)
     llvm::Module *M = &m_Session.ModuleRef();
     auto &DM = M->GetDxilModule();
     llvm::Function *EntryPoint = DM.GetEntryFunction();
@@ -1395,32 +1238,27 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForAllCUs() {
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForCU(
-    llvm::DICompileUnit *CU) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForCU(llvm::DICompileUnit *CU) {
   for (llvm::DIGlobalVariable *GlobalVariable : CU->getGlobalVariables()) {
     DWORD dwUnusedNewGVID;
-    const DWORD dwParentID =
-        GlobalVariable->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
+    const DWORD dwParentID = GlobalVariable->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
     auto *GVType = dyn_cast_to_ditype<llvm::DIType>(GlobalVariable->getType());
     DWORD dwGVTypeID;
     IFR(CreateType(GVType, &dwGVTypeID));
-    IFR(AddSymbol<symbol_factory::GlobalVariable>(
-        dwParentID, &dwUnusedNewGVID, GlobalVariable, dwGVTypeID, GVType));
+    IFR(AddSymbol<symbol_factory::GlobalVariable>(dwParentID, &dwUnusedNewGVID, GlobalVariable, dwGVTypeID, GVType));
   }
 
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForAllCUs() {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForAllCUs() {
   for (llvm::DICompileUnit *pCU : m_Session.InfoRef().compile_units()) {
     IFR(CreateGlobalVariablesForCU(pCU));
   }
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S,
-                                                              DWORD *pScopeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S, DWORD *pScopeID) {
   auto ParentScopeIt = m_ScopeToSym.find(S);
   if (ParentScopeIt != m_ScopeToSym.end()) {
     *pScopeID = ParentScopeIt->second;
@@ -1435,9 +1273,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S,
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type,
-                                                      DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type, DWORD *pNewTypeID) {
   if (Type == nullptr) {
     return E_FAIL;
   }
@@ -1456,16 +1292,14 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type,
     return S_OK;
   } else if (auto *CT = llvm::dyn_cast<llvm::DICompositeType>(Type)) {
     DWORD dwParentID = HlslProgramId;
-    if (auto *ParentScope =
-            dyn_cast_to_ditype_or_null<llvm::DIScope>(CT->getScope())) {
+    if (auto *ParentScope = dyn_cast_to_ditype_or_null<llvm::DIScope>(CT->getScope())) {
       IFR(GetScopeID(ParentScope, &dwParentID));
     }
     IFR(CreateCompositeType(dwParentID, CT, pNewTypeID));
     return S_OK;
   } else if (auto *DT = llvm::dyn_cast<llvm::DIDerivedType>(Type)) {
     DWORD dwParentID = HlslProgramId;
-    if (auto *ParentScope =
-            dyn_cast_to_ditype_or_null<llvm::DIScope>(DT->getScope())) {
+    if (auto *ParentScope = dyn_cast_to_ditype_or_null<llvm::DIScope>(DT->getScope())) {
       IFR(GetScopeID(ParentScope, &dwParentID));
     }
     IFR(HandleDerivedType(dwParentID, DT, pNewTypeID));
@@ -1475,8 +1309,7 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type,
   return E_FAIL;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(
-    DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID) {
   LazySymbolName LazyName;
 
   llvm::DITypeRefArray Types = ST->getTypeArray();
@@ -1531,25 +1364,23 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(
     };
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID,
-                                    SymTagFunctionType, ST, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID, SymTagFunctionType, ST, LazyName));
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(
-    DWORD dwParentID, llvm::DIBasicType *BT, DWORD *pNewTypeID) {
-  DXASSERT_ARGS(dwParentID == HlslProgramId, "%d vs %d", dwParentID,
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(DWORD dwParentID, llvm::DIBasicType *BT, DWORD *pNewTypeID) {
+  DXASSERT_ARGS(dwParentID == HlslProgramId,
+                "%d vs %d",
+                dwParentID,
                 HlslProgramId);
 
-  LazySymbolName LazyName = [BT](Session *pSession,
-                                 std::string *Name) -> HRESULT {
+  LazySymbolName LazyName = [BT](Session *pSession, std::string *Name) -> HRESULT {
     *Name = BT->getName();
     return S_OK;
   };
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, SymTagBaseType,
-                                    BT, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, SymTagBaseType, BT, LazyName));
 
   TypeInfo *TI;
   IFR(GetTypeInfo(BT, &TI));
@@ -1558,12 +1389,10 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
-    DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID) {
   switch (CT->getTag()) {
   case llvm::dwarf::DW_TAG_array_type: {
-    auto *BaseType =
-        dyn_cast_to_ditype_or_null<llvm::DIType>(CT->getBaseType());
+    auto *BaseType = dyn_cast_to_ditype_or_null<llvm::DIType>(CT->getBaseType());
     if (BaseType == nullptr) {
       return E_FAIL;
     }
@@ -1571,8 +1400,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
     DWORD dwBaseTypeID = kNullSymbolID;
     IFR(CreateType(BaseType, &dwBaseTypeID));
 
-    auto LazyName = [CT, dwBaseTypeID](Session *pSession,
-                                       std::string *Name) -> HRESULT {
+    auto LazyName = [CT, dwBaseTypeID](Session *pSession, std::string *Name) -> HRESULT {
       auto &SM = pSession->SymMgr();
       Name->clear();
       llvm::raw_string_ostream OS(*Name);
@@ -1611,8 +1439,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
       return S_OK;
     };
 
-    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID,
-                                      SymTagArrayType, CT, LazyName));
+    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID, SymTagArrayType, CT, LazyName));
     TypeInfo *ctTI;
     IFR(GetTypeInfo(CT, &ctTI));
     TypeInfo *baseTI;
@@ -1662,8 +1489,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(
-    llvm::DICompositeType *T, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(llvm::DICompositeType *T, DWORD *pNewTypeID) {
   DWORD dwEltTyID;
   std::uint32_t ElemCnt;
   HRESULT hr;
@@ -1675,8 +1501,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(
   return S_FALSE;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(
-    llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt) {
   llvm::StringRef Name = T->getName();
   if (!Name.startswith("vector<")) {
     return S_FALSE;
@@ -1703,10 +1528,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(
   if (ElemCntParam == nullptr) {
     return E_FAIL;
   }
-  auto *ElemCntMD =
-      llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
-  auto *ElemCnt =
-      llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
+  auto *ElemCntMD = llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
+  auto *ElemCnt = llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
   if (ElemCnt == nullptr) {
     return E_FAIL;
   }
@@ -1719,9 +1542,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(
-    llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt,
-    DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt, DWORD *pNewTypeID) {
   llvm::DITemplateParameterArray Args = T->getTemplateParams();
   if (Args.size() != 2) {
     return E_FAIL;
@@ -1743,10 +1564,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(
   if (ElemCntParam == nullptr) {
     return E_FAIL;
   }
-  auto *ElemCntMD =
-      llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
-  auto *ElemCnt =
-      llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
+  auto *ElemCntMD = llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
+  auto *ElemCnt = llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
   if (ElemCnt == nullptr) {
     return E_FAIL;
   }
@@ -1755,8 +1574,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(
   }
 
   const DWORD dwParentID = HlslProgramId;
-  IFR(AddType<symbol_factory::VectorType>(
-      dwParentID, T, pNewTypeID, T, dwElemTyID, ElemCnt->getLimitedValue()));
+  IFR(AddType<symbol_factory::VectorType>(dwParentID, T, pNewTypeID, T, dwElemTyID, ElemCnt->getLimitedValue()));
 
   TypeInfo *vecTI;
   IFR(GetTypeInfo(T, &vecTI));
@@ -1769,8 +1587,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
-    DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID) {
   DWORD st;
   LazySymbolName LazyName;
 
@@ -1780,9 +1597,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
     IFR(CreateType(BaseTy, &dwBaseTypeID));
   }
 
-  auto LazyNameWithQualifier = [dwBaseTypeID,
-                                DT](Session *pSession, std::string *Name,
-                                    const char *Qualifier) -> HRESULT {
+  auto LazyNameWithQualifier = [dwBaseTypeID, DT](Session *pSession, std::string *Name, const char *Qualifier) -> HRESULT {
     auto &SM = pSession->SymMgr();
     Name->clear();
     llvm::raw_string_ostream OS(*Name);
@@ -1823,8 +1638,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
       return E_FAIL;
     }
 
-    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, DT,
-                                             dwBaseTypeID));
+    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, DT, dwBaseTypeID));
 
     TypeInfo *dtTI;
     IFR(GetTypeInfo(DT, &dtTI));
@@ -1840,8 +1654,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
     }
 
     st = SymTagCustomType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
-                         std::placeholders::_2, " const");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " const");
     break;
   }
   case llvm::dwarf::DW_TAG_pointer_type: {
@@ -1850,8 +1663,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
     }
 
     st = SymTagPointerType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
-                         std::placeholders::_2, " *");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " *");
     break;
   }
   case llvm::dwarf::DW_TAG_reference_type: {
@@ -1860,14 +1672,12 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
     }
 
     st = SymTagCustomType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
-                         std::placeholders::_2, " &");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " &");
     break;
   }
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, st, DT,
-                                    LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, st, DT, LazyName));
 
   if (DT->getTag() == llvm::dwarf::DW_TAG_const_type) {
     TypeInfo *dtTI;
@@ -1880,8 +1690,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(
-    DWORD dwParentID, llvm::DILocalVariable *LV) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(DWORD dwParentID, llvm::DILocalVariable *LV) {
   auto *LVTy = dyn_cast_to_ditype<llvm::DIType>(LV->getType());
   if (LVTy == nullptr) {
     return E_FAIL;
@@ -1906,8 +1715,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(
     DWORD dwNewLVID;
     newVars.emplace_back(std::make_shared<symbol_factory::LocalVarInfo>());
     std::shared_ptr<symbol_factory::LocalVarInfo> VI = newVars.back();
-    IFR(AddSymbol<symbol_factory::LocalVariable>(dwParentID, &dwNewLVID, LV,
-                                                 dwLVTypeID, LVTy, VI));
+    IFR(AddSymbol<symbol_factory::LocalVariable>(dwParentID, &dwNewLVID, LV, dwLVTypeID, LVTy, VI));
     VI->SetVarID(dwNewLVID);
     VI->SetOffsetInUDT(dwOffsetInUDT);
 
@@ -1917,13 +1725,12 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(
-    llvm::DIType *Ty, std::vector<DWORD> *pRet) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(llvm::DIType *Ty, std::vector<DWORD> *pRet) {
   pRet->clear();
 
   TypeInfo *TI;
   IFR(GetTypeInfo(Ty, &TI));
-  for (llvm::DIType *T : TI->GetLayout()) {
+  for (llvm::DIType * T : TI->GetLayout()) {
     TypeInfo *eTI;
     IFR(GetTypeInfo(T, &eTI));
     pRet->emplace_back(eTI->GetTypeID());
@@ -1931,8 +1738,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(
-    DWORD dwParentID, llvm::DIDerivedType *Field) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(DWORD dwParentID, llvm::DIDerivedType *Field) {
   auto *FieldTy = dyn_cast_to_ditype<llvm::DIType>(Field->getBaseType());
   if (FieldTy == nullptr) {
     return E_FAIL;
@@ -1946,16 +1752,17 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(
   IFR(CreateType(FieldTy, &dwLVTypeID));
   if (m_pCurUDT != nullptr) {
     const DWORD dwOffsetInBytes = CurrentUDTInfo().GetCurrentSizeInBytes();
-    DXASSERT_ARGS(dwOffsetInBytes == Field->getOffsetInBits() / 8, "%d vs %d",
-                  dwOffsetInBytes, Field->getOffsetInBits() / 8);
+    DXASSERT_ARGS(dwOffsetInBytes == Field->getOffsetInBits() / 8,
+      "%d vs %d",
+      dwOffsetInBytes,
+      Field->getOffsetInBits() / 8);
     TypeInfo *lvTI;
     IFR(GetTypeInfo(FieldTy, &lvTI));
     CurrentUDTInfo().Embed(*lvTI);
   }
 
   DWORD dwNewLVID;
-  IFR(AddSymbol<symbol_factory::UDTField>(dwParentID, &dwNewLVID, Field,
-                                          dwLVTypeID, FieldTy));
+  IFR(AddSymbol<symbol_factory::UDTField>(dwParentID, &dwNewLVID, Field, dwLVTypeID, FieldTy));
   m_FieldToID.insert(std::make_pair(Field, dwNewLVID));
   return S_OK;
 }
@@ -1963,21 +1770,17 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(
 HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariables() {
   llvm::Module *M = &m_Session.ModuleRef();
 
-  llvm::Function *DbgDeclare =
-      llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
+  llvm::Function *DbgDeclare = llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
   for (llvm::Value *U : DbgDeclare->users()) {
     auto *CI = llvm::dyn_cast<llvm::CallInst>(U);
-    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(
-        CI->getDebugLoc()->getInlinedAtScope());
+    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(CI->getDebugLoc()->getInlinedAtScope());
     auto SymIt = m_ScopeToSym.find(LS);
     if (SymIt == m_ScopeToSym.end()) {
       return E_FAIL;
     }
 
-    auto *LocalNameMetadata =
-        llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1));
-    if (auto *LV = llvm::dyn_cast<llvm::DILocalVariable>(
-            LocalNameMetadata->getMetadata())) {
+    auto *LocalNameMetadata = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1));
+    if (auto *LV = llvm::dyn_cast<llvm::DILocalVariable>(LocalNameMetadata->getMetadata())) {
       const DWORD dwParentID = SymIt->second;
       IFR(CreateLocalVariable(dwParentID, LV));
     }
@@ -2059,8 +1862,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
         continue;
       }
       Var->SetDxilRegister(Reg + dwRegIndex);
-      m_SymToLR[Var->GetVarID()] =
-          SymbolManager::LiveRange{static_cast<uint32_t>(FirstUseRVA),
+      m_SymToLR[Var->GetVarID()] = SymbolManager::LiveRange{
+          static_cast<uint32_t>(FirstUseRVA),
           endOfScopeRVA - static_cast<uint32_t>(FirstUseRVA)};
     }
   }
@@ -2070,7 +1873,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
 HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
     llvm::Module *M, const llvm::Instruction *I, DWORD *pReg, DWORD *pRegSize,
     llvm::DILocalVariable **LV, uint64_t *pStartOffset, uint64_t *pEndOffset,
-    dxil_dia::Session::RVA *pLowestUserRVA, dxil_dia::Session::RVA *pHighestUserRVA) {
+    dxil_dia::Session::RVA *pLowestUserRVA,
+    dxil_dia::Session::RVA *pHighestUserRVA) {
   auto *CI = llvm::dyn_cast<llvm::CallInst>(I);
   if (CI == nullptr) {
     return S_FALSE;
@@ -2091,7 +1895,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
   std::vector<dxil_dia::Session::RVA> usesRVAs;
 
   if (auto *RegMV =
-    llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
+          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
     if (auto *RegVM =
             llvm::dyn_cast<llvm::ValueAsMetadata>(RegMV->getMetadata())) {
       if (auto *Reg = llvm::dyn_cast<llvm::Instruction>(RegVM->getValue())) {
@@ -2114,7 +1918,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
 
   if (!usesRVAs.empty()) {
     *pLowestUserRVA = *std::min_element(usesRVAs.begin(), usesRVAs.end());
-    *pHighestUserRVA = * std::max_element(usesRVAs.begin(), usesRVAs.end());
+    *pHighestUserRVA = *std::max_element(usesRVAs.begin(), usesRVAs.end());
   }
 
   if (auto *LVMV =
@@ -2164,8 +1968,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(
-    llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize) {
   auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(I);
   if (Alloca == nullptr) {
     return S_FALSE;
@@ -2182,23 +1985,23 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(
   return S_OK;
 }
 
-HRESULT
-dxil_dia::hlsl_symbols::SymbolManagerInit::PopulateParentToChildrenIDMap(
-    SymbolManager::ParentToChildrenMap *pParentToChildren) {
-  DXASSERT_ARGS(
-      m_SymCtors.size() == m_Parent.size(),
-      "parents vector must be the same size of symbols ctor vector: %d vs %d",
-      m_SymCtors.size(), m_Parent.size());
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::PopulateParentToChildrenIDMap(SymbolManager::ParentToChildrenMap *pParentToChildren) {
+  DXASSERT_ARGS(m_SymCtors.size() == m_Parent.size(),
+                "parents vector must be the same size of symbols ctor vector: %d vs %d",
+                m_SymCtors.size(),
+                m_Parent.size());
 
   for (size_t i = 0; i < m_Parent.size(); ++i) {
 #ifndef NDEBUG
     {
       CComPtr<Symbol> S;
       IFT(m_SymCtors[i]->Create(&m_Session, &S));
-      DXASSERT_ARGS(S->GetID() == i + 1, "Invalid symbol index %d for %d",
-                    S->GetID(), i + 1);
+      DXASSERT_ARGS(S->GetID() == i + 1,
+                    "Invalid symbol index %d for %d",
+                    S->GetID(),
+                   i + 1);
     }
-#endif // !NDEBUG
+#endif  // !NDEBUG
 
     DXASSERT_ARGS(m_Parent[i] != kNullSymbolID || (i + 1) == HlslProgramId,
                   "Parentless symbol %d", i + 1);
@@ -2217,7 +2020,9 @@ dxil_dia::SymbolManager::SymbolFactory::~SymbolFactory() = default;
 
 dxil_dia::SymbolManager::SymbolManager() = default;
 
-dxil_dia::SymbolManager::~SymbolManager() { m_pSession = nullptr; }
+dxil_dia::SymbolManager::~SymbolManager() {
+  m_pSession = nullptr;
+}
 
 void dxil_dia::SymbolManager::Init(Session *pSes) {
   DXASSERT(m_pSession == nullptr, "SymbolManager already initialized");
@@ -2231,65 +2036,72 @@ void dxil_dia::SymbolManager::Init(Session *pSes) {
   }
   llvm::DICompileUnit *ShaderCU = *DIFinder.compile_units().begin();
 
-  hlsl_symbols::SymbolManagerInit SMI(pSes, &m_symbolCtors, &m_scopeToID,
-                                      &m_symbolToLiveRange);
+  hlsl_symbols::SymbolManagerInit SMI(pSes, &m_symbolCtors, &m_scopeToID, &m_symbolToLiveRange);
 
   DWORD dwHlslProgramID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::GlobalScope>(
-      kNullSymbolID, &dwHlslProgramID));
-  DXASSERT_ARGS(dwHlslProgramID == HlslProgramId, "%d vs %d", dwHlslProgramID,
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::GlobalScope>(kNullSymbolID, &dwHlslProgramID));
+  DXASSERT_ARGS(dwHlslProgramID == HlslProgramId,
+                "%d vs %d",
+                dwHlslProgramID,
                 HlslProgramId);
 
+
   DWORD dwHlslCompilandID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::Compiland>(
-      dwHlslProgramID, &dwHlslCompilandID, ShaderCU));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::Compiland>(dwHlslProgramID, &dwHlslCompilandID, ShaderCU));
   m_scopeToID.insert(std::make_pair(ShaderCU, dwHlslCompilandID));
-  DXASSERT_ARGS(dwHlslCompilandID == HlslCompilandId, "%d vs %d",
-                dwHlslCompilandID, HlslCompilandId);
+  DXASSERT_ARGS(dwHlslCompilandID == HlslCompilandId,
+                "%d vs %d",
+                dwHlslCompilandID,
+                HlslCompilandId);
+
 
   DWORD dwHlslCompilandDetailsId;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandDetails>(
-      dwHlslCompilandID, &dwHlslCompilandDetailsId));
-  DXASSERT_ARGS(dwHlslCompilandDetailsId == HlslCompilandDetailsId, "%d vs %d",
-                dwHlslCompilandDetailsId, HlslCompilandDetailsId);
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandDetails>(dwHlslCompilandID, &dwHlslCompilandDetailsId));
+  DXASSERT_ARGS(dwHlslCompilandDetailsId == HlslCompilandDetailsId,
+                "%d vs %d",
+                dwHlslCompilandDetailsId,
+                HlslCompilandDetailsId);
+
 
   DWORD dwHlslCompilandEnvFlagsID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
-          hlsl_symbols::CompilandEnvSymbol::CreateFlags>>(
-      dwHlslCompilandID, &dwHlslCompilandEnvFlagsID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateFlags>>(dwHlslCompilandID, &dwHlslCompilandEnvFlagsID));
   DXASSERT_ARGS(dwHlslCompilandEnvFlagsID == HlslCompilandEnvFlagsId,
-                "%d vs %d", dwHlslCompilandEnvFlagsID, HlslCompilandEnvFlagsId);
+                "%d vs %d",
+                dwHlslCompilandEnvFlagsID,
+                HlslCompilandEnvFlagsId);
+
 
   DWORD dwHlslCompilandEnvTargetID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
-          hlsl_symbols::CompilandEnvSymbol::CreateTarget>>(
-      dwHlslCompilandID, &dwHlslCompilandEnvTargetID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateTarget>>(dwHlslCompilandID, &dwHlslCompilandEnvTargetID));
   DXASSERT_ARGS(dwHlslCompilandEnvTargetID == HlslCompilandEnvTargetId,
-                "%d vs %d", dwHlslCompilandEnvTargetID,
+                "%d vs %d",
+                dwHlslCompilandEnvTargetID,
                 HlslCompilandEnvTargetId);
 
+
   DWORD dwHlslCompilandEnvEntryID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
-          hlsl_symbols::CompilandEnvSymbol::CreateEntry>>(
-      dwHlslCompilandID, &dwHlslCompilandEnvEntryID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateEntry>>(dwHlslCompilandID, &dwHlslCompilandEnvEntryID));
   DXASSERT_ARGS(dwHlslCompilandEnvEntryID == HlslCompilandEnvEntryId,
-                "%d vs %d", dwHlslCompilandEnvEntryID, HlslCompilandEnvEntryId);
+                "%d vs %d",
+                dwHlslCompilandEnvEntryID,
+                HlslCompilandEnvEntryId);
+
 
   DWORD dwHlslCompilandEnvDefinesID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
-          hlsl_symbols::CompilandEnvSymbol::CreateDefines>>(
-      dwHlslCompilandID, &dwHlslCompilandEnvDefinesID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateDefines>>(dwHlslCompilandID, &dwHlslCompilandEnvDefinesID));
   DXASSERT_ARGS(dwHlslCompilandEnvDefinesID == HlslCompilandEnvDefinesId,
-                "%d vs %d", dwHlslCompilandEnvDefinesID,
+                "%d vs %d",
+                dwHlslCompilandEnvDefinesID,
                 HlslCompilandEnvDefinesId);
 
+
   DWORD dwHlslCompilandEnvArgumentsID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
-          hlsl_symbols::CompilandEnvSymbol::CreateArguments>>(
-      dwHlslCompilandID, &dwHlslCompilandEnvArgumentsID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateArguments>>(dwHlslCompilandID, &dwHlslCompilandEnvArgumentsID));
   DXASSERT_ARGS(dwHlslCompilandEnvArgumentsID == HlslCompilandEnvArgumentsId,
-                "%d vs %d", dwHlslCompilandEnvArgumentsID,
+                "%d vs %d",
+                dwHlslCompilandEnvArgumentsID,
                 HlslCompilandEnvArgumentsId);
+
 
   IFT(SMI.CreateFunctionsForAllCUs());
   IFT(SMI.CreateGlobalVariablesForAllCUs());
@@ -2298,8 +2110,7 @@ void dxil_dia::SymbolManager::Init(Session *pSes) {
   IFT(SMI.PopulateParentToChildrenIDMap(&m_parentToChildren));
 }
 
-HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id,
-                                               Symbol **ppSym) const {
+HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id, Symbol **ppSym) const {
   if (ppSym == nullptr) {
     return E_INVALIDARG;
   }
@@ -2321,8 +2132,7 @@ HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id,
   return S_OK;
 }
 
-HRESULT dxil_dia::SymbolManager::GetLiveRangeOf(Symbol *pSym,
-                                                LiveRange *LR) const {
+HRESULT dxil_dia::SymbolManager::GetLiveRangeOf(Symbol *pSym, LiveRange *LR) const {
   const DWORD dwSymID = pSym->GetID();
   if (dwSymID <= 0 || dwSymID > m_symbolCtors.size()) {
     return E_INVALIDARG;
@@ -2340,8 +2150,7 @@ HRESULT dxil_dia::SymbolManager::GetGlobalScope(Symbol **ppSym) const {
   return GetSymbolByID(HlslProgramId, ppSym);
 }
 
-HRESULT dxil_dia::SymbolManager::ChildrenOf(
-    DWORD ID, std::vector<CComPtr<Symbol>> *pChildren) const {
+HRESULT dxil_dia::SymbolManager::ChildrenOf(DWORD ID, std::vector<CComPtr<Symbol>> *pChildren) const {
   pChildren->clear();
   auto childrenList = m_parentToChildren.equal_range(ID);
   for (auto it = childrenList.first; it != childrenList.second; ++it) {
@@ -2352,16 +2161,13 @@ HRESULT dxil_dia::SymbolManager::ChildrenOf(
   return S_OK;
 }
 
-HRESULT dxil_dia::SymbolManager::ChildrenOf(
-    Symbol *pSym, std::vector<CComPtr<Symbol>> *pChildren) const {
+HRESULT dxil_dia::SymbolManager::ChildrenOf(Symbol *pSym, std::vector<CComPtr<Symbol>> *pChildren) const {
   const std::uint32_t pSymID = pSym->GetID();
   IFR(ChildrenOf(pSymID, pChildren));
   return S_OK;
 }
 
-HRESULT
-dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr,
-                                    SymbolChildrenEnumerator **ppRet) const {
+HRESULT dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr, SymbolChildrenEnumerator **ppRet) const {
   *ppRet = nullptr;
 
   const llvm::DebugLoc &DL = instr->getDebugLoc();
@@ -2384,13 +2190,11 @@ dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr,
 
   auto scopeIt = m_scopeToID.find(LS);
   if (scopeIt == m_scopeToID.end()) {
-    // This is a failure because all scopes should already exist in the symbol
-    // manager.
+    // This is a failure because all scopes should already exist in the symbol manager.
     return E_FAIL;
   }
 
-  CComPtr<SymbolChildrenEnumerator> ret =
-      SymbolChildrenEnumerator::Alloc(m_pSession->GetMallocNoRef());
+  CComPtr<SymbolChildrenEnumerator> ret = SymbolChildrenEnumerator::Alloc(m_pSession->GetMallocNoRef());
   if (!ret) {
     return E_OUTOFMEMORY;
   }

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -655,8 +655,7 @@ public:
                            uint64_t *pEndOffset,
                            dxil_dia::Session::RVA *pLowestUserRVA,
                            dxil_dia::Session::RVA *pHighestUserRVA);
-  HRESULT GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum,
-                                DWORD *pRegSize);
+  HRESULT GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize);
   HRESULT PopulateParentToChildrenIDMap(SymbolManager::ParentToChildrenMap *pParentToChildren);
 
 private:
@@ -1805,16 +1804,13 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
   const auto &Instrs = m_Session.InstructionsRef();
   llvm::DenseMap<llvm::DILocalScope *, Session::RVA> EndOfScope;
   for (auto It = Instrs.rbegin(); It != Instrs.rend(); ++It) {
-    Session::RVA RVA = It->first;
+    const Session::RVA RVA = It->first;
     const auto *I = It->second;
     const llvm::DebugLoc &DL = I->getDebugLoc();
     if (!DL) {
       continue;
     }
     llvm::MDNode *LocalScope = DL.getScope();
-    if (LocalScope == nullptr) {
-      LocalScope = DL.getScope();
-    }
     if (LocalScope == nullptr) {
       continue;
     }
@@ -1863,8 +1859,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
       }
       Var->SetDxilRegister(Reg + dwRegIndex);
       m_SymToLR[Var->GetVarID()] = SymbolManager::LiveRange{
-          static_cast<uint32_t>(FirstUseRVA),
-          endOfScopeRVA - static_cast<uint32_t>(FirstUseRVA)};
+        static_cast<uint32_t>(FirstUseRVA),
+        endOfScopeRVA - static_cast<uint32_t>(FirstUseRVA)
+      };
     }
   }
   return S_OK;
@@ -1880,8 +1877,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
     return S_FALSE;
   }
 
-  llvm::Function *DbgDeclare =
-      llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
+  llvm::Function *DbgDeclare = llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
   if (CI->getCalledFunction() != DbgDeclare) {
     return S_FALSE;
   }
@@ -1894,10 +1890,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
 
   std::vector<dxil_dia::Session::RVA> usesRVAs;
 
-  if (auto *RegMV =
-          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
-    if (auto *RegVM =
-            llvm::dyn_cast<llvm::ValueAsMetadata>(RegMV->getMetadata())) {
+  if (auto *RegMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
+    if (auto *RegVM = llvm::dyn_cast<llvm::ValueAsMetadata>(RegMV->getMetadata())) {
       if (auto *Reg = llvm::dyn_cast<llvm::Instruction>(RegVM->getValue())) {
         HRESULT hr;
         IFR(hr = GetDxilAllocaRegister(Reg, pReg, pRegSize));
@@ -1921,16 +1915,14 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
     *pHighestUserRVA = *std::max_element(usesRVAs.begin(), usesRVAs.end());
   }
 
-  if (auto *LVMV =
-          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1))) {
+  if (auto *LVMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1))) {
     *LV = llvm::dyn_cast<llvm::DILocalVariable>(LVMV->getMetadata());
     if (*LV == nullptr) {
       return E_FAIL;
     }
   }
 
-  if (auto *FieldsMV =
-          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(2))) {
+  if (auto *FieldsMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(2))) {
     auto *Fields = llvm::dyn_cast<llvm::DIExpression>(FieldsMV->getMetadata());
     if (Fields == nullptr) {
       return E_FAIL;

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -39,42 +39,42 @@ namespace hlsl_symbols {
 
 // HLSL Symbol Hierarchy
 // ---- ------ ---------
-// 
+//
 //                                  +---------------+
-//                                  | Program (EXE) |                                   Global Scope
+//                                  | Program (EXE) | Global Scope
 //                                  +------+--------+
 //                                         |
 //                                +--------^-----------+
-//                                | Compiland (Shader) |                                Compilation Unit
+//                                | Compiland (Shader) | Compilation Unit
 //                                +--------+-----------+
 //                                         |
 //      +------------+------------+--------+-------+------------+--------------+
-//      |            |            |        |       |            |              |        
-// +----^----+   +---^---+   +----^---+    |   +---^---+   +----^----+   +-----^-----+
-// | Details |   | Flags |   | Target |    |   | Entry |   | Defines |   | Arguments |  Synthetic Symbols
-// +---------+   +-------+   +--------+    |   +-------+   +---------+   +-----------+
+//      |            |            |        |       |            |              |
+// +----^----+   +---^---+   +----^---+    |   +---^---+   +----^----+
+// +-----^-----+ | Details |   | Flags |   | Target |    |   | Entry |   |
+// Defines |   | Arguments |  Synthetic Symbols
+// +---------+   +-------+   +--------+    |   +-------+   +---------+
+// +-----------+
 //                                         |
 //                                         |
 //       +---------------+------------+----+-----+-------------+-----------+
-//       |               |            |          |             |           | 
+//       |               |            |          |             |           |
 // +-----^-----+   +-----^-----+   +--^--+   +---^--+      +---^--+     +--^--+
-// | Function0 |   | Function1 |   | ... |   | UDT0 |      | UDT1 |     | ... |         Source Symbols
+// | Function0 |   | Function1 |   | ... |   | UDT0 |      | UDT1 |     | ... |
+// Source Symbols
 // +-----+-----+   +-----+-----+   +-----+   +---+--+      +---+--+     +-----+
 //       |               |                       |             |
 //  +----^----+     +----^----+             +----^----+   +----^----+
 //  | Locals0 |     | Locals1 |             | Fields0 |   | Fields1 |
 //  +---------+     +---------+             +---------+   +---------+
 
-static const std::string & DxilEntryName(Session *pSession);
+static const std::string &DxilEntryName(Session *pSession);
 
-template <typename S, typename... C, typename = typename std::enable_if<!std::is_same<Symbol, S>::value>::type>
-HRESULT AllocAndInit(
-  IMalloc *pMalloc,
-  Session *pSession,
-  DWORD dwIndex,
-  DWORD dwSymTag,
-  S **ppSymbol,
-  C... ctorArgs) {
+template <
+    typename S, typename... C,
+    typename = typename std::enable_if<!std::is_same<Symbol, S>::value>::type>
+HRESULT AllocAndInit(IMalloc *pMalloc, Session *pSession, DWORD dwIndex,
+                     DWORD dwSymTag, S **ppSymbol, C... ctorArgs) {
   *ppSymbol = S::Alloc(pMalloc, ctorArgs...);
   if (*ppSymbol == nullptr) {
     return E_OUTOFMEMORY;
@@ -84,29 +84,26 @@ HRESULT AllocAndInit(
   return S_OK;
 }
 
-template <typename T, typename R>
-T *dyn_cast_to_ditype(R ref) {
-  return llvm::dyn_cast<T>((llvm::Metadata *) ref);
+template <typename T, typename R> T *dyn_cast_to_ditype(R ref) {
+  return llvm::dyn_cast<T>((llvm::Metadata *)ref);
 }
 
-template <typename T, typename R>
-T *dyn_cast_to_ditype_or_null(R ref) {
-  return llvm::dyn_cast_or_null<T>((llvm::Metadata *) ref);
+template <typename T, typename R> T *dyn_cast_to_ditype_or_null(R ref) {
+  return llvm::dyn_cast_or_null<T>((llvm::Metadata *)ref);
 }
 
-template <typename N>
-struct DISymbol : public Symbol {
+template <typename N> struct DISymbol : public Symbol {
   DISymbol(IMalloc *M, N Node) : Symbol(M), m_pNode(Node) {}
 
   N m_pNode;
 };
 
-template <typename N>
-struct TypedSymbol : public DISymbol<N> {
-  TypedSymbol(IMalloc *M, N Node, DWORD dwTypeID, llvm::DIType *Type) : DISymbol(M, Node), m_dwTypeID(dwTypeID), m_pType(Type) {}
+template <typename N> struct TypedSymbol : public DISymbol<N> {
+  TypedSymbol(IMalloc *M, N Node, DWORD dwTypeID, llvm::DIType *Type)
+      : DISymbol(M, Node), m_dwTypeID(dwTypeID), m_pType(Type) {}
 
   STDMETHODIMP get_type(
-    /* [retval][out] */ IDiaSymbol **ppRetVal) override {
+      /* [retval][out] */ IDiaSymbol **ppRetVal) override {
     if (ppRetVal == nullptr) {
       return E_INVALIDARG;
     }
@@ -137,40 +134,42 @@ struct GlobalScopeSymbol : public Symbol {
 namespace symbol_factory {
 class GlobalScope final : public SymbolManager::SymbolFactory {
 public:
-    GlobalScope(DWORD ID, DWORD ParentID)
-        : SymbolManager::SymbolFactory(ID, ParentID) {}
+  GlobalScope(DWORD ID, DWORD ParentID)
+      : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        return hlsl_symbols::GlobalScopeSymbol::Create(pMalloc, pSession, ppRet);
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    return hlsl_symbols::GlobalScopeSymbol::Create(pMalloc, pSession, ppRet);
+  }
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct CompilandSymbol : public DISymbol<llvm::DICompileUnit *> {
   DXC_MICROCOM_TM_ALLOC(CompilandSymbol)
-  explicit CompilandSymbol(IMalloc *M, llvm::DICompileUnit *CU) : DISymbol<llvm::DICompileUnit *>(M, CU) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, llvm::DICompileUnit *CU, Symbol **ppSym);
+  explicit CompilandSymbol(IMalloc *M, llvm::DICompileUnit *CU)
+      : DISymbol<llvm::DICompileUnit *>(M, CU) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession,
+                        llvm::DICompileUnit *CU, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class Compiland final : public SymbolManager::SymbolFactory {
 public:
-    Compiland(DWORD ID, DWORD ParentID, llvm::DICompileUnit *CU)
-        : SymbolManager::SymbolFactory(ID, ParentID), m_CU(CU) {}
+  Compiland(DWORD ID, DWORD ParentID, llvm::DICompileUnit *CU)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_CU(CU) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(hlsl_symbols::CompilandSymbol::Create(pMalloc, pSession, m_CU, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(hlsl_symbols::CompilandSymbol::Create(pMalloc, pSession, m_CU, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 
 private:
-    llvm::DICompileUnit *m_CU;
+  llvm::DICompileUnit *m_CU;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct CompilandDetailsSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(CompilandDetailsSymbol)
@@ -191,14 +190,14 @@ struct CompilandDetailsSymbol : public Symbol {
 // be static (thus requiring the explicit <this> parameter) so that
 // DEFINE_SIMPLE_GETTER can use decltype(name(nullptr)) in order to
 // define the property parameter type.
-#define DEFINE_SIMPLE_GETTER(name)                                        \
-    STDMETHODIMP get_ ## name(decltype(name(nullptr)) *pValue) override { \
-      if (pValue == nullptr) {                                            \
-        return E_INVALIDARG;                                              \
-      }                                                                   \
-      *pValue = name(this);                                               \
-      return S_OK;                                                        \
-    }
+#define DEFINE_SIMPLE_GETTER(name)                                             \
+  STDMETHODIMP get_##name(decltype(name(nullptr)) *pValue) override {          \
+    if (pValue == nullptr) {                                                   \
+      return E_INVALIDARG;                                                     \
+    }                                                                          \
+    *pValue = name(this);                                                      \
+    return S_OK;                                                               \
+  }
 
   static constexpr DWORD platform(CompilandDetailsSymbol *) { return 256; }
   static constexpr DWORD language(CompilandDetailsSymbol *) { return 16; }
@@ -228,107 +227,121 @@ struct CompilandDetailsSymbol : public Symbol {
 namespace symbol_factory {
 class CompilandDetails final : public SymbolManager::SymbolFactory {
 public:
-    CompilandDetails(DWORD ID, DWORD ParentID)
-        : SymbolManager::SymbolFactory(ID, ParentID) {}
+  CompilandDetails(DWORD ID, DWORD ParentID)
+      : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(hlsl_symbols::CompilandDetailsSymbol::Create(pMalloc, pSession, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(hlsl_symbols::CompilandDetailsSymbol::Create(pMalloc, pSession, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct CompilandEnvSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(CompilandEnvSymbol)
   explicit CompilandEnvSymbol(IMalloc *M) : Symbol(M) {}
-  static HRESULT CreateFlags(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
-  static HRESULT CreateTarget(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
-  static HRESULT CreateEntry(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
-  static HRESULT CreateDefines(IMalloc *pMalloc, Session *pSession, Symbol **pSym);
-  static HRESULT CreateArguments(IMalloc *pMalloc, Session *pSession, Symbol **ppSym);
+  static HRESULT CreateFlags(IMalloc *pMalloc, Session *pSession,
+                             Symbol **ppSym);
+  static HRESULT CreateTarget(IMalloc *pMalloc, Session *pSession,
+                              Symbol **ppSym);
+  static HRESULT CreateEntry(IMalloc *pMalloc, Session *pSession,
+                             Symbol **ppSym);
+  static HRESULT CreateDefines(IMalloc *pMalloc, Session *pSession,
+                               Symbol **pSym);
+  static HRESULT CreateArguments(IMalloc *pMalloc, Session *pSession,
+                                 Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 using CompilandEnvCreateFn = HRESULT(IMalloc *, Session *, Symbol **);
-template<CompilandEnvCreateFn C>
+template <CompilandEnvCreateFn C>
 class CompilandEnv final : public SymbolManager::SymbolFactory {
 public:
-    CompilandEnv(DWORD ID, DWORD ParentID)
-        : SymbolManager::SymbolFactory(ID, ParentID) {}
+  CompilandEnv(DWORD ID, DWORD ParentID)
+      : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(C(pMalloc, pSession, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(C(pMalloc, pSession, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct FunctionSymbol : public TypedSymbol<llvm::DISubprogram *> {
   DXC_MICROCOM_TM_ALLOC(FunctionSymbol)
-  FunctionSymbol(IMalloc *M, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DISubprogram *>(M, Node, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
+  FunctionSymbol(IMalloc *M, llvm::DISubprogram *Node, DWORD dwTypeID,
+                 llvm::DIType *Type)
+      : TypedSymbol<llvm::DISubprogram *>(M, Node, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
+                        llvm::DISubprogram *Node, DWORD dwTypeID,
+                        llvm::DIType *Type, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class Function final : public SymbolManager::SymbolFactory {
 public:
-    Function(DWORD ID, DWORD ParentID, llvm::DISubprogram *Node, DWORD TypeID)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_TypeID(TypeID) {}
+  Function(DWORD ID, DWORD ParentID, llvm::DISubprogram *Node, DWORD TypeID)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_TypeID(TypeID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(FunctionSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Node->getType(), ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(FunctionSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
+                               m_Node->getType(), ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+    return S_OK;
+  }
 
 private:
-    llvm::DISubprogram *m_Node;
-    DWORD m_TypeID;
+  llvm::DISubprogram *m_Node;
+  DWORD m_TypeID;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct FunctionBlockSymbol : public Symbol {
   DXC_MICROCOM_TM_ALLOC(FunctionBlockSymbol)
   explicit FunctionBlockSymbol(IMalloc *M) : Symbol(M) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, Symbol **ppSym);
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
+                        Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class FunctionBlock final : public SymbolManager::SymbolFactory {
 public:
-    FunctionBlock(DWORD ID, DWORD ParentID)
-        : SymbolManager::SymbolFactory(ID, ParentID) {}
+  FunctionBlock(DWORD ID, DWORD ParentID)
+      : SymbolManager::SymbolFactory(ID, ParentID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(FunctionBlockSymbol::Create(pMalloc, pSession, m_ID, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(FunctionBlockSymbol::Create(pMalloc, pSession, m_ID, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct TypeSymbol : public DISymbol<llvm::DIType *> {
   using LazySymbolName = std::function<HRESULT(Session *, std::string *)>;
   DXC_MICROCOM_TM_ALLOC(TypeSymbol)
-  TypeSymbol(IMalloc *M, llvm::DIType *Node, LazySymbolName LazySymbolName) : DISymbol<llvm::DIType *>(M, Node), m_lazySymbolName(LazySymbolName) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st, llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym);
+  TypeSymbol(IMalloc *M, llvm::DIType *Node, LazySymbolName LazySymbolName)
+      : DISymbol<llvm::DIType *>(M, Node), m_lazySymbolName(LazySymbolName) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
+                        DWORD dwID, DWORD st, llvm::DIType *Node,
+                        LazySymbolName LazySymbolName, Symbol **ppSym);
   STDMETHODIMP get_name(
-    /* [retval][out] */ BSTR *pRetVal) override;
+      /* [retval][out] */ BSTR *pRetVal) override;
   STDMETHODIMP get_baseType(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_length(
-    /* [retval][out] */ ULONGLONG *pRetVal) override;
+      /* [retval][out] */ ULONGLONG *pRetVal) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 
@@ -338,31 +351,36 @@ struct TypeSymbol : public DISymbol<llvm::DIType *> {
 namespace symbol_factory {
 class Type final : public SymbolManager::SymbolFactory {
 public:
-    Type(DWORD ID, DWORD ParentID, DWORD st, llvm::DIType *Node, TypeSymbol::LazySymbolName LazySymbolName)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_st(st), m_Node(Node), m_LazySymbolName(LazySymbolName) {}
+  Type(DWORD ID, DWORD ParentID, DWORD st, llvm::DIType *Node,
+       TypeSymbol::LazySymbolName LazySymbolName)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_st(st), m_Node(Node),
+        m_LazySymbolName(LazySymbolName) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(TypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_st, m_Node, m_LazySymbolName, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(TypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_st, m_Node,
+                           m_LazySymbolName, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 
 private:
-    DWORD m_st;
-    llvm::DIType *m_Node;
-    TypeSymbol::LazySymbolName m_LazySymbolName;
+  DWORD m_st;
+  llvm::DIType *m_Node;
+  TypeSymbol::LazySymbolName m_LazySymbolName;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct TypedefTypeSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(TypedefTypeSymbol)
-  TypedefTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwBaseTypeID) : TypeSymbol(M, Node, nullptr), m_dwBaseTypeID(dwBaseTypeID) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym);
+  TypedefTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwBaseTypeID)
+      : TypeSymbol(M, Node, nullptr), m_dwBaseTypeID(dwBaseTypeID) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
+                        DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID,
+                        Symbol **ppSym);
 
   STDMETHODIMP get_type(
-    /* [retval][out] */ IDiaSymbol **ppRetVal) override;
+      /* [retval][out] */ IDiaSymbol **ppRetVal) override;
 
   const DWORD m_dwBaseTypeID;
 };
@@ -370,33 +388,39 @@ struct TypedefTypeSymbol : public TypeSymbol {
 namespace symbol_factory {
 class TypedefType final : public SymbolManager::SymbolFactory {
 public:
-    TypedefType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD BaseTypeID)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_BaseTypeID(BaseTypeID) {}
+  TypedefType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD BaseTypeID)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_BaseTypeID(BaseTypeID) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(TypedefTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_BaseTypeID, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(TypedefTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
+                                  m_BaseTypeID, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+    return S_OK;
+  }
 
 private:
-    llvm::DIType *m_Node;
-    DWORD m_BaseTypeID;
+  llvm::DIType *m_Node;
+  DWORD m_BaseTypeID;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct VectorTypeSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(VectorTypeSymbol)
-  VectorTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts) : TypeSymbol(M, Node, nullptr), m_ElemTyID(dwElemTyID), m_NumElts(NumElts) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts, Symbol **ppSym);
+  VectorTypeSymbol(IMalloc *M, llvm::DIType *Node, DWORD dwElemTyID,
+                   std::uint32_t NumElts)
+      : TypeSymbol(M, Node, nullptr), m_ElemTyID(dwElemTyID),
+        m_NumElts(NumElts) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
+                        DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID,
+                        std::uint32_t NumElts, Symbol **ppSym);
 
   STDMETHODIMP get_count(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_type(
-    /* [retval][out] */ IDiaSymbol **ppRetVal) override;
+      /* [retval][out] */ IDiaSymbol **ppRetVal) override;
 
   std::uint32_t m_ElemTyID;
   std::uint32_t m_NumElts;
@@ -405,101 +429,121 @@ struct VectorTypeSymbol : public TypeSymbol {
 namespace symbol_factory {
 class VectorType final : public SymbolManager::SymbolFactory {
 public:
-    VectorType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD ElemTyID, std::uint32_t NumElts)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_ElemTyID(ElemTyID), m_NumElts(NumElts) {}
+  VectorType(DWORD ID, DWORD ParentID, llvm::DIType *Node, DWORD ElemTyID,
+             std::uint32_t NumElts)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_ElemTyID(ElemTyID), m_NumElts(NumElts) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(VectorTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_ElemTyID, m_NumElts, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(VectorTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
+                                 m_ElemTyID, m_NumElts, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+    return S_OK;
+  }
 
 private:
-    llvm::DIType *m_Node;
-    DWORD m_ElemTyID;
-    std::uint32_t m_NumElts;
+  llvm::DIType *m_Node;
+  DWORD m_ElemTyID;
+  std::uint32_t m_NumElts;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct UDTSymbol : public TypeSymbol {
   DXC_MICROCOM_TM_ALLOC(UDTSymbol)
-  UDTSymbol(IMalloc *M, llvm::DICompositeType *Node, LazySymbolName LazyName) : TypeSymbol(M, Node, LazyName) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DICompositeType *Node, LazySymbolName LazySymbolName, Symbol **ppSym);
+  UDTSymbol(IMalloc *M, llvm::DICompositeType *Node, LazySymbolName LazyName)
+      : TypeSymbol(M, Node, LazyName) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID,
+                        DWORD dwID, llvm::DICompositeType *Node,
+                        LazySymbolName LazySymbolName, Symbol **ppSym);
 };
 
 namespace symbol_factory {
 class UDT final : public SymbolManager::SymbolFactory {
 public:
-    UDT(DWORD ID, DWORD ParentID, llvm::DICompositeType *Node, TypeSymbol::LazySymbolName LazySymbolName)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_LazySymbolName(LazySymbolName) {}
+  UDT(DWORD ID, DWORD ParentID, llvm::DICompositeType *Node,
+      TypeSymbol::LazySymbolName LazySymbolName)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_LazySymbolName(LazySymbolName) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(UDTSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node, m_LazySymbolName, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(UDTSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
+                          m_LazySymbolName, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    return S_OK;
+  }
 
 private:
-    llvm::DICompositeType *m_Node;
-    TypeSymbol::LazySymbolName m_LazySymbolName;
+  llvm::DICompositeType *m_Node;
+  TypeSymbol::LazySymbolName m_LazySymbolName;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct GlobalVariableSymbol : public TypedSymbol<llvm::DIGlobalVariable *> {
   DXC_MICROCOM_TM_ALLOC(GlobalVariableSymbol)
-  GlobalVariableSymbol(IMalloc *M, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DIGlobalVariable *>(M, GV, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
+  GlobalVariableSymbol(IMalloc *M, llvm::DIGlobalVariable *GV, DWORD dwTypeID,
+                       llvm::DIType *Type)
+      : TypedSymbol<llvm::DIGlobalVariable *>(M, GV, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
+                        llvm::DIGlobalVariable *GV, DWORD dwTypeID,
+                        llvm::DIType *Type, Symbol **ppSym);
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
 
 namespace symbol_factory {
 class GlobalVariable final : public SymbolManager::SymbolFactory {
 public:
-    GlobalVariable(DWORD ID, DWORD ParentID, llvm::DIGlobalVariable *GV, DWORD TypeID, llvm::DIType *Type)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_GV(GV), m_TypeID(TypeID), m_Type(Type) {}
+  GlobalVariable(DWORD ID, DWORD ParentID, llvm::DIGlobalVariable *GV,
+                 DWORD TypeID, llvm::DIType *Type)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_GV(GV), m_TypeID(TypeID),
+        m_Type(Type) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(GlobalVariableSymbol::Create(pMalloc, pSession, m_ID, m_GV, m_TypeID, m_Type, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str()));
-        (*ppRet)->SetIsHLSLData(true);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(GlobalVariableSymbol::Create(pMalloc, pSession, m_ID, m_GV, m_TypeID,
+                                     m_Type, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str()));
+    (*ppRet)->SetIsHLSLData(true);
+    return S_OK;
+  }
 
 private:
-    llvm::DIGlobalVariable *m_GV;
-    DWORD m_TypeID;
-    llvm::DIType *m_Type;
+  llvm::DIGlobalVariable *m_GV;
+  DWORD m_TypeID;
+  llvm::DIType *m_Type;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct LocalVariableSymbol : public TypedSymbol<llvm::DIVariable *> {
   DXC_MICROCOM_TM_ALLOC(LocalVariableSymbol)
-  LocalVariableSymbol(IMalloc *M, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum) : TypedSymbol<llvm::DIVariable *>(M, Node, dwTypeID, Type), m_dwOffsetInUDT(dwOffsetInUDT), m_dwDxilRegNum(dwDxilRegNum) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD m_dwDxilRegNum, Symbol **ppSym);
+  LocalVariableSymbol(IMalloc *M, llvm::DIVariable *Node, DWORD dwTypeID,
+                      llvm::DIType *Type, DWORD dwOffsetInUDT,
+                      DWORD dwDxilRegNum)
+      : TypedSymbol<llvm::DIVariable *>(M, Node, dwTypeID, Type),
+        m_dwOffsetInUDT(dwOffsetInUDT), m_dwDxilRegNum(dwDxilRegNum) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
+                        llvm::DIVariable *Node, DWORD dwTypeID,
+                        llvm::DIType *Type, DWORD dwOffsetInUDT,
+                        DWORD m_dwDxilRegNum, Symbol **ppSym);
   STDMETHODIMP get_locationType(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_isAggregated(
-    /* [retval][out] */ BOOL *pRetVal) override;
+      /* [retval][out] */ BOOL *pRetVal) override;
   STDMETHODIMP get_registerType(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_offsetInUdt(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_sizeInUdt(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_numberOfRegisterIndices(
-    /* [retval][out] */ DWORD *pRetVal) override;
+      /* [retval][out] */ DWORD *pRetVal) override;
   STDMETHODIMP get_numericProperties(
-    /* [in] */ DWORD cnt,
-    /* [out] */ DWORD *pcnt,
-    /* [size_is][out] */ DWORD *pProperties) override;
+      /* [in] */ DWORD cnt,
+      /* [out] */ DWORD *pcnt,
+      /* [size_is][out] */ DWORD *pProperties) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 
@@ -530,33 +574,44 @@ private:
 
 class LocalVariable final : public SymbolManager::SymbolFactory {
 public:
-    LocalVariable(DWORD ID, DWORD ParentID, llvm::DIVariable *Node, DWORD TypeID, llvm::DIType *Type, std::shared_ptr<LocalVarInfo> VI)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_TypeID(TypeID), m_Type(Type), m_VI(VI) {}
+  LocalVariable(DWORD ID, DWORD ParentID, llvm::DIVariable *Node, DWORD TypeID,
+                llvm::DIType *Type, std::shared_ptr<LocalVarInfo> VI)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_TypeID(TypeID), m_Type(Type), m_VI(VI) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(LocalVariableSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Type, m_VI->GetOffsetInUDT(), m_VI->GetDxilRegister(), ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-        (*ppRet)->SetDataKind(m_Node->getTag() == llvm::dwarf::DW_TAG_arg_variable ? DataIsParam : DataIsLocal);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(LocalVariableSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
+                                    m_Type, m_VI->GetOffsetInUDT(),
+                                    m_VI->GetDxilRegister(), ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+    (*ppRet)->SetDataKind(m_Node->getTag() == llvm::dwarf::DW_TAG_arg_variable
+                              ? DataIsParam
+                              : DataIsLocal);
+    return S_OK;
+  }
+
+  llvm::DIVariable *Node() const { return m_Node; }
 
 private:
-    llvm::DIVariable *m_Node;
-    DWORD m_TypeID;
-    llvm::DIType *m_Type;
-    std::shared_ptr<LocalVarInfo> m_VI;
+  llvm::DIVariable *m_Node;
+  DWORD m_TypeID;
+  llvm::DIType *m_Type;
+  std::shared_ptr<LocalVarInfo> m_VI;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 struct UDTFieldSymbol : public TypedSymbol<llvm::DIDerivedType *> {
   DXC_MICROCOM_TM_ALLOC(UDTFieldSymbol)
-  UDTFieldSymbol(IMalloc *M, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type) : TypedSymbol<llvm::DIDerivedType *>(M, Node, dwTypeID, Type) {}
-  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym);
+  UDTFieldSymbol(IMalloc *M, llvm::DIDerivedType *Node, DWORD dwTypeID,
+                 llvm::DIType *Type)
+      : TypedSymbol<llvm::DIDerivedType *>(M, Node, dwTypeID, Type) {}
+  static HRESULT Create(IMalloc *pMalloc, Session *pSession, DWORD dwID,
+                        llvm::DIDerivedType *Node, DWORD dwTypeID,
+                        llvm::DIType *Type, Symbol **ppSym);
   STDMETHODIMP get_offset(
-    /* [retval][out] */ LONG *pRetVal) override;
+      /* [retval][out] */ LONG *pRetVal) override;
 
   HRESULT GetChildren(std::vector<CComPtr<Symbol>> *children) override;
 };
@@ -564,29 +619,33 @@ struct UDTFieldSymbol : public TypedSymbol<llvm::DIDerivedType *> {
 namespace symbol_factory {
 class UDTField final : public SymbolManager::SymbolFactory {
 public:
-    UDTField(DWORD ID, DWORD ParentID, llvm::DIDerivedType *Node, DWORD TypeID, llvm::DIType *Type)
-        : SymbolManager::SymbolFactory(ID, ParentID),
-          m_Node(Node), m_TypeID(TypeID), m_Type(Type) {}
+  UDTField(DWORD ID, DWORD ParentID, llvm::DIDerivedType *Node, DWORD TypeID,
+           llvm::DIType *Type)
+      : SymbolManager::SymbolFactory(ID, ParentID), m_Node(Node),
+        m_TypeID(TypeID), m_Type(Type) {}
 
-    virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
-        IMalloc *pMalloc = pSession->GetMallocNoRef();
-        IFR(UDTFieldSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID, m_Type, ppRet));
-        (*ppRet)->SetLexicalParent(m_ParentID);
-        (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
-        (*ppRet)->SetDataKind(m_Node->isStaticMember() ? DataIsStaticLocal : DataIsMember);
-        return S_OK;
-    }
+  virtual HRESULT Create(Session *pSession, Symbol **ppRet) override {
+    IMalloc *pMalloc = pSession->GetMallocNoRef();
+    IFR(UDTFieldSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
+                               m_Type, ppRet));
+    (*ppRet)->SetLexicalParent(m_ParentID);
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
+    (*ppRet)->SetDataKind(m_Node->isStaticMember() ? DataIsStaticLocal
+                                                   : DataIsMember);
+    return S_OK;
+  }
 
 private:
-    llvm::DIDerivedType *m_Node;
-    DWORD m_TypeID;
-    llvm::DIType *m_Type;
+  llvm::DIDerivedType *m_Node;
+  DWORD m_TypeID;
+  llvm::DIType *m_Type;
 };
-}  // namespace symbol_factory
+} // namespace symbol_factory
 
 class SymbolManagerInit {
 public:
-  using SymbolCtor = std::function<HRESULT(Session *pSession, DWORD ID, Symbol **ppSym)>;
+  using SymbolCtor =
+      std::function<HRESULT(Session *pSession, DWORD ID, Symbol **ppSym)>;
 
   using LazySymbolName = TypeSymbol::LazySymbolName;
 
@@ -611,7 +670,8 @@ public:
     std::vector<llvm::DIType *> m_Layout;
     DWORD m_dwCurrentSizeInBytes = 0;
   };
-  using TypeToInfoMap = llvm::DenseMap<llvm::DIType *, std::unique_ptr<TypeInfo> >;
+  using TypeToInfoMap =
+      llvm::DenseMap<llvm::DIType *, std::unique_ptr<TypeInfo>>;
 
   // Because of the way the VarToID map is constructed, the
   // vector<LocalVarInfo> may need to grow. The Symbol Constructor for local
@@ -627,59 +687,76 @@ public:
   using UDTFieldToIDMap = llvm::DenseMap<llvm::DIDerivedType *, DWORD>;
 
   SymbolManagerInit(
-    Session *pSession,
-    std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
-    SymbolManager::ScopeToIDMap *pScopeToSym,
-    SymbolManager::IDToLiveRangeMap *pSymToLR);
+      Session *pSession,
+      std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
+      SymbolManager::ScopeToIDMap *pScopeToSym,
+      SymbolManager::IDToLiveRangeMap *pSymToLR);
 
   template <typename Factory, typename... Args>
-  HRESULT AddSymbol(DWORD dwParentID, DWORD *pNewSymID, Args&&... args) {
-      if (dwParentID > m_SymCtors.size()) {
-          return E_FAIL;
-      }
+  HRESULT AddSymbol(DWORD dwParentID, DWORD *pNewSymID, Args &&... args) {
+    if (dwParentID > m_SymCtors.size()) {
+      return E_FAIL;
+    }
 
-      const DWORD dwNewSymID = m_SymCtors.size() + 1;
-      m_SymCtors.emplace_back(std::unique_ptr<Factory>(new Factory(dwNewSymID, dwParentID, std::forward<Args>(args)...)));
-      *pNewSymID = dwNewSymID;
-      IFR(AddParent(dwParentID));
-      return S_OK;
+    const DWORD dwNewSymID = m_SymCtors.size() + 1;
+    m_SymCtors.emplace_back(std::unique_ptr<Factory>(
+        new Factory(dwNewSymID, dwParentID, std::forward<Args>(args)...)));
+    *pNewSymID = dwNewSymID;
+    IFR(AddParent(dwParentID));
+    return S_OK;
   }
 
   HRESULT CreateFunctionsForAllCUs();
   HRESULT CreateGlobalVariablesForAllCUs();
   HRESULT CreateLocalVariables();
   HRESULT CreateLiveRanges();
-  HRESULT IsDbgDeclareCall(llvm::Module *M, const llvm::Instruction *I, DWORD *pReg, DWORD *pRegSize, llvm::DILocalVariable **LV, uint64_t *pStartOffset, uint64_t *pEndOffset);
-  HRESULT GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize);
-  HRESULT PopulateParentToChildrenIDMap(SymbolManager::ParentToChildrenMap *pParentToChildren);
+  HRESULT IsDbgDeclareCall(llvm::Module *M, const llvm::Instruction *I,
+                           DWORD *pReg, DWORD *pRegSize,
+                           llvm::DILocalVariable **LV, uint64_t *pStartOffset,
+                           uint64_t *pEndOffset, dxil_dia::Session::RVA *pLowestUserRVA,
+                           dxil_dia::Session::RVA *pHighestUserRVA );
+  HRESULT GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum,
+                                DWORD *pRegSize);
+  HRESULT PopulateParentToChildrenIDMap(
+      SymbolManager::ParentToChildrenMap *pParentToChildren);
 
 private:
   HRESULT GetTypeInfo(llvm::DIType *T, TypeInfo **TI);
 
-  template<typename Factory, typename... Args>
-  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID, Args&&... args) {
-      IFR(AddSymbol<Factory>(dwParentID, pNewSymID, std::forward<Args>(args)...));
-      if (!m_TypeToInfo.insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID))).second) {
-          return E_FAIL;
-      }
-      return S_OK;
+  template <typename Factory, typename... Args>
+  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID,
+                  Args &&... args) {
+    IFR(AddSymbol<Factory>(dwParentID, pNewSymID, std::forward<Args>(args)...));
+    if (!m_TypeToInfo
+             .insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID)))
+             .second) {
+      return E_FAIL;
+    }
+    return S_OK;
   }
 
   HRESULT AddParent(DWORD dwParentIndex);
-  HRESULT CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS, DWORD *pNewSymID);
+  HRESULT CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS,
+                                           DWORD *pNewSymID);
   HRESULT CreateFunctionBlockForInstruction(llvm::Instruction *I);
   HRESULT CreateFunctionBlocksForFunction(llvm::Function *F);
   HRESULT CreateFunctionsForCU(llvm::DICompileUnit *CU);
   HRESULT CreateGlobalVariablesForCU(llvm::DICompileUnit *CU);
   HRESULT GetScopeID(llvm::DIScope *S, DWORD *pScopeID);
   HRESULT CreateType(llvm::DIType *T, DWORD *pNewTypeID);
-  HRESULT CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID);
-  HRESULT CreateBasicType(DWORD dwParentID, llvm::DIBasicType *VT, DWORD *pNewTypeID);
-  HRESULT CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID);
+  HRESULT CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST,
+                               DWORD *pNewTypeID);
+  HRESULT CreateBasicType(DWORD dwParentID, llvm::DIBasicType *VT,
+                          DWORD *pNewTypeID);
+  HRESULT CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT,
+                              DWORD *pNewTypeID);
   HRESULT CreateHLSLType(llvm::DICompositeType *T, DWORD *pNewTypeID);
-  HRESULT IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt);
-  HRESULT CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt, DWORD *pNewTypeID);
-  HRESULT HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID);
+  HRESULT IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID,
+                           std::uint32_t *pElemCnt);
+  HRESULT CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID,
+                               std::uint32_t pElemCnt, DWORD *pNewTypeID);
+  HRESULT HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT,
+                            DWORD *pNewTypeID);
   HRESULT CreateLocalVariable(DWORD dwParentID, llvm::DILocalVariable *LV);
   HRESULT GetTypeLayout(llvm::DIType *Ty, std::vector<DWORD> *pRet);
   HRESULT CreateUDTField(DWORD dwParentID, llvm::DIDerivedType *Field);
@@ -719,14 +796,13 @@ private:
   UDTScope BeginUDTScope(TypeInfo *pNext) {
     return UDTScope(&m_pCurUDT, pNext);
   }
-
 };
 
-}  // namespace hlsl_symbols
-}  // namespace dxil_dia
+} // namespace hlsl_symbols
+} // namespace dxil_dia
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -736,13 +812,17 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
     const DWORD SizeInBits = BT->getSizeInBits();
     switch (BT->getEncoding()) {
     case llvm::dwarf::DW_ATE_boolean:
-      *pRetVal = btBool; break;
+      *pRetVal = btBool;
+      break;
     case llvm::dwarf::DW_ATE_unsigned:
-      *pRetVal = btUInt; break;
+      *pRetVal = btUInt;
+      break;
     case llvm::dwarf::DW_ATE_signed:
-      *pRetVal = btInt; break;
+      *pRetVal = btInt;
+      break;
     case llvm::dwarf::DW_ATE_float:
-      *pRetVal = btFloat; break;
+      *pRetVal = btFloat;
+      break;
     }
   }
 
@@ -750,7 +830,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_baseType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_length(
-  /* [retval][out] */ ULONGLONG *pRetVal) {
+    /* [retval][out] */ ULONGLONG *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -765,75 +845,103 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_length(
   return S_OK;
 }
 
-static const std::string &dxil_dia::hlsl_symbols::DxilEntryName(Session *pSession) {
+static const std::string &
+dxil_dia::hlsl_symbols::DxilEntryName(Session *pSession) {
   return pSession->DxilModuleRef().GetEntryFunctionName();
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::Create(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslProgramId, SymTagExe, (GlobalScopeSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::Create(IMalloc *pMalloc,
+                                                          Session *pSession,
+                                                          Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslProgramId, SymTagExe,
+                   (GlobalScopeSymbol **)ppSym));
   (*ppSym)->SetName(L"HLSL");
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::GlobalScopeSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::Create(IMalloc *pMalloc, Session *pSession, llvm::DICompileUnit *CU, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandId, SymTagCompiland, (CompilandSymbol**)ppSym, CU));
+HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::Create(IMalloc *pMalloc,
+                                                        Session *pSession,
+                                                        llvm::DICompileUnit *CU,
+                                                        Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandId, SymTagCompiland,
+                   (CompilandSymbol **)ppSym, CU));
   (*ppSym)->SetName(L"main");
   if (pSession->MainFileName()) {
-    llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(pSession->MainFileName()->getOperand(0)->getOperand(0))->getString();
-    std::string str(strRef.begin(), strRef.size()); // To make sure str is null terminated
-    (*ppSym)->SetSourceFileName(_bstr_t(Unicode::UTF8ToUTF16StringOrThrow(str.data()).c_str()));
+    llvm::StringRef strRef =
+        llvm::dyn_cast<llvm::MDString>(
+            pSession->MainFileName()->getOperand(0)->getOperand(0))
+            ->getString();
+    std::string str(strRef.begin(),
+                    strRef.size()); // To make sure str is null terminated
+    (*ppSym)->SetSourceFileName(
+        _bstr_t(Unicode::UTF8ToUTF16StringOrThrow(str.data()).c_str()));
   }
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::Create(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandDetailsId, SymTagCompilandDetails, (CompilandDetailsSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandDetailsId,
+                   SymTagCompilandDetails, (CompilandDetailsSymbol **)ppSym));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandDetailsSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateFlags(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvFlagsId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateFlags(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvFlagsId,
+                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
   (*ppSym)->SetName(L"hlslFlags");
   (*ppSym)->SetValue(pSession->DxilModuleRef().GetGlobalFlags());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateTarget(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvTargetId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateTarget(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvTargetId,
+                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
   (*ppSym)->SetName(L"hlslTarget");
   (*ppSym)->SetValue(pSession->DxilModuleRef().GetShaderModel()->GetName());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateEntry(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvEntryId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateEntry(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvEntryId,
+                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
   (*ppSym)->SetName(L"hlslEntry");
   (*ppSym)->SetValue(DxilEntryName(pSession).c_str());
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvDefinesId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvDefinesId,
+                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
   (*ppSym)->SetName(L"hlslDefines");
   llvm::MDNode *definesNode = pSession->Defines()->getOperand(0);
-  // Construct a double null terminated string for defines with L"\0" as a delimiter
+  // Construct a double null terminated string for defines with L"\0" as a
+  // delimiter
   CComBSTR pBSTR;
-  for (llvm::MDNode::op_iterator it = definesNode->op_begin(); it != definesNode->op_end(); ++it) {
+  for (llvm::MDNode::op_iterator it = definesNode->op_begin();
+       it != definesNode->op_end(); ++it) {
     llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(*it)->getString();
     std::string str(strRef.begin(), strRef.size());
     CA2W cv(str.c_str());
@@ -848,14 +956,17 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(IMalloc *pMall
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvArgumentsId, SymTagCompilandEnv, (CompilandEnvSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(
+    IMalloc *pMalloc, Session *pSession, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, HlslCompilandEnvArgumentsId,
+                   SymTagCompilandEnv, (CompilandEnvSymbol **)ppSym));
   (*ppSym)->SetName(L"hlslArguments");
   auto Arguments = pSession->Arguments()->getOperand(0);
   auto NumArguments = Arguments->getNumOperands();
   std::string args;
   for (unsigned i = 0; i < NumArguments; ++i) {
-    llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(Arguments->getOperand(i))->getString();
+    llvm::StringRef strRef =
+        llvm::dyn_cast<llvm::MDString>(Arguments->getOperand(i))->getString();
     if (!args.empty())
       args.push_back(' ');
     args = args + strRef.str();
@@ -864,36 +975,49 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateArguments(IMalloc *pMa
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagFunction, (FunctionSymbol**)ppSym, Node, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DISubprogram *Node,
+    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagFunction,
+                   (FunctionSymbol **)ppSym, Node, dwTypeID, Type));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::FunctionSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagBlock, (FunctionBlockSymbol**)ppSym));
+HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::Create(IMalloc *pMalloc,
+                                                            Session *pSession,
+                                                            DWORD dwID,
+                                                            Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagBlock,
+                   (FunctionBlockSymbol **)ppSym));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::FunctionBlockSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st, llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, st, (TypeSymbol**)ppSym, Node, LazySymbolName));
+HRESULT dxil_dia::hlsl_symbols::TypeSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, DWORD st,
+    llvm::DIType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, st, (TypeSymbol **)ppSym, Node,
+                   LazySymbolName));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_name(
-  /* [retval][out] */ BSTR *pRetVal) {
+    /* [retval][out] */ BSTR *pRetVal) {
   DxcThreadMalloc TM(m_pSession->GetMallocNoRef());
   if (m_lazySymbolName != nullptr) {
     DXASSERT(!this->HasName(), "Setting type name multiple times.");
@@ -905,17 +1029,22 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_name(
   return Symbol::get_name(pRetVal);
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypeSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::TypeSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   return m_pSession->SymMgr().ChildrenOf(this, children);
 }
 
-HRESULT dxil_dia::hlsl_symbols::VectorTypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagVectorType, (VectorTypeSymbol**)ppSym, Node, dwElemTyID, NumElts));
+HRESULT dxil_dia::hlsl_symbols::VectorTypeSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID,
+    llvm::DIType *Node, DWORD dwElemTyID, std::uint32_t NumElts,
+    Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagVectorType,
+                   (VectorTypeSymbol **)ppSym, Node, dwElemTyID, NumElts));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_count(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -925,7 +1054,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_count(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_type(
-  /* [retval][out] */ IDiaSymbol **ppRetVal) {
+    /* [retval][out] */ IDiaSymbol **ppRetVal) {
   if (ppRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -938,18 +1067,27 @@ STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_type(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DICompositeType *Node, LazySymbolName LazySymbolName, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagUDT, (UDTSymbol**)ppSym, Node, LazySymbolName));
+HRESULT dxil_dia::hlsl_symbols::UDTSymbol::Create(IMalloc *pMalloc,
+                                                  Session *pSession,
+                                                  DWORD dwParentID, DWORD dwID,
+                                                  llvm::DICompositeType *Node,
+                                                  LazySymbolName LazySymbolName,
+                                                  Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagUDT, (UDTSymbol **)ppSym,
+                   Node, LazySymbolName));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::TypedefTypeSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID, llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagTypedef, (TypedefTypeSymbol**)ppSym, Node, dwBaseTypeID));
+HRESULT dxil_dia::hlsl_symbols::TypedefTypeSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwParentID, DWORD dwID,
+    llvm::DIType *Node, DWORD dwBaseTypeID, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagTypedef,
+                   (TypedefTypeSymbol **)ppSym, Node, dwBaseTypeID));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::TypedefTypeSymbol::get_type(
-  /* [retval][out] */ IDiaSymbol **ppRetVal) {
+    /* [retval][out] */ IDiaSymbol **ppRetVal) {
   if (ppRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -962,23 +1100,32 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypedefTypeSymbol::get_type(
   return S_FALSE;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (GlobalVariableSymbol**)ppSym, GV, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIGlobalVariable *GV,
+    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
+                   (GlobalVariableSymbol **)ppSym, GV, dwTypeID, Type));
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::GlobalVariableSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node, DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (LocalVariableSymbol**)ppSym, Node, dwTypeID, Type, dwOffsetInUDT, dwDxilRegNum));
+HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIVariable *Node,
+    DWORD dwTypeID, llvm::DIType *Type, DWORD dwOffsetInUDT, DWORD dwDxilRegNum,
+    Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
+                   (LocalVariableSymbol **)ppSym, Node, dwTypeID, Type,
+                   dwOffsetInUDT, dwDxilRegNum));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_locationType(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -988,7 +1135,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_locationType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_isAggregated(
-  /* [retval][out] */ BOOL *pRetVal) {
+    /* [retval][out] */ BOOL *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -998,7 +1145,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_isAggregated(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_registerType(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1009,7 +1156,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_registerType(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_offsetInUdt(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1019,19 +1166,20 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_offsetInUdt(
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_sizeInUdt(
-  /* [retval][out] */ DWORD *pRetVal) {
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
 
   static constexpr DWORD kBitsPerByte = 8;
-  //auto *DT = llvm::cast<llvm::DIDerivedType>(m_pType);
-  *pRetVal = 4; //DT->getSizeInBits() / kBitsPerByte;
+  // auto *DT = llvm::cast<llvm::DIDerivedType>(m_pType);
+  *pRetVal = 4; // DT->getSizeInBits() / kBitsPerByte;
   return S_OK;
 }
 
-STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIndices(
-  /* [retval][out] */ DWORD *pRetVal) {
+STDMETHODIMP
+dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIndices(
+    /* [retval][out] */ DWORD *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1041,9 +1189,9 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numberOfRegisterIn
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numericProperties(
-  /* [in] */ DWORD cnt,
-  /* [out] */ DWORD *pcnt,
-  /* [size_is][out] */ DWORD *pProperties) {
+    /* [in] */ DWORD cnt,
+    /* [out] */ DWORD *pcnt,
+    /* [size_is][out] */ DWORD *pProperties) {
   if (pcnt == nullptr || pProperties == nullptr || cnt != 1) {
     return E_INVALIDARG;
   }
@@ -1053,18 +1201,22 @@ STDMETHODIMP dxil_dia::hlsl_symbols::LocalVariableSymbol::get_numericProperties(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::LocalVariableSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::Create(IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node, DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
-  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData, (UDTFieldSymbol**)ppSym, Node, dwTypeID, Type));
+HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::Create(
+    IMalloc *pMalloc, Session *pSession, DWORD dwID, llvm::DIDerivedType *Node,
+    DWORD dwTypeID, llvm::DIType *Type, Symbol **ppSym) {
+  IFR(AllocAndInit(pMalloc, pSession, dwID, SymTagData,
+                   (UDTFieldSymbol **)ppSym, Node, dwTypeID, Type));
   return S_OK;
 }
 
 STDMETHODIMP dxil_dia::hlsl_symbols::UDTFieldSymbol::get_offset(
-  /* [retval][out] */ LONG *pRetVal) {
+    /* [retval][out] */ LONG *pRetVal) {
   if (pRetVal == nullptr) {
     return E_INVALIDARG;
   }
@@ -1074,7 +1226,8 @@ STDMETHODIMP dxil_dia::hlsl_symbols::UDTFieldSymbol::get_offset(
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::GetChildren(std::vector<CComPtr<Symbol>> *children) {
+HRESULT dxil_dia::hlsl_symbols::UDTFieldSymbol::GetChildren(
+    std::vector<CComPtr<Symbol>> *children) {
   children->clear();
   return S_OK;
 }
@@ -1084,31 +1237,31 @@ dxil_dia::hlsl_symbols::SymbolManagerInit::SymbolManagerInit(
     std::vector<std::unique_ptr<SymbolManager::SymbolFactory>> *pSymCtors,
     SymbolManager::ScopeToIDMap *pScopeToSym,
     SymbolManager::IDToLiveRangeMap *pSymToLR)
-  : m_Session(*pSession),
-    m_SymCtors(*pSymCtors),
-    m_ScopeToSym(*pScopeToSym),
-    m_SymToLR(*pSymToLR) {
+    : m_Session(*pSession), m_SymCtors(*pSymCtors), m_ScopeToSym(*pScopeToSym),
+      m_SymToLR(*pSymToLR) {
   DXASSERT_ARGS(m_Parent.size() == m_SymCtors.size(),
                 "parent and symbol array size mismatch: %d vs %d",
-                m_Parent.size(),
-                m_SymCtors.size());
+                m_Parent.size(), m_SymCtors.size());
 }
 
-void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::Embed(const TypeInfo &TI) {
+void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::Embed(
+    const TypeInfo &TI) {
   for (const auto &E : TI.GetLayout()) {
     m_Layout.emplace_back(E);
   }
   m_dwCurrentSizeInBytes += TI.m_dwCurrentSizeInBytes;
 }
 
-void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::AddBasicType(llvm::DIBasicType *BT) {
+void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::AddBasicType(
+    llvm::DIBasicType *BT) {
   m_Layout.emplace_back(BT);
 
   static constexpr DWORD kNumBitsPerByte = 8;
   m_dwCurrentSizeInBytes += BT->getSizeInBits() / kNumBitsPerByte;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T, TypeInfo **TI) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T,
+                                                               TypeInfo **TI) {
   auto tyInfoIt = m_TypeToInfo.find(T);
   if (tyInfoIt == m_TypeToInfo.end()) {
     return E_FAIL;
@@ -1118,12 +1271,15 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeInfo(llvm::DIType *T, 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::AddParent(DWORD dwParentIndex) {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::AddParent(DWORD dwParentIndex) {
   m_Parent.emplace_back(dwParentIndex);
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalScope(llvm::DILocalScope *LS, DWORD *pNewSymID) {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalScope(
+    llvm::DILocalScope *LS, DWORD *pNewSymID) {
   if (LS == nullptr) {
     return E_FAIL;
   }
@@ -1159,7 +1315,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForLocalSc
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruction(llvm::Instruction *I) {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruction(
+    llvm::Instruction *I) {
   const llvm::DebugLoc &DL = I->getDebugLoc();
   if (!DL) {
     return S_OK;
@@ -1186,7 +1344,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlockForInstruc
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFunction(llvm::Function *F) {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFunction(
+    llvm::Function *F) {
   for (llvm::BasicBlock &BB : *F) {
     for (llvm::Instruction &I : BB) {
       IFR(CreateFunctionBlockForInstruction(&I));
@@ -1196,14 +1356,17 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionBlocksForFuncti
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(llvm::DICompileUnit *CU) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(
+    llvm::DICompileUnit *CU) {
   bool FoundFunctions = false;
   for (llvm::DISubprogram *SubProgram : CU->getSubprograms()) {
     DWORD dwNewFunID;
-    const DWORD dwParentID = SubProgram->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
+    const DWORD dwParentID =
+        SubProgram->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
     DWORD dwSubprogramTypeID;
     IFR(CreateType(SubProgram->getType(), &dwSubprogramTypeID));
-    IFR(AddSymbol<symbol_factory::Function>(dwParentID, &dwNewFunID, SubProgram, dwSubprogramTypeID));
+    IFR(AddSymbol<symbol_factory::Function>(dwParentID, &dwNewFunID, SubProgram,
+                                            dwSubprogramTypeID));
     m_ScopeToSym.insert(std::make_pair(SubProgram, dwNewFunID));
 
     if (llvm::Function *F = SubProgram->getFunction()) {
@@ -1214,8 +1377,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForCU(llvm::DI
 
   if (!FoundFunctions) {
     // This works around an old bug in dxcompiler whose effects are still
-    // sometimes present in PIX users' traces. (The bug was that the subprogram(s)
-    // weren't pointing to their contained function.)
+    // sometimes present in PIX users' traces. (The bug was that the
+    // subprogram(s) weren't pointing to their contained function.)
     llvm::Module *M = &m_Session.ModuleRef();
     auto &DM = M->GetDxilModule();
     llvm::Function *EntryPoint = DM.GetEntryFunction();
@@ -1232,27 +1395,32 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateFunctionsForAllCUs() {
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForCU(llvm::DICompileUnit *CU) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForCU(
+    llvm::DICompileUnit *CU) {
   for (llvm::DIGlobalVariable *GlobalVariable : CU->getGlobalVariables()) {
     DWORD dwUnusedNewGVID;
-    const DWORD dwParentID = GlobalVariable->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
+    const DWORD dwParentID =
+        GlobalVariable->isLocalToUnit() ? HlslCompilandId : HlslProgramId;
     auto *GVType = dyn_cast_to_ditype<llvm::DIType>(GlobalVariable->getType());
     DWORD dwGVTypeID;
     IFR(CreateType(GVType, &dwGVTypeID));
-    IFR(AddSymbol<symbol_factory::GlobalVariable>(dwParentID, &dwUnusedNewGVID, GlobalVariable, dwGVTypeID, GVType));
+    IFR(AddSymbol<symbol_factory::GlobalVariable>(
+        dwParentID, &dwUnusedNewGVID, GlobalVariable, dwGVTypeID, GVType));
   }
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForAllCUs() {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::CreateGlobalVariablesForAllCUs() {
   for (llvm::DICompileUnit *pCU : m_Session.InfoRef().compile_units()) {
     IFR(CreateGlobalVariablesForCU(pCU));
   }
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S, DWORD *pScopeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S,
+                                                              DWORD *pScopeID) {
   auto ParentScopeIt = m_ScopeToSym.find(S);
   if (ParentScopeIt != m_ScopeToSym.end()) {
     *pScopeID = ParentScopeIt->second;
@@ -1267,7 +1435,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetScopeID(llvm::DIScope *S, 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type, DWORD *pNewTypeID) {
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type,
+                                                      DWORD *pNewTypeID) {
   if (Type == nullptr) {
     return E_FAIL;
   }
@@ -1286,14 +1456,16 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type
     return S_OK;
   } else if (auto *CT = llvm::dyn_cast<llvm::DICompositeType>(Type)) {
     DWORD dwParentID = HlslProgramId;
-    if (auto *ParentScope = dyn_cast_to_ditype_or_null<llvm::DIScope>(CT->getScope())) {
+    if (auto *ParentScope =
+            dyn_cast_to_ditype_or_null<llvm::DIScope>(CT->getScope())) {
       IFR(GetScopeID(ParentScope, &dwParentID));
     }
     IFR(CreateCompositeType(dwParentID, CT, pNewTypeID));
     return S_OK;
   } else if (auto *DT = llvm::dyn_cast<llvm::DIDerivedType>(Type)) {
     DWORD dwParentID = HlslProgramId;
-    if (auto *ParentScope = dyn_cast_to_ditype_or_null<llvm::DIScope>(DT->getScope())) {
+    if (auto *ParentScope =
+            dyn_cast_to_ditype_or_null<llvm::DIScope>(DT->getScope())) {
       IFR(GetScopeID(ParentScope, &dwParentID));
     }
     IFR(HandleDerivedType(dwParentID, DT, pNewTypeID));
@@ -1303,7 +1475,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateType(llvm::DIType *Type
   return E_FAIL;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(
+    DWORD dwParentID, llvm::DISubroutineType *ST, DWORD *pNewTypeID) {
   LazySymbolName LazyName;
 
   llvm::DITypeRefArray Types = ST->getTypeArray();
@@ -1358,23 +1531,25 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(DWORD dw
     };
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID, SymTagFunctionType, ST, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID,
+                                    SymTagFunctionType, ST, LazyName));
 
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(DWORD dwParentID, llvm::DIBasicType *BT, DWORD *pNewTypeID) {
-  DXASSERT_ARGS(dwParentID == HlslProgramId,
-                "%d vs %d",
-                dwParentID,
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(
+    DWORD dwParentID, llvm::DIBasicType *BT, DWORD *pNewTypeID) {
+  DXASSERT_ARGS(dwParentID == HlslProgramId, "%d vs %d", dwParentID,
                 HlslProgramId);
 
-  LazySymbolName LazyName = [BT](Session *pSession, std::string *Name) -> HRESULT {
+  LazySymbolName LazyName = [BT](Session *pSession,
+                                 std::string *Name) -> HRESULT {
     *Name = BT->getName();
     return S_OK;
   };
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, SymTagBaseType, BT, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, SymTagBaseType,
+                                    BT, LazyName));
 
   TypeInfo *TI;
   IFR(GetTypeInfo(BT, &TI));
@@ -1383,10 +1558,12 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(DWORD dwParen
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
+    DWORD dwParentID, llvm::DICompositeType *CT, DWORD *pNewTypeID) {
   switch (CT->getTag()) {
   case llvm::dwarf::DW_TAG_array_type: {
-    auto *BaseType = dyn_cast_to_ditype_or_null<llvm::DIType>(CT->getBaseType());
+    auto *BaseType =
+        dyn_cast_to_ditype_or_null<llvm::DIType>(CT->getBaseType());
     if (BaseType == nullptr) {
       return E_FAIL;
     }
@@ -1394,7 +1571,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
     DWORD dwBaseTypeID = kNullSymbolID;
     IFR(CreateType(BaseType, &dwBaseTypeID));
 
-    auto LazyName = [CT, dwBaseTypeID](Session *pSession, std::string *Name) -> HRESULT {
+    auto LazyName = [CT, dwBaseTypeID](Session *pSession,
+                                       std::string *Name) -> HRESULT {
       auto &SM = pSession->SymMgr();
       Name->clear();
       llvm::raw_string_ostream OS(*Name);
@@ -1433,7 +1611,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
       return S_OK;
     };
 
-    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID, SymTagArrayType, CT, LazyName));
+    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID,
+                                      SymTagArrayType, CT, LazyName));
     TypeInfo *ctTI;
     IFR(GetTypeInfo(CT, &ctTI));
     TypeInfo *baseTI;
@@ -1483,7 +1662,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(llvm::DICompositeType *T, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(
+    llvm::DICompositeType *T, DWORD *pNewTypeID) {
   DWORD dwEltTyID;
   std::uint32_t ElemCnt;
   HRESULT hr;
@@ -1495,7 +1675,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLType(llvm::DICompos
   return S_FALSE;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(
+    llvm::DICompositeType *T, DWORD *pEltTyID, std::uint32_t *pElemCnt) {
   llvm::StringRef Name = T->getName();
   if (!Name.startswith("vector<")) {
     return S_FALSE;
@@ -1522,8 +1703,10 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(llvm::DIComp
   if (ElemCntParam == nullptr) {
     return E_FAIL;
   }
-  auto *ElemCntMD = llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
-  auto *ElemCnt = llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
+  auto *ElemCntMD =
+      llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
+  auto *ElemCnt =
+      llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
   if (ElemCnt == nullptr) {
     return E_FAIL;
   }
@@ -1536,7 +1719,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsHLSLVectorType(llvm::DIComp
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(
+    llvm::DICompositeType *T, DWORD pEltTyID, std::uint32_t pElemCnt,
+    DWORD *pNewTypeID) {
   llvm::DITemplateParameterArray Args = T->getTemplateParams();
   if (Args.size() != 2) {
     return E_FAIL;
@@ -1558,8 +1743,10 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DI
   if (ElemCntParam == nullptr) {
     return E_FAIL;
   }
-  auto *ElemCntMD = llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
-  auto *ElemCnt = llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
+  auto *ElemCntMD =
+      llvm::dyn_cast<llvm::ConstantAsMetadata>(ElemCntParam->getValue());
+  auto *ElemCnt =
+      llvm::dyn_cast_or_null<llvm::ConstantInt>(ElemCntMD->getValue());
   if (ElemCnt == nullptr) {
     return E_FAIL;
   }
@@ -1568,7 +1755,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DI
   }
 
   const DWORD dwParentID = HlslProgramId;
-  IFR(AddType<symbol_factory::VectorType>(dwParentID, T, pNewTypeID, T, dwElemTyID, ElemCnt->getLimitedValue()));
+  IFR(AddType<symbol_factory::VectorType>(
+      dwParentID, T, pNewTypeID, T, dwElemTyID, ElemCnt->getLimitedValue()));
 
   TypeInfo *vecTI;
   IFR(GetTypeInfo(T, &vecTI));
@@ -1581,7 +1769,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DI
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
+    DWORD dwParentID, llvm::DIDerivedType *DT, DWORD *pNewTypeID) {
   DWORD st;
   LazySymbolName LazyName;
 
@@ -1591,7 +1780,9 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
     IFR(CreateType(BaseTy, &dwBaseTypeID));
   }
 
-  auto LazyNameWithQualifier = [dwBaseTypeID, DT](Session *pSession, std::string *Name, const char *Qualifier) -> HRESULT {
+  auto LazyNameWithQualifier = [dwBaseTypeID,
+                                DT](Session *pSession, std::string *Name,
+                                    const char *Qualifier) -> HRESULT {
     auto &SM = pSession->SymMgr();
     Name->clear();
     llvm::raw_string_ostream OS(*Name);
@@ -1632,7 +1823,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
       return E_FAIL;
     }
 
-    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, DT, dwBaseTypeID));
+    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, DT,
+                                             dwBaseTypeID));
 
     TypeInfo *dtTI;
     IFR(GetTypeInfo(DT, &dtTI));
@@ -1648,7 +1840,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
     }
 
     st = SymTagCustomType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " const");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
+                         std::placeholders::_2, " const");
     break;
   }
   case llvm::dwarf::DW_TAG_pointer_type: {
@@ -1657,7 +1850,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
     }
 
     st = SymTagPointerType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " *");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
+                         std::placeholders::_2, " *");
     break;
   }
   case llvm::dwarf::DW_TAG_reference_type: {
@@ -1666,12 +1860,14 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
     }
 
     st = SymTagCustomType;
-    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1, std::placeholders::_2, " &");
+    LazyName = std::bind(LazyNameWithQualifier, std::placeholders::_1,
+                         std::placeholders::_2, " &");
     break;
   }
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, st, DT, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, st, DT,
+                                    LazyName));
 
   if (DT->getTag() == llvm::dwarf::DW_TAG_const_type) {
     TypeInfo *dtTI;
@@ -1684,7 +1880,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(DWORD dwParentID, llvm::DILocalVariable *LV) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(
+    DWORD dwParentID, llvm::DILocalVariable *LV) {
   auto *LVTy = dyn_cast_to_ditype<llvm::DIType>(LV->getType());
   if (LVTy == nullptr) {
     return E_FAIL;
@@ -1709,7 +1906,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(DWORD dwP
     DWORD dwNewLVID;
     newVars.emplace_back(std::make_shared<symbol_factory::LocalVarInfo>());
     std::shared_ptr<symbol_factory::LocalVarInfo> VI = newVars.back();
-    IFR(AddSymbol<symbol_factory::LocalVariable>(dwParentID, &dwNewLVID, LV, dwLVTypeID, LVTy, VI));
+    IFR(AddSymbol<symbol_factory::LocalVariable>(dwParentID, &dwNewLVID, LV,
+                                                 dwLVTypeID, LVTy, VI));
     VI->SetVarID(dwNewLVID);
     VI->SetOffsetInUDT(dwOffsetInUDT);
 
@@ -1719,12 +1917,13 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariable(DWORD dwP
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(llvm::DIType *Ty, std::vector<DWORD> *pRet) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(
+    llvm::DIType *Ty, std::vector<DWORD> *pRet) {
   pRet->clear();
 
   TypeInfo *TI;
   IFR(GetTypeInfo(Ty, &TI));
-  for (llvm::DIType * T : TI->GetLayout()) {
+  for (llvm::DIType *T : TI->GetLayout()) {
     TypeInfo *eTI;
     IFR(GetTypeInfo(T, &eTI));
     pRet->emplace_back(eTI->GetTypeID());
@@ -1732,7 +1931,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetTypeLayout(llvm::DIType *T
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(DWORD dwParentID, llvm::DIDerivedType *Field) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(
+    DWORD dwParentID, llvm::DIDerivedType *Field) {
   auto *FieldTy = dyn_cast_to_ditype<llvm::DIType>(Field->getBaseType());
   if (FieldTy == nullptr) {
     return E_FAIL;
@@ -1746,17 +1946,16 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(DWORD dwParent
   IFR(CreateType(FieldTy, &dwLVTypeID));
   if (m_pCurUDT != nullptr) {
     const DWORD dwOffsetInBytes = CurrentUDTInfo().GetCurrentSizeInBytes();
-    DXASSERT_ARGS(dwOffsetInBytes == Field->getOffsetInBits() / 8,
-      "%d vs %d",
-      dwOffsetInBytes,
-      Field->getOffsetInBits() / 8);
+    DXASSERT_ARGS(dwOffsetInBytes == Field->getOffsetInBits() / 8, "%d vs %d",
+                  dwOffsetInBytes, Field->getOffsetInBits() / 8);
     TypeInfo *lvTI;
     IFR(GetTypeInfo(FieldTy, &lvTI));
     CurrentUDTInfo().Embed(*lvTI);
   }
 
   DWORD dwNewLVID;
-  IFR(AddSymbol<symbol_factory::UDTField>(dwParentID, &dwNewLVID, Field, dwLVTypeID, FieldTy));
+  IFR(AddSymbol<symbol_factory::UDTField>(dwParentID, &dwNewLVID, Field,
+                                          dwLVTypeID, FieldTy));
   m_FieldToID.insert(std::make_pair(Field, dwNewLVID));
   return S_OK;
 }
@@ -1764,17 +1963,21 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(DWORD dwParent
 HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLocalVariables() {
   llvm::Module *M = &m_Session.ModuleRef();
 
-  llvm::Function *DbgDeclare = llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
+  llvm::Function *DbgDeclare =
+      llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
   for (llvm::Value *U : DbgDeclare->users()) {
     auto *CI = llvm::dyn_cast<llvm::CallInst>(U);
-    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(CI->getDebugLoc()->getInlinedAtScope());
+    auto *LS = llvm::dyn_cast_or_null<llvm::DILocalScope>(
+        CI->getDebugLoc()->getInlinedAtScope());
     auto SymIt = m_ScopeToSym.find(LS);
     if (SymIt == m_ScopeToSym.end()) {
       return E_FAIL;
     }
 
-    auto *LocalNameMetadata = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1));
-    if (auto *LV = llvm::dyn_cast<llvm::DILocalVariable>(LocalNameMetadata->getMetadata())) {
+    auto *LocalNameMetadata =
+        llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1));
+    if (auto *LV = llvm::dyn_cast<llvm::DILocalVariable>(
+            LocalNameMetadata->getMetadata())) {
       const DWORD dwParentID = SymIt->second;
       IFR(CreateLocalVariable(dwParentID, LV));
     }
@@ -1792,19 +1995,20 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
   //     if scope not in end_of_scope:
   //       end_of_scope[scope] = rva(I)
   //     if I is dbg.declare:
-  //       live_range[symbol of I] = SymbolManager.LiveRange[RVA(I), end_of_scope[scope]]
+  //       live_range[symbol of I] = SymbolManager.LiveRange[FirstUseRVA,
+  //       end_of_scope[scope]]
   llvm::Module *M = &m_Session.ModuleRef();
   m_SymToLR.clear();
   const auto &Instrs = m_Session.InstructionsRef();
   llvm::DenseMap<llvm::DILocalScope *, Session::RVA> EndOfScope;
   for (auto It = Instrs.rbegin(); It != Instrs.rend(); ++It) {
-    const Session::RVA RVA = It->first;
+    Session::RVA RVA = It->first;
     const auto *I = It->second;
     const llvm::DebugLoc &DL = I->getDebugLoc();
     if (!DL) {
       continue;
     }
-    llvm::MDNode *LocalScope = DL.getInlinedAtScope();
+    llvm::MDNode *LocalScope = DL.getScope();
     if (LocalScope == nullptr) {
       LocalScope = DL.getScope();
     }
@@ -1826,10 +2030,15 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
     llvm::DILocalVariable *LV;
     uint64_t StartOffset;
     uint64_t EndOffset;
-    HRESULT hr = IsDbgDeclareCall(M, I, &Reg, &RegSize, &LV, &StartOffset, &EndOffset);
+    Session::RVA FirstUseRVA;
+    Session::RVA LastUseRVA;
+    HRESULT hr = IsDbgDeclareCall(M, I, &Reg, &RegSize, &LV, &StartOffset,
+                                  &EndOffset, &FirstUseRVA, &LastUseRVA);
     if (hr != S_OK) {
       continue;
     }
+
+    endOfScopeRVA = std::max<Session::RVA>(endOfScopeRVA, LastUseRVA);
 
     auto varIt = m_VarToID.find(LV);
     if (varIt == m_VarToID.end()) {
@@ -1850,23 +2059,25 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateLiveRanges() {
         continue;
       }
       Var->SetDxilRegister(Reg + dwRegIndex);
-      m_SymToLR[Var->GetVarID()] = SymbolManager::LiveRange{
-        static_cast<uint32_t>(RVA),
-        endOfScopeRVA - static_cast<uint32_t>(RVA)
-      };
+      m_SymToLR[Var->GetVarID()] =
+          SymbolManager::LiveRange{static_cast<uint32_t>(FirstUseRVA),
+          endOfScopeRVA - static_cast<uint32_t>(FirstUseRVA)};
     }
-
   }
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(llvm::Module *M, const llvm::Instruction *I, DWORD *pReg, DWORD *pRegSize, llvm::DILocalVariable **LV, uint64_t *pStartOffset, uint64_t *pEndOffset) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(
+    llvm::Module *M, const llvm::Instruction *I, DWORD *pReg, DWORD *pRegSize,
+    llvm::DILocalVariable **LV, uint64_t *pStartOffset, uint64_t *pEndOffset,
+    dxil_dia::Session::RVA *pLowestUserRVA, dxil_dia::Session::RVA *pHighestUserRVA) {
   auto *CI = llvm::dyn_cast<llvm::CallInst>(I);
   if (CI == nullptr) {
     return S_FALSE;
   }
 
-  llvm::Function *DbgDeclare = llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
+  llvm::Function *DbgDeclare =
+      llvm::Intrinsic::getDeclaration(M, llvm::Intrinsic::dbg_declare);
   if (CI->getCalledFunction() != DbgDeclare) {
     return S_FALSE;
   }
@@ -1874,27 +2085,48 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(llvm::Module
   *LV = nullptr;
   *pReg = *pRegSize = 0;
   *pStartOffset = *pEndOffset = 0;
+  *pLowestUserRVA = 0;
+  *pHighestUserRVA = 0;
 
-  if (auto *RegMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
-    if (auto *RegVM = llvm::dyn_cast<llvm::ValueAsMetadata>(RegMV->getMetadata())) {
+  std::vector<dxil_dia::Session::RVA> usesRVAs;
+
+  if (auto *RegMV =
+    llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(0))) {
+    if (auto *RegVM =
+            llvm::dyn_cast<llvm::ValueAsMetadata>(RegMV->getMetadata())) {
       if (auto *Reg = llvm::dyn_cast<llvm::Instruction>(RegVM->getValue())) {
         HRESULT hr;
         IFR(hr = GetDxilAllocaRegister(Reg, pReg, pRegSize));
         if (hr != S_OK) {
           return hr;
         }
+        llvm::iterator_range<llvm::Value::user_iterator> users = Reg->users();
+        for (llvm::User *user : users) {
+          auto *inst = llvm::dyn_cast<llvm::Instruction>(user);
+          if (inst != nullptr) {
+            auto rva = m_Session.RvaMapRef().find(inst);
+            usesRVAs.push_back(rva->second);
+          }
+        }
       }
     }
   }
 
-  if (auto *LVMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1))) {
+  if (!usesRVAs.empty()) {
+    *pLowestUserRVA = *std::min_element(usesRVAs.begin(), usesRVAs.end());
+    *pHighestUserRVA = * std::max_element(usesRVAs.begin(), usesRVAs.end());
+  }
+
+  if (auto *LVMV =
+          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(1))) {
     *LV = llvm::dyn_cast<llvm::DILocalVariable>(LVMV->getMetadata());
-    if (LV == nullptr) {
+    if (*LV == nullptr) {
       return E_FAIL;
     }
   }
 
-  if (auto *FieldsMV = llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(2))) {
+  if (auto *FieldsMV =
+          llvm::dyn_cast<llvm::MetadataAsValue>(CI->getArgOperand(2))) {
     auto *Fields = llvm::dyn_cast<llvm::DIExpression>(FieldsMV->getMetadata());
     if (Fields == nullptr) {
       return E_FAIL;
@@ -1932,7 +2164,8 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::IsDbgDeclareCall(llvm::Module
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize) {
+HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(
+    llvm::Instruction *I, DWORD *pRegNum, DWORD *pRegSize) {
   auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(I);
   if (Alloca == nullptr) {
     return S_FALSE;
@@ -1949,23 +2182,23 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::GetDxilAllocaRegister(llvm::I
   return S_OK;
 }
 
-HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::PopulateParentToChildrenIDMap(SymbolManager::ParentToChildrenMap *pParentToChildren) {
-  DXASSERT_ARGS(m_SymCtors.size() == m_Parent.size(),
-                "parents vector must be the same size of symbols ctor vector: %d vs %d",
-                m_SymCtors.size(),
-                m_Parent.size());
+HRESULT
+dxil_dia::hlsl_symbols::SymbolManagerInit::PopulateParentToChildrenIDMap(
+    SymbolManager::ParentToChildrenMap *pParentToChildren) {
+  DXASSERT_ARGS(
+      m_SymCtors.size() == m_Parent.size(),
+      "parents vector must be the same size of symbols ctor vector: %d vs %d",
+      m_SymCtors.size(), m_Parent.size());
 
   for (size_t i = 0; i < m_Parent.size(); ++i) {
 #ifndef NDEBUG
     {
       CComPtr<Symbol> S;
       IFT(m_SymCtors[i]->Create(&m_Session, &S));
-      DXASSERT_ARGS(S->GetID() == i + 1,
-                    "Invalid symbol index %d for %d",
-                    S->GetID(),
-                   i + 1);
+      DXASSERT_ARGS(S->GetID() == i + 1, "Invalid symbol index %d for %d",
+                    S->GetID(), i + 1);
     }
-#endif  // !NDEBUG
+#endif // !NDEBUG
 
     DXASSERT_ARGS(m_Parent[i] != kNullSymbolID || (i + 1) == HlslProgramId,
                   "Parentless symbol %d", i + 1);
@@ -1984,9 +2217,7 @@ dxil_dia::SymbolManager::SymbolFactory::~SymbolFactory() = default;
 
 dxil_dia::SymbolManager::SymbolManager() = default;
 
-dxil_dia::SymbolManager::~SymbolManager() {
-  m_pSession = nullptr;
-}
+dxil_dia::SymbolManager::~SymbolManager() { m_pSession = nullptr; }
 
 void dxil_dia::SymbolManager::Init(Session *pSes) {
   DXASSERT(m_pSession == nullptr, "SymbolManager already initialized");
@@ -2000,72 +2231,65 @@ void dxil_dia::SymbolManager::Init(Session *pSes) {
   }
   llvm::DICompileUnit *ShaderCU = *DIFinder.compile_units().begin();
 
-  hlsl_symbols::SymbolManagerInit SMI(pSes, &m_symbolCtors, &m_scopeToID, &m_symbolToLiveRange);
+  hlsl_symbols::SymbolManagerInit SMI(pSes, &m_symbolCtors, &m_scopeToID,
+                                      &m_symbolToLiveRange);
 
   DWORD dwHlslProgramID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::GlobalScope>(kNullSymbolID, &dwHlslProgramID));
-  DXASSERT_ARGS(dwHlslProgramID == HlslProgramId,
-                "%d vs %d",
-                dwHlslProgramID,
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::GlobalScope>(
+      kNullSymbolID, &dwHlslProgramID));
+  DXASSERT_ARGS(dwHlslProgramID == HlslProgramId, "%d vs %d", dwHlslProgramID,
                 HlslProgramId);
 
-
   DWORD dwHlslCompilandID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::Compiland>(dwHlslProgramID, &dwHlslCompilandID, ShaderCU));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::Compiland>(
+      dwHlslProgramID, &dwHlslCompilandID, ShaderCU));
   m_scopeToID.insert(std::make_pair(ShaderCU, dwHlslCompilandID));
-  DXASSERT_ARGS(dwHlslCompilandID == HlslCompilandId,
-                "%d vs %d",
-                dwHlslCompilandID,
-                HlslCompilandId);
-
+  DXASSERT_ARGS(dwHlslCompilandID == HlslCompilandId, "%d vs %d",
+                dwHlslCompilandID, HlslCompilandId);
 
   DWORD dwHlslCompilandDetailsId;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandDetails>(dwHlslCompilandID, &dwHlslCompilandDetailsId));
-  DXASSERT_ARGS(dwHlslCompilandDetailsId == HlslCompilandDetailsId,
-                "%d vs %d",
-                dwHlslCompilandDetailsId,
-                HlslCompilandDetailsId);
-
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandDetails>(
+      dwHlslCompilandID, &dwHlslCompilandDetailsId));
+  DXASSERT_ARGS(dwHlslCompilandDetailsId == HlslCompilandDetailsId, "%d vs %d",
+                dwHlslCompilandDetailsId, HlslCompilandDetailsId);
 
   DWORD dwHlslCompilandEnvFlagsID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateFlags>>(dwHlslCompilandID, &dwHlslCompilandEnvFlagsID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
+          hlsl_symbols::CompilandEnvSymbol::CreateFlags>>(
+      dwHlslCompilandID, &dwHlslCompilandEnvFlagsID));
   DXASSERT_ARGS(dwHlslCompilandEnvFlagsID == HlslCompilandEnvFlagsId,
-                "%d vs %d",
-                dwHlslCompilandEnvFlagsID,
-                HlslCompilandEnvFlagsId);
-
+                "%d vs %d", dwHlslCompilandEnvFlagsID, HlslCompilandEnvFlagsId);
 
   DWORD dwHlslCompilandEnvTargetID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateTarget>>(dwHlslCompilandID, &dwHlslCompilandEnvTargetID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
+          hlsl_symbols::CompilandEnvSymbol::CreateTarget>>(
+      dwHlslCompilandID, &dwHlslCompilandEnvTargetID));
   DXASSERT_ARGS(dwHlslCompilandEnvTargetID == HlslCompilandEnvTargetId,
-                "%d vs %d",
-                dwHlslCompilandEnvTargetID,
+                "%d vs %d", dwHlslCompilandEnvTargetID,
                 HlslCompilandEnvTargetId);
 
-
   DWORD dwHlslCompilandEnvEntryID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateEntry>>(dwHlslCompilandID, &dwHlslCompilandEnvEntryID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
+          hlsl_symbols::CompilandEnvSymbol::CreateEntry>>(
+      dwHlslCompilandID, &dwHlslCompilandEnvEntryID));
   DXASSERT_ARGS(dwHlslCompilandEnvEntryID == HlslCompilandEnvEntryId,
-                "%d vs %d",
-                dwHlslCompilandEnvEntryID,
-                HlslCompilandEnvEntryId);
-
+                "%d vs %d", dwHlslCompilandEnvEntryID, HlslCompilandEnvEntryId);
 
   DWORD dwHlslCompilandEnvDefinesID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateDefines>>(dwHlslCompilandID, &dwHlslCompilandEnvDefinesID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
+          hlsl_symbols::CompilandEnvSymbol::CreateDefines>>(
+      dwHlslCompilandID, &dwHlslCompilandEnvDefinesID));
   DXASSERT_ARGS(dwHlslCompilandEnvDefinesID == HlslCompilandEnvDefinesId,
-                "%d vs %d",
-                dwHlslCompilandEnvDefinesID,
+                "%d vs %d", dwHlslCompilandEnvDefinesID,
                 HlslCompilandEnvDefinesId);
 
-
   DWORD dwHlslCompilandEnvArgumentsID;
-  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<hlsl_symbols::CompilandEnvSymbol::CreateArguments>>(dwHlslCompilandID, &dwHlslCompilandEnvArgumentsID));
+  IFT(SMI.AddSymbol<hlsl_symbols::symbol_factory::CompilandEnv<
+          hlsl_symbols::CompilandEnvSymbol::CreateArguments>>(
+      dwHlslCompilandID, &dwHlslCompilandEnvArgumentsID));
   DXASSERT_ARGS(dwHlslCompilandEnvArgumentsID == HlslCompilandEnvArgumentsId,
-                "%d vs %d",
-                dwHlslCompilandEnvArgumentsID,
+                "%d vs %d", dwHlslCompilandEnvArgumentsID,
                 HlslCompilandEnvArgumentsId);
-
 
   IFT(SMI.CreateFunctionsForAllCUs());
   IFT(SMI.CreateGlobalVariablesForAllCUs());
@@ -2074,7 +2298,8 @@ void dxil_dia::SymbolManager::Init(Session *pSes) {
   IFT(SMI.PopulateParentToChildrenIDMap(&m_parentToChildren));
 }
 
-HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id, Symbol **ppSym) const {
+HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id,
+                                               Symbol **ppSym) const {
   if (ppSym == nullptr) {
     return E_INVALIDARG;
   }
@@ -2096,7 +2321,8 @@ HRESULT dxil_dia::SymbolManager::GetSymbolByID(size_t id, Symbol **ppSym) const 
   return S_OK;
 }
 
-HRESULT dxil_dia::SymbolManager::GetLiveRangeOf(Symbol *pSym, LiveRange *LR) const {
+HRESULT dxil_dia::SymbolManager::GetLiveRangeOf(Symbol *pSym,
+                                                LiveRange *LR) const {
   const DWORD dwSymID = pSym->GetID();
   if (dwSymID <= 0 || dwSymID > m_symbolCtors.size()) {
     return E_INVALIDARG;
@@ -2114,7 +2340,8 @@ HRESULT dxil_dia::SymbolManager::GetGlobalScope(Symbol **ppSym) const {
   return GetSymbolByID(HlslProgramId, ppSym);
 }
 
-HRESULT dxil_dia::SymbolManager::ChildrenOf(DWORD ID, std::vector<CComPtr<Symbol>> *pChildren) const {
+HRESULT dxil_dia::SymbolManager::ChildrenOf(
+    DWORD ID, std::vector<CComPtr<Symbol>> *pChildren) const {
   pChildren->clear();
   auto childrenList = m_parentToChildren.equal_range(ID);
   for (auto it = childrenList.first; it != childrenList.second; ++it) {
@@ -2125,13 +2352,16 @@ HRESULT dxil_dia::SymbolManager::ChildrenOf(DWORD ID, std::vector<CComPtr<Symbol
   return S_OK;
 }
 
-HRESULT dxil_dia::SymbolManager::ChildrenOf(Symbol *pSym, std::vector<CComPtr<Symbol>> *pChildren) const {
+HRESULT dxil_dia::SymbolManager::ChildrenOf(
+    Symbol *pSym, std::vector<CComPtr<Symbol>> *pChildren) const {
   const std::uint32_t pSymID = pSym->GetID();
   IFR(ChildrenOf(pSymID, pChildren));
   return S_OK;
 }
 
-HRESULT dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr, SymbolChildrenEnumerator **ppRet) const {
+HRESULT
+dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr,
+                                    SymbolChildrenEnumerator **ppRet) const {
   *ppRet = nullptr;
 
   const llvm::DebugLoc &DL = instr->getDebugLoc();
@@ -2154,11 +2384,13 @@ HRESULT dxil_dia::SymbolManager::DbgScopeOf(const llvm::Instruction *instr, Symb
 
   auto scopeIt = m_scopeToID.find(LS);
   if (scopeIt == m_scopeToID.end()) {
-    // This is a failure because all scopes should already exist in the symbol manager.
+    // This is a failure because all scopes should already exist in the symbol
+    // manager.
     return E_FAIL;
   }
 
-  CComPtr<SymbolChildrenEnumerator> ret = SymbolChildrenEnumerator::Alloc(m_pSession->GetMallocNoRef());
+  CComPtr<SymbolChildrenEnumerator> ret =
+      SymbolChildrenEnumerator::Alloc(m_pSession->GetMallocNoRef());
   if (!ret) {
     return E_OUTOFMEMORY;
   }


### PR DESCRIPTION
The previous code took the dbg-declare instruction to be the start of the live range for a variable. But the actual variable can be created and used before this declaration.

This change seeks the first and last use of each variable, and defines the live range to be the first use through to the end of the local scope, or the last use, whichever is later. (But of course, the end of the scope should really always be later.)