### PR TITLE
Problem with Preprocess() when the filename is null. Default copied from Compile()

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -860,6 +860,7 @@ public:
       DefaultFPEnvScope fpEnvScope;
 
       CComPtr<AbstractMemoryStream> pOutputStream;
+      pSourceName = (pSourceName && *pSourceName) ? pSourceName : L"hlsl.hlsl"; // declared optional, so pick a default
       dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(utf8Source, pSourceName, pIncludeHandler);
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
 


### PR DESCRIPTION
Compiler will crash when null is passed as pSourceName in Process(). Compile() uses a default of "hlsl.hlsl"