### PR TITLE
PIX: Shader access tracking pass: Use DWORD-aligned accesses for raw stores.

### DIFF
--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -254,7 +254,8 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
                                           Value *ByteIndex,
                                           ShaderAccessFlags access) {
   
-  auto OffsetByteIndex = Builder.CreateAdd(ByteIndex, HlslOP->GetU32Const(static_cast<unsigned>(OffsetFromAccess(access))), "OffsetByteIndex");
+  unsigned OffsetForAccessType = static_cast<unsigned>(OffsetFromAccess(access) * BytesPerDWORD);
+  auto OffsetByteIndex = Builder.CreateAdd(ByteIndex, HlslOP->GetU32Const(OffsetForAccessType), "OffsetByteIndex");
 
   UndefValue* UndefIntArg = UndefValue::get(Type::getInt32Ty(Ctx));
   Constant* LiteralOne = HlslOP->GetU32Const(1);

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -Emain -Tcs_6_5 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=M0:0:1i0;S0:1:1i0;U0:2:10i0;.. | %FileCheck %s
+
+// Check we added the UAV:
+// CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
+
+// Feedback UAV:
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
+
+// Texture:
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
+
+// Sampler:
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
+
+Texture2D texture : register(t0);
+SamplerState samplerState : register(s0);
+
+FeedbackTexture2D<SAMPLER_FEEDBACK_MIN_MIP> map : register(u0);
+
+[numthreads(4, 4, 1)] 
+void main(uint3 threadId : SV_DispatchThreadId) {
+  float2 uv = threadId.xy;
+  uv /= 256;
+
+  map.WriteSamplerFeedbackLevel(texture, samplerState, uv, threadId.x % 8);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
@@ -13,13 +13,13 @@
 
 // Now the writes with atomicBinOp "|=2":
 
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.f32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.i32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.f16
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 25, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
 // CHECK: call void @dx.op.rawBufferStore.i16
 
 struct S


### PR DESCRIPTION
This fixes a bug caused by a recent change to this pass: Previously it would write one of three bits into a single DWORD per resource, but was changed to write a whole DWORD into one of three DWORDs per resource. (The RMW of a bit-set turned out to be a lot slower than the newer write-only version.)

Unfortunately the offset into the three DWORDs was being calculated as a byte offset, not a DWORD offset.
