### PR TITLE
[spirv] fix OpDecorate Location bug for colmajor mat

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -159,6 +159,12 @@ QualType desugarType(QualType type, llvm::Optional<bool> *isRowMajor);
 /// a row into a column here.
 bool isRowMajorMatrix(const SpirvCodeGenOptions &, QualType type);
 
+/// Returns true if a matrix or an array of matrix has the majorness
+/// attribute. When it contains the attribute, it updates `isRowMajorAttr`
+/// properly.
+bool containsMatrixMajorAttr(const ASTContext &astContext, QualType type,
+                             llvm::Optional<bool> *isRowMajorAttr);
+
 /// \brief Returns true if the given type is a (RW)StructuredBuffer type.
 bool isStructuredBuffer(QualType type);
 

--- a/tools/clang/test/CodeGenSPIRV/semantic.location.default_colmajor.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.location.default_colmajor.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpDecorate %in_var_TEXCOORD0 Location 0
+// CHECK: OpDecorate %in_var_POSITION Location 3
+// CHECK: OpDecorate %in_var_TANGENT Location 7
+// CHECK: OpDecorate %in_var_NORMAL Location 10
+// CHECK: OpDecorate %in_var_COLOR Location 19
+
+struct PSInput {
+  column_major float4x3 a : TEXCOORD0;
+  row_major float4x3 b : POSITION;
+  float4x3 c : TANGENT;
+  float4x3 d[3] : NORMAL;
+  float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+  return input.color;
+}

--- a/tools/clang/test/CodeGenSPIRV/semantic.location.default_rowmajor.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.location.default_rowmajor.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -Zpr -E main
+
+// CHECK: OpDecorate %in_var_TEXCOORD0 Location 0
+// CHECK: OpDecorate %in_var_POSITION Location 3
+// CHECK: OpDecorate %in_var_TANGENT Location 7
+// CHECK: OpDecorate %in_var_NORMAL Location 11
+// CHECK: OpDecorate %in_var_COLOR Location 23
+
+struct PSInput {
+  column_major float4x3 a : TEXCOORD0;
+  row_major float4x3 b : POSITION;
+  float4x3 c : TANGENT;
+  float4x3 d[3] : NORMAL;
+  float4 color : COLOR;
+};
+
+float4 main(PSInput input) : SV_TARGET {
+  return input.color;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.stage-io.16bit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.stage-io.16bit.hlsl
@@ -6,15 +6,15 @@
 
 // CHECK: OpDecorate %in_var_A Location 0
 // CHECK: OpDecorate %in_var_B Location 4
-// CHECK: OpDecorate %in_var_C Location 6
-// CHECK: OpDecorate %in_var_D Location 7
-// CHECK: OpDecorate %in_var_E Location 8
+// CHECK: OpDecorate %in_var_C Location 7
+// CHECK: OpDecorate %in_var_D Location 8
+// CHECK: OpDecorate %in_var_E Location 9
 
 // CHECK: OpDecorate %out_var_A Location 0
-// CHECK: OpDecorate %out_var_B Location 2
-// CHECK: OpDecorate %out_var_C Location 6
-// CHECK: OpDecorate %out_var_D Location 7
-// CHECK: OpDecorate %out_var_E Location 8
+// CHECK: OpDecorate %out_var_B Location 3
+// CHECK: OpDecorate %out_var_C Location 7
+// CHECK: OpDecorate %out_var_D Location 8
+// CHECK: OpDecorate %out_var_E Location 9
 
 // CHECK:  %in_var_A = OpVariable %_ptr_Input__arr_v2half_uint_4 Input
 // CHECK:  %in_var_B = OpVariable %_ptr_Input__arr_v3ushort_uint_2 Input
@@ -29,19 +29,19 @@
 // CHECK: %out_var_E = OpVariable %_ptr_Output_v3ushort Output
 
 struct VSOut {
-    half2x3   outA    : A; // 2 locations: 0, 1
-    int16_t2  outB[4] : B; // 4 locations: 2, 3, 4, 5
-    half      outC    : C; // 1 location : 6
-    int16_t2  outD    : D; // 1 location : 7
-    uint16_t3 outE    : E; // 1 location : 8
+    half2x3   outA    : A; // 3 locations: 0, 1, 2
+    int16_t2  outB[4] : B; // 4 locations: 3, 4, 5, 6
+    half      outC    : C; // 1 location : 7
+    int16_t2  outD    : D; // 1 location : 8
+    uint16_t3 outE    : E; // 1 location : 9
 };
 
 VSOut main(
     half2        inA[4] : A, // 4 locations: 0, 1, 2, 3
-    uint16_t2x3  inB    : B, // 2 locations: 4, 5
-    int16_t      inC    : C, // 1 location : 6
-    uint16_t2    inD    : D, // 1 location : 7
-    float16_t3x2 inE    : E  // 3 location : 8, 9, 10
+    uint16_t2x3  inB    : B, // 3 locations: 4, 5, 6
+    int16_t      inC    : C, // 1 location : 7
+    uint16_t2    inD    : D, // 1 location : 8
+    float16_t3x2 inE    : E  // 2 location : 9, 10
 ) {
     VSOut o;
     o.outA    = inA[0].x;

--- a/tools/clang/test/CodeGenSPIRV/vk.location.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.location.composite.hlsl
@@ -6,30 +6,30 @@
 // CHECK: OpDecorate %in_var_D Location 4
 // CHECK: OpDecorate %in_var_E Location 6
 // CHECK: OpDecorate %in_var_F Location 8
-// CHECK: OpDecorate %in_var_G Location 16
+// CHECK: OpDecorate %in_var_G Location 14
 
 // CHECK: OpDecorate %out_var_A Location 0
-// CHECK: OpDecorate %out_var_B Location 2
-// CHECK: OpDecorate %out_var_C Location 3
-// CHECK: OpDecorate %out_var_D Location 4
-// CHECK: OpDecorate %out_var_E Location 5
-// CHECK: OpDecorate %out_var_F Location 11
-// CHECK: OpDecorate %out_var_G Location 13
-// CHECK: OpDecorate %out_var_H Location 14
+// CHECK: OpDecorate %out_var_B Location 3
+// CHECK: OpDecorate %out_var_C Location 4
+// CHECK: OpDecorate %out_var_D Location 5
+// CHECK: OpDecorate %out_var_E Location 6
+// CHECK: OpDecorate %out_var_F Location 15
+// CHECK: OpDecorate %out_var_G Location 17
+// CHECK: OpDecorate %out_var_H Location 18
 
 struct S {
-    half2x3  matrix2x3 : A; // 0 (+2)
-    float1x2 vector1x2 : B; // 2 (+1)
-    float3x1 vector3x1 : C; // 3 (+1)
-    float1x1 scalar1x1 : D; // 4 (+1)
+    half2x3  matrix2x3 : A; // 0 (+3)
+    float1x2 vector1x2 : B; // 3 (+1)
+    float3x1 vector3x1 : C; // 4 (+1)
+    float1x1 scalar1x1 : D; // 5 (+1)
 };
 
 struct T {
     S        s;
-    float2x3 array1[3] : E; // 5  (+2*3)
-    half1x2  array2[2] : F; // 11 (+1*2)
-    half3x1  array3[1] : G; // 13 (+1*1)
-    float    array4[4] : H; // 14 (+1*4)
+    float2x3 array1[3] : E; // 6  (+3*3)
+    half1x2  array2[2] : F; // 15 (+1*2)
+    half3x1  array3[1] : G; // 17 (+1*1)
+    float    array4[4] : H; // 18 (+1*4)
 };
 
 T main(
@@ -38,8 +38,8 @@ T main(
     double3   c   : C, // 2  (+2)
     double4   d   : D, // 4  (+2)
     double2x2 e   : E, // 6  (+1*2)
-    double2x3 f[2]: F, // 8  (+2*2*2)
-    double2x3 g   : G  // 16 (+2x2)
+    double2x3 f[2]: F, // 8  (+2*3)
+    double2x3 g   : G  // 14 (+3)
 ) {
     T t = (T)0;
     return t;

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -785,6 +785,12 @@ TEST_F(FileTest, SemanticDuplication) {
   runFileTest("semantic.duplication.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, SemanticOnStruct) { runFileTest("semantic.on-struct.hlsl"); }
+TEST_F(FileTest, SemanticLocationDefaultColMajor) {
+  runFileTest("semantic.location.default_colmajor.hlsl");
+}
+TEST_F(FileTest, SemanticLocationDefaultRowMajor) {
+  runFileTest("semantic.location.default_rowmajor.hlsl");
+}
 
 // For texture methods
 TEST_F(FileTest, TextureSample) { runFileTest("texture.sample.hlsl"); }
@@ -1881,7 +1887,8 @@ TEST_F(FileTest, NonFpColMajorError) {
   runFileTest("vk.layout.non-fp-matrix.error.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, NonFpColMajorErrorArrayStruct) {
-  runFileTest("vk.layout.non-fp-matrix.array.struct.error.hlsl", Expect::Failure);
+  runFileTest("vk.layout.non-fp-matrix.array.struct.error.hlsl",
+              Expect::Failure);
 }
 
 TEST_F(FileTest, NamespaceFunctions) {


### PR DESCRIPTION
Problem: DXC emits a wrong "OpDecorate .. Location" for a column
major input/output matrix.
This CL: Handle a matrix in HLSL with column_major attribute (or if
the default is column_major) correctly based on Vulkan spec for
"Location Assignment".

Fixes #2522