### PR TITLE
Just run clang format on PIX passes

### DIFF
--- a/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
@@ -10,12 +10,13 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/DXIL/DxilOperations.h"
+
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
-#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/DXIL/DxilUtil.h"
+#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 
 #include "llvm/IR/PassManager.h"
 #include "llvm/Transforms/Utils/Local.h"
@@ -39,8 +40,7 @@ public:
   bool runOnModule(Module &M) override;
 };
 
-void DxilAddPixelHitInstrumentation::applyOptions(PassOptions O)
-{
+void DxilAddPixelHitInstrumentation::applyOptions(PassOptions O) {
   GetPassOptionBool(O, "force-early-z", &ForceEarlyZ, false);
   GetPassOptionBool(O, "add-pixel-cost", &AddPixelCost, false);
   GetPassOptionInt(O, "rt-width", &RTWidth, 0);
@@ -48,64 +48,73 @@ void DxilAddPixelHitInstrumentation::applyOptions(PassOptions O)
   GetPassOptionInt(O, "sv-position-index", &SVPositionIndex, 0);
 }
 
-bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
-{
+bool DxilAddPixelHitInstrumentation::runOnModule(Module &M) {
   // This pass adds instrumentation for pixel hit counting and pixel cost.
 
   DxilModule &DM = M.GetOrCreateDxilModule();
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
 
-  // ForceEarlyZ is incompatible with the discard function (the Z has to be tested/written, and may be written before the shader even runs)
-  if (ForceEarlyZ)
-  {
+  // ForceEarlyZ is incompatible with the discard function (the Z has to be
+  // tested/written, and may be written before the shader even runs)
+  if (ForceEarlyZ) {
     DM.m_ShaderFlags.SetForceEarlyDepthStencil(true);
   }
-  
-  hlsl::DxilSignature & InputSignature = DM.GetInputSignature();
 
-  auto & InputElements = InputSignature.GetElements();
+  hlsl::DxilSignature &InputSignature = DM.GetInputSignature();
+
+  auto &InputElements = InputSignature.GetElements();
 
   unsigned SV_Position_ID;
 
-  auto SV_Position = std::find_if(InputElements.begin(), InputElements.end(), [](const std::unique_ptr<DxilSignatureElement> & Element) {
-    return Element->GetSemantic()->GetKind() == hlsl::DXIL::SemanticKind::Position; });
+  auto SV_Position =
+      std::find_if(InputElements.begin(), InputElements.end(),
+                   [](const std::unique_ptr<DxilSignatureElement> &Element) {
+                     return Element->GetSemantic()->GetKind() ==
+                            hlsl::DXIL::SemanticKind::Position;
+                   });
 
-  // SV_Position, if present, has to have full mask, so we needn't worry 
+  // SV_Position, if present, has to have full mask, so we needn't worry
   // about the shader having selected components that don't include x or y.
   // If not present, we add it.
-  if ( SV_Position == InputElements.end() ) {
-    auto SVPosition = llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::PSIn);
-    SVPosition->Initialize("Position", hlsl::CompType::getF32(), hlsl::DXIL::InterpolationMode::Linear, 1, 4, SVPositionIndex == -1 ? 0 : SVPositionIndex, 0);
+  if (SV_Position == InputElements.end()) {
+    auto SVPosition =
+        llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::PSIn);
+    SVPosition->Initialize("Position", hlsl::CompType::getF32(),
+                           hlsl::DXIL::InterpolationMode::Linear, 1, 4,
+                           SVPositionIndex == -1 ? 0 : SVPositionIndex, 0);
     SVPosition->AppendSemanticIndex(0);
     SVPosition->SetSigPointKind(DXIL::SigPointKind::PSIn);
     SVPosition->SetKind(hlsl::DXIL::SemanticKind::Position);
 
     auto index = InputSignature.AppendElement(std::move(SVPosition));
     SV_Position_ID = InputElements[index]->GetID();
-  }
-  else {
+  } else {
     SV_Position_ID = SV_Position->get()->GetID();
   }
 
   auto EntryPointFunction = DM.GetEntryFunction();
 
-  auto & EntryBlock = EntryPointFunction->getEntryBlock();
+  auto &EntryBlock = EntryPointFunction->getEntryBlock();
 
   CallInst *HandleForUAV;
   {
-    IRBuilder<> Builder(dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction()));
-    
-    unsigned int UAVResourceHandle = static_cast<unsigned int>(DM.GetUAVs().size());
+    IRBuilder<> Builder(
+        dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction()));
+
+    unsigned int UAVResourceHandle =
+        static_cast<unsigned int>(DM.GetUAVs().size());
 
     // Set up a UAV with structure of a single int
-    SmallVector<llvm::Type*, 1> Elements{ Type::getInt32Ty(Ctx) };
-    llvm::StructType *UAVStructTy = llvm::StructType::create(Elements, "class.RWStructuredBuffer");
+    SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(Ctx)};
+    llvm::StructType *UAVStructTy =
+        llvm::StructType::create(Elements, "class.RWStructuredBuffer");
     std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
     pUAV->SetGlobalName("PIX_CountUAVName");
     pUAV->SetGlobalSymbol(UndefValue::get(UAVStructTy->getPointerTo()));
     pUAV->SetID(UAVResourceHandle);
-    pUAV->SetSpaceID((unsigned int)-2); // This is the reserved-for-tools register space
+    pUAV->SetSpaceID(
+        (unsigned int)-2); // This is the reserved-for-tools register space
     pUAV->SetSampleCount(1);
     pUAV->SetGloballyCoherent(false);
     pUAV->SetHasCounter(false);
@@ -116,11 +125,11 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
     pUAV->SetRW(true);
 
     auto pAnnotation = DM.GetTypeSystem().GetStructAnnotation(UAVStructTy);
-    if (pAnnotation == nullptr)
-    {
+    if (pAnnotation == nullptr) {
       pAnnotation = DM.GetTypeSystem().AddStructAnnotation(UAVStructTy);
       pAnnotation->GetFieldAnnotation(0).SetCBufferOffset(0);
-      pAnnotation->GetFieldAnnotation(0).SetCompType(hlsl::DXIL::ComponentType::I32);
+      pAnnotation->GetFieldAnnotation(0).SetCompType(
+          hlsl::DXIL::ComponentType::I32);
       pAnnotation->GetFieldAnnotation(0).SetFieldName("count");
     }
 
@@ -129,118 +138,163 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M)
     assert((unsigned)ID == UAVResourceHandle);
 
     // Create handle for the newly-added UAV
-    Function* CreateHandleOpFunc = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
-    Constant* CreateHandleOpcodeArg = HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
-    Constant* UAVArg = HlslOP->GetI8Const(static_cast<std::underlying_type<DxilResourceBase::Class>::type>(DXIL::ResourceClass::UAV));
-    Constant* MetaDataArg = HlslOP->GetU32Const(ID); // position of the metadata record in the corresponding metadata list
-    Constant* IndexArg = HlslOP->GetU32Const(0); // 
-    Constant* FalseArg = HlslOP->GetI1Const(0); // non-uniform resource index: false
-    HandleForUAV = Builder.CreateCall(CreateHandleOpFunc,
-    { CreateHandleOpcodeArg, UAVArg, MetaDataArg, IndexArg, FalseArg }, "PIX_CountUAV_Handle");
+    Function *CreateHandleOpFunc =
+        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+    Constant *CreateHandleOpcodeArg =
+        HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
+    Constant *UAVArg = HlslOP->GetI8Const(
+        static_cast<std::underlying_type<DxilResourceBase::Class>::type>(
+            DXIL::ResourceClass::UAV));
+    Constant *MetaDataArg =
+        HlslOP->GetU32Const(ID); // position of the metadata record in the
+                                 // corresponding metadata list
+    Constant *IndexArg = HlslOP->GetU32Const(0); //
+    Constant *FalseArg =
+        HlslOP->GetI1Const(0); // non-uniform resource index: false
+    HandleForUAV = Builder.CreateCall(
+        CreateHandleOpFunc,
+        {CreateHandleOpcodeArg, UAVArg, MetaDataArg, IndexArg, FalseArg},
+        "PIX_CountUAV_Handle");
 
     DM.ReEmitDxilResources();
   }
-  // todo: is it a reasonable assumption that there will be a "Ret" in the entry block, and that these are the only
-  // points from which the shader can exit (except for a pixel-kill?)
-  auto & Instructions = EntryBlock.getInstList();
+  // todo: is it a reasonable assumption that there will be a "Ret" in the entry
+  // block, and that these are the only points from which the shader can exit
+  // (except for a pixel-kill?)
+  auto &Instructions = EntryBlock.getInstList();
   auto It = Instructions.begin();
-  while(It != Instructions.end()) {
+  while (It != Instructions.end()) {
     auto ThisInstruction = It++;
     LlvmInst_Ret Ret(ThisInstruction);
     if (Ret) {
-      // Check that there is at least one instruction preceding the Ret (no need to instrument it if there isn't)
+      // Check that there is at least one instruction preceding the Ret (no need
+      // to instrument it if there isn't)
       if (ThisInstruction->getPrevNode() != nullptr) {
 
         // Start adding instructions right before the Ret:
         IRBuilder<> Builder(ThisInstruction);
 
         // ------------------------------------------------------------------------------------------------------------
-        // Generate instructions to increment (by one) a UAV value corresponding to the pixel currently being rendered
+        // Generate instructions to increment (by one) a UAV value corresponding
+        // to the pixel currently being rendered
         // ------------------------------------------------------------------------------------------------------------
 
         // Useful constants
-        Constant* Zero32Arg = HlslOP->GetU32Const(0);
-        Constant* Zero8Arg = HlslOP->GetI8Const(0);
-        Constant* One32Arg = HlslOP->GetU32Const(1);
-        Constant* One8Arg = HlslOP->GetI8Const(1);
-        UndefValue* UndefArg = UndefValue::get(Type::getInt32Ty(Ctx));
-        Constant* NumPixelsByteOffsetArg = HlslOP->GetU32Const(NumPixels * 4);
+        Constant *Zero32Arg = HlslOP->GetU32Const(0);
+        Constant *Zero8Arg = HlslOP->GetI8Const(0);
+        Constant *One32Arg = HlslOP->GetU32Const(1);
+        Constant *One8Arg = HlslOP->GetI8Const(1);
+        UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(Ctx));
+        Constant *NumPixelsByteOffsetArg = HlslOP->GetU32Const(NumPixels * 4);
 
-        // Step 1: Convert SV_POSITION to UINT          
-        Value * XAsInt;
-        Value * YAsInt;
+        // Step 1: Convert SV_POSITION to UINT
+        Value *XAsInt;
+        Value *YAsInt;
         {
-          auto LoadInputOpFunc = HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getFloatTy(Ctx));
-          Constant* LoadInputOpcode = HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
-          Constant*  SV_Pos_ID = HlslOP->GetU32Const(SV_Position_ID);
-          auto XPos = Builder.CreateCall(LoadInputOpFunc,
-          { LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/, Zero8Arg /*column*/, UndefArg }, "XPos");
-          auto YPos = Builder.CreateCall(LoadInputOpFunc,
-          { LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/, One8Arg /*column*/, UndefArg }, "YPos");
+          auto LoadInputOpFunc =
+              HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getFloatTy(Ctx));
+          Constant *LoadInputOpcode =
+              HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
+          Constant *SV_Pos_ID = HlslOP->GetU32Const(SV_Position_ID);
+          auto XPos =
+              Builder.CreateCall(LoadInputOpFunc,
+                                 {LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/,
+                                  Zero8Arg /*column*/, UndefArg},
+                                 "XPos");
+          auto YPos =
+              Builder.CreateCall(LoadInputOpFunc,
+                                 {LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/,
+                                  One8Arg /*column*/, UndefArg},
+                                 "YPos");
 
-          XAsInt = Builder.CreateCast(Instruction::CastOps::FPToUI, XPos, Type::getInt32Ty(Ctx), "XIndex");
-          YAsInt = Builder.CreateCast(Instruction::CastOps::FPToUI, YPos, Type::getInt32Ty(Ctx), "YIndex");
+          XAsInt = Builder.CreateCast(Instruction::CastOps::FPToUI, XPos,
+                                      Type::getInt32Ty(Ctx), "XIndex");
+          YAsInt = Builder.CreateCast(Instruction::CastOps::FPToUI, YPos,
+                                      Type::getInt32Ty(Ctx), "YIndex");
         }
 
         // Step 2: Calculate pixel index
-        Value * Index;
+        Value *Index;
         {
-          Constant* RTWidthArg = HlslOP->GetI32Const(RTWidth);
+          Constant *RTWidthArg = HlslOP->GetI32Const(RTWidth);
           auto YOffset = Builder.CreateMul(YAsInt, RTWidthArg, "YOffset");
-          auto Elementoffset = Builder.CreateAdd(XAsInt, YOffset, "ElementOffset");
-          Index = Builder.CreateMul(Elementoffset, HlslOP->GetU32Const(4), "ByteIndex");
+          auto Elementoffset =
+              Builder.CreateAdd(XAsInt, YOffset, "ElementOffset");
+          Index = Builder.CreateMul(Elementoffset, HlslOP->GetU32Const(4),
+                                    "ByteIndex");
         }
 
         // Insert the UAV increment instruction:
-        Function* AtomicOpFunc = HlslOP->GetOpFunc(OP::OpCode::AtomicBinOp, Type::getInt32Ty(Ctx));
-        Constant* AtomicBinOpcode = HlslOP->GetU32Const((unsigned)OP::OpCode::AtomicBinOp);
-        Constant* AtomicAdd = HlslOP->GetU32Const((unsigned)DXIL::AtomicBinOpCode::Add);
+        Function *AtomicOpFunc =
+            HlslOP->GetOpFunc(OP::OpCode::AtomicBinOp, Type::getInt32Ty(Ctx));
+        Constant *AtomicBinOpcode =
+            HlslOP->GetU32Const((unsigned)OP::OpCode::AtomicBinOp);
+        Constant *AtomicAdd =
+            HlslOP->GetU32Const((unsigned)DXIL::AtomicBinOpCode::Add);
         {
-          (void)Builder.CreateCall(AtomicOpFunc, {
-            AtomicBinOpcode,// i32, ; opcode
-            HandleForUAV,   // %dx.types.Handle, ; resource handle
-            AtomicAdd,      // i32, ; binary operation code : EXCHANGE, IADD, AND, OR, XOR, IMIN, IMAX, UMIN, UMAX
-            Index,          // i32, ; coordinate c0: byte offset
-            UndefArg,       // i32, ; coordinate c1 (unused)
-            UndefArg,       // i32, ; coordinate c2 (unused)
-            One32Arg        // i32); increment value
-          }, "UAVIncResult");
+          (void)Builder.CreateCall(
+              AtomicOpFunc,
+              {
+                  AtomicBinOpcode, // i32, ; opcode
+                  HandleForUAV,    // %dx.types.Handle, ; resource handle
+                  AtomicAdd, // i32, ; binary operation code : EXCHANGE, IADD,
+                             // AND, OR, XOR, IMIN, IMAX, UMIN, UMAX
+                  Index,     // i32, ; coordinate c0: byte offset
+                  UndefArg,  // i32, ; coordinate c1 (unused)
+                  UndefArg,  // i32, ; coordinate c2 (unused)
+                  One32Arg   // i32); increment value
+              },
+              "UAVIncResult");
         }
 
         if (AddPixelCost) {
           // ------------------------------------------------------------------------------------------------------------
-          // Generate instructions to increment a value corresponding to the current pixel in the second half of the UAV, 
-          // by an amount proportional to the estimated average cost of each pixel in the current draw call.
+          // Generate instructions to increment a value corresponding to the
+          // current pixel in the second half of the UAV, by an amount
+          // proportional to the estimated average cost of each pixel in the
+          // current draw call.
           // ------------------------------------------------------------------------------------------------------------
 
-          // Step 1: Retrieve weight value from UAV; it will be placed after the range we're writing to
-          Value * Weight;
+          // Step 1: Retrieve weight value from UAV; it will be placed after the
+          // range we're writing to
+          Value *Weight;
           {
-            Function* LoadWeight = HlslOP->GetOpFunc(OP::OpCode::BufferLoad, Type::getInt32Ty(Ctx));
-            Constant* LoadWeightOpcode = HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferLoad);
-            Constant* OffsetIntoUAV = HlslOP->GetU32Const(NumPixels * 2 * 4);
-            auto WeightStruct = Builder.CreateCall(LoadWeight, {
-              LoadWeightOpcode, // i32 opcode
-              HandleForUAV,     // %dx.types.Handle, ; resource handle
-              OffsetIntoUAV,    // i32 c0: byte offset
-              UndefArg          // i32 c1: unused
-            }, "WeightStruct");
-            Weight = Builder.CreateExtractValue(WeightStruct, static_cast<uint64_t>(0LL), "Weight");
+            Function *LoadWeight = HlslOP->GetOpFunc(OP::OpCode::BufferLoad,
+                                                     Type::getInt32Ty(Ctx));
+            Constant *LoadWeightOpcode =
+                HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferLoad);
+            Constant *OffsetIntoUAV = HlslOP->GetU32Const(NumPixels * 2 * 4);
+            auto WeightStruct = Builder.CreateCall(
+                LoadWeight,
+                {
+                    LoadWeightOpcode, // i32 opcode
+                    HandleForUAV,     // %dx.types.Handle, ; resource handle
+                    OffsetIntoUAV,    // i32 c0: byte offset
+                    UndefArg          // i32 c1: unused
+                },
+                "WeightStruct");
+            Weight = Builder.CreateExtractValue(
+                WeightStruct, static_cast<uint64_t>(0LL), "Weight");
           }
 
-          // Step 2: Update write position ("Index") to second half of the UAV 
-          auto OffsetIndex = Builder.CreateAdd(Index, NumPixelsByteOffsetArg, "OffsetByteIndex");
+          // Step 2: Update write position ("Index") to second half of the UAV
+          auto OffsetIndex = Builder.CreateAdd(Index, NumPixelsByteOffsetArg,
+                                               "OffsetByteIndex");
 
           // Step 3: Increment UAV value by the weight
-          (void)Builder.CreateCall(AtomicOpFunc,{
-            AtomicBinOpcode,          // i32, ; opcode
-            HandleForUAV,   // %dx.types.Handle, ; resource handle
-            AtomicAdd,      // i32, ; binary operation code : EXCHANGE, IADD, AND, OR, XOR, IMIN, IMAX, UMIN, UMAX
-            OffsetIndex,    // i32, ; coordinate c0: byte offset
-            UndefArg,       // i32, ; coordinate c1 (unused)
-            UndefArg,       // i32, ; coordinate c2 (unused)
-            Weight          // i32); increment value
-          }, "UAVIncResult2");
+          (void)Builder.CreateCall(
+              AtomicOpFunc,
+              {
+                  AtomicBinOpcode, // i32, ; opcode
+                  HandleForUAV,    // %dx.types.Handle, ; resource handle
+                  AtomicAdd,   // i32, ; binary operation code : EXCHANGE, IADD,
+                               // AND, OR, XOR, IMIN, IMAX, UMIN, UMAX
+                  OffsetIndex, // i32, ; coordinate c0: byte offset
+                  UndefArg,    // i32, ; coordinate c1 (unused)
+                  UndefArg,    // i32, ; coordinate c2 (unused)
+                  Weight       // i32); increment value
+              },
+              "UAVIncResult2");
         }
       }
     }
@@ -257,4 +311,6 @@ ModulePass *llvm::createDxilAddPixelHitInstrumentationPass() {
   return new DxilAddPixelHitInstrumentation();
 }
 
-INITIALIZE_PASS(DxilAddPixelHitInstrumentation, "hlsl-dxil-add-pixel-hit-instrmentation", "DXIL Count completed PS invocations and costs", false, false)
+INITIALIZE_PASS(DxilAddPixelHitInstrumentation,
+                "hlsl-dxil-add-pixel-hit-instrmentation",
+                "DXIL Count completed PS invocations and costs", false, false)

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -9,72 +9,87 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilOperations.h"
+#include "dxc/DXIL/DxilUtil.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/DxilPIXPasses/DxilPIXVirtualRegisters.h"
-#include "dxc/DXIL/DxilUtil.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 
-#include "llvm/IR/Module.h"
-#include "llvm/IR/Constants.h"
-#include "llvm/IR/InstIterator.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Module.h"
 
 using namespace llvm;
 using namespace hlsl;
 
 // Overview of instrumentation:
-// 
-// In summary, instructions are added that cause a "trace" of the execution of the shader to be written
-// out to a UAV. This trace is then used by a debugger application to provide a post-mortem debugging
-// experience that reconstructs the execution history of the shader.
-// 
-// The trace is only required for a particular shader instance of interest, and a branchless mechanism
-// is used to write the trace either to an incrementing location within the UAV, or to a "dumping ground"
-// area at the top of the UAV if the instance is not of interest.
-// 
+//
+// In summary, instructions are added that cause a "trace" of the execution of
+// the shader to be written out to a UAV. This trace is then used by a debugger
+// application to provide a post-mortem debugging experience that reconstructs
+// the execution history of the shader.
+//
+// The trace is only required for a particular shader instance of interest, and
+// a branchless mechanism is used to write the trace either to an incrementing
+// location within the UAV, or to a "dumping ground" area at the top of the UAV
+// if the instance is not of interest.
+//
 // The following modifications are made:
-// 
-// First, instructions are added to the top of the entry point function that implement the following:
-// -  Examine the input variables that define the instance of the shader that is running. This will
-//    be SV_Position for pixel shaders, SV_Vertex+SV_Instance for vertex shaders, thread id for compute
-//    shaders etc. If these system values need to be added to the shader, then they are also added to the
-//    input signature, if appropriate.
-// -  Compare the above variables with the instance of interest defined by the invoker of this pass.
-//    Deduce two values: a multiplicand and an addend that together allow a branchless calculation of
-//    the offset into the UAV at which to write via "offset = offset * multiplicand + addend."
-//    If the instance is NOT of interest, the multiplicand is zero and the addend is 
-//    sizeof(UAV)-(a little bit), causing writes for uninteresting invocations to end up at the top of 
+//
+// First, instructions are added to the top of the entry point function that
+// implement the following:
+// -  Examine the input variables that define the instance of the shader that is
+// running. This will
+//    be SV_Position for pixel shaders, SV_Vertex+SV_Instance for vertex
+//    shaders, thread id for compute shaders etc. If these system values need to
+//    be added to the shader, then they are also added to the input signature,
+//    if appropriate.
+// -  Compare the above variables with the instance of interest defined by the
+// invoker of this pass.
+//    Deduce two values: a multiplicand and an addend that together allow a
+//    branchless calculation of the offset into the UAV at which to write via
+//    "offset = offset * multiplicand + addend." If the instance is NOT of
+//    interest, the multiplicand is zero and the addend is sizeof(UAV)-(a little
+//    bit), causing writes for uninteresting invocations to end up at the top of
 //    the UAV. Otherwise the multiplicand is 1 and the addend is 0.
-// -  Calculate an "instance identifier". Even with the above instance identification, several invocations may
-//    end up matching the selection criteria. Specifically, this happens during a draw call in which many
-//    triangles overlap the pixel of interest. More on this below.
-//    
-// During execution, the instrumentation for most instructions cause data to be emitted to the UAV. 
-// The index at which data is written is identified by treating the first uint32 of the UAV as an index 
-// which is atomically incremented by the instrumentation. The very first value of this counter that is
-// encountered by each invocation is used as the "instance identifier" mentioned above. That instance
-// identifier is written out with each packet, since many pixel shaders executing in parallel will emit
-// interleaved packets, and the debugger application uses the identifiers to group packets from each separate
-// invocation together.
-// 
-// If an instruction has a non-void and primitive return type, i.e. isn't a struct, then the instrumentation
-// will write that value out to the UAV as well as part of the "step" data packet.
-//    
-// The limiting size of the UAV is enforced in a branchless way by ANDing the offset with a precomputed
-// value that is sizeof(UAV)-64. The actual size of the UAV allocated by the caller is required to be
-// a power of two plus 64 for this reason. The caller detects UAV overrun by examining a canary value
-// close to the end of the power-of-two size of the UAV. If this value has been overwritten, the debug session
-// is deemed to have overflowed the UAV. The caller will than allocate a UAV that is twice the size and
-// try again, up to a predefined maximum.
+// -  Calculate an "instance identifier". Even with the above instance
+// identification, several invocations may
+//    end up matching the selection criteria. Specifically, this happens during
+//    a draw call in which many triangles overlap the pixel of interest. More on
+//    this below.
+//
+// During execution, the instrumentation for most instructions cause data to be
+// emitted to the UAV. The index at which data is written is identified by
+// treating the first uint32 of the UAV as an index which is atomically
+// incremented by the instrumentation. The very first value of this counter that
+// is encountered by each invocation is used as the "instance identifier"
+// mentioned above. That instance identifier is written out with each packet,
+// since many pixel shaders executing in parallel will emit interleaved packets,
+// and the debugger application uses the identifiers to group packets from each
+// separate invocation together.
+//
+// If an instruction has a non-void and primitive return type, i.e. isn't a
+// struct, then the instrumentation will write that value out to the UAV as well
+// as part of the "step" data packet.
+//
+// The limiting size of the UAV is enforced in a branchless way by ANDing the
+// offset with a precomputed value that is sizeof(UAV)-64. The actual size of
+// the UAV allocated by the caller is required to be a power of two plus 64 for
+// this reason. The caller detects UAV overrun by examining a canary value close
+// to the end of the power-of-two size of the UAV. If this value has been
+// overwritten, the debug session is deemed to have overflowed the UAV. The
+// caller will than allocate a UAV that is twice the size and try again, up to a
+// predefined maximum.
 
-// Keep this in sync with the same-named value in the debugger application's WinPixShaderUtils.h
+// Keep this in sync with the same-named value in the debugger application's
+// WinPixShaderUtils.h
 constexpr uint64_t DebugBufferDumpingGroundSize = 64 * 1024;
 
-
-// These definitions echo those in the debugger application's debugshaderrecord.h file
+// These definitions echo those in the debugger application's
+// debugshaderrecord.h file
 enum DebugShaderModifierRecordType {
   DebugShaderModifierRecordTypeInvocationStartMarker,
   DebugShaderModifierRecordTypeStep,
@@ -92,12 +107,13 @@ enum DebugShaderModifierRecordType {
   DebugShaderModifierRecordTypeDXILStepDouble = 255,
 };
 
-// These structs echo those in the debugger application's debugshaderrecord.h file, but are recapitulated here
-// because the originals use unnamed unions which are disallowed by DXCompiler's build.
-// 
-#pragma pack(push,4)
+// These structs echo those in the debugger application's debugshaderrecord.h
+// file, but are recapitulated here because the originals use unnamed unions
+// which are disallowed by DXCompiler's build.
+//
+#pragma pack(push, 4)
 struct DebugShaderModifierRecordHeader {
-  union  {
+  union {
     struct {
       uint32_t SizeDwords : 4;
       uint32_t Flags : 4;
@@ -123,8 +139,9 @@ struct DebugShaderModifierRecordDXILStepBase {
   uint32_t InstructionOffset;
 };
 
-template< typename ReturnType >
-struct DebugShaderModifierRecordDXILStep : public DebugShaderModifierRecordDXILStepBase {
+template <typename ReturnType>
+struct DebugShaderModifierRecordDXILStep
+    : public DebugShaderModifierRecordDXILStepBase {
   ReturnType ReturnValue;
   union {
     struct {
@@ -135,14 +152,15 @@ struct DebugShaderModifierRecordDXILStep : public DebugShaderModifierRecordDXILS
   } ValueOrdinal;
 };
 
-template< >
-struct DebugShaderModifierRecordDXILStep<void> : public DebugShaderModifierRecordDXILStepBase {
-};
+template <>
+struct DebugShaderModifierRecordDXILStep<void>
+    : public DebugShaderModifierRecordDXILStepBase {};
 #pragma pack(pop)
 
-
-uint32_t DebugShaderModifierRecordPayloadSizeDwords(size_t recordTotalSizeBytes) {
-  return ((recordTotalSizeBytes - sizeof(DebugShaderModifierRecordHeader)) / sizeof(uint32_t));
+uint32_t
+DebugShaderModifierRecordPayloadSizeDwords(size_t recordTotalSizeBytes) {
+  return ((recordTotalSizeBytes - sizeof(DebugShaderModifierRecordHeader)) /
+          sizeof(uint32_t));
 }
 
 class DxilDebugInstrumentation : public ModulePass {
@@ -167,7 +185,7 @@ private:
       unsigned PrimitiveId;
       unsigned InstanceId;
     } GeometryShader;
-  } m_Parameters = { {0,0,0} };
+  } m_Parameters = {{0, 0, 0}};
 
   union SystemValueIndices {
     struct PixelShaderParameters {
@@ -183,60 +201,72 @@ private:
     } GeometryShader;
   };
 
-  uint64_t m_UAVSize = 1024*1024;
-  Value * m_SelectionCriterion = nullptr;
-  CallInst * m_HandleForUAV = nullptr;
-  Value * m_InvocationId = nullptr;
+  uint64_t m_UAVSize = 1024 * 1024;
+  Value *m_SelectionCriterion = nullptr;
+  CallInst *m_HandleForUAV = nullptr;
+  Value *m_InvocationId = nullptr;
 
-  // Together these two values allow branchless writing to the UAV. An invocation of the shader
-  // is either of interest or not (e.g. it writes to the pixel the user selected for debugging
-  // or it doesn't). If not of interest, debugging output will still occur, but it will be
-  // relegated to the very top few bytes of the UAV. Invocations of interest, by contrast, will
-  // be written to the UAV at sequentially increasing offsets.
+  // Together these two values allow branchless writing to the UAV. An
+  // invocation of the shader is either of interest or not (e.g. it writes to
+  // the pixel the user selected for debugging or it doesn't). If not of
+  // interest, debugging output will still occur, but it will be relegated to
+  // the very top few bytes of the UAV. Invocations of interest, by contrast,
+  // will be written to the UAV at sequentially increasing offsets.
 
-  // This value will either be one or zero (one if the invocation is of interest, zero otherwise)
-  Value * m_OffsetMultiplicand = nullptr;
-  // This will either be zero (if the invocation is of interest) or (UAVSize)-(SmallValue) if not.
-  Value * m_OffsetAddend = nullptr;
+  // This value will either be one or zero (one if the invocation is of
+  // interest, zero otherwise)
+  Value *m_OffsetMultiplicand = nullptr;
+  // This will either be zero (if the invocation is of interest) or
+  // (UAVSize)-(SmallValue) if not.
+  Value *m_OffsetAddend = nullptr;
 
-  Constant * m_OffsetMask = nullptr;
+  Constant *m_OffsetMask = nullptr;
 
   struct BuilderContext {
     Module &M;
     DxilModule &DM;
-    LLVMContext & Ctx;
-    OP * HlslOP;
-    IRBuilder<> & Builder;
+    LLVMContext &Ctx;
+    OP *HlslOP;
+    IRBuilder<> &Builder;
   };
 
   uint32_t m_RemainingReservedSpaceInBytes = 0;
-  Value * m_CurrentIndex = nullptr;
+  Value *m_CurrentIndex = nullptr;
 
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilDebugInstrumentation() : ModulePass(ID) {}
-  const char *getPassName() const override { return "Add PIX debug instrumentation"; }
+  const char *getPassName() const override {
+    return "Add PIX debug instrumentation";
+  }
   void applyOptions(PassOptions O) override;
   bool runOnModule(Module &M) override;
 
 private:
   SystemValueIndices addRequiredSystemValues(BuilderContext &BC);
   void addUAV(BuilderContext &BC);
-  void addInvocationSelectionProlog(BuilderContext &BC, SystemValueIndices SVIndices);
-  Value * addPixelShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices);
-  Value * addGeometryShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices);
-  Value * addDispatchedShaderProlog(BuilderContext &BC);
-  Value * addVertexShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices);
-  void addDebugEntryValue(BuilderContext &BC, Value * TheValue);
+  void addInvocationSelectionProlog(BuilderContext &BC,
+                                    SystemValueIndices SVIndices);
+  Value *addPixelShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices);
+  Value *addGeometryShaderProlog(BuilderContext &BC,
+                                 SystemValueIndices SVIndices);
+  Value *addDispatchedShaderProlog(BuilderContext &BC);
+  Value *addVertexShaderProlog(BuilderContext &BC,
+                               SystemValueIndices SVIndices);
+  void addDebugEntryValue(BuilderContext &BC, Value *TheValue);
   void addInvocationStartMarker(BuilderContext &BC);
   void reserveDebugEntrySpace(BuilderContext &BC, uint32_t SpaceInDwords);
   void addStoreStepDebugEntry(BuilderContext &BC, StoreInst *Inst);
   void addStepDebugEntry(BuilderContext &BC, Instruction *Inst);
-  void addStepDebugEntryValue(BuilderContext &BC, std::uint32_t InstNum, Value *V, std::uint32_t ValueOrdinal, Value *ValueOrdinalIndex);
+  void addStepDebugEntryValue(BuilderContext &BC, std::uint32_t InstNum,
+                              Value *V, std::uint32_t ValueOrdinal,
+                              Value *ValueOrdinalIndex);
   uint32_t UAVDumpingGroundOffset();
-  template<typename ReturnType>
-  void addStepEntryForType(DebugShaderModifierRecordType RecordType, BuilderContext &BC, std::uint32_t InstNum, Value *V, std::uint32_t ValueOrdinal, Value *ValueOrdinalIndex);
-
+  template <typename ReturnType>
+  void addStepEntryForType(DebugShaderModifierRecordType RecordType,
+                           BuilderContext &BC, std::uint32_t InstNum, Value *V,
+                           std::uint32_t ValueOrdinal,
+                           Value *ValueOrdinalIndex);
 };
 
 void DxilDebugInstrumentation::applyOptions(PassOptions O) {
@@ -250,13 +280,13 @@ uint32_t DxilDebugInstrumentation::UAVDumpingGroundOffset() {
   return static_cast<uint32_t>(m_UAVSize - DebugBufferDumpingGroundSize);
 }
 
-
-DxilDebugInstrumentation::SystemValueIndices DxilDebugInstrumentation::addRequiredSystemValues(BuilderContext &BC) {
+DxilDebugInstrumentation::SystemValueIndices
+DxilDebugInstrumentation::addRequiredSystemValues(BuilderContext &BC) {
   SystemValueIndices SVIndices{};
 
-  hlsl::DxilSignature & InputSignature = BC.DM.GetInputSignature();
+  hlsl::DxilSignature &InputSignature = BC.DM.GetInputSignature();
 
-  auto & InputElements = InputSignature.GetElements();
+  auto &InputElements = InputSignature.GetElements();
 
   auto ShaderModel = BC.DM.GetShaderModel();
   switch (ShaderModel->GetKind()) {
@@ -268,48 +298,58 @@ DxilDebugInstrumentation::SystemValueIndices DxilDebugInstrumentation::addRequir
   case DXIL::ShaderKind::Vertex: {
     {
       auto Existing_SV_VertexId = std::find_if(
-        InputElements.begin(), InputElements.end(),
-        [](const std::unique_ptr<DxilSignatureElement> & Element) {
-        return Element->GetSemantic()->GetKind() == hlsl::DXIL::SemanticKind::VertexID; });
+          InputElements.begin(), InputElements.end(),
+          [](const std::unique_ptr<DxilSignatureElement> &Element) {
+            return Element->GetSemantic()->GetKind() ==
+                   hlsl::DXIL::SemanticKind::VertexID;
+          });
 
       if (Existing_SV_VertexId == InputElements.end()) {
-        auto Added_SV_VertexId = llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::VSIn);
-        Added_SV_VertexId->Initialize("VertexId", hlsl::CompType::getF32(), hlsl::DXIL::InterpolationMode::Undefined, 1, 1);
+        auto Added_SV_VertexId =
+            llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::VSIn);
+        Added_SV_VertexId->Initialize("VertexId", hlsl::CompType::getF32(),
+                                      hlsl::DXIL::InterpolationMode::Undefined,
+                                      1, 1);
         Added_SV_VertexId->AppendSemanticIndex(0);
         Added_SV_VertexId->SetSigPointKind(DXIL::SigPointKind::VSIn);
         Added_SV_VertexId->SetKind(hlsl::DXIL::SemanticKind::VertexID);
 
         auto index = InputSignature.AppendElement(std::move(Added_SV_VertexId));
         SVIndices.VertexShader.VertexId = InputElements[index]->GetID();
-      }
-      else {
+      } else {
         SVIndices.VertexShader.VertexId = Existing_SV_VertexId->get()->GetID();
       }
     }
     {
       auto Existing_SV_InstanceId = std::find_if(
-        InputElements.begin(), InputElements.end(),
-        [](const std::unique_ptr<DxilSignatureElement> & Element) {
-        return Element->GetSemantic()->GetKind() == hlsl::DXIL::SemanticKind::InstanceID; });
+          InputElements.begin(), InputElements.end(),
+          [](const std::unique_ptr<DxilSignatureElement> &Element) {
+            return Element->GetSemantic()->GetKind() ==
+                   hlsl::DXIL::SemanticKind::InstanceID;
+          });
 
       if (Existing_SV_InstanceId == InputElements.end()) {
-        auto Added_SV_InstanceId = llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::VSIn);
-        Added_SV_InstanceId->Initialize("InstanceId", hlsl::CompType::getF32(), hlsl::DXIL::InterpolationMode::Undefined, 1, 1);
+        auto Added_SV_InstanceId =
+            llvm::make_unique<DxilSignatureElement>(DXIL::SigPointKind::VSIn);
+        Added_SV_InstanceId->Initialize(
+            "InstanceId", hlsl::CompType::getF32(),
+            hlsl::DXIL::InterpolationMode::Undefined, 1, 1);
         Added_SV_InstanceId->AppendSemanticIndex(0);
         Added_SV_InstanceId->SetSigPointKind(DXIL::SigPointKind::VSIn);
         Added_SV_InstanceId->SetKind(hlsl::DXIL::SemanticKind::InstanceID);
 
-        auto index = InputSignature.AppendElement(std::move(Added_SV_InstanceId));
+        auto index =
+            InputSignature.AppendElement(std::move(Added_SV_InstanceId));
         SVIndices.VertexShader.InstanceId = InputElements[index]->GetID();
-      }
-      else {
-        SVIndices.VertexShader.InstanceId = Existing_SV_InstanceId->get()->GetID();
+      } else {
+        SVIndices.VertexShader.InstanceId =
+            Existing_SV_InstanceId->get()->GetID();
       }
     }
   } break;
-  case DXIL::ShaderKind::Geometry: 
+  case DXIL::ShaderKind::Geometry:
     // GS Instance Id and Primitive Id are not in the input signature
-  break;
+    break;
   case DXIL::ShaderKind::Pixel: {
     auto Existing_SV_Position =
         std::find_if(InputElements.begin(), InputElements.end(),
@@ -344,118 +384,175 @@ DxilDebugInstrumentation::SystemValueIndices DxilDebugInstrumentation::addRequir
   return SVIndices;
 }
 
-Value * DxilDebugInstrumentation::addDispatchedShaderProlog(BuilderContext &BC) {
-  Constant* Zero32Arg = BC.HlslOP->GetU32Const(0);
-  Constant* One32Arg = BC.HlslOP->GetU32Const(1);
-  Constant* Two32Arg = BC.HlslOP->GetU32Const(2);
+Value *DxilDebugInstrumentation::addDispatchedShaderProlog(BuilderContext &BC) {
+  Constant *Zero32Arg = BC.HlslOP->GetU32Const(0);
+  Constant *One32Arg = BC.HlslOP->GetU32Const(1);
+  Constant *Two32Arg = BC.HlslOP->GetU32Const(2);
 
-  auto ThreadIdFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::ThreadId, Type::getInt32Ty(BC.Ctx));
-  Constant* Opcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::ThreadId);
-  auto ThreadIdX = BC.Builder.CreateCall(ThreadIdFunc, { Opcode, Zero32Arg }, "ThreadIdX");
-  auto ThreadIdY = BC.Builder.CreateCall(ThreadIdFunc, { Opcode, One32Arg  }, "ThreadIdY");
-  auto ThreadIdZ = BC.Builder.CreateCall(ThreadIdFunc, { Opcode, Two32Arg  }, "ThreadIdZ");
+  auto ThreadIdFunc =
+      BC.HlslOP->GetOpFunc(DXIL::OpCode::ThreadId, Type::getInt32Ty(BC.Ctx));
+  Constant *Opcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::ThreadId);
+  auto ThreadIdX =
+      BC.Builder.CreateCall(ThreadIdFunc, {Opcode, Zero32Arg}, "ThreadIdX");
+  auto ThreadIdY =
+      BC.Builder.CreateCall(ThreadIdFunc, {Opcode, One32Arg}, "ThreadIdY");
+  auto ThreadIdZ =
+      BC.Builder.CreateCall(ThreadIdFunc, {Opcode, Two32Arg}, "ThreadIdZ");
 
   // Compare to expected thread ID
-  auto CompareToX = BC.Builder.CreateICmpEQ(ThreadIdX, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdX), "CompareToThreadIdX");
-  auto CompareToY = BC.Builder.CreateICmpEQ(ThreadIdY, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdY), "CompareToThreadIdY");
-  auto CompareToZ = BC.Builder.CreateICmpEQ(ThreadIdZ, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdZ), "CompareToThreadIdZ");
+  auto CompareToX = BC.Builder.CreateICmpEQ(
+      ThreadIdX, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdX),
+      "CompareToThreadIdX");
+  auto CompareToY = BC.Builder.CreateICmpEQ(
+      ThreadIdY, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdY),
+      "CompareToThreadIdY");
+  auto CompareToZ = BC.Builder.CreateICmpEQ(
+      ThreadIdZ, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdZ),
+      "CompareToThreadIdZ");
 
-  auto CompareXAndY = BC.Builder.CreateAnd(CompareToX, CompareToY, "CompareXAndY");
+  auto CompareXAndY =
+      BC.Builder.CreateAnd(CompareToX, CompareToY, "CompareXAndY");
 
-  auto CompareAll = BC.Builder.CreateAnd(CompareXAndY, CompareToZ, "CompareAll");
+  auto CompareAll =
+      BC.Builder.CreateAnd(CompareXAndY, CompareToZ, "CompareAll");
 
   return CompareAll;
 }
 
-Value * DxilDebugInstrumentation::addVertexShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices) {
-  Constant* Zero32Arg = BC.HlslOP->GetU32Const(0);
-  Constant* Zero8Arg = BC.HlslOP->GetI8Const(0);
-  UndefValue* UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+Value *
+DxilDebugInstrumentation::addVertexShaderProlog(BuilderContext &BC,
+                                                SystemValueIndices SVIndices) {
+  Constant *Zero32Arg = BC.HlslOP->GetU32Const(0);
+  Constant *Zero8Arg = BC.HlslOP->GetI8Const(0);
+  UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
 
-  auto LoadInputOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getInt32Ty(BC.Ctx));
-  Constant* LoadInputOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
-  Constant*  SV_Vert_ID = BC.HlslOP->GetU32Const(SVIndices.VertexShader.VertexId);
-  auto VertId = BC.Builder.CreateCall(LoadInputOpFunc,
-  { LoadInputOpcode, SV_Vert_ID, Zero32Arg /*row*/, Zero8Arg /*column*/, UndefArg }, "VertId");
+  auto LoadInputOpFunc =
+      BC.HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getInt32Ty(BC.Ctx));
+  Constant *LoadInputOpcode =
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
+  Constant *SV_Vert_ID =
+      BC.HlslOP->GetU32Const(SVIndices.VertexShader.VertexId);
+  auto VertId =
+      BC.Builder.CreateCall(LoadInputOpFunc,
+                            {LoadInputOpcode, SV_Vert_ID, Zero32Arg /*row*/,
+                             Zero8Arg /*column*/, UndefArg},
+                            "VertId");
 
-  Constant*  SV_Instance_ID = BC.HlslOP->GetU32Const(SVIndices.VertexShader.InstanceId);
-  auto InstanceId = BC.Builder.CreateCall(LoadInputOpFunc,
-  { LoadInputOpcode, SV_Instance_ID, Zero32Arg /*row*/, Zero8Arg /*column*/, UndefArg }, "InstanceId");
+  Constant *SV_Instance_ID =
+      BC.HlslOP->GetU32Const(SVIndices.VertexShader.InstanceId);
+  auto InstanceId =
+      BC.Builder.CreateCall(LoadInputOpFunc,
+                            {LoadInputOpcode, SV_Instance_ID, Zero32Arg /*row*/,
+                             Zero8Arg /*column*/, UndefArg},
+                            "InstanceId");
 
   // Compare to expected vertex ID and instance ID
-  auto CompareToVert = BC.Builder.CreateICmpEQ(VertId, BC.HlslOP->GetU32Const(m_Parameters.VertexShader.VertexId), "CompareToVertId");
-  auto CompareToInstance = BC.Builder.CreateICmpEQ(InstanceId, BC.HlslOP->GetU32Const(m_Parameters.VertexShader.InstanceId), "CompareToInstanceId");
-  auto CompareBoth = BC.Builder.CreateAnd(CompareToVert, CompareToInstance, "CompareBoth");
+  auto CompareToVert = BC.Builder.CreateICmpEQ(
+      VertId, BC.HlslOP->GetU32Const(m_Parameters.VertexShader.VertexId),
+      "CompareToVertId");
+  auto CompareToInstance = BC.Builder.CreateICmpEQ(
+      InstanceId, BC.HlslOP->GetU32Const(m_Parameters.VertexShader.InstanceId),
+      "CompareToInstanceId");
+  auto CompareBoth =
+      BC.Builder.CreateAnd(CompareToVert, CompareToInstance, "CompareBoth");
 
   return CompareBoth;
 }
 
-Value * DxilDebugInstrumentation::addGeometryShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices) {
+Value *DxilDebugInstrumentation::addGeometryShaderProlog(
+    BuilderContext &BC, SystemValueIndices SVIndices) {
 
-  auto PrimitiveIdOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::PrimitiveID, Type::getInt32Ty(BC.Ctx));
-  Constant* PrimitiveIdOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::PrimitiveID);
-  auto PrimId = BC.Builder.CreateCall(PrimitiveIdOpFunc,
-  { PrimitiveIdOpcode }, "PrimId");
+  auto PrimitiveIdOpFunc =
+      BC.HlslOP->GetOpFunc(DXIL::OpCode::PrimitiveID, Type::getInt32Ty(BC.Ctx));
+  Constant *PrimitiveIdOpcode =
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::PrimitiveID);
+  auto PrimId =
+      BC.Builder.CreateCall(PrimitiveIdOpFunc, {PrimitiveIdOpcode}, "PrimId");
 
-  auto CompareToPrim = BC.Builder.CreateICmpEQ(PrimId, BC.HlslOP->GetU32Const(m_Parameters.GeometryShader.PrimitiveId), "CompareToPrimId");
+  auto CompareToPrim = BC.Builder.CreateICmpEQ(
+      PrimId, BC.HlslOP->GetU32Const(m_Parameters.GeometryShader.PrimitiveId),
+      "CompareToPrimId");
 
   if (BC.DM.GetGSInstanceCount() <= 1) {
     return CompareToPrim;
   }
 
-  auto GSInstanceIdOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::GSInstanceID, Type::getInt32Ty(BC.Ctx));
-  Constant* GSInstanceIdOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::GSInstanceID);
-  auto GSInstanceId = BC.Builder.CreateCall(GSInstanceIdOpFunc,
-  { GSInstanceIdOpcode }, "GSInstanceId");
+  auto GSInstanceIdOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::GSInstanceID,
+                                                 Type::getInt32Ty(BC.Ctx));
+  Constant *GSInstanceIdOpcode =
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::GSInstanceID);
+  auto GSInstanceId = BC.Builder.CreateCall(
+      GSInstanceIdOpFunc, {GSInstanceIdOpcode}, "GSInstanceId");
 
   // Compare to expected vertex ID and instance ID
-  auto CompareToInstance = BC.Builder.CreateICmpEQ(GSInstanceId, BC.HlslOP->GetU32Const(m_Parameters.GeometryShader.InstanceId), "CompareToInstanceId");
-  auto CompareBoth = BC.Builder.CreateAnd(CompareToPrim, CompareToInstance, "CompareBoth");
+  auto CompareToInstance = BC.Builder.CreateICmpEQ(
+      GSInstanceId,
+      BC.HlslOP->GetU32Const(m_Parameters.GeometryShader.InstanceId),
+      "CompareToInstanceId");
+  auto CompareBoth =
+      BC.Builder.CreateAnd(CompareToPrim, CompareToInstance, "CompareBoth");
 
   return CompareBoth;
 }
 
-Value * DxilDebugInstrumentation::addPixelShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices) {
-  Constant* Zero32Arg = BC.HlslOP->GetU32Const(0);
-  Constant* Zero8Arg = BC.HlslOP->GetI8Const(0);
-  Constant* One8Arg = BC.HlslOP->GetI8Const(1);
-  UndefValue* UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+Value *
+DxilDebugInstrumentation::addPixelShaderProlog(BuilderContext &BC,
+                                               SystemValueIndices SVIndices) {
+  Constant *Zero32Arg = BC.HlslOP->GetU32Const(0);
+  Constant *Zero8Arg = BC.HlslOP->GetI8Const(0);
+  Constant *One8Arg = BC.HlslOP->GetI8Const(1);
+  UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
 
-  // Convert SV_POSITION to UINT    
-  Value * XAsInt;
-  Value * YAsInt;
+  // Convert SV_POSITION to UINT
+  Value *XAsInt;
+  Value *YAsInt;
   {
-    auto LoadInputOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getFloatTy(BC.Ctx));
-    Constant* LoadInputOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
-    Constant*  SV_Pos_ID = BC.HlslOP->GetU32Const(SVIndices.PixelShader.Position);
-    auto XPos = BC.Builder.CreateCall(LoadInputOpFunc,
-    { LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/, Zero8Arg /*column*/, UndefArg }, "XPos");
-    auto YPos = BC.Builder.CreateCall(LoadInputOpFunc,
-    { LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/, One8Arg /*column*/, UndefArg }, "YPos");
+    auto LoadInputOpFunc =
+        BC.HlslOP->GetOpFunc(DXIL::OpCode::LoadInput, Type::getFloatTy(BC.Ctx));
+    Constant *LoadInputOpcode =
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::LoadInput);
+    Constant *SV_Pos_ID =
+        BC.HlslOP->GetU32Const(SVIndices.PixelShader.Position);
+    auto XPos =
+        BC.Builder.CreateCall(LoadInputOpFunc,
+                              {LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/,
+                               Zero8Arg /*column*/, UndefArg},
+                              "XPos");
+    auto YPos =
+        BC.Builder.CreateCall(LoadInputOpFunc,
+                              {LoadInputOpcode, SV_Pos_ID, Zero32Arg /*row*/,
+                               One8Arg /*column*/, UndefArg},
+                              "YPos");
 
-    XAsInt = BC.Builder.CreateCast(Instruction::CastOps::FPToUI, XPos, Type::getInt32Ty(BC.Ctx), "XIndex");
-    YAsInt = BC.Builder.CreateCast(Instruction::CastOps::FPToUI, YPos, Type::getInt32Ty(BC.Ctx), "YIndex");
+    XAsInt = BC.Builder.CreateCast(Instruction::CastOps::FPToUI, XPos,
+                                   Type::getInt32Ty(BC.Ctx), "XIndex");
+    YAsInt = BC.Builder.CreateCast(Instruction::CastOps::FPToUI, YPos,
+                                   Type::getInt32Ty(BC.Ctx), "YIndex");
   }
 
   // Compare to expected pixel position and primitive ID
-  auto CompareToX = BC.Builder.CreateICmpEQ(XAsInt, BC.HlslOP->GetU32Const(m_Parameters.PixelShader.X), "CompareToX");
-  auto CompareToY = BC.Builder.CreateICmpEQ(YAsInt, BC.HlslOP->GetU32Const(m_Parameters.PixelShader.Y), "CompareToY");
+  auto CompareToX = BC.Builder.CreateICmpEQ(
+      XAsInt, BC.HlslOP->GetU32Const(m_Parameters.PixelShader.X), "CompareToX");
+  auto CompareToY = BC.Builder.CreateICmpEQ(
+      YAsInt, BC.HlslOP->GetU32Const(m_Parameters.PixelShader.Y), "CompareToY");
   auto ComparePos = BC.Builder.CreateAnd(CompareToX, CompareToY, "ComparePos");
 
   return ComparePos;
 }
 
-void DxilDebugInstrumentation::addUAV(BuilderContext &BC)
-{
+void DxilDebugInstrumentation::addUAV(BuilderContext &BC) {
   // Set up a UAV with structure of a single int
-  unsigned int UAVResourceHandle = static_cast<unsigned int>(BC.DM.GetUAVs().size());
-  SmallVector<llvm::Type*, 1> Elements{ Type::getInt32Ty(BC.Ctx) };
-  llvm::StructType *UAVStructTy = llvm::StructType::create(Elements, "PIX_DebugUAV_Type");
+  unsigned int UAVResourceHandle =
+      static_cast<unsigned int>(BC.DM.GetUAVs().size());
+  SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(BC.Ctx)};
+  llvm::StructType *UAVStructTy =
+      llvm::StructType::create(Elements, "PIX_DebugUAV_Type");
   std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
   pUAV->SetGlobalName("PIX_DebugUAVName");
   pUAV->SetGlobalSymbol(UndefValue::get(UAVStructTy->getPointerTo()));
   pUAV->SetID(UAVResourceHandle);
-  pUAV->SetSpaceID((unsigned int)-2); // This is the reserved-for-tools register space
+  pUAV->SetSpaceID(
+      (unsigned int)-2); // This is the reserved-for-tools register space
   pUAV->SetSampleCount(1);
   pUAV->SetGloballyCoherent(false);
   pUAV->SetHasCounter(false);
@@ -471,20 +568,29 @@ void DxilDebugInstrumentation::addUAV(BuilderContext &BC)
   BC.DM.m_ShaderFlags.SetEnableRawAndStructuredBuffers(true);
 
   // Create handle for the newly-added UAV
-  Function* CreateHandleOpFunc = BC.HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(BC.Ctx));
-  Constant* CreateHandleOpcodeArg = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
-  Constant* UAVVArg = BC.HlslOP->GetI8Const(static_cast<std::underlying_type<DxilResourceBase::Class>::type>(DXIL::ResourceClass::UAV));
-  Constant* MetaDataArg = BC.HlslOP->GetU32Const(ID); // position of the metadata record in the corresponding metadata list
-  Constant* IndexArg = BC.HlslOP->GetU32Const(0); // 
-  Constant* FalseArg = BC.HlslOP->GetI1Const(0); // non-uniform resource index: false
-  m_HandleForUAV = BC.Builder.CreateCall(CreateHandleOpFunc,
-  { CreateHandleOpcodeArg, UAVVArg, MetaDataArg, IndexArg, FalseArg }, "PIX_DebugUAV_Handle");
+  Function *CreateHandleOpFunc =
+      BC.HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(BC.Ctx));
+  Constant *CreateHandleOpcodeArg =
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
+  Constant *UAVVArg = BC.HlslOP->GetI8Const(
+      static_cast<std::underlying_type<DxilResourceBase::Class>::type>(
+          DXIL::ResourceClass::UAV));
+  Constant *MetaDataArg = BC.HlslOP->GetU32Const(
+      ID); // position of the metadata record in the corresponding metadata list
+  Constant *IndexArg = BC.HlslOP->GetU32Const(0); //
+  Constant *FalseArg =
+      BC.HlslOP->GetI1Const(0); // non-uniform resource index: false
+  m_HandleForUAV = BC.Builder.CreateCall(
+      CreateHandleOpFunc,
+      {CreateHandleOpcodeArg, UAVVArg, MetaDataArg, IndexArg, FalseArg},
+      "PIX_DebugUAV_Handle");
 }
 
-void DxilDebugInstrumentation::addInvocationSelectionProlog(BuilderContext &BC, SystemValueIndices SVIndices) {
+void DxilDebugInstrumentation::addInvocationSelectionProlog(
+    BuilderContext &BC, SystemValueIndices SVIndices) {
   auto ShaderModel = BC.DM.GetShaderModel();
 
-  Value * ParameterTestResult = nullptr;
+  Value *ParameterTestResult = nullptr;
   switch (ShaderModel->GetKind()) {
   case DXIL::ShaderKind::Compute:
   case DXIL::ShaderKind::Amplification:
@@ -504,144 +610,177 @@ void DxilDebugInstrumentation::addInvocationSelectionProlog(BuilderContext &BC, 
     assert(false); // guaranteed by runOnModule
   }
 
-  // This is a convenient place to calculate the values that modify the UAV offset for invocations of interest and for
-  // UAV size.
-  m_OffsetMultiplicand = BC.Builder.CreateCast(Instruction::CastOps::ZExt, ParameterTestResult, Type::getInt32Ty(BC.Ctx), "OffsetMultiplicand");
-  auto InverseOffsetMultiplicand = BC.Builder.CreateSub(BC.HlslOP->GetU32Const(1), m_OffsetMultiplicand, "ComplementOfMultiplicand");
-  m_OffsetAddend = BC.Builder.CreateMul(BC.HlslOP->GetU32Const(UAVDumpingGroundOffset()), InverseOffsetMultiplicand, "OffsetAddend");
+  // This is a convenient place to calculate the values that modify the UAV
+  // offset for invocations of interest and for UAV size.
+  m_OffsetMultiplicand =
+      BC.Builder.CreateCast(Instruction::CastOps::ZExt, ParameterTestResult,
+                            Type::getInt32Ty(BC.Ctx), "OffsetMultiplicand");
+  auto InverseOffsetMultiplicand =
+      BC.Builder.CreateSub(BC.HlslOP->GetU32Const(1), m_OffsetMultiplicand,
+                           "ComplementOfMultiplicand");
+  m_OffsetAddend =
+      BC.Builder.CreateMul(BC.HlslOP->GetU32Const(UAVDumpingGroundOffset()),
+                           InverseOffsetMultiplicand, "OffsetAddend");
   m_OffsetMask = BC.HlslOP->GetU32Const(UAVDumpingGroundOffset() - 1);
 
   m_SelectionCriterion = ParameterTestResult;
 }
 
-void DxilDebugInstrumentation::reserveDebugEntrySpace(BuilderContext &BC, uint32_t SpaceInBytes) {
+void DxilDebugInstrumentation::reserveDebugEntrySpace(BuilderContext &BC,
+                                                      uint32_t SpaceInBytes) {
   assert(m_CurrentIndex == nullptr);
   assert(m_RemainingReservedSpaceInBytes == 0);
 
   m_RemainingReservedSpaceInBytes = SpaceInBytes;
 
   // Insert the UAV increment instruction:
-  Function* AtomicOpFunc = BC.HlslOP->GetOpFunc(OP::OpCode::AtomicBinOp, Type::getInt32Ty(BC.Ctx));
-  Constant* AtomicBinOpcode = BC.HlslOP->GetU32Const((unsigned)OP::OpCode::AtomicBinOp);
-  Constant* AtomicAdd = BC.HlslOP->GetU32Const((unsigned)DXIL::AtomicBinOpCode::Add);
-  Constant* Zero32Arg = BC.HlslOP->GetU32Const(0);
-  UndefValue* UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+  Function *AtomicOpFunc =
+      BC.HlslOP->GetOpFunc(OP::OpCode::AtomicBinOp, Type::getInt32Ty(BC.Ctx));
+  Constant *AtomicBinOpcode =
+      BC.HlslOP->GetU32Const((unsigned)OP::OpCode::AtomicBinOp);
+  Constant *AtomicAdd =
+      BC.HlslOP->GetU32Const((unsigned)DXIL::AtomicBinOpCode::Add);
+  Constant *Zero32Arg = BC.HlslOP->GetU32Const(0);
+  UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
 
   // so inc will be zero for uninteresting invocations:
-  Constant* Increment = BC.HlslOP->GetU32Const(SpaceInBytes);
-  Value* IncrementForThisInvocation = BC.Builder.CreateMul(Increment, m_OffsetMultiplicand, "IncrementForThisInvocation");
+  Constant *Increment = BC.HlslOP->GetU32Const(SpaceInBytes);
+  Value *IncrementForThisInvocation = BC.Builder.CreateMul(
+      Increment, m_OffsetMultiplicand, "IncrementForThisInvocation");
 
-  auto PreviousValue = BC.Builder.CreateCall(AtomicOpFunc, {
-    AtomicBinOpcode,// i32, ; opcode
-    m_HandleForUAV, // %dx.types.Handle, ; resource handle
-    AtomicAdd,      // i32, ; binary operation code : EXCHANGE, IADD, AND, OR, XOR, IMIN, IMAX, UMIN, UMAX
-    Zero32Arg,      // i32, ; coordinate c0: index in bytes
-    UndefArg,       // i32, ; coordinate c1 (unused)
-    UndefArg,       // i32, ; coordinate c2 (unused)
-    IncrementForThisInvocation,      // i32); increment value
-  }, "UAVIncResult");
+  auto PreviousValue = BC.Builder.CreateCall(
+      AtomicOpFunc,
+      {
+          AtomicBinOpcode, // i32, ; opcode
+          m_HandleForUAV,  // %dx.types.Handle, ; resource handle
+          AtomicAdd, // i32, ; binary operation code : EXCHANGE, IADD, AND, OR,
+                     // XOR, IMIN, IMAX, UMIN, UMAX
+          Zero32Arg, // i32, ; coordinate c0: index in bytes
+          UndefArg,  // i32, ; coordinate c1 (unused)
+          UndefArg,  // i32, ; coordinate c2 (unused)
+          IncrementForThisInvocation, // i32); increment value
+      },
+      "UAVIncResult");
 
-  if (m_InvocationId == nullptr)
-  {
-      m_InvocationId = PreviousValue;
+  if (m_InvocationId == nullptr) {
+    m_InvocationId = PreviousValue;
   }
 
-  auto MaskedForLimit = BC.Builder.CreateAnd(PreviousValue, m_OffsetMask, "MaskedForUAVLimit");
-  // The return value will either end up being itself (multiplied by one and added with zero)
-  // or the "dump uninteresting things here" value of (UAVSize - a bit).
-  auto MultipliedForInterest = BC.Builder.CreateMul(MaskedForLimit, m_OffsetMultiplicand, "MultipliedForInterest");
-  auto AddedForInterest = BC.Builder.CreateAdd(MultipliedForInterest, m_OffsetAddend, "AddedForInterest");
+  auto MaskedForLimit =
+      BC.Builder.CreateAnd(PreviousValue, m_OffsetMask, "MaskedForUAVLimit");
+  // The return value will either end up being itself (multiplied by one and
+  // added with zero) or the "dump uninteresting things here" value of (UAVSize
+  // - a bit).
+  auto MultipliedForInterest = BC.Builder.CreateMul(
+      MaskedForLimit, m_OffsetMultiplicand, "MultipliedForInterest");
+  auto AddedForInterest = BC.Builder.CreateAdd(
+      MultipliedForInterest, m_OffsetAddend, "AddedForInterest");
   m_CurrentIndex = AddedForInterest;
 }
 
-void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC, Value * TheValue) {
+void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
+                                                  Value *TheValue) {
   assert(m_RemainingReservedSpaceInBytes > 0);
 
   auto TheValueTypeID = TheValue->getType()->getTypeID();
   if (TheValueTypeID == Type::TypeID::DoubleTyID) {
-    Function* SplitDouble = BC.HlslOP->GetOpFunc(OP::OpCode::SplitDouble, TheValue->getType());
-    Constant* SplitDoubleOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::SplitDouble);
-    auto SplitDoubleIntruction = BC.Builder.CreateCall(SplitDouble, { SplitDoubleOpcode, TheValue }, "SplitDouble");
-    auto LowBits = BC.Builder.CreateExtractValue(SplitDoubleIntruction, 0, "LowBits");
-    auto HighBits = BC.Builder.CreateExtractValue(SplitDoubleIntruction, 1, "HighBits");
-    //addDebugEntryValue(BC, BC.HlslOP->GetU32Const(0)); // padding
+    Function *SplitDouble =
+        BC.HlslOP->GetOpFunc(OP::OpCode::SplitDouble, TheValue->getType());
+    Constant *SplitDoubleOpcode =
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::SplitDouble);
+    auto SplitDoubleIntruction = BC.Builder.CreateCall(
+        SplitDouble, {SplitDoubleOpcode, TheValue}, "SplitDouble");
+    auto LowBits =
+        BC.Builder.CreateExtractValue(SplitDoubleIntruction, 0, "LowBits");
+    auto HighBits =
+        BC.Builder.CreateExtractValue(SplitDoubleIntruction, 1, "HighBits");
+    // addDebugEntryValue(BC, BC.HlslOP->GetU32Const(0)); // padding
     addDebugEntryValue(BC, LowBits);
     addDebugEntryValue(BC, HighBits);
-  }
-  else if (TheValueTypeID == Type::TypeID::IntegerTyID && TheValue->getType()->getIntegerBitWidth() == 64) {
-    auto LowBits = BC.Builder.CreateTrunc(TheValue, Type::getInt32Ty(BC.Ctx), "LowBits");
+  } else if (TheValueTypeID == Type::TypeID::IntegerTyID &&
+             TheValue->getType()->getIntegerBitWidth() == 64) {
+    auto LowBits =
+        BC.Builder.CreateTrunc(TheValue, Type::getInt32Ty(BC.Ctx), "LowBits");
     auto ShiftedBits = BC.Builder.CreateLShr(TheValue, 32, "ShiftedBits");
-    auto HighBits = BC.Builder.CreateTrunc(ShiftedBits, Type::getInt32Ty(BC.Ctx), "HighBits");
-    //addDebugEntryValue(BC, BC.HlslOP->GetU32Const(0)); // padding
+    auto HighBits = BC.Builder.CreateTrunc(
+        ShiftedBits, Type::getInt32Ty(BC.Ctx), "HighBits");
+    // addDebugEntryValue(BC, BC.HlslOP->GetU32Const(0)); // padding
     addDebugEntryValue(BC, LowBits);
     addDebugEntryValue(BC, HighBits);
-  }
-  else if (TheValueTypeID == Type::TypeID::IntegerTyID &&
-    (TheValue->getType()->getIntegerBitWidth() == 16 || TheValue->getType()->getIntegerBitWidth() == 1)) {
-    auto As32 = BC.Builder.CreateZExt(TheValue, Type::getInt32Ty(BC.Ctx), "As32");
+  } else if (TheValueTypeID == Type::TypeID::IntegerTyID &&
+             (TheValue->getType()->getIntegerBitWidth() == 16 ||
+              TheValue->getType()->getIntegerBitWidth() == 1)) {
+    auto As32 =
+        BC.Builder.CreateZExt(TheValue, Type::getInt32Ty(BC.Ctx), "As32");
     addDebugEntryValue(BC, As32);
-  }
-  else if (TheValueTypeID == Type::TypeID::HalfTyID) {
-    auto AsFloat = BC.Builder.CreateFPCast(TheValue, Type::getFloatTy(BC.Ctx), "AsFloat");
+  } else if (TheValueTypeID == Type::TypeID::HalfTyID) {
+    auto AsFloat =
+        BC.Builder.CreateFPCast(TheValue, Type::getFloatTy(BC.Ctx), "AsFloat");
     addDebugEntryValue(BC, AsFloat);
-  }
-  else {
-    Function* StoreValue = BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore, TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
-    Constant* StoreValueOpcode = BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
-    UndefValue* Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
-    UndefValue* UndefArg = nullptr;
+  } else {
+    Function *StoreValue =
+        BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore,
+                             TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
+    Constant *StoreValueOpcode =
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
+    UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+    UndefValue *UndefArg = nullptr;
     if (TheValueTypeID == Type::TypeID::IntegerTyID) {
-        UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+      UndefArg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
+    } else if (TheValueTypeID == Type::TypeID::FloatTyID) {
+      UndefArg = UndefValue::get(Type::getFloatTy(BC.Ctx));
+    } else {
+      // The above are the only two valid types for a UAV store
+      assert(false);
     }
-    else if (TheValueTypeID == Type::TypeID::FloatTyID) {
-        UndefArg = UndefValue::get(Type::getFloatTy(BC.Ctx));
-    }
-    else {
-        // The above are the only two valid types for a UAV store
-        assert(false);
-    }
-    Constant* WriteMask_X = BC.HlslOP->GetI8Const(1);
-    (void)BC.Builder.CreateCall(StoreValue, {
-      StoreValueOpcode, // i32 opcode
-      m_HandleForUAV,   // %dx.types.Handle, ; resource handle
-      m_CurrentIndex,   // i32 c0: index in bytes into UAV
-      Undef32Arg,       // i32 c1: unused
-      TheValue,
-      UndefArg,         // unused values
-      UndefArg,         // unused values
-      UndefArg,         // unused values
-      WriteMask_X
-    });
+    Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
+    (void)BC.Builder.CreateCall(
+        StoreValue, {StoreValueOpcode, // i32 opcode
+                     m_HandleForUAV,   // %dx.types.Handle, ; resource handle
+                     m_CurrentIndex,   // i32 c0: index in bytes into UAV
+                     Undef32Arg,       // i32 c1: unused
+                     TheValue,
+                     UndefArg, // unused values
+                     UndefArg, // unused values
+                     UndefArg, // unused values
+                     WriteMask_X});
 
     m_RemainingReservedSpaceInBytes -= 4;
-    assert(m_RemainingReservedSpaceInBytes < 1024);  // check for underflow
+    assert(m_RemainingReservedSpaceInBytes < 1024); // check for underflow
 
     if (m_RemainingReservedSpaceInBytes != 0) {
-      m_CurrentIndex = BC.Builder.CreateAdd(m_CurrentIndex, BC.HlslOP->GetU32Const(4));
-    }
-    else {
+      m_CurrentIndex =
+          BC.Builder.CreateAdd(m_CurrentIndex, BC.HlslOP->GetU32Const(4));
+    } else {
       m_CurrentIndex = nullptr;
     }
   }
 }
 
 void DxilDebugInstrumentation::addInvocationStartMarker(BuilderContext &BC) {
-  DebugShaderModifierRecordHeader marker{ {{0, 0, 0, 0}}, 0 };
+  DebugShaderModifierRecordHeader marker{{{0, 0, 0, 0}}, 0};
   reserveDebugEntrySpace(BC, sizeof(marker));
 
-  marker.Header.Details.SizeDwords = DebugShaderModifierRecordPayloadSizeDwords(sizeof(marker));;
+  marker.Header.Details.SizeDwords =
+      DebugShaderModifierRecordPayloadSizeDwords(sizeof(marker));
+  ;
   marker.Header.Details.Flags = 0;
-  marker.Header.Details.Type = DebugShaderModifierRecordTypeInvocationStartMarker;
+  marker.Header.Details.Type =
+      DebugShaderModifierRecordTypeInvocationStartMarker;
   addDebugEntryValue(BC, BC.HlslOP->GetU32Const(marker.Header.u32Header));
   addDebugEntryValue(BC, m_InvocationId);
 }
 
-template<typename ReturnType>
-void DxilDebugInstrumentation::addStepEntryForType(DebugShaderModifierRecordType RecordType, BuilderContext &BC, std::uint32_t InstNum, Value *V, std::uint32_t ValueOrdinal, Value *ValueOrdinalIndex) {
+template <typename ReturnType>
+void DxilDebugInstrumentation::addStepEntryForType(
+    DebugShaderModifierRecordType RecordType, BuilderContext &BC,
+    std::uint32_t InstNum, Value *V, std::uint32_t ValueOrdinal,
+    Value *ValueOrdinalIndex) {
   DebugShaderModifierRecordDXILStep<ReturnType> step = {};
   reserveDebugEntrySpace(BC, sizeof(step));
 
-  step.Header.Details.SizeDwords = DebugShaderModifierRecordPayloadSizeDwords(sizeof(step));
+  step.Header.Details.SizeDwords =
+      DebugShaderModifierRecordPayloadSizeDwords(sizeof(step));
   step.Header.Details.Type = static_cast<uint8_t>(RecordType);
   addDebugEntryValue(BC, BC.HlslOP->GetU32Const(step.Header.u32Header));
   addDebugEntryValue(BC, m_InvocationId);
@@ -653,17 +792,22 @@ void DxilDebugInstrumentation::addStepEntryForType(DebugShaderModifierRecordType
     IRBuilder<> &B = BC.Builder;
 
     Value *VO = BC.HlslOP->GetU32Const(ValueOrdinal << 16);
-    Value *VOI = B.CreateAnd(ValueOrdinalIndex, BC.HlslOP->GetU32Const(0xFFFF), "ValueOrdinalIndex");
-    Value *EncodedValueOrdinalAndIndex = BC.Builder.CreateOr(VO, VOI, "ValueOrdinal");
+    Value *VOI = B.CreateAnd(ValueOrdinalIndex, BC.HlslOP->GetU32Const(0xFFFF),
+                             "ValueOrdinalIndex");
+    Value *EncodedValueOrdinalAndIndex =
+        BC.Builder.CreateOr(VO, VOI, "ValueOrdinal");
     addDebugEntryValue(BC, EncodedValueOrdinalAndIndex);
   }
 }
 
-void DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext &BC, StoreInst *Inst) {
+void DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext &BC,
+                                                      StoreInst *Inst) {
   std::uint32_t ValueOrdinalBase;
   std::uint32_t UnusedValueOrdinalSize;
   llvm::Value *ValueOrdinalIndex;
-  if (!pix_dxil::PixAllocaRegWrite::FromInst(Inst, &ValueOrdinalBase, &UnusedValueOrdinalSize, &ValueOrdinalIndex)) {
+  if (!pix_dxil::PixAllocaRegWrite::FromInst(Inst, &ValueOrdinalBase,
+                                             &UnusedValueOrdinalSize,
+                                             &ValueOrdinalIndex)) {
     return;
   }
 
@@ -672,10 +816,12 @@ void DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext &BC, StoreI
     return;
   }
 
-  addStepDebugEntryValue(BC, InstNum, Inst->getValueOperand(), ValueOrdinalBase, ValueOrdinalIndex);
+  addStepDebugEntryValue(BC, InstNum, Inst->getValueOperand(), ValueOrdinalBase,
+                         ValueOrdinalIndex);
 }
 
-void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC, Instruction *Inst) {
+void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
+                                                 Instruction *Inst) {
   if (Inst->getOpcode() == Instruction::OtherOps::PHI) {
     return;
   }
@@ -698,36 +844,46 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC, Instruction
   addStepDebugEntryValue(BC, InstNum, Inst, RegNum, BC.Builder.getInt32(0));
 }
 
-void DxilDebugInstrumentation::addStepDebugEntryValue(BuilderContext &BC, std::uint32_t InstNum, Value *V, std::uint32_t ValueOrdinal, Value *ValueOrdinalIndex) {
+void DxilDebugInstrumentation::addStepDebugEntryValue(
+    BuilderContext &BC, std::uint32_t InstNum, Value *V,
+    std::uint32_t ValueOrdinal, Value *ValueOrdinalIndex) {
   const Type::TypeID ID = V->getType()->getTypeID();
 
   switch (ID) {
   case Type::TypeID::StructTyID:
   case Type::TypeID::VoidTyID:
-    addStepEntryForType<void>(DebugShaderModifierRecordTypeDXILStepVoid, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
+    addStepEntryForType<void>(DebugShaderModifierRecordTypeDXILStepVoid, BC,
+                              InstNum, V, ValueOrdinal, ValueOrdinalIndex);
     break;
   case Type::TypeID::FloatTyID:
-    addStepEntryForType<float>(DebugShaderModifierRecordTypeDXILStepFloat, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
+    addStepEntryForType<float>(DebugShaderModifierRecordTypeDXILStepFloat, BC,
+                               InstNum, V, ValueOrdinal, ValueOrdinalIndex);
     break;
   case Type::TypeID::IntegerTyID:
     if (V->getType()->getIntegerBitWidth() == 64) {
-      addStepEntryForType<uint64_t>(DebugShaderModifierRecordTypeDXILStepUint64, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
-    }
-    else {
-      addStepEntryForType<uint32_t>(DebugShaderModifierRecordTypeDXILStepUint32, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
+      addStepEntryForType<uint64_t>(DebugShaderModifierRecordTypeDXILStepUint64,
+                                    BC, InstNum, V, ValueOrdinal,
+                                    ValueOrdinalIndex);
+    } else {
+      addStepEntryForType<uint32_t>(DebugShaderModifierRecordTypeDXILStepUint32,
+                                    BC, InstNum, V, ValueOrdinal,
+                                    ValueOrdinalIndex);
     }
     break;
   case Type::TypeID::DoubleTyID:
-    addStepEntryForType<double>(DebugShaderModifierRecordTypeDXILStepDouble, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
+    addStepEntryForType<double>(DebugShaderModifierRecordTypeDXILStepDouble, BC,
+                                InstNum, V, ValueOrdinal, ValueOrdinalIndex);
     break;
   case Type::TypeID::HalfTyID:
-    addStepEntryForType<float>(DebugShaderModifierRecordTypeDXILStepFloat, BC, InstNum, V, ValueOrdinal, ValueOrdinalIndex);
+    addStepEntryForType<float>(DebugShaderModifierRecordTypeDXILStepFloat, BC,
+                               InstNum, V, ValueOrdinal, ValueOrdinalIndex);
     break;
   case Type::TypeID::PointerTyID:
-    // Skip pointer calculation instructions. They aren't particularly meaningful to the user (being a mere
-    // implementation detail for lookup tables, etc.), and their type is problematic from a UI point of view.
-    // The subsequent instructions that dereference the pointer will be properly instrumented and show the
-    // (meaningful) retrieved value.
+    // Skip pointer calculation instructions. They aren't particularly
+    // meaningful to the user (being a mere implementation detail for lookup
+    // tables, etc.), and their type is problematic from a UI point of view. The
+    // subsequent instructions that dereference the pointer will be properly
+    // instrumented and show the (meaningful) retrieved value.
     break;
   case Type::TypeID::FP128TyID:
   case Type::TypeID::LabelTyID:
@@ -740,12 +896,11 @@ void DxilDebugInstrumentation::addStepDebugEntryValue(BuilderContext &BC, std::u
   case Type::TypeID::PPC_FP128TyID:
     assert(false);
   }
-
 }
 
 bool DxilDebugInstrumentation::runOnModule(Module &M) {
   DxilModule &DM = M.GetOrCreateDxilModule();
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
 
   auto ShaderModel = DM.GetShaderModel();
@@ -761,26 +916,32 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
     return false;
   }
 
-
   // First record pointers to all instructions in the function:
-  std::vector<Instruction*> AllInstructions;
-  for (inst_iterator I = inst_begin(DM.GetEntryFunction()), E = inst_end(DM.GetEntryFunction()); I != E; ++I) {
+  std::vector<Instruction *> AllInstructions;
+  for (inst_iterator I = inst_begin(DM.GetEntryFunction()),
+                     E = inst_end(DM.GetEntryFunction());
+       I != E; ++I) {
     AllInstructions.push_back(&*I);
   }
 
   // Branchless instrumentation requires taking care of a few things:
-  // -Each invocation of the shader will be either of interest or not of interest
+  // -Each invocation of the shader will be either of interest or not of
+  // interest
   //    -If of interest, the offset into the output UAV will be as expected
-  //    -If not, the offset is forced to (UAVsize) - (Small Amount), and that output is ignored by the CPU-side code.
-  // -The invocation of interest may overflow the UAV. This is handled by taking the modulus of the
-  //  output index. Overflow is then detected on the CPU side by checking for the presence of a canary
-  //  value at (UAVSize) - (Small Amount) * 2 (which is actually a conservative definition of overflow).
+  //    -If not, the offset is forced to (UAVsize) - (Small Amount), and that
+  //    output is ignored by the CPU-side code.
+  // -The invocation of interest may overflow the UAV. This is handled by taking
+  // the modulus of the
+  //  output index. Overflow is then detected on the CPU side by checking for
+  //  the presence of a canary value at (UAVSize) - (Small Amount) * 2 (which is
+  //  actually a conservative definition of overflow).
   //
 
-  Instruction* firstInsertionPt = dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction());
+  Instruction *firstInsertionPt =
+      dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction());
   IRBuilder<> Builder(firstInsertionPt);
 
-  BuilderContext BC{ M, DM, Ctx, HlslOP, Builder };
+  BuilderContext BC{M, DM, Ctx, HlslOP, Builder};
 
   addUAV(BC);
   auto SystemValues = addRequiredSystemValues(BC);
@@ -788,18 +949,17 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
   addInvocationStartMarker(BC);
 
   // Instrument original instructions:
-  for (auto & Inst : AllInstructions) {
-    // Instrumentation goes after the instruction if it is not a terminator. Otherwise,
-    // Instrumentation goes prior to the instruction.
+  for (auto &Inst : AllInstructions) {
+    // Instrumentation goes after the instruction if it is not a terminator.
+    // Otherwise, Instrumentation goes prior to the instruction.
     if (!Inst->isTerminator()) {
       IRBuilder<> Builder(Inst->getNextNode());
-      BuilderContext BC2{ BC.M, BC.DM, BC.Ctx, BC.HlslOP, Builder };
+      BuilderContext BC2{BC.M, BC.DM, BC.Ctx, BC.HlslOP, Builder};
       addStepDebugEntry(BC2, Inst);
-    }
-    else {
+    } else {
       // Insert before this instruction
       IRBuilder<> Builder(Inst);
-      BuilderContext BC2{ BC.M, BC.DM, BC.Ctx, BC.HlslOP, Builder };
+      BuilderContext BC2{BC.M, BC.DM, BC.Ctx, BC.HlslOP, Builder};
       addStepDebugEntry(BC2, Inst);
     }
   }
@@ -815,4 +975,5 @@ ModulePass *llvm::createDxilDebugInstrumentationPass() {
   return new DxilDebugInstrumentation();
 }
 
-INITIALIZE_PASS(DxilDebugInstrumentation, "hlsl-dxil-debug-instrumentation", "HLSL DXIL debug instrumentation for PIX", false, false)
+INITIALIZE_PASS(DxilDebugInstrumentation, "hlsl-dxil-debug-instrumentation",
+                "HLSL DXIL debug instrumentation for PIX", false, false)

--- a/lib/DxilPIXPasses/DxilForceEarlyZ.cpp
+++ b/lib/DxilPIXPasses/DxilForceEarlyZ.cpp
@@ -9,9 +9,9 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 #include "llvm/IR/Module.h"
 
 using namespace llvm;
@@ -26,9 +26,7 @@ public:
   bool runOnModule(Module &M) override;
 };
 
-
-bool DxilForceEarlyZ::runOnModule(Module &M)
-{
+bool DxilForceEarlyZ::runOnModule(Module &M) {
   // This pass adds the force-early-z flag
 
   DxilModule &DM = M.GetOrCreateDxilModule();
@@ -42,8 +40,9 @@ bool DxilForceEarlyZ::runOnModule(Module &M)
 
 char DxilForceEarlyZ::ID = 0;
 
-ModulePass *llvm::createDxilForceEarlyZPass() {
-  return new DxilForceEarlyZ();
-}
+ModulePass *llvm::createDxilForceEarlyZPass() { return new DxilForceEarlyZ(); }
 
-INITIALIZE_PASS(DxilForceEarlyZ, "hlsl-dxil-force-early-z", "HLSL DXIL Force the early Z global flag, if shader has no discard calls", false, false)
+INITIALIZE_PASS(
+    DxilForceEarlyZ, "hlsl-dxil-force-early-z",
+    "HLSL DXIL Force the early Z global flag, if shader has no discard calls",
+    false, false)

--- a/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
+++ b/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
@@ -10,10 +10,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/HLSL/DxilSpanAllocator.h"
 
 #include "llvm/IR/PassManager.h"
@@ -25,8 +25,7 @@ using namespace hlsl;
 
 class DxilOutputColorBecomesConstant : public ModulePass {
 
-  enum VisualizerInstrumentationMode
-  {
+  enum VisualizerInstrumentationMode {
     FromLiteralConstant,
     FromConstantBuffer
   };
@@ -37,11 +36,10 @@ class DxilOutputColorBecomesConstant : public ModulePass {
   float Alpha = 1.f;
   VisualizerInstrumentationMode Mode = FromLiteralConstant;
 
-  void visitOutputInstructionCallers(
-    Function * OutputFunction, 
-    const hlsl::DxilSignature &OutputSignature, 
-    OP * HlslOP, 
-    std::function<void(CallInst*)> Visitor);
+  void visitOutputInstructionCallers(Function *OutputFunction,
+                                     const hlsl::DxilSignature &OutputSignature,
+                                     OP *HlslOP,
+                                     std::function<void(CallInst *)> Visitor);
 
 public:
   static char ID; // Pass identification, replacement for typeid
@@ -63,26 +61,29 @@ void DxilOutputColorBecomesConstant::applyOptions(PassOptions O) {
 }
 
 void DxilOutputColorBecomesConstant::visitOutputInstructionCallers(
-  Function * OutputFunction,
-  const hlsl::DxilSignature &OutputSignature,
-  OP * HlslOP,
-  std::function<void(CallInst*)> Visitor) {
+    Function *OutputFunction, const hlsl::DxilSignature &OutputSignature,
+    OP *HlslOP, std::function<void(CallInst *)> Visitor) {
 
   auto OutputFunctionUses = OutputFunction->uses();
 
   for (Use &FunctionUse : OutputFunctionUses) {
     iterator_range<Value::user_iterator> FunctionUsers = FunctionUse->users();
-    for (User * FunctionUser : FunctionUsers) {
+    for (User *FunctionUser : FunctionUsers) {
       if (isa<Instruction>(FunctionUser)) {
         auto CallInstruction = cast<CallInst>(FunctionUser);
 
-        // Check if the instruction writes to a render target (as opposed to a system-value, such as RenderTargetArrayIndex)
-        Value *OutputID = CallInstruction->getArgOperand(DXIL::OperandIndex::kStoreOutputIDOpIdx);
-        unsigned SignatureElementIndex = cast<ConstantInt>(OutputID)->getLimitedValue();
-        const DxilSignatureElement &SignatureElement = OutputSignature.GetElement(SignatureElementIndex);
+        // Check if the instruction writes to a render target (as opposed to a
+        // system-value, such as RenderTargetArrayIndex)
+        Value *OutputID = CallInstruction->getArgOperand(
+            DXIL::OperandIndex::kStoreOutputIDOpIdx);
+        unsigned SignatureElementIndex =
+            cast<ConstantInt>(OutputID)->getLimitedValue();
+        const DxilSignatureElement &SignatureElement =
+            OutputSignature.GetElement(SignatureElementIndex);
 
         // We only modify the output color for RTV0
-        if (SignatureElement.GetSemantic()->GetKind() == DXIL::SemanticKind::Target &&
+        if (SignatureElement.GetSemantic()->GetKind() ==
+                DXIL::SemanticKind::Target &&
             SignatureElement.GetSemanticStartIndex() == 0) {
 
           // Replace the source operand with the appropriate constant value
@@ -93,138 +94,173 @@ void DxilOutputColorBecomesConstant::visitOutputInstructionCallers(
   }
 }
 
-bool DxilOutputColorBecomesConstant::runOnModule(Module &M)
-{
-  // This pass finds all users of the "StoreOutput" function, and replaces their source operands with a constant
-  // value. 
+bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
+  // This pass finds all users of the "StoreOutput" function, and replaces their
+  // source operands with a constant value.
 
   DxilModule &DM = M.GetOrCreateDxilModule();
 
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
 
   OP *HlslOP = DM.GetOP();
 
-  const hlsl::DxilSignature & OutputSignature = DM.GetOutputSignature();
+  const hlsl::DxilSignature &OutputSignature = DM.GetOutputSignature();
 
-  Function * FloatOutputFunction = HlslOP->GetOpFunc(DXIL::OpCode::StoreOutput, Type::getFloatTy(Ctx));
-  Function * IntOutputFunction = HlslOP->GetOpFunc(DXIL::OpCode::StoreOutput, Type::getInt32Ty(Ctx));
+  Function *FloatOutputFunction =
+      HlslOP->GetOpFunc(DXIL::OpCode::StoreOutput, Type::getFloatTy(Ctx));
+  Function *IntOutputFunction =
+      HlslOP->GetOpFunc(DXIL::OpCode::StoreOutput, Type::getInt32Ty(Ctx));
 
   bool hasFloatOutputs = false;
   bool hasIntOutputs = false;
 
-  visitOutputInstructionCallers(FloatOutputFunction, OutputSignature, HlslOP, [&hasFloatOutputs](CallInst *) {
-    hasFloatOutputs = true;
-  });
+  visitOutputInstructionCallers(
+      FloatOutputFunction, OutputSignature, HlslOP,
+      [&hasFloatOutputs](CallInst *) { hasFloatOutputs = true; });
 
-  visitOutputInstructionCallers(IntOutputFunction, OutputSignature, HlslOP, [&hasIntOutputs](CallInst *) {
-    hasIntOutputs = true;
-  });
+  visitOutputInstructionCallers(
+      IntOutputFunction, OutputSignature, HlslOP,
+      [&hasIntOutputs](CallInst *) { hasIntOutputs = true; });
 
-  if (!hasFloatOutputs && !hasIntOutputs)
-  {
+  if (!hasFloatOutputs && !hasIntOutputs) {
     return false;
   }
 
-  // Otherwise, we assume the shader outputs only one or the other (because the 0th RTV can't have a mixed type)
-  DXASSERT(!hasFloatOutputs || !hasIntOutputs, "Only one or the other type of output: float or int");
+  // Otherwise, we assume the shader outputs only one or the other (because the
+  // 0th RTV can't have a mixed type)
+  DXASSERT(!hasFloatOutputs || !hasIntOutputs,
+           "Only one or the other type of output: float or int");
 
   std::array<llvm::Value *, 4> ReplacementColors;
 
-  switch (Mode)
-  {
-    case FromLiteralConstant: {
-      if (hasFloatOutputs) {
-        ReplacementColors[0] = HlslOP->GetFloatConst(Red);
-        ReplacementColors[1] = HlslOP->GetFloatConst(Green);
-        ReplacementColors[2] = HlslOP->GetFloatConst(Blue);
-        ReplacementColors[3] = HlslOP->GetFloatConst(Alpha);
-      }
-      if (hasIntOutputs) {
-        ReplacementColors[0] = HlslOP->GetI32Const(static_cast<int>(Red));
-        ReplacementColors[1] = HlslOP->GetI32Const(static_cast<int>(Green));
-        ReplacementColors[2] = HlslOP->GetI32Const(static_cast<int>(Blue));
-        ReplacementColors[3] = HlslOP->GetI32Const(static_cast<int>(Alpha));
-      }
+  switch (Mode) {
+  case FromLiteralConstant: {
+    if (hasFloatOutputs) {
+      ReplacementColors[0] = HlslOP->GetFloatConst(Red);
+      ReplacementColors[1] = HlslOP->GetFloatConst(Green);
+      ReplacementColors[2] = HlslOP->GetFloatConst(Blue);
+      ReplacementColors[3] = HlslOP->GetFloatConst(Alpha);
     }
-    break;
-    case FromConstantBuffer: {
+    if (hasIntOutputs) {
+      ReplacementColors[0] = HlslOP->GetI32Const(static_cast<int>(Red));
+      ReplacementColors[1] = HlslOP->GetI32Const(static_cast<int>(Green));
+      ReplacementColors[2] = HlslOP->GetI32Const(static_cast<int>(Blue));
+      ReplacementColors[3] = HlslOP->GetI32Const(static_cast<int>(Alpha));
+    }
+  } break;
+  case FromConstantBuffer: {
 
-      // Setup a constant buffer with a single float4 in it:
-      SmallVector<llvm::Type*, 4> Elements { Type::getFloatTy(Ctx), Type::getFloatTy(Ctx) , Type::getFloatTy(Ctx) , Type::getFloatTy(Ctx) };
-      llvm::StructType *CBStructTy = llvm::StructType::create(Elements, "PIX_ConstantColorCB_Type");
-      std::unique_ptr<DxilCBuffer> pCBuf = llvm::make_unique<DxilCBuffer>();
-      pCBuf->SetGlobalName("PIX_ConstantColorCBName");
-      pCBuf->SetGlobalSymbol(UndefValue::get(CBStructTy));
-      pCBuf->SetID(0);
-      pCBuf->SetSpaceID((unsigned int)-2); // This is the reserved-for-tools register space
-      pCBuf->SetLowerBound(0);
-      pCBuf->SetRangeSize(1);
-      pCBuf->SetSize(4);
+    // Setup a constant buffer with a single float4 in it:
+    SmallVector<llvm::Type *, 4> Elements{
+        Type::getFloatTy(Ctx), Type::getFloatTy(Ctx), Type::getFloatTy(Ctx),
+        Type::getFloatTy(Ctx)};
+    llvm::StructType *CBStructTy =
+        llvm::StructType::create(Elements, "PIX_ConstantColorCB_Type");
+    std::unique_ptr<DxilCBuffer> pCBuf = llvm::make_unique<DxilCBuffer>();
+    pCBuf->SetGlobalName("PIX_ConstantColorCBName");
+    pCBuf->SetGlobalSymbol(UndefValue::get(CBStructTy));
+    pCBuf->SetID(0);
+    pCBuf->SetSpaceID(
+        (unsigned int)-2); // This is the reserved-for-tools register space
+    pCBuf->SetLowerBound(0);
+    pCBuf->SetRangeSize(1);
+    pCBuf->SetSize(4);
 
-      ID = DM.AddCBuffer(std::move(pCBuf));
+    ID = DM.AddCBuffer(std::move(pCBuf));
 
-      Instruction * entryPointInstruction = &*(DM.GetEntryFunction()->begin()->begin());
-      IRBuilder<> Builder(entryPointInstruction);
+    Instruction *entryPointInstruction =
+        &*(DM.GetEntryFunction()->begin()->begin());
+    IRBuilder<> Builder(entryPointInstruction);
 
-      // Create handle for the newly-added constant buffer (which is achieved via a function call)
-      auto ConstantBufferName = "PIX_Constant_Color_CB_Handle";
-      Function *createHandle = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
-      Constant *CreateHandleOpcodeArg = HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
-      Constant *CBVArg = HlslOP->GetI8Const(static_cast<std::underlying_type<DxilResourceBase::Class>::type>(DXIL::ResourceClass::CBuffer)); 
-      Constant *MetaDataArg = HlslOP->GetU32Const(ID); // position of the metadata record in the corresponding metadata list
-      Constant *IndexArg = HlslOP->GetU32Const(0); // 
-      Constant *FalseArg = HlslOP->GetI1Const(0); // non-uniform resource index: false
-      CallInst *callCreateHandle = Builder.CreateCall(createHandle, { CreateHandleOpcodeArg, CBVArg, MetaDataArg, IndexArg, FalseArg }, ConstantBufferName);
+    // Create handle for the newly-added constant buffer (which is achieved via
+    // a function call)
+    auto ConstantBufferName = "PIX_Constant_Color_CB_Handle";
+    Function *createHandle =
+        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+    Constant *CreateHandleOpcodeArg =
+        HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
+    Constant *CBVArg = HlslOP->GetI8Const(
+        static_cast<std::underlying_type<DxilResourceBase::Class>::type>(
+            DXIL::ResourceClass::CBuffer));
+    Constant *MetaDataArg =
+        HlslOP->GetU32Const(ID); // position of the metadata record in the
+                                 // corresponding metadata list
+    Constant *IndexArg = HlslOP->GetU32Const(0); //
+    Constant *FalseArg =
+        HlslOP->GetI1Const(0); // non-uniform resource index: false
+    CallInst *callCreateHandle = Builder.CreateCall(
+        createHandle,
+        {CreateHandleOpcodeArg, CBVArg, MetaDataArg, IndexArg, FalseArg},
+        ConstantBufferName);
 
-      DM.ReEmitDxilResources();
+    DM.ReEmitDxilResources();
 
 #define PIX_CONSTANT_VALUE "PIX_Constant_Color_Value"
 
-      // Insert the Buffer load instruction:
-      Function *CBLoad = HlslOP->GetOpFunc(OP::OpCode::CBufferLoadLegacy, hasFloatOutputs ? Type::getFloatTy(Ctx) : Type::getInt32Ty(Ctx));
-      Constant *OpArg = HlslOP->GetU32Const((unsigned)OP::OpCode::CBufferLoadLegacy);
-      Value * ResourceHandle = callCreateHandle;
-      Constant *RowIndex = HlslOP->GetU32Const(0);
-      CallInst *loadLegacy = Builder.CreateCall(CBLoad, { OpArg, ResourceHandle, RowIndex }, PIX_CONSTANT_VALUE);
+    // Insert the Buffer load instruction:
+    Function *CBLoad = HlslOP->GetOpFunc(
+        OP::OpCode::CBufferLoadLegacy,
+        hasFloatOutputs ? Type::getFloatTy(Ctx) : Type::getInt32Ty(Ctx));
+    Constant *OpArg =
+        HlslOP->GetU32Const((unsigned)OP::OpCode::CBufferLoadLegacy);
+    Value *ResourceHandle = callCreateHandle;
+    Constant *RowIndex = HlslOP->GetU32Const(0);
+    CallInst *loadLegacy = Builder.CreateCall(
+        CBLoad, {OpArg, ResourceHandle, RowIndex}, PIX_CONSTANT_VALUE);
 
-      // Now extract four color values:
-      ReplacementColors[0] = Builder.CreateExtractValue(loadLegacy, 0, PIX_CONSTANT_VALUE "0");
-      ReplacementColors[1] = Builder.CreateExtractValue(loadLegacy, 1, PIX_CONSTANT_VALUE "1");
-      ReplacementColors[2] = Builder.CreateExtractValue(loadLegacy, 2, PIX_CONSTANT_VALUE "2");
-      ReplacementColors[3] = Builder.CreateExtractValue(loadLegacy, 3, PIX_CONSTANT_VALUE "3");
-    }
-    break;
-    default:
-      assert(false);
-      return 0;
+    // Now extract four color values:
+    ReplacementColors[0] =
+        Builder.CreateExtractValue(loadLegacy, 0, PIX_CONSTANT_VALUE "0");
+    ReplacementColors[1] =
+        Builder.CreateExtractValue(loadLegacy, 1, PIX_CONSTANT_VALUE "1");
+    ReplacementColors[2] =
+        Builder.CreateExtractValue(loadLegacy, 2, PIX_CONSTANT_VALUE "2");
+    ReplacementColors[3] =
+        Builder.CreateExtractValue(loadLegacy, 3, PIX_CONSTANT_VALUE "3");
+  } break;
+  default:
+    assert(false);
+    return 0;
   }
 
   bool Modified = false;
 
-  // The StoreOutput function can store either a float or an integer, depending on the intended output
-  // render-target resource view.
+  // The StoreOutput function can store either a float or an integer, depending
+  // on the intended output render-target resource view.
   if (hasFloatOutputs) {
-    visitOutputInstructionCallers(FloatOutputFunction, OutputSignature, HlslOP, 
-      [&ReplacementColors, &Modified](CallInst * CallInstruction) {
-      Modified = true;
-      // The output column is the channel (red, green, blue or alpha) within the output pixel
-      Value * OutputColumnOperand = CallInstruction->getOperand(hlsl::DXIL::OperandIndex::kStoreOutputColOpIdx);
-      ConstantInt * OutputColumnConstant = cast<ConstantInt>(OutputColumnOperand);
-      APInt OutputColumn = OutputColumnConstant->getValue();
-      CallInstruction->setOperand(hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx, ReplacementColors[*OutputColumn.getRawData()]);
-    });
+    visitOutputInstructionCallers(
+        FloatOutputFunction, OutputSignature, HlslOP,
+        [&ReplacementColors, &Modified](CallInst *CallInstruction) {
+          Modified = true;
+          // The output column is the channel (red, green, blue or alpha) within
+          // the output pixel
+          Value *OutputColumnOperand = CallInstruction->getOperand(
+              hlsl::DXIL::OperandIndex::kStoreOutputColOpIdx);
+          ConstantInt *OutputColumnConstant =
+              cast<ConstantInt>(OutputColumnOperand);
+          APInt OutputColumn = OutputColumnConstant->getValue();
+          CallInstruction->setOperand(
+              hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx,
+              ReplacementColors[*OutputColumn.getRawData()]);
+        });
   }
 
   if (hasIntOutputs) {
-    visitOutputInstructionCallers(IntOutputFunction, OutputSignature, HlslOP, 
-    [&ReplacementColors, &Modified](CallInst * CallInstruction) {
-      Modified = true;
-      // The output column is the channel (red, green, blue or alpha) within the output pixel
-      Value * OutputColumnOperand = CallInstruction->getOperand(hlsl::DXIL::OperandIndex::kStoreOutputColOpIdx);
-      ConstantInt * OutputColumnConstant = cast<ConstantInt>(OutputColumnOperand);
-      APInt OutputColumn = OutputColumnConstant->getValue();
-      CallInstruction->setOperand(hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx, ReplacementColors[*OutputColumn.getRawData()]);
-    });
+    visitOutputInstructionCallers(
+        IntOutputFunction, OutputSignature, HlslOP,
+        [&ReplacementColors, &Modified](CallInst *CallInstruction) {
+          Modified = true;
+          // The output column is the channel (red, green, blue or alpha) within
+          // the output pixel
+          Value *OutputColumnOperand = CallInstruction->getOperand(
+              hlsl::DXIL::OperandIndex::kStoreOutputColOpIdx);
+          ConstantInt *OutputColumnConstant =
+              cast<ConstantInt>(OutputColumnOperand);
+          APInt OutputColumn = OutputColumnConstant->getValue();
+          CallInstruction->setOperand(
+              hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx,
+              ReplacementColors[*OutputColumn.getRawData()]);
+        });
   }
 
   return Modified;
@@ -236,4 +272,5 @@ ModulePass *llvm::createDxilOutputColorBecomesConstantPass() {
   return new DxilOutputColorBecomesConstant();
 }
 
-INITIALIZE_PASS(DxilOutputColorBecomesConstant, "hlsl-dxil-constantColor", "DXIL Constant Color Mod", false, false)
+INITIALIZE_PASS(DxilOutputColorBecomesConstant, "hlsl-dxil-constantColor",
+                "DXIL Constant Color Mod", false, false)

--- a/lib/DxilPIXPasses/DxilPIXPasses.cpp
+++ b/lib/DxilPIXPasses/DxilPIXPasses.cpp
@@ -9,14 +9,14 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/Support/WinIncludes.h"
-#include "dxc/Support/Global.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/Support/Global.h"
+#include "dxc/Support/WinIncludes.h"
 
+#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/PassInfo.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 
 using namespace llvm;
@@ -25,8 +25,7 @@ using namespace hlsl;
 namespace hlsl {
 
 HRESULT SetupRegistryPassForPIX() {
-  try
-  {
+  try {
     PassRegistry &Registry = *PassRegistry::getPassRegistry();
     /* <py::lines('INIT-PASSES')>hctdb_instrhelp.get_init_passes(set(["pix"]))</py>*/
     // INIT-PASSES:BEGIN
@@ -44,4 +43,4 @@ HRESULT SetupRegistryPassForPIX() {
   return S_OK;
 }
 
-}
+} // namespace hlsl

--- a/lib/DxilPIXPasses/DxilPIXVirtualRegisters.cpp
+++ b/lib/DxilPIXPasses/DxilPIXVirtualRegisters.cpp
@@ -15,22 +15,26 @@
 #include "dxc/Support/Global.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Type.h"
 
-void pix_dxil::PixDxilInstNum::AddMD(llvm::LLVMContext &Ctx, llvm::Instruction *pI, std::uint32_t InstNum) {
+void pix_dxil::PixDxilInstNum::AddMD(llvm::LLVMContext &Ctx,
+                                     llvm::Instruction *pI,
+                                     std::uint32_t InstNum) {
   llvm::IRBuilder<> B(Ctx);
   pI->setMetadata(
-    llvm::StringRef(MDName),
-    llvm::MDNode::get(Ctx, { llvm::ConstantAsMetadata::get(B.getInt32(ID)),
-                             llvm::ConstantAsMetadata::get(B.getInt32(InstNum)) }));
+      llvm::StringRef(MDName),
+      llvm::MDNode::get(Ctx,
+                        {llvm::ConstantAsMetadata::get(B.getInt32(ID)),
+                         llvm::ConstantAsMetadata::get(B.getInt32(InstNum))}));
 }
 
-bool pix_dxil::PixDxilInstNum::FromInst(llvm::Instruction *pI, std::uint32_t *pInstNum) {
+bool pix_dxil::PixDxilInstNum::FromInst(llvm::Instruction *pI,
+                                        std::uint32_t *pInstNum) {
   *pInstNum = 0;
 
   auto *mdNodes = pI->getMetadata(MDName);
@@ -43,12 +47,14 @@ bool pix_dxil::PixDxilInstNum::FromInst(llvm::Instruction *pI, std::uint32_t *pI
     return false;
   }
 
-  auto *mdID = llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
+  auto *mdID =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
   if (mdID == nullptr || mdID->getLimitedValue() != ID) {
     return false;
   }
 
-  auto *mdInstNum = llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(1));
+  auto *mdInstNum =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(1));
   if (mdInstNum == nullptr) {
     return false;
   }
@@ -57,15 +63,18 @@ bool pix_dxil::PixDxilInstNum::FromInst(llvm::Instruction *pI, std::uint32_t *pI
   return true;
 }
 
-void pix_dxil::PixDxilReg::AddMD(llvm::LLVMContext &Ctx, llvm::Instruction *pI, std::uint32_t RegNum) {
+void pix_dxil::PixDxilReg::AddMD(llvm::LLVMContext &Ctx, llvm::Instruction *pI,
+                                 std::uint32_t RegNum) {
   llvm::IRBuilder<> B(Ctx);
   pI->setMetadata(
       llvm::StringRef(MDName),
-      llvm::MDNode::get(Ctx, { llvm::ConstantAsMetadata::get(B.getInt32(ID)),
-                               llvm::ConstantAsMetadata::get(B.getInt32(RegNum)) }));
+      llvm::MDNode::get(Ctx,
+                        {llvm::ConstantAsMetadata::get(B.getInt32(ID)),
+                         llvm::ConstantAsMetadata::get(B.getInt32(RegNum))}));
 }
 
-bool pix_dxil::PixDxilReg::FromInst(llvm::Instruction *pI, std::uint32_t *pRegNum) {
+bool pix_dxil::PixDxilReg::FromInst(llvm::Instruction *pI,
+                                    std::uint32_t *pRegNum) {
   *pRegNum = 0;
 
   auto *mdNodes = pI->getMetadata(MDName);
@@ -78,12 +87,14 @@ bool pix_dxil::PixDxilReg::FromInst(llvm::Instruction *pI, std::uint32_t *pRegNu
     return false;
   }
 
-  auto *mdID = llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
+  auto *mdID =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
   if (mdID == nullptr || mdID->getLimitedValue() != ID) {
     return false;
   }
 
-  auto *mdRegNum = llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(1));
+  auto *mdRegNum =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(1));
   if (mdRegNum == nullptr) {
     return false;
   }
@@ -92,18 +103,22 @@ bool pix_dxil::PixDxilReg::FromInst(llvm::Instruction *pI, std::uint32_t *pRegNu
   return true;
 }
 
-static bool ParsePixAllocaReg(llvm::MDNode *MD, std::uint32_t *RegNum, std::uint32_t *Count) {
+static bool ParsePixAllocaReg(llvm::MDNode *MD, std::uint32_t *RegNum,
+                              std::uint32_t *Count) {
   if (MD->getNumOperands() != 3) {
     return false;
   }
 
   auto *mdID = llvm::mdconst::dyn_extract<llvm::ConstantInt>(MD->getOperand(0));
-  if (mdID == nullptr || mdID->getLimitedValue() != pix_dxil::PixAllocaReg::ID) {
+  if (mdID == nullptr ||
+      mdID->getLimitedValue() != pix_dxil::PixAllocaReg::ID) {
     return false;
   }
 
-  auto *mdRegNum = llvm::mdconst::dyn_extract<llvm::ConstantInt>(MD->getOperand(1));
-  auto *mdCount = llvm::mdconst::dyn_extract<llvm::ConstantInt>(MD->getOperand(2));
+  auto *mdRegNum =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(MD->getOperand(1));
+  auto *mdCount =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(MD->getOperand(2));
 
   if (mdRegNum == nullptr || mdCount == nullptr) {
     return false;
@@ -114,16 +129,21 @@ static bool ParsePixAllocaReg(llvm::MDNode *MD, std::uint32_t *RegNum, std::uint
   return true;
 }
 
-void pix_dxil::PixAllocaReg::AddMD(llvm::LLVMContext &Ctx, llvm::AllocaInst *pAlloca, std::uint32_t RegNum, std::uint32_t Count) {
+void pix_dxil::PixAllocaReg::AddMD(llvm::LLVMContext &Ctx,
+                                   llvm::AllocaInst *pAlloca,
+                                   std::uint32_t RegNum, std::uint32_t Count) {
   llvm::IRBuilder<> B(Ctx);
   pAlloca->setMetadata(
       llvm::StringRef(MDName),
-      llvm::MDNode::get(Ctx, { llvm::ConstantAsMetadata::get(B.getInt32(ID)),
-                               llvm::ConstantAsMetadata::get(B.getInt32(RegNum)),
-                               llvm::ConstantAsMetadata::get(B.getInt32(Count)) }));
+      llvm::MDNode::get(Ctx,
+                        {llvm::ConstantAsMetadata::get(B.getInt32(ID)),
+                         llvm::ConstantAsMetadata::get(B.getInt32(RegNum)),
+                         llvm::ConstantAsMetadata::get(B.getInt32(Count))}));
 }
 
-bool pix_dxil::PixAllocaReg::FromInst(llvm::AllocaInst *pAlloca, std::uint32_t *pRegBase, std::uint32_t *pRegSize) {
+bool pix_dxil::PixAllocaReg::FromInst(llvm::AllocaInst *pAlloca,
+                                      std::uint32_t *pRegBase,
+                                      std::uint32_t *pRegSize) {
   *pRegBase = 0;
   *pRegSize = 0;
 
@@ -139,18 +159,21 @@ namespace pix_dxil {
 namespace PixAllocaRegWrite {
 static constexpr uint32_t IndexIsConst = 1;
 static constexpr uint32_t IndexIsPixInst = 2;
-}  // namespace PixAllocaRegWrite
-}  // namespace pix_dxil {
+} // namespace PixAllocaRegWrite
+} // namespace pix_dxil
 
-void pix_dxil::PixAllocaRegWrite::AddMD(llvm::LLVMContext &Ctx, llvm::StoreInst *pSt, llvm::MDNode *pAllocaReg, llvm::Value *Index) {
+void pix_dxil::PixAllocaRegWrite::AddMD(llvm::LLVMContext &Ctx,
+                                        llvm::StoreInst *pSt,
+                                        llvm::MDNode *pAllocaReg,
+                                        llvm::Value *Index) {
   llvm::IRBuilder<> B(Ctx);
   if (auto *C = llvm::dyn_cast<llvm::ConstantInt>(Index)) {
     pSt->setMetadata(
-      llvm::StringRef(MDName),
-      llvm::MDNode::get(Ctx, { llvm::ConstantAsMetadata::get(B.getInt32(ID)),
-                               pAllocaReg,
-                               llvm::ConstantAsMetadata::get(B.getInt32(IndexIsConst)),
-                               llvm::ConstantAsMetadata::get(C) }));
+        llvm::StringRef(MDName),
+        llvm::MDNode::get(
+            Ctx, {llvm::ConstantAsMetadata::get(B.getInt32(ID)), pAllocaReg,
+                  llvm::ConstantAsMetadata::get(B.getInt32(IndexIsConst)),
+                  llvm::ConstantAsMetadata::get(C)}));
   }
 
   if (auto *I = llvm::dyn_cast<llvm::Instruction>(Index)) {
@@ -159,15 +182,18 @@ void pix_dxil::PixAllocaRegWrite::AddMD(llvm::LLVMContext &Ctx, llvm::StoreInst 
       return;
     }
     pSt->setMetadata(
-      llvm::StringRef(MDName),
-      llvm::MDNode::get(Ctx, { llvm::ConstantAsMetadata::get(B.getInt32(ID)),
-                               pAllocaReg,
-                               llvm::ConstantAsMetadata::get(B.getInt32(IndexIsPixInst)),
-                               llvm::ConstantAsMetadata::get(B.getInt32(InstNum)) }));
+        llvm::StringRef(MDName),
+        llvm::MDNode::get(
+            Ctx, {llvm::ConstantAsMetadata::get(B.getInt32(ID)), pAllocaReg,
+                  llvm::ConstantAsMetadata::get(B.getInt32(IndexIsPixInst)),
+                  llvm::ConstantAsMetadata::get(B.getInt32(InstNum))}));
   }
 }
 
-bool pix_dxil::PixAllocaRegWrite::FromInst(llvm::StoreInst *pI, std::uint32_t *pRegBase, std::uint32_t *pRegSize, llvm::Value **pIndex) {
+bool pix_dxil::PixAllocaRegWrite::FromInst(llvm::StoreInst *pI,
+                                           std::uint32_t *pRegBase,
+                                           std::uint32_t *pRegSize,
+                                           llvm::Value **pIndex) {
   *pRegBase = 0;
   *pRegSize = 0;
   *pIndex = nullptr;
@@ -177,27 +203,31 @@ bool pix_dxil::PixAllocaRegWrite::FromInst(llvm::StoreInst *pI, std::uint32_t *p
     return false;
   }
 
-  auto *mdID = llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
+  auto *mdID =
+      llvm::mdconst::dyn_extract<llvm::ConstantInt>(mdNodes->getOperand(0));
   if (mdID == nullptr || mdID->getLimitedValue() != ID) {
     return false;
   }
 
   auto *mdAllocaReg = llvm::dyn_cast<llvm::MDNode>(mdNodes->getOperand(1));
-  if (mdAllocaReg == nullptr || !ParsePixAllocaReg(mdAllocaReg, pRegBase, pRegSize)) {
+  if (mdAllocaReg == nullptr ||
+      !ParsePixAllocaReg(mdAllocaReg, pRegBase, pRegSize)) {
     return false;
   }
 
-  auto *mdIndexType = llvm::dyn_cast<llvm::ConstantAsMetadata>(mdNodes->getOperand(2));
+  auto *mdIndexType =
+      llvm::dyn_cast<llvm::ConstantAsMetadata>(mdNodes->getOperand(2));
   if (mdIndexType == nullptr) {
     return false;
   }
 
-  auto* cIndexType = llvm::dyn_cast<llvm::ConstantInt>(mdIndexType->getValue());
+  auto *cIndexType = llvm::dyn_cast<llvm::ConstantInt>(mdIndexType->getValue());
   if (cIndexType == nullptr) {
     return false;
   }
 
-  auto *mdIndex = llvm::dyn_cast<llvm::ConstantAsMetadata>(mdNodes->getOperand(3));
+  auto *mdIndex =
+      llvm::dyn_cast<llvm::ConstantAsMetadata>(mdNodes->getOperand(3));
   if (mdIndex == nullptr) {
     return false;
   }
@@ -217,7 +247,8 @@ bool pix_dxil::PixAllocaRegWrite::FromInst(llvm::StoreInst *pI, std::uint32_t *p
   }
 
   case IndexIsPixInst: {
-    for (llvm::Instruction &I : llvm::inst_range(pI->getParent()->getParent())) {
+    for (llvm::Instruction &I :
+         llvm::inst_range(pI->getParent()->getParent())) {
       uint32_t InstNum;
       if (PixDxilInstNum::FromInst(&I, &InstNum)) {
         *pIndex = &I;

--- a/lib/DxilPIXPasses/DxilReduceMSAAToSingleSample.cpp
+++ b/lib/DxilPIXPasses/DxilReduceMSAAToSingleSample.cpp
@@ -9,15 +9,15 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
-#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/IR/Constants.h"
 
 using namespace llvm;
 using namespace hlsl;
@@ -27,43 +27,50 @@ class DxilReduceMSAAToSingleSample : public ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilReduceMSAAToSingleSample() : ModulePass(ID) {}
-  const char *getPassName() const override { return "HLSL DXIL Reduce all MSAA reads to single-sample reads"; }
+  const char *getPassName() const override {
+    return "HLSL DXIL Reduce all MSAA reads to single-sample reads";
+  }
   bool runOnModule(Module &M) override;
 };
 
-bool DxilReduceMSAAToSingleSample::runOnModule(Module &M)
-{
+bool DxilReduceMSAAToSingleSample::runOnModule(Module &M) {
   DxilModule &DM = M.GetOrCreateDxilModule();
 
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
 
-  // FP16 type doesn't have its own identity, and is covered by float type... 
+  // FP16 type doesn't have its own identity, and is covered by float type...
 
-
-  auto TextureLoadOverloads = std::vector<Type*>{ Type::getFloatTy(Ctx), Type::getInt16Ty(Ctx), Type::getInt32Ty(Ctx) };
+  auto TextureLoadOverloads = std::vector<Type *>{
+      Type::getFloatTy(Ctx), Type::getInt16Ty(Ctx), Type::getInt32Ty(Ctx)};
 
   bool Modified = false;
 
-  for (const auto & Overload : TextureLoadOverloads) {
+  for (const auto &Overload : TextureLoadOverloads) {
 
-    Function * TexLoadFunction = HlslOP->GetOpFunc(DXIL::OpCode::TextureLoad, Overload);
+    Function *TexLoadFunction =
+        HlslOP->GetOpFunc(DXIL::OpCode::TextureLoad, Overload);
     auto TexLoadFunctionUses = TexLoadFunction->uses();
 
-    for (auto FI = TexLoadFunctionUses.begin(); FI != TexLoadFunctionUses.end(); ) {
-      auto & FunctionUse = *FI++;
+    for (auto FI = TexLoadFunctionUses.begin();
+         FI != TexLoadFunctionUses.end();) {
+      auto &FunctionUse = *FI++;
       auto FunctionUser = FunctionUse.getUser();
       auto instruction = cast<Instruction>(FunctionUser);
       DxilInst_TextureLoad LoadInstruction(instruction);
       auto TextureHandle = LoadInstruction.get_srv();
       auto TextureHandleInst = cast<CallInst>(TextureHandle);
       DxilInst_CreateHandle createHandle(TextureHandleInst);
-      // Dynamic rangeId is not supported 
-      if (isa<ConstantInt>(createHandle.get_rangeId())){
-        unsigned rangeId = cast<ConstantInt>(createHandle.get_rangeId())->getLimitedValue();
-        if (static_cast<DXIL::ResourceClass>(createHandle.get_resourceClass_val()) == DXIL::ResourceClass::SRV) {
+      // Dynamic rangeId is not supported
+      if (isa<ConstantInt>(createHandle.get_rangeId())) {
+        unsigned rangeId =
+            cast<ConstantInt>(createHandle.get_rangeId())->getLimitedValue();
+        if (static_cast<DXIL::ResourceClass>(
+                createHandle.get_resourceClass_val()) ==
+            DXIL::ResourceClass::SRV) {
           auto Resource = DM.GetSRV(rangeId);
-          if (Resource.GetKind() == DXIL::ResourceKind::Texture2DMS || Resource.GetKind() == DXIL::ResourceKind::Texture2DMSArray) {
+          if (Resource.GetKind() == DXIL::ResourceKind::Texture2DMS ||
+              Resource.GetKind() == DXIL::ResourceKind::Texture2DMSArray) {
             // "2" is the mip-level/sample-index operand index:
             // https://github.com/Microsoft/DirectXShaderCompiler/blob/master/docs/DXIL.rst#textureload
             instruction->setOperand(2, HlslOP->GetI32Const(0));
@@ -83,4 +90,6 @@ ModulePass *llvm::createDxilReduceMSAAToSingleSamplePass() {
   return new DxilReduceMSAAToSingleSample();
 }
 
-INITIALIZE_PASS(DxilReduceMSAAToSingleSample, "hlsl-dxil-reduce-msaa-to-single", "HLSL DXIL Reduce all MSAA writes to single-sample writes", false, false)
+INITIALIZE_PASS(DxilReduceMSAAToSingleSample, "hlsl-dxil-reduce-msaa-to-single",
+                "HLSL DXIL Reduce all MSAA writes to single-sample writes",
+                false, false)

--- a/lib/DxilPIXPasses/DxilReduceMSAAToSingleSample.cpp
+++ b/lib/DxilPIXPasses/DxilReduceMSAAToSingleSample.cpp
@@ -9,9 +9,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "dxc/DXIL/DxilOperations.h"
+
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
-#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/HLSL/DxilGenerationPass.h"
 

--- a/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
+++ b/lib/DxilPIXPasses/DxilRemoveDiscards.cpp
@@ -9,10 +9,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
@@ -25,24 +25,28 @@ class DxilRemoveDiscards : public ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilRemoveDiscards() : ModulePass(ID) {}
-  const char *getPassName() const override { return "DXIL Remove all discard instructions"; }
+  const char *getPassName() const override {
+    return "DXIL Remove all discard instructions";
+  }
   bool runOnModule(Module &M) override;
 };
 
-bool DxilRemoveDiscards::runOnModule(Module &M)
-{
-  // This pass removes all instances of the discard instruction within the shader.
+bool DxilRemoveDiscards::runOnModule(Module &M) {
+  // This pass removes all instances of the discard instruction within the
+  // shader.
   DxilModule &DM = M.GetOrCreateDxilModule();
 
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
-  Function * DiscardFunction = HlslOP->GetOpFunc(DXIL::OpCode::Discard, Type::getVoidTy(Ctx));
+  Function *DiscardFunction =
+      HlslOP->GetOpFunc(DXIL::OpCode::Discard, Type::getVoidTy(Ctx));
   auto DiscardFunctionUses = DiscardFunction->uses();
 
   bool Modified = false;
 
-  for (auto FI = DiscardFunctionUses.begin(); FI != DiscardFunctionUses.end(); ) {
-    auto & FunctionUse = *FI++;
+  for (auto FI = DiscardFunctionUses.begin();
+       FI != DiscardFunctionUses.end();) {
+    auto &FunctionUse = *FI++;
     auto FunctionUser = FunctionUse.getUser();
     auto instruction = cast<Instruction>(FunctionUser);
     instruction->eraseFromParent();
@@ -58,4 +62,5 @@ ModulePass *llvm::createDxilRemoveDiscardsPass() {
   return new DxilRemoveDiscards();
 }
 
-INITIALIZE_PASS(DxilRemoveDiscards, "hlsl-dxil-remove-discards", "HLSL DXIL Remove all discard instructions", false, false)
+INITIALIZE_PASS(DxilRemoveDiscards, "hlsl-dxil-remove-discards",
+                "HLSL DXIL Remove all discard instructions", false, false)

--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -10,11 +10,11 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/HLSL/DxilGenerationPass.h"
-#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/HLSL/DxilSpanAllocator.h"
 
 #include "llvm/IR/PassManager.h"
@@ -29,9 +29,7 @@
 using namespace llvm;
 using namespace hlsl;
 
-
-void ThrowIf(bool a)
-{
+void ThrowIf(bool a) {
   if (a) {
     throw ::hlsl::Exception(E_INVALIDARG);
   }
@@ -40,19 +38,20 @@ void ThrowIf(bool a)
 //---------------------------------------------------------------------------------------------------------------------------------
 // These types are taken from PIX's ShaderAccessHelpers.h
 
-enum class ShaderAccessFlags : uint32_t
-{
+enum class ShaderAccessFlags : uint32_t {
   None = 0,
   Read = 1 << 0,
   Write = 1 << 1,
 
-  // "Counter" access is only applicable to UAVs; it means the counter buffer attached to the UAV
-  // was accessed, but not necessarily the UAV resource.
+  // "Counter" access is only applicable to UAVs; it means the counter buffer
+  // attached to the UAV was accessed, but not necessarily the UAV resource.
   Counter = 1 << 2,
 
   // Descriptor-only read (if any), but not the resource contents (if any).
-  // Used for GetDimensions, samplers, and secondary texture for sampler feedback.
-  // TODO: Make this a unique value if supported in PIX, then enable GetDimensions
+  // Used for GetDimensions, samplers, and secondary texture for sampler
+  // feedback.
+  // TODO: Make this a unique value if supported in PIX, then enable
+  // GetDimensions
   DescriptorRead = 1 << 0,
 };
 
@@ -72,16 +71,16 @@ static uint32_t OffsetFromAccess(ShaderAccessFlags access) {
   }
 }
 
-// This enum doesn't have to match PIX's version, because the values are received from PIX encoded in ASCII.
-// However, for ease of comparing this code with PIX, and to be less confusing to future maintainers, this
-// enum does indeed match the same-named enum in PIX.
-enum class RegisterType
-{
+// This enum doesn't have to match PIX's version, because the values are
+// received from PIX encoded in ASCII. However, for ease of comparing this code
+// with PIX, and to be less confusing to future maintainers, this enum does
+// indeed match the same-named enum in PIX.
+enum class RegisterType {
   CBV,
   SRV,
   UAV,
-  RTV, // not used. 
-  DSV, // not used. 
+  RTV, // not used.
+  DSV, // not used.
   Sampler,
   SOV, // not used.
   Invalid,
@@ -89,46 +88,51 @@ enum class RegisterType
 };
 
 RegisterType RegisterTypeFromResourceClass(DXIL::ResourceClass c) {
-  switch (c)
-  {
-  case DXIL::ResourceClass::SRV    : return RegisterType::SRV    ; break;
-  case DXIL::ResourceClass::UAV    : return RegisterType::UAV    ; break;
-  case DXIL::ResourceClass::CBuffer: return RegisterType::CBV    ; break;
-  case DXIL::ResourceClass::Sampler: return RegisterType::Sampler; break;
-  case DXIL::ResourceClass::Invalid: return RegisterType::Invalid; break;
+  switch (c) {
+  case DXIL::ResourceClass::SRV:
+    return RegisterType::SRV;
+    break;
+  case DXIL::ResourceClass::UAV:
+    return RegisterType::UAV;
+    break;
+  case DXIL::ResourceClass::CBuffer:
+    return RegisterType::CBV;
+    break;
+  case DXIL::ResourceClass::Sampler:
+    return RegisterType::Sampler;
+    break;
+  case DXIL::ResourceClass::Invalid:
+    return RegisterType::Invalid;
+    break;
   default:
     ThrowIf(true);
     return RegisterType::Invalid;
   }
 }
 
-struct RegisterTypeAndSpace
-{
-  bool operator < (const RegisterTypeAndSpace & o) const {
+struct RegisterTypeAndSpace {
+  bool operator<(const RegisterTypeAndSpace &o) const {
     return static_cast<int>(Type) < static_cast<int>(o.Type) ||
-      (static_cast<int>(Type) == static_cast<int>(o.Type) && Space < o.Space);
+           (static_cast<int>(Type) == static_cast<int>(o.Type) &&
+            Space < o.Space);
   }
   RegisterType Type;
-  unsigned     Space;
+  unsigned Space;
 };
 
 // Identifies a bind point as defined by the root signature
-struct RSRegisterIdentifier
-{
+struct RSRegisterIdentifier {
   RegisterType Type;
-  unsigned     Space;
-  unsigned     Index;
+  unsigned Space;
+  unsigned Index;
 
-  bool operator < (const RSRegisterIdentifier & o) const {
-    return
-      static_cast<unsigned>(Type) < static_cast<unsigned>(o.Type) &&
-      Space < o.Space &&
-      Index < o.Index;
+  bool operator<(const RSRegisterIdentifier &o) const {
+    return static_cast<unsigned>(Type) < static_cast<unsigned>(o.Type) &&
+           Space < o.Space && Index < o.Index;
   }
 };
 
-struct SlotRange
-{
+struct SlotRange {
   unsigned startSlot;
   unsigned numSlots;
 
@@ -136,10 +140,9 @@ struct SlotRange
   unsigned numInvariableSlots;
 };
 
-
 struct DxilResourceAndClass {
-  DxilResourceBase * resource;
-  Value * index;
+  DxilResourceBase *resource;
+  Value *index;
   DXIL::ResourceClass resClass;
 };
 
@@ -149,26 +152,30 @@ class DxilShaderAccessTracking : public ModulePass {
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilShaderAccessTracking() : ModulePass(ID) {}
-  const char *getPassName() const override { return "DXIL shader access tracking"; }
+  const char *getPassName() const override {
+    return "DXIL shader access tracking";
+  }
   bool runOnModule(Module &M) override;
   void applyOptions(PassOptions O) override;
 
 private:
-  void EmitAccess(LLVMContext & Ctx, OP *HlslOP, IRBuilder<> &, Value *slot, ShaderAccessFlags access);
-  bool EmitResourceAccess(DxilResourceAndClass &res, Instruction * instruction, OP * HlslOP, LLVMContext & Ctx, ShaderAccessFlags readWrite);
+  void EmitAccess(LLVMContext &Ctx, OP *HlslOP, IRBuilder<> &, Value *slot,
+                  ShaderAccessFlags access);
+  bool EmitResourceAccess(DxilResourceAndClass &res, Instruction *instruction,
+                          OP *HlslOP, LLVMContext &Ctx,
+                          ShaderAccessFlags readWrite);
 
 private:
   bool m_CheckForDynamicIndexing = false;
   std::map<RegisterTypeAndSpace, SlotRange> m_slotAssignments;
-  std::map<llvm::Function*, CallInst *> m_FunctionToUAVHandle;
+  std::map<llvm::Function *, CallInst *> m_FunctionToUAVHandle;
   std::set<RSRegisterIdentifier> m_DynamicallyIndexedBindPoints;
 };
 
-static unsigned DeserializeInt(std::deque<char> & q) {
+static unsigned DeserializeInt(std::deque<char> &q) {
   unsigned i = 0;
 
-  while(!q.empty() && isdigit(q.front()))
-  {
+  while (!q.empty() && isdigit(q.front())) {
     i *= 10;
     i += q.front() - '0';
     q.pop_front();
@@ -176,38 +183,47 @@ static unsigned DeserializeInt(std::deque<char> & q) {
   return i;
 }
 
-static char DequeFront(std::deque<char> & q) {
+static char DequeFront(std::deque<char> &q) {
   ThrowIf(q.empty());
   auto c = q.front();
   q.pop_front();
   return c;
 }
 
-static RegisterType ParseRegisterType(std::deque<char> & q) {
-  switch (DequeFront(q))
-  {
-  case 'C': return RegisterType::CBV;
-  case 'S': return RegisterType::SRV;
-  case 'U': return RegisterType::UAV;
-  case 'M': return RegisterType::Sampler;
-  case 'I': return RegisterType::Invalid;
-  default: return RegisterType::Terminator;
+static RegisterType ParseRegisterType(std::deque<char> &q) {
+  switch (DequeFront(q)) {
+  case 'C':
+    return RegisterType::CBV;
+  case 'S':
+    return RegisterType::SRV;
+  case 'U':
+    return RegisterType::UAV;
+  case 'M':
+    return RegisterType::Sampler;
+  case 'I':
+    return RegisterType::Invalid;
+  default:
+    return RegisterType::Terminator;
   }
 }
 
 static char EncodeRegisterType(RegisterType r) {
-  switch (r)
-  {
-  case RegisterType::CBV:     return 'C';
-  case RegisterType::SRV:     return 'S';
-  case RegisterType::UAV:     return 'U';
-  case RegisterType::Sampler: return 'M';
-  case RegisterType::Invalid: return 'I';
+  switch (r) {
+  case RegisterType::CBV:
+    return 'C';
+  case RegisterType::SRV:
+    return 'S';
+  case RegisterType::UAV:
+    return 'U';
+  case RegisterType::Sampler:
+    return 'M';
+  case RegisterType::Invalid:
+    return 'I';
   }
   return '.';
 }
 
-static void ValidateDelimiter(std::deque<char> & q, char d) {
+static void ValidateDelimiter(std::deque<char> &q, char d) {
   ThrowIf(q.front() != d);
   q.pop_front();
 }
@@ -222,7 +238,8 @@ void DxilShaderAccessTracking::applyOptions(PassOptions O) {
     std::deque<char> config;
     config.assign(configOption.begin(), configOption.end());
 
-    // Parse slot assignments. Compare with PIX's ShaderAccessHelpers.cpp (TrackingConfiguration::SerializedRepresentation)
+    // Parse slot assignments. Compare with PIX's ShaderAccessHelpers.cpp
+    // (TrackingConfiguration::SerializedRepresentation)
     RegisterType rt = ParseRegisterType(config);
     while (rt != RegisterType::Terminator) {
 
@@ -253,65 +270,87 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
                                           IRBuilder<> &Builder,
                                           Value *ByteIndex,
                                           ShaderAccessFlags access) {
-  
-  unsigned OffsetForAccessType = static_cast<unsigned>(OffsetFromAccess(access) * BytesPerDWORD);
-  auto OffsetByteIndex = Builder.CreateAdd(ByteIndex, HlslOP->GetU32Const(OffsetForAccessType), "OffsetByteIndex");
 
-  UndefValue* UndefIntArg = UndefValue::get(Type::getInt32Ty(Ctx));
-  Constant* LiteralOne = HlslOP->GetU32Const(1);
-  Constant* ElementMask = HlslOP->GetI8Const(1);
+  unsigned OffsetForAccessType =
+      static_cast<unsigned>(OffsetFromAccess(access) * BytesPerDWORD);
+  auto OffsetByteIndex = Builder.CreateAdd(
+      ByteIndex, HlslOP->GetU32Const(OffsetForAccessType), "OffsetByteIndex");
 
-  Function* StoreFunc = HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(Ctx));
-  Constant* StoreOpcode = HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
-  (void)Builder.CreateCall(StoreFunc, {
-      StoreOpcode,       // i32, ; opcode
-      m_FunctionToUAVHandle.at(Builder.GetInsertBlock()->getParent()), // %dx.types.Handle, ; resource handle
-      OffsetByteIndex,   // i32, ; coordinate c0: byte offset
-      UndefIntArg,       // i32, ; coordinate c1 (unused)
-      LiteralOne,        // i32, ; value v0
-      UndefIntArg,       // i32, ; value v1
-      UndefIntArg,       // i32, ; value v2
-      UndefIntArg,       // i32, ; value v3
-      ElementMask        // i8 ; just the first value is used
-  });
+  UndefValue *UndefIntArg = UndefValue::get(Type::getInt32Ty(Ctx));
+  Constant *LiteralOne = HlslOP->GetU32Const(1);
+  Constant *ElementMask = HlslOP->GetI8Const(1);
+
+  Function *StoreFunc =
+      HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(Ctx));
+  Constant *StoreOpcode =
+      HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
+  (void)Builder.CreateCall(
+      StoreFunc,
+      {
+          StoreOpcode, // i32, ; opcode
+          m_FunctionToUAVHandle.at(
+              Builder.GetInsertBlock()
+                  ->getParent()), // %dx.types.Handle, ; resource handle
+          OffsetByteIndex,        // i32, ; coordinate c0: byte offset
+          UndefIntArg,            // i32, ; coordinate c1 (unused)
+          LiteralOne,             // i32, ; value v0
+          UndefIntArg,            // i32, ; value v1
+          UndefIntArg,            // i32, ; value v2
+          UndefIntArg,            // i32, ; value v3
+          ElementMask             // i8 ; just the first value is used
+      });
 }
 
-bool DxilShaderAccessTracking::EmitResourceAccess(DxilResourceAndClass &res, Instruction * instruction, OP * HlslOP, LLVMContext & Ctx, ShaderAccessFlags readWrite) {
+bool DxilShaderAccessTracking::EmitResourceAccess(DxilResourceAndClass &res,
+                                                  Instruction *instruction,
+                                                  OP *HlslOP, LLVMContext &Ctx,
+                                                  ShaderAccessFlags readWrite) {
 
-  RegisterTypeAndSpace typeAndSpace{ RegisterTypeFromResourceClass(res.resClass), res.resource->GetSpaceID() };
+  RegisterTypeAndSpace typeAndSpace{RegisterTypeFromResourceClass(res.resClass),
+                                    res.resource->GetSpaceID()};
 
   auto slot = m_slotAssignments.find(typeAndSpace);
   // If the assignment isn't found, we assume it's not accessed
   if (slot != m_slotAssignments.end()) {
 
     IRBuilder<> Builder(instruction);
-    Value * slotIndex;
+    Value *slotIndex;
 
     if (isa<ConstantInt>(res.index)) {
       unsigned index = cast<ConstantInt>(res.index)->getLimitedValue();
       if (index > slot->second.numSlots) {
         // out-of-range accesses are written to slot zero:
         slotIndex = HlslOP->GetU32Const(0);
+      } else {
+        slotIndex = HlslOP->GetU32Const((slot->second.startSlot + index) *
+                                        DWORDsPerResource * BytesPerDWORD);
       }
-      else {
-        slotIndex = HlslOP->GetU32Const((slot->second.startSlot + index) * DWORDsPerResource * BytesPerDWORD);
-      }
-    }
-    else {
-      RSRegisterIdentifier id{ typeAndSpace.Type, typeAndSpace.Space,  res.resource->GetID() };
+    } else {
+      RSRegisterIdentifier id{typeAndSpace.Type, typeAndSpace.Space,
+                              res.resource->GetID()};
       m_DynamicallyIndexedBindPoints.emplace(std::move(id));
 
+      // CompareWithSlotLimit will contain 1 if the access is out-of-bounds
+      // (both over- and and under-flow via the unsigned >= with slot count)
+      auto CompareWithSlotLimit = Builder.CreateICmpUGE(
+          res.index, HlslOP->GetU32Const(slot->second.numSlots),
+          "CompareWithSlotLimit");
+      auto CompareWithSlotLimitAsUint = Builder.CreateCast(
+          Instruction::CastOps::ZExt, CompareWithSlotLimit,
+          Type::getInt32Ty(Ctx), "CompareWithSlotLimitAsUint");
 
-      // CompareWithSlotLimit will contain 1 if the access is out-of-bounds (both over- and and under-flow 
-      // via the unsigned >= with slot count)
-      auto CompareWithSlotLimit = Builder.CreateICmpUGE(res.index, HlslOP->GetU32Const(slot->second.numSlots), "CompareWithSlotLimit");
-      auto CompareWithSlotLimitAsUint = Builder.CreateCast(Instruction::CastOps::ZExt, CompareWithSlotLimit, Type::getInt32Ty(Ctx), "CompareWithSlotLimitAsUint");
+      // IsInBounds will therefore contain 0 if the access is out-of-bounds, and
+      // 1 otherwise.
+      auto IsInBounds = Builder.CreateSub(
+          HlslOP->GetU32Const(1), CompareWithSlotLimitAsUint, "IsInBounds");
 
-      // IsInBounds will therefore contain 0 if the access is out-of-bounds, and 1 otherwise.
-      auto IsInBounds = Builder.CreateSub(HlslOP->GetU32Const(1), CompareWithSlotLimitAsUint, "IsInBounds");
-
-      auto SlotDwordOffset = Builder.CreateAdd(res.index, HlslOP->GetU32Const(slot->second.startSlot), "SlotDwordOffset");
-      auto SlotByteOffset = Builder.CreateMul(SlotDwordOffset, HlslOP->GetU32Const(DWORDsPerResource * BytesPerDWORD),"SlotByteOffset");
+      auto SlotDwordOffset = Builder.CreateAdd(
+          res.index, HlslOP->GetU32Const(slot->second.startSlot),
+          "SlotDwordOffset");
+      auto SlotByteOffset = Builder.CreateMul(
+          SlotDwordOffset,
+          HlslOP->GetU32Const(DWORDsPerResource * BytesPerDWORD),
+          "SlotByteOffset");
 
       // This will drive an out-of-bounds access slot down to 0
       slotIndex = Builder.CreateMul(SlotByteOffset, IsInBounds, "slotIndex");
@@ -324,14 +363,12 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilResourceAndClass &res, Ins
   return false; // did not modify
 }
 
+DxilResourceAndClass GetResourceFromHandle(Value *resHandle, DxilModule &DM) {
 
-DxilResourceAndClass GetResourceFromHandle(Value * resHandle, DxilModule &DM) {
-
-  DxilResourceAndClass ret{ nullptr, nullptr, DXIL::ResourceClass::Invalid };
+  DxilResourceAndClass ret{nullptr, nullptr, DXIL::ResourceClass::Invalid};
 
   CallInst *handle = cast<CallInst>(resHandle);
   DxilInst_CreateHandle createHandle(handle);
-
 
   // Dynamic rangeId is not supported - skip and let validation report the
   // error.
@@ -339,9 +376,10 @@ DxilResourceAndClass GetResourceFromHandle(Value * resHandle, DxilModule &DM) {
     return ret;
 
   unsigned rangeId =
-    cast<ConstantInt>(createHandle.get_rangeId())->getLimitedValue();
+      cast<ConstantInt>(createHandle.get_rangeId())->getLimitedValue();
 
-  auto resClass = static_cast<DXIL::ResourceClass>(createHandle.get_resourceClass_val());
+  auto resClass =
+      static_cast<DXIL::ResourceClass>(createHandle.get_resourceClass_val());
 
   switch (resClass) {
   case DXIL::ResourceClass::SRV:
@@ -367,12 +405,11 @@ DxilResourceAndClass GetResourceFromHandle(Value * resHandle, DxilModule &DM) {
   return ret;
 }
 
-bool DxilShaderAccessTracking::runOnModule(Module &M)
-{
+bool DxilShaderAccessTracking::runOnModule(Module &M) {
   // This pass adds instrumentation for shader access to resources
 
   DxilModule &DM = M.GetOrCreateDxilModule();
-  LLVMContext & Ctx = M.getContext();
+  LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
 
   bool Modified = false;
@@ -381,13 +418,14 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
 
     bool FoundDynamicIndexing = false;
 
-    auto CreateHandleFn = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+    auto CreateHandleFn =
+        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
     auto CreateHandleUses = CreateHandleFn->uses();
-    for (auto FI = CreateHandleUses.begin(); FI != CreateHandleUses.end(); ) {
-      auto & FunctionUse = *FI++;
+    for (auto FI = CreateHandleUses.begin(); FI != CreateHandleUses.end();) {
+      auto &FunctionUse = *FI++;
       auto FunctionUser = FunctionUse.getUser();
       auto instruction = cast<Instruction>(FunctionUser);
-      Value * index = instruction->getOperand(3);
+      Value *index = instruction->getOperand(3);
       if (!isa<Constant>(index)) {
         FoundDynamicIndexing = true;
         break;
@@ -400,8 +438,7 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         FOS << "FoundDynamicIndexing";
       }
     }
-  }
-  else {
+  } else {
     {
       if (DM.m_ShaderFlags.GetForceEarlyDepthStencil()) {
         if (OSOverride != nullptr) {
@@ -410,20 +447,24 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         }
       }
 
-      for (llvm::Function & F : M.functions()) {
+      for (llvm::Function &F : M.functions()) {
         if (!F.getBasicBlockList().empty()) {
           IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
 
-          unsigned int UAVResourceHandle = static_cast<unsigned int>(DM.GetUAVs().size());
+          unsigned int UAVResourceHandle =
+              static_cast<unsigned int>(DM.GetUAVs().size());
 
           // Set up a UAV with structure of a single int
-          SmallVector<llvm::Type*, 1> Elements{ Type::getInt32Ty(Ctx) };
-          llvm::StructType *UAVStructTy = llvm::StructType::create(Elements, "class.RWStructuredBuffer");
-          std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
+          SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(Ctx)};
+          llvm::StructType *UAVStructTy =
+              llvm::StructType::create(Elements, "class.RWStructuredBuffer");
+          std::unique_ptr<DxilResource> pUAV =
+              llvm::make_unique<DxilResource>();
           pUAV->SetGlobalName("PIX_CountUAVName");
           pUAV->SetGlobalSymbol(UndefValue::get(UAVStructTy->getPointerTo()));
           pUAV->SetID(UAVResourceHandle);
-          pUAV->SetSpaceID((unsigned int)-2); // This is the reserved-for-tools register space
+          pUAV->SetSpaceID((
+              unsigned int)-2); // This is the reserved-for-tools register space
           pUAV->SetSampleCount(1);
           pUAV->SetGloballyCoherent(false);
           pUAV->SetHasCounter(false);
@@ -432,12 +473,14 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
           pUAV->SetRangeSize(1);
           pUAV->SetKind(DXIL::ResourceKind::RawBuffer);
 
-          auto pAnnotation = DM.GetTypeSystem().GetStructAnnotation(UAVStructTy);
+          auto pAnnotation =
+              DM.GetTypeSystem().GetStructAnnotation(UAVStructTy);
           if (pAnnotation == nullptr) {
 
             pAnnotation = DM.GetTypeSystem().AddStructAnnotation(UAVStructTy);
             pAnnotation->GetFieldAnnotation(0).SetCBufferOffset(0);
-            pAnnotation->GetFieldAnnotation(0).SetCompType(hlsl::DXIL::ComponentType::I32);
+            pAnnotation->GetFieldAnnotation(0).SetCompType(
+                hlsl::DXIL::ComponentType::I32);
             pAnnotation->GetFieldAnnotation(0).SetFieldName("count");
           }
 
@@ -446,28 +489,40 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
           assert((unsigned)ID == UAVResourceHandle);
 
           // Create handle for the newly-added UAV
-          Function* CreateHandleOpFunc = HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
-          Constant* CreateHandleOpcodeArg = HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
-          Constant* UAVArg = HlslOP->GetI8Const(static_cast<std::underlying_type<DxilResourceBase::Class>::type>(DXIL::ResourceClass::UAV));
-          Constant* MetaDataArg = HlslOP->GetU32Const(ID); // position of the metadata record in the corresponding metadata list
-          Constant* IndexArg = HlslOP->GetU32Const(0); // 
-          Constant* FalseArg = HlslOP->GetI1Const(0); // non-uniform resource index: false
-          m_FunctionToUAVHandle[&F] = Builder.CreateCall(CreateHandleOpFunc,
-            { CreateHandleOpcodeArg, UAVArg, MetaDataArg, IndexArg, FalseArg }, "PIX_CountUAV_Handle");
+          Function *CreateHandleOpFunc = HlslOP->GetOpFunc(
+              DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+          Constant *CreateHandleOpcodeArg =
+              HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandle);
+          Constant *UAVArg = HlslOP->GetI8Const(
+              static_cast<std::underlying_type<DxilResourceBase::Class>::type>(
+                  DXIL::ResourceClass::UAV));
+          Constant *MetaDataArg =
+              HlslOP->GetU32Const(ID); // position of the metadata record in the
+                                       // corresponding metadata list
+          Constant *IndexArg = HlslOP->GetU32Const(0); //
+          Constant *FalseArg =
+              HlslOP->GetI1Const(0); // non-uniform resource index: false
+          m_FunctionToUAVHandle[&F] = Builder.CreateCall(
+              CreateHandleOpFunc,
+              {CreateHandleOpcodeArg, UAVArg, MetaDataArg, IndexArg, FalseArg},
+              "PIX_CountUAV_Handle");
         }
       }
       DM.ReEmitDxilResources();
     }
 
-    for (llvm::Function & F : M.functions()) {
+    for (llvm::Function &F : M.functions()) {
       // Only used DXIL intrinsics:
-      if (!F.isDeclaration() || F.isIntrinsic() || F.use_empty() || !OP::IsDxilOpFunc(&F))
+      if (!F.isDeclaration() || F.isIntrinsic() || F.use_empty() ||
+          !OP::IsDxilOpFunc(&F))
         continue;
 
       // Gather handle parameter indices, if any
-      FunctionType *fnTy = cast<FunctionType>(F.getType()->getPointerElementType());
+      FunctionType *fnTy =
+          cast<FunctionType>(F.getType()->getPointerElementType());
       SmallVector<unsigned, 4> handleParams;
-      for (unsigned iParam = 1; iParam < fnTy->getFunctionNumParams(); ++iParam) {
+      for (unsigned iParam = 1; iParam < fnTy->getFunctionNumParams();
+           ++iParam) {
         if (fnTy->getParamType(iParam) == HlslOP->GetHandleType())
           handleParams.push_back(iParam);
       }
@@ -475,13 +530,14 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         continue;
 
       auto FunctionUses = F.uses();
-      for (auto FI = FunctionUses.begin(); FI != FunctionUses.end(); ) {
-        auto & FunctionUse = *FI++;
+      for (auto FI = FunctionUses.begin(); FI != FunctionUses.end();) {
+        auto &FunctionUse = *FI++;
         auto FunctionUser = FunctionUse.getUser();
         auto Call = cast<CallInst>(FunctionUser);
         auto opCode = OP::GetDxilOpFuncCallInst(Call);
 
-        // Base Read/Write on function attribute - should match for all normal resource operations
+        // Base Read/Write on function attribute - should match for all normal
+        // resource operations
         ShaderAccessFlags readWrite = ShaderAccessFlags::Write;
         if (OP::GetMemAccessAttr(opCode) == llvm::Attribute::AttrKind::ReadOnly)
           readWrite = ShaderAccessFlags::Read;
@@ -489,7 +545,8 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         // Special cases
         switch (opCode) {
         case DXIL::OpCode::GetDimensions:
-          // readWrite = ShaderAccessFlags::DescriptorRead;  // TODO: Support GetDimensions
+          // readWrite = ShaderAccessFlags::DescriptorRead;  // TODO: Support
+          // GetDimensions
           continue;
         case DXIL::OpCode::BufferUpdateCounter:
           readWrite = ShaderAccessFlags::Counter;
@@ -497,7 +554,8 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         case DXIL::OpCode::TraceRay:
         case DXIL::OpCode::RayQuery_TraceRayInline:
           // Read of AccelerationStructure; doesn't match function attribute
-          // readWrite = ShaderAccessFlags::Read;  // TODO: Support TraceRay[Inline]
+          // readWrite = ShaderAccessFlags::Read;  // TODO: Support
+          // TraceRay[Inline]
           continue;
         default:
           break;
@@ -506,7 +564,8 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
         for (unsigned iParam : handleParams) {
           auto res = GetResourceFromHandle(Call->getArgOperand(iParam), DM);
           // Don't instrument the accesses to the UAV that we just added
-          if (res.resClass == DXIL::ResourceClass::UAV && res.resource->GetSpaceID() == (unsigned)-2) {
+          if (res.resClass == DXIL::ResourceClass::UAV &&
+              res.resource->GetSpaceID() == (unsigned)-2) {
             break;
           }
           if (EmitResourceAccess(res, Call, HlslOP, Ctx, readWrite)) {
@@ -521,8 +580,9 @@ bool DxilShaderAccessTracking::runOnModule(Module &M)
     if (OSOverride != nullptr) {
       formatted_raw_ostream FOS(*OSOverride);
       FOS << "DynamicallyIndexedBindPoints=";
-      for (auto const & bp : m_DynamicallyIndexedBindPoints) {
-        FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index <<';';
+      for (auto const &bp : m_DynamicallyIndexedBindPoints) {
+        FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index
+            << ';';
       }
       FOS << ".";
     }
@@ -537,4 +597,6 @@ ModulePass *llvm::createDxilShaderAccessTrackingPass() {
   return new DxilShaderAccessTracking();
 }
 
-INITIALIZE_PASS(DxilShaderAccessTracking, "hlsl-dxil-pix-shader-access-instrumentation", "HLSL DXIL shader access tracking for PIX", false, false)
+INITIALIZE_PASS(DxilShaderAccessTracking,
+                "hlsl-dxil-pix-shader-access-instrumentation",
+                "HLSL DXIL shader access tracking for PIX", false, false)

--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -10,9 +10,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "dxc/DXIL/DxilOperations.h"
+
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
-#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/HLSL/DxilGenerationPass.h"
 #include "dxc/HLSL/DxilSpanAllocator.h"


### PR DESCRIPTION
Zero code change here, except moving the #include for DxilOperations.h to be on its own in a few files, in order to cope with our clang-format's habit of ordering includes alphabetically.

This is in preparation for a real change coming next.
