### PR TITLE
[spirv] fix crash from debug info gen with opt

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.o1.option.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.o1.option.hlsl
@@ -1,0 +1,22 @@
+// Run: %dxc -E main -T vs_6_0 -Zi -O1
+
+// This test ensures that the debug info generation does not cause
+// crash when we enable spirv-opt with it.
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK-SAME: spirv.debug.o1.option.hlsl
+
+struct VSOUT {
+  float4 pos   : SV_POSITION;
+  float4 color : COLOR;
+};
+
+// CHECK:      OpLine [[file]] 15 1
+VSOUT main(float4 pos   : POSITION,
+           float4 color : COLOR)
+{
+  VSOUT foo;
+  foo.pos = pos;
+  foo.color = color;
+  return foo;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.o2.option.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.o2.option.hlsl
@@ -1,0 +1,22 @@
+// Run: %dxc -E main -T vs_6_0 -Zi -O2
+
+// This test ensures that the debug info generation does not cause
+// crash when we enable spirv-opt with it.
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK-SAME: spirv.debug.o2.option.hlsl
+
+struct VSOUT {
+  float4 pos   : SV_POSITION;
+  float4 color : COLOR;
+};
+
+// CHECK:      OpLine [[file]] 15 1
+VSOUT main(float4 pos   : POSITION,
+           float4 color : COLOR)
+{
+  VSOUT foo;
+  foo.pos = pos;
+  foo.color = color;
+  return foo;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.o3.option.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.o3.option.hlsl
@@ -1,0 +1,22 @@
+// Run: %dxc -E main -T vs_6_0 -fspv-target-env=vulkan1.1 -Zi -O3
+
+// This test ensures that the debug info generation does not cause
+// crash when we enable spirv-opt with it.
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK-SAME: spirv.debug.o3.option.hlsl
+
+struct VSOUT {
+  float4 pos   : SV_POSITION;
+  float4 color : COLOR;
+};
+
+// CHECK:      OpLine [[file]] 15 1
+VSOUT main(float4 pos   : POSITION,
+           float4 color : COLOR)
+{
+  VSOUT foo;
+  foo.pos = pos;
+  foo.color = color;
+  return foo;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -865,8 +865,16 @@ public:
 
       bool hasErrorOccurred = compiler.getDiagnostics().hasErrorOccurred();
 
+// SPIRV change starts
+#if defined(ENABLE_SPIRV_CODEGEN)
+      bool writePDB = !opts.GenSPIRV;
+#else
+      bool writePDB = true;
+#endif
+// SPIRV change ends
       if (!hasErrorOccurred) {
-        if (opts.IsDebugInfoEnabled() && !opts.CodeGenHighLevel && !opts.OptDump) {
+        if (writePDB && opts.IsDebugInfoEnabled() && !opts.CodeGenHighLevel &&
+            !opts.OptDump) {
           CComPtr<IDxcBlob> pDebugBlob;
           IFT(pOutputStream.QueryInterface(&pDebugBlob));
           CComPtr<IDxcBlob> pStrippedContainer;
@@ -1345,7 +1353,18 @@ HRESULT DxcCompilerAdapter::WrapCompile(
 
     LPCWSTR EmbedDebugOpt[] = { L"-Qembed_debug" };
     if (opts.DebugInfo && !ppDebugBlob && !opts.EmbedDebug && !opts.StripDebug) {
-      outStream << "warning: no output provided for debug - embedding PDB in shader container.  Use -Qembed_debug to silence this warning.\n";
+// SPIRV change starts
+#if defined(ENABLE_SPIRV_CODEGEN)
+      if (!opts.GenSPIRV)
+        outStream << "warning: no output provided for debug - embedding PDB in "
+                     "shader container.  Use -Qembed_debug to silence this "
+                     "warning.\n";
+#else
+      outStream << "warning: no output provided for debug - embedding PDB in "
+                   "shader container.  Use -Qembed_debug to silence this "
+                   "warning.\n";
+#endif
+// SPIRV change ends
       IFT(pArgs->AddArguments(EmbedDebugOpt, _countof(EmbedDebugOpt)));
     }
 

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1546,6 +1546,19 @@ TEST_F(FileTest, SpirvDebugClOption) {
   runFileTest("spirv.debug.cl-option.hlsl");
 }
 
+TEST_F(FileTest, SpirvDebugO1Option) {
+  runFileTest("spirv.debug.o1.option.hlsl");
+}
+
+TEST_F(FileTest, SpirvDebugO2Option) {
+  runFileTest("spirv.debug.o2.option.hlsl");
+}
+
+TEST_F(FileTest, SpirvDebugO3Option) {
+  useVulkan1p1();
+  runFileTest("spirv.debug.o3.option.hlsl");
+}
+
 TEST_F(FileTest, SpirvDebugControlFile) {
   useVulkan1p1();
   runFileTest("spirv.debug.ctrl.file.hlsl");


### PR DESCRIPTION
When we use -Zi option without -fcgl, shader compile results in an
error. This is because SPIR-V backend of DXC does not have code
for PBD file, but the debug info gen with optimization lets DXC
use the PBD file. This CL lets DXC skips it.