### PR TITLE
Add pragma control for diagnostics and option printing

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -144,6 +144,7 @@ public:
   bool OutputWarnings = true; // OPT_no_warnings
   bool ShowHelp = false;  // OPT_help
   bool ShowHelpHidden = false; // OPT__help_hidden
+  bool ShowOptionNames = false; // OPT_fdiagnostics_show_option
   bool UseColor = false; // OPT_Cc
   bool UseHexLiterals = false; // OPT_Lx
   bool UseInstructionByteOffsets = false; // OPT_No
@@ -171,6 +172,8 @@ public:
   bool ExportShadersOnly = false; // OPT_export_shaders_only
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
+
+  std::vector<std::string> Warnings;
 
   bool IsRootSignatureProfile();
   bool IsLibraryProfile();

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -41,8 +41,8 @@ def T_Group               : OptionGroup<"<T group>">;
 def O_Group               : OptionGroup<"<O group>">, Group<CompileOnly_Group>;
 def R_Group               : OptionGroup<"<R group>">, Group<CompileOnly_Group>;
 def R_value_Group         : OptionGroup<"<R (with value) group>">, Group<R_Group>;
-def W_Group               : OptionGroup<"<W group>">, Group<CompileOnly_Group>;
-def W_value_Group         : OptionGroup<"<W (with value) group>">, Group<W_Group>;
+def W_Group               : OptionGroup<"<W group>">, Group<CompileOnly_Group>, HelpText<"Warning Options">;
+def W_value_Group         : OptionGroup<"<W (with value) group>">, Group<W_Group>, HelpText<"Warning Options">;
 def d_Group               : OptionGroup<"<d group>">;
 def f_Group               : OptionGroup<"<f group>">, Group<CompileOnly_Group>;
 def f_clang_Group         : OptionGroup<"<f (clang-only) group>">, Group<CompileOnly_Group>;
@@ -100,10 +100,10 @@ def Odump : Flag<["-", "/"], "Odump">, Group<hlslcomp_Group>, Flags<[CoreOption]
     HelpText<"Print the optimizer commands.">;
 def Qunused_arguments : Flag<["-"], "Qunused-arguments">, Group<hlslcore_Group>, Flags<[CoreOption]>,
   HelpText<"Don't emit warning for unused driver arguments">;
-def Wall : Flag<["-"], "Wall">, Group<hlslcomp_Group>, Flags<[CoreOption]>;
-def Wdeprecated : Flag<["-"], "Wdeprecated">, Group<hlslcomp_Group>, Flags<[CoreOption]>;
-//def W_Joined : Joined<["-"], "W">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
-//  MetaVarName<"<warning>">, HelpText<"Enable the specified warning">;
+def Wall : Flag<["-"], "Wall">, Group<W_Group>, Flags<[CoreOption]>;
+def Wdeprecated : Flag<["-"], "Wdeprecated">, Group<W_Group>, Flags<[CoreOption]>;
+def W_Joined : Joined<["-"], "W">, Group<W_Group>, Flags<[CoreOption]>,
+  MetaVarName<"[no-]<warning>">, HelpText<"Enable/Disable the specified warning">;
 def d_Flag : Flag<["-"], "d">, Group<d_Group>;
 def d_Joined : Joined<["-"], "d">, Group<d_Group>;
 //def fcolor_diagnostics : Flag<["-"], "fcolor-diagnostics">, Group<hlslcomp_Group>,
@@ -117,8 +117,10 @@ def fconstexpr_depth_EQ : Joined<["-"], "fconstexpr-depth=">, Group<f_Group>;
 def fconstexpr_steps_EQ : Joined<["-"], "fconstexpr-steps=">, Group<f_Group>;
 def fconstexpr_backtrace_limit_EQ : Joined<["-"], "fconstexpr-backtrace-limit=">,
                                     Group<f_Group>;
-//def fdiagnostics_show_option : Flag<["-"], "fdiagnostics-show-option">, Group<hlslcomp_Group>,
-//    Flags<[CoreOption]>, HelpText<"Print option name with mappable diagnostics">;
+def fdiagnostics_show_option : Flag<["-"], "fdiagnostics-show-option">, Group<hlslcomp_Group>,
+    Flags<[CoreOption]>, HelpText<"Print option name with mappable diagnostics">;
+def fno_diagnostics_show_option : Flag<["-"], "fno-diagnostics-show-option">, Group<hlslcomp_Group>,
+    Flags<[CoreOption]>, HelpText<"Do not print option name with mappable diagnostics">;
 def fdiagnostics_show_category_EQ : Joined<["-"], "fdiagnostics-show-category=">, Group<hlslcomp_Group>;
 def ferror_limit_EQ : Joined<["-"], "ferror-limit=">, Group<hlslcomp_Group>, Flags<[CoreOption]>;
 

--- a/tools/clang/lib/Lex/Pragma.cpp
+++ b/tools/clang/lib/Lex/Pragma.cpp
@@ -1435,6 +1435,7 @@ void Preprocessor::RegisterBuiltinPragmas() {
     // TODO: add HLSL-specific pragma handlers
     AddPragmaHandler(new PragmaOnceHandler());
     AddPragmaHandler(new PragmaMarkHandler());
+    AddPragmaHandler("dxc", new PragmaDiagnosticHandler("dxc"));
     AddPragmaHandler(new PragmaMessageHandler(PPCallbacks::PMK_Message));
     return;
   }

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/disable-warning-with-option.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/disable-warning-with-option.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T vs_6_0 -Wno-parentheses-equality -Wno-conversion %s | FileCheck %s
+
+// Make sure the specified warnings get turned off
+
+float4 foo;
+
+// This function has no output semantic on purpose in order to produce an error,
+// otherwise, the warnings will not be captured in the output for FileCheck.
+float main() {
+  float4 x = foo;
+
+// CHECK-NOT: equality comparison with extraneous parentheses
+  if ((x.y == 0))
+  {
+
+// CHECK-NOT: implicit truncation of vector type
+    return x;
+
+  }
+  return x.y;
+
+}
+
+// CHECK: error: Semantic must be defined

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/show-option-names.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/show-option-names.hlsl
@@ -1,8 +1,8 @@
-// RUN: %dxc -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -T vs_6_0 %s | FileCheck %s -check-prefix=CHECK -check-prefix=CHK_OPTION
+// RUN: %dxc -T vs_6_0 -fdiagnostics-show-option %s | FileCheck %s -check-prefix=CHECK -check-prefix=CHK_OPTION
+// RUN: %dxc -T vs_6_0 -fno-diagnostics-show-option %s | FileCheck %s -check-prefix=CHECK -check-prefix=CHK_NO_OPTION
 
-// Make sure the option for disabling the warning is printed.
-// At the time of this writing, these may only be used with the pragma:
-// #pragma dxc diagnostic ignored "-Wparentheses-equality"
+// Make sure the option name for the warning is printed.
 
 float4 foo;
 
@@ -12,12 +12,14 @@ float main() {
   float4 x = foo;
 
 // CHECK: equality comparison with extraneous parentheses
-// CHECK: -Wparentheses-equality
+// CHK_OPTION: -Wparentheses-equality
+// CHK_NO_OPTION-NOT
   if ((x.y == 0))
   {
 
 // CHECK: implicit truncation of vector type
-// CHECK: -Wconversion
+// CHK_OPTION: -Wconversion
+// CHK_NO_OPTION-NOT: -Wconversion
     return x;
 
   }

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/show-option-names.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/show-option-names.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T vs_6_0 %s | FileCheck %s
+
+// Make sure the option for disabling the warning is printed.
+// At the time of this writing, these may only be used with the pragma:
+// #pragma dxc diagnostic ignored "-Wparentheses-equality"
+
+float4 foo;
+
+// This function has no output semantic on purpose in order to produce an error,
+// otherwise, the warnings will not be captured in the output for FileCheck.
+float main() {
+  float4 x = foo;
+
+// CHECK: equality comparison with extraneous parentheses
+// CHECK: -Wparentheses-equality
+  if ((x.y == 0))
+  {
+
+// CHECK: implicit truncation of vector type
+// CHECK: -Wconversion
+    return x;
+
+  }
+  return x.y;
+
+}
+
+// CHECK: error: Semantic must be defined

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T vs_6_0 %s | FileCheck %s
+
+float4 foo;
+
+// This function has no output semantic on purpose in order to produce an error,
+// otherwise, the warnings will not be captured in the output for FileCheck.
+float main() {
+  float4 x = foo;
+
+#pragma dxc diagnostic push
+
+// CHECK-NOT: equality comparison with extraneous parentheses
+#pragma dxc diagnostic ignored "-Wparentheses-equality"
+  if ((x.y == 0))
+  {
+
+// CHECK-NOT: implicit truncation of vector type
+#pragma dxc diagnostic ignored "-Wconversion"
+    return x;
+
+  }
+  return x.y;
+
+#pragma dxc diagnostic pop
+
+}
+
+// CHECK: error: Semantic must be defined

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
@@ -4,7 +4,7 @@ float4 foo;
 
 // This function has no output semantic on purpose in order to produce an error,
 // otherwise, the warnings will not be captured in the output for FileCheck.
-float main() {
+float main() : OUT {
   float4 x = foo;
 
 #pragma dxc diagnostic push
@@ -14,8 +14,8 @@ float main() {
   if ((x.y == 0))
   {
 
-// CHECK-NOT: implicit truncation of vector type
-#pragma dxc diagnostic ignored "-Wconversion"
+// CHECK: error: implicit truncation of vector type
+#pragma dxc diagnostic error "-Wconversion"
     return x;
 
   }
@@ -24,5 +24,3 @@ float main() {
 #pragma dxc diagnostic pop
 
 }
-
-// CHECK: error: Semantic must be defined

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/pragma/pragma-diagnostic.hlsl
@@ -1,26 +1,30 @@
 // RUN: %dxc -T vs_6_0 %s | FileCheck %s
 
+// Verify pragma control for warnings, plus push/pop behavior
+
 float4 foo;
 
-// This function has no output semantic on purpose in order to produce an error,
-// otherwise, the warnings will not be captured in the output for FileCheck.
 float main() : OUT {
   float4 x = foo;
 
 #pragma dxc diagnostic push
-
 // CHECK-NOT: equality comparison with extraneous parentheses
 #pragma dxc diagnostic ignored "-Wparentheses-equality"
   if ((x.y == 0))
   {
-
 // CHECK: error: implicit truncation of vector type
 #pragma dxc diagnostic error "-Wconversion"
     return x;
-
   }
-  return x.y;
-
 #pragma dxc diagnostic pop
+
+// Verify restoration of diagnostics
+
+// CHECK: warning: equality comparison with extraneous parentheses
+  if ((x.z == 0))
+  {
+// CHECK: warning: implicit truncation of vector type
+    return x.yzwx;
+  }
 
 }

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -992,6 +992,7 @@ public:
       ? hlsl::DXIL::kNewLayoutString
       : hlsl::DXIL::kLegacyLayoutString;
     compiler.HlslLangExtensions = helper;
+    compiler.getDiagnosticOpts().ShowOptionNames = 1;
     compiler.createDiagnostics(diagPrinter, false);
     // don't output warning to stderr/file if "/no-warnings" is present.
     compiler.getDiagnostics().setIgnoreAllWarnings(!Opts.OutputWarnings);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -992,7 +992,8 @@ public:
       ? hlsl::DXIL::kNewLayoutString
       : hlsl::DXIL::kLegacyLayoutString;
     compiler.HlslLangExtensions = helper;
-    compiler.getDiagnosticOpts().ShowOptionNames = 1;
+    compiler.getDiagnosticOpts().ShowOptionNames = Opts.ShowOptionNames ? 1 : 0;
+    compiler.getDiagnosticOpts().Warnings = std::move(Opts.Warnings);
     compiler.createDiagnostics(diagPrinter, false);
     // don't output warning to stderr/file if "/no-warnings" is present.
     compiler.getDiagnostics().setIgnoreAllWarnings(!Opts.OutputWarnings);


### PR DESCRIPTION
Fixes #2655.

- Adds `#pragma dxc diagnostic ...` so specific warnings may be ignored.
- Prints the option name for disabling the warning after the warning message, when available.

Future improvements:
- Add the diagnostic options to dxc command line arguments
- Better categorization of HLSL warnings