### PR TITLE
Correct official versioning in master branch

### DIFF
--- a/utils/version/gen_version.py
+++ b/utils/version/gen_version.py
@@ -81,7 +81,7 @@ class VersionGen():
                 base_commit_count = int(get_commit_count(self.latest_release_info["sha"]))
             current_commit_count = int(get_commit_count("HEAD"))
             distance_from_base = current_commit_count - base_commit_count
-            if (self.current_branch is "master"):
+            if (self.current_branch == "master"):
                 distance_from_base += 10000
             self.rc_version_field_4_cache = str(distance_from_base)
         return self.rc_version_field_4_cache


### PR DESCRIPTION
According to the description at the top of gen_version.py and the
commit that introduced it, the "Official build" versioning is meant
to add 10000 to the number of commits since the last official release
when the build is in the master branch. However, because of the use
of "is" instead of "==", the comparison between the variable and
the string literal in the python script was never succeeding. The
"is" operator only succeeds when it compares two variables that
have been assigned the same variable or one has been assigned to
the other. For comparisons of contents, "==" should be used.