### PR TITLE
Correct -Od precise qualifier validation errors

### DIFF
--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -309,6 +309,9 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
 
   MPM.add(createDeadCodeEliminationPass());
 
+  MPM.add(createPromoteMemoryToRegisterPass());
+  MPM.add(createDxilEliminateVectorPass());
+
   if (OptLevel > 0) {
     MPM.add(createDxilFixConstArrayInitializerPass());
   }


### PR DESCRIPTION
When using a precise qualifier on a matrix type, mem2reg conversion
was delayed and not ultimately completed. By adding the conversion
to the end of the HLSL passes, the conversion takes place, converting
the types before validation.

Fixes #2189