### PR TITLE
Fix crash when using precise matrix with -Od

### DIFF
--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -211,6 +211,9 @@ public:
   static bool HasPreciseAttributeWithMetadata(llvm::Instruction *I);
   static void MarkPreciseAttributeWithMetadata(llvm::Instruction *I);
   static void ClearPreciseAttributeWithMetadata(llvm::Instruction *I);
+  template<class BuilderTy>
+  static void MarkPreciseAttributeOnValWithFunctionCall(llvm::Value *V,
+							BuilderTy &Builder, llvm::Module &M);
   static void MarkPreciseAttributeOnPtrWithFunctionCall(llvm::Value *Ptr,
                                                         llvm::Module &M);
   static bool HasPreciseAttribute(llvm::Function *F);

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -213,7 +213,7 @@ public:
   static void ClearPreciseAttributeWithMetadata(llvm::Instruction *I);
   template<class BuilderTy>
   static void MarkPreciseAttributeOnValWithFunctionCall(llvm::Value *V,
-							BuilderTy &Builder, llvm::Module &M);
+                                                        BuilderTy &Builder, llvm::Module &M);
   static void MarkPreciseAttributeOnPtrWithFunctionCall(llvm::Value *Ptr,
                                                         llvm::Module &M);
   static bool HasPreciseAttribute(llvm::Function *F);

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -150,6 +150,7 @@ private:
   void lowerReturn(ReturnInst* Return);
   Value *lowerCall(CallInst *Call);
   Value *lowerNonHLCall(CallInst *Call);
+  void lowerPreciseCall(CallInst *Call, IRBuilder<> Builder);
   Value *lowerHLOperation(CallInst *Call, HLOpcodeGroup OpcodeGroup);
   Value *lowerHLIntrinsic(CallInst *Call, IntrinsicOp Opcode);
   Value *lowerHLMulIntrinsic(Value* Lhs, Value *Rhs, bool Unsigned, IRBuilder<> &Builder);
@@ -683,6 +684,19 @@ Value *HLMatrixLowerPass::lowerCall(CallInst *Call) {
     ? lowerNonHLCall(Call) : lowerHLOperation(Call, OpcodeGroup);
 }
 
+// Special function to lower precise call applied to a matrix
+// The matrix should be lowered and the call regenerated with vector arg
+void HLMatrixLowerPass::lowerPreciseCall(CallInst *Call, IRBuilder<> Builder) {
+  DXASSERT(Call->getNumArgOperands() == 1, "Only one arg expected for precise matrix call");
+  Value *Arg = Call->getArgOperand(0);
+  Value *LoweredArg = getLoweredByValOperand(Arg, Builder);
+  for (Value *A : Call->arg_operands()) {
+    DXASSERT(A == Arg, "oops");
+  }
+  HLModule::MarkPreciseAttributeOnValWithFunctionCall(LoweredArg, Builder, *m_pModule);
+  addToDeadInsts(Call);
+}
+
 Value *HLMatrixLowerPass::lowerNonHLCall(CallInst *Call) {
   // First, handle any operand of matrix-derived type
   // We don't lower the callee's signature in this pass,
@@ -691,6 +705,13 @@ Value *HLMatrixLowerPass::lowerNonHLCall(CallInst *Call) {
   // pass knows how to eliminate.
   IRBuilder<> PreCallBuilder(Call);
   unsigned NumArgs = Call->getNumArgOperands();
+  Function *Func = Call->getCalledFunction();
+  StringRef FuncName = Func->getName();
+  if (Func && FuncName.startswith("dx.attribute.precise")) {
+    lowerPreciseCall(Call, PreCallBuilder);
+    return nullptr;
+  }
+
   for (unsigned ArgIdx = 0; ArgIdx < NumArgs; ++ArgIdx) {
     Use &ArgUse = Call->getArgOperandUse(ArgIdx);
     if (ArgUse->getType()->isPointerTy()) {

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -703,7 +703,7 @@ Value *HLMatrixLowerPass::lowerNonHLCall(CallInst *Call) {
   IRBuilder<> PreCallBuilder(Call);
   unsigned NumArgs = Call->getNumArgOperands();
   Function *Func = Call->getCalledFunction();
-  if (Func && static_cast<StringRef>Func->getName()).startswith("dx.attribute.precise")) {
+  if (Func && HLModule::HasPreciseAttribute(Func)) {
     lowerPreciseCall(Call, PreCallBuilder);
     return nullptr;
   }

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -690,9 +690,6 @@ void HLMatrixLowerPass::lowerPreciseCall(CallInst *Call, IRBuilder<> Builder) {
   DXASSERT(Call->getNumArgOperands() == 1, "Only one arg expected for precise matrix call");
   Value *Arg = Call->getArgOperand(0);
   Value *LoweredArg = getLoweredByValOperand(Arg, Builder);
-  for (Value *A : Call->arg_operands()) {
-    DXASSERT(A == Arg, "oops");
-  }
   HLModule::MarkPreciseAttributeOnValWithFunctionCall(LoweredArg, Builder, *m_pModule);
   addToDeadInsts(Call);
 }
@@ -706,8 +703,7 @@ Value *HLMatrixLowerPass::lowerNonHLCall(CallInst *Call) {
   IRBuilder<> PreCallBuilder(Call);
   unsigned NumArgs = Call->getNumArgOperands();
   Function *Func = Call->getCalledFunction();
-  StringRef FuncName = Func->getName();
-  if (Func && FuncName.startswith("dx.attribute.precise")) {
+  if (Func && static_cast<StringRef>Func->getName()).startswith("dx.attribute.precise")) {
     lowerPreciseCall(Call, PreCallBuilder);
     return nullptr;
   }

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -1191,8 +1191,9 @@ static void MarkPreciseAttribute(Function *F) {
   F->setMetadata(DxilMDHelper::kDxilPreciseAttributeMDName, preciseNode);
 }
 
-static void MarkPreciseAttributeOnValWithFunctionCall(
-    llvm::Value *V, llvm::IRBuilder<> &Builder, llvm::Module &M) {
+template<typename BuilderTy>
+void HLModule::MarkPreciseAttributeOnValWithFunctionCall(
+    llvm::Value *V, BuilderTy &Builder, llvm::Module &M) {
   Type *Ty = V->getType();
   Type *EltTy = Ty->getScalarType();
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/matrix_od.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/matrix_od.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -Od -E main -T vs_6_0 %s | FileCheck %s
+
+// Test that precise modifier on a matrix has an effect
+// and that -Od flag doesn't cause crash or validation failures
+
+// CHECK-NOT: fmul fast float
+// CHECK: fmul float
+// CHECK-NOT: fmul fast float
+// CHECK: fmul float
+// CHECK-NOT: fmul fast float
+// CHECK: fmul float
+// CHECK-NOT: fmul fast float
+// CHECK: fmul float
+// CHECK-NOT: fmul fast float
+
+float2x2 main(float2x2 m : IN) : OUT
+{
+  precise float2x2 result = m * m;
+  return result;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/propagate_to_producers_interproc_matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/propagate_to_producers_interproc_matrix.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Test that precise applies retroactively to matrix instructions
+// producing a given value, interprocedurally.
+
+// CHECK-NOT: fmul fast float
+// CHECK: fmul float
+// CHECK-NOT: fmul fast float
+
+float3x3 square(float3x3 f) { return f * f; }
+
+float3x3 make_precise(float3x3 f)
+{
+  precise float3x3 pf = f;
+  return f;
+}
+
+float3x3 main(float3x3 f : IN) : OUT
+{
+  float3x3 result = square(f);
+  return make_precise(result);
+}


### PR DESCRIPTION
To flag a variable as precise, a dx.attribute.precise call is inserted.
In the case of matrices, this becomes a problem if it persists too long
due to validation errors because the matrix is never lowered. When we
reach the HLMatrixLowerPass, the matrix can be lowered to vector. This
change detects when the precise call is applied to a matrix, lowers the
parameters and replaces the call with one taking a vector instead.
The call is necessary to keep the precise informaton across function
calls.

Adds variante of precise tests. precise/matrix.hlsl is modified by
matrix_od.hlsl to take the -Od parameter.
precise/propagate_to_producers_interproc.hlsl is modified to use
matrices since an earlier fix for this bug caused a regression when this
alteration was made.

Fixes #2189