### PR TITLE
Correct include of absolute '/' paths on windows

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -153,7 +153,7 @@ bool IsAbsoluteOrCurDirRelativeW(LPCWSTR Path) {
     return Path[1] == L'\0' || Path[1] == L'/' || Path[1] == L'\\';
   }
   // Disk designator, then absolute path.
-  if (Path[1] == L':' && Path[2] == L'\\') {
+  if (Path[1] == L':' && (Path[2] == L'\\' || Path[2] == L'/')) {
     return TRUE;
   }
   // UNC name


### PR DESCRIPTION
When an include path is detected to not be absolute, "./" is inserted in
front of it. The absolute path detection only allowed for *:\ and not
*:/ even though windows functions are defined as accepting paths with /
instead of \ which meant that all other paths could be specified this
way.

By changing the absolute path detection to allow for c:/* and similar,
when the file descriptor is searched in dxcfilesystem, it will be
found to match the original definition so the includes will succeed.

Fixes #2669