### PR TITLE
Separate generation of DXC macro version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,14 +85,6 @@ set(HLSL_VERSION_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/utils/version)
 option(HLSL_OFFICIAL_BUILD "If set, embeds official version in the binaries (based on the latest release version)" OFF) # HLSL Change
 option(HLSL_ENABLE_FIXED_VER "Reads version information from a file." OFF) # HLSL Change
 
-if (HLSL_ENABLE_FIXED_VER)
-  set(HLSL_EMBED_VERSION ON)
-  if (NOT DEFINED HLSL_FIXED_VERSION_LOCATION OR HLSL_FIXED_VERSION_LOCATION STREQUAL "")
-    # HLSL Change - Directory with fixed version.inc file
-    set(HLSL_FIXED_VERSION_LOCATION  ${CMAKE_CURRENT_SOURCE_DIR}/utils/version)
-  endif()
-endif()
-
 option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) # HLSL Change
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
 

--- a/tools/clang/lib/Frontend/CMakeLists.txt
+++ b/tools/clang/lib/Frontend/CMakeLists.txt
@@ -46,7 +46,7 @@ add_clang_library(clangFrontend
   DEPENDS
   ClangDriverOptions
   TablegenHLSLOptions
-  hlsl_version_autogen # HLSL Change
+  hlsl_dxcversion_autogen # HLSL Change
 
   LINK_LIBS
   clangAST

--- a/tools/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/tools/clang/lib/Frontend/InitPreprocessor.cpp
@@ -27,7 +27,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
-#include "version.inc" // HLSL Change
+#include "dxcversion.inc" // HLSL Change
 #include "dxc/DXIL/DxilConstants.h" // HLSL Change
 #include "dxc/DXIL/DxilShaderModel.h" // HLSL Change
 using namespace clang;

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/version_defines/target_version_vertex.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/version_defines/target_version_vertex.hlsl
@@ -14,21 +14,21 @@ float4 main(float4 pos : IN) : OUT
   float4 outPos = pos;
 
   // Will need to change if there's ever a major version bump
-#if defined(__DXC_VERSION_MAJOR)// && __DXC_VERSION_MAJOR == 1 // FIXME: excluded for xbtools builds
+#if defined(__DXC_VERSION_MAJOR) && __DXC_VERSION_MAJOR == 1
   x += 1;
 #else
   x -= 1;
 #endif
 
   // Minor version is expected to change fairly frequently. So be conservative
-#if defined(__DXC_VERSION_MINOR)// && __DXC_VERSION_MINOR >= 0 && __DXC_VERSION_MINOR < 50 // FIXME: excluded for xbtools builds
+#if defined(__DXC_VERSION_MINOR) && __DXC_VERSION_MINOR >= 0 && __DXC_VERSION_MINOR < 50
   x += 1;
 #else
   x -= 1;
 #endif
 
   // Release is either based on the year/month or set to zero for dev builds
-#if defined(__DXC_VERSION_RELEASE)// && (__DXC_VERSION_RELEASE == 0 ||  __DXC_VERSION_RELEASE > 1900) // FIXME: excluded for xbtools builds
+#if defined(__DXC_VERSION_RELEASE) && (__DXC_VERSION_RELEASE == 0 ||  __DXC_VERSION_RELEASE > 1900)
   x += 1;
 #else
   x -= 1;
@@ -37,7 +37,7 @@ float4 main(float4 pos : IN) : OUT
   // The last number varies a lot. In a dev build, Release is 0, and this number
   // is the total number of commits since the beginning of the project.
   // which can be expected to be more than 1000 at least.
-#if defined(__DXC_VERSION_COMMITS)// && (__DXC_VERSION_RELEASE > 0 ||  __DXC_VERSION_COMMITS > 1000) // FIXME: excluded for xbtools builds
+#if defined(__DXC_VERSION_COMMITS) && (__DXC_VERSION_RELEASE > 0 ||  __DXC_VERSION_COMMITS > 1000)
   x += 1;
 #else
   x -= 1;

--- a/utils/version/CMakeLists.txt
+++ b/utils/version/CMakeLists.txt
@@ -35,7 +35,7 @@ file(TO_NATIVE_PATH "${HLSL_VERSION_LOCATION}/dxcversion.inc" HLSL_DXC_VERSION_F
 add_custom_target(hlsl_dxcversion_autogen
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_GEN_VERSION_FILE} ${HLSL_DXC_VERSION_FILE}
     DEPENDS ${HLSL_GEN_VERSION_FILE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
 )
 
 set_property(SOURCE ${HLSL_DXC_VERSION_FILE}

--- a/utils/version/CMakeLists.txt
+++ b/utils/version/CMakeLists.txt
@@ -1,42 +1,74 @@
-if(HLSL_EMBED_VERSION)
-    if (WIN32)
-        string(REPLACE "/" "\\" HLSL_VERSION_LOCATION_local ${HLSL_VERSION_LOCATION}\\)
-    else (WIN32)
-        set(HLSL_VERSION_LOCATION_local ${HLSL_VERSION_LOCATION}/)
-    endif (WIN32)
+file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/version.gen" HLSL_GEN_VERSION_FILE)
 
-    set(HLSL_VERSION_FILE ${HLSL_VERSION_LOCATION_local}version.inc)
-    if(HLSL_ENABLE_FIXED_VER)
-        if (WIN32)
-            string(REPLACE "/" "\\" HLSL_FIXED_VERSION_LOCATION_local ${HLSL_FIXED_VERSION_LOCATION}\\)
-        else (WIN32)
-            set(HLSL_FIXED_VERSION_LOCATION_local ${HLSL_FIXED_VERSION_LOCATION}/)
-        endif (WIN32)
-        message("Using fixed version file ${HLSL_FIXED_VERSION_LOCATION_local}version.inc")
-        add_custom_target(hlsl_version_autogen
-            COMMAND echo "Using fixed version file ${HLSL_FIXED_VERSION_LOCATION_local}version.inc"
-            COMMAND ${CMAKE_COMMAND} -E copy ${HLSL_FIXED_VERSION_LOCATION_local}version.inc ${HLSL_VERSION_LOCATION_local}
-            )
-    else(HLSL_ENABLE_FIXED_VER)
-        if (HLSL_OFFICIAL_BUILD)
-            message("Will generate official build version based on the latest release fork sha and current commit count")
-            set(GEN_VERSION_OFFICIAL_OPTION "--official")
-        else (HLSL_OFFICIAL_BUILD)
-            message("Will generate dev build version based on current commit count")
-            set(GEN_VERSION_OFFICIAL_OPTION "")
-        endif(HLSL_OFFICIAL_BUILD)
+# First create the DXC version header
+# generated per gen_version.py except where explicit fixed version path is provided
+if(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+    FILE(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/version.inc" HLSL_FIXED_VERSION_FILE)
+    message("Using fixed version file ${HLSL_FIXED_VERSION_FILE}")
+    add_custom_command(
+        OUTPUT ${HLSL_GEN_VERSION_FILE}
+        COMMAND echo "Using fixed version file ${HLSL_FIXED_VERSION_FILE}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_FIXED_VERSION_FILE} ${HLSL_GEN_VERSION_FILE}
+        DEPENDS ${HLSL_FIXED_VERSION_FILE}
+    )
+else(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+    # If official or the dxc case for fixed version location
+    if (HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
+        message("Will generate official build version based on the latest release fork sha and current commit count")
+        set(HLSL_GEN_VERSION_OFFICIAL_OPTION "--official")
+    else (HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
+        message("Will generate dev build version based on current commit count")
+        set(HLSL_GEN_VERSION_OFFICIAL_OPTION "")
+    endif(HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
 
-        add_custom_target(hlsl_version_autogen
-            COMMAND echo "Generating version"
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${GEN_VERSION_OFFICIAL_OPTION} > ${HLSL_VERSION_FILE}
-        )
-        set_property(SOURCE ${HLSL_VERSION_FILE} 
-            PROPERTY GENERATED True
-        )
-    endif(HLSL_ENABLE_FIXED_VER)
+    add_custom_command(
+        OUTPUT ${HLSL_GEN_VERSION_FILE}
+        COMMAND echo "Generating version"
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${HLSL_GEN_VERSION_OFFICIAL_OPTION} > ${HLSL_GEN_VERSION_FILE}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
+    )
+endif(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+
+# do dxcversion.inc copy
+file(TO_NATIVE_PATH "${HLSL_VERSION_LOCATION}/dxcversion.inc" HLSL_DXC_VERSION_FILE)
+
+add_custom_target(hlsl_dxcversion_autogen
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_GEN_VERSION_FILE} ${HLSL_DXC_VERSION_FILE}
+    DEPENDS ${HLSL_GEN_VERSION_FILE}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
+)
+
+set_property(SOURCE ${HLSL_DXC_VERSION_FILE}
+    PROPERTY GENERATED True
+)
+
+set_target_properties(hlsl_dxcversion_autogen PROPERTIES
+    FOLDER version
+)
+
+
+# do version.inc copy
+if (HLSL_EMBED_VERSION OR HLSL_ENABLE_FIXED_VER)
+    # If there is an explicit fixed version location, version.inc should copy from there
+    # Used to propagate GDK versions to the RC data
+    if( NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+        FILE(TO_NATIVE_PATH "${HLSL_FIXED_VERSION_LOCATION}/version.inc" HLSL_COPY_VERSION_FILE)
+    else( NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+        SET(HLSL_COPY_VERSION_FILE ${HLSL_GEN_VERSION_FILE})
+    endif(NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+    file(TO_NATIVE_PATH "${HLSL_VERSION_LOCATION}/version.inc" HLSL_VERSION_FILE)
+
+    add_custom_target(hlsl_version_autogen
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_COPY_VERSION_FILE} ${HLSL_VERSION_FILE}
+        DEPENDS ${HLSL_COPY_VERSION_FILE}
+    )
     
+    set_property(SOURCE ${HLSL_VERSION_FILE}
+        PROPERTY GENERATED True
+    )
+
     set_target_properties(hlsl_version_autogen PROPERTIES
         FOLDER version
     )
 
-endif(HLSL_EMBED_VERSION)
+endif(HLSL_EMBED_VERSION OR HLSL_ENABLE_FIXED_VER)


### PR DESCRIPTION
The original generation of HLSL macros containing version information
used the same generated header file as the RC file. This was fine except
when building in xbtools where the version information in the RC is
overridden to match the GDK.

To maintain the DXC macros as communicating the version of the DXC
component to better enable workarounds based on that information, the
same generator script is used, but the header file is separate and
doesn't abide by the fixed version location provided via cmake defines.
This way it will always contain DXC information while the RC file can
continue to contain the version information as it did before.

To allow for the case where the headers are not the same, a preliminary
version.gen file is created according to the dxc version requirements
and copied to the dxc header. In most cases, it is copied to the RC
header as well. When an explicit path is specified for the fixed
version, the DXC version uses the "offficial" generated header and the
RC file gets the version specified by the file in the given location.

Reverts the changes to the target_version_vertex.hlsl test since it
should always succeed now.