### PR TITLE
Correct 16-bit detection in reflection stripping

### DIFF
--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1631,15 +1631,8 @@ bool DxilModule::StripReflection() {
         structsToKeep.insert(containedStructs.begin(), containedStructs.end());
     }
 
-    for (auto Ty : structsToKeep) {
+    for (auto Ty : structsToKeep)
       structsToRemove.remove(Ty);
-      // Clear names
-      m_pTypeSystem->GetStructAnnotationMap().erase(Ty);
-      DxilStructAnnotation *pSA = m_pTypeSystem->GetStructAnnotation(Ty);
-      for (unsigned i = 0; i < pSA->GetNumFields(); ++i) {
-        DxilFieldAnnotation &FA = pSA->GetFieldAnnotation(i);
-        FA.SetFieldName("");
-      }
     for (auto Ty : structsToRemove) {
       m_pTypeSystem->GetStructAnnotationMap().erase(Ty);
     }

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1631,8 +1631,15 @@ bool DxilModule::StripReflection() {
         structsToKeep.insert(containedStructs.begin(), containedStructs.end());
     }
 
-    for (auto Ty : structsToKeep)
+    for (auto Ty : structsToKeep) {
       structsToRemove.remove(Ty);
+      // Clear names
+      m_pTypeSystem->GetStructAnnotationMap().erase(Ty);
+      DxilStructAnnotation *pSA = m_pTypeSystem->GetStructAnnotation(Ty);
+      for (unsigned i = 0; i < pSA->GetNumFields(); ++i) {
+        DxilFieldAnnotation &FA = pSA->GetFieldAnnotation(i);
+        FA.SetFieldName("");
+      }
     for (auto Ty : structsToRemove) {
       m_pTypeSystem->GetStructAnnotationMap().erase(Ty);
     }

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_alignment_16.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_alignment_16.hlsl
@@ -1,0 +1,51 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// CHECK: ; Buffer Definitions:
+// CHECK: ;
+// CHECK: ; cbuffer cbuf
+// CHECK: ; {
+// CHECK: ;
+// CHECK: ;   struct cbuf
+// CHECK: ;   {
+// CHECK: ;
+// CHECK: ;       struct struct.Agg
+// CHECK: ;       {
+// CHECK: ;
+// CHECK: ;           struct struct.Value
+// CHECK: ;           {
+// CHECK: ;
+// CHECK: ;               uint v;                               ; Offset:    0
+// CHECK: ;
+// CHECK: ;           } value[1];;                              ; Offset:    0
+// CHECK: ;
+// CHECK: ;           min16ui fodder;                           ; Offset:    4
+// CHECK: ;
+// CHECK: ;       } aggie;                                      ; Offset:    0
+// CHECK: ;
+// CHECK: ;
+// CHECK: ;   } cbuf;                                           ; Offset:    0 Size:     8
+// CHECK: ;
+// CHECK: ; }
+
+
+// Test Cbuffer validation likely to cause mistaken overlaps
+struct Value { uint v; }; // This may be stripped because it has nothing below 32 bits
+
+struct Agg {
+
+  Value value[1];
+  min16uint fodder; // This will cause this struct to be preserved
+};
+
+cbuffer cbuf : register(b1)
+{
+  Agg aggie;
+}
+
+RWBuffer<int> Out : register(u0);
+
+[shader("raygeneration")]
+void main()
+{
+  Out[0] = aggie.value[0].v;
+}

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_alignment_matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_alignment_matrix.hlsl
@@ -1,0 +1,52 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// CHECK: ; Buffer Definitions:
+// CHECK: ;
+// CHECK: ; cbuffer cbuf
+// CHECK: ; {
+// CHECK: ;
+// CHECK: ;   struct cbuf
+// CHECK: ;   {
+// CHECK: ;
+// CHECK: ;       struct struct.Agg
+// CHECK: ;       {
+// CHECK: ;
+// CHECK: ;           column_major uint2x2 mat;                 ; Offset:    0
+// CHECK: ;           struct struct.Value
+// CHECK: ;           {
+// CHECK: ;
+// CHECK: ;               uint v;                               ; Offset:    32
+// CHECK: ;
+// CHECK: ;           } value[1];;                              ; Offset:    32
+// CHECK: ;
+// CHECK: ;           uint fodder;                              ; Offset:    36
+// CHECK: ;
+// CHECK: ;       } aggie;                                      ; Offset:    0
+// CHECK: ;
+// CHECK: ;
+// CHECK: ;   } cbuf;                                           ; Offset:    0 Size:     40
+// CHECK: ;
+// CHECK: ; }
+
+
+// Test Cbuffer validation likely to cause mistaken overlaps
+struct Value { uint v; }; // This will be stripped because it has nothing below 32 bits
+
+struct Agg {
+  uint2x2 mat; // This will cause the struct to be 
+  Value value[1];
+  uint fodder;// This will give the struct something to overlap
+};
+
+cbuffer cbuf : register(b1)
+{
+  Agg aggie;
+}
+
+RWBuffer<int> Out : register(u0);
+
+[shader("raygeneration")]
+void main()
+{
+  Out[0] = aggie.value[0].v;
+}


### PR DESCRIPTION
When stripping reflection data, structures are searched for any member
or submember scalars that are smaller than 32 bits. When one is found
and min precision is being used, the structure is identified as not
being able to be stripped.

In the case of a shader that has a resource that contains a struct which
contains an array which contains a struct, the struct was not being
processed as a struct, but rather as a scalar, which would cause it to
return a size of zero, which was found to be less than 32 bits. This
isn't right if the innermost struct contained a 32 bit integer. Either
way, this resulted in inconsistent results for the parent struct and the
innermost struct. As a result, the annotations were stripped from the
innermost, but left on the outermost. Because the parent struct had
annotations, validation was attempted, but ultimately hit an assert or
caused validation failures because of the innermost struct being
stripped.

By reorganizing the function that searches for 16 bit scalars to look
for a struct only after processing the arrays, the struct is properly
traversed and all annotations are stripped, avoiding the failures.