### PR TITLE
Update DxilMDHelper's SM for correct MinValVersion info.

### DIFF
--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -229,6 +229,7 @@ void DxilMDHelper::LoadDxilShaderModel(const ShaderModel *&pSM) {
     string ErrorMsg(ErrorMsgTxt);
     throw hlsl::Exception(DXC_E_INCORRECT_DXIL_METADATA, ErrorMsg);
   }
+  SetShaderModel(pSM);
 }
 
 //


### PR DESCRIPTION
Bug triggered DXASSERT, but otherwise harmless on fre builds.