### PR TITLE
Correct generated version race condition

### DIFF
--- a/utils/version/CMakeLists.txt
+++ b/utils/version/CMakeLists.txt
@@ -1,74 +1,69 @@
-file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/version.gen" HLSL_GEN_VERSION_FILE)
+# HLSL Change - generate version include
 
-# First create the DXC version header
-# generated per gen_version.py except where explicit fixed version path is provided
-if(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
-    FILE(TO_NATIVE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/version.inc" HLSL_FIXED_VERSION_FILE)
-    message("Using fixed version file ${HLSL_FIXED_VERSION_FILE}")
-    add_custom_command(
-        OUTPUT ${HLSL_GEN_VERSION_FILE}
-        COMMAND echo "Using fixed version file ${HLSL_FIXED_VERSION_FILE}"
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_FIXED_VERSION_FILE} ${HLSL_GEN_VERSION_FILE}
-        DEPENDS ${HLSL_FIXED_VERSION_FILE}
+macro(generate_version_include name input_file output_file gen_flags)
+    if ("${input_file}" STREQUAL "")
+        FILE(TO_NATIVE_PATH "${output_file}.gen" gen_file)
+        add_custom_command(
+            OUTPUT ${gen_file}
+            COMMAND echo Generating version
+            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${gen_flags} > ${gen_file}
+            DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
+        )
+    else ()
+        SET(gen_file ${input_file})
+    endif ()
+
+    add_custom_target(${name}
+        BYPRODUCTS ${output_file}
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${gen_file} ${output_file}
+        DEPENDS ${gen_file}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
     )
-else(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
-    # If official or the dxc case for fixed version location
+
+    set_target_properties(${name} PROPERTIES
+        FOLDER version
+    )
+endmacro(generate_version_include)
+
+# end HLSL Change - generate version include
+
+if(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+    SET(HLSL_FIXED_VERSION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/version.inc")
+    message("Using fixed version file ${HLSL_FIXED_VERSION_FILE}")
+else()
+    SET(HLSL_FIXED_VERSION_FILE "")
     if (HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
         message("Will generate official build version based on the latest release fork sha and current commit count")
         set(HLSL_GEN_VERSION_OFFICIAL_OPTION "--official")
     else (HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
         message("Will generate dev build version based on current commit count")
         set(HLSL_GEN_VERSION_OFFICIAL_OPTION "")
-    endif(HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
+    endif (HLSL_OFFICIAL_BUILD OR HLSL_ENABLE_FIXED_VER)
+endif()
 
-    add_custom_command(
-        OUTPUT ${HLSL_GEN_VERSION_FILE}
-        COMMAND echo "Generating version"
-        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py ${HLSL_GEN_VERSION_OFFICIAL_OPTION} > ${HLSL_GEN_VERSION_FILE}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
-    )
-endif(HLSL_ENABLE_FIXED_VER AND "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
 
-# do dxcversion.inc copy
-file(TO_NATIVE_PATH "${HLSL_VERSION_LOCATION}/dxcversion.inc" HLSL_DXC_VERSION_FILE)
-
-add_custom_target(hlsl_dxcversion_autogen
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_GEN_VERSION_FILE} ${HLSL_DXC_VERSION_FILE}
-    DEPENDS ${HLSL_GEN_VERSION_FILE}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/gen_version.py
+generate_version_include(hlsl_dxcversion_autogen
+    "${HLSL_FIXED_VERSION_FILE}"
+    "${HLSL_VERSION_LOCATION}/dxcversion.inc"
+    "${HLSL_GEN_VERSION_OFFICIAL_OPTION}"
 )
 
-set_property(SOURCE ${HLSL_DXC_VERSION_FILE}
-    PROPERTY GENERATED True
-)
-
-set_target_properties(hlsl_dxcversion_autogen PROPERTIES
-    FOLDER version
-)
-
-
-# do version.inc copy
 if (HLSL_EMBED_VERSION OR HLSL_ENABLE_FIXED_VER)
     # If there is an explicit fixed version location, version.inc should copy from there
     # Used to propagate GDK versions to the RC data
-    if( NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
-        FILE(TO_NATIVE_PATH "${HLSL_FIXED_VERSION_LOCATION}/version.inc" HLSL_COPY_VERSION_FILE)
-    else( NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
-        SET(HLSL_COPY_VERSION_FILE ${HLSL_GEN_VERSION_FILE})
+    if (NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
+        FILE(TO_CMAKE_PATH "${HLSL_FIXED_VERSION_LOCATION}/version.inc" HLSL_FIXED_VERSION_FILE)
     endif(NOT "${HLSL_FIXED_VERSION_LOCATION}" STREQUAL "")
-    file(TO_NATIVE_PATH "${HLSL_VERSION_LOCATION}/version.inc" HLSL_VERSION_FILE)
 
-    add_custom_target(hlsl_version_autogen
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${HLSL_COPY_VERSION_FILE} ${HLSL_VERSION_FILE}
-        DEPENDS ${HLSL_COPY_VERSION_FILE}
-    )
-    
-    set_property(SOURCE ${HLSL_VERSION_FILE}
-        PROPERTY GENERATED True
-    )
+    message(        ${HLSL_FIXED_VERSION_FILE}
+        "${HLSL_VERSION_LOCATION}/version.inc"
+        "${HLSL_GEN_VERSION_OFFICIAL_OPTION}")
 
-    set_target_properties(hlsl_version_autogen PROPERTIES
-        FOLDER version
-    )
 
+    generate_version_include(hlsl_version_autogen
+        "${HLSL_FIXED_VERSION_FILE}"
+        "${HLSL_VERSION_LOCATION}/version.inc"
+        "${HLSL_GEN_VERSION_OFFICIAL_OPTION}"
+    )
 endif(HLSL_EMBED_VERSION OR HLSL_ENABLE_FIXED_VER)
+


### PR DESCRIPTION
When run on a fast system with a lot of threading, the custom cmake
commands to generate version include information ran into a problem
because the two include files both depended on the same intermediate
file for some builds. As a result, when the first thread started writing
to it, the second thread couldn't access it if it started to try before
the first finished. The result was an empty header and no defined
version macros

By elminating the common intermediate file and giving each output file
their own intermediate file, the generation should proceed no matter how
many threads and unnecessary recompilation won't result when
regeneration results in no changes.

To facilitate this, I've added a cmake macro that handles both cases.
The peculiarities of how they are generated are all handled outside the
macro.