### PR TITLE
[spirv] handle not initialized specialization const

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -6295,22 +6295,20 @@ void SpirvEmitter::createSpecConstant(const VarDecl *varDecl) {
     }
   }
 
-  if (!varDecl->hasInit()) {
+  const auto *init = varDecl->getInit();
+
+  if (!init) {
     emitError("missing default value for specialization constant",
               varDecl->getLocation());
+    hasError = true;
+  } else if (!isAcceptedSpecConstantInit(init)) {
+    emitError("unsupported specialization constant initializer",
+              init->getLocStart())
+        << init->getSourceRange();
     hasError = true;
   }
 
   if (hasError) {
-    stopEntireCompilation = true;
-    return;
-  }
-
-  const auto *init = varDecl->getInit();
-  if (!isAcceptedSpecConstantInit(init)) {
-    emitError("unsupported specialization constant initializer",
-              init->getLocStart())
-        << init->getSourceRange();
     stopEntireCompilation = true;
     return;
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1156,6 +1156,13 @@ private:
 
   /// The <result-id> of the OpString containing the main source file's path.
   SpirvString *mainSourceFile;
+
+  /// When there is an error, we want to stop compilation to prevent it from
+  /// causing segmentation faults. If it causes a segfault, we cannot check
+  /// the actual error message.
+  /// TODO: I am worried that this is a global variable in this class and it
+  ///       can be easily mis-used. Revisit this design.
+  bool stopEntireCompilation;
 };
 
 void SpirvEmitter::doDeclStmt(const DeclStmt *declStmt) {

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.hlsl
@@ -22,8 +22,4 @@ float main() : A {
     return 1.0;
 }
 
-// CHECK:  :7:18: error: unsupported specialization constant initializer
-// CHECK:  :10:1: error: unsupported specialization constant type
-// CHECK: :13:11: error: missing default value for specialization constant
-// CHECK: :16:17: error: unsupported specialization constant initializer
-// CHECK: :19:18: error: specialization constant must be externally visible
+// CHECK: :7:18: error: unsupported specialization constant initializer

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.not.segfault.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.error.not.segfault.hlsl
@@ -1,0 +1,16 @@
+// Run: %dxc -T cs_6_0 -E main
+
+[[vk::binding(0)]] RWByteAddressBuffer src;
+#define LOCAL_SIZE 32
+
+[[vk::constant_id(0)]] int gBufferSize;
+[[vk::constant_id(1)]] int gSetValue;
+
+[numthreads(LOCAL_SIZE, 1, 1)]
+void main(uint3 dispatchThreadID : SV_DispatchThreadID)
+{
+  if ((4 * dispatchThreadID.x) < gBufferSize)
+    src.Store4(4 * dispatchThreadID.x, uint4(gSetValue, gSetValue, gSetValue, gSetValue));
+}
+
+// CHECK: :6:28: error: missing default value for specialization constant

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1750,6 +1750,9 @@ TEST_F(FileTest, VulkanSpecConstantUsage) {
 TEST_F(FileTest, VulkanSpecConstantError) {
   runFileTest("vk.spec-constant.error.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, VulkanSpecConstantErrorNotSegfault) {
+  runFileTest("vk.spec-constant.error.not.segfault.hlsl", Expect::Failure);
+}
 
 TEST_F(FileTest, VulkanLayoutCBufferMatrixZpr) {
   runFileTest("vk.layout.cbuffer.zpr.hlsl");


### PR DESCRIPTION
When we do not initialize specialization const, its decl->getInit()
can be non-null value. We must check its decl->hasInit().

Note that I added "stopEntireCompilation" in SpirvEmitter. The main
purpose of this is to correctly print error message. If we keep
processing the code emission for the code with errors, it can cause
segfaults that prevent us from printing error messages. It results in a
silent failure. Because of the engineering cost to make all methods
report success/failure, I added "stopEntireCompilation". However, I am
worried that it is a global variable (easily can be mis-used) and we
should revisit it.