### PR TITLE
Fix outputs -Fre, -Fsh, -Frs, and -Fc with -Fh (#2716)

### DIFF
--- a/include/dxc/Support/dxcapi.impl.h
+++ b/include/dxc/Support/dxcapi.impl.h
@@ -189,7 +189,7 @@ struct DxcOutputObject {
   }
   HRESULT SetName(_In_opt_z_ llvm::StringRef Name) {
     DXASSERT_NOMSG(!name);
-    if (!Name.empty())
+    if (Name.empty())
       return S_OK;
     CComPtr<IDxcBlobEncoding> pBlobEncoding;
     IFR(TranslateUtf8StringForOutput(Name.data(), Name.size(), DXC_CP_UTF16, &pBlobEncoding));

--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -302,15 +302,22 @@ int DxcContext::ActOnBlob(IDxcBlob *pBlob, IDxcBlob *pDebugBlob, LPCWSTR pDebugB
 #endif // ENABLE_SPIRV_CODEGEN
   // SPIRV Change Ends
 
+  bool disassemblyWritten = false;
   if (!m_Opts.OutputHeader.empty()) {
     llvm::Twine varName = m_Opts.VariableName.empty()
                               ? llvm::Twine("g_", m_Opts.EntryPoint)
                               : m_Opts.VariableName;
     WriteHeader(pDisassembleResult, pBlob, varName,
                 StringRefUtf16(m_Opts.OutputHeader));
-  } else if (!m_Opts.AssemblyCode.empty()) {
+    disassemblyWritten = true;
+  }
+
+  if (!m_Opts.AssemblyCode.empty()) {
     WriteBlobToFile(pDisassembleResult, m_Opts.AssemblyCode, m_Opts.DefaultTextCodePage);
-  } else {
+    disassemblyWritten = true;
+  }
+
+  if (!disassemblyWritten) {
     WriteBlobToConsole(pDisassembleResult);
   }
   return retVal;

--- a/utils/hct/cmdtestfiles/smoke.hlsl
+++ b/utils/hct/cmdtestfiles/smoke.hlsl
@@ -1,4 +1,6 @@
 int g;
+static int g_unused;
+
 #ifndef semantic
 #define semantic SV_Target
 #endif

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -340,7 +340,7 @@ call :check_file smoke.rebuilt-container2.cso del
 if %Failed% neq 0 goto :failed
 
 set testname=Smoke test for dxopt command line
-call :run dxc /Odump /T ps_6_0 "%testfiles%\smoke.hlsl" -Fo passes.txt
+call :run-nolog dxc /Odump /T ps_6_0 "%testfiles%\smoke.hlsl" > passes.txt
 call :check_file passes.txt find emit
 if %Failed% neq 0 goto :failed
 echo -print-module >> passes.txt


### PR DESCRIPTION
- Fix output naming for StringRef
- Support /Fc when /Fh is provided
- Fix root sig strip flag
- Create root sig stream output
- Validate -Frs root sig output for signing with DXIL.dll
- Move outputs under valHR success branch
- Add test for -Fre, -Fsh, -Frs, and -Fc with -Fh
- Rework hcttestcmds.cmd completely: checks a lot more stuff and is way more robust,
  while being much easier to read, add to, and maintain, I hope.

cherry-picked from #2716 - 367dd44.