### PR TITLE
Rewriter: improvements plus extract uniforms to global scope

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -41,6 +41,7 @@ enum HlslFlags {
   NoArgumentUnused = (1 << 14),
   CoreOption = (1 << 15),
   ISenseOption = (1 << 16),
+  RewriteOption = (1 << 17),
 };
 
 enum ID {
@@ -64,7 +65,7 @@ static const unsigned CompilerFlags = HlslFlags::CoreOption;
 /// Flags for dxc.exe command-line tool.
 static const unsigned DxcFlags = HlslFlags::CoreOption | HlslFlags::DriverOption;
 /// Flags for dxr.exe command-line tool.
-static const unsigned DxrFlags = HlslFlags::CoreOption | HlslFlags::DriverOption;
+static const unsigned DxrFlags = HlslFlags::RewriteOption | HlslFlags::DriverOption;
 /// Flags for IDxcIntelliSense APIs.
 static const unsigned ISenseFlags = HlslFlags::CoreOption | HlslFlags::ISenseOption;
 
@@ -83,6 +84,16 @@ public:
   UINT32 ComputeNumberOfWCharsNeededForDefines();
   const DxcDefine *data() const { return DefineVector.data(); }
   unsigned size() const { return DefineVector.size(); }
+};
+
+struct RewriterOpts {
+  bool Unchanged = false;                   // OPT_rw_unchanged
+  bool SkipFunctionBody = false;            // OPT_rw_skip_function_body
+  bool SkipStatic = false;                  // OPT_rw_skip_static
+  bool GlobalExternByDefault = false;       // OPT_rw_global_extern_by_default
+  bool KeepUserMacro = false;               // OPT_rw_keep_user_macro
+  bool ExtractEntryUniforms = false;        // OPT_rw_extract_entry_uniforms
+  bool RemoveUnusedGlobals = false;         // OPT_rw_remove_unused_globals
 };
 
 /// Use this class to capture all options.
@@ -172,6 +183,9 @@ public:
   bool ExportShadersOnly = false; // OPT_export_shaders_only
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
+
+  // Rewriter Options
+  RewriterOpts RWOpt;
 
   std::vector<std::string> Warnings;
 

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -26,6 +26,9 @@ def CoreOption : OptionFlag;
 // ISenseOption - This option is only supported for IntelliSense.
 def ISenseOption : OptionFlag;
 
+// RewriteOption - This is considered a "rewriter" HLSL option.
+def RewriteOption : OptionFlag;
+
 //////////////////////////////////////////////////////////////////////////////
 // Groups
 
@@ -66,6 +69,7 @@ def hlslcomp_Group : OptionGroup<"HLSL Compilation">, HelpText<"Compilation Opti
 def hlsloptz_Group : OptionGroup<"HLSL Optimization">, HelpText<"Optimization Options">;
 def hlslutil_Group : OptionGroup<"HLSL Utility">, HelpText<"Utility Options">;
 def hlslcore_Group : OptionGroup<"HLSL Core">, HelpText<"Common Options">;
+def hlslrewrite_Group : OptionGroup<"HLSL Rewriter">, HelpText<"Rewriter Options">;
 
 def spirv_Group : OptionGroup<"SPIR-V CodeGen">, HelpText<"SPIR-V CodeGen Options">; // SPIRV Change
 
@@ -82,11 +86,11 @@ def spirv_Group : OptionGroup<"SPIR-V CodeGen">, HelpText<"SPIR-V CodeGen Option
 // The general approach is to include only things that are in use, in the
 // same order as in Options.td.
 
-def D : JoinedOrSeparate<["-", "/"], "D">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def D : JoinedOrSeparate<["-", "/"], "D">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
     HelpText<"Define macro">;
 def H : Flag<["-"], "H">, Flags<[CoreOption]>, Group<hlslcomp_Group>,
     HelpText<"Show header includes and nesting depth">;
-def I : JoinedOrSeparate<["-", "/"], "I">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def I : JoinedOrSeparate<["-", "/"], "I">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
     HelpText<"Add directory to include search path">;
 def O0 : Flag<["-", "/"], "O0">, Group<hlsloptz_Group>, Flags<[CoreOption]>,
     HelpText<"Optimization Level 0">;
@@ -211,13 +215,13 @@ def _help_question : Flag<["-", "/"], "?">, Flags<[DriverOption]>, Alias<help>;
 
 def ast_dump : Flag<["-", "/"], "ast-dump">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Dumps the parsed Abstract Syntax Tree.">; // should not be core, but handy workaround until explicit API written
-def external_lib : Separate<["-", "/"], "external">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,
+def external_lib : Separate<["-", "/"], "external">, Group<hlslcore_Group>, Flags<[DriverOption, RewriteOption, HelpHidden]>,
   HelpText<"External DLL name to load for compiler support">;
-def external_fn : Separate<["-", "/"], "external-fn">, Group<hlslcore_Group>, Flags<[DriverOption, HelpHidden]>,
+def external_fn : Separate<["-", "/"], "external-fn">, Group<hlslcore_Group>, Flags<[DriverOption, RewriteOption, HelpHidden]>,
   HelpText<"External function name to load for compiler support">;
 def fcgl : Flag<["-", "/"], "fcgl">, Group<hlslcore_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Generate high-level code only">;
-def flegacy_macro_expansion : Flag<["-", "/"], "flegacy-macro-expansion">, Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,
+def flegacy_macro_expansion : Flag<["-", "/"], "flegacy-macro-expansion">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,
     HelpText<"Expand the operands before performing token-pasting operation (fxc behavior)">;
 def flegacy_resource_reservation : Flag<["-", "/"], "flegacy-resource-reservation">, Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,
     HelpText<"Reserve unused explicit register assignments for compatibility with shader model 5.0 and below">;
@@ -233,13 +237,13 @@ def pack_optimized : Flag<["-", "/"], "pack-optimized">, Group<hlslcomp_Group>, 
   HelpText<"Optimize signature packing assuming identical signature provided for each connecting stage">;
 def pack_optimized_ : Flag<["-", "/"], "pack_optimized">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Optimize signature packing assuming identical signature provided for each connecting stage">;
-def hlsl_version : Separate<["-", "/"], "HV">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def hlsl_version : Separate<["-", "/"], "HV">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
   HelpText<"HLSL version (2016, 2017, 2018). Default is 2018">;
-def no_warnings : Flag<["-", "/"], "no-warnings">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def no_warnings : Flag<["-", "/"], "no-warnings">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
   HelpText<"Suppress warnings">;
 def rootsig_define : Separate<["-", "/"], "rootsig-define">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Read root signature from a #define">;
-def enable_16bit_types: Flag<["-", "/"], "enable-16bit-types">, Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>,
+def enable_16bit_types: Flag<["-", "/"], "enable-16bit-types">, Flags<[CoreOption, RewriteOption, DriverOption]>, Group<hlslcomp_Group>,
   HelpText<"Enable 16bit types and disable min precision types. Available in HLSL 2018 and shader model 6.2">;
 def ignore_line_directives : Flag<["-", "/"], "ignore-line-directives">, HelpText<"Ignore line directives">, Flags<[CoreOption]>, Group<hlslcomp_Group>;
 def auto_binding_space : Separate<["-", "/"], "auto-binding-space">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
@@ -250,7 +254,7 @@ def export_shaders_only : Flag<["-", "/"], "export-shaders-only">, Group<hlslcom
   HelpText<"Only export shaders when compiling a library">;
 def default_linkage : Separate<["-", "/"], "default-linkage">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Set default linkage for non-shader functions when compiling or linking to a library target (internal, external)">;
-def encoding : Separate<["-", "/"], "encoding">, Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,
+def encoding : Separate<["-", "/"], "encoding">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,
   HelpText<"Set default encoding for text outputs (utf8|utf16) default=utf8">;
 def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
@@ -313,7 +317,7 @@ def target_profile : JoinedOrSeparate<["-", "/"], "T">, Flags<[CoreOption]>, Gro
   // VALRULE-TEXT:BEGIN
   HelpText<"Set target profile. \n\t<profile>: ps_6_0, ps_6_1, ps_6_2, ps_6_3, ps_6_4, ps_6_5, ps_6_6, \n\t\t vs_6_0, vs_6_1, vs_6_2, vs_6_3, vs_6_4, vs_6_5, vs_6_6, \n\t\t gs_6_0, gs_6_1, gs_6_2, gs_6_3, gs_6_4, gs_6_5, gs_6_6, \n\t\t hs_6_0, hs_6_1, hs_6_2, hs_6_3, hs_6_4, hs_6_5, hs_6_6, \n\t\t ds_6_0, ds_6_1, ds_6_2, ds_6_3, ds_6_4, ds_6_5, ds_6_6, \n\t\t cs_6_0, cs_6_1, cs_6_2, cs_6_3, cs_6_4, cs_6_5, cs_6_6, \n\t\t lib_6_1, lib_6_2, lib_6_3, lib_6_4, lib_6_5, lib_6_6, \n\t\t ms_6_5, ms_6_6, \n\t\t as_6_5, as_6_6, \n\t\t ">;
   // VALRULE-TEXT:END
-def entrypoint :  JoinedOrSeparate<["-", "/"], "E">, Flags<[CoreOption]>, Group<hlslcomp_Group>,
+def entrypoint :  JoinedOrSeparate<["-", "/"], "E">, Flags<[CoreOption, RewriteOption]>, Group<hlslcomp_Group>,
   HelpText<"Entry point name">;
 // /I <include> - already defined above
 def _vi : Flag<["-", "/"], "Vi">, Alias<H>, Flags<[CoreOption]>, Group<hlslcomp_Group>,
@@ -347,7 +351,7 @@ def Gis : Flag<["-", "/"], "Gis">, HelpText<"Force IEEE strictness">, Flags<[Cor
 
 def denorm : JoinedOrSeparate<["-", "/"], "denorm">, HelpText<"select denormal value options (any, preserve, ftz). any is the default.">, Flags<[CoreOption]>, Group<hlslcomp_Group>;
 
-def Fo : JoinedOrSeparate<["-", "/"], "Fo">, MetaVarName<"<file>">, HelpText<"Output object file">, Flags<[CoreOption, DriverOption]>, Group<hlslcomp_Group>;
+def Fo : JoinedOrSeparate<["-", "/"], "Fo">, MetaVarName<"<file>">, HelpText<"Output object file">, Flags<[CoreOption, RewriteOption, DriverOption]>, Group<hlslcomp_Group>;
 // def Fl : JoinedOrSeparate<["-", "/"], "Fl">, MetaVarName<"<file>">, HelpText<"Output a library">;
 def Fc : JoinedOrSeparate<["-", "/"], "Fc">, MetaVarName<"<file>">, HelpText<"Output assembly code listing file">, Flags<[DriverOption]>, Group<hlslcomp_Group>;
 //def Fx : JoinedOrSeparate<["-", "/"], "Fx">, MetaVarName<"<file>">, HelpText<"Output assembly code and hex listing file">;
@@ -424,6 +428,24 @@ def getprivate : JoinedOrSeparate<["-", "/"], "getprivate">, Flags<[DriverOption
 
 def nologo : Flag<["-", "/"], "nologo">, Group<hlslcore_Group>, Flags<[DriverOption]>,
   HelpText<"Suppress copyright message">;
+
+//////////////////////////////////////////////////////////////////////////////
+// Rewriter Options
+
+def rw_unchanged : Flag<["-", "/"], "unchanged">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"Rewrite HLSL, without changes.">;
+def rw_skip_function_body : Flag<["-", "/"], "skip-fn-body">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"">;
+def rw_skip_static : Flag<["-", "/"], "skip-static">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"">;
+def rw_global_extern_by_default : Flag<["-", "/"], "global-extern-by-default">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"">;
+def rw_keep_user_macro : Flag<["-", "/"], "keep-user-macro">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"">;
+def rw_extract_entry_uniforms : Flag<["-", "/"], "extract-entry-uniforms">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"Move uniform parameters from entry point to global scope">;
+def rw_remove_unused_globals : Flag<["-", "/"], "remove-unused-globals">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
+  HelpText<"Remove unused static globals and functions">;
 
 // Also removed: compress, decompress, /Gch (child effect), /Gpp (partial precision)
 // /Op - no support for preshaders.

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -435,13 +435,13 @@ def nologo : Flag<["-", "/"], "nologo">, Group<hlslcore_Group>, Flags<[DriverOpt
 def rw_unchanged : Flag<["-", "/"], "unchanged">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
   HelpText<"Rewrite HLSL, without changes.">;
 def rw_skip_function_body : Flag<["-", "/"], "skip-fn-body">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
-  HelpText<"">;
+  HelpText<"Translate function definitions to declarations">;
 def rw_skip_static : Flag<["-", "/"], "skip-static">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
-  HelpText<"">;
+  HelpText<"Remove static functions and globals when used with -skip-fn-body">;
 def rw_global_extern_by_default : Flag<["-", "/"], "global-extern-by-default">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
-  HelpText<"">;
+  HelpText<"Set extern on non-static globals">;
 def rw_keep_user_macro : Flag<["-", "/"], "keep-user-macro">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
-  HelpText<"">;
+  HelpText<"Write out user defines after rewritten HLSL">;
 def rw_extract_entry_uniforms : Flag<["-", "/"], "extract-entry-uniforms">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,
   HelpText<"Move uniform parameters from entry point to global scope">;
 def rw_remove_unused_globals : Flag<["-", "/"], "remove-unused-globals">, Group<hlslrewrite_Group>, Flags<[RewriteOption]>,

--- a/include/llvm/Option/OptTable.h
+++ b/include/llvm/Option/OptTable.h
@@ -42,7 +42,7 @@ public:
     unsigned ID;
     unsigned char Kind;
     unsigned char Param;
-    unsigned short Flags;
+    unsigned long Flags;
     unsigned short GroupID;
     unsigned short AliasID;
     const char *AliasArgs;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -676,7 +676,9 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   // XXX TODO: Sort this out, since it's required for new API, but a separate argument for old APIs.
   if ((flagsToInclude & hlsl::options::DriverOption) &&
-      opts.TargetProfile.empty() && !opts.DumpBin && opts.Preprocess.empty() && !opts.RecompileFromBinary) {
+      !(flagsToInclude & hlsl::options::RewriteOption) &&
+      opts.TargetProfile.empty() && !opts.DumpBin && opts.Preprocess.empty() && !opts.RecompileFromBinary
+      ) {
     // Target profile is required in arguments only for drivers when compiling;
     // APIs take this through an argument.
     errors << "Target profile argument is missing";
@@ -874,6 +876,23 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   if (opts.DebugNameForSource && !opts.DebugInfo) {
     errors << "/Zss requires debug info (/Zi)";
     return 1;
+  }
+
+  // Rewriter Options
+  if (flagsToInclude & hlsl::options::RewriteOption) {
+    opts.RWOpt.Unchanged = Args.hasFlag(OPT_rw_unchanged, OPT_INVALID, false);
+    opts.RWOpt.SkipFunctionBody = Args.hasFlag(OPT_rw_skip_function_body, OPT_INVALID, false);
+    opts.RWOpt.SkipStatic = Args.hasFlag(OPT_rw_skip_static, OPT_INVALID, false);
+    opts.RWOpt.GlobalExternByDefault = Args.hasFlag(OPT_rw_global_extern_by_default, OPT_INVALID, false);
+    opts.RWOpt.KeepUserMacro = Args.hasFlag(OPT_rw_keep_user_macro, OPT_INVALID, false);
+    opts.RWOpt.ExtractEntryUniforms = Args.hasFlag(OPT_rw_extract_entry_uniforms, OPT_INVALID, false);
+    opts.RWOpt.RemoveUnusedGlobals = Args.hasFlag(OPT_rw_remove_unused_globals, OPT_INVALID, false);
+
+    if (opts.EntryPoint.empty() &&
+        (opts.RWOpt.RemoveUnusedGlobals || opts.RWOpt.ExtractEntryUniforms)) {
+      errors << "-rw-remove-unused-globals and -rw-extract-entry-uniforms requires entry point (-E) to be specified.";
+      return 1;
+    }
   }
 
   opts.Args = std::move(Args);

--- a/tools/clang/include/clang/AST/PrettyPrinter.h
+++ b/tools/clang/include/clang/AST/PrettyPrinter.h
@@ -43,7 +43,8 @@ struct PrintingPolicy {
       Bool(LO.Bool), TerseOutput(false), PolishForDeclaration(false),
       Half(LO.HLSL || LO.Half), // HLSL Change - always print 'half' for HLSL
       MSWChar(LO.MicrosoftExt && !LO.WChar),
-      IncludeNewlines(true) { }
+      IncludeNewlines(true),
+      HLSLSuppressUniformParameters(false) { }
 
   /// \brief What language we're printing.
   LangOptions LangOpts;
@@ -164,6 +165,11 @@ struct PrintingPolicy {
 
   /// \brief When true, include newlines after statements like "break", etc.
   unsigned IncludeNewlines : 1;
+
+  // HLSL Change Begin
+  /// \brief When true, exclude uniform function parameters
+  unsigned HLSLSuppressUniformParameters : 1;
+  // HLSL Change Ends
 };
 
 } // end namespace clang

--- a/tools/clang/lib/AST/DeclPrinter.cpp
+++ b/tools/clang/lib/AST/DeclPrinter.cpp
@@ -510,6 +510,10 @@ void DeclPrinter::VisitFunctionDecl(FunctionDecl *D) {
       llvm::raw_string_ostream POut(Proto);
       DeclPrinter ParamPrinter(POut, SubPolicy, Indentation);
       for (unsigned i = 0, e = D->getNumParams(); i != e; ++i) {
+        if (Policy.HLSLSuppressUniformParameters &&
+            Policy.LangOpts.HLSL &&
+            D->getParamDecl(i)->hasAttr<HLSLUniformAttr>())  // HLSL Change
+          continue;
         if (i) POut << ", ";
         ParamPrinter.VisitParmVarDecl(D->getParamDecl(i));
       }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12405,7 +12405,7 @@ void hlsl::CustomPrintHLSLAttr(const clang::Attr *A, llvm::raw_ostream &Out, con
     Attr * noconst = const_cast<Attr*>(A);
     HLSLRootSignatureAttr *ACast = static_cast<HLSLRootSignatureAttr*>(noconst);
     Indent(Indentation, Out);
-    Out << "[RootSignature(" << ACast->getSignatureName() << ")]\n";
+    Out << "[RootSignature(\"" << ACast->getSignatureName() << "\")]\n";
     break;
   }
 

--- a/tools/clang/test/HLSL/rewriter/correct_rewrites/array-length-rw_gold.hlsl
+++ b/tools/clang/test/HLSL/rewriter/correct_rewrites/array-length-rw_gold.hlsl
@@ -1,6 +1,6 @@
 // Rewrite unchanged result:
 const float4 planes[8];
-[RootSignature(CBV(b0, space=0, visibility=SHADER_VISIBILITY_ALL))]
+[RootSignature("CBV(b0, space=0, visibility=SHADER_VISIBILITY_ALL)")]
 float main() {
   float4 x = float4(1., 1., 1., 1.);
   for (uint i = 0; i < planes.Length; ++i) {

--- a/tools/clang/test/HLSL/rewriter/rewrite-uniforms.hlsl
+++ b/tools/clang/test/HLSL/rewriter/rewrite-uniforms.hlsl
@@ -1,0 +1,15 @@
+#define RS "RootFlags(0),DescriptorTable(UAV(u0, numDescriptors = 1), CBV(b0, numDescriptors = 1))"
+
+[RootSignature(RS)]
+[numthreads(4,8,16)]
+void FloatFunc(uint3 id : SV_DispatchThreadID, uniform RWStructuredBuffer<float> buf, uniform uint ui)
+{
+    buf[id.x+id.y+id.z] = id.x;
+}
+
+[RootSignature(RS)]
+[numthreads(4,8,16)]
+void IntFunc(uint3 id : SV_DispatchThreadID, uniform RWStructuredBuffer<int> buf, uniform uint ui)
+{
+    buf[id.x+id.y+id.z] = id.x + ui;
+}

--- a/tools/clang/tools/dxclib/dxc.h
+++ b/tools/clang/tools/dxclib/dxc.h
@@ -13,8 +13,22 @@
 #ifndef __DXC_DXCLIB__
 #define __DXC_DXCLIB__
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace dxc
 {
+class DxcDllSupport;
+
+// Writes compiler version info to stream
+void WriteDxCompilerVersionInfo(llvm::raw_ostream &OS,
+                                const char *ExternalLib,
+                                const char *ExternalFn,
+                                dxc::DxcDllSupport &DxcSupport);
+void WriteDXILVersionInfo(llvm::raw_ostream &OS,
+                          dxc::DxcDllSupport &DxilSupport);
+
 #ifdef _WIN32
 int main(int argc, const wchar_t **argv_);
 #else

--- a/tools/clang/tools/dxr/CMakeLists.txt
+++ b/tools/clang/tools/dxr/CMakeLists.txt
@@ -5,6 +5,7 @@
 set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   dxcsupport
+  Option     # option library
   Support    # For Atomic increment/decrement
   )
 
@@ -14,13 +15,16 @@ add_clang_executable(dxr
   )
 
 target_link_libraries(dxr
+  dxclib
   dxcompiler
   )
 
 set_target_properties(dxr PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 # set_target_properties(dxr PROPERTIES ENABLE_EXPORTS 1)
 
-add_dependencies(dxr dxcompiler)
+include_directories(${LLVM_SOURCE_DIR}/tools/clang/tools)
+
+add_dependencies(dxr dxclib dxcompiler)
 
 if(UNIX)
   set(CLANGXX_LINK_OR_COPY create_symlink)

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -329,17 +329,16 @@ void WriteUserMacroDefines(CompilerInstance &compiler, raw_string_ostream &o) {
 }
 
 static
-HRESULT ReadOptsAndValidate(LPCWSTR *pArguments, _In_ UINT32 argCount,
+HRESULT ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
                             hlsl::options::DxcOpts &opts,
                             _COM_Outptr_ IDxcOperationResult **ppResult) {
-  hlsl::options::MainArgs mainArgs(argCount, pArguments, 0);
   const llvm::opt::OptTable *table = ::options::getHlslOptTable();
 
   CComPtr<AbstractMemoryStream> pOutputStream;
   IFT(CreateMemoryStream(GetGlobalHeapMalloc(), &pOutputStream));
   raw_stream_ostream outStream(pOutputStream);
 
-  if (0 != hlsl::options::ReadDxcOpts(table, hlsl::options::CompilerFlags,
+  if (0 != hlsl::options::ReadDxcOpts(table, hlsl::options::HlslFlags::RewriteOption,
                                       mainArgs, opts, outStream)) {
     CComPtr<IDxcBlob> pErrorBlob;
     IFT(pOutputStream->QueryInterface(&pErrorBlob));
@@ -350,40 +349,70 @@ HRESULT ReadOptsAndValidate(LPCWSTR *pArguments, _In_ UINT32 argCount,
       }, ppResult));
     return S_OK;
   }
-  DXASSERT(opts.HLSLVersion > 2015,
-           "else ReadDxcOpts didn't fail for non-isense");
   return S_OK;
 }
 
+static
+bool HasUniformParams(FunctionDecl *FD) {
+  for (auto PD : FD->params()) {
+    if (PD->hasAttr<HLSLUniformAttr>())
+      return true;
+  }
+  return false;
+}
 
 static
-HRESULT DoRewriteUnused(_In_ DxcLangExtensionsHelper *pHelper,
-                     _In_ LPCSTR pFileName,
-                     _In_ ASTUnit::RemappedFile *pRemap,
-                     _In_ LPCSTR pEntryPoint,
-                     _In_ LPCSTR pDefines,
-                     std::string &warnings,
-                     std::string &result) {
+void WriteUniformParamsAsGlobals(FunctionDecl *FD,
+                                 raw_ostream &o,
+                                 PrintingPolicy &p) {
+  // Extract resources first, to avoid placing in cbuffer _Params
+  for (auto PD : FD->params()) {
+    if (PD->hasAttr<HLSLUniformAttr>() &&
+        hlsl::IsHLSLResourceType(PD->getType())) {
+      PD->print(o, p);
+      o << ";\n";
+    }
+  }
+  // Extract any non-resource uniforms into cbuffer _Params
+  bool startedParams = false;
+  for (auto PD : FD->params()) {
+    if (PD->hasAttr<HLSLUniformAttr>() &&
+        !hlsl::IsHLSLResourceType(PD->getType())) {
+      if (!startedParams) {
+        o << "cbuffer _Params {\n";
+        startedParams = true;
+      }
+      PD->print(o, p);
+      o << ";\n";
+    }
+  }
+  if (startedParams) {
+    o << "}\n";
+  }
+}
 
-  raw_string_ostream o(result);
-  raw_string_ostream w(warnings);
+static
+void PrintTranslationUnitWithTranslatedUniformParams(
+    TranslationUnitDecl *tu,
+    FunctionDecl *entryFnDecl,
+    raw_ostream &o,
+    PrintingPolicy &p) {
+  // Print without the entry function
+  entryFnDecl->setImplicit(true); // Prevent printing of this decl
+  tu->print(o, p);
+  entryFnDecl->setImplicit(false);
 
-  // Setup a compiler instance.
-  CompilerInstance compiler;
-  std::unique_ptr<TextDiagnosticPrinter> diagPrinter =
-      llvm::make_unique<TextDiagnosticPrinter>(w, &compiler.getDiagnosticOpts());  
+  WriteUniformParamsAsGlobals(entryFnDecl, o, p);
 
-  hlsl::options::DxcOpts opts;
-  opts.HLSLVersion = 2015;
+  PrintingPolicy SubPolicy(p);
+  SubPolicy.HLSLSuppressUniformParameters = true;
+  entryFnDecl->print(o, SubPolicy);
+}
 
-  SetupCompilerForRewrite(compiler, pHelper, pFileName, diagPrinter.get(), pRemap, opts, pDefines);
-
-  // Parse the source file.
-  compiler.getDiagnosticClient().BeginSourceFile(compiler.getLangOpts(), &compiler.getPreprocessor());
-  ParseAST(compiler.getSema(), false, false);
-
-  ASTContext& C = compiler.getASTContext();
-  TranslationUnitDecl *tu = C.getTranslationUnitDecl();
+static HRESULT DoRewriteUnused( TranslationUnitDecl *tu,
+                                LPCSTR pEntryPoint,
+                                raw_ostream &w) {
+  ASTContext& C = tu->getASTContext();
 
   // Gather all global variables that are not in cbuffers and all functions.
   SmallPtrSet<VarDecl*, 128> unusedGlobals;
@@ -418,82 +447,123 @@ HRESULT DoRewriteUnused(_In_ DxcLangExtensionsHelper *pHelper,
   DeclContext::lookup_result l = tu->lookup(DeclarationName(&C.Idents.get(StringRef(pEntryPoint))));
   if (l.empty()) {
     w << "//entry point not found\n";
+    return E_FAIL;
   }
-  else {
-    w << "//entry point found\n";
-    NamedDecl *entryDecl = l.front();
-    FunctionDecl *entryFnDecl = dyn_cast_or_null<FunctionDecl>(entryDecl);
-    if (entryFnDecl == nullptr) {
-      o << "//entry point found but is not a function declaration\n";
-    }
-    else {
-      // Traverse reachable functions and variables.
-      SmallPtrSet<FunctionDecl*, 128> visitedFunctions;
-      SmallVector<FunctionDecl*, 32> pendingFunctions;
-      VarReferenceVisitor visitor(unusedGlobals, visitedFunctions, pendingFunctions);
-      pendingFunctions.push_back(entryFnDecl);
-      while (!pendingFunctions.empty() && !unusedGlobals.empty()) {
-        FunctionDecl* pendingDecl = pendingFunctions.pop_back_val();
-        visitedFunctions.insert(pendingDecl);
-        visitor.TraverseDecl(pendingDecl);
-      }
 
-      // Don't bother doing work if there are no globals to remove.
-      if (unusedGlobals.empty()) {
-        w << "//no unused globals found - no work to be done\n";
-        StringRef contents = C.getSourceManager().getBufferData(C.getSourceManager().getMainFileID());
-        o << contents;
-      }
-      else {
-        w << "//found " << unusedGlobals.size() << " globals to remove\n";
+  w << "//entry point found\n";
+  NamedDecl *entryDecl = l.front();
+  FunctionDecl *entryFnDecl = dyn_cast_or_null<FunctionDecl>(entryDecl);
+  if (entryFnDecl == nullptr) {
+    w << "//entry point found but is not a function declaration\n";
+    return E_FAIL;
+  }
 
-        // Don't remove visited functions.
-        for (FunctionDecl *visitedFn : visitedFunctions) {
-          unusedFunctions.erase(visitedFn);
+  // Traverse reachable functions and variables.
+  SmallPtrSet<FunctionDecl*, 128> visitedFunctions;
+  SmallVector<FunctionDecl*, 32> pendingFunctions;
+  VarReferenceVisitor visitor(unusedGlobals, visitedFunctions, pendingFunctions);
+  pendingFunctions.push_back(entryFnDecl);
+  while (!pendingFunctions.empty() && !unusedGlobals.empty()) {
+    FunctionDecl* pendingDecl = pendingFunctions.pop_back_val();
+    visitedFunctions.insert(pendingDecl);
+    visitor.TraverseDecl(pendingDecl);
+  }
+
+  // Don't bother doing work if there are no globals to remove.
+  if (unusedGlobals.empty()) {
+    return S_FALSE;
+  }
+
+  w << "//found " << unusedGlobals.size() << " globals to remove\n";
+
+  // Don't remove visited functions.
+  for (FunctionDecl *visitedFn : visitedFunctions) {
+    unusedFunctions.erase(visitedFn);
+  }
+  w << "//found " << unusedFunctions.size() << " functions to remove\n";
+
+  // Remove all unused variables and functions.
+  for (VarDecl *unusedGlobal : unusedGlobals) {
+    if (const RecordType *recordTy = unusedGlobal->getType()->getAs<RecordType>()) {
+      RecordDecl *recordDecl = recordTy->getDecl();
+      if (recordDecl && recordDecl->getName().empty()) {
+        // Anonymous structs can only be referenced by the variable they declare.
+        // If we've removed all declared variables of such a struct, remove it too,
+        // because anonymous structs without variable declarations in global scope are illegal.
+        auto recordRefCountIter = anonymousRecordRefCounts.find(recordDecl);
+        DXASSERT_NOMSG(recordRefCountIter != anonymousRecordRefCounts.end() && recordRefCountIter->second > 0);
+        recordRefCountIter->second--;
+        if (recordRefCountIter->second == 0) {
+          tu->removeDecl(recordDecl);
+          anonymousRecordRefCounts.erase(recordRefCountIter);
         }
-        w << "//found " << unusedFunctions.size() << " functions to remove\n";
-
-        // Remove all unused variables and functions.
-        for (VarDecl *unusedGlobal : unusedGlobals) {
-          if (const RecordType *recordTy = unusedGlobal->getType()->getAs<RecordType>()) {
-            RecordDecl *recordDecl = recordTy->getDecl();
-            if (recordDecl && recordDecl->getName().empty()) {
-              // Anonymous structs can only be referenced by the variable they declare.
-              // If we've removed all declared variables of such a struct, remove it too,
-              // because anonymous structs without variable declarations in global scope are illegal.
-              auto recordRefCountIter = anonymousRecordRefCounts.find(recordDecl);
-              DXASSERT_NOMSG(recordRefCountIter != anonymousRecordRefCounts.end() && recordRefCountIter->second > 0);
-              recordRefCountIter->second--;
-              if (recordRefCountIter->second == 0) {
-                tu->removeDecl(recordDecl);
-                anonymousRecordRefCounts.erase(recordRefCountIter);
-              }
-            }
-          }
-
-          tu->removeDecl(unusedGlobal);
-        }
-
-        for (FunctionDecl *unusedFn : unusedFunctions) {
-          tu->removeDecl(unusedFn);
-        }
-
-        o << "// Rewrite unused globals result:\n";
-        PrintingPolicy p = PrintingPolicy(C.getPrintingPolicy());
-        p.Indentation = 1;
-        tu->print(o, p);
-
-        WriteSemanticDefines(compiler, pHelper, o);
       }
     }
+
+    tu->removeDecl(unusedGlobal);
   }
+
+  for (FunctionDecl *unusedFn : unusedFunctions) {
+    tu->removeDecl(unusedFn);
+  }
+
+  // Flush and return results.
+  w.flush();
+  return S_OK;
+}
+
+static
+HRESULT DoRewriteUnused(_In_ DxcLangExtensionsHelper *pHelper,
+                     _In_ LPCSTR pFileName,
+                     _In_ ASTUnit::RemappedFile *pRemap,
+                     _In_ LPCSTR pEntryPoint,
+                     _In_ LPCSTR pDefines,
+                     std::string &warnings,
+                     std::string &result) {
+
+  raw_string_ostream o(result);
+  raw_string_ostream w(warnings);
+
+  // Setup a compiler instance.
+  CompilerInstance compiler;
+  std::unique_ptr<TextDiagnosticPrinter> diagPrinter =
+      llvm::make_unique<TextDiagnosticPrinter>(w, &compiler.getDiagnosticOpts());
+
+  hlsl::options::DxcOpts opts;
+  opts.HLSLVersion = 2015;
+
+  SetupCompilerForRewrite(compiler, pHelper, pFileName, diagPrinter.get(), pRemap, opts, pDefines);
+
+  // Parse the source file.
+  compiler.getDiagnosticClient().BeginSourceFile(compiler.getLangOpts(), &compiler.getPreprocessor());
+  ParseAST(compiler.getSema(), false, false);
+
+  ASTContext& C = compiler.getASTContext();
+  TranslationUnitDecl *tu = C.getTranslationUnitDecl();
+
+  if (compiler.getDiagnosticClient().getNumErrors() > 0)
+    return E_FAIL;
+
+  HRESULT hr = DoRewriteUnused(tu, pEntryPoint, w);
+  if (FAILED(hr))
+    return hr;
+
+  if (hr == S_FALSE) {
+    w << "//no unused globals found - no work to be done\n";
+    StringRef contents = C.getSourceManager().getBufferData(C.getSourceManager().getMainFileID());
+    o << contents;
+  } else {
+    PrintingPolicy p = PrintingPolicy(C.getPrintingPolicy());
+    p.Indentation = 1;
+    tu->print(o, p);
+  }
+
+  WriteSemanticDefines(compiler, pHelper, o);
 
   // Flush and return results.
   o.flush();
   w.flush();
 
-  if (compiler.getDiagnosticClient().getNumErrors() > 0)
-    return E_FAIL;
   return S_OK;
 }
 
@@ -546,10 +616,10 @@ HRESULT DoSimpleReWrite(_In_ DxcLangExtensionsHelper *pHelper,
                std::string &warnings,
                std::string &result) {
 
-  bool bSkipFunctionBody = rewriteOption & RewriterOptionMask::SkipFunctionBody;
-  bool bSkipStatic = rewriteOption & RewriterOptionMask::SkipStatic;
-  bool bGlobalExternByDefault = rewriteOption & RewriterOptionMask::GlobalExternByDefault;
-  bool bKeepUserMacro = rewriteOption & RewriterOptionMask::KeepUserMacro;
+  opts.RWOpt.SkipFunctionBody |= rewriteOption & RewriterOptionMask::SkipFunctionBody;
+  opts.RWOpt.SkipStatic |= rewriteOption & RewriterOptionMask::SkipStatic;
+  opts.RWOpt.GlobalExternByDefault |= rewriteOption & RewriterOptionMask::GlobalExternByDefault;
+  opts.RWOpt.KeepUserMacro |= rewriteOption & RewriterOptionMask::KeepUserMacro;
 
   raw_string_ostream o(result);
   raw_string_ostream w(warnings);
@@ -563,27 +633,54 @@ HRESULT DoSimpleReWrite(_In_ DxcLangExtensionsHelper *pHelper,
   // Parse the source file.
   compiler.getDiagnosticClient().BeginSourceFile(compiler.getLangOpts(), &compiler.getPreprocessor());
 
-  ParseAST(compiler.getSema(), false, bSkipFunctionBody);
+  ParseAST(compiler.getSema(), false, opts.RWOpt.SkipFunctionBody);
 
   ASTContext& C = compiler.getASTContext();
   TranslationUnitDecl *tu = C.getTranslationUnitDecl();
 
-  if (bSkipStatic && bSkipFunctionBody) {
+  if (opts.RWOpt.SkipStatic && opts.RWOpt.SkipFunctionBody) {
     // Remove static functions and globals.
     RemoveStaticDecls(*tu);
   }
 
-  if (bGlobalExternByDefault) {
+  if (opts.RWOpt.GlobalExternByDefault) {
     GlobalVariableAsExternByDefault(*tu);
   }
 
-  o << "// Rewrite unchanged result:\n";
+  if (opts.EntryPoint.empty())
+    opts.EntryPoint = "main";
+
+  if (opts.RWOpt.RemoveUnusedGlobals) {
+    HRESULT hr = DoRewriteUnused(tu, opts.EntryPoint.data(), w);
+    if (FAILED(hr))
+      return hr;
+  } else {
+    o << "// Rewrite unchanged result:\n";
+  }
+
+  FunctionDecl *entryFnDecl = nullptr;
+  if (opts.RWOpt.ExtractEntryUniforms) {
+    DeclContext::lookup_result l = tu->lookup(DeclarationName(&C.Idents.get(opts.EntryPoint)));
+    if (l.empty()) {
+      w << "//entry point not found\n";
+      return E_FAIL;
+    }
+    entryFnDecl = dyn_cast_or_null<FunctionDecl>(l.front());
+    if (!HasUniformParams(entryFnDecl))
+      entryFnDecl = nullptr;
+  }
+
   PrintingPolicy p = PrintingPolicy(C.getPrintingPolicy());
   p.Indentation = 1;
-  tu->print(o, p);
+
+  if (entryFnDecl) {
+    PrintTranslationUnitWithTranslatedUniformParams(tu, entryFnDecl, o, p);
+  } else {
+    tu->print(o, p);
+  }
 
   WriteSemanticDefines(compiler, pHelper, o);
-  if (bKeepUserMacro)
+  if (opts.RWOpt.KeepUserMacro)
     WriteUserMacroDefines(compiler, o);
 
   // Flush and return results.
@@ -802,8 +899,9 @@ public:
 
       std::string definesStr = DefinesToString(pDefines, defineCount);
 
+      hlsl::options::MainArgs mainArgs(argCount, pArguments, 0);
       hlsl::options::DxcOpts opts;
-      IFR(ReadOptsAndValidate(pArguments, argCount, opts, ppResult));
+      IFR(ReadOptsAndValidate(mainArgs, opts, ppResult));
       HRESULT hr;
       if (*ppResult && SUCCEEDED((*ppResult)->GetStatus(&hr)) && FAILED(hr)) {
         // Looks odd, but this call succeeded enough to allocate a result

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -115,14 +115,14 @@ TEST_F(OptionsTest, ReadOptionsWhenExtensionsThenOK) {
     L"exe.exe",   L"/E",        L"main",    L"/T",           L"ps_6_0",
     L"hlsl.hlsl", L"-external", L"foo.dll" };
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   VERIFY_ARE_EQUAL_STR("CreateObj", o->ExternalFn.data());
   VERIFY_ARE_EQUAL_STR("foo.dll", o->ExternalLib.data());
 
   MainArgsArr ArgsNoLibArr(ArgsNoLib);
-  ReadOptsTest(ArgsNoLibArr, DxrFlags, true, true);
+  ReadOptsTest(ArgsNoLibArr, DxcFlags, true, true);
   MainArgsArr ArgsNoFnArr(ArgsNoFn);
-  ReadOptsTest(ArgsNoFnArr, DxrFlags, true, true);
+  ReadOptsTest(ArgsNoFnArr, DxcFlags, true, true);
 }
 
 TEST_F(OptionsTest, ReadOptionsForOutputObject) {
@@ -130,7 +130,7 @@ TEST_F(OptionsTest, ReadOptionsForOutputObject) {
       L"exe.exe",   L"/E",        L"main",    L"/T",           L"ps_6_0",
       L"hlsl.hlsl", L"-Fo", L"hlsl.dxbc"};
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   VERIFY_ARE_EQUAL_STR("hlsl.dxbc", o->OutputObject.data());  
 }
 
@@ -140,33 +140,33 @@ TEST_F(OptionsTest, ReadOptionsConflict) {
       L"-Zpr", L"-Zpc",
       L"hlsl.hlsl"};
   MainArgsArr ArgsArr(matrixArgs);
-  ReadOptsTest(ArgsArr, DxrFlags, "Cannot specify /Zpr and /Zpc together, use /? to get usage information");
+  ReadOptsTest(ArgsArr, DxcFlags, "Cannot specify /Zpr and /Zpc together, use /? to get usage information");
 
   const wchar_t *controlFlowArgs[] = {
       L"exe.exe",   L"/E",        L"main",    L"/T",           L"ps_6_0",
       L"-Gfa", L"-Gfp",
       L"hlsl.hlsl"};
   MainArgsArr controlFlowArr(controlFlowArgs);
-  ReadOptsTest(controlFlowArr, DxrFlags, "Cannot specify /Gfa and /Gfp together, use /? to get usage information");
+  ReadOptsTest(controlFlowArr, DxcFlags, "Cannot specify /Gfa and /Gfp together, use /? to get usage information");
 
   const wchar_t *libArgs[] = {
       L"exe.exe",   L"/E",        L"main",    L"/T",           L"lib_6_1",
       L"hlsl.hlsl"};
   MainArgsArr libArr(libArgs);
-  ReadOptsTest(libArr, DxrFlags, "Must disable validation for unsupported lib_6_1 or lib_6_2 targets.");
+  ReadOptsTest(libArr, DxcFlags, "Must disable validation for unsupported lib_6_1 or lib_6_2 targets.");
 }
 
 TEST_F(OptionsTest, ReadOptionsWhenHelpThenShortcut) {
   const wchar_t *Args[] = { L"exe.exe", L"--help", L"--unknown-flag" };
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   EXPECT_EQ(true, o->ShowHelp);
 }
 
 TEST_F(OptionsTest, ReadOptionsWhenValidThenOK) {
   const wchar_t *Args[] = { L"exe.exe", L"/E", L"main", L"/T", L"ps_6_0", L"hlsl.hlsl" };
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   VERIFY_ARE_EQUAL_STR("main", o->EntryPoint.data());
   VERIFY_ARE_EQUAL_STR("ps_6_0", o->TargetProfile.data());
   VERIFY_ARE_EQUAL_STR("hlsl.hlsl", o->InputFile.data());
@@ -175,7 +175,7 @@ TEST_F(OptionsTest, ReadOptionsWhenValidThenOK) {
 TEST_F(OptionsTest, ReadOptionsWhenJoinedThenOK) {
   const wchar_t *Args[] = { L"exe.exe", L"/Emain", L"/Tps_6_0", L"hlsl.hlsl" };
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   VERIFY_ARE_EQUAL_STR("main", o->EntryPoint.data());
   VERIFY_ARE_EQUAL_STR("ps_6_0", o->TargetProfile.data());
   VERIFY_ARE_EQUAL_STR("hlsl.hlsl", o->InputFile.data());
@@ -186,7 +186,7 @@ TEST_F(OptionsTest, ReadOptionsWhenNoEntryThenOK) {
   // set to 'main' on behalf of callers either.
   const wchar_t *Args[] = { L"exe.exe", L"/T", L"ps_6_0", L"hlsl.hlsl" };
   MainArgsArr ArgsArr(Args);
-  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxrFlags);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
   VERIFY_IS_TRUE(o->EntryPoint.empty());
 }
 
@@ -202,11 +202,11 @@ TEST_F(OptionsTest, ReadOptionsWhenInvalidThenFail) {
   MainArgsArr ArgsNoTargetArr(ArgsNoTarget),
       ArgsNoInputArr(ArgsNoInput), ArgsNoArgArr(ArgsNoArg),
     ArgsUnknownArr(ArgsUnknown), ArgsUnknownButIgnoreArr(ArgsUnknownButIgnore);
-  ReadOptsTest(ArgsNoTargetArr, DxrFlags, true, true);
-  ReadOptsTest(ArgsNoInputArr, DxrFlags, true, true);
-  ReadOptsTest(ArgsNoArgArr, DxrFlags, true, true);
-  ReadOptsTest(ArgsUnknownArr, DxrFlags, true, true);
-  ReadOptsTest(ArgsUnknownButIgnoreArr, DxrFlags);
+  ReadOptsTest(ArgsNoTargetArr, DxcFlags, true, true);
+  ReadOptsTest(ArgsNoInputArr, DxcFlags, true, true);
+  ReadOptsTest(ArgsNoArgArr, DxcFlags, true, true);
+  ReadOptsTest(ArgsUnknownArr, DxcFlags, true, true);
+  ReadOptsTest(ArgsUnknownButIgnoreArr, DxcFlags);
 }
 
 TEST_F(OptionsTest, ReadOptionsWhenDefinesThenInit) {
@@ -219,22 +219,22 @@ TEST_F(OptionsTest, ReadOptionsWhenDefinesThenInit) {
       ArgsTwoDefinesArr(ArgsTwoDefines), ArgsEmptyDefineArr(ArgsEmptyDefine);
 
   std::unique_ptr<DxcOpts> o;
-  o = ReadOptsTest(ArgsNoDefinesArr, DxrFlags);
+  o = ReadOptsTest(ArgsNoDefinesArr, DxcFlags);
   EXPECT_EQ(0U, o->Defines.size());
   
-  o = ReadOptsTest(ArgsOneDefineArr, DxrFlags);
+  o = ReadOptsTest(ArgsOneDefineArr, DxcFlags);
   EXPECT_EQ(1U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_STREQW(L"1", o->Defines.data()[0].Value);
 
-  o = ReadOptsTest(ArgsTwoDefinesArr, DxrFlags);
+  o = ReadOptsTest(ArgsTwoDefinesArr, DxcFlags);
   EXPECT_EQ(2U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_STREQW(L"1", o->Defines.data()[0].Value);
   EXPECT_STREQW(L"NAME2", o->Defines.data()[1].Name);
   EXPECT_STREQW(L"2", o->Defines.data()[1].Value);
 
-  o = ReadOptsTest(ArgsEmptyDefineArr, DxrFlags);
+  o = ReadOptsTest(ArgsEmptyDefineArr, DxcFlags);
   EXPECT_EQ(1U, o->Defines.size());
   EXPECT_STREQW(L"NAME1", o->Defines.data()[0].Name);
   EXPECT_EQ(nullptr, o->Defines.data()[0].Value);


### PR DESCRIPTION
- Added rewriter functions for extracting uniforms into global scope
- Will not work if name collides (namespaces have bugs)
- Values under cbuffer _Params, resources outside (more bugs)
- Added rewriter HLSLOptions and support all through RewriteWithOptions
- Refactored dxr.exe to use HLSLOptions and RewriteWithOptions
- Exposed Write*VersionInfo functions from dxclib
- Fixed issue with External[Lib/Fn] for version printing.