### PR TITLE
Add option to hctbuild.cmd to skip building dxilconv.dll and related tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(HLSL_ENABLE_FIXED_VER "Reads version information from a file." OFF) # HLS
 
 option(HLSL_ENABLE_ANALYZE "Enables compiler analysis during compilation." OFF) # HLSL Change
 option(HLSL_OPTIONAL_PROJS_IN_DEFAULT "Include optional projects in default build target." OFF) # HLSL Change
+option(HLSL_BUILD_DXILCONV "Include DXBC to DXIL converter and tools." ON) # HLSL Change
 
 # HLSL Change Starts - support commit querying
 option(HLSL_SUPPORT_QUERY_GIT_COMMIT_INFO "Supports querying Git commit info." ON)

--- a/projects/CMakeLists.txt
+++ b/projects/CMakeLists.txt
@@ -1,3 +1,3 @@
-if(WIN32)
+if(WIN32 AND HLSL_BUILD_DXILCONV)
   add_subdirectory(dxilconv)
 endif (WIN32)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -13,7 +13,10 @@ else()
   ignore_llvm_tool_subdirectory(llvm-shlib)
 endif()
 
+if (HLSL_BUILD_DXILCONV) # HLSL Change
 add_llvm_tool_subdirectory(opt) # HLSL Change
+endif()
+
 # add_llvm_tool_subdirectory(llvm-as) # HLSL Change
 # add_llvm_tool_subdirectory(llvm-dis) # HLSL Change
 # add_llvm_tool_subdirectory(llvm-mc) # HLSL Change

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -56,6 +56,7 @@ set FIXED_LOC=
 set VENDOR=
 set SPIRV=OFF
 set SPV_TEST=OFF
+set DXILCONV=ON
 
 if "%1"=="-s" (
   set DO_BUILD=0
@@ -159,6 +160,11 @@ if "%1"=="-no-parallel" (
   shift /1
 )
 
+if "%1"=="-no-dxilconv" (
+  set DXILCONV=OFF
+  shift /1
+)
+
 rem If only VS 2017 is available, pick that by default.
 if "%BUILD_VS_VER%"=="2015" (
   reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\vs\Servicing\14.0\devenv /v Install /reg:32 1>nul 2>nul
@@ -212,6 +218,7 @@ set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_ENABLE_ANALYZE:BOOL=%ANALYZE%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_OFFICIAL_BUILD:BOOL=%OFFICIAL%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_ENABLE_FIXED_VER:BOOL=%FIXED_VER%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_ENABLE_FIXED_VER:BOOL=%FIXED_VER% -DHLSL_FIXED_VERSION_LOCATION:STRING=%FIXED_LOC%
+set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_BUILD_DXILCONV:BOOL=%DXILCONV%
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_VENDOR:STRING=%VENDOR%
 set CMAKE_OPTS=%CMAKE_OPTS% -DENABLE_SPIRV_CODEGEN:BOOL=%SPIRV%
 set CMAKE_OPTS=%CMAKE_OPTS% -DSPIRV_BUILD_TESTS:BOOL=%SPV_TEST%
@@ -289,7 +296,7 @@ exit /b 0
 echo Builds HLSL solutions and the product and test binaries for the current
 echo flavor and architecture.
 echo.
-echo hctbuild [-s or -b] [-alldef] [-analyze] [-official] [-fv] [-fvloc <path>] [-rel] [-arm or -arm64 or -x86 or -x64] [-Release] [-Debug] [-vs2015] [-ninja] [-tblgen path] [-dont-speak] [-parallel]
+echo hctbuild [-s or -b] [-alldef] [-analyze] [-official] [-fv] [-fvloc <path>] [-rel] [-arm or -arm64 or -x86 or -x64] [-Release] [-Debug] [-vs2015] [-ninja] [-tblgen path] [-dont-speak] [-no-parallel] [-no-dxilconv]
 echo.
 echo   -s   creates the projects only, without building
 echo   -b   builds the existing project
@@ -302,6 +309,7 @@ echo   -fvloc <path>  directory with the version.inc file
 echo   -rel           builds release rather than debug
 echo   -dont-speak    disables audible build confirmation
 echo   -no-parallel   disables parallel build
+echo   -no-dxilconv   disables build of DXBC to DXIL converter and tools
 echo.
 echo current BUILD_ARCH=%BUILD_ARCH%.  Override with:
 echo   -x86 targets an x86 build (aka. Win32)


### PR DESCRIPTION
The recently added DXBC to DXIL converter requires header d3d12TokenizedProgramFormat.hpp from the latest Windows Driver Kit (version 10.0.18362.0) and therefore introduces a build dependency on the latest WDK.

This PR adds an option to hctbuild.cmd that enables a build of DXC without the converter and latest WDK.