### PR TITLE
[linux] Initialize m_count for IUnknown

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -592,6 +592,7 @@ template <typename T> inline void **IID_PPV_ARGS_Helper(T **pp) {
 //===--------------------- COM Interfaces ---------------------------------===//
 
 struct __declspec(uuid("00000000-0000-0000-C000-000000000046")) IUnknown {
+  IUnknown() : m_count(0) {};
   virtual HRESULT QueryInterface(REFIID riid, void **ppvObject) = 0;
   virtual ULONG AddRef();
   virtual ULONG Release();


### PR DESCRIPTION
The Linux adapter code includes an implementation of the IUnknown
interface that contains m_count to keep track of the reference counts.
That variable is used extensively, but is not initialized.

Complaints about use before initialization due to this make up the
overwhelming majority of the complaints Valgrind makes against DXC on
Linux. Adding a constructor makes IUnknown no longer an interface,
but the build doesn't seem to care.