### PR TITLE
Add support for SPV_KHR_ray_tracing.

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2959,6 +2959,8 @@ Flow chart for various stages in a raytracing pipeline is as follows:
 
 | *Note : DXC does not add special shader profiles for raytracing under -T option.*
 | *All raytracing shaders must be compiled as library using lib_6_3/lib_6_4 profile option.*
+| *Note: To compile for cross vendor KHR extension use -fspv-extension=SPV_KHR_ray_tracing.*
+| *This extension is provisional and subject to change*.
 
 Ray Generation Stage
 ~~~~~~~~~~~~~~~~~~~~
@@ -3187,9 +3189,11 @@ Mesh Interface Variables
 Raytracing in Vulkan and SPIRV
 ==============================
 
-| SPIR-V codegen is currently supported for NVIDIA platforms via SPV_NV_ray_tracing extension
+| SPIR-V codegen is currently supported for NVIDIA platforms via SPV_NV_ray_tracing extension or
+| on other platforms via provisional cross vendor SPV_KHR_ray_tracing extension.
 | SPIR-V specification for reference:
 | https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/NV/SPV_NV_ray_tracing.asciidoc
+| https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_ray_tracing.asciidoc
 
 | Vulkan ray tracing samples:
 | https://developer.nvidia.com/rtx/raytracing/vkray
@@ -3204,47 +3208,48 @@ Intrinsics
 
 | Following table provides mapping for system value intrinsics along with supported shader stages.
 
-============================    ============================ ====== ============ =========== ======= ======== ========
-        HLSL                               SPIR-V                             HLSL Shader Stage
-----------------------------    ---------------------------- ---------------------------------------------------------
-  System Value Intrinsic               Builtin               Raygen Intersection Closest Hit Any Hit   Miss   Callable
-============================    ============================ ====== ============ =========== ======= ======== ========
-``DispatchRaysIndex()``         ``LaunchIdNV``                 ✓         ✓            ✓        ✓      ✓        ✓
-``DispatchRaysDimensions()``    ``LaunchSizeNV``               ✓         ✓            ✓        ✓      ✓        ✓
-``WorldRayOrigin()``            ``WorldRayOriginNV``                     ✓            ✓        ✓      ✓
-``WorldRayDirection()``         ``WorldRayDirectionNV``                  ✓            ✓        ✓      ✓
-``RayTMin()``                   ``RayTminNV``                            ✓            ✓        ✓      ✓
-``RayTCurrent()``               ``HitTNV``                               ✓            ✓        ✓      ✓
-``RayFlags()``                  ``IncomingRayFlagsNV``                   ✓            ✓        ✓      ✓
-``InstanceIndex()``             ``InstanceId``                           ✓            ✓        ✓
-``InstanceID()``                ``InstanceCustomIndexNV``                ✓            ✓        ✓
-``PrimitiveIndex()``            ``PrimitiveId``                          ✓            ✓        ✓
-``ObjectRayOrigin()``           ``ObjectRayOriginNV``                    ✓            ✓        ✓
-``ObjectRayDirection()``        ``ObjectRayDirectionNV``                 ✓            ✓        ✓
-``ObjectToWorld3x4()``          ``ObjectToWorldNV``                      ✓            ✓        ✓
-``ObjectToWorld4x3()``          ``ObjectToWorldNV``                      ✓            ✓        ✓
-``WorldToObject3x4()``          ``WorldToObjectNV``                      ✓            ✓        ✓
-``WorldToObject4x3()``          ``WorldToObjectNV``                      ✓            ✓        ✓
-``HitKind()``                   ``HitKindNV``                            ✓            ✓        ✓
-============================    ============================ ====== ============ =========== ======= ======== ========
+============================    ===============================    ====== ============ =========== ======= ======== ========
+        HLSL                               SPIR-V                               HLSL Shader Stage
+----------------------------    -------------------------------    ---------------------------------------------------------
+  System Value Intrinsic               Builtin                     Raygen Intersection Closest Hit Any Hit   Miss   Callable
+============================    ===============================    ====== ============ =========== ======= ======== ========
+``DispatchRaysIndex()``         ``LaunchId{NV/KHR}``               ✓       ✓             ✓          ✓       ✓       ✓
+``DispatchRaysDimensions()``    ``LaunchSize{NV/KHR}``             ✓       ✓             ✓          ✓       ✓       ✓
+``WorldRayOrigin()``            ``WorldRayOrigin{NV/KHR}``                 ✓             ✓          ✓       ✓
+``WorldRayDirection()``         ``WorldRayDirection{NV/KHR}``              ✓             ✓          ✓       ✓
+``RayTMin()``                   ``RayTmin{NV/KHR}``                        ✓             ✓          ✓       ✓
+``RayTCurrent()``               ``HitT{NV/KHR}``                           ✓             ✓          ✓       ✓
+``RayFlags()``                  ``IncomingRayFlags{NV/KHR}``               ✓             ✓          ✓       ✓
+``InstanceIndex()``             ``InstanceId``                             ✓             ✓          ✓
+``GeometryIndex()``             ``RayGeometryIndexKHR``                    ✓             ✓          ✓
+``InstanceID()``                ``InstanceCustomIndex{NV/KHR}``            ✓             ✓          ✓
+``PrimitiveIndex()``            ``PrimitiveId``                            ✓             ✓          ✓
+``ObjectRayOrigin()``           ``ObjectRayOrigin{NV/KHR}``                ✓             ✓          ✓
+``ObjectRayDirection()``        ``ObjectRayDirection{NV/KHR}``             ✓             ✓          ✓
+``ObjectToWorld3x4()``          ``ObjectToWorld{NV/KHR}``                  ✓             ✓          ✓
+``ObjectToWorld4x3()``          ``ObjectToWorld{NV/KHR}``                  ✓             ✓          ✓
+``WorldToObject3x4()``          ``WorldToObject{NV/KHR}``                  ✓             ✓          ✓
+``WorldToObject4x3()``          ``WorldToObject{NV/KHR}``                  ✓             ✓          ✓
+``HitKind()``                   ``HitKind{NV/KHR}``                        ✓             ✓          ✓
+============================    ===============================    ====== ============ =========== ======= ======== ========
 
 | *There is no separate builtin for transposed matrices ObjectToWorld3x4 and WorldToObject3x4 in SPIR-V hence we internally transpose during translation*
-
+| *GeometryIndex() is only supported under SPV_KHR_ray_tracing extension.*
 
 | Following table provides mapping for other intrinsics along with supported shader stages.
 
 
-===========================     ============================ ====== ============ =========== ======= ===== ========
-        HLSL                               SPIR-V                             HLSL Shader Stage
----------------------------     ---------------------------- ------------------------------------------------------
-   Intrinsic                              Opcode             Raygen Intersection Closest Hit Any Hit  Miss Callable
-===========================     ============================ ====== ============ =========== ======= ===== ========
-``TraceRay``                    ``OpTraceNV``                  ✓                     ✓                ✓
-``ReportHit``                   ``OpReportIntersectionNV``     ✓         ✓
-``IgnoreHit``                   ``OpIgnoreIntersectionNV``     ✓                                ✓
-``AcceptHitAndEndSearch``       ``OpTerminateRayNV``           ✓                                ✓
-``CallShader``                  ``OpExecuteCallable``          ✓                     ✓                ✓      ✓
-===========================     ============================ ====== ============ =========== ======= ===== ========
+===========================     =================================     ====== ============ =========== ======= ===== ========
+        HLSL                               SPIR-V                                 HLSL Shader Stage
+---------------------------     ---------------------------------     ------------------------------------------------------
+   Intrinsic                              Opcode                      Raygen Intersection Closest Hit Any Hit  Miss Callable
+===========================     =================================     ====== ============ =========== ======= ===== ========
+``TraceRay``                    ``OpTrace{NV/KHR}``                     ✓                    ✓                    ✓
+``ReportHit``                   ``OpReportIntersection{NV/KHR}``        ✓         ✓
+``IgnoreHit``                   ``OpIgnoreIntersection{NV/KHR}``        ✓                             ✓
+``AcceptHitAndEndSearch``       ``OpTerminateRay{NV/KHR}``              ✓                             ✓
+``CallShader``                  ``OpExecuteCallable{NV/KHR}``           ✓                    ✓             ✓     ✓
+===========================     =================================     ====== ============ =========== ======= ===== ========
 
 
 Resource Types
@@ -3253,11 +3258,11 @@ Resource Types
 | Following table provides mapping for new resource types supported in all raytracing shaders.
 
 
-===================================     =================================
-        HLSL Type                               SPIR-V Opcode
------------------------------------     ---------------------------------
-``RaytracingAccelerationStructure``     ``OpTypeAccelerationStructureNV``
-===================================     =================================
+===================================     =======================================
+        HLSL Type                                   SPIR-V Opcode
+-----------------------------------     ---------------------------------------
+``RaytracingAccelerationStructure``     ``OpTypeAccelerationStructure{NV/KHR}``
+===================================     =======================================
 
 Interface Variables
 ~~~~~~~~~~~~~~~~~~~
@@ -3266,15 +3271,15 @@ Interface Variables
 | Following table gives high level overview of the mapping.
 
 
-===========================     ===========================================================
-   SPIR-V Storage Class                Created For
----------------------------     -----------------------------------------------------------
-``RayPayloadNV``                Last argument to TraceRay
-``IncomingRayPayloadNV``        First argument of entry for AnyHit/ClosestHit & Miss stage
-``HitAttributeNV``              Last argument to ReportHit
-``CallableDataNV``              Last argument to CallShader
-``IncomingCallableDataNV``      First argument of entry for Callable stage
-===========================     ===========================================================
+=================================       ===========================================================
+   SPIR-V Storage Class                        Created For
+---------------------------------       -----------------------------------------------------------
+``RayPayload{NV/KHR}``                  Last argument to TraceRay
+``IncomingRayPayload{NV/KHR}``          First argument of entry for AnyHit/ClosestHit & Miss stage
+``HitAttribute{NV/KHR}``                Last argument to ReportHit
+``CallableData{NV/KHR}``                Last argument to CallShader
+``IncomingCallableData{NV/KHR}``        First argument of entry for Callable stage
+=================================       ===========================================================
 
 
 Shader Model 6.0 Wave Intrinsics

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2959,8 +2959,9 @@ Flow chart for various stages in a raytracing pipeline is as follows:
 
 | *Note : DXC does not add special shader profiles for raytracing under -T option.*
 | *All raytracing shaders must be compiled as library using lib_6_3/lib_6_4 profile option.*
-| *Note: To compile for cross vendor KHR extension use -fspv-extension=SPV_KHR_ray_tracing.*
+| *Note : DXC now targets SPV_KHR_ray_tracing extension by default.
 | *This extension is provisional and subject to change*.
+| *To compile for cross vendor KHR extension use -fspv-extension=SPV_NV_ray_tracing.*
 
 Ray Generation Stage
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2959,7 +2959,7 @@ Flow chart for various stages in a raytracing pipeline is as follows:
 
 | *Note : DXC does not add special shader profiles for raytracing under -T option.*
 | *All raytracing shaders must be compiled as library using lib_6_3/lib_6_4 profile option.*
-| *Note : DXC now targets SPV_KHR_ray_tracing extension by default.
+| *Note : DXC now targets SPV_KHR_ray_tracing extension by default.*
 | *This extension is provisional and subject to change*.
 | *To compile for cross vendor KHR extension use -fspv-extension=SPV_NV_ray_tracing.*
 

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2961,7 +2961,7 @@ Flow chart for various stages in a raytracing pipeline is as follows:
 | *All raytracing shaders must be compiled as library using lib_6_3/lib_6_4 profile option.*
 | *Note : DXC now targets SPV_KHR_ray_tracing extension by default.*
 | *This extension is provisional and subject to change*.
-| *To compile for cross vendor KHR extension use -fspv-extension=SPV_NV_ray_tracing.*
+| *To compile for NV extension use -fspv-extension=SPV_NV_ray_tracing.*
 
 Ray Generation Stage
 ~~~~~~~~~~~~~~~~~~~~

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -34,6 +34,7 @@ enum class Extension {
   KHR_multiview,
   KHR_shader_draw_parameters,
   KHR_post_depth_coverage,
+  KHR_ray_tracing,
   EXT_descriptor_indexing,
   EXT_fragment_fully_covered,
   EXT_fragment_invocation_density,
@@ -86,6 +87,9 @@ public:
   /// Returns true if the given extension is not part of the core of the target
   /// environment.
   bool isExtensionRequiredForTargetEnv(Extension);
+
+  /// Returns true if the given extension is set in allowedExtensions
+  bool isExtensionEnabled(llvm::StringRef name);
 
 private:
   /// \brief Wrapper method to create an error message and report it

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -503,8 +503,13 @@ bool CapabilityVisitor::visit(SpirvEntryPoint *entryPoint) {
   case spv::ExecutionModel::AnyHitNV:
   case spv::ExecutionModel::MissNV:
   case spv::ExecutionModel::CallableNV:
-    addCapability(spv::Capability::RayTracingNV);
-    addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
+    if (featureManager.isExtensionEnabled("SPV_NV_ray_tracing")) {
+      addCapability(spv::Capability::RayTracingNV);
+      addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
+    } else {
+      addCapability(spv::Capability::RayTracingProvisionalKHR);
+      addExtension(Extension::KHR_ray_tracing, "SPV_KHR_ray_tracing", {});
+    }
     break;
   case spv::ExecutionModel::MeshNV:
   case spv::ExecutionModel::TaskNV:

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2585,6 +2585,7 @@ SpirvVariable *DeclResultIdMapper::getBuiltinVar(spv::BuiltIn builtIn,
   case spv::BuiltIn::HitKindNV:
   case spv::BuiltIn::IncomingRayFlagsNV:
   case spv::BuiltIn::InstanceCustomIndexNV:
+  case spv::BuiltIn::RayGeometryIndexKHR:
   case spv::BuiltIn::PrimitiveId:
   case spv::BuiltIn::InstanceId:
   case spv::BuiltIn::WorldRayDirectionNV:

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -23,7 +23,10 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
   if (opts.allowedExtensions.empty()) {
     // If no explicit extension control from command line, use the default mode:
     // allowing all extensions.
+    // Special case : KHR_ray_tracing and NV_ray_tracing are mutually exclusive
+    // so enable only NV extension by default (for compatibility)
     allowAllKnownExtensions();
+    allowedExtensions.reset(static_cast<unsigned>(Extension::KHR_ray_tracing));
   } else {
     for (auto ext : opts.allowedExtensions)
       allowExtension(ext);
@@ -103,6 +106,7 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_KHR_multiview", Extension::KHR_multiview)
       .Case("SPV_KHR_shader_draw_parameters",
             Extension::KHR_shader_draw_parameters)
+      .Case("SPV_KHR_ray_tracing", Extension::KHR_ray_tracing)
       .Case("SPV_EXT_descriptor_indexing", Extension::EXT_descriptor_indexing)
       .Case("SPV_EXT_fragment_fully_covered",
             Extension::EXT_fragment_fully_covered)
@@ -140,6 +144,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_KHR_shader_draw_parameters";
   case Extension::KHR_post_depth_coverage:
     return "SPV_KHR_post_depth_coverage";
+  case Extension::KHR_ray_tracing:
+    return "SPV_KHR_ray_tracing";
   case Extension::EXT_descriptor_indexing:
     return "SPV_EXT_descriptor_indexing";
   case Extension::EXT_fragment_fully_covered:
@@ -213,6 +219,15 @@ bool FeatureManager::isExtensionRequiredForTargetEnv(Extension ext) {
   }
 
   return required;
+}
+
+bool FeatureManager::isExtensionEnabled(llvm::StringRef name) {
+  bool allowed = false;
+  Extension ext = getExtensionSymbol(name);
+  if (ext != Extension::Unknown &&
+      allowedExtensions.test(static_cast<unsigned>(ext)))
+    allowed = true;
+  return allowed;
 }
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -24,9 +24,9 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
     // If no explicit extension control from command line, use the default mode:
     // allowing all extensions.
     // Special case : KHR_ray_tracing and NV_ray_tracing are mutually exclusive
-    // so enable only NV extension by default (for compatibility)
+    // so enable only KHR extension by default
     allowAllKnownExtensions();
-    allowedExtensions.reset(static_cast<unsigned>(Extension::KHR_ray_tracing));
+    allowedExtensions.reset(static_cast<unsigned>(Extension::NV_ray_tracing));
   } else {
     for (auto ext : opts.allowedExtensions)
       allowExtension(ext);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7097,6 +7097,7 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
   // DXR raytracing intrinsics
   case hlsl::IntrinsicOp::IOP_DispatchRaysDimensions:
   case hlsl::IntrinsicOp::IOP_DispatchRaysIndex:
+  case hlsl::IntrinsicOp::IOP_GeometryIndex:
   case hlsl::IntrinsicOp::IOP_HitKind:
   case hlsl::IntrinsicOp::IOP_InstanceIndex:
   case hlsl::IntrinsicOp::IOP_InstanceID:
@@ -9418,6 +9419,11 @@ SpirvInstruction *SpirvEmitter::processRayBuiltins(const CallExpr *callExpr,
     break;
   case hlsl::IntrinsicOp::IOP_ObjectRayOrigin:
     builtin = spv::BuiltIn::ObjectRayOriginNV;
+    break;
+  case hlsl::IntrinsicOp::IOP_GeometryIndex:
+    featureManager.requestExtension(Extension::KHR_ray_tracing,
+                                    "GeometryIndex()", loc);
+    builtin = spv::BuiltIn::RayGeometryIndexKHR;
     break;
   case hlsl::IntrinsicOp::IOP_InstanceIndex:
     builtin = spv::BuiltIn::InstanceId;

--- a/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
@@ -1,0 +1,82 @@
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_KHR_ray_tracing
+// CHECK:  OpCapability RayTracingProvisionalKHR
+// CHECK:  OpExtension "SPV_KHR_ray_tracing"
+// CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV
+// CHECK:  OpDecorate [[b:%\d+]] BuiltIn LaunchSizeNV
+// CHECK:  OpDecorate [[c:%\d+]] BuiltIn WorldRayOriginNV
+// CHECK:  OpDecorate [[d:%\d+]] BuiltIn WorldRayDirectionNV
+// CHECK:  OpDecorate [[e:%\d+]] BuiltIn RayTminNV
+// CHECK:  OpDecorate [[f:%\d+]] BuiltIn IncomingRayFlagsNV
+// CHECK:  OpDecorate %gl_InstanceID BuiltIn InstanceId
+// CHECK:  OpDecorate [[g:%\d+]] BuiltIn InstanceCustomIndexNV
+// CHECK:  OpDecorate %gl_PrimitiveID BuiltIn PrimitiveId
+// CHECK:  OpDecorate [[h:%\d+]] BuiltIn ObjectRayOriginNV
+// CHECK:  OpDecorate [[i:%\d+]] BuiltIn ObjectRayDirectionNV
+// CHECK:  OpDecorate [[j:%\d+]] BuiltIn ObjectToWorldNV
+// CHECK:  OpDecorate [[k:%\d+]] BuiltIn WorldToObjectNV
+// CHECK:  OpDecorate [[l:%\d+]] BuiltIn HitKindNV
+// CHECK:  OpDecorate [[m:%\d+]] BuiltIn RayGeometryIndexKHR
+
+// CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
+struct Payload
+{
+  float4 color;
+};
+// CHECK:  OpTypePointer HitAttributeNV %Attribute
+struct Attribute
+{
+  float2 bary;
+};
+
+// CHECK-COUNT-1: [[rstype:%\d+]] = OpTypeAccelerationStructureNV
+RaytracingAccelerationStructure rs;
+
+[shader("closesthit")]
+void main(inout Payload MyPayload, in Attribute MyAttr) {
+
+// CHECK:  OpLoad %v3uint [[a]]
+  uint3 _1 = DispatchRaysIndex();
+// CHECK:  OpLoad %v3uint [[b]]
+  uint3 _2 = DispatchRaysDimensions();
+// CHECK:  OpLoad %v3float [[c]]
+  float3 _3 = WorldRayOrigin();
+// CHECK:  OpLoad %v3float [[d]]
+  float3 _4 = WorldRayDirection();
+// CHECK:  OpLoad %float [[e]]
+  float _5 = RayTMin();
+// CHECK:  OpLoad %uint [[f]]
+  uint _6 = RayFlags();
+// CHECK:  OpLoad %uint %gl_InstanceID
+  uint _7 = InstanceIndex();
+// CHECK:  OpLoad %uint [[g]]
+  uint _8 = InstanceID();
+// CHECK:  OpLoad %uint %gl_PrimitiveID
+  uint _9 = PrimitiveIndex();
+// CHECK:  OpLoad %v3float [[h]]
+  float3 _10 = ObjectRayOrigin();
+// CHECK:  OpLoad %v3float [[i]]
+  float3 _11 = ObjectRayDirection();
+// CHECK: [[matotw:%\d+]] = OpLoad %mat4v3float [[j]]
+// CHECK-NEXT: OpTranspose %mat3v4float [[matotw]]
+  float3x4 _12 = ObjectToWorld3x4();
+// CHECK:  OpLoad %mat4v3float [[j]]
+  float4x3 _13 = ObjectToWorld4x3();
+// CHECK: [[matwto:%\d+]] = OpLoad %mat4v3float [[k]]
+// CHECK-NEXT: OpTranspose %mat3v4float [[matwto]]
+  float3x4 _14 = WorldToObject3x4();
+// CHECK:  OpLoad %mat4v3float [[k]]
+  float4x3 _15 = WorldToObject4x3();
+// CHECK:  OpLoad %uint [[l]]
+  uint _16 = HitKind();
+// CHECK:  OpLoad %uint [[m]]
+  uint _17 = GeometryIndex();
+
+  Payload myPayload = { float4(0.0f,0.0f,0.0f,0.0f) };
+  RayDesc rayDesc;
+  rayDesc.Origin = float3(0.0f, 0.0f, 0.0f);
+  rayDesc.Direction = float3(0.0f, 0.0f, -1.0f);
+  rayDesc.TMin = 0.0f;
+  rayDesc.TMax = 1000.0f;
+// CHECK: OpTraceNV {{%\d+}} %uint_0 %uint_255 %uint_0 %uint_1 %uint_0 {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}} %uint_0
+  TraceRay(rs, 0x0, 0xff, 0, 1, 0, rayDesc, myPayload);
+}

--- a/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.khr.closesthit.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3 -fspv-extension=SPV_KHR_ray_tracing
+// Run: %dxc -T lib_6_3
 // CHECK:  OpCapability RayTracingProvisionalKHR
 // CHECK:  OpExtension "SPV_KHR_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.anyhit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.anyhit.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.callable.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.callable.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.closesthit.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.enum.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.library.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.library.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpEntryPoint RayGenerationNV %MyRayGenMain "MyRayGenMain" {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}} %gl_InstanceID {{%\d+}} %gl_PrimitiveID {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}} {{%\d+}}

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.miss.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.miss.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.raygen.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.raygen.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T lib_6_3
+// Run: %dxc -T lib_6_3 -fspv-extension=SPV_NV_ray_tracing
 // CHECK:  OpCapability RayTracingNV
 // CHECK:  OpExtension "SPV_NV_ray_tracing"
 // CHECK:  OpDecorate [[a:%\d+]] BuiltIn LaunchIdNV

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2090,6 +2090,11 @@ TEST_F(FileTest, RayTracingNVLibrary) {
   runFileTest("raytracing.nv.library.hlsl");
 }
 
+// === Raytracing KHR examples ===
+TEST_F(FileTest, RayTracingKHRClosestHit) {
+  runFileTest("raytracing.khr.closesthit.hlsl");
+}
+
 // For decoration uniqueness
 TEST_F(FileTest, DecorationUnique) { runFileTest("decoration.unique.hlsl"); }
 


### PR DESCRIPTION
Added support for generating SPIR-V for provisional cross vendor spec.
By default we generate code for NV extension(to preserve compatibility) and enable KHR extension using -fspv-extension=SPV_KHR_ray_tracing

Note: Opcodes for KHR extension alias with NV other than below

1) GeometryIndex() is supported only in KHR extension.
2) New Capability : CapabilityRayTracingProvisionalKHR.

Added unit test and updated documentation

Once provisional spec is ratified to final, i plan to cleanup existing NV suffixes used for various internal symbols( for ex IK_RayTracingOpNV) and generate code for KHR by default

@ehsannas @jaebaek : Please review or redirect to appropriate folks
Thanks!


