### PR TITLE
Fix static global resource arrays.

### DIFF
--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -18,6 +18,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
 #include <unordered_set>
@@ -184,11 +185,18 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
       GlobalVariable *GV = *(it++);
       // Build list of instructions to promote.
       for (User *U : GV->users()) {
-        Instruction *I = cast<Instruction>(U);
-        Insts.emplace_back(I);
+        if (isa<LoadInst>(U) || isa<StoreInst>(U)) {
+          Insts.emplace_back(cast<Instruction>(U));
+        } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
+          for (User *gepU : GEP->users()) {
+            DXASSERT_NOMSG(isa<LoadInst>(gepU) || isa<StoreInst>(gepU));
+            Insts.emplace_back(cast<Instruction>(gepU));
+          }
+        }
       }
 
       LoadAndStorePromoter(Insts, SSA).run(Insts);
+      GV->removeDeadConstantUsers();
       if (GV->user_empty()) {
         bUpdated = true;
         staticResources.erase(GV);

--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -190,8 +190,11 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
         } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
           for (User *gepU : GEP->users()) {
             DXASSERT_NOMSG(isa<LoadInst>(gepU) || isa<StoreInst>(gepU));
-            Insts.emplace_back(cast<Instruction>(gepU));
+            if (isa<LoadInst>(gepU) || isa<StoreInst>(gepU))
+              Insts.emplace_back(cast<Instruction>(gepU));
           }
+        } else {
+          DXASSERT(false, "Unhandled user of resource static global");
         }
       }
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3307,8 +3307,9 @@ bool SROA_Helper::DoScalarReplacement(GlobalVariable *GV,
     }
 
     if (ElTy->isStructTy() &&
-        // Skip Matrix type.
-        !HLMatrixType::isa(ElTy)) {
+        // Skip Matrix and Resource type.
+        !HLMatrixType::isa(ElTy) &&
+        !dxilutil::IsHLSLResourceType(ElTy)) {
       // for array of struct
       // split into arrays of struct elements
       StructType *ElST = cast<StructType>(ElTy);

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -6254,9 +6254,7 @@ public:
         staticGVs.emplace_back(&GV);
       } else {
         // Lower static [array of] resources
-        while (EltTy->isArrayTy())
-          EltTy = EltTy->getArrayElementType();
-        if (dxilutil::IsHLSLObjectType(EltTy)) {
+        if (dxilutil::IsHLSLObjectType(dxilutil::GetArrayEltTy(EltTy))) {
           staticGVs.emplace_back(&GV);
         }
       }

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_res_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_res_array.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// CHECK: @dx.op.textureLoad.f32(i32 66,
+
+Texture2D<float4> A, B;
+
+struct ResStruct {
+  Texture2D<float4> arr[2];
+};
+
+static ResStruct RS = { { A, B } };
+
+float4 main() : OUT {
+  return RS.arr[1].Load(uint3(0,0,0));
+}
+
+// TODO: The following still doesn't work because use of DxilValueCache
+// does not extend to LoadAndStorePromoter used in PromoteStaticGlobalResources
+float4 main2() : OUT {
+  float4 result = 0;
+  [unroll]
+  for (uint i = 0; i < 2; i++)
+    result += RS.arr[i].Load(uint3(0,0,0));
+  return result;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_res_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_res_array.hlsl
@@ -1,6 +1,16 @@
 // RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -Od %s | FileCheck %s -check-prefix=CHECKOD
 
 // CHECK: @dx.op.textureLoad.f32(i32 66,
+// CHECK: @dx.op.textureLoad.f32(i32 66,
+// CHECK-NOT: @dx.op.textureLoad.f32(i32 66,
+
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
+// CHECKOD: @dx.op.textureLoad.f32(i32 66,
 
 Texture2D<float4> A, B;
 
@@ -9,17 +19,14 @@ struct ResStruct {
 };
 
 static ResStruct RS = { { A, B } };
+static const ResStruct RS_const = { { A, B } };
 
 float4 main() : OUT {
-  return RS.arr[1].Load(uint3(0,0,0));
-}
-
-// TODO: The following still doesn't work because use of DxilValueCache
-// does not extend to LoadAndStorePromoter used in PromoteStaticGlobalResources
-float4 main2() : OUT {
-  float4 result = 0;
+  float4 result = RS.arr[1].Load(uint3(0,0,0))
+                + RS_const.arr[1].Load(uint3(0,0,0));
   [unroll]
   for (uint i = 0; i < 2; i++)
-    result += RS.arr[i].Load(uint3(0,0,0));
+    result += RS.arr[i].Load(uint3(0,0,0))
+            + RS_const.arr[i].Load(uint3(0,0,0));
   return result;
 }


### PR DESCRIPTION
Fixes #2061 

Additional work needed to support unroll case since GEP not known to be constant there.  Either need simplification between unroll and DxilPromoteStaticResources (no good for /Od case though), or DxilValueCache access in LoadAndStorePromoter.  But not sure LoadAndStorePromoter should be used on static global uses in the first place.  Perhaps an another solution is needed.