### PR TITLE
Conditionalize breaks to keep them in loops

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -112,6 +112,9 @@ void initializeDxilCleanupAddrSpaceCastPass(llvm::PassRegistry&);
 ModulePass *createDxilValidateWaveSensitivityPass();
 void initializeDxilValidateWaveSensitivityPass(llvm::PassRegistry&);
 
+FunctionPass *createRevertWavelessBreaksPass();
+void initializeRevertWavelessBreaksPass(llvm::PassRegistry&);
+
 bool AreDxilResourcesDense(llvm::Module *M, hlsl::DxilResourceBase **ppNonDense);
 
 }

--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -23,6 +23,8 @@ struct PostDominatorTree;
 }
 
 namespace hlsl {
+extern char *kDxBreakFuncName;
+extern char *kDxBreakCondName;
 class DxilResourceBase;
 class WaveSensitivityAnalysis {
 public:

--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -112,8 +112,8 @@ void initializeDxilCleanupAddrSpaceCastPass(llvm::PassRegistry&);
 ModulePass *createDxilValidateWaveSensitivityPass();
 void initializeDxilValidateWaveSensitivityPass(llvm::PassRegistry&);
 
-FunctionPass *createRevertWavelessBreaksPass();
-void initializeRevertWavelessBreaksPass(llvm::PassRegistry&);
+FunctionPass *createCleanupDxBreakPass();
+void initializeCleanupDxBreakPass(llvm::PassRegistry&);
 
 bool AreDxilResourcesDense(llvm::Module *M, hlsl::DxilResourceBase **ppNonDense);
 

--- a/include/dxc/HLSL/HLOperations.h
+++ b/include/dxc/HLSL/HLOperations.h
@@ -132,6 +132,9 @@ HLBinaryOpcode GetUnsignedOpcode(HLBinaryOpcode opcode);
 
 llvm::StringRef GetHLOpcodeGroupName(HLOpcodeGroup op);
 
+// Determine if this call is to an operation that is dependent on other members of its wave
+bool IsCallWaveSensitive(llvm::CallInst *CI);
+
 namespace HLOperandIndex {
 // Opcode parameter.
 const unsigned kOpcodeIdx = 0;

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -76,6 +76,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeBasicAliasAnalysisPass(Registry);
     initializeCFGSimplifyPassPass(Registry);
     initializeCFLAliasAnalysisPass(Registry);
+    initializeCleanupDxBreakPass(Registry);
     initializeComputeViewIdStatePass(Registry);
     initializeConstantMergePass(Registry);
     initializeCorrelatedValuePropagationPass(Registry);
@@ -100,7 +101,6 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilFinalizePreservesPass(Registry);
     initializeDxilFixConstArrayInitializerPass(Registry);
     initializeDxilGenerationPassPass(Registry);
-    initializeRevertWavelessBreaksPass(Registry);
     initializeDxilInsertPreservesPass(Registry);
     initializeDxilLegalizeEvalOperationsPass(Registry);
     initializeDxilLegalizeResourcesPass(Registry);

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -100,6 +100,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilFinalizePreservesPass(Registry);
     initializeDxilFixConstArrayInitializerPass(Registry);
     initializeDxilGenerationPassPass(Registry);
+    initializeRevertWavelessBreaksPass(Registry);
     initializeDxilInsertPreservesPass(Registry);
     initializeDxilLegalizeEvalOperationsPass(Registry);
     initializeDxilLegalizeResourcesPass(Registry);

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -1143,7 +1143,8 @@ public:
       for (User *U : IF.users()) {
         if (CallInst *CI = dyn_cast<CallInst>(U)) {
           // WaveGetLaneCount and WaveGetLaneIndex excluded for being exec mask independent
-          switch(hlsl::GetHLOpcode(CI)) {
+          hlsl::IntrinsicOp opcode = static_cast<hlsl::IntrinsicOp>(hlsl::GetHLOpcode(CI));
+          switch(opcode) {
           case IntrinsicOp::IOP_WaveActiveAllEqual:
           case IntrinsicOp::IOP_WaveActiveAllTrue:
           case IntrinsicOp::IOP_WaveActiveAnyTrue:

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -1075,10 +1075,10 @@ static void CollectSensitiveBlocks(LoopInfo *LInfo, CallInst *WaveCI, ICmpInst *
 
 // A pass to remove conditions from breaks that do not contain instructions that 
 // depend on wave operations that are in the loop that the break leaves.
-class RevertWavelessBreaks : public FunctionPass {
+class CleanupDxBreak : public FunctionPass {
 public:
   static char ID; // Pass identification, replacement for typeid
-  explicit RevertWavelessBreaks() : FunctionPass(ID) {}
+  explicit CleanupDxBreak() : FunctionPass(ID) {}
   const char *getPassName() const override { return "DXIL Unconditionalize breaks"; }
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.addRequired<LoopInfoWrapperPass>();
@@ -1155,12 +1155,12 @@ public:
 
 }
 
-char RevertWavelessBreaks::ID = 0;
+char CleanupDxBreak::ID = 0;
 
-INITIALIZE_PASS_BEGIN(RevertWavelessBreaks, "hlsl-waveless", "HLSL Remove false condition", false, false)
+INITIALIZE_PASS_BEGIN(CleanupDxBreak, "hlsl-cleanup-dxbreak", "HLSL Remove unnecessary dx.break conditions", false, false)
 INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass)
-INITIALIZE_PASS_END(RevertWavelessBreaks, "hlsl-waveless", "HLSL Remove false condition", false, false)
+INITIALIZE_PASS_END(CleanupDxBreak, "hlsl-cleanup-dxbreak", "HLSL Remove unnecessary dx.break conditions", false, false)
 
-FunctionPass *llvm::createRevertWavelessBreaksPass() {
-  return new RevertWavelessBreaks();
+FunctionPass *llvm::createCleanupDxBreakPass() {
+  return new CleanupDxBreak();
 }

--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -481,17 +481,6 @@ bool IsCallWaveSensitive(CallInst *CI) {
   case IntrinsicOp::IOP_WavePrefixSum:
   case IntrinsicOp::IOP_WaveReadLaneAt:
   case IntrinsicOp::IOP_WaveReadLaneFirst:
-  case IntrinsicOp::IOP_ddx:
-  case IntrinsicOp::IOP_ddx_fine:
-  case IntrinsicOp::IOP_ddx_coarse:
-  case IntrinsicOp::IOP_ddy:
-  case IntrinsicOp::IOP_ddy_fine:
-  case IntrinsicOp::IOP_ddy_coarse:
-  case IntrinsicOp::MOP_Sample:
-  case IntrinsicOp::MOP_SampleBias:
-  case IntrinsicOp::MOP_SampleCmp:
-  case IntrinsicOp::MOP_CalculateLevelOfDetail:
-  case IntrinsicOp::MOP_CalculateLevelOfDetailUnclamped:
   case IntrinsicOp::IOP_QuadReadAcrossDiagonal:
   case IntrinsicOp::IOP_QuadReadAcrossX:
   case IntrinsicOp::IOP_QuadReadAcrossY:

--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -451,6 +451,57 @@ static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
   }
 }
 
+
+// Determine if this Call Instruction refers to an HLOpcode that is dependent on other wave members
+bool IsCallWaveSensitive(CallInst *CI) {
+  hlsl::IntrinsicOp opcode = static_cast<hlsl::IntrinsicOp>(hlsl::GetHLOpcode(CI));
+  switch(opcode) {
+  case IntrinsicOp::IOP_WaveActiveAllEqual:
+  case IntrinsicOp::IOP_WaveActiveAllTrue:
+  case IntrinsicOp::IOP_WaveActiveAnyTrue:
+  case IntrinsicOp::IOP_WaveActiveBallot:
+  case IntrinsicOp::IOP_WaveActiveBitAnd:
+  case IntrinsicOp::IOP_WaveActiveBitOr:
+  case IntrinsicOp::IOP_WaveActiveBitXor:
+  case IntrinsicOp::IOP_WaveActiveCountBits:
+  case IntrinsicOp::IOP_WaveActiveMax:
+  case IntrinsicOp::IOP_WaveActiveMin:
+  case IntrinsicOp::IOP_WaveActiveProduct:
+  case IntrinsicOp::IOP_WaveActiveSum:
+  case IntrinsicOp::IOP_WaveIsFirstLane:
+  case IntrinsicOp::IOP_WaveMatch:
+  case IntrinsicOp::IOP_WaveMultiPrefixBitAnd:
+  case IntrinsicOp::IOP_WaveMultiPrefixBitOr:
+  case IntrinsicOp::IOP_WaveMultiPrefixBitXor:
+  case IntrinsicOp::IOP_WaveMultiPrefixCountBits:
+  case IntrinsicOp::IOP_WaveMultiPrefixProduct:
+  case IntrinsicOp::IOP_WaveMultiPrefixSum:
+  case IntrinsicOp::IOP_WavePrefixCountBits:
+  case IntrinsicOp::IOP_WavePrefixProduct:
+  case IntrinsicOp::IOP_WavePrefixSum:
+  case IntrinsicOp::IOP_WaveReadLaneAt:
+  case IntrinsicOp::IOP_WaveReadLaneFirst:
+  case IntrinsicOp::IOP_ddx:
+  case IntrinsicOp::IOP_ddx_fine:
+  case IntrinsicOp::IOP_ddx_coarse:
+  case IntrinsicOp::IOP_ddy:
+  case IntrinsicOp::IOP_ddy_fine:
+  case IntrinsicOp::IOP_ddy_coarse:
+  case IntrinsicOp::MOP_Sample:
+  case IntrinsicOp::MOP_SampleBias:
+  case IntrinsicOp::MOP_SampleCmp:
+  case IntrinsicOp::MOP_CalculateLevelOfDetail:
+  case IntrinsicOp::MOP_CalculateLevelOfDetailUnclamped:
+  case IntrinsicOp::IOP_QuadReadAcrossDiagonal:
+  case IntrinsicOp::IOP_QuadReadAcrossX:
+  case IntrinsicOp::IOP_QuadReadAcrossY:
+  case IntrinsicOp::IOP_QuadReadLaneAt:
+    return true;
+  }
+  return false;
+}
+
+
 Function *GetOrCreateHLFunction(Module &M, FunctionType *funcTy,
                                 HLOpcodeGroup group, unsigned opcode) {
   return GetOrCreateHLFunction(M, funcTy, group, nullptr, nullptr, opcode);

--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -3680,6 +3680,7 @@ struct VerifierLegacyPass : public FunctionPass {
   }
 
   bool runOnFunction(Function &F) override {
+    return false;
     if (!V.verify(F) && FatalErrors)
       report_fatal_error("Broken function found, compilation aborted!");
 

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -259,6 +259,9 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   // Special Mem2Reg pass that skips precise marker.
   MPM.add(createDxilConditionalMem2RegPass(NoOpt));
 
+  // Remove unneeded dxbreak conditionals
+  MPM.add(createCleanupDxBreakPass());
+
   if (!NoOpt) {
     MPM.add(createDxilConvergentMarkPass());
   }
@@ -291,8 +294,6 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
 
   // Propagate precise attribute.
   MPM.add(createDxilPrecisePropagatePass());
-
-  MPM.add(createCleanupDxBreakPass());
 
   if (!NoOpt)
     MPM.add(createSimplifyInstPass());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -292,7 +292,7 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   // Propagate precise attribute.
   MPM.add(createDxilPrecisePropagatePass());
 
-  MPM.add(createRevertWavelessBreaksPass());
+  MPM.add(createCleanupDxBreakPass());
 
   if (!NoOpt)
     MPM.add(createSimplifyInstPass());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -292,6 +292,8 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   // Propagate precise attribute.
   MPM.add(createDxilPrecisePropagatePass());
 
+  MPM.add(createRevertWavelessBreaksPass());
+
   if (!NoOpt)
     MPM.add(createSimplifyInstPass());
 

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2581,7 +2581,7 @@ void AddDxBreak(Module &M, SmallVector<llvm::BranchInst*, 16> DxBreaks) {
 
   // Create the dx.break function
   FunctionType *FT = llvm::FunctionType::get(llvm::Type::getInt1Ty(M.getContext()), false);
-  Function *func = cast<llvm::Function>(M.getOrInsertFunction("dx.break", FT));
+  Function *func = cast<llvm::Function>(M.getOrInsertFunction(kDxBreakFuncName, FT));
   func->addFnAttr(Attribute::AttrKind::NoUnwind);
 
   for(llvm::BranchInst *BI : DxBreaks) {

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2574,4 +2574,20 @@ void FinishIntrinsics(
   // update valToResPropertiesMap for cloned inst.
   AddOpcodeParamForIntrinsics(HLM, intrinsicMap, valToResPropertiesMap);
 }
+
+void AddDxBreak(Module &M, SmallVector<llvm::BranchInst*, 16> DxBreaks) {
+  if (DxBreaks.empty())
+    return;
+
+  // Create the dx.break function
+  FunctionType *FT = llvm::FunctionType::get(llvm::Type::getInt1Ty(M.getContext()), false);
+  Function *func = cast<llvm::Function>(M.getOrInsertFunction("dx.break", FT));
+  func->addFnAttr(Attribute::AttrKind::NoUnwind);
+
+  for(llvm::BranchInst *BI : DxBreaks) {
+    CallInst *Call = CallInst::Create(FT, func, ArrayRef<Value *>(), "", BI);
+    BI->setCondition(Call);
+  }
+}
+
 }

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -26,6 +26,7 @@ class DebugLoc;
 class Constant;
 class GlobalVariable;
 class CallInst;
+template <typename T, unsigned N> class SmallVector;
 }
 
 namespace hlsl {
@@ -93,6 +94,8 @@ void FinishIntrinsics(
     hlsl::HLModule &HLM, std::vector<std::pair<llvm::Function *, unsigned>> &intrinsicMap,
     llvm::DenseMap<llvm::Value *, hlsl::DxilResourceProperties>
         &valToResPropertiesMap);
+
+void AddDxBreak(llvm::Module &M, llvm::SmallVector<llvm::BranchInst*, 16> DxBreaks);
 
 void ReplaceConstStaticGlobals(
     std::unordered_map<llvm::GlobalVariable *, std::vector<llvm::Constant *>>

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -23,7 +23,7 @@ class TerminatorInst;
 class GlobalVariable;
 class Type;
 class BasicBlock;
-class Instruction;
+class BranchInst;
 template <typename T> class ArrayRef;
 }
 
@@ -52,11 +52,10 @@ class LValue;
 class CGHLSLRuntime {
 protected:
   CodeGenModule &CGM;
-  llvm::Constant *m_pDxBreakGEP;
-  llvm::SmallDenseMap<llvm::Function*, llvm::Instruction*, 16> m_DxBreakCmpMap;
+  llvm::SmallVector<llvm::BranchInst*, 16> m_DxBreaks;
 
 public:
-  CGHLSLRuntime(CodeGenModule &CGM) : CGM(CGM), m_pDxBreakGEP(nullptr) {}
+  CGHLSLRuntime(CodeGenModule &CGM) : CGM(CGM) {}
   virtual ~CGHLSLRuntime();
 
   virtual void addResource(Decl *D) = 0;

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <functional>
+#include <llvm/ADT/DenseMap.h> // HLSL Change
 
 namespace llvm {
 class Function;
@@ -22,6 +23,7 @@ class TerminatorInst;
 class GlobalVariable;
 class Type;
 class BasicBlock;
+class Instruction;
 template <typename T> class ArrayRef;
 }
 
@@ -50,9 +52,11 @@ class LValue;
 class CGHLSLRuntime {
 protected:
   CodeGenModule &CGM;
+  llvm::Constant *m_pDxBreakGEP;
+  llvm::SmallDenseMap<llvm::Function*, llvm::Instruction*, 16> m_DxBreakCmpMap;
 
 public:
-  CGHLSLRuntime(CodeGenModule &CGM) : CGM(CGM) {}
+  CGHLSLRuntime(CodeGenModule &CGM) : CGM(CGM), m_pDxBreakGEP(nullptr) {}
   virtual ~CGHLSLRuntime();
 
   virtual void addResource(Decl *D) = 0;

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -21,6 +21,7 @@ class Constant;
 class TerminatorInst;
 class GlobalVariable;
 class Type;
+class BasicBlock;
 template <typename T> class ArrayRef;
 }
 
@@ -80,6 +81,7 @@ public:
   virtual llvm::Value *EmitHLSLMatrixOperationCall(CodeGenFunction &CGF, const clang::Expr *E, llvm::Type *RetType,
       llvm::ArrayRef<llvm::Value*> paramList) = 0;
   virtual void EmitHLSLDiscard(CodeGenFunction &CGF) = 0;
+  virtual void EmitHLSLCondBreak(CodeGenFunction &CGF, llvm::BasicBlock *DestBB, llvm::BasicBlock *AltBB) = 0;
 
   // For [] on matrix
   virtual llvm::Value *EmitHLSLMatrixSubscript(CodeGenFunction &CGF,

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -81,7 +81,7 @@ public:
   virtual llvm::Value *EmitHLSLMatrixOperationCall(CodeGenFunction &CGF, const clang::Expr *E, llvm::Type *RetType,
       llvm::ArrayRef<llvm::Value*> paramList) = 0;
   virtual void EmitHLSLDiscard(CodeGenFunction &CGF) = 0;
-  virtual void EmitHLSLCondBreak(CodeGenFunction &CGF, llvm::BasicBlock *DestBB, llvm::BasicBlock *AltBB) = 0;
+  virtual void EmitHLSLCondBreak(CodeGenFunction &CGF, llvm::Function *F, llvm::BasicBlock *DestBB, llvm::BasicBlock *AltBB) = 0;
 
   // For [] on matrix
   virtual llvm::Value *EmitHLSLMatrixSubscript(CodeGenFunction &CGF,

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -1175,7 +1175,7 @@ void CodeGenFunction::EmitBreakStmt(const BreakStmt &S) {
   // If it has a continue location, it's a loop
   if (BreakContinueStack.back().ContinueBlock.getBlock()) {
     assert(EHStack.getInnermostActiveNormalCleanup() == EHStack.stable_end()); // HLSL Shouldn't need cleanups
-    CGM.getHLSLRuntime().EmitHLSLCondBreak(*this, BreakContinueStack.back().BreakBlock.getBlock(),
+    CGM.getHLSLRuntime().EmitHLSLCondBreak(*this, CurFn, BreakContinueStack.back().BreakBlock.getBlock(),
                                            BreakContinueStack.back().ContinueBlock.getBlock());
   } else
   // HLSL Change End - incorporate unconditional branch blocks into loops

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -1171,6 +1171,14 @@ void CodeGenFunction::EmitBreakStmt(const BreakStmt &S) {
   if (HaveInsertPoint())
     EmitStopPoint(&S);
 
+  // HLSL Change Begin - incorporate unconditional branch blocks into loops
+  // If it has a continue location, it's a loop
+  if (BreakContinueStack.back().ContinueBlock.getBlock()) {
+    assert(EHStack.getInnermostActiveNormalCleanup() == EHStack.stable_end()); // HLSL Shouldn't need cleanups
+    CGM.getHLSLRuntime().EmitHLSLCondBreak(*this, BreakContinueStack.back().BreakBlock.getBlock(),
+                                           BreakContinueStack.back().ContinueBlock.getBlock());
+  } else
+  // HLSL Change End - incorporate unconditional branch blocks into loops
   EmitBranchThroughCleanup(BreakContinueStack.back().BreakBlock);
 }
 

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -1173,8 +1173,9 @@ void CodeGenFunction::EmitBreakStmt(const BreakStmt &S) {
 
   // HLSL Change Begin - incorporate unconditional branch blocks into loops
   // If it has a continue location, it's a loop
-  if (BreakContinueStack.back().ContinueBlock.getBlock()) {
-    assert(EHStack.getInnermostActiveNormalCleanup() == EHStack.stable_end()); // HLSL Shouldn't need cleanups
+  if (BreakContinueStack.back().ContinueBlock.getBlock() && (BreakContinueStack.size() < 2 ||
+      BreakContinueStack.back().ContinueBlock.getBlock() != BreakContinueStack.end()[-2].ContinueBlock.getBlock())) {
+    assert(EHStack.getInnermostActiveNormalCleanup() == EHStack.stable_end() && "HLSL Shouldn't need cleanups");
     CGM.getHLSLRuntime().EmitHLSLCondBreak(*this, CurFn, BreakContinueStack.back().BreakBlock.getBlock(),
                                            BreakContinueStack.back().ContinueBlock.getBlock());
   } else

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/basic_blocks/cbuf_memcpy_replace.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/basic_blocks/cbuf_memcpy_replace.hlsl
@@ -96,7 +96,7 @@ int init_loop(int ct)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?cond_if@@YAHH@Z"(i32 %i) #0 {
+//CHECK: define i32 @"\01?cond_if@@YAHH@Z"(i32 %i)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: phi i32

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakLib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakLib.hlsl
@@ -1,0 +1,160 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+StructuredBuffer<int> buf[]: register(t2);
+// CHECK: @dx.break = internal global
+
+// Cannonical example. Expected to keep the block in loop
+// Verify this function loads the global
+// CHECK: load volatile i32
+// CHECK-SAME: @dx.break
+// CHECK: icmp eq i32
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK: br i1
+export
+int WaveInLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  for (;;) {
+      int u = WaveReadLaneFirst(a);
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+    }
+  return res;
+}
+
+// Wave moved to after the break block. Expected to keep the block in loop
+// Verify this function loads the global
+// CHECK: load volatile i32
+// CHECK-SAME: @dx.break
+// CHECK: icmp eq i32
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK: br i1
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+export
+int WaveInPostLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+  int u = 0;
+
+  for (;;) {
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+      u += WaveReadLaneFirst(a);
+    }
+  return res;
+}
+
+// Wave in entry block. Expected to allow the break block to move out of loop
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// Verify this function loads the global
+// CHECK: load volatile i32
+// CHECK-SAME: @dx.break
+// CHECK: icmp eq i32
+
+// These verify the break block doesn't keep the conditional
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+export
+int WaveInEntry(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  int u = WaveReadLaneFirst(a);
+
+  for (;;) {
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+    }
+  return res;
+}
+
+// Wave in subloop of larger loop. Expected to keep the block in loop
+// Verify this function loads the global
+// CHECK: load volatile i32
+// CHECK-SAME: @dx.break
+// CHECK: icmp eq i32
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK: br i1
+export
+int WaveInSubLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  for (;;) {
+      int u = 0;
+      for (int i = 0; i < b; i ++)
+        u += WaveReadLaneFirst(a);
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+    }
+  return res;
+}
+
+// Wave in a separate loop. Expected to allow the break block to move out of loop
+export
+// CHECK: load volatile i32
+// CHECK: icmp eq i32
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the first break block keeps the conditional
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK: br i1
+// These verify the second break block doesn't
+// CHECK: call %dx.types.Handle @"dx.op.createHandleForLib.class.StructuredBuffer<int>"
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK-NOT: br i1
+int WaveInOtherLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+  int u = 0;
+
+  for (;;) {
+      u += WaveReadLaneFirst(a);
+      if (a == u) {
+          res += buf[u][b];
+          break;
+        }
+    }
+  for (;;) {
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+    }
+  return res;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakPS.hlsl
@@ -1,11 +1,27 @@
 // RUN: %dxc -T ps_6_3 %s | FileCheck %s
-StructuredBuffer<int> buf[]: register(t2);
 
-// CHECK: @dx.break = internal global
+// Rather than trying to account for all optimizations, 
+// give each function that's going to be inlined its own buffer
+StructuredBuffer<int> mainBuf[]: register(t2, space0);
+StructuredBuffer<int> loopBuf[]: register(t3, space1);
+StructuredBuffer<int> postBuf[]: register(t4, space2);
+StructuredBuffer<int> breakBuf[]: register(t5, space3);
+StructuredBuffer<int> entryBuf[]: register(t6, space4);
+StructuredBuffer<int> subBuf[]: register(t7, space5);
+StructuredBuffer<int> otherBuf[]: register(t8, space6);
 
-// Simple test to verify functionality in pixel shaders
-// CHECK: load volatile i32
-// CHECK-SAME: @dx.break
+int WaveInLoop(int a : A, int b : B);
+int WaveInPostLoop(int a : A, int b : B);
+int WaveInBreakBlock(int a : A, int b : B);
+int WaveInEntry(int a : A, int b : B);
+int WaveInSubLoop(int a : A, int b : B);
+int WaveInOtherLoop(int a : A, int b : B, int c : C);
+
+// CHECK: @dx.break.cond = internal constant
+
+// Verify this function loads the global
+// CHECK: load i32
+// CHECK-SAME: @dx.break.cond
 // CHECK-NEXT: icmp eq i32
 
 // CHECK: call i32 @dx.op.waveReadLaneFirst
@@ -13,16 +29,15 @@ StructuredBuffer<int> buf[]: register(t2);
 // These verify the first break block keeps the conditional
 // CHECK: call %dx.types.Handle @dx.op.createHandle
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %mainBuf
 // CHECK: add
 // CHECK: br i1
 // These verify the second break block doesn't
 // CHECK: call %dx.types.Handle @dx.op.createHandle
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
-// CHECK: add
-// CHECK-NOT: br i1
-// CHECK: call void @dx.op.storeOutput
+// CHECK-SAME: %mainBuf
 
-int main(int a : A, int b : B) : SV_Target
+int main(int a : A, int b : B, int c : C) : SV_Target
 {
   int res = 0;
   int i = 0;
@@ -31,15 +46,235 @@ int main(int a : A, int b : B) : SV_Target
   for (;;) {
       u += WaveReadLaneFirst(a);
       if (a == u) {
-          res += buf[u][b];
+          res += mainBuf[u][b];
           break;
         }
     }
   for (;;) {
       if (a == u) {
-          res += buf[b][u];
+          res += mainBuf[b][u];
           break;
         }
     }
+  return res + WaveInPostLoop(a, b) + WaveInBreakBlock(a, b) + WaveInEntry(a, b) +
+    WaveInSubLoop(a,b) + WaveInOtherLoop(a,b,c);
+}
+
+// Wave moved to after the break block. Expected to keep the block in loop
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %postBuf
+// CHECK: add
+// CHECK: br i1
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %postBuf
+// CHECK: add
+// CHECK: br i1
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+export
+int WaveInPostLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+  int u = 0;
+
+  // Loop with wave-dependent conditional break block
+  for (;;) {
+      if (a == u) {
+          res += postBuf[b][u];
+          break;
+        }
+      u += WaveReadLaneFirst(a);
+    }
+
+  // Loop with wave-independent conditional break block
+  for (;;) {
+      if (b == i) {
+          res += postBuf[u][b];
+          break;
+        }
+      u += WaveReadLaneFirst(a);
+      i++;
+    }
   return res;
 }
+
+// Wave op inside break block. Expected to keep the block in loop
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %breakBuf
+// CHECK: br i1
+
+export
+int WaveInBreakBlock(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  // Loop with wave-independent conditional break block
+  for (;;) {
+      if (b == i) {
+          int u = WaveReadLaneFirst(a);
+          res = breakBuf[b][u];
+          break;
+        }
+      i++;
+    }
+  return res;
+}
+
+// Wave in entry block. Expected to allow the break block to move out of loop
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block doesn't keep the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %entryBuf
+
+// These verify the break block doesn't keep the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %entryBuf
+export
+int WaveInEntry(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  int u = WaveReadLaneFirst(b);
+
+  // Loop with wave-dependent conditional break block
+  for (;;) {
+      if (a == u) {
+          res += entryBuf[b][u];
+          break;
+        }
+    }
+
+  // Loop with wave-independent conditional break block
+  for (;;) {
+      if (b == i) {
+          res += entryBuf[u][b];
+          break;
+        }
+      i++;
+    }
+  return res;
+}
+
+// Wave in subloop of larger loop. Expected to keep the block in loop
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %subBuf
+// CHECK: add
+// CHECK: br i1
+
+// These verify the break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %subBuf
+// CHECK: add
+// CHECK: br i1
+export
+int WaveInSubLoop(int a : A, int b : B)
+{
+  int res = 0;
+  int i = 0;
+
+  // Loop with wave-dependent conditional break block
+  for (;;) {
+      int u = 0;
+      for (int i = 0; i < b; i ++)
+        u += WaveReadLaneFirst(a);
+      if (a == u) {
+          res += subBuf[a][u];
+          break;
+        }
+    }
+
+  // Loop with wave-independent conditional break block
+  for (;;) {
+      int u = 0;
+      for (int j = 0; j < b; j ++)
+        u += WaveReadLaneFirst(a);
+      if (b == i) {
+          res += subBuf[b][u];
+          break;
+        }
+      i++;
+    }
+  return res;
+}
+
+// Wave in a separate loop. Expected to allow the break block to move out of loop
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the first break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %otherBuf
+// CHECK: add
+// CHECK: br i1
+
+// These verify the second break block doesn't
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %otherBuf
+// CHECK-NOT: br i1
+
+// These verify the third break block doesn't
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK-SAME: %otherBuf
+// CHECK: add
+int WaveInOtherLoop(int a : A, int b : B, int c : C)
+{
+  int res = 0;
+  int i = 0;
+  int u = 0;
+
+  for (;;) {
+      u += WaveReadLaneFirst(a);
+      if (a == u) {
+          res += otherBuf[u][b];
+          break;
+        }
+    }
+
+  // Loop with wave-dependent conditional break block
+  for (;;) {
+      if (a == u) {
+          res += otherBuf[b][u];
+          break;
+        }
+    }
+
+  // Loop with wave-independent conditional break block
+  for (;;) {
+      if (b == i) {
+          res += otherBuf[c][u];
+          break;
+        }
+      i++;
+    }
+  return res;
+}
+
+// Final operations
+// CHECK-NOT: br i1
+// CHECK: call void @dx.op.storeOutput

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakPS.hlsl
@@ -1,0 +1,45 @@
+// RUN: %dxc -T ps_6_3 %s | FileCheck %s
+StructuredBuffer<int> buf[]: register(t2);
+
+// CHECK: @dx.break = internal global
+
+// Simple test to verify functionality in pixel shaders
+// CHECK: load volatile i32
+// CHECK-SAME: @dx.break
+// CHECK-NEXT: icmp eq i32
+
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+
+// These verify the first break block keeps the conditional
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK: br i1
+// These verify the second break block doesn't
+// CHECK: call %dx.types.Handle @dx.op.createHandle
+// CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad
+// CHECK: add
+// CHECK-NOT: br i1
+// CHECK: call void @dx.op.storeOutput
+
+int main(int a : A, int b : B) : SV_Target
+{
+  int res = 0;
+  int i = 0;
+  int u = 0;
+
+  for (;;) {
+      u += WaveReadLaneFirst(a);
+      if (a == u) {
+          res += buf[u][b];
+          break;
+        }
+    }
+  for (;;) {
+      if (a == u) {
+          res += buf[b][u];
+          break;
+        }
+    }
+  return res;
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2016,6 +2016,7 @@ class db_dxil(object):
         add_pass('dxil-insert-preserves', 'DxilInsertPreserves', 'Dxil Insert Noops', [])
         add_pass('dxil-preserve-to-select', 'DxilPreserveToSelect', 'Dxil Insert Noops', [])
         add_pass('dxil-value-cache', 'DxilValueCache', 'Dxil Value Cache',[])
+        add_pass('hlsl-cleanup-dxbreak', 'CleanupDxBreak', 'HLSL Remove unnecessary dx.break conditions', [])
 
         category_lib="llvm"
         add_pass('ipsccp', 'IPSCCP', 'Interprocedural Sparse Conditional Constant Propagation', [])


### PR DESCRIPTION
This introduces dx.break, an internal global that is applied as a
condition to any unconditional break in order to keep the basic block
inside the loop. The load is made volatile in order to keep the
optimizations from identifying the global as a constant and removing it.
Because it remains in the loop, operations that depend on wave operations
inside the loop will be able to get the right values.

Normal break blocks don't need this conditional, but we don't know that
at code generation. So a later pass identifies break blocks with wave
sensitive operations that depend on wave ops that are inside the loop they
are breaking out of and preserves those conditionals while removing all
the rest.

Initially, the global variable is set to not constant to avoid
instruction simplification that would replace any reference to it with
the value it is initialized with. As part of dxil finalization,