### PR TITLE
Add simplify to DxilValueCache for dx.break()

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1438,6 +1438,9 @@ namespace DXIL {
   extern const char* kFP32DenormValuePreserveString;
   extern const char* kFP32DenormValueFtzString;
 
+  static const char *kDxBreakFuncName = "dx.break";
+  static const char *kDxBreakCondName = "dx.break.cond";
+
 } // namespace DXIL
 
 } // namespace hlsl

--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -23,8 +23,6 @@ struct PostDominatorTree;
 }
 
 namespace hlsl {
-extern char *kDxBreakFuncName;
-extern char *kDxBreakCondName;
 class DxilResourceBase;
 class WaveSensitivityAnalysis {
 public:

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -15,9 +15,6 @@
 
 namespace llvm {
 
-extern const char *kDxBreakFuncName;
-extern const char *kDxBreakCondName;
-
 class Module;
 class DominatorTree;
 class Constant;

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -15,6 +15,9 @@
 
 namespace llvm {
 
+extern const char *kDxBreakFuncName;
+extern const char *kDxBreakCondName;
+
 class Module;
 class DominatorTree;
 class Constant;
@@ -60,8 +63,8 @@ private:
   Value *ProcessValue(Value *V, DominatorTree *DT);
 
   Value *ProcessAndSimplify_PHI(Instruction *I, DominatorTree *DT);
-  Value *ProcessAndSimpilfy_Br(Instruction *I, DominatorTree *DT);
-  Value *ProcessAndSimpilfy_Load(Instruction *LI, DominatorTree *DT);
+  Value *ProcessAndSimplify_Br(Instruction *I, DominatorTree *DT);
+  Value *ProcessAndSimplify_Load(Instruction *LI, DominatorTree *DT);
   Value *SimplifyAndCacheResult(Instruction *I, DominatorTree *DT);
 
 public:

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -12,6 +12,7 @@
 
 
 #include "llvm/Pass.h"
+#include "dxc/DXIL/DxilConstants.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Constants.h"
@@ -225,8 +226,7 @@ Value *DxilValueCache::SimplifyAndCacheResult(Instruction *I, DominatorTree *DT)
   else if (Instruction::Call == I->getOpcode()) {
     Module *M = I->getModule();
     CallInst *CI = cast<CallInst>(I);
-    Function *BreakFunc = M->getFunction("dx.break");
-    if (CI->getCalledFunction() == BreakFunc) {
+    if (CI->getCalledFunction()->getName() == hlsl::DXIL::kDxBreakFuncName) {
       llvm::Type *i1Ty = llvm::Type::getInt1Ty(M->getContext());
       Simplified = llvm::ConstantInt::get(i1Ty, 1);
     }

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -33,9 +33,6 @@
 
 using namespace llvm;
 
-const char *llvm::kDxBreakFuncName = "dx.break";
-const char *llvm::kDxBreakCondName = "dx.break.cond";
-
 static
 bool IsConstantTrue(const Value *V) {
   if (const ConstantInt *C = dyn_cast<ConstantInt>(V))

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Pass.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/DxilValueCache.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include <memory>
 #include <unordered_set>
@@ -53,9 +54,6 @@ public:
   bool runOnModule(Module &M) override;
 };
 }
-
-char *hlsl::kDxBreakFuncName = "dx.break";
-char *hlsl::kDxBreakCondName = "dx.break.cond";
 
 char InvalidateUndefResources::ID = 0;
 

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -18,6 +18,7 @@
 #include "dxc/DXIL/DxilUtil.h"
 #include "dxc/DXIL/DxilFunctionProps.h"
 #include "dxc/DXIL/DxilInstructions.h"
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/HlslIntrinsicOp.h"
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/IR/IRBuilder.h"
@@ -631,7 +632,7 @@ private:
 
   // Convert all uses of dx.break() into per-function load/cmp of dx.break.cond global constant
   void LowerDxBreak(Module &M) {
-    if (Function *BreakFunc = M.getFunction(kDxBreakFuncName)) {
+    if (Function *BreakFunc = M.getFunction(DXIL::kDxBreakFuncName)) {
       if (BreakFunc->getNumUses()) {
         llvm::Type *i32Ty = llvm::Type::getInt32Ty(M.getContext());
         Type *i32ArrayTy = ArrayType::get(i32Ty, 1);
@@ -639,7 +640,7 @@ private:
         Constant *InitialValue = ConstantDataArray::get(M.getContext(), Values);
         Constant *GV = new GlobalVariable(M, i32ArrayTy, true,
                                           GlobalValue::InternalLinkage,
-                                          InitialValue, kDxBreakCondName);
+                                          InitialValue, DXIL::kDxBreakCondName);
 
         Constant *Indices[] = { ConstantInt::get(i32Ty, 0), ConstantInt::get(i32Ty, 0) };
         Constant *Gep = ConstantExpr::getGetElementPtr(nullptr, GV, Indices);
@@ -1142,7 +1143,7 @@ public:
     // Only check ps and lib profile.
     Module *M = F.getEntryBlock().getModule();
 
-    Function *BreakFunc = M->getFunction(kDxBreakFuncName);
+    Function *BreakFunc = M->getFunction(DXIL::kDxBreakFuncName);
     if (!BreakFunc)
       return false;
 

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -18,6 +18,7 @@
 #include "llvm/IR/GetElementPtrTypeIterator.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/DxilValueCache.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2582,7 +2582,7 @@ void AddDxBreak(Module &M, SmallVector<llvm::BranchInst*, 16> DxBreaks) {
 
   // Create the dx.break function
   FunctionType *FT = llvm::FunctionType::get(llvm::Type::getInt1Ty(M.getContext()), false);
-  Function *func = cast<llvm::Function>(M.getOrInsertFunction(kDxBreakFuncName, FT));
+  Function *func = cast<llvm::Function>(M.getOrInsertFunction(DXIL::kDxBreakFuncName, FT));
   func->addFnAttr(Attribute::AttrKind::NoUnwind);
 
   for(llvm::BranchInst *BI : DxBreaks) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T cs_6_0 %s | FileCheck %s
+// A test of explicit loop unrolling on a loop that uses a wave op in a break block
+
+StructuredBuffer<float> t0;
+RWStructuredBuffer<float> u0;
+
+[RootSignature("DescriptorTable(SRV(t0), UAV(u0))")]
+[numthreads(64,1,1)]
+void main(uint GI : SV_GroupIndex)
+{
+  float r = 0;
+  [unroll]
+  for (int i = 0; i < 8; ++i) {
+    r += t0[i];
+    if (i > 4) {
+      r += WaveActiveSum(t0[i+1]);
+      break;
+    }
+  }
+  u0[GI] = r;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
@@ -3,21 +3,28 @@
 
 // CHECK: void @main
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
 // CHECK: @dx.op.cbufferLoadLegacy.i32
 // CHECK: br i1
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
 // CHECK: @dx.op.cbufferLoadLegacy.i32
 // CHECK: br i1
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
 // CHECK: @dx.op.cbufferLoadLegacy.i32
 // CHECK: br i1
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
 // CHECK: @dx.op.cbufferLoadLegacy.i32
 // CHECK: br i1
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
 // CHECK: @dx.op.cbufferLoadLegacy.i32
 // CHECK: br i1
 // CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.waveActiveOp.f32
+// CHECK-NOT: @dx.op.waveActiveOp.f32
 // CHECK: br
 // CHECK: ret void
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
@@ -1,21 +1,41 @@
 // RUN: %dxc -T cs_6_0 %s | FileCheck %s
 // A test of explicit loop unrolling on a loop that uses a wave op in a break block
 
-StructuredBuffer<float> t0;
-RWStructuredBuffer<float> u0;
+// CHECK: void @main
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.cbufferLoadLegacy.i32
+// CHECK: br i1
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.cbufferLoadLegacy.i32
+// CHECK: br i1
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.cbufferLoadLegacy.i32
+// CHECK: br i1
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.cbufferLoadLegacy.i32
+// CHECK: br i1
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: @dx.op.cbufferLoadLegacy.i32
+// CHECK: br i1
+// CHECK: @dx.op.cbufferLoadLegacy.f32
+// CHECK: br
+// CHECK: ret void
 
-[RootSignature("DescriptorTable(SRV(t0), UAV(u0))")]
+RWStructuredBuffer<float> u0;
+uint C;
+float f;
 [numthreads(64,1,1)]
 void main(uint GI : SV_GroupIndex)
 {
-  float r = 0;
-  [unroll]
-  for (int i = 0; i < 8; ++i) {
-    r += t0[i];
-    if (i > 4) {
-      r += WaveActiveSum(t0[i+1]);
-      break;
+    float r = 0;
+    [unroll]
+    for (int i = 0; i < C && i < 64; ++i) {
+        r += WaveActiveSum(f);
+        if (i > 4) {
+          r *= 2;
+          break;
+        }
     }
-  }
-  u0[GI] = r;
+
+    u0[GI] = r;
 }


### PR DESCRIPTION
To allow loop unrolling, call instructions that reference dx.break()
are given a constant true boolean simplification in DxilValueCache.

This required making the constant string available by moving it into
Analysis.

As an incidental change, I corrected the spelling of simplify in a
couple cases.