### PR TITLE
Correct function name for RawBufferLoad

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1784,7 +1784,7 @@ RawBufferStore
 The following signature shows the operation syntax::
 
   ; overloads: SM5.1: f32|i32,  SM6.0: f32|i32, SM6.2: f16|f32|i16|i32
-  declare void @dx.op.bufferStore.f32(
+  declare void @dx.op.rawBufferStore.f32(
       i32,                  ; opcode
       %dx.types.Handle,     ; resource handle
       i32,                  ; coordinate c0 (index)

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1731,7 +1731,7 @@ The following signature shows the operation syntax::
 
   ; overloads: SM5.1: f32|i32,  SM6.0: f32|i32, SM6.2: f16|f32|i16|i32
   ; returns: status
-  declare %dx.types.ResRet.f32 @dx.op.bufferLoad.f32(
+  declare %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(
       i32,                  ; opcode
       %dx.types.Handle,     ; resource handle
       i32,                  ; coordinate c0 (index)


### PR DESCRIPTION
`@dx.op.bufferLoad` is for `BufferLoad`, not `RawBufferLoad`.

This matches what DxilOperations.cpp does.