### PR TITLE
Don't assume branch user of dx.break

### DIFF
--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -657,8 +657,7 @@ private:
           // In spite of the <=1 assert above, loop here in case the assumption is wrong
           for (auto II = U->user_begin(), EE = U->user_end(); II != EE;) {
             User *UU = *II++;
-            Instruction *I = dyn_cast<Instruction>(UU);
-            if (!I) continue;
+            Instruction *I = cast<Instruction>(UU);
             Function *F = I->getParent()->getParent();
             ICmpInst *Cmp = DxBreakCmpMap.lookup(F);
             if (!Cmp) {


### PR DESCRIPTION
The previous lowering of dx.break() assumed that the user was still a
branch as it was when it was set up. However, optimizations can switch
things around so this assumption is wrong.

By allowing for other instructions or even not an instruction, the
replacement takes place just the same regardless of whether its a
branch.