### PR TITLE
Make remove-unused-globals remove non-static globals

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -100,7 +100,7 @@ public:
   FileRunCommandResult Run(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior, PluginToolsPaths *pPluginToolsPaths = nullptr );
   FileRunCommandResult RunHashTests(dxc::DxcDllSupport &DllSupport);
   
-  FileRunCommandResult ReadOptsForDxc(hlsl::options::MainArgs &argStrings, hlsl::options::DxcOpts &Opts);
+  FileRunCommandResult ReadOptsForDxc(hlsl::options::MainArgs &argStrings, hlsl::options::DxcOpts &Opts, unsigned flagsToInclude = 0);
 
   std::string Command;      // Command to run, eg %dxc
   std::string Arguments;    // Arguments to command
@@ -112,6 +112,7 @@ private:
   FileRunCommandResult RunDxv(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunOpt(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunD3DReflect(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
+  FileRunCommandResult RunDxr(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunTee(const FileRunCommandResult *Prior);
   FileRunCommandResult RunXFail(const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxilVer(dxc::DxcDllSupport& DllSupport, const FileRunCommandResult* Prior);

--- a/tools/clang/test/HLSLFileCheck/rewriter/remove-unused-globals.hlsl
+++ b/tools/clang/test/HLSLFileCheck/rewriter/remove-unused-globals.hlsl
@@ -44,6 +44,9 @@ SamplerState UnusedSampler;
 // CHECK: TestSampler
 SamplerState TestSampler;
 
+// CHECK: float3 ReferencedButDead;
+float3 ReferencedButDead;
+
 // CHECK: void main(
 void main(in float4 SvPosition : SV_Position,
           out float4 OutTarget0 : SV_Target0)
@@ -55,6 +58,9 @@ void main(in float4 SvPosition : SV_Position,
   {
     Index = TestInt;
   }
+
+  // Should keep any referenced global, even if it is unused.
+  (void)ReferencedButDead;
 
   float2 UV = LookupTable[Index].xy + LookupTable[Index].zw;
   float4 Value = TestTex.SampleLevel(TestSampler, UV, 0);

--- a/tools/clang/test/HLSLFileCheck/rewriter/remove-unused-globals.hlsl
+++ b/tools/clang/test/HLSLFileCheck/rewriter/remove-unused-globals.hlsl
@@ -1,0 +1,65 @@
+// RUN: %dxr -E main -remove-unused-globals %s | FileCheck %s
+
+// CHECK: cbuffer TestCBuffer
+cbuffer TestCBuffer
+{
+// CHECK: int TestInt;
+  int TestInt;
+// UnusedFloat is not removed if inside a cbuffer declaration with a used global
+// CHECK: float UnusedFloat;
+  float UnusedFloat;
+}
+// CHECK: }
+
+// Unused cbuffers are not removed at this time
+// CHECK: cbuffer UnusedCBuffer
+cbuffer UnusedCBuffer
+{
+// CHECK: float FloatInUnusedCBuffer;
+  float FloatInUnusedCBuffer;
+}
+// CHECK: }
+
+// CHECK-NOT: RandomGlobal
+float4 RandomGlobal[2];
+
+// CHECK: LookupTable
+float4 LookupTable[1];
+
+// CHECK-NOT: UnusedBool
+bool UnusedBool;
+
+// CHECK: TestBool
+bool TestBool;
+
+// CHECK-NOT: UnusedTex
+Texture2D UnusedTex;
+
+// CHECK: TestTex
+Texture2D TestTex;
+
+// CHECK-NOT: UnusedSampler
+SamplerState UnusedSampler;
+
+// CHECK: TestSampler
+SamplerState TestSampler;
+
+// CHECK: void main(
+void main(in float4 SvPosition : SV_Position,
+          out float4 OutTarget0 : SV_Target0)
+{
+  float3 Color = 0;
+  uint Index = 0;
+
+  if (TestBool)
+  {
+    Index = TestInt;
+  }
+
+  float2 UV = LookupTable[Index].xy + LookupTable[Index].zw;
+  float4 Value = TestTex.SampleLevel(TestSampler, UV, 0);
+
+  Color += Value.rgb + (1 - Value.a);
+
+  OutTarget0 = float4 (Color, 1.0f);
+}

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -422,7 +422,7 @@ static HRESULT DoRewriteUnused( TranslationUnitDecl *tu,
     if (tuDecl->isImplicit()) continue;
 
     VarDecl* varDecl = dyn_cast_or_null<VarDecl>(tuDecl);
-    if (varDecl != nullptr && varDecl->getFormalLinkage() == clang::Linkage::InternalLinkage) {
+    if (varDecl != nullptr) {
       unusedGlobals.insert(varDecl);
       if (const RecordType *recordType = varDecl->getType()->getAs<RecordType>()) {
         RecordDecl *recordDecl = recordType->getDecl();


### PR DESCRIPTION
- Add support for rewriter (dxr) to FileCheckerTest
- Add test for removing globals

Can help in scenario #2726