### PR TITLE
Skip copy of inout args when coming from function arg

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -5459,7 +5459,8 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
       if (argLV.isSimple())
         argAddr = argLV.getAddress();
       // Skip copy-in copy-out for local variables.
-      if (bInOut && argAddr && isa<AllocaInst>(argAddr)) {
+      if (bInOut && argAddr &&
+          (isa<AllocaInst>(argAddr) || isa<Argument>(argAddr))) {
         llvm::Type *ToTy = CGF.ConvertType(ParamTy.getNonReferenceType());
         if (argAddr->getType()->getPointerElementType() == ToTy &&
             // Check clang Type for case like int cast to unsigned.

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/inout_from_arg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/inout_from_arg.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -E main -Tps_6_0 -fcgl %s | FileCheck %s
+
+
+// Make sure only one alloca [5 x i32], and none for nested call.
+// CHECK:define float @main(
+// CHECK:alloca [5 x i32]
+// CHECK-NOT:alloca [5 x i32]
+
+void foo(inout uint a[5], uint b) {
+    a[0] = b;
+    a[1] = b+1;
+    a[2] = b+2;
+    a[3] = b+3;
+    a[4] = b+4;
+}
+
+uint bar(inout uint a[5], uint2 i) {
+  foo(a, i.x);
+  return a[i.y];
+}
+
+float main(uint2 i:A) : SV_Target {
+  uint a[5];
+  return bar(a, i);
+}


### PR DESCRIPTION
- Update existing optimization that skipped extra copying of inout call
  args when passing a local var, to also skip when passing a function
  argument.