### PR TITLE
Handle more complicated dx.break circumstances

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -95,7 +95,7 @@ void FinishIntrinsics(
     llvm::DenseMap<llvm::Value *, hlsl::DxilResourceProperties>
         &valToResPropertiesMap);
 
-void AddDxBreak(llvm::Module &M, llvm::SmallVector<llvm::BranchInst*, 16> DxBreaks);
+void AddDxBreak(llvm::Module &M, const llvm::SmallVector<llvm::BranchInst*, 16> &DxBreaks);
 
 void ReplaceConstStaticGlobals(
     std::unordered_map<llvm::GlobalVariable *, std::vector<llvm::Constant *>>

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -12,11 +12,10 @@
 #pragma once
 
 #include <functional>
-#include <llvm/ADT/DenseMap.h> // HLSL Change
+#include <llvm/ADT/SmallVector.h> // HLSL Change
 
 namespace llvm {
 class Function;
-template <typename T, unsigned N> class SmallVector;
 class Value;
 class Constant;
 class TerminatorInst;

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakMerge.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveAndBreakMerge.hlsl
@@ -1,0 +1,49 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+// When a conditional break block follows a conditional while loop entry,
+// There can be some merging of conditionals, particularly when the dx.break
+// adds a conditional of its own. This ensures they are handled appropriately.
+
+// CHECK: @dx.break.cond = internal constant
+
+// CHECK: define i32
+// CHECK-SAME: CondMergeWave
+// CHECK: load i32
+// CHECK-SAME: @dx.break.cond
+// CHECK: icmp eq i32
+
+// These verify the break block keeps the merged conditional
+// CHECK: call i32 @dx.op.waveReadLaneFirst
+// CHECK: and i1
+// CHECK: br i1
+// CHECK: ret i32
+export
+int CondMergeWave(uint Bits, float4 Bobs)
+{
+  while (Bits) {
+    if (Bobs.a < 0.001) {
+      Bits = WaveReadLaneFirst(Bits);
+      break;
+    }
+    Bits >>= 1;
+  }
+  return Bits;
+}
+
+// CHECK: define i32
+// CHECK-SAME: CondMerge
+
+// Shouldn't be any use of dx.break nor any need to and anything
+// CHECK-NOT: dx.break.cond
+// CHECK-NOT: and i1
+// CHECK: ret i32
+export
+int CondMerge(uint Bits, float4 Bobs)
+{
+  while (Bits) {
+    if (Bobs.a < 0.001)
+      break;
+    Bits >>= 1;
+  }
+  return Bits;
+}
+


### PR DESCRIPTION
This includes a number of different changes to allow the dx.break
artificial branch conditional to function properly in different
situations that might arise as a result of optimization passes.

First of all, the dx.break usage is eliminated entirely for any function
found to not have need of it during code gen finishing. The dependencies
are not all clear at this stage, so it only determines if the function
makes use of any wave operations.

During the original dx.break elimination pass, the code allows for any
kind of instruction. This requires a bit more information about the user
of dx.break since the immediate user might not be a branch. So first the
dx.break users are traversed the same way that the wave users are. Then
the wave users are used to cull the list of dxbreak users. Then the
remaining dx.break users, which are not wave sensitive have their branch
conditionals removed by traversing the users until the branch is found.

An incidental optimization in the finding of wave sensitive functions is
used which requires depth first traversal. Since certain checks are
performed on a per-block basis and the user chain can be expected to
stay in the same block at least for a bit, by using depth first search,
we can skip when the new block matches the one just processed.

There is a bit of consolidation of logic here. Instead of repeatly
checking for the pattern that indicates a dx.break modified branch, it
is done once to collect all such blocks and thereafter, its presence
there is taken to mean that it qualifies.

A test is added to verify that this solves the original motivation of
this which was a circumstance where merging of conditionals resulted in
the dx.break call instruction was not immediately used by the branch.