### PR TITLE
Fix the "unused function" warning caused by UuidStrHash

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -561,6 +561,12 @@ enum tagSTATFLAG {
 
 //===--------------------- UUID Related Macros ----------------------------===//
 
+#ifdef __EMULATE_UUID
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
 static size_t UuidStrHash(const char *k) {
   long h = 0;
   while (*k) {
@@ -572,8 +578,9 @@ static size_t UuidStrHash(const char *k) {
   }
   return h;
 }
-
-#ifdef __EMULATE_UUID
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 // The following macros are defined to facilitate the lack of 'uuid' on Linux.
 #define DECLARE_CROSS_PLATFORM_UUIDOF(T)                                       \

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -563,24 +563,7 @@ enum tagSTATFLAG {
 
 #ifdef __EMULATE_UUID
 
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#endif
-static size_t UuidStrHash(const char *k) {
-  long h = 0;
-  while (*k) {
-    h = (h << 4) + *(k++);
-    long g = h & 0xF0000000L;
-    if (g != 0)
-      h ^= g >> 24;
-    h &= ~g;
-  }
-  return h;
-}
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
+size_t UuidStrHash(const char* k);
 
 // The following macros are defined to facilitate the lack of 'uuid' on Linux.
 #define DECLARE_CROSS_PLATFORM_UUIDOF(T)                                       \

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -12,6 +12,24 @@
 #include "dxc/Support/WinAdapter.h"
 #include "dxc/Support/WinFunctions.h"
 
+//===--------------------- UUID Related Macros ----------------------------===//
+
+#ifdef __EMULATE_UUID
+
+size_t UuidStrHash(const char* k) {
+    long h = 0;
+    while (*k) {
+        h = (h << 4) + *(k++);
+        long g = h & 0xF0000000L;
+        if (g != 0)
+            h ^= g >> 24;
+        h &= ~g;
+    }
+    return h;
+}
+
+#endif // __EMULATE_UUID
+
 DEFINE_CROSS_PLATFORM_UUIDOF(IUnknown)
 DEFINE_CROSS_PLATFORM_UUIDOF(INoMarshal)
 DEFINE_CROSS_PLATFORM_UUIDOF(IStream)


### PR DESCRIPTION
Move the declaration of UuidStrHash into #ifdef __EMULATE_UUID/#endif, and move its implementation to WinAdapter.cpp.