### PR TITLE
Support constant expression truncation

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/types/vector/constVecTrunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/vector/constVecTrunc.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T ps_6_0 %s  | FileCheck %s
+
+// Test vector/matrix truncation and splats in constant expressions
+// If they remain constant, it should simplify down to just storeOutputs
+
+// CHECK: define void @main
+// CHECK-NEXT: call void @dx.op.storeOutput
+// CHECK-NEXT: call void @dx.op.storeOutput
+// CHECK-NEXT: call void @dx.op.storeOutput
+// CHECK-NEXT: call void @dx.op.storeOutput
+// CHECK: ret void
+float4 main() : SV_Target
+{
+  const float val = float4(0.1F, 1, 0, 1);
+  const float val2 = 0.2F;
+  const float2x2 mat = float3x2(1.1,1.2,2.1,2.2,3.1,3.2);
+  const float2x3 mat2 = 5.0;
+  return float4(val, val2, mat[0][0], mat2[1][1]);
+}


### PR DESCRIPTION
This adds implementations for HLSL vector and matrix truncation. Using
Constant classes to construct a constant vector or structure.

Incidental changes to vector and struct splatting to take advantage of
an existing operation for that purpose.

Adds a test for truncations and splats in constant expressions.

Fixes #2832