### PR TITLE
CMake customization and bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 cmake_minimum_required(VERSION 2.8.12.2)
 
+if (NOT "${DXC_CMAKE_BEGINS_INCLUDE}" STREQUAL "")
+  include(${DXC_CMAKE_BEGINS_INCLUDE})
+endif()
+
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
@@ -736,4 +740,8 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
                               -DCMAKE_INSTALL_COMPONENT=llvm-headers
                               -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
   endif()
+endif()
+
+if (NOT "${DXC_CMAKE_ENDS_INCLUDE}" STREQUAL "")
+  include(${DXC_CMAKE_ENDS_INCLUDE})
 endif()

--- a/cmake/modules/FindD3D12.cmake
+++ b/cmake/modules/FindD3D12.cmake
@@ -33,38 +33,28 @@ find_path(DXGI_INCLUDE_DIR    # Set variable DXGI_INCLUDE_DIR
           DOC "path to WIN10 SDK header files"
           HINTS
           )
-
-if ("${DXC_BUILD_ARCH}" STREQUAL "x64" )
-  find_library(D3D12_LIBRARY NAMES d3d12.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x64 )
-elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM")
-  find_library(D3D12_LIBRARY NAMES d3d12.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm )
-elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM64" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM64")
-  find_library(D3D12_LIBRARY NAMES d3d12.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm64 )
-elseif ("${DXC_BUILD_ARCH}" STREQUAL "Win32" )
-  find_library(D3D12_LIBRARY NAMES d3d12.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x86 )
-endif ("${DXC_BUILD_ARCH}" STREQUAL "x64" )
-
-if ("${DXC_BUILD_ARCH}" STREQUAL "x64" )
-  find_library(DXGI_LIBRARY NAMES dxgi.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x64 )
-elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM")
-  find_library(DXGI_LIBRARY NAMES dxgi.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm )
-elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM64" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM64")
-  find_library(DXGI_LIBRARY NAMES dxgi.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm64 )
-elseif ("${DXC_BUILD_ARCH}" STREQUAL "Win32" )
-  find_library(DXGI_LIBRARY NAMES dxgi.lib
-               HINTS ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x86 )
-endif ("${DXC_BUILD_ARCH}" STREQUAL "x64" )
-
-set(D3D12_LIBRARIES ${D3D12_LIBRARY} ${DXGI_LIBRARY})
 set(D3D12_INCLUDE_DIRS ${D3D12_INCLUDE_DIR} ${DXGI_INCLUDE_DIR})
 
+# Find D3D libraries
+set(D3D12_LIB_NAMES d3d12.lib dxgi.lib d3dcompiler.lib)
+
+if ("${DXC_BUILD_ARCH}" STREQUAL "x64" )
+    set(D3D12_HINTS_PATH ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x64)
+elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM")
+    set(D3D12_HINTS_PATH ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm)
+elseif (CMAKE_GENERATOR MATCHES "Visual Studio.*ARM64" OR "${DXC_BUILD_ARCH}" STREQUAL "ARM64")
+    set(D3D12_HINTS_PATH ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/arm64)
+elseif ("${DXC_BUILD_ARCH}" STREQUAL "Win32" )
+    set(D3D12_HINTS_PATH ${WIN10_SDK_PATH}/Lib/${WIN10_SDK_VERSION}/um/x86)
+else ("${DXC_BUILD_ARCH}" STREQUAL "x64")
+   message(FATAL_ERROR "Cannot match platform.")
+endif ("${DXC_BUILD_ARCH}" STREQUAL "x64")
+
+set(D3D12_LIBRARIES)
+foreach (D3D12_LIB_NAME ${D3D12_LIB_NAMES})
+  find_library(${D3D12_LIB_NAME}_LOC NAMES ${D3D12_LIB_NAME} HINTS ${D3D12_HINTS_PATH})
+  set(D3D12_LIBRARIES ${D3D12_LIBRARIES} ${${D3D12_LIB_NAME}_LOC})
+endforeach(D3D12_LIB_NAME)
 
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set D3D12_FOUND to TRUE

--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -52,7 +52,7 @@ set(DIASDK_INCLUDE_DIRS ${DIASDK_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set DIASDK_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(DIASDK  DEFAULT_MSG
+find_package_handle_standard_args(DiaSDK  DEFAULT_MSG
                                   DIASDK_LIBRARIES DIASDK_INCLUDE_DIR)
 
 mark_as_advanced(DIASDK_INCLUDE_DIRS DIASDK_LIBRARIES)

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -165,6 +165,24 @@ if "%1"=="-no-dxilconv" (
   shift /1
 )
 
+if "%1"=="-dxc-cmake-extra-args" (
+  set CMAKE_OPTS=%CMAKE_OPTS% %~2
+  shift /1
+  shift /1
+)
+
+if "%1"=="-dxc-cmake-begins-include" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -DDXC_CMAKE_BEGINS_INCLUDE=%2
+  shift /1
+  shift /1
+)
+
+if "%1"=="-dxc-cmake-ends-include" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -DDXC_CMAKE_ENDS_INCLUDE=%2
+  shift /1
+  shift /1
+)
+
 rem If only VS 2017 is available, pick that by default.
 if "%BUILD_VS_VER%"=="2015" (
   reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\vs\Servicing\14.0\devenv /v Install /reg:32 1>nul 2>nul
@@ -213,7 +231,7 @@ if "%1"=="-ninja" (
   shift /1
 )
 
-set CMAKE_OPTS=-DHLSL_OPTIONAL_PROJS_IN_DEFAULT:BOOL=%ALL_DEFS%
+set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_OPTIONAL_PROJS_IN_DEFAULT:BOOL=%ALL_DEFS%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_ENABLE_ANALYZE:BOOL=%ANALYZE%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_OFFICIAL_BUILD:BOOL=%OFFICIAL%
 set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_ENABLE_FIXED_VER:BOOL=%FIXED_VER%


### PR DESCRIPTION
Add new options to hctbuild that enable passing in additional arguments to cmake invocation
and also cmake customization hooks that will be included at the beginning and end of DXC's cmake processing.

Rework library search in FindD3D12.cmake and add one more library to look for.

Fix case in FindDiaSDK.cmake - fixes a cmake warning.