### PR TITLE
Fix compiling issues in x86 configuration

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -683,7 +683,7 @@ bool isSameType(const ASTContext &astContext, QualType type1, QualType type2) {
         // consider them different.
         if (fieldTypes1.size() != fieldTypes2.size())
           return false;
-        for (auto i = 0; i < fieldTypes1.size(); ++i)
+        for (size_t i = 0; i < fieldTypes1.size(); ++i)
           if (!isSameType(astContext, fieldTypes1[i], fieldTypes2[i]))
             return false;
         return true;

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -190,6 +190,12 @@ rem End SPIRV change
 
 set BUILD_ARM_CROSSCOMPILING=0
 
+if /i "%BUILD_ARCH%"=="Win32" (
+  if "%BUILD_VS_VER%"=="2019" (
+    set VS2019ARCH=-AWin32
+  )
+)
+
 if /i "%BUILD_ARCH%"=="x64" (
   set BUILD_GENERATOR=%BUILD_GENERATOR% %BUILD_ARCH:x64=Win64%
   if "%BUILD_VS_VER%"=="2019" (
@@ -201,11 +207,17 @@ if /i "%BUILD_ARCH%"=="x64" (
 if /i "%BUILD_ARCH%"=="arm" (
   set BUILD_GENERATOR_PLATFORM=ARM
   set BUILD_ARM_CROSSCOMPILING=1
+  if "%BUILD_VS_VER%"=="2019" (
+    set VS2019ARCH=-AARM
+  )
 )
 
 if /i "%BUILD_ARCH%"=="arm64" (
   set BUILD_GENERATOR_PLATFORM=ARM64
   set BUILD_ARM_CROSSCOMPILING=1
+  if "%BUILD_VS_VER%"=="2019" (
+    set VS2019ARCH=-AARM64
+  )
 )
 
 if "%1"=="-ninja" (

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -353,6 +353,7 @@ rem %1 - the conf name
 rem %2 - the platform name
 rem %3 - the build directory
 rem %4 - the generator name
+rem %5 - the vs2019 architecture name
 if not exist %3 (
   mkdir %3
   if errorlevel 1 (
@@ -369,13 +370,8 @@ if "%DO_SETUP%"=="1" (
     cmake -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   ) else (
     rem -DCMAKE_BUILD_TYPE:STRING=%1 is not necessary for multi-config generators like VS
-    if "%BUILD_VS_VER%"=="2019" (
-      echo Running cmake %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% > %3\cmake-log.txt
-      cmake %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
-    ) else (
-      echo Running cmake %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% > %3\cmake-log.txt
-      cmake %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
-    )
+    echo Running cmake %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% > %3\cmake-log.txt
+    cmake %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   )
   if errorlevel 1 (
     echo Failed to configure cmake projects.


### PR DESCRIPTION
Two issues.

1. When building with VS2019, -A<arch> is not set by hctbuild. It'll generate the project in x64, but set the TAEF path as x86, causing a linking problem.

1. A signed/unsigned mismatch warning (as error) in AstTypeProbe.

