### PR TITLE
hcttest.cmd: Enable specifying location of dxilconv.dll and custom set of binaries

### DIFF
--- a/projects/dxilconv/unittests/DxilConvTests.cpp
+++ b/projects/dxilconv/unittests/DxilConvTests.cpp
@@ -226,7 +226,7 @@ private:
 
 bool DxilConvTest::InitSupport() {
   if (!m_dllSupport.IsEnabled()) {
-    VERIFY_SUCCEEDED(m_dllSupport.Initialize());
+    VERIFY_SUCCEEDED(m_dllSupport.InitializeForDll(L"dxilconv.dll", "DxcCreateInstance"));
   }
 
   if (!FindFxc()) {


### PR DESCRIPTION
Adds an option to hcttest to specify a custom set of binaries to copy to a test folder
plus a custom location of dxilconv.dll. 