### PR TITLE
Correct Const vector truncation test for debug

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/types/vector/constVecTrunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/vector/constVecTrunc.hlsl
@@ -4,7 +4,7 @@
 // If they remain constant, it should simplify down to just storeOutputs
 
 // CHECK: define void @main
-// CHECK-NEXT: call void @dx.op.storeOutput
+// CHECK: call void @dx.op.storeOutput
 // CHECK-NEXT: call void @dx.op.storeOutput
 // CHECK-NEXT: call void @dx.op.storeOutput
 // CHECK-NEXT: call void @dx.op.storeOutput


### PR DESCRIPTION
Debug adds a target for the entry that release doesn't. This accounts
for that slight discrepancy.