### PR TITLE
PIX: Rely on debug info for struct packing

### DIFF
--- a/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
@@ -242,16 +242,6 @@ void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::D
   {
     m_fragmentLocations.push_back({ MemberSize, static_cast<unsigned>(BaseOffset) });
   }
-  //  else
-  //  {
-  //    if (auto* DT = llvm::dyn_cast<llvm::DIDerivedType>(diType)) 
-  //    {
-  //      const llvm::DITypeIdentifierMap EmptyMap;
-  //      llvm::DIType* BT = DT->getBaseType().resolve(EmptyMap);
-  //      DetermineStructMemberSizesAndOffsets(BT, MemberOffset + BaseOffset);
-  //    }
-  //  }
-  //}
   else
   {
     if (auto* CT = llvm::dyn_cast<llvm::DICompositeType>(diType))
@@ -302,11 +292,6 @@ void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::D
       llvm::DIType* BT = DT->getBaseType().resolve(EmptyMap);
       DetermineStructMemberSizesAndOffsets(BT, BaseOffset);
     }
-    //else
-    //{
-    //  assert(!"Unhandled DIType");
-    //  throw hlsl::Exception(E_FAIL, "Unhandled DIType");
-    //}
   }
 }
 

--- a/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
@@ -213,85 +213,108 @@ private:
   std::vector<FragmentSizeAndOffset> m_fragmentLocations;
   unsigned m_currentFragment = 0;
   void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(
-    llvm::DIType const*);
+    llvm::DIType const*, uint64_t BaseOffset);
 };
 
-
-void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::DIType const*diType) 
+unsigned SizeIfBaseType(llvm::DIType const* diType)
 {
-  auto AddANewFragment = [=](llvm::DIType const * type)
+  if (auto* BT = llvm::dyn_cast<llvm::DIBasicType>(diType))
   {
-    unsigned size = static_cast<unsigned>(type->getSizeInBits());
-    if (m_fragmentLocations.empty())
-    {
-      m_fragmentLocations.push_back({ size, 0 });
-    }
-    else
-    {
-      unsigned offset = m_fragmentLocations.back().Offset + m_fragmentLocations.back().Size;
-      m_fragmentLocations.push_back({ size, offset });
-    }
-  };
-
-  if (auto* BT = llvm::dyn_cast<llvm::DIBasicType>(diType)) 
-  {
-    AddANewFragment(BT);
+    return BT->getSizeInBits();
   }
-  else if (auto* CT = llvm::dyn_cast<llvm::DICompositeType>(diType))
-  {
-    switch (diType->getTag())
-    {
-    case llvm::dwarf::DW_TAG_array_type :
-    {
-      llvm::DINodeArray elements = CT->getElements();
-      unsigned arraySize = 1;
-      for (auto const& node : elements)
-      {
-        if (llvm::DISubrange* SR = llvm::dyn_cast<llvm::DISubrange>(node))
-        {
-          arraySize *= SR->getCount();
-        }
-      }
-      const llvm::DITypeIdentifierMap EmptyMap;
-      llvm::DIType *BT = CT->getBaseType().resolve(EmptyMap);
-      for (unsigned i = 0; i < arraySize; ++i) {
-        DetermineStructMemberSizesAndOffsets(BT);
-      }
-    }
-      break;
-    case llvm::dwarf::DW_TAG_class_type:
-    case llvm::dwarf::DW_TAG_structure_type:
-      for (auto const& node : CT->getElements())
-      {
-        if (llvm::DIType* subType = llvm::dyn_cast<llvm::DIType>(node))
-        {
-          DetermineStructMemberSizesAndOffsets(subType);
-        }
-
-      }
-      break;
-    default:
-      diType->dump();
-      break;
-    }
-  }
-  else if (auto *DT = llvm::dyn_cast<llvm::DIDerivedType>(diType)) 
+  if (auto* DT = llvm::dyn_cast<llvm::DIDerivedType>(diType))
   {
     const llvm::DITypeIdentifierMap EmptyMap;
-    llvm::DIType *BT = DT->getBaseType().resolve(EmptyMap);
-    DetermineStructMemberSizesAndOffsets(BT);
+    return SizeIfBaseType(DT->getBaseType().resolve(EmptyMap));
   }
+  return 0;
+}
+
+void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::DIType const*diType, uint64_t BaseOffset)
+{
+  diType->dump();
+  if (diType->getTag() == llvm::dwarf::DW_TAG_member)
+  {
+    BaseOffset += diType->getOffsetInBits();
+  }
+  unsigned MemberSize = SizeIfBaseType(diType);
+  if (MemberSize != 0)
+  {
+    m_fragmentLocations.push_back({ MemberSize, static_cast<unsigned>(BaseOffset) });
+  }
+  //  else
+  //  {
+  //    if (auto* DT = llvm::dyn_cast<llvm::DIDerivedType>(diType)) 
+  //    {
+  //      const llvm::DITypeIdentifierMap EmptyMap;
+  //      llvm::DIType* BT = DT->getBaseType().resolve(EmptyMap);
+  //      DetermineStructMemberSizesAndOffsets(BT, MemberOffset + BaseOffset);
+  //    }
+  //  }
+  //}
   else
   {
-    assert(!"Unhandled DIType");
-    throw hlsl::Exception(E_FAIL, "Unhandled DIType");
+    if (auto* CT = llvm::dyn_cast<llvm::DICompositeType>(diType))
+    {
+
+      switch (diType->getTag())
+      {
+      case llvm::dwarf::DW_TAG_array_type:
+      {
+        llvm::DINodeArray elements = CT->getElements();
+        unsigned arraySize = 1;
+        for (auto const& node : elements)
+        {
+          if (llvm::DISubrange* SR = llvm::dyn_cast<llvm::DISubrange>(node))
+          {
+            arraySize *= SR->getCount();
+          }
+        }
+        if (arraySize != 0)
+        {
+          const llvm::DITypeIdentifierMap EmptyMap;
+          llvm::DIType* BT = CT->getBaseType().resolve(EmptyMap);
+          unsigned elementSize = static_cast<unsigned>(CT->getSizeInBits()) / arraySize;
+          for (unsigned i = 0; i < arraySize; ++i) {
+            DetermineStructMemberSizesAndOffsets(BT, BaseOffset + i * elementSize);
+          }
+        }
+      }
+      break;
+      case llvm::dwarf::DW_TAG_class_type:
+      case llvm::dwarf::DW_TAG_structure_type:
+        for (auto const& node : CT->getElements())
+        {
+          if (llvm::DIType* subType = llvm::dyn_cast<llvm::DIType>(node))
+          {
+            DetermineStructMemberSizesAndOffsets(subType, BaseOffset /*TODO: plus member offset*/);
+          }
+        }
+        break;
+      default:
+        diType->dump();
+        break;
+      }
+    }
+    else if (auto* DT = llvm::dyn_cast<llvm::DIDerivedType>(diType))
+    {
+      const llvm::DITypeIdentifierMap EmptyMap;
+      llvm::DIType* BT = DT->getBaseType().resolve(EmptyMap);
+      DetermineStructMemberSizesAndOffsets(BT, BaseOffset);
+    }
+    //else
+    //{
+    //  assert(!"Unhandled DIType");
+    //  throw hlsl::Exception(E_FAIL, "Unhandled DIType");
+    //}
   }
 }
 
 CompositeTypeFragmentIterator::CompositeTypeFragmentIterator(
   llvm::DICompositeType* CT)
 {
-  DetermineStructMemberSizesAndOffsets(CT);
+  OutputDebugStringA("--------------------------------------------\n");
+  DetermineStructMemberSizesAndOffsets(CT, 0);
 }
 
 unsigned CompositeTypeFragmentIterator::SizeInBits(unsigned Index) const

--- a/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
@@ -232,7 +232,6 @@ unsigned SizeIfBaseType(llvm::DIType const* diType)
 
 void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::DIType const*diType, uint64_t BaseOffset)
 {
-  diType->dump();
   if (diType->getTag() == llvm::dwarf::DW_TAG_member)
   {
     BaseOffset += diType->getOffsetInBits();
@@ -298,7 +297,6 @@ void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(llvm::D
 CompositeTypeFragmentIterator::CompositeTypeFragmentIterator(
   llvm::DICompositeType* CT)
 {
-  OutputDebugStringA("--------------------------------------------\n");
   DetermineStructMemberSizesAndOffsets(CT, 0);
 }
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -629,7 +629,7 @@ public:
       WEX::Logging::Log::Error(errorTextW);
     }
 
-#if 1 //handy for debugging
+#if 0 //handy for debugging
     {
       CComPtr<IDxcBlob> pProgram;
       CheckOperationSucceeded(pResult, &pProgram);

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -1785,8 +1785,6 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(const char* hlsl)
           }
           else
           {
-            // Next member has to start where the previous one ended:
-            //VERIFY_ARE_EQUAL(iterator->OffsetInBits(memberIndex), startingBit + coveredBits);
             coveredBits = std::max<unsigned int>( coveredBits, iterator->OffsetInBits(memberIndex) + iterator->SizeInBits(memberIndex));
           }
         }
@@ -1811,7 +1809,7 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(const char* hlsl)
           // memberIndex might be greater, because the fragment iterator also includes contained derived types as
           // fragments, in addition to the members of that contained derived types. CountStructMembers only counts
           // the leaf-node types.
-          VERIFY_IS_GREATER_THAN_OR_EQUAL(memberIndex, countOfMembers);
+          VERIFY_ARE_EQUAL(countOfMembers, memberIndex);
         }
         else if (pAllocaTy->isFloatingPointTy() || pAllocaTy->isIntegerTy())
         {
@@ -1839,7 +1837,7 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(const char* hlsl)
       {
         VERIFY_IS_FALSE(found);
         found = true;
-        VERIFY_IS_GREATER_THAN_OR_EQUAL((int)cover.countOfMembers, valueLocation.count);
+        VERIFY_ARE_EQUAL(valueLocation.count, cover.countOfMembers);
       }
     }
     VERIFY_IS_TRUE(found);


### PR DESCRIPTION
Previously, this fragment iterator would attempt to figure out offsets for each struct fragment by itself. This was error-prone and unnecessary: the debug info already has this information.
In particular, the old code didn't handle natural alignment and the possible dead space between fragments that this might create.
Unfortunately the debug info is pretty hard to parse: things with the "member" tag are a few layers of type above the basic type that they actually represent, and contained structs' members have offsets relative to the start of that contained struct, not to the start of the whole struct. Both of these necessitate a recursive approach.
Subsequent work: run these tests with and without -enable-16bit-types and with different optimization levels. The latter is blocked behind bugs in the dbg.value-to-declare pass.