### PR TITLE
Add iostream header to files using std::hex

### DIFF
--- a/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 #include <set>
+#include <iostream>
 
 #include "DxilRootSignatureHelper.h"
 

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -37,6 +37,7 @@
 #include <comdef.h>
 #include <thread>
 #include <unordered_map>
+#include <iostream>
 
 #include "llvm/Support//MSFileSystem.h"
 #include "llvm/Support/CommandLine.h"


### PR DESCRIPTION
Possibly due to a visual studio update, building with vs2019 started
causing build failures due to using std::hex without the necessary
iostream include. This adds that include to the two files that need it.