### PR TITLE
Allow SV_CullPrimitive on PS input, resolve to false

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -702,7 +702,7 @@ InsideTessFactor       NA           NA       NA           NA           NA       
 ViewID                 NotInSig _61 NA       NotInSig _61 NotInSig _61 NA       NA       NA         NotInSig _61 NA       NA       NA       NotInSig _61 NA       NotInSig _61  NA            NA       NotInSig NA       NA        NA
 Barycentrics           NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NotPacked _61 NA            NA       NA       NA       NA        NA
 ShadingRate            NA           SV _64   NA           NA           SV _64   SV _64   NA         NA           SV _64   SV _64   SV _64   NA           SV _64   SV _64        NA            NA       NA       NA       SV        NA
-CullPrimitive          NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NA            NA            NA       NA       NA       NotPacked NA
+CullPrimitive          NA           NA       NA           NA           NA       NA       NA         NA           NA       NA       NA       NA           NA       NotInSig      NA            NA       NA       NA       NotPacked NA
 ====================== ============ ======== ============ ============ ======== ======== ========== ============ ======== ======== ======== ============ ======== ============= ============= ======== ======== ======== ========= ========
 
 .. SEMINT-TABLE-RST:END

--- a/include/dxc/DXIL/DxilSigPoint.inl
+++ b/include/dxc/DXIL/DxilSigPoint.inl
@@ -85,7 +85,7 @@ const SigPoint SigPoint::ms_SigPoints[kNumSigPointRecords] = {
   ROW(ViewID,                 NotInSig _61, NA,       NotInSig _61, NotInSig _61, NA,       NA,       NA,         NotInSig _61, NA,       NA,       NA,       NotInSig _61, NA,       NotInSig _61,  NA,            NA,       NotInSig, NA,       NA,        NA) \
   ROW(Barycentrics,           NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NotPacked _61, NA,            NA,       NA,       NA,       NA,        NA) \
   ROW(ShadingRate,            NA,           SV _64,   NA,           NA,           SV _64,   SV _64,   NA,         NA,           SV _64,   SV _64,   SV _64,   NA,           SV _64,   SV _64,        NA,            NA,       NA,       NA,       SV,        NA) \
-  ROW(CullPrimitive,          NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NA,            NA,            NA,       NA,       NA,       NotPacked, NA)
+  ROW(CullPrimitive,          NA,           NA,       NA,           NA,           NA,       NA,       NA,         NA,           NA,       NA,       NA,       NA,           NA,       NotInSig,      NA,            NA,       NA,       NA,       NotPacked, NA)
 // INTERPRETATION-TABLE:END
 
 const VersionedSemanticInterpretation SigPoint::ms_SemanticInterpretationTable[(unsigned)DXIL::SemanticKind::Invalid][(unsigned)SigPoint::Kind::Invalid] = {

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -141,6 +141,10 @@ void replaceInputOutputWithIntrinsic(DXIL::SemanticKind semKind, Value *GV,
   case Semantic::Kind::GroupIndex:
     opcode = OP::OpCode::FlattenedThreadIdInGroup;
     break;
+  case Semantic::Kind::CullPrimitive: {
+    GV->replaceAllUsesWith(ConstantInt::get(Ty, (uint64_t)0));
+    return;
+  } break;
   default:
     DXASSERT(0, "invalid semantic");
     return;

--- a/tools/clang/test/HLSL/system-values.hlsl
+++ b/tools/clang/test/HLSL/system-values.hlsl
@@ -39,6 +39,7 @@
 #define Def_ViewID DECLARE(uint viewID : SV_ViewID) USE(uint, viewID)
 #define Def_Barycentrics DECLARE(float3 BaryWeights : SV_Barycentrics) USE(float, BaryWeights.x) USE(float, BaryWeights.y) USE(float, BaryWeights.z)
 #define Def_ShadingRate DECLARE(uint rate : SV_ShadingRate) USE(uint, rate)
+#define Def_CullPrimitive DECLARE(bool cullprim : SV_CullPrimitive) USE(bool, cullprim)
 
 #define Domain_Quad 0
 #define Domain_Tri 1

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_cullprimitive/cullprimitive.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_cullprimitive/cullprimitive.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T ps_6_4 -E main %s | FileCheck %s
+
+// SV_CullPrimitive just lowers to false, with nothing in signature
+// CHECK: ; Input signature:
+// CHECK-NEXT: ;
+// CHECK-NEXT: ; Name                 Index   Mask Register SysValue  Format   Used
+// CHECK-NEXT: ; -------------------- ----- ------ -------- -------- ------- ------
+// CHECK-NEXT: ; no parameters
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 0)
+
+uint main(bool b : SV_CullPrimitive) : SV_Target {
+  return b;
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2267,7 +2267,7 @@ class db_dxil(object):
             ViewID,NotInSig _61,NA,NotInSig _61,NotInSig _61,NA,NA,NA,NotInSig _61,NA,NA,NA,NotInSig _61,NA,NotInSig _61,NA,NA,NotInSig,NA,NA,NA
             Barycentrics,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NotPacked _61,NA,NA,NA,NA,NA,NA
             ShadingRate,NA,SV _64,NA,NA,SV _64,SV _64,NA,NA,SV _64,SV _64,SV _64,NA,SV _64,SV _64,NA,NA,NA,NA,SV,NA
-            CullPrimitive,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NotPacked,NA
+            CullPrimitive,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NA,NotInSig,NA,NA,NA,NA,NotPacked,NA
         """
         table = [list(map(str.strip, line.split(','))) for line in SemanticInterpretationCSV.splitlines() if line.strip()]
         for row in table[1:]: assert(len(row) == len(table[0])) # Ensure table is rectangular


### PR DESCRIPTION
Allow SV_CullPrimitive to be declared on PS input so structures are more easily shared between mesh shader and pixel shaders.

This would just resolve to constant false if read, and won't appear in the input signature for the compiled shader.  So this is only a front-end change, not a change to DXIL.