### PR TITLE
Better post-CG error formats using custom diaginfo

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -84,8 +84,6 @@ namespace dxilutil {
   void EmitWarningOnGlobalVariable(llvm::GlobalVariable *GV, llvm::Twine Msg);
 
   void EmitResMappingError(llvm::Instruction *Res);
-  std::string FormatMessageAtLocation(const llvm::DebugLoc &DL, const llvm::Twine& Msg);
-  llvm::Twine FormatMessageWithoutLocation(const llvm::Twine& Msg);
   // Simple demangle just support case "\01?name@" pattern.
   llvm::StringRef DemangleFunctionName(llvm::StringRef name);
   // ReplaceFunctionName replaces the undecorated portion of originalName with undecorated newName

--- a/include/llvm/IR/DiagnosticInfo.h
+++ b/include/llvm/IR/DiagnosticInfo.h
@@ -58,6 +58,7 @@ enum DiagnosticKind {
   DK_OptimizationRemarkAnalysis,
   DK_OptimizationFailure,
   DK_MIRParser,
+  DK_DXIL, // HLSL Change
   DK_FirstPluginKind
 };
 
@@ -472,6 +473,38 @@ void emitLoopVectorizeWarning(LLVMContext &Ctx, const Function &Fn,
 /// diagnostic is generated. \p Msg is the message string to use.
 void emitLoopInterleaveWarning(LLVMContext &Ctx, const Function &Fn,
                                const DebugLoc &DLoc, const Twine &Msg);
+
+// HLSL Change start - Dxil Diagnostic Info reporter
+
+/// Diagnostic information for Dxil errors
+/// Intended for use in post-codegen passes
+/// where location information is stored in metadata
+class DiagnosticInfoDxil : public DiagnosticInfo {
+private:
+  // Location information
+  const DILocation *DLoc;
+
+  /// Message to be reported.
+  const Twine &MsgStr;
+
+public:
+  /// This class does not copy \p MsgStr, therefore the reference must be valid
+  /// for the whole life time of the Diagnostic.
+  DiagnosticInfoDxil(const DILocation *Loc, const Twine &MsgStr,
+                     DiagnosticSeverity Severity = DS_Error)
+    : DiagnosticInfo(DK_DXIL, Severity), DLoc(Loc), MsgStr(MsgStr) {}
+
+  const DILocation *getLocation() const { return DLoc; }
+  const Twine &getMsgStr() const { return MsgStr; }
+
+  /// \see DiagnosticInfo::print.
+  void print(DiagnosticPrinter &DP) const override;
+
+  static bool classof(const DiagnosticInfo *DI) {
+    return DI->getKind() == DK_DXIL;
+  }
+};
+// HLSL Change end - Dxil Diagnostic Info reporter
 
 } // End namespace llvm
 

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -321,7 +321,7 @@ void HLSignatureLower::ProcessArgument(Function *func,
            SemanticUseMap.count((unsigned)DXIL::SemanticKind::Coverage) > 0)) {
         dxilutil::EmitErrorOnFunction(func,
             "Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually "
-            "exclusive");
+            "exclusive.");
         return;
       }
     }
@@ -1128,7 +1128,7 @@ void HLSignatureLower::GenerateDxilInputsOutputs(DXIL::SignatureKind SK) {
       OSS << "(type for " << SE->GetName() << ")";
       OSS << " cannot be used as shader inputs or outputs.";
       OSS.flush();
-      HLM.GetCtx().emitError(O);
+      dxilutil::EmitErrorOnFunction(Entry, O);
       continue;
     }
     Function *dxilFunc = hlslOP->GetOpFunc(opcode, Ty);

--- a/lib/IR/DiagnosticInfo.cpp
+++ b/lib/IR/DiagnosticInfo.cpp
@@ -229,3 +229,26 @@ void llvm::emitLoopInterleaveWarning(LLVMContext &Ctx, const Function &Fn,
   Ctx.diagnose(DiagnosticInfoOptimizationFailure(
       Fn, DLoc, Twine("loop not interleaved: " + Msg)));
 }
+
+// HLSL Change start - Dxil Diagnostic Info reporter
+
+// Slapdash printing of diagnostic information as a last resort
+// Used by dxl. Doesn't include source snippets.
+void DiagnosticInfoDxil::print(DiagnosticPrinter &DP) const {
+  if (DLoc) {
+    DIScope *scope = cast<DIScope>(DLoc->getRawScope());
+    DP << scope->getFilename() << DLoc->getLine() << ":";
+    unsigned Column = DLoc->getColumn();
+    if (Column > 0)
+      DP << Column << ":";
+  }
+
+  switch (getSeverity()) {
+  case DiagnosticSeverity::DS_Note:    DP << " note: "; break;
+  case DiagnosticSeverity::DS_Remark:  DP << " remark: "; break;
+  case DiagnosticSeverity::DS_Warning: DP << " warning: "; break;
+  case DiagnosticSeverity::DS_Error:   DP << " error: "; break;
+  }
+  DP << getMsgStr();
+}
+// HLSL Change end - Dxil Diagnostic Info reporter

--- a/lib/Transforms/Scalar/DxilLoopUnroll.cpp
+++ b/lib/Transforms/Scalar/DxilLoopUnroll.cpp
@@ -68,6 +68,7 @@
 #include "llvm/Transforms/Utils/SSAUpdater.h"
 #include "llvm/Transforms/Utils/LoopUtils.h"
 #include "llvm/Transforms/Utils/PromoteMemToReg.h"
+#include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
@@ -137,18 +138,10 @@ public:
 char DxilLoopUnroll::ID;
 
 static void FailLoopUnroll(bool WarnOnly, LLVMContext &Ctx, DebugLoc DL, const Twine &Message) {
-  if (WarnOnly) {
-    if (DL)
-      Ctx.emitWarning(hlsl::dxilutil::FormatMessageAtLocation(DL, Message));
-    else
-      Ctx.emitWarning(hlsl::dxilutil::FormatMessageWithoutLocation(Message));
-  }
-  else {
-    if (DL)
-      Ctx.emitError(hlsl::dxilutil::FormatMessageAtLocation(DL, Message));
-    else
-      Ctx.emitError(hlsl::dxilutil::FormatMessageWithoutLocation(Message));
-  }
+  DiagnosticSeverity severity = DiagnosticSeverity::DS_Error;
+  if (WarnOnly)
+    severity = DiagnosticSeverity::DS_Warning;
+  Ctx.diagnose(DiagnosticInfoDxil(DL.get(), Message, severity));
 }
 
 struct LoopIteration {

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -538,18 +538,16 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
   ComputeDiagID(D.getSeverity(), inline_asm, DiagID);
 
   SourceManager &SourceMgr = Context->getSourceManager();
-  FileManager &FileMgr = SourceMgr.getFileManager();
-  StringRef Filename;
-  unsigned Line, Column;
   SourceLocation DILoc;
   std::string Message = D.getMsgStr().str();
   const DILocation *DLoc = D.getLocation();
 
   // Convert Filename/Line/Column triplet into SourceLocation
   if (DLoc) {
-    Filename = DLoc->getFilename();
-    Line = DLoc->getLine();
-    Column = DLoc->getColumn();
+    FileManager &FileMgr = SourceMgr.getFileManager();
+    StringRef Filename = DLoc->getFilename();
+    unsigned Line = DLoc->getLine();
+    unsigned Column = DLoc->getColumn();
     const FileEntry *FE = FileMgr.getFile(Filename);
     if (FE && Line > 0) {
       DILoc = SourceMgr.translateFileLineCol(FE, Line, Column ? Column : 1);

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -266,6 +266,8 @@ namespace clang {
         const llvm::DiagnosticInfoOptimizationRemarkAnalysis &D);
     void OptimizationFailureHandler(
         const llvm::DiagnosticInfoOptimizationFailure &D);
+    bool DxilDiagHandler(const llvm::DiagnosticInfoDxil &D);
+
   };
   
   void BackendConsumer::anchor() {}
@@ -529,6 +531,41 @@ void BackendConsumer::linkerDiagnosticHandler(const DiagnosticInfo &DI) {
       << LinkModule->getModuleIdentifier() << MsgStorage;
 }
 
+// HLSL Change start - Dxil Diagnostic Info reporter
+bool
+BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
+  unsigned DiagID;
+  ComputeDiagID(D.getSeverity(), inline_asm, DiagID);
+
+  SourceManager &SourceMgr = Context->getSourceManager();
+  FileManager &FileMgr = SourceMgr.getFileManager();
+  StringRef Filename;
+  unsigned Line, Column;
+  SourceLocation DILoc;
+  std::string Message = D.getMsgStr().str();
+  const DILocation *DLoc = D.getLocation();
+
+  // Convert Filename/Line/Column triplet into SourceLocation
+  if (DLoc) {
+    Filename = DLoc->getFilename();
+    Line = DLoc->getLine();
+    Column = DLoc->getColumn();
+    const FileEntry *FE = FileMgr.getFile(Filename);
+    if (FE && Line > 0) {
+      DILoc = SourceMgr.translateFileLineCol(FE, Line, Column ? Column : 1);
+    }
+  }
+  FullSourceLoc Loc(DILoc, SourceMgr);
+
+  // If no location information is available, prompt for debug flag
+  if (Loc.isInvalid())
+    Message += " Use /Zi for source location.";
+  Diags.Report(Loc, DiagID).AddString(Message);
+
+  return true;
+}
+// HLSL Change end - Dxil Diagnostic Info reporter
+
 /// \brief This function is invoked when the backend needs
 /// to report something to the user.
 void BackendConsumer::DiagnosticHandlerImpl(const DiagnosticInfo &DI) {
@@ -567,6 +604,13 @@ void BackendConsumer::DiagnosticHandlerImpl(const DiagnosticInfo &DI) {
     // handler.
     OptimizationFailureHandler(cast<DiagnosticInfoOptimizationFailure>(DI));
     return;
+// HLSL Change start - Dxil Diagnostic Info reporter
+  case llvm::DK_DXIL:
+    if (DxilDiagHandler(cast<DiagnosticInfoDxil>(DI)))
+      return;
+    ComputeDiagID(Severity, inline_asm, DiagID);
+    break;
+// HLSL Change end - Dxil Diagnostic Info reporter
   default:
     // Plugin IDs are not bound to any value as they are set dynamically.
     ComputeDiagRemarkID(Severity, backend_plugin, DiagID);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/AddUint64Odd.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/AddUint64Odd.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: AddUint64 can only be applied to uint2 and uint4 operands
+// CHK_DB: 8:12: error: AddUint64 can only be applied to uint2 and uint4 operands.
+// CHK_NODB: error: AddUint64 can only be applied to uint2 and uint4 operands. Use /Zi for source location.
 
 float4 main(uint4 a : A, uint4 b :B) : SV_TARGET {
   uint c = AddUint64(a.x, b.x);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/InnerCoverage.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/InnerCoverage.hlsl
@@ -1,9 +1,12 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // note: define GENLL in order to generate the basis for InnerCoverage.ll
 
-// CHECK: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0
-// CHECK: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive
+// CHK_DB: 11:1: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0.
+// CHK_DB: 11:1: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive.
+// CHK_NODB: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0. Use /Zi for source location.
+// CHK_NODB: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive. Use /Zi for source location.
 
 void main(snorm float b : B, uint c:C, 
 #ifndef GENLL

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/invalid_input_output_types.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/invalid_input_output_types.hlsl
@@ -1,7 +1,10 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: cannot be used as shader inputs or outputs
-// CHECK: cannot be used as shader inputs or outputs
+// CHK_DB: 9:1: error: i64(type for I) cannot be used as shader inputs or outputs.
+// CHK_DB: 9:1: error: double(type for SV_Target) cannot be used as shader inputs or outputs.
+// CHK_NODB: cannot be used as shader inputs or outputs. Use /Zi for source location.
+// CHK_NODB: cannot be used as shader inputs or outputs. Use /Zi for source location.
 
 double main(uint64_t i:I) : SV_Target {
     return 1;

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource2.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
+// CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource3.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
+// CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
@@ -1,7 +1,8 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
-// CHECK: Use /Zi for source location
+// CHK_DB: 17:7: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
@@ -1,6 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
 // CHECK: local resource not guaranteed to map to unique global resource
+// CHECK: Use /Zi for source location
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5_dbg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5_dbg.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
+// CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
+// CHK_DB: 18:7: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6_dbg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6_dbg.hlsl
@@ -1,6 +1,8 @@
-// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: local resource not guaranteed to map to unique global resource
+// CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
+// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt3.hlsl
@@ -1,6 +1,12 @@
-// RUN: %dxc -E main -T ps_6_0 -Od %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: Offsets for Sample* must be immediated value
+// CHK_DB: 20:36: error: Offsets for Sample* must be immediated value
+// CHK_DB: 20:40: error: Offsets for Sample* must be immediated value
+// CHK_NODB: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
+// CHK_NODB: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
 
 SamplerState samp1 : register(s5);
 Texture2D<float4> text1 : register(t3);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt4.hlsl
@@ -1,6 +1,19 @@
-// RUN: %dxc -E main -T ps_6_0 -Od %s | FileCheck %s
+// RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHECK: Offsets for Sample* must be immediated value
+// CHK_DB: 27:39: error: Offsets for Sample* must be immediated value
+// CHK_DB: 27:43: error: Offsets for Sample* must be immediated value
+// CHK_DB: 27:10: error: Offsets for Sample* must be immediated value
+// CHK_DB: 27:10: error: Offsets for Sample* must be immediated value
+
+// CHK_NODB: error: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
+// CHK_NODB: error: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
+// CHK_NODB: error: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
+// CHK_NODB: error: Offsets for Sample* must be immediated value.
+// CHK_NODB-SAME Use /Zi for source location.
 
 SamplerState samp1 : register(s5);
 Texture2D<float4> text1 : register(t3);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unsupported_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unsupported_error.hlsl
@@ -1,8 +1,10 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // Regression test for a crash when lowering unsupported intrinsics
 
-// CHECK: error: Unsupported intrinsic
+// CHK_DB: 10:50: error: Unsupported intrinsic
+// CHK_NODB: error: Unsupported intrinsic. Use /Zi for source location.
 
 sampler TextureSampler;
 float4 main(float2 uv	: UV) : SV_Target { return tex2D(TextureSampler, uv); }


### PR DESCRIPTION
The existing diagnosticinfo and handler relied on a token for the source
location that isn't available to these locations. By creating
specialized versions, we can retrieve the information from where it is
available and convert it to the source location ID that allows the usage
of the existing diagnostic output complete with code snippets