### PR TITLE
[spirv] handle bindless opaque array type argument passing

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -276,6 +276,9 @@ bool isOrContainsNonFpColMajorMatrix(const ASTContext &,
 /// \bried Returns true if the given type is a String or StringLiteral type.
 bool isStringType(QualType);
 
+/// \bried Returns true if the given type is a bindless array of an opaque type.
+bool isBindlessOpaqueArray(QualType type);
+
 /// \brief Generates the corresponding SPIR-V vector type for the given Clang
 /// frontend matrix type's vector component and returns the <result-id>.
 ///

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -71,7 +71,6 @@ public:
   ///
   /// At any time, there can only exist at most one function under building.
   SpirvFunction *beginFunction(QualType returnType,
-                               llvm::ArrayRef<QualType> paramTypes,
                                SourceLocation, llvm::StringRef name = "",
                                bool isPrecise = false,
                                SpirvFunction *func = nullptr);

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -80,27 +80,12 @@ public:
   SpirvFunctionParameter *addFnParam(QualType ptrType, bool isPrecise,
                                      SourceLocation, llvm::StringRef name = "");
 
-  /// \brief Creates and registers a function parameter of the given pointer
-  /// type in the current function and returns its pointer.
-  ///
-  /// The function parameter will have a SpirvType without a QualType.
-  SpirvFunctionParameter *addFnParam(const SpirvType *spvType, bool isPrecise,
-                                     SourceLocation, llvm::StringRef name = "");
-
   /// \brief Creates a local variable of the given type in the current
   /// function and returns it.
   ///
   /// The corresponding pointer type of the given type will be constructed in
   /// this method for the variable itself.
   SpirvVariable *addFnVar(QualType valueType, SourceLocation,
-                          llvm::StringRef name = "", bool isPrecise = false,
-                          SpirvInstruction *init = nullptr);
-
-  /// \brief Creates a local variable of the given type in the current
-  /// function and returns it.
-  ///
-  /// The local variable will have a SpirvType without a QualType.
-  SpirvVariable *addFnVar(const SpirvType *spvType, SourceLocation,
                           llvm::StringRef name = "", bool isPrecise = false,
                           SpirvInstruction *init = nullptr);
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -81,12 +81,27 @@ public:
   SpirvFunctionParameter *addFnParam(QualType ptrType, bool isPrecise,
                                      SourceLocation, llvm::StringRef name = "");
 
+  /// \brief Creates and registers a function parameter of the given pointer
+  /// type in the current function and returns its pointer.
+  ///
+  /// The function parameter will have a SpirvType without a QualType.
+  SpirvFunctionParameter *addFnParam(const SpirvType *spvType, bool isPrecise,
+                                     SourceLocation, llvm::StringRef name = "");
+
   /// \brief Creates a local variable of the given type in the current
   /// function and returns it.
   ///
   /// The corresponding pointer type of the given type will be constructed in
   /// this method for the variable itself.
   SpirvVariable *addFnVar(QualType valueType, SourceLocation,
+                          llvm::StringRef name = "", bool isPrecise = false,
+                          SpirvInstruction *init = nullptr);
+
+  /// \brief Creates a local variable of the given type in the current
+  /// function and returns it.
+  ///
+  /// The local variable will have a SpirvType without a QualType.
+  SpirvVariable *addFnVar(const SpirvType *spvType, SourceLocation,
                           llvm::StringRef name = "", bool isPrecise = false,
                           SpirvInstruction *init = nullptr);
 

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -24,7 +24,7 @@ class SpirvVisitor;
 /// The class representing a SPIR-V function in memory.
 class SpirvFunction {
 public:
-  SpirvFunction(QualType astReturnType, llvm::ArrayRef<QualType> astParamTypes,
+  SpirvFunction(QualType astReturnType,
                 SourceLocation, llvm::StringRef name = "",
                 bool precise = false);
   ~SpirvFunction() = default;
@@ -53,12 +53,8 @@ public:
   // Gets the function AST return type
   QualType getAstReturnType() const { return astReturnType; }
 
-  // Sets the vector of parameter QualTypes.
-  void setAstParamTypes(llvm::ArrayRef<QualType> paramTypes) {
-    astParamTypes.append(paramTypes.begin(), paramTypes.end());
-  }
-  // Gets the vector of parameter QualTypes.
-  llvm::ArrayRef<QualType> getAstParamTypes() const { return astParamTypes; }
+  // Gets the vector of parameters.
+  llvm::SmallVector<SpirvFunctionParameter *, 8> getParameters() const { return parameters; }
 
   // Sets the SPIR-V type of the function
   void setFunctionType(SpirvType *type) { fnType = type; }
@@ -99,7 +95,6 @@ private:
   uint32_t functionId; ///< This function's <result-id>
 
   QualType astReturnType;                       ///< The return type
-  llvm::SmallVector<QualType, 4> astParamTypes; ///< The paratemer types in AST
   SpirvType *returnType;                        ///< The lowered return type
   SpirvType *fnType;                            ///< The SPIR-V function type
 

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -24,9 +24,8 @@ class SpirvVisitor;
 /// The class representing a SPIR-V function in memory.
 class SpirvFunction {
 public:
-  SpirvFunction(QualType astReturnType,
-                SourceLocation, llvm::StringRef name = "",
-                bool precise = false);
+  SpirvFunction(QualType astReturnType, SourceLocation,
+                llvm::StringRef name = "", bool precise = false);
   ~SpirvFunction() = default;
 
   // Forbid copy construction and assignment
@@ -54,7 +53,9 @@ public:
   QualType getAstReturnType() const { return astReturnType; }
 
   // Gets the vector of parameters.
-  llvm::SmallVector<SpirvFunctionParameter *, 8> getParameters() const { return parameters; }
+  llvm::SmallVector<SpirvFunctionParameter *, 8> getParameters() const {
+    return parameters;
+  }
 
   // Sets the SPIR-V type of the function
   void setFunctionType(SpirvType *type) { fnType = type; }

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -454,6 +454,10 @@ public:
   SpirvVariable(QualType resultType, SourceLocation loc, spv::StorageClass sc,
                 bool isPrecise, SpirvInstruction *initializerId = 0);
 
+  SpirvVariable(const SpirvType *spvType, SourceLocation loc,
+                spv::StorageClass sc, bool isPrecise,
+                SpirvInstruction *initializerId = 0);
+
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
     return inst->getKind() == IK_Variable;
@@ -480,6 +484,9 @@ private:
 class SpirvFunctionParameter : public SpirvInstruction {
 public:
   SpirvFunctionParameter(QualType resultType, bool isPrecise,
+                         SourceLocation loc);
+
+  SpirvFunctionParameter(const SpirvType *spvType, bool isPrecise,
                          SourceLocation loc);
 
   // For LLVM-style RTTI

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1124,6 +1124,11 @@ bool isStringType(QualType type) {
   return hlsl::IsStringType(type) || hlsl::IsStringLiteralType(type);
 }
 
+bool isBindlessOpaqueArray(QualType type) {
+  return !type.isNull() && isOpaqueArrayType(type) &&
+         !type->isConstantArrayType();
+}
+
 QualType getComponentVectorType(const ASTContext &astContext,
                                 QualType matrixType) {
   assert(isMxNMatrix(matrixType));

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1051,7 +1051,7 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
   // account whether the function is a member function of a class/struct (in
   // which case a 'this' parameter is added at the beginnig).
   SpirvFunction *spirvFunction = new (spvContext)
-      SpirvFunction(fn->getReturnType(), /* param QualTypes */ {},
+      SpirvFunction(fn->getReturnType(),
                     fn->getLocation(), fn->getName(), isPrecise);
 
   // No need to dereference to get the pointer. Function returns that are

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1050,9 +1050,8 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
   // definition is seen, the parameter types will be set properly and take into
   // account whether the function is a member function of a class/struct (in
   // which case a 'this' parameter is added at the beginnig).
-  SpirvFunction *spirvFunction = new (spvContext)
-      SpirvFunction(fn->getReturnType(),
-                    fn->getLocation(), fn->getName(), isPrecise);
+  SpirvFunction *spirvFunction = new (spvContext) SpirvFunction(
+      fn->getReturnType(), fn->getLocation(), fn->getName(), isPrecise);
 
   // No need to dereference to get the pointer. Function returns that are
   // stand-alone aliases are already pointers to values. All other cases should

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -36,7 +36,7 @@ namespace clang {
 namespace spirv {
 
 bool LowerTypeVisitor::visit(SpirvFunction *fn, Phase phase) {
-  if (phase == Visitor::Phase::Init) {
+  if (phase == Visitor::Phase::Done) {
     // Lower the function return type.
     const SpirvType *spirvReturnType =
         lowerType(fn->getAstReturnType(), SpirvLayoutRule::Void,
@@ -45,14 +45,10 @@ bool LowerTypeVisitor::visit(SpirvFunction *fn, Phase phase) {
     fn->setReturnType(const_cast<SpirvType *>(spirvReturnType));
 
     // Lower the function parameter types.
-    auto paramQualTypes = fn->getAstParamTypes();
+    auto params = fn->getParameters();
     llvm::SmallVector<const SpirvType *, 4> spirvParamTypes;
-    for (auto qualtype : paramQualTypes) {
-      const auto *spirvParamType =
-          lowerType(qualtype, SpirvLayoutRule::Void,
-                    /*isRowMajor*/ llvm::None, fn->getSourceLocation());
-      spirvParamTypes.push_back(spvContext.getPointerType(
-          spirvParamType, spv::StorageClass::Function));
+    for (auto *param : params) {
+      spirvParamTypes.push_back(param->getResultType());
     }
     fn->setFunctionType(
         spvContext.getFunctionType(spirvReturnType, spirvParamTypes));

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -41,8 +41,8 @@ SpirvFunction *SpirvBuilder::beginFunction(QualType returnType,
     function->setFunctionName(funcName);
     function->setPrecise(isPrecise);
   } else {
-    function = new (context)
-        SpirvFunction(returnType, loc, funcName, isPrecise);
+    function =
+        new (context) SpirvFunction(returnType, loc, funcName, isPrecise);
   }
 
   return function;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -29,7 +29,6 @@ SpirvBuilder::SpirvBuilder(ASTContext &ac, SpirvContext &ctx,
 }
 
 SpirvFunction *SpirvBuilder::beginFunction(QualType returnType,
-                                           llvm::ArrayRef<QualType> paramTypes,
                                            SourceLocation loc,
                                            llvm::StringRef funcName,
                                            bool isPrecise,
@@ -38,13 +37,12 @@ SpirvFunction *SpirvBuilder::beginFunction(QualType returnType,
   if (func) {
     function = func;
     function->setAstReturnType(returnType);
-    function->setAstParamTypes(paramTypes);
     function->setSourceLocation(loc);
     function->setFunctionName(funcName);
     function->setPrecise(isPrecise);
   } else {
     function = new (context)
-        SpirvFunction(returnType, paramTypes, loc, funcName, isPrecise);
+        SpirvFunction(returnType, loc, funcName, isPrecise);
   }
 
   return function;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -62,12 +62,35 @@ SpirvFunctionParameter *SpirvBuilder::addFnParam(QualType ptrType,
   return param;
 }
 
+SpirvFunctionParameter *SpirvBuilder::addFnParam(const SpirvType *spvType,
+                                                 bool isPrecise,
+                                                 SourceLocation loc,
+                                                 llvm::StringRef name) {
+  assert(function && "found detached parameter");
+  auto *param = new (context) SpirvFunctionParameter(spvType, isPrecise, loc);
+  param->setStorageClass(spv::StorageClass::Function);
+  param->setDebugName(name);
+  function->addParameter(param);
+  return param;
+}
+
 SpirvVariable *SpirvBuilder::addFnVar(QualType valueType, SourceLocation loc,
                                       llvm::StringRef name, bool isPrecise,
                                       SpirvInstruction *init) {
   assert(function && "found detached local variable");
   auto *var = new (context) SpirvVariable(
       valueType, loc, spv::StorageClass::Function, isPrecise, init);
+  var->setDebugName(name);
+  function->addVariable(var);
+  return var;
+}
+
+SpirvVariable *SpirvBuilder::addFnVar(const SpirvType *spvType,
+                                      SourceLocation loc, llvm::StringRef name,
+                                      bool isPrecise, SpirvInstruction *init) {
+  assert(function && "found detached local variable");
+  auto *var = new (context)
+      SpirvVariable(spvType, loc, spv::StorageClass::Function, isPrecise, init);
   var->setDebugName(name);
   function->addVariable(var);
   return var;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -54,11 +54,11 @@ SpirvFunctionParameter *SpirvBuilder::addFnParam(QualType ptrType,
                                                  llvm::StringRef name) {
   assert(function && "found detached parameter");
   SpirvFunctionParameter *param = nullptr;
-  if (isBindlessOpaqueArray(type)) {
+  if (isBindlessOpaqueArray(ptrType)) {
     // If it is a bindless array of an opaque type, we have to use
     // a pointer to a pointer of the runtime array.
     param = new (context) SpirvFunctionParameter(
-        spvContext.getPointerType(ptrType, spv::StorageClass::UniformConstant),
+        context.getPointerType(ptrType, spv::StorageClass::UniformConstant),
         isPrecise, loc);
   } else {
     param = new (context) SpirvFunctionParameter(ptrType, isPrecise, loc);
@@ -74,11 +74,11 @@ SpirvVariable *SpirvBuilder::addFnVar(QualType valueType, SourceLocation loc,
                                       SpirvInstruction *init) {
   assert(function && "found detached local variable");
   SpirvVariable *var = nullptr;
-  if (isBindlessOpaqueArray(param->getType())) {
+  if (isBindlessOpaqueArray(valueType)) {
     // If it is a bindless array of an opaque type, we have to use
     // a pointer to a pointer of the runtime array.
     var = new (context)
-        SpirvVariable(spvContext.getPointerType(
+        SpirvVariable(context.getPointerType(
                           valueType, spv::StorageClass::UniformConstant),
                       loc, spv::StorageClass::Function, isPrecise, init);
   } else {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2168,19 +2168,8 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
       // do not need to mark the "param.var.*" variables as precise.
       const bool isPrecise = false;
 
-      SpirvVariable *tempVar = nullptr;
-      if (isOpaqueArrayType(param->getType()) &&
-          !param->getType()->isConstantArrayType()) {
-        // If it is a bindless array of an opaque type, we have to use
-        // a pointer to a pointer of the runtime array.
-        tempVar = spvBuilder.addFnVar(
-            spvContext.getPointerType(varType,
-                                      spv::StorageClass::UniformConstant),
-            arg->getLocStart(), varName, isPrecise);
-      } else {
-        tempVar = spvBuilder.addFnVar(varType, arg->getLocStart(), varName,
-                                      isPrecise);
-      }
+      auto *tempVar =
+          spvBuilder.addFnVar(varType, arg->getLocStart(), varName, isPrecise);
 
       vars.push_back(tempVar);
       isTempVar.push_back(true);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1039,8 +1039,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
     if (!memberFn->isStatic()) {
       // For non-static member function, the first parameter should be the
       // object on which we are invoking this method.
-      QualType valueType =
-          memberFn->getThisType(astContext)->getPointeeType();
+      QualType valueType = memberFn->getThisType(astContext)->getPointeeType();
 
       // Remember the parameter for the 'this' object so later we can handle
       // CXXThisExpr correctly.
@@ -10739,9 +10738,8 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   // The wrapper entry function surely does not have pre-assigned <result-id>
   // for it like other functions that got added to the work queue following
   // function calls. And the wrapper is the entry function.
-  entryFunction =
-      spvBuilder.beginFunction(astContext.VoidTy,
-                               decl->getLocStart(), decl->getName());
+  entryFunction = spvBuilder.beginFunction(
+      astContext.VoidTy, decl->getLocStart(), decl->getName());
   // Note this should happen before using declIdMapper for other tasks.
   declIdMapper.setEntryFunction(entryFunction);
 

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -15,11 +15,9 @@
 namespace clang {
 namespace spirv {
 
-SpirvFunction::SpirvFunction(QualType returnType,
-                             SourceLocation loc, llvm::StringRef name,
-                             bool isPrecise)
-    : functionId(0), astReturnType(returnType),
-      returnType(nullptr),
+SpirvFunction::SpirvFunction(QualType returnType, SourceLocation loc,
+                             llvm::StringRef name, bool isPrecise)
+    : functionId(0), astReturnType(returnType), returnType(nullptr),
       fnType(nullptr), relaxedPrecision(false), precise(isPrecise),
       containsAlias(false), rvalue(false), functionLoc(loc),
       functionName(name) {}

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -16,11 +16,10 @@ namespace clang {
 namespace spirv {
 
 SpirvFunction::SpirvFunction(QualType returnType,
-                             llvm::ArrayRef<QualType> paramTypes,
                              SourceLocation loc, llvm::StringRef name,
                              bool isPrecise)
     : functionId(0), astReturnType(returnType),
-      astParamTypes(paramTypes.begin(), paramTypes.end()), returnType(nullptr),
+      returnType(nullptr),
       fnType(nullptr), relaxedPrecision(false), precise(isPrecise),
       containsAlias(false), rvalue(false), functionLoc(loc),
       functionName(name) {}

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -255,11 +255,31 @@ SpirvVariable::SpirvVariable(QualType resultType, SourceLocation loc,
   setPrecise(precise);
 }
 
+SpirvVariable::SpirvVariable(const SpirvType *spvType, SourceLocation loc,
+                             spv::StorageClass sc, bool precise,
+                             SpirvInstruction *initializerInst)
+    : SpirvInstruction(IK_Variable, spv::Op::OpVariable, QualType(), loc),
+      initializer(initializerInst), descriptorSet(-1), binding(-1),
+      hlslUserType("") {
+  setResultType(spvType);
+  setStorageClass(sc);
+  setPrecise(precise);
+}
+
 SpirvFunctionParameter::SpirvFunctionParameter(QualType resultType,
                                                bool isPrecise,
                                                SourceLocation loc)
     : SpirvInstruction(IK_FunctionParameter, spv::Op::OpFunctionParameter,
                        resultType, loc) {
+  setPrecise(isPrecise);
+}
+
+SpirvFunctionParameter::SpirvFunctionParameter(const SpirvType *spvType,
+                                               bool isPrecise,
+                                               SourceLocation loc)
+    : SpirvInstruction(IK_FunctionParameter, spv::Op::OpFunctionParameter,
+                       QualType(), loc) {
+  setResultType(spvType);
   setPrecise(isPrecise);
 }
 

--- a/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array-o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array-o3.hlsl
@@ -1,0 +1,23 @@
+// Run: %dxc -T ps_6_0 -E main -O3
+
+struct PSInput
+{
+    float4 color : COLOR;
+};
+
+Texture2D bindless[];
+
+sampler DummySampler;
+
+// CHECK: [[src:%\d+]] = OpAccessChain %_ptr_UniformConstant_type_2d_image %bindless %uint_4
+// CHECK:                OpLoad %type_2d_image [[src]]
+
+float4 SampleArray(Texture2D src[], uint index, float2 uv)
+{
+    return src[index].Sample(DummySampler, uv);
+}
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color * SampleArray(bindless, 4, float2(1,1));
+}

--- a/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array.hlsl
@@ -1,0 +1,29 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct PSInput
+{
+    float4 color : COLOR;
+};
+
+Texture2D bindless[];
+
+sampler DummySampler;
+
+// CHECK: %_ptr_Function__ptr_UniformConstant__runtimearr_type_2d_image = OpTypePointer Function %_ptr_UniformConstant__runtimearr_type_2d_image
+// CHECK: %param_var_src = OpVariable %_ptr_Function__ptr_UniformConstant__runtimearr_type_2d_image Function
+// CHECK:                OpStore %param_var_src %bindless
+// CHECK:                OpFunctionCall
+// CHECK:         %src = OpFunctionParameter %_ptr_Function__ptr_UniformConstant__runtimearr_type_2d_image
+// CHECK: [[idx:%\d+]] = OpLoad %uint %index
+// CHECK: [[src:%\d+]] = OpLoad %_ptr_UniformConstant__runtimearr_type_2d_image %src
+// CHECK:                OpAccessChain %_ptr_Function_type_2d_image [[src]] [[idx]]
+
+float4 SampleArray(Texture2D src[], uint index, float2 uv)
+{
+    return src[index].Sample(DummySampler, uv);
+}
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color * SampleArray(bindless, 4, float2(1,1));
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -561,6 +561,12 @@ TEST_F(FileTest, FunctionParamUnsizedArray) {
   // Unsized ararys as function params are not supported.
   runFileTest("fn.param.unsized-array.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, FunctionParamUnsizedOpaqueArray) {
+  runFileTest("fn.param.unsized-opaque-array.hlsl", Expect::Success, false);
+}
+TEST_F(FileTest, FunctionParamUnsizedOpaqueArrayO3) {
+  runFileTest("fn.param.unsized-opaque-array-o3.hlsl");
+}
 TEST_F(FileTest, FunctionInOutParamTypeMismatch) {
   // The type for the inout parameter doesn't match the argument type.
   runFileTest("fn.param.inout.type-mismatch.hlsl");


### PR DESCRIPTION
When a function has a bindless opaque array type as its function
parameter, we have to use a pointer to a pointer of
`OpTypeRuntimeArray` e.g.,
`%_ptr_Function__ptr_UniformConstant__runtimearr_type_2d_image`.
This commit handles the bindless opaque array type argument
passing.

In addition, this commit drops `astParamTypes` of `SpirvFunction`.
`astParamTypes` is used only by lowering the parameter type of
a function type but we can replace it to `resultType` of
`parameters`, which makes the code simpler. Previously, whenever
we update the code for function parameters, we have to update
two places i.e., function type and parameters, but now we can
simply update the code handling parameters.