### PR TITLE
Simplifying branches to reduce complexity of cfg.

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1440,6 +1440,7 @@ namespace DXIL {
 
   static const char *kDxBreakFuncName = "dx.break";
   static const char *kDxBreakCondName = "dx.break.cond";
+  static const char *kDxBreakMDName = "dx.break.br";
 
 } // namespace DXIL
 

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -18,6 +18,7 @@ namespace llvm {
 class Module;
 class DominatorTree;
 class Constant;
+class ConstantInt;
 
 struct DxilValueCache : public ImmutablePass {
   static char ID;
@@ -73,6 +74,7 @@ public:
   void dump() const;
   Value *GetValue(Value *V, DominatorTree *DT=nullptr);
   Constant *GetConstValue(Value *V, DominatorTree *DT = nullptr);
+  ConstantInt *GetConstInt(Value *V, DominatorTree *DT = nullptr);
   void ResetUnknowns() { ValueMap.ResetUnknowns(); }
   bool IsAlwaysReachable(BasicBlock *BB, DominatorTree *DT=nullptr);
   bool IsUnreachable(BasicBlock *BB, DominatorTree *DT=nullptr);

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -385,6 +385,8 @@ const char *DxilValueCache::getPassName() const {
 }
 
 Value *DxilValueCache::GetValue(Value *V, DominatorTree *DT) {
+  if (dyn_cast<Constant>(V))
+    return V;
   if (Value *NewV = ValueMap.Get(V))
     return NewV;
   return ProcessValue(V, DT);
@@ -393,6 +395,12 @@ Value *DxilValueCache::GetValue(Value *V, DominatorTree *DT) {
 Constant *DxilValueCache::GetConstValue(Value *V, DominatorTree *DT) {
   if (Value *NewV = GetValue(V))
     return dyn_cast<Constant>(NewV);
+  return nullptr;
+}
+
+ConstantInt *DxilValueCache::GetConstInt(Value *V, DominatorTree *DT) {
+  if (Value *NewV = GetValue(V))
+    return dyn_cast<ConstantInt>(NewV);
   return nullptr;
 }
 

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -662,6 +662,14 @@ private:
         }
       }
       BreakFunc->eraseFromParent();
+
+      for (Function &F : M) {
+        for (BasicBlock &BB : F) {
+          if (BranchInst *BI = dyn_cast<BranchInst>(BB.getTerminator())) {
+            BI->setMetadata(DXIL::kDxBreakMDName, nullptr);
+          }
+        }
+      }
     }
   }
 };

--- a/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
+++ b/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
@@ -68,15 +68,17 @@ static bool EraseDeadBlocks(Function &F, DxilValueCache *DVC) {
 
           Add(Succ);
 
-          // Rewrite conditional branch as unconditional branch
-          {
+          // Rewrite conditional branch as unconditional branch if
+          // we don't have structural information that needs it to
+          // be alive.
+          if (!Br->getMetadata(hlsl::DXIL::kDxBreakMDName)) {
             BranchInst *NewBr = BranchInst::Create(Succ, BB);
             hlsl::DxilMDHelper::CopyMetadata(*NewBr, *Br);
             RemoveIncomingValueFrom(NotSucc, BB);
-            Changed = true;
 
             Br->eraseFromParent();
             Br = nullptr;
+            Changed = true;
           }
         }
         else {

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2607,6 +2607,9 @@ void AddDxBreak(Module &M, const SmallVector<llvm::BranchInst*, 16> &DxBreaks) {
     if (WaveUsers.count(BI->getParent()->getParent())) {
       CallInst *Call = CallInst::Create(FT, func, ArrayRef<Value *>(), "", BI);
       BI->setCondition(Call);
+      if (!BI->getMetadata(DXIL::kDxBreakMDName)) {
+        BI->setMetadata(DXIL::kDxBreakMDName, llvm::MDNode::get(BI->getContext(), {}));
+      }
     }
   }
 }

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/new_noop_no_fold_double.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/new_noop_no_fold_double.hlsl
@@ -34,7 +34,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/new_noop_no_fold_int.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/new_noop_no_fold_int.hlsl
@@ -36,7 +36,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_no_fold.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_no_fold.hlsl
@@ -34,7 +34,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_no_fold_vec.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_no_fold_vec.hlsl
@@ -41,7 +41,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (foo.x+bar.y >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold.hlsl
@@ -18,7 +18,7 @@ float4 main() : SV_Target {
   // CHECK: fdiv
 
   Texture2D tex = tex0; 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: br

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold_vec.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold_vec.hlsl
@@ -23,7 +23,7 @@ float4 main() : SV_Target {
   // CHECK: fdiv
 
   Texture2D tex = tex0; 
-  // CHECK: br i1
+  // CHECK: br
   if (foo.x+bar.y >= 0) {
     tex = tex1;
     // CHECK: br

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/noop_no_fold_double.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/noop_no_fold_double.hlsl
@@ -30,7 +30,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/noop_no_fold_int.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/noop_no_fold_int.hlsl
@@ -32,7 +32,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/noops_no_fold.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/noops_no_fold.hlsl
@@ -30,7 +30,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (w >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/noops_no_fold_vec.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/noops_no_fold_vec.hlsl
@@ -37,7 +37,7 @@ float4 main() : SV_Target {
   // CHECK: load i32, i32*
   // CHECK-SAME: @dx.nothing
 
-  // CHECK: br i1
+  // CHECK: br
   if (foo.x+bar.y >= 0) {
     tex = tex1;
     // CHECK: load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -T cs_6_0 -Od %s | FileCheck %s
 // A test of explicit loop unrolling on a loop that uses a wave op in a break block
 
 // CHECK: void @main


### PR DESCRIPTION
This change modified DxilRemoveDeadBlocks to rewrite conditional branches to unconditional branches for cases even when no blocks are actually dead, so the cfg becomes simpler.

To avoid removing dx.break annotations, during compilation a special metadata was added to branches in dx.break blocks so DxilRemoveDeadBlocks knows not to rewrite them.