### PR TITLE
Missing import causing error on compilation

### DIFF
--- a/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
@@ -26,7 +26,6 @@
 #include <utility>
 #include <vector>
 #include <set>
-#include <iostream>
 #include <ios>
 
 #include "DxilRootSignatureHelper.h"

--- a/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <set>
 #include <iostream>
+#include <ios>
 
 #include "DxilRootSignatureHelper.h"
 

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -37,7 +37,7 @@
 #include <comdef.h>
 #include <thread>
 #include <unordered_map>
-#include <iostream>
+#include <ios>
 
 #include "llvm/Support//MSFileSystem.h"
 #include "llvm/Support/CommandLine.h"


### PR DESCRIPTION
It seems that a include is missing, when compiling I get this error: 
`DxilRootSignatureValidator.cpp(286,1) error C2039: 'hex' is not a member of 'std'`. I also get the same error on my CI.
Adding `#include <ios>` to DxilRootSignatureValidator.cpp seems to resolve the issue.

This error is similar to #2897 