### PR TITLE
Dxil container builder refactor + bug fix

### DIFF
--- a/include/dxc/DxilContainer/DxcContainerBuilder.h
+++ b/include/dxc/DxilContainer/DxcContainerBuilder.h
@@ -1,0 +1,66 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxcContainerBuilder.h                                                     //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Implements the Dxil Container Builder                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+//#include "llvm/ADT/STLExtras.h"
+#include "dxc/dxcapi.h"
+#include "dxc/Support/Global.h"
+#include "dxc/Support/WinIncludes.h"
+#include "dxc/DxilContainer/DxilContainer.h"
+#include "dxc/Support/microcom.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace hlsl;
+namespace hlsl {
+  class AbstractMemoryStream;
+}
+
+class DxcContainerBuilder : public IDxcContainerBuilder {
+public:
+  HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader) override; // Loads DxilContainer to the builder
+  HRESULT STDMETHODCALLTYPE AddPart(_In_ UINT32 fourCC, _In_ IDxcBlob *pSource) override; // Add the given part with fourCC
+  HRESULT STDMETHODCALLTYPE RemovePart(_In_ UINT32 fourCC) override;                // Remove the part with fourCC
+  HRESULT STDMETHODCALLTYPE SerializeContainer(_Out_ IDxcOperationResult **ppResult) override; // Builds a container of the given container builder state
+
+  DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcContainerBuilder)
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppvObject) override {
+    return DoBasicQueryInterface<IDxcContainerBuilder>(this, riid, ppvObject);
+  }
+
+  void Init(const char *warning = nullptr) {
+    m_warning = warning;
+    m_RequireValidation = false;
+  }
+
+protected:
+  DXC_MICROCOM_TM_REF_FIELDS()
+
+private:
+  class DxilPart {
+  public:
+    UINT32 m_fourCC;
+    CComPtr<IDxcBlob> m_Blob;
+    DxilPart(UINT32 fourCC, IDxcBlob *pSource) : m_fourCC(fourCC), m_Blob(pSource) {}
+  };
+  typedef llvm::SmallVector<DxilPart, 8> PartList;
+
+  PartList m_parts;
+  CComPtr<IDxcBlob> m_pContainer; 
+  const char *m_warning;
+  bool m_RequireValidation;
+
+  UINT32 ComputeContainerSize();
+  HRESULT UpdateContainerHeader(AbstractMemoryStream *pStream, uint32_t containerSize);
+  HRESULT UpdateOffsetTable(AbstractMemoryStream *pStream);
+  HRESULT UpdateParts(AbstractMemoryStream *pStream);
+};

--- a/include/dxc/DxilContainer/DxcContainerBuilder.h
+++ b/include/dxc/DxilContainer/DxcContainerBuilder.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-//#include "llvm/ADT/STLExtras.h"
 #include "dxc/dxcapi.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"

--- a/lib/DxilContainer/CMakeLists.txt
+++ b/lib/DxilContainer/CMakeLists.txt
@@ -4,6 +4,7 @@ add_llvm_library(LLVMDxilContainer
   DxilContainer.cpp
   DxilContainerAssembler.cpp
   DxilContainerReader.cpp
+  DxcContainerBuilder.cpp
   DxilRuntimeReflection.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -52,7 +52,6 @@ set(SOURCES
   DXCompiler.def
   dxcfilesystem.cpp
   dxillib.cpp
-  dxcontainerbuilder.cpp
   dxcutil.cpp
   dxcdisassembler.cpp
   dxclinker.cpp
@@ -65,7 +64,6 @@ set(SOURCES
   dxcompilerobj.cpp
   DXCompiler.cpp
   dxcfilesystem.cpp
-  dxcontainerbuilder.cpp
   dxcutil.cpp
   dxcdisassembler.cpp
   dxillib.cpp

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -24,6 +24,7 @@
 #include "dxcetw.h"
 #endif
 #include "dxillib.h"
+#include "dxc/DxilContainer/DxcContainerBuilder.h"
 #include <memory>
 
 // Initialize the UUID for the interfaces.
@@ -78,6 +79,24 @@ HRESULT CreateDxcContainerReflection(_In_ REFIID riid, _Out_ LPVOID *ppv) {
   catch (const std::bad_alloc&) {
     return E_OUTOFMEMORY;
   }
+}
+
+HRESULT CreateDxcContainerBuilder(_In_ REFIID riid, _Out_ LPVOID *ppv) {
+  // Call dxil.dll's containerbuilder 
+  *ppv = nullptr;
+  const char *warning;
+  HRESULT hr = DxilLibCreateInstance(CLSID_DxcContainerBuilder, (IDxcContainerBuilder**)ppv);
+  if (FAILED(hr)) {
+    warning = "Unable to create container builder from dxil.dll. Resulting container will not be signed.\n";
+  }
+  else {
+    return hr;
+  }
+
+  CComPtr<DxcContainerBuilder> Result = DxcContainerBuilder::Alloc(DxcGetThreadMallocNoRef());
+  IFROOM(Result.p);
+  Result->Init(warning);
+  return Result->QueryInterface(riid, ppv);
 }
 
 static HRESULT ThreadMallocDxcCreateInstance(


### PR DESCRIPTION
- move from dxcompiler to DxilContainer.lib
- rename source file, move class definition to header file
- enable inheritance by changing microcom fields to protected
- enable AddPart for shader debug info
- move CreateDxcContainerBuilder to dxcapi.h to remove dependency
  on DxilLibCreateInstance from DxcContainerBuilder.cpp