### PR TITLE
Add option to dump FileCheck input to directory for diffing

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -97,7 +97,7 @@ public:
   FileRunCommandPart(const FileRunCommandPart&) = default;
   FileRunCommandPart(FileRunCommandPart&&) = default;
   
-  FileRunCommandResult Run(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior, PluginToolsPaths *pPluginToolsPaths = nullptr );
+  FileRunCommandResult Run(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior, PluginToolsPaths *pPluginToolsPaths = nullptr, LPCWSTR dumpName = nullptr);
   FileRunCommandResult RunHashTests(dxc::DxcDllSupport &DllSupport);
   
   FileRunCommandResult ReadOptsForDxc(hlsl::options::MainArgs &argStrings, hlsl::options::DxcOpts &Opts, unsigned flagsToInclude = 0);
@@ -107,7 +107,7 @@ public:
   LPCWSTR CommandFileName;  // File name replacement for %s
 
 private:
-  FileRunCommandResult RunFileChecker(const FileRunCommandResult *Prior);
+  FileRunCommandResult RunFileChecker(const FileRunCommandResult *Prior, LPCWSTR dumpName = nullptr);
   FileRunCommandResult RunDxc(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxv(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunOpt(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
@@ -137,8 +137,13 @@ public:
   std::string ErrorMessage;
   int RunResult;
   static FileRunTestResult RunHashTestFromFileCommands(LPCWSTR fileName);
-  static FileRunTestResult RunFromFileCommands(LPCWSTR fileName, PluginToolsPaths *pPluginToolsPaths = nullptr);
-  static FileRunTestResult RunFromFileCommands(LPCWSTR fileName, dxc::DxcDllSupport &dllSupport, PluginToolsPaths *pPluginToolsPaths = nullptr);
+  static FileRunTestResult RunFromFileCommands(LPCWSTR fileName,
+                                               PluginToolsPaths *pPluginToolsPaths = nullptr,
+                                               LPCWSTR dumpName = nullptr);
+  static FileRunTestResult RunFromFileCommands(LPCWSTR fileName,
+                                               dxc::DxcDllSupport &dllSupport,
+                                               PluginToolsPaths *pPluginToolsPaths = nullptr,
+                                               LPCWSTR dumpName = nullptr);
 };
 
 void AssembleToContainer(dxc::DxcDllSupport &dllSupport, IDxcBlob *pModule, IDxcBlob **pContainer);

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -28,6 +28,7 @@ using namespace std;
 
 #ifndef HLSLDATAFILEPARAM
 #define HLSLDATAFILEPARAM L"HlslDataDir"
+#define FILECHECKDUMPDIRPARAM L"FileCheckDumpDir"
 #endif
 
 // If TAEF verify macros are available, use them to alias other legacy
@@ -158,10 +159,16 @@ inline void LogErrorFmt(_In_z_ _Printf_format_string_ const wchar_t *fmt, ...) {
     WEX::Logging::Log::Error(buf.data());
 }
 
-inline std::wstring GetPathToHlslDataFile(const wchar_t* relative) {
+inline std::wstring GetPathToHlslDataFile(const wchar_t* relative, LPCWSTR paramName = HLSLDATAFILEPARAM) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   WEX::Common::String HlslDataDirValue;
-  ASSERT_HRESULT_SUCCEEDED(WEX::TestExecution::RuntimeParameters::TryGetValue(HLSLDATAFILEPARAM, HlslDataDirValue));
+  if (std::wstring(paramName).compare(HLSLDATAFILEPARAM) != 0) {
+    // Not fatal, for instance, FILECHECKDUMPDIRPARAM will dump files before running FileCheck, so they can be compared run to run
+    if (FAILED(WEX::TestExecution::RuntimeParameters::TryGetValue(paramName, HlslDataDirValue)))
+      return std::wstring();
+  } else {
+    ASSERT_HRESULT_SUCCEEDED(WEX::TestExecution::RuntimeParameters::TryGetValue(HLSLDATAFILEPARAM, HlslDataDirValue));
+  }
 
   wchar_t envPath[MAX_PATH];
   wchar_t expanded[MAX_PATH];

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -375,6 +375,7 @@ echo   -adapter "adapter name" - overrides Adapter for execution tests
 echo   -verbose - for TAEF: turns off /parallel and removes logging filter
 echo   -custom-bin-set "file [file]..." - custom set of binaries to copy into test directory
 echo   -dxilconv-loc "dxilconv.dll location" - fetch dxilconv.dll from custom location
+echo   -file-check-dump "dump-path" - dump file-check inputs to files under dump-path
 echo.
 echo current BUILD_ARCH=%BUILD_ARCH%.  Override with:
 echo   -x86 targets an x86 build (aka. Win32)

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -155,7 +155,10 @@ if "%1"=="-clean" (
   shift /1
 ) else if "%1"=="-custom-bin-set" (
   set CUSTOM_BIN_SET=%~2
- shift /1
+  shift /1
+) else if "%1"=="-file-check-dump" (
+  set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% /p:"FileCheckDumpDir=%~2\HLSL"
+  shift /1
 ) else if "%1"=="--" (
   shift /1
   goto :done_opt


### PR DESCRIPTION
So far, the option only applies to `CompilerTest::*` tests that use `FileCheck`.  Dumps the `FileCheck` input to `<filename>.<num>.txt`, where `<filename>` is the input test filename, and `<num>` increments for each `RUN` line in the file.

Processing/filtering will still likely be needed to eliminate differences you don't care about, but it's a start.

Use with hcttest:
`hcttest -file-check-dump <target-path>`