### PR TITLE
Disable pragma in Linux build

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -66,7 +66,9 @@
 #include <algorithm>
 #include <unordered_map>
 
+#ifdef _WIN32
 #pragma comment(lib, "version.lib")
+#endif
 
 // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN


### PR DESCRIPTION
`#pragma comment(.., some.lib)` causes a build failure in some Linux
compilers. This commit disables it for Linux build.