### PR TITLE
Use HlslDataDir for DxilConv instead of DxilConvDataDir

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -26,10 +26,8 @@
 
 using namespace std;
 
-#ifndef HLSLDATAFILEPARAM
 #define HLSLDATAFILEPARAM L"HlslDataDir"
 #define FILECHECKDUMPDIRPARAM L"FileCheckDumpDir"
-#endif
 
 // If TAEF verify macros are available, use them to alias other legacy
 // comparison macros that don't have a direct translation.

--- a/projects/dxilconv/unittests/DxilConvTests.cpp
+++ b/projects/dxilconv/unittests/DxilConvTests.cpp
@@ -27,10 +27,7 @@
 #include <atlfile.h>
 
 #include "dxc/test/HLSLTestData.h"
-
-#define HLSLDATAFILEPARAM L"DxilConvDataDir"
 #include "dxc/test/HlslTestUtils.h"
-
 #include "dxc/test/DxcTestUtils.h"
 
 #include "llvm/Support/raw_os_ostream.h"

--- a/projects/dxilconv/unittests/dxilconv-tests.vcxproj.user.txt
+++ b/projects/dxilconv/unittests/dxilconv-tests.vcxproj.user.txt
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LocalDebuggerCommand>${DOS_TAEF_BIN_DIR}\$(PlatformTarget)\Te.exe</LocalDebuggerCommand>
     <LocalDebuggerCommand Condition="'$(PlatformTarget)' == 'x64' And Exists('${DOS_TAEF_BIN_DIR}\amd64\Te.exe')">${DOS_TAEF_BIN_DIR}\amd64\Te.exe</LocalDebuggerCommand>
-    <LocalDebuggerCommandArguments>$(TargetPath) /inproc /p:"DxilConvDataDir=${DOS_STYLE_SOURCE_DIR}\..\test" /name:*</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>$(TargetPath) /inproc /p:"HlslDataDir=${DOS_STYLE_SOURCE_DIR}\..\test" /name:*</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
 </Project>

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -203,10 +203,12 @@ if "%GENERATOR_NINJA%"=="1" (
   set TEST_DIR=%HLSL_BLD_DIR%\%BUILD_CONFIG%\test
 )
 
+if "%DXILCONV_LOC%"=="" ( 
+  set DXILCONV_LOC=%BIN_DIR%
+)
 if "%TEST_DXILCONV%"=="1" (
-  if "%DXILCONV_LOC%"=="" ( set DXILCONV_LOC=%BIN_DIR%\dxilconv.dll )
-  if not exist "%DXILCONV_LOC%" (
-    echo Skipping dxilconv tests, dxilconv.dll not found.
+  if not exist "%DXILCONV_LOC%\dxilconv.dll" (
+    echo Skipping dxilconv tests, dxilconv.dll not found at %DXILCONV_LOC%.
     set TEST_DXILCONV=0
   )
 )
@@ -315,7 +317,7 @@ if exist "%HCT_EXTRAS%\hcttest-extras.cmd" (
 )
 
 if "%TEST_DXILCONV%"=="1" (
-  call :runte dxilconv-tests.dll /p:"DxilConvDataDir=%HLSL_SRC_DIR%\projects\dxilconv\test" %TEST_DXILCONV_FILTER%
+  call :runte dxilconv-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\projects\dxilconv\test" %TEST_DXILCONV_FILTER%
   set RES_DXILCONV=!ERRORLEVEL!
 )
 

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -409,7 +409,7 @@ echo.
 echo Delete test directory and do not copy binaries or run tests:
 echo   hcttest clean
 echo.
-call :showtesample clang-hlsl-tests.dll /p:"DxilConvDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL"
+call :showtesample clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL"
 
 goto :eof
 


### PR DESCRIPTION
This was using a define before a header to change the option name.
An inline function used the define when adding the path to a filename.
Unfortunately, this header was included from multiple places with
different values defined for the variable name, and it seems that
sheer luck made it work for a while, even when called from a cpp
file that would have had it defined differently.