### PR TITLE
Add hidden flag to disable optimization passes

### DIFF
--- a/include/dxc/Support/HLSLOptimizationOptions.h
+++ b/include/dxc/Support/HLSLOptimizationOptions.h
@@ -1,0 +1,24 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// HLSLOptions.h                                                             //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Option defined related to optimization customization.                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef LLVM_HLSL_OPTIMIZATION_OPTIONS_H
+#define LLVM_HLSL_OPTIMIZATION_OPTIONS_H
+
+namespace hlsl {
+  // Optimizations that can be disabled
+  enum OptimizationToggles {
+    OptToggleGvn = (1 << 0)
+  };
+}
+
+#endif

--- a/include/dxc/Support/HLSLOptimizationOptions.h
+++ b/include/dxc/Support/HLSLOptimizationOptions.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //                                                                           //
-// HLSLOptions.h                                                             //
+// HLSLOptimizationOptions.h                                                 //
 // Copyright (C) Microsoft Corporation. All rights reserved.                 //
 // This file is distributed under the University of Illinois Open Source     //
 // License. See LICENSE.TXT for details.                                     //
@@ -11,14 +11,11 @@
 
 #pragma once
 
-#ifndef LLVM_HLSL_OPTIMIZATION_OPTIONS_H
-#define LLVM_HLSL_OPTIMIZATION_OPTIONS_H
-
 namespace hlsl {
   // Optimizations that can be disabled
-  enum OptimizationToggles {
-    OptToggleGvn = (1 << 0)
+  struct OptimizationOptions {
+    unsigned DisableGVN : 1;
+    unsigned Reserved : 31;
   };
 }
 
-#endif

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/ArgList.h"
 #include "dxc/dxcapi.h"
+#include "dxc/Support/HLSLOptimizationOptions.h"
 #include "dxc/Support/SPIRVOptions.h"
 
 namespace llvm {
@@ -187,7 +188,7 @@ public:
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
-  unsigned long DisabledOptimizations; // OPT_opt_disable
+  hlsl::OptimizationOptions OptimizationOptions; // OPT_opt_disable
 
   // Rewriter Options
   RewriterOpts RWOpt;

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -187,6 +187,7 @@ public:
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
+  unsigned long DisabledOptimizations; // OPT_opt_disable
 
   // Rewriter Options
   RewriterOpts RWOpt;

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -188,7 +188,7 @@ public:
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
-  hlsl::OptimizationOptions OptimizationOptions; // OPT_opt_disable
+  hlsl::OptimizationOptions DxcOptimizationOptions; // OPT_opt_disable
 
   // Rewriter Options
   RewriterOpts RWOpt;

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -156,6 +156,8 @@ def fno_honor_infinities : Flag<["-"], "fno-honor-infinities">, Group<hlsloptz_G
 def flimited_precision_EQ : Joined<["-"], "flimited-precision=">, Group<hlsloptz_Group>;
 def memdep_block_scan_limit : Separate<["-", "/"], "memdep-block-scan-limit">, Group<hlsloptz_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"The number of instructions to scan in a block in memory dependency analysis.">;
+def opt_disable : Separate<["-", "/"], "opt-disable">, Group<hlsloptz_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
+  HelpText<"Disable this optimization.">;
 
 /*
 def fno_caret_diagnostics : Flag<["-"], "fno-caret-diagnostics">, Group<hlslcomp_Group>,

--- a/include/llvm/Transforms/IPO/PassManagerBuilder.h
+++ b/include/llvm/Transforms/IPO/PassManagerBuilder.h
@@ -131,6 +131,7 @@ public:
   hlsl::HLSLExtensionsCodegenHelper *HLSLExtensionsCodeGen = nullptr; // HLSL Change
   bool HLSLResMayAlias = false; // HLSL Change
   unsigned ScanLimit = 0; // HLSL Change
+  unsigned long DisabledOptimizations; // HLSL Change
 
 private:
   /// ExtensionList - This is list of all of the extensions that are registered.

--- a/include/llvm/Transforms/IPO/PassManagerBuilder.h
+++ b/include/llvm/Transforms/IPO/PassManagerBuilder.h
@@ -132,7 +132,7 @@ public:
   hlsl::HLSLExtensionsCodegenHelper *HLSLExtensionsCodeGen = nullptr; // HLSL Change
   bool HLSLResMayAlias = false; // HLSL Change
   unsigned ScanLimit = 0; // HLSL Change
-  hlsl::OptimizationOptions HLSLOptimizationOptions; // HLSL Change
+  hlsl::OptimizationOptions HLSLOptimizationOptions = {0}; // HLSL Change
 
 private:
   /// ExtensionList - This is list of all of the extensions that are registered.

--- a/include/llvm/Transforms/IPO/PassManagerBuilder.h
+++ b/include/llvm/Transforms/IPO/PassManagerBuilder.h
@@ -16,6 +16,7 @@
 #define LLVM_TRANSFORMS_IPO_PASSMANAGERBUILDER_H
 
 #include <vector>
+#include "dxc/Support/HLSLOptimizationOptions.h" // HLSL Change
 
 namespace hlsl {
   class HLSLExtensionsCodegenHelper;
@@ -131,7 +132,7 @@ public:
   hlsl::HLSLExtensionsCodegenHelper *HLSLExtensionsCodeGen = nullptr; // HLSL Change
   bool HLSLResMayAlias = false; // HLSL Change
   unsigned ScanLimit = 0; // HLSL Change
-  unsigned long DisabledOptimizations; // HLSL Change
+  hlsl::OptimizationOptions HLSLOptimizationOptions; // HLSL Change
 
 private:
   /// ExtensionList - This is list of all of the extensions that are registered.

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -17,7 +17,6 @@
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/HLSLOptions.h"
-#include "dxc/Support/HLSLOptimizationOptions.h"
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/dxcapi.use.h"
 #include "dxc/DXIL/DxilShaderModel.h"
@@ -493,12 +492,12 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   if (!limit.empty())
     opts.ScanLimit = std::stoul(std::string(limit));
 
-  opts.DisabledOptimizations = 0;
+  opts.OptimizationOptions = {0};
   std::vector<std::string> DisabledOptimizations = Args.getAllArgValues(OPT_opt_disable);
   for (std::string opt : DisabledOptimizations) {
     llvm::StringRef gvn("gvn");
     if (gvn.equals_lower(opt))
-      opts.DisabledOptimizations |= hlsl::OptToggleGvn;
+      opts.OptimizationOptions.DisableGVN = true;
     else
       errors << "Unsupported optimization '" << opt
              << "' disabled.";

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -492,12 +492,12 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   if (!limit.empty())
     opts.ScanLimit = std::stoul(std::string(limit));
 
-  opts.OptimizationOptions = {0};
+  opts.DxcOptimizationOptions = {0};
   std::vector<std::string> DisabledOptimizations = Args.getAllArgValues(OPT_opt_disable);
   for (std::string opt : DisabledOptimizations) {
     llvm::StringRef gvn("gvn");
     if (gvn.equals_lower(opt))
-      opts.OptimizationOptions.DisableGVN = true;
+      opts.DxcOptimizationOptions.DisableGVN = true;
   }
 
   if (!opts.ForceRootSigVer.empty() && opts.ForceRootSigVer != "rootsig_1_0" &&

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -498,9 +498,6 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     llvm::StringRef gvn("gvn");
     if (gvn.equals_lower(opt))
       opts.OptimizationOptions.DisableGVN = true;
-    else
-      errors << "Unsupported optimization '" << opt
-             << "' disabled.";
   }
 
   if (!opts.ForceRootSigVer.empty() && opts.ForceRootSigVer != "rootsig_1_0" &&

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -17,6 +17,7 @@
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/HLSLOptions.h"
+#include "dxc/Support/HLSLOptimizationOptions.h"
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/dxcapi.use.h"
 #include "dxc/DXIL/DxilShaderModel.h"
@@ -491,6 +492,17 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   llvm::StringRef limit = Args.getLastArgValue(OPT_memdep_block_scan_limit);
   if (!limit.empty())
     opts.ScanLimit = std::stoul(std::string(limit));
+
+  opts.DisabledOptimizations = 0;
+  std::vector<std::string> DisabledOptimizations = Args.getAllArgValues(OPT_opt_disable);
+  for (std::string opt : DisabledOptimizations) {
+    llvm::StringRef gvn("gvn");
+    if (gvn.equals_lower(opt))
+      opts.DisabledOptimizations |= hlsl::OptToggleGvn;
+    else
+      errors << "Unsupported optimization '" << opt
+             << "' disabled.";
+  }
 
   if (!opts.ForceRootSigVer.empty() && opts.ForceRootSigVer != "rootsig_1_0" &&
       opts.ForceRootSigVer != "rootsig_1_1") {

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -29,7 +29,6 @@
 #include "dxc/HLSL/DxilGenerationPass.h" // HLSL Change
 #include "dxc/HLSL/HLMatrixLowerPass.h" // HLSL Change
 #include "dxc/HLSL/ComputeViewIdState.h" // HLSL Change
-#include "dxc/Support/HLSLOptimizationOptions.h" // HLSL Change
 #include "llvm/Analysis/DxilValueCache.h" // HLSL Change
 
 using namespace llvm;
@@ -133,7 +132,7 @@ PassManagerBuilder::PassManagerBuilder() {
     VerifyOutput = false;
     MergeFunctions = false;
     PrepareForLTO = false;
-    DisabledOptimizations = 0;
+    HLSLOptimizationOptions = {0};
 }
 
 PassManagerBuilder::~PassManagerBuilder() {
@@ -469,7 +468,7 @@ void PassManagerBuilder::populateModulePassManager(
     if (EnableMLSM)
       MPM.add(createMergedLoadStoreMotionPass()); // Merge ld/st in diamonds
     // HLSL Change Begins
-    if (!(DisabledOptimizations & hlsl::OptToggleGvn)) {
+    if (!(HLSLOptimizationOptions.DisableGVN)) {
       MPM.add(createGVNPass(DisableGVNLoadPRE));  // Remove redundancies
       if (!HLSLResMayAlias)
         MPM.add(createDxilSimpleGVNHoistPass());
@@ -743,7 +742,7 @@ void PassManagerBuilder::addLTOOptimizationPasses(legacy::PassManagerBase &PM) {
   // PM.add(createLICMPass());                 // Hoist loop invariants.
   if (EnableMLSM)
     PM.add(createMergedLoadStoreMotionPass()); // Merge ld/st in diamonds.
-  if (!(DisabledOptimizations & hlsl::OptToggleGvn)) // HLSL Change
+  if (!(HLSLOptimizationOptions.DisableGVN)) // HLSL Change
     PM.add(createGVNPass(DisableGVNLoadPRE)); // Remove redundancies.
   PM.add(createMemCpyOptPass());            // Remove dead memcpys.
 

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -132,7 +132,6 @@ PassManagerBuilder::PassManagerBuilder() {
     VerifyOutput = false;
     MergeFunctions = false;
     PrepareForLTO = false;
-    HLSLOptimizationOptions = {0};
 }
 
 PassManagerBuilder::~PassManagerBuilder() {

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -222,7 +222,7 @@ public:
   /// Lookback scan limit for memory dependencies
   unsigned ScanLimit = 0;
   /// Disabled optimization passes
-  hlsl::OptimizationOptions HLSLOptimizationOptions;
+  hlsl::OptimizationOptions HLSLOptimizationOptions = {0};
   // HLSL Change Ends
 
   // SPIRV Change Starts

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h" // HLSL change
+#include "dxc/Support/HLSLOptimizationOptions.h" // HLSL Change
 #include "dxc/Support/SPIRVOptions.h" // SPIR-V Change
 
 namespace clang {
@@ -221,7 +222,7 @@ public:
   /// Lookback scan limit for memory dependencies
   unsigned ScanLimit = 0;
   /// Disabled optimization passes
-  unsigned long DisabledOptimizations;
+  hlsl::OptimizationOptions HLSLOptimizationOptions;
   // HLSL Change Ends
 
   // SPIRV Change Starts

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -220,6 +220,8 @@ public:
   bool HLSLResMayAlias = false;
   /// Lookback scan limit for memory dependencies
   unsigned ScanLimit = 0;
+  /// Disabled optimization passes
+  unsigned long DisabledOptimizations;
   // HLSL Change Ends
 
   // SPIRV Change Starts

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -327,7 +327,7 @@ void EmitAssemblyHelper::CreatePasses() {
   PMBuilder.HLSLExtensionsCodeGen = CodeGenOpts.HLSLExtensionsCodegen.get(); // HLSL Change
   PMBuilder.HLSLResMayAlias = CodeGenOpts.HLSLResMayAlias; // HLSL Change
   PMBuilder.ScanLimit = CodeGenOpts.ScanLimit; // HLSL Change
-  PMBuilder.DisabledOptimizations = CodeGenOpts.DisabledOptimizations; // HLSL Change
+  PMBuilder.HLSLOptimizationOptions = CodeGenOpts.HLSLOptimizationOptions; // HLSL Change
 
   PMBuilder.DisableUnitAtATime = !CodeGenOpts.UnitAtATime;
   PMBuilder.DisableUnrollLoops = !CodeGenOpts.UnrollLoops;

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -327,6 +327,7 @@ void EmitAssemblyHelper::CreatePasses() {
   PMBuilder.HLSLExtensionsCodeGen = CodeGenOpts.HLSLExtensionsCodegen.get(); // HLSL Change
   PMBuilder.HLSLResMayAlias = CodeGenOpts.HLSLResMayAlias; // HLSL Change
   PMBuilder.ScanLimit = CodeGenOpts.ScanLimit; // HLSL Change
+  PMBuilder.DisabledOptimizations = CodeGenOpts.DisabledOptimizations; // HLSL Change
 
   PMBuilder.DisableUnitAtATime = !CodeGenOpts.UnitAtATime;
   PMBuilder.DisableUnrollLoops = !CodeGenOpts.UnrollLoops;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/gvn/disablegvn.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/gvn/disablegvn.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -opt-disable gvn -T ps_6_0 %s | FileCheck %s
+
+// Simple test to verify disabling of gvn pass
+
+// Verify that GVN is disabled by the presence
+// of the second sin(), which GVN would have removed
+// CHECK: call float @dx.op.unary.f32
+// CHECK: call float @dx.op.unary.f32
+
+float main(float a : A) : SV_Target {
+  float res = sin(a);
+  return res + sin(a);
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1107,7 +1107,7 @@ public:
     compiler.getCodeGenOpts().HLSLAllowPreserveValues = Opts.AllowPreserveValues;
     compiler.getCodeGenOpts().HLSLResMayAlias = Opts.ResMayAlias;
     compiler.getCodeGenOpts().ScanLimit = Opts.ScanLimit;
-    compiler.getCodeGenOpts().DisabledOptimizations = Opts.DisabledOptimizations;
+    compiler.getCodeGenOpts().HLSLOptimizationOptions = Opts.OptimizationOptions;
     compiler.getCodeGenOpts().HLSLAllResourcesBound = Opts.AllResourcesBound;
     compiler.getCodeGenOpts().HLSLDefaultRowMajor = Opts.DefaultRowMajor;
     compiler.getCodeGenOpts().HLSLPreferControlFlow = Opts.PreferFlowControl;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1107,7 +1107,7 @@ public:
     compiler.getCodeGenOpts().HLSLAllowPreserveValues = Opts.AllowPreserveValues;
     compiler.getCodeGenOpts().HLSLResMayAlias = Opts.ResMayAlias;
     compiler.getCodeGenOpts().ScanLimit = Opts.ScanLimit;
-    compiler.getCodeGenOpts().HLSLOptimizationOptions = Opts.OptimizationOptions;
+    compiler.getCodeGenOpts().HLSLOptimizationOptions = Opts.DxcOptimizationOptions;
     compiler.getCodeGenOpts().HLSLAllResourcesBound = Opts.AllResourcesBound;
     compiler.getCodeGenOpts().HLSLDefaultRowMajor = Opts.DefaultRowMajor;
     compiler.getCodeGenOpts().HLSLPreferControlFlow = Opts.PreferFlowControl;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1107,6 +1107,7 @@ public:
     compiler.getCodeGenOpts().HLSLAllowPreserveValues = Opts.AllowPreserveValues;
     compiler.getCodeGenOpts().HLSLResMayAlias = Opts.ResMayAlias;
     compiler.getCodeGenOpts().ScanLimit = Opts.ScanLimit;
+    compiler.getCodeGenOpts().DisabledOptimizations = Opts.DisabledOptimizations;
     compiler.getCodeGenOpts().HLSLAllResourcesBound = Opts.AllResourcesBound;
     compiler.getCodeGenOpts().HLSLDefaultRowMajor = Opts.DefaultRowMajor;
     compiler.getCodeGenOpts().HLSLPreferControlFlow = Opts.PreferFlowControl;


### PR DESCRIPTION
It can be helpful to disable an optimization pass or set of passes in
select circumstances. This adds the ability to disable the gvn pass
only, but introduces a way to disable various passes just by accepting
the chosen string to represent them in HLSLOptions and using the
DisablePasses values to determine when a pass needs to be left out in
PassManagerBuilder.