### PR TITLE
Verify valid intrinsic parameter casts

### DIFF
--- a/tools/clang/include/clang/AST/Decl.h
+++ b/tools/clang/include/clang/AST/Decl.h
@@ -810,8 +810,13 @@ protected:
     /// declared.
     unsigned ScopeDepthOrObjCQuals : 7;
 
+    // HLSL Change start
     /// Whether the parameter is copied out.
     unsigned IsModifierOut : 1;
+
+    // Index into allowable parameter conversions
+    unsigned LegalTypesIdx : 6;
+    // HLSL Change end
 
     /// The number of parameters preceding this parameter in the
     /// function parameter scope in which it was declared.
@@ -1455,6 +1460,9 @@ public:
   void setModifierIn(bool value) { ParmVarDeclBits.IsKNRPromoted = !value; }
   bool isModifierOut() const { return ParmVarDeclBits.IsModifierOut; }
   void setModifierOut(bool value) { ParmVarDeclBits.IsModifierOut = value; }
+
+  unsigned getLegalTypes() const { return ParmVarDeclBits.LegalTypesIdx; }
+  void setLegalTypes(unsigned idx) { ParmVarDeclBits.LegalTypesIdx = idx; }
   /// Synthesize a ParameterModifier value for this parameter.
   hlsl::ParameterModifier getParamModifiers() const {
     if (isModifierIn() && !isModifierOut())

--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -256,6 +256,9 @@ clang::QualType CheckVectorConditional(
 
 }
 
+// Returns true if Type is allowed by the types represented by LegalTypesIdx
+bool ValidateParamTypeCast(clang::ExternalSemaSource *source, clang::QualType Ty, uint8_t LegalTypesIdx);
+
 bool IsTypeNumeric(_In_ clang::Sema* self, _In_ clang::QualType &type);
 bool IsExprAccessingOutIndicesArray(clang::Expr* BaseExpr);
 

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -5838,8 +5838,21 @@ Sema::AddOverloadCandidate(FunctionDecl *Function,
       // parameter of F.
       // HLSL Change Starts
       if (getLangOpts().HLSL) {
+        ParmVarDecl *Param = Function->getParamDecl(ArgIdx);
+        // extract allowable type info from param
+        unsigned legalTypes = Param->getLegalTypes();
+        QualType argType = Args[ArgIdx]->getType();
+        if (!ValidateParamTypeCast(ExternalSource, argType, legalTypes)) {
+          Candidate.Viable = false;
+          Candidate.FailureKind = ovl_fail_bad_conversion;
+          QualType ParamType = Proto->getParamType(ArgIdx);
+          Candidate.Conversions[ArgIdx].setBad(
+          BadConversionSequence::no_conversion, ParamType, argType);
+          return;
+        }
+
         InitCallParamConversions(
-            *this, Proto, Function->getParamDecl(ArgIdx), ArgIdx, Args[ArgIdx],
+            *this, Proto, Param, ArgIdx, Args[ArgIdx],
             SuppressUserConversions, true, AllowExplicit,
             Candidate.Conversions[ArgIdx], Candidate.OutConversions[ArgIdx]);
       } else {

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/intrinsic_overloading_errors.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/intrinsic_overloading_errors.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T lib_6_4 %s | FileCheck %s
+
+// This tests intrinsic overloads using parameter combinations that should fail, but didn't
+
+CHECK: error: use of undeclared identifier 'fma'
+
+export
+double MismatchedIntrins(double d1, double d2, float f) {
+  return fma(d1, d2, f);
+}
+
+CHECK: error: use of undeclared identifier 'fma'
+
+export
+double InvalidAfterValidIntrins(double d1, double d2, double d3,
+                                float f1, float f2, float f3) {
+  // This is valid and would let the next, invalid call slip through
+  double ret = fma(d1, d2, d3);
+  ret += fma(f1, f2, f3);
+  return ret;
+}


### PR DESCRIPTION
In a couple of cases, intrinsics with parameters that weren't supposed
to allow casts were getting at least one parameter cast to a type not in
the accepted list. To consolidate this check, a function is added to
determine if a given type is accepted by the given list of acceptable
types.

First, where an intrinsic referred to another parameter to determine
acceptable types, all parameters fed into a single parameter
representing the common type. If the first parameter was acceptable, but
the second wasn't, the second would get merged with the first regardless
of allowable casts.

Second, if an intrinsic call with valid arguments is followed by one
with invalid arguments, the second will be accepted and casts added to
convert to the existing intrinsic because it has already been added to
the list of possible overloads.