### PR TITLE
Support case whole scope is return.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -5685,7 +5685,6 @@ void CGMSHLSLRuntime::MarkIfStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) {
 void CGMSHLSLRuntime::MarkSwitchStmt(CodeGenFunction &CGF,
                                      SwitchInst *switchInst,
                                      BasicBlock *endSwitch) {
-
   if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn))
     Scope->AddSwitch(endSwitch);
 }

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -285,8 +285,7 @@ public:
   void MarkRetTemp(CodeGenFunction &CGF, llvm::Value *V,
                   clang::QualType QaulTy) override;
   void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D, llvm::Value *V) override;
-  void MarkThenStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) override;
-  void MarkElseStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) override;
+  void MarkIfStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) override;
   void MarkSwitchStmt(CodeGenFunction &CGF, SwitchInst *switchInst,
                       BasicBlock *endSwitch) override;
   void MarkReturnStmt(CodeGenFunction &CGF, BasicBlock *bbWithRet) override;
@@ -5677,15 +5676,11 @@ ScopeInfo *CGMSHLSLRuntime::GetScopeInfo(Function *F) {
   return &it->second;
 }
 
-void CGMSHLSLRuntime::MarkThenStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) {
+void CGMSHLSLRuntime::MarkIfStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) {
   if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn))
-    Scope->AddThen(endIfBB);
+    Scope->AddIf(endIfBB);
 }
 
-void CGMSHLSLRuntime::MarkElseStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) {
-  if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn))
-    Scope->AddElse(endIfBB);
-}
 
 void CGMSHLSLRuntime::MarkSwitchStmt(CodeGenFunction &CGF,
                                      SwitchInst *switchInst,
@@ -5709,8 +5704,11 @@ void CGMSHLSLRuntime::MarkLoopStmt(CodeGenFunction &CGF,
 }
 
 void CGMSHLSLRuntime::MarkScopeEnd(CodeGenFunction &CGF) {
-  if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn))
-    Scope->EndScope();
+  if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn)) {
+    llvm::BasicBlock *CurBB = CGF.Builder.GetInsertBlock();
+    bool bScopeFinishedWithRet = !CurBB || CurBB->getTerminator();
+    Scope->EndScope(bScopeFinishedWithRet);
+  }
 }
 
 CGHLSLRuntime *CodeGen::CreateMSHLSLRuntime(CodeGenModule &CGM) {

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2805,7 +2805,8 @@ void InitRetValue(BasicBlock *exitBB) {
     Type *Ty = RetVAlloc->getAllocatedType();
     Value *Init = Constant::getNullValue(Ty);
     if (Ty->isAggregateType()) {
-      // TODO:
+      // TODO: support aggreagate type and out parameters.
+      // Skip it here will cause undef on phi which the incoming path should never hit.
     } else {
       B.CreateStore(Init, RetVAlloc);
     }

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -88,7 +88,6 @@ struct Scope {
  llvm::BasicBlock *EndScopeBB;
  // Save loopContinueBB to create dxBreak.
  llvm::BasicBlock *loopContinueBB;
-
  // For case like
  // if () {
  //   ...
@@ -118,10 +117,13 @@ public:
   const llvm::SmallVector<unsigned, 2> &GetRetScopes() { return rets; }
   void LegalizeWholeReturnedScope();
   llvm::SmallVector<Scope, 16> &GetScopes() { return scopes; }
+  bool CanSkipStructurize();
 
 private:
   void AddScope(Scope::ScopeKind k, llvm::BasicBlock *endScopeBB);
   llvm::SmallVector<unsigned, 2> rets;
+  unsigned maxRetLevel;
+  bool bAllReturnsInIf;
   llvm::SmallVector<unsigned, 8> scopeStack;
   // save all scopes.
   llvm::SmallVector<Scope, 16> scopes;

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -78,8 +78,7 @@ private:
 // Scope to help transform multiple returns.
 struct Scope {
  enum class ScopeKind {
-   ThenScope,
-   ElseScope,
+   IfScope,
    SwitchScope,
    LoopScope,
    ReturnScope,
@@ -89,6 +88,20 @@ struct Scope {
  llvm::BasicBlock *EndScopeBB;
  // Save loopContinueBB to create dxBreak.
  llvm::BasicBlock *loopContinueBB;
+
+ // For case like
+ // if () {
+ //   ...
+ //   return;
+ // } else {
+ //   ...
+ //   return;
+ // }
+ //
+ // both path is returned.
+ // When whole scope is returned, go to parent scope directly.
+ // Anything after it is unreachable.
+ bool bWholeScopeReturned;
  unsigned parentScopeIndex;
 };
 
@@ -96,14 +109,16 @@ class ScopeInfo {
 public:
   ScopeInfo(){}
   ScopeInfo(llvm::Function *F);
-  void AddThen(llvm::BasicBlock *endIfBB);
-  void AddElse(llvm::BasicBlock *endIfBB);
+  void AddIf(llvm::BasicBlock *endIfBB);
   void AddSwitch(llvm::BasicBlock *endSwitchBB);
   void AddLoop(llvm::BasicBlock *loopContinue, llvm::BasicBlock *endLoopBB);
   void AddRet(llvm::BasicBlock *bbWithRet);
-  void EndScope();
+  void EndScope(bool bScopeFinishedWithRet);
   Scope &GetScope(unsigned i);
   const llvm::SmallVector<unsigned, 2> &GetRetScopes() { return rets; }
+  void LegalizeWholeReturnedScope();
+  llvm::SmallVector<Scope, 16> &GetScopes() { return scopes; }
+
 private:
   void AddScope(Scope::ScopeKind k, llvm::BasicBlock *endScopeBB);
   llvm::SmallVector<unsigned, 2> rets;

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -130,8 +130,7 @@ public:
 
   virtual void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D,
                              llvm::Value *V) = 0;
-  virtual void MarkIfStmt(CodeGenFunction &CGF,
-                            llvm::BasicBlock *endIfBB) = 0;
+  virtual void MarkIfStmt(CodeGenFunction &CGF, llvm::BasicBlock *endIfBB) = 0;
   virtual void MarkSwitchStmt(CodeGenFunction &CGF,
                               llvm::SwitchInst *switchInst,
                               llvm::BasicBlock *endSwitch) = 0;

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -130,9 +130,7 @@ public:
 
   virtual void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D,
                              llvm::Value *V) = 0;
-  virtual void MarkThenStmt(CodeGenFunction &CGF,
-                            llvm::BasicBlock *endIfBB) = 0;
-  virtual void MarkElseStmt(CodeGenFunction &CGF,
+  virtual void MarkIfStmt(CodeGenFunction &CGF,
                             llvm::BasicBlock *endIfBB) = 0;
   virtual void MarkSwitchStmt(CodeGenFunction &CGF,
                               llvm::SwitchInst *switchInst,
@@ -142,6 +140,7 @@ public:
   virtual void MarkLoopStmt(CodeGenFunction &CGF,
                              llvm::BasicBlock *loopContinue,
                              llvm::BasicBlock *loopExit) = 0;
+
   virtual void MarkScopeEnd(CodeGenFunction &CGF) = 0;
 };
 

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -600,7 +600,7 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S,
   llvm::TerminatorInst *TI =
       cast<llvm::TerminatorInst>(*ThenBlock->user_begin());
   CGM.getHLSLRuntime().AddControlFlowHint(*this, S, TI, Attrs);
-  CGM.getHLSLRuntime().MarkThenStmt(*this, ContBlock);
+  CGM.getHLSLRuntime().MarkIfStmt(*this, ContBlock);
   // HLSL Change Ends
 
   // Emit the 'then' code.
@@ -612,15 +612,8 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S,
   }
   EmitBranch(ContBlock);
 
-  // HLSL Change Begin.
-  CGM.getHLSLRuntime().MarkScopeEnd(*this);
-  // HLSL Change End.
-
   // Emit the 'else' code if present.
   if (const Stmt *Else = S.getElse()) {
-    // HLSL Change Begin.
-    CGM.getHLSLRuntime().MarkElseStmt(*this, ContBlock);
-    // HLSL Change End.
     {
       // There is no need to emit line number for an unconditional branch.
       auto NL = ApplyDebugLocation::CreateEmpty(*this);
@@ -636,10 +629,10 @@ void CodeGenFunction::EmitIfStmt(const IfStmt &S,
       EmitBranch(ContBlock);
     }
 
-    // HLSL Change Begin.
-    CGM.getHLSLRuntime().MarkScopeEnd(*this);
-    // HLSL Change End.
   }
+  // HLSL Change Begin.
+  CGM.getHLSLRuntime().MarkScopeEnd(*this);
+  // HLSL Change End.
   // Emit the continuation block for code after the if.
   EmitBlock(ContBlock, true);
 }
@@ -827,6 +820,10 @@ void CodeGenFunction::EmitWhileStmt(const WhileStmt &S,
 
   LoopStack.pop();
 
+  // HLSL Change Begin.
+  CGM.getHLSLRuntime().MarkScopeEnd(*this);
+  // HLSL Change End.
+
   // Emit the exit block.
   EmitBlock(LoopExit.getBlock(), true);
 
@@ -834,9 +831,6 @@ void CodeGenFunction::EmitWhileStmt(const WhileStmt &S,
   // a branch, try to erase it.
   if (!EmitBoolCondBranch)
     SimplifyForwardingBlocks(LoopHeader.getBlock());
-  // HLSL Change Begin.
-  CGM.getHLSLRuntime().MarkScopeEnd(*this);
-  // HLSL Change End.
 }
 
 void CodeGenFunction::EmitDoStmt(const DoStmt &S,
@@ -896,6 +890,10 @@ void CodeGenFunction::EmitDoStmt(const DoStmt &S,
 
   LoopStack.pop();
 
+  // HLSL Change Begin.
+  CGM.getHLSLRuntime().MarkScopeEnd(*this);
+  // HLSL Change End.
+
   // Emit the exit block.
   EmitBlock(LoopExit.getBlock());
 
@@ -903,9 +901,6 @@ void CodeGenFunction::EmitDoStmt(const DoStmt &S,
   // emitting a branch, try to erase it.
   if (!EmitBoolCondBranch)
     SimplifyForwardingBlocks(LoopCond.getBlock());
-  // HLSL Change Begin.
-  CGM.getHLSLRuntime().MarkScopeEnd(*this);
-  // HLSL Change End.
 }
 
 void CodeGenFunction::EmitForStmt(const ForStmt &S,
@@ -1004,11 +999,12 @@ void CodeGenFunction::EmitForStmt(const ForStmt &S,
 
   LoopStack.pop();
 
-  // Emit the fall-through block.
-  EmitBlock(LoopExit.getBlock(), true);
   // HLSL Change Begin.
   CGM.getHLSLRuntime().MarkScopeEnd(*this);
   // HLSL Change End.
+
+  // Emit the fall-through block.
+  EmitBlock(LoopExit.getBlock(), true);
 }
 
 void
@@ -1728,6 +1724,10 @@ void CodeGenFunction::EmitSwitchStmt(const SwitchStmt &S,
 
   ConditionScope.ForceCleanup();
 
+  // HLSL Change Begin.
+  CGM.getHLSLRuntime().MarkScopeEnd(*this);
+  // HLSL Change End.
+
   // Emit continuation.
   EmitBlock(SwitchExit.getBlock(), true);
   incrementProfileCounter(&S);
@@ -1744,9 +1744,6 @@ void CodeGenFunction::EmitSwitchStmt(const SwitchStmt &S,
   SwitchInsn = SavedSwitchInsn;
   SwitchWeights = SavedSwitchWeights;
   CaseRangeBlock = SavedCRBlock;
-  // HLSL Change Begin.
-  CGM.getHLSLRuntime().MarkScopeEnd(*this);
-  // HLSL Change End.
 }
 
 static std::string

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/multi_ret.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/multi_ret.hlsl
@@ -6,6 +6,8 @@ float main(float4 a:A) : SV_Target {
 // Init bReturned.
 // CHECK:%[[bReturned:.*]] = alloca i1
 // CHECK:store i1 false, i1* %[[bReturned]]
+// Init retVal to 0.
+// CHECK:store float 0.000000e+00
 
   float c = 0;
 
@@ -20,7 +22,7 @@ float main(float4 a:A) : SV_Target {
 // guard rest of scope with !bReturned
 // CHECK: [[label_bRet_cmp_false:.*]] ; preds =
 // CHECK:%[[RET:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET:.*]] = xor i1 %[[RET]], true
+// CHECK:%[[NRET:.*]] = icmp ne i1 %[[RET]], false
 // CHECK:br i1 %[[NRET]],
 
 // CHECK: [[label3:.*]]  ; preds =
@@ -35,7 +37,7 @@ float main(float4 a:A) : SV_Target {
       return -5;
 // CHECK: [[label_bRet_cmp_false2:.*]] ; preds =
 // CHECK:%[[RET2:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET2:.*]] = xor i1 %[[RET2]], true
+// CHECK:%[[NRET2:.*]] = icmp ne i1 %[[RET2]], false
 // CHECK:br i1 %[[NRET2]],
 
 // CHECK: [[label4:.*]] ; preds =
@@ -43,13 +45,9 @@ float main(float4 a:A) : SV_Target {
 // guard after endif.
 // CHECK: [[label_bRet_cmp_false3:.*]] ; preds =
 // CHECK:%[[RET3:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET3:.*]] = xor i1 %[[RET3]], true
+// CHECK:%[[NRET3:.*]] = icmp ne i1 %[[RET3]], false
 // CHECK:br i1 %[[NRET3]],
-// guard after endif for else.
-// CHECK: [[label_bRet_cmp_false4:.*]] ; preds =
-// CHECK:%[[RET4:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET4:.*]] = xor i1 %[[RET4]], true
-// CHECK:br i1 %[[NRET4]],
+
   }
 // CHECK: [[endif:.*]] ; preds =
 
@@ -63,14 +61,10 @@ float main(float4 a:A) : SV_Target {
     if (c > 10)
 // set bIsReturn to true
 // CHECK:store i1 true, i1* %[[bReturned]]
+// dxBreak.
+// CHECK:br i1 true,
       return -2;
 
-// CHECK: [[label_bRet_cmp_true:.*]] ; preds =
-// CHECK:%[[RET5:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:br i1 %[[RET5]],
-// CHECK: [[label_bRet_break:.*]] ; preds =
-// dxBreak
-// CHECK:br i1 true,
 // CHECK: [[endif_in_loop:.*]] ; preds =
 
 // CHECK: [[for_inc:.*]] ; preds =
@@ -78,7 +72,7 @@ float main(float4 a:A) : SV_Target {
 // Guard after loop.
 // CHECK: [[label_bRet_cmp_false5:.*]] ; preds =
 // CHECK:%[[RET6:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET6:.*]] = xor i1 %[[RET6]], true
+// CHECK:%[[NRET6:.*]] = icmp ne i1 %[[RET6]], false
 // CHECK:br i1 %[[NRET6]],
 
   }
@@ -103,13 +97,8 @@ float main(float4 a:A) : SV_Target {
          if (c < 10)
 // set bIsReturn to true
 // CHECK:store i1 true, i1* %[[bReturned]]
+// return just change to branch out of switch.
          return -3;
-// CHECK: [[label_bRet_cmp_true2:.*]] ; preds =
-// CHECK:%[[RET7:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:br i1 %[[RET7]],
-// CHECK: [[label_bRet_break2:.*]] ; preds =
-// normal break
-// CHECK:br label
 
 // CHECK: [[endif_in_switch:.*]] ; preds =
        c += sin(a.x);
@@ -118,7 +107,7 @@ float main(float4 a:A) : SV_Target {
 // guard code after switch.
 // CHECK: [[label_bRet_cmp_false6:.*]] ; preds =
 // CHECK:%[[RET8:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET8:.*]] = xor i1 %[[RET8]], true
+// CHECK:%[[NRET8:.*]] = icmp ne i1 %[[RET8]], false
 // CHECK:br i1 %[[NRET8]]
 
 // CHECK: [[end_switch:.*]]; preds =

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_if.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_if.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -E main -fcgl -structurize-returns -T ps_6_0 %s | FileCheck %s
+
+float main(float4 a:A) : SV_Target {
+// Init bReturned.
+// CHECK:%[[bReturned:.*]] = alloca i1
+// CHECK:store i1 false, i1* %[[bReturned]]
+
+// CHECK: [[label:.*]] ; preds =
+  if (a.w < 0) {
+// CHECK: [[label2:.*]] ; preds =
+   if (floor(a.x) > 1) {
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+     return sin(a.y);
+   } else {
+// CHECK: [[else:.*]] ; preds =
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+     float r = log(a.z);
+     return r;
+   }
+  }
+// guard rest of scope with !bReturned
+// CHECK: [[label_bRet_cmp_false:.*]] ; preds =
+// CHECK:%[[RET:.*]] = load i1, i1* %[[bReturned]]
+// CHECK:%[[NRET:.*]] = xor i1 %[[RET]], true
+// CHECK:br i1 %[[NRET]],
+
+// CHECK: [[label_bRet_cmp_false2:.*]] ; preds =
+// CHECK:%[[RET2:.*]] = load i1, i1* %[[bReturned]]
+// CHECK:%[[NRET2:.*]] = xor i1 %[[RET2]], true
+// CHECK:br i1 %[[NRET2]],
+
+// CHECK: [[label3:.*]]  ; preds =
+  return cos(a.x+a.y);
+// CHECK: [[exit:.*]]  ; preds =
+// CHECK-NOT:preds
+// CHECK:ret float
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_if.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_if.hlsl
@@ -5,6 +5,9 @@ float main(float4 a:A) : SV_Target {
 // CHECK:%[[bReturned:.*]] = alloca i1
 // CHECK:store i1 false, i1* %[[bReturned]]
 
+// Init retVal to 0.
+// CHECK:store float 0.000000e+00
+
 // CHECK: [[label:.*]] ; preds =
   if (a.w < 0) {
 // CHECK: [[label2:.*]] ; preds =
@@ -23,13 +26,8 @@ float main(float4 a:A) : SV_Target {
 // guard rest of scope with !bReturned
 // CHECK: [[label_bRet_cmp_false:.*]] ; preds =
 // CHECK:%[[RET:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET:.*]] = xor i1 %[[RET]], true
+// CHECK:%[[NRET:.*]] = icmp ne i1 %[[RET]], false
 // CHECK:br i1 %[[NRET]],
-
-// CHECK: [[label_bRet_cmp_false2:.*]] ; preds =
-// CHECK:%[[RET2:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET2:.*]] = xor i1 %[[RET2]], true
-// CHECK:br i1 %[[NRET2]],
 
 // CHECK: [[label3:.*]]  ; preds =
   return cos(a.x+a.y);

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_loop.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_loop.hlsl
@@ -1,28 +1,32 @@
 // RUN: %dxc -E main -fcgl -structurize-returns -T ps_6_0 %s | FileCheck %s
 
 int i;
-
+// CHECK:define float @main
 float main(float4 a:A) : SV_Target {
 // Init bReturned.
 // CHECK:%[[bReturned:.*]] = alloca i1
-// CHECK:store i1 false, i1* %[[bReturned]]
+// CHECK-NEXT:store i1 false, i1* %[[bReturned]]
+// Init retVal to 0.
+// CHECK:store float 0.000000e+00
   float r = a.w;
 
-// CHECK: [[label:.*]] ; preds =
+// CHECK: [[if_then:.*]] ; preds =
   if (a.z > 0) {
 // CHECK: [[for_cond:.*]] ; preds =
     for (int j=0;j<i;j++) {
 // CHECK: [[for_body:.*]] ; preds =
 // set bReturned to true.
 // CHECK:store i1 true, i1* %[[bReturned]]
+// dxBreak
+// CHECK:br i1 true
        return log(i);
 
-// CHECK: [[for_inc:.*]] ; No predecessors!
+// CHECK: [[for_inc:.*]] ; preds =
     }
 // guard rest of scope with !bReturned
-// CHECK: [[label_bRet_cmp_false:.*]] ; preds =
+// CHECK: [[bRet_cmp_false:.*]] ; preds =
 // CHECK:%[[RET:.*]] = load i1, i1* %[[bReturned]]
-// CHECK:%[[NRET:.*]] = xor i1 %[[RET]], true
+// CHECK:%[[NRET:.*]] = icmp ne i1 %[[RET]], false
 // CHECK:br i1 %[[NRET]],
 
 // CHECK: [[for_end:.*]]  ; preds =

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_loop.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_loop.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -E main -fcgl -structurize-returns -T ps_6_0 %s | FileCheck %s
+
+int i;
+
+float main(float4 a:A) : SV_Target {
+// Init bReturned.
+// CHECK:%[[bReturned:.*]] = alloca i1
+// CHECK:store i1 false, i1* %[[bReturned]]
+  float r = a.w;
+
+// CHECK: [[label:.*]] ; preds =
+  if (a.z > 0) {
+// CHECK: [[for_cond:.*]] ; preds =
+    for (int j=0;j<i;j++) {
+// CHECK: [[for_body:.*]] ; preds =
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+       return log(i);
+
+// CHECK: [[for_inc:.*]] ; No predecessors!
+    }
+// guard rest of scope with !bReturned
+// CHECK: [[label_bRet_cmp_false:.*]] ; preds =
+// CHECK:%[[RET:.*]] = load i1, i1* %[[bReturned]]
+// CHECK:%[[NRET:.*]] = xor i1 %[[RET]], true
+// CHECK:br i1 %[[NRET]],
+
+// CHECK: [[for_end:.*]]  ; preds =
+    r += sin(a.y);
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+    return sin(a.x * a.z + r);
+  } else {
+// CHECK: [[else:.*]]  ; preds =
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+    return cos(r + a.z);
+  }
+
+// dead code which not has code generated.
+  return a.x + a.y;
+
+// CHECK: [[exit:.*]]  ; preds =
+// CHECK-NOT:preds
+// CHECK:ret float
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_switch.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/whole_scope_returned_switch.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -E main -fcgl -structurize-returns -T ps_6_0 %s | FileCheck %s
+
+int i;
+
+float main(float4 a:A) : SV_Target {
+// Init bReturned.
+// CHECK:%[[bReturned:.*]] = alloca i1
+// CHECK:store i1 false, i1* %[[bReturned]]
+
+// CHECK:switch
+  switch (i) {
+  default:
+// CHECK: [[default:.*]] ; preds =
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+    return sin(a.y);
+  case 1:
+// CHECK: [[case1:.*]] ; preds =
+// set bReturned to true.
+// CHECK:store i1 true, i1* %[[bReturned]]
+    return cos(a.x);
+  }
+// CHECK: [[exit:.*]]  ; preds =
+// CHECK-NOT:preds
+// CHECK:ret float
+}


### PR DESCRIPTION
For case like
if () {
  ...
  return;
} else {
  ...
  return;
}

both path is returned.
When whole scope is returned, the endScopeBB will be deleted in codeGen.
Add ScopeInfo::LegalizeWholeReturnedScope to update the whole returned scope's endScope to parent scope's endScope.