### PR TITLE
Rename bound resource globals when linking to prevent merging

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -114,6 +114,8 @@ public:
   void RemoveResourcesWithUnusedSymbols();
   void RemoveFunction(llvm::Function *F);
 
+  void RenameResourceGlobalsWithBinding(bool bKeepName = true);
+
   // Signatures.
   DxilSignature &GetInputSignature();
   const DxilSignature &GetInputSignature() const;

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -42,6 +42,7 @@ public:
   OP(llvm::LLVMContext &Ctx, llvm::Module *pModule);
 
   void RefreshCache();
+  void FixOverloadNames();
 
   llvm::Function *GetOpFunc(OpCode OpCode, llvm::Type *pOverloadType);
   const llvm::SmallMapVector<llvm::Type *, llvm::Function *, 8> &GetOpFuncList(OpCode OpCode) const;
@@ -162,6 +163,8 @@ private:
   static unsigned GetTypeSlot(llvm::Type *pType);
   static const char *GetOverloadTypeName(unsigned TypeSlot);
   static llvm::StringRef GetTypeName(llvm::Type *Ty, std::string &str);
+  static llvm::StringRef ConstructOverloadName(llvm::Type *Ty, DXIL::OpCode opCode,
+    std::string &funcNameStorage);
 };
 
 } // namespace hlsl

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -164,7 +164,7 @@ private:
   static const char *GetOverloadTypeName(unsigned TypeSlot);
   static llvm::StringRef GetTypeName(llvm::Type *Ty, std::string &str);
   static llvm::StringRef ConstructOverloadName(llvm::Type *Ty, DXIL::OpCode opCode,
-    std::string &funcNameStorage);
+                                               std::string &funcNameStorage);
 };
 
 } // namespace hlsl

--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -1350,7 +1350,6 @@ DxilLinkerImpl::Link(StringRef entry, StringRef profile, dxilutil::ExportMap &ex
     pLib->CollectUsedInitFunctions(addedFunctionSet, workList);
   }
 
-  // Fix intrinsic overloads.
   for (auto &pLib : libSet) {
     pLib->FixIntrinsicOverloads();
   }

--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -128,6 +128,8 @@ public:
   void CollectUsedInitFunctions(SetVector<StringRef> &addedFunctionSet,
                                 SmallVector<StringRef, 4> &workList);
 
+  void FixIntrinsicOverloads();
+
 private:
   std::unique_ptr<llvm::Module> m_pModule;
   DxilModule &m_DM;
@@ -188,7 +190,7 @@ DxilFunctionLinkInfo::DxilFunctionLinkInfo(Function *F) : func(F) {
 DxilLib::DxilLib(std::unique_ptr<llvm::Module> pModule)
     : m_pModule(std::move(pModule)), m_DM(m_pModule->GetOrCreateDxilModule()) {
   Module &M = *m_pModule;
-  const std::string &MID = M.getModuleIdentifier();
+  const std::string MID = (Twine(M.getModuleIdentifier()) + ".").str();
 
   // Collect function defines.
   for (Function &F : M.functions()) {
@@ -209,6 +211,19 @@ DxilLib::DxilLib(std::unique_ptr<llvm::Module> pModule)
       GV.setName(MID + GV.getName());
     }
   }
+
+  // Rename resources that have bindings to be based on that binding.
+  // Prevents collisions between resources of the same name that are
+  // bound to different locations.
+  m_DM.RenameResourceGlobalsWithBinding(/*bKeepName*/true);
+}
+
+void DxilLib::FixIntrinsicOverloads() {
+  // Fix DXIL overload name collisions that may be caused by name
+  // collisions between dxil ops with different overload types,
+  // when those types may have had the same name in the original
+  // modules.
+  m_DM.GetOP()->FixOverloadNames();
 }
 
 void DxilLib::LazyLoadFunction(Function *F) {
@@ -354,14 +369,24 @@ private:
   bool AddResource(DxilResourceBase *res, llvm::GlobalVariable *GV);
   void AddResourceToDM(DxilModule &DM);
   llvm::MapVector<DxilFunctionLinkInfo *, DxilLib *> m_functionDefs;
-  llvm::StringMap<llvm::Function *> m_functionDecls;
-  // New created functions.
-  llvm::StringMap<llvm::Function *> m_newFunctions;
-  // New created globals.
-  llvm::StringMap<llvm::GlobalVariable *> m_newGlobals;
-  // Map for resource.
-  llvm::StringMap<std::pair<DxilResourceBase *, llvm::GlobalVariable *>>
-      m_resourceMap;
+
+  // Function decls, in order added.
+  llvm::MapVector<llvm::StringRef,
+                  std::pair<llvm::SmallPtrSet<llvm::FunctionType *, 2>,
+                            llvm::SmallVector<llvm::Function *, 2>>>
+    m_functionDecls;
+
+  // New created functions, in order added.
+  llvm::MapVector<llvm::StringRef, llvm::Function *> m_newFunctions;
+
+  // New created globals, in order added.
+  llvm::MapVector<llvm::StringRef, llvm::GlobalVariable *> m_newGlobals;
+
+  // Map for resource, ordered by name.
+  std::map<llvm::StringRef,
+           std::pair<DxilResourceBase *, llvm::GlobalVariable *>>
+    m_resourceMap;
+
   LLVMContext &m_ctx;
   dxilutil::ExportMap &m_exportMap;
   unsigned m_valMajor, m_valMinor;
@@ -456,8 +481,8 @@ bool IsMatchedType(Type *Ty0, Type *Ty) {
 } // namespace
 
 bool DxilLinkJob::AddResource(DxilResourceBase *res, llvm::GlobalVariable *GV) {
-  if (m_resourceMap.count(res->GetGlobalName())) {
-    DxilResourceBase *res0 = m_resourceMap[res->GetGlobalName()].first;
+  if (m_resourceMap.count(GV->getName())) {
+    DxilResourceBase *res0 = m_resourceMap[GV->getName()].first;
     Type *Ty0 = res0->GetGlobalSymbol()->getType()->getPointerElementType();
     Type *Ty = res->GetGlobalSymbol()->getType()->getPointerElementType();
     // Make sure res0 match res.
@@ -466,11 +491,11 @@ bool DxilLinkJob::AddResource(DxilResourceBase *res, llvm::GlobalVariable *GV) {
       // Report error.
       dxilutil::EmitErrorOnGlobalVariable(dyn_cast<GlobalVariable>(res->GetGlobalSymbol()),
                                           Twine(kRedefineResource) + res->GetResClassName() + " for " +
-                                          res->GetGlobalName());
+                                          GV->getName());
       return false;
     }
   } else {
-    m_resourceMap[res->GetGlobalName()] = std::make_pair(res, GV);
+    m_resourceMap[GV->getName()] = std::make_pair(res, GV);
   }
   return true;
 }
@@ -575,11 +600,15 @@ void DxilLinkJob::LinkNamedMDNodes(Module *pM, ValueToValueMapTy &vmap) {
 
 void DxilLinkJob::AddFunctionDecls(Module *pM) {
   for (auto &it : m_functionDecls) {
-    Function *F = it.second;
-    Function *NewF = Function::Create(F->getFunctionType(), F->getLinkage(),
-                                      F->getName(), pM);
-    NewF->setAttributes(F->getAttributes());
-    m_newFunctions[NewF->getName()] = NewF;
+    for (auto F : it.second.second) {
+      Function *NewF = pM->getFunction(F->getName());
+      if (!NewF || F->getFunctionType() != NewF->getFunctionType()) {
+        NewF = Function::Create(F->getFunctionType(), F->getLinkage(),
+                                          F->getName(), pM);
+        NewF->setAttributes(F->getAttributes());
+      }
+      m_newFunctions[F->getName()] = NewF;
+    }
   }
 }
 
@@ -934,7 +963,12 @@ void DxilLinkJob::AddFunction(
 }
 
 void DxilLinkJob::AddFunction(llvm::Function *F) {
-  m_functionDecls[F->getName()] = F;
+  // Rarely, DXIL op overloads could collide, due to different types with same name.
+  // Later, we will rename these functions, but for now, we need to prevent clobbering
+  // an existing entry.
+  auto &entry = m_functionDecls[F->getName()];
+  if (entry.first.insert(F->getFunctionType()).second)
+    entry.second.push_back(F);
 }
 
 // Clone of StripDeadDebugInfo::runOnModule.
@@ -1315,6 +1349,12 @@ DxilLinkerImpl::Link(StringRef entry, StringRef profile, dxilutil::ExportMap &ex
   for (auto &pLib : libSet) {
     pLib->CollectUsedInitFunctions(addedFunctionSet, workList);
   }
+
+  // Fix intrinsic overloads.
+  for (auto &pLib : libSet) {
+    pLib->FixIntrinsicOverloads();
+  }
+
   // Add init functions if used.
   // All init function already loaded in BuildGlobalUsage,
   // so set bLazyLoadDone to true here.

--- a/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
@@ -1,0 +1,15 @@
+struct S
+{
+    float values;
+};
+
+ConstantBuffer<S> g_buf : register(b0);
+RWByteAddressBuffer b : register(u0);
+
+float Extern(uint dtid);
+
+[numthreads(31, 1, 1)]
+void main(uint dtid : SV_DispatchThreadId)
+{
+    b.Store2(dtid * 4, float2(Extern(dtid), g_buf.values));
+}

--- a/tools/clang/test/CodeGenHLSL/lib_res_bound2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_res_bound2.hlsl
@@ -1,0 +1,12 @@
+struct S1
+{
+    float values;
+};
+
+ConstantBuffer<S1> g_buf : register(b1);
+
+export
+float Extern(uint dtid)
+{
+     return g_buf.values + dtid;
+}

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -39,6 +39,7 @@ public:
   TEST_CLASS_SETUP(InitSupport);
 
   TEST_METHOD(RunLinkResource);
+  TEST_METHOD(RunLinkResourceWithBinding);
   TEST_METHOD(RunLinkAllProfiles);
   TEST_METHOD(RunLinkFailNoDefine);
   TEST_METHOD(RunLinkFailReDefine);
@@ -178,6 +179,26 @@ TEST_F(LinkerTest, RunLinkResource) {
   RegisterDxcModule(libResName, pResLib, pLinker);
 
   Link(L"entry", L"cs_6_0", pLinker, {libResName, libName}, {} ,{});
+}
+
+TEST_F(LinkerTest, RunLinkResourceWithBinding) {
+  // These two libraries both have a ConstantBuffer resource named g_buf.
+  // These are explicitly bound to different slots, and the types don't match.
+  // This would have broken in linking before a change to rename bound resources
+  // to prevent an attempt to merge them because they have the same name.
+  CComPtr<IDxcBlob> pLib1;
+  CompileLib(L"..\\CodeGenHLSL\\lib_res_bound1.hlsl", &pLib1);
+  CComPtr<IDxcBlob> pLib2;
+  CompileLib(L"..\\CodeGenHLSL\\lib_res_bound2.hlsl", &pLib2);
+  CComPtr<IDxcLinker> pLinker;
+  CreateLinker(&pLinker);
+  LPCWSTR lib1Name = L"lib1";
+  RegisterDxcModule(lib1Name, pLib1, pLinker);
+
+  LPCWSTR lib2Name = L"lib2";
+  RegisterDxcModule(lib2Name, pLib2, pLinker);
+
+  Link(L"main", L"cs_6_0", pLinker, {lib1Name, lib2Name}, {} ,{});
 }
 
 TEST_F(LinkerTest, RunLinkAllProfiles) {


### PR DESCRIPTION
- This also fixes the intrinsic overload problem when types of the same
  name don't match.
- This should also improve determinism in the linker, since various
  unordered maps were being iterated before.