### PR TITLE
Add resource rename pass, dx op overload fix

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -114,6 +114,9 @@ public:
   void RemoveResourcesWithUnusedSymbols();
   void RemoveFunction(llvm::Function *F);
 
+  bool RenameResourcesWithPrefix(const std::string &prefix);
+  bool RenameResourceGlobalsWithBinding(bool bKeepName = true);
+
   // Signatures.
   DxilSignature &GetInputSignature();
   const DxilSignature &GetInputSignature() const;

--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -42,6 +42,7 @@ public:
   OP(llvm::LLVMContext &Ctx, llvm::Module *pModule);
 
   void RefreshCache();
+  void FixOverloadNames();
 
   llvm::Function *GetOpFunc(OpCode OpCode, llvm::Type *pOverloadType);
   const llvm::SmallMapVector<llvm::Type *, llvm::Function *, 8> &GetOpFuncList(OpCode OpCode) const;
@@ -162,6 +163,8 @@ private:
   static unsigned GetTypeSlot(llvm::Type *pType);
   static const char *GetOverloadTypeName(unsigned TypeSlot);
   static llvm::StringRef GetTypeName(llvm::Type *Ty, std::string &str);
+  static llvm::StringRef ConstructOverloadName(llvm::Type *Ty, DXIL::OpCode opCode,
+                                               std::string &funcNameStorage);
 };
 
 } // namespace hlsl

--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -75,6 +75,7 @@ ModulePass *createPausePassesPass();
 ModulePass *createResumePassesPass();
 FunctionPass *createMatrixBitcastLowerPass();
 ModulePass *createDxilCleanupAddrSpaceCastPass();
+ModulePass *createDxilRenameResourcesPass();
 
 void initializeDxilCondenseResourcesPass(llvm::PassRegistry&);
 void initializeDxilLowerCreateHandleForLibPass(llvm::PassRegistry&);
@@ -108,6 +109,7 @@ void initializePausePassesPass(llvm::PassRegistry&);
 void initializeResumePassesPass(llvm::PassRegistry&);
 void initializeMatrixBitcastLowerPassPass(llvm::PassRegistry&);
 void initializeDxilCleanupAddrSpaceCastPass(llvm::PassRegistry&);
+void initializeDxilRenameResourcesPass(llvm::PassRegistry&);
 
 ModulePass *createDxilValidateWaveSensitivityPass();
 void initializeDxilValidateWaveSensitivityPass(llvm::PassRegistry&);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -1042,6 +1042,62 @@ void DxilModule::RemoveResourcesWithUnusedSymbols() {
   RemoveResourcesWithUnusedSymbolsHelper(m_Samplers);
 }
 
+namespace {
+template <typename TResource>
+static bool RenameResources(std::vector<std::unique_ptr<TResource>> &vec, const std::string &prefix) {
+  bool bChanged = false;
+  for (auto &res : vec) {
+    res->SetGlobalName(prefix + res->GetGlobalName());
+    if (GlobalVariable *GV = dyn_cast<GlobalVariable>(res->GetGlobalSymbol())) {
+      GV->setName(prefix + GV->getName());
+    }
+    bChanged = true;
+  }
+  return bChanged;
+}
+}
+
+bool DxilModule::RenameResourcesWithPrefix(const std::string &prefix) {
+  bool bChanged = false;
+  bChanged |= RenameResources(m_SRVs, prefix);
+  bChanged |= RenameResources(m_UAVs, prefix);
+  bChanged |= RenameResources(m_CBuffers, prefix);
+  bChanged |= RenameResources(m_Samplers, prefix);
+  return bChanged;
+}
+
+namespace {
+template <typename TResource>
+static bool RenameGlobalsWithBinding(std::vector<std::unique_ptr<TResource>> &vec, llvm::StringRef prefix, bool bKeepName) {
+  bool bChanged = false;
+  for (auto &res : vec) {
+    if (res->IsAllocated()) {
+      std::string newName;
+      if (bKeepName)
+        newName = (Twine(res->GetGlobalName()) + "." + Twine(prefix) + Twine(res->GetLowerBound()) + "." + Twine(res->GetSpaceID())).str();
+      else
+        newName = (Twine(prefix) + Twine(res->GetLowerBound()) + "." + Twine(res->GetSpaceID())).str();
+
+      res->SetGlobalName(newName);
+      if (GlobalVariable *GV = dyn_cast<GlobalVariable>(res->GetGlobalSymbol())) {
+        GV->setName(newName);
+      }
+      bChanged = true;
+    }
+  }
+  return bChanged;
+}
+}
+
+bool DxilModule::RenameResourceGlobalsWithBinding(bool bKeepName) {
+  bool bChanged = false;
+  bChanged |= RenameGlobalsWithBinding(m_SRVs, "t", bKeepName);
+  bChanged |= RenameGlobalsWithBinding(m_UAVs, "u", bKeepName);
+  bChanged |= RenameGlobalsWithBinding(m_CBuffers, "b", bKeepName);
+  bChanged |= RenameGlobalsWithBinding(m_Samplers, "s", bKeepName);
+  return bChanged;
+}
+
 DxilSignature &DxilModule::GetInputSignature() {
   DXASSERT(m_DxilEntryPropsMap.size() == 1 && !m_pSM->IsLib(),
            "only works for non-lib profile");

--- a/lib/HLSL/CMakeLists.txt
+++ b/lib/HLSL/CMakeLists.txt
@@ -26,6 +26,7 @@ add_llvm_library(LLVMHLSL
   DxilPatchShaderRecordBindings.cpp
   DxilNoops.cpp
   DxilPreserveAllOutputs.cpp
+  DxilRenameResourcesPass.cpp
   DxilSimpleGVNHoist.cpp
   DxilSignatureValidation.cpp
   DxilTargetLowering.cpp

--- a/lib/HLSL/DxilRenameResourcesPass.cpp
+++ b/lib/HLSL/DxilRenameResourcesPass.cpp
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxilRenameResourcesPass.cpp                                             //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "dxc/DXIL/DxilModule.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
+
+using namespace llvm;
+using namespace hlsl;
+
+// Rename resources with prefix
+
+namespace {
+
+class DxilRenameResources : public ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit DxilRenameResources()
+      : ModulePass(ID) {}
+
+  void applyOptions(PassOptions O) override {
+    GetPassOptionBool(O, "from-binding", &m_bFromBinding, false);
+    GetPassOptionBool(O, "keep-name", &m_bKeepName, true);
+    StringRef prefix;
+    GetPassOption(O, "prefix", &prefix);
+    m_Prefix = prefix.str();
+  }
+
+  const char *getPassName() const override {
+    return "DXIL rename resources";
+  }
+
+  bool runOnModule(Module &M) override {
+    DxilModule &DM = M.GetOrCreateDxilModule();
+    bool bChanged = false;
+    if (m_bFromBinding) {
+      bChanged = DM.RenameResourceGlobalsWithBinding(m_bKeepName);
+    }
+    if (!m_Prefix.empty()) {
+      bChanged |= DM.RenameResourcesWithPrefix(m_Prefix);
+    }
+    if (bChanged) {
+      DM.ReEmitDxilResources();
+    }
+    return bChanged;
+  }
+
+private:
+  bool m_bFromBinding;
+  bool m_bKeepName;
+  std::string m_Prefix;
+};
+
+char DxilRenameResources::ID = 0;
+
+}
+
+ModulePass *llvm::createDxilRenameResourcesPass() {
+  return new DxilRenameResources();
+}
+
+INITIALIZE_PASS(DxilRenameResources,
+                "dxil-rename-resources",
+                "DXIL rename resources", false, false)

--- a/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
@@ -1,0 +1,15 @@
+struct S
+{
+    float values;
+};
+
+ConstantBuffer<S> g_buf : register(b0);
+RWByteAddressBuffer b : register(u0);
+
+float Extern(uint dtid);
+
+[numthreads(31, 1, 1)]
+void main(uint dtid : SV_DispatchThreadId)
+{
+    b.Store2(dtid * 4, float2(Extern(dtid), g_buf.values));
+}

--- a/tools/clang/test/CodeGenHLSL/lib_res_bound2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_res_bound2.hlsl
@@ -1,0 +1,12 @@
+struct S1
+{
+    float values;
+};
+
+ConstantBuffer<S1> g_buf : register(b1);
+
+export
+float Extern(uint dtid)
+{
+     return g_buf.values + dtid;
+}

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -39,6 +39,7 @@ public:
   TEST_CLASS_SETUP(InitSupport);
 
   TEST_METHOD(RunLinkResource);
+  TEST_METHOD(RunLinkResourceWithBinding);
   TEST_METHOD(RunLinkAllProfiles);
   TEST_METHOD(RunLinkFailNoDefine);
   TEST_METHOD(RunLinkFailReDefine);
@@ -180,6 +181,61 @@ TEST_F(LinkerTest, RunLinkResource) {
   Link(L"entry", L"cs_6_0", pLinker, {libResName, libName}, {} ,{});
 }
 
+TEST_F(LinkerTest, RunLinkResourceWithBinding) {
+  // These two libraries both have a ConstantBuffer resource named g_buf.
+  // These are explicitly bound to different slots, and the types don't match.
+  // This test runs a pass to rename resources to prevent merging of resource globals.
+  // Then tests linking these, which requires dxil op overload renaming
+  // because of a typename collision between the two libraries.
+  CComPtr<IDxcBlob> pLib1;
+  CompileLib(L"..\\CodeGenHLSL\\lib_res_bound1.hlsl", &pLib1);
+  CComPtr<IDxcBlob> pLib2;
+  CompileLib(L"..\\CodeGenHLSL\\lib_res_bound2.hlsl", &pLib2);
+
+  LPCWSTR optOptions[] = {
+    L"-dxil-rename-resources,prefix=lib1",
+    L"-dxil-rename-resources,prefix=lib2",
+  };
+
+  CComPtr<IDxcOptimizer> pOptimizer;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcOptimizer, &pOptimizer));
+
+  CComPtr<IDxcContainerReflection> pContainerReflection;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcContainerReflection, &pContainerReflection));
+  UINT32 partIdx = 0;
+  VERIFY_SUCCEEDED(pContainerReflection->Load(pLib1));
+  VERIFY_SUCCEEDED(pContainerReflection->FindFirstPartKind(DXC_PART_DXIL, &partIdx));
+  CComPtr<IDxcBlob> pLib1Module;
+  VERIFY_SUCCEEDED(pContainerReflection->GetPartContent(partIdx, &pLib1Module));
+
+  CComPtr<IDxcBlob> pLib1ModuleRenamed;
+  VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(pLib1Module, &optOptions[0], 1, &pLib1ModuleRenamed, nullptr));
+  pLib1Module.Release();
+  pLib1.Release();
+  AssembleToContainer(m_dllSupport, pLib1ModuleRenamed, &pLib1);
+
+  VERIFY_SUCCEEDED(pContainerReflection->Load(pLib2));
+  VERIFY_SUCCEEDED(pContainerReflection->FindFirstPartKind(DXC_PART_DXIL, &partIdx));
+  CComPtr<IDxcBlob> pLib2Module;
+  VERIFY_SUCCEEDED(pContainerReflection->GetPartContent(partIdx, &pLib2Module));
+
+  CComPtr<IDxcBlob> pLib2ModuleRenamed;
+  VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(pLib2Module, &optOptions[1], 1, &pLib2ModuleRenamed, nullptr));
+  pLib2Module.Release();
+  pLib2.Release();
+  AssembleToContainer(m_dllSupport, pLib2ModuleRenamed, &pLib2);
+
+  CComPtr<IDxcLinker> pLinker;
+  CreateLinker(&pLinker);
+  LPCWSTR lib1Name = L"lib1";
+  RegisterDxcModule(lib1Name, pLib1, pLinker);
+
+  LPCWSTR lib2Name = L"lib2";
+  RegisterDxcModule(lib2Name, pLib2, pLinker);
+
+  Link(L"main", L"cs_6_0", pLinker, {lib1Name, lib2Name}, {} ,{});
+}
+
 TEST_F(LinkerTest, RunLinkAllProfiles) {
   CComPtr<IDxcLinker> pLinker;
   CreateLinker(&pLinker);
@@ -257,7 +313,6 @@ TEST_F(LinkerTest, RunLinkFailReDefineGlobal) {
 
   CComPtr<IDxcBlob> pLib1;
   CompileLib(L"..\\CodeGenHLSL\\lib_global4.hlsl", &pLib1);
-
 
   CComPtr<IDxcLinker> pLinker;
   CreateLinker(&pLinker);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2106,6 +2106,11 @@ class db_dxil(object):
         add_pass('dxil-delete-loop', 'DxilLoopDeletion', 'Dxil Loop Deletion', [])
         add_pass('dxil-value-cache', 'DxilValueCache', 'Dxil Value Cache',[])
         add_pass('hlsl-cleanup-dxbreak', 'CleanupDxBreak', 'HLSL Remove unnecessary dx.break conditions', [])
+        add_pass('dxil-rename-resources', 'DxilRenameResources', 'Rename resources to prevent merge by name during linking', [
+                {'n':'prefix', 'i':'Prefix', 't':'string', 'd':'Prefix to add to resource names'},
+                {'n':'from-binding', 'i':'FromBinding', 't':'bool', 'c':1, 'd':'Append binding to name when bound'},
+                {'n':'keep-name', 'i':'KeepName', 't':'bool', 'c':1, 'd':'Keep name when appending binding'},
+            ])
 
         category_lib="llvm"
         add_pass('ipsccp', 'IPSCCP', 'Interprocedural Sparse Conditional Constant Propagation', [])


### PR DESCRIPTION
- Add method to DxilModule to rename resources based on a prefix,
  preventing resource merging during linking.
- Also one to rename by binding if desired.
- Add pass to access this resource renaming.
- Fix dxil intrinsic overload names when type disambiguation causes
  types with same name to be renamed with .0+ suffix, but intrinsic
  names remain in collision.
- Handle colliding intrinsic names with unique types in linker.