### PR TITLE
Fixed #line issues with debug info and error messages

### DIFF
--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -121,7 +121,7 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
 
   SourceManager &SM = CGM.getContext().getSourceManager();
   auto *Scope = cast<llvm::DIScope>(LexicalBlockStack.back());
-  PresumedLoc PCLoc = SM.getPresumedLoc(CurLoc, false); // HLSL Change
+  PresumedLoc PCLoc = SM.getPresumedLoc(CurLoc, /*UseLineDirectives*/ false); // HLSL Change
 
   if (PCLoc.isInvalid() || Scope->getFilename() == PCLoc.getFilename())
     return;
@@ -243,7 +243,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     return DBuilder.createFile(TheCU->getFilename(), TheCU->getDirectory());
 
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc, false); // HLSL Change
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc, /*UseLineDirectives*/ false); // HLSL Change
 
   if (PLoc.isInvalid() || StringRef(PLoc.getFilename()).empty())
     // If the location is not valid then use main input file.
@@ -274,7 +274,7 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, false); // HLSL Change
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, /*UseLineDirectives*/ false); // HLSL Change
   return PLoc.isValid() ? PLoc.getLine() : 0;
 }
 
@@ -287,7 +287,7 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, false); // HLSL Change
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, /*UseLineDirectives*/ false); // HLSL Change
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -121,7 +121,7 @@ void CGDebugInfo::setLocation(SourceLocation Loc) {
 
   SourceManager &SM = CGM.getContext().getSourceManager();
   auto *Scope = cast<llvm::DIScope>(LexicalBlockStack.back());
-  PresumedLoc PCLoc = SM.getPresumedLoc(CurLoc);
+  PresumedLoc PCLoc = SM.getPresumedLoc(CurLoc, false); // HLSL Change
 
   if (PCLoc.isInvalid() || Scope->getFilename() == PCLoc.getFilename())
     return;
@@ -243,7 +243,7 @@ llvm::DIFile *CGDebugInfo::getOrCreateFile(SourceLocation Loc) {
     return DBuilder.createFile(TheCU->getFilename(), TheCU->getDirectory());
 
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc);
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc, false); // HLSL Change
 
   if (PLoc.isInvalid() || StringRef(PLoc.getFilename()).empty())
     // If the location is not valid then use main input file.
@@ -274,7 +274,7 @@ unsigned CGDebugInfo::getLineNumber(SourceLocation Loc) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc);
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, false); // HLSL Change
   return PLoc.isValid() ? PLoc.getLine() : 0;
 }
 
@@ -287,7 +287,7 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
   if (Loc.isInvalid() && CurLoc.isInvalid())
     return 0;
   SourceManager &SM = CGM.getContext().getSourceManager();
-  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc);
+  PresumedLoc PLoc = SM.getPresumedLoc(Loc.isValid() ? Loc : CurLoc, false); // HLSL Change
   return PLoc.isValid() ? PLoc.getColumn() : 0;
 }
 

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/pound_line.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/pound_line.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -Zi -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK-NOT: !{{[0-9]+}} = !DIFile(filename: "FileThatDoesntExist.hlsl"
+// CHECK-NOT: !{{[0-9]+}} = !DILocation(line: 32
+// CHECK-NOT: !{{[0-9]+}} = !DILocation(line: 33
+
+#line 30 "FileThatDoesntExist.hlsl"
+[RootSignature("")]
+float main(int a : TEXCOORD) : SV_Target {
+  float x = 0;
+  return x;
+}
+
+

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pound_line.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pound_line.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -Zi -E main -T ps_6_0 %s -O0 | FileCheck %s
+
+// CHECK: FileThatDoesntExist.hlsl:4:3: error: Could not unroll loop. Loop bound could not be deduced at compile time.
+
+// Regression test to confirm #line directives are reflected in the error messages.
+
+[RootSignature("")]
+float main(int a : TEXCOORD) : SV_Target {
+#line 1 "FileThatDoesntExist.hlsl"
+
+  float x = 0;
+  [unroll]
+  for (uint i = 0; i < a; i++)
+    x++;
+
+  return x;
+}
+


### PR DESCRIPTION
This change made the debug metadata store the original unprocessed source locations instead of the #line locations.

The debug metadata used to contain the #line locations, but since we use the source stored in the PDB instead of actual source files on disk, the debug info ended up mapping to non-existent files. Maybe when we could restore this old behaviour when debuggers support loading source files on disk.

This change also fixes error messages whenever there are #line directives. Since the error messages use the same mechanism to create location info as generating the debug info, they need the original unprocessed locations (rather than the #line locations).
