### PR TITLE
Enable recompile of shaders with includes in dxc

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -42,6 +42,7 @@
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinFunctions.h"
 #include "dxc.h"
+#include <algorithm>
 #include <vector>
 #include <string>
 
@@ -555,7 +556,9 @@ public:
     _COM_Outptr_result_maybenull_ IDxcBlob **ppIncludeSource
   ) override {
     try {
-      *ppIncludeSource = includeFiles.at(std::wstring(pFilename));
+      std::wstring FilenameStr(pFilename);
+      std::replace(FilenameStr.begin(), FilenameStr.end(), '/', '\\');
+      *ppIncludeSource = includeFiles.at(FilenameStr);
       (*ppIncludeSource)->AddRef();
     }
     CATCH_CPP_RETURN_HRESULT()

--- a/utils/hct/cmdtestfiles/inc2.hlsli
+++ b/utils/hct/cmdtestfiles/inc2.hlsli
@@ -1,0 +1,4 @@
+int f2(int g)
+{
+  return g*42;
+}

--- a/utils/hct/cmdtestfiles/include/inc1.hlsli
+++ b/utils/hct/cmdtestfiles/include/inc1.hlsli
@@ -1,0 +1,7 @@
+// Verify that we can find an include header in the original directory
+#include "inc2.hlsli"
+
+int f1(int g)
+{
+  return f2(g);
+}

--- a/utils/hct/cmdtestfiles/smoke.hlsl
+++ b/utils/hct/cmdtestfiles/smoke.hlsl
@@ -1,3 +1,6 @@
+// Verify that we can successfully process an include
+#include "include/inc1.hlsli"
+
 int g;
 static int g_unused;
 
@@ -15,5 +18,5 @@ float4 main() : semantic
   int x = 3;
   x;
   #endif
-  return g;
+  return f1(g);
 }


### PR DESCRIPTION
When recompiling, the dxc executable stores all file blobs under names
that use backslashes. However, when recompiling, the filenames of the
includes in a shader are joined with the directory using a forward
slash. In addition, many authors use forward slashes to separate
subdirectories in these includes. Because of this, no includes could
ever match.

By converting all / in the path to \ just before trying to retrieve the
associated pseudo-file, the file is found. Recompilation is only
supported on Windows presently, so other OS path dividers needn't be
considered.

Modify smoke.hlsl to verify that recompilation works