### PR TITLE
Avoid crash in ilist_node getPrev/getNext when Next/Prev is null

### DIFF
--- a/include/llvm/ADT/ilist_node.h
+++ b/include/llvm/ADT/ilist_node.h
@@ -59,7 +59,7 @@ public:
     NodeTy *Prev = this->getPrev();
 
     // Check for sentinel.
-    if (!Prev->getNext())
+    if (Prev && !Prev->getNext()) // HLSL Change: Prev may be nullptr
       return nullptr;
 
     return Prev;
@@ -70,7 +70,7 @@ public:
     const NodeTy *Prev = this->getPrev();
 
     // Check for sentinel.
-    if (!Prev->getNext())
+    if (Prev && !Prev->getNext()) // HLSL Change: Prev may be nullptr
       return nullptr;
 
     return Prev;
@@ -81,7 +81,7 @@ public:
     NodeTy *Next = getNext();
 
     // Check for sentinel.
-    if (!Next->getNext())
+    if (Next && !Next->getNext()) // HLSL Change: Next may be nullptr
       return nullptr;
 
     return Next;
@@ -92,7 +92,7 @@ public:
     const NodeTy *Next = getNext();
 
     // Check for sentinel.
-    if (!Next->getNext())
+    if (Next && !Next->getNext()) // HLSL Change: Next may be nullptr
       return nullptr;
 
     return Next;

--- a/tools/clang/test/HLSLFileCheck/validation/no_return_unreachable.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/no_return_unreachable.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxilver 1.6 | %dxc -T lib_6_3 -Wno-return-type %s | FileCheck %s
+
+// disable return-type warning (that defaults to error) to catch
+// validation case that would crash before HLSL Change to ilist_node
+// preventing deref of Prev nullptr.
+
+// CHECK: error: Instructions must be of an allowed type.
+// CHECK: note: at 'unreachable' in block
+// CHECK-SAME: of function
+// CHECK-SAME: no_return
+
+export float4 no_return() {
+  float4 f = 1.0;
+  f += 2.0;
+}


### PR DESCRIPTION
Related: #2975.