### PR TITLE
Fix remaining Clang warnings

### DIFF
--- a/include/dxc/DXIL/DxilShaderModel.h
+++ b/include/dxc/DXIL/DxilShaderModel.h
@@ -88,7 +88,6 @@ private:
   const char *m_pszName;
   unsigned m_NumInputRegs;
   unsigned m_NumOutputRegs;
-  bool     m_bUAVs;
   bool     m_bTypedUavs;
   unsigned m_NumUAVRegs;
 

--- a/include/llvm/LinkAllPasses.h
+++ b/include/llvm/LinkAllPasses.h
@@ -16,6 +16,7 @@
 #define LLVM_LINKALLPASSES_H
 
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/Analysis/AliasSetTracker.h"
 #include "llvm/Analysis/CallPrinter.h"
 #include "llvm/Analysis/DomPrinter.h"
@@ -42,10 +43,6 @@
 namespace {
   struct ForcePassLinking {
     ForcePassLinking() {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnull-dereference"
-#endif
       // We must reference the passes in such a way that compilers will not
       // delete it all as dead code, even with whole program optimization,
       // yet is effectively a NO-OP. As the compiler isn't smart enough
@@ -158,9 +155,13 @@ namespace {
       (void) llvm::createMetaRenamerPass();
       (void) llvm::createFunctionAttrsPass();
       (void) llvm::createMergeFunctionsPass();
-      (void) llvm::createPrintModulePass(*(llvm::raw_ostream*)nullptr);
-      (void) llvm::createPrintFunctionPass(*(llvm::raw_ostream*)nullptr);
-      (void) llvm::createPrintBasicBlockPass(*(llvm::raw_ostream*)nullptr);
+      // HLSL Change Begin - avoid casting nullptrs
+      std::string buf;
+      llvm::raw_string_ostream os(buf);
+      (void) llvm::createPrintModulePass(os);
+      (void) llvm::createPrintFunctionPass(os);
+      (void) llvm::createPrintBasicBlockPass(os);
+      // HLSL Change End - avoid casting nullptrs
       (void) llvm::createModuleDebugInfoPrinterPass();
       (void) llvm::createPartialInliningPass();
       (void) llvm::createLintPass();
@@ -184,16 +185,14 @@ namespace {
 
       (void)new llvm::IntervalPartition();
       (void)new llvm::ScalarEvolution();
-      ((llvm::Function*)nullptr)->viewCFGOnly();
-      llvm::RGPassManager RGM;
-      ((llvm::RegionPass*)nullptr)->runOnRegion((llvm::Region*)nullptr, RGM);
-      llvm::AliasSetTracker X(*(llvm::AliasAnalysis*)nullptr);
+      // HLSL Change Begin - avoid casting nullptrs
+      llvm::Function::Create(nullptr, llvm::GlobalValue::ExternalLinkage)->viewCFGOnly();
+      llvm::AliasAnalysis AA;
+      llvm::AliasSetTracker X(AA);
+      // HLSL Change End - avoid casting nullptrs
       X.add(nullptr, 0, llvm::AAMDNodes()); // for -print-alias-sets
       (void) llvm::AreStatisticsEnabled();
       (void) llvm::sys::RunningOnValgrind();
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     }
   } ForcePassLinking; // Force link by creating a global definition.
 }

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -116,8 +116,8 @@ void initializeHLExpandStoreIntrinsicsPass(PassRegistry&);
 // ScalarReplAggregatesHLSL - Break up alloca's of aggregates into multiple allocas
 // for hlsl. Array will not change, all structures will be broken up.
 //
-FunctionPass *createScalarReplAggregatesHLSLPass(bool UseDomTree = true,
-                                                 bool Promote = false);
+FunctionPass *createScalarReplAggregatesHLSLPass();
+
 void initializeSROA_DT_HLSLPass(PassRegistry&);
 //===----------------------------------------------------------------------===//
 //

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -285,8 +285,6 @@ Value *DxilValueCache::SimplifyAndCacheResult(Instruction *I, DominatorTree *DT)
   return Simplified;
 }
 
-STATISTIC(StaleValuesEncountered, "Stale Values Encountered");
-
 bool DxilValueCache::WeakValueMap::Seen(Value *V) {
   auto FindIt = Map.find(V);
   if (FindIt == Map.end())

--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -54,7 +54,11 @@ ShaderFlags::ShaderFlags():
 , m_bSamplerFeedback(false)
 , m_align0(0)
 , m_align1(0)
-{}
+{
+  // Silence unused field warnings
+  (void)m_align0;
+  (void)m_align1;
+}
 
 uint64_t ShaderFlags::GetFeatureInfo() const {
   uint64_t Flags = 0;

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -26,7 +26,6 @@ ShaderModel::ShaderModel(Kind Kind, unsigned Major, unsigned Minor, const char *
 , m_pszName(pszName)
 , m_NumInputRegs(NumInputRegs)
 , m_NumOutputRegs(NumOutputRegs)
-, m_bUAVs(bUAVs)
 , m_bTypedUavs(bTypedUavs)
 , m_NumUAVRegs(NumUAVRegs) {
 }

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -171,7 +171,7 @@ UINT32 DxcCodePageFromBytes(const char *bytes, size_t byteLen) throw() {
   return codePage;
 }
 
-static bool IsSizeWcharAligned(SIZE_T size) { return (size & (sizeof(wchar_t) - 1)) == 0; }
+#define IsSizeWcharAligned(size) (((size) & (sizeof(wchar_t) - 1)) == 0)
 
 template<typename _char>
 bool IsUtfBufferNullTerminated(LPCVOID pBuffer, SIZE_T size) {

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -421,6 +421,7 @@ llvm::AllocaInst *VariableRegisters::GetRegisterForAlignedOffset(
   return it->second;
 }
 
+#ifndef NDEBUG
 // DITypePeelTypeAlias peels const, typedef, and other alias types off of Ty,
 // returning the unalised type.
 static llvm::DIType *DITypePeelTypeAlias(
@@ -443,6 +444,8 @@ static llvm::DIType *DITypePeelTypeAlias(
 
   return Ty;
 }
+#endif // NDEBUG
+
 
 VariableRegisters::VariableRegisters(
     llvm::DIVariable *Variable,

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -180,7 +180,7 @@ Value *DxilPIXMeshShaderOutputInstrumentation::reserveDebugEntrySpace(
   
   // Check that the caller didn't ask for so much memory that it will 
   // overwrite the offset counter:
-  assert(m_RemainingReservedSpaceInBytes < CounterOffsetBeyondUsefulData);
+  assert(m_RemainingReservedSpaceInBytes < (int)CounterOffsetBeyondUsefulData);
 
   m_RemainingReservedSpaceInBytes = SpaceInBytes;
 

--- a/lib/HLSL/DxilNoops.cpp
+++ b/lib/HLSL/DxilNoops.cpp
@@ -124,17 +124,6 @@ static Constant *GetConstGep(Constant *Ptr, unsigned Idx0, unsigned Idx1) {
   return ConstantExpr::getGetElementPtr(nullptr, Ptr, Indices);
 }
 
-static bool ShouldPreserve(Value *V) {
-  if (isa<Constant>(V)) return true;
-  if (isa<Argument>(V)) return true;
-  if (isa<LoadInst>(V)) return true;
-  if (ExtractElementInst *GEP = dyn_cast<ExtractElementInst>(V)) {
-    return ShouldPreserve(GEP->getVectorOperand());
-  }
-  if (isa<CallInst>(V)) return true;
-  return false;
-}
-
 struct Store_Info {
   Instruction *StoreOrMC = nullptr;
   Value *Source = nullptr; // Alloca, GV, or Argument

--- a/lib/Transforms/IPO/Inliner.cpp
+++ b/lib/Transforms/IPO/Inliner.cpp
@@ -39,7 +39,7 @@ using namespace llvm;
 STATISTIC(NumInlined, "Number of functions inlined");
 STATISTIC(NumCallsDeleted, "Number of call sites deleted, not inlined");
 STATISTIC(NumDeleted, "Number of functions deleted because all callers found");
-STATISTIC(NumMergedAllocas, "Number of allocas merged together");
+// STATISTIC(NumMergedAllocas, "Number of allocas merged together"); // HLSL Change - unused
 
 // This weirdly named statistic tracks the number of times that, when attempting
 // to inline a function A into B, we analyze the callers of B in order to see

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -230,8 +230,7 @@ static void addHLSLPasses(bool HLSLHighLevel, unsigned OptLevel, hlsl::HLSLExten
   MPM.add(createSROA_Parameter_HLSL());
 
   // Split struct.
-  MPM.add(createScalarReplAggregatesHLSLPass(/*UseDomTree*/ true,
-                                             /*Promote*/ !NoOpt));
+  MPM.add(createScalarReplAggregatesHLSLPass());
 
   MPM.add(createHLMatrixLowerPass());
   // DCE should after SROA to remove unused element.

--- a/lib/Transforms/Scalar/DxilEliminateVector.cpp
+++ b/lib/Transforms/Scalar/DxilEliminateVector.cpp
@@ -95,21 +95,6 @@ bool CollectVectorElements(Value *V, SmallVector<Value *, 4> &Elements) {
   return false;
 }
 
-static bool HasDebugValue(Value *V) {
-  Instruction *I = dyn_cast<Instruction>(V);
-  if (!I) return false;
-
-  MetadataAsValue *DebugI = GetAsMetadata(I);
-  if (!DebugI) return false;
-
-  for (User *U : DebugI->users()) {
-    if (isa<DbgValueInst>(U))
-      return true;
-  }
-
-  return false;
-}
-
 bool DxilEliminateVector::TryRewriteDebugInfoForVector(InsertElementInst *IE) {
 
   // If this is not ever used as meta-data, there's no debug

--- a/tools/clang/lib/CodeGen/CGCall.cpp
+++ b/tools/clang/lib/CodeGen/CGCall.cpp
@@ -2979,7 +2979,7 @@ void CodeGenFunction::EmitCallArg(CallArgList &args, const Expr *E,
           // RWBuffer<uint> buf;
           // InterlockedAdd(buf[0].r, 1);
           llvm::Value *V = LV.getAddress();
-          Ptr = Builder.CreateGEP(V, { Builder.getInt32(0) });
+          Ptr = Builder.CreateGEP(V, Builder.getInt32(0));
         } else {
           llvm::Value *V = LV.getExtVectorAddr();
           llvm::Constant *Elts = LV.getExtVectorElts();

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1041,7 +1041,7 @@ bool CGDebugInfo::TryCollectHLSLRecordElements(const RecordType *Ty,
     unsigned VecSize = hlsl::GetHLSLVecSize(QualTy);
     unsigned ElemSizeInBits = CGM.getContext().getTypeSize(ElemQualTy);
     for (unsigned ElemIdx = 0; ElemIdx < VecSize; ++ElemIdx) {
-      StringRef FieldName = StringRef("xyzw" + ElemIdx, 1);
+      StringRef FieldName = StringRef(&"xyzw"[ElemIdx], 1);
       unsigned OffsetInBits = ElemSizeInBits * ElemIdx;
       llvm::DIType *FieldType = createFieldType(FieldName, ElemQualTy, 0,
         SourceLocation(), AccessSpecifier::AS_public, OffsetInBits,

--- a/tools/clang/lib/SPIRV/RawBufferMethods.cpp
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.cpp
@@ -190,10 +190,6 @@ SpirvInstruction *RawBufferHandler::processTemplatedLoadFromBuffer(
     const QualType targetType, uint32_t &bitOffset) {
   const auto loc = buffer->getSourceLocation();
   SpirvInstruction *result = nullptr;
-  auto *constUint0 =
-      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
-  auto *constUint1 =
-      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
 
   // TODO: If 8-bit types are to be supported in the future, we should also
   // add code to support bitOffset 8 and 24.
@@ -639,10 +635,6 @@ void RawBufferHandler::processTemplatedStoreToBuffer(SpirvInstruction *value,
                                                      uint32_t &bitOffset) {
   assert(bitOffset == 0 || bitOffset == 16);
   const auto loc = buffer->getSourceLocation();
-  auto *constUint0 =
-      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 0));
-  auto *constUint1 =
-      spvBuilder.getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, 1));
 
   // Scalar types
   if (isScalarType(valueType)) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2138,7 +2138,6 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
     }
 
     auto *argInst = doExpr(arg);
-    auto argType = arg->getType();
 
     // If argInfo is nullptr and argInst is a rvalue, we do not have a proper
     // pointer to pass to the function. we need a temporary variable in that
@@ -11656,7 +11655,6 @@ SpirvEmitter::processRayQueryIntrinsics(const CXXMemberCallExpr *expr,
         cast<ClassTemplateSpecializationDecl>(RT->getDecl());
     ClassTemplateDecl *templateDecl =
         templateSpecDecl->getSpecializedTemplate();
-    const auto retType = exprType;
     exprType = getHLSLMatrixType(astContext, theCompilerInstance.getSema(),
                                  templateDecl, astContext.FloatTy, 4, 3);
   }

--- a/tools/clang/lib/Sema/SemaAccess.cpp
+++ b/tools/clang/lib/Sema/SemaAccess.cpp
@@ -1762,9 +1762,9 @@ Sema::AccessResult Sema::CheckFriendAccess(NamedDecl *target) {
   // while the ParsingDeclarator is active.
   EffectiveContext EC(CurContext);
   switch (CheckEffectiveAccess(*this, EC, target->getLocation(), entity)) {
-  case AR_accessible: return Sema::AR_accessible;
-  case AR_inaccessible: return Sema::AR_inaccessible;
-  case AR_dependent: return Sema::AR_dependent;
+  case ::AR_accessible: return Sema::AR_accessible; // HLSL Change - disambiguate enum
+  case ::AR_inaccessible: return Sema::AR_inaccessible; // HLSL Change - disambiguate enum
+  case ::AR_dependent: return Sema::AR_dependent; // HLSL Change - disambiguate enum
   }
   llvm_unreachable("falling off end");
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/umaxObjectAtomic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/umaxObjectAtomic.hlsl
@@ -47,7 +47,7 @@ float4 main(uint4 a : A, float4 b : B) : SV_Target
     uint4 r = a;
     uint comparevalue = r.w;
     uint newvalue = r.z;
-    uint origvalue;
+    uint origvalue = buf0[r.z];
 
     InterlockedAdd(buf0[r.z], newvalue);
     InterlockedMin(buf0[r.z], newvalue);

--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -896,12 +896,6 @@ void DxcContext::Preprocess() {
   }
 }
 
-static void WriteString(HANDLE hFile, _In_z_ LPCSTR value, LPCWSTR pFileName) {
-  DWORD written;
-  if (FALSE == WriteFile(hFile, value, strlen(value) * sizeof(value[0]), &written, nullptr))
-    IFT_Data(HRESULT_FROM_WIN32(GetLastError()), pFileName);
-}
-
 void DxcContext::WriteHeader(IDxcBlobEncoding *pDisassembly, IDxcBlob *pCode,
                              llvm::Twine &pVariableName, LPCWSTR pFileName) {
   // Use older interface for compatibility with older DLL.

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -83,26 +83,6 @@ HRESULT RunInternalValidator(_In_ IDxcValidator *pValidator,
                              _In_ IDxcBlob *pShader, UINT32 Flags,
                              _In_ IDxcOperationResult **ppResult);
 
-static void CreateOperationResultFromOutputs(
-    IDxcBlob *pResultBlob, dxcutil::DxcArgsFileSystem *msfPtr,
-    const std::string &warnings, clang::DiagnosticsEngine &diags,
-    _COM_Outptr_ IDxcOperationResult **ppResult) {
-  CComPtr<IStream> pErrorStream;
-  msfPtr->GetStdOutpuHandleStream(&pErrorStream);
-  dxcutil::CreateOperationResultFromOutputs(pResultBlob, pErrorStream, warnings,
-                                            diags.hasErrorOccurred(), ppResult);
-}
-
-static void CreateOperationResultFromOutputs(
-    AbstractMemoryStream *pOutputStream, dxcutil::DxcArgsFileSystem *msfPtr,
-    const std::string &warnings, clang::DiagnosticsEngine &diags,
-    _COM_Outptr_ IDxcOperationResult **ppResult) {
-  CComPtr<IDxcBlob> pResultBlob;
-  IFT(pOutputStream->QueryInterface(&pResultBlob));
-  CreateOperationResultFromOutputs(pResultBlob, msfPtr, warnings, diags,
-                                   ppResult);
-}
-
 static bool ShouldPartBeIncludedInPDB(UINT32 FourCC) {
   switch (FourCC) {
   case hlsl::DFCC_ShaderDebugName:

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -223,14 +223,6 @@ public:
   }
 };
 
-static void raw_string_ostream_to_CoString(raw_string_ostream &o, _Outptr_result_z_ LPSTR *pResult) {
-  std::string& s = o.str(); // .str() will flush automatically
-  *pResult = (LPSTR)CoTaskMemAlloc(s.size() + 1);
-  if (*pResult == nullptr) 
-    throw std::bad_alloc();
-  strncpy(*pResult, s.c_str(), s.size() + 1);
-}
-
 static
 void SetupCompilerForRewrite(CompilerInstance &compiler,
                              _In_ DxcLangExtensionsHelper *helper,


### PR DESCRIPTION
Many of these take the form of removing unused member variables and
unused functions. Where they were truly unused, I removed them. Where
they were only used in asserts, I hid them for the release builds. Where
the code in question was original to LLVM, I didn't remove so much as
comment out the offending code. In most cases these changes are
counterparts to already excluded code for HLSL.

A few cases concern indexing or type matches. Where relevant, I lifted
the same solutions in the current source of the llvm project.

I altered the fix made recently to LinkAllPasses.h. Instead of just
disabling the warning, I used the temporary variables that the current
llvm project uses to avoid having to cast null pointers.