### PR TITLE
Preserve precise metadata when replacing instructions in transformations

### DIFF
--- a/include/dxc/DXIL/DxilMetadataHelper.h
+++ b/include/dxc/DXIL/DxilMetadataHelper.h
@@ -488,6 +488,8 @@ private:
 public:
   // Utility functions.
   static bool IsKnownNamedMetaData(const llvm::NamedMDNode &Node);
+  static bool IsKnownMetadataID(llvm::LLVMContext &Ctx, unsigned ID);
+  static void GetKnownMetadataIDs(llvm::LLVMContext &Ctx, llvm::SmallVectorImpl<unsigned> *pIDs);
   static void combineDxilMetadata(llvm::Instruction *K, const llvm::Instruction *J);
   static llvm::ConstantAsMetadata *Int32ToConstMD(int32_t v, llvm::LLVMContext &Ctx);
   llvm::ConstantAsMetadata *Int32ToConstMD(int32_t v);

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2356,6 +2356,26 @@ bool DxilMDHelper::IsKnownNamedMetaData(const llvm::NamedMDNode &Node) {
   return false;
 }
 
+bool DxilMDHelper::IsKnownMetadataID(LLVMContext &Ctx, unsigned ID)
+{
+    SmallVector<unsigned, 2> IDs;
+    GetKnownMetadataIDs(Ctx, &IDs);
+    return std::find(IDs.begin(), IDs.end(), ID) != IDs.end();
+}
+
+void DxilMDHelper::GetKnownMetadataIDs(LLVMContext &Ctx, SmallVectorImpl<unsigned> *pIDs)
+{
+    auto AddIdIfExists = [&Ctx, &pIDs](StringRef Name) {
+        unsigned ID = 0;
+        if (Ctx.findMDKindID(hlsl::DxilMDHelper::kDxilPreciseAttributeMDName, &ID))
+        {
+            pIDs->push_back(ID);
+        }
+    };
+
+    AddIdIfExists(hlsl::DxilMDHelper::kDxilPreciseAttributeMDName);
+    AddIdIfExists(hlsl::DxilMDHelper::kDxilNonUniformAttributeMDName);
+}
 void DxilMDHelper::combineDxilMetadata(llvm::Instruction *K,
                                        const llvm::Instruction *J) {
   if (IsMarkedNonUniform(J))

--- a/tools/clang/test/CodeGenHLSL/precise/precise_gvn.hlsl
+++ b/tools/clang/test/CodeGenHLSL/precise/precise_gvn.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Make sure that gvn preserves precise metadata when replacing instructions.
+// CHECK: @dx.op.dot4.f32{{.*}} !dx.precise
+
+
+struct VSIn
+{
+    float4 Pos : P;
+    float4 A   : A;
+};
+
+struct VSOut
+{
+    precise float4 Pos : SV_Position;
+    float4 N : A;
+};
+
+[RootSignature("")]
+VSOut main(VSIn input)
+{
+    float4 X  = input.A * input.A;
+    float4 Y  = input.A + input.A;
+    float4 R1 = mul(X, Y);
+    float4 R2 = mul(X, Y);
+
+    VSOut O;
+    O.Pos = R1 * R1;
+    O.N   = R2;
+    return O;
+}


### PR DESCRIPTION
We were not correctly preserving precise metadata when replacing instructions
in various transformations. This caused precise metadata to be dropped
when one a precise instruction was replaced with a non-precise instruction.

For example, given the two equivalent mul expressions

    float x = mul(a, b)
    precise float y = mul(a, b)
    z = x + y

GVN would replace `y` with `x` in the computation of `z`. This caused x to
be computed in non-precise mode.

The fix is to make sure we combine known dxil metadata when replacing instructions.