### PR TITLE
Enable warnings as errors for clang builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
 
 before_script:
   - git submodule update --init
-  - if [ ${CC} = gcc ]; then CC=gcc-5; CXX=g++-5; fi
+  - if [ ${CC} = gcc ]; then CC=gcc-5; CXX=g++-5; CXX_FLAGS=; else CXX_FLAGS=-Werror; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ulimit -Sn 1024; fi
 
 script:
@@ -68,6 +68,7 @@ script:
       -DSPIRV_BUILD_TESTS=ON
       -DCMAKE_BUILD_TYPE=${DXC_BUILD_TYPE}
       -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX}
+      -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
   - ninja
   - ./bin/dxc --help
   - ./bin/dxc -T ps_6_0 ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ before_build:
 build_script:
 - cmd: call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -spirvtest
 - sh: mkdir build && cd build
-- sh: cmake .. -GNinja $(cat ../utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+- sh: cmake .. -GNinja $(cat ../utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror
 - sh: ninja
 
 test_script:

--- a/include/dxc/DXIL/DxilInterpolationMode.h
+++ b/include/dxc/DXIL/DxilInterpolationMode.h
@@ -22,6 +22,7 @@ public:
   using Kind = DXIL::InterpolationMode;
 
   InterpolationMode();
+  InterpolationMode(const InterpolationMode &Mode) = default;
   InterpolationMode(Kind Kind);
   InterpolationMode(unsigned long long Kind);
   InterpolationMode(bool bNoInterpolation, bool bLinear, bool bNoperspective, bool bCentroid, bool bSample);

--- a/include/llvm/ADT/PackedVector.h
+++ b/include/llvm/ADT/PackedVector.h
@@ -135,11 +135,6 @@ public:
     return Bits != RHS.Bits;
   }
 
-  const PackedVector &operator=(const PackedVector &RHS) {
-    Bits = RHS.Bits;
-    return *this;
-  }
-
   PackedVector &operator|=(const PackedVector &RHS) {
     Bits |= RHS.Bits;
     return *this;

--- a/include/llvm/IR/ValueHandle.h
+++ b/include/llvm/IR/ValueHandle.h
@@ -145,6 +145,8 @@ public:
   WeakVH(const WeakVH &RHS)
     : ValueHandleBase(Weak, RHS) {}
 
+  WeakVH &operator=(const WeakVH &RHS) = default;
+
   Value *operator=(Value *RHS) {
     return ValueHandleBase::operator=(RHS);
   }
@@ -214,6 +216,7 @@ public:
 #else
   AssertingVH() : ThePtr(nullptr) {}
   AssertingVH(ValueTy *P) : ThePtr(GetAsValue(P)) {}
+  AssertingVH(const AssertingVH<ValueTy> &) = default;
 #endif
 
   operator ValueTy*() const {

--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -317,9 +317,9 @@ private:
     if (m_CI->getType()->isVoidTy())
       return m_ReplicatedCalls.back();
 
-      Value *retVal = llvm::UndefValue::get(m_CI->getType());
-      for (unsigned i = 0; i < m_ReplicatedCalls.size(); ++i)
-        retVal = m_Builder.CreateInsertElement(retVal, m_ReplicatedCalls[i], i);
+    Value *retVal = llvm::UndefValue::get(m_CI->getType());
+    for (unsigned i = 0; i < m_ReplicatedCalls.size(); ++i)
+      retVal = m_Builder.CreateInsertElement(retVal, m_ReplicatedCalls[i], i);
 
     return retVal;
   }

--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -952,8 +952,8 @@ void Cost::RateRegister(const SCEV *Reg,
          isa<SCEVConstant>(cast<SCEVAddRecExpr>(Reg)->getStart()))))
     ++SetupCost;
 
-    NumIVMuls += isa<SCEVMulExpr>(Reg) &&
-                 SE.hasComputableLoopEvolution(Reg, L);
+  NumIVMuls += isa<SCEVMulExpr>(Reg) &&
+               SE.hasComputableLoopEvolution(Reg, L);
 }
 
 /// RatePrimaryRegister - Record this register in the set. If we haven't seen it

--- a/tools/clang/lib/AST/ASTImporter.cpp
+++ b/tools/clang/lib/AST/ASTImporter.cpp
@@ -620,8 +620,8 @@ static bool IsStructurallyEquivalent(StructuralEquivalenceContext &Context,
     if (!IsStructurallyEquivalent(Context, Function1->getReturnType(),
                                   Function2->getReturnType()))
       return false;
-      if (Function1->getExtInfo() != Function2->getExtInfo())
-        return false;
+    if (Function1->getExtInfo() != Function2->getExtInfo())
+      return false;
     break;
   }
    

--- a/tools/clang/lib/CodeGen/CGBlocks.cpp
+++ b/tools/clang/lib/CodeGen/CGBlocks.cpp
@@ -240,7 +240,7 @@ namespace {
     else
       RightValue = right.Alignment;
     
-      return LeftValue > RightValue;
+    return LeftValue > RightValue;
   }
 }
 


### PR DESCRIPTION
This fixes up the last of the clang warnings that are unique to clang 10.
These take two forms, First, indentation that might indicate the mistaken
impression that a line is within an unbraced conditional block produces
a warning and is corrected in a few places. Second, a warning is
produced when a class has one of copy constructor or assignment operator
explicitly defined and the other left to implicit definition. The
solution is generally to add a definition with the = default assignment.

Finally, this adds the -Werror flag to all clang builds to keep the
build warnings clean and detect flaws that can affect all builds and
platforms.