### PR TITLE
Avoid subprog mismatch inserting dbg value intrinsic

### DIFF
--- a/lib/Transforms/Scalar/DxilConditionalMem2Reg.cpp
+++ b/lib/Transforms/Scalar/DxilConditionalMem2Reg.cpp
@@ -387,7 +387,8 @@ public:
           else {
             NewExpr = DIExpression::get(Ctx, {});
           }
-          DIB.insertDbgValueIntrinsic(Val, 0, Var, NewExpr, Loc, Store);
+          if (Loc->getScope()->getSubprogram() == Var->getScope()->getSubprogram())
+            DIB.insertDbgValueIntrinsic(Val, 0, Var, NewExpr, Loc, Store);
         }
 
         Declare->eraseFromParent();

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/vs_output2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/vs_output2.hlsl
@@ -1,0 +1,55 @@
+// RUN: %dxc /T vs_6_0 /E BezierVS /DDX12 /Od /Zi %s | FileCheck %s
+
+// CHECK-DAG: call void @llvm.dbg.value(metadata float %{{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK-DAG: call void @llvm.dbg.value(metadata float %{{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: call void @llvm.dbg.value(metadata float %{{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 64, 32)
+
+//--------------------------------------------------------------------------------------
+// vs_output2.hlsl
+//
+// variation on vs_output.hlsl that breaks up the basic blocks 
+// so that the llvm.dbg.declare and the store are in different scopes
+//
+// Advanced Technology Group (ATG)
+// Copyright (C) Microsoft Corporation. All rights reserved.
+//--------------------------------------------------------------------------------------
+
+#ifdef DX12
+#define RS \
+[RootSignature(" \
+    RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), \
+    DescriptorTable(CBV(b0, numDescriptors = 1), visibility=SHADER_VISIBILITY_ALL) \
+")]
+#else
+#define RS
+#endif
+
+//--------------------------------------------------------------------------------------
+// Vertex shader section
+//--------------------------------------------------------------------------------------
+struct VS_CONTROL_POINT_INPUT
+{
+    float3 pos      : POSITION;
+};
+
+struct VS_CONTROL_POINT_OUTPUT
+{
+    float3 pos      : POSITION;
+};
+
+void SubProg(out VS_CONTROL_POINT_OUTPUT output, VS_CONTROL_POINT_INPUT input)
+{
+  output.pos = input.pos;
+  if (output.pos.z > 3)
+    output.pos.z = 1;
+}
+
+RS
+VS_CONTROL_POINT_OUTPUT BezierVS( VS_CONTROL_POINT_INPUT input )
+{
+    VS_CONTROL_POINT_OUTPUT output;
+
+    SubProg(output, input);
+    return output;
+}
+


### PR DESCRIPTION
In order to be able to insert a rewritten declare before the store that
uses it, the declare must be in the same scope as the store. In some
cases where the blocks are broken up a bit, this isn't the case.

By performing the check before making the call, the erroneous case is
avoided.