### PR TITLE
Intuitively handle space in joined option syntax

### DIFF
--- a/lib/Option/Option.cpp
+++ b/lib/Option/Option.cpp
@@ -182,10 +182,11 @@ Arg *Option::accept(const ArgList &Args,
     { // HLSL Change Begin: Except if value separated by spaces here
       if (JoinedSpaces) {
         const char *Value = Args.getArgString(Index) + ArgSize + JoinedSpaces;
-        return new Arg(*this, Spelling, Index++, Value);
-      }
+        if (*Value != '\0')
+          return new Arg(*this, Spelling, Index++, Value);
+      } else
       // HLSL Change End
-      return nullptr;
+        return nullptr;
     }
 
     Index += 2;
@@ -217,7 +218,9 @@ Arg *Option::accept(const ArgList &Args,
     if (ArgSize != strlen(Args.getArgString(Index))) {
       const char *Value = Args.getArgString(Index) + ArgSize
         + JoinedSpaces; // HLSL Change: Skip spaces in joined case
-      return new Arg(*this, Spelling, Index++, Value);
+      // HLSL Change: don't interpret trailing spaces as empty value:
+      if (*Value != '\0')
+        return new Arg(*this, Spelling, Index++, Value);
     }
 
     // Otherwise it must be separate.

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -78,6 +78,8 @@ public:
   TEST_METHOD(CopyOptionsWhenSingleThenOK)
   //TEST_METHOD(CopyOptionsWhenMultipleThenOK)
 
+  TEST_METHOD(ReadOptionsJoinedWithSpacesThenOK)
+
   std::unique_ptr<DxcOpts> ReadOptsTest(const MainArgs &mainArgs,
                                         unsigned flagsToInclude,
                                         bool shouldFail = false,
@@ -305,4 +307,20 @@ TEST_F(OptionsTest, CopyOptionsWhenSingleThenOK) {
   VERIFY_ARE_NOT_EQUAL(outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"/E")));
   VERIFY_ARE_NOT_EQUAL(outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"main")));
   VERIFY_ARE_EQUAL    (outArgs.end(), std::find(outArgs.begin(), outArgs.end(), std::wstring(L"hlsl.hlsl")));
+}
+
+TEST_F(OptionsTest, ReadOptionsJoinedWithSpacesThenOK) {
+  // Ensure parsing arguments in joined form with embedded spaces
+  // between the option and the argument works, for these argument types:
+  // - JoinedOrSeparateClass (-E, -T)
+  // - SeparateClass (-external, -external-fn)
+  const wchar_t *Args[] = {
+    L"exe.exe",   L"-E main",    L"/T  ps_6_0",
+    L"hlsl.hlsl", L"-external foo.dll", L"-external-fn  CreateObj"};
+  MainArgsArr ArgsArr(Args);
+  std::unique_ptr<DxcOpts> o = ReadOptsTest(ArgsArr, DxcFlags);
+  VERIFY_ARE_EQUAL_STR("main", o->EntryPoint.data());
+  VERIFY_ARE_EQUAL_STR("ps_6_0", o->TargetProfile.data());
+  VERIFY_ARE_EQUAL_STR("CreateObj", o->ExternalFn.data());
+  VERIFY_ARE_EQUAL_STR("foo.dll", o->ExternalLib.data());
 }


### PR DESCRIPTION
A frequent mistake is to pass arguments to the compiler API where the
option is in the same string as the value, separated by a space, such
as L"-T ps_6_0".  This is normally interpreted as a joined form of the
"-T" option, with the value being " ps_6_0" - note the leading space in
the value.  This is not intentional and leads to confusion.

This change handles the case where an option is either the SeparateClass
or JoinedOrSeparateClass, and it appears to be joined form, starting with
spaces.  It's more than likely this is the mistake, so the spaces are
skipped, and the value starts after the spaces.  If you really want a
value that starts with space, that value can still be provided by using
the separate option: L"-Fo", L" filename-starting-with-space.dxo".