### PR TITLE
Allow integer attribs to GetAttributeAtvertex

### DIFF
--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -261,7 +261,7 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
   {  OC::WavePrefixBitCount,      "WavePrefixBitCount",       OCC::WavePrefixOp,             "wavePrefixOp",              {  true, false, false, false, false, false, false, false, false, false, false}, Attribute::None,     },
 
   // Pixel shader                                                                                                            void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
-  {  OC::AttributeAtVertex,       "AttributeAtVertex",        OCC::AttributeAtVertex,        "attributeAtVertex",         { false,  true,  true, false, false, false, false,  true, false, false, false}, Attribute::ReadNone, },
+  {  OC::AttributeAtVertex,       "AttributeAtVertex",        OCC::AttributeAtVertex,        "attributeAtVertex",         { false,  true,  true, false, false, false,  true,  true, false, false, false}, Attribute::ReadNone, },
 
   // Graphics shader                                                                                                         void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
   {  OC::ViewID,                  "ViewID",                   OCC::ViewID,                   "viewID",                    { false, false, false, false, false, false, false,  true, false, false, false}, Attribute::ReadNone, },

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -261,7 +261,7 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
   {  OC::WavePrefixBitCount,      "WavePrefixBitCount",       OCC::WavePrefixOp,             "wavePrefixOp",              {  true, false, false, false, false, false, false, false, false, false, false}, Attribute::None,     },
 
   // Pixel shader                                                                                                            void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
-  {  OC::AttributeAtVertex,       "AttributeAtVertex",        OCC::AttributeAtVertex,        "attributeAtVertex",         { false,  true,  true, false, false, false, false, false, false, false, false}, Attribute::ReadNone, },
+  {  OC::AttributeAtVertex,       "AttributeAtVertex",        OCC::AttributeAtVertex,        "attributeAtVertex",         { false,  true,  true, false, false, false, false,  true, false, false, false}, Attribute::ReadNone, },
 
   // Graphics shader                                                                                                         void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
   {  OC::ViewID,                  "ViewID",                   OCC::ViewID,                   "viewID",                    { false, false, false, false, false, false, false,  true, false, false, false}, Attribute::ReadNone, },

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 %s | FileCheck %s
+
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 0, i8 0)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 1, i8 0)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 2, i8 0)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 3, i8 0)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 0, i8 1)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 1, i8 1)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 2, i8 1)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 3, i8 1)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 0, i8 2)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 1, i8 2)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 2, i8 2)
+// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 3, i8 2)
+
+int4 main(nointerpolation int4 a : A, nointerpolation int4 b : B, nointerpolation int4 c : C) : SV_Target
+{
+  int4 a0 = GetAttributeAtVertex(a, 0);
+  int4 b1 = GetAttributeAtVertex(b, 1);
+  int4 c2 = GetAttributeAtVertex(c, 2);
+
+  return a0 + b1 + c2;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
@@ -1,19 +1,21 @@
-// RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 %s | FileCheck %s
+// RUN: %dxilver 1.1 | %dxc -E main -T ps_6_2 -HV 2018 -enable-16bit-types %s | FileCheck %s
 
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 0, i8 0)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 1, i8 0)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 2, i8 0)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 3, i8 0)
-// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 0, i8 1)
-// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 1, i8 1)
-// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 2, i8 1)
-// CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 1, i32 0, i8 3, i8 1)
+
+// CHECK: call i16 @dx.op.attributeAtVertex.i16(i32 137, i32 1, i32 0, i8 0, i8 1)
+// CHECK: call i16 @dx.op.attributeAtVertex.i16(i32 137, i32 1, i32 0, i8 1, i8 1)
+// CHECK: call i16 @dx.op.attributeAtVertex.i16(i32 137, i32 1, i32 0, i8 2, i8 1)
+// CHECK: call i16 @dx.op.attributeAtVertex.i16(i32 137, i32 1, i32 0, i8 3, i8 1)
+
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 0, i8 2)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 1, i8 2)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 2, i8 2)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 2, i32 0, i8 3, i8 2)
 
-int4 main(nointerpolation int4 a : A, nointerpolation int4 b : B, nointerpolation int4 c : C) : SV_Target
+int4 main(nointerpolation int4 a : A, nointerpolation int16_t4 b : B, nointerpolation int4 c : C) : SV_Target
 {
   int4 a0 = GetAttributeAtVertex(a, 0);
   int4 b1 = GetAttributeAtVertex(b, 1);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1270,7 +1270,7 @@ class db_dxil(object):
         # End of DXIL 1.0 opcodes.
         self.set_op_count_for_version(1, 0, next_op_idx)
 
-        self.add_dxil_op("AttributeAtVertex", next_op_idx, "AttributeAtVertex", "returns the values of the attributes at the vertex.", "hfi", "rn", [
+        self.add_dxil_op("AttributeAtVertex", next_op_idx, "AttributeAtVertex", "returns the values of the attributes at the vertex.", "hfiw", "rn", [
             db_dxil_param(0, "$o", "", "result"),
             db_dxil_param(2, "i32", "inputSigId", "input signature element ID"),
             db_dxil_param(3, "i32", "inputRowIndex", "row index of an input attribute"),

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -1270,7 +1270,7 @@ class db_dxil(object):
         # End of DXIL 1.0 opcodes.
         self.set_op_count_for_version(1, 0, next_op_idx)
 
-        self.add_dxil_op("AttributeAtVertex", next_op_idx, "AttributeAtVertex", "returns the values of the attributes at the vertex.", "hf", "rn", [
+        self.add_dxil_op("AttributeAtVertex", next_op_idx, "AttributeAtVertex", "returns the values of the attributes at the vertex.", "hfi", "rn", [
             db_dxil_param(0, "$o", "", "result"),
             db_dxil_param(2, "i32", "inputSigId", "input signature element ID"),
             db_dxil_param(3, "i32", "inputRowIndex", "row index of an input attribute"),


### PR DESCRIPTION
An oversight left out integer types for the attribute accessed by
GetAttributeAtVertex. This adds the integer indicator to the generation
script, which prevents the validation fail.