### PR TITLE
Removing unnecessary DisableThreadLibraryCalls() calls

### DIFF
--- a/projects/dxilconv/tools/dxilconv/dxilconv.cpp
+++ b/projects/dxilconv/tools/dxilconv/dxilconv.cpp
@@ -104,11 +104,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID )
 {
   if (Reason == DLL_PROCESS_ATTACH)
   {
-    DisableThreadLibraryCalls(hinstDLL);
     EventRegisterMicrosoft_Windows_DxcRuntime_API();
 
     DxcRuntimeEtw_DxcRuntimeInitialization_Start();
-    DisableThreadLibraryCalls(hinstDLL);
     HRESULT hr = InitMaybeFail();
     if (FAILED(hr)) {
       DxcRuntimeEtw_DxcRuntimeInitialization_Stop(hr);

--- a/tools/clang/tools/d3dcomp/d3dcomp.cpp
+++ b/tools/clang/tools/d3dcomp/d3dcomp.cpp
@@ -368,12 +368,5 @@ HRESULT WINAPI BridgeD3DPreprocess(_In_reads_bytes_(SrcDataSize) LPCVOID pSrcDat
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID) {
-  BOOL result = TRUE;
-  if (Reason == DLL_PROCESS_ATTACH) {
-    DisableThreadLibraryCalls(hinstDLL);
-  } else if (Reason == DLL_PROCESS_DETACH) {
-    // Nothing to clean-up.
-  }
-
-  return result;
+  return TRUE;
 }

--- a/tools/clang/tools/dxcompiler/DXCompiler.cpp
+++ b/tools/clang/tools/dxcompiler/DXCompiler.cpp
@@ -99,7 +99,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID reserved) {
   if (Reason == DLL_PROCESS_ATTACH) {
     EventRegisterMicrosoft_Windows_DXCompiler_API();
     DxcEtw_DXCompilerInitialization_Start();
-    DisableThreadLibraryCalls(hinstDLL);
     HRESULT hr = InitMaybeFail();
     DxcEtw_DXCompilerInitialization_Stop(hr);
     result = SUCCEEDED(hr) ? TRUE : FALSE;

--- a/tools/clang/tools/dxlib-sample/dxlib_sample.cpp
+++ b/tools/clang/tools/dxlib-sample/dxlib_sample.cpp
@@ -42,8 +42,6 @@ void  __CRTDECL operator delete (void* ptr, const std::nothrow_t& nothrow_consta
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID) {
   BOOL result = TRUE;
   if (Reason == DLL_PROCESS_ATTACH) {
-    DisableThreadLibraryCalls(hinstDLL);
-
     DxcInitThreadMalloc();
     DxcSetThreadMallocToDefault();
 

--- a/tools/clang/tools/dxrfallbackcompiler/DXCompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/DXCompiler.cpp
@@ -78,7 +78,6 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID reserved) {
   if (Reason == DLL_PROCESS_ATTACH) {
     EventRegisterMicrosoft_Windows_DXCompiler_API();
     DxcEtw_DXCompilerInitialization_Start();
-    DisableThreadLibraryCalls(hinstDLL);
     HRESULT hr = InitMaybeFail();
     DxcEtw_DXCompilerInitialization_Stop(hr);
     result = SUCCEEDED(hr) ? TRUE : FALSE;


### PR DESCRIPTION
DisableThreadLibraryCalls acts as a no-op due to TLS section