### PR TITLE
Correct codegenoption assigning from semantic defines

### DIFF
--- a/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
+++ b/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
@@ -63,6 +63,10 @@ public:
   // Write semantic defines as metadata in the module.
   virtual SemanticDefineErrorList WriteSemanticDefines(llvm::Module *M) = 0;
 
+  // Query the named option enable
+  // Needed because semantic defines may have set it since options were copied
+  virtual bool IsOptionEnabled(std::string option) = 0;
+
   // Get the name to use for the dxil intrinsic function.
   virtual std::string GetIntrinsicName(unsigned opcode) = 0;
 

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -3307,9 +3307,7 @@ void CGMSHLSLRuntime::FinishCodeGen() {
     ExtensionCodeGen(HLM, CGM);
   }
 
-  if (CGM.getCodeGenOpts().HLSLOptimizationToggles.count("structurize-returns") &&
-      CGM.getCodeGenOpts().HLSLOptimizationToggles.find("structurize-returns")->second)
-    StructurizeMultiRet(M, m_ScopeMap, bWaveEnabledStage, m_DxBreaks);
+  StructurizeMultiRet(M, CGM, m_ScopeMap, bWaveEnabledStage, m_DxBreaks);
 
   FinishEntries(HLM, Entry, CGM, entryFunctionMap, HSEntryPatchConstantFuncAttr,
                 patchConstantFunctionMap, patchConstantFunctionPropsMap);

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -3015,9 +3015,19 @@ void StructurizeMultiRetFunction(Function *F, ScopeInfo &ScopeInfo,
 } // namespace
 
 namespace CGHLSLMSHelper {
-void StructurizeMultiRet(Module &M, DenseMap<Function *, ScopeInfo> &ScopeMap,
+void StructurizeMultiRet(Module &M, clang::CodeGen::CodeGenModule &CGM,
+                         DenseMap<Function *, ScopeInfo> &ScopeMap,
                          bool bWaveEnabledStage,
                          SmallVector<BranchInst *, 16> &DxBreaks) {
+  if (CGM.getCodeGenOpts().HLSLExtensionsCodegen) {
+    if (!CGM.getCodeGenOpts().HLSLExtensionsCodegen->IsOptionEnabled("structurize-returns"))
+      return;
+  } else {
+    if (!CGM.getCodeGenOpts().HLSLOptimizationToggles.count("structurize-returns") ||
+        !CGM.getCodeGenOpts().HLSLOptimizationToggles.find("structurize-returns")->second)
+      return;
+  }
+
   for (Function &F : M) {
     if (F.isDeclaration())
       continue;

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -184,6 +184,7 @@ void UpdateLinkage(
     llvm::StringMap<PatchConstantInfo> &patchConstantFunctionMap);
 
 void StructurizeMultiRet(llvm::Module &M,
+                         clang::CodeGen::CodeGenModule &CGM,
                          llvm::DenseMap<llvm::Function *, ScopeInfo> &ScopeMap,
                          bool bWaveEnabledStage,
                          llvm::SmallVector<llvm::BranchInst *, 16> &DxBreaks);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -300,12 +300,20 @@ private:
       }
 
       // Add semantic defines to option flag equivalents
-      if (!define.Name.compare(prefixPos, enableStr.length(), enableStr))
-        optToggles[StringRef(define.Name.substr(prefixPos + enableStr.length())).lower()] = true;
-      else if (!define.Name.compare(prefixPos, disableStr.length(), disableStr))
-        optToggles[StringRef(define.Name.substr(prefixPos + disableStr.length())).lower()] = false;
-      else if (!define.Name.compare(prefixPos, selectStr.length(), selectStr))
-        optSelects[StringRef(define.Name.substr(prefixPos + selectStr.length())).lower()] = define.Value;
+      // Convert define-style '_' into option-style '-' and lowercase everything
+      if (!define.Name.compare(prefixPos, enableStr.length(), enableStr)) {
+        std::string optName = define.Name.substr(prefixPos + enableStr.length());
+        std::replace(optName.begin(), optName.end(), '_', '-');
+        optToggles[StringRef(optName).lower()] = true;
+      } else if (!define.Name.compare(prefixPos, disableStr.length(), disableStr)) {
+        std::string optName = define.Name.substr(prefixPos + disableStr.length());
+        std::replace(optName.begin(), optName.end(), '_', '-');
+        optToggles[StringRef(optName).lower()] = false;
+      } else if (!define.Name.compare(prefixPos, selectStr.length(), selectStr)) {
+        std::string optName = define.Name.substr(prefixPos + selectStr.length());
+        std::replace(optName.begin(), optName.end(), '_', '-');
+        optSelects[StringRef(optName).lower()] = define.Value;
+      }
     }
 
     // Add root node with pointers to all define metadata nodes.
@@ -349,6 +357,11 @@ public:
     GetValidatedSemanticDefines(defines, validated, errors);
     WriteSemanticDefines(M, validated);
     return errors;
+  }
+
+  virtual bool IsOptionEnabled(std::string option) override {
+    return m_CI.getCodeGenOpts().HLSLOptimizationToggles.count(option) &&
+      m_CI.getCodeGenOpts().HLSLOptimizationToggles.find(option)->second;
   }
 
   virtual std::string GetIntrinsicName(UINT opcode) override {


### PR DESCRIPTION
For structurize-returns, the codegenopts assigned were a copy of those
the compiler possesses. This is by design in clang as explicitly stated
in comments. As a result, when the compiler codegenopts are updated, the
codegenmodule's are not.

By adding the ability to query the optimization enables from the hlsl
extension helper, these options can be reflected.

Additionally, the structurize-returns flag would have required a define
with a '-' in it, which isn't possible. So now it converts between '_'
for defines and '-' for options, which is consistent with how other
flags are interpretted.

Adds a unit test similar to that of disable gvn that makes a simple
check to verify that the resturn structurization is enabled.