### PR TITLE
Add load for argument matrix subscript lowering

### DIFF
--- a/lib/HLSL/HLLowerUDT.cpp
+++ b/lib/HLSL/HLLowerUDT.cpp
@@ -408,7 +408,7 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
 
         std::vector<Instruction*> DeadInsts;
         HLMatrixSubscriptUseReplacer UseReplacer(
-          CI, NewV, ElemIndices, /*AllowLoweredPtrGEPs*/true, DeadInsts);
+          CI, NewV, /*TempLoweredMatrix*/nullptr, ElemIndices, /*AllowLoweredPtrGEPs*/true, DeadInsts);
         DXASSERT(CI->use_empty(),
                  "Expected all matrix subscript uses to have been replaced.");
         CI->eraseFromParent();

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -406,7 +406,7 @@ Value *HLMatrixLowerPass::tryGetLoweredPtrOperand(Value *Ptr, IRBuilder<> &Build
     RootPtr = GEP->getPointerOperand();
 
   Argument *Arg = dyn_cast<Argument>(RootPtr);
-  bool IsNonShaderArg = Arg != nullptr && !m_pHLModule->IsGraphicsShader(m_pHLModule->GetEntryFunction());
+  bool IsNonShaderArg = Arg != nullptr && !m_pHLModule->IsEntryThatUsesSignatures(Arg->getParent());
   if (IsNonShaderArg || isa<AllocaInst>(RootPtr)) {
     // Bitcast the matrix pointer to its lowered equivalent.
     // The HLMatrixBitcast pass will take care of this later.

--- a/lib/HLSL/HLMatrixSubscriptUseReplacer.h
+++ b/lib/HLSL/HLMatrixSubscriptUseReplacer.h
@@ -30,7 +30,7 @@ namespace hlsl {
 class HLMatrixSubscriptUseReplacer {
 public:
   // The constructor does everything
-  HLMatrixSubscriptUseReplacer(llvm::CallInst* Call, llvm::Value *LoweredPtr,
+  HLMatrixSubscriptUseReplacer(llvm::CallInst* Call, llvm::Value *LoweredPtr, llvm::Value *TempLoweredMatrix,
     llvm::SmallVectorImpl<llvm::Value*> &ElemIndices, bool AllowLoweredPtrGEPs,
     std::vector<llvm::Instruction*> &DeadInsts);
 
@@ -51,6 +51,7 @@ private:
   bool AllowLoweredPtrGEPs = false;
   bool HasScalarResult = false;
   bool HasDynamicElemIndex = false;
+  llvm::Type *LoweredTy = nullptr;
 
   // The entire lowered matrix as loaded from LoweredPtr,
   // nullptr if we copied it to a temporary array.

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript.hlsl
@@ -1,0 +1,64 @@
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T ps_6_0 %s | FileCheck %s
+
+// Test for general subscript operations on matrix arrays.
+// Specifically focused on shader inputs which failed to lower previously
+
+float3 GetRow(const float3x3 m, const int j)
+{
+  return m[j];
+}
+
+float3x3 g[2];
+groupshared float3x3 gs[2];
+
+struct JustMtx {
+  float3x3 mtx;
+};
+
+struct MtxArray {
+  float3x3 mtx[2];
+};
+
+float3 main(const int i : I, const int j : J, const float3x3 m[2]: M, JustMtx jm[2] : JM, MtxArray ma : A) : SV_Target
+{
+  float3 ret = 0.0;
+
+  // CHECK: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32
+  // CHECK: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32
+  // CHECK: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32
+  ret += g[MIDX][VIDX];
+
+  // CHECK: load float, float addrspace(3)*
+  // CHECK: load float, float addrspace(3)*
+  // CHECK: load float, float addrspace(3)*
+  ret += gs[MIDX][VIDX];
+
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 2, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 2, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 2, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  ret += m[MIDX][VIDX];
+
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 3, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 3, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 3, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  ret += jm[MIDX].mtx[VIDX];
+
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 4, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 4, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 4, i32 {{%?[0-9]*}}, i8 2, i32 undef)
+  ret += ma.mtx[MIDX][VIDX];
+
+  ret += GetRow(g[MIDX], VIDX);
+  ret += GetRow(gs[MIDX], VIDX);
+  ret += GetRow(m[MIDX], VIDX);
+  ret += GetRow(jm[MIDX].mtx, VIDX);
+  ret += GetRow(ma.mtx[MIDX], VIDX);
+
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %{{.*}})
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float %{{.*}})
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float %{{.*}})
+  return ret;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript.hlsl
@@ -2,6 +2,10 @@
 // RUN: %dxc -DMIDX=i -DVIDX=2 -T ps_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=1 -DVIDX=j -T ps_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=i -DVIDX=j -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T lib_6_3 %s | FileCheck %s
 
 // Test for general subscript operations on matrix arrays.
 // Specifically focused on shader inputs which failed to lower previously
@@ -22,6 +26,7 @@ struct MtxArray {
   float3x3 mtx[2];
 };
 
+[shader("pixel")]
 float3 main(const int i : I, const int j : J, const float3x3 m[2]: M, JustMtx jm[2] : JM, MtxArray ma : A) : SV_Target
 {
   float3 ret = 0.0;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_ds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_ds.hlsl
@@ -2,6 +2,10 @@
 // RUN: %dxc -DMIDX=i -DVIDX=2 -T ds_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=1 -DVIDX=j -T ds_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=i -DVIDX=j -T ds_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T lib_6_3 %s | FileCheck %s
 
 // Specific test for subscript operation on OutputPatch matrix data
 
@@ -15,6 +19,7 @@ float4 GetRow(const OutputPatch<MatStruct, 3> tri, int i, int j)
 }
 
 [domain("tri")]
+[shader("domain")]
 float4 main(int i : I, int j : J, const OutputPatch<MatStruct, 3> tri) : SV_Position {
 
   float4 ret = 0;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_ds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_ds.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T ds_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T ds_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T ds_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T ds_6_0 %s | FileCheck %s
+
+// Specific test for subscript operation on OutputPatch matrix data
+
+struct MatStruct {
+ float4x4 mtx : M;
+};
+
+float4 GetRow(const OutputPatch<MatStruct, 3> tri, int i, int j)
+{
+  return tri[MIDX].mtx[VIDX];
+}
+
+[domain("tri")]
+float4 main(int i : I, int j : J, const OutputPatch<MatStruct, 3> tri) : SV_Position {
+
+  float4 ret = 0;
+
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 {{%?[0-9]*}}, i8 2, i32 {{%?[0-9]*}})
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 {{%?[0-9]*}}, i8 2, i32 {{%?[0-9]*}})
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 {{%?[0-9]*}}, i8 2, i32 {{%?[0-9]*}})
+  // CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 {{%?[0-9]*}}, i8 2, i32 {{%?[0-9]*}})
+  ret += tri[MIDX].mtx[VIDX];
+
+  ret += GetRow(tri, MIDX, VIDX);
+
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %{{.*}})
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float %{{.*}})
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float %{{.*}})
+  // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float %{{.*}})
+  return ret;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
@@ -2,6 +2,10 @@
 // RUN: %dxc -DMIDX=i -DVIDX=2 -T hs_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=1 -DVIDX=j -T hs_6_0 %s | FileCheck %s
 // RUN: %dxc -DMIDX=i -DVIDX=j -T hs_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T lib_6_3 %s | FileCheck %s
 
 // Specific test for subscript operation on matrix array inputs in patch functions
 
@@ -49,6 +53,7 @@ Output Patch(InputPatch<MatStruct, 3> inputs)
 [outputtopology("triangle_cw")]
 [patchconstantfunc("Patch")]
 [outputcontrolpoints(3)]
+[shader("hull")]
 float4 main(InputPatch<MatStruct, 3> inputs) : SV_Position
 {
   int i = inputs[0].uv.x;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -DMIDX=1 -DVIDX=2 -T hs_6_0 %s | FileCheck %s
-// RN: %dxc -DMIDX=i -DVIDX=2 -T hs_6_0 %s | FileCheck %s
-// RN: %dxc -DMIDX=1 -DVIDX=j -T hs_6_0 %s | FileCheck %s
-// RN: %dxc -DMIDX=i -DVIDX=j -T hs_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=2 -T hs_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=1 -DVIDX=j -T hs_6_0 %s | FileCheck %s
+// RUN: %dxc -DMIDX=i -DVIDX=j -T hs_6_0 %s | FileCheck %s
 
 // Specific test for subscript operation on matrix array inputs in patch functions
 
@@ -15,10 +15,10 @@ struct Output {
   float inside : SV_InsideTessFactor;
 };
 
+// Instruction order here is a bit inconsistent.
+// So we can't test for all the outputs
 // CHECK: call float @dx.op.loadInput.f32
-// CHECK: call void @dx.op.storePatchConstant.f32
 // CHECK: call float @dx.op.loadInput.f32
-// CHECK: call void @dx.op.storePatchConstant.f32
 // CHECK: call float @dx.op.loadInput.f32
 // CHECK: call void @dx.op.storePatchConstant.f32
 // CHECK: call void @dx.op.storePatchConstant.f32

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_subscript_hs.hlsl
@@ -1,0 +1,57 @@
+// RUN: %dxc -DMIDX=1 -DVIDX=2 -T hs_6_0 %s | FileCheck %s
+// RN: %dxc -DMIDX=i -DVIDX=2 -T hs_6_0 %s | FileCheck %s
+// RN: %dxc -DMIDX=1 -DVIDX=j -T hs_6_0 %s | FileCheck %s
+// RN: %dxc -DMIDX=i -DVIDX=j -T hs_6_0 %s | FileCheck %s
+
+// Specific test for subscript operation on matrix array inputs in patch functions
+
+struct MatStruct {
+  int2 uv : TEXCOORD0;
+  float3x4  m_ObjectToWorld : TEXCOORD1;
+};
+
+struct Output {
+  float edges[3] : SV_TessFactor;
+  float inside : SV_InsideTessFactor;
+};
+
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call void @dx.op.storePatchConstant.f32
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call void @dx.op.storePatchConstant.f32
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call void @dx.op.storePatchConstant.f32
+// CHECK: call void @dx.op.storePatchConstant.f32
+Output Patch(InputPatch<MatStruct, 3> inputs)
+{
+  Output ret;
+  int i = inputs[0].uv.x;
+  int j = inputs[0].uv.y;
+
+  ret.edges[0] = inputs[MIDX].m_ObjectToWorld[VIDX][0];
+  ret.edges[1] = inputs[MIDX].m_ObjectToWorld[VIDX][1];
+  ret.edges[2] = inputs[MIDX].m_ObjectToWorld[VIDX][2];
+  ret.inside = 1.0f;
+  return ret;
+}
+
+
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call float @dx.op.loadInput.f32
+// CHECK: call void @dx.op.storeOutput.f32
+// CHECK: call void @dx.op.storeOutput.f32
+// CHECK: call void @dx.op.storeOutput.f32
+// CHECK: call void @dx.op.storeOutput.f32
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("Patch")]
+[outputcontrolpoints(3)]
+float4 main(InputPatch<MatStruct, 3> inputs) : SV_Position
+{
+  int i = inputs[0].uv.x;
+  int j = inputs[0].uv.y;
+  return inputs[MIDX].m_ObjectToWorld[VIDX];
+}


### PR DESCRIPTION
Matrix lowering was not handling subscript oeprations when the matrix
was a shader input. copying the matrix to a temporary explicitly or
implicitly as part of a copy in function call worked around the problem.
When the argument copy was eliminated, this problem was exposed.

By adding a load for the indicated matrix for a subscript of a shader
input matrix, the lowering can procede using the lowered matrix from the
load.

Additionally, hull shaders with their uninlineable functions were
failing to detect the constanthull function as a graphics function so
the subscript lowering was being treated as if it were in a library.
Even when it got to signature lowering, there was no support for
lowering matrix loads.

The test for shaderism now tests the function attributes of the module's
entry function. The signature lowering for matrix loads is moved into a
function that is called by input lowering for both the constant hull and
entry functions.

Added general tests for matrix subscripts from different memory types as
well as specific tests for the argument passing problem in pixel and
domain shaders.

Fixes #2958