### PR TITLE
Remove unneeded rawbuf Ld/St return type reassign

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -9331,7 +9331,6 @@ Sema::TemplateDeductionResult HLSLExternalSource::DeduceTemplateArgumentsForHLSL
 
     // Currently only intrinsic we allow for explicit template arguments are
     // for Load/Store for ByteAddressBuffer/RWByteAddressBuffer
-    // TODO: handle template arguments for future intrinsics in a more natural way
 
     // Check Explicit template arguments
     UINT intrinsicOp = (*cursor)->Op;
@@ -9355,7 +9354,6 @@ Sema::TemplateDeductionResult HLSLExternalSource::DeduceTemplateArgumentsForHLSL
               && !functionTemplateTypeArg.isNull()
               && hlsl::IsHLSLNumericOrAggregateOfNumericType(functionTemplateTypeArg)) {
             isLegalTemplate = true;
-            argTypes[0] = functionTemplateTypeArg;
           }
         }
       }

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/ByteAddressBuffer/store_template_specification.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/ByteAddressBuffer/store_template_specification.hlsl
@@ -3,6 +3,13 @@
 // Tests that ByteAddressBuffer.Store<T> works with the various ways the
 // template type can be specified.
 
+struct S
+{
+  int16_t i;
+  // 2-byte padding here, to test offsets.
+  struct { float f; } s; // Nested struct, to test recursion
+  struct {} _; // 0-byte field, to test offsets
+};
 RWByteAddressBuffer buf;
 
 void main() {
@@ -14,6 +21,10 @@ void main() {
   // CHECK: call void @dx.op.rawBufferStore.i32(i32 140, {{.*}}, i32 200, i32 undef, i32 42, i32 42, i32 42, i32 42, i8 15, i32 4)
   buf.Store<int2x2>(200, 42);
   
+  // Explicit template type with struct
+  // CHECK: call void @dx.op.rawBufferStore.f32(i32 140, {{.*}}, i32 254, i32 undef, float 4.200000e+01, float undef, float undef, float undef, i8 1, i32 4)
+  buf.Store<S>(250, (S)42);
+
   // Deduced template type
   // CHECK: call void @dx.op.rawBufferStore.i32(i32 140, {{.*}}, i32 300, i32 undef, i32 42, i32 42, i32 42, i32 42, i8 15, i32 4)
   buf.Store(300, (int2x2)42);
@@ -23,4 +34,5 @@ void main() {
   // CHECK: call void @dx.op.rawBufferStore.f32(i32 140, {{.*}}, i32 404, i32 undef, float 4.200000e+01, float undef, float undef, float undef, i8 1, i32 4)
   buf.Store(400, 42);
   buf.Store(404, 42.0);
+
 }


### PR DESCRIPTION
Prior to a more robust mechanism of handling types determined by
explicit templates in MatchArguments, a special case was made for
ByteAddressBuffer Loads that explicitly assigned the return type. When
the more robust mechanism was added as part of support for
ByteAddressBuffer Store, not only was this explicit assignment left in,
but it was also applied to the new Store method. The result was an
assert later on a store operation that is expected to return void.

By removing this now unneeded assignment, the assert no longer fires and
nothing else is changed sonce the return value was never read apart from
that anyway.

Fixes #2438