### PR TITLE
Fix vs2019 build warnings for custom build items

### DIFF
--- a/include/dxc/Tracing/CMakeLists.txt
+++ b/include/dxc/Tracing/CMakeLists.txt
@@ -5,13 +5,13 @@
 # Create the header in a temporary file and only update when necessary,
 # to avoid invalidating targets that depend on it.
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/tmpdxcetw.h
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcetw.h
   COMMAND mc -r ${CMAKE_CURRENT_BINARY_DIR} -h ${CMAKE_CURRENT_BINARY_DIR} -p DxcEtw_ -um -z tmpdxcetw ${CMAKE_CURRENT_SOURCE_DIR}/dxcetw.man
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/dxcetw.man
   COMMENT "Building instrumentation manifest ..."
 )
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/dxcetw.h
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dxcetw.h
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcetw.h
         ${CMAKE_CURRENT_BINARY_DIR}/dxcetw.h
@@ -24,7 +24,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcetw_MSG00001.bin
         ${CMAKE_CURRENT_BINARY_DIR}/MSG00001.bin
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/tmpdxcetw.h
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcetw.h
   COMMENT "Updating instrumentation manifest ..."
 )
 
@@ -34,7 +34,7 @@ set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/dxcetwTEMP.bin PROPERTIE
 set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/MSG00001.bin PROPERTIES GENERATED 1)
 
 add_custom_target(DxcEtw
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/dxcetw.h
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dxcetw.h
   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/dxcetw.man
 )
 

--- a/projects/include/Tracing/CMakeLists.txt
+++ b/projects/include/Tracing/CMakeLists.txt
@@ -5,13 +5,13 @@
 # Create the header in a temporary file and only update when necessary,
 # to avoid invalidating targets that depend on it.
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/tmpdxcruntimeetw.h
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcruntimeetw.h
   COMMAND mc -r ${CMAKE_CURRENT_BINARY_DIR} -h ${CMAKE_CURRENT_BINARY_DIR} -p DxcRuntimeEtw_ -um -z tmpdxcruntimeetw ${CMAKE_CURRENT_SOURCE_DIR}/DxcRuntime.man
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/DxcRuntime.man
   COMMENT "Building instrumentation manifest ..."
 )
 add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/DxcRuntimeEtw.h
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtw.h
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcruntimeetw.h
         ${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtw.h
@@ -24,7 +24,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcruntimeetw_msg00001.bin
         ${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtw_msg00001.bin
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/tmpdxcruntimeetw.h
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/tmpdxcruntimeetw.h
   COMMENT "Updating instrumentation manifest ..."
 )
 
@@ -34,7 +34,7 @@ set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtwtemp.bin PR
 set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtw_msg00001.bin PROPERTIES GENERATED 1)
 
 add_custom_target(DxcRuntimeEtw
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/dxc/Tracing/DxcRuntimeEtw.h
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/DxcRuntimeEtw.h
   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/DxcRuntime.man
 )
 


### PR DESCRIPTION
This should fix the warnings that have this pattern:

warning MSB8065: Custom build for item "...\tmpdxcetw.h.rule" succeeded,
but specified output "...\include\dxc\tracing\dxc\tracing\tmpdxcetw.h"
has not been created. This may cause incremental build to work incorrectly.