### PR TITLE
Fix crash with implicit truncation of vector to constant

### DIFF
--- a/tools/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/tools/clang/lib/CodeGen/CGExprConstant.cpp
@@ -773,18 +773,21 @@ public:
       if (llvm::ConstantDataVector *CDV = dyn_cast<llvm::ConstantDataVector>(C)) {
         for (unsigned i = 0; i < vecSize; i++)
           Elts[i] = CDV->getElementAsConstant(i);
-      } else {
-        llvm::ConstantVector *CV = dyn_cast<llvm::ConstantVector>(C);
+        return llvm::ConstantVector::get(Elts);
+      }
+      if (llvm::ConstantVector *CV = dyn_cast<llvm::ConstantVector>(C)) {
         for (unsigned i = 0; i < vecSize; i++)
           Elts[i] = CV->getOperand(i);
+        return llvm::ConstantVector::get(Elts);
       }
-      return llvm::ConstantVector::get(Elts);
+      return C;
     }
     case CK_HLSLVectorToScalarCast: {
-      if (llvm::ConstantDataVector *CDV = cast<llvm::ConstantDataVector>(C))
+      if (llvm::ConstantDataVector *CDV = dyn_cast<llvm::ConstantDataVector>(C))
         return CDV->getElementAsConstant(0);
-      llvm::ConstantVector *CV = cast<llvm::ConstantVector>(C);
-      return CV->getOperand(0);
+      if (llvm::ConstantVector *CV = dyn_cast<llvm::ConstantVector>(C))
+        return CV->getOperand(0);
+      return C;
     }
     case CK_HLSLMatrixTruncationCast: {
       llvm::StructType *ST =

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/issue2445.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/issue2445.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK:define void @main
+
+// This checks for the absence of a bug reported in issue #2445 "Implicit truncation of vector to constant causes crash"
+// The behavior varied depending on the init values of the float4 constructor.
+// (0,0,0,0) => core dumped
+// (1,0,0,0) => compiled successfully
+// (0,1,0,0) => asserted in include/llvm/Support/Casting.h
+// It is assumed that if the compilation succeeds the bug is not present.
+
+float4 main() : SV_Target0
+{
+  const float e1 = float4(0,0,0,0);
+  const float e2 = float4(1,0,0,0);
+  const float e3 = float4(0,1,0,0);
+  return e1 + e2 + e3;
+}


### PR DESCRIPTION
Issue #2445 reported a crash when implicitly truncating a vector
to a constant.
This was caused by the use of cast<> when dyn_cast<> was appropriate.
This change simply corrects this, and also allows for the case where
the cast is a no-op.

Fixes #2445