### PR TITLE
[spirv] Error on implicit-lod sampling in non-fragment shaders

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4170,7 +4170,8 @@ SpirvInstruction *SpirvEmitter::createImageSample(
 
   // Implicit-lod instructions are only allowed in pixel shader.
   if (!spvContext.isPS() && !isExplicit)
-    emitError("sampling with implicit lod is only allowed in fragment shaders", loc);
+    emitError("sampling with implicit lod is only allowed in fragment shaders",
+              loc);
 
   auto *retVal = spvBuilder.createImageSample(
       texelType, imageType, image, sampler, coordinate, compareVal, bias, lod,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4170,7 +4170,7 @@ SpirvInstruction *SpirvEmitter::createImageSample(
 
   // Implicit-lod instructions are only allowed in pixel shader.
   if (!spvContext.isPS() && !isExplicit)
-    needsLegalization = true;
+    emitError("sampling with implicit lod is only allowed in fragment shaders", loc);
 
   auto *retVal = spvBuilder.createImageSample(
       texelType, imageType, image, sampler, coordinate, compareVal, bias, lod,

--- a/tools/clang/test/CodeGenSPIRV/texture.sample-invalid-implicit-lod.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample-invalid-implicit-lod.hlsl
@@ -1,0 +1,40 @@
+// Run: %dxc -T vs_6_0 -E main
+
+SamplerState gSampler : register(s5);
+
+// Note: The front end forbids sampling from non-floating-point texture formats.
+
+Texture1D   <float4> t1 : register(t1);
+Texture2D   <float4> t2 : register(t2);
+Texture3D   <float4> t3 : register(t3);
+TextureCube <float4> t4 : register(t4);
+
+float4 main(int2 offset: A) : SV_Position {
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val1 = t1.Sample(gSampler, 0.5);
+
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val2 = t2.Sample(gSampler, float2(0.5, 0.25), offset);
+
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val3 = t3.Sample(gSampler, float3(0.5, 0.25, 0.3), 3);
+
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val4 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3));
+
+    float clamp;
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val5 = t2.Sample(gSampler, float2(0.5, 0.25), offset, clamp);
+
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val6 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3), /*clamp*/ 2.0f);
+
+    uint status;
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val7 = t2.Sample(gSampler, float2(0.5, 0.25), offset, clamp, status);
+
+// CHECK: sampling with implicit lod is only allowed in fragment shaders
+    float4 val8 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3), /*clamp*/ 2.0f, status);
+
+    return float4(0.0, 0.0, 0.0, 1.0);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -918,6 +918,9 @@ TEST_F(FileTest, TextureSampleCmpLevelZero) {
 TEST_F(FileTest, TextureArraySampleCmpLevelZero) {
   runFileTest("texture.array.sample-cmp-level-zero.hlsl");
 }
+TEST_F(FileTest, TextureSampleInvalidImplicitLod) {
+  runFileTest("texture.sample-invalid-implicit-lod.hlsl", Expect::Failure);
+}
 
 // For structured buffer methods
 TEST_F(FileTest, StructuredBufferLoad) {


### PR DESCRIPTION
Report an error when using implicit-lod sampling in non-fragment shaders for spirv codegen.

- The spirv legalization pass `replace-invalid-opcode` replaces texture sampling opcodes that expect implicit derivatives with a `0xDEADBEEF` constant for shader stages that don't support implicit derivatives (see https://github.com/KhronosGroup/SPIRV-Tools/blob/726af6f78f80988271c8b558ae9cc84fa5a65016/source/opt/replace_invalid_opc.cpp#L189). This traces a warning but is hard to oversee and definitely not in the programmers intend. Therefore, this pr triggers an error instead of requiring legalization when such an instruction is processed by the spirv emitter.

Addresses #2663