### PR TITLE
Remove assert.h include from DxilPipelineStateValidation.h

### DIFF
--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -14,7 +14,11 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <assert.h>
+
+// Don't include assert.h here.
+// Since this header is included from multiple environments,
+// it is necessary to define assert before this header is included.
+// #include <assert.h>
 
 #ifndef UINT_MAX
 #define UINT_MAX 0xffffffff

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include "assert.h"
+#include <assert.h>
 
 #ifndef UINT_MAX
 #define UINT_MAX 0xffffffff
@@ -602,13 +602,13 @@ DxilPipelineStateValidation::CheckedReaderWriter::CheckBounds(size_t size) {
 inline bool
 DxilPipelineStateValidation::CheckedReaderWriter::IncrementPos(size_t size) {
   PSV_RETB(size <= UINT_MAX);
-  uint32_t uSize = size;
+  uint32_t uSize = (uint32_t)size;
   if (Mode == RWMode::CalcSize) {
     PSV_RETB(uSize <= Size + uSize);
     Size += uSize;
   }
   PSV_RETB(CheckBounds(size));
-  Offset += size;
+  Offset += uSize;
   return true;
 }
 

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -32,6 +32,7 @@
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/FileIOHelper.h"
 #include "dxc/Support/dxcapi.impl.h"
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/DxilContainer/DxilRuntimeReflection.h"
 #include "dxc/DXIL/DxilCounters.h"

--- a/lib/DxilRootSignature/DxilRootSignature.cpp
+++ b/lib/DxilRootSignature/DxilRootSignature.cpp
@@ -11,7 +11,6 @@
 
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DxilRootSignature/DxilRootSignature.h"
-#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinFunctions.h"

--- a/lib/DxilRootSignature/DxilRootSignatureConvert.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureConvert.cpp
@@ -11,7 +11,6 @@
 
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DxilRootSignature/DxilRootSignature.h"
-#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinFunctions.h"

--- a/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
@@ -11,7 +11,6 @@
 
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DxilRootSignature/DxilRootSignature.h"
-#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinFunctions.h"

--- a/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureValidator.cpp
@@ -11,7 +11,6 @@
 
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DxilRootSignature/DxilRootSignature.h"
-#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/Support/WinFunctions.h"
@@ -27,6 +26,9 @@
 #include <vector>
 #include <set>
 #include <ios>
+
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
+#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 
 #include "DxilRootSignatureHelper.h"
 

--- a/lib/HLSL/DxilSignatureValidation.cpp
+++ b/lib/HLSL/DxilSignatureValidation.cpp
@@ -17,6 +17,7 @@
 using namespace hlsl;
 using namespace llvm;
 
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include <functional>
 #include "dxc/HLSL/ViewIDPipelineValidation.inl"

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -28,6 +28,7 @@
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Format.h"
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/DxilContainer/DxilRuntimeReflection.h"

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -52,6 +52,7 @@
 #include "dxc/Support/HLSLOptions.h"
 #include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/DxilContainer/DxilRuntimeReflection.h"
+#include <assert.h> // Needed for DxilPipelineStateValidation.h
 #include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/DXIL/DxilShaderFlags.h"
 #include "dxc/DXIL/DxilUtil.h"


### PR DESCRIPTION
Also:
- fixed size_t to uint32_t error when building with other tools.
- removed DxilPipelineStateValidation.h where unused.