### PR TITLE
 Enable Visual Studio 2019 build by default

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ before_build:
 - cmd: call utils\hct\hctstart %HLSL_SRC_DIR% %HLSL_BLD_DIR%
 
 build_script:
-- cmd: call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -spirvtest
+- cmd: call utils\hct\hctbuild -%PLATFORM% -%CONFIGURATION% -vs2017 -spirvtest
 - sh: mkdir build && cd build
 - sh: cmake .. -GNinja $(cat ../utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS=-Werror
 - sh: ninja

--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -1,37 +1,29 @@
 # Find the DIA SDK path.
-get_filename_component(VS_PATH32 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\VisualStudio\\14.0;InstallDir]" ABSOLUTE CACHE)
-get_filename_component(VS_PATH64 "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\Microsoft\\VisualStudio\\14.0;InstallDir]" ABSOLUTE CACHE)
-# VS_PATH32 will be something like C:/Program Files (x86)/Microsoft Visual Studio 14.0/Common7/IDE
+# It will typically look something like this:
+# C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\DIA SDK\include
 
-# Also look for in vs15 or vs16 install.
-set(PROGRAMFILES_X86 "ProgramFiles(x86)")
-set(VS_PATH32 "$ENV{${PROGRAMFILES_X86}}/Microsoft Visual Studio")
-get_filename_component(VS15_C_PATH32 "${VS_PATH32}/2017/Community/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS15_P_PATH32 "${VS_PATH32}/2017/Professional/Common7/IDE" ABSOLUTE CACHE)
-get_filename_component(VS15_E_PATH32 "${VS_PATH32}/2017/Enterprise/Common7/IDE" ABSOLUTE CACHE)
+# CMAKE_GENERATOR_INSTANCE has the location of Visual Studio used
+# i.e. C:/Program Files (x86)/Microsoft Visual Studio/2019/Community
+set(VS_PATH ${CMAKE_GENERATOR_INSTANCE})
+get_filename_component(VS_DIA_INC_PATH "${VS_PATH}/DIA SDK/include" ABSOLUTE CACHE)
 
 # Starting in VS 15.2, vswhere is included.
 # Unclear what the right component to search for is, might be Microsoft.VisualStudio.Component.VC.DiagnosticTools
 # (although the friendly name of that is C++ profiling tools).  The toolset is the most likely target.
+set(PROGRAMFILES_X86 "ProgramFiles(x86)")
 execute_process(
-  COMMAND "${VS_PATH32}/Installer/vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+  COMMAND "$ENV{${PROGRAMFILES_X86}}/Microsoft Visual Studio/Installer/vswhere.exe" -latest -prerelease -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
   OUTPUT_VARIABLE VSWHERE_LATEST
   ERROR_QUIET
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-# Find the DIA SDK path, it will typically look something like this.
-# C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\DIA SDK\include
 # C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\DIA SDK\include
 # C:\Program Files (x86)\Microsoft Visual Studio 14.0\DIA SDK\include
 find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
+          HINTS "${VS_DIA_INC_PATH}"
           HINTS "${VSWHERE_LATEST}/DIA SDK/include"
-          HINTS "${VS15_C_PATH32}/../../DIA SDK/include" 
-          HINTS "${VS15_P_PATH32}/../../DIA SDK/include"
-          HINTS "${VS15_E_PATH32}/../../DIA SDK/include"
-          HINTS "${VS_PATH64}/../../DIA SDK/include"
-          HINTS "${VS_PATH32}/../../DIA SDK/include"
           DOC "path to DIA SDK header files"
           )
 

--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -18,8 +18,6 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
-# C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\DIA SDK\include
-# C:\Program Files (x86)\Microsoft Visual Studio 14.0\DIA SDK\include
 find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
           HINTS "${VS_DIA_INC_PATH}"

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -41,8 +41,8 @@ if "%BUILD_ARCH%"=="" (
   set BUILD_ARCH=Win32
 )
 
-set BUILD_GENERATOR=Visual Studio 15 2017
-set BUILD_VS_VER=2017
+set BUILD_GENERATOR=Visual Studio 16 2019
+set BUILD_VS_VER=2019
 set BUILD_CONFIG=Debug
 set DO_SETUP=1
 set DO_BUILD=1
@@ -128,16 +128,11 @@ if "%1"=="-Release" (
   shift /1
 )
 if "%1"=="-vs2017" (
-  shift /1
-)
-if "%1"=="-vs2015" (
-  set BUILD_GENERATOR=Visual Studio 14 2015
-  set BUILD_VS_VER=2015
+  set BUILD_GENERATOR=Visual Studio 15 2017
+  set BUILD_VS_VER=2017
   shift /1
 )
 if "%1"=="-vs2019" (
-  set BUILD_GENERATOR=Visual Studio 16 2019
-  set BUILD_VS_VER=2019
   shift /1
 )
 
@@ -184,13 +179,12 @@ if "%1"=="-dxc-cmake-ends-include" (
   shift /1
 )
 
-rem If only VS 2017 is available, pick that by default.
-if "%BUILD_VS_VER%"=="2015" (
-  reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\DevDiv\vs\Servicing\14.0\devenv /v Install /reg:32 1>nul 2>nul
-  if errorlevel 1 (
-    echo Visual Studio 2015 not available, setting up build for Visual Studio 2017.
-    set BUILD_GENERATOR=Visual Studio 15 2017
-    set BUILD_VS_VER=2017
+rem If only VS 2019 is available, pick that by default.
+if "%BUILD_VS_VER%"=="2017" (
+  if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017" (
+    echo Visual Studio 2017 not available, setting up build for Visual Studio 2019.
+    set BUILD_GENERATOR=Visual Studio 16 2019
+    set BUILD_VS_VER=2019
   )
 )
 
@@ -327,7 +321,7 @@ exit /b 0
 echo Builds HLSL solutions and the product and test binaries for the current
 echo flavor and architecture.
 echo.
-echo hctbuild [-s or -b] [-alldef] [-analyze] [-official] [-fv] [-fvloc <path>] [-rel] [-arm or -arm64 or -x86 or -x64] [-Release] [-Debug] [-vs2015] [-ninja] [-tblgen path] [-dont-speak] [-no-parallel] [-no-dxilconv]
+echo hctbuild [-s or -b] [-alldef] [-analyze] [-official] [-fv] [-fvloc <path>] [-rel] [-arm or -arm64 or -x86 or -x64] [-Release] [-Debug] [-vs2017] [-vs2019] [-ninja] [-tblgen path] [-dont-speak] [-no-parallel] [-no-dxilconv]
 echo.
 echo   -s   creates the projects only, without building
 echo   -b   builds the existing project
@@ -341,6 +335,8 @@ echo   -rel           builds release rather than debug
 echo   -dont-speak    disables audible build confirmation
 echo   -no-parallel   disables parallel build
 echo   -no-dxilconv   disables build of DXBC to DXIL converter and tools
+echo   -vs2017        uses Visual Studio 2017 to build
+echo   -vs2019        uses Visual Studio 2019 to build
 echo.
 echo current BUILD_ARCH=%BUILD_ARCH%.  Override with:
 echo   -x86 targets an x86 build (aka. Win32)
@@ -354,7 +350,6 @@ echo.
 echo AppVeyor Support
 echo   -Release builds release
 echo   -Debug builds debug
-echo   -vs2015 uses Visual Studio 2015 to build; ARM64 not supported 
 echo.
 echo ARM build support
 echo   -tblgen sets path to x86 or x64 versions of clang-tblgen and llvm-tblgen tools
@@ -420,17 +415,6 @@ if "%DO_BUILD%" neq "1" (
   exit /b 0
 )
 
-rem Should add support for the non-x86-qualified programfiles.
-echo Building solution files for %2 with %1 configuration.
-if "%BUILD_GENERATOR%" NEQ "Ninja" (
-  if "%BUILD_VS_VER%"=="2015" (
-    if exist "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" (
-      call :buildvs_x86dir %1 %2 %3
-      goto :donebuild
-    )
-  )
-)
-
 rem Just defer to cmake for now.
 cmake --build . --config %1 -- %PARALLEL_OPT%
 goto :donebuild
@@ -440,23 +424,6 @@ if errorlevel 1 (
   echo Failed to build projects.
   echo After fixing, run 'cmake --build --config %1 .' in %2
   call :handlefail
-  exit /b 1
-)
-endlocal
-exit /b 0
-
-
-:buildvs_x86dir
-rem Build with the VS tools in the x86 program files directory, maxcpucount makes this goes much faster.
-rem 1 - config
-rem 2 - platform
-rem 3 - build directory
-setlocal
-call "%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %BUILD_TOOLS%
-rem Add /ds for a detailed summary at the end.
-echo Logging to %3\msbuild-log.txt
-MSBuild.exe /nologo /property:Configuration=%1 /property:Platform=%2 /maxcpucount:2 %3\LLVM.sln /consoleloggerparameters:Summary;Verbosity=minimal /fileloggerparameters:LogFile=%3\msbuild-log.txt
-if NOT "%ERRORLEVEL%"=="0" (
   exit /b 1
 )
 endlocal

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -182,16 +182,16 @@ if "%1"=="-dxc-cmake-ends-include" (
 rem If only VS 2019 is available, pick that by default.
 if "%BUILD_VS_VER%"=="2017" (
   if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017" (
-    echo Cannot find Visual Studio 2017 at %ProgramFiles(x86)%\Microsoft Visual Studio\2017.
-    echo Use hctbuild without -vs2017 (or with -vs2019) to build with Visual Studio 2019.
+    echo "Cannot find Visual Studio 2017 at %ProgramFiles(x86)%\Microsoft Visual Studio\2017."
+    echo "Use hctbuild without -vs2017 (or with -vs2019) to build with Visual Studio 2019."
     exit /b 1
   )
 )
 
 if "%BUILD_VS_VER%"=="2019" (
   if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019" (
-    echo Cannot find Visual Studio 2019 at %ProgramFiles(x86)%\Microsoft Visual Studio\2019.
-    echo Use hctbuild -vs2017 to build with Visual Studio 2017.
+    echo "Cannot find Visual Studio 2019 at %ProgramFiles(x86)%\Microsoft Visual Studio\2019."
+    echo "Use hctbuild -vs2017 to build with Visual Studio 2017."
     exit /b 1
   )
 )

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -188,6 +188,13 @@ if "%BUILD_VS_VER%"=="2017" (
   )
 )
 
+if "%BUILD_VS_VER%"=="2019" (
+  if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019" (
+    echo Visual Studio 2019 not available. Use hctbuild -vs2017 to build with Visual Studio 2017.
+    exit /b 1
+  )
+)
+
 rem Begin SPIRV change
 if "%1"=="-spirv" (
   echo SPIR-V codegen is enabled.

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -182,15 +182,16 @@ if "%1"=="-dxc-cmake-ends-include" (
 rem If only VS 2019 is available, pick that by default.
 if "%BUILD_VS_VER%"=="2017" (
   if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017" (
-    echo Visual Studio 2017 not available, setting up build for Visual Studio 2019.
-    set BUILD_GENERATOR=Visual Studio 16 2019
-    set BUILD_VS_VER=2019
+    echo Cannot find Visual Studio 2017 at %ProgramFiles(x86)%\Microsoft Visual Studio\2017.
+    echo Use hctbuild without -vs2017 (or with -vs2019) to build with Visual Studio 2019.
+    exit /b 1
   )
 )
 
 if "%BUILD_VS_VER%"=="2019" (
   if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019" (
-    echo Visual Studio 2019 not available. Use hctbuild -vs2017 to build with Visual Studio 2017.
+    echo Cannot find Visual Studio 2019 at %ProgramFiles(x86)%\Microsoft Visual Studio\2019.
+    echo Use hctbuild -vs2017 to build with Visual Studio 2017.
     exit /b 1
   )
 )

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -187,7 +187,6 @@ if "%BUILD_VS_VER%"=="2017" (
     exit /b 1
   )
 )
-
 if "%BUILD_VS_VER%"=="2019" (
   if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019" (
     echo "Cannot find Visual Studio 2019 at %ProgramFiles(x86)%\Microsoft Visual Studio\2019."

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 
 if "%1"=="/?" goto :showhelp
 if "%1"=="-?" goto :showhelp
@@ -83,11 +84,6 @@ if errorlevel 1 (
   call :findcmake
 )
 
-call :checkcmake
-if errorlevel 1 (
-  echo WARNING: cmake version is not supported. Your build may fail.
-)
-
 where python.exe 1>nul 2>nul
 if errorlevel 1 (
   call :findpython
@@ -103,6 +99,7 @@ if errorlevel 1 (
   call :findgit
 )
 
+endlocal
 pushd %HLSL_SRC_DIR%
 
 goto :eof
@@ -119,20 +116,14 @@ echo.
 goto :eof
 
 :findcmake 
-call :ifexistaddpath "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-if "%ERRORLEVEL%"=="0" (
-  echo Path adjusted to include cmake from Visual Studio 2017 Community
-  exit /b 0
-)
-call :ifexistaddpath "C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-if "%ERRORLEVEL%"=="0" (
-  echo Path adjusted to include cmake from Visual Studio 2017 Professional
-  exit /b 0
-)
-call :ifexistaddpath "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-if "%ERRORLEVEL%"=="0" (
-  echo Path adjusted to include cmake from Visual Studio 2017 Enterprise
-  exit /b 0
+for %%v in (2019 2017) do (
+  for %%e in (Community Professional Enterprise) do (
+    call :ifexistaddpath "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+    if "!ERRORLEVEL!"=="0" (
+      echo Path adjusted to include cmake from Visual Studio %%v %%e
+      exit /b 0
+    )
+  )
 )
 if errorlevel 1 if exist "%programfiles%\CMake\bin" set path=%path%;%programfiles%\CMake\bin
 if errorlevel 1 if exist "%programfiles(x86)%\CMake\bin" set path=%path%;%programfiles(x86)%\CMake\bin
@@ -167,8 +158,8 @@ if exist %1 exit /b 0
 exit /b 1
 
 :findgit 
-if exist "C:\Program Files (x86)\Git\cmd\git.exe" set path=%path%;C:\Program Files (x86)\Git\cmd
-if exist "C:\Program Files\Git\cmd\git.exe" set path=%path%;C:\Program Files\Git\cmd
+if exist "%programfiles(x86)%\Git\cmd\git.exe" set path=%path%;%programfiles(x86)%\Git\cmd
+if exist "%programfiles%\Git\cmd\git.exe" set path=%path%;%programfiles%\Git\cmd
 if exist "%LOCALAPPDATA%\Programs\Git\cmd\git.exe" set path=%path%;%LOCALAPPDATA%\Programs\Git\cmd
 where git 1>nul 2>nul
 if errorlevel 1 (
@@ -247,19 +238,4 @@ if ""=="%d3d12_sdk_ver%" (
 endlocal
 goto :eof
 
-:checkcmake 
-cmake --version | findstr 3.4.3 1>nul 2>nul
-if "0"=="%ERRORLEVEL%" exit /b 0
-cmake --version | findstr 3.7.2 1>nul 2>nul
-if "0"=="%ERRORLEVEL%" exit /b 0
-cmake --version | findstr 3.9.0-MSVC 1>nul 2>nul
-if "0"=="%ERRORLEVEL%" exit /b 0
-cmake --version | findstr 3.11.2 1>nul 2>nul
-if "0"=="%ERRORLEVEL%" exit /b 0
-cmake --version | findstr /R 3.*MSVC 1>nul 2>nul
-if errorlevel 1 (
-  echo CMake 3.4.3, 3.7.2, 3.9.0 or 3.11.2 are the currently supported versions for VS 2015 and VS 2017 - your installed cmake is not supported.
-  echo See README.md at the root for an explanation of dependencies.
-  exit /b 1
-)
-goto :eof
+endlocal

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -1,5 +1,4 @@
 @echo off
-setlocal enabledelayedexpansion
 
 if "%1"=="/?" goto :showhelp
 if "%1"=="-?" goto :showhelp
@@ -99,7 +98,6 @@ if errorlevel 1 (
   call :findgit
 )
 
-endlocal
 pushd %HLSL_SRC_DIR%
 
 goto :eof
@@ -118,9 +116,9 @@ goto :eof
 :findcmake 
 for %%v in (2019 2017) do (
   for %%e in (Community Professional Enterprise) do (
-    call :ifexistaddpath "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-    if "!ERRORLEVEL!"=="0" (
-      echo Path adjusted to include cmake from Visual Studio %%v %%e
+    if exist "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
+      set "PATH=%PATH%;%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+      echo Path adjusted to include cmake from Visual Studio %%v %%e.
       exit /b 0
     )
   )
@@ -150,12 +148,6 @@ if errorlevel 1 (
   exit /b 1
 )
 echo Path adjusted to include TAEF te.exe.
-
-:ifexistaddpath 
-rem If the argument exists, add to PATH and return 0, else 1. Useful to avoid parens in values without setlocal changes.
-if exist %1 set PATH=%PATH%;%~1
-if exist %1 exit /b 0
-exit /b 1
 
 :findgit 
 if exist "%programfiles(x86)%\Git\cmd\git.exe" set path=%path%;%programfiles(x86)%\Git\cmd


### PR DESCRIPTION
This PR is switching the default build of DXC to Visual Studio 2019.
The build script hctbuild.cmd will error when VS2019 is not installed. Use -vs2017 option to build with VS2017.
VS2015 is no longer supported.

Removes cmake version checking from hctstart.cmd
Fixes cmake detection in Visual Studio installations 
Fixes DIA SDK lookup - use CMAKE_GENERATOR to detect VS version used and select the corresponding DIA SDK
Use environment variable instead of c:\Program Files

