### PR TITLE
-print-after-all directly prints to stderr.

### DIFF
--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -696,8 +696,18 @@ void PMTopLevelManager::schedulePass(Pass *P) {
 
   // HLSL Change - begin
   if (PI && !PI->isAnalysis() && this->HLSLPrintAfterAll) {
+    class direct_stderr_stream : public raw_ostream {
+      uint64_t current_pos() const override { return 0; }
+      /// See raw_ostream::write_impl.
+      void write_impl(const char *Ptr, size_t Size) override {
+        fwrite(Ptr, Size, 1, stderr);
+      }
+    };
+
+    static direct_stderr_stream stderr_stream;
+
     Pass *PP = P->createPrinterPass(
-      errs(), std::string("*** IR Dump After ") + P->getPassName() + " (" + PI->getPassArgument() + ") ***");
+      stderr_stream, std::string("*** IR Dump After ") + P->getPassName() + " (" + PI->getPassArgument() + ") ***");
     PP->assignPassManager(activeStack, getTopLevelPassManagerType());
   }
   // HLSL Change - end


### PR DESCRIPTION
Made `-print-after-all` print directly to stderr instead of into the error buffer. This is a hidden debug feature that mainly helps compiler development. When debugging things that crash or fail the compilation, it's helpful to see history of the IR. It's also helpful for large shaders since we don't have to wait for the whole thing to finish to see the output.