### PR TITLE
[spirv] Fix issues of RWByteAddressBuffer in the InitList

### DIFF
--- a/tools/clang/lib/SPIRV/InitListHandler.h
+++ b/tools/clang/lib/SPIRV/InitListHandler.h
@@ -133,8 +133,8 @@ private:
   SpirvInstruction *createInitForStructType(QualType type, SourceLocation);
   SpirvInstruction *createInitForConstantArrayType(QualType type,
                                                    SourceLocation);
-  SpirvInstruction *createInitForSamplerImageType(QualType type,
-                                                  SourceLocation);
+  SpirvInstruction *createInitForBufferOrImageType(QualType type,
+                                                   SourceLocation);
 
 private:
   const ASTContext &astContext;

--- a/tools/clang/test/CodeGenSPIRV/initializelist.rwbyteaddressbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/initializelist.rwbyteaddressbuffer.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T cs_6_0 -E main
+RWBuffer<int> buffer1 : register(u1);
+RWByteAddressBuffer buffer2 : register(u2);
+
+// CHECK: [[Resource:%\w+]] = OpTypeStruct %type_RWByteAddressBuffer %uint
+struct Resource {
+  RWByteAddressBuffer rwbuffer;
+  uint offset;
+};
+
+[numthreads(8, 1, 1)]
+void main(uint globalId : SV_DispatchThreadID,
+          uint localId  : SV_GroupThreadID,
+          uint groupId  : SV_GroupID) {
+// CHECK: [[buffer2:%\w+]] = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
+  Resource resourceInfo2 = {buffer2, 2};
+// CHECK: OpCompositeConstruct [[Resource]] [[buffer2]] %uint_2
+  buffer1[0] = resourceInfo2.rwbuffer.Load(0);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -983,6 +983,11 @@ TEST_F(FileTest, RWByteAddressBufferAtomicMethods) {
   runFileTest("method.rw-byte-address-buffer.atomic.hlsl");
 }
 
+TEST_F(FileTest, InitializeListRWByteAddressBuffer) {
+  runFileTest("initializelist.rwbyteaddressbuffer.hlsl", Expect::Success,
+              /* runValidation */ false);
+}
+
 // For Buffer/RWBuffer methods
 TEST_F(FileTest, BufferLoad) { runFileTest("method.buffer.load.hlsl"); }
 TEST_F(FileTest, BufferGetDimensions) {


### PR DESCRIPTION
RWByteAddressBuffer object in the initList should be handled like
OpaqueType RWBuffer or Texture2D.