### PR TITLE
Remove VS checks that assume Visual Studio is installed on C: drive

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -179,22 +179,6 @@ if "%1"=="-dxc-cmake-ends-include" (
   shift /1
 )
 
-rem If only VS 2019 is available, pick that by default.
-if "%BUILD_VS_VER%"=="2017" (
-  if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017" (
-    echo "Cannot find Visual Studio 2017 at %ProgramFiles(x86)%\Microsoft Visual Studio\2017."
-    echo "Use hctbuild without -vs2017 (or with -vs2019) to build with Visual Studio 2019."
-    exit /b 1
-  )
-)
-if "%BUILD_VS_VER%"=="2019" (
-  if not exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019" (
-    echo "Cannot find Visual Studio 2019 at %ProgramFiles(x86)%\Microsoft Visual Studio\2019."
-    echo "Use hctbuild -vs2017 to build with Visual Studio 2017."
-    exit /b 1
-  )
-)
-
 rem Begin SPIRV change
 if "%1"=="-spirv" (
   echo SPIR-V codegen is enabled.


### PR DESCRIPTION
These checks were there only to provide a nice error message when VS 2019 is not installed but it does not take into account that it can be installed at other locations than the default one. Removing these will still result in an error from cmake if it can't find Visual Studio installed.

Fixes #3151