### PR TITLE
Added an option to disable fold-cond-branch-on-phi in simplifyCFG

### DIFF
--- a/include/llvm/Transforms/IPO/PassManagerBuilder.h
+++ b/include/llvm/Transforms/IPO/PassManagerBuilder.h
@@ -129,6 +129,7 @@ public:
   bool HLSLHighLevel = false; // HLSL Change
   bool HLSLAllowPreserveValues = false; // HLSL Change
   bool HLSLOnlyWarnOnUnrollFail = false; // HLSL Change
+  bool HLSLAllowFoldCondBranchOnPHI = false; // HLSL Change
   hlsl::HLSLExtensionsCodegenHelper *HLSLExtensionsCodeGen = nullptr; // HLSL Change
   bool HLSLResMayAlias = false; // HLSL Change
   unsigned ScanLimit = 0; // HLSL Change

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -337,7 +337,7 @@ FunctionPass *createJumpThreadingPass(int Threshold = -1);
 // simplify terminator instructions, etc...
 //
 FunctionPass *createCFGSimplificationPass(
-    int Threshold = -1, std::function<bool(const Function &)> Ftor = nullptr);
+    int Threshold = -1, std::function<bool(const Function &)> Ftor = nullptr, /* HLSL Change */bool AllowFoldCondBranchOnPHI=false);
 
 //===----------------------------------------------------------------------===//
 //

--- a/include/llvm/Transforms/Utils/Local.h
+++ b/include/llvm/Transforms/Utils/Local.h
@@ -137,7 +137,8 @@ bool EliminateDuplicatePHINodes(BasicBlock *BB);
 /// the basic block that was pointed to.
 ///
 bool SimplifyCFG(BasicBlock *BB, const TargetTransformInfo &TTI,
-                 unsigned BonusInstThreshold, AssumptionCache *AC = nullptr);
+                 unsigned BonusInstThreshold, AssumptionCache *AC = nullptr,
+                 bool AllowFoldCondBranchOnPHI = false); // HLSL Change
 
 /// FlatternCFG - This function is used to flatten a CFG.  For
 /// example, it uses parallel-and and parallel-or mode to collapse

--- a/lib/Transforms/Utils/SimplifyCFG.cpp
+++ b/lib/Transforms/Utils/SimplifyCFG.cpp
@@ -144,7 +144,7 @@ class SimplifyCFGOpt {
 public:
   SimplifyCFGOpt(const TargetTransformInfo &TTI, const DataLayout &DL,
                  unsigned BonusInstThreshold, AssumptionCache *AC, /*HLSL Change */bool AllowFoldCondBranchOnPHI)
-      : TTI(TTI), DL(DL), BonusInstThreshold(BonusInstThreshold), AC(AC), /*HLSL Change*/ AllowFoldCondBranchOnPHI(AllowFoldCondBranchOnPHI) {}
+      : TTI(TTI), DL(DL), BonusInstThreshold(BonusInstThreshold), /*HLSL Change*/ AllowFoldCondBranchOnPHI(AllowFoldCondBranchOnPHI), AC(AC) {}
   bool run(BasicBlock *BB);
 };
 }

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -340,6 +340,10 @@ void EmitAssemblyHelper::CreatePasses() {
                         CodeGenOpts.HLSLOptimizationToggles.count("structurize-loop-exits-for-unroll") &&
                         CodeGenOpts.HLSLOptimizationToggles.find("structurize-loop-exits-for-unroll")->second;
 
+  PMBuilder.HLSLAllowFoldCondBranchOnPHI = // True by default
+                        !CodeGenOpts.HLSLOptimizationToggles.count("fold-cond-branch-on-phi") ||
+                        CodeGenOpts.HLSLOptimizationToggles.find("fold-cond-branch-on-phi")->second;
+
   // HLSL Change - end
 
   PMBuilder.DisableUnitAtATime = !CodeGenOpts.UnitAtATime;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/cfgsimplify/fold-cond-branch-on-phi.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/cfgsimplify/fold-cond-branch-on-phi.hlsl
@@ -1,0 +1,33 @@
+
+RWStructuredBuffer<uint> output : register( u256 );
+cbuffer minimal_cbuffer : register(b256) {
+  float a,b,c,d,e,f,g,h;
+  uint t;
+  uint count;
+}
+
+bool foo() {
+  if (e > a)
+    return true;
+  if (b > 0) {
+    if (d >= h)
+      return true;
+    if (f >= c)
+      return true;
+  }
+  return false;
+}
+
+[numthreads(64, 1, 1)]
+void main(uint i : SV_GroupIndex) {
+  uint idx = 0;
+  uint mask = 0;
+  if (!foo())
+    mask |= uint((t >> 24) & 0x7);
+  if (!(mask & 4))
+    idx |= 1;
+  output[idx] += 1;
+}
+
+
+


### PR DESCRIPTION
This particular transformation in SimplifyCFG often causes unstructured flow. This option allows for it to be disabled when appropriate.