### PR TITLE
Fix a crash in reflection when comparing a container's iterator with another's

### DIFF
--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -2317,11 +2317,19 @@ ID3D12ShaderReflectionConstantBuffer* DxilModuleReflection::_GetConstantBufferBy
     return &g_InvalidSRConstantBuffer;
   }
 
+  size_t index = m_CBs.size();
   auto it = m_CBsByName.find(Name);
-  if (it == m_CBsByName.end())
+  if (it != m_CBsByName.end()) {
+    index = it->second;
+  } else {
     it = m_StructuredBufferCBsByName.find(Name);
-  if (it != m_StructuredBufferCBsByName.end())
-    return m_CBs[it->second].get();
+    if (it != m_StructuredBufferCBsByName.end()) {
+      index = it->second;
+    }
+  }
+  if (index < m_CBs.size()) {
+    return m_CBs[index].get();
+  }
 
   return &g_InvalidSRConstantBuffer;
 }


### PR DESCRIPTION
In the original code, there are chances to compare an iterator from m_CBsByName to m_StructuredBufferCBsByName.end(). It crashes if _ITERATOR_DEBUG_LEVEL is not 0. Fix it by comparing an iterator to the container it's from.