### PR TITLE
Correct GV error message crash

### DIFF
--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -560,8 +560,10 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
   // and add function name to give some information
   if (Loc.isInvalid()) {
     Message += " Use /Zi for source location.";
-    if (auto *DiagClient = dynamic_cast<TextDiagnosticPrinter*>(Diags.getClient()))
-      DiagClient->setPrefix("Function: " + D.getFunction()->getName().str());
+    auto *DiagClient = dynamic_cast<TextDiagnosticPrinter*>(Diags.getClient());
+    auto *func = D.getFunction();
+    if (DiagClient && func)
+      DiagClient->setPrefix("Function: " + func->getName().str());
   }
   Diags.Report(Loc, DiagID).AddString(Message);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/assign_texture_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/assign_texture_error.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_0 %s  | FileCheck %s
+
+// CHECK: error: resource MyTexture could not be allocated
+
+Texture2D Textures[];
+Texture2D MyTexture;
+
+sampler samp : register(s0);
+
+float4 main() : SV_Target
+{
+ MyTexture = Textures[0];
+ return MyTexture.Sample(samp, 0.0);
+}


### PR DESCRIPTION
When reporting a globalvariable associated error message without -Zi,
an attempt is made to report the associated function, but there was no
check to see if that function existed, so it crashed.

Fixes #2989