### PR TITLE
Fix dxilconv crash when initialization fails

### DIFF
--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -58,10 +58,13 @@ IMalloc *DxcGetThreadMallocNoRef() throw() {
 }
 
 void DxcClearThreadMalloc() throw() {
-  DXASSERT(g_ThreadMallocTls != nullptr, "else prior to DxcInitThreadMalloc or after DxcCleanupThreadMalloc");
   IMalloc *pMalloc = DxcGetThreadMallocNoRef();
-  g_ThreadMallocTls->erase();
-  pMalloc->Release();
+  if (g_ThreadMallocTls != nullptr) {
+    g_ThreadMallocTls->erase();
+  }
+  if (pMalloc != nullptr) {
+    pMalloc->Release();
+  }
 }
 
 void DxcSetThreadMallocToDefault() throw() {


### PR DESCRIPTION
When dxilconv initialization fails in InitMaybeFail (for example under memory pressure) the malloc references are null yet  DxcClearThreadMalloc is called expecting non-null references.

Adds nullptr checks to DxcClearThreadMalloc before erasing and releasing the allocators.