### PR TITLE
[spirv] report error for invalid tex2d multiplication

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -5556,6 +5556,8 @@ SpirvInstruction *SpirvEmitter::processBinaryOp(
   } else {
     // Evalute lhs before rhs
     lhsPtr = doExpr(lhs);
+    if (lhsPtr == nullptr)
+      return nullptr;
     lhsVal = loadIfGLValue(lhs, lhsPtr);
     rhsVal = loadIfGLValue(rhs);
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -5556,7 +5556,7 @@ SpirvInstruction *SpirvEmitter::processBinaryOp(
   } else {
     // Evalute lhs before rhs
     lhsPtr = doExpr(lhs);
-    if (lhsPtr == nullptr)
+    if (!lhsPtr)
       return nullptr;
     lhsVal = loadIfGLValue(lhs, lhsPtr);
     rhsVal = loadIfGLValue(rhs);

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.invalid.tex2d.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.invalid.tex2d.hlsl
@@ -1,0 +1,9 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: deprecated tex2D intrinsic function will not be supported
+sampler Sampler;
+
+float4 main(float2 texCoord : TEXCOORD0) : SV_TARGET0
+{
+    return tex2D(Sampler, texCoord) * 1;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -921,6 +921,9 @@ TEST_F(FileTest, TextureArraySampleCmpLevelZero) {
 TEST_F(FileTest, TextureSampleInvalidImplicitLod) {
   runFileTest("texture.sample-invalid-implicit-lod.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, TextureInvalidTex2D) {
+  runFileTest("texture.sample.invalid.tex2d.hlsl", Expect::Failure);
+}
 
 // For structured buffer methods
 TEST_F(FileTest, StructuredBufferLoad) {


### PR DESCRIPTION
Calling tex2D must report an error but the multiplication using it
crashes instead of an error report.

Fixes #3166