### PR TITLE
PIX: Don't attempt to write ray query handles to the debug trace UAV

### DIFF
--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -833,6 +833,18 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
     return;
   }
 
+  if (Inst->getOpcode() == Instruction::OtherOps::Call) {
+    if (Inst->getNumOperands() > 0) {
+      if (auto *asInt =
+              llvm::cast_or_null<llvm::ConstantInt>(Inst->getOperand(0))) {
+        if (asInt->getZExtValue() == (uint64_t)DXIL::OpCode::AllocateRayQuery) {
+          // Ray query handles should not be stored in the debug trace UAV
+          return;
+        }
+      }
+    }
+  }
+
   if (auto *St = llvm::dyn_cast<llvm::StoreInst>(Inst)) {
     addStoreStepDebugEntry(BC, St);
     return;


### PR DESCRIPTION
A simple change to allow PIX to debug shaders with DispatchRay calls. Previously, the instrumentation would attempt to cast the handle to an integer and store the result in the UAV. The nvidia driver, at least, disliked this notion and declared device-removed.