### PR TITLE
[spirv] add DebugScope after compound statement

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -722,6 +722,9 @@ void SpirvEmitter::doStmt(const Stmt *stmt,
       // We are done with processing this compound statement. Remove its lexical
       // block from the stack of lexical scopes.
       spvContext.popDebugLexicalScope(info);
+      if (!spvBuilder.isCurrentBasicBlockTerminated()) {
+        spvBuilder.createDebugScope(spvContext.getCurrentLexicalScope());
+      }
     } else {
       // Iterate over sub-statements
       for (auto *st : compoundStmt->body())

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.scope.after.compound.statement.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.scope.after.compound.statement.hlsl
@@ -1,0 +1,47 @@
+// Run: %dxc -T vs_6_0 -E main -fspv-debug=rich
+
+struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+};
+
+//CHECK: [[fn:%\d+]] = OpExtInst %void [[ext:%\d+]] DebugFunction
+//CHECK: [[bb0:%\d+]] = OpExtInst %void [[ext]] DebugLexicalBlock {{%\d+}} 14 {{\d+}} [[fn]]
+//CHECK: [[bb1:%\d+]] = OpExtInst %void [[ext]] DebugLexicalBlock {{%\d+}} 21 {{\d+}} [[bb0]]
+//CHECK: [[bb2:%\d+]] = OpExtInst %void [[ext]] DebugLexicalBlock {{%\d+}} 27 {{\d+}} [[bb1]]
+//CHECK: [[a:%\d+]] = OpExtInst %void [[ext]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 32 {{\d+}} [[bb2]]
+
+VS_OUTPUT main(float4 pos : POSITION,
+               float4 color : COLOR) {
+//CHECK: OpLabel
+//CHECK: DebugScope [[bb0]]
+  float a = 1.0;
+  float b = 2.0;
+  float c = 3.0;
+  float x = a + b + c;
+  {
+//CHECK:      DebugScope [[bb1]]
+//CHECK-NEXT: OpLine [[file:%\d+]] 24
+    float a = 3.0;
+    float b = 4.0;
+    x += a + b + c;
+    {
+//CHECK:      DebugScope [[bb2]]
+//CHECK-NEXT: OpLine [[file:%\d+]] 32
+//CHECK-NEXT: OpStore [[var_a:%\w+]] %float_6
+//CHECK-NEXT: DebugDeclare [[a]] [[var_a]]
+      float a = 6.0;
+      x += a + b + c;
+    }
+//CHECK:      DebugScope [[bb1]]
+//CHECK-NEXT: OpLine [[file:%\d+]] 37
+    x += a + b + c;
+  }
+//CHECK:      DebugScope [[bb0]]
+//CHECK-NEXT: OpLine [[file:%\d+]] 41
+  x += a + b + c;
+
+  VS_OUTPUT vout;
+  vout.pos = pos;
+  vout.pos.w += x * 0.000001;
+  return vout;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2415,142 +2415,109 @@ TEST_F(FileTest, CompatibilityWithVk1p1) {
 }
 
 // Tests for Rich Debug Information
-// TODO: change |runValidation| parameter back to 'true' once the following bug
-// has been fixed in SPIRV-Tools:
-// https://github.com/KhronosGroup/SPIRV-Tools/issues/3086
-const bool runValidationForRichDebugInfo = true;
 
 TEST_F(FileTest, RichDebugInfoDebugSource) {
-  runFileTest("rich.debug.debugsource.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.debugsource.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoDebugCompilationUnit) {
-  runFileTest("rich.debug.debugcompilationunit.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.debugcompilationunit.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoDebugLexicalBlock) {
-  runFileTest("rich.debug.debuglexicalblock.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.debuglexicalblock.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeBool) {
-  runFileTest("rich.debug.type.bool.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.bool.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeInt) {
-  runFileTest("rich.debug.type.int.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.int.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeFloat) {
-  runFileTest("rich.debug.type.float.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.float.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeVector) {
-  runFileTest("rich.debug.type.vector.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.vector.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeMatrix) {
-  runFileTest("rich.debug.type.matrix.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.matrix.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeArray) {
-  runFileTest("rich.debug.type.array.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.array.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeArrayFromSameType) {
-  runFileTest("rich.debug.type.array-from-same-type.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.array-from-same-type.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeFunction) {
-  runFileTest("rich.debug.type.function.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.function.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeMemberFunction) {
-  runFileTest("rich.debug.type.member.function.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.member.function.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeCompositeBeforeFunction) {
-  runFileTest("rich.debug.type.composite.before.function.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.composite.before.function.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoMemberFunctionParam) {
-  runFileTest("rich.debug.member.function.param.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.member.function.param.hlsl");
 }
 TEST_F(FileTest, DISABLED_RichDebugInfoMemberFunctionWithoutCall) {
-  runFileTest("rich.debug.member.function.without-call.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.member.function.without-call.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeComposite) {
-  runFileTest("rich.debug.type.composite.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.composite.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeCompositeEmpty) {
-  runFileTest("rich.debug.type.composite.empty.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
+  runFileTest("rich.debug.type.composite.empty.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoLocalVariable) {
+  runFileTest("rich.debug.local-variable.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoGlobalVariable) {
+  runFileTest("rich.debug.global-variable.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoFunction) {
+  runFileTest("rich.debug.function.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoFunctionParent) {
+  runFileTest("rich.debug.function.parent.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoFunctionParam) {
+  runFileTest("rich.debug.function.param.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {
+  runFileTest("rich.debug.debugsource.multiple.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoDeclare) {
+  runFileTest("rich.debug.debugdeclare.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoDeclareWithoutInit) {
+  runFileTest("rich.debug.debugdeclare.without.init.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoScope) {
+  runFileTest("rich.debug.debugscope.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoTypeTexture) {
+  runFileTest("rich.debug.texture.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoTypeRWTexture) {
+  runFileTest("rich.debug.rwtexture.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoTypeSampler) {
+  runFileTest("rich.debug.sampler.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoCbuffer) {
+  runFileTest("rich.debug.cbuffer.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoSortTypeTemplate) {
+  runFileTest("rich.debug.sort.type.template.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoSwitchDebugScope) {
+  runFileTest("rich.debug.switch.debugscope.hlsl");
+}
+TEST_F(FileTest, RichDebugInfoScopeAfterCompoundStatement) {
+  runFileTest("rich.debug.scope.after.compound.statement.hlsl");
 }
 TEST_F(FileTest, RichDebugInfoTypeStructuredBuffer) {
   runFileTest("rich.debug.structured-buffer.hlsl", Expect::Success,
               /*runValidation*/ false);
-}
-TEST_F(FileTest, RichDebugInfoLocalVariable) {
-  runFileTest("rich.debug.local-variable.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoGlobalVariable) {
-  runFileTest("rich.debug.global-variable.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoFunction) {
-  runFileTest("rich.debug.function.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoFunctionParent) {
-  runFileTest("rich.debug.function.parent.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoFunctionParam) {
-  runFileTest("rich.debug.function.param.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoDebugSourceMultiple) {
-  runFileTest("rich.debug.debugsource.multiple.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoDeclare) {
-  runFileTest("rich.debug.debugdeclare.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoDeclareWithoutInit) {
-  runFileTest("rich.debug.debugdeclare.without.init.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoScope) {
-  runFileTest("rich.debug.debugscope.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoTypeTexture) {
-  runFileTest("rich.debug.texture.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoTypeRWTexture) {
-  runFileTest("rich.debug.rwtexture.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoTypeSampler) {
-  runFileTest("rich.debug.sampler.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoCbuffer) {
-  runFileTest("rich.debug.cbuffer.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoSortTypeTemplate) {
-  runFileTest("rich.debug.sort.type.template.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
-}
-TEST_F(FileTest, RichDebugInfoSwitchDebugScope) {
-  runFileTest("rich.debug.switch.debugscope.hlsl", Expect::Success,
-              /*runValidation*/ runValidationForRichDebugInfo);
 }
 
 } // namespace


### PR DESCRIPTION
Before/after handling a compound statement i.e., `{ .. }`, we have to
add DebugScope for the lexical scope updates. We added it before
handling a compound statement, but we did not add it after doing it.
This commit adds a DebugScope after handling a compound statement.