### PR TITLE
Fix PIX file-check tests (no product impact)

### DIFF
--- a/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DbgValueToDbgDeclare.hlsl
@@ -1,9 +1,7 @@
-// RUN: %dxc -EFlowControlPS -Tps_6_0 /O3 /Zi %s                                          | %FileCheck %s --check-prefixes=VEC,VEC-BUG 
-// RUN: %dxc -EFlowControlPS -Tps_6_0 /O3 /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s --check-prefixes=VEC,VEC-CHK
-// RUN: %dxc -ESVPosAt1PS    -Tps_6_0 /Od /Zi %s                                          | %FileCheck %s --check-prefixes=NULL,NULL-BUG
-// RUN: %dxc -ESVPosAt1PS    -Tps_6_0 /Od /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s --check-prefixes=NULL,NULL-CHK
-// RUN: %dxc -EGeometryPS    -Tps_6_0 /O3 /Zi %s                                          | %FileCheck %s --check-prefixes=RES,RES-BUG
-// RUN: %dxc -EGeometryPS    -Tps_6_0 /O3 /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s --check-prefixes=RES,RES-CHK
+// RUN: %dxc -EFlowControlPS -Tps_6_0 /O3 /Zi %s                                          | %FileCheck %s -check-prefixes=VEC,VEC-BUG 
+// RUN: %dxc -EFlowControlPS -Tps_6_0 /O3 /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s -check-prefixes=VEC,VEC-CHK
+// RUN: %dxc -EGeometryPS    -Tps_6_0 /O3 /Zi %s                                          | %FileCheck %s -check-prefixes=RES,RES-BUG
+// RUN: %dxc -EGeometryPS    -Tps_6_0 /O3 /Zi %s | %opt -S -dxil-dbg-value-to-dbg-declare | %FileCheck %s -check-prefixes=RES,RES-CHK
 
 // These tests are designed to exercise the dbg.value to dbg.declare conversion
 // pass' handling of known issues with dxcompiler's emission of debug info.
@@ -101,22 +99,8 @@ float4 FlowControlPS(VS_OUTPUT_ENV input) : SV_Target
 
 /***************************************************
  * Test for dxcompiler bug workaround:             *
- * null value in dbg.value                         *
- ***************************************************/
-// NULL-LABEL: entry:
-// NULL-BUG:       @llvm.dbg.value(metadata ![[NUL_MD:[0-9]+]]
-// NULL-BUG:       ![[NUL_MD]] = {}
-// NULL-CHK-NOT:   call {{.*}} @llvm.dbg.value
-float4 SVPosAt1PS(VS_OUTPUT_PosAt1 input) : SV_Target
-{
-    return float4(input.Pos.x / 512.f, input.Pos.y / 512.f, 1.f, 1.f);
-}
-
-/***************************************************
- * Test for dxcompiler bug workaround:             *
  * dx.types.ResRet.f32 in dbg.value                *
  ***************************************************/
-// RES-LABEL: entry:
 // RES:           %[[S:[0-9]+]] = call %dx.types.ResRet.f32 @dx.op.sample.f32
 // RES-BUG:       @llvm.dbg.value(metadata %dx.types.ResRet.f32
 // RES-CHK-DAG:   %[[X:[0-9]+]] = extractvalue %dx.types.ResRet.f32 %[[S]], 0

--- a/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
@@ -16,11 +16,11 @@
 // CHECK: %IncrementForThisInvocation = mul i32 8, %OffsetMultiplicand
 
 // Check the first instruction was instrumented:
-// CHECK: %UAVIncResult = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_DebugUAV_Handle, i32 0, i32 0, i32 undef, i32 undef, i32 %IncrementForThisInvocation)
+// CHECK: %UAVIncResult = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_DebugUAV_Handle, i32 0
 // CHECK: %MaskedForUAVLimit = and i32 %UAVIncResult, 983039
 // CHECK: %MultipliedForInterest = mul i32 %MaskedForUAVLimit, %OffsetMultiplicand
 // CHECK: %AddedForInterest = add i32 %MultipliedForInterest, %OffsetAddend
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest, i32 undef, i32 0, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest
 
 
 [RootSignature("")]

--- a/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
@@ -2,7 +2,7 @@
 
 // Check that flow control constructs don't break the instrumentation.
 
-// CHECK:  %UAVIncResult2 = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_DebugUAV_Handle, i32 0, i32 0, i32 undef, i32 undef, i32 %IncrementForThisInvocation1)
+// CHECK:  %UAVIncResult2 = call i32 @dx.op.atomicBinOp.i32(i32 78, %dx.types.Handle %PIX_DebugUAV_Handle, i32 0
 
 // CHECK:  %MaskedForUAVLimit3 = and i32 %UAVIncResult2, 983039
 
@@ -10,7 +10,7 @@
 
 // CHECK:  %AddedForInterest5 = add i32 %MultipliedForInterest4, %OffsetAddend
 
-// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5, i32 undef
+// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5
 
 
 struct VS_OUTPUT_ENV {


### PR DESCRIPTION
These tests had gone stale while I wasn't looking.
The numeric value of disassembled "undef" arguments appears to be something other than 0 now.
The syntax for multiple prefixes in FileCheck <string> is now -check-prefixes and not --check-prefixes .
No longer need to check value-to-declare pass' workaround for a fixed bug.
