### PR TITLE
PIX: Add an API to retrieve source location from RVA

### DIFF
--- a/include/dxc/dxcpix.h
+++ b/include/dxc/dxcpix.h
@@ -140,7 +140,16 @@ struct __declspec(uuid("eb71f85e-8542-44b5-87da-9d76045a1910"))
   virtual STDMETHODIMP_(DWORD) GetOffsetByIndex(_In_ DWORD Index) = 0;
 };
 
-struct __declspec(uuid("6dd5d45e-a417-4a26-b0ff-bdb7d6dcc63d"))
+struct __declspec(uuid("761c833d-e7b8-4624-80f8-3a3fb4146342"))
+  IDxcPixDxilSourceLocations : public IUnknown
+{
+  virtual STDMETHODIMP_(DWORD) GetCount() = 0;
+  virtual STDMETHODIMP_(DWORD) GetLineNumberByIndex(_In_ DWORD Index) = 0;
+  virtual STDMETHODIMP_(DWORD) GetColumnByIndex(_In_ DWORD Index) = 0;
+  virtual STDMETHODIMP GetFileNameByIndex(_In_ DWORD Index, _Outptr_result_z_ BSTR *Name) = 0;
+};
+
+struct __declspec(uuid("b875638e-108a-4d90-a53a-68d63773cb38"))
 IDxcPixDxilDebugInfo : public IUnknown
 {
   virtual STDMETHODIMP GetLiveVariablesAt(
@@ -164,6 +173,10 @@ IDxcPixDxilDebugInfo : public IUnknown
       _In_ DWORD SourceLine,
       _In_ DWORD SourceColumn,
       _COM_Outptr_ IDxcPixDxilInstructionOffsets** ppOffsets) = 0;
+
+  virtual STDMETHODIMP SourceLocationsFromInstructionOffset(
+      _In_ DWORD InstructionOffset,
+      _COM_Outptr_ IDxcPixDxilSourceLocations**ppSourceLocations) = 0;
 };
 
 struct __declspec(uuid("61b16c95-8799-4ed8-bdb0-3b6c08a141b4"))

--- a/lib/DxilDia/DxcPixDxilDebugInfo.h
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.h
@@ -84,6 +84,10 @@ public:
       _In_ DWORD SourceColumn, 
       _COM_Outptr_ IDxcPixDxilInstructionOffsets **ppOffsets) override;
 
+  STDMETHODIMP  SourceLocationsFromInstructionOffset(
+      _In_ DWORD InstructionOffset,
+      _COM_Outptr_ IDxcPixDxilSourceLocations** ppSourceLocations) override;
+
   llvm::Module *GetModuleRef();
 
   IMalloc *GetMallocNoRef()
@@ -118,4 +122,38 @@ public:
   virtual STDMETHODIMP_(DWORD) GetCount() override;
   virtual STDMETHODIMP_(DWORD) GetOffsetByIndex(_In_ DWORD Index) override;
 };
+
+class DxcPixDxilSourceLocations : public IDxcPixDxilSourceLocations
+{
+private:
+  DXC_MICROCOM_TM_REF_FIELDS()
+
+  DxcPixDxilSourceLocations(
+    IMalloc* pMalloc,
+    dxil_dia::Session *pSession,
+    llvm::Instruction* IP);
+
+  struct Location
+  {
+      CComBSTR Filename;
+      DWORD Line;
+      DWORD Column;
+  };
+  std::vector<Location> m_locations;
+
+public:
+  DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_ALLOC(DxcPixDxilSourceLocations)
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+    return DoBasicQueryInterface<IDxcPixDxilSourceLocations>(this, iid, ppvObject);
+  }
+
+  virtual STDMETHODIMP_(DWORD) GetCount() override;
+  virtual STDMETHODIMP_(DWORD) GetLineNumberByIndex(_In_ DWORD Index) override;
+  virtual STDMETHODIMP_(DWORD) GetColumnByIndex(_In_ DWORD Index)override;
+  virtual STDMETHODIMP GetFileNameByIndex(_In_ DWORD Index,
+                                          _Outptr_result_z_ BSTR *Name) override;
+};
+
 }  // namespace dxil_debug_info

--- a/lib/DxilDia/DxcPixEntrypoints.cpp
+++ b/lib/DxilDia/DxcPixEntrypoints.cpp
@@ -728,6 +728,13 @@ struct IDxcPixDxilDebugInfoEntrypoint : public Entrypoint<IDxcPixDxilDebugInfo>
   {
     return InvokeOnReal(&IInterface::InstructionOffsetsFromSourceLocation, CheckNotNull(InParam(FileName)), SourceLine, SourceColumn, CheckNotNull(OutParam(ppOffsets)));
   }
+
+  STDMETHODIMP SourceLocationsFromInstructionOffset(
+      _In_ DWORD InstructionOffset,
+      _COM_Outptr_ IDxcPixDxilSourceLocations** ppSourceLocations) override
+  {
+      return InvokeOnReal(&IInterface::SourceLocationsFromInstructionOffset, InstructionOffset, CheckNotNull(OutParam(ppSourceLocations)));
+  }
 };
 DEFINE_ENTRYPOINT_WRAPPER_TRAIT(IDxcPixDxilDebugInfo);
 
@@ -746,6 +753,31 @@ struct IDxcPixDxilInstructionOffsetsEntrypoint : public Entrypoint<IDxcPixDxilIn
   }
 };
 DEFINE_ENTRYPOINT_WRAPPER_TRAIT(IDxcPixDxilInstructionOffsets);
+
+struct IDxcPixDxilSourceLocationsEntrypoint : public Entrypoint<IDxcPixDxilSourceLocations>
+{
+  DEFINE_ENTRYPOINT_BOILERPLATE(IDxcPixDxilSourceLocationsEntrypoint);
+
+  STDMETHODIMP_(DWORD) GetCount() override
+  {
+      return InvokeOnReal(&IInterface::GetCount);
+  }
+
+  STDMETHODIMP_(DWORD) GetLineNumberByIndex(_In_ DWORD Index) override
+  {
+    return InvokeOnReal(&IInterface::GetLineNumberByIndex, Index);
+  }
+
+  STDMETHODIMP_(DWORD) GetColumnByIndex(_In_ DWORD Index) override
+  {
+    return InvokeOnReal(&IInterface::GetColumnByIndex, Index);
+  }
+  STDMETHODIMP GetFileNameByIndex(_In_ DWORD Index, _Outptr_result_z_ BSTR* Name) override
+  {
+    return InvokeOnReal(&IInterface::GetFileNameByIndex, Index, CheckNotNull(OutParam(Name)));
+  }
+};
+DEFINE_ENTRYPOINT_WRAPPER_TRAIT(IDxcPixDxilSourceLocations);
 
 struct IDxcPixCompilationInfoEntrypoint
     : public Entrypoint<IDxcPixCompilationInfo>


### PR DESCRIPTION
The impetus for this was a recent change that modified how dx.source.contents was filled out.
But, on the plus side, I'd wanted to do this forever so that PIX is pretty much ready to stop using DIA altogether (and we'll be able to delete the DIA implementation from dxcompiler).
Tests exist in the PIX repo (which broke, which is how I noticed this :-) ).