### PR TITLE
Fixed some cases where O0 fails compilation

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -125,4 +125,7 @@ void initializeHLLegalizeParameterPass(llvm::PassRegistry &);
 
 bool AreDxilResourcesDense(llvm::Module *M, hlsl::DxilResourceBase **ppNonDense);
 
+ModulePass *createDxilNoOptLegalizePass();
+void initializeDxilNoOptLegalizePass(llvm::PassRegistry&);
+
 }

--- a/include/dxc/HLSL/DxilNoops.h
+++ b/include/dxc/HLSL/DxilNoops.h
@@ -10,9 +10,15 @@
 
 #include "llvm/ADT/StringRef.h"
 
+namespace llvm {
+  class Instruction;
+}
+
 namespace hlsl {
 static const llvm::StringRef kNoopName = "dx.noop";
 static const llvm::StringRef kPreservePrefix = "dx.preserve.";
 static const llvm::StringRef kNothingName = "dx.nothing.a";
 static const llvm::StringRef kPreserveName = "dx.preserve.value.a";
+
+bool IsPreserve(llvm::Instruction *S);
 }

--- a/include/llvm/Analysis/DxilSimplify.h
+++ b/include/llvm/Analysis/DxilSimplify.h
@@ -34,15 +34,8 @@ namespace hlsl {
 /// If this call could not be simplified returns null.
 llvm::Value *SimplifyDxilCall(llvm::Function *F,
                               llvm::ArrayRef<llvm::Value *> Args,
-                              const llvm::Instruction *I);
-
-/// \brief Given a function and set of arguments, see if we can fold the
-/// result as dxil operation. Inserts instructions if necessary.
-///
-/// If this call could not be simplified returns null.
-llvm::Value *SimplifyDxilCallMayInsert(llvm::Function *F,
-                              llvm::ArrayRef<llvm::Value *> Args,
-                              llvm::Instruction *I);
+                              llvm::Instruction *I,
+                              bool MayInsert);
 
 /// CanSimplify
 /// Return true on dxil operation function which can be simplified.

--- a/include/llvm/Analysis/DxilSimplify.h
+++ b/include/llvm/Analysis/DxilSimplify.h
@@ -33,7 +33,8 @@ namespace hlsl {
 /// If this call could not be simplified returns null.
 llvm::Value *SimplifyDxilCall(llvm::Function *F,
                               llvm::ArrayRef<llvm::Value *> Args,
-                              llvm::Instruction *I);
+                              const llvm::Instruction *I,
+                              llvm::Instruction *MutableI); // If you don't want the IR to be modified, this should be given nullptr
 
 /// CanSimplify
 /// Return true on dxil operation function which can be simplified.

--- a/include/llvm/Analysis/DxilSimplify.h
+++ b/include/llvm/Analysis/DxilSimplify.h
@@ -27,14 +27,22 @@ class Value;
 } // namespace llvm
 
 namespace hlsl {
+
 /// \brief Given a function and set of arguments, see if we can fold the
 /// result as dxil operation.
 ///
 /// If this call could not be simplified returns null.
 llvm::Value *SimplifyDxilCall(llvm::Function *F,
                               llvm::ArrayRef<llvm::Value *> Args,
-                              const llvm::Instruction *I,
-                              llvm::Instruction *MutableI); // If you don't want the IR to be modified, this should be given nullptr
+                              const llvm::Instruction *I);
+
+/// \brief Given a function and set of arguments, see if we can fold the
+/// result as dxil operation. Inserts instructions if necessary.
+///
+/// If this call could not be simplified returns null.
+llvm::Value *SimplifyDxilCallMayInsert(llvm::Function *F,
+                              llvm::ArrayRef<llvm::Value *> Args,
+                              llvm::Instruction *I);
 
 /// CanSimplify
 /// Return true on dxil operation function which can be simplified.

--- a/lib/Analysis/DxilSimplify.cpp
+++ b/lib/Analysis/DxilSimplify.cpp
@@ -49,6 +49,9 @@ bool CanSimplify(const llvm::Function *F) {
     return false;
   }
 
+  if (CanConstantFoldCallTo(F))
+    return true;
+
   // Lookup opcode class in dxil module. Set default value to invalid class.
   OP::OpCodeClass opClass = OP::OpCodeClass::NumOpClasses;
   const bool found =
@@ -72,7 +75,9 @@ bool CanSimplify(const llvm::Function *F) {
 ///
 /// If this call could not be simplified returns null.
 Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
-                        llvm::Instruction *I) {
+                        const llvm::Instruction *I,
+                        llvm::Instruction *MutableI)
+{
   if (!F->getParent()->HasDxilModule()) {
     assert(!OP::IsDxilOpFunc(F) && "dx.op function with no dxil module?");
     return nullptr;
@@ -124,21 +129,23 @@ Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
     if (op1 == zero)
       return op2;
 
-    Constant *one = ConstantFP::get(op0->getType(), 1);
-    if (op0 == one) {
-      IRBuilder<> Builder(I);
-      llvm::FastMathFlags FMF;
-      FMF.setUnsafeAlgebraHLSL();
-      Builder.SetFastMathFlags(FMF);
-      return Builder.CreateFAdd(op1, op2);
-    }
-    if (op1 == one) {
-      IRBuilder<> Builder(I);
-      llvm::FastMathFlags FMF;
-      FMF.setUnsafeAlgebraHLSL();
-      Builder.SetFastMathFlags(FMF);
+    if (MutableI) {
+      Constant *one = ConstantFP::get(op0->getType(), 1);
+      if (op0 == one) {
+        IRBuilder<> Builder(MutableI);
+        llvm::FastMathFlags FMF;
+        FMF.setUnsafeAlgebraHLSL();
+        Builder.SetFastMathFlags(FMF);
+        return Builder.CreateFAdd(op1, op2);
+      }
+      if (op1 == one) {
+        IRBuilder<> Builder(MutableI);
+        llvm::FastMathFlags FMF;
+        FMF.setUnsafeAlgebraHLSL();
+        Builder.SetFastMathFlags(FMF);
 
-      return Builder.CreateFAdd(op0, op2);
+        return Builder.CreateFAdd(op0, op2);
+      }
     }
     return nullptr;
   } break;
@@ -153,14 +160,16 @@ Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
     if (op1 == zero)
       return op2;
 
-    Constant *one = ConstantInt::get(op0->getType(), 1);
-    if (op0 == one) {
-      IRBuilder<> Builder(I);
-      return Builder.CreateAdd(op1, op2);
-    }
-    if (op1 == one) {
-      IRBuilder<> Builder(I);
-      return Builder.CreateAdd(op0, op2);
+    if (MutableI) {
+      Constant *one = ConstantInt::get(op0->getType(), 1);
+      if (op0 == one) {
+        IRBuilder<> Builder(MutableI);
+        return Builder.CreateAdd(op1, op2);
+      }
+      if (op1 == one) {
+        IRBuilder<> Builder(MutableI);
+        return Builder.CreateAdd(op0, op2);
+      }
     }
     return nullptr;
   } break;

--- a/lib/Analysis/DxilSimplify.cpp
+++ b/lib/Analysis/DxilSimplify.cpp
@@ -39,44 +39,10 @@ DXIL::OpCode GetOpcode(Value *opArg) {
   }
   return DXIL::OpCode::NumOpCodes;
 }
-} // namespace
 
-namespace hlsl {
-bool CanSimplify(const llvm::Function *F) {
-  // Only simplify dxil functions when we have a valid dxil module.
-  if (!F->getParent()->HasDxilModule()) {
-    assert(!OP::IsDxilOpFunc(F) && "dx.op function with no dxil module?");
-    return false;
-  }
-
-  if (CanConstantFoldCallTo(F))
-    return true;
-
-  // Lookup opcode class in dxil module. Set default value to invalid class.
-  OP::OpCodeClass opClass = OP::OpCodeClass::NumOpClasses;
-  const bool found =
-      F->getParent()->GetDxilModule().GetOP()->GetOpCodeClass(F, opClass);
-
-  // Return true for those dxil operation classes we can simplify.
-  if (found) {
-    switch (opClass) {
-    default:
-      break;
-    case OP::OpCodeClass::Tertiary:
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/// \brief Given a function and set of arguments, see if we can fold the
-/// result as dxil operation.
-///
-/// If this call could not be simplified returns null.
-Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
+Value *SimplifyDxilCallImpl(llvm::Function *F, ArrayRef<Value *> Args,
                         const llvm::Instruction *I,
-                        llvm::Instruction *MutableI)
+                        llvm::Instruction *InsertPt)
 {
   if (!F->getParent()->HasDxilModule()) {
     assert(!OP::IsDxilOpFunc(F) && "dx.op function with no dxil module?");
@@ -129,17 +95,17 @@ Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
     if (op1 == zero)
       return op2;
 
-    if (MutableI) {
+    if (InsertPt) {
       Constant *one = ConstantFP::get(op0->getType(), 1);
       if (op0 == one) {
-        IRBuilder<> Builder(MutableI);
+        IRBuilder<> Builder(InsertPt);
         llvm::FastMathFlags FMF;
         FMF.setUnsafeAlgebraHLSL();
         Builder.SetFastMathFlags(FMF);
         return Builder.CreateFAdd(op1, op2);
       }
       if (op1 == one) {
-        IRBuilder<> Builder(MutableI);
+        IRBuilder<> Builder(InsertPt);
         llvm::FastMathFlags FMF;
         FMF.setUnsafeAlgebraHLSL();
         Builder.SetFastMathFlags(FMF);
@@ -160,20 +126,71 @@ Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
     if (op1 == zero)
       return op2;
 
-    if (MutableI) {
+    if (InsertPt) {
       Constant *one = ConstantInt::get(op0->getType(), 1);
       if (op0 == one) {
-        IRBuilder<> Builder(MutableI);
+        IRBuilder<> Builder(InsertPt);
         return Builder.CreateAdd(op1, op2);
       }
       if (op1 == one) {
-        IRBuilder<> Builder(MutableI);
+        IRBuilder<> Builder(InsertPt);
         return Builder.CreateAdd(op0, op2);
       }
     }
     return nullptr;
   } break;
   }
+}
+
+} // namespace
+
+namespace hlsl {
+bool CanSimplify(const llvm::Function *F) {
+  // Only simplify dxil functions when we have a valid dxil module.
+  if (!F->getParent()->HasDxilModule()) {
+    assert(!OP::IsDxilOpFunc(F) && "dx.op function with no dxil module?");
+    return false;
+  }
+
+  if (CanConstantFoldCallTo(F))
+    return true;
+
+  // Lookup opcode class in dxil module. Set default value to invalid class.
+  OP::OpCodeClass opClass = OP::OpCodeClass::NumOpClasses;
+  const bool found =
+      F->getParent()->GetDxilModule().GetOP()->GetOpCodeClass(F, opClass);
+
+  // Return true for those dxil operation classes we can simplify.
+  if (found) {
+    switch (opClass) {
+    default:
+      break;
+    case OP::OpCodeClass::Tertiary:
+      return true;
+    }
+  }
+
+  return false;
+}
+/// \brief Given a function and set of arguments, see if we can fold the
+/// result as dxil operation. Inserts instructions if necessary.
+///
+/// If this call could not be simplified returns null.
+llvm::Value *SimplifyDxilCallMayInsert(llvm::Function *F,
+                              llvm::ArrayRef<llvm::Value *> Args,
+                              llvm::Instruction *I)
+{
+  return SimplifyDxilCallImpl(F, Args, I, I);
+}
+
+/// \brief Given a function and set of arguments, see if we can fold the
+/// result as dxil operation.
+///
+/// If this call could not be simplified returns null.
+Value *SimplifyDxilCall(llvm::Function *F, ArrayRef<Value *> Args,
+                        const llvm::Instruction *I)
+{
+  return SimplifyDxilCallImpl(F, Args, I, nullptr);
 }
 
 } // namespace hlsl

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -241,7 +241,7 @@ Value *DxilValueCache::SimplifyAndCacheResult(Instruction *I, DominatorTree *DT)
       }
 
       if (hlsl::CanSimplify(Callee)) {
-        Simplified = hlsl::SimplifyDxilCall(Callee, Args, CI);
+        Simplified = hlsl::SimplifyDxilCall(Callee, Args, CI, /* MayInsert */ false);
       }
       else {
         Simplified = llvm::SimplifyCall(Callee, Args, DL, nullptr, DT);

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4406,7 +4406,7 @@ Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
     if (Function *Callee = CS.getCalledFunction()) {
       if (hlsl::CanSimplify(Callee)) {
         SmallVector<Value *, 4> Args(CS.arg_begin(), CS.arg_end());
-        if (Value *DxilResult = hlsl::SimplifyDxilCall(CS.getCalledFunction(), Args, I)) {
+        if (Value *DxilResult = hlsl::SimplifyDxilCall(CS.getCalledFunction(), Args, I, I)) {
           Result = DxilResult;
           break;
         }

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4406,7 +4406,7 @@ Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
     if (Function *Callee = CS.getCalledFunction()) {
       if (hlsl::CanSimplify(Callee)) {
         SmallVector<Value *, 4> Args(CS.arg_begin(), CS.arg_end());
-        if (Value *DxilResult = hlsl::SimplifyDxilCall(CS.getCalledFunction(), Args, I, I)) {
+        if (Value *DxilResult = hlsl::SimplifyDxilCallMayInsert(CS.getCalledFunction(), Args, I)) {
           Result = DxilResult;
           break;
         }

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -4406,7 +4406,7 @@ Value *llvm::SimplifyInstruction(Instruction *I, const DataLayout &DL,
     if (Function *Callee = CS.getCalledFunction()) {
       if (hlsl::CanSimplify(Callee)) {
         SmallVector<Value *, 4> Args(CS.arg_begin(), CS.arg_end());
-        if (Value *DxilResult = hlsl::SimplifyDxilCallMayInsert(CS.getCalledFunction(), Args, I)) {
+        if (Value *DxilResult = hlsl::SimplifyDxilCall(CS.getCalledFunction(), Args, I, /* MayInsert */ true)) {
           Result = DxilResult;
           break;
         }

--- a/lib/HLSL/CMakeLists.txt
+++ b/lib/HLSL/CMakeLists.txt
@@ -54,6 +54,7 @@ add_llvm_library(LLVMHLSL
   HLUtil.cpp
   PauseResumePasses.cpp
   WaveSensitivityAnalysis.cpp
+  DxilNoOptLegalize.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -109,6 +109,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilLoopDeletionPass(Registry);
     initializeDxilLoopUnrollPass(Registry);
     initializeDxilLowerCreateHandleForLibPass(Registry);
+    initializeDxilNoOptLegalizePass(Registry);
     initializeDxilPrecisePropagatePassPass(Registry);
     initializeDxilPreserveAllOutputsPass(Registry);
     initializeDxilPreserveToSelectPass(Registry);

--- a/lib/HLSL/DxilNoOptLegalize.cpp
+++ b/lib/HLSL/DxilNoOptLegalize.cpp
@@ -1,0 +1,85 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxilNoOptLegalize.cpp                                                     //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "llvm/Pass.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Instructions.h"
+#include "dxc/HLSL/DxilGenerationPass.h"
+#include "llvm/IR/Operator.h"
+
+using namespace llvm;
+
+class DxilNoOptLegalize : public ModulePass {
+  SmallVector<Value *, 16> Worklist;
+
+public:
+  static char ID;
+  DxilNoOptLegalize() : ModulePass(ID) {
+    initializeDxilNoOptLegalizePass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnModule(Module &M) override;
+  bool RemoveStoreUndefsForPointer(Value *V);
+  bool RemoveStoreUndefs(Module &M);
+};
+char DxilNoOptLegalize::ID;
+
+bool DxilNoOptLegalize::RemoveStoreUndefsForPointer(Value *Ptr) {
+  bool Changed = false;
+  Worklist.clear();
+  Worklist.push_back(Ptr);
+
+  while (Worklist.size()) {
+    Value *V = Worklist.back();
+    Worklist.pop_back();
+    if (isa<AllocaInst>(V) || isa<GlobalVariable>(V) || isa<GEPOperator>(V)) {
+      for (User *U : V->users())
+        Worklist.push_back(U);
+    }
+    else if (StoreInst *Store = dyn_cast<StoreInst>(V)) {
+      if (isa<UndefValue>(Store->getValueOperand())) {
+        Store->eraseFromParent();
+        Changed = true;
+      }
+    }
+  }
+
+  return Changed;
+}
+
+bool DxilNoOptLegalize::RemoveStoreUndefs(Module &M) {
+  bool Changed = false;
+  for (GlobalVariable &GV : M.globals()) {
+    Changed |= RemoveStoreUndefsForPointer(&GV);
+  }
+  for (Function &F : M) {
+    if (F.empty())
+      continue;
+
+    BasicBlock &Entry = F.getEntryBlock();
+    for (Instruction &I : Entry) {
+      if (isa<AllocaInst>(&I))
+        Changed |= RemoveStoreUndefsForPointer(&I);
+    }
+  }
+  return Changed;
+}
+
+bool DxilNoOptLegalize::runOnModule(Module &M) {
+  bool Changed = false;
+  Changed |= RemoveStoreUndefs(M);
+  return Changed;
+}
+
+ModulePass *llvm::createDxilNoOptLegalizePass() {
+  return new DxilNoOptLegalize();
+}
+
+INITIALIZE_PASS(DxilNoOptLegalize, "dxil-o0-legalize", "DXIL No-Opt Legalize", false, false)
+

--- a/lib/HLSL/DxilNoops.cpp
+++ b/lib/HLSL/DxilNoops.cpp
@@ -229,6 +229,28 @@ static Value *GetOrCreatePreserveCond(Function *F) {
   return B.CreateTrunc(Load, B.getInt1Ty());
 }
 
+bool hlsl::IsPreserve(llvm::Instruction *I) {
+  SelectInst *S = dyn_cast<SelectInst>(I);
+  if (!S)
+    return false;
+
+  TruncInst *Trunc = dyn_cast<TruncInst>(S->getCondition());
+  if (!Trunc)
+    return false;
+
+  LoadInst *Load = dyn_cast<LoadInst>(Trunc->getOperand(0));
+  if (!Load)
+    return false;
+
+  GEPOperator *GEP = dyn_cast<GEPOperator>(Load->getPointerOperand());
+  if (!GEP)
+    return false;
+
+  GlobalVariable *GV = dyn_cast<GlobalVariable>(GEP->getPointerOperand());
+
+  return GV && GV->getLinkage() == GlobalVariable::LinkageTypes::InternalLinkage && GV->getName() == kPreserveName;
+}
+
 
 static Function *GetOrCreatePreserveF(Module *M, Type *Ty) {
   std::string str = hlsl::kPreservePrefix;

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -361,6 +361,7 @@ void PassManagerBuilder::populateModulePassManager(
       MPM.add(createDxilConvergentClearPass());
       MPM.add(createMultiDimArrayToOneDimArrayPass());
       MPM.add(createDxilRemoveDeadBlocksPass());
+      MPM.add(createDxilNoOptLegalizePass());
       MPM.add(createDeadCodeEliminationPass());
       MPM.add(createGlobalDCEPass());
       MPM.add(createDxilLowerCreateHandleForLibPass());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -359,9 +359,10 @@ void PassManagerBuilder::populateModulePassManager(
 
     if (!HLSLHighLevel) {
       MPM.add(createDxilConvergentClearPass());
-      MPM.add(createMultiDimArrayToOneDimArrayPass());
       MPM.add(createDxilRemoveDeadBlocksPass());
       MPM.add(createDxilNoOptLegalizePass());
+      MPM.add(createGlobalOptimizerPass());
+      MPM.add(createMultiDimArrayToOneDimArrayPass());
       MPM.add(createDeadCodeEliminationPass());
       MPM.add(createGlobalDCEPass());
       MPM.add(createDxilLowerCreateHandleForLibPass());

--- a/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
+++ b/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
@@ -148,6 +148,15 @@ static bool EraseDeadBlocks(Function &F, DxilValueCache *DVC) {
   return true;
 }
 
+static bool EraseDeadBlocksIterate(Function &F,DxilValueCache *DVC) {
+  bool Changed = false;
+  while (EraseDeadBlocks(F,DVC)) {
+    Changed = true;
+    DVC->ResetUnknowns();
+  }
+  return Changed;
+}
+
 namespace {
 
 struct DxilRemoveDeadBlocks : public FunctionPass {

--- a/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
+++ b/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
@@ -148,15 +148,6 @@ static bool EraseDeadBlocks(Function &F, DxilValueCache *DVC) {
   return true;
 }
 
-static bool EraseDeadBlocksIterate(Function &F,DxilValueCache *DVC) {
-  bool Changed = false;
-  while (EraseDeadBlocks(F,DVC)) {
-    Changed = true;
-    DVC->ResetUnknowns();
-  }
-  return Changed;
-}
-
 namespace {
 
 struct DxilRemoveDeadBlocks : public FunctionPass {

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_o0_legalize/selects.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_o0_legalize/selects.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// Regression test for selecting on bad resources.
+
+// CHECK: @main
+
+Texture2D t0 : register(t0);
+
+struct Foo {
+  Texture2D a, b;
+};
+
+float4 bar(uint x, int3 off, Foo foo) {
+  return x ? foo.a.Load(off) : foo.b.Load(off);
+}
+
+float4 main(int3 off : OFF) : SV_Target {
+  Foo foo;
+  foo.a = t0;
+  return bar(1, off, foo);
+}
+

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_o0_legalize/store_undef.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_o0_legalize/store_undef.hlsl
@@ -1,0 +1,49 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// Regression test for validation failure in O0 due to
+// storing structure with uninitialized member.
+
+// CHECK: @main
+
+Texture2D t0 : register(t0);
+Texture2D t1 : register(t1);
+
+struct Foo {
+  float a,b,c,d,e,f,g,h,i;
+};
+
+groupshared Foo foos[4];
+
+Foo make_foo(float x, float y, float z) {
+  Foo foo;
+  foo.a = x;
+  foo.b = y;
+  // foo.c is missing
+  foo.d = x;
+  foo.e = y;
+  foo.f = z;
+  foo.g = x;
+  foo.h = y;
+  foo.i = z;
+  return foo;
+}
+
+void foo(float x, float y, float z) {
+ [unroll]
+ for( int i = (4) - 1; i >= 0; --i ) {
+   foos[i] = make_foo( x, y, z );
+  }
+}
+
+float bar(Foo f) {
+  return f.e;
+}
+
+float main(uint3 off : OFF) : SV_Target {
+  foo(1, 2, 0);
+  return bar(foos[3]);
+}
+
+
+
+

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/dxil_ops.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/dxil_ops.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
 
+// Regression test for dxil operations not being evaluated.
+
 // CHECK: @main
 
 Texture2D t0 : register(t0);

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/dxil_ops.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/dxil_ops.hlsl
@@ -1,0 +1,38 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// CHECK: @main
+
+Texture2D t0 : register(t0);
+Texture2D t1 : register(t1);
+
+static const uint global = 1;
+static const uint global2 = 2;
+
+static const uint global3[3] = { 0, 1, 1 };
+
+cbuffer cb {
+  float bar, baz;
+};
+
+Texture2D foo(float x, float y, float z) {
+  int i;
+  i = mad(bar, 0, y); // 0
+  [branch]
+  if (mad(x, y, 0) == 0) { // true
+    i = mad(bar, 0, x); // 1
+  }
+
+  int j = i - 1;
+
+  if (j) {
+    return t0;
+  }
+  else {
+    return t1;
+  }
+}
+
+float main(uint3 off : OFF) : SV_Target {
+  return foo(1, 0, 2).Load(off).x;
+}
+

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/store_only.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/store_only.hlsl
@@ -1,0 +1,40 @@
+// RUN: %dxc %s -T vs_6_0 -Od | FileCheck %s
+
+// CHECK: @main
+
+// Regression test to make sure resources used by stores to unused globals
+// are removed.
+
+struct Foo {
+  float4 member[8];
+};
+
+struct Bar {
+  Texture2D t0;
+};
+
+struct Baz {
+    Foo foo;
+    Bar bar;
+};
+
+Texture2D t0 : register(t0 , space6);
+cbuffer Baz_cbuffer : register(b0 , space6 ) {
+  Foo cb_foo;
+};
+
+Baz CreateBaz() {
+  Baz i;
+  i.foo = cb_foo;
+  i.bar.t0 = t0;
+  return i;
+}
+
+static const Baz g_Baz = CreateBaz();
+
+[RootSignature("")]
+float4 main() : SV_Position {
+  return float4(0,0,0,0);
+}
+
+

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2144,6 +2144,7 @@ class db_dxil(object):
         ])
         add_pass('dxil-erase-dead-region', 'DxilEraseDeadRegion', 'DxilEraseDeadRegion', [])
         add_pass('dxil-remove-dead-blocks', 'DxilRemoveDeadBlocks', 'DxilRemoveDeadBlocks', [])
+        add_pass('dxil-o0-legalize', 'DxilNoOptLegalize', 'DXIL No-Opt Legalize', [])
         add_pass('loop-deletion', 'LoopDeletion', "Delete dead loops", [])
         add_pass('loop-interchange', 'LoopInterchange', 'Interchanges loops for cache reuse', [])
         add_pass('loop-unroll', 'LoopUnroll', 'Unroll loops', [


### PR DESCRIPTION
- Fixed value tracking for dxil intrinsics
- Fixed some selects holding on to invalid resource uses
- Fixed some cases where unused globals hold on to invalid resource uses
- Fixed some cases where stores of undefs stick around