### PR TITLE
[spirv] handle sizeof using Clang's const folding

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11992,7 +11992,7 @@ SpirvEmitter::doUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *expr) {
   AlignmentSizeCalculator alignmentCalc(astContext, spirvOptions);
   uint32_t size = 0, stride = 0;
   std::tie(std::ignore, size) = alignmentCalc.getAlignmentAndSize(
-      expr->getArgumentType(), SpirvLayoutRule::Void,
+      expr->getArgumentType(), SpirvLayoutRule::Scalar,
       /*isRowMajor*/ llvm::None, &stride);
   auto *sizeConst = spvBuilder.getConstantInt(astContext.UnsignedIntTy,
                                               llvm::APInt(32, size));

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11984,6 +11984,11 @@ SpirvEmitter::doUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *expr) {
     return nullptr;
   }
 
+  if (auto *constExpr = tryToEvaluateAsConst(expr)) {
+    constExpr->setRValue();
+    return constExpr;
+  }
+
   AlignmentSizeCalculator alignmentCalc(astContext, spirvOptions);
   uint32_t size = 0, stride = 0;
   std::tie(std::ignore, size) = alignmentCalc.getAlignmentAndSize(

--- a/tools/clang/test/CodeGenSPIRV/op.sizeof.same.for.init.and.return.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.sizeof.same.for.init.and.return.hlsl
@@ -1,0 +1,23 @@
+// Run: %dxc -E main -T cs_6_2
+
+
+struct StructA
+{
+  float3 one;
+  float3 two;
+};
+
+uint foo()
+{
+  return sizeof(StructA);
+}
+
+[numthreads(64, 1, 1)]
+void main()
+{
+  uint a = foo();
+// CHECK: OpStore %b %uint_24
+  uint b = sizeof(StructA);
+}
+// CHECK: %foo = OpFunction
+// CHECK: OpReturnValue %uint_24

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -420,6 +420,9 @@ TEST_F(FileTest, OpTextureSampleAccess) {
   runFileTest("op.texture.sample-access.hlsl");
 }
 TEST_F(FileTest, OpSizeOf) { runFileTest("op.sizeof.hlsl"); }
+TEST_F(FileTest, OpSizeOfSameForInitAndReturn) {
+  runFileTest("op.sizeof.same.for.init.and.return.hlsl");
+}
 
 // For casting
 TEST_F(FileTest, CastNoOp) { runFileTest("cast.no-op.hlsl"); }


### PR DESCRIPTION
```
struct StructA
{
  float3 one;
  float3 two;
};
```

`sizeof(StructA)` must be 24 bytes. `AlignmentSizeCalculator` with a void
memory layout will return 32 bytes for it. We have to use the constant
folding provided by Clang.

Fixes #3198 