### PR TITLE
[spirv] Fix [[vk::push_constant]] on ConstantBuffer

### DIFF
--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -838,8 +838,10 @@ hlsl::DeclareConstantBufferViewType(clang::ASTContext &context, bool bTBuf) {
   // template<typename T> ConstantBuffer { int h; }
   DeclContext *DC = context.getTranslationUnitDecl();
 
-  BuiltinTypeDeclBuilder typeDeclBuilder(DC, bTBuf ? "TextureBuffer"
-                                                   : "ConstantBuffer");
+  BuiltinTypeDeclBuilder typeDeclBuilder(DC,
+                                         bTBuf ? "TextureBuffer"
+                                               : "ConstantBuffer",
+                                         TagDecl::TagKind::TTK_Struct);
   (void)typeDeclBuilder.addTypeTemplateParam("T");
   typeDeclBuilder.startDefinition();
   CXXRecordDecl *templateRecordDecl = typeDeclBuilder.getRecordDecl();

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.constantbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.constantbuffer.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct StructA
+{
+    float3 one;
+    float3 two;
+};
+
+// CHECK: %PushConstants = OpVariable %_ptr_PushConstant_type_PushConstant_ConstantBuffer PushConstant
+[[vk::push_constant]] ConstantBuffer<StructA> PushConstants;
+
+void main()
+{
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1868,6 +1868,10 @@ TEST_F(FileTest, VulkanMultiplePushConstant) {
   runFileTest("vk.push-constant.multiple.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, VulkanPushCOnstantOnConstantBuffer) {
+  runFileTest("vk.push-constant.constantbuffer.hlsl");
+}
+
 TEST_F(FileTest, VulkanSpecConstantInit) {
   runFileTest("vk.spec-constant.init.hlsl");
 }


### PR DESCRIPTION
This commit fix a regression introduced by #3147: when`[[vk::push_constant]]` is apply to a  ConstantBuffer, error shows that `'push_constant' attribute only applies to global variables of struct type`.