### PR TITLE
[spirv] Fix [[vk::push_constant]] on ConstantBuffer part II

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1090,7 +1090,14 @@ SpirvVariable *DeclResultIdMapper::createCTBuffer(const VarDecl *decl) {
 
 SpirvVariable *DeclResultIdMapper::createPushConstant(const VarDecl *decl) {
   // The front-end errors out if non-struct type push constant is used.
-  const auto *recordType = decl->getType()->getAs<RecordType>();
+  const QualType type = decl->getType();
+  const auto *recordType = type->getAs<RecordType>();
+
+  if (isConstantBuffer(type)) {
+    // Get the templated type for ConstantBuffer.
+    recordType = hlsl::GetHLSLResourceResultType(type)->getAs<RecordType>();
+  }
+
   assert(recordType);
 
   const std::string structName =
@@ -1207,9 +1214,9 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
   // definition is seen, the parameter types will be set properly and take into
   // account whether the function is a member function of a class/struct (in
   // which case a 'this' parameter is added at the beginnig).
-  SpirvFunction *spirvFunction = spvBuilder.createSpirvFunction(
-      fn->getReturnType(), fn->getLocation(), fn->getName(), isPrecise,
-      isNoInline);
+  SpirvFunction *spirvFunction =
+      spvBuilder.createSpirvFunction(fn->getReturnType(), fn->getLocation(),
+                                     fn->getName(), isPrecise, isNoInline);
 
   // No need to dereference to get the pointer. Function returns that are
   // stand-alone aliases are already pointers to values. All other cases should
@@ -3629,7 +3636,7 @@ void DeclResultIdMapper::tryToCreateImplicitConstVar(const ValueDecl *decl) {
     return;
 
   APValue *val = varDecl->evaluateValue();
-  if(!val)
+  if (!val)
     return;
 
   SpirvInstruction *constVal =

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.constantbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.constantbuffer.hlsl
@@ -6,7 +6,8 @@ struct StructA
     float3 two;
 };
 
-// CHECK: %PushConstants = OpVariable %_ptr_PushConstant_type_PushConstant_ConstantBuffer PushConstant
+// CHECK: %type_PushConstant_StructA = OpTypeStruct %v3float %v3float
+// CHECK: %PushConstants = OpVariable %_ptr_PushConstant_type_PushConstant_StructA PushConstant
 [[vk::push_constant]] ConstantBuffer<StructA> PushConstants;
 
 void main()

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1871,7 +1871,7 @@ TEST_F(FileTest, VulkanMultiplePushConstant) {
   runFileTest("vk.push-constant.multiple.hlsl", Expect::Failure);
 }
 
-TEST_F(FileTest, VulkanPushCOnstantOnConstantBuffer) {
+TEST_F(FileTest, VulkanPushConstantOnConstantBuffer) {
   runFileTest("vk.push-constant.constantbuffer.hlsl");
 }
 


### PR DESCRIPTION
I wasn't noticing that the last fix #3215 only fixed the error-checking. It was generating an OpTypeStruct without any member.

This commit fixes that push constant should use the templated type of constant buffer to create the struct.