### PR TITLE
[spirv] globallycoherent should generate SPIR-V decoration Coherent

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -78,8 +78,7 @@ public:
   /// At any time, there can only exist at most one function under building.
   SpirvFunction *beginFunction(QualType returnType, SourceLocation,
                                llvm::StringRef name = "",
-                               bool isPrecise = false,
-                               bool isNoInline = false,
+                               bool isPrecise = false, bool isNoInline = false,
                                SpirvFunction *func = nullptr);
 
   /// \brief Creates and registers a function parameter of the given pointer
@@ -611,6 +610,9 @@ public:
   /// \brief Decorates the given target with PerTaskNV
   void decoratePerTaskNV(SpirvInstruction *target, uint32_t offset,
                          SourceLocation);
+
+  /// \brief Decorates the given target with Coherent
+  void decorateCoherent(SpirvInstruction *target, SourceLocation);
 
   /// --- Constants ---
   /// Each of these methods can acquire a unique constant from the SpirvContext,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -115,10 +115,12 @@ public:
               const hlsl::RegisterAssignment *r, const VKBindingAttr *b,
               const VKCounterBindingAttr *cb, bool counter = false,
               bool globalsBuffer = false)
-      : variable(var), srcLoc(loc), reg(r), binding(b), counterBinding(cb),
-        isCounterVar(counter), isGlobalsCBuffer(globalsBuffer) {}
+      : variable(var), declaration(decl), srcLoc(loc), reg(r), binding(b),
+        counterBinding(cb), isCounterVar(counter),
+        isGlobalsCBuffer(globalsBuffer) {}
 
   SpirvVariable *getSpirvInstr() const { return variable; }
+  const Decl *getDeclaration() const { return declaration; }
   SourceLocation getSourceLocation() const { return srcLoc; }
   const hlsl::RegisterAssignment *getRegister() const { return reg; }
   const VKBindingAttr *getBinding() const { return binding; }
@@ -130,6 +132,7 @@ public:
 
 private:
   SpirvVariable *variable;                    ///< The variable
+  const Decl *declaration;                    ///< The declaration
   SourceLocation srcLoc;                      ///< Source location
   const hlsl::RegisterAssignment *reg;        ///< HLSL register assignment
   const VKBindingAttr *binding;               ///< Vulkan binding assignment
@@ -524,6 +527,10 @@ public:
   /// module under construction.
   bool decorateResourceBindings();
 
+  /// \brief Decorates resource variables with Coherent decoration if they
+  /// are declared as globallycoherent.
+  bool decorateResourceCoherent();
+
   /// \brief Returns whether the SPIR-V module requires SPIR-V legalization
   /// passes run to make it legal.
   bool requiresLegalization() const { return needsLegalization; }
@@ -759,7 +766,8 @@ private:
   /// b - for constant buffer views (CBV)
   ///    CBUFFER
   ///    CONSTANTBUFFER
-  bool getImplicitRegisterType(const ResourceVar &var, char *registerTypeOut) const;
+  bool getImplicitRegisterType(const ResourceVar &var,
+                               char *registerTypeOut) const;
 
 private:
   SpirvBuilder &spvBuilder;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -34,8 +34,8 @@ SpirvFunction *SpirvBuilder::createSpirvFunction(QualType returnType,
                                                  llvm::StringRef name,
                                                  bool isPrecise,
                                                  bool isNoInline) {
-  auto *fn = new (context) SpirvFunction(returnType, loc, name, isPrecise,
-                                         isNoInline);
+  auto *fn =
+      new (context) SpirvFunction(returnType, loc, name, isPrecise, isNoInline);
   mod->addFunction(fn);
   return fn;
 }
@@ -43,8 +43,7 @@ SpirvFunction *SpirvBuilder::createSpirvFunction(QualType returnType,
 SpirvFunction *SpirvBuilder::beginFunction(QualType returnType,
                                            SourceLocation loc,
                                            llvm::StringRef funcName,
-                                           bool isPrecise,
-                                           bool isNoInline,
+                                           bool isPrecise, bool isNoInline,
                                            SpirvFunction *func) {
   assert(!function && "found nested function");
   if (func) {
@@ -55,8 +54,8 @@ SpirvFunction *SpirvBuilder::beginFunction(QualType returnType,
     function->setPrecise(isPrecise);
     function->setNoInline(isNoInline);
   } else {
-    function = createSpirvFunction(returnType, loc, funcName, isPrecise,
-                                   isNoInline);
+    function =
+        createSpirvFunction(returnType, loc, funcName, isPrecise, isNoInline);
   }
 
   return function;
@@ -1146,6 +1145,13 @@ void SpirvBuilder::decoratePerTaskNV(SpirvInstruction *target, uint32_t offset,
   mod->addDecoration(decor);
   decor = new (context)
       SpirvDecoration(srcLoc, target, spv::Decoration::Offset, {offset});
+  mod->addDecoration(decor);
+}
+
+void SpirvBuilder::decorateCoherent(SpirvInstruction *target,
+                                    SourceLocation srcLoc) {
+  auto *decor =
+      new (context) SpirvDecoration(srcLoc, target, spv::Decoration::Coherent);
   mod->addDecoration(decor);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -578,6 +578,10 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
   if (!declIdMapper.decorateResourceBindings())
     return;
 
+  // Add Coherent docrations to resource variables.
+  if (!declIdMapper.decorateResourceCoherent())
+    return;
+
   // Output the constructed module.
   std::vector<uint32_t> m = spvBuilder.takeModule();
 
@@ -645,7 +649,7 @@ void SpirvEmitter::doDecl(const Decl *decl) {
   }
 
   if (const auto *varDecl = dyn_cast<VarDecl>(decl)) {
-      doVarDecl(varDecl);
+    doVarDecl(varDecl);
   } else if (const auto *namespaceDecl = dyn_cast<NamespaceDecl>(decl)) {
     for (auto *subDecl : namespaceDecl->decls())
       // Note: We only emit functions as they are discovered through the call
@@ -1207,7 +1211,7 @@ bool SpirvEmitter::validateVKAttributes(const NamedDecl *decl) {
       isValidType = bufDecl->isCBuffer();
     else if ((bufDecl = dyn_cast<HLSLBufferDecl>(decl->getDeclContext())))
       isValidType = bufDecl->isCBuffer();
-    else if(isa<VarDecl>(decl))
+    else if (isa<VarDecl>(decl))
       isValidType = isConstantBuffer(dyn_cast<VarDecl>(decl)->getType());
 
     if (!isValidType) {
@@ -2676,7 +2680,7 @@ SpirvInstruction *SpirvEmitter::processFlatConversion(
   // `-MemberExpr
   //   `-ImplicitCastExpr 'const T' lvalue <FlatConversion>
   //     `-ArraySubscriptExpr 'ConstantBuffer<T>':'ConstantBuffer<T>' lvalue
-  if(isConstantTextureBuffer(initType)) {
+  if (isConstantTextureBuffer(initType)) {
     return initInstr;
   }
 
@@ -8028,8 +8032,8 @@ SpirvInstruction *SpirvEmitter::processWaveBroadcast(const CallExpr *callExpr) {
     // might incorrectly suggest so). The proper mapping to SPIR-V for
     // it is OpGroupNonUniformShuffle, *not* OpGroupNonUniformBroadcast.
     return spvBuilder.createGroupNonUniformBinaryOp(
-        spv::Op::OpGroupNonUniformShuffle, retType, spv::Scope::Subgroup,
-        value, doExpr(callExpr->getArg(1)), srcLoc);
+        spv::Op::OpGroupNonUniformShuffle, retType, spv::Scope::Subgroup, value,
+        doExpr(callExpr->getArg(1)), srcLoc);
   else
     return spvBuilder.createGroupNonUniformUnaryOp(
         srcLoc, spv::Op::OpGroupNonUniformBroadcastFirst, retType,

--- a/tools/clang/test/CodeGenSPIRV/decoration.coherent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.coherent.hlsl
@@ -1,0 +1,22 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct StructA
+{
+    uint one;
+};
+
+// CHECK: OpDecorate %buffer1 Coherent
+globallycoherent RWByteAddressBuffer buffer1;
+
+// CHECK: OpDecorate %buffer2 Coherent
+globallycoherent RWStructuredBuffer<StructA> buffer2;
+
+// CHECK-NOT: OpDecorate %buffer3 Coherent
+RWByteAddressBuffer buffer3;
+
+// CHECK-NOT: OpDecorate %buffer4 Coherent
+RWStructuredBuffer<StructA> buffer4;
+
+void main()
+{
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -55,9 +55,7 @@ TEST_F(FileTest, StructTypes) { runFileTest("type.struct.hlsl"); }
 TEST_F(FileTest, StructTypeUniqueness) {
   runFileTest("type.struct.uniqueness.hlsl");
 }
-TEST_F(FileTest, StringTypes) {
-  runFileTest("type.string.hlsl");
-}
+TEST_F(FileTest, StringTypes) { runFileTest("type.string.hlsl"); }
 TEST_F(FileTest, StringTypesUninitializedError) {
   runFileTest("type.string.uninitialized.hlsl", Expect::Failure);
 }
@@ -2266,6 +2264,10 @@ TEST_F(FileTest, DecorationNoContractionStageVars) {
 // For UserTypeGOOGLE decorations
 TEST_F(FileTest, DecorationUserTypeGOOGLE) {
   runFileTest("decoration.user-type.hlsl");
+}
+
+TEST_F(FileTest, DecorationCoherent) {
+  runFileTest("decoration.coherent.hlsl");
 }
 
 // For pragmas


### PR DESCRIPTION
globallycoherent on resource variables should result in decoration Coherent in generated SPIR-V.