### PR TITLE
[spirv] add location for DebugDeclare

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -482,6 +482,7 @@ public:
 
   SpirvDebugDeclare *createDebugDeclare(
       SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
+      SourceLocation loc = {},
       llvm::Optional<SpirvDebugExpression *> dbgExpr = llvm::None);
 
   SpirvDebugFunction *

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2294,7 +2294,7 @@ private:
 class SpirvDebugDeclare : public SpirvDebugInstruction {
 public:
   SpirvDebugDeclare(SpirvDebugLocalVariable *, SpirvInstruction *,
-                    SpirvDebugExpression *);
+                    SpirvDebugExpression *, SourceLocation loc);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDebugDeclare)
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -701,7 +701,7 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
         type, name, info->source, line, column, info->scopeStack.back(), flags,
         dbgArgNumber);
-    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr);
+    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr, loc);
   }
 
   return fnParamInstr;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -890,12 +890,13 @@ SpirvDebugExpression *SpirvBuilder::getOrCreateNullDebugExpression() {
 }
 
 SpirvDebugDeclare *SpirvBuilder::createDebugDeclare(
-    SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
+    SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var, SourceLocation loc,
     llvm::Optional<SpirvDebugExpression *> dbgExpr) {
   auto *decl = new (context)
       SpirvDebugDeclare(dbgVar, var,
                         dbgExpr.hasValue() ? dbgExpr.getValue()
-                                           : getOrCreateNullDebugExpression());
+                                           : getOrCreateNullDebugExpression(),
+                        loc);
   if (isa<SpirvFunctionParameter>(var)) {
     assert(function && "found detached parameter");
     function->addParameterDebugDeclare(decl);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1074,7 +1074,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
         auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
             valueType, "this", info->source, line, column,
             info->scopeStack.back(), flags, 1);
-        spvBuilder.createDebugDeclare(debugLocalVar, curThis);
+        spvBuilder.createDebugDeclare(debugLocalVar, curThis, loc);
       }
 
       isNonStaticMemberFn = true;
@@ -1417,7 +1417,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
       auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
           decl->getType(), decl->getName(), info->source, line, column,
           info->scopeStack.back(), flags);
-      spvBuilder.createDebugDeclare(debugLocalVar, var);
+      spvBuilder.createDebugDeclare(debugLocalVar, var, loc);
     }
 
     // Variables that are not externally visible and of opaque types should

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -893,9 +893,12 @@ SpirvDebugExpression::SpirvDebugExpression(
 
 SpirvDebugDeclare::SpirvDebugDeclare(SpirvDebugLocalVariable *debugVar_,
                                      SpirvInstruction *var_,
-                                     SpirvDebugExpression *expr)
+                                     SpirvDebugExpression *expr,
+                                     SourceLocation loc)
     : SpirvDebugInstruction(IK_DebugDeclare, /*opcode*/ 28u),
-      debugVar(debugVar_), var(var_), expression(expr) {}
+      debugVar(debugVar_), var(var_), expression(expr) {
+  srcLoc = loc;
+}
 
 SpirvDebugLexicalBlock::SpirvDebugLexicalBlock(SpirvDebugSource *source_,
                                                uint32_t line_, uint32_t column_,

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
@@ -3,22 +3,25 @@
 // TODO: FlagIsPublic is shown as FlagIsProtected|FlagIsPrivate.
 
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK: [[y:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 23 {{%\d+}} FlagIsLocal 2
-// CHECK: [[x:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 14 {{%\d+}} FlagIsLocal 1
-// CHECK: [[condition:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 30 8 {{%\d+}} FlagIsLocal
+// CHECK: [[y:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 26 23 {{%\d+}} FlagIsLocal 2
+// CHECK: [[x:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 26 14 {{%\d+}} FlagIsLocal 1
+// CHECK: [[condition:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 33 8 {{%\d+}} FlagIsLocal
 // CHECK: [[expr:%\d+]] = OpExtInst %void [[set]] DebugExpression
-// CHECK: [[color:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 28 20 {{%\d+}} FlagIsLocal 1
+// CHECK: [[color:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 31 20 {{%\d+}} FlagIsLocal 1
 
 // CHECK:     %color = OpFunctionParameter
 // CHECK:   {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[color]] %color [[expr]]
 // CHECK: %condition = OpVariable
+// CHECK:              OpLine {{%\d+}} 33 8
 // CHECK:              OpStore %condition %false
 // CHECK:   {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[condition]] %condition [[expr]]
 
-// CHECK:       %x = OpFunctionParameter
-// CHECK:       %y = OpFunctionParameter
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[x]] %x [[expr]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[y]] %y [[expr]]
+// CHECK:            %x = OpFunctionParameter
+// CHECK:            %y = OpFunctionParameter
+// CHECK:                 OpLine {{%\d+}} 26 14
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[x]] %x [[expr]]
+// CHECK-NEXT:            OpLine {{%\d+}} 26 23
+// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[y]] %y [[expr]]
 
 void foo(int x, float y)
 {


### PR DESCRIPTION
This commit adds the SourceLocation to SpirvDebugDeclare class that will
result in emitting the OpLine for the declaration (where the declaration
happens). It will help the spirv-opt to preserve the value assignment
location. In particular, it will be useful for simple shaders that
spirv-opt almost strips out all the instructions and keeps only
DebugValue instructions. We can recognize the location of value
assignments based on OpLine.