### PR TITLE
[SPIRV] Add support hlsl export function attribute

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -98,6 +98,14 @@ public:
   /// Returns true if the given extension is set in allowedExtensions
   bool isExtensionEnabled(Extension);
 
+  /// Returns true if the target environment is Vulkan 1.1 or above.
+  /// Returns false otherwise.
+  bool isTargetEnvVulkan1p1OrAbove();
+
+  /// Returns true if the target environment is Vulkan 1.2 or above.
+  /// Returns false otherwise.
+  bool isTargetEnvVulkan1p2OrAbove();
+
 private:
   /// Returns whether codegen should allow usage of this extension by default.
   bool enabledByDefault(Extension);
@@ -124,6 +132,7 @@ private:
 
   llvm::SmallBitVector allowedExtensions;
   spv_target_env targetEnv;
+  std::string targetEnvStr;
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -601,5 +601,17 @@ bool CapabilityVisitor::visit(SpirvDemoteToHelperInvocationEXT *inst) {
   return true;
 }
 
+bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
+  // If there are no entry-points in the module (hence shaderModel is not set),
+  // add the Linkage capability. This allows library shader models to use
+  // 'export' attribute on functions, and generate an "incomplete/partial"
+  // SPIR-V binary.
+  if (phase == Visitor::Phase::Done &&
+      shaderModel == spv::ExecutionModel::Max) {
+    addCapability(spv::Capability::Linkage, SourceLocation());
+  }
+  return true;
+}
+
 } // end namespace spirv
 } // end namespace clang

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -201,8 +201,10 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
       addCapability(spv::Capability::RayTracingNV);
       addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
     } else {
-      // KHR_ray_tracing extension requires SPIR-V 1.4/Vulkan 1.2
-      featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_2, "Raytracing", {});
+      // KHR_ray_tracing extension requires Vulkan 1.1 with VK_KHR_spirv_1_4
+      // extention or Vulkan 1.2.
+      featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1_SPIRV_1_4,
+                                      "Raytracing", {});
       addCapability(spv::Capability::RayTracingKHR);
       addExtension(Extension::KHR_ray_tracing, "SPV_KHR_ray_tracing", {});
     }
@@ -538,8 +540,10 @@ bool CapabilityVisitor::visit(SpirvEntryPoint *entryPoint) {
       addCapability(spv::Capability::RayTracingNV);
       addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
     } else {
-      // KHR_ray_tracing extension requires SPIR-V 1.4/Vulkan 1.2
-      featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_2, "Raytracing", {});
+      // KHR_ray_tracing extension requires Vulkan 1.1 with VK_KHR_spirv_1_4
+      // extention or Vulkan 1.2.
+      featureManager.requestTargetEnv(SPV_ENV_VULKAN_1_1_SPIRV_1_4,
+                                      "Raytracing", {});
       addCapability(spv::Capability::RayTracingKHR);
       addExtension(Extension::KHR_ray_tracing, "SPV_KHR_ray_tracing", {});
     }
@@ -608,6 +612,7 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
   // SPIR-V binary.
   if (phase == Visitor::Phase::Done &&
       shaderModel == spv::ExecutionModel::Max) {
+    addCapability(spv::Capability::Shader);
     addCapability(spv::Capability::Linkage, SourceLocation());
   }
   return true;

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -610,10 +610,12 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
   // add the Linkage capability. This allows library shader models to use
   // 'export' attribute on functions, and generate an "incomplete/partial"
   // SPIR-V binary.
+  // ExecutionModel::Max means that no entrypoints exist, therefore we should
+  // add the Linkage Capability.
   if (phase == Visitor::Phase::Done &&
       shaderModel == spv::ExecutionModel::Max) {
     addCapability(spv::Capability::Shader);
-    addCapability(spv::Capability::Linkage, SourceLocation());
+    addCapability(spv::Capability::Linkage);
   }
   return true;
 }

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.h
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.h
@@ -24,7 +24,10 @@ public:
   CapabilityVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
                     const SpirvCodeGenOptions &opts, SpirvBuilder &builder)
       : Visitor(opts, spvCtx), spvBuilder(builder),
+        shaderModel(spv::ExecutionModel::Max),
         featureManager(astCtx.getDiagnostics(), opts) {}
+
+  bool visit(SpirvModule *, Phase) override;
 
   bool visit(SpirvDecoration *decor) override;
   bool visit(SpirvEntryPoint *) override;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2910,6 +2910,9 @@ SpirvVariable *DeclResultIdMapper::getBuiltinVar(spv::BuiltIn builtIn,
   case spv::BuiltIn::WorldToObjectNV:
   case spv::BuiltIn::LaunchIdNV:
   case spv::BuiltIn::LaunchSizeNV:
+  case spv::BuiltIn::GlobalInvocationId:
+  case spv::BuiltIn::WorkgroupId:
+  case spv::BuiltIn::LocalInvocationIndex:
     sc = spv::StorageClass::Input;
     break;
   case spv::BuiltIn::PrimitiveCountNV:

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -89,16 +89,9 @@ bool isOpLineLegalForOp(spv::Op op) {
 uint32_t getHeaderVersion(llvm::StringRef env) {
   if (env == "vulkan1.1")
     return 0x00010300u;
-  if (env == "vulkan1.2")
+  if (env == "vulkan1.2" || env == "universal1.5")
     return 0x00010500u;
   return 0x00010000u;
-}
-
-// Returns true if the BufferBlock decoration is deprecated for the target
-// Vulkan environment.
-bool isBufferBlockDecorationDeprecated(
-    const clang::spirv::SpirvCodeGenOptions &opts) {
-  return opts.targetEnv.compare("vulkan1.2") >= 0;
 }
 
 // Read the file in |filePath| and returns its contents as a string.
@@ -2115,8 +2108,9 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
     // Emit Block or BufferBlock decorations if necessary.
     auto interfaceType = structType->getInterfaceType();
     if (interfaceType == StructInterfaceType::StorageBuffer)
+      // BufferBlock decoration is deprecated in Vulkan 1.2 and later.
       emitDecoration(id,
-                     isBufferBlockDecorationDeprecated(spvOptions)
+                     featureManager.isTargetEnvVulkan1p2OrAbove()
                          ? spv::Decoration::Block
                          : spv::Decoration::BufferBlock,
                      {});

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -51,7 +51,7 @@ public:
                   std::vector<uint32_t> *decVec,
                   std::vector<uint32_t> *typesVec,
                   const std::function<uint32_t()> &takeNextIdFn)
-      : astContext(astCtx), context(spvContext), spvOptions(opts),
+      : astContext(astCtx), context(spvContext),
         featureManager(astCtx.getDiagnostics(), opts),
         debugVariableBinary(debugVec), annotationsBinary(decVec),
         typeConstantBinary(typesVec), takeNextIdFunction(takeNextIdFn),
@@ -147,7 +147,6 @@ private:
 private:
   ASTContext &astContext;
   SpirvContext &context;
-  const SpirvCodeGenOptions &spvOptions;
   FeatureManager featureManager;
   std::vector<uint32_t> curTypeInst;
   std::vector<uint32_t> curDecorationInst;

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -8,6 +8,7 @@
 #ifndef LLVM_CLANG_SPIRV_EMITVISITOR_H
 #define LLVM_CLANG_SPIRV_EMITVISITOR_H
 
+#include "clang/SPIRV/FeatureManager.h"
 #include "clang/SPIRV/SpirvContext.h"
 #include "clang/SPIRV/SpirvVisitor.h"
 #include "llvm/ADT/DenseMap.h"
@@ -51,6 +52,7 @@ public:
                   std::vector<uint32_t> *typesVec,
                   const std::function<uint32_t()> &takeNextIdFn)
       : astContext(astCtx), context(spvContext), spvOptions(opts),
+        featureManager(astCtx.getDiagnostics(), opts),
         debugVariableBinary(debugVec), annotationsBinary(decVec),
         typeConstantBinary(typesVec), takeNextIdFunction(takeNextIdFn),
         emittedConstantInts({}), emittedConstantFloats({}),
@@ -146,6 +148,7 @@ private:
   ASTContext &astContext;
   SpirvContext &context;
   const SpirvCodeGenOptions &spvOptions;
+  FeatureManager featureManager;
   std::vector<uint32_t> curTypeInst;
   std::vector<uint32_t> curDecorationInst;
   std::vector<uint32_t> *debugVariableBinary;

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -29,15 +29,21 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
       allowExtension(ext);
   }
 
+  targetEnvStr = opts.targetEnv;
+
   if (opts.targetEnv == "vulkan1.0")
     targetEnv = SPV_ENV_VULKAN_1_0;
   else if (opts.targetEnv == "vulkan1.1")
     targetEnv = SPV_ENV_VULKAN_1_1;
   else if (opts.targetEnv == "vulkan1.2")
     targetEnv = SPV_ENV_VULKAN_1_2;
+  else if(opts.targetEnv == "universal1.5")
+    targetEnv = SPV_ENV_UNIVERSAL_1_5;
   else {
     emitError("unknown SPIR-V target environment '%0'", {}) << opts.targetEnv;
-    emitNote("allowed options are:\n vulkan1.0\n vulkan1.1\n vulkan1.2", {});
+    emitNote("allowed options are:\n vulkan1.0\n vulkan1.1\n vulkan1.2\n "
+             "universal1.5",
+             {});
   }
 }
 
@@ -255,6 +261,18 @@ bool FeatureManager::enabledByDefault(Extension ext) {
   default:
     return true;
   }
+}
+
+bool FeatureManager::isTargetEnvVulkan1p1OrAbove() {
+  std::string vulkanStr = "vulkan";
+  return targetEnvStr.substr(0, vulkanStr.size()) == vulkanStr &&
+         targetEnvStr.compare("vulkan1.1") >= 0;
+}
+
+bool FeatureManager::isTargetEnvVulkan1p2OrAbove() {
+  std::string vulkanStr = "vulkan";
+  return targetEnvStr.substr(0, vulkanStr.size()) == vulkanStr &&
+         targetEnvStr.compare("vulkan1.2") >= 0;
 }
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
@@ -10,24 +10,19 @@
 #include "RemoveBufferBlockVisitor.h"
 #include "clang/SPIRV/SpirvContext.h"
 
-namespace {
-
-bool isBufferBlockDecorationDeprecated(
-    const clang::spirv::SpirvCodeGenOptions &opts) {
-  return opts.targetEnv.compare("vulkan1.2") >= 0;
-}
-
-} // end anonymous namespace
-
 namespace clang {
 namespace spirv {
+
+bool RemoveBufferBlockVisitor::isBufferBlockDecorationDeprecated() {
+  return featureManager.isTargetEnvVulkan1p2OrAbove();
+}
 
 bool RemoveBufferBlockVisitor::visit(SpirvModule *mod, Phase phase) {
   // If the target environment is Vulkan 1.2 or later, BufferBlock decoration is
   // deprecated and should be removed from the module.
   // Otherwise, no action is needed by this IMR visitor.
   if (phase == Visitor::Phase::Init)
-    if (!isBufferBlockDecorationDeprecated(spvOptions))
+    if (!isBufferBlockDecorationDeprecated())
       return false;
 
   return true;

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
@@ -10,6 +10,8 @@
 #ifndef LLVM_CLANG_LIB_SPIRV_REMOVEBUFFERBLOCKVISITOR_H
 #define LLVM_CLANG_LIB_SPIRV_REMOVEBUFFERBLOCKVISITOR_H
 
+#include "clang/AST/ASTContext.h"
+#include "clang/SPIRV/FeatureManager.h"
 #include "clang/SPIRV/SpirvVisitor.h"
 
 namespace clang {
@@ -19,9 +21,9 @@ class SpirvContext;
 
 class RemoveBufferBlockVisitor : public Visitor {
 public:
-  RemoveBufferBlockVisitor(SpirvContext &spvCtx,
+  RemoveBufferBlockVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
                            const SpirvCodeGenOptions &opts)
-      : Visitor(opts, spvCtx) {}
+      : Visitor(opts, spvCtx), featureManager(astCtx.getDiagnostics(), opts) {}
 
   bool visit(SpirvModule *, Phase) override;
 
@@ -38,6 +40,12 @@ private:
   /// Returns true if |type| is a SPIR-V type whose interface type is
   /// StorageBuffer.
   bool hasStorageBufferInterfaceType(const SpirvType *type);
+
+  ///  Returns true if the BufferBlock decoration is deprecated (Vulkan 1.2 or
+  ///  above).
+  bool isBufferBlockDecorationDeprecated();
+
+  FeatureManager featureManager;
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1220,7 +1220,8 @@ std::vector<uint32_t> SpirvBuilder::takeModule() {
   RelaxedPrecisionVisitor relaxedPrecisionVisitor(context, spirvOptions);
   PreciseVisitor preciseVisitor(context, spirvOptions);
   NonUniformVisitor nonUniformVisitor(context, spirvOptions);
-  RemoveBufferBlockVisitor removeBufferBlockVisitor(context, spirvOptions);
+  RemoveBufferBlockVisitor removeBufferBlockVisitor(astContext, context,
+                                                    spirvOptions);
   EmitVisitor emitVisitor(astContext, context, spirvOptions);
 
   mod->invokeVisitor(&literalTypeVisitor, true);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -10471,7 +10471,6 @@ SpirvEmitter::getSpirvShaderStage(hlsl::ShaderModel::Kind smk) {
   case hlsl::ShaderModel::Kind::Pixel:
     return spv::ExecutionModel::Fragment;
   case hlsl::ShaderModel::Kind::Compute:
-  case hlsl::ShaderModel::Kind::Library:
     return spv::ExecutionModel::GLCompute;
   case hlsl::ShaderModel::Kind::RayGeneration:
     return spv::ExecutionModel::RayGenerationNV;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -520,7 +520,7 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
   }
 
   if (spirvOptions.debugInfoTool &&
-      spirvOptions.targetEnv.compare("vulkan1.1") >= 0) {
+      featureManager.isTargetEnvVulkan1p1OrAbove()) {
     // Emit OpModuleProcessed to indicate the commit information.
     std::string commitHash =
         std::string("dxc-commit-hash: ") + clang::getGitCommitHash();
@@ -584,8 +584,6 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
       return;
   }
 
-  const spv_target_env targetEnv = featureManager.getTargetEnv();
-
   // Addressing and memory model are required in a valid SPIR-V module.
   spvBuilder.setMemoryModel(spv::AddressingModel::Logical,
                             spv::MemoryModel::GLSL450);
@@ -602,7 +600,7 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
     spvBuilder.addEntryPoint(
         getSpirvShaderStage(entryInfo->shaderModelKind),
         entryInfo->entryFunction, entryInfo->funcDecl->getName(),
-        targetEnv == SPV_ENV_VULKAN_1_2
+        featureManager.isTargetEnvVulkan1p2OrAbove()
             ? spvBuilder.getModule()->getVariables()
             : llvm::ArrayRef<SpirvVariable *>(declIdMapper.collectStageVars()));
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -700,6 +700,14 @@ private:
   /// variables for some cases.
   bool emitEntryFunctionWrapperForRayTracing(const FunctionDecl *entryFunction,
                                              SpirvFunction *entryFuncId);
+
+  /// \brief Emits dummy entry function for hlsl library
+  /// returns spirvFunction
+
+  /// Spirv validation require entry function without input parameters and
+  /// return void. which is not garanteed by the exported functions, so create
+  /// a dummy compute shader function
+  SpirvFunction* emitDummyEntryFunction();
   /// \brief Performs the following operations for the Hull shader:
   /// * Creates an output variable which is an Array containing results for all
   /// control points.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -701,13 +701,6 @@ private:
   bool emitEntryFunctionWrapperForRayTracing(const FunctionDecl *entryFunction,
                                              SpirvFunction *entryFuncId);
 
-  /// \brief Emits dummy entry function for hlsl library
-  /// returns spirvFunction
-
-  /// Spirv validation require entry function without input parameters and
-  /// return void. which is not garanteed by the exported functions, so create
-  /// a dummy compute shader function
-  SpirvFunction* emitDummyEntryFunction();
   /// \brief Performs the following operations for the Hull shader:
   /// * Creates an output variable which is an Array containing results for all
   /// control points.

--- a/tools/clang/test/CodeGenSPIRV/binary-op.mul-assign.type-mismatch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.mul-assign.type-mismatch.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_2 -E main -enable-16bit-types
+// Run: %dxc -T ps_6_2 -E main -fspv-target-env=vulkan1.1 -enable-16bit-types
  
 Texture2D tex;
 SamplerState texSampler;

--- a/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
@@ -1,8 +1,9 @@
-// Run: %dxc -T lib_6_3 -Od
+// Run: %dxc -T lib_6_3 -fspv-target-env=universal1.5
 
+// CHECK: OpCapability Shader
+// CHECK: OpCapability Linkage
 RWBuffer< float4 > output : register(u1);
 
-// CHECK: OpEntryPoint GLCompute %dummyEntry "dummyEntry"
 // CHECK: %main = OpFunction %int None
 export int main(inout float4 color) {
   output[0] = color;

--- a/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T lib_6_3 -Od
+
+RWBuffer< float4 > output : register(u1);
+
+// CHECK: OpEntryPoint GLCompute %dummyEntry "dummyEntry"
+// CHECK: %main = OpFunction %int None
+export int main(inout float4 color) {
+  output[0] = color;
+  return 1;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.ctrl.line.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.ctrl.line.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_1 -E main -fspv-debug=line
+// Run: %dxc -T ps_6_1 -E main -fspv-target-env=vulkan1.1 -fspv-debug=line
 
 // Have file path
 // CHECK:      [[file:%\d+]] = OpString

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.ctrl.unknown.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.ctrl.unknown.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_1 -E main -fspv-debug=t
+// Run: %dxc -T ps_6_1 -E main -fspv-target-env=vulkan1.1 -fspv-debug=t
 
 float4 main(uint val : A) : SV_Target {
   uint a = reversebits(val);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -595,6 +595,7 @@ TEST_F(FileTest, FunctionInCTBuffer) {
 }
 
 TEST_F(FileTest, FunctionNoInline) { runFileTest("fn.noinline.hlsl"); }
+TEST_F(FileTest, FunctionExport) { runFileTest("fn.export.hlsl"); }
 
 // For OO features
 TEST_F(FileTest, StructMethodCall) {

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -295,7 +295,6 @@ TEST_F(FileTest, BinaryOpMixedTypeArithAssign) {
   runFileTest("binary-op.arith-assign.mixed.type.hlsl");
 }
 TEST_F(FileTest, BinaryOpMulAssignTypeMismatch) {
-  useVulkan1p1();
   runFileTest("binary-op.mul-assign.type-mismatch.hlsl");
 }
 

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1306,113 +1306,88 @@ TEST_F(FileTest, PrimitiveErrorGS) {
 
 // Shader model 6.0 wave query
 TEST_F(FileTest, SM6WaveIsFirstLane) {
-  useVulkan1p1();
   runFileTest("sm6.wave-is-first-lane.hlsl");
 }
 TEST_F(FileTest, SM6WaveGetLaneCount) {
-  useVulkan1p1();
   runFileTest("sm6.wave-get-lane-count.hlsl");
 }
 TEST_F(FileTest, SM6WaveGetLaneIndex) {
-  useVulkan1p1();
   runFileTest("sm6.wave-get-lane-index.hlsl");
 }
 TEST_F(FileTest, SM6WaveBuiltInNoDuplicate) {
-  useVulkan1p1();
   runFileTest("sm6.wave.builtin.no-dup.hlsl");
 }
 
 // Shader model 6.0 wave vote
 TEST_F(FileTest, SM6WaveActiveAnyTrue) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-any-true.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveAllTrue) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-all-true.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveBallot) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-ballot.hlsl");
 }
 
 // Shader model 6.0 wave reduction
 TEST_F(FileTest, SM6WaveActiveAllEqual) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-all-equal.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveSum) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-sum.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveProduct) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-product.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveMax) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-max.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveMin) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-min.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveBitAnd) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-bit-and.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveBitOr) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-bit-or.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveBitXor) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-bit-xor.hlsl");
 }
 TEST_F(FileTest, SM6WaveActiveCountBits) {
-  useVulkan1p1();
   runFileTest("sm6.wave-active-count-bits.hlsl");
 }
 
 // Shader model 6.0 wave scan/prefix
 TEST_F(FileTest, SM6WavePrefixSum) {
-  useVulkan1p1();
   runFileTest("sm6.wave-prefix-sum.hlsl");
 }
 TEST_F(FileTest, SM6WavePrefixProduct) {
-  useVulkan1p1();
   runFileTest("sm6.wave-prefix-product.hlsl");
 }
 TEST_F(FileTest, SM6WavePrefixCountBits) {
-  useVulkan1p1();
   runFileTest("sm6.wave-prefix-count-bits.hlsl");
 }
 
 // Shader model 6.0 wave broadcast
 TEST_F(FileTest, SM6WaveReadLaneAt) {
-  useVulkan1p1();
   runFileTest("sm6.wave-read-lane-at.hlsl");
 }
 TEST_F(FileTest, SM6WaveReadLaneFirst) {
-  useVulkan1p1();
   runFileTest("sm6.wave-read-lane-first.hlsl");
 }
 
 // Shader model 6.0 wave quad-wide shuffle
 TEST_F(FileTest, SM6QuadReadAcrossX) {
-  useVulkan1p1();
   runFileTest("sm6.quad-read-across-x.hlsl");
 }
 TEST_F(FileTest, SM6QuadReadAcrossY) {
-  useVulkan1p1();
   runFileTest("sm6.quad-read-across-y.hlsl");
 }
 TEST_F(FileTest, SM6QuadReadAcrossDiagonal) {
-  useVulkan1p1();
   runFileTest("sm6.quad-read-across-diagonal.hlsl");
 }
 TEST_F(FileTest, SM6QuadReadLaneAt) {
-  useVulkan1p1();
   runFileTest("sm6.quad-read-lane-at.hlsl");
 }
 
@@ -1613,7 +1588,6 @@ TEST_F(FileTest, SpirvDebugOpLineIntrinsicsControlBarrier) {
   runFileTest("spirv.debug.opline.intrinsic.control.barrier.hlsl");
 }
 TEST_F(FileTest, SpirvDebugOpLineIntrinsicsVulkan1_1) {
-  useVulkan1p1();
   runFileTest("spirv.debug.opline.intrinsic.vulkan1.1.hlsl");
 }
 TEST_F(FileTest, SpirvDebugOpLineOperators) {
@@ -1630,13 +1604,11 @@ TEST_F(FileTest, SpirvDebugOpLineEndOfShader) {
 }
 
 TEST_F(FileTest, SpirvDebugDxcCommitInfo) {
-  useVulkan1p1();
   runFileTest("spirv.debug.commit.hlsl");
 }
 
 // Test that command line options are exposed using OpModuleProcessed.
 TEST_F(FileTest, SpirvDebugClOption) {
-  useVulkan1p1();
   runFileTest("spirv.debug.cl-option.hlsl");
 }
 
@@ -1649,24 +1621,19 @@ TEST_F(FileTest, SpirvDebugO2Option) {
 }
 
 TEST_F(FileTest, SpirvDebugO3Option) {
-  useVulkan1p1();
   runFileTest("spirv.debug.o3.option.hlsl");
 }
 
 TEST_F(FileTest, SpirvDebugControlFile) {
-  useVulkan1p1();
   runFileTest("spirv.debug.ctrl.file.hlsl");
 }
 TEST_F(FileTest, SpirvDebugControlLine) {
-  useVulkan1p1();
   runFileTest("spirv.debug.ctrl.line.hlsl");
 }
 TEST_F(FileTest, SpirvDebugControlTool) {
-  useVulkan1p1();
   runFileTest("spirv.debug.ctrl.tool.hlsl");
 }
 TEST_F(FileTest, SpirvDebugControlUnknown) {
-  useVulkan1p1();
   runFileTest("spirv.debug.ctrl.unknown.hlsl", Expect::Failure);
 }
 
@@ -2234,18 +2201,15 @@ TEST_F(FileTest, RayTracingNVLibrary) {
   runFileTest("raytracing.nv.library.hlsl");
 }
 TEST_F(FileTest, RayTracingNVAccelerationStructure) {
-  useVulkan1p2();
   runFileTest("raytracing.nv.acceleration-structure.hlsl");
 }
 
 // === Raytracing KHR examples ===
 TEST_F(FileTest, RayTracingKHRClosestHit) {
-  useVulkan1p2();
   runFileTest("raytracing.khr.closesthit.hlsl");
 }
 
 TEST_F(FileTest, RayTracingAccelerationStructure) {
-  useVulkan1p2();
   runFileTest("raytracing.acceleration-structure.hlsl");
 }
 
@@ -2378,7 +2342,6 @@ TEST_F(FileTest, MeshShadingNVAmplification) {
               /* runValidation */ false);
 }
 TEST_F(FileTest, MeshShadingNVAmplificationFunCall) {
-  useVulkan1p1();
   // TODO: Re-enable spirv-val once issue#3006 is fixed.
   runFileTest("meshshading.nv.fncall.amplification.hlsl", Expect::Success,
               /* runValidation */ false);
@@ -2398,17 +2361,14 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 
 // Test OpEntryPoint in the Vulkan1.2 target environment
 TEST_F(FileTest, Vk1p2EntryPoint) {
-  useVulkan1p2();
   runFileTest("vk.1p2.entry-point.hlsl");
 }
 
 // Test deprecation of BufferBlock decoration after SPIR-V 1.3.
 TEST_F(FileTest, Vk1p2BlockDecoration) {
-  useVulkan1p2();
   runFileTest("vk.1p2.block-decoration.hlsl");
 }
 TEST_F(FileTest, Vk1p2RemoveBufferBlockRuntimeArray) {
-  useVulkan1p2();
   runFileTest("vk.1p2.remove.bufferblock.runtimearray.hlsl");
 }
 
@@ -2416,7 +2376,6 @@ TEST_F(FileTest, Vk1p2RemoveBufferBlockRuntimeArray) {
 // -fspv-target-env=vulkan1.2 option to make sure that enabling
 // Vulkan1.2 also enables Vulkan1.1.
 TEST_F(FileTest, CompatibilityWithVk1p1) {
-  useVulkan1p2();
   // TODO: Re-enable spirv-val once issue#3006 is fixed.
   runFileTest("meshshading.nv.fncall.amplification.vulkan1.2.hlsl",
               Expect::Success,

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -47,7 +47,7 @@ bool FileTest::parseInputFile() {
     const auto runCmdEndPos = checkCommands.find('\n', runCmdStartPos);
     const auto runCommand = checkCommands.substr(runCmdStartPos, runCmdEndPos);
     if (!utils::processRunCommandArgs(runCommand, &targetProfile, &entryPoint,
-                                      &restArgs)) {
+                                      &targetEnv, &restArgs)) {
       // An error has occured when parsing the Run command.
       return false;
     }

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -31,8 +31,6 @@ public:
       : targetEnv(SPV_ENV_VULKAN_1_0), beforeHLSLLegalization(false),
         glLayout(false), dxLayout(false) {}
 
-  void useVulkan1p1() { targetEnv = SPV_ENV_VULKAN_1_1; }
-  void useVulkan1p2() { targetEnv = SPV_ENV_VULKAN_1_2; }
   void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
   void setGlLayout() { glLayout = true; }
   void setDxLayout() { dxLayout = true; }

--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -61,6 +61,7 @@ bool validateSpirvBinary(spv_target_env env, std::vector<uint32_t> &binary,
 
 bool processRunCommandArgs(const llvm::StringRef runCommandLine,
                            std::string *targetProfile, std::string *entryPoint,
+                           spv_target_env *targetEnv,
                            std::vector<std::string> *restArgs) {
   std::istringstream buf(runCommandLine);
   std::istream_iterator<std::string> start(buf), end;
@@ -74,12 +75,30 @@ bool processRunCommandArgs(const llvm::StringRef runCommandLine,
 
   std::ostringstream rest;
   for (uint32_t i = 3; i < tokens.size(); ++i) {
-    if (tokens[i] == "-T" && (++i) < tokens.size())
+    if (tokens[i] == "-T" && (++i) < tokens.size()) {
       *targetProfile = tokens[i];
-    else if (tokens[i] == "-E" && (++i) < tokens.size())
+    } else if (tokens[i] == "-E" && (++i) < tokens.size()) {
       *entryPoint = tokens[i];
-    else
+    } else if (tokens[i].substr(0, 17) == "-fspv-target-env=") {
+      std::string targetEnvStr = tokens[i].substr(17);
+      if (targetEnvStr == "vulkan1.0")
+        *targetEnv = SPV_ENV_VULKAN_1_0;
+      else if (targetEnvStr == "vulkan1.1")
+        *targetEnv = SPV_ENV_VULKAN_1_1;
+      else if (targetEnvStr == "vulkan1.2")
+        *targetEnv = SPV_ENV_VULKAN_1_2;
+      else if (targetEnvStr == "universal1.5")
+        *targetEnv = SPV_ENV_UNIVERSAL_1_5;
+      else {
+        fprintf(stderr, "Error: Found unknown target environment.\n");
+        return false;
+      }
+      // Also push target environment to restArgs so that it gets passed to the
+      // compile command.
       restArgs->push_back(tokens[i]);
+    } else {
+      restArgs->push_back(tokens[i]);
+    }
   }
 
   if (targetProfile->empty()) {

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -37,11 +37,12 @@ bool validateSpirvBinary(spv_target_env, std::vector<uint32_t> &binary,
                          bool dxLayout, bool scalarLayout,
                          std::string *message = nullptr);
 
-/// \brief Parses the Target Profile and Entry Point from the Run command
-/// Returns the target profile, entry point, and the rest via arguments.
-/// Returns true on success, and false otherwise.
+/// \brief Parses the Target Profile, Entry Point, and Target Environment from
+/// the Run command returns the target profile, entry point, target environment,
+/// and the rest via arguments. Returns true on success, and false otherwise.
 bool processRunCommandArgs(const llvm::StringRef runCommandLine,
                            std::string *targetProfile, std::string *entryPoint,
+                           spv_target_env *targetEnv,
                            std::vector<std::string> *restArgs);
 
 /// \brief Converts an IDxcBlob into a vector of 32-bit unsigned integers which

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
@@ -32,7 +32,7 @@ bool WholeFileTest::parseInputFile() {
       if (line.find(hlslStartLabel) != std::string::npos) {
         foundRunCommand = true;
         if (!utils::processRunCommandArgs(line, &targetProfile, &entryPoint,
-                                          &restArgs)) {
+                                          &targetEnv, &restArgs)) {
           // An error has occured when parsing the Run command.
           return false;
         }

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
@@ -51,8 +51,6 @@ public:
 
   WholeFileTest() : targetEnv(SPV_ENV_VULKAN_1_0) {}
 
-  void useVulkan1p1() { targetEnv = SPV_ENV_VULKAN_1_1; }
-
 private:
   /// \brief Reads in the given input file.
   /// Stores the SPIR-V portion of the file into the <expectedSpirvAsm>


### PR DESCRIPTION
DXIL could export functions with export attribute while spirv would
ignore such functions. Currently glsl spirv does not have linkage
export decorate. so the exported function would be treated as normal
function while add dummy entry point according to the spirv validations