### PR TITLE
Revert "[spirv] add location for DebugDeclare"

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -482,7 +482,6 @@ public:
 
   SpirvDebugDeclare *createDebugDeclare(
       SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
-      SourceLocation loc = {},
       llvm::Optional<SpirvDebugExpression *> dbgExpr = llvm::None);
 
   SpirvDebugFunction *

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -2294,7 +2294,7 @@ private:
 class SpirvDebugDeclare : public SpirvDebugInstruction {
 public:
   SpirvDebugDeclare(SpirvDebugLocalVariable *, SpirvInstruction *,
-                    SpirvDebugExpression *, SourceLocation loc);
+                    SpirvDebugExpression *);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDebugDeclare)
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -701,7 +701,7 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
         type, name, info->source, line, column, info->scopeStack.back(), flags,
         dbgArgNumber);
-    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr, loc);
+    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr);
   }
 
   return fnParamInstr;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -890,13 +890,12 @@ SpirvDebugExpression *SpirvBuilder::getOrCreateNullDebugExpression() {
 }
 
 SpirvDebugDeclare *SpirvBuilder::createDebugDeclare(
-    SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var, SourceLocation loc,
+    SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
     llvm::Optional<SpirvDebugExpression *> dbgExpr) {
   auto *decl = new (context)
       SpirvDebugDeclare(dbgVar, var,
                         dbgExpr.hasValue() ? dbgExpr.getValue()
-                                           : getOrCreateNullDebugExpression(),
-                        loc);
+                                           : getOrCreateNullDebugExpression());
   if (isa<SpirvFunctionParameter>(var)) {
     assert(function && "found detached parameter");
     function->addParameterDebugDeclare(decl);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1074,7 +1074,7 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
         auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
             valueType, "this", info->source, line, column,
             info->scopeStack.back(), flags, 1);
-        spvBuilder.createDebugDeclare(debugLocalVar, curThis, loc);
+        spvBuilder.createDebugDeclare(debugLocalVar, curThis);
       }
 
       isNonStaticMemberFn = true;
@@ -1417,7 +1417,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
       auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
           decl->getType(), decl->getName(), info->source, line, column,
           info->scopeStack.back(), flags);
-      spvBuilder.createDebugDeclare(debugLocalVar, var, loc);
+      spvBuilder.createDebugDeclare(debugLocalVar, var);
     }
 
     // Variables that are not externally visible and of opaque types should

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -893,12 +893,9 @@ SpirvDebugExpression::SpirvDebugExpression(
 
 SpirvDebugDeclare::SpirvDebugDeclare(SpirvDebugLocalVariable *debugVar_,
                                      SpirvInstruction *var_,
-                                     SpirvDebugExpression *expr,
-                                     SourceLocation loc)
+                                     SpirvDebugExpression *expr)
     : SpirvDebugInstruction(IK_DebugDeclare, /*opcode*/ 28u),
-      debugVar(debugVar_), var(var_), expression(expr) {
-  srcLoc = loc;
-}
+      debugVar(debugVar_), var(var_), expression(expr) {}
 
 SpirvDebugLexicalBlock::SpirvDebugLexicalBlock(SpirvDebugSource *source_,
                                                uint32_t line_, uint32_t column_,

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugdeclare.hlsl
@@ -3,25 +3,22 @@
 // TODO: FlagIsPublic is shown as FlagIsProtected|FlagIsPrivate.
 
 // CHECK: [[set:%\d+]] = OpExtInstImport "OpenCL.DebugInfo.100"
-// CHECK: [[y:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 26 23 {{%\d+}} FlagIsLocal 2
-// CHECK: [[x:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 26 14 {{%\d+}} FlagIsLocal 1
-// CHECK: [[condition:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 33 8 {{%\d+}} FlagIsLocal
+// CHECK: [[y:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 23 {{%\d+}} FlagIsLocal 2
+// CHECK: [[x:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 23 14 {{%\d+}} FlagIsLocal 1
+// CHECK: [[condition:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 30 8 {{%\d+}} FlagIsLocal
 // CHECK: [[expr:%\d+]] = OpExtInst %void [[set]] DebugExpression
-// CHECK: [[color:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 31 20 {{%\d+}} FlagIsLocal 1
+// CHECK: [[color:%\d+]] = OpExtInst %void [[set]] DebugLocalVariable {{%\d+}} {{%\d+}} {{%\d+}} 28 20 {{%\d+}} FlagIsLocal 1
 
 // CHECK:     %color = OpFunctionParameter
 // CHECK:   {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[color]] %color [[expr]]
 // CHECK: %condition = OpVariable
-// CHECK:              OpLine {{%\d+}} 33 8
 // CHECK:              OpStore %condition %false
 // CHECK:   {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[condition]] %condition [[expr]]
 
-// CHECK:            %x = OpFunctionParameter
-// CHECK:            %y = OpFunctionParameter
-// CHECK:                 OpLine {{%\d+}} 26 14
-// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[x]] %x [[expr]]
-// CHECK-NEXT:            OpLine {{%\d+}} 26 23
-// CHECK-NEXT: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[y]] %y [[expr]]
+// CHECK:       %x = OpFunctionParameter
+// CHECK:       %y = OpFunctionParameter
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[x]] %x [[expr]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugDeclare [[y]] %y [[expr]]
 
 void foo(int x, float y)
 {


### PR DESCRIPTION
Reverts microsoft/DirectXShaderCompiler#3230

- I considered this change for a while. I think it is weird that DebugDeclare has a line instruction
because DebugDeclare must be not control-dependent by the [definition](
https://llvm.org/docs/SourceLevelDebugging.html#llvm-dbg-declare) i.e., the declaration is
effective in the scope of the local variable regardless of its location. This revert will let DXC
not emit the OpLine for DebugDeclare.