### PR TITLE
Fix lost debug info on DispatchMesh payload in AS

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1736,6 +1736,10 @@ bool SROAGlobalAndAllocas(HLModule &HLM, bool bHasDbgInfo) {
       if (Value *NewV = TranslatePtrIfUsedByLoweredFn(AI, typeSys)) {
         if (NewV != AI) {
           DXASSERT(AI->getNumUses() == 0, "must have zero users.");
+          // Update debug declare.
+          if (DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(AI)) {
+            DDI->setArgOperand(0, MetadataAsValue::get(NewV->getContext(), ValueAsMetadata::get(NewV)));
+          }
           AI->eraseFromParent();
           Changed = true;
         }

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/as_payload_debug.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/as_payload_debug.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -Zi -E main -T as_6_5 %s | FileCheck %s
+
+// CHECK: call void @llvm.dbg.value(metadata %struct.smallPayload{{.*}}*
+
+// Exclude quoted source file (see readme)
+// CHECK-LABEL: {{!"[^"]*\\0A[^"]*"}}
+
+struct smallPayload
+{
+    float f1;
+    float2 f2;
+};
+
+
+[numthreads(1, 1, 1)]
+void main()
+{
+    smallPayload p;
+    p.f1 = 1;
+    p.f2 = float2(2,3);
+    DispatchMesh(1, 1, 1, p);
+}


### PR DESCRIPTION
Note that this debug info was lost only when the payload struct used was a local variable, which shouldn't be the common case, since the idea is to cooperate across threads to construct a single payload in groupshared memory, rather than constructing a payload in per-thread (local) memory, then only using the one from the first thread.