### PR TITLE
[spirv] emit OpLine at the end of entry function

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -207,10 +207,11 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
   if (!spvOptions.debugInfoLine)
     return;
 
-  // Technically entry function wrappers do not exist in HLSL. They
-  // are just created by DXC. We do not want to emit line information
-  // for their instructions.
-  if (inEntryFunctionWrapper)
+  // Technically entry function wrappers do not exist in HLSL. They are just
+  // created by DXC. We do not want to emit line information for their
+  // instructions. To prevent spirv-opt from removing all debug info, we emit
+  // at least a single OpLine to specify the end of the shader.
+  if (inEntryFunctionWrapper && op != spv::Op::OpReturn)
     return;
 
   // Based on SPIR-V spec, OpSelectionMerge must immediately precede either an

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11154,7 +11154,7 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   // for return statement, because it is not the location of the actual
   // return and emitting the location of the end of entry function makes
   // us confused. It is better to emit debug line just before OpFunctionEnd.
-  spvBuilder.createReturn(/* SourceLocation */ {});
+  spvBuilder.createReturn(decl->getLocEnd());
   spvBuilder.endFunction();
 
   // For Hull shaders, there is no explicit call to the PCF in the HLSL source.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11150,10 +11150,9 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
     }
   }
 
-  // For wrapper of entry point, it is better not to specify SourceLocation
-  // for return statement, because it is not the location of the actual
-  // return and emitting the location of the end of entry function makes
-  // us confused. It is better to emit debug line just before OpFunctionEnd.
+  // To prevent spirv-opt from removing all debug info, we emit at least
+  // a single OpLine to specify the end of the shader. This SourceLocation
+  // will provide the information.
   spvBuilder.createReturn(decl->getLocEnd());
   spvBuilder.endFunction();
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.end.of.shader.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.end.of.shader.hlsl
@@ -1,0 +1,6 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=rich -O3
+
+void main() {
+}
+// CHECK:     OpLine {{%\d+}} 4 1
+// CHECK-NOT: OpLine

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1610,6 +1610,9 @@ TEST_F(FileTest, SpirvDebugOpLineVariables) {
 TEST_F(FileTest, SpirvDebugOpLineInclude) {
   runFileTest("spirv.debug.opline.include.hlsl");
 }
+TEST_F(FileTest, SpirvDebugOpLineEndOfShader) {
+  runFileTest("spirv.debug.opline.end.of.shader.hlsl");
+}
 
 TEST_F(FileTest, SpirvDebugDxcCommitInfo) {
   useVulkan1p1();


### PR DESCRIPTION
For some cases, spirv-opt removes all line information because of the
optimization. Emitting at least a single OpLine helps debuggers know it
is the end of the shader execution.