### PR TITLE
dxcisense: Allocate "TM" classes using IMalloc instead of new

### DIFF
--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -37,13 +37,12 @@ private:
   CXCursor m_cursor;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcCursor)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcCursor>(this, iid, ppvObject);
   }
 
-  DxcCursor();
-  ~DxcCursor();
   void Initialize(const CXCursor& cursor);
   static HRESULT Create(const CXCursor& cursor, _Outptr_result_nullonfailure_ IDxcCursor** pObject);
 
@@ -86,12 +85,13 @@ private:
   CXDiagnostic m_diagnostic;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_ALLOC(DxcDiagnostic)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcDiagnostic>(this, iid, ppvObject);
   }
 
-  DxcDiagnostic();
+  DxcDiagnostic(IMalloc *pMalloc);
   ~DxcDiagnostic();
   void Initialize(const CXDiagnostic& diagnostic);
   static HRESULT Create(const CXDiagnostic& diagnostic, _Outptr_result_nullonfailure_ IDxcDiagnostic** pObject);
@@ -117,13 +117,12 @@ private:
   CXFile m_file;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcFile)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcFile>(this, iid, ppvObject);
   }
 
-  DxcFile();
-  ~DxcFile();
   void Initialize(const CXFile& file);
   static HRESULT Create(const CXFile& file, _Outptr_result_nullonfailure_ IDxcFile** pObject);
 
@@ -142,12 +141,13 @@ private:
   unsigned m_locationLength;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_ALLOC(DxcInclusion)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcInclusion>(this, iid, ppvObject);
   }
 
-  DxcInclusion();
+  DxcInclusion(IMalloc *pMalloc);
   ~DxcInclusion();
   HRESULT Initialize(CXFile file, unsigned locations, _In_count_(locations) CXSourceLocation *pLocation);
   static HRESULT Create(CXFile file, unsigned locations, _In_count_(locations) CXSourceLocation *pLocation, _COM_Outptr_ IDxcInclusion **pResult);
@@ -166,12 +166,13 @@ private:
     hlsl::DxcLangExtensionsHelper m_langHelper;
 public:
     DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+    DXC_MICROCOM_TM_ALLOC(DxcIndex)
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
     {
       return DoBasicQueryInterface<IDxcIndex>(this, iid, ppvObject);
     }
 
-    DxcIndex();
+    DxcIndex(IMalloc *pMalloc);
     ~DxcIndex();
     HRESULT Initialize(hlsl::DxcLangExtensionsHelper& langHelper);
     static HRESULT Create(hlsl::DxcLangExtensionsHelper& langHelper, _Outptr_result_nullonfailure_ DxcIndex** index);
@@ -195,6 +196,7 @@ private:
 
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL();
+  DXC_MICROCOM_TM_CTOR(DxcIntelliSense)
   DXC_LANGEXTENSIONS_HELPER_IMPL(m_langHelper);
 
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
@@ -203,21 +205,19 @@ public:
         this, iid, ppvObject);
   }
 
-  DxcIntelliSense(IMalloc *pMalloc);
-
-    HRESULT STDMETHODCALLTYPE CreateIndex(_Outptr_result_nullonfailure_ IDxcIndex** index) override;
-    HRESULT STDMETHODCALLTYPE GetNullLocation(_Outptr_result_nullonfailure_ IDxcSourceLocation** location) override;
-    HRESULT STDMETHODCALLTYPE GetNullRange(_Outptr_result_nullonfailure_ IDxcSourceRange** location) override;
-    HRESULT STDMETHODCALLTYPE GetRange(
-      _In_ IDxcSourceLocation* start,
-      _In_ IDxcSourceLocation* end,
-      _Outptr_result_nullonfailure_ IDxcSourceRange** location) override;
-    HRESULT STDMETHODCALLTYPE GetDefaultDiagnosticDisplayOptions(
-      _Out_ DxcDiagnosticDisplayOptions* pValue) override;
-    HRESULT STDMETHODCALLTYPE GetDefaultEditingTUOptions(_Out_ DxcTranslationUnitFlags* pValue) override;
-    HRESULT STDMETHODCALLTYPE CreateUnsavedFile(
-      _In_ LPCSTR fileName, _In_ LPCSTR contents, unsigned contentLength,
-      _Outptr_result_nullonfailure_ IDxcUnsavedFile** pResult) override;
+  HRESULT STDMETHODCALLTYPE CreateIndex(_Outptr_result_nullonfailure_ IDxcIndex** index) override;
+  HRESULT STDMETHODCALLTYPE GetNullLocation(_Outptr_result_nullonfailure_ IDxcSourceLocation** location) override;
+  HRESULT STDMETHODCALLTYPE GetNullRange(_Outptr_result_nullonfailure_ IDxcSourceRange** location) override;
+  HRESULT STDMETHODCALLTYPE GetRange(
+    _In_ IDxcSourceLocation* start,
+    _In_ IDxcSourceLocation* end,
+    _Outptr_result_nullonfailure_ IDxcSourceRange** location) override;
+  HRESULT STDMETHODCALLTYPE GetDefaultDiagnosticDisplayOptions(
+    _Out_ DxcDiagnosticDisplayOptions* pValue) override;
+  HRESULT STDMETHODCALLTYPE GetDefaultEditingTUOptions(_Out_ DxcTranslationUnitFlags* pValue) override;
+  HRESULT STDMETHODCALLTYPE CreateUnsavedFile(
+    _In_ LPCSTR fileName, _In_ LPCSTR contents, unsigned contentLength,
+    _Outptr_result_nullonfailure_ IDxcUnsavedFile** pResult) override;
 };
 
 class DxcSourceLocation : public IDxcSourceLocation
@@ -227,13 +227,12 @@ private:
   CXSourceLocation m_location;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcSourceLocation)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcSourceLocation>(this, iid, ppvObject);
   }
 
-  DxcSourceLocation();
-  ~DxcSourceLocation();
   void Initialize(const CXSourceLocation& location);
   static HRESULT Create(const CXSourceLocation& location, _Outptr_result_nullonfailure_ IDxcSourceLocation** pObject);
 
@@ -258,13 +257,12 @@ private:
   CXSourceRange m_range;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcSourceRange)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcSourceRange>(this, iid, ppvObject);
   }
 
-  DxcSourceRange();
-  ~DxcSourceRange();
   void Initialize(const CXSourceRange& range);
   static HRESULT Create(const CXSourceRange& range, _Outptr_result_nullonfailure_ IDxcSourceRange** pObject);
 
@@ -283,13 +281,12 @@ private:
   CXTranslationUnit m_tu;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcToken)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcToken>(this, iid, ppvObject);
   }
 
-  DxcToken();
-  ~DxcToken();
   void Initialize(const CXTranslationUnit& tu, const CXToken& token);
   static HRESULT Create(const CXTranslationUnit& tu, const CXToken& token, _Outptr_result_nullonfailure_ IDxcToken** pObject);
 
@@ -306,12 +303,13 @@ private:
     CXTranslationUnit m_tu;
 public:
     DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+    DXC_MICROCOM_TM_ALLOC(DxcTranslationUnit)
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
     {
       return DoBasicQueryInterface<IDxcTranslationUnit>(this, iid, ppvObject);
     }
 
-    DxcTranslationUnit();
+    DxcTranslationUnit(IMalloc *pMalloc);
     ~DxcTranslationUnit();
     void Initialize(CXTranslationUnit tu);
 
@@ -358,13 +356,12 @@ private:
   CXType m_type;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcType)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override
   {
     return DoBasicQueryInterface<IDxcType>(this, iid, ppvObject);
   }
 
-  DxcType();
-  ~DxcType();
   void Initialize(const CXType& type);
   static HRESULT Create(const CXType& type, _Outptr_result_nullonfailure_ IDxcType** pObject);
 
@@ -380,12 +377,12 @@ private:
   CXCodeCompleteResults* m_ccr;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcCodeCompleteResults)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
                                            void **ppvObject) override {
     return DoBasicQueryInterface<IDxcCodeCompleteResults>(this, iid, ppvObject);
   }
 
-  DxcCodeCompleteResults();
   ~DxcCodeCompleteResults();
   void Initialize(CXCodeCompleteResults* ccr);
 
@@ -400,13 +397,12 @@ private:
   CXCompletionResult m_cr;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcCompletionResult)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
                                            void **ppvObject) override {
     return DoBasicQueryInterface<IDxcCompletionResult>(this, iid, ppvObject);
   }
 
-  DxcCompletionResult();
-  ~DxcCompletionResult();
   void Initialize(const CXCompletionResult& cr);
 
   HRESULT STDMETHODCALLTYPE GetCursorKind(_Out_ DxcCursorKind *pResult) override;
@@ -420,13 +416,12 @@ private:
   CXCompletionString m_cs;
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
+  DXC_MICROCOM_TM_CTOR(DxcCompletionString)
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
                                            void **ppvObject) override {
     return DoBasicQueryInterface<IDxcCompletionString>(this, iid, ppvObject);
   }
 
-  DxcCompletionString();
-  ~DxcCompletionString();
   void Initialize(const CXCompletionString& cs);
 
   HRESULT STDMETHODCALLTYPE GetNumCompletionChunks(_Out_ unsigned *pResult) override;


### PR DESCRIPTION
When running valgrind over a program using `DxcIntelliSense` (to validate our own deallocations [1]) a bunch of mismatching `new` with `free()` show up:

    Mismatched free() / delete / delete []
       at 0x483B9AB: free (vg_replace_malloc.c:538)
       by 0x52B06A8: IMalloc::Free(void*) (WinAdapter.cpp:34)
       by 0x6DC7D19: DxcTranslationUnit::Release() (dxcisenseimpl.h:308)
       by 0x14278E: com_rs::unknown::IUnknown::release (unknown.rs:55)
       [...]
     Address 0x4c3c930 is 0 bytes inside a block of size 40 alloc'd
       at 0x483B07F: operator new(unsigned long, std::nothrow_t const&) (vg_replace_malloc.c:385)
       by 0x6DC06EB: DxcIndex::ParseTranslationUnit(char const*, char const* const*, int, IDxcUnsavedFile**, unsigned int, DxcTranslationUnitFlags, IDxcTranslationUnit**) (dxcisenseimpl.cpp:1192)
       by 0x13020A: hassle_rs::intellisense::ffi::IDxcIndex::parse_translation_unit (macros.rs:108)
       by 0x119B74: hassle_rs::intellisense::wrapper::DxcIndex::parse_translation_unit (wrapper.rs:101)
       [...]

And so on for the other intellisense classes.  All these classes have `DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL` which deallocates `this` on the associated `m_pMalloc` with `free()`:

    The "TM" version keep an IMalloc field that, if not null, indicate
    ownership of 'this' and of any allocations used during release.

Yet are allocated using `new`, resulting in this mismatch.  The solution is to follow a similar approach as the introduction of `IMalloc` to `DxcIntelliSense` in d5bb308 by rewriting all classes to take an `IMalloc *` in the constructor and invoking it either through `::Alloc` from `DXC_MICROCOM_TM_ALLOC` or `CreateOnMalloc`.

[1]: https://github.com/microsoft/DirectXShaderCompiler/pull/3250#issuecomment-726216850