### PR TITLE
Move force-zero-store-lifetimes flag to help-hidden

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -271,7 +271,7 @@ def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcom
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR after each pass.">;
-def force_zero_store_lifetimes : Flag<["-", "/"], "force-zero-store-lifetimes">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def force_zero_store_lifetimes : Flag<["-", "/"], "force-zero-store-lifetimes">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Instead of generating lifetime intrinsics (SM >= 6.6) or storing undef (SM < 6.6), force fall back to storing zeroinitializer.">;
 def enable_lifetime_markers : Flag<["-", "/"], "enable-lifetime-markers">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Enable generation of lifetime markers">;

--- a/tools/clang/test/HLSLFileCheck/passes/llvm/simplifycfg/fold-cond-branch-on-phi.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/llvm/simplifycfg/fold-cond-branch-on-phi.hlsl
@@ -7,7 +7,6 @@
 // CHECK: %[[cond:.+]] = phi i1
 // CHECK-SAME: [ false
 // CHECK: br i1 %[[cond]]
-// CHECK: @main
 
 cbuffer cb : register(b0) {
   uint a,b,c,d,e,f,g,h,i,j,k,l,m,n;


### PR DESCRIPTION
- The flag is supposed to be temporary.
- Also remove check that was accidentally left in from a test.