### PR TITLE
Reword misleading type buffer atomic error message

### DIFF
--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -7304,7 +7304,7 @@ void TranslateDefaultSubscript(CallInst *CI, HLOperationLowerHelper &helper,  HL
           // Invalid operations.
           Translated = false;
           dxilutil::EmitErrorOnInstruction(
-              userCall, "Atomic operation on typed buffer is not supported.");
+              userCall, "Typed resources used in atomic operations must have a scalar element type.");
           return;
         } break;
         default:

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/swizzle/swizzleAtomic2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/swizzle/swizzleAtomic2.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
 
-// CHECK: Atomic operation on typed buffer is not supported
+// CHECK: Typed resources used in atomic operations must have a scalar element type
 
 RWBuffer<uint4> bufA;
 


### PR DESCRIPTION
Saying that typed buffers are not supported is inaccurate. Scalar types
are required for it to work though.