### PR TITLE
Allow adding object methods when in namespace

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11767,18 +11767,17 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC, Expr *BitWidth,
          "otherwise this is called without checking language first");
 
   // NOTE: some tests may declare templates.
-  if (DC->isNamespace() || DC->isDependentContext()) return true;
+  if (DC->isDependentContext()) return true;
 
   DeclSpec::SCS storage = D.getDeclSpec().getStorageClassSpec();
   assert(!DC->isClosure() && "otherwise parser accepted closure syntax instead of failing with a syntax error");
   assert(!DC->isDependentContext() && "otherwise parser accepted a template instead of failing with a syntax error");
-  assert(!DC->isNamespace() && "otherwise parser accepted a namespace instead of failing a syntax error");
 
   bool result = true;
   bool isTypedef = storage == DeclSpec::SCS_typedef;
   bool isFunction = D.isFunctionDeclarator() && !DC->isRecord();
   bool isLocalVar = DC->isFunctionOrMethod() && !isFunction && !isTypedef;
-  bool isGlobal = !isParameter && !isTypedef && !isFunction && (DC->isTranslationUnit() || DC->getDeclKind() == Decl::HLSLBuffer);
+  bool isGlobal = !isParameter && !isTypedef && !isFunction && (DC->isTranslationUnit() || DC->isNamespace() || DC->getDeclKind() == Decl::HLSLBuffer);
   bool isMethod = DC->isRecord() && D.isFunctionDeclarator() && !isTypedef;
   bool isField = DC->isRecord() && !D.isFunctionDeclarator() && !isTypedef;
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/namespace/texture_in_namespace.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/namespace/texture_in_namespace.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T ps_6_0 %s  | FileCheck %s
+
+// CHECK: dx.op.sample.f32
+// CHECK: dx.op.sample.f32
+
+namespace Textures {
+  Texture2D<float4> Color : register(t0);
+}
+
+namespace Samplers {
+  SamplerState Point : register(s0);
+}
+
+Texture2D<float4> GlobalTex : register(t1);
+SamplerState GlobalSamp : register(s1);
+
+float4 main(in float2 uv : TEXCOORD0) : SV_TARGET0
+{
+ return (Textures::Color.Sample(Samplers::Point, uv) + GlobalTex.Sample(GlobalSamp, uv))/2.0;
+}


### PR DESCRIPTION
Builtin object types such as Texture2D add all their object methods
to the associated decl context when they are first seen. However,
previously, if the code meant to effect that was found in a namespace
it would skip this addition. This removes that restriction so that
the methods can be added and then found when needed.

Fixes #2472