### PR TITLE
Update dxexp to 6.6

### DIFF
--- a/tools/dxexp/dxexp.cpp
+++ b/tools/dxexp/dxexp.cpp
@@ -140,6 +140,10 @@ typedef struct D3D12_FEATURE_DATA_D3D12_OPTIONS5
 #define D3D_SHADER_MODEL_6_5 ((D3D_SHADER_MODEL)0x65)
 #endif
 
+#ifndef D3D_SHADER_MODEL_6_6
+#define D3D_SHADER_MODEL_6_6 ((D3D_SHADER_MODEL)0x66)
+#endif
+
 static char *BoolToStrJson(bool value) {
   return value ? "true" : "false";
 }
@@ -163,6 +167,7 @@ static char *ShaderModelToStr(D3D_SHADER_MODEL SM) {
   case D3D_SHADER_MODEL_6_3: return "6.3";
   case D3D_SHADER_MODEL_6_4: return "6.4";
   case D3D_SHADER_MODEL_6_5: return "6.5";
+  case D3D_SHADER_MODEL_6_6: return "6.6";
   default: return "ERROR";
   }
 }
@@ -187,7 +192,7 @@ static char *RaytracingTierToStr(D3D12_RAYTRACING_TIER Tier) {
 
 static HRESULT GetHighestShaderModel(ID3D12Device *pDevice, D3D12_FEATURE_DATA_SHADER_MODEL &DeviceSM) {
   HRESULT hr = E_INVALIDARG;
-  D3D_SHADER_MODEL SM = D3D_SHADER_MODEL_6_5;
+  D3D_SHADER_MODEL SM = D3D_SHADER_MODEL_6_6;
   while (hr == E_INVALIDARG && SM >= D3D_SHADER_MODEL_6_0) {
     DeviceSM.HighestShaderModel = SM;
     hr = pDevice->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &DeviceSM, sizeof(DeviceSM));


### PR DESCRIPTION
To report support correctly, it needs to start with 6.6 and work
backward.