### PR TITLE
Enabled loop exit structurizer by default.

### DIFF
--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -337,7 +337,7 @@ void EmitAssemblyHelper::CreatePasses() {
                         CodeGenOpts.HLSLOptimizationToggles.find("gvn")->second;
 
   PMBuilder.StructurizeLoopExitsForUnroll =
-                        CodeGenOpts.HLSLOptimizationToggles.count("structurize-loop-exits-for-unroll") &&
+                        !CodeGenOpts.HLSLOptimizationToggles.count("structurize-loop-exits-for-unroll") ||
                         CodeGenOpts.HLSLOptimizationToggles.find("structurize-loop-exits-for-unroll")->second;
 
   PMBuilder.HLSLEnableLifetimeMarkers = CodeGenOpts.HLSLEnableLifetimeMarkers;

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/struct_exit_disable.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/struct_exit_disable.hlsl
@@ -1,6 +1,6 @@
-// RUN: %dxc -E main -Zi -O3 -T ps_6_0 %s | FileCheck %s
-// RUN: %dxc -E main -Zi -Od -T ps_6_0 %s -DFORCE_UNROLL | FileCheck %s
-// RUN: %dxc -E main -Zi -T ps_6_0 %s -DFORCE_UNROLL | FileCheck %s
+// RUN: %dxc -opt-disable structurize-loop-exits-for-unroll -E main -Zi -O3 -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -opt-disable structurize-loop-exits-for-unroll -E main -Zi -Od -T ps_6_0 %s -DFORCE_UNROLL | FileCheck %s
+// RUN: %dxc -opt-disable structurize-loop-exits-for-unroll -E main -Zi -T ps_6_0 %s -DFORCE_UNROLL | FileCheck %s
 
 // CHECK: %{{.+}} = call float @dx.op.unary.f32(i32 13
 // CHECK: %{{.+}} = call float @dx.op.unary.f32(i32 13


### PR DESCRIPTION
Also:
- Replaced undefs with 0's for numeric types.
- Fixed a bug in loop exit structurizer where exit values don't dominate users.