### PR TITLE
Fix mesh and groupshared in ExecutionTest

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -219,10 +219,9 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             g_bufMesh[ix] = DerivTest(ix);
         }
         float4 PSMain(PSInput input) : SV_TARGET {
@@ -322,9 +321,8 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             g_bufMesh[ix] = QuadReadTest(ix);
         }
 
@@ -473,10 +471,9 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             g_bufMesh[ix] = DerivTest(ix);
         }
 
@@ -1670,8 +1667,36 @@
           XCHG_TEST(VEC_CALL3, VEC_CALL4, g_xtex64Buf)
         }
 
-        void AtomicGroupSharedTest(uint ix, uint bitSize) {
+        void InitSharedMem(uint ix) {
+          // Zero-init shared memory
+          g_uintShare[ix%6] = 0;
+          g_sintShare[ix%3] = 0;
+          g_xchgShare[ix%64] = 0;
+
+          GroupMemoryBarrierWithGroupSync();
+
+          InterlockedCompareStore(g_uintShare[1], 0, 99999999);
+          InterlockedCompareStore(g_uintShare[3], 0, -1);
+          InterlockedCompareStore(g_sintShare[1], 0, 99999999);
+        }
+
+        void InitSharedMem64(uint ix) {
+          // Zero-init shared memory
+          g_uint64Share[ix%6] = 0;
+          g_sint64Share[ix%3] = 0;
+          g_xchg64Share[ix%64] = 0;
+
+          GroupMemoryBarrierWithGroupSync();
+
+          InterlockedCompareStore(g_uint64Share[1], 0, 99999999ULL | (99999999ULL << 32));
+          InterlockedCompareStore(g_uint64Share[3], 0, ~0ULL);
+          InterlockedCompareStore(g_sint64Share[1], 0, 99999999ULL | (99999999ULL << 32));
+
+        }
+
+        void AtomicGroupSharedTest(uint ix) {
           uint stride = 1;
+          uint bitSize = 32;
           uint value = (ix) | ((ix) << (bitSize/2));
           uint addVal = ix; // 32 bits isn't enough room to dupliate upper and lower
           uint uminMaxVal = ~value*(~value&1) + value*(value&1);
@@ -1680,34 +1705,16 @@
           uint xchgVal = (ix << (bitSize/2)) | ((ix/3)%64);
           uint output = 0;
 
-          uint uIx = ix%(6*stride);
-          uint sIx = ix%(3*stride);
-
-          // Zero-init shared memory
-          g_uintShare[uIx] = 0;
-          g_sintShare[sIx] = 0;
-          g_xchgShare[ix%64] = 0;
-
-          GroupMemoryBarrierWithGroupSync();
-
-          InterlockedCompareStore(g_uintShare[stride], 0, 99999999);
-          InterlockedCompareStore(g_uintShare[3*stride], 0, -1);
-          InterlockedCompareStore(g_sintShare[stride], 0, 99999999);
-
           OP_TEST(VEC_CALL, VEC_CALL, g_uintShare, g_sintShare)
           XCHG_TEST(VEC_CALL3, VEC_CALL4, g_xchgShare)
 
           GroupMemoryBarrierWithGroupSync();
-
-          g_shareBuf[uIx].x = g_uintShare[uIx];
-          g_shareBuf[6 + sIx].x = g_sintShare[sIx + 1];
-
-          g_shareXchgBuf[(ix/3)%64].x = g_xchgShare[(ix/3)%64];
         }
 
-        void AtomicGroupShared64Test(uint ix, uint64_t bitSize) {
+        void AtomicGroupShared64Test(uint ix) {
           uint64_t lix = ix;
           uint stride = 1;
+          uint64_t bitSize = 64;
           uint64_t value = (lix) | ((lix) << (bitSize/2));
           uint64_t addVal = value;
           uint64_t uminMaxVal = ~value*(~value&1) + value*(value&1);
@@ -1716,34 +1723,20 @@
           uint64_t xchgVal = (lix << (bitSize/2)) | ((lix/3)%64);
           uint64_t output = 0;
 
-          uint uIx = ix%(6*stride);
-          uint sIx = ix%(3*stride);
-
-          // Zero-init shared memory
-          g_uint64Share[uIx] = 0;
-          g_sint64Share[sIx] = 0;
-          g_xchg64Share[ix%64] = 0;
-
-          GroupMemoryBarrierWithGroupSync();
-
-          InterlockedCompareStore(g_uint64Share[stride], 0, 99999999ULL | (99999999ULL << (bitSize/2)));
-          InterlockedCompareStore(g_uint64Share[3*stride], 0, ~0ULL);
-          InterlockedCompareStore(g_sint64Share[stride], 0, 99999999ULL | (99999999ULL << (bitSize/2)));
-
           OP_TEST(VEC_CALL, VEC_CALL, g_uint64Share, g_sint64Share)
           XCHG_TEST(VEC_CALL3, VEC_CALL4, g_xchg64Share)
 
           GroupMemoryBarrierWithGroupSync();
-
-          g_share64Buf[uIx] = g_uint64Share[uIx];
-          g_share64Buf[sIx + 6] = g_sint64Share[sIx + 1];
-
-          g_shareXchg64Buf[(ix/3)%64] = g_xchg64Share[(ix/3)%64];
-
         }
 
         struct Payload {
-          uint nothing;
+          uint arith[16];
+          uint xchg[64];
+        };
+
+        struct Payload64 {
+          uint64_t arith[16];
+          uint64_t xchg[64];
         };
 
         static float4 g_Verts[6] = {
@@ -1764,12 +1757,19 @@
           { 1.0f, 0.0f },
           { 1.0f, 1.0f }};
 
+        groupshared Payload payload;
+
         [NumThreads(8, 8, 2)]
         void ASMain(uint ix : SV_GroupIndex) {
-          Payload payload;
-          payload.nothing = 0;
-          AtomicTest(64*64 + 8*8 + ix, 32);
-          AtomicGroupSharedTest(64*64 + 8*8 + ix, 32);
+          AtomicTest(64*64 + 8*8*2 + ix, 32);
+
+          InitSharedMem(ix);
+          AtomicGroupSharedTest(ix);
+
+          payload.arith[ix%6] = g_uintShare[ix%6];
+          payload.arith[ix%3 + 6] = g_sintShare[ix%3 + 1];
+          payload.xchg[ix%64] = g_xchgShare[ix%64];
+
           DispatchMesh(1, 1, 1, payload);
         }
 
@@ -1781,12 +1781,24 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
+
             AtomicTest(64*64 + ix, 32);
-            AtomicGroupSharedTest(64*64 + ix, 32);
+
+            g_uintShare[ix%6] = payload.arith[ix%6];
+            g_sintShare[ix%3] = payload.arith[ix%3 + 6];
+            g_xchgShare[ix%64] = payload.xchg[ix%64];
+
+            GroupMemoryBarrierWithGroupSync();
+
+            AtomicGroupSharedTest(8*8*2 + ix);
+
+            g_shareBuf[ix%6].x = g_uintShare[ix%6];
+            g_shareBuf[ix%3 + 6].x = g_sintShare[ix%3 + 1];
+
+            g_shareXchgBuf[ix%64].x = g_xchgShare[ix%64];
         }
 
         PSInput VSMain(float3 position : POSITION, float2 uv : TEXCOORD, uint ix : SV_VertexID) {
@@ -1806,14 +1818,18 @@
         [NumThreads(32, 32, 1)]
         void CSMain(uint ix : SV_GroupIndex) {
           AtomicTest(ix, 32);
-          AtomicGroupSharedTest(ix, 32);
+          InitSharedMem(ix);
+          AtomicGroupSharedTest(ix);
+
+          g_shareBuf[ix%6].x = g_uintShare[ix%6];
+          g_shareBuf[ix%3 + 6].x = g_sintShare[ix%3 + 1];
+
+          g_shareXchgBuf[ix%64].x = g_xchgShare[ix%64];
         }
 
         [NumThreads(8, 8, 2)]
         void ASMain64(uint ix : SV_GroupIndex) {
-          Payload payload;
-          payload.nothing = 0;
-          AtomicRaw64Test(64*64 + 8*8 + ix, 64);
+          AtomicRaw64Test(64*64 + 8*8*2 + ix, 64);
           DispatchMesh(1, 1, 1, payload);
         }
 
@@ -1825,10 +1841,9 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             AtomicRaw64Test(64*64 + ix, 64);
         }
 
@@ -1853,9 +1868,7 @@
 
         [NumThreads(8, 8, 2)]
         void ASMainTyped64(uint ix : SV_GroupIndex) {
-          Payload payload;
-          payload.nothing = 0;
-          AtomicTyped64Test(64*64 + 8*8 + ix, 64);
+          AtomicTyped64Test(64*64 + 8*8*2 + ix, 64);
           DispatchMesh(1, 1, 1, payload);
         }
 
@@ -1867,10 +1880,9 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             AtomicTyped64Test(64*64 + ix, 64);
         }
 
@@ -1893,32 +1905,57 @@
           AtomicTyped64Test(ix, 64);
         }
 
+        groupshared Payload64 payload64;
+
         [NumThreads(8, 8, 2)]
         void ASMainShared64(uint ix : SV_GroupIndex) {
-          Payload payload;
-          payload.nothing = 0;
-          AtomicGroupShared64Test(64*64 + 8*8 + ix, 64);
-          DispatchMesh(1, 1, 1, payload);
+          InitSharedMem64(ix);
+          AtomicGroupShared64Test(ix);
+
+          payload64.arith[ix%6] = g_uint64Share[ix%6];
+          payload64.arith[ix%3 + 6] = g_sint64Share[ix%3 + 1];
+          payload64.xchg[ix%64] = g_xchg64Share[ix%64];
+
+          DispatchMesh(1, 1, 1, payload64);
         }
 
         [NumThreads(8, 8, 2)]
         [OutputTopology("triangle")]
         void MSMainShared64(
           uint ix : SV_GroupIndex,
-          in payload Payload payload,
+          in payload Payload64 payload,
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
-            AtomicGroupShared64Test(64*64 + ix, 64);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
+
+            g_uint64Share[ix%6] = payload.arith[ix%6];
+            g_sint64Share[ix%3] = payload.arith[ix%3 + 6];
+            g_xchg64Share[ix%64] = payload.xchg[ix%64];
+
+            GroupMemoryBarrierWithGroupSync();
+
+            AtomicGroupShared64Test(8*8*2 + ix);
+
+            g_share64Buf[ix%6] = g_uint64Share[ix%6];
+            g_share64Buf[ix%3 + 6] = g_sint64Share[ix%3 + 1];
+
+            g_shareXchg64Buf[ix%64] = g_xchg64Share[ix%64];
+
         }
 
         [NumThreads(32, 32, 1)]
         void CSMainShared64(uint ix : SV_GroupIndex) {
-          AtomicGroupShared64Test(ix, 64);
+          InitSharedMem64(ix);
+          AtomicGroupShared64Test(ix);
+
+          g_share64Buf[ix%6] = g_uint64Share[ix%6];
+          g_share64Buf[ix%3 + 6] = g_sint64Share[ix%3 + 1];
+
+          g_shareXchg64Buf[ix%64] = g_xchg64Share[ix%64];
+
         }
       ]]>
     </Shader>
@@ -2105,10 +2142,9 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
-            verts[ix].position = g_Verts[ix];
-            verts[ix].uv = g_UV[ix];
-            if (ix % 3)
-              tris[ix / 3] = uint3(ix, ix + 1, ix + 2);
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             AtomicTest(ix);
             AtomicGroupSharedTest(ix);
         }

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -219,6 +219,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
@@ -321,6 +322,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
             g_bufMesh[ix] = QuadReadTest(ix);
@@ -471,6 +473,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
@@ -1729,6 +1732,7 @@
           GroupMemoryBarrierWithGroupSync();
         }
 
+        // Payloads are used to transport AS test results to MS where they are finalized
         struct Payload {
           uint arith[16];
           uint xchg[64];
@@ -1766,6 +1770,9 @@
           InitSharedMem(ix);
           AtomicGroupSharedTest(ix);
 
+          // Copy AS test results to payload and ultimately to MS
+          // More threads than results are possible,
+          // so indices will result in duplicate copies
           payload.arith[ix%6] = g_uintShare[ix%6];
           payload.arith[ix%3 + 6] = g_sintShare[ix%3 + 1];
           payload.xchg[ix%64] = g_xchgShare[ix%64];
@@ -1781,12 +1788,16 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
 
             AtomicTest(64*64 + ix, 32);
 
+            // Load AS test results from payload
+            // More threads than results are possible,
+            // so indices will result in duplicate copies
             g_uintShare[ix%6] = payload.arith[ix%6];
             g_sintShare[ix%3] = payload.arith[ix%3 + 6];
             g_xchgShare[ix%64] = payload.xchg[ix%64];
@@ -1795,9 +1806,9 @@
 
             AtomicGroupSharedTest(8*8*2 + ix);
 
+            // Copy final AS + MS results to output UAVs
             g_shareBuf[ix%6].x = g_uintShare[ix%6];
             g_shareBuf[ix%3 + 6].x = g_sintShare[ix%3 + 1];
-
             g_shareXchgBuf[ix%64].x = g_xchgShare[ix%64];
         }
 
@@ -1841,6 +1852,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
@@ -1880,6 +1892,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
@@ -1912,6 +1925,9 @@
           InitSharedMem64(ix);
           AtomicGroupShared64Test(ix);
 
+          // Copy AS test results to payload and ultimately to MS
+          // More threads than results are possible,
+          // so indices will result in duplicate copies
           payload64.arith[ix%6] = g_uint64Share[ix%6];
           payload64.arith[ix%3 + 6] = g_sint64Share[ix%3 + 1];
           payload64.xchg[ix%64] = g_xchg64Share[ix%64];
@@ -1927,10 +1943,14 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
 
+            // Load AS test results from payload
+            // More threads than results are possible,
+            // so indices will result in duplicate copies
             g_uint64Share[ix%6] = payload.arith[ix%6];
             g_sint64Share[ix%3] = payload.arith[ix%3 + 6];
             g_xchg64Share[ix%64] = payload.xchg[ix%64];
@@ -1939,9 +1959,9 @@
 
             AtomicGroupShared64Test(8*8*2 + ix);
 
+            // Copy final AS + MS results to output UAVs
             g_share64Buf[ix%6] = g_uint64Share[ix%6];
             g_share64Buf[ix%3 + 6] = g_sint64Share[ix%3 + 1];
-
             g_shareXchg64Buf[ix%64] = g_xchg64Share[ix%64];
 
         }
@@ -1951,9 +1971,9 @@
           InitSharedMem64(ix);
           AtomicGroupShared64Test(ix);
 
+          // Copy final results to output UAVs
           g_share64Buf[ix%6] = g_uint64Share[ix%6];
           g_share64Buf[ix%3 + 6] = g_sint64Share[ix%3 + 1];
-
           g_shareXchg64Buf[ix%64] = g_xchg64Share[ix%64];
 
         }
@@ -2142,6 +2162,7 @@
           out vertices PSInput verts[6],
           out indices uint3 tris[2]) {
             SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
             verts[ix%6].position = g_Verts[ix%6];
             verts[ix%6].uv = g_UV[ix%6];
             tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -8297,7 +8297,7 @@ void VerifyAtomicResults(const BYTE *uResults, const BYTE *sResults,
   LogCommentFmt(L"Verifying %d-bit integer atomic add", bitSize);
   // For 32-bit values, the sum exceeds the 16 bit limit, so we can't duplicate
   // That's fine, the duplication is really for 64-bit values.
-  if (addResult >= 1ULL << shBits)
+  if (bitSize < 64)
     VERIFY_IS_TRUE(AtomicResultMatches(uResults + stride*ADD_IDX, addResult, byteSize));
   else
     VERIFY_IS_TRUE(AtomicResultMatches(uResults + stride*ADD_IDX, SHIFT(addResult, shBits), byteSize));
@@ -8518,11 +8518,9 @@ void VerifyAtomicsSharedTest(std::shared_ptr<ShaderOpTestResult> test,
 }
 
 void VerifyAtomicsTest(std::shared_ptr<ShaderOpTestResult> test,
-                       size_t maxIdx, size_t bitSize, bool hasGroupShared) {
+                       size_t maxIdx, size_t bitSize) {
   VerifyAtomicsRawTest(test, maxIdx, bitSize);
   VerifyAtomicsTypedTest(test, maxIdx, bitSize);
-  if (hasGroupShared)
-    VerifyAtomicsSharedTest(test, maxIdx, bitSize);
 }
 
 TEST_F(ExecutionTest, AtomicsTest) {
@@ -8544,21 +8542,23 @@ TEST_F(ExecutionTest, AtomicsTest) {
   LogCommentFmt(L"Verifying 32-bit integer atomic operations in compute shader");
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
 
-  VerifyAtomicsTest(test, 32*32, 32, true /* hasGroupShared */);
+  VerifyAtomicsTest(test, 32*32, 32);
+  VerifyAtomicsSharedTest(test, 32*32, 32);
 
   // Test mesh shader if available
   pShaderOp->CS = nullptr;
   if (DoesDeviceSupportMeshShaders(pDevice)) {
     LogCommentFmt(L"Verifying 32-bit integer atomic operations in amp/mesh/pixel shaders");
     test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
-    VerifyAtomicsTest(test, 8*8*8*8 + 64*64, 32, false /* hasGroupShared */);
+    VerifyAtomicsTest(test, 8*8*2 + 8*8*2 + 64*64, 32);
+    VerifyAtomicsSharedTest(test, 8*8*2 + 8*8*2, 32);
   }
 
   // Test Vertex + Pixel shader
   pShaderOp->MS = nullptr;
   LogCommentFmt(L"Verifying 32-bit integer atomic operations in vert/pixel shaders");
   test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
-  VerifyAtomicsTest(test, 64*64+6, 32, false /* hasGroupShared */);
+  VerifyAtomicsTest(test, 64*64+6, 32);
 }
 
 TEST_F(ExecutionTest, Atomics64Test) {
@@ -8603,7 +8603,7 @@ TEST_F(ExecutionTest, Atomics64Test) {
   if (DoesDeviceSupportMeshShaders(pDevice)) {
     LogCommentFmt(L"Verifying 64-bit integer atomic operations on raw buffers in amp/mesh/pixel shader");
     test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
-    VerifyAtomicsRawTest(test, 8*8*8*8 + 64*64, 64);
+    VerifyAtomicsRawTest(test, 8*8*2 + 8*8*2 + 64*64, 64);
   }
 
   // Test Vertex + Pixel shader
@@ -8667,7 +8667,7 @@ TEST_F(ExecutionTest, AtomicsTyped64Test) {
   if (DoesDeviceSupportMeshShaders(pDevice)) {
     LogCommentFmt(L"Verifying 64-bit integer atomic operations on typed resources in amp/mesh/pixel shader");
     test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
-    VerifyAtomicsTypedTest(test, 8*8*8*8 + 64*64, 64);
+    VerifyAtomicsTypedTest(test, 8*8*2 + 8*8*2 + 64*64, 64);
   }
 
   // Test Vertex + Pixel shader
@@ -8729,7 +8729,7 @@ TEST_F(ExecutionTest, AtomicsShared64Test) {
   if (DoesDeviceSupportMeshShaders(pDevice)) {
     LogCommentFmt(L"Verifying 64-bit integer atomic operations on groupshared variables in amp/mesh/pixel shader");
     test = RunShaderOpTestAfterParse(pDevice, m_support, "Atomics", nullptr, ShaderOpSet);
-    VerifyAtomicsSharedTest(test, 8*8*8*8 + 64*64, 64);
+    VerifyAtomicsSharedTest(test, 8*8*2 + 8*8*2, 64);
   }
 }
 
@@ -8757,7 +8757,18 @@ void VerifyAtomicFloatResults(const float *results, size_t maxIdx) {
   }
 }
 
-void VerifyAtomicsFloatTest(std::shared_ptr<ShaderOpTestResult> test, size_t maxIdx, bool hasGroupShared) {
+void VerifyAtomicsFloatSharedTest(std::shared_ptr<ShaderOpTestResult> test, size_t maxIdx) {
+  MappedData Data;
+  const float *pData = nullptr;
+
+  test->Test->GetReadBackData("U4", &Data);
+  pData = (float *)Data.data();
+
+  LogCommentFmt(L"Verifying float cmp/xchg atomic operations on groupshared variables");
+  VerifyAtomicFloatResults(pData, maxIdx);
+}
+
+void VerifyAtomicsFloatTest(std::shared_ptr<ShaderOpTestResult> test, size_t maxIdx) {
 
   // struct mirroring that in the shader
   struct AtomicStuff {
@@ -8795,13 +8806,6 @@ void VerifyAtomicsFloatTest(std::shared_ptr<ShaderOpTestResult> test, size_t max
   LogCommentFmt(L"Verifying float cmp/xchg atomic operations on RWTexture resources");
   VerifyAtomicFloatResults(pData, maxIdx);
 
-  if (hasGroupShared) {
-    test->Test->GetReadBackData("U4", &Data);
-    pData = (float *)Data.data();
-
-    LogCommentFmt(L"Verifying float cmp/xchg atomic operations on groupshared variables");
-    VerifyAtomicFloatResults(pData, maxIdx);
-  }
 }
 
 TEST_F(ExecutionTest, AtomicsFloatTest) {
@@ -8822,21 +8826,23 @@ TEST_F(ExecutionTest, AtomicsFloatTest) {
   // Test compute shader
   LogCommentFmt(L"Verifying float cmp/xchg atomic operations in compute shader");
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "FloatAtomics", nullptr, ShaderOpSet);
-  VerifyAtomicsFloatTest(test, 32*32, true /* hasGroupShared */);
+  VerifyAtomicsFloatTest(test, 32*32);
+  VerifyAtomicsFloatSharedTest(test, 32*32);
 
   // Test mesh shader if available
   pShaderOp->CS = nullptr;
   if (DoesDeviceSupportMeshShaders(pDevice)) {
     LogCommentFmt(L"Verifying float cmp/xchg atomic operations in amp/mesh/pixel shaders");
     test = RunShaderOpTestAfterParse(pDevice, m_support, "FloatAtomics", nullptr, ShaderOpSet);
-    VerifyAtomicsFloatTest(test, 8*8*8*8 + 64*64, false /* hasGroupShared */);
+    VerifyAtomicsFloatTest(test, 8*8*2 + 8*8*2 + 64*64);
+    VerifyAtomicsFloatSharedTest(test, 8*8*2 + 8*8*2);
   }
 
   // Test Vertex + Pixel shader
   pShaderOp->MS = nullptr;
     LogCommentFmt(L"Verifying float cmp/xchg atomic operations in vert/pixel shaders");
   test = RunShaderOpTestAfterParse(pDevice, m_support, "FloatAtomics", nullptr, ShaderOpSet);
-  VerifyAtomicsFloatTest(test, 64*64+6, false /* hasGroupShared */);
+  VerifyAtomicsFloatTest(test, 64*64+6);
 }
 
 #ifndef _HLK_CONF

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -230,7 +230,11 @@ public:
 // Use this structure to refer to a command allocator/list/queue triple.
 struct CommandListRefs {
   CComPtr<ID3D12CommandAllocator> Allocator;
+#if defined(NTDDI_WIN10_VB) && WDK_NTDDI_VERSION >= NTDDI_WIN10_VB
+  CComPtr<ID3D12GraphicsCommandList6> List;
+#else
   CComPtr<ID3D12GraphicsCommandList> List;
+#endif
   CComPtr<ID3D12CommandQueue> Queue;
 
   void CreateForDevice(ID3D12Device *pDevice, bool compute);


### PR DESCRIPTION
The ShaderOpTest code for mesh shaders had a lot of problems. This
corrects the initialization of the pipeline and the dispatch.

In addition, there were various problems with ExecutionTests for atomics
where mesh shaders were used. This adds testing for mesh results that
was being skipped. This required adjustment of the indices.

Also required was proper accumulation of groupshared values between
amplification and mesh shaders.

Various and sundry indexing corrections were also required.