### PR TITLE
Don't create static global for uninited local const

### DIFF
--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -143,9 +143,8 @@ void CodeGenFunction::EmitVarDecl(const VarDecl &D) {
   // HLSL Change Begin - treat local constant as static.
   // Global variable will be generated instead of alloca.
   if (D.getType().isConstQualified() && D.isLocalVarDecl()) {
-    llvm::Constant *Init = CGM.EmitConstantInit(D, this);
     // Only create global when has constant init.
-    if (Init) {
+    if (!isTrivialInitializer(D.getInit()) && CGM.EmitConstantInit(D, this)) {
       llvm::GlobalValue::LinkageTypes Linkage =
           CGM.getLLVMLinkageVarDefinition(&D, /*isConstant=*/false);
       return EmitStaticVarDecl(D, Linkage);

--- a/tools/clang/test/HLSLFileCheck/validation/UndefConst.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/UndefConst.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T ps_6_0 %s | FileCheck %s
+
+// A warning should be produced, but isn't at present
+// CHXXXCK: Instructions should not read uninitialized value
+
+// For now, just check for no crash
+// CHECK: @main
+
+float main() : SV_Target {
+  const float a;
+  return a;
+}


### PR DESCRIPTION
Previously, codegen attempted to skip the alloca creation that would
be encountered below and just emit the constant init. However, the
code in EmitAutoVarDecl() first checks whether the Init is null using
isTrivialInitializer() and just bails if it is.

This adds the isTrivialInitializer() call to the conditions here
since we fallback to the alloca if there is no constant initializer.