### PR TITLE
[spirv] Fix target env error message.

### DIFF
--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -97,7 +97,7 @@ bool FeatureManager::requestTargetEnv(spv_target_env requestedEnv,
                                       SourceLocation srcLoc) {
   if (targetEnv < requestedEnv) {
     emitError("%0 is required for %1 but not permitted to use", srcLoc)
-        << (requestedEnv == SPV_ENV_VULKAN_1_2 ? "Vulkan 1.2" : "Vulkan 1.1")
+        << (requestedEnv > SPV_ENV_VULKAN_1_1 ? "Vulkan 1.2" : "Vulkan 1.1")
         << target;
     emitNote("please specify your target environment via command line option "
              "-fspv-target-env=",

--- a/tools/clang/test/CodeGenSPIRV/raytracing.target-env-error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.target-env-error.hlsl
@@ -1,0 +1,27 @@
+// Run: %dxc -T lib_6_3
+
+// CHECK: error: Vulkan 1.2 is required for Raytracing but not permitted to use
+
+struct Payload {
+  float4 color;
+};
+struct CallData {
+  float4 data;
+};
+struct Attribute {
+  float2 bary;
+};
+
+RaytracingAccelerationStructure rs;
+[shader("closesthit")]
+void main(inout Payload MyPayload, in Attribute MyAttr) {
+  Payload myPayload = { float4(0.0f,0.0f,0.0f,0.0f) };
+  CallData myCallData = { float4(0.0f,0.0f,0.0f,0.0f) };
+  RayDesc rayDesc;
+  rayDesc.Origin = float3(0.0f, 0.0f, 0.0f);
+  rayDesc.Direction = float3(0.0f, 0.0f, -1.0f);
+  rayDesc.TMin = 0.0f;
+  rayDesc.TMax = 1000.0f;
+  TraceRay(rs, 0x0, 0xff, 0, 1, 0, rayDesc, myPayload);
+  CallShader(0, myCallData);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2269,6 +2269,10 @@ TEST_F(FileTest, RayTracingTerminate) {
   runFileTest("raytracing.khr.terminate.hlsl");
 }
 
+TEST_F(FileTest, RayTracingTargetEnvErro) {
+  runFileTest("raytracing.target-env-error.hlsl", Expect::Failure);
+}
+
 // For decoration uniqueness
 TEST_F(FileTest, DecorationUnique) { runFileTest("decoration.unique.hlsl"); }
 


### PR DESCRIPTION
In absence of any extensions, ray tracing is only available on Vulkan 1.2 and later.

Without `-fspv-target-env`, dxc was incorrectly printing a message that "Vulkan 1.1 was required", where in fact Vulkan 1.2 is required.