### PR TITLE
[spirv] Don't apply RelaxedPrecision to ops operating on bools

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -343,6 +343,10 @@ bool isStructureContainingMixOfResourcesAndNonResources(QualType type);
 /// (RW|Append|Consume)StructuredBuffer.
 bool isStructureContainingAnyKindOfBuffer(QualType type);
 
+/// Returns true if the given type is a scalar, vector, or matrix of numeric
+/// types, or it's an array of scalar, vector, or matrix of numeric types.
+bool isScalarOrNonStructAggregateOfNumericalTypes(QualType type);
+
 } // namespace spirv
 } // namespace clang
 

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1355,5 +1355,22 @@ bool isStructureContainingAnyKindOfBuffer(QualType type) {
   return false;
 }
 
+bool isScalarOrNonStructAggregateOfNumericalTypes(QualType type) {
+  // Remove arrayness if present.
+  while (type->isArrayType())
+    type = type->getAsArrayTypeUnsafe()->getElementType();
+
+  QualType elemType = {};
+  if (isScalarType(type, &elemType) || isVectorType(type, &elemType) ||
+      isMxNMatrix(type, &elemType)) {
+    // Return true if the basic elemen type is a float or non-boolean integer
+    // type.
+    return elemType->isFloatingType() ||
+           (elemType->isIntegerType() && !elemType->isBooleanType());
+  }
+
+  return false;
+}
+
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/RelaxedPrecisionVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RelaxedPrecisionVisitor.cpp
@@ -71,34 +71,50 @@ bool RelaxedPrecisionVisitor::visit(SpirvUnaryOp *inst) {
   }
 
   // If the argument of the unary operation is RelaxedPrecision, the result is
-  // also RelaxedPrecision.
-  if (inst->getOperand()->isRelaxedPrecision())
+  // also RelaxedPrecision, unless the unary operation is not operating on
+  // numerical values.
+  if (inst->getOperand()->isRelaxedPrecision() &&
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand()->getAstResultType()))
     inst->setRelaxedPrecision();
   return true;
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvBinaryOp *inst) {
   // If either argument of the binary operation is RelaxedPrecision, the result
-  // is also RelaxedPrecision.
+  // is also RelaxedPrecision, unless the instruction is not operating on
+  // numerical values.
   if (inst->getOperand1()->isRelaxedPrecision() &&
-      inst->getOperand2()->isRelaxedPrecision())
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand1()->getAstResultType()) &&
+      inst->getOperand2()->isRelaxedPrecision() &&
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand2()->getAstResultType()))
     inst->setRelaxedPrecision();
   return true;
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvSpecConstantUnaryOp *inst) {
   // If the argument of the unary operation is RelaxedPrecision, the result is
-  // also RelaxedPrecision.
-  if (inst->getOperand()->isRelaxedPrecision())
+  // also RelaxedPrecision, unless the unary operation is not operating on
+  // numerical values.
+  if (inst->getOperand()->isRelaxedPrecision() &&
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand()->getAstResultType()))
     inst->setRelaxedPrecision();
   return true;
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvSpecConstantBinaryOp *inst) {
   // If either argument of the binary operation is RelaxedPrecision, the result
-  // is also RelaxedPrecision.
+  // is also RelaxedPrecision, unless the instruction is not operating on
+  // numerical values.
   if (inst->getOperand1()->isRelaxedPrecision() &&
-      inst->getOperand2()->isRelaxedPrecision())
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand1()->getAstResultType()) &&
+      inst->getOperand2()->isRelaxedPrecision() &&
+      isScalarOrNonStructAggregateOfNumericalTypes(
+          inst->getOperand2()->getAstResultType()))
     inst->setRelaxedPrecision();
   return true;
 }

--- a/tools/clang/lib/SPIRV/RelaxedPrecisionVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RelaxedPrecisionVisitor.cpp
@@ -70,9 +70,9 @@ bool RelaxedPrecisionVisitor::visit(SpirvUnaryOp *inst) {
     break;
   }
 
-  // If the argument of the unary operation is RelaxedPrecision, the result is
-  // also RelaxedPrecision, unless the unary operation is not operating on
-  // numerical values.
+  // If the argument of the unary operation is RelaxedPrecision and the unary
+  // operation is operating on numerical values, the result is also
+  // RelaxedPrecision.
   if (inst->getOperand()->isRelaxedPrecision() &&
       isScalarOrNonStructAggregateOfNumericalTypes(
           inst->getOperand()->getAstResultType()))
@@ -81,9 +81,9 @@ bool RelaxedPrecisionVisitor::visit(SpirvUnaryOp *inst) {
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvBinaryOp *inst) {
-  // If either argument of the binary operation is RelaxedPrecision, the result
-  // is also RelaxedPrecision, unless the instruction is not operating on
-  // numerical values.
+  // If either argument of the binary operation is RelaxedPrecision, and the
+  // binary operation is operating on numerical values, the result is also
+  // RelaxedPrecision.
   if (inst->getOperand1()->isRelaxedPrecision() &&
       isScalarOrNonStructAggregateOfNumericalTypes(
           inst->getOperand1()->getAstResultType()) &&
@@ -95,9 +95,9 @@ bool RelaxedPrecisionVisitor::visit(SpirvBinaryOp *inst) {
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvSpecConstantUnaryOp *inst) {
-  // If the argument of the unary operation is RelaxedPrecision, the result is
-  // also RelaxedPrecision, unless the unary operation is not operating on
-  // numerical values.
+  // If the argument of the unary operation is RelaxedPrecision and the unary
+  // operation is operating on numerical values, the result is also
+  // RelaxedPrecision.
   if (inst->getOperand()->isRelaxedPrecision() &&
       isScalarOrNonStructAggregateOfNumericalTypes(
           inst->getOperand()->getAstResultType()))
@@ -106,9 +106,9 @@ bool RelaxedPrecisionVisitor::visit(SpirvSpecConstantUnaryOp *inst) {
 }
 
 bool RelaxedPrecisionVisitor::visit(SpirvSpecConstantBinaryOp *inst) {
-  // If either argument of the binary operation is RelaxedPrecision, the result
-  // is also RelaxedPrecision, unless the instruction is not operating on
-  // numerical values.
+  // If either argument of the binary operation is RelaxedPrecision, and the
+  // binary operation is operating on numerical values, the result is also
+  // RelaxedPrecision.
   if (inst->getOperand1()->isRelaxedPrecision() &&
       isScalarOrNonStructAggregateOfNumericalTypes(
           inst->getOperand1()->getAstResultType()) &&

--- a/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
@@ -1,0 +1,33 @@
+// Run: %dxc -T cs_6_0 -E main
+
+// According to the SPIR-V spec (2.14. Relaxed Precision):
+// The RelaxedPrecision decoration can be applied to:
+// The Result <id> of an instruction that operates on numerical types, meaning
+// the instruction is to operate at relaxed precision. The instruction's
+// operands may also be truncated to the relaxed precision.
+//
+// In this example, (a > 0.0) comparison is operating on floats with relaxed
+// precision, and should therefore have the decoration. However, the "any"
+// intrinsic function is operating on a vector of booleans, and it should not
+// be decorated.
+
+// CHECK:     OpDecorate %a RelaxedPrecision
+// CHECK:     OpDecorate [[a:%\d+]] RelaxedPrecision
+// CHECK:     OpDecorate [[compare_op:%\d+]] RelaxedPrecision
+//
+// We should NOT have a decoration for the 'any' operation.
+//
+// CHECK-NOT: OpDecorate {{%\d+}} RelaxedPrecision
+
+// CHECK:           [[a]] = OpLoad %v2float %a
+// CHECK:  [[compare_op]] = OpFOrdGreaterThan %v2bool [[a]] {{%\d+}}
+// CHECK: [[any_op:%\d+]] = OpAny %bool [[compare_op]]
+
+RWBuffer<float2> Buf;
+
+[numthreads(1, 1, 1)]
+void main() {
+  min16float2 a = Buf[0];
+  if (any(a > 0.0))
+    Buf[0] = 1;
+}

--- a/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
@@ -12,22 +12,33 @@
 // be decorated.
 
 // CHECK:     OpDecorate %a RelaxedPrecision
+// CHECK:     OpDecorate %b RelaxedPrecision
 // CHECK:     OpDecorate [[a:%\d+]] RelaxedPrecision
 // CHECK:     OpDecorate [[compare_op:%\d+]] RelaxedPrecision
+// CHECK:     OpDecorate [[b:%\d+]] RelaxedPrecision
+// CHECK:     OpDecorate [[compare_op_2:%\d+]] RelaxedPrecision
 //
 // We should NOT have a decoration for the 'any' operation.
+// We should NOT have a decoration for the '||' operation.
 //
 // CHECK-NOT: OpDecorate {{%\d+}} RelaxedPrecision
 
-// CHECK:           [[a]] = OpLoad %v2float %a
-// CHECK:  [[compare_op]] = OpFOrdGreaterThan %v2bool [[a]] {{%\d+}}
-// CHECK: [[any_op:%\d+]] = OpAny %bool [[compare_op]]
+// CHECK:            [[a]] = OpLoad %float %a
+// CHECK:   [[compare_op]] = OpFOrdGreaterThan %bool [[a]] %float_0
+// CHECK:            [[b]] = OpLoad %v2float %b
+// CHECK: [[compare_op_2]] = OpFOrdGreaterThan %v2bool [[b]] {{%\d+}}
+// CHECK:  [[any_op:%\d+]] = OpAny %bool %26
+// CHECK:   [[or_op:%\d+]] = OpLogicalOr %bool
 
 RWBuffer<float2> Buf;
 
 [numthreads(1, 1, 1)]
 void main() {
-  min16float2 a = Buf[0];
-  if (any(a > 0.0))
-    Buf[0] = 1;
+  // Scalar
+  min16float a;
+
+  // Vector
+  min16float2 b;
+
+  bool x = (a > 0.0) || any(b > 0.0);
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2288,6 +2288,9 @@ TEST_F(FileTest, DecorationRelaxedPrecisionStruct) {
 TEST_F(FileTest, DecorationRelaxedPrecisionImage) {
   runFileTest("decoration.relaxed-precision.image.hlsl");
 }
+TEST_F(FileTest, DecorationRelaxedPrecisionBool) {
+  runFileTest("decoration.relaxed-precision.bool.hlsl");
+}
 
 // For NoContraction decorations
 TEST_F(FileTest, DecorationNoContraction) {


### PR DESCRIPTION
Fixed #3358 