### PR TITLE
[spirv] Fix failure caused by multiplying size() and int

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -441,6 +441,8 @@ uint32_t getElementSpirvBitwidth(const ASTContext &astContext, QualType type,
     case BuiltinType::Int8_4Packed:
     case BuiltinType::UInt8_4Packed:
     case BuiltinType::Float:
+    case BuiltinType::Long:
+    case BuiltinType::ULong:
       return 32;
     case BuiltinType::Double:
     case BuiltinType::LongLong:

--- a/tools/clang/test/CodeGenSPIRV/op.sizeof.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.sizeof.hlsl
@@ -45,4 +45,10 @@ void main() {
     struct {} _; // Zero-sized field.
   } complexStruct;
   buf.Append(sizeof(complexStruct));
+
+// CHECK:         [[foo:%\d+]] = OpLoad %int %foo
+// CHECK-NEXT: [[ui_foo:%\d+]] = OpBitcast %uint [[foo]]
+// CHECK-NEXT:                   OpIMul %uint %uint_4 [[ui_foo]]
+  int foo;
+  buf.Append(sizeof(float) * foo);
 }


### PR DESCRIPTION
The code `int foo; .. size(float) * foo` causes failure because
`getElementSpirvBitwidth()` in AstTypeProbe.cpp does not handle the type
of `sizeof()` which is the "unsigned long" type. This commit handles it.

Fixes #2814