### PR TITLE
silence sign warning on some systems

### DIFF
--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1113,7 +1113,7 @@ static void VerifyPdbUtil(dxc::DxcDllSupport &dllSupport,
       tally[std::wstring(def)]++;
     }
     auto Expected = ExpectedDefines;
-    for (int i = 0; i < Expected.size(); i++) {
+    for (size_t i = 0; i < Expected.size(); i++) {
       auto it = tally.find(Expected[i]);
       VERIFY_IS_TRUE(it != tally.end() && it->second == 1);
       tally.erase(it);


### PR DESCRIPTION
A recent change produces a warning, which is sometimes interpretted as
an error, causing builds to fail