### PR TITLE
[spirv] Add vk::image_format attribute for Buffers, RWBuffers and RWTextures

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -786,6 +786,73 @@ are translated into SPIR-V ``OpTypeImage``, with parameters:
 The meanings of the headers in the above table is explained in ``OpTypeImage``
 of the SPIR-V spec.
 
+Vulkan specific Image Formats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since HLSL lacks the syntax for fully specifying image formats for textures in
+SPIR-V, we introduce ``[[vk::image_format("FORMAT")]]`` attribute for texture types.
+For example,
+
+.. code:: hlsl
+  [[vk::image_format("rgba8")]]
+  RWBuffer<float4> Buf;
+
+  [[vk::image_format("rg16f")]]
+  RWTexture2D<float2> Tex;
+
+  RWTexture2D<float2> Tex2; // Works like before
+
+``rgba8`` means ``Rgba8`` `SPIR-V Image Format <https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_image_format_a_image_format>`_.
+The following table lists the mapping between ``FORMAT`` of
+``[[vk::image_format("FORMAT")]]`` and its corresponding SPIR-V Image Format.
+
+======================= ============================================
+       FORMAT                   SPIR-V Image Format
+======================= ============================================
+``unknown``             ``Unknown``
+``rgba32f``             ``Rgba32f``
+``rgba16f``             ``Rgba16f``
+``r32f``                ``R32f``
+``rgba8``               ``Rgba8``
+``rgba8snorm``          ``Rgba8Snorm``
+``rg32f``               ``Rg32f``
+``rg16f``               ``Rg16f``
+``r11g11b10f``          ``R11fG11fB10f``
+``r16f``                ``R16f``
+``rgba16``              ``Rgba16``
+``rgb10a2``             ``Rgb10A2``
+``rg16``                ``Rg16``
+``rg8``                 ``Rg8``
+``r16``                 ``R16``
+``r8``                  ``R8``
+``rgba16snorm``         ``Rgba16Snorm``
+``rg16snorm``           ``Rg16Snorm``
+``rg8snorm``            ``Rg8Snorm``
+``r16snorm``            ``R16Snorm``
+``r8snorm``             ``R8Snorm``
+``rgba32i``             ``Rgba32i``
+``rgba16i``             ``Rgba16i``
+``rgba8i``              ``Rgba8i``
+``r32i``                ``R32i``
+``rg32i``               ``Rg32i``
+``rg16i``               ``Rg16i``
+``rg8i``                ``Rg8i``
+``r16i``                ``R16i``
+``r8i``                 ``R8i``
+``rgba32ui``            ``Rgba32ui``
+``rgba16ui``            ``Rgba16ui``
+``rgba8ui``             ``Rgba8ui``
+``r32ui``               ``R32ui``
+``rgb10a2ui``           ``Rgb10a2ui``
+``rg32ui``              ``Rg32ui``
+``rg16ui``              ``Rg16ui``
+``rg8ui``               ``Rg8ui``
+``r16ui``               ``R16ui``
+``r8ui``                ``R8ui``
+``r64ui``               ``R64ui``
+``r64i``                ``R64i``
+======================= ============================================
+
 Constant/Texture/Structured/Byte Buffers
 ----------------------------------------
 

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1028,20 +1028,20 @@ def VKImageFormat : InheritableAttr {
   let Subjects = SubjectList<[RWTexture, Buffer],
                              ErrorDiag, "ExpectedRWTextureOrBuffer">;
   let Args = [EnumArgument<"ImageFormat", "ImageFormatType",
-                           ["Unknown", "Rgba32f", "Rgba16f", "R32f", "Rgba8", "Rgba8Snorm",
-                           "Rg32f", "Rg16f", "R11fG11fB10f", "R16f", "Rgba16", "Rgb10A2",
-                           "Rg16", "Rg8", "R16", "R8", "Rgba16Snorm", "Rg16Snorm", "Rg8Snorm",
-                           "R16Snorm", "R8Snorm", "Rgba32i", "Rgba16i", "Rgba8i", "R32i",
-                           "Rg32i", "Rg16i", "Rg8i", "R16i", "R8i", "Rgba32ui", "Rgba16ui", "Rgba8ui",
-                           "R32ui", "Rgb10a2ui", "Rg32ui", "Rg16ui", "Rg8ui", "R16ui",
-                           "R8ui", "R64ui", "R64i"],
-                           ["Unknown", "Rgba32f", "Rgba16f", "R32f", "Rgba8", "Rgba8Snorm",
-                           "Rg32f", "Rg16f", "R11fG11fB10f", "R16f", "Rgba16", "Rgb10A2",
-                           "Rg16", "Rg8", "R16", "R8", "Rgba16Snorm", "Rg16Snorm", "Rg8Snorm",
-                           "R16Snorm", "R8Snorm", "Rgba32i", "Rgba16i", "Rgba8i", "R32i",
-                           "Rg32i", "Rg16i", "Rg8i", "R16i", "R8i", "Rgba32ui", "Rgba16ui", "Rgba8ui",
-                           "R32ui", "Rgb10a2ui", "Rg32ui", "Rg16ui", "Rg8ui", "R16ui",
-                           "R8ui", "R64ui", "R64i"]>];
+                           ["unknown", "rgba32f", "rgba16f", "r32f", "rgba8", "rgba8snorm",
+                           "rg32f", "rg16f", "r11g11b10f", "r16f", "rgba16", "rgb10a2",
+                           "rg16", "rg8", "r16", "r8", "rgba16snorm", "rg16snorm", "rg8snorm",
+                           "r16snorm", "r8snorm", "rgba32i", "rgba16i", "rgba8i", "r32i",
+                           "rg32i", "rg16i", "rg8i", "r16i", "r8i", "rgba32ui", "rgba16ui", "rgba8ui",
+                           "r32ui", "rgb10a2ui", "rg32ui", "rg16ui", "rg8ui", "r16ui",
+                           "r8ui", "r64ui", "r64i"],
+                           ["unknown", "rgba32f", "rgba16f", "r32f", "rgba8", "rgba8snorm",
+                           "rg32f", "rg16f", "r11g11b10f", "r16f", "rgba16", "rgb10a2",
+                           "rg16", "rg8", "r16", "r8", "rgba16snorm", "rg16snorm", "rg8snorm",
+                           "r16snorm", "r8snorm", "rgba32i", "rgba16i", "rgba8i", "r32i",
+                           "rg32i", "rg16i", "rg8i", "r16i", "r8i", "rgba32ui", "rgba16ui", "rgba8ui",
+                           "r32ui", "rgb10a2ui", "rg32ui", "rg16ui", "rg8ui", "r16ui",
+                           "r8ui", "r64ui", "r64i"]>];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -937,6 +937,32 @@ def ConstantTextureBuffer
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "TextureBuffer")}]>;
 
+// Global variable with "RWTexture" type
+def RWTexture
+    : SubsetSubject<
+          Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
+                 S->getType()->getAs<RecordType>()->getDecl() &&
+                  (S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWTexture1D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWTexture1DArray" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWTexture2D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWTexture2DArray" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWTexture3D")}]>;
+
+// Global variable with "[RW]Buffer" type
+def Buffer
+    : SubsetSubject<
+          Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
+                 S->getType()->getAs<RecordType>()->getDecl() &&
+                 (S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "Buffer" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RWBuffer")}]>;
+
 def VKBuiltIn : InheritableAttr {
   let Spellings = [CXX11<"vk", "builtin">];
   let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;
@@ -993,6 +1019,29 @@ def VKOffset : InheritableAttr {
   let Spellings = [CXX11<"vk", "offset">];
   let Subjects = SubjectList<[Field], ErrorDiag, "ExpectedField">;
   let Args = [IntArgument<"Offset">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+def VKImageFormat : InheritableAttr {
+  let Spellings = [CXX11<"vk", "image_format">];
+  let Subjects = SubjectList<[RWTexture, Buffer],
+                             ErrorDiag, "ExpectedRWTextureOrBuffer">;
+  let Args = [EnumArgument<"ImageFormat", "ImageFormatType",
+                           ["Unknown", "Rgba32f", "Rgba16f", "R32f", "Rgba8", "Rgba8Snorm",
+                           "Rg32f", "Rg16f", "R11fG11fB10f", "R16f", "Rgba16", "Rgb10A2",
+                           "Rg16", "Rg8", "R16", "R8", "Rgba16Snorm", "Rg16Snorm", "Rg8Snorm",
+                           "R16Snorm", "R8Snorm", "Rgba32i", "Rgba16i", "Rgba8i", "R32i",
+                           "Rg32i", "Rg16i", "Rg8i", "R16i", "R8i", "Rgba32ui", "Rgba16ui", "Rgba8ui",
+                           "R32ui", "Rgb10a2ui", "Rg32ui", "Rg16ui", "Rg8ui", "R16ui",
+                           "R8ui", "R64ui", "R64i"],
+                           ["Unknown", "Rgba32f", "Rgba16f", "R32f", "Rgba8", "Rgba8Snorm",
+                           "Rg32f", "Rg16f", "R11fG11fB10f", "R16f", "Rgba16", "Rgb10A2",
+                           "Rg16", "Rg8", "R16", "R8", "Rgba16Snorm", "Rg16Snorm", "Rg8Snorm",
+                           "R16Snorm", "R8Snorm", "Rgba32i", "Rgba16i", "Rgba8i", "R32i",
+                           "Rg32i", "Rg16i", "Rg8i", "R16i", "R8i", "Rgba32ui", "Rgba16ui", "Rgba8ui",
+                           "R32ui", "Rgb10a2ui", "Rg32ui", "Rg16ui", "Rg8ui", "R16ui",
+                           "R8ui", "R64ui", "R64i"]>];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2332,6 +2332,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
+  "RWTextures, Buffers and RWBuffers"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"
   "cbuffer or ConstantBuffer|"

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2332,7 +2332,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
-  "RWTextures, Buffers and RWBuffers"
+  "RWTextures, Buffers and RWBuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"
   "cbuffer or ConstantBuffer|"

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -235,6 +235,10 @@ public:
                                 ImageType::WithDepth, bool arrayed, bool ms,
                                 ImageType::WithSampler sampled,
                                 spv::ImageFormat);
+  // Get ImageType whose attributes are the same with imageTypeWithUnknownFormat
+  // but it has spv::ImageFormat format.
+  const ImageType *getImageType(const ImageType *imageTypeWithUnknownFormat,
+                                spv::ImageFormat format);
   const SamplerType *getSamplerType() const { return samplerType; }
   const SampledImageType *getSampledImageType(const ImageType *image);
   const HybridSampledImageType *getSampledImageType(QualType image);
@@ -333,6 +337,20 @@ public:
   /// class instance entered.
   SpirvDebugInstruction *getCurrentLexicalScope() {
     return currentLexicalScope;
+  }
+
+  /// Function to add/get the mapping from a SPIR-V OpVariable to its image
+  /// format.
+  void registerImageFormatForSpirvVariable(const SpirvVariable *spvVar,
+                                           spv::ImageFormat format) {
+    assert(spvVar != nullptr);
+    spvVarToImageFormat[spvVar] = format;
+  }
+  spv::ImageFormat getImageFormatForSpirvVariable(const SpirvVariable *spvVar) {
+    auto itr = spvVarToImageFormat.find(spvVar);
+    if (itr == spvVarToImageFormat.end())
+      return spv::ImageFormat::Unknown;
+    return itr->second;
   }
 
   /// Function to add/get the mapping from a SPIR-V type to its Decl for
@@ -442,6 +460,9 @@ private:
   // Mapping from FunctionDecl to SPIR-V debug function.
   llvm::DenseMap<const FunctionDecl *, SpirvDebugFunction *>
       declToDebugFunction;
+
+  // Mapping from SPIR-V OpVariable to SPIR-V image format.
+  llvm::DenseMap<const SpirvVariable *, spv::ImageFormat> spvVarToImageFormat;
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -192,9 +192,6 @@ public:
   void setStorageClass(spv::StorageClass sc) { storageClass = sc; }
   spv::StorageClass getStorageClass() const { return storageClass; }
 
-  void setImageFormat(spv::ImageFormat format) { imageFormat = format; }
-  spv::ImageFormat getImageFormat() const { return imageFormat; }
-
   void setRValue(bool rvalue = true) { isRValue_ = rvalue; }
   bool isRValue() const { return isRValue_; }
 
@@ -244,7 +241,6 @@ protected:
   bool containsAlias;
 
   spv::StorageClass storageClass;
-  spv::ImageFormat imageFormat;
   bool isRValue_;
   bool isRelaxedPrecision_;
   bool isNonUniform_;

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -192,6 +192,9 @@ public:
   void setStorageClass(spv::StorageClass sc) { storageClass = sc; }
   spv::StorageClass getStorageClass() const { return storageClass; }
 
+  void setImageFormat(spv::ImageFormat format) { imageFormat = format; }
+  spv::ImageFormat getImageFormat() const { return imageFormat; }
+
   void setRValue(bool rvalue = true) { isRValue_ = rvalue; }
   bool isRValue() const { return isRValue_; }
 
@@ -241,6 +244,7 @@ protected:
   bool containsAlias;
 
   spv::StorageClass storageClass;
+  spv::ImageFormat imageFormat;
   bool isRValue_;
   bool isRelaxedPrecision_;
   bool isNonUniform_;

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -860,6 +860,7 @@ enum AttributeDeclKind {
   ,ExpectedScalarGlobalVar
   ,ExpectedStructGlobalVar
   ,ExpectedGlobalVarOrCTBuffer
+  ,ExpectedRWTextureOrBuffer
   ,ExpectedCounterStructuredBuffer
   ,ExpectedSubpassInput
   ,ExpectedCTBuffer

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -854,19 +854,19 @@ enum AttributeDeclKind {
   ExpectedStructOrUnionOrTypedef,
   ExpectedStructOrTypedef,
   ExpectedObjectiveCInterfaceOrProtocol,
-  ExpectedKernelFunction
+  ExpectedKernelFunction,
   // SPIRV Change Begins
-  ,ExpectedField
-  ,ExpectedScalarGlobalVar
-  ,ExpectedStructGlobalVar
-  ,ExpectedGlobalVarOrCTBuffer
-  ,ExpectedRWTextureOrBuffer
-  ,ExpectedCounterStructuredBuffer
-  ,ExpectedSubpassInput
-  ,ExpectedCTBuffer
+  ExpectedField,
+  ExpectedScalarGlobalVar,
+  ExpectedStructGlobalVar,
+  ExpectedGlobalVarOrCTBuffer,
+  ExpectedRWTextureOrBuffer,
+  ExpectedCounterStructuredBuffer,
+  ExpectedSubpassInput,
+  ExpectedCTBuffer,
   // SPIRV Change Ends
   // HLSL Change Begins - add attribute decl combinations
-  ,ExpectedVariableOrParam,
+  ExpectedVariableOrParam,
   ExpectedFunctionOrParamOrField,
   ExpectedFunctionOrVariableOrParamOrFieldOrType
   // HLSL Change Ends

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -398,6 +398,144 @@ SpirvLayoutRule getLayoutRuleForExternVar(QualType type,
   return SpirvLayoutRule::Void;
 }
 
+void handleImageFormat(const VarDecl *var, SpirvVariable *varInstr) {
+  const auto *imageFormatAttr = var->getAttr<VKImageFormatAttr>();
+  if (imageFormatAttr) {
+    const VKImageFormatAttr::ImageFormatType format =
+        imageFormatAttr->getImageFormat();
+    spv::ImageFormat spvFormat;
+    switch (format) {
+    case VKImageFormatAttr::Unknown:
+      spvFormat = spv::ImageFormat::Unknown;
+      break;
+    case VKImageFormatAttr::Rgba32f:
+      spvFormat = spv::ImageFormat::Rgba32f;
+      break;
+    case VKImageFormatAttr::Rgba16f:
+      spvFormat = spv::ImageFormat::Rgba16f;
+      break;
+    case VKImageFormatAttr::R32f:
+      spvFormat = spv::ImageFormat::R32f;
+      break;
+    case VKImageFormatAttr::Rgba8:
+      spvFormat = spv::ImageFormat::Rgba8;
+      break;
+    case VKImageFormatAttr::Rgba8Snorm:
+      spvFormat = spv::ImageFormat::Rgba8Snorm;
+      break;
+    case VKImageFormatAttr::Rg32f:
+      spvFormat = spv::ImageFormat::Rg32f;
+      break;
+    case VKImageFormatAttr::Rg16f:
+      spvFormat = spv::ImageFormat::Rg16f;
+      break;
+    case VKImageFormatAttr::R11fG11fB10f:
+      spvFormat = spv::ImageFormat::R11fG11fB10f;
+      break;
+    case VKImageFormatAttr::R16f:
+      spvFormat = spv::ImageFormat::R16f;
+      break;
+    case VKImageFormatAttr::Rgba16:
+      spvFormat = spv::ImageFormat::Rgba16;
+      break;
+    case VKImageFormatAttr::Rgb10A2:
+      spvFormat = spv::ImageFormat::Rgb10A2;
+      break;
+    case VKImageFormatAttr::Rg16:
+      spvFormat = spv::ImageFormat::Rg16;
+      break;
+    case VKImageFormatAttr::Rg8:
+      spvFormat = spv::ImageFormat::Rg8;
+      break;
+    case VKImageFormatAttr::R16:
+      spvFormat = spv::ImageFormat::R16;
+      break;
+    case VKImageFormatAttr::R8:
+      spvFormat = spv::ImageFormat::R8;
+      break;
+    case VKImageFormatAttr::Rgba16Snorm:
+      spvFormat = spv::ImageFormat::Rgba16Snorm;
+      break;
+    case VKImageFormatAttr::Rg16Snorm:
+      spvFormat = spv::ImageFormat::Rg16Snorm;
+      break;
+    case VKImageFormatAttr::Rg8Snorm:
+      spvFormat = spv::ImageFormat::Rg8Snorm;
+      break;
+    case VKImageFormatAttr::R16Snorm:
+      spvFormat = spv::ImageFormat::R16Snorm;
+      break;
+    case VKImageFormatAttr::R8Snorm:
+      spvFormat = spv::ImageFormat::R8Snorm;
+      break;
+    case VKImageFormatAttr::Rgba32i:
+      spvFormat = spv::ImageFormat::Rgba32i;
+      break;
+    case VKImageFormatAttr::Rgba16i:
+      spvFormat = spv::ImageFormat::Rgba16i;
+      break;
+    case VKImageFormatAttr::Rgba8i:
+      spvFormat = spv::ImageFormat::Rgba8i;
+      break;
+    case VKImageFormatAttr::R32i:
+      spvFormat = spv::ImageFormat::R32i;
+      break;
+    case VKImageFormatAttr::Rg32i:
+      spvFormat = spv::ImageFormat::Rg32i;
+      break;
+    case VKImageFormatAttr::Rg16i:
+      spvFormat = spv::ImageFormat::Rg16i;
+      break;
+    case VKImageFormatAttr::Rg8i:
+      spvFormat = spv::ImageFormat::Rg8i;
+      break;
+    case VKImageFormatAttr::R16i:
+      spvFormat = spv::ImageFormat::R16i;
+      break;
+    case VKImageFormatAttr::R8i:
+      spvFormat = spv::ImageFormat::R8i;
+      break;
+    case VKImageFormatAttr::Rgba32ui:
+      spvFormat = spv::ImageFormat::Rgba32ui;
+      break;
+    case VKImageFormatAttr::Rgba16ui:
+      spvFormat = spv::ImageFormat::Rgba16ui;
+      break;
+    case VKImageFormatAttr::Rgba8ui:
+      spvFormat = spv::ImageFormat::Rgba8ui;
+      break;
+    case VKImageFormatAttr::R32ui:
+      spvFormat = spv::ImageFormat::R32ui;
+      break;
+    case VKImageFormatAttr::Rgb10a2ui:
+      spvFormat = spv::ImageFormat::Rgb10a2ui;
+      break;
+    case VKImageFormatAttr::Rg32ui:
+      spvFormat = spv::ImageFormat::Rg32ui;
+      break;
+    case VKImageFormatAttr::Rg16ui:
+      spvFormat = spv::ImageFormat::Rg16ui;
+      break;
+    case VKImageFormatAttr::Rg8ui:
+      spvFormat = spv::ImageFormat::Rg8ui;
+      break;
+    case VKImageFormatAttr::R16ui:
+      spvFormat = spv::ImageFormat::R16ui;
+      break;
+    case VKImageFormatAttr::R8ui:
+      spvFormat = spv::ImageFormat::R8ui;
+      break;
+    case VKImageFormatAttr::R64ui:
+      spvFormat = spv::ImageFormat::R64ui;
+      break;
+    case VKImageFormatAttr::R64i:
+      spvFormat = spv::ImageFormat::R64i;
+      break;
+    }
+    varInstr->setImageFormat(spvFormat);
+  }
+}
+
 } // anonymous namespace
 
 std::string StageVar::getSemanticStr() const {
@@ -847,6 +985,8 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
       type, storageClass, var->hasAttr<HLSLPreciseAttr>(), name, llvm::None,
       loc);
   varInstr->setLayoutRule(rule);
+  handleImageFormat(var, varInstr);
+
   DeclSpirvInfo info(varInstr);
   astDecls[var] = info;
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -405,130 +405,130 @@ void handleImageFormat(const VarDecl *var, SpirvVariable *varInstr) {
         imageFormatAttr->getImageFormat();
     spv::ImageFormat spvFormat;
     switch (format) {
-    case VKImageFormatAttr::Unknown:
+    case VKImageFormatAttr::unknown:
       spvFormat = spv::ImageFormat::Unknown;
       break;
-    case VKImageFormatAttr::Rgba32f:
+    case VKImageFormatAttr::rgba32f:
       spvFormat = spv::ImageFormat::Rgba32f;
       break;
-    case VKImageFormatAttr::Rgba16f:
+    case VKImageFormatAttr::rgba16f:
       spvFormat = spv::ImageFormat::Rgba16f;
       break;
-    case VKImageFormatAttr::R32f:
+    case VKImageFormatAttr::r32f:
       spvFormat = spv::ImageFormat::R32f;
       break;
-    case VKImageFormatAttr::Rgba8:
+    case VKImageFormatAttr::rgba8:
       spvFormat = spv::ImageFormat::Rgba8;
       break;
-    case VKImageFormatAttr::Rgba8Snorm:
+    case VKImageFormatAttr::rgba8snorm:
       spvFormat = spv::ImageFormat::Rgba8Snorm;
       break;
-    case VKImageFormatAttr::Rg32f:
+    case VKImageFormatAttr::rg32f:
       spvFormat = spv::ImageFormat::Rg32f;
       break;
-    case VKImageFormatAttr::Rg16f:
+    case VKImageFormatAttr::rg16f:
       spvFormat = spv::ImageFormat::Rg16f;
       break;
-    case VKImageFormatAttr::R11fG11fB10f:
+    case VKImageFormatAttr::r11g11b10f:
       spvFormat = spv::ImageFormat::R11fG11fB10f;
       break;
-    case VKImageFormatAttr::R16f:
+    case VKImageFormatAttr::r16f:
       spvFormat = spv::ImageFormat::R16f;
       break;
-    case VKImageFormatAttr::Rgba16:
+    case VKImageFormatAttr::rgba16:
       spvFormat = spv::ImageFormat::Rgba16;
       break;
-    case VKImageFormatAttr::Rgb10A2:
+    case VKImageFormatAttr::rgb10a2:
       spvFormat = spv::ImageFormat::Rgb10A2;
       break;
-    case VKImageFormatAttr::Rg16:
+    case VKImageFormatAttr::rg16:
       spvFormat = spv::ImageFormat::Rg16;
       break;
-    case VKImageFormatAttr::Rg8:
+    case VKImageFormatAttr::rg8:
       spvFormat = spv::ImageFormat::Rg8;
       break;
-    case VKImageFormatAttr::R16:
+    case VKImageFormatAttr::r16:
       spvFormat = spv::ImageFormat::R16;
       break;
-    case VKImageFormatAttr::R8:
+    case VKImageFormatAttr::r8:
       spvFormat = spv::ImageFormat::R8;
       break;
-    case VKImageFormatAttr::Rgba16Snorm:
+    case VKImageFormatAttr::rgba16snorm:
       spvFormat = spv::ImageFormat::Rgba16Snorm;
       break;
-    case VKImageFormatAttr::Rg16Snorm:
+    case VKImageFormatAttr::rg16snorm:
       spvFormat = spv::ImageFormat::Rg16Snorm;
       break;
-    case VKImageFormatAttr::Rg8Snorm:
+    case VKImageFormatAttr::rg8snorm:
       spvFormat = spv::ImageFormat::Rg8Snorm;
       break;
-    case VKImageFormatAttr::R16Snorm:
+    case VKImageFormatAttr::r16snorm:
       spvFormat = spv::ImageFormat::R16Snorm;
       break;
-    case VKImageFormatAttr::R8Snorm:
+    case VKImageFormatAttr::r8snorm:
       spvFormat = spv::ImageFormat::R8Snorm;
       break;
-    case VKImageFormatAttr::Rgba32i:
+    case VKImageFormatAttr::rgba32i:
       spvFormat = spv::ImageFormat::Rgba32i;
       break;
-    case VKImageFormatAttr::Rgba16i:
+    case VKImageFormatAttr::rgba16i:
       spvFormat = spv::ImageFormat::Rgba16i;
       break;
-    case VKImageFormatAttr::Rgba8i:
+    case VKImageFormatAttr::rgba8i:
       spvFormat = spv::ImageFormat::Rgba8i;
       break;
-    case VKImageFormatAttr::R32i:
+    case VKImageFormatAttr::r32i:
       spvFormat = spv::ImageFormat::R32i;
       break;
-    case VKImageFormatAttr::Rg32i:
+    case VKImageFormatAttr::rg32i:
       spvFormat = spv::ImageFormat::Rg32i;
       break;
-    case VKImageFormatAttr::Rg16i:
+    case VKImageFormatAttr::rg16i:
       spvFormat = spv::ImageFormat::Rg16i;
       break;
-    case VKImageFormatAttr::Rg8i:
+    case VKImageFormatAttr::rg8i:
       spvFormat = spv::ImageFormat::Rg8i;
       break;
-    case VKImageFormatAttr::R16i:
+    case VKImageFormatAttr::r16i:
       spvFormat = spv::ImageFormat::R16i;
       break;
-    case VKImageFormatAttr::R8i:
+    case VKImageFormatAttr::r8i:
       spvFormat = spv::ImageFormat::R8i;
       break;
-    case VKImageFormatAttr::Rgba32ui:
+    case VKImageFormatAttr::rgba32ui:
       spvFormat = spv::ImageFormat::Rgba32ui;
       break;
-    case VKImageFormatAttr::Rgba16ui:
+    case VKImageFormatAttr::rgba16ui:
       spvFormat = spv::ImageFormat::Rgba16ui;
       break;
-    case VKImageFormatAttr::Rgba8ui:
+    case VKImageFormatAttr::rgba8ui:
       spvFormat = spv::ImageFormat::Rgba8ui;
       break;
-    case VKImageFormatAttr::R32ui:
+    case VKImageFormatAttr::r32ui:
       spvFormat = spv::ImageFormat::R32ui;
       break;
-    case VKImageFormatAttr::Rgb10a2ui:
+    case VKImageFormatAttr::rgb10a2ui:
       spvFormat = spv::ImageFormat::Rgb10a2ui;
       break;
-    case VKImageFormatAttr::Rg32ui:
+    case VKImageFormatAttr::rg32ui:
       spvFormat = spv::ImageFormat::Rg32ui;
       break;
-    case VKImageFormatAttr::Rg16ui:
+    case VKImageFormatAttr::rg16ui:
       spvFormat = spv::ImageFormat::Rg16ui;
       break;
-    case VKImageFormatAttr::Rg8ui:
+    case VKImageFormatAttr::rg8ui:
       spvFormat = spv::ImageFormat::Rg8ui;
       break;
-    case VKImageFormatAttr::R16ui:
+    case VKImageFormatAttr::r16ui:
       spvFormat = spv::ImageFormat::R16ui;
       break;
-    case VKImageFormatAttr::R8ui:
+    case VKImageFormatAttr::r8ui:
       spvFormat = spv::ImageFormat::R8ui;
       break;
-    case VKImageFormatAttr::R64ui:
+    case VKImageFormatAttr::r64ui:
       spvFormat = spv::ImageFormat::R64ui;
       break;
-    case VKImageFormatAttr::R64i:
+    case VKImageFormatAttr::r64i:
       spvFormat = spv::ImageFormat::R64i;
       break;
     }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -398,142 +398,97 @@ SpirvLayoutRule getLayoutRuleForExternVar(QualType type,
   return SpirvLayoutRule::Void;
 }
 
-void handleImageFormat(const VarDecl *var, SpirvVariable *varInstr) {
-  const auto *imageFormatAttr = var->getAttr<VKImageFormatAttr>();
-  if (imageFormatAttr) {
-    const VKImageFormatAttr::ImageFormatType format =
-        imageFormatAttr->getImageFormat();
-    spv::ImageFormat spvFormat;
-    switch (format) {
-    case VKImageFormatAttr::unknown:
-      spvFormat = spv::ImageFormat::Unknown;
-      break;
-    case VKImageFormatAttr::rgba32f:
-      spvFormat = spv::ImageFormat::Rgba32f;
-      break;
-    case VKImageFormatAttr::rgba16f:
-      spvFormat = spv::ImageFormat::Rgba16f;
-      break;
-    case VKImageFormatAttr::r32f:
-      spvFormat = spv::ImageFormat::R32f;
-      break;
-    case VKImageFormatAttr::rgba8:
-      spvFormat = spv::ImageFormat::Rgba8;
-      break;
-    case VKImageFormatAttr::rgba8snorm:
-      spvFormat = spv::ImageFormat::Rgba8Snorm;
-      break;
-    case VKImageFormatAttr::rg32f:
-      spvFormat = spv::ImageFormat::Rg32f;
-      break;
-    case VKImageFormatAttr::rg16f:
-      spvFormat = spv::ImageFormat::Rg16f;
-      break;
-    case VKImageFormatAttr::r11g11b10f:
-      spvFormat = spv::ImageFormat::R11fG11fB10f;
-      break;
-    case VKImageFormatAttr::r16f:
-      spvFormat = spv::ImageFormat::R16f;
-      break;
-    case VKImageFormatAttr::rgba16:
-      spvFormat = spv::ImageFormat::Rgba16;
-      break;
-    case VKImageFormatAttr::rgb10a2:
-      spvFormat = spv::ImageFormat::Rgb10A2;
-      break;
-    case VKImageFormatAttr::rg16:
-      spvFormat = spv::ImageFormat::Rg16;
-      break;
-    case VKImageFormatAttr::rg8:
-      spvFormat = spv::ImageFormat::Rg8;
-      break;
-    case VKImageFormatAttr::r16:
-      spvFormat = spv::ImageFormat::R16;
-      break;
-    case VKImageFormatAttr::r8:
-      spvFormat = spv::ImageFormat::R8;
-      break;
-    case VKImageFormatAttr::rgba16snorm:
-      spvFormat = spv::ImageFormat::Rgba16Snorm;
-      break;
-    case VKImageFormatAttr::rg16snorm:
-      spvFormat = spv::ImageFormat::Rg16Snorm;
-      break;
-    case VKImageFormatAttr::rg8snorm:
-      spvFormat = spv::ImageFormat::Rg8Snorm;
-      break;
-    case VKImageFormatAttr::r16snorm:
-      spvFormat = spv::ImageFormat::R16Snorm;
-      break;
-    case VKImageFormatAttr::r8snorm:
-      spvFormat = spv::ImageFormat::R8Snorm;
-      break;
-    case VKImageFormatAttr::rgba32i:
-      spvFormat = spv::ImageFormat::Rgba32i;
-      break;
-    case VKImageFormatAttr::rgba16i:
-      spvFormat = spv::ImageFormat::Rgba16i;
-      break;
-    case VKImageFormatAttr::rgba8i:
-      spvFormat = spv::ImageFormat::Rgba8i;
-      break;
-    case VKImageFormatAttr::r32i:
-      spvFormat = spv::ImageFormat::R32i;
-      break;
-    case VKImageFormatAttr::rg32i:
-      spvFormat = spv::ImageFormat::Rg32i;
-      break;
-    case VKImageFormatAttr::rg16i:
-      spvFormat = spv::ImageFormat::Rg16i;
-      break;
-    case VKImageFormatAttr::rg8i:
-      spvFormat = spv::ImageFormat::Rg8i;
-      break;
-    case VKImageFormatAttr::r16i:
-      spvFormat = spv::ImageFormat::R16i;
-      break;
-    case VKImageFormatAttr::r8i:
-      spvFormat = spv::ImageFormat::R8i;
-      break;
-    case VKImageFormatAttr::rgba32ui:
-      spvFormat = spv::ImageFormat::Rgba32ui;
-      break;
-    case VKImageFormatAttr::rgba16ui:
-      spvFormat = spv::ImageFormat::Rgba16ui;
-      break;
-    case VKImageFormatAttr::rgba8ui:
-      spvFormat = spv::ImageFormat::Rgba8ui;
-      break;
-    case VKImageFormatAttr::r32ui:
-      spvFormat = spv::ImageFormat::R32ui;
-      break;
-    case VKImageFormatAttr::rgb10a2ui:
-      spvFormat = spv::ImageFormat::Rgb10a2ui;
-      break;
-    case VKImageFormatAttr::rg32ui:
-      spvFormat = spv::ImageFormat::Rg32ui;
-      break;
-    case VKImageFormatAttr::rg16ui:
-      spvFormat = spv::ImageFormat::Rg16ui;
-      break;
-    case VKImageFormatAttr::rg8ui:
-      spvFormat = spv::ImageFormat::Rg8ui;
-      break;
-    case VKImageFormatAttr::r16ui:
-      spvFormat = spv::ImageFormat::R16ui;
-      break;
-    case VKImageFormatAttr::r8ui:
-      spvFormat = spv::ImageFormat::R8ui;
-      break;
-    case VKImageFormatAttr::r64ui:
-      spvFormat = spv::ImageFormat::R64ui;
-      break;
-    case VKImageFormatAttr::r64i:
-      spvFormat = spv::ImageFormat::R64i;
-      break;
-    }
-    varInstr->setImageFormat(spvFormat);
+spv::ImageFormat getSpvImageFormat(const VKImageFormatAttr *imageFormatAttr) {
+  if (imageFormatAttr == nullptr)
+    return spv::ImageFormat::Unknown;
+
+  switch (imageFormatAttr->getImageFormat()) {
+  case VKImageFormatAttr::unknown:
+    return spv::ImageFormat::Unknown;
+  case VKImageFormatAttr::rgba32f:
+    return spv::ImageFormat::Rgba32f;
+  case VKImageFormatAttr::rgba16f:
+    return spv::ImageFormat::Rgba16f;
+  case VKImageFormatAttr::r32f:
+    return spv::ImageFormat::R32f;
+  case VKImageFormatAttr::rgba8:
+    return spv::ImageFormat::Rgba8;
+  case VKImageFormatAttr::rgba8snorm:
+    return spv::ImageFormat::Rgba8Snorm;
+  case VKImageFormatAttr::rg32f:
+    return spv::ImageFormat::Rg32f;
+  case VKImageFormatAttr::rg16f:
+    return spv::ImageFormat::Rg16f;
+  case VKImageFormatAttr::r11g11b10f:
+    return spv::ImageFormat::R11fG11fB10f;
+  case VKImageFormatAttr::r16f:
+    return spv::ImageFormat::R16f;
+  case VKImageFormatAttr::rgba16:
+    return spv::ImageFormat::Rgba16;
+  case VKImageFormatAttr::rgb10a2:
+    return spv::ImageFormat::Rgb10A2;
+  case VKImageFormatAttr::rg16:
+    return spv::ImageFormat::Rg16;
+  case VKImageFormatAttr::rg8:
+    return spv::ImageFormat::Rg8;
+  case VKImageFormatAttr::r16:
+    return spv::ImageFormat::R16;
+  case VKImageFormatAttr::r8:
+    return spv::ImageFormat::R8;
+  case VKImageFormatAttr::rgba16snorm:
+    return spv::ImageFormat::Rgba16Snorm;
+  case VKImageFormatAttr::rg16snorm:
+    return spv::ImageFormat::Rg16Snorm;
+  case VKImageFormatAttr::rg8snorm:
+    return spv::ImageFormat::Rg8Snorm;
+  case VKImageFormatAttr::r16snorm:
+    return spv::ImageFormat::R16Snorm;
+  case VKImageFormatAttr::r8snorm:
+    return spv::ImageFormat::R8Snorm;
+  case VKImageFormatAttr::rgba32i:
+    return spv::ImageFormat::Rgba32i;
+  case VKImageFormatAttr::rgba16i:
+    return spv::ImageFormat::Rgba16i;
+  case VKImageFormatAttr::rgba8i:
+    return spv::ImageFormat::Rgba8i;
+  case VKImageFormatAttr::r32i:
+    return spv::ImageFormat::R32i;
+  case VKImageFormatAttr::rg32i:
+    return spv::ImageFormat::Rg32i;
+  case VKImageFormatAttr::rg16i:
+    return spv::ImageFormat::Rg16i;
+  case VKImageFormatAttr::rg8i:
+    return spv::ImageFormat::Rg8i;
+  case VKImageFormatAttr::r16i:
+    return spv::ImageFormat::R16i;
+  case VKImageFormatAttr::r8i:
+    return spv::ImageFormat::R8i;
+  case VKImageFormatAttr::rgba32ui:
+    return spv::ImageFormat::Rgba32ui;
+  case VKImageFormatAttr::rgba16ui:
+    return spv::ImageFormat::Rgba16ui;
+  case VKImageFormatAttr::rgba8ui:
+    return spv::ImageFormat::Rgba8ui;
+  case VKImageFormatAttr::r32ui:
+    return spv::ImageFormat::R32ui;
+  case VKImageFormatAttr::rgb10a2ui:
+    return spv::ImageFormat::Rgb10a2ui;
+  case VKImageFormatAttr::rg32ui:
+    return spv::ImageFormat::Rg32ui;
+  case VKImageFormatAttr::rg16ui:
+    return spv::ImageFormat::Rg16ui;
+  case VKImageFormatAttr::rg8ui:
+    return spv::ImageFormat::Rg8ui;
+  case VKImageFormatAttr::r16ui:
+    return spv::ImageFormat::R16ui;
+  case VKImageFormatAttr::r8ui:
+    return spv::ImageFormat::R8ui;
+  case VKImageFormatAttr::r64ui:
+    return spv::ImageFormat::R64ui;
+  case VKImageFormatAttr::r64i:
+    return spv::ImageFormat::R64i;
   }
+  return spv::ImageFormat::Unknown;
 }
 
 } // anonymous namespace
@@ -985,7 +940,12 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
       type, storageClass, var->hasAttr<HLSLPreciseAttr>(), name, llvm::None,
       loc);
   varInstr->setLayoutRule(rule);
-  handleImageFormat(var, varInstr);
+
+  // If this variable has [[vk::image_format("..")]] attribute, we have to keep
+  // it in the SpirvContext and use it when we lower the QualType to SpirvType.
+  auto spvImageFormat = getSpvImageFormat(var->getAttr<VKImageFormatAttr>());
+  if (spvImageFormat != spv::ImageFormat::Unknown)
+    spvContext.registerImageFormatForSpirvVariable(varInstr, spvImageFormat);
 
   DeclSpirvInfo info(varInstr);
   astDecls[var] = info;

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -46,10 +46,8 @@ public:
   ///
   /// The lowering is recursive; all the types that the target type depends
   /// on will be created in SpirvContext.
-  const SpirvType *
-  lowerType(QualType type, SpirvLayoutRule, llvm::Optional<bool> isRowMajor,
-            SourceLocation,
-            spv::ImageFormat explicitImageFormat = spv::ImageFormat::Unknown);
+  const SpirvType *lowerType(QualType type, SpirvLayoutRule,
+                             llvm::Optional<bool> isRowMajor, SourceLocation);
 
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
@@ -70,8 +68,7 @@ private:
 
   /// Lowers the given HLSL resource type into its SPIR-V type.
   const SpirvType *lowerResourceType(QualType type, SpirvLayoutRule rule,
-                                     SourceLocation,
-                                     spv::ImageFormat explicitImageFormat);
+                                     SourceLocation);
 
   /// For the given sampled type, returns the corresponding image format
   /// that can be used to create an image object.

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -31,7 +31,6 @@ public:
   bool visit(SpirvModule *, Phase) override { return true; }
   bool visit(SpirvFunction *, Phase) override;
   bool visit(SpirvBasicBlock *, Phase) override { return true; }
-  //bool visit(SpirvLoad *, Phase) override;
 
   using Visitor::visit;
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -31,6 +31,7 @@ public:
   bool visit(SpirvModule *, Phase) override { return true; }
   bool visit(SpirvFunction *, Phase) override;
   bool visit(SpirvBasicBlock *, Phase) override { return true; }
+  //bool visit(SpirvLoad *, Phase) override;
 
   using Visitor::visit;
 
@@ -45,8 +46,10 @@ public:
   ///
   /// The lowering is recursive; all the types that the target type depends
   /// on will be created in SpirvContext.
-  const SpirvType *lowerType(QualType type, SpirvLayoutRule,
-                             llvm::Optional<bool> isRowMajor, SourceLocation);
+  const SpirvType *
+  lowerType(QualType type, SpirvLayoutRule, llvm::Optional<bool> isRowMajor,
+            SourceLocation,
+            spv::ImageFormat explicitImageFormat = spv::ImageFormat::Unknown);
 
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
@@ -67,7 +70,8 @@ private:
 
   /// Lowers the given HLSL resource type into its SPIR-V type.
   const SpirvType *lowerResourceType(QualType type, SpirvLayoutRule rule,
-                                     SourceLocation);
+                                     SourceLocation,
+                                     spv::ImageFormat explicitImageFormat);
 
   /// For the given sampled type, returns the corresponding image format
   /// that can be used to create an image object.

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -184,6 +184,17 @@ const SpirvType *SpirvContext::getMatrixType(const SpirvType *elemType,
   return ptr;
 }
 
+const ImageType *
+SpirvContext::getImageType(const ImageType *imageTypeWithUnknownFormat,
+                           spv::ImageFormat format) {
+  return getImageType(imageTypeWithUnknownFormat->getSampledType(),
+                      imageTypeWithUnknownFormat->getDimension(),
+                      imageTypeWithUnknownFormat->getDepth(),
+                      imageTypeWithUnknownFormat->isArrayedImage(),
+                      imageTypeWithUnknownFormat->isMSImage(),
+                      imageTypeWithUnknownFormat->withSampler(), format);
+}
+
 const ImageType *SpirvContext::getImageType(const SpirvType *sampledType,
                                             spv::Dim dim,
                                             ImageType::WithDepth depth,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -114,8 +114,8 @@ SpirvInstruction::SpirvInstruction(Kind k, spv::Op op, QualType astType,
     : kind(k), opcode(op), astResultType(astType), resultId(0), srcLoc(loc),
       debugName(), resultType(nullptr), resultTypeId(0),
       layoutRule(SpirvLayoutRule::Void), containsAlias(false),
-      storageClass(spv::StorageClass::Function), isRValue_(false),
-      isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
+      storageClass(spv::StorageClass::Function), imageFormat(spv::ImageFormat::Unknown),
+      isRValue_(false), isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
 
 bool SpirvInstruction::isArithmeticInstruction() const {
   switch (opcode) {

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -114,8 +114,8 @@ SpirvInstruction::SpirvInstruction(Kind k, spv::Op op, QualType astType,
     : kind(k), opcode(op), astResultType(astType), resultId(0), srcLoc(loc),
       debugName(), resultType(nullptr), resultTypeId(0),
       layoutRule(SpirvLayoutRule::Void), containsAlias(false),
-      storageClass(spv::StorageClass::Function), imageFormat(spv::ImageFormat::Unknown),
-      isRValue_(false), isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
+      storageClass(spv::StorageClass::Function), isRValue_(false),
+      isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
 
 bool SpirvInstruction::isArithmeticInstruction() const {
   switch (opcode) {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11709,7 +11709,7 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     VKImageFormatAttr::ImageFormatType Kind = ValidateAttributeEnumArg<
         VKImageFormatAttr, VKImageFormatAttr::ImageFormatType,
         VKImageFormatAttr::ConvertStrToImageFormatType>(
-        S, A, VKImageFormatAttr::ImageFormatType::Unknown);
+        S, A, VKImageFormatAttr::ImageFormatType::unknown);
     declAttr = ::new (S.Context) VKImageFormatAttr(
         A.getRange(), S.Context, Kind, A.getAttributeSpellingListIndex());
     break;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11137,6 +11137,28 @@ static int ValidateAttributeFloatArg(Sema &S, const AttributeList &Attr,
   return value;
 }
 
+template <typename AttrType, typename EnumType,
+          bool (*ConvertStrToEnumType)(StringRef, EnumType &)>
+static EnumType ValidateAttributeEnumArg(Sema &S, const AttributeList &Attr,
+                                         EnumType defaultValue,
+                                         unsigned index = 0) {
+  EnumType value(defaultValue);
+  StringRef Str = "";
+  SourceLocation ArgLoc;
+
+  if (Attr.getNumArgs() > index) {
+    if (!S.checkStringLiteralArgumentAttr(Attr, 0, Str, &ArgLoc))
+      return value;
+
+    if (!ConvertStrToEnumType(Str, value)) {
+      S.Diag(Attr.getLoc(), diag::warn_attribute_type_not_supported)
+          << Attr.getName() << Str << ArgLoc;
+    }
+    return value;
+  }
+  return value;
+}
+
 static Stmt* IgnoreParensAndDecay(Stmt* S)
 {
   for (;;)
@@ -11683,6 +11705,15 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     declAttr = ::new (S.Context) VKOffsetAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKImageFormat: {
+    VKImageFormatAttr::ImageFormatType Kind = ValidateAttributeEnumArg<
+        VKImageFormatAttr, VKImageFormatAttr::ImageFormatType,
+        VKImageFormatAttr::ConvertStrToImageFormatType>(
+        S, A, VKImageFormatAttr::ImageFormatType::Unknown);
+    declAttr = ::new (S.Context) VKImageFormatAttr(
+        A.getRange(), S.Context, Kind, A.getAttributeSpellingListIndex());
+    break;
+  }
   case AttributeList::AT_VKInputAttachmentIndex:
     declAttr = ::new (S.Context) VKInputAttachmentIndexAttr(
         A.getRange(), S.Context, ValidateAttributeIntArg(S, A),

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.hlsl
@@ -1,0 +1,91 @@
+// Run: %dxc -T cs_6_0 -E main
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba16f
+[[vk::image_format("rgba16f")]]
+RWBuffer<float4> Buf;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 R32f
+[[vk::image_format("r32f")]]
+RWBuffer<float4> Buf_r32f;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba8Snorm
+[[vk::image_format("rgba8snorm")]]
+RWBuffer<float4> Buf_rgba8snorm;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rg16f
+[[vk::image_format("rg16f")]]
+RWBuffer<float4> Buf_rg16f;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 R11fG11fB10f
+[[vk::image_format("r11g11b10f")]]
+RWBuffer<float4> Buf_r11g11b10f;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgb10A2
+[[vk::image_format("rgb10a2")]]
+RWBuffer<float4> Buf_rgb10a2;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rg8
+[[vk::image_format("rg8")]]
+RWBuffer<float4> Buf_rg8;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 R8
+[[vk::image_format("r8")]]
+RWBuffer<float4> Buf_r8;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rg16Snorm
+[[vk::image_format("rg16snorm")]]
+RWBuffer<float4> Buf_rg16snorm;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba32i
+[[vk::image_format("rgba32i")]]
+RWBuffer<float4> Buf_rgba32i;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rg8i
+[[vk::image_format("rg8i")]]
+RWBuffer<float4> Buf_rg8i;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba16ui
+[[vk::image_format("rgba16ui")]]
+RWBuffer<float4> Buf_rgba16ui;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgb10a2ui
+[[vk::image_format("rgb10a2ui")]]
+RWBuffer<float4> Buf_rgb10a2ui;
+
+struct S {
+    RWBuffer<float4> b;
+};
+
+float4 getVal(RWBuffer<float4> b) {
+    return b[0];
+}
+
+float4 getValStruct(S s) {
+    return s.b[1];
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+    RWBuffer<float4> foo;
+
+    foo = Buf;
+
+    float4 test = getVal(foo);
+    test += getVal(Buf_r32f);
+
+    S s;
+    s.b = Buf;
+    test += getValStruct(s);
+
+    S s2;
+    s2.b = Buf_r32f;
+    test += getValStruct(s2);
+
+    RWBuffer<float4> var = Buf;
+    RWBuffer<float4> var2 = Buf_r32f;
+    test += var[2];
+    test += var2[2];
+
+    Buf[10] = test + 1;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.o3.hlsl
@@ -1,0 +1,79 @@
+// Run: %dxc -T cs_6_0 -E main -O3
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba16f
+[[vk::image_format("rgba16f")]]
+RWBuffer<float4> Buf;
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 R32f
+[[vk::image_format("r32f")]]
+RWBuffer<float4> Buf_r32f;
+
+[[vk::image_format("rgba8snorm")]]
+RWBuffer<float4> Buf_rgba8snorm;
+
+[[vk::image_format("rg16f")]]
+RWBuffer<float4> Buf_rg16f;
+
+[[vk::image_format("r11g11b10f")]]
+RWBuffer<float4> Buf_r11g11b10f;
+
+[[vk::image_format("rgb10a2")]]
+RWBuffer<float4> Buf_rgb10a2;
+
+[[vk::image_format("rg8")]]
+RWBuffer<float4> Buf_rg8;
+
+[[vk::image_format("r8")]]
+RWBuffer<float4> Buf_r8;
+
+[[vk::image_format("rg16snorm")]]
+RWBuffer<float4> Buf_rg16snorm;
+
+[[vk::image_format("rgba32i")]]
+RWBuffer<float4> Buf_rgba32i;
+
+[[vk::image_format("rg8i")]]
+RWBuffer<float4> Buf_rg8i;
+
+[[vk::image_format("rgba16ui")]]
+RWBuffer<float4> Buf_rgba16ui;
+
+[[vk::image_format("rgb10a2ui")]]
+RWBuffer<float4> Buf_rgb10a2ui;
+
+struct S {
+    RWBuffer<float4> b;
+};
+
+float4 getVal(RWBuffer<float4> b) {
+    return b[0];
+}
+
+float4 getValStruct(S s) {
+    return s.b[1];
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+    RWBuffer<float4> foo;
+
+    foo = Buf;
+
+    float4 test = getVal(foo);
+    test += getVal(Buf_r32f);
+
+    S s;
+    s.b = Buf;
+    test += getValStruct(s);
+
+    S s2;
+    s2.b = Buf_r32f;
+    test += getValStruct(s2);
+
+    RWBuffer<float4> var = Buf;
+    RWBuffer<float4> var2 = Buf_r32f;
+    test += var[2];
+    test += var2[2];
+
+    Buf[10] = test + 1;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1708,6 +1708,11 @@ TEST_F(FileTest, VulkanAttributeShaderRecordEXTInvalidUsages) {
   runFileTest("vk.attribute.shader-record-ext.invalid.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, VulkanAttributeImageFormat) {
+  runFileTest("vk.attribute.image-format.hlsl", Expect::Success,
+              /*runValidation*/ false);
+}
+
 TEST_F(FileTest, VulkanCLOptionInvertYVS) {
   runFileTest("vk.cloption.invert-y.vs.hlsl");
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1712,6 +1712,9 @@ TEST_F(FileTest, VulkanAttributeImageFormat) {
   runFileTest("vk.attribute.image-format.hlsl", Expect::Success,
               /*runValidation*/ false);
 }
+TEST_F(FileTest, VulkanAttributeImageFormatO3) {
+  runFileTest("vk.attribute.image-format.o3.hlsl");
+}
 
 TEST_F(FileTest, VulkanCLOptionInvertYVS) {
   runFileTest("vk.cloption.invert-y.vs.hlsl");


### PR DESCRIPTION
According to Vulkan specification when using `OpImageRead/OpImageWrite`, the `OpTypeImage` (`Buffers`, `RWBuffers`, `RWTextures`) must have a format that matches the format on the API side, unless the StorageImageReadWithoutFormat/StorageImageWriteWithoutFormat is added and `Unknown` is used as the format.

This pull request addressess #2498 for the format part by adding an attribute `[[vk::image_format("<image format as spelled in SPIR-V spec>")]].` Example of the syntax:

```
[[vk::image_format("rgba8")]]
RWBuffer<float4> Buf;

[[vk::image_format("rg16f")]]
RWTexture2D<float2> Tex;

RWTexture2D<float2> Tex2; // Works like before
```

The `image_format` only applies to **global variables** of type `Buffer`, `RWBuffer`, `RWTexture`. For variables and function parameters it is propagated by the inlining pass in legalization. This required a small change to one of the passes in SPIRV-Tools, that should be also checked by someone more familiar with the codebase: https://github.com/KhronosGroup/SPIRV-Tools/pull/4126

Note that this does not fix the handling of unspecified format (that case still works like before, using `R32f`, etc. based on the type in shader), although it should be still fixed to add the
StorageImageReadWithoutFormat and/or StorageImageWriteWithoutFormat and use Undefined. But I think the ability to specify the format is more urgent.

Design note from Jaebaek:
Since the `image_format` attribute only applies to **global variables**, under the DXC architecture
only `DeclResultIdMapper` can check the attribute when it handles `VarDecl`s. It means
we have to pass the `image_format` information to `LowerTypeVisitor` because it cannot access to
`VarDecl`. In order to pass the `image_format`, we use `SpirvContext` that can be accessed by
`SpirvEmitter` and all visitors. We use `SpirvVariable` to `spv::ImageFormat` mapping because the
attribute only applies to **global variables** (not to image types).
See how we use `llvm::DenseMap<const SpirvVariable *, spv::ImageFormat> spvVarToImageFormat`.