### PR TITLE
Defined behavior on all wave sensitivity outcomes

### DIFF
--- a/lib/HLSL/WaveSensitivityAnalysis.cpp
+++ b/lib/HLSL/WaveSensitivityAnalysis.cpp
@@ -210,7 +210,10 @@ void WaveSensitivityAnalyzer::VisitInst(Instruction *I) {
 
 bool WaveSensitivityAnalyzer::IsWaveSensitive(Instruction *op) {
   auto c = InstState.find(op);
-  DXASSERT(c != InstState.end(), "else analysis didn't complete");
+  if(c == InstState.end()) {
+    DXASSERT(false, "Instruction sensitivity not foud. Analysis didn't complete!");
+    return false;
+  }
   DXASSERT((*c).second != Unknown, "else analysis is missing a case");
   return (*c).second == KnownSensitive;
 }


### PR DESCRIPTION
The wave sensitivity analysis should produce a result for any relevant
instruction. It fails in some cases, which is a bug. However, the result
of that bug shouldn't be intermittent incorrect errors as it is now.

When a result isn't found, assume that there is no wave sensitivity. The
assert is kept and might produce a warning ultimately. This is meant to
add a guard rail to the worst case scenario.