### PR TITLE
Update HLMatrixType.cpp

### DIFF
--- a/lib/HLSL/HLMatrixType.cpp
+++ b/lib/HLSL/HLMatrixType.cpp
@@ -104,7 +104,7 @@ Value *HLMatrixType::emitLoweredVectorColToRow(Value *VecVal, IRBuilder<> &Build
 
 bool HLMatrixType::isa(Type *Ty) {
   StructType *StructTy = llvm::dyn_cast<StructType>(Ty);
-  return StructTy != nullptr && StructTy->getName().startswith(StructNamePrefix);
+  return StructTy != nullptr && !StructTy->isLiteral() && StructTy->getName().startswith(StructNamePrefix);
 }
 
 bool HLMatrixType::isMatrixPtr(Type *Ty) {


### PR DESCRIPTION
Calling getName() on a literal StructType will assert/segfault. Must check StructType::isLiteral first.