### PR TITLE
Fixes for RWBuffer/groupshared to have right Format and StructureByte…

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2063,11 +2063,11 @@
       <Descriptor Name="U1" Kind="UAV" ResName="U1"
                   NumElements="64" StructureByteStride="4" />
       <Descriptor Name="U2" Kind="UAV" ResName="U2"
-                  NumElements="64" StructureByteStride="4" />
+                  NumElements="64" Format="R32_FLOAT" StructureByteStride="0" />
       <Descriptor Name="U3" Kind="UAV" ResName="U3" Dimension="TEXTURE1D"
                   NumElements="64" StructureByteStride="4" />
       <Descriptor Name="U4" Kind="UAV" ResName="U4"
-                  NumElements="64" StructureByteStride="4" />
+                  NumElements="64" Format="R32_FLOAT" StructureByteStride="0" />
     </DescriptorHeap>
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
       <Descriptor Name="RTarget" Kind="RTV"/>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2063,11 +2063,11 @@
       <Descriptor Name="U1" Kind="UAV" ResName="U1"
                   NumElements="64" StructureByteStride="4" />
       <Descriptor Name="U2" Kind="UAV" ResName="U2"
-                  NumElements="64" Format="R32_FLOAT" StructureByteStride="0" />
+                  NumElements="64" Format="R32_FLOAT" />
       <Descriptor Name="U3" Kind="UAV" ResName="U3" Dimension="TEXTURE1D"
-                  NumElements="64" StructureByteStride="4" />
+                  NumElements="64" Format="R32_FLOAT" />
       <Descriptor Name="U4" Kind="UAV" ResName="U4"
-                  NumElements="64" Format="R32_FLOAT" StructureByteStride="0" />
+                  NumElements="64" Format="R32_FLOAT" />
     </DescriptorHeap>
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
       <Descriptor Name="RTarget" Kind="RTV"/>


### PR DESCRIPTION
…Size

Having the format not set correctly was causing issues in striding and causing the float atomics test to fail.