### PR TITLE
PIX: Shader debug: don't instrument ray query handles

### DIFF
--- a/lib/DxilPIXPasses/CMakeLists.txt
+++ b/lib/DxilPIXPasses/CMakeLists.txt
@@ -13,7 +13,7 @@ add_llvm_library(LLVMDxilPIXPasses
   DxilShaderAccessTracking.cpp
   DxilPIXPasses.cpp
   DxilPIXVirtualRegisters.cpp
-
+  PixPassHelpers.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -350,6 +350,23 @@ static OffsetInBits GetAlignedOffsetFromDIExpression(
   return Exp->getBitPieceOffset();
 }
 
+static bool IsAllocateRayQueryInstruction(llvm::Value *Val) {
+  if (llvm::Instruction *Inst = llvm::dyn_cast<llvm::Instruction>(Val)) {
+    if (Inst->getOpcode() == llvm::Instruction::OtherOps::Call) {
+      if (Inst->getNumOperands() > 0) {
+        if (auto *asInt =
+                llvm::cast_or_null<llvm::ConstantInt>(Inst->getOperand(0))) {
+          if (asInt->getZExtValue() ==
+              (uint64_t)hlsl::DXIL::OpCode::AllocateRayQuery) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
 bool DxilDbgValueToDbgDeclare::runOnModule(
     llvm::Module &M
 )
@@ -364,6 +381,10 @@ bool DxilDbgValueToDbgDeclare::runOnModule(
 
     if (auto *DbgValue = llvm::dyn_cast<llvm::DbgValueInst>(User))
     {
+      llvm::Value *V = DbgValue->getValue();
+      if (IsAllocateRayQueryInstruction(V)) {
+          continue;
+      }
       Changed = true;
       handleDbgValue(M, DbgValue);
       DbgValue->eraseFromParent();

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -7,16 +7,7 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "dxc/DXIL/DxilConstants.h"
-#include "dxc/DXIL/DxilModule.h"
-#include "dxc/DXIL/DxilResourceBase.h"
-#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
-#include "llvm/IR/DebugInfo.h"
-#include "llvm/IR/DebugInfoMetadata.h"
-#include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Instructions.h"
-#include "llvm/IR/IntrinsicInst.h"
-#include "llvm/IR/Intrinsics.h"
+#include "dxc/DXIL/DxilOperations.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Pass.h"
 
@@ -24,17 +15,7 @@ namespace PIXPassHelpers
 {
     bool IsAllocateRayQueryInstruction(llvm::Value* Val) {
         if (llvm::Instruction* Inst = llvm::dyn_cast<llvm::Instruction>(Val)) {
-            if (Inst->getOpcode() == llvm::Instruction::OtherOps::Call) {
-                if (Inst->getNumOperands() > 0) {
-                    if (auto* asInt =
-                        llvm::cast_or_null<llvm::ConstantInt>(Inst->getOperand(0))) {
-                        if (asInt->getZExtValue() ==
-                            (uint64_t)hlsl::DXIL::OpCode::AllocateRayQuery) {
-                            return true;
-                        }
-                    }
-                }
-            }
+            return hlsl::OP::IsDxilOpFuncCallInst(Inst, hlsl::OP::OpCode::AllocateRayQuery);
         }
         return false;
     }

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -1,0 +1,41 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// PixPassHelpers.cpp														 //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "dxc/DXIL/DxilConstants.h"
+#include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilResourceBase.h"
+#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
+
+namespace PIXPassHelpers
+{
+    bool IsAllocateRayQueryInstruction(llvm::Value* Val) {
+        if (llvm::Instruction* Inst = llvm::dyn_cast<llvm::Instruction>(Val)) {
+            if (Inst->getOpcode() == llvm::Instruction::OtherOps::Call) {
+                if (Inst->getNumOperands() > 0) {
+                    if (auto* asInt =
+                        llvm::cast_or_null<llvm::ConstantInt>(Inst->getOperand(0))) {
+                        if (asInt->getZExtValue() ==
+                            (uint64_t)hlsl::DXIL::OpCode::AllocateRayQuery) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -1,0 +1,15 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// PixPassHelpers.h  														 //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace PIXPassHelpers
+{
+	bool IsAllocateRayQueryInstruction(llvm::Value* Val);
+}


### PR DESCRIPTION
These handles are just integers, but drivers compile them to ? and don't like it when you try to store them somewhere in a UAV.
PIX bug #31509503.