### PR TITLE
Fix memory corruption in DxilCounters.cpp

### DIFF
--- a/lib/DXIL/DxilCounters.cpp
+++ b/lib/DXIL/DxilCounters.cpp
@@ -50,28 +50,27 @@ PointerInfo GetPointerInfo(Value* V, PointerInfoMap &ptrInfoMap) {
   if (it != ptrInfoMap.end())
     return it->second;
 
-  PointerInfo &PI = ptrInfoMap[V];
   Type *Ty = V->getType()->getPointerElementType();
-  PI.isArray = Ty->isArrayTy();
+  ptrInfoMap[V].isArray = Ty->isArrayTy();
 
   if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
     if (GV->getType()->getPointerAddressSpace() == DXIL::kTGSMAddrSpace)
-      PI.memType = PointerInfo::MemType::Global_TGSM;
+      ptrInfoMap[V].memType = PointerInfo::MemType::Global_TGSM;
     else if (!GV->isConstant() &&
              GV->getLinkage() == GlobalVariable::LinkageTypes::InternalLinkage &&
              GV->getType()->getPointerAddressSpace() == DXIL::kDefaultAddrSpace)
-      PI.memType = PointerInfo::MemType::Global_Static;
+      ptrInfoMap[V].memType = PointerInfo::MemType::Global_Static;
   } else if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
-    PI.memType = PointerInfo::MemType::Alloca;
+      ptrInfoMap[V].memType = PointerInfo::MemType::Alloca;
   } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(V)) {
-    PI = GetPointerInfo(GEP->getPointerOperand(), ptrInfoMap);
+    ptrInfoMap[V] = GetPointerInfo(GEP->getPointerOperand(), ptrInfoMap);
   } else if (BitCastOperator *BC = dyn_cast<BitCastOperator>(V)) {
-    PI = GetPointerInfo(BC->getOperand(0), ptrInfoMap);
+    ptrInfoMap[V] = GetPointerInfo(BC->getOperand(0), ptrInfoMap);
   } else if (AddrSpaceCastInst *AC = dyn_cast<AddrSpaceCastInst>(V)) {
-    PI = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
+    ptrInfoMap[V] = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
   } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(V)) {
     if (CE->getOpcode() == LLVMAddrSpaceCast)
-      PI = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
+      ptrInfoMap[V] = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
   //} else if (PHINode *PN = dyn_cast<PHINode>(V)) {
   //  for (auto it = PN->value_op_begin(), e = PN->value_op_end(); it != e; ++it) {
   //    PI = GetPointerInfo(*it, ptrInfoMap);
@@ -79,7 +78,7 @@ PointerInfo GetPointerInfo(Value* V, PointerInfoMap &ptrInfoMap) {
   //      break;
   //  }
   }
-  return PI;
+  return ptrInfoMap[V];
 };
 
 struct ValueInfo {


### PR DESCRIPTION
Noticed a crash because of this while running PIX tests and then narrowed it down with appverif's full page-heap.
The previous "PI" variable was pointing into nowhere because the recursion could cause the map's contents to be reallocated.
"PI" could have been used safely in a few of these places, but rather than spot-fix it, I removed the use of this variable in order to preclude this class of bug from the other locations which I may or may not be exercising in my tests.