### PR TITLE
Fix issues with structured buffer load lowering

### DIFF
--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -6895,9 +6895,7 @@ static Value* TranslateStructBufVecLd(Type* VecEltTy, unsigned ElemCount,
   if (baseOffset == nullptr)
     offset = OP->GetU32Const(0);
 
-  //unsigned matSize = MatTy.getNumElements();
   std::vector<Value*> elts(ElemCount);
-
   unsigned rest = (ElemCount % 4);
   if (rest) {
     Value* ResultElts[4];

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -3578,6 +3578,10 @@ Value *GenerateStructBufLd(Value *handle, Value *bufIdx, Value *offset,
   MutableArrayRef<Value *> resultElts, hlsl::OP *OP,
   IRBuilder<> &Builder, unsigned NumComponents, Constant *alignment);
 
+static Value* TranslateStructBufVecLd(Type* VecEltTy, unsigned VecElemCount,
+  IRBuilder<>& Builder, Value* handle, hlsl::OP* OP, Value* status,
+  Value* bufIdx, Value* baseOffset, const DataLayout& DL, std::vector<Value*>& bufLds);
+
 void TranslateLoad(ResLoadHelper &helper, HLResource::Kind RK,
                    IRBuilder<> &Builder, hlsl::OP *OP, const DataLayout &DL) {
 
@@ -3607,12 +3611,36 @@ void TranslateLoad(ResLoadHelper &helper, HLResource::Kind RK,
   }
 
   if (DXIL::IsStructuredBuffer(RK)) {
-    // Basic type case for StructuredBuffer::Load()
-    Value *ResultElts[4];
-    Value *StructBufLoad = GenerateStructBufLd(helper.handle, helper.addr, OP->GetU32Const(0),
-      helper.status, EltTy, ResultElts, OP, Builder, numComponents, Alignment);
-    dxilutil::MigrateDebugValue(helper.retVal, StructBufLoad);
-    Value *retValNew = ScalarizeElements(Ty, ResultElts, Builder);
+    Type* RetTy = helper.retVal->getType();
+    unsigned ElemCount = RetTy->isVectorTy() ? RetTy->getVectorNumElements() : 1;
+    std::vector<Value*> bufLds;
+    const bool isBool = EltTy->isIntegerTy(1);
+
+    // Bool are represented as i32 in memory
+    Type* MemReprTy = isBool ? Builder.getInt32Ty() : EltTy;
+    Value* retValNew = TranslateStructBufVecLd(MemReprTy, ElemCount, Builder, helper.handle, OP, helper.status,
+      helper.addr, OP->GetU32Const(0), DL, bufLds);
+    DXASSERT_NOMSG(!bufLds.empty());
+    dxilutil::MigrateDebugValue(helper.retVal, bufLds.front());
+
+    if (isBool) {
+      // Convert result back to register representation.
+      retValNew = Builder.CreateICmpNE(retValNew, Constant::getNullValue(retValNew->getType()));
+    }
+
+    // We always get a vector from TranslateStructBufVecLd(). For vec1 case,
+    // convert it to scalar if needed to match the target type.
+    // Ex 1: For stbuf.Load<float1x1>(i), both the new value type and
+    // the target type is <1 x float>. No conversion needed here.
+    //
+    // Ex 2: For stbuf.Load<float>(i), the new value type is <1 x float>, but
+    // the target type is float, so we need a conversion here.
+    Type* NewValTy = retValNew->getType();
+    if (NewValTy->isVectorTy() && NewValTy->getVectorNumElements() == 1 &&
+       helper.retVal->getType() == NewValTy->getVectorElementType()) {
+      retValNew = Builder.CreateExtractElement(retValNew, (uint64_t) 0);
+    }
+
     helper.retVal->replaceAllUsesWith(retValNew);
     helper.retVal = retValNew;
     return;
@@ -6856,34 +6884,34 @@ void GenerateStructBufSt(Value *handle, Value *bufIdx, Value *offset,
   Builder.CreateCall(dxilF, Args);
 }
 
-Value *TranslateStructBufMatLd(Type *matType, IRBuilder<> &Builder,
-                               Value *handle, hlsl::OP *OP, Value *status,
-                               Value *bufIdx, Value *baseOffset,
-                               const DataLayout &DL) {
-  HLMatrixType MatTy = HLMatrixType::cast(matType);
-  Type *EltTy = MatTy.getElementTypeForMem();
-  unsigned  EltSize = DL.getTypeAllocSize(EltTy);
+
+static Value* TranslateStructBufVecLd(Type* VecEltTy, unsigned ElemCount,
+  IRBuilder<>& Builder, Value* handle, hlsl::OP* OP, Value* status,
+  Value* bufIdx, Value* baseOffset, const DataLayout& DL, std::vector<Value*> &bufLds) {
+  unsigned  EltSize = DL.getTypeAllocSize(VecEltTy);
   Constant* alignment = OP->GetI32Const(EltSize);
 
-  Value *offset = baseOffset;
+  Value* offset = baseOffset;
   if (baseOffset == nullptr)
     offset = OP->GetU32Const(0);
 
-  unsigned matSize = MatTy.getNumElements();
-  std::vector<Value *> elts(matSize);
+  //unsigned matSize = MatTy.getNumElements();
+  std::vector<Value*> elts(ElemCount);
 
-  unsigned rest = (matSize % 4);
+  unsigned rest = (ElemCount % 4);
   if (rest) {
-    Value *ResultElts[4];
-    GenerateStructBufLd(handle, bufIdx, offset, status, EltTy, ResultElts, OP, Builder, 3, alignment);
+    Value* ResultElts[4];
+    Value *bufLd = GenerateStructBufLd(handle, bufIdx, offset, status, VecEltTy, ResultElts, OP, Builder, rest, alignment);
+    bufLds.emplace_back(bufLd);
     for (unsigned i = 0; i < rest; i++)
       elts[i] = ResultElts[i];
     offset = Builder.CreateAdd(offset, OP->GetU32Const(EltSize * rest));
   }
 
-  for (unsigned i = rest; i < matSize; i += 4) {
-    Value *ResultElts[4];
-    GenerateStructBufLd(handle, bufIdx, offset, status, EltTy, ResultElts, OP, Builder, 4, alignment);
+  for (unsigned i = rest; i < ElemCount; i += 4) {
+    Value* ResultElts[4];
+    Value* bufLd = GenerateStructBufLd(handle, bufIdx, offset, status, VecEltTy, ResultElts, OP, Builder, 4, alignment);
+    bufLds.emplace_back(bufLd);
     elts[i] = ResultElts[0];
     elts[i + 1] = ResultElts[1];
     elts[i + 2] = ResultElts[2];
@@ -6893,7 +6921,19 @@ Value *TranslateStructBufMatLd(Type *matType, IRBuilder<> &Builder,
     offset = Builder.CreateAdd(offset, OP->GetU32Const(4 * EltSize));
   }
 
-  Value *Vec = HLMatrixLower::BuildVector(EltTy, elts, Builder);
+  Value* Vec = HLMatrixLower::BuildVector(VecEltTy, elts, Builder);
+  return Vec;
+}
+
+Value *TranslateStructBufMatLd(Type *matType, IRBuilder<> &Builder,
+                               Value *handle, hlsl::OP *OP, Value *status,
+                               Value *bufIdx, Value *baseOffset,
+                               const DataLayout &DL) {
+  HLMatrixType MatTy = HLMatrixType::cast(matType);
+  Type *EltTy = MatTy.getElementTypeForMem();
+  unsigned matSize = MatTy.getNumElements();
+  std::vector<Value*> bufLds;
+  Value* Vec = TranslateStructBufVecLd(EltTy, matSize, Builder, handle, OP, status, bufIdx, baseOffset, DL, bufLds);
   Vec = MatTy.emitLoweredMemToReg(Vec, Builder);
   return Vec;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_load_method.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_load_method.hlsl
@@ -1,0 +1,48 @@
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1x1 %s | FileCheck %s -check-prefix=CHK_MAT1x1
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool1x2 %s | FileCheck %s -check-prefix=CHK_MAT1x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int2x1 %s | FileCheck %s -check-prefix=CHK_MAT2x1
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint2x2 %s | FileCheck %s -check-prefix=CHK_MAT2x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float16_t2x3 %s | FileCheck %s -check-prefix=CHK_MAT2x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint16_t3x2 %s | FileCheck %s -check-prefix=CHK_MAT3x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float3x3 %s | FileCheck %s -check-prefix=CHK_MAT3x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int3x4 %s | FileCheck %s -check-prefix=CHK_MAT3x4
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool4x3 %s | FileCheck %s -check-prefix=CHK_MAT4x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint4x4 %s | FileCheck %s -check-prefix=CHK_MAT4x4
+
+
+// CHK_MAT1x1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+
+// CHK_MAT1x2: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 4)
+
+// CHK_MAT2x1: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 4)
+
+// CHK_MAT2x2: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+
+// CHK_MAT2x3: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT2x3: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 2)
+
+// CHK_MAT3x2: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT3x2: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 2)
+
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 4)
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 20, i8 15, i32 4)
+
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 48, i8 15, i32 4)
+
+StructuredBuffer<TY> stbuf;
+
+TY main (int i : IN0) : OUT {
+  return stbuf.Load(i);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_load_method.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_load_method.hlsl
@@ -1,3 +1,5 @@
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float %s | FileCheck %s -check-prefix=CHK_SCALAR
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1 %s | FileCheck %s -check-prefix=CHK_VEC1
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1x1 %s | FileCheck %s -check-prefix=CHK_MAT1x1
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool1x2 %s | FileCheck %s -check-prefix=CHK_MAT1x2
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int2x1 %s | FileCheck %s -check-prefix=CHK_MAT2x1
@@ -9,6 +11,10 @@
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool4x3 %s | FileCheck %s -check-prefix=CHK_MAT4x3
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint4x4 %s | FileCheck %s -check-prefix=CHK_MAT4x4
 
+
+// CHK_SCALAR: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+
+// CHK_VEC1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
 
 // CHK_MAT1x1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_subscript_method.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_subscript_method.hlsl
@@ -1,0 +1,48 @@
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1x1 %s | FileCheck %s -check-prefix=CHK_MAT1x1
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool1x2 %s | FileCheck %s -check-prefix=CHK_MAT1x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int2x1 %s | FileCheck %s -check-prefix=CHK_MAT2x1
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint2x2 %s | FileCheck %s -check-prefix=CHK_MAT2x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float16_t2x3 %s | FileCheck %s -check-prefix=CHK_MAT2x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint16_t3x2 %s | FileCheck %s -check-prefix=CHK_MAT3x2
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float3x3 %s | FileCheck %s -check-prefix=CHK_MAT3x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int3x4 %s | FileCheck %s -check-prefix=CHK_MAT3x4
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool4x3 %s | FileCheck %s -check-prefix=CHK_MAT4x3
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint4x4 %s | FileCheck %s -check-prefix=CHK_MAT4x4
+
+
+// CHK_MAT1x1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+
+// CHK_MAT1x2: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 4)
+
+// CHK_MAT2x1: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 4)
+
+// CHK_MAT2x2: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+
+// CHK_MAT2x3: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT2x3: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 2)
+
+// CHK_MAT3x2: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT3x2: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 2)
+
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 4, i8 15, i32 4)
+// CHK_MAT3x3: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 20, i8 15, i32 4)
+
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT3x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT4x3: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 16, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 32, i8 15, i32 4)
+// CHK_MAT4x4: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 48, i8 15, i32 4)
+
+StructuredBuffer<TY> stbuf;
+
+TY main (int i : IN0) : OUT {
+  return stbuf[i];
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_subscript_method.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/struct_buf_mat_subscript_method.hlsl
@@ -1,3 +1,5 @@
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float %s | FileCheck %s -check-prefix=CHK_SCALAR
+// RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1 %s | FileCheck %s -check-prefix=CHK_VEC1
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=float1x1 %s | FileCheck %s -check-prefix=CHK_MAT1x1
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool1x2 %s | FileCheck %s -check-prefix=CHK_MAT1x2
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=int2x1 %s | FileCheck %s -check-prefix=CHK_MAT2x1
@@ -9,6 +11,10 @@
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=bool4x3 %s | FileCheck %s -check-prefix=CHK_MAT4x3
 // RUN: %dxc -E main -T vs_6_2 -enable-16bit-types -DTY=uint4x4 %s | FileCheck %s -check-prefix=CHK_MAT4x4
 
+
+// CHK_SCALAR: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
+
+// CHK_VEC1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
 
 // CHK_MAT1x1: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %{{.*}}, i32 %{{.*}}, i32 0, i8 1, i32 4)
 


### PR DESCRIPTION
Fixes three issues related to lowering of structured buffer load. 

The first one is a crash in templated structured buffer load on matrices of size > 4 when using `.Load()` method. The same worked fine for subscript-based loads. For the case of subscript-based loads, the matrix type is not lowered to vector type in `HLMatrixLower`. This allows special handling of matrix type in `HLOperationLower` as the type information is preserved. For the `.Load()` method case, the matrix type is lowered to vector type in `HLMatrixLower` itself. Therefore in the `HLOperationLower` pass, the lowering of matrix-load using the `.Load` method was getting treated as just another load of vector type and was causing a crash when the component count of vector exceeds 4 (in case of matrices).  This PR refactors the lowering code used for the subscript-based matrix load into a new function `TranslateStructBufVecLd` which can lower load for any size vectors (including scalar). The same method (`TranslateStructBufVecLd`) is now also used for lowering loads involving the `.Load()` method.

The second issue is related to not handling bool types correctly for the `.Load()` case. `Boolean` type is represented as `i32` in memory, but we were not converting `i1` to `i32` before lowering which was causing an assert in debug mode and also validation errors as `i1` overload for dxil op `rawBufferLoad` is not supported.

The third issue is that for subscript-based load, we were hardcoding the component count to 3 in some cases leading to mask getting wrongly set as 7. It works fine for the `.Load()` case.

Fixes #2219, #3448, #3449