### PR TITLE
Update append/consume tests

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/ConsumeStructuredBuffer/consume_mat_col_major.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/ConsumeStructuredBuffer/consume_mat_col_major.hlsl
@@ -27,21 +27,21 @@ TY main() : OUT
 // CHK_MAT2x2: i32 %{{.*}}, i32 0, i8 15, i32 4)
 
 // CHK_MAT2x3: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT2x3: i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT2x3: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT2x3: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT2x3: i32 %{{.*}}, i32 4, i8 15, i32 2)
+// CHK_MAT2x3: i32 %{{.*}}, i32 8, i8 3, i32 2)
 
 // CHK_MAT3x2: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT3x2: i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT3x2: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT3x2: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT3x2: i32 %{{.*}}, i32 4, i8 15, i32 2)
+// CHK_MAT3x2: i32 %{{.*}}, i32 8, i8 3, i32 2)
 
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 0, i8 1, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 2, i8 15, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 8, i8 15, i32 2)
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 10, i8 15, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 16, i8 1, i32 2)
 
 // CHK_MAT3x4: dx.op.rawBufferLoad.f32(i32 139, 
 // CHK_MAT3x4: i32 %{{.*}}, i32 0, i8 15, i32 4)

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/ConsumeStructuredBuffer/consume_mat_row_major.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/ConsumeStructuredBuffer/consume_mat_row_major.hlsl
@@ -27,21 +27,21 @@ TY main() : OUT
 // CHK_MAT2x2: i32 %{{.*}}, i32 0, i8 15, i32 4)
 
 // CHK_MAT2x3: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT2x3: i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT2x3: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT2x3: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT2x3: i32 %{{.*}}, i32 4, i8 15, i32 2)
+// CHK_MAT2x3: i32 %{{.*}}, i32 8, i8 3, i32 2)
 
 // CHK_MAT3x2: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT3x2: i32 %{{.*}}, i32 0, i8 3, i32 2)
+// CHK_MAT3x2: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT3x2: dx.op.rawBufferLoad.i16(i32 139, 
-// CHK_MAT3x2: i32 %{{.*}}, i32 4, i8 15, i32 2)
+// CHK_MAT3x2: i32 %{{.*}}, i32 8, i8 3, i32 2)
 
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 0, i8 1, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 0, i8 15, i32 2)
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 2, i8 15, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 8, i8 15, i32 2)
 // CHK_MAT3x3: dx.op.rawBufferLoad.f16(i32 139, 
-// CHK_MAT3x3: i32 %{{.*}}, i32 10, i8 15, i32 2)
+// CHK_MAT3x3: i32 %{{.*}}, i32 16, i8 1, i32 2)
 
 // CHK_MAT3x4: dx.op.rawBufferLoad.f32(i32 139, 
 // CHK_MAT3x4: i32 %{{.*}}, i32 0, i8 15, i32 4)


### PR DESCRIPTION
The change in #3462 introduced changes in the ordering of `rawBufferLoad` dxil op. This necessitates updates in a couple of tests added as part of #3460. Both changes went in parallel which is why the tests missed the update.