### PR TITLE
Consider ranges when counting UAVs for 64UAV

### DIFF
--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -316,16 +316,13 @@ void DxilModule::CollectShaderFlagsForModule(ShaderFlags &Flags) {
 
   const ShaderModel *SM = GetShaderModel();
 
-  unsigned NumUAVs = m_UAVs.size();
+  unsigned NumUAVs = 0;
   const unsigned kSmallUAVCount = 8;
-  if (NumUAVs > kSmallUAVCount)
-    Flags.Set64UAVs(true);
-  if (NumUAVs && !(SM->IsCS() || SM->IsPS()))
-    Flags.SetUAVsAtEveryStage(true);
 
   bool hasRawAndStructuredBuffer = false;
 
   for (auto &UAV : m_UAVs) {
+    NumUAVs += UAV->GetRangeSize();
     if (UAV->IsROV())
       Flags.SetROVs(true);
     switch (UAV->GetKind()) {
@@ -338,6 +335,12 @@ void DxilModule::CollectShaderFlagsForModule(ShaderFlags &Flags) {
       break;
     }
   }
+  if (NumUAVs > kSmallUAVCount)
+    Flags.Set64UAVs(true);
+  if (NumUAVs && !(SM->IsCS() || SM->IsPS()))
+    Flags.SetUAVsAtEveryStage(true);
+
+
   for (auto &SRV : m_SRVs) {
     switch (SRV->GetKind()) {
     case DXIL::ResourceKind::RawBuffer:

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uav64.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uav64.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+
+// Verify that 9 UAVs will set the 64Uav shader flag
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK: 64 UAV slots
+// CHECK: @main
+
+RWBuffer<float> output : register(u0);
+RWStructuredBuffer<float> g_buf1 : register(u1);
+RWStructuredBuffer<float> g_buf2 : register(u2);
+RWStructuredBuffer<float> g_buf3 : register(u3);
+RWStructuredBuffer<float> g_buf4 : register(u4);
+RWStructuredBuffer<float> g_buf5 : register(u5);
+RWStructuredBuffer<float> g_buf6 : register(u6);
+RWStructuredBuffer<float> g_buf7 : register(u7);
+RWStructuredBuffer<float> g_buf8 : register(u8);
+
+[numthreads(8,8,1)]
+void main(uint GI : SV_GroupIndex) {
+    output[GI] = g_buf1[GI] + g_buf2[GI] + g_buf3[GI] + g_buf4[GI] +
+                 g_buf5[GI] + g_buf6[GI] + g_buf7[GI] + g_buf8[GI];
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uavArray64.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uavArray64.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+
+// Verify that 9 UAVs in an array will still add the 64Uav shader flag
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK: 64 UAV slots
+// CHECK: @main
+
+RWBuffer<float> output : register(u0);
+RWStructuredBuffer<float> g_buf[8] : register(u1);
+
+[numthreads(8,8,1)]
+void main(uint GI : SV_GroupIndex) {
+    output[GI] = g_buf[1][GI] + g_buf[2][GI] + g_buf[3][GI] + g_buf[4][GI] +
+                 g_buf[5][GI] + g_buf[6][GI] + g_buf[7][GI];
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uavUnboundArray64.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/uavUnboundArray64.hlsl
@@ -1,16 +1,15 @@
 // RUN: %dxilver 1.6 | %dxc -E main -T cs_6_0 %s | FileCheck %s
 
-// Verify that 9 UAVs in an array will still add the 64Uav shader flag
+// Verify that an unbounded array will add the 64Uav shader flag
 
 // CHECK: Note: shader requires additional functionality:
 // CHECK: 64 UAV slots
 // CHECK: @main
 
 RWBuffer<float> output : register(u0);
-RWStructuredBuffer<float> g_buf[8] : register(u1);
+RWStructuredBuffer<float> g_buf[] : register(u1);
 
 [numthreads(8,8,1)]
 void main(uint GI : SV_GroupIndex) {
-    output[GI] = g_buf[1][GI] + g_buf[2][GI] + g_buf[3][GI] + g_buf[4][GI] +
-                 g_buf[5][GI] + g_buf[6][GI] + g_buf[7][GI];
+    output[GI] = g_buf[1][GI] + g_buf[2][GI] + g_buf[3][GI] + g_buf[4][GI];
 }


### PR DESCRIPTION
The 64UAV flag is meant to indicate that 9 or more UAVs are in use.
Previously, each UAV was considered as one regardless of range. By
adding up the ranges, we get a more accurate determinatiohn.

Fixes: #2964