### PR TITLE
[spirv] remove groupshared from tests with PS

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.isomorphism.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main
 
 struct R {
   int a;
@@ -37,6 +37,7 @@ groupshared S gsarr[10];
 // CHECK: %starr = OpVariable %_ptr_Private__arr_S_uint_10 Private
 static S starr[10];
 
+[numthreads(1, 1, 1)]
 void main() {
 // CHECK:    %fn = OpVariable %_ptr_Function_S Function
   S fn;

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
@@ -4,7 +4,7 @@
 
 // CHECK: rich.debug.debugsource.multiple.hlsl
 // CHECK: spirv.debug.opline.include-file-3.hlsl
-// CHECK: [[file3_code:%\d+]] = OpString "groupshared int b;
+// CHECK: [[file3_code:%\d+]] = OpString "int b;
 // CHECK: spirv.debug.opline.include-file-2.hlsl
 // CHECK: [[file2_code:%\d+]] = OpString "static int a;
 // CHECK: spirv.debug.opline.include-file-1.hlsl

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
@@ -21,7 +21,7 @@ RWStructuredBuffer<R> rwsb;
 
 void decr(inout R a, in R b, out R c, R d, const R e);
 
-groupshared R r[5];
+static R r[5];
 
 R getR(uint i);
 
@@ -50,11 +50,11 @@ void foo(in float4 a, out float3 b) {
 
 // CHECK:                     OpLine [[file]] 54 1
 // CHECK-NEXT:      %R_incr = OpFunction %void None
-// CHECK-NEXT:  %param_this = OpFunctionParameter %_ptr_Function_R_0
+// CHECK-NEXT:  %param_this = OpFunctionParameter %_ptr_Function_R
 void R::incr() { ++a; }
 
 // CHECK:                     OpLine [[file]] 60 1
-// CHECK-NEXT:        %getR = OpFunction %R_0 None
+// CHECK-NEXT:        %getR = OpFunction %R None
 // CHECK-NEXT:                OpLine [[file]] 60 13
 // CHECK-NEXT:           %i = OpFunctionParameter %_ptr_Function_uint
 R getR(uint i) { return r[i]; }
@@ -62,9 +62,9 @@ R getR(uint i) { return r[i]; }
 // CHECK:                     OpLine [[file]] 68 1
 // CHECK-NEXT:        %decr = OpFunction %void None
 // CHECK-NEXT:                OpLine [[file]] 68 19
-// CHECK-NEXT:         %a_0 = OpFunctionParameter %_ptr_Function_R_0
+// CHECK-NEXT:         %a_0 = OpFunctionParameter %_ptr_Function_R
 // CHECK-NEXT:                OpLine [[file]] 68 27
-// CHECK-NEXT:         %b_0 = OpFunctionParameter %_ptr_Function_R_0
+// CHECK-NEXT:         %b_0 = OpFunctionParameter %_ptr_Function_R
 void decr(inout R a, in R b, out R c, R d, const R e) { a.a--; }
 
 // CHECK:             OpLine [[file]] 11 1

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include-file-3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include-file-3.hlsl
@@ -1,4 +1,4 @@
-groupshared int b;
+int b;
 
 int function3() {
   return b;

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
@@ -11,7 +11,7 @@
 // CHECK-NEXT: OpSource HLSL 600 [[file2]] "static int a;
 // CHECK:      [[file3:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-3.hlsl
-// CHECK-NEXT: OpSource HLSL 600 [[file3]] "groupshared int b;
+// CHECK-NEXT: OpSource HLSL 600 [[file3]] "int b;
 
 // CHECK:                  OpLine [[main]] 65 1
 // CHECK-NEXT: %src_main = OpFunction %void None
@@ -101,4 +101,4 @@ void main() {
 // CHECK:      OpLine [[file3]] 3 1
 // CHECK-NEXT: %function3 = OpFunction %int None
 // CHECK:      OpLine [[file3]] 4 10
-// CHECK-NEXT: OpLoad %int %b
+// CHECK:      OpLoad %int

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.intrinsic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.intrinsic.hlsl
@@ -3,7 +3,7 @@
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.intrinsic.hlsl
 
-groupshared int dest_i;
+static int dest_i;
 
 void main() {
   float2 v2f;
@@ -75,9 +75,9 @@ void main() {
 // CHECK-NEXT: {{%\d+}} = OpExtInst %v2float {{%\d+}} FClamp
   v2f = saturate(v2f);
 
-// CHECK:      OpLine [[file]] 80 17
-// CHECK-NEXT: OpAtomicCompareExchange %int %dest_i %uint_1 %uint_0 %uint_0
-  /* comment */ InterlockedCompareStore(dest_i, v4i.x, v4i.y);
+// CHECK: OpLine [[file]] 80 26
+// CHECK: OpAny
+  /* comment */ dest_i = any(v4i);
 
 // CHECK:                     OpLine [[file]] 87 41
 // CHECK-NEXT: [[idx:%\d+]] = OpIAdd %uint

--- a/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.enum.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main
+// Run: %dxc -T cs_6_0 -E main
 
 //CHECK:      %First = OpVariable %_ptr_Private_int Private %int_0
 //CHECK-NEXT: %Second = OpVariable %_ptr_Private_int Private %int_1
@@ -24,6 +24,7 @@ AppendStructuredBuffer<Number> c;
 void testParam(Number param) {}
 void testParamTypeCast(int param) {}
 
+[numthreads(1, 1, 1)]
 void main() {
 //CHECK:      [[a:%\d+]] = OpLoad %int %a
 //CHECK-NEXT:              OpStore %foo [[a]]


### PR DESCRIPTION
`groupshared` variables must not be used in pixel shaders.
This commit removes groupshared variables from unit tests with PS.