### PR TITLE
[spirv] support non-int type SV_DispatchThreadId

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.cs.float.dispatch-thread-id.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.cs.float.dispatch-thread-id.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T cs_6_0 -E main
+
+// CHECK: %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3int Input
+
+// CHECK: %in_var_SV_DispatchThreadID = OpVariable %_ptr_Function_v2float Function
+
+// CHECK:         [[load:%\d+]] = OpLoad %v3int %gl_GlobalInvocationID
+// CHECK-NEXT: [[shuffle:%\d+]] = OpVectorShuffle %v2int [[load]] [[load]] 0 1
+// CHECK-NEXT:    [[cast:%\d+]] = OpConvertSToF %v2float [[shuffle]]
+// CHECK-NEXT:                    OpStore %in_var_SV_DispatchThreadID [[cast]]
+// CHECK-NEXT:                    OpLoad %v2float %in_var_SV_DispatchThreadID
+
+RWStructuredBuffer<float4> rwTexture;
+
+[numthreads(1, 1, 1)]
+void main(float2 id : SV_DispatchThreadID)
+{
+    rwTexture[3] = id.xxxx;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1561,6 +1561,10 @@ TEST_F(FileTest, SpirvStageIO16bitTypes) {
   runFileTest("spirv.stage-io.16bit.hlsl");
 }
 
+TEST_F(FileTest, DispatchThreadIdWithFloatType) {
+  runFileTest("spirv.interface.cs.float.dispatch-thread-id.hlsl");
+}
+
 TEST_F(FileTest, SpirvInterpolationPS) {
   runFileTest("spirv.interpolation.ps.hlsl");
 }


### PR DESCRIPTION
Based on the SPIR-V spec, we cannot use types other than a vector
with 3 integer element for `%gl_GlobalInvocationID`. However, HLSL
`SV_DispatchThreadId` stage variable allows other types. This
difference results in a SPIR-V validation error when we use float for
`SV_DispatchThreadId`. This commit fixes the issue.

Fixes #3443