### PR TITLE
Avoid trying to get disubprogram without debug MD

### DIFF
--- a/lib/Transforms/Utils/InlineFunction.cpp
+++ b/lib/Transforms/Utils/InlineFunction.cpp
@@ -881,6 +881,9 @@ static void fixupLineNumbers(Function *Fn, Function::iterator FI,
   // get a location. Fix it here by giving it a dummy location so the debug
   // info is well-formed.
   if (!TheCallDL) {
+    // If no debug metadata, don't bother trying to find the subprog
+    if (!getDebugMetadataVersionFromModule(*Fn->getParent()))
+      return;
     if (DISubprogram *Subprogram = getDISubprogram(Fn)) {
       TheCallDL = DebugLoc(llvm::DILocation::get(Fn->getContext(), 0, 0, Subprogram));
       TheCall->setDebugLoc(TheCallDL);


### PR DESCRIPTION
When trying to fixup line numbers when inlining a function, if the call
instruction had no debug location, the DIsubprogram was queried. That
query took a very long time and was pointless when there is no debug
info.

The code now checks for debug metatdata before trying to get the
disubprogram

Fixes #3130