### PR TITLE
Add barycentric shader flag when used

### DIFF
--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -293,6 +293,7 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   bool hasMulticomponentUAVLoads = false;
   bool hasViewportOrRTArrayIndex = false;
   bool hasShadingRate = false;
+  bool hasBarycentrics = false;
   bool hasSamplerFeedback = false;
   bool hasRaytracingTier1_1 = false;
   bool hasAtomicInt64OnTypedResource = false;
@@ -467,6 +468,9 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
       case Semantic::Kind::ShadingRate:
         hasShadingRate = true;
         break;
+      case Semantic::Kind::Barycentrics:
+        hasBarycentrics = true;
+        break;
       default:
         break;
       }
@@ -531,6 +535,7 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   flag.SetViewID(hasViewID);
   flag.SetViewportAndRTArrayIndex(hasViewportOrRTArrayIndex);
   flag.SetShadingRate(hasShadingRate);
+  flag.SetBarycentrics(hasBarycentrics);
   flag.SetSamplerFeedback(hasSamplerFeedback);
   flag.SetRaytracingTier1_1(hasRaytracingTier1_1);
   flag.SetAtomicInt64OnTypedResource(hasAtomicInt64OnTypedResource);

--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -409,6 +409,9 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
         case DXIL::OpCode::GeometryIndex:
           hasRaytracingTier1_1 = true;
           break;
+        case DXIL::OpCode::AttributeAtVertex:
+          hasBarycentrics = true;
+        break;
         case DXIL::OpCode::AtomicBinOp:
         case DXIL::OpCode::AtomicCompareExchange:
           if (isInt64) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertex.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertex.hlsl
@@ -1,5 +1,9 @@
 // RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 %s | FileCheck %s
 
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NEXT: Barycentrics
+
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 0, i32 0, i8 0, i8 0)
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 0, i32 0, i8 1, i8 0)
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 0, i32 0, i8 2, i8 0)

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexInt.hlsl
@@ -1,5 +1,9 @@
 // RUN: %dxilver 1.6 | %dxc -E main -T ps_6_2 -HV 2018 -enable-16bit-types %s | FileCheck %s
 
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NEXT: Barycentrics
+
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 0, i8 0)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 1, i8 0)
 // CHECK: call i32 @dx.op.attributeAtVertex.i32(i32 137, i32 0, i32 0, i8 2, i8 0)

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexNoOpt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pixel/attr/attributeAtVertexNoOpt.hlsl
@@ -1,5 +1,8 @@
 // RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 -O0 %s | FileCheck %s
 
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NEXT: Barycentrics
+
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 0, i8 0)
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 1, i8 0)
 // CHECK: call float @dx.op.attributeAtVertex.f32(i32 137, i32 1, i32 0, i8 2, i8 0)

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_barycentrics/barycentrics.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_barycentrics/barycentrics.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 %s | FileCheck %s
 
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NEXT: Barycentrics
 // CHECK: !"SV_Barycentrics"
 
 float4 main(float3 bary : SV_Barycentrics) : SV_Target

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_barycentrics/barycentrics1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_barycentrics/barycentrics1.hlsl
@@ -1,5 +1,8 @@
 // RUN: %dxilver 1.1 | %dxc -E main -T ps_6_1 %s | FileCheck %s
 
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NEXT: Barycentrics
+
 // CHECK: ; SV_Barycentrics
 // CHECK: ; SV_Barycentrics
 // CHECK: ; SV_Barycentrics


### PR DESCRIPTION
A Dxil shader flag should be added when SV_Barycentrics semantic is
used. It was defined and member variables created for it, but it wasn't
actually set.
