### PR TITLE
Fix PackUnpackTest on HW without 16-bit support

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -7936,6 +7936,12 @@ TEST_F(ExecutionTest, PackUnpackTest) {
     }
 #endif
 
+    if (!DoesDeviceSupportNative16bitOps(pDevice)) {
+        WEX::Logging::Log::Comment(L"Device does not support native 16-bit operations.");
+        WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+        return;
+    }
+
     int tableSize = sizeof(PackUnpackOpParameters) / sizeof(TableParameter);
     TableParameterHandler handler(PackUnpackOpParameters, tableSize);
 


### PR DESCRIPTION
On devices without native 16-bit support, PackUnpackTest fails to run.  Check and skip the test when unsupported.

D3D12 ERROR: ID3D12Device::CreateComputeShader: Shader uses native 16bit ops, but the device does not support this. To check for support, check device caps via the CheckFeatureSupport() API [ STATE_CREATION ERROR #622: CREATESHADER_INVALIDBYTECODE]