### PR TITLE
Fix Dynamic Resources when used with -Od

### DIFF
--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -667,6 +667,12 @@ std::pair<bool, DxilResourceProperties> GetHLSLResourceProperties(llvm::Type *Ty
     if (name == "RaytracingAccelerationStructure")
       return RetType(true, MakeResourceProperties(hlsl::DXIL::ResourceKind::RTAccelerationStructure, false, false, false));
 
+    if (name.startswith("ConstantBuffer<"))
+      return RetType(true, MakeResourceProperties(hlsl::DXIL::ResourceKind::CBuffer, false, false, false));
+
+    if (name.startswith("TextureBuffer<"))
+      return RetType(true, MakeResourceProperties(hlsl::DXIL::ResourceKind::TBuffer, false, false, false));
+
     if (ConsumePrefix(name, "FeedbackTexture2D")) {
       hlsl::DXIL::ResourceKind kind = hlsl::DXIL::ResourceKind::Invalid;
       if (ConsumePrefix(name, "Array"))
@@ -676,6 +682,8 @@ std::pair<bool, DxilResourceProperties> GetHLSLResourceProperties(llvm::Type *Ty
 
       if (name.startswith("<"))
         return RetType(true, MakeResourceProperties(kind, false, false, false));
+
+      return FalseRet;
     }
 
     bool ROV = ConsumePrefix(name, "RasterizerOrdered");
@@ -732,6 +740,9 @@ bool IsHLSLObjectType(llvm::Type *Ty) {
     StringRef name = ST->getName();
     // TODO: don't check names.
     if (name.startswith("dx.types.wave_t"))
+      return true;
+
+    if (name.compare("dx.types.Handle") == 0)
       return true;
 
     if (name.endswith("_slice_type"))

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/NonUniformDynamic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/NonUniformDynamic.hlsl
@@ -1,4 +1,7 @@
 // RUN: %dxc -T cs_6_6 %s | %FileCheck %s
+// RUN: %dxc -T cs_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T cs_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKOD
+// RUN: %dxc -T cs_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKOD
 
 // Make sure nonUniformIndex is true.
 // CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 %{{[0-9]+}}, i1 false, i1 true)
@@ -19,3 +22,6 @@ void main( uint2 ID : SV_DispatchThreadID) {
   float v = read(ID.x);
   write(ID.y, v);
 }
+
+// Exclude quoted source file (see readme)
+// CHECKOD-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/annotateHandle.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/annotateHandle.hlsl
@@ -1,12 +1,17 @@
 // RUN: %dxc -T ps_6_6 %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T ps_6_6 -Zi -Od %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
 // Make sure generate createHandleFromBinding for sm6.6.
-// CHECK:call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
-// CHECK:call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 3 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK:call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)
+// CHECK:call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 3 }, i32 0, i1 false)
 // Make sure sampler and texture get correct annotateHandle.
 
-// CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<F32>
-// CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerState
+// CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })
+// CHECK-SAME: resource: Texture2D<F32>
+// CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })
+// CHECK-SAME: resource: SamplerState
 
 SamplerState samplers : register(s0);
 SamplerState foo() { return samplers; }
@@ -16,3 +21,6 @@ float4 main( float2 uv : TEXCOORD ) : SV_TARGET {
   float4 val = t0.Sample(foo(), uv);
   return val;
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap.hlsl
@@ -1,9 +1,17 @@
 // RUN: %dxc -T ps_6_6 %s | %FileCheck %s
-// CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 %{{.*}}, i1 false, i1 false)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
-// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 10, i32 265 })  ; AnnotateHandle(res,props)  resource: TypedBuffer<F32>
+// RUN: %dxc -T ps_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T ps_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+
+// CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 %{{.*}}, i1 false, i1 false)
+// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 10, i32 265 })
+// CHECK-SAME: resource: TypedBuffer<F32>
 
 uint ID;
 float main(uint i:I): SV_Target {
   Buffer<float> buf = ResourceDescriptorHeap[ID];
   return buf[i];
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap2.hlsl
@@ -1,12 +1,18 @@
 // RUN: %dxc -T ps_6_6 %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T ps_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
 // Make sure snorm/unorm and globallycoherent works.
 // CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218
-// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 4106, i32 270 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<UNormF32>
+// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 4106, i32 270 })
+// CHECK-SAME: resource: RWTypedBuffer<UNormF32>
 // CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218
-// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20490, i32 269 })  ; AnnotateHandle(res,props)  resource: globallycoherent RWTypedBuffer<SNormF32>
+// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20490, i32 269 })
+// CHECK-SAME: resource: globallycoherent RWTypedBuffer<SNormF32>
 // CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218
-// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20490, i32 269 })  ; AnnotateHandle(res,props)  resource: globallycoherent RWTypedBuffer<SNormF32>
+// CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20490, i32 269 })
+// CHECK-SAME: resource: globallycoherent RWTypedBuffer<SNormF32>
 
 
 struct S {
@@ -22,3 +28,6 @@ float main(uint i:I): SV_Target {
   s.buf1[1] = ResourceDescriptorHeap[ID+2];
   return s.buf[i] + s.buf1[0][i] + s.buf1[1][i];
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap3.hlsl
@@ -1,9 +1,14 @@
 // RUN: %dxc -T ps_6_6 %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T ps_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
-//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 false, i1 false)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
-//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<F32>
-//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 true, i1 false)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
-//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerState
+//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 false, i1 false)
+//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })
+//CHECK-SAME: resource: Texture2D<F32>
+//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 true, i1 false)
+//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })
+//CHECK-SAME: resource: SamplerState
 
 
 [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED|SAMPLER_HEAP_DIRECTLY_INDEXED)")]
@@ -14,3 +19,6 @@ float4 main(float2 c:C) : SV_Target {
   return t.Sample(s, c);
 
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap4.hlsl
@@ -1,11 +1,17 @@
 // RUN: %dxc -T ps_6_6 %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T ps_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T ps_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
-//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 false, i1 false)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
-//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 13, i32 4 })  ; AnnotateHandle(res,props)  resource: CBuffer
-//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 1, i1 false, i1 false)  ; CreateHandleFromHeap(index,samplerHeap,nonUniformIndex)
-//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 15, i32 4 })  ; AnnotateHandle(res,props)  resource: TBuffer
-//CHECK:call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %{{.*}}, i32 0)  ; CBufferLoadLegacy(handle,regIndex)
-//CHECK:call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %{{.*}}, i32 0, i32 undef)  ; BufferLoad(srv,index,wot)
+//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 false, i1 false)
+//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 13, i32 4 })
+//CHECK-SAME: resource: CBuffer
+//CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 1, i1 false, i1 false)
+//CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 15, i32 4 })
+//CHECK-SAME: resource: TBuffer
+//CHECK:call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(i32 59, %dx.types.Handle %{{.*}}, i32 0)
+//CHECK:call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %{{.*}}, i32 0, i32 undef)
+
 struct A {
   float a;
 };
@@ -19,3 +25,6 @@ TextureBuffer<A> T= ResourceDescriptorHeap[1];
   return C.a * T.a;
 
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib.hlsl
@@ -1,4 +1,7 @@
 // RUN: %dxc -T lib_6_6 %s | %FileCheck %s
+// RUN: %dxc -T lib_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T lib_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T lib_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
 // Make sure each entry get 2 createHandleFromHeap.
 // CHECK:define void
@@ -33,3 +36,6 @@ void csmain2(uint ix : SV_GroupIndex)
 {
   g_result[ix] = g_rawBuf.Load<float>(ix+ID);
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib2.hlsl
@@ -1,4 +1,7 @@
 // RUN: %dxc -T lib_6_6 %s | %FileCheck %s
+// RUN: %dxc -T lib_6_6 -Od %s | %FileCheck %s
+// RUN: %dxc -T lib_6_6 -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
+// RUN: %dxc -T lib_6_6 -Od -Zi %s | %FileCheck %s -check-prefixes=CHECK,CHECKZI
 
 // Make sure each entry get 2 createHandleFromHeap.
 // CHECK:define void
@@ -42,3 +45,6 @@ void RayGeneration()
 {
   g_result[0] = g_rawBuf.Load<float>(1);
 }
+
+// Exclude quoted source file (see readme)
+// CHECKZI-LABEL: {{!"[^"]*\\0A[^"]*"}}


### PR DESCRIPTION
- SROA was not skipping handle type, now present with dynamic resources
  changes, or ConstantBuffer<> / TextureBuffer<> types, as it should.
- Updated unit tests to add combinations of -Od and -Zi.