### PR TITLE
Add used by atomics resource flag

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -1861,7 +1861,7 @@ The following signature shows the operation syntax::
 
   ; overloads: SM5.1: i32,  SM6.0: i32
   ; returns: original value in memory before the operation
-  declare i32 @dx.op.atomicBinOp.i32(
+  declare i32 @dx.op.atomicCompareExchange.i32(
       i32,                  ; opcode
       %dx.types.Handle,     ; resource handle
       i32,                  ; coordinate c0

--- a/include/dxc/DXIL/DxilResource.h
+++ b/include/dxc/DXIL/DxilResource.h
@@ -66,6 +66,9 @@ public:
   bool IsTBuffer() const;
   bool IsFeedbackTexture() const;
 
+  bool HasAtomic64Use() const;
+  void SetHasAtomic64Use(bool b);
+
   static bool classof(const DxilResourceBase *R) {
     return R->GetClass() == DXIL::ResourceClass::SRV || R->GetClass() == DXIL::ResourceClass::UAV;
   }
@@ -78,6 +81,7 @@ private:
   bool m_bGloballyCoherent;
   bool m_bHasCounter;
   bool m_bROV;
+  bool m_bHasAtomic64Use;
 };
 
 } // namespace hlsl

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -179,6 +179,12 @@ enum class PSVResourceKind
   NumEntries
 };
 
+enum class PSVResourceFlag
+{
+  None           = 0x00000000,
+  UsedByAtomic64 = 0x00000001,
+};
+
 // Table of null-terminated strings, overall size aligned to dword boundary, last byte must be null
 struct PSVStringTable {
   const char *Table;
@@ -203,6 +209,7 @@ struct PSVResourceBindInfo0
 struct PSVResourceBindInfo1 : public PSVResourceBindInfo0
 {
   uint32_t ResKind;     // PSVResourceKind
+  uint32_t ResFlags;    // special characteristics of the resource
 };
 
 // Helpers for output dependencies (ViewID and Input-Output tables)

--- a/lib/DXIL/DxilResource.cpp
+++ b/lib/DXIL/DxilResource.cpp
@@ -149,6 +149,14 @@ bool DxilResource::IsFeedbackTexture() const {
   return GetKind() == Kind::FeedbackTexture2D || GetKind() == Kind::FeedbackTexture2DArray;
 }
 
+bool DxilResource::HasAtomic64Use() const {
+  return m_bHasAtomic64Use;
+}
+
+void DxilResource::SetHasAtomic64Use(bool b) {
+  m_bHasAtomic64Use = b;
+}
+
 unsigned DxilResource::GetNumCoords(Kind ResourceKind) {
   const unsigned CoordSizeTab[] = {
       0, // Invalid = 0,

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -764,6 +764,7 @@ public:
       pBindInfo->UpperBound = R->GetUpperBound();
       if (pBindInfo1) {
         pBindInfo1->ResKind = (UINT)R->GetKind();
+        pBindInfo1->ResFlags |= R->HasAtomic64Use()? (UINT)PSVResourceFlag::UsedByAtomic64 : 0;
       }
       uResIndex++;
     }


### PR DESCRIPTION
To identify resources that are used in 64-bit atomics operations in order to catch invalid use of heap resources 