### PR TITLE
64-bit atomics usage resource flags

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1416,8 +1416,9 @@ namespace DXIL {
   const uint64_t ShaderFeatureInfo_AtomicInt64OnTypedResource = 0x400000;
   const uint64_t ShaderFeatureInfo_AtomicInt64OnGroupShared = 0x800000;
   const uint64_t ShaderFeatureInfo_DerivativesInMeshAndAmpShaders = 0x1000000;
+  const uint64_t ShaderFeatureInfo_AtomicInt64OnHeapResource = 0x2000000;
 
-  const unsigned ShaderFeatureInfoCount = 25;
+  const unsigned ShaderFeatureInfoCount = 26;
 
   // DxilSubobjectType must match D3D12_STATE_SUBOBJECT_TYPE, with
   // certain values reserved, since they cannot be used from Dxil.

--- a/include/dxc/DXIL/DxilMetadataHelper.h
+++ b/include/dxc/DXIL/DxilMetadataHelper.h
@@ -199,6 +199,7 @@ public:
   static const unsigned kDxilTypedBufferElementTypeTag            = 0;
   static const unsigned kDxilStructuredBufferElementStrideTag     = 1;
   static const unsigned kDxilSamplerFeedbackKindTag               = 2;
+  static const unsigned kDxilAtomic64UseTag                       = 3;
 
   // Type system.
   static const char kDxilTypeSystemMDName[];

--- a/include/dxc/DXIL/DxilResourceProperties.h
+++ b/include/dxc/DXIL/DxilResourceProperties.h
@@ -89,8 +89,7 @@ llvm::Constant *getAsConstant(const DxilResourceProperties &, llvm::Type *Ty,
                               const ShaderModel &);
 DxilResourceProperties loadPropsFromConstant(const llvm::Constant &C);
 DxilResourceProperties
-loadPropsFromAnnotateHandle(DxilInst_AnnotateHandle &annotateHandle, llvm::Type *Ty,
-                       const ShaderModel &);
+loadPropsFromAnnotateHandle(DxilInst_AnnotateHandle &annotateHandle, const ShaderModel &);
 DxilResourceProperties loadPropsFromResourceBase(const DxilResourceBase *);
 
 } // namespace resource_helper

--- a/include/dxc/DXIL/DxilShaderFlags.h
+++ b/include/dxc/DXIL/DxilShaderFlags.h
@@ -120,6 +120,9 @@ namespace hlsl {
     void SetAtomicInt64OnGroupShared(bool flag) { m_bAtomicInt64OnGroupShared = flag; }
     bool GetAtomicInt64OnGroupShared() const { return m_bAtomicInt64OnGroupShared; }
 
+    void SetAtomicInt64OnHeapResource(bool flag) { m_bAtomicInt64OnHeapResource = flag; }
+    bool GetAtomicInt64OnHeapResource() const { return m_bAtomicInt64OnHeapResource; }
+
     void SetDerivativesInMeshAndAmpShaders(bool flag) { m_bDerivativesInMeshAndAmpShaders = flag; }
     bool GetDerivativesInMeshAndAmpShaders() { return m_bDerivativesInMeshAndAmpShaders; }
 
@@ -162,11 +165,13 @@ namespace hlsl {
     unsigned m_bSamplerFeedback : 1; // SHADER_FEATURE_SAMPLER_FEEDBACK
 
     unsigned m_bAtomicInt64OnTypedResource : 1; // SHADER_FEATURE_ATOMIC_INT64_ON_TYPED_RESOURCE
-    unsigned m_bAtomicInt64OnGroupShared : 1;//SHADER_FEATURE_ATOMIC_INT64_ON_GROUP_SHARED
+    unsigned m_bAtomicInt64OnGroupShared : 1; // SHADER_FEATURE_ATOMIC_INT64_ON_GROUP_SHARED
 
     unsigned m_bDerivativesInMeshAndAmpShaders : 1; //SHADER_FEATURE_DERIVATIVES_IN_MESH_AND_AMPLIFICATION_SHADERS
 
-    unsigned m_align0 : 2;        // align to 32 bit.
+    unsigned m_bAtomicInt64OnHeapResource : 1; // SHADER_FEATURE_ATOMIC_INT64_ON_DESCRIPTOR_HEAP_RESOURCE
+
+    unsigned m_align0 : 1;        // align to 32 bit.
     uint32_t m_align1;            // align to 64 bit.
   };
 

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2244,6 +2244,11 @@ void DxilExtraPropertyHelper::EmitUAVProperties(const DxilResource &UAV, std::ve
     MDVals.emplace_back(DxilMDHelper::Uint32ToConstMD(DxilMDHelper::kDxilSamplerFeedbackKindTag, m_Ctx));
     MDVals.emplace_back(DxilMDHelper::Uint32ToConstMD((unsigned)UAV.GetSamplerFeedbackType(), m_Ctx));
   }
+  // Whether resource is used for 64-bit atomic op
+  if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 6) >= 0 && UAV.HasAtomic64Use()) {
+    MDVals.emplace_back(DxilMDHelper::Uint32ToConstMD(DxilMDHelper::kDxilAtomic64UseTag, m_Ctx));
+    MDVals.emplace_back(DxilMDHelper::Uint32ToConstMD((unsigned)true, m_Ctx));
+  }
 }
 
 void DxilExtraPropertyHelper::LoadUAVProperties(const MDOperand &MDO, DxilResource &UAV) {
@@ -2274,6 +2279,9 @@ void DxilExtraPropertyHelper::LoadUAVProperties(const MDOperand &MDO, DxilResour
     case DxilMDHelper::kDxilSamplerFeedbackKindTag:
       DXASSERT_NOMSG(UAV.IsFeedbackTexture());
       UAV.SetSamplerFeedbackType((DXIL::SamplerFeedbackType)DxilMDHelper::ConstMDToUint32(MDO));
+      break;
+    case DxilMDHelper::kDxilAtomic64UseTag:
+      UAV.SetHasAtomic64Use(DxilMDHelper::ConstMDToBool(MDO));
       break;
     default:
       DXASSERT(false, "Unknown resource record tag");

--- a/lib/DXIL/DxilResourceProperties.cpp
+++ b/lib/DXIL/DxilResourceProperties.cpp
@@ -130,7 +130,7 @@ DxilResourceProperties loadPropsFromConstant(const Constant &C) {
 
 DxilResourceProperties
 loadPropsFromAnnotateHandle(DxilInst_AnnotateHandle &annotateHandle,
-                            llvm::Type *Ty, const ShaderModel &SM) {
+                            const ShaderModel &SM) {
   Constant *ResProp = cast<Constant>(annotateHandle.get_props());
   return loadPropsFromConstant(*ResProp);
 }

--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -55,8 +55,8 @@ ShaderFlags::ShaderFlags():
 , m_bSamplerFeedback(false)
 , m_bAtomicInt64OnTypedResource(false)
 , m_bAtomicInt64OnGroupShared(false)
-, m_bAtomicInt64OnHeapResource(false)
 , m_bDerivativesInMeshAndAmpShaders(false)
+, m_bAtomicInt64OnHeapResource(false)
 , m_align0(0)
 , m_align1(0)
 {
@@ -484,7 +484,7 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
             if (DxilResource *res = GetResourceFromAnnotateHandle(handleCall, resMap)) {
               res->SetHasAtomic64Use(true);
             } else {
-              // assuming CreateHandleFromHeap, which is always dynamic
+              // Assuming CreateHandleFromHeap, which indicates a descriptor
               hasAtomicInt64OnHeapResource = true;
             }
           }

--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -2290,7 +2290,7 @@ bool DxilLowerCreateHandleForLib::PatchDynamicTBuffers(DxilModule &DM) {
     CallInst *CI = cast<CallInst>(U);
     DxilInst_AnnotateHandle annot(CI);
     DxilResourceProperties RP = resource_helper::loadPropsFromAnnotateHandle(
-        annot, hlslOP->GetResourcePropertiesType(), *DM.GetShaderModel());
+        annot, *DM.GetShaderModel());
 
     if (RP.getResourceKind() != DXIL::ResourceKind::TBuffer)
       continue;

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -600,7 +600,6 @@ struct ValidationContext {
         }
       }
     }
-    Type *ResPropTy = hlslOP->GetResourcePropertiesType();
     const ShaderModel &SM = *DxilMod.GetShaderModel();
 
     for (auto &it : hlslOP->GetOpFuncList(DXIL::OpCode::AnnotateHandle)) {
@@ -612,7 +611,7 @@ struct ValidationContext {
         CallInst *CI = cast<CallInst>(U);
         DxilInst_AnnotateHandle hdl(CI);
         DxilResourceProperties RP =
-            resource_helper::loadPropsFromAnnotateHandle(hdl, ResPropTy, SM);
+            resource_helper::loadPropsFromAnnotateHandle(hdl, SM);
         if (RP.getResourceKind() == DXIL::ResourceKind::Invalid) {
           EmitInstrError(CI, ValidationRule::InstrOpConstRange);
           continue;

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_dynamic_resource.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_dynamic_resource.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s
+// Test atomic operations on dynamic resources
+
+// CHECK: RGInt64OnDescriptorHeapIndex
+// CHCK: Note: shader requires additional functionality:
+// CHCK: 64-bit Atomics on Typed Resources
+// CHCK: 64-bit Atomics on Heap Resources
+
+[shader("raygeneration")]
+void RGInt64OnDescriptorHeapIndex()
+{
+    RWTexture2D<int64_t> myTexture = ResourceDescriptorHeap[7];
+    InterlockedAdd(myTexture[int2(0,0)], 1);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_heap_resource.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_heap_resource.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_6 %s | FileCheck %s
+// Test atomic operations on heap resources
+
+// For now just check that it compiles.
+// TODO: improve disassembly output for resources to verify the flag
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK: 64-bit Atomics on Typed Resources
+
+RWTexture2D<int64_t> myTexture : register (u0);
+
+void main() : SV_Target
+{
+    InterlockedAdd(myTexture[int2(0,0)], 1);
+}

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -342,7 +342,8 @@ PCSTR g_pFeatureInfoNames[] = {
     "Sampler feedback",
     "64-bit Atomics on Typed Resources",
     "64-bit Atomics on Group Shared",
-    "Derivatives in mesh and amplification shaders"
+    "Derivatives in mesh and amplification shaders",
+    "64-bit Atomics on Heap Resources",
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount, "g_pFeatureInfoNames needs to be updated");
 


### PR DESCRIPTION
When a resource comes from a binding, we can't determine if it is on a
heap or not, so we set a flag on it to let the runtime sort it out.

When a resource comes from the heap directly, we know it's on the heap
so we set the shader flag to check for platform support.