### PR TITLE
Correct atomics on heap usage for libs

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -148,6 +148,7 @@ enum class DxilResourceFlag : uint32_t {
   UAVCounter                = 1 << 1,
   UAVRasterizerOrderedView  = 1 << 2,
   DynamicIndexing           = 1 << 3,
+  Atomics64Use              = 1 << 4,
 };
 
 struct RuntimeDataResourceInfo {

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1179,8 +1179,6 @@ private:
         info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVGloballyCoherent);
       if (pRes->IsROV())
         info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVRasterizerOrderedView);
-      if (pRes->IsROV())
-        info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVRasterizerOrderedView);
       if (pRes->HasAtomic64Use())
         info.Flags |= static_cast<uint32_t>(DxilResourceFlag::Atomics64Use);
       // TODO: add dynamic index flag

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1179,6 +1179,10 @@ private:
         info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVGloballyCoherent);
       if (pRes->IsROV())
         info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVRasterizerOrderedView);
+      if (pRes->IsROV())
+        info.Flags |= static_cast<uint32_t>(DxilResourceFlag::UAVRasterizerOrderedView);
+      if (pRes->HasAtomic64Use())
+        info.Flags |= static_cast<uint32_t>(DxilResourceFlag::Atomics64Use);
       // TODO: add dynamic index flag
     }
     m_pResourceTable->Insert(info);

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_root_resource.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_i64_root_resource.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s
+// Make sure library targets correctly identify non-dynamic resources
+
+// CHECK: Note: shader requires additional functionality:
+// CHECK-NOT: 64-bit Atomics on Heap Resources
+
+
+RWStructuredBuffer<int64_t> myBuf : register(u0);
+
+[shader("raygeneration")]
+[RootSignature("UAV(u0)")]
+void RGInt64OnDescriptorHeapIndex()
+{
+    InterlockedAdd(myBuf[0], 1);
+}


### PR DESCRIPTION
The previous shader flag code failed to account for the library-specific
handle creation function