### PR TITLE
Add CHECK_HR around CreatePipelineState

### DIFF
--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -478,7 +478,7 @@ void ShaderOpTest::CreatePipelineState() {
     ID3D12Device2 *pDevice2;
     CHECK_HR(m_pDevice->QueryInterface(&pDevice2));
 
-    pDevice2->CreatePipelineState(&PDesc, IID_PPV_ARGS(&m_pPSO));
+    CHECK_HR(pDevice2->CreatePipelineState(&PDesc, IID_PPV_ARGS(&m_pPSO)));
   }
 #endif
   else {


### PR DESCRIPTION
ShaderOpTest::CreatePipelineState needs to check the return code from ID3D12Device2::CreatePipelineState so failures immediately stop here.

Otherwise we might get a failure in a subsequent call like when CommandListRefs::CreateForDevice() calls ID3D12Device::CreateCommandQueue() - this one will fail with return code 0x887a0005 - The GPU device instance has been suspended. Use GetDeviceRemovedReason to determine the appropriate action.