### PR TITLE
Return Scatterer object for argument values

### DIFF
--- a/lib/Transforms/Scalar/Scalarizer.cpp
+++ b/lib/Transforms/Scalar/Scalarizer.cpp
@@ -316,7 +316,7 @@ Scatterer Scalarizer::scatter(Instruction *Point, Value *V) {
     auto InsertPoint = BB->begin();
     while (InsertPoint != BB->end() && isa<DbgInfoIntrinsic>(InsertPoint))
       InsertPoint++;
-    Scatterer(BB, InsertPoint, V, AllowFolding, &Scattered[V]);
+    return Scatterer(BB, InsertPoint, V, AllowFolding, &Scattered[V]);
     // HLSL Change - End
   }
   if (Instruction *VOp = dyn_cast<Instruction>(V)) {

--- a/tools/clang/test/HLSLFileCheck/passes/llvm/scalarizer/argument_scatter.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/llvm/scalarizer/argument_scatter.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// Test for failure where the extractelement ops ended up after the loop phi that used them
+// Resulted in a crash in LCSSA, but the order could have been out of whack regardless
+
+// make sure the four extractions come before their usage in the loop
+// CHECK: [[X:%[A-Za-z0-9\.]+]] = extractelement <4 x float> {{%?[A-Za-z0-9]+}}, i32 0
+// CHECK: [[Y:%[A-Za-z0-9\.]+]] = extractelement <4 x float> {{%?[A-Za-z0-9]+}}, i32 1
+// CHECK: [[Z:%[A-Za-z0-9\.]+]] = extractelement <4 x float> {{%?[A-Za-z0-9]+}}, i32 2
+// CHECK: [[W:%[A-Za-z0-9\.]+]] = extractelement <4 x float> {{%?[A-Za-z0-9]+}}, i32 3
+
+// CHECK: phi float {{.*}}[[X]],
+// CHECK: phi float {{.*}}[[Y]],
+// CHECK: phi float {{.*}}[[Z]],
+// CHECK: phi float {{.*}}[[W]],
+
+export
+float4 ScatterLoop(float4 color, int ct) {
+  // surprised this can't be unrolled
+  for( int i = 0; i < ct; i++ )
+    color += 1;
+  return color;
+}


### PR DESCRIPTION
An unrelated earlier change mistakenly removed the return on a line
calling the Scatterer constructor for an argument value. As a result,
the constructor is called, but the resulting object which would insert
new extraction ops in the entry block is not used at all. Instead,
the default case is encountered where the vector PHI op is used as an
insertion point, which places the extractions after the new scalar PHIs
that use them. This is caught in the loop case by an assert because the
assumptions that caused LCSSA to be skipped for this BB are faulty.