### PR TITLE
Fix unbound arrays flattened type compare

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5262,6 +5262,8 @@ public:
   QualType getCurrentElement() const;
   /// <summary>Get the number of repeated current elements.</summary>
   unsigned int getCurrentElementSize() const;
+  /// <summary>Gets the current element's Iterkind.</summary>
+  FlattenedIterKind getCurrentElementKind() const { return m_typeTrackers.back().IterKind; }
   /// <summary>Checks whether the iterator has a current element type to report.</summary>
   bool hasCurrentElement() const;
   /// <summary>Consumes count elements on this iterator.</summary>
@@ -10996,6 +10998,11 @@ FlattenedTypeIterator::CompareIterators(
       rightIter.replaceExpr(convertedExpr.get());
       advance = 1;
     }
+
+    // If both elements are unbound arrays, break out or we'll never finish
+    if (leftIter.getCurrentElementKind() == FK_IncompleteArray &&
+        rightIter.getCurrentElementKind() == FK_IncompleteArray)
+      break;
 
     leftIter.advanceCurrentElement(advance);
     rightIter.advanceCurrentElement(advance);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unbound_unbound_init.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unbound_unbound_init.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T ps_6_0  %s | FileCheck %s
+
+// Verify that error for unbounded array struct member is produced
+// even if the struct is initialized with a resource that is an unbounded array
+// Previously, this would hang the compiler
+
+Texture2D unboundResource[] : register(t0);
+
+// CHECK:  error: array dimensions of struct/class members must be explicit
+static const struct {
+  Texture2D unboundField[];
+} unboundStruct = { unboundResource };
+
+float4 main() {
+  return 0.0;
+}


### PR DESCRIPTION
Comparing two unbound arrays where one was initilizing the other
resulted in infinitely incrementing both and never reaching a
conclusion.

This adds detection to FlattenedTypeIterator for the situation whereupon
the comparison is terminated and the result returned.

A simple test of the assignment is added expecting the correct error.