### PR TITLE
[spirv] Generate RelaxedPrecision decorations also for arrays of minimum precision variables

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -86,6 +86,13 @@ bool isMx1Matrix(QualType type, QualType *elemType = nullptr,
 bool isMxNMatrix(QualType type, QualType *elemType = nullptr,
                  uint32_t *rowCount = nullptr, uint32_t *colCount = nullptr);
 
+/// Returns true if the given type will be translated into a SPIR-V array type.
+///
+/// Writes the element type and count into *elementType and *count respectively
+/// if they are not nullptr.
+bool isArrayType(QualType type, QualType *elemType = nullptr,
+                 uint32_t *elemCount = nullptr);
+
 /// \brief Returns true if the given type is a ConstantBuffer or an array of
 /// ConstantBuffers.
 bool isConstantBuffer(QualType);

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -266,7 +266,6 @@ bool isSubpassInputMS(QualType type) {
 }
 
 bool isArrayType(QualType type, QualType *elemType, uint32_t *elemCount) {
-  bool isArray = type->isArrayType();
   if (const auto *arrayType = type->getAsArrayTypeUnsafe()) {
     if (elemType)
       *elemType = arrayType->getElementType();

--- a/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.array.hlsl
@@ -1,0 +1,46 @@
+// Run: %dxc -T cs_6_0 -E main
+
+// CHECK:                      OpDecorate %testShared RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate %test RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate %testTypedef RelaxedPrecision
+// CHECK-NOT:                  OpDecorate %notMin16 RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate %a RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[compositeConstr1:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[compositeConstr2:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadFromTest1:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadFromTest2:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadFromTestTypedef:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[multiply1:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadVariable1:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[multiply2:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadFromShared:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[loadVariable2:%\d+]] RelaxedPrecision
+// CHECK-NEXT:                 OpDecorate [[multiply3:%\d+]] RelaxedPrecision
+
+typedef min16float ArrayOfMin16Float0[2];
+typedef ArrayOfMin16Float0 ArrayOfMin16Float;
+
+groupshared min16float testShared[2];
+
+[numthreads(1, 1, 1)] void main()
+{
+// CHECK: [[compositeConstr1:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 %float_1 %float_1
+    min16float test[2] = { 1.0, 1.0 };
+// CHECK: [[compositeConstr2:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 %float_1 %float_1
+    ArrayOfMin16Float testTypedef = { 1.0, 1.0 };
+    float notMin16[2] = { 1.0, 1.0 };
+// CHECK: [[loadFromTest1:%\d+]] = OpLoad %float {{%\d+}}
+    testShared[0] = test[0];
+
+    min16float a = 1.0;
+// CHECK: [[loadFromTest2:%\d+]] = OpLoad %float {{%\d+}}
+// CHECK: [[loadFromTestTypedef:%\d+]] = OpLoad %float {{%\d+}}
+// CHECK: [[multiply1:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}
+// CHECK: [[loadVariable1:%\d+]] = OpLoad %float %a
+// CHECK: [[multiply2:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}
+    a *= (test[0] * testTypedef[0]);
+// CHECK: [[loadFromShared:%\d+]] = OpLoad %float {{%\d+}}
+// CHECK: [[loadVariable2:%\d+]] = OpLoad %float %a
+// CHECK: [[multiply3:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}
+    a *= testShared[0];
+}

--- a/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.array.hlsl
@@ -24,13 +24,13 @@ groupshared min16float testShared[2];
 
 [numthreads(1, 1, 1)] void main()
 {
+// CHECK: [[compositeConstr2:%\d+]] = OpCompositeConstruct %_arr_v2float_uint_2 {{%\d+}} {{%\d+}}
+    min16float2 test[2] = { float2(1.0, 1.0), float2(1.0, 1.0) };
 // CHECK: [[compositeConstr1:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 %float_1 %float_1
-    min16float test[2] = { 1.0, 1.0 };
-// CHECK: [[compositeConstr2:%\d+]] = OpCompositeConstruct %_arr_float_uint_2 %float_1 %float_1
     ArrayOfMin16Float testTypedef = { 1.0, 1.0 };
     float notMin16[2] = { 1.0, 1.0 };
 // CHECK: [[loadFromTest1:%\d+]] = OpLoad %float {{%\d+}}
-    testShared[0] = test[0];
+    testShared[0] = test[0].x;
 
     min16float a = 1.0;
 // CHECK: [[loadFromTest2:%\d+]] = OpLoad %float {{%\d+}}
@@ -38,7 +38,7 @@ groupshared min16float testShared[2];
 // CHECK: [[multiply1:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}
 // CHECK: [[loadVariable1:%\d+]] = OpLoad %float %a
 // CHECK: [[multiply2:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}
-    a *= (test[0] * testTypedef[0]);
+    a *= (test[0].x * testTypedef[0]);
 // CHECK: [[loadFromShared:%\d+]] = OpLoad %float {{%\d+}}
 // CHECK: [[loadVariable2:%\d+]] = OpLoad %float %a
 // CHECK: [[multiply3:%\d+]] = OpFMul %float {{%\d+}} {{%\d+}}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2315,6 +2315,9 @@ TEST_F(FileTest, DecorationRelaxedPrecisionImage) {
 TEST_F(FileTest, DecorationRelaxedPrecisionBool) {
   runFileTest("decoration.relaxed-precision.bool.hlsl");
 }
+TEST_F(FileTest, DecorationRelaxedPrecisionArray) {
+  runFileTest("decoration.relaxed-precision.array.hlsl");
+}
 
 // For NoContraction decorations
 TEST_F(FileTest, DecorationNoContraction) {


### PR DESCRIPTION
Currently, arrays of min16float etc. types don't get a RelaxedPrecision decoration for the OpVariable. This has some real performance implications since at least some hardware can fit more RelaxedPrecision variables into registers, and maybe also groupshared memory.

This pull request add the missing RelaxedPrecision decoration for OpVariables of array types in a similar way vector and matrix minimum precision types are already handled.