### PR TITLE
Correct WaveSensitivity debug test iterations

### DIFF
--- a/lib/HLSL/WaveSensitivityAnalysis.cpp
+++ b/lib/HLSL/WaveSensitivityAnalysis.cpp
@@ -111,9 +111,10 @@ void WaveSensitivityAnalyzer::Analyze(Function *F) {
           }
         }
 #ifndef NDEBUG
-        for (User *U : Phi->users()) {
-          Instruction *UI = cast<Instruction>(U);
-          DXASSERT_LOCALVAR(UI, GetInstState(UI) != KnownSensitive, "Unknown wave-status Phi argument should not be able to be known sensitive");
+        for (unsigned i = 0; i < Phi->getNumOperands(); ++i) {
+          if (Instruction *IArg = dyn_cast<Instruction>(Phi->getOperand(i))) {
+            DXASSERT_LOCALVAR(UI, GetInstState(IArg) != KnownSensitive, "Unknown wave-status Phi argument should not be able to be known sensitive");
+          }
         }
 #endif
         if (allPredsVisited)


### PR DESCRIPTION
Instead of verifying that the args of an known phi were not known to be
sensitive, it was checking the users, which can very well be wave
sensitive