### PR TITLE
Texture2DMS fixes: missing ResProp data; reflection default NumSamples = 0

### DIFF
--- a/lib/DXIL/DxilResourceProperties.cpp
+++ b/lib/DXIL/DxilResourceProperties.cpp
@@ -159,7 +159,6 @@ DxilResourceProperties loadPropsFromResourceBase(const DxilResourceBase *Res) {
       break;
     case DXIL::ResourceKind::Texture2DMS:
     case DXIL::ResourceKind::Texture2DMSArray:
-      break;
     case DXIL::ResourceKind::TypedBuffer:
     case DXIL::ResourceKind::Texture1D:
     case DXIL::ResourceKind::Texture2D:

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1631,7 +1631,9 @@ void DxilModuleReflection::CreateReflectionObjectForResource(DxilResourceBase *R
     if (inputBind.NumSamples == 0) {
       if (R->IsStructuredBuffer()) {
         inputBind.NumSamples = CalcResTypeSize(*m_pDxilModule, *R);
-      } else if (!R->IsRawBuffer() && !R->IsTBuffer()) {
+      } else if (!R->IsRawBuffer() && !R->IsTBuffer() &&
+                 R->GetKind() != DXIL::ResourceKind::Texture2DMS &&
+                 R->GetKind() != DXIL::ResourceKind::Texture2DMSArray) {
         inputBind.NumSamples = 0xFFFFFFFF;
       }
     }

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/texture2dms.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/texture2dms.hlsl
@@ -1,0 +1,86 @@
+// RUN: %dxc -T ps_6_0 -E main %s | %D3DReflect %s | FileCheck %s
+
+Texture2DMS<float4> msTexture;
+Texture2DMSArray<float4> msTextureArray : register(t2, space2);
+
+// Not sure what -1 means, but it's legal for fxc, and it's preserved, so we match it here.
+Texture2DMS<float4, -1> msTexture1 : register(t1);
+Texture2DMSArray<float4, -1> msTextureArray1 : register(t2);
+
+Texture2DMS<float4, 8> msTexture2 : register(t3);
+Texture2DMSArray<float4, 4> msTextureArray2 : register(t4);
+
+float4 main(uint4 color : COLOR) : SV_TARGET
+{
+  return float4(0,0,0,0)
+   + msTexture.sample[2][color.xy]
+   + msTextureArray.sample[3][color.xyz]
+   + msTexture1.sample[2][color.xy]
+   + msTextureArray1.sample[3][color.xyz]
+   + msTexture2.sample[2][color.xy]
+   + msTextureArray2.sample[3][color.xyz]
+   ;
+}
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK:   Bound Resources:
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 0
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 0
+// CHECK-NEXT:      Space: 0
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
+// CHECK-NEXT:      NumSamples (or stride): 0
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 1
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 2
+// CHECK-NEXT:      Space: 2
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMSARRAY
+// CHECK-NEXT:      NumSamples (or stride): 0
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture1
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 2
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 1
+// CHECK-NEXT:      Space: 0
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
+// CHECK-NEXT:      NumSamples (or stride): 4294967295
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray1
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 3
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 2
+// CHECK-NEXT:      Space: 0
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMSARRAY
+// CHECK-NEXT:      NumSamples (or stride): 4294967295
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture2
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 4
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 3
+// CHECK-NEXT:      Space: 0
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
+// CHECK-NEXT:      NumSamples (or stride): 8
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
+// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray2
+// CHECK-NEXT:      Type: D3D_SIT_TEXTURE
+// CHECK-NEXT:      uID: 5
+// CHECK-NEXT:      BindCount: 1
+// CHECK-NEXT:      BindPoint: 4
+// CHECK-NEXT:      Space: 0
+// CHECK-NEXT:      ReturnType: D3D_RETURN_TYPE_FLOAT
+// CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMSARRAY
+// CHECK-NEXT:      NumSamples (or stride): 4
+// CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/annotateHandle.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/annotateHandle.hlsl
@@ -9,7 +9,7 @@
 // Make sure sampler and texture get correct annotateHandle.
 
 // CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })
-// CHECK-SAME: resource: Texture2D<F32>
+// CHECK-SAME: resource: Texture2D<4xF32>
 // CHECK-DAG:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })
 // CHECK-SAME: resource: SamplerState
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/createFromHeap3.hlsl
@@ -10,7 +10,7 @@
 
 //CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 false, i1 false)
 //CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 2, i32 1033 })
-//CHECK-SAME: resource: Texture2D<F32>
+//CHECK-SAME: resource: Texture2D<4xF32>
 //CHECK:call %dx.types.Handle @dx.op.createHandleFromHeap(i32 218, i32 0, i1 true, i1 false)
 //CHECK:call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 14, i32 0 })
 //CHECK-SAME: resource: SamplerState

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
@@ -1,0 +1,66 @@
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1          | FileCheck %s -D ELTY=F32   -D PROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,0  | FileCheck %s -D ELTY=F32   -D PROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,8  | FileCheck %s -D ELTY=F32   -D PROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1                     | FileCheck %s -D ELTY=F32   -D PROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=2                     | FileCheck %s -D ELTY=2xF32 -D PROP1=521
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=3                     | FileCheck %s -D ELTY=3xF32 -D PROP1=777
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float                            | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,0                    | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,8                    | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
+
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=int                              | FileCheck %s -D ELTY=4xI32 -D PROP1=1028
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=uint                             | FileCheck %s -D ELTY=4xU32 -D PROP1=1029
+
+// half is float for shader type unless -enable-16bit-types is specified
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=half                             | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=half       -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
+
+// component type is shader type, not storage type,
+// so it's 16-bit for min-precision with or without -enable-16bit-types
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float                       | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int                         | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int   -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
+
+// Native 16-bit type looks the same in props as min16
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float16_t  -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=int16_t    -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
+
+// Ensure that MS textures from heap have expected properties
+
+// CHECK: 
+// CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 3, i32 [[PROP1]] })
+// CHECK-SAME: resource: Texture2DMS<[[ELTY]]>
+// CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 8, i32 [[PROP1]] })
+// CHECK-SAME: resource: Texture2DMSArray<[[ELTY]]>
+
+// CT = ComponentType
+// CC = ComponentCount
+#ifndef CC
+#define CC 4
+#endif
+// SC = SampleCount
+#ifndef SC
+#define SC
+#endif
+
+#ifdef SCALAR
+Texture2DMS<CT SC> TexMS_scalar : register(t0);
+Texture2DMSArray<CT SC> TexMSA_scalar : register(t1);
+#else
+Texture2DMS<vector<CT, CC> SC> TexMS_vector : register(t0);
+Texture2DMSArray<vector<CT, CC> SC> TexMSA_vector : register(t1);
+#endif
+
+vector<CT, CC> main(int4 a : A, float4 coord : TEXCOORD) : SV_TARGET
+{
+  return (vector<CT, CC>)(0)
+#ifdef SCALAR
+    + TexMS_scalar.Load(a.xy, a.w)
+    + TexMSA_scalar.Load(a.xyz, a.w)
+#else
+    + TexMS_vector.Load(a.xy, a.w)
+    + TexMSA_vector.Load(a.xyz, a.w)
+#endif
+    ;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
@@ -1,34 +1,33 @@
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1          | FileCheck %s -D ELTY=F32   -D PROP1=265
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,0  | FileCheck %s -D ELTY=F32   -D PROP1=265
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,8  | FileCheck %s -D ELTY=F32   -D PROP1=265
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1                     | FileCheck %s -D ELTY=F32   -D PROP1=265
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=2                     | FileCheck %s -D ELTY=2xF32 -D PROP1=521
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=3                     | FileCheck %s -D ELTY=3xF32 -D PROP1=777
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float                            | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,0                    | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,8                    | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1          | FileCheck %s -DELTY=F32   -DPROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,0  | FileCheck %s -DELTY=F32   -DPROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,8  | FileCheck %s -DELTY=F32   -DPROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1                     | FileCheck %s -DELTY=F32   -DPROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=2                     | FileCheck %s -DELTY=2xF32 -DPROP1=521
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=3                     | FileCheck %s -DELTY=3xF32 -DPROP1=777
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float                            | FileCheck %s -DELTY=4xF32 -DPROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,0                    | FileCheck %s -DELTY=4xF32 -DPROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,8                    | FileCheck %s -DELTY=4xF32 -DPROP1=1033
 
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=int                              | FileCheck %s -D ELTY=4xI32 -D PROP1=1028
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=uint                             | FileCheck %s -D ELTY=4xU32 -D PROP1=1029
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=int                              | FileCheck %s -DELTY=4xI32 -DPROP1=1028
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=uint                             | FileCheck %s -DELTY=4xU32 -DPROP1=1029
 
 // half is float for shader type unless -enable-16bit-types is specified
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=half                             | FileCheck %s -D ELTY=4xF32 -D PROP1=1033
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=half       -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=half                             | FileCheck %s -DELTY=4xF32 -DPROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=half       -enable-16bit-types   | FileCheck %s -DELTY=4xF16 -DPROP1=1032
 
 // component type is shader type, not storage type,
 // so it's 16-bit for min-precision with or without -enable-16bit-types
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float                       | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int                         | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int   -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float                       | FileCheck %s -DELTY=4xF16 -DPROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16float -enable-16bit-types   | FileCheck %s -DELTY=4xF16 -DPROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int                         | FileCheck %s -DELTY=4xI16 -DPROP1=1026
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=min16int   -enable-16bit-types   | FileCheck %s -DELTY=4xI16 -DPROP1=1026
 
 // Native 16-bit type looks the same in props as min16
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float16_t  -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1032
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=int16_t    -enable-16bit-types   | FileCheck %s -D ELTY=4xF32 -D PROP1=1026
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float16_t  -enable-16bit-types   | FileCheck %s -DELTY=4xF16 -DPROP1=1032
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=int16_t    -enable-16bit-types   | FileCheck %s -DELTY=4xI16 -DPROP1=1026
 
 // Ensure that MS textures from heap have expected properties
 
-// CHECK: 
 // CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 3, i32 [[PROP1]] })
 // CHECK-SAME: resource: Texture2DMS<[[ELTY]]>
 // CHECK: call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 8, i32 [[PROP1]] })

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -1393,16 +1393,13 @@ void PrintResourceProperties(DxilResourceProperties &RP,
   case DXIL::ResourceKind::Texture2DArray:
   case DXIL::ResourceKind::TextureCubeArray:
   case DXIL::ResourceKind::TypedBuffer:
-    OS << GC << RW << ResourceKindToString(RP.getResourceKind());
-    OS << "<" << CompTypeToString(RP.getCompType())
-       << (bUAV && RP.Typed.CompCount > 1 ? "[vec]" : "")
-       << ">";
-    break;
-
   case DXIL::ResourceKind::Texture2DMS:
   case DXIL::ResourceKind::Texture2DMSArray:
-    OS << ResourceKindToString(RP.getResourceKind());
-    OS << "<" << CompTypeToString(RP.getCompType())
+    OS << GC << RW << ResourceKindToString(RP.getResourceKind());
+    OS << "<";
+    if (RP.Typed.CompCount > 1)
+      OS << std::to_string(RP.Typed.CompCount) << "x";
+    OS << CompTypeToString(RP.getCompType())
        << ">";
     break;
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -1799,6 +1799,7 @@ TEST_F(DxilContainerTest, ReflectionMatchesDXBC_CheckIn) {
   ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\d3dreflect\\cb_sizes.hlsl").c_str(), false);
   ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\d3dreflect\\tbuffer.hlsl").c_str(), false,
     D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY);
+  ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\d3dreflect\\texture2dms.hlsl").c_str(), false);
 }
 
 TEST_F(DxilContainerTest, ReflectionMatchesDXBC_Full) {


### PR DESCRIPTION
- Fix missing component type and count for Texture2DMS in ResProps
- Fix reflection for Texture2DMS with default NumSamples

Fixes #2788