### PR TITLE
Fix a misfiring assert due to unused static const involving matrix type

### DIFF
--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -531,8 +531,8 @@ void HLMatrixLowerPass::replaceAllVariableUses(
     }
 
     if (ConstantExpr *CE = dyn_cast<ConstantExpr>(Use.getUser())) {
-      DXASSERT(CE->getOpcode() == Instruction::AddrSpaceCast,
-               "Unexpected constant user");
+      DXASSERT(CE->getOpcode() == Instruction::AddrSpaceCast ||
+        CE->use_empty(), "Unexpected constant user");
       replaceAllVariableUses(GEPIdxStack, CE, LoweredPtr);
       DXASSERT_NOMSG(CE->use_empty());
       CE->destroyConstant();

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/unused_static_global_matrix_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/unused_static_global_matrix_array.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// Regression test for github issue #3579
+
+// CHECK: define void @main
+
+
+cbuffer C
+{
+ float1x1 foo[1];
+}
+
+static const float1x1 bar[1] = foo;
+
+void main() {}
+


### PR DESCRIPTION
A global static const (involving aggregate type) gets replaced in SROA Param HLSL pass if there are valid users. However, if it is dead, then it gets optimized away later in Global Variable Optimizer (globalopt) pass. This PR updates a misfiring assert in HLMatrixLowering pass to cover the case where a constexpr with no users is allowed as it gets trivially deleted in this pass.   

Fixes #3579 


