### PR TITLE
ShaderOpTest limit commandlist6 to where supported

### DIFF
--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -475,7 +475,7 @@ void ShaderOpTest::CreatePipelineState() {
     PDesc.SizeInBytes = sizeof(MDesc);
     PDesc.pPipelineStateSubobjectStream = &MDesc;
 
-    ID3D12Device2 *pDevice2;
+    CComPtr<ID3D12Device2> pDevice2;
     CHECK_HR(m_pDevice->QueryInterface(&pDevice2));
 
     CHECK_HR(pDevice2->CreatePipelineState(&PDesc, IID_PPV_ARGS(&m_pPSO)));
@@ -902,7 +902,12 @@ void ShaderOpTest::RunCommandList() {
 
 #if defined(NTDDI_WIN10_VB) && WDK_NTDDI_VERSION >= NTDDI_WIN10_VB
     if (m_pShaderOp->MS) {
-      ID3D12GraphicsCommandList6 *pList6 = m_CommandList.List.p;
+#ifndef NDEBUG
+      D3D12_FEATURE_DATA_D3D12_OPTIONS7 O7;
+      DXASSERT_LOCALVAR(O7, SUCCEEDED(m_pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS7, &O7, sizeof(O7))), "mesh shader test enabled on platform without mesh support");
+#endif
+      CComPtr<ID3D12GraphicsCommandList6> pList6;
+      CHECK_HR(m_CommandList.List.p->QueryInterface(&pList6));
       pList6->BeginQuery(m_pQueryHeap, D3D12_QUERY_TYPE_PIPELINE_STATISTICS, 0);
       pList6->DispatchMesh(1, 1, 1);
       pList6->EndQuery(m_pQueryHeap, D3D12_QUERY_TYPE_PIPELINE_STATISTICS, 0);

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -240,11 +240,7 @@ public:
 // Use this structure to refer to a command allocator/list/queue triple.
 struct CommandListRefs {
   CComPtr<ID3D12CommandAllocator> Allocator;
-#if defined(NTDDI_WIN10_VB) && WDK_NTDDI_VERSION >= NTDDI_WIN10_VB
-  CComPtr<ID3D12GraphicsCommandList6> List;
-#else
   CComPtr<ID3D12GraphicsCommandList> List;
-#endif
   CComPtr<ID3D12CommandQueue> Queue;
 
   void CreateForDevice(ID3D12Device *pDevice, bool compute);


### PR DESCRIPTION
Merged  #3600 into release-1.6.2104

Because version 6 of the command list pointer was being created whenever
the available SDK supported it, sometimes the test would try to create
version 6 where it wasn't supported.

Instead, this just stores the base pointer type and casts it up where we
know support is available.

(cherry picked from commit 30e306f3265674351d6e7e166bf39e8a976fd155)