### PR TITLE
Exec test - WAR SM feature check on older runtime

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -702,9 +702,9 @@ public:
       const UINT D3D12_FEATURE_SHADER_MODEL = 7;
       D3D12_FEATURE_DATA_SHADER_MODEL SMData;
       SMData.HighestShaderModel = testModel;
-      VERIFY_SUCCEEDED(pDevice->CheckFeatureSupport(
-        (D3D12_FEATURE)D3D12_FEATURE_SHADER_MODEL, &SMData, sizeof(SMData)));
-      if (SMData.HighestShaderModel < testModel) {
+      if (FAILED(pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_SHADER_MODEL,
+                                              &SMData, sizeof(SMData))) ||
+          SMData.HighestShaderModel < testModel) {
         UINT minor = (UINT)testModel & 0x0f;
         LogCommentFmt(L"The selected device does not support "
                       L"shader model 6.%1u", minor);


### PR DESCRIPTION
An earlier version of the D3D runtime doesn't handle CheckFeatureSupport
for FEATURE_SHADER_MODEL when the corresponding struct is set to a
unrecognized shader model. Instead of returning the highest supported
shader model that is less than the one provided as documented, the call
fails. In practice, this only occurred for 6.6 tests where the SDK had
6.6 capability, but the installed runtime did not.

To work around this, we don't verify that the call succeeds. Instead,
a failing return result is interpretted the same way as when the highest 
shader model value returned is lower than that requested.