### PR TITLE
Rename payload qualifier field to not match type

### DIFF
--- a/tools/clang/lib/Sema/SemaDXR.cpp
+++ b/tools/clang/lib/Sema/SemaDXR.cpp
@@ -67,7 +67,7 @@ struct PayloadAccessInfo {
 };
 
 struct DxrShaderDiagnoseInfo {
-  const FunctionDecl *FunctionDecl;
+  const FunctionDecl *funcDecl;
   const VarDecl *Payload;
   DXIL::PayloadAccessShaderStage Stage;
   std::vector<TraceRayCall> TraceCalls;
@@ -689,7 +689,7 @@ DiagnosePayloadAsFunctionArg(
       }
 
       if (CalleeInfo.Payload) {
-        CalleeInfo.FunctionDecl = CalledFunction;
+        CalleeInfo.funcDecl = CalledFunction;
         CalleeInfo.Stage = Info.Stage;
         auto FieldsToIgnoreRead = CollectDominatingWritesForCall(Use, Info, DT);
         auto FieldsToIgnoreWrite = CollectReachableWritesForCall(Use, Info);
@@ -925,7 +925,7 @@ DiagnosePayloadAccess(Sema &S, DxrShaderDiagnoseInfo &Info,
   clang::DominatorTree DT;
   AnalysisDeclContextManager AnalysisManager;
   AnalysisDeclContext *AnalysisContext =
-      AnalysisManager.getContext(Info.FunctionDecl);
+      AnalysisManager.getContext(Info.funcDecl);
 
   CFG &TheCFG = *AnalysisContext->getCFG();
   DT.buildDominatorTree(*AnalysisContext);
@@ -1093,7 +1093,7 @@ public:
         DiagnosePayloadParameter(S, Payload, Decl, Stage);
       }
       DxrShaderDiagnoseInfo Info;
-      Info.FunctionDecl = Decl;
+      Info.funcDecl = Decl;
       Info.Payload = Payload;
       Info.Stage = Stage;
 


### PR DESCRIPTION
Some compilers (gcc) get really unhappy when your field name matches the
type name. In the defense of such, it does make you wonder what sizeof()
would return if the member were not of its namesake's type.

Anyway, gcc should be able to build. This renames the member to differ
from the type to make all the Gnus happy.