### PR TITLE
Correct exception handler sprintf for 32-bit

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -1241,7 +1241,7 @@ static LONG CALLBACK ExceptionFilter(PEXCEPTION_POINTERS pExceptionInfo)
     else
       fputs("read", stderr);
     fputs(" from address ", stderr);
-    sprintf_s(scratch, _countof(scratch), "0x%016llx\n", pExceptionInfo->ExceptionRecord->ExceptionInformation[1]);
+    sprintf_s(scratch, _countof(scratch), "0x%p\n", (void*)pExceptionInfo->ExceptionRecord->ExceptionInformation[1]);
     fputs(scratch, stderr);
   } break;
   case EXCEPTION_STACK_OVERFLOW:


### PR DESCRIPTION
The size of ULONG_PTR varies based on the address size of the
architecture. For 32-bit systems, it was invalid to treat it like a
64-bit value. By casting the value to a void pointer and changing the
print code to %p, we get the right thing for all platforms