### PR TITLE
Internal validator error messages don't need /Zi anymore. (#3606)

### DIFF
--- a/include/dxc/HLSL/DxilValidation.h
+++ b/include/dxc/HLSL/DxilValidation.h
@@ -347,6 +347,13 @@ HRESULT ValidateDxilContainer(_In_reads_bytes_(ContainerSize) const void *pConta
                               _In_ uint32_t ContainerSize,
                               _In_ llvm::raw_ostream &DiagStream);
 
+// Full container validation, including ValidateDxilModule, with debug module
+HRESULT ValidateDxilContainer(_In_reads_bytes_(ContainerSize) const void *pContainer,
+                              _In_ uint32_t ContainerSize,
+                              const void *pOptDebugBitcode,
+                              uint32_t OptDebugBitcodeSize,
+                              _In_ llvm::raw_ostream &DiagStream);
+
 class PrintDiagnosticContext {
 private:
   llvm::DiagnosticPrinter &m_Printer;

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -511,6 +511,17 @@ struct IDxcValidator : public IUnknown {
     ) = 0;
 };
 
+CROSS_PLATFORM_UUIDOF(IDxcValidator2, "458e1fd1-b1b2-4750-a6e1-9c10f03bed92")
+struct IDxcValidator2 : public IDxcValidator {
+  // Validate a shader.
+  virtual HRESULT STDMETHODCALLTYPE ValidateWithDebug(
+    _In_ IDxcBlob *pShader,                       // Shader to validate.
+    _In_ UINT32 Flags,                            // Validation flags.
+    _In_opt_ DxcBuffer *pOptDebugBitcode,         // Optional debug module bitcode to provide line numbers
+    _COM_Outptr_ IDxcOperationResult **ppResult   // Validation output status, buffer, and errors
+    ) = 0;
+};
+
 CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder, "334b1f50-2292-4b35-99a1-25588d8c17fe")
 struct IDxcContainerBuilder : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader) = 0;                // Loads DxilContainer to the builder

--- a/include/llvm/IR/DebugInfo.h
+++ b/include/llvm/IR/DebugInfo.h
@@ -60,6 +60,7 @@ bool stripDebugInfo(Function &F);
 
 /// \brief Return Debug Info Metadata Version by checking module flags.
 unsigned getDebugMetadataVersionFromModule(const Module &M);
+bool hasDebugInfo(const Module &M); // HLSL Change - Helper function to check if there's real debug info (variables, types)
 
 /// \brief Utility to find all debug info in a module.
 ///

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -314,7 +314,7 @@ static void EmitWarningOrErrorOnGlobalVariable(llvm::LLVMContext &Ctx, GlobalVar
 
   if (GV) {
     Module &M = *GV->getParent();
-    if (getDebugMetadataVersionFromModule(M) != 0) {
+    if (hasDebugInfo(M)) {
       DebugInfoFinder FinderObj;
       DebugInfoFinder &Finder = FinderObj;
       // Debug modules have no dxil modules. Use it if you got it.

--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -560,7 +560,7 @@ public:
 
     // Load up debug information, to cross-reference values and the instructions
     // used to load them.
-    m_HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+    m_HasDbgInfo = hasDebugInfo(M);
 
     GenerateDxilResourceHandles();
 

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -201,7 +201,7 @@ public:
 
     // Load up debug information, to cross-reference values and the instructions
     // used to load them.
-    m_HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+    m_HasDbgInfo = hasDebugInfo(M);
 
     // EntrySig for shader functions.
     DxilEntryPropsMap EntryPropsMap;

--- a/lib/HLSL/HLMatrixLowerPass.cpp
+++ b/lib/HLSL/HLMatrixLowerPass.cpp
@@ -197,7 +197,7 @@ bool HLMatrixLowerPass::runOnModule(Module &M) {
   m_pHLModule = &m_pModule->GetOrCreateHLModule();
   // Load up debug information, to cross-reference values and the instructions
   // used to load them.
-  m_HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+  m_HasDbgInfo = hasDebugInfo(M);
   m_matToVecStubs = &matToVecStubs;
   m_vecToMatStubs = &vecToMatStubs;
 

--- a/lib/IR/DebugInfo.cpp
+++ b/lib/IR/DebugInfo.cpp
@@ -379,6 +379,21 @@ unsigned llvm::getDebugMetadataVersionFromModule(const Module &M) {
   return 0;
 }
 
+// HLSL Change - begin
+bool llvm::hasDebugInfo(const Module &M) {
+  // We might just get away with checking if there's "llvm.dbg.cu",
+  // but this is more robust.
+  for (Module::const_named_metadata_iterator NMI = M.named_metadata_begin(),
+                                             NME = M.named_metadata_end();
+       NMI != NME; ++NMI) {
+    if (NMI->getName().startswith("llvm.dbg.")) {
+      return true;
+    }
+  }
+  return false;
+}
+// HLSL Change - end
+
 DenseMap<const llvm::Function *, DISubprogram *>
 llvm::makeSubprogramMap(const Module &M) {
   DenseMap<const Function *, DISubprogram *> R;

--- a/lib/IR/DiagnosticInfo.cpp
+++ b/lib/IR/DiagnosticInfo.cpp
@@ -246,15 +246,12 @@ void DiagnosticInfoDxil::print(DiagnosticPrinter &DP) const {
     DP << "Function: " << Func->getName() << ": ";
   }
 
-  bool ZiPrompt = true;
   switch (getSeverity()) {
-  case DiagnosticSeverity::DS_Note:    DP << "note: "; ZiPrompt = false; break;
-  case DiagnosticSeverity::DS_Remark:  DP << "remark: "; ZiPrompt = false; break;
+  case DiagnosticSeverity::DS_Note:    DP << "note: "; break;
+  case DiagnosticSeverity::DS_Remark:  DP << "remark: "; break;
   case DiagnosticSeverity::DS_Warning: DP << "warning: "; break;
   case DiagnosticSeverity::DS_Error:   DP << "error: "; break;
   }
   DP << getMsgStr();
-  if (!DLoc && ZiPrompt)
-    DP << " Use /Zi for source location.";
 }
 // HLSL Change end - Dxil Diagnostic Info reporter

--- a/lib/Transforms/Scalar/LowerTypePasses.cpp
+++ b/lib/Transforms/Scalar/LowerTypePasses.cpp
@@ -130,7 +130,7 @@ bool LowerTypePass::runOnModule(Module &M) {
   initialize(M);
   // Load up debug information, to cross-reference values and the instructions
   // used to load them.
-  bool HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+  bool HasDbgInfo = llvm::hasDebugInfo(M);
   llvm::DebugInfoFinder Finder;
   if (HasDbgInfo) {
     Finder.processModule(M);

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3899,7 +3899,7 @@ public:
     const DataLayout &DL = M.getDataLayout();
     // Load up debug information, to cross-reference values and the instructions
     // used to load them.
-    m_HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+    m_HasDbgInfo = nullptr != M.getNamedMetadata("llvm.dbg.cu");
 
     InjectReturnAfterNoReturnPreserveOutput(*m_pHLModule);
 

--- a/lib/Transforms/Scalar/Scalarizer.cpp
+++ b/lib/Transforms/Scalar/Scalarizer.cpp
@@ -729,7 +729,7 @@ bool Scalarizer::finish() {
   Module &M = *Gathered.front().first->getModule();
   LLVMContext &Ctx = M.getContext();
   const DataLayout &DL = M.getDataLayout();
-  bool HasDbgInfo = getDebugMetadataVersionFromModule(M) != 0;
+  bool HasDbgInfo = hasDebugInfo(M);
   // Map from an extract element inst to a Value which replaced it.
   DenseMap<Instruction *, Value*> EltMap;
   // HLSL Change Ends.

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -556,10 +556,8 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
   }
   FullSourceLoc Loc(DILoc, SourceMgr);
 
-  // If no location information is available, prompt for debug flag
-  // and add function name to give some information
+  // If no location information is available, add function name
   if (Loc.isInvalid()) {
-    Message += " Use /Zi for source location.";
     auto *DiagClient = dynamic_cast<TextDiagnosticPrinter*>(Diags.getClient());
     auto *func = D.getFunction();
     if (DiagClient && func)

--- a/tools/clang/test/CodeGenHLSL/mesh-val/asOversizePayload.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh-val/asOversizePayload.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxilver 1.6 | %dxc -E main -T as_6_5 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 23:5: error: For amplification shader with entry 'main', payload size 16400 is greater than maximum size of 16384 bytes.
-// CHK_NODB: For amplification shader with entry 'main', payload size 16400 is greater than maximum size of 16384 bytes.
+// CHK_NODB: 23:5: error: For amplification shader with entry 'main', payload size 16400 is greater than maximum size of 16384 bytes.
 
 #define NUM_THREADS 32
 

--- a/tools/clang/test/CodeGenHLSL/mesh-val/msOversizePayload.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh-val/msOversizePayload.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxilver 1.6 | %dxc -E main -T ms_6_5 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: :29: error: For mesh shader with entry 'main', payload size 16404 is greater than maximum size of 16384 bytes.
-// CHK_NODB: error: For mesh shader with entry 'main', payload size 16404 is greater than maximum size of 16384 bytes. Use /Zi for source location.
+// CHK_NODB: :29: error: For mesh shader with entry 'main', payload size 16404 is greater than maximum size of 16384 bytes.
 
 #define MAX_VERT 32
 #define MAX_PRIM 16

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/AddUint64Odd.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/AddUint64Odd.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 8:12: error: AddUint64 can only be applied to uint2 and uint4 operands.
-// CHK_NODB: error: AddUint64 can only be applied to uint2 and uint4 operands. Use /Zi for source location.
+// CHK_NODB: 8:12: error: AddUint64 can only be applied to uint2 and uint4 operands.
 
 float4 main(uint4 a : A, uint4 b :B) : SV_TARGET {
   uint c = AddUint64(a.x, b.x);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/InnerCoverage.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/InnerCoverage.hlsl
@@ -5,8 +5,8 @@
 
 // CHK_DB: 11:1: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0.
 // CHK_DB: 11:1: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive.
-// CHK_NODB: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0. Use /Zi for source location.
-// CHK_NODB: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive. Use /Zi for source location.
+// CHK_NODB: 11:1: error: Parameter with semantic SV_InnerCoverage has overlapping semantic index at 0.
+// CHK_NODB: 11:1: error: Pixel shader inputs SV_Coverage and SV_InnerCoverage are mutually exclusive.
 
 void main(snorm float b : B, uint c:C, 
 #ifndef GENLL

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/invalid_input_output_types.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/invalid_input_output_types.hlsl
@@ -3,8 +3,8 @@
 
 // CHK_DB: 9:1: error: i64(type for I) cannot be used as shader inputs or outputs.
 // CHK_DB: 9:1: error: double(type for SV_Target) cannot be used as shader inputs or outputs.
-// CHK_NODB: cannot be used as shader inputs or outputs. Use /Zi for source location.
-// CHK_NODB: cannot be used as shader inputs or outputs. Use /Zi for source location.
+// CHK_NODB: 9:1: error: i64(type for I) cannot be used as shader inputs or outputs.
+// CHK_NODB: 9:1: error: double(type for SV_Target) cannot be used as shader inputs or outputs.
 
 double main(uint64_t i:I) : SV_Target {
     return 1;

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource2.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 9:10: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource3.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 9:10: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 17:7: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 17:7: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5_dbg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource5_dbg.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 9:10: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 18:7: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 18:7: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6_dbg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/local_resource6_dbg.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
 // CHK_DB: 9:10: error: local resource not guaranteed to map to unique global resource.
-// CHK_NODB: error: local resource not guaranteed to map to unique global resource. Use /Zi for source location.
+// CHK_NODB: 9:10: error: local resource not guaranteed to map to unique global resource.
 
 float4 Tex2D(Texture2D<float4> t,
   SamplerState s, float2 c) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt3.hlsl
@@ -1,9 +1,8 @@
 // RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHK_DB: 17:7: error: Offsets to texture access operations must be immediate values
+// CHK_DB: 16:7: error: Offsets to texture access operations must be immediate values
 // CHK_NODB: Offsets to texture access operations must be immediate values.
-// CHK_NODB-SAME Use /Zi for source location.
 
 SamplerState samp1 : register(s5);
 Texture2D<float4> text1 : register(t3);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/optForNoOpt4.hlsl
@@ -1,13 +1,11 @@
 // RUN: %dxc -Zi -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_DB
 // RUN: %dxc -E main -Od -T ps_6_0 %s | FileCheck %s -check-prefix=CHK_NODB
 
-// CHK_DB: 21:10: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
-// CHK_DB: 21:10: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
+// CHK_DB: 19:10: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
+// CHK_DB: 19:10: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
 
 // CHK_NODB: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
-// CHK_NODB-SAME Use /Zi for source location.
 // CHK_NODB: error: Offsets to texture access operations must be immediate values. Unrolling the loop containing the offset value manually and using -O3 may help in some cases.
-// CHK_NODB-SAME Use /Zi for source location.
 
 SamplerState samp1 : register(s5);
 Texture2D<float4> text1 : register(t3);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unsupported_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/unsupported_error.hlsl
@@ -4,7 +4,7 @@
 // Regression test for a crash when lowering unsupported intrinsics
 
 // CHK_DB: 10:50: error: Unsupported intrinsic
-// CHK_NODB: error: Unsupported intrinsic. Use /Zi for source location.
+// CHK_NODB: 10:50: error: Unsupported intrinsic
 
 sampler TextureSampler;
 float4 main(float2 uv	: UV) : SV_Target { return tex2D(TextureSampler, uv); }

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-attribute-statement.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-attribute-statement.hlsl
@@ -2,6 +2,8 @@
 
 // Make sure the specified warning gets turned off
 
+// CHECK: 9:1: error: Semantic must be defined
+
 // This function has no output semantic on purpose in order to produce an error,
 // otherwise, the warnings will not be captured in the output for FileCheck.
 float main() {
@@ -14,4 +16,3 @@ float main() {
   return 0;
 }
 
-// CHECK: error: Semantic must be defined

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-comma-in-init.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-comma-in-init.hlsl
@@ -7,7 +7,7 @@
 float main() {
 
 // comma expression used where a constructor list may have been intended
-// CHECK-NOT: comma
+// CHECK-NOT: comma expression
   int a = 1, b = 2;
   int c = (a, b);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-for-redefinition.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/Wno-for-redefinition.hlsl
@@ -7,7 +7,7 @@
 float main() {
 
 // redefinition of %0 shadows declaration in the outer scope; most recent declaration will be used
-// CHECK-NOT: redefinition
+// CHECK-NOT: redefinition of
   for (int i=0; i<4; i++);
   for (int i=0; i<4; i++);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/entrypoints/unused_func.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/entrypoints/unused_func.hlsl
@@ -2,8 +2,8 @@
 
 // Make sure unused functions are not generated.
 
-// CHECK-NOT: unused
+// CHECK-NOT: unused_function_name
 
-void unused() {}
+void unused_function_name() {}
 void main() {}
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pack/sm_6_6_pack_unpack_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/pack/sm_6_6_pack_unpack_error.hlsl
@@ -1,22 +1,23 @@
 // RUN: %dxilver 1.6 | %dxc -T ps_6_5 -enable-16bit-types  %s | FileCheck %s
 
-// CHECK: Opcode Pack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Pack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Unpack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Unpack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Unpack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Unpack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Pack4x8 not valid in shader model ps_6_5
-// CHECK: Opcode Pack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 13:{{[0-9]+}}: error: Opcode Pack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 14:{{[0-9]+}}: error: Opcode Pack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 15:{{[0-9]+}}: error: Opcode Unpack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 16:{{[0-9]+}}: error: Opcode Unpack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 17:{{[0-9]+}}: error: Opcode Pack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 18:{{[0-9]+}}: error: Opcode Pack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 19:{{[0-9]+}}: error: Opcode Unpack4x8 not valid in shader model ps_6_5
+// CHECK-DAG: 20:{{[0-9]+}}: error: Opcode Unpack4x8 not valid in shader model ps_6_5
 
 int16_t4 main(int4 input1 : Inputs1, int16_t4 input2 : Inputs2) : SV_Target {
   int8_t4_packed ps1 = pack_s8(input1);
   int8_t4_packed ps2 = pack_clamp_s8(input1);
-  int16_t4 up1_out = unpack_s8s16(ps1) + unpack_s8s16(ps2);
-
+  int16_t4 up1_out = unpack_s8s16(ps1)
+   + unpack_s8s16(ps2);
   uint8_t4_packed pu1 = pack_u8(input2);
   uint8_t4_packed pu2 = pack_clamp_u8(input2);
-  uint16_t4 up2_out = unpack_u8u16(pu1) + unpack_u8u16(pu2);
+  uint16_t4 up2_out = unpack_u8u16(pu1)
+    + unpack_u8u16(pu2);
 
   return up1_out + up2_out;
 }

--- a/tools/clang/test/HLSLFileCheck/validation/UndefStore.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/UndefStore.hlsl
@@ -2,7 +2,7 @@
 // RUN: %dxilver 1.6 | %dxc -E main -T cs_6_0 %s | FileCheck %s -check-prefix=CHECK -check-prefix=CHK_NODB
 
 // CHK_DB: 18:17: error: Assignment of undefined values to UAV.
-// CHK_NODB: Function: main: error: Assignment of undefined values to UAV. Use /Zi for source location.
+// CHK_NODB: 18:17: error: Assignment of undefined values to UAV.
 
 RWBuffer<uint> output;
 

--- a/tools/clang/tools/dxcompiler/dxclinker.cpp
+++ b/tools/clang/tools/dxcompiler/dxclinker.cpp
@@ -271,7 +271,7 @@ HRESULT STDMETHODCALLTYPE DxcLinker::Link(
         dxcutil::AssembleInputs inputs(
           std::move(pM), pOutputBlob, pMalloc, SerializeFlags,
           pOutputStream,
-          opts.DebugInfo, opts.DebugFile, &Diag);
+          opts.DebugFile, &Diag);
         if (needsValidation) {
           valHR = dxcutil::ValidateAndAssembleToContainer(inputs);
         } else {

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -973,7 +973,7 @@ public:
 
           dxcutil::AssembleInputs inputs(
                 std::move(serializeModule), pOutputBlob, m_pMalloc, SerializeFlags,
-                pOutputStream, opts.GenerateFullDebugInfo(),
+                pOutputStream,
                 opts.GetPDBName(), &compiler.getDiagnostics(),
                 &ShaderHashContent, pReflectionStream, pRootSigStream);
 
@@ -1251,6 +1251,11 @@ public:
       CGOpts.DwarfVersion = 4; // Latest version.
       // TODO: consider
       // DebugPass, DebugCompilationDir, DwarfDebugFlags, SplitDwarfFile
+    }
+    else {
+      CodeGenOptions &CGOpts = compiler.getCodeGenOpts();
+      CGOpts.setDebugInfo(CodeGenOptions::LocTrackingOnly);
+      CGOpts.DebugColumnInfo = 1;
     }
 
     clang::PreprocessorOptions &PPOpts(compiler.getPreprocessorOpts());

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -45,7 +45,6 @@ struct AssembleInputs {
                  IMalloc *pMalloc,
                  hlsl::SerializeDxilFlags SerializeFlags,
                  CComPtr<hlsl::AbstractMemoryStream> &pModuleBitcode,
-                 bool bDebugInfo = false,
                  llvm::StringRef DebugName = llvm::StringRef(),
                  clang::DiagnosticsEngine *pDiag = nullptr,
                  hlsl::DxilShaderHash *pShaderHashOut = nullptr,
@@ -56,7 +55,6 @@ struct AssembleInputs {
   IMalloc *pMalloc;
   hlsl::SerializeDxilFlags SerializeFlags;
   CComPtr<hlsl::AbstractMemoryStream> &pModuleBitcode;
-  bool bDebugInfo;
   llvm::StringRef DebugName = llvm::StringRef();
   clang::DiagnosticsEngine *pDiag;
   hlsl::DxilShaderHash *pShaderHashOut = nullptr;


### PR DESCRIPTION
(cherry picked from commit 86104f415f0c9cd0d8db03da5c9fba3b40f9e996)