### PR TITLE
Fix dxa/dxv options, crashes, support signing

### DIFF
--- a/tools/clang/tools/dxa/CMakeLists.txt
+++ b/tools/clang/tools/dxa/CMakeLists.txt
@@ -13,6 +13,7 @@ set( LLVM_LINK_COMPONENTS
   HLSL
   dxcsupport
   Option     # option library
+  MSSupport  # for CreateMSFileSystemForDisk
   )
 
 add_clang_executable(dxa

--- a/tools/clang/tools/dxv/CMakeLists.txt
+++ b/tools/clang/tools/dxv/CMakeLists.txt
@@ -6,6 +6,7 @@ set( LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
   dxcsupport
   Option     # option library
+  MSSupport  # for CreateMSFileSystemForDisk
   )
 
 add_clang_executable(dxv

--- a/tools/clang/tools/dxv/CMakeLists.txt
+++ b/tools/clang/tools/dxv/CMakeLists.txt
@@ -7,6 +7,7 @@ set( LLVM_LINK_COMPONENTS
   dxcsupport
   Option     # option library
   MSSupport  # for CreateMSFileSystemForDisk
+  dxilcontainer
   )
 
 add_clang_executable(dxv


### PR DESCRIPTION
- Set up missing thread malloc and MSFileSystemForDisk causing crashes.
- Removed default "-" input since it doesn't even work to select stdin.
- dxv: Support loading/signing full shader binary, -o for output file if signed.

Fixes #1500.