### PR TITLE
[templates] Fix issues with dependent template names

### DIFF
--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -5507,7 +5507,8 @@ public:
 
   void LookupTemplateName(LookupResult &R, Scope *S, CXXScopeSpec &SS,
                           QualType ObjectType, bool EnteringContext,
-                          bool &MemberOfUnknownSpecialization);
+                          bool &MemberOfUnknownSpecialization,
+                          bool NextIsLess = false); // HLSL Change - additional special case flag
 
   TemplateNameKind isTemplateName(Scope *S,
                                   CXXScopeSpec &SS,
@@ -5516,7 +5517,8 @@ public:
                                   ParsedType ObjectType,
                                   bool EnteringContext,
                                   TemplateTy &Template,
-                                  bool &MemberOfUnknownSpecialization);
+                                  bool &MemberOfUnknownSpecialization,
+                                  bool NextIsLess = false); // HLSL Change - additional special case flag
 
   bool DiagnoseUnknownTemplateName(const IdentifierInfo &II,
                                    SourceLocation IILoc,

--- a/tools/clang/lib/Parse/ParseExprCXX.cpp
+++ b/tools/clang/lib/Parse/ParseExprCXX.cpp
@@ -553,7 +553,8 @@ bool Parser::ParseOptionalCXXScopeSpecifier(CXXScopeSpec &SS,
                                                         ObjectType,
                                                         EnteringContext,
                                                         Template,
-                                              MemberOfUnknownSpecialization)) {
+                                              MemberOfUnknownSpecialization,
+                                                        nextIsLess)) {  // HLSL Change
         // We have found a template name, so annotate this token
         // with a template-id annotation. We do not permit the
         // template-id to be translated into a type annotation,
@@ -569,10 +570,9 @@ bool Parser::ParseOptionalCXXScopeSpecifier(CXXScopeSpec &SS,
         continue;
       }
 
-      // HLSL Change: templates aren't really supported in HLSL unless the
-      // EnableTemplates option is enabled, so avoid handling other cases and
-      // emitting incorrect diagnostics if the template lookup fails.
-      if (!nextIsLess && getLangOpts().HLSL && !getLangOpts().EnableTemplates) {
+      // HLSL Change: avoid handling other cases and emitting incorrect
+      // diagnostics if the template lookup fails.
+      if (!nextIsLess && getLangOpts().HLSL) {
         break;
       }
 

--- a/tools/clang/lib/Parse/Parser.cpp
+++ b/tools/clang/lib/Parse/Parser.cpp
@@ -1748,7 +1748,8 @@ bool Parser::TryAnnotateTypeOrScopeTokenAfterScopeSpec(bool EnteringContext,
                                    /*hasTemplateKeyword=*/false, TemplateName,
                                    /*ObjectType=*/ ParsedType(),
                                    EnteringContext,
-                                   Template, MemberOfUnknownSpecialization)) {
+                                   Template, MemberOfUnknownSpecialization,
+                                   /*NextIsLess*/ true)) {  // HLSL Change - additional flag
         // Consume the identifier.
         ConsumeToken();
         if (AnnotateTemplateIdToken(Template, TNK, SS, SourceLocation(),

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -602,7 +602,7 @@ void Sema::DiagnoseUnknownTypeName(IdentifierInfo *&II,
     return;
   }
 
-  if (getLangOpts().CPlusPlus) {
+  if (getLangOpts().CPlusPlus && !getLangOpts().HLSL) {  // HLSL Change
     // See if II is a class template that the user forgot to pass arguments to.
     UnqualifiedId Name;
     Name.setIdentifier(II, IILoc);

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/missing_typename.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/missing_typename.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T vs_6_0 -E VSMain -enable-templates -DTYPENAME= %s | FileCheck %s -check-prefix=MISSING
+// RUN: %dxc -T vs_6_0 -E VSMain -enable-templates -DTYPENAME=typename %s | FileCheck %s -check-prefix=PRESENT
+
+// MISSING: error: missing 'typename' prior to dependent type name 'TVec::value_type'
+// PRESENT: define void @VSMain() {
+
+template <typename T>
+struct Vec2 {
+    T x, y;
+    T Length() {
+        return sqrt(x*x + y*y);
+    }
+    typedef T value_type;
+};
+
+template <typename TVec>
+TYPENAME TVec::value_type Length(TVec v) { // <-- Must be "typename TVec::value_type"
+    return v.Length();
+}
+
+void VSMain() {
+    Vec2<int> v_i;
+    Vec2<float> v_f;
+   
+    int   a = Length(v_i);
+    float b = Length(v_f);
+}


### PR DESCRIPTION
Errors were reported for the use of some dependent template names
in cases where the code should have been accepted, caused by the
incorrect handling of some HLSL cases - which are fixed by this
change.

Fixes #3556