### PR TITLE
Fix build failure with undefined variable

### DIFF
--- a/lib/MC/MCObjectStreamer.cpp
+++ b/lib/MC/MCObjectStreamer.cpp
@@ -280,10 +280,8 @@ void MCObjectStreamer::EmitInstToFragment(const MCInst &Inst,
   IF->getContents().append(Code.begin(), Code.end());
 }
 
-#ifndef NDEBUG
 static const char *const BundlingNotImplementedMsg =
   "Aligned bundling is not implemented for this object format";
-#endif
 
 void MCObjectStreamer::EmitBundleAlignMode(unsigned AlignPow2) {
   llvm_unreachable(BundlingNotImplementedMsg);


### PR DESCRIPTION
PR #3636 (commit 6b44d611f7) changes the definition of
`llvm_unreachable(msg)`. Now it evaluates the `msg` even when
NDEBUG flag is defined.

For the following code,
```
static const char *const BundlingNotImplementedMsg =
  "Aligned bundling is not implemented for this object format";

void MCObjectStreamer::EmitBundleAlignMode(unsigned AlignPow2) {
  llvm_unreachable(BundlingNotImplementedMsg);
}
```

`llvm_unreachable(BundlingNotImplementedMsg)` did not evaluate
`BundlingNotImplementedMsg`. After PR #3636, it is evaluated and it
results in "undefined object" for `BundlingNotImplementedMsg`.