### PR TITLE
PIX: CP: Null check before dyn_cast (#3654)

### DIFF
--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -24,9 +24,11 @@ using namespace hlsl;
 
 namespace PIXPassHelpers {
 bool IsAllocateRayQueryInstruction(llvm::Value *Val) {
-  if (llvm::Instruction *Inst = llvm::dyn_cast<llvm::Instruction>(Val)) {
-    return hlsl::OP::IsDxilOpFuncCallInst(Inst,
-                                          hlsl::OP::OpCode::AllocateRayQuery);
+  if (Val != nullptr) {
+    if (llvm::Instruction *Inst = llvm::dyn_cast<llvm::Instruction>(Val)) {
+      return hlsl::OP::IsDxilOpFuncCallInst(Inst,
+                                            hlsl::OP::OpCode::AllocateRayQuery);
+    }
   }
   return false;
 }


### PR DESCRIPTION
dbg.value can occasionally return a null value. (Hit this in a customer (343) shader via PIX.) This is expected. From IntrinsicInst.cpp:

  // When the value goes to null, it gets replaced by an empty MDNode.