### PR TITLE
No sinking coord calc for sample in libs

### DIFF
--- a/lib/HLSL/DxilConvergent.cpp
+++ b/lib/HLSL/DxilConvergent.cpp
@@ -48,7 +48,7 @@ public:
   bool runOnModule(Module &M) override {
     if (M.HasHLModule()) {
       const ShaderModel *SM = M.GetHLModule().GetShaderModel();
-      if (!SM->IsPS() && (!SM->IsSM66Plus() || (!SM->IsCS() && !SM->IsMS() && !SM->IsAS())))
+      if (!SM->IsPS() && !SM->IsLib() && (!SM->IsSM66Plus() || (!SM->IsCS() && !SM->IsMS() && !SM->IsAS())))
         return false;
     }
     bool bUpdated = false;


### PR DESCRIPTION
Merge  #3658 into release-1.6.2104

Amidst catching the CS/AS/MS cases where convergent markers weren't
getting generated, it was pointed out that libs may need these too.

(cherry picked from commit cac37e68905f8cbd98a24984df2320ecf42baae3)