### PR TITLE
[spirv] Use object of correct base class for method call

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -975,6 +975,15 @@ private:
                                           SpirvInstruction *sampleIndex,
                                           SourceLocation loc);
 
+  /// \brief Returns OpAccessChain to the struct/class object that defines
+  /// memberFn when the struct/class is a base struct/class of objectType.
+  /// If the struct/class that defines memberFn is not a base of objectType,
+  /// returns nullptr.
+  SpirvInstruction *getBaseOfMemberFunction(QualType objectType,
+                                            SpirvInstruction * objInstr,
+                                            const CXXMethodDecl* memberFn,
+                                       SourceLocation loc);
+
 private:
   /// \brief Takes a vector of size 4, and returns a vector of size 1 or 2 or 3
   /// or 4. Creates a CompositeExtract or VectorShuffle instruction to extract

--- a/tools/clang/test/CodeGenSPIRV/oo.call.method.with.same.base.method.name.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.call.method.with.same.base.method.name.hlsl
@@ -11,28 +11,28 @@ struct empty {
 struct bar : empty {
   float4x4 trans;
   float4 value() {
-    return mul(float4(1,1,1,0), trans);
+    return 0;
   }
 };
 
 struct foo : bar {
+  float4 value() {
+    return 1;
+  }
 
-// When foo calls bar::value(), it must use
-// (this's 0th object)->value() instead of this->value()
-// because this's 0th object is the object of the base struct in SPIR-V.
+// When foo calls foo::value(), it must use
+// this->value() instead of (this's 0th object)->value()
 
 // CHECK:     %foo_get = OpFunction
 // CHECK:  %param_this = OpFunctionParameter %_ptr_Function_foo
-// CHECK: [[bar:%\w+]] = OpAccessChain %_ptr_Function_bar %param_this %uint_0
-// CHECK:                OpFunctionCall %v4float %bar_value [[bar]]
+// CHECK:                OpFunctionCall %v4float %foo_value %param_this
 
   float4 get() {
     return value();
   }
 };
 
-void main(out float4 Position : SV_Position)
-{
+void main(out float4 Position : SV_Position) {
   foo x;
   Position = x.get();
 }

--- a/tools/clang/test/CodeGenSPIRV/oo.inheritance.call.base.method.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/oo.inheritance.call.base.method.hlsl
@@ -1,0 +1,38 @@
+// Run: %dxc -T vs_5_0 -E main -fspv-target-env=vulkan1.1
+
+// CHECK: %bar = OpTypeStruct %empty %mat4v4float
+// CHECK: %foo = OpTypeStruct %bar
+
+// CHECK: OpFunctionCall %v4float %foo_get %x
+
+struct empty {
+};
+
+struct bar : empty {
+  float4x4 trans;
+  float4 value() {
+    return mul(float4(1,1,1,0), trans);
+  }
+};
+
+struct foo : bar {
+
+// When foo calls bar::value(), it must use
+// (this's 0th object)->value() instead of this->value()
+// because this's 0th object is the object of the base struct in SPIR-V.
+
+// CHECK:       %foo_get = OpFunction %v4float None %32
+// CHECK:    %param_this = OpFunctionParameter %_ptr_Function_foo
+// CHECK:   [[bar:%\w+]] = OpAccessChain %_ptr_Function_bar %param_this %uint_0
+// CHECK:                  OpFunctionCall %v4float %bar_value [[bar]]
+
+  float4 get() {
+    return value();
+  }
+};
+
+void main(out float4 Position : SV_Position)
+{
+  foo x;
+  Position = x.get();
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -656,6 +656,9 @@ TEST_F(FileTest, InheritanceCallMethodOfBase) {
   runFileTest("oo.inheritance.call.base.method.hlsl", Expect::Success,
               /* runValidation */ false);
 }
+TEST_F(FileTest, InheritanceCallMethodWithSameBaseMethodName) {
+  runFileTest("oo.call.method.with.same.base.method.name.hlsl");
+}
 
 // For semantics
 // SV_Position, SV_ClipDistance, and SV_CullDistance are covered in

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -652,6 +652,10 @@ TEST_F(FileTest, InheritanceLayoutDifferences) {
 TEST_F(FileTest, InheritanceLayoutEmptyStruct) {
   runFileTest("oo.inheritance.layout.empty-struct.hlsl");
 }
+TEST_F(FileTest, InheritanceCallMethodOfBase) {
+  runFileTest("oo.inheritance.call.base.method.hlsl", Expect::Success,
+              /* runValidation */ false);
+}
 
 // For semantics
 // SV_Position, SV_ClipDistance, and SV_CullDistance are covered in


### PR DESCRIPTION
When calling a method using an object, we have to correctly pass "this"
object. When the class of the object used for the method call has
multiple base classes, it does not use the correct base class. It simply
uses "this" object. This commit fixes the issue.

Fixes #3644