### PR TITLE
[spirv] Fix bug of CTBuffer DX memory layout with matrix

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
@@ -90,6 +90,12 @@ public:
   /// block.
   void addInstruction(SpirvInstruction *inst) { instructions.push_back(inst); }
 
+  /// Adds the given OpFunctionCall instruction as the first instruction
+  /// of this SPIR-V basic block.
+  void addModuleInitCall(SpirvInstruction *fnCall) {
+    instructions.push_front(fnCall);
+  }
+
   /// Return true if instructions is empty. Otherwise, return false.
   bool empty() { return instructions.empty(); }
 

--- a/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
@@ -90,10 +90,10 @@ public:
   /// block.
   void addInstruction(SpirvInstruction *inst) { instructions.push_back(inst); }
 
-  /// Adds the given OpFunctionCall instruction as the first instruction
-  /// of this SPIR-V basic block.
-  void addModuleInitCall(SpirvInstruction *fnCall) {
-    instructions.push_front(fnCall);
+  /// Adds the given instruction as the first instruction of this SPIR-V basic
+  /// block.
+  void addFirstInstruction(SpirvInstruction *inst) {
+    instructions.push_front(inst);
   }
 
   /// Return true if instructions is empty. Otherwise, return false.

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -690,8 +690,17 @@ private:
   /// clone dst. This method assumes
   ///   1. src has a pointer type to a type with FXC memory layout rule
   ///   2. dst has a pointer type to a type with void memory layout rule
-  void createCopyInstructionsFromFxcCTBufferToClone(SpirvInstruction *dst,
-                                                    SpirvInstruction *src);
+  void
+  createCopyInstructionsFromFxcCTBufferToClone(SpirvInstruction *fxcCTBuffer,
+                                               SpirvInstruction *clone);
+  void createCopyArrayInFxcCTBufferToClone(const ArrayType *fxcCTBufferArrTy,
+                                           SpirvInstruction *fxcCTBuffer,
+                                           const SpirvType *cloneType,
+                                           SpirvInstruction *clone,
+                                           SourceLocation loc);
+  void createCopyStructInFxcCTBufferToClone(
+      const StructType *fxcCTBufferStructTy, SpirvInstruction *fxcCTBuffer,
+      const SpirvType *cloneType, SpirvInstruction *clone, SourceLocation loc);
 
   /// \brief Sets moduleInitInsertPoint as insertPoint.
   void switchInsertPointToModuleInit();

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -503,10 +503,10 @@ public:
   /// OpIgnoreIntersectionKHR/OpTerminateIntersectionKHR
   void createRaytracingTerminateKHR(spv::Op opcode, SourceLocation loc);
 
-  /// \brief Creates and returns a clone SPIR-V variable for CTBuffer with FXC
-  /// memory layout if some sub-components of instr contain HLSL matrix 1xN
-  /// QualType. Otherwise, returns instr.
-  SpirvInstruction *createCloneVarForFxcCTBuffer(SpirvInstruction *instr);
+  /// \brief Returns a clone SPIR-V variable for CTBuffer with FXC memory layout
+  /// if it contains HLSL matrix 1xN. It also creates copy instructions from the
+  /// CTBuffer to the clone variable in module.init. Otherwise, returns instr.
+  SpirvInstruction *initializeCloneVarForFxcCTBuffer(SpirvInstruction *instr);
 
   // === SPIR-V Module Structure ===
   inline void setMemoryModel(spv::AddressingModel, spv::MemoryModel);
@@ -712,6 +712,11 @@ private:
 
   /// \brief Ends building of the module initialization function.
   void endModuleInitFunction();
+
+  /// \brief Creates a clone SPIR-V variable for CTBuffer.
+  SpirvVariable *createCloneVarForFxcCTBuffer(QualType astType,
+                                              const SpirvType *spvType,
+                                              SpirvInstruction *var);
 
 private:
   ASTContext &astContext;

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -691,6 +691,10 @@ private:
   void createStoreForModuleInit(SpirvInstruction *address,
                                 SpirvInstruction *value, SourceLocation loc);
 
+  /// \brief Creates a return instruction and adds it as a part of module
+  /// initialization.
+  void createReturnForModuleInit();
+
   /// \brief Creates instructions to copy sub-components of src to dst. This
   /// method assumes
   ///   1. src has a pointer to a type with FXC memory layout rule

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -706,6 +706,13 @@ private:
   /// function.
   void addModuleInitInstruction(SpirvInstruction *inst);
 
+  /// \brief Adds OpFunctionCall instructions for ModuleInit to all entry
+  /// points.
+  void addModuleInitCallToEntryPoints();
+
+  /// \brief Ends building of the module initialization function.
+  void endModuleInitFunction();
+
 private:
   ASTContext &astContext;
   SpirvContext &context; ///< From which we allocate various SPIR-V object

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -203,6 +203,10 @@ public:
   createAccessChain(QualType resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
                     SourceLocation loc);
+  SpirvAccessChain *
+  createAccessChain(const SpirvType *resultType, SpirvInstruction *base,
+                    llvm::ArrayRef<SpirvInstruction *> indexes,
+                    SourceLocation loc);
 
   /// \brief Creates a unary operation with the given SPIR-V opcode. Returns
   /// the instruction pointer for the result.
@@ -671,30 +675,6 @@ private:
       SpirvInstruction *constOffsets, SpirvInstruction *sample,
       SpirvInstruction *minLod);
 
-  /// \brief Creates an access chain instruction to retrieve the element from
-  /// the given base by walking through the given indexes and adds it as a part
-  /// of module initialization. Returns the instruction pointer for the pointer
-  /// to the element.
-  SpirvAccessChain *createAccessChainForModuleInit(
-      const SpirvType *resultType, SpirvInstruction *base,
-      llvm::ArrayRef<SpirvInstruction *> indexes, SourceLocation loc);
-
-  /// \brief Creates a load instruction loading the value of the given
-  /// <result-type> from the given pointer and adds it as a part of module
-  /// initialization. Returns the instruction pointer for the loaded value.
-  SpirvLoad *createLoadForModuleInit(const SpirvType *resultType,
-                                     SpirvInstruction *pointer,
-                                     SourceLocation loc);
-
-  /// \brief Creates a store instruction storing the given value into the given
-  /// address and adds it as a part of module initialization.
-  void createStoreForModuleInit(SpirvInstruction *address,
-                                SpirvInstruction *value, SourceLocation loc);
-
-  /// \brief Creates a return instruction and adds it as a part of module
-  /// initialization.
-  void createReturnForModuleInit();
-
   /// \brief Creates instructions to copy sub-components of CTBuffer src to its
   /// clone dst. This method assumes
   ///   1. src has a pointer type to a type with FXC memory layout rule
@@ -702,9 +682,8 @@ private:
   void createCopyInstructionsFromFxcCTBufferToClone(SpirvInstruction *dst,
                                                     SpirvInstruction *src);
 
-  /// \brief Adds the given SPIR-V instruction to the module initialization
-  /// function.
-  void addModuleInitInstruction(SpirvInstruction *inst);
+  /// \brief Sets moduleInitInsertPoint as insertPoint.
+  void switchInsertPointToModuleInit();
 
   /// \brief Adds OpFunctionCall instructions for ModuleInit to all entry
   /// points.

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -695,12 +695,12 @@ private:
   /// initialization.
   void createReturnForModuleInit();
 
-  /// \brief Creates instructions to copy sub-components of src to dst. This
-  /// method assumes
-  ///   1. src has a pointer to a type with FXC memory layout rule
-  ///   2. dst has a pointer to a type with void memory layout rule
-  void createCopyInstructionsForFxcCTBuffer(SpirvInstruction *dst,
-                                            SpirvInstruction *src);
+  /// \brief Creates instructions to copy sub-components of CTBuffer src to its
+  /// clone dst. This method assumes
+  ///   1. src has a pointer type to a type with FXC memory layout rule
+  ///   2. dst has a pointer type to a type with void memory layout rule
+  void createCopyInstructionsFromFxcCTBufferToClone(SpirvInstruction *dst,
+                                                    SpirvInstruction *src);
 
   /// \brief Adds the given SPIR-V instruction to the module initialization
   /// function.

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -375,7 +375,7 @@ public:
   }
 
   /// Adds inst to instructionsWithLoweredType.
-  void addToTypeLoweredInstructions(const SpirvInstruction *inst) {
+  void addToInstructionsWithLoweredType(const SpirvInstruction *inst) {
     instructionsWithLoweredType.insert(inst);
   }
 

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -374,6 +374,17 @@ public:
     return declToDebugFunction[decl];
   }
 
+  /// Adds inst to instructionsWithLoweredType.
+  void addToTypeLoweredInstructions(const SpirvInstruction *inst) {
+    instructionsWithLoweredType.insert(inst);
+  }
+
+  /// Returns whether inst is in instructionsWithLoweredType or not.
+  bool hasLoweredType(const SpirvInstruction *inst) {
+    return instructionsWithLoweredType.find(inst) !=
+           instructionsWithLoweredType.end();
+  }
+
 private:
   /// \brief The allocator used to create SPIR-V entity objects.
   ///
@@ -463,6 +474,9 @@ private:
 
   // Mapping from SPIR-V OpVariable to SPIR-V image format.
   llvm::DenseMap<const SpirvVariable *, spv::ImageFormat> spvVarToImageFormat;
+
+  // Set of instructions that already have lowered SPIR-V types.
+  llvm::DenseSet<const SpirvInstruction *> instructionsWithLoweredType;
 };
 
 } // end namespace spirv

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -91,11 +91,11 @@ public:
   void addVariable(SpirvVariable *);
   void addBasicBlock(SpirvBasicBlock *);
 
-  /// Adds the given OpFunctionCall instruction as the first instruction
-  /// of this SPIR-V function body.
-  void addModuleInitCall(SpirvInstruction *fnCall) {
+  /// Adds the given instruction as the first instruction of this SPIR-V
+  /// function body.
+  void addFirstInstruction(SpirvInstruction *inst) {
     assert(basicBlocks.size() != 0);
-    basicBlocks[0]->addModuleInitCall(fnCall);
+    basicBlocks[0]->addFirstInstruction(inst);
   }
 
   /// Legalization-specific code

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -11,6 +11,7 @@
 
 #include <vector>
 
+#include "clang/SPIRV/SpirvBasicBlock.h"
 #include "clang/SPIRV/SpirvInstruction.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
@@ -18,7 +19,6 @@
 namespace clang {
 namespace spirv {
 
-class SpirvBasicBlock;
 class SpirvVisitor;
 
 /// The class representing a SPIR-V function in memory.
@@ -90,6 +90,13 @@ public:
   }
   void addVariable(SpirvVariable *);
   void addBasicBlock(SpirvBasicBlock *);
+
+  /// Adds the given OpFunctionCall instruction as the first instruction
+  /// of this SPIR-V function body.
+  void addModuleInitCall(SpirvInstruction *fnCall) {
+    assert(basicBlocks.size() != 0);
+    basicBlocks[0]->addModuleInitCall(fnCall);
+  }
 
   /// Legalization-specific code
   ///

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -149,6 +149,10 @@ public:
 
   llvm::ArrayRef<SpirvVariable *> getVariables() const { return variables; }
 
+  llvm::ArrayRef<SpirvEntryPoint *> getEntryPoints() const {
+    return entryPoints;
+  }
+
 private:
   // Use a set for storing capabilities. This will ensure there are no duplicate
   // capabilities. Although the set stores pointers, the provided

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -196,7 +196,9 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
   if (rule == SpirvLayoutRule::FxcCTBuffer && hlsl::IsHLSLMatType(type)) {
     uint32_t rowCount = 0, colCount = 0;
     hlsl::GetHLSLMatRowColCount(type, rowCount, colCount);
-    if (useRowMajor(isRowMajor, type) && colCount > 1) {
+    if (!useRowMajor(isRowMajor, type))
+      std::swap(rowCount, colCount);
+    if (colCount > 1) {
       auto elemType = hlsl::GetHLSLMatElementType(type);
       uint32_t alignment = 0, size = 0;
       std::tie(alignment, size) =

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -9,7 +9,6 @@
 
 #include "AlignmentSizeCalculator.h"
 #include "clang/AST/Attr.h"
-#include "clang/SPIRV/AstTypeProbe.h"
 
 namespace {
 
@@ -129,6 +128,10 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
   // - Vector base alignment is set as its element type's base alignment.
   // - Arrays/structs do not need to have padding at the end; arrays/structs do
   //   not affect the base offset of the member following them.
+  // - For typeNxM matrix, if M > 1,
+  //   - It must be alinged to 16 bytes.
+  //   - Its size must be (16 * (M - 1)) + N * sizeof(type).
+  //   - We have the same rule for column_major typeNxM and row_major typeMxN.
   //
   // FxcSBuffer:
   // - Vector/matrix/array base alignment is set as its element type's base
@@ -186,6 +189,24 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
         }
   }
 
+  // FxcCTBuffer for typeNxM matrix where M > 1,
+  // - It must be alinged to 16 bytes.
+  // - Its size must be (16 * (M - 1)) + N * sizeof(type).
+  // - We have the same rule for column_major typeNxM and row_major typeMxN.
+  if (rule == SpirvLayoutRule::FxcCTBuffer && hlsl::IsHLSLMatType(type)) {
+    uint32_t rowCount = 0, colCount = 0;
+    hlsl::GetHLSLMatRowColCount(type, rowCount, colCount);
+    if (useRowMajor(isRowMajor, type) && colCount > 1) {
+      auto elemType = hlsl::GetHLSLMatElementType(type);
+      uint32_t alignment = 0, size = 0;
+      std::tie(alignment, size) =
+          getAlignmentAndSize(elemType, rule, isRowMajor, stride);
+      alignment = roundToPow2(alignment * (rowCount == 3 ? 4 : rowCount), kStd140Vec4Alignment);
+      *stride = alignment;
+      return {alignment, 16 * (colCount - 1) + rowCount * size};
+    }
+  }
+
   { // Rule 2 and 3
     QualType elemType = {};
     uint32_t elemCount = {};
@@ -215,9 +236,7 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
       // The base alignment and array stride are set to match the base alignment
       // of a single array element, according to rules 1, 2, and 3, and rounded
       // up to the base alignment of a vec4.
-      bool rowMajor = isRowMajor.hasValue()
-                          ? isRowMajor.getValue()
-                          : isRowMajorMatrix(spvOptions, type);
+      bool rowMajor = useRowMajor(isRowMajor, type);
 
       const uint32_t vecStorageSize = rowMajor ? rowCount : colCount;
 

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -203,7 +203,8 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
       uint32_t alignment = 0, size = 0;
       std::tie(alignment, size) =
           getAlignmentAndSize(elemType, rule, isRowMajor, stride);
-      alignment = roundToPow2(alignment * (rowCount == 3 ? 4 : rowCount), kStd140Vec4Alignment);
+      alignment = roundToPow2(alignment * (rowCount == 3 ? 4 : rowCount),
+                              kStd140Vec4Alignment);
       *stride = alignment;
       return {alignment, 16 * (colCount - 1) + rowCount * size};
     }

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
@@ -12,6 +12,7 @@
 
 #include "dxc/Support/SPIRVOptions.h"
 #include "clang/AST/ASTContext.h"
+#include "clang/SPIRV/AstTypeProbe.h"
 
 namespace clang {
 namespace spirv {
@@ -47,6 +48,12 @@ public:
   void alignUsingHLSLRelaxedLayout(QualType fieldType, uint32_t fieldSize,
                                    uint32_t fieldAlignment,
                                    uint32_t *currentOffset);
+
+  /// \brief Returns true if we use row-major matrix for type. Otherwise,
+  /// returns false.
+  bool useRowMajor(llvm::Optional<bool> isRowMajor, clang::QualType type) {
+    return isRowMajor.hasValue() ? isRowMajor.getValue() : isRowMajorMatrix(spvOptions, type);
+  }
 
 private:
   /// Emits error to the diagnostic engine associated with this visitor.

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
@@ -52,7 +52,8 @@ public:
   /// \brief Returns true if we use row-major matrix for type. Otherwise,
   /// returns false.
   bool useRowMajor(llvm::Optional<bool> isRowMajor, clang::QualType type) {
-    return isRowMajor.hasValue() ? isRowMajor.getValue() : isRowMajorMatrix(spvOptions, type);
+    return isRowMajor.hasValue() ? isRowMajor.getValue()
+                                 : isRowMajorMatrix(spvOptions, type);
   }
 
 private:

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -723,7 +723,7 @@ DeclResultIdMapper::getOrCreateCloneVarForFxcCTBuffer(SpirvInstruction *var) {
   if (varToCloneItr != varToClone.end()) {
     return varToCloneItr->second;
   }
-  auto *clone = spvBuilder.createCloneVarForFxcCTBuffer(var);
+  auto *clone = spvBuilder.initializeCloneVarForFxcCTBuffer(var);
   varToClone[var] = clone;
   return clone;
 }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -437,10 +437,8 @@ private:
     /// Default constructor to satisfy DenseMap
     DeclSpirvInfo() : instr(nullptr), indexInCTBuffer(-1) {}
 
-    DeclSpirvInfo(DeclResultIdMapper *declResultIdMapper,
-                  SpirvInstruction *instr_, int index = -1)
-        : instr(declResultIdMapper->getOrCreateCloneVarForFxcCTBuffer(instr_)),
-          indexInCTBuffer(index) {}
+    DeclSpirvInfo(SpirvInstruction *instr_, int index = -1)
+        : instr(instr_), indexInCTBuffer(index) {}
 
     /// Implicit conversion to SpirvInstruction*.
     operator SpirvInstruction *() const { return instr; }
@@ -455,11 +453,15 @@ private:
   /// Returns nullptr if no such decl was previously registered.
   const DeclSpirvInfo *getDeclSpirvInfo(const ValueDecl *decl) const;
 
-  /// \brief Returns the clone of the given var if we already created it.
-  /// Otherwise, creates a clone and returns it. If we do not need to create a
-  /// clone i.e., the AST type of var does not include matrix type1xN in
-  /// CTBuffer with FXC memory layout rule, it just returns var.
-  SpirvInstruction *getOrCreateCloneVarForFxcCTBuffer(SpirvInstruction *var);
+  /// \brief Creates DeclSpirvInfo using the given instr and index. It creates a
+  /// clone variable if it is CTBuffer including matrix 1xN with FXC memory
+  /// layout.
+  DeclSpirvInfo createDeclSpirvInfo(SpirvInstruction *instr,
+                                    int index = -1) const {
+    if (auto *clone = spvBuilder.initializeCloneVarForFxcCTBuffer(instr))
+      instr = clone;
+    return DeclSpirvInfo(instr, index);
+  }
 
 public:
   /// \brief Returns the information for the given decl.
@@ -794,21 +796,6 @@ private:
   /// Mapping of all Clang AST decls to their instruction pointers.
   llvm::DenseMap<const ValueDecl *, DeclSpirvInfo> astDecls;
   llvm::DenseMap<const ValueDecl *, SpirvFunction *> astFunctionDecls;
-
-  /// Mapping of SPIR-V instruction for variable Decl to its clone SPIR-V
-  /// OpVariable. We translate a matrix type1xN as a vector typeN, but type1xN
-  /// in CTBuffer with FXC memory layout rule must have a stride 16 bytes
-  /// between elements. We must use a SPIR-V array type[N] with stride 16 bytes
-  /// for it. Since we translate it into a vector typeN for all places, it has
-  /// side effects. We use a clone variable to fix this issue i.e., when we use
-  /// FXC memory layout,
-  ///  1. Use a SPIR-V variable with array type[N] for a variable with matrix
-  ///     type1xN in CTBuffer.
-  ///  2. Create a SPIR-V vector typeN variable with Private storage class.
-  ///  3. Copy the SPIR-V variable with array type[N] to the one with vector
-  ///     typeN.
-  ///  4. Use the SPIR-V vector typeN variable for all places.
-  llvm::DenseMap<SpirvInstruction *, SpirvInstruction *> varToClone;
 
   /// Vector of all defined stage variables.
   llvm::SmallVector<StageVar, 8> stageVars;

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -378,7 +378,9 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
   if (rule == SpirvLayoutRule::FxcCTBuffer && hlsl::IsHLSLMatType(type)) {
     uint32_t rowCount = 0, colCount = 0;
     hlsl::GetHLSLMatRowColCount(type, rowCount, colCount);
-    if (alignmentCalc.useRowMajor(isRowMajor, type) && rowCount == 1) {
+    if (!alignmentCalc.useRowMajor(isRowMajor, type))
+      std::swap(rowCount, colCount);
+    if (rowCount == 1) {
       auto elemType = hlsl::GetHLSLMatElementType(type);
       uint32_t stride = 0;
       alignmentCalc.getAlignmentAndSize(type, rule, isRowMajor, &stride);

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -375,9 +375,10 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
   // handle them via HLSL type inspection functions.
 
   // When the memory layout rule is FxcCTBuffer, typeNxM matrix with M > 1 and
-  // N == 1 is a matrix with M rows of the vector with type and size 1. Since
-  // SPIR-V does not have a vector with size 1, we have to use an array.
-  // We have the same rule for column_major typeNxM and row_major typeMxN.
+  // N == 1 consists of M vectors where each vector has a single element. Since
+  // SPIR-V does not have a vector with single element, we have to use an
+  // OpTypeArray with ArrayStride 16 instead of OpTypeVector. We have the same
+  // rule for column_major typeNxM and row_major typeMxN.
   if (rule == SpirvLayoutRule::FxcCTBuffer && hlsl::IsHLSLMatType(type)) {
     uint32_t rowCount = 0, colCount = 0;
     hlsl::GetHLSLMatRowColCount(type, rowCount, colCount);

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -384,7 +384,8 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
       auto elemType = hlsl::GetHLSLMatElementType(type);
       uint32_t stride = 0;
       alignmentCalc.getAlignmentAndSize(type, rule, isRowMajor, &stride);
-      return spvContext.getArrayType(lowerType(elemType, rule, isRowMajor, srcLoc), colCount, stride);
+      return spvContext.getArrayType(
+          lowerType(elemType, rule, isRowMajor, srcLoc), colCount, stride);
     }
   }
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -57,6 +57,9 @@ bool LowerTypeVisitor::visit(SpirvFunction *fn, Phase phase) {
 }
 
 bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
+  if (spvContext.hasLoweredType(instr))
+    return true;
+
   const QualType astType = instr->getAstResultType();
   const SpirvType *hybridType = instr->getResultType();
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -381,6 +381,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     if (!alignmentCalc.useRowMajor(isRowMajor, type))
       std::swap(rowCount, colCount);
     if (rowCount == 1) {
+      useArrayForMat1xN = true;
       auto elemType = hlsl::GetHLSLMatElementType(type);
       uint32_t stride = 0;
       alignmentCalc.getAlignmentAndSize(type, rule, isRowMajor, &stride);

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -25,7 +25,7 @@ public:
   LowerTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
                    const SpirvCodeGenOptions &opts)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        alignmentCalc(astCtx, opts) {}
+        alignmentCalc(astCtx, opts), useArrayForMat1xN(false) {}
 
   // Visiting different SPIR-V constructs.
   bool visit(SpirvModule *, Phase) override { return true; }
@@ -47,6 +47,8 @@ public:
   /// on will be created in SpirvContext.
   const SpirvType *lowerType(QualType type, SpirvLayoutRule,
                              llvm::Optional<bool> isRowMajor, SourceLocation);
+
+  bool useSpvArrayForHlslMat1xN() { return useArrayForMat1xN; }
 
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
@@ -87,6 +89,7 @@ private:
   ASTContext &astContext;                /// AST context
   SpirvContext &spvContext;              /// SPIR-V context
   AlignmentSizeCalculator alignmentCalc; /// alignment calculator
+  bool useArrayForMat1xN;                /// SPIR-V array for HLSL Matrix 1xN
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1116,6 +1116,15 @@ SpirvBuilder::createCloneVarForFxcCTBuffer(SpirvInstruction *instr) {
         addModuleVar(astType, spv::StorageClass::Private, var->isPrecise(),
                      var->getDebugName(), llvm::None, var->getSourceLocation());
   } else {
+    if (const auto *ty = dyn_cast<StructType>(spvType)) {
+      spvType = context.getStructType(ty->getFields(), ty->getName(),
+                                      ty->isReadOnly(),
+                                      StructInterfaceType::InternalStorage);
+    } else if (const auto *ty = dyn_cast<HybridStructType>(spvType)) {
+      spvType = context.getHybridStructType(
+          ty->getFields(), ty->getName(), ty->isReadOnly(),
+          StructInterfaceType::InternalStorage);
+    }
     clone =
         addModuleVar(spvType, spv::StorageClass::Private, var->isPrecise(),
                      var->getDebugName(), llvm::None, var->getSourceLocation());

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -9,7 +9,6 @@
 
 #include "clang/SPIRV/SpirvFunction.h"
 #include "BlockReadableOrder.h"
-#include "clang/SPIRV/SpirvBasicBlock.h"
 #include "clang/SPIRV/SpirvVisitor.h"
 
 namespace clang {

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.array.hlsl
@@ -1,0 +1,31 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[type_of_foo:%\w+]] ArrayStride 32
+// CHECK: OpDecorate [[type_of_bar_elem:%\w+]] ArrayStride 16
+// CHECK: OpDecorate [[type_of_bar:%\w+]] ArrayStride 48
+
+// CHECK: OpMemberDecorate %type_buffer0 0 Offset 0
+// CHECK: OpMemberDecorate %type_buffer0 1 Offset 16
+// CHECK: OpMemberDecorate %type_buffer0 1 MatrixStride 16
+// CHECK: OpMemberDecorate %type_buffer0 1 RowMajor
+// CHECK: OpMemberDecorate %type_buffer0 2 Offset 240
+// CHECK: OpMemberDecorate %type_buffer0 3 Offset 468
+
+// CHECK: %mat3v2float = OpTypeMatrix %v2float 3
+// CHECK: [[type_of_foo]] = OpTypeArray %mat3v2float %uint_7
+// CHECK: [[type_of_bar_elem]] = OpTypeArray %float %uint_3
+// CHECK: [[type_of_bar]] = OpTypeArray [[type_of_bar_elem]] %uint_5
+// CHECK: %type_buffer0 = OpTypeStruct %float [[type_of_foo]] [[type_of_bar]] %float
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float3x2 foo[7];                   // Offset:   16 Size:   220 [unused]
+  float1x3 bar[5];                   // Offset:  240 Size:   228 [unused]
+  float end;                         // Offset:  468 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.global.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.global.hlsl
@@ -1,0 +1,26 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[arr_f2:%\w+]] ArrayStride 16
+// CHECK: OpMemberDecorate {{%\w+}} 0 Offset 0
+// CHECK: OpMemberDecorate {{%\w+}} 1 Offset 16
+// CHECK: OpMemberDecorate {{%\w+}} 2 Offset 36
+
+// CHECK: [[arr_f2]] = OpTypeArray %float %uint_2
+// CHECK: %type__Globals = OpTypeStruct %float [[arr_f2]] %float
+// CHECK: %_ptr_Uniform_type__Globals = OpTypePointer Uniform %type__Globals
+
+// CHECK: [[Globals_clone:%\w+]] = OpTypeStruct %float %v2float %float
+// CHECK: [[ptr_Globals_clone:%\w+]] = OpTypePointer Private [[Globals_clone]]
+
+// CHECK: %_Globals = OpVariable %_ptr_Uniform_type__Globals Uniform
+// CHECK:             OpVariable [[ptr_Globals_clone]] Private
+
+float dummy0;                      // Offset:    0 Size:     4 [unused]
+float1x2 foo;                      // Offset:   16 Size:    20 [unused]
+float end;                         // Offset:   36 Size:     4
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.majorness.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.majorness.hlsl
@@ -1,0 +1,40 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[type_of_foo:%\w+]] ArrayStride 16
+// CHECK: OpDecorate %_arr_mat2v3float_uint_7 ArrayStride 48
+// CHECK: OpDecorate %_arr_float_uint_3 ArrayStride 16
+// CHECK: OpDecorate %_arr__arr_float_uint_3_uint_5 ArrayStride 48
+// CHECK: OpMemberDecorate %type_buffer0 0 Offset 0
+// CHECK: OpMemberDecorate %type_buffer0 1 Offset 16
+// CHECK: OpMemberDecorate %type_buffer0 2 Offset 48
+// CHECK: OpMemberDecorate %type_buffer0 2 MatrixStride 16
+// CHECK: OpMemberDecorate %type_buffer0 2 RowMajor
+// CHECK: OpMemberDecorate %type_buffer0 3 Offset 384
+// CHECK: OpMemberDecorate %type_buffer0 4 Offset 624
+// CHECK: OpMemberDecorate %type_buffer0 5 Offset 852
+
+// CHECK: [[type_of_foo]] = OpTypeArray %float %uint_2
+// CHECK: %_arr_float_uint_3 = OpTypeArray %float %uint_3
+// CHECK: %_arr__arr_float_uint_3_uint_5 = OpTypeArray %_arr_float_uint_3 %uint_5
+// CHECK: %type_buffer0 = OpTypeStruct %float [[type_of_foo]] %_arr_mat2v3float_uint_7 %_arr__arr_float_uint_3_uint_5 %_arr__arr_float_uint_3_uint_5 %float
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float1x2 foo;                      // Offset:   16 Size:    20 [unused]
+  float2x3 bar[7];                   // Offset:   48 Size:   328 [unused]
+  row_major float3x1 zar[5];         // Offset:  384 Size:   228 [unused]
+  float1x3 x[5];                     // Offset:  624 Size:   228 [unused]
+  float end;                         // Offset:  852 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+// CHECK: [[type_of_arr:%\w+]] = OpTypeArray %float %uint_2
+// CHECK: [[ptr_type_of_arr:%\w+]] = OpTypePointer Function [[type_of_arr]]
+
+// CHECK: %arr = OpVariable [[ptr_type_of_arr]] Function
+
+  float arr[2];
+  color.x += end;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.n-by-m.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.n-by-m.hlsl
@@ -1,0 +1,20 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+
+// CHECK: OpMemberDecorate {{%\w+}} 0 Offset 0
+// CHECK: OpMemberDecorate {{%\w+}} 1 Offset 16
+// CHECK: OpMemberDecorate {{%\w+}} 1 MatrixStride 16
+// CHECK: OpMemberDecorate {{%\w+}} 1 RowMajor
+// CHECK: OpMemberDecorate {{%\w+}} 2 Offset 56
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float2x3 foo;                      // Offset:   16 Size:    40 [unused]
+  float end;                         // Offset:   56 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.simple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.simple.hlsl
@@ -7,6 +7,13 @@
 
 // CHECK: [[arr_f2]] = OpTypeArray %float %uint_2
 // CHECK: %type_buffer0 = OpTypeStruct %float [[arr_f2]] %float
+// CHECK: %_ptr_Uniform_type_buffer0 = OpTypePointer Uniform %type_buffer0
+
+// CHECK: [[buffer0_clone:%\w+]] = OpTypeStruct %float %v2float %float
+// CHECK: [[ptr_buffer0_clone:%\w+]] = OpTypePointer Private [[buffer0_clone]]
+
+// CHECK: %buffer0 = OpVariable %_ptr_Uniform_type_buffer0 Uniform
+// CHECK:            OpVariable [[ptr_buffer0_clone]] Private
 
 cbuffer buffer0 {
   float dummy0;                      // Offset:    0 Size:     4 [unused]

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.simple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.simple.hlsl
@@ -1,0 +1,21 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[arr_f2:%\w+]] ArrayStride 16
+// CHECK: OpMemberDecorate {{%\w+}} 0 Offset 0
+// CHECK: OpMemberDecorate {{%\w+}} 1 Offset 16
+// CHECK: OpMemberDecorate {{%\w+}} 2 Offset 36
+
+// CHECK: [[arr_f2]] = OpTypeArray %float %uint_2
+// CHECK: %type_buffer0 = OpTypeStruct %float [[arr_f2]] %float
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float1x2 foo;                      // Offset:   16 Size:    20 [unused]
+  float end;                         // Offset:   36 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
@@ -10,6 +10,15 @@
 
 // CHECK: [[arr_f2]] = OpTypeArray %float %uint_2
 // CHECK: %layout = OpTypeStruct %float [[arr_f2]] %float
+// CHECK: %type_buffer0 = OpTypeStruct %float %layout %float
+// CHECK: %_ptr_Uniform_type_buffer0 = OpTypePointer Uniform %type_buffer0
+
+// CHECK: [[layout_clone:%\w+]] = OpTypeStruct %float %v2float %float
+// CHECK: [[type_buffer0_clone:%\w+]] = OpTypeStruct %float [[layout_clone]] %float
+// CHECK: [[ptr_type_buffer0_clone:%\w+]] = OpTypePointer Private [[type_buffer0_clone]]
+
+// CHECK: %buffer0 = OpVariable %_ptr_Uniform_type_buffer0 Uniform
+// CHECK: [[buffer0_clone:%\w+]] = OpVariable [[ptr_type_buffer0_clone]] Private
 
 cbuffer buffer0 {
   float dummy0;                      // Offset:    0 Size:     4 [unused]
@@ -22,6 +31,22 @@ cbuffer buffer0 {
   } bar;                             // Offset:   16 Size:    40 [unused]
   float end;                         // Offset:   56 Size:     4
 };
+
+// CHECK: %module_init = OpFunction %void
+// CHECK: %module_init_bb = OpLabel
+// CHECK: [[ptr_layout:%\w+]] = OpAccessChain %_ptr_Uniform_layout %buffer0 %uint_1
+// CHECK: [[ptr_layout_clone:%\w+]] = OpAccessChain %_ptr_Private_layout_0 [[buffer0_clone]] %uint_1
+
+// CHECK: [[ptr_foo:%\w+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_2 [[ptr_layout]] %uint_1
+// CHECK: [[ptr_foo_clone:%\w+]] = OpAccessChain %_ptr_Private_v2float [[ptr_layout_clone]] %uint_1
+// CHECK: [[ptr_foo_0:%\w+]] = OpAccessChain %_ptr_Uniform_float [[ptr_foo]] %uint_0
+// CHECK: [[ptr_foo_clone_0:%\w+]] = OpAccessChain %_ptr_Private_float [[ptr_foo_clone]] %uint_0
+// CHECK: [[foo_0:%\w+]] = OpLoad %float [[ptr_foo_0]]
+// CHECK: OpStore [[ptr_foo_clone_0]] [[foo_0]]
+// CHECK: [[ptr_foo_1:%\w+]] = OpAccessChain %_ptr_Uniform_float [[ptr_foo]] %uint_1
+// CHECK: [[ptr_foo_clone_1:%\w+]] = OpAccessChain %_ptr_Private_float [[ptr_foo_clone]] %uint_1
+// CHECK: [[foo_1:%\w+]] = OpLoad %float [[ptr_foo_1]]
+// CHECK: OpStore [[ptr_foo_clone_1]] [[foo_1]]
 
 float4 main(float4 color : COLOR) : SV_TARGET
 {

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
@@ -1,0 +1,38 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[arr_f2:%\w+]] ArrayStride 16
+// CHECK: OpMemberDecorate %layout 0 Offset 0
+// CHECK: OpMemberDecorate %layout 1 Offset 16
+// CHECK: OpMemberDecorate %layout 2 Offset 36
+// CHECK: OpMemberDecorate %type_buffer0 0 Offset 0
+// CHECK: OpMemberDecorate %type_buffer0 1 Offset 16
+// CHECK: OpMemberDecorate %type_buffer0 2 Offset 56
+
+// CHECK: [[arr_f2]] = OpTypeArray %float %uint_2
+// CHECK: %layout = OpTypeStruct %float [[arr_f2]] %float
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  struct layout
+  {
+      float1x1 dummy0;               // Offset:   16
+      float1x2 foo;                  // Offset:   32
+      float end;                     // Offset:   52
+
+  } bar;                             // Offset:   16 Size:    40 [unused]
+  float end;                         // Offset:   56 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+
+// CHECK: [[ptr_layout:%\w+]] = OpTypePointer Uniform %layout
+// CHECK: [[buffer0_1:%\w+]] = OpAccessChain [[ptr_layout]] %buffer0 %int_1
+// CHECK: [[ptr_foo:%\w+]] = OpAccessChain {{%\w+}} [[buffer0_1]] %int_1
+// CHECK: [[ptr_foo_1:%\w+]] = OpAccessChain {{%\w+}} [[ptr_foo]] %int_1
+// CHECK: OpLoad %float [[ptr_foo_1]]
+  color.x += bar.foo._12;
+
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
@@ -32,6 +32,19 @@ cbuffer buffer0 {
   float end;                         // Offset:   56 Size:     4
 };
 
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+// CHECK: %main = OpFunction %void None
+// CHECK:         OpFunctionCall %void %module_init
+// CHECK:         OpFunctionCall %v4float %src_main
+
+  color.x += end;
+
+  color.x += bar.foo._12;
+
+  return color;
+}
+
 // CHECK: %module_init = OpFunction %void
 // CHECK: %module_init_bb = OpLabel
 // CHECK: [[ptr_layout:%\w+]] = OpAccessChain %_ptr_Uniform_layout %buffer0 %uint_1
@@ -47,12 +60,3 @@ cbuffer buffer0 {
 // CHECK: [[ptr_foo_clone_1:%\w+]] = OpAccessChain %_ptr_Private_float [[ptr_foo_clone]] %uint_1
 // CHECK: [[foo_1:%\w+]] = OpLoad %float [[ptr_foo_1]]
 // CHECK: OpStore [[ptr_foo_clone_1]] [[foo_1]]
-
-float4 main(float4 color : COLOR) : SV_TARGET
-{
-  color.x += end;
-
-  color.x += bar.foo._12;
-
-  return color;
-}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.struct.hlsl
@@ -27,11 +27,6 @@ float4 main(float4 color : COLOR) : SV_TARGET
 {
   color.x += end;
 
-// CHECK: [[ptr_layout:%\w+]] = OpTypePointer Uniform %layout
-// CHECK: [[buffer0_1:%\w+]] = OpAccessChain [[ptr_layout]] %buffer0 %int_1
-// CHECK: [[ptr_foo:%\w+]] = OpAccessChain {{%\w+}} [[buffer0_1]] %int_1
-// CHECK: [[ptr_foo_1:%\w+]] = OpAccessChain {{%\w+}} [[ptr_foo]] %int_1
-// CHECK: OpLoad %float [[ptr_foo_1]]
   color.x += bar.foo._12;
 
   return color;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.hlsl
@@ -1,0 +1,49 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout
+
+// CHECK: OpDecorate [[arr_f3:%\w+]] ArrayStride 16
+// CHECK: OpMemberDecorate {{%\w+}} 0 Offset 0
+// CHECK: OpMemberDecorate {{%\w+}} 1 Offset 16
+// CHECK: OpMemberDecorate {{%\w+}} 2 Offset 52
+
+// CHECK: [[arr_f3]] = OpTypeArray %float %uint_3
+// CHECK: %type_buffer0 = OpTypeStruct %float [[arr_f3]] %float
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float1x3 foo;                      // Offset:   16 Size:    20 [unused]
+  float end;                         // Offset:   36 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  float1x2 bar = foo;
+  color.x += bar._m00;
+  return color;
+}
+
+// CHECK: %module_init = OpFunction %void
+// CHECK: %module_init_bb = OpLabel
+// CHECK: [[dummy0:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0:%\w+]] %uint_0
+// CHECK: [[dummy0_clone:%\w+]] = OpAccessChain %_ptr_Private_float [[clone:%\w+]] %uint_0
+// CHECK: [[dummy0_value:%\w+]] = OpLoad %float [[dummy0]]
+// CHECK:                OpStore [[dummy0_clone]] [[dummy0_value]]
+// CHECK: [[foo:%\w+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_3 [[buffer0]] %uint_1
+// CHECK: [[foo_clone:%\w+]] = OpAccessChain %_ptr_Private_v3float [[clone]] %uint_1
+// CHECK: [[foo_0:%\w+]] = OpAccessChain %_ptr_Uniform_float [[foo]] %uint_0
+// CHECK: [[foo_clone_0:%\w+]] = OpAccessChain %_ptr_Private_float [[foo_clone]] %uint_0
+// CHECK: [[foo_0_value:%\w+]] = OpLoad %float [[foo_0]]
+// CHECK:                OpStore [[foo_clone_0]] [[foo_0_value]]
+// CHECK: [[foo_1:%\w+]] = OpAccessChain %_ptr_Uniform_float [[foo]] %uint_1
+// CHECK: [[foo_clone_1:%\w+]] = OpAccessChain %_ptr_Private_float [[foo_clone]] %uint_1
+// CHECK: [[foo_1_value:%\w+]] = OpLoad %float [[foo_1]]
+// CHECK:                OpStore [[foo_clone_1]] [[foo_1_value]]
+// CHECK: [[foo_2:%\w+]] = OpAccessChain %_ptr_Uniform_float [[foo]] %uint_2
+// CHECK: [[foo_clone_2:%\w+]] = OpAccessChain %_ptr_Private_float [[foo_clone]] %uint_2
+// CHECK: [[foo_2_value:%\w+]] = OpLoad %float [[foo_2]]
+// CHECK:                OpStore [[foo_clone_2]] [[foo_2_value]]
+// CHECK: [[end:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_2
+// CHECK: [[end_clone:%\w+]] = OpAccessChain %_ptr_Private_float [[clone]] %uint_2
+// CHECK: [[end_value:%\w+]] = OpLoad %float [[end]]
+// CHECK:                OpStore [[end_clone]] [[end_value]]
+// CHECK:                OpReturn
+// CHECK:                OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.hlsl
@@ -16,6 +16,10 @@ cbuffer buffer0 {
 
 float4 main(float4 color : COLOR) : SV_TARGET
 {
+// CHECK: %main = OpFunction %void None
+// CHECK:         OpFunctionCall %void %module_init
+// CHECK:         OpFunctionCall %v4float %src_main
+
   float1x2 bar = foo;
   color.x += bar._m00;
   return color;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl
@@ -6,10 +6,15 @@
 // CHECK: OpMemberDecorate {{%\w+}} 2 Offset 52
 
 // CHECK: [[arr_f3]] = OpTypeArray %float %uint_3
-// CHECK: [[type_buffer0:%\w+]] = OpTypeStruct %float [[arr_f3]] %float
-// CHECK: [[type_ptr_buffer0:%\w+]] = OpTypePointer Uniform [[type_buffer0]]
-// CHECK: [[type_buffer0_clone:%\w+]] = OpTypeStruct %float %v3float %float
-// CHECK: [[buffer0:%\w+]] = OpVariable [[type_ptr_buffer0]] Uniform
+// CHECK: %type_buffer0 = OpTypeStruct %float [[arr_f3]] %float
+// CHECK-NOT: OpTypeStruct
+// CHECK-NOT: OpTypeArray
+
+// Type for `float4 color`
+// CHECK: %v4float = OpTypeVector %float 4
+// CHECK-NOT: OpTypeVector
+
+// CHECK: %buffer0 = OpVariable %_ptr_Uniform_type_buffer0 Uniform
 
 cbuffer buffer0 {
   float dummy0;                      // Offset:    0 Size:     4 [unused]
@@ -19,17 +24,10 @@ cbuffer buffer0 {
 
 float4 main(float4 color : COLOR) : SV_TARGET
 {
-// CHECK: [[buffer0_clone:%\w+]] = {{\w+}} [[type_buffer0_clone]]
-
-// CHECK: [[foo_0:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_0
+// CHECK: [[foo_0:%\w+]] = OpAccessChain %_ptr_Uniform_float %buffer0 %uint_1 %uint_0
 // CHECK: [[foo_0_value:%\w+]] = OpLoad %float [[foo_0]]
-// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_0_value]] [[buffer0_clone]] 1 0
-// CHECK: [[foo_1:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_1
-// CHECK: [[foo_1_value:%\w+]] = OpLoad %float [[foo_1]]
-// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_1_value]] [[buffer0_clone]] 1 1
-// CHECK: [[foo_2:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_2
-// CHECK: [[foo_2_value:%\w+]] = OpLoad %float [[foo_2]]
-// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_2_value]] [[buffer0_clone]] 1 2
+// CHECK:                  OpFAdd %float {{%\w+}} [[foo_0_value]]
+
   float1x2 bar = foo;
   color.x += bar._m00;
   return color;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T ps_6_0 -E main -fvk-use-dx-layout -O3
+
+// CHECK: OpDecorate [[arr_f3:%\w+]] ArrayStride 16
+// CHECK: OpMemberDecorate {{%\w+}} 0 Offset 0
+// CHECK: OpMemberDecorate {{%\w+}} 1 Offset 16
+// CHECK: OpMemberDecorate {{%\w+}} 2 Offset 52
+
+// CHECK: [[arr_f3]] = OpTypeArray %float %uint_3
+// CHECK: [[type_buffer0:%\w+]] = OpTypeStruct %float [[arr_f3]] %float
+// CHECK: [[type_ptr_buffer0:%\w+]] = OpTypePointer Uniform [[type_buffer0]]
+// CHECK: [[type_buffer0_clone:%\w+]] = OpTypeStruct %float %v3float %float
+// CHECK: [[buffer0:%\w+]] = OpVariable [[type_ptr_buffer0]] Uniform
+
+cbuffer buffer0 {
+  float dummy0;                      // Offset:    0 Size:     4 [unused]
+  float1x3 foo;                      // Offset:   16 Size:    20 [unused]
+  float end;                         // Offset:   36 Size:     4
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+// CHECK: [[buffer0_clone:%\w+]] = {{\w+}} [[type_buffer0_clone]]
+
+// CHECK: [[foo_0:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_0
+// CHECK: [[foo_0_value:%\w+]] = OpLoad %float [[foo_0]]
+// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_0_value]] [[buffer0_clone]] 1 0
+// CHECK: [[foo_1:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_1
+// CHECK: [[foo_1_value:%\w+]] = OpLoad %float [[foo_1]]
+// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_1_value]] [[buffer0_clone]] 1 1
+// CHECK: [[foo_2:%\w+]] = OpAccessChain %_ptr_Uniform_float [[buffer0]] %uint_1 %uint_2
+// CHECK: [[foo_2_value:%\w+]] = OpLoad %float [[foo_2]]
+// CHECK: [[buffer0_clone:%\w+]] = OpCompositeInsert [[type_buffer0_clone]] [[foo_2_value]] [[buffer0_clone]] 1 2
+  float1x2 bar = foo;
+  color.x += bar._m00;
+  return color;
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.offset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.offset.hlsl
@@ -9,9 +9,10 @@
 // CHECK: OpMemberDecorate %type_buffer0 5 Offset 40
 // CHECK: OpMemberDecorate %type_buffer0 6 Offset 48
 // CHECK: OpMemberDecorate %type_buffer0 7 Offset 52
-// CHECK: OpMemberDecorate %type_buffer0 8 Offset 60
+// CHECK: OpMemberDecorate %type_buffer0 8 Offset 64
+// CHECK: OpMemberDecorate %type_buffer0 9 Offset 72
 
-// CHECK: %type_buffer0 = OpTypeStruct %half %_arr_float_uint_1 %half %float %v3half %double %half %v2float %float
+// CHECK: %type_buffer0 = OpTypeStruct %half %_arr_float_uint_1 %half %float %v3half %double %half %v2float %v2float %float
 
 cbuffer buffer0 {
   float16_t a;  // Offset:    0
@@ -22,7 +23,8 @@ cbuffer buffer0 {
   double f;     // Offset:   40
   float16_t g;  // Offset:   48
   float2 h;     // Offset:   52
-  float end;    // Offset:   60
+  float2 i;     // Offset:   64
+  float end;    // Offset:   72
 };
 
 float4 main(float4 color : COLOR) : SV_TARGET

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.offset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.fxc.offset.hlsl
@@ -1,0 +1,32 @@
+// Run: %dxc -T ps_6_2 -E main -fvk-use-dx-layout -enable-16bit-types
+
+// CHECK: OpDecorate %_arr_float_uint_1 ArrayStride 16
+// CHECK: OpMemberDecorate %type_buffer0 0 Offset 0
+// CHECK: OpMemberDecorate %type_buffer0 1 Offset 16
+// CHECK: OpMemberDecorate %type_buffer0 2 Offset 20
+// CHECK: OpMemberDecorate %type_buffer0 3 Offset 24
+// CHECK: OpMemberDecorate %type_buffer0 4 Offset 32
+// CHECK: OpMemberDecorate %type_buffer0 5 Offset 40
+// CHECK: OpMemberDecorate %type_buffer0 6 Offset 48
+// CHECK: OpMemberDecorate %type_buffer0 7 Offset 52
+// CHECK: OpMemberDecorate %type_buffer0 8 Offset 60
+
+// CHECK: %type_buffer0 = OpTypeStruct %half %_arr_float_uint_1 %half %float %v3half %double %half %v2float %float
+
+cbuffer buffer0 {
+  float16_t a;  // Offset:    0
+  float b[1];   // Offset:   16
+  float16_t c;  // Offset:   20
+  float d;      // Offset:   24
+  float16_t3 e; // Offset:   32
+  double f;     // Offset:   40
+  float16_t g;  // Offset:   48
+  float2 h;     // Offset:   52
+  float end;    // Offset:   60
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  color.x += end;
+  return color;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2091,6 +2091,10 @@ TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixStruct) {
   setDxLayout();
   runFileTest("vk.layout.cbuffer.fxc.matrix.struct.hlsl");
 }
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixMajorness) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.majorness.hlsl");
+}
 
 TEST_F(FileTest, VulkanLayoutFxcRulesCBuffer1) {
   // cbuffer/tbuffer/ConstantBuffer/TextureBuffer with fxc layout rules

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2075,6 +2075,23 @@ TEST_F(FileTest, VulkanLayoutFxcRulesCBuffer) {
   runFileTest("vk.layout.cbuffer.fxc.hlsl");
 }
 
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrix) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.simple.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixNxM) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.n-by-m.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixArray) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.array.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixStruct) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.struct.hlsl");
+}
+
 TEST_F(FileTest, VulkanLayoutFxcRulesCBuffer1) {
   // cbuffer/tbuffer/ConstantBuffer/TextureBuffer with fxc layout rules
   setDxLayout();

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2095,6 +2095,14 @@ TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixMajorness) {
   setDxLayout();
   runFileTest("vk.layout.cbuffer.fxc.matrix.majorness.hlsl");
 }
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixUseArrayForVertex) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.v2arr.conversion.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixUseArrayForVertexWithO3) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl");
+}
 
 TEST_F(FileTest, VulkanLayoutFxcRulesCBuffer1) {
   // cbuffer/tbuffer/ConstantBuffer/TextureBuffer with fxc layout rules

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2103,6 +2103,14 @@ TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixUseArrayForVertexWithO3) {
   setDxLayout();
   runFileTest("vk.layout.cbuffer.fxc.matrix.v2arr.conversion.o3.hlsl");
 }
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferOffset) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.offset.hlsl");
+}
+TEST_F(FileTest, VulkanLayoutFxcRulesCBufferMatrixGlobal) {
+  setDxLayout();
+  runFileTest("vk.layout.cbuffer.fxc.matrix.global.hlsl");
+}
 
 TEST_F(FileTest, VulkanLayoutFxcRulesCBuffer1) {
   // cbuffer/tbuffer/ConstantBuffer/TextureBuffer with fxc layout rules


### PR DESCRIPTION
When a CTBuffer contains a matrix and we use FXC memory layout for it i.e.,
`-fvk-use-dx-layout`, the memory layout of the generated struct is different
from what FXC generates. FXC memory layout rule for matrices or array of
matrices are:
1. `floatMxN` means `N` float vectors and each vector has `M` elements.
  - How to calculate size: 16 * (N - 1) + 4 * M bytes
  - How to calculate offset:
    - If the size is greater than or equal to 16 bytes: the offset must be aligned to 16 bytes
    - Otherwise (less than 16): it cannot be split into multiple 16 bytes slots.
  - For example, float2x3 has 16 * (3 - 1) + 4 * 2 = 40 bytes as its size. Since its size 40 bytes is greater than 16 bytes, it must be aligned to 16 bytes.

2. `floatMxN[K]` means an array of `floatMxN` with `K` elements.
  - size: (K - 1) * N * 16 + 16 * (N - 1) + 4 * M
  - offset:
    - If K > 1, it must be aligned to 16 bytes
    - If K == 1, it is the same with floatMxN.
  - For example, the size of float3x2 foo[7]; is (7 - 1) * 2 * 16 + 16 * (2 - 1) + 4 * 3 = 220.

The non-trivial case is `float1xN` which is a matrix with `N` vectors and each vector has 1 element.
Its size should be `16 * (N - 1) + 4` based on the FXC memory layout rule.
For example, the size of `float1x2` must be 20 in bytes, which means we want to put the first float value of
`float1x2` at the offset 0 in bytes and the second float value at the offset 16 in bytes.
It means we must not generate it as a SPIR-V vector type because setting it as a SPIR-V vector results in
putting the first at the offset 0 in bytes and the second at the offset 4 in bytes.
In addition, we cannot set it as a SPIR-V matrix type because SPIR-V does not allow a matrix with a single
row and a vector with a single element.
The only available option is to set it as a SPIR-V array with `ArrayStride 16`.

Since we currently consider `float1xN` as an `OpTypeVector` and generate all SPIR-V code based on the assumption.
Changing the type of `float1xN` to `OpTypeArray` needs huge engineering costs to handle all the cases.
For example, in many places e.g., addition, subtraction, multiplication, we use `OpVectorShuffle` for `float1xN` because we consider it as `OpTypeArray`.

Our solution is to create two variables for CTBuffer including `type1xN` with FXC memory layout:
1. Original: One with correct subtypes and memory layouts i.e., `OpTypeArray` for `type1xN`
2. Clone: One with Private storage class i.e., without physical memory layout
    - `OpTypeVector` for `type1xN` as the current DXC does.

The Original variable is in charge of getting CTBuffer data from CPU.
We create a module initialization function to copy the Original variable to the Clone variable.
We insert `OpFunctionCall` for the module initialization function into all entry points.
We use the Clone variable for the CTBuffer in all places.