### PR TITLE
DiagnosticsEngine incorrectly handles ReportOnce diagnostics and asserts

### DIFF
--- a/tools/clang/include/clang/Basic/Diagnostic.h
+++ b/tools/clang/include/clang/Basic/Diagnostic.h
@@ -1154,8 +1154,11 @@ inline DiagnosticBuilder DiagnosticsEngine::ReportOnce(unsigned DiagID) {
 inline DiagnosticBuilder DiagnosticsEngine::ReportOnce(SourceLocation Loc,
                                                        unsigned DiagID) {
   if (std::find(DiagOnceDiagnostics.begin(), DiagOnceDiagnostics.end(),
-                DiagID) != DiagOnceDiagnostics.end())
-    return DiagnosticBuilder(this);
+                DiagID) != DiagOnceDiagnostics.end()) {
+    auto DisabledDiag =  DiagnosticBuilder(this);
+    DisabledDiag.IsActive = false;
+    return DisabledDiag;
+  }
 
   DiagOnceDiagnostics.push_back(DiagID);
   return Report(Loc, DiagID);

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
@@ -15,12 +15,18 @@
 // check if we get DXIL and the payload type is there 
 // CHK4: Invalid target for payload access qualifiers. Only lib_6_6 and beyond are supported.
 // CHK5: warning: payload access qualifieres are only supported for target lib_6_6 and beyond. You can opt-in for lib_6_6 with the -enable-payload-qualifiers flag. Qualifiers will be dropped.
+// CHK5: struct [raypayload] Payload {
+// CHK5-NOT: struct [raypayload] OtherPayload {
 // CHK6: %struct.Payload = type { i32, i32 }
 
 // CHK7: error: type 'Payload' used as payload requires that it is annotated with the {{\[[a-z]*\]}} attribute
 
 #if TEST_NUM <= 4
 struct [raypayload] Payload {
+    int a : read(closesthit) : write(caller);
+    int b : write(closesthit) : read(caller);
+};
+struct [raypayload] OtherPayload {
     int a : read(closesthit) : write(caller);
     int b : write(closesthit) : read(caller);
 };


### PR DESCRIPTION
When a diagnostic that should be emitted with ReportOnce has already been emitted, an invalid DiagnosticsBuilder is returned to prohibit another emittance of the diagnostic. The current implementation, however, does not set IsActive=false and the DiagnosticsEngine tries to emit a diagnostic with an invalid DiagID. This function is currently only used with payload access qualifiers to emit a warning only once if qualifiers are dropped because PAQs are disabled because of the SM version or the user opted-out. (Update the corresponding test accordingly).