### PR TITLE
[spirv] add unit test to check function template instance

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/type.template.function.template-instance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.template.function.template-instance.hlsl
@@ -1,0 +1,47 @@
+// Run: %dxc -T ps_6_0 -E main -enable-templates
+
+template <typename T>
+T square(T number) {
+  return number * number;
+}
+
+template <typename T>
+T plusTwo(int n) {
+  return 2 + n;
+}
+
+template <typename T>
+int triple(T x) {
+  return 3 * x;
+}
+
+void main() {
+  int x;
+  float y;
+
+// CHECK: [[fn_param_int_ret_int:%\w+]] = OpTypeFunction %int %_ptr_Function_int
+// CHECK: [[fn_param_float_ret_float:%\w+]] = OpTypeFunction %float %_ptr_Function_float
+// CHECK: [[fn_param_double_ret_double:%\w+]] = OpTypeFunction %double %_ptr_Function_double
+// CHECK: [[fn_param_int_ret_bool:%\w+]] = OpTypeFunction %bool %_ptr_Function_int
+// CHECK: [[fn_param_double_ret_int:%\w+]] = OpTypeFunction %int %_ptr_Function_double
+
+// CHECK: OpFunction %int None [[fn_param_int_ret_int]]
+// CHECK: OpFunctionParameter %_ptr_Function_int
+  x = square<int>(x);
+
+// CHECK: OpFunction %float None [[fn_param_float_ret_float]]
+// CHECK: OpFunctionParameter %_ptr_Function_float
+  y = square<float>(y);
+
+// CHECK: OpFunction %double None [[fn_param_double_ret_double]]
+// CHECK: OpFunctionParameter %_ptr_Function_double
+  y = square<double>(x);
+
+// CHECK: %plusTwo = OpFunction %bool None [[fn_param_int_ret_bool]]
+// CHECK: %n = OpFunctionParameter %_ptr_Function_int
+  y = plusTwo<bool>(x);
+
+// CHECK: %triple = OpFunction %int None [[fn_param_double_ret_int]]
+// CHECK: OpFunctionParameter %_ptr_Function_double
+  y = triple<double>(x);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -145,6 +145,10 @@ TEST_F(FileTest, TriangleStreamTypes) {
   runFileTest("type.triangle-stream.hlsl");
 }
 
+TEST_F(FileTest, TemplateFunctionInstance) {
+  runFileTest("type.template.function.template-instance.hlsl");
+}
+
 // For constants
 TEST_F(FileTest, ScalarConstants) { runFileTest("constant.scalar.hlsl"); }
 TEST_F(FileTest, 16BitDisabledScalarConstants) {


### PR DESCRIPTION
After investigating #3557, I realized we have to change some parts of SPIR-V backend
to support template correctly. The function template instance works fine while the
struct/class template instance has some issues, but I want to add an unit test for the
function template instance to make sure it works fine.