### PR TITLE
Fix detection of inner UDT ptr used by lowered intrinsic (DispatchMesh)

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -334,12 +334,12 @@ static unsigned IsPtrUsedByLoweredFn(
             "otherwise, multiple uses in single call");
       }
 
-    } else if (GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(user)) {
+    } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(user)) {
       // Not what we are looking for if GEP result is not [array of] struct.
       // If use is under struct member, we can still SROA the outer struct.
       if (!dxilutil::StripArrayTypes(GEP->getType()->getPointerElementType())
             ->isStructTy() ||
-          FindFirstStructMemberIdxInGEP(cast<GEPOperator>(GEP)))
+          FindFirstStructMemberIdxInGEP(GEP))
         continue;
       if (IsPtrUsedByLoweredFn(user, CollectedUses))
         bFound = true;
@@ -350,7 +350,7 @@ static unsigned IsPtrUsedByLoweredFn(
 
     } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(user)) {
       unsigned opcode = CE->getOpcode();
-      if (opcode == Instruction::AddrSpaceCast || opcode == Instruction::GetElementPtr)
+      if (opcode == Instruction::AddrSpaceCast)
         if (IsPtrUsedByLoweredFn(user, CollectedUses))
           bFound = true;
     }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/as-groupshared-nested-payload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/as-groupshared-nested-payload.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E amplification -T as_6_5 %s | FileCheck %s
 
-// Make sure we pass groupshared mesh payload directly
-// in to DispatchMesh, with no alloca involved.
+// Make sure we pass groupshared mesh payload directly into DispatchMesh,
+// with correct type, and no alloca involved.
 
 // CHECK: define void @amplification
 // CHECK-NOT: alloca
@@ -13,13 +13,14 @@
 
 struct MeshPayload
 {
+  float arr[3];
   uint4 data;
 };
 
 struct GSStruct
 {
-  uint i;
   MeshPayload pld;
+  MeshPayload pld2;
 };
 
 groupshared GSStruct gs;
@@ -28,8 +29,7 @@ GSStruct cb_gs;
 [numthreads(4,1,1)]
 void amplification(uint gtid : SV_GroupIndex)
 {
-  gs = cb_gs;
-  gs.i = 1;
+//  gs = cb_gs;
   gs.pld.data[gtid] = gtid;
   DispatchMesh(1,1,1,gs.pld);
 }


### PR DESCRIPTION
- In constant GEP case, the outer structure would be reported as used by
the intrinsic, preventing SROA of outer struct and resulting in the wrong
type for the intrinsic.