### PR TITLE
Fixed linker not putting subprogram of inlined functions into CU

### DIFF
--- a/include/llvm/IR/DebugInfoMetadata.h
+++ b/include/llvm/IR/DebugInfoMetadata.h
@@ -545,6 +545,7 @@ public:
 
 
   Metadata *getRawScope() const { return getOperand(1); }
+  void setScope(Metadata *scope) { setOperand(1, scope); } // HLSL Change
   MDString *getRawName() const { return getOperandAs<MDString>(2); }
 
   void setFlags(unsigned NewFlags) {
@@ -1826,6 +1827,7 @@ public:
     return "";
   }
 
+  void setScope(DIScope *scope) { setOperand(0, scope); } // HLSL Change
   Metadata *getRawScope() const { return getOperand(0); }
   MDString *getRawName() const { return getOperandAs<MDString>(1); }
   Metadata *getRawFile() const { return getOperand(2); }

--- a/include/llvm/IR/IntrinsicInst.h
+++ b/include/llvm/IR/IntrinsicInst.h
@@ -29,6 +29,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/IR/DebugInfoMetadata.h" // HLSL Change
 
 namespace llvm {
   /// IntrinsicInst - A useful wrapper class for inspecting calls to intrinsic
@@ -89,6 +90,8 @@ namespace llvm {
       return cast<DIExpression>(getRawExpression());
     }
 
+    void setVariable(DIVariable *v) { setArgOperand(1, MetadataAsValue::get(getContext(), v)); } // HLSL Change
+
     Metadata *getRawVariable() const {
       return cast<MetadataAsValue>(getArgOperand(1))->getMetadata();
     }
@@ -121,6 +124,8 @@ namespace llvm {
     DIExpression *getExpression() const {
       return cast<DIExpression>(getRawExpression());
     }
+
+    void setVariable(DIVariable *v) { setArgOperand(2, MetadataAsValue::get(getContext(), v)); } // HLSL Change
 
     Metadata *getRawVariable() const {
       return cast<MetadataAsValue>(getArgOperand(2))->getMetadata();

--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -1063,7 +1063,10 @@ void DxilLinkJob::StripDeadDebugInfo(Module &M) {
         else
           SubprogramChange = true;
       } else {
-        SubprogramChange = true;
+        // Copy it in anyway even if there's no function. When function is inlined
+        // the function reference is gone, but the subprogram is still valid as
+        // scope.
+        LiveSubprograms.push_back(DISP);
       }
     }
 

--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -1058,10 +1058,9 @@ void DxilLinkJob::StripDeadDebugInfo(Module &M) {
 
       // If the function referenced by DISP is not null, the function is live.
       if (Function *Func = DISP->getFunction()) {
-        if (Func->getParent() == &M)
-          LiveSubprograms.push_back(DISP);
-        else
-          SubprogramChange = true;
+        LiveSubprograms.push_back(DISP);
+        if (Func->getParent() != &M)
+          DISP->replaceFunction(nullptr);
       } else {
         // Copy it in anyway even if there's no function. When function is inlined
         // the function reference is gone, but the subprogram is still valid as


### PR DESCRIPTION
- Fixed linker not adding subprogram of inlined functions into CU. Newer versions of LLVM will consider all the debug info invalid and ignore it if a subprogram is not associated with a CU.
- Added some other helper functions that are going to come in handy when cloning debug metadata from one cloned function to another