### PR TITLE
Fix build when `SUPPORT_QUERY_GIT_COMMIT_INFO` is disabled

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -118,15 +118,17 @@ struct CompilerVersionPartWriter {
       IFT(pVersionInfo2->GetCommitInfo(&CommitCount, &m_CommitShaStorage));
       m_CommitSha = llvm::StringRef(m_CommitShaStorage.m_pData, strlen(m_CommitShaStorage.m_pData));
       m_Header.CommitCount = CommitCount;
-      m_Header.VersionStringListSizeInBytes += m_CommitSha.size() + /*null term*/1;
+      m_Header.VersionStringListSizeInBytes += m_CommitSha.size();
     }
+    m_Header.VersionStringListSizeInBytes += /*null term*/ 1;
 
     CComPtr<IDxcVersionInfo3> pVersionInfo3;
     if (SUCCEEDED(pVersionInfo->QueryInterface(&pVersionInfo3))) {
       IFT(pVersionInfo3->GetCustomVersionString(&m_CustomStringStorage));
       m_CustomString = llvm::StringRef(m_CustomStringStorage, strlen(m_CustomStringStorage.m_pData));
-      m_Header.VersionStringListSizeInBytes += m_CustomString.size() + /*null term*/1;
+      m_Header.VersionStringListSizeInBytes += m_CustomString.size();
     }
+    m_Header.VersionStringListSizeInBytes += /*null term*/ 1;
   }
 
   static uint32_t PadToDword(uint32_t size, uint32_t *outNumPadding=nullptr) {

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -552,6 +552,8 @@ class DxcCompiler : public IDxcCompiler3,
                     public IDxcVersionInfo3,
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
                     public IDxcVersionInfo2
+#else
+                    public IDxcVersionInfo
 #endif // SUPPORT_QUERY_GIT_COMMIT_INFO
 {
 private:


### PR DESCRIPTION
This fixes two compile errors and a runtime error when `SUPPORT_QUERY_GIT_COMMIT_INFO` is disabled:
1. Inheritance list of `DxcCompiler` does no longer have a trailing comma.
https://github.com/microsoft/DirectXShaderCompiler/blob/56e22b30c5e43632f56a1f97865f37108ec35463/tools/clang/tools/dxcompiler/dxcompilerobj.cpp#L552
2. Static cast from `DxcCompiler` to `IDxcVersionInfo` works again as `IDxcVersionInfo3` is derived from `IUnknown` only.
https://github.com/microsoft/DirectXShaderCompiler/blob/56e22b30c5e43632f56a1f97865f37108ec35463/tools/clang/tools/dxcompiler/dxcompilerobj.cpp#L1087
3. The byte count for null terminators must always be added to `VersionStringListSizeInBytes` in `CompilerVersionPartWriter::Init` as those strings are always written even when empty:
https://github.com/microsoft/DirectXShaderCompiler/blob/56e22b30c5e43632f56a1f97865f37108ec35463/tools/clang/tools/dxcompiler/dxcompilerobj.cpp#L121