### PR TITLE
Add InstCombine to Loop Delete followup passes

### DIFF
--- a/lib/HLSL/DxilLoopDeletion.cpp
+++ b/lib/HLSL/DxilLoopDeletion.cpp
@@ -45,9 +45,10 @@ bool DxilLoopDeletion::runOnFunction(Function &F) {
   DeleteLoopPM.add(createLoopDeletionPass());
   bool bUpdated = false;
 
-  legacy::FunctionPassManager SimpilfyPM(F.getParent());
-  SimpilfyPM.add(createCFGSimplificationPass());
-  SimpilfyPM.add(createDeadCodeEliminationPass());
+  legacy::FunctionPassManager SimplifyPM(F.getParent());
+  SimplifyPM.add(createCFGSimplificationPass());
+  SimplifyPM.add(createDeadCodeEliminationPass());
+  SimplifyPM.add(createInstructionCombiningPass());
 
   const unsigned kMaxIteration = 3;
   unsigned i=0;
@@ -55,7 +56,7 @@ bool DxilLoopDeletion::runOnFunction(Function &F) {
     if (!DeleteLoopPM.run(F))
       break;
 
-    SimpilfyPM.run(F);
+    SimplifyPM.run(F);
     i++;
     bUpdated = true;
   }

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -617,7 +617,6 @@ void PassManagerBuilder::populateModulePassManager(
   addExtensionsToPM(EP_Peephole, MPM);
   MPM.add(createCFGSimplificationPass());
   MPM.add(createDxilLoopDeletionPass()); // HLSL Change - try to delete loop again.
-  MPM.add(createInstructionCombiningPass());
 
   if (!DisableUnrollLoops) {
     MPM.add(createLoopUnrollPass(/* HLSL Change begin */-1, -1, -1, -1, this->StructurizeLoopExitsForUnroll /* HLSL Change end */));    // Unroll small loops


### PR DESCRIPTION
Needed to pick up new DCE opportunities and fully eliminate useless
loops. We ran it after the total runs anyway. Now we run it after every
repetition

Correct a variable name typo