### PR TITLE
[spirv] always use r-value for flat conversion target

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2765,7 +2765,7 @@ SpirvInstruction *SpirvEmitter::doCastExpr(const CastExpr *expr) {
     }
 
     if (!subExprInstr)
-      subExprInstr = doExpr(subExpr);
+      subExprInstr = loadIfGLValue(subExpr);
 
     auto *val = processFlatConversion(toType, evalType, subExprInstr,
                                       expr->getExprLoc());

--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.decl-ref.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.decl-ref.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct A {
+    float a;
+    uint b;
+    float GetA() { return a; }
+};
+
+ConstantBuffer<A> foo : register(b0, space2);
+
+void main(out float4 col : SV_Target0) {
+// CHECK:        [[foo:%\d+]] = OpLoad %type_ConstantBuffer_A %foo
+// CHECK:      [[foo_a:%\d+]] = OpCompositeExtract %float [[foo]] 0
+// CHECK:      [[foo_b:%\d+]] = OpCompositeExtract %uint [[foo]] 1
+// CHECK: [[foo_rvalue:%\d+]] = OpCompositeConstruct %A [[foo_a]] [[foo_b]]
+// CHECK:                       OpStore %temp_var_A [[foo_rvalue]]
+// CHECK:                       OpFunctionCall %float %A_GetA %temp_var_A
+    col.x = foo.GetA();
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -451,6 +451,9 @@ TEST_F(FileTest, CastFlatConversionArrayToVector) {
 TEST_F(FileTest, CastImplicitFlatConversion) {
   runFileTest("cast.flat-conversion.implicit.hlsl");
 }
+TEST_F(FileTest, CastFlatConversionDeclRef) {
+  runFileTest("cast.flat-conversion.decl-ref.hlsl");
+}
 TEST_F(FileTest, CastFlatConversionStruct) {
   runFileTest("cast.flat-conversion.struct.hlsl");
 }


### PR DESCRIPTION
The flat conversion method `SpirvEmitter::processFlatConversion()`
conducts bit-casts, composite construction, ... to covert the target to
the specific type. Since we cannot convert a pointer to other types, we
should make sure the target is r-value. In particular, it fixes bugs
when the target is a constant or texture buffer. The existing code just
returns `OpVariable` for the constant or texture buffer conversion, but
`OpVariable` is not r-value and it results in a spirv-val error.

Fixes #3681