### PR TITLE
[spirv] image with minimum precision scalar data types

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -314,9 +314,8 @@ public:
       SourceLocation loc);
 
   /// \brief Creates SPIR-V instructions for writing to the given image.
-  void createImageWrite(QualType imageType, SpirvInstruction *image,
-                        SpirvInstruction *coord, SpirvInstruction *texel,
-                        SourceLocation loc);
+  void createImageWrite(SpirvInstruction *image, SpirvInstruction *coord,
+                        SpirvInstruction *texel, SourceLocation loc);
 
   /// \brief Creates SPIR-V instructions for gathering the given image.
   ///

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -305,22 +305,22 @@ void EmitVisitor::initInstruction(SpirvInstruction *inst) {
   if (inst->hasResultType()) {
     const uint32_t resultTypeId = typeHandler.emitType(inst->getResultType());
     inst->setResultTypeId(resultTypeId);
-  }
 
-  // Emit NonUniformEXT decoration (if any).
-  if (inst->isNonUniform()) {
-    typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
-                               spv::Decoration::NonUniformEXT, {});
-  }
-  // Emit RelaxedPrecision decoration (if any).
-  if (inst->isRelaxedPrecision()) {
-    typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
-                               spv::Decoration::RelaxedPrecision, {});
-  }
-  // Emit NoContraction decoration (if any).
-  if (inst->isPrecise() && inst->isArithmeticInstruction()) {
-    typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
-                               spv::Decoration::NoContraction, {});
+    // Emit NonUniformEXT decoration (if any).
+    if (inst->isNonUniform()) {
+      typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
+                                 spv::Decoration::NonUniformEXT, {});
+    }
+    // Emit RelaxedPrecision decoration (if any).
+    if (inst->isRelaxedPrecision()) {
+      typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
+                                 spv::Decoration::RelaxedPrecision, {});
+    }
+    // Emit NoContraction decoration (if any).
+    if (inst->isPrecise() && inst->isArithmeticInstruction()) {
+      typeHandler.emitDecoration(getOrAssignResultId<SpirvInstruction>(inst),
+                                 spv::Decoration::NoContraction, {});
+    }
   }
 
   // According to Section 2.4. Logical Layout of a Module in the SPIR-V spec:

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -562,13 +562,13 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
   return fetchOrReadInst;
 }
 
-void SpirvBuilder::createImageWrite(QualType imageType, SpirvInstruction *image,
+void SpirvBuilder::createImageWrite(SpirvInstruction *image,
                                     SpirvInstruction *coord,
                                     SpirvInstruction *texel,
                                     SourceLocation loc) {
   assert(insertPoint && "null insert point");
   auto *writeInst = new (context) SpirvImageOp(
-      spv::Op::OpImageWrite, imageType, loc, image, coord,
+      spv::Op::OpImageWrite, /*QualType*/ {}, loc, image, coord,
       spv::ImageOperandsMask::MaskNone,
       /*dref*/ nullptr, /*bias*/ nullptr, /*lod*/ nullptr, /*gradDx*/ nullptr,
       /*gradDy*/ nullptr, /*constOffset*/ nullptr, /*varOffset*/ nullptr,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -6377,7 +6377,7 @@ SpirvEmitter::tryToAssignToRWBufferRWTexture(const Expr *lhs,
     auto *baseInfo = doExpr(baseExpr);
     auto *image =
         spvBuilder.createLoad(imageType, baseInfo, baseExpr->getExprLoc());
-    spvBuilder.createImageWrite(imageType, image, loc, rhs, lhs->getExprLoc());
+    spvBuilder.createImageWrite(image, loc, rhs, lhs->getExprLoc());
     return rhs;
   }
   return nullptr;

--- a/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.min.precision.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.min.precision.scalar.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T cs_6_0 -E main -Vd
+// Run: %dxc -T cs_6_0 -E main
 
 // CHECK: %type_2d_image = OpTypeImage %float 2D 2 0 0 2 Rgba32f
 // CHECK: %_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -70,9 +70,7 @@ TEST_F(FileTest, SamplerTypes) { runFileTest("type.sampler.hlsl"); }
 TEST_F(FileTest, TextureTypes) { runFileTest("type.texture.hlsl"); }
 TEST_F(FileTest, RWTextureTypes) { runFileTest("type.rwtexture.hlsl"); }
 TEST_F(FileTest, RWTextureTypesWithMinPrecisionScalarTypes) {
-  // TODO: Fix the valiation error
-  runFileTest("type.rwtexture.with.min.precision.scalar.hlsl", Expect::Success,
-              /* runValidation */ false);
+  runFileTest("type.rwtexture.with.min.precision.scalar.hlsl");
 }
 TEST_F(FileTest, BufferType) { runFileTest("type.buffer.hlsl"); }
 TEST_F(FileTest, BufferTypeStructError1) {


### PR DESCRIPTION
1. Support image with minimum precision scalar data types
2. Do not set AST result type for `OpImageWrite` instruction.
Note that [OpImageWrite](https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpImageWrite)
does not have `Result Type`.
3. Do not set `RelaxedPrecision` decoration if the instruction does not have a result type.