### PR TITLE
Add option to override semantic defines

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -20,6 +20,7 @@
 #include "dxc/dxcapi.h"
 #include "dxc/Support/SPIRVOptions.h"
 #include <map>
+#include <set>
 
 namespace llvm {
 namespace opt {
@@ -133,6 +134,7 @@ public:
   unsigned DefaultTextCodePage = DXC_CP_UTF8; // OPT_encoding
 
   bool AllResourcesBound = false; // OPT_all_resources_bound
+  bool IgnoreOptSemDefs = false; // OPT_ignore_opt_semdefs
   bool AstDump = false; // OPT_ast_dump
   bool ColorCodeAssembly = false; // OPT_Cc
   bool CodeGenHighLevel = false; // OPT_fcgl
@@ -199,6 +201,9 @@ public:
   // Optimization pass enables, disables and selects
   std::map<std::string, bool> DxcOptimizationToggles; // OPT_opt_enable & OPT_opt_disable
   std::map<std::string, std::string> DxcOptimizationSelects; // OPT_opt_select
+
+  std::set<std::string> IgnoreSemDefs; // OPT_ignore_semdef
+  std::map<std::string, std::string> OverrideSemDefs; // OPT_override_semdef
 
   bool PrintAfterAll; // OPT_print_after_all
   bool EnablePayloadQualifiers = false; // OPT_enable_payload_qualifiers

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -271,6 +271,12 @@ def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcom
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR after each pass.">;
+def ignore_opt_semdefs : Flag<["-", "/"], "ignore-opt-semdefs">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Ignore optional semantic defines which are not required to ensure program correctness.">;
+def ignore_semdef : Separate<["-", "/"], "ignore-semdef">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Ignore the semantic define passed as a value to this flag.">;
+def override_semdef : Separate<["-", "/"], "override-semdef">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Override the value of semantic define with the one passed with this flag.">;
 def force_zero_store_lifetimes : Flag<["-", "/"], "force-zero-store-lifetimes">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Instead of generating lifetime intrinsics (SM >= 6.6) or storing undef (SM < 6.6), force fall back to storing zeroinitializer.">;
 def enable_lifetime_markers : Flag<["-", "/"], "enable-lifetime-markers">, Group<hlslcomp_Group>, Flags<[CoreOption]>,

--- a/include/dxc/dxcapi.internal.h
+++ b/include/dxc/dxcapi.internal.h
@@ -194,7 +194,11 @@ CROSS_PLATFORM_UUIDOF(IDxcLangExtensions2, "2490C368-89EE-4491-A4B2-C6547B6C9381
 struct IDxcLangExtensions2 : public IDxcLangExtensions {
 public:
   virtual HRESULT STDMETHODCALLTYPE SetTargetTriple(LPCSTR name) = 0;
+};
 
+CROSS_PLATFORM_UUIDOF(IDxcLangExtensions3, "A1B19880-FB1F-4920-9BC5-50356483BAC1")
+struct IDxcLangExtensions3 : public IDxcLangExtensions2 {
+public:
   /// Registers a semantic define which cannot be overriden using the flag -override-opt-semdefs
   virtual HRESULT STDMETHODCALLTYPE RegisterNonOptSemanticDefine(LPCWSTR name) = 0;
 };

--- a/include/dxc/dxcapi.internal.h
+++ b/include/dxc/dxcapi.internal.h
@@ -194,6 +194,9 @@ CROSS_PLATFORM_UUIDOF(IDxcLangExtensions2, "2490C368-89EE-4491-A4B2-C6547B6C9381
 struct IDxcLangExtensions2 : public IDxcLangExtensions {
 public:
   virtual HRESULT STDMETHODCALLTYPE SetTargetTriple(LPCSTR name) = 0;
+
+  /// Registers a semantic define which cannot be overriden using the flag -override-opt-semdefs
+  virtual HRESULT STDMETHODCALLTYPE RegisterNonOptSemanticDefine(LPCWSTR name) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcSystemAccess, "454b764f-3549-475b-958c-a7a6fcd05fbc")

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -258,6 +258,18 @@ static void addDiagnosticArgs(ArgList &Args, OptSpecifier Group,
   }
 }
 
+static std::pair<std::string, std::string> ParseDefine(std::string &argVal) {
+  std::pair<std::string, std::string> result = std::make_pair("", "");
+  if (argVal.empty())
+    return result;
+  auto defEndPos = argVal.find('=') == std::string::npos ? argVal.size() : argVal.find('=');
+  result.first = argVal.substr(0, defEndPos);
+  if (!result.first.empty() && defEndPos < argVal.size() - 1) {
+    result.second = argVal.substr(defEndPos + 1, argVal.size() - defEndPos - 1);
+  }
+  return result;
+}
+
 // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
 /// Checks and collects the arguments for -fvk-{b|s|t|u}-shift into *shifts.
@@ -507,6 +519,23 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     }
   }
 
+  std::vector<std::string> ignoreSemDefs = Args.getAllArgValues(OPT_ignore_semdef);
+  for (std::string &ignoreSemDef : ignoreSemDefs) {
+    opts.IgnoreSemDefs.insert(ignoreSemDef);
+  }
+
+  std::vector<std::string> overrideSemDefs = Args.getAllArgValues(OPT_override_semdef);
+  for (std::string &overrideSemDef : overrideSemDefs) {
+    auto kv = ParseDefine(overrideSemDef);
+    if (kv.first.empty())
+      continue;
+    if (opts.OverrideSemDefs.find(kv.first) == opts.OverrideSemDefs.end()) {
+      opts.OverrideSemDefs.insert(std::make_pair(kv.first, kv.second));
+    } else {
+      opts.OverrideSemDefs[kv.first] = kv.second;
+    }
+  }
+
   std::vector<std::string> optSelects = Args.getAllArgValues(OPT_opt_select);
   for (unsigned i = 0; i + 1 < optSelects.size(); i+=2) {
     std::string optimization = llvm::StringRef(optSelects[i]).lower();
@@ -612,6 +641,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   opts.AllResourcesBound = Args.hasFlag(OPT_all_resources_bound, OPT_INVALID, false);
   opts.AllResourcesBound = Args.hasFlag(OPT_all_resources_bound_, OPT_INVALID, opts.AllResourcesBound);
+  opts.IgnoreOptSemDefs = Args.hasFlag(OPT_ignore_opt_semdefs, OPT_INVALID, false);
   opts.ColorCodeAssembly = Args.hasFlag(OPT_Cc, OPT_INVALID, false);
   opts.DefaultRowMajor = Args.hasFlag(OPT_Zpr, OPT_INVALID, false);
   opts.DefaultColMajor = Args.hasFlag(OPT_Zpc, OPT_INVALID, false);

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <set>
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h" // HLSL change
 #include "dxc/Support/SPIRVOptions.h" // SPIR-V Change
 
@@ -194,6 +195,12 @@ public:
   bool HLSLAvoidControlFlow = false;
   /// Force [flatten] on every if.
   bool HLSLAllResourcesBound = false;
+  /// Skip adding optional semantics defines except ones which are required for correctness.
+  bool HLSLIgnoreOptSemDefs = false;
+  /// List of semantic defines that must be ignored.
+  std::set<std::string> HLSLIgnoreSemDefs;
+  /// List of semantic defines that must be overridden with user-provided values.
+  std::map<std::string, std::string> HLSLOverrideSemDefs;
   /// Major version of validator to run.
   unsigned HLSLValidatorMajorVer = 0;
   /// Minor version of validator to run.

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -582,6 +582,7 @@ public:
     HRESULT hr = DoBasicQueryInterface<
       IDxcCompiler3,
       IDxcLangExtensions,
+      IDxcLangExtensions2,
       IDxcLangExtensions3,
       IDxcContainerEvent,
       IDxcVersionInfo

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1347,6 +1347,9 @@ public:
     compiler.getCodeGenOpts().HLSLOptimizationToggles = Opts.DxcOptimizationToggles;
     compiler.getCodeGenOpts().HLSLOptimizationSelects = Opts.DxcOptimizationSelects;
     compiler.getCodeGenOpts().HLSLAllResourcesBound = Opts.AllResourcesBound;
+    compiler.getCodeGenOpts().HLSLIgnoreOptSemDefs = Opts.IgnoreOptSemDefs;
+    compiler.getCodeGenOpts().HLSLIgnoreSemDefs = Opts.IgnoreSemDefs;
+    compiler.getCodeGenOpts().HLSLOverrideSemDefs = Opts.OverrideSemDefs;
     compiler.getCodeGenOpts().HLSLDefaultRowMajor = Opts.DefaultRowMajor;
     compiler.getCodeGenOpts().HLSLPreferControlFlow = Opts.PreferFlowControl;
     compiler.getCodeGenOpts().HLSLAvoidControlFlow = Opts.AvoidFlowControl;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -547,7 +547,7 @@ static void CreateDefineStrings(
 }
 
 class DxcCompiler : public IDxcCompiler3,
-                    public IDxcLangExtensions2,
+                    public IDxcLangExtensions3,
                     public IDxcContainerEvent,
                     public IDxcVersionInfo3,
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
@@ -582,7 +582,7 @@ public:
     HRESULT hr = DoBasicQueryInterface<
       IDxcCompiler3,
       IDxcLangExtensions,
-      IDxcLangExtensions2,
+      IDxcLangExtensions3,
       IDxcContainerEvent,
       IDxcVersionInfo
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -201,7 +201,7 @@ public:
 
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIntelliSense, IDxcLangExtensions,
-                                 IDxcLangExtensions3>(
+                                 IDxcLangExtensions2, IDxcLangExtensions3>(
         this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -189,7 +189,7 @@ public:
       _Outptr_result_nullonfailure_ IDxcTranslationUnit** pTranslationUnit) override;
 };
 
-class DxcIntelliSense : public IDxcIntelliSense, public IDxcLangExtensions2 {
+class DxcIntelliSense : public IDxcIntelliSense, public IDxcLangExtensions3 {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
   hlsl::DxcLangExtensionsHelper m_langHelper;
@@ -201,7 +201,7 @@ public:
 
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIntelliSense, IDxcLangExtensions,
-                                 IDxcLangExtensions2>(
+                                 IDxcLangExtensions3>(
         this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -1278,7 +1278,7 @@ public:
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
                                            void **ppvObject) override {
     return DoBasicQueryInterface<IDxcRewriter2, IDxcRewriter,
-                                 IDxcLangExtensions, IDxcLangExtensions3>(
+                                 IDxcLangExtensions, IDxcLangExtensions2, IDxcLangExtensions3>(
         this, iid, ppvObject);
   }
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -340,6 +340,11 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
   const llvm::SmallVector<std::string, 2> &defineExclusions =
       helper->GetSemanticDefineExclusions();
 
+  const llvm::SetVector<std::string> &defineInclusions =
+    helper->GetNonOptSemanticDefines();
+
+  std::set<std::string> overridenMacroSemDef;
+
   // This is very inefficient in general, but in practice we either have
   // no semantic defines, or we have a star define for a some reserved prefix.
   // These will be sorted so rewrites are stable.
@@ -374,7 +379,42 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
         continue;
       }
 
+      // overriding a semantic define takes the first precedence
+      if (compiler.getCodeGenOpts().HLSLOverrideSemDefs.size() > 0 &&
+        compiler.getCodeGenOpts().HLSLOverrideSemDefs.find(ii->getName().str()) !=
+        compiler.getCodeGenOpts().HLSLOverrideSemDefs.end()) {
+        std::string defName = ii->getName().str();
+        std::string defValue = compiler.getCodeGenOpts().HLSLOverrideSemDefs[defName];
+        overridenMacroSemDef.insert(defName);
+        parsedDefines.emplace_back(ParsedSemanticDefine{ defName, defValue, 0 });
+        continue;
+      }
+
+      // ignoring a specific semantic define takes second precedence
+      if (compiler.getCodeGenOpts().HLSLIgnoreSemDefs.size() > 0 &&
+        compiler.getCodeGenOpts().HLSLIgnoreSemDefs.find(ii->getName().str()) !=
+        compiler.getCodeGenOpts().HLSLIgnoreSemDefs.end()) {
+        continue;
+      }
+
+      // ignoring all non-correctness semantic defines takes third precendence
+      if (compiler.getCodeGenOpts().HLSLIgnoreOptSemDefs &&
+        !defineInclusions.count(ii->getName().str())) {
+        continue;
+      }
+
       macros.push_back(std::pair<const IdentifierInfo *, MacroInfo *>(ii, mi));
+    }
+  }
+
+  // If there are semantic defines which are passed using -override-semdef flag,
+  // but we don't have that semantic define present in source or arglist, then 
+  // we just add the semantic define.
+  for (auto &kv : compiler.getCodeGenOpts().HLSLOverrideSemDefs) {
+    std::string overrideDefName = kv.first;
+    std::string overrideDefVal = kv.second;
+    if (overridenMacroSemDef.find(overrideDefName) == overridenMacroSemDef.end()) {
+      parsedDefines.emplace_back(ParsedSemanticDefine{ overrideDefName, overrideDefVal, 0 });
     }
   }
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -340,7 +340,7 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
   const llvm::SmallVector<std::string, 2> &defineExclusions =
       helper->GetSemanticDefineExclusions();
 
-  const llvm::SetVector<std::string> &defineInclusions =
+  const llvm::SetVector<std::string> &nonOptDefines =
     helper->GetNonOptSemanticDefines();
 
   std::set<std::string> overridenMacroSemDef;
@@ -399,7 +399,7 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
 
       // ignoring all non-correctness semantic defines takes third precendence
       if (compiler.getCodeGenOpts().HLSLIgnoreOptSemDefs &&
-        !defineInclusions.count(ii->getName().str())) {
+        !nonOptDefines.count(ii->getName().str())) {
         continue;
       }
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -1266,7 +1266,7 @@ HRESULT DoReWriteWithLineDirective(
 }
 } // namespace
 
-class DxcRewriter : public IDxcRewriter2, public IDxcLangExtensions2 {
+class DxcRewriter : public IDxcRewriter2, public IDxcLangExtensions3 {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
   DxcLangExtensionsHelper m_langExtensionsHelper;
@@ -1278,7 +1278,7 @@ public:
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
                                            void **ppvObject) override {
     return DoBasicQueryInterface<IDxcRewriter2, IDxcRewriter,
-                                 IDxcLangExtensions, IDxcLangExtensions2>(
+                                 IDxcLangExtensions, IDxcLangExtensions3>(
         this, iid, ppvObject);
   }
 

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -494,7 +494,7 @@ public:
 
   dxc::DxcDllSupport &m_dllSupport;
   CComPtr<IDxcCompiler> pCompiler;
-  CComPtr<IDxcLangExtensions2> pLangExtensions;
+  CComPtr<IDxcLangExtensions3> pLangExtensions;
   CComPtr<IDxcBlobEncoding> pCodeBlob;
   CComPtr<IDxcOperationResult> pCompileResult;
   CComPtr<IDxcSemanticDefineValidator> pTestSemanticDefineValidator;


### PR DESCRIPTION
Introduce below three hidden options to control overriding semantic defines which are passed through the source using `#define` and/or passed in the argument list using the `-D` option.

`-ignore-opt-semdefs`: Ignores all optional semantic defines which are not required to ensure program correctness.
`-ignore-semdef <semantic_define_name>`: Ignores the specific semantic define passed using this flag. 
`-override-semdef <semantic_define_name>=<semantic_define_value>`: Overrides the value of semantic define passed using this flag.
