### PR TITLE
Allowing use of const static variables in library exports

### DIFF
--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -43,7 +43,7 @@ using namespace hlsl;
 
 namespace {
 
-static const StringRef kStaticResourceLibErrorMsg = "static global resource use is disallowed in library exports.";
+static const StringRef kStaticResourceLibErrorMsg = "non const static global resource use is disallowed in library exports.";
 
 class DxilPromoteStaticResources : public ModulePass {
 public:
@@ -166,6 +166,7 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
     //  optimized away for the exported function.
     for (auto &GV : M.globals()) {
       if (GV.getLinkage() == GlobalVariable::LinkageTypes::InternalLinkage &&
+		!GV.isConstant() && 
         dxilutil::IsHLSLObjectType(dxilutil::GetArrayEltTy(GV.getType()))) {
         if (!GV.user_empty()) {
           if (Instruction *I = dyn_cast<Instruction>(*GV.user_begin())) {


### PR DESCRIPTION
We're currently in the process of converting already existing shader assets to raytracing equivalent versions. While doing so we run in to the following compile error when using global static variables in our library export: "static global resource use is disallowed in library exports."

shadercode:

```
Texture2D<float2> RainDepth : register(t1, space1);

SamplerState samplerPoint_BorderWhite 
{ 
    Filter = MIN_MAG_MIP_POINT ; 
    AddressU = BORDER ; 
    AddressV = BORDER ; 
    AddressW = BORDER ; 
    MipLODBias = 0 ; 
    MaxAnisotropy = 1 ; 
    BorderColor = float4 ( 1 , 1 , 1 , 1 ) ; 
} ; 

static const SamplerState samplerMIN_MAG_MIP_POINTBORDERBORDERWHITE = samplerPoint_BorderWhite ; 

static const SamplerState samplerStaticRainDepth = samplerMIN_MAG_MIP_POINTBORDERBORDERWHITE ; 

struct Payload{
	uint value;
};

struct Attributes
{
 float2 Barycentrics;
};

[shader("closesthit")]
void CHSMain(inout Payload payload, Attributes attributes)
{
 float val = RainDepth.SampleLevel ( samplerStaticRainDepth , float2(0,0), 0 ) ; 
}
```

While there is an explanation for why the use of global static variables is disallowed in [DxilPromoteResourcePasses.cpp ](https://github.com/microsoft/DirectXShaderCompiler/blob/aa4f5176ebba010a860a214d73f33bdc5b5042ce/lib/HLSL/DxilPromoteResourcePasses.cpp#L155) it remains unclear if **const** variables are disallowed by design, or if we can loosen the restrictions a bit to let global static const variables through? 

Note: changing from global static to preprocessor defines would work for the problem at hand, but it's a non trivial task given the amount of already existing assets in the engine.





