### PR TITLE
[spirv] emit correct OpEntryPoint operands for multiple entry functions

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -56,7 +56,7 @@ public:
       : sigPoint(sig), semanticInfo(std::move(semaInfo)), builtinAttr(builtin),
         type(astType), value(nullptr), isBuiltin(false),
         storageClass(spv::StorageClass::Max), location(nullptr),
-        locationCount(locCount) {
+        locationCount(locCount), entryPoint(nullptr) {
     isBuiltin = builtinAttr != nullptr;
   }
 
@@ -85,6 +85,9 @@ public:
 
   uint32_t getLocationCount() const { return locationCount; }
 
+  SpirvFunction *getEntryPoint() const { return entryPoint; }
+  void setEntryPoint(SpirvFunction *entry) { entryPoint = entry; }
+
 private:
   /// HLSL SigPoint. It uniquely identifies each set of parameters that may be
   /// input or output for each entry point.
@@ -107,6 +110,9 @@ private:
   const VKIndexAttr *indexAttr;
   /// How many locations this stage variable takes.
   uint32_t locationCount;
+  /// Entry point for this stage variable. If this stage variable is not
+  /// specific for an entry point e.g., built-in, it must be nullptr.
+  SpirvFunction *entryPoint;
 };
 
 class ResourceVar {
@@ -506,9 +512,10 @@ public:
   /// won't attach Block/BufferBlock decoration.
   const SpirvType *getCTBufferPushConstantType(const DeclContext *decl);
 
-  /// \brief Returns all defined stage (builtin/input/ouput) variables in this
-  /// mapper.
-  std::vector<SpirvVariable *> collectStageVars() const;
+  /// \brief Returns all defined stage (builtin/input/ouput) variables for the
+  /// entry point function entryPoint in this mapper.
+  std::vector<SpirvVariable *>
+  collectStageVars(SpirvFunction *entryPoint) const;
 
   /// \brief Writes out the contents in the function parameter for the GS
   /// stream output to the corresponding stage output variables in a recursive

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1012,6 +1012,11 @@ private:
                     SpirvInstruction *minLod, SpirvInstruction *residencyCodeId,
                     SourceLocation loc);
 
+  /// \brief Returns OpVariable to be used as 'Interface' operands of
+  /// OpEntryPoint. entryPoint is the SpirvFunction for the OpEntryPoint.
+  std::vector<SpirvVariable *>
+  getInterfacesForEntryPoint(SpirvFunction *entryPoint);
+
 private:
   /// \brief If the given FunctionDecl is not already in the workQueue, creates
   /// a FunctionInfo object for it, and inserts it into the workQueue. It also

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave.builtin.no-dup.vulkan1.2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave.builtin.no-dup.vulkan1.2.hlsl
@@ -6,7 +6,8 @@
 RWStructuredBuffer<uint> values;
 
 // CHECK: OpEntryPoint GLCompute
-// CHECK-SAME: %SubgroupSize %SubgroupLocalInvocationId
+// CHECK-DAG: %SubgroupSize
+// CHECK-DAG: %SubgroupLocalInvocationId
 
 // CHECK: OpDecorate %SubgroupSize BuiltIn SubgroupSize
 // CHECK-NOT: OpDecorate {{%\w+}} BuiltIn SubgroupSize

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.built-in.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.built-in.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T lib_6_6
+
+// CHECK: OpEntryPoint GLCompute %bar "bar" %gl_GlobalInvocationID
+// CHECK: OpEntryPoint GLCompute %foo "foo" %gl_GlobalInvocationID
+
+RWBuffer<uint> MyBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void bar(uint tid : SV_DispatchThreadId) {
+    MyBuffer[0] = tid;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void foo(uint tid : SV_DispatchThreadId) {
+    MyBuffer[0] = tid;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.built-in.vk.1p2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.built-in.vk.1p2.hlsl
@@ -1,0 +1,23 @@
+// Run: %dxc -T lib_6_6 -fspv-target-env=vulkan1.2
+
+// CHECK: OpEntryPoint GLCompute %bar "bar"
+// CHECK-DAG: %MyBuffer
+// CHECK-DAG: %gl_GlobalInvocationID
+
+// CHECK: OpEntryPoint GLCompute %foo "foo"
+// CHECK-DAG: %MyBuffer
+// CHECK-DAG: %gl_GlobalInvocationID
+
+RWBuffer<uint> MyBuffer;
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void bar(uint tid : SV_DispatchThreadId) {
+    MyBuffer[0] = tid;
+}
+
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void foo(uint tid : SV_DispatchThreadId) {
+    MyBuffer[0] = tid;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.hlsl
@@ -1,0 +1,85 @@
+// Run: %dxc -T lib_6_6
+
+struct Inner {
+    float2 cull2 : SV_CullDistance2;            // Builtin CullDistance
+    float3 foo   : FOO;                         // Input variable
+};
+
+struct PsIn {
+    float4 pos   : SV_Position;                 // Builtin FragCoord
+    float2 clip0 : SV_ClipDistance0;            // Builtin ClipDistance
+    Inner  s;
+};
+
+// CHECK: OpEntryPoint Fragment %entry "entry"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_FOO
+// CHECK-DAG: %in_var_BAR
+// CHECK-DAG: %out_var_SV_Target
+
+// CHECK: OpEntryPoint Fragment %entry_with_same_interfaces "entry_with_same_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_FOO_0
+// CHECK-DAG: %in_var_BAR_0
+// CHECK-DAG: %out_var_SV_Target_0
+
+// CHECK: OpEntryPoint Fragment %entry_with_slightly_different_interfaces "entry_with_slightly_different_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_ZOO
+// CHECK-DAG: %out_var_SV_TARGET0
+
+// CHECK: OpEntryPoint Fragment %entry_with_completely_different_interfaces "entry_with_completely_different_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %in_var_COLOR
+// CHECK-DAG: %in_var_X
+// CHECK-DAG: %in_var_Y
+// CHECK-DAG: %in_var_Z
+// CHECK-DAG: %out_var_SV_TARGET1
+
+[shader("pixel")]
+float4 entry(
+               PsIn   psIn,
+               float  clip1 : SV_ClipDistance1, // Builtin ClipDistance
+               float3 cull1 : SV_CullDistance1, // Builtin CullDistance
+            in float  bar   : BAR               // Input variable
+           ) : SV_Target {                      // Output variable
+    return psIn.pos + float4(clip1 + bar, cull1);
+}
+
+[shader("pixel")]
+float4 entry_with_same_interfaces(
+               PsIn   psIn,
+               float  clip1 : SV_ClipDistance1, // Builtin ClipDistance
+               float3 cull1 : SV_CullDistance1, // Builtin CullDistance
+            in float  bar   : BAR               // Input variable
+           ) : SV_Target {                      // Output variable
+    return psIn.pos + float4(clip1 + bar, cull1);
+}
+
+[shader("pixel")]
+float4 entry_with_slightly_different_interfaces(
+               float4 pos   : SV_Position,
+               float  clip2 : SV_ClipDistance2, // Builtin ClipDistance
+               float3 cull4 : SV_CullDistance4, // Builtin CullDistance
+            in float  zoo   : ZOO               // Input variable
+           ) : SV_TARGET0 {                     // Output variable
+    return pos + float4(clip2 + zoo, cull4);
+}
+
+[shader("pixel")]
+float4 entry_with_completely_different_interfaces(
+               float4 color : COLOR,
+               float  clip3 : SV_ClipDistance3, // Builtin ClipDistance
+            in float  x     : X,                // Input variable
+            in float  y     : Y,                // Input variable
+            in float  z     : Z                 // Input variable
+           ) : SV_TARGET1 {                     // Output variable
+    return color + float4(clip3, x, y, z);
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.simple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.simple.hlsl
@@ -1,0 +1,23 @@
+// Run: %dxc -T lib_6_6
+
+// CHECK: OpEntryPoint Fragment %x "x" %out_var_SV_TARGET
+// CHECK: OpEntryPoint Fragment %y "y" %out_var_SV_TARGET_0
+// CHECK: OpEntryPoint Fragment %z "z" %out_var_SV_TARGET1
+
+[shader("pixel")]
+float4 x(): SV_TARGET
+{
+    return float4(1.0, 0.0, 0.0, 0.0);
+}
+
+[shader("pixel")]
+float4 y(): SV_TARGET
+{
+    return float4(0.0, 1.0, 0.0, 0.0);
+}
+
+[shader("pixel")]
+float4 z(): SV_TARGET1
+{
+    return float4(0.0, 0.0, 1.0, 0.0);
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.vk.1p2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.vk.1p2.hlsl
@@ -28,6 +28,11 @@ struct PsIn {
 // CHECK-DAG: %in_var_FOO
 // CHECK-DAG: %in_var_BAR
 // CHECK-DAG: %out_var_SV_Target
+// CHECK-DAG: %bab
+// CHECK-DAG: %rwbab
+// CHECK-DAG: %tb
+// CHECK-DAG: %sb
+// CHECK-DAG: %rwsb
 
 // CHECK: OpEntryPoint Fragment %entry_with_same_interfaces "entry_with_same_interfaces"
 // CHECK-DAG: %gl_ClipDistance
@@ -36,6 +41,11 @@ struct PsIn {
 // CHECK-DAG: %in_var_FOO_0
 // CHECK-DAG: %in_var_BAR_0
 // CHECK-DAG: %out_var_SV_Target_0
+// CHECK-DAG: %bab
+// CHECK-DAG: %rwbab
+// CHECK-DAG: %tb
+// CHECK-DAG: %sb
+// CHECK-DAG: %rwsb
 
 // CHECK: OpEntryPoint Fragment %entry_with_slightly_different_interfaces "entry_with_slightly_different_interfaces"
 // CHECK-DAG: %gl_ClipDistance
@@ -43,6 +53,11 @@ struct PsIn {
 // CHECK-DAG: %gl_FragCoord
 // CHECK-DAG: %in_var_ZOO
 // CHECK-DAG: %out_var_SV_TARGET0
+// CHECK-DAG: %bab
+// CHECK-DAG: %rwbab
+// CHECK-DAG: %tb
+// CHECK-DAG: %sb
+// CHECK-DAG: %rwsb
 
 // CHECK: OpEntryPoint Fragment %entry_with_completely_different_interfaces "entry_with_completely_different_interfaces"
 // CHECK-DAG: %gl_ClipDistance
@@ -52,6 +67,11 @@ struct PsIn {
 // CHECK-DAG: %in_var_Y
 // CHECK-DAG: %in_var_Z
 // CHECK-DAG: %out_var_SV_TARGET1
+// CHECK-DAG: %bab
+// CHECK-DAG: %rwbab
+// CHECK-DAG: %tb
+// CHECK-DAG: %sb
+// CHECK-DAG: %rwsb
 
 [shader("pixel")]
 float4 entry(

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.vk.1p2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.multiple.entries.vk.1p2.hlsl
@@ -1,0 +1,96 @@
+// Run: %dxc -T lib_6_6 -fspv-target-env=vulkan1.2
+
+struct S {
+  float f;
+};
+
+ByteAddressBuffer bab;
+RWByteAddressBuffer rwbab;
+TextureBuffer<S> tb;
+StructuredBuffer<uint3> sb;
+RWStructuredBuffer<S> rwsb;
+
+struct Inner {
+    float2 cull2 : SV_CullDistance2;            // Builtin CullDistance
+    float3 foo   : FOO;                         // Input variable
+};
+
+struct PsIn {
+    float4 pos   : SV_Position;                 // Builtin FragCoord
+    float2 clip0 : SV_ClipDistance0;            // Builtin ClipDistance
+    Inner  s;
+};
+
+// CHECK: OpEntryPoint Fragment %entry "entry"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_FOO
+// CHECK-DAG: %in_var_BAR
+// CHECK-DAG: %out_var_SV_Target
+
+// CHECK: OpEntryPoint Fragment %entry_with_same_interfaces "entry_with_same_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_FOO_0
+// CHECK-DAG: %in_var_BAR_0
+// CHECK-DAG: %out_var_SV_Target_0
+
+// CHECK: OpEntryPoint Fragment %entry_with_slightly_different_interfaces "entry_with_slightly_different_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %gl_FragCoord
+// CHECK-DAG: %in_var_ZOO
+// CHECK-DAG: %out_var_SV_TARGET0
+
+// CHECK: OpEntryPoint Fragment %entry_with_completely_different_interfaces "entry_with_completely_different_interfaces"
+// CHECK-DAG: %gl_ClipDistance
+// CHECK-DAG: %gl_CullDistance
+// CHECK-DAG: %in_var_COLOR
+// CHECK-DAG: %in_var_X
+// CHECK-DAG: %in_var_Y
+// CHECK-DAG: %in_var_Z
+// CHECK-DAG: %out_var_SV_TARGET1
+
+[shader("pixel")]
+float4 entry(
+               PsIn   psIn,
+               float  clip1 : SV_ClipDistance1, // Builtin ClipDistance
+               float3 cull1 : SV_CullDistance1, // Builtin CullDistance
+            in float  bar   : BAR               // Input variable
+           ) : SV_Target {                      // Output variable
+    return psIn.pos + float4(clip1 + bar, cull1);
+}
+
+[shader("pixel")]
+float4 entry_with_same_interfaces(
+               PsIn   psIn,
+               float  clip1 : SV_ClipDistance1, // Builtin ClipDistance
+               float3 cull1 : SV_CullDistance1, // Builtin CullDistance
+            in float  bar   : BAR               // Input variable
+           ) : SV_Target {                      // Output variable
+    return psIn.pos + float4(clip1 + bar, cull1);
+}
+
+[shader("pixel")]
+float4 entry_with_slightly_different_interfaces(
+               float4 pos   : SV_Position,
+               float  clip2 : SV_ClipDistance2, // Builtin ClipDistance
+               float3 cull4 : SV_CullDistance4, // Builtin CullDistance
+            in float  zoo   : ZOO               // Input variable
+           ) : SV_TARGET0 {                     // Output variable
+    return pos + float4(clip2 + zoo, cull4) + bab.Load4(zoo);
+}
+
+[shader("pixel")]
+float4 entry_with_completely_different_interfaces(
+               float4 color : COLOR,
+               float  clip3 : SV_ClipDistance3, // Builtin ClipDistance
+            in float  x     : X,                // Input variable
+            in float  y     : Y,                // Input variable
+            in float  z     : Z                 // Input variable
+           ) : SV_TARGET1 {                     // Output variable
+    rwsb.IncrementCounter();
+    return color + float4(clip3, x, y, z);
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.1p2.entry-point.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.1p2.entry-point.hlsl
@@ -1,7 +1,14 @@
 // Run: %dxc -T ps_6_0 -E main -fspv-target-env=vulkan1.2
 
 // CHECK: OpEntryPoint Fragment %main "main"
-// CHECK-SAME: %_Globals %gSampler %gTex %MyCBuffer %gCBuffer %gSPInput %gRWBuffer %out_var_SV_Target
+// CHECK-DAG: %_Globals
+// CHECK-DAG: %gSampler
+// CHECK-DAG: %gTex
+// CHECK-DAG: %MyCBuffer
+// CHECK-DAG: %gCBuffer
+// CHECK-DAG: %gSPInput
+// CHECK-DAG: %gRWBuffer
+// CHECK-DAG: %out_var_SV_Target
 
 int gScalar;
 SamplerState gSampler;

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1570,6 +1570,22 @@ TEST_F(FileTest, SpirvStageIOAliasBuiltIn) {
   runFileTest("spirv.interface.alias-builtin.hlsl");
 }
 
+TEST_F(FileTest, SpirvInterfacesForMultipleEntryPointsSimple) {
+  runFileTest("spirv.interface.multiple.entries.simple.hlsl");
+}
+TEST_F(FileTest, SpirvInterfacesForMultipleEntryPointsBuiltIn) {
+  runFileTest("spirv.interface.multiple.entries.built-in.hlsl");
+}
+TEST_F(FileTest, SpirvInterfacesForMultipleEntryPointsBuiltInVulkan1p2) {
+  runFileTest("spirv.interface.multiple.entries.built-in.vk.1p2.hlsl");
+}
+TEST_F(FileTest, SpirvInterfacesForMultipleEntryPoints) {
+  runFileTest("spirv.interface.multiple.entries.hlsl");
+}
+TEST_F(FileTest, SpirvInterfacesForMultipleEntryPointsVulkan1p2) {
+  runFileTest("spirv.interface.multiple.entries.vk.1p2.hlsl");
+}
+
 // For testing UserSemantic decoration
 TEST_F(FileTest, SpirvUserSemanticVS) {
   runFileTest("spirv.user-semantic.vs.hlsl");


### PR DESCRIPTION
As mentioned in #3759 and https://github.com/KhronosGroup/SPIRV-Tools/pull/4275,
DXC does not generate correct operands of `OpEntryPoint` when the shader has
multiple entry functions. The main reason is that the existing SPIR-V backend does
not separate interfaces between entry functions. This commit lets `DeclResultIdMapper`
keep the information of the entry point of each stage variable in `StageVar` and
lets `SpirvEmitter` correctly emit interfaces for each `OpEntryPoint`.