### PR TITLE
Support replace for BAB.Load<>() in LowerMemcpy

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/ByteAddressBuffer/bab-array-alias.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/ByteAddressBuffer/bab-array-alias.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -E main -T ps_6_3  %s  | FileCheck %s
+
+// Make sure there's only one rawBufferLoad, meaning local copy aliased
+// through memcpy to buffer load, rather than loading to local array
+// and indexing that.
+
+// CHECK: @dx.op.rawBufferLoad.f32(i32 139,
+// CHECK-NOT: @dx.op.rawBufferLoad.f32(i32 139,
+// CHECK: ret void
+
+struct Foo {
+  float4 farr[16];
+};
+
+ByteAddressBuffer BAB;
+
+uint offset;
+
+Foo babload(uint o) {
+  return BAB.Load<Foo>(o);
+}
+
+float4 main(uint i : IN) : SV_Target {
+  Foo foo = babload(offset);
+  return foo.farr[i];
+}


### PR DESCRIPTION
LowerMemcpy has existing support for subscript op to replace use of
alloca with original pointer from subscript op, eliminating copy and
making sure loads from the local copy load directly from the buffer
instead (such as for dynamic indexing a local array loaded from a buffer).
New templated ByteAddressBuffer::Load<UDT>() method wasn't handled, so
this change adds this support.
Still, only SRV is supported, since additional analysis would be required
to prove replacement is safe for UAV.