### PR TITLE
Fix bugs with ConstantBuffer resource object usage

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -46,6 +46,7 @@ namespace llvm {
 /// Note that this pass is designed for use with the legacy pass manager.
 ModulePass *createDxilLowerCreateHandleForLibPass();
 ModulePass *createDxilAllocateResourcesForLibPass();
+ModulePass *createDxilCleanupAnnotateHandlePass();
 ModulePass *createDxilEliminateOutputDynamicIndexingPass();
 ModulePass *createDxilGenerationPass(bool NotOptimized, hlsl::HLSLExtensionsCodegenHelper *extensionsHelper);
 ModulePass *createHLEmitMetadataPass();
@@ -78,6 +79,7 @@ ModulePass *createDxilRenameResourcesPass();
 
 void initializeDxilLowerCreateHandleForLibPass(llvm::PassRegistry&);
 void initializeDxilAllocateResourcesForLibPass(llvm::PassRegistry&);
+void initializeDxilCleanupAnnotateHandlePass(llvm::PassRegistry&);
 void initializeDxilEliminateOutputDynamicIndexingPass(llvm::PassRegistry&);
 void initializeDxilGenerationPassPass(llvm::PassRegistry&);
 void initializeHLEnsureMetadataPass(llvm::PassRegistry&);

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -108,6 +108,7 @@ HRESULT SetupRegistryPassForHLSL() {
     initializeDxilLoopDeletionPass(Registry);
     initializeDxilLoopUnrollPass(Registry);
     initializeDxilLowerCreateHandleForLibPass(Registry);
+    initializeDxilCleanupAnnotateHandlePass(Registry);
     initializeDxilMutateResourceToHandlePass(Registry);
     initializeDxilNoOptLegalizePass(Registry);
     initializeDxilNoOptSimplifyInstructionsPass(Registry);

--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -2163,9 +2163,13 @@ void PatchTBufferLoad(CallInst *handle, DxilModule &DM,
 
   // Replace corresponding cbuffer loads with typed buffer loads
   for (auto U = handle->user_begin(); U != handle->user_end();) {
-    CallInst *I = cast<CallInst>(*(U++));
-    DXASSERT(I && OP::IsDxilOpFuncCallInst(I),
+    User *user = *(U++);
+    CallInst *I = dyn_cast<CallInst>(user);
+    // Could also be store for out arg in lib.
+    DXASSERT(isa<StoreInst>(user) || (I && OP::IsDxilOpFuncCallInst(I)),
              "otherwise unexpected user of CreateHandle value");
+    if (!I)
+      continue;
     DXIL::OpCode opcode = OP::GetDxilOpFuncCallInst(I);
     if (opcode == DXIL::OpCode::CBufferLoadLegacy) {
       DxilInst_CBufferLoadLegacy cbLoad(I);
@@ -2255,6 +2259,9 @@ void PatchTBufferLoad(CallInst *handle, DxilModule &DM,
       PatchTBufferLoad(cast<CallInst>(I), DM,
                        patchedSet);
       continue;
+    } else if (opcode == DXIL::OpCode::BufferLoad) {
+      // Already translated, skip.
+      continue;
     } else {
       DXASSERT(false, "otherwise unexpected user of CreateHandle value");
     }
@@ -2312,8 +2319,31 @@ bool DxilLowerCreateHandleForLib::PatchDynamicTBuffers(DxilModule &DM) {
 bool DxilLowerCreateHandleForLib::PatchTBuffers(DxilModule &DM) {
   bool bChanged = false;
   // move tbuffer resources to SRVs
-  unsigned offset = DM.GetSRVs().size();
   Module &M = *DM.GetModule();
+  const ShaderModel &SM = *DM.GetShaderModel();
+  DenseSet<Value*> patchedSet;
+
+  // First, patch users of AnnotateHandle calls if we have them.
+  // This will pick up uses in lib_6_x functions that otherwise
+  // would be missed.
+  if (SM.IsSM66Plus()) {
+    for (auto it : DM.GetOP()->GetOpFuncList(DXIL::OpCode::AnnotateHandle)) {
+      Function *F = it.second;
+      for (auto U = F->user_begin(); U != F->user_end(); ) {
+        User *user = *(U++);
+        if (CallInst *CI = dyn_cast<CallInst>(user)) {
+          DxilInst_AnnotateHandle AH(CI);
+          if (AH) {
+            DxilResourceProperties RP = resource_helper::loadPropsFromAnnotateHandle(AH, SM);
+            if (RP.getResourceKind() == DXIL::ResourceKind::TBuffer)
+              PatchTBufferLoad(CI, DM, patchedSet);
+          }
+        }
+      }
+    }
+  }
+
+  unsigned offset = DM.GetSRVs().size();
   for (auto it = DM.GetCBuffers().begin(); it != DM.GetCBuffers().end(); it++) {
     DxilCBuffer *CB = it->get();
     if (CB->GetKind() == DXIL::ResourceKind::TBuffer) {
@@ -2324,7 +2354,6 @@ bool DxilLowerCreateHandleForLib::PatchTBuffers(DxilModule &DM) {
       GlobalVariable *GV = dyn_cast<GlobalVariable>(CB->GetGlobalSymbol());
       if (GV == nullptr)
         continue;
-      DenseSet<Value*> patchedSet;
       PatchTBufferUse(GV, DM, patchedSet);
       // Set global symbol for cbuffer to an unused value so it can be removed
       // in RemoveUnusedResourceSymbols.
@@ -2595,9 +2624,6 @@ INITIALIZE_PASS_END(DxilLowerCreateHandleForLib, "hlsl-dxil-lower-handle-for-lib
 
 
 class DxilAllocateResourcesForLib : public ModulePass {
-private:
-  RemapEntryCollection m_rewrites;
-
 public:
   static char ID; // Pass identification, replacement for typeid
   explicit DxilAllocateResourcesForLib() : ModulePass(ID), m_AutoBindingSpace(UINT_MAX) {}
@@ -2605,7 +2631,7 @@ public:
   void applyOptions(PassOptions O) override {
     GetPassOptionUInt32(O, "auto-binding-space", &m_AutoBindingSpace, UINT_MAX);
   }
-  const char *getPassName() const override { return "DXIL Condense Resources"; }
+  const char *getPassName() const override { return "DXIL Allocate Resources For Library"; }
 
   bool runOnModule(Module &M) override {
     DxilModule &DM = M.GetOrCreateDxilModule();
@@ -2637,3 +2663,58 @@ ModulePass *llvm::createDxilAllocateResourcesForLibPass() {
 }
 
 INITIALIZE_PASS(DxilAllocateResourcesForLib, "hlsl-dxil-allocate-resources-for-lib", "DXIL Allocate Resources For Library", false, false)
+
+
+class DxilCleanupAnnotateHandle : public ModulePass {
+public:
+  static char ID; // Pass identification, replacement for typeid
+  explicit DxilCleanupAnnotateHandle() : ModulePass(ID) {}
+
+  const char *getPassName() const override { return "DXIL Cleanup extra annotate handle calls"; }
+
+  bool runOnModule(Module &M) override {
+    DxilModule &DM = M.GetOrCreateDxilModule();
+
+    // Nothing to do if Dxil ver < 1.6
+    unsigned dxilMajor, dxilMinor;
+    DM.GetShaderModel()->GetDxilVersion(dxilMajor, dxilMinor);
+    if (DXIL::CompareVersions(dxilMajor, dxilMinor, 1, 6) < 0)
+      return false;
+
+    bool bChanged = false;
+
+    // Iterate AnnotateHandle calls and eliminate redundant annotate handle call chains.
+    hlsl::OP *op = DM.GetOP();
+    for (auto it : op->GetOpFuncList(OP::OpCode::AnnotateHandle)) {
+      Function *F = it.second;
+      for (auto U = F->user_begin(); U != F->user_end(); ) {
+        CallInst *CI = dyn_cast<CallInst>(*(U++));
+        if (CI) {
+          DxilInst_AnnotateHandle AH(CI);
+          if (AH) {
+            CallInst *Res = dyn_cast<CallInst>(AH.get_res());
+            DxilInst_AnnotateHandle PrevAH(Res);
+            if (PrevAH) {
+              DXASSERT(AH.get_props() == PrevAH.get_props(), "otherwise, AnnotateHandle chain with inconsistent props");
+              CI->replaceAllUsesWith(Res);
+              CI->eraseFromParent();
+              bChanged = true;
+            }
+          }
+        }
+      }
+    }
+
+    return bChanged;
+  }
+
+private:
+};
+
+char DxilCleanupAnnotateHandle::ID = 0;
+
+ModulePass *llvm::createDxilCleanupAnnotateHandlePass() {
+  return new DxilCleanupAnnotateHandle();
+}
+
+INITIALIZE_PASS(DxilCleanupAnnotateHandle, "hlsl-dxil-cleanup-annotate-handle", "DXIL Cleanup extra annotate handle calls", false, false)

--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -282,7 +282,7 @@ public:
   }
 
 private:
-  Type *mutateToHandleTy(Type *Ty);
+  Type *mutateToHandleTy(Type *Ty, bool bResType = false);
   bool mutateTypesToHandleTy(SmallVector<Type *, 4> &Tys);
 
   void collectGlobalResource(DxilResourceBase *Res,
@@ -302,7 +302,7 @@ private:
 
 char DxilMutateResourceToHandle::ID = 0;
 
-Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty) {
+Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty, bool bResType) {
   auto it = MutateTypeMap.find(Ty);
   if (it != MutateTypeMap.end())
     return it->second;
@@ -315,7 +315,7 @@ Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty) {
       nestedSize.emplace_back(NestAT->getNumElements());
       EltTy = NestAT->getElementType();
     }
-    Type *mutatedTy = mutateToHandleTy(EltTy);
+    Type *mutatedTy = mutateToHandleTy(EltTy, bResType);
     if (mutatedTy == EltTy) {
       ResultTy = Ty;
     } else {
@@ -326,7 +326,7 @@ Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty) {
     }
   } else if (PointerType *PT = dyn_cast<PointerType>(Ty)) {
     Type *EltTy = PT->getElementType();
-    Type *mutatedTy = mutateToHandleTy(EltTy);
+    Type *mutatedTy = mutateToHandleTy(EltTy, bResType);
     if (mutatedTy == EltTy)
       ResultTy = Ty;
     else
@@ -334,7 +334,11 @@ Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty) {
   } else if (dxilutil::IsHLSLResourceType(Ty)) {
     ResultTy = hdlTy;
   } else if (StructType *ST = dyn_cast<StructType>(Ty)) {
-    if (!ST->isOpaque()) {
+    if (bResType) {
+      // For top-level resource GV type, the first struct type is the resource
+      // type to be changed into handle.
+      ResultTy = hdlTy;
+    } else if (!ST->isOpaque()) {
       SmallVector<Type *, 4> Elts(ST->element_begin(), ST->element_end());
       if (!mutateTypesToHandleTy(Elts)) {
         ResultTy = Ty;
@@ -342,6 +346,13 @@ Type *DxilMutateResourceToHandle::mutateToHandleTy(Type *Ty) {
         ResultTy = StructType::create(Elts, ST->getName().str() + ".hdl");
       }
     } else {
+
+      // FIXME: Opaque type "ConstantBuffer" is only used for an empty cbuffer.
+      // We should never use an empty cbuffer, and we should try to get rid of
+      // the need for this type in the first place, like using nullptr for the
+      // DxilResourceBase::m_pSymbol, since this resource should get deleted
+      // before final dxil in all cases.
+
       if (ST->getName() == "ConstantBuffer")
         ResultTy = hdlTy;
       else
@@ -382,7 +393,7 @@ void DxilMutateResourceToHandle::collectGlobalResource(
   Value *GV = Res->GetGlobalSymbol();
   // Save hlsl type before mutate to handle.
   Res->SetHLSLType(GV->getType());
-  mutateToHandleTy(GV->getType());
+  mutateToHandleTy(GV->getType(), /*bResType*/true);
   WorkList.emplace_back(GV);
 }
 void DxilMutateResourceToHandle::collectAlloca(
@@ -407,36 +418,6 @@ SmallVector<Value *, 8>
 DxilMutateResourceToHandle::collectHlslObjects(Module &M) {
   // Add all global/function/argument/alloca has resource type.
   SmallVector<Value *, 8> WorkList;
-
-  // Assume this is after SROA so no struct for global/alloca.
-
-  // Functions.
-  for (Function &F : M) {
-    collectAlloca(F, WorkList);
-    FunctionType *FT = F.getFunctionType();
-    FunctionType *MFT = cast<FunctionType>(mutateToHandleTy(FT));
-    if (FT == MFT)
-      continue;
-    WorkList.emplace_back(&F);
-    // Check args.
-    for (Argument &Arg : F.args()) {
-      Type *Ty = Arg.getType();
-      Type *MTy = mutateToHandleTy(Ty);
-      if (Ty == MTy)
-        continue;
-      WorkList.emplace_back(&Arg);
-    }
-  }
-
-  // Static globals.
-  for (GlobalVariable &GV : M.globals()) {
-    if (!dxilutil::IsStaticGlobal(&GV))
-      continue;
-    Type *Ty = dxilutil::GetArrayEltTy(GV.getValueType());
-    if (!dxilutil::IsHLSLObjectType(Ty))
-      continue;
-    WorkList.emplace_back(&GV);
-  }
 
   // Global resources.
   if (M.HasHLModule()) {
@@ -468,6 +449,37 @@ DxilMutateResourceToHandle::collectHlslObjects(Module &M) {
       collectGlobalResource(Res.get(), WorkList);
     }
   }
+
+  // Assume this is after SROA so no struct for global/alloca.
+
+  // Functions.
+  for (Function &F : M) {
+    collectAlloca(F, WorkList);
+    FunctionType *FT = F.getFunctionType();
+    FunctionType *MFT = cast<FunctionType>(mutateToHandleTy(FT));
+    if (FT == MFT)
+      continue;
+    WorkList.emplace_back(&F);
+    // Check args.
+    for (Argument &Arg : F.args()) {
+      Type *Ty = Arg.getType();
+      Type *MTy = mutateToHandleTy(Ty);
+      if (Ty == MTy)
+        continue;
+      WorkList.emplace_back(&Arg);
+    }
+  }
+
+  // Static globals.
+  for (GlobalVariable &GV : M.globals()) {
+    if (!dxilutil::IsStaticGlobal(&GV))
+      continue;
+    Type *Ty = dxilutil::GetArrayEltTy(GV.getValueType());
+    if (!dxilutil::IsHLSLObjectType(Ty))
+      continue;
+    WorkList.emplace_back(&GV);
+  }
+
   return WorkList;
 }
 
@@ -642,6 +654,16 @@ void DxilMutateResourceToHandle::mutateCandidates(Module &M) {
           }
         }
       }
+    }
+
+    if (hlsl::GetHLOpcodeGroup(F) == HLOpcodeGroup::HLCast) {
+      // Eliminate pass-through cast
+      for (auto it = F->user_begin(); it != F->user_end();) {
+        CallInst *CI = cast<CallInst>(*(it++));
+        CI->replaceAllUsesWith(CI->getArgOperand(1));
+        CI->eraseFromParent();
+      }
+      continue;
     }
 
     if (!MF) {

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -377,6 +377,7 @@ void PassManagerBuilder::populateModulePassManager(
       MPM.add(createGlobalDCEPass());
       MPM.add(createDxilMutateResourceToHandlePass());
       MPM.add(createDxilLowerCreateHandleForLibPass());
+      MPM.add(createDxilCleanupAnnotateHandlePass());
       MPM.add(createDxilTranslateRawBuffer());
       MPM.add(createDxilLegalizeSampleOffsetPass());
       MPM.add(createDxilNoOptLegalizePass());
@@ -679,6 +680,7 @@ void PassManagerBuilder::populateModulePassManager(
     MPM.add(createGlobalDCEPass());
     MPM.add(createDxilMutateResourceToHandlePass());
     MPM.add(createDxilLowerCreateHandleForLibPass());
+    MPM.add(createDxilCleanupAnnotateHandlePass());
     MPM.add(createDxilTranslateRawBuffer());
     // Always try to legalize sample offsets as loop unrolling
     // is not guaranteed for higher opt levels.

--- a/tools/clang/lib/CodeGen/CGCall.cpp
+++ b/tools/clang/lib/CodeGen/CGCall.cpp
@@ -2898,8 +2898,8 @@ void CodeGenFunction::EmitCallArgs(CallArgList &Args,
       // HLSL Change begin.
       RValue CallArg = Args.back().RV;
       if (CallArg.isAggregate())
-        CGM.getHLSLRuntime().MarkCallArgumentTemp(*this, CallArg.getAggregateAddr(),
-                                                  ArgTypes[I]);
+        CGM.getHLSLRuntime().MarkPotentialResourceTemp(
+            *this, CallArg.getAggregateAddr(), ArgTypes[I]);
       // HLSL Change end.
       EmitNonNullArgCheck(Args.back().RV, ArgTypes[I], Arg->getExprLoc(),
                           CalleeDecl, ParamsToSkip + I);
@@ -3283,7 +3283,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       }
     }
     // HLSL Change begin.
-    CGM.getHLSLRuntime().MarkRetTemp(*this, SRetPtr, RetTy);
+    CGM.getHLSLRuntime().MarkPotentialResourceTemp(*this, SRetPtr, RetTy);
     // HLSL Change end.
     if (IRFunctionArgs.hasSRetArg()) {
       IRCallArgs[IRFunctionArgs.getSRetArgNo()] = SRetPtr;

--- a/tools/clang/lib/CodeGen/CGExprAgg.cpp
+++ b/tools/clang/lib/CodeGen/CGExprAgg.cpp
@@ -743,6 +743,8 @@ void AggExprEmitter::VisitCastExpr(CastExpr *E) {
           LV = CGF.EmitLValue(SrcDecl);
         else if (ArraySubscriptExpr *ArraySubExpr = dyn_cast<ArraySubscriptExpr>(Src))
           LV = CGF.EmitLValue(ArraySubExpr);
+        else if (ParenExpr *parenExpr = dyn_cast<ParenExpr>(Src))
+          LV = CGF.EmitLValue(parenExpr->getSubExpr());
         else
           LV = CGF.EmitAggExprToLValue(Src);
 
@@ -1505,6 +1507,7 @@ LValue CodeGenFunction::EmitAggExprToLValue(const Expr *E) {
   assert(hasAggregateEvaluationKind(E->getType()) && "Invalid argument!");
   llvm::Value *Temp = CreateMemTemp(E->getType());
   LValue LV = MakeAddrLValue(Temp, E->getType());
+  CGM.getHLSLRuntime().MarkPotentialResourceTemp(*this, Temp, E->getType());
   EmitAggExpr(E, AggValueSlot::forLValue(LV, AggValueSlot::IsNotDestructed,
                                          AggValueSlot::DoesNotNeedGCBarriers,
                                          AggValueSlot::IsNotAliased));

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2086,7 +2086,7 @@ struct CleanupIfUnused {
       I = cast<_InstructionT>(V);
   }
   ~CleanupIfUnused() {
-    if (I->user_empty())
+    if (I && I->user_empty())
       I->eraseFromParent();
     I = nullptr;
   }

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2077,8 +2077,67 @@ void AllocateDxilConstantBuffers(
 
 namespace {
 
+// Instruction pointer wrapper that cleans up the instruction if unused
+template<typename _InstructionT>
+struct CleanupIfUnused {
+  _InstructionT *I = nullptr;
+  CleanupIfUnused(Value *V) {
+    if (V)
+      I = cast<_InstructionT>(V);
+  }
+  ~CleanupIfUnused() {
+    if (I->user_empty())
+      I->eraseFromParent();
+    I = nullptr;
+  }
+  operator _InstructionT*() { return I; }
+  _InstructionT *operator->() { return I; }
+  operator bool() { return I != nullptr; }
+};
+
+// When replacing CBV use, it's possible for the resource itself to be used,
+// in which case we need to either use a cast from handle back to the resource
+// type, or if it's a pointer, use an alloca where that casted resource is
+// stored.
+// Later we will mutate the original resource type to a handle type,
+// and eliminate this cast.
+// This helper produces the cast and a store to new alloca in case either a
+// value or a pointer to the original resource type is needed, and cleans up any
+// unused instructions afterward.
+// Instructions are only produced if hlResTy is non-null, indicating
+// ConstantBuffer<> object type rather than legacy cbuffer type that has no
+// resource object.
+struct HandleToResHelper {
+  HandleToResHelper(IRBuilder<> &Builder, Type *hlResTy, Value* Handle, Function &F, HLModule &HLM) {
+    if (hlResTy) {
+      Cast = cast<CallInst>(HLM.EmitHLOperationCall(
+          Builder, HLOpcodeGroup::HLCast, (unsigned)HLCastOpcode::HandleToResCast,
+          hlResTy, {Handle}, *HLM.GetModule()));
+      IRBuilder<>  AllocaBuilder(F.getEntryBlock().getFirstInsertionPt());
+      Alloca = AllocaBuilder.CreateAlloca(hlResTy);
+      Store = Builder.CreateStore(Cast, Alloca);
+    }
+  }
+  ~HandleToResHelper() {
+    if (Alloca && Alloca->hasOneUse()) {
+      Store->eraseFromParent();
+      Alloca->eraseFromParent();
+      if (Cast->user_empty())
+        Cast->eraseFromParent();
+    }
+  }
+  operator bool() { return Store != nullptr; }
+
+  StoreInst *Store = nullptr;
+  AllocaInst *Alloca = nullptr;
+  CallInst *Cast = nullptr;
+};
+
 void ReplaceUseInFunction(Value *V, Value *NewV, Function *F,
-                          IRBuilder<> &Builder) {
+                          IRBuilder<> &Builder, HandleToResHelper *pH2ResHelper = nullptr) {
+  Type *VTy = V->getType()->getPointerElementType();
+  bool bIsResourceTy =
+      dxilutil::IsHLSLResourceType(VTy);
   for (auto U = V->user_begin(); U != V->user_end();) {
     User *user = *(U++);
     if (Instruction *I = dyn_cast<Instruction>(user)) {
@@ -2091,7 +2150,27 @@ void ReplaceUseInFunction(Value *V, Value *NewV, Function *F,
             continue;
           }
         }
-        I->replaceUsesOfWith(V, NewV);
+        // Only replace when type matches.
+        if (V->getType() == NewV->getType()) {
+          I->replaceUsesOfWith(V, NewV);
+          continue;
+        }
+        if (pH2ResHelper && *pH2ResHelper && bIsResourceTy) {
+          // This means CBV case, so use casted value or pointer instead.
+          if (LoadInst *LI = dyn_cast<LoadInst>(I)) {
+            Instruction *OrigPtrInst = dyn_cast<Instruction>(LI->getPointerOperand());
+            LI->replaceAllUsesWith(pH2ResHelper->Cast);
+            LI->eraseFromParent();
+            // Clean up original pointer instruction (GEP) if unused.
+            if (OrigPtrInst && OrigPtrInst->user_empty())
+              OrigPtrInst->eraseFromParent();
+            continue;
+          } else {
+            I->replaceUsesOfWith(V, pH2ResHelper->Alloca);
+            continue;
+          }
+        }
+        DXASSERT(false, "otherwise, attempting CB user replacement with mismatching type");
       }
     } else {
       // For constant operator, create local clone which use GEP.
@@ -2102,6 +2181,11 @@ void ReplaceUseInFunction(Value *V, Value *NewV, Function *F,
         ReplaceUseInFunction(GEPOp, NewGEP, F, Builder);
       } else if (GlobalVariable *GV = dyn_cast<GlobalVariable>(user)) {
         // Change the init val into NewV with Store.
+
+        // FIXME: This store needs to be placed in a new init function for
+        // this GV, rather than being placed in whichever function we happen
+        // to be iterating at this point.  Otherwise it may not actually be
+        // initialized when used from another function.
         GV->setInitializer(nullptr);
         Builder.CreateStore(NewV, GV);
       } else {
@@ -2238,6 +2322,14 @@ bool CreateCBufferVariable(HLCBuffer &CB, HLModule &HLM, llvm::Type *HandleTy) {
     MarkUsedFunctionForConst(GV, constUsedFuncList[C->GetID()]);
   }
 
+  // If ConstantBuffer<> style CBV, get resource type used for translating
+  // handles back to resource objects.
+  Type *hlResTy = nullptr;
+  if (CB.IsView()) {
+    hlResTy = CB.GetConstants().front()->GetHLSLType()->getPointerElementType();
+    hlResTy = dxilutil::StripArrayTypes(hlResTy);
+  }
+
   for (Function &F : M.functions()) {
     if (F.isDeclaration())
       continue;
@@ -2249,15 +2341,14 @@ bool CreateCBufferVariable(HLCBuffer &CB, HLModule &HLM, llvm::Type *HandleTy) {
 
     // create HL subscript to make all the use of cbuffer start from it.
     HandleArgs[HLOperandIndex::kCreateHandleResourceOpIdx - 1] = cbGV;
-    CallInst *Handle = HLM.EmitHLOperationCall(
+    CleanupIfUnused<CallInst> OrigHandle = HLM.EmitHLOperationCall(
         Builder, HLOpcodeGroup::HLCreateHandle, 0, HandleTy, HandleArgs, M);
-    CallInst *OrigHandle = Handle;
     DxilResourceProperties RP = resource_helper::loadPropsFromResourceBase(&CB);
-    Handle = CreateAnnotateHandle(HLM, Handle, RP, cbGV->getType()->getElementType(), Builder);
+    CleanupIfUnused<CallInst> Handle = CreateAnnotateHandle(
+        HLM, OrigHandle, RP, cbGV->getType()->getElementType(), Builder);
 
     args[HLOperandIndex::kSubscriptObjectOpIdx] = Handle;
-    Instruction *cbSubscript =
-        cast<Instruction>(Builder.CreateCall(subscriptFunc, {args}));
+    CleanupIfUnused<Instruction> cbSubscript = Builder.CreateCall(subscriptFunc, {args});
 
     // Replace constant var with GEP pGV
     for (const std::unique_ptr<DxilResourceBase> &C : CB.GetConstants()) {
@@ -2267,14 +2358,14 @@ bool CreateCBufferVariable(HLCBuffer &CB, HLModule &HLM, llvm::Type *HandleTy) {
 
       Value *idx = indexArray[C->GetID()];
       if (!isCBArray) {
-        Instruction *GEP = cast<Instruction>(
-            Builder.CreateInBoundsGEP(cbSubscript, {zero, idx}));
+        CleanupIfUnused<Instruction> GEP =
+            Builder.CreateInBoundsGEP(cbSubscript, {zero, idx});
         // TODO: make sure the debug info is synced to GEP.
         // GEP->setDebugLoc(GV);
-        ReplaceUseInFunction(GV, GEP, &F, Builder);
-        // Delete if no use in F.
-        if (GEP->user_empty())
-          GEP->eraseFromParent();
+
+        HandleToResHelper H2ResHelper(Builder, hlResTy, Handle, F, HLM);
+        ReplaceUseInFunction(GV, GEP, &F, Builder, &H2ResHelper);
+
       } else {
         for (auto U = GV->user_begin(); U != GV->user_end();) {
           User *user = *(U++);
@@ -2318,34 +2409,28 @@ bool CreateCBufferVariable(HLCBuffer &CB, HLModule &HLM, llvm::Type *HandleTy) {
           }
 
           HandleArgs[HLOperandIndex::kCreateHandleIndexOpIdx - 1] = arrayIdx;
-          CallInst *Handle =
-
-              HLM.EmitHLOperationCall(*instBuilder,
-                                      HLOpcodeGroup::HLCreateHandle, 0,
-                                      HandleTy, HandleArgs, M);
+          CleanupIfUnused<CallInst> OrigHandle = HLM.EmitHLOperationCall(
+              *instBuilder, HLOpcodeGroup::HLCreateHandle, 0, HandleTy,
+              HandleArgs, M);
 
           DxilResourceProperties RP = resource_helper::loadPropsFromResourceBase(&CB);
-          Handle = CreateAnnotateHandle(HLM, Handle, RP, cbGV->getType()->getElementType(), *instBuilder);
+          CleanupIfUnused<CallInst> Handle = CreateAnnotateHandle(
+              HLM, OrigHandle, RP, cbGV->getType()->getElementType(), *instBuilder);
 
           args[HLOperandIndex::kSubscriptObjectOpIdx] = Handle;
           args[HLOperandIndex::kSubscriptIndexOpIdx] = arrayIdx;
 
-          Instruction *cbSubscript =
-              cast<Instruction>(instBuilder->CreateCall(subscriptFunc, {args}));
+          CleanupIfUnused<Instruction> cbSubscript =
+              instBuilder->CreateCall(subscriptFunc, {args});
+          CleanupIfUnused<Instruction> NewGEP =
+              instBuilder->CreateInBoundsGEP(cbSubscript, idxList);
 
-          Instruction *NewGEP = cast<Instruction>(
-              instBuilder->CreateInBoundsGEP(cbSubscript, idxList));
-
-          ReplaceUseInFunction(GEPOp, NewGEP, &F, *instBuilder);
+          HandleToResHelper H2ResHelper(*instBuilder, hlResTy, Handle, F, HLM);
+          ReplaceUseInFunction(GEPOp, NewGEP, &F, *instBuilder, &H2ResHelper);
         }
       }
     }
-    // Delete if no use in F.
-    if (cbSubscript->user_empty()) {
-      cbSubscript->eraseFromParent();
-      Handle->eraseFromParent();
-      OrigHandle->eraseFromParent();
-    } else {
+    if (!cbSubscript->user_empty()) {
       // merge GEP use for cbSubscript.
       HLModule::MergeGepUse(cbSubscript);
     }
@@ -2392,6 +2477,10 @@ void ConstructCBuffer(
   for (unsigned i = 0; i < HLM.GetCBuffers().size(); i++) {
     HLCBuffer &CB = *static_cast<HLCBuffer *>(&(HLM.GetCBuffer(i)));
     if (CB.GetConstants().size() == 0) {
+
+      // FIXME: Can we avoid creating a fake variable here, since this empty
+      // cbuffer presumably can't be used?
+
       // Create Fake variable for cbuffer which is empty.
       llvm::GlobalVariable *pGV = new llvm::GlobalVariable(
           *HLM.GetModule(), CBufferType, true,
@@ -2402,6 +2491,10 @@ void ConstructCBuffer(
       if (bCreated)
         ConstructCBufferAnnotation(CB, dxilTypeSys, AnnotationMap);
       else {
+
+        // FIXME: Can we avoid creating a fake variable here, since this empty
+        // cbuffer presumably can't be used?
+
         // Create Fake variable for cbuffer which is unused.
         llvm::GlobalVariable *pGV = new llvm::GlobalVariable(
             *HLM.GetModule(), CBufferType, true,

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -81,10 +81,8 @@ public:
   virtual void EmitHLSLOutParamConversionCopyBack(
       CodeGenFunction &CGF, llvm::SmallVector<LValue, 8> &castArgList,
       llvm::SmallVector<LValue, 8> &lifetimeCleanupList) = 0;
-  virtual void MarkRetTemp(CodeGenFunction &CGF, llvm::Value *V,
-                          clang::QualType QaulTy) = 0;
-  virtual void MarkCallArgumentTemp(CodeGenFunction &CGF, llvm::Value *V,
-                  clang::QualType QaulTy) = 0;
+  virtual void MarkPotentialResourceTemp(CodeGenFunction &CGF, llvm::Value *V,
+                                         clang::QualType QaulTy) = 0;
   virtual llvm::Value *EmitHLSLMatrixOperationCall(CodeGenFunction &CGF, const clang::Expr *E, llvm::Type *RetType,
       llvm::ArrayRef<llvm::Value*> paramList) = 0;
   virtual void EmitHLSLDiscard(CodeGenFunction &CGF) = 0;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/CBV-paren-expr.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/CBV-paren-expr.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T ps_6_0  %s  | FileCheck %s
+
+// Make sure ParenExpr compiles properly.
+// CHECK:extractvalue %dx.types.CBufRet.f32 %{{.*}}, 0
+
+struct S {
+  float a;
+  float b;
+};
+
+ConstantBuffer<S> c[2]: register(b2, space5);
+
+export ConstantBuffer<S> getCBV(uint i) {
+  return c[i];
+}
+
+float fn(S s) {
+  return s.a;
+}
+
+export float useCBV(ConstantBuffer<S> cbv) {
+  return fn(cbv);
+}
+
+float main(uint4 i : IN1, uint4 j : IN2) : SV_Target {
+  float result = 0.0;
+  result += fn(c[i.x]);
+  result += fn((c[i.y]));
+  result += fn(((getCBV(i.z))));
+  result += useCBV(c[j.x]);
+  result += useCBV((c[j.y]));
+  result += useCBV(getCBV(j.z));
+  result += useCBV((getCBV(j.w)));
+  return result;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retCBV2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retCBV2.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -E main -T ps_6_0  %s  | FileCheck %s
+// RUN: %dxc -E main -T ps_6_6  %s  | FileCheck %s
+// RUN: %dxc -E main -T lib_6_x  %s  | FileCheck %s
+
+// Make sure both a and b are used.
+// CHECK:extractvalue %dx.types.CBufRet.f32 %{{.*}}, 0
+// CHECK:extractvalue %dx.types.CBufRet.f32 %{{.*}}, 1
+struct S {
+  float a;
+  float b;
+};
+
+ConstantBuffer<S> c: register(b2, space5);;
+
+export ConstantBuffer<S> getCBV() {
+  return c;
+}
+
+export S getS(ConstantBuffer<S> cbv) {
+  return cbv;
+}
+
+float main() : SV_Target {
+  return c.a + getS(getCBV()).b;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retCBV3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retCBV3.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -E main -T ps_6_0  %s  | FileCheck %s
+// RUN: %dxc -E main -T ps_6_6  %s  | FileCheck %s
+// RUN: %dxc -E main -T lib_6_x  %s  | FileCheck %s
+
+// Make sure both a and b are used.
+// CHECK:extractvalue %dx.types.CBufRet.f32 %{{.*}}, 0
+// CHECK:extractvalue %dx.types.CBufRet.f32 %{{.*}}, 1
+struct S {
+  float a;
+  float b;
+};
+
+ConstantBuffer<S> c[2]: register(b2, space5);;
+
+export ConstantBuffer<S> getCBV(uint i) {
+  return c[i];
+}
+
+export S getS(ConstantBuffer<S> cbv) {
+  return cbv;
+}
+
+float main(uint i : IN) : SV_Target {
+  return c[i].a + getS(getCBV(i)).b;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retTBV2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retTBV2.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T ps_6_0  %s  | FileCheck %s
+// RUN: %dxc -E main -T ps_6_6  %s  | FileCheck %s
+// RUN: %dxc -E main -T lib_6_x  %s  | FileCheck %s
+
+// Make sure cbuffer use has been translated
+// CHECK-NOT: @dx.op.cbufferLoadLegacy.f32(i32 59,
+// CHECK-NOT: extractvalue %dx.types.CBufRet.f32
+
+// Make sure both a and b are used from correct buffer load
+// CHECK: @dx.op.bufferLoad.i32(i32 68,
+// CHECK:extractvalue %dx.types.ResRet.i32 %{{.*}}, 0
+// CHECK:extractvalue %dx.types.ResRet.i32 %{{.*}}, 1
+
+// Make sure cbuffer use has been translated
+// CHECK-NOT: @dx.op.cbufferLoadLegacy.f32(i32 59,
+// CHECK-NOT: extractvalue %dx.types.CBufRet.f32
+
+struct S {
+  float a;
+  float b;
+};
+
+TextureBuffer<S> c: register(t2, space5);;
+
+export TextureBuffer<S> getTBV() {
+  return c;
+}
+
+export S getS(TextureBuffer<S> tbv) {
+  return tbv;
+}
+
+float main() : SV_Target {
+  return c.a + getS(getTBV()).b;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retTBV3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/retTBV3.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T ps_6_0  %s  | FileCheck %s
+// RUN: %dxc -E main -T ps_6_6  %s  | FileCheck %s
+// RUN: %dxc -E main -T lib_6_x  %s  | FileCheck %s
+
+// Make sure cbuffer use has been translated
+// CHECK-NOT: @dx.op.cbufferLoadLegacy.f32(i32 59,
+// CHECK-NOT: extractvalue %dx.types.CBufRet.f32
+
+// Make sure both a and b are used from correct buffer load
+// CHECK: @dx.op.bufferLoad.i32(i32 68,
+// CHECK:extractvalue %dx.types.ResRet.i32 %{{.*}}, 0
+// CHECK:extractvalue %dx.types.ResRet.i32 %{{.*}}, 1
+
+// Make sure cbuffer use has been translated
+// CHECK-NOT: @dx.op.cbufferLoadLegacy.f32(i32 59,
+// CHECK-NOT: extractvalue %dx.types.CBufRet.f32
+
+struct S {
+  float a;
+  float b;
+};
+
+TextureBuffer<S> c[2]: register(t2, space5);;
+
+export TextureBuffer<S> getTBV(uint i) {
+  return c[i];
+}
+
+export S getS(TextureBuffer<S> tbv) {
+  return tbv;
+}
+
+float main(uint i : IN) : SV_Target {
+  return c[i].a + getS(getTBV(i)).b;
+}


### PR DESCRIPTION
ConstantBuffer<> and TextureBuffer<> resource objects were not being
handled when the objects themselves were used instead of just reading from
them.  Examples are passing to/from functions, but also simply an extra
layer of ParenExpr.  For simple ParenExpr case, it's easy to just drill
through, but this isn't possible for other cases.  More temps need to be
potentially marked, so MarkRetTemp/MarkCallArgumentTemp is unified into
MarkPotentialResourceTemp which is also used for temp created during
EmitAggExprToLValue.  CBuffer init code in FinishCodeGen also needed
fixing.  When replacing resource users with subscript operator, users of
the actual resource object need the original HL resource type, which is
constructed through the HL HandleToResCast and stored to an alloca for
pointer users.

Fixed MutateResourceToHandle pass for CBV/TBV, and for HandleToResCast
case.

Fixed PatchTBufferLoad issues with AnnotateHandle and library cases.

Also added a pass to cleanup doubled AnnotateHandle calls leftover after
inlining.

Along the way, noticed a global init translation bug potentially impacting
the library case, but don't yet have fix implemented, or a specific test
case hitting this.

Also noticed that there's a whole special case for empty cbuffer that gets
created, but I don't think it's actually necessary.  Other code may need
adjusting, but it should be fine to skip emiting of the special opaque-
typed global value for the empty, unused cbuffer.  Added some FIXME
comments for this, but have not tried to make this change yet.