### PR TITLE
Disable execinfo.h include for Android build in WinAdapter.h

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -32,7 +32,12 @@
 #include <typeinfo>
 #include <vector>
 #endif // __cplusplus
+
+// There is no execinfo.h on Android. However, this is only required for
+// CaptureStackBackTrace which is only used in tests.
+#ifndef __ANDROID__
 #include <execinfo.h>
+#endif
 
 //===----------------------------------------------------------------------===//
 //

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -33,12 +33,6 @@
 #include <vector>
 #endif // __cplusplus
 
-// There is no execinfo.h on Android. However, this is only required for
-// CaptureStackBackTrace which is only used in tests.
-#ifndef __ANDROID__
-#include <execinfo.h>
-#endif
-
 //===----------------------------------------------------------------------===//
 //
 //                             Begin: Macro Definitions
@@ -199,10 +193,6 @@
 
 #define OutputDebugStringA(msg) fputs(msg, stderr)
 #define OutputDebugFormatA(...) fprintf(stderr, __VA_ARGS__)
-
-#define CaptureStackBackTrace(FramesToSkip, FramesToCapture, BackTrace,        \
-                              BackTraceHash)                                   \
-  backtrace(BackTrace, FramesToCapture)
 
 // Event Tracing for Windows (ETW) provides application programmers the ability
 // to start and stop event tracing sessions, instrument an application to


### PR DESCRIPTION
This small change makes it possible to build and use DirectXShaderCompiler on Android, at least on arm64-v8a.

execinfo.h does not exist in Android toolchain. However it is only used by clang-hlsl-tests which can be disabled from the build.

I hope this could be merged, or fixed in another way, since being able to load the compiler on Android can help development quite a bit, even though for a shipped version the binary (~20 MB) would be maybe a bit too large to include in smaller apps (and glslang is not always an option as new HLSL features seem to land into DXC first). I've already used the Android build for debugging shader related issues quickly by hot-reloading shader source code changes directly on the Android device without having to restart the app and compile shaders manually on the host.