### PR TITLE
[spirv] fix build failure caused by vector ctor

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -574,7 +574,11 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
       interfaces.insert(moduleVar);
     }
   }
-  return std::vector<SpirvVariable *>(interfaces.begin(), interfaces.end());
+  std::vector<SpirvVariable *> interfacesInVector;
+  for (auto *interface : interfaces) {
+    interfacesInVector.push_back(interface);
+  }
+  return interfacesInVector;
 }
 
 void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -575,6 +575,7 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
     }
   }
   std::vector<SpirvVariable *> interfacesInVector;
+  interfacesInVector.reserve(interfaces.size());
   for (auto *interface : interfaces) {
     interfacesInVector.push_back(interface);
   }


### PR DESCRIPTION
Some versions of VisualStudio does not accept
`std::vector(llvm_denseset.begin(), llvm_denseset.end())`. This commit
simply updates the code generating `std::vector` from `llvm::DenseSet`.