### PR TITLE
Fold bitcast-to-base into GEP in MergeGepUse, plus refactor and resource fixes

### DIFF
--- a/include/dxc/DXIL/DxilTypeSystem.h
+++ b/include/dxc/DXIL/DxilTypeSystem.h
@@ -27,7 +27,6 @@ class Function;
 class MDNode;
 class Type;
 class StructType;
-class StringRef;
 }
 
 
@@ -95,7 +94,7 @@ private:
   bool m_bCBufferVarUsed; // true if this field represents a top level variable in CB structure, and it is used.
 };
 
-class DxilTemplateArgAnnotation : DxilFieldAnnotation {
+class DxilTemplateArgAnnotation {
 public:
   DxilTemplateArgAnnotation();
 
@@ -126,6 +125,10 @@ public:
   void SetCBufferSize(unsigned size);
   void MarkEmptyStruct();
   bool IsEmptyStruct();
+  // Since resources don't take real space, IsEmptyBesidesResources
+  // determines if the structure is empty or contains only resources.
+  bool IsEmptyBesidesResources();
+  bool ContainsResources() const;
 
   // For template args, GetNumTemplateArgs() will return 0 if not a template
   unsigned GetNumTemplateArgs() const;
@@ -134,10 +137,15 @@ public:
   const DxilTemplateArgAnnotation &GetTemplateArgAnnotation(unsigned argIdx) const;
 
 private:
-  const llvm::StructType *m_pStructType;
+  const llvm::StructType *m_pStructType = nullptr;
   std::vector<DxilFieldAnnotation> m_FieldAnnotations;
-  unsigned m_CBufferSize;  // The size of struct if inside constant buffer.
+  unsigned m_CBufferSize = 0;  // The size of struct if inside constant buffer.
   std::vector<DxilTemplateArgAnnotation> m_TemplateAnnotations;
+
+  // m_ResourcesContained property not stored to metadata
+  void SetContainsResources();
+  // HasResources::Only will be set on MarkEmptyStruct() when HasResources::True
+  enum class HasResources { True, False, Only } m_ResourcesContained = HasResources::False;
 };
 
 
@@ -223,10 +231,17 @@ public:
   const llvm::Function *GetFunction() const;
   DxilParameterAnnotation &GetRetTypeAnnotation();
   const DxilParameterAnnotation &GetRetTypeAnnotation() const;
+
+  bool ContainsResourceArgs() { return m_bContainsResourceArgs; }
+
 private:
   const llvm::Function *m_pFunction;
   std::vector<DxilParameterAnnotation> m_parameterAnnotations;
   DxilParameterAnnotation m_retTypeAnnotation;
+
+  // m_bContainsResourceArgs property not stored to metadata
+  void SetContainsResourceArgs() { m_bContainsResourceArgs = true; }
+  bool m_bContainsResourceArgs = false;
 };
 
 /// Use this class to represent structure type annotations in HL and DXIL.
@@ -239,9 +254,11 @@ public:
   DxilTypeSystem(llvm::Module *pModule);
 
   DxilStructAnnotation *AddStructAnnotation(const llvm::StructType *pStructType, unsigned numTemplateArgs = 0);
+  void FinishStructAnnotation(DxilStructAnnotation &SA);
   DxilStructAnnotation *GetStructAnnotation(const llvm::StructType *pStructType);
   const DxilStructAnnotation *GetStructAnnotation(const llvm::StructType *pStructType) const;
   void EraseStructAnnotation(const llvm::StructType *pStructType);
+  void EraseUnusedStructAnnotations();
 
   StructAnnotationMap &GetStructAnnotationMap();
   const StructAnnotationMap &GetStructAnnotationMap() const;
@@ -255,6 +272,7 @@ public:
   const PayloadAnnotationMap &GetPayloadAnnotationMap() const;
 
   DxilFunctionAnnotation *AddFunctionAnnotation(const llvm::Function *pFunction);
+  void FinishFunctionAnnotation(DxilFunctionAnnotation &FA);
   DxilFunctionAnnotation *GetFunctionAnnotation(const llvm::Function *pFunction);
   const DxilFunctionAnnotation *GetFunctionAnnotation(const llvm::Function *pFunction) const;
   void EraseFunctionAnnotation(const llvm::Function *pFunction);
@@ -274,6 +292,9 @@ public:
 
   bool UseMinPrecision();
   void SetMinPrecision(bool bMinPrecision);
+
+  // Determines whether type is a resource or contains a resource
+  bool IsResourceContained(llvm::Type *Ty);
 
 private:
   llvm::Module *m_pModule;

--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -155,6 +155,10 @@ namespace dxilutil {
 
   bool IsConvergentMarker(llvm::Value *V);
   llvm::Value *GetConvergentSource(llvm::Value *V);
+
+  /// If value is a bitcast to base class pattern, this will transform it into
+  /// a GEP with all zero indices and return that instruction.
+  llvm::Value *TryReplaceBaseCastWithGep(llvm::Value *V);
 }
 
 }

--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -156,8 +156,10 @@ namespace dxilutil {
   bool IsConvergentMarker(llvm::Value *V);
   llvm::Value *GetConvergentSource(llvm::Value *V);
 
-  /// If value is a bitcast to base class pattern, this will transform it into
-  /// a GEP with all zero indices and return that instruction.
+  /// If value is a bitcast to base class pattern, equivalent
+  /// to a getelementptr X, 0, 0, 0...  turn it into the appropriate gep.
+  /// This can enhance SROA and other transforms that want type-safe pointers,
+  /// and enables merging with other getelementptr's.
   llvm::Value *TryReplaceBaseCastWithGep(llvm::Value *V);
 }
 

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -842,6 +842,7 @@ void DxilMDHelper::LoadDxilTypeSystemNode(const llvm::MDTuple &MDT,
 
       DxilStructAnnotation *pSA = TypeSystem.AddStructAnnotation(pGVType);
       LoadDxilStructAnnotation(MDT.getOperand(i + 1), *pSA);
+      TypeSystem.FinishStructAnnotation(*pSA);
     }
   } else {
     IFTBOOL((MDT.getNumOperands() & 0x1) == 1, DXC_E_INCORRECT_DXIL_METADATA);
@@ -849,6 +850,7 @@ void DxilMDHelper::LoadDxilTypeSystemNode(const llvm::MDTuple &MDT,
       Function *F = dyn_cast<Function>(ValueMDToValue(MDT.getOperand(i)));
       DxilFunctionAnnotation *pFA = TypeSystem.AddFunctionAnnotation(F);
       LoadDxilFunctionAnnotation(MDT.getOperand(i + 1), *pFA);
+      TypeSystem.FinishFunctionAnnotation(*pFA);
     }
   }
 }

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1192,6 +1192,10 @@ Value *GetConvergentSource(Value *V) {
   return cast<CallInst>(V)->getOperand(0);
 }
 
+/// If value is a bitcast to base class pattern, equivalent
+/// to a getelementptr X, 0, 0, 0...  turn it into the appropriate gep.
+/// This can enhance SROA and other transforms that want type-safe pointers,
+/// and enables merging with other getelementptr's.
 Value *TryReplaceBaseCastWithGep(Value *V) {
   if (BitCastOperator *BCO = dyn_cast<BitCastOperator>(V)) {
     if (!BCO->getSrcTy()->isPointerTy())

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -980,8 +980,25 @@ void HLModule::GetParameterRowsAndCols(Type *Ty, unsigned &rows, unsigned &cols,
   rows *= arraySize;
 }
 
-static Value *MergeGEP(GEPOperator *SrcGEP, GetElementPtrInst *GEP) {
-  IRBuilder<> Builder(GEP);
+static Value *ReplaceGEPInstOrConstant(GEPOperator *GEP, Value *SrcPtr,
+                                       ArrayRef<Value *> Indices) {
+  Type *SrcTy = cast<PointerType>(SrcPtr->getType()->getScalarType())->getElementType();
+  Value *newGEP = nullptr;
+  GetElementPtrInst *GEPI = dyn_cast<GetElementPtrInst>(GEP);
+  if (GEPI) {
+    IRBuilder<> Builder(GEPI);
+    newGEP = Builder.CreateInBoundsGEP(SrcTy, SrcPtr, Indices, GEPI->getName());
+  } else {
+    newGEP = ConstantExpr::getInBoundsGetElementPtr(
+        SrcTy, cast<Constant>(SrcPtr), Indices);
+  }
+  GEP->replaceAllUsesWith(newGEP);
+  if (GEPI)
+    GEPI->eraseFromParent();
+  return newGEP;
+}
+
+static Value *MergeGEP(GEPOperator *SrcGEP, GEPOperator *GEP) {
   SmallVector<Value *, 8> Indices;
 
   // Find out whether the last index in the source GEP is a sequential idx.
@@ -1009,6 +1026,9 @@ static Value *MergeGEP(GEPOperator *SrcGEP, GetElementPtrInst *GEP) {
       // that before the merge.
       if (!isa<Constant>(GO1) || !isa<Constant>(SO1))
         return nullptr;
+      IRBuilder<> Builder(GEP->getContext());
+      if (Instruction *I = dyn_cast<Instruction>(GEP))
+        Builder.SetInsertPoint(I);
       Sum = Builder.CreateAdd(SO1, GO1);
     }
 
@@ -1029,42 +1049,88 @@ static Value *MergeGEP(GEPOperator *SrcGEP, GetElementPtrInst *GEP) {
     Indices.append(GEP->idx_begin() + 1, GEP->idx_end());
   }
   if (!Indices.empty())
-    return Builder.CreateInBoundsGEP(SrcGEP->getSourceElementType(),
-                                     SrcGEP->getOperand(0), Indices,
-                                     GEP->getName());
+    return ReplaceGEPInstOrConstant(GEP, SrcGEP->getOperand(0), Indices);
   else
     llvm_unreachable("must merge");
 }
 
-void HLModule::MergeGepUse(Value *V) {
+// If bitcast is to self or inner base struct, return true and report depth.
+static bool IsBitCastToBaseOrSelf(BitCastOperator *BCO, unsigned &depth) {
+  depth = 0;
+  Type *SrcTy = BCO->getSrcTy()->getPointerElementType();
+  Type *DestTy = BCO->getType()->getPointerElementType();
+  if (SrcTy == DestTy) {
+    return true;
+  } else if (DestTy->isStructTy()) {
+    // Drill into first element recursively to match cast-to-base struct pattern
+    Type *InnerTy = SrcTy;
+    while (InnerTy->isStructTy() && InnerTy != DestTy &&
+           InnerTy->getStructNumElements() > 0) {
+      InnerTy = InnerTy->getStructElementType(0);
+      depth++;
+    }
+    return InnerTy == DestTy;
+  }
+  return false;
+}
+
+static void MergeGepUseImpl(Value *V);
+
+// Given a bitcast-to-base pattern of specified depth, merge into GEP users
+static void MergeBitCastToBaseIntoGepUse(BitCastOperator *BCO, unsigned depth) {
+  Value *SrcPtr = BCO->getOperand(0);
+  if (depth == 0) {
+    DXASSERT_NOMSG(BCO->getSrcTy() == BCO->getDestTy());
+    BCO->replaceAllUsesWith(SrcPtr);
+    return;
+  }
+  for (auto U = BCO->user_begin(); U != BCO->user_end();) {
+    auto Use = U++;
+    if (GEPOperator *GEP = dyn_cast<GEPOperator>(*Use)) {
+      if (GEP->hasIndices() && isa<Constant>(*GEP->idx_begin()) &&
+          cast<Constant>(*GEP->idx_begin())->isNullValue()) {
+        // add zero indices to new GEP
+        Constant *Zero = ConstantInt::get(GEP->getOperand(1)->getType(), (uint64_t)0, false);
+        // add depth zeros plus the initial zero ptr index
+        SmallVector<Value *, 8> Indices (depth + 1, Zero);
+        Indices.append(GEP->idx_begin() + 1, GEP->idx_end());
+        Value *newGEP = ReplaceGEPInstOrConstant(GEP, SrcPtr, Indices);
+        MergeGepUseImpl(newGEP);
+      } else {
+        MergeGepUseImpl(GEP);
+      }
+    } else if (BitCastOperator *InnerBCO = dyn_cast<BitCastOperator>(*Use)) {
+      unsigned innerDepth = 0;
+      if (IsBitCastToBaseOrSelf(InnerBCO, innerDepth)) {
+        // Set inner bitcast src to outer src, add depth and recurse.
+        InnerBCO->setOperand(0, BCO->getOperand(0));
+        MergeBitCastToBaseIntoGepUse(InnerBCO, depth + innerDepth);
+      }
+    }
+  }
+  if (BitCastInst *I = dyn_cast<BitCastInst>(BCO)) {
+    if (I->user_empty()) {
+      I->eraseFromParent();
+    }
+  }
+}
+
+static void MergeGepUseImpl(Value *V) {
   for (auto U = V->user_begin(); U != V->user_end();) {
     auto Use = U++;
 
-    if (GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(*Use)) {
+    if (GEPOperator *GEP = dyn_cast<GEPOperator>(*Use)) {
       if (GEPOperator *prevGEP = dyn_cast<GEPOperator>(V)) {
         // merge the 2 GEPs
         Value *newGEP = MergeGEP(prevGEP, GEP);
-        // Don't need to replace when GEP is updated in place
-        if (newGEP != GEP) {
-          GEP->replaceAllUsesWith(newGEP);
-          GEP->eraseFromParent();
-        }
-        MergeGepUse(newGEP);
+        MergeGepUseImpl(newGEP);
       } else {
-        MergeGepUse(*Use);
+        MergeGepUseImpl(*Use);
       }
-    } else if (dyn_cast<GEPOperator>(*Use)) {
-      if (GEPOperator *prevGEP = dyn_cast<GEPOperator>(V)) {
-        // merge the 2 GEPs
-        Value *newGEP = MergeGEP(prevGEP, GEP);
-        // Don't need to replace when GEP is updated in place
-        if (newGEP != GEP) {
-          GEP->replaceAllUsesWith(newGEP);
-          GEP->eraseFromParent();
-        }
-        MergeGepUse(newGEP);
-      } else {
-        MergeGepUse(*Use);
+    } else if (BitCastOperator *BCO = dyn_cast<BitCastOperator>(*Use)) {
+      unsigned depth = 0;
+      if (IsBitCastToBaseOrSelf(BCO, depth)) {
+        MergeBitCastToBaseIntoGepUse(BCO, depth);
       }
     }
   }
@@ -1073,6 +1139,10 @@ void HLModule::MergeGepUse(Value *V) {
     if (GetElementPtrInst *I = dyn_cast<GetElementPtrInst>(V))
       I->eraseFromParent();
   }
+}
+
+void HLModule::MergeGepUse(Value *V) {
+  MergeGepUseImpl(V);
 }
 
 template

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -394,6 +394,7 @@ bool IsHLSLTriangleStreamType(clang::QualType type);
 bool IsHLSLStreamOutputType(clang::QualType type);
 bool IsHLSLResourceType(clang::QualType type);
 bool IsHLSLBufferViewType(clang::QualType type);
+bool IsHLSLStructuredBufferType(clang::QualType type);
 bool IsHLSLNumericOrAggregateOfNumericType(clang::QualType type);
 bool IsHLSLNumericUserDefinedType(clang::QualType type);
 bool IsHLSLAggregateType(clang::QualType type);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -562,6 +562,18 @@ bool IsHLSLBufferViewType(clang::QualType type) {
   return false;
 }
 
+bool IsHLSLStructuredBufferType(clang::QualType type) {
+  if (const RecordType *RT = type->getAs<RecordType>()) {
+    StringRef name = RT->getDecl()->getName();
+    if (name == "StructuredBuffer" || name == "RWStructuredBuffer")
+      return true;
+
+    if (name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer")
+      return true;
+  }
+  return false;
+}
+
 bool IsHLSLSubobjectType(clang::QualType type) {
   DXIL::SubobjectKind kind;
   DXIL::HitGroupType hgType;

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -975,7 +975,7 @@ unsigned CGMSHLSLRuntime::ConstructStructAnnotation(DxilStructAnnotation *annota
         DxilStructAnnotation *baseAnnotation =
             dxilTypeSys.GetStructAnnotation(baseType);
 
-        if (size || baseAnnotation && !baseAnnotation->IsEmptyStruct()) {
+        if (size || (baseAnnotation && !baseAnnotation->IsEmptyStruct())) {
           DxilFieldAnnotation &fieldAnnotation =
               annotation->GetFieldAnnotation(fieldIdx++);
 

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -1984,6 +1984,10 @@ unsigned AlignCBufferOffset(unsigned offset, unsigned size, llvm::Type *Ty,
                             bool bRowMajor, bool bMinPrecMode,
                             bool &bCurRowIsMinPrec) {
   DXASSERT(!(offset & 1), "otherwise we have an invalid offset.");
+  // resources, empty structure, or structures with only resources have
+  // zero size, and need no alignment.
+  if (size == 0)
+    return offset;
   bool bNeedNewRow = Ty->isArrayTy();
   // In min-precision mode, a new row is needed when
   // going into or out of min-precision component type.

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/bindings1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/bindings1.hlsl
@@ -93,8 +93,6 @@
 // CHECK: ; RWTex4                                UAV     f32          2d      U2            u17     6
 // CHECK: ; RWTex1                                UAV     f32          2d      U3             u0     4
 
-// CHECK: %struct.Resources = type { %"class.Texture2D<float>", %"class.Texture2D<vector<float, 4> >", %"class.Texture2D<float>", %"class.Texture2D<vector<float, 4> >", %"class.RWTexture2D<vector<float, 4> >", %"class.RWTexture2D<vector<float, 4> >", %"class.RWTexture2D<vector<float, 4> >", %"class.RWTexture2D<vector<float, 4> >", %struct.SamplerComparisonState, %struct.SamplerState, %struct.SamplerComparisonState, %struct.SamplerState, <4 x float> }
-
 // CHK60: %[[RWTex2:.*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 7, i1 false)
 // CHK60: %[[MyTB:.*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 4, i32 11, i1 false)
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer.hlsl
@@ -3,17 +3,17 @@
 // Make sure structures with only resources have resource fields removed,
 // are considered empty, take no space in CBuffer, and do not force alignment.
 // CHECK: cbuffer $Globals
-// CHECK:   struct dx.alignment.legacy.$Globals
+// CHECK:   struct hostlayout.$Globals
 // CHECK:       float h;                                      ; Offset:    0
-// CHECK:       struct dx.alignment.legacy.struct.LegacyTex
+// CHECK:       struct hostlayout.struct.LegacyTex
 // CHECK:           /* empty struct */
 // CHECK:       } tx1;                                        ; Offset:    4
 // CHECK:       float i;                                      ; Offset:    4
 // CHECK:   } $Globals;                                       ; Offset:    0 Size:     8
 // CHECK: cbuffer CB0
-// CHECK:   struct dx.alignment.legacy.CB0
+// CHECK:   struct hostlayout.CB0
 // CHECK:       float f;                                      ; Offset:    0
-// CHECK:       struct dx.alignment.legacy.struct.LegacyTex
+// CHECK:       struct hostlayout.struct.LegacyTex
 // CHECK:           /* empty struct */
 // CHECK:       } tx0;                                        ; Offset:    4
 // CHECK:       float g;                                      ; Offset:    4

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer2.hlsl
@@ -1,23 +1,22 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
 
-// Make sure structures with only resources have resource fields removed,
-// are considered empty, take no space in CBuffer, and do not force alignment.
+// Make sure structures with resources have resource fields removed.
 // CHECK: cbuffer $Globals
 // CHECK:   struct dx.alignment.legacy.$Globals
 // CHECK:       float h;                                      ; Offset:    0
 // CHECK:       struct dx.alignment.legacy.struct.LegacyTex
-// CHECK:           /* empty struct */
-// CHECK:       } tx1;                                        ; Offset:    4
-// CHECK:       float i;                                      ; Offset:    4
-// CHECK:   } $Globals;                                       ; Offset:    0 Size:     8
+// CHECK:           float f;                                  ; Offset:   16
+// CHECK:       } tx1;                                        ; Offset:   16
+// CHECK:       float i;                                      ; Offset:   20
+// CHECK:   } $Globals;                                       ; Offset:    0 Size:    24
 // CHECK: cbuffer CB0
 // CHECK:   struct dx.alignment.legacy.CB0
 // CHECK:       float f;                                      ; Offset:    0
 // CHECK:       struct dx.alignment.legacy.struct.LegacyTex
-// CHECK:           /* empty struct */
-// CHECK:       } tx0;                                        ; Offset:    4
-// CHECK:       float g;                                      ; Offset:    4
-// CHECK:   } CB0;                                            ; Offset:    0 Size:     8
+// CHECK:           float f;                                  ; Offset:   16
+// CHECK:       } tx0;                                        ; Offset:   16
+// CHECK:       float g;                                      ; Offset:   20
+// CHECK:   } CB0;                                            ; Offset:    0 Size:    24
 
 // CHECK: $Globals                          cbuffer      NA          NA     CB0            cb0     1
 // CHECK: CB0                               cbuffer      NA          NA     CB1            cb1     1
@@ -36,26 +35,27 @@
 struct LegacyTex
 {
   Texture2D t;
+  float f;
   SamplerState  s;
 };
 
 cbuffer CB0 {
   float f;          // CB0[0].x
-  LegacyTex tx0;    // t0, s0
-  float g;          // CB0[0].y
+  LegacyTex tx0;    // t0, s0, CB0[1].x
+  float g;          // CB0[2].x
 }
 Buffer<float4> b0;  // t1
 float h;            // $Globals[0].x
-LegacyTex tx1;      // t2, s1
-float i;            // $Globals[0].y
+LegacyTex tx1;      // t2, s1, $Globals[1].x
+float i;            // $Globals[2].x
 Buffer<float4> b1;  // t3
 
 float4 tex2D(LegacyTex tx, float2 uv)
 {
-  return tx.t.Sample(tx.s,uv);
+  return tx.t.Sample(tx.s,uv) * tx.f;
 }
 
 float4 main(float2 uv:UV) : SV_Target
 {
-  return h * b0[(uint)uv.y] * tex2D(tx1,uv) + b1[(uint)uv.x] * tex2D(tx0,uv) * f + g + i;
+  return h * b0[(uint)uv.y] * tex2D(tx1,uv) + b1[(uint)uv.x] * tex2D(tx0,uv) * f + g * i;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_in_cbuffer2.hlsl
@@ -2,17 +2,17 @@
 
 // Make sure structures with resources have resource fields removed.
 // CHECK: cbuffer $Globals
-// CHECK:   struct dx.alignment.legacy.$Globals
+// CHECK:   struct hostlayout.$Globals
 // CHECK:       float h;                                      ; Offset:    0
-// CHECK:       struct dx.alignment.legacy.struct.LegacyTex
+// CHECK:       struct hostlayout.struct.LegacyTex
 // CHECK:           float f;                                  ; Offset:   16
 // CHECK:       } tx1;                                        ; Offset:   16
 // CHECK:       float i;                                      ; Offset:   20
 // CHECK:   } $Globals;                                       ; Offset:    0 Size:    24
 // CHECK: cbuffer CB0
-// CHECK:   struct dx.alignment.legacy.CB0
+// CHECK:   struct hostlayout.CB0
 // CHECK:       float f;                                      ; Offset:    0
-// CHECK:       struct dx.alignment.legacy.struct.LegacyTex
+// CHECK:       struct hostlayout.struct.LegacyTex
 // CHECK:           float f;                                  ; Offset:   16
 // CHECK:       } tx0;                                        ; Offset:   16
 // CHECK:       float g;                                      ; Offset:   20

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/default-matrix-in-template.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/default-matrix-in-template.hlsl
@@ -1,5 +1,6 @@
-// RUN: %dxc -E main -T cs_6_0 %s  | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -fcgl %s  | FileCheck %s
 
+// Check unlowered type
 // CHECK: %"class.StructuredBuffer<matrix<float, 4, 4> >" = type { %class.matrix.float.4.4 }
 
 StructuredBuffer<matrix> buf1;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_hs_shaders_only.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_hs_shaders_only.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -auto-binding-space 13 -T lib_6_3 -export-shaders-only %s | FileCheck %s
 
-// CHECK: class.Buffer
 // CHECK-NOT: unused
 // CHECK-NOT: @"\01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@V?$InputPatch@UPSSceneIn@@$0BA@@@@Z"
 // CHECK: define void @"\01?HSPerPatchFunc2

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_shaders_only.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_shaders_only.hlsl
@@ -1,7 +1,6 @@
 // RUN: %dxc -auto-binding-space 13 -T lib_6_3 -export-shaders-only %s | FileCheck %s
 
 // CHECK: %struct.Payload
-// CHECK: class.Buffer
 // CHECK-NOT: unused
 // CHECK: define void @"\01?AnyHit
 // CHECK: define void @"\01?Callable

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_derived_payload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_derived_payload.hlsl
@@ -1,6 +1,11 @@
 // RUN: %dxc -T lib_6_3 -Od %s | FileCheck %s
 
-// Make sure bitcast to base gets folded into GEP on -Od
+// Verifies packoffset of struct with multiple levels of inheritance
+// CHECK:       } cb_pld;                                     ; Offset:   32
+// CHECK:       float f;                                      ; Offset:    4
+// CHECK:   } CB;                                             ; Offset:    0 Size:    72
+
+// Make sure bitcast to base for `this` as part of the method call gets folded into GEP on -Od
 // CHECK: define void [[raygen1:@"\\01\?raygen1@[^\"]+"]]() #0 {
 // CHECK-NOT: bitcast
 // CHECK:   ret void
@@ -16,6 +21,7 @@ struct BasePayload : SuperBasePayload {
 };
 
 struct MyPayload : BasePayload {
+  int i;
   float4 color;
   uint2 pos;
 };
@@ -23,15 +29,19 @@ struct MyPayload : BasePayload {
 RaytracingAccelerationStructure RTAS : register(t5);
 RWByteAddressBuffer BAB :  register(u0) ;
 
+cbuffer CB : register(b0) {
+  MyPayload cb_pld : packoffset(c2.x);
+  float f : packoffset(c0.y);
+}
 
 [shader("raygeneration")]
 void raygen1()
 {
-  MyPayload p = (MyPayload)0;
+  MyPayload p = cb_pld;
   p.pos = DispatchRaysIndex();
   float3 origin = {0, 0, 0};
   float3 dir = normalize(float3(p.pos / (float)DispatchRaysDimensions(), 1));
   RayDesc ray = { origin, 0.125, dir, 128.0};
   TraceRay(RTAS, RAY_FLAG_NONE, 0, 0, 1, 0, ray, p);
-  BAB.Store(p.pos.x + p.pos.y * DispatchRaysDimensions().x, p.DoSomething());  // Causes bad bitcast
+  BAB.Store(p.pos.x + p.pos.y * DispatchRaysDimensions().x, p.DoSomething());
 }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_derived_payload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_derived_payload.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -T lib_6_3 -Od %s | FileCheck %s
+
+// Make sure bitcast to base gets folded into GEP on -Od
+// CHECK: define void [[raygen1:@"\\01\?raygen1@[^\"]+"]]() #0 {
+// CHECK-NOT: bitcast
+// CHECK:   ret void
+
+struct SuperBasePayload {
+  float g;
+  bool DoInner() { return g < 0; }
+};
+
+struct BasePayload : SuperBasePayload {
+  float f;
+  bool DoSomething() { return f < 0 && DoInner(); }
+};
+
+struct MyPayload : BasePayload {
+  float4 color;
+  uint2 pos;
+};
+
+RaytracingAccelerationStructure RTAS : register(t5);
+RWByteAddressBuffer BAB :  register(u0) ;
+
+
+[shader("raygeneration")]
+void raygen1()
+{
+  MyPayload p = (MyPayload)0;
+  p.pos = DispatchRaysIndex();
+  float3 origin = {0, 0, 0};
+  float3 dir = normalize(float3(p.pos / (float)DispatchRaysDimensions(), 1));
+  RayDesc ray = { origin, 0.125, dir, 128.0};
+  TraceRay(RTAS, RAY_FLAG_NONE, 0, 0, 1, 0, ray, p);
+  BAB.Store(p.pos.x + p.pos.y * DispatchRaysDimensions().x, p.DoSomething());  // Causes bad bitcast
+}

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -204,7 +204,13 @@ public:
     std::string baseName(baseDesc.Name);
     if (baseName.compare(0, 4, "half", 4) == 0)
       baseName = baseName.replace(0, 4, "float", 5);
-    VERIFY_ARE_EQUAL_STR(testDesc.Name, baseName.c_str());
+
+    // For anonymous structures, fxc uses "scope::<unnamed>",
+    // dxc uses "anon", and may have additional ".#" for name disambiguation.
+    // Just skip name check if struct is unnamed according to fxc.
+    if (baseName.find("<unnamed>") == std::string::npos) {
+      VERIFY_ARE_EQUAL_STR(testDesc.Name, baseName.c_str());
+    }
 
     for (UINT i = 0; i < baseDesc.Members; ++i) {
       ID3D12ShaderReflectionType* testMemberType = pTest->GetMemberTypeByIndex(i);
@@ -1800,6 +1806,7 @@ TEST_F(DxilContainerTest, ReflectionMatchesDXBC_CheckIn) {
   ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\d3dreflect\\tbuffer.hlsl").c_str(), false,
     D3DCOMPILE_ENABLE_BACKWARDS_COMPATIBILITY);
   ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\d3dreflect\\texture2dms.hlsl").c_str(), false);
+  ReflectionTest(hlsl_test::GetPathToHlslDataFile(L"..\\HLSLFileCheck\\hlsl\\objects\\StructuredBuffer\\layout.hlsl").c_str(), false);
 }
 
 TEST_F(DxilContainerTest, ReflectionMatchesDXBC_Full) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -738,17 +738,17 @@ TEST_F(ValidationTest, BarrierFail) {
       {"dx.op.barrier(i32 80, i32 8)",
         "dx.op.barrier(i32 80, i32 9)",
         "dx.op.barrier(i32 80, i32 11)",
-        "%\"class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { %class.matrix.float.2.2 }\n",
+        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { [2 x <2 x float>] }\n",
         "call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)",
       },
       {"dx.op.barrier(i32 80, i32 15)",
         "dx.op.barrier(i32 80, i32 0)",
         "dx.op.barrier(i32 80, i32 %rem)",
-        "%\"class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { %class.matrix.float.2.2 }\n"
-        "@dx.typevar.8 = external addrspace(1) constant %\"class.RWStructuredBuffer<matrix<float, 2, 2> >\"\n"
+        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { [2 x <2 x float>] }\n"
+        "@dx.typevar.8 = external addrspace(1) constant %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\"\n"
         "@\"internalGV\" = internal global [64 x <4 x float>] undef\n",
         "call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)\n"
-        "%load = load %\"class.RWStructuredBuffer<matrix<float, 2, 2> >\", %\"class.RWStructuredBuffer<matrix<float, 2, 2> >\" addrspace(1)* @dx.typevar.8",
+        "%load = load %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\", %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" addrspace(1)* @dx.typevar.8",
       },
       {"Internal declaration 'internalGV' is unused",
        "External declaration 'dx.typevar.8' is unused",

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -489,9 +489,22 @@ public:
         if (bRegex) {
           llvm::Regex RE(pLookFor);
           std::string reErrors;
+          if (!RE.isValid(reErrors)) {
+            WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                L"Regex errors:\r\n%.*S\r\nWhile compiling expression '%S'",
+                (unsigned)reErrors.size(), reErrors.data(),
+                pLookFor));
+          }
           VERIFY_IS_TRUE(RE.isValid(reErrors));
           std::string replaced = RE.sub(pReplacement, disassembly, &reErrors);
           if (!bOptional) {
+            if (!reErrors.empty()) {
+              WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                  L"Regex errors:\r\n%.*S\r\nWhile searching for '%S' in text:\r\n%.*S",
+                  (unsigned)reErrors.size(), reErrors.data(),
+                  pLookFor,
+                  (unsigned)disassembly.size(), disassembly.data()));
+            }
             VERIFY_ARE_NOT_EQUAL(disassembly, replaced);
             VERIFY_IS_TRUE(reErrors.empty());
           }
@@ -510,6 +523,12 @@ public:
             pos += replaceLen;
           }
           if (!bOptional) {
+            if (!found) {
+              WEX::Logging::Log::Comment(WEX::Common::String().Format(
+                  L"String not found: '%S' in text:\r\n%.*S",
+                  pLookFor,
+                  (unsigned)disassembly.size(), disassembly.data()));
+            }
             VERIFY_IS_TRUE(found);
           }
         }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -3842,22 +3842,30 @@ TEST_F(ValidationTest, ValidatePrintfNotAllowed) {
 
 TEST_F(ValidationTest, ValidateVersionNotAllowed) {
   if (m_ver.SkipDxilVersion(1, 6)) return;
-  std::string maxValMinor = std::to_string(m_ver.m_ValMinor);
-  std::string higherValMinor = std::to_string(m_ver.m_ValMinor + 1);
-  std::string maxDxilMinor = std::to_string(m_ver.m_DxilMinor);
-  std::string higherDxilMinor = std::to_string(m_ver.m_DxilMinor + 1);
+  // When validator version is < dxil verrsion, compiler has a newer version
+  // than validator.  We are checking the validator, so only use the validator
+  // version.
+  // This will also assume that the versions are tied together.  This has always
+  // been the case, but it's not assumed that it has to be the case.  If the
+  // versions diverged, it would be impossible to tell what DXIL version a
+  // validator supports just from the version returned in the IDxcVersion
+  // interface, without separate knowledge of the supported dxil version based
+  // on the validator version.  If these versions must diverge in the future, we
+  // could rev the IDxcVersion interface to accomodate.
+  std::string maxMinor = std::to_string(m_ver.m_ValMinor);
+  std::string higherMinor = std::to_string(m_ver.m_ValMinor + 1);
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\basic.hlsl", "ps_6_0",
-    ("= !{i32 1, i32 " + maxValMinor + "}").c_str(),
-    ("= !{i32 1, i32 " + higherValMinor + "}").c_str(),
-    ("error: Validator version in metadata (1." + higherValMinor + ") is not supported; maximum: (1." + maxValMinor + ")").c_str());
+    ("= !{i32 1, i32 " + maxMinor + "}").c_str(),
+    ("= !{i32 1, i32 " + higherMinor + "}").c_str(),
+    ("error: Validator version in metadata (1." + higherMinor + ") is not supported; maximum: (1." + maxMinor + ")").c_str());
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\basic.hlsl", "ps_6_0",
     "= !{i32 1, i32 0}",
     "= !{i32 1, i32 1}",
     "error: Shader model requires Dxil Version 1.0");
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\basic.hlsl", "ps_6_0",
     "= !{i32 1, i32 0}",
-    ("= !{i32 1, i32 " + higherDxilMinor + "}").c_str(),
-    ("error: Dxil version in metadata (1." + higherDxilMinor + ") is not supported; maximum: (1." + maxDxilMinor + ")").c_str());
+    ("= !{i32 1, i32 " + higherMinor + "}").c_str(),
+    ("error: Dxil version in metadata (1." + higherMinor + ") is not supported; maximum: (1." + maxMinor + ")").c_str());
 }
 
 TEST_F(ValidationTest, CreateHandleNotAllowedSM66) {


### PR DESCRIPTION
* Fold bitcast-to-base into GEP in MergeGepUse, plus refactor

  - Fixes case where bitcast isn't eliminated under -Od.
  - Fix issue with constant GEP path that was unintentionally using GEP
    from failed prior branch.
  - Change to worklist pattern, which simplifies things.
  - One case wasn't handled, which was going to complicate code:
    GEP -> bitcast -> GEP would combine bitcast -> GEP, but not combine
    outer GEP with the new one.
  - Add dxilutil::TryReplaceBaseCastWithGep that simply replaces if it matches.

* Fix cbuffer layouts when resources are in structs

  - keep track of resources in type annotation information
  - fix cbuffer packing locations for things around resources
  - when translating struct for legacy:
    - remove resource fields from struct types
    - properly replace HLSL type
  - remove unused structs and annotations
  - don't produce type annotations for silly things
  - fix other random bugs found along the way

* Fix ValidateVersionNotAllowed test issue with external validator

  It turns out the test wasn't correct in assuming dxil version reported was
  the one it should expect to be supported by the validator, since that
  represents the compiler version.  The validator version constrains the
  dxil version supported by the validator, not the compiler version.
  See comments in the test for details.

* Fix error reporting in ValidationTest::RewriteAssemblyToText

* Fix tests for translated structs and hostlayout name change.
