### PR TITLE
PIX: Entry point can be null for DXBC->DXIL hull shader

### DIFF
--- a/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilAddPixelHitInstrumentation.cpp
@@ -95,14 +95,14 @@ bool DxilAddPixelHitInstrumentation::runOnModule(Module &M) {
     SV_Position_ID = SV_Position->get()->GetID();
   }
 
-  auto EntryPointFunction = DM.GetEntryFunction();
+  auto EntryPointFunction = PIXPassHelpers::GetEntryFunction(DM);
 
   auto &EntryBlock = EntryPointFunction->getEntryBlock();
 
   CallInst *HandleForUAV;
   {
     IRBuilder<> Builder(
-        dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction()));
+        dxilutil::FirstNonAllocaInsertionPt(PIXPassHelpers::GetEntryFunction(DM)));
 
     HandleForUAV = PIXPassHelpers::CreateUAV(DM, Builder, 0, "PIX_CountUAV_Handle");
 

--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -35,6 +35,8 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "PixPassHelpers.h"
+
 #define DEBUG_TYPE "dxil-annotate-with-virtual-regs"
 
 uint32_t CountStructMembers(llvm::Type const *pType) {
@@ -87,7 +89,7 @@ private:
     m_DM = &M.GetOrCreateDxilModule();
     m_uVReg = 0;
     m_MST.reset(new llvm::ModuleSlotTracker(&M));
-    m_MST->incorporateFunction(*m_DM->GetEntryFunction());
+    m_MST->incorporateFunction(*PIXPassHelpers::GetEntryFunction(*m_DM));
   }
 };
 
@@ -106,7 +108,7 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
   }
 
   std::uint32_t InstNum = 0;
-  for (llvm::Instruction &I : llvm::inst_range(m_DM->GetEntryFunction())) {
+  for (llvm::Instruction &I : llvm::inst_range(PIXPassHelpers::GetEntryFunction(*m_DM))) {
     if (!llvm::isa<llvm::DbgDeclareInst>(&I)) {
       pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, InstNum++);
     }
@@ -124,11 +126,11 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
     *OSOverride << "\nBegin - dxil values to virtual register mapping\n";
   }
 
-  for (llvm::Instruction &I : llvm::inst_range(m_DM->GetEntryFunction())) {
+  for (llvm::Instruction &I : llvm::inst_range(PIXPassHelpers::GetEntryFunction(*m_DM))) {
     AnnotateValues(&I);
   }
 
-  for (llvm::Instruction &I : llvm::inst_range(m_DM->GetEntryFunction())) {
+  for (llvm::Instruction &I : llvm::inst_range(PIXPassHelpers::GetEntryFunction(*m_DM))) {
     AnnotateStore(&I);
   }
 

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -793,7 +793,7 @@ VariableRegisters::VariableRegisters(
     llvm::Module *M)
   : m_dbgLoc(dbgLoc)
   ,m_Variable(Variable)
-  , m_B(M->GetOrCreateDxilModule().GetEntryFunction()->getEntryBlock().begin())
+  , m_B(PIXPassHelpers::GetEntryFunction(M->GetOrCreateDxilModule())->getEntryBlock().begin())
   , m_DbgDeclareFn(llvm::Intrinsic::getDeclaration(
       M, llvm::Intrinsic::dbg_declare))
 {

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -887,8 +887,8 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
 
   // First record pointers to all instructions in the function:
   std::vector<Instruction *> AllInstructions;
-  for (inst_iterator I = inst_begin(DM.GetEntryFunction()),
-                     E = inst_end(DM.GetEntryFunction());
+  for (inst_iterator I = inst_begin(PIXPassHelpers::GetEntryFunction(DM)),
+                     E = inst_end(PIXPassHelpers::GetEntryFunction(DM));
        I != E; ++I) {
     AllInstructions.push_back(&*I);
   }
@@ -907,7 +907,7 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
   //
 
   Instruction *firstInsertionPt =
-      dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction());
+      dxilutil::FirstNonAllocaInsertionPt(PIXPassHelpers::GetEntryFunction(DM));
   IRBuilder<> Builder(firstInsertionPt);
 
   BuilderContext BC{M, DM, Ctx, HlslOP, Builder};
@@ -921,7 +921,7 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
   // Explicitly name new blocks in order to provide stable names for testing purposes
   int NewBlockCounter = 0;
 
-  auto Fn = DM.GetEntryFunction();
+  auto Fn = PIXPassHelpers::GetEntryFunction(DM);
   auto &Blocks = Fn->getBasicBlockList();
   for (auto &CurrentBlock : Blocks) {
     struct ValueAndPhi {

--- a/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
+++ b/lib/DxilPIXPasses/DxilOutputColorBecomesConstant.cpp
@@ -169,7 +169,7 @@ bool DxilOutputColorBecomesConstant::runOnModule(Module &M) {
     pCBuf->SetSize(4);
 
     Instruction *entryPointInstruction =
-        &*(DM.GetEntryFunction()->begin()->begin());
+        &*(PIXPassHelpers::GetEntryFunction(DM)->begin()->begin());
     IRBuilder<> Builder(entryPointInstruction);
 
     // Create handle for the newly-added constant buffer (which is achieved via

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -222,7 +222,7 @@ bool DxilPIXMeshShaderOutputInstrumentation::runOnModule(Module &M)
   OP *HlslOP = DM.GetOP();
 
   Instruction *firstInsertionPt =
-      dxilutil::FirstNonAllocaInsertionPt(DM.GetEntryFunction());
+      dxilutil::FirstNonAllocaInsertionPt(PIXPassHelpers::GetEntryFunction(DM));
   IRBuilder<> Builder(firstInsertionPt);
 
   BuilderContext BC{M, DM, Ctx, HlslOP, Builder};

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -166,6 +166,12 @@ llvm::CallInst *CreateUAV(DxilModule &DM, IRBuilder<> &Builder,
   return handle;
 }
 
+llvm::Function* GetEntryFunction(hlsl::DxilModule& DM) {
+    if (DM.GetEntryFunction() != nullptr) {
+        return DM.GetEntryFunction();
+    }
+    return DM.GetPatchConstantFunction();
+}
 
 #ifdef PIX_DEBUG_DUMP_HELPER
 

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -23,7 +23,7 @@ namespace PIXPassHelpers
     llvm::CallInst* CreateHandleForResource(hlsl::DxilModule& DM, llvm::IRBuilder<>& Builder,
         hlsl::DxilResourceBase * resource,
         const char* name);
-
+    llvm::Function* GetEntryFunction(hlsl::DxilModule& DM);
 #ifdef PIX_DEBUG_DUMP_HELPER
     void Log(const char* format, ...);
     void LogPartialLine(const char* format, ...);

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -2130,6 +2130,9 @@ static bool GetUnsignedVal(Value *V, uint32_t *pValue) {
 
 void DxilShaderReflection::MarkUsedSignatureElements() {
   Function *F = m_pDxilModule->GetEntryFunction();
+  if (F == nullptr) {
+    F = m_pDxilModule->GetPatchConstantFunction();
+  }
   DXASSERT(F != nullptr, "else module load should have failed");
   // For every loadInput/storeOutput, update the corresponding ReadWriteMask.
   // F is a pointer to a Function instance


### PR DESCRIPTION
This is a bit of a corner-case, but PIX tripped up on it while capturing an app under d3d11on12.
PIX is probably the only client who cares about this case, since it's only relevant when DXBC->DXIL has been run (e.g. 11on12), and then examined via reflection and/or the PIX-specific passes.

Here's the entry-point metadata provided by DXBC->DXIL for a representative case. It has a null entry point, but a non-null patch-constant function:
```
!dx.entryPoints = !{!7}
!7 = !{null, !"", !8, !2, !24}
!24 = !{i32 0, i64 256, i32 3, !25}
!25 = !{void ()* @pc_main, i32 3, i32 3, i32 2, i32 3, i32 3, float 0.000000e+00}
```

(Documentation of DXBC->DXIL's operation in this case is here: https://github.com/Microsoft/DirectXShaderCompiler/blob/master/docs/DXIL.rst#hull-shader-representation)

(PIX bug #32030124)