### PR TITLE
[spirv] set needsLegalization as true when variable offset is found

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4461,6 +4461,9 @@ SpirvInstruction *SpirvEmitter::createImageSample(
     SpirvInstruction *minLod, SpirvInstruction *residencyCodeId,
     SourceLocation loc) {
 
+  if (varOffset)
+    needsLegalization = true;
+
   // SampleDref* instructions in SPIR-V always return a scalar.
   // They also have the correct type in HLSL.
   if (compareVal) {
@@ -4892,6 +4895,9 @@ SpirvEmitter::processBufferTextureLoad(const CXXMemberCallExpr *expr) {
       if (hasOffsetArg)
         handleOffsetInMethodCall(expr, 1, &constOffset, &varOffset);
     }
+
+    if (varOffset)
+      needsLegalization = true;
 
     return processBufferTextureLoad(object, coordinate, constOffset, varOffset,
                                     lod, status, loc);

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.hlsl
@@ -3,6 +3,12 @@
 SamplerState      gSampler  : register(s5);
 Texture2D<float4> t         : register(t1);
 
+// This shader uses a variable offset for texture sampling that is supposed to
+// be converted to a constant value after the legalization. Since we set
+// needsLegalization as true when we find a variable offset for texture
+// sampling, `--before-legalize-hlsl` option for spirv-val should be enabled
+// because of `-fcgl`.
+
 // CHECK:      OpImageSparseSampleImplicitLod
 // CHECK-SAME: Offset
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -E main
+
+SamplerState      gSampler  : register(s5);
+Texture2D<float4> t         : register(t1);
+
+// CHECK:      OpImageSparseSampleImplicitLod
+// CHECK-SAME: Offset
+
+float4 sample(int offset, float clamp) {
+    uint status;
+    return t.Sample(gSampler, float2(0.1, 0.2), offset, clamp, status);
+}
+
+float4 main(int2 offset: A) : SV_Target {
+    float4 val = 0;
+    [unroll] for (int i = 0; i < 3; ++i)
+        val = sample(i, offset.x);
+    return val;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.o0.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.o0.hlsl
@@ -3,6 +3,9 @@
 SamplerState      gSampler  : register(s5);
 Texture2D<float4> t         : register(t1);
 
+// This shader uses a variable offset for texture sampling that is supposed to
+// be converted to a constant value after the legalization.
+
 // CHECK:      OpImageSparseSampleImplicitLod
 // CHECK-SAME: ConstOffset
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.o0.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.offset.needs.legalization.o0.hlsl
@@ -1,0 +1,19 @@
+// Run: %dxc -T ps_6_0 -E main -O0
+
+SamplerState      gSampler  : register(s5);
+Texture2D<float4> t         : register(t1);
+
+// CHECK:      OpImageSparseSampleImplicitLod
+// CHECK-SAME: ConstOffset
+
+float4 sample(int offset, float clamp) {
+    uint status;
+    return t.Sample(gSampler, float2(0.1, 0.2), offset, clamp, status);
+}
+
+float4 main(int2 offset: A) : SV_Target {
+    float4 val = 0;
+    [unroll] for (int i = 0; i < 3; ++i)
+        val = sample(i, offset.x);
+    return val;
+}

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.variable-offset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.variable-offset.hlsl
@@ -2,6 +2,11 @@
 SamplerState      gSampler  : register(s5);
 Texture2D<float4> t         : register(t1);
 
+// This shader uses a variable offset for texture sampling, which is illegal.
+// Since we set needsLegalization as true when we find a variable offset for
+// texture sampling, `--before-legalize-hlsl` option for spirv-val should be
+// enabled because of `-fcgl`. Therefore, it must not generate any errors.
+
 // CHECK:      OpImageSparseSampleImplicitLod
 // CHECK-SAME: Offset
 

--- a/tools/clang/test/CodeGenSPIRV/texture.sample.variable-offset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/texture.sample.variable-offset.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T ps_6_0 -E main
+SamplerState      gSampler  : register(s5);
+Texture2D<float4> t         : register(t1);
+
+// CHECK:      OpImageSparseSampleImplicitLod
+// CHECK-SAME: Offset
+
+float4 sample(int2 offset, float clamp) {
+    uint status;
+    return t.Sample(gSampler, float2(0.1, 0.2), offset, clamp, status);
+}
+
+float4 main(int2 offset: A) : SV_Target {
+    float4 val = 0;
+    for (int i = 0; i < 3; ++i)
+        val = sample(offset, i);
+    return val;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -980,6 +980,28 @@ TEST_F(FileTest, TextureInvalidTex2D) {
 TEST_F(FileTest, TextureSampleOffsetWithLoopUnroll) {
   runFileTest("texture.sample-offset.with.loop-unroll.hlsl");
 }
+TEST_F(FileTest, TextureSampleVariableOffsetBeforeLegalizeHLSL) {
+  // The shader uses a variable offset for texture sampling, which is illegal.
+  // Since we set needsLegalization as true when we find a variable offset for
+  // texture sampling, `--before-legalize-hlsl` option for spirv-val should be
+  // enabled because of `-fcgl` and the compile must not generate any errors.
+  setBeforeHLSLLegalization();
+  runFileTest("texture.sample.variable-offset.hlsl");
+}
+TEST_F(FileTest, TextureSampleOffsetNeedsLegalization) {
+  // The shader uses a variable offset for texture sampling that is supposed to
+  // be converted to a constant value after the legalization. Since we set
+  // needsLegalization as true when we find a variable offset for texture
+  // sampling, `--before-legalize-hlsl` option for spirv-val should be enabled
+  // because of `-fcgl`.
+  setBeforeHLSLLegalization();
+  runFileTest("texture.sample.offset.needs.legalization.hlsl");
+}
+TEST_F(FileTest, TextureSampleConstOffsetAfterLegalization) {
+  // The shader uses a variable offset for texture sampling that is supposed to
+  // be converted to a constant value after the legalization.
+  runFileTest("texture.sample.offset.needs.legalization.o0.hlsl");
+}
 
 // For structured buffer methods
 TEST_F(FileTest, StructuredBufferLoad) {

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -981,25 +981,14 @@ TEST_F(FileTest, TextureSampleOffsetWithLoopUnroll) {
   runFileTest("texture.sample-offset.with.loop-unroll.hlsl");
 }
 TEST_F(FileTest, TextureSampleVariableOffsetBeforeLegalizeHLSL) {
-  // The shader uses a variable offset for texture sampling, which is illegal.
-  // Since we set needsLegalization as true when we find a variable offset for
-  // texture sampling, `--before-legalize-hlsl` option for spirv-val should be
-  // enabled because of `-fcgl` and the compile must not generate any errors.
   setBeforeHLSLLegalization();
   runFileTest("texture.sample.variable-offset.hlsl");
 }
 TEST_F(FileTest, TextureSampleOffsetNeedsLegalization) {
-  // The shader uses a variable offset for texture sampling that is supposed to
-  // be converted to a constant value after the legalization. Since we set
-  // needsLegalization as true when we find a variable offset for texture
-  // sampling, `--before-legalize-hlsl` option for spirv-val should be enabled
-  // because of `-fcgl`.
   setBeforeHLSLLegalization();
   runFileTest("texture.sample.offset.needs.legalization.hlsl");
 }
 TEST_F(FileTest, TextureSampleConstOffsetAfterLegalization) {
-  // The shader uses a variable offset for texture sampling that is supposed to
-  // be converted to a constant value after the legalization.
   runFileTest("texture.sample.offset.needs.legalization.o0.hlsl");
 }
 


### PR DESCRIPTION
When we find a variable offset used for the texture sampling, we have to
- Run legalization if `-fcgl` is not enabled.
- Enable `--before-legalize-hlsl` for spirv-val if `-fcgl` is enabled.
to match the behavior of the DXIL backend.

In order to do that, we set SpirvEmitter::needsLegalization as true when
we find a variable offset used for the texture sampling. SpirvEmitter
will determine enabling `--before-legalize-hlsl` or running the
legalization depending on `-fcgl`.