### PR TITLE
Fix atomics resource declaration issue

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1774,12 +1774,12 @@
     <Resource Name="U1" Dimension="BUFFER" Width="9216"
               Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
               Init="Zero" ReadBack="true" />
-    <Resource Name="U2" Dimension="BUFFER" Width="256"
+    <Resource Name="U2" Dimension="BUFFER" Width="256" Format="R32_TYPELESS"
               Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
               Init="FromBytes" ReadBack="true">
       { 0I, 0I, 99999999I, 99999999I, 0I, 0I, -1I, -1I, 0I, 0I, 0I, 0I, 42I, 42I, 42I, 42I }
     </Resource>
-    <Resource Name="U3" Dimension="BUFFER" Width="1024"
+    <Resource Name="U3" Dimension="BUFFER" Width="1024" Format="R32_TYPELESS"
               Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
               Init="Zero" ReadBack="true" />
     <!-- groupshared output buffers -->
@@ -1852,10 +1852,10 @@
                   NumElements="8" StructureByteStride="72" />
       <Descriptor Name="U1" Kind="UAV" ResName="U1"
                   NumElements="128" StructureByteStride="72" />
-      <Descriptor Name="U2" Kind="UAV" ResName="U2"
-                  NumElements="16" StructureByteStride="8" />
-      <Descriptor Name="U3" Kind="UAV" ResName="U3"
-                  NumElements="128" StructureByteStride="8" />
+      <Descriptor Name="U2" Kind="UAV" ResName="U2" Flags='RAW' Format="R32_TYPELESS"
+                  NumElements="16" StructureByteStride="0" />
+      <Descriptor Name="U3" Kind="UAV" ResName="U3" Flags='RAW' Format="R32_TYPELESS"
+                  NumElements="128" StructureByteStride="0" />
       <!-- groupshared output buffers -->
       <Descriptor Name="U4" Kind="UAV" ResName="U4"
                   NumElements="8" StructureByteStride="8" />
@@ -2322,7 +2322,7 @@
     <Resource Name="U0" Dimension="BUFFER" Width="2816"
               Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
               Init="Zero" ReadBack="true" />
-    <Resource Name="U1" Dimension="BUFFER" Width="256"
+    <Resource Name="U1" Dimension="BUFFER" Width="256" Format="R32_TYPELESS"
               Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
               Init="Zero" ReadBack="true" />
     <Resource Name="U2" Dimension="BUFFER" Width="256"
@@ -2340,8 +2340,8 @@
     <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="U0" Kind="UAV" ResName="U0"
                   NumElements="64" StructureByteStride="44" />
-      <Descriptor Name="U1" Kind="UAV" ResName="U1"
-                  NumElements="64" StructureByteStride="4" />
+      <Descriptor Name="U1" Kind="UAV" ResName="U1" Flags='RAW' Format="R32_TYPELESS"
+                  NumElements="64" StructureByteStride="0" />
       <Descriptor Name="U2" Kind="UAV" ResName="U2"
                   NumElements="64" Format="R32_FLOAT" />
       <Descriptor Name="U3" Kind="UAV" ResName="U3" Dimension="TEXTURE1D"


### PR DESCRIPTION
Resources used as raw RWByteAddressBuffer but created as structured could see conflicting allocation and stride values, resulting in OOB access in some configurations.

Setting the stride to 0 (I like being explicit) and adding the raw/typeless qualifiers, I no longer see OOB accesses.