### PR TITLE
dxexp: add explicit dependency on D3D12 (#3710)

### DIFF
--- a/tools/dxexp/CMakeLists.txt
+++ b/tools/dxexp/CMakeLists.txt
@@ -2,4 +2,11 @@
 # This file is distributed under the University of Illinois Open Source License. See LICENSE.TXT for details.
 add_llvm_tool(dxexp
   dxexp.cpp
-  )
+)
+
+find_package(D3D12 REQUIRED)
+
+target_link_libraries(dxexp
+  ${D3D12_LIBRARIES}
+  dxguid.lib
+)


### PR DESCRIPTION
(cherry picked from commit 88ddd4c978e4c2c3d63a43fd682a56eb428c6829)