### PR TITLE
Add /bigobj flag on big spirvtest object

### DIFF
--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -44,6 +44,10 @@ target_include_directories(clang-spirv-tests
 set_output_directory(clang-spirv-tests
   ${LLVM_RUNTIME_OUTPUT_INTDIR} ${LLVM_LIBRARY_OUTPUT_INTDIR})
 
+if(WIN32)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # otherwise will hit fatal error C1128 on windows x64
+endif(WIN32)
+
 add_test(NAME test-spirv-codegen
   COMMAND clang-spirv-tests --spirv-test-root
           ${PROJECT_SOURCE_DIR}/tools/clang/test/CodeGenSPIRV)


### PR DESCRIPTION
This build was failing on windows debug because recent additions pulled
it over a size threshold. This flag is used elsewhere in the compile
already and works fine here.