### PR TITLE
[spirv] Fix null pointer dereference

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4962,8 +4962,9 @@ SpirvEmitter::doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr) {
 
   auto base = loadIfAliasVarRef(baseExpr);
 
-  if (indices.empty())
-    return base; // For indexing into size-1 vectors and 1xN matrices
+  if (base == nullptr ||
+      indices.empty()) // For indexing into size-1 vectors and 1xN matrices
+    return base;
 
   // If we are indexing into a rvalue, to use OpAccessChain, we first need
   // to create a local variable to hold the rvalue.

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.hlsl
@@ -1,0 +1,25 @@
+// Run: %dxc -T ps_6_1 -E main
+
+struct PSInput {
+  float4 position : SV_POSITION;
+  nointerpolation float3 color : COLOR;
+};
+
+cbuffer constants : register(b0) {
+  float4 g_constants;
+}
+
+float4 main(PSInput input) : SV_TARGET {
+  uint cmp = (uint)(g_constants[0]);
+
+  // CHECK: 16:21: error: GetAttributeAtVertex intrinsic function unimplemented
+  float colorAtV0 = GetAttributeAtVertex(input.color, 0)[cmp];
+
+  // CHECK: 19:21: error: GetAttributeAtVertex intrinsic function unimplemented
+  float colorAtV1 = GetAttributeAtVertex(input.color, 1)[cmp];
+
+  // CHECK: 22:21: error: GetAttributeAtVertex intrinsic function unimplemented
+  float colorAtV2 = GetAttributeAtVertex(input.color, 2)[cmp];
+
+  return float4(colorAtV0, colorAtV1, colorAtV2, 0);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1287,6 +1287,9 @@ TEST_F(FileTest, IntrinsicsNonUniformResourceIndex) {
 TEST_F(FileTest, IntrinsicsMultiPrefix) {
   runFileTest("intrinsics.multiprefix.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, IntrinsicsGetAttributeAtVertex) {
+  runFileTest("intrinsics.get-attribute-at-vertex.hlsl", Expect::Failure);
+}
 
 // Vulkan-specific intrinsic functions
 TEST_F(FileTest, IntrinsicsVkCrossDeviceScope) {


### PR DESCRIPTION
Fix a null pointer dereference which can occur when an unimplemented
intrinsic is used. The repro shader from issue #2955 (added as a unit
test) now fails with a useful message rather than a silent crash.