### PR TITLE
[spirv] Add null check to binary op processing

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -5794,6 +5794,9 @@ SpirvInstruction *SpirvEmitter::processBinaryOp(
   case BO_OrAssign:
   case BO_XorAssign: {
 
+    if (lhsVal == nullptr || rhsVal == nullptr)
+      return nullptr;
+
     // To evaluate this expression as an OpSpecConstantOp, we need to make sure
     // both operands are constant and at least one of them is a spec constant.
     if (SpirvConstant *lhsValConstant = dyn_cast<SpirvConstant>(lhsVal)) {

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot4add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot4add.hlsl
@@ -1,0 +1,23 @@
+// Run: %dxc -E frag -T ps_6_4 -fspv-target-env=vulkan1.1
+
+uint frag(float4 vertex
+          : SV_POSITION) : SV_Target {
+  uint acc = 0;
+
+  // CHECK: 8:14: error: dot4add_u8packed intrinsic function unimplemented
+  acc += 1 + dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y));
+
+  // CHECK: 11:14: error: dot4add_i8packed intrinsic function unimplemented
+  acc += 2 + dot4add_i8packed(vertex.z, vertex.w, int(vertex.x));
+
+  // CHECK: 14:10: error: dot4add_u8packed intrinsic function unimplemented
+  acc += dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y)) + 1;
+
+  // CHECK: 17:13: error: dot4add_u8packed intrinsic function unimplemented
+  acc = 1 + dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y));
+
+  // CHECK: 20:9: error: dot4add_u8packed intrinsic function unimplemented
+  acc = dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y)) + 1;
+
+  return acc;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1290,6 +1290,9 @@ TEST_F(FileTest, IntrinsicsMultiPrefix) {
 TEST_F(FileTest, IntrinsicsGetAttributeAtVertex) {
   runFileTest("intrinsics.get-attribute-at-vertex.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, IntrinsicsDot4Add) {
+  runFileTest("intrinsics.dot4add.hlsl", Expect::Failure);
+}
 
 // Vulkan-specific intrinsic functions
 TEST_F(FileTest, IntrinsicsVkCrossDeviceScope) {


### PR DESCRIPTION
The repro shader from issue #2953 now fails with a useful error message
and has been added as a unit test.