### PR TITLE
Amend hctdb_instrhelp.py for case-sensitive filesystems

### DIFF
--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -1463,10 +1463,10 @@ if __name__ == "__main__":
         pj = lambda *parts: os.path.abspath(os.path.join(*parts))
         files = [
             'docs/DXIL.rst',
-            'lib/DXIL/DXILOperations.cpp',
-            'lib/DXIL/DXILShaderModel.cpp',
-            'include/dxc/DXIL/DXILConstants.h',
-            'include/dxc/DXIL/DXILShaderModel.h',
+            'lib/DXIL/DxilOperations.cpp',
+            'lib/DXIL/DxilShaderModel.cpp',
+            'include/dxc/DXIL/DxilConstants.h',
+            'include/dxc/DXIL/DxilShaderModel.h',
             'include/dxc/HLSL/DxilValidation.h',
             'include/dxc/Support/HLSLOptions.td',
             'include/dxc/DXIL/DxilInstructions.h',


### PR DESCRIPTION
Trivial changes to the case of some file names used by hctdb_instrhelp.py
to match the actual case of the files in the repo. This fixes problems
experienced when using the script on Linux.