### PR TITLE
Warns when semantic name same as identifier.

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/tools/clang/include/clang/Basic/DiagnosticGroups.td
@@ -797,4 +797,5 @@ def HLSLPayloadAccessQualifer: DiagGroup<"payload-access-qualifier", [
      HLSLPayloadAccessQualiferPerf,
      HLSLPayloadAccessQualiferCall
   ]>;
+def HLSLSemanticIdentifierCollision : DiagGroup<"semantic-identifier-collision">;
 // HLSL Change Ends

--- a/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticParseKinds.td
@@ -1022,6 +1022,9 @@ def warn_hlsl_effect_state_block : Warning <
 def warn_hlsl_effect_technique : Warning <
   "effect technique ignored - effect syntax is deprecated">,
   InGroup< HLSLEffectsSyntax >;
+def warn_hlsl_semantic_identifier_collision : Warning <
+  "'%0' interpreted as semantic; previous definition(s) ignored">,
+  InGroup< HLSLSemanticIdentifierCollision >;
 def err_hlsl_enum : Error<
   "enum is unsupported in HLSL before 2017">;
 

--- a/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
@@ -499,7 +499,7 @@ my_label: local_i = 1; // expected-error {{label is unsupported in HLSL}}
   // for without initialization
   for (int j;;) { break; }
   // ranged for is disallowed
-  for (int n : local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected ';' in 'for' statement specifier}} expected-error {{semantic is not a valid modifier for a local variable}}
+  for (int n : local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected ';' in 'for' statement specifier}} expected-warning {{'local_i' interpreted as semantic; previous definition(s) ignored}} expected-error {{semantic is not a valid modifier for a local variable}}
     break;
   }
   for (int n_again in local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected unqualified-id}} expected-error {{unknown type name 'local_i'}} expected-error {{variable declaration in condition must have an initializer}}

--- a/tools/clang/test/HLSL/cpp-errors.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors.hlsl
@@ -495,7 +495,7 @@ my_label: local_i = 1; // expected-error {{label is unsupported in HLSL}}
   // for without initialization
   for (int j;;) { break; }
   // ranged for is disallowed
-  for (int n : local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected ';' in 'for' statement specifier}} expected-error {{semantic is not a valid modifier for a local variable}}
+  for (int n : local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected ';' in 'for' statement specifier}} expected-warning {{'local_i' interpreted as semantic; previous definition(s) ignored}} expected-error {{semantic is not a valid modifier for a local variable}}
     break;
   }
   for (int n_again in local_i) { // expected-error {{expected ';' in 'for' statement specifier}} expected-error {{expected unqualified-id}} expected-error {{unknown type name 'local_i'}} expected-error {{variable declaration in condition must have an initializer}}


### PR DESCRIPTION
Intent is to avoid confusion where C++ syntax would allow named constant as bitfield width, which is disallowed in HLSL because of conflict with syntax for semantics.