### PR TITLE
[spirv] support clip/cull distance stage vars with array types

### DIFF
--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -664,7 +664,11 @@ void GlPerVertex::writeClipCullArrayFromType(
   }
 
   // Writing to an array only happens in HSCPOut or MSOut.
-  assert(spvContext.isHS() || spvContext.isMS());
+  if (!spvContext.isHS() && !spvContext.isMS()) {
+    llvm_unreachable("Writing to clip/cull distance in hull/mesh shader is "
+                     "not allowed");
+  }
+
   // And we are only writing to the array element with InvocationId as index.
   assert(invocationId.hasValue());
 

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -130,8 +130,9 @@ private:
   bool doGlPerVertexFacts(const DeclaratorDecl *decl, QualType type,
                           bool asInput);
 
-  /// Returns whether the type is a scalar, vector, or array only with floats.
-  bool isArrayVectorOrScalarOnlyWithFloats(QualType type) const;
+  /// Returns whether the type is a scalar, vector, or array that contains
+  /// only scalars with float type.
+  bool containOnlyFloatType(QualType type) const;
 
   /// Returns the number of all scalar components recursively included in a
   /// scalar, vector, or array type. If type is not a scalar, vector, or array,

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -130,6 +130,9 @@ private:
   bool doGlPerVertexFacts(const DeclaratorDecl *decl, QualType type,
                           bool asInput);
 
+  /// Returns whether the type is a scalar, vector, or array only with floats.
+  bool isArrayVectorOrScalarOnlyWithFloats(QualType type) const;
+
   /// Returns the number of all scalar components recursively included in a
   /// scalar, vector, or array type. If type is not a scalar, vector, or array,
   /// returns 0.

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -87,6 +87,9 @@ public:
                    SpirvInstruction *vecComponent, SourceLocation loc);
 
 private:
+  using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
+  using SemanticIndexToArrayOffsetMap = llvm::DenseMap<uint32_t, uint32_t>;
+
   template <unsigned N>
   DiagnosticBuilder emitError(const char (&message)[N], SourceLocation loc) {
     const auto diagId = astContext.getDiagnostics().getCustomDiagID(
@@ -171,10 +174,14 @@ private:
       SpirvInstruction *offset, SourceLocation loc,
       llvm::Optional<SpirvInstruction *> arrayIndex = llvm::None) const;
 
-private:
-  using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
-  using SemanticIndexToArrayOffsetMap = llvm::DenseMap<uint32_t, uint32_t>;
+  /// Keeps the mapping semanticIndex to clipCullDistanceType in typeMap and
+  /// returns true if clipCullDistanceType is a valid type for clip/cull
+  /// distance. Otherwise, returns false.
+  bool setClipCullDistanceType(SemanticIndexToTypeMap *typeMap,
+                               uint32_t semanticIndex,
+                               QualType clipCullDistanceType) const;
 
+private:
   ASTContext &astContext;
   SpirvContext &spvContext;
   SpirvBuilder &spvBuilder;

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -158,7 +158,7 @@ private:
   bool createScalarClipCullDistanceStore(
       SpirvInstruction *ptr, SpirvInstruction *value, QualType valueType,
       SpirvInstruction *offset, SourceLocation loc,
-      llvm::Optional<uint32_t> valueOffset,
+      llvm::ArrayRef<uint32_t> valueIndices,
       llvm::Optional<SpirvInstruction *> arrayIndex = llvm::None) const;
   /// Creates store instruction for clip or cull distance with a scalar or
   /// vector type.

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -127,6 +127,11 @@ private:
   bool doGlPerVertexFacts(const DeclaratorDecl *decl, QualType type,
                           bool asInput);
 
+  /// Returns the number of all scalar components recursively included in a
+  /// scalar, vector, or array type. If type is not a scalar, vector, or array,
+  /// returns 0.
+  uint32_t getNumberOfScalarComponentsInScalarVectorArray(QualType type) const;
+
 private:
   using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
   using SemanticIndexToArrayOffsetMap = llvm::DenseMap<uint32_t, uint32_t>;

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -144,7 +144,6 @@ private:
   /// type.
   SpirvInstruction *createScalarOrVectorClipCullDistanceLoad(
       SpirvInstruction *ptr, QualType asType, uint32_t offset,
-      llvm::SmallVector<SpirvInstruction *, 4> *loadsForComponents,
       SourceLocation loc,
       llvm::Optional<uint32_t> arrayIndex = llvm::None) const;
   /// Creates load instruction for clip or cull distance with a scalar or vector

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -132,6 +132,25 @@ private:
   /// returns 0.
   uint32_t getNumberOfScalarComponentsInScalarVectorArray(QualType type) const;
 
+  /// Creates load instruction for clip or cull distance with a scalar type.
+  SpirvInstruction *createScalarClipCullDistanceLoad(
+      SpirvInstruction *ptr, QualType asType, uint32_t offset,
+      SourceLocation loc,
+      llvm::Optional<uint32_t> arrayIndex = llvm::None) const;
+  /// Creates load instruction for clip or cull distance with a scalar or vector
+  /// type.
+  SpirvInstruction *createScalarOrVectorClipCullDistanceLoad(
+      SpirvInstruction *ptr, QualType asType, uint32_t offset,
+      llvm::SmallVector<SpirvInstruction *, 4> *loadsForComponents,
+      SourceLocation loc,
+      llvm::Optional<uint32_t> arrayIndex = llvm::None) const;
+  /// Creates load instruction for clip or cull distance with a scalar or vector
+  /// or array type of them.
+  SpirvInstruction *createClipCullDistanceLoad(
+      SpirvInstruction *ptr, QualType asType, uint32_t offset,
+      SourceLocation loc,
+      llvm::Optional<uint32_t> arrayIndex = llvm::None) const;
+
 private:
   using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
   using SemanticIndexToArrayOffsetMap = llvm::DenseMap<uint32_t, uint32_t>;

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -151,6 +151,26 @@ private:
       SourceLocation loc,
       llvm::Optional<uint32_t> arrayIndex = llvm::None) const;
 
+  /// Creates store instruction for clip or cull distance with a scalar type.
+  bool createScalarClipCullDistanceStore(
+      SpirvInstruction *ptr, SpirvInstruction *value, QualType valueType,
+      SpirvInstruction *offset, SourceLocation loc,
+      llvm::Optional<uint32_t> valueOffset,
+      llvm::Optional<SpirvInstruction *> arrayIndex = llvm::None) const;
+  /// Creates store instruction for clip or cull distance with a scalar or
+  /// vector type.
+  bool createScalarOrVectorClipCullDistanceStore(
+      SpirvInstruction *ptr, SpirvInstruction *value, QualType valueType,
+      SpirvInstruction *offset, SourceLocation loc,
+      llvm::Optional<uint32_t> valueOffset,
+      llvm::Optional<SpirvInstruction *> arrayIndex = llvm::None) const;
+  /// Creates store instruction for clip or cull distance with a scalar or
+  /// vector or array type of them.
+  bool createClipCullDistanceStore(
+      SpirvInstruction *ptr, SpirvInstruction *value, QualType valueType,
+      SpirvInstruction *offset, SourceLocation loc,
+      llvm::Optional<SpirvInstruction *> arrayIndex = llvm::None) const;
+
 private:
   using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
   using SemanticIndexToArrayOffsetMap = llvm::DenseMap<uint32_t, uint32_t>;

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.array.sv_clipdistance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.array.sv_clipdistance.hlsl
@@ -1,0 +1,42 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct PSInput
+{
+    float4 color[2] : SV_ClipDistance;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+// CHECK:  [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0
+// CHECK: [[load0:%\d+]] = OpLoad %float [[ptr0]]
+
+// CHECK:  [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1
+// CHECK: [[load1:%\d+]] = OpLoad %float [[ptr1]]
+
+// CHECK:  [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_2
+// CHECK: [[load2:%\d+]] = OpLoad %float [[ptr2]]
+
+// CHECK:  [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_3
+// CHECK: [[load3:%\d+]] = OpLoad %float [[ptr3]]
+
+// CHECK: [[vec0:%\d+]] = OpCompositeConstruct %v4float [[load0]] [[load1]] [[load2]] [[load3]]
+
+// CHECK:  [[ptr4:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_4
+// CHECK: [[load4:%\d+]] = OpLoad %float [[ptr4]]
+
+// CHECK:  [[ptr5:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_5
+// CHECK: [[load5:%\d+]] = OpLoad %float [[ptr5]]
+
+// CHECK:  [[ptr6:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_6
+// CHECK: [[load6:%\d+]] = OpLoad %float [[ptr6]]
+
+// CHECK:  [[ptr7:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_7
+// CHECK: [[load7:%\d+]] = OpLoad %float [[ptr7]]
+
+// CHECK: [[vec1:%\d+]] = OpCompositeConstruct %v4float [[load4]] [[load5]] [[load6]] [[load7]]
+
+// CHECK: [[array:%\d+]] = OpCompositeConstruct %_arr_v4float_uint_2 [[vec0]] [[vec1]]
+// CHECK:                  OpCompositeConstruct %PSInput [[array]]
+
+    return input.color[0];
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.multiple.array.sv_clipdistance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.multiple.array.sv_clipdistance.hlsl
@@ -1,0 +1,71 @@
+// Run: %dxc -T ps_6_0 -E main
+
+struct PSInput
+{
+    float2 foo[4] : SV_ClipDistance0;
+    float3 bar[2] : SV_ClipDistance1;
+};
+
+float4 main(PSInput input) : SV_TARGET
+{
+// CHECK:  [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0
+// CHECK: [[load0:%\d+]] = OpLoad %float [[ptr0]]
+
+// CHECK:  [[ptr1:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_1
+// CHECK: [[load1:%\d+]] = OpLoad %float [[ptr1]]
+
+// CHECK: [[vec0:%\d+]] = OpCompositeConstruct %v2float [[load0]] [[load1]]
+
+// CHECK:  [[ptr2:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_2
+// CHECK: [[load2:%\d+]] = OpLoad %float [[ptr2]]
+
+// CHECK:  [[ptr3:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_3
+// CHECK: [[load3:%\d+]] = OpLoad %float [[ptr3]]
+
+// CHECK: [[vec1:%\d+]] = OpCompositeConstruct %v2float [[load2]] [[load3]]
+
+// CHECK:  [[ptr4:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_4
+// CHECK: [[load4:%\d+]] = OpLoad %float [[ptr4]]
+
+// CHECK:  [[ptr5:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_5
+// CHECK: [[load5:%\d+]] = OpLoad %float [[ptr5]]
+
+// CHECK: [[vec2:%\d+]] = OpCompositeConstruct %v2float [[load4]] [[load5]]
+
+// CHECK:  [[ptr6:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_6
+// CHECK: [[load6:%\d+]] = OpLoad %float [[ptr6]]
+
+// CHECK:  [[ptr7:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_7
+// CHECK: [[load7:%\d+]] = OpLoad %float [[ptr7]]
+
+// CHECK:   [[vec3:%\d+]] = OpCompositeConstruct %v2float [[load6]] [[load7]]
+// CHECK: [[array0:%\d+]] = OpCompositeConstruct %_arr_v2float_uint_4 [[vec0]] [[vec1]] [[vec2]] [[vec3]]
+
+// CHECK:  [[ptr8:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_8
+// CHECK: [[load8:%\d+]] = OpLoad %float [[ptr8]]
+
+// CHECK:  [[ptr9:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_9
+// CHECK: [[load9:%\d+]] = OpLoad %float [[ptr9]]
+
+// CHECK:  [[ptr10:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_10
+// CHECK: [[load10:%\d+]] = OpLoad %float [[ptr10]]
+
+// CHECK: [[vec0:%\d+]] = OpCompositeConstruct %v3float [[load8]] [[load9]] [[load10]]
+
+// CHECK:  [[ptr11:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_11
+// CHECK: [[load11:%\d+]] = OpLoad %float [[ptr11]]
+
+// CHECK:  [[ptr12:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_12
+// CHECK: [[load12:%\d+]] = OpLoad %float [[ptr12]]
+
+// CHECK:  [[ptr13:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_13
+// CHECK: [[load13:%\d+]] = OpLoad %float [[ptr13]]
+
+// CHECK:   [[vec1:%\d+]] = OpCompositeConstruct %v3float [[load11]] [[load12]] [[load13]]
+// CHECK: [[array1:%\d+]] = OpCompositeConstruct %_arr_v3float_uint_2 [[vec0]] [[vec1]]
+
+// CHECK:                   OpCompositeConstruct %PSInput [[array0]] [[array1]]
+
+    float4 result = {input.foo[0], input.bar[1].yz};
+    return result;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.array.sv_clipdistance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.array.sv_clipdistance.hlsl
@@ -1,0 +1,58 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct VS_OUTPUT {
+    float4 clips[2] : SV_ClipDistance;
+};
+
+// CHECK:       %VS_OUTPUT = OpTypeStruct %_arr_v4float_uint_2
+// CHECK: %gl_ClipDistance = OpVariable %_ptr_Output__arr_float_uint_8 Output
+
+VS_OUTPUT main() {
+// CHECK: [[VS_OUTPUT:%\d+]] = OpFunctionCall %VS_OUTPUT %src_main
+
+// CHECK:  [[clips:%\d+]] = OpCompositeExtract %_arr_v4float_uint_2 [[VS_OUTPUT]] 0
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_0
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 0 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 0 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_2
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 0 2
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_3
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 0 3
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_4
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 1 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 1 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_2
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 1 2
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_3
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[clips]] 1 3
+// CHECK:                   OpStore [[ptr]] [[value]]
+    return (VS_OUTPUT) 0;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.clip_distance.type.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.clip_distance.type.error.hlsl
@@ -1,0 +1,12 @@
+// Run: %dxc -T vs_6_0 -E main
+
+// CHECK: error: elements for SV_ClipDistance variable 'foo' must be scalar, vector, or array with floats
+
+struct VS_OUTPUT {
+    int3 foo[2] : SV_ClipDistance0;
+    float4 bar[2] : SV_ClipDistance1;
+};
+
+VS_OUTPUT main() {
+    return (VS_OUTPUT) 0;
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.clip_distance.type.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.clip_distance.type.error.hlsl
@@ -1,6 +1,6 @@
 // Run: %dxc -T vs_6_0 -E main
 
-// CHECK: error: elements for SV_ClipDistance variable 'foo' must be scalar, vector, or array with floats
+// CHECK: error: elements for SV_ClipDistance variable 'foo' must be scalar, vector, or array with float type
 
 struct VS_OUTPUT {
     int3 foo[2] : SV_ClipDistance0;

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.multiple.array.sv_clipdistance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.vs.multiple.array.sv_clipdistance.hlsl
@@ -1,0 +1,97 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct VS_OUTPUT {
+    float2 foo[4] : SV_ClipDistance0;
+    float3 bar[2] : SV_ClipDistance1;
+};
+
+// CHECK:       %VS_OUTPUT = OpTypeStruct %_arr_v2float_uint_4 %_arr_v3float_uint_2
+// CHECK: %gl_ClipDistance = OpVariable %_ptr_Output__arr_float_uint_14 Output
+
+VS_OUTPUT main() {
+// CHECK: [[VS_OUTPUT:%\d+]] = OpFunctionCall %VS_OUTPUT %src_main
+
+// CHECK:  [[foo:%\d+]] = OpCompositeExtract %_arr_v2float_uint_4 [[VS_OUTPUT]] 0
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_0
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 0 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 0 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_2
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 1 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 1 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_4
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 2 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 2 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_0 %uint_6
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 3 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[foo]] 3 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK:  [[bar:%\d+]] = OpCompositeExtract %_arr_v3float_uint_2 [[VS_OUTPUT]] 1
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_8 %uint_0
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 0 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 0 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_2
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 0 2
+
+// CHECK: [[offset_base:%\d+]] = OpIAdd %uint %uint_8 %uint_3
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_0
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 1 0
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_1
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 1 1
+// CHECK:                   OpStore [[ptr]] [[value]]
+
+// CHECK: [[offset:%\d+]] = OpIAdd %uint [[offset_base]] %uint_2
+// CHECK:    [[ptr:%\d+]] = OpAccessChain %_ptr_Output_float %gl_ClipDistance [[offset]]
+// CHECK:  [[value:%\d+]] = OpCompositeExtract %float [[bar]] 1 2
+
+    return (VS_OUTPUT) 0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1589,6 +1589,16 @@ TEST_F(FileTest, SpirvStageIOInterfaceVSArraySVClipDistance) {
 TEST_F(FileTest, SpirvStageIOInterfacePSArraySVClipDistance) {
   runFileTest("spirv.interface.ps.array.sv_clipdistance.hlsl");
 }
+TEST_F(FileTest, SpirvStageIOInterfaceVSMultipleArraySVClipDistance) {
+  runFileTest("spirv.interface.vs.multiple.array.sv_clipdistance.hlsl");
+}
+TEST_F(FileTest, SpirvStageIOInterfacePSMultipleArraySVClipDistance) {
+  runFileTest("spirv.interface.ps.multiple.array.sv_clipdistance.hlsl");
+}
+TEST_F(FileTest, SpirvStageIOInterfaceVSClipDistanceInvalidType) {
+  runFileTest("spirv.interface.vs.clip_distance.type.error.hlsl",
+              Expect::Failure);
+}
 
 TEST_F(FileTest, SpirvStageIOAliasBuiltIn) {
   runFileTest("spirv.interface.alias-builtin.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1583,6 +1583,10 @@ TEST_F(FileTest, SpirvStageIOInterfacePS) {
   runFileTest("spirv.interface.ps.hlsl");
 }
 
+TEST_F(FileTest, SpirvStageIOInterfaceVSArraySVClipDistance) {
+  runFileTest("spirv.interface.vs.array.sv_clipdistance.hlsl");
+}
+
 TEST_F(FileTest, SpirvStageIOAliasBuiltIn) {
   runFileTest("spirv.interface.alias-builtin.hlsl");
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1586,6 +1586,9 @@ TEST_F(FileTest, SpirvStageIOInterfacePS) {
 TEST_F(FileTest, SpirvStageIOInterfaceVSArraySVClipDistance) {
   runFileTest("spirv.interface.vs.array.sv_clipdistance.hlsl");
 }
+TEST_F(FileTest, SpirvStageIOInterfacePSArraySVClipDistance) {
+  runFileTest("spirv.interface.ps.array.sv_clipdistance.hlsl");
+}
 
 TEST_F(FileTest, SpirvStageIOAliasBuiltIn) {
   runFileTest("spirv.interface.alias-builtin.hlsl");


### PR DESCRIPTION
`GlPerVertex` class mainly handles clip/cull distance stage variable.

This change entirely refactors methods of `GlPerVertex` class to
improve the code readability. Mainly it splits each method handling
multiple cases within a single method/loop into multiple methods.

In addition, this change adds the code to support  clip/cull distance
stage vars with array types.

Fixes #3278