### PR TITLE
[spirv] support unittests with inlined HLSL code

### DIFF
--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2727,4 +2727,36 @@ TEST_F(FileTest, RichDebugInfoTypeStructuredBuffer) {
               /*runValidation*/ false);
 }
 
+TEST_F(FileTest, InlinedCodeTest) {
+  const std::string command(R"(// Run: %dxc -T ps_6_0 -E PSMain)");
+  const std::string code = command + R"(
+struct PSInput
+{
+        float4 color : COLOR;
+};
+
+// CHECK: OpFunctionCall %v4float %src_PSMain
+float4 PSMain(PSInput input) : SV_TARGET
+{
+        return input.color;
+})";
+  runCodeTest(code);
+}
+
+TEST_F(FileTest, InlinedCodeWithErrorTest) {
+  const std::string command(R"(// Run: %dxc -T ps_6_0 -E PSMain)");
+  const std::string code = command + R"(
+struct PSInput
+{
+        float4 color : COLOR;
+};
+
+// CHECK: error: cannot initialize return object of type 'float4' with an lvalue of type 'PSInput'
+float4 PSMain(PSInput input) : SV_TARGET
+{
+        return input;
+})";
+  runCodeTest(code, Expect::Failure);
+}
+
 } // namespace

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -18,7 +18,6 @@ namespace clang {
 namespace spirv {
 
 bool FileTest::parseInputFile() {
-  const char hlslStartLabel[] = "// Run:";
   std::stringstream inputSS;
   std::ifstream inputFile;
   inputFile.exceptions(std::ifstream::failbit);
@@ -36,12 +35,15 @@ bool FileTest::parseInputFile() {
 
   // Close the input file.
   inputFile.close();
+  checkCommands = inputSS.str();
+  return parseCommand();
+}
 
+bool FileTest::parseCommand() {
   // Effcee skips any input line which doesn't have a CHECK directive, therefore
   // we can pass the entire input to effcee. This way, any warning/error message
   // provided by effcee also reflects the correct line number in the input file.
-  checkCommands = inputSS.str();
-
+  const char hlslStartLabel[] = "// Run:";
   const auto runCmdStartPos = checkCommands.find(hlslStartLabel);
   if (runCmdStartPos != std::string::npos) {
     const auto runCmdEndPos = checkCommands.find('\n', runCmdStartPos);
@@ -70,13 +72,38 @@ void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
   // Parse the input file.
   ASSERT_TRUE(parseInputFile());
 
-  std::string errorMessages;
-
   // Feed the HLSL source into the Compiler.
-  const bool compileOk = utils::runCompilerWithSpirvGeneration(
+  std::string errorMessages;
+  const bool compileOk = utils::compileFileWithSpirvGeneration(
       inputFilePath, entryPoint, targetProfile, restArgs, &generatedBinary,
       &errorMessages);
 
+  checkTestResult(filename, compileOk, errorMessages, expect, runValidation);
+}
+
+void FileTest::runCodeTest(llvm::StringRef code, Expect expect,
+                           bool runValidation) {
+  if (beforeHLSLLegalization)
+    assert(runValidation);
+
+  inputFilePath = "(Inlined HLSL code)";
+
+  checkCommands = code;
+  ASSERT_TRUE(parseCommand());
+
+  // Feed the HLSL source into the Compiler.
+  std::string errorMessages;
+  const bool compileOk = utils::compileCodeWithSpirvGeneration(
+      inputFilePath, code, entryPoint, targetProfile, restArgs,
+      &generatedBinary, &errorMessages);
+
+  checkTestResult(inputFilePath, compileOk, errorMessages, expect,
+                  runValidation);
+}
+
+void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
+                               const std::string &errorMessages, Expect expect,
+                               bool runValidation) {
   effcee::Result result(effcee::Result::Status::Ok);
 
   if (expect == Expect::Success) {

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -36,13 +36,34 @@ public:
   void setDxLayout() { dxLayout = true; }
   void setScalarLayout() { scalarLayout = true; }
 
-  /// \brief Runs a File Test! (See class description for more info)
+  /// \brief Runs a test with the given input HLSL file.
+  ///
+  /// The first line of HLSL code must start with "// Run:" and following DXC
+  /// arguments to run the test. Next lines must be proper HLSL code for the
+  /// test. It uses file check style output check e.g., "// CHECK: ...".
   void runFileTest(llvm::StringRef path, Expect expect = Expect::Success,
                    bool runValidation = true);
 
+  /// \brief Runs a test with the given HLSL code.
+  ///
+  /// The first line of code must start with "// Run:" and following DXC
+  /// arguments to run the test. Next lines must be proper HLSL code for the
+  /// test. It uses file check style output check e.g., "// CHECK: ...".
+  void runCodeTest(llvm::StringRef code, Expect expect = Expect::Success,
+                   bool runValidation = true);
+
 private:
-  /// \brief Reads in the given input file.
+  /// \brief Reads in the given input file and parses the command to get
+  /// arguments to run DXC.
   bool parseInputFile();
+  /// \brief Parses the command and gets arguments to run DXC.
+  bool parseCommand();
+  /// \brief Checks the compile result. Reports whether the expected compile
+  /// result matches the actual result and  whether the expected validation
+  /// result matches the actual one or not.
+  void checkTestResult(llvm::StringRef filename, const bool compileOk,
+                       const std::string &errorMessages, Expect expect,
+                       bool runValidation);
 
   std::string targetProfile;             ///< Target profile (argument of -T)
   std::string entryPoint;                ///< Entry point name (argument of -E)

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -59,12 +59,42 @@ std::string getAbsPathOfInputDataFile(const llvm::StringRef filename);
 /// Returns the generated SPIR-V binary via 'generatedBinary' argument.
 /// Returns true on success, and false on failure. Writes error messages to
 /// errorMessages and stderr on failure.
-bool runCompilerWithSpirvGeneration(const llvm::StringRef inputFilePath,
+bool compileFileWithSpirvGeneration(const llvm::StringRef inputFilePath,
                                     const llvm::StringRef entryPoint,
                                     const llvm::StringRef targetProfile,
                                     const std::vector<std::string> &restArgs,
                                     std::vector<uint32_t> *generatedBinary,
                                     std::string *errorMessages);
+
+/// \brief Passes the string HLSL code to the DXC compiler with SPIR-V CodeGen.
+/// Returns the generated SPIR-V binary via 'generatedBinary' argument.
+/// Returns true on success, and false on failure. Writes error messages to
+/// errorMessages and stderr on failure.
+bool compileCodeWithSpirvGeneration(const llvm::StringRef inputFilePath,
+                                    const llvm::StringRef code,
+                                    const llvm::StringRef entryPoint,
+                                    const llvm::StringRef targetProfile,
+                                    const std::vector<std::string> &restArgs,
+                                    std::vector<uint32_t> *generatedBinary,
+                                    std::string *errorMessages);
+
+/// \brief A struct to keep the input file path and HLSL code information.
+struct SourceCodeInfo {
+  const llvm::StringRef inputFilePath;
+  const llvm::StringRef code;
+};
+
+/// \brief Passes the HLSL source information to the DXC compiler with SPIR-V
+/// CodeGen. Returns the generated SPIR-V binary via 'generatedBinary' argument.
+/// Returns true on success, and false on failure. Writes error messages to
+/// errorMessages and stderr on failure. If srcInfo.code is an empty string, it
+/// reads the HLSL input from srcInfo.inputFilePath file.
+bool compileWithSpirvGeneration(const SourceCodeInfo &srcInfo,
+                                const llvm::StringRef entryPoint,
+                                const llvm::StringRef targetProfile,
+                                const std::vector<std::string> &restArgs,
+                                std::vector<uint32_t> *generatedBinary,
+                                std::string *errorMessages);
 
 } // end namespace utils
 } // end namespace spirv

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
@@ -94,7 +94,7 @@ void WholeFileTest::runWholeFileTest(llvm::StringRef filename,
   std::string errorMessages;
 
   // Feed the HLSL source into the Compiler.
-  ASSERT_TRUE(utils::runCompilerWithSpirvGeneration(
+  ASSERT_TRUE(utils::compileFileWithSpirvGeneration(
       inputFilePath, entryPoint, targetProfile, restArgs, &generatedBinary,
       &errorMessages));
 


### PR DESCRIPTION
So far we added SPIR-V unittests only with separate HLSL source code
file. To add unittests in a scalable and flexible way, this commit
supports unittests with inlined HLSL code.