### PR TITLE
Add windows builds to azdo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,53 +1,112 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 resources:
 - repo: self
 
 stages:
 - stage: Build
   jobs:
-  - job: Linux
+  - job: Windows
     timeoutInMinutes: 90
 
     pool:
-      vmImage: Ubuntu-18.04
+      vmImage: windows-2019
+
+    variables:
+      HLSL_SRC_DIR: '$(Build.SourcesDirectory)'
+      HLSL_BLD_DIR: '$(Agent.BuildDirectory)'
+      platform: x64
 
     strategy:
       matrix:
-        Clang_Release:
+        VS2019_Release:
          configuration: Release
-         CC: clang
-         CXX: clang++
-         CXX_FLAGS: -Werror
-        Clang_Debug:
+        VS2019_Debug:
          configuration: Debug
-         CC: clang
-         CXX: clang++
-         CXX_FLAGS: -Werror
-        Gcc_Release:
+
+    steps:
+    - script: git submodule update --init
+      displayName: 'Updating submodules'
+    - script: |
+        call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+        call utils\hct\hctbuild.cmd -$(platform) -$(configuration) -show-cmake-log -spirvtest
+      displayName: 'Building'
+    - script: |
+        call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+        call utils\hct\hcttest.cmd -$(configuration) noexec
+      displayName: 'DXIL Tests'
+    - script: |
+        call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
+        call utils\hct\hcttest.cmd -$(configuration) spirv_only
+      displayName: 'SPIRV Tests'
+
+  - job: Nix
+    timeoutInMinutes: 90
+
+    variables:
+      macOS: macOS-10.14
+      linux: Ubuntu-18.04
+
+    strategy:
+      matrix:
+        Linux_Clang_Release:
+          image: ${{ variables.linux }}
+          configuration: Release
+          CC: clang
+          CXX: clang++
+          CXX_FLAGS: -Werror
+          OS: Linux
+        Linux_Clang_Debug:
+          image: ${{ variables.linux }}
+          configuration: Debug
+          CC: clang
+          CXX: clang++
+          CXX_FLAGS: -Werror
+        Linux_Gcc_Release:
+          image: ${{ variables.linux }}
           configuration: Release
           CC: gcc-7
           CXX: g++-7
           CXX_FLAGS:
-        Gcc_Debug:
+        Linux_Gcc_Debug:
+          image: ${{ variables.linux }}
           configuration: Debug
           CC: gcc-7
           CXX: g++-7
           CXX_FLAGS:
+        MacOS_Clang_Release:
+          image: ${{ variables.macOS }}
+          configuration: Release
+          CC: clang
+          CXX: clang++
+          CXX_FLAGS: -Werror
+          OS: MacOS
+        MacOS_Clang_Debug:
+          image: ${{ variables.macOS }}
+          configuration: Debug
+          CC: clang
+          CXX: clang++
+          CXX_FLAGS: -Werror
+
+    pool:
+      vmImage: $(image)
 
     steps:
     - bash: sudo apt-get install ninja-build
       displayName: 'Installing dependencies'
+      condition: eq(variables['image'], variables['linux'])
+
+    - bash: |
+        brew update
+        brew install ninja
+        ulimit -Sn 1024
+      displayName: 'Installing dependencies'
+      condition: eq(variables['image'], variables['macOS'])
     - bash: git submodule update --init
       displayName: 'Updating submodules'
     - bash: |
         mkdir build
         cd build
-        cmake -G Ninja .. $(cat ../utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$(configuration) -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
-      displayName: 'Cmake configuration'
+        cmake -G Ninja $BUILD_SOURCESDIRECTORY $(cat $BUILD_SOURCESDIRECTORY/utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${configuration} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
+      displayName: 'Running Cmake'
     - bash: |
         cd build
         ninja
@@ -56,57 +115,11 @@ stages:
         ./build/bin/dxc -T ps_6_0 tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
         ./build/bin/dxc -T ps_6_0 -Fo passthru-ps.dxil tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
         ./build/bin/dxc -T ps_6_0 -Fo passthru-ps.spv tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv -spirv
+        ls -ld $AGENT_BUILDDIRECTORY
+        ls -ld $BUILD_SOURCESDIRECTORY
       displayName: 'Smoke tests'
     - bash: ./build/bin/clang-spirv-tests --spirv-test-root tools/clang/test/CodeGenSPIRV/
       displayName: 'SPIRV tests'
     - bash: ./build/bin/clang-hlsl-tests --HlslDataDir $PWD/tools/clang/test/HLSL/
       displayName: 'DXIL tests'
 
-  - job: MacOS
-    timeoutInMinutes: 90
-
-    pool:
-      vmImage: macOS-10.14
-
-    variables:
-      configuration: Release
-      CC: clang
-      CXX: clang++
-      CXX_FLAGS: -Werror
-
-    strategy:
-      matrix:
-        Clang_Release:
-         configuration: Release
-        Clang_Debug:
-         configuration: Debug
-
-    steps:
-    - bash: |
-        brew update
-        brew install ninja
-      displayName: 'Installing dependencies'
-    - bash: git submodule update --init
-      displayName: 'Updating submodules'
-    - bash: |
-        mkdir build
-        cd build
-        cmake -G Ninja .. $(cat ../utils/cmake-predefined-config-params) -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$(configuration) -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
-      displayName: 'Cmake configuration'
-    - bash: |
-        cd build
-        ninja
-      displayName: 'Building'
-    - bash: |
-        ./build/bin/dxc -T ps_6_0 tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
-        ./build/bin/dxc -T ps_6_0 -Fo passthru-ps.dxil tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
-        ./build/bin/dxc -T ps_6_0 -Fo passthru-ps.spv tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv -spirv
-      displayName: 'Smoke tests'
-    - bash: |
-        ulimit -Sn 1024
-        ./build/bin/clang-spirv-tests --spirv-test-root tools/clang/test/CodeGenSPIRV/
-      displayName: 'SPIRV tests'
-    - bash: |
-        ulimit -Sn 1024
-        ./build/bin/clang-hlsl-tests --HlslDataDir $PWD/tools/clang/test/HLSL/
-      displayName: 'DXIL tests'


### PR DESCRIPTION
Adds Windows builds previously done by appveyor to azure dev ops.

Also consolidates, cleans up, and otherwise reorganizes the previous build scripts