### PR TITLE
Document that ComputeSample PS is a dummy

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -564,8 +564,7 @@
         }
 
         float4 PSMain(PSInput input) : SV_TARGET {
-          uint ix = convert2Dto1D(input.uv.x, input.uv.y, 84);
-          g_bufMain[ix] = DerivTest(ix, 84*4*3);
+          // Dummy PS to satisfy pipeline creation requirements
           return 1;
         }
         [NumThreads(336, 1, 1)]


### PR DESCRIPTION
Just to avoid any suspicion about passing float `uv.x` and `uv.y` into
convert2Dto1D which requires uint.  It's a dummy PS and the data written
to g_bufMain (u0) is not read back.