### PR TITLE
[spirv] emit valid stride for array of empty struct

### DIFF
--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -374,6 +374,8 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
       // of a single array element, according to rules 1, 2, and 3, and rounded
       // up to the base alignment of a vec4.
       alignment = roundToPow2(alignment, kStd140Vec4Alignment);
+      if (size == 0)
+        size = alignment;
     }
     if (rule == SpirvLayoutRule::FxcCTBuffer) {
       // In fxc cbuffer/tbuffer packing rules, arrays does not affect the data

--- a/tools/clang/test/CodeGenSPIRV/type.struct.empty-struct.array-stride.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.struct.empty-struct.array-stride.hlsl
@@ -1,0 +1,18 @@
+// Run: %dxc -T ps_6_0 -E main -O0
+
+// CHECK: OpDecorate %_arr__struct_12_uint_2 ArrayStride 16
+
+struct PSInput
+{
+    float4 color : COLOR;
+};
+
+cbuffer foo {
+    struct {
+    } bar[2];
+}
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -52,6 +52,9 @@ TEST_F(FileTest, MatrixTypesMajornessZpc) {
   runFileTest("type.matrix.majorness.zpc.hlsl");
 }
 TEST_F(FileTest, StructTypes) { runFileTest("type.struct.hlsl"); }
+TEST_F(FileTest, StructTypeEmptyStructArrayStride) {
+  runFileTest("type.struct.empty-struct.array-stride.hlsl");
+}
 TEST_F(FileTest, StructTypeUniqueness) {
   runFileTest("type.struct.uniqueness.hlsl");
 }


### PR DESCRIPTION
Fixes #3101