### PR TITLE
-strict-udt-casting prevents implicit casts between unrelated structs

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -198,6 +198,7 @@ public:
   bool ForceZeroStoreLifetimes = false; // OPT_force_zero_store_lifetimes
   bool EnableLifetimeMarkers = false; // OPT_enable_lifetime_markers
   bool EnableTemplates = false; // OPT_enable_templates
+  bool StrictUDTCasting = false; // OPT_strict_udt_casting
 
   // Optimization pass enables, disables and selects
   std::map<std::string, bool> DxcOptimizationToggles; // OPT_opt_enable & OPT_opt_disable

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -285,6 +285,8 @@ def disable_lifetime_markers : Flag<["-", "/"], "disable-lifetime-markers">, Gro
   HelpText<"Disable generation of lifetime markers where they would be otherwise (6.6+)">;
 def enable_templates: Flag<["-", "/"], "enable-templates">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Enable template support for HLSL.">;
+def strict_udt_casting: Flag<["-", "/"], "strict-udt-casting">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Require explicit casts between different structure types with compatible layouts.">;
 def enable_payload_qualifiers : Flag<["-", "/"], "enable-payload-qualifiers">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,
   HelpText<"Enables support for payload access qualifiers for raytracing payloads in SM 6.6.">;
 def disable_payload_qualifiers : Flag<["-", "/"], "disable-payload-qualifiers">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -477,6 +477,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.ExtractPrivateFile = Args.getLastArgValue(OPT_getprivate);
   opts.Enable16BitTypes = Args.hasFlag(OPT_enable_16bit_types, OPT_INVALID, false);
   opts.EnableTemplates = Args.hasFlag(OPT_enable_templates, OPT_INVALID, false);
+  opts.StrictUDTCasting = Args.hasFlag(OPT_strict_udt_casting, OPT_INVALID, false);
   opts.OutputObject = Args.getLastArgValue(OPT_Fo);
   opts.OutputHeader = Args.getLastArgValue(OPT_Fh);
   opts.OutputWarningsFile = Args.getLastArgValue(OPT_Fe);

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -159,6 +159,7 @@ public:
   bool EnableDX9CompatMode;
   bool EnableFXCCompatMode;
   bool EnableTemplates;
+  bool StrictUDTCasting = false;
   bool EnablePayloadAccessQualifiers;
   // HLSL Change Ends
 

--- a/tools/clang/include/clang/Driver/Options.td
+++ b/tools/clang/include/clang/Driver/Options.td
@@ -682,6 +682,8 @@ def enable_16bit_types: Flag<["-", "/"], "enable-16bit-types">, Flags<[CoreOptio
   HelpText<"Enable 16bit types and disable min precision types.">; // HLSL Change - mimic the HLSLOptions.td flag
 def enable_templates: Flag<["-", "/"], "enable-templates">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Enable template support for HLSL.">; // HLSL Change
+def strict_udt_casting: Flag<["-", "/"], "strict-udt-casting">, Flags<[CoreOption, DriverOption, HelpHidden]>,
+  HelpText<"Require explicit casts between different structure types with compatible layouts.">;
 def fms_compatibility_version
     : Joined<["-"], "fms-compatibility-version=">,
       Group<f_Group>,

--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1749,6 +1749,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.UseMinPrecision = !Args.hasArg(options::OPT_enable_16bit_types);
   // Enable template support for HLSL
   Opts.EnableTemplates = Args.hasArg(options::OPT_enable_templates);
+  Opts.StrictUDTCasting = Args.hasArg(options::OPT_strict_udt_casting);
 #endif // #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -8631,7 +8631,7 @@ bool HLSLExternalSource::CanConvert(
     && sourceExpr->getStmtClass() != Expr::StringLiteralClass;
 
   bool targetRef = target->isReferenceType();
-  bool TargetUnnamed = false;
+  bool TargetIsAnonymous = false;
 
   // Initialize the output standard sequence if available.
   if (standard != nullptr) {
@@ -8723,7 +8723,7 @@ bool HLSLExternalSource::CanConvert(
         }
         // There is no way to cast to anonymous structures.  So we allow legacy
         // HLSL implicit casts to matching anonymous structure types.
-        TargetUnnamed = !targetRD->hasNameForLinkage();
+        TargetIsAnonymous = !targetRD->hasNameForLinkage();
       }
     }
 
@@ -8755,7 +8755,7 @@ bool HLSLExternalSource::CanConvert(
     } else if (m_sema->getLangOpts().StrictUDTCasting &&
                (SourceInfo.ShapeKind == AR_TOBJ_COMPOUND ||
                 TargetInfo.ShapeKind == AR_TOBJ_COMPOUND) &&
-               !TargetUnnamed) {
+               !TargetIsAnonymous) {
       // Not explicit, either are struct/class, not derived-to-base,
       // target is named (so explicit cast is possible),
       // and using strict UDT rules: disallow this implicit cast.

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -8631,6 +8631,7 @@ bool HLSLExternalSource::CanConvert(
     && sourceExpr->getStmtClass() != Expr::StringLiteralClass;
 
   bool targetRef = target->isReferenceType();
+  bool TargetUnnamed = false;
 
   // Initialize the output standard sequence if available.
   if (standard != nullptr) {
@@ -8694,7 +8695,6 @@ bool HLSLExternalSource::CanConvert(
   // Structure cast.
   SourceIsAggregate = SourceInfo.ShapeKind == AR_TOBJ_COMPOUND || SourceInfo.ShapeKind == AR_TOBJ_ARRAY;
   TargetIsAggregate = TargetInfo.ShapeKind == AR_TOBJ_COMPOUND || TargetInfo.ShapeKind == AR_TOBJ_ARRAY;
-  bool TargetUnnamed = false;
   if (SourceIsAggregate || TargetIsAggregate) {
     // For implicit conversions, FXC treats arrays the same as structures
     // and rejects conversions between them and numeric types

--- a/tools/clang/test/HLSL/conversions-between-type-shapes-strictudt.hlsl
+++ b/tools/clang/test/HLSL/conversions-between-type-shapes-strictudt.hlsl
@@ -1,0 +1,349 @@
+// RUN: %clang_cc1 -strict-udt-casting -Wno-unused-value -fsyntax-only -ffreestanding -verify -verify-ignore-unexpected=note %s
+
+// Tests all implicit conversions and explicit casts between type shapes
+// (scalars, vectors, matrices, arrays and structs).
+
+// Explicit casts are assumed to be "stronger" than implicit conversions.
+// > If an implicit conversion succeeds, we don't test the explicit cast
+// > If an explicit cast fails, we don't test the implicit conversion
+
+// This variation tests the -strict-udt-casting rule, which disables
+// implicit casts between unrelated structure types (non-base casts),
+// no matter how compatible they are element-wise.
+
+typedef int A1[1];
+typedef int A2[2];
+typedef int A4[4];
+typedef int A5[5];
+struct S1 { int a; };
+struct S2 { int a, b; };
+struct S4 { int a, b, c, d; };
+struct S5 { int a, b, c, d, e; };
+
+typedef S2 TD_S2;
+struct Like_S2 { int a, b; };
+struct DerivedFrom_S2 : S2 {
+    int c;
+};
+
+// Clang generates a bunch of "notes" about overload candidates here, but we're not testing for these
+void to_i(int i) {}
+void to_v1(int1 v) {}
+void to_v2(int2 v) {}
+void to_v4(int4 v) {}
+void to_m1x1(int1x1 m) {}
+void to_m1x2(int1x2 m) {}
+void to_m2x1(int2x1 m) {}
+void to_m2x2(int2x2 m) {}
+void to_m3x3(int3x3 m) {}
+void to_a1(A1 a) {}
+void to_a2(A2 a) {}
+void to_a4(A4 a) {}
+void to_a5(A5 a) {}
+void to_s1(S1 s) {}
+void to_s2(S2 s) {}
+void to_s4(S4 s) {}
+void to_s5(S5 s) {}
+
+void main()
+{
+    int i = 0;
+    int1 v1 = 0;
+    int2 v2 = 0;
+    int4 v4 = 0;
+    int1x1 m1x1 = 0;
+    int1x2 m1x2 = 0;
+    int2x1 m2x1 = 0;
+    int2x2 m2x2 = 0;
+    int1x3 m1x3 = 0;
+    int2x3 m2x3 = 0;
+    int3x1 m3x1 = 0;
+    int3x2 m3x2 = 0;
+    int3x3 m3x3 = 0;
+    A1 a1 = { 0 };
+    A2 a2 = { 0, 0 };
+    A4 a4 = { 0, 0, 0, 0 };
+    A5 a5 = { 0, 0, 0, 0, 0 };
+    S1 s1 = { 0 };
+    S2 s2 = { 0, 0 };
+    S4 s4 = { 0, 0, 0, 0 };
+    S5 s5 = { 0, 0, 0, 0, 0 };
+    TD_S2 td_s2 = { 0, 0 };
+    Like_S2 like_s2 = { 0, 0 };
+    DerivedFrom_S2 derivedfrom_s2 = { 0, 0, 0 };
+
+    // =========== Scalar/single-element ===========
+    to_i(v1);
+    to_i(m1x1);
+    to_i(a1);                                               /* expected-error {{no matching function for call to 'to_i'}} fxc-error {{X3017: 'to_i': cannot convert from 'typedef int[1]' to 'int'}} */
+    (int)a1;
+    to_i(s1);                                               /* expected-error {{no matching function for call to 'to_i'}} fxc-error {{X3017: 'to_i': cannot convert from 'struct S1' to 'int'}} */
+    (int)s1;
+
+    to_v1(i);
+    to_v1(m1x1);
+    to_v1(a1);                                              /* expected-error {{no matching function for call to 'to_v1'}} fxc-error {{X3017: 'to_v1': cannot convert from 'typedef int[1]' to 'int1'}} */
+    (int1)a1;
+    to_v1(s1);                                              /* expected-error {{no matching function for call to 'to_v1'}} fxc-error {{X3017: 'to_v1': cannot convert from 'struct S1' to 'int1'}} */
+    (int1)s1;
+
+    to_m1x1(i);
+    to_m1x1(v1);
+    to_m1x1(a1);                                            /* expected-error {{no matching function for call to 'to_m1x1'}} fxc-error {{X3017: 'to_m1x1': cannot convert from 'typedef int[1]' to 'int1'}} */
+    (int1x1)a1;
+    to_m1x1(s1);                                            /* expected-error {{no matching function for call to 'to_m1x1'}} fxc-error {{X3017: 'to_m1x1': cannot convert from 'struct S1' to 'int1'}} */
+    (int1x1)s1;
+
+    to_a1(i);                                               /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'int' to 'typedef int[1]'}} */
+    (A1)i;
+    to_a1(v1);                                              /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'int1' to 'typedef int[1]'}} */
+    (A1)v1;
+    to_a1(m1x1);                                            /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'int1' to 'typedef int[1]'}} */
+    (A1)m1x1;
+    // Illegal with -strict-udt-casting
+    to_a1(s1);                                              /* expected-error {{no matching function for call to 'to_a1'}} */
+    (A1)s1;
+
+    to_s1(i);                                               /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'int' to 'struct S1'}} */
+    (S1)i;
+    to_s1(v1);                                              /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'int1' to 'struct S1'}} */
+    (S1)v1;
+    to_s1(m1x1);                                            /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'int1' to 'struct S1'}} */
+    (S1)m1x1;
+    // Illegal with -strict-udt-casting
+    to_s1(a1);                                              /* expected-error {{no matching function for call to 'to_s1'}} */
+    (S1)a1;
+
+    // =========== Truncation to scalar/single-element ===========
+    // Single element sources already tested
+    to_i(v2);                                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_i': implicit truncation of vector type}} */
+    to_i(m2x2);                                             /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_i': implicit truncation of vector type}} */
+    to_i(a2);                                               /* expected-error {{no matching function for call to 'to_i'}} fxc-error {{X3017: 'to_i': cannot convert from 'typedef int[2]' to 'int'}} */
+    (int)a2;
+    to_i(s2);                                               /* expected-error {{no matching function for call to 'to_i'}} fxc-error {{X3017: 'to_i': cannot convert from 'struct S2' to 'int'}} */
+    (int)s2;
+
+    to_v1(v2);                                              /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_v1': implicit truncation of vector type}} */
+    to_v1(m2x2);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_v1': implicit truncation of vector type}} */
+    to_v1(a2);                                              /* expected-error {{no matching function for call to 'to_v1'}} fxc-error {{X3017: 'to_v1': cannot convert from 'typedef int[2]' to 'int1'}} */
+    (int1)a2;
+    to_v1(s2);                                              /* expected-error {{no matching function for call to 'to_v1'}} fxc-error {{X3017: 'to_v1': cannot convert from 'struct S2' to 'int1'}} */
+    (int1)s2;
+
+    to_m1x1(v2);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m1x1': implicit truncation of vector type}} */
+    to_m1x1(m2x2);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m1x1': implicit truncation of vector type}} */
+    to_m1x1(a2);                                            /* expected-error {{no matching function for call to 'to_m1x1'}} fxc-error {{X3017: 'to_m1x1': cannot convert from 'typedef int[2]' to 'int1'}} */
+    (int1x1)a2;
+    to_m1x1(s2);                                            /* expected-error {{no matching function for call to 'to_m1x1'}} fxc-error {{X3017: 'to_m1x1': cannot convert from 'struct S2' to 'int1'}} */
+    (int1x1)s2;
+
+    to_a1(v2);                                              /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'int2' to 'typedef int[1]'}} */
+    to_a1(m2x2);                                            /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot implicitly convert from 'int2x2' to 'typedef int[1]'}} */
+    to_a1(a2);                                              /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'typedef int[2]' to 'typedef int[1]'}} */
+    (A1)a2;
+    to_a1(s2);                                              /* expected-error {{no matching function for call to 'to_a1'}} fxc-error {{X3017: 'to_a1': cannot convert from 'struct S2' to 'typedef int[1]'}} */
+    (A1)s2;
+
+    to_s1(v2);                                              /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'int2' to 'struct S1'}} */
+    to_s1(m2x2);                                            /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot implicitly convert from 'int2x2' to 'struct S1'}} */
+    to_s1(a2);                                              /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'typedef int[2]' to 'struct S1'}} */
+    (S1)a2;
+    to_s1(s2);                                              /* expected-error {{no matching function for call to 'to_s1'}} fxc-error {{X3017: 'to_s1': cannot convert from 'struct S2' to 'struct S1'}} */
+    (S1)s2;
+
+    // =========== Splatting ===========
+    // Single element dests already tested
+    to_v2(i);
+    to_v2(v1);
+    to_v2(m1x1);
+    (int2)a1;                                               /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'int2'}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'int2'}} */
+    (int2)s1;                                               /* expected-error {{cannot convert from 'S1' to 'int2'}} fxc-error {{X3017: cannot convert from 'struct S1' to 'int2'}} */
+
+    to_m2x2(i);
+    to_m2x2(v1);
+    to_m2x2(m1x1);
+    (int2x2)a1;                                             /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'int2x2'}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'int2x2'}} */
+    (int2x2)s1;                                             /* expected-error {{cannot convert from 'S1' to 'int2x2'}} fxc-error {{X3017: cannot convert from 'struct S1' to 'int2x2'}} */
+
+    to_a2(i);                                               /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int' to 'typedef int[2]'}} */
+    (A2)i;
+    to_a2(v1);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int1' to 'typedef int[2]'}} */
+    (A2)v1;
+    to_a2(m1x1);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int1' to 'typedef int[2]'}} */
+    (A2)m1x1;
+    (A2)a1;                                                 /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'A2' (aka 'int [2]')}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'typedef int[2]'}} */
+    (A2)s1;                                                 /* expected-error {{cannot convert from 'S1' to 'A2' (aka 'int [2]')}} fxc-error {{X3017: cannot convert from 'struct S1' to 'typedef int[2]'}} */
+
+    to_s2(i);                                               /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int' to 'struct S2'}} */
+    (S2)i;
+    to_s2(v1);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int1' to 'struct S2'}} */
+    (S2)v1;
+    to_s2(m1x1);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int1' to 'struct S2'}} */
+    (S2)m1x1;
+    (S2)a1;                                                 /* expected-error {{cannot convert from 'A1' (aka 'int [1]') to 'S2'}} fxc-error {{X3017: cannot convert from 'typedef int[1]' to 'struct S2'}} */
+    (S2)s1;                                                 /* expected-error {{cannot convert from 'S1' to 'S2'}} fxc-error {{X3017: cannot convert from 'struct S1' to 'struct S2'}} */
+
+    // =========== Element-preserving ===========
+    // Single element sources/dests already tested
+    to_v2(m1x2);
+    to_v2(m2x1);
+    to_v4(m2x2);
+    to_v2(a2);                                              /* expected-error {{no matching function for call to 'to_v2'}} fxc-error {{X3017: 'to_v2': cannot convert from 'typedef int[2]' to 'int2'}} */
+    (int2)a2;
+    to_v2(s2);                                              /* expected-error {{no matching function for call to 'to_v2'}} fxc-error {{X3017: 'to_v2': cannot convert from 'struct S2' to 'int2'}} */
+    (int2)s2;
+
+    to_m1x2(v2);
+    to_m2x1(v2);
+    to_m2x2(v4);
+    (int1x2)m2x1;                                           /* expected-error {{cannot convert from 'int2x1' to 'int1x2'}} fxc-error {{X3017: cannot convert from 'int2x1' to 'int2'}} */
+    (int2x1)m1x2;                                           /* expected-error {{cannot convert from 'int1x2' to 'int2x1'}} fxc-error {{X3017: cannot convert from 'int2' to 'int2x1'}} */
+    to_m1x2(a2);                                            /* expected-error {{no matching function for call to 'to_m1x2'}} fxc-error {{X3017: 'to_m1x2': cannot convert from 'typedef int[2]' to 'int2'}} */
+    (int1x2)a2;
+    to_m2x1(a2);                                            /* expected-error {{no matching function for call to 'to_m2x1'}} fxc-error {{X3017: 'to_m2x1': cannot convert from 'typedef int[2]' to 'int2x1'}} */
+    (int2x1)a2;
+    to_m2x2(a4);                                            /* expected-error {{no matching function for call to 'to_m2x2'}} fxc-error {{X3017: 'to_m2x2': cannot convert from 'typedef int[4]' to 'int2x2'}} */
+    (int2x2)a4;
+    to_m1x2(s2);                                            /* expected-error {{no matching function for call to 'to_m1x2'}} fxc-error {{X3017: 'to_m1x2': cannot convert from 'struct S2' to 'int2'}} */
+    (int1x2)s2;
+    to_m2x1(s2);                                            /* expected-error {{no matching function for call to 'to_m2x1'}} fxc-error {{X3017: 'to_m2x1': cannot convert from 'struct S2' to 'int2x1'}} */
+    (int2x1)s2;
+    to_m2x2(s4);                                            /* expected-error {{no matching function for call to 'to_m2x2'}} fxc-error {{X3017: 'to_m2x2': cannot convert from 'struct S4' to 'int2x2'}} */
+    (int2x2)s4;
+
+    to_a2(v2);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int2' to 'typedef int[2]'}} */
+    (A2)v2;
+    to_a2(m1x2);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int2' to 'typedef int[2]'}} */
+    (A2)m1x2;
+    to_a2(m2x1);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int2x1' to 'typedef int[2]'}} */
+    (A2)m2x1;
+    to_a4(m2x2);                                            /* expected-error {{no matching function for call to 'to_a4'}} fxc-error {{X3017: 'to_a4': cannot convert from 'int2x2' to 'typedef int[4]'}} */
+    (A4)m2x2;
+    // Illegal with -strict-udt-casting
+    to_a2(s2);                                              /* expected-error {{no matching function for call to 'to_a2'}} */
+    (A2)s2;
+
+    to_s2(v2);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int2' to 'struct S2'}} */
+    (S2)v2;
+    to_s2(m1x2);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int2' to 'struct S2'}} */
+    (S2)m1x2;
+    to_s2(m2x1);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int2x1' to 'struct S2'}} */
+    (S2)m2x1;
+    to_s4(m2x2);                                            /* expected-error {{no matching function for call to 'to_s4'}} fxc-error {{X3017: 'to_s4': cannot convert from 'int2x2' to 'struct S4'}} */
+    (S4)m2x2;
+    // Illegal with -strict-udt-casting
+    to_s2(a2);                                              /* expected-error {{no matching function for call to 'to_s2'}} */
+    (S2)a2;
+    // typedef is same
+    to_s2(td_s2);
+    (S2)td_s2;
+    // derived-to-base implicit cast is ok
+    to_s2(derivedfrom_s2);
+    (S2)derivedfrom_s2;
+    // identical struct of different name is not the same:
+    to_s2(like_s2);                                         /* expected-error {{no matching function for call to 'to_s2'}} */
+    (S2)like_s2;
+    // implicit casting to anonymous struct of identical layout ok
+    struct { int a, b; } anon2_1 = s2;
+
+    // =========== Truncating ===========
+    // Single element dests already tested
+    to_v2(v4);                                              /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_v2': implicit truncation of vector type}} */
+    to_v2(m1x3);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_v2': implicit truncation of vector type}} */
+    to_v2(m3x1);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_v2': implicit truncation of vector type}} */
+    (int2)m2x2;                                             /* expected-error {{cannot convert from 'int2x2' to 'int2'}} fxc-error {{X3017: cannot convert from 'int2x2' to 'int2'}} */
+    (int2)m3x3;                                             /* expected-error {{cannot convert from 'int3x3' to 'int2'}} fxc-error {{X3017: cannot convert from 'int3x3' to 'int2'}} */
+    to_v2(a4);                                              /* expected-error {{no matching function for call to 'to_v2'}} fxc-error {{X3017: 'to_v2': cannot convert from 'typedef int[4]' to 'int2'}} */
+    (int2)a4;
+    to_v2(s4);                                              /* expected-error {{no matching function for call to 'to_v2'}} fxc-error {{X3017: 'to_v2': cannot convert from 'struct S4' to 'int2'}} */
+    (int2)s4;
+
+    to_m1x2(v4);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m1x2': implicit truncation of vector type}} */
+    to_m2x1(v4);                                            /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x1': implicit truncation of vector type}} */
+    to_m1x2(m1x3);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m1x2': implicit truncation of vector type}} */
+    (int1x2)m3x1;                                           /* expected-error {{cannot convert from 'int3x1' to 'int1x2'}} fxc-error {{X3017: cannot convert from 'int3x1' to 'int2'}} */
+    to_m1x2(m2x2);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m1x2': implicit truncation of vector type}} */
+    to_m2x1(m3x1);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x1': implicit truncation of vector type}} */
+    (int2x1)m1x3;                                           /* expected-error {{cannot convert from 'int1x3' to 'int2x1'}} fxc-error {{X3017: cannot convert from 'int3' to 'int2x1'}} */
+    to_m2x1(m2x2);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x1': implicit truncation of vector type}} */
+    to_m2x2(m2x3);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x2': implicit truncation of vector type}} */
+    to_m2x2(m3x2);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x2': implicit truncation of vector type}} */
+    to_m2x2(m3x3);                                          /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: 'to_m2x2': implicit truncation of vector type}} */
+    to_m1x2(a4);                                            /* expected-error {{no matching function for call to 'to_m1x2'}} fxc-error {{X3017: 'to_m1x2': cannot convert from 'typedef int[4]' to 'int2'}} */
+    (int1x2)a4;
+    to_m2x1(a4);                                            /* expected-error {{no matching function for call to 'to_m2x1'}} fxc-error {{X3017: 'to_m2x1': cannot convert from 'typedef int[4]' to 'int2x1'}} */
+    (int2x1)a4;
+    to_m2x2(a5);                                            /* expected-error {{no matching function for call to 'to_m2x2'}} fxc-error {{X3017: 'to_m2x2': cannot implicitly convert from 'typedef int[5]' to 'int2x2'}} */
+    (int2x2)a5;                                             /* fxc-error {{X3017: cannot convert from 'typedef int[5]' to 'int2x2'}} */
+    to_m1x2(s4);                                            /* expected-error {{no matching function for call to 'to_m1x2'}} fxc-error {{X3017: 'to_m1x2': cannot convert from 'struct S4' to 'int2'}} */
+    (int1x2)s4;
+    to_m2x1(s4);                                            /* expected-error {{no matching function for call to 'to_m2x1'}} fxc-error {{X3017: 'to_m2x1': cannot convert from 'struct S4' to 'int2x1'}} */
+    (int2x1)s4;
+    to_m2x2(s5);                                            /* expected-error {{no matching function for call to 'to_m2x2'}} fxc-error {{X3017: 'to_m2x2': cannot implicitly convert from 'struct S5' to 'int2x2'}} */
+    (int2x2)s5;                                             /* fxc-error {{X3017: cannot convert from 'struct S5' to 'int2x2'}} */
+
+    to_a2(v4);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int4' to 'typedef int[2]'}} */
+    (A2)v4;
+    to_a2(m1x3);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int3' to 'typedef int[2]'}} */
+    (A2)m1x3;
+    to_a2(m3x1);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'int3x1' to 'typedef int[2]'}} */
+    (A2)m3x1;
+    to_a2(m2x2);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot implicitly convert from 'int2x2' to 'typedef int[2]'}} */
+    (A2)m2x2;                                               /* fxc-error {{X3017: cannot convert from 'int2x2' to 'typedef int[2]'}} */
+    to_a2(m3x3);                                            /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot implicitly convert from 'int3x3' to 'typedef int[2]'}} */
+    (A2)m3x3;                                               /* fxc-error {{X3017: cannot convert from 'int3x3' to 'typedef int[2]'}} */
+    to_a2(a4);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'typedef int[4]' to 'typedef int[2]'}} */
+    (A2)a4;
+    to_a2(s4);                                              /* expected-error {{no matching function for call to 'to_a2'}} fxc-error {{X3017: 'to_a2': cannot convert from 'struct S4' to 'typedef int[2]'}} */
+    (A2)s4;
+
+    to_s2(v4);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int4' to 'struct S2'}} */
+    (S2)v4;
+    to_s2(m1x3);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int3' to 'struct S2'}} */
+    (S2)m1x3;
+    to_s2(m3x1);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'int3x1' to 'struct S2'}} */
+    (S2)m3x1;
+    to_s2(m2x2);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot implicitly convert from 'int2x2' to 'struct S2'}} */
+    (S2)m2x2;                                               /* fxc-error {{X3017: cannot convert from 'int2x2' to 'struct S2'}} */
+    to_s2(m3x3);                                            /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot implicitly convert from 'int3x3' to 'struct S2'}} */
+    (S2)m3x3;                                               /* fxc-error {{X3017: cannot convert from 'int3x3' to 'struct S2'}} */
+    to_s2(a4);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'typedef int[4]' to 'struct S2'}} */
+    (S2)a4;
+    to_s2(s4);                                              /* expected-error {{no matching function for call to 'to_s2'}} fxc-error {{X3017: 'to_s2': cannot convert from 'struct S4' to 'struct S2'}} */
+    (S2)s4;
+
+    // implicit casting to anonymous struct of subset layout is not legal
+    struct { int a, b; } anon2_2;
+    anon2_2 = derivedfrom_s2;                               /* expected-error {{cannot implicitly convert from 'DerivedFrom_S2' to 'struct (anonymous struct at }} */
+    struct { int a, b; } anon2_3;
+    anon2_3 = s4;                                           /* expected-error {{cannot implicitly convert from 'S4' to 'struct (anonymous struct at }} */
+
+    // =========== Extending ===========
+    // Single element sources already tested (splatting)
+    (int4)v2;                                               /* expected-error {{cannot convert from 'int2' to 'int4'}} fxc-error {{X3017: cannot convert from 'int2' to 'int4'}} */
+    (int4)m1x2;                                             /* expected-error {{cannot convert from 'int1x2' to 'int4'}} fxc-error {{X3017: cannot convert from 'int2' to 'int4'}} */
+    (int4)m2x1;                                             /* expected-error {{cannot convert from 'int2x1' to 'int4'}} fxc-error {{X3017: cannot convert from 'int2x1' to 'int4'}} */
+    (int4)a2;                                               /* expected-error {{cannot convert from 'A2' (aka 'int [2]') to 'int4'}} fxc-error {{X3017: cannot convert from 'typedef int[2]' to 'int4'}} */
+    (int4)s2;                                               /* expected-error {{cannot convert from 'S2' to 'int4'}} fxc-error {{X3017: cannot convert from 'struct S2' to 'int4'}} */
+
+    (int2x2)v2;                                             /* expected-error {{cannot convert from 'int2' to 'int2x2'}} fxc-error {{X3017: cannot convert from 'int2' to 'int2x2'}} */
+    (int2x2)m1x2;                                           /* expected-error {{cannot convert from 'int1x2' to 'int2x2'}} fxc-error {{X3017: cannot convert from 'int2' to 'int2x2'}} */
+    (int2x2)m2x1;                                           /* expected-error {{cannot convert from 'int2x1' to 'int2x2'}} fxc-error {{X3017: cannot convert from 'int2x1' to 'int2x2'}} */
+    (int3x3)m2x2;                                           /* expected-error {{cannot convert from 'int2x2' to 'int3x3'}} fxc-error {{X3017: cannot convert from 'int2x2' to 'int3x3'}} */
+    (int2x2)a2;                                             /* expected-error {{cannot convert from 'A2' (aka 'int [2]') to 'int2x2'}} fxc-error {{X3017: cannot convert from 'typedef int[2]' to 'int2x2'}} */
+    (int2x2)s2;                                             /* expected-error {{cannot convert from 'S2' to 'int2x2'}} fxc-error {{X3017: cannot convert from 'struct S2' to 'int2x2'}} */
+
+    (A4)v2;                                                 /* expected-error {{cannot convert from 'int2' to 'A4' (aka 'int [4]')}} fxc-error {{X3017: cannot convert from 'int2' to 'typedef int[4]'}} */
+    (A4)m1x2;                                               /* expected-error {{cannot convert from 'int1x2' to 'A4' (aka 'int [4]')}} fxc-error {{X3017: cannot convert from 'int2' to 'typedef int[4]'}} */
+    (A4)m2x1;                                               /* expected-error {{cannot convert from 'int2x1' to 'A4' (aka 'int [4]')}} fxc-error {{X3017: cannot convert from 'int2x1' to 'typedef int[4]'}} */
+    (A5)m2x2;                                               /* expected-error {{cannot convert from 'int2x2' to 'A5' (aka 'int [5]')}} fxc-error {{X3017: cannot convert from 'int2x2' to 'typedef int[5]'}} */
+    (A4)a2;                                                 /* expected-error {{cannot convert from 'A2' (aka 'int [2]') to 'A4' (aka 'int [4]')}} fxc-error {{X3017: cannot convert from 'typedef int[2]' to 'typedef int[4]'}} */
+    (A4)s2;                                                 /* expected-error {{cannot convert from 'S2' to 'A4' (aka 'int [4]')}} fxc-error {{X3017: cannot convert from 'struct S2' to 'typedef int[4]'}} */
+
+    (S4)v2;                                                 /* expected-error {{cannot convert from 'int2' to 'S4'}} fxc-error {{X3017: cannot convert from 'int2' to 'struct S4'}} */
+    (S4)m1x2;                                               /* expected-error {{cannot convert from 'int1x2' to 'S4'}} fxc-error {{X3017: cannot convert from 'int2' to 'struct S4'}} */
+    (S4)m2x1;                                               /* expected-error {{cannot convert from 'int2x1' to 'S4'}} fxc-error {{X3017: cannot convert from 'int2x1' to 'struct S4'}} */
+    (S5)m2x2;                                               /* expected-error {{cannot convert from 'int2x2' to 'S5'}} fxc-error {{X3017: cannot convert from 'int2x2' to 'struct S5'}} */
+    (S4)a2;                                                 /* expected-error {{cannot convert from 'A2' (aka 'int [2]') to 'S4'}} fxc-error {{X3017: cannot convert from 'typedef int[2]' to 'struct S4'}} */
+    (S4)s2;                                                 /* expected-error {{cannot convert from 'S2' to 'S4'}} fxc-error {{X3017: cannot convert from 'struct S2' to 'struct S4'}} */
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray-strictudt.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// CHECK: switch
+
+struct Vertex
+{
+    float4 position     : POSITION0;
+    float4 color        : COLOR0;
+    float4 a[3]         : A;
+};
+
+struct Interpolants
+{
+    float4 position     : SV_POSITION0;
+    float4 color        : COLOR0;
+    float4 a[3]         : A;
+};
+
+uint i;
+
+void main( Vertex In, int j : J, out Interpolants output )
+{
+    output = (Interpolants)In;
+    output.a[1][i] = 3;
+    output.a[0] = 4;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-1.hlsl
@@ -1,0 +1,59 @@
+// RUN: %dxc -E main -T ps_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -enable-templates -D USE_TEMPLATE %s | FileCheck %s
+
+// Based on GitHub issue #3563
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 2.000000e+00)
+
+struct LinearRGB
+{
+  float3 RGB;
+};
+
+struct LinearYCoCg
+{
+  float3 YCoCg;
+};
+
+#ifndef USE_TEMPLATE
+
+// Without -strict-udt-casting
+// error: call to 'GetLuma4' is ambiguous
+float GetLuma4(LinearRGB In)
+{
+  return In.RGB.g * 2.0 + In.RGB.r + In.RGB.b;
+}
+
+float GetLuma4(LinearYCoCg In)
+{
+  return In.YCoCg.x;
+}
+
+#else // works but code getting too complicated
+  
+template<typename InputColorSpace>
+float GetLuma4(InputColorSpace In);
+
+template<>
+float GetLuma4<LinearRGB>(LinearRGB In)
+{
+  return In.RGB.g * 2.0 + In.RGB.r + In.RGB.b;
+}
+
+template<>
+float GetLuma4<LinearYCoCg>(LinearYCoCg In)
+{
+  return In.YCoCg.x;
+}
+
+#endif
+
+float4 main() : SV_TARGET {
+  LinearYCoCg YCoCg = { {1.0f, 0.0, 0.0} };
+  float f = GetLuma4(YCoCg);  // gets .x (1.0f)
+
+  LinearRGB Color;
+  Color.RGB = float3(0, f, 0);
+
+  return float4(GetLuma4(Color), 0.0, 0.0, 0.0);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-2.hlsl
@@ -1,0 +1,77 @@
+// RUN: %dxc -E main -T ps_6_0 -enable-templates -strict-udt-casting %s | FileCheck %s
+
+// Based on GitHub issue #3564
+
+// CHECK: error: cannot initialize a variable of type 'LinearYCoCg' with an rvalue of type 'LinearRGB'
+
+struct LinearRGB
+{
+  float3 RGB;
+};
+
+struct LinearYCoCg
+{
+  float3 YCoCg;
+};
+
+
+LinearYCoCg RGBToYCoCg(LinearRGB In)
+{
+  float Y = dot(In.RGB, float3(1, 2, 1));
+  float Co = dot(In.RGB, float3(2, 0, -2));
+  float Cg = dot(In.RGB, float3(-1, 2, -1));
+
+  LinearYCoCg Out;
+  Out.YCoCg = float3(Y, Co, Cg);
+  return Out;
+}
+
+LinearRGB YCoCgToRGB(LinearYCoCg In)
+{
+  float Y =  In.YCoCg.x * float(0.25);
+  float Co = In.YCoCg.y * float(0.25);
+  float Cg = In.YCoCg.z * float(0.25);
+
+  float R = Y + Co - Cg;
+  float G = Y + Cg;
+  float B = Y - Co - Cg;
+
+  LinearRGB Out;
+  Out.RGB = float3(R, G, B);
+  return Out;
+}
+
+template<typename OutputColorSpace, typename InputColorSpace>
+OutputColorSpace TransformColor(InputColorSpace In)
+{
+  //static_assert(sizeof(InputColorSpace) == 0, "TransformColor() not implemented");
+  float Array[!sizeof(InputColorSpace)];
+  Array[0];
+  return In;
+}
+
+template<>
+LinearYCoCg TransformColor<LinearYCoCg, LinearRGB>(LinearRGB In)
+{
+  return RGBToYCoCg(In);
+}
+
+
+template<>
+LinearRGB TransformColor<LinearRGB, LinearYCoCg>(LinearYCoCg In)
+{
+  return YCoCgToRGB(In);
+}
+
+float4 main() : SV_TARGET {
+  LinearRGB Color;
+  Color.RGB = float3(0, 1, 0);
+
+  LinearYCoCg Color2 = TransformColor<LinearYCoCg>(Color);
+  LinearRGB Color3 = TransformColor<LinearRGB>(Color2);
+  
+  // ISSUE: TransformColor<LinearRGB>() returns LinearRGB, but get cast silently in LinearYCoCg without error.
+  LinearYCoCg Color4 = TransformColor<LinearRGB>(Color2);
+
+  return float4(Color4.YCoCg, 0.0);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast-strictudt.hlsl
@@ -1,0 +1,48 @@
+// RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// CHECK: SV_RenderTargetArrayIndex or SV_ViewportArrayIndex from any shader feeding rasterizer
+
+struct Vertex
+{
+    float4 position     : POSITION0;
+    float4 color        : COLOR0;
+
+uint   RTIndex      : SV_RenderTargetArrayIndex;
+};
+
+struct Interpolants
+{
+    float4 position     : SV_POSITION0;
+    float4 color        : COLOR0;
+
+uint   RTIndex      : SV_RenderTargetArrayIndex;
+};
+
+struct Inh : Interpolants {
+    float a;
+};
+
+struct Interpolants2
+{
+    float4 position     : SV_POSITION0;
+    float4 color        : COLOR0;
+
+    float4 color2        : COLOR2;
+};
+
+
+Interpolants2 c2;
+Inh  c;
+int i;
+uint4 i4;
+
+Interpolants main(  Vertex In)
+{
+  if (i>1)
+     return (Interpolants)i4.z;
+  else if (i>0)
+     return (Interpolants) c;
+  else if (i > -1)
+     return (Interpolants )c2;
+  return (Interpolants)In;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param-strictudt.hlsl
@@ -1,0 +1,150 @@
+// RUN: %dxc /Tvs_6_0 /Emain -strict-udt-casting %s | FileCheck %s
+// Test explicit cast between structs of identical layout where
+// the destination struct is marked as out param.
+
+// o1.f1 = input.f1
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 3.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 4.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.f3[4] = input.f3[4]
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 0, i8 0, float 1.300000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 0, i8 1, float 1.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 1, i8 0, float 1.500000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 1, i8 1, float 1.600000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 2, i8 0, float 1.700000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 2, i8 1, float 1.800000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 3, i8 0, float 1.900000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 2, i32 3, i8 1, float 2.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.f4 = input.f4
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 3, i32 0, i8 0, i32 21)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 3, i32 0, i8 1, i32 22)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 3, i32 0, i8 2, i32 23)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.s.f5 = input.s.f5
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 4, i32 0, i8 0, float 2.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 4, i32 0, i8 1, float 2.500000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 4, i32 0, i8 2, float 2.600000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 4, i32 0, i8 3, float 2.700000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.s.f6 = input.s.f6
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 5, i32 0, i8 0, float 2.800000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 5, i32 0, i8 1, float 2.900000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 5, i32 0, i8 2, float 3.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.f7 = input.f7
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 6, i32 0, i8 0, i32 1)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f1 = input.f1
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 7, i32 0, i8 0, float 1.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 7, i32 0, i8 1, float 2.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 7, i32 0, i8 2, float 3.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 7, i32 0, i8 3, float 4.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f3[4] = input.f3[4]
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 0, i8 0, float 1.300000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 0, i8 1, float 1.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 1, i8 0, float 1.500000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 1, i8 1, float 1.600000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 2, i8 0, float 1.700000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 2, i8 1, float 1.800000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 3, i8 0, float 1.900000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 9, i32 3, i8 1, float 2.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f4 = input.f4
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 10, i32 0, i8 0, i32 21)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 10, i32 0, i8 1, i32 22)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 10, i32 0, i8 2, i32 23)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f5 = input.f5
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 11, i32 0, i8 0, float 2.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 11, i32 0, i8 1, float 2.500000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 11, i32 0, i8 2, float 2.600000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 11, i32 0, i8 3, float 2.700000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f6 = input.f6
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 12, i32 0, i8 0, float 2.800000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 12, i32 0, i8 1, float 2.900000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 12, i32 0, i8 2, float 3.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f7 = input.f7
+// CHECK: call void  @dx.op.storeOutput.i32(i32 5, i32 13, i32 0, i8 0, i32 1)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o1.f2 (column_major) = input.f2
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float 5.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 1, float 7.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 2, float 9.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 3, float 1.100000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 1, i8 0, float 6.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 1, i8 1, float 8.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 1, i8 2, float 1.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 1, i32 1, i8 3, float 1.200000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+// o2.f2 (column_major) = input.f2
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 0, i8 0, float 5.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 0, i8 1, float 7.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 0, i8 2, float 9.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 0, i8 3, float 1.100000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 1, i8 0, float 6.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 1, i8 1, float 8.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 1, i8 2, float 1.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void  @dx.op.storeOutput.f32(i32 5, i32 8, i32 1, i8 3, float 1.200000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+
+struct VSIn_1
+{
+    float4 f5 : VIN4;
+    float3 f6 : VIN5;
+};
+    
+struct VSIn
+{
+    float4 f1 : VIN0;
+    float4x2 f2 : VIN1;
+    float2 f3[4] : VIN2;
+    uint3 f4 : VIN3;
+    VSIn_1 s;
+    bool f7 : VIN6;
+};
+
+struct VSOut_1
+{
+    float4 f5 : VOUT4;
+    float3 f6 : VOUT5;
+};
+   
+   
+struct VSOut
+{
+    float4 f1 : VOUT0;
+    float4x2 f2 : VOUT1;
+    float2 f3[4] : VOUT2;
+    uint3 f4 : VOUT3;
+    VSOut_1 s;
+    bool f7 : VOUT6;
+};
+
+void main(out VSOut o1 : A, out VSOut o2 : B)
+{
+   VSIn input;
+   input.f1 = float4(1, 2, 3, 4);
+   input.f2[0][0] = 5;
+   input.f2[0][1] = 6;
+   input.f2[1][0] = 7;
+   input.f2[1][1] = 8;
+   input.f2[2][0] = 9;
+   input.f2[2][1] = 10;
+   input.f2[3][0] = 11;
+   input.f2[3][1] = 12;
+   input.f3[0] = float2(13, 14);
+   input.f3[1] = float2(15, 16);
+   input.f3[2] = float2(17, 18);
+   input.f3[3] = float2(19, 20);   
+   input.f4 = uint3(21, 22, 23);
+   input.s.f5 = float4(24, 25, 26, 27);
+   input.s.f6 = float3(28, 29, 30);
+   input.f7 = true;
+   o1 = (VSOut)input;
+   o2 = (VSOut)input;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario-strictudt.hlsl
@@ -1,0 +1,54 @@
+// RUN: %dxc -E main -T ps_6_0 -strict-udt-casting %s | FileCheck %s
+// github issue #1725
+// Test implicit cast scenario between structs of identical layout
+// which would crash as reported by a user.
+
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.000000e+00)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 0.000000e+00)
+  
+struct BUFF
+{
+    float4 rt0 : SV_Target0;
+};
+
+struct VSOUT_A
+{
+    float4 hclip : SV_Position;
+    float3 wp : WORLD_POSITION;
+};
+
+struct VSOUT_B
+{
+    VSOUT_A position;
+    float3 normal : NORMAL;
+};
+
+struct VSOUT_C
+{
+    VSOUT_A position;
+    float3 normal : NORMAL;
+};
+
+float3 getNormal(in VSOUT_B vsout)
+{
+    return vsout.normal;
+}
+
+struct VSOUT_D
+{
+    VSOUT_C standard;
+};
+
+void foo(in VSOUT_A stdP)
+{
+    (stdP) = (stdP);
+}
+
+BUFF main(VSOUT_D input)
+{
+    foo(input.standard.position);        // comment out and it will compile fine
+    float3 N = getNormal( (VSOUT_B)input.standard ); // comment this out and it will compile fine    
+    return (BUFF)0;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append-strictudt.hlsl
@@ -1,0 +1,62 @@
+// RUN: %dxc /Tgs_6_0 /Emain -strict-udt-casting %s | FileCheck %s
+// github issue #1560
+
+// CHECK: main
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 3.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 4.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float 5.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 1, float 6.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 2, float 7.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 3, float 8.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.emitStream(i32 97, i8 0)  ; EmitStream(streamId)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 9.000000e+00)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 1.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 1.100000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 1.200000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float 1.300000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 1, float 1.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 2, float 1.500000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 3, float 1.600000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.emitStream(i32 97, i8 0)  ; EmitStream(streamId)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.700000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 1.800000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 1.900000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 2.000000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 0, float 2.100000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 1, float 2.200000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 2, float 2.300000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 1, i32 0, i8 3, float 2.400000e+01)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+// CHECK: call void @dx.op.emitStream(i32 97, i8 0)  ; EmitStream(streamId)
+// CHECK: ret void
+
+struct VSOutGSIn
+{
+    float4  clr : COLOR0;
+    float4  pos : SV_Position;
+};
+
+struct GSOutPSIn
+{
+    float4  clr : COLOR0;
+    float4  pos : SV_Position;
+};
+
+[maxvertexcount(3)]
+void main(inout TriangleStream<GSOutPSIn> stream)
+{
+    VSOutGSIn tri[3];
+    tri[0].clr = float4(1, 2, 3, 4);
+    tri[0].pos = float4(5, 6, 7, 8);
+
+    tri[1].clr = float4(9, 10, 11, 12);
+    tri[1].pos = float4(13, 14, 15, 16);
+
+    tri[2].clr = float4(17, 18, 19, 20);
+    tri[2].pos = float4(21, 22, 23, 24);
+    
+    stream.Append((GSOutPSIn)tri[0]);
+    stream.Append((GSOutPSIn)tri[1]);
+    stream.Append((GSOutPSIn)tri[2]);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous-strictudt.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// Tests declarations and uses of anonymous structs.
+
+// CHECK: call i32 @dx.op.loadInput.i32
+// CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: add nsw i32
+// CHECK: call void @dx.op.storeOutput.i32
+
+typedef struct { int x; } typedefed;
+
+struct { int x; } global;
+struct Outer
+{
+    struct { int x; } field;
+};
+
+int main(Outer input : IN) : OUT
+{
+    struct { int x; } local = input.field;
+    typedefed retval = (typedefed)local;
+    return retval.x + global.x;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray-strictudt.hlsl
@@ -1,0 +1,35 @@
+// RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// CHECK: @main
+struct Vertex
+{
+    float4 position     : POSITION0;
+    float4 color        : COLOR0;
+};
+
+struct Interpolants
+{
+    float4 position     : SV_POSITION0;
+    float4 color        : COLOR0;
+};
+
+
+struct T {
+  float4 t;
+};
+
+struct TA {
+  T  ta[2];
+};
+
+TA test(T t[2]) {
+  TA ta = { t };
+  return ta;
+}
+
+Interpolants main(  Vertex In)
+{
+  TA ta = (TA)In;
+
+  return (Interpolants)test(ta.ta);
+}

--- a/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_split_regression-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_split_regression-strictudt.hlsl
@@ -1,0 +1,85 @@
+// RUN: %dxc -E main -T ps_6_0 -Od -strict-udt-casting %s | FileCheck %s
+
+//
+// CHECK: @main
+//
+// Regression test for certain allocas not being split by SROA because
+// SROA_Helper::LowerMemcpy returned true but didn't actually remove all uses
+// of the alloca.
+//
+// Consider the following example:
+// 
+//     a = alloca MyStruct
+//     b = alloca MyStruct
+//     c = alloca MyStruct
+//     ...
+//     memcpy(b, a, sizeof(MyStruct))
+//     ...
+//     memcpy(c, b, sizeof(MyStruct))
+//
+// When SROA_Helper::LowerMemcpy is working on b, ReplaceMemcpy replaces the
+// memcpy with loads and stores and returns true:
+// 
+//     a = alloca MyStruct
+//     b = alloca MyStruct
+//     c = alloca MyStruct
+//     ...
+//     b->member1 = a->member1;
+//     b->member2 = a->member2;
+//     ...
+//     b->memberN = a->memberN;
+//     ...
+//     memcpy(c, b, sizeof(MyStruct))
+//
+// At this point SROA_Helper::LowerMemcpy returned true because it incorrectly
+// assumed that all uses of `b` has been removed because it only has one store
+// which is memcpy, and ReplaceMemcpy has replaced it, even though the alloca
+// is still being used.
+//
+
+struct MyStruct {
+  float4 foo;
+  float4 bar;
+  float4 baz;
+};
+
+cbuffer cb : register(b0) {
+  float4 foo;
+  float4 bar;
+  float4 baz;
+};
+
+MyStruct make() {
+  MyStruct local;
+  local.foo = foo;
+  local.bar = bar;
+  local.baz = baz;
+  return local;
+}
+
+MyStruct transform_mul(MyStruct arg_0) {
+  MyStruct st[1] = {{
+    arg_0.foo * 2,
+    arg_0.bar * 2,
+    arg_0.baz * 2,
+  }};
+  return arg_0;
+}
+
+MyStruct transform(MyStruct arg) {
+  MyStruct ret;
+  ret = transform_mul(arg);
+  return ret;
+}
+
+float4 main() : SV_Target {
+  MyStruct v0 = (MyStruct)0;
+  v0 = make();
+  MyStruct v1[1] = {transform(v0)};
+  MyStruct v2[1] = {transform(v1[0])};
+  MyStruct v3[1] = {transform(v2[0])};
+  MyStruct v4[1] = {transform(v3[0])};
+  return v4[0].foo + v4[0].bar + v4[0].baz;
+}
+
+

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs-strictudt.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -E main -T gs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// Regression test for an SROA bug where the flattening the output stream argument
+// would not handle the case where its input had already been SROA'd.
+
+// CHECK: define void @main()
+// CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 0)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float {{.*}})
+// CHECK: call void @dx.op.emitStream(i32 97, i8 0)
+// CHECK: ret void
+
+struct GSIn { float value : TEXCOORD0; };
+struct GSOut { float value : TEXCOORD0; };
+
+[maxvertexcount(1)]
+void main(point GSIn input[1], inout PointStream<GSOut> output)
+{
+    output.Append((GSOut)input[0]);
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs-strictudt.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -E main -T gs_6_0 -strict-udt-casting %s | FileCheck %s
+
+// Regression test for an SROA bug where the flattening the output stream argument
+// would not handle the case where its input had already been SROA'd.
+
+// CHECK: define void @main()
+// CHECK: call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 0)
+// CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float {{.*}})
+// CHECK: call void @dx.op.emitStream(i32 97, i8 0)
+// CHECK: ret void
+
+struct GSIn { float value : TEXCOORD0; };
+struct GSOut { float value : TEXCOORD0; };
+
+[maxvertexcount(1)]
+void main(inout PointStream<GSOut> output, point GSIn input[1])
+{
+    output.Append((GSOut)input[0]);
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch-strictudt.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc -T lib_6_x -default-linkage external -strict-udt-casting %s | FileCheck %s
+
+// CHECK: define <4 x float>
+// CHECK-SAME: main
+// CHECK-NOT: bitcast
+// CHECK-NOT: CallStruct
+// CHECK: ParamStruct
+// CHECK: call void @llvm.lifetime.start
+// CHECK-NOT: bitcast
+// CHECK-NOT: CallStruct
+// CHECK-LABEL: ret <4 x float>
+
+struct ParamStruct {
+  int i;
+  float f;
+};
+
+struct CallStruct {
+  int i;
+  float f;
+};
+
+void modify(inout ParamStruct s) {
+  s.f += 1;
+}
+
+void modify_ext(inout ParamStruct s);
+
+CallStruct g_struct;
+
+float4 main() : SV_Target {
+  CallStruct local = g_struct;
+  modify((ParamStruct)local);
+  modify_ext((ParamStruct)local);
+  return local.f;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1303,6 +1303,7 @@ public:
     compiler.getLangOpts().EnableDX9CompatMode = Opts.EnableDX9CompatMode;
     compiler.getLangOpts().EnableFXCCompatMode = Opts.EnableFXCCompatMode;
     compiler.getLangOpts().EnableTemplates = Opts.EnableTemplates;
+    compiler.getLangOpts().StrictUDTCasting = Opts.StrictUDTCasting;
 
     compiler.getLangOpts().UseMinPrecision = !Opts.Enable16BitTypes;
 

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -460,6 +460,7 @@ void SetupCompilerCommon(CompilerInstance &compiler,
     compiler.getDiagnostics().setWarningsAsErrors(true);
   compiler.getDiagnostics().setIgnoreAllWarnings(!opts.OutputWarnings);
   compiler.getLangOpts().HLSLVersion = (unsigned)opts.HLSLVersion;
+  compiler.getLangOpts().StrictUDTCasting = opts.StrictUDTCasting;
   compiler.getLangOpts().UseMinPrecision = !opts.Enable16BitTypes;
   compiler.getLangOpts().EnableDX9CompatMode = opts.EnableDX9CompatMode;
   compiler.getLangOpts().EnableFXCCompatMode = opts.EnableFXCCompatMode;

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -42,6 +42,7 @@ public:
   TEST_METHOD(RunConstAssign)
   TEST_METHOD(RunConstDefault)
   TEST_METHOD(RunConversionsBetweenTypeShapes)
+  TEST_METHOD(RunConversionsBetweenTypeShapesStrictUDT)
   TEST_METHOD(RunConversionsNonNumericAggregates)
   TEST_METHOD(RunCppErrors)
   TEST_METHOD(RunCppErrorsHV2015)
@@ -173,6 +174,10 @@ TEST_F(VerifierTest, RunConstDefault) {
 
 TEST_F(VerifierTest, RunConversionsBetweenTypeShapes) {
   CheckVerifiesHLSL(L"conversions-between-type-shapes.hlsl");
+}
+
+TEST_F(VerifierTest, RunConversionsBetweenTypeShapesStrictUDT) {
+  CheckVerifiesHLSL(L"conversions-between-type-shapes-strictudt.hlsl");
 }
 
 TEST_F(VerifierTest, RunConversionsNonNumericAggregates) {

--- a/utils/hct/VerifierHelper.py
+++ b/utils/hct/VerifierHelper.py
@@ -60,6 +60,7 @@ VerifierTests = {
     'RunConstDefault': 'const-default.hlsl',
     'RunConstExpr': 'const-expr.hlsl',
     'RunConversionsBetweenTypeShapes': 'conversions-between-type-shapes.hlsl',
+    'RunConversionsBetweenTypeShapesStrictUDT': 'conversions-between-type-shapes-strictudt.hlsl',
     'RunConversionsNonNumericAggregates': 'conversions-non-numeric-aggregates.hlsl',
     'RunCppErrors': 'cpp-errors.hlsl',
     'RunCppErrorsHV2015': 'cpp-errors-hv2015.hlsl',


### PR DESCRIPTION
TODO: Enable this by default under -HV 2021

Fixes #3564.
Fixes #3563.