### PR TITLE
Add attr::HLSLShader to list of HLSL attributes in IsHLSLAttr()

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -13317,6 +13317,7 @@ bool hlsl::IsHLSLAttr(clang::attr::Kind AttrKind) {
   case clang::attr::HLSLRowMajor:
   case clang::attr::HLSLSample:
   case clang::attr::HLSLSemantic:
+  case clang::attr::HLSLShader:
   case clang::attr::HLSLShared:
   case clang::attr::HLSLSnorm:
   case clang::attr::HLSLUniform:


### PR DESCRIPTION
`IsHLSLAttr(clang::attr::Kind AttrKind)` must return `true` for `clang::attr::HLSLShader` to support SM6.3 `[shader("...")]` attributes.