### PR TITLE
Fix crash when structurizing multi-return loops

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -300,7 +300,7 @@ public:
   void MarkReturnStmt(CodeGenFunction &CGF, BasicBlock *bbWithRet) override;
   void MarkLoopStmt(CodeGenFunction &CGF, BasicBlock *loopContinue,
                      BasicBlock *loopExit) override;
-  void MarkScopeEnd(CodeGenFunction &CGF) override;
+  CGHLSLMSHelper::Scope* MarkScopeEnd(CodeGenFunction &CGF) override;
   bool NeedHLSLMartrixCastForStoreOp(const clang::Decl* TD,
     llvm::SmallVector<llvm::Value*, 16>& IRCallArgs) override;
   void EmitHLSLMartrixCastForStoreOp(CodeGenFunction& CGF,
@@ -6147,12 +6147,14 @@ void CGMSHLSLRuntime::MarkLoopStmt(CodeGenFunction &CGF,
     Scope->AddLoop(loopContinue, loopExit);
 }
 
-void CGMSHLSLRuntime::MarkScopeEnd(CodeGenFunction &CGF) {
+Scope *CGMSHLSLRuntime::MarkScopeEnd(CodeGenFunction &CGF) {
   if (ScopeInfo *Scope = GetScopeInfo(CGF.CurFn)) {
     llvm::BasicBlock *CurBB = CGF.Builder.GetInsertBlock();
     bool bScopeFinishedWithRet = !CurBB || CurBB->getTerminator();
-    Scope->EndScope(bScopeFinishedWithRet);
+    return &Scope->EndScope(bScopeFinishedWithRet);
   }
+
+  return nullptr;
 }
 
 CGHLSLRuntime *CodeGen::CreateMSHLSLRuntime(CodeGenModule &CGM) {

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -3331,13 +3331,14 @@ void ScopeInfo::AddRet(BasicBlock *bbWithRet) {
   // Don't need to put retScope to stack since it cannot nested other scopes.
 }
 
-void ScopeInfo::EndScope(bool bScopeFinishedWithRet) {
+Scope& ScopeInfo::EndScope(bool bScopeFinishedWithRet) {
   unsigned idx = scopeStack.pop_back_val();
   Scope &Scope = GetScope(idx);
   // If whole stmt is finished and end scope bb has not used(nothing branch to
   // it). Then the whole scope is returned.
   Scope.bWholeScopeReturned =
       bScopeFinishedWithRet && Scope.EndScopeBB->user_empty();
+  return Scope;
 }
 
 Scope &ScopeInfo::GetScope(unsigned i) { return scopes[i]; }

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -124,7 +124,7 @@ public:
   void AddSwitch(llvm::BasicBlock *endSwitchBB);
   void AddLoop(llvm::BasicBlock *loopContinue, llvm::BasicBlock *endLoopBB);
   void AddRet(llvm::BasicBlock *bbWithRet);
-  void EndScope(bool bScopeFinishedWithRet);
+  Scope &EndScope(bool bScopeFinishedWithRet);
   Scope &GetScope(unsigned i);
   const llvm::SmallVector<unsigned, 2> &GetRetScopes() { return rets; }
   void LegalizeWholeReturnedScope();

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -14,6 +14,11 @@
 #include <functional>
 #include <llvm/ADT/SmallVector.h> // HLSL Change
 
+namespace CGHLSLMSHelper
+{
+    struct Scope;
+}
+
 namespace llvm {
 class Function;
 class Value;
@@ -139,7 +144,7 @@ public:
                              llvm::BasicBlock *loopContinue,
                              llvm::BasicBlock *loopExit) = 0;
 
-  virtual void MarkScopeEnd(CodeGenFunction &CGF) = 0;
+  virtual CGHLSLMSHelper::Scope *MarkScopeEnd(CodeGenFunction &CGF) = 0;
 
   virtual bool NeedHLSLMartrixCastForStoreOp(const clang::Decl* TD,
                               llvm::SmallVector<llvm::Value*, 16>& IRCallArgs) = 0;

--- a/tools/clang/lib/CodeGen/CodeGenFunction.h
+++ b/tools/clang/lib/CodeGen/CodeGenFunction.h
@@ -36,6 +36,11 @@
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/Support/Debug.h"
 
+namespace CGHLSLMSHelper
+{
+struct Scope;
+};
+
 namespace llvm {
 class BasicBlock;
 class LLVMContext;
@@ -1485,7 +1490,10 @@ public:
   /// SimplifyForwardingBlocks - If the given basic block is only a branch to
   /// another basic block, simplify it. This assumes that no other code could
   /// potentially reference the basic block.
-  void SimplifyForwardingBlocks(llvm::BasicBlock *BB);
+  ///
+  /// HLSL CHANGE: Pass the loop scope to update the simplified block pointer.
+  ///
+  void SimplifyForwardingBlocks(llvm::BasicBlock *BB, CGHLSLMSHelper::Scope *LoopScope);
 
   /// EmitBlock - Emit the given block \arg BB and set it as the insert point,
   /// adding a fall-through branch from the current insert block if

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/structurize_multiexit_crash_do.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/structurize_multiexit_crash_do.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T ps_6_0 -opt-enable structurize-returns %s | FileCheck %s
+
+// Make sure we do not crash when structurizing returns from a do {...} while(0) loop.
+// CHECK: define void @main
+
+Texture1D<float> tex;
+
+float foo(uint index)
+{
+    float accum = 0.0;
+    do {
+        float t = tex[index++];
+        if (t == 0.0)
+        {
+            break;
+        }
+        
+        accum += t;
+        
+        if (accum > 2.0)
+        {
+            return t;
+        }
+    } while (0);
+
+    return accum;
+}
+
+[RootSignature("DescriptorTable(SRV(t0))")]
+float main(float a : A) : SV_Target
+{
+    return foo(a);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/structurize_multiexit_crash_while.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/structurize_multiexit_crash_while.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T ps_6_0 -opt-enable structurize-returns %s | FileCheck %s
+
+// Make sure we do not crash when structurizing returns from a while(true) loop.
+// CHECK: define void @main
+Texture1D<float> tex;
+
+float foo(uint index)
+{
+    float accum = 0.0;
+    while (true)
+    {
+        float t = tex[index++];
+        if (t == 0.0)
+        {
+            break;
+        }
+        
+        accum += t;
+        
+        if (accum > 2.0)
+        {
+            return t;
+        }
+    }
+
+    return accum;
+}
+
+[RootSignature("DescriptorTable(SRV(t0))")]
+float main(float a : A) : SV_Target
+{
+    return foo(a);
+}


### PR DESCRIPTION
Clang does a small optimization during codegen for loops of the form
`while(true){...}` and `do{...}while(false)`. It attempts to merge
the loop continue block with the unique successor. Our scope
analysis was not updating its pointers when the original continue
block was removed by this optimization leading to crashes when running
`StructurizeMultiRetFunction()` at the end of codegen.