### PR TITLE
Execute optimizations on functions to be inlined to avoid code explosion

### DIFF
--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -126,7 +126,7 @@ void initializeSROA_Parameter_HLSLPass(PassRegistry&);
 Pass *createDxilFixConstArrayInitializerPass();
 void initializeDxilFixConstArrayInitializerPass(PassRegistry&);
 
-Pass *createDxilConditionalMem2RegPass(bool NoOpt);
+Pass *createDxilConditionalMem2RegPass(bool NoOpt, bool SkipExported = false);
 void initializeDxilConditionalMem2RegPass(PassRegistry&);
 
 Pass *createDxilLoopUnrollPass(unsigned MaxIterationAttempt, bool OnlyWarnOnFail, bool StructurizeLoopExits);
@@ -213,7 +213,7 @@ Pass *createIndVarSimplifyPass();
 // into:
 //    %Z = add int 2, %X
 //
-FunctionPass *createInstructionCombiningPass();
+FunctionPass *createInstructionCombiningPass(bool SkipExported = false);  // HLSL Change - add SkipExported parameter
 
 //===----------------------------------------------------------------------===//
 //

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -405,6 +405,16 @@ void PassManagerBuilder::populateModulePassManager(
   MPM.add(createDxilRewriteOutputArgDebugInfoPass()); // Fix output argument types.
 
   MPM.add(createHLLegalizeParameter()); // legalize parameters before inline.
+
+  // Execute some optimizations on functions to be inlined to avoid code explosion
+  MPM.add(createDxilCleanupAddrSpaceCastPass());
+  MPM.add(createHLPreprocessPass());
+  MPM.add(createDxilConditionalMem2RegPass(/*NoOpt*/false, /*SkipExported*/true));
+  MPM.add(createDxilConvergentMarkPass());  // avoid sample coordinate sinking into control flow (convergent_cs.hlsl)
+  MPM.add(createInstructionCombiningPass(/*SkipExported*/true));
+  MPM.add(createCFGSimplificationPass());
+  MPM.add(createInstructionCombiningPass(/*SkipExported*/true));
+
   MPM.add(createAlwaysInlinerPass(/*InsertLifeTime*/this->HLSLEnableLifetimeMarkers));
   if (Inliner) {
     delete Inliner;

--- a/lib/Transforms/InstCombine/InstCombineCalls.cpp
+++ b/lib/Transforms/InstCombine/InstCombineCalls.cpp
@@ -390,6 +390,7 @@ Instruction *InstCombiner::visitCallInst(CallInst &CI) {
         return EraseInstFromFunction(CI);
     }
 
+#if 0 // HLSL Change - Don't convert MemTransfer or MemSet instructions to i1/2/4/8 load/stores
     // If we can determine a pointer alignment that is bigger than currently
     // set, update the alignment.
     if (isa<MemTransferInst>(MI)) {
@@ -399,6 +400,7 @@ Instruction *InstCombiner::visitCallInst(CallInst &CI) {
       if (Instruction *I = SimplifyMemSet(MSI))
         return I;
     }
+#endif // HLSL Change - Don't convert MemTransfer or MemSet instructions to i1/2/4/8 load/stores
 
     if (Changed) return II;
   }

--- a/lib/Transforms/InstCombine/InstCombineCasts.cpp
+++ b/lib/Transforms/InstCombine/InstCombineCasts.cpp
@@ -289,6 +289,7 @@ bool InstCombiner::ShouldOptimizeCast(Instruction::CastOps opc, const Value *V,
 Instruction *InstCombiner::commonCastTransforms(CastInst &CI) {
   Value *Src = CI.getOperand(0);
 
+#if 0 // HLSL Change - Don't eliminate casts of casts to avoid problems with SROA_Helper::LowerMemcpy
   // Many cases of "cast of a cast" are eliminable. If it's eliminable we just
   // eliminate it now.
   if (CastInst *CSrc = dyn_cast<CastInst>(Src)) {   // A->B->C cast
@@ -299,6 +300,7 @@ Instruction *InstCombiner::commonCastTransforms(CastInst &CI) {
       return CastInst::Create(opc, CSrc->getOperand(0), CI.getType());
     }
   }
+#endif // HLSL Change - Don't eliminate casts of casts to avoid problems with SROA_Helper::LowerMemcpy
 
   // If we are casting a select then fold the cast into the select
   if (SelectInst *SI = dyn_cast<SelectInst>(Src))

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure function call on external function has correct type.
-// CHECK: call float @"\01?test_extern@@YAMUT@@Y01U1@U1@AIAV?$matrix@M$01$01@@@Z"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* {{.*}}, %class.matrix.float.2.2* dereferenceable(16) {{.*}})
+// CHECK: call float @"\01?test_extern@@YAMUT@@Y01U1@U1@AIAV?$matrix@M$01$01@@@Z"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* {{.*}}, %class.matrix.float.2.2* nonnull dereferenceable(16) {{.*}})
 
 struct T {
   float a;


### PR DESCRIPTION
The DirectXShaderCompiler always inlines all functions. But it does so before applying any optimizations. Thus unoptimized code is inlined into functions which are also inlined into other functions quickly leading to code explosion for complex call graphs, which results in very slow compile time.
With these changes, a few optimizations are applied before inlining to reduce the compile time.

- Allow to execute DxilConditionalMem2Reg pass without touching functions
  requiring special care due to DXIL signatures, inputs, outputs, etc.,
  i.e. skipping entry functions and other functions with Dxil function
  properties ("exported" functions).
- Fixes TryRemoveUnusedAlloca() skipping casts while comparing the source
  of a MemCpyInst with a BitCast.
- Disable conversion of MemTransfer or MemSet instructions to
  i1/2/4/7 load/stores in InstCombine causing SROA_Helper::RewriteBitCast
  to assert.
- Disable elimination of casts of casts in InstCombine to avoid
  SROA_Helper::LowerMemcpy to fail due to non-matching types.
- Adapted tests:
  - lib_arg_flatten: add a nonnull in the expected call arguments