### PR TITLE
Add --version flag to print dxc version info

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -164,6 +164,7 @@ public:
   bool ShowHelp = false;  // OPT_help
   bool ShowHelpHidden = false; // OPT__help_hidden
   bool ShowOptionNames = false; // OPT_fdiagnostics_show_option
+  bool ShowVersion = false; // OPT_version
   bool UseColor = false; // OPT_Cc
   bool UseHexLiterals = false; // OPT_Lx
   bool UseInstructionByteOffsets = false; // OPT_No

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -216,6 +216,7 @@ def working_directory_EQ : Joined<["-"], "working-directory=">, Flags<[CoreOptio
 def _all_warnings : Flag<["--"], "all-warnings">, Flags<[CoreOption]>, Alias<Wall>;
 def _help_hidden : Flag<["--"], "help-hidden">, Flags<[DriverOption]>;
 def _help_question : Flag<["-", "/"], "?">, Flags<[DriverOption]>, Alias<help>;
+def _version : Flag<["-", "/"], "version">, Flags<[DriverOption]>; //why does this have double __
 
 //////////////////////////////////////////////////////////////////////////////
 // New HLSL-specific flags.

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -216,7 +216,8 @@ def working_directory_EQ : Joined<["-"], "working-directory=">, Flags<[CoreOptio
 def _all_warnings : Flag<["--"], "all-warnings">, Flags<[CoreOption]>, Alias<Wall>;
 def _help_hidden : Flag<["--"], "help-hidden">, Flags<[DriverOption]>;
 def _help_question : Flag<["-", "/"], "?">, Flags<[DriverOption]>, Alias<help>;
-def _version : Flag<["-", "/"], "version">, Flags<[DriverOption]>; //why does this have double __
+def _version : Flag<["--"], "version">, Group<hlslcore_Group>, Flags<[DriverOption]>,
+  HelpText<"Display compiler version information">;
 
 //////////////////////////////////////////////////////////////////////////////
 // New HLSL-specific flags.

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -377,6 +377,11 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     return 0;
   }
 
+  opts.ShowVersion = Args.hasFlag(OPT__version, OPT_INVALID, false);
+  if (opts.ShowVersion) {
+    return 0;
+  }
+
   if (missingArgCount) {
     errors << "Argument to '" << Args.getArgString(missingArgIndex)
       << "' is missing.";

--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -1353,6 +1353,15 @@ int dxc::main(int argc, const char **argv_) {
       helpStream.flush();
       WriteUtf8ToConsoleSizeT(helpString.data(), helpString.size());
       return 0;
+    } 
+
+    if (dxcOpts.ShowVersion) {
+      std::string version;
+      llvm::raw_string_ostream versionStream(version);
+      context.GetCompilerVersionInfo(versionStream);
+      versionStream.flush();
+      WriteUtf8ToConsoleSizeT(version.data(), version.size());
+      return 0;
     }
 
     // TODO: implement all other actions.

--- a/tools/clang/tools/dxr/dxr.cpp
+++ b/tools/clang/tools/dxr/dxr.cpp
@@ -176,6 +176,21 @@ int __cdecl wmain(int argc, const wchar_t **argv_) {
       return 0;
     }
 
+    if (dxcOpts.ShowVersion) {
+      std::string version;
+      llvm::raw_string_ostream versionStream(version);
+      WriteDxCompilerVersionInfo(
+          versionStream,
+          dxcOpts.ExternalLib.empty() ? (LPCSTR) nullptr
+                                      : dxcOpts.ExternalLib.data(),
+          dxcOpts.ExternalFn.empty() ? (LPCSTR) nullptr
+                                     : dxcOpts.ExternalFn.data(),
+          dxcSupport);
+      versionStream.flush();
+      WriteUtf8ToConsoleSizeT(version.data(), version.size());
+      return 0;
+    }
+
     CComPtr<IDxcRewriter2> pRewriter;
     CComPtr<IDxcOperationResult> pRewriteResult;
     CComPtr<IDxcBlobEncoding> pSource;


### PR DESCRIPTION
- Added a --version flag to display the same dxc version info displayed from the -? flag
- Added --version flag description to the help text displayed from the -? flag