### PR TITLE
Allow host to be passed to CMake for cross compile

### DIFF
--- a/cmake/config-ix.cmake
+++ b/cmake/config-ix.cmake
@@ -318,8 +318,10 @@ endif()
 
 # By default, we target the host, but this can be overridden at CMake
 # invocation time.
-include(GetHostTriple)
-get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+if (NOT DEFINED LLVM_INFERRED_HOST_TRIPLE)
+  include(GetHostTriple)
+  get_host_triple(LLVM_INFERRED_HOST_TRIPLE)
+endif()
 
 set(LLVM_HOST_TRIPLE "${LLVM_INFERRED_HOST_TRIPLE}" CACHE STRING
     "Host on which LLVM binaries will run")


### PR DESCRIPTION
When cross compiling for Android on Windows, GetHostTriple.cmake will end up running Linux shell commands.  This small change lets the user pass in LLVM_INFERRED_HOST_TRIPLE via the cmake command line and bypass the need to invoke the GetHostTriple logic.

With this change I was able to build for Android on Windows using the ninja generator and passing -DLLVM_INFERRED_HOST_TRIPLE=x86_64-pc-win32 to cmake.