### PR TITLE
[SPIRV] Add linkageAttributes decorates

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -641,6 +641,10 @@ public:
   void decorateCoherent(SpirvInstruction *target, SourceLocation);
 
   /// \brief Decorates the given target with LinkageAttributes
+  /// We have to set targetInst as nullptr when it is an imported or exported
+  /// function.
+  /// We have to set targetFunc as nullptr when it is an imported or
+  /// exported global variable.
   void decorateLinkage(SpirvInstruction *targetInst, SpirvFunction *targetFunc,
                        llvm::StringRef name, spv::LinkageType linkageType,
                        SourceLocation);

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -640,6 +640,11 @@ public:
   /// \brief Decorates the given target with Coherent
   void decorateCoherent(SpirvInstruction *target, SourceLocation);
 
+  /// \brief Decorates the given target with LinkageAttributes
+  void decorateLinkage(SpirvInstruction *targetInst, SpirvFunction *targetFunc,
+                       llvm::StringRef name, spv::LinkageType linkageType,
+                       SourceLocation);
+
   /// --- Constants ---
   /// Each of these methods can acquire a unique constant from the SpirvContext,
   /// and add the context to the list of constants in the module.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -470,10 +470,8 @@ public:
                   spv::Decoration decor,
                   llvm::ArrayRef<SpirvInstruction *> params);
 
-  SpirvDecoration(SourceLocation loc, SpirvInstruction *target,
-                  SpirvFunction *targetFunc, spv::Decoration decor,
-                  llvm::ArrayRef<uint32_t> params = {},
-                  llvm::Optional<uint32_t> index = llvm::None);
+  SpirvDecoration(SourceLocation loc, SpirvFunction *targetFunc,
+                  spv::Decoration decor, llvm::ArrayRef<uint32_t> params);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDecoration)
 

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -470,6 +470,11 @@ public:
                   spv::Decoration decor,
                   llvm::ArrayRef<SpirvInstruction *> params);
 
+  SpirvDecoration(SourceLocation loc, SpirvInstruction *target,
+                  SpirvFunction *targetFunc, spv::Decoration decor,
+                  llvm::ArrayRef<uint32_t> params = {},
+                  llvm::Optional<uint32_t> index = llvm::None);
+
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDecoration)
 
   // For LLVM-style RTTI
@@ -483,7 +488,7 @@ public:
 
   // Returns the instruction that is the target of the decoration.
   SpirvInstruction *getTarget() const { return target; }
-
+  SpirvFunction *getTargetFunc() const { return targetFunction; }
   spv::Decoration getDecoration() const { return decoration; }
   llvm::ArrayRef<uint32_t> getParams() const { return params; }
   llvm::ArrayRef<SpirvInstruction *> getIdParams() const { return idParams; }
@@ -496,6 +501,7 @@ private:
 
 private:
   SpirvInstruction *target;
+  SpirvFunction *targetFunction;
   spv::Decoration decoration;
   llvm::Optional<uint32_t> index;
   llvm::SmallVector<uint32_t, 4> params;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1402,9 +1402,10 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
       spvBuilder.createSpirvFunction(fn->getReturnType(), fn->getLocation(),
                                      fn->getName(), isPrecise, isNoInline);
 
-  if (fn->getAttr<HLSLExportAttr>())
+  if (fn->getAttr<HLSLExportAttr>()) {
     spvBuilder.decorateLinkage(nullptr, spirvFunction, fn->getName(),
                                spv::LinkageType::Export, fn->getLocation());
+  }
 
   // No need to dereference to get the pointer. Function returns that are
   // stand-alone aliases are already pointers to values. All other cases should

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1285,7 +1285,7 @@ SpirvVariable *DeclResultIdMapper::createPushConstant(const VarDecl *decl) {
 }
 
 SpirvVariable *
-DeclResultIdMapper::createShaderRecordBuffer(const VarDecl *decl, 
+DeclResultIdMapper::createShaderRecordBuffer(const VarDecl *decl,
                                                 ContextUsageKind kind) {
   const auto *recordType =
       hlsl::GetHLSLResourceResultType(decl->getType())->getAs<RecordType>();
@@ -1401,6 +1401,10 @@ SpirvFunction *DeclResultIdMapper::getOrRegisterFn(const FunctionDecl *fn) {
   SpirvFunction *spirvFunction =
       spvBuilder.createSpirvFunction(fn->getReturnType(), fn->getLocation(),
                                      fn->getName(), isPrecise, isNoInline);
+
+  if (fn->getAttr<HLSLExportAttr>())
+    spvBuilder.decorateLinkage(nullptr, spirvFunction, fn->getName(),
+                               spv::LinkageType::Export, fn->getLocation());
 
   // No need to dereference to get the pointer. Function returns that are
   // stand-alone aliases are already pointers to values. All other cases should

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -591,9 +591,9 @@ bool EmitVisitor::visit(SpirvModuleProcessed *inst) {
 
 bool EmitVisitor::visit(SpirvDecoration *inst) {
   initInstruction(inst);
-  if (inst->getTarget())
+  if (inst->getTarget()) {
     curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getTarget()));
-  else {
+  } else {
     assert(inst->getTargetFunc() != nullptr);
     curInst.push_back(
         getOrAssignResultId<SpirvFunction>(inst->getTargetFunc()));

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -591,7 +591,14 @@ bool EmitVisitor::visit(SpirvModuleProcessed *inst) {
 
 bool EmitVisitor::visit(SpirvDecoration *inst) {
   initInstruction(inst);
-  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getTarget()));
+  if (inst->getTarget())
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getTarget()));
+  else {
+    assert(inst->getTargetFunc() != nullptr);
+    curInst.push_back(
+        getOrAssignResultId<SpirvFunction>(inst->getTargetFunc()));
+  }
+
   if (inst->isMemberDecoration())
     curInst.push_back(inst->getMemberIndex());
   curInst.push_back(static_cast<uint32_t>(inst->getDecoration()));

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1385,14 +1385,22 @@ void SpirvBuilder::decorateLinkage(SpirvInstruction *targetInst,
                                    llvm::StringRef name,
                                    spv::LinkageType linkageType,
                                    SourceLocation srcLoc) {
+  // We have to set a decoration for the linkage of a global variable or a
+  // function, but we cannot set them at the same time.
+  assert((targetInst == nullptr) != (targetFunc == nullptr));
   SmallVector<uint32_t, 4> operands;
   const auto &stringWords = string::encodeSPIRVString(name);
   operands.insert(operands.end(), stringWords.begin(), stringWords.end());
   operands.push_back(static_cast<uint32_t>(linkageType));
-
-  auto *decor = new (context)
-      SpirvDecoration(srcLoc, targetInst, targetFunc,
-                      spv::Decoration::LinkageAttributes, operands);
+  SpirvDecoration *decor = nullptr;
+  if (targetInst) {
+    decor = new (context) SpirvDecoration(
+        srcLoc, targetInst, spv::Decoration::LinkageAttributes, operands);
+  } else {
+    decor = new (context) SpirvDecoration(
+        srcLoc, targetFunc, spv::Decoration::LinkageAttributes, operands);
+  }
+  assert(decor != nullptr);
   mod->addDecoration(decor);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -19,6 +19,7 @@
 #include "RemoveBufferBlockVisitor.h"
 #include "SortDebugInfoVisitor.h"
 #include "clang/SPIRV/AstTypeProbe.h"
+#include "clang/SPIRV/String.h"
 
 namespace clang {
 namespace spirv {
@@ -1376,6 +1377,22 @@ void SpirvBuilder::decorateCoherent(SpirvInstruction *target,
                                     SourceLocation srcLoc) {
   auto *decor =
       new (context) SpirvDecoration(srcLoc, target, spv::Decoration::Coherent);
+  mod->addDecoration(decor);
+}
+
+void SpirvBuilder::decorateLinkage(SpirvInstruction *targetInst,
+                                   SpirvFunction *targetFunc,
+                                   llvm::StringRef name,
+                                   spv::LinkageType linkageType,
+                                   SourceLocation srcLoc) {
+  SmallVector<uint32_t, 4> operands;
+  const auto &stringWords = string::encodeSPIRVString(name);
+  operands.insert(operands.end(), stringWords.begin(), stringWords.end());
+  operands.push_back(static_cast<uint32_t>(linkageType));
+
+  auto *decor = new (context)
+      SpirvDecoration(srcLoc, targetInst, targetFunc,
+                      spv::Decoration::LinkageAttributes, operands);
   mod->addDecoration(decor);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -225,7 +225,7 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
                                  llvm::Optional<uint32_t> idx)
     : SpirvInstruction(IK_Decoration, getDecorateOpcode(decor, idx),
                        /*type*/ {}, loc),
-      target(targetInst), decoration(decor), index(idx),
+      target(targetInst), targetFunction(nullptr), decoration(decor), index(idx),
       params(p.begin(), p.end()), idParams() {}
 
 SpirvDecoration::SpirvDecoration(SourceLocation loc,
@@ -235,7 +235,8 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
                                  llvm::Optional<uint32_t> idx)
     : SpirvInstruction(IK_Decoration, getDecorateOpcode(decor, idx),
                        /*type*/ {}, loc),
-      target(targetInst), decoration(decor), index(idx), params(), idParams() {
+      target(targetInst), targetFunction(nullptr), decoration(decor), index(idx),
+      params(), idParams() {
   const auto &stringWords = string::encodeSPIRVString(strParam);
   params.insert(params.end(), stringWords.begin(), stringWords.end());
 }
@@ -246,8 +247,19 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
                                  llvm::ArrayRef<SpirvInstruction *> ids)
     : SpirvInstruction(IK_Decoration, spv::Op::OpDecorateId,
                        /*type*/ {}, loc),
-      target(targetInst), decoration(decor), index(llvm::None), params(),
+      target(targetInst), targetFunction(nullptr), decoration(decor), index(llvm::None), params(),
       idParams(ids.begin(), ids.end()) {}
+
+SpirvDecoration::SpirvDecoration(SourceLocation loc,
+                                 SpirvInstruction *targetInst,
+                                 SpirvFunction *targetFunc,
+                                 spv::Decoration decor,
+                                 llvm::ArrayRef<uint32_t> p,
+                                 llvm::Optional<uint32_t> idx)
+    : SpirvInstruction(IK_Decoration, getDecorateOpcode(decor, idx),
+                       /*type*/ {}, loc),
+      target(targetInst), targetFunction(targetFunc), decoration(decor),
+      index(idx), params(p.begin(), p.end()), idParams() {}
 
 spv::Op SpirvDecoration::getDecorateOpcode(
     spv::Decoration decoration, const llvm::Optional<uint32_t> &memberIndex) {

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -250,16 +250,13 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
       target(targetInst), targetFunction(nullptr), decoration(decor), index(llvm::None), params(),
       idParams(ids.begin(), ids.end()) {}
 
-SpirvDecoration::SpirvDecoration(SourceLocation loc,
-                                 SpirvInstruction *targetInst,
-                                 SpirvFunction *targetFunc,
+SpirvDecoration::SpirvDecoration(SourceLocation loc, SpirvFunction *targetFunc,
                                  spv::Decoration decor,
-                                 llvm::ArrayRef<uint32_t> p,
-                                 llvm::Optional<uint32_t> idx)
-    : SpirvInstruction(IK_Decoration, getDecorateOpcode(decor, idx),
+                                 llvm::ArrayRef<uint32_t> p)
+    : SpirvInstruction(IK_Decoration, spv::Op::OpDecorate,
                        /*type*/ {}, loc),
-      target(targetInst), targetFunction(targetFunc), decoration(decor),
-      index(idx), params(p.begin(), p.end()), idParams() {}
+      target(nullptr), targetFunction(targetFunc), decoration(decor),
+      index(llvm::None), params(p.begin(), p.end()), idParams() {}
 
 spv::Op SpirvDecoration::getDecorateOpcode(
     spv::Decoration decoration, const llvm::Optional<uint32_t> &memberIndex) {

--- a/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.export.hlsl
@@ -4,6 +4,7 @@
 // CHECK: OpCapability Linkage
 RWBuffer< float4 > output : register(u1);
 
+// CHECK: OpDecorate %main LinkageAttributes "main" Export
 // CHECK: %main = OpFunction %int None
 export int main(inout float4 color) {
   output[0] = color;


### PR DESCRIPTION
Add linkageAttributes OpDecorate as required by the spirv spec for the
exported/imported values of Linkage capability