### PR TITLE
[spirv] support vk::combinedImageSampler

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -968,6 +968,16 @@ def Buffer
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "RWBuffer")}]>;
 
+// Global variable with "Texture2D" or "SamplerState" type
+def Texture2DOrSampler
+    : SubsetSubject<
+          Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
+                 S->getType()->getAs<RecordType>()->getDecl() &&
+                 (S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "Texture2D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "SamplerState")}]>;
+
 def VKBuiltIn : InheritableAttr {
   let Spellings = [CXX11<"vk", "builtin">];
   let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;
@@ -1024,6 +1034,15 @@ def VKOffset : InheritableAttr {
   let Spellings = [CXX11<"vk", "offset">];
   let Subjects = SubjectList<[Field], ErrorDiag, "ExpectedField">;
   let Args = [IntArgument<"Offset">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+def VKCombinedImageSampler : InheritableAttr {
+  let Spellings = [CXX11<"vk", "combinedImageSampler">];
+  let Subjects = SubjectList<[Texture2DOrSampler],
+                             ErrorDiag, "ExpectedTexture2DOrSamplerState">;
+  let Args = [];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -968,13 +968,12 @@ def Buffer
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "RWBuffer")}]>;
 
-// Global variable with "Texture2D" or "SamplerState" type
-def Texture2DOrSampler
+// Global variable with "Texture" or "SamplerState" type
+def TextureOrSampler
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
                  S->getType()->getAs<RecordType>()->getDecl() &&
-                 (S->getType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "Texture2D" ||
+                 (S->getType()->getAs<RecordType>()->getDecl()->getName().startswith("Texture") ||
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "SamplerState")}]>;
 
@@ -1040,8 +1039,8 @@ def VKOffset : InheritableAttr {
 
 def VKCombinedImageSampler : InheritableAttr {
   let Spellings = [CXX11<"vk", "combinedImageSampler">];
-  let Subjects = SubjectList<[Texture2DOrSampler],
-                             ErrorDiag, "ExpectedTexture2DOrSamplerState">;
+  let Subjects = SubjectList<[TextureOrSampler],
+                             ErrorDiag, "ExpectedTextureOrSamplerState">;
   let Args = [];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2332,6 +2332,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
+  "Texture2D and SamplerState|"
   "RWTextures, Buffers and RWBuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2332,7 +2332,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
-  "Texture2D and SamplerState|"
+  "Textures (e.g., Texture2D) and SamplerState|"
   "RWTextures, Buffers and RWBuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -10,6 +10,7 @@
 #define LLVM_CLANG_SPIRV_SPIRVCONTEXT_H
 
 #include <array>
+#include <limits>
 
 #include "dxc/DXIL/DxilShaderModel.h"
 #include "clang/AST/DeclTemplate.h"
@@ -148,8 +149,14 @@ struct DescriptorSetAndBinding {
 // Provides DenseMapInfo for DescriptorSetAndBinding so we can create a
 // DenseSet of DescriptorSetAndBinding.
 struct DescriptorSetAndBindingMapInfo {
-  static inline DescriptorSetAndBinding getEmptyKey() { return {-1, -1}; }
-  static inline DescriptorSetAndBinding getTombstoneKey() { return {-1, -1}; }
+  static inline DescriptorSetAndBinding getEmptyKey() {
+    return {std::numeric_limits<uint32_t>::max(),
+            std::numeric_limits<uint32_t>::max()};
+  }
+  static inline DescriptorSetAndBinding getTombstoneKey() {
+    return {std::numeric_limits<uint32_t>::max(),
+            std::numeric_limits<uint32_t>::max()};
+  }
   static unsigned getHashValue(const DescriptorSetAndBinding &Val) {
     return llvm::hash_combine(Val.descriptorSet, Val.binding);
   }

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -860,6 +860,7 @@ enum AttributeDeclKind {
   ExpectedScalarGlobalVar,
   ExpectedStructGlobalVar,
   ExpectedGlobalVarOrCTBuffer,
+  ExpectedTexture2DOrSamplerState,
   ExpectedRWTextureOrBuffer,
   ExpectedCounterStructuredBuffer,
   ExpectedSubpassInput,

--- a/tools/clang/include/clang/Sema/AttributeList.h
+++ b/tools/clang/include/clang/Sema/AttributeList.h
@@ -860,7 +860,7 @@ enum AttributeDeclKind {
   ExpectedScalarGlobalVar,
   ExpectedStructGlobalVar,
   ExpectedGlobalVarOrCTBuffer,
-  ExpectedTexture2DOrSamplerState,
+  ExpectedTextureOrSamplerState,
   ExpectedRWTextureOrBuffer,
   ExpectedCounterStructuredBuffer,
   ExpectedSubpassInput,

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -125,10 +125,10 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
         var->setHlslUserType(getHlslResourceTypeName(var->getAstResultType()));
       }
 
-      auto spvImageFormat = spvContext.getImageFormatForSpirvVariable(var);
-      if (spvImageFormat != spv::ImageFormat::Unknown) {
+      auto vkImgFeatures = spvContext.getVkImageFeaturesForSpirvVariable(var);
+      if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
         if (const auto *imageType = dyn_cast<ImageType>(resultType)) {
-          resultType = spvContext.getImageType(imageType, spvImageFormat);
+          resultType = spvContext.getImageType(imageType, vkImgFeatures.format);
           instr->setResultType(resultType);
         }
       }

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1280,8 +1280,8 @@ void SpirvBuilder::decorateDSetBinding(SpirvVariable *target,
   // --convert-to-sampled-image pass.
   if (context.getVkImageFeaturesForSpirvVariable(target)
           .isCombinedImageSampler) {
-    context.registerTypeAndDSetBindingForSampledImage(
-        target->getAstResultType(), {setNumber, bindingNumber});
+    context.registerResourceInfoForSampledImage(target->getAstResultType(),
+                                                setNumber, bindingNumber);
   }
 
   mod->addDecoration(binding);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1274,6 +1274,15 @@ void SpirvBuilder::decorateDSetBinding(SpirvVariable *target,
   target->setDescriptorSetNo(setNumber);
   target->setBindingNo(bindingNumber);
 
+  // If the variable has the [[vk::combinedImageSampler]] attribute, we keep
+  // setNumber and bindingNumber pair to combine the image and the sampler with
+  // with the pair. The combining process will be conducted by spirv-opt
+  // --convert-to-sampled-image pass.
+  if (context.getVkImageFeaturesForSpirvVariable(target)
+          .isCombinedImageSampler) {
+    context.registerDSetBindingForSampledImage({setNumber, bindingNumber});
+  }
+
   mod->addDecoration(binding);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1280,7 +1280,8 @@ void SpirvBuilder::decorateDSetBinding(SpirvVariable *target,
   // --convert-to-sampled-image pass.
   if (context.getVkImageFeaturesForSpirvVariable(target)
           .isCombinedImageSampler) {
-    context.registerDSetBindingForSampledImage({setNumber, bindingNumber});
+    context.registerTypeAndDSetBindingForSampledImage(
+        target->getAstResultType(), {setNumber, bindingNumber});
   }
 
   mod->addDecoration(binding);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1033,9 +1033,13 @@ private:
 
   /// \brief Helper function to run SPIRV-Tools optimizer's legalization passes.
   /// Runs the SPIRV-Tools legalization on the given SPIR-V module |mod|, and
-  /// gets the info/warning/error messages via |messages|.
+  /// gets the info/warning/error messages via |messages|. If
+  /// |dsetbindingsToCombineImageSampler| is not empty, runs
+  /// --convert-to-sampled-image pass.
   /// Returns true on success and false otherwise.
-  bool spirvToolsLegalize(std::vector<uint32_t> *mod, std::string *messages);
+  bool spirvToolsLegalize(std::vector<uint32_t> *mod, std::string *messages,
+                          const llvm::SmallVectorImpl<DescriptorSetAndBinding>
+                              *dsetbindingsToCombineImageSampler);
 
   /// \brief Helper function to run the SPIRV-Tools validator.
   /// Runs the SPIRV-Tools validator on the given SPIR-V module |mod|, and

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -35,6 +35,18 @@
 
 #include "DeclResultIdMapper.h"
 
+namespace spvtools {
+namespace opt {
+
+// A struct for a pair of descriptor set and binding.
+struct DescriptorSetAndBinding {
+  uint32_t descriptor_set;
+  uint32_t binding;
+};
+
+} // namespace opt
+} // namespace spvtools
+
 namespace clang {
 namespace spirv {
 
@@ -1037,9 +1049,10 @@ private:
   /// |dsetbindingsToCombineImageSampler| is not empty, runs
   /// --convert-to-sampled-image pass.
   /// Returns true on success and false otherwise.
-  bool spirvToolsLegalize(std::vector<uint32_t> *mod, std::string *messages,
-                          const llvm::SmallVectorImpl<DescriptorSetAndBinding>
-                              *dsetbindingsToCombineImageSampler);
+  bool
+  spirvToolsLegalize(std::vector<uint32_t> *mod, std::string *messages,
+                     const std::vector<spvtools::opt::DescriptorSetAndBinding>
+                         *dsetbindingsToCombineImageSampler);
 
   /// \brief Helper function to run the SPIRV-Tools validator.
   /// Runs the SPIRV-Tools validator on the given SPIR-V module |mod|, and

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11914,6 +11914,10 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     declAttr = ::new (S.Context) VKOffsetAttr(A.getRange(), S.Context,
       ValidateAttributeIntArg(S, A), A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKCombinedImageSampler:
+    declAttr = ::new (S.Context) VKCombinedImageSamplerAttr(
+        A.getRange(), S.Context, A.getAttributeSpellingListIndex());
+    break;
   case AttributeList::AT_VKImageFormat: {
     VKImageFormatAttr::ImageFormatType Kind = ValidateAttributeEnumArg<
         VKImageFormatAttr, VKImageFormatAttr::ImageFormatType,

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.error.hlsl
@@ -1,0 +1,30 @@
+// Run: %dxc -T ps_6_0 -E main -O0
+
+// CHECK:      fatal error: Texture or Sampler with
+// CHECK-SAME: attribute is missing for descriptor set and binding: 0, 1
+
+Texture2DArray textureArray : register(t1);
+
+[[vk::combinedImageSampler]]
+SamplerState samplerArray : register(s1);
+
+struct VSOutput
+{
+[[vk::location(0)]] float3 Normal : NORMAL0;
+[[vk::location(1)]] float3 Color : COLOR0;
+[[vk::location(2)]] float3 UV : TEXCOORD0;
+[[vk::location(3)]] float3 ViewVec : TEXCOORD1;
+[[vk::location(4)]] float3 LightVec : TEXCOORD2;
+};
+
+float4 main(VSOutput input) : SV_TARGET
+{
+	float4 color = textureArray.Sample(samplerArray, input.UV) * float4(input.Color, 1.0);
+	float3 N = normalize(input.Normal);
+	float3 L = normalize(input.LightVec);
+	float3 V = normalize(input.ViewVec);
+	float3 R = reflect(-L, N);
+	float3 diffuse = max(dot(N, L), 0.1) * input.Color;
+	float3 specular = (dot(N,L) > 0.0) ? pow(max(dot(R, V), 0.0), 16.0) * float3(0.75, 0.75, 0.75) * color.r : float3(0.0, 0.0, 0.0);
+	return float4(diffuse * color.rgb + specular, 1.0);
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
@@ -1,0 +1,16 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpDecorate %gSampler DescriptorSet 3
+// CHECK: OpDecorate %gSampler Binding 2
+// CHECK: OpDecorate %t2 DescriptorSet 0
+// CHECK: OpDecorate %t2 Binding 2
+
+[[vk::combinedImageSampler]] [[vk::binding(2, 3)]]
+SamplerState gSampler : register(s5);
+
+[[vk::combinedImageSampler]]
+Texture2D<float4> t2 : register(t2);
+
+float4 main(int3 offset: A) : SV_Target {
+    return t2.SampleLevel(gSampler, float2(1, 2), 10, 2);
+}

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
@@ -1,16 +1,70 @@
-// Run: %dxc -T ps_6_0 -E main
+// Run: %dxc -T ps_6_0 -E main -O0
 
-// CHECK: OpDecorate %gSampler DescriptorSet 3
-// CHECK: OpDecorate %gSampler Binding 2
-// CHECK: OpDecorate %t2 DescriptorSet 0
-// CHECK: OpDecorate %t2 Binding 2
+// CHECK: OpDecorate %tex0 DescriptorSet 1
+// CHECK: OpDecorate %tex0 Binding 0
+[[vk::combinedImageSampler]][[vk::binding(0, 1)]]
+SamplerState sam0;
+[[vk::combinedImageSampler]][[vk::binding(0, 1)]]
+Texture2D<float4> tex0;
 
-[[vk::combinedImageSampler]] [[vk::binding(2, 3)]]
-SamplerState gSampler : register(s5);
-
+// CHECK: OpDecorate %tex1 DescriptorSet 0
+// CHECK: OpDecorate %tex1 Binding 1
 [[vk::combinedImageSampler]]
-Texture2D<float4> t2 : register(t2);
+SamplerState sam1 : register(s1);
+[[vk::combinedImageSampler]]
+Texture2D<float4> tex1 : register(t1);
+
+// CHECK: OpDecorate %tex2 DescriptorSet 0
+// CHECK: OpDecorate %tex2 Binding 2
+[[vk::combinedImageSampler]]
+SamplerState sam2 : register(s2);
+[[vk::combinedImageSampler]]
+Texture2D<float4> tex2 : register(t2);
+
+// CHECK: OpDecorate %sam3 DescriptorSet 0
+// CHECK: OpDecorate %sam3 Binding 0
+SamplerState sam3 : register(s0);
+
+Texture2D<float4> getTexture(int i) {
+  if (i == 0) return tex0;
+  if (i == 1) return tex1;
+  if (i == 2) return tex2;
+  return tex0;
+}
+
+SamplerState getSampler(int i) {
+  if (i == 0) return sam0;
+  if (i == 1) return sam1;
+  if (i == 2) return sam2;
+  if (i == 3) return sam3;
+  return sam0;
+}
+
+float4 sampleLevel(int i) {
+  return getTexture(i).SampleLevel(getSampler(i), float2(1, 2), 10, 2);
+}
 
 float4 main(int3 offset: A) : SV_Target {
-    return t2.SampleLevel(gSampler, float2(1, 2), 10, 2);
+  float4 ret = 0;
+
+// CHECK: [[tex0:%\w+]] = OpLoad %type_sampled_image %tex0
+// CHECK: OpImageSampleExplicitLod %v4float [[tex0]]
+  ret += sampleLevel(0);
+
+// CHECK: [[tex1:%\w+]] = OpLoad %type_sampled_image %tex1
+// CHECK: OpImageSampleExplicitLod %v4float [[tex1]]
+  ret += sampleLevel(1);
+
+// CHECK: [[tex2:%\w+]] = OpLoad %type_sampled_image %tex2
+// CHECK: OpImageSampleExplicitLod %v4float [[tex2]]
+  ret += sampleLevel(2);
+
+// CHECK: [[tex0:%\w+]] = OpLoad %type_sampled_image %tex0
+// CHECK: [[img_extracted_from_tex0:%\w+]] = OpImage %type_2d_image [[tex0]]
+// CHECK: [[sam3:%\w+]] = OpLoad %type_sampler %sam3
+// CHECK: [[sampled_image:%\w+]] = OpSampledImage %type_sampled_image [[img_extracted_from_tex0]] [[sam3]]
+// CHECK: OpImageSampleExplicitLod %v4float [[sampled_image]]
+  ret += getTexture(0).SampleLevel(getSampler(3), float2(1, 2), 10, 2);
+
+  return ret;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.texture-array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.texture-array.hlsl
@@ -1,0 +1,32 @@
+// Run: %dxc -T ps_6_0 -E main -O0
+
+// CHECK:         [[img:%\w+]] = OpTypeImage %float 2D 2 1 0 1 Unknown
+// CHECK: [[sampled_img:%\w+]] = OpTypeSampledImage [[img]]
+// CHECK:    [[ptr_type:%\w+]] = OpTypePointer UniformConstant [[sampled_img]]
+// CHECK:        %textureArray = OpVariable [[ptr_type]] UniformConstant
+
+[[vk::combinedImageSampler]]
+Texture2DArray textureArray : register(t1);
+[[vk::combinedImageSampler]]
+SamplerState samplerArray : register(s1);
+
+struct VSOutput
+{
+[[vk::location(0)]] float3 Normal : NORMAL0;
+[[vk::location(1)]] float3 Color : COLOR0;
+[[vk::location(2)]] float3 UV : TEXCOORD0;
+[[vk::location(3)]] float3 ViewVec : TEXCOORD1;
+[[vk::location(4)]] float3 LightVec : TEXCOORD2;
+};
+
+float4 main(VSOutput input) : SV_TARGET
+{
+	float4 color = textureArray.Sample(samplerArray, input.UV) * float4(input.Color, 1.0);
+	float3 N = normalize(input.Normal);
+	float3 L = normalize(input.LightVec);
+	float3 V = normalize(input.ViewVec);
+	float3 R = reflect(-L, N);
+	float3 diffuse = max(dot(N, L), 0.1) * input.Color;
+	float3 specular = (dot(N,L) > 0.0) ? pow(max(dot(R, V), 0.0), 16.0) * float3(0.75, 0.75, 0.75) * color.r : float3(0.0, 0.0, 0.0);
+	return float4(diffuse * color.rgb + specular, 1.0);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2070,6 +2070,9 @@ TEST_F(FileTest, VulkanPushConstantOnConstantBuffer) {
 TEST_F(FileTest, VulkanCombinedImageSampler) {
   runFileTest("vk.combined-image-sampler.hlsl");
 }
+TEST_F(FileTest, VulkanCombinedImageSamplerTextureArray) {
+  runFileTest("vk.combined-image-sampler.texture-array.hlsl");
+}
 
 TEST_F(FileTest, VulkanSpecConstantInit) {
   runFileTest("vk.spec-constant.init.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2067,6 +2067,10 @@ TEST_F(FileTest, VulkanPushConstantOnConstantBuffer) {
   runFileTest("vk.push-constant.constantbuffer.hlsl");
 }
 
+TEST_F(FileTest, VulkanCombinedImageSampler) {
+  runFileTest("vk.combined-image-sampler.hlsl");
+}
+
 TEST_F(FileTest, VulkanSpecConstantInit) {
   runFileTest("vk.spec-constant.init.hlsl");
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2073,6 +2073,9 @@ TEST_F(FileTest, VulkanCombinedImageSampler) {
 TEST_F(FileTest, VulkanCombinedImageSamplerTextureArray) {
   runFileTest("vk.combined-image-sampler.texture-array.hlsl");
 }
+TEST_F(FileTest, VulkanCombinedImageSamplerError) {
+  runFileTest("vk.combined-image-sampler.error.hlsl", Expect::Failure);
+}
 
 TEST_F(FileTest, VulkanSpecConstantInit) {
   runFileTest("vk.spec-constant.init.hlsl");


### PR DESCRIPTION
How to use `vk::combinedImageSampler`:
1. Define `SamplerState` and `Texture2D` with the same descriptor set and binding numbers e.g.,
```
[[vk::combinedImageSampler]][[vk::binding(0, 1)]]
SamplerState sam0;
[[vk::combinedImageSampler]][[vk::binding(0, 1)]]
Texture2D<float4> tex0;
```
2. Use them e.g., `tex0.SampleLevel(sam0, float2(1, 2), 10, 2);`
3. Run the legalization after SPIR-V codegen.

Note that we can use the texture `tex0` with samplers other than `sam0`
but we cannot use `sam0` with textures other than `tex0`.