### PR TITLE
[SPIR-V] Fix an issue with duplicate specialisation constants

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1799,7 +1799,7 @@ uint32_t EmitTypeHandler::getOrCreateConstantFloat(SpirvConstantFloat *inst) {
 
   // SpecConstant instructions are not unique, so we should not re-use existing
   // spec constants.
-  if (!isSpecConstant) {
+  if (!isSpecConst) {
     // If this constant has already been emitted, return its result-id.
     auto foundResultId = emittedConstantFloats.find(valueTypePair);
     if (foundResultId != emittedConstantFloats.end()) {

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1929,10 +1929,11 @@ EmitTypeHandler::getOrCreateConstantInt(llvm::APInt value,
   finalizeTypeInstruction();
 
   // Remember this constant for future
-  if (isSpecConst)
+  if (isSpecConst) {
     emittedSpecConstantInstructions.insert(constantInstruction);
-  else
+  } else {
     emittedConstantInts[valueTypePair] = constantResultId;
+  }
 
   return constantResultId;
 }

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -12,6 +12,7 @@
 #include "clang/SPIRV/SpirvContext.h"
 #include "clang/SPIRV/SpirvVisitor.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
 
 #include <functional>
@@ -165,6 +166,7 @@ private:
   llvm::SmallVector<SpirvConstantComposite *, 8> emittedConstantComposites;
   llvm::SmallVector<SpirvConstantNull *, 8> emittedConstantNulls;
   SpirvConstantBoolean *emittedConstantBools[2];
+  llvm::DenseSet<const SpirvInstruction *> emittedSpecConstantInstructions;
 
   // emittedTypes is a map that caches the result-id of types in order to avoid
   // emitting an identical type multiple times.

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.reuse.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.reuse.hlsl
@@ -1,0 +1,10 @@
+// Run: %dxc -T ps_6_0 -E main
+
+// CHECK: OpDecorate %y SpecId 0
+[[vk::constant_id(0)]] const bool y = false;
+
+[shader("pixel")]
+float4 main(float4 position : SV_Position) : SV_Target0 {
+// CHECK: OpConstantComposite %v4bool %y %y %y %y
+    return y ? position : 1.0;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2073,6 +2073,9 @@ TEST_F(FileTest, VulkanSpecConstantInit) {
 TEST_F(FileTest, VulkanSpecConstantUsage) {
   runFileTest("vk.spec-constant.usage.hlsl");
 }
+TEST_F(FileTest, VulkanSpecConstantReuse) {
+  runFileTest("vk.spec-constant.reuse.hlsl");
+}
 TEST_F(FileTest, VulkanSpecConstantError1) {
   runFileTest("vk.spec-constant.error1.hlsl", Expect::Failure);
 }


### PR DESCRIPTION
Fix an issue where specialization constants could be emitted multiple times (once by themselves and once in composites). Resolves #3903.