### PR TITLE
[spirv] Add support for RValues with OpaqueArrayType

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/binary-op.assign.opaque.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.assign.opaque.array.hlsl
@@ -1,5 +1,6 @@
 // Run: %dxc -T ps_6_0 -E main
 
+Texture2D    gTexture;
 Texture2D    gTextures[1];
 SamplerState gSamplers[2];
 
@@ -22,6 +23,12 @@ struct Resources {
 float4 doSample(Texture2D t, SamplerState s[2]);
 
 float4 main() : SV_Target {
+    // Initialize array with brace-enclosed list
+// CHECK:      [[elem0:%\d+]] = OpLoad %type_2d_image %gTexture
+// CHECK-NEXT:  [[arr0:%\d+]] = OpCompositeConstruct %_arr_type_2d_image_uint_1 [[elem0]]
+// CHECK-NEXT:                  OpStore %textures0 [[arr0]]
+    Texture2D textures0[1] = { gTexture };
+
     Resources r;
     // Copy to struct field
 // CHECK:      OpAccessChain %_ptr_UniformConstant_type_2d_image %gTextures %int_0


### PR DESCRIPTION
RValues with OpaqueArrayType can now be legalized with spirv-opt.

Fixes #3677