### PR TITLE
Allow calling DxcInitThreadMalloc again after calling DxcCleanupThreadMalloc

### DIFF
--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -23,11 +23,18 @@ static llvm::sys::ThreadLocal<IMalloc> *g_ThreadMallocTls;
 static IMalloc *g_pDefaultMalloc;
 
 HRESULT DxcInitThreadMalloc() throw() {
-  DXASSERT(g_pDefaultMalloc == nullptr, "else InitThreadMalloc already called");
-
-  // We capture the default malloc early to avoid potential failures later on.
-  HRESULT hrMalloc = CoGetMalloc(1, &g_pDefaultMalloc);
-  if (FAILED(hrMalloc)) return hrMalloc;
+  // Allow a default malloc from a previous call to Init.
+  // This will not be cleaned up in the call to Cleanup because
+  // it can still be referenced after Cleanup is called.
+  if (g_pDefaultMalloc) {
+    g_pDefaultMalloc->AddRef();
+  }
+  else {
+    // We capture the default malloc early to avoid potential failures later on.
+    HRESULT hrMalloc = CoGetMalloc(1, &g_pDefaultMalloc);
+    if (FAILED(hrMalloc)) return hrMalloc;
+  }
+  DXASSERT(g_ThreadMallocTls == nullptr, "else InitThreadMalloc already called");
 
   g_ThreadMallocTls = (llvm::sys::ThreadLocal<IMalloc>*)g_pDefaultMalloc->Alloc(sizeof(llvm::sys::ThreadLocal<IMalloc>));
   if (g_ThreadMallocTls == nullptr) {
@@ -45,7 +52,6 @@ void DxcCleanupThreadMalloc() throw() {
     DXASSERT(g_pDefaultMalloc, "else DxcInitThreadMalloc didn't work/fail atomically");
     g_ThreadMallocTls->~ThreadLocal();
     g_pDefaultMalloc->Free(g_ThreadMallocTls);
-    g_pDefaultMalloc = nullptr;
     g_ThreadMallocTls = nullptr;
   }
 }

--- a/lib/DxcSupport/dxcmem.cpp
+++ b/lib/DxcSupport/dxcmem.cpp
@@ -45,6 +45,7 @@ void DxcCleanupThreadMalloc() throw() {
     DXASSERT(g_pDefaultMalloc, "else DxcInitThreadMalloc didn't work/fail atomically");
     g_ThreadMallocTls->~ThreadLocal();
     g_pDefaultMalloc->Free(g_ThreadMallocTls);
+    g_pDefaultMalloc = nullptr;
     g_ThreadMallocTls = nullptr;
   }
 }

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -48,6 +48,12 @@ bool TestModuleCleanup() {
   ::llvm::llvm_shutdown();
   DxcClearThreadMalloc();
   DxcCleanupThreadMalloc();
+
+  // Make sure we can run init/cleanup mulitple times.
+  if (FAILED(DxcInitThreadMalloc()))
+    return false;
+  DxcCleanupThreadMalloc();
+
   llvm::sys::fs::CleanupPerThreadFileSystem();
   return true;
 }


### PR DESCRIPTION
Without this change we cannot call a sequence of

    DxcInitThreadMalloc()
    DxcCleanupThreadMalloc()
    ...
    DxcInitThreadMalloc() // <- This will trigger an assert

because we hit an assert that assumes the default malloc pointer is nullptr.