### PR TITLE
NoUnwind fix. HLExtIntrinsic collision fix.

### DIFF
--- a/lib/HLSL/DxilLegalizeEvalOperations.cpp
+++ b/lib/HLSL/DxilLegalizeEvalOperations.cpp
@@ -42,7 +42,7 @@ public:
   bool runOnModule(Module &M) override {
     for (Function &F : M.getFunctionList()) {
       hlsl::HLOpcodeGroup group = hlsl::GetHLOpcodeGroup(&F);
-      if (group != HLOpcodeGroup::NotHL) {
+      if (group == HLOpcodeGroup::HLIntrinsic) {
         std::vector<CallInst *> EvalFunctionCalls;
         // Find all EvaluateAttribute calls
         for (User *U : F.users()) {

--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -189,6 +189,7 @@ protected:
     copyAttribute(Attribute::AttrKind::ReadOnly);
     copyAttribute(Attribute::AttrKind::ReadNone);
     copyAttribute(Attribute::AttrKind::ArgMemOnly);
+    copyAttribute(Attribute::AttrKind::NoUnwind);
 
     return attributes;
   }

--- a/lib/HLSL/HLOperations.cpp
+++ b/lib/HLSL/HLOperations.cpp
@@ -421,6 +421,8 @@ HLBinaryOpcode GetUnsignedOpcode(HLBinaryOpcode opcode) {
 
 static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
                                        unsigned opcode) {
+  F->addFnAttr(Attribute::NoUnwind);
+
   switch (group) {
   case HLOpcodeGroup::HLUnOp:
   case HLOpcodeGroup::HLBinOp:
@@ -428,14 +430,12 @@ static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
   case HLOpcodeGroup::HLSubscript:
     if (!F->hasFnAttribute(Attribute::ReadNone)) {
       F->addFnAttr(Attribute::ReadNone);
-      F->addFnAttr(Attribute::NoUnwind);
     }
     break;
   case HLOpcodeGroup::HLInit:
     if (!F->hasFnAttribute(Attribute::ReadNone))
       if (!F->getReturnType()->isVoidTy()) {
         F->addFnAttr(Attribute::ReadNone);
-        F->addFnAttr(Attribute::NoUnwind);
       }
     break;
   case HLOpcodeGroup::HLMatLoadStore: {
@@ -444,16 +444,13 @@ static void SetHLFunctionAttribute(Function *F, HLOpcodeGroup group,
         matOp == HLMatLoadStoreOpcode::RowMatLoad)
       if (!F->hasFnAttribute(Attribute::ReadOnly)) {
         F->addFnAttr(Attribute::ReadOnly);
-        F->addFnAttr(Attribute::NoUnwind);
       }
   } break;
   case HLOpcodeGroup::HLCreateHandle: {
     F->addFnAttr(Attribute::ReadNone);
-    F->addFnAttr(Attribute::NoUnwind);
   } break;
   case HLOpcodeGroup::HLAnnotateHandle: {
     F->addFnAttr(Attribute::ReadNone);
-    F->addFnAttr(Attribute::NoUnwind);
   } break;
   case HLOpcodeGroup::HLIntrinsic: {
     IntrinsicOp intrinsicOp = static_cast<IntrinsicOp>(opcode);

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -1131,8 +1131,8 @@ TEST_F(ExtensionTest, EvalAttributeCollision) {
     std::string disassembly = c.Disassemble();
 
     auto match1 = Match(disassembly, std::string("%([0-9.a-zA-Z]*) = call float @collide_proc\\(i32 ") + std::to_string(Intrinsic.hlsl.Op));
-    VERIFY_ARE_EQUAL(match1.size(), 2);
-    VERIFY_ARE_NOT_EQUAL(Match(disassembly, std::string("call void @dx.op.storeOutput.f32\\(i32 5, i32 0, i32 0, i8 0, float %") + match1[1]).size(), 0);
+    VERIFY_IS_TRUE(match1.size() == 2U);
+    VERIFY_IS_TRUE(Match(disassembly, std::string("call void @dx.op.storeOutput.f32\\(i32 5, i32 0, i32 0, i8 0, float %") + match1[1]).size() != 0U);
   }
 }
 
@@ -1161,8 +1161,8 @@ TEST_F(ExtensionTest, NoUnwind) {
   *   attributes #1 = { nounwind }
   */
   auto m1 = Match(disassembly, std::string("declare float @test_proc\\(i32, float\\) #([0-9]*)"));
-  VERIFY_ARE_EQUAL(m1.size(), 2);
-  VERIFY_ARE_NOT_EQUAL(Match(disassembly, std::string("attributes #") + m1[1] + " = { nounwind").size(), 0);
+  VERIFY_IS_TRUE(m1.size() == 2U);
+  VERIFY_IS_TRUE(Match(disassembly, std::string("attributes #") + m1[1] + " = { nounwind").size() != 0U);
 }
 
 // Regression test for extension function calls not getting DCE'ed becuase they had no 'nounwind' attribute


### PR DESCRIPTION
- Fixed HL operations and DXIL operations not having the NoUnwind attribute, and therefore not DCE'ed
- Fixed LegalizeEvalOp not checking for the right intrinsic group and incorrectly removing Allocas for HLExtIntrinsic intrinsics