### PR TITLE
[SPIRV] Add support of the GL_EXT_spirv_intrinsics

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1109,13 +1109,15 @@ def VKInstructionExt : InheritableAttr {
 
 def VKLiteralExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_literal">];
-  let Subjects = SubjectList<[ParmVar]>;
+  let Subjects = SubjectList<[ParmVar], ErrorDiag>;
+  let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }
 
 def VKReferenceExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_reference">];
-  let Subjects = SubjectList<[ParmVar]>;
+  let Subjects = SubjectList<[ParmVar], ErrorDiag>;
+  let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }
 

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1010,10 +1010,26 @@ def VKBinding : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKCapabilityExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_capability">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Args = [IntArgument<"capability">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 def VKCounterBinding : InheritableAttr {
   let Spellings = [CXX11<"vk", "counter_binding">];
   let Subjects = SubjectList<[CounterStructuredBuffer], ErrorDiag, "ExpectedCounterStructuredBuffer">;
   let Args = [IntArgument<"Binding">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+def VKExtensionExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_extension">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Args = [StringArgument<"name">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }
@@ -1079,6 +1095,14 @@ def VKInputAttachmentIndex : InheritableAttr {
   let Spellings = [CXX11<"vk", "input_attachment_index">];
   let Subjects = SubjectList<[SubpassInput], ErrorDiag, "ExpectedSubpassInput">;
   let Args = [IntArgument<"index">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+def VKInstructionExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_instruction">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Args = [IntArgument<"opcode">, StringArgument<"instruction_set", 1>];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1107,6 +1107,18 @@ def VKInstructionExt : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKLiteralExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_literal">];
+  let Subjects = SubjectList<[ParmVar]>;
+  let Documentation = [Undocumented];
+}
+
+def VKReferenceExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_reference">];
+  let Subjects = SubjectList<[ParmVar]>;
+  let Documentation = [Undocumented];
+}
+
 // Global variables that are of scalar type
 def ScalarGlobalVar : SubsetSubject<Var, [{S->hasGlobalStorage() && S->getType()->isScalarType()}]>;
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -508,11 +508,11 @@ public:
   void createRaytracingTerminateKHR(spv::Op opcode, SourceLocation loc);
 
   /// \brief Create spirv intrinsic instructions
-  SpirvInstruction *
-  createSpirvIntrInstExt(uint32_t opcode, QualType retType,
-                         llvm::ArrayRef<SpirvInstruction *> operands,
-                         llvm::StringRef ext, llvm::StringRef instSet,
-                         llvm::ArrayRef<uint32_t> capts, SourceLocation loc);
+  SpirvInstruction *createSpirvIntrInstExt(
+      uint32_t opcode, QualType retType,
+      llvm::ArrayRef<SpirvInstruction *> operands,
+      llvm::ArrayRef<llvm::StringRef> extensions, llvm::StringRef instSet,
+      llvm::ArrayRef<uint32_t> capablities, SourceLocation loc);
 
   /// \brief Returns a clone SPIR-V variable for CTBuffer with FXC memory layout
   /// and creates copy instructions from the CTBuffer to the clone variable in

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -507,6 +507,13 @@ public:
   /// OpIgnoreIntersectionKHR/OpTerminateIntersectionKHR
   void createRaytracingTerminateKHR(spv::Op opcode, SourceLocation loc);
 
+  /// \brief Create spirv intrinsic instructions
+  SpirvInstruction *
+  createSpirvIntrInstExt(uint32_t opcode, QualType retType,
+                         llvm::ArrayRef<SpirvInstruction *> operands,
+                         llvm::StringRef ext, llvm::StringRef instSet,
+                         llvm::ArrayRef<uint32_t> capts, SourceLocation loc);
+
   /// \brief Returns a clone SPIR-V variable for CTBuffer with FXC memory layout
   /// and creates copy instructions from the CTBuffer to the clone variable in
   /// module.init if it contains HLSL matrix 1xN. Otherwise, returns nullptr.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -127,6 +127,7 @@ public:
     IK_Store,                     // OpStore
     IK_UnaryOp,                   // Unary operations
     IK_VectorShuffle,             // OpVectorShuffle
+    IK_SpirvIntrinsicInstruction, // Spirv Instructions for no particular op
 
     // For DebugInfo instructions defined in OpenCL.DebugInfo.100
     IK_DebugInfoNone,
@@ -1997,6 +1998,36 @@ public:
   }
 
   bool invokeVisitor(Visitor *v) override;
+};
+
+class SpirvIntrinsicInstruction : public SpirvInstruction {
+public:
+  SpirvIntrinsicInstruction(QualType resultType, uint32_t opcode,
+                            llvm::ArrayRef<SpirvInstruction *> operands,
+                            llvm::StringRef ext, SpirvExtInstImport *set,
+                            llvm::ArrayRef<uint32_t> capts, SourceLocation loc);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvIntrinsicInstruction)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_SpirvIntrinsicInstruction;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  llvm::ArrayRef<SpirvInstruction *> getOperands() const { return operands; }
+  llvm::ArrayRef<uint32_t> getCapabilities() const { return capabilities; }
+  llvm::StringRef getExtension() const { return extension; }
+  SpirvExtInstImport *getInstructionSet() const { return instructionSet; }
+  uint32_t getInstruction() const { return instruction; }
+
+private:
+  uint32_t instruction;
+  llvm::SmallVector<SpirvInstruction *, 4> operands;
+  llvm::SmallVector<uint32_t, 4> capabilities;
+  std::string extension;
+  SpirvExtInstImport *instructionSet;
 };
 
 /// \breif Base class for all OpenCL.DebugInfo.100 extension instructions.

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -139,6 +139,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvRayQueryOpKHR)
   DEFINE_VISIT_METHOD(SpirvReadClock)
   DEFINE_VISIT_METHOD(SpirvRayTracingTerminateOpKHR)
+  DEFINE_VISIT_METHOD(SpirvIntrinsicInstruction)
 #undef DEFINE_VISIT_METHOD
 
 protected:

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -448,6 +448,16 @@ bool CapabilityVisitor::visitInstruction(SpirvInstruction *instr) {
     addCapability(getNonUniformCapability(resultType));
   }
 
+  if (instr->getKind() == SpirvInstruction::IK_SpirvIntrinsicInstruction) {
+    SpirvIntrinsicInstruction *pSpvInst =
+        dyn_cast<SpirvIntrinsicInstruction>(instr);
+    for (auto &cap : pSpvInst->getCapabilities()) {
+      addCapability(static_cast<spv::Capability>(cap));
+    }
+    if (pSpvInst->getExtension().size() > 0)
+      spvBuilder.requireExtension(pSpvInst->getExtension(), loc);
+  }
+
   // Add opcode-specific capabilities
   switch (opcode) {
   case spv::Op::OpDPdxCoarse:

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -454,8 +454,9 @@ bool CapabilityVisitor::visitInstruction(SpirvInstruction *instr) {
     for (auto &cap : pSpvInst->getCapabilities()) {
       addCapability(static_cast<spv::Capability>(cap));
     }
-    if (pSpvInst->getExtension().size() > 0)
-      spvBuilder.requireExtension(pSpvInst->getExtension(), loc);
+    for (auto ext : pSpvInst->getExtensions()) {
+      spvBuilder.requireExtension(ext, loc);
+    }
   }
 
   // Add opcode-specific capabilities

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -454,7 +454,7 @@ bool CapabilityVisitor::visitInstruction(SpirvInstruction *instr) {
     for (auto &cap : pSpvInst->getCapabilities()) {
       addCapability(static_cast<spv::Capability>(cap));
     }
-    for (auto ext : pSpvInst->getExtensions()) {
+    for (const auto &ext : pSpvInst->getExtensions()) {
       spvBuilder.requireExtension(ext, loc);
     }
   }

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1672,6 +1672,7 @@ bool EmitVisitor::visit(SpirvIntrinsicInstruction *inst) {
   }
 
   for (const auto operand : inst->getOperands()) {
+    // TODO: Handle Literals with other types.
     auto literalOperand = dyn_cast<SpirvConstantInteger>(operand);
     if (literalOperand && literalOperand->getLiteral()) {
         curInst.push_back(literalOperand->getValue().getZExtValue());

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1659,6 +1659,23 @@ bool EmitVisitor::visit(SpirvRayTracingTerminateOpKHR *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvIntrinsicInstruction *inst) {
+  initInstruction(inst);
+  curInst.push_back(inst->getResultTypeId());
+  curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst));
+  if (inst->getInstructionSet()) {
+    curInst.push_back(
+        getOrAssignResultId<SpirvInstruction>(inst->getInstructionSet()));
+    curInst.push_back(inst->getInstruction());
+  }
+
+  for (const auto operand : inst->getOperands())
+    curInst.push_back(getOrAssignResultId<SpirvInstruction>(operand));
+
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
 // EmitTypeHandler ------
 
 void EmitTypeHandler::initTypeInstruction(spv::Op op) {

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -289,6 +289,7 @@ public:
   bool visit(SpirvDebugTypeMember *) override;
   bool visit(SpirvDebugTypeTemplate *) override;
   bool visit(SpirvDebugTypeTemplateParameter *) override;
+  bool visit(SpirvIntrinsicInstruction *) override;
 
   using Visitor::visit;
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -964,17 +964,17 @@ SpirvInstruction *SpirvBuilder::createReadClock(SpirvInstruction *scope,
 
 SpirvInstruction *SpirvBuilder::createSpirvIntrInstExt(
     uint32_t opcode, QualType retType,
-    llvm::ArrayRef<SpirvInstruction *> operands, llvm::StringRef ext,
-    llvm::StringRef instSet, llvm::ArrayRef<uint32_t> capts,
-    SourceLocation loc) {
+    llvm::ArrayRef<SpirvInstruction *> operands,
+    llvm::ArrayRef<llvm::StringRef> extensions, llvm::StringRef instSet,
+    llvm::ArrayRef<uint32_t> capablities, SourceLocation loc) {
   assert(insertPoint && "null insert point");
 
   SpirvExtInstImport *set =
       (instSet.size() == 0) ? nullptr : getExtInstSet(instSet);
 
   auto *inst = new (context) SpirvIntrinsicInstruction(
-      retType, opcode, operands, ext, set, capts, loc);
-
+      retType->isVoidType() ? QualType() : retType, opcode, operands,
+      extensions, set, capablities, loc);
   insertPoint->addInstruction(inst);
   return inst;
 }

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -962,6 +962,23 @@ SpirvInstruction *SpirvBuilder::createReadClock(SpirvInstruction *scope,
   return inst;
 }
 
+SpirvInstruction *SpirvBuilder::createSpirvIntrInstExt(
+    uint32_t opcode, QualType retType,
+    llvm::ArrayRef<SpirvInstruction *> operands, llvm::StringRef ext,
+    llvm::StringRef instSet, llvm::ArrayRef<uint32_t> capts,
+    SourceLocation loc) {
+  assert(insertPoint && "null insert point");
+
+  SpirvExtInstImport *set =
+      (instSet.size() == 0) ? nullptr : getExtInstSet(instSet);
+
+  auto *inst = new (context) SpirvIntrinsicInstruction(
+      retType, opcode, operands, ext, set, capts, loc);
+
+  insertPoint->addInstruction(inst);
+  return inst;
+}
+
 void SpirvBuilder::createRaytracingTerminateKHR(spv::Op opcode,
                                                 SourceLocation loc) {
   assert(insertPoint && "null insert point");

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12464,7 +12464,8 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
   auto funcDecl = expr->getDirectCallee();
   auto &attrs = funcDecl->getAttrs();
   QualType retType = funcDecl->getReturnType();
-  llvm::SmallVector<uint32_t, 8> capbilities;
+
+  llvm::SmallVector<uint32_t, 2> capbilities;
   llvm::SmallVector<llvm::StringRef, 2> extensions;
   llvm::StringRef instSet = "";
   uint32_t op = 0;
@@ -12488,7 +12489,9 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
     SpirvInstruction *argInst = doExpr(arg);
     if (param->hasAttr<VKReferenceExtAttr>()) {
       if (argInst->isRValue()) {
-        emitError("argument must be a reference", arg->getExprLoc());
+        emitError("argument for a parameter with vk::ext_reference attribute "
+                  "must be a reference",
+                  arg->getExprLoc());
         return nullptr;
       }
       spvArgs.push_back(argInst);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2317,13 +2317,12 @@ SpirvInstruction *SpirvEmitter::doCallExpr(const CallExpr *callExpr) {
     return doCXXMemberCallExpr(memberCall);
 
   auto funcDecl = callExpr->getDirectCallee();
+  if (funcDecl && funcDecl->hasAttr<VKInstructionExtAttr>()) {
+    return processSpvIntrinsicCallExpr(callExpr);
+  }
   // Intrinsic functions such as 'dot' or 'mul'
   if (hlsl::IsIntrinsicOp(funcDecl)) {
     return processIntrinsicCallExpr(callExpr);
-  }
-
-  if (funcDecl && funcDecl->hasAttr<VKInstructionExtAttr>()) {
-    return processSpvIntrinsicCallExpr(callExpr);
   }
 
   // Normal standalone functions

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12465,7 +12465,7 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
   auto &attrs = funcDecl->getAttrs();
   QualType retType = funcDecl->getReturnType();
   llvm::SmallVector<uint32_t, 8> capbilities;
-  llvm::SmallVector<llvm::StringRef, 8> extensions;
+  llvm::SmallVector<llvm::StringRef, 2> extensions;
   llvm::StringRef instSet = "";
   uint32_t op = 0;
   for (auto &attr : attrs) {
@@ -12487,6 +12487,10 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
     const Expr *arg = args[i]->IgnoreParenLValueCasts();
     SpirvInstruction *argInst = doExpr(arg);
     if (param->hasAttr<VKReferenceExtAttr>()) {
+      if (argInst->isRValue()) {
+        emitError("argument must be a reference", arg->getExprLoc());
+        return nullptr;
+      }
       spvArgs.push_back(argInst);
     } else if (param->hasAttr<VKLiteralExtAttr>()) {
       auto constArg = dyn_cast<SpirvConstantInteger>(argInst);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -591,6 +591,8 @@ private:
   /// Process ray query intrinsics
   SpirvInstruction *processRayQueryIntrinsics(const CXXMemberCallExpr *expr,
                                               hlsl::IntrinsicOp opcode);
+  /// Process spirv intrinsic instruction
+  SpirvInstruction *processSpvIntrinsicCallExpr(const CallExpr *expr);
 
 private:
   /// Returns the <result-id> for constant value 0 of the given type.

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -106,6 +106,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugTypeTemplateParameter)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvRayQueryOpKHR)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvReadClock)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvRayTracingTerminateOpKHR)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvIntrinsicInstruction)
 
 #undef DEFINE_INVOKE_VISITOR_FOR_CLASS
 
@@ -1003,6 +1004,18 @@ SpirvRayTracingTerminateOpKHR::SpirvRayTracingTerminateOpKHR(spv::Op opcode,
   assert(opcode == spv::Op::OpTerminateRayKHR ||
          opcode == spv::Op::OpIgnoreIntersectionKHR);
 }
+
+SpirvIntrinsicInstruction::SpirvIntrinsicInstruction(
+    QualType resultType, uint32_t opcode,
+    llvm::ArrayRef<SpirvInstruction *> vecOperands, llvm::StringRef ext,
+    SpirvExtInstImport *set, llvm::ArrayRef<uint32_t> capts, SourceLocation loc)
+    : SpirvInstruction(IK_SpirvIntrinsicInstruction,
+                       set != nullptr ? spv::Op::OpExtInst
+                                      : static_cast<spv::Op>(opcode),
+                       resultType, loc),
+      instruction(opcode), operands(vecOperands.begin(), vecOperands.end()),
+      capabilities(capts.begin(), capts.end()), extension(ext.data()),
+      instructionSet(set) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -500,11 +500,11 @@ bool SpirvConstantBoolean::operator==(const SpirvConstantBoolean &that) const {
 }
 
 SpirvConstantInteger::SpirvConstantInteger(QualType type, llvm::APInt val,
-                                           bool isSpecConst)
+                                           bool isSpecConst, bool literal)
     : SpirvConstant(IK_ConstantInteger,
                     isSpecConst ? spv::Op::OpSpecConstant : spv::Op::OpConstant,
                     type),
-      value(val) {
+      value(val), isLiteral(literal) {
   assert(type->isIntegerType());
 }
 
@@ -1007,15 +1007,16 @@ SpirvRayTracingTerminateOpKHR::SpirvRayTracingTerminateOpKHR(spv::Op opcode,
 
 SpirvIntrinsicInstruction::SpirvIntrinsicInstruction(
     QualType resultType, uint32_t opcode,
-    llvm::ArrayRef<SpirvInstruction *> vecOperands, llvm::StringRef ext,
-    SpirvExtInstImport *set, llvm::ArrayRef<uint32_t> capts, SourceLocation loc)
+    llvm::ArrayRef<SpirvInstruction *> vecOperands,
+    llvm::ArrayRef<llvm::StringRef> exts, SpirvExtInstImport *set,
+    llvm::ArrayRef<uint32_t> capts, SourceLocation loc)
     : SpirvInstruction(IK_SpirvIntrinsicInstruction,
                        set != nullptr ? spv::Op::OpExtInst
                                       : static_cast<spv::Op>(opcode),
                        resultType, loc),
       instruction(opcode), operands(vecOperands.begin(), vecOperands.end()),
-      capabilities(capts.begin(), capts.end()), extension(ext.data()),
-      instructionSet(set) {}
+      capabilities(capts.begin(), capts.end()),
+      extensions(exts.begin(), exts.end()), instructionSet(set) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12038,6 +12038,22 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
   case AttributeList::AT_VKShaderRecordEXT:
     declAttr = ::new (S.Context) VKShaderRecordEXTAttr(A.getRange(), S.Context, A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKCapabilityExt:
+    declAttr = ::new (S.Context) VKCapabilityExtAttr(
+        A.getRange(), S.Context, ValidateAttributeIntArg(S, A),
+        A.getAttributeSpellingListIndex());
+    break;
+  case AttributeList::AT_VKExtensionExt:
+    declAttr = ::new (S.Context) VKExtensionExtAttr(
+        A.getRange(), S.Context, ValidateAttributeStringArg(S, A, nullptr),
+        A.getAttributeSpellingListIndex());
+    break;
+  case AttributeList::AT_VKInstructionExt:
+    declAttr = ::new (S.Context) VKInstructionExtAttr(
+        A.getRange(), S.Context, ValidateAttributeIntArg(S, A),
+        ValidateAttributeStringArg(S, A, nullptr, 1),
+        A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12054,6 +12054,14 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
         ValidateAttributeStringArg(S, A, nullptr, 1),
         A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKLiteralExt:
+    declAttr = ::new (S.Context) VKLiteralExtAttr(
+        A.getRange(), S.Context, A.getAttributeSpellingListIndex());
+    break;
+  case AttributeList::AT_VKReferenceExt:
+    declAttr = ::new (S.Context) VKReferenceExtAttr(
+        A.getRange(), S.Context, A.getAttributeSpellingListIndex());
+    break;
   default:
     Handled = false;
     return;

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsic.reference.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsic.reference.error.hlsl
@@ -1,0 +1,25 @@
+// Run: %dxc -T vs_6_0 -E main
+
+[[vk::ext_instruction(/* OpLoad */ 61)]]
+float4 load([[vk::ext_reference]] float4 pointer, [[vk::ext_literal]] int memoryOperands);
+
+[[vk::ext_instruction(/* OpStore */ 62)]]
+void store([[vk::ext_reference]] float4 pointer, float4 object, [[vk::ext_literal]] int memoryOperands);
+
+struct SInstanceData {
+  float4 Output;
+};
+
+struct VS_INPUT {
+  float4 Position : POSITION;
+};
+
+float4 main(const VS_INPUT v) : SV_Position {
+    SInstanceData kk;
+    kk.Output = v.Position;
+    float4 output = float4(0.0, 0.0, 0.0, 1.0);
+// CHECK: error: argument for a parameter with vk::ext_reference attribute must be a reference
+    store(float4(0.0, 0.0, 0.0, 1.0), load(kk.Output, 0x0), 1);
+    return output;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
@@ -2,6 +2,7 @@
 
 // CHECK: OpCapability ShaderClockKHR
 // CHECK: {{%\d+}} = OpExtInstImport "GLSL.std.450"
+// CHECK: {{%\d+}} = OpExtInstImport "SPV_AMD_shader_trinary_minmax"
 
 struct SInstanceData {
   float4x3 VisualToWorld;
@@ -21,6 +22,9 @@ uint64_t ReadClock(uint scope);
 [[vk::ext_instruction(/* Sin*/ 13, "GLSL.std.450")]]
 float4 spv_sin(float4 v);
 
+[[vk::ext_instruction(/* FMin3AMD */ 1, "SPV_AMD_shader_trinary_minmax")]]
+float FMin3AMD(float x, float y, float z);
+
 float4 main(const VS_INPUT v) : SV_Position {
 	SInstanceData	I = v.InstanceData;
   uint64_t clock;
@@ -28,6 +32,8 @@ float4 main(const VS_INPUT v) : SV_Position {
   I.Output = spv_sin(v.InstanceData.Output);
 // CHECK: {{%\d+}} = OpReadClockKHR %ulong %uint_1
   clock = ReadClock(vk::DeviceScope);
+// CHECK: {{%\d+}} = OpExtInst %float {{%\d+}} FMin3AMD {{%\d+}} {{%\d+}} {{%\d+}}
+  I.Output.w = FMin3AMD(I.Output.z, I.Output.y, I.Output.z);
 
   return I.Output;
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
@@ -1,5 +1,8 @@
 // Run: %dxc -T vs_6_0 -E main
 
+// CHECK: OpCapability ShaderClockKHR
+// CHECK: {{%\d+}} = OpExtInstImport "GLSL.std.450"
+
 struct SInstanceData {
   float4x3 VisualToWorld;
   float4 Output;
@@ -17,10 +20,6 @@ uint64_t ReadClock(uint scope);
 
 [[vk::ext_instruction(/* Sin*/ 13, "GLSL.std.450")]]
 float4 spv_sin(float4 v);
-
-// CHECK: OpCapability ShaderClockKHR
-// CHECK-NEXT: OpExtension "SPV_KHR_shader_clock"
-// CHECK-NEXT: {{%\d+}} = OpExtInstImport "GLSL.std.450"
 
 float4 main(const VS_INPUT v) : SV_Position {
 	SInstanceData	I = v.InstanceData;

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T vs_6_0 -E main
+
+struct SInstanceData {
+  float4x3 VisualToWorld;
+  float4 Output;
+};
+
+struct VS_INPUT	{
+  float3 Position : POSITION;
+  SInstanceData	InstanceData : TEXCOORD4;
+};
+
+[[vk::ext_capability(5055)]]
+[[vk::ext_extension("SPV_KHR_shader_clock")]]
+[[vk::ext_instruction(/* OpReadClockKHR */ 5056)]]
+uint64_t ReadClock(uint scope);
+
+[[vk::ext_instruction(/* Sin*/ 13, "GLSL.std.450")]]
+float4 spv_sin(float4 v);
+
+// CHECK: OpCapability ShaderClockKHR
+// CHECK-NEXT: OpExtension "SPV_KHR_shader_clock"
+// CHECK-NEXT: {{%\d+}} = OpExtInstImport "GLSL.std.450"
+
+float4 main(const VS_INPUT v) : SV_Position {
+	SInstanceData	I = v.InstanceData;
+  uint64_t clock;
+// CHECK: {{%\d+}} = OpExtInst %v4float {{%\d+}} Sin {{%\d+}}
+  I.Output = spv_sin(v.InstanceData.Output);
+// CHECK: {{%\d+}} = OpReadClockKHR %ulong %uint_1
+  clock = ReadClock(vk::DeviceScope);
+
+  return I.Output;
+}

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteral.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicLiteral.hlsl
@@ -1,0 +1,26 @@
+// Run: %dxc -T vs_6_0 -E main
+
+[[vk::ext_instruction(/* OpLoad */ 61)]]
+float4 load([[vk::ext_reference]] float4 pointer, [[vk::ext_literal]] int memoryOperands);
+
+[[vk::ext_instruction(/* OpStore */ 62)]]
+void store([[vk::ext_reference]] float4 pointer, float4 object, [[vk::ext_literal]] int memoryOperands);
+
+struct SInstanceData {
+  float4 Output;
+};
+
+struct VS_INPUT	{
+  float4 Position : POSITION;
+};
+
+float4 main(const VS_INPUT v) : SV_Position {
+    SInstanceData kk;
+    kk.Output = v.Position;
+    float4 output = float4(0.0, 0.0, 0.0, 1.0);
+// CHECK: {{%\d+}} = OpLoad %v4float {{%\d+}} None
+// CHECK: OpStore %output {{%\d+}} Volatile    
+    store(output, load(kk.Output, 0x0), 1);
+    return output;
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1341,6 +1341,7 @@ TEST_F(FileTest, IntrinsicsVkQueueFamilyScope) {
 }
 TEST_F(FileTest, IntrinsicsSpirv) {
   runFileTest("spv.intrinsicInstruction.hlsl", Expect::Success, false);
+  runFileTest("spv.intrinsicLiteral.hlsl", Expect::Success, false);
 }
 TEST_F(FileTest, IntrinsicsVkReadClock) {
   runFileTest("intrinsics.vkreadclock.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1343,6 +1343,10 @@ TEST_F(FileTest, IntrinsicsVkReadClock) {
   runFileTest("intrinsics.vkreadclock.hlsl");
 }
 
+TEST_F(FileTest, IntrinsicsSpirv) {
+  runFileTest("spv.intrinsicInstruction.hlsl");
+}
+
 // Intrinsics added in SM 6.6
 TEST_F(FileTest, IntrinsicsSM66PackU8S8) {
   runFileTest("intrinsics.sm6_6.pack_s8u8.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1340,8 +1340,9 @@ TEST_F(FileTest, IntrinsicsVkQueueFamilyScope) {
   runFileTest("intrinsics.vkqueuefamilyscope.hlsl");
 }
 TEST_F(FileTest, IntrinsicsSpirv) {
-  runFileTest("spv.intrinsicInstruction.hlsl", Expect::Success, false);
-  runFileTest("spv.intrinsicLiteral.hlsl", Expect::Success, false);
+  runFileTest("spv.intrinsicInstruction.hlsl");
+  runFileTest("spv.intrinsicLiteral.hlsl");
+  runFileTest("spv.intrinsic.reference.error.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, IntrinsicsVkReadClock) {
   runFileTest("intrinsics.vkreadclock.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1339,14 +1339,12 @@ TEST_F(FileTest, IntrinsicsVkInvocationScope) {
 TEST_F(FileTest, IntrinsicsVkQueueFamilyScope) {
   runFileTest("intrinsics.vkqueuefamilyscope.hlsl");
 }
+TEST_F(FileTest, IntrinsicsSpirv) {
+  runFileTest("spv.intrinsicInstruction.hlsl", Expect::Success, false);
+}
 TEST_F(FileTest, IntrinsicsVkReadClock) {
   runFileTest("intrinsics.vkreadclock.hlsl");
 }
-
-TEST_F(FileTest, IntrinsicsSpirv) {
-  runFileTest("spv.intrinsicInstruction.hlsl");
-}
-
 // Intrinsics added in SM 6.6
 TEST_F(FileTest, IntrinsicsSM66PackU8S8) {
   runFileTest("intrinsics.sm6_6.pack_s8u8.hlsl");


### PR DESCRIPTION
Related to the issue: https://github.com/microsoft/DirectXShaderCompiler/issues/3919
Add these attributes

vk::ext_capability
vk::ext_extension
vk::ext_instruction