### PR TITLE
Fix check in dxc extra output processing for non-blob output

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -229,10 +229,10 @@ static void WriteDxcExtraOuputs(IDxcResult *pResult) {
     CComPtr<IDxcBlobUtf16> pFileName;
     CComPtr<IDxcBlobUtf16> pType;
     CComPtr<IDxcBlob> pBlob;
-    IFT(pOutputs->GetOutput(i, IID_PPV_ARGS(&pBlob), &pType, &pFileName));
+    HRESULT hr = pOutputs->GetOutput(i, IID_PPV_ARGS(&pBlob), &pType, &pFileName);
 
     // Not a blob
-    if (!pBlob)
+    if (FAILED(hr))
       continue;
 
     UINT32 uCodePage = CP_ACP;


### PR DESCRIPTION
When processing the DXC_OUT_EXTRA_OUTPUTS output from a compile there
is an attempt to skip non-blob outputs. The check is written incorrectly
because the call to `GetOutput` will fail (when it tries to QueryInterface
on the blob output).

The fix is to check the HRESULT returned from GetOutput and skip the output
if it failed.

Found when using the dxclib from an external project. I did not see an easy
way to add a test for this.