### PR TITLE
Expose the DxcCompilerAdapter through the com interface

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -511,10 +511,15 @@ struct IDxcCompiler3 : public IUnknown {
 // This will enable the adapter to support the IDxcCompiler and IDxcCompiler2
 // interfaces.
 //
+// The compiler passed to SetDxcCompiler is not retained by the adapter interface
+// to avoid creating a cyclic AddRef between the adapter and compiler classes.
+// It is the callers responsibility to ensure the compiler is valid during
+// the lifetime of the compiler adapter interface.
+//
 CROSS_PLATFORM_UUIDOF(IDxcCompilerAdapter, "DC9153FA-12E0-403E-80D3-29F36CBA536E")
 struct IDxcCompilerAdapter : public IUnknown {
     virtual HRESULT STDMETHODCALLTYPE SetDxcCompiler(
-        _In_ IUnknown* pCompiler
+        _In_ IDxcCompiler3 * pCompiler
     ) = 0;
 };
 

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -495,6 +495,29 @@ struct IDxcCompiler3 : public IUnknown {
     ) = 0;
 };
 
+//
+// The IDxcCompilerAdapter interface is here to enable an implementation
+// to support all of the IDxcCompiler* interfaces by only implementing the
+// latest interface.
+//
+// The implementation will create an instance of IDxcCompilerAdapter and call
+// SetDxcCompiler() passing itself as the pCompiler pointer. For any compiler
+// interface not directly supported by the implementation it can call
+// QueryInterface on the adapter to get an instance of the requested compiler
+// interface that will call back into the original implementation to do the
+// actual compilation.
+// 
+// Currently we only support passing an instance of IDxcCompiler3 to SetDxcCompiler.
+// This will enable the adapter to support the IDxcCompiler and IDxcCompiler2
+// interfaces.
+//
+CROSS_PLATFORM_UUIDOF(IDxcCompilerAdapter, "DC9153FA-12E0-403E-80D3-29F36CBA536E")
+struct IDxcCompilerAdapter : public IUnknown {
+    virtual HRESULT STDMETHODCALLTYPE SetDxcCompiler(
+        _In_ IUnknown* pCompiler
+    ) = 0;
+};
+
 static const UINT32 DxcValidatorFlags_Default = 0;
 static const UINT32 DxcValidatorFlags_InPlaceEdit = 1;  // Validator is allowed to update shader blob in-place.
 static const UINT32 DxcValidatorFlags_RootSignatureOnly = 2;
@@ -649,6 +672,13 @@ CLSID_SCOPE const CLSID CLSID_DxcCompiler = {
     0xe6ce,
     0x47f3,
     {0xb5, 0xbf, 0xf0, 0x66, 0x4f, 0x39, 0xc1, 0xb0}};
+
+// {619B969E-5E43-4669-AF49-229EF88BE09E}
+CLSID_SCOPE const CLSID CLSID_DxcCompilerAdapter = {
+    0x619b969e,
+    0x5e43,
+    0x4669,
+    { 0xaf, 0x49, 0x22, 0x9e, 0xf8, 0x8b, 0xe0, 0x9e }};
 
 // {EF6A8087-B0EA-4D56-9E45-D07E1A8B7806}
 CLSID_SCOPE const GUID CLSID_DxcLinker = {

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 
 HRESULT CreateDxcCompiler(_In_ REFIID riid, _Out_ LPVOID *ppv);
+HRESULT CreateDxcCompilerAdapter(_In_ REFIID riid, _Out_ LPVOID *ppv);
 HRESULT CreateDxcDiaDataSource(_In_ REFIID riid, _Out_ LPVOID *ppv);
 HRESULT CreateDxcIntelliSense(_In_ REFIID riid, _Out_ LPVOID *ppv);
 HRESULT CreateDxcCompilerArgs(_In_ REFIID riid, _Out_ LPVOID *ppv);
@@ -82,6 +83,9 @@ static HRESULT ThreadMallocDxcCreateInstance(
   *ppv = nullptr;
   if (IsEqualCLSID(rclsid, CLSID_DxcCompiler)) {
     hr = CreateDxcCompiler(riid, ppv);
+  }
+  else if (IsEqualCLSID(rclsid, CLSID_DxcCompilerAdapter)) {
+    hr = CreateDxcCompilerAdapter(riid, ppv);
   }
   else if (IsEqualCLSID(rclsid, CLSID_DxcCompilerArgs)) {
     hr = CreateDxcCompilerArgs(riid, ppv);

--- a/tools/clang/tools/dxcompiler/dxcompileradapter.h
+++ b/tools/clang/tools/dxcompiler/dxcompileradapter.h
@@ -51,6 +51,11 @@ public:
   ULONG STDMETHODCALLTYPE Release() override;
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override;
 
+  void SetDxcCompiler(IDxcCompiler3* pCompilerImpl)
+  {
+      m_pCompilerImpl = pCompilerImpl;
+  }
+
   // ================ IDxcCompiler ================
 
   // Compile a single entry point to the target shader model

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1777,7 +1777,7 @@ public:
     return hr;
   }
 
-  HRESULT SetDxcCompiler(IUnknown *pCompiler)
+  HRESULT SetDxcCompiler(IUnknown *pCompiler) override
   {
       HRESULT hr = pCompiler->QueryInterface(IID_PPV_ARGS(&m_pDxcCompiler3));
       if (SUCCEEDED(hr))

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1755,7 +1755,7 @@ class DxcCompilerAdapterInterface : public IDxcCompilerAdapter, public IDxcCompi
 {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
-  CComPtr<IDxcCompiler3> m_pDxcCompiler3;
+  IDxcCompiler3 *m_pDxcCompiler3;
   DxcCompilerAdapter m_DxcCompilerAdapter;
 
 public:
@@ -1779,12 +1779,8 @@ public:
 
   HRESULT SetDxcCompiler(IUnknown *pCompiler) override
   {
-      HRESULT hr = pCompiler->QueryInterface(IID_PPV_ARGS(&m_pDxcCompiler3));
-      if (SUCCEEDED(hr))
-      {
-          m_DxcCompilerAdapter.SetDxcCompiler(m_pDxcCompiler3);
-      }
-      return hr;
+      m_pDxcCompiler3 = pCompiler;
+      return S_OK;
   }
   
   virtual HRESULT STDMETHODCALLTYPE Compile(

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1777,7 +1777,7 @@ public:
     return hr;
   }
 
-  HRESULT SetDxcCompiler(IUnknown *pCompiler) override
+  HRESULT SetDxcCompiler(IDxcCompiler3 *pCompiler) override
   {
       m_pDxcCompiler3 = pCompiler;
       return S_OK;


### PR DESCRIPTION
This commit exposes the DxcCompilerAdapter class through the standard
Dxc com interface. The DxcCompilerAdapter is used to implement
the IDxcCompiler and IDxcCompiler2 interfaces by backing it with
an instance of the IDxcCompiler3 interface.

The class is used internally by the DxcCompiler class to support the
older compiler interfaces. We have an external project that could
take advantage of this support as well so we now expose it through
the com interface.