### PR TITLE
PIX: Disambiguate mesh shader activity based on full XYZ dispatch paramete…

### DIFF
--- a/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
+++ b/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
@@ -35,17 +35,22 @@ public:
   const char *getPassName() const override { return "DXIL Add flat thread id to payload from AS to MS"; }
   bool runOnModule(Module &M) override;
   void applyOptions(PassOptions O) override;
-
-private:
-
-    void EmitInstructionsToCopyStructContents(llvm::IRBuilder<> &B,
-        llvm::Value *NewStructAlloca,
-        llvm::Value*OldStructAlloca);
 };
 
 void DxilPIXAddTidToAmplificationShaderPayload::applyOptions(PassOptions O) {
   GetPassOptionUInt32(O, "dispatchArgY", &m_DispatchArgumentY, 1);
   GetPassOptionUInt32(O, "dispatchArgZ", &m_DispatchArgumentZ, 1);
+}
+
+void AddValueToExpandedPayload(OP* HlslOP, llvm::IRBuilder<> &B, ExpandedStruct & expanded, AllocaInst* NewStructAlloca, unsigned int expandedValueIndex, Value* value) {
+  Constant *Zero32Arg = HlslOP->GetU32Const(0);
+  SmallVector<Value *, 2> IndexToAppendedValue;
+  IndexToAppendedValue.push_back(Zero32Arg);
+  IndexToAppendedValue.push_back(HlslOP->GetU32Const(expandedValueIndex));
+  auto *PointerToEmbeddedNewValue =
+      B.CreateInBoundsGEP(expanded.ExpandedPayloadStructType, NewStructAlloca,
+                          IndexToAppendedValue, "PointerToEmbeddedNewValue" + std::to_string(expandedValueIndex));
+  B.CreateStore(value, PointerToEmbeddedNewValue);
 }
 
 bool DxilPIXAddTidToAmplificationShaderPayload::runOnModule(Module &M) {
@@ -127,22 +132,22 @@ bool DxilPIXAddTidToAmplificationShaderPayload::runOnModule(Module &M) {
       auto * XYxZ = B.CreateMul(XandY, HlslOP->GetU32Const(m_DispatchArgumentZ));
       auto * XYZ = B.CreateAdd(ThreadIdZ, XYxZ);
 
-
-      SmallVector<Value *, 2> IndexToAppendedValue;
-      IndexToAppendedValue.push_back(Zero32Arg);
-      IndexToAppendedValue.push_back(HlslOP->GetU32Const(OriginalPayloadStructType->getStructNumElements()));
-      auto *PointerToEmbeddedNewValue = B.CreateInBoundsGEP(expanded.ExpandedPayloadStructType, NewStructAlloca, IndexToAppendedValue, "PointerToEmbeddedNewValue");
-      B.CreateStore(XYZ, PointerToEmbeddedNewValue);
+      AddValueToExpandedPayload(
+        HlslOP, B, expanded, NewStructAlloca, 
+        OriginalPayloadStructType->getStructNumElements(), XYZ);
+      AddValueToExpandedPayload(
+          HlslOP, B, expanded, NewStructAlloca,
+          OriginalPayloadStructType->getStructNumElements() + 1,
+          DispatchMesh.get_threadGroupCountY());
+      AddValueToExpandedPayload(
+          HlslOP, B, expanded, NewStructAlloca,
+          OriginalPayloadStructType->getStructNumElements() + 2,
+          DispatchMesh.get_threadGroupCountZ());
   }
 
   DM.ReEmitDxilResources();
 
   return true;
-}
-
-void DxilPIXAddTidToAmplificationShaderPayload::EmitInstructionsToCopyStructContents(llvm::IRBuilder<> & B,
-    llvm::Value * NewStructPointer,
-    llvm::Value* OldStruct) {
 }
 
 char DxilPIXAddTidToAmplificationShaderPayload::ID = 0;

--- a/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
+++ b/lib/DxilPIXPasses/DxilPIXAddTidToAmplificationShaderPayload.cpp
@@ -128,8 +128,8 @@ bool DxilPIXAddTidToAmplificationShaderPayload::runOnModule(Module &M) {
           B.CreateCall(ThreadIdFunc, {Opcode, Two32Arg }, "ThreadIdZ");
 
       auto * XxY = B.CreateMul(ThreadIdX, HlslOP->GetU32Const(m_DispatchArgumentY));
-      auto * XandY = B.CreateAdd(ThreadIdY, XxY);
-      auto * XYxZ = B.CreateMul(XandY, HlslOP->GetU32Const(m_DispatchArgumentZ));
+      auto * XplusY = B.CreateAdd(ThreadIdY, XxY);
+      auto * XYxZ = B.CreateMul(XplusY, HlslOP->GetU32Const(m_DispatchArgumentZ));
       auto * XYZ = B.CreateAdd(ThreadIdZ, XYxZ);
 
       AddValueToExpandedPayload(

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -227,8 +227,8 @@ SmallVector<Value*, 2> DxilPIXMeshShaderOutputInstrumentation::
 
     auto *XxY =
       Builder.CreateMul(GroupIdX, ASDispatchMeshYCount);
-    auto *XandY = Builder.CreateAdd(GroupIdY, XxY);
-    auto *XYxZ = Builder.CreateMul(XandY, ASDispatchMeshZCount);
+    auto *XplusY = Builder.CreateAdd(GroupIdY, XxY);
+    auto *XYxZ = Builder.CreateMul(XplusY, ASDispatchMeshZCount);
     auto *XYZ = Builder.CreateAdd(GroupIdZ, XYxZ);
 
     SmallVector<Value *, 2> ret;

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -186,6 +186,16 @@ void DxilPIXMeshShaderOutputInstrumentation::Instrument(BuilderContext &BC,
   }
 }
 
+Value* GetValueFromExpandedPayload(IRBuilder<> &Builder, StructType* originalPayloadStructType, Instruction* firstGetPayload, unsigned int offset, const char * name) {
+  auto *DerefPointer = Builder.getInt32(0);
+  auto *OffsetToExpandedData = Builder.getInt32(offset);
+  auto *GEP = Builder.CreateGEP(
+      cast<PointerType>(firstGetPayload->getType()->getScalarType())
+          ->getElementType(),
+      firstGetPayload, {DerefPointer, OffsetToExpandedData});
+  return Builder.CreateLoad(GEP, name);
+}
+
 SmallVector<Value*, 2> DxilPIXMeshShaderOutputInstrumentation::
     insertInstructionsToCreateDisambiguationValue(OP* HlslOP, LLVMContext& Ctx, StructType* originalPayloadStructType, Instruction* firstGetPayload) {
 
@@ -196,21 +206,34 @@ SmallVector<Value*, 2> DxilPIXMeshShaderOutputInstrumentation::
     // will have added that value to the AS->MS payload...
 
     IRBuilder<> Builder(firstGetPayload->getNextNode());
-    auto *DerefPointer = Builder.getInt32(0);
-    auto *OffsetToExpandedData = Builder.getInt32(originalPayloadStructType->getStructNumElements());
-    auto *GEP = Builder.CreateGEP(cast<PointerType>(firstGetPayload->getType()->getScalarType())->getElementType(), firstGetPayload, {DerefPointer, OffsetToExpandedData});
-    SmallVector<Value*, 2> ret;
-    ret.push_back(Builder.CreateLoad(GEP, "Disambiguator0"));
+
+    auto * ASThreadId = GetValueFromExpandedPayload(Builder, originalPayloadStructType, firstGetPayload, originalPayloadStructType->getStructNumElements(), "ASThreadId");
+    auto * ASDispatchMeshYCount = GetValueFromExpandedPayload(Builder, originalPayloadStructType, firstGetPayload, originalPayloadStructType->getStructNumElements() + 1, "ASDispatchMeshYCount");
+    auto * ASDispatchMeshZCount = GetValueFromExpandedPayload(Builder, originalPayloadStructType, firstGetPayload, originalPayloadStructType->getStructNumElements() + 2, "ASDispatchMeshZCount");
 
     Constant *Zero32Arg = HlslOP->GetU32Const(0);
+    Constant *One32Arg = HlslOP->GetU32Const(1);
+    Constant *Two32Arg = HlslOP->GetU32Const(2);
 
     auto GroupIdFunc =
         HlslOP->GetOpFunc(DXIL::OpCode::GroupId, Type::getInt32Ty(Ctx));
     Constant *Opcode = HlslOP->GetU32Const((unsigned)DXIL::OpCode::GroupId);
-    auto * GroupId =
-        Builder.CreateCall(GroupIdFunc, {Opcode, Zero32Arg}, "ThreadIdX");
+    auto * GroupIdX =
+        Builder.CreateCall(GroupIdFunc, {Opcode, Zero32Arg}, "GroupIdX");
+    auto * GroupIdY =
+        Builder.CreateCall(GroupIdFunc, {Opcode, One32Arg}, "GroupIdY");
+    auto * GroupIdZ =
+        Builder.CreateCall(GroupIdFunc, {Opcode, Two32Arg}, "GroupIdZ");
 
-    ret.push_back(GroupId);
+    auto *XxY =
+      Builder.CreateMul(GroupIdX, ASDispatchMeshYCount);
+    auto *XandY = Builder.CreateAdd(GroupIdY, XxY);
+    auto *XYxZ = Builder.CreateMul(XandY, ASDispatchMeshZCount);
+    auto *XYZ = Builder.CreateAdd(GroupIdZ, XYxZ);
+
+    SmallVector<Value *, 2> ret;
+    ret.push_back(ASThreadId);
+    ret.push_back(XYZ);
 
     return ret;
 }

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -180,6 +180,8 @@ ExpandedStruct ExpandStructType(LLVMContext &Ctx,
       Elements.push_back(OriginalPayloadStructType->getStructElementType(i));
   }
   Elements.push_back(Type::getInt32Ty(Ctx));
+  Elements.push_back(Type::getInt32Ty(Ctx));
+  Elements.push_back(Type::getInt32Ty(Ctx));
   ExpandedStruct ret;
   ret.ExpandedPayloadStructType =
       StructType::create(Ctx, Elements, "PIX_AS2MS_Expanded_Type");


### PR DESCRIPTION
PIX's mesh shader output instrumentation needs to disambiguate groups of mesh shader invocations, so that PIX can reconstruct the intended mesh after the fact. In the case where an amplification shader is present, the previous code was incomplete: it included only the X value of the mesh shader's group ID relative to the AS DispatchMesh call. The full X*Y*Z value is needed. Unfortunately, this value does not necessarily fit into a single DWORD for returning to PIX via the instrumentation, but various spec constraints mean that the product of the group ID cube's dimensions will fit in a DWORD.
So this change expands the custom data added to the AS->MS payload to include the Y and Z group counts that the AS passed to DispatchMesh. The mesh shader can then multiply its group ID's component values by these counts in order to come up with a single unique group ID value.