### PR TITLE
Fix bugs in signature reflection, add signatures to dumper and tests

### DIFF
--- a/include/dxc/Test/D3DReflectionDumper.h
+++ b/include/dxc/Test/D3DReflectionDumper.h
@@ -38,6 +38,10 @@ LPCSTR ToString(D3D_SHADER_VARIABLE_FLAGS Flag);
 LPCSTR ToString(D3D_SHADER_INPUT_FLAGS Flag);
 LPCSTR ToString(D3D_SHADER_CBUFFER_FLAGS Flag);
 LPCSTR ToString(D3D_PARAMETER_FLAGS Flag);
+LPCSTR ToString(D3D_NAME Name);
+LPCSTR ToString(D3D_REGISTER_COMPONENT_TYPE CompTy);
+LPCSTR ToString(D3D_MIN_PRECISION MinPrec);
+LPCSTR CompMaskToString(unsigned CompMask);
 
 template<typename _T>
 struct EnumValue {
@@ -163,6 +167,7 @@ public:
   void Dump(D3D12_SHADER_VARIABLE_DESC &varDesc);
   void Dump(D3D12_SHADER_BUFFER_DESC &Desc);
   void Dump(D3D12_SHADER_INPUT_BIND_DESC &resDesc);
+  void Dump(D3D12_SIGNATURE_PARAMETER_DESC &elDesc);
   void Dump(D3D12_SHADER_DESC &Desc);
   void Dump(D3D12_FUNCTION_DESC &Desc);
   void Dump(D3D12_LIBRARY_DESC &Desc);

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1983,6 +1983,8 @@ D3D_NAME SemanticToSystemValueType(const Semantic *S, DXIL::TessellatorDomain do
     default:
     return D3D_NAME_UNDEFINED;
     }
+  case Semantic::Kind::Barycentrics:
+    return (D3D_NAME)DxilProgramSigSemantic::Barycentrics;
   case Semantic::Kind::ShadingRate:
     return (D3D_NAME)DxilProgramSigSemantic::ShadingRate;
   case Semantic::Kind::CullPrimitive:
@@ -2047,6 +2049,8 @@ void DxilShaderReflection::CreateReflectionObjectsForSignature(
           Desc.SemanticIndex == 1)
         Desc.SystemValueType = D3D_NAME_FINAL_LINE_DETAIL_TESSFACTOR;
       Descs.push_back(Desc);
+      // When indexVec.size() > 1, subsequent indices need incremented register index
+      Desc.Register += 1;
     }
   }
 }

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/anon_struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/anon_struct.hlsl
@@ -9,7 +9,7 @@ float main(int N : A, int C : B) : SV_TARGET {
 }
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK:   D3D12_SHADER_BUFFER_DESC:
+// CHECK:   D3D12_SHADER_DESC:
 // CHECK:     Shader Version: Pixel 6.0
 // CHECK:     ConstantBuffers: 1
 // CHECK:     BoundResources: 1
@@ -44,7 +44,7 @@ float main(int N : A, int C : B) : SV_TARGET {
 // CHECK:           CBuffer: $Globals
 // CHECK:       }
 // CHECK:   Bound Resources:
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:       Type: D3D_SIT_CBUFFER
 // CHECK:       uID: 0
 // CHECK:       BindPoint: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cb_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cb_array.hlsl
@@ -7,7 +7,7 @@ float main(int i : A) : SV_TARGET
 }
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK:   D3D12_SHADER_BUFFER_DESC:
+// CHECK:   D3D12_SHADER_DESC:
 // CHECK:     Shader Version: Pixel 6.0
 // CHECK:     ConstantBuffers: 1
 // CHECK:     BoundResources: 1
@@ -34,7 +34,7 @@ float main(int i : A) : SV_TARGET
 // CHECK:           CBuffer: $Globals
 // CHECK:       }
 // CHECK:   Bound Resources:
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:       Type: D3D_SIT_CBUFFER
 // CHECK:       uID: 0
 // CHECK:       BindPoint: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-phi.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-phi.hlsl
@@ -54,12 +54,12 @@ float4 main() : SV_Target {
 // CHECK:             uFlags: (D3D_SVF_USED)
 // CHECK:       }
 // CHECK:   Bound Resources:
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:       BindCount: 1
 // CHECK:       BindPoint: 0
 // CHECK:       Space: 0
 // CHECK:       uFlags: (D3D_SIF_USERPACKED)
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: CB
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: CB
 // CHECK:       BindCount: 1
 // CHECK:       BindPoint: 1
 // CHECK:       Space: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_default_val.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer_default_val.hlsl
@@ -9,7 +9,7 @@ float main() : SV_TARGET
 
 // Default value unsupported for now:
 // CHECK: ID3D12ShaderReflection:
-// CHECK:   D3D12_SHADER_BUFFER_DESC:
+// CHECK:   D3D12_SHADER_DESC:
 // CHECK:     Shader Version: Pixel 6.0
 // CHECK:     ConstantBuffers: 1
 // CHECK:     BoundResources: 1
@@ -35,7 +35,7 @@ float main() : SV_TARGET
 // CHECK:           CBuffer: $Globals
 // CHECK:       }
 // CHECK:   Bound Resources:
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:       Type: D3D_SIT_CBUFFER
 // CHECK:       uID: 0
 // CHECK:       BindPoint: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_struct2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_struct2.hlsl
@@ -26,7 +26,7 @@ float4 main(float4 pos : POSITION) : SV_POSITION { return foo + bar; }
 
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK:   D3D12_SHADER_BUFFER_DESC:
+// CHECK:   D3D12_SHADER_DESC:
 // CHECK:     Shader Version: Vertex 6.0
 // CHECK:     ConstantBuffers: 2
 // CHECK:     BoundResources: 2
@@ -100,7 +100,7 @@ float4 main(float4 pos : POSITION) : SV_POSITION { return foo + bar; }
 // CHECK:          CBuffer: Params_cbuffer2
 // CHECK:      }
 // CHECK:   Bound Resources:
-// CHECK:     D3D12_SHADER_BUFFER_DESC: Name: Params_cbuffer
+// CHECK:     D3D12_SHADER_INPUT_BIND_DESC: Name: Params_cbuffer
 // CHECK:       Type: D3D_SIT_CBUFFER
 // CHECK:       uID: 0
 // CHECK:       BindPoint: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
@@ -31,7 +31,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -41,7 +41,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 2
 // CHECK:         BindCount: 1
@@ -56,7 +56,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -71,7 +71,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Pixel 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -81,7 +81,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 2
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
@@ -35,7 +35,7 @@ void RayGen() {
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: U0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
 // CHECK:         Type: D3D_SIT_UAV_RWBYTEADDRESS
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -50,7 +50,7 @@ void RayGen() {
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: U0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
 // CHECK:         Type: D3D_SIT_UAV_RWBYTEADDRESS
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -65,7 +65,7 @@ void RayGen() {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -80,7 +80,7 @@ void RayGen() {
 // CHECK:       Shader Version: Vertex 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
@@ -26,7 +26,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -36,7 +36,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -51,7 +51,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -61,7 +61,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -76,7 +76,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -86,7 +86,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -101,7 +101,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Pixel 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -111,7 +111,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -126,7 +126,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Pixel 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -136,7 +136,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -151,7 +151,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Pixel 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -161,7 +161,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports4.hlsl
@@ -26,7 +26,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -41,7 +41,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -51,7 +51,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 2
 // CHECK:         BindCount: 1
@@ -66,7 +66,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Vertex 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 1
 // CHECK:         BindCount: 1
@@ -81,7 +81,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Shader Version: Pixel 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T0
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -91,7 +91,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: 0
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T2
 // CHECK:         Type: D3D_SIT_STRUCTURED
 // CHECK:         uID: 2
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports_nocollision.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports_nocollision.hlsl
@@ -40,7 +40,7 @@ void RayGen() {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -55,7 +55,7 @@ void RayGen() {
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: U0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
 // CHECK:         Type: D3D_SIT_UAV_RWBYTEADDRESS
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -70,7 +70,7 @@ void RayGen() {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: U0
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: U0
 // CHECK:         Type: D3D_SIT_UAV_RWBYTEADDRESS
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1
@@ -85,7 +85,7 @@ void RayGen() {
 // CHECK:       Shader Version: Vertex 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: T1
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: T1
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_global.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_global.hlsl
@@ -140,7 +140,7 @@
 // CHECK-NEXT:             CBuffer: X
 // CHECK-NEXT:         }
 // CHECK-NEXT:     Bound Resources:
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: X
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: X
 // CHECK-NEXT:         Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:         uID: 0
 // CHECK-NEXT:         BindCount: 1
@@ -150,7 +150,7 @@
 // CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:         NumSamples (or stride): 0
 // CHECK-NEXT:         uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: X
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: X
 // CHECK-NEXT:         Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:         uID: 1
 // CHECK-NEXT:         BindCount: 1
@@ -290,7 +290,7 @@
 // CHECK-NEXT:             CBuffer: X
 // CHECK-NEXT:         }
 // CHECK-NEXT:     Bound Resources:
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: X
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: X
 // CHECK-NEXT:               Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:               uID: 0
 // CHECK-NEXT:               BindCount: 1
@@ -300,7 +300,7 @@
 // CHECK-NEXT:               Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:               NumSamples (or stride): 0
 // CHECK-NEXT:               uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: g_samLinear
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: g_samLinear
 // CHECK-NEXT:         Type: D3D_SIT_SAMPLER
 // CHECK-NEXT:         uID: 0
 // CHECK-NEXT:         BindCount: 1
@@ -310,7 +310,7 @@
 // CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:         NumSamples (or stride): 0
 // CHECK-NEXT:         uFlags: 0
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: g_txDiffuse
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: g_txDiffuse
 // CHECK-NEXT:         Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:         uID: 0
 // CHECK-NEXT:         BindCount: 1
@@ -320,7 +320,7 @@
 // CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_TEXTURE2D
 // CHECK-NEXT:         NumSamples (or stride): 4294967295
 // CHECK-NEXT:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: X
+// CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: X
 // CHECK-NEXT:         Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:         uID: 1
 // CHECK-NEXT:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray.hlsl
@@ -37,7 +37,7 @@ float4 emit(inout float2 f2, RayDesc Ray:R, inout Payload p )  {
 // CHECK:       FunctionParameterCount: 0
 // CHECK:       HasReturn: FALSE
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: Acc
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: Acc
 // CHECK:         Type: D3D_SIT_RTACCELERATIONSTRUCTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray_readback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray_readback.hlsl
@@ -52,7 +52,7 @@ void RayGenTestMain()
 // CHECK:           uFlags: 0
 // CHECK:           Num Variables: 3
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: scene
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: scene
 // CHECK:         Type: D3D_SIT_RTACCELERATIONSTRUCTURE
 // CHECK:         uID: 0
 // CHECK:         BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/reflect-lib-1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/reflect-lib-1.hlsl
@@ -54,13 +54,13 @@ float4 function2(float4 x : POSITION) : SV_Position { return x + cbval1 + cbval3
 // CHECK:             CBuffer: MyCB
 // CHECK:         }
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: MyCB
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: MyCB
 // CHECK:         Type: D3D_SIT_CBUFFER
 // CHECK:         uID: 1
 // CHECK:         BindPoint: 11
 // CHECK:         Space: 2
 // CHECK:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: tex
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: tex
 // CHECK:         Type: D3D_SIT_UAV_RWTYPED
 // CHECK:         uID: 0
 // CHECK:         BindPoint: 5
@@ -92,23 +92,23 @@ float4 function2(float4 x : POSITION) : SV_Position { return x + cbval1 + cbval3
 // CHECK:             CBuffer: $Globals
 // CHECK:         }
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:         Type: D3D_SIT_CBUFFER
 // CHECK:         uID: 0
 // CHECK:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: samp
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: samp
 // CHECK:         Type: D3D_SIT_SAMPLER
 // CHECK:         uID: 0
 // CHECK:         BindPoint: 7
 // CHECK:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: tex2
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: tex2
 // CHECK:         Type: D3D_SIT_TEXTURE
 // CHECK:         uID: 0
 // CHECK:         BindPoint: 0
 // CHECK:         ReturnType: D3D_RETURN_TYPE_FLOAT
 // CHECK:         Dimension: D3D_SRV_DIMENSION_TEXTURE1D
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: b_buf
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: b_buf
 // CHECK:         Type: D3D_SIT_UAV_RWBYTEADDRESS
 // CHECK:         uID: 1
 // CHECK:         ReturnType: D3D_RETURN_TYPE_MIXED
@@ -168,11 +168,11 @@ float4 function2(float4 x : POSITION) : SV_Position { return x + cbval1 + cbval3
 // CHECK:             CBuffer: MyCB
 // CHECK:         }
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: $Globals
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: $Globals
 // CHECK:         Type: D3D_SIT_CBUFFER
 // CHECK:         uID: 0
 // CHECK:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: MyCB
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: MyCB
 // CHECK:         Type: D3D_SIT_CBUFFER
 // CHECK:         uID: 1
 // CHECK:         BindPoint: 11

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/sig-array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/sig-array.hlsl
@@ -1,0 +1,198 @@
+// RUN: %dxc -E VSMain -T vs_6_0 %s | %D3DReflect %s | FileCheck %s
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK:   D3D12_SHADER_DESC:
+// CHECK:     Shader Version: Vertex 6.0
+// CHECK:     ConstantBuffers: 0
+// CHECK:     BoundResources: 0
+// CHECK:     InputParameters: 11
+// CHECK:     OutputParameters: 11
+// CHECK:   InputParameter Elements: 11
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 0
+// CHECK-NEXT:       Register: 0
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 1
+// CHECK-NEXT:       Register: 1
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 2
+// CHECK-NEXT:       Register: 2
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 3
+// CHECK-NEXT:       Register: 3
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: F SemanticIndex: 0
+// CHECK-NEXT:       Register: 4
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: G SemanticIndex: 0
+// CHECK-NEXT:       Register: 5
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: x---
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 0
+// CHECK-NEXT:       Register: 6
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xy--
+// CHECK-NEXT:       ReadWriteMask: xy--
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 1
+// CHECK-NEXT:       Register: 7
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xy--
+// CHECK-NEXT:       ReadWriteMask: xy--
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 2
+// CHECK-NEXT:       Register: 8
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xy--
+// CHECK-NEXT:       ReadWriteMask: xy--
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 3
+// CHECK-NEXT:       Register: 9
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xy--
+// CHECK-NEXT:       ReadWriteMask: xy--
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: SV_Position SemanticIndex: 0
+// CHECK-NEXT:       Register: 10
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xyzw
+// CHECK-NEXT:       ReadWriteMask: xyzw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:   OutputParameter Elements: 11
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 0
+// CHECK-NEXT:       Register: 0
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: -yzw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 1
+// CHECK-NEXT:       Register: 1
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: -yzw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 2
+// CHECK-NEXT:       Register: 2
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: -yzw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ARRAY SemanticIndex: 3
+// CHECK-NEXT:       Register: 3
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: x---
+// CHECK-NEXT:       ReadWriteMask: -yzw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: F SemanticIndex: 0
+// CHECK-NEXT:       Register: 0
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: -y--
+// CHECK-NEXT:       ReadWriteMask: x-zw
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: G SemanticIndex: 0
+// CHECK-NEXT:       Register: 0
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: --z-
+// CHECK-NEXT:       ReadWriteMask: xy-w
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 0
+// CHECK-NEXT:       Register: 1
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: -yz-
+// CHECK-NEXT:       ReadWriteMask: x--w
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 1
+// CHECK-NEXT:       Register: 2
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: -yz-
+// CHECK-NEXT:       ReadWriteMask: x--w
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 2
+// CHECK-NEXT:       Register: 3
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: -yz-
+// CHECK-NEXT:       ReadWriteMask: x--w
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MATRIX_ARRAY SemanticIndex: 3
+// CHECK-NEXT:       Register: 4
+// CHECK-NEXT:       SystemValueType: D3D_NAME_UNDEFINED
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: -yz-
+// CHECK-NEXT:       ReadWriteMask: x--w
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// CHECK-NEXT:     D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: SV_POSITION SemanticIndex: 0
+// CHECK-NEXT:       Register: 5
+// CHECK-NEXT:       SystemValueType: D3D_NAME_POSITION
+// CHECK-NEXT:       ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// CHECK-NEXT:       Mask: xyzw
+// CHECK-NEXT:       ReadWriteMask: ----
+// CHECK-NEXT:       Stream: 0
+// CHECK-NEXT:       MinPrecision: D3D_MIN_PRECISION_DEFAULT
+
+struct IO {
+   float arr[4] : ARRAY;
+   float f : F,
+         g : G;
+   float2x2 mat_arr[2] : MATRIX_ARRAY;
+   float4 pos : SV_Position;
+};
+
+void VSMain(inout IO io) {
+}

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_getdim_stride.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_getdim_stride.hlsl
@@ -20,7 +20,7 @@ uint UseBuf(int2 idx) {
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
-// CHECK:       D3D12_SHADER_BUFFER_DESC: Name: g_buffer
+// CHECK:       D3D12_SHADER_INPUT_BIND_DESC: Name: g_buffer
 // CHECK:         Type: D3D_SIT_UAV_RWSTRUCTURED
 // CHECK:         uID: 0
 // CHECK:         BindCount: 2

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_layout.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_layout.hlsl
@@ -1208,7 +1208,7 @@
 // CHECK-NEXT:          CBuffer: StructuredBufferUnbounded[0]
 // CHECK-NEXT:      }
 // CHECK-NEXT:  Bound Resources:
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: CB
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: CB
 // CHECK-NEXT:      Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:      uID: 0
 // CHECK-NEXT:      BindCount: 1
@@ -1218,7 +1218,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: CBuffer
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: CBuffer
 // CHECK-NEXT:      Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:      uID: 1
 // CHECK-NEXT:      BindCount: 1
@@ -1228,7 +1228,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: ConstantBufferArray
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: ConstantBufferArray
 // CHECK-NEXT:      Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:      uID: 2
 // CHECK-NEXT:      BindCount: 6
@@ -1238,7 +1238,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: ConstantBufferA1
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: ConstantBufferA1
 // CHECK-NEXT:      Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:      uID: 3
 // CHECK-NEXT:      BindCount: 1
@@ -1248,7 +1248,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: ConstantBufferUnbounded
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: ConstantBufferUnbounded
 // CHECK-NEXT:      Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:      uID: 4
 // CHECK-NEXT:      BindCount: 4294967295
@@ -1258,7 +1258,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_USERPACKED)
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: SamplerUnbounded
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: SamplerUnbounded
 // CHECK-NEXT:      Type: D3D_SIT_SAMPLER
 // CHECK-NEXT:      uID: 0
 // CHECK-NEXT:      BindCount: 0
@@ -1268,7 +1268,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: SB
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: SB
 // CHECK-NEXT:      Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:      uID: 0
 // CHECK-NEXT:      BindCount: 1
@@ -1278,7 +1278,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK-NEXT:      NumSamples (or stride): 64
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: StructuredBufferArray
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: StructuredBufferArray
 // CHECK-NEXT:      Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:      uID: 1
 // CHECK-NEXT:      BindCount: 6
@@ -1288,7 +1288,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK-NEXT:      NumSamples (or stride): 128
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: StructuredBufferA1
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: StructuredBufferA1
 // CHECK-NEXT:      Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:      uID: 2
 // CHECK-NEXT:      BindCount: 1
@@ -1298,7 +1298,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK-NEXT:      NumSamples (or stride): 64
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: StructuredBufferUnbounded
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: StructuredBufferUnbounded
 // CHECK-NEXT:      Type: D3D_SIT_STRUCTURED
 // CHECK-NEXT:      uID: 3
 // CHECK-NEXT:      BindCount: 0
@@ -1308,7 +1308,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_BUFFER
 // CHECK-NEXT:      NumSamples (or stride): 64
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: Texture2DUnbounded
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: Texture2DUnbounded
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 4
 // CHECK-NEXT:      BindCount: 0
@@ -1318,7 +1318,7 @@
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2D
 // CHECK-NEXT:      NumSamples (or stride): 4294967295
 // CHECK-NEXT:      uFlags: 0
-// CHECK-NEXT:    D3D12_SHADER_BUFFER_DESC: Name: RWBufferUnbounded
+// CHECK-NEXT:    D3D12_SHADER_INPUT_BIND_DESC: Name: RWBufferUnbounded
 // CHECK-NEXT:      Type: D3D_SIT_UAV_RWTYPED
 // CHECK-NEXT:      uID: 0
 // CHECK-NEXT:      BindCount: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-16bit.hlsl
@@ -35,7 +35,7 @@ float main(int i : A) : SV_TARGET
 }
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK-NEXT:   D3D12_SHADER_BUFFER_DESC:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
 // CHECK-NEXT:     Shader Version: Pixel 6.2
 // CHECK:     Flags: 0
 // CHECK-NEXT:     ConstantBuffers: 1
@@ -59,7 +59,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:     cBarrierInstructions: 0
 // CHECK-NEXT:     cInterlockedInstructions: 0
 // CHECK-NEXT:     cTextureStoreInstructions: 0
-// CHECK-NEXT:   Constant Buffers:
+// CHECK:   Constant Buffers:
 // CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
 // CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: tb
 // CHECK-NEXT:         Type: D3D_CT_TBUFFER
@@ -293,7 +293,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:           CBuffer: tb
 // CHECK-NEXT:       }
 // CHECK-NEXT:   Bound Resources:
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: tb
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: tb
 // CHECK-NEXT:       Type: D3D_SIT_TBUFFER
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer.hlsl
@@ -47,7 +47,7 @@ float main(int i : A) : SV_TARGET
 }
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK-NEXT:   D3D12_SHADER_BUFFER_DESC:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
 // CHECK-NEXT:     Shader Version: Pixel 6.0
 // CHECK:     Flags: 0
 // CHECK-NEXT:     ConstantBuffers: 1
@@ -71,7 +71,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:     cBarrierInstructions: 0
 // CHECK-NEXT:     cInterlockedInstructions: 0
 // CHECK-NEXT:     cTextureStoreInstructions: 0
-// CHECK-NEXT:   Constant Buffers:
+// CHECK:   Constant Buffers:
 // CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
 // CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: tb
 // CHECK-NEXT:         Type: D3D_CT_TBUFFER
@@ -241,7 +241,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:           CBuffer: tb
 // CHECK-NEXT:       }
 // CHECK-NEXT:   Bound Resources:
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: tb
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: tb
 // CHECK-NEXT:       Type: D3D_SIT_TBUFFER
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/texture2dms.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/texture2dms.hlsl
@@ -24,7 +24,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 
 // CHECK: ID3D12ShaderReflection:
 // CHECK:   Bound Resources:
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTexture
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 0
 // CHECK-NEXT:      BindCount: 1
@@ -34,7 +34,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTextureArray
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 1
 // CHECK-NEXT:      BindCount: 1
@@ -44,7 +44,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMSARRAY
 // CHECK-NEXT:      NumSamples (or stride): 0
 // CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture1
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTexture1
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 2
 // CHECK-NEXT:      BindCount: 1
@@ -54,7 +54,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
 // CHECK-NEXT:      NumSamples (or stride): 4294967295
 // CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray1
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTextureArray1
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 3
 // CHECK-NEXT:      BindCount: 1
@@ -64,7 +64,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMSARRAY
 // CHECK-NEXT:      NumSamples (or stride): 4294967295
 // CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTexture2
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTexture2
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 4
 // CHECK-NEXT:      BindCount: 1
@@ -74,7 +74,7 @@ float4 main(uint4 color : COLOR) : SV_TARGET
 // CHECK-NEXT:      Dimension: D3D_SRV_DIMENSION_TEXTURE2DMS
 // CHECK-NEXT:      NumSamples (or stride): 8
 // CHECK-NEXT:      uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
-// CHECK:    D3D12_SHADER_BUFFER_DESC: Name: msTextureArray2
+// CHECK:    D3D12_SHADER_INPUT_BIND_DESC: Name: msTextureArray2
 // CHECK-NEXT:      Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:      uID: 5
 // CHECK-NEXT:      BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/FeedbackTexture/feedback-reflect.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/FeedbackTexture/feedback-reflect.hlsl
@@ -31,7 +31,7 @@ float main() : SV_Target
 }
 
 // CHECK: ID3D12ShaderReflection:
-// CHECK-NEXT:   D3D12_SHADER_BUFFER_DESC:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
 // CHECK-NEXT:     Shader Version: Pixel 6.5
 // CHECK:     Flags: 0
 // CHECK-NEXT:     ConstantBuffers: 0
@@ -39,7 +39,7 @@ float main() : SV_Target
 // CHECK-NEXT:     InputParameters: 0
 // CHECK-NEXT:     OutputParameters: 1
 // CHECK:   Bound Resources:
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: samp
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: samp
 // CHECK-NEXT:       Type: D3D_SIT_SAMPLER
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1
@@ -49,7 +49,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_UNKNOWN
 // CHECK-NEXT:       NumSamples (or stride): 0
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: texture2D
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: texture2D
 // CHECK-NEXT:       Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1
@@ -59,7 +59,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_TEXTURE2D
 // CHECK-NEXT:       NumSamples (or stride): 4294967295
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: texture2DArray
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: texture2DArray
 // CHECK-NEXT:       Type: D3D_SIT_TEXTURE
 // CHECK-NEXT:       uID: 1
 // CHECK-NEXT:       BindCount: 1
@@ -69,7 +69,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_TEXTURE2DARRAY
 // CHECK-NEXT:       NumSamples (or stride): 4294967295
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: feedbackMinMip
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: feedbackMinMip
 // CHECK-NEXT:       Type: D3D_SIT_UAV_FEEDBACKTEXTURE
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1
@@ -79,7 +79,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_TEXTURE2D
 // CHECK-NEXT:       NumSamples (or stride): 4294967295
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: feedbackMipRegionUsed
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: feedbackMipRegionUsed
 // CHECK-NEXT:       Type: D3D_SIT_UAV_FEEDBACKTEXTURE
 // CHECK-NEXT:       uID: 1
 // CHECK-NEXT:       BindCount: 1
@@ -89,7 +89,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_TEXTURE2D
 // CHECK-NEXT:       NumSamples (or stride): 4294967295
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: feedbackMinMipArray
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: feedbackMinMipArray
 // CHECK-NEXT:       Type: D3D_SIT_UAV_FEEDBACKTEXTURE
 // CHECK-NEXT:       uID: 2
 // CHECK-NEXT:       BindCount: 1
@@ -99,7 +99,7 @@ float main() : SV_Target
 // CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_TEXTURE2DARRAY
 // CHECK-NEXT:       NumSamples (or stride): 4294967295
 // CHECK-NEXT:       uFlags: 0
-// CHECK-NEXT:     D3D12_SHADER_BUFFER_DESC: Name: feebackMipRegionUsedArray
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: feebackMipRegionUsedArray
 // CHECK-NEXT:       Type: D3D_SIT_UAV_FEEDBACKTEXTURE
 // CHECK-NEXT:       uID: 3
 // CHECK-NEXT:       BindCount: 1

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/mesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/mesh.hlsl
@@ -81,6 +81,9 @@ void main(
     verts[tig] = ov;
 }
 
+// REFL: InputParameters: 0
+// REFL: OutputParameters: 5
+// REFL: PatchConstantParameters: 11
 // REFL: TempArrayCount: 64
 // REFL: DynamicFlowControlCount: 1
 // REFL: ArrayInstructionCount: 2
@@ -97,3 +100,134 @@ void main(
 // REFL: cBarrierInstructions: 0
 // REFL: cInterlockedInstructions: 0
 // REFL: cTextureStoreInstructions: 0
+
+// REFL:  OutputParameter Elements: 5
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: SV_POSITION SemanticIndex: 0
+// REFL-NEXT:      Register: 0
+// REFL-NEXT:      SystemValueType: D3D_NAME_POSITION
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: xyzw
+// REFL-NEXT:      ReadWriteMask: ----
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: COLOR SemanticIndex: 0
+// REFL-NEXT:      Register: 1
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: COLOR SemanticIndex: 1
+// REFL-NEXT:      Register: 2
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: COLOR SemanticIndex: 2
+// REFL-NEXT:      Register: 3
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: COLOR SemanticIndex: 3
+// REFL-NEXT:      Register: 4
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:  PatchConstantParameter Elements: 11
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: NORMAL SemanticIndex: 0
+// REFL-NEXT:      Register: 0
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: MALNOR SemanticIndex: 0
+// REFL-NEXT:      Register: 0
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: -y--
+// REFL-NEXT:      ReadWriteMask: x-zw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ALNORM SemanticIndex: 0
+// REFL-NEXT:      Register: 0
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: --z-
+// REFL-NEXT:      ReadWriteMask: xy-w
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ORMALN SemanticIndex: 0
+// REFL-NEXT:      Register: 0
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_FLOAT32
+// REFL-NEXT:      Mask: ---w
+// REFL-NEXT:      ReadWriteMask: xyz-
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 0
+// REFL-NEXT:      Register: 1
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 1
+// REFL-NEXT:      Register: 2
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 2
+// REFL-NEXT:      Register: 3
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 3
+// REFL-NEXT:      Register: 4
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 4
+// REFL-NEXT:      Register: 5
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: LAYER SemanticIndex: 5
+// REFL-NEXT:      Register: 6
+// REFL-NEXT:      SystemValueType: D3D_NAME_UNDEFINED
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_SINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT
+// REFL-NEXT:    D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: SV_CULLPRIMITIVE SemanticIndex: 0
+// REFL-NEXT:      Register: 4294967295
+// REFL-NEXT:      SystemValueType: D3D_NAME_CULLPRIMITIVE
+// REFL-NEXT:      ComponentType: D3D_REGISTER_COMPONENT_UINT32
+// REFL-NEXT:      Mask: x---
+// REFL-NEXT:      ReadWriteMask: -yzw
+// REFL-NEXT:      Stream: 0
+// REFL-NEXT:      MinPrecision: D3D_MIN_PRECISION_DEFAULT

--- a/tools/clang/unittests/HLSLTestLib/D3DReflectionDumper.cpp
+++ b/tools/clang/unittests/HLSLTestLib/D3DReflectionDumper.cpp
@@ -10,6 +10,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/Support/Global.h"
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/test/D3DReflectionDumper.h"
 #include "dxc/DxilContainer/DxilContainer.h"
 #include <sstream>
@@ -347,6 +348,96 @@ LPCSTR ToString(D3D_PARAMETER_FLAGS Flag) {
   return nullptr;
 }
 
+#ifndef D3D_NAME_SHADINGRATE
+#define D3D_NAME_SHADINGRATE ((D3D_NAME)hlsl::DxilProgramSigSemantic::ShadingRate)
+#endif
+#ifndef D3D_NAME_CULLPRIMITIVE
+#define D3D_NAME_CULLPRIMITIVE ((D3D_NAME)hlsl::DxilProgramSigSemantic::CullPrimitive)
+#endif
+
+LPCSTR ToString(D3D_NAME Name) {
+  switch (Name) {
+  case D3D_NAME_UNDEFINED: return "D3D_NAME_UNDEFINED";
+  case D3D_NAME_POSITION: return "D3D_NAME_POSITION";
+  case D3D_NAME_CLIP_DISTANCE: return "D3D_NAME_CLIP_DISTANCE";
+  case D3D_NAME_CULL_DISTANCE: return "D3D_NAME_CULL_DISTANCE";
+  case D3D_NAME_RENDER_TARGET_ARRAY_INDEX: return "D3D_NAME_RENDER_TARGET_ARRAY_INDEX";
+  case D3D_NAME_VIEWPORT_ARRAY_INDEX: return "D3D_NAME_VIEWPORT_ARRAY_INDEX";
+  case D3D_NAME_VERTEX_ID: return "D3D_NAME_VERTEX_ID";
+  case D3D_NAME_PRIMITIVE_ID: return "D3D_NAME_PRIMITIVE_ID";
+  case D3D_NAME_INSTANCE_ID: return "D3D_NAME_INSTANCE_ID";
+  case D3D_NAME_IS_FRONT_FACE: return "D3D_NAME_IS_FRONT_FACE";
+  case D3D_NAME_SAMPLE_INDEX: return "D3D_NAME_SAMPLE_INDEX";
+  case D3D_NAME_FINAL_QUAD_EDGE_TESSFACTOR: return "D3D_NAME_FINAL_QUAD_EDGE_TESSFACTOR";
+  case D3D_NAME_FINAL_QUAD_INSIDE_TESSFACTOR: return "D3D_NAME_FINAL_QUAD_INSIDE_TESSFACTOR";
+  case D3D_NAME_FINAL_TRI_EDGE_TESSFACTOR: return "D3D_NAME_FINAL_TRI_EDGE_TESSFACTOR";
+  case D3D_NAME_FINAL_TRI_INSIDE_TESSFACTOR: return "D3D_NAME_FINAL_TRI_INSIDE_TESSFACTOR";
+  case D3D_NAME_FINAL_LINE_DETAIL_TESSFACTOR: return "D3D_NAME_FINAL_LINE_DETAIL_TESSFACTOR";
+  case D3D_NAME_FINAL_LINE_DENSITY_TESSFACTOR: return "D3D_NAME_FINAL_LINE_DENSITY_TESSFACTOR";
+  case D3D_NAME_BARYCENTRICS: return "D3D_NAME_BARYCENTRICS";
+  case D3D_NAME_TARGET: return "D3D_NAME_TARGET";
+  case D3D_NAME_DEPTH: return "D3D_NAME_DEPTH";
+  case D3D_NAME_COVERAGE: return "D3D_NAME_COVERAGE";
+  case D3D_NAME_DEPTH_GREATER_EQUAL: return "D3D_NAME_DEPTH_GREATER_EQUAL";
+  case D3D_NAME_DEPTH_LESS_EQUAL: return "D3D_NAME_DEPTH_LESS_EQUAL";
+  case D3D_NAME_STENCIL_REF: return "D3D_NAME_STENCIL_REF";
+  case D3D_NAME_INNER_COVERAGE: return "D3D_NAME_INNER_COVERAGE";
+  case D3D_NAME_SHADINGRATE: return "D3D_NAME_SHADINGRATE";
+  case D3D_NAME_CULLPRIMITIVE: return "D3D_NAME_CULLPRIMITIVE";
+  }
+  return nullptr;
+}
+
+LPCSTR ToString(D3D_REGISTER_COMPONENT_TYPE CompTy) {
+  switch (CompTy) {
+  case D3D_REGISTER_COMPONENT_UNKNOWN: return "D3D_REGISTER_COMPONENT_UNKNOWN";
+  case D3D_REGISTER_COMPONENT_UINT32: return "D3D_REGISTER_COMPONENT_UINT32";
+  case D3D_REGISTER_COMPONENT_SINT32: return "D3D_REGISTER_COMPONENT_SINT32";
+  case D3D_REGISTER_COMPONENT_FLOAT32: return "D3D_REGISTER_COMPONENT_FLOAT32";
+  }
+  return nullptr;
+}
+
+LPCSTR ToString(D3D_MIN_PRECISION MinPrec) {
+  switch (MinPrec) {
+  case D3D_MIN_PRECISION_DEFAULT: return "D3D_MIN_PRECISION_DEFAULT";
+  case D3D_MIN_PRECISION_FLOAT_16: return "D3D_MIN_PRECISION_FLOAT_16";
+  case D3D_MIN_PRECISION_FLOAT_2_8: return "D3D_MIN_PRECISION_FLOAT_2_8";
+  case D3D_MIN_PRECISION_RESERVED: return "D3D_MIN_PRECISION_RESERVED";
+  case D3D_MIN_PRECISION_SINT_16: return "D3D_MIN_PRECISION_SINT_16";
+  case D3D_MIN_PRECISION_UINT_16: return "D3D_MIN_PRECISION_UINT_16";
+  case D3D_MIN_PRECISION_ANY_16: return "D3D_MIN_PRECISION_ANY_16";
+  case D3D_MIN_PRECISION_ANY_10: return "D3D_MIN_PRECISION_ANY_10";
+  }
+  return nullptr;
+}
+
+LPCSTR CompMaskToString(unsigned CompMask) {
+  static const LPCSTR masks[16] = {
+    "----",
+    "x---",
+    "-y--",
+    "xy--",
+    "--z-",
+    "x-z-",
+    "-yz-",
+    "xyz-",
+    "---w",
+    "x--w",
+    "-y-w",
+    "xy-w",
+    "--zw",
+    "x-zw",
+    "-yzw",
+    "xyzw"
+  };
+  if (CompMask < 16) {
+    return masks[CompMask];
+  }
+  return "<invalid mask>";
+}
+
+
 void D3DReflectionDumper::DumpDefaultValue(LPCVOID pDefaultValue, UINT Size) {
   WriteLn("DefaultValue: ", pDefaultValue ? "<present>" : "<nullptr>");    // TODO: Dump DefaultValue
 }
@@ -411,7 +502,7 @@ void D3DReflectionDumper::Dump(D3D12_SHADER_BUFFER_DESC &Desc) {
 }
 void D3DReflectionDumper::Dump(D3D12_SHADER_INPUT_BIND_DESC &resDesc) {
   SetLastName(resDesc.Name);
-  WriteLn("D3D12_SHADER_BUFFER_DESC: Name: ", m_LastName);
+  WriteLn("D3D12_SHADER_INPUT_BIND_DESC: Name: ", m_LastName);
   Indent();
   DumpEnum("Type", resDesc.Type);
   WriteLn("uID: ", resDesc.uID);
@@ -424,8 +515,20 @@ void D3DReflectionDumper::Dump(D3D12_SHADER_INPUT_BIND_DESC &resDesc) {
   WriteLn("uFlags: ", FlagsValue<D3D_SHADER_INPUT_FLAGS>(resDesc.uFlags));
   Dedent();
 }
+void D3DReflectionDumper::Dump(D3D12_SIGNATURE_PARAMETER_DESC &elDesc) {
+  WriteLn("D3D12_SIGNATURE_PARAMETER_DESC: SemanticName: ", elDesc.SemanticName, " SemanticIndex: ", elDesc.SemanticIndex);
+  Indent();
+  WriteLn("Register: ", elDesc.Register);
+  DumpEnum("SystemValueType", elDesc.SystemValueType);
+  DumpEnum("ComponentType", elDesc.ComponentType);
+  WriteLn("Mask: ", CompMaskToString(elDesc.Mask), " (", (UINT)elDesc.Mask, ")");
+  WriteLn("ReadWriteMask: ", CompMaskToString(elDesc.ReadWriteMask), " (", (UINT)elDesc.ReadWriteMask, ") (AlwaysReads/NeverWrites)");
+  WriteLn("Stream: ", elDesc.Stream);
+  DumpEnum("MinPrecision", elDesc.MinPrecision);
+  Dedent();
+}
 void D3DReflectionDumper::Dump(D3D12_SHADER_DESC &Desc) {
-  WriteLn("D3D12_SHADER_BUFFER_DESC:");
+  WriteLn("D3D12_SHADER_DESC:");
   Indent();
   DumpShaderVersion(Desc.Version);
   WriteLn("Creator: ", Desc.Creator ? Desc.Creator : "<nullptr>");
@@ -453,6 +556,9 @@ void D3DReflectionDumper::Dump(D3D12_SHADER_DESC &Desc) {
     WriteLn("PatchConstantParameters: ", Desc.PatchConstantParameters);
     WriteLn("cControlPoints: ", Desc.cControlPoints);
     DumpEnum("TessellatorDomain", Desc.TessellatorDomain);
+  }
+  if (ShaderKind == hlsl::DXIL::ShaderKind::Mesh) {
+    WriteLn("PatchConstantParameters: ", Desc.PatchConstantParameters, " (output primitive parameters for mesh shader)");
   }
   // Instruction Counts
   WriteLn("InstructionCount: ", Desc.InstructionCount);
@@ -582,12 +688,57 @@ void D3DReflectionDumper::Dump(ID3D12ShaderReflection *pShaderReflection) {
     return;
   }
   Dump(Desc);
+
+  if (Desc.InputParameters) {
+    WriteLn("InputParameter Elements: ", Desc.InputParameters);
+    Indent();
+    for (UINT i = 0; i < Desc.InputParameters; ++i) {
+      D3D12_SIGNATURE_PARAMETER_DESC elDesc;
+      if(FAILED(pShaderReflection->GetInputParameterDesc(i, &elDesc))) {
+        Failure("GetInputParameterDesc ", i);
+        continue;
+      }
+      Dump(elDesc);
+    }
+    Dedent();
+  }
+  if (Desc.OutputParameters) {
+    WriteLn("OutputParameter Elements: ", Desc.OutputParameters);
+    Indent();
+    for (UINT i = 0; i < Desc.OutputParameters; ++i) {
+      D3D12_SIGNATURE_PARAMETER_DESC elDesc;
+      if(FAILED(pShaderReflection->GetOutputParameterDesc(i, &elDesc))) {
+        Failure("GetOutputParameterDesc ", i);
+        continue;
+      }
+      Dump(elDesc);
+    }
+    Dedent();
+  }
+  if (Desc.PatchConstantParameters) {
+    WriteLn("PatchConstantParameter Elements: ", Desc.PatchConstantParameters);
+    Indent();
+    for (UINT i = 0; i < Desc.PatchConstantParameters; ++i) {
+      D3D12_SIGNATURE_PARAMETER_DESC elDesc;
+      if(FAILED(pShaderReflection->GetPatchConstantParameterDesc(i, &elDesc))) {
+        Failure("GetPatchConstantParameterDesc ", i);
+        continue;
+      }
+      Dump(elDesc);
+    }
+    Dedent();
+  }
+
   if (Desc.ConstantBuffers) {
     WriteLn("Constant Buffers:");
     Indent();
     bool bCheckByNameFailed = false;
     for (UINT uCB = 0; uCB < Desc.ConstantBuffers; uCB++) {
       ID3D12ShaderReflectionConstantBuffer *pCB = pShaderReflection->GetConstantBufferByIndex(uCB);
+      if (!pCB) {
+        Failure("GetConstantBufferByIndex ", uCB);
+        continue;
+      }
       Dump(pCB);
       if (m_bCheckByName && m_LastName) {
         if (pShaderReflection->GetConstantBufferByName(m_LastName) != pCB) {
@@ -608,6 +759,8 @@ void D3DReflectionDumper::Dump(ID3D12ShaderReflection *pShaderReflection) {
     for (UINT uRes = 0; uRes < Desc.BoundResources; uRes++) {
       D3D12_SHADER_INPUT_BIND_DESC bindDesc;
       if (FAILED(pShaderReflection->GetResourceBindingDesc(uRes, &bindDesc))) {
+        Failure("GetResourceBindingDesc ", uRes);
+        continue;
       }
       Dump(bindDesc);
       if (m_bCheckByName && bindDesc.Name) {


### PR DESCRIPTION
- Fix Barycentric system value translation
- Increment Register for array elements
- Add signature dumping to D3DReflectionDumper
- Dump PatchConstantParameters when mesh shader

Fixes #3952