### PR TITLE
Fixed an assert when a dxil error happens with global variable

### DIFF
--- a/include/llvm/IR/DiagnosticInfo.h
+++ b/include/llvm/IR/DiagnosticInfo.h
@@ -484,22 +484,33 @@ private:
   // Function
   const Function *Func;
 
-  // Location information
-  const DILocation *DLoc;
+  bool HasLocation = false;
+  unsigned Line = 0;
+  unsigned Column = 0;
+  StringRef FileName;
 
   /// Message to be reported.
   const Twine &MsgStr;
 
+
 public:
   /// This class does not copy \p MsgStr, therefore the reference must be valid
   /// for the whole life time of the Diagnostic.
+  /// 
+  DiagnosticInfoDxil(const Function *F, const Twine &MsgStr, DiagnosticSeverity Severity) :
+    DiagnosticInfo(DK_DXIL, Severity), Func(F), MsgStr(MsgStr)
+  {}
   DiagnosticInfoDxil(const Function *F, const DILocation *Loc, const Twine &MsgStr,
-                     DiagnosticSeverity Severity = DS_Error)
-    : DiagnosticInfo(DK_DXIL, Severity), Func(F), DLoc(Loc), MsgStr(MsgStr) {}
+                      DiagnosticSeverity Severity = DS_Error);
+  DiagnosticInfoDxil(const Function *F, const DIGlobalVariable *DGV, const Twine &MsgStr,
+                      DiagnosticSeverity Severity = DS_Error);
 
   const Function *getFunction() const { return Func; }
-  const DILocation *getLocation() const { return DLoc; }
   const Twine &getMsgStr() const { return MsgStr; }
+  bool hasLocation() const { return HasLocation; }
+  unsigned getLine() const { return Line; }
+  unsigned getColumn() const { return Column; }
+  StringRef getFileName() const { return FileName; }
 
   /// \see DiagnosticInfo::print.
   void print(DiagnosticPrinter &DP) const override;

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -310,9 +310,7 @@ void EmitWarningOnFunction(llvm::LLVMContext &Ctx, Function *F, Twine Msg) {
 
 static void EmitWarningOrErrorOnGlobalVariable(llvm::LLVMContext &Ctx, GlobalVariable *GV,
                                                Twine Msg, DiagnosticSeverity severity) {
-  DIVariable *DIV = nullptr;
-
-  DILocation *DLoc = nullptr;
+  DIGlobalVariable *DIV = nullptr;
 
   if (GV) {
     Module &M = *GV->getParent();
@@ -325,13 +323,10 @@ static void EmitWarningOrErrorOnGlobalVariable(llvm::LLVMContext &Ctx, GlobalVar
       else
         Finder.processModule(M);
       DIV = FindGlobalVariableDebugInfo(GV, Finder);
-      if (DIV)
-        DLoc = DILocation::get(GV->getContext(), DIV->getLine(), 0,
-                               DIV->getScope(), nullptr /*InlinedAt*/);
     }
   }
 
-  Ctx.diagnose(DiagnosticInfoDxil(nullptr /*Function*/, DLoc, Msg, severity));
+  Ctx.diagnose(DiagnosticInfoDxil(nullptr /*Function*/, DIV, Msg, severity));
 }
 
 void EmitErrorOnGlobalVariable(llvm::LLVMContext &Ctx, GlobalVariable *GV, Twine Msg) {
@@ -350,8 +345,7 @@ void EmitResMappingError(Instruction *Res) {
 
 // Mostly just a locationless diagnostic output
 static void EmitWarningOrErrorOnContext(LLVMContext &Ctx, Twine Msg, DiagnosticSeverity severity) {
-  Ctx.diagnose(DiagnosticInfoDxil(nullptr /*Func*/, nullptr /*DLoc*/,
-                                  Msg, severity));
+  Ctx.diagnose(DiagnosticInfoDxil(nullptr /*Func*/, Msg, severity));
 }
 
 void EmitErrorOnContext(LLVMContext &Ctx, Twine Msg) {

--- a/lib/IR/DiagnosticInfo.cpp
+++ b/lib/IR/DiagnosticInfo.cpp
@@ -231,14 +231,35 @@ void llvm::emitLoopInterleaveWarning(LLVMContext &Ctx, const Function &Fn,
 }
 
 // HLSL Change start - Dxil Diagnostic Info reporter
+DiagnosticInfoDxil::DiagnosticInfoDxil(const Function *F, const DILocation *Loc, const Twine &MsgStr,
+                                       DiagnosticSeverity Severity)
+  : DiagnosticInfoDxil(F, MsgStr, Severity)
+{
+  if (Loc) {
+    HasLocation = true;
+    FileName = Loc->getFilename();
+    Line     = Loc->getLine();
+    Column   = Loc->getColumn();
+  }
+}
+
+DiagnosticInfoDxil::DiagnosticInfoDxil(const Function *F, const DIGlobalVariable *DGV, const Twine &MsgStr,
+                   DiagnosticSeverity Severity)
+  : DiagnosticInfoDxil(F, MsgStr, Severity)
+{
+  if (DGV) {
+    HasLocation = true;
+    FileName = DGV->getFilename();
+    Line     = DGV->getLine();
+    Column   = 0;
+  }
+}
 
 // Slapdash printing of diagnostic information as a last resort
 // Used by validation and linker errors. Doesn't include source snippets.
 void DiagnosticInfoDxil::print(DiagnosticPrinter &DP) const {
-  if (DLoc) {
-    DIScope *scope = cast<DIScope>(DLoc->getRawScope());
-    DP << scope->getFilename() << ":" << DLoc->getLine() << ":";
-    unsigned Column = DLoc->getColumn();
+  if (HasLocation) {
+    DP << FileName << ":" << Line << ":";
     if (Column > 0)
       DP << Column << ":";
     DP << " ";

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -541,14 +541,13 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
   SourceManager &SourceMgr = Context->getSourceManager();
   SourceLocation DILoc;
   std::string Message = D.getMsgStr().str();
-  const DILocation *DLoc = D.getLocation();
 
   // Convert Filename/Line/Column triplet into SourceLocation
-  if (DLoc) {
+  if (D.hasLocation()) {
     FileManager &FileMgr = SourceMgr.getFileManager();
-    StringRef Filename = DLoc->getFilename();
-    unsigned Line = DLoc->getLine();
-    unsigned Column = DLoc->getColumn();
+    StringRef Filename = D.getFileName();
+    unsigned Line = D.getLine();
+    unsigned Column = D.getColumn();
     const FileEntry *FE = FileMgr.getFile(Filename);
     if (FE && Line > 0) {
       DILoc = SourceMgr.translateFileLineCol(FE, Line, Column ? Column : 1);

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/resource_conflict.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/resource_conflict.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -E main -T ps_6_0 %s -Zi | FileCheck %s
+
+// CHECK: error: resource b at register 5 overlaps with resource a at register 5
+// CHECK-NOT: Internal Compiler error
+
+Texture2D a : register(t5);
+Texture2D b : register(t5);
+SamplerState s : register(s0);
+
+float4 main(float2 uv : TEXCOORD) : SV_Target {
+    return a.Sample(s, uv) + b.Sample(s, uv);
+}


### PR DESCRIPTION
`DILocation` can't actually point to any non-local scopes, so can't be used to represent location of a global variable. Must use `DIGlobalVariable` instead.

Changed `DiagnosticInfoDxil` to hold the actual location info instead of a pointer to a `DILocation`.