### PR TITLE
[NFC] Add additional helper methods for DXT::ResourceKind

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -336,9 +336,31 @@ namespace DXIL {
     NumEntries,
   };
 
+  /// Whether the resource kind is a texture. This does not include
+  /// FeedbackTextures.
   inline bool IsAnyTexture(DXIL::ResourceKind ResourceKind) {
     return DXIL::ResourceKind::Texture1D <= ResourceKind &&
            ResourceKind <= DXIL::ResourceKind::TextureCubeArray;
+  }
+
+  /// Whether the resource kind is an array of textures. This does not include
+  /// FeedbackTextures.
+  inline bool IsAnyArrayTexture(DXIL::ResourceKind ResourceKind) {
+    return DXIL::ResourceKind::Texture1DArray <= ResourceKind &&
+           ResourceKind <= DXIL::ResourceKind::TextureCubeArray;
+  }
+
+  /// Whether the resource kind is a Texture or FeedbackTexture with array
+  /// dimension.
+  inline bool IsArrayKind(DXIL::ResourceKind ResourceKind) {
+    return IsAnyArrayTexture(ResourceKind) ||
+           ResourceKind == DXIL::ResourceKind::FeedbackTexture2DArray;
+  }
+
+  /// Whether the resource kind is a TextureCube or TextureCubeArray.
+  inline bool IsAnyTextureCube(DXIL::ResourceKind ResourceKind) {
+    return DXIL::ResourceKind::TextureCube == ResourceKind || 
+           DXIL::ResourceKind::TextureCubeArray == ResourceKind;
   }
 
   inline bool IsStructuredBuffer(DXIL::ResourceKind ResourceKind) {
@@ -361,6 +383,7 @@ namespace DXIL {
     return ResourceKind == DXIL::ResourceKind::TBuffer;
   }
 
+  /// Whether the resource kind is a FeedbackTexture.
   inline bool IsFeedbackTexture(DXIL::ResourceKind ResourceKind) {
     return ResourceKind == DXIL::ResourceKind::FeedbackTexture2D ||
            ResourceKind == DXIL::ResourceKind::FeedbackTexture2DArray;

--- a/include/dxc/DXIL/DxilResource.h
+++ b/include/dxc/DXIL/DxilResource.h
@@ -29,8 +29,19 @@ public:
   static unsigned GetNumDimensionsForCalcLOD(Kind ResourceKind);
   /// Total number of offsets (in [-8,7]) necessary to access resource.
   static unsigned GetNumOffsets(Kind ResourceKind);
-  /// Whether the resource kind is texture.
+  /// Whether the resource kind is a texture. This does not include
+  /// FeedbackTextures.
   static bool IsAnyTexture(Kind ResourceKind);
+  /// Whether the resource kind is an array of textures. This does not include
+  /// FeedbackTextures.
+  static bool IsAnyArrayTexture(Kind ResourceKind);
+  /// Whether the resource kind is a TextureCube or TextureCubeArray.
+  static bool IsAnyTextureCube(Kind ResourceKind);
+  /// Whether the resource kind is a FeedbackTexture.
+  static bool IsFeedbackTexture(Kind ResourceKind);
+  /// Whether the resource kind is a Texture or FeedbackTexture kind with array
+  /// dimension.
+  static bool IsArrayKind(Kind ResourceKind);
 
   DxilResource();
 
@@ -68,6 +79,9 @@ public:
   bool IsRawBuffer() const;
   bool IsTBuffer() const;
   bool IsFeedbackTexture() const;
+  bool IsAnyArrayTexture() const;
+  bool IsAnyTextureCube() const;
+  bool IsArrayKind() const;
 
   bool HasAtomic64Use() const;
   void SetHasAtomic64Use(bool b);

--- a/lib/DXIL/DxilResource.cpp
+++ b/lib/DXIL/DxilResource.cpp
@@ -8,6 +8,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/DXIL/DxilResource.h"
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/Support/Global.h"
 #include "dxc/DXIL/DxilResourceBase.h"
 #include "llvm/IR/Constant.h"
@@ -134,8 +135,31 @@ bool DxilResource::IsAnyTexture() const {
 }
 
 bool DxilResource::IsAnyTexture(Kind ResourceKind) {
-  return Kind::Texture1D <= ResourceKind &&
-         ResourceKind <= Kind::TextureCubeArray;
+  return DXIL::IsAnyTexture(ResourceKind);
+}
+
+bool DxilResource::IsAnyArrayTexture() const {
+  return IsAnyArrayTexture(GetKind());
+}
+
+bool DxilResource::IsAnyArrayTexture(Kind ResourceKind) {
+  return DXIL::IsAnyArrayTexture(ResourceKind);
+}
+
+bool DxilResource::IsAnyTextureCube() const {
+  return IsAnyTextureCube(GetKind());
+}
+
+bool DxilResource::IsAnyTextureCube(Kind ResourceKind) {
+  return DXIL::IsAnyTextureCube(ResourceKind);
+}
+
+bool DxilResource::IsArrayKind() const {
+  return IsArrayKind(GetKind());
+}
+
+bool DxilResource::IsArrayKind(Kind ResourceKind) {
+  return DXIL::IsArrayKind(ResourceKind);
 }
 
 bool DxilResource::IsStructuredBuffer() const {
@@ -155,7 +179,11 @@ bool DxilResource::IsTBuffer() const {
 }
 
 bool DxilResource::IsFeedbackTexture() const {
-  return GetKind() == Kind::FeedbackTexture2D || GetKind() == Kind::FeedbackTexture2DArray;
+  return IsFeedbackTexture(GetKind());
+}
+
+bool DxilResource::IsFeedbackTexture(Kind ResourceKind) {
+  return DXIL::IsFeedbackTexture(ResourceKind);
 }
 
 bool DxilResource::HasAtomic64Use() const {

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -33,6 +33,7 @@ add_clang_library(clang-hlsl-tests SHARED
   CompilerTest.cpp
   DxilContainerTest.cpp
   DxilModuleTest.cpp
+  DxilResourceTests.cpp
   DXIsenseTest.cpp
   ExecutionTest.cpp
   ExtensionTest.cpp
@@ -66,6 +67,7 @@ set(HLSL_IGNORE_SOURCES
 add_clang_unittest(clang-hlsl-tests
   AllocatorTest.cpp
   DxilModuleTest.cpp
+  DxilResourceTests.cpp
   DXIsenseTest.cpp
   ExtensionTest.cpp
   FunctionTest.cpp

--- a/tools/clang/unittests/HLSL/DxilResourceTests.cpp
+++ b/tools/clang/unittests/HLSL/DxilResourceTests.cpp
@@ -1,0 +1,88 @@
+//===- unittests/DXIL/DxilResourceTests.cpp ----- Tests for DXIL Resource -===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "dxc/DXIL/DxilConstants.h"
+#include "dxc/DXIL/DxilResource.h"
+#include "dxc/Support/WinIncludes.h"
+
+#include "dxc/Test/HlslTestUtils.h"
+
+using namespace hlsl;
+using namespace hlsl::DXIL;
+
+#ifdef _WIN32
+class DxilResourceTest {
+#else
+class DxilResourceTest : public ::testing::Test {
+#endif
+public:
+  BEGIN_TEST_CLASS(DxilResourceTest)
+  TEST_CLASS_PROPERTY(L"Parallel", L"true")
+  TEST_METHOD_PROPERTY(L"Priority", L"0")
+  END_TEST_CLASS()
+
+  TEST_METHOD(KindChecks)
+};
+
+struct KindTestCase {
+  ResourceKind Kind;
+  bool IsTexture;
+  bool IsTextureArray;
+  bool IsTextureCube;
+  bool IsFeedbackTexture;
+  bool IsArray;
+};
+
+KindTestCase Kinds[] = {
+    {ResourceKind::Invalid, false, false, false, false, false},
+    {ResourceKind::Texture1D, true, false, false, false, false},
+    {ResourceKind::Texture2D, true, false, false, false, false},
+    {ResourceKind::Texture2DMS, true, false, false, false, false},
+    {ResourceKind::Texture3D, true, false, false, false, false},
+    {ResourceKind::TextureCube, true, false, true, false, false},
+    {ResourceKind::Texture1DArray, true, true, false, false, true},
+    {ResourceKind::Texture2DArray, true, true, false, false, true},
+    {ResourceKind::Texture2DMSArray, true, true, false, false, true},
+    {ResourceKind::TextureCubeArray, true, true, true, false, true},
+    {ResourceKind::TypedBuffer, false, false, false, false, false},
+    {ResourceKind::RawBuffer, false, false, false, false, false},
+    {ResourceKind::StructuredBuffer, false, false, false, false, false},
+    {ResourceKind::CBuffer, false, false, false, false, false},
+    {ResourceKind::Sampler, false, false, false, false, false},
+    {ResourceKind::TBuffer, false, false, false, false, false},
+    {ResourceKind::RTAccelerationStructure, false, false, false, false, false},
+    {ResourceKind::FeedbackTexture2D, false, false, false, true, false},
+    {ResourceKind::FeedbackTexture2DArray, false, false, false, true, true}};
+
+static_assert(sizeof(Kinds) / sizeof(KindTestCase) ==
+                  (int)ResourceKind::NumEntries,
+              "There is a missing resoure type in the test cases!");
+
+TEST_F(DxilResourceTest, KindChecks) {
+  for (int Idx = 0; Idx < (int)ResourceKind::NumEntries; ++Idx) {
+    EXPECT_EQ(IsAnyTexture(Kinds[Idx].Kind), Kinds[Idx].IsTexture);
+    EXPECT_EQ(IsAnyArrayTexture(Kinds[Idx].Kind), Kinds[Idx].IsTextureArray);
+    EXPECT_EQ(IsAnyTextureCube(Kinds[Idx].Kind), Kinds[Idx].IsTextureCube);
+    EXPECT_EQ(IsFeedbackTexture(Kinds[Idx].Kind), Kinds[Idx].IsFeedbackTexture);
+    EXPECT_EQ(IsArrayKind(Kinds[Idx].Kind), Kinds[Idx].IsArray);
+
+    // Also test the entries through the DxilResource class, these tests should
+    // be redundant, but historically DxilResource had its own implementations.
+    EXPECT_EQ(DxilResource::IsAnyTexture(Kinds[Idx].Kind),
+              Kinds[Idx].IsTexture);
+    EXPECT_EQ(DxilResource::IsAnyArrayTexture(Kinds[Idx].Kind),
+              Kinds[Idx].IsTextureArray);
+    EXPECT_EQ(DxilResource::IsAnyTextureCube(Kinds[Idx].Kind),
+              Kinds[Idx].IsTextureCube);
+    EXPECT_EQ(DxilResource::IsFeedbackTexture(Kinds[Idx].Kind),
+              Kinds[Idx].IsFeedbackTexture);
+    EXPECT_EQ(DxilResource::IsArrayKind(Kinds[Idx].Kind),
+              Kinds[Idx].IsArray);
+  }
+}


### PR DESCRIPTION
* Added `IsAnyTextureArray` and `IsAnyTextureCube` helper methods.
* Added test case for all non-trival `Is...(ResouceKind)` methods