### PR TITLE
Follow HLSL rule for shift ops during constant folding

### DIFF
--- a/lib/IR/ConstantFold.cpp
+++ b/lib/IR/ConstantFold.cpp
@@ -1142,15 +1142,24 @@ Constant *llvm::ConstantFoldBinaryInstruction(unsigned Opcode,
       case Instruction::Shl:
         if (C2V.ult(C1V.getBitWidth()))
           return ConstantInt::get(CI1->getContext(), C1V.shl(C2V));
-        return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Begins: Shift only uses bottom bitwidth-1 bits
+        return ConstantInt::get(CI1->getContext(), C1V.shl(C2V & APInt(C2V.getBitWidth(), (uint64_t)(C1V.getBitWidth() - 1))));
+        //return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Ends
       case Instruction::LShr:
         if (C2V.ult(C1V.getBitWidth()))
           return ConstantInt::get(CI1->getContext(), C1V.lshr(C2V));
-        return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Begins: Shift only uses bottom bitwidth-1 bits
+        return ConstantInt::get(CI1->getContext(), C1V.lshr(C2V & APInt(C2V.getBitWidth(), (uint64_t)(C1V.getBitWidth() - 1))));
+        //return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Ends
       case Instruction::AShr:
         if (C2V.ult(C1V.getBitWidth()))
           return ConstantInt::get(CI1->getContext(), C1V.ashr(C2V));
-        return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Begins: Shift only uses bottom bitwidth-1 bits
+        return ConstantInt::get(CI1->getContext(), C1V.ashr(C2V & APInt(C2V.getBitWidth(), (uint64_t)(C1V.getBitWidth() - 1))));
+        //return UndefValue::get(C1->getType()); // too big shift is undef
+        // HLSL Change Ends
       }
     }
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/shift-fold.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/shift-fold.hlsl
@@ -1,0 +1,40 @@
+// RUN: %dxc -E mainS -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E mainU -T vs_6_0 %s | FileCheck %s
+
+// The shift for hlsl only use the LSB 5 bits (0-31 range) of src1 for int/uint.
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 -8)
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 1, i32 16777215)
+
+// The shift for hlsl only use the LSB 6 bits (0-63 range) of src1 for int64_t/uint64_t.
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 2, i32 4)
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 3, i32 512)
+
+uint4 mainS(int4 i : INT, uint u : UINT) : OUT {
+  uint4 result = 0;
+
+// The shift for hlsl only use the LSB 5 bits (0-31 range) of src1 for int/uint.
+  result.x = 0xFFFFFFFFL << 35;
+  result.y = 0xFFFFFFFFL >> 40;
+
+// The shift for hlsl only use the LSB 6 bits (0-63 range) of src1 for int64_t/uint64_t.
+  uint64_t u64 = 1LL << 105; // = 1 << 40 = 1099511627776 (0x10000000000)
+  u64 += 16LL >> 66; // + 4 = (0x10000000004)
+  result.z = (uint)(u64 & 0xFFFFFFFF);
+  result.w = (uint)(u64 >> 32);
+  return result;
+}
+
+uint4 mainU(int4 i : INT, uint u : UINT) : OUT {
+  uint4 result = 0;
+
+// The shift for hlsl only use the LSB 5 bits (0-31 range) of src1 for int/uint.
+  result.x = 0xFFFFFFFFU << 35;
+  result.y = 0xFFFFFFFFU >> 40;
+
+// The shift for hlsl only use the LSB 6 bits (0-63 range) of src1 for int64_t/uint64_t.
+  uint64_t u64 = 1ULL << 105; // = 1 << 40 = 1099511627776 (0x10000000000)
+  u64 += 16ULL >> 66; // + 4 = (0x10000000004)
+  result.z = (uint)(u64 & 0xFFFFFFFF);
+  result.w = (uint)(u64 >> 32);
+  return result;
+}


### PR DESCRIPTION
- Shift operators (Shl, LShr, AShr) use (RHS & (bitwidth-1))
  (5 LSB for 32-bit operation, 6 LSB for 64-bit operation)