### PR TITLE
Always update end scope when structurize returns.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -23,6 +23,7 @@
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
+#include "llvm/Support/Debug.h"
 
 #include "CodeGenModule.h"
 #include "clang/Basic/LangOptions.h"
@@ -3394,6 +3395,45 @@ void ScopeInfo::LegalizeWholeReturnedScope() {
   }
 }
 
+void Scope::dump() {
+  auto &OS = llvm::dbgs();
+  switch (kind) {
+  case ScopeKind::IfScope:
+    OS << "If\n";
+    break;
+  case ScopeKind::LoopScope:
+    OS << "Loop\n";
+    break;
+  case ScopeKind::ReturnScope:
+    OS << "Return\n";
+    break;
+  case ScopeKind::SwitchScope:
+    OS << "Switch\n";
+    break;
+  case ScopeKind::FunctionScope:
+    OS << "Function\n";
+    break;
+  }
+  if (kind == ScopeKind::FunctionScope)
+    return;
+
+  OS << "parent:" << parentScopeIndex << "\n";
+  if (bWholeScopeReturned)
+    OS << "whole scope returned\n";
+  OS << "endBB:";
+  EndScopeBB->printAsOperand(OS);
+  OS << "\n";
+}
+
+void ScopeInfo::dump() {
+  auto &OS = llvm::dbgs();
+  for (int i = 0; i < scopes.size(); ++i) {
+    Scope &scope = scopes[i];
+    OS << "Scope:" << i << "\n";
+    scope.dump();
+  }
+}
+
 } // namespace CGHLSLMSHelper
 
 namespace {
@@ -3406,9 +3446,12 @@ void updateEndScope(
   DXASSERT(it != EndBBToScopeIndexMap.end(),
            "fail to find endScopeBB in EndBBToScopeIndexMap");
   SmallVector<unsigned, 2> &scopeList = it->second;
-  // Don't need to update when not share endBB with other scope.
-  if (scopeList.size() < 2)
-    return;
+  // Update even when not share endBB with other scope.
+  // The endBB might be used by nested returns like the return 1 in
+  //if (b == 77)
+  //  return 0;
+  //else if (b != 3)
+  //  return 1;
   for (unsigned i : scopeList) {
     Scope &S = ScopeInfo.GetScope(i);
     // Don't update return endBB, because that is the Block has return branch.

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -3427,7 +3427,7 @@ void Scope::dump() {
 
 void ScopeInfo::dump() {
   auto &OS = llvm::dbgs();
-  for (int i = 0; i < scopes.size(); ++i) {
+  for (unsigned i = 0; i < scopes.size(); ++i) {
     Scope &scope = scopes[i];
     OS << "Scope:" << i << "\n";
     scope.dump();

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -114,6 +114,7 @@ struct Scope {
  // Anything after it is unreachable.
  bool bWholeScopeReturned;
  unsigned parentScopeIndex;
+ void dump();
 };
 
 class ScopeInfo {
@@ -130,6 +131,7 @@ public:
   void LegalizeWholeReturnedScope();
   llvm::SmallVector<Scope, 16> &GetScopes() { return scopes; }
   bool CanSkipStructurize();
+  void dump();
 
 private:
   void AddScope(Scope::ScopeKind k, llvm::BasicBlock *endScopeBB);

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/if_ret_with_else_ret.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/if_ret_with_else_ret.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -E main -opt-enable structurize-returns -T ps_6_0 %s | FileCheck %s
+
+// Make sure the return value is 1.
+// CHECK:define void @main() {
+// CHECK:  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
+// CHECK-NEXT:ret void
+
+// This is for case
+//        if ( b == 0xFF )
+//        return 0 ;
+//        else if ( b  != 0 )
+//        return 1 ;
+// where the return 1 in else if need branch to new endif create for return 0, instead of old endif.
+
+static const
+uint data [8] = {2,1,2,1,2,1,2,1};
+float main(float a:A) : SV_Target {
+        uint b  = 0 ;
+        for ( uint i = 0 ; i < 8 ; i ++ )
+        {
+            b  |= data[i];
+        }
+
+        if ( b == 77 )
+        return 0 ;
+        else if ( b  != 0 )
+        return 1 ;
+
+        uint x = 2;
+        for ( uint i = 0 ; i < 8 ; i ++ )
+        {
+             x *= data[i];
+        }
+        if ( x == 32)
+        {
+            return 0 ;
+        }
+        return a;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/multi_ret_in_switch_not_whole_scope_ret.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/multi_ret_in_switch_not_whole_scope_ret.hlsl
@@ -1,0 +1,51 @@
+// RUN: %dxc -E main -opt-enable structurize-returns -T ps_6_0 %s | FileCheck %s
+
+// Make sure the return value is 9.
+// CHECK:define void @main() {
+// CHECK:  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 9.000000e+00)
+// CHECK-NEXT:ret void
+
+// This is for case
+//        if ( b == 0xFF )
+//        return 0 ;
+//        else if ( b  != 0 )
+//        return 1 ;
+// where the return 1 in else if need branch to new endif create for return 0, instead of old endif.
+
+static const
+uint data [8] = {2,1,2,1,2,1,2,1};
+float main(float a:A) : SV_Target {
+        uint b  = 0 ;
+        for ( uint i = 0 ; i < 8 ; i ++ )
+        {
+            b  |= data[i];
+        }
+
+switch (b) {
+  case 77:
+    return 3;
+  case 3:
+    return 9;
+  default:
+    return 12;
+  case 39:
+  case 0:
+    break;
+}
+
+        if ( b == 77 )
+        return 0 ;
+        else if ( b  != 0 )
+        return 1 ;
+
+        uint x = 2;
+        for ( uint i = 0 ; i < 8 ; i ++ )
+        {
+             x *= data[i];
+        }
+        if ( x == 32)
+        {
+            return 0 ;
+        }
+        return a;
+}


### PR DESCRIPTION
When structurize return like return 1 in
  if (b == 77)
    return 0;
  else if (b != 3)
    return 1;

the end scope of if (b == 77) should be updated to bReturned.Cmp.false

Final cfg should be the right one, left one is wrong cfg without the fix.
![cfg](https://user-images.githubusercontent.com/22380486/135166496-5e6458ce-08a0-45cf-b9be-66498859c643.png)
to