### PR TITLE
Enable -HV 2021

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -206,6 +206,8 @@ public:
   // Experimental option to enable short-circuiting operators
   bool EnableShortCircuit = false; // OPT_enable_short_circuit
 
+  bool EnableBitfields = false; // OPT_enable_bitfields
+
   // Optimization pass enables, disables and selects
   std::map<std::string, bool> DxcOptimizationToggles; // OPT_opt_enable & OPT_opt_disable
   std::map<std::string, std::string> DxcOptimizationSelects; // OPT_opt_select

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -252,7 +252,7 @@ def pack_optimized : Flag<["-", "/"], "pack-optimized">, Group<hlslcomp_Group>, 
 def pack_optimized_ : Flag<["-", "/"], "pack_optimized">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Optimize signature packing assuming identical signature provided for each connecting stage">;
 def hlsl_version : Separate<["-", "/"], "HV">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
-  HelpText<"HLSL version (2016, 2017, 2018). Default is 2018">;
+  HelpText<"HLSL version (2016, 2017, 2018, 2021). Default is 2018">;
 def no_warnings : Flag<["-", "/"], "no-warnings">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption]>,
   HelpText<"Suppress warnings">;
 def rootsig_define : Separate<["-", "/"], "rootsig-define">, Group<hlslcomp_Group>, Flags<[CoreOption]>,

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -288,9 +288,9 @@ def enable_lifetime_markers : Flag<["-", "/"], "enable-lifetime-markers">, Group
   HelpText<"Enable generation of lifetime markers">;
 def disable_lifetime_markers : Flag<["-", "/"], "disable-lifetime-markers">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Disable generation of lifetime markers where they would be otherwise (6.6+)">;
-def enable_templates: Flag<["-", "/"], "enable-templates">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def enable_templates: Flag<["-", "/"], "enable-templates">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Enable template support for HLSL.">;
-def enable_operator_overloading: Flag<["-", "/"], "enable-operator-overloading">, Group<hlslcomp_Group>, Flags<[CoreOption]>,
+def enable_operator_overloading: Flag<["-", "/"], "enable-operator-overloading">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Enable operator overloading support for HLSL.">;
 def strict_udt_casting: Flag<["-", "/"], "strict-udt-casting">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Require explicit casts between different structure types with compatible layouts.">;
@@ -460,6 +460,9 @@ def Qstrip_reflect_from_dxil : Flag<["-", "/"], "Qstrip_reflect_from_dxil">,
 
 def enable_short_circuit : Flag<["-", "/"], "enable-short-circuit">, Flags<[CoreOption, HelpHidden]>, Group<hlslcomp_Group>,
   HelpText<"Operators '&&', '||', and '?:' will short circuit, only accepting scalar inputs.  Use and(), or(), and select() intrinsics in place of non-short-circuiting vector operators.">;
+
+def enable_bitfields : Flag<["-", "/"], "enable-bitfields">, Flags<[CoreOption, HelpHidden]>, Group<hlslcomp_Group>,
+  HelpText<"Enables bitfields on struct members">;
 
 /*
 def shtemplate : JoinedOrSeparate<["-", "/"], "shtemplate">, MetaVarName<"<file>">, Group<hlslcomp_Group>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -521,7 +521,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       if (opts.EnableBitfields)
         errors << "/enable-bitfields is not supported with HLSL Version " << opts.HLSLVersion;
 
-        return 1;
+      return 1;
     }
   }
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -446,8 +446,15 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   } else {
     try {
       opts.HLSLVersion = std::stoul(std::string(ver));
-      if (opts.HLSLVersion < 2015 || opts.HLSLVersion > 2021) {
-        errors << "Unknown HLSL version: " << opts.HLSLVersion;
+      switch (opts.HLSLVersion) {
+      case 2015:
+      case 2016:
+      case 2017:
+      case 2018:
+      case 2021:
+        break;
+      default:
+        errors << "Unknown HLSL version: " << opts.HLSLVersion << ". Valid versions: 2016, 2017, 2018, 2021";
         return 1;
       }
     }

--- a/tools/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -194,6 +194,6 @@ def warn_target_unsupported_nanlegacy : Warning<
   InGroup<UnsupportedNan>;
 
 // HLSL Change Starts
-def err_hlsl_invalid_drv_for_operator_overloading : Error<"/enable-operator-overloading is not supported with HLSL Version '%0'">;
+def err_hlsl_invalid_drv_for_feature : Error<"%0 is not supported with HLSL Version '%1'">;
 // HLSL Change Ends
 }

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -163,6 +163,7 @@ public:
   bool StrictUDTCasting = false;
   bool EnablePayloadAccessQualifiers = false;
   bool EnableShortCircuit = false;
+  bool EnableBitfields = false;
   // HLSL Change Ends
 
   bool SPIRV = false;  // SPIRV Change

--- a/tools/clang/include/clang/Driver/Options.td
+++ b/tools/clang/include/clang/Driver/Options.td
@@ -685,7 +685,9 @@ def enable_templates: Flag<["-", "/"], "enable-templates">, Flags<[CoreOption, D
 def enable_operator_overloading: Flag<["-", "/"], "enable-operator-overloading">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Enable operator overloading support for HLSL.">; // HLSL Change
 def strict_udt_casting: Flag<["-", "/"], "strict-udt-casting">, Flags<[CoreOption, DriverOption, HelpHidden]>,
-  HelpText<"Require explicit casts between different structure types with compatible layouts.">;
+  HelpText<"Require explicit casts between different structure types with compatible layouts.">; // HLSL Change
+def enable_bitfields : Flag<["-", "/"], "enable-bitfields">, Flags<[CoreOption, DriverOption, HelpHidden]>,
+  HelpText<"Enables bitfields on struct members">; // HLSL Change
 def fms_compatibility_version
     : Joined<["-"], "fms-compatibility-version=">,
       Group<f_Group>,

--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1747,20 +1747,37 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   // Enable low precision for HLSL 2018
   // TODO: should we tie low precision to HLSL2018 only?
   Opts.UseMinPrecision = !Args.hasArg(options::OPT_enable_16bit_types);
-  // Enable template support for HLSL
-  Opts.EnableTemplates = Args.hasArg(options::OPT_enable_templates);
 
-  // Enable operator overloading support for HLSL
-  // If the HLSL version is 2021, allow the operator overloading by default.
-  // If the HLSL version is 2016 or 2018, allow the operator overloading only
-  // when -enable-operator-overloading option is enabled.
-  // If the HLSL version is 2015, do not allow the operator overloading.
-  Opts.EnableOperatorOverloading =
-      Opts.HLSLVersion >= 2021 ||
-      Args.hasArg(options::OPT_enable_operator_overloading);
-  Opts.StrictUDTCasting = Args.hasArg(options::OPT_strict_udt_casting);
-  if (Opts.HLSLVersion <= 2015 && Opts.EnableOperatorOverloading) {
-    Diags.Report(diag::err_hlsl_invalid_drv_for_operator_overloading) << ver;
+  // If the HLSL version is 2021, allow the 2021 features by default.
+  // If the HLSL version is 2016 or 2018, allow them only
+  // when the individual option is enabled.
+  // If the HLSL version is 2015, dissallow these features
+  if (Opts.HLSLVersion >= 2021) {
+    // Enable operator overloading in structs
+    Opts.EnableOperatorOverloading = true;
+    // Enable template support
+    Opts.EnableTemplates = true;
+    // Determine overload matching based on UDT names, not just types
+    Opts.StrictUDTCasting = true;
+    // Enable bitfield support
+    Opts.EnableBitfields = true;
+
+  } else {
+    Opts.EnableOperatorOverloading = Args.hasArg(OPT_enable_operator_overloading);
+    Opts.EnableTemplates = Args.hasArg(OPT_enable_templates);
+    Opts.StrictUDTCasting = Args.hasArg(OPT_strict_udt_casting);
+    Opts.EnableBitfields = Args.hasArg(OPT_enable_bitfields);
+
+    if (Opts.HLSLVersion <= 2015) {
+      if (Opts.EnableOperatorOverloading)
+        Diags.Report(diag::err_hlsl_invalid_drv_for_feature) << "/enable-operator-overloading" << ver;
+      if (Opts.EnableTemplates)
+        Diags.Report(diag::err_hlsl_invalid_drv_for_feature) << "/enable-templates" << ver;
+      if (Opts.StrictUDTCasting)
+        Diags.Report(diag::err_hlsl_invalid_drv_for_feature) << "/enable-udt-casting" << ver;
+      if (Opts.EnableBitfields)
+        Diags.Report(diag::err_hlsl_invalid_drv_for_feature) << "/enable-bitfields" << ver;
+    }
   }
 #endif // #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12853,8 +12853,8 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC, Expr *BitWidth,
 #endif // ENABLE_SPIRV_CODEGEN
   // SPIRV change ends
 
-  // Disallow bitfields
-  if (BitWidth && getLangOpts().HLSLVersion <= 2015) {
+  // Disallow bitfields where not enabled explicitly or by HV
+  if (BitWidth && !getLangOpts().EnableBitfields) {
     Diag(BitWidth->getExprLoc(), diag::err_hlsl_bitfields);
     result = false;
   }

--- a/tools/clang/test/HLSL/bitfields.hlsl
+++ b/tools/clang/test/HLSL/bitfields.hlsl
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -enable-bitfields -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -HV 2021 -fsyntax-only -ffreestanding -verify %s
 
 typedef int T : 1; /* expected-error {{expected unqualified-id}} expected-error {{expected ';' after top level declarator}} */
 static int sb : 1; /* expected-error {{expected unqualified-id}} expected-error {{expected ';' after top level declarator}} */

--- a/tools/clang/test/HLSL/overloading-new-delete-errors.hlsl
+++ b/tools/clang/test/HLSL/overloading-new-delete-errors.hlsl
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -verify -enable-operator-overloading %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -verify -HV 2021 %s
 
 // This test checks that when we overload new or delete operator
 // dxcompiler generates error and no crashes are observed.

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: switch
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.assign.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.assign.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-operator-overloading %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: [[pos_y:%[^ ]+]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1, i32 undef)
 // CHECK: [[b:%[^ ]+]] = fptosi float [[pos_y]] to i32

--- a/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.call.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.call.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-operator-overloading %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: define void @main()
 // CHECK: %[[pos:[^ ]+]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 undef)

--- a/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.star.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operator_overloading/operator.overloading.star.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-operator-overloading %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: [[pos_x:%[^ ]+]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 0, i32 undef)
 // CHECK: [[pos_y:%[^ ]+]] = call float @dx.op.loadInput.f32(i32 4, i32 0, i32 0, i8 1, i32 undef)

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/AddMulOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/AddMulOps.hlsl
@@ -1,6 +1,9 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 %s -enable-templates -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s /Zi | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -HV 2021 -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s /Zi | FileCheck %s
 
 template<typename T>
 T test_add(T t0, T t1) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/AnyAll.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/AnyAll.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 
 
 // pass - bool, int, float, vector, matrix

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/AssignmentOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/AssignmentOps.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 %s -enable-templates -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -HV 2021 -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 
 template<typename T0, typename T1>
 void assign(inout T0 t0, T1 t1) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/BitwiseAssignOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/BitwiseAssignOps.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s 2>&1 | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s 2>&1 | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 
 // Check that HLSL bitwise assignment operators deal with dependent types
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/BooleanMathOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/BooleanMathOps.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 -DNOVEC %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 
 
 template<typename T>
@@ -38,7 +40,7 @@ void main() : SV_Target {
   // DIAG: deduced conflicting types for parameter
   ternary_or(bb, sa);
   // DIAG: function cannot return array type
-  ternary_or(iarra, iarra);
+  ternary_or(iarra, iarrb);
 
   // DIAG: error: scalar, vector, or matrix expected
   ternary_and(sa, sb);
@@ -51,16 +53,19 @@ void main() : SV_Target {
 // CHECK: define void @main
 
   ternary_and(ba, bb);
-  ternary_and(b3a, b3b);
-  ternary_and(b4x4a, b4x4b);
   ternary_and(ia, ib);
-  ternary_and(i3a, i3b);
   ternary_and(ua, ub);
-  ternary_and(u4a, u4b);
   ternary_and(fa, fb);
   ternary_and(int(fa), ib);
   ternary_or(iarra[2], iarra[4]);
+
+#ifndef NOVEC
+  ternary_and(b3a, b3b);
+  ternary_and(b4x4a, b4x4b);
+  ternary_and(i3a, i3b);
+  ternary_and(u4a, u4b);
   ternary_and(sa.a, sb.b);
+#endif
 
 #endif
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/ComparisonOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/ComparisonOps.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s -DCHECK_DIAGNOSTICS | FileCheck %s -check-prefix=DIAG
 
 
 template<typename T0, typename T1>

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/PrefixPostfixOps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/PrefixPostfixOps.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 %s -enable-templates -DCHECK_DIAGNOSTICS | FileCheck -check-prefix=DIAG %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -HV 2021 -DCHECK_DIAGNOSTICS | FileCheck -check-prefix=DIAG %s
 
 template<typename T>
 T preinc(T t0) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/RandomGenerators.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/RandomGenerators.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x404FD93640000000)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x4047269780000000)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x4045A83E40000000)

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/ackermann.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/ackermann.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 125)
 
 // template<unsigned M, unsigned N>

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/dependent-sized_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/dependent-sized_array.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: error: 'a3' declared as an array with a negative size
 
 template<int N>

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/elaborated-type-specifier.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/elaborated-type-specifier.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T ps_6_0 -enable-templates %s 2>&1| FileCheck %s
+// RUN: %dxc -T ps_6_0 -HV 2021 %s 2>&1| FileCheck %s
 // CHECK: error: use of 'X' with tag type that does not match previous declaration
 // CHECK: note: in instantiation of template class 'PR6915::D<PR6915::D2>' requested here
 // CHECK: note: previous use is here

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/enum-forward.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/enum-forward.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: error: ISO C++ forbids forward references to 'enum' types
 
 template<typename T>

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/factorial.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/factorial.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
 
 template<uint n>

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/missing_typename.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/missing_typename.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -T vs_6_0 -E VSMain -enable-templates -DTYPENAME= %s | FileCheck %s -check-prefix=MISSING
 // RUN: %dxc -T vs_6_0 -E VSMain -enable-templates -DTYPENAME=typename %s | FileCheck %s -check-prefix=PRESENT
+// RUN: %dxc -T vs_6_0 -E VSMain -HV 2021 -DTYPENAME= %s | FileCheck %s -check-prefix=MISSING
+// RUN: %dxc -T vs_6_0 -E VSMain -HV 2021 -DTYPENAME=typename %s | FileCheck %s -check-prefix=PRESENT
 
 // MISSING: error: missing 'typename' prior to dependent type name 'TVec::value_type'
 // PRESENT: define void @VSMain() {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-1.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -E main -T ps_6_0 -strict-udt-casting %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -enable-templates -D USE_TEMPLATE %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 -D USE_TEMPLATE %s | FileCheck %s
 
 // Based on GitHub issue #3563
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/strict-udt-casting-2.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // Based on GitHub issue #3564
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateFunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateFunc.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateMethod.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateMethod.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateStruct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateStruct.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc2.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateTypename.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateTypename.hlsl
@@ -1,5 +1,7 @@
 // RUN: %dxc -DTEMPLATE= -T ps_6_0 -enable-templates %s | FileCheck %s -check-prefix=CHK_FAIL
 // RUN: %dxc -DTEMPLATE=template -T ps_6_0 -enable-templates %s | FileCheck %s -check-prefix=CHK_PASS
+// RUN: %dxc -DTEMPLATE= -T ps_6_0 -HV 2021 %s | FileCheck %s -check-prefix=CHK_FAIL
+// RUN: %dxc -DTEMPLATE=template -T ps_6_0 -HV 2021 %s | FileCheck %s -check-prefix=CHK_PASS
 
 // CHK_PASS:define void @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/variadic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/variadic.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // CHECK: error: variadic templates are not supported in HLSL
 
 template<typename T>

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: SV_RenderTargetArrayIndex or SV_ViewportArrayIndex from any shader feeding rasterizer
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc /Tvs_6_0 /Emain -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc /Tvs_6_0 /Emain -HV 2021 %s | FileCheck %s
 // Test explicit cast between structs of identical layout where
 // the destination struct is marked as out param.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
 // github issue #1725
 // Test implicit cast scenario between structs of identical layout
 // which would crash as reported by a user.

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc /Tgs_6_0 /Emain -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc /Tgs_6_0 /Emain -HV 2021 %s | FileCheck %s
 // github issue #1560
 
 // CHECK: main

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2021 %s | FileCheck %s
 
 // Tests declarations and uses of anonymous structs.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/bitfields.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/bitfields.hlsl
@@ -1,4 +1,5 @@
-// RUN: %dxc /Zi /T vs_6_2 /E main %s | FileCheck %s
+// RUN: %dxc /Zi /enable-bitfields /T vs_6_2 /E main %s | FileCheck %s
+// RUN: %dxc /Zi /HV 2021 /T vs_6_2 /E main %s | FileCheck %s
 
 RWByteAddressBuffer BufferOut : register(u0);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T vs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2021 %s | FileCheck %s
 
 // CHECK: @main
 struct Vertex

--- a/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_split_regression-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/sroa_hlsl/memcpy_split_regression-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 -Od -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -Od -HV 2021 %s | FileCheck %s
 
 //
 // CHECK: @main

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T gs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T gs_6_0 -HV 2021 %s | FileCheck %s
 
 // Regression test for an SROA bug where the flattening the output stream argument
 // would not handle the case where its input had already been SROA'd.

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -E main -T gs_6_0 -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -E main -T gs_6_0 -HV 2021 %s | FileCheck %s
 
 // Regression test for an SROA bug where the flattening the output stream argument
 // would not handle the case where its input had already been SROA'd.

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch-strictudt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch-strictudt.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_x -default-linkage external -strict-udt-casting %s | FileCheck %s
+// RUN: %dxc -T lib_6_x -default-linkage external -HV 2021 %s | FileCheck %s
 
 // CHECK: define <4 x float>
 // CHECK-SAME: main

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1353,6 +1353,7 @@ public:
 
     compiler.getLangOpts().EnablePayloadAccessQualifiers = Opts.EnablePayloadQualifiers;
     compiler.getLangOpts().EnableShortCircuit = Opts.EnableShortCircuit;
+    compiler.getLangOpts().EnableBitfields = Opts.EnableBitfields;
 
 // SPIRV change starts
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -179,7 +179,7 @@ public:
   TEST_METHOD(CompileHlsl2016ThenOK)
   TEST_METHOD(CompileHlsl2017ThenOK)
   TEST_METHOD(CompileHlsl2018ThenOK)
-  TEST_METHOD(CompileHlsl2019ThenFail)
+  TEST_METHOD(CompileHlsl2022ThenFail)
 
   TEST_METHOD(CodeGenFloatingPointEnvironment)
   TEST_METHOD(CodeGenInclude)
@@ -3064,7 +3064,7 @@ TEST_F(CompilerTest, CompileHlsl2018ThenOK) {
   VERIFY_SUCCEEDED(status);
 }
 
-TEST_F(CompilerTest, CompileHlsl2019ThenFail) {
+TEST_F(CompilerTest, CompileHlsl2022ThenFail) {
   CComPtr<IDxcCompiler> pCompiler;
   CComPtr<IDxcOperationResult> pResult;
   CComPtr<IDxcBlobEncoding> pSource;
@@ -3073,7 +3073,7 @@ TEST_F(CompilerTest, CompileHlsl2019ThenFail) {
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
   CreateBlobFromText("float4 main(float4 pos : SV_Position) : SV_Target { return pos; }", &pSource);
 
-  LPCWSTR args[2] = { L"-HV", L"2019" };
+  LPCWSTR args[2] = { L"-HV", L"2022" };
 
   VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
     L"ps_6_0", args, 2, nullptr, 0, nullptr, &pResult));

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -179,6 +179,9 @@ public:
   TEST_METHOD(CompileHlsl2016ThenOK)
   TEST_METHOD(CompileHlsl2017ThenOK)
   TEST_METHOD(CompileHlsl2018ThenOK)
+  TEST_METHOD(CompileHlsl2019ThenFail)
+  TEST_METHOD(CompileHlsl2020ThenFail)
+  TEST_METHOD(CompileHlsl2021ThenOK)
   TEST_METHOD(CompileHlsl2022ThenFail)
 
   TEST_METHOD(CodeGenFloatingPointEnvironment)
@@ -3055,6 +3058,69 @@ TEST_F(CompilerTest, CompileHlsl2018ThenOK) {
   CreateBlobFromText("float4 main(float4 pos : SV_Position) : SV_Target { return pos; }", &pSource);
 
   LPCWSTR args[2] = { L"-HV", L"2018" };
+
+  VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
+    L"ps_6_0", args, 2, nullptr, 0, nullptr, &pResult));
+
+  HRESULT status;
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_SUCCEEDED(status);
+}
+
+TEST_F(CompilerTest, CompileHlsl2019ThenFail) {
+  CComPtr<IDxcCompiler> pCompiler;
+  CComPtr<IDxcOperationResult> pResult;
+  CComPtr<IDxcBlobEncoding> pSource;
+  CComPtr<IDxcBlobEncoding> pErrors;
+
+  VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
+  CreateBlobFromText("float4 main(float4 pos : SV_Position) : SV_Target { return pos; }", &pSource);
+
+  LPCWSTR args[2] = { L"-HV", L"2019" };
+
+  VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
+    L"ps_6_0", args, 2, nullptr, 0, nullptr, &pResult));
+
+  HRESULT status;
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_ARE_EQUAL(status, E_INVALIDARG);
+  VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrors));
+  LPCSTR pErrorMsg = "Unknown HLSL version";
+  CheckOperationResultMsgs(pResult, &pErrorMsg, 1, false, false);
+}
+
+TEST_F(CompilerTest, CompileHlsl2020ThenFail) {
+  CComPtr<IDxcCompiler> pCompiler;
+  CComPtr<IDxcOperationResult> pResult;
+  CComPtr<IDxcBlobEncoding> pSource;
+  CComPtr<IDxcBlobEncoding> pErrors;
+
+  VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
+  CreateBlobFromText("float4 main(float4 pos : SV_Position) : SV_Target { return pos; }", &pSource);
+
+  LPCWSTR args[2] = { L"-HV", L"2020" };
+
+  VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
+    L"ps_6_0", args, 2, nullptr, 0, nullptr, &pResult));
+
+  HRESULT status;
+  VERIFY_SUCCEEDED(pResult->GetStatus(&status));
+  VERIFY_ARE_EQUAL(status, E_INVALIDARG);
+  VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrors));
+  LPCSTR pErrorMsg = "Unknown HLSL version";
+  CheckOperationResultMsgs(pResult, &pErrorMsg, 1, false, false);
+}
+
+TEST_F(CompilerTest, CompileHlsl2021ThenOK) {
+  CComPtr<IDxcCompiler> pCompiler;
+  CComPtr<IDxcOperationResult> pResult;
+  CComPtr<IDxcBlobEncoding> pSource;
+  CComPtr<IDxcBlobEncoding> pErrors;
+
+  VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
+  CreateBlobFromText("float4 main(float4 pos : SV_Position) : SV_Target { return pos; }", &pSource);
+
+  LPCWSTR args[2] = { L"-HV", L"2021" };
 
   VERIFY_SUCCEEDED(pCompiler->Compile(pSource, L"source.hlsl", L"main",
     L"ps_6_0", args, 2, nullptr, 0, nullptr, &pResult));


### PR DESCRIPTION
Enables the associated feature flags when 2021 is selected. Also adds a
feature flag for bitfields.

Add to all feature tests a variant that uses -HV 2021

Made some small changes to a template test that relied on vector
operands with binary logical operators