### PR TITLE
Consistent order gradient ops warnings.

### DIFF
--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -1456,7 +1456,7 @@ public:
       if (F.isDeclaration())
         continue;
 
-      DenseSet<Instruction *> localGradientArgs;
+      SetVector<Instruction *> localGradientArgs;
       for (CallInst *CI : gradientOps) {
         if (CI->getParent()->getParent() == &F) {
           for (Value *V : CI->arg_operands()) {

--- a/tools/clang/test/CodeGenHLSL/val-wave-failures-ps.hlsl
+++ b/tools/clang/test/CodeGenHLSL/val-wave-failures-ps.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input=stderr %s
 
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 37:7: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 30:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 9:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
 
 float4 main(float4 p: SV_Position) : SV_Target {
   // cannot feed into ddx

--- a/tools/clang/test/DXILValidation/val-wave-failures-ps.hlsl
+++ b/tools/clang/test/DXILValidation/val-wave-failures-ps.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
 
-// CHECK: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 37:7: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 30:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 9:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
 
 float4 main(float4 p: SV_Position) : SV_Target {
   // cannot feed into ddx

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveSensitivityAndCycles.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveSensitivityAndCycles.hlsl
@@ -1,8 +1,9 @@
 // RUN: %dxc -T lib_6_3 %s | FileCheck %s -input=stderr
 
-// CHECK: warning: Gradient operations are not affected by wave-sensitive data or control flow
-// CHECK: warning: Gradient operations are not affected by wave-sensitive data or control flow
-// CHECK: warning: Gradient operations are not affected by wave-sensitive data or control flow
+// CHECK: 18:19: warning: Gradient operations are not affected by wave-sensitive data or control flow
+// CHECK: 37:19: warning: Gradient operations are not affected by wave-sensitive data or control flow
+// CHECK: 49:12: warning: Gradient operations are not affected by wave-sensitive data or control flow
+// CHECK: 50:12: warning: Gradient operations are not affected by wave-sensitive data or control flow
 
 export
 float main1(float dep : DEPTH) : SV_TARGET {

--- a/tools/clang/test/HLSLFileCheck/validation/val-wave-failures-ps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/val-wave-failures-ps.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input=stderr %s
 
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
-// CHECK:warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 37:7: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 30:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
+// CHECK: 9:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.
 
 float4 main(float4 p: SV_Position) : SV_Target {
   // cannot feed into ddx


### PR DESCRIPTION
To fix gradient ops warnings generating in non-deterministic order. Added order checking to existing gradient ops warnings tests.