### PR TITLE
[NFC] Silence a few new clang warnings

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -330,8 +330,8 @@ PCSTR g_pFeatureInfoNames[] = {
     "PS Inner Coverage",
     "Typed UAV Load Additional Formats",
     "Raster Ordered UAVs",
-    "SV_RenderTargetArrayIndex or SV_ViewportArrayIndex from any shader "
-    "feeding rasterizer",
+    ("SV_RenderTargetArrayIndex or SV_ViewportArrayIndex from any shader "
+    "feeding rasterizer"),
     "Wave level operations",
     "64-Bit integer",
     "View Instancing",

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -198,7 +198,7 @@ TEST_F(OptionsTest, ReadOptionsWhenInvalidThenFail) {
   const wchar_t *ArgsNoArg[] = {L"exe.exe", L"hlsl.hlsl", L"/E", L"main",
                                 L"/T"};
   const wchar_t *ArgsUnknown[] = { L"exe.exe", L"hlsl.hlsl", L"/E", L"main",
-    L"/T" L"ps_6_0", L"--unknown"};
+    (L"/T" L"ps_6_0"), L"--unknown"};
   const wchar_t *ArgsUnknownButIgnore[] = { L"exe.exe", L"hlsl.hlsl", L"/E", L"main",
     L"/T", L"ps_6_0", L"--unknown", L"-Qunused-arguments" };
   MainArgsArr ArgsNoTargetArr(ArgsNoTarget),


### PR DESCRIPTION
Clang has added new warnings for possible unintended string
concatenations. When concatonating strings in an array literal warpping
the concatenation in parentesis quiets the warning.