### PR TITLE
Remove unintended LLVM function attributes

### DIFF
--- a/tools/clang/lib/CodeGen/CGCall.cpp
+++ b/tools/clang/lib/CodeGen/CGCall.cpp
@@ -1479,7 +1479,7 @@ void CodeGenModule::ConstructAttributeList(const CGFunctionInfo &FI,
       FuncAttrs.addAttribute(llvm::Attribute::NoBuiltin);
     if (!CodeGenOpts.TrapFuncName.empty())
       FuncAttrs.addAttribute("trap-func-name", CodeGenOpts.TrapFuncName);
-  } else {
+  } else if (!getLangOpts().HLSL) {
     // Attributes that should go on the function, but not the call site.
     if (!CodeGenOpts.DisableFPElim) {
       FuncAttrs.addAttribute("no-frame-pointer-elim", "false");

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/fn_attr_experimental.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/fn_attr_experimental.hlsl
@@ -6,7 +6,7 @@
 // CHECK: #0
 // CHECK: attributes #0
 // CHECK: "exp-foo"="bar"
-// CHECK: "exp-zzz" "
+// CHECK: "exp-zzz"
 
 [experimental("foo", "bar")]
 [experimental("zzz", "")]

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten3.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure function call on external function has correct type.
 
-// CHECK: call float @"\01?test_extern@@YAMUT@@@Z"(%struct.T* nonnull {{.*}}) #2
+// CHECK: call float @"\01?test_extern@@YAMUT@@@Z"(%struct.T* nonnull {{.*}})
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_vanilla_fn_attributes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_vanilla_fn_attributes.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+
+// Make sure a bunch of vanilla function attributes are not added to the functions which are not inlined. 
+
+// CHECK-NOT: "disable-tail-calls"="false"
+// CHECK-NOT: "less-precise-fpmad"="false"
+// CHECK-NOT: "no-frame-pointer-elim"="false"
+// CHECK-NOT: "no-infs-fp-math"="false" 
+// CHECK-NOT: "no-nans-fp-math"="false" 
+// CHECK-NOT: "no-realign-stack" 
+// CHECK-NOT: "stack-protector-buffer-size"="0" 
+// CHECK-NOT: "unsafe-fp-math"="false" 
+// CHECK-NOT: "use-soft-float"="false"
+
+export float foo(float a) {
+    return a*a;
+}


### PR DESCRIPTION
This PR filters out a list of below LLVM function attributes which would get (unintentionally) added to export functions. These function attributes are not supported in the current DXIL specification and shouldn't impact functionality.

- `disable-tail-calls`
- `less-precise-fpmad`
- `no-frame-pointer-elim`
- `no-infs-fp-math`
- `no-nans-fp-math`
- `no-realign-stack `
- `stack-protector-buffer-size`
- `unsafe-fp-math`
- `use-soft-float`