### PR TITLE
Enable building llvm-dis

### DIFF
--- a/include/llvm/Support/MSFileSystem.h
+++ b/include/llvm/Support/MSFileSystem.h
@@ -12,8 +12,6 @@
 #ifndef LLVM_SUPPORT_MSFILESYSTEM_H
 #define LLVM_SUPPORT_MSFILESYSTEM_H
 
-#include "dxc/Support/WinIncludes.h"
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // MSFileSystem interface.
 struct stat;

--- a/tools/llvm-dis/llvm-dis.cpp
+++ b/tools/llvm-dis/llvm-dis.cpp
@@ -133,7 +133,7 @@ static void diagnosticHandler(const DiagnosticInfo &DI, void *Context) {
 }
 
 // HLSL Change Starts
-#define NOMINMAX
+#include "dxc/Support/WinIncludes.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
 // HLSL Change Ends


### PR DESCRIPTION
llvm-dis is a lightweight tool for reading IR modules as bitcode and
dumping them as textual IR. It is useful for debugging and verification
of bitcode-related issues.

This patch just re-enables the llvm-dis build and updates the code to
build cleanly on *nix systems.