### PR TITLE
[spirv] Add support for NonSemantic.Shader.DebugInfo.100 generation

### DIFF
--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -43,6 +43,9 @@ struct SpirvCodeGenOptions {
   bool debugInfoSource;
   bool debugInfoTool;
   bool debugInfoRich;
+  /// Use NonSemantic.Vulkan.DebugInfo.100 debug info instead of
+  /// OpenCL.DebugInfo.100
+  bool debugInfoVulkan;
   bool defaultRowMajor;
   bool disableValidation;
   bool enable16BitTypes;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -936,6 +936,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.debugInfoFile = opts.SpirvOptions.debugInfoSource = false;
   opts.SpirvOptions.debugInfoLine = opts.SpirvOptions.debugInfoTool = false;
   opts.SpirvOptions.debugInfoRich = false;
+  opts.SpirvOptions.debugInfoVulkan = false;
   if (Args.hasArg(OPT_fspv_debug_EQ)) {
     opts.DebugInfo = true;
     for (const Arg *A : Args.filtered(OPT_fspv_debug_EQ)) {
@@ -961,6 +962,18 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
         opts.SpirvOptions.debugInfoSource = true;
         opts.SpirvOptions.debugInfoLine = true;
         opts.SpirvOptions.debugInfoRich = true;
+      } else if (v == "vulkan") {
+        opts.SpirvOptions.debugInfoFile = true;
+        opts.SpirvOptions.debugInfoSource = false;
+        opts.SpirvOptions.debugInfoLine = true;
+        opts.SpirvOptions.debugInfoRich = true;
+        opts.SpirvOptions.debugInfoVulkan = true;
+      } else if (v == "vulkan-with-source") {
+        opts.SpirvOptions.debugInfoFile = true;
+        opts.SpirvOptions.debugInfoSource = true;
+        opts.SpirvOptions.debugInfoLine = true;
+        opts.SpirvOptions.debugInfoRich = true;
+        opts.SpirvOptions.debugInfoVulkan = true;
       } else {
         errors << "unknown SPIR-V debug info control parameter: " << v;
         return 1;

--- a/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBasicBlock.h
@@ -106,7 +106,13 @@ public:
   /// Handle SPIR-V basic block visitors.
   /// If a basic block is the first basic block in a function, it must include
   /// all the variable definitions of the entire function.
+  ///
+  /// For NonSemantic.Shader.DebugInfo.100 we also pass in the function scope
+  /// and function-level debug declares, since these can't appear outside of
+  /// basic blocks.
   bool invokeVisitor(Visitor *, llvm::ArrayRef<SpirvVariable *> vars,
+                     SpirvDebugScope *functionScope,
+                     llvm::ArrayRef<SpirvDebugDeclare *> debugDeclares,
                      bool reverseOrder = false);
 
   /// \brief Adds the given basic block as a successsor to this basic block.

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -104,7 +104,7 @@ public:
   /// for the basic block. On failure, returns zero.
   SpirvBasicBlock *createBasicBlock(llvm::StringRef name = "");
 
-  /// \brief Creates a SPIR-V DebugScope (OpenCL.DebugInfo.100 instruction).
+  /// \brief Creates a SPIR-V rich DebugInfo DebugScope instruction.
   /// On success, returns the <id> of DebugScope. On failure, returns nullptr.
   SpirvDebugScope *createDebugScope(SpirvDebugInstruction *scope);
 
@@ -495,6 +495,9 @@ public:
                       llvm::StringRef linkageName, uint32_t flags,
                       uint32_t scopeLine, SpirvFunction *fn);
 
+  SpirvDebugFunctionDefinition *
+  createDebugFunctionDef(SpirvDebugFunction *function, SpirvFunction *fn);
+
   /// \brief Create SPIR-V instructions for KHR RayQuery ops
   SpirvInstruction *
   createRayQueryOpsKHR(spv::Op opcode, QualType resultType,
@@ -554,9 +557,10 @@ public:
   void addModuleProcessed(llvm::StringRef process);
 
   /// \brief If not added already, adds an OpExtInstImport (import of extended
-  /// instruction set) of the OpenCL.DebugInfo.100 instruction set. Returns the
-  /// imported instruction set.
-  SpirvExtInstImport *getOpenCLDebugInfoExtInstSet();
+  /// instruction set) of the rich DebugInfo instruction set, either OpenCL or
+  /// Vulkan.
+  /// Returns the imported instruction set.
+  SpirvExtInstImport *getDebugInfoExtInstSet(bool vulkanDebugInfo);
 
   /// \brief Adds a stage input/ouput variable whose value is of the given type.
   ///

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -129,12 +129,14 @@ public:
     IK_VectorShuffle,             // OpVectorShuffle
     IK_SpirvIntrinsicInstruction, // Spirv Intrinsic Instructions
 
-    // For DebugInfo instructions defined in OpenCL.DebugInfo.100
+    // For DebugInfo instructions defined in
+    // OpenCL.DebugInfo.100 and NonSemantic.Shader.DebugInfo.100
     IK_DebugInfoNone,
     IK_DebugCompilationUnit,
     IK_DebugSource,
     IK_DebugFunctionDecl,
     IK_DebugFunction,
+    IK_DebugFunctionDef,
     IK_DebugLocalVariable,
     IK_DebugGlobalVariable,
     IK_DebugOperation,
@@ -2041,7 +2043,7 @@ private:
   SpirvExtInstImport *instructionSet;
 };
 
-/// \breif Base class for all OpenCL.DebugInfo.100 extension instructions.
+/// \brief Base class for all rich DebugInfo extension instructions.
 /// Note that all of these instructions should be added to the SPIR-V module as
 /// an OpExtInst instructions. So, all of these instructions must:
 /// 1) contain the result-id of the extended instruction set
@@ -2243,6 +2245,26 @@ private:
   clang::spirv::FunctionType *fnType;
 };
 
+class SpirvDebugFunctionDefinition : public SpirvDebugInstruction {
+public:
+  SpirvDebugFunctionDefinition(SpirvDebugFunction *function, SpirvFunction *fn);
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDebugFunctionDefinition)
+
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_DebugFunctionDef;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+
+  SpirvDebugFunction *getDebugFunction() const { return function; }
+  SpirvFunction *getFunction() const { return fn; }
+
+private:
+  SpirvDebugFunction *function;
+  SpirvFunction *fn;
+};
+
 class SpirvDebugLocalVariable : public SpirvDebugInstruction {
 public:
   SpirvDebugLocalVariable(QualType debugQualType, llvm::StringRef varName,
@@ -2424,8 +2446,8 @@ private:
   SpirvDebugInstruction *scope;
 };
 
-/// The following classes represent debug types defined in the
-/// OpenCL.DebugInfo.100 spec.
+/// The following classes represent debug types defined in the rich DebugInfo
+/// spec.
 ///
 /// Note: While debug type and SPIR-V type are very similar, they are not quite
 /// identical. For example: the debug type contains the HLL string name of the

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -196,7 +196,7 @@ private:
   // vector is not in any particular order, and may contain unused functions.
   llvm::SetVector<SpirvFunction *> allFunctions;
 
-  // Keep all OpenCL.DebugInfo.100 instructions.
+  // Keep all rich DebugInfo instructions.
   llvm::SmallVector<SpirvDebugInstruction *, 32> debugInstructions;
 };
 

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -120,6 +120,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvDebugCompilationUnit)
   DEFINE_VISIT_METHOD(SpirvDebugFunctionDeclaration)
   DEFINE_VISIT_METHOD(SpirvDebugFunction)
+  DEFINE_VISIT_METHOD(SpirvDebugFunctionDefinition)
   DEFINE_VISIT_METHOD(SpirvDebugLocalVariable)
   DEFINE_VISIT_METHOD(SpirvDebugGlobalVariable)
   DEFINE_VISIT_METHOD(SpirvDebugOperation)
@@ -142,11 +143,11 @@ public:
   DEFINE_VISIT_METHOD(SpirvIntrinsicInstruction)
 #undef DEFINE_VISIT_METHOD
 
+  const SpirvCodeGenOptions &getCodeGenOptions() const { return spvOptions; }
+
 protected:
   explicit Visitor(const SpirvCodeGenOptions &opts, SpirvContext &ctx)
       : spvOptions(opts), context(ctx) {}
-
-  const SpirvCodeGenOptions &getCodeGenOptions() const { return spvOptions; }
 
 protected:
   const SpirvCodeGenOptions &spvOptions;

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -595,9 +595,14 @@ bool CapabilityVisitor::visit(SpirvExecutionMode *execMode) {
 }
 
 bool CapabilityVisitor::visit(SpirvExtInstImport *instr) {
-  if (instr->getExtendedInstSetName() == "NonSemantic.DebugPrintf")
+  if (instr->getExtendedInstSetName() == "NonSemantic.DebugPrintf") {
     addExtension(Extension::KHR_non_semantic_info, "DebugPrintf",
                  /*SourceLocation*/ {});
+  } else if (instr->getExtendedInstSetName() ==
+             "NonSemantic.Shader.DebugInfo.100") {
+    addExtension(Extension::KHR_non_semantic_info, "Shader.DebugInfo.100",
+                 /*SourceLocation*/ {});
+  }
   return true;
 }
 

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -32,7 +32,8 @@ void addTemplateTypeAndItsParamsToModule(SpirvModule *module,
 void DebugTypeVisitor::setDefaultDebugInfo(SpirvDebugInstruction *instr) {
   instr->setAstResultType(astContext.VoidTy);
   instr->setResultType(context.getVoidType());
-  instr->setInstructionSet(spvBuilder.getOpenCLDebugInfoExtInstSet());
+  instr->setInstructionSet(
+      spvBuilder.getDebugInfoExtInstSet(spvOptions.debugInfoVulkan));
 }
 
 SpirvDebugInfoNone *DebugTypeVisitor::getDebugInfoNone() {

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.h
@@ -22,7 +22,7 @@ class SpirvBuilder;
 class LowerTypeVisitor;
 
 /// The class responsible to translate SPIR-V types into DebugType*
-/// types as defined in the OpenCL.DebugInfo.100 spec.
+/// types as defined in the rich DebugInfo spec.
 /// This visitor must be run after the LowerTypeVisitor pass.
 class DebugTypeVisitor : public Visitor {
 public:
@@ -85,7 +85,7 @@ private:
                          SpirvDebugTypeComposite *debugTypeComposite);
 
   /// Set the result type of debug instructions to OpTypeVoid.
-  /// According to the OpenCL.DebugInfo.100 spec, all debug instructions are
+  /// According to the rich DebugInfo spec, all debug instructions are
   /// OpExtInst with result type of void.
   void setDefaultDebugInfo(SpirvDebugInstruction *instr);
 

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -277,6 +277,7 @@ public:
   bool visit(SpirvDebugScope *) override;
   bool visit(SpirvDebugFunctionDeclaration *) override;
   bool visit(SpirvDebugFunction *) override;
+  bool visit(SpirvDebugFunctionDefinition *) override;
   bool visit(SpirvDebugLocalVariable *) override;
   bool visit(SpirvDebugDeclare *) override;
   bool visit(SpirvDebugGlobalVariable *) override;
@@ -314,6 +315,12 @@ private:
   /// If we already created OpString for str, just return the id of the created
   /// one. Otherwise, create it, keep it in stringIdMap, and return its id.
   uint32_t getOrCreateOpStringId(llvm::StringRef str);
+
+  /// In the OpenCL.DebugInfo.100 spec some parameters are literals, where in
+  /// the NonSemantic.Shader.DebugInfo.100 spec they are encoded as constant
+  /// operands. This function takes care of checking which version we are
+  /// emitting and either returning the literal directly or a constant.
+  uint32_t getLiteralEncodedForDebugInfo(uint32_t val);
 
   // Emits an OpLine instruction for the given operation into the given binary
   // section.

--- a/tools/clang/lib/SPIRV/SortDebugInfoVisitor.h
+++ b/tools/clang/lib/SPIRV/SortDebugInfoVisitor.h
@@ -21,8 +21,11 @@ namespace spirv {
 class SpirvFunction;
 class SpirvBasicBlock;
 
-/// The class responsible to sort OpenCL.DebugInfo.100 instructions in a
-/// valid order without any invalid forward reference.
+/// The class responsible to sort rich DebugInfo instructions in a valid order
+/// without any invalid forward references.
+///
+/// Since NonSemantic.Shader.DebugInfo.100 has no valid forward references, the
+/// result will have no forward references at all.
 class SortDebugInfoVisitor : public Visitor {
 public:
   SortDebugInfoVisitor(SpirvContext &spvCtx, const SpirvCodeGenOptions &opts)

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -941,6 +941,15 @@ SpirvDebugFunction *SpirvBuilder::createDebugFunction(
   return inst;
 }
 
+SpirvDebugFunctionDefinition *
+SpirvBuilder::createDebugFunctionDef(SpirvDebugFunction *function,
+                                     SpirvFunction *fn) {
+  auto *inst = new (context) SpirvDebugFunctionDefinition(function, fn);
+  assert(insertPoint && "null insert point");
+  insertPoint->addInstruction(inst);
+  return inst;
+}
+
 SpirvInstruction *
 SpirvBuilder::createRayQueryOpsKHR(spv::Op opcode, QualType resultType,
                                    ArrayRef<SpirvInstruction *> operands,
@@ -1186,8 +1195,9 @@ SpirvExtInstImport *SpirvBuilder::getExtInstSet(llvm::StringRef extName) {
   return set;
 }
 
-SpirvExtInstImport *SpirvBuilder::getOpenCLDebugInfoExtInstSet() {
-  return getExtInstSet("OpenCL.DebugInfo.100");
+SpirvExtInstImport *SpirvBuilder::getDebugInfoExtInstSet(bool vulkanDebugInfo) {
+  return getExtInstSet(vulkanDebugInfo ? "NonSemantic.Shader.DebugInfo.100"
+                                       : "OpenCL.DebugInfo.100");
 }
 
 SpirvVariable *SpirvBuilder::addStageIOVar(QualType type,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -88,6 +88,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugSource)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugCompilationUnit)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugFunctionDeclaration)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugFunction)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugFunctionDefinition)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugLocalVariable)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugGlobalVariable)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvDebugOperation)
@@ -866,6 +867,11 @@ SpirvDebugFunctionDeclaration::SpirvDebugFunctionDeclaration(
       flags(flags_) {
   debugName = name;
 }
+
+SpirvDebugFunctionDefinition::SpirvDebugFunctionDefinition(
+    SpirvDebugFunction *function_, SpirvFunction *fn_)
+    : SpirvDebugInstruction(IK_DebugFunctionDef, /*opcode*/ 101u),
+      function(function_), fn(fn_) {}
 
 SpirvDebugLocalVariable::SpirvDebugLocalVariable(
     QualType debugQualType_, llvm::StringRef varName, SpirvDebugSource *src,

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.debuglexicalblock.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.debuglexicalblock.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:      [[debugSet:%\d+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+// CHECK:   [[debugSource:%\d+]] = OpExtInst %void [[debugSet]] DebugSource
+// CHECK:          [[main:%\d+]] = OpExtInst %void [[debugSet]] DebugFunction
+// CHECK: [[mainFnLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] %uint_13 %uint_1 [[main]]
+// CHECK: [[whileLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] %uint_21 %uint_3 [[mainFnLexBlock]]
+// CHECK: [[ifStmtLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] %uint_26 %uint_20 [[whileLoopLexBlock]]
+// CHECK: [[tempLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] %uint_28 %uint_7 [[ifStmtLexBlock]]
+// CHECK: [[forLoopLexBlock:%\d+]] = OpExtInst %void [[debugSet]] DebugLexicalBlock [[debugSource]] %uint_15 %uint_12 [[mainFnLexBlock]]
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  float4 c = 0.xxxx;
+  for (;;) {
+    float4 a = 0.xxxx;
+    float4 b = 1.xxxx;
+    c = c + a + b;
+  }
+  while (c.x)
+  {
+    float4 a = 0.xxxx;
+    float4 b = 1.xxxx;
+    c = c + a + b;
+
+    if (bool(c.x)) {
+      c = c + c;
+      {
+        c = c + c;
+      }
+    }
+  }
+
+  return color + c;
+}
+

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
@@ -1,0 +1,36 @@
+// Run: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// TODO: FlagIsPublic is shown as FlagIsProtected|FlagIsPrivate.
+
+// CHECK:             [[set:%\d+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+// CHECK:         [[fooName:%\d+]] = OpString "foo"
+// CHECK:        [[emptyStr:%\d+]] = OpString ""
+// CHECK:        [[mainName:%\d+]] = OpString "main"
+
+// CHECK:    [[int:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 %uint_4 %uint_0
+// CHECK:  [[float:%\d+]] = OpExtInst %void [[set]] DebugTypeBasic {{%\d+}} %uint_32 %uint_3 %uint_0
+
+// CHECK: [[fooFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 %void [[int]] [[float]]
+// CHECK:          [[source:%\d+]] = OpExtInst %void [[set]] DebugSource
+// CHECK: [[compilationUnit:%\d+]] = OpExtInst %void [[set]] DebugCompilationUnit
+
+// Check DebugFunction instructions
+//
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] %uint_25 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_26
+
+// CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] %uint_4
+// CHECK: [[mainFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 [[float4]] [[float4]]
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] %uint_30 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_31 
+
+void foo(int x, float y)
+{
+  x = x + y;
+}
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+  bool condition = false;
+  foo(1, color.x);
+  return color;
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2954,5 +2954,11 @@ struct validType {
 // CHECK:    %output = OpTypeStruct %validType
 )"));
 }
+TEST_F(FileTest, ShaderDebugInfoFunction) {
+  runFileTest("shader.debug.function.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoDebugLexicalBlock) {
+  runFileTest("shader.debug.debuglexicalblock.hlsl");
+}
 
 } // namespace


### PR DESCRIPTION
This commit generally only adds those instructions that intersect with
OpenCL.DebugInfo.100, although it does also add generation of
new DebugFunctionDefinition to tie DebugFunction to function.