### PR TITLE
Fix llvm::BitVector::resize

### DIFF
--- a/include/llvm/ADT/BitVector.h
+++ b/include/llvm/ADT/BitVector.h
@@ -534,7 +534,7 @@ private:
     // HLSL Change Starts: Use overridable operator new
     // Bits = (BitWord *)std::realloc(Bits, Capacity * sizeof(BitWord));
     BitWord  *newBits = new BitWord[Capacity];
-    std::memcpy(newBits, Bits, NumBitWords(Size));
+    std::memcpy(newBits, Bits, NumBitWords(Size) * sizeof(BitWord));
     delete[] Bits;
     Bits = newBits;
     // HLSL Change Ends


### PR DESCRIPTION
This bug has been latent for a long time, and was exposed by getting
the unit tests running again. When resizing the buffer we were not
copying all the bits.