### PR TITLE
Fix triple normalization

### DIFF
--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -432,7 +432,7 @@ static Triple::OSType parseOS(StringRef OSName) {
     .StartsWith("cuda", Triple::CUDA)
     .StartsWith("nvcl", Triple::NVCL)
     .StartsWith("amdhsa", Triple::AMDHSA)
-    .StartsWith("dx", Triple::DirectX)    // HLSL Change
+    .Case("dx", Triple::DirectX)    // HLSL Change - For DirectX this must match
     .StartsWith("ps4", Triple::PS4)
     .Default(Triple::UnknownOS);
 }


### PR DESCRIPTION
For the DirectX match we need an exact match otherwise this will match
against the `dxil` arch or `dxbc` as an object format (if we add it).
This will resolve a failure in the triple normalization unit test.