### PR TITLE
Fix bug with HLSL case-insensitive attribute parsing

### DIFF
--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -644,10 +644,10 @@ bool Parser::MaybeParseHLSLAttributes(std::vector<hlsl::UnusualAnnotation *> &ta
 // HLSL Change Ends
 
 /// \brief Normalizes an attribute name by dropping prefixed and suffixed __.
-static StringRef normalizeAttrName(StringRef Name) {
+static std::string normalizeAttrName(StringRef Name) {  // HLSL Change: return std::string
   if (Name.size() >= 4 && Name.startswith("__") && Name.endswith("__"))
     Name = Name.drop_front(2).drop_back(2);
-  return Name;
+  return Name.lower();  // HLSL Change: make lowercase
 }
 
 /// \brief Determine whether the given attribute has an identifier argument.


### PR DESCRIPTION
During parsing, some properties about attributes are determined by
matching the identifier used in the source with the attribute spelling
in Attr.td. The assumption here was that attributes are all
case-sensitive.  But HLSL attributes are not case-sensitive, and even
though code that matches these attributes to kind and determines
whether the attribute is valid has been adjusted to handle
case-insensitivity, the code that looks up properties had not.

One impact was that identifier arguments were not being recognized and
stored in the attributes properly (attributeHasIdentifierArg).

This change makes normalizeAttrName use lower() to force lowercase for
the incoming attribute name before it gets used in the StringSwitch.
normalizeAttrName now must return std::string instead of StringRef
since it's potentially changing the string, not just slicing it.

It would seem better to use the AttributeList::Kind in a switch instead
of matching the string used, but that would be a much more significant
change.

Note: for attributes to work now, all spellings for valid attributes
must be lower case in Attr.td (fortunately they currently are).