### PR TITLE
[NFC] Change FileCheck flag from -input to -input-file

### DIFF
--- a/tools/clang/test/CodeGenHLSL/Include.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Include.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | FileCheck -input-file=stderr %s
 
 
 

--- a/tools/clang/test/CodeGenHLSL/val-wave-failures-ps.hlsl
+++ b/tools/clang/test/CodeGenHLSL/val-wave-failures-ps.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input-file=stderr %s
 
 // CHECK: 37:7: warning: Gradient operations are not affected by wave-sensitive data or control flow.
 // CHECK: 30:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.

--- a/tools/clang/test/DXILValidation/Include.hlsl
+++ b/tools/clang/test/DXILValidation/Include.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T ps_6_0 -Vi -I inc %s | FileCheck -input-file=stderr %s
 
 
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/unused-output-target-warning.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/unused-output-target-warning.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 %s | FileCheck -input=stderr %s
+// RUN: %dxc -T ps_6_0 %s | FileCheck -input-file=stderr %s
 
 // CHECK-NOT: warning: Declared output SV_Target0 not fully written in shader.
 // CHECK: warning: Declared output SV_Target1 not fully written in shader.

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveSensitivityAndCycles.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveSensitivityAndCycles.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_3 %s | FileCheck %s -input=stderr
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s -input-file=stderr
 
 // CHECK: 18:19: warning: Gradient operations are not affected by wave-sensitive data or control flow
 // CHECK: 37:19: warning: Gradient operations are not affected by wave-sensitive data or control flow

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/access.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/access.hlsl
@@ -1,15 +1,15 @@
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=0 | FileCheck -check-prefix=CHK0 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=1 | FileCheck -check-prefix=CHK1 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=2 | FileCheck -check-prefix=CHK2 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=3 | FileCheck -check-prefix=CHK3 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=4 | FileCheck -check-prefix=CHK4 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=5 | FileCheck -check-prefix=CHK5 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=6 | FileCheck -check-prefix=CHK6 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=7 | FileCheck -check-prefix=CHK7 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=8 | FileCheck -check-prefix=CHK8 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=9 | FileCheck -check-prefix=CHK9 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=10 | FileCheck -check-prefix=CHK10 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=11 | FileCheck -check-prefix=CHK11 -input=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=0 | FileCheck -check-prefix=CHK0 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=1 | FileCheck -check-prefix=CHK1 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=2 | FileCheck -check-prefix=CHK2 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=3 | FileCheck -check-prefix=CHK3 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=4 | FileCheck -check-prefix=CHK4 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=5 | FileCheck -check-prefix=CHK5 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=6 | FileCheck -check-prefix=CHK6 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=7 | FileCheck -check-prefix=CHK7 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=8 | FileCheck -check-prefix=CHK8 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=9 | FileCheck -check-prefix=CHK9 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=10 | FileCheck -check-prefix=CHK10 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=11 | FileCheck -check-prefix=CHK11 -input-file=stderr  %s
 
 // CHK0-NOT: -Wpayload-access-
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/extern_call.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/extern_call.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_6 %s -enable-payload-qualifiers | FileCheck -input=stderr %s
+// RUN: %dxc -T lib_6_6 %s -enable-payload-qualifiers | FileCheck -input-file=stderr %s
 
 // CHECK: warning: passing a qualified payload to an extern function can cause undefined behavior if payload qualifiers mismatch
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
@@ -2,8 +2,8 @@
 // RUN: %dxc -T lib_6_x -D TEST_NUM=1 %s | FileCheck -check-prefix=CHK1 %s
 // RUN: %dxc -T lib_6_x -D TEST_NUM=2 %s | FileCheck -check-prefix=CHK2 %s
 // RUN: %dxc -T lib_6_x -D TEST_NUM=3 %s | FileCheck -check-prefix=CHK3 %s
-// RUN: %dxc -T lib_6_5 -D TEST_NUM=4 %s -enable-payload-qualifiers | FileCheck -input=stderr -check-prefix=CHK4 %s
-// RUN: %dxc -T lib_6_6 -D TEST_NUM=4 %s | FileCheck -input=stderr -check-prefix=CHK5 %s
+// RUN: %dxc -T lib_6_5 -D TEST_NUM=4 %s -enable-payload-qualifiers | FileCheck -input-file=stderr -check-prefix=CHK4 %s
+// RUN: %dxc -T lib_6_6 -D TEST_NUM=4 %s | FileCheck -input-file=stderr -check-prefix=CHK5 %s
 // RUN: %dxc -T lib_6_6 -D TEST_NUM=4 %s -enable-payload-qualifiers | FileCheck -check-prefix=CHK6 %s
 // RUN: %dxc -T lib_6_6 -D TEST_NUM=5 %s -enable-payload-qualifiers | FileCheck -check-prefix=CHK7 %s
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/nested_access.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/nested_access.hlsl
@@ -1,12 +1,12 @@
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=0 | FileCheck -check-prefix=CHK0 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=1 | FileCheck -check-prefix=CHK1 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=2 | FileCheck -check-prefix=CHK2 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=3 | FileCheck -check-prefix=CHK3 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=4 | FileCheck -check-prefix=CHK4 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=5 | FileCheck -check-prefix=CHK5 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=6 | FileCheck -check-prefix=CHK6 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=7 | FileCheck -check-prefix=CHK7 -input=stderr  %s
-// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=8 | FileCheck -check-prefix=CHK8 -input=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=0 | FileCheck -check-prefix=CHK0 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=1 | FileCheck -check-prefix=CHK1 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=2 | FileCheck -check-prefix=CHK2 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=3 | FileCheck -check-prefix=CHK3 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=4 | FileCheck -check-prefix=CHK4 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=5 | FileCheck -check-prefix=CHK5 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=6 | FileCheck -check-prefix=CHK6 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=7 | FileCheck -check-prefix=CHK7 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=8 | FileCheck -check-prefix=CHK8 -input-file=stderr  %s
 
 // CHK0-NOT: -Wpayload-access-
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_3.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input-file=stderr %s
 
 // CHECK: warning: Ignoring unsupported 'VFACE' in the target attribute string
 

--- a/tools/clang/test/HLSLFileCheck/samples/SimpleHs10.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/SimpleHs10.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T hs_6_0  %s 2>&1 | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T hs_6_0  %s 2>&1 | FileCheck -input-file=stderr %s
 
 // Same as SimpleHS11.hlsl, except that we only verify StdErr for the warning
 // message.

--- a/tools/clang/test/HLSLFileCheck/validation/val-wave-failures-ps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/val-wave-failures-ps.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input=stderr %s
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -input-file=stderr %s
 
 // CHECK: 37:7: warning: Gradient operations are not affected by wave-sensitive data or control flow.
 // CHECK: 30:16: warning: Gradient operations are not affected by wave-sensitive data or control flow.

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -139,7 +139,7 @@ FileRunCommandResult FileRunCommandPart::RunFileChecker(const FileRunCommandResu
   auto args = strtok(Arguments);
   for (const std::string& arg : args) {
     if (arg == "%s") hasInputFilename = true;
-    else if (arg == "-input=stderr") {
+    else if (arg == "-input-file=stderr") {
       t.InputForStdin = Prior->StdErr;
       t.AllowEmptyInput = true;
     } else if (strstartswith(arg, checkPrefixStr))


### PR DESCRIPTION
FileCheck's actual flag is named -input-file. This change is one step
toward getting the FileCheck tests to run with FileCheck.