### PR TITLE
Adding line ending settings to .gitattributes

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -1,6 +1,5 @@
 @echo off
 
-
 if "%1"=="/?" goto :showhelp
 if "%1"=="-?" goto :showhelp
 if "%1"=="-h" goto :showhelp


### PR DESCRIPTION
This should make it so that cmd and bat files are always crlf and sh and
config.guess are always lf.

Thanks @tex3d for the pointers on this!