### PR TITLE
Convert Windows 1252 to UTF-8

### DIFF
--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_BuildGridCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_BuildGridCS.hlsl
@@ -16,7 +16,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_BuildGridIndicesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_BuildGridIndicesCS.hlsl
@@ -13,7 +13,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ClearGridIndicesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ClearGridIndicesCS.hlsl
@@ -12,7 +12,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Grid.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Grid.hlsl
@@ -17,7 +17,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Shared.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Shared.hlsl
@@ -20,7 +20,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Simple.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_DensityCS_Simple.hlsl
@@ -14,7 +14,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Grid.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Grid.hlsl
@@ -21,7 +21,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Shared.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Shared.hlsl
@@ -20,7 +20,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Simple.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_ForceCS_Simple.hlsl
@@ -18,7 +18,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_IntegrateCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_IntegrateCS.hlsl
@@ -15,7 +15,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_RearrangeParticlesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/FluidCS11_RearrangeParticlesCS.hlsl
@@ -13,7 +13,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_BuildGridCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_BuildGridCS.hlsl
@@ -16,7 +16,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_BuildGridIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_BuildGridIndicesCS.hlsl
@@ -13,7 +13,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ClearGridIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ClearGridIndicesCS.hlsl
@@ -12,7 +12,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Grid.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Grid.hlsl
@@ -17,7 +17,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Shared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Shared.hlsl
@@ -20,7 +20,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Simple.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_DensityCS_Simple.hlsl
@@ -14,7 +14,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Grid.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Grid.hlsl
@@ -21,7 +21,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Shared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Shared.hlsl
@@ -20,7 +20,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Simple.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_ForceCS_Simple.hlsl
@@ -18,7 +18,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_IntegrateCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_IntegrateCS.hlsl
@@ -15,7 +15,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_RearrangeParticlesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/FluidCS11_RearrangeParticlesCS.hlsl
@@ -13,7 +13,7 @@
 //--------------------------------------------------------------------------------------
 // Smoothed Particle Hydrodynamics Algorithm Based Upon:
 // Particle-Based Fluid Simulation for Interactive Applications
-// Matthias Müller
+// Matthias MÃ¼ller
 //--------------------------------------------------------------------------------------
 
 //--------------------------------------------------------------------------------------


### PR DESCRIPTION
These testcases all had a Windows 1252 ü character instead of a utf-8
character. Converting to utf-8 makes the world happy :)