### PR TITLE
[spirv] Add Shader.DebugInfo.100 support for DebugLine and DebugNoLine

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -199,9 +199,9 @@ public:
         typeHandler(astCtx, spvCtx, opts, &debugVariableBinary,
                     &annotationsBinary, &typeConstantBinary,
                     [this]() -> uint32_t { return takeNextId(); }),
-        debugMainFileId(0), debugLine(0), debugColumn(0),
-        lastOpWasMergeInst(false), inEntryFunctionWrapper(false),
-        hlslVersion(0) {}
+        debugMainFileId(0), debugInfoExtInstId(0), debugLine(0),
+	    debugColumn(0), lastOpWasMergeInst(false),
+	    inEntryFunctionWrapper(false), hlslVersion(0) {}
 
   ~EmitVisitor();
 
@@ -405,6 +405,8 @@ private:
   llvm::StringMap<uint32_t> stringIdMap;
   // Main file information for debugging that will be used by OpLine.
   uint32_t debugMainFileId;
+  // Id for Vulkan DebugInfo extended instruction set. Used when generating Debug[No]Line
+  uint32_t debugInfoExtInstId;
   // One HLSL source line may result in several SPIR-V instructions. In order to
   // avoid emitting many OpLine instructions with identical line and column
   // numbers, we record the last line and column number that was used by OpLine,
@@ -417,8 +419,10 @@ private:
   bool lastOpWasMergeInst;
   // True if currently it enters an entry function wrapper.
   bool inEntryFunctionWrapper;
-  // Set of files that we already dumped their source code in OpSource.
-  llvm::DenseSet<uint32_t> dumpedFiles;
+  // Map of filename string id to the id of its DebugSource instruction. When
+  // generating OpSource instruction without a result id, use 1 to remember it
+  // was generated.
+  llvm::DenseMap<uint32_t, uint32_t> emittedSource;
   uint32_t hlslVersion;
   // Vector to contain SpirvInstruction objects created by this class. The
   // destructor of this class will release them.

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
@@ -1,0 +1,34 @@
+// Run: %dxc -T ps_6_0 -E MainPs -fspv-debug=vulkan
+
+// CHECK:      [[ext:%\d+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+// CHECK:      [[src:%\d+]] = OpExtInst %void [[ext]] DebugSource {{%\d+}}
+
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_57 %uint_57
+// CHECK-NEXT: OpAccessChain %_ptr_Function_v2float %i %int_0
+
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_26 %uint_26
+// CHECK-NEXT: OpSampledImage
+// CHECK-NEXT: OpImageSampleImplicitLod
+
+Texture2D g_tColor;
+
+SamplerState g_sAniso;
+
+struct PS_INPUT
+{
+    float2 vTextureCoords : TEXCOORD2 ;
+} ;
+
+struct PS_OUTPUT
+{
+    float4 vColor : SV_Target0 ;
+} ;
+
+PS_OUTPUT MainPs ( PS_INPUT i )
+{
+    PS_OUTPUT ps_output ;
+
+    ps_output . vColor = g_tColor . Sample ( g_sAniso , i . vTextureCoords . xy ) ;
+    return ps_output ;
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2966,5 +2966,8 @@ TEST_F(FileTest, ShaderDebugInfoSource) {
 TEST_F(FileTest, ShaderDebugInfoSourceContinued) {
   runFileTest("shader.debug.sourcecontinued.hlsl");
 }
+TEST_F(FileTest, ShaderDebugInfoLine) {
+  runFileTest("shader.debug.line.hlsl");
+}
 
 } // namespace


### PR DESCRIPTION
This commit generates end values for lines and columns identical to the
start values. A follow-up commit will add correct end values for lines
and columns.