### PR TITLE
Fix issues in intrinsic properties in hctdb.py

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -896,9 +896,6 @@ static bool ValidateOpcodeInProfile(DXIL::OpCode opcode,
   // Instructions: StorePatchConstant=106, OutputControlPointID=107
   if ((106 <= op && op <= 107))
     return (SK == DXIL::ShaderKind::Hull);
-  // Instructions: QuadReadLaneAt=122, QuadOp=123
-  if ((122 <= op && op <= 123))
-    return (SK == DXIL::ShaderKind::Library || SK == DXIL::ShaderKind::Compute || SK == DXIL::ShaderKind::Amplification || SK == DXIL::ShaderKind::Mesh || SK == DXIL::ShaderKind::Pixel);
   // Instructions: WaveIsFirstLane=110, WaveGetLaneIndex=111,
   // WaveGetLaneCount=112, WaveAnyTrue=113, WaveAllTrue=114,
   // WaveActiveAllEqual=115, WaveActiveBallot=116, WaveReadLaneAt=117,
@@ -907,8 +904,9 @@ static bool ValidateOpcodeInProfile(DXIL::OpCode opcode,
   if ((110 <= op && op <= 121) || (135 <= op && op <= 136))
     return (SK == DXIL::ShaderKind::Library || SK == DXIL::ShaderKind::Compute || SK == DXIL::ShaderKind::Amplification || SK == DXIL::ShaderKind::Mesh || SK == DXIL::ShaderKind::Pixel || SK == DXIL::ShaderKind::Vertex || SK == DXIL::ShaderKind::Hull || SK == DXIL::ShaderKind::Domain || SK == DXIL::ShaderKind::Geometry || SK == DXIL::ShaderKind::RayGeneration || SK == DXIL::ShaderKind::Intersection || SK == DXIL::ShaderKind::AnyHit || SK == DXIL::ShaderKind::ClosestHit || SK == DXIL::ShaderKind::Miss || SK == DXIL::ShaderKind::Callable);
   // Instructions: Sample=60, SampleBias=61, SampleCmp=64, CalculateLOD=81,
-  // DerivCoarseX=83, DerivCoarseY=84, DerivFineX=85, DerivFineY=86
-  if ((60 <= op && op <= 61) || op == 64 || op == 81 || (83 <= op && op <= 86))
+  // DerivCoarseX=83, DerivCoarseY=84, DerivFineX=85, DerivFineY=86,
+  // QuadReadLaneAt=122, QuadOp=123
+  if ((60 <= op && op <= 61) || op == 64 || op == 81 || (83 <= op && op <= 86) || (122 <= op && op <= 123))
     return (SK == DXIL::ShaderKind::Library || SK == DXIL::ShaderKind::Pixel || SK == DXIL::ShaderKind::Compute || SK == DXIL::ShaderKind::Amplification || SK == DXIL::ShaderKind::Mesh);
   // Instructions: RenderTargetGetSamplePosition=76,
   // RenderTargetGetSampleCount=77, Discard=82, EvalSnapped=87,
@@ -1007,7 +1005,7 @@ static bool ValidateOpcodeInProfile(DXIL::OpCode opcode,
   // Instructions: WriteSamplerFeedback=174, WriteSamplerFeedbackBias=175
   if ((174 <= op && op <= 175))
     return (major > 6 || (major == 6 && minor >= 5))
-        && (SK == DXIL::ShaderKind::Library || SK == DXIL::ShaderKind::Pixel);
+        && (SK == DXIL::ShaderKind::Library || SK == DXIL::ShaderKind::Pixel || SK == DXIL::ShaderKind::Compute || SK == DXIL::ShaderKind::Amplification || SK == DXIL::ShaderKind::Mesh);
   // Instructions: SetMeshOutputCounts=168, EmitIndices=169, GetMeshPayload=170,
   // StoreVertexOutput=171, StorePrimitiveOutput=172
   if ((168 <= op && op <= 172))

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -344,7 +344,7 @@ class db_dxil(object):
             elif i.name.startswith("Quad"):
                 i.category = "Quad Wave Ops"
                 i.is_wave = True
-                i.shader_stages = ("library", "compute", "amplification", "mesh", "pixel")
+                i.shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
             elif i.name.startswith("Bitcast"):
                 i.category = "Bitcasts with different sizes"
         for i in "ViewID,AttributeAtVertex".split(","):
@@ -411,6 +411,8 @@ class db_dxil(object):
         for i in "AnnotateHandle,CreateHandleFromBinding,CreateHandleFromHeap".split(","):
             self.name_idx[i].category = "Get handle from heap"
             self.name_idx[i].shader_model = 6,6
+        for i in "AnnotateHandle,CreateHandleFromBinding".split(","):
+            self.name_idx[i].shader_model_translated = 6,0
         for i in "Dot4AddU8Packed,Dot4AddI8Packed,Dot2AddHalf".split(","):
             self.name_idx[i].category = "Dot product with accumulate"
             self.name_idx[i].shader_model = 6,4
@@ -430,7 +432,7 @@ class db_dxil(object):
             self.name_idx[i].is_feedback = True
             self.name_idx[i].is_gradient = True
             self.name_idx[i].shader_model = 6,5
-            self.name_idx[i].shader_stages = ("library", "pixel",)
+            self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
         for i in "WriteSamplerFeedbackLevel,WriteSamplerFeedbackGrad".split(","):
             self.name_idx[i].category = "Sampler Feedback"
             self.name_idx[i].is_feedback = True
@@ -825,7 +827,7 @@ class db_dxil(object):
             counters=('tex_grad',))
         next_op_idx += 1
         self.add_dxil_op("SampleCmp", next_op_idx, "SampleCmp", "samples a texture and compares a single component against the specified comparison value", "hf", "ro", [
-            db_dxil_param(0, "$r", "", "the value for the constant buffer variable"),
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
             db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
             db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
             db_dxil_param(4, "f", "coord0", "coordinate"),
@@ -840,7 +842,7 @@ class db_dxil(object):
             counters=('tex_cmp',))
         next_op_idx += 1
         self.add_dxil_op("SampleCmpLevelZero", next_op_idx, "SampleCmpLevelZero", "samples a texture and compares a single component against the specified comparison value", "hf", "ro", [
-            db_dxil_param(0, "$r", "", "the value for the constant buffer variable"),
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
             db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
             db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
             db_dxil_param(4, "f", "coord0", "coordinate"),


### PR DESCRIPTION
Two changes that impact RDAT, and thus validation:
- AnnotateHandle and CreateHandleFromBinding can be translated down to SM 6.0
- Sampler Feedback operations available in additional stages
  The translation issue here is the same as for other sampler/deriv ops.
  Currently, we mask off the additional stages for RDAT, while allowing
  those instructions on those stages for the validator.  RDAT will have
  to be fixed to describe the more complicated feature requirements of
  these operations, but that's not necessary now since RDAT will only be
  used for DXR stage for now, meaning that this deficiency won't block
  any valid scenario.

Couple of minor edits with no functional impact:
- sync stage order, enabling merging of some generated conditions
- fix a couple bad descriptions for return values on dxil ops