### PR TITLE
[spirv] Enable legalization when the vk::image_format attribute is used

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1013,6 +1013,12 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
   VkImageFeatures vkImgFeatures = {
       var->getAttr<VKCombinedImageSamplerAttr>() != nullptr,
       getSpvImageFormat(var->getAttr<VKImageFormatAttr>())};
+  if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
+    // Legalization is needed to propagate the correct image type for 
+    // instructions in addition to cases where the resource is assigned to
+    // another variable or function parameter
+    needsLegalization = true;
+  }
   if (vkImgFeatures.isCombinedImageSampler ||
       vkImgFeatures.format != spv::ImageFormat::Unknown) {
     spvContext.registerVkImageFeaturesForSpvVariable(varInstr, vkImgFeatures);

--- a/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.simple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.attribute.image-format.simple.hlsl
@@ -1,0 +1,14 @@
+// Run: %dxc -T cs_6_0 -E main -O3
+
+//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba16f
+[[vk::image_format("rgba16f")]]
+RWBuffer<float4> Buf;
+//CHECK: OpTypeImage %float 2D 2 0 0 2 Rgba16f
+[[vk::image_format("rgba16f")]]
+RWTexture2D<float4> Tex;
+
+[numthreads(1, 1, 1)]
+void main() {
+    Buf[0] = Tex[uint2(0, 0)];
+    Tex[uint2(1, 0)] = Buf[1];
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1819,6 +1819,9 @@ TEST_F(FileTest, VulkanAttributeImageFormat) {
 TEST_F(FileTest, VulkanAttributeImageFormatO3) {
   runFileTest("vk.attribute.image-format.o3.hlsl");
 }
+TEST_F(FileTest, VulkanAttributeImageFormatSimple) {
+  runFileTest("vk.attribute.image-format.simple.hlsl", Expect::Success);
+}
 
 TEST_F(FileTest, VulkanCLOptionInvertYVS) {
   runFileTest("vk.cloption.invert-y.vs.hlsl");


### PR DESCRIPTION
Legalization is required to propagate the correct type of the OpLoad even when
the resource variables are not being passed or assigned

This fixes a validation error in simple shaders using vk::image_format, where legalization
would not be needed otherwise

This fixes https://github.com/microsoft/DirectXShaderCompiler/issues/3767