### PR TITLE
Added source encoding option

### DIFF
--- a/include/dxc/Support/FileIOHelper.h
+++ b/include/dxc/Support/FileIOHelper.h
@@ -218,7 +218,8 @@ DxcCreateBlobWithEncodingOnMallocCopy(
   _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) throw();
 
 HRESULT DxcGetBlobAsUtf8(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
-                         _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) throw();
+                         _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding,
+                         UINT32 defaultCodePage = CP_ACP) throw();
 HRESULT
 DxcGetBlobAsUtf16(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
                   _COM_Outptr_ IDxcBlobUtf16 **pBlobEncoding) throw();

--- a/include/dxc/Support/dxcfilesystem.h
+++ b/include/dxc/Support/dxcfilesystem.h
@@ -45,7 +45,8 @@ public:
 
 DxcArgsFileSystem *
 CreateDxcArgsFileSystem(_In_ IDxcBlobUtf8 *pSource, _In_ LPCWSTR pSourceName,
-                        _In_opt_ IDxcIncludeHandler *pIncludeHandler);
+                        _In_opt_ IDxcIncludeHandler *pIncludeHandler,
+                        _In_opt_ UINT32 defaultCodePage = CP_ACP);
 
 void MakeAbsoluteOrCurDirRelativeW(LPCWSTR &Path, std::wstring &PathStorage);
 

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -921,7 +921,7 @@ DxcCreateBlobWithEncodingOnMallocCopy(IMalloc *pIMalloc, LPCVOID pText, UINT32 s
 }
 
 _Use_decl_annotations_
-HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf8 **pBlobEncoding) throw() {
+HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf8 **pBlobEncoding, UINT32 defaultCodePage) throw() {
   IFRBOOL(pBlob, E_POINTER);
   IFRBOOL(pBlobEncoding, E_POINTER);
   *pBlobEncoding = nullptr;
@@ -949,6 +949,11 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf8 **pBlob
     // BOM exists, adjust pointer and size to strip.
     bufferPointer += bomSize;
     blobLen -= bomSize;
+    // This is checking if the codePage is still default AND the defaulCodePage is NOT default(CP_ACP) and Has been specified
+    // THEN set the codePage to te default from the flag
+    if (codePage == CP_ACP && defaultCodePage != CP_ACP) {
+      codePage = defaultCodePage;
+    }
   }
 
   if (!pMalloc)

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -725,8 +725,9 @@ public:
       IFC(hlsl::DxcGetBlobAsUtf8(pSourceEncoding, m_pMalloc, &utf8Source));
 
       CComPtr<IDxcBlob> pOutputBlob;
-      dxcutil::DxcArgsFileSystem *msfPtr =
-        dxcutil::CreateDxcArgsFileSystem(utf8Source, pUtf16SourceName.m_psz, pIncludeHandler);
+      dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(
+          utf8Source, pUtf16SourceName.m_psz, pIncludeHandler,
+          opts.DefaultTextCodePage);
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
 
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -722,7 +722,9 @@ public:
 #endif // ENABLE_SPIRV_CODEGEN
 
       // Convert source code encoding
-      IFC(hlsl::DxcGetBlobAsUtf8(pSourceEncoding, m_pMalloc, &utf8Source));
+      IFC(hlsl::DxcGetBlobAsUtf8(
+          pSourceEncoding, m_pMalloc, &utf8Source,
+          opts.DefaultTextCodePage));
 
       CComPtr<IDxcBlob> pOutputBlob;
       dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(


### PR DESCRIPTION
Using the existing -encoding option to also specify source encoding. Includes support for UTF-8 and UTF-16 encoded sources with and without BOMs by using specified encoding if a BOM is not detected in a source file. 

TO-DO: Add a specific error for UTF-16 encoded file without a BOM used with -encoding utf8 option

