### PR TITLE
Require Windows 7 Everywhere

### DIFF
--- a/include/dxc/Support/WinIncludes.h
+++ b/include/dxc/Support/WinIncludes.h
@@ -12,6 +12,14 @@
 
 #ifdef _MSC_VER
 
+// mingw-w64 tends to define it as 0x0502 in its headers.
+#undef _WIN32_WINNT
+#undef _WIN32_IE
+
+// Require at least Windows 7 (Updated from XP)
+#define _WIN32_WINNT 0x0601
+#define _WIN32_IE    0x0800 // MinGW at it again.
+
 #define NOATOM 1
 #define NOGDICAPMASKS 1
 #define NOMETAFILE 1

--- a/lib/Support/Windows/WindowsSupport.h
+++ b/lib/Support/Windows/WindowsSupport.h
@@ -23,6 +23,9 @@
 #ifndef LLVM_SUPPORT_WINDOWSSUPPORT_H
 #define LLVM_SUPPORT_WINDOWSSUPPORT_H
 
+/* HLSL Change - Moved to WinIncludes.h
+
+These values need to be the same everywhere that windows headers are included.
 // mingw-w64 tends to define it as 0x0502 in its headers.
 #undef _WIN32_WINNT
 #undef _WIN32_IE
@@ -30,6 +33,7 @@
 // Require at least Windows XP(5.1) API.
 #define _WIN32_WINNT 0x0501
 #define _WIN32_IE    0x0600 // MinGW at it again.
+*/
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"


### PR DESCRIPTION
Some of the LLVM APIs were expecting Windows XP support, while other
places in the code were going with whatever your SDK configured.
This should get things consistent and avoid mismatches in the Windows
headers.