### PR TITLE
[spirv] Improve lines and columns for DebugLine (pt 1)

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -173,9 +173,9 @@ public:
   /// <result-type> from the given pointer. Returns the instruction pointer for
   /// the loaded value.
   SpirvLoad *createLoad(QualType resultType, SpirvInstruction *pointer,
-                        SourceLocation loc);
+                        SourceLocation loc, SourceRange range = {});
   SpirvLoad *createLoad(const SpirvType *resultType, SpirvInstruction *pointer,
-                        SourceLocation loc);
+                        SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates an OpCopyObject instruction from the given pointer.
   SpirvCopyObject *createCopyObject(QualType resultType,
@@ -184,7 +184,7 @@ public:
   /// \brief Creates a store instruction storing the given value into the given
   /// address.
   void createStore(SpirvInstruction *address, SpirvInstruction *value,
-                   SourceLocation loc);
+                   SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates a function call instruction and returns the instruction
   /// pointer for the return value.
@@ -202,7 +202,7 @@ public:
   SpirvAccessChain *
   createAccessChain(QualType resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
-                    SourceLocation loc);
+                    SourceLocation loc, SourceRange range = {});
   SpirvAccessChain *
   createAccessChain(const SpirvType *resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
@@ -217,7 +217,7 @@ public:
   /// the instruction pointer for the result.
   SpirvBinaryOp *createBinaryOp(spv::Op op, QualType resultType,
                                 SpirvInstruction *lhs, SpirvInstruction *rhs,
-                                SourceLocation loc);
+                                SourceLocation loc, SourceRange range = {});
 
   SpirvSpecConstantBinaryOp *createSpecConstantBinaryOp(spv::Op op,
                                                         QualType resultType,
@@ -257,7 +257,8 @@ public:
   /// decorations for the given parameters.
   SpirvSampledImage *createSampledImage(QualType, SpirvInstruction *image,
                                         SpirvInstruction *sampler,
-                                        SourceLocation);
+                                        SourceLocation loc,
+                                        SourceRange range = {});
 
   /// \brief Creates an OpImageTexelPointer SPIR-V instruction with the given
   /// parameters.
@@ -295,7 +296,7 @@ public:
                     SpirvInstruction *constOffset, SpirvInstruction *varOffset,
                     SpirvInstruction *constOffsets, SpirvInstruction *sample,
                     SpirvInstruction *minLod, SpirvInstruction *residencyCodeId,
-                    SourceLocation loc);
+                    SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for reading a texel from an image. If
   /// doImageFetch is true, OpImageFetch is used. OpImageRead is used otherwise.
@@ -335,7 +336,7 @@ public:
                     SpirvInstruction *compareVal, SpirvInstruction *constOffset,
                     SpirvInstruction *varOffset, SpirvInstruction *constOffsets,
                     SpirvInstruction *sample, SpirvInstruction *residencyCode,
-                    SourceLocation);
+                    SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates an OpImageSparseTexelsResident SPIR-V instruction for the
   /// given Resident Code and returns the instruction pointer.
@@ -393,9 +394,10 @@ public:
       spv::LoopControlMask loopControl = spv::LoopControlMask::MaskNone);
 
   /// \brief Creates a return instruction.
-  void createReturn(SourceLocation);
+  void createReturn(SourceLocation, SourceRange range = {});
   /// \brief Creates a return value instruction.
-  void createReturnValue(SpirvInstruction *value, SourceLocation);
+  void createReturnValue(SpirvInstruction *value, SourceLocation,
+                         SourceRange range = {});
 
   /// \brief Creates an OpExtInst instruction for the GLSL extended instruction
   /// set, with the given instruction number, and operands. Returns the
@@ -486,6 +488,7 @@ public:
 
   SpirvDebugDeclare *createDebugDeclare(
       SpirvDebugLocalVariable *dbgVar, SpirvInstruction *var,
+      SourceLocation loc = {}, SourceRange range = {},
       llvm::Optional<SpirvDebugExpression *> dbgExpr = llvm::None);
 
   SpirvDebugFunction *
@@ -668,7 +671,7 @@ public:
   /// \brief Decorates the given target with the given string.
   void decorateString(SpirvInstruction *target, unsigned decorate,
                       llvm::StringRef strLiteral,
-                      llvm::Optional<uint32_t> memberIdx = llvm::None);                    
+                      llvm::Optional<uint32_t> memberIdx = llvm::None);
 
   /// --- Constants ---
   /// Each of these methods can acquire a unique constant from the SpirvContext,

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -183,6 +183,7 @@ public:
   void setResultId(uint32_t id) { resultId = id; }
 
   clang::SourceLocation getSourceLocation() const { return srcLoc; }
+  clang::SourceRange getSourceRange() const { return srcRange; }
 
   void setDebugName(llvm::StringRef name) { debugName = name; }
   llvm::StringRef getDebugName() const { return debugName; }
@@ -219,7 +220,7 @@ public:
 protected:
   // Forbid creating SpirvInstruction directly
   SpirvInstruction(Kind kind, spv::Op opcode, QualType astResultType,
-                   SourceLocation loc);
+                   SourceLocation loc, SourceRange range = {});
 
 protected:
   const Kind kind;
@@ -228,6 +229,7 @@ protected:
   QualType astResultType;
   uint32_t resultId;
   SourceLocation srcLoc;
+  SourceRange srcRange;
   std::string debugName;
   const SpirvType *resultType;
   uint32_t resultTypeId;
@@ -659,7 +661,8 @@ public:
   }
 
 protected:
-  SpirvTerminator(Kind kind, spv::Op opcode, SourceLocation loc);
+  SpirvTerminator(Kind kind, spv::Op opcode, SourceLocation loc,
+                  SourceRange range = {});
 };
 
 /// \brief Base class for branching instructions
@@ -751,7 +754,8 @@ public:
 /// \brief OpReturn and OpReturnValue instructions
 class SpirvReturn : public SpirvTerminator {
 public:
-  SpirvReturn(SourceLocation loc, SpirvInstruction *retVal = 0);
+  SpirvReturn(SourceLocation loc, SpirvInstruction *retVal = 0,
+              SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvReturn)
 
@@ -825,7 +829,8 @@ class SpirvAccessChain : public SpirvInstruction {
 public:
   SpirvAccessChain(QualType resultType, SourceLocation loc,
                    SpirvInstruction *base,
-                   llvm::ArrayRef<SpirvInstruction *> indexVec);
+                   llvm::ArrayRef<SpirvInstruction *> indexVec,
+                   SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvAccessChain)
 
@@ -1002,7 +1007,8 @@ private:
 class SpirvBinaryOp : public SpirvInstruction {
 public:
   SpirvBinaryOp(spv::Op opcode, QualType resultType, SourceLocation loc,
-                SpirvInstruction *op1, SpirvInstruction *op2);
+                SpirvInstruction *op1, SpirvInstruction *op2,
+                SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvBinaryOp)
 
@@ -1481,20 +1487,18 @@ private:
 ///
 class SpirvImageOp : public SpirvInstruction {
 public:
-  SpirvImageOp(spv::Op opcode, QualType resultType, SourceLocation loc,
-               SpirvInstruction *image, SpirvInstruction *coordinate,
-               spv::ImageOperandsMask mask, SpirvInstruction *dref = nullptr,
-               SpirvInstruction *bias = nullptr,
-               SpirvInstruction *lod = nullptr,
-               SpirvInstruction *gradDx = nullptr,
-               SpirvInstruction *gradDy = nullptr,
-               SpirvInstruction *constOffset = nullptr,
-               SpirvInstruction *offset = nullptr,
-               SpirvInstruction *constOffsets = nullptr,
-               SpirvInstruction *sample = nullptr,
-               SpirvInstruction *minLod = nullptr,
-               SpirvInstruction *component = nullptr,
-               SpirvInstruction *texelToWrite = nullptr);
+  SpirvImageOp(
+      spv::Op opcode, QualType resultType, SourceLocation loc,
+      SpirvInstruction *image, SpirvInstruction *coordinate,
+      spv::ImageOperandsMask mask, SpirvInstruction *dref = nullptr,
+      SpirvInstruction *bias = nullptr, SpirvInstruction *lod = nullptr,
+      SpirvInstruction *gradDx = nullptr, SpirvInstruction *gradDy = nullptr,
+      SpirvInstruction *constOffset = nullptr,
+      SpirvInstruction *offset = nullptr,
+      SpirvInstruction *constOffsets = nullptr,
+      SpirvInstruction *sample = nullptr, SpirvInstruction *minLod = nullptr,
+      SpirvInstruction *component = nullptr,
+      SpirvInstruction *texelToWrite = nullptr, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvImageOp)
 
@@ -1647,6 +1651,7 @@ private:
 class SpirvLoad : public SpirvInstruction {
 public:
   SpirvLoad(QualType resultType, SourceLocation loc, SpirvInstruction *pointer,
+            SourceRange range = {},
             llvm::Optional<spv::MemoryAccessMask> mask = llvm::None);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvLoad)
@@ -1697,7 +1702,8 @@ private:
 class SpirvSampledImage : public SpirvInstruction {
 public:
   SpirvSampledImage(QualType resultType, SourceLocation loc,
-                    SpirvInstruction *image, SpirvInstruction *sampler);
+                    SpirvInstruction *image, SpirvInstruction *sampler,
+                    SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvSampledImage)
 
@@ -1795,7 +1801,8 @@ class SpirvStore : public SpirvInstruction {
 public:
   SpirvStore(SourceLocation loc, SpirvInstruction *pointer,
              SpirvInstruction *object,
-             llvm::Optional<spv::MemoryAccessMask> mask = llvm::None);
+             llvm::Optional<spv::MemoryAccessMask> mask = llvm::None,
+             SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvStore)
 
@@ -2383,7 +2390,8 @@ private:
 class SpirvDebugDeclare : public SpirvDebugInstruction {
 public:
   SpirvDebugDeclare(SpirvDebugLocalVariable *, SpirvInstruction *,
-                    SpirvDebugExpression *);
+                    SpirvDebugExpression *, SourceLocation loc = {},
+                    SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvDebugDeclare)
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -840,6 +840,7 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
                                   uint32_t dbgArgNumber) {
   const auto type = getTypeOrFnRetType(param);
   const auto loc = param->getLocation();
+  const auto range = param->getSourceRange();
   const auto name = param->getName();
   SpirvFunctionParameter *fnParamInstr = spvBuilder.addFnParam(
       type, param->hasAttr<HLSLPreciseAttr>(), loc, param->getName());
@@ -861,7 +862,7 @@ DeclResultIdMapper::createFnParam(const ParmVarDecl *param,
     auto *debugLocalVar = spvBuilder.createDebugLocalVariable(
         type, name, info->source, line, column, info->scopeStack.back(), flags,
         dbgArgNumber);
-    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr);
+    spvBuilder.createDebugDeclare(debugLocalVar, fnParamInstr, loc, range);
   }
 
   return fnParamInstr;

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -199,9 +199,10 @@ public:
         typeHandler(astCtx, spvCtx, opts, &debugVariableBinary,
                     &annotationsBinary, &typeConstantBinary,
                     [this]() -> uint32_t { return takeNextId(); }),
-        debugMainFileId(0), debugInfoExtInstId(0), debugLine(0),
-	    debugColumn(0), lastOpWasMergeInst(false),
-	    inEntryFunctionWrapper(false), hlslVersion(0) {}
+        debugMainFileId(0), debugInfoExtInstId(0), debugLineStart(0),
+        debugLineEnd(0), debugColumnStart(0), debugColumnEnd(0),
+        lastOpWasMergeInst(false), inEntryFunctionWrapper(false),
+        hlslVersion(0) {}
 
   ~EmitVisitor();
 
@@ -336,7 +337,8 @@ private:
   // Emits an OpLine instruction for the given operation into the given binary
   // section.
   void emitDebugLine(spv::Op op, const SourceLocation &loc,
-                     std::vector<uint32_t> *section, bool isDebugScope = false);
+                     const SourceRange &range, std::vector<uint32_t> *section,
+                     bool isDebugScope = false);
 
   // Initiates the creation of a new instruction with the given Opcode.
   void initInstruction(spv::Op, const SourceLocation &);
@@ -405,16 +407,18 @@ private:
   llvm::StringMap<uint32_t> stringIdMap;
   // Main file information for debugging that will be used by OpLine.
   uint32_t debugMainFileId;
-  // Id for Vulkan DebugInfo extended instruction set. Used when generating Debug[No]Line
+  // Id for Vulkan DebugInfo extended instruction set. Used when generating
+  // Debug[No]Line
   uint32_t debugInfoExtInstId;
-  // One HLSL source line may result in several SPIR-V instructions. In order to
-  // avoid emitting many OpLine instructions with identical line and column
-  // numbers, we record the last line and column number that was used by OpLine,
-  // and only emit a new OpLine when a new line/column in the source is
-  // discovered. The last debug line number information emitted by OpLine.
-  uint32_t debugLine;
-  // The last debug column number information emitted by OpLine.
-  uint32_t debugColumn;
+  // One HLSL source line may result in several SPIR-V instructions. In order
+  // to avoid emitting debug line instructions with identical line and column
+  // numbers, we record the last line and column numbers that were used in a
+  // debug line op, and only emit a new debug line op when a new line/column
+  // in the source is discovered.
+  uint32_t debugLineStart;
+  uint32_t debugLineEnd;
+  uint32_t debugColumnStart;
+  uint32_t debugColumnEnd;
   // True if the last emitted instruction was OpSelectionMerge or OpLoopMerge.
   bool lastOpWasMergeInst;
   // True if currently it enters an entry function wrapper.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -73,7 +73,7 @@ public:
 
   void doDecl(const Decl *decl);
   void doStmt(const Stmt *stmt, llvm::ArrayRef<const Attr *> attrs = {});
-  SpirvInstruction *doExpr(const Expr *expr);
+  SpirvInstruction *doExpr(const Expr *expr, SourceRange rangeOverride = {});
 
   /// Processes the given expression and emits SPIR-V instructions. If the
   /// result is a GLValue, does an additional load.
@@ -122,7 +122,8 @@ private:
   SpirvInstruction *doExtMatrixElementExpr(const ExtMatrixElementExpr *expr);
   SpirvInstruction *doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr);
   SpirvInstruction *doInitListExpr(const InitListExpr *expr);
-  SpirvInstruction *doMemberExpr(const MemberExpr *expr);
+  SpirvInstruction *doMemberExpr(const MemberExpr *expr,
+                                 SourceRange rangeOverride = {});
   SpirvInstruction *doUnaryOperator(const UnaryOperator *expr);
   SpirvInstruction *
   doUnaryExprOrTypeTraitExpr(const UnaryExprOrTypeTraitExpr *expr);
@@ -163,13 +164,15 @@ private:
   /// lhs again.
   SpirvInstruction *processAssignment(const Expr *lhs, SpirvInstruction *rhs,
                                       bool isCompoundAssignment,
-                                      SpirvInstruction *lhsPtr = nullptr);
+                                      SpirvInstruction *lhsPtr = nullptr,
+                                      SourceRange range = {});
 
   /// Generates SPIR-V instructions to store rhsVal into lhsPtr. This will be
   /// recursive if lhsValType is a composite type. rhsExpr will be used as a
   /// reference to adjust the CodeGen if not nullptr.
   void storeValue(SpirvInstruction *lhsPtr, SpirvInstruction *rhsVal,
-                  QualType lhsValType, SourceLocation loc);
+                  QualType lhsValType, SourceLocation loc,
+                  SourceRange range = {});
 
   /// Decomposes and reconstructs the given srcVal of the given valType to meet
   /// the requirements of the dstLR layout rule.
@@ -345,7 +348,7 @@ private:
   turnIntoElementPtr(QualType baseType, SpirvInstruction *base,
                      QualType elemType,
                      const llvm::SmallVector<SpirvInstruction *, 4> &indices,
-                     SourceLocation loc);
+                     SourceLocation loc, SourceRange range = {});
 
 private:
   /// Validates that vk::* attributes are used correctly and returns false if
@@ -1025,7 +1028,7 @@ private:
                     SpirvInstruction *constOffset, SpirvInstruction *varOffset,
                     SpirvInstruction *constOffsets, SpirvInstruction *sample,
                     SpirvInstruction *minLod, SpirvInstruction *residencyCodeId,
-                    SourceLocation loc);
+                    SourceLocation loc, SourceRange range = {});
 
   /// \brief Returns OpVariable to be used as 'Interface' operands of
   /// OpEntryPoint. entryPoint is the SpirvFunction for the OpEntryPoint.

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
@@ -3,10 +3,10 @@
 // CHECK:      [[ext:%\d+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 // CHECK:      [[src:%\d+]] = OpExtInst %void [[ext]] DebugSource {{%\d+}}
 
-// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_57 %uint_57
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_57 %uint_61
 // CHECK-NEXT: OpAccessChain %_ptr_Function_v2float %i %int_0
 
-// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_26 %uint_26
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_26 %uint_81
 // CHECK-NEXT: OpSampledImage
 // CHECK-NEXT: OpImageSampleImplicitLod
 


### PR DESCRIPTION
In particular, add support for start and end lines and columns for
DebugLine. Previously, end line and column was same as start line and
column.

This is just the first installment of this change. It covers binary ops,
OpAccessChain, OpLoad, OpStore, DebugDeclare, OpSample and OpReturn. A
second commit will complete support.

This commit primarily adds SourceRange to the appropriate emit and
generation functions. This is necessary since sometimes neither value
in the SourceRange matches the accompanying SourceLocation.

Note that while the end column is more correct than it was previously, it
is not perfectly correct. It currently points to the beginning of the last
token of the computation rather than the end of that token. We will
attempt to improve this with a followup commit.