### PR TITLE
PIX: Use DebugLoc for filenames instead of file list

### DIFF
--- a/lib/DxilDia/DxcPixDxilDebugInfo.cpp
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.cpp
@@ -164,20 +164,20 @@ static bool CompareFilenames(const wchar_t * l, const char * r)
 }
 
 dxil_debug_info::DxcPixDxilInstructionOffsets::DxcPixDxilInstructionOffsets(
-  IMalloc* pMalloc,
-  dxil_dia::Session* pSession,
-  const wchar_t* FileName,
+  IMalloc *pMalloc,
+  dxil_dia::Session *pSession,
+  const wchar_t *FileName,
   DWORD SourceLine,
-  DWORD SourceColumn)
+  DWORD SourceColumn) 
 {
   assert(SourceColumn == 0);
   (void)SourceColumn;
   auto Fn = pSession->DxilModuleRef().GetEntryFunction();
-  auto& Blocks = Fn->getBasicBlockList();
+  auto &Blocks = Fn->getBasicBlockList();
   for (auto& CurrentBlock : Blocks) {
     auto& Is = CurrentBlock.getInstList();
     for (auto& Inst : Is) {
-      auto& debugLoc = Inst.getDebugLoc();
+      auto & debugLoc = Inst.getDebugLoc();
       if (debugLoc)
       {
         unsigned line = debugLoc.getLine();


### PR DESCRIPTION
 This fix is for shaders (in particular those for materials from Unreal Engine) that feature #line directives.

In the UE case, for example, there is one source file called hlsl.hlsl, with many #line directives pointing to the original HLSL files from which the source was assembled via UE's material system.

At the start of shader debugging, all the filenames from DebugLoc are returned from code near here to PIX. Those filenames are the ones from the #line directives.

The previous code would iterate over source file names (which in the UE case would be just hlsl.hlsl), and fail to find the filename that PIX is now asking to find the instructions for.

Instead, we now gather the filenames from the DebugLoc. Note that the filename comparison is done after the line number comparison for performance's sake.