### PR TITLE
Remove LTO and ArgumentPromotion passes

### DIFF
--- a/include/llvm/LinkAllPasses.h
+++ b/include/llvm/LinkAllPasses.h
@@ -55,7 +55,7 @@ namespace {
       (void) llvm::createBitTrackingDCEPass();
       (void) llvm::createAliasAnalysisCounterPass();
       (void) llvm::createAliasDebugger();
-      (void) llvm::createArgumentPromotionPass();
+      // (void) llvm::createArgumentPromotionPass(); // HLSL Change - do not link
       (void) llvm::createAlignmentFromAssumptionsPass();
       (void) llvm::createBasicAliasAnalysisPass();
       (void) llvm::createLibCallAliasAnalysisPass(nullptr);

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,7 +7,7 @@ add_subdirectory(Bitcode)
 add_subdirectory(Transforms)
 add_subdirectory(Linker)
 add_subdirectory(Analysis)
-add_subdirectory(LTO)
+# add_subdirectory(LTO) # HLSL Change
 # add_subdirectory(MC) # HLSL Change
 # add_subdirectory(Object) # HLSL Change
 add_subdirectory(Option)

--- a/lib/LLVMBuild.txt
+++ b/lib/LLVMBuild.txt
@@ -28,7 +28,6 @@ subdirectories =
  Linker
  IR
  IRReader
- LTO
  MC
  Object
  Option
@@ -48,7 +47,7 @@ subdirectories =
  DxcBindingTable
  Miniz
 
-; HLSL Change: remove LibDriver, LineEditor, add HLSL, DxrtFallback, DXIL, DxilContainer, DxilDia, DxilPIXPasses, DxilRootSignature, DxcBindingTable
+; HLSL Change: remove LibDriver, LineEditor, add HLSL, DxrtFallback, DXIL, DxilContainer, DxilDia, DxilPIXPasses, DxilRootSignature, DxcBindingTable, LTO
 
 [component_0]
 type = Group

--- a/lib/Transforms/IPO/CMakeLists.txt
+++ b/lib/Transforms/IPO/CMakeLists.txt
@@ -1,5 +1,5 @@
+set(HLSL_IGNORE_SOURCES ArgumentPromotion.cpp)
 add_llvm_library(LLVMipo
-  ArgumentPromotion.cpp
   BarrierNoopPass.cpp
   ConstantMerge.cpp
   DeadArgumentElimination.cpp

--- a/lib/Transforms/IPO/IPO.cpp
+++ b/lib/Transforms/IPO/IPO.cpp
@@ -22,7 +22,9 @@
 using namespace llvm;
 
 void llvm::initializeIPO(PassRegistry &Registry) {
+#if 0  // HLSL Change Starts: Disable ArgPromotion
   initializeArgPromotionPass(Registry);
+#endif // HLSL Change Ends
   initializeConstantMergePass(Registry);
   initializeDAEPass(Registry);
   initializeDAHPass(Registry);
@@ -53,9 +55,11 @@ void LLVMInitializeIPO(LLVMPassRegistryRef R) {
   initializeIPO(*unwrap(R));
 }
 
+#if 0  // HLSL Change Starts: Disable ArgPromotion
 void LLVMAddArgumentPromotionPass(LLVMPassManagerRef PM) {
   unwrap(PM)->add(createArgumentPromotionPass());
 }
+#endif // HLSL Change Ends
 
 void LLVMAddConstantMergePass(LLVMPassManagerRef PM) {
   unwrap(PM)->add(createConstantMergePass());

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -443,8 +443,11 @@ void PassManagerBuilder::populateModulePassManager(
   }
   if (!DisableUnitAtATime)
     MPM.add(createFunctionAttrsPass());       // Set readonly/readnone attrs
+
+#if 0  // HLSL Change Starts: Disable ArgumentPromotion
   if (OptLevel > 2)
     MPM.add(createArgumentPromotionPass());   // Scalarize uninlined fn args
+#endif // HLSL Change Ends
 
   // Start of function pass.
   // Break up aggregate allocas, using SSAUpdater.
@@ -700,6 +703,7 @@ void PassManagerBuilder::populateModulePassManager(
   addExtensionsToPM(EP_OptimizerLast, MPM);
 }
 
+#if 0 // HLSL Change: No LTO
 void PassManagerBuilder::addLTOOptimizationPasses(legacy::PassManagerBase &PM) {
   // Provide AliasAnalysis services for optimizations.
   addInitialAliasAnalysisPasses(PM);
@@ -834,6 +838,7 @@ void PassManagerBuilder::populateLTOPassManager(legacy::PassManagerBase &PM) {
   if (VerifyOutput)
     PM.add(createVerifierPass());
 }
+#endif
 
 inline PassManagerBuilder *unwrap(LLVMPassManagerBuilderRef P) {
     return reinterpret_cast<PassManagerBuilder*>(P);
@@ -910,6 +915,7 @@ LLVMPassManagerBuilderPopulateModulePassManager(LLVMPassManagerBuilderRef PMB,
   Builder->populateModulePassManager(*MPM);
 }
 
+#if 0 // HLSL Change: No LTO
 void LLVMPassManagerBuilderPopulateLTOPassManager(LLVMPassManagerBuilderRef PMB,
                                                   LLVMPassManagerRef PM,
                                                   LLVMBool Internalize,
@@ -924,3 +930,4 @@ void LLVMPassManagerBuilderPopulateLTOPassManager(LLVMPassManagerBuilderRef PMB,
 
   Builder->populateLTOPassManager(*LPM);
 }
+#endif

--- a/tools/LLVMBuild.txt
+++ b/tools/LLVMBuild.txt
@@ -28,7 +28,6 @@ subdirectories =
  llvm-dwarfdump
  llvm-extract
  llvm-link
- llvm-lto
  llvm-mc
  llvm-mcmarkup
  llvm-nm
@@ -46,4 +45,4 @@ type = Group
 name = Tools
 parent = $ROOT
 
-; HLSL Changes: remove bugpoint, llvm-ar, llvm-jitlistener
+; HLSL Changes: remove bugpoint, llvm-ar, llvm-jitlistener, llvm-lto

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -29,7 +29,7 @@ set(LLVM_LINK_COMPONENTS
 #  libdriver
 #  lineeditor
   linker
-  lto
+#  lto
 #  mirparser # no support for LLVM codegen
   mssupport
 #  object # no support for object files (coff, elf)

--- a/tools/clang/tools/dxrfallbackcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxrfallbackcompiler/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LLVM_LINK_COMPONENTS
 #  libdriver
 #  lineeditor
   linker
-  lto
+#  lto
 #  mirparser # no support for LLVM codegen
   mssupport
 #  object # no support for object files (coff, elf)

--- a/tools/clang/unittests/DxrFallback/CMakeLists.txt
+++ b/tools/clang/unittests/DxrFallback/CMakeLists.txt
@@ -15,7 +15,7 @@ set(LLVM_LINK_COMPONENTS
   ipo
   irreader
   linker
-  lto
+#  lto
   mssupport
   option
   profiledata

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -119,9 +119,11 @@ static cl::opt<bool>
 DisableOptimizations("disable-opt",
                      cl::desc("Do not run any optimization passes"));
 
+#if 0  // HLSL Change Starts: Disable LTO for DXIL
 static cl::opt<bool>
 StandardLinkOpts("std-link-opts",
                  cl::desc("Include the standard link time optimizations"));
+#endif // HLSL Change Ends
 
 static cl::opt<bool>
 OptLevelO1("O1",
@@ -246,6 +248,7 @@ static void AddOptimizationPasses(legacy::PassManagerBase &MPM,
   Builder.populateModulePassManager(MPM);
 }
 
+#if 0  // HLSL Change Starts: Disable LTO for DXIL
 static void AddStandardLinkPasses(legacy::PassManagerBase &PM) {
   PassManagerBuilder Builder;
   Builder.VerifyInput = true;
@@ -256,6 +259,7 @@ static void AddStandardLinkPasses(legacy::PassManagerBase &PM) {
     Builder.Inliner = createFunctionInliningPass();
   Builder.populateLTOPassManager(PM);
 }
+#endif // HLSL Change Ends
 
 //===----------------------------------------------------------------------===//
 // CodeGen-related helper functions.
@@ -514,11 +518,13 @@ int __cdecl main(int argc, char **argv) {
 
   // Create a new optimization pass for each one specified on the command line
   for (unsigned i = 0; i < PassList.size(); ++i) {
+#if 0  // HLSL Change Starts: Disable LTO for DXIL
     if (StandardLinkOpts &&
         StandardLinkOpts.getPosition() < PassList.getPosition(i)) {
       AddStandardLinkPasses(Passes);
       StandardLinkOpts = false;
     }
+#endif // HLSL Change Ends
 
     if (OptLevelO1 && OptLevelO1.getPosition() < PassList.getPosition(i)) {
       AddOptimizationPasses(Passes, *FPasses, 1, 0);
@@ -587,10 +593,12 @@ int __cdecl main(int argc, char **argv) {
           createPrintModulePass(errs(), "", PreserveAssemblyUseListOrder));
   }
 
+#if 0  // HLSL Change Starts: Disable LTO for DXIL
   if (StandardLinkOpts) {
     AddStandardLinkPasses(Passes);
     StandardLinkOpts = false;
   }
+#endif // HLSL Change Ends
 
   if (OptLevelO1)
     AddOptimizationPasses(Passes, *FPasses, 1, 0);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2158,8 +2158,8 @@ class db_dxil(object):
         add_pass('instcombine', 'InstructionCombiningPass', 'Combine redundant instructions', [])
         add_pass('prune-eh', 'PruneEH', 'Remove unused exception handling info', [])
         add_pass('functionattrs', 'FunctionAttrs', 'Deduce function attributes', [])
-        add_pass('argpromotion', 'ArgPromotion', "Promote 'by reference' arguments to scalars", [
-            {'n':'maxElements', 't':'unsigned', 'c':1}])
+        # add_pass('argpromotion', 'ArgPromotion', "Promote 'by reference' arguments to scalars", [
+        #     {'n':'maxElements', 't':'unsigned', 'c':1}])
         add_pass('jump-threading', 'JumpThreading', 'Jump Threading', [
             {'n':'Threshold', 't':'int', 'c':1},
             {'n':'jump-threading-threshold', 'i':'BBDuplicateThreshold', 't':'unsigned', 'd':'Max block size to duplicate for jump threading'}])


### PR DESCRIPTION
LTO was unused, and ArgumentPromotion would not have any effect on DXIL
until you use noinline, and it might decompose HLSL/DXIL objects, which
could break things.