### PR TITLE
[NFC] HLSL doesn't really support digraphs

### DIFF
--- a/tools/clang/include/clang/Frontend/LangStandards.def
+++ b/tools/clang/include/clang/Frontend/LangStandards.def
@@ -134,7 +134,7 @@ LANGSTANDARD(gnucxx1z, "gnu++1z",
 // HLSL Change: HLSL Language standard declaration
 LANGSTANDARD(hlsl, "hlsl",
              "HLSL",
-             LineComment | CPlusPlus | Digraphs)
+             LineComment | CPlusPlus )
 
 // OpenCL
 LANGSTANDARD(opencl, "cl",


### PR DESCRIPTION
Digraphs are support in C for non-ASCII conforming keyboards. Pretty
sure we don't really need that, and it doesn't work anyways.