### PR TITLE
[HLSL21] Use C++ for loop scoping rules #584

### DIFF
--- a/tools/clang/lib/Parse/ParseStmt.cpp
+++ b/tools/clang/lib/Parse/ParseStmt.cpp
@@ -1582,7 +1582,7 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc) {
     ScopeFlags = Scope::DeclScope | Scope::ControlScope;
 
   // HLSL Change Starts - leak declarations in for control parts into outer scope
-  if (getLangOpts().HLSLVersion < 2020) {
+  if (getLangOpts().HLSLVersion < 2021) {
     ScopeFlags = Scope::ForDeclScope;
   }
   // HLSL Change Ends

--- a/tools/clang/lib/Parse/ParseStmt.cpp
+++ b/tools/clang/lib/Parse/ParseStmt.cpp
@@ -1582,7 +1582,7 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc) {
     ScopeFlags = Scope::DeclScope | Scope::ControlScope;
 
   // HLSL Change Starts - leak declarations in for control parts into outer scope
-  if (getLangOpts().HLSL) {
+  if (getLangOpts().HLSLVersion < 2020) {
     ScopeFlags = Scope::ForDeclScope;
   }
   // HLSL Change Ends

--- a/tools/clang/test/HLSL/loop-induction-scoping-2021.hlsl
+++ b/tools/clang/test/HLSL/loop-induction-scoping-2021.hlsl
@@ -1,0 +1,22 @@
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify -HV 2021 %s
+
+uint g_count1;
+uint g_count2;
+Buffer<float4> Things;
+
+float4 main() : SV_Target
+{
+	float4 data=0;
+	for( uint i=0; i<g_count1; i++ )
+	{
+		data += Things[i];
+	}
+
+  // not-expected-warning@+1:{{redefinition of 'i'}}
+	for( uint i=0; i<g_count2; i++ )
+	{
+		data += Things[g_count1+i];
+	}
+
+	return data;
+}


### PR DESCRIPTION
This should resolve #584 by adopting C++ for loop scoping rules for
HLSL 2021.