### PR TITLE
(Cherry-pick) PIX: Use DebugLoc for filenames instead of file list (#4077)

### DIFF
--- a/lib/DxilDia/DxcPixDxilDebugInfo.cpp
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.cpp
@@ -172,32 +172,24 @@ dxil_debug_info::DxcPixDxilInstructionOffsets::DxcPixDxilInstructionOffsets(
 {
   assert(SourceColumn == 0);
   (void)SourceColumn;
-
-  auto files = pSession->Contents()->operands();
-  for (const auto& file : files)
-  {
-    auto candidateFilename = llvm::dyn_cast<llvm::MDString>(file->getOperand(0))
-        ->getString();
-
-    if (CompareFilenames(FileName, candidateFilename.str().c_str()))
-    {
-
-      auto Fn = pSession->DxilModuleRef().GetEntryFunction();
-      auto &Blocks = Fn->getBasicBlockList();
-      for (auto& CurrentBlock : Blocks) {
-        auto& Is = CurrentBlock.getInstList();
-        for (auto& Inst : Is) {
-          auto & debugLoc = Inst.getDebugLoc();
-          if (debugLoc)
+  auto Fn = pSession->DxilModuleRef().GetEntryFunction();
+  auto &Blocks = Fn->getBasicBlockList();
+  for (auto& CurrentBlock : Blocks) {
+    auto& Is = CurrentBlock.getInstList();
+    for (auto& Inst : Is) {
+      auto & debugLoc = Inst.getDebugLoc();
+      if (debugLoc)
+      {
+        unsigned line = debugLoc.getLine();
+        if (line == SourceLine)
+        {
+          auto file = debugLoc.get()->getFilename();
+          if (CompareFilenames(FileName, file.str().c_str()))
           {
-            unsigned line = debugLoc.getLine();
-            if (line == SourceLine)
+            std::uint32_t InstructionNumber;
+            if (pix_dxil::PixDxilInstNum::FromInst(&Inst, &InstructionNumber))
             {
-              std::uint32_t InstructionNumber;
-              if (pix_dxil::PixDxilInstNum::FromInst(&Inst, &InstructionNumber))
-              {
-                m_offsets.push_back(InstructionNumber);
-              }
+              m_offsets.push_back(InstructionNumber);
             }
           }
         }


### PR DESCRIPTION
This fix is for shaders (in particular those for materials from Unreal Engine) that feature #line directives.

In the UE case, for example, there is one source file called hlsl.hlsl, with many #line directives pointing to the original HLSL files from which the source was assembled via UE's material system.

At the start of shader debugging, all the filenames from DebugLoc are returned from code near here to PIX. Those filenames are the ones from the #line directives.

The previous code would iterate over source file names (which in the UE case would be just hlsl.hlsl), and fail to find the filename that PIX is now asking to find the instructions for.

Instead, we now gather the filenames from the DebugLoc. Note that the filename comparison is done after the line number comparison for performance's sake.