### PR TITLE
Propagate ParameterModifiers in templates

### DIFF
--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -1254,10 +1254,12 @@ public:
   /// \returns A suitable function type, if there are no errors. The
   /// unqualified type will always be a FunctionProtoType.
   /// Otherwise, returns a NULL type.
-  QualType BuildFunctionType(QualType T,
-                             MutableArrayRef<QualType> ParamTypes,
+  // HLSL Change - FIX - We should move param mods to parameter QualTypes
+  QualType BuildFunctionType(QualType T, MutableArrayRef<QualType> ParamTypes,
                              SourceLocation Loc, DeclarationName Entity,
-                             const FunctionProtoType::ExtProtoInfo &EPI);
+                             const FunctionProtoType::ExtProtoInfo &EPI,
+                             ArrayRef<hlsl::ParameterModifier> ParamMods);
+  // HLSL Change - End
 
   QualType BuildMemberPointerType(QualType T, QualType Class,
                                   SourceLocation Loc,

--- a/tools/clang/lib/Sema/SemaTemplateDeduction.cpp
+++ b/tools/clang/lib/Sema/SemaTemplateDeduction.cpp
@@ -2605,10 +2605,12 @@ Sema::SubstituteExplicitTemplateArguments(
     return TDK_SubstitutionFailure;
 
   if (FunctionType) {
-    *FunctionType = BuildFunctionType(ResultType, ParamTypes,
-                                      Function->getLocation(),
-                                      Function->getDeclName(),
-                                      Proto->getExtProtoInfo());
+    // HLSL Change - FIX - We should move param mods to parameter QualTypes
+    *FunctionType = BuildFunctionType(
+        ResultType, ParamTypes, Function->getLocation(),
+        Function->getDeclName(), Proto->getExtProtoInfo(),
+        cast<FunctionProtoType>(Function->getType())->getParamMods());
+    // HLSL Change - End
     if (FunctionType->isNull() || Trap.hasErrorOccurred())
       return TDK_SubstitutionFailure;
   }

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -2240,10 +2240,13 @@ bool Sema::CheckFunctionReturnType(QualType T, SourceLocation Loc) {
   return false;
 }
 
+// HLSL Change - FIX - We should move param mods to parameter QualTypes
 QualType Sema::BuildFunctionType(QualType T,
                                  MutableArrayRef<QualType> ParamTypes,
                                  SourceLocation Loc, DeclarationName Entity,
-                                 const FunctionProtoType::ExtProtoInfo &EPI) {
+                                 const FunctionProtoType::ExtProtoInfo &EPI,
+                                 ArrayRef<hlsl::ParameterModifier> ParamMods) {
+// HLSL Change - End
   bool Invalid = false;
 
   Invalid |= CheckFunctionReturnType(T, Loc);
@@ -2267,8 +2270,9 @@ QualType Sema::BuildFunctionType(QualType T,
   if (Invalid)
     return QualType();
 
-  // HLSL Change - FIX - current contexts specialize templates with always-in parameters
-  return Context.getFunctionType(T, ParamTypes, EPI, None);
+  // HLSL Change - FIX - We should move param mods to parameter QualTypes
+  return Context.getFunctionType(T, ParamTypes, EPI, ParamMods);
+  // HLSL Change End
 }
 
 /// \brief Build a member pointer type \c T Class::*.

--- a/tools/clang/lib/Sema/TreeTransform.h
+++ b/tools/clang/lib/Sema/TreeTransform.h
@@ -793,9 +793,12 @@ public:
   ///
   /// By default, performs semantic analysis when building the function type.
   /// Subclasses may override this routine to provide different behavior.
-  QualType RebuildFunctionProtoType(QualType T,
-                                    MutableArrayRef<QualType> ParamTypes,
-                                    const FunctionProtoType::ExtProtoInfo &EPI);
+  // HLSL Change - FIX - We should move param mods to parameter QualTypes
+  QualType
+  RebuildFunctionProtoType(QualType T, MutableArrayRef<QualType> ParamTypes,
+                           ArrayRef<hlsl::ParameterModifier> ParamMods,
+                           const FunctionProtoType::ExtProtoInfo &EPI);
+  // HLSL Change - End
 
   /// \brief Build a new unprototyped function type.
   QualType RebuildFunctionNoProtoType(QualType ResultType);
@@ -4745,7 +4748,10 @@ QualType TreeTransform<Derived>::TransformFunctionProtoType(
       T->getNumParams() != ParamTypes.size() ||
       !std::equal(T->param_type_begin(), T->param_type_end(),
                   ParamTypes.begin()) || EPIChanged) {
-    Result = getDerived().RebuildFunctionProtoType(ResultType, ParamTypes, EPI);
+    // HLSL Change - FIX - We should move param mods to parameter QualTypes
+    Result = getDerived().RebuildFunctionProtoType(ResultType, ParamTypes,
+                                                   T->getParamMods(), EPI);
+    // HLSL Change - End
     if (Result.isNull())
       return QualType();
   }
@@ -10631,9 +10637,11 @@ TreeTransform<Derived>::TransformBlockExpr(BlockExpr *E) {
   QualType exprResultType =
       getDerived().TransformType(exprFunctionType->getReturnType());
 
-  QualType functionType =
-    getDerived().RebuildFunctionProtoType(exprResultType, paramTypes,
-                                          exprFunctionType->getExtProtoInfo());
+  // HLSL Change - FIX - We should move param mods to parameter QualTypes
+  QualType functionType = getDerived().RebuildFunctionProtoType(
+      exprResultType, paramTypes, exprFunctionType->getParamMods(),
+      exprFunctionType->getExtProtoInfo());
+  // HLSL Change - End
   blockScope->FunctionType = functionType;
 
   // Set the parameters on the block decl.
@@ -10873,16 +10881,19 @@ TreeTransform<Derived>::RebuildDependentSizedExtVectorType(QualType ElementType,
   return SemaRef.BuildExtVectorType(ElementType, SizeExpr, AttributeLoc);
 }
 
+// HLSL Change - FIX - We should move param mods to parameter QualTypes
 template<typename Derived>
 QualType TreeTransform<Derived>::RebuildFunctionProtoType(
     QualType T,
     MutableArrayRef<QualType> ParamTypes,
+    ArrayRef<hlsl::ParameterModifier> ParamMods,
     const FunctionProtoType::ExtProtoInfo &EPI) {
   return SemaRef.BuildFunctionType(T, ParamTypes,
                                    getDerived().getBaseLocation(),
                                    getDerived().getBaseEntity(),
-                                   EPI);
+                                   EPI, ParamMods);
 }
+// HLSL Change - End
 
 template<typename Derived>
 QualType TreeTransform<Derived>::RebuildFunctionNoProtoType(QualType T) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/template-param-modifiers.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/template-param-modifiers.hlsl
@@ -1,0 +1,61 @@
+// RUN: %dxc -E main -T cs_6_0 -enable-templates -ast-dump %s | FileCheck %s
+template<typename T>
+void apply(in T X, inout T Y, out T Z);
+
+template<>
+void apply<int>(in int X, inout int Y, out int Z){
+  Z = (Y += X);
+}
+
+template<>
+void apply<float3>(in float3 X, inout float3 Y, out float3 Z) {
+  Y += X;
+  Z = Y + X;
+}
+
+[numthreads(1,1,1)]
+void main() {
+  int X = 1, Y = 2;
+  int Z;
+  apply(X, Y, Z);
+
+  float3 V = {0.0, 0.0, 0.0};
+  float3 W = {0.0, 1.0, 1.0};
+  float3 T;
+  apply(V, W, T);
+}
+
+
+// CHECK:      FunctionTemplateDecl
+// CHECK-NEXT: | |-TemplateTypeParmDecl 0x{{[0-9a-fA-F]+}} <line:2:10, col:19> col:19 referenced typename T
+// CHECK-NEXT: | |-FunctionDecl 0x{{[0-9a-fA-F]+}} <line:3:1, col:38> col:6 apply 'void (T, T &__restrict, T &__restrict)'
+// CHECK-NEXT: | | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:12, col:17> col:17 X 'T'
+// CHECK-NEXT: | | | `-HLSLInAttr 0x{{[0-9a-fA-F]+}} <col:12>
+// CHECK-NEXT: | | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:20, col:28> col:28 Y 'T &__restrict'
+// CHECK-NEXT: | | | `-HLSLInOutAttr 0x{{[0-9a-fA-F]+}} <col:20>
+// CHECK-NEXT: | | `-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:31, col:37> col:37 Z 'T &__restrict'
+// CHECK-NEXT: | |   `-HLSLOutAttr 0x{{[0-9a-fA-F]+}} <col:31>
+// CHECK-NEXT: | |-Function 0x{{[0-9a-fA-F]+}} 'apply' 'void (int, int &__restrict, int &__restrict)'
+// CHECK-NEXT: | `-Function 0x{{[0-9a-fA-F]+}} 'apply' 'void (float3, float3 &__restrict, float3 &__restrict)'
+// CHECK-NEXT: |-FunctionDecl 0x{{[0-9a-fA-F]+}} prev 0x{{[0-9a-fA-F]+}} <line:5:1, line:8:1> line:6:6 used apply 'void (int, int &__restrict, int &__restrict)'
+// CHECK-NEXT: | |-TemplateArgument type 'int'
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:17, col:24> col:24 used X 'int'
+// CHECK-NEXT: | | `-HLSLInAttr 0x{{[0-9a-fA-F]+}} <col:17>
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:27, col:37> col:37 used Y 'int &__restrict'
+// CHECK-NEXT: | | `-HLSLInOutAttr 0x{{[0-9a-fA-F]+}} <col:27>
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:40, col:48> col:48 used Z 'int &__restrict'
+// CHECK-NEXT: | | `-HLSLOutAttr 0x{{[0-9a-fA-F]+}} <col:40>
+
+// CHECK:      |-FunctionDecl 0x{{[0-9a-fA-F]+}} prev 0x{{[0-9a-fA-F]+}} <line:10:1, line:14:1> line:11:6 used apply 'void (float3, float3 &__restrict, float3 &__restrict)'
+// CHECK-NEXT: | |-TemplateArgument type 'vector<float, 3>'
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:20, col:30> col:30 used X 'float3':'vector<float, 3>'
+// CHECK-NEXT: | | `-HLSLInAttr 0x{{[0-9a-fA-F]+}} <col:20>
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:33, col:46> col:46 used Y 'float3 &__restrict'
+// CHECK-NEXT: | | `-HLSLInOutAttr 0x{{[0-9a-fA-F]+}} <col:33>
+// CHECK-NEXT: | |-ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:49, col:60> col:60 used Z 'float3 &__restrict'
+// CHECK-NEXT: | | `-HLSLOutAttr 0x{{[0-9a-fA-F]+}} <col:49>
+
+// CHECK:      | |-CallExpr 0x{{[0-9a-fA-F]+}} <line:20:3, col:16> 'void'
+// CHECK-NEXT: | | |-ImplicitCastExpr 0x{{[0-9a-fA-F]+}} <col:3> 'void (*)(int, int &__restrict, int &__restrict)' <FunctionToPointerDecay>
+// CHECK:      | `-CallExpr 0x{{[0-9a-fA-F]+}} <line:25:3, col:16> 'void'
+// CHECK-NEXT: |   |-ImplicitCastExpr 0x{{[0-9a-fA-F]+}} <col:3> 'void (*)(float3, float3 &__restrict, float3 &__restrict)' <FunctionToPointerDecay>


### PR DESCRIPTION
This addresses two issues that blocked template instantiation of
functions with ParameterModifiers.

The first issue is that template deduction was not propagating
ParameterModifiers, but since the modifiers do influence overload
resolution, matches were never being found.

The second issue is that template instantiation was not propagating
ParameterModifiers, so even if dedution managed to succeed, it would
produce an instantiaton that wouldn't match.

The silly issue that still remains after this is that our
ParameterModifiers sholud be attached to the QualType for the
parameters. We already bake in the effect of the ParameterModifier to
the QualType, so we were getting overload mismatches on identical
functions. If we move the ParameterModifiers to the QualTypes similar
to other type qualifiers, we can actually get rid of this patch.

This resolves #4084