### PR TITLE
[HLSL2021] Fix template parameter for buffer types

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4830,6 +4830,17 @@ public:
               << argType;
           return true;
         }
+        if (auto *TST = dyn_cast<TemplateSpecializationType>(argType)) {
+          // This is a bit of a special case we need to handle. Because the
+          // buffer types don't use their template parameter in a way that would
+          // force instantiation, we need to force specialization here.
+          GetOrCreateTemplateSpecialization(
+              *m_context, *m_sema,
+              cast<ClassTemplateDecl>(
+                  TST->getTemplateName().getAsTemplateDecl()),
+              llvm::ArrayRef<TemplateArgument>(TST->getArgs(),
+                                               TST->getNumArgs()));
+        }
         if (const RecordType* recordType = argType->getAsStructureType()) {
           if (!recordType->getDecl()->isCompleteDefinition()) {
             m_sema->Diag(argSrcLoc, diag::err_typecheck_decl_incomplete_type)

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/InstantiateBufferParamTypes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/InstantiateBufferParamTypes.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T cs_6_0 -ast-dump -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -ast-dump -HV 2021 %s | FileCheck %s
+struct Foo { float f;};
+template <typename T> struct Wrap { T value; };
+ConstantBuffer<Wrap<Foo> >CB;
+
+[numthreads(1,1,1)]
+void main() {
+}
+
+// CHECK: ClassTemplateSpecializationDecl 0x{{[0-9a-zA-Z]+}} <col:1, col:46> col:30 struct Wrap definition
+// CHECK-NEXT: TemplateArgument type 'Foo'
+// CHECK-NEXT: CXXRecordDecl 0x{{[0-9a-zA-Z]+}} prev 0x{{[0-9a-zA-Z]+}} <col:23, col:30> col:30 implicit struct Wrap
+// CHECK-NEXT: `-FieldDecl 0x{{[0-9a-zA-Z]+}} <col:37, col:39> col:39 value 'Foo':'Foo'


### PR DESCRIPTION
This is a bit of an oddball situation caused by a two factors.

(1) We verify that template parameters for buffer types are complete
(2) The template expansion for the HLSL buffer types doesn't actually
require instantiation of the parameter type

We could, skip verification of template parameters, but doing so causes
the backend to crash because we need the buffer type expanded for code
generation. Skipping verification might work in some common cases, but
will fail if buffers are unused, and if nothing else forces the
instantiation.

The safe approach is to force instantiation ourselves, and that's what
this change does. Basically if the parameter of a buffer type is a
template specialization, we force the specialization to instantiate by
creating the specialization in the AST.

This allows us to continue verifing that the types are complete,
because after instantiation the template type is complete.