### PR TITLE
Extend encoding option to specify source encoding

### DIFF
--- a/include/dxc/Support/FileIOHelper.h
+++ b/include/dxc/Support/FileIOHelper.h
@@ -218,7 +218,8 @@ DxcCreateBlobWithEncodingOnMallocCopy(
   _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) throw();
 
 HRESULT DxcGetBlobAsUtf8(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
-                         _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) throw();
+                         _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding,
+                         UINT32 defaultCodePage = CP_ACP) throw();
 HRESULT
 DxcGetBlobAsUtf16(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
                   _COM_Outptr_ IDxcBlobUtf16 **pBlobEncoding) throw();

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -273,7 +273,7 @@ def default_linkage : Separate<["-", "/"], "default-linkage">, Group<hlslcomp_Gr
 def precise_output : Separate<["-", "/"], "precise-output">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
     HelpText<"Mark output semantic as precise">;
 def encoding : Separate<["-", "/"], "encoding">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,
-  HelpText<"Set default encoding for text outputs (utf8|utf16) default=utf8">;
+  HelpText<"Set default encoding for source inputs and text outputs (utf8|utf16) default=utf8">;
 def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/include/dxc/Support/dxcfilesystem.h
+++ b/include/dxc/Support/dxcfilesystem.h
@@ -46,7 +46,8 @@ public:
 
 DxcArgsFileSystem *
 CreateDxcArgsFileSystem(_In_ IDxcBlobUtf8 *pSource, _In_ LPCWSTR pSourceName,
-                        _In_opt_ IDxcIncludeHandler *pIncludeHandler);
+                        _In_opt_ IDxcIncludeHandler *pIncludeHandler,
+                        _In_opt_ UINT32 defaultCodePage = CP_ACP);
 
 void MakeAbsoluteOrCurDirRelativeW(LPCWSTR &Path, std::wstring &PathStorage);
 

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -756,7 +756,7 @@ HRESULT DxcCreateBlobEncodingFromBlob(
     }
     if (encodingKnown) {
       if (TryCreateBlobUtfFromBlob(pFromBlob, codePage, pMalloc,
-                                   +ppBlobEncoding)) {
+                                   ppBlobEncoding)) {
         return S_OK;
       }
       IFR(InternalDxcBlobEncoding::CreateFromBlob(

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -926,7 +926,7 @@ DxcCreateBlobWithEncodingOnMallocCopy(IMalloc *pIMalloc, LPCVOID pText, UINT32 s
   return DxcCreateBlob(pText, size, false, true, true, codePage, pIMalloc, ppBlobEncoding);
 }
 
-_Use_decl_annotations_ 
+_Use_decl_annotations_
 HRESULT
 DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc,
                  IDxcBlobUtf8 **pBlobEncoding, UINT32 defaultCodePage) throw() {

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -474,7 +474,9 @@ static HRESULT CodePageBufferToUtf8(UINT32 codePage, LPCVOID bufferPointer,
   UINT32 utf16CharCount = 0;
   const WCHAR *utf16Chars = nullptr;
   if (codePage == CP_UTF16) {
-    DXASSERT(IsSizeWcharAligned(bufferSize), "otherwise, odd buffer size with UTF-16");
+    if (!IsSizeWcharAligned(bufferSize))
+      throw hlsl::Exception(DXC_E_STRING_ENCODING_FAILED,
+                            "Error in encoding argument specified");
     utf16Chars = (const WCHAR*)bufferPointer;
     utf16CharCount = bufferSize / sizeof(wchar_t);
   } else if (bufferSize) {
@@ -753,6 +755,10 @@ HRESULT DxcCreateBlobEncodingFromBlob(
       return S_OK;
     }
     if (encodingKnown) {
+      if (TryCreateBlobUtfFromBlob(pFromBlob, codePage, pMalloc,
+                                   +ppBlobEncoding)) {
+        return S_OK;
+      }
       IFR(InternalDxcBlobEncoding::CreateFromBlob(
           pFromBlob, pMalloc, true, codePage, &internalEncoding));
       *ppBlobEncoding = internalEncoding;
@@ -920,8 +926,10 @@ DxcCreateBlobWithEncodingOnMallocCopy(IMalloc *pIMalloc, LPCVOID pText, UINT32 s
   return DxcCreateBlob(pText, size, false, true, true, codePage, pIMalloc, ppBlobEncoding);
 }
 
-_Use_decl_annotations_
-HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf8 **pBlobEncoding) throw() {
+_Use_decl_annotations_ 
+HRESULT
+DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc,
+                 IDxcBlobUtf8 **pBlobEncoding, UINT32 defaultCodePage) throw() {
   IFRBOOL(pBlob, E_POINTER);
   IFRBOOL(pBlobEncoding, E_POINTER);
   *pBlobEncoding = nullptr;
@@ -949,6 +957,10 @@ HRESULT DxcGetBlobAsUtf8(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf8 **pBlob
     // BOM exists, adjust pointer and size to strip.
     bufferPointer += bomSize;
     blobLen -= bomSize;
+    // If no BOM, use encoding option if specified
+    if (codePage == CP_ACP && defaultCodePage != CP_ACP) {
+      codePage = defaultCodePage;
+    }
   }
 
   if (!pMalloc)
@@ -1057,8 +1069,8 @@ HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf16 **pBl
 
   // Reuse or copy the underlying blob depending on null-termination
   if (codePage == CP_UTF16) {
-    DXASSERT(IsSizeWcharAligned(blobLen),
-             "otherwise, UTF-16 blob size not evenly divisible by 2");
+    if (!IsSizeWcharAligned(blobLen))
+      return DXC_E_STRING_ENCODING_FAILED;
     utf16CharCount = blobLen / sizeof(wchar_t);
     if (IsBufferNullTerminated(bufferPointer, blobLen, CP_UTF16)) {
       // Already null-terminated, reference other blob's memory

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -233,6 +233,7 @@ private:
   CComPtr<IDxcIncludeHandler> m_includeLoader;
   std::vector<std::wstring> m_searchEntries;
   bool m_bDisplayIncludeProcess;
+  UINT32 m_DefaultCodePage;
 
   // Some constraints of the current design: opening the same file twice
   // will return the same handle/structure, and thus the same file pointer.
@@ -299,7 +300,8 @@ private:
       }
       if (fileBlob.p != nullptr) {
         CComPtr<IDxcBlobUtf8> fileBlobUtf8;
-        if (FAILED(hlsl::DxcGetBlobAsUtf8(fileBlob, DxcGetThreadMallocNoRef(), &fileBlobUtf8))) {
+        if (FAILED(hlsl::DxcGetBlobAsUtf8(fileBlob, DxcGetThreadMallocNoRef(),
+                                          &fileBlobUtf8, m_DefaultCodePage))) {
           return ERROR_UNHANDLED_EXCEPTION;
         }
         CComPtr<IStream> fileStream;
@@ -338,9 +340,11 @@ private:
   }
 
 public:
-  DxcArgsFileSystemImpl(_In_ IDxcBlobUtf8 *pSource, LPCWSTR pSourceName, _In_opt_ IDxcIncludeHandler* pHandler)
-      : m_pSource(pSource), m_pSourceName(pSourceName), m_pOutputStreamName(nullptr),
-        m_includeLoader(pHandler), m_bDisplayIncludeProcess(false) {
+  DxcArgsFileSystemImpl(_In_ IDxcBlobUtf8 *pSource, LPCWSTR pSourceName,
+                        _In_opt_ IDxcIncludeHandler *pHandler,
+                        _In_opt_ UINT32 defaultCodePage)
+      : m_pSource(pSource), m_pSourceName(pSourceName), m_pOutputStreamName(nullptr), m_includeLoader(pHandler),
+        m_bDisplayIncludeProcess(false), m_DefaultCodePage(defaultCodePage) {
     MakeAbsoluteOrCurDirRelativeW(m_pSourceName, m_pAbsSourceName);
     IFT(CreateReadOnlyBlobStream(m_pSource, &m_pSourceStream));
     m_includedFiles.push_back(IncludedFile(std::wstring(m_pSourceName), m_pSource, m_pSourceStream));
@@ -827,8 +831,10 @@ namespace dxcutil {
 DxcArgsFileSystem *
 CreateDxcArgsFileSystem(
     _In_ IDxcBlobUtf8 *pSource, _In_ LPCWSTR pSourceName,
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler) {
-  return new DxcArgsFileSystemImpl(pSource, pSourceName, pIncludeHandler);
+                        _In_opt_ IDxcIncludeHandler *pIncludeHandler,
+                        _In_opt_ UINT32 defaultCodePage) {
+  return new DxcArgsFileSystemImpl(pSource, pSourceName, pIncludeHandler,
+                                   defaultCodePage);
 }
 
 } // namespace dxcutil

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -722,11 +722,13 @@ public:
 #endif // ENABLE_SPIRV_CODEGEN
 
       // Convert source code encoding
-      IFC(hlsl::DxcGetBlobAsUtf8(pSourceEncoding, m_pMalloc, &utf8Source));
+      IFC(hlsl::DxcGetBlobAsUtf8(pSourceEncoding, m_pMalloc, &utf8Source,
+                                 opts.DefaultTextCodePage));
 
       CComPtr<IDxcBlob> pOutputBlob;
-      dxcutil::DxcArgsFileSystem *msfPtr =
-        dxcutil::CreateDxcArgsFileSystem(utf8Source, pUtf16SourceName.m_psz, pIncludeHandler);
+      dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(
+          utf8Source, pUtf16SourceName.m_psz, pIncludeHandler,
+          opts.DefaultTextCodePage);
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
 
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2612,7 +2612,7 @@ void CompilerTest::TestEncodingImpl(const void *sourceData, size_t sourceSize, U
   CreateBlobPinned((const char *)sourceData, sourceSize, codePage,
                    &pSource);
   pInclude = new TestIncludeHandler(m_dllSupport);
-  pInclude->CallResults.emplace_back(includedData, includedSize, 0);
+  pInclude->CallResults.emplace_back(includedData, includedSize, CP_ACP);
 
   const WCHAR *pArgs[] = {L"-encoding",
                           encoding};


### PR DESCRIPTION
Extend the current text output `-encoding` option to also specify a default encoding for source files. 

Includes support for UTF-8 and UTF-16 encoded sources with and without BOMs. The default encoding, specified with the `-encoding` option, will be used for the main source file when there is no BOM and the DxcBuffer encoding is not specified. The default encoding will be used for included source files with no BOM.