### PR TITLE
[spirv] handle hull shader OutputPatch

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/hs.const.output-patch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/hs.const.output-patch.hlsl
@@ -10,23 +10,19 @@ struct HSPatchConstData {
   float4 constData : CONSTANTDATA;
 };
 
-// CHECK: OpDecorate %temp_var_hullMainRetVal Location 2
-
-// CHECK: %temp_var_hullMainRetVal = OpVariable %_ptr_Output__arr_HSCtrlPt_uint_3 Output
-// CHECK:        [[invoc_id:%\d+]] = OpLoad %uint %gl_InvocationID
-// CHECK:        [[HSResult:%\d+]] = OpFunctionCall %HSCtrlPt %src_main
-// CHECK:         [[OutCtrl:%\d+]] = OpAccessChain %_ptr_Output_HSCtrlPt %temp_var_hullMainRetVal [[invoc_id]]
-// CHECK:                            OpStore [[OutCtrl]] [[HSResult]]
+// CHECK: OpFunctionCall %HSPatchConstData %HSPatchConstantFunc %temp_var_hullMainRetVal
 
 HSPatchConstData HSPatchConstantFunc(const OutputPatch<HSCtrlPt, 3> input) {
   HSPatchConstData data;
 
-// CHECK: [[OutCtrl0:%\d+]] = OpAccessChain %_ptr_Output_v4float %temp_var_hullMainRetVal %uint_0 %int_0
+// CHECK: %input = OpFunctionParameter %_ptr_Function__arr_HSCtrlPt_uint_3
+
+// CHECK: [[OutCtrl0:%\d+]] = OpAccessChain %_ptr_Function_v4float %input %uint_0 %int_0
 // CHECK:   [[input0:%\d+]] = OpLoad %v4float [[OutCtrl0]]
-// CHECK: [[OutCtrl1:%\d+]] = OpAccessChain %_ptr_Output_v4float %temp_var_hullMainRetVal %uint_1 %int_0
+// CHECK: [[OutCtrl1:%\d+]] = OpAccessChain %_ptr_Function_v4float %input %uint_1 %int_0
 // CHECK:   [[input1:%\d+]] = OpLoad %v4float [[OutCtrl1]]
 // CHECK:      [[add:%\d+]] = OpFAdd %v4float [[input0]] [[input1]]
-// CHECK: [[OutCtrl2:%\d+]] = OpAccessChain %_ptr_Output_v4float %temp_var_hullMainRetVal %uint_2 %int_0
+// CHECK: [[OutCtrl2:%\d+]] = OpAccessChain %_ptr_Function_v4float %input %uint_2 %int_0
 // CHECK:   [[input2:%\d+]] = OpLoad %v4float [[OutCtrl2]]
 // CHECK:                     OpFAdd %v4float [[add]] [[input2]]
   data.constData = input[0].ctrlPt + input[1].ctrlPt + input[2].ctrlPt;

--- a/tools/clang/test/CodeGenSPIRV/hs.pcf.output-patch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/hs.pcf.output-patch.hlsl
@@ -5,23 +5,38 @@
 // Test: PCF takes the output (OutputPatch) of the main entry point function.
 
 
-// CHECK:             %_arr_BEZIER_CONTROL_POINT_uint_16 = OpTypeArray %BEZIER_CONTROL_POINT %uint_16
-// CHECK: %_ptr_Output__arr_BEZIER_CONTROL_POINT_uint_16 = OpTypePointer Output %_arr_BEZIER_CONTROL_POINT_uint_16
+// CHECK:             %_arr_BEZIER_CONTROL_POINT_uint_3 = OpTypeArray %BEZIER_CONTROL_POINT %uint_3
+// CHECK: %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_3 = OpTypePointer Function %_arr_BEZIER_CONTROL_POINT_uint_3
 // CHECK:                                 [[fType:%\d+]] = OpTypeFunction %HS_CONSTANT_DATA_OUTPUT
-// CHECK: %temp_var_hullMainRetVal = OpVariable %_ptr_Output__arr_BEZIER_CONTROL_POINT_uint_16 Output
 
 // CHECK:                    %main = OpFunction %void None {{%\d+}}
+// CHECK: %temp_var_hullMainRetVal = OpVariable %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_3 Function
 
-// CHECK:              [[id:%\d+]] = OpLoad %uint %gl_InvocationID
 // CHECK:      [[mainResult:%\d+]] = OpFunctionCall %BEZIER_CONTROL_POINT %src_main %param_var_ip %param_var_i %param_var_PatchID
-// CHECK:             [[loc:%\d+]] = OpAccessChain %_ptr_Output_BEZIER_CONTROL_POINT %temp_var_hullMainRetVal [[id]]
-// CHECK:                            OpStore [[loc]] [[mainResult]]
 
-// CHECK:                 {{%\d+}} = OpFunctionCall %HS_CONSTANT_DATA_OUTPUT %PCF
+// CHECK:      [[output_patch_0:%\d+]] = OpAccessChain %_ptr_Function_BEZIER_CONTROL_POINT %temp_var_hullMainRetVal %uint_0
+// CHECK:    [[output_patch_0_0:%\d+]] = OpAccessChain %_ptr_Function_v3float [[output_patch_0]] %uint_0
+// CHECK: [[out_var_BEZIERPOS_0:%\d+]] = OpAccessChain %_ptr_Output_v3float %out_var_BEZIERPOS %uint_0
+// CHECK:         [[BEZIERPOS_0:%\d+]] = OpLoad %v3float [[out_var_BEZIERPOS_0]]
+// CHECK:                                OpStore [[output_patch_0_0]] [[BEZIERPOS_0]]
+
+// CHECK:      [[output_patch_1:%\d+]] = OpAccessChain %_ptr_Function_BEZIER_CONTROL_POINT %temp_var_hullMainRetVal %uint_1
+// CHECK:    [[output_patch_1_0:%\d+]] = OpAccessChain %_ptr_Function_v3float [[output_patch_1]] %uint_0
+// CHECK: [[out_var_BEZIERPOS_1:%\d+]] = OpAccessChain %_ptr_Output_v3float %out_var_BEZIERPOS %uint_1
+// CHECK:         [[BEZIERPOS_1:%\d+]] = OpLoad %v3float [[out_var_BEZIERPOS_1]]
+// CHECK:                                OpStore [[output_patch_1_0]] [[BEZIERPOS_1]]
+
+// CHECK:      [[output_patch_2:%\d+]] = OpAccessChain %_ptr_Function_BEZIER_CONTROL_POINT %temp_var_hullMainRetVal %uint_2
+// CHECK:    [[output_patch_2_0:%\d+]] = OpAccessChain %_ptr_Function_v3float [[output_patch_2]] %uint_0
+// CHECK: [[out_var_BEZIERPOS_2:%\d+]] = OpAccessChain %_ptr_Output_v3float %out_var_BEZIERPOS %uint_2
+// CHECK:         [[BEZIERPOS_2:%\d+]] = OpLoad %v3float [[out_var_BEZIERPOS_2]]
+// CHECK:                                OpStore [[output_patch_2_0]] [[BEZIERPOS_2]]
+
+// CHECK:                 {{%\d+}} = OpFunctionCall %HS_CONSTANT_DATA_OUTPUT %PCF %temp_var_hullMainRetVal
 
 // CHECK:      %PCF = OpFunction %HS_CONSTANT_DATA_OUTPUT None [[fType]]
 
-HS_CONSTANT_DATA_OUTPUT PCF(OutputPatch<BEZIER_CONTROL_POINT, MAX_POINTS> op) {
+HS_CONSTANT_DATA_OUTPUT PCF(OutputPatch<BEZIER_CONTROL_POINT, 3> op) {
   HS_CONSTANT_DATA_OUTPUT Output;
   // Must initialize Edges and Inside; otherwise HLSL validation will fail.
   Output.Edges[0]  = 1.0;
@@ -36,9 +51,9 @@ HS_CONSTANT_DATA_OUTPUT PCF(OutputPatch<BEZIER_CONTROL_POINT, MAX_POINTS> op) {
 [domain("isoline")]
 [partitioning("fractional_odd")]
 [outputtopology("line")]
-[outputcontrolpoints(16)]
+[outputcontrolpoints(3)]
 [patchconstantfunc("PCF")]
-BEZIER_CONTROL_POINT main(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POINTS> ip, uint i : SV_OutputControlPointID, uint PatchID : SV_PrimitiveID) {
+BEZIER_CONTROL_POINT main(InputPatch<VS_CONTROL_POINT_OUTPUT, 3> ip, uint i : SV_OutputControlPointID, uint PatchID : SV_PrimitiveID) {
   VS_CONTROL_POINT_OUTPUT vsOutput;
   BEZIER_CONTROL_POINT result;
   result.vPosition = vsOutput.vPosition;

--- a/tools/clang/test/CodeGenSPIRV/method.input-output-patch.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.input-output-patch.access.hlsl
@@ -31,6 +31,7 @@ struct HS_CONSTANT_DATA_OUTPUT
 };
 
 HS_CONSTANT_DATA_OUTPUT PCF(OutputPatch<BEZIER_CONTROL_POINT, MAX_POINTS> op) {
+// CHECK: %op = OpFunctionParameter %_ptr_Function__arr_BEZIER_CONTROL_POINT_uint_16
   HS_CONSTANT_DATA_OUTPUT Output;
   // Must initialize Edges and Inside; otherwise HLSL validation will fail.
   Output.Edges[0]  = 1.0;
@@ -42,12 +43,12 @@ HS_CONSTANT_DATA_OUTPUT PCF(OutputPatch<BEZIER_CONTROL_POINT, MAX_POINTS> op) {
 
   uint x = 5;
 
-// CHECK:      [[op_1_loc:%\d+]] = OpAccessChain %_ptr_Output_v3float %temp_var_hullMainRetVal %uint_1 %int_0
+// CHECK:      [[op_1_loc:%\d+]] = OpAccessChain %_ptr_Function_v3float %op %uint_1 %int_0
 // CHECK-NEXT:          {{%\d+}} = OpLoad %v3float [[op_1_loc]]
   float3 out1pos = op[1].vPosition;
 
 // CHECK:             [[x:%\d+]] = OpLoad %uint %x
-// CHECK-NEXT: [[op_x_loc:%\d+]] = OpAccessChain %_ptr_Output_uint %temp_var_hullMainRetVal [[x]] %int_1
+// CHECK-NEXT: [[op_x_loc:%\d+]] = OpAccessChain %_ptr_Function_uint %op [[x]] %int_1
 // CHECK-NEXT:          {{%\d+}} = OpLoad %uint [[op_x_loc]]
   uint out5id = op[x].pointID;
 


### PR DESCRIPTION
The existing code creates a temporary variable with Output storage class
for the parameter with OutputPatch type for the patch constant
functions. However, this adds an additional output stage variable and
consumes more locations. In addition, it can also change the rendering
result depending on the driver.

This commit removes the additional output stage variable and use the
actual output stage variables for the argument passing for the
OutputPatch. This is correctly working because the output stage variable
keeps the output value for all invocation id and we can simply reuse it.

Fixes #2641