### PR TITLE
Fix dropping of DXIL metadata like nonuniform in mldst-motion

### DIFF
--- a/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
+++ b/lib/Transforms/Scalar/MergedLoadStoreMotion.cpp
@@ -90,6 +90,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/SSAUpdater.h"
+#include "llvm/Transforms/Utils/Local.h"
 #include <vector>
 using namespace llvm;
 
@@ -293,7 +294,7 @@ void MergedLoadStoreMotion::hoistInstruction(BasicBlock *BB,
 
   // Intersect optional metadata.
   HoistCand->intersectOptionalDataWith(ElseInst);
-  HoistCand->dropUnknownMetadata();
+  combineMetadata(HoistCand, ElseInst, None);     // HLSL Change: Preserve DXIL metadata
 
   // Prepend point for instruction insert
   Instruction *HoistPt = BB->getTerminator();
@@ -480,7 +481,7 @@ bool MergedLoadStoreMotion::sinkStore(BasicBlock *BB, StoreInst *S0,
     BasicBlock::iterator InsertPt = BB->getFirstInsertionPt();
     // Intersect optional metadata.
     S0->intersectOptionalDataWith(S1);
-    S0->dropUnknownMetadata();
+    combineMetadata(S0, S1, None);      // HLSL Change: Preserve DXIL metadata
 
     // Create the new store to be inserted at the join point.
     StoreInst *SNew = (StoreInst *)(S0->clone());

--- a/tools/clang/test/HLSLFileCheck/passes/mldst-motion/preserve-nonuniform.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/mldst-motion/preserve-nonuniform.hlsl
@@ -1,0 +1,38 @@
+// RUN: %dxc -T vs_6_0 %s | FileCheck %s
+
+// Make sure we preserve non-uniform through mldst-motion
+
+// CHECK-NOT: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 {{.*}}, i1 false)
+// CHECK: call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 {{.*}}, i1 true)
+
+StructuredBuffer<uint>      g_ObjectIndices[]   : register( t0, space2 );
+
+uint getIndex16Bit( int iInstance, uint uIdx )
+{
+  uint uIndexToAccess = uIdx;
+
+  if ( ( uIdx & 1 ) == 0 )
+  {
+    uint uReadIdx = g_ObjectIndices[ NonUniformResourceIndex( iInstance ) ][ NonUniformResourceIndex( uIndexToAccess ) ];
+    return uReadIdx & 0xffff;
+  }
+  else
+  {
+    uint uReadIdx = g_ObjectIndices[ NonUniformResourceIndex( iInstance ) ][ NonUniformResourceIndex( uIndexToAccess ) ];
+    uReadIdx = uReadIdx >> 16;
+    return uReadIdx & 0xffff;
+  }
+}
+
+uint3 GetIndex16Bit( int instance, int primitiveIndex )
+{
+  uint idx = 3 * primitiveIndex;
+  uint uIdx0 = getIndex16Bit( instance, idx );
+  uint uIdx1 = getIndex16Bit( instance, idx + 1 );
+  uint uIdx2 = getIndex16Bit( instance, idx + 2 );
+  return uint3( uIdx0, uIdx1, uIdx2 );
+}
+
+uint3 main( int instance : INSTANCE, int primitiveIndex : PRIMINDEX ) : OUT {
+  return GetIndex16Bit(instance, primitiveIndex);
+}


### PR DESCRIPTION
In mldst-motion, use llvm::combineMetadata which is modified to preserve dxil metadata, instead of Instruction::dropUnknownMetadata.

Fixes #4120