### PR TITLE
Handle implicit `this` methods

### DIFF
--- a/tools/clang/lib/Sema/SemaExprCXX.cpp
+++ b/tools/clang/lib/Sema/SemaExprCXX.cpp
@@ -982,8 +982,10 @@ CXXThisExpr *Sema::genereateHLSLThis(SourceLocation Loc, QualType ThisType,
                                    bool isImplicit) {
   // Expressions cannot be of reference type - instead, they yield
   // an lvalue on the underlying type.
-  CXXThisExpr *ResultExpr = new (Context)
-      CXXThisExpr(Loc, ThisType.getTypePtr()->getPointeeType(), isImplicit);
+  const Type *TypePtr = ThisType.getTypePtr();
+  CXXThisExpr *ResultExpr = new (Context) CXXThisExpr(
+      Loc, TypePtr->isPointerType() ? TypePtr->getPointeeType() : ThisType,
+      isImplicit);
   ResultExpr->setValueKind(ExprValueKind::VK_LValue);
   return ResultExpr;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/method-implicit-this.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/method-implicit-this.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T ps_6_0 -ast-dump %s | FileCheck %s
+
+struct Foo {
+  float m;
+  float2 f(float2 v) { return 0; }
+  float3 f(float3 v) { return 1; }
+  float2 g(float2 v) { return f(v); }
+};
+
+// CHECK:     CXXMemberCallExpr 0x{{[0-9a-zA-Z]+}} <col:31, col:34> 'float2':'vector<float, 2>'
+// CHECK-NEXT: MemberExpr 0x{{[0-9a-zA-Z]+}} <col:31> '<bound member function type>' .f
+// CHECK-NEXT: CXXThisExpr 0x{{[0-9a-zA-Z]+}} <col:31> 'Foo' lvalue this
+// CHECK-NEXT: ImplicitCastExpr 0x{{[0-9a-zA-Z]+}} <col:33> 'float2':'vector<float, 2>' <LValueToRValue>
+// CHECK-NEXT: DeclRefExpr 0x{{[0-9a-zA-Z]+}} <col:33> 'float2':'vector<float, 2>' lvalue ParmVar 0x{{[0-9a-zA-Z]+}} 'v' 'float2':'vector<float, 2>'
+
+float4 main(float2 coord: TEXCOORD) : SV_TARGET {
+  Foo foo = { coord.x };
+  return float4(foo.g(coord.y), 0, 1);
+}


### PR DESCRIPTION
This catches a case I missed in #4112, for handling implicit `this` in
member method lookups.