### PR TITLE
[NFC] Ignore all build* directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,7 @@ autoconf/autom4te.cache
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
 # Build directories
-build.x64
-build.x86
+build*
 # External projects that are tracked independently.
 external/*
 # Clang, which is tracked independently.


### PR DESCRIPTION
This allows build directories to be ignored as long as they start with
the name `build`.