### PR TITLE
[SPIR-V] Improve lines and columns for DebugLine (pt 2)

### DIFF
--- a/tools/clang/include/clang/AST/Stmt.h
+++ b/tools/clang/include/clang/AST/Stmt.h
@@ -923,6 +923,7 @@ class IfStmt : public Stmt {
 
   SourceLocation IfLoc;
   SourceLocation ElseLoc;
+  SourceLocation MergeLoc;
 
 public:
   IfStmt(const ASTContext &C, SourceLocation IL, VarDecl *var, Expr *cond,
@@ -964,6 +965,8 @@ public:
   void setIfLoc(SourceLocation L) { IfLoc = L; }
   SourceLocation getElseLoc() const { return ElseLoc; }
   void setElseLoc(SourceLocation L) { ElseLoc = L; }
+  SourceLocation getMergeLoc() const { return MergeLoc; }
+  void setMergeLoc(SourceLocation L) { MergeLoc = L; }
 
   SourceLocation getLocStart() const LLVM_READONLY { return IfLoc; }
   SourceLocation getLocEnd() const LLVM_READONLY {

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -142,14 +142,15 @@ public:
   SpirvCompositeConstruct *
   createCompositeConstruct(QualType resultType,
                            llvm::ArrayRef<SpirvInstruction *> constituents,
-                           SourceLocation loc);
+                           SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates a composite extract instruction. The given composite is
   /// indexed using the given literal indexes to obtain the resulting element.
   /// Returns the instruction pointer for the extracted element.
   SpirvCompositeExtract *
   createCompositeExtract(QualType resultType, SpirvInstruction *composite,
-                         llvm::ArrayRef<uint32_t> indexes, SourceLocation loc);
+                         llvm::ArrayRef<uint32_t> indexes, SourceLocation loc,
+                         SourceRange range = {});
 
   /// \brief Creates a composite insert instruction. The given object will
   /// replace the component in the composite at the given indices. Returns the
@@ -158,7 +159,8 @@ public:
                                               SpirvInstruction *composite,
                                               llvm::ArrayRef<uint32_t> indices,
                                               SpirvInstruction *object,
-                                              SourceLocation loc);
+                                              SourceLocation loc,
+                                              SourceRange range = {});
 
   /// \brief Creates a vector shuffle instruction of selecting from the two
   /// vectors using selectors and returns the instruction pointer of the result
@@ -167,7 +169,8 @@ public:
                                           SpirvInstruction *vector1,
                                           SpirvInstruction *vector2,
                                           llvm::ArrayRef<uint32_t> selectors,
-                                          SourceLocation loc);
+                                          SourceLocation loc,
+                                          SourceRange range = {});
 
   /// \brief Creates a load instruction loading the value of the given
   /// <result-type> from the given pointer. Returns the instruction pointer for
@@ -191,7 +194,7 @@ public:
   SpirvFunctionCall *
   createFunctionCall(QualType returnType, SpirvFunction *func,
                      llvm::ArrayRef<SpirvInstruction *> params,
-                     SourceLocation loc);
+                     SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates an access chain instruction to retrieve the element from
   /// the given base by walking through the given indexes. Returns the
@@ -211,7 +214,8 @@ public:
   /// \brief Creates a unary operation with the given SPIR-V opcode. Returns
   /// the instruction pointer for the result.
   SpirvUnaryOp *createUnaryOp(spv::Op op, QualType resultType,
-                              SpirvInstruction *operand, SourceLocation loc);
+                              SpirvInstruction *operand, SourceLocation loc,
+                              SourceRange range = {});
   SpirvUnaryOp *createUnaryOp(spv::Op op, const SpirvType *resultType,
                               SpirvInstruction *operand, SourceLocation loc);
 
@@ -247,13 +251,14 @@ public:
                               SpirvInstruction *orignalValuePtr,
                               spv::Scope scope,
                               spv::MemorySemanticsMask memorySemantics,
-                              SpirvInstruction *valueToOp, SourceLocation);
+                              SpirvInstruction *valueToOp, SourceLocation,
+                              SourceRange range = {});
   SpirvAtomic *createAtomicCompareExchange(
       QualType resultType, SpirvInstruction *orignalValuePtr, spv::Scope scope,
       spv::MemorySemanticsMask equalMemorySemantics,
       spv::MemorySemanticsMask unequalMemorySemantics,
-      SpirvInstruction *valueToOp, SpirvInstruction *comparator,
-      SourceLocation);
+      SpirvInstruction *valueToOp, SpirvInstruction *comparator, SourceLocation,
+      SourceRange range = {});
 
   /// \brief Creates an OpSampledImage SPIR-V instruction with proper
   /// decorations for the given parameters.
@@ -314,12 +319,12 @@ public:
       SpirvInstruction *lod, SpirvInstruction *constOffset,
       SpirvInstruction *varOffset, SpirvInstruction *constOffsets,
       SpirvInstruction *sample, SpirvInstruction *residencyCode,
-      SourceLocation loc);
+      SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for writing to the given image.
   void createImageWrite(QualType imageType, SpirvInstruction *image,
                         SpirvInstruction *coord, SpirvInstruction *texel,
-                        SourceLocation loc);
+                        SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for gathering the given image.
   ///
@@ -344,7 +349,7 @@ public:
   /// given Resident Code and returns the instruction pointer.
   SpirvImageSparseTexelsResident *
   createImageSparseTexelsResident(SpirvInstruction *resident_code,
-                                  SourceLocation);
+                                  SourceLocation, SourceRange range = {});
 
   /// \brief Creates an image query instruction.
   /// The given 'lod' is used as the Lod argument in the case of
@@ -352,13 +357,15 @@ public:
   /// case of OpImageQueryLod.
   SpirvImageQuery *createImageQuery(spv::Op opcode, QualType resultType,
                                     SourceLocation loc, SpirvInstruction *image,
-                                    SpirvInstruction *lod = nullptr);
+                                    SpirvInstruction *lod = nullptr,
+                                    SourceRange range = {});
 
   /// \brief Creates a select operation with the given values for true and false
   /// cases and returns the instruction pointer.
   SpirvSelect *createSelect(QualType resultType, SpirvInstruction *condition,
                             SpirvInstruction *trueValue,
-                            SpirvInstruction *falseValue, SourceLocation);
+                            SpirvInstruction *falseValue, SourceLocation,
+                            SourceRange range = {});
 
   /// \brief Creates a switch statement for the given selector, default, and
   /// branches. Results in OpSelectionMerge followed by OpSwitch.
@@ -366,10 +373,10 @@ public:
   createSwitch(SpirvBasicBlock *mergeLabel, SpirvInstruction *selector,
                SpirvBasicBlock *defaultLabel,
                llvm::ArrayRef<std::pair<uint32_t, SpirvBasicBlock *>> target,
-               SourceLocation);
+               SourceLocation, SourceRange);
 
   /// \brief Creates a fragment-shader discard via by emitting OpKill.
-  void createKill(SourceLocation);
+  void createKill(SourceLocation, SourceRange range = {});
 
   /// \brief Creates an unconditional branch to the given target label.
   /// If mergeBB and continueBB are non-null, it creates an OpLoopMerge
@@ -377,7 +384,8 @@ public:
   void createBranch(
       SpirvBasicBlock *targetLabel, SourceLocation loc,
       SpirvBasicBlock *mergeBB = nullptr, SpirvBasicBlock *continueBB = nullptr,
-      spv::LoopControlMask loopControl = spv::LoopControlMask::MaskNone);
+      spv::LoopControlMask loopControl = spv::LoopControlMask::MaskNone,
+      SourceRange range = {});
 
   /// \brief Creates a conditional branch. An OpSelectionMerge instruction
   /// will be created if mergeLabel is not null and continueLabel is null.
@@ -393,7 +401,8 @@ public:
       SpirvBasicBlock *continueLabel = nullptr,
       spv::SelectionControlMask selectionControl =
           spv::SelectionControlMask::MaskNone,
-      spv::LoopControlMask loopControl = spv::LoopControlMask::MaskNone);
+      spv::LoopControlMask loopControl = spv::LoopControlMask::MaskNone,
+      SourceRange range = {});
 
   /// \brief Creates a return instruction.
   void createReturn(SourceLocation, SourceRange range = {});
@@ -406,12 +415,12 @@ public:
   /// resulting instruction pointer.
   SpirvInstruction *
   createGLSLExtInst(QualType resultType, GLSLstd450 instId,
-                    llvm::ArrayRef<SpirvInstruction *> operands,
-                    SourceLocation);
+                    llvm::ArrayRef<SpirvInstruction *> operands, SourceLocation,
+                    SourceRange range = {});
   SpirvInstruction *
   createGLSLExtInst(const SpirvType *resultType, GLSLstd450 instId,
-                    llvm::ArrayRef<SpirvInstruction *> operands,
-                    SourceLocation);
+                    llvm::ArrayRef<SpirvInstruction *> operands, SourceLocation,
+                    SourceRange range = {});
 
   /// \brief Creates an OpExtInst instruction for the NonSemantic.DebugPrintf
   /// extension set. Returns the resulting instruction pointer.
@@ -424,7 +433,8 @@ public:
   /// is created; otherwise an OpMemoryBarrier is created.
   void createBarrier(spv::Scope memoryScope,
                      spv::MemorySemanticsMask memorySemantics,
-                     llvm::Optional<spv::Scope> exec, SourceLocation);
+                     llvm::Optional<spv::Scope> exec, SourceLocation,
+                     SourceRange range = {});
 
   /// \brief Creates an OpBitFieldInsert SPIR-V instruction for the given
   /// arguments.
@@ -442,15 +452,16 @@ public:
                                               bool isSigned, SourceLocation);
 
   /// \brief Creates an OpEmitVertex instruction.
-  void createEmitVertex(SourceLocation);
+  void createEmitVertex(SourceLocation, SourceRange range = {});
 
   /// \brief Creates an OpEndPrimitive instruction.
-  void createEndPrimitive(SourceLocation);
+  void createEndPrimitive(SourceLocation, SourceRange range = {});
 
   /// \brief Creates an OpArrayLength instruction.
   SpirvArrayLength *createArrayLength(QualType resultType, SourceLocation loc,
                                       SpirvInstruction *structure,
-                                      uint32_t arrayMember);
+                                      uint32_t arrayMember,
+                                      SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for NV raytracing ops.
   SpirvInstruction *
@@ -507,7 +518,8 @@ public:
   SpirvInstruction *
   createRayQueryOpsKHR(spv::Op opcode, QualType resultType,
                        llvm::ArrayRef<SpirvInstruction *> operands,
-                       bool cullFlags, SourceLocation loc);
+                       bool cullFlags, SourceLocation loc,
+                       SourceRange range = {});
   /// \brief Creates an OpReadClockKHR instruction.
   SpirvInstruction *createReadClock(SpirvInstruction *scope, SourceLocation);
 

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -589,7 +589,7 @@ public:
 
 protected:
   SpirvMerge(Kind kind, spv::Op opcode, SourceLocation loc,
-             SpirvBasicBlock *mergeBlock);
+             SpirvBasicBlock *mergeBlock, SourceRange range = {});
 
   // For LLVM-style RTTI
   static bool classof(const SpirvInstruction *inst) {
@@ -604,7 +604,8 @@ private:
 class SpirvLoopMerge : public SpirvMerge {
 public:
   SpirvLoopMerge(SourceLocation loc, SpirvBasicBlock *mergeBlock,
-                 SpirvBasicBlock *contTarget, spv::LoopControlMask mask);
+                 SpirvBasicBlock *contTarget, spv::LoopControlMask mask,
+                 SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvLoopMerge)
 
@@ -626,7 +627,7 @@ private:
 class SpirvSelectionMerge : public SpirvMerge {
 public:
   SpirvSelectionMerge(SourceLocation loc, SpirvBasicBlock *mergeBlock,
-                      spv::SelectionControlMask mask);
+                      spv::SelectionControlMask mask, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvSelectionMerge)
 
@@ -680,13 +681,15 @@ public:
   virtual llvm::ArrayRef<SpirvBasicBlock *> getTargetBranches() const = 0;
 
 protected:
-  SpirvBranching(Kind kind, spv::Op opcode, SourceLocation loc);
+  SpirvBranching(Kind kind, spv::Op opcode, SourceLocation loc,
+                 SourceRange range = {});
 };
 
 /// \brief OpBranch instruction
 class SpirvBranch : public SpirvBranching {
 public:
-  SpirvBranch(SourceLocation loc, SpirvBasicBlock *target);
+  SpirvBranch(SourceLocation loc, SpirvBasicBlock *target,
+              SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvBranch)
 
@@ -742,7 +745,7 @@ private:
 /// \brief OpKill instruction
 class SpirvKill : public SpirvTerminator {
 public:
-  SpirvKill(SourceLocation loc);
+  SpirvKill(SourceLocation loc, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvKill)
 
@@ -877,12 +880,13 @@ class SpirvAtomic : public SpirvInstruction {
 public:
   SpirvAtomic(spv::Op opcode, QualType resultType, SourceLocation loc,
               SpirvInstruction *pointer, spv::Scope, spv::MemorySemanticsMask,
-              SpirvInstruction *value = nullptr);
+              SpirvInstruction *value = nullptr, SourceRange range = {});
   SpirvAtomic(spv::Op opcode, QualType resultType, SourceLocation loc,
               SpirvInstruction *pointer, spv::Scope,
               spv::MemorySemanticsMask semanticsEqual,
               spv::MemorySemanticsMask semanticsUnequal,
-              SpirvInstruction *value, SpirvInstruction *comparator);
+              SpirvInstruction *value, SpirvInstruction *comparator,
+              SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvAtomic)
 
@@ -921,7 +925,8 @@ class SpirvBarrier : public SpirvInstruction {
 public:
   SpirvBarrier(SourceLocation loc, spv::Scope memoryScope,
                spv::MemorySemanticsMask memorySemantics,
-               llvm::Optional<spv::Scope> executionScope = llvm::None);
+               llvm::Optional<spv::Scope> executionScope = llvm::None,
+               SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvBarrier)
 
@@ -1228,7 +1233,8 @@ public:
 class SpirvCompositeConstruct : public SpirvInstruction {
 public:
   SpirvCompositeConstruct(QualType resultType, SourceLocation loc,
-                          llvm::ArrayRef<SpirvInstruction *> constituentsVec);
+                          llvm::ArrayRef<SpirvInstruction *> constituentsVec,
+                          SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvCompositeConstruct)
 
@@ -1252,7 +1258,8 @@ class SpirvCompositeExtract : public SpirvInstruction {
 public:
   SpirvCompositeExtract(QualType resultType, SourceLocation loc,
                         SpirvInstruction *composite,
-                        llvm::ArrayRef<uint32_t> indices);
+                        llvm::ArrayRef<uint32_t> indices,
+                        SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvCompositeExtract)
 
@@ -1276,7 +1283,8 @@ class SpirvCompositeInsert : public SpirvInstruction {
 public:
   SpirvCompositeInsert(QualType resultType, SourceLocation loc,
                        SpirvInstruction *composite, SpirvInstruction *object,
-                       llvm::ArrayRef<uint32_t> indices);
+                       llvm::ArrayRef<uint32_t> indices,
+                       SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvCompositeInsert)
 
@@ -1300,7 +1308,7 @@ private:
 /// \brief EmitVertex instruction
 class SpirvEmitVertex : public SpirvInstruction {
 public:
-  SpirvEmitVertex(SourceLocation loc);
+  SpirvEmitVertex(SourceLocation loc, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvEmitVertex)
 
@@ -1315,7 +1323,7 @@ public:
 /// \brief EndPrimitive instruction
 class SpirvEndPrimitive : public SpirvInstruction {
 public:
-  SpirvEndPrimitive(SourceLocation loc);
+  SpirvEndPrimitive(SourceLocation loc, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvEndPrimitive)
 
@@ -1331,7 +1339,8 @@ public:
 class SpirvExtInst : public SpirvInstruction {
 public:
   SpirvExtInst(QualType resultType, SourceLocation loc, SpirvExtInstImport *set,
-               uint32_t inst, llvm::ArrayRef<SpirvInstruction *> operandsVec);
+               uint32_t inst, llvm::ArrayRef<SpirvInstruction *> operandsVec,
+               SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvExtInst)
 
@@ -1357,7 +1366,8 @@ class SpirvFunctionCall : public SpirvInstruction {
 public:
   SpirvFunctionCall(QualType resultType, SourceLocation loc,
                     SpirvFunction *function,
-                    llvm::ArrayRef<SpirvInstruction *> argsVec);
+                    llvm::ArrayRef<SpirvInstruction *> argsVec,
+                    SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvFunctionCall)
 
@@ -1577,7 +1587,7 @@ class SpirvImageQuery : public SpirvInstruction {
 public:
   SpirvImageQuery(spv::Op opcode, QualType resultType, SourceLocation loc,
                   SpirvInstruction *img, SpirvInstruction *lod = nullptr,
-                  SpirvInstruction *coord = nullptr);
+                  SpirvInstruction *coord = nullptr, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvImageQuery)
 
@@ -1604,7 +1614,8 @@ private:
 class SpirvImageSparseTexelsResident : public SpirvInstruction {
 public:
   SpirvImageSparseTexelsResident(QualType resultType, SourceLocation loc,
-                                 SpirvInstruction *resCode);
+                                 SpirvInstruction *resCode,
+                                 SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvImageSparseTexelsResident)
 
@@ -1734,7 +1745,8 @@ private:
 class SpirvSelect : public SpirvInstruction {
 public:
   SpirvSelect(QualType resultType, SourceLocation loc, SpirvInstruction *cond,
-              SpirvInstruction *trueId, SpirvInstruction *falseId);
+              SpirvInstruction *trueId, SpirvInstruction *falseId,
+              SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvSelect)
 
@@ -1875,7 +1887,7 @@ private:
 class SpirvUnaryOp : public SpirvInstruction {
 public:
   SpirvUnaryOp(spv::Op opcode, QualType resultType, SourceLocation loc,
-               SpirvInstruction *op);
+               SpirvInstruction *op, SourceRange range = {});
 
   SpirvUnaryOp(spv::Op opcode, const SpirvType *resultType, SourceLocation loc,
                SpirvInstruction *op);
@@ -1901,7 +1913,8 @@ class SpirvVectorShuffle : public SpirvInstruction {
 public:
   SpirvVectorShuffle(QualType resultType, SourceLocation loc,
                      SpirvInstruction *vec1, SpirvInstruction *vec2,
-                     llvm::ArrayRef<uint32_t> componentsVec);
+                     llvm::ArrayRef<uint32_t> componentsVec,
+                     SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvVectorShuffle)
 
@@ -1925,7 +1938,8 @@ private:
 class SpirvArrayLength : public SpirvInstruction {
 public:
   SpirvArrayLength(QualType resultType, SourceLocation loc,
-                   SpirvInstruction *structure, uint32_t arrayMember);
+                   SpirvInstruction *structure, uint32_t arrayMember,
+                   SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvArrayLength)
 
@@ -1973,7 +1987,7 @@ class SpirvRayQueryOpKHR : public SpirvInstruction {
 public:
   SpirvRayQueryOpKHR(QualType resultType, spv::Op opcode,
                      llvm::ArrayRef<SpirvInstruction *> vecOperands, bool flags,
-                     SourceLocation loc);
+                     SourceLocation loc, SourceRange range = {});
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvRayQueryOpKHR)
 

--- a/tools/clang/lib/AST/Stmt.cpp
+++ b/tools/clang/lib/AST/Stmt.cpp
@@ -883,8 +883,7 @@ const VarDecl *CXXForRangeStmt::getLoopVariable() const {
 
 IfStmt::IfStmt(const ASTContext &C, SourceLocation IL, VarDecl *var, Expr *cond,
                Stmt *then, SourceLocation EL, Stmt *elsev)
-  : Stmt(IfStmtClass), IfLoc(IL), ElseLoc(EL)
-{
+    : Stmt(IfStmtClass), IfLoc(IL), ElseLoc(EL), MergeLoc(SourceLocation()) {
   setConditionVariable(C, var);
   SubExprs[COND] = cond;
   SubExprs[THEN] = then;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -784,7 +784,8 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
 }
 
 SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
-                                                      SourceLocation loc) {
+                                                      SourceLocation loc,
+                                                      SourceRange range) {
   const DeclSpirvInfo *info = getDeclSpirvInfo(decl);
 
   // If DeclSpirvInfo is not found for this decl, it might be because it is an
@@ -807,7 +808,7 @@ SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
           valueType, info->instr,
           {spvBuilder.getConstantInt(
               astContext.IntTy, llvm::APInt(32, info->indexInCTBuffer, true))},
-          loc);
+          loc, range);
     } else if (auto *type = info->instr->getResultType()) {
       const auto *ptrTy = dyn_cast<HybridPointerType>(type);
 
@@ -815,7 +816,7 @@ SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
       // array of an opaque type, we have to load it because we pass a
       // pointer of a global variable that has the bindless opaque array.
       if (ptrTy != nullptr && isBindlessOpaqueArray(decl->getType())) {
-        auto *load = spvBuilder.createLoad(ptrTy, info->instr, loc);
+        auto *load = spvBuilder.createLoad(ptrTy, info->instr, loc, range);
         load->setRValue(false);
         return load;
       } else {
@@ -3017,7 +3018,8 @@ bool DeclResultIdMapper::createPayloadStageVars(
 
 bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
                                                QualType type,
-                                               SpirvInstruction *value) {
+                                               SpirvInstruction *value,
+                                               SourceRange range) {
   assert(spvContext.isGS()); // Only for GS use
 
   if (hlsl::IsHLSLStreamOutputType(type))
@@ -3036,7 +3038,7 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
     if (glPerVertex.tryToAccess(
             hlsl::DXIL::SigPointKind::GSOut, semanticInfo.semantic->GetKind(),
             semanticInfo.index, llvm::None, &value,
-            /*noWriteBack=*/false, /*vecComponent=*/nullptr, loc))
+            /*noWriteBack=*/false, /*vecComponent=*/nullptr, loc, range))
       return true;
 
     // Query the <result-id> for the stage output variable generated out
@@ -3050,16 +3052,16 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
 
     // Negate SV_Position.y if requested
     if (semanticInfo.semantic->GetKind() == hlsl::Semantic::Kind::Position)
-      value = invertYIfRequested(value, loc);
+      value = invertYIfRequested(value, loc, range);
 
     // Boolean stage output variables are represented as unsigned integers.
     if (isBooleanStageIOVar(decl, type, semanticInfo.semantic->GetKind(),
                             hlsl::SigPoint::Kind::GSOut)) {
       QualType uintType = getUintTypeWithSourceComponents(astContext, type);
-      value = theEmitter.castToType(value, type, uintType, loc);
+      value = theEmitter.castToType(value, type, uintType, loc, range);
     }
 
-    spvBuilder.createStore(found->second, value, loc);
+    spvBuilder.createStore(found->second, value, loc, range);
     return true;
   }
 
@@ -3075,11 +3077,10 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
   if (const auto *cxxDecl = type->getAsCXXRecordDecl()) {
     uint32_t baseIndex = 0;
     for (auto base : cxxDecl->bases()) {
-      auto *subValue = spvBuilder.createCompositeExtract(base.getType(), value,
-                                                         {baseIndex++}, loc);
+      auto *subValue = spvBuilder.createCompositeExtract(base.getType(), value, {baseIndex++}, loc, range);
 
       if (!writeBackOutputStream(base.getType()->getAsCXXRecordDecl(),
-                                 base.getType(), subValue))
+                                 base.getType(), subValue, range))
         return false;
     }
   }
@@ -3091,9 +3092,9 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
     const auto fieldType = field->getType();
     auto *subValue = spvBuilder.createCompositeExtract(
         fieldType, value, {getNumBaseClasses(type) + field->getFieldIndex()},
-        loc);
+        loc, range);
 
-    if (!writeBackOutputStream(field, field->getType(), subValue))
+    if (!writeBackOutputStream(field, field->getType(), subValue, range))
       return false;
   }
 
@@ -3102,16 +3103,15 @@ bool DeclResultIdMapper::writeBackOutputStream(const NamedDecl *decl,
 
 SpirvInstruction *
 DeclResultIdMapper::invertYIfRequested(SpirvInstruction *position,
-                                       SourceLocation loc) {
+                                       SourceLocation loc, SourceRange range) {
   // Negate SV_Position.y if requested
   if (spirvOptions.invertY) {
     const auto oldY = spvBuilder.createCompositeExtract(astContext.FloatTy,
-                                                        position, {1}, loc);
-    const auto newY = spvBuilder.createUnaryOp(spv::Op::OpFNegate,
-                                               astContext.FloatTy, oldY, loc);
+                                                        position, {1}, loc, range);
+    const auto newY = spvBuilder.createUnaryOp(spv::Op::OpFNegate, astContext.FloatTy, oldY, loc, range);
     position = spvBuilder.createCompositeInsert(
         astContext.getExtVectorType(astContext.FloatTy, 4), position, {1}, newY,
-        loc);
+        loc, range);
   }
   return position;
 }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -468,9 +468,12 @@ public:
   };
 
   /// Raytracing specific functions
-  /// \brief Creates a ShaderRecordBufferEXT or ShaderRecordBufferNV block from the given decl.
-  SpirvVariable *createShaderRecordBuffer(const VarDecl *decl, ContextUsageKind kind);
-  SpirvVariable *createShaderRecordBuffer(const HLSLBufferDecl *decl, ContextUsageKind kind);
+  /// \brief Creates a ShaderRecordBufferEXT or ShaderRecordBufferNV block from
+  /// the given decl.
+  SpirvVariable *createShaderRecordBuffer(const VarDecl *decl,
+                                          ContextUsageKind kind);
+  SpirvVariable *createShaderRecordBuffer(const HLSLBufferDecl *decl,
+                                          ContextUsageKind kind);
 
 private:
   /// The struct containing SPIR-V information of a AST Decl.
@@ -508,7 +511,8 @@ public:
   /// \brief Returns the information for the given decl.
   ///
   /// This method will panic if the given decl is not registered.
-  SpirvInstruction *getDeclEvalInfo(const ValueDecl *decl, SourceLocation loc);
+  SpirvInstruction *getDeclEvalInfo(const ValueDecl *decl, SourceLocation loc,
+                                    SourceRange range = {});
 
   /// \brief Returns the instruction pointer for the given function if already
   /// registered; otherwise, treats the given function as a normal decl and
@@ -563,11 +567,12 @@ public:
   /// This method is specially for writing back per-vertex data at the time of
   /// OpEmitVertex in GS.
   bool writeBackOutputStream(const NamedDecl *decl, QualType type,
-                             SpirvInstruction *value);
+                             SpirvInstruction *value, SourceRange range = {});
 
   /// \brief Negates to get the additive inverse of SV_Position.y if requested.
   SpirvInstruction *invertYIfRequested(SpirvInstruction *position,
-                                       SourceLocation loc);
+                                       SourceLocation loc,
+                                       SourceRange range = {});
 
   /// \brief Reciprocates to get the multiplicative inverse of SV_Position.w
   /// if requested.

--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -84,7 +84,8 @@ public:
                    uint32_t semanticIndex,
                    llvm::Optional<SpirvInstruction *> invocation,
                    SpirvInstruction **value, bool noWriteBack,
-                   SpirvInstruction *vecComponent, SourceLocation loc);
+                   SpirvInstruction *vecComponent, SourceLocation loc,
+                   SourceRange range = {});
 
 private:
   using SemanticIndexToTypeMap = llvm::DenseMap<uint32_t, QualType>;
@@ -105,11 +106,12 @@ private:
   /// the ClipDistance/CullDistance builtin. The data read will be transformed
   /// into the given type asType.
   SpirvInstruction *readClipCullArrayAsType(bool isClip, uint32_t offset,
-                                            QualType asType,
-                                            SourceLocation loc) const;
+                                            QualType asType, SourceLocation loc,
+                                            SourceRange range = {}) const;
   /// Creates SPIR-V instructions to read a field in gl_PerVertex.
   bool readField(hlsl::Semantic::Kind semanticKind, uint32_t semanticIndex,
-                 SpirvInstruction **value, SourceLocation loc);
+                 SpirvInstruction **value, SourceLocation loc,
+                 SourceRange range = {});
 
   /// Creates SPIR-V instructions for writing data into the ClipDistance/
   /// CullDistance builtin starting from offset. The value to be written is
@@ -119,12 +121,12 @@ private:
   writeClipCullArrayFromType(llvm::Optional<SpirvInstruction *> invocationId,
                              bool isClip, SpirvInstruction *offset,
                              QualType fromType, SpirvInstruction *fromValue,
-                             SourceLocation loc) const;
+                             SourceLocation loc, SourceRange range = {}) const;
   /// Creates SPIR-V instructions to write a field in gl_PerVertex.
   bool writeField(hlsl::Semantic::Kind semanticKind, uint32_t semanticIndex,
                   llvm::Optional<SpirvInstruction *> invocationId,
                   SpirvInstruction **value, SpirvInstruction *vecComponent,
-                  SourceLocation loc);
+                  SourceLocation loc, SourceRange range = {});
 
   /// Internal implementation for recordClipCullDistanceDecl().
   bool doGlPerVertexFacts(const DeclaratorDecl *decl, QualType type,

--- a/tools/clang/lib/SPIRV/InitListHandler.h
+++ b/tools/clang/lib/SPIRV/InitListHandler.h
@@ -84,7 +84,8 @@ public:
 
   /// Processes the given InitListExpr and returns the <result-id> for the final
   /// SPIR-V value.
-  SpirvInstruction *processInit(const InitListExpr *expr);
+  SpirvInstruction *processInit(const InitListExpr *expr,
+                                SourceRange rangeOverride = {});
 
   /// Casts the given Expr to the given toType and returns the <result-id> for
   /// the final SPIR-V value.
@@ -102,7 +103,8 @@ private:
 
   /// Construct a SPIR-V instruction whose type is |type| using |initializers|
   /// and returns the <result-id> for the final SPIR-V value of the given type.
-  SpirvInstruction *doProcess(QualType type, SourceLocation srcLoc);
+  SpirvInstruction *doProcess(QualType type, SourceLocation srcLoc,
+                              SourceRange range = {});
 
   /// Flattens the given InitListExpr and generates SPIR-V instructions for
   /// all non-InitListExpr AST nodes. Puts those generated SPIR-V instructions
@@ -124,15 +126,19 @@ private:
   /// Emits the necessary SPIR-V instructions to create a SPIR-V value of the
   /// given type. The scalars and initializers queue will be used to fetch the
   /// next value.
-  SpirvInstruction *createInitForType(QualType type, SourceLocation);
+  SpirvInstruction *createInitForType(QualType type, SourceLocation,
+                                      SourceRange range = {});
   SpirvInstruction *createInitForBuiltinType(QualType type, SourceLocation);
   SpirvInstruction *createInitForVectorType(QualType elemType, uint32_t count,
-                                            SourceLocation);
-  SpirvInstruction *createInitForMatrixType(QualType matrixType,
-                                            SourceLocation);
-  SpirvInstruction *createInitForStructType(QualType type, SourceLocation);
+                                            SourceLocation,
+                                            SourceRange range = {});
+  SpirvInstruction *createInitForMatrixType(QualType matrixType, SourceLocation,
+                                            SourceRange range = {});
+  SpirvInstruction *createInitForStructType(QualType type, SourceLocation,
+                                            SourceRange range = {});
   SpirvInstruction *createInitForConstantArrayType(QualType type,
-                                                   SourceLocation);
+                                                   SourceLocation,
+                                                   SourceRange range = {});
   SpirvInstruction *createInitForBufferOrImageType(QualType type,
                                                    SourceLocation);
 

--- a/tools/clang/lib/SPIRV/RawBufferMethods.h
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.h
@@ -38,7 +38,8 @@ public:
   SpirvInstruction *processTemplatedLoadFromBuffer(SpirvInstruction *buffer,
                                                    SpirvInstruction *&index,
                                                    const QualType targetType,
-                                                   uint32_t &bitOffset);
+                                                   uint32_t &bitOffset,
+                                                   SourceRange range = {});
 
   /// \brief Performs RWByteAddressBuffer.Store<T>(address, value).
   /// RWByteAddressBuffers are represented in SPIR-V as structs with only one
@@ -57,59 +58,69 @@ public:
                                      SpirvInstruction *buffer,
                                      SpirvInstruction *&index,
                                      const QualType valueType,
-                                     uint32_t &bitOffset);
+                                     uint32_t &bitOffset,
+                                     SourceRange range = {});
 
 private:
   SpirvInstruction *load16BitsAtBitOffset0(SpirvInstruction *buffer,
                                            SpirvInstruction *&index,
                                            QualType target16BitType,
-                                           uint32_t &bitOffset);
+                                           uint32_t &bitOffset,
+                                           SourceRange range = {});
 
   SpirvInstruction *load32BitsAtBitOffset0(SpirvInstruction *buffer,
                                            SpirvInstruction *&index,
                                            QualType target32BitType,
-                                           uint32_t &bitOffset);
+                                           uint32_t &bitOffset,
+                                           SourceRange range = {});
 
   SpirvInstruction *load64BitsAtBitOffset0(SpirvInstruction *buffer,
                                            SpirvInstruction *&index,
                                            QualType target64BitType,
-                                           uint32_t &bitOffset);
+                                           uint32_t &bitOffset,
+                                           SourceRange range = {});
 
   SpirvInstruction *load16BitsAtBitOffset16(SpirvInstruction *buffer,
                                             SpirvInstruction *&index,
                                             QualType target16BitType,
-                                            uint32_t &bitOffset);
+                                            uint32_t &bitOffset,
+                                            SourceRange range = {});
 
 private:
   void store16BitsAtBitOffset0(SpirvInstruction *value,
                                SpirvInstruction *buffer,
                                SpirvInstruction *&index,
-                               const QualType valueType);
+                               const QualType valueType,
+                               SourceRange range = {});
 
   void store32BitsAtBitOffset0(SpirvInstruction *value,
                                SpirvInstruction *buffer,
                                SpirvInstruction *&index,
-                               const QualType valueType);
+                               const QualType valueType,
+                               SourceRange range = {});
 
   void store64BitsAtBitOffset0(SpirvInstruction *value,
                                SpirvInstruction *buffer,
                                SpirvInstruction *&index,
-                               const QualType valueType);
+                               const QualType valueType,
+                               SourceRange range = {});
 
   void store16BitsAtBitOffset16(SpirvInstruction *value,
                                 SpirvInstruction *buffer,
                                 SpirvInstruction *&index,
-                                const QualType valueType);
+                                const QualType valueType,
+                                SourceRange range = {});
 
   void storeArrayOfScalars(std::deque<SpirvInstruction *> values,
                            SpirvInstruction *buffer, SpirvInstruction *&index,
                            const QualType valueType, uint32_t &bitOffset,
-                           SourceLocation);
+                           SourceLocation, SourceRange range = {});
 
   /// \brief Serializes the given values into their components until a scalar or
   /// a struct has been reached. Returns the most basic type it reaches.
   QualType serializeToScalarsOrStruct(std::deque<SpirvInstruction *> *values,
-                                      QualType valueType, SourceLocation);
+                                      QualType valueType, SourceLocation,
+                                      SourceRange range = {});
 
 private:
   /// \brief Performs an OpBitCast from |fromType| to |toType| on the given
@@ -121,7 +132,8 @@ private:
   /// the given instruction
   SpirvInstruction *bitCastToNumericalOrBool(SpirvInstruction *instr,
                                              QualType fromType, QualType toType,
-                                             SourceLocation loc);
+                                             SourceLocation loc,
+                                             SourceRange range = {});
 
 private:
   SpirvEmitter &theEmitter;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -144,10 +144,11 @@ void SpirvBuilder::setContinueTarget(SpirvBasicBlock *continueLabel) {
 
 SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
     QualType resultType, llvm::ArrayRef<SpirvInstruction *> constituents,
-    SourceLocation loc) {
+    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction =
-      new (context) SpirvCompositeConstruct(resultType, loc, constituents);
+      new (context) SpirvCompositeConstruct(resultType, loc, constituents,
+                                            range);
   insertPoint->addInstruction(instruction);
   if (!constituents.empty()) {
     instruction->setLayoutRule(constituents[0]->getLayoutRule());
@@ -157,10 +158,12 @@ SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
 
 SpirvCompositeExtract *SpirvBuilder::createCompositeExtract(
     QualType resultType, SpirvInstruction *composite,
-    llvm::ArrayRef<uint32_t> indexes, SourceLocation loc) {
+    llvm::ArrayRef<uint32_t> indexes, SourceLocation loc,
+    SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction =
-      new (context) SpirvCompositeExtract(resultType, loc, composite, indexes);
+      new (context) SpirvCompositeExtract(resultType, loc, composite, indexes,
+                                          range);
   instruction->setRValue();
   insertPoint->addInstruction(instruction);
   return instruction;
@@ -169,20 +172,21 @@ SpirvCompositeExtract *SpirvBuilder::createCompositeExtract(
 SpirvCompositeInsert *SpirvBuilder::createCompositeInsert(
     QualType resultType, SpirvInstruction *composite,
     llvm::ArrayRef<uint32_t> indices, SpirvInstruction *object,
-    SourceLocation loc) {
+    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context)
-      SpirvCompositeInsert(resultType, loc, composite, object, indices);
+      SpirvCompositeInsert(resultType, loc, composite, object, indices, range);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
 
 SpirvVectorShuffle *SpirvBuilder::createVectorShuffle(
     QualType resultType, SpirvInstruction *vector1, SpirvInstruction *vector2,
-    llvm::ArrayRef<uint32_t> selectors, SourceLocation loc) {
+    llvm::ArrayRef<uint32_t> selectors, SourceLocation loc,
+    SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context)
-      SpirvVectorShuffle(resultType, loc, vector1, vector2, selectors);
+      SpirvVectorShuffle(resultType, loc, vector1, vector2, selectors, range);
   instruction->setRValue();
   insertPoint->addInstruction(instruction);
   return instruction;
@@ -262,10 +266,10 @@ void SpirvBuilder::createStore(SpirvInstruction *address,
 SpirvFunctionCall *
 SpirvBuilder::createFunctionCall(QualType returnType, SpirvFunction *func,
                                  llvm::ArrayRef<SpirvInstruction *> params,
-                                 SourceLocation loc) {
+                                 SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction =
-      new (context) SpirvFunctionCall(returnType, loc, func, params);
+      new (context) SpirvFunctionCall(returnType, loc, func, params, range);
   instruction->setRValue(func->isRValue());
   instruction->setContainsAliasComponent(func->constainsAliasComponent());
 
@@ -327,9 +331,11 @@ SpirvBuilder::createAccessChain(QualType resultType, SpirvInstruction *base,
 
 SpirvUnaryOp *SpirvBuilder::createUnaryOp(spv::Op op, QualType resultType,
                                           SpirvInstruction *operand,
-                                          SourceLocation loc) {
+                                          SourceLocation loc,
+                                          SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *instruction = new (context) SpirvUnaryOp(op, resultType, loc, operand);
+  auto *instruction =
+      new (context) SpirvUnaryOp(op, resultType, loc, operand, range);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
@@ -399,11 +405,11 @@ SpirvNonUniformBinaryOp *SpirvBuilder::createGroupNonUniformBinaryOp(
 SpirvAtomic *SpirvBuilder::createAtomicOp(
     spv::Op opcode, QualType resultType, SpirvInstruction *originalValuePtr,
     spv::Scope scope, spv::MemorySemanticsMask memorySemantics,
-    SpirvInstruction *valueToOp, SourceLocation loc) {
+    SpirvInstruction *valueToOp, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction =
       new (context) SpirvAtomic(opcode, resultType, loc, originalValuePtr,
-                                scope, memorySemantics, valueToOp);
+                                scope, memorySemantics, valueToOp, range);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
@@ -413,12 +419,12 @@ SpirvAtomic *SpirvBuilder::createAtomicCompareExchange(
     spv::MemorySemanticsMask equalMemorySemantics,
     spv::MemorySemanticsMask unequalMemorySemantics,
     SpirvInstruction *valueToOp, SpirvInstruction *comparator,
-    SourceLocation loc) {
+    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context)
       SpirvAtomic(spv::Op::OpAtomicCompareExchange, resultType, loc,
                   originalValuePtr, scope, equalMemorySemantics,
-                  unequalMemorySemantics, valueToOp, comparator);
+                  unequalMemorySemantics, valueToOp, comparator, range);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
@@ -533,10 +539,11 @@ SpirvInstruction *SpirvBuilder::createImageSample(
   if (isSparse) {
     // Write the Residency Code
     const auto status = createCompositeExtract(astContext.UnsignedIntTy,
-                                               imageSampleInst, {0}, loc);
-    createStore(residencyCode, status, loc);
+                                               imageSampleInst, {0}, loc,
+		                                       range);
+    createStore(residencyCode, status, loc, range);
     // Extract the real result from the struct
-    return createCompositeExtract(texelType, imageSampleInst, {1}, loc);
+    return createCompositeExtract(texelType, imageSampleInst, {1}, loc, range);
   }
 
   return imageSampleInst;
@@ -548,7 +555,7 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
     SpirvInstruction *lod, SpirvInstruction *constOffset,
     SpirvInstruction *varOffset, SpirvInstruction *constOffsets,
     SpirvInstruction *sample, SpirvInstruction *residencyCode,
-    SourceLocation loc) {
+    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
 
   const auto mask = composeImageOperandsMask(
@@ -565,16 +572,17 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
   auto *fetchOrReadInst = new (context) SpirvImageOp(
       op, texelType, loc, image, coordinate, mask,
       /*dref*/ nullptr, /*bias*/ nullptr, lod, /*gradDx*/ nullptr,
-      /*gradDy*/ nullptr, constOffset, varOffset, constOffsets, sample);
+      /*gradDy*/ nullptr, constOffset, varOffset, constOffsets, sample,
+      nullptr, nullptr, nullptr, range);
   insertPoint->addInstruction(fetchOrReadInst);
 
   if (isSparse) {
     // Write the Residency Code
-    const auto status = createCompositeExtract(astContext.UnsignedIntTy,
-                                               fetchOrReadInst, {0}, loc);
-    createStore(residencyCode, status, loc);
+    const auto status = createCompositeExtract(
+        astContext.UnsignedIntTy, fetchOrReadInst, {0}, loc, range);
+    createStore(residencyCode, status, loc, range);
     // Extract the real result from the struct
-    return createCompositeExtract(texelType, fetchOrReadInst, {1}, loc);
+    return createCompositeExtract(texelType, fetchOrReadInst, {1}, loc, range);
   }
 
   return fetchOrReadInst;
@@ -583,7 +591,7 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
 void SpirvBuilder::createImageWrite(QualType imageType, SpirvInstruction *image,
                                     SpirvInstruction *coord,
                                     SpirvInstruction *texel,
-                                    SourceLocation loc) {
+                                    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *writeInst = new (context) SpirvImageOp(
       spv::Op::OpImageWrite, imageType, loc, image, coord,
@@ -591,7 +599,7 @@ void SpirvBuilder::createImageWrite(QualType imageType, SpirvInstruction *image,
       /*dref*/ nullptr, /*bias*/ nullptr, /*lod*/ nullptr, /*gradDx*/ nullptr,
       /*gradDy*/ nullptr, /*constOffset*/ nullptr, /*varOffset*/ nullptr,
       /*constOffsets*/ nullptr, /*sample*/ nullptr, /*minLod*/ nullptr,
-      /*component*/ nullptr, texel);
+      /*component*/ nullptr, texel, range);
   insertPoint->addInstruction(writeInst);
 }
 
@@ -642,21 +650,20 @@ SpirvInstruction *SpirvBuilder::createImageGather(
   return imageInstruction;
 }
 
-SpirvImageSparseTexelsResident *
-SpirvBuilder::createImageSparseTexelsResident(SpirvInstruction *residentCode,
-                                              SourceLocation loc) {
+SpirvImageSparseTexelsResident *SpirvBuilder::createImageSparseTexelsResident(
+    SpirvInstruction *residentCode, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *inst = new (context)
-      SpirvImageSparseTexelsResident(astContext.BoolTy, loc, residentCode);
+      SpirvImageSparseTexelsResident(astContext.BoolTy, loc, residentCode,
+		                             range);
   insertPoint->addInstruction(inst);
   return inst;
 }
 
-SpirvImageQuery *SpirvBuilder::createImageQuery(spv::Op opcode,
-                                                QualType resultType,
-                                                SourceLocation loc,
-                                                SpirvInstruction *image,
-                                                SpirvInstruction *lod) {
+SpirvImageQuery *
+SpirvBuilder::createImageQuery(spv::Op opcode, QualType resultType,
+                               SourceLocation loc, SpirvInstruction *image,
+                               SpirvInstruction *lod, SourceRange range) {
   assert(insertPoint && "null insert point");
   SpirvInstruction *lodParam = nullptr;
   SpirvInstruction *coordinateParam = nullptr;
@@ -666,7 +673,7 @@ SpirvImageQuery *SpirvBuilder::createImageQuery(spv::Op opcode,
     coordinateParam = lod;
 
   auto *inst = new (context) SpirvImageQuery(opcode, resultType, loc, image,
-                                             lodParam, coordinateParam);
+                                             lodParam, coordinateParam, range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -675,10 +682,10 @@ SpirvSelect *SpirvBuilder::createSelect(QualType resultType,
                                         SpirvInstruction *condition,
                                         SpirvInstruction *trueValue,
                                         SpirvInstruction *falseValue,
-                                        SourceLocation loc) {
+                                        SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *inst = new (context)
-      SpirvSelect(resultType, loc, condition, trueValue, falseValue);
+      SpirvSelect(resultType, loc, condition, trueValue, falseValue, range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -687,11 +694,11 @@ void SpirvBuilder::createSwitch(
     SpirvBasicBlock *mergeLabel, SpirvInstruction *selector,
     SpirvBasicBlock *defaultLabel,
     llvm::ArrayRef<std::pair<uint32_t, SpirvBasicBlock *>> target,
-    SourceLocation loc) {
+    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   // Create the OpSelectioMerege.
-  auto *selectionMerge = new (context)
-      SpirvSelectionMerge(loc, mergeLabel, spv::SelectionControlMask::MaskNone);
+  auto *selectionMerge = new (context) SpirvSelectionMerge(
+      loc, mergeLabel, spv::SelectionControlMask::MaskNone, range);
   insertPoint->addInstruction(selectionMerge);
 
   // Create the OpSwitch.
@@ -700,25 +707,26 @@ void SpirvBuilder::createSwitch(
   insertPoint->addInstruction(switchInst);
 }
 
-void SpirvBuilder::createKill(SourceLocation loc) {
+void SpirvBuilder::createKill(SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *kill = new (context) SpirvKill(loc);
+  auto *kill = new (context) SpirvKill(loc, range);
   insertPoint->addInstruction(kill);
 }
 
 void SpirvBuilder::createBranch(SpirvBasicBlock *targetLabel,
                                 SourceLocation loc, SpirvBasicBlock *mergeBB,
                                 SpirvBasicBlock *continueBB,
-                                spv::LoopControlMask loopControl) {
+                                spv::LoopControlMask loopControl,
+                                SourceRange range) {
   assert(insertPoint && "null insert point");
 
   if (mergeBB && continueBB) {
     auto *loopMerge =
-        new (context) SpirvLoopMerge(loc, mergeBB, continueBB, loopControl);
+        new (context) SpirvLoopMerge(loc, mergeBB, continueBB, loopControl, range);
     insertPoint->addInstruction(loopMerge);
   }
 
-  auto *branch = new (context) SpirvBranch(loc, targetLabel);
+  auto *branch = new (context) SpirvBranch(loc, targetLabel, range);
   insertPoint->addInstruction(branch);
 }
 
@@ -727,17 +735,17 @@ void SpirvBuilder::createConditionalBranch(
     SpirvBasicBlock *falseLabel, SourceLocation loc,
     SpirvBasicBlock *mergeLabel, SpirvBasicBlock *continueLabel,
     spv::SelectionControlMask selectionControl,
-    spv::LoopControlMask loopControl) {
+    spv::LoopControlMask loopControl, SourceRange range) {
   assert(insertPoint && "null insert point");
 
   if (mergeLabel) {
     if (continueLabel) {
       auto *loopMerge = new (context)
-          SpirvLoopMerge(loc, mergeLabel, continueLabel, loopControl);
+          SpirvLoopMerge(loc, mergeLabel, continueLabel, loopControl, range);
       insertPoint->addInstruction(loopMerge);
     } else {
-      auto *selectionMerge =
-          new (context) SpirvSelectionMerge(loc, mergeLabel, selectionControl);
+      auto *selectionMerge = new (context)
+          SpirvSelectionMerge(loc, mergeLabel, selectionControl, range);
       insertPoint->addInstruction(selectionMerge);
     }
   }
@@ -763,10 +771,10 @@ void SpirvBuilder::createReturnValue(SpirvInstruction *value,
 SpirvInstruction *
 SpirvBuilder::createGLSLExtInst(QualType resultType, GLSLstd450 inst,
                                 llvm::ArrayRef<SpirvInstruction *> operands,
-                                SourceLocation loc) {
+                                SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *extInst = new (context) SpirvExtInst(
-      resultType, loc, getExtInstSet("GLSL.std.450"), inst, operands);
+      resultType, loc, getExtInstSet("GLSL.std.450"), inst, operands, range);
   insertPoint->addInstruction(extInst);
   return extInst;
 }
@@ -774,10 +782,11 @@ SpirvBuilder::createGLSLExtInst(QualType resultType, GLSLstd450 inst,
 SpirvInstruction *
 SpirvBuilder::createGLSLExtInst(const SpirvType *resultType, GLSLstd450 inst,
                                 llvm::ArrayRef<SpirvInstruction *> operands,
-                                SourceLocation loc) {
+                                SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *extInst = new (context) SpirvExtInst(
-      /*QualType*/ {}, loc, getExtInstSet("GLSL.std.450"), inst, operands);
+      /*QualType*/ {}, loc, getExtInstSet("GLSL.std.450"), inst, operands,
+	  range);
   extInst->setResultType(resultType);
   insertPoint->addInstruction(extInst);
   return extInst;
@@ -797,10 +806,10 @@ SpirvInstruction *SpirvBuilder::createNonSemanticDebugPrintfExtInst(
 void SpirvBuilder::createBarrier(spv::Scope memoryScope,
                                  spv::MemorySemanticsMask memorySemantics,
                                  llvm::Optional<spv::Scope> exec,
-                                 SourceLocation loc) {
+                                 SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   SpirvBarrier *barrier =
-      new (context) SpirvBarrier(loc, memoryScope, memorySemantics, exec);
+      new (context) SpirvBarrier(loc, memoryScope, memorySemantics, exec, range);
   insertPoint->addInstruction(barrier);
 }
 
@@ -824,25 +833,27 @@ SpirvBitFieldExtract *SpirvBuilder::createBitFieldExtract(
   return inst;
 }
 
-void SpirvBuilder::createEmitVertex(SourceLocation loc) {
+void SpirvBuilder::createEmitVertex(SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *inst = new (context) SpirvEmitVertex(loc);
+  auto *inst = new (context) SpirvEmitVertex(loc, range);
   insertPoint->addInstruction(inst);
 }
 
-void SpirvBuilder::createEndPrimitive(SourceLocation loc) {
+void SpirvBuilder::createEndPrimitive(SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *inst = new (context) SpirvEndPrimitive(loc);
+  auto *inst = new (context) SpirvEndPrimitive(loc, range);
   insertPoint->addInstruction(inst);
 }
 
 SpirvArrayLength *SpirvBuilder::createArrayLength(QualType resultType,
                                                   SourceLocation loc,
                                                   SpirvInstruction *structure,
-                                                  uint32_t arrayMember) {
+                                                  uint32_t arrayMember,
+                                                  SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *inst =
-      new (context) SpirvArrayLength(resultType, loc, structure, arrayMember);
+      new (context) SpirvArrayLength(resultType, loc, structure, arrayMember,
+                                     range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -974,10 +985,11 @@ SpirvBuilder::createDebugFunctionDef(SpirvDebugFunction *function,
 SpirvInstruction *
 SpirvBuilder::createRayQueryOpsKHR(spv::Op opcode, QualType resultType,
                                    ArrayRef<SpirvInstruction *> operands,
-                                   bool cullFlags, SourceLocation loc) {
+                                   bool cullFlags, SourceLocation loc,
+                                   SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *inst = new (context)
-      SpirvRayQueryOpKHR(resultType, opcode, operands, cullFlags, loc);
+      SpirvRayQueryOpKHR(resultType, opcode, operands, cullFlags, loc, range);
   insertPoint->addInstruction(inst);
   return inst;
 }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -83,12 +83,14 @@ public:
   /// not be wrapped in ImplicitCastExpr (LValueToRValue) when appearing in
   /// HLSLVectorElementExpr since the generated HLSLVectorElementExpr itself can
   /// be lvalue or rvalue.
-  SpirvInstruction *loadIfGLValue(const Expr *expr);
+  SpirvInstruction *loadIfGLValue(const Expr *expr,
+                                  SourceRange rangeOverride = {});
 
   /// Casts the given value from fromType to toType. fromType and toType should
   /// both be scalar or vector types of the same size.
   SpirvInstruction *castToType(SpirvInstruction *value, QualType fromType,
-                               QualType toType, SourceLocation);
+                               QualType toType, SourceLocation,
+                               SourceRange range = {});
 
 private:
   void doFunctionDecl(const FunctionDecl *decl);
@@ -111,17 +113,23 @@ private:
   void doDoStmt(const DoStmt *, llvm::ArrayRef<const Attr *> attrs = {});
   void doContinueStmt(const ContinueStmt *);
 
-  SpirvInstruction *doArraySubscriptExpr(const ArraySubscriptExpr *expr);
+  SpirvInstruction *doArraySubscriptExpr(const ArraySubscriptExpr *expr,
+                                         SourceRange rangeOverride = {});
   SpirvInstruction *doBinaryOperator(const BinaryOperator *expr);
-  SpirvInstruction *doCallExpr(const CallExpr *callExpr);
-  SpirvInstruction *doCastExpr(const CastExpr *expr);
+  SpirvInstruction *doCallExpr(const CallExpr *callExpr,
+                               SourceRange rangeOverride = {});
+  SpirvInstruction *doCastExpr(const CastExpr *expr,
+                               SourceRange rangeOverride = {});
   SpirvInstruction *doCompoundAssignOperator(const CompoundAssignOperator *);
   SpirvInstruction *doConditionalOperator(const ConditionalOperator *expr);
   SpirvInstruction *doCXXMemberCallExpr(const CXXMemberCallExpr *expr);
-  SpirvInstruction *doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr);
+  SpirvInstruction *doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr,
+                                          SourceRange rangeOverride = {});
   SpirvInstruction *doExtMatrixElementExpr(const ExtMatrixElementExpr *expr);
-  SpirvInstruction *doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr);
-  SpirvInstruction *doInitListExpr(const InitListExpr *expr);
+  SpirvInstruction *doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr,
+                                            SourceRange rangeOverride = {});
+  SpirvInstruction *doInitListExpr(const InitListExpr *expr,
+                                   SourceRange rangeOverride = {});
   SpirvInstruction *doMemberExpr(const MemberExpr *expr,
                                  SourceRange rangeOverride = {});
   SpirvInstruction *doUnaryOperator(const UnaryOperator *expr);
@@ -138,7 +146,8 @@ private:
   /// more explanation regarding this.
   ///
   /// Note: legalization specific code
-  SpirvInstruction *loadIfAliasVarRef(const Expr *expr);
+  SpirvInstruction *loadIfAliasVarRef(const Expr *expr,
+                                      SourceRange rangeOverride = {});
 
   /// Loads the pointer of the aliased-to-variable and ajusts aliasVarInfo
   /// accordingly if aliasVarExpr is referencing an alias variable. Returns true
@@ -146,7 +155,8 @@ private:
   ///
   /// Note: legalization specific code
   bool loadIfAliasVarRef(const Expr *aliasVarExpr,
-                         SpirvInstruction **aliasVarInstr);
+                         SpirvInstruction **aliasVarInstr,
+                         SourceRange rangeOverride = {});
 
 private:
   /// Translates the given frontend binary operator into its SPIR-V equivalent
@@ -177,7 +187,8 @@ private:
   /// Decomposes and reconstructs the given srcVal of the given valType to meet
   /// the requirements of the dstLR layout rule.
   SpirvInstruction *reconstructValue(SpirvInstruction *srcVal, QualType valType,
-                                     SpirvLayoutRule dstLR, SourceLocation loc);
+                                     SpirvLayoutRule dstLR, SourceLocation loc,
+                                     SourceRange range = {});
 
   /// Generates the necessary instructions for conducting the given binary
   /// operation on lhs and rhs.
@@ -240,7 +251,8 @@ private:
   /// the given scalarExpr. The generated vector will have the same element
   /// type as scalarExpr and of the given size. If resultIsConstant is not
   /// nullptr, writes true to it if the generated instruction is a constant.
-  SpirvInstruction *createVectorSplat(const Expr *scalarExpr, uint32_t size);
+  SpirvInstruction *createVectorSplat(const Expr *scalarExpr, uint32_t size,
+                                      SourceRange rangeOverride = {});
 
   /// Splits the given vector into the last element and the rest (as a new
   /// vector).
@@ -256,7 +268,8 @@ private:
   SpirvInstruction *convertVectorToStruct(QualType structType,
                                           QualType elemType,
                                           SpirvInstruction *vector,
-                                          SourceLocation loc);
+                                          SourceLocation loc,
+                                          SourceRange range = {});
 
   /// Translates a floatN * float multiplication into SPIR-V instructions and
   /// returns the <result-id>. Returns 0 if the given binary operation is not
@@ -272,18 +285,21 @@ private:
   /// accessing expression. Returns 0 if the trial fails and no instructions
   /// are generated.
   SpirvInstruction *tryToAssignToVectorElements(const Expr *lhs,
-                                                SpirvInstruction *rhs);
+                                                SpirvInstruction *rhs,
+	                                            SourceRange range = {});
 
   /// Tries to emit instructions for assigning to the given matrix element
   /// accessing expression. Returns 0 if the trial fails and no instructions
   /// are generated.
   SpirvInstruction *tryToAssignToMatrixElements(const Expr *lhs,
-                                                SpirvInstruction *rhs);
+                                                SpirvInstruction *rhs,
+	                                            SourceRange range = {});
 
   /// Tries to emit instructions for assigning to the given RWBuffer/RWTexture
   /// object. Returns 0 if the trial fails and no instructions are generated.
   SpirvInstruction *tryToAssignToRWBufferRWTexture(const Expr *lhs,
-                                                   SpirvInstruction *rhs);
+                                                   SpirvInstruction *rhs,
+                                                   SourceRange range = {});
 
   /// Tries to emit instructions for assigning to the given mesh out attribute
   /// or indices object. Returns 0 if the trial fails and no instructions are
@@ -312,7 +328,7 @@ private:
       llvm::function_ref<SpirvInstruction *(uint32_t, QualType,
                                             SpirvInstruction *)>
           actOnEachVector,
-      SourceLocation loc = {});
+      SourceLocation loc = {}, SourceRange range = {});
 
   /// Translates the given varDecl into a spec constant.
   void createSpecConstant(const VarDecl *varDecl);
@@ -363,22 +379,26 @@ private:
   /// float/integer type.
   SpirvInstruction *convertBitwidth(SpirvInstruction *value, SourceLocation loc,
                                     QualType fromType, QualType toType,
-                                    QualType *resultType = nullptr);
+                                    QualType *resultType = nullptr,
+                                    SourceRange range = {});
 
   /// Processes the given expr, casts the result into the given bool (vector)
   /// type and returns the <result-id> of the casted value.
   SpirvInstruction *castToBool(SpirvInstruction *value, QualType fromType,
-                               QualType toType, SourceLocation loc);
+                               QualType toType, SourceLocation loc,
+                               SourceRange range = {});
 
   /// Processes the given expr, casts the result into the given integer (vector)
   /// type and returns the <result-id> of the casted value.
   SpirvInstruction *castToInt(SpirvInstruction *value, QualType fromType,
-                              QualType toType, SourceLocation);
+                              QualType toType, SourceLocation,
+                              SourceRange srcRange = {});
 
   /// Processes the given expr, casts the result into the given float (vector)
   /// type and returns the <result-id> of the casted value.
   SpirvInstruction *castToFloat(SpirvInstruction *value, QualType fromType,
-                                QualType toType, SourceLocation);
+                                QualType toType, SourceLocation,
+                                SourceRange range = {});
 
 private:
   /// Processes HLSL instrinsic functions.
@@ -433,22 +453,23 @@ private:
   /// transpose.
   SpirvInstruction *processNonFpMatrixTranspose(QualType matType,
                                                 SpirvInstruction *matrix,
-                                                SourceLocation loc);
+                                                SourceLocation loc,
+                                                SourceRange range = {});
 
   /// Processes the dot product of two non-floating point vectors. The SPIR-V
   /// OpDot only accepts float vectors. Assumes that the two vectors are of the
   /// same size and have the same element type (elemType).
   SpirvInstruction *processNonFpDot(SpirvInstruction *vec1Id,
                                     SpirvInstruction *vec2Id, uint32_t vecSize,
-                                    QualType elemType, SourceLocation loc);
+                                    QualType elemType, SourceLocation loc,
+                                    SourceRange range = {});
 
   /// Processes the multiplication of a *non-floating point* matrix by a scalar.
   /// Assumes that the matrix element type and the scalar type are the same.
-  SpirvInstruction *processNonFpScalarTimesMatrix(QualType scalarType,
-                                                  SpirvInstruction *scalar,
-                                                  QualType matType,
-                                                  SpirvInstruction *matrix,
-                                                  SourceLocation loc);
+  SpirvInstruction *
+  processNonFpScalarTimesMatrix(QualType scalarType, SpirvInstruction *scalar,
+                                QualType matType, SpirvInstruction *matrix,
+                                SourceLocation loc, SourceRange range = {});
 
   /// Processes the multiplication of a *non-floating point* matrix by a vector.
   /// Assumes the matrix element type and the vector element type are the same.
@@ -457,28 +478,25 @@ private:
   /// matrix must be transposed in order to easily get each column. If
   /// 'matrixTranspose' is non-zero, it will be used as the transpose matrix
   /// result-id; otherwise the function will perform the transpose itself.
-  SpirvInstruction *
-  processNonFpVectorTimesMatrix(QualType vecType, SpirvInstruction *vector,
-                                QualType matType, SpirvInstruction *matrix,
-                                SourceLocation loc,
-                                SpirvInstruction *matrixTranspose = nullptr);
+  SpirvInstruction *processNonFpVectorTimesMatrix(
+      QualType vecType, SpirvInstruction *vector, QualType matType,
+      SpirvInstruction *matrix, SourceLocation loc,
+      SpirvInstruction *matrixTranspose = nullptr, SourceRange range = {});
 
   /// Processes the multiplication of a vector by a *non-floating point* matrix.
   /// Assumes the matrix element type and the vector element type are the same.
-  SpirvInstruction *processNonFpMatrixTimesVector(QualType matType,
-                                                  SpirvInstruction *matrix,
-                                                  QualType vecType,
-                                                  SpirvInstruction *vector,
-                                                  SourceLocation loc);
+  SpirvInstruction *
+  processNonFpMatrixTimesVector(QualType matType, SpirvInstruction *matrix,
+                                QualType vecType, SpirvInstruction *vector,
+                                SourceLocation loc, SourceRange range = {});
 
   /// Processes a non-floating point matrix multiplication. Assumes that the
   /// number of columns in lhs matrix is the same as number of rows in the rhs
   /// matrix. Also assumes that the two matrices have the same element type.
-  SpirvInstruction *processNonFpMatrixTimesMatrix(QualType lhsType,
-                                                  SpirvInstruction *lhs,
-                                                  QualType rhsType,
-                                                  SpirvInstruction *rhs,
-                                                  SourceLocation loc);
+  SpirvInstruction *
+  processNonFpMatrixTimesMatrix(QualType lhsType, SpirvInstruction *lhs,
+                                QualType rhsType, SpirvInstruction *rhs,
+                                SourceLocation loc, SourceRange range = {});
 
   /// Processes the 'dot' intrinsic function.
   SpirvInstruction *processIntrinsicDot(const CallExpr *);
@@ -525,7 +543,8 @@ private:
   SpirvInstruction *processIntrinsicUsingGLSLInst(const CallExpr *,
                                                   GLSLstd450 instr,
                                                   bool canOperateOnMatrix,
-                                                  SourceLocation);
+                                                  SourceLocation,
+                                                  SourceRange range = {});
 
   /// Processes the given intrinsic function call using the given SPIR-V
   /// instruction. If the given instruction cannot operate on matrices, it
@@ -641,7 +660,8 @@ private:
   SpirvInstruction *processFlatConversion(const QualType type,
                                           const QualType initType,
                                           SpirvInstruction *initId,
-                                          SourceLocation);
+                                          SourceLocation,
+                                          SourceRange range = {});
 
 private:
   /// Translates the given frontend APValue into its SPIR-V equivalent for the
@@ -871,7 +891,8 @@ private:
   processBufferTextureLoad(const Expr *object, SpirvInstruction *location,
                            SpirvInstruction *constOffset,
                            SpirvInstruction *varOffset, SpirvInstruction *lod,
-                           SpirvInstruction *residencyCode, SourceLocation loc);
+                           SpirvInstruction *residencyCode, SourceLocation loc,
+                           SourceRange range = {});
 
   /// \brief Processes .Sample() and .Gather() method calls for texture objects.
   SpirvInstruction *processTextureSampleGather(const CXXMemberCallExpr *expr,
@@ -999,16 +1020,17 @@ private:
   /// with 1, 2, 4, 8, or 16 samples. Returns float2(0) for other cases.
   SpirvInstruction *emitGetSamplePosition(SpirvInstruction *sampleCount,
                                           SpirvInstruction *sampleIndex,
-                                          SourceLocation loc);
+                                          SourceLocation loc,
+                                          SourceRange range = {});
 
   /// \brief Returns OpAccessChain to the struct/class object that defines
   /// memberFn when the struct/class is a base struct/class of objectType.
   /// If the struct/class that defines memberFn is not a base of objectType,
   /// returns nullptr.
   SpirvInstruction *getBaseOfMemberFunction(QualType objectType,
-                                            SpirvInstruction * objInstr,
-                                            const CXXMethodDecl* memberFn,
-                                       SourceLocation loc);
+                                            SpirvInstruction *objInstr,
+                                            const CXXMethodDecl *memberFn,
+                                            SourceLocation loc);
 
 private:
   /// \brief Takes a vector of size 4, and returns a vector of size 1 or 2 or 3
@@ -1019,7 +1041,8 @@ private:
   SpirvInstruction *extractVecFromVec4(SpirvInstruction *fromInstr,
                                        uint32_t targetVecSize,
                                        QualType targetElemType,
-                                       SourceLocation loc);
+                                       SourceLocation loc,
+                                       SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for sampling the given image.
   /// It utilizes the ModuleBuilder's createImageSample and it ensures that the

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.branch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.branch.hlsl
@@ -1,0 +1,92 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[dbgsrc:%\d+]] = OpExtInst %void %1 DebugSource [[file]]
+
+static int a, b, c;
+
+void main() {
+// CHECK:       DebugLine [[dbgsrc]] %uint_11 %uint_11 %uint_3 %uint_3
+// CHECK-NEXT:  OpBranch %do_while_header
+  do {
+// CHECK:       DebugLine [[dbgsrc]] %uint_11 %uint_11 %uint_6 %uint_6
+// CHECK-NEXT:  OpLoopMerge %do_while_merge %do_while_continue None
+// CHECK-NEXT:  OpBranch %do_while_body
+    if (a < 27) {
+      ++a;
+// CHECK:       DebugLine [[dbgsrc]] %uint_19 %uint_19 %uint_7 %uint_7
+// CHECK-NEXT:  OpBranch %do_while_continue
+      continue;
+    }
+    b += a;
+// CHECK:       DebugLine [[dbgsrc]] %uint_27 %uint_27 %uint_3 %uint_3
+// CHECK-NEXT:  OpBranch %do_while_continue
+
+// CHECK:       DebugLine [[dbgsrc]] %uint_27 %uint_27 %uint_17 %uint_17
+// CHECK-NEXT:  OpBranchConditional {{%\d+}} %do_while_header %do_while_merge
+  } while (c < b);
+
+// CHECK:       DebugLine [[dbgsrc]] %uint_33 %uint_33 %uint_3 %uint_3
+// CHECK-NEXT:  OpBranch %while_check
+// CHECK:       DebugLine [[dbgsrc]] %uint_33 %uint_33 %uint_10 %uint_14
+// CHECK:       OpLoopMerge %while_merge %while_continue None
+  while (a < c) {
+// CHECK:       DebugLine [[dbgsrc]] %uint_37 %uint_37 %uint_9 %uint_13
+// CHECK:       OpSelectionMerge %if_merge_1 None
+// CHECK-NEXT:  OpBranchConditional {{%\d+}} %if_true_0 %if_false
+    if (b < 34) {
+      a = 99;
+// CHECK:       DebugLine [[dbgsrc]] %uint_42 %uint_42 %uint_16 %uint_20 
+// CHECK:       OpSelectionMerge %if_merge_0 None
+// CHECK-NEXT:  OpBranchConditional {{%\d+}} %if_true_1 %if_false_0
+    } else if (a > 100) {
+      a -= 20;
+// CHECK:       DebugLine [[dbgsrc]] %uint_46 %uint_46 %uint_7 %uint_7
+// CHECK-NEXT:  OpBranch %while_merge
+      break;
+    } else {
+      c = b;
+// CHECK:       DebugLine [[dbgsrc]] %uint_51 %uint_51 %uint_5 %uint_5
+// CHECK-NEXT:  OpBranch %if_merge_0
+    }
+// CHECK:                        DebugLine [[dbgsrc]] %uint_57 %uint_57 %uint_3 %uint_3
+// CHECK-NEXT:                   OpBranch %while_continue
+// CHECK-NEXT: %while_continue = OpLabel
+// CHECK:                        DebugLine [[dbgsrc]] %uint_57 %uint_57 %uint_3 %uint_3
+// CHECK-NEXT:                   OpBranch %while_check
+  }
+
+// CHECK:       DebugLine [[dbgsrc]] %uint_61 %uint_61 %uint_8 %uint_17
+// CHECK-NEXT:  OpBranch %for_check
+  for (int i = 0; i < 10 && float(a / b) < 2.7; ++i) {
+// CHECK:       DebugLine [[dbgsrc]] %uint_61 %uint_61 %uint_19 %uint_44
+// CHECK:       OpLoopMerge %for_merge %for_continue None
+// CHECK-NEXT:  OpBranchConditional {{%\d+}} %for_body %for_merge
+    c = a + 2 * b + c;
+// CHECK:                      DebugLine [[dbgsrc]] %uint_61 %uint_61 %uint_49 %uint_51
+// CHECK-NEXT:                 OpBranch %for_continue
+// CHECK-NEXT: %for_continue = OpLabel
+  }
+// CHECK:                      DebugLine [[dbgsrc]] %uint_61 %uint_61 %uint_49 %uint_51
+// CHECK:                      OpBranch %for_check
+// CHECK-NEXT:    %for_merge = OpLabel
+
+  switch (a) {
+  case 1:
+    b = c;
+// CHECK:      DebugLine [[dbgsrc]] %uint_79 %uint_79 %uint_5 %uint_5
+// CHECK-NEXT: OpBranch %switch_merge
+    break;
+  case 2:
+    b = 2 * c;
+// CHECK:      DebugLine [[dbgsrc]] %uint_84 %uint_84 %uint_3 %uint_3
+// CHECK-NEXT: OpBranch %switch_4
+  case 4:
+    b = b + 4;
+    break;
+  default:
+    b = a;
+// CHECK:      DebugLine [[dbgsrc]] %uint_86 %uint_86 %uint_5 %uint_5
+// CHECK-NEXT: OpBranch %switch_merge
+  }
+}

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.composite.hlsl
@@ -1,0 +1,118 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[src:%\d+]] = OpExtInst %void %2 DebugSource [[file]]
+
+struct int4_bool_float3 {
+  int4 a;
+  bool b;
+  float3 c;
+};
+
+int4_bool_float3 test_struct() {
+  int4_bool_float3 x;
+  return x;
+}
+
+cbuffer CONSTANTS {
+  int4_bool_float3 y;
+};
+
+RWTexture2D<int3> z;
+
+struct S {
+  int a;
+  // TODO(greg-lunarg): void inc() { a++; }
+};
+
+S getS() {
+  S a;
+  return a;
+}
+
+struct init {
+  int first;
+  float second;
+};
+
+// Note that preprocessor prepends a "#line 1 ..." line to the whole file,
+// the compliation sees line numbers incremented by 1.
+
+void main() {
+  S foo;
+
+  init bar;
+
+  int4 a = {
+      float2(1, 0),
+// CHECK: DebugLine [[src]] %uint_50 %uint_50 %uint_7 %uint_19
+// CHECK: OpFunctionCall %int4_bool_float3_0 %test_struct
+      test_struct().c.zx
+// CHECK:      OpCompositeExtract %float {{%\d+}} 0
+// CHECK-NEXT: OpCompositeExtract %float {{%\d+}} 1
+// CHECK-NEXT: DebugLine [[src]] %uint_46 %uint_46 %uint_12 %uint_12
+// CHECK-NEXT: OpConvertFToS %int
+// CHECK-NEXT: OpConvertFToS %int
+// CHECK:      OpCompositeConstruct %v4int
+  };
+
+// CHECK:                        OpFDiv %float {{%\d+}} %float_2
+// CHECK-NEXT:                   DebugLine [[src]] %uint_64 %uint_64 %uint_16 %uint_57
+// CHECK-NEXT:  [[first:%\d+]] = OpCompositeConstruct %v2float {{%\d+}} {{%\d+}}
+// CHECK-NEXT: [[second:%\d+]] = OpCompositeConstruct %v2float {{%\d+}} {{%\d+}}
+// CHECK-NEXT:        {{%\d+}} = OpCompositeConstruct %mat2v2float [[first]] [[second]]
+  float2x2 b = float2x2(a.x, b._m00, 2 + a.y, b._m11 / 2);
+
+// CHECK:                   DebugLine [[src]] %uint_69 %uint_69 %uint_12 %uint_14
+// CHECK-NEXT: [[y:%\d+]] = OpAccessChain %_ptr_Uniform_int4_bool_float3 %CONSTANTS %int_0
+// CHECK-NEXT:   {{%\d+}} = OpAccessChain %_ptr_Uniform_v4int [[y]] %int_0
+  int4 c = y.a;
+
+// CHECK:                   DebugLine [[src]] %uint_76 %uint_76 %uint_3 %uint_3
+// CHECK-NEXT: [[z:%\d+]] = OpLoad %type_2d_image %z
+// CHECK-NEXT: [[z:%\d+]] = OpImageRead %v4int [[z]] {{%\d+}} None
+// CHECK-NEXT: [[z:%\d+]] = OpVectorShuffle %v3int [[z]] [[z]] 0 1 2
+// CHECK:        {{%\d+}} = OpCompositeInsert %v3int %int_16 [[z]] 0
+  z[uint2(2, 3)].x = 16;
+
+// CHECK:      DebugLine [[src]] %uint_82 %uint_82 %uint_3 %uint_4
+// CHECK-NEXT: OpLoad %mat2v2float %b
+// CHECK:      DebugLine [[src]] %uint_82 %uint_82 %uint_3 %uint_4
+// CHECK-NEXT: OpFSub %v2float
+  b--;
+
+  int2x2 d;
+// CHECK:      DebugLine [[src]] %uint_91 %uint_91 %uint_8 %uint_8
+// CHECK-NEXT: OpLoad %mat2v2float %b
+// CHECK-NEXT: DebugLine [[src]] %uint_91 %uint_91 %uint_3 %uint_12
+// CHECK-NEXT: OpCompositeExtract %v2float
+// CHECK:      OpCompositeConstruct %_arr_v2int_uint_2
+// CHECK-NEXT: OpStore %d
+  modf(b, d);
+
+// CHECK-TODO:      DebugLine [[src]] %uint_95 %uint_95 %uint_3 %uint_11
+// CHECK-NEXT-TODO: OpFunctionCall %void %S_inc %foo
+// TODO(greg-lunarg):  foo.inc();
+
+// CHECK-TODO:      DebugLine [[src]] %uint_99 %uint_99 %uint_3 %uint_14
+// CHECK-NEXT-TODO: OpFunctionCall %void %S_inc %temp_var_S
+// TODO(greg-lunarg):  getS().inc();
+
+// CHECK:      DebugLine [[src]] %uint_105 %uint_105 %uint_19 %uint_19
+// CHECK-NEXT: OpLoad %init %bar
+// CHECK:      DebugLine [[src]] %uint_105 %uint_105 %uint_12 %uint_12
+// CHECK-NEXT: OpConvertFToS %int
+  int4 e = {1, 2, bar};
+
+// CHECK:      DebugLine [[src]] %uint_111 %uint_111 %uint_7 %uint_25
+// CHECK-NEXT: OpCompositeConstruct %v2float %float_1 %float_2
+// CHECK-NEXT: DebugLine [[src]] %uint_111 %uint_111 %uint_22 %uint_22
+// CHECK-NEXT: OpCompositeExtract %int
+  b = float2x2(1, 2, bar);
+// CHECK:      DebugLine [[src]] %uint_111 %uint_111 %uint_3 %uint_25
+// CHECK-NEXT: OpStore %b
+
+// TODO(jaebaek): Update InitListHandler to properly emit debug info.
+  b = float2x2(c);
+  c = int4(b);
+}

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.hlsl
@@ -3,7 +3,7 @@
 // CHECK:      [[ext:%\d+]] = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
 // CHECK:      [[src:%\d+]] = OpExtInst %void [[ext]] DebugSource {{%\d+}}
 
-// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_57 %uint_61
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_57 %uint_78
 // CHECK-NEXT: OpAccessChain %_ptr_Function_v2float %i %int_0
 
 // CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_26 %uint_81

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.include.hlsl
@@ -1,0 +1,107 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:           [[main:%\d+]] = OpString
+// CHECK-SAME:      shader.debug.line.include.hlsl
+// CHECK:           OpString
+// CHECK:           [[file3:%\d+]] = OpString
+// CHECK-SAME:      spirv.debug.opline.include-file-3.hlsl
+// CHECK:           OpString
+// CHECK:           OpString
+// CHECK:           [[file2:%\d+]] = OpString
+// CHECK-SAME:      spirv.debug.opline.include-file-2.hlsl
+// CHECK:           OpString
+// CHECK:           [[file1:%\d+]] = OpString
+// CHECK-SAME:      spirv.debug.opline.include-file-1.hlsl
+// CHECK:      [[src3:%\d+]] = OpExtInst %void %1 DebugSource [[file3]]
+// CHECK:      [[src2:%\d+]] = OpExtInst %void %1 DebugSource [[file2]]
+// CHECK:      [[src1:%\d+]] = OpExtInst %void %1 DebugSource [[file1]]
+// CHECK:      [[src0:%\d+]] = OpExtInst %void %1 DebugSource [[main]]
+
+// DebugLine cannot preceed OpFunction
+// CHECK:      %src_main = OpFunction %void None
+
+#include "spirv.debug.opline.include-file-1.hlsl"
+
+int callFunction1() {
+  return function1();
+}
+
+#include "spirv.debug.opline.include-file-2.hlsl"
+
+int callFunction2() {
+  // This
+  // is
+  // an
+  // intentional
+  // multiple
+  // lines.
+  // It
+  // might
+  // be
+  // a
+  // single
+  // line
+  // in
+  // OpSource.
+  return function2();
+}
+
+#include "spirv.debug.opline.include-file-3.hlsl"
+
+int callFunction3() {
+  // This
+  // is
+  // an
+  // intentional
+  // multiple
+  // lines.
+  // It
+  // might
+  // be
+  // a
+  // single
+  // line
+  // in
+  // OpSource.
+  CALL_FUNCTION_3;
+}
+
+void main() {
+// CHECK:      DebugLine [[src0]] %uint_72 %uint_72 %uint_3 %uint_17
+// CHECK-NEXT: OpFunctionCall %int %callFunction1
+  callFunction1();
+
+  // This
+  // is
+  // an
+  // intentional
+  // multiple
+  // lines.
+  // It
+  // might
+  // be
+  // a
+  // single
+  // line
+  // in
+  // OpSource.
+// CHECK:      DebugLine [[src0]] %uint_90 %uint_90 %uint_3 %uint_17
+// CHECK-NEXT: OpFunctionCall %int %callFunction2
+  callFunction2();
+
+// CHECK:      DebugLine [[src0]] %uint_94 %uint_94 %uint_3 %uint_17
+// CHECK-NEXT: OpFunctionCall %int %callFunction3
+  callFunction3();
+}
+
+// CHECK:      %function1 = OpFunction %int None
+// CHECK:      DebugLine [[src1]] %uint_2 %uint_2 %uint_3 %uint_10
+// CHECK-NEXT: OpReturnValue %int_1
+
+// CHECK:      %function2 = OpFunction %int None
+// CHECK:      DebugLine [[src2]] %uint_3 %uint_3 %uint_10 %uint_10
+// CHECK-NEXT: OpLoad %int %a
+
+// CHECK:      %function3 = OpFunction %int None
+// CHECK:      DebugLine [[src3]] %uint_4 %uint_4 %uint_10 %uint_10
+// CHECK:      OpLoad %int

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.intrinsic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.intrinsic.hlsl
@@ -1,0 +1,186 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan -no-warnings
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[src:%\d+]] = OpExtInst %void %2 DebugSource [[file]]
+
+static int dest_i;
+
+void main() {
+  float2 v2f;
+  uint4 v4i;
+  float2x2 m2x2f;
+
+// CHECK:                     DebugLine [[src]] %uint_16 %uint_22 %uint_3 %uint_14
+// CHECK-NEXT: [[mod:%\d+]] = OpExtInst %ModfStructType {{%\d+}} ModfStruct {{%\d+}}
+// CHECK-NEXT:     {{%\d+}} = OpCompositeExtract %v2float [[mod]] 1
+  modf(v2f,
+// CHECK:      [[mod:%\d+]] = OpConvertFToU %v2uint {{%\d+}}
+// CHECK-NEXT:                DebugLine [[src]] %uint_22 %uint_22 %uint_8 %uint_8
+// CHECK-NEXT: [[v4i:%\d+]] = OpLoad %v4uint %v4i
+// CHECK-NEXT: [[v4i:%\d+]] = OpVectorShuffle %v4uint [[v4i]] [[mod]] 4 5 2 3
+// CHECK-NEXT:                OpStore %v4i [[v4i]]
+       v4i.xy);
+
+// CHECK:                      DebugLine [[src]] %uint_29 %uint_29 %uint_9 %uint_9
+// CHECK-NEXT: [[v4ix:%\d+]] = OpCompositeExtract %uint {{%\d+}} 0
+// CHECK-NEXT:      {{%\d+}} = OpShiftLeftLogical %uint [[v4ix]] %uint_8
+// CHECK-NEXT:      {{%\d+}} = OpShiftLeftLogical %uint [[v4ix]] %uint_16
+// CHECK-NEXT:      {{%\d+}} = OpShiftLeftLogical %uint [[v4ix]] %uint_24
+  v4i = msad4(v4i.x, v4i.xy, v4i);
+// CHECK:      DebugLine [[src]] %uint_29 %uint_29 %uint_3 %uint_33
+// CHECK-NEXT: OpStore %v4i {{%\d+}}
+
+// CHECK:      DebugLine [[src]] %uint_35 %uint_35 %uint_23 %uint_67
+// CHECK:      OpExtInst %v2float {{%\d+}} Fma
+  /* comment */ v4i = mad(m2x2f, float2x2(v4i), float2x2(v2f, v2f));
+// CHECK:      DebugLine [[src]] %uint_35 %uint_35 %uint_17 %uint_67
+// CHECK-NEXT: OpStore %v4i
+
+// CHECK:                 DebugLine [[src]] %uint_41 %uint_41 %uint_9 %uint_23
+// CHECK-NEXT: {{%\d+}} = OpMatrixTimesVector %v2float
+  v2f = mul(v2f, m2x2f);
+
+// CHECK:                 DebugLine [[src]] %uint_45 %uint_45 %uint_11 %uint_26
+// CHECK-NEXT: {{%\d+}} = OpDot %float
+  v2f.x = dot(v4i.xy, v2f);
+
+// CHECK:                 DebugLine [[src]] %uint_49 %uint_49 %uint_11 %uint_25
+// CHECK-NEXT: {{%\d+}} = OpExtInst %v2float {{%\d+}} UnpackHalf2x16
+  v2f.x = f16tof32(v4i.x);
+
+// CHECK:                 DebugLine [[src]] %uint_53 %uint_53 %uint_11 %uint_20
+// CHECK-NEXT: {{%\d+}} = OpDPdx %v2float
+  m2x2f = ddx(m2x2f);
+
+// CHECK:                       DebugLine [[src]] %uint_60 %uint_60 %uint_11 %uint_36
+// CHECK-NEXT: [[fmod0:%\d+]] = OpFRem %v2float {{%\d+}} {{%\d+}}
+// CHECK:                       DebugLine [[src]] %uint_60 %uint_60 %uint_11 %uint_36
+// CHECK-NEXT: [[fmod1:%\d+]] = OpFRem %v2float {{%\d+}} {{%\d+}}
+// CHECK-NEXT:       {{%\d+}} = OpCompositeConstruct %mat2v2float [[fmod0]] [[fmod1]]
+  m2x2f = fmod(m2x2f, float2x2(v4i));
+
+// CHECK:                     DebugLine [[src]] %uint_65 %uint_65 %uint_7 %uint_7
+// CHECK-NEXT: [[v2f:%\d+]] = OpFOrdNotEqual %v2bool
+// CHECK:          {{%\d+}} = OpAll %bool [[v2f]]
+  if (all(v2f))
+// CHECK:                      DebugLine [[src]] %uint_72 %uint_72 %uint_5 %uint_31
+// CHECK:       [[sin:%\d+]] = OpExtInst %float {{%\d+}} Sin {{%\d+}}
+// CHECK-NEXT:                 DebugLine [[src]] %uint_72 %uint_72 %uint_19 %uint_23
+// CHECK-NEXT: [[v2fx:%\d+]] = OpAccessChain %_ptr_Function_float %v2f %int_1
+// CHECK-NEXT:                 DebugLine [[src]] %uint_72 %uint_72 %uint_5 %uint_31
+// CHECK-NEXT:                 OpStore [[v2fx]] [[sin]]
+    sincos(v2f.x, v2f.y, v2f.x);
+
+// CHECK:                 DebugLine [[src]] %uint_76 %uint_76 %uint_9 %uint_21
+// CHECK-NEXT: {{%\d+}} = OpExtInst %v2float {{%\d+}} FClamp
+  v2f = saturate(v2f);
+
+// CHECK: DebugLine [[src]] %uint_80 %uint_80 %uint_26 %uint_33
+// CHECK: OpAny
+  /* comment */ dest_i = any(v4i);
+
+// CHECK:                     DebugLine [[src]] %uint_87 %uint_87 %uint_35 %uint_47
+// CHECK-NEXT: [[idx:%\d+]] = OpIAdd %uint
+// CHECK:                     DebugLine [[src]] %uint_87 %uint_87 %uint_3 %uint_48
+// CHECK-NEXT: [[v4i:%\d+]] = OpAccessChain %_ptr_Function_uint %v4i %int_0
+// CHECK-NEXT:                OpStore [[v4i]] {{%\d+}}
+  v4i.x = NonUniformResourceIndex(v4i.y + v4i.z);
+
+// CHECK:      DebugLine [[src]] %uint_93 %uint_93 %uint_11 %uint_39
+// CHECK-NEXT: OpImageSparseTexelsResident %bool
+// CHECK:      DebugLine [[src]] %uint_93 %uint_93 %uint_3 %uint_39
+// CHECK-NEXT: OpAccessChain %_ptr_Function_uint %v4i %int_2
+  v4i.z = CheckAccessFullyMapped(v4i.w);
+
+// CHECK:                     DebugLine [[src]] %uint_101 %uint_101 %uint_19 %uint_36
+// CHECK-NEXT: [[add:%\d+]] = OpFAdd %v2float
+// CHECK-NEXT:                DebugLine [[src]] %uint_101 %uint_101 %uint_12 %uint_39
+// CHECK-NEXT:                OpBitcast %v2uint [[add]]
+// CHECK-NEXT:                DebugLine [[src]] %uint_101 %uint_101 %uint_3 %uint_39
+// CHECK-NEXT:                OpLoad %v4uint %v4i
+  v4i.xy = asuint(m2x2f._m00_m11 + v2f);
+
+// CHECK:      DebugLine [[src]] %uint_107 %uint_107 %uint_8 %uint_23
+// CHECK-NEXT: OpFMul %v2float
+// CHECK-NEXT: DebugLine [[src]] %uint_107 %uint_107 %uint_3 %uint_31
+// CHECK-NEXT: OpFOrdLessThan %v2bool
+  clip(v4i.yz * m2x2f._m00_m11);
+
+  float4 v4f;
+
+// CHECK:      DebugLine [[src]] %uint_115 %uint_115 %uint_9 %uint_37
+// CHECK:      OpFMul %float
+// CHECK-NEXT: OpCompositeConstruct %v4float
+// CHECK-NEXT: OpConvertFToU %v4uint
+  v4i = dst(v4f + 3 * v4f, v4f - v4f);
+
+// CHECK:      DebugLine [[src]] %uint_121 %uint_121 %uint_17 %uint_43
+// CHECK-NEXT: OpExtInst %float {{%\d+}} Exp2
+// CHECK:      DebugLine [[src]] %uint_121 %uint_121 %uint_11 %uint_44
+// CHECK-NEXT: OpBitcast %int
+  v4i.x = asint(ldexp(v4f.x + v4f.y, v4f.w));
+
+// CHECK:      DebugLine [[src]] %uint_129 %uint_129 %uint_19 %uint_31
+// CHECK-NEXT: OpFAdd %float
+// CHECK-NEXT: DebugLine [[src]] %uint_129 %uint_129 %uint_34 %uint_38
+// CHECK-NEXT: OpAccessChain %_ptr_Function_float %v4f %int_3
+// CHECK-NEXT: DebugLine [[src]] %uint_129 %uint_129 %uint_13 %uint_39
+// CHECK-NEXT: OpExtInst %FrexpStructType {{%\d+}} FrexpStruct
+  v4f = lit(frexp(v4f.x + v4f.y, v4f.w),
+// CHECK:                     DebugLine [[src]] %uint_133 %uint_133 %uint_13 %uint_17
+// CHECK-NEXT: [[v4f:%\d+]] = OpAccessChain %_ptr_Function_float %v4f %int_2
+// CHECK-NEXT:                OpLoad %float [[v4f]]
+            v4f.z,
+// CHECK:                       DebugLine [[src]] %uint_140 %uint_140 %uint_13 %uint_58
+// CHECK-NEXT: [[clamp:%\d+]] = OpExtInst %uint {{%\d+}} UClamp
+// CHECK-NEXT:                  OpConvertUToF %float [[clamp]]
+// CHECK-NEXT:                  DebugLine [[src]] %uint_129 %uint_140 %uint_9 %uint_59
+// CHECK-NEXT:                  OpExtInst %float {{%\d+}} FMax %float_0
+// CHECK-NEXT:                  OpExtInst %float {{%\d+}} FMin
+            clamp(v4i.x + v4i.y, 2 * v4i.z, v4i.w - v4i.z));
+
+// CHECK:                      DebugLine [[src]] %uint_146 %uint_146 %uint_33 %uint_59
+// CHECK-NEXT: [[sign:%\d+]] = OpExtInst %v3float {{%\d+}} FSign
+// CHECK-NEXT:                 DebugLine [[src]] %uint_146 %uint_146 %uint_38 %uint_38
+// CHECK-NEXT:                 OpConvertFToS %v3int [[sign]]
+  v4i = D3DCOLORtoUBYTE4(float4(sign(v4f.xyz - 2 * v4f.xyz),
+// CHECK:      DebugLine [[src]] %uint_149 %uint_149 %uint_33 %uint_43
+// CHECK-NEXT: OpExtInst %float {{%\d+}} FSign
+                                sign(v4f.w)));
+// CHECK:                     DebugLine [[src]] %uint_146 %uint_149 %uint_9 %uint_45
+// CHECK-NEXT: [[arg:%\d+]] = OpVectorShuffle %v4float {{%\d+}} {{%\d+}} 2 1 0 3
+// CHECK-NEXT:                OpVectorTimesScalar %v4float [[arg]]
+
+// CHECK:      DebugLine [[src]] %uint_156 %uint_156 %uint_7 %uint_19
+// CHECK-NEXT: OpIsNan %v4bool
+  if (isfinite(v4f).x)
+// CHECK:                     DebugLine [[src]] %uint_161 %uint_161 %uint_15 %uint_30
+// CHECK-NEXT: [[rcp:%\d+]] = OpFDiv %v4float
+// CHECK-NEXT:                DebugLine [[src]] %uint_161 %uint_161 %uint_11 %uint_31
+// CHECK-NEXT:                OpExtInst %v4float {{%\d+}} Sin [[rcp]]
+    v4f = sin(rcp(v4f / v4i.x));
+
+// CHECK:                     DebugLine [[src]] %uint_168 %uint_168 %uint_20 %uint_47
+// CHECK-NEXT:                OpExtInst %float {{%\d+}} Log2
+// CHECK:                     DebugLine [[src]] %uint_168 %uint_168 %uint_11 %uint_48
+// CHECK-NEXT: [[arg:%\d+]] = OpCompositeConstruct %v2float
+// CHECK-NEXT:                OpExtInst %uint {{%\d+}} PackHalf2x16 [[arg]]
+  v4i.x = f32tof16(log10(v2f.x * v2f.y + v4f.x));
+
+// CHECK:      DebugLine [[src]] %uint_172 %uint_172 %uint_3 %uint_26
+// CHECK-NEXT: OpTranspose %mat2v2float
+  transpose(m2x2f + m2x2f);
+
+// CHECK:                     DebugLine [[src]] %uint_180 %uint_180 %uint_25 %uint_42
+// CHECK-NEXT: [[abs:%\d+]] = OpExtInst %float {{%\d+}} FAbs
+// CHECK-NEXT:                DebugLine [[src]] %uint_180 %uint_180 %uint_20 %uint_43
+// CHECK-NEXT:                OpExtInst %float {{%\d+}} Sqrt [[abs]]
+// CHECK:      DebugLine [[src]] %uint_180 %uint_180 %uint_7 %uint_52
+// CHECK-NEXT: OpExtInst %uint {{%\d+}} FindUMsb
+  max(firstbithigh(sqrt(abs(v2f.x * v4f.w)) + v4i.x),
+// CHECK:      DebugLine [[src]] %uint_183 %uint_183 %uint_7 %uint_16
+// CHECK-NEXT: OpExtInst %float {{%\d+}} Cos
+      cos(v4f.x));
+// CHECK:      DebugLine [[src]] %uint_180 %uint_183 %uint_3 %uint_17
+// CHECK-NEXT: OpExtInst %float {{%\d+}} FMax
+}

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.operators.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.operators.hlsl
@@ -1,0 +1,172 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan -no-warnings
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[src:%\d+]] = OpExtInst %void %1 DebugSource [[file]]
+
+static int a, b, c;
+
+void main() {
+// CHECK:      DebugLine [[src]] %uint_11 %uint_11 %uint_11 %uint_15
+// CHECK-NEXT: OpIAdd %int
+  int d = a + b;
+
+// CHECK:      DebugLine [[src]] %uint_15 %uint_15 %uint_7 %uint_11
+// CHECK-NEXT: OpIMul %int
+  c = a * b;
+
+// CHECK:      DebugLine [[src]] %uint_19 %uint_19 %uint_21 %uint_25
+// CHECK-NEXT: OpISub %int
+  /* comment */ c = a - b;
+
+// CHECK:      DebugLine [[src]] %uint_23 %uint_23 %uint_7 %uint_11
+// CHECK-NEXT: OpSDiv %int
+  c = a / b;
+
+// CHECK:      DebugLine [[src]] %uint_27 %uint_27 %uint_8 %uint_12
+// CHECK-NEXT: OpSLessThan %bool
+  c = (a < b);
+
+// CHECK:      DebugLine [[src]] %uint_31 %uint_31 %uint_7 %uint_11
+// CHECK-NEXT: OpSGreaterThan %bool
+  c = a > b;
+
+// CHECK:      DebugLine [[src]] %uint_35 %uint_35 %uint_7 %uint_14
+// CHECK-NEXT: OpLogicalAnd %bool
+  c = (a) && b;
+
+// CHECK:      DebugLine [[src]] %uint_39 %uint_39 %uint_3 %uint_8
+// CHECK-NEXT: OpLogicalOr %bool
+  a || b;
+
+// CHECK: DebugLine [[src]] %uint_43 %uint_43 %uint_3 %uint_8
+// CHECK: OpShiftLeftLogical %int
+  a << b;
+
+// CHECK: DebugLine [[src]] %uint_47 %uint_47 %uint_7 %uint_12
+// CHECK: OpShiftRightArithmetic %int
+  c = a >> b;
+
+// CHECK:      DebugLine [[src]] %uint_51 %uint_51 %uint_7 %uint_11
+// CHECK-NEXT: OpBitwiseAnd %int
+  c = a & b;
+
+// CHECK:      DebugLine [[src]] %uint_55 %uint_55 %uint_7 %uint_8
+// CHECK-NEXT: OpNot %int
+  c = ~b;
+
+// CHECK:      DebugLine [[src]] %uint_59 %uint_59 %uint_7 %uint_11
+// CHECK-NEXT: OpBitwiseXor %int
+  c = a ^ b;
+
+// CHECK:      DebugLine [[src]] %uint_67 %uint_67 %uint_3 %uint_7
+// CHECK-NEXT: OpIAdd %int
+// CHECK:      DebugLine [[src]] %uint_67 %uint_67 %uint_11 %uint_12
+// CHECK-NEXT: OpNot %int
+// CHECK-NEXT: DebugLine [[src]] %uint_67 %uint_67 %uint_3 %uint_12
+// CHECK-NEXT: OpBitwiseXor %int
+  c + a ^ ~b;
+
+// CHECK:      DebugLine [[src]] %uint_71 %uint_71 %uint_3 %uint_5
+// CHECK:      OpIAdd %int
+  ++a;
+
+// CHECK:      DebugLine [[src]] %uint_75 %uint_75 %uint_3 %uint_4
+// CHECK:      OpIAdd %int
+  a++;
+
+// CHECK:      DebugLine [[src]] %uint_79 %uint_79 %uint_3 %uint_4
+// CHECK:      OpISub %int
+  a--;
+
+// CHECK:      DebugLine [[src]] %uint_83 %uint_83 %uint_3 %uint_5
+// CHECK:      OpISub %int
+  --a;
+
+// CHECK: DebugLine [[src]] %uint_87 %uint_87 %uint_3 %uint_9
+// CHECK: OpShiftLeftLogical %int
+  a <<= 10;
+
+// CHECK:      DebugLine [[src]] %uint_91 %uint_91 %uint_3 %uint_8
+// CHECK-NEXT: OpISub %int
+  a -= 10;
+
+// CHECK:      DebugLine [[src]] %uint_95 %uint_95 %uint_3 %uint_8
+// CHECK-NEXT: OpIMul %int
+  a *= 10;
+
+// CHECK:      DebugLine [[src]] %uint_103 %uint_103 %uint_13 %uint_17
+// CHECK-NEXT: OpIAdd %int
+// CHECK-NEXT: DebugLine [[src]] %uint_103 %uint_103 %uint_8 %uint_18
+// CHECK-NEXT: OpIAdd %int
+// CHECK:      DebugLine [[src]] %uint_103 %uint_103 %uint_3 %uint_18
+// CHECK-NEXT: OpSDiv %int
+  a /= d + (b + c);
+
+// CHECK:      DebugLine [[src]] %uint_109 %uint_109 %uint_8 %uint_12
+// CHECK-NEXT: OpSLessThan %bool
+// CHECK-NEXT: DebugLine [[src]] %uint_109 %uint_109 %uint_7 %uint_18
+// CHECK-NEXT: OpLogicalAnd %bool
+  b = (a < c) && true;
+
+// CHECK:      DebugLine [[src]] %uint_113 %uint_113 %uint_3 %uint_8
+// CHECK-NEXT: OpIAdd %int
+  a += c;
+
+// CHECK:      DebugLine [[src]] %uint_121 %uint_121 %uint_11 %uint_17
+// CHECK-NEXT: OpIMul %int %int_100
+// CHECK:      DebugLine [[src]] %uint_121 %uint_121 %uint_22 %uint_27
+// CHECK-NEXT: OpISub %int %int_20
+// CHECK-NEXT: DebugLine [[src]] %uint_121 %uint_121 %uint_11 %uint_28
+// CHECK-NEXT: OpSDiv %int
+  d = a + 100 * b / (20 - c);
+// CHECK-NEXT: DebugLine [[src]] %uint_121 %uint_121 %uint_7 %uint_28
+// CHECK-NEXT: OpIAdd %int
+
+  float2x2 m2x2f;
+  int2x2 m2x2i;
+
+// CHECK:      DebugLine [[src]] %uint_132 %uint_132 %uint_11 %uint_15
+// CHECK-NEXT: OpMatrixTimesScalar %mat2v2float
+// CHECK:      DebugLine %35 %uint_132 %uint_132 %uint_11 %uint_23
+// CHECK-NEXT: OpFAdd %v2float
+  m2x2f = 2 * m2x2f + m2x2i;
+
+// CHECK:      DebugLine [[src]] %uint_140 %uint_140 %uint_11 %uint_19
+// CHECK-NEXT: OpFMul %v2float
+// CHECK:      DebugLine [[src]] %uint_140 %uint_140 %uint_11 %uint_19
+// CHECK-NEXT: OpFMul %v2float
+// CHECK-NEXT: OpCompositeConstruct %mat2v2float
+// this line added intentionally to keep from changing lines numbers
+  m2x2f = m2x2f * m2x2i;
+
+  float4 v4f;
+  int4 v4i;
+
+// CHECK:      DebugLine [[src]] %uint_147 %uint_147 %uint_9 %uint_15
+// CHECK-NEXT: OpFDiv %v4float
+  v4i = v4f / v4i;
+
+// CHECK:      DebugLine [[src]] %uint_155 %uint_155 %uint_11 %uint_19
+// CHECK-NEXT: OpFMul %v2float
+// CHECK:      DebugLine [[src]] %uint_155 %uint_155 %uint_11 %uint_19
+// CHECK-NEXT: OpFMul %v2float
+// CHECK-NEXT: OpCompositeConstruct %mat2v2float
+// this line added intentionally to keep from changing lines numbers
+  m2x2f = m2x2f * v4f;
+
+// CHECK:      DebugLine [[src]] %uint_159 %uint_159 %uint_11 %uint_23
+// CHECK-NEXT: OpMatrixTimesScalar %mat2v2float
+  m2x2f = m2x2f * v4f.x;
+
+// CHECK:      DebugLine [[src]] %uint_165 %uint_165 %uint_4 %uint_10
+// CHECK-NEXT: OpIMul %v4int
+// CHECK:      DebugLine [[src]] %uint_165 %uint_165 %uint_3 %uint_15
+// CHECK-NEXT: OpFOrdLessThan %v4bool
+  (v4i * a) < m2x2f;
+
+// CHECK:      DebugLine [[src]] %uint_171 %uint_171 %uint_4 %uint_10
+// CHECK-NEXT: OpSDiv %v4int
+// CHECK:      DebugLine [[src]] %uint_171 %uint_171 %uint_3 %uint_16
+// CHECK-NEXT: OpLogicalAnd %v4bool
+  (v4i / a) && v4f;
+}

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.precedence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.precedence.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T cs_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[src:%\d+]] = OpExtInst %void %1 DebugSource [[file]]
+
+[numthreads(1,1,1)]void main() {
+  int a;
+  int b;
+
+//CHECK:      DebugLine [[src]] %uint_12 %uint_12 %uint_11 %uint_11
+//CHECK:      OpSelectionMerge %switch_merge None
+  switch (a) {
+  default:
+    b = 0;
+  case 1:
+    b = 1;
+    break;
+  case 2:
+    b = 2;
+  }
+
+//CHECK:      DebugLine [[src]] %uint_24 %uint_24 %uint_19 %uint_23
+//CHECK:      OpLoopMerge %for_merge %for_continue None
+  for (int i = 0; i < 4; i++) {
+    b += i;
+  }
+}

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.variables.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.variables.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:      [[file:%\d+]] = OpString
+// CHECK:      [[src:%\d+]] = OpExtInst %void %1 DebugSource [[file]]
+
+float test_function_variables() {
+// CHECK:                 DebugLine [[src]] %uint_9 %uint_9 %uint_22 %uint_22
+// CHECK-NEXT: {{%\d+}} = OpLoad %bool %init_done_foo
+  static float foo = 2.f;
+  return foo;
+}
+
+// DebugLine cannot appear before OpFunction
+// CHECK:     %test_function_param = OpFunction %v2float None
+// DebugLine cannot appear before OpFunctionParameter
+// CHECK-NEXT:           %a = OpFunctionParameter %_ptr_Function_v2float
+// DebugLine cannot appear before OpFunctionParameter
+// CHECK-NEXT:           %b = OpFunctionParameter %_ptr_Function_v3bool
+float2 test_function_param(float2 a, inout bool3 b,
+// DebugLine cannot appear before OpFunctionParameter
+// CHECK-NEXT:           %c = OpFunctionParameter %_ptr_Function_int
+// DebugLine cannot appear before OpFunctionParameter
+// CHECK-NEXT:           %d = OpFunctionParameter %_ptr_Function_v3float
+                           const int c, out float3 d) {
+// CHECK:      DebugLine [[src]] %uint_27 %uint_27 %uint_3 %uint_15
+// CHECK-NEXT: OpStore %f
+  float f = a.x;
+  return a + d.xy + float2(f, a.y);
+}
+
+void main() {
+  float bar = test_function_variables();
+
+  bool3 param_b;
+  float3 param_d;
+  test_function_param(float2(1, 0), param_b, 13, param_d);
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.hlsl
@@ -59,7 +59,7 @@ float4 main(uint val : A) : SV_Target {
 // CHECK:      OpLine [[file]] 63 7
 // CHECK-NEXT: OpAccessChain %_ptr_Function_float %c %int_0
 // CHECK:      OpLine [[file]] 63 3
-// CHECK-NEXT: pStore %a
+// CHECK-NEXT: OpStore %a
   a = c.x;
 
   return b * c;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -704,7 +704,8 @@ public:
       // first for such case. Then we invoke the compilation process over the
       // preprocessed source code, so that line numbers are consistent with the
       // embedded source code.
-      if (!isPreprocessing && opts.GenSPIRV && opts.DebugInfo) {
+      if (!isPreprocessing && opts.GenSPIRV && opts.DebugInfo &&
+          !opts.SpirvOptions.debugInfoVulkan) {
         CComPtr<IDxcResult> pSrcCodeResult;
         std::vector<LPCWSTR> PreprocessArgs;
         PreprocessArgs.reserve(argCount + 1);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2987,5 +2987,26 @@ TEST_F(FileTest, ShaderDebugInfoSourceContinued) {
 TEST_F(FileTest, ShaderDebugInfoLine) {
   runFileTest("shader.debug.line.hlsl");
 }
+TEST_F(FileTest, ShaderDebugInfoLineBranch) {
+  runFileTest("shader.debug.line.branch.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLineComposite) {
+  runFileTest("shader.debug.line.composite.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLineInclude) {
+  runFileTest("shader.debug.line.include.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLineIntrinsic) {
+  runFileTest("shader.debug.line.intrinsic.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLineOperators) {
+  runFileTest("shader.debug.line.operators.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLinePrecedence) {
+  runFileTest("shader.debug.line.precedence.hlsl");
+}
+TEST_F(FileTest, ShaderDebugInfoLineVariables) {
+  runFileTest("shader.debug.line.variables.hlsl");
+}
 
 } // namespace


### PR DESCRIPTION
The continues the work of pt 1. In paticular, it improved DebugLine for
constructors; array refs; swizzle; increments; intrinsics; builtins;
if; loops; switch; variable initialization; compound assigns; zero casts;
texture samples; vector and matrix swizzle LHS assignment;
matrix, struct and array initializers; function call args;
matrix element stores; matrix multiply.