### PR TITLE
Fix verifier tests for HLSL 2021

### DIFF
--- a/tools/clang/include/clang/Driver/Options.td
+++ b/tools/clang/include/clang/Driver/Options.td
@@ -677,7 +677,7 @@ def fms_volatile : Joined<["-"], "fms-volatile">, Group<f_Group>, Flags<[CC1Opti
 def fmsc_version : Joined<["-"], "fmsc-version=">, Group<f_Group>, Flags<[DriverOption, CoreOption]>,
   HelpText<"Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))">;
 def hlsl_version : Separate<["-", "/"], "HV">, Group<f_Group>, Flags<[DriverOption, CoreOption, CC1Option]>,
-  HelpText<"HLSL version (2015, 2016, 2017)">; // HLSL Change - mimic the HLSLOptions.td flag
+  HelpText<"HLSL version (2015, 2016, 2017, 2018, 2021)">; // HLSL Change - mimic the HLSLOptions.td flag
 def enable_16bit_types: Flag<["-", "/"], "enable-16bit-types">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Enable 16bit types and disable min precision types.">; // HLSL Change - mimic the HLSLOptions.td flag
 def enable_templates: Flag<["-", "/"], "enable-templates">, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1727,7 +1727,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   else {
     try {
       Opts.HLSLVersion = std::stoi(std::string(ver));
-      if (Opts.HLSLVersion < 2015 || Opts.HLSLVersion > 2018) {
+      if (Opts.HLSLVersion < 2015 || Opts.HLSLVersion > 2021) {
        Diags.Report(diag::err_drv_invalid_value)
         << Args.getLastArg(OPT_hlsl_version)->getAsString(Args)
         << ver;
@@ -1759,6 +1759,8 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     Opts.EnableTemplates = true;
     // Determine overload matching based on UDT names, not just types
     Opts.StrictUDTCasting = true;
+    // Experimental option to enable short-circuiting operators
+    Opts.EnableShortCircuit = true;
     // Enable bitfield support
     Opts.EnableBitfields = true;
 

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -98,7 +98,9 @@ public:
     const char startMarker[] = "%clang_cc1";
     const char endMarker[] = "%s";
 
-    char firstLine[200];
+    // I bumped this up to 1024, if we have a run line that large in our tests
+    // bad will happen, and we probably deserve the pain...
+    char firstLine[1024];
     memset(firstLine, 0, sizeof(firstLine));
 
     char* commandLine;
@@ -114,30 +116,44 @@ public:
     // and chopping off everything after '%s'.
     //
 
-    {
-      ifstream infile(CW2A(path).m_psz);
-      ASSERT_EQ(false, infile.bad());
+    ifstream infile(CW2A(path).m_psz);
+    ASSERT_EQ(false, infile.bad());
 
+    bool FoundRun = false;
+
+    // This loop is super hacky, and not at all how we should do this. We should
+    // have _one_ implementation of reading and interpreting RUN but instead we
+    // currently have many, and this one only supports one RUN directive, which
+    // is confusing and has resulted in test cases that aren't being run at all,
+    // and are hiding bugs.
+
+    // The goal of this loop is to process RUN lines at the top of the file,
+    // until the first non-run line. This also isn't ideal, but is better.
+    while (!infile.eof()) {
       infile.getline(firstLine, _countof(firstLine));
-      char* found = strstr(firstLine, startMarker);
-      ASSERT_NE(nullptr, found);
+      char *found = strstr(firstLine, startMarker);
+      if (found)
+        FoundRun = true;
+      else
+        break;
 
       commandLine = found + strlen(startMarker);
 
-      char* fileArgument = strstr(commandLine, endMarker);
+      char *fileArgument = strstr(commandLine, endMarker);
       ASSERT_NE(nullptr, fileArgument);
       *fileArgument = '\0';
-    }
 
-    CW2A asciiPath(path);
-    CompilationResult result = CompilationResult::CreateForCommandLine(commandLine, asciiPath);
-    if (!result.ParseSucceeded()) {
-      std::stringstream ss;
-      ss << "for program " << asciiPath << " with errors:\n" << result.GetTextForErrors();
-      CA2W pszW(ss.str().c_str());
-      ::WEX::Logging::Log::Comment(pszW);
+      CW2A asciiPath(path);
+      CompilationResult result = CompilationResult::CreateForCommandLine(commandLine, asciiPath);
+      if (!result.ParseSucceeded()) {
+        std::stringstream ss;
+        ss << "for program " << asciiPath << " with errors:\n" << result.GetTextForErrors();
+        CA2W pszW(ss.str().c_str());
+        ::WEX::Logging::Log::Comment(pszW);
+      }
+      VERIFY_IS_TRUE(result.ParseSucceeded());
     }
-    VERIFY_IS_TRUE(result.ParseSucceeded());
+    ASSERT_TRUE(FoundRun);
   }
 
   void CheckVerifiesHLSL(LPCWSTR name) {

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -153,7 +153,7 @@ public:
       }
       VERIFY_IS_TRUE(result.ParseSucceeded());
     }
-    ASSERT_TRUE(FoundRun);
+    ASSERT_EQ(true, FoundRun);
   }
 
   void CheckVerifiesHLSL(LPCWSTR name) {


### PR DESCRIPTION
This fixes two issues in the verifier tests that impacted HLSL 2021.

(1) The verifier test runner only handles one `RUN` line, which results in the tests skipping subsequent lines. This becomes a problem with our pattern of features tests for HLSL 2021, where we verify both the individual feature flag and `-HV 2021`

(2) Turns out, the clang option parser had not been updated for HLSL 2021, and was not able to parse the option at all. We missed this because the second run line is the one that we put `-HV 2021` on, and because of the previous issue, we weren't running those tests. Additionally HLSL 2021 wasn't implemented with the same feature set in the clang driver, so I copied over the feature settings.