### PR TITLE
PIX: ensure allocas generated by value-to-declare dominate uses (#4145)

### DIFF
--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -814,7 +814,7 @@ VariableRegisters::VariableRegisters(
     llvm::Module *M)
   : m_dbgLoc(DbgValue->getDebugLoc())
   , m_Variable(Variable)
-  , m_B(DbgValue)
+  , m_B(DbgValue->getParent()->getParent()->getEntryBlock().begin())
   , m_DbgDeclareFn(llvm::Intrinsic::getDeclaration(
       M, llvm::Intrinsic::dbg_declare))
 {


### PR DESCRIPTION
This fixes a regression introduced by #3985

One IHV's driver compiler was upset by the placement of the allocas generated by this builder (m_B, that is).
Restoring the insertion point to the start of the function makes the driver happy again.

(cherry picked from commit b71cfcb07734948f64747c74eb7438d035dd7758)