### PR TITLE
FixIt diagnostic for HLSL 2021 ?: operator

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7751,7 +7751,7 @@ def err_hlsl_out_indices_array_incorrect_access: Error<
 def err_hlsl_logical_binop_scalar : Error<
    "operands for short-circuiting logical binary operator must be scalar">;
 def err_hlsl_ternary_scalar : Error<
-   "condition for short-circuiting ternary operator must be scalar">;
+   "condition for short-circuiting ternary operator must be scalar, for non-scalar types use 'select'">;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/test/HLSL/vector-select.hlsl
+++ b/tools/clang/test/HLSL/vector-select.hlsl
@@ -1,0 +1,15 @@
+// RUN: %clang_cc1 -HV 2021 -fsyntax-only -ffreestanding -verify %s
+
+RWStructuredBuffer<int3> rw;
+
+struct FV {
+  int3 f;
+};
+
+ConstantBuffer<FV> c;
+
+[numthreads(1,1,1)]
+void main() {
+// expected-error@+1 {{condition for short-circuiting ternary operator must be scalar, for non-scalar types use 'select'}}
+  rw[0] = rw[0] ? rw[0] : c.f;
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -92,6 +92,7 @@ public:
   TEST_METHOD(RunWave)
   TEST_METHOD(RunBinopDims)
   TEST_METHOD(RunBitfields)
+  TEST_METHOD(RunVectorSelect)
 
   void CheckVerifies(const wchar_t* path) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -375,6 +375,10 @@ TEST_F(VerifierTest, RunVectorConditional) {
   CheckVerifiesHLSL(L"vector-conditional.hlsl");
 }
 
+TEST_F(VerifierTest, RunVectorSelect) {
+  CheckVerifiesHLSL(L"vector-select.hlsl");
+}
+
 TEST_F(VerifierTest, RunUint4Add3) {
   CheckVerifiesHLSL(L"uint4_add3.hlsl");
 }


### PR DESCRIPTION
This updates the diagnostic for the HLSL 2021 short-circuiting ternary operator to issue a fixit suggesting using the select intrinsic. I don't have a good way right now to execute the FixIt, which makes it difficult to write a test that it applies cleanly. I'm working on that in a subsequent patch, but it's not going well...

This patch does add a test that verifies the error emission, and the diagnostic provided will include a FixIt resulting in the error output:

```
./vector-select.hlsl:14:17: error: condition for short-circuiting ternary operator must be scalar, for non-scalar types use 'select'
  rw[0] = rw[0] ? rw[0] : c.f;
          ~~~~~~^~~~~~~~~~~~~
          select(rw[0], rw[0], c.f)
```