### PR TITLE
Disable NRVO for `precise` decls

### DIFF
--- a/tools/clang/include/clang/AST/Decl.h
+++ b/tools/clang/include/clang/AST/Decl.h
@@ -1228,9 +1228,8 @@ public:
   /// return slot when returning from the function. Within the function body,
   /// each return that returns the NRVO object will have this variable as its
   /// NRVO candidate.
-  bool isNRVOVariable() const {
-    return isa<ParmVarDecl>(this) ? false : NonParmVarDeclBits.NRVOVariable;
-  }
+  bool isNRVOVariable() const;  // HLSL Change - Moved to Decl.cpp
+
   void setNRVOVariable(bool NRVO) {
     assert(!isa<ParmVarDecl>(this));
     NonParmVarDeclBits.NRVOVariable = NRVO;

--- a/tools/clang/lib/AST/Decl.cpp
+++ b/tools/clang/lib/AST/Decl.cpp
@@ -44,6 +44,17 @@ bool Decl::isOutOfLine() const {
   return !getLexicalDeclContext()->Equals(getDeclContext());
 }
 
+// HLSL Change - Begin
+// We need to disable NRVO for anything with the precise attribute assigned.
+// NRVO prevents creating an alloca which breaks how precise is currently
+// implemented. This should have no performance impact.
+bool VarDecl::isNRVOVariable() const {
+  return (isa<ParmVarDecl>(this) || hasAttr<HLSLPreciseAttr>())
+             ? false
+             : NonParmVarDeclBits.NRVOVariable;
+}
+// HLSL Change - End
+
 TranslationUnitDecl::TranslationUnitDecl(ASTContext &ctx)
     : Decl(TranslationUnit, nullptr, SourceLocation()),
       DeclContext(TranslationUnit), Ctx(ctx), AnonymousNamespace(nullptr) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -T cs_6_0 -Od %s | FileCheck %s
+
+struct MyStruct {
+  float x;
+};
+
+MyStruct makeStruct(float x) {
+  precise MyStruct ret;
+  ret.x = x;
+  return ret;
+}
+
+StructuredBuffer<MyStruct> DataIn;
+RWStructuredBuffer<MyStruct> DataOut;
+
+[numthreads(1,1,1)]
+void main(uint3 dispatchid : SV_DispatchThreadID) {
+  MyStruct d = makeStruct(DataIn[dispatchid.x].x);
+  DataOut[dispatchid.x] = d;
+}
+
+// CHECK:  %[[Alloca:[0-9]]] = alloca float, !dx.precise !13
+// CHECK: %[[Buffer:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
+// CHECK: %[[Value:[0-9]]] = extractvalue %dx.types.ResRet.f32 %[[Buffer]], 0
+// CHECK: store float %[[Value]], float* %[[Alloca]], align 4, !noalias !14
+// CHECK: %[[Value:[0-9]+]] = load float, float* %[[Alloca]]
+// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %1, i32 %{{[0-9]}}, i32 0, float %[[Value]], float undef, float undef, float undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -19,9 +19,9 @@ void main(uint3 dispatchid : SV_DispatchThreadID) {
   DataOut[dispatchid.x] = d;
 }
 
-// CHECK:  %[[Alloca:.*]] = alloca float, !dx.precise !13
+// CHECK:  %[[Alloca:.*]] = alloca float, !dx.precise
 // CHECK: %[[Buffer:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
 // CHECK: %[[Value:[0-9]]] = extractvalue %dx.types.ResRet.f32 %[[Buffer]], 0
-// CHECK: store float %[[Value]], float* %[[Alloca]], align 4, !noalias !14
+// CHECK: store float %[[Value]], float* %[[Alloca]], align 4, !noalias
 // CHECK: %[[Value:[0-9]+]] = load float, float* %[[Alloca]]
-// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %1, i32 %{{[0-9]}}, i32 0, float %[[Value]], float undef, float undef, float undef, i8 1)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %{{.*}}, i32 %{{[0-9]}}, i32 0, float %[[Value]], float undef, float undef, float undef, i8 1)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -19,7 +19,7 @@ void main(uint3 dispatchid : SV_DispatchThreadID) {
   DataOut[dispatchid.x] = d;
 }
 
-// CHECK:  %[[Alloca:[0-9]]] = alloca float, !dx.precise !13
+// CHECK:  %[[Alloca:.*]] = alloca float, !dx.precise !13
 // CHECK: %[[Buffer:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
 // CHECK: %[[Value:[0-9]]] = extractvalue %dx.types.ResRet.f32 %[[Buffer]], 0
 // CHECK: store float %[[Value]], float* %[[Alloca]], align 4, !noalias !14


### PR DESCRIPTION
Named return value optimization prevents allocating objects when
returning objects by value. This optimization trips up our
implementation of `precise` whihc requires the attribute be applied to
an `alloca`.

Disabling NRVO for Decls with the HLSLPreciseAttr attached avoids a
crash in the compiler.

Disabling this optimization should have no performance impact on most
existing HLSL code because function calls are inlined, and HLSL doesn't
support side-effecting constructors. Those two factors should allow the
optimizer to eliminte redundant copies even without NRVO enabled.