### PR TITLE
Preserve qualifiers on array subscript

### DIFF
--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -699,6 +699,11 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
     return ExprError();
   }
 
+  // HLSL Change Begin
+  // For HLSL we should not strip qualifiers for array types.
+  bool StripQualifiers = getLangOpts().HLSL ? !T->isArrayType() : true;
+  // HLSL Change End
+
   // C++ [conv.lval]p1:
   //   [...] If T is a non-class type, the type of the prvalue is the
   //   cv-unqualified version of T. Otherwise, the type of the
@@ -708,7 +713,7 @@ ExprResult Sema::DefaultLvalueConversion(Expr *E) {
   //   If the lvalue has qualified type, the value has the unqualified
   //   version of the type of the lvalue; otherwise, the value has the
   //   type of the lvalue.
-  if (T.hasQualifiers())
+  if (T.hasQualifiers() && StripQualifiers) // HLSL Change don't unqualify
     T = T.getUnqualifiedType();
 
   UpdateMarkingForLValueToRValue(E);
@@ -4267,6 +4272,10 @@ Sema::CreateBuiltinArraySubscriptExpr(Expr *Base, SourceLocation LLoc,
       BaseExpr = LHSExp;
       IndexExpr = RHSExp;
       ResultType = LHSTy->getAsArrayTypeUnsafe()->getElementType();
+      // We need to make sure to preserve qualifiers on array types, since these
+      // are in effect references.
+      if (LHSTy.hasQualifiers())
+        ResultType.setLocalFastQualifiers(LHSTy.getLocalFastQualifiers());
     } else {
     // HLSL Change Ends
       Diag(LHSExp->getLocStart(), diag::ext_subscript_non_lvalue) <<

--- a/tools/clang/test/HLSL/InputPatch-const.hlsl
+++ b/tools/clang/test/HLSL/InputPatch-const.hlsl
@@ -1,9 +1,4 @@
-// RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
-
-// CHECK: InputPrimitive=patch2
-// CHECK: emitStream
-// CHECK: cutStream
-// CHECK: i32 24}
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
 
 struct GSOut {
   float2 uv : TEXCOORD0;
@@ -21,8 +16,8 @@ cbuffer b : register(b0) {
 [instance(24)]
 void main(InputPatch<GSOut, 2>points, inout PointStream<GSOut> stream) {
 
-  points[0].norm[0] = 1;
-  points[0].norm[1] = 2;
+  points[0].norm[0] = 1; // expected-error {{read-only variable is not assignable}}
+  points[0].norm[1] = 2; // expected-error {{read-only variable is not assignable}}
   stream.Append(points[0]);
 
   stream.RestartStrip();

--- a/tools/clang/test/HLSL/array-const-assign.hlsl
+++ b/tools/clang/test/HLSL/array-const-assign.hlsl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+
+struct MyData {
+   float3 x[4];  
+};
+
+StructuredBuffer<MyData> DataIn;
+RWStructuredBuffer<MyData> DataOut;
+
+[numthreads(64, 1, 1)]
+void CSMain(uint3 dispatchid : SV_DispatchThreadID)
+{
+    const MyData data = DataIn[dispatchid.x];
+    data.x[0] = 1.0f; // expected-error {{read-only variable is not assignable}}
+    DataOut[dispatchid.x] = data;
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -94,6 +94,7 @@ public:
   TEST_METHOD(RunBitfields)
   TEST_METHOD(RunVectorSelect)
   TEST_METHOD(RunArrayConstAssign)
+  TEST_METHOD(RunInputPatchConst)
 
   void CheckVerifies(const wchar_t* path) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
@@ -403,4 +404,8 @@ TEST_F(VerifierTest, RunBitfields) {
 
 TEST_F(VerifierTest, RunArrayConstAssign) {
   CheckVerifiesHLSL(L"array-const-assign.hlsl");
+}
+
+TEST_F(VerifierTest, RunInputPatchConst) {
+  CheckVerifiesHLSL(L"InputPatch-const.hlsl");
 }

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -93,6 +93,7 @@ public:
   TEST_METHOD(RunBinopDims)
   TEST_METHOD(RunBitfields)
   TEST_METHOD(RunVectorSelect)
+  TEST_METHOD(RunArrayConstAssign)
 
   void CheckVerifies(const wchar_t* path) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
@@ -398,4 +399,8 @@ TEST_F(VerifierTest, RunBinopDims) {
 
 TEST_F(VerifierTest, RunBitfields) {
   CheckVerifiesHLSL(L"bitfields.hlsl");
+}
+
+TEST_F(VerifierTest, RunArrayConstAssign) {
+  CheckVerifiesHLSL(L"array-const-assign.hlsl");
 }


### PR DESCRIPTION
This change prevents dropping const qualifiers on array subscript
operators. Without this change the array subscript operator converts
from an lvalue to an rvalue that drops the type qualifiers. Since
arrays are actually addresses to the start of the array, it results in
dropping the qualifiers on the underlying array, making the array
modifiable.

This resolves #2860