### PR TITLE
Fix the order of shader profiles in hct code gen

### DIFF
--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -1200,7 +1200,7 @@ shader_profiles = [ shader_profile(0, "ps", "Kind::Pixel", "4_0", 32, 8),
 
 def getShaderProfiles():
     # order match DXIL::ShaderKind.
-    profiles = {"ps":"4_0", "vs":"4_0", "gs":"4_0", "hs":"5_0", "ds":"5_0", "cs":"4_0", "lib":"6_1", "ms":"6_5", "as":"6_5"}
+    profiles = (("ps", "4_0"), ("vs", "4_0"), ("gs", "4_0"), ("hs", "5_0"), ("ds", "5_0"), ("cs", "4_0"), ("lib", "6_1"), ("ms", "6_5"), ("as", "6_5"))
     return profiles;
 
 def get_shader_models():
@@ -1341,7 +1341,7 @@ def get_target_profiles():
     shader_models = getShaderModels()
 
     base_sm = "%d_0"%highest_major
-    for profile, min_sm in profiles.items():
+    for profile, min_sm in profiles:
         for shader_model in shader_models:
             if (base_sm > shader_model):
                 continue


### PR DESCRIPTION
Fix #4138 . Change the dict to tuple, because dict is not order preserved.