### PR TITLE
[spirv] Use t shift for combined image samplers

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -164,6 +164,10 @@ lets you to specify the descriptor for the source at a certain register.
 ``-fvk-{b|s|t|u}-shift`` lets you to apply shifts to all register numbers
 of a certain register type. They cannot be used together, though.
 
+When the ``[[vk::combinedImageSampler]]`` attribute is applied, only the
+``-fvk-t-shift`` value will be used to apply shifts to combined texture and
+sampler resource bindings and any ``-fvk-s-shift`` value will be ignored.
+
 Without attribute and command-line option, ``:register(xX, spaceY)`` will be
 mapped to binding ``X`` in descriptor set ``Y``. Note that register type ``x``
 is ignored, so this may cause overlap.
@@ -324,6 +328,11 @@ The namespace ``vk`` will be used for all Vulkan attributes:
   location. Used for dual-source blending.
 - ``post_depth_coverage``: The input variable decorated with SampleMask will
   reflect the result of the EarlyFragmentTests. Only valid on pixel shader entry points.
+- ``combinedImageSampler``: For specifying a Texture (e.g., ``Texture2D``,
+  ``Texture1DArray``, ``TextureCube``) and ``SamplerState`` to use the combined image
+  sampler (or sampled image) type with the same descriptor set and binding numbers (see
+  `wiki page <https://github.com/microsoft/DirectXShaderCompiler/wiki/Vulkan-combined-image-sampler-type>`_
+  for more detail).
 
 Only ``vk::`` attributes in the above list are supported. Other attributes will
 result in warnings and be ignored by the compiler. All C++11 attributes will

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2159,6 +2159,14 @@ bool DeclResultIdMapper::decorateResourceBindings() {
           binding += tShiftMapper.getShiftForSet(set);
           break;
         case 's':
+          // For combined texture and sampler resources, always use the t shift
+          // value and ignore the s shift value.
+          if (const auto *decl = var.getDeclaration()) {
+            if (decl->getAttr<VKCombinedImageSamplerAttr>() != nullptr) {
+              binding += tShiftMapper.getShiftForSet(set);
+              break;
+            }
+          }
           binding += sShiftMapper.getShiftForSet(set);
           break;
         case 'u':

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.binding-shift.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.binding-shift.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_0 -E main -fvk-t-shift 10 0 -fvk-s-shift 20 0
+
+// CHECK: OpDecorate %sam DescriptorSet 0
+// CHECK: OpDecorate %sam Binding 10
+[[vk::combinedImageSampler]]
+SamplerState sam : register(s0);
+
+// CHECK: OpDecorate %tex DescriptorSet 0
+// CHECK: OpDecorate %tex Binding 10
+[[vk::combinedImageSampler]]
+Texture2D<float4> tex : register(t0);
+
+// CHECK: OpDecorate %sam0 DescriptorSet 0
+// CHECK: OpDecorate %sam0 Binding 20
+SamplerState sam0 : register(s0);
+
+// CHECK: OpDecorate %sam1 DescriptorSet 0
+// CHECK: OpDecorate %sam1 Binding 21
+SamplerState sam1 : register(s1);
+
+float4 main(float4 P : SV_POSITION) : SV_TARGET
+{
+    return tex.Sample(sam, P.xy);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2115,6 +2115,9 @@ TEST_F(FileTest, VulkanPushConstantOnConstantBuffer) {
 TEST_F(FileTest, VulkanCombinedImageSampler) {
   runFileTest("vk.combined-image-sampler.hlsl");
 }
+TEST_F(FileTest, VulkanCombinedImageSamplerBindingShift) {
+  runFileTest("vk.combined-image-sampler.binding-shift.hlsl");
+}
 TEST_F(FileTest, VulkanCombinedImageSamplerTextureArray) {
   runFileTest("vk.combined-image-sampler.texture-array.hlsl");
 }


### PR DESCRIPTION
When command-line shift values are provided for binding numbers inferred
for register types, always use the t shift value for combined image
sampler resources, and ignore the s shift value.

Fixes #4166