### PR TITLE
Exclude errs and outs from per-thread FS

### DIFF
--- a/tools/clang/tools/driver/driver.cpp
+++ b/tools/clang/tools/driver/driver.cpp
@@ -382,7 +382,6 @@ int __cdecl main(int argc_, const char **argv_) {
     return 1;
   std::unique_ptr<llvm::sys::fs::MSFileSystem> msf(msfPtr);
   llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
-  llvm::STDStreamCloser stdStreamCloser;
   // HLSL Change Ends
 
   llvm::sys::PrintStackTraceOnErrorSignal();

--- a/tools/clang/utils/TableGen/TableGen.cpp
+++ b/tools/clang/utils/TableGen/TableGen.cpp
@@ -260,7 +260,6 @@ int main(int argc, char **argv) {
     return 1;
   std::unique_ptr<llvm::sys::fs::MSFileSystem> msf(msfPtr);
   llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
-  llvm::STDStreamCloser stdStreamCloser;
   // HLSL Change Ends
 
   // sys::PrintStackTraceOnErrorSignal(); // HLSL Change

--- a/tools/llvm-as/llvm-as.cpp
+++ b/tools/llvm-as/llvm-as.cpp
@@ -102,7 +102,6 @@ int __cdecl main(int argc, char **argv) {
     return 1;
   std::unique_ptr<llvm::sys::fs::MSFileSystem> msf(msfPtr);
   llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
-  llvm::STDStreamCloser stdStreamCloser;
   // HLSL Change Ends
 
   LLVMContext &Context = getGlobalContext();

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -325,7 +325,6 @@ int __cdecl main(int argc, char **argv) {
   if (FAILED(CreateMSFileSystemForDisk(&msfPtr))) return 1;
   std::unique_ptr<llvm::sys::fs::MSFileSystem> msf(msfPtr);
   llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
-  //llvm::STDStreamCloser stdStreamCloser;
   // HLSL Change Ends
   
   //sys::PrintStackTraceOnErrorSignal();          // HLSL Change

--- a/utils/FileCheck/FileCheck.cpp
+++ b/utils/FileCheck/FileCheck.cpp
@@ -1298,7 +1298,6 @@ int main(int argc, char **argv) {
     return 1;
   std::unique_ptr<llvm::sys::fs::MSFileSystem> msf(msfPtr);
   llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
-  STDStreamCloser stdStreamCloser;
   // HLSL Change Ends
   
   sys::PrintStackTraceOnErrorSignal();


### PR DESCRIPTION
The per-thread filesystem is useful if you're hitting the filesystem. If
you are writing to stdout/stderrs, multi-threading is going to cause all
sorts of crazy issues anyways the per-thread filesystem gets us nothing
but bugs.

This change adds an option to exclude raw_fd_ostreams from the
per-thread filesystem on creation. If opted-out they will fallback to
using the normal POSIX C interfaces. This change also removes the RAII
construct used to flush stdout and stderr and close stdout. Closing
stdout is not required on any platform, modern LLVM also excludes
closing stdout & stderr on all platforms.