### PR TITLE
Adding shader model version promotion warning

### DIFF
--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -766,6 +766,9 @@ int DxcContext::Compile() {
       const hlsl::ShaderModel *SM = hlsl::ShaderModel::GetByName(m_Opts.TargetProfile.str().c_str());
       if (SM->IsValid() && SM->GetMajor() < 6) {
         TargetProfile = hlsl::ShaderModel::Get(SM->GetKind(), 6, 0)->GetName();
+        std::string versionWarningString =
+            "warning: Promoting older shader model profile to 6.0 version.";
+        fprintf(stderr, "%s\n", versionWarningString.data());
         if (!SM->IsSM51Plus()) {
           // Add flag for backcompat with SM 5.0 resource reservation
           args.push_back(L"-flegacy-resource-reservation");

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -323,6 +323,15 @@ rem smoke.ll is used later to assemble, so don't delete it.
 call :check_file smoke.ll find "DICompileUnit"
 if %Failed% neq 0 goto :failed
 
+set testname=dxc.exe shader model version promtion warning
+rem shader model version promotion warning prints to stderr, so not captured in /Fe
+dxc.exe "%testfiles%\smoke.hlsl" /Emain /Tps_5_0 2>smoke.err
+call :check_file smoke.err find "warning: Promoting older shader model profile to 6.0 version."
+if %Failed% neq 0 goto :failed
+dxc.exe "%testfiles%\smoke.hlsl" /Emain /Tps_5_1 2>smoke.err
+call :check_file smoke.err find "warning: Promoting older shader model profile to 6.0 version."
+if %Failed% neq 0 goto :failed
+
 set testname=dxa command line program
 call :run dxa.exe smoke.cso -listfiles
 if %Failed% neq 0 goto :failed


### PR DESCRIPTION
Adding a warning when the shader model version is promoted from an older version to the 6.0 version. 

The motivation for adding this warning is to make this version promotion more explicit, clearing up errors if features from the newer SM are not supported on the driver.  Fixes #4038 