### PR TITLE
proposal: improve source compatibility with MinGW and Zig compilers

### DIFF
--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -24,6 +24,9 @@ typedef _Return_type_success_(return >= 0) long HRESULT;
 #endif // !_HRESULT_DEFINED
 #endif // _WIN32
 
+#ifdef __MINGW32__
+#include <objidl.h>
+#endif
 #include <stdarg.h>
 #include <system_error>
 #include "dxc/Support/exception.h"

--- a/include/dxc/Support/WinFunctions.h
+++ b/include/dxc/Support/WinFunctions.h
@@ -15,6 +15,11 @@
 #ifndef LLVM_SUPPORT_WINFUNCTIONS_H
 #define LLVM_SUPPORT_WINFUNCTIONS_H
 
+#ifdef __MINGW32__
+#include "dxc/Support/WinAdapter.h"
+HRESULT UInt32Mult(UINT a, UINT b, UINT *out);
+#endif
+
 #ifndef _WIN32
 
 #include "dxc/Support/WinAdapter.h"

--- a/include/dxc/Support/WinIncludes.h
+++ b/include/dxc/Support/WinIncludes.h
@@ -10,7 +10,10 @@
 
 #pragma once
 
-#ifdef _MSC_VER
+// Always include WinAdapter, for MSC it will do nothing but for MinGW it will emulate ATL.
+#include "dxc/Support/WinAdapter.h"
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 // mingw-w64 tends to define it as 0x0502 in its headers.
 #undef _WIN32_WINNT
@@ -40,7 +43,9 @@
 
 #include <windows.h>
 #include <unknwn.h>
+#ifndef __MINGW32__
 #include <atlbase.h> // atlbase.h needs to come before strsafe.h
+#endif // __MINGW32__
 #include <strsafe.h>
 #include <intsafe.h>
 #include <ObjIdl.h>
@@ -57,10 +62,9 @@ template <class T> void swap(CComHeapPtr<T> &a, CComHeapPtr<T> &b) {
   b.m_pData = c;
 }
 
-#else // _MSC_VER
+#endif // defined(_MSC_VER) || defined(__MINGW32__)
 
-#include "dxc/Support/WinAdapter.h"
-
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 #ifdef __cplusplus
 // Define operator overloads to enable bit operations on enum values that are
 // used to define flags. Use DEFINE_ENUM_FLAG_OPERATORS(YOUR_TYPE) to enable these
@@ -109,4 +113,4 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) { return (ENUMTYPE &)(((_
 #define DEFINE_ENUM_FLAG_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
 #endif
 
-#endif // _MSC_VER
+#endif // !defined(_MSC_VER) && !defined(__MINGW32__)

--- a/include/llvm/Support/Atomic.h
+++ b/include/llvm/Support/Atomic.h
@@ -16,6 +16,17 @@
 
 #include "llvm/Support/DataTypes.h"
 
+#ifdef __MINGW32__
+#define __int64 long long
+#define NOMINMAX 1
+#include <windows.h>
+// HACK: Pretend we're CYGWIN when including intrin.h, otherwise the MinGW headers will not know
+// that strcat and other conflicting symbols are already defined.
+#define __CYGWIN__
+#include <intrin.h>
+#undef __CYGWIN__
+#endif // __MINGW32__
+
 namespace llvm {
   namespace sys {
     void MemoryFence();

--- a/lib/DxcSupport/WinFunctions.cpp
+++ b/lib/DxcSupport/WinFunctions.cpp
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(__MINGW32__)
+
 #include <fcntl.h>
 #include <map>
 #include <string.h>
@@ -20,6 +21,17 @@
 #include <unistd.h>
 
 #include "dxc/Support/WinFunctions.h"
+
+HRESULT UInt32Mult(UINT a, UINT b, UINT *out) {
+  uint64_t result = (uint64_t)a * (uint64_t)b;
+  if (result > uint64_t(UINT_MAX))
+    return ERROR_ARITHMETIC_OVERFLOW;
+
+  *out = (uint32_t)result;
+  return S_OK;
+}
+
+#ifndef __MINGW32__
 
 HRESULT StringCchCopyEx(LPSTR pszDest, size_t cchDest, LPCSTR pszSrc,
                         LPSTR *ppszDestEnd, size_t *pcchRemaining, DWORD dwFlags) {
@@ -88,14 +100,6 @@ HRESULT SizeTToInt(size_t in, int *out) {
     hr = ERROR_ARITHMETIC_OVERFLOW;
   }
   return hr;
-}
-HRESULT UInt32Mult(UINT a, UINT b, UINT *out) {
-  uint64_t result = (uint64_t)a * (uint64_t)b;
-  if (result > uint64_t(UINT_MAX))
-    return ERROR_ARITHMETIC_OVERFLOW;
-
-  *out = (uint32_t)result;
-  return S_OK;
 }
 
 int strnicmp(const char *str1, const char *str2, size_t count) {
@@ -351,4 +355,6 @@ HANDLE GetProcessHeap() {
   return (HANDLE)&g_processHeap;
 }
 
-#endif // _WIN32
+#endif // __MINGW32__
+
+#endif // !defined(_WIN32) || defined(__MINGW32__)

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -16,6 +16,36 @@
 #include "dxc/Support/FileIOHelper.h"
 #include "dxc/Support/WinFunctions.h"
 
+// For MinGW, export specializations for our public COM interface. See WinAdapter.h for more info.
+#ifdef __MINGW32__
+MINGW_UUIDOF(IDxcBlob, "8BA5FB08-5195-40e2-AC58-0D989C3A0102")
+MINGW_UUIDOF(IDxcBlobEncoding, "7241d424-2646-4191-97c0-98e96e42fc68")
+MINGW_UUIDOF(IDxcBlobUtf16, "A3F84EAB-0FAA-497E-A39C-EE6ED60B2D84")
+MINGW_UUIDOF(IDxcBlobUtf8, "3DA636C9-BA71-4024-A301-30CBF125305B")
+MINGW_UUIDOF(IDxcIncludeHandler, "7f61fc7d-950d-467f-b3e3-3c02fb49187c")
+MINGW_UUIDOF(IDxcCompilerArgs, "73EFFE2A-70DC-45F8-9690-EFF64C02429D")
+MINGW_UUIDOF(IDxcLibrary, "e5204dc7-d18c-4c3c-bdfb-851673980fe7")
+MINGW_UUIDOF(IDxcOperationResult, "CEDB484A-D4E9-445A-B991-CA21CA157DC2")
+MINGW_UUIDOF(IDxcCompiler, "8c210bf3-011f-4422-8d70-6f9acb8db617")
+MINGW_UUIDOF(IDxcCompiler2, "A005A9D9-B8BB-4594-B5C9-0E633BEC4D37")
+MINGW_UUIDOF(IDxcLinker, "F1B5BE2A-62DD-4327-A1C2-42AC1E1E78E6")
+MINGW_UUIDOF(IDxcUtils, "4605C4CB-2019-492A-ADA4-65F20BB7D67F")
+MINGW_UUIDOF(IDxcResult, "58346CDA-DDE7-4497-9461-6F87AF5E0659")
+MINGW_UUIDOF(IDxcExtraOutputs, "319b37a2-a5c2-494a-a5de-4801b2faf989")
+MINGW_UUIDOF(IDxcCompiler3, "228B4687-5A6A-4730-900C-9702B2203F54")
+MINGW_UUIDOF(IDxcValidator, "A6E82BD2-1FD7-4826-9811-2857E797F49A")
+MINGW_UUIDOF(IDxcValidator2, "458e1fd1-b1b2-4750-a6e1-9c10f03bed92")
+MINGW_UUIDOF(IDxcContainerBuilder, "334b1f50-2292-4b35-99a1-25588d8c17fe")
+MINGW_UUIDOF(IDxcAssembler, "091f7a26-1c1f-4948-904b-e6e3a8a771d5")
+MINGW_UUIDOF(IDxcContainerReflection, "d2c21b26-8350-4bdc-976a-331ce6f4c54c")
+MINGW_UUIDOF(IDxcOptimizerPass, "AE2CD79F-CC22-453F-9B6B-B124E7A5204C")
+MINGW_UUIDOF(IDxcOptimizer, "25740E2E-9CBA-401B-9119-4FB42F39F270")
+MINGW_UUIDOF(IDxcVersionInfo, "b04f5b50-2059-4f12-a8ff-a1e0cde1cc7e")
+MINGW_UUIDOF(IDxcVersionInfo2, "fb6904c4-42f0-4b62-9c46-983af7da7c83")
+MINGW_UUIDOF(IDxcVersionInfo3, "5e13e843-9d25-473c-9ad2-03b2d0b44b1e")
+MINGW_UUIDOF(IDxcPdbUtils, "E6C9647E-9D6A-4C3B-B94C-524B5A6C343D")
+#endif
+
 namespace dxc {
 
 #ifdef _WIN32
@@ -33,7 +63,7 @@ static std::string GetWin32ErrorMessage(DWORD err) {
   DWORD formattedMsgLen =
       FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
                     nullptr, err, 0, formattedMsg, _countof(formattedMsg), 0);
-  if (formattedMsg > 0 && formattedMsgLen < _countof(formattedMsg)) {
+  if (formattedMsgLen > 0 && formattedMsgLen < _countof(formattedMsg)) {
     TrimEOL(formattedMsg);
     return std::string(formattedMsg);
   }

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1349,7 +1349,11 @@ static unsigned CalcTypeSize(Type *Ty, unsigned &alignment) {
 }
 
 static unsigned CalcResTypeSize(DxilModule &M, DxilResource &R) {
+  #ifndef __MINGW32__
+  // avoids:
+  //  error: object of type 'hlsl::DxilModule' cannot be assigned because its copy assignment operator is implicitly deleted
   UNREFERENCED_PARAMETER(M);
+  #endif
   Type *Ty = R.GetHLSLType()->getPointerElementType();
   if (R.IsStructuredBuffer()) {
     Ty = dxilutil::StripArrayTypes(Ty);

--- a/lib/IR/PassRegistry.cpp
+++ b/lib/IR/PassRegistry.cpp
@@ -35,7 +35,9 @@ using namespace llvm;
 // A simple global initialized at DllMain-time will do (still does more work
 // than we should likely perform though).
 static uint32_t g_PassRegistryTid;
+#ifndef __MINGW32__
 extern "C" uint32_t __stdcall GetCurrentThreadId(void);
+#endif // __MINGW32__
 static void CheckThreadId() {
   if (g_PassRegistryTid == 0)
     g_PassRegistryTid = GetCurrentThreadId();

--- a/lib/Support/regexec.c
+++ b/lib/Support/regexec.c
@@ -130,6 +130,9 @@
 #define	ISSETBACK(v, n)	((v)[here - (n)])
 /* function names */
 #define	LNAMES			/* flag */
+#ifndef __inexpressible_readableTo
+#define __inexpressible_readableTo(size)
+#endif
 #define _states_param_ __inexpressible_readableTo(stopmarker)
 
 #include "regengine.inc"


### PR DESCRIPTION
Hello! In [Mach engine](https://hexops.com/mach/) we are consuming the C/C++ sources of DirectXShaderCompiler directly (without Visual Studio, CMake, etc.) via the [Zig programming language](https://ziglang.org) (which is also a C/C++ compiler) in order to build Google's Dawn / WebGPU implementation.

Zig utilizes the MinGW windows headers by default, rather than the Windows SDK / official Microsoft headers. While MinGW headers are mostly compatible with those in the Windows SDKs, there are some notable omissions such as missing ATL support currently. Luckily, I found `WinIncludes.h` etc. in this repository has some emulated support for non-Windows targets.

Thus, in order to build dxcompiler with Zig, [we're maintaining these patches on our end](https://github.com/hexops/mach/issues/151). I'd love to upstream these patches so others can benefit from improved compatibility with Zig and MinGW, if you'd have it.

Would you be open to accepting such contributions? I'm happy to continue ensuring this works well into the future, is maintained, etc. and the changes are pretty minimal. I am also happy to send smaller PRs with more details on each patch if desired (I sent all patches in this PR so you can easily get the full picture of what is involved)