### PR TITLE
Fix cbuffer alignment for u64, add tests

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -899,7 +899,8 @@ static unsigned AlignBaseOffset(unsigned baseOffset, unsigned size, QualType Ty,
   }
   if (BT) {
     if (BT->getKind() == clang::BuiltinType::Kind::Double ||
-        BT->getKind() == clang::BuiltinType::Kind::LongLong)
+        BT->getKind() == clang::BuiltinType::Kind::LongLong ||
+        BT->getKind() == clang::BuiltinType::Kind::ULongLong)
       scalarSizeInBytes = 8;
     else if (BT->getKind() == clang::BuiltinType::Kind::Half ||
              BT->getKind() == clang::BuiltinType::Kind::Short ||

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/ConstantBuffer-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/ConstantBuffer-16bit.hlsl
@@ -1,0 +1,248 @@
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_2 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_6 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+
+// -Vd -validator-version 0.0 is used to keep the reflection information
+// in the actual module containing the cbuffer/tbuffer usage info.
+// This is only necessary for test path at the moment because of the way
+// the IR gets into D3DReflect by way of module disassembly and reassembly.
+// Otherwise the separate reflection blob would correctly contain the usage information,
+// since the metadata there is not gated on the shader target.
+
+struct CBStruct
+{
+  float b;
+  double d;         // aligned at 8 (4-bytes padding)
+  float f;
+  half4 h4;         // 8-bytes at 20
+  // spill vector to new row:
+  float16_t3 f16_3; // 6-bytes at 32 (4-bytes padding)
+  min16float mf1;   // 2-bytes at 38 (must look at shift/trunc to detect use)
+  uint16_t u16;     // 2-bytes at 40
+  int16_t2 i16;     // 4-bytes at 42 (may need to look at multiple extractelement users to detect use of i16.x, if u16 is used)
+  int i;            // 4-bytes at 48 (2-bytes padding)
+  uint16_t4 u16_4;  // 8-bytes at 52
+  half2 h2;         // 4-bytes at 60 (maps to float16_t2, fits in remaining row)
+  float16_t f16;    // 2-bytes at 64
+  int64_t i64;      // 8-bytes at 72 (6-bytes padding)
+  float16_t f16b;   // 2-bytes at 80
+  uint64_t u64;     // 8-bytes at 88 (6-bytes padding)
+  float16_t f16c;   // 2-bytes at 96
+  // overall size should be aligned to 16-byte boundary.
+  // unaligned size = 98
+  // aligned size = 112
+};
+
+ConstantBuffer<CBStruct> CBS : register(b1);
+
+float main(int i : A) : SV_TARGET
+{
+  return CBS.b + CBS.mf1 + CBS.h2.y + CBS.f16_3.z + (float)(CBS.d * CBS.i64 + CBS.u64) + CBS.u16 * CBS.i16.x;
+}
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
+// CHECK-NEXT:     Shader Version: Pixel
+// CHECK:     Flags: 0
+// CHECK-NEXT:     ConstantBuffers: 1
+// CHECK-NEXT:     BoundResources: 1
+// CHECK-NEXT:     InputParameters: 1
+// CHECK-NEXT:     OutputParameters: 1
+// CHECK-NEXT:     InstructionCount: {{34|35}}
+// CHECK-NEXT:     TempArrayCount: 0
+// CHECK-NEXT:     DynamicFlowControlCount: 0
+// CHECK-NEXT:     ArrayInstructionCount: 0
+// CHECK-NEXT:     TextureNormalInstructions: 0
+// CHECK-NEXT:     TextureLoadInstructions: 0
+// CHECK-NEXT:     TextureCompInstructions: 0
+// CHECK-NEXT:     TextureBiasInstructions: 0
+// CHECK-NEXT:     TextureGradientInstructions: 0
+// CHECK-NEXT:     FloatInstructionCount: 14
+// CHECK-NEXT:     IntInstructionCount: 1
+// CHECK-NEXT:     UintInstructionCount: 0
+// CHECK-NEXT:     CutInstructionCount: 0
+// CHECK-NEXT:     EmitInstructionCount: 0
+// CHECK-NEXT:     cBarrierInstructions: 0
+// CHECK-NEXT:     cInterlockedInstructions: 0
+// CHECK-NEXT:     cTextureStoreInstructions: 0
+// CHECK:   Constant Buffers:
+// CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
+// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: CBS
+// CHECK-NEXT:         Type: D3D_CT_CBUFFER
+// CHECK-NEXT:         Size: 112
+// CHECK-NEXT:         uFlags: 0
+// CHECK-NEXT:         Num Variables: 1
+// CHECK-NEXT:       {
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: CBS
+// CHECK-NEXT:             Size: 98
+// CHECK-NEXT:             StartOffset: 0
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: CBStruct
+// CHECK-NEXT:               Class: D3D_SVC_STRUCT
+// CHECK-NEXT:               Type: D3D_SVT_VOID
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 26
+// CHECK-NEXT:               Members: 16
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:             {
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 0
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: double
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_DOUBLE
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 8
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 16
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 20
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t3
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 3
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 32
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 40
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 42
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_INT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 44
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 48
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 52
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 60
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 64
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 72
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 80
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 88
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 96
+// CHECK-NEXT:             }
+// CHECK-NEXT:           CBuffer: CBS
+// CHECK-NEXT:       }
+// CHECK-NEXT:   Bound Resources:
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: CBS
+// CHECK-NEXT:       Type: D3D_SIT_CBUFFER
+// CHECK-NEXT:       uID: 0
+// CHECK-NEXT:       BindCount: 1
+// CHECK-NEXT:       BindPoint: 1
+// CHECK-NEXT:       Space: 0
+// CHECK-NEXT:       ReturnType: <unknown: 0>
+// CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_UNKNOWN
+// CHECK-NEXT:       NumSamples (or stride): 0
+// CHECK-NEXT:       uFlags: (D3D_SIF_USERPACKED)

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/TextureBuffer-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/TextureBuffer-16bit.hlsl
@@ -1,0 +1,248 @@
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_2 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_6 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+
+// -Vd -validator-version 0.0 is used to keep the reflection information
+// in the actual module containing the cbuffer/tbuffer usage info.
+// This is only necessary for test path at the moment because of the way
+// the IR gets into D3DReflect by way of module disassembly and reassembly.
+// Otherwise the separate reflection blob would correctly contain the usage information,
+// since the metadata there is not gated on the shader target.
+
+struct TBStruct
+{
+  float b;
+  double d;         // aligned at 8 (4-bytes padding)
+  float f;
+  half4 h4;         // 8-bytes at 20
+  // spill vector to new row:
+  float16_t3 f16_3; // 6-bytes at 32 (4-bytes padding)
+  min16float mf1;   // 2-bytes at 38 (must look at shift/trunc to detect use)
+  uint16_t u16;     // 2-bytes at 40
+  int16_t2 i16;     // 4-bytes at 42 (may need to look at multiple extractelement users to detect use of i16.x, if u16 is used)
+  int i;            // 4-bytes at 48 (2-bytes padding)
+  uint16_t4 u16_4;  // 8-bytes at 52
+  half2 h2;         // 4-bytes at 60 (maps to float16_t2, fits in remaining row)
+  float16_t f16;    // 2-bytes at 64
+  int64_t i64;      // 8-bytes at 72 (6-bytes padding)
+  float16_t f16b;   // 2-bytes at 80
+  uint64_t u64;     // 8-bytes at 88 (6-bytes padding)
+  float16_t f16c;   // 2-bytes at 96
+  // overall size should be aligned to 16-byte boundary.
+  // unaligned size = 98
+  // aligned size = 112
+};
+
+TextureBuffer<TBStruct> TBS : register(t1);
+
+float main(int i : A) : SV_TARGET
+{
+  return TBS.b + TBS.mf1 + TBS.h2.y + TBS.f16_3.z + (float)(TBS.d * TBS.i64 + TBS.u64) + TBS.u16 * TBS.i16.x;
+}
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
+// CHECK-NEXT:     Shader Version: Pixel
+// CHECK:     Flags: 0
+// CHECK-NEXT:     ConstantBuffers: 1
+// CHECK-NEXT:     BoundResources: 1
+// CHECK-NEXT:     InputParameters: 1
+// CHECK-NEXT:     OutputParameters: 1
+// CHECK-NEXT:     InstructionCount: {{57|58}}
+// CHECK-NEXT:     TempArrayCount: 0
+// CHECK-NEXT:     DynamicFlowControlCount: 0
+// CHECK-NEXT:     ArrayInstructionCount: 0
+// CHECK-NEXT:     TextureNormalInstructions: 0
+// CHECK-NEXT:     TextureLoadInstructions: 7
+// CHECK-NEXT:     TextureCompInstructions: 0
+// CHECK-NEXT:     TextureBiasInstructions: 0
+// CHECK-NEXT:     TextureGradientInstructions: 0
+// CHECK-NEXT:     FloatInstructionCount: 14
+// CHECK-NEXT:     IntInstructionCount: 6
+// CHECK-NEXT:     UintInstructionCount: 10
+// CHECK-NEXT:     CutInstructionCount: 0
+// CHECK-NEXT:     EmitInstructionCount: 0
+// CHECK-NEXT:     cBarrierInstructions: 0
+// CHECK-NEXT:     cInterlockedInstructions: 0
+// CHECK-NEXT:     cTextureStoreInstructions: 0
+// CHECK:   Constant Buffers:
+// CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
+// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: TBS
+// CHECK-NEXT:         Type: D3D_CT_TBUFFER
+// CHECK-NEXT:         Size: 112
+// CHECK-NEXT:         uFlags: 0
+// CHECK-NEXT:         Num Variables: 1
+// CHECK-NEXT:       {
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: TBS
+// CHECK-NEXT:             Size: 98
+// CHECK-NEXT:             StartOffset: 0
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: TBStruct
+// CHECK-NEXT:               Class: D3D_SVC_STRUCT
+// CHECK-NEXT:               Type: D3D_SVT_VOID
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 26
+// CHECK-NEXT:               Members: 16
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:             {
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 0
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: double
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_DOUBLE
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 8
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 16
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 20
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t3
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 3
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 32
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 40
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 42
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_INT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 44
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 48
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 52
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 60
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 64
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 72
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 80
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 88
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 96
+// CHECK-NEXT:             }
+// CHECK-NEXT:           CBuffer: TBS
+// CHECK-NEXT:       }
+// CHECK-NEXT:   Bound Resources:
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: TBS
+// CHECK-NEXT:       Type: D3D_SIT_TBUFFER
+// CHECK-NEXT:       uID: 0
+// CHECK-NEXT:       BindCount: 1
+// CHECK-NEXT:       BindPoint: 1
+// CHECK-NEXT:       Space: 0
+// CHECK-NEXT:       ReturnType: <unknown: 0>
+// CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_UNKNOWN
+// CHECK-NEXT:       NumSamples (or stride): 0
+// CHECK-NEXT:       uFlags: (D3D_SIF_USERPACKED)

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer-16bit.hlsl
@@ -8,7 +8,7 @@
 // Otherwise the separate reflection blob would correctly contain the usage information,
 // since the metadata there is not gated on the shader target.
 
-tbuffer tb : register(t1)
+cbuffer cb : register(b1)
 {
   float b;
   double d;         // aligned at 8 (4-bytes padding)
@@ -45,18 +45,18 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:     BoundResources: 1
 // CHECK-NEXT:     InputParameters: 1
 // CHECK-NEXT:     OutputParameters: 1
-// CHECK-NEXT:     InstructionCount: {{58|59}}
+// CHECK-NEXT:     InstructionCount: {{34|35}}
 // CHECK-NEXT:     TempArrayCount: 0
 // CHECK-NEXT:     DynamicFlowControlCount: 0
 // CHECK-NEXT:     ArrayInstructionCount: 0
 // CHECK-NEXT:     TextureNormalInstructions: 0
-// CHECK-NEXT:     TextureLoadInstructions: 7
+// CHECK-NEXT:     TextureLoadInstructions: 0
 // CHECK-NEXT:     TextureCompInstructions: 0
 // CHECK-NEXT:     TextureBiasInstructions: 0
 // CHECK-NEXT:     TextureGradientInstructions: 0
 // CHECK-NEXT:     FloatInstructionCount: 14
-// CHECK-NEXT:     IntInstructionCount: 6
-// CHECK-NEXT:     UintInstructionCount: 11
+// CHECK-NEXT:     IntInstructionCount: 1
+// CHECK-NEXT:     UintInstructionCount: 0
 // CHECK-NEXT:     CutInstructionCount: 0
 // CHECK-NEXT:     EmitInstructionCount: 0
 // CHECK-NEXT:     cBarrierInstructions: 0
@@ -64,8 +64,8 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:     cTextureStoreInstructions: 0
 // CHECK:   Constant Buffers:
 // CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
-// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: tb
-// CHECK-NEXT:         Type: D3D_CT_TBUFFER
+// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: cb
+// CHECK-NEXT:         Type: D3D_CT_CBUFFER
 // CHECK-NEXT:         Size: 112
 // CHECK-NEXT:         uFlags: 0
 // CHECK-NEXT:         Num Variables: 16
@@ -85,7 +85,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: d
 // CHECK-NEXT:             Size: 8
@@ -101,7 +101,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f
 // CHECK-NEXT:             Size: 4
@@ -117,7 +117,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: h4
 // CHECK-NEXT:             Size: 8
@@ -133,7 +133,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 4
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16_3
 // CHECK-NEXT:             Size: 6
@@ -149,7 +149,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 3
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: mf1
 // CHECK-NEXT:             Size: 2
@@ -165,7 +165,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: u16
 // CHECK-NEXT:             Size: 2
@@ -181,7 +181,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: i16
 // CHECK-NEXT:             Size: 4
@@ -197,7 +197,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 2
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: i
 // CHECK-NEXT:             Size: 4
@@ -213,7 +213,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: u16_4
 // CHECK-NEXT:             Size: 8
@@ -229,7 +229,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 4
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: h2
 // CHECK-NEXT:             Size: 4
@@ -245,7 +245,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 2
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16
 // CHECK-NEXT:             Size: 2
@@ -261,7 +261,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: i64
 // CHECK-NEXT:             Size: 8
@@ -277,7 +277,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16b
 // CHECK-NEXT:             Size: 2
@@ -293,7 +293,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: u64
 // CHECK-NEXT:             Size: 8
@@ -309,7 +309,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16c
 // CHECK-NEXT:             Size: 2
@@ -325,11 +325,11 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:               Columns: 1
 // CHECK-NEXT:               Members: 0
 // CHECK-NEXT:               Offset: 0
-// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:           CBuffer: cb
 // CHECK-NEXT:       }
 // CHECK-NEXT:   Bound Resources:
-// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: tb
-// CHECK-NEXT:       Type: D3D_SIT_TBUFFER
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: cb
+// CHECK-NEXT:       Type: D3D_SIT_CBUFFER
 // CHECK-NEXT:       uID: 0
 // CHECK-NEXT:       BindCount: 1
 // CHECK-NEXT:       BindPoint: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer-struct-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuffer-struct-16bit.hlsl
@@ -1,0 +1,251 @@
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_2 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_6 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+
+// -Vd -validator-version 0.0 is used to keep the reflection information
+// in the actual module containing the cbuffer/tbuffer usage info.
+// This is only necessary for test path at the moment because of the way
+// the IR gets into D3DReflect by way of module disassembly and reassembly.
+// Otherwise the separate reflection blob would correctly contain the usage information,
+// since the metadata there is not gated on the shader target.
+
+struct CBStruct
+{
+  float b;
+  double d;         // aligned at 8 (4-bytes padding)
+  float f;
+  half4 h4;         // 8-bytes at 20
+  // spill vector to new row:
+  float16_t3 f16_3; // 6-bytes at 32 (4-bytes padding)
+  min16float mf1;   // 2-bytes at 38 (must look at shift/trunc to detect use)
+  uint16_t u16;     // 2-bytes at 40
+  int16_t2 i16;     // 4-bytes at 42 (may need to look at multiple extractelement users to detect use of i16.x, if u16 is used)
+  int i;            // 4-bytes at 48 (2-bytes padding)
+  uint16_t4 u16_4;  // 8-bytes at 52
+  half2 h2;         // 4-bytes at 60 (maps to float16_t2, fits in remaining row)
+  float16_t f16;    // 2-bytes at 64
+  int64_t i64;      // 8-bytes at 72 (6-bytes padding)
+  float16_t f16b;   // 2-bytes at 80
+  uint64_t u64;     // 8-bytes at 88 (6-bytes padding)
+  float16_t f16c;   // 2-bytes at 96
+  // overall size should be aligned to 16-byte boundary.
+  // unaligned size = 98
+  // aligned size = 112
+};
+
+cbuffer cb : register(b1)
+{
+  CBStruct CBS;
+}
+
+float main(int i : A) : SV_TARGET
+{
+  return CBS.b + CBS.mf1 + CBS.h2.y + CBS.f16_3.z + (float)(CBS.d * CBS.i64 + CBS.u64) + CBS.u16 * CBS.i16.x;
+}
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
+// CHECK-NEXT:     Shader Version: Pixel
+// CHECK:     Flags: 0
+// CHECK-NEXT:     ConstantBuffers: 1
+// CHECK-NEXT:     BoundResources: 1
+// CHECK-NEXT:     InputParameters: 1
+// CHECK-NEXT:     OutputParameters: 1
+// CHECK-NEXT:     InstructionCount: {{34|35}}
+// CHECK-NEXT:     TempArrayCount: 0
+// CHECK-NEXT:     DynamicFlowControlCount: 0
+// CHECK-NEXT:     ArrayInstructionCount: 0
+// CHECK-NEXT:     TextureNormalInstructions: 0
+// CHECK-NEXT:     TextureLoadInstructions: 0
+// CHECK-NEXT:     TextureCompInstructions: 0
+// CHECK-NEXT:     TextureBiasInstructions: 0
+// CHECK-NEXT:     TextureGradientInstructions: 0
+// CHECK-NEXT:     FloatInstructionCount: 14
+// CHECK-NEXT:     IntInstructionCount: 1
+// CHECK-NEXT:     UintInstructionCount: 0
+// CHECK-NEXT:     CutInstructionCount: 0
+// CHECK-NEXT:     EmitInstructionCount: 0
+// CHECK-NEXT:     cBarrierInstructions: 0
+// CHECK-NEXT:     cInterlockedInstructions: 0
+// CHECK-NEXT:     cTextureStoreInstructions: 0
+// CHECK:   Constant Buffers:
+// CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
+// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: cb
+// CHECK-NEXT:         Type: D3D_CT_CBUFFER
+// CHECK-NEXT:         Size: 112
+// CHECK-NEXT:         uFlags: 0
+// CHECK-NEXT:         Num Variables: 1
+// CHECK-NEXT:       {
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: CBS
+// CHECK-NEXT:             Size: 98
+// CHECK-NEXT:             StartOffset: 0
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: CBStruct
+// CHECK-NEXT:               Class: D3D_SVC_STRUCT
+// CHECK-NEXT:               Type: D3D_SVT_VOID
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 26
+// CHECK-NEXT:               Members: 16
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:             {
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 0
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: double
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_DOUBLE
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 8
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 16
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 20
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t3
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 3
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 32
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 40
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 42
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_INT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 44
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 48
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 52
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 60
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 64
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 72
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 80
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 88
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 96
+// CHECK-NEXT:             }
+// CHECK-NEXT:           CBuffer: cb
+// CHECK-NEXT:       }
+// CHECK-NEXT:   Bound Resources:
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: cb
+// CHECK-NEXT:       Type: D3D_SIT_CBUFFER
+// CHECK-NEXT:       uID: 0
+// CHECK-NEXT:       BindCount: 1
+// CHECK-NEXT:       BindPoint: 1
+// CHECK-NEXT:       Space: 0
+// CHECK-NEXT:       ReturnType: <unknown: 0>
+// CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_UNKNOWN
+// CHECK-NEXT:       NumSamples (or stride): 0
+// CHECK-NEXT:       uFlags: (D3D_SIF_USERPACKED)

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_global.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_global.hlsl
@@ -63,13 +63,13 @@
 // CHECK-NEXT:       ID3D12ShaderReflectionConstantBuffer:
 // CHECK-NEXT:         D3D12_SHADER_BUFFER_DESC: Name: X
 // CHECK-NEXT:           Type: D3D_CT_RESOURCE_BIND_INFO
-// CHECK-NEXT:           Size: 56
+// CHECK-NEXT:           Size: 72
 // CHECK-NEXT:           uFlags: 0
 // CHECK-NEXT:           Num Variables: 1
 // CHECK-NEXT:         {
 // CHECK-NEXT:           ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:             D3D12_SHADER_VARIABLE_DESC: Name: $Element
-// CHECK-NEXT:               Size: 56
+// CHECK-NEXT:               Size: 72
 // CHECK-NEXT:               StartOffset: 0
 // CHECK-NEXT:               uFlags: (D3D_SVF_USED)
 // CHECK-NEXT:               DefaultValue: <nullptr>
@@ -79,37 +79,10 @@
 // CHECK-NEXT:                 Type: D3D_SVT_VOID
 // CHECK-NEXT:                 Elements: 0
 // CHECK-NEXT:                 Rows: 1
-// CHECK-NEXT:                 Columns: 9
-// CHECK-NEXT:                 Members: 6
+// CHECK-NEXT:                 Columns: 11
+// CHECK-NEXT:                 Members: 8
 // CHECK-NEXT:                 Offset: 0
 // CHECK-NEXT:               {
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint64_t
-// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
-// CHECK-NEXT:                     Type: D3D_SVT_UINT64
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 1
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 0
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int64_t
-// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
-// CHECK-NEXT:                     Type: D3D_SVT_INT64
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 1
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 8
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: float4
-// CHECK-NEXT:                     Class: D3D_SVC_VECTOR
-// CHECK-NEXT:                     Type: D3D_SVT_FLOAT
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 4
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 16
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -118,7 +91,52 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 0
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_UINT64
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 8
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT16
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 16
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT64
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 24
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: float4
+// CHECK-NEXT:                     Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                     Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 4
+// CHECK-NEXT:                     Members: 0
 // CHECK-NEXT:                     Offset: 32
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT16
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 48
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: double
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -127,7 +145,7 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 40
+// CHECK-NEXT:                     Offset: 56
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint16_t
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -136,7 +154,7 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 48
+// CHECK-NEXT:                     Offset: 64
 // CHECK-NEXT:               }
 // CHECK-NEXT:             CBuffer: X
 // CHECK-NEXT:         }
@@ -159,7 +177,7 @@
 // CHECK-NEXT:         Space: 4294967295
 // CHECK-NEXT:         ReturnType: D3D_RETURN_TYPE_MIXED
 // CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_BUFFER
-// CHECK-NEXT:         NumSamples (or stride): 56
+// CHECK-NEXT:         NumSamples (or stride): 72
 // CHECK-NEXT:         uFlags: 0
 // CHECK-NEXT:   ID3D12FunctionReflection:
 // CHECK-NEXT:     D3D12_FUNCTION_DESC: Name: test
@@ -213,13 +231,13 @@
 // CHECK-NEXT:       ID3D12ShaderReflectionConstantBuffer:
 // CHECK-NEXT:         D3D12_SHADER_BUFFER_DESC: Name: X
 // CHECK-NEXT:           Type: D3D_CT_RESOURCE_BIND_INFO
-// CHECK-NEXT:           Size: 56
+// CHECK-NEXT:           Size: 72
 // CHECK-NEXT:           uFlags: 0
 // CHECK-NEXT:           Num Variables: 1
 // CHECK-NEXT:         {
 // CHECK-NEXT:           ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:             D3D12_SHADER_VARIABLE_DESC: Name: $Element
-// CHECK-NEXT:               Size: 56
+// CHECK-NEXT:               Size: 72
 // CHECK-NEXT:               StartOffset: 0
 // CHECK-NEXT:               uFlags: (D3D_SVF_USED)
 // CHECK-NEXT:               DefaultValue: <nullptr>
@@ -229,37 +247,10 @@
 // CHECK-NEXT:                 Type: D3D_SVT_VOID
 // CHECK-NEXT:                 Elements: 0
 // CHECK-NEXT:                 Rows: 1
-// CHECK-NEXT:                 Columns: 9
-// CHECK-NEXT:                 Members: 6
+// CHECK-NEXT:                 Columns: 11
+// CHECK-NEXT:                 Members: 8
 // CHECK-NEXT:                 Offset: 0
 // CHECK-NEXT:               {
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint64_t
-// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
-// CHECK-NEXT:                     Type: D3D_SVT_UINT64
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 1
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 0
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int64_t
-// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
-// CHECK-NEXT:                     Type: D3D_SVT_INT64
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 1
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 8
-// CHECK-NEXT:                 ID3D12ShaderReflectionType:
-// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: float4
-// CHECK-NEXT:                     Class: D3D_SVC_VECTOR
-// CHECK-NEXT:                     Type: D3D_SVT_FLOAT
-// CHECK-NEXT:                     Elements: 0
-// CHECK-NEXT:                     Rows: 1
-// CHECK-NEXT:                     Columns: 4
-// CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 16
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -268,7 +259,52 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 0
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_UINT64
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 8
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT16
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 16
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT64
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 24
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: float4
+// CHECK-NEXT:                     Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                     Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 4
+// CHECK-NEXT:                     Members: 0
 // CHECK-NEXT:                     Offset: 32
+// CHECK-NEXT:                 ID3D12ShaderReflectionType:
+// CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: int16_t
+// CHECK-NEXT:                     Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                     Type: D3D_SVT_INT16
+// CHECK-NEXT:                     Elements: 0
+// CHECK-NEXT:                     Rows: 1
+// CHECK-NEXT:                     Columns: 1
+// CHECK-NEXT:                     Members: 0
+// CHECK-NEXT:                     Offset: 48
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: double
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -277,7 +313,7 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 40
+// CHECK-NEXT:                     Offset: 56
 // CHECK-NEXT:                 ID3D12ShaderReflectionType:
 // CHECK-NEXT:                   D3D12_SHADER_TYPE_DESC: Name: uint16_t
 // CHECK-NEXT:                     Class: D3D_SVC_SCALAR
@@ -286,21 +322,21 @@
 // CHECK-NEXT:                     Rows: 1
 // CHECK-NEXT:                     Columns: 1
 // CHECK-NEXT:                     Members: 0
-// CHECK-NEXT:                     Offset: 48
+// CHECK-NEXT:                     Offset: 64
 // CHECK-NEXT:               }
 // CHECK-NEXT:             CBuffer: X
 // CHECK-NEXT:         }
 // CHECK-NEXT:     Bound Resources:
 // CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: X
-// CHECK-NEXT:               Type: D3D_SIT_CBUFFER
-// CHECK-NEXT:               uID: 0
-// CHECK-NEXT:               BindCount: 1
-// CHECK-NEXT:               BindPoint: 4294967295
-// CHECK-NEXT:               Space: 4294967295
-// CHECK-NEXT:               ReturnType: <unknown: 0>
-// CHECK-NEXT:               Dimension: D3D_SRV_DIMENSION_UNKNOWN
-// CHECK-NEXT:               NumSamples (or stride): 0
-// CHECK-NEXT:               uFlags: (D3D_SIF_USERPACKED)
+// CHECK-NEXT:         Type: D3D_SIT_CBUFFER
+// CHECK-NEXT:         uID: 0
+// CHECK-NEXT:         BindCount: 1
+// CHECK-NEXT:         BindPoint: 4294967295
+// CHECK-NEXT:         Space: 4294967295
+// CHECK-NEXT:         ReturnType: <unknown: 0>
+// CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_UNKNOWN
+// CHECK-NEXT:         NumSamples (or stride): 0
+// CHECK-NEXT:         uFlags: (D3D_SIF_USERPACKED)
 // CHECK-NEXT:       D3D12_SHADER_INPUT_BIND_DESC: Name: g_samLinear
 // CHECK-NEXT:         Type: D3D_SIT_SAMPLER
 // CHECK-NEXT:         uID: 0
@@ -329,7 +365,7 @@
 // CHECK-NEXT:         Space: 4294967295
 // CHECK-NEXT:         ReturnType: D3D_RETURN_TYPE_MIXED
 // CHECK-NEXT:         Dimension: D3D_SRV_DIMENSION_BUFFER
-// CHECK-NEXT:         NumSamples (or stride): 56
+// CHECK-NEXT:         NumSamples (or stride): 72
 // CHECK-NEXT:         uFlags: 0
 #endif
 
@@ -337,7 +373,9 @@ Texture2D    g_txDiffuse;
 SamplerState    g_samLinear;
 
 struct SBStruct {
+  int16_t pad0; // ensure alignment of next to 8-bytes
   uint64_t u64;
+  int16_t pad1; // ensure alignment of next to 8-bytes
   int64_t i64;
   float4 f4;
   int16_t i16;

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-struct-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-struct-16bit.hlsl
@@ -1,0 +1,251 @@
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_2 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -enable-16bit-types -E main -T ps_6_6 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+
+// -Vd -validator-version 0.0 is used to keep the reflection information
+// in the actual module containing the cbuffer/tbuffer usage info.
+// This is only necessary for test path at the moment because of the way
+// the IR gets into D3DReflect by way of module disassembly and reassembly.
+// Otherwise the separate reflection blob would correctly contain the usage information,
+// since the metadata there is not gated on the shader target.
+
+struct TBStruct
+{
+  float b;
+  double d;         // aligned at 8 (4-bytes padding)
+  float f;
+  half4 h4;         // 8-bytes at 20
+  // spill vector to new row:
+  float16_t3 f16_3; // 6-bytes at 32 (4-bytes padding)
+  min16float mf1;   // 2-bytes at 38 (must look at shift/trunc to detect use)
+  uint16_t u16;     // 2-bytes at 40
+  int16_t2 i16;     // 4-bytes at 42 (may need to look at multiple extractelement users to detect use of i16.x, if u16 is used)
+  int i;            // 4-bytes at 48 (2-bytes padding)
+  uint16_t4 u16_4;  // 8-bytes at 52
+  half2 h2;         // 4-bytes at 60 (maps to float16_t2, fits in remaining row)
+  float16_t f16;    // 2-bytes at 64
+  int64_t i64;      // 8-bytes at 72 (6-bytes padding)
+  float16_t f16b;   // 2-bytes at 80
+  uint64_t u64;     // 8-bytes at 88 (6-bytes padding)
+  float16_t f16c;   // 2-bytes at 96
+  // overall size should be aligned to 16-byte boundary.
+  // unaligned size = 98
+  // aligned size = 112
+};
+
+tbuffer tb : register(t1)
+{
+  TBStruct TBS;
+}
+
+float main(int i : A) : SV_TARGET
+{
+  return TBS.b + TBS.mf1 + TBS.h2.y + TBS.f16_3.z + (float)(TBS.d * TBS.i64 + TBS.u64) + TBS.u16 * TBS.i16.x;
+}
+
+// CHECK: ID3D12ShaderReflection:
+// CHECK-NEXT:   D3D12_SHADER_DESC:
+// CHECK-NEXT:     Shader Version: Pixel
+// CHECK:     Flags: 0
+// CHECK-NEXT:     ConstantBuffers: 1
+// CHECK-NEXT:     BoundResources: 1
+// CHECK-NEXT:     InputParameters: 1
+// CHECK-NEXT:     OutputParameters: 1
+// CHECK-NEXT:     InstructionCount: {{57|58}}
+// CHECK-NEXT:     TempArrayCount: 0
+// CHECK-NEXT:     DynamicFlowControlCount: 0
+// CHECK-NEXT:     ArrayInstructionCount: 0
+// CHECK-NEXT:     TextureNormalInstructions: 0
+// CHECK-NEXT:     TextureLoadInstructions: 7
+// CHECK-NEXT:     TextureCompInstructions: 0
+// CHECK-NEXT:     TextureBiasInstructions: 0
+// CHECK-NEXT:     TextureGradientInstructions: 0
+// CHECK-NEXT:     FloatInstructionCount: 14
+// CHECK-NEXT:     IntInstructionCount: 6
+// CHECK-NEXT:     UintInstructionCount: 10
+// CHECK-NEXT:     CutInstructionCount: 0
+// CHECK-NEXT:     EmitInstructionCount: 0
+// CHECK-NEXT:     cBarrierInstructions: 0
+// CHECK-NEXT:     cInterlockedInstructions: 0
+// CHECK-NEXT:     cTextureStoreInstructions: 0
+// CHECK:   Constant Buffers:
+// CHECK-NEXT:     ID3D12ShaderReflectionConstantBuffer:
+// CHECK-NEXT:       D3D12_SHADER_BUFFER_DESC: Name: tb
+// CHECK-NEXT:         Type: D3D_CT_TBUFFER
+// CHECK-NEXT:         Size: 112
+// CHECK-NEXT:         uFlags: 0
+// CHECK-NEXT:         Num Variables: 1
+// CHECK-NEXT:       {
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: TBS
+// CHECK-NEXT:             Size: 98
+// CHECK-NEXT:             StartOffset: 0
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: TBStruct
+// CHECK-NEXT:               Class: D3D_SVC_STRUCT
+// CHECK-NEXT:               Type: D3D_SVT_VOID
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 26
+// CHECK-NEXT:               Members: 16
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:             {
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 0
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: double
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_DOUBLE
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 8
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 16
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 20
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t3
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 3
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 32
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 40
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 42
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_INT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 44
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 48
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint16_t4
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 4
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 52
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t2
+// CHECK-NEXT:                   Class: D3D_SVC_VECTOR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 2
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 60
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 64
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: int64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_INT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 72
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 80
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: uint64_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_UINT64
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 88
+// CHECK-NEXT:               ID3D12ShaderReflectionType:
+// CHECK-NEXT:                 D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:                   Class: D3D_SVC_SCALAR
+// CHECK-NEXT:                   Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:                   Elements: 0
+// CHECK-NEXT:                   Rows: 1
+// CHECK-NEXT:                   Columns: 1
+// CHECK-NEXT:                   Members: 0
+// CHECK-NEXT:                   Offset: 96
+// CHECK-NEXT:             }
+// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:       }
+// CHECK-NEXT:   Bound Resources:
+// CHECK-NEXT:     D3D12_SHADER_INPUT_BIND_DESC: Name: tb
+// CHECK-NEXT:       Type: D3D_SIT_TBUFFER
+// CHECK-NEXT:       uID: 0
+// CHECK-NEXT:       BindCount: 1
+// CHECK-NEXT:       BindPoint: 1
+// CHECK-NEXT:       Space: 0
+// CHECK-NEXT:       ReturnType: <unknown: 0>
+// CHECK-NEXT:       Dimension: D3D_SRV_DIMENSION_UNKNOWN
+// CHECK-NEXT:       NumSamples (or stride): 0
+// CHECK-NEXT:       uFlags: (D3D_SIF_USERPACKED)


### PR DESCRIPTION
When using uint64_t fields in structures, the member was not being aligned to 8-bytes in constant buffers like it should be.

Constant buffer offsets come from type annotation information, rather than raw data layout.  The CBufferOffset for FieldAnnotation was not being properly aligned for u64 field types, though it was ok for i64.  This was because the offset alignment code was missing ULongLong when checking the basic type.

This change fixes the issue with a minimal change by adding ULongLong to the if condition.

Modified and added tests to check this case for StructuredBuffer, cbuffer/tbuffer (both inside and outside struct member), ConstantBuffer, and TextureBuffer.