### PR TITLE
[spirv] correctly handle rayquery var init Expr

### DIFF
--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -220,7 +220,8 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
   // this is an issue in future (more devices are identified that support
   // ray_tracing but not ray_query), then we should consider addressing this
   // interaction with a spirv-opt pass instead.
-  else if (isa<AccelerationStructureTypeNV>(type)) {
+  else if (isa<AccelerationStructureTypeNV>(type) ||
+           isa<RayQueryTypeKHR>(type)) {
     addCapability(spv::Capability::RayQueryKHR);
     addExtension(Extension::KHR_ray_query, "SPV_KHR_ray_query", {});
   }

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -213,7 +213,7 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
     for (auto field : structType->getFields())
       addCapabilityForType(field.type, loc, sc);
   }
-  // AccelerationStructureTypeNV type
+  // AccelerationStructureTypeNV and RayQueryTypeKHR type
   // Note: Because AccelerationStructureType can be provided by both
   // SPV_KHR_ray_query and SPV_{NV,KHR}_ray_tracing extensions, this logic will
   // result in SPV_KHR_ray_query being unnecessarily required in some cases. If

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -992,7 +992,8 @@ SpirvInstruction *SpirvEmitter::doExpr(const Expr *expr,
     assert(curThis);
     result = curThis;
   } else if (isa<CXXConstructExpr>(expr)) {
-    result = curThis;
+    if (!hlsl::IsHLSLRayQueryType(expr->getType()))
+      result = curThis;
   } else if (const auto *unaryExpr = dyn_cast<UnaryExprOrTypeTraitExpr>(expr)) {
     result = doUnaryExprOrTypeTraitExpr(unaryExpr);
   } else {
@@ -5789,10 +5790,6 @@ void SpirvEmitter::storeValue(SpirvInstruction *lhsPtr,
     // let SPIRV-Tools opt to do the legalization work.
     //
     // Note: legalization specific code
-    if (hlsl::IsHLSLRayQueryType(lhsValType)) {
-      emitError("store value of type %0 is unsupported", {}) << lhsValType;
-      return;
-    }
     spvBuilder.createStore(lhsPtr, rhsVal, loc, range);
     needsLegalization = true;
   } else if (isAKindOfStructuredOrByteBuffer(lhsValType)) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -992,6 +992,10 @@ SpirvInstruction *SpirvEmitter::doExpr(const Expr *expr,
     assert(curThis);
     result = curThis;
   } else if (isa<CXXConstructExpr>(expr)) {
+    // For RayQuery type, we should not explicitly initialize it using
+    // CXXConstructExpr e.g., RayQuery<0> r = RayQuery<0>() is the same as we do
+    // not have a variable initialization. Setting nullptr for the SPIR-V
+    // instruction used for expr will let us skip the variable initialization.
     if (!hlsl::IsHLSLRayQueryType(expr->getType()))
       result = curThis;
   } else if (const auto *unaryExpr = dyn_cast<UnaryExprOrTypeTraitExpr>(expr)) {

--- a/tools/clang/test/CodeGenSPIRV/rayquery_init_expr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rayquery_init_expr.hlsl
@@ -2,6 +2,9 @@
 
 // Ignore "init" Expr of RayQuery in the AST traversal.
 
+// CHECK: OpCapability RayQueryKHR
+// CHECK: OpExtension "SPV_KHR_ray_query"
+
 void Fun() {
   RayQuery<0> RayQ;
 }

--- a/tools/clang/test/CodeGenSPIRV/rayquery_init_expr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rayquery_init_expr.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T cs_6_3 -E main -fspv-target-env=vulkan1.2
+
+// Ignore "init" Expr of RayQuery in the AST traversal.
+
+void Fun() {
+  RayQuery<0> RayQ;
+}
+
+struct SomeStruct {
+  void DummyMethod() {};
+};
+
+[numthreads(1, 1, 1)]
+void main() {
+  SomeStruct Payload;
+  Payload.DummyMethod();
+
+// CHECK:     %RayQ0 = OpVariable %_ptr_Function_rayQueryKHR Function
+// CHECK-NOT: OpStore %RayQ0
+  RayQuery<0> RayQ0;
+
+// CHECK:     %RayQ1 = OpVariable %_ptr_Function_rayQueryKHR Function
+// CHECK-NOT: OpStore %RayQ1
+  RayQuery<0> RayQ1 = RayQuery<0>();
+
+// CHECK: %RayQ2 = OpVariable %_ptr_Function_rayQueryKHR Function
+// CHECK: [[rayq0:%\w+]] = OpLoad {{%\w+}} %RayQ0
+// CHECK: OpStore %RayQ2 [[rayq0]]
+  RayQuery<0> RayQ2 = RayQ0;
+
+// CHECK: %RayQ = OpVariable %_ptr_Function_rayQueryKHR Function
+  Fun();
+}

--- a/tools/clang/test/CodeGenSPIRV/rayquery_init_expr_error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rayquery_init_expr_error.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T cs_6_3 -E main -fspv-target-env=vulkan1.2
+
+void Fun() {
+// CHECK: error: cannot initialize a variable of type 'RayQuery<0>' with an rvalue of type 'literal int'
+  RayQuery<0> RayQ = 0;
+}
+
+struct SomeStruct {
+  void DummyMethod() {};
+};
+
+[numthreads(1, 1, 1)]
+void main() {
+  SomeStruct Payload;
+  Payload.DummyMethod();
+
+// CHECK: error: type mismatch
+  RayQuery<0> RayQ = {0};
+  Fun();
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3019,5 +3019,9 @@ TEST_F(FileTest, ShaderDebugInfoLinePrecedence) {
 TEST_F(FileTest, ShaderDebugInfoLineVariables) {
   runFileTest("shader.debug.line.variables.hlsl");
 }
+TEST_F(FileTest, RayQueryInitExpr) { runFileTest("rayquery_init_expr.hlsl"); }
+TEST_F(FileTest, RayQueryInitExprError) {
+  runFileTest("rayquery_init_expr_error.hlsl", Expect::Failure);
+}
 
 } // namespace


### PR DESCRIPTION
The AST for `RayQuery` always has the initialization Expr e.g.,
```
`-VarDecl 0xba2768 <col:3, col:15> col:15 RayQ 'RayQuery<0>':'RayQuery<0>' callinit
  `-CXXConstructExpr 0xba27d8 <col:15> 'RayQuery<0>':'RayQuery<0>' 'void ()'
```
Since the existing SPIR-V code gen simply uses the most recent "this" of
struct/class for CXXConstructExpr, RayQuery var defined after a struct or
class has weird initialization that results in failures.

This commit simply ignores the initialization Expr when it is
CXXConstructExpr e.g., `RayQuery<0> r = RayQuery<0>();` will not have
the initialization in SPIR-V. Note that we correctly handles the
initialization with another RayQuery var e.g.,
```
RayQuery<0> r = RayQuery<0>();
RayQuery<0> q = r;
```
Also note that the type mismatch for the initialization is handled by
AST parser e.g., parser will report an error for `RayQuery<0> r = {0};`.

Fixes #3119