### PR TITLE
[SPIR-V] Handle storage buffer interfaces in structs

### DIFF
--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
@@ -119,27 +119,27 @@ bool RemoveBufferBlockVisitor::updateStorageClass(
   // For pointer-to-struct cases, we may need to update the storage class for
   // the inner struct fields.
   if (const auto *innerStructType = dyn_cast<StructType>(innerType)) {
-    auto fields = innerStructType->getFields();
-    std::vector<StructType::FieldInfo> newFields(fields.begin(), fields.end());
-    for (size_t i = 0; i < fields.size(); i++) {
-      if (const auto *innerPtrType =
-              dyn_cast<SpirvPointerType>(fields[i].type)) {
-        if (hasStorageBufferInterfaceType(innerPtrType->getPointeeType()) &&
-            innerPtrType->getStorageClass() !=
-                spv::StorageClass::StorageBuffer) {
-          auto *newInnerType = context.getPointerType(
-              innerPtrType->getPointeeType(), spv::StorageClass::StorageBuffer);
-          newFields[i] = newInnerType;
-          *newType = context.getPointerType(
-              context.getStructType(
-                  llvm::ArrayRef<StructType::FieldInfo>(newFields),
-                  innerStructType->getStructName()),
-              ptrType->getStorageClass());
-          *newStorageClass = ptrType->getStorageClass();
-          return true;
-        }
+    bool transformed = false;
+    llvm::SmallVector<StructType::FieldInfo, 2> newFields;
+    for (auto field : innerStructType->getFields()) {
+      const auto *innerPtrType = dyn_cast<SpirvPointerType>(field.type);
+      if (innerPtrType &&
+          hasStorageBufferInterfaceType(innerPtrType->getPointeeType()) &&
+          innerPtrType->getStorageClass() != spv::StorageClass::StorageBuffer) {
+        auto *newInnerType = context.getPointerType(
+            innerPtrType->getPointeeType(), spv::StorageClass::StorageBuffer);
+        newFields.push_back(newInnerType);
+        transformed = true;
+      } else {
+        newFields.push_back(field);
       }
     }
+    *newType = context.getPointerType(
+        context.getStructType(llvm::ArrayRef<StructType::FieldInfo>(newFields),
+                              innerStructType->getStructName()),
+        ptrType->getStorageClass());
+    *newStorageClass = ptrType->getStorageClass();
+    return transformed;
   }
 
   return false;

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
@@ -51,17 +51,28 @@ private:
   ///
   /// 1- a pointer to a structure with StorageBuffer interface
   /// 2- a pointer to a pointer to a structure with StorageBuffer interface
+  /// 3- a pointer to a struct containing a structure with StorageBuffer
+  /// interface
   ///
   /// by updating the storage class of the pointer whose pointee is the struct.
   ///
   /// Example of case (1):
-  /// type:              _ptr_Uniform_SturcturedBuffer_float
-  /// new type:          _ptr_StorageBuffer_SturcturedBuffer_float
+  /// type:              _ptr_Uniform_StructuredBuffer_float
+  /// new type:          _ptr_StorageBuffer_StructuredBuffer_float
   /// new storage class: StorageBuffer
   ///
   /// Example of case (2):
-  /// type:              _ptr_Function__ptr_Uniform_SturcturedBuffer_float
-  /// new type:          _ptr_Function__ptr_StorageBuffer_SturcturedBuffer_float
+  /// type:              _ptr_Function__ptr_Uniform_StructuredBuffer_float
+  /// new type:          _ptr_Function__ptr_StorageBuffer_StructuredBuffer_float
+  /// new storage class: Function
+  ///
+  /// Example of case (3):
+  /// type:              _ptr_Function_Struct
+  ///                    where %Struct = OpTypeStruct
+  ///                        %_ptr_Uniform_type_StructuredBuffer_float
+  /// new type:          _ptr_Function_Struct
+  ///                    where %Struct = OpTypeStruct
+  ///                        %_ptr_StorageBuffer_type_StructuredBuffer_float
   /// new storage class: Function
   ///
   /// If |type| is transformed, the |newType| and |newStorageClass| are

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1.2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1.2.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T cs_6_3 -fspv-target-env=vulkan1.2 -E main
+
+// CHECK: %Struct = OpTypeStruct %v3float %_ptr_StorageBuffer_type_StructuredBuffer_uint
+struct Struct
+{
+  float3 foo;
+  StructuredBuffer<uint> buffer;
+};
+
+// CHECK: %g_stuff_buffer = OpVariable %_ptr_StorageBuffer_type_StructuredBuffer_uint StorageBuffer
+StructuredBuffer<uint> g_stuff_buffer;
+
+// CHECK: %g_output = OpVariable %_ptr_StorageBuffer_type_RWStructuredBuffer_uint StorageBuffer
+RWStructuredBuffer<uint> g_output;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+// CHECK:          %s = OpVariable %_ptr_Function_Struct Function
+  Struct s;
+
+// CHECK: [[p0:%\d+]] = OpAccessChain %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_uint %s %int_1
+// CHECK:               OpStore [[p0]] %g_stuff_buffer
+  s.buffer = g_stuff_buffer;
+
+// CHECK: [[p1:%\d+]] = OpAccessChain %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_uint %s %int_1
+// CHECK: [[p2:%\d+]] = OpLoad %_ptr_StorageBuffer_type_StructuredBuffer_uint [[p1]]
+// CHECK: [[p3:%\d+]] = OpAccessChain %_ptr_StorageBuffer_uint [[p2]] %int_0 %uint_0
+// CHECK: [[p4:%\d+]] = OpLoad %uint [[p3]]
+// CHECK: [[p5:%\d+]] = OpAccessChain %_ptr_StorageBuffer_uint %g_output %int_0 %uint_0
+// CHECK:               OpStore [[p5]] [[p4]]
+  g_output[0] = s.buffer[0];
+}

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1p2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1p2.hlsl
@@ -15,22 +15,26 @@ struct Struct2
   StructuredBuffer<uint> buffer2;
 };
 
+// CHECK: [[fn1:%\d+]] = OpTypeFunction %Struct
 // CHECK: %g_stuff_buffer = OpVariable %_ptr_StorageBuffer_type_StructuredBuffer_uint StorageBuffer
-StructuredBuffer<uint> g_stuff_buffer;
-
 // CHECK: %g_output = OpVariable %_ptr_StorageBuffer_type_RWStructuredBuffer_uint StorageBuffer
+StructuredBuffer<uint> g_stuff_buffer;
 RWStructuredBuffer<uint> g_output;
+
+Struct make_struct()
+{
+  Struct s;
+  s.buffer = g_stuff_buffer;
+  return s;
+}
 
 [numthreads(1, 1, 1)]
 void main()
 {
-// CHECK:          %s = OpVariable %_ptr_Function_Struct Function
-  Struct s;
+// CHECK: %s = OpVariable %_ptr_Function_Struct Function
+  Struct s = make_struct();
 
-// CHECK: [[p0:%\d+]] = OpAccessChain %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_uint %s %int_1
-// CHECK:               OpStore [[p0]] %g_stuff_buffer
-  s.buffer = g_stuff_buffer;
-
+// CHECK: %s2 = OpVariable %_ptr_Function_Struct2 Function
   Struct2 s2;
   s2.buffer1 = g_stuff_buffer;
   s2.buffer2 = g_stuff_buffer;
@@ -43,3 +47,5 @@ void main()
 // CHECK:               OpStore [[p5]] [[p4]]
   g_output[0] = s.buffer[0];
 }
+
+// CHECK: %make_struct = OpFunction %Struct None [[fn1]]

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1p2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.struct.vulkan1p2.hlsl
@@ -7,6 +7,14 @@ struct Struct
   StructuredBuffer<uint> buffer;
 };
 
+// CHECK: %Struct2 = OpTypeStruct %v3float %_ptr_StorageBuffer_type_StructuredBuffer_uint %_ptr_StorageBuffer_type_StructuredBuffer_uint
+struct Struct2
+{
+  float3 foo;
+  StructuredBuffer<uint> buffer1;
+  StructuredBuffer<uint> buffer2;
+};
+
 // CHECK: %g_stuff_buffer = OpVariable %_ptr_StorageBuffer_type_StructuredBuffer_uint StorageBuffer
 StructuredBuffer<uint> g_stuff_buffer;
 
@@ -22,6 +30,10 @@ void main()
 // CHECK: [[p0:%\d+]] = OpAccessChain %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_uint %s %int_1
 // CHECK:               OpStore [[p0]] %g_stuff_buffer
   s.buffer = g_stuff_buffer;
+
+  Struct2 s2;
+  s2.buffer1 = g_stuff_buffer;
+  s2.buffer2 = g_stuff_buffer;
 
 // CHECK: [[p1:%\d+]] = OpAccessChain %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_uint %s %int_1
 // CHECK: [[p2:%\d+]] = OpLoad %_ptr_StorageBuffer_type_StructuredBuffer_uint [[p1]]

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1733,7 +1733,7 @@ TEST_F(FileTest, SpirvLegalizationStructuredBufferInStruct) {
 }
 TEST_F(FileTest, SpirvLegalizationStructuredBufferInStructVk1p2) {
   setBeforeHLSLLegalization();
-  runFileTest("spirv.legal.sbuffer.struct.vulkan1.2.hlsl");
+  runFileTest("spirv.legal.sbuffer.struct.vulkan1p2.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationConstantBuffer) {
   runFileTest("spirv.legal.cbuffer.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1731,6 +1731,10 @@ TEST_F(FileTest, SpirvLegalizationStructuredBufferInStruct) {
   setBeforeHLSLLegalization();
   runFileTest("spirv.legal.sbuffer.struct.hlsl");
 }
+TEST_F(FileTest, SpirvLegalizationStructuredBufferInStructVk1p2) {
+  setBeforeHLSLLegalization();
+  runFileTest("spirv.legal.sbuffer.struct.vulkan1.2.hlsl");
+}
 TEST_F(FileTest, SpirvLegalizationConstantBuffer) {
   runFileTest("spirv.legal.cbuffer.hlsl");
 }


### PR DESCRIPTION
This change modifies the RemoveBufferBlockVisitor to recurse through nested pointers to transform the storage class of inner pointers where required, as well as the fields of structs. Some uses arrays are handled by hasStorageBufferInterfaceType, but this PR leaves as a TODO further verification of the handling of of other composite types.

Fixes #4185, #4187