### PR TITLE
[spirv] support [[vk::ext_decorate_id]] attribute

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1029,7 +1029,15 @@ def VKCounterBinding : InheritableAttr {
 def VKDecorateExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_decorate">];
   let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
-  let Args = [UnsignedArgument<"decorate">, VariadicUnsignedArgument<"literal">];
+  let Args = [UnsignedArgument<"decorate">, VariadicUnsignedArgument<"literals">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
+def VKDecorateIdExt : InheritableAttr {
+  let Spellings = [CXX11<"vk", "ext_decorate_id">];
+  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
+  let Args = [UnsignedArgument<"decorate">, VariadicExprArgument<"arguments">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }
@@ -1037,7 +1045,7 @@ def VKDecorateExt : InheritableAttr {
 def VKDecorateStringExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_decorate_string">];
   let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
-  let Args = [UnsignedArgument<"decorate">, StringArgument<"literals">];
+  let Args = [UnsignedArgument<"decorate">, VariadicStringArgument<"arguments">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
 }

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -696,14 +696,13 @@ public:
                        SourceLocation);
 
   /// \brief Decorates the given target with information from VKDecorateExt
-  void decorateLiterals(SpirvInstruction *targetInst, unsigned decorate,
-                        unsigned *literal, unsigned literalSize,
-                        SourceLocation);
+  void decorateWithLiterals(SpirvInstruction *targetInst, unsigned decorate,
+                            llvm::ArrayRef<unsigned> literals, SourceLocation);
 
-  /// \brief Decorates the given target with the given string.
-  void decorateString(SpirvInstruction *target, unsigned decorate,
-                      llvm::StringRef strLiteral,
-                      llvm::Optional<uint32_t> memberIdx = llvm::None);
+  /// \brief Decorates the given target with the given strings.
+  void decorateWithStrings(SpirvInstruction *target, unsigned decorate,
+                           llvm::ArrayRef<llvm::StringRef> strLiteral,
+                           SourceLocation loc);
 
   /// --- Constants ---
   /// Each of these methods can acquire a unique constant from the SpirvContext,

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -699,6 +699,11 @@ public:
   void decorateWithLiterals(SpirvInstruction *targetInst, unsigned decorate,
                             llvm::ArrayRef<unsigned> literals, SourceLocation);
 
+  /// \brief Decorates the given target with result ids of SPIR-V
+  /// instructions.
+  void decorateWithIds(SpirvInstruction *targetInst, unsigned decorate,
+                       llvm::ArrayRef<SpirvInstruction *> ids, SourceLocation);
+
   /// \brief Decorates the given target with the given strings.
   void decorateWithStrings(SpirvInstruction *target, unsigned decorate,
                            llvm::ArrayRef<llvm::StringRef> strLiteral,

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -474,7 +474,8 @@ public:
 
   // OpDecorateString/OpMemberDecorateString
   SpirvDecoration(SourceLocation loc, SpirvInstruction *target,
-                  spv::Decoration decor, llvm::StringRef stringParam,
+                  spv::Decoration decor,
+                  llvm::ArrayRef<llvm::StringRef> stringParam,
                   llvm::Optional<uint32_t> index = llvm::None);
 
   // Used for creating OpDecorateId instructions

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -617,9 +617,12 @@ public:
     return value;
   }
 
-  /// \brief Decorate variable with spirv intrinsic attributes
-  void decorateVariableWithIntrinsicAttrs(const NamedDecl *decl,
-                                          SpirvVariable *varInst);
+  /// Decorate with spirv intrinsic attributes with lamda function variable
+  /// check
+  void decorateWithIntrinsicAttrs(
+      const NamedDecl *decl, SpirvVariable *varInst,
+      llvm::function_ref<void(VKDecorateExtAttr *)> extraFunctionForDecoAttr =
+          [](VKDecorateExtAttr *) {});
 
   /// \brief Creates instructions to load the value of output stage variable
   /// defined by outputPatchDecl and store it to ptr. Since the output stage
@@ -848,11 +851,12 @@ private:
   bool getImplicitRegisterType(const ResourceVar &var,
                                char *registerTypeOut) const;
 
-  /// Decorate with spirv intrinsic attributes with lamda function variable
-  /// check
-  template <typename Functor>
-  void decorateWithIntrinsicAttrs(const NamedDecl *decl, SpirvVariable *varInst,
-                                  Functor func);
+  /// \brief Decorates stage variable with spirv intrinsic attributes. If
+  /// it is BuiltIn or Location decoration, sets locOrBuiltinDecorateAttr
+  /// of stageVar as true.
+  void decorateStageVarWithIntrinsicAttrs(const NamedDecl *decl,
+                                          StageVar *stageVar,
+                                          SpirvVariable *varInst);
 
 private:
   SpirvBuilder &spvBuilder;

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1513,6 +1513,16 @@ void SpirvBuilder::decorateWithLiterals(SpirvInstruction *targetInst,
   mod->addDecoration(decor);
 }
 
+void SpirvBuilder::decorateWithIds(SpirvInstruction *targetInst,
+                                   unsigned decorate,
+                                   llvm::ArrayRef<SpirvInstruction *> ids,
+                                   SourceLocation srcLoc) {
+  SpirvDecoration *decor = new (context) SpirvDecoration(
+      srcLoc, targetInst, static_cast<spv::Decoration>(decorate), ids);
+  assert(decor != nullptr);
+  mod->addDecoration(decor);
+}
+
 void SpirvBuilder::decorateWithStrings(
     SpirvInstruction *target, unsigned decorate,
     llvm::ArrayRef<llvm::StringRef> strLiteral, SourceLocation srcLoc) {

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1503,24 +1503,22 @@ void SpirvBuilder::decorateLinkage(SpirvInstruction *targetInst,
   mod->addDecoration(decor);
 }
 
-void SpirvBuilder::decorateLiterals(SpirvInstruction *targetInst,
-                                    unsigned decorate, unsigned *literal,
-                                    unsigned literalSize,
-                                    SourceLocation srcLoc) {
-  SmallVector<uint32_t, 2> operands(literal, literal + literalSize);
+void SpirvBuilder::decorateWithLiterals(SpirvInstruction *targetInst,
+                                        unsigned decorate,
+                                        llvm::ArrayRef<unsigned> literals,
+                                        SourceLocation srcLoc) {
   SpirvDecoration *decor = new (context) SpirvDecoration(
-      srcLoc, targetInst, static_cast<spv::Decoration>(decorate), operands);
+      srcLoc, targetInst, static_cast<spv::Decoration>(decorate), literals);
   assert(decor != nullptr);
   mod->addDecoration(decor);
 }
 
-void SpirvBuilder::decorateString(SpirvInstruction *target, unsigned decorate,
-                                  llvm::StringRef strLiteral,
-                                  llvm::Optional<uint32_t> memberIdx) {
+void SpirvBuilder::decorateWithStrings(
+    SpirvInstruction *target, unsigned decorate,
+    llvm::ArrayRef<llvm::StringRef> strLiteral, SourceLocation srcLoc) {
 
   auto *decor = new (context) SpirvDecoration(
-      target->getSourceLocation(), target,
-      static_cast<spv::Decoration>(decorate), strLiteral, memberIdx);
+      srcLoc, target, static_cast<spv::Decoration>(decorate), strLiteral);
   mod->addDecoration(decor);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1672,7 +1672,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
   }
 
   if (var != nullptr && decl->hasAttrs()) {
-    declIdMapper.decorateVariableWithIntrinsicAttrs(decl, var);
+    declIdMapper.decorateWithIntrinsicAttrs(decl, var);
     if (auto attr = decl->getAttr<VKStorageClassExtAttr>()) {
       var->setStorageClass(static_cast<spv::StorageClass>(attr->getStclass()));
     }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -234,14 +234,16 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
 SpirvDecoration::SpirvDecoration(SourceLocation loc,
                                  SpirvInstruction *targetInst,
                                  spv::Decoration decor,
-                                 llvm::StringRef strParam,
+                                 llvm::ArrayRef<llvm::StringRef> strParams,
                                  llvm::Optional<uint32_t> idx)
     : SpirvInstruction(IK_Decoration, getDecorateStringOpcode(idx.hasValue()),
                        /*type*/ {}, loc),
       target(targetInst), targetFunction(nullptr), decoration(decor),
       index(idx), params(), idParams() {
-  const auto &stringWords = string::encodeSPIRVString(strParam);
-  params.insert(params.end(), stringWords.begin(), stringWords.end());
+  for (llvm::StringRef str : strParams) {
+    const auto &stringWords = string::encodeSPIRVString(str);
+    params.insert(params.end(), stringWords.begin(), stringWords.end());
+  }
 }
 
 SpirvDecoration::SpirvDecoration(SourceLocation loc,

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11891,6 +11891,37 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A, 
     declAttr = ::new (S.Context) HLSLRayPayloadAttr(
         A.getRange(), S.Context, A.getAttributeSpellingListIndex());
     break;
+  // SPIRV Change Starts
+  case AttributeList::AT_VKDecorateIdExt: {
+    if (A.getNumArgs() == 0 || !A.getArg(0).is<clang::Expr *>()) {
+      Handled = false;
+      break;
+    }
+
+    unsigned decoration = 0;
+    if (IntegerLiteral *decorationAsLiteral =
+            dyn_cast<IntegerLiteral>(A.getArg(0).get<clang::Expr *>())) {
+      decoration = decorationAsLiteral->getValue().getZExtValue();
+    } else {
+      Handled = false;
+      break;
+    }
+
+    llvm::SmallVector<Expr *, 2> args;
+    for (unsigned i = 1; i < A.getNumArgs(); ++i) {
+      if (!A.getArg(i).is<clang::Expr *>()) {
+        Handled = false;
+        break;
+      }
+      args.push_back(A.getArg(i).get<clang::Expr *>());
+    }
+    if (!Handled)
+      break;
+    declAttr = ::new (S.Context)
+        VKDecorateIdExtAttr(A.getRange(), S.Context, decoration, args.data(),
+                            args.size(), A.getAttributeSpellingListIndex());
+  } break;
+  // SPIRV Change Ends
 
   default:
     Handled = false;

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicDecorate.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicDecorate.hlsl
@@ -3,8 +3,9 @@
 [[vk::ext_decorate(1, 0)]]
 bool b0;
 
-[[vk::ext_decorate(30, 23)]]
-float4 main(
+int getAlignment() {
+  return 16;
+}
 
 //CHECK: OpDecorate {{%\w+}} SpecId 0
 //CHECK: OpDecorate {{%\w+}} BuiltIn BaryCoordNoPerspAMD
@@ -15,25 +16,36 @@ float4 main(
 //CHECK: OpDecorate {{%\w+}} BuiltIn BaryCoordSmoothSampleAMD
 //CHECK: OpDecorate {{%\w+}} BuiltIn BaryCoordPullModelAMD
 //CHECK: OpDecorate {{%\w+}} ExplicitInterpAMD
-//CHECK: OpDecorate {{%\w+}} Location 23
-//CHECK: OpDecorateString {{%\w+}} UserSemantic "return variable"
-//CHECK: OpDecorate {{%\w+}} FPRoundingMode RTE
-    
-    // spv::Decoration::builtIn = 11
-    [[vk::ext_decorate(11, 4992)]] float2 b0 : COLOR0,
-    [[vk::ext_decorate(11, 4993)]] float2 b1 : COLOR1,
-    [[vk::ext_decorate(11, 4994)]] float2 b2 : COLOR2,
-    [[vk::ext_decorate(11, 4995)]] float2 b3 : COLOR3,
-    [[vk::ext_decorate(11, 4996)]] float2 b4 : COLOR4,
-    [[vk::ext_decorate(11, 4997)]] float2 b5 : COLOR5,
-    [[vk::ext_decorate(11, 4998)]] float2 b6 : COLOR6,
-    // ExplicitInterpAMD
-    [[vk::location(12), vk::ext_decorate(4999)]] float2 b7 : COLOR7
-            ) : SV_Target {
-    
-    // spv::Decoration::FPRoundingMode = 39, RTZ=0
-    [[vk::ext_decorate(39, 0), vk::ext_decorate_string(5635, "return variable")]] float4 ret = 1.0;
-    ret.xy = b0 * b1 + b2 + b3 + b4;
-    ret.zw = b5 + b6 + b7;
-    return ret;
+
+//CHECK-DAG: OpDecorate {{%\w+}} Location 23
+//CHECK-DAG: OpDecorateString {{%\w+}} UserSemantic "return variable"
+//CHECK-DAG: OpDecorate {{%\w+}} FPRoundingMode RTE
+
+//CHECK-DAG: OpDecorateId {{%\w+}} AlignmentId [[alignment:%\w+]]
+//CHECK-DAG: OpDecorateId {{%\w+}} UniformId %int_13
+//CHECK-DAG: [[alignment]] = OpFunctionCall %int %getAlignment
+
+[[vk::ext_decorate(30, 23)]]
+float4 main(
+// spv::Decoration::builtIn = 11
+[[vk::ext_decorate(11, 4992)]] float2 b0 : COLOR0,
+[[vk::ext_decorate(11, 4993)]] float2 b1 : COLOR1,
+[[vk::ext_decorate(11, 4994)]] float2 b2 : COLOR2,
+[[vk::ext_decorate(11, 4995)]] float2 b3 : COLOR3,
+[[vk::ext_decorate(11, 4996)]] float2 b4 : COLOR4,
+[[vk::ext_decorate(11, 4997)]] float2 b5 : COLOR5,
+[[vk::ext_decorate(11, 4998)]] float2 b6 : COLOR6,
+// ExplicitInterpAMD
+[[vk::location(12), vk::ext_decorate(4999)]] float2 b7 : COLOR7,
+[[vk::location(13), vk::ext_decorate_id(/* AlignmentId */ 46, getAlignment())]]
+int foo : FOO
+) : SV_Target {
+  [[vk::ext_decorate_id(/* UniformId */ 27, 13)]]
+  int bar;
+
+  // spv::Decoration::FPRoundingMode = 39, RTZ=0
+  [[vk::ext_decorate(39, 0), vk::ext_decorate_string(5635, "return variable")]] float4 ret = 1.0;
+  ret.xy = b0 * b1 + b2 + b3 + b4;
+  ret.zw = b5 + b6 + b7;
+  return ret;
 }


### PR DESCRIPTION
As a part of HLSL version of GL_EXT_spirv_intrinsics, this commit adds
vk::ext_decorate_id attribute.
    
Related to #3919