### PR TITLE
Fixed SlotTracker slowness bug

### DIFF
--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -804,12 +804,14 @@ void SlotTracker::processFunction() {
 
   ST_DEBUG("Inserting Instructions:\n");
 
+  // Process function metadata if it wasn't hit at the module-level.
+  if (ShouldInitializeAllMetadata)
+    processFunctionMetadata(*TheFunction);
+
   // Add all of the basic blocks and instructions with no names.
   for (auto &BB : *TheFunction) {
     if (!BB.hasName())
       CreateFunctionSlot(&BB);
-
-    processFunctionMetadata(*TheFunction);
 
     for (auto &I : BB) {
       if (!I.getType()->isVoidTy() && !I.hasName())
@@ -838,11 +840,12 @@ void SlotTracker::processFunction() {
 
 void SlotTracker::processFunctionMetadata(const Function &F) {
   SmallVector<std::pair<unsigned, MDNode *>, 4> MDs;
-  for (auto &BB : F) {
-    F.getAllMetadata(MDs);
-    for (auto &MD : MDs)
-      CreateMetadataSlot(MD.second);
 
+  F.getAllMetadata(MDs);
+  for (auto &MD : MDs)
+    CreateMetadataSlot(MD.second);
+
+  for (auto &BB : F) {
     for (auto &I : BB)
       processInstructionMetadata(I);
   }

--- a/lib/IR/AsmWriter.cpp
+++ b/lib/IR/AsmWriter.cpp
@@ -805,7 +805,7 @@ void SlotTracker::processFunction() {
   ST_DEBUG("Inserting Instructions:\n");
 
   // Process function metadata if it wasn't hit at the module-level.
-  if (ShouldInitializeAllMetadata)
+  if (!ShouldInitializeAllMetadata)
     processFunctionMetadata(*TheFunction);
 
   // Add all of the basic blocks and instructions with no names.


### PR DESCRIPTION
There was a bug that was reprocessing metadata of the entire function for every BasicBlock. When there's a lot of metadata and a lot of basic blocks, this becomes really slow.

Basically exactly [this](https://github.com/llvm-mirror/llvm/commit/812e1e45de5aac14029573e9fb81885922a2120b) upstream change.