### PR TITLE
FixIt for HLSL 2021 logical operations && and ||

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7749,7 +7749,7 @@ def err_hlsl_load_from_mesh_out_arrays: Error<
 def err_hlsl_out_indices_array_incorrect_access: Error<
    "a vector in out indices array must be accessed as a whole">;
 def err_hlsl_logical_binop_scalar : Error<
-   "operands for short-circuiting logical binary operator must be scalar">;
+   "operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic">;
 def err_hlsl_ternary_scalar : Error<
    "condition for short-circuiting ternary operator must be scalar, for non-scalar types use 'select'">;
 // HLSL Change Ends

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7749,7 +7749,7 @@ def err_hlsl_load_from_mesh_out_arrays: Error<
 def err_hlsl_out_indices_array_incorrect_access: Error<
    "a vector in out indices array must be accessed as a whole">;
 def err_hlsl_logical_binop_scalar : Error<
-   "operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic">;
+   "operands for short-circuiting logical binary operator must be scalar, for non-scalar types use '%select{and|or}0'">;
 def err_hlsl_ternary_scalar : Error<
    "condition for short-circuiting ternary operator must be scalar, for non-scalar types use 'select'">;
 // HLSL Change Ends

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -9211,6 +9211,7 @@ void HLSLExternalSource::CheckBinOpForHLSL(
           SourceRange FullRange =
               SourceRange(LHS.get()->getLocStart(), RHS.get()->getLocEnd());
           m_sema->Diag(OpLoc, diag::err_hlsl_logical_binop_scalar)
+              << (Opc == BinaryOperatorKind::BO_LOr)
               << FixItHint::CreateReplacement(FullRange, OS.str());
           return;
         }

--- a/tools/clang/test/HLSL/vector-and.hlsl
+++ b/tools/clang/test/HLSL/vector-and.hlsl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -HV 2021 -fsyntax-only -ffreestanding -verify %s
+
+RWStructuredBuffer<int3> rw;
+
+[numthreads(1,1,1)]
+void main() {
+// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic}}
+  rw[0] = rw[0] && rw[0];
+}

--- a/tools/clang/test/HLSL/vector-and.hlsl
+++ b/tools/clang/test/HLSL/vector-and.hlsl
@@ -4,6 +4,6 @@ RWStructuredBuffer<int3> rw;
 
 [numthreads(1,1,1)]
 void main() {
-// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic}}
+// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use 'and'}}
   rw[0] = rw[0] && rw[0];
 }

--- a/tools/clang/test/HLSL/vector-or.hlsl
+++ b/tools/clang/test/HLSL/vector-or.hlsl
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -HV 2021 -fsyntax-only -ffreestanding -verify %s
+
+RWStructuredBuffer<int3> rw;
+
+[numthreads(1, 1, 1)]
+void main()
+{
+// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic}}
+    rw[0] = rw[0] || rw[0];
+}

--- a/tools/clang/test/HLSL/vector-or.hlsl
+++ b/tools/clang/test/HLSL/vector-or.hlsl
@@ -5,6 +5,6 @@ RWStructuredBuffer<int3> rw;
 [numthreads(1, 1, 1)]
 void main()
 {
-// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use the logical intrinsic}}
+// expected-error@+1 {{operands for short-circuiting logical binary operator must be scalar, for non-scalar types use 'or'}}
     rw[0] = rw[0] || rw[0];
 }

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -93,6 +93,8 @@ public:
   TEST_METHOD(RunBinopDims)
   TEST_METHOD(RunBitfields)
   TEST_METHOD(RunVectorSelect)
+  TEST_METHOD(RunVectorAnd)
+  TEST_METHOD(RunVectorOr)
   TEST_METHOD(RunArrayConstAssign)
   TEST_METHOD(RunInputPatchConst)
 
@@ -380,6 +382,14 @@ TEST_F(VerifierTest, RunVectorConditional) {
 
 TEST_F(VerifierTest, RunVectorSelect) {
   CheckVerifiesHLSL(L"vector-select.hlsl");
+}
+
+TEST_F(VerifierTest, RunVectorAnd) {
+  CheckVerifiesHLSL(L"vector-and.hlsl");
+}
+
+TEST_F(VerifierTest, RunVectorOr) {
+  CheckVerifiesHLSL(L"vector-or.hlsl");
 }
 
 TEST_F(VerifierTest, RunUint4Add3) {


### PR DESCRIPTION
Adding FixIts to the diagnostics for short-circuiting logical binary operations && and || on non-scalar values, to suggest logical intrinsics _and()_  and _or()_. 