### PR TITLE
Fix OOB index when propagating precise through GEP

### DIFF
--- a/lib/HLSL/DxilPrecisePropagatePass.cpp
+++ b/lib/HLSL/DxilPrecisePropagatePass.cpp
@@ -221,12 +221,8 @@ void DxilPrecisePropagatePass::PropagateOnPointerUsers(Value *Ptr) {
         if (!F->isIntrinsic())
           PropagateOnPointerUsedInCall(Ptr, CI);
       }
-    } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
-      PropagateOnPointerUsers(GEP);
-      continue;
-    } else if (BitCastInst *BC = dyn_cast<BitCastInst>(U)) {
-      PropagateOnPointerUsers(BC);
-      continue;
+    } else if (isa<GEPOperator>(U) || isa<BitCastOperator>(U)) {
+      PropagateOnPointerUsers(U);
     }
   }
 }

--- a/lib/HLSL/DxilPrecisePropagatePass.cpp
+++ b/lib/HLSL/DxilPrecisePropagatePass.cpp
@@ -216,7 +216,17 @@ void DxilPrecisePropagatePass::PropagateOnPointerUsers(Value *Ptr) {
       Value *val = stInst->getValueOperand();
       AddToWorkList(val);
     } else if (CallInst *CI = dyn_cast<CallInst>(U)) {
-      PropagateOnPointerUsedInCall(Ptr, CI);
+      if (Function *F = CI->getCalledFunction()) {
+        // Skip llvm intrinsics (debug/lifetime intrinsics)
+        if (!F->isIntrinsic())
+          PropagateOnPointerUsedInCall(Ptr, CI);
+      }
+    } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
+      PropagateOnPointerUsers(GEP);
+      continue;
+    } else if (BitCastInst *BC = dyn_cast<BitCastInst>(U)) {
+      PropagateOnPointerUsers(BC);
+      continue;
     }
   }
 }
@@ -240,7 +250,15 @@ void DxilPrecisePropagatePass::PropagateThroughGEPs(
       auto idx = GEP->idx_begin();
       idx++;
       unsigned i = 0;
-      while (idx != GEP->idx_end()) {
+      // FIXME: When i points outside idxList, it's an indication that this GEP
+      // is deeper than the one we are matching. This can happen with vector
+      // components or aggregates when marking the aggregate precise, such as
+      // when propagating through call with aggregate argument. This solution
+      // only prevents OOB memory access, it does not fix the underlying
+      // problems that lead to it, which will likely require significant work -
+      // perhaps even a rewrite using alias analysis or some other more accurate
+      // mechanism.
+      while (idx != GEP->idx_end() && i < idxList.size()) {
         if (ConstantInt *C = dyn_cast<ConstantInt>(*idx)) {
           if (ConstantInt *CRef = dyn_cast<ConstantInt>(idxList[i])) {
             if (CRef->getLimitedValue() != C->getLimitedValue()) {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/precise_payload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/precise_payload.hlsl
@@ -1,0 +1,55 @@
+// RUN: %dxc -T lib_6_3 -auto-binding-space 11 %s | FileCheck %s
+
+// CHECK: define void [[raygen1:@"\\01\?raygen1@[^\"]+"]]() #0 {
+// CHECK: fdiv float
+// CHECK: fdiv float
+// CHECK: fmul float
+// CHECK: fmul float
+// CHECK: fmul float
+// CHECK: fmul float
+// CHECK: fmul float
+// CHECK: ret void
+
+float3 PreciseMul(float3 a, float3 b) {
+  precise float3 result = a * b;
+  return result;
+}
+
+struct MyPayload {
+  float4 color;
+  uint2 pos;
+  void Modify(float3 v) {
+    color.xyz = PreciseMul(v, color.xyz);
+  }
+};
+
+#define WIDTH 16
+RWStructuredBuffer<MyPayload> SB : register(u7);
+
+struct Data {
+  MyPayload pld;
+  RayDesc ray;
+  void Write() {
+    SB[pld.pos.x + pld.pos.y * WIDTH] = pld;
+  }
+};
+
+void DoIt(inout Data data) {
+  data.pld.Modify(data.ray.Direction);
+}
+
+RaytracingAccelerationStructure RTAS : register(t5);
+
+[shader("raygeneration")]
+void raygen1()
+{
+  Data data = (Data)0;
+  data.pld.pos = DispatchRaysIndex().xy;
+  data.ray.Origin = float3(0, 0, 0);
+  data.ray.Direction = normalize(float3(data.pld.pos / (float2)DispatchRaysDimensions().xy, 1));
+  data.ray.TMin = 0.125;
+  data.ray.TMax = 128.0;
+  TraceRay(RTAS, RAY_FLAG_NONE, 0, 0, 1, 0, data.ray, data.pld);
+  DoIt(data);
+  data.Write();
+}


### PR DESCRIPTION
This fixes the OOB indexing by ending the loop early if GEP is deeper than the index list being matched.

Libraries with vectors, and intrnisics that operate on aggregate PTRs are not handled properly for precise propagation.

Some potential over/under marking is partially fixed by additional cases in PropagateOnPointerUsers:
  - recurse GEP and Bitcast
  - skip llvm intrinsics like lifetime

There's still some question as to how much we should really be marking precise (at function boundaries like TraceRay, for instance).

Basically, there's more to be done to improve precise propagation, potentially requiring a rewrite in the future.
But this change should improve things for now, and prevent a crash.

Fixes #4193