### PR TITLE
[dxil2spv] Construct minimal SPIR-V module

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -734,6 +734,7 @@ public:
 
 public:
   std::vector<uint32_t> takeModule();
+  std::vector<uint32_t> takeModuleForDxilToSpv();
 
 protected:
   /// Only friend classes are allowed to add capability/extension to the module

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -52,6 +52,8 @@ class SpirvBuilder {
 public:
   SpirvBuilder(ASTContext &ac, SpirvContext &c, const SpirvCodeGenOptions &,
                FeatureManager &featureMgr);
+  SpirvBuilder(SpirvContext &c, const SpirvCodeGenOptions &,
+               FeatureManager &featureMgr);
   ~SpirvBuilder() = default;
 
   // Forbid copy construction and assignment
@@ -792,7 +794,7 @@ private:
                                               SpirvInstruction *var);
 
 private:
-  ASTContext &astContext;
+  ASTContext *astContext;
   SpirvContext &context; ///< From which we allocate various SPIR-V object
   FeatureManager &featureManager;
 

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -298,7 +298,7 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
   }
 
   auto fileId = debugMainFileId;
-  const auto &sm = astContext.getSourceManager();
+  const auto &sm = astContext->getSourceManager();
   const char *fileName = sm.getPresumedLoc(loc).getFilename();
   if (fileName)
     fileId = getOrCreateOpStringId(fileName);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -46,7 +46,7 @@ public:
   };
 
 public:
-  EmitTypeHandler(ASTContext &astCtx, SpirvContext &spvContext,
+  EmitTypeHandler(ASTContext *astCtx, SpirvContext &spvContext,
                   const SpirvCodeGenOptions &opts, FeatureManager &featureMgr,
                   std::vector<uint32_t> *debugVec,
                   std::vector<uint32_t> *decVec,
@@ -145,13 +145,13 @@ private:
   template <unsigned N>
   DiagnosticBuilder emitError(const char (&message)[N],
                               SourceLocation loc = {}) {
-    const auto diagId = astContext.getDiagnostics().getCustomDiagID(
+    const auto diagId = astContext->getDiagnostics().getCustomDiagID(
         clang::DiagnosticsEngine::Error, message);
-    return astContext.getDiagnostics().Report(loc, diagId);
+    return astContext->getDiagnostics().Report(loc, diagId);
   }
 
 private:
-  ASTContext &astContext;
+  ASTContext *astContext;
   SpirvContext &context;
   FeatureManager featureManager;
   std::vector<uint32_t> curTypeInst;
@@ -198,7 +198,7 @@ public:
   };
 
 public:
-  EmitVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
+  EmitVisitor(ASTContext *astCtx, SpirvContext &spvCtx,
               const SpirvCodeGenOptions &opts, FeatureManager &featureMgr)
       : Visitor(opts, spvCtx), astContext(astCtx), id(0),
         typeHandler(astCtx, spvCtx, opts, featureMgr, &debugVariableBinary,
@@ -373,14 +373,14 @@ private:
   template <unsigned N>
   DiagnosticBuilder emitError(const char (&message)[N],
                               SourceLocation loc = {}) {
-    const auto diagId = astContext.getDiagnostics().getCustomDiagID(
+    const auto diagId = astContext->getDiagnostics().getCustomDiagID(
         clang::DiagnosticsEngine::Error, message);
-    return astContext.getDiagnostics().Report(loc, diagId);
+    return astContext->getDiagnostics().Report(loc, diagId);
   }
 
 private:
   // Object that holds Clang AST nodes.
-  ASTContext &astContext;
+  ASTContext *astContext;
   // The last result-id that's been used so far.
   uint32_t id;
   // Handler for emitting types and their related instructions.

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -27,7 +27,15 @@ namespace spirv {
 SpirvBuilder::SpirvBuilder(ASTContext &ac, SpirvContext &ctx,
                            const SpirvCodeGenOptions &opt,
                            FeatureManager &featureMgr)
-    : astContext(ac), context(ctx), featureManager(featureMgr),
+    : astContext(&ac), context(ctx), featureManager(featureMgr),
+      mod(llvm::make_unique<SpirvModule>()), function(nullptr),
+      moduleInit(nullptr), moduleInitInsertPoint(nullptr), spirvOptions(opt),
+      builtinVars(), debugNone(nullptr), nullDebugExpr(nullptr),
+      stringLiterals() {}
+
+SpirvBuilder::SpirvBuilder(SpirvContext &ctx, const SpirvCodeGenOptions &opt,
+                           FeatureManager &featureMg)
+    : astContext(nullptr), context(ctx), featureManager(featureMg),
       mod(llvm::make_unique<SpirvModule>()), function(nullptr),
       moduleInit(nullptr), moduleInitInsertPoint(nullptr), spirvOptions(opt),
       builtinVars(), debugNone(nullptr), nullDebugExpr(nullptr),
@@ -540,9 +548,8 @@ SpirvInstruction *SpirvBuilder::createImageSample(
 
   if (isSparse) {
     // Write the Residency Code
-    const auto status = createCompositeExtract(astContext.UnsignedIntTy,
-                                               imageSampleInst, {0}, loc,
-		                                       range);
+    const auto status = createCompositeExtract(
+        astContext->UnsignedIntTy, imageSampleInst, {0}, loc, range);
     createStore(residencyCode, status, loc, range);
     // Extract the real result from the struct
     return createCompositeExtract(texelType, imageSampleInst, {1}, loc, range);
@@ -581,7 +588,7 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
   if (isSparse) {
     // Write the Residency Code
     const auto status = createCompositeExtract(
-        astContext.UnsignedIntTy, fetchOrReadInst, {0}, loc, range);
+        astContext->UnsignedIntTy, fetchOrReadInst, {0}, loc, range);
     createStore(residencyCode, status, loc, range);
     // Extract the real result from the struct
     return createCompositeExtract(texelType, fetchOrReadInst, {1}, loc, range);
@@ -642,7 +649,7 @@ SpirvInstruction *SpirvBuilder::createImageGather(
 
   if (residencyCode) {
     // Write the Residency Code
-    const auto status = createCompositeExtract(astContext.UnsignedIntTy,
+    const auto status = createCompositeExtract(astContext->UnsignedIntTy,
                                                imageInstruction, {0}, loc);
     createStore(residencyCode, status, loc);
     // Extract the real result from the struct
@@ -655,9 +662,8 @@ SpirvInstruction *SpirvBuilder::createImageGather(
 SpirvImageSparseTexelsResident *SpirvBuilder::createImageSparseTexelsResident(
     SpirvInstruction *residentCode, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *inst = new (context)
-      SpirvImageSparseTexelsResident(astContext.BoolTy, loc, residentCode,
-		                             range);
+  auto *inst = new (context) SpirvImageSparseTexelsResident(
+      astContext->BoolTy, loc, residentCode, range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -1009,7 +1015,7 @@ SpirvInstruction *SpirvBuilder::createReadClock(SpirvInstruction *scope,
   assert(insertPoint && "null insert point");
   assert(scope->getAstResultType()->isIntegerType());
   auto *inst =
-      new (context) SpirvReadClock(astContext.UnsignedLongLongTy, scope, loc);
+      new (context) SpirvReadClock(astContext->UnsignedLongLongTy, scope, loc);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -1071,11 +1077,11 @@ void SpirvBuilder::createCopyArrayInFxcCTBufferToClone(
   for (uint32_t i = 0; i < fxcCTBufferArrTy->getElementCount(); ++i) {
     auto *ptrToFxcCTBufferElem = createAccessChain(
         fxcCTBufferElemPtrTy, fxcCTBuffer,
-        {getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, i))}, loc);
+        {getConstantInt(astContext->UnsignedIntTy, llvm::APInt(32, i))}, loc);
     context.addToInstructionsWithLoweredType(ptrToFxcCTBufferElem);
     auto *ptrToCloneElem = createAccessChain(
         cloneElemPtrTy, clone,
-        {getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, i))}, loc);
+        {getConstantInt(astContext->UnsignedIntTy, llvm::APInt(32, i))}, loc);
     context.addToInstructionsWithLoweredType(ptrToCloneElem);
     createCopyInstructionsFromFxcCTBufferToClone(ptrToFxcCTBufferElem,
                                                  ptrToCloneElem);
@@ -1095,13 +1101,13 @@ void SpirvBuilder::createCopyStructInFxcCTBufferToClone(
           fxcCTBufferFields[i].type, fxcCTBuffer->getStorageClass());
       auto *ptrToFxcCTBufferElem = createAccessChain(
           fxcCTBufferElemPtrTy, fxcCTBuffer,
-          {getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, i))}, loc);
+          {getConstantInt(astContext->UnsignedIntTy, llvm::APInt(32, i))}, loc);
       context.addToInstructionsWithLoweredType(ptrToFxcCTBufferElem);
       auto *cloneElemPtrTy =
           context.getPointerType(cloneFields[i].type, clone->getStorageClass());
       auto *ptrToCloneElem = createAccessChain(
           cloneElemPtrTy, clone,
-          {getConstantInt(astContext.UnsignedIntTy, llvm::APInt(32, i))}, loc);
+          {getConstantInt(astContext->UnsignedIntTy, llvm::APInt(32, i))}, loc);
       context.addToInstructionsWithLoweredType(ptrToCloneElem);
       createCopyInstructionsFromFxcCTBufferToClone(ptrToFxcCTBufferElem,
                                                    ptrToCloneElem);
@@ -1152,7 +1158,7 @@ void SpirvBuilder::createCopyInstructionsFromFxcCTBufferToClone(
 
 void SpirvBuilder::switchInsertPointToModuleInit() {
   if (moduleInitInsertPoint == nullptr) {
-    moduleInit = createSpirvFunction(astContext.VoidTy, SourceLocation(),
+    moduleInit = createSpirvFunction(astContext->VoidTy, SourceLocation(),
                                      "module.init", false);
     moduleInitInsertPoint = new (context) SpirvBasicBlock("module.init.bb");
     moduleInit->addBasicBlock(moduleInitInsertPoint);
@@ -1205,7 +1211,7 @@ SpirvBuilder::initializeCloneVarForFxcCTBuffer(SpirvInstruction *instr) {
   auto astType = var->getAstResultType();
   const auto *spvType = var->getResultType();
 
-  LowerTypeVisitor lowerTypeVisitor(astContext, context, spirvOptions);
+  LowerTypeVisitor lowerTypeVisitor(*astContext, context, spirvOptions);
   lowerTypeVisitor.visitInstruction(var);
   context.addToInstructionsWithLoweredType(instr);
   if (!lowerTypeVisitor.useSpvArrayForHlslMat1xN()) {
@@ -1552,7 +1558,7 @@ SpirvConstant *SpirvBuilder::getConstantFloat(QualType type,
 SpirvConstant *SpirvBuilder::getConstantBool(bool value, bool specConst) {
   // We do not care about making unique constants at this point.
   auto *boolConst =
-      new (context) SpirvConstantBoolean(astContext.BoolTy, value, specConst);
+      new (context) SpirvConstantBoolean(astContext->BoolTy, value, specConst);
   mod->addConstant(boolConst);
   return boolConst;
 }
@@ -1607,7 +1613,7 @@ void SpirvBuilder::addModuleInitCallToEntryPoints() {
 
   for (auto *entry : mod->getEntryPoints()) {
     auto *instruction = new (context)
-        SpirvFunctionCall(astContext.VoidTy, /* SourceLocation */ {},
+        SpirvFunctionCall(astContext->VoidTy, /* SourceLocation */ {},
                           moduleInit, /* params */ {});
     instruction->setRValue(true);
     entry->getEntryPoint()->addFirstInstruction(instruction);
@@ -1633,48 +1639,53 @@ std::vector<uint32_t> SpirvBuilder::takeModule() {
   addModuleInitCallToEntryPoints();
 
   // Run necessary visitor passes first
-  LiteralTypeVisitor literalTypeVisitor(astContext, context, spirvOptions);
-  LowerTypeVisitor lowerTypeVisitor(astContext, context, spirvOptions);
-  CapabilityVisitor capabilityVisitor(astContext, context, spirvOptions, *this,
-                                      featureManager);
-  RelaxedPrecisionVisitor relaxedPrecisionVisitor(context, spirvOptions);
-  PreciseVisitor preciseVisitor(context, spirvOptions);
-  NonUniformVisitor nonUniformVisitor(context, spirvOptions);
-  RemoveBufferBlockVisitor removeBufferBlockVisitor(
-      astContext, context, spirvOptions, featureManager);
-  EmitVisitor emitVisitor(astContext, context, spirvOptions, featureManager);
-
-  mod->invokeVisitor(&literalTypeVisitor, true);
+  if (astContext) {
+    LiteralTypeVisitor literalTypeVisitor(*astContext, context, spirvOptions);
+    mod->invokeVisitor(&literalTypeVisitor, true);
+  }
 
   // Propagate NonUniform decorations
+  NonUniformVisitor nonUniformVisitor(context, spirvOptions);
   mod->invokeVisitor(&nonUniformVisitor);
 
   // Lower types
-  mod->invokeVisitor(&lowerTypeVisitor);
+  if (astContext) {
+    LowerTypeVisitor lowerTypeVisitor(*astContext, context, spirvOptions);
+    mod->invokeVisitor(&lowerTypeVisitor);
 
-  // Generate debug types (if needed)
-  if (spirvOptions.debugInfoRich) {
-    DebugTypeVisitor debugTypeVisitor(astContext, context, spirvOptions, *this,
-                                      lowerTypeVisitor);
-    SortDebugInfoVisitor sortDebugInfoVisitor(context, spirvOptions);
-    mod->invokeVisitor(&debugTypeVisitor);
-    mod->invokeVisitor(&sortDebugInfoVisitor);
+    // Generate debug types (if needed)
+    if (spirvOptions.debugInfoRich) {
+      DebugTypeVisitor debugTypeVisitor(*astContext, context, spirvOptions,
+                                        *this, lowerTypeVisitor);
+      SortDebugInfoVisitor sortDebugInfoVisitor(context, spirvOptions);
+      mod->invokeVisitor(&debugTypeVisitor);
+      mod->invokeVisitor(&sortDebugInfoVisitor);
+    }
   }
 
   // Add necessary capabilities and extensions
+  CapabilityVisitor capabilityVisitor(*astContext, context, spirvOptions, *this,
+                                      featureManager);
   mod->invokeVisitor(&capabilityVisitor);
 
   // Propagate RelaxedPrecision decorations
+  RelaxedPrecisionVisitor relaxedPrecisionVisitor(context, spirvOptions);
   mod->invokeVisitor(&relaxedPrecisionVisitor);
 
   // Propagate NoContraction decorations
+  PreciseVisitor preciseVisitor(context, spirvOptions);
   mod->invokeVisitor(&preciseVisitor, true);
 
   // Remove BufferBlock decoration if necessary (this decoration is deprecated
   // after SPIR-V 1.3).
-  mod->invokeVisitor(&removeBufferBlockVisitor);
+  if (astContext) {
+    RemoveBufferBlockVisitor removeBufferBlockVisitor(
+        *astContext, context, spirvOptions, featureManager);
+    mod->invokeVisitor(&removeBufferBlockVisitor);
+  }
 
   // Emit SPIR-V
+  EmitVisitor emitVisitor(astContext, context, spirvOptions, featureManager);
   mod->invokeVisitor(&emitVisitor);
 
   return emitVisitor.takeBinary();

--- a/tools/clang/tools/dxil2spv/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/CMakeLists.txt
@@ -16,6 +16,8 @@ add_clang_executable(dxil2spv
 target_link_libraries(dxil2spv
   dxcompiler
   dxclib
+  clangSPIRV
+  SPIRV-Tools
   )
 
 llvm_map_components_to_libnames(llvm_libs support core irreader dxil)

--- a/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
+++ b/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
@@ -139,8 +139,8 @@ int main(int argc, const char **argv_) {
   spvContext.setMinorVersion(shaderModel->GetMinor());
 
   clang::spirv::SpirvCodeGenOptions spvOpts{};
-  spvOpts.targetEnv =
-      "vulkan1.0"; // TODO: Allow configuration of targetEnv via options.
+  // TODO: Allow configuration of targetEnv via options.
+  spvOpts.targetEnv = "vulkan1.0";
 
   // Construct SPIR-V builder with diagnostics
   clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagnosticOpts =
@@ -160,7 +160,7 @@ int main(int argc, const char **argv_) {
                             spv::MemoryModel::GLSL450);
 
   // Contsruct the SPIR-V module.
-  std::vector<uint32_t> m = spvBuilder.takeModule();
+  std::vector<uint32_t> m = spvBuilder.takeModuleForDxilToSpv();
 
   // Disassemble SPIR-V for output.
   std::string assembly;


### PR DESCRIPTION
Modify SpirvBuilder to allow unset astContext, because astContext is
unavilable when translating from DXIL. Initialize a SpirvContext and
SpirvBuilder to generate a basic module, and output as disassembled
SPIR-V to STDOUT.