### PR TITLE
[dxil2spv] Add initial testing

### DIFF
--- a/tools/clang/test/Dxil2Spv/passthru-ps.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-ps.ll
@@ -1,3 +1,4 @@
+; RUN: %dxil2spv
 ;
 ; Input signature:
 ;
@@ -100,3 +101,12 @@ attributes #1 = { nounwind }
 !12 = !{!13}
 !13 = !{i32 0, !"SV_Target", i8 9, i8 16, !9, i8 0, i32 1, i8 4, i32 0, i8 0, !11}
 
+; CHECK-WHOLE-SPIR-V:
+; ; SPIR-V
+; ; Version: 1.0
+; ; Generator: Google spiregg; 0
+; ; Bound: 1
+; ; Schema: 0
+;                OpCapability Shader
+;                OpCapability Linkage
+;                OpMemoryModel Logical GLSL450

--- a/tools/clang/tools/dxil2spv/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/CMakeLists.txt
@@ -9,6 +9,8 @@ set( LLVM_LINK_COMPONENTS
   dxilcontainer
   )
 
+add_subdirectory(lib)
+
 add_clang_executable(dxil2spv
   dxil2spvmain.cpp
   )
@@ -18,6 +20,7 @@ target_link_libraries(dxil2spv
   dxclib
   clangSPIRV
   SPIRV-Tools
+  dxil2spvlib
   )
 
 llvm_map_components_to_libnames(llvm_libs support core irreader dxil)

--- a/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
+++ b/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
@@ -29,30 +29,14 @@
 // TODO: The current implementation produces incomplete SPIR-V output.
 //===----------------------------------------------------------------------===//
 
-#include "dxc/DXIL/DxilModule.h"
-#include "dxc/DXIL/DxilUtil.h"
-#include "dxc/DxilContainer/DxilContainer.h"
-#include "dxc/DxilContainer/DxilContainerReader.h"
 #include "dxc/Support/ErrorCodes.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/HLSLOptions.h"
 #include "dxc/Support/dxcapi.use.h"
-#include "dxc/dxcapi.h"
-
-#include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/IRReader/IRReader.h"
+#include "lib/dxil2spv.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
-
-#include "spirv-tools/libspirv.hpp"
-#include "clang/Frontend/TextDiagnosticPrinter.h"
-#include "clang/SPIRV/SpirvBuilder.h"
-#include "clang/SPIRV/SpirvContext.h"
-
-static dxc::DxcDllSupport dxcSupport;
 
 #ifdef _WIN32
 int __cdecl wmain(int argc, const wchar_t **argv_) {
@@ -79,101 +63,10 @@ int main(int argc, const char **argv_) {
   hlsl::options::StringRefUtf16 filename(argv_[1]);
 
   // Read input file.
+  dxc::DxcDllSupport dxcSupport;
   IFT(dxcSupport.Initialize());
   CComPtr<IDxcBlobEncoding> blob;
   ReadFileIntoBlob(dxcSupport, filename, &blob);
-  const char *blobContext =
-      reinterpret_cast<const char *>(blob->GetBufferPointer());
-  unsigned blobSize = blob->GetBufferSize();
 
-  llvm::LLVMContext context;
-  llvm::SMDiagnostic err;
-  std::unique_ptr<llvm::MemoryBuffer> memoryBuffer;
-  std::unique_ptr<llvm::Module> module;
-
-  // Parse LLVM module from bitcode.
-  hlsl::DxilContainerHeader *pBlobHeader =
-      (hlsl::DxilContainerHeader *)blob->GetBufferPointer();
-  if (hlsl::IsValidDxilContainer(pBlobHeader,
-                                 pBlobHeader->ContainerSizeInBytes)) {
-
-    // Get DXIL program from container.
-    const hlsl::DxilPartHeader *pPartHeader =
-        hlsl::GetDxilPartByType(pBlobHeader, hlsl::DxilFourCC::DFCC_DXIL);
-    IFTBOOL(pPartHeader != nullptr, DXC_E_MISSING_PART);
-    const hlsl::DxilProgramHeader *pProgramHeader =
-        reinterpret_cast<const hlsl::DxilProgramHeader *>(
-            GetDxilPartData(pPartHeader));
-
-    // Parse DXIL program to module.
-    if (IsValidDxilProgramHeader(pProgramHeader, pPartHeader->PartSize)) {
-      std::string DiagStr;
-      GetDxilProgramBitcode(pProgramHeader, &blobContext, &blobSize);
-      module = hlsl::dxilutil::LoadModuleFromBitcode(
-          llvm::StringRef(blobContext, blobSize), context, DiagStr);
-    }
-  }
-  // Parse LLVM module from IR.
-  else {
-    llvm::StringRef bufStrRef(blobContext, blobSize);
-    memoryBuffer = llvm::MemoryBuffer::getMemBufferCopy(bufStrRef);
-    module = parseIR(memoryBuffer->getMemBufferRef(), err, context);
-  }
-
-  if (module == nullptr) {
-    llvm::errs() << "Could not parse DXIL module\n";
-    return DXC_E_GENERAL_INTERNAL_ERROR;
-  }
-
-  // Construct DXIL module.
-  hlsl::DxilModule &program = module->GetOrCreateDxilModule();
-
-  const hlsl::ShaderModel *shaderModel = program.GetShaderModel();
-  if (shaderModel->GetKind() == hlsl::ShaderModel::Kind::Invalid)
-    llvm::errs() << "Unknown shader model: " << shaderModel->GetName();
-
-  // Set shader model kind and HLSL major/minor version.
-  clang::spirv::SpirvContext spvContext;
-  spvContext.setCurrentShaderModelKind(shaderModel->GetKind());
-  spvContext.setMajorVersion(shaderModel->GetMajor());
-  spvContext.setMinorVersion(shaderModel->GetMinor());
-
-  clang::spirv::SpirvCodeGenOptions spvOpts{};
-  // TODO: Allow configuration of targetEnv via options.
-  spvOpts.targetEnv = "vulkan1.0";
-
-  // Construct SPIR-V builder with diagnostics
-  clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagnosticOpts =
-      new clang::DiagnosticOptions();
-  clang::TextDiagnosticPrinter diagnosticPrinter(llvm::errs(),
-                                                 &*diagnosticOpts);
-  clang::DiagnosticsEngine diagnosticEngine(
-      clang::IntrusiveRefCntPtr<clang::DiagnosticIDs>(
-          new clang::DiagnosticIDs()),
-      &*diagnosticOpts, &diagnosticPrinter, false);
-
-  clang::spirv::FeatureManager featureMgr(diagnosticEngine, spvOpts);
-  clang::spirv::SpirvBuilder spvBuilder(spvContext, spvOpts, featureMgr);
-
-  // Set default addressing and memory model for SPIR-V module.
-  spvBuilder.setMemoryModel(spv::AddressingModel::Logical,
-                            spv::MemoryModel::GLSL450);
-
-  // Contsruct the SPIR-V module.
-  std::vector<uint32_t> m = spvBuilder.takeModuleForDxilToSpv();
-
-  // Disassemble SPIR-V for output.
-  std::string assembly;
-  spvtools::SpirvTools spirvTools(SPV_ENV_VULKAN_1_1);
-  uint32_t spirvDisOpts = (SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES |
-                           SPV_BINARY_TO_TEXT_OPTION_INDENT);
-
-  if (!spirvTools.Disassemble(m, &assembly, spirvDisOpts)) {
-    llvm::errs() << "SPIR-V disassembly failed\n";
-    return DXC_E_GENERAL_INTERNAL_ERROR;
-  }
-
-  llvm::outs() << assembly;
-
-  return 0;
+  return dxil2spvlib::RunTranslator(blob, llvm::outs(), llvm::errs());
 }

--- a/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
@@ -1,0 +1,25 @@
+# This file is distributed under the University of Illinois Open Source License. See LICENSE.TXT for details.
+
+set( LLVM_LINK_COMPONENTS
+  ${LLVM_TARGETS_TO_BUILD}
+  dxcsupport
+  Support
+  dxil
+  dxilcontainer
+  )
+
+
+add_clang_library(dxil2spvlib
+  dxil2spv.cpp
+  )
+
+target_link_libraries(dxil2spvlib
+  dxcompiler
+  dxclib
+  clangSPIRV
+  SPIRV-Tools
+  )
+
+llvm_map_components_to_libnames(llvm_libs support core irreader dxil)
+
+target_link_libraries(dxil2spvlib ${llvm_libs})

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -1,0 +1,127 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// dxil2spv.cpp                                                              //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Provides wrappers to dxil2spv main function.                              //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#include "dxil2spv.h"
+
+#include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilUtil.h"
+#include "dxc/DxilContainer/DxilContainer.h"
+#include "dxc/DxilContainer/DxilContainerReader.h"
+#include "dxc/Support/ErrorCodes.h"
+#include "dxc/Support/Global.h"
+#include "dxc/dxcapi.h"
+
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "spirv-tools/libspirv.hpp"
+#include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/SPIRV/SpirvBuilder.h"
+#include "clang/SPIRV/SpirvContext.h"
+
+int dxil2spvlib::RunTranslator(CComPtr<IDxcBlobEncoding> blob,
+                               llvm::raw_ostream &OS, llvm::raw_ostream &ERR) {
+  const char *blobContext =
+      reinterpret_cast<const char *>(blob->GetBufferPointer());
+  unsigned blobSize = blob->GetBufferSize();
+
+  llvm::LLVMContext context;
+  llvm::SMDiagnostic err;
+  std::unique_ptr<llvm::MemoryBuffer> memoryBuffer;
+  std::unique_ptr<llvm::Module> module;
+
+  // Parse LLVM module from bitcode.
+  hlsl::DxilContainerHeader *pBlobHeader =
+      (hlsl::DxilContainerHeader *)blob->GetBufferPointer();
+  if (hlsl::IsValidDxilContainer(pBlobHeader,
+                                 pBlobHeader->ContainerSizeInBytes)) {
+
+    // Get DXIL program from container.
+    const hlsl::DxilPartHeader *pPartHeader =
+        hlsl::GetDxilPartByType(pBlobHeader, hlsl::DxilFourCC::DFCC_DXIL);
+    IFTBOOL(pPartHeader != nullptr, DXC_E_MISSING_PART);
+    const hlsl::DxilProgramHeader *pProgramHeader =
+        reinterpret_cast<const hlsl::DxilProgramHeader *>(
+            GetDxilPartData(pPartHeader));
+
+    // Parse DXIL program to module.
+    if (IsValidDxilProgramHeader(pProgramHeader, pPartHeader->PartSize)) {
+      std::string DiagStr;
+      GetDxilProgramBitcode(pProgramHeader, &blobContext, &blobSize);
+      module = hlsl::dxilutil::LoadModuleFromBitcode(
+          llvm::StringRef(blobContext, blobSize), context, DiagStr);
+    }
+  }
+  // Parse LLVM module from IR.
+  else {
+    llvm::StringRef bufStrRef(blobContext, blobSize);
+    memoryBuffer = llvm::MemoryBuffer::getMemBufferCopy(bufStrRef);
+    module = parseIR(memoryBuffer->getMemBufferRef(), err, context);
+  }
+
+  if (module == nullptr) {
+    ERR << "Could not parse DXIL module\n";
+    return DXC_E_GENERAL_INTERNAL_ERROR;
+  }
+
+  // Construct DXIL module.
+  hlsl::DxilModule &program = module->GetOrCreateDxilModule();
+
+  const hlsl::ShaderModel *shaderModel = program.GetShaderModel();
+  if (shaderModel->GetKind() == hlsl::ShaderModel::Kind::Invalid)
+    ERR << "Unknown shader model: " << shaderModel->GetName();
+
+  // Set shader model kind and HLSL major/minor version.
+  clang::spirv::SpirvContext spvContext;
+  spvContext.setCurrentShaderModelKind(shaderModel->GetKind());
+  spvContext.setMajorVersion(shaderModel->GetMajor());
+  spvContext.setMinorVersion(shaderModel->GetMinor());
+
+  clang::spirv::SpirvCodeGenOptions spvOpts{};
+  // TODO: Allow configuration of targetEnv via options.
+  spvOpts.targetEnv = "vulkan1.0";
+
+  // Construct SPIR-V builder with diagnostics
+  clang::IntrusiveRefCntPtr<clang::DiagnosticOptions> diagnosticOpts =
+      new clang::DiagnosticOptions();
+  clang::TextDiagnosticPrinter diagnosticPrinter(ERR, &*diagnosticOpts);
+  clang::DiagnosticsEngine diagnosticEngine(
+      clang::IntrusiveRefCntPtr<clang::DiagnosticIDs>(
+          new clang::DiagnosticIDs()),
+      &*diagnosticOpts, &diagnosticPrinter, false);
+
+  clang::spirv::FeatureManager featureMgr(diagnosticEngine, spvOpts);
+  clang::spirv::SpirvBuilder spvBuilder(spvContext, spvOpts, featureMgr);
+
+  // Set default addressing and memory model for SPIR-V module.
+  spvBuilder.setMemoryModel(spv::AddressingModel::Logical,
+                            spv::MemoryModel::GLSL450);
+
+  // Contsruct the SPIR-V module.
+  std::vector<uint32_t> m = spvBuilder.takeModuleForDxilToSpv();
+
+  // Disassemble SPIR-V for output.
+  std::string assembly;
+  spvtools::SpirvTools spirvTools(SPV_ENV_VULKAN_1_1);
+  uint32_t spirvDisOpts = (SPV_BINARY_TO_TEXT_OPTION_FRIENDLY_NAMES |
+                           SPV_BINARY_TO_TEXT_OPTION_INDENT);
+
+  if (!spirvTools.Disassemble(m, &assembly, spirvDisOpts)) {
+    ERR << "SPIR-V disassembly failed\n";
+    return DXC_E_GENERAL_INTERNAL_ERROR;
+  }
+
+  OS << assembly;
+
+  return 0;
+}

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// dxil2spv.h                                                                //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Provides wrappers to dxil2spv main function.                              //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+#ifndef __DXIL2SPV_DXIL2SPV__
+#define __DXIL2SPV_DXIL2SPV__
+
+#include "dxc/dxcapi.h"
+
+namespace llvm {
+class raw_ostream;
+}
+
+namespace dxil2spvlib {
+int RunTranslator(CComPtr<IDxcBlobEncoding> blob, llvm::raw_ostream &OS,
+                  llvm::raw_ostream &ERR);
+}
+
+#endif // __DXIL2SPV_DXIL2SPV__

--- a/tools/clang/unittests/CMakeLists.txt
+++ b/tools/clang/unittests/CMakeLists.txt
@@ -53,6 +53,9 @@ endif (HLSL_INCLUDE_TESTS)
 
 if (SPIRV_BUILD_TESTS)
   add_subdirectory(SPIRV)
+if (ENABLE_DXIL2SPV)
+  add_subdirectory(Dxil2Spv)
+endif (ENABLE_DXIL2SPV)
 endif (SPIRV_BUILD_TESTS)
 
 # SPIRV Change Ends

--- a/tools/clang/unittests/Dxil2Spv/CMakeLists.txt
+++ b/tools/clang/unittests/Dxil2Spv/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  dxcsupport
+  dxil
+  dxilrootsignature
+  hlsl
+  )
+
+add_clang_unittest(clang-dxil2spv-tests
+  TestMain.cpp
+  LitTest.cpp
+  WholeFileTestFixture.cpp
+  WholeFileTestFixture.h
+  FileTestUtils.cpp
+  FileTestUtils.h
+  Dxil2SpvTestOptions.cpp
+  Dxil2SpvTestOptions.h
+  )
+
+target_link_libraries(clang-dxil2spv-tests
+  dxcompiler
+  effcee
+  dxil2spvlib
+  )
+
+include_directories(${LLVM_SOURCE_DIR}/tools/clang/tools)
+
+target_include_directories(clang-dxil2spv-tests
+  PRIVATE ${SPIRV_TOOLS_INCLUDE_DIR} ${DXC_EFFCEE_DIR})
+
+set_output_directory(clang-dxil2spv-tests
+  ${LLVM_RUNTIME_OUTPUT_INTDIR} ${LLVM_LIBRARY_OUTPUT_INTDIR})
+
+add_test(NAME test-dxil2spv
+  COMMAND clang-dxil2spv-tests --dxil2spv-test-root
+          ${PROJECT_SOURCE_DIR}/tools/clang/test/Dxil2Spv)

--- a/tools/clang/unittests/Dxil2Spv/Dxil2SpvTestOptions.cpp
+++ b/tools/clang/unittests/Dxil2Spv/Dxil2SpvTestOptions.cpp
@@ -1,0 +1,25 @@
+//===- Dxil2SpvTestOptions.cpp ----- Test Options Init---------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines and initializes command line options that can be passed to
+// SPIR-V gtests.
+//
+//===----------------------------------------------------------------------===//
+
+#include "Dxil2SpvTestOptions.h"
+
+namespace clang {
+namespace dxil2spv {
+namespace testOptions {
+
+std::string inputDataDir = "";
+
+} // namespace testOptions
+} // namespace dxil2spv
+} // namespace clang

--- a/tools/clang/unittests/Dxil2Spv/Dxil2SpvTestOptions.h
+++ b/tools/clang/unittests/Dxil2Spv/Dxil2SpvTestOptions.h
@@ -1,0 +1,35 @@
+//===- Dxil2SpvTestOptions.h ----- Command Line Options--------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the command line options that can be passed to dxil2spv
+// gtests.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_UNITTESTS_DXIL2SPV_TEST_OPTIONS_H
+#define LLVM_CLANG_UNITTESTS_DXIL2SPV_TEST_OPTIONS_H
+
+#include <string>
+
+namespace clang {
+namespace dxil2spv {
+
+/// \brief Includes any command line options that may be passed to gtest for
+/// running the dxil2spv tests.
+namespace testOptions {
+
+/// \brief Command line option that specifies the path to the directory that
+/// contains files that have the DXIL source code and expected SPIR-V code.
+extern std::string inputDataDir;
+
+} // namespace testOptions
+} // namespace dxil2spv
+} // namespace clang
+
+#endif

--- a/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
+++ b/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
@@ -1,0 +1,75 @@
+//===- FileTestUtils.cpp ---- Implementation of FileTestUtils -------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "FileTestUtils.h"
+
+#include "dxc/Support/HLSLOptions.h"
+
+#include "Dxil2SpvTestOptions.h"
+#include "dxil2spv/lib/dxil2spv.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+
+namespace clang {
+namespace dxil2spv {
+namespace utils {
+
+std::string getAbsPathOfInputDataFile(const llvm::StringRef filename) {
+
+  std::string path = clang::dxil2spv::testOptions::inputDataDir;
+
+#ifdef _WIN32
+  const char sep = '\\';
+  std::replace(path.begin(), path.end(), '/', '\\');
+#else
+  const char sep = '/';
+#endif
+
+  if (path[path.size() - 1] != sep) {
+    path = path + sep;
+  }
+  path += filename;
+  return path;
+}
+
+bool translateFileWithDxil2Spv(const llvm::StringRef inputFilePath,
+                               std::string *generatedSpirv,
+                               std::string *errorMessages) {
+  bool success = true;
+
+  hlsl::options::StringRefUtf16 filename(inputFilePath);
+
+  std::string stdoutStr;
+  std::string stderrStr;
+  llvm::raw_string_ostream OS(stdoutStr);
+  llvm::raw_string_ostream ERR(stderrStr);
+
+  try {
+    dxc::DxcDllSupport dxcSupport;
+    IFT(dxcSupport.Initialize());
+    CComPtr<IDxcBlobEncoding> blob;
+    ReadFileIntoBlob(dxcSupport, filename, &blob);
+
+    dxil2spvlib::RunTranslator(blob, OS, ERR);
+  } catch (...) {
+    success = false;
+  }
+
+  OS.flush();
+  ERR.flush();
+
+  generatedSpirv->assign(stdoutStr);
+  errorMessages->assign(stderrStr);
+
+  return success;
+}
+
+} // end namespace utils
+} // end namespace dxil2spv
+} // end namespace clang

--- a/tools/clang/unittests/Dxil2Spv/FileTestUtils.h
+++ b/tools/clang/unittests/Dxil2Spv/FileTestUtils.h
@@ -1,0 +1,43 @@
+//===- FileTestUtils.h ---- Utilities For Running File Tests --------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_UNITTESTS_SPIRV_FILETESTUTILS_H
+#define LLVM_CLANG_UNITTESTS_SPIRV_FILETESTUTILS_H
+
+#include <string>
+#include <vector>
+
+#include "dxc/Support/Global.h"
+#include "dxc/Support/WinIncludes.h"
+#include "dxc/Support/dxcapi.use.h"
+#include "spirv-tools/libspirv.hpp"
+#include "llvm/ADT/StringRef.h"
+
+namespace clang {
+namespace dxil2spv {
+namespace utils {
+
+/// \brief Returns the absolute path to the input file of the test.
+/// The input file is expected to be located in the directory given by the
+/// testOptions::inputDataDir
+std::string getAbsPathOfInputDataFile(const llvm::StringRef filename);
+
+/// \brief Passes the DXIL input file to the dxil2spv translator.
+/// Returns the generated SPIR-V code via 'generatedSpirv' argument.
+/// Returns true on success, and false on failure. Writes error messages to
+/// errorMessages and stderr on failure.
+bool translateFileWithDxil2Spv(const llvm::StringRef inputFilePath,
+                               std::string *generatedSpirv,
+                               std::string *errorMessages);
+
+} // end namespace utils
+} // end namespace dxil2spv
+} // end namespace clang
+
+#endif

--- a/tools/clang/unittests/Dxil2Spv/LitTest.cpp
+++ b/tools/clang/unittests/Dxil2Spv/LitTest.cpp
@@ -1,0 +1,19 @@
+//===- utils/unittest/Dxil2Spv/LitTest.cpp ---- Run dxil2spv lit tests ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "WholeFileTestFixture.h"
+
+namespace {
+using clang::dxil2spv::WholeFileTest;
+
+TEST_F(WholeFileTest, PassThruPixelShader) {
+  runWholeFileTest("passthru-ps.ll");
+}
+
+} // namespace

--- a/tools/clang/unittests/Dxil2Spv/TestMain.cpp
+++ b/tools/clang/unittests/Dxil2Spv/TestMain.cpp
@@ -1,0 +1,144 @@
+//===--- utils/unittest/Dxil2Spv/TestMain.cpp - unittest driver -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "llvm/Support/Signals.h"
+
+#include "Dxil2SpvTestOptions.h"
+#include "dxc/Support/Global.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#if defined(_MSC_VER)
+#include <crtdbg.h>
+#endif
+#endif
+
+namespace {
+using namespace ::testing;
+
+/// A GoogleTest event printer that only prints test failures.
+class FailurePrinter : public TestEventListener {
+public:
+  explicit FailurePrinter(TestEventListener *listener)
+      : defaultListener(listener) {}
+
+  ~FailurePrinter() override { delete defaultListener; }
+
+  void OnTestProgramStart(const UnitTest &ut) override {
+    defaultListener->OnTestProgramStart(ut);
+  }
+
+  void OnTestIterationStart(const UnitTest &ut, int iteration) override {
+    defaultListener->OnTestIterationStart(ut, iteration);
+  }
+
+  void OnEnvironmentsSetUpStart(const UnitTest &ut) override {
+    defaultListener->OnEnvironmentsSetUpStart(ut);
+  }
+
+  void OnEnvironmentsSetUpEnd(const UnitTest &ut) override {
+    defaultListener->OnEnvironmentsSetUpEnd(ut);
+  }
+
+  void OnTestCaseStart(const TestCase &tc) override {
+    defaultListener->OnTestCaseStart(tc);
+  }
+
+  void OnTestStart(const TestInfo &ti) override {
+    // Do not output on test start
+    // defaultListener->OnTestStart(ti);
+  }
+
+  void OnTestPartResult(const TestPartResult &result) override {
+    defaultListener->OnTestPartResult(result);
+  }
+
+  void OnTestEnd(const TestInfo &ti) override {
+    // Only output if failure on test end
+    if (ti.result()->Failed())
+      defaultListener->OnTestEnd(ti);
+  }
+
+  void OnTestCaseEnd(const TestCase &tc) override {
+    defaultListener->OnTestCaseEnd(tc);
+  }
+
+  void OnEnvironmentsTearDownStart(const UnitTest &ut) override {
+    defaultListener->OnEnvironmentsTearDownStart(ut);
+  }
+
+  void OnEnvironmentsTearDownEnd(const UnitTest &ut) override {
+    defaultListener->OnEnvironmentsTearDownEnd(ut);
+  }
+
+  void OnTestIterationEnd(const UnitTest &ut, int iteration) override {
+    defaultListener->OnTestIterationEnd(ut, iteration);
+  }
+
+  void OnTestProgramEnd(const UnitTest &ut) override {
+    defaultListener->OnTestProgramEnd(ut);
+  }
+
+private:
+  TestEventListener *defaultListener;
+};
+} // namespace
+
+const char *TestMainArgv0;
+
+int main(int argc, char **argv) {
+  llvm::sys::PrintStackTraceOnErrorSignal(true /* Disable crash reporting */);
+
+  for (int i = 1; i < argc; ++i) {
+    if (std::string("--dxil2spv-test-root") == argv[i]) {
+      // Allow the user set the root directory for test input files.
+      if (i + 1 < argc) {
+        clang::dxil2spv::testOptions::inputDataDir = argv[++i];
+      } else {
+        fprintf(stderr, "Error: --dxil2spv-test-root requires an argument\n");
+        return 1;
+      }
+    }
+  }
+
+  // Initialize both gmock and gtest.
+  testing::InitGoogleMock(&argc, argv);
+
+  // Switch event listener to one that only prints failures.
+  testing::TestEventListeners &listeners =
+      ::testing::UnitTest::GetInstance()->listeners();
+  auto *defaultPrinter = listeners.Release(listeners.default_result_printer());
+  // Google Test takes the ownership.
+  listeners.Append(new FailurePrinter(defaultPrinter));
+
+  // Make it easy for a test to re-execute itself by saving argv[0].
+  TestMainArgv0 = argv[0];
+
+#if defined(_WIN32)
+  // Disable all of the possible ways Windows conspires to make automated
+  // testing impossible.
+  ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+#if defined(_MSC_VER)
+  ::_set_error_mode(_OUT_TO_STDERR);
+  _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ERROR, _CRTDBG_FILE_STDERR);
+  _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+  _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+#endif
+
+  int result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.cpp
@@ -1,0 +1,95 @@
+//===- WholeFileTestFixture.cpp - WholeFileTest impl-----------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include <fstream>
+
+#include "FileTestUtils.h"
+#include "WholeFileTestFixture.h"
+
+namespace clang {
+namespace dxil2spv {
+
+namespace {
+const char dxilStartLabel[] = "; RUN:";
+const char spirvStartLabel[] = "; CHECK-WHOLE-SPIR-V:";
+} // namespace
+
+bool WholeFileTest::parseInputFile() {
+  bool foundRunCommand = false;
+  bool parseSpirv = false;
+  std::ostringstream outString;
+  std::ifstream inputFile;
+  inputFile.exceptions(std::ifstream::failbit);
+  try {
+    inputFile.open(inputFilePath);
+    for (std::string line; std::getline(inputFile, line);) {
+      if (line.find(dxilStartLabel) != std::string::npos) {
+        foundRunCommand = true;
+      } else if (line.find(spirvStartLabel) != std::string::npos) {
+        // DXIL source has ended.
+        // SPIR-V source starts on the next line.
+        parseSpirv = true;
+      } else if (parseSpirv) {
+        // Strip the leading "; " from the SPIR-V assembly (skip 1 characters)
+        if (line.size() > 2u) {
+          line = line.substr(2);
+        }
+        if (line[line.size() - 1] == '\r')
+          line = line.substr(0, line.size() - 1);
+        outString << line << std::endl;
+      }
+    }
+  } catch (...) {
+    if (!inputFile.eof()) {
+      fprintf(
+          stderr,
+          "Error: Exception occurred while opening/reading the input file %s\n",
+          inputFilePath.c_str());
+      return false;
+    }
+  }
+
+  if (!foundRunCommand) {
+    fprintf(stderr, "Error: Missing \"RUN:\" command.\n");
+    return false;
+  }
+  if (!parseSpirv) {
+    fprintf(stderr, "Error: Missing \"CHECK-WHOLE-SPIR-V:\" command.\n");
+    return false;
+  }
+
+  // Reached the end of the file. SPIR-V source has ended. Store it for
+  // comparison.
+  expectedSpirvAsm = outString.str();
+
+  // Close the input file.
+  inputFile.close();
+
+  // Everything was successful.
+  return true;
+}
+
+void WholeFileTest::runWholeFileTest(llvm::StringRef filename) {
+  inputFilePath = utils::getAbsPathOfInputDataFile(filename);
+
+  // Parse the input file.
+  ASSERT_TRUE(parseInputFile());
+
+  std::string errorMessages;
+
+  // Feed the HLSL source into the Compiler.
+  ASSERT_TRUE(utils::translateFileWithDxil2Spv(
+      inputFilePath, &generatedSpirvAsm, &errorMessages));
+
+  // Compare the expected and the generted SPIR-V code.
+  EXPECT_EQ(expectedSpirvAsm, generatedSpirvAsm);
+}
+
+} // end namespace dxil2spv
+} // end namespace clang

--- a/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.h
+++ b/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.h
@@ -1,0 +1,61 @@
+//===- WholeFileTestFixture.h - Whole file test Fixture--------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_UNITTESTS_DXIL2SPV_WHOLEFILETESTFIXTURE_H
+#define LLVM_CLANG_UNITTESTS_DXIL2SPV_WHOLEFILETESTFIXTURE_H
+
+#include "llvm/ADT/StringRef.h"
+#include "gtest/gtest.h"
+
+namespace clang {
+namespace dxil2spv {
+
+/// \brief The purpose of the this test class is to take in an input file with
+/// the following format:
+///
+///    ; Comments...
+///    ; More comments...
+///    ; RUN: %dxil2spv
+///    ...
+///    <DXIL bitcode goes here>
+///    ...
+///    ; CHECK-WHOLE-SPIR-V:
+///    ; ...
+///    ; <SPIR-V code goes here>
+///    ; ...
+///
+/// This file is fully read in as the DXIL source (therefore any non-DXIL must
+/// be commented out). It is fed to dxil2spv to translate to SPIR-V. The
+/// resulting SPIR-V assembly text is compared to the second part of the input
+/// file (after the <CHECK-WHOLE-SPIR-V:> directive). If these match, the test
+/// is marked as a PASS, and marked as a FAILED otherwise.
+class WholeFileTest : public ::testing::Test {
+public:
+  /// \brief Runs a WHOLE-FILE-TEST! (See class description for more info)
+  /// Returns true if the test passes; false otherwise.
+  void runWholeFileTest(llvm::StringRef path);
+
+  WholeFileTest() {}
+
+private:
+  /// \brief Reads in the given input file.
+  /// Stores the SPIR-V portion of the file into the <expectedSpirvAsm>
+  /// member variable.
+  /// Returns true on success, and false on failure.
+  bool parseInputFile();
+
+  std::string inputFilePath;     ///< Path to the input test file
+  std::string expectedSpirvAsm;  ///< Expected SPIR-V parsed from input
+  std::string generatedSpirvAsm; ///< Disassembled binary (SPIR-V code)
+};
+
+} // end namespace dxil2spv
+} // end namespace clang
+
+#endif


### PR DESCRIPTION
Add whole file testing for dxil2spv, starting with a simple passthrough
pixel shader. dxil2spv does not yet generate complete output for this
sample, but adding testing now will help reviewing iterations.