### PR TITLE
Globally disable NRVO for HLSL; Merge resprops for resource return

### DIFF
--- a/tools/clang/include/clang/AST/Decl.h
+++ b/tools/clang/include/clang/AST/Decl.h
@@ -1228,7 +1228,9 @@ public:
   /// return slot when returning from the function. Within the function body,
   /// each return that returns the NRVO object will have this variable as its
   /// NRVO candidate.
-  bool isNRVOVariable() const;  // HLSL Change - Moved to Decl.cpp
+  bool isNRVOVariable() const {
+    return isa<ParmVarDecl>(this) ? false : NonParmVarDeclBits.NRVOVariable;
+  }
 
   void setNRVOVariable(bool NRVO) {
     assert(!isa<ParmVarDecl>(this));

--- a/tools/clang/lib/AST/Decl.cpp
+++ b/tools/clang/lib/AST/Decl.cpp
@@ -44,17 +44,6 @@ bool Decl::isOutOfLine() const {
   return !getLexicalDeclContext()->Equals(getDeclContext());
 }
 
-// HLSL Change - Begin
-// We need to disable NRVO for anything with the precise attribute assigned.
-// NRVO prevents creating an alloca which breaks how precise is currently
-// implemented. This should have no performance impact.
-bool VarDecl::isNRVOVariable() const {
-  return (isa<ParmVarDecl>(this) || hasAttr<HLSLPreciseAttr>())
-             ? false
-             : NonParmVarDeclBits.NRVOVariable;
-}
-// HLSL Change - End
-
 TranslationUnitDecl::TranslationUnitDecl(ASTContext &ctx)
     : Decl(TranslationUnit, nullptr, SourceLocation()),
       DeclContext(TranslationUnit), Ctx(ctx), AnonymousNamespace(nullptr) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2665,8 +2665,6 @@ const clang::Expr *CGMSHLSLRuntime::CheckReturnStmtGLCMismatch(
   LValue argLV = CGF.EmitLValue(RV);
   Value *argAddr = argLV.getAddress();
 
-  LValue tmpLV = LValue::MakeAddr(tmpArgAddr, FnRetTy, argLV.getAlignment(),
-                                  CGF.getContext());
   // Annotate return value when mismatch with function return type.
   DxilResourceProperties RP = BuildResourceProperty(RV->getType());
   CopyAndAnnotateResourceArgument(argAddr, tmpArgAddr, RP, *m_pHLModule, CGF);

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -296,7 +296,13 @@ public:
                           ArrayRef<const Attr *> Attrs) override;
   void MarkPotentialResourceTemp(CodeGenFunction &CGF, llvm::Value *V,
                                  clang::QualType QaulTy) override;
-  void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D, llvm::Value *V) override;
+  void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D,
+                     llvm::Value *V) override;
+  const clang::Expr *CheckReturnStmtGLCMismatch(
+      CodeGenFunction &CGF, const Expr *RV, const clang::ReturnStmt &S,
+      clang::QualType FnRetTy,
+      const std::function<void(const VarDecl *, llvm::Value *)> &TmpArgMap)
+      override;
   void MarkIfStmt(CodeGenFunction &CGF, BasicBlock *endIfBB) override;
   void MarkSwitchStmt(CodeGenFunction &CGF, SwitchInst *switchInst,
                       BasicBlock *endSwitch) override;
@@ -2575,8 +2581,9 @@ void CGMSHLSLRuntime::AddControlFlowHint(CodeGenFunction &CGF, const Stmt &S,
   }
 }
 
-void CGMSHLSLRuntime::MarkPotentialResourceTemp(CodeGenFunction &CGF, llvm::Value *V,
-                                           clang::QualType QualTy) {
+void CGMSHLSLRuntime::MarkPotentialResourceTemp(CodeGenFunction &CGF,
+                                                llvm::Value *V,
+                                                clang::QualType QualTy) {
   // Save object properties for temp that may be created for
   // call args, return value, or agg expr copy.
   if (objectProperties.GetResource(V).isValid())
@@ -2584,10 +2591,8 @@ void CGMSHLSLRuntime::MarkPotentialResourceTemp(CodeGenFunction &CGF, llvm::Valu
   AddValToPropertyMap(V, QualTy);
 }
 
-static bool isGLCMismatch(QualType Ty0, QualType Ty1,
-                             const Expr *SrcExp,
-                             clang::SourceLocation Loc,
-                             DiagnosticsEngine &Diags) {
+static bool isGLCMismatch(QualType Ty0, QualType Ty1, const Expr *SrcExp,
+                          clang::SourceLocation Loc, DiagnosticsEngine &Diags) {
   if (HasHLSLGloballyCoherent(Ty0) == HasHLSLGloballyCoherent(Ty1))
     return false;
   if (const CastExpr *Cast = dyn_cast<CastExpr>(SrcExp)) {
@@ -2620,6 +2625,52 @@ void CGMSHLSLRuntime::FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D,
       objectProperties.updateGLC(V);
     }
   }
+}
+
+const clang::Expr *CGMSHLSLRuntime::CheckReturnStmtGLCMismatch(
+    CodeGenFunction &CGF, const Expr *RV, const clang::ReturnStmt &S,
+    clang::QualType FnRetTy,
+    const std::function<void(const VarDecl *, llvm::Value *)> &TmpArgMap) {
+  if (!isGLCMismatch(RV->getType(), FnRetTy, RV, S.getReturnLoc(),
+                     CGM.getDiags())) {
+    return RV;
+  }
+  const FunctionDecl *FD = cast<FunctionDecl>(CGF.CurFuncDecl);
+  // create temp Var
+  VarDecl *tmpArg =
+      VarDecl::Create(CGF.getContext(), const_cast<FunctionDecl *>(FD),
+                      SourceLocation(), SourceLocation(),
+                      /*IdentifierInfo*/ nullptr, FnRetTy,
+                      CGF.getContext().getTrivialTypeSourceInfo(FnRetTy),
+                      StorageClass::SC_Auto);
+
+  // Aggregate type will be indirect param convert to pointer type.
+  // So don't update to ReferenceType, use RValue for it.
+  const DeclRefExpr *tmpRef = DeclRefExpr::Create(
+      CGF.getContext(), NestedNameSpecifierLoc(), SourceLocation(), tmpArg,
+      /*enclosing*/ false, tmpArg->getLocation(), FnRetTy, VK_RValue);
+
+  // create alloc for the tmp arg
+  Value *tmpArgAddr = nullptr;
+  BasicBlock *InsertBlock = CGF.Builder.GetInsertBlock();
+  Function *F = InsertBlock->getParent();
+
+  // Make sure the alloca is in entry block to stop inline create stacksave.
+  IRBuilder<> AllocaBuilder(dxilutil::FindAllocaInsertionPt(F));
+  tmpArgAddr = AllocaBuilder.CreateAlloca(CGF.ConvertTypeForMem(FnRetTy));
+
+  // add it to local decl map
+  TmpArgMap(tmpArg, tmpArgAddr);
+
+  LValue argLV = CGF.EmitLValue(RV);
+  Value *argAddr = argLV.getAddress();
+
+  LValue tmpLV = LValue::MakeAddr(tmpArgAddr, FnRetTy, argLV.getAlignment(),
+                                  CGF.getContext());
+  // Annotate return value when mismatch with function return type.
+  DxilResourceProperties RP = BuildResourceProperty(RV->getType());
+  CopyAndAnnotateResourceArgument(argAddr, tmpArgAddr, RP, *m_pHLModule, CGF);
+  return tmpRef;
 }
 
 hlsl::InterpolationMode CGMSHLSLRuntime::GetInterpMode(const Decl *decl,

--- a/tools/clang/lib/CodeGen/CGHLSLRuntime.h
+++ b/tools/clang/lib/CodeGen/CGHLSLRuntime.h
@@ -42,6 +42,7 @@ class CallExpr;
 class InitListExpr;
 class Expr;
 class Stmt;
+class ReturnStmt;
 class Attr;
 class VarDecl;
 class HLSLRootSignatureAttr;
@@ -134,6 +135,10 @@ public:
 
   virtual void FinishAutoVar(CodeGenFunction &CGF, const VarDecl &D,
                              llvm::Value *V) = 0;
+  virtual const clang::Expr *CheckReturnStmtGLCMismatch(
+      CodeGenFunction &CGF, const clang::Expr *RV, const clang::ReturnStmt &S,
+      clang::QualType FnRetTy,
+      const std::function<void(const VarDecl *, llvm::Value *)> &TmpArgMap) = 0;
   virtual void MarkIfStmt(CodeGenFunction &CGF, llvm::BasicBlock *endIfBB) = 0;
   virtual void MarkSwitchStmt(CodeGenFunction &CGF,
                               llvm::SwitchInst *switchInst,

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -1169,6 +1169,14 @@ void CodeGenFunction::EmitReturnStmt(const ReturnStmt &S) {
                                 /*isInit*/ true);
       break;
     case TEK_Aggregate: {
+      CodeGenFunction::HLSLOutParamScope OutParamScope(*this);
+      // HLSL Change Begins.
+      auto MapTemp = [&](const VarDecl *LocalVD, llvm::Value *TmpArg) {
+        OutParamScope.addTemp(LocalVD, TmpArg);
+      };
+      RV = CGM.getHLSLRuntime().CheckReturnStmtGLCMismatch(*this, RV, S,
+                                                           FnRetTy, MapTemp);
+      // HLSL Change Ends.
       CharUnits Alignment = getContext().getTypeAlignInChars(RV->getType());
       EmitAggExpr(RV, AggValueSlot::forAddr(ReturnValue, Alignment,
                                             Qualifiers(),

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Scenarios/glc-dynamic-return.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Scenarios/glc-dynamic-return.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -E main -T ps_6_6 %s | FileCheck %s
+
+// call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %{{.*}}, %dx.types.ResourceProperties { i32 20491, i32 0 })
+// CHECK: ; AnnotateHandle(res,props)  resource: globallycoherent RWByteAddressBuffer
+
+RWByteAddressBuffer getBuf(uint i) {
+  globallycoherent RWByteAddressBuffer buf = ResourceDescriptorHeap[i];
+  return buf;
+}
+
+float4 main(uint i:I) : SV_Target {
+  return asfloat(getBuf(i).Load(i));
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_param8.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_param8.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -default-linkage external %s | FileCheck %s
 
 // Make sure return matrix struct works.
-// CHECK: bitcast %class.matrix.float.3.2* {{.*}} to <6 x float>*
-// CHECK: bitcast %class.matrix.float.2.3* {{.*}} to <6 x float>*
-// CHECK: bitcast %class.matrix.float.3.2* {{.*}} to <6 x float>*
-// CHECK: bitcast %class.matrix.float.2.3* {{.*}} to <6 x float>*
+// CHECK-DAG: bitcast %class.matrix.float.3.2* {{.*}} to <6 x float>*
+// CHECK-DAG: bitcast %class.matrix.float.2.3* {{.*}} to <6 x float>*
+// CHECK-DAG: bitcast %class.matrix.float.3.2* {{.*}} to <6 x float>*
+// CHECK-DAG: bitcast %class.matrix.float.2.3* {{.*}} to <6 x float>*
 
 struct MA {
   float2x3 ma[2];


### PR DESCRIPTION
NRVO can drop type attributes not captured into QualType, like glc.  HLSL does not need NRVO, and it only poses problems in various areas, so this change turns it off globally for HLSL.

The test required an additional fix to resource return resprops merging, provided by @python3kgae.