### PR TITLE
Fix non-deterministic output when overriding semantic defines

### DIFF
--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -312,6 +312,12 @@ bool MacroPairCompareIsLessThan(
   return left.first->getName().compare(right.first->getName()) < 0;
 }
 
+bool ParsedSemanticDefineCompareIsLessThan(
+    const ParsedSemanticDefine &left,
+    const ParsedSemanticDefine &right) {
+    return left.Name < right.Name;
+}
+
 ParsedSemanticDefineList
 CollectUserMacrosParsedByCompiler(CompilerInstance &compiler) {
   ParsedSemanticDefineList parsedDefines;
@@ -496,7 +502,6 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
   }
 
   if (!macros.empty()) {
-    std::sort(macros.begin(), macros.end(), MacroPairCompareIsLessThan);
     MacroExpander expander(pp);
     for (std::pair<const IdentifierInfo *, MacroInfo *> m : macros) {
       std::string expandedValue;
@@ -507,6 +512,7 @@ ParsedSemanticDefineList hlsl::CollectSemanticDefinesParsedByCompiler(
     }
   }
 
+  std::stable_sort(parsedDefines.begin(), parsedDefines.end(), ParsedSemanticDefineCompareIsLessThan);
   return parsedDefines;
 }
 


### PR DESCRIPTION
When overrriding a semantic define with the -override-semdef flag
we could generate non-determinstic dxil output because the defines
would be listed in the source in a different order.

This commit fixes that bug by sorting the defines before writing
them into the dxil. We were missing tests for the -override-semdef
flag so I added those as part of this commit.

The newly added tests were passing before this change except for the
test for non-determinism.