### PR TITLE
Fix DxilProgramSignature size alignment.

### DIFF
--- a/include/dxc/DxilContainer/DxilContainerAssembler.h
+++ b/include/dxc/DxilContainer/DxilContainerAssembler.h
@@ -51,7 +51,8 @@ DxilPartWriter *NewFeatureInfoWriter(const DxilModule &M);
 DxilPartWriter *NewPSVWriter(const DxilModule &M, uint32_t PSVVersion = UINT_MAX);
 DxilPartWriter *NewRDATWriter(const DxilModule &M);
 
-DxilContainerWriter *NewDxilContainerWriter();
+// Unaligned is for matching container for validator version < 1.7.
+DxilContainerWriter *NewDxilContainerWriter(bool bUnaligned = false);
 
 // Set validator version to 0,0 (not validated) then re-emit as much reflection metadata as possible.
 void ReEmitLatestReflectionData(llvm::Module *pReflectionM);

--- a/lib/DxilContainer/DxilContainer.cpp
+++ b/lib/DxilContainer/DxilContainer.cpp
@@ -66,6 +66,8 @@ bool IsValidDxilContainer(const DxilContainerHeader *pHeader, size_t length) {
   const uint8_t *pLinearContainer = reinterpret_cast<const uint8_t *>(pHeader);
   const uint32_t *pPartOffsetTable =
       reinterpret_cast<const uint32_t *>(pHeader + 1);
+  const uint8_t *nextPartBegin = ((const uint8_t *)pPartOffsetTable) +
+                                 (sizeof(uint32_t) * pHeader->PartCount);
   for (uint32_t i = 0; i < pHeader->PartCount; ++i) {
     // The part header should fit.
     if (pPartOffsetTable[i] >
@@ -76,14 +78,22 @@ bool IsValidDxilContainer(const DxilContainerHeader *pHeader, size_t length) {
     const DxilPartHeader *pPartHeader =
         reinterpret_cast<const DxilPartHeader *>(pLinearContainer +
                                                  pPartOffsetTable[i]);
+
+    // Each part should start at next location with no gaps.
+    if ((const void*)nextPartBegin != pPartHeader)
+      return false;
+
     if (pPartOffsetTable[i] + sizeof(DxilPartHeader) + pPartHeader->PartSize >
         pHeader->ContainerSizeInBytes) {
       return false;
     }
+
+    nextPartBegin += sizeof(DxilPartHeader) + pPartHeader->PartSize;
   }
 
-  // Note: the container parts may overlap and there may be holes
-  // based on this validation
+  // Container size should match end of last part
+  if (nextPartBegin - pLinearContainer != pHeader->ContainerSizeInBytes)
+    return false;
 
   return true;
 }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -561,7 +561,8 @@ public:
     const DxilContainerHeader *pHeader2 = IsDxilContainerLike(pProgram2->GetBufferPointer(), pProgram2->GetBufferSize());
     VERIFY_IS_NOT_NULL(pHeader2);
 
-    unique_ptr<DxilContainerWriter> pContainerWriter(NewDxilContainerWriter());
+    unique_ptr<DxilContainerWriter> pContainerWriter(NewDxilContainerWriter(
+        DXIL::CompareVersions(m_ver.m_ValMajor, m_ver.m_ValMinor, 1, 7) < 0));
 
     // Add desired parts from first container
     for (auto pPart : pHeader1) {


### PR DESCRIPTION
- Maintain compatibility for validator version < 1.7.
- DxilContainerWriter_impl verifies size alignment for all parts, unless created with bUnaligned=true, used for backward compatibility.
- DxilValidation uses NewProgramSignatureWriter(), so bUnaligned is based on validator version in module.

Fixes #4236