### PR TITLE
Refactor HLSLVersion to enum

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -18,6 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Option/ArgList.h"
 #include "dxc/dxcapi.h"
+#include "dxc/Support/HLSLVersion.h"
 #include "dxc/Support/SPIRVOptions.h"
 #include <map>
 #include <set>
@@ -163,7 +164,7 @@ public:
   bool EnableStrictMode = false;     // OPT_Ges
   bool EnableDX9CompatMode = false;     // OPT_Gec
   bool EnableFXCCompatMode = false;     // internal flag
-  unsigned long HLSLVersion = 0; // OPT_hlsl_version (2015-2018)
+  LangStd HLSLVersion = LangStd::vUnset; // OPT_hlsl_version (2015-2021)
   bool Enable16BitTypes = false; // OPT_enable_16bit_types
   bool OptDump = false; // OPT_ODump - dump optimizer commands
   bool OutputWarnings = true; // OPT_no_warnings

--- a/include/dxc/Support/HLSLVersion.h
+++ b/include/dxc/Support/HLSLVersion.h
@@ -1,0 +1,37 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// HLSLOptions.h                                                             //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Support for command-line-style option parsing.                            //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef LLVM_HLSL_HLSLVERSION_H
+#define LLVM_HLSL_HLSLVERSION_H
+
+namespace hlsl {
+
+ // This Updates to this enum must be reflected in HLSLOptions.td and Options.td
+ // for the hlsl_version option.
+enum class LangStd : unsigned long  {
+  vUnset = 0,
+  vError = 1,
+  v2015 = 2015,
+  v2016 = 2016,
+  v2017 = 2017,
+  v2018 = 2018,
+  v2021 = 2021,
+  v202x = 2029,
+  vLatest = v2018
+};
+
+constexpr const char *ValidVersionsStr = "2015, 2016, 2017, 2018, and 2021";
+
+LangStd parseHLSLVersion(llvm::StringRef Ver);
+
+} // namespace hlsl
+
+#endif // LLVM_HLSL_HLSLVERSION_H

--- a/include/dxc/Support/HLSLVersion.h
+++ b/include/dxc/Support/HLSLVersion.h
@@ -5,7 +5,7 @@
 // This file is distributed under the University of Illinois Open Source     //
 // License. See LICENSE.TXT for details.                                     //
 //                                                                           //
-// Support for command-line-style option parsing.                            //
+// HLSL version enumeration and parsing support                              //
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -20,6 +20,7 @@
 #include "clang/Basic/ObjCRuntime.h"
 #include "clang/Basic/Sanitizers.h"
 #include "clang/Basic/Visibility.h"
+#include "dxc/Support/HLSLVersion.h"
 #include <string>
 #include <vector>
 
@@ -149,7 +150,7 @@ public:
 #endif
 
   // HLSL Change Starts
-  unsigned HLSLVersion = 2018;
+  hlsl::LangStd HLSLVersion = hlsl::LangStd::vLatest;
   std::string HLSLEntryFunction;
   std::string HLSLProfile;
   unsigned RootSigMajor = 1;

--- a/tools/clang/include/clang/Driver/Options.td
+++ b/tools/clang/include/clang/Driver/Options.td
@@ -677,7 +677,7 @@ def fms_volatile : Joined<["-"], "fms-volatile">, Group<f_Group>, Flags<[CC1Opti
 def fmsc_version : Joined<["-"], "fmsc-version=">, Group<f_Group>, Flags<[DriverOption, CoreOption]>,
   HelpText<"Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))">;
 def hlsl_version : Separate<["-", "/"], "HV">, Group<f_Group>, Flags<[DriverOption, CoreOption, CC1Option]>,
-  HelpText<"HLSL version (2015, 2016, 2017, 2018, 2021)">; // HLSL Change - mimic the HLSLOptions.td flag
+  HelpText<"HLSL version (2015, 2016, 2017, 2018, 2021). Default is 2018">; // HLSL Change - mimic the HLSLOptions.td flag
 def enable_16bit_types: Flag<["-", "/"], "enable-16bit-types">, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Enable 16bit types and disable min precision types.">; // HLSL Change - mimic the HLSLOptions.td flag
 def enable_templates: Flag<["-", "/"], "enable-templates">, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -193,7 +193,7 @@ static HLSLScalarType FindScalarTypeByName(const char *typeName, const size_t ty
   }
   // fixed width types (int16_t, uint16_t, int32_t, uint32_t, float16_t, float32_t, float64_t)
   // are only supported in HLSL 2018
-  if (langOptions.HLSLVersion >= 2018) {
+  if (langOptions.HLSLVersion >= hlsl::LangStd::v2018) {
     switch (typeLen) {
     case 7: // int16_t, int32_t
       if (typeName[0] == 'i' && typeName[1] == 'n') {

--- a/tools/clang/lib/Basic/CMakeLists.txt
+++ b/tools/clang/lib/Basic/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   Core
 #  MC # HLSL Change
+  DxcSupport # HLSL Change
   Support
   )
 

--- a/tools/clang/lib/Basic/LangOptions.cpp
+++ b/tools/clang/lib/Basic/LangOptions.cpp
@@ -25,7 +25,7 @@ using namespace clang;
 #endif // LLVM_ON_UNIX
 
 LangOptions::LangOptions() 
-    : HLSLVersion(2018) {
+    : HLSLVersion(hlsl::LangStd::vLatest) {
 #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 #define LANGOPT(Name, Bits, Default, Description) Name = Default;
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Description) set##Name(Default);

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1007,7 +1007,8 @@ unsigned CGMSHLSLRuntime::ConstructStructAnnotation(DxilStructAnnotation *annota
     if (Field->isBitField()) {
       // TODO(?): Consider refactoring, as this branch duplicates much
       // of the logic of CGRecordLowering::accumulateBitFields().
-      DXASSERT(CGM.getLangOpts().HLSLVersion > 2015, "We should have already ensured we have no bitfields.");
+      DXASSERT(CGM.getLangOpts().HLSLVersion > hlsl::LangStd::v2015,
+               "We should have already ensured we have no bitfields.");
       CodeGenTypes &Types = CGM.getTypes();
       ASTContext &Context = Types.getContext();
       const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
@@ -3820,7 +3821,8 @@ RValue CGMSHLSLRuntime::EmitHLSLBuiltinCallExpr(CodeGenFunction &CGF,
           StringRef intrinsicGroup;
           hlsl::GetIntrinsicOp(FD, intrinsicOpcode, intrinsicGroup);
           IntrinsicOp opcode = static_cast<IntrinsicOp>(intrinsicOpcode);
-          if (Value *Result = TryEvalIntrinsic(CI, opcode, CGM.getLangOpts().HLSLVersion)) {
+          if (Value *Result =
+                  TryEvalIntrinsic(CI, opcode, CGM.getLangOpts().HLSLVersion)) {
             RV = RValue::get(Result);
           }
         }

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -1840,7 +1840,7 @@ void SimpleTransformForHLDXIRInst(Instruction *I, SmallInstSet &deadInsts) {
 namespace CGHLSLMSHelper {
 
 Value *TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp,
-                        unsigned hlslVersion) {
+                        hlsl::LangStd hlslVersion) {
   switch (intriOp) {
   case IntrinsicOp::IOP_tan: {
     return EvalUnaryIntrinsic(CI, tanf, tan);
@@ -1955,7 +1955,7 @@ Value *TryEvalIntrinsic(CallInst *CI, IntrinsicOp intriOp,
     // For back compat, DXC still preserves the above behavior for language
     // versions 2016 or below. However, for newer language versions, DXC now
     // always use nearest even for round() intrinsic in all cases.
-    if (hlslVersion <= 2016) {
+    if (hlslVersion <= hlsl::LangStd::v2016) {
       return EvalUnaryIntrinsic(CI, roundf, round);
     } else {
       auto roundingMode = fegetround();
@@ -3245,7 +3245,7 @@ void FinishEntries(
     // const global to allow writing to it.
     // TODO: Verfiy the behavior of static globals in hull shader
     if (CGM.getLangOpts().EnableDX9CompatMode &&
-        CGM.getLangOpts().HLSLVersion <= 2016)
+        CGM.getLangOpts().HLSLVersion <= hlsl::LangStd::v2016)
       CreateWriteEnabledStaticGlobals(HLM.GetModule(), HLM.GetEntryFunction());
     if (HLM.GetShaderModel()->IsHS()) {
       SetPatchConstantFunction(Entry, HSEntryPatchConstantFuncAttr,

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -228,7 +228,8 @@ void StructurizeMultiRet(llvm::Module &M,
                          bool bWaveEnabledStage,
                          llvm::SmallVector<llvm::BranchInst *, 16> &DxBreaks);
 
-llvm::Value *TryEvalIntrinsic(llvm::CallInst *CI, hlsl::IntrinsicOp intriOp, unsigned hlslVersion);
+llvm::Value *TryEvalIntrinsic(llvm::CallInst *CI, hlsl::IntrinsicOp intriOp,
+                              hlsl::LangStd hlslVersion);
 void SimpleTransformForHLDXIR(llvm::Module *pM);
 void ExtensionCodeGen(hlsl::HLModule &HLM, clang::CodeGen::CodeGenModule &CGM);
 } // namespace CGHLSLMSHelper

--- a/tools/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/tools/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1723,25 +1723,14 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   Opts.SanitizerBlacklistFiles = Args.getAllArgValues(OPT_fsanitize_blacklist);
 #else
   llvm::StringRef ver = Args.getLastArgValue(OPT_hlsl_version);
-  if (ver.empty()) { Opts.HLSLVersion = 2018; }   // Default to latest
+  if (ver.empty()) {
+    Opts.HLSLVersion = hlsl::LangStd::vLatest;
+  } // Default to latest
   else {
-    try {
-      Opts.HLSLVersion = std::stoi(std::string(ver));
-      if (Opts.HLSLVersion < 2015 || Opts.HLSLVersion > 2021) {
-       Diags.Report(diag::err_drv_invalid_value)
-        << Args.getLastArg(OPT_hlsl_version)->getAsString(Args)
-        << ver;
-      }
-    }
-    catch (const std::invalid_argument &) {
+    Opts.HLSLVersion = hlsl::parseHLSLVersion(ver);
+    if (Opts.HLSLVersion == hlsl::LangStd::vError) {
       Diags.Report(diag::err_drv_invalid_value)
-        << Args.getLastArg(OPT_hlsl_version)->getAsString(Args)
-        << ver;
-    }
-    catch (const std::out_of_range &) {
-      Diags.Report(diag::err_drv_invalid_value)
-        << Args.getLastArg(OPT_hlsl_version)->getAsString(Args)
-        << ver;
+          << Args.getLastArg(OPT_hlsl_version)->getAsString(Args) << ver;
     }
   }
   // Enable low precision for HLSL 2018
@@ -1752,7 +1741,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
   // If the HLSL version is 2016 or 2018, allow them only
   // when the individual option is enabled.
   // If the HLSL version is 2015, dissallow these features
-  if (Opts.HLSLVersion >= 2021) {
+  if (Opts.HLSLVersion >= hlsl::LangStd::v2021) {
     // Enable operator overloading in structs
     Opts.EnableOperatorOverloading = true;
     // Enable template support
@@ -1770,7 +1759,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     Opts.StrictUDTCasting = Args.hasArg(OPT_strict_udt_casting);
     Opts.EnableBitfields = Args.hasArg(OPT_enable_bitfields);
 
-    if (Opts.HLSLVersion <= 2015) {
+    if (Opts.HLSLVersion <= hlsl::LangStd::v2015) {
       if (Opts.EnableOperatorOverloading)
         Diags.Report(diag::err_hlsl_invalid_drv_for_feature) << "/enable-operator-overloading" << ver;
       if (Opts.EnableTemplates)

--- a/tools/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/tools/clang/lib/Frontend/InitPreprocessor.cpp
@@ -374,7 +374,8 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     Builder.defineMacro("__DXC_VERSION_RELEASE", STRINGIFY(RC_VERSION_FIELD_3));
     Builder.defineMacro("__DXC_VERSION_COMMITS", STRINGIFY(RC_VERSION_FIELD_4));
     // HLSL Version
-    Builder.defineMacro("__HLSL_VERSION", Twine(LangOpts.HLSLVersion));
+    Builder.defineMacro("__HLSL_VERSION",
+                        Twine((unsigned int)LangOpts.HLSLVersion));
     // Shader target information
     // "enums" for shader stages
     Builder.defineMacro("__SHADER_STAGE_VERTEX",  Twine((unsigned)hlsl::DXIL::ShaderKind::Vertex));

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -2282,7 +2282,11 @@ Parser::DeclGroupPtrTy Parser::ParseDeclGroup(ParsingDeclSpec &DS,
   // global variable can be inside a global structure as a static member.
   // Check if the global is a static member and skip global const pass.
   // in backcompat mode, the check for global const is deferred to later stage in CGMSHLSLRuntime::FinishCodeGen()
-  bool CheckGlobalConst = getLangOpts().HLSL && getLangOpts().EnableDX9CompatMode && getLangOpts().HLSLVersion <= 2016 ? false : true;
+  bool CheckGlobalConst =
+      getLangOpts().HLSL && getLangOpts().EnableDX9CompatMode &&
+              getLangOpts().HLSLVersion <= hlsl::LangStd::v2016
+          ? false
+          : true;
   if (NestedNameSpecifier *nameSpecifier = D.getCXXScopeSpec().getScopeRep()) {
     if (nameSpecifier->getKind() == NestedNameSpecifier::SpecifierKind::TypeSpec) {
       const Type *type = D.getCXXScopeSpec().getScopeRep()->getAsType();
@@ -4555,7 +4559,7 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
                                 const ParsedTemplateInfo &TemplateInfo,
                                 AccessSpecifier AS, DeclSpecContext DSC) {
   // HLSL Change Starts
-  if (getLangOpts().HLSL && getLangOpts().HLSLVersion < 2017) {
+  if (getLangOpts().HLSL && getLangOpts().HLSLVersion < hlsl::LangStd::v2017) {
     Diag(Tok, diag::err_hlsl_enum);
     // Skip the rest of this declarator, up until the comma or semicolon.
     SkipUntil(tok::comma, StopAtSemi);
@@ -4615,7 +4619,7 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
 
   bool AllowFixedUnderlyingType = AllowDeclaration &&
     (getLangOpts().CPlusPlus11 || getLangOpts().MicrosoftExt ||
-     getLangOpts().ObjC2 || getLangOpts().HLSLVersion >= 2017);
+     getLangOpts().ObjC2 || getLangOpts().HLSLVersion >= hlsl::LangStd::v2017);
 
   CXXScopeSpec &SS = DS.getTypeSpecScope();
   if (getLangOpts().CPlusPlus) {
@@ -4917,7 +4921,8 @@ void Parser::ParseEnumSpecifier(SourceLocation StartLoc, DeclSpec &DS,
 ///         identifier
 ///
 void Parser::ParseEnumBody(SourceLocation StartLoc, Decl *EnumDecl) {
-  assert(getLangOpts().HLSLVersion >= 2017 && "HLSL does not support enums before 2017"); // HLSL Change
+  assert(getLangOpts().HLSLVersion >= hlsl::LangStd::v2017 &&
+         "HLSL does not support enums before 2017"); // HLSL Change
 
   // Enter the scope of the enum body and start the definition.
   ParseScope EnumScope(this, Scope::DeclScope | Scope::EnumScope);

--- a/tools/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/tools/clang/lib/Parse/ParseDeclCXX.cpp
@@ -2891,20 +2891,21 @@ void Parser::ParseCXXMemberSpecification(SourceLocation RecordLoc,
         NonNestedClass = false;
 
         // HLSL Change Starts
-        if (getLangOpts().HLSL && getLangOpts().HLSLVersion < 2016 &&
+        if (getLangOpts().HLSL &&
+            getLangOpts().HLSLVersion < hlsl::LangStd::v2016 &&
             cast<NamedDecl>(TagDecl)->getDeclName()) {
           Diag(RecordLoc, diag::err_hlsl_unsupported_nested_struct);
           break;
         } else {
-        // HLSL Change Ends - succeeding block is now conditional
-        // The Microsoft extension __interface does not permit nested classes.
-        if (getCurrentClass().IsInterface) {
-          Diag(RecordLoc, diag::err_invalid_member_in_interface)
-            << /*ErrorType=*/6
-            << (isa<NamedDecl>(TagDecl)
-                  ? cast<NamedDecl>(TagDecl)->getQualifiedNameAsString()
-                  : "(anonymous)");
-        }
+          // HLSL Change Ends - succeeding block is now conditional
+          // The Microsoft extension __interface does not permit nested classes.
+          if (getCurrentClass().IsInterface) {
+            Diag(RecordLoc, diag::err_invalid_member_in_interface)
+                << /*ErrorType=*/6
+                << (isa<NamedDecl>(TagDecl)
+                        ? cast<NamedDecl>(TagDecl)->getQualifiedNameAsString()
+                        : "(anonymous)");
+          }
         } // HLSL Change - close conditional
         break;
       }

--- a/tools/clang/lib/Parse/ParseStmt.cpp
+++ b/tools/clang/lib/Parse/ParseStmt.cpp
@@ -1582,7 +1582,7 @@ StmtResult Parser::ParseForStatement(SourceLocation *TrailingElseLoc) {
     ScopeFlags = Scope::DeclScope | Scope::ControlScope;
 
   // HLSL Change Starts - leak declarations in for control parts into outer scope
-  if (getLangOpts().HLSLVersion < 2021) {
+  if (getLangOpts().HLSLVersion < hlsl::LangStd::v2021) {
     ScopeFlags = Scope::ForDeclScope;
   }
   // HLSL Change Ends

--- a/tools/clang/lib/Sema/SemaCXXScopeSpec.cpp
+++ b/tools/clang/lib/Sema/SemaCXXScopeSpec.cpp
@@ -618,7 +618,7 @@ bool Sema::BuildCXXNestedNameSpecifier(Scope *S,
   if (!AcceptSpec && IsExtension) {
     AcceptSpec = true;
     // HLSL Change: Suppress c++11 extension warnings for nested name specifier in HLSL2017
-    if (getLangOpts().HLSLVersion < 2017)
+    if (getLangOpts().HLSLVersion < hlsl::LangStd::v2017)
         Diag(IdentifierLoc, diag::ext_nested_name_spec_is_enum);
   }
   if (AcceptSpec) {

--- a/tools/clang/lib/Sema/SemaChecking.cpp
+++ b/tools/clang/lib/Sema/SemaChecking.cpp
@@ -8469,7 +8469,7 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     }
 
     // HLSL Change Starts
-    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > 2016) {
+    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > hlsl::LangStd::v2016) {
       DiagRuntimeBehavior(BaseExpr->getLocStart(), BaseExpr,
         PDiag(diag::err_hlsl_array_element_index_out_of_bounds) << index.toString(10, true));
     }
@@ -8488,7 +8488,7 @@ void Sema::CheckArrayAccess(const Expr *BaseExpr, const Expr *IndexExpr,
     } // HLSL Change
   } else {
     // HLSL Change Starts
-    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > 2016) {
+    if (getLangOpts().HLSL && getLangOpts().HLSLVersion > hlsl::LangStd::v2016) {
       DiagRuntimeBehavior(BaseExpr->getLocStart(), BaseExpr,
         PDiag(diag::err_hlsl_array_element_index_out_of_bounds) << index.toString(10, true));
     }

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -11703,7 +11703,7 @@ Decl *Sema::ActOnTag(Scope *S, unsigned TagSpec, TagUseKind TUK,
   }
 
   // HLSL Change Starts
-  if (getLangOpts().HLSLVersion == 2015 && TUK == TUK_Declaration) {
+  if (getLangOpts().HLSLVersion == hlsl::LangStd::v2015 && TUK == TUK_Declaration) {
     Diag(NameLoc, diag::err_hlsl_unsupported_construct)
         << "struct declaration without definition";
   }
@@ -13658,7 +13658,8 @@ EnumConstantDecl *Sema::CheckEnumConstant(EnumDecl *Enum,
     else {
       SourceLocation ExpLoc;
       // HLSL Change - check constant expression for enum
-      if ((getLangOpts().HLSLVersion >= 2017 || getLangOpts().CPlusPlus11) &&
+      if ((getLangOpts().HLSLVersion >= hlsl::LangStd::v2017 ||
+           getLangOpts().CPlusPlus11) &&
           Enum->isFixed() && !getLangOpts().MSVCCompat) {
         // C++11 [dcl.enum]p5: If the underlying type is fixed, [...] the
         // constant-expression in the enumerator-definition shall be a converted
@@ -13672,8 +13673,8 @@ EnumConstantDecl *Sema::CheckEnumConstant(EnumDecl *Enum,
         else
           Val = Converted.get();
       } else if (!Val->isValueDependent() &&
-                 !(Val = VerifyIntegerConstantExpression(Val,
-                                                         &EnumVal).get())) {
+                 !(Val =
+                       VerifyIntegerConstantExpression(Val, &EnumVal).get())) {
         // C99 6.7.2.2p2: Make sure we have an integer constant expression.
       } else {
         if (Enum->isFixed()) {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -3870,7 +3870,7 @@ public:
   }
 
   bool DiagnoseHLSLScalarType(HLSLScalarType type, SourceLocation Loc) {
-    if (getSema()->getLangOpts().HLSLVersion < 2018) {
+    if (getSema()->getLangOpts().HLSLVersion < hlsl::LangStd::v2018) {
       switch (type) {
       case HLSLScalarType_float16:
       case HLSLScalarType_float32:
@@ -8036,12 +8036,12 @@ ExprResult HLSLExternalSource::LookupArrayMemberExprForHLSL(
   if (member->getLength() == 6 && 0 == strcmp(memberText, "Length")) {
     if (const ConstantArrayType *CAT = dyn_cast<ConstantArrayType>(BaseType)) {
       // check version support
-      unsigned hlslVer = getSema()->getLangOpts().HLSLVersion;
-      if (hlslVer > 2016) {
+      hlsl::LangStd hlslVer = getSema()->getLangOpts().HLSLVersion;
+      if (hlslVer > hlsl::LangStd::v2016) {
         m_sema->Diag(MemberLoc, diag::err_hlsl_unsupported_for_version_lower) << "Length" << "2016";
         return ExprError();
       }
-      if (hlslVer == 2016) {
+      if (hlslVer == hlsl::LangStd::v2016) {
         m_sema->Diag(MemberLoc, diag::warn_deprecated) << "Length";
       }
 
@@ -9782,7 +9782,7 @@ Sema::TemplateDeductionResult HLSLExternalSource::DeduceTemplateArgumentsForHLSL
     // Check Explicit template arguments
     UINT intrinsicOp = (*cursor)->Op;
     LPCSTR intrinsicName = (*cursor)->pArgs[0].pName;
-    bool Is2018 = getSema()->getLangOpts().HLSLVersion >= 2018;
+    bool Is2018 = getSema()->getLangOpts().HLSLVersion >= hlsl::LangStd::v2018;
     bool IsBAB =
         objectName == g_ArBasicTypeNames[AR_OBJECT_BYTEADDRESS_BUFFER] ||
         objectName == g_ArBasicTypeNames[AR_OBJECT_RWBYTEADDRESS_BUFFER];

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -5137,7 +5137,8 @@ static ExprResult CheckConvertedConstantExpression(Sema &S, Expr *From,
                                                    QualType T, APValue &Value,
                                                    Sema::CCEKind CCE,
                                                    bool RequireInt) {
-  assert((S.getLangOpts().CPlusPlus11 || S.getLangOpts().HLSLVersion >= 2017) &&
+  assert((S.getLangOpts().CPlusPlus11 ||
+          S.getLangOpts().HLSLVersion >= hlsl::LangStd::v2017) &&
          "converted constant expression outside C++11");
 
   if (checkPlaceholderForOverload(S, From))

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -392,7 +392,8 @@ Sema::ActOnCaseStmt(SourceLocation CaseLoc, Expr *LHSVal,
     return StmtError();
   LHSVal = LHS.get();
 
-  if (!getLangOpts().CPlusPlus11 && getLangOpts().HLSLVersion < 2017) {
+  if (!getLangOpts().CPlusPlus11 &&
+      getLangOpts().HLSLVersion < hlsl::LangStd::v2017) {
     // C99 6.8.4.2p3: The expression shall be an integer constant.
     // However, GCC allows any evaluatable integer expression.
     if (!LHSVal->isTypeDependent() && !LHSVal->isValueDependent()) {
@@ -860,7 +861,8 @@ Sema::ActOnFinishSwitchStmt(SourceLocation SwitchLoc, Stmt *Switch,
 
       llvm::APSInt LoVal;
 
-      if (getLangOpts().CPlusPlus11 || getLangOpts().HLSLVersion >= 2017) {
+      if (getLangOpts().CPlusPlus11 ||
+          getLangOpts().HLSLVersion >= hlsl::LangStd::v2017) {
         // C++11 [stmt.switch]p2: the constant-expression shall be a converted
         // constant expression of the promoted type of the switch condition.
         ExprResult ConvLo =

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1400,7 +1400,7 @@ public:
     }
     compiler.getLangOpts().RootSigMajor = 1;
     compiler.getLangOpts().RootSigMinor = rootSigMinor;
-    compiler.getLangOpts().HLSLVersion = (unsigned) Opts.HLSLVersion;
+    compiler.getLangOpts().HLSLVersion = Opts.HLSLVersion;
     compiler.getLangOpts().EnableDX9CompatMode = Opts.EnableDX9CompatMode;
     compiler.getLangOpts().EnableFXCCompatMode = Opts.EnableFXCCompatMode;
     compiler.getLangOpts().EnableTemplates = Opts.EnableTemplates;

--- a/tools/clang/tools/dxcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxcompiler/dxcutil.cpp
@@ -134,7 +134,7 @@ void ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
     finished = true;
     return;
   }
-  DXASSERT(opts.HLSLVersion > 2015,
+  DXASSERT(opts.HLSLVersion > hlsl::LangStd::v2015,
            "else ReadDxcOpts didn't fail for non-isense");
   finished = false;
 }

--- a/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
+++ b/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
@@ -94,7 +94,8 @@ static void ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
     finished = true;
     return;
   }
-  DXASSERT(opts.HLSLVersion > 2015, "else ReadDxcOpts didn't fail for non-isense");
+  DXASSERT(opts.HLSLVersion > hlsl::LangStd::v2015,
+           "else ReadDxcOpts didn't fail for non-isense");
   finished = false;
 }
 

--- a/tools/clang/tools/dxrfallbackcompiler/dxcutil.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcutil.cpp
@@ -135,7 +135,7 @@ void ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
     finished = true;
     return;
   }
-  DXASSERT(opts.HLSLVersion > 2015,
+  DXASSERT(opts.HLSLVersion > hlsl::LangStd::v2015,
            "else ReadDxcOpts didn't fail for non-isense");
   finished = false;
 }

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -541,7 +541,7 @@ void SetupCompilerCommon(CompilerInstance &compiler,
   if (opts.WarningAsError)
     compiler.getDiagnostics().setWarningsAsErrors(true);
   compiler.getDiagnostics().setIgnoreAllWarnings(!opts.OutputWarnings);
-  compiler.getLangOpts().HLSLVersion = (unsigned)opts.HLSLVersion;
+  compiler.getLangOpts().HLSLVersion = opts.HLSLVersion;
   compiler.getLangOpts().StrictUDTCasting = opts.StrictUDTCasting;
   compiler.getLangOpts().UseMinPrecision = !opts.Enable16BitTypes;
   compiler.getLangOpts().EnableDX9CompatMode = opts.EnableDX9CompatMode;
@@ -979,7 +979,7 @@ DoRewriteUnused(_In_ DxcLangExtensionsHelper *pHelper, _In_ LPCSTR pFileName,
 
   ASTHelper astHelper;
   hlsl::options::DxcOpts opts;
-  opts.HLSLVersion = 2015;
+  opts.HLSLVersion = hlsl::LangStd::v2015;
 
   GenerateAST(pHelper, pFileName, pRemap, pDefines, defineCount, astHelper,
               opts, msfPtr, w);
@@ -1645,7 +1645,7 @@ public:
       std::unique_ptr<ASTUnit::RemappedFile> pRemap(new ASTUnit::RemappedFile(fakeName, pBuffer.release()));
 
       hlsl::options::DxcOpts opts;
-      opts.HLSLVersion = 2015;
+      opts.HLSLVersion = hlsl::LangStd::v2015;
 
       std::string errors;
       std::string rewrite;
@@ -1695,7 +1695,7 @@ public:
       std::unique_ptr<ASTUnit::RemappedFile> pRemap(new ASTUnit::RemappedFile(fName, pBuffer.release()));
 
       hlsl::options::DxcOpts opts;
-      opts.HLSLVersion = 2015;
+      opts.HLSLVersion = hlsl::LangStd::v2015;
 
       opts.RWOpt.SkipFunctionBody |=
           rewriteOption & RewriterOptionMask::SkipFunctionBody;

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -451,6 +451,12 @@ for %%v in (2016 2017 2018 2021) do (
   if %Failed% neq 0 goto :failed
 )
 
+set testname=Test v202x macro
+call :run dxc.exe -HV 202x -P v202x.hlsl.pp %testfiles%\VersionMacro.hlsl
+if %Failed% neq 0 goto :failed
+call :check_file v202x.hlsl.pp find 2029 del
+if %Failed% neq 0 goto :failed
+
 set testname=Test shader profile macro
 for %%p in (vs ps gs hs ds cs lib) do (
   for %%v in (5 6) do (


### PR DESCRIPTION
This change converts HLSLVersion to an enum type `hlsl::LangStd`. Most
of the change is a mechanical appending `hlsl::LangStd::v` to the
integers we previously compared for version checks.

Additionally this change does the following:
* Adds a parseHLSLVersion function to unify parsing code
* Parsing code is converted to an llvm::StringSwitch over the possible
values instead of converting to integer
* Added enum value for `vLatest` so that changing the latest version is
done in one place
* Added enum value for `v202x` which parses from 202x to allow new
language features a place to land