### PR TITLE
[linux] Fix incorrect REGDB_E_CLASSNOTREG value

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -88,13 +88,12 @@
 #define FALSE 0
 #define TRUE 1
 
-#define REGDB_E_CLASSNOTREG 1
-
 // We ignore the code page completely on Linux.
 #define GetConsoleOutputCP() 0
 
 #define _HRESULT_TYPEDEF_(_sc) ((HRESULT)_sc)
 #define DISP_E_BADINDEX _HRESULT_TYPEDEF_(0x8002000BL)
+#define REGDB_E_CLASSNOTREG _HRESULT_TYPEDEF_(0x80040154L)
 
 // This is an unsafe conversion. If needed, we can later implement a safe
 // conversion that throws exceptions for overflow cases.


### PR DESCRIPTION
REGDB_E_CLASSNOTREG was defined to 1, which is a success code for HRESULT.
This value is returned when trying to create an unsupported object with DxcCreateInstance.
Since create appears to have succeeded, it would lead to a deref of a null pointer - segfault.