### PR TITLE
Rename UTF16 to Wide

### DIFF
--- a/include/dxc/Support/DxcLangExtensionsCommonHelper.h
+++ b/include/dxc/Support/DxcLangExtensionsCommonHelper.h
@@ -39,7 +39,7 @@ private:
     try {
       IFTPTR(name);
       std::string s;
-      if (!Unicode::UTF16ToUTF8String(name, &s)) {
+      if (!Unicode::WideToUTF8String(name, &s)) {
         throw ::hlsl::Exception(E_INVALIDARG);
       }
       here.push_back(s);
@@ -53,7 +53,7 @@ private:
     try {
       IFTPTR(name);
       std::string s;
-      if (!Unicode::UTF16ToUTF8String(name, &s)) {
+      if (!Unicode::WideToUTF8String(name, &s)) {
         throw ::hlsl::Exception(E_INVALIDARG);
       }
       here.insert(s);

--- a/include/dxc/Support/FileIOHelper.h
+++ b/include/dxc/Support/FileIOHelper.h
@@ -21,7 +21,7 @@
 struct IDxcBlob;
 struct IDxcBlobEncoding;
 struct IDxcBlobUtf8;
-struct IDxcBlobUtf16;
+struct IDxcBlobWide;
 
 namespace hlsl {
 
@@ -137,10 +137,10 @@ UINT32 DxcCodePageFromBytes(_In_count_(byteLen) const char *bytes,
 // Null pMalloc means use current thread malloc.
 // bPinned will point to existing memory without managing it;
 // bCopy will copy to heap; bPinned and bCopy are mutually exclusive.
-// If encodingKnown, UTF-8 or UTF-16, and null-termination possible,
-// an IDxcBlobUtf8 or IDxcBlobUtf16 will be constructed.
+// If encodingKnown, UTF-8 or wide, and null-termination possible,
+// an IDxcBlobUtf8 or IDxcBlobWide will be constructed.
 // If text, it's best if size includes null terminator when not copying,
-// otherwise IDxcBlobUtf8 or IDxcBlobUtf16 will not be constructed.
+// otherwise IDxcBlobUtf8 or IDxcBlobWide will not be constructed.
 HRESULT DxcCreateBlob(
     LPCVOID pPtr, SIZE_T size, bool bPinned, bool bCopy,
     bool encodingKnown, UINT32 codePage,
@@ -221,8 +221,8 @@ HRESULT DxcGetBlobAsUtf8(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
                          _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding,
                          UINT32 defaultCodePage = CP_ACP) throw();
 HRESULT
-DxcGetBlobAsUtf16(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
-                  _COM_Outptr_ IDxcBlobUtf16 **pBlobEncoding) throw();
+DxcGetBlobAsWide(_In_ IDxcBlob *pBlob, _In_ IMalloc *pMalloc,
+                  _COM_Outptr_ IDxcBlobWide **pBlobEncoding) throw();
 
 bool IsBlobNullOrEmpty(_In_opt_ IDxcBlob *pBlob) throw();
 

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -268,12 +268,12 @@ public:
 };
 
 /// Use this class to convert a StringRef into a wstring, handling empty values as nulls.
-class StringRefUtf16 {
+class StringRefWide {
 private:
   std::wstring m_value;
 
 public:
-  StringRefUtf16(llvm::StringRef value);
+  StringRefWide(llvm::StringRef value);
   operator LPCWSTR() const { return m_value.size() ? m_value.data() : nullptr; }
 };
 

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -279,7 +279,7 @@ def default_linkage : Separate<["-", "/"], "default-linkage">, Group<hlslcomp_Gr
 def precise_output : Separate<["-", "/"], "precise-output">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
     HelpText<"Mark output semantic as precise">;
 def encoding : Separate<["-", "/"], "encoding">, Group<hlslcomp_Group>, Flags<[CoreOption, RewriteOption, DriverOption]>,
-  HelpText<"Set default encoding for source inputs and text outputs (utf8|utf16) default=utf8">;
+  HelpText<"Set default encoding for source inputs and text outputs (utf8|utf16(win)|utf32(*nix)|wide) default=utf8">;
 def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/include/dxc/Support/Unicode.h
+++ b/include/dxc/Support/Unicode.h
@@ -52,45 +52,45 @@ _Success_(return != false)
 bool UTF8ToConsoleString(_In_z_ const char* text, _Inout_ std::string* pValue, _Out_opt_ bool* lossy);
 
 _Success_(return != false)
-bool UTF16ToConsoleString(_In_opt_count_(textLen) const wchar_t* text, _In_ size_t textLen, _Inout_ std::string* pValue, _Out_opt_ bool* lossy);
+bool WideToConsoleString(_In_opt_count_(textLen) const wchar_t* text, _In_ size_t textLen, _Inout_ std::string* pValue, _Out_opt_ bool* lossy);
 
 _Success_(return != false)
-bool UTF16ToConsoleString(_In_z_ const wchar_t* text, _Inout_ std::string* pValue, _Out_opt_ bool* lossy);
+bool WideToConsoleString(_In_z_ const wchar_t* text, _Inout_ std::string* pValue, _Out_opt_ bool* lossy);
 
 _Success_(return != false)
-bool UTF8ToUTF16String(_In_opt_z_ const char *pUTF8, _Inout_ std::wstring *pUTF16);
+bool UTF8ToWideString(_In_opt_z_ const char *pUTF8, _Inout_ std::wstring *pWide);
 
 _Success_(return != false)
-bool UTF8ToUTF16String(_In_opt_count_(cbUTF8) const char *pUTF8, size_t cbUTF8, _Inout_ std::wstring *pUTF16);
+bool UTF8ToWideString(_In_opt_count_(cbUTF8) const char *pUTF8, size_t cbUTF8, _Inout_ std::wstring *pWide);
 
-std::wstring UTF8ToUTF16StringOrThrow(_In_z_ const char *pUTF8);
+std::wstring UTF8ToWideStringOrThrow(_In_z_ const char *pUTF8);
 
 _Success_(return != false)
-bool UTF16ToUTF8String(_In_z_ const wchar_t *pUTF16, size_t cUTF16, _Inout_ std::string *pUTF8);
-bool UTF16ToUTF8String(_In_z_ const wchar_t *pUTF16, _Inout_ std::string *pUTF8);
+bool WideToUTF8String(_In_z_ const wchar_t *pWide, size_t cWide, _Inout_ std::string *pUTF8);
+bool WideToUTF8String(_In_z_ const wchar_t *pWide, _Inout_ std::string *pUTF8);
 
-std::string UTF16ToUTF8StringOrThrow(_In_z_ const wchar_t *pUTF16);
+std::string WideToUTF8StringOrThrow(_In_z_ const wchar_t *pWide);
 
 bool IsStarMatchUTF8(_In_reads_opt_(maskLen) const char *pMask, size_t maskLen,
                      _In_reads_opt_(nameLen) const char *pName, size_t nameLen);
-bool IsStarMatchUTF16(_In_reads_opt_(maskLen) const wchar_t *pMask, size_t maskLen,
+bool IsStarMatchWide(_In_reads_opt_(maskLen) const wchar_t *pMask, size_t maskLen,
                       _In_reads_opt_(nameLen) const wchar_t *pName, size_t nameLen);
 
 _Success_(return != false)
-bool UTF8BufferToUTF16ComHeap(_In_z_ const char *pUTF8,
-                              _Outptr_result_z_ wchar_t **ppUTF16) throw();
+bool UTF8BufferToWideComHeap(_In_z_ const char *pUTF8,
+                              _Outptr_result_z_ wchar_t **ppWide) throw();
 
 _Success_(return != false)
-bool UTF8BufferToUTF16Buffer(
+bool UTF8BufferToWideBuffer(
   _In_NLS_string_(cbUTF8) const char *pUTF8,
   int cbUTF8, 
-  _Outptr_result_buffer_(*pcchUTF16) wchar_t **ppUTF16,
-  size_t *pcchUTF16) throw();
+  _Outptr_result_buffer_(*pcchWide) wchar_t **ppWide,
+  size_t *pcchWide) throw();
 
 _Success_(return != false)
-bool UTF16BufferToUTF8Buffer(
-  _In_NLS_string_(cchUTF16) const wchar_t *pUTF16,
-  int cchUTF16,
+bool WideBufferToUTF8Buffer(
+  _In_NLS_string_(cchWide) const wchar_t *pWide,
+  int cchWide,
   _Outptr_result_buffer_(*pcbUTF8) char **ppUTF8,
   size_t *pcbUTF8) throw();
 

--- a/include/dxc/Support/dxcapi.impl.h
+++ b/include/dxc/Support/dxcapi.impl.h
@@ -38,19 +38,19 @@ HRESULT TranslateUtf8StringForOutput(
     _In_opt_count_(size) LPCSTR pStr, SIZE_T size, UINT32 codePage, IDxcBlobEncoding **ppBlobEncoding) {
   CComPtr<IDxcBlobEncoding> pBlobEncoding;
   IFR(hlsl::DxcCreateBlobWithEncodingOnHeapCopy(pStr, size, DXC_CP_UTF8, &pBlobEncoding));
-  if (codePage == DXC_CP_UTF16) {
-    CComPtr<IDxcBlobUtf16> pBlobUtf16;
-    IFT(hlsl::DxcGetBlobAsUtf16(pBlobEncoding, nullptr, &pBlobUtf16))
-      pBlobEncoding = pBlobUtf16;
+  if (codePage == DXC_CP_WIDE) {
+    CComPtr<IDxcBlobWide> pBlobWide;
+    IFT(hlsl::DxcGetBlobAsWide(pBlobEncoding, nullptr, &pBlobWide))
+      pBlobEncoding = pBlobWide;
   }
   *ppBlobEncoding = pBlobEncoding.Detach();
   return S_OK;
 }
 
-HRESULT TranslateUtf16StringForOutput(
+HRESULT TranslateWideStringForOutput(
     _In_opt_count_(size) LPCWSTR pStr, SIZE_T size, UINT32 codePage, IDxcBlobEncoding **ppBlobEncoding) {
   CComPtr<IDxcBlobEncoding> pBlobEncoding;
-  IFR(hlsl::DxcCreateBlobWithEncodingOnHeapCopy(pStr, size, DXC_CP_UTF16, &pBlobEncoding));
+  IFR(hlsl::DxcCreateBlobWithEncodingOnHeapCopy(pStr, size, DXC_CP_WIDE, &pBlobEncoding));
   if (codePage == DXC_CP_UTF8) {
     CComPtr<IDxcBlobUtf8> pBlobUtf8;
     IFT(hlsl::DxcGetBlobAsUtf8(pBlobEncoding, nullptr, &pBlobUtf8))
@@ -69,8 +69,8 @@ HRESULT TranslateStringBlobForOutput(IDxcBlob *pBlob, UINT32 codePage, IDxcBlobE
   IFRBOOL(known, E_INVALIDARG);
   if (inputCP == DXC_CP_UTF8) {
     return TranslateUtf8StringForOutput((LPCSTR)pBlob->GetBufferPointer(), pBlob->GetBufferSize(), codePage, ppBlobEncoding);
-  } else if (inputCP == DXC_CP_UTF16) {
-    return TranslateUtf16StringForOutput((LPCWSTR)pBlob->GetBufferPointer(), pBlob->GetBufferSize(), codePage, ppBlobEncoding);
+  } else if (inputCP == DXC_CP_WIDE) {
+    return TranslateWideStringForOutput((LPCWSTR)pBlob->GetBufferPointer(), pBlob->GetBufferSize(), codePage, ppBlobEncoding);
   }
   return E_INVALIDARG;
 }
@@ -108,7 +108,7 @@ static const LPCWSTR DxcOutNoName = nullptr;
 
 struct DxcOutputObject {
   CComPtr<IUnknown> object;
-  CComPtr<IDxcBlobUtf16> name;
+  CComPtr<IDxcBlobWide> name;
   DXC_OUT_KIND kind = DXC_OUT_NONE;
 
   /////////////////////////
@@ -150,7 +150,7 @@ struct DxcOutputObject {
     if (size == kAutoSize)
       size = wcslen(pText);
     CComPtr<IDxcBlobEncoding> pBlobEncoding;
-    IFR(TranslateUtf16StringForOutput(pText, size, codePage, &pBlobEncoding));
+    IFR(TranslateWideStringForOutput(pText, size, codePage, &pBlobEncoding));
     object = pBlobEncoding;
     return S_OK;
   }
@@ -165,7 +165,7 @@ struct DxcOutputObject {
     object = pBlobEncoding;
     return S_OK;
   }
-  HRESULT SetName(_In_opt_z_ IDxcBlobUtf16 *pName) {
+  HRESULT SetName(_In_opt_z_ IDxcBlobWide *pName) {
     DXASSERT_NOMSG(!name);
     name = pName;
     return S_OK;
@@ -176,7 +176,7 @@ struct DxcOutputObject {
       return S_OK;
     CComPtr<IDxcBlobEncoding> pBlobEncoding;
     IFR(hlsl::DxcCreateBlobWithEncodingOnHeapCopy(
-          pName, (wcslen(pName) + 1) * sizeof(wchar_t), DXC_CP_UTF16, &pBlobEncoding));
+          pName, (wcslen(pName) + 1) * sizeof(wchar_t), DXC_CP_WIDE, &pBlobEncoding));
     return pBlobEncoding->QueryInterface(&name);
   }
   HRESULT SetName(_In_opt_z_ LPCSTR pName) {
@@ -184,7 +184,7 @@ struct DxcOutputObject {
     if (!pName)
       return S_OK;
     CComPtr<IDxcBlobEncoding> pBlobEncoding;
-    IFR(TranslateUtf8StringForOutput(pName, strlen(pName) + 1, DXC_CP_UTF16, &pBlobEncoding));
+    IFR(TranslateUtf8StringForOutput(pName, strlen(pName) + 1, DXC_CP_WIDE, &pBlobEncoding));
     return pBlobEncoding->QueryInterface(&name);
   }
   HRESULT SetName(_In_opt_z_ llvm::StringRef Name) {
@@ -192,7 +192,7 @@ struct DxcOutputObject {
     if (Name.empty())
       return S_OK;
     CComPtr<IDxcBlobEncoding> pBlobEncoding;
-    IFR(TranslateUtf8StringForOutput(Name.data(), Name.size(), DXC_CP_UTF16, &pBlobEncoding));
+    IFR(TranslateUtf8StringForOutput(Name.data(), Name.size(), DXC_CP_WIDE, &pBlobEncoding));
     return pBlobEncoding->QueryInterface(&name);
   }
 
@@ -286,8 +286,8 @@ struct DxcOutputObject {
 };
 
 struct DxcExtraOutputObject {
-  CComPtr<IDxcBlobUtf16> pType; // Custom name to identify the object
-  CComPtr<IDxcBlobUtf16> pName; // The file path for the output
+  CComPtr<IDxcBlobWide> pType; // Custom name to identify the object
+  CComPtr<IDxcBlobWide> pName; // The file path for the output
   CComPtr<IUnknown> pObject;    // The object itself
 };
 
@@ -320,8 +320,8 @@ public:
 
   HRESULT STDMETHODCALLTYPE GetOutput(_In_ UINT32 uIndex,
     _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
-    _COM_Outptr_opt_result_maybenull_ IDxcBlobUtf16 **ppOutputType,
-    _COM_Outptr_opt_result_maybenull_ IDxcBlobUtf16 **ppOutputName) override
+    _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputType,
+    _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputName) override
   {
     if (uIndex >= m_uCount)
       return E_INVALIDARG;
@@ -430,7 +430,7 @@ public:
   }
   HRESULT STDMETHODCALLTYPE GetOutput(_In_ DXC_OUT_KIND dxcOutKind,
       _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
-      _COM_Outptr_ IDxcBlobUtf16 **ppOutputName) override {
+      _COM_Outptr_ IDxcBlobWide **ppOutputName) override {
     if (ppvObject == nullptr)
       return E_INVALIDARG;
     if (dxcOutKind <= DXC_OUT_NONE || (unsigned)dxcOutKind > kNumDxcOutputTypes)
@@ -478,7 +478,7 @@ public:
   /////////////////////
 
   HRESULT SetEncoding(UINT32 textEncoding) {
-    if (textEncoding != DXC_CP_ACP && textEncoding != DXC_CP_UTF8 && textEncoding != DXC_CP_UTF16)
+    if (textEncoding != DXC_CP_ACP && textEncoding != DXC_CP_UTF8 && textEncoding != DXC_CP_WIDE)
       return E_INVALIDARG;
     m_textEncoding = textEncoding;
     return S_OK;

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -157,7 +157,7 @@ public:
 
 void AssembleToContainer(dxc::DxcDllSupport &dllSupport, IDxcBlob *pModule, IDxcBlob **pContainer);
 std::string BlobToUtf8(_In_ IDxcBlob *pBlob);
-std::wstring BlobToUtf16(_In_ IDxcBlob *pBlob);
+std::wstring BlobToWide(_In_ IDxcBlob *pBlob);
 void CheckOperationSucceeded(IDxcOperationResult *pResult, IDxcBlob **ppBlob);
 bool CheckOperationResultMsgs(IDxcOperationResult *pResult,
                               llvm::ArrayRef<LPCSTR> pErrorMsgs,
@@ -177,8 +177,8 @@ void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &va
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);
-void Utf16ToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlob **ppBlob);
-void Utf16ToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlobEncoding **ppBlob);
+void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlob **ppBlob);
+void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, LPCWSTR pArgs,
                      _Outptr_ IDxcBlob **ppResult);

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -289,8 +289,8 @@ inline bool GetTestParamBool(LPCWSTR name) {
   if (NameValue.IsEmpty()) {
     return false;
   }
-  return Unicode::IsStarMatchUTF16(ParamValue, ParamValue.GetLength(),
-                                   NameValue, NameValue.GetLength());
+  return Unicode::IsStarMatchWide(ParamValue, ParamValue.GetLength(),
+                                  NameValue, NameValue.GetLength());
 }
 
 inline bool GetTestParamUseWARP(bool defaultVal) {

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -90,8 +90,15 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
 // For convenience, equivalent definitions to CP_UTF8 and CP_UTF16.
 #define DXC_CP_UTF8 65001
 #define DXC_CP_UTF16 1200
+#define DXC_CP_UTF32 12000
 // Use DXC_CP_ACP for: Binary;  ANSI Text;  Autodetect UTF with BOM
 #define DXC_CP_ACP 0
+
+#ifdef _WIN32
+#define DXC_CP_WIDE DXC_CP_UTF16
+#else
+#define DXC_CP_WIDE DXC_CP_UTF32
+#endif
 
 // This flag indicates that the shader hash was computed taking into account source information (-Zss)
 #define DXC_HASHFLAG_INCLUDES_SOURCE  1
@@ -153,17 +160,17 @@ public:
                                                 _Out_ UINT32 *pCodePage) = 0;
 };
 
-// Notes on IDxcBlobUtf16 and IDxcBlobUtf8
-// These guarantee null-terminated text and the stated encoding.
+// Notes on IDxcBlobWide and IDxcBlobUtf8
+// These guarantee null-terminated text and eithre utf8 or the native wide char encoding.
 // GetBufferSize() will return the size in bytes, including null-terminator
 // GetStringLength() will return the length in characters, excluding the null-terminator
-// Name strings will use IDxcBlobUtf16, while other string output blobs,
+// Name strings will use IDxcBlobWide, while other string output blobs,
 // such as errors/warnings, preprocessed HLSL, or other text will be based
 // on the -encoding option.
 
 // The API will use this interface for output name strings
-CROSS_PLATFORM_UUIDOF(IDxcBlobUtf16, "A3F84EAB-0FAA-497E-A39C-EE6ED60B2D84")
-struct IDxcBlobUtf16 : public IDxcBlobEncoding {
+CROSS_PLATFORM_UUIDOF(IDxcBlobWide, "A3F84EAB-0FAA-497E-A39C-EE6ED60B2D84")
+struct IDxcBlobWide : public IDxcBlobEncoding {
 public:
   virtual LPCWSTR STDMETHODCALLTYPE GetStringPointer(void) = 0;
   virtual SIZE_T STDMETHODCALLTYPE GetStringLength(void) = 0;
@@ -174,6 +181,11 @@ public:
   virtual LPCSTR STDMETHODCALLTYPE GetStringPointer(void) = 0;
   virtual SIZE_T STDMETHODCALLTYPE GetStringLength(void) = 0;
 };
+
+// Define legacy name IDxcBlobUtf16 as IDxcBlobWide for Win32
+#ifdef _WIN32
+typedef IDxcBlobWide IDxcBlobUtf16;
+#endif
 
 CROSS_PLATFORM_UUIDOF(IDxcIncludeHandler, "7f61fc7d-950d-467f-b3e3-3c02fb49187c")
 struct IDxcIncludeHandler : public IUnknown {
@@ -246,6 +258,8 @@ struct IDxcLibrary : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
 };
 
@@ -400,7 +414,9 @@ struct IDxcUtils : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf16 **pBlobEncoding) = 0;
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) = 0;
+  virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) = 0;
 
   virtual HRESULT STDMETHODCALLTYPE GetDxilContainerPart(
     _In_ const DxcBuffer *pShader,
@@ -435,12 +451,12 @@ struct IDxcUtils : public IUnknown {
 typedef enum DXC_OUT_KIND {
   DXC_OUT_NONE = 0,
   DXC_OUT_OBJECT = 1,         // IDxcBlob - Shader or library object
-  DXC_OUT_ERRORS = 2,         // IDxcBlobUtf8 or IDxcBlobUtf16
+  DXC_OUT_ERRORS = 2,         // IDxcBlobUtf8 or IDxcBlobWide
   DXC_OUT_PDB = 3,            // IDxcBlob
   DXC_OUT_SHADER_HASH = 4,    // IDxcBlob - DxcShaderHash of shader or shader with source info (-Zsb/-Zss)
-  DXC_OUT_DISASSEMBLY = 5,    // IDxcBlobUtf8 or IDxcBlobUtf16 - from Disassemble
-  DXC_OUT_HLSL = 6,           // IDxcBlobUtf8 or IDxcBlobUtf16 - from Preprocessor or Rewriter
-  DXC_OUT_TEXT = 7,           // IDxcBlobUtf8 or IDxcBlobUtf16 - other text, such as -ast-dump or -Odump
+  DXC_OUT_DISASSEMBLY = 5,    // IDxcBlobUtf8 or IDxcBlobWide - from Disassemble
+  DXC_OUT_HLSL = 6,           // IDxcBlobUtf8 or IDxcBlobWide - from Preprocessor or Rewriter
+  DXC_OUT_TEXT = 7,           // IDxcBlobUtf8 or IDxcBlobWide - other text, such as -ast-dump or -Odump
   DXC_OUT_REFLECTION = 8,     // IDxcBlob - RDAT part with reflection data
   DXC_OUT_ROOT_SIGNATURE = 9, // IDxcBlob - Serialized root signature output
   DXC_OUT_EXTRA_OUTPUTS  = 10,// IDxcExtraResults - Extra outputs
@@ -453,7 +469,7 @@ struct IDxcResult : public IDxcOperationResult {
   virtual BOOL STDMETHODCALLTYPE HasOutput(_In_ DXC_OUT_KIND dxcOutKind) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetOutput(_In_ DXC_OUT_KIND dxcOutKind,
     _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
-    _COM_Outptr_ IDxcBlobUtf16 **ppOutputName) = 0;
+    _COM_Outptr_ IDxcBlobWide **ppOutputName) = 0;
 
   virtual UINT32 GetNumOutputs() = 0;
   virtual DXC_OUT_KIND GetOutputByIndex(UINT32 Index) = 0;
@@ -470,8 +486,8 @@ struct IDxcExtraOutputs : public IUnknown {
   virtual UINT32 STDMETHODCALLTYPE GetOutputCount() = 0;
   virtual HRESULT STDMETHODCALLTYPE GetOutput(_In_ UINT32 uIndex,
     _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
-    _COM_Outptr_opt_result_maybenull_ IDxcBlobUtf16 **ppOutputType,
-    _COM_Outptr_opt_result_maybenull_ IDxcBlobUtf16 **ppOutputName) = 0;
+    _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputType,
+    _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputName) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompiler3, "228B4687-5A6A-4730-900C-9702B2203F54")

--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -241,7 +241,7 @@ bool IsUtfBufferNullTerminated(LPCVOID pBuffer, SIZE_T size) {
 static bool IsBufferNullTerminated(LPCVOID pBuffer, SIZE_T size, UINT32 codePage) {
   switch (codePage) {
   case DXC_CP_UTF8: return IsUtfBufferNullTerminated<char>(pBuffer, size);
-  case DXC_CP_UTF16: return IsUtfBufferNullTerminated<wchar_t>(pBuffer, size);
+  case DXC_CP_WIDE: return IsUtfBufferNullTerminated<wchar_t>(pBuffer, size);
   default: return false;
   }
 }
@@ -253,7 +253,7 @@ bool IsUtfBufferEmptyString(LPCVOID pBuffer, SIZE_T size) {
 static bool IsBufferEmptyString(LPCVOID pBuffer, SIZE_T size, UINT32 codePage) {
   switch (codePage) {
   case DXC_CP_UTF8: return IsUtfBufferEmptyString<char>(pBuffer, size);
-  case DXC_CP_UTF16: return IsUtfBufferEmptyString<wchar_t>(pBuffer, size);
+  case DXC_CP_WIDE: return IsUtfBufferEmptyString<wchar_t>(pBuffer, size);
   default: return IsUtfBufferEmptyString<char>(pBuffer, size);
   }
 }
@@ -264,10 +264,10 @@ public:
   static const UINT32 CodePage = CP_ACP;
 };
 
-class DxcBlobUtf16_Impl : public IDxcBlobUtf16 {
+class DxcBlobWide_Impl : public IDxcBlobWide {
 public:
-  static const UINT32 CodePage = CP_UTF16;
-  typedef IDxcBlobUtf16 Base;
+  static const UINT32 CodePage = DXC_CP_WIDE;
+  typedef IDxcBlobWide Base;
   virtual LPCWSTR STDMETHODCALLTYPE GetStringPointer(void) override {
     if (GetBufferSize() < sizeof(wchar_t)) {
       return L""; // Special case for empty string blob
@@ -405,21 +405,21 @@ public:
 };
 
 typedef InternalDxcBlobEncoding_Impl<DxcBlobNoEncoding_Impl> InternalDxcBlobEncoding;
-typedef InternalDxcBlobEncoding_Impl<DxcBlobUtf16_Impl> InternalDxcBlobUtf16;
+typedef InternalDxcBlobEncoding_Impl<DxcBlobWide_Impl> InternalDxcBlobWide;
 typedef InternalDxcBlobEncoding_Impl<DxcBlobUtf8_Impl> InternalDxcBlobUtf8;
 
-static HRESULT CodePageBufferToUtf16(UINT32 codePage, LPCVOID bufferPointer,
+static HRESULT CodePageBufferToWide(UINT32 codePage, LPCVOID bufferPointer,
                                      SIZE_T bufferSize,
-                                     CDxcMallocHeapPtr<WCHAR> &utf16NewCopy,
+                                     CDxcMallocHeapPtr<WCHAR> &wideNewCopy,
                                      _Out_ UINT32 *pConvertedCharCount) {
   *pConvertedCharCount = 0;
 
   // If the buffer is empty, don't dereference bufferPointer at all.
   // Keep the null terminator post-condition.
   if (IsBufferEmptyString(bufferPointer, bufferSize, codePage)) {
-    if (!utf16NewCopy.Allocate(1))
+    if (!wideNewCopy.Allocate(1))
       return E_OUTOFMEMORY;
-    utf16NewCopy.m_pData[0] = L'\0';
+    wideNewCopy.m_pData[0] = L'\0';
     DXASSERT(*pConvertedCharCount == 0, "else didn't init properly");
     return S_OK;
   }
@@ -428,40 +428,40 @@ static HRESULT CodePageBufferToUtf16(UINT32 codePage, LPCVOID bufferPointer,
     return DXC_E_STRING_ENCODING_FAILED;
 
   // Calculate the length of the buffer in wchar_t elements.
-  int numToConvertUTF16 =
+  int numToConvertWide =
       MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (LPCSTR)bufferPointer,
                           bufferSize, nullptr, 0);
-  if (numToConvertUTF16 == 0)
+  if (numToConvertWide == 0)
     return HRESULT_FROM_WIN32(GetLastError());
 
   // Add an extra character in case we need it for null-termination
-  unsigned buffSizeUTF16;
-  IFR(Int32ToUInt32(numToConvertUTF16, &buffSizeUTF16));
-  IFR(UInt32Add(buffSizeUTF16, 1, &buffSizeUTF16));
-  IFR(UInt32Mult(buffSizeUTF16, sizeof(WCHAR), &buffSizeUTF16));
-  utf16NewCopy.AllocateBytes(buffSizeUTF16);
-  IFROOM(utf16NewCopy.m_pData);
+  unsigned buffSizeWide;
+  IFR(Int32ToUInt32(numToConvertWide, &buffSizeWide));
+  IFR(UInt32Add(buffSizeWide, 1, &buffSizeWide));
+  IFR(UInt32Mult(buffSizeWide, sizeof(WCHAR), &buffSizeWide));
+  wideNewCopy.AllocateBytes(buffSizeWide);
+  IFROOM(wideNewCopy.m_pData);
 
-  int numActuallyConvertedUTF16 =
+  int numActuallyConvertedWide =
       MultiByteToWideChar(codePage, MB_ERR_INVALID_CHARS, (LPCSTR)bufferPointer,
-                          bufferSize, utf16NewCopy, buffSizeUTF16);
+                          bufferSize, wideNewCopy, buffSizeWide);
 
-  if (numActuallyConvertedUTF16 == 0)
+  if (numActuallyConvertedWide == 0)
     return HRESULT_FROM_WIN32(GetLastError());
-  if (numActuallyConvertedUTF16 < 0)
+  if (numActuallyConvertedWide < 0)
     return E_OUTOFMEMORY;
 
   // If all we have is null terminator, return with zero count.
-  if (utf16NewCopy.m_pData[0] == L'\0') {
+  if (wideNewCopy.m_pData[0] == L'\0') {
     DXASSERT(*pConvertedCharCount == 0, "else didn't init properly");
     return S_OK;
   }
 
-  if ((UINT32)numActuallyConvertedUTF16 < (buffSizeUTF16 / sizeof(wchar_t)) &&
-      utf16NewCopy.m_pData[numActuallyConvertedUTF16 - 1] != L'\0') {
-    utf16NewCopy.m_pData[numActuallyConvertedUTF16++] = L'\0';
+  if ((UINT32)numActuallyConvertedWide < (buffSizeWide / sizeof(wchar_t)) &&
+      wideNewCopy.m_pData[numActuallyConvertedWide - 1] != L'\0') {
+    wideNewCopy.m_pData[numActuallyConvertedWide++] = L'\0';
   }
-  *pConvertedCharCount = (UINT32)numActuallyConvertedUTF16;
+  *pConvertedCharCount = (UINT32)numActuallyConvertedWide;
 
   return S_OK;
 }
@@ -472,28 +472,24 @@ static HRESULT CodePageBufferToUtf8(UINT32 codePage, LPCVOID bufferPointer,
                                     CDxcMallocHeapPtr<char> &utf8NewCopy,
                                     _Out_ UINT32 *pConvertedCharCount) {
   *pConvertedCharCount = 0;
-  CDxcMallocHeapPtr<WCHAR> utf16NewCopy(pMalloc);
-  UINT32 utf16CharCount = 0;
-  const WCHAR *utf16Chars = nullptr;
-#if _WIN32
-  if (codePage == CP_UTF16) {
-#else
-  if (codePage == CP_UTF16 || codePage == CP_UTF32LE) {
-#endif
+  CDxcMallocHeapPtr<WCHAR> wideNewCopy(pMalloc);
+  UINT32 wideCharCount = 0;
+  const WCHAR *wideChars = nullptr;
+  if (codePage == DXC_CP_WIDE) {
     if (!IsSizeWcharAligned(bufferSize))
       throw hlsl::Exception(DXC_E_STRING_ENCODING_FAILED,
                             "Error in encoding argument specified");
-    utf16Chars = (const WCHAR*)bufferPointer;
-    utf16CharCount = bufferSize / sizeof(wchar_t);
+    wideChars = (const WCHAR*)bufferPointer;
+    wideCharCount = bufferSize / sizeof(wchar_t);
   } else if (bufferSize) {
-    IFR(CodePageBufferToUtf16(codePage, bufferPointer, bufferSize,
-                              utf16NewCopy, &utf16CharCount));
-    utf16Chars = utf16NewCopy.m_pData;
+    IFR(CodePageBufferToWide(codePage, bufferPointer, bufferSize,
+                              wideNewCopy, &wideCharCount));
+    wideChars = wideNewCopy.m_pData;
   }
 
   // If the buffer is empty, don't dereference bufferPointer at all.
   // Keep the null terminator post-condition.
-  if (IsUtfBufferEmptyString<wchar_t>(utf16Chars, utf16CharCount)) {
+  if (IsUtfBufferEmptyString<wchar_t>(wideChars, wideCharCount)) {
     if (!utf8NewCopy.Allocate(1))
       return E_OUTOFMEMORY;
     DXASSERT(*pConvertedCharCount == 0, "else didn't init properly");
@@ -502,14 +498,14 @@ static HRESULT CodePageBufferToUtf8(UINT32 codePage, LPCVOID bufferPointer,
   }
 
   int numToConvertUtf8 =
-    WideCharToMultiByte(CP_UTF8, 0, utf16Chars, utf16CharCount,
+    WideCharToMultiByte(CP_UTF8, 0, wideChars, wideCharCount,
                         NULL, 0, NULL, NULL);
   if (numToConvertUtf8 == 0)
     return HRESULT_FROM_WIN32(GetLastError());
 
   UINT32 buffSizeUtf8;
   IFR(Int32ToUInt32(numToConvertUtf8, &buffSizeUtf8));
-  if (!IsBufferNullTerminated(utf16Chars, utf16CharCount * sizeof(wchar_t), CP_UTF16)) {
+  if (!IsBufferNullTerminated(wideChars, wideCharCount * sizeof(wchar_t), DXC_CP_WIDE)) {
     // If original size doesn't include null-terminator,
     // we have to add one to the converted buffer.
     IFR(UInt32Add(buffSizeUtf8, 1, &buffSizeUtf8));
@@ -518,7 +514,7 @@ static HRESULT CodePageBufferToUtf8(UINT32 codePage, LPCVOID bufferPointer,
   IFROOM(utf8NewCopy.m_pData);
 
   int numActuallyConvertedUtf8 =
-    WideCharToMultiByte(CP_UTF8, 0, utf16Chars, utf16CharCount,
+    WideCharToMultiByte(CP_UTF8, 0, wideChars, wideCharCount,
                         utf8NewCopy, buffSizeUtf8, NULL, NULL);
   if (numActuallyConvertedUtf8 == 0)
     return HRESULT_FROM_WIN32(GetLastError());
@@ -542,11 +538,11 @@ static bool TryCreateEmptyBlobUtf(
           nullptr, pMalloc, 0, true, codePage, &internalUtf8));
     *ppBlobEncoding = internalUtf8;
     return true;
-  } else if (codePage == CP_UTF16) {
-    InternalDxcBlobUtf16 *internalUtf16;
-    IFR(InternalDxcBlobUtf16::CreateFromMalloc(
-          nullptr, pMalloc, 0, true, codePage, &internalUtf16));
-    *ppBlobEncoding = internalUtf16;
+  } else if (codePage == DXC_CP_WIDE) {
+    InternalDxcBlobWide *internalWide;
+    IFR(InternalDxcBlobWide::CreateFromMalloc(
+          nullptr, pMalloc, 0, true, codePage, &internalWide));
+    *ppBlobEncoding = internalWide;
     return true;
   }
   return false;
@@ -555,7 +551,7 @@ static bool TryCreateEmptyBlobUtf(
 static bool TryCreateBlobUtfFromBlob(
     IDxcBlob *pFromBlob, UINT32 codePage, IMalloc *pMalloc,
     IDxcBlobEncoding **ppBlobEncoding) {
-  // Try to create a IDxcBlobUtf8 or IDxcBlobUtf16
+  // Try to create a IDxcBlobUtf8 or IDxcBlobWide
   if (IsBlobNullOrEmpty(pFromBlob)) {
     return TryCreateEmptyBlobUtf(codePage, pMalloc, ppBlobEncoding);
   } else if (IsBufferNullTerminated(pFromBlob->GetBufferPointer(),
@@ -566,11 +562,11 @@ static bool TryCreateBlobUtfFromBlob(
             pFromBlob, pMalloc, true, codePage, &internalUtf8));
       *ppBlobEncoding = internalUtf8;
       return true;
-    } else if (codePage == CP_UTF16) {
-      InternalDxcBlobUtf16 *internalUtf16;
-      IFR(InternalDxcBlobUtf16::CreateFromBlob(
-            pFromBlob, pMalloc, true, codePage, &internalUtf16));
-      *ppBlobEncoding = internalUtf16;
+    } else if (codePage == DXC_CP_WIDE) {
+      InternalDxcBlobWide *internalWide;
+      IFR(InternalDxcBlobWide::CreateFromBlob(
+            pFromBlob, pMalloc, true, codePage, &internalWide));
+      *ppBlobEncoding = internalWide;
       return true;
     }
   }
@@ -633,12 +629,12 @@ HRESULT DxcCreateBlob(
           *ppBlobEncoding = internalUtf8;
           internalUtf8->ClearFreeFlag();
           return S_OK;
-        } else if (codePage == CP_UTF16) {
-          InternalDxcBlobUtf16 *internalUtf16;
-          IFR(InternalDxcBlobUtf16::CreateFromMalloc(
-              pPtr, pMalloc, size, true, codePage, &internalUtf16));
-          *ppBlobEncoding = internalUtf16;
-          internalUtf16->ClearFreeFlag();
+        } else if (codePage == DXC_CP_WIDE) {
+          InternalDxcBlobWide *internalWide;
+          IFR(InternalDxcBlobWide::CreateFromMalloc(
+              pPtr, pMalloc, size, true, codePage, &internalWide));
+          *ppBlobEncoding = internalWide;
+          internalWide->ClearFreeFlag();
           return S_OK;
         }
       }
@@ -661,7 +657,7 @@ HRESULT DxcCreateBlob(
         if (codePage == CP_UTF8) {
           newSize += sizeof(char);
           bNullTerminated = true;
-        } else if (codePage == CP_UTF16) {
+        } else if (codePage == DXC_CP_WIDE) {
           newSize += sizeof(wchar_t);
           bNullTerminated = true;
         }
@@ -684,13 +680,13 @@ HRESULT DxcCreateBlob(
     IFR(InternalDxcBlobUtf8::CreateFromMalloc(
         pData, pMalloc, newSize, true, codePage, &internalUtf8));
     *ppBlobEncoding = internalUtf8;
-  } else if (bNullTerminated && codePage == CP_UTF16) {
+  } else if (bNullTerminated && codePage == DXC_CP_WIDE) {
     if (bCopy && newSize > size)
       ((wchar_t*)pData)[(newSize / sizeof(wchar_t)) - 1] = 0;
-    InternalDxcBlobUtf16 *internalUtf16;
-    IFR(InternalDxcBlobUtf16::CreateFromMalloc(
-        pData, pMalloc, newSize, true, codePage, &internalUtf16));
-    *ppBlobEncoding = internalUtf16;
+    InternalDxcBlobWide *internalWide;
+    IFR(InternalDxcBlobWide::CreateFromMalloc(
+        pData, pMalloc, newSize, true, codePage, &internalWide));
+    *ppBlobEncoding = internalWide;
   } else {
     InternalDxcBlobEncoding *internalEncoding;
     IFR(InternalDxcBlobEncoding::CreateFromMalloc(
@@ -735,10 +731,10 @@ HRESULT DxcCreateBlobEncodingFromBlob(
       return S_OK;
     }
   }
-  if (!encodingKnown || codePage == CP_UTF16) {
-    IDxcBlobUtf16 *pBlobUtf16;
-    if (SUCCEEDED(pFromBlob->QueryInterface(&pBlobUtf16))) {
-      *ppBlobEncoding = pBlobUtf16;
+  if (!encodingKnown || codePage == DXC_CP_WIDE) {
+    IDxcBlobWide *pBlobWide;
+    if (SUCCEEDED(pFromBlob->QueryInterface(&pBlobWide))) {
+      *ppBlobEncoding = pBlobWide;
       return S_OK;
     }
   }
@@ -1035,7 +1031,7 @@ DxcGetBlobAsUtf8NullTerm(_In_ IDxcBlob *pBlob,
 }
 
 _Use_decl_annotations_
-HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf16 **pBlobEncoding) throw() {
+HRESULT DxcGetBlobAsWide(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobWide **pBlobEncoding) throw() {
   IFRBOOL(pBlob, E_POINTER);
   IFRBOOL(pBlobEncoding, E_POINTER);
   *pBlobEncoding = nullptr;
@@ -1070,18 +1066,18 @@ HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf16 **pBl
   if (!pMalloc)
     pMalloc = DxcGetThreadMallocNoRef();
 
-  CDxcMallocHeapPtr<WCHAR> utf16NewCopy(pMalloc);
-  UINT32 utf16CharCount = 0;
+  CDxcMallocHeapPtr<WCHAR> wideNewCopy(pMalloc);
+  UINT32 wideCharCount = 0;
 
   // Reuse or copy the underlying blob depending on null-termination
-  if (codePage == CP_UTF16) {
+  if (codePage == DXC_CP_WIDE) {
     if (!IsSizeWcharAligned(blobLen))
       return DXC_E_STRING_ENCODING_FAILED;
-    utf16CharCount = blobLen / sizeof(wchar_t);
-    if (IsBufferNullTerminated(bufferPointer, blobLen, CP_UTF16)) {
+    wideCharCount = blobLen / sizeof(wchar_t);
+    if (IsBufferNullTerminated(bufferPointer, blobLen, DXC_CP_WIDE)) {
       // Already null-terminated, reference other blob's memory
-      InternalDxcBlobUtf16* internalEncoding;
-      hr = InternalDxcBlobUtf16::CreateFromBlob(pBlob, pMalloc, true, CP_UTF16, &internalEncoding);
+      InternalDxcBlobWide* internalEncoding;
+      hr = InternalDxcBlobWide::CreateFromBlob(pBlob, pMalloc, true, DXC_CP_WIDE, &internalEncoding);
       if (SUCCEEDED(hr)) {
         // Adjust if buffer has BOM; blobLen is already adjusted.
         if (bomSize)
@@ -1091,31 +1087,31 @@ HRESULT DxcGetBlobAsUtf16(IDxcBlob *pBlob, IMalloc *pMalloc, IDxcBlobUtf16 **pBl
       return hr;
     } else {
       // Copy to new buffer and null-terminate
-      if(!utf16NewCopy.Allocate(utf16CharCount + 1))
+      if(!wideNewCopy.Allocate(wideCharCount + 1))
         return E_OUTOFMEMORY;
-      memcpy(utf16NewCopy.m_pData, bufferPointer, blobLen);
-      utf16NewCopy.m_pData[utf16CharCount++] = 0;
+      memcpy(wideNewCopy.m_pData, bufferPointer, blobLen);
+      wideNewCopy.m_pData[wideCharCount++] = 0;
     }
   } else {
     // Convert and create a blob that owns the encoding.
     if (FAILED(
-      hr = CodePageBufferToUtf16(codePage, bufferPointer, blobLen,
-                                 utf16NewCopy, &utf16CharCount))) {
+      hr = CodePageBufferToWide(codePage, bufferPointer, blobLen,
+                                 wideNewCopy, &wideCharCount))) {
       return hr;
     }
   }
 
-  // At this point, we have new utf16NewCopy to wrap in a blob
-  DXASSERT(!utf16CharCount ||
-           IsBufferNullTerminated(utf16NewCopy.m_pData, utf16CharCount * sizeof(wchar_t), CP_UTF16),
+  // At this point, we have new wideNewCopy to wrap in a blob
+  DXASSERT(!wideCharCount ||
+           IsBufferNullTerminated(wideNewCopy.m_pData, wideCharCount * sizeof(wchar_t), DXC_CP_WIDE),
            "otherwise, failed to null-terminate buffer.");
-  InternalDxcBlobUtf16* internalEncoding;
-  hr = InternalDxcBlobUtf16::CreateFromMalloc(
-      utf16NewCopy.m_pData, pMalloc,
-      utf16CharCount * sizeof(WCHAR), true, CP_UTF16, &internalEncoding);
+  InternalDxcBlobWide* internalEncoding;
+  hr = InternalDxcBlobWide::CreateFromMalloc(
+      wideNewCopy.m_pData, pMalloc,
+      wideCharCount * sizeof(WCHAR), true, DXC_CP_WIDE, &internalEncoding);
   if (SUCCEEDED(hr)) {
     *pBlobEncoding = internalEncoding;
-    utf16NewCopy.Detach();
+    wideNewCopy.Detach();
   }
   return hr;
 }

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -80,10 +80,10 @@ UINT32 DxcDefines::ComputeNumberOfWCharsNeededForDefines() {
   for (llvm::StringRef &S : DefineStrings) {
     DXASSERT(S.size() > 0,
              "else DxcDefines::push_back should not have added this");
-    const int utf16Length = ::MultiByteToWideChar(
+    const int wideLength = ::MultiByteToWideChar(
         CP_UTF8, MB_ERR_INVALID_CHARS, S.data(), S.size(), nullptr, 0);
-    IFTARG(utf16Length != 0);
-    wcharSize += utf16Length + 1; // adding null terminated character
+    IFTARG(wideLength != 0);
+    wcharSize += wideLength + 1; // adding null terminated character
   }
   return wcharSize;
 }
@@ -102,12 +102,12 @@ void DxcDefines::BuildDefines() {
   for (size_t i = 0; i < DefineStrings.size(); ++i) {
     llvm::StringRef &S = DefineStrings[i];
     DxcDefine &D = DefineVector[i];
-    const int utf16Length =
+    const int wideLength =
         ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, S.data(), S.size(),
                               pWriteCursor, remaining);
-    DXASSERT(utf16Length > 0,
+    DXASSERT(wideLength > 0,
              "else it should have failed during size calculation");
-    LPWSTR pDefineEnd = pWriteCursor + utf16Length;
+    LPWSTR pDefineEnd = pWriteCursor + wideLength;
     D.Name = pWriteCursor;
 
     LPWSTR pEquals = std::find(pWriteCursor, pDefineEnd, L'=');
@@ -119,13 +119,13 @@ void DxcDefines::BuildDefines() {
     }
 
     // Advance past converted characters and include the null terminator.
-    pWriteCursor += utf16Length;
+    pWriteCursor += wideLength;
     *pWriteCursor = L'\0';
     ++pWriteCursor;
 
     DXASSERT(pWriteCursor <= DefineValues + wcharSize,
              "else this function is calculating this incorrectly");
-    remaining -= (utf16Length + 1);
+    remaining -= (wideLength + 1);
   }
 }
 
@@ -169,7 +169,7 @@ MainArgs::MainArgs(int argc, const wchar_t **argv, int skipArgCount) {
     Utf8StringVector.reserve(argc - skipArgCount);
     Utf8CharPtrVector.reserve(argc - skipArgCount);
     for (int i = skipArgCount; i < argc; ++i) {
-      Utf8StringVector.emplace_back(Unicode::UTF16ToUTF8StringOrThrow(argv[i]));
+      Utf8StringVector.emplace_back(Unicode::WideToUTF8StringOrThrow(argv[i]));
       Utf8CharPtrVector.push_back(Utf8StringVector.back().data());
     }
   }
@@ -207,9 +207,9 @@ MainArgs& MainArgs::operator=(const MainArgs &other) {
   return *this;
 }
 
-StringRefUtf16::StringRefUtf16(llvm::StringRef value) {
+StringRefWide::StringRefWide(llvm::StringRef value) {
   if (!value.empty())
-    m_value = Unicode::UTF8ToUTF16StringOrThrow(value.data());
+    m_value = Unicode::UTF8ToWideStringOrThrow(value.data());
 }
 
 static bool GetTargetVersionFromString(llvm::StringRef ref, unsigned *major, unsigned *minor) {
@@ -352,11 +352,23 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   if (!encoding.empty()) {
     if (encoding.equals_lower("utf8")) {
       opts.DefaultTextCodePage = DXC_CP_UTF8;
+#ifdef _WIN32
     } else if (encoding.equals_lower("utf16")) {
-      opts.DefaultTextCodePage = DXC_CP_UTF16;
+      opts.DefaultTextCodePage = DXC_CP_UTF16; // Only on Windows
+#else
+    } else if (encoding.equals_lower("utf32")) {
+      opts.DefaultTextCodePage = DXC_CP_UTF32; // Only on *nix
+#endif
+    } else if (encoding.equals_lower("wide")) {
+      opts.DefaultTextCodePage = DXC_CP_WIDE;
     } else {
       errors << "Unsupported value '" << encoding
-        << "for -encoding option.  Allowed values: utf8, utf16.";
+        << "for -encoding option.  Allowed values: wide, utf8, "
+#ifdef _WIN32
+        "utf16.";
+#else
+        "utf32.";
+#endif
       return 1;
     }
   }
@@ -1140,7 +1152,7 @@ int SetupDxcDllSupport(const DxcOpts &opts, dxc::DxcDllSupport &dxcSupport,
                        llvm::raw_ostream &errors) {
   if (!opts.ExternalLib.empty()) {
     DXASSERT(!opts.ExternalFn.empty(), "else ReadDxcOpts should have failed");
-    StringRefUtf16 externalLib(opts.ExternalLib);
+    StringRefWide externalLib(opts.ExternalLib);
     HRESULT hrLoad =
         dxcSupport.InitializeForDll(externalLib, opts.ExternalFn.data());
     if (DXC_FAILED(hrLoad)) {
@@ -1162,7 +1174,7 @@ void CopyArgsToWStrings(const InputArgList &inArgs, unsigned flagsToInclude,
     }
   }
   for (const char *argText : stringList) {
-    outArgs.emplace_back(Unicode::UTF8ToUTF16StringOrThrow(argText));
+    outArgs.emplace_back(Unicode::UTF8ToWideStringOrThrow(argText));
   }
 }
 

--- a/lib/DxilDia/DxilDia.cpp
+++ b/lib/DxilDia/DxilDia.cpp
@@ -18,7 +18,7 @@ HRESULT dxil_dia::StringRefToBSTR(llvm::StringRef value, BSTR *pRetVal) {
   try {
     wchar_t *wide;
     size_t sideSize;
-    if (!Unicode::UTF8BufferToUTF16Buffer(value.data(), value.size(), &wide,
+    if (!Unicode::UTF8BufferToWideBuffer(value.data(), value.size(), &wide,
       &sideSize))
       return E_FAIL;
     *pRetVal = SysAllocString(wide);

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -790,7 +790,7 @@ HRESULT dxil_dia::hlsl_symbols::CompilandSymbol::Create(IMalloc *pMalloc, Sessio
   if (pSession->MainFileName()) {
     llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(pSession->MainFileName()->getOperand(0)->getOperand(0))->getString();
     std::string str(strRef.begin(), strRef.size()); // To make sure str is null terminated
-    (*ppSym)->SetSourceFileName(_bstr_t(Unicode::UTF8ToUTF16StringOrThrow(str.data()).c_str()));
+    (*ppSym)->SetSourceFileName(_bstr_t(Unicode::UTF8ToWideStringOrThrow(str.data()).c_str()));
   }
 
   return S_OK;

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -66,7 +66,7 @@ static void FatalErrorHandlerStreamWrite(void *user_data, const std::string& rea
   throw std::exception();
 }
 
-static HRESULT Utf8ToUtf16CoTaskMalloc(LPCSTR pValue, LPWSTR *ppResult) {
+static HRESULT Utf8ToWideCoTaskMalloc(LPCSTR pValue, LPWSTR *ppResult) {
   if (ppResult == nullptr)
     return E_POINTER;
   int count = MultiByteToWideChar(CP_UTF8, 0, pValue, -1, nullptr, 0);
@@ -111,10 +111,10 @@ public:
   }
 
   HRESULT STDMETHODCALLTYPE GetOptionName(_COM_Outptr_ LPWSTR *ppResult) override {
-    return Utf8ToUtf16CoTaskMalloc(m_pOptionName, ppResult);
+    return Utf8ToWideCoTaskMalloc(m_pOptionName, ppResult);
   }
   HRESULT STDMETHODCALLTYPE GetDescription(_COM_Outptr_ LPWSTR *ppResult) override {
-    return Utf8ToUtf16CoTaskMalloc(m_pDescription, ppResult);
+    return Utf8ToWideCoTaskMalloc(m_pDescription, ppResult);
   }
 
   HRESULT STDMETHODCALLTYPE GetOptionArgCount(_Out_ UINT32 *pCount) override {
@@ -126,12 +126,12 @@ public:
   HRESULT STDMETHODCALLTYPE GetOptionArgName(UINT32 argIndex, LPWSTR *ppResult) override {
     if (!ppResult) return E_INVALIDARG;
     if (argIndex >= m_pArgNames.size()) return E_INVALIDARG;
-    return Utf8ToUtf16CoTaskMalloc(m_pArgNames[argIndex], ppResult);
+    return Utf8ToWideCoTaskMalloc(m_pArgNames[argIndex], ppResult);
   }
   HRESULT STDMETHODCALLTYPE GetOptionArgDescription(UINT32 argIndex, LPWSTR *ppResult) override {
     if (!ppResult) return E_INVALIDARG;
     if (argIndex >= m_pArgDescriptions.size()) return E_INVALIDARG;
-    return Utf8ToUtf16CoTaskMalloc(m_pArgDescriptions[argIndex], ppResult);
+    return Utf8ToWideCoTaskMalloc(m_pArgDescriptions[argIndex], ppResult);
   }
 };
 

--- a/lib/HLSL/DxilPatchShaderRecordBindings.cpp
+++ b/lib/HLSL/DxilPatchShaderRecordBindings.cpp
@@ -203,7 +203,7 @@ static inline std::string GetUnmangledName(StringRef name) {
 
 static Function* getFunctionFromName(Module &M, const std::wstring& exportName) {
   for (auto F = M.begin(), E = M.end(); F != E; ++F) {
-    std::wstring functionName = Unicode::UTF8ToUTF16StringOrThrow(GetUnmangledName(F->getName()).c_str());
+    std::wstring functionName = Unicode::UTF8ToWideStringOrThrow(GetUnmangledName(F->getName()).c_str());
     if (exportName == functionName) {
       return F;
     }

--- a/tools/clang/tools/dxa/dxa.cpp
+++ b/tools/clang/tools/dxa/dxa.cpp
@@ -81,7 +81,7 @@ void DxaContext::Assemble() {
 
   {
     CComPtr<IDxcBlobEncoding> pSource;
-    ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+    ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
 
     CComPtr<IDxcAssembler> pAssembler;
     IFT(m_dxcSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
@@ -115,7 +115,7 @@ void DxaContext::Assemble() {
         }
       }
 
-      WriteBlobToFile(pContainer, StringRefUtf16(OutputFilename), DXC_CP_ACP);
+      WriteBlobToFile(pContainer, StringRefWide(OutputFilename), DXC_CP_ACP);
       printf("Output written to \"%s\"\n", OutputFilename.c_str());
     }
   } else {
@@ -153,7 +153,7 @@ HRESULT DxaContext::FindModule(hlsl::DxilFourCC fourCC, IDxcBlob *pSource, IDxcL
 
 void DxaContext::ListFiles() {
   CComPtr<IDxcBlobEncoding> pSource;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
 
   CComPtr<IDxcPdbUtils> pPdbUtils;
   IFT(m_dxcSupport.CreateInstance(CLSID_DxcPdbUtils, &pPdbUtils));
@@ -171,7 +171,7 @@ void DxaContext::ListFiles() {
 
 bool DxaContext::ExtractFile(const char *pName) {
   CComPtr<IDxcBlobEncoding> pSource;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
 
   CComPtr<IDxcPdbUtils> pPdbUtils;
   IFT(m_dxcSupport.CreateInstance(CLSID_DxcPdbUtils, &pPdbUtils));
@@ -200,7 +200,7 @@ bool DxaContext::ExtractPart(uint32_t PartKind, IDxcBlob **ppTargetBlob) {
   CComPtr<IDxcContainerReflection> pReflection;
   CComPtr<IDxcBlobEncoding> pSource;
   UINT32 partCount;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
   IFT(m_dxcSupport.CreateInstance(CLSID_DxcContainerReflection, &pReflection));
   IFT(pReflection->Load(pSource));
   IFT(pReflection->GetPartCount(&partCount));
@@ -269,7 +269,7 @@ bool DxaContext::ExtractPart(const char *pName) {
     std::swap(pModuleBlob, pContent);
   }
 
-  WriteBlobToFile(pContent, StringRefUtf16(OutputFilename),
+  WriteBlobToFile(pContent, StringRefWide(OutputFilename),
                   DXC_CP_UTF8); // TODO: Support DefaultTextCodePage
   printf("%Iu bytes written to %s\n", pContent->GetBufferSize(),
          OutputFilename.c_str());
@@ -278,7 +278,7 @@ bool DxaContext::ExtractPart(const char *pName) {
 
 void DxaContext::ListParts() {
   CComPtr<IDxcBlobEncoding> pSource;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
 
   CComPtr<IDxcContainerReflection> pReflection;
   IFT(m_dxcSupport.CreateInstance(CLSID_DxcContainerReflection, &pReflection));

--- a/tools/clang/tools/dxclib/dxc.cpp
+++ b/tools/clang/tools/dxclib/dxc.cpp
@@ -165,7 +165,7 @@ public:
 };
 
 static void WriteBlobToFile(_In_opt_ IDxcBlob *pBlob, llvm::StringRef FName, UINT32 defaultTextCodePage) {
-  ::dxc::WriteBlobToFile(pBlob, StringRefUtf16(FName), defaultTextCodePage);
+  ::dxc::WriteBlobToFile(pBlob, StringRefWide(FName), defaultTextCodePage);
 }
 
 static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
@@ -184,7 +184,7 @@ static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
 
   const char *pData = hlsl::GetDxilPartData(*it);
   DWORD dataLen = (*it)->PartSize;
-  StringRefUtf16 WideName(FName);
+  StringRefWide WideName(FName);
   CHandle file(CreateFileW(WideName, GENERIC_WRITE, FILE_SHARE_READ, nullptr,
                            CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr));
   if (file == INVALID_HANDLE_VALUE) {
@@ -199,14 +199,14 @@ static void WritePartToFile(IDxcBlob *pBlob, hlsl::DxilFourCC CC,
 static void WriteDxcOutputToFile(DXC_OUT_KIND kind, IDxcResult *pResult, UINT32 textCodePage) {
   if (pResult->HasOutput(kind)) {
     CComPtr<IDxcBlob> pData;
-    CComPtr<IDxcBlobUtf16> pName;
+    CComPtr<IDxcBlobWide> pName;
     IFT(pResult->GetOutput(kind, IID_PPV_ARGS(&pData), &pName));
     if (pName && pName->GetStringLength() > 0)
       WriteBlobToFile(pData, pName->GetStringPointer(), textCodePage);
   }
 }
 
-static bool StringBlobEqualUtf16(IDxcBlobUtf16 *pBlob, const WCHAR *pStr) {
+static bool StringBlobEqualWide(IDxcBlobWide *pBlob, const WCHAR *pStr) {
   size_t uSize = wcslen(pStr);
   if (pBlob && pBlob->GetStringLength() == uSize) {
     return 0 == memcmp(pBlob->GetBufferPointer(), pStr, pBlob->GetBufferSize());
@@ -221,13 +221,13 @@ static void WriteDxcExtraOuputs(IDxcResult *pResult) {
   }
 
   CComPtr<IDxcExtraOutputs> pOutputs;
-  CComPtr<IDxcBlobUtf16> pName;
+  CComPtr<IDxcBlobWide> pName;
   IFT(pResult->GetOutput(kind, IID_PPV_ARGS(&pOutputs), &pName));
 
   UINT32 uOutputCount = pOutputs->GetOutputCount();
   for (UINT32 i = 0; i < uOutputCount; i++) {
-    CComPtr<IDxcBlobUtf16> pFileName;
-    CComPtr<IDxcBlobUtf16> pType;
+    CComPtr<IDxcBlobWide> pFileName;
+    CComPtr<IDxcBlobWide> pType;
     CComPtr<IDxcBlob> pBlob;
     HRESULT hr = pOutputs->GetOutput(i, IID_PPV_ARGS(&pBlob), &pType, &pFileName);
 
@@ -247,12 +247,12 @@ static void WriteDxcExtraOuputs(IDxcResult *pResult) {
     }
 
     if (pFileName && pFileName->GetStringLength() > 0) {
-      if (StringBlobEqualUtf16(pFileName, DXC_EXTRA_OUTPUT_NAME_STDOUT)) {
+      if (StringBlobEqualWide(pFileName, DXC_EXTRA_OUTPUT_NAME_STDOUT)) {
         if (uCodePage != CP_ACP) {
           WriteBlobToConsole(pBlob, STD_OUTPUT_HANDLE);
         }
       }
-      else if (StringBlobEqualUtf16(pFileName, DXC_EXTRA_OUTPUT_NAME_STDERR)) {
+      else if (StringBlobEqualWide(pFileName, DXC_EXTRA_OUTPUT_NAME_STDERR)) {
         if (uCodePage != CP_ACP) {
           WriteBlobToConsole(pBlob, STD_ERROR_HANDLE);
         }
@@ -392,7 +392,7 @@ int DxcContext::ActOnBlob(IDxcBlob *pBlob, IDxcBlob *pDebugBlob, LPCWSTR pDebugB
                               ? llvm::Twine("g_", m_Opts.EntryPoint)
                               : m_Opts.VariableName;
     WriteHeader(pDisassembleResult, pBlob, varName,
-                StringRefUtf16(m_Opts.OutputHeader));
+                StringRefWide(m_Opts.OutputHeader));
     disassemblyWritten = true;
   }
 
@@ -436,7 +436,7 @@ void DxcContext::UpdatePart(IDxcBlob *pSource, IDxcBlob **ppResult) {
   if (!m_Opts.PrivateSource.empty()) {
     CComPtr<IDxcBlob> privateBlob;
     IFT(ReadFileIntoPartContent(hlsl::DxilFourCC::DFCC_PrivateData,
-                                StringRefUtf16(m_Opts.PrivateSource),
+                                StringRefWide(m_Opts.PrivateSource),
                                 &privateBlob));
 
     // setprivate option can replace existing private part. 
@@ -449,7 +449,7 @@ void DxcContext::UpdatePart(IDxcBlob *pSource, IDxcBlob **ppResult) {
     // We only want to add RTS0 part to the container builder. 
     CComPtr<IDxcBlob> RootSignatureBlob;
     IFT(ReadFileIntoPartContent(hlsl::DxilFourCC::DFCC_RootSignature,
-                                StringRefUtf16(m_Opts.RootSignatureSource),
+                                StringRefWide(m_Opts.RootSignatureSource),
                                 &RootSignatureBlob));
 
     // setrootsignature option can replace existing rootsignature part
@@ -562,7 +562,7 @@ void DxcContext::ExtractRootSignature(IDxcBlob *pBlob, IDxcBlob **ppResult) {
 int DxcContext::VerifyRootSignature() {
   // Get dxil container from file
   CComPtr<IDxcBlobEncoding> pSource;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(m_Opts.InputFile), &pSource);
   hlsl::DxilContainerHeader *pSourceHeader = (hlsl::DxilContainerHeader *)pSource->GetBufferPointer();
   IFTBOOLMSG(hlsl::IsValidDxilContainer(pSourceHeader, pSourceHeader->ContainerSizeInBytes), E_INVALIDARG, "invalid DXIL container to verify.");
 
@@ -571,7 +571,7 @@ int DxcContext::VerifyRootSignature() {
 
   IFTMSG(ReadFileIntoPartContent(
              hlsl::DxilFourCC::DFCC_RootSignature,
-             StringRefUtf16(m_Opts.VerifyRootSignatureSource), &pRootSignature),
+             StringRefWide(m_Opts.VerifyRootSignatureSource), &pRootSignature),
          "invalid root signature to verify.");
 
   // TODO : Right now we are just going to bild a new blob with updated root signature to verify root signature
@@ -639,10 +639,10 @@ public:
   ) override {
     try {
       // Convert pFilename into native form for indexing as is done when the MD is created
-      std::string FilenameStr8 = Unicode::UTF16ToUTF8StringOrThrow(pFilename);
+      std::string FilenameStr8 = Unicode::WideToUTF8StringOrThrow(pFilename);
       llvm::SmallString<128> NormalizedPath;
       llvm::sys::path::native(FilenameStr8, NormalizedPath);
-      std::wstring FilenameStr16 = Unicode::UTF8ToUTF16StringOrThrow(NormalizedPath.c_str());
+      std::wstring FilenameStr16 = Unicode::UTF8ToWideStringOrThrow(NormalizedPath.c_str());
       *ppIncludeSource = includeFiles.at(FilenameStr16);
       (*ppIncludeSource)->AddRef();
     }
@@ -727,7 +727,7 @@ void DxcContext::Recompile(IDxcBlob *pSource, IDxcLibrary *pLibrary,
   if (!m_Opts.DebugFile.empty()) {
     CComPtr<IDxcCompiler2> pCompiler2;
     CComHeapPtr<WCHAR> pDebugName;
-    Unicode::UTF8ToUTF16String(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
+    Unicode::UTF8ToWideString(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
     IFT(pCompiler->QueryInterface(&pCompiler2));
     IFT(pCompiler2->CompileWithDebug(
         pCompileSource, pMainFileName, pEntryPoint,
@@ -773,7 +773,7 @@ int DxcContext::Compile() {
     CComPtr<IDxcLibrary> pLibrary;
     IFT(CreateInstance(CLSID_DxcLibrary, &pLibrary));
     IFT(CreateInstance(CLSID_DxcCompiler, &pCompiler));
-    ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
+    ReadFileIntoBlob(m_dxcSupport, StringRefWide(m_Opts.InputFile), &pSource);
     IFTARG(pSource->GetBufferSize() >= 4);
 
     if (m_Opts.RecompileFromBinary) {
@@ -800,11 +800,11 @@ int DxcContext::Compile() {
       if (!m_Opts.DebugFile.empty()) {
         CComPtr<IDxcCompiler2> pCompiler2;
         CComHeapPtr<WCHAR> pDebugName;
-        Unicode::UTF8ToUTF16String(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
+        Unicode::UTF8ToWideString(m_Opts.DebugFile.str().c_str(), &outputPDBPath);
         IFT(pCompiler.QueryInterface(&pCompiler2));
         IFT(pCompiler2->CompileWithDebug(
-            pSource, StringRefUtf16(m_Opts.InputFile),
-            StringRefUtf16(m_Opts.EntryPoint), StringRefUtf16(TargetProfile),
+            pSource, StringRefWide(m_Opts.InputFile),
+            StringRefWide(m_Opts.EntryPoint), StringRefWide(TargetProfile),
             args.data(), args.size(), m_Opts.Defines.data(),
             m_Opts.Defines.size(), pIncludeHandler, &pCompileResult,
             &pDebugName, &pDebugBlob));
@@ -812,9 +812,9 @@ int DxcContext::Compile() {
           outputPDBPath += pDebugName.m_pData;
         }
       } else {
-        IFT(pCompiler->Compile(pSource, StringRefUtf16(m_Opts.InputFile),
-          StringRefUtf16(m_Opts.EntryPoint),
-          StringRefUtf16(TargetProfile), args.data(),
+        IFT(pCompiler->Compile(pSource, StringRefWide(m_Opts.InputFile),
+          StringRefWide(m_Opts.EntryPoint),
+          StringRefWide(TargetProfile), args.data(),
           args.size(), m_Opts.Defines.data(),
           m_Opts.Defines.size(), pIncludeHandler, &pCompileResult));
       }
@@ -872,7 +872,7 @@ int DxcContext::Link() {
   std::vector<LPCWSTR> wpInputFiles;
   wpInputFiles.reserve(InputFileList.size());
   for (auto &file : InputFileList) {
-    wInputFiles.emplace_back(StringRefUtf16(file.str()));
+    wInputFiles.emplace_back(StringRefWide(file.str()));
     wpInputFiles.emplace_back(wInputFiles.back().c_str());
     CComPtr<IDxcBlobEncoding> pLib;
     ReadFileIntoBlob(m_dxcSupport, wInputFiles.back().c_str(), &pLib);
@@ -889,8 +889,8 @@ int DxcContext::Link() {
   for (const std::wstring &a : argStrings)
     args.push_back(a.data());
 
-  IFT(pLinker->Link(StringRefUtf16(m_Opts.EntryPoint),
-                    StringRefUtf16(m_Opts.TargetProfile), wpInputFiles.data(),
+  IFT(pLinker->Link(StringRefWide(m_Opts.EntryPoint),
+                    StringRefWide(m_Opts.TargetProfile), wpInputFiles.data(),
                     wpInputFiles.size(), args.data(), args.size(),
                     &pLinkResult));
 
@@ -916,7 +916,7 @@ int DxcContext::Link() {
 
 int DxcContext::DumpBinary() {
   CComPtr<IDxcBlobEncoding> pSource;
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(m_Opts.InputFile), &pSource);
   return ActOnBlob(pSource.p);
 }
 
@@ -939,9 +939,9 @@ void DxcContext::Preprocess() {
   IFT(CreateInstance(CLSID_DxcLibrary, &pLibrary));
   IFT(pLibrary->CreateIncludeHandler(&pIncludeHandler));
 
-  ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(m_Opts.InputFile), &pSource);
+  ReadFileIntoBlob(m_dxcSupport, StringRefWide(m_Opts.InputFile), &pSource);
   IFT(CreateInstance(CLSID_DxcCompiler, &pCompiler));
-  IFT(pCompiler->Preprocess(pSource, StringRefUtf16(m_Opts.InputFile),
+  IFT(pCompiler->Preprocess(pSource, StringRefWide(m_Opts.InputFile),
                             args.data(), args.size(), m_Opts.Defines.data(),
                             m_Opts.Defines.size(), pIncludeHandler,
                             &pPreprocessResult));

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -314,7 +314,7 @@ private:
         if (m_bDisplayIncludeProcess) {
           std::string openFileStr;
           raw_string_ostream s(openFileStr);
-          std::string fileName = Unicode::UTF16ToUTF8StringOrThrow(lpFileName);
+          std::string fileName = Unicode::WideToUTF8StringOrThrow(lpFileName);
           s << "Opening file [" << fileName << "], stack top [" << (index-1)
             << "]\n";
           s.flush();
@@ -403,11 +403,11 @@ public:
     for (unsigned i = 0, e = entries.size(); i != e; ++i) {
       const clang::HeaderSearchOptions::Entry &E = entries[i];
       if (dxcutil::IsAbsoluteOrCurDirRelative(E.Path.c_str())) {
-        m_searchEntries.emplace_back(Unicode::UTF8ToUTF16StringOrThrow(E.Path.c_str()));
+        m_searchEntries.emplace_back(Unicode::UTF8ToWideStringOrThrow(E.Path.c_str()));
       }
       else {
         std::wstring ws(L"./");
-        ws += Unicode::UTF8ToUTF16StringOrThrow(E.Path.c_str());
+        ws += Unicode::UTF8ToWideStringOrThrow(E.Path.c_str());
         m_searchEntries.emplace_back(std::move(ws));
       }
     }
@@ -802,13 +802,13 @@ public:
 
   // fake my way toward as linux-y a file_status as I can get
   virtual int Stat(const char *lpFileName, struct stat *Status) throw() override {
-    CA2W fileName_utf16(lpFileName, CP_UTF8);
+    CA2W fileName_wide(lpFileName, CP_UTF8);
 
-    DWORD attr = GetFileAttributesW(fileName_utf16);
+    DWORD attr = GetFileAttributesW(fileName_wide);
     if (attr == INVALID_FILE_ATTRIBUTES)
       return -1;
 
-    HANDLE H = CreateFileW(fileName_utf16, 0, // Attributes only.
+    HANDLE H = CreateFileW(fileName_wide, 0, // Attributes only.
                            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
                            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL);
     if (H == INVALID_HANDLE_VALUE)

--- a/tools/clang/tools/dxcompiler/dxclibrary.cpp
+++ b/tools/clang/tools/dxcompiler/dxclibrary.cpp
@@ -216,6 +216,8 @@ public:
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
   HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
+  HRESULT STDMETHODCALLTYPE GetBlobAsWide(
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
 };
 
 class DxcUtils : public IDxcUtils {
@@ -312,10 +314,15 @@ public:
     return ::hlsl::DxcGetBlobAsUtf8(pBlob, m_pMalloc, pBlobEncoding);
   }
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf16 **pBlobEncoding) override {
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) override {
+    return GetBlobAsWide(pBlob, pBlobEncoding);
+  }
+
+  virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) override {
     DxcThreadMalloc TM(m_pMalloc);
     try {
-      return ::hlsl::DxcGetBlobAsUtf16(pBlob, m_pMalloc, pBlobEncoding);
+      return ::hlsl::DxcGetBlobAsWide(pBlob, m_pMalloc, pBlobEncoding);
     }
     CATCH_CPP_RETURN_HRESULT();
   }
@@ -569,7 +576,12 @@ HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsUtf8(
 
 HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsUtf16(
   _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) {
-  CComPtr<IDxcBlobUtf16> pBlobUtf16;
+  return GetBlobAsWide(pBlob, pBlobEncoding);
+}
+
+HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsWide(
+  _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) {
+  CComPtr<IDxcBlobWide> pBlobUtf16;
   IFR(self.GetBlobAsUtf16(pBlob, &pBlobUtf16));
   IFR(pBlobUtf16->QueryInterface(pBlobEncoding));
   return S_OK;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -679,17 +679,17 @@ public:
 
       // Formerly API values.
       const char *pUtf8SourceName = opts.InputFile.empty() ? "hlsl.hlsl" : opts.InputFile.data();
-      CA2W pUtf16SourceName(pUtf8SourceName, CP_UTF8);
+      CA2W pWideSourceName(pUtf8SourceName, CP_UTF8);
       const char *pUtf8EntryPoint = opts.EntryPoint.empty() ? "main" : opts.EntryPoint.data();
       const char *pUtf8OutputName = isPreprocessing
                                     ? opts.Preprocess.data()
                                     : opts.OutputObject.empty()
                                       ? "" : opts.OutputObject.data();
-      CA2W pUtf16OutputName(isPreprocessing ?
+      CA2W pWideOutputName(isPreprocessing ?
                               opts.Preprocess.data() : pUtf8OutputName,
                             CP_UTF8);
       LPCWSTR pObjectName = (!isPreprocessing && opts.OutputObject.empty()) ?
-                            nullptr : pUtf16OutputName.m_psz;
+                            nullptr : pWideOutputName.m_psz;
       IFT(primaryOutput.SetName(pObjectName));
 
       // Wrap source in blob
@@ -728,7 +728,7 @@ public:
 
       CComPtr<IDxcBlob> pOutputBlob;
       dxcutil::DxcArgsFileSystem *msfPtr = dxcutil::CreateDxcArgsFileSystem(
-          utf8Source, pUtf16SourceName.m_psz, pIncludeHandler,
+          utf8Source, pWideSourceName.m_psz, pIncludeHandler,
           opts.DefaultTextCodePage);
       std::unique_ptr<::llvm::sys::fs::MSFileSystem> msf(msfPtr);
 
@@ -852,7 +852,7 @@ public:
           compiler.getCodeGenOpts().BindingTableParser.reset(new BindingTableParserImpl(compiler, opts.BindingTableDefine));
         }
         else if (opts.ImportBindingTable.size()) {
-          hlsl::options::StringRefUtf16 wstrRef(opts.ImportBindingTable);
+          hlsl::options::StringRefWide wstrRef(opts.ImportBindingTable);
           CComPtr<IDxcBlob> pBlob;
           std::string error;
           llvm::raw_string_ostream os(error);
@@ -1060,7 +1060,7 @@ public:
           SerializeFlags |= SerializeDxilFlags::StripRootSignature;
         }
         if (!opts.RootSignatureSource.empty()) {
-          hlsl::options::StringRefUtf16 wstrRef(opts.RootSignatureSource);
+          hlsl::options::StringRefWide wstrRef(opts.RootSignatureSource);
           std::string error;
           llvm::raw_string_ostream os(error);
           if (!pIncludeHandler) {
@@ -1078,7 +1078,7 @@ public:
           }
         }
         if (!opts.PrivateSource.empty()) {
-          hlsl::options::StringRefUtf16 wstrRef(opts.PrivateSource);
+          hlsl::options::StringRefWide wstrRef(opts.PrivateSource);
           std::string error;
           llvm::raw_string_ostream os(error);
           if (!pIncludeHandler) {
@@ -1829,7 +1829,7 @@ HRESULT DxcCompilerAdapter::WrapCompile(
     CComHeapPtr<wchar_t> pDebugNameOnComHeap;
     CComPtr<IDxcBlob> pDebugBlob;
     if (SUCCEEDED(hr)) {
-      CComPtr<IDxcBlobUtf16> pDebugName;
+      CComPtr<IDxcBlobWide> pDebugName;
       hr = pResult->GetOutput(DXC_OUT_PDB, IID_PPV_ARGS(&pDebugBlob), &pDebugName);
       if (SUCCEEDED(hr) && ppDebugBlobName && pDebugName) {
         if (!pDebugNameOnComHeap.AllocateBytes(pDebugName->GetBufferSize()))

--- a/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
+++ b/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
@@ -65,7 +65,7 @@ int main(int argc, const char **argv_) {
     llvm::errs() << "Required input file argument is missing\n";
     return DXC_E_GENERAL_INTERNAL_ERROR;
   }
-  hlsl::options::StringRefUtf16 filename(argv_[1]);
+  hlsl::options::StringRefWide filename(argv_[1]);
 
   // Read input file.
   dxc::DxcDllSupport dxcSupport;

--- a/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
+++ b/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
@@ -201,8 +201,8 @@ HRESULT CompileFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
       linker->RegisterLibrary(hashList.back(), pOutputBlob);
       pOutputBlob.Detach(); // Ownership is in libCache.
     }
-    std::wstring wEntry = Unicode::UTF8ToUTF16StringOrThrow(pEntrypoint);
-    std::wstring wTarget = Unicode::UTF8ToUTF16StringOrThrow(Target);
+    std::wstring wEntry = Unicode::UTF8ToWideStringOrThrow(pEntrypoint);
+    std::wstring wTarget = Unicode::UTF8ToWideStringOrThrow(Target);
 
     // Link
 #ifdef LIB_SHARE_DBG

--- a/tools/clang/tools/dxopt/dxopt.cpp
+++ b/tools/clang/tools/dxopt/dxopt.cpp
@@ -106,7 +106,7 @@ static void PrintOptOutput(LPCWSTR pFileName, IDxcBlob *pBlob, IDxcBlobEncoding 
   CComPtr<IDxcLibrary> pLibrary;
   CComPtr<IDxcBlobEncoding> pOutputText16;
   IFT(g_DxcSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-  IFT(pLibrary->GetBlobAsUtf16(pOutputText, &pOutputText16));
+  IFT(pLibrary->GetBlobAsWide(pOutputText, &pOutputText16));
   wprintf(L"%*s", (int)pOutputText16->GetBufferSize(),
           (wchar_t *)pOutputText16->GetBufferPointer());
   if (pBlob && pFileName && *pFileName) {
@@ -164,9 +164,9 @@ static void ReadFileOpts(LPCWSTR pPassFileName, IDxcBlobEncoding **ppPassOpts, s
   }
 
   CComPtr<IDxcBlob> pPassOptsBlob;
-  CComPtr<IDxcBlobUtf16> pPassOpts;
+  CComPtr<IDxcBlobWide> pPassOpts;
   BlobFromFile(pPassFileName, &pPassOptsBlob);
-  IFT(hlsl::DxcGetBlobAsUtf16(pPassOptsBlob, hlsl::GetGlobalHeapMalloc(), &pPassOpts));
+  IFT(hlsl::DxcGetBlobAsWide(pPassOptsBlob, hlsl::GetGlobalHeapMalloc(), &pPassOpts));
   LPWSTR pCursor = const_cast<LPWSTR>(pPassOpts->GetStringPointer());
   while (*pCursor) {
     passes.push_back(pCursor);

--- a/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcdxrfallbackcompiler.cpp
@@ -209,7 +209,7 @@ static inline std::string GetUnmangledName(StringRef name) {
 
 static Function* getFunctionFromName(Module &M, const std::wstring& exportName) {
     for (auto F = M.begin(), E = M.end(); F != E; ++F) {
-        std::wstring functionName = Unicode::UTF8ToUTF16StringOrThrow(GetUnmangledName(F->getName()).c_str());
+        std::wstring functionName = Unicode::UTF8ToWideStringOrThrow(GetUnmangledName(F->getName()).c_str());
         if (exportName == functionName) {
             return F;
         }

--- a/tools/clang/tools/dxv/dxv.cpp
+++ b/tools/clang/tools/dxv/dxv.cpp
@@ -52,7 +52,7 @@ public:
 void DxvContext::Validate() {
   {
     CComPtr<IDxcBlobEncoding> pSource;
-    ReadFileIntoBlob(m_dxcSupport, StringRefUtf16(InputFilename), &pSource);
+    ReadFileIntoBlob(m_dxcSupport, StringRefWide(InputFilename), &pSource);
 
     bool bSourceIsDxilContainer = hlsl::IsValidDxilContainer(
         hlsl::IsDxilContainerLike(pSource->GetBufferPointer(),
@@ -109,7 +109,7 @@ void DxvContext::Validate() {
         if (bSourceIsDxilContainer) {
           const hlsl::DxilContainerHeader *pHeader = hlsl::IsDxilContainerLike(
               pSource->GetBufferPointer(), pSource->GetBufferSize());
-          WriteBlobToFile(pSource, StringRefUtf16(OutputFilename), CP_ACP);
+          WriteBlobToFile(pSource, StringRefWide(OutputFilename), CP_ACP);
           if (memcmp(&pHeader->Hash, &origHash,
                      sizeof(hlsl::DxilContainerHash)) != 0) {
             printf("Signed DxilContainer written to \"%s\"\n", OutputFilename.c_str());

--- a/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
+++ b/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
@@ -44,7 +44,7 @@ bool translateFileWithDxil2Spv(const llvm::StringRef inputFilePath,
                                std::string *errorMessages) {
   bool success = true;
 
-  hlsl::options::StringRefUtf16 filename(inputFilePath);
+  hlsl::options::StringRefWide filename(inputFilePath);
 
   std::string stdoutStr;
   std::string stderrStr;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -597,7 +597,7 @@ public:
       CComPtr<IDxcBlobEncoding> errors;
       VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&errors));
 #ifndef _HLK_CONF
-      LogCommentFmt(L"Failed to compile shader: %s", BlobToUtf16(errors).data());
+      LogCommentFmt(L"Failed to compile shader: %s", BlobToWide(errors).data());
 #endif
     }
     VERIFY_SUCCEEDED(resultCode);

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -267,24 +267,24 @@ TEST_F(OptionsTest, ReadOptionsForApiWhenApiArgMissingThenOK) {
 
 
 TEST_F(OptionsTest, ConvertWhenFailThenThrow) {
-  std::wstring utf16;
+  std::wstring wstr;
 
   // Simple test to verify conversion works.
-  EXPECT_EQ(true, Unicode::UTF8ToUTF16String("test", &utf16));
-  EXPECT_STREQW(L"test", utf16.data());
+  EXPECT_EQ(true, Unicode::UTF8ToWideString("test", &wstr));
+  EXPECT_STREQW(L"test", wstr.data());
 
   // Simple test to verify conversion works with actual UTF-8 and not just ASCII.
   // n with tilde is Unicode 0x00F1, encoded in UTF-8 as 0xC3 0xB1
-  EXPECT_EQ(true, Unicode::UTF8ToUTF16String("\xC3\xB1", &utf16));
-  EXPECT_STREQW(L"\x00F1", utf16.data());
+  EXPECT_EQ(true, Unicode::UTF8ToWideString("\xC3\xB1", &wstr));
+  EXPECT_STREQW(L"\x00F1", wstr.data());
 
   // Fail when the sequence is incomplete.
-  EXPECT_EQ(false, Unicode::UTF8ToUTF16String("\xC3", &utf16));
+  EXPECT_EQ(false, Unicode::UTF8ToWideString("\xC3", &wstr));
 
   // Throw on failure.
   bool thrown = false;
   try {
-    Unicode::UTF8ToUTF16StringOrThrow("\xC3");
+    Unicode::UTF8ToWideStringOrThrow("\xC3");
   }
   catch (...) {
     thrown = true;

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -75,10 +75,10 @@ public:
   TEST_METHOD(RunIncludes);
   TEST_METHOD(RunStructMethods);
   TEST_METHOD(RunPredefines);
-  TEST_METHOD(RunUTF16OneByte);
-  TEST_METHOD(RunUTF16TwoByte);
-  TEST_METHOD(RunUTF16ThreeByteBadChar);
-  TEST_METHOD(RunUTF16ThreeByte);
+  TEST_METHOD(RunWideOneByte);
+  TEST_METHOD(RunWideTwoByte);
+  TEST_METHOD(RunWideThreeByteBadChar);
+  TEST_METHOD(RunWideThreeByte);
   TEST_METHOD(RunNonUnicode);
   TEST_METHOD(RunEffect);
   TEST_METHOD(RunSemanticDefines);
@@ -239,7 +239,7 @@ public:
         ::WEX::Logging::Log::Error(L"\nCompilation failed.\n");
         CComPtr<IDxcBlobEncoding> pErrorBuffer;
         IFT((*ppResult)->GetErrorBuffer(&pErrorBuffer));
-        std::wstring errorStr = BlobToUtf16(pErrorBuffer);
+        std::wstring errorStr = BlobToWide(pErrorBuffer);
         ::WEX::Logging::Log::Error(errorStr.data());
         VERIFY_SUCCEEDED(hrStatus);
         return;
@@ -408,15 +408,15 @@ TEST_F(RewriterTest, RunPredefines) {
 
 static const UINT32 CP_UTF16 = 1200;
 
-TEST_F(RewriterTest, RunUTF16OneByte) {
+TEST_F(RewriterTest, RunWideOneByte) {
   CComPtr<IDxcRewriter> pRewriter;
   VERIFY_SUCCEEDED(CreateRewriter(&pRewriter));
   CComPtr<IDxcOperationResult> pRewriteResult;
 
-  WCHAR utf16text[] = { L"\x0069\x006e\x0074\x0020\x0069\x003b" }; // "int i;"
+  WCHAR widetext[] = { L"\x0069\x006e\x0074\x0020\x0069\x003b" }; // "int i;"
 
   CComPtr<IDxcBlobEncoding> source;
-  CreateBlobPinned(utf16text, sizeof(utf16text), CP_UTF16, &source);
+  CreateBlobPinned(widetext, sizeof(widetext), DXC_CP_WIDE, &source);
 
   VERIFY_SUCCEEDED(pRewriter->RewriteUnchanged(source, 0, 0, &pRewriteResult));
 
@@ -426,15 +426,15 @@ TEST_F(RewriterTest, RunUTF16OneByte) {
   VERIFY_IS_TRUE(strcmp(BlobToUtf8(result).c_str(), "// Rewrite unchanged result:\n\x63\x6f\x6e\x73\x74\x20\x69\x6e\x74\x20\x69\x3b\n") == 0); // const added by default
 }
 
-TEST_F(RewriterTest, RunUTF16TwoByte) {
+TEST_F(RewriterTest, RunWideTwoByte) {
   CComPtr<IDxcRewriter> pRewriter;
   VERIFY_SUCCEEDED(CreateRewriter(&pRewriter));
   CComPtr<IDxcOperationResult> pRewriteResult;
 
-  WCHAR utf16text[] = { L"\x0069\x006e\x0074\x0020\x00ed\x00f1\x0167\x003b" }; // "int (i w/ acute)(n w/tilde)(t w/ 2 strokes);"
+  WCHAR widetext[] = { L"\x0069\x006e\x0074\x0020\x00ed\x00f1\x0167\x003b" }; // "int (i w/ acute)(n w/tilde)(t w/ 2 strokes);"
 
   CComPtr<IDxcBlobEncoding> source;
-  CreateBlobPinned(utf16text, sizeof(utf16text), CP_UTF16, &source);
+  CreateBlobPinned(widetext, sizeof(widetext), DXC_CP_WIDE, &source);
 
   VERIFY_SUCCEEDED(pRewriter->RewriteUnchanged(source, 0, 0, &pRewriteResult));
 
@@ -444,15 +444,15 @@ TEST_F(RewriterTest, RunUTF16TwoByte) {
   VERIFY_IS_TRUE(strcmp(BlobToUtf8(result).c_str(), "// Rewrite unchanged result:\n\x63\x6f\x6e\x73\x74\x20\x69\x6e\x74\x20\xc3\xad\xc3\xb1\xc5\xa7\x3b\n") == 0); // const added by default
 }
 
-TEST_F(RewriterTest, RunUTF16ThreeByteBadChar) {
+TEST_F(RewriterTest, RunWideThreeByteBadChar) {
   CComPtr<IDxcRewriter> pRewriter;
   VERIFY_SUCCEEDED(CreateRewriter(&pRewriter));
   CComPtr<IDxcOperationResult> pRewriteResult;
 
-  WCHAR utf16text[] = { L"\x0069\x006e\x0074\x0020\x0041\x2655\x265a\x003b" }; // "int A(white queen)(black king);"
+  WCHAR widetext[] = { L"\x0069\x006e\x0074\x0020\x0041\x2655\x265a\x003b" }; // "int A(white queen)(black king);"
 
   CComPtr<IDxcBlobEncoding> source;
-  CreateBlobPinned(utf16text, sizeof(utf16text), CP_UTF16, &source);
+  CreateBlobPinned(widetext, sizeof(widetext), DXC_CP_WIDE, &source);
 
   VERIFY_SUCCEEDED(pRewriter->RewriteUnchanged(source, 0, 0, &pRewriteResult));
 
@@ -462,15 +462,15 @@ TEST_F(RewriterTest, RunUTF16ThreeByteBadChar) {
   VERIFY_IS_TRUE(strcmp(BlobToUtf8(result).c_str(), "// Rewrite unchanged result:\n\x63\x6f\x6e\x73\x74\x20\x69\x6e\x74\x20\x41\x3b\n") == 0); //"const int A;" -> should remove the weird characters
 }
 
-TEST_F(RewriterTest, RunUTF16ThreeByte) {
+TEST_F(RewriterTest, RunWideThreeByte) {
   CComPtr<IDxcRewriter> pRewriter;
   VERIFY_SUCCEEDED(CreateRewriter(&pRewriter));
   CComPtr<IDxcOperationResult> pRewriteResult;
 
-  WCHAR utf16text[] = { L"\x0069\x006e\x0074\x0020\x1e8b\x003b" }; // "int (x with dot above);"
+  WCHAR widetext[] = { L"\x0069\x006e\x0074\x0020\x1e8b\x003b" }; // "int (x with dot above);"
 
   CComPtr<IDxcBlobEncoding> source;
-  CreateBlobPinned(utf16text, sizeof(utf16text), CP_UTF16, &source);
+  CreateBlobPinned(widetext, sizeof(widetext), DXC_CP_WIDE, &source);
 
   VERIFY_SUCCEEDED(pRewriter->RewriteUnchanged(source, 0, 0, &pRewriteResult));
 
@@ -740,7 +740,7 @@ TEST_F(RewriterTest, RunRewriterFails) {
   ::WEX::Logging::Log::Comment(L"\nCompilation failed as expected.\n");
   CComPtr<IDxcBlobEncoding> pErrorBuffer;
   IFT(pRewriteResult->GetErrorBuffer(&pErrorBuffer));
-  std::wstring errorStr = BlobToUtf16(pErrorBuffer);
+  std::wstring errorStr = BlobToWide(pErrorBuffer);
   
   ::WEX::Logging::Log::Comment(errorStr.data());
 

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -24,7 +24,7 @@
 
 #include "dxc/dxcapi.h"             // IDxcCompiler
 #include "dxc/Support/Global.h"     // OutputDebugBytes
-#include "dxc/Support/Unicode.h"    // IsStarMatchUTF16
+#include "dxc/Support/Unicode.h"    // IsStarMatchWide
 #include "dxc/Support/dxcapi.use.h" // DxcDllSupport
 #include "dxc/DXIL/DxilConstants.h" // ComponentType
 #include "WexTestClass.h"           // TAEF
@@ -104,7 +104,7 @@ bool UseHardwareDevice(const DXGI_ADAPTER_DESC1 &desc, LPCWSTR AdapterName) {
 
   if (!AdapterName)
     return true;
-  return Unicode::IsStarMatchUTF16(AdapterName, wcslen(AdapterName),
+  return Unicode::IsStarMatchWide(AdapterName, wcslen(AdapterName),
                                    desc.Description, wcslen(desc.Description));
 }
 
@@ -798,9 +798,9 @@ void ShaderOpTest::CreateShaders() {
       CHECK_HR(pResult->GetResult(&pCode));
       CComPtr<IDxcBlobEncoding> pBlob;
       CHECK_HR(pCompiler->Disassemble((IDxcBlob *)pCode, (IDxcBlobEncoding **)&pBlob));
-      CComPtr<IDxcBlobEncoding> pUtf16Blob;
-      pLibrary->GetBlobAsUtf16(pBlob, &pUtf16Blob);
-      hlsl_test::LogCommentFmt(L"%*s", (int)pUtf16Blob->GetBufferSize() / 2, (LPCWSTR)pUtf16Blob->GetBufferPointer());
+      CComPtr<IDxcBlobEncoding> pWideBlob;
+      pLibrary->GetBlobAsWide(pBlob, &pWideBlob);
+      hlsl_test::LogCommentFmt(L"%*s", (int)pWideBlob->GetBufferSize() / 2, (LPCWSTR)pWideBlob->GetBufferPointer());
 #endif
     } else {
       CComPtr<ID3DBlob> pError;

--- a/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
+++ b/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
@@ -134,7 +134,7 @@ int main()
     // Save shader binary.
     //
     CComPtr<IDxcBlob> pShader = nullptr;
-    CComPtr<IDxcBlobUtf16> pShaderName = nullptr;
+    CComPtr<IDxcBlobWide> pShaderName = nullptr;
     if (SUCCEEDED(pResults->GetOutput(DXC_OUT_OBJECT, IID_PPV_ARGS(&pShader), &pShaderName)) &&
         pShader != nullptr)
     {
@@ -149,7 +149,7 @@ int main()
     // Save pdb.
     //
     CComPtr<IDxcBlob> pPDB = nullptr;
-    CComPtr<IDxcBlobUtf16> pPDBName = nullptr;
+    CComPtr<IDxcBlobWide> pPDBName = nullptr;
     if(SUCCEEDED(pResults->GetOutput(DXC_OUT_PDB, IID_PPV_ARGS(&pPDB), &pPDBName)))
     {
         FILE* fp = NULL;

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -291,7 +291,7 @@ static void AddOutputsToFileMap(IUnknown *pUnkResult, FileMap *pVFS) {
     if (SUCCEEDED(pUnkResult->QueryInterface(IID_PPV_ARGS(&pResult)))) {
       for (unsigned i = 0; i < pResult->GetNumOutputs(); i++) {
         CComPtr<IDxcBlob> pOutput;
-        CComPtr<IDxcBlobUtf16> pOutputName;
+        CComPtr<IDxcBlobWide> pOutputName;
         if (SUCCEEDED(pResult->GetOutput(pResult->GetOutputByIndex(i),
                                 IID_PPV_ARGS(&pOutput), &pOutputName)) &&
             pOutput && pOutputName && pOutputName->GetStringLength() > 0) {
@@ -315,9 +315,9 @@ static HRESULT CompileForHash(hlsl::options::DxcOpts &opts, LPCWSTR CommandFileN
   CComPtr<IDxcBlob> pPDBBlob;
 
   std::wstring entry =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.EntryPoint.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.EntryPoint.str().c_str());
   std::wstring profile =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.TargetProfile.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.TargetProfile.str().c_str());
 
   IFT(DllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
   IFT(pLibrary->CreateBlobFromFile(CommandFileName, nullptr, &pSource));
@@ -476,9 +476,9 @@ FileRunCommandResult FileRunCommandPart::RunDxc(dxc::DxcDllSupport &DllSupport, 
   if (readOptsResult.ExitCode) return readOptsResult;
 
   std::wstring entry =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.EntryPoint.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.EntryPoint.str().c_str());
   std::wstring profile =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.TargetProfile.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.TargetProfile.str().c_str());
   std::vector<LPCWSTR> flags;
   if (opts.CodeGenHighLevel) {
     flags.push_back(L"-fcgl");
@@ -643,7 +643,7 @@ FileRunCommandResult FileRunCommandPart::RunOpt(dxc::DxcDllSupport &DllSupport, 
   std::vector<std::wstring> optionStrings;
   for (llvm::StringRef S : splitArgs) {
     optionStrings.push_back(
-        Unicode::UTF8ToUTF16StringOrThrow(strtrim(S.str()).c_str()));
+        Unicode::UTF8ToWideStringOrThrow(strtrim(S.str()).c_str()));
   }
 
   // Add the options outside the above loop in case the vector is resized.
@@ -740,7 +740,7 @@ FileRunCommandResult FileRunCommandPart::RunDxr(dxc::DxcDllSupport &DllSupport, 
   if (readOptsResult.ExitCode) return readOptsResult;
 
   std::wstring entry =
-    Unicode::UTF8ToUTF16StringOrThrow(opts.EntryPoint.str().c_str());
+    Unicode::UTF8ToWideStringOrThrow(opts.EntryPoint.str().c_str());
 
   std::vector<LPCWSTR> flags;
   std::vector<std::wstring> argWStrings;
@@ -787,9 +787,9 @@ FileRunCommandResult FileRunCommandPart::RunLink(dxc::DxcDllSupport &DllSupport,
   if (readOptsResult.ExitCode) return readOptsResult;
 
   std::wstring entry =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.EntryPoint.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.EntryPoint.str().c_str());
   std::wstring profile =
-      Unicode::UTF8ToUTF16StringOrThrow(opts.TargetProfile.str().c_str());
+      Unicode::UTF8ToWideStringOrThrow(opts.TargetProfile.str().c_str());
   std::vector<LPCWSTR> flags;
 
   // Skip targets that require a newer compiler or validator.
@@ -825,11 +825,11 @@ FileRunCommandResult FileRunCommandPart::RunLink(dxc::DxcDllSupport &DllSupport,
   // Parse semicolon separated list of library names.
   llvm::StringRef optLibraries = opts.Args.getLastArgValue(hlsl::options::OPT_INPUT);
   auto libs_utf8 = strtok(optLibraries.str().c_str(), ";");
-  std::vector<std::wstring> libs_utf16;
+  std::vector<std::wstring> libs_wide;
   for (auto name : libs_utf8)
-    libs_utf16.emplace_back(Unicode::UTF8ToUTF16StringOrThrow(name.c_str()));
+    libs_wide.emplace_back(Unicode::UTF8ToWideStringOrThrow(name.c_str()));
   std::vector<LPCWSTR> libNames;
-  for (auto &name : libs_utf16)
+  for (auto &name : libs_wide)
     libNames.emplace_back(name.data());
 
   CComPtr<IDxcLibrary> pLibrary;


### PR DESCRIPTION
In many cases, systems where wchar was represented as 32-bits were being
referred to by types and variables affixed with "utf16" or similar
consistent with what they are on windows. To avoid confusion, this
renames all such places to "wide".

In a few cases, conversions were explicitly 16-bit, which wasn't the
intent. They have been converted to platform-specific wide char
conversions