### PR TITLE
Enable Container Builder on *nix

### DIFF
--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -88,13 +88,12 @@
 #define FALSE 0
 #define TRUE 1
 
-#define REGDB_E_CLASSNOTREG 1
-
 // We ignore the code page completely on Linux.
 #define GetConsoleOutputCP() 0
 
 #define _HRESULT_TYPEDEF_(_sc) ((HRESULT)_sc)
 #define DISP_E_BADINDEX _HRESULT_TYPEDEF_(0x8002000BL)
+#define REGDB_E_CLASSNOTREG _HRESULT_TYPEDEF_(0x80040154L)
 
 // This is an unsafe conversion. If needed, we can later implement a safe
 // conversion that throws exceptions for overflow cases.

--- a/tools/clang/tools/dxcompiler/dxcapi.cpp
+++ b/tools/clang/tools/dxcompiler/dxcapi.cpp
@@ -105,6 +105,9 @@ static HRESULT ThreadMallocDxcCreateInstance(
   else if (IsEqualCLSID(rclsid, CLSID_DxcIntelliSense)) {
     hr = CreateDxcIntelliSense(riid, ppv);
   }
+  else if (IsEqualCLSID(rclsid, CLSID_DxcContainerBuilder)) {
+    hr = CreateDxcContainerBuilder(riid, ppv);
+  }
 // Note: The following targets are not yet enabled for non-Windows platforms.
 #ifdef _WIN32
   else if (IsEqualCLSID(rclsid, CLSID_DxcRewriter)) {
@@ -118,9 +121,6 @@ static HRESULT ThreadMallocDxcCreateInstance(
   }
   else if (IsEqualCLSID(rclsid, CLSID_DxcLinker)) {
     hr = CreateDxcLinker(riid, ppv);
-  }
-  else if (IsEqualCLSID(rclsid, CLSID_DxcContainerBuilder)) {
-    hr = CreateDxcContainerBuilder(riid, ppv);
   }
   else if (IsEqualCLSID(rclsid, CLSID_DxcPdbUtils)) {
     hr = CreateDxcPdbUtils(riid, ppv);

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -304,11 +304,9 @@ public:
  
   void TestPdbUtils(bool bSlim, bool bLegacy, bool bStrip);
 
-#ifdef _WIN32 // No ContainerBuilder support yet
   HRESULT CreateContainerBuilder(IDxcContainerBuilder **ppResult) {
     return m_dllSupport.CreateInstance(CLSID_DxcContainerBuilder, ppResult);
   }
-#endif
 
   template <typename T, typename TDefault, typename TIface>
   void WriteIfValue(TIface *pSymbol, std::wstringstream &o,
@@ -878,8 +876,6 @@ TEST_F(CompilerTest, CompileWhenWorksThenDisassembleWorks) {
   // WEX::Logging::Log::Comment(disassembleStringW.m_psz);
 }
 
-#ifdef _WIN32 // Container builder unsupported
-
 TEST_F(CompilerTest, CompileWhenDebugWorksThenStripDebug) {
   CComPtr<IDxcCompiler> pCompiler;
   CComPtr<IDxcOperationResult> pResult;
@@ -1054,6 +1050,7 @@ TEST_F(CompilerTest, CompileThenAddCustomDebugName) {
   VERIFY_IS_NULL(pPartHeader);
 }
 
+#ifdef _WIN32 // No PDBUtil support
 static void VerifyPdbUtil(dxc::DxcDllSupport &dllSupport,
     IDxcBlob *pBlob, IDxcPdbUtils *pPdbUtils,
     const WCHAR *pMainFileName,
@@ -1492,7 +1489,6 @@ static void VerifyPdbUtil(dxc::DxcDllSupport &dllSupport,
   }
 }
 
-#ifdef _WIN32
 
 TEST_F(CompilerTest, CompileThenTestPdbUtilsStripped) {
   if (m_ver.SkipDxilVersion(1, 5)) return;
@@ -2009,7 +2005,7 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsEmptyEntry) {
   VERIFY_ARE_EQUAL(pEntryName, L"main");
 }
 
-#endif
+#endif //  _WIN32 - No PDBUtil support
 
 void CompilerTest::TestResourceBindingImpl(
   const char *bindingFileContent,
@@ -2353,6 +2349,7 @@ TEST_F(CompilerTest, CompileWithRootSignatureThenStripRootSignature) {
   VERIFY_IS_NOT_NULL(pPartHeader);
 }
 
+#if _WIN32 // API -setrootsignature requires reflection, which isn't supported on non-win
 TEST_F(CompilerTest, CompileThenSetRootSignatureThenValidate) {
   CComPtr<IDxcCompiler> pCompiler;
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
@@ -2487,7 +2484,7 @@ TEST_F(CompilerTest, CompileThenSetRootSignatureThenValidate) {
                              pRSBlobReplace->GetBufferPointer(),
                              pRSBlob->GetBufferSize()));
 }
-
+#endif // _WIN32 - API -setrootsignature requires reflection, which isn't supported on non-win
 TEST_F(CompilerTest, CompileSetPrivateThenWithStripPrivate) {
   CComPtr<IDxcCompiler> pCompiler;
   CComPtr<IDxcOperationResult> pResult;
@@ -2608,7 +2605,6 @@ TEST_F(CompilerTest, CompileWithMultiplePrivateOptionsThenFail) {
       "Cannot specify /Qpdb_in_private and /setprivate together.";
   CheckOperationResultMsgs(pResult, &pErrorMsg2, 1, false, false);
 }
-#endif // Container builder unsupported
 
 TEST_F(CompilerTest, CompileWhenIncludeThenLoadInvoked) {
   CComPtr<IDxcCompiler> pCompiler;

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -601,7 +601,7 @@ bool DxilContainerTest::InitSupport() {
   return true;
 }
 
-#ifdef _WIN32
+#ifdef _WIN32 // - No reflection support
 TEST_F(DxilContainerTest, CompileWhenDebugSourceThenSourceMatters) {
   char program1[] = "float4 main() : SV_Target { return 0; }";
   char program2[] = "  float4 main() : SV_Target { return 0; }  ";
@@ -658,6 +658,7 @@ TEST_F(DxilContainerTest, CompileWhenDebugSourceThenSourceMatters) {
   // Source hash and bin hash should be different
   VERIFY_IS_FALSE(0 == strcmp(binHash1Zss.c_str(), binHash1.c_str()));
 }
+#endif // WIN32 - No reflection support
 
 TEST_F(DxilContainerTest, ContainerBuilder_AddPrivateForceLast) {
   if (m_ver.SkipDxilVersion(1, 7)) return;
@@ -754,7 +755,6 @@ TEST_F(DxilContainerTest, ContainerBuilder_AddPrivateForceLast) {
   GetPart(pNewContainer, hlsl::DFCC_ShaderDebugInfoDXIL);
   VerifyPrivateLast(pNewContainer);
 }
-#endif // _WIN32
 
 TEST_F(DxilContainerTest, CompileWhenOKThenIncludesSignatures) {
   char program[] =


### PR DESCRIPTION
This never got enabled in dxcapi.cpp in spite of all the code to support
it being in place. This enables the creation of the interface and
enables the tests that were disabled for want of it.

As an incidental, correctly defines the REGDB_E_CLASSNOTREG which made
the lack of this interface on Linux hard to diagnose.