### PR TITLE
Fix ReplaceMemcpy IR corruption on constant user replacement.

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -3215,9 +3215,12 @@ bool SROA_Helper::DoScalarReplacement(GlobalVariable *GV,
 }
 
 static void ReplaceConstantWithInst(Constant *C, Value *V, IRBuilder<> &Builder) {
+  Function *F = Builder.GetInsertBlock()->getParent();
   for (auto it = C->user_begin(); it != C->user_end(); ) {
     User *U = *(it++);
     if (Instruction *I = dyn_cast<Instruction>(U)) {
+      if (I->getParent()->getParent() != F)
+        continue;
       I->replaceUsesOfWith(C, V);
     } else {
       // Skip unused ConstantExpr.


### PR DESCRIPTION
When replacing constant users, those users could be in functions other than the one being worked on.
The code would happily replace uses of the constant with instructions that weren't in the same function.
This would lead to bizarre consequences due to corrupt IR down the line.
This change prevents that from happenning.