### PR TITLE
Uniquely detect low 16-bit usage properly for tbuffer

### DIFF
--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -2529,11 +2529,15 @@ static unsigned GetCBOffset(Value *V, OffsetForValueMap &visited) {
 
 typedef std::map<unsigned, DxilFieldAnnotation*> FieldAnnotationByOffsetMap;
 
-static void MarkCBUse(unsigned offset, FieldAnnotationByOffsetMap &fieldMap) {
+// Returns size in bits of the field if it's a basic type, otherwise 0.
+static unsigned MarkCBUse(unsigned offset, FieldAnnotationByOffsetMap &fieldMap) {
   auto it = fieldMap.upper_bound(offset);
   it--;
-  if (it != fieldMap.end())
+  if (it != fieldMap.end()) {
     it->second->SetCBVarUsed(true);
+    return it->second->GetCompType().GetSizeInBits();
+  }
+  return 0;
 }
 
 // Detect patterns of lshr v,16 or trunc to 16-bits and return low and high
@@ -2546,11 +2550,11 @@ static unsigned DetectLowAndHighWordUsage(ExtractValueInst *EV) {
   if (EV->getType()->getScalarSizeInBits() == 32) {
     for (auto U : EV->users()) {
       Instruction *I = cast<Instruction>(U);
-      if (I->getOpcode() == LLVMLShr) {
+      if (I->getOpcode() == Instruction::LShr) {
         ConstantInt *CShift = dyn_cast<ConstantInt>(I->getOperand(1));
         if (CShift && CShift->getLimitedValue() == 16)
           result |= kHighWordUsed;
-      } else if (I->getOpcode() == LLVMTrunc &&
+      } else if (I->getOpcode() == Instruction::Trunc &&
                I->getType()->getPrimitiveSizeInBits() == 16) {
         result |= kLowWordUsed;
       } else {
@@ -2585,9 +2589,17 @@ static void MarkCBUsesForExtractElement(
     ExtractValueInst *EV, bool bMinPrecision) {
   unsigned lowHighWordUsage = 0;
   unsigned evOffset = GetOffsetForCBExtractValue(EV, bMinPrecision, lowHighWordUsage);
+
+  // For tbuffer, where value extracted is always 32-bits:
+  // If lowHighWordUsage is 0, it means 32-bits used.
+  // If field marked is < 32 bits, we still need to mark the high 16-bits as
+  // used, in case there is another 16-bit field.
+  // Since MarkCBUse could return 0 on non-basic type field, look for 16
+  // when determining whether we still need to mark high word as used.
+  bool highUnmarked = EV->getType()->getScalarSizeInBits() == 32;
   if (!lowHighWordUsage || 0 != (lowHighWordUsage & kLowWordUsed))
-    MarkCBUse(offset + evOffset, fieldMap);
-  if (lowHighWordUsage & kHighWordUsed)
+    highUnmarked &= MarkCBUse(offset + evOffset, fieldMap) == 16;
+  if (highUnmarked && (!lowHighWordUsage || 0 != (lowHighWordUsage & kHighWordUsed)))
     MarkCBUse(offset + evOffset + 2, fieldMap);
 }
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/tbuffer-16bit.hlsl
@@ -26,15 +26,28 @@ tbuffer tb : register(t1)
   int64_t i64;      // 8-bytes at 72 (6-bytes padding)
   float16_t f16b;   // 2-bytes at 80
   uint64_t u64;     // 8-bytes at 88 (6-bytes padding)
-  float16_t f16c;   // 2-bytes at 96
+  float16_t f16c;   // 2-bytes at 96 (used)
+  float16_t f16d;   // 2-bytes at 98 (unused)
+
+  // in theory, the following would be used as a single 32-bit value to test
+  // the case where a 32-bit usage needs to mark 2 16-bit fields.
+  // Unfortunately, DXC isn't smart enough to eliminate the split and re-join
+  // of the low and high words.
+  // So if the instruction count goes down for this shader, check to see if
+  // optimizations have reduced this case, so it may be testing what it
+  // originally intended.
+  uint16_t u16b, u16c;  // 4-bytes at 100 (used together as 32-bits)
+
   // overall size should be aligned to 16-byte boundary.
-  // unaligned size = 98
+  // unaligned size = 104
   // aligned size = 112
 };
 
 float main(int i : A) : SV_TARGET
 {
-  return b + mf1 + h2.y + f16_3.z + (float)(d * i64 + u64) + u16 * i16.x;
+  // Try to use two 16-bit fields together as 32-bits:
+  float fused = asfloat((uint)u16b + (((uint)u16c) << 16));
+  return b + mf1 + h2.y + f16_3.z + (float)(d * i64 + u64) + u16 * i16.x + f16c + fused;
 }
 
 // CHECK: ID3D12ShaderReflection:
@@ -45,18 +58,18 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:     BoundResources: 1
 // CHECK-NEXT:     InputParameters: 1
 // CHECK-NEXT:     OutputParameters: 1
-// CHECK-NEXT:     InstructionCount: {{58|59}}
+// CHECK-NEXT:     InstructionCount: {{76|77}}
 // CHECK-NEXT:     TempArrayCount: 0
 // CHECK-NEXT:     DynamicFlowControlCount: 0
 // CHECK-NEXT:     ArrayInstructionCount: 0
 // CHECK-NEXT:     TextureNormalInstructions: 0
-// CHECK-NEXT:     TextureLoadInstructions: 7
+// CHECK-NEXT:     TextureLoadInstructions: 9
 // CHECK-NEXT:     TextureCompInstructions: 0
 // CHECK-NEXT:     TextureBiasInstructions: 0
 // CHECK-NEXT:     TextureGradientInstructions: 0
-// CHECK-NEXT:     FloatInstructionCount: 14
-// CHECK-NEXT:     IntInstructionCount: 6
-// CHECK-NEXT:     UintInstructionCount: 11
+// CHECK-NEXT:     FloatInstructionCount: 17
+// CHECK-NEXT:     IntInstructionCount: 9
+// CHECK-NEXT:     UintInstructionCount: 16
 // CHECK-NEXT:     CutInstructionCount: 0
 // CHECK-NEXT:     EmitInstructionCount: 0
 // CHECK-NEXT:     cBarrierInstructions: 0
@@ -68,7 +81,7 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:         Type: D3D_CT_TBUFFER
 // CHECK-NEXT:         Size: 112
 // CHECK-NEXT:         uFlags: 0
-// CHECK-NEXT:         Num Variables: 16
+// CHECK-NEXT:         Num Variables: 19
 // CHECK-NEXT:       {
 // CHECK-NEXT:         ID3D12ShaderReflectionVariable:
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: b
@@ -314,12 +327,60 @@ float main(int i : A) : SV_TARGET
 // CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16c
 // CHECK-NEXT:             Size: 2
 // CHECK-NEXT:             StartOffset: 96
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: float16_t
+// CHECK-NEXT:               Class: D3D_SVC_SCALAR
+// CHECK-NEXT:               Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 1
+// CHECK-NEXT:               Members: 0
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: f16d
+// CHECK-NEXT:             Size: 2
+// CHECK-NEXT:             StartOffset: 98
 // CHECK-NEXT:             uFlags: 0
 // CHECK-NEXT:             DefaultValue: <nullptr>
 // CHECK-NEXT:           ID3D12ShaderReflectionType:
 // CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: float16_t
 // CHECK-NEXT:               Class: D3D_SVC_SCALAR
 // CHECK-NEXT:               Type: D3D_SVT_FLOAT16
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 1
+// CHECK-NEXT:               Members: 0
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: u16
+// CHECK-NEXT:             Size: 2
+// CHECK-NEXT:             StartOffset: 100
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:               Class: D3D_SVC_SCALAR
+// CHECK-NEXT:               Type: D3D_SVT_UINT16
+// CHECK-NEXT:               Elements: 0
+// CHECK-NEXT:               Rows: 1
+// CHECK-NEXT:               Columns: 1
+// CHECK-NEXT:               Members: 0
+// CHECK-NEXT:               Offset: 0
+// CHECK-NEXT:           CBuffer: tb
+// CHECK-NEXT:         ID3D12ShaderReflectionVariable:
+// CHECK-NEXT:           D3D12_SHADER_VARIABLE_DESC: Name: u16
+// CHECK-NEXT:             Size: 2
+// CHECK-NEXT:             StartOffset: 102
+// CHECK-NEXT:             uFlags: (D3D_SVF_USED)
+// CHECK-NEXT:             DefaultValue: <nullptr>
+// CHECK-NEXT:           ID3D12ShaderReflectionType:
+// CHECK-NEXT:             D3D12_SHADER_TYPE_DESC: Name: uint16_t
+// CHECK-NEXT:               Class: D3D_SVC_SCALAR
+// CHECK-NEXT:               Type: D3D_SVT_UINT16
 // CHECK-NEXT:               Elements: 0
 // CHECK-NEXT:               Rows: 1
 // CHECK-NEXT:               Columns: 1


### PR DESCRIPTION
Uniquely detect low 16-bit usage properly for tbuffer, while detecting the case where full 32-bits are used that map to two 16-bit fields, requiring both fields to be marked.