### PR TITLE
[spirv] Generate correct Shader.DebugInfo for runtime arrays.

### DIFF
--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -325,7 +325,17 @@ SpirvDebugType *DebugTypeVisitor::lowerToDebugType(const SpirvType *spirvType) {
     debugType = spvContext.getDebugTypeArray(spirvType, elemDebugType, counts);
     break;
   }
-  // TODO: Handle TK_RuntimeArray. We need spec updates for the bindless array.
+  case SpirvType::TK_RuntimeArray: {
+    auto *arrType = dyn_cast<RuntimeArrayType>(spirvType);
+    SpirvDebugInstruction *elemDebugType =
+        lowerToDebugType(arrType->getElementType());
+
+    llvm::SmallVector<uint32_t, 4> counts;
+    counts.push_back(0u);
+
+    debugType = spvContext.getDebugTypeArray(spirvType, elemDebugType, counts);
+    break;
+  }
   case SpirvType::TK_Vector: {
     auto *vecType = dyn_cast<VectorType>(spirvType);
     SpirvDebugInstruction *elemDebugType =

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.runtimearray.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.runtimearray.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+struct PSInput
+{
+    float4 color : COLOR;
+};
+
+Texture2D bindless[];
+
+sampler DummySampler;
+
+// CHECK: {{%\d+}} = OpExtInst %void {{%\d+}} DebugTypeArray {{%\d+}} %uint_0
+
+float4 main(PSInput input) : SV_TARGET
+{
+    return input.color * bindless[4].Sample(DummySampler, float2(1,1));
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3005,6 +3005,9 @@ TEST_F(FileTest, ShaderDebugInfoSource) {
 TEST_F(FileTest, ShaderDebugInfoSourceContinued) {
   runFileTest("shader.debug.sourcecontinued.hlsl");
 }
+TEST_F(FileTest, ShaderDebugInfoRuntimeArray) {
+  runFileTest("shader.debug.runtimearray.hlsl");
+}
 TEST_F(FileTest, ShaderDebugInfoLine) {
   runFileTest("shader.debug.line.hlsl");
 }


### PR DESCRIPTION
This is a common construct for bindless shaders.