### PR TITLE
WriteSemanticDefines before clang codeGen to update codeGen option

### DIFF
--- a/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
+++ b/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
@@ -14,6 +14,10 @@
 #include <vector>
 #include <string>
 
+namespace clang {
+class CodeGenOptions;
+}
+
 namespace llvm {
 class CallInst;
 class Value;
@@ -61,8 +65,8 @@ public:
   typedef std::vector<SemanticDefineError> SemanticDefineErrorList;
 
   // Write semantic defines as metadata in the module.
-  virtual SemanticDefineErrorList WriteSemanticDefines(llvm::Module *M) = 0;
-
+  virtual void WriteSemanticDefines(llvm::Module *M) = 0;
+  virtual void UpdateCodeGenOptions(clang::CodeGenOptions &CGO) = 0;
   // Query the named option enable
   // Needed because semantic defines may have set it since options were copied
   virtual bool IsOptionEnabled(std::string option) = 0;

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -2937,22 +2937,7 @@ void AddRegBindingsForResourceInConstantBuffer(
 
 // extension codegen.
 void ExtensionCodeGen(HLModule &HLM, clang::CodeGen::CodeGenModule &CGM) {
-  // Add semantic defines for extensions if any are available.
-  HLSLExtensionsCodegenHelper::SemanticDefineErrorList errors =
-      CGM.getCodeGenOpts().HLSLExtensionsCodegen->WriteSemanticDefines(
-          HLM.GetModule());
-
-  clang::DiagnosticsEngine &Diags = CGM.getDiags();
-  for (const HLSLExtensionsCodegenHelper::SemanticDefineError &error : errors) {
-    clang::DiagnosticsEngine::Level level = clang::DiagnosticsEngine::Error;
-    if (error.IsWarning())
-      level = clang::DiagnosticsEngine::Warning;
-    unsigned DiagID = Diags.getCustomDiagID(level, "%0");
-    Diags.Report(clang::SourceLocation::getFromRawEncoding(error.Location()),
-                 DiagID)
-        << error.Message();
-  }
-
+  auto &Diags = CGM.getDiags();
   // Add root signature from a #define. Overrides root signature in function
   // attribute.
   {

--- a/tools/clang/lib/CodeGen/ModuleBuilder.cpp
+++ b/tools/clang/lib/CodeGen/ModuleBuilder.cpp
@@ -211,6 +211,22 @@ namespace {
         M.reset();
         return;
       }
+      // HLSL Change Begins.
+      if (&Ctx == this->Ctx) {
+        if (Builder) {
+          // Add semantic defines for extensions if any are available.
+          auto &CodeGenOpts =
+              const_cast<CodeGenOptions &>(Builder->getCodeGenOpts());
+          if (CodeGenOpts.HLSLExtensionsCodegen) {
+            CodeGenOpts.HLSLExtensionsCodegen->WriteSemanticDefines(
+                    M.get());
+            // Builder->CodeGenOpts is a copy. So update it for every Builder.
+            CodeGenOpts.HLSLExtensionsCodegen->UpdateCodeGenOptions(
+                CodeGenOpts);
+          }
+        }
+      }
+      // HLSL Change Ends.
       if (Builder)
         Builder->Release();
 


### PR DESCRIPTION
WriteSemanticDefines before clang codeGen to update codeGen option based on HLSLOptimizationToggles.