### PR TITLE
[SM6.7] QuadAny/All execution test (1/2)

### DIFF
--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -648,11 +648,13 @@ public:
 
         if (OpKind == (uint64_t)DXIL::QuadVoteOpKind::All) {
           Value *XY = B.CreateAnd(X, Y);
-          Result = B.CreateAnd(XY, Z);
+          Value *XYZ = B.CreateAnd(XY, Z);
+          Result = B.CreateAnd(XYZ, Cond);
         } else {
           DXASSERT_NOMSG(OpKind == (uint64_t)DXIL::QuadVoteOpKind::Any);
           Value *XY = B.CreateOr(X, Y);
-          Result = B.CreateOr(XY, Z);
+          Value *XYZ = B.CreateOr(XY, Z);
+          Result = B.CreateOr(XYZ, Cond);
         }
         Value *Res = B.CreateTrunc(Result, Type::getInt1Ty(M.getContext()));
         CI->replaceAllUsesWith(Res);

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2933,29 +2933,36 @@
 ]]>
     </Shader>
   </ShaderOp>
-  <ShaderOp Name="QuadAnyAll" CS="CS" MS="MS" AS="AS" DispatchX="8" DispatchY="8">
-    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), UAV(u0)</RootSignature>
-    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="256" InitialResourceState="COPY_DEST" Init="ByName" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS" ReadBack="true" />
-    <Shader Name="MS66" Target="ms_6_6" EntryPoint="main" Text="@CS"/>
-    <Shader Name="AS66" Target="as_6_6" EntryPoint="main" Text="@CS"/>
-    <Shader Name="CS66" Target="cs_6_6" EntryPoint="main" Text="@CS"/>
-    <Shader Name="MS" Target="ms_6_7" EntryPoint="main" Text="@CS"/>
-    <Shader Name="AS" Target="as_6_7" EntryPoint="main" Text="@CS"/>
-    <Shader Name="CS" Target="cs_6_7" EntryPoint="main">
+  <ShaderOp Name="QuadAnyAll" CS="CS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="1024" InitialResourceState="COPY_DEST" Init="Zero" Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true" />
+    <RootValues>
+      <RootValue Index="0" ResName="UAVBuffer0"/>
+    </RootValues>
+    <Shader Name="CS67" Target="cs_6_7" EntryPoint="main" Text="@CS"/>
+    <Shader Name="CS" Target="cs_6_0" EntryPoint="main">
     <![CDATA[
 RWStructuredBuffer<int2> Values;
-
+groupshared uint WaveOffset = 0;
 [numthreads(8, 8, 1)]
-void main(uint3 ID: SV_DispatchThreadID) {
-  uint Idx = (ID.z * 64) + (ID.y * 8) + ID.x;
-  uint QuadId = (4*(ID.y/2) + (ID.x/2));
-  uint QuadX = ID.x % 2;
-  uint QuadY = ID.y % 2;
-  uint QuadElem = (QuadY*2) + QuadX;
-
-  uint QuadBool = 0x000F & QuadId;
-  bool ThreadBool = (QuadBool & (0x1 << QuadElem)) == 0;
-
+void main(uint TID: SV_GroupIndex) {
+  if (TID == 0)
+    WaveOffset = 0;
+  GroupMemoryBarrierWithGroupSync();
+  uint Offset = 0;
+  uint QuadElem = WaveGetLaneIndex() & 3;
+  if (QuadElem == 0)
+    Offset = WavePrefixSum(4);
+  Offset = QuadReadLaneAt(Offset, 0) + QuadElem;
+  uint LocalWaveOffset = 0;
+  if (WaveGetLaneIndex() == 0) {
+    InterlockedAdd(WaveOffset, WaveGetLaneCount(), LocalWaveOffset);
+  }
+  uint Idx = Offset + WaveReadLaneFirst(LocalWaveOffset);
+  uint2 ID = {Idx / 8, Idx % 8};
+  uint QuadId = Idx / 4;
+  uint QuadMask = 0x1U << QuadElem;
+  bool ThreadBool = (QuadMask & QuadId) != 0;
   Values[Idx].x = QuadAny(ThreadBool) ? 1 : 2;
   Values[Idx].y = QuadAll(ThreadBool) ? 3 : 4;
 }

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2933,4 +2933,33 @@
 ]]>
     </Shader>
   </ShaderOp>
+  <ShaderOp Name="QuadAnyAll" CS="CS" MS="MS" AS="AS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), UAV(u0)</RootSignature>
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="256" InitialResourceState="COPY_DEST" Init="ByName" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS" ReadBack="true" />
+    <Shader Name="MS66" Target="ms_6_6" EntryPoint="main" Text="@CS"/>
+    <Shader Name="AS66" Target="as_6_6" EntryPoint="main" Text="@CS"/>
+    <Shader Name="CS66" Target="cs_6_6" EntryPoint="main" Text="@CS"/>
+    <Shader Name="MS" Target="ms_6_7" EntryPoint="main" Text="@CS"/>
+    <Shader Name="AS" Target="as_6_7" EntryPoint="main" Text="@CS"/>
+    <Shader Name="CS" Target="cs_6_7" EntryPoint="main">
+    <![CDATA[
+RWStructuredBuffer<int2> Values;
+
+[numthreads(8, 8, 1)]
+void main(uint3 ID: SV_DispatchThreadID) {
+  uint Idx = (ID.z * 64) + (ID.y * 8) + ID.x;
+  uint QuadId = (4*(ID.y/2) + (ID.x/2));
+  uint QuadX = ID.x % 2;
+  uint QuadY = ID.y % 2;
+  uint QuadElem = (QuadY*2) + QuadX;
+
+  uint QuadBool = 0x000F & QuadId;
+  bool ThreadBool = (QuadBool & (0x1 << QuadElem)) == 0;
+
+  Values[Idx].x = QuadAny(ThreadBool) ? 1 : 2;
+  Values[Idx].y = QuadAll(ThreadBool) ? 3 : 4;
+}
+]]>
+    </Shader>
+  </ShaderOp>
 </ShaderOpSet>

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/vote/any-all.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/vote/any-all.hlsl
@@ -10,7 +10,8 @@
 // SM66-NEXT: [[y:%[a-zA-Z0-9]+]] = call i32 @dx.op.quadOp.i32(i32 123, i32 [[cond]], i8 1)
 // SM66-NEXT: [[z:%[a-zA-Z0-9]+]] = call i32 @dx.op.quadOp.i32(i32 123, i32 [[cond]], i8 2)
 // SM66-NEXT: [[xy:%[a-z0-9]+]] = or i32 [[x]], [[y]]
-// SM66-NEXT: [[wide:%[a-z0-9]+]] = or i32 [[xy]], [[z]]
+// SM66-NEXT: [[xyz:%[a-z0-9]+]] = or i32 [[xy]], [[z]]
+// SM66-NEXT: [[wide:%[a-z0-9]+]] = or i32 [[xyz]], [[cond]]
 // SM66-NEXT: [[any:%[a-z0-9]+]] = trunc i32 [[wide]] to i1 
 
 // SM67:      [[cond:%[a-z0-9]+]] = icmp ne i1 %{{[a-z0-9]+}}, false
@@ -24,7 +25,8 @@
 // SM66-NEXT: [[y:%[a-zA-Z0-9]+]] = call i32 @dx.op.quadOp.i32(i32 123, i32 [[cond]], i8 1)
 // SM66-NEXT: [[z:%[a-zA-Z0-9]+]] = call i32 @dx.op.quadOp.i32(i32 123, i32 [[cond]], i8 2)
 // SM66-NEXT: [[xy:%[a-z0-9]+]] = and i32 [[x]], [[y]]
-// SM66-NEXT: [[wide:%[a-z0-9]+]] = and i32 [[xy]], [[z]]
+// SM66-NEXT: [[xyz:%[a-z0-9]+]] = and i32 [[xy]], [[z]]
+// SM66-NEXT: [[wide:%[a-z0-9]+]] = and i32 [[xyz]], [[cond]]
 // SM66-NEXT: [[all:%[a-z0-9]+]] = trunc i32 [[wide]] to i1
 
 // SM67:      [[cond:%[a-z0-9]+]] = icmp ne i1 %{{[a-z0-9]+}}, false

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9465,7 +9465,7 @@ TEST_F(ExecutionTest, HelperLaneTestWave) {
 
   bool testPassed = true;
 
-  D3D_SHADER_MODEL TestShaderModels[] = { D3D_SHADER_MODEL_6_0 };
+  D3D_SHADER_MODEL TestShaderModels[] = { D3D_SHADER_MODEL_6_0, D3D_SHADER_MODEL_6_5, D3D_SHADER_MODEL_6_6, D3D_SHADER_MODEL_6_7 };
   for (unsigned i = 0; i < _countof(TestShaderModels); i++) {
     D3D_SHADER_MODEL sm = TestShaderModels[i];
     LogCommentFmt(L"\r\nVerifying IsHelperLane using Wave intrinsics in shader model 6.%1u", ((UINT)sm & 0x0f));


### PR DESCRIPTION
This adds a first set of execution tests for QuadAny and QuadAll to test
compute, mesh, and amplification shaders. A separate execution test will
be coming for pixel shaders.