### PR TITLE
Return empty string from CGDebugInfo::getCurrentDirname()

### DIFF
--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -292,6 +292,7 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
 }
 
 StringRef CGDebugInfo::getCurrentDirname() {
+  if (CGM.getLangOpts().HLSL) return "";  // HLSL Change
   if (!CGM.getCodeGenOpts().DebugCompilationDir.empty())
     return CGM.getCodeGenOpts().DebugCompilationDir;
 

--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -292,8 +292,8 @@ unsigned CGDebugInfo::getColumnNumber(SourceLocation Loc, bool Force) {
 }
 
 StringRef CGDebugInfo::getCurrentDirname() {
-  if (CGM.getLangOpts().HLSL) return "";  // HLSL Change
-  if (!CGM.getCodeGenOpts().DebugCompilationDir.empty())
+  if (!CGM.getCodeGenOpts().DebugCompilationDir.empty()
+      || CGM.getLangOpts().HLSL) // HLSL Change
     return CGM.getCodeGenOpts().DebugCompilationDir;
 
   if (!CWDName.empty())

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1393,11 +1393,19 @@ public:
       CGOpts.DwarfVersion = 4; // Latest version.
       // TODO: consider
       // DebugPass, DebugCompilationDir, DwarfDebugFlags, SplitDwarfFile
+
+      // Prevent attemt to fill this in automatically, which leads to call
+      // into include handler with the current working directory.
+      CGOpts.DebugCompilationDir = ".";
     }
     else {
       CodeGenOptions &CGOpts = compiler.getCodeGenOpts();
       CGOpts.setDebugInfo(CodeGenOptions::LocTrackingOnly);
       CGOpts.DebugColumnInfo = 1;
+
+      // Prevent attemt to fill this in automatically, which leads to call
+      // into include handler with the current working directory.
+      CGOpts.DebugCompilationDir = ".";
     }
 
     clang::PreprocessorOptions &PPOpts(compiler.getPreprocessorOpts());

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1393,19 +1393,11 @@ public:
       CGOpts.DwarfVersion = 4; // Latest version.
       // TODO: consider
       // DebugPass, DebugCompilationDir, DwarfDebugFlags, SplitDwarfFile
-
-      // Prevent attemt to fill this in automatically, which leads to call
-      // into include handler with the current working directory.
-      CGOpts.DebugCompilationDir = ".";
     }
     else {
       CodeGenOptions &CGOpts = compiler.getCodeGenOpts();
       CGOpts.setDebugInfo(CodeGenOptions::LocTrackingOnly);
       CGOpts.DebugColumnInfo = 1;
-
-      // Prevent attemt to fill this in automatically, which leads to call
-      // into include handler with the current working directory.
-      CGOpts.DebugCompilationDir = ".";
     }
 
     clang::PreprocessorOptions &PPOpts(compiler.getPreprocessorOpts());

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -61,21 +61,6 @@ using namespace std;
 using namespace hlsl_test;
 
 
-// Examines a virtual filename to determine if it looks like a dir
-// Based on whether the final path segment contains a dot
-// Not ironclad, but good enough for testing
-static bool LooksLikeDir(std::wstring fileName) {
-  for(int i = fileName.size() - 1; i > -1; i--) {
-    wchar_t ch = fileName[i];
-    if (ch == L'\\' || ch == L'/')
-      return true;
-    if (ch == L'.')
-      return false;
-  }
-  // No divider, no dot, assume file
-  return false;
-}
-
 class TestIncludeHandler : public IDxcIncludeHandler {
   DXC_MICROCOM_REF_FIELD(m_dwRef)
 public:
@@ -117,15 +102,7 @@ public:
     _In_ LPCWSTR pFilename,                   // Filename as written in #include statement
     _COM_Outptr_ IDxcBlob **ppIncludeSource   // Resultant source object for included file
     ) override {
-
-    LoadSourceCallInfo callInfo = LoadSourceCallInfo(pFilename);
-
-    // *nix will call stat() on dirs, which attempts to find it here
-    // This loader isn't meant for dirs, so return failure
-    if (LooksLikeDir(callInfo.Filename))
-      return m_defaultErrorCode;
-
-    CallInfos.push_back(callInfo);
+    CallInfos.push_back(LoadSourceCallInfo(pFilename));
 
     *ppIncludeSource = nullptr;
     if (callIndex >= CallResults.size()) {


### PR DESCRIPTION
Include handler is only meant to handle file requests.  However, if DebugCompilationDir is not set, CGDebugInfo::getCurrentDirname() will try to get the current working directory, and on (*nix) it will expand $PWD, then perform status() on that.  With a virtualized file system backed only by an include handler, you can't get thet status of files or directories, so failing the directory detection, it will attempt to open the file, which results in a call to get the file contents of the current working directory from the include handler.

The approach here is just to return DebugCompilationDir on HLSL, even if empty.

This prevents it from trying to fill it in automatically, cutting
off the path normally causing this problem.

Fixes #4212