### PR TITLE
[spirv] change __spirv definition to __spirv__

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -364,12 +364,12 @@ Macro for SPIR-V
 
 If SPIR-V CodeGen is enabled and ``-spirv`` flag is used as one of the command
 line options (meaning that "generates SPIR-V code"), it defines an implicit
-macro ``__spirv``. For example, this macro definition can be used for SPIR-V
+macro ``__spirv__``. For example, this macro definition can be used for SPIR-V
 specific part of the HLSL code:
 
 .. code:: hlsl
 
-  #ifdef __spirv
+  #ifdef __spirv__
   [[vk::binding(X, Y), vk::counter_binding(Z)]]
   #endif
   RWStructuredBuffer<S> mySBuffer;

--- a/tools/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/tools/clang/lib/Frontend/InitPreprocessor.cpp
@@ -396,7 +396,7 @@ static void InitializeStandardPredefinedMacros(const TargetInfo &TI,
     // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN
     if (LangOpts.SPIRV) {
-      Builder.defineMacro("__spirv");
+      Builder.defineMacro("__spirv__");
     }
 #endif // ENABLE_SPIRV_CODEGEN
     // SPIRV Change Ends

--- a/tools/clang/test/CodeGenSPIRV/ifdef.spirv.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/ifdef.spirv.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T ps_6_0 -E main
 
-#ifndef __spirv
+#ifndef __spirv__
 [[vk::constant_id(1)]] const float foo = 0.3;
 #endif
 
-#ifdef __spirv
+#ifdef __spirv__
 [[vk::constant_id(1)]] const float bar = 0.3;
 #endif
 
@@ -15,7 +15,7 @@ float4 main(float4 color : COLOR) : SV_TARGET
 
 // CHECK-NOT: error: use of undeclared identifier 'bar'
 // CHECK:     error: use of undeclared identifier 'zoo'
-#ifdef __spirv
+#ifdef __spirv__
     color.y = bar;
     color.z = zoo;
 #endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/version_defines/define_spirv.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/version_defines/define_spirv.hlsl
@@ -10,7 +10,7 @@ cbuffer cb : register(b0) {
 [numthreads(8, 8, 1)]
 void main(uint id : SV_DispatchThreadId) {
     float x = foo;
-#if defined(__spirv)
+#if defined(__spirv__)
     x -= 1;
 #else
     x += 1;


### PR DESCRIPTION
We implicitly defined `__spirv` when SPIR-V code gen is enabled and
`-spirv` command line option is given. This commit changes it to
__spirv__.