### PR TITLE
Delete dbg.declare in scopes where the alloca is unused

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -162,6 +162,10 @@ namespace dxilutil {
   /// This can enhance SROA and other transforms that want type-safe pointers,
   /// and enables merging with other getelementptr's.
   llvm::Value *TryReplaceBaseCastWithGep(llvm::Value *V);
+
+  llvm::Value::user_iterator mdv_users_end(llvm::Value *V);
+  llvm::Value::user_iterator mdv_users_begin(llvm::Value *V);
+
 }
 
 }

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/scoped_fragments.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/scoped_fragments.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_0 -Od -Zi %s | FileCheck %s
+
+// CHECK-NOT: call void @llvm.dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"ctx" !DIExpression(DW_OP_bit_piece, 64, 32) func:"foo"
+// CHECK-NOT: call void @llvm.dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"ctx" !DIExpression(DW_OP_bit_piece, 64, 32) func:"bar"
+
+// CHECK: call void @llvm.dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"ctx" !DIExpression(DW_OP_bit_piece, 64, 32) func:"main"
+
+// CHECK-NOT: call void @llvm.dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"ctx" !DIExpression(DW_OP_bit_piece, 64, 32) func:"foo"
+// CHECK-NOT: call void @llvm.dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"ctx" !DIExpression(DW_OP_bit_piece, 64, 32) func:"bar"
+
+struct Context {
+   float a, b, c;
+};
+void bar(inout Context ctx) {
+  ctx.b = ctx.a * 2;
+}
+void foo(inout Context ctx) {
+  ctx.a = 10;
+  bar(ctx);
+}
+
+float main() : SV_Target {
+  Context ctx = (Context)0;
+  foo(ctx);
+  return ctx.a + ctx.b + ctx.c;
+}
+
+


### PR DESCRIPTION
Delete all dbg.declare instructions for allocas that are never touched in scopes. This could greatly improve compilation speed and binary size at the cost of in-scope but unused (part of) variables being invisible in certain functions. For example:
```
struct Context {
   float a, b, c;
};
void bar(inout Context ctx) {
  ctx.b = ctx.a * 2;
}
void foo(inout Context ctx) {
  ctx.a = 10;
  bar(ctx);
}

float main() : SV_Target {
  Context ctx = (Context)0;
  foo(ctx);
  return ctx.a + ctx.b + ctx.c;
}
```
Before running this, shader would generate dbg.declare for members `a`, `b`, and `c` for variable `ctx` in every scope (`main`, `foo`, and `bar`). In the call stack with `foo` and `bar`, member `c` is never used in any way, so it's a waste to generate dbg.declare for member `c` for the `ctx` in scope `foo` and scope `bar`, so they can be removed.