### PR TITLE
Only set ResMayNotAlias flag when on DXIL 1.7

### DIFF
--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -390,6 +390,12 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   bool hasViewportOrRTArrayIndexBackCombat = valMajor == 1 && valMinor < 4;
   bool hasBarycentricsBackCompat = valMajor == 1 && valMinor < 6;
 
+  // Setting additional flag for downlevel shader model may cause some driver to
+  // fail shader create due to an unrecognized flag.
+  uint32_t dxilMajor, dxilMinor;
+  M->GetDxilVersion(dxilMajor, dxilMinor);
+  bool canSetResMayNotAlias = DXIL::CompareVersions(dxilMajor, dxilMinor, 1, 7) >= 0;
+
   Type *int16Ty = Type::getInt16Ty(F->getContext());
   Type *int64Ty = Type::getInt64Ty(F->getContext());
 
@@ -695,8 +701,8 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   flag.SetWriteableMSAATextures(hasWriteableMSAATextures);
 
   // Only bother setting the flag when there are UAVs.
-  flag.SetResMayNotAlias(DXIL::CompareVersions(valMajor, valMinor, 1, 7) >= 0 &&
-                         hasUAVs && !M->GetResMayAlias());
+  flag.SetResMayNotAlias(canSetResMayNotAlias && hasUAVs &&
+                         !M->GetResMayAlias());
 
   return flag;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/compile_options/res-may-alias.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/compile_options/res-may-alias.hlsl
@@ -1,11 +1,11 @@
 // RUN: %dxilver 1.7 | %dxc -E main -T ps_6_7 %s | FileCheck %s -check-prefixes=CHECK,NOALIAS
 // RUN: %dxilver 1.7 | %dxc -E main -T ps_6_7 -res-may-alias %s | FileCheck %s -check-prefixes=CHECK,ALIAS
-// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefixes=CHECK,NOALIAS
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 %s | FileCheck %s -check-prefixes=CHECK,ALIAS
 // RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -res-may-alias %s | FileCheck %s -check-prefixes=CHECK,ALIAS
 // RUN: %dxilver 1.5 | %dxc -E main -T ps_6_0 -validator-version 1.5 %s | FileCheck %s -check-prefixes=CHECK,ALIAS
 // RUN: %dxilver 1.5 | %dxc -E main -T ps_6_0 -validator-version 1.5 -res-may-alias %s | FileCheck %s -check-prefixes=CHECK,ALIAS
 
-// flag masked off when validator version < 1.7, meaning resources may alias.
+// flag masked off when dxil version < 1.7, meaning resources may alias.
 // CHECK: = !{void ()* @main, !"main", !{{.*}}, !{{.*}}, ![[flags:[0-9]+]]}
 // ALIAS: ![[flags]] = !{i32 0, i64 16}
 // NOALIAS: ![[flags]] = !{i32 0, i64 8589934608}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/uint64_2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Cbuffer/uint64_2.hlsl
@@ -1,11 +1,9 @@
-// RUN: %dxilver 1.1 | %dxc -E main -T cs_6_0 -validator-version 1.1 -not_use_legacy_cbuf_load  %s | FileCheck %s -check-prefixes=CHECK,CHECK61
-// RUN: %dxilver 1.7 | %dxc -E main -T cs_6_0 -not_use_legacy_cbuf_load  %s | FileCheck %s -check-prefixes=CHECK,CHECK67
+// RUN: %dxilver 1.1 | %dxc -E main -T cs_6_0 -validator-version 1.1 -not_use_legacy_cbuf_load  %s | FileCheck %s
 
 // CHECK: 64-Bit integer
 // CHECK: dx.op.bufferStore.i32
 // CHECK: dx.op.bufferStore.i32
-// CHECK61: !{i32 0, i64 1048576
-// CHECK67: !{i32 0, i64 8590983168
+// CHECK: !{i32 0, i64 1048576
 
 // Note: a change in the internal layout will produce
 // a difference in the serialized flags, eg:


### PR DESCRIPTION
Avoid failure in existing driver on unrecognized raw flags.