### PR TITLE
ExecutionTest for SampleCmpLevel

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -653,11 +653,12 @@
         SamplerComparisonState g_sampCmp : register(s1);
 
         uint2 DoSampleCmpLevel( float2 coord, uint lod ) {
-#if __SHADER_TARGET_MINOR == 7
-          return uint2( g_tex.SampleCmpLevelZero(g_sampCmp, coord) == g_tex.SampleCmpLevel(g_sampCmp, coord, 0),
-                        g_tex.SampleCmpLevel(g_sampCmp, coord, lod));
+          float expected = float(lod) + 0.5;
+#if  __SHADER_TARGET_MAJOR > 6 || (__SHADER_TARGET_MAJOR == 6 && __SHADER_TARGET_MINOR >= 7)
+          return uint2( g_tex.SampleCmpLevelZero(g_sampCmp, coord, expected) == g_tex.SampleCmpLevel(g_sampCmp, coord, expected, 0),
+                        g_tex.SampleCmpLevel(g_sampCmp, coord, expected, lod));
 #else
-          return uint2(1, g_tex.SampleLevel(g_samp, coord, lod) == lod);
+          return uint2(1, g_tex.SampleLevel(g_samp, coord, lod) == expected);
 #endif
         }
 

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -649,7 +649,7 @@
         RWStructuredBuffer<uint2> g_bufMesh : register(u1);
         RWStructuredBuffer<uint2> g_bufAmp : register(u2);
 
-        SamplerState g_samp : register(s0);
+        SamplerState g_samp : register(s0); // Just used for the pre-6.7 fakes
         SamplerComparisonState g_sampCmp : register(s1);
 
         uint2 DoSampleCmpLevel( float2 coord, uint lod ) {
@@ -658,6 +658,7 @@
           return uint2( g_tex.SampleCmpLevelZero(g_sampCmp, coord, expected) == g_tex.SampleCmpLevel(g_sampCmp, coord, expected, 0),
                         g_tex.SampleCmpLevel(g_sampCmp, coord, expected, lod));
 #else
+          // The initial compare is meaningless here, so just give the value expected
           return uint2(1, g_tex.SampleLevel(g_samp, coord, lod) == expected);
 #endif
         }
@@ -684,7 +685,7 @@
           uint nothing;
         };
 
-        [NumThreads(42, 2, 1)]
+        [NumThreads(8, 2, 1)]
         void ASMain(uint ix : SV_GroupIndex) {
           Payload payload;
           g_bufAmp[ix % MAX_MIP] = DoSampleCmpLevel(float2(0.5, 0.5), ix % MAX_MIP);
@@ -692,7 +693,7 @@
           DispatchMesh(1, 1, 1, payload);
         }
 
-        [NumThreads(42, 2, 1)]
+        [NumThreads(8, 2, 1)]
         [OutputTopology("triangle")]
         void MSMain(
           uint ix : SV_GroupIndex,
@@ -721,8 +722,9 @@
           return 1;
         }
 
-        [NumThreads(84, 4, 3)]
+        [NumThreads(16, 1, 1)]
         void CSMain(uint ix : SV_GroupIndex) {
+          // all mip levels contain the same values, so 0.5,0.5 is just as good as any
           g_bufMain[ix % MAX_MIP] = DoSampleCmpLevel(float2(0.5, 0.5), ix % MAX_MIP);
         }
 

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -581,6 +581,153 @@
       ]]>
     </Shader>
   </ShaderOp>
+  <ShaderOp Name="SampleCmpLevel" PS="PS" VS="VS" CS="CS" AS="AS" MS="MS" TopologyType="TRIANGLE">
+    <RootSignature>
+      RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT),
+      DescriptorTable(SRV(t0,numDescriptors=1), UAV(u0), UAV(u1), UAV(u2)),
+      StaticSampler(s0, addressU = TEXTURE_ADDRESS_WRAP, addressV = TEXTURE_ADDRESS_WRAP, filter = FILTER_MIN_MAG_LINEAR_MIP_POINT),
+      StaticSampler(s1, addressU = TEXTURE_ADDRESS_WRAP, addressV = TEXTURE_ADDRESS_WRAP, filter = FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT)
+    </RootSignature>
+    <Resource Name="VBuffer" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" Topology="TRIANGLELIST">
+      { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },
+      { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },
+      { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },
+
+      { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },
+      { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },
+      { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } }
+    </Resource>
+    <Resource Name="T0" Dimension="Texture2D" Width="336" Height="336" MipLevels="7" InitialResourceState="COPY_DEST" Init="ByName" Format="R32_FLOAT" />
+    <Resource Name="RTarget" Dimension="TEXTURE2D" Width="84" Height="4" Format="R32G32B32A32_FLOAT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" />
+    <Resource Name="U0" Dimension="BUFFER" Width="8192"
+              Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
+              Init="Zero" ReadBack="true" />
+    <Resource Name="U1" Dimension="BUFFER" Width="1024"
+              Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
+              Init="Zero" ReadBack="true" />
+    <Resource Name="U2" Dimension="BUFFER" Width="1024"
+              Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST"
+              Init="Zero" ReadBack="true" />
+
+    <RootValues>
+      <RootValue HeapName="ResHeap" />
+    </RootValues>
+    <DescriptorHeap Name="ResHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name='T0' Kind='SRV' ResName='T0' />
+      <Descriptor Name='U0' Kind='UAV' ResName='U0'
+                  NumElements="336" StructureByteStride="8" />
+      <Descriptor Name='U1' Kind='UAV' ResName='U1'
+                  NumElements="128" StructureByteStride="8" />
+      <Descriptor Name='U2' Kind='UAV' ResName='U2'
+                  NumElements="128" StructureByteStride="8" />
+    </DescriptorHeap>
+    <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
+      <Descriptor Name="RTarget" Kind="RTV"/>
+    </DescriptorHeap>
+
+    <InputElements>
+      <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
+      <InputElement SemanticName="TEXCOORD" Format="R32G32_FLOAT" AlignedByteOffset="12" />
+    </InputElements>
+    <RenderTargets>
+      <RenderTarget Name="RTarget"/>
+    </RenderTargets>
+    <Shader Name="CS" Target="cs_6_7" EntryPoint="CSMain" Text="@PS"/>
+    <Shader Name="AS" Target="as_6_7" EntryPoint="ASMain" Text="@PS"/>
+    <Shader Name="MS" Target="ms_6_7" EntryPoint="MSMain" Text="@PS"/>
+    <Shader Name="VS" Target="vs_6_7" EntryPoint="VSMain" Text="@PS"/>
+    <Shader Name="PS" Target="ps_6_7" EntryPoint="PSMain">
+      <![CDATA[
+        #define MAX_MIP 7
+        struct PSInput {
+          float4 position : SV_POSITION;
+          float2 uv : TEXCOORD;
+        };
+
+        Texture2D<float> g_tex : register(t0);
+        RWStructuredBuffer<uint2> g_bufMain : register(u0);
+        RWStructuredBuffer<uint2> g_bufMesh : register(u1);
+        RWStructuredBuffer<uint2> g_bufAmp : register(u2);
+
+        SamplerState g_samp : register(s0);
+        SamplerComparisonState g_sampCmp : register(s1);
+
+        uint2 DoSampleCmpLevel( float2 coord, uint lod ) {
+#if __SHADER_TARGET_MINOR == 7
+          return uint2( g_tex.SampleCmpLevelZero(g_sampCmp, coord) == g_tex.SampleCmpLevel(g_sampCmp, coord, 0),
+                        g_tex.SampleCmpLevel(g_sampCmp, coord, lod));
+#else
+          return uint2(1, g_tex.SampleLevel(g_samp, coord, lod) == lod);
+#endif
+        }
+
+        static float4 g_Verts[6] = {
+          { -1.0f,  1.0f, 0.0f, 1.0f },
+          {  1.0f,  1.0f, 0.0f, 1.0f },
+          { -1.0f, -1.0f, 0.0f, 1.0f },
+
+          { -1.0f, -1.0f, 0.0f, 1.0f },
+          {  1.0f,  1.0f, 0.0f, 1.0f },
+          {  1.0f, -1.0f, 0.0f, 1.0f }};
+
+        static float2 g_UV[6] = {
+          { 0.0f, 0.0f },
+          { 1.0f, 0.0f },
+          { 0.0f, 1.0f },
+
+          { 0.0f, 1.0f },
+          { 1.0f, 0.0f },
+          { 1.0f, 1.0f }};
+
+        struct Payload {
+          uint nothing;
+        };
+
+        [NumThreads(42, 2, 1)]
+        void ASMain(uint ix : SV_GroupIndex) {
+          Payload payload;
+          g_bufAmp[ix % MAX_MIP] = DoSampleCmpLevel(float2(0.5, 0.5), ix % MAX_MIP);
+          payload.nothing = 0;
+          DispatchMesh(1, 1, 1, payload);
+        }
+
+        [NumThreads(42, 2, 1)]
+        [OutputTopology("triangle")]
+        void MSMain(
+          uint ix : SV_GroupIndex,
+          in payload Payload payload,
+          out vertices PSInput verts[6],
+          out indices uint3 tris[2]) {
+            SetMeshOutputCounts(6, 2);
+            // Assign static fullscreen 2 tri quad
+            verts[ix%6].position = g_Verts[ix%6];
+            verts[ix%6].uv = g_UV[ix%6];
+            tris[ix&1] = uint3((ix&1)*3, (ix&1)*3 + 1, (ix&1)*3 + 2);
+            g_bufMesh[ix % MAX_MIP] = DoSampleCmpLevel(float2(0.5, 0.5), ix % MAX_MIP);
+        }
+
+
+        PSInput VSMain(float3 position : POSITION, float2 uv : TEXCOORD) {
+          PSInput result;
+          result.position = float4(position, 1.0);
+          result.uv = uv;
+          return result;
+        }
+
+        float4 PSMain(PSInput input) : SV_TARGET {
+          uint ix = uint(input.uv.x * 336);
+          g_bufMain[ix % MAX_MIP] = DoSampleCmpLevel(input.uv, ix % MAX_MIP);
+          return 1;
+        }
+
+        [NumThreads(84, 4, 3)]
+        void CSMain(uint ix : SV_GroupIndex) {
+          g_bufMain[ix % MAX_MIP] = DoSampleCmpLevel(float2(0.5, 0.5), ix % MAX_MIP);
+        }
+
+      ]]>
+    </Shader>
+  </ShaderOp>
   <ShaderOp Name="OOB" PS="PS" VS="VS">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), CBV(b0), DescriptorTable(SRV(t0,numDescriptors=2))</RootSignature>
     <Resource Name="CB0" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" TransitionTo="VERTEX_AND_CONSTANT_BUFFER">

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3539,6 +3539,9 @@ TEST_F(ExecutionTest, ComputeSampleTest) {
   }
 }
 
+// A mipmapped texture containing the value of LOD at each location in each
+// level is used to sample at each level using SampleCmpLevel and confirm
+// that the correct level is used for the comparison.
 TEST_F(ExecutionTest, ATOSampleCmpLevelTest) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
@@ -3588,6 +3591,8 @@ TEST_F(ExecutionTest, ATOSampleCmpLevelTest) {
 
   // Check that each LOD matches what's expected
   unsigned count = 2*7;
+  // Since the results consist of a boolean, which should be true followed by the result of a sampcmplvl,
+  // the only result expected is 1.
   for (unsigned i = 0; i < count; i++)
     VERIFY_ARE_EQUAL(pPixels[i], 1U);
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -303,7 +303,7 @@ public:
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
   TEST_METHOD(ComputeSampleTest);
-  TEST_METHOD(SampleCmpLevelTest);
+  TEST_METHOD(ATOSampleCmpLevelTest);
   TEST_METHOD(AtomicsTest);
   TEST_METHOD(Atomics64Test);
   TEST_METHOD(AtomicsRawHeap64Test);
@@ -3539,13 +3539,13 @@ TEST_F(ExecutionTest, ComputeSampleTest) {
   }
 }
 
-TEST_F(ExecutionTest, SampleCmpLevelTest) {
+TEST_F(ExecutionTest, ATOSampleCmpLevelTest) {
   WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
   CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6))
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_7))
       return;
 
   std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
@@ -3563,17 +3563,17 @@ TEST_F(ExecutionTest, SampleCmpLevelTest) {
                         size_t size = sizeof(float) * texWidth * texHeight * 2;
                         Data.resize(size);
                         float *pPrimitives = (float *)Data.data();
-                        float lod = 0.0;
+                        float val = 0.5;
                         int ix = 0;
                         while (texHeight > 0 && texWidth > 0) {
                           if(!texHeight) texHeight = 1;
                           if(!texWidth) texWidth = 1;
                           for (size_t j = 0; j < texHeight; ++j) {
                             for (size_t i = 0; i < texWidth; ++i) {
-                              pPrimitives[ix++] = lod;
+                              pPrimitives[ix++] = val;
                             }
                           }
-                          lod += 1.0;
+                          val += 1.0;
                           texHeight >>= 1;
                           texWidth >>= 1;
                         }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3857,7 +3857,7 @@ TEST_F(ExecutionTest, ATOSampleCmpLevelTest) {
   for (unsigned i = 0; i < count; i++)
     VERIFY_ARE_EQUAL(pPixels[i], 1U);
 
-  if (DoesDeviceSupportMeshAmpDerivatives(pDevice)) {
+  if (DoesDeviceSupportMeshShaders(pDevice)) {
     // Disable CS so mesh goes forward
     pShaderOp->CS = nullptr;
     test = RunShaderOpTestAfterParse(pDevice, m_support, "SampleCmpLevel", SampleInitFn, ShaderOpSet);


### PR DESCRIPTION
A mipmapped texture containing the value of LOD at each location in each
level is used to sample at each level using SampleCmpLevel and confirm
that the correct level is used for the comparison.

Additionally, the result of SampleCmpLevelZero is compared to the
SampleCmpLevel equivalent