### PR TITLE
Extending QuadAnyAll test for MS and AS

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2933,23 +2933,87 @@
 ]]>
     </Shader>
   </ShaderOp>
-  <ShaderOp Name="QuadAnyAll" CS="CS" DispatchX="8" DispatchY="8">
-    <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
-    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="1024" InitialResourceState="COPY_DEST" Init="Zero" Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true" />
+  <ShaderOp Name="QuadAnyAll" CS="CS" VS="VS" PS="PS" DispatchX="8" DispatchY="8">
+    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), UAV(u0)</RootSignature>
+    <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="2048" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ZERO" ReadBack="true"/>
+    <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_UINT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
+    <Resource Name="VBuffer" Dimension="BUFFER" InitialResourceState="COPY_DEST" Init="FromBytes" Topology="TRIANGLELIST">
+      { { -1.0f, 1.0f, 0.0f }, { 0.0f, 0.0f } },
+      { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },
+      { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },
+
+      { { -1.0f, -1.0f, 0.0f }, { 0.0f, 1.0f } },
+      { { 1.0f, 1.0f, 0.0f }, { 1.0f, 0.0f } },
+      { { 1.0f, -1.0f, 0.0f }, { 1.0f, 1.0f } }
+    </Resource>
     <RootValues>
-      <RootValue Index="0" ResName="UAVBuffer0"/>
+      <RootValue Index="0" ResName="UAVBuffer0" />
     </RootValues>
-    <Shader Name="CS67" Target="cs_6_7" EntryPoint="main" Text="@CS"/>
-    <Shader Name="CS" Target="cs_6_0" EntryPoint="main">
+    <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
+      <Descriptor Name="RTarget" Kind="RTV"/>
+    </DescriptorHeap>
+    <InputElements>
+      <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
+      <InputElement SemanticName="TEXCOORD" Format="R32G32_FLOAT" AlignedByteOffset="12" />
+    </InputElements>
+    <RenderTargets>
+      <RenderTarget Name="RTarget">
+        <Viewport Width="2.0" Height="2.0" MaxDepth="1.0"/>
+      </RenderTarget>
+    </RenderTargets>
+    
+    <Shader Name="PS" Target="ps_6_5" EntryPoint="PSMain" Text="@CS"/>
+    <Shader Name="VS" Target="vs_6_5" EntryPoint="VSMain" Text="@CS"/>
+    <Shader Name="AS67" Target="as_6_7" EntryPoint="ASMain" Text="@CS"/>
+    <Shader Name="AS" Target="as_6_5" EntryPoint="ASMain" Text="@CS"/>
+    <Shader Name="MS67" Target="ms_6_7" EntryPoint="MSMain" Text="@CS"/>
+    <Shader Name="MS" Target="ms_6_5" EntryPoint="MSMain" Text="@CS"/>
+    <Shader Name="CS67" Target="cs_6_7" EntryPoint="CSMain" Text="@CS"/>
+    <Shader Name="CS" Target="cs_6_0" EntryPoint="CSMain">
     <![CDATA[
-RWStructuredBuffer<int2> Values;
+RWStructuredBuffer<int2> Values : register(u0);
 groupshared uint WaveOffset = 0;
-[numthreads(8, 8, 1)]
-void main(uint TID: SV_GroupIndex) {
-  if (TID == 0)
+
+struct PSInput {
+  float4 position : SV_POSITION;
+  float2 uv : TEXCOORD;
+};
+
+static float4 g_Verts[6] = {
+  { -1.0f,  1.0f, 0.0f, 1.0f },
+  {  1.0f,  1.0f, 0.0f, 1.0f },
+  { -1.0f, -1.0f, 0.0f, 1.0f },
+
+  { -1.0f, -1.0f, 0.0f, 1.0f },
+  {  1.0f,  1.0f, 0.0f, 1.0f },
+  {  1.0f, -1.0f, 0.0f, 1.0f }};
+
+static float2 g_UV[6] = {
+  { 0.0f, 0.0f },
+  { 1.0f, 0.0f },
+  { 0.0f, 1.0f },
+
+  { 0.0f, 1.0f },
+  { 1.0f, 0.0f },
+  { 1.0f, 1.0f }};
+
+float4 PSMain(PSInput input) : SV_TARGET {
+  // This output doesn't actually matter
+  return input.position;
+}
+
+PSInput VSMain(float3 position : POSITION, float2 uv : TEXCOORD) {
+  PSInput result;
+  result.position = float4(position, 1.0);
+  result.uv = uv;
+  return result;
+}
+
+void QuadAnyAllTest(uint GID, uint StartOffset) {
+  if (GID == 0)
     WaveOffset = 0;
   GroupMemoryBarrierWithGroupSync();
-  uint Offset = 0;
+  uint Offset = StartOffset;
   uint QuadElem = WaveGetLaneIndex() & 3;
   if (QuadElem == 0)
     Offset = WavePrefixSum(4);
@@ -2965,6 +3029,36 @@ void main(uint TID: SV_GroupIndex) {
   bool ThreadBool = (QuadMask & QuadId) != 0;
   Values[Idx].x = QuadAny(ThreadBool) ? 1 : 2;
   Values[Idx].y = QuadAll(ThreadBool) ? 3 : 4;
+}
+
+[numthreads(8, 8, 1)]
+void CSMain(uint GID: SV_GroupIndex) {
+  QuadAnyAllTest(GID, 0);
+}
+
+struct Payload {
+  uint nothing;
+};
+
+[numthreads(8, 8, 1)]
+void ASMain(uint GID : SV_GroupIndex) {
+  QuadAnyAllTest(GID, 0);
+  Payload P = {0};
+  DispatchMesh(1, 1, 1, P);
+}
+
+[numthreads(8, 8, 1)]
+[OutputTopology("triangle")]
+void MSMain(uint GID : SV_GroupIndex,
+            in payload Payload payload,
+            out vertices PSInput verts[6],
+            out indices uint3 tris[2]) {
+    SetMeshOutputCounts(6, 2);
+    // Assign static fullscreen 2 tri quad
+    verts[GID%6].position = g_Verts[GID%6];
+    verts[GID%6].uv = g_UV[GID%6];
+    tris[GID&1] = uint3((GID&1)*3, (GID&1)*3 + 1, (GID&1)*3 + 2);
+    QuadAnyAllTest(GID, 64);
 }
 ]]>
     </Shader>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -2933,7 +2933,7 @@
 ]]>
     </Shader>
   </ShaderOp>
-  <ShaderOp Name="QuadAnyAll" CS="CS" VS="VS" PS="PS" DispatchX="8" DispatchY="8">
+  <ShaderOp Name="QuadAnyAll" CS="CS" PS="PS" DispatchX="8" DispatchY="8">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), UAV(u0)</RootSignature>
     <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="2048" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" TransitionTo="UNORDERED_ACCESS" Init="ZERO" ReadBack="true"/>
     <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_UINT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
@@ -2963,7 +2963,6 @@
     </RenderTargets>
     
     <Shader Name="PS" Target="ps_6_5" EntryPoint="PSMain" Text="@CS"/>
-    <Shader Name="VS" Target="vs_6_5" EntryPoint="VSMain" Text="@CS"/>
     <Shader Name="AS67" Target="as_6_7" EntryPoint="ASMain" Text="@CS"/>
     <Shader Name="AS" Target="as_6_5" EntryPoint="ASMain" Text="@CS"/>
     <Shader Name="MS67" Target="ms_6_7" EntryPoint="MSMain" Text="@CS"/>
@@ -3002,13 +3001,6 @@ float4 PSMain(PSInput input) : SV_TARGET {
   return input.position;
 }
 
-PSInput VSMain(float3 position : POSITION, float2 uv : TEXCOORD) {
-  PSInput result;
-  result.position = float4(position, 1.0);
-  result.uv = uv;
-  return result;
-}
-
 void QuadAnyAllTest(uint GID, uint StartOffset) {
   if (GID == 0)
     WaveOffset = 0;
@@ -3016,7 +3008,7 @@ void QuadAnyAllTest(uint GID, uint StartOffset) {
   uint Offset = StartOffset;
   uint QuadElem = WaveGetLaneIndex() & 3;
   if (QuadElem == 0)
-    Offset = WavePrefixSum(4);
+    Offset += WavePrefixSum(4);
   Offset = QuadReadLaneAt(Offset, 0) + QuadElem;
   uint LocalWaveOffset = 0;
   if (WaveGetLaneIndex() == 0) {

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3040,10 +3040,11 @@ struct Payload {
   uint nothing;
 };
 
+groupshared Payload P{0};
+
 [numthreads(8, 8, 1)]
 void ASMain(uint GID : SV_GroupIndex) {
   QuadAnyAllTest(GID, 0);
-  Payload P = {0};
   DispatchMesh(1, 1, 1, P);
 }
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9627,45 +9627,61 @@ struct int2 {
 };
 
 bool VerifyQuadAnyAllResults(int2 *Res) {
-    int Idx = 0;
-    for ( ; Idx < 4; ++Idx) {
-      if (Res[Idx].x != 2) return false;
-      if (Res[Idx].y != 4) return false;
-    }
-    for ( ; Idx < 60; ++Idx) {
-      if (Res[Idx].x != 1) return false;
-      if (Res[Idx].y != 4) return false;
-    }
-    for ( ; Idx < 64; ++Idx) {
-      if (Res[Idx].x != 1) return false;
-      if (Res[Idx].y != 3) return false;
-    }
-    return true;
+  int Idx = 0;
+  for (; Idx < 4; ++Idx) {
+    if (Res[Idx].x != 2)
+      return false;
+    if (Res[Idx].y != 4)
+      return false;
+  }
+  for (; Idx < 60; ++Idx) {
+    if (Res[Idx].x != 1)
+      return false;
+    if (Res[Idx].y != 4)
+      return false;
+  }
+  for (; Idx < 64; ++Idx) {
+    if (Res[Idx].x != 1)
+      return false;
+    if (Res[Idx].y != 3)
+      return false;
+  }
+  return true;
 }
 
 TEST_F(ExecutionTest, QuadAnyAll) {
-  WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
-  std::shared_ptr<st::ShaderOpSet> ShaderOpSet = std::make_shared<st::ShaderOpSet>();
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+      std::make_shared<st::ShaderOpSet>();
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
-  st::ShaderOp* pShaderOp = ShaderOpSet->GetShaderOp("QuadAnyAll");
+  st::ShaderOp *pShaderOp = ShaderOpSet->GetShaderOp("QuadAnyAll");
 
   LPCSTR args = "/Od";
 
   if (args[0]) {
-    for (st::ShaderOpShader& S : pShaderOp->Shaders)
+    for (st::ShaderOpShader &S : pShaderOp->Shaders)
       S.Arguments = args;
   }
 
   bool Skipped = true;
-  D3D_SHADER_MODEL TestShaderModels[] = { D3D_SHADER_MODEL_6_0, D3D_SHADER_MODEL_6_7 };
+  D3D_SHADER_MODEL TestShaderModels[] = {D3D_SHADER_MODEL_6_0,
+                                         D3D_SHADER_MODEL_6_5};
   for (unsigned i = 0; i < _countof(TestShaderModels); i++) {
     D3D_SHADER_MODEL sm = TestShaderModels[i];
-    LogCommentFmt(L"\r\nVerifying QuadAny/QuadAll using Wave intrinsics in shader model 6.%1u", ((UINT)sm & 0x0f));
+    LogCommentFmt(L"\r\nVerifying QuadAny/QuadAll using Wave intrinsics in "
+                  L"shader model 6.%1u",
+                  ((UINT)sm & 0x0f));
 
-    if (sm == D3D_SHADER_MODEL_6_7) {
+    if (sm == D3D_SHADER_MODEL_6_5) {
+      pShaderOp->MS = pShaderOp->GetString("MS");
+      pShaderOp->AS = pShaderOp->GetString("AS");
+    } else if (sm == D3D_SHADER_MODEL_6_7) {
+      pShaderOp->AS = pShaderOp->GetString("AS67");
+      pShaderOp->MS = pShaderOp->GetString("MS67");
       pShaderOp->CS = pShaderOp->GetString("CS67");
     }
 
@@ -9680,18 +9696,34 @@ TEST_F(ExecutionTest, QuadAnyAll) {
     }
 
     if (!DoesDeviceSupportWaveOps(pDevice)) {
-      LogCommentFmt(L"Device does not support wave operations in shader model 6.%1u", ((UINT)sm & 0x0f));
+      LogCommentFmt(
+          L"Device does not support wave operations in shader model 6.%1u",
+          ((UINT)sm & 0x0f));
       continue;
     }
     Skipped = false;
 
     // test compute
-    std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "QuadAnyAll",
-      CleanUAVBuffer0Buffer, ShaderOpSet);
+    std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
+        pDevice, m_support, "QuadAnyAll", CleanUAVBuffer0Buffer, ShaderOpSet);
 
     MappedData uavData;
     test->Test->GetReadBackData("UAVBuffer0", &uavData);
-    bool Result = VerifyQuadAnyAllResults((int2*)uavData.data());
+    bool Result = VerifyQuadAnyAllResults((int2 *)uavData.data());
+    VERIFY_IS_TRUE(Result);
+
+    if (!DoesDeviceSupportMeshShaders(pDevice))
+      continue;
+
+    pShaderOp->CS = nullptr;
+    // test AS/MS
+    test = RunShaderOpTestAfterParse(pDevice, m_support, "QuadAnyAll",
+                                     CleanUAVBuffer0Buffer, ShaderOpSet);
+
+    test->Test->GetReadBackData("UAVBuffer0", &uavData);
+    Result = VerifyQuadAnyAllResults((int2 *)uavData.data());
+    VERIFY_IS_TRUE(Result);
+    Result = VerifyQuadAnyAllResults(&((int2 *)uavData.data())[64]);
     VERIFY_IS_TRUE(Result);
   }
   if (Skipped)

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9669,7 +9669,8 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 
   bool Skipped = true;
   D3D_SHADER_MODEL TestShaderModels[] = {D3D_SHADER_MODEL_6_0,
-                                         D3D_SHADER_MODEL_6_5};
+                                         D3D_SHADER_MODEL_6_5,
+                                         D3D_SHADER_MODEL_6_7};
   for (unsigned i = 0; i < _countof(TestShaderModels); i++) {
     D3D_SHADER_MODEL sm = TestShaderModels[i];
     LogCommentFmt(L"\r\nVerifying QuadAny/QuadAll using Wave intrinsics in "
@@ -9712,7 +9713,7 @@ TEST_F(ExecutionTest, QuadAnyAll) {
     bool Result = VerifyQuadAnyAllResults((int2 *)uavData.data());
     VERIFY_IS_TRUE(Result);
 
-    if (!DoesDeviceSupportMeshShaders(pDevice))
+    if (sm < D3D_SHADER_MODEL_6_5 || !DoesDeviceSupportMeshShaders(pDevice))
       continue;
 
     pShaderOp->CS = nullptr;


### PR DESCRIPTION
This extends the existing compute test to cover Mesh and Amplifiction
shaders.