### PR TITLE
Missing break in CreateHandleFromHeap case caused unwanted shader flags

### DIFF
--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -576,7 +576,7 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
                 hasUAVs = true;
             }
           }
-        }
+        } break;
         case DXIL::OpCode::TextureStoreSample:
           hasWriteableMSAATextures = true;
           __fallthrough;


### PR DESCRIPTION
hasWriteableMSAATextures and hasAdvancedTextureOps were being set if you used CreateHandleFromHeap because of a missing break.