### PR TITLE
New HLSL_AGILITYSDK_DIR and HLSLHost dependency copying help.

### DIFF
--- a/cmake/modules/FindTAEF.cmake
+++ b/cmake/modules/FindTAEF.cmake
@@ -43,7 +43,11 @@ set(TAEF_INCLUDE_DIRS ${TAEF_INCLUDE_DIR})
 set(TAEF_NUGET_BIN ${TAEF_INCLUDE_DIR}/../Binaries/Release)
 set(TAEF_SDK_BIN ${TAEF_INCLUDE_DIR}/../../Runtimes/TAEF)
 
-if(EXISTS "${TAEF_NUGET_BIN}/x64/te.exe" AND EXISTS "${TAEF_NUGET_BIN}/x86/te.exe")
+if(EXISTS "$ENV{HLSL_TAEF_DIR}/x64/te.exe" OR EXISTS "$ENV{HLSL_TAEF_DIR}/x86/te.exe")
+  # Use HLSL_TAEF_DIR for debug executable setting if set.
+  # we don't actually support multiple architectures in the same project.
+  set(TAEF_BIN_DIR "$ENV{HLSL_TAEF_DIR}")
+elseif(EXISTS "${TAEF_NUGET_BIN}/x64/te.exe" AND EXISTS "${TAEF_NUGET_BIN}/x86/te.exe")
   set(TAEF_BIN_DIR "${TAEF_NUGET_BIN}")
 elseif(EXISTS "${TAEF_SDK_BIN}/x64/te.exe" AND EXISTS "${TAEF_SDK_BIN}/x86/te.exe")
   set(TAEF_BIN_DIR "${TAEF_SDK_BIN}")

--- a/utils/hct/hctbins.cmd
+++ b/utils/hct/hctbins.cmd
@@ -55,7 +55,7 @@ goto :eof
 
 :copytobin
 if not "%HLSL_TAEF_DIR%"=="" (
-  call %HCT_DIR%\hctcopy.cmd "%HLSL_TAEF_DIR%" "%~1" TE.Common.dll Wex.Common.dll Wex.Communication.dll Wex.Logger.dll
+  call %HCT_DIR%\hctcopy.cmd "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%" "%~1" TE.Common.dll Wex.Common.dll Wex.Communication.dll Wex.Logger.dll
 )
 if not "%FULL_AGILITY_PATH%"=="" (
   mkdir "%~1\D3D12" 1>nul 2>nul

--- a/utils/hct/hctbins.cmd
+++ b/utils/hct/hctbins.cmd
@@ -1,0 +1,71 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+
+set HCT_DIR=%~dp0
+
+if "%BUILD_CONFIG%"=="" (
+  set BUILD_CONFIG=Debug
+)
+
+:opt_loop
+if "%1"=="" (goto :done_opt)
+
+if "%1"=="/?" goto :showhelp
+if "%1"=="-?" goto :showhelp
+if "%1"=="-h" goto :showhelp
+if "%1"=="-help" goto :showhelp
+if "%1"=="--help" goto :showhelp
+
+if "%1"=="-rel" (
+  set BUILD_CONFIG=Release
+) else (
+  goto :done_opt
+)
+shift /1
+goto :opt_loop
+:done_opt
+
+if "%HLSL_TAEF_DIR%"=="" (
+  echo No HLSL_TAEF_DIR is set, no TAEF components will be copied.
+)
+
+set FULL_AGILITY_PATH=
+if "%HLSL_AGILITYSDK_DIR%"=="" (
+  echo No HLSL_AGILITYSDK_DIR is set, no AgilitySDK binaries will be copied.
+) else (
+  if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+    set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%
+  ) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+    set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%
+  ) else if exist "%HLSL_AGILITYSDK_DIR%\D3D12Core.dll" (
+    set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%
+  ) else (
+    echo HLSL_AGILITYSDK_DIR is set, but unable to resolve path to binaries
+  )
+)
+
+if exist "%HLSL_BLD_DIR%\%BUILD_CONFIG%\bin" (
+  call :copytobin "%HLSL_BLD_DIR%\%BUILD_CONFIG%\bin"
+)
+if exist "%HLSL_BLD_DIR%\%BUILD_CONFIG%\test" (
+  call :copytobin "%HLSL_BLD_DIR%\%BUILD_CONFIG%\test"
+)
+goto :eof
+
+
+:copytobin
+if not "%HLSL_TAEF_DIR%"=="" (
+  call %HCT_DIR%\hctcopy.cmd "%HLSL_TAEF_DIR%" "%~1" TE.Common.dll Wex.Common.dll Wex.Communication.dll Wex.Logger.dll
+)
+if not "%FULL_AGILITY_PATH%"=="" (
+  mkdir "%~1\D3D12" 1>nul 2>nul
+  call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%~1\D3D12" D3D12Core.dll d3d12SDKLayers.dll
+)
+goto :eof
+
+:showhelp 
+echo Usage:
+echo   hctbins [-rel]
+echo.
+echo Copies extra binary dependencies to bin and test outputs for tools such as HLSLHost.exe.
+goto :eof

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -88,6 +88,7 @@ if errorlevel 1 (
   call :findpython
 )
 
+call :findminte
 where te.exe 1>nul 2>nul
 if errorlevel 1 (
   call :findte
@@ -132,6 +133,26 @@ if errorlevel 1 (
 )
 echo Path adjusted to include cmake.
 goto :eof
+
+:findminte 
+set HLSL_TAEF_DIR=
+set HLSL_TAEF_MINTE=
+if exist "%HLSL_SRC_DIR%\external\taef\build\Binaries\%BUILD_ARCH:Win32=x86%\Te.exe" set HLSL_TAEF_MINTE=%HLSL_SRC_DIR%\external\taef\build\Binaries\%BUILD_ARCH:Win32=x86%
+if exist "%programfiles%\windows kits\10\Testing\Runtimes\TAEF\%BUILD_ARCH:Win32=x86%\MinTe\Te.exe" set HLSL_TAEF_MINTE=%programfiles%\windows kits\10\Testing\Runtimes\TAEF\%BUILD_ARCH:Win32=x86%\MinTe
+if exist "%programfiles(x86)%\windows kits\10\Testing\Runtimes\TAEF\%BUILD_ARCH:Win32=x86%\MinTe\Te.exe" set HLSL_TAEF_MINTE=%programfiles(x86)%\windows kits\10\Testing\Runtimes\TAEF\%BUILD_ARCH:Win32=x86%\MinTe
+if exist "%programfiles%\windows kits\10\Testing\Runtimes\TAEF\MinTe\Te.exe" set HLSL_TAEF_MINTE=%programfiles%\windows kits\10\Testing\Runtimes\TAEF\MinTe
+if exist "%programfiles(x86)%\windows kits\10\Testing\Runtimes\TAEF\MinTe\Te.exe" set HLSL_TAEF_MINTE=%programfiles(x86)%\windows kits\10\Testing\Runtimes\TAEF\MinTe
+if "%HLSL_TAEF_MINTE%"=="" (
+  echo Unable to find matching MinTe, will not auto-copy AgilitySDK binaries.
+  exit /b 1
+)
+echo Found TAEF at %HLSL_TAEF_MINTE%
+set HLSL_TAEF_DIR=%HLSL_BLD_DIR%\TAEF
+echo Copying to %HLSL_TAEF_DIR% for use with AgilitySDK
+mkdir "%HLSL_TAEF_DIR%" 1>nul 2>nul
+robocopy /NP /NJH /NJS /S "%HLSL_TAEF_MINTE%" "%HLSL_TAEF_DIR%" *
+set path=%path%;%HLSL_TAEF_DIR%
+goto:eof
 
 :findte 
 if exist "%programfiles%\windows kits\10\Testing\Runtimes\TAEF\Te.exe" set path=%path%;%programfiles%\windows kits\10\Testing\Runtimes\TAEF

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -149,9 +149,9 @@ if "%HLSL_TAEF_MINTE%"=="" (
 echo Found TAEF at %HLSL_TAEF_MINTE%
 set HLSL_TAEF_DIR=%HLSL_BLD_DIR%\TAEF
 echo Copying to %HLSL_TAEF_DIR% for use with AgilitySDK
-mkdir "%HLSL_TAEF_DIR%" 1>nul 2>nul
-robocopy /NP /NJH /NJS /S "%HLSL_TAEF_MINTE%" "%HLSL_TAEF_DIR%" *
-set path=%path%;%HLSL_TAEF_DIR%
+mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%"" 1>nul 2>nul
+robocopy /NP /NJH /NJS /S "%HLSL_TAEF_MINTE%" "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%" *
+set path=%path%;%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%
 goto:eof
 
 :findte 

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -491,7 +491,6 @@ if "%HLSL_TAEF_DIR%"=="" (
   echo HLSL_AGILITYSDK_DIR set, but no HLSL_TAEF_DIR set, no AgilitySDK will be copied
   exit /b 1
 )
-echo MARK 4
 set FULL_AGILITY_PATH=
 if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
   set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -300,6 +300,9 @@ if "%TEST_CMD%"=="1" (
 
 if "%TEST_EXEC%"=="1" (
   call :copyagility
+)
+
+if "%TEST_EXEC%"=="1" (
   echo Sniffing for D3D12 configuration ...
   call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:ExecutionTest::BasicTriangleTest /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK%
   set RES_EXEC=!ERRORLEVEL!
@@ -439,7 +442,7 @@ rem %4 - third argument to te
 if %HLSL_TAEF_DIR%=="" (
   set TE=te
 ) else (
-  set TE="%HLSL_TAEF_DIR%\te"
+  set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\te"
 )
 echo %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
 call %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
@@ -483,11 +486,12 @@ goto :eof
 if "%HLSL_AGILITYSDK_DIR%"=="" (
   exit /b 0
 )
-set %USE_AGILITY_SDK%=/p:D3D12SDKVersion=1
+set USE_AGILITY_SDK=/p:D3D12SDKVersion=1
 if "%HLSL_TAEF_DIR%"=="" (
   echo HLSL_AGILITYSDK_DIR set, but no HLSL_TAEF_DIR set, no AgilitySDK will be copied
   exit /b 1
 )
+echo MARK 4
 set FULL_AGILITY_PATH=
 if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
   set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%
@@ -499,6 +503,6 @@ if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Cor
   echo HLSL_AGILITYSDK_DIR is set, but unable to resolve path to binaries
   exit /b 1
 )
-mkdir "%HLSL_TAEF_DIR%\D3D12" 1>nul 2>nul
-call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
+mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" 1>nul 2>nul
+call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
 exit /b %ERRORLEVEL%

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -25,6 +25,7 @@ set MANUAL_FILE_CHECK_PATH=
 set TEST_MANUAL_FILE_CHECK=0
 set SINGLE_FILE_CHECK_NAME=0
 set CUSTOM_BIN_SET=
+set USE_AGILITY_SDK=
 
 rem Begin SPIRV change
 set TEST_SPIRV=0
@@ -298,26 +299,26 @@ if "%TEST_CMD%"=="1" (
 )
 
 if "%TEST_EXEC%"=="1" (
+  call :copyagility
   echo Sniffing for D3D12 configuration ...
-  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:ExecutionTest::BasicTriangleTest /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER%
-  rem  /p:"ExperimentalShaders=*"
+  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:ExecutionTest::BasicTriangleTest /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK%
   set RES_EXEC=!ERRORLEVEL!
   if errorlevel 1 (
     if not "%TEST_EXEC_REQUIRED%"=="1" (
       echo Basic triangle test failed.
       echo Assuming this is an environmental limitation not a regression
       set TEST_EXEC=0
-    ) else (
-      echo Basic triangle test succeeded. Proceeding with execution tests.
     )
+  ) else (
+    echo Basic triangle test succeeded. Proceeding with execution tests.
   )
 )
 
 if "%TEST_EXEC%"=="1" (
   if "%TEST_EXEC_FUTURE%"=="1" (
-    call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /select:"@Name='%TEST_EXEC_FILTER%' AND @Priority=2" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %ADDITIONAL_OPTS%
+    call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /select:"@Name='%TEST_EXEC_FILTER%' AND @Priority=2" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK% %ADDITIONAL_OPTS%
   ) else (
-    call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /select:"@Name='%TEST_EXEC_FILTER%' AND @Priority<2" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %ADDITIONAL_OPTS%
+    call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /select:"@Name='%TEST_EXEC_FILTER%' AND @Priority<2" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK% %ADDITIONAL_OPTS%
   )
   set RES_EXEC=!ERRORLEVEL!
 )
@@ -435,8 +436,13 @@ rem %2 - first argument to te
 rem %3 - second argument to te
 rem %4 - third argument to te
 
-echo te /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
-call te /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
+if %HLSL_TAEF_DIR%=="" (
+  set TE=te
+) else (
+  set TE="%HLSL_TAEF_DIR%\te"
+)
+echo %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
+call %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
 
 if errorlevel 1 (
   call :showtesample %*
@@ -472,3 +478,27 @@ if not "%2"=="" (
   )
 )
 goto :eof
+
+:copyagility
+if "%HLSL_AGILITYSDK_DIR%"=="" (
+  exit /b 0
+)
+set %USE_AGILITY_SDK%=/p:D3D12SDKVersion=1
+if "%HLSL_TAEF_DIR%"=="" (
+  echo HLSL_AGILITYSDK_DIR set, but no HLSL_TAEF_DIR set, no AgilitySDK will be copied
+  exit /b 1
+)
+set FULL_AGILITY_PATH=
+if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%
+) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%
+) else if exist "%HLSL_AGILITYSDK_DIR%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%
+) else (
+  echo HLSL_AGILITYSDK_DIR is set, but unable to resolve path to binaries
+  exit /b 1
+)
+mkdir "%HLSL_TAEF_DIR%\D3D12" 1>nul 2>nul
+call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
Use environment variable HLSL_AGILITYSDK_DIR which you can point to
extracted contents of an AgilitySDK.
Automatically copy binaries to appropriate location when set.

Look for MinTe binary set from TAEF.  If found, set a local TAEF binary
location.
If this is set when running execution tests, copy MinTe there, and if the
HLSL_AGILITYSDK_DIR was set, also copy agility SDK binaries under the
.\D3D12\ subdir there, so the test can automatically pick it up.

Add hctbins.cmd to copy extra bins necessary for running things out of
the ...\bin or ...\test directories such as HLSLHost.exe.  This includes
AgilitySDK bins if set.