### PR TITLE
Forward compiler arguments to rewriter to support SPIR-V and HLSL 2021 features

### DIFF
--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -546,6 +546,15 @@ void SetupCompilerCommon(CompilerInstance &compiler,
   compiler.getLangOpts().UseMinPrecision = !opts.Enable16BitTypes;
   compiler.getLangOpts().EnableDX9CompatMode = opts.EnableDX9CompatMode;
   compiler.getLangOpts().EnableFXCCompatMode = opts.EnableFXCCompatMode;
+  compiler.getLangOpts().EnableTemplates = opts.EnableTemplates;
+  compiler.getLangOpts().EnableOperatorOverloading = opts.EnableOperatorOverloading;
+  compiler.getLangOpts().StrictUDTCasting = opts.StrictUDTCasting;
+  compiler.getLangOpts().EnablePayloadAccessQualifiers = opts.EnablePayloadQualifiers;
+  compiler.getLangOpts().EnableShortCircuit = opts.EnableShortCircuit;
+  compiler.getLangOpts().EnableBitfields = opts.EnableBitfields;
+#ifdef ENABLE_SPIRV_CODEGEN
+  compiler.getLangOpts().SPIRV = opts.GenSPIRV;
+#endif
   compiler.getDiagnostics().setIgnoreAllWarnings(!opts.OutputWarnings);
   compiler.getCodeGenOpts().MainFileName = pMainFile;
 
@@ -838,7 +847,9 @@ HRESULT ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,
   IFT(CreateMemoryStream(GetGlobalHeapMalloc(), &pOutputStream));
   raw_stream_ostream outStream(pOutputStream);
 
-  if (0 != hlsl::options::ReadDxcOpts(table, hlsl::options::HlslFlags::RewriteOption,
+  if (0 != hlsl::options::ReadDxcOpts(table,
+                                      hlsl::options::HlslFlags::RewriteOption |
+                                          hlsl::options::HlslFlags::CoreOption,
                                       mainArgs, opts, outStream)) {
     CComPtr<IDxcBlob> pErrorBlob;
     IFT(pOutputStream->QueryInterface(&pErrorBlob));


### PR DESCRIPTION
This is a proposal to forward compiler arguments such as `-spirv` and `-HV 2021` to the rewriter which we use in UE5.
It introduces a breaking change in the interface of `RemoveUnusedGlobals`, `RewriteUnchanged`, and `RewriteUnchangedWithInclude` but I'm open for discussions about getting this in as a non-breaking change, perhaps by just adding alternative interface functions.