### PR TITLE
Enable 'using' keyword.

### DIFF
--- a/tools/clang/include/clang/Lex/Token.h
+++ b/tools/clang/include/clang/Lex/Token.h
@@ -311,7 +311,7 @@ public:
       is(tok::kw_reinterpret_cast) ||
       is(tok::kw_signed) || is(tok::kw_sizeof) || is(tok::kw_static_cast) ||
       is(tok::kw_template) || is(tok::kw_throw) || is(tok::kw_try) || is(tok::kw_typename) ||
-      is(tok::kw_union) || is(tok::kw_using) ||
+      is(tok::kw_union) ||
       is(tok::kw_virtual);
   }
   // HLSL Change Starts  

--- a/tools/clang/include/clang/Lex/Token.h
+++ b/tools/clang/include/clang/Lex/Token.h
@@ -311,7 +311,7 @@ public:
       is(tok::kw_reinterpret_cast) ||
       is(tok::kw_signed) || is(tok::kw_sizeof) || is(tok::kw_static_cast) ||
       is(tok::kw_template) || is(tok::kw_throw) || is(tok::kw_try) || is(tok::kw_typename) ||
-      is(tok::kw_union) ||
+      is(tok::kw_union) || is(tok::kw_using) ||
       is(tok::kw_virtual);
   }
   // HLSL Change Starts  

--- a/tools/clang/lib/Parse/ParseDecl.cpp
+++ b/tools/clang/lib/Parse/ParseDecl.cpp
@@ -2035,11 +2035,6 @@ Parser::DeclGroupPtrTy Parser::ParseDeclaration(unsigned Context,
     SingleDecl = ParseNamespace(Context, DeclEnd);
     break;
   case tok::kw_using:
-    if (getLangOpts().HLSL) {
-      Diag(Tok, diag::err_hlsl_reserved_keyword) << Tok.getName();
-      SkipMalformedDecl();
-      return DeclGroupPtrTy();
-    }
     SingleDecl = ParseUsingDirectiveOrDeclaration(Context, ParsedTemplateInfo(),
                                                   DeclEnd, attrs, &OwnedType);
     break;

--- a/tools/clang/lib/Parse/ParseDeclCXX.cpp
+++ b/tools/clang/lib/Parse/ParseDeclCXX.cpp
@@ -508,7 +508,6 @@ Decl *Parser::ParseUsingDeclaration(unsigned Context,
   // alias-declaration.
   ParsedAttributesWithRange MisplacedAttrs(AttrFactory);
   MaybeParseCXX11Attributes(MisplacedAttrs);
-  assert(!getLangOpts().HLSL); // HLSL Change: in lieu of MaybeParseHLSLAttributes - using not allowed
 
   // Ignore optional 'typename'.
   // FIXME: This is wrong; we should parse this as a typename-specifier.
@@ -567,7 +566,6 @@ Decl *Parser::ParseUsingDeclaration(unsigned Context,
   ParsedAttributesWithRange Attrs(AttrFactory);
   MaybeParseGNUAttributes(Attrs);
   MaybeParseCXX11Attributes(Attrs);
-  assert(!getLangOpts().HLSL); // HLSL Change: in lieu of MaybeParseHLSLAttributes - using not allowed
 
   // Maybe this is an alias-declaration.
   TypeResult TypeAlias;
@@ -2382,13 +2380,6 @@ void Parser::ParseCXXClassMemberDeclaration(AccessSpecifier AS,
   MaybeParseMicrosoftAttributes(attrs);
 
   if (Tok.is(tok::kw_using)) {
-    // HLSL Change Starts
-    if (getLangOpts().HLSL) {
-      Diag(Tok, diag::err_hlsl_reserved_keyword) << Tok.getName();
-      SkipUntil(tok::semi, StopBeforeMatch);
-      return;
-    }
-    // HLSL Change Ends
     ProhibitAttributes(attrs);
 
     // Eat 'using'.

--- a/tools/clang/lib/Parse/ParseTemplate.cpp
+++ b/tools/clang/lib/Parse/ParseTemplate.cpp
@@ -198,18 +198,8 @@ Parser::ParseSingleDeclarationAfterTemplate(
   // HLSL Change: comment only - MaybeParseHLSLAttributes would go here if allowed at this point
 
   if (Tok.is(tok::kw_using))
-    // HLSL Change Starts
-    {
-    if (getLangOpts().HLSL) {
-      Diag(Tok, diag::err_hlsl_reserved_keyword) << "using";
-      SkipMalformedDecl();
-    }
-    else {
-    // HLSL Change Ends - succeeding statement is now conditional
       return ParseUsingDirectiveOrDeclaration(Context, TemplateInfo, DeclEnd,
                                               prefixAttrs);
-    } // HLSL Change - close conditional
-    } // HLSL Change - close conditional
 
   // Parse the declaration specifiers, stealing any diagnostics from
   // the template parameters.

--- a/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors-hv2015.hlsl
@@ -292,7 +292,7 @@ namespace MyNs {
 // namespace alias definition.
 namespace NamespaceAlias = MyNs; // expected-error {{expected identifier}}
 
-using MyNS; // expected-error {{'using' is a reserved keyword in HLSL}}
+using namespace MyNS;
 int using; // expected-error {{'using' is a reserved keyword in HLSL}}
 
 struct my_struct { };
@@ -336,7 +336,7 @@ struct s_with_template_member {
 };
 
 struct s_with_using {
-  using MyNS; // expected-error {{'using' is a reserved keyword in HLSL}}
+  using namespace MyNS; // expected-error {{'using namespace' is not allowed in classes}}
 };
 
 struct s_with_init {

--- a/tools/clang/test/HLSL/cpp-errors.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors.hlsl
@@ -288,7 +288,7 @@ namespace MyNs {
 // namespace alias definition.
 namespace NamespaceAlias = MyNs; // expected-error {{expected identifier}}
 
-using MyNS; // expected-error {{'using' is a reserved keyword in HLSL}}
+using namespace MyNS;
 int using; // expected-error {{'using' is a reserved keyword in HLSL}}
 
 struct my_struct { };
@@ -332,7 +332,7 @@ struct s_with_template_member {
 };
 
 struct s_with_using {
-  using MyNS; // expected-error {{'using' is a reserved keyword in HLSL}}
+  using MyNs::my_ns_extension; // expected-error {{using declaration in class refers into 'MyNs::', which is not a class}}
 };
 
 struct s_with_init {

--- a/tools/clang/test/HLSLFileCheck/hlsl/namespace/using.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/namespace/using.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+// CHECK:call float @dx.op.unary.f32(i32 13
+
+namespace n {
+    using f = float;
+    namespace n2 {
+       f foo(f a) { return sin(a); }
+    }
+
+}
+
+using namespace n;
+using f32 = n::f;
+
+
+using n2::foo;
+
+f32 main(f32 a:A) : SV_Target {
+
+  return foo(a);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/namespace/using2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/namespace/using2.hlsl
@@ -1,0 +1,45 @@
+// RUN: %dxc -E main -T ps_6_0 -enable-templates %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s
+
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 125)
+
+namespace  n {
+template<unsigned int M, unsigned int N>
+struct Ackermann {
+ enum {
+   value = Ackermann<M-1, Ackermann<M, N-1>::value >::value
+ };
+};
+
+template<unsigned int M> struct Ackermann<M, 0> {
+ enum {
+   value = Ackermann<M-1, 1>::value
+ };
+};
+
+template<unsigned int N> struct Ackermann<0, N> {
+ enum {
+   value = N + 1
+ };
+};
+
+template<> struct Ackermann<0, 0> {
+ enum {
+   value = 1
+ };
+};
+
+  using A34 = Ackermann<3, 4>;
+
+}
+
+
+namespace  n2 {
+    using n::A34;
+}
+
+
+
+int main(int a:A) : SV_Target {
+  return n2::A34::value;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/namespace/using3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/namespace/using3.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+
+
+// CHECK:call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
+// CHECK: call %dx.types.ResRet.f32 @dx.op.textureLoad.f32
+
+namespace  n {
+   using T2D = Texture2D<float>;
+}
+
+
+namespace  n2 {
+    using n::T2D;
+}
+
+namespace n3 {
+   cbuffer A {
+    n2::T2D t0;
+    int i;
+   };
+}
+
+using namespace n3;
+
+int main(int a:A) : SV_Target {
+  return t0.Load(i);
+}


### PR DESCRIPTION
Enable 'using' keyword to help move hlsl intrinsic inside hlsl namespace.

This is just reenable existing c++ feature by remove check on HLSL.