### PR TITLE
Fix AtomicsShared64 ExecutionTest

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9286,7 +9286,6 @@ TEST_F(ExecutionTest, AtomicsShared64Test) {
   // Reassign shader stages to 64-bit versions
   // Collect 64-bit shaders
   pShaderOp->CS = pShaderOp->GetString("CSSH64");
-  pShaderOp->PS = pShaderOp->GetString("PS64");
   pShaderOp->AS = pShaderOp->GetString("ASSH64");
   pShaderOp->MS = pShaderOp->GetString("MSSH64");
 


### PR DESCRIPTION
The test was assigning a pixel shader that didn't exist due to the
conversion of mistaken code that was harmless in the previous form, but
results in an error message in the new.