### PR TITLE
[dxil2spv] Read file directly into llvm::MemoryBuffer

### DIFF
--- a/lib/Transforms/IPO/CMakeLists.txt
+++ b/lib/Transforms/IPO/CMakeLists.txt
@@ -30,4 +30,4 @@ add_llvm_library(LLVMipo
 
 add_dependencies(LLVMipo intrinsics_gen)
 
-target_link_libraries(LLVMipo PUBLIC LLVMDXIL) # HLSL Change
+target_link_libraries(LLVMipo PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -68,4 +68,4 @@ add_llvm_library(LLVMScalarOpts
 
 add_dependencies(LLVMScalarOpts intrinsics_gen)
 
-target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL) # HLSL Change
+target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change

--- a/tools/clang/tools/dxil2spv/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/CMakeLists.txt
@@ -1,31 +1,19 @@
 # This file is distributed under the University of Illinois Open Source License. See LICENSE.TXT for details.
 # Builds dxil2spv.exe
 
-set( LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  dxcsupport
-  Support    # just for assert and raw streams
-  dxil
-  dxilcontainer
-  )
-
-add_subdirectory(lib)
-
 add_clang_executable(dxil2spv
   dxil2spvmain.cpp
   )
 
+add_subdirectory(lib)
+
 target_link_libraries(dxil2spv
-  dxcompiler
-  dxclib
   clangSPIRV
-  SPIRV-Tools
+  dxclib
+  dxcompiler
   dxil2spvlib
+  SPIRV-Tools
   )
-
-llvm_map_components_to_libnames(llvm_libs support core irreader dxil)
-
-target_link_libraries(dxil2spv ${llvm_libs})
 
 set_target_properties(dxil2spv
   PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})

--- a/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
+++ b/tools/clang/tools/dxil2spv/dxil2spvmain.cpp
@@ -65,13 +65,6 @@ int main(int argc, const char **argv_) {
     llvm::errs() << "Required input file argument is missing\n";
     return DXC_E_GENERAL_INTERNAL_ERROR;
   }
-  hlsl::options::StringRefWide filename(argv_[1]);
-
-  // Read input file.
-  dxc::DxcDllSupport dxcSupport;
-  IFT(dxcSupport.Initialize());
-  CComPtr<IDxcBlobEncoding> blob;
-  ReadFileIntoBlob(dxcSupport, filename, &blob);
 
   // Setup a compiler instance with diagnostics.
   clang::CompilerInstance instance;
@@ -83,7 +76,11 @@ int main(int argc, const char **argv_) {
   // TODO: Allow configuration of targetEnv via options.
   instance.getCodeGenOpts().SpirvOptions.targetEnv = "vulkan1.0";
 
+  // Set input filename.
+  const llvm::StringRef inputFilename(argv_[1]);
+  instance.getCodeGenOpts().MainFileName = inputFilename;
+
   // Run translator.
   clang::dxil2spv::Translator translator(instance);
-  return translator.Run(blob);
+  return translator.Run();
 }

--- a/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
@@ -1,25 +1,26 @@
 # This file is distributed under the University of Illinois Open Source License. See LICENSE.TXT for details.
 
-set( LLVM_LINK_COMPONENTS
+set(LLVM_LINK_COMPONENTS
   ${LLVM_TARGETS_TO_BUILD}
+  core
   dxcsupport
-  Support
   dxil
   dxilcontainer
+  irreader
+  support
   )
-
 
 add_clang_library(dxil2spvlib
   dxil2spv.cpp
   )
 
 target_link_libraries(dxil2spvlib
-  dxcompiler
-  dxclib
+  clangBasic
+  clangCodeGen
   clangSPIRV
+  dxclib
+  dxcompiler
+  LLVMHLSL
+  LLVMipo
   SPIRV-Tools
   )
-
-llvm_map_components_to_libnames(llvm_libs support core irreader dxil)
-
-target_link_libraries(dxil2spvlib ${llvm_libs})

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -25,6 +25,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 
 #include "spirv-tools/libspirv.hpp"
+#include "clang/CodeGen/CodeGenAction.h"
 #include "clang/Frontend/CodeGenOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 
@@ -37,43 +38,47 @@ Translator::Translator(CompilerInstance &instance)
       featureManager(diagnosticsEngine, spirvOptions),
       spvBuilder(spvContext, spirvOptions, featureManager) {}
 
-int Translator::Run(CComPtr<IDxcBlobEncoding> blob) {
-  const char *blobContext =
-      reinterpret_cast<const char *>(blob->GetBufferPointer());
-  unsigned blobSize = blob->GetBufferSize();
-
-  llvm::LLVMContext context;
-  llvm::SMDiagnostic err;
-  std::unique_ptr<llvm::MemoryBuffer> memoryBuffer;
-  std::unique_ptr<llvm::Module> module;
+int Translator::Run() {
+  // Read input file to memory buffer.
+  std::string filename = ci.getCodeGenOpts().MainFileName;
+  auto errorOrInputFile = llvm::MemoryBuffer::getFileOrSTDIN(filename);
+  if (!errorOrInputFile) {
+    emitError("Error reading %0: %1")
+        << filename << errorOrInputFile.getError().message();
+    return DXC_E_GENERAL_INTERNAL_ERROR;
+  }
+  llvm::MemoryBuffer *memoryBuffer = errorOrInputFile.get().release();
+  const char *blobContext = memoryBuffer->getBufferStart();
+  unsigned blobSize = memoryBuffer->getBufferSize();
 
   // Parse LLVM module from bitcode.
-  hlsl::DxilContainerHeader *pBlobHeader =
-      (hlsl::DxilContainerHeader *)blob->GetBufferPointer();
-  if (hlsl::IsValidDxilContainer(pBlobHeader,
-                                 pBlobHeader->ContainerSizeInBytes)) {
+  llvm::LLVMContext llvmContext;
+  std::unique_ptr<llvm::Module> module;
+  const hlsl::DxilContainerHeader *blobHeader =
+      reinterpret_cast<const hlsl::DxilContainerHeader *>(blobContext);
+  if (hlsl::IsValidDxilContainer(blobHeader,
+                                 blobHeader->ContainerSizeInBytes)) {
 
     // Get DXIL program from container.
-    const hlsl::DxilPartHeader *pPartHeader =
-        hlsl::GetDxilPartByType(pBlobHeader, hlsl::DxilFourCC::DFCC_DXIL);
-    IFTBOOL(pPartHeader != nullptr, DXC_E_MISSING_PART);
-    const hlsl::DxilProgramHeader *pProgramHeader =
+    const hlsl::DxilPartHeader *partHeader =
+        hlsl::GetDxilPartByType(blobHeader, hlsl::DxilFourCC::DFCC_DXIL);
+    IFTBOOL(partHeader != nullptr, DXC_E_MISSING_PART);
+    const hlsl::DxilProgramHeader *programHeader =
         reinterpret_cast<const hlsl::DxilProgramHeader *>(
-            GetDxilPartData(pPartHeader));
+            GetDxilPartData(partHeader));
 
     // Parse DXIL program to module.
-    if (IsValidDxilProgramHeader(pProgramHeader, pPartHeader->PartSize)) {
-      std::string DiagStr;
-      GetDxilProgramBitcode(pProgramHeader, &blobContext, &blobSize);
+    if (IsValidDxilProgramHeader(programHeader, partHeader->PartSize)) {
+      std::string diagStr;
+      GetDxilProgramBitcode(programHeader, &blobContext, &blobSize);
       module = hlsl::dxilutil::LoadModuleFromBitcode(
-          llvm::StringRef(blobContext, blobSize), context, DiagStr);
+          llvm::StringRef(blobContext, blobSize), llvmContext, diagStr);
     }
   }
   // Parse LLVM module from IR.
   else {
-    llvm::StringRef bufStrRef(blobContext, blobSize);
-    memoryBuffer = llvm::MemoryBuffer::getMemBufferCopy(bufStrRef);
-    module = parseIR(memoryBuffer->getMemBufferRef(), err, context);
+    llvm::SMDiagnostic err;
+    module = parseIR(memoryBuffer->getMemBufferRef(), err, llvmContext);
   }
 
   if (module == nullptr) {

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -26,7 +26,7 @@ namespace dxil2spv {
 class Translator {
 public:
   Translator(CompilerInstance &instance);
-  int Run(CComPtr<IDxcBlobEncoding> blob);
+  int Run();
 
 private:
   CompilerInstance &ci;


### PR DESCRIPTION
Read DXIL file directly into llvm::MemoryBuffer rather than through an
IDxcBlobEncoding. This also allows support for supplying file by STDIN
(not yet with dedicated CLI).

Also clean up some CMake LLVM dependencies.