### PR TITLE
Clean up debug preprocessor macros

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -57,6 +57,8 @@ endif()
 
 if( LLVM_ENABLE_ASSERTIONS )
   # MSVC doesn't like _DEBUG on release builds. See PR 4379.
+  # HLSL Note: the above comment referrs to llvm.org problem, not pull request: 
+  #            https://bugs.llvm.org/show_bug.cgi?id=4379
   if( NOT MSVC )
     add_definitions( -D_DEBUG )
   endif()

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -56,9 +56,10 @@ int main() { return (float)x; }"
 endif()
 
 if( LLVM_ENABLE_ASSERTIONS )
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDBG") # HLSL Change
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -UNDEBUG") # HLSL Change
-  if (0) # HLSL Change Starts
+  # MSVC doesn't like _DEBUG on release builds. See PR 4379.
+  if( NOT MSVC )
+    add_definitions( -D_DEBUG )
+  endif()
   # On non-Debug builds cmake automatically defines NDEBUG, so we
   # explicitly undefine it:
   if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
@@ -75,7 +76,6 @@ if( LLVM_ENABLE_ASSERTIONS )
         "${flags_var_to_scrub}" "${${flags_var_to_scrub}}")
     endforeach()
   endif()
-  endif (0) # HLSL Change Ends
 endif()
 
 string(TOUPPER "${LLVM_ABI_BREAKING_CHECKS}" uppercase_LLVM_ABI_BREAKING_CHECKS)

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -31,11 +31,11 @@ inline uint32_t PSVComputeInputOutputTableDwords(uint32_t InputVectors, uint32_t
 #define PSVALIGN(ptr, alignbits) (((ptr) + ((1 << (alignbits))-1)) & ~((1 << (alignbits))-1))
 #define PSVALIGN4(ptr) (((ptr) + 3) & ~3)
 
-#ifdef DBG
+#ifndef NDEBUG
 #define PSV_RETB(exp) do { if(!(exp)) { assert(false && #exp); return false; } } while(0)
-#else   // DBG
+#else   // NDEBUG
 #define PSV_RETB(exp) do { if(!(exp)) { return false; } } while(0)
-#endif  // DBG
+#endif  // NDEBUG
 
 struct VSInfo {
   char OutputPositionPresent;

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -146,11 +146,11 @@ bool DxilRuntimeData::InitFromRDAT(const void *pRDAT, size_t size) {
           continue; // Skip unrecognized parts
         }
       }
-#ifdef DBG
+#ifndef NDEBUG
       return Validate();
-#else  // DBG
+#else  // NDEBUG
       return true;
-#endif // DBG
+#endif // NDEBUG
     } catch(CheckedReader::exception e) {
       // TODO: error handling
       //throw hlsl::Exception(DXC_E_MALFORMED_CONTAINER, e.what());

--- a/include/dxc/HLSL/DxilSignatureAllocator.inl
+++ b/include/dxc/HLSL/DxilSignatureAllocator.inl
@@ -469,7 +469,7 @@ unsigned DxilSignatureAllocator::PackOptimized(std::vector<PackElement*> element
       if (bFullyAllocated) {
         // Found a spot, do real allocation
         PackGreedy(clipcullElements, row, DXIL::kMaxClipOrCullDistanceElementCount);
-#ifdef DBG
+#ifndef NDEBUG
         for (auto &SE : clipcullElements) {
           bFullyAllocated &= SE->IsAllocated();
           if (!bFullyAllocated)

--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -178,7 +178,7 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 
 #endif // _MSC_VER
 
-#ifdef DBG
+#ifndef NDEBUG
 
 #ifdef _WIN32
 
@@ -226,7 +226,7 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 
 #endif // _WIN32
 
-#else // DBG
+#else // NDEBUG
 
 // DXASSERT_ARGS is disabled in free builds.
 #define DXASSERT_ARGS(exp, s, ...) _Analysis_assume_(exp)
@@ -244,4 +244,4 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 // DXVERIFY is patterned after NT_VERIFY and will evaluate the expression
 #define DXVERIFY_NOMSG(exp) do { (void)(exp); _Analysis_assume_(exp); } while (0)
 
-#endif // DBG
+#endif // NDEBUG

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -124,7 +124,7 @@ DxilModule::DxilModule(Module *pModule)
   DXASSERT_NOMSG(m_pModule != nullptr);
   SetDxilHook(*m_pModule);
 
-#ifdef NDEBUG
+#ifndef NDEBUG
   // Pin LLVM dump methods.
   void (__thiscall Module::*pfnModuleDump)() const = &Module::dump;
   void (__thiscall Type::*pfnTypeDump)() const = &Type::dump;

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -124,7 +124,7 @@ DxilModule::DxilModule(Module *pModule)
   DXASSERT_NOMSG(m_pModule != nullptr);
   SetDxilHook(*m_pModule);
 
-#if defined(_DEBUG) || defined(DBG)
+#ifdef NDEBUG
   // Pin LLVM dump methods.
   void (__thiscall Module::*pfnModuleDump)() const = &Module::dump;
   void (__thiscall Type::*pfnTypeDump)() const = &Type::dump;
@@ -1622,7 +1622,7 @@ void DxilModule::LoadDxilMetadata() {
     m_pMDHelper->LoadDxilTypeSystem(*m_pTypeSystem.get());
   } catch (hlsl::Exception &) {
     m_bMetadataErrors = true;
-#ifdef DBG
+#ifndef NDEBUG
     throw;
 #endif
     m_pTypeSystem->GetStructAnnotationMap().clear();
@@ -1634,7 +1634,7 @@ void DxilModule::LoadDxilMetadata() {
     m_pMDHelper->LoadDxrPayloadAnnotations(*m_pTypeSystem.get());
   } catch (hlsl::Exception &) {
     m_bMetadataErrors = true;
-#ifdef DBG
+#ifndef NDEBUG
     throw;
 #endif
     m_pTypeSystem->GetPayloadAnnotationMap().clear();

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -745,7 +745,7 @@ static bool ProcessUnhandledObjectType(
   D3D_SHADER_VARIABLE_TYPE    *outObjectType)
 {
   // Don't actually make this a hard error, but instead report the problem using a suitable debug message.
-#ifdef DBG
+#ifndef NDEBUG
   OutputDebugFormatA("DxilContainerReflection.cpp: error: unhandled object type '%s'.\n", structType->getName().str().c_str());
 #endif
   *outObjectType = D3D_SVT_VOID;
@@ -1034,7 +1034,7 @@ HRESULT CShaderReflectionType::Initialize(
     break;
 
   default:
-#ifdef DBG
+#ifndef NDEBUG
     OutputDebugStringA("DxilContainerReflection.cpp: error: unknown component type\n");
 #endif
     break;
@@ -1051,7 +1051,7 @@ HRESULT CShaderReflectionType::Initialize(
     switch(matrixAnnotation.Orientation)
     {
     default:
-#ifdef DBG
+#ifndef NDEBUG
       OutputDebugStringA("DxilContainerReflection.cpp: error: unknown matrix orientation\n");
 #endif
     // Note: column-major layout is the default
@@ -1193,7 +1193,7 @@ HRESULT CShaderReflectionType::Initialize(
   }
   else if( type->isPointerTy() )
   {
-#ifdef DBG
+#ifndef NDEBUG
       OutputDebugStringA("DxilContainerReflection.cpp: error: cannot reflect pointer type\n");
 #endif
   }

--- a/lib/Support/MSFileSystemBasic.cpp
+++ b/lib/Support/MSFileSystemBasic.cpp
@@ -971,7 +971,7 @@ int MSFileSystemForIface::Fstat(int FD, struct stat *Status) throw() {
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Blocked MSFileSystem implementation.
 
-#ifdef DBG
+#ifndef NDEBUG
 static void MSFileSystemBlockedCalled() { DebugBreak(); }
 #else
 static void MSFileSystemBlockedCalled() { }

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -908,7 +908,7 @@ void DxbcConverter::ConvertSignature(SignatureHelper &SigHelper, DxilSignature &
               E.SetRows(Rows);
               SigHelper.m_Signature.AppendElement(std::move(pE));
             } else {
-#ifdef DBG
+#ifndef NDEBUG
               // Verify match with range representative element.
               DxilSignatureElement &RE = SigHelper.m_Signature.GetElement(itKeyDxilEl->second);
               DXASSERT_DXBC(RE.GetCompType() == E.GetCompType());
@@ -1862,7 +1862,7 @@ void DxbcConverter::AnalyzeShader(D3D10ShaderBinary::CShaderCodeParser &Parser) 
       DXASSERT_DXBC(Inst.m_NumOperands == 0);
       auto& Iface = m_Interfaces[Inst.m_InterfaceDecl.InterfaceNumber];
       Iface.Tables.assign(Inst.m_InterfaceDecl.pFunctionTableIdentifiers, Inst.m_InterfaceDecl.pFunctionTableIdentifiers + Inst.m_InterfaceDecl.TableLength);
-#ifdef DBG
+#ifndef NDEBUG
       for (unsigned TableIdx : Iface.Tables) {
           DXASSERT_DXBC(m_FunctionTables[TableIdx].size() == Inst.m_InterfaceDecl.ExpectedTableSize);
       }

--- a/tools/clang/lib/AST/HlslBuiltinTypeDeclBuilder.cpp
+++ b/tools/clang/lib/AST/HlslBuiltinTypeDeclBuilder.cpp
@@ -109,7 +109,7 @@ FieldDecl* BuiltinTypeDeclBuilder::addField(StringRef name, QualType type, Acces
   fieldDecl->setImplicit(true);
   m_recordDecl->addDecl(fieldDecl);
 
-#ifdef DBG
+#ifndef NDEBUG
   // Verify that we can read the field member from the record.
   DeclContext::lookup_result lookupResult = m_recordDecl->lookup(DeclarationName(&nameId));
   DXASSERT(!lookupResult.empty(), "Field cannot be looked up");

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -820,7 +820,7 @@ QualType GetOrCreateMatrixSpecialization(ASTContext& context, Sema* sema,
 
   QualType matrixSpecializationType = GetOrCreateTemplateSpecialization(context, *sema, matrixTemplateDecl, ArrayRef<TemplateArgument>(templateArgs));
 
-#ifdef DBG
+#ifndef NDEBUG
   // Verify that we can read the field member from the template record.
   DXASSERT(matrixSpecializationType->getAsCXXRecordDecl(), 
            "type of non-dependent specialization is not a RecordType");
@@ -851,7 +851,7 @@ QualType GetOrCreateVectorSpecialization(ASTContext& context, Sema* sema,
 
   QualType vectorSpecializationType = GetOrCreateTemplateSpecialization(context, *sema, vectorTemplateDecl, ArrayRef<TemplateArgument>(templateArgs));
 
-#ifdef DBG
+#ifndef NDEBUG
   // Verify that we can read the field member from the template record.
   DXASSERT(vectorSpecializationType->getAsCXXRecordDecl(), 
            "type of non-dependent specialization is not a RecordType");

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -43,7 +43,7 @@ namespace {
 #endif
 
 #ifdef _WIN32
-#ifdef DBG
+#ifndef NDEBUG
 
 // This should be improved with global enabled mask rather than a compile-time mask.
 #define DXTRACE_MASK_ENABLED  0
@@ -61,7 +61,7 @@ namespace {
 
 #define DXTRACE_FMT_APIFS(...)
 
-#endif // DBG
+#endif // NDEBUG
 #else  // _WIN32
 #define DXTRACE_FMT_APIFS(...)
 #endif // _WIN32
@@ -732,7 +732,7 @@ public:
       return -1;
     }
 
-#ifdef _DEBUG
+#ifndef NDEBUG
     if (fd == STDERR_FILENO) {
         char* copyWithNull = new char[count+1];
         strncpy(copyWithNull, (const char*)buffer, count);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1619,7 +1619,7 @@ public:
     if (pFlags == nullptr)
       return E_INVALIDARG;
     *pFlags = DxcVersionInfoFlags_None;
-#ifdef _DEBUG
+#ifndef NDEBUG
     *pFlags |= DxcVersionInfoFlags_Debug;
 #endif
     return S_OK;

--- a/tools/clang/tools/dxcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxcompiler/dxcvalidator.cpp
@@ -247,7 +247,7 @@ HRESULT STDMETHODCALLTYPE DxcValidator::GetFlags(_Out_ UINT32 *pFlags) {
   if (pFlags == nullptr)
     return E_INVALIDARG;
   *pFlags = DxcVersionInfoFlags_None;
-#ifdef _DEBUG
+#ifndef NDEBUG
   *pFlags |= DxcVersionInfoFlags_Debug;
 #endif
   *pFlags |= DxcVersionInfoFlags_Internal;

--- a/tools/clang/tools/dxrfallbackcompiler/dxcvalidator.cpp
+++ b/tools/clang/tools/dxrfallbackcompiler/dxcvalidator.cpp
@@ -158,7 +158,7 @@ HRESULT STDMETHODCALLTYPE DxcValidator::GetFlags(_Out_ UINT32 *pFlags) {
   if (pFlags == nullptr)
     return E_INVALIDARG;
   *pFlags = DxcVersionInfoFlags_None;
-#ifdef _DEBUG
+#ifndef NDEBUG
   *pFlags |= DxcVersionInfoFlags_Debug;
 #endif
   *pFlags |= DxcVersionInfoFlags_Internal;

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -1998,7 +1998,7 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(
 void PixTest::ValidateAllocaWrite(std::vector<AllocaWrite> const &allocaWrites,
                                   size_t index, const char *name) {
   VERIFY_ARE_EQUAL(index, allocaWrites[index].regBase + allocaWrites[index].index);
-#if DBG
+#ifndef NDEBUG
   // Compilation may add a prefix to the struct member name:
   VERIFY_IS_TRUE(0 == strncmp(name, allocaWrites[index].memberName.c_str(), strlen(name)));
 #endif


### PR DESCRIPTION
This change removes the `DBG` macro value in favor of `NDEBUG`, and
also converts many uses of `_DEBUG` with `NDEBUG`.

`_DEBUG` is set by MSVC when debug information generation is enabled.
`NDEBUG` is set by CMake debug configurations and by LLVM on all
configurations when `LLVM_ENABLE_ASSERTIONS` is set.

Aligning with LLVM's `NDEBUG` usage allows a consistent pattern
throughout the codebase.