### PR TITLE
Make external sema source handle type completion

### DIFF
--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -407,7 +407,7 @@ CXXRecordDecl* hlsl::DeclareRecordTypeWithHandle(ASTContext& context, StringRef 
   BuiltinTypeDeclBuilder typeDeclBuilder(context.getTranslationUnitDecl(), name, TagDecl::TagKind::TTK_Struct);
   typeDeclBuilder.startDefinition();
   typeDeclBuilder.addField("h", GetHLSLObjectHandleType(context));
-  return typeDeclBuilder.completeDefinition();
+  return typeDeclBuilder.getRecordDecl();
 }
 
 // creates a global static constant unsigned integer with value.
@@ -725,7 +725,7 @@ CXXRecordDecl* hlsl::DeclareTemplateTypeWithHandleInDeclContext(
 
   typeDeclBuilder.addField("h", elementType);
 
-  return typeDeclBuilder.completeDefinition();
+  return typeDeclBuilder.getRecordDecl();
 }
 
 FunctionTemplateDecl* hlsl::CreateFunctionTemplateDecl(
@@ -866,7 +866,7 @@ CXXRecordDecl *hlsl::DeclareUIntTemplatedTypeWithHandleInDeclContext(
   typeDeclBuilder.addIntegerTemplateParam(templateParamName, context.UnsignedIntTy);
   typeDeclBuilder.startDefinition();
   typeDeclBuilder.addField("h", context.UnsignedIntTy); // Add an 'h' field to hold the handle.
-  return typeDeclBuilder.completeDefinition();
+  return typeDeclBuilder.getRecordDecl();
 }
 
 clang::CXXRecordDecl *
@@ -887,7 +887,7 @@ hlsl::DeclareConstantBufferViewType(clang::ASTContext &context, bool bTBuf) {
   typeDeclBuilder.addField(
       "h", context.UnsignedIntTy); // Add an 'h' field to hold the handle.
 
-  typeDeclBuilder.completeDefinition();
+  typeDeclBuilder.getRecordDecl();
 
   return templateRecordDecl;
 }
@@ -907,7 +907,7 @@ CXXRecordDecl* hlsl::DeclareRayQueryType(ASTContext& context) {
   CreateConstructorDeclaration(context, typeDeclBuilder.getRecordDecl(), context.VoidTy, {}, context.DeclarationNames.getCXXConstructorName(canQualType), false, &pConstructorDecl, &pTypeSourceInfo);
   typeDeclBuilder.getRecordDecl()->addDecl(pConstructorDecl);
 
-  return typeDeclBuilder.completeDefinition();
+  return typeDeclBuilder.getRecordDecl();
 }
 
 CXXRecordDecl* hlsl::DeclareResourceType(ASTContext& context, bool bSampler) {
@@ -920,7 +920,7 @@ CXXRecordDecl* hlsl::DeclareResourceType(ASTContext& context, bool bSampler) {
 
   typeDeclBuilder.addField("h", GetHLSLObjectHandleType(context));
 
-  CXXRecordDecl *recordDecl = typeDeclBuilder.completeDefinition();
+  CXXRecordDecl *recordDecl = typeDeclBuilder.getRecordDecl();
 
   QualType indexType = context.UnsignedIntTy;
   QualType resultType = context.getRecordType(recordDecl);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5114,24 +5114,25 @@ public:
   ImplicitConversionSequence TrySubscriptIndexInitialization(_In_ clang::Expr* SrcExpr, clang::QualType DestType);
 
   void CompleteType(TagDecl *Tag) override {
-    if(Tag->isCompleteDefinition() || !isa<CXXRecordDecl>(Tag))
+    if (Tag->isCompleteDefinition() || !isa<CXXRecordDecl>(Tag))
       return;
 
     CXXRecordDecl *recordDecl = cast<CXXRecordDecl>(Tag);
-    if (auto TDecl = dyn_cast<ClassTemplateSpecializationDecl>(recordDecl))
+    if (auto TDecl = dyn_cast<ClassTemplateSpecializationDecl>(recordDecl)) {
       recordDecl = TDecl->getSpecializedTemplate()->getTemplatedDecl();
 
-    if (recordDecl->isCompleteDefinition())
-      return;
-    
+      if (recordDecl->isCompleteDefinition())
+        return;
+    }
+
     int idx = FindObjectBasicKindIndex(recordDecl);
     // Not object type.
     if (idx == -1)
       return;
-    
+
     ArBasicKind kind = g_ArBasicKindsAsTypes[idx];
     uint8_t templateArgCount = g_ArBasicKindsTemplateCount[idx];
-    
+
     int startDepth = 0;
 
     if (templateArgCount > 0) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/InstantiateObjectMethods.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/InstantiateObjectMethods.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_6 -E main -HV 2021 -ast-dump %s | FileCheck %s
+template <typename T> struct MyTex2D {
+  uint heapId;
+
+  template <typename Arg0> T Load(Arg0 arg0) { return Get().Load(arg0); }
+
+  Texture2D<T> Get() { return (Texture2D<T>)ResourceDescriptorHeap[heapId]; }
+};
+
+cbuffer constantBuffer : register(b0) {
+  MyTex2D<float4> tex;
+};
+
+float4 main() : SV_Target {
+  float4 output = tex.Load(float3(0, 0, 0));
+  return output;
+}
+
+// CHECK:      CXXMemberCallExpr 0x{{[0-9a-fA-F]+}} <col:55, col:70> 'vector<float, 4>'
+// CHECK-NEXT: MemberExpr 0x{{[0-9a-fA-F]+}} <col:55, col:61> '<bound member function type>' .Load
+// CHECK-NEXT: CXXMemberCallExpr 0x{{[0-9a-fA-F]+}} <col:55, col:59> 'Texture2D<vector<float, 4> >':'Texture2D<vector<float, 4> >'
+// CHECK-NEXT: MemberExpr 0x{{[0-9a-fA-F]+}} <col:55> '<bound member function type>' .Get
+// CHECK-NEXT: CXXThisExpr 0x{{[0-9a-fA-F]+}} <col:55> 'MyTex2D<vector<float, 4>
+// >' lvalue this


### PR DESCRIPTION
Prior to this change the HLSL built in types are inserted into the AST
during initialization as complete types missing their methods. The
method implementations are then inserted during parsing when handling
declarators and parameter declarations of the built in types.

This method of lazy expansion does not work with HLSL templates because
template declarators in dependent contexts are not handled by the
parser, so they bypass the code path that generates method definitions
(see #4315).

This change alters how we lazy initialize types. Instead of
lazy-initializing in parsing, this change lazy initializes when the
type is required to be complete. This is accomplished by creating the
built in type objects as incomplete decls, and adding an override for
`CompleteType` to the `HLSLExternalSource`.

This change simplifies our code because we can use the type's
`IsCompleteDefinition` flag to track types that have been completed
instead of our own bitmask system.

Fixes #4315