### PR TITLE
Add -arm64 argument to hcttest; exclude tests with issues on ARM64 & WARP

### DIFF
--- a/tools/clang/test/HLSLDisabled/memcpy_split_regression-strictudt.hlsl
+++ b/tools/clang/test/HLSLDisabled/memcpy_split_regression-strictudt.hlsl
@@ -1,3 +1,6 @@
+// This test is disabled because it crashes on ARM64. Bug filed:
+// 38575954: ARM64-only compiler crash in memcpy_split_regression-strictudt.hlsl
+
 // RUN: %dxc -E main -T ps_6_0 -Od -strict-udt-casting %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -Od -HV 2021 %s | FileCheck %s
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3514,7 +3514,7 @@ TEST_F(CompilerTest, CompileHlsl2022ThenFail) {
   CheckOperationResultMsgs(pResult, &pErrorMsg, 1, false, false);
 }
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_M_ARM64) // this test has issues on ARM64; disable until we figure out what it going on
 
 #pragma fenv_access(on)
 #pragma optimize("", off)
@@ -3556,7 +3556,6 @@ void VerifyDivByZeroThrows() {
   VERIFY_IS_TRUE(bCaughtExpectedException);
 }
 
-#ifndef _M_ARM64 // this test has issues on ARM64; disable until we figure out what it going on
 TEST_F(CompilerTest, CodeGenFloatingPointEnvironment) {
   unsigned int fpOriginal;
   VERIFY_IS_TRUE(_controlfp_s(&fpOriginal, 0, 0) == 0);
@@ -3588,18 +3587,17 @@ TEST_F(CompilerTest, CodeGenFloatingPointEnvironment) {
   VERIFY_IS_TRUE(_controlfp_s(&fpLocal, 0, 0) == 0);
   VERIFY_ARE_EQUAL(fpLocal, fpOriginal);
 }
-#endif
 
 #pragma optimize("", on)
 
-#else   // _WIN32
+#else   //  defined(_WIN32) && !defined(_M_ARM64)
 
 // Only implemented on Win32
 TEST_F(CompilerTest, CodeGenFloatingPointEnvironment) {
   VERIFY_IS_TRUE(true);
 }
 
-#endif  // _WIN32
+#endif  //  defined(_WIN32) && !defined(_M_ARM64)
 
 TEST_F(CompilerTest, CodeGenInclude) {
   CodeGenTestCheck(L"Include.hlsl");

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3514,7 +3514,7 @@ TEST_F(CompilerTest, CompileHlsl2022ThenFail) {
   CheckOperationResultMsgs(pResult, &pErrorMsg, 1, false, false);
 }
 
-#if defined(_WIN32) && !defined(_M_ARM64) // this test has issues on ARM64; disable until we figure out what it going on
+#if defined(_WIN32) && !(defined(_M_ARM64) || defined(_M_ARM64EC)) // this test has issues on ARM64; disable until we figure out what it going on
 
 #pragma fenv_access(on)
 #pragma optimize("", off)

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -6940,14 +6940,6 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
     return;
   }
 
-#if defined(_M_ARM64) || defined(_M_ARM64EC)
-  if (GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) {
-    WEX::Logging::Log::Comment(L"WARP has an issue with DenormBinaryFloatOpTest on ARM64.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-#endif // defined(_M_ARM64) || defined(_M_ARM64EC)
-
   // Read data from the table
   int tableSize = sizeof(DenormBinaryFPOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(DenormBinaryFPOpParameters, tableSize);
@@ -6983,6 +6975,15 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
     DXASSERT(Validation_Expected2->size() == Validation_Expected1->size(),
              "must have same number of expected values");
   }
+
+  #if defined(_M_ARM64) || defined(_M_ARM64EC)
+    if ((GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) && mode == Float32DenormMode::Preserve) {
+      WEX::Logging::Log::Comment(L"WARP has an issue with DenormBinaryFloatOpTest with '-denorm preserve' on ARM64.");
+      WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+      return;
+    }
+  #endif // defined(_M_ARM64) || defined(_M_ARM64EC)
+
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
     pDevice, m_support, pStream, "BinaryFPOp",
     // this callbacked is called when the test
@@ -7057,14 +7058,6 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
     return;
   }
 
-#ifdef _M_ARM64
-  if (GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) {
-    WEX::Logging::Log::Comment(L"WARP has an issue with DenormTertiaryFloatOpTest on ARM64.");
-    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
-    return;
-  }
-#endif
-
   // Read data from the table
   int tableSize = sizeof(DenormTertiaryFPOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(DenormTertiaryFPOpParameters, tableSize);
@@ -7102,6 +7095,15 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
     DXASSERT(Validation_Expected2->size() == Validation_Expected1->size(),
       "must have same number of expected values");
   }
+
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+  if ((GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) && mode == Float32DenormMode::Preserve) {
+    WEX::Logging::Log::Comment(L"WARP has an issue with DenormTertiaryFloatOpTest with '-denorm preserve' on ARM64.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+#endif // defined(_M_ARM64) || defined(_M_ARM64EC)
+
   std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(
     pDevice, m_support, pStream, "TertiaryFPOp",
     // this callbacked is called when the test

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -6940,13 +6940,13 @@ TEST_F(ExecutionTest, DenormBinaryFloatOpTest) {
     return;
   }
 
-#ifdef _M_ARM64
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
   if (GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) {
     WEX::Logging::Log::Comment(L"WARP has an issue with DenormBinaryFloatOpTest on ARM64.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
     return;
   }
-#endif
+#endif // defined(_M_ARM64) || defined(_M_ARM64EC)
 
   // Read data from the table
   int tableSize = sizeof(DenormBinaryFPOpParameters) / sizeof(TableParameter);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -7056,8 +7056,16 @@ TEST_F(ExecutionTest, DenormTertiaryFloatOpTest) {
   if (!CreateDevice(&pDevice, D3D_SHADER_MODEL::D3D_SHADER_MODEL_6_2)) {
     return;
   }
-  // Read data from the table
 
+#ifdef _M_ARM64
+  if (GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) {
+    WEX::Logging::Log::Comment(L"WARP has an issue with DenormTertiaryFloatOpTest on ARM64.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+#endif
+
+  // Read data from the table
   int tableSize = sizeof(DenormTertiaryFPOpParameters) / sizeof(TableParameter);
   TableParameterHandler handler(DenormTertiaryFPOpParameters, tableSize);
 

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal ENABLEDELAYEDEXPANSION
+setlocal ENABLEDELAYEDEXPANSION ENABLEEXTENSIONS
 
 if "%BUILD_CONFIG%"=="" (
   set BUILD_CONFIG=Debug
@@ -26,7 +26,6 @@ set TEST_MANUAL_FILE_CHECK=0
 set SINGLE_FILE_CHECK_NAME=0
 set CUSTOM_BIN_SET=
 set USE_AGILITY_SDK=
-set BUILD_ARCH=x64
 
 rem Begin SPIRV change
 set TEST_SPIRV=0
@@ -146,7 +145,7 @@ if "%1"=="-clean" (
   set BUILD_CONFIG=Debug
 ) else if /i "%1"=="-x86" (
   rem Allow BUILD_ARCH override.  This may be used by HCT_EXTRAS scripts.
-  set BUILD_ARCH=x86
+  set BUILD_ARCH=Win32
 ) else if /i "%1"=="-x64" (
   set BUILD_ARCH=x64
 ) else if /i "%1"=="-arm" (
@@ -451,7 +450,7 @@ rem %4 - third argument to te
 if "%HLSL_TAEF_DIR%"=="" (
   set TE=te
 ) else (
-  set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH%\te"
+  set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\te"
 )
 echo %TE% /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
 call %TE% /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
@@ -501,16 +500,16 @@ if "%HLSL_TAEF_DIR%"=="" (
   exit /b 1
 )
 set FULL_AGILITY_PATH=
-if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH%\D3D12Core.dll" (
-  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH%
-) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH%\D3D12Core.dll" (
-  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH%
+if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%
+) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%
 ) else if exist "%HLSL_AGILITYSDK_DIR%\D3D12Core.dll" (
   set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%
 ) else (
   echo HLSL_AGILITYSDK_DIR is set, but unable to resolve path to binaries
   exit /b 1
 )
-mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH%\D3D12" 1>nul 2>nul
-call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\%BUILD_ARCH%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
+mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" 1>nul 2>nul
+call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
 exit /b %ERRORLEVEL%

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -281,6 +281,11 @@ rem End SPIRV change
 
 echo Running HLSL tests ...
 
+if "%BUILD_ARCH%"=="ARM64" (
+    rem ARM64 TAEF has an issue when running ARM64X tests with /parallel flag
+    set PARALLEL_OPTION=
+)
+
 if exist "%HCT_EXTRAS%\hcttest-before.cmd" (
   call "%HCT_EXTRAS%\hcttest-before.cmd" %TEST_DIR%
   if errorlevel 1 (
@@ -447,8 +452,8 @@ if "%HLSL_TAEF_DIR%"=="" (
 ) else (
   set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH%\te"
 )
-echo %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
-call %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
+echo %TE% /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
+call %TE% /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
 
 if errorlevel 1 (
   call :showtesample %*

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -26,6 +26,7 @@ set TEST_MANUAL_FILE_CHECK=0
 set SINGLE_FILE_CHECK_NAME=0
 set CUSTOM_BIN_SET=
 set USE_AGILITY_SDK=
+set BUILD_ARCH=x64
 
 rem Begin SPIRV change
 set TEST_SPIRV=0
@@ -143,13 +144,15 @@ if "%1"=="-clean" (
   set BUILD_CONFIG=Release
 ) else if /i "%1"=="-Debug" (
   set BUILD_CONFIG=Debug
-) else if "%1"=="-x86" (
+) else if /i "%1"=="-x86" (
   rem Allow BUILD_ARCH override.  This may be used by HCT_EXTRAS scripts.
-  set BUILD_ARCH=Win32
-) else if "%1"=="-x64" (
+  set BUILD_ARCH=x86
+) else if /i "%1"=="-x64" (
   set BUILD_ARCH=x64
-) else if "%1"=="-arm" (
+) else if /i "%1"=="-arm" (
   set BUILD_ARCH=ARM
+) else if /i "%1"=="-arm64" (
+  set BUILD_ARCH=ARM64
 ) else if "%1"=="-adapter" (
   set TEST_ADAPTER= /p:"Adapter=%~2"
   shift /1
@@ -442,7 +445,7 @@ rem %4 - third argument to te
 if "%HLSL_TAEF_DIR%"=="" (
   set TE=te
 ) else (
-  set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\te"
+  set TE="%HLSL_TAEF_DIR%\%BUILD_ARCH%\te"
 )
 echo %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
 call %TE% /labMode /miniDumpOnCrash /unicodeOutput:false /outputFolder:%TEST_DIR% %LOG_FILTER% %PARALLEL_OPTION% %TEST_DIR%\%*
@@ -492,16 +495,16 @@ if "%HLSL_TAEF_DIR%"=="" (
   exit /b 1
 )
 set FULL_AGILITY_PATH=
-if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
-  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH:Win32=x86%
-) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%\D3D12Core.dll" (
-  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH:Win32=x86%
+if exist "%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\build\native\bin\%BUILD_ARCH%
+) else if exist "%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH%\D3D12Core.dll" (
+  set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%\%BUILD_ARCH%
 ) else if exist "%HLSL_AGILITYSDK_DIR%\D3D12Core.dll" (
   set FULL_AGILITY_PATH=%HLSL_AGILITYSDK_DIR%
 ) else (
   echo HLSL_AGILITYSDK_DIR is set, but unable to resolve path to binaries
   exit /b 1
 )
-mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" 1>nul 2>nul
-call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
+mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH%\D3D12" 1>nul 2>nul
+call %HCT_DIR%\hctcopy.cmd "%FULL_AGILITY_PATH%" "%HLSL_TAEF_DIR%\%BUILD_ARCH%\D3D12" D3D12Core.dll d3d12SDKLayers.dll
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
- add arm64 argument to hcttest; use x86 as BUILD_ARCH instead of Win32 
- temporarily disable tests that have issues on ARM64, ARM64EC and WARP; bugs filed to track.
- remove obsoleted /labmode argument to TE.exe
- do not run arm64 tests in parallel (new TAEF has bug when -parallel is used, TAEF team has been notified)
