### PR TITLE
[dxil2spv] Implement simple entry function creation

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -74,6 +74,9 @@ public:
   SpirvFunction *createSpirvFunction(QualType returnType, SourceLocation,
                                      llvm::StringRef name, bool isPrecise,
                                      bool isNoInline = false);
+  SpirvFunction *createSpirvFunction(const SpirvType *returnType,
+                                     SourceLocation, llvm::StringRef name,
+                                     bool isPrecise, bool isNoInline = false);
 
   /// \brief Begins building a SPIR-V function by allocating a SpirvFunction
   /// object. Returns the pointer for the function on success. Returns nullptr
@@ -81,6 +84,10 @@ public:
   ///
   /// At any time, there can only exist at most one function under building.
   SpirvFunction *beginFunction(QualType returnType, SourceLocation,
+                               llvm::StringRef name = "",
+                               bool isPrecise = false, bool isNoInline = false,
+                               SpirvFunction *func = nullptr);
+  SpirvFunction *beginFunction(const SpirvType *returnType, SourceLocation,
                                llvm::StringRef name = "",
                                bool isPrecise = false, bool isNoInline = false,
                                SpirvFunction *func = nullptr);
@@ -720,6 +727,8 @@ public:
   /// Each of these methods can acquire a unique constant from the SpirvContext,
   /// and add the context to the list of constants in the module.
   SpirvConstant *getConstantInt(QualType type, llvm::APInt value,
+                                bool specConst = false);
+  SpirvConstant *getConstantInt(const SpirvType *type, llvm::APInt value,
                                 bool specConst = false);
   SpirvConstant *getConstantFloat(QualType type, llvm::APFloat value,
                                   bool specConst = false);

--- a/tools/clang/include/clang/SPIRV/SpirvFunction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvFunction.h
@@ -27,6 +27,9 @@ public:
   SpirvFunction(QualType astReturnType, SourceLocation,
                 llvm::StringRef name = "", bool precise = false,
                 bool noInline = false);
+  SpirvFunction(const SpirvType *spirvReturnType, SourceLocation,
+                llvm::StringRef name = "", bool precise = false,
+                bool noInline = false);
 
   ~SpirvFunction();
 

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1152,6 +1152,8 @@ class SpirvConstantInteger : public SpirvConstant {
 public:
   SpirvConstantInteger(QualType type, llvm::APInt value,
                        bool isSpecConst = false);
+  SpirvConstantInteger(const SpirvType *type, llvm::APInt value,
+                       bool isSpecConst = false);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvConstantInteger)
 

--- a/tools/clang/include/clang/SPIRV/SpirvUtils.h
+++ b/tools/clang/include/clang/SPIRV/SpirvUtils.h
@@ -1,0 +1,27 @@
+//===-- SpirvUtils.h - SPIR-V Utils ---------------------------*- C++ -*---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#ifndef LLVM_CLANG_SPIRV_SPIRVUTILS_H
+#define LLVM_CLANG_SPIRV_SPIRVUTILS_H
+
+#include "dxc/DXIL/DxilShaderModel.h"
+#include "dxc/DXIL/DxilSignatureElement.h"
+#include "spirv/unified1/spirv.hpp11"
+
+namespace clang {
+namespace spirv {
+
+class SpirvUtils {
+public:
+  static spv::ExecutionModel getSpirvShaderStage(hlsl::ShaderModel::Kind smk);
+};
+
+} // namespace spirv
+} // namespace clang
+
+#endif // LLVM_CLANG_SPIRV_SPIRVUTILS_H

--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -31,6 +31,7 @@ add_clang_library(clangSPIRV
   SpirvModule.cpp
   SpirvType.cpp
   String.cpp
+  SpirvUtils.cpp
 
   LINK_LIBS
   clangAST

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -14,16 +14,17 @@
 #include "SpirvEmitter.h"
 
 #include "AlignmentSizeCalculator.h"
+#include "InitListHandler.h"
 #include "RawBufferMethods.h"
+#include "dxc/DXIL/DxilConstants.h"
 #include "dxc/HlslIntrinsicOp.h"
 #include "spirv-tools/optimizer.hpp"
 #include "clang/SPIRV/AstTypeProbe.h"
+#include "clang/SPIRV/SpirvUtils.h"
 #include "clang/SPIRV/String.h"
 #include "clang/Sema/Sema.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringExtras.h"
-#include "InitListHandler.h"
-#include "dxc/DXIL/DxilConstants.h"
 
 #ifdef SUPPORT_QUERY_GIT_COMMIT_INFO
 #include "clang/Basic/Version.h"
@@ -702,7 +703,7 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
     const FunctionInfo *entryInfo = workQueue[i];
     assert(entryInfo->isEntryFunction);
     spvBuilder.addEntryPoint(
-        getSpirvShaderStage(entryInfo->shaderModelKind),
+        SpirvUtils::getSpirvShaderStage(entryInfo->shaderModelKind),
         entryInfo->entryFunction, entryInfo->funcDecl->getName(),
         getInterfacesForEntryPoint(entryInfo->entryFunction));
   }
@@ -11261,43 +11262,6 @@ hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName) {
     llvm_unreachable("unknown stage name");
   }
   return smk;
-}
-
-spv::ExecutionModel
-SpirvEmitter::getSpirvShaderStage(hlsl::ShaderModel::Kind smk) {
-  switch (smk) {
-  case hlsl::ShaderModel::Kind::Vertex:
-    return spv::ExecutionModel::Vertex;
-  case hlsl::ShaderModel::Kind::Hull:
-    return spv::ExecutionModel::TessellationControl;
-  case hlsl::ShaderModel::Kind::Domain:
-    return spv::ExecutionModel::TessellationEvaluation;
-  case hlsl::ShaderModel::Kind::Geometry:
-    return spv::ExecutionModel::Geometry;
-  case hlsl::ShaderModel::Kind::Pixel:
-    return spv::ExecutionModel::Fragment;
-  case hlsl::ShaderModel::Kind::Compute:
-    return spv::ExecutionModel::GLCompute;
-  case hlsl::ShaderModel::Kind::RayGeneration:
-    return spv::ExecutionModel::RayGenerationNV;
-  case hlsl::ShaderModel::Kind::Intersection:
-    return spv::ExecutionModel::IntersectionNV;
-  case hlsl::ShaderModel::Kind::AnyHit:
-    return spv::ExecutionModel::AnyHitNV;
-  case hlsl::ShaderModel::Kind::ClosestHit:
-    return spv::ExecutionModel::ClosestHitNV;
-  case hlsl::ShaderModel::Kind::Miss:
-    return spv::ExecutionModel::MissNV;
-  case hlsl::ShaderModel::Kind::Callable:
-    return spv::ExecutionModel::CallableNV;
-  case hlsl::ShaderModel::Kind::Mesh:
-    return spv::ExecutionModel::MeshNV;
-  case hlsl::ShaderModel::Kind::Amplification:
-    return spv::ExecutionModel::TaskNV;
-  default:
-    llvm_unreachable("invalid shader model kind");
-    break;
-  }
 }
 
 bool SpirvEmitter::processGeometryShaderAttributes(const FunctionDecl *decl,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -717,7 +717,6 @@ private:
   spv::LoopControlMask translateLoopAttribute(const Stmt *, const Attr &);
 
   static hlsl::ShaderModel::Kind getShaderModelKind(StringRef stageName);
-  static spv::ExecutionModel getSpirvShaderStage(hlsl::ShaderModel::Kind smk);
 
   /// \brief Adds necessary execution modes for the hull/domain shaders based on
   /// the HLSL attributes of the entry point function.

--- a/tools/clang/lib/SPIRV/SpirvFunction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvFunction.cpp
@@ -23,6 +23,14 @@ SpirvFunction::SpirvFunction(QualType returnType, SourceLocation loc,
       functionLoc(loc), functionName(name), isWrapperOfEntry(false),
       debugScope(nullptr) {}
 
+SpirvFunction::SpirvFunction(const SpirvType *returnType, SourceLocation loc,
+                             llvm::StringRef name, bool isPrecise,
+                             bool isNoInline)
+    : functionId(0), astReturnType({}), returnType(returnType), fnType(nullptr),
+      relaxedPrecision(false), precise(isPrecise), noInline(isNoInline),
+      containsAlias(false), rvalue(false), functionLoc(loc), functionName(name),
+      isWrapperOfEntry(false), debugScope(nullptr) {}
+
 SpirvFunction::~SpirvFunction() {
   for (auto *param : parameters)
     param->releaseMemory();

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -534,6 +534,15 @@ SpirvConstantInteger::SpirvConstantInteger(QualType type, llvm::APInt val,
   assert(type->isIntegerType());
 }
 
+SpirvConstantInteger::SpirvConstantInteger(const SpirvType *type,
+                                           llvm::APInt val, bool isSpecConst)
+    : SpirvConstant(IK_ConstantInteger,
+                    isSpecConst ? spv::Op::OpSpecConstant : spv::Op::OpConstant,
+                    type),
+      value(val) {
+  assert(isa<IntegerType>(type));
+}
+
 bool SpirvConstantInteger::operator==(const SpirvConstantInteger &that) const {
   return resultType == that.resultType && astResultType == that.astResultType &&
          value == that.value && opcode == that.opcode;

--- a/tools/clang/lib/SPIRV/SpirvUtils.cpp
+++ b/tools/clang/lib/SPIRV/SpirvUtils.cpp
@@ -1,0 +1,53 @@
+//===------- SpirvUtils.cpp - SPIR-V Utils ----------------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//===----------------------------------------------------------------------===//
+
+#include "clang/SPIRV/SpirvUtils.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace clang {
+namespace spirv {
+
+spv::ExecutionModel
+SpirvUtils::getSpirvShaderStage(hlsl::ShaderModel::Kind smk) {
+  switch (smk) {
+  case hlsl::ShaderModel::Kind::Vertex:
+    return spv::ExecutionModel::Vertex;
+  case hlsl::ShaderModel::Kind::Hull:
+    return spv::ExecutionModel::TessellationControl;
+  case hlsl::ShaderModel::Kind::Domain:
+    return spv::ExecutionModel::TessellationEvaluation;
+  case hlsl::ShaderModel::Kind::Geometry:
+    return spv::ExecutionModel::Geometry;
+  case hlsl::ShaderModel::Kind::Pixel:
+    return spv::ExecutionModel::Fragment;
+  case hlsl::ShaderModel::Kind::Compute:
+    return spv::ExecutionModel::GLCompute;
+  case hlsl::ShaderModel::Kind::RayGeneration:
+    return spv::ExecutionModel::RayGenerationNV;
+  case hlsl::ShaderModel::Kind::Intersection:
+    return spv::ExecutionModel::IntersectionNV;
+  case hlsl::ShaderModel::Kind::AnyHit:
+    return spv::ExecutionModel::AnyHitNV;
+  case hlsl::ShaderModel::Kind::ClosestHit:
+    return spv::ExecutionModel::ClosestHitNV;
+  case hlsl::ShaderModel::Kind::Miss:
+    return spv::ExecutionModel::MissNV;
+  case hlsl::ShaderModel::Kind::Callable:
+    return spv::ExecutionModel::CallableNV;
+  case hlsl::ShaderModel::Kind::Mesh:
+    return spv::ExecutionModel::MeshNV;
+  case hlsl::ShaderModel::Kind::Amplification:
+    return spv::ExecutionModel::TaskNV;
+  default:
+    llvm_unreachable("invalid shader model kind");
+    break;
+  }
+}
+
+} // namespace spirv
+} // namespace clang

--- a/tools/clang/test/Dxil2Spv/passthru-ps.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-ps.ll
@@ -105,18 +105,46 @@ attributes #1 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 8
+; ; Bound: 29
 ; ; Schema: 0
 ;                OpCapability Shader
-;                OpCapability Linkage
 ;                OpMemoryModel Logical GLSL450
+;                OpEntryPoint Fragment %PSMain "PSMain" %SV_Position %COLOR %SV_Target
 ;                OpName %SV_Position "SV_Position"
 ;                OpName %COLOR "COLOR"
 ;                OpName %SV_Target "SV_Target"
+;                OpName %PSMain "PSMain"
+;        %uint = OpTypeInt 32 0
+;      %uint_0 = OpConstant %uint 0
+;      %uint_1 = OpConstant %uint 1
+;      %uint_2 = OpConstant %uint 2
+;      %uint_3 = OpConstant %uint 3
 ;       %float = OpTypeFloat 32
 ;     %v4float = OpTypeVector %float 4
 ; %_ptr_Input_v4float = OpTypePointer Input %v4float
 ; %_ptr_Output_v4float = OpTypePointer Output %v4float
+;        %void = OpTypeVoid
+;          %15 = OpTypeFunction %void
 ; %SV_Position = OpVariable %_ptr_Input_v4float Input
 ;       %COLOR = OpVariable %_ptr_Input_v4float Input
 ;   %SV_Target = OpVariable %_ptr_Output_v4float Output
+;      %PSMain = OpFunction %void None %15
+;          %16 = OpLabel
+;          %17 = OpAccessChain %float %COLOR %uint_0
+;          %18 = OpLoad %float %17
+;          %19 = OpAccessChain %float %COLOR %uint_1
+;          %20 = OpLoad %float %19
+;          %21 = OpAccessChain %float %COLOR %uint_2
+;          %22 = OpLoad %float %21
+;          %23 = OpAccessChain %float %COLOR %uint_3
+;          %24 = OpLoad %float %23
+;          %25 = OpAccessChain %float %SV_Target %uint_0
+;                OpStore %25 %18
+;          %26 = OpAccessChain %float %SV_Target %uint_1
+;                OpStore %26 %20
+;          %27 = OpAccessChain %float %SV_Target %uint_2
+;                OpStore %27 %22
+;          %28 = OpAccessChain %float %SV_Target %uint_3
+;                OpStore %28 %24
+;                OpReturn
+;                OpFunctionEnd

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -28,6 +28,7 @@
 #include "clang/CodeGen/CodeGenAction.h"
 #include "clang/Frontend/CodeGenOptions.h"
 #include "clang/Frontend/TextDiagnosticPrinter.h"
+#include "clang/SPIRV/SpirvUtils.h"
 
 namespace clang {
 namespace dxil2spv {
@@ -109,18 +110,11 @@ int Translator::Run() {
                             spv::MemoryModel::GLSL450);
 
   // Add stage variable interface.
-  for (auto &elem : program.GetInputSignature().GetElements()) {
-    spvBuilder.addStageIOVar(
-        spvContext.getPointerType(toSpirvType(elem.get()),
-                                  spv::StorageClass::Input),
-        spv::StorageClass::Input, elem->GetSemanticName(), false, {});
-  }
-  for (auto &elem : program.GetOutputSignature().GetElements()) {
-    spvBuilder.addStageIOVar(
-        spvContext.getPointerType(toSpirvType(elem.get()),
-                                  spv::StorageClass::Output),
-        spv::StorageClass::Output, elem->GetSemanticName(), false, {});
-  }
+  createStageIOVariables(program.GetInputSignature().GetElements(),
+                         program.GetOutputSignature().GetElements());
+
+  // Create entry function.
+  createEntryFunction(program.GetEntryFunction());
 
   // Contsruct the SPIR-V module.
   std::vector<uint32_t> m = spvBuilder.takeModuleForDxilToSpv();
@@ -139,6 +133,155 @@ int Translator::Run() {
   *ci.getOutStream() << assembly;
 
   return 0;
+}
+
+void Translator::createStageIOVariables(
+    const std::vector<std::unique_ptr<hlsl::DxilSignatureElement>>
+        &inputSignature,
+    const std::vector<std::unique_ptr<hlsl::DxilSignatureElement>>
+        &outputSignature) {
+  interfaceVars.reserve(inputSignature.size() + outputSignature.size());
+
+  // Translate DXIL input signature to SPIR-V stage input vars.
+  for (const std::unique_ptr<hlsl::DxilSignatureElement> &elem :
+       inputSignature) {
+    clang::spirv::SpirvVariable *var = spvBuilder.addStageIOVar(
+        spvContext.getPointerType(toSpirvType(elem.get()),
+                                  spv::StorageClass::Input),
+        spv::StorageClass::Input, elem->GetSemanticName(), false, {});
+    interfaceVars.push_back(var);
+    inputSignatureElementMap[elem->GetID()] = var;
+  }
+
+  // Translate DXIL input signature to SPIR-V stage ouput vars.
+  for (const std::unique_ptr<hlsl::DxilSignatureElement> &elem :
+       outputSignature) {
+    clang::spirv::SpirvVariable *var = spvBuilder.addStageIOVar(
+        spvContext.getPointerType(toSpirvType(elem.get()),
+                                  spv::StorageClass::Output),
+        spv::StorageClass::Output, elem->GetSemanticName(), false, {});
+    interfaceVars.push_back(var);
+    outputSignatureElementMap[elem->GetID()] = var;
+  }
+}
+
+void Translator::createEntryFunction(llvm::Function *entryFunction) {
+  spirv::SpirvFunction *spirvEntryFunction =
+      spvBuilder.beginFunction(toSpirvType(entryFunction->getReturnType()), {},
+                               entryFunction->getName());
+
+  // Translate entry function parameters.
+  llvm::SmallVector<const spirv::SpirvType *, 4> spirvParamTypes;
+  for (llvm::Argument &argument : entryFunction->getArgumentList()) {
+    spirvParamTypes.push_back(toSpirvType(argument.getType()));
+  }
+  spirvEntryFunction->setFunctionType(spvContext.getFunctionType(
+      spirvEntryFunction->getReturnType(), spirvParamTypes));
+
+  // Create entry function basic blocks.
+  for (llvm::BasicBlock &basicBlock : *entryFunction) {
+    createBasicBlock(basicBlock);
+  }
+  spvBuilder.endFunction();
+  spvBuilder.addEntryPoint(
+      spirv::SpirvUtils::getSpirvShaderStage(
+          spvContext.getCurrentShaderModelKind()),
+      spirvEntryFunction, spirvEntryFunction->getFunctionName(), interfaceVars);
+}
+
+void Translator::createBasicBlock(llvm::BasicBlock &basicBlock) {
+  spvBuilder.setInsertPoint(spvBuilder.createBasicBlock());
+
+  // Translate each intruction in basic block.
+  for (llvm::Instruction &instruction : basicBlock) {
+    createInstruction(instruction);
+  }
+}
+
+void Translator::createInstruction(llvm::Instruction &instruction) {
+  // Handle Call instructions.
+  if (isa<llvm::CallInst>(instruction)) {
+    llvm::CallInst &callInstruction = cast<llvm::CallInst>(instruction);
+    // Many shader operations are represented by call instructions that call
+    // external functions, whose name is prefixed with dx.op. (i.e.
+    // dx.op.loadInput, dx.op.storeOutput).
+    hlsl::DXIL::OpCode dxilOpcode =
+        hlsl::OP::GetDxilOpFuncCallInst(&instruction);
+    switch (dxilOpcode) {
+    case hlsl::DXIL::OpCode::LoadInput: {
+      unsigned inputID = cast<llvm::ConstantInt>(
+                             callInstruction.getArgOperand(
+                                 hlsl::DXIL::OperandIndex::kLoadInputIDOpIdx))
+                             ->getLimitedValue();
+      spirv::SpirvVariable *inputVar = inputSignatureElementMap[inputID];
+      const spirv::SpirvType *pointeeType =
+          cast<spirv::SpirvPointerType>(inputVar->getResultType())
+              ->getPointeeType();
+
+      // TODO: Handle other input signature types. Only vector for initial
+      // passthrough shader support.
+      assert(isa<spirv::VectorType>(pointeeType));
+      const spirv::SpirvType *elemType =
+          cast<spirv::VectorType>(pointeeType)->getElementType();
+
+      // Translate index into variable to SPIR-V constant.
+      const llvm::APInt col =
+          dyn_cast<llvm::Constant>(
+              callInstruction.getArgOperand(
+                  hlsl::DXIL::OperandIndex::kLoadInputColOpIdx))
+              ->getUniqueInteger();
+      spirv::SpirvConstant *index =
+          spvBuilder.getConstantInt(spvContext.getUIntType(32), col);
+
+      // Create access chain and load.
+      spirv::SpirvAccessChain *loadPtr =
+          spvBuilder.createAccessChain(elemType, inputVar, {index}, {});
+      spirv::SpirvLoad *loadInstr =
+          spvBuilder.createLoad(elemType, loadPtr, {});
+
+      instructionMap[&callInstruction] = loadInstr;
+    } break;
+    case hlsl::DXIL::OpCode::StoreOutput: {
+      unsigned outputID =
+          cast<llvm::ConstantInt>(
+              callInstruction.getArgOperand(
+                  hlsl::DXIL::OperandIndex::kStoreOutputIDOpIdx))
+              ->getLimitedValue();
+      spirv::SpirvVariable *outputVar = outputSignatureElementMap[outputID];
+      const spirv::SpirvType *pointeeType =
+          cast<spirv::SpirvPointerType>(outputVar->getResultType())
+              ->getPointeeType();
+
+      // TODO: Handle other output signature types. Only vector for initial
+      // passthrough shader support.
+      assert(isa<spirv::VectorType>(pointeeType));
+      const spirv::SpirvType *elemType =
+          cast<spirv::VectorType>(pointeeType)->getElementType();
+
+      // Translate index into variable to SPIR-V constant.
+      const llvm::APInt col =
+          dyn_cast<llvm::Constant>(
+              callInstruction.getArgOperand(
+                  hlsl::DXIL::OperandIndex::kLoadInputColOpIdx))
+              ->getUniqueInteger();
+      spirv::SpirvConstant *index =
+          spvBuilder.getConstantInt(spvContext.getUIntType(32), col);
+
+      // Create access chain and store.
+      spirv::SpirvAccessChain *outputVarPtr =
+          spvBuilder.createAccessChain(elemType, outputVar, {index}, {});
+      spirv::SpirvInstruction *valueToStore =
+          instructionMap[callInstruction.getArgOperand(
+              hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx)];
+      spvBuilder.createStore(outputVarPtr, valueToStore, {});
+    } break;
+    default: {
+      emitError("Unhandled DXIL opcode");
+    } break;
+    }
+  } else if (isa<llvm::ReturnInst>(instruction)) {
+    spvBuilder.createReturn({});
+  }
 }
 
 const spirv::SpirvType *Translator::toSpirvType(hlsl::CompType compType) {
@@ -168,6 +311,12 @@ Translator::toSpirvType(hlsl::DxilSignatureElement *elem) {
     return vecType;
 
   return spvContext.getMatrixType(vecType, rowCount);
+}
+
+const spirv::SpirvType *Translator::toSpirvType(llvm::Type *llvmType) {
+  if (llvmType->isVoidTy())
+    return new spirv::VoidType();
+  return toSpirvType(hlsl::CompType::GetCompType(llvmType));
 }
 
 template <unsigned N>

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -63,6 +63,8 @@ private:
 
   // Create SPIR-V instruction(s) from DXIL instruction.
   void createInstruction(llvm::Instruction &instruction);
+  void createLoadInputInstruction(llvm::CallInst &instruction);
+  void createStoreOutputInstruction(llvm::CallInst &instruction);
 
   // Translate HLSL/DXIL types to corresponding SPIR-V types.
   const spirv::SpirvType *toSpirvType(hlsl::CompType compType);


### PR DESCRIPTION
Translate a DXIL entry function to a SPIR-V entry function. This is
currently only supporting the few types and instructions needed to
create the entry function for a simple passthrough pixel shader.