### PR TITLE
Remove LLVMHLSL dependency from IPO and ScalarOpts

### DIFF
--- a/lib/Transforms/IPO/CMakeLists.txt
+++ b/lib/Transforms/IPO/CMakeLists.txt
@@ -30,4 +30,4 @@ add_llvm_library(LLVMipo
 
 add_dependencies(LLVMipo intrinsics_gen)
 
-target_link_libraries(LLVMipo PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change
+target_link_libraries(LLVMipo PUBLIC LLVMDXIL) # HLSL Change

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -68,4 +68,4 @@ add_llvm_library(LLVMScalarOpts
 
 add_dependencies(LLVMScalarOpts intrinsics_gen)
 
-target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change
+target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL) # HLSL Change


### PR DESCRIPTION
It causes circular target dependency when embedding the DXC in an internal project and it does not seem like it is necessary (builds fine without it).