### PR TITLE
[dxil2spv] SPIR-V validation and related fixes

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvUtils.h
+++ b/tools/clang/include/clang/SPIRV/SpirvUtils.h
@@ -12,13 +12,25 @@
 #include "dxc/DXIL/DxilShaderModel.h"
 #include "dxc/DXIL/DxilSignatureElement.h"
 #include "spirv/unified1/spirv.hpp11"
+#include "clang/SPIRV/SpirvContext.h"
 
 namespace clang {
 namespace spirv {
 
 class SpirvUtils {
 public:
+  SpirvUtils(SpirvContext &context);
+
+  // Get SPIR-V execution model from HLSL shader model kind.
   static spv::ExecutionModel getSpirvShaderStage(hlsl::ShaderModel::Kind smk);
+
+  // Apply required transformations to SPIR-V instruction's result type. These
+  // transformations are needed by both the SPIR-V backend's LowerTypeVisitor as
+  // well as the dxil2spv translator's SpirvTypeVisitor.
+  void applyResultTypeTransformations(SpirvInstruction *instr);
+
+private:
+  SpirvContext &spvContext;
 };
 
 } // namespace spirv

--- a/tools/clang/lib/SPIRV/CMakeLists.txt
+++ b/tools/clang/lib/SPIRV/CMakeLists.txt
@@ -16,6 +16,7 @@ add_clang_library(clangSPIRV
   InitListHandler.cpp
   LiteralTypeVisitor.cpp
   LowerTypeVisitor.cpp
+  SpirvTypeVisitor.cpp
   SortDebugInfoVisitor.cpp
   NonUniformVisitor.cpp
   PreciseVisitor.cpp

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -14,6 +14,7 @@
 #include "clang/AST/HlslTypes.h"
 #include "clang/SPIRV/AstTypeProbe.h"
 #include "clang/SPIRV/SpirvFunction.h"
+#include "clang/SPIRV/SpirvUtils.h"
 
 namespace {
 /// Returns the :packoffset() annotation on the given decl. Returns nullptr if
@@ -159,13 +160,8 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
 
   // Apply additional SPIR-V type transformations, including ensuring variables
   // and function parameters have a pointer type.
-  // NOTE: Ideally this pass should be run after LowerTypeVisitor is complete,
-  // in SpirvBuilder::takeModule(), but currently other functions in this class
-  // depend on visitInstruction being run here. If/when further refactoring is
-  // done to move more of this class's post-lowering logic to SpirvTypeVisitor,
-  // we should reconsider replacing this.
-  SpirvTypeVisitor spirvTypeVisitor(context, opts);
-  spirvTypeVisitor.visitInstruction(instr);
+  SpirvUtils utils(context);
+  utils.applyResultTypeTransformations(instr);
 
   // The instruction does not have a result-type, so nothing to do.
   return true;

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -8,7 +8,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "LowerTypeVisitor.h"
-#include "SpirvTypeVisitor.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/HlslTypes.h"

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -159,6 +159,11 @@ bool LowerTypeVisitor::visitInstruction(SpirvInstruction *instr) {
 
   // Apply additional SPIR-V type transformations, including ensuring variables
   // and function parameters have a pointer type.
+  // NOTE: Ideally this pass should be run after LowerTypeVisitor is complete,
+  // in SpirvBuilder::takeModule(), but currently other functions in this class
+  // depend on visitInstruction being run here. If/when further refactoring is
+  // done to move more of this class's post-lowering logic to SpirvTypeVisitor,
+  // we should reconsider replacing this.
   SpirvTypeVisitor spirvTypeVisitor(context, opts);
   spirvTypeVisitor.visitInstruction(instr);
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -25,7 +25,7 @@ public:
   LowerTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
                    const SpirvCodeGenOptions &opts)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        alignmentCalc(astCtx, opts), useArrayForMat1xN(false) {}
+        alignmentCalc(astCtx, opts), useArrayForMat1xN(false), opts(opts) {}
 
   // Visiting different SPIR-V constructs.
   bool visit(SpirvModule *, Phase) override { return true; }
@@ -95,6 +95,7 @@ private:
   SpirvContext &spvContext;              /// SPIR-V context
   AlignmentSizeCalculator alignmentCalc; /// alignment calculator
   bool useArrayForMat1xN;                /// SPIR-V array for HLSL Matrix 1xN
+  const SpirvCodeGenOptions &opts;       /// SPIR-V code gen options
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -25,7 +25,7 @@ public:
   LowerTypeVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
                    const SpirvCodeGenOptions &opts)
       : Visitor(opts, spvCtx), astContext(astCtx), spvContext(spvCtx),
-        alignmentCalc(astCtx, opts), useArrayForMat1xN(false), opts(opts) {}
+        alignmentCalc(astCtx, opts), useArrayForMat1xN(false) {}
 
   // Visiting different SPIR-V constructs.
   bool visit(SpirvModule *, Phase) override { return true; }
@@ -95,7 +95,6 @@ private:
   SpirvContext &spvContext;              /// SPIR-V context
   AlignmentSizeCalculator alignmentCalc; /// alignment calculator
   bool useArrayForMat1xN;                /// SPIR-V array for HLSL Matrix 1xN
-  const SpirvCodeGenOptions &opts;       /// SPIR-V code gen options
 };
 
 } // end namespace spirv

--- a/tools/clang/lib/SPIRV/SpirvTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SpirvTypeVisitor.cpp
@@ -9,45 +9,14 @@
 
 #include "SpirvTypeVisitor.h"
 #include "clang/SPIRV/SpirvFunction.h"
+#include "clang/SPIRV/SpirvUtils.h"
 
 namespace clang {
 namespace spirv {
 
 bool SpirvTypeVisitor::visitInstruction(SpirvInstruction *instr) {
-  // Instruction-specific type updates
-
-  const auto *resultType = instr->getResultType();
-  switch (instr->getopcode()) {
-  // Variables and function parameters must have a pointer type.
-  case spv::Op::OpFunctionParameter:
-  case spv::Op::OpVariable: {
-    if (auto *var = dyn_cast<SpirvVariable>(instr)) {
-      auto vkImgFeatures = spvContext.getVkImageFeaturesForSpirvVariable(var);
-      if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
-        if (const auto *imageType = dyn_cast<ImageType>(resultType)) {
-          resultType = spvContext.getImageType(imageType, vkImgFeatures.format);
-          instr->setResultType(resultType);
-        }
-      }
-    }
-    const SpirvType *pointerType =
-        spvContext.getPointerType(resultType, instr->getStorageClass());
-    instr->setResultType(pointerType);
-    break;
-  }
-  // Access chains must have a pointer type. The storage class for the pointer
-  // is the same as the storage class of the access base.
-  case spv::Op::OpAccessChain: {
-    const auto *pointerType = spvContext.getPointerType(
-        resultType,
-        cast<SpirvAccessChain>(instr)->getBase()->getStorageClass());
-    instr->setResultType(pointerType);
-    break;
-  }
-  default:
-    break;
-  }
-
+  SpirvUtils utils(spvContext);
+  utils.applyResultTypeTransformations(instr);
   return true;
 }
 

--- a/tools/clang/lib/SPIRV/SpirvTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SpirvTypeVisitor.cpp
@@ -1,0 +1,55 @@
+//===--- SpirvTypeVisitor.cpp - AST type to SPIR-V type impl -----*- C++ -*-==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SpirvTypeVisitor.h"
+#include "clang/SPIRV/SpirvFunction.h"
+
+namespace clang {
+namespace spirv {
+
+bool SpirvTypeVisitor::visitInstruction(SpirvInstruction *instr) {
+  // Instruction-specific type updates
+
+  const auto *resultType = instr->getResultType();
+  switch (instr->getopcode()) {
+  // Variables and function parameters must have a pointer type.
+  case spv::Op::OpFunctionParameter:
+  case spv::Op::OpVariable: {
+    if (auto *var = dyn_cast<SpirvVariable>(instr)) {
+      auto vkImgFeatures = spvContext.getVkImageFeaturesForSpirvVariable(var);
+      if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
+        if (const auto *imageType = dyn_cast<ImageType>(resultType)) {
+          resultType = spvContext.getImageType(imageType, vkImgFeatures.format);
+          instr->setResultType(resultType);
+        }
+      }
+    }
+    const SpirvType *pointerType =
+        spvContext.getPointerType(resultType, instr->getStorageClass());
+    instr->setResultType(pointerType);
+    break;
+  }
+  // Access chains must have a pointer type. The storage class for the pointer
+  // is the same as the storage class of the access base.
+  case spv::Op::OpAccessChain: {
+    const auto *pointerType = spvContext.getPointerType(
+        resultType,
+        cast<SpirvAccessChain>(instr)->getBase()->getStorageClass());
+    instr->setResultType(pointerType);
+    break;
+  }
+  default:
+    break;
+  }
+
+  return true;
+}
+
+} // namespace spirv
+} // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/SpirvTypeVisitor.h
@@ -1,0 +1,43 @@
+//===--- SpirvTypeVisitor.h - SPIR-V type visitor ----------------*- C++ -*-==//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_LIB_SPIRV_SPIRVTYPEVISITOR_H
+#define LLVM_CLANG_LIB_SPIRV_SPIRVTYPEVISITOR_H
+
+#include "clang/SPIRV/SpirvContext.h"
+#include "clang/SPIRV/SpirvVisitor.h"
+
+namespace clang {
+namespace spirv {
+
+/// The class responsible for some legalization of SPIR-V types. It performs a
+/// subset of the operations needed by the SPIR-V backend's LowerTypeVisitor
+/// which are also relevant to DXIL to SPIR-V translation.
+class SpirvTypeVisitor : public Visitor {
+public:
+  SpirvTypeVisitor(SpirvContext &spvCtx, const SpirvCodeGenOptions &opts)
+      : Visitor(opts, spvCtx), spvContext(spvCtx) {}
+
+  using Visitor::visit;
+
+  /// The "sink" visit function for all instructions.
+  ///
+  /// By default, all other visit instructions redirect to this visit function.
+  /// So that you want override this visit function to handle all instructions,
+  /// regardless of their polymorphism.
+  bool visitInstruction(SpirvInstruction *instr) override;
+
+private:
+  SpirvContext &spvContext; /// SPIR-V context
+};
+
+} // end namespace spirv
+} // end namespace clang
+
+#endif // LLVM_CLANG_LIB_SPIRV_SPIRVTYPEVISITOR_H

--- a/tools/clang/lib/SPIRV/SpirvTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/SpirvTypeVisitor.h
@@ -16,9 +16,7 @@
 namespace clang {
 namespace spirv {
 
-/// The class responsible for some legalization of SPIR-V types. It performs a
-/// subset of the operations needed by the SPIR-V backend's LowerTypeVisitor
-/// which are also relevant to DXIL to SPIR-V translation.
+/// The class responsible for some legalization of SPIR-V types.
 class SpirvTypeVisitor : public Visitor {
 public:
   SpirvTypeVisitor(SpirvContext &spvCtx, const SpirvCodeGenOptions &opts)

--- a/tools/clang/lib/SPIRV/SpirvUtils.cpp
+++ b/tools/clang/lib/SPIRV/SpirvUtils.cpp
@@ -12,6 +12,8 @@
 namespace clang {
 namespace spirv {
 
+SpirvUtils::SpirvUtils(SpirvContext &context) : spvContext(context) {}
+
 spv::ExecutionModel
 SpirvUtils::getSpirvShaderStage(hlsl::ShaderModel::Kind smk) {
   switch (smk) {
@@ -45,6 +47,40 @@ SpirvUtils::getSpirvShaderStage(hlsl::ShaderModel::Kind smk) {
     return spv::ExecutionModel::TaskNV;
   default:
     llvm_unreachable("invalid shader model kind");
+    break;
+  }
+}
+
+void SpirvUtils::applyResultTypeTransformations(SpirvInstruction *instr) {
+  const auto *resultType = instr->getResultType();
+  switch (instr->getopcode()) {
+  // Variables and function parameters must have a pointer type.
+  case spv::Op::OpFunctionParameter:
+  case spv::Op::OpVariable: {
+    if (auto *var = dyn_cast<SpirvVariable>(instr)) {
+      auto vkImgFeatures = spvContext.getVkImageFeaturesForSpirvVariable(var);
+      if (vkImgFeatures.format != spv::ImageFormat::Unknown) {
+        if (const auto *imageType = dyn_cast<ImageType>(resultType)) {
+          resultType = spvContext.getImageType(imageType, vkImgFeatures.format);
+          instr->setResultType(resultType);
+        }
+      }
+    }
+    const SpirvType *pointerType =
+        spvContext.getPointerType(resultType, instr->getStorageClass());
+    instr->setResultType(pointerType);
+    break;
+  }
+  // Access chains must have a pointer type. The storage class for the pointer
+  // is the same as the storage class of the access base.
+  case spv::Op::OpAccessChain: {
+    const auto *pointerType = spvContext.getPointerType(
+        resultType,
+        cast<SpirvAccessChain>(instr)->getBase()->getStorageClass());
+    instr->setResultType(pointerType);
+    break;
+  }
+  default:
     break;
   }
 }

--- a/tools/clang/test/Dxil2Spv/passthru-ps.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-ps.ll
@@ -105,15 +105,19 @@ attributes #1 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 29
+; ; Bound: 31
 ; ; Schema: 0
 ;                OpCapability Shader
 ;                OpMemoryModel Logical GLSL450
 ;                OpEntryPoint Fragment %PSMain "PSMain" %SV_Position %COLOR %SV_Target
+;                OpExecutionMode %PSMain OriginUpperLeft
 ;                OpName %SV_Position "SV_Position"
 ;                OpName %COLOR "COLOR"
 ;                OpName %SV_Target "SV_Target"
 ;                OpName %PSMain "PSMain"
+;                OpDecorate %SV_Position Location 0
+;                OpDecorate %COLOR Location 1
+;                OpDecorate %SV_Target Location 0
 ;        %uint = OpTypeInt 32 0
 ;      %uint_0 = OpConstant %uint 0
 ;      %uint_1 = OpConstant %uint 1
@@ -125,26 +129,28 @@ attributes #1 = { nounwind }
 ; %_ptr_Output_v4float = OpTypePointer Output %v4float
 ;        %void = OpTypeVoid
 ;          %15 = OpTypeFunction %void
+; %_ptr_Input_float = OpTypePointer Input %float
+; %_ptr_Output_float = OpTypePointer Output %float
 ; %SV_Position = OpVariable %_ptr_Input_v4float Input
 ;       %COLOR = OpVariable %_ptr_Input_v4float Input
 ;   %SV_Target = OpVariable %_ptr_Output_v4float Output
 ;      %PSMain = OpFunction %void None %15
 ;          %16 = OpLabel
-;          %17 = OpAccessChain %float %COLOR %uint_0
-;          %18 = OpLoad %float %17
-;          %19 = OpAccessChain %float %COLOR %uint_1
-;          %20 = OpLoad %float %19
-;          %21 = OpAccessChain %float %COLOR %uint_2
-;          %22 = OpLoad %float %21
-;          %23 = OpAccessChain %float %COLOR %uint_3
-;          %24 = OpLoad %float %23
-;          %25 = OpAccessChain %float %SV_Target %uint_0
-;                OpStore %25 %18
-;          %26 = OpAccessChain %float %SV_Target %uint_1
-;                OpStore %26 %20
-;          %27 = OpAccessChain %float %SV_Target %uint_2
-;                OpStore %27 %22
-;          %28 = OpAccessChain %float %SV_Target %uint_3
-;                OpStore %28 %24
+;          %18 = OpAccessChain %_ptr_Input_float %COLOR %uint_0
+;          %19 = OpLoad %float %18
+;          %20 = OpAccessChain %_ptr_Input_float %COLOR %uint_1
+;          %21 = OpLoad %float %20
+;          %22 = OpAccessChain %_ptr_Input_float %COLOR %uint_2
+;          %23 = OpLoad %float %22
+;          %24 = OpAccessChain %_ptr_Input_float %COLOR %uint_3
+;          %25 = OpLoad %float %24
+;          %27 = OpAccessChain %_ptr_Output_float %SV_Target %uint_0
+;                OpStore %27 %19
+;          %28 = OpAccessChain %_ptr_Output_float %SV_Target %uint_1
+;                OpStore %28 %21
+;          %29 = OpAccessChain %_ptr_Output_float %SV_Target %uint_2
+;                OpStore %29 %23
+;          %30 = OpAccessChain %_ptr_Output_float %SV_Target %uint_3
+;                OpStore %30 %25
 ;                OpReturn
 ;                OpFunctionEnd

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -66,6 +66,9 @@ private:
   void createLoadInputInstruction(llvm::CallInst &instruction);
   void createStoreOutputInstruction(llvm::CallInst &instruction);
 
+  // SPIR-V Tools wrapper functions.
+  bool spirvToolsValidate(std::vector<uint32_t> *mod, std::string *messages);
+
   // Translate HLSL/DXIL types to corresponding SPIR-V types.
   const spirv::SpirvType *toSpirvType(hlsl::CompType compType);
   const spirv::SpirvType *toSpirvType(hlsl::DxilSignatureElement *elem);


### PR DESCRIPTION
Add SPIR-V validation after the module is generated, and apply some
fixes required for validation to succeed with a passthrough pixel
shader:
- Add execution mode
- Decorate with SPIR-V Locations
- Refactor some LowerTypeVisitor logic to a visitor that is shared with
  dxil2spv
- Remove extra pointerness on stage IO vars now that it is handled by
  the above pass