### PR TITLE
[spirv] Improve ray tracing capability error

### DIFF
--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -19,6 +19,8 @@ namespace {
 const char *spvEnvironmentAsString(spv_target_env spvEnv) {
   if (spvEnv > SPV_ENV_VULKAN_1_2)
     return "Vulkan 1.3";
+  if (spvEnv == SPV_ENV_VULKAN_1_1_SPIRV_1_4)
+    return "Vulkan 1.1 with SPIR-V 1.4";
   if (spvEnv > SPV_ENV_VULKAN_1_1)
     return "Vulkan 1.2";
   if (spvEnv > SPV_ENV_VULKAN_1_0)

--- a/tools/clang/test/CodeGenSPIRV/raytracing.target-env-error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.target-env-error.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -T lib_6_3
 
-// CHECK: error: Vulkan 1.2 is required for Raytracing but not permitted to use
+// CHECK: error: Vulkan 1.1 with SPIR-V 1.4 is required for Raytracing but not permitted to use
 
 struct Payload {
   float4 color;


### PR DESCRIPTION
When the specific target environment required is exactly
SPV_ENV_VULKAN_1_1_SPIRV_1_4, then make the error message explicitly
note that it is met by Vulkan 1.1 with Spirv 1.4 (rather than simply
requiring Vulkan 1.2).

Fixes #4313