### PR TITLE
Pix hull shader debug

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -82,7 +82,7 @@ public:
   const llvm::Function *GetPatchConstantFunction() const;
   void SetPatchConstantFunction(llvm::Function *pFunc);
   bool IsEntryOrPatchConstantFunction(const llvm::Function* pFunc) const;
-  llvm::SmallVector<llvm::Function *, 64> GetExportedFunctions() const;
+  llvm::SmallVector<llvm::Function *, 64> GetExportedFunctions();
 
   // Flags.
   unsigned GetGlobalFlags() const;

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -233,12 +233,19 @@ const Function *DxilModule::GetEntryFunction() const {
   return m_pEntryFunc;
 }
 
-llvm::SmallVector<llvm::Function *, 64> DxilModule::GetExportedFunctions() const {
+llvm::SmallVector<llvm::Function *, 64> DxilModule::GetExportedFunctions() {
     llvm::SmallVector<llvm::Function *, 64> ret;
     for (auto const& fn : m_DxilEntryPropsMap) {
       if (fn.first != nullptr) {
         ret.push_back(const_cast<llvm::Function*>(fn.first));
       }
+    }
+    if (ret.empty()) {
+      auto *entryFunction = m_pEntryFunc;
+      if (entryFunction == nullptr) {
+        entryFunction = GetPatchConstantFunction();
+      }
+      ret.push_back(entryFunction);
     }
     return ret;
 }

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -434,8 +434,6 @@ Value *DxilDebugInstrumentation::addDispatchedShaderProlog(BuilderContext &BC) {
 }
 
 Value *DxilDebugInstrumentation::addRaygenShaderProlog(BuilderContext &BC) {
-  return BC.HlslOP->GetU8Const(1);
-  #if 0
   auto DispatchRaysIndexOpFunc =
       BC.HlslOP->GetOpFunc(DXIL::OpCode::DispatchRaysIndex, Type::getInt32Ty(BC.Ctx));
   Constant *DispatchRaysIndexOpcode =
@@ -463,7 +461,6 @@ Value *DxilDebugInstrumentation::addRaygenShaderProlog(BuilderContext &BC) {
   auto CompareAll =
       BC.Builder.CreateAnd(CompareXAndY, CompareToZ, "CompareAll");
   return CompareAll;
-  #endif
 }
 
 Value *

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -972,19 +972,15 @@ bool DxilDebugInstrumentation::RunOnFunction(
   DxilModule &DM,
   llvm::Function * entryFunction) 
 {
-  auto functionForProps = entryFunction;
-  if (!DM.HasDxilFunctionProps(functionForProps)) {
-    // In the dxbc2dxil hull-shader case, the function prop map will have one
-    // entry with a key of nullptr.
-    functionForProps = nullptr;
+  DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
+  if (!DM.HasDxilFunctionProps(entryFunction)) {
+    auto ShaderModel = DM.GetShaderModel();
+    shaderKind = ShaderModel->GetKind();
+  } else {
+    hlsl::DxilFunctionProps const &props =
+        DM.GetDxilFunctionProps(entryFunction);
+    shaderKind = props.shaderKind;
   }
-  if (!DM.HasDxilFunctionProps(functionForProps)) {
-    return false;
-  }
-
-  hlsl::DxilFunctionProps const &props =
-      DM.GetDxilFunctionProps(functionForProps);
-  DXIL::ShaderKind shaderKind = props.shaderKind;
 
   switch (shaderKind) {
   case DXIL::ShaderKind::Amplification:

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -974,6 +974,8 @@ bool DxilDebugInstrumentation::RunOnFunction(
 {
   auto functionForProps = entryFunction;
   if (!DM.HasDxilFunctionProps(functionForProps)) {
+    // In the dxbc2dxil hull-shader case, the function prop map will have one
+    // entry with a key of nullptr.
     functionForProps = nullptr;
   }
   if (!DM.HasDxilFunctionProps(functionForProps)) {

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -434,6 +434,8 @@ Value *DxilDebugInstrumentation::addDispatchedShaderProlog(BuilderContext &BC) {
 }
 
 Value *DxilDebugInstrumentation::addRaygenShaderProlog(BuilderContext &BC) {
+  return BC.HlslOP->GetU8Const(1);
+  #if 0
   auto DispatchRaysIndexOpFunc =
       BC.HlslOP->GetOpFunc(DXIL::OpCode::DispatchRaysIndex, Type::getInt32Ty(BC.Ctx));
   Constant *DispatchRaysIndexOpcode =
@@ -461,6 +463,7 @@ Value *DxilDebugInstrumentation::addRaygenShaderProlog(BuilderContext &BC) {
   auto CompareAll =
       BC.Builder.CreateAnd(CompareXAndY, CompareToZ, "CompareAll");
   return CompareAll;
+  #endif
 }
 
 Value *
@@ -972,11 +975,16 @@ bool DxilDebugInstrumentation::RunOnFunction(
   DxilModule &DM,
   llvm::Function * entryFunction) 
 {
-  if (!DM.HasDxilFunctionProps(entryFunction)) {
+  auto functionForProps = entryFunction;
+  if (!DM.HasDxilFunctionProps(functionForProps)) {
+    functionForProps = nullptr;
+  }
+  if (!DM.HasDxilFunctionProps(functionForProps)) {
     return false;
   }
 
-  hlsl::DxilFunctionProps const &props = DM.GetDxilFunctionProps(entryFunction);
+  hlsl::DxilFunctionProps const &props =
+      DM.GetDxilFunctionProps(functionForProps);
   DXIL::ShaderKind shaderKind = props.shaderKind;
 
   switch (shaderKind) {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -202,6 +202,9 @@ llvm::Function* GetEntryFunction(hlsl::DxilModule& DM) {
 std::vector<llvm::BasicBlock*> GetAllBlocks(hlsl::DxilModule& DM) {
     std::vector<llvm::BasicBlock*> ret;
     auto entryPoints = DM.GetExportedFunctions();
+    if (entryPoints.empty()) {
+      entryPoints.push_back(GetEntryFunction(DM));
+    }
     for (auto& fn : entryPoints) {
       auto& blocks = fn->getBasicBlockList();
       for (auto& block : blocks) {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -202,9 +202,6 @@ llvm::Function* GetEntryFunction(hlsl::DxilModule& DM) {
 std::vector<llvm::BasicBlock*> GetAllBlocks(hlsl::DxilModule& DM) {
     std::vector<llvm::BasicBlock*> ret;
     auto entryPoints = DM.GetExportedFunctions();
-    if (entryPoints.empty()) {
-      entryPoints.push_back(GetEntryFunction(DM));
-    }
     for (auto& fn : entryPoints) {
       auto& blocks = fn->getBasicBlockList();
       for (auto& block : blocks) {


### PR DESCRIPTION
A couple of minor changes to support PIX shader debugging for hull shaders generated by the 11on12 mapping layer for DXBC originals.