### PR TITLE
[dxil2spv] Add error checking to file tests

### DIFF
--- a/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
+++ b/tools/clang/unittests/Dxil2Spv/FileTestUtils.cpp
@@ -67,6 +67,7 @@ bool translateFileWithDxil2Spv(const llvm::StringRef inputFilePath,
     instance.createDiagnostics(diagnosticPrinter, false);
     instance.setOutStream(&OS);
     instance.getCodeGenOpts().MainFileName = inputFilePath;
+    instance.getCodeGenOpts().SpirvOptions.targetEnv = "vulkan1.0";
 
     Translator translator(instance);
     translator.Run();

--- a/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.h
+++ b/tools/clang/unittests/Dxil2Spv/WholeFileTestFixture.h
@@ -53,6 +53,8 @@ private:
   std::string inputFilePath;     ///< Path to the input test file
   std::string expectedSpirvAsm;  ///< Expected SPIR-V parsed from input
   std::string generatedSpirvAsm; ///< Disassembled binary (SPIR-V code)
+  std::string expectedErrors;    ///< Expected errors parsed from input
+  std::string generatedErrors;   ///< Actual errors from running
 };
 
 } // end namespace dxil2spv


### PR DESCRIPTION
Compare the expected and generated error output for whole file check
tests. For existing tests, these should be empty, but upcoming tests
will check expected errors as we iterate towards passthrough compute
shader support.