### PR TITLE
Pix: Cherry-pick:  hull shader debug (#4342)

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -82,7 +82,7 @@ public:
   const llvm::Function *GetPatchConstantFunction() const;
   void SetPatchConstantFunction(llvm::Function *pFunc);
   bool IsEntryOrPatchConstantFunction(const llvm::Function* pFunc) const;
-  llvm::SmallVector<llvm::Function *, 64> GetExportedFunctions() const;
+  llvm::SmallVector<llvm::Function *, 64> GetExportedFunctions();
 
   // Flags.
   unsigned GetGlobalFlags() const;

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -231,12 +231,19 @@ const Function *DxilModule::GetEntryFunction() const {
   return m_pEntryFunc;
 }
 
-llvm::SmallVector<llvm::Function *, 64> DxilModule::GetExportedFunctions() const {
+llvm::SmallVector<llvm::Function *, 64> DxilModule::GetExportedFunctions() {
     llvm::SmallVector<llvm::Function *, 64> ret;
     for (auto const& fn : m_DxilEntryPropsMap) {
       if (fn.first != nullptr) {
         ret.push_back(const_cast<llvm::Function*>(fn.first));
       }
+    }
+    if (ret.empty()) {
+      auto *entryFunction = m_pEntryFunc;
+      if (entryFunction == nullptr) {
+        entryFunction = GetPatchConstantFunction();
+      }
+      ret.push_back(entryFunction);
     }
     return ret;
 }

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -972,12 +972,15 @@ bool DxilDebugInstrumentation::RunOnFunction(
   DxilModule &DM,
   llvm::Function * entryFunction) 
 {
+  DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
   if (!DM.HasDxilFunctionProps(entryFunction)) {
-    return false;
+    auto ShaderModel = DM.GetShaderModel();
+    shaderKind = ShaderModel->GetKind();
+  } else {
+    hlsl::DxilFunctionProps const &props =
+        DM.GetDxilFunctionProps(entryFunction);
+    shaderKind = props.shaderKind;
   }
-
-  hlsl::DxilFunctionProps const &props = DM.GetDxilFunctionProps(entryFunction);
-  DXIL::ShaderKind shaderKind = props.shaderKind;
 
   switch (shaderKind) {
   case DXIL::ShaderKind::Amplification:


### PR DESCRIPTION
A couple of minor changes to support PIX shader debugging for hull shaders generated by the 11on12 mapping layer for DXBC originals.

Co-authored-by: Jeff Noyle <jeffno@ntdev.microsoft.com>