### PR TITLE
Fix stale/reordered argument pointers

### DIFF
--- a/tools/clang/tools/dxcompiler/dxclibrary.cpp
+++ b/tools/clang/tools/dxcompiler/dxclibrary.cpp
@@ -66,14 +66,11 @@ public:
 class DxcCompilerArgs : public IDxcCompilerArgs {
 private:
   DXC_MICROCOM_TM_REF_FIELDS()
-  std::unordered_set<std::wstring> m_Strings;
+  std::list<std::wstring> m_Strings;
   std::vector<LPCWSTR> m_Arguments;
 
-  LPCWSTR AddArgument(LPCWSTR pArg) {
-    auto it = m_Strings.insert(pArg);
-    LPCWSTR pInternalVersion = (it.first)->c_str();
-    m_Arguments.push_back(pInternalVersion);
-    return pInternalVersion;
+  void AddArgument(LPCWSTR pArg) {
+    m_Strings.push_back(pArg);
   }
 
 public:
@@ -86,10 +83,16 @@ public:
 
   // Pass GetArguments() and GetCount() to Compile
   LPCWSTR* STDMETHODCALLTYPE GetArguments() override {
+    if (m_Arguments.size() != m_Strings.size()) {
+      m_Arguments.clear();
+      for (auto const &arg : m_Strings) {
+        m_Arguments.push_back(arg.c_str());
+      }
+    }
     return m_Arguments.data();
   }
   UINT32 STDMETHODCALLTYPE GetCount() override {
-    return static_cast<UINT32>(m_Arguments.size());
+    return static_cast<UINT32>(m_Strings.size());
   }
 
   // Add additional arguments or defines here, if desired.


### PR DESCRIPTION
This is a hard-to-hit but pretty catastrophic bug. The std::unordered_set inside DxcCompilerArgs can reallocate its contained items, invalidating the m_Arguments array of invasive pointers. This happens *sometimes* in particular when DxcCompilerAdapter::WrapCompile calls AddArguments twice, the second time for -qembed_debug in dxcompilerobj.cpp, line 1820.
(Moreover, the std::unordered_set may reorder its contained items, and in my test case the -qembed_debug ends up in the middle of the previously-set arguments, potentially coming in between a switch and its argument. This side-effect wasn't a problem, by chance, because the m_Arguments is built on the fly and would still be in the same order, which would be great if it weren't for the afore-mentioned reallocation of the strings it's pointing to.)

By contrast, the added std::list does guarantee no reallocations or reordering when elements are added, allowing us to defer the dangerous storing of invasive pointers (i.e. via m_Arguments) until we actually need them.

Here's an example of the bug, i.e. the possible effects of the reallocation. The "filename" argument ended up being garbage, resulting in this  !scope line in the compiled module:

    !1 = !DIFile(filename: "\EA\BB\90\E7\96\A4\E7\BF\BB", directory: "")

....which should have been: filename: "shaders.hlsl".
