### PR TITLE
[dxil2spv] Add support for dx.op.threadId

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -627,6 +627,10 @@ public:
                                     spv::StorageClass storageClass,
                                     spv::BuiltIn, bool isPrecise,
                                     SourceLocation loc);
+  SpirvVariable *addStageBuiltinVar(const SpirvType *type,
+                                    spv::StorageClass storageClass,
+                                    spv::BuiltIn, bool isPrecise,
+                                    SourceLocation loc);
 
   /// \brief Adds a module variable. This variable should not have the Function
   /// storage class.

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1354,6 +1354,37 @@ SpirvVariable *SpirvBuilder::addStageBuiltinVar(QualType type,
   return var;
 }
 
+SpirvVariable *SpirvBuilder::addStageBuiltinVar(const SpirvType *type,
+                                                spv::StorageClass storageClass,
+                                                spv::BuiltIn builtin,
+                                                bool isPrecise,
+                                                SourceLocation loc) {
+  // If the built-in variable has already been added (via a built-in alias),
+  // return the existing variable.
+  auto found = std::find_if(
+      builtinVars.begin(), builtinVars.end(),
+      [storageClass, builtin](const BuiltInVarInfo &varInfo) {
+        return varInfo.sc == storageClass && varInfo.builtIn == builtin;
+      });
+  if (found != builtinVars.end()) {
+    return found->variable;
+  }
+
+  // Note: We store the underlying type in the variable, *not* the pointer type.
+  auto *var = new (context) SpirvVariable(type, loc, storageClass, isPrecise);
+  mod->addVariable(var);
+
+  // Decorate with the specified Builtin
+  auto *decor = new (context) SpirvDecoration(
+      loc, var, spv::Decoration::BuiltIn, {static_cast<uint32_t>(builtin)});
+  mod->addDecoration(decor);
+
+  // Add variable to cache.
+  builtinVars.emplace_back(storageClass, builtin, var);
+
+  return var;
+}
+
 SpirvVariable *
 SpirvBuilder::addModuleVar(QualType type, spv::StorageClass storageClass,
                            bool isPrecise, llvm::StringRef name,

--- a/tools/clang/test/Dxil2Spv/passthru-cs.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-cs.ll
@@ -86,15 +86,16 @@ attributes #2 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 13
+; ; Bound: 20
 ; ; Schema: 0
 ;                OpCapability Shader
 ;                OpMemoryModel Logical GLSL450
-;                OpEntryPoint GLCompute %main "main"
+;                OpEntryPoint GLCompute %main "main" %gl_GlobalInvocationID
 ;                OpExecutionMode %main LocalSize 1 1 1
 ;                OpName %type_ByteAddressBuffer "type.ByteAddressBuffer"
 ;                OpName %type_RWByteAddressBuffer "type.RWByteAddressBuffer"
 ;                OpName %main "main"
+;                OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 ;                OpDecorate %_runtimearr_uint ArrayStride 4
 ;                OpMemberDecorate %type_ByteAddressBuffer 0 Offset 0
 ;                OpMemberDecorate %type_ByteAddressBuffer 0 NonWritable
@@ -102,22 +103,28 @@ attributes #2 = { nounwind }
 ;                OpMemberDecorate %type_RWByteAddressBuffer 0 Offset 0
 ;                OpDecorate %type_RWByteAddressBuffer BufferBlock
 ;        %uint = OpTypeInt 32 0
+;      %uint_0 = OpConstant %uint 0
+;      %v3uint = OpTypeVector %uint 3
+; %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 ; %_runtimearr_uint = OpTypeRuntimeArray %uint
 ; %type_ByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_ByteAddressBuffer = OpTypePointer Uniform %type_ByteAddressBuffer
 ; %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
 ;        %void = OpTypeVoid
-;          %11 = OpTypeFunction %void
-;           %6 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
-;           %9 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
-;        %main = OpFunction %void None %11
-;          %12 = OpLabel
+;          %15 = OpTypeFunction %void
+; %_ptr_Input_uint = OpTypePointer Input %uint
+; %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
+;          %10 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
+;          %13 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
+;        %main = OpFunction %void None %15
+;          %16 = OpLabel
+;          %18 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+;          %19 = OpLoad %uint %18
 ;                OpReturn
 ;                OpFunctionEnd
 ; CHECK-ERRORS:
 ; error: Unhandled DXIL opcode: CreateHandle
 ; error: Unhandled DXIL opcode: CreateHandle
-; error: Unhandled DXIL opcode: ThreadId
 ; error: Unhandled DXIL opcode: BufferLoad
 ; error: Unhandled DXIL opcode: BufferStore

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -70,6 +70,7 @@ private:
   void createInstruction(llvm::Instruction &instruction);
   void createLoadInputInstruction(llvm::CallInst &instruction);
   void createStoreOutputInstruction(llvm::CallInst &instruction);
+  void createThreadIdInstruction(llvm::CallInst &instruction);
 
   // SPIR-V Tools wrapper functions.
   bool spirvToolsValidate(std::vector<uint32_t> *mod, std::string *messages);


### PR DESCRIPTION
Translate the dx.op.threadId instruction to a load of a single element
of the SPIR-V BuiltIn GlobalInvocationID.