### PR TITLE
[spirv] support signature packing

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -647,6 +647,9 @@ public:
   /// \brief Decorates the given target with the given location.
   void decorateLocation(SpirvInstruction *target, uint32_t location);
 
+  /// \brief Decorates the given target with the given component.
+  void decorateComponent(SpirvInstruction *target, uint32_t component);
+
   /// \brief Decorates the given target with the given index.
   void decorateIndex(SpirvInstruction *target, uint32_t index, SourceLocation);
 

--- a/tools/clang/include/clang/SPIRV/SpirvContext.h
+++ b/tools/clang/include/clang/SPIRV/SpirvContext.h
@@ -424,6 +424,10 @@ public:
            instructionsWithLoweredType.end();
   }
 
+  /// Getter/setter of signaturePacking.
+  bool isSignaturePackingEnabled() const { return signaturePacking; }
+  void enableSignaturePacking() { signaturePacking = true; }
+
 private:
   /// \brief The allocator used to create SPIR-V entity objects.
   ///
@@ -482,6 +486,8 @@ private:
   // Major/Minor hlsl profile version.
   uint32_t majorVersion;
   uint32_t minorVersion;
+
+  bool signaturePacking; ///< Whether signature packing is enabled or not
 
   /// File name to rich debug info map. When the main source file
   /// includes header files, we create an element of debugInfo for

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1719,10 +1719,8 @@ private:
 class PackedLocationAndComponentSet {
 public:
   PackedLocationAndComponentSet(SpirvBuilder &spirvBuilder,
-                                llvm::function_ref<uint32_t(uint32_t)> nextLocs,
-                                bool forInput_)
-      : spvBuilder(spirvBuilder), assignLocs(nextLocs),
-        forInput(forInput_) {}
+                                llvm::function_ref<uint32_t(uint32_t)> nextLocs)
+      : spvBuilder(spirvBuilder), assignLocs(nextLocs) {}
 
   bool assignLocAndComponent(const StageVar *var) {
     if (tryReuseLocations(var)) {
@@ -1798,7 +1796,6 @@ private:
   llvm::SmallVector<uint32_t, 8>
       nextUnusedComponent; ///< A vector to keep the starting unused component
                            ///< number in each assigned location
-  bool forInput;
 };
 
 /// A class for managing resource bindings to avoid duplicate uses of the same
@@ -1933,7 +1930,7 @@ bool DeclResultIdMapper::isDuplicatedStageVarLocation(
 bool DeclResultIdMapper::packSignature(
     const std::vector<const StageVar *> &vars,
     llvm::function_ref<uint32_t(uint32_t)> nextLocs, bool forInput) {
-  PackedLocationAndComponentSet packedLocSet(spvBuilder, nextLocs, forInput);
+  PackedLocationAndComponentSet packedLocSet(spvBuilder, nextLocs);
   auto assignLocationAndComponent = [&packedLocSet](const StageVar *var) {
     return packedLocSet.assignLocAndComponent(var);
   };

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1392,6 +1392,18 @@ void SpirvBuilder::decorateLocation(SpirvInstruction *target,
   mod->addDecoration(decor);
 }
 
+void SpirvBuilder::decorateComponent(SpirvInstruction *target,
+                                     uint32_t component) {
+  // Based on the SPIR-V spec, 'Component' decoration must be a member of a
+  // struct or memory object declaration. Since we do not have a pointer type in
+  // HLSL, we always convert a variable with 'Component' decoration as a part of
+  // a struct.
+  auto *decor =
+      new (context) SpirvDecoration(target->getSourceLocation(), target,
+                                    spv::Decoration::Component, {component});
+  mod->addDecoration(decor);
+}
+
 void SpirvBuilder::decorateIndex(SpirvInstruction *target, uint32_t index,
                                  SourceLocation srcLoc) {
   auto *decor = new (context)
@@ -1691,8 +1703,8 @@ std::vector<uint32_t> SpirvBuilder::takeModule() {
   addModuleInitCallToEntryPoints();
 
   // Run necessary visitor passes first
-    LiteralTypeVisitor literalTypeVisitor(*astContext, context, spirvOptions);
-    mod->invokeVisitor(&literalTypeVisitor, true);
+  LiteralTypeVisitor literalTypeVisitor(*astContext, context, spirvOptions);
+  mod->invokeVisitor(&literalTypeVisitor, true);
 
   // Propagate NonUniform decorations
   NonUniformVisitor nonUniformVisitor(context, spirvOptions);

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -20,7 +20,7 @@ SpirvContext::SpirvContext()
     : allocator(), voidType(nullptr), boolType(nullptr), sintTypes({}),
       uintTypes({}), floatTypes({}), samplerType(nullptr),
       curShaderModelKind(ShaderModelKind::Invalid), majorVersion(0),
-      minorVersion(0), currentLexicalScope(nullptr) {
+      minorVersion(0), signaturePacking(false), currentLexicalScope(nullptr) {
   voidType = new (this) VoidType;
   boolType = new (this) BoolType;
   samplerType = new (this) SamplerType;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -534,7 +534,7 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
   spvContext.setMajorVersion(shaderModel->GetMajor());
   spvContext.setMinorVersion(shaderModel->GetMinor());
   if (ci.getCodeGenOpts().HLSLSignaturePackingStrategy != 0)
-    spvContext.enableSignaturePacking()
+    spvContext.enableSignaturePacking();
 
   if (spirvOptions.useDxLayout) {
     spirvOptions.cBufferLayoutRule = SpirvLayoutRule::FxcCTBuffer;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -533,6 +533,8 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
   spvContext.setCurrentShaderModelKind(shaderModel->GetKind());
   spvContext.setMajorVersion(shaderModel->GetMajor());
   spvContext.setMinorVersion(shaderModel->GetMinor());
+  if (ci.getCodeGenOpts().HLSLSignaturePackingStrategy != 0)
+    spvContext.enableSignaturePacking()
 
   if (spirvOptions.useDxLayout) {
     spirvOptions.cBufferLayoutRule = SpirvLayoutRule::FxcCTBuffer;

--- a/tools/clang/test/CodeGenSPIRV/signature.packing.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/signature.packing.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc -T vs_6_0 -E main -pack-optimized
+
+struct VS_OUTPUT {
+  float4 pos : SV_POSITION;
+
+// CHECK: OpDecorate %out_var_A Location 0
+  float a : A;
+
+// CHECK-DAG: OpDecorate %out_var_B Location 0
+// CHECK-DAG: OpDecorate %out_var_B Component 2
+  double b : B;
+
+// CHECK-DAG: OpDecorate %out_var_C Location 1
+  float2 c : C;
+
+// CHECK-DAG: OpDecorate %out_var_D Location 1
+// CHECK-DAG: OpDecorate %out_var_D Component 2
+  float2 d : D;
+
+// CHECK-DAG: OpDecorate %out_var_E Location 2
+  int e : E;
+
+// CHECK-DAG: OpDecorate %out_var_F Location 2
+// CHECK-DAG: OpDecorate %out_var_F Component 1
+  float2 f : F;
+
+// CHECK-DAG: OpDecorate %out_var_G Location 2
+// CHECK-DAG: OpDecorate %out_var_G Component 3
+  float g : G;
+};
+
+VS_OUTPUT main(float4 pos : POSITION,
+               float4 color : COLOR) {
+  VS_OUTPUT vout;
+  return vout;
+}

--- a/tools/clang/test/CodeGenSPIRV/signature.packing.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/signature.packing.hs.hlsl
@@ -1,0 +1,75 @@
+// RUN: %dxc -T hs_6_0 -E main -pack-optimized
+
+struct HSPatchConstData {
+  float tessFactor[3] : SV_TessFactor;
+  float insideTessFactor[1] : SV_InsideTessFactor;
+
+// CHECK-DAG: OpDecorate %out_var_A Location 0
+// CHECK-DAG: OpDecorate %out_var_A Patch
+  float a : A;
+
+// CHECK-DAG: OpDecorate %out_var_B Location 0
+// CHECK-DAG: OpDecorate %out_var_B Component 2
+// CHECK-DAG: OpDecorate %out_var_B Patch
+  double b : B;
+
+// CHECK-DAG: OpDecorate %out_var_C Location 1
+// CHECK-DAG: OpDecorate %out_var_C Patch
+  float2 c : C;
+
+// CHECK-DAG: OpDecorate %out_var_D Location 1
+// CHECK-DAG: OpDecorate %out_var_D Component 2
+// CHECK-DAG: OpDecorate %out_var_D Patch
+  float2 d : D;
+
+// CHECK-DAG: OpDecorate %out_var_E Location 2
+// CHECK-DAG: OpDecorate %out_var_E Patch
+  int e : E;
+
+// CHECK-DAG: OpDecorate %out_var_F Location 2
+// CHECK-DAG: OpDecorate %out_var_F Component 1
+// CHECK-DAG: OpDecorate %out_var_F Patch
+  float2 f : F;
+
+// CHECK-DAG: OpDecorate %out_var_G Location 2
+// CHECK-DAG: OpDecorate %out_var_G Component 3
+// CHECK-DAG: OpDecorate %out_var_G Patch
+  float g : G;
+};
+
+struct HSCtrlPt {
+// CHECK-DAG: OpDecorate %out_var_H Location 3
+  float h : H;
+
+// CHECK-DAG: OpDecorate %out_var_I Location 3
+// CHECK-DAG: OpDecorate %out_var_I Component 1
+  float2 i : I;
+
+// CHECK-DAG: OpDecorate %out_var_J Location 3
+// CHECK-DAG: OpDecorate %out_var_J Component 3
+  float j : J;
+
+// CHECK-DAG: OpDecorate %out_var_K Location 4
+  float3 k : K;
+};
+
+HSPatchConstData HSPatchConstantFunc(const OutputPatch<HSCtrlPt, 3> input) {
+  HSPatchConstData data;
+  data.tessFactor[0] = 3.0;
+  data.tessFactor[1] = 3.0;
+  data.tessFactor[2] = 3.0;
+  data.insideTessFactor[0] = 3.0;
+  return data;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[outputcontrolpoints(3)]
+[patchconstantfunc("HSPatchConstantFunc")]
+[maxtessfactor(15)]
+HSCtrlPt main(InputPatch<HSCtrlPt, 3> input, uint CtrlPtID : SV_OutputControlPointID) {
+  HSCtrlPt data;
+  data.k = input[CtrlPtID].k;
+  return data;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3094,4 +3094,9 @@ TEST_F(FileTest, DefineSpirvMacro) {
   runFileTest("ifdef.spirv.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, SignaturePacking) { runFileTest("signature.packing.hlsl"); }
+TEST_F(FileTest, SignaturePackingHS) {
+  runFileTest("signature.packing.hs.hlsl");
+}
+
 } // namespace


### PR DESCRIPTION
Currently, DXC assigns new locations for each stage variable. When there
are lots of stage variables, the number of locations we use can exceed the
maximum location limit. This commit uses `Component` decoration to pack
signature and reduce the number of locations DXC uses.

Fixes #2618 and #3870