### PR TITLE
[spirv] fix source info bug for in-memory source code

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -650,6 +650,9 @@ bool EmitVisitor::visit(SpirvSource *inst) {
   std::string text;
   if (spvOptions.debugInfoSource && inst->hasFile()) {
     text = ReadSourceCode(inst->getFile()->getString());
+    if (text.empty()) {
+      text = inst->getSource().str();
+    }
     if (!text.empty()) {
       chopString(text, &choppedSrcCode, kMaximumCharOpSource,
                  kMaximumCharOpSourceContinued);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -368,6 +368,28 @@ private:
   // TODO: Add a method for adding OpMemberName instructions for struct members
   // using the type information.
 
+  // Returns the SPIR-V result id of the OpString for the File operand of
+  // OpSource instruction.
+  uint32_t getSourceFileId(SpirvSource *inst) {
+    uint32_t fileId = debugMainFileId;
+    if (inst->hasFile()) {
+      fileId = getOrCreateOpStringId(inst->getFile()->getString());
+    }
+    return fileId;
+  }
+
+  // Returns true if we already emitted the OpSource instruction whose File
+  // operand is |fileId|.
+  bool isSourceWithFileEmitted(uint32_t fileId) {
+    return emittedSource[fileId] != 0;
+  }
+
+  // Inserts the file id of OpSource instruction to the id of its
+  // corresponding DebugSource instruction.
+  void setFileOfSourceToDebugSourceId(uint32_t fileId, uint32_t dbg_src_id) {
+    emittedSource[fileId] = dbg_src_id;
+  }
+
 private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3094,4 +3094,13 @@ TEST_F(FileTest, DefineSpirvMacro) {
   runFileTest("ifdef.spirv.hlsl", Expect::Failure);
 }
 
+TEST_F(FileTest, SourceCodeWithoutFilePath) {
+  const std::string command(R"(// RUN: %dxc -T ps_6_0 -E PSMain -Zi)");
+  const std::string code = command + R"(
+float4 PSMain(float4 color : COLOR) : SV_TARGET { return color; }
+// CHECK: float4 PSMain(float4 color : COLOR) : SV_TARGET { return color; }
+)";
+  runCodeTest(code);
+}
+
 } // namespace


### PR DESCRIPTION
SPIR-V backend finds the source code by reading the source file,
which does not work when we pass the source code via memory
buffer. This commit adds a fallback for the case.

Fixes #4218