### PR TITLE
Updating the .NET version

### DIFF
--- a/tools/clang/tools/dotnetc/dndxc.csproj.txt
+++ b/tools/clang/tools/dotnetc/dndxc.csproj.txt
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MainNs</RootNamespace>
     <AssemblyName>dndxc</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Updating the .NET version from 4.5(deprecated) to 4.8 to build on Windows11 with VS2022.

Fixes #4079 