### PR TITLE
Omit BufferBlock on SPIR-V 1.4 (~ Vulkan 1.1) instead of Vulkan 1.2

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -107,6 +107,10 @@ public:
   /// Returns false otherwise.
   bool isTargetEnvVulkan1p1OrAbove();
 
+  /// Returns true if the target environment is SPIR-V 1.4 or above.
+  /// Returns false otherwise.
+  bool isTargetEnvSpirv1p4OrAbove();
+
   /// Returns true if the target environment is Vulkan 1.1 with SPIR-V 1.4 or
   /// above. Returns false otherwise.
   bool isTargetEnvVulkan1p1Spirv1p4OrAbove();

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -2438,9 +2438,9 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
     // Emit Block or BufferBlock decorations if necessary.
     auto interfaceType = structType->getInterfaceType();
     if (interfaceType == StructInterfaceType::StorageBuffer)
-      // BufferBlock decoration is deprecated in Vulkan 1.2 and later.
+      // The BufferBlock decoration requires SPIR-V version 1.3 or earlier.
       emitDecoration(id,
-                     featureManager.isTargetEnvVulkan1p2OrAbove()
+                     featureManager.isTargetEnvSpirv1p4OrAbove()
                          ? spv::Decoration::Block
                          : spv::Decoration::BufferBlock,
                      {});

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -302,12 +302,16 @@ bool FeatureManager::isTargetEnvVulkan1p1OrAbove() {
   return targetEnv >= SPV_ENV_VULKAN_1_1;
 }
 
-bool FeatureManager::isTargetEnvVulkan1p2OrAbove() {
-  return targetEnv >= SPV_ENV_VULKAN_1_2;
+bool FeatureManager::isTargetEnvSpirv1p4OrAbove() {
+  return targetEnv >= SPV_ENV_UNIVERSAL_1_4;
 }
 
 bool FeatureManager::isTargetEnvVulkan1p1Spirv1p4OrAbove() {
   return targetEnv >= SPV_ENV_VULKAN_1_1_SPIRV_1_4;
+}
+
+bool FeatureManager::isTargetEnvVulkan1p2OrAbove() {
+  return targetEnv >= SPV_ENV_VULKAN_1_2;
 }
 
 bool FeatureManager::isTargetEnvVulkan1p3OrAbove() {

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
@@ -14,16 +14,16 @@
 namespace clang {
 namespace spirv {
 
-bool RemoveBufferBlockVisitor::isBufferBlockDecorationDeprecated() {
-  return featureManager.isTargetEnvVulkan1p2OrAbove();
+bool RemoveBufferBlockVisitor::isBufferBlockDecorationAvailable() {
+  return !featureManager.isTargetEnvSpirv1p4OrAbove();
 }
 
 bool RemoveBufferBlockVisitor::visit(SpirvModule *mod, Phase phase) {
-  // If the target environment is Vulkan 1.2 or later, BufferBlock decoration is
-  // deprecated and should be removed from the module.
+  // The BufferBlock decoration requires SPIR-V version 1.3 or earlier. It should be
+  // removed from the module on newer versions.
   // Otherwise, no action is needed by this IMR visitor.
   if (phase == Visitor::Phase::Init)
-    if (!isBufferBlockDecorationDeprecated())
+    if (isBufferBlockDecorationAvailable())
       return false;
 
   return true;

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.h
@@ -43,9 +43,9 @@ private:
   /// StorageBuffer.
   bool hasStorageBufferInterfaceType(const SpirvType *type);
 
-  /// Returns true if the BufferBlock decoration is deprecated (Vulkan 1.2 or
-  /// above).
-  bool isBufferBlockDecorationDeprecated();
+  /// Returns true if the BufferBlock decoration is available (SPIR-V 1.3
+  /// or below).
+  bool isBufferBlockDecorationAvailable();
 
   /// Transforms the given |type| if it is one of the following cases:
   ///


### PR DESCRIPTION
According to the SPIR-V validator this annotation was last usable on SPIR-V 1.3:

    fatal error: generated SPIR-V is invalid: 2nd operand of Decorate: operand BufferBlock(3) requires SPIR-V version 1.3 or earlier
        OpDecorate %type_ByteAddressBuffer BufferBlock

    note: please file a bug report on https://github.com/Microsoft/DirectXShaderCompiler/issues with source code if possible

The visitor was originally built to remove/omit it on Vulkan 1.2 and higher only, but since supporting Vulkan 1.1 with SPIR-V 1.4 (in #4364)
- which conveniently sits inbetween SPIR-V 1.3 and Vulkan 1.2 - the check must be made more stict and apply from SPIR-V 1.4 universal onwards.
