### PR TITLE
[dxil2spv] Fix build warning

### DIFF
--- a/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
+++ b/tools/clang/tools/dxil2spv/lib/CMakeLists.txt
@@ -14,7 +14,7 @@ add_clang_library(dxil2spvlib
   dxil2spv.cpp
   )
 
-target_link_libraries(dxil2spvlib
+target_link_libraries(dxil2spvlib PRIVATE
   clangBasic
   clangCodeGen
   clangSPIRV

--- a/tools/clang/unittests/Dxil2Spv/CMakeLists.txt
+++ b/tools/clang/unittests/Dxil2Spv/CMakeLists.txt
@@ -18,9 +18,10 @@ add_clang_unittest(clang-dxil2spv-tests
   )
 
 target_link_libraries(clang-dxil2spv-tests
+  clangSPIRV
   dxcompiler
-  effcee
   dxil2spvlib
+  effcee
   )
 
 include_directories(${LLVM_SOURCE_DIR}/tools/clang/tools)


### PR DESCRIPTION
Address the "Policy CMP0023 is not set: Plain and keyword target_link_libraries signatures cannot be mixed." warning.
