### PR TITLE
Added a pass using GVN to eliminate redundant code without doing code motion.

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -137,4 +137,7 @@ void initializeDxilMutateResourceToHandlePass(llvm::PassRegistry&);
 ModulePass *createDxilDeleteRedundantDebugValuesPass();
 void initializeDxilDeleteRedundantDebugValuesPass(llvm::PassRegistry&);
 
+FunctionPass *createDxilSimpleGVNEliminateRegionPass();
+void initializeDxilSimpleGVNEliminateRegionPass(llvm::PassRegistry&);
+
 }

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -504,7 +504,7 @@ void PassManagerBuilder::populateModulePassManager(
 
   // HLSL Change Begins.
   // Use value numbering to figure out if regions are equivalent, and branch to only one.
-  //MPM.add(createDxilSimpleGVNEliminateRegionPass());
+  MPM.add(createDxilSimpleGVNEliminateRegionPass());
   // HLSL don't allow memcpy and memset.
   //MPM.add(createMemCpyOptPass());             // Remove memcpy / form memset
   // HLSL Change Ends.

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -501,7 +501,10 @@ void PassManagerBuilder::populateModulePassManager(
     }
     // HLSL Change Ends
   }
+
   // HLSL Change Begins.
+  // Use value numbering to figure out if regions are equivalent, and branch to only one.
+  //MPM.add(createDxilSimpleGVNEliminateRegionPass());
   // HLSL don't allow memcpy and memset.
   //MPM.add(createMemCpyOptPass());             // Remove memcpy / form memset
   // HLSL Change Ends.

--- a/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-commutative.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-commutative.hlsl
@@ -26,14 +26,14 @@ cbuffer cb1 : register(b1) {
 
 float foo(float2 uv) {
   if (a < b)
-    return sin(a) + b + c;
+    return sin(a) + b;
   else
     return a - b + c;
 }
 
 float bar() {
   if (a < b)
-    return sin(a) + b + c;
+    return b + sin(a);
   else
     return a - b + c;
 }
@@ -47,3 +47,4 @@ float main(float2 uv : TEXCOORD) : SV_Target {
     return bar();
   }
 }
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-mem-read.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-mem-read.hlsl
@@ -1,0 +1,42 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: @main
+// CHECK: call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66
+// CHECK-NOT: call %dx.types.ResRet.f32 @dx.op.textureLoad.f32(i32 66
+
+RWTexture1D<float> my_uav : register(u0);
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  uint idx;
+  float a, b, c;
+};
+
+float foo(float2 uv) {
+  if (a < b)
+    return my_uav[idx] + sin(a) + b + c;
+  else
+    return a - b + c;
+}
+
+float bar() {
+  if (a < b)
+    return my_uav[idx] + sin(a) + b + c;
+  else
+    return a - b + c;
+}
+
+[RootSignature("CBV(b1),DescriptorTable(UAV(u0))")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}
+
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-mem-write.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region-mem-write.hlsl
@@ -1,0 +1,41 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: error: validation errors
+// CHECK: Shader CBV descriptor range
+
+RWTexture1D<float> my_uav : register(u0);
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+float foo(float2 uv) {
+  my_uav[0] = 10;
+  if (a < b)
+    return sin(a) + b + c;
+  else
+    return a - b + c;
+}
+
+float bar() {
+  my_uav[0] = 10;
+  if (a < b)
+    return sin(a) + b + c;
+  else
+    return a - b + c;
+}
+
+[RootSignature("CBV(b1),DescriptorTable(UAV(u0))")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/gvn-eliminate-region/gvn-eliminate-region.hlsl
@@ -1,0 +1,45 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: @main
+
+// Without GVN, some basic ability to recognize equivalent regions was lost.
+// This test makes sure we can still eliminate redundancies even when regular GVN
+// is disabled to reduce code motion.
+// 
+// In this regression test, foo and bar do the exact same thing. The branch that
+// decides which one to call reads from a resource not bound in root signature.
+// The compiler should be able to recognize that both sides are equivalent and
+// eliminate the condition even when gvn is turned off.
+//
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+float foo(float2 uv) {
+  if (a < b)
+    return a + b + c;
+  else
+    return a - b + c;
+}
+
+float bar() {
+  if (a < b)
+    return a + b + c;
+  else
+    return a - b + c;
+}
+
+[RootSignature("CBV(b1)")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2165,6 +2165,7 @@ class db_dxil(object):
         add_pass('hlsl-dxil-precise', 'DxilPrecisePropagatePass', 'DXIL precise attribute propagate', [])
         add_pass('dxil-legalize-sample-offset', 'DxilLegalizeSampleOffsetPass', 'DXIL legalize sample offset', [])
         add_pass('dxil-gvn-hoist', 'DxilSimpleGVNHoist', 'DXIL simple gvn hoist', [])
+        add_pass('dxil-gvn-eliminate-region', 'DxilSimpleGVNEliminateRegion', 'DXIL simple eliminate region', [])
         add_pass('hlsl-hlensure', 'HLEnsureMetadata', 'HLSL High-Level Metadata Ensure', [])
         add_pass('multi-dim-one-dim', 'MultiDimArrayToOneDimArray', 'Flatten multi-dim array into one-dim array', [])
         add_pass('resource-handle', 'ResourceToHandle', 'Lower resource into handle', [])


### PR DESCRIPTION
Without GVN, some basic ability to eliminate redundancy was lost. This change adds a pass that uses value numbering to eliminate redundant code without code motion.


