### PR TITLE
Complete builtin types when used as array params

### DIFF
--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -6734,6 +6734,17 @@ bool Sema::RequireCompleteTypeImpl(SourceLocation Loc, QualType T,
   while (const ConstantArrayType *Array
            = Context.getAsConstantArrayType(MaybeTemplate))
     MaybeTemplate = Array->getElementType();
+
+  // HLSL Change - Begin
+  // In HLSL we don't decay pointers to arrays, so we need to require
+  // complete types for array elements.
+  if (LangOpts.HLSL) {
+    if (const TagType *Tag = MaybeTemplate->getAs<TagType>()) {
+      if (auto *Source = Context.getExternalSource())
+        Source->CompleteType(Tag->getDecl());
+    }
+  }
+  // HLSL Change - End
   if (const RecordType *Record = MaybeTemplate->getAs<RecordType>()) {
     if (ClassTemplateSpecializationDecl *ClassTemplateSpec
           = dyn_cast<ClassTemplateSpecializationDecl>(Record->getDecl())) {

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -6736,8 +6736,8 @@ bool Sema::RequireCompleteTypeImpl(SourceLocation Loc, QualType T,
     MaybeTemplate = Array->getElementType();
 
   // HLSL Change - Begin
-  // In HLSL we don't decay pointers to arrays, so we need to require
-  // complete types for array elements.
+  // In HLSL we don't decay arrays to pointers, so we need to require complete
+  // types for array elements.
   if (LangOpts.HLSL) {
     if (const TagType *Tag = MaybeTemplate->getAs<TagType>()) {
       if (auto *Source = Context.getExternalSource())

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/complete-array-parameter.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/complete-array-parameter.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T lib_6_3 -ast-dump %s | FileCheck %s
+
+float4 Val(Texture2D f[2]) {
+  return float4(0,0,0,0);
+}
+
+// CHECK: FunctionDecl 0x{{[0-9a-fA-F]+}} <{{.*}}, line:5:1> line:3:8 Val 'float4 (Texture2D [2])'
+// CHECK-NEXT: ParmVarDecl 0x{{[0-9a-fA-F]+}} <col:12, col:25> col:22 f 'Texture2D [2]'


### PR DESCRIPTION
This is an odd edge case.

C doesn't require array element types to be complete because they decay
to pointers. In HLSL we don't decay to pointers, so we need them to be
complete, otherwise things trip up.