### PR TITLE
Reenable NRVO when no precise and global coherent.

### DIFF
--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -2710,7 +2710,7 @@ VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
     // NRVO breaks on bool component type due to diff between
     // i32 memory and i1 register representation
     if (hlsl::IsHLSLVecMatType(ReturnType))
-      return false;
+      return nullptr;
     QualType ArrayEltTy = ReturnType;
     while (const clang::ArrayType *AT =
                Context.getAsArrayType(ArrayEltTy)) {
@@ -2718,15 +2718,15 @@ VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
     }
     // exclude resource for globallycoherent.
     if (hlsl::IsHLSLResourceType(ArrayEltTy))
-      return false;
+      return nullptr;
     // exclude precise.
     if (VD->hasAttr<HLSLPreciseAttr>()) {
-      return false;
+      return nullptr;
     }
     if (const FunctionDecl *FD = getCurFunctionDecl()) {
       if (FD->hasAttr<HLSLPreciseAttr>()) {
         VD->addAttr(FD->getAttr<HLSLPreciseAttr>());
-        return false;
+        return nullptr;
       }
     }
   }

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -2723,6 +2723,7 @@ VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
     if (VD->hasAttr<HLSLPreciseAttr>()) {
       return nullptr;
     }
+    // propagate precise the the VD.
     if (const FunctionDecl *FD = getCurFunctionDecl()) {
       if (FD->hasAttr<HLSLPreciseAttr>()) {
         VD->addAttr(FD->getAttr<HLSLPreciseAttr>());

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -2704,7 +2704,6 @@ VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
   // HLSL Change Begins: NRVO unsafe for a variety of cases in HLSL
   // - vectors/matrix with bool component types
   // - attributes not captured to QualType, such as precise and globallycoherent
-  // NRVO is also unnecessary for HLSL correctness or performance.
   if (getLangOpts().HLSL) {
     // exclude vectors/matrix (not treated as record type)
     // NRVO breaks on bool component type due to diff between

--- a/tools/clang/lib/Sema/SemaStmt.cpp
+++ b/tools/clang/lib/Sema/SemaStmt.cpp
@@ -2689,14 +2689,6 @@ Sema::ActOnBreakStmt(SourceLocation BreakLoc, Scope *CurScope) {
 VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
                                        Expr *E,
                                        bool AllowFunctionParameter) {
-  // HLSL Change Begins: NRVO unsafe for a variety of cases in HLSL
-  // - vectors/matrix with bool component types
-  // - attributes not captured to QualType, such as precise and globallycoherent
-  // NRVO is also unnecessary for HLSL correctness or performance.
-  if (getLangOpts().HLSL)
-    return nullptr;
-  // HLSL Change Ends
-
   if (!getLangOpts().CPlusPlus)
     return nullptr;
 
@@ -2708,6 +2700,37 @@ VarDecl *Sema::getCopyElisionCandidate(QualType ReturnType,
   VarDecl *VD = dyn_cast<VarDecl>(DR->getDecl());
   if (!VD)
     return nullptr;
+
+  // HLSL Change Begins: NRVO unsafe for a variety of cases in HLSL
+  // - vectors/matrix with bool component types
+  // - attributes not captured to QualType, such as precise and globallycoherent
+  // NRVO is also unnecessary for HLSL correctness or performance.
+  if (getLangOpts().HLSL) {
+    // exclude vectors/matrix (not treated as record type)
+    // NRVO breaks on bool component type due to diff between
+    // i32 memory and i1 register representation
+    if (hlsl::IsHLSLVecMatType(ReturnType))
+      return false;
+    QualType ArrayEltTy = ReturnType;
+    while (const clang::ArrayType *AT =
+               Context.getAsArrayType(ArrayEltTy)) {
+      ArrayEltTy = AT->getElementType();
+    }
+    // exclude resource for globallycoherent.
+    if (hlsl::IsHLSLResourceType(ArrayEltTy))
+      return false;
+    // exclude precise.
+    if (VD->hasAttr<HLSLPreciseAttr>()) {
+      return false;
+    }
+    if (const FunctionDecl *FD = getCurFunctionDecl()) {
+      if (FD->hasAttr<HLSLPreciseAttr>()) {
+        VD->addAttr(FD->getAttr<HLSLPreciseAttr>());
+        return false;
+      }
+    }
+  }
+  // HLSL Change Ends
 
   if (isCopyElisionCandidate(ReturnType, VD, AllowFunctionParameter))
     return VD;

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/EnableNRVO.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/EnableNRVO.hlsl
@@ -1,0 +1,50 @@
+// RUN: %dxc -E main -fcgl  -T ps_6_0  %s | FileCheck %s -check-prefix=IR
+// RUN: %dxc -E main -T ps_6_0  -enable-short-circuit %s | FileCheck %s -check-prefix=DXIL
+
+// The issue happens when d.cb copy in foo and copy in d.cb = cbv.
+// Then, when lower memcpy, there're more than one write to d.cb.
+// As a result, the memcopy will be flattened into ld/st which will generate alloca and lot of cb load.
+// Enable NRVO (Named Return Value Optimization) will avoid copy in return d inside foo and resolve the issue.
+
+// For clang codeGen IR make sure only 1 memcpy call.
+// IR:call void @llvm.memcpy
+// IR-NOT:call void @llvm.memcpy
+
+
+// For DXIL, make sure no alloca and only 2 cb load ( 1 for arrayidx, 1 for cbv.idx[arrayidx] ).
+// DXIL-NOT:alloca
+// DXIL:call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy
+// DXIL:call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy
+// DXIL-NOT:call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy
+
+
+struct CB {
+  uint idx[8];
+};
+
+ConstantBuffer<CB> cbv;
+
+struct Data {
+  CB cb;
+};
+
+// Named Return Value Optimization
+Data foo() {
+  Data d;
+  // When NRVO is disabled, there will be a copy from d to return value.
+  return d;
+}
+
+uint arrayidx;
+
+Buffer<float> buf;
+
+float main() : SV_Target {
+  Data d = foo();
+  d.cb = cbv;
+
+  return buf[d.cb.idx[arrayidx]];
+}
+
+
+

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -35,7 +35,7 @@ void main(uint3 dispatchid : SV_DispatchThreadID) {
 // CHECK: %[[Value:[0-9]+]] = load float, float* %[[Alloca]]
 // CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %{{.*}}, i32 %{{[0-9]}}, i32 0, float %[[Value]], float undef, float undef, float undef, i8 1)
 
-// CHECK: %[[Buffer2:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
+// CHECK: %[[Buffer2:[0-9]+]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
 // CHECK: %[[Value2:[0-9]+]] = extractvalue %dx.types.ResRet.f32 %[[Buffer2]], 0
 // CHECK: %[[SIN:[0-9a-zA-Z]+]] = call float @dx.op.unary.f32(i32 13, float %[[Value2]]), !dx.precise
 // CHECK: store float %[[SIN]], float* %[[Alloca2]], align 4, !noalias

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -1,5 +1,5 @@
 // RUN: %dxc -T cs_6_0 -Od %s | FileCheck %s
-
+// RUN: %dxc -T cs_6_0 -ast-dump %s | FileCheck %s -check-prefix=AST
 struct MyStruct {
   float x;
 };
@@ -15,6 +15,11 @@ precise MyStruct makeStruct2(float x) {
   ret.x = sin(x);
   return ret;
 }
+
+// Make sure precise propagated to MyStruct ret on line14.
+// AST:-DeclStmt 0x{{[^ ]+}} <line:14:3, col:15>
+// AST-NEXT:-VarDecl 0x{{[^ ]+}} <col:3, col:12> col:12 used ret 'MyStruct'
+// AST-NEXT:-HLSLPreciseAttr 0x{{[^ ]+}} <line:13:1>
 
 StructuredBuffer<MyStruct> DataIn;
 RWStructuredBuffer<MyStruct> DataOut;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/precise/disable-nrvo.hlsl
@@ -10,6 +10,12 @@ MyStruct makeStruct(float x) {
   return ret;
 }
 
+precise MyStruct makeStruct2(float x) {
+  MyStruct ret;
+  ret.x = sin(x);
+  return ret;
+}
+
 StructuredBuffer<MyStruct> DataIn;
 RWStructuredBuffer<MyStruct> DataOut;
 
@@ -17,11 +23,21 @@ RWStructuredBuffer<MyStruct> DataOut;
 void main(uint3 dispatchid : SV_DispatchThreadID) {
   MyStruct d = makeStruct(DataIn[dispatchid.x].x);
   DataOut[dispatchid.x] = d;
+  MyStruct d2 = makeStruct2(DataIn[dispatchid.x].x);
+  DataOut[dispatchid.x*2+1] = d2;
 }
 
 // CHECK:  %[[Alloca:.*]] = alloca float, !dx.precise
+// CHECK:  %[[Alloca2:.*]] = alloca float, !dx.precise
 // CHECK: %[[Buffer:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
 // CHECK: %[[Value:[0-9]]] = extractvalue %dx.types.ResRet.f32 %[[Buffer]], 0
 // CHECK: store float %[[Value]], float* %[[Alloca]], align 4, !noalias
 // CHECK: %[[Value:[0-9]+]] = load float, float* %[[Alloca]]
 // CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %{{.*}}, i32 %{{[0-9]}}, i32 0, float %[[Value]], float undef, float undef, float undef, i8 1)
+
+// CHECK: %[[Buffer2:[0-9]]] = call %dx.types.ResRet.f32 @dx.op.bufferLoad.f32
+// CHECK: %[[Value2:[0-9]+]] = extractvalue %dx.types.ResRet.f32 %[[Buffer2]], 0
+// CHECK: %[[SIN:[0-9a-zA-Z]+]] = call float @dx.op.unary.f32(i32 13, float %[[Value2]]), !dx.precise
+// CHECK: store float %[[SIN]], float* %[[Alloca2]], align 4, !noalias
+// CHECK: %[[Value3:[0-9]+]] = load float, float* %[[Alloca2]]
+// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %{{.*}}, i32 %{{[0-9a-zA-Z]+}}, i32 0, float %[[Value3]], float undef, float undef, float undef, i8 1)


### PR DESCRIPTION
Enable NRVO when no precise and global coherent to avoid extra memcpy created in clang codeGen.
Also propagate precise from the function to named return value.