### PR TITLE
Added a pass to use GVN to remove redundant branches without doing code motion.

### DIFF
--- a/include/dxc/HLSL/DxilGenerationPass.h
+++ b/include/dxc/HLSL/DxilGenerationPass.h
@@ -137,4 +137,7 @@ void initializeDxilMutateResourceToHandlePass(llvm::PassRegistry&);
 ModulePass *createDxilDeleteRedundantDebugValuesPass();
 void initializeDxilDeleteRedundantDebugValuesPass(llvm::PassRegistry&);
 
+FunctionPass *createDxilSimpleGVNEliminateRegionPass();
+void initializeDxilSimpleGVNEliminateRegionPass(llvm::PassRegistry&);
+
 }

--- a/lib/HLSL/DxilSimpleGVNHoist.cpp
+++ b/lib/HLSL/DxilSimpleGVNHoist.cpp
@@ -643,7 +643,7 @@ class DxilSimpleGVNEliminateRegion : public FunctionPass {
       }
     }
     BlockHasSideEffects[BB] = HasSideEffects;
-    return false;
+    return HasSideEffects;
   }
   bool ProcessBB(BasicBlock &BB, ValueTable &VT, DominatorTree *DT, PostDominatorTree *PDT);
 

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -374,6 +374,7 @@ void PassManagerBuilder::populateModulePassManager(
 
     if (!HLSLHighLevel) {
       MPM.add(createDxilConvergentClearPass());
+      MPM.add(createDxilSimpleGVNEliminateRegionPass());
       MPM.add(createDxilEraseDeadRegionPass());
       MPM.add(createDeadCodeEliminationPass());
       MPM.add(createDxilRemoveDeadBlocksPass());
@@ -501,7 +502,10 @@ void PassManagerBuilder::populateModulePassManager(
     }
     // HLSL Change Ends
   }
+
   // HLSL Change Begins.
+  // Use value numbering to figure out if regions are equivalent, and branch to only one.
+  MPM.add(createDxilSimpleGVNEliminateRegionPass());
   // HLSL don't allow memcpy and memset.
   //MPM.add(createMemCpyOptPass());             // Remove memcpy / form memset
   // HLSL Change Ends.

--- a/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region.hlsl
@@ -1,0 +1,43 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: @main
+// CHECK: call float @dx.op.unary.f32(i32 13
+// CHECK-NOT: call float @dx.op.unary.f32(i32 13
+// ^Make sure sin is only seen once
+
+// Without GVN, some basic ability to recognize equivalent regions was lost.
+// This test makes sure we can still eliminate redundancies even when regular GVN
+// is disabled to reduce code motion.
+// 
+// In this regression test, foo and bar do the exact same thing. The branch that
+// decides which one to call reads from a resource not bound in root signature.
+// The compiler should be able to recognize that both sides are equivalent and
+// eliminate the condition even when gvn is turned off.
+//
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+float foo(float2 uv) {
+  return sin(a) + b + c;
+}
+
+float bar() {
+  return sin(a) + b + c;
+}
+
+[RootSignature("CBV(b1)")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_inside_loop.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_inside_loop.hlsl
@@ -1,0 +1,49 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: @main
+// CHECK: call float @dx.op.unary.f32(i32 13
+// CHECK-NOT: call float @dx.op.unary.f32(i32 13
+// ^Make sure sin is only seen once
+
+// Without GVN, some basic ability to recognize equivalent regions was lost.
+// This test makes sure we can still eliminate redundancies even when regular GVN
+// is disabled to reduce code motion.
+// 
+// In this regression test, foo and bar do the exact same thing. The branch that
+// decides which one to call reads from a resource not bound in root signature.
+// The compiler should be able to recognize that both sides are equivalent and
+// eliminate the condition even when gvn is turned off.
+//
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+float foo(float2 uv) {
+  return sin(a) + b + c;
+}
+
+float bar() {
+  return sin(a) + b + c;
+}
+
+[RootSignature("CBV(b1)")]
+float main(float2 uv : TEXCOORD, int loopBound : LOOPBOUND) : SV_Target {
+    float ret = 0;
+    [loop]
+    for (int i = 0; i < loopBound; i++) {
+        if (bCond) {
+            ret += foo(uv);
+        }
+        else {
+            ret += bar();
+        }
+    }
+    return ret;
+}
+
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_loop.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_loop.hlsl
@@ -1,0 +1,43 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: validation errors
+// CHECK: Root Signature in DXIL container is not compatible with shader
+
+// Make sure when there's loops, the pass is not doing anything.
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+RWTexture1D<float> uav0 : register(u0);
+
+float foo(float2 uv) {
+  float ret = 0;
+  for (uint i = 0; i < b; i++)
+    ret += sin(a);
+  return ret;
+}
+
+float bar() {
+  float ret = 0;
+  for (uint i = 0; i < b; i++)
+    ret += sin(a);
+  return ret;
+}
+
+[RootSignature("CBV(b1),DescriptorTable(UAV(u0))")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}
+
+
+

--- a/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_sideeffect.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/simple_gvn_hoists/simple_gvn_delete_region_sideeffect.hlsl
@@ -1,0 +1,38 @@
+// RUN: %dxc -T ps_6_0 -E main /opt-disable gvn %s | FileCheck %s
+
+// CHECK: validation errors
+// CHECK: Root Signature in DXIL container is not compatible with shader
+
+// Make sure when there's side effect, the pass is not doing anything.
+
+cbuffer cb : register(b6) {
+  bool bCond;
+};
+
+cbuffer cb1 : register(b1) {
+  float a, b, c;
+};
+
+RWTexture1D<float> uav0 : register(u0);
+
+float foo(float2 uv) {
+  uav0[0] = 10;
+  return sin(a) + b + c;
+}
+
+float bar() {
+  uav0[0] = 10;
+  return sin(a) + b + c;
+}
+
+[RootSignature("CBV(b1),DescriptorTable(UAV(u0))")]
+float main(float2 uv : TEXCOORD) : SV_Target {
+  if (bCond) {
+    return foo(uv);
+  }
+  else {
+    return bar();
+  }
+}
+
+

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2165,6 +2165,7 @@ class db_dxil(object):
         add_pass('hlsl-dxil-precise', 'DxilPrecisePropagatePass', 'DXIL precise attribute propagate', [])
         add_pass('dxil-legalize-sample-offset', 'DxilLegalizeSampleOffsetPass', 'DXIL legalize sample offset', [])
         add_pass('dxil-gvn-hoist', 'DxilSimpleGVNHoist', 'DXIL simple gvn hoist', [])
+        add_pass('dxil-gvn-eliminate-region', 'DxilSimpleGVNEliminateRegion', 'DXIL simple eliminate region', [])
         add_pass('hlsl-hlensure', 'HLEnsureMetadata', 'HLSL High-Level Metadata Ensure', [])
         add_pass('multi-dim-one-dim', 'MultiDimArrayToOneDimArray', 'Flatten multi-dim array into one-dim array', [])
         add_pass('resource-handle', 'ResourceToHandle', 'Lower resource into handle', [])


### PR DESCRIPTION
Sometimes GVN is turned off deliberately to avoid code motion, which can lead to certain redundant code being left behind. This change adds a pass that uses value numbering to identify and remove identical code from two sides of a conditional branch.