### PR TITLE
[dxil2spv] Support shl instruction

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -235,6 +235,9 @@ public:
   SpirvBinaryOp *createBinaryOp(spv::Op op, QualType resultType,
                                 SpirvInstruction *lhs, SpirvInstruction *rhs,
                                 SourceLocation loc, SourceRange range = {});
+  SpirvBinaryOp *createBinaryOp(spv::Op op, const SpirvType *resultType,
+                                SpirvInstruction *lhs, SpirvInstruction *rhs,
+                                SourceLocation loc, SourceRange range = {});
 
   SpirvSpecConstantBinaryOp *createSpecConstantBinaryOp(spv::Op op,
                                                         QualType resultType,

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -222,6 +222,8 @@ protected:
   // Forbid creating SpirvInstruction directly
   SpirvInstruction(Kind kind, spv::Op opcode, QualType astResultType,
                    SourceLocation loc, SourceRange range = {});
+  SpirvInstruction(Kind kind, spv::Op opcode, const SpirvType *resultType,
+                   SourceLocation loc, SourceRange range = {});
 
 protected:
   const Kind kind;
@@ -1017,6 +1019,9 @@ private:
 class SpirvBinaryOp : public SpirvInstruction {
 public:
   SpirvBinaryOp(spv::Op opcode, QualType resultType, SourceLocation loc,
+                SpirvInstruction *op1, SpirvInstruction *op2,
+                SourceRange range = {});
+  SpirvBinaryOp(spv::Op opcode, const SpirvType *resultType, SourceLocation loc,
                 SpirvInstruction *op1, SpirvInstruction *op2,
                 SourceRange range = {});
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -405,6 +405,17 @@ SpirvBinaryOp *SpirvBuilder::createBinaryOp(spv::Op op, QualType resultType,
   return instruction;
 }
 
+SpirvBinaryOp *
+SpirvBuilder::createBinaryOp(spv::Op op, const SpirvType *resultType,
+                             SpirvInstruction *lhs, SpirvInstruction *rhs,
+                             SourceLocation loc, SourceRange range) {
+  assert(insertPoint && "null insert point");
+  auto *instruction =
+      new (context) SpirvBinaryOp(op, resultType, loc, lhs, rhs, range);
+  insertPoint->addInstruction(instruction);
+  return instruction;
+}
+
 SpirvSpecConstantBinaryOp *SpirvBuilder::createSpecConstantBinaryOp(
     spv::Op op, QualType resultType, SpirvInstruction *lhs,
     SpirvInstruction *rhs, SourceLocation loc) {

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -120,6 +120,15 @@ SpirvInstruction::SpirvInstruction(Kind k, spv::Op op, QualType astType,
       storageClass(spv::StorageClass::Function), isRValue_(false),
       isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
 
+SpirvInstruction::SpirvInstruction(Kind k, spv::Op op,
+                                   const SpirvType *resultType,
+                                   SourceLocation loc, SourceRange range)
+    : kind(k), opcode(op), astResultType({}), resultId(0), srcLoc(loc),
+      srcRange(range), debugName(), resultType(resultType), resultTypeId(0),
+      layoutRule(SpirvLayoutRule::Void), containsAlias(false),
+      storageClass(spv::StorageClass::Function), isRValue_(false),
+      isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
+
 bool SpirvInstruction::isArithmeticInstruction() const {
   switch (opcode) {
   case spv::Op::OpSNegate:
@@ -455,6 +464,12 @@ SpirvBinaryOp::SpirvBinaryOp(spv::Op opcode, QualType resultType,
                              SpirvInstruction *op2, SourceRange range)
     : SpirvInstruction(IK_BinaryOp, opcode, resultType, loc, range),
 	  operand1(op1), operand2(op2) {}
+
+SpirvBinaryOp::SpirvBinaryOp(spv::Op opcode, const SpirvType *resultType,
+                             SourceLocation loc, SpirvInstruction *op1,
+                             SpirvInstruction *op2, SourceRange range)
+    : SpirvInstruction(IK_BinaryOp, opcode, resultType, loc, range),
+      operand1(op1), operand2(op2) {}
 
 SpirvBitField::SpirvBitField(Kind kind, spv::Op op, QualType resultType,
                              SourceLocation loc, SpirvInstruction *baseInst,

--- a/tools/clang/test/Dxil2Spv/passthru-cs.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-cs.ll
@@ -86,7 +86,7 @@ attributes #2 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 20
+; ; Bound: 22
 ; ; Schema: 0
 ;                OpCapability Shader
 ;                OpMemoryModel Logical GLSL450
@@ -104,6 +104,7 @@ attributes #2 = { nounwind }
 ;                OpDecorate %type_RWByteAddressBuffer BufferBlock
 ;        %uint = OpTypeInt 32 0
 ;      %uint_0 = OpConstant %uint 0
+;      %uint_2 = OpConstant %uint 2
 ;      %v3uint = OpTypeVector %uint 3
 ; %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 ; %_runtimearr_uint = OpTypeRuntimeArray %uint
@@ -112,19 +113,21 @@ attributes #2 = { nounwind }
 ; %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
 ;        %void = OpTypeVoid
-;          %15 = OpTypeFunction %void
+;          %16 = OpTypeFunction %void
 ; %_ptr_Input_uint = OpTypePointer Input %uint
 ; %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
-;          %10 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
-;          %13 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
-;        %main = OpFunction %void None %15
-;          %16 = OpLabel
-;          %18 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
-;          %19 = OpLoad %uint %18
+;          %11 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
+;          %14 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
+;        %main = OpFunction %void None %16
+;          %17 = OpLabel
+;          %19 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+;          %20 = OpLoad %uint %19
+;          %21 = OpShiftLeftLogical %uint %20 %uint_2
 ;                OpReturn
 ;                OpFunctionEnd
 ; CHECK-ERRORS:
 ; error: Unhandled DXIL opcode: CreateHandle
 ; error: Unhandled DXIL opcode: CreateHandle
 ; error: Unhandled DXIL opcode: BufferLoad
+; error: Unhandled LLVM instruction:   %6 = extractvalue %dx.types.ResRet.i32 %5, 0
 ; error: Unhandled DXIL opcode: BufferStore

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -385,6 +385,14 @@ void Translator::createBinaryOpInstruction(llvm::BinaryOperator &instruction) {
   case llvm::Instruction::Shl: {
     // Value to be shifted.
     spirv::SpirvInstruction *val = instructionMap[instruction.getOperand(0)];
+    if (!val) {
+      std::string instStr;
+      llvm::raw_string_ostream os(instStr);
+      instruction.print(os);
+      emitError("Could not find translation of instruction operand 0: %0")
+          << os.str();
+      return;
+    }
 
     // Amount to shift by.
     const spirv::IntegerType *uint32 = spvContext.getUIntType(32);

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.h
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.h
@@ -19,6 +19,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/SPIRV/SpirvBuilder.h"
 #include "clang/SPIRV/SpirvContext.h"
+#include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -71,6 +72,7 @@ private:
   void createLoadInputInstruction(llvm::CallInst &instruction);
   void createStoreOutputInstruction(llvm::CallInst &instruction);
   void createThreadIdInstruction(llvm::CallInst &instruction);
+  void createBinaryOpInstruction(llvm::BinaryOperator &instruction);
 
   // SPIR-V Tools wrapper functions.
   bool spirvToolsValidate(std::vector<uint32_t> *mod, std::string *messages);


### PR DESCRIPTION
Add support for translating the first simple binary operator
instruction, shift left, from DXIL to SPIR-V.