### PR TITLE
[dxil2spv] Translate createHandle and bufferLoad

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -105,6 +105,9 @@ public:
   SpirvVariable *addFnVar(QualType valueType, SourceLocation,
                           llvm::StringRef name = "", bool isPrecise = false,
                           SpirvInstruction *init = nullptr);
+  SpirvVariable *addFnVar(const spirv::SpirvType *valueType, SourceLocation,
+                          llvm::StringRef name = "", bool isPrecise = false,
+                          SpirvInstruction *init = nullptr);
 
   /// \brief Ends building of the current function. All basic blocks constructed
   /// from the beginning or after ending the previous function will be collected

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -147,6 +147,18 @@ SpirvVariable *SpirvBuilder::addFnVar(QualType valueType, SourceLocation loc,
   return var;
 }
 
+SpirvVariable *SpirvBuilder::addFnVar(const spirv::SpirvType *valueType,
+                                      SourceLocation loc, llvm::StringRef name,
+                                      bool isPrecise, SpirvInstruction *init) {
+  assert(function && "found detached local variable");
+  // TODO: Handle potential bindless array of an opaque type.
+  SpirvVariable *var = new (context) SpirvVariable(
+      valueType, loc, spv::StorageClass::Function, isPrecise, init);
+  var->setDebugName(name);
+  function->addVariable(var);
+  return var;
+}
+
 void SpirvBuilder::endFunction() {
   assert(function && "no active function");
   mod->addFunctionToListOfSortedModuleFunctions(function);

--- a/tools/clang/test/Dxil2Spv/passthru-cs.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-cs.ll
@@ -86,7 +86,7 @@ attributes #2 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 25
+; ; Bound: 56
 ; ; Schema: 0
 ;                OpCapability Shader
 ;                OpMemoryModel Logical GLSL450
@@ -95,6 +95,7 @@ attributes #2 = { nounwind }
 ;                OpName %type_ByteAddressBuffer "type.ByteAddressBuffer"
 ;                OpName %type_RWByteAddressBuffer "type.RWByteAddressBuffer"
 ;                OpName %main "main"
+;                OpName %dx_types_ResRet_i32 "dx.types.ResRet.i32"
 ;                OpDecorate %3 DescriptorSet 0
 ;                OpDecorate %3 Binding 0
 ;                OpDecorate %4 DescriptorSet 0
@@ -109,6 +110,9 @@ attributes #2 = { nounwind }
 ;        %uint = OpTypeInt 32 0
 ;      %uint_0 = OpConstant %uint 0
 ;      %uint_2 = OpConstant %uint 2
+;      %uint_1 = OpConstant %uint 1
+;      %uint_3 = OpConstant %uint 3
+;      %uint_4 = OpConstant %uint 4
 ; %_runtimearr_uint = OpTypeRuntimeArray %uint
 ; %type_ByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_ByteAddressBuffer = OpTypePointer Uniform %type_ByteAddressBuffer
@@ -117,19 +121,52 @@ attributes #2 = { nounwind }
 ;      %v3uint = OpTypeVector %uint 3
 ; %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 ;        %void = OpTypeVoid
-;          %16 = OpTypeFunction %void
+;          %19 = OpTypeFunction %void
+;         %int = OpTypeInt 32 1
+; %dx_types_ResRet_i32 = OpTypeStruct %int %int %int %int %int
+; %_ptr_Function_dx_types_ResRet_i32 = OpTypePointer Function %dx_types_ResRet_i32
 ; %_ptr_Input_uint = OpTypePointer Input %uint
 ; %_ptr_Uniform_uint = OpTypePointer Uniform %uint
+; %_ptr_Function_int = OpTypePointer Function %int
 ;           %3 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
 ;           %4 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
 ; %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
-;        %main = OpFunction %void None %16
-;          %17 = OpLabel
-;          %19 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
-;          %20 = OpLoad %uint %19
-;          %21 = OpShiftLeftLogical %uint %20 %uint_2
-;          %23 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %21
-;          %24 = OpLoad %uint %23
+;        %main = OpFunction %void None %19
+;          %20 = OpLabel
+;          %24 = OpVariable %_ptr_Function_dx_types_ResRet_i32 Function
+;          %26 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
+;          %27 = OpLoad %uint %26
+;          %28 = OpShiftLeftLogical %uint %27 %uint_2
+;          %29 = OpIAdd %uint %28 %uint_0
+;          %31 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %29
+;          %32 = OpLoad %uint %31
+;          %34 = OpAccessChain %_ptr_Function_int %24 %uint_0
+;          %35 = OpBitcast %int %32
+;                OpStore %34 %35
+;          %36 = OpIAdd %uint %28 %uint_1
+;          %37 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %36
+;          %38 = OpLoad %uint %37
+;          %39 = OpAccessChain %_ptr_Function_int %24 %uint_1
+;          %40 = OpBitcast %int %38
+;                OpStore %39 %40
+;          %41 = OpIAdd %uint %28 %uint_2
+;          %42 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %41
+;          %43 = OpLoad %uint %42
+;          %44 = OpAccessChain %_ptr_Function_int %24 %uint_2
+;          %45 = OpBitcast %int %43
+;                OpStore %44 %45
+;          %46 = OpIAdd %uint %28 %uint_3
+;          %47 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %46
+;          %48 = OpLoad %uint %47
+;          %49 = OpAccessChain %_ptr_Function_int %24 %uint_3
+;          %50 = OpBitcast %int %48
+;                OpStore %49 %50
+;          %51 = OpIAdd %uint %28 %uint_4
+;          %52 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %51
+;          %53 = OpLoad %uint %52
+;          %54 = OpAccessChain %_ptr_Function_int %24 %uint_4
+;          %55 = OpBitcast %int %53
+;                OpStore %54 %55
 ;                OpReturn
 ;                OpFunctionEnd
 ; CHECK-ERRORS:

--- a/tools/clang/test/Dxil2Spv/passthru-cs.ll
+++ b/tools/clang/test/Dxil2Spv/passthru-cs.ll
@@ -86,7 +86,7 @@ attributes #2 = { nounwind }
 ; ; SPIR-V
 ; ; Version: 1.0
 ; ; Generator: Google spiregg; 0
-; ; Bound: 22
+; ; Bound: 25
 ; ; Schema: 0
 ;                OpCapability Shader
 ;                OpMemoryModel Logical GLSL450
@@ -95,6 +95,10 @@ attributes #2 = { nounwind }
 ;                OpName %type_ByteAddressBuffer "type.ByteAddressBuffer"
 ;                OpName %type_RWByteAddressBuffer "type.RWByteAddressBuffer"
 ;                OpName %main "main"
+;                OpDecorate %3 DescriptorSet 0
+;                OpDecorate %3 Binding 0
+;                OpDecorate %4 DescriptorSet 0
+;                OpDecorate %4 Binding 1
 ;                OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 ;                OpDecorate %_runtimearr_uint ArrayStride 4
 ;                OpMemberDecorate %type_ByteAddressBuffer 0 Offset 0
@@ -105,29 +109,29 @@ attributes #2 = { nounwind }
 ;        %uint = OpTypeInt 32 0
 ;      %uint_0 = OpConstant %uint 0
 ;      %uint_2 = OpConstant %uint 2
-;      %v3uint = OpTypeVector %uint 3
-; %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 ; %_runtimearr_uint = OpTypeRuntimeArray %uint
 ; %type_ByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_ByteAddressBuffer = OpTypePointer Uniform %type_ByteAddressBuffer
 ; %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 ; %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
+;      %v3uint = OpTypeVector %uint 3
+; %_ptr_Input_v3uint = OpTypePointer Input %v3uint
 ;        %void = OpTypeVoid
 ;          %16 = OpTypeFunction %void
 ; %_ptr_Input_uint = OpTypePointer Input %uint
+; %_ptr_Uniform_uint = OpTypePointer Uniform %uint
+;           %3 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
+;           %4 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
 ; %gl_GlobalInvocationID = OpVariable %_ptr_Input_v3uint Input
-;          %11 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
-;          %14 = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
 ;        %main = OpFunction %void None %16
 ;          %17 = OpLabel
 ;          %19 = OpAccessChain %_ptr_Input_uint %gl_GlobalInvocationID %uint_0
 ;          %20 = OpLoad %uint %19
 ;          %21 = OpShiftLeftLogical %uint %20 %uint_2
+;          %23 = OpAccessChain %_ptr_Uniform_uint %3 %uint_0 %21
+;          %24 = OpLoad %uint %23
 ;                OpReturn
 ;                OpFunctionEnd
 ; CHECK-ERRORS:
-; error: Unhandled DXIL opcode: CreateHandle
-; error: Unhandled DXIL opcode: CreateHandle
-; error: Unhandled DXIL opcode: BufferLoad
 ; error: Unhandled LLVM instruction:   %6 = extractvalue %dx.types.ResRet.i32 %5, 0
 ; error: Unhandled DXIL opcode: BufferStore

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -573,7 +573,7 @@ DiagnosticBuilder Translator::emitError(const char (&message)[N],
   std::string str;
   llvm::raw_string_ostream os(str);
   value.print(os);
-  emitError(message) << os.str();
+  return emitError(message) << os.str();
 }
 
 } // namespace dxil2spv

--- a/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
+++ b/tools/clang/tools/dxil2spv/lib/dxil2spv.cpp
@@ -17,6 +17,7 @@
 #include "dxc/Support/ErrorCodes.h"
 #include "dxc/Support/Global.h"
 
+#include "clang/SPIRV/SpirvInstruction.h"
 #include "clang/SPIRV/SpirvType.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
@@ -114,6 +115,10 @@ int Translator::Run() {
   createStageIOVariables(program.GetInputSignature().GetElements(),
                          program.GetOutputSignature().GetElements());
 
+  // Add HLSL resources.
+  createModuleVariables(program.GetSRVs());
+  createModuleVariables(program.GetUAVs());
+
   // Create entry function.
   spirv::SpirvFunction *entryFunction =
       createEntryFunction(program.GetEntryFunction());
@@ -130,10 +135,6 @@ int Translator::Run() {
                                  program.GetNumThreads(2)},
                                 {});
   }
-
-  // Add HLSL resources.
-  createModuleVariables(program.GetSRVs());
-  createModuleVariables(program.GetUAVs());
 
   // Contsruct the SPIR-V module.
   std::vector<uint32_t> m = spvBuilder.takeModuleForDxilToSpv();
@@ -204,8 +205,12 @@ void Translator::createModuleVariables(
     assert(hlslType->isPointerTy());
     llvm::Type *pointeeType =
         cast<llvm::PointerType>(hlslType)->getPointerElementType();
-    spvBuilder.addModuleVar(toSpirvType(pointeeType),
-                            spv::StorageClass::Uniform, false);
+    spirv::SpirvVariable *moduleVar = spvBuilder.addModuleVar(
+        toSpirvType(pointeeType), spv::StorageClass::Uniform, false);
+    spvBuilder.decorateDSetBinding(moduleVar, nextDescriptorSet,
+                                   nextBindingNo++);
+    resourceMap[{static_cast<unsigned>(resource->GetClass()),
+                 resource->GetID()}] = moduleVar;
   }
 }
 
@@ -263,6 +268,12 @@ void Translator::createInstruction(llvm::Instruction &instruction) {
     case hlsl::DXIL::OpCode::ThreadId: {
       createThreadIdInstruction(callInstruction);
     } break;
+    case hlsl::DXIL::OpCode::CreateHandle: {
+      createHandleInstruction(callInstruction);
+    } break;
+    case hlsl::DXIL::OpCode::BufferLoad: {
+      createBufferLoadInstruction(callInstruction);
+    } break;
     default: {
       emitError("Unhandled DXIL opcode: %0")
           << hlsl::OP::GetOpCodeName(dxilOpcode);
@@ -281,10 +292,7 @@ void Translator::createInstruction(llvm::Instruction &instruction) {
   }
   // Unhandled instruction type.
   else {
-    std::string instStr;
-    llvm::raw_string_ostream os(instStr);
-    instruction.print(os);
-    emitError("Unhandled LLVM instruction: %0") << os.str();
+    emitError("Unhandled LLVM instruction: %0", instruction);
   }
 }
 
@@ -344,8 +352,8 @@ void Translator::createStoreOutputInstruction(llvm::CallInst &instruction) {
   spirv::SpirvAccessChain *outputVarPtr =
       spvBuilder.createAccessChain(elemType, outputVar, {index}, {});
   spirv::SpirvInstruction *valueToStore =
-      instructionMap[instruction.getArgOperand(
-          hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx)];
+      getSpirvInstruction(instruction.getArgOperand(
+          hlsl::DXIL::OperandIndex::kStoreOutputValOpIdx));
   spvBuilder.createStore(outputVarPtr, valueToStore, {});
 }
 
@@ -384,15 +392,8 @@ void Translator::createBinaryOpInstruction(llvm::BinaryOperator &instruction) {
   // Shift left instruction.
   case llvm::Instruction::Shl: {
     // Value to be shifted.
-    spirv::SpirvInstruction *val = instructionMap[instruction.getOperand(0)];
-    if (!val) {
-      std::string instStr;
-      llvm::raw_string_ostream os(instStr);
-      instruction.print(os);
-      emitError("Could not find translation of instruction operand 0: %0")
-          << os.str();
-      return;
-    }
+    spirv::SpirvInstruction *val =
+        getSpirvInstruction(instruction.getOperand(0));
 
     // Amount to shift by.
     const spirv::IntegerType *uint32 = spvContext.getUIntType(32);
@@ -410,6 +411,54 @@ void Translator::createBinaryOpInstruction(llvm::BinaryOperator &instruction) {
   }
 
   instructionMap[&instruction] = result;
+}
+
+void Translator::createHandleInstruction(llvm::CallInst &instruction) {
+  unsigned resourceClass =
+      cast<llvm::ConstantInt>(
+          instruction.getArgOperand(
+              hlsl::DXIL::OperandIndex::kCreateHandleResClassOpIdx))
+          ->getLimitedValue();
+  unsigned resourceRangeId =
+      cast<llvm::ConstantInt>(
+          instruction.getArgOperand(
+              hlsl::DXIL::OperandIndex::kCreateHandleResIDOpIdx))
+          ->getLimitedValue();
+  spirv::SpirvVariable *inputVar =
+      resourceMap[{resourceClass, resourceRangeId}];
+  if (!inputVar) {
+    emitError("No resource found corresponding to handle: %0", instruction);
+    return;
+  }
+
+  instructionMap[&instruction] = inputVar;
+}
+
+void Translator::createBufferLoadInstruction(llvm::CallInst &instruction) {
+  // ByteAddressBuffers are represented as a struct with one member that is a
+  // runtime array of unsigned integers. The SPIR-V OpAccessChain instruction is
+  // then used to access that offset, and OpLoad is used to load a 32-bit
+  // unsigned integer.
+  // TODO: Extend this function to work with all buffer types on which it is
+  // used, not just ByteAddressBuffers.
+  llvm::Value *handle = instruction.getArgOperand(
+      hlsl::DXIL::OperandIndex::kBufferLoadHandleOpIdx);
+  spirv::SpirvInstruction *inputVar = getSpirvInstruction(handle);
+
+  // Translate indices into resource buffer to SPIR-V instructions.
+  auto uint32 = spvContext.getUIntType(32);
+  spirv::SpirvConstant *indexIntoStruct =
+      spvBuilder.getConstantInt(uint32, llvm::APInt(32, 0));
+  spirv::SpirvInstruction *indexIntoArray =
+      getSpirvInstruction(instruction.getArgOperand(
+          hlsl::DXIL::OperandIndex::kBufferLoadCoord0OpIdx));
+
+  // Create access chain and load.
+  spirv::SpirvAccessChain *loadPtr = spvBuilder.createAccessChain(
+      uint32, inputVar, {indexIntoStruct, indexIntoArray}, {});
+  spirv::SpirvLoad *loadInstr = spvBuilder.createLoad(uint32, loadPtr, {});
+
+  instructionMap[&instruction] = loadInstr;
 }
 
 bool Translator::spirvToolsValidate(std::vector<uint32_t> *mod,
@@ -500,11 +549,31 @@ const spirv::SpirvType *Translator::toSpirvType(llvm::StructType *structType) {
   return spvContext.getStructType(fields, name);
 }
 
+spirv::SpirvInstruction *
+Translator::getSpirvInstruction(llvm::Value *instruction) {
+  spirv::SpirvInstruction *spirvInstruction = instructionMap[instruction];
+  if (!spirvInstruction) {
+    emitError("Expected SPIR-V instruction not found for DXIL instruction: %0",
+              *instruction);
+    return nullptr;
+  }
+  return spirvInstruction;
+}
+
 template <unsigned N>
 DiagnosticBuilder Translator::emitError(const char (&message)[N]) {
   const auto diagId =
       diagnosticsEngine.getCustomDiagID(DiagnosticsEngine::Error, message);
   return diagnosticsEngine.Report({}, diagId);
+}
+
+template <unsigned N>
+DiagnosticBuilder Translator::emitError(const char (&message)[N],
+                                        llvm::Value &value) {
+  std::string str;
+  llvm::raw_string_ostream os(str);
+  value.print(os);
+  emitError(message) << os.str();
 }
 
 } // namespace dxil2spv


### PR DESCRIPTION
Add support for translating createHandle and bufferLoad DXIL operations
to SPIR-V instructions. The most significant limitation of this current
implementation is the naive translation of descriptor set and binding
numbers, but it is sufficient for simple passthrough shaders.

Some error handling is also simplified with a wrapper function for the
frequently used instructionMap accesses.