### PR TITLE
PIX: Incorrect index for CreateHandleFromBinding (#4382)

### DIFF
--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -96,7 +96,7 @@ llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
     Value *bindingV = resource_helper::getAsConstant(
         binding, HlslOP->GetResourceBindingType(), *DM.GetShaderModel());
 
-    Value *registerIndex = HlslOP->GetU32Const(resourceMetaDataId);
+    Value *registerIndex = HlslOP->GetU32Const(0);
 
     Value *isUniformRes = HlslOP->GetI1Const(0);
 
@@ -146,7 +146,7 @@ llvm::CallInst *CreateUAV(DxilModule &DM, IRBuilder<> &Builder,
 
   SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(Ctx)};
   llvm::StructType *UAVStructTy =
-      llvm::StructType::create(Elements, "class.RWStructuredBuffer");
+      llvm::StructType::create(Elements, "class.PIXRWStructuredBuffer");
 
   std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
 


### PR DESCRIPTION
This mistake was upsetting a certain driver. The UAV being declared is always u0 in space -2. Also changed the name of one struct type to make it more obvious what PIX had added.

authored-by: Jeff Noyle <jeffno@ntdev.microsoft.com>