### PR TITLE
Od fixes for April 2022

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -169,6 +169,10 @@ namespace dxilutil {
     return mdv_users_begin(V) == mdv_users_end(V);
   }
 
+  /// Finds all allocas that only have stores and delete them.
+  /// These allocas hold on to values that do not contribute to the
+  /// shader's results.
+  bool DeleteDeadAllocas(llvm::Function &F);
 }
 
 }

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -65,6 +65,7 @@ private:
 
   Value *ProcessAndSimplify_PHI(Instruction *I, DominatorTree *DT);
   Value *ProcessAndSimplify_Br(Instruction *I, DominatorTree *DT);
+  Value *ProcessAndSimplify_Switch(Instruction *I, DominatorTree *DT);
   Value *ProcessAndSimplify_Load(Instruction *LI, DominatorTree *DT);
   Value *SimplifyAndCacheResult(Instruction *I, DominatorTree *DT);
 

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -994,5 +994,86 @@ Value *TryReplaceBaseCastWithGep(Value *V) {
   return nullptr;
 }
 
+struct AllocaDeleter {
+  SmallVector<Value *, 10> WorkList;
+  std::unordered_set<Value *> Seen;
+
+  void Add(Value *V) {
+    if (!Seen.count(V)) {
+      Seen.insert(V);
+      WorkList.push_back(V);
+    }
+  }
+
+  bool TryDeleteUnusedAlloca(AllocaInst *AI) {
+    Seen.clear();
+    WorkList.clear();
+
+    Add(AI);
+    while (WorkList.size()) {
+      Value *V = WorkList.pop_back_val();
+      // Keep adding users if we encounter one of these.
+      // None of them imply the alloca is being read.
+      if (isa<GEPOperator>(V) ||
+          isa<BitCastOperator>(V) ||
+          isa<AllocaInst>(V) ||
+          isa<StoreInst>(V))
+      {
+        for (User *U : V->users())
+          Add(U);
+      }
+      // If it's anything else, we'll assume it's reading the
+      // alloca. Give up.
+      else {
+        return false;
+      }
+    }
+
+    if (!Seen.size())
+      return false;
+
+    // Delete all the instructions associated with the
+    // alloca.
+    for (Value *V : Seen) {
+      Instruction *I = dyn_cast<Instruction>(V);
+      if (I) {
+        I->dropAllReferences();
+      }
+    }
+    for (Value *V : Seen) {
+      Instruction *I = dyn_cast<Instruction>(V);
+      if (I) {
+        I->eraseFromParent();
+      }
+    }
+
+    return true;
+  }
+};
+
+bool DeleteDeadAllocas(llvm::Function &F) {
+  if (F.empty())
+    return false;
+
+  AllocaDeleter Deleter;
+  BasicBlock &Entry = *F.begin();
+  bool Changed = false;
+
+  while (1) {
+    bool LocalChanged = false;
+    for (auto it = Entry.begin(), end = Entry.end(); it != end;) {
+      AllocaInst *AI = dyn_cast<AllocaInst>(&*(it++));
+      if (!AI)
+        continue;
+      LocalChanged |= Deleter.TryDeleteUnusedAlloca(AI);
+    }
+    Changed |= LocalChanged;
+    if (!LocalChanged)
+      break;
+  }
+
+  return Changed;
+}
+
 }
 }

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -375,9 +375,9 @@ void PassManagerBuilder::populateModulePassManager(
     if (!HLSLHighLevel) {
       MPM.add(createDxilConvergentClearPass());
       MPM.add(createDxilSimpleGVNEliminateRegionPass());
-      MPM.add(createDxilEraseDeadRegionPass());
       MPM.add(createDeadCodeEliminationPass());
       MPM.add(createDxilRemoveDeadBlocksPass());
+      MPM.add(createDxilEraseDeadRegionPass());
       MPM.add(createDxilNoOptSimplifyInstructionsPass());
       MPM.add(createGlobalOptimizerPass());
       MPM.add(createMultiDimArrayToOneDimArrayPass());

--- a/lib/Transforms/Scalar/DxilEraseDeadRegion.cpp
+++ b/lib/Transforms/Scalar/DxilEraseDeadRegion.cpp
@@ -34,6 +34,7 @@
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilMetadataHelper.h"
 #include "dxc/HLSL/DxilNoops.h"
+#include "dxc/DXIL/DxilUtil.h"
 
 #include <unordered_map>
 #include <unordered_set>
@@ -358,6 +359,7 @@ struct DxilEraseDeadRegion : public FunctionPass {
     while (1) {
       bool LocalChanged = false;
 
+      LocalChanged |= hlsl::dxilutil::DeleteDeadAllocas(F);
       LocalChanged |= this->TryRemoveSimpleDeadLoops(LI);
 
       for (Function::iterator It = F.begin(), E = F.end(); It != E; It++) {

--- a/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
+++ b/lib/Transforms/Scalar/DxilRemoveDeadBlocks.cpp
@@ -44,94 +44,6 @@ static void RemoveIncomingValueFrom(BasicBlock *SuccBB, BasicBlock *BB) {
   }
 }
 
-namespace {
-
-struct AllocaDeleter {
-  SmallVector<Value *, 10> WorkList;
-  std::unordered_set<Value *> Seen;
-
-  void Add(Value *V) {
-    if (!Seen.count(V)) {
-      Seen.insert(V);
-      WorkList.push_back(V);
-    }
-  }
-
-  bool TryDeleteUnusedAlloca(AllocaInst *AI) {
-    Seen.clear();
-    WorkList.clear();
-
-    Add(AI);
-    while (WorkList.size()) {
-      Value *V = WorkList.pop_back_val();
-      // Keep adding users if we encounter one of these.
-      // None of them imply the alloca is being read.
-      if (isa<GEPOperator>(V) ||
-          isa<BitCastOperator>(V) ||
-          isa<AllocaInst>(V) ||
-          isa<StoreInst>(V))
-      {
-        for (User *U : V->users())
-          Add(U);
-      }
-      // If it's anything else, we'll assume it's reading the
-      // alloca. Give up.
-      else {
-        return false;
-      }
-    }
-
-    if (!Seen.size())
-      return false;
-
-    // Delete all the instructions associated with the
-    // alloca.
-    for (Value *V : Seen) {
-      Instruction *I = dyn_cast<Instruction>(V);
-      if (I) {
-        I->dropAllReferences();
-      }
-    }
-    for (Value *V : Seen) {
-      Instruction *I = dyn_cast<Instruction>(V);
-      if (I) {
-        I->eraseFromParent();
-      }
-    }
-
-    return true;
-  }
-};
-
-}
-
-// Finds all allocas that only have stores and delete them.
-// These allocas hold on to values that do not contribute to the
-// shader's results.
-static bool DeleteDeadAllocas(Function &F) {
-  if (F.empty())
-    return false;
-
-  AllocaDeleter Deleter;
-  BasicBlock &Entry = *F.begin();
-  bool Changed = false;
-
-  while (1) {
-    bool LocalChanged = false;
-    for (auto it = Entry.begin(), end = Entry.end(); it != end;) {
-      AllocaInst *AI = dyn_cast<AllocaInst>(&*(it++));
-      if (!AI)
-        continue;
-      LocalChanged |= Deleter.TryDeleteUnusedAlloca(AI);
-    }
-    Changed |= LocalChanged;
-    if (!LocalChanged)
-      break;
-  }
-
-  return Changed;
-}
-
 struct DeadBlockDeleter {
   bool Run(Function &F, DxilValueCache *DVC);
 
@@ -335,9 +247,14 @@ struct ValueDeleter {
       WorkList.pop_back();
       Instruction *I = dyn_cast<Instruction>(V);
       if (I) {
-        for (Value * op : I->operands()) {
-          if (Instruction *OpI = dyn_cast<Instruction>(op))
-            Add(OpI);
+        for (unsigned i = 0; i < I->getNumOperands(); i++) {
+          Value *op = I->getOperand(i);
+          if (Instruction *OpI = dyn_cast<Instruction>(op)) {
+            if (Constant *C = DVC->GetConstValue(OpI))
+              I->setOperand(i, C);
+            else
+              Add(OpI);
+          }
         }
       }
     }
@@ -349,14 +266,15 @@ struct ValueDeleter {
         Instruction *I = &*(it++);
         if (isa<DbgInfoIntrinsic>(I)) continue;
         if (IsDxBreak(I)) continue;
-        if (!Seen.count(I)) {
-          if (!I->user_empty())
-            I->replaceAllUsesWith(UndefValue::get(I->getType()));
+        // This here is mostly for correcting dbg.value
+        if (Constant *C = DVC->GetConstValue(I)) {
+          I->replaceAllUsesWith(C);
           I->eraseFromParent();
           Changed = true;
         }
-        else if (Constant *C = DVC->GetConstValue(I)) {
-          I->replaceAllUsesWith(C);
+        else if (!Seen.count(I)) {
+          if (!I->user_empty())
+            I->replaceAllUsesWith(UndefValue::get(I->getType()));
           I->eraseFromParent();
           Changed = true;
         }
@@ -405,7 +323,7 @@ struct DxilRemoveDeadBlocks : public FunctionPass {
   bool runOnFunction(Function &F) override {
     DxilValueCache *DVC = &getAnalysis<DxilValueCache>();
     bool Changed = false;
-    Changed |= DeleteDeadAllocas(F);
+    Changed |= hlsl::dxilutil::DeleteDeadAllocas(F);
     Changed |= DeleteDeadBlocks(F, DVC);
     Changed |= DeleteNonContributingValues(F, DVC);
     return Changed;

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/out_args.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/out_args.hlsl
@@ -1,15 +1,10 @@
 // RUN: %dxc -E main -T ps_6_0 %s -Zi -O0 | FileCheck %s
 
 // CHECK-NOT: DW_OP_deref
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg0" !DIExpression(DW_OP_bit_piece, 0, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg0" !DIExpression(DW_OP_bit_piece, 32, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg0" !DIExpression(DW_OP_bit_piece, 64, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg1" !DIExpression(DW_OP_bit_piece, 0, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg1" !DIExpression(DW_OP_bit_piece, 32, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg1" !DIExpression(DW_OP_bit_piece, 64, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 0, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 32, 32)
-// CHECK-DAG: dbg.value(metadata float {{.+}}, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression(DW_OP_bit_piece, 64, 32)
+
+// CHECK-DAG: call void @llvm.dbg.value(metadata <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg1" !DIExpression() func:"bar"
+// CHECK-DAG: call void @llvm.dbg.value(metadata <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"arg0" !DIExpression() func:"foo"
+// CHECK-DAG: call void @llvm.dbg.value(metadata <3 x float> <float 1.000000e+00, float 2.000000e+00, float 3.000000e+00>, i64 0, metadata !{{[0-9]+}}, metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"output" !DIExpression() func:"main"
 
 void foo(out float3 arg0) {
   arg0 = float3(1,2,3); // @BREAK

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_constant_dce.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_constant_dce.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// This test verifies the fix for a deficiency in RemoveDeadBlocks where:
+//
+// - Value 'ret' that can be reduced to constant by DxilValueCache is removed
+// - It held on uses for a PHI 'val', but 'val' was not removed
+// - 'val' is not used, but also not DCE'ed until after DeleteDeadRegion is run
+// - DeleteDeadRegion cannot delete 'if (foo)' because 'val' still exists.
+
+// CHECK: @main
+// CHECK-NOT: phi
+
+cbuffer cb : register(b0) {
+  float foo;
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  float val = 0;
+  if (foo)
+    val = 1;
+
+  float zero = 0;
+  float ret = val * zero;
+
+  return ret;
+}

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// CBuffer member 'foo' is used for a condition to decide the value of 'cond'.
+// But 'cond' is eventually set to 0, under a compile time known condition 'my_cond'.
+//
+// The way the Od dead code removal passes were arranged was unable to clean up this pattern.
+// EraseDeadRegion would run first, but unable to delete 'if (foo)' because of outflowing
+// value 'cond' still being used.
+//
+// If we run RemoveDeadBlocks first, however, it would delete the branch `if (!my_cond)` and
+// relieve the use of 'cond', allowing EraseDeadRegion to delete `if (foo)`.
+//
+
+// CHECK: @main
+// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(
+
+cbuffer cb : register(b0) {
+  float foo;
+  float bar;
+}
+
+[RootSignature("")]
+float main(float i : I) : SV_Target {
+
+  float cond = 0;
+  if (foo) {
+    cond = sin(i);
+  }
+
+  float my_cond = 0;
+  if (!my_cond) {
+    cond = 0;
+  }
+
+  return cond ? 10 : 20;
+}

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/switch_unroll_bound.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/switch_unroll_bound.hlsl
@@ -1,0 +1,44 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// When switch's cases have more control flow than just one simple block,
+// DVC couldn't deduce the outflowing values.
+
+// CHECK: @main
+// CHECK-NOT: switch
+
+uint get(uint p, uint off) {
+  if (p & 1) {
+    return p << 2;
+  }
+  else {
+    return p + off;
+  }
+}
+
+uint get_bound(uint param) {
+  switch (param) {
+    case 0:  return get(param, 1);
+    case 1:  return get(param, 2);
+    case 2:  return get(param, 3);
+    case 3:  return get(param, 4);
+    case 4:  return get(param, 5);
+    case 10: return get(param, 6);
+  }
+  return 0;
+}
+
+Texture1D<float> t0 : register(t0);
+
+[RootSignature("DescriptorTable(SRV(t0))")]
+float main() : SV_Target {
+  uint param = 10;
+  uint bound = get_bound(param);
+
+  float ret = 0;
+  [unroll]
+  for (uint i = 0; i < bound; i++) {
+    ret += t0[i];
+  }
+
+  return ret;
+}

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -581,6 +581,7 @@ void main( uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint GI : S
                 else
                 {
                     int ring = GetRingFromIndexStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, index_id - num.z);
+                    DebugOutput[DTid.x+1] = int4(ring,0,0,0); // HLSL Change: Use that output so the value defines it doens't get deleted.
 
                     int tn = TotalNumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, ring - 1) * 3;
                     int n = NumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w - 2 * ring);


### PR DESCRIPTION
- Reordered passes so now ExilEraseDeadRegions happens AFTER DxilRemoveDeadBlocks. ExilEraseDeadRegions may depend on simplifications made by DxilRemoveDeadBlocks more than the reverse is true. The only thing that DxilRemoveDeadBlocks needed from ExilEraseDeadRegions was removing dead allocas that only had stores but no loads. This change also factors it out to a helper that both passes can call.
- Fixed the issue that DxilValueCache wasn't able to handle switch statements where each case had more than on basic block. This change adds reachability analysis for it similar to normal branches.
- Fixed the issue that DxilRemoveDeadBlocks removes all instructions that could be replaced with constants, but did not perform DCE on those instructions' operands, which are not guaranteed to also be constants. For example, `fmul %value, 0`. Those instructions could hold on to PHIs and prevent ExilEraseDeadRegions from deleting certain regions.