### PR TITLE
Moved DxilEraseDeadRegions to after DxilRemoveDeadBlocks

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -169,6 +169,10 @@ namespace dxilutil {
     return mdv_users_begin(V) == mdv_users_end(V);
   }
 
+  /// Finds all allocas that only have stores and delete them.
+  /// These allocas hold on to values that do not contribute to the
+  /// shader's results.
+  bool DeleteDeadAllocas(llvm::Function &F);
 }
 
 }

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -994,5 +994,86 @@ Value *TryReplaceBaseCastWithGep(Value *V) {
   return nullptr;
 }
 
+struct AllocaDeleter {
+  SmallVector<Value *, 10> WorkList;
+  std::unordered_set<Value *> Seen;
+
+  void Add(Value *V) {
+    if (!Seen.count(V)) {
+      Seen.insert(V);
+      WorkList.push_back(V);
+    }
+  }
+
+  bool TryDeleteUnusedAlloca(AllocaInst *AI) {
+    Seen.clear();
+    WorkList.clear();
+
+    Add(AI);
+    while (WorkList.size()) {
+      Value *V = WorkList.pop_back_val();
+      // Keep adding users if we encounter one of these.
+      // None of them imply the alloca is being read.
+      if (isa<GEPOperator>(V) ||
+          isa<BitCastOperator>(V) ||
+          isa<AllocaInst>(V) ||
+          isa<StoreInst>(V))
+      {
+        for (User *U : V->users())
+          Add(U);
+      }
+      // If it's anything else, we'll assume it's reading the
+      // alloca. Give up.
+      else {
+        return false;
+      }
+    }
+
+    if (!Seen.size())
+      return false;
+
+    // Delete all the instructions associated with the
+    // alloca.
+    for (Value *V : Seen) {
+      Instruction *I = dyn_cast<Instruction>(V);
+      if (I) {
+        I->dropAllReferences();
+      }
+    }
+    for (Value *V : Seen) {
+      Instruction *I = dyn_cast<Instruction>(V);
+      if (I) {
+        I->eraseFromParent();
+      }
+    }
+
+    return true;
+  }
+};
+
+bool DeleteDeadAllocas(llvm::Function &F) {
+  if (F.empty())
+    return false;
+
+  AllocaDeleter Deleter;
+  BasicBlock &Entry = *F.begin();
+  bool Changed = false;
+
+  while (1) {
+    bool LocalChanged = false;
+    for (auto it = Entry.begin(), end = Entry.end(); it != end;) {
+      AllocaInst *AI = dyn_cast<AllocaInst>(&*(it++));
+      if (!AI)
+        continue;
+      LocalChanged |= Deleter.TryDeleteUnusedAlloca(AI);
+    }
+    Changed |= LocalChanged;
+    if (!LocalChanged)
+      break;
+  }
+
+  return Changed;
+}
+
 }
 }

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -375,9 +375,9 @@ void PassManagerBuilder::populateModulePassManager(
     if (!HLSLHighLevel) {
       MPM.add(createDxilConvergentClearPass());
       MPM.add(createDxilSimpleGVNEliminateRegionPass());
-      MPM.add(createDxilEraseDeadRegionPass());
       MPM.add(createDeadCodeEliminationPass());
       MPM.add(createDxilRemoveDeadBlocksPass());
+      MPM.add(createDxilEraseDeadRegionPass());
       MPM.add(createDxilNoOptSimplifyInstructionsPass());
       MPM.add(createGlobalOptimizerPass());
       MPM.add(createMultiDimArrayToOneDimArrayPass());

--- a/lib/Transforms/Scalar/DxilEraseDeadRegion.cpp
+++ b/lib/Transforms/Scalar/DxilEraseDeadRegion.cpp
@@ -34,6 +34,7 @@
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilMetadataHelper.h"
 #include "dxc/HLSL/DxilNoops.h"
+#include "dxc/DXIL/DxilUtil.h"
 
 #include <unordered_map>
 #include <unordered_set>
@@ -358,6 +359,7 @@ struct DxilEraseDeadRegion : public FunctionPass {
     while (1) {
       bool LocalChanged = false;
 
+      LocalChanged |= hlsl::dxilutil::DeleteDeadAllocas(F);
       LocalChanged |= this->TryRemoveSimpleDeadLoops(LI);
 
       for (Function::iterator It = F.begin(), E = F.end(); It != E; It++) {

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
@@ -12,7 +12,7 @@
 //
 
 // CHECK: @main
-// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(
+// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoad.f32(
 
 cbuffer cb : register(b0) {
   float foo;

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// CBuffer member 'foo' is used for a condition to decide the value of 'cond'.
+// But 'cond' is eventually set to 0, under a compile time known condition 'my_cond'.
+//
+// The way the Od dead code removal passes were arranged was unable to clean up this pattern.
+// EraseDeadRegion would run first, but unable to delete 'if (foo)' because of outflowing
+// value 'cond' still being used.
+//
+// If we run RemoveDeadBlocks first, however, it would delete the branch `if (!my_cond)` and
+// relieve the use of 'cond', allowing EraseDeadRegion to delete `if (foo)`.
+//
+
+// CHECK: @main
+// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoadLegacy.f32(
+
+cbuffer cb : register(b0) {
+  float foo;
+  float bar;
+}
+
+[RootSignature("")]
+float main(float i : I) : SV_Target {
+
+  float cond = 0;
+  if (foo) {
+    cond = sin(i);
+  }
+
+  float my_cond = 0;
+  if (!my_cond) {
+    cond = 0;
+  }
+
+  return cond ? 10 : 20;
+}

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_region_after_remove_dead_blocks.hlsl
@@ -12,7 +12,7 @@
 //
 
 // CHECK: @main
-// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoad.f32(
+// CHECK-NOT: call %dx.types.CBufRet.f32 @dx.op.cbufferLoad
 
 cbuffer cb : register(b0) {
   float foo;


### PR DESCRIPTION
Reordered passes so now ExilEraseDeadRegions happens AFTER DxilRemoveDeadBlocks.

ExilEraseDeadRegions may depend on simplifications made by DxilRemoveDeadBlocks more than the reverse. The only thing that DxilRemoveDeadBlocks needed from ExilEraseDeadRegions was removing dead allocas that only had stores but no loads. This change also factors it out to a helper that both passes can call.