### PR TITLE
Taught DxilValueCache to handle complex switch statements.

### DIFF
--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -55,9 +55,7 @@ private:
   WeakValueMap ValueMap;
   bool (*ShouldSkipCallback)(Value *V) = nullptr;
 
-  void MarkAlwaysReachable(BasicBlock *BB);
   void MarkUnreachable(BasicBlock *BB);
-  bool IsAlwaysReachable_(BasicBlock *BB);
   bool IsUnreachable_(BasicBlock *BB);
   bool MayBranchTo(BasicBlock *A, BasicBlock *B);
   Value *TryGetCachedValue(Value *V);
@@ -81,7 +79,6 @@ public:
   ConstantInt *GetConstInt(Value *V, DominatorTree *DT = nullptr);
   void ResetUnknowns() { ValueMap.ResetUnknowns(); }
   void ResetAll() { ValueMap.ResetAll(); }
-  bool IsAlwaysReachable(BasicBlock *BB, DominatorTree *DT=nullptr);
   bool IsUnreachable(BasicBlock *BB, DominatorTree *DT=nullptr);
   void SetShouldSkipCallback(bool (*Callback)(Value *V)) { ShouldSkipCallback = Callback; };
 };

--- a/include/llvm/Analysis/DxilValueCache.h
+++ b/include/llvm/Analysis/DxilValueCache.h
@@ -65,6 +65,7 @@ private:
 
   Value *ProcessAndSimplify_PHI(Instruction *I, DominatorTree *DT);
   Value *ProcessAndSimplify_Br(Instruction *I, DominatorTree *DT);
+  Value *ProcessAndSimplify_Switch(Instruction *I, DominatorTree *DT);
   Value *ProcessAndSimplify_Load(Instruction *LI, DominatorTree *DT);
   Value *SimplifyAndCacheResult(Instruction *I, DominatorTree *DT);
 

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -211,7 +211,8 @@ Value *DxilValueCache::ProcessAndSimplify_Switch(Instruction *I, DominatorTree *
 
     BasicBlock *DefaultSucc = Sw->getDefaultDest();
     if (FoundCase) {
-      MarkUnreachable(DefaultSucc);
+      if (DefaultSucc->getSinglePredecessor())
+        MarkUnreachable(DefaultSucc);
     }
     else {
       if (IsAlwaysReachable_(BB))

--- a/lib/Analysis/DxilValueCache.cpp
+++ b/lib/Analysis/DxilValueCache.cpp
@@ -180,7 +180,7 @@ Value *DxilValueCache::ProcessAndSimplify_Switch(Instruction *I, DominatorTree *
   if (IsUnreachable_(BB)) {
     for (unsigned i = 0; i < Sw->getNumSuccessors(); i++) {
       BasicBlock *Succ = Sw->getSuccessor(i);
-      if (Succ->getSinglePredecessor())
+      if (Succ->getUniquePredecessor())
         MarkUnreachable(Succ);
     }
   }
@@ -200,7 +200,7 @@ Value *DxilValueCache::ProcessAndSimplify_Switch(Instruction *I, DominatorTree *
     if (ConstDest) {
       for (unsigned i = 0; i < Sw->getNumSuccessors(); i++) {
         BasicBlock *Succ = Sw->getSuccessor(i);
-        if (Succ != ConstDest && Succ->getSinglePredecessor()) {
+        if (Succ != ConstDest && Succ->getUniquePredecessor()) {
           MarkUnreachable(Succ);
         }
       }

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/switch_unroll_bound.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/switch_unroll_bound.hlsl
@@ -1,0 +1,44 @@
+// RUN: %dxc %s -T ps_6_0 -Od | FileCheck %s
+
+// When switch's cases have more control flow than just one simple block,
+// DVC couldn't deduce the outflowing values.
+
+// CHECK: @main
+// CHECK-NOT: switch
+
+uint get(uint p, uint off) {
+  if (p & 1) {
+    return p << 2;
+  }
+  else {
+    return p + off;
+  }
+}
+
+uint get_bound(uint param) {
+  switch (param) {
+    case 0:  return get(param, 1);
+    case 1:  return get(param, 2);
+    case 2:  return get(param, 3);
+    case 3:  return get(param, 4);
+    case 4:  return get(param, 5);
+    case 10: return get(param, 6);
+  }
+  return 0;
+}
+
+Texture1D<float> t0 : register(t0);
+
+[RootSignature("DescriptorTable(SRV(t0))")]
+float main() : SV_Target {
+  uint param = 10;
+  uint bound = get_bound(param);
+
+  float ret = 0;
+  [unroll]
+  for (uint i = 0; i < bound; i++) {
+    ret += t0[i];
+  }
+
+  return ret;
+}

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -581,6 +581,7 @@ void main( uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint GI : S
                 else
                 {
                     int ring = GetRingFromIndexStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, index_id - num.z);
+                    DebugOutput[DTid.x+1] = int4(ring,0,0,0); // HLSL Change: Use that output so the value defines it doens't get deleted.
 
                     int tn = TotalNumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, ring - 1) * 3;
                     int n = NumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w - 2 * ring);

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -581,7 +581,6 @@ void main( uint3 DTid : SV_DispatchThreadID, uint3 Gid : SV_GroupID, uint GI : S
                 else
                 {
                     int ring = GetRingFromIndexStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, index_id - num.z);
-                    DebugOutput[DTid.x+1] = int4(ring,0,0,0); // HLSL Change: Use that output so the value defines it doens't get deleted.
 
                     int tn = TotalNumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w, ring - 1) * 3;
                     int n = NumStitchRegular(true, DIAGONALS_MIRRORED, processedTessFactors.numPointsForOutsideInside.w - 2 * ring);


### PR DESCRIPTION
- Taught DxilValueCache to handle switch statements where each case has more than just a single block.
- Fixed `DxilValueCache::ResetUnknowns` just setting value association to nullptr, which was entirely incorrect. Now it correctly deletes the value association that have been marked as unknown.
- Deleted the idea of 'AlwaysReachable' from DxilValueCache, which is unused, ill-defined, and potentially dangerous.
- Improved the dump function for 'DxilValueCache' for better debugging.