### PR TITLE
Handle UDT ptr collisions in FixOverloadNames

### DIFF
--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -1050,7 +1050,7 @@ void OP::FixOverloadNames() {
       CallInst *CI = cast<CallInst>(*F.user_begin());
       DXIL::OpCode opCode = OP::GetDxilOpFuncCallInst(CI);
       llvm::Type *Ty = OP::GetOverloadType(opCode, &F);
-      if (isa<StructType>(Ty)) {
+      if (isa<StructType>(Ty) || isa<PointerType>(Ty)) {
         std::string funcName;
         if (OP::ConstructOverloadName(Ty, opCode, funcName).compare(F.getName()) != 0) {
           F.setName(funcName);

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/link_multi_traceray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/link_multi_traceray.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -T lib_6_6 -D ENTRY=MyRaygen0 -D TYPE=float4 -Fo lib0 %s | FileCheck %s -check-prefix=LIB0
+// RUN: %dxc -T lib_6_6 -D ENTRY=MyRaygen1 -D TYPE=int3 -Fo lib1 %s | FileCheck %s -check-prefix=LIB1
+// RUN: %dxl -T lib_6_6 lib0;lib1 %s  | FileCheck %s -check-prefixes=CHKLINK
+
+// Ensures that colliding RayPayload structure which is different causes intrinsics to be renamed appropriately
+
+// LIB0: %struct.RayPayload = type { <4 x float> }
+// LIB0: define void {{.*}}MyRaygen0
+
+// LIB1: %struct.RayPayload = type { <3 x i32> }
+// LIB1: define void {{.*}}MyRaygen1
+
+// CHKLINK-DAG: %struct.RayPayload = type
+// CHKLINK-DAG: %struct.RayPayload.1 = type
+// CHKLINK-DAG: declare void @dx.op.traceRay.struct.RayPayload(i32, %dx.types.Handle, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, %struct.RayPayload*)
+// CHKLINK-DAG: declare void @dx.op.traceRay.struct.RayPayload.1(i32, %dx.types.Handle, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, %struct.RayPayload.1*)
+
+RaytracingAccelerationStructure scene : register(t0);
+
+struct RayPayload
+{
+    TYPE color;
+};
+
+[shader("raygeneration")]
+void ENTRY()
+{
+    RayDesc ray = {{0,0,0}, {0,0,1}, 0.05, 1000.0};
+    RayPayload pld;
+    TraceRay(scene, 0 /*rayFlags*/, 0xFF /*rayMask*/, 0 /*sbtRecordOffset*/, 1 /*sbtRecordStride*/, 0 /*missIndex*/, ray, pld);
+}


### PR DESCRIPTION
FixOverloadNames renames intrinsics to match renamed overload types,
which happen as a result of loading modules with conflicting types into
the same llvm context.  A conflicting type would be one that has the same
name but is a different type.

UDT arguments are always pointer types, so when the intrinsic overload is
based on a UDT argument, the type retrieved by GetOverloadType will be a
pointer.  The code did not handle this case, skipping the overload name fix.

This change adds the check for pointer type so UDT overloads will be fixed.

The test links two libraries with a conflicting UDT by the same name, used
in a TraceRay call.  This previously crashed during bitcode writing because
of invalid IR.