### PR TITLE
Dedup semantic names in IO signature parts for valver 1.7

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -119,6 +119,7 @@ private:
   FileRunCommandResult RunDxc(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxv(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunOpt(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
+  FileRunCommandResult RunListParts(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunD3DReflect(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunDxr(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);
   FileRunCommandResult RunLink(dxc::DxcDllSupport &DllSupport, const FileRunCommandResult *Prior);

--- a/tools/clang/test/HLSLFileCheck/hlsl/signature/sig-dedup.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/signature/sig-dedup.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxilver 1.4 | %dxc -E main -T ps_6_0 -validator-version 1.4 %s | %listparts | FileCheck %s -check-prefix=NODEDUP
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -validator-version 1.7 %s | %listparts | FileCheck %s -check-prefix=DEDUP
+
+// NODEDUP: #1 - ISG1 (124 bytes)
+// DEDUP: #1 - ISG1 (116 bytes)
+
+float4 main(float4 f0 : TEXCOORD0, uint2 u1 : U1, float2 f2 : TEXCOORD2) : SV_Target
+{
+	return f0 + (u1 * f2).xyxy;
+}


### PR DESCRIPTION
Create new `NameOffsetMap` that uses `StringRef` to prevent identical strings from being duplicated. Old behavior is maintained when earlier validator version set by using a `*_nodedup` map that continues to use a pointer to allow duplicates as previous validators did.

Fixes #3844 