### PR TITLE
Fix Writable MSAA ExecutionTest device checks

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3720,15 +3720,19 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
   if (!CreateDevice(&pDevice, sm))
       return;
 
-  if (DoesDeviceSupportAdvancedTexOps(pDevice)) {
+#ifndef WRITEMSAA_FALLBACK
+  if (!DoesDeviceSupportAdvancedTexOps(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Advanced Texture Operations.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
   }
 
-  if (DoesDeviceSupportWritableMSAA(pDevice)) {
+  if (!DoesDeviceSupportWritableMSAA(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Writable MSAA.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
   }
+#endif
 
   static const char pWriteShader[] =
     "#define SAMPLES 4\n"


### PR DESCRIPTION
Writable MSAA ExecutionTest was setting TestResults::Skipped for devices
that have the necessary support and continuing to run the test.

Follow the style of the RawGather ExecutionTest.