### PR TITLE
[SM6.7][WritableMSAA] Front-end and test fixes

### DIFF
--- a/lib/DXIL/DxilResourceProperties.cpp
+++ b/lib/DXIL/DxilResourceProperties.cpp
@@ -173,6 +173,7 @@ DxilResourceProperties loadPropsFromResourceBase(const DxilResourceBase *Res) {
       Type *Ty = Res.GetRetType();
       RP.Typed.CompCount = dxilutil::GetResourceComponentCount(Ty);
       RP.Typed.CompType = (uint8_t)Res.GetCompType().GetKind();
+      RP.Typed.SampleCount = (uint8_t)Res.GetSampleCount();
       break;
     }
   };

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/props_ms.hlsl
@@ -1,12 +1,12 @@
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1          | FileCheck %s -DELTY=F32   -DPROP1=265
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,0  | FileCheck %s -DELTY=F32   -DPROP1=265
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,8  | FileCheck %s -DELTY=F32   -DPROP1=265
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1 -DSCALAR=1 -DSC=,8  | FileCheck %s -DELTY=F32   -DPROP1=524553
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=1                     | FileCheck %s -DELTY=F32   -DPROP1=265
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=2                     | FileCheck %s -DELTY=2xF32 -DPROP1=521
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DCC=3                     | FileCheck %s -DELTY=3xF32 -DPROP1=777
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float                            | FileCheck %s -DELTY=4xF32 -DPROP1=1033
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,0                    | FileCheck %s -DELTY=4xF32 -DPROP1=1033
-// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,8                    | FileCheck %s -DELTY=4xF32 -DPROP1=1033
+// RUN: %dxc -E main -T ps_6_6 %s -DCT=float -DSC=,8                    | FileCheck %s -DELTY=4xF32 -DPROP1=525321
 
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=int                              | FileCheck %s -DELTY=4xI32 -DPROP1=1028
 // RUN: %dxc -E main -T ps_6_6 %s -DCT=uint                             | FileCheck %s -DELTY=4xU32 -DPROP1=1029

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -935,31 +935,35 @@ public:
       nullptr,
       IID_PPV_ARGS(&pResource)));
 
-    VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
-      &uploadHeapProperties,
-      D3D12_HEAP_FLAG_NONE,
-      &uploadBufferDesc,
-      D3D12_RESOURCE_STATE_GENERIC_READ,
-      nullptr,
-      IID_PPV_ARGS(&pUploadResource)));
+    if (ppUploadResource)
+      VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
+        &uploadHeapProperties,
+        D3D12_HEAP_FLAG_NONE,
+        &uploadBufferDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr,
+        IID_PPV_ARGS(&pUploadResource)));
 
     if (ppReadBuffer)
       VERIFY_SUCCEEDED(pDevice->CreateCommittedResource(
         &readHeap, D3D12_HEAP_FLAG_NONE, &readDesc,
         D3D12_RESOURCE_STATE_COPY_DEST, nullptr, IID_PPV_ARGS(&pReadBuffer)));
 
-    transferData.pData = values;
-    transferData.RowPitch = (LONG_PTR)(valueSizeInBytes/resDesc.Height);
-    transferData.SlicePitch = (LONG_PTR)valueSizeInBytes;
+    if (ppUploadResource) {
+      transferData.pData = values;
+      transferData.RowPitch = (LONG_PTR)(valueSizeInBytes/resDesc.Height);
+      transferData.SlicePitch = (LONG_PTR)valueSizeInBytes;
 
-    UpdateSubresources<1>(pCommandList, pResource.p, pUploadResource.p, 0, 0, 1, &transferData);
-    if (resDesc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
-      RecordTransitionBarrier(pCommandList, pResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    else
-      RecordTransitionBarrier(pCommandList, pResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COMMON);
+      UpdateSubresources<1>(pCommandList, pResource.p, pUploadResource.p, 0, 0, 1, &transferData);
+      if (resDesc.Flags & D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS)
+        RecordTransitionBarrier(pCommandList, pResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+      else
+        RecordTransitionBarrier(pCommandList, pResource, D3D12_RESOURCE_STATE_COPY_DEST, D3D12_RESOURCE_STATE_COMMON);
+    }
 
     *ppResource = pResource.Detach();
-    *ppUploadResource = pUploadResource.Detach();
+    if (ppUploadResource)
+      *ppUploadResource = pUploadResource.Detach();
     if (ppReadBuffer)
       *ppReadBuffer = pReadBuffer.Detach();
   }
@@ -3722,12 +3726,12 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
   if (!CreateDevice(&pDevice, sm))
       return;
 
-  if (DoesDeviceSupportAdvancedTexOps(pDevice)) {
+  if (!DoesDeviceSupportAdvancedTexOps(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Advanced Texture Operations.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
   }
 
-  if (DoesDeviceSupportWritableMSAA(pDevice)) {
+  if (!DoesDeviceSupportWritableMSAA(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Writable MSAA.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
   }
@@ -3826,7 +3830,6 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
 
   // Set up texture Resource.
   CComPtr<ID3D12Resource> pUavResource;
-  CComPtr<ID3D12Resource> pUploadResource;
   float values[valueSize];
   memset(values, 0xc, valueSizeInBytes);
 
@@ -3838,10 +3841,10 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
 #endif
 
   D3D12_RESOURCE_DESC tex2dDesc = CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R32_FLOAT,
-                                   NumThreadsX, NumThreadsY, ArraySize, 0, numsamp, 0,
-                                   D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
+                                   NumThreadsX, NumThreadsY, ArraySize, 1, numsamp, 0,
+                                   D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS | D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
   CreateTestResources(pDevice, pCommandList, values, valueSizeInBytes, tex2dDesc,
-                      &pUavResource, &pUploadResource);
+                      &pUavResource, nullptr);
 
   // Close the command list and execute it to perform the resource uploads
   pCommandList->Close();

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -3729,11 +3729,13 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
   if (!DoesDeviceSupportAdvancedTexOps(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Advanced Texture Operations.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
   }
 
   if (!DoesDeviceSupportWritableMSAA(pDevice)) {
     WEX::Logging::Log::Comment(L"Device does not support Writable MSAA.");
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
   }
 
   static const char pWriteShader[] =


### PR DESCRIPTION
This change fixes DXC to properly pass the SampleCount attribute to DXIL
metadata. A few test issues are also fixed, namely:

- Do not create upload resource for MSAA textures, since this will cause
  a sample count mismatch in the runtime and we do not need the upload
  resource anyway.
- Fix inverted logic to detect support for ATO and WritableMSAA.
- Pass D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET resource flag when
  creating MSAA resource, which is required by the runtime.