### PR TITLE
[SM6.7][HelperLane] Test fixes for HelperLaneTestWave

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3178,12 +3178,23 @@
             // waterfall loop
             int count = 0;
             int waveCount = WaveGetLaneCount();
+#if  __SHADER_TARGET_MAJOR > 6 || (__SHADER_TARGET_MAJOR == 6 && __SHADER_TARGET_MINOR >= 7)
+            // Count active lanes - includes helper lanes
+            while (count < waveCount) {
+                count++;
+                if (WaveIsFirstLane()) {
+                    break;
+                }
+            }
+#else
+            // Count active lanes and ensure none are helper lanes
             while (count < waveCount) {
                 count++;
                 if (WaveReadLaneFirst(!CALL(IsHelperLane())) && WaveIsFirstLane()) {
                     break;
                 }
             }
+#endif
             tr.waterfallLoopCount = count;
             
             is_helper = CALL(IsHelperLane());

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -10736,11 +10736,20 @@ HelperLaneWaveTestResult HelperLane_PSAfterDiscard_ExpectedResults = {
 
 HelperLaneWaveTestResult IncludesHelperLane_PS_ExpectedResults = {
   // HelperLaneWaveTestResult60
-  { 1, 0, { 0xF, 0, 0, 0 }, 4, 0, 4, 16, 256, 0, 1, 1, 1, 10, 3, 64, 8 },
+  { 1, 0, { 0xF, 0, 0, 0 }, 4, 0, 4, 16, 256, 0, 1, 1, 1, 10, 3, 64, 6 },
+  // HelperLaneQuadTestResult
+  { 0, 1, 0, 0 },
+  // HelperLaneWaveTestResult65
+  { {0xF, 0, 0, 0}, 3, 6, 64, 0, 1, 1 }
+};
+
+HelperLaneWaveTestResult IncludesHelperLane_PSAfterDiscard_ExpectedResults = {
+  // HelperLaneWaveTestResult60
+  { 1, 0, { 0xF, 0, 0, 0 }, 4, 0, 4, 16, 256, 0, 1, 0, 1, 10, 3, 64, 6 },
   // HelperLaneQuadTestResult
   { 0, 1, 0, 1 },
   // HelperLaneWaveTestResult65
-  { {0xF, 0, 0, 0}, 3, 8, 64, 0, 1, 1 }
+  { {0xF, 0, 0, 0}, 3, 6, 64, 0, 1, 0 }
 };
 
 bool HelperLaneResultLogAndVerify(const wchar_t* testDesc, uint32_t expectedValue, uint32_t actualValue) {
@@ -10980,11 +10989,10 @@ TEST_F(ExecutionTest, HelperLaneTestWave) {
       pShaderOp->PS = pShaderOp->GetString("PS66");
     } else if (sm == D3D_SHADER_MODEL_6_7) {
       // Reassign shader stages to 6.7 versions
-      LPCSTR PS67 = nullptr;
-      for (st::ShaderOpShader& S : pShaderOp->Shaders) {
-        if (!strcmp(S.Name, "PS67")) PS67 = S.Name;
-      }
-      pShaderOp->PS = PS67;
+      pShaderOp->CS = pShaderOp->GetString("CS66");
+      pShaderOp->VS = pShaderOp->GetString("VS66");
+      // Only PS has SM 6.7 version to test new [WaveOpsIncludeHelperLanes] attribute
+      pShaderOp->PS = pShaderOp->GetString("PS67");
     }
 
     const unsigned CS_INDEX = 0, VS_INDEX = 0, PS_INDEX = 1, PS_INDEX_AFTER_DISCARD = 2;
@@ -11006,7 +11014,7 @@ TEST_F(ExecutionTest, HelperLaneTestWave) {
                                      : HelperLane_PS_ExpectedResults;
     HelperLaneWaveTestResult &PSAfterDiscard_ExpectedResults =
         (sm >= D3D_SHADER_MODEL_6_7)
-            ? IncludesHelperLane_PS_ExpectedResults
+            ? IncludesHelperLane_PSAfterDiscard_ExpectedResults
             : HelperLane_PSAfterDiscard_ExpectedResults;
 
     // Test Vertex + Pixel shader


### PR DESCRIPTION
The following subtests have updated expected results to account for
helper lanes being a part of wave operations in SM 6.7:

- WavePrefixSum
- WaveMultiPrefixSum
- QuadReadAcross for lane 0
- WaveActiveBitXor

The WaveReadLaneFirst waterfall loop test has also been updated to use a
new loop structure for SM 6.7 as suggested by Tex.