### PR TITLE
[ATORawGather] Remove unreferenced local variable

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -4692,7 +4692,6 @@ TEST_F(ExecutionTest, ATORawGather) {
   static const int NumThreadsX = 32;
   static const int NumThreadsY = 32;
   static const int ThreadsPerGroup = NumThreadsX * NumThreadsY;
-  const size_t valueSize = ThreadsPerGroup;
 
   // Create an array of texture variants with the raw texture base class
   // Then plug them into DoRawGather to perform the test and evaluate the results for each


### PR DESCRIPTION
This is causing VS2022 builds to fail with warnings-as-errors enabled.