### PR TITLE
Fix interface breaks in IDxcUtils and IDxcLibrary from GetBlobAsWide

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -257,8 +257,8 @@ struct IDxcLibrary : public IUnknown {
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IStream **ppStream) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  // Renamed from GetBlobAsUtf16 to GetBlobAsWide
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
 };
@@ -413,8 +413,8 @@ struct IDxcUtils : public IUnknown {
   // Convert or return matching encoded text blobs
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) = 0;
-  virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) = 0;
+
+  // Renamed from GetBlobAsUtf16 to GetBlobAsWide
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) = 0;
 

--- a/tools/clang/tools/dxcompiler/dxclibrary.cpp
+++ b/tools/clang/tools/dxcompiler/dxclibrary.cpp
@@ -214,8 +214,6 @@ public:
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IStream **ppStream) override;
   HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
-  HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
   HRESULT STDMETHODCALLTYPE GetBlobAsWide(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) override;
 };
@@ -312,10 +310,6 @@ public:
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) override {
     DxcThreadMalloc TM(m_pMalloc);
     return ::hlsl::DxcGetBlobAsUtf8(pBlob, m_pMalloc, pBlobEncoding);
-  }
-  virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) override {
-    return GetBlobAsWide(pBlob, pBlobEncoding);
   }
 
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
@@ -574,15 +568,10 @@ HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsUtf8(
   return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsUtf16(
-  _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) {
-  return GetBlobAsWide(pBlob, pBlobEncoding);
-}
-
 HRESULT STDMETHODCALLTYPE DxcLibrary::GetBlobAsWide(
   _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) {
   CComPtr<IDxcBlobWide> pBlobUtf16;
-  IFR(self.GetBlobAsUtf16(pBlob, &pBlobUtf16));
+  IFR(self.GetBlobAsWide(pBlob, &pBlobUtf16));
   IFR(pBlobUtf16->QueryInterface(pBlobEncoding));
   return S_OK;
 }


### PR DESCRIPTION
GetBlobAsWide was added as a new method to the existing interfaces,
but the existing GetBlobAsUtf16 should have simply been renamed to
GetBlobAsWide instead, since that's what GetBlobAsUtf16 actually did.
Otherwise interface compatibility is broken between builds/releases.

If we want to add a GetBlobAsUtf16 which guarantees UTF16 across platforms,
we can add that in a future interface revision.