### PR TITLE
enable optimization passes to throw hlsl exceptions

### DIFF
--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -567,7 +567,7 @@ public:
     bChanged |= RemovePhiOnResource();
 
     if (m_bLegalizationFailed)
-      throw hlsl::Exception(DXC_E_OPTIMIZATION_FAILED, "Resource legalization failed");
+      return bChanged;
 
     if (m_bIsLib) {
       if (DM.GetOP()->UseMinPrecision())

--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -567,7 +567,7 @@ public:
     bChanged |= RemovePhiOnResource();
 
     if (m_bLegalizationFailed)
-      return bChanged;
+      throw hlsl::Exception(DXC_E_OPTIMIZATION_FAILED, "Resource legalization failed");
 
     if (m_bIsLib) {
       if (DM.GetOP()->UseMinPrecision())

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -763,18 +763,15 @@ void clang::EmitBackendOutput(DiagnosticsEngine &Diags,
                               raw_pwrite_stream *OS) {
   EmitAssemblyHelper AsmHelper(Diags, CGOpts, TOpts, LOpts, M);
 
-  // Catch any fatal errors during optimization passes here
-  // so that future passes can be skipped.
-  try {
+
+  try { // HLSL Change Starts
+    // Catch any fatal errors during optimization passes here
+    // so that future passes can be skipped.
     AsmHelper.EmitAssembly(Action, OS);
   } catch (const ::hlsl::Exception &hlslException) {
-    const char *msg = hlslException.what();
-    const std::string msgStr(msg);
-    unsigned DiagID = Diags.getCustomDiagID(
-        DiagnosticsEngine::Error,
-        "'%0'\nFatal error during optimization, aborting.");
-    Diags.Report(DiagID) << msgStr;
-  }
+    Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0"))
+        << StringRef(hlslException.what());
+  } // HLSL Change Ends
 
   // If an optional clang TargetInfo description string was passed in, use it to
   // verify the LLVM TargetMachine's DataLayout.

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -769,7 +769,7 @@ void clang::EmitBackendOutput(DiagnosticsEngine &Diags,
     // so that future passes can be skipped.
     AsmHelper.EmitAssembly(Action, OS);
   } catch (const ::hlsl::Exception &hlslException) {
-    Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0"))
+    Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0\nFatal error during optimization, aborting"))
         << StringRef(hlslException.what());
   } // HLSL Change Ends
 

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -7,7 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "dxc/Support/Global.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/LangOptions.h"
@@ -44,6 +43,7 @@
 #include <memory>
 #include "dxc/HLSL/DxilGenerationPass.h" // HLSL Change
 #include "dxc/HLSL/HLMatrixLowerPass.h"  // HLSL Change
+#include "dxc/Support/Global.h" // HLSL Change
 
 using namespace clang;
 using namespace llvm;
@@ -769,7 +769,7 @@ void clang::EmitBackendOutput(DiagnosticsEngine &Diags,
     // so that future passes can be skipped.
     AsmHelper.EmitAssembly(Action, OS);
   } catch (const ::hlsl::Exception &hlslException) {
-    Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0\nFatal error during optimization, aborting"))
+    Diags.Report(Diags.getCustomDiagID(DiagnosticsEngine::Error, "%0\n"))
         << StringRef(hlslException.what());
   } // HLSL Change Ends
 


### PR DESCRIPTION
Previously, during optimization passes, 
either exceptions would be thrown and diagnostic data would be lost, 
or fatal errors discovered during the passes would not prevent later passes from executing when execution should stop.

This change's purpose is to allow optimization passes the option to abort further compilation 
(stop later passes from executing), and capture relevant error data in the Diagnostic object before terminating.

This was tested with a cherry-pick here: bece3d4fafe4d7d50f5d0df59597a467d4f89f85,
and an accompanying hlsl file with invalid semantics. The thrown exception looked like this in HLSLSignatureLower.cpp:
```
void HLSignatureLower::Run() {

  // Generate error and exit if semantic type
  // is not one of the allowed types
  if (!ValidateSemanticType(Entry))
    throw hlsl::Exception(DXC_E_NOT_SUPPORTED, "Semantic type invalid");
```

Output to the console window was:

```
D:\DirectXShaderCompiler\tools\clang\test\HLSLFileCheck\hlsl\diagnostics\errors\semantics_type_checking\unsupported_types_cs_input_semantics.hlsl:41:1: error: invalid type used for 'SV_GroupThreadID' semantic.
void main(TID_TY tid : SV_DispatchThreadID,
^
error: 'Semantic type invalid'
Fatal error during optimization, aborting.


D:\hlsl.bin\Debug\bin\dxc.exe (process 187836) exited with code -2147467259.
To automatically close the console when debugging stops, enable Tools->Options->Debugging->Automatically close the console when debugging stops.
Press any key to close this window . . .
```