### PR TITLE
add non-uniform dynamic indexing option to dynamic resources uniform indexing test

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3494,7 +3494,7 @@ void MSMain(uint GID : SV_GroupIndex,
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="DynamicResourcesUniformAndNonUniformIndexing" CS="CS66" VS="VS66" PS="PS66">
+  <ShaderOp Name="DynamicResourcesDynamicIndexing" CS="CS66" VS="VS66" PS="PS66">
 
     <Resource Name="ConstantBuffer" Dimension="BUFFER" Width="256" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
       { 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 11u}
@@ -3505,40 +3505,40 @@ void MSMain(uint GID : SV_GroupIndex,
     </Resource>
 
     <Resource Name="T1"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
-      10.0
+      11.0
     </Resource>
 
     <Resource Name="T2"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
-      11.0
+      12.0
     </Resource>
 
     <Resource Name="T3"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
-      11.0
+      13.0
     </Resource>
 
     <Resource Name="T4"            Dimension="Texture2D"  Width="4" Height="4"  InitialResourceState="COPY_DEST" Init="FromBytes" Format="R32_FLOAT">
-      12.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      14.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     </Resource>
     <Resource Name="T5"            Dimension="Texture2D"  Width="4" Height="4"  InitialResourceState="COPY_DEST" Init="FromBytes" Format="R32_FLOAT">
-      12.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+      15.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     </Resource>
     
     <Resource Name="U0"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
-      23.0
+      20.0
     </Resource>
     <Resource Name="U1"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
-      23.0
+      21.0
     </Resource>
     
     <Resource Name="U2"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
-      24.0
+      22.0
     </Resource>
     <Resource Name="U3"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
-      24.0
+      23.0
     </Resource>
     
     <Resource Name="U4"            Dimension="TEXTURE1D"  Width="4"             InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" Format="R32_FLOAT" TransitionTo="UNORDERED_ACCESS">
-      25.0 0 0 0
+      24.0 0 0 0
     </Resource>
     <Resource Name="U5"            Dimension="TEXTURE1D"  Width="4"             InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" Format="R32_FLOAT" TransitionTo="UNORDERED_ACCESS">
       25.0 0 0 0
@@ -3643,9 +3643,9 @@ void MSMain(uint GID : SV_GroupIndex,
 
     ConstantBuffer<Constants> CB               : register(b12);
     // Result buffers
-    RWBuffer<float> g_result   : register(u13);
-    RWBuffer<float> g_resultVS : register(u14);
-    RWBuffer<float> g_resultPS : register(u15);
+    RWStructuredBuffer <float> g_result   : register(u13);
+    RWStructuredBuffer <float> g_resultVS : register(u14);
+    RWStructuredBuffer <float> g_resultPS : register(u15);
     
     #else // NO FALLBACK
 
@@ -3661,8 +3661,10 @@ void MSMain(uint GID : SV_GroupIndex,
     
     #endif // FALLBACK
     
-    #ifndef FALLBACK
+    
     void TestResources(RWStructuredBuffer<float> result, uint ix) {
+        
+    #ifndef FALLBACK
         ByteAddressBuffer rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
         StructuredBuffer<float> structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
         Texture2D<float> tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
@@ -3673,8 +3675,8 @@ void MSMain(uint GID : SV_GroupIndex,
         static SamplerState g_samp = SamplerDescriptorHeap[INDEXER(CB.idx0, ix)];
         static SamplerComparisonState g_sampCmp  = SamplerDescriptorHeap[INDEXER(CB.idx2, ix)];
     #endif
+    
     #ifdef FALLBACK
-    void FallBackTestResources(RWBuffer<float> result, uint ix) {
         ByteAddressBuffer rawBuf = g_fallback_rawBuf[INDEXER(0,ix)];
         StructuredBuffer<float> structBuf = g_fallback_structBuf[INDEXER(0,ix)];
         Texture2D<float> tex = g_fallback_tex[INDEXER(0,ix)];
@@ -3699,11 +3701,7 @@ void MSMain(uint GID : SV_GroupIndex,
     ROOT_SIG
     [NumThreads(2, 2, 1)]
     void main(uint ix : SV_GroupIndex) {
-        #ifndef FALLBACK
         TestResources(g_result, ix);
-        #else
-        FallBackTestResources(g_result, ix);
-        #endif
     }
     
     struct PSInput {
@@ -3713,22 +3711,14 @@ void MSMain(uint GID : SV_GroupIndex,
     ROOT_SIG
     float4 PSMain(PSInput input) : SV_TARGET {
         int ix = WaveGetLaneIndex();
-        #ifndef FALLBACK
-        TestResources(g_resultPS, ix);
-        #else
-        FallBackTestResources(g_resultPS, ix);
-        #endif       
+        TestResources(g_resultPS, ix);      
         // This output doesn't actually matter
         return input.position;
     }
     
     ROOT_SIG
     PSInput VSMain(float3 pos : POSITION, uint ix : SV_VertexID) {
-        #ifndef FALLBACK
         TestResources(g_resultVS, ix);
-        #else
-        FallBackTestResources(g_resultVS, ix);
-        #endif
         PSInput r;
         r.position = float4(pos, 1); 
         return r;

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3631,15 +3631,15 @@ void MSMain(uint GID : SV_GroupIndex,
     #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( SRV(t0, numDescriptors=6), UAV(u6, numDescriptors=6), CBV(b12), UAV(u13,numDescriptors=3) ), \
     DescriptorTable(Sampler(s0, numDescriptors=2), Sampler(s2, numDescriptors=2))")]
     
-    ByteAddressBuffer fallback_g_rawBuf[2]              : register(t0);
-    StructuredBuffer<float> fallback_g_structBuf[2]     : register(t2);
-    Texture2D<float> fallback_g_tex[2]                  : register(t4);
-    RWByteAddressBuffer fallback_g_rwRawBuf[2]          : register(u6);
-    RWStructuredBuffer<float> fallback_g_rwStructBuf[2] : register(u8);
-    RWTexture1D<float> fallback_g_rwTex[2]              : register(u10);
+    ByteAddressBuffer g_fallback_rawBuf[2]              : register(t0);
+    StructuredBuffer<float> g_fallback_structBuf[2]     : register(t2);
+    Texture2D<float> g_fallback_tex[2]                  : register(t4);
+    RWByteAddressBuffer g_fallback_rwRawBuf[2]          : register(u6);
+    RWStructuredBuffer<float> g_fallback_rwStructBuf[2] : register(u8);
+    RWTexture1D<float> g_fallback_rwTex[2]              : register(u10);
 
-    SamplerState fallback_g_samp[2]              : register(s0);
-    SamplerComparisonState fallback_g_sampCmp[2] : register(s2);
+    SamplerState g_fallback_samp[2]              : register(s0);
+    SamplerComparisonState g_fallback_sampCmp[2] : register(s2);
 
     ConstantBuffer<Constants> CB               : register(b12);
     // Result buffers
@@ -3663,51 +3663,38 @@ void MSMain(uint GID : SV_GroupIndex,
     
     #ifndef FALLBACK
     void TestResources(RWStructuredBuffer<float> result, uint ix) {
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
+        ByteAddressBuffer rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
+        Texture2D<float> tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
+        RWByteAddressBuffer rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
+        RWStructuredBuffer<float> rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
+        RWTexture1D<float> rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
         
         static SamplerState g_samp = SamplerDescriptorHeap[INDEXER(CB.idx0, ix)];
         static SamplerComparisonState g_sampCmp  = SamplerDescriptorHeap[INDEXER(CB.idx2, ix)];
-        
-        result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
-        result[1*2 + ix%2] = g_structBuf.Load(0);
-        result[2*2 + ix%2] = g_tex.Load(0);
-        result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
-        result[4*2 + ix%2] = g_rwStructBuf.Load(0);
-        result[5*2 + ix%2] = g_rwTex.Load(0);
-        result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0);
-        result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, (float)INDEXER(32, ix)) ? (float)INDEXER(32, ix) : 0.0;
-    }
     #endif
-    
     #ifdef FALLBACK
     void FallBackTestResources(RWBuffer<float> result, uint ix) {
+        ByteAddressBuffer rawBuf = g_fallback_rawBuf[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> structBuf = g_fallback_structBuf[INDEXER(CB.idx0,ix)];
+        Texture2D<float> tex = g_fallback_tex[INDEXER(CB.idx0,ix)];
+        RWByteAddressBuffer rwRawBuf = g_fallback_rwRawBuf[INDEXER(CB.idx0,ix)];
+        RWStructuredBuffer<float> rwStructBuf = g_fallback_rwStructBuf[INDEXER(CB.idx0,ix)];
+        RWTexture1D<float> rwTex = g_fallback_rwTex[INDEXER(CB.idx0,ix)];
         
-        
-        ByteAddressBuffer g_rawBuf = fallback_g_rawBuf[INDEXER(CB.idx0,ix)];
-        StructuredBuffer<float> g_structBuf = fallback_g_structBuf[INDEXER(CB.idx0,ix)];
-        Texture2D<float> g_tex = fallback_g_tex[INDEXER(CB.idx0,ix)];
-        RWByteAddressBuffer g_rwRawBuf = fallback_g_rwRawBuf[INDEXER(CB.idx0,ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = fallback_g_rwStructBuf[INDEXER(CB.idx0,ix)];
-        RWTexture1D<float> g_rwTex = fallback_g_rwTex[INDEXER(CB.idx0,ix)];
-        
-        static SamplerState g_samp = fallback_g_samp[INDEXER(CB.idx0, ix)];
-        static SamplerComparisonState g_sampCmp = fallback_g_sampCmp[INDEXER(CB.idx0, ix)];
+        static SamplerState g_samp = g_fallback_samp[INDEXER(CB.idx0, ix)];
+        static SamplerComparisonState g_sampCmp = g_fallback_sampCmp[INDEXER(CB.idx0, ix)];
+   #endif
 
-        result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
-        result[1*2 + ix%2] = g_structBuf.Load(0);
-        result[2*2 + ix%2] = g_tex.Load(0);
-        result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
-        result[4*2 + ix%2] = g_rwStructBuf.Load(0);
-        result[5*2 + ix%2] = g_rwTex.Load(0);
-        result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0);
-        result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, (float)INDEXER(32, ix)) ? (float)INDEXER(32, ix) : 0.0;
+        result[0*2 + ix%2] = rawBuf.Load<float>(0);
+        result[1*2 + ix%2] = structBuf.Load(0);
+        result[2*2 + ix%2] = tex.Load(0);
+        result[3*2 + ix%2] = rwRawBuf.Load<float>(0);
+        result[4*2 + ix%2] = rwStructBuf.Load(0);
+        result[5*2 + ix%2] = rwTex.Load(0);
+        result[6*2 + ix%2] = tex.SampleLevel(g_samp, -0.5, 0);
+        result[7*2 + ix%2] = tex.SampleCmpLevelZero(g_sampCmp, -0.5, (float)INDEXER(32, ix)) ? (float)INDEXER(32, ix) : 0.0;
     }
-    #endif
 
     ROOT_SIG
     [NumThreads(2, 2, 1)]

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3675,15 +3675,15 @@ void MSMain(uint GID : SV_GroupIndex,
     #endif
     #ifdef FALLBACK
     void FallBackTestResources(RWBuffer<float> result, uint ix) {
-        ByteAddressBuffer rawBuf = g_fallback_rawBuf[INDEXER(CB.idx0,ix)];
-        StructuredBuffer<float> structBuf = g_fallback_structBuf[INDEXER(CB.idx0,ix)];
-        Texture2D<float> tex = g_fallback_tex[INDEXER(CB.idx0,ix)];
-        RWByteAddressBuffer rwRawBuf = g_fallback_rwRawBuf[INDEXER(CB.idx0,ix)];
-        RWStructuredBuffer<float> rwStructBuf = g_fallback_rwStructBuf[INDEXER(CB.idx0,ix)];
-        RWTexture1D<float> rwTex = g_fallback_rwTex[INDEXER(CB.idx0,ix)];
+        ByteAddressBuffer rawBuf = g_fallback_rawBuf[INDEXER(0,ix)];
+        StructuredBuffer<float> structBuf = g_fallback_structBuf[INDEXER(0,ix)];
+        Texture2D<float> tex = g_fallback_tex[INDEXER(0,ix)];
+        RWByteAddressBuffer rwRawBuf = g_fallback_rwRawBuf[INDEXER(0,ix)];
+        RWStructuredBuffer<float> rwStructBuf = g_fallback_rwStructBuf[INDEXER(0,ix)];
+        RWTexture1D<float> rwTex = g_fallback_rwTex[INDEXER(0,ix)];
         
-        static SamplerState g_samp = g_fallback_samp[INDEXER(CB.idx0, ix)];
-        static SamplerComparisonState g_sampCmp = g_fallback_sampCmp[INDEXER(CB.idx0, ix)];
+        static SamplerState g_samp = g_fallback_samp[INDEXER(0, ix)];
+        static SamplerComparisonState g_sampCmp = g_fallback_sampCmp[INDEXER(0, ix)];
    #endif
 
         result[0*2 + ix%2] = rawBuf.Load<float>(0);

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3579,8 +3579,10 @@ void MSMain(uint GID : SV_GroupIndex,
     </DescriptorHeap>
 
     <DescriptorHeap Name="SamplerDescriptorHeap" Type="SAMPLER">
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="1.0" />
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="1.0" ComparisonFunc="EQUAL"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="30.0" />
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="31.0" />
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="32.0" ComparisonFunc="EQUAL"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="33.0" ComparisonFunc="EQUAL"/>
     </DescriptorHeap>
     
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
@@ -3602,14 +3604,11 @@ void MSMain(uint GID : SV_GroupIndex,
     <Shader Name="CS66" Target="cs_6_6" EntryPoint="main" Text="@MAIN"/> 
     <!-- -->
     
-    <!-- FALLBACK BEGINS ->
+    <!-- This root value is only applied in the fallback case -->
     <RootValues>
-      <RootValue HeapName="ResourceDescriptorHeap" />
+      <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
+      <RootValue HeapName="SamplerDescriptorHeap"  Index="1" />
     </RootValues>
-    <Shader Name="PS66" Target="ps_6_0" EntryPoint="PSMain" Text="@MAIN" Arguments="/DFALLBACK=1"/>
-    <Shader Name="VS66" Target="vs_6_0" EntryPoint="VSMain" Text="@MAIN" Arguments="/DFALLBACK=1"/>
-    <Shader Name="CS66" Target="cs_6_0" EntryPoint="main" Text="@MAIN" Arguments="/DFALLBACK=1"/>
-    <!- FALLBACK ENDS -->
 
     <Shader Name="MAIN" Target="cs_6_6" EntryPoint="main">
       <![CDATA[
@@ -3617,28 +3616,37 @@ void MSMain(uint GID : SV_GroupIndex,
     {
       uint idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9, idx10;
     };
+    
+    // globally declare these so that non-fallback won't throw an unknown identifier error
+    
+    #ifndef NON_UNIFORM
+    #define INDEXER(idx,ix) idx
+    #else
+    #define INDEXER(idx,ix) NonUniformResourceIndex(idx + ix%2)
+    #endif
+
 
     #ifdef FALLBACK
 
-    #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( SRV(t0), SRV(t1), SRV(t2), UAV(u3), UAV(u4), UAV(u5), CBV(b6), UAV(u7,numDescriptors=3) ), StaticSampler(s0, addressU = TEXTURE_ADDRESS_BORDER, addressV = TEXTURE_ADDRESS_BORDER, borderColor=STATIC_BORDER_COLOR_OPAQUE_WHITE), StaticSampler(s1, addressU = TEXTURE_ADDRESS_BORDER, addressV = TEXTURE_ADDRESS_BORDER, borderColor=STATIC_BORDER_COLOR_OPAQUE_WHITE, comparisonFunc=COMPARISON_EQUAL)")]
+    #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( SRV(t0, numDescriptors=6), UAV(u6, numDescriptors=6), CBV(b12), UAV(u13,numDescriptors=3) ), \
+    DescriptorTable(Sampler(s0, numDescriptors=2), Sampler(s2, numDescriptors=2))")]
+    
+    ByteAddressBuffer fallback_g_rawBuf[2]              : register(t0);
+    StructuredBuffer<float> fallback_g_structBuf[2]     : register(t2);
+    Texture2D<float> fallback_g_tex[2]                  : register(t4);
+    RWByteAddressBuffer fallback_g_rwRawBuf[2]          : register(u6);
+    RWStructuredBuffer<float> fallback_g_rwStructBuf[2] : register(u8);
+    RWTexture1D<float> fallback_g_rwTex[2]              : register(u10);
 
-    ConstantBuffer<Constants> CB : register(b6);
+    SamplerState fallback_g_samp[2]              : register(s0);
+    SamplerComparisonState fallback_g_sampCmp[2] : register(s2);
 
-    ByteAddressBuffer g_rawBuf : register(t0);
-    StructuredBuffer<float> g_structBuf : register(t1);
-    Texture2D<float> g_tex : register(t2);
-    RWByteAddressBuffer g_rwRawBuf : register(u3);
-    RWStructuredBuffer<float> g_rwStructBuf : register(u4);
-    RWTexture1D<float> g_rwTex : register(u5);
-
+    ConstantBuffer<Constants> CB               : register(b12);
     // Result buffers
-    RWBuffer<float> g_result : register(u7);
-    RWBuffer<float> g_resultVS : register(u8);
-    RWBuffer<float> g_resultPS : register(u9);
-
-    SamplerState g_samp : register(s0);
-    SamplerComparisonState g_sampCmp : register(s1);
-
+    RWBuffer<float> g_result   : register(u13);
+    RWBuffer<float> g_resultVS : register(u14);
+    RWBuffer<float> g_resultPS : register(u15);
+    
     #else // NO FALLBACK
 
     #define ROOT_SIG [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)")]
@@ -3646,42 +3654,69 @@ void MSMain(uint GID : SV_GroupIndex,
     static const int CBIndex = 12;
     static ConstantBuffer<Constants> CB = ResourceDescriptorHeap[CBIndex];
 
-    #define NON_UNIFORM
-    #ifndef NON_UNIFORM
-    #define INDEXER(idx,ix) idx
-    #else
-    #define INDEXER(idx,ix) NonUniformResourceIndex(idx + ix%2)
-    #endif
-
     // Result buffers
-    static RWStructuredBuffer<float> g_result = ResourceDescriptorHeap[CBIndex+1];
+    static RWStructuredBuffer<float> g_result   = ResourceDescriptorHeap[CBIndex+1];
     static RWStructuredBuffer<float> g_resultVS = ResourceDescriptorHeap[CBIndex+2];
     static RWStructuredBuffer<float> g_resultPS = ResourceDescriptorHeap[CBIndex+3];
     
-    static SamplerState g_samp = SamplerDescriptorHeap[CB.idx0];
-    static SamplerComparisonState g_sampCmp = SamplerDescriptorHeap[CB.idx1];
-
     #endif // FALLBACK
-
-    ROOT_SIG
-    [NumThreads(2, 2, 1)]
-    void main(uint ix : SV_GroupIndex) {
     
+    #ifndef FALLBACK
+    void TestResources(RWStructuredBuffer<float> result, uint ix) {
         ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
         StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
         Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
         RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
         RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
         RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
+        
+        static SamplerState g_samp = SamplerDescriptorHeap[INDEXER(CB.idx0, ix)];
+        static SamplerComparisonState g_sampCmp  = SamplerDescriptorHeap[INDEXER(CB.idx2, ix)];
+        
+        result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
+        result[1*2 + ix%2] = g_structBuf.Load(0);
+        result[2*2 + ix%2] = g_tex.Load(0);
+        result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
+        result[4*2 + ix%2] = g_rwStructBuf.Load(0);
+        result[5*2 + ix%2] = g_rwTex.Load(0);
+        result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0);
+        result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, (float)INDEXER(32, ix)) ? (float)INDEXER(32, ix) : 0.0;
+    }
+    #endif
     
-        g_result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
-        g_result[1*2 + ix%2] = g_structBuf.Load(0);
-        g_result[2*2 + ix%2] = g_tex.Load(0);
-        g_result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
-        g_result[4*2 + ix%2] = g_rwStructBuf.Load(0);
-        g_result[5*2 + ix%2] = g_rwTex.Load(0);
-        g_result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
-        g_result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
+    #ifdef FALLBACK
+    void FallBackTestResources(RWBuffer<float> result, uint ix) {
+        
+        
+        ByteAddressBuffer g_rawBuf = fallback_g_rawBuf[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> g_structBuf = fallback_g_structBuf[INDEXER(CB.idx0,ix)];
+        Texture2D<float> g_tex = fallback_g_tex[INDEXER(CB.idx0,ix)];
+        RWByteAddressBuffer g_rwRawBuf = fallback_g_rwRawBuf[INDEXER(CB.idx0,ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = fallback_g_rwStructBuf[INDEXER(CB.idx0,ix)];
+        RWTexture1D<float> g_rwTex = fallback_g_rwTex[INDEXER(CB.idx0,ix)];
+        
+        static SamplerState g_samp = fallback_g_samp[INDEXER(CB.idx0, ix)];
+        static SamplerComparisonState g_sampCmp = fallback_g_sampCmp[INDEXER(CB.idx0, ix)];
+
+        result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
+        result[1*2 + ix%2] = g_structBuf.Load(0);
+        result[2*2 + ix%2] = g_tex.Load(0);
+        result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
+        result[4*2 + ix%2] = g_rwStructBuf.Load(0);
+        result[5*2 + ix%2] = g_rwTex.Load(0);
+        result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0);
+        result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, (float)INDEXER(32, ix)) ? (float)INDEXER(32, ix) : 0.0;
+    }
+    #endif
+
+    ROOT_SIG
+    [NumThreads(2, 2, 1)]
+    void main(uint ix : SV_GroupIndex) {
+        #ifndef FALLBACK
+        TestResources(g_result, ix);
+        #else
+        FallBackTestResources(g_result, ix);
+        #endif
     }
     
     struct PSInput {
@@ -3691,48 +3726,22 @@ void MSMain(uint GID : SV_GroupIndex,
     ROOT_SIG
     float4 PSMain(PSInput input) : SV_TARGET {
         int ix = WaveGetLaneIndex();
-        
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
-        
-        // Can't control number of threads for VS / PS shaders, so
-        // make sure how ever many of threads run this, that 
-        // the result assignment variance is 2 at maximum
-        g_resultPS[0*2 + ix%2] = g_rawBuf.Load<float>(0);
-        g_resultPS[1*2 + ix%2] = g_structBuf.Load(0);
-        g_resultPS[2*2 + ix%2] = g_tex.Load(0);
-        g_resultPS[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
-        g_resultPS[4*2 + ix%2] = g_rwStructBuf.Load(0);
-        g_resultPS[5*2 + ix%2] = g_rwTex.Load(0);
-        g_resultPS[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
-        g_resultPS[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
-        
+        #ifndef FALLBACK
+        TestResources(g_resultPS, ix);
+        #else
+        FallBackTestResources(g_resultPS, ix);
+        #endif       
         // This output doesn't actually matter
         return input.position;
     }
     
     ROOT_SIG
     PSInput VSMain(float3 pos : POSITION, uint ix : SV_VertexID) {
-    
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
-    
-        g_resultVS[0*2 + ix%2] = g_rawBuf.Load<float>(0);
-        g_resultVS[1*2 + ix%2] = g_structBuf.Load(0);
-        g_resultVS[2*2 + ix%2] = g_tex.Load(0);
-        g_resultVS[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
-        g_resultVS[4*2 + ix%2] = g_rwStructBuf.Load(0);
-        g_resultVS[5*2 + ix%2] = g_rwTex.Load(0);
-        g_resultVS[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
-        g_resultVS[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
+        #ifndef FALLBACK
+        TestResources(g_resultVS, ix);
+        #else
+        FallBackTestResources(g_resultVS, ix);
+        #endif
         PSInput r;
         r.position = float4(pos, 1); 
         return r;

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3497,7 +3497,7 @@ void MSMain(uint GID : SV_GroupIndex,
   <ShaderOp Name="DynamicResourcesUniformIndexing" CS="CS66" VS="VS66" PS="PS66">
 
     <Resource Name="ConstantBuffer" Dimension="BUFFER" Width="256" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
-      { 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u }
+      { 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 11u}
     </Resource>
     
     <Resource Name="T0"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
@@ -3505,21 +3505,41 @@ void MSMain(uint GID : SV_GroupIndex,
     </Resource>
 
     <Resource Name="T1"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
+      10.0
+    </Resource>
+
+    <Resource Name="T2"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
       11.0
     </Resource>
 
-    <Resource Name="T2"            Dimension="Texture2D"  Width="4" Height="4"  InitialResourceState="COPY_DEST" Init="FromBytes" Format="R32_FLOAT">
+    <Resource Name="T3"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" >
+      11.0
+    </Resource>
+
+    <Resource Name="T4"            Dimension="Texture2D"  Width="4" Height="4"  InitialResourceState="COPY_DEST" Init="FromBytes" Format="R32_FLOAT">
+      12.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    </Resource>
+    <Resource Name="T5"            Dimension="Texture2D"  Width="4" Height="4"  InitialResourceState="COPY_DEST" Init="FromBytes" Format="R32_FLOAT">
       12.0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
     </Resource>
     
-    <Resource Name="U3"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
+    <Resource Name="U0"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
+      23.0
+    </Resource>
+    <Resource Name="U1"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
       23.0
     </Resource>
     
-    <Resource Name="U4"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
+    <Resource Name="U2"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
+      24.0
+    </Resource>
+    <Resource Name="U3"            Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS">
       24.0
     </Resource>
     
+    <Resource Name="U4"            Dimension="TEXTURE1D"  Width="4"             InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" Format="R32_FLOAT" TransitionTo="UNORDERED_ACCESS">
+      25.0 0 0 0
+    </Resource>
     <Resource Name="U5"            Dimension="TEXTURE1D"  Width="4"             InitialResourceState="COPY_DEST" Init="FromBytes" Flags="ALLOW_UNORDERED_ACCESS" Format="R32_FLOAT" TransitionTo="UNORDERED_ACCESS">
       25.0 0 0 0
     </Resource>
@@ -3541,10 +3561,16 @@ void MSMain(uint GID : SV_GroupIndex,
 
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="T0" Kind="SRV" Flags='RAW' NumElements="1" Format="R32_TYPELESS"/>
-      <Descriptor Name="T1" Kind="SRV" NumElements="1" StructureByteStride="4"/>
-      <Descriptor Name="T2" Kind="SRV" />
-      <Descriptor Name="U3" Kind="UAV" Flags='RAW' NumElements="1" Format="R32_TYPELESS"/>
-      <Descriptor Name="U4" Kind="UAV" NumElements="1" StructureByteStride="4"/>
+      <Descriptor Name="T1" Kind="SRV" Flags='RAW' NumElements="1" Format="R32_TYPELESS"/>
+      <Descriptor Name="T2" Kind="SRV" NumElements="1" StructureByteStride="4"/>
+      <Descriptor Name="T3" Kind="SRV" NumElements="1" StructureByteStride="4"/>
+      <Descriptor Name="T4" Kind="SRV" />
+      <Descriptor Name="T5" Kind="SRV" />
+      <Descriptor Name="U0" Kind="UAV" Flags='RAW' NumElements="1" Format="R32_TYPELESS"/>
+      <Descriptor Name="U1" Kind="UAV" Flags='RAW' NumElements="1" Format="R32_TYPELESS"/>
+      <Descriptor Name="U2" Kind="UAV" NumElements="1" StructureByteStride="4"/>
+      <Descriptor Name="U3" Kind="UAV" NumElements="1" StructureByteStride="4"/>
+      <Descriptor Name="U4" Kind="UAV" Dimension="TEXTURE1D" Format="R32_FLOAT"/>
       <Descriptor Name="U5" Kind="UAV" Dimension="TEXTURE1D" Format="R32_FLOAT"/>
       <Descriptor Name="ConstantBuffer" Kind="CBV"/>
       <Descriptor Name="g_result"   NumElements="8" Kind="UAV"  StructureByteStride="4"/>
@@ -3589,7 +3615,7 @@ void MSMain(uint GID : SV_GroupIndex,
       <![CDATA[
     struct Constants
     {
-      uint idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7;
+      uint idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7, idx8, idx9, idx10;
     };
 
     #ifdef FALLBACK
@@ -3616,20 +3642,22 @@ void MSMain(uint GID : SV_GroupIndex,
     #else // NO FALLBACK
 
     #define ROOT_SIG [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)")]
+    
+    static ConstantBuffer<Constants> CB = ResourceDescriptorHeap[12];
 
-    static ConstantBuffer<Constants> CB = ResourceDescriptorHeap[6];
-
-    static ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[CB.idx0];
-    static StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[CB.idx1];
-    static Texture2D<float> g_tex = ResourceDescriptorHeap[CB.idx2];
-    static RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[CB.idx3];
-    static RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[CB.idx4];
-    static RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[CB.idx5];
+    #define NON_UNIFORM
+    #ifndef NON_UNIFORM
+    #define INDEXER(ix) ix
+    #define OFFSET(ix) 0
+    #else
+    #define INDEXER(ix) NonUniformResourceIndex(ix)
+    #define OFFSET(ix) ix % 2
+    #endif
 
     // Result buffers
-    static RWStructuredBuffer<float> g_result = ResourceDescriptorHeap[7];
-    static RWStructuredBuffer<float> g_resultVS = ResourceDescriptorHeap[8];
-    static RWStructuredBuffer<float> g_resultPS = ResourceDescriptorHeap[9];
+    static RWStructuredBuffer<float> g_result = ResourceDescriptorHeap[13];
+    static RWStructuredBuffer<float> g_resultVS = ResourceDescriptorHeap[14];
+    static RWStructuredBuffer<float> g_resultPS = ResourceDescriptorHeap[15];
     
     static SamplerState g_samp = SamplerDescriptorHeap[CB.idx0];
     static SamplerComparisonState g_sampCmp = SamplerDescriptorHeap[CB.idx1];
@@ -3637,8 +3665,16 @@ void MSMain(uint GID : SV_GroupIndex,
     #endif // FALLBACK
 
     ROOT_SIG
-    [NumThreads(1, 1, 1)]
+    [NumThreads(8, 8, 1)]
     void main(uint ix : SV_GroupIndex) {
+    
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
+    
         g_result[0] = g_rawBuf.Load<float>(0);
         g_result[1] = g_structBuf.Load(0);
         g_result[2] = g_tex.Load(0);
@@ -3655,6 +3691,17 @@ void MSMain(uint GID : SV_GroupIndex,
 
     ROOT_SIG
     float4 PSMain(PSInput input) : SV_TARGET {
+    
+        int x = (int)input.position.x;
+        int y = (int)input.position.y;
+        int ix = x+y;
+        
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
         
         g_resultPS[0] = g_rawBuf.Load<float>(0);
         g_resultPS[1] = g_structBuf.Load(0);
@@ -3670,7 +3717,15 @@ void MSMain(uint GID : SV_GroupIndex,
     }
     
     ROOT_SIG
-    PSInput VSMain(float3 pos : POSITION) {
+    PSInput VSMain(float3 pos : POSITION, uint ix : SV_VertexID) {
+      
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
+    
         g_resultVS[0] = g_rawBuf.Load<float>(0);
         g_resultVS[1] = g_structBuf.Load(0);
         g_resultVS[2] = g_tex.Load(0);

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3494,7 +3494,7 @@ void MSMain(uint GID : SV_GroupIndex,
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="DynamicResourcesUniformIndexing" CS="CS66" VS="VS66" PS="PS66">
+  <ShaderOp Name="DynamicResourcesUniformAndNonUniformIndexing" CS="CS66" VS="VS66" PS="PS66">
 
     <Resource Name="ConstantBuffer" Dimension="BUFFER" Width="256" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
       { 0u, 1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 11u}
@@ -3553,9 +3553,9 @@ void MSMain(uint GID : SV_GroupIndex,
     { 1.0f, -1.0f, 0.0f },
     </Resource>
     
-    <Resource Name="g_result"      Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
-    <Resource Name="g_resultPS"    Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
-    <Resource Name="g_resultVS"    Dimension="BUFFER"     Width="32"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_result"      Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_resultPS"    Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_resultVS"    Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     
     <Resource Name="RTarget" Dimension="TEXTURE2D" Width="16" Height="16" Format="R32G32B32A32_FLOAT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true"/>
 
@@ -3573,9 +3573,9 @@ void MSMain(uint GID : SV_GroupIndex,
       <Descriptor Name="U4" Kind="UAV" Dimension="TEXTURE1D" Format="R32_FLOAT"/>
       <Descriptor Name="U5" Kind="UAV" Dimension="TEXTURE1D" Format="R32_FLOAT"/>
       <Descriptor Name="ConstantBuffer" Kind="CBV"/>
-      <Descriptor Name="g_result"   NumElements="8" Kind="UAV"  StructureByteStride="4"/>
-      <Descriptor Name="g_resultVS" NumElements="8" Kind="UAV"  StructureByteStride="4"/>
-      <Descriptor Name="g_resultPS" NumElements="8" Kind="UAV"  StructureByteStride="4"/>
+      <Descriptor Name="g_result"   NumElements="16" Kind="UAV"  StructureByteStride="4"/>
+      <Descriptor Name="g_resultVS" NumElements="16" Kind="UAV"  StructureByteStride="4"/>
+      <Descriptor Name="g_resultPS" NumElements="16" Kind="UAV"  StructureByteStride="4"/>
     </DescriptorHeap>
 
     <DescriptorHeap Name="SamplerDescriptorHeap" Type="SAMPLER">
@@ -3643,21 +3643,20 @@ void MSMain(uint GID : SV_GroupIndex,
 
     #define ROOT_SIG [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)")]
     
-    static ConstantBuffer<Constants> CB = ResourceDescriptorHeap[12];
+    static const int CBIndex = 12;
+    static ConstantBuffer<Constants> CB = ResourceDescriptorHeap[CBIndex];
 
     #define NON_UNIFORM
     #ifndef NON_UNIFORM
-    #define INDEXER(ix) ix
-    #define OFFSET(ix) 0
+    #define INDEXER(idx,ix) idx
     #else
-    #define INDEXER(ix) NonUniformResourceIndex(ix)
-    #define OFFSET(ix) ix % 2
+    #define INDEXER(idx,ix) NonUniformResourceIndex(idx + ix%2)
     #endif
 
     // Result buffers
-    static RWStructuredBuffer<float> g_result = ResourceDescriptorHeap[13];
-    static RWStructuredBuffer<float> g_resultVS = ResourceDescriptorHeap[14];
-    static RWStructuredBuffer<float> g_resultPS = ResourceDescriptorHeap[15];
+    static RWStructuredBuffer<float> g_result = ResourceDescriptorHeap[CBIndex+1];
+    static RWStructuredBuffer<float> g_resultVS = ResourceDescriptorHeap[CBIndex+2];
+    static RWStructuredBuffer<float> g_resultPS = ResourceDescriptorHeap[CBIndex+3];
     
     static SamplerState g_samp = SamplerDescriptorHeap[CB.idx0];
     static SamplerComparisonState g_sampCmp = SamplerDescriptorHeap[CB.idx1];
@@ -3665,24 +3664,24 @@ void MSMain(uint GID : SV_GroupIndex,
     #endif // FALLBACK
 
     ROOT_SIG
-    [NumThreads(8, 8, 1)]
+    [NumThreads(2, 2, 1)]
     void main(uint ix : SV_GroupIndex) {
     
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
     
-        g_result[0] = g_rawBuf.Load<float>(0);
-        g_result[1] = g_structBuf.Load(0);
-        g_result[2] = g_tex.Load(0);
-        g_result[3] = g_rwRawBuf.Load<float>(0);
-        g_result[4] = g_rwStructBuf.Load(0);
-        g_result[5] = g_rwTex.Load(0);
-        g_result[6] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
-        g_result[7] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
+        g_result[0*2 + ix%2] = g_rawBuf.Load<float>(0);
+        g_result[1*2 + ix%2] = g_structBuf.Load(0);
+        g_result[2*2 + ix%2] = g_tex.Load(0);
+        g_result[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
+        g_result[4*2 + ix%2] = g_rwStructBuf.Load(0);
+        g_result[5*2 + ix%2] = g_rwTex.Load(0);
+        g_result[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
+        g_result[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
     }
     
     struct PSInput {
@@ -3691,26 +3690,26 @@ void MSMain(uint GID : SV_GroupIndex,
 
     ROOT_SIG
     float4 PSMain(PSInput input) : SV_TARGET {
-    
-        int x = (int)input.position.x;
-        int y = (int)input.position.y;
-        int ix = x+y;
+        int ix = WaveGetLaneIndex();
         
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
         
-        g_resultPS[0] = g_rawBuf.Load<float>(0);
-        g_resultPS[1] = g_structBuf.Load(0);
-        g_resultPS[2] = g_tex.Load(0);
-        g_resultPS[3] = g_rwRawBuf.Load<float>(0);
-        g_resultPS[4] = g_rwStructBuf.Load(0);
-        g_resultPS[5] = g_rwTex.Load(0);
-        g_resultPS[6] = g_tex.SampleLevel(g_samp, -0.5, 0) == 1.0 ? 30.0 : 0.0;
-        g_resultPS[7] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
+        // Can't control number of threads for VS / PS shaders, so
+        // make sure how ever many of threads run this, that 
+        // the result assignment variance is 2 at maximum
+        g_resultPS[0*2 + ix%2] = g_rawBuf.Load<float>(0);
+        g_resultPS[1*2 + ix%2] = g_structBuf.Load(0);
+        g_resultPS[2*2 + ix%2] = g_tex.Load(0);
+        g_resultPS[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
+        g_resultPS[4*2 + ix%2] = g_rwStructBuf.Load(0);
+        g_resultPS[5*2 + ix%2] = g_rwTex.Load(0);
+        g_resultPS[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
+        g_resultPS[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
         
         // This output doesn't actually matter
         return input.position;
@@ -3718,22 +3717,22 @@ void MSMain(uint GID : SV_GroupIndex,
     
     ROOT_SIG
     PSInput VSMain(float3 pos : POSITION, uint ix : SV_VertexID) {
-      
-        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0) + OFFSET(ix)];
-        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2) + OFFSET(ix)];
-        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4) + OFFSET(ix)];
-        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6) + OFFSET(ix)];
-        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8) + OFFSET(ix)];
-        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10) + OFFSET(ix)];
     
-        g_resultVS[0] = g_rawBuf.Load<float>(0);
-        g_resultVS[1] = g_structBuf.Load(0);
-        g_resultVS[2] = g_tex.Load(0);
-        g_resultVS[3] = g_rwRawBuf.Load<float>(0);
-        g_resultVS[4] = g_rwStructBuf.Load(0);
-        g_resultVS[5] = g_rwTex.Load(0);
-        g_resultVS[6] = g_tex.SampleLevel(g_samp, -0.5, 0) == 1.0 ? 30.0 : 0.0;
-        g_resultVS[7] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
+        ByteAddressBuffer g_rawBuf = ResourceDescriptorHeap[INDEXER(CB.idx0,ix)];
+        StructuredBuffer<float> g_structBuf = ResourceDescriptorHeap[INDEXER(CB.idx2,ix)];
+        Texture2D<float> g_tex = ResourceDescriptorHeap[INDEXER(CB.idx4,ix)];
+        RWByteAddressBuffer g_rwRawBuf = ResourceDescriptorHeap[INDEXER(CB.idx6,ix)];
+        RWStructuredBuffer<float> g_rwStructBuf = ResourceDescriptorHeap[INDEXER(CB.idx8,ix)];
+        RWTexture1D<float> g_rwTex = ResourceDescriptorHeap[INDEXER(CB.idx10,ix)];
+    
+        g_resultVS[0*2 + ix%2] = g_rawBuf.Load<float>(0);
+        g_resultVS[1*2 + ix%2] = g_structBuf.Load(0);
+        g_resultVS[2*2 + ix%2] = g_tex.Load(0);
+        g_resultVS[3*2 + ix%2] = g_rwRawBuf.Load<float>(0);
+        g_resultVS[4*2 + ix%2] = g_rwStructBuf.Load(0);
+        g_resultVS[5*2 + ix%2] = g_rwTex.Load(0);
+        g_resultVS[6*2 + ix%2] = g_tex.SampleLevel(g_samp, -0.5, 0) ? 30.0 : 0.0;;
+        g_resultVS[7*2 + ix%2] = g_tex.SampleCmpLevelZero(g_sampCmp, -0.5, 1.0) ? 31.0 : 0.0;
         PSInput r;
         r.position = float4(pos, 1); 
         return r;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9729,6 +9729,22 @@ void EnableShaderBasedValidation() {
   spDebugController1->SetEnableGPUBasedValidation(true);
 }
 
+void TestReadbackDynamicResourcesUniformAndNonUniformIndexing(int non_uniform_bit, const float* resultFloats, float *expectedResults, int expectedResultsSize)
+{
+  for (int j = 0; j < expectedResultsSize; j++)
+  {
+    if (j == expectedResultsSize-4 && !non_uniform_bit)
+    {
+      VERIFY_ARE_EQUAL(resultFloats[j],   30.0);
+      VERIFY_ARE_EQUAL(resultFloats[j+1], 30.0);
+      VERIFY_ARE_EQUAL(resultFloats[j+2], 32.0);
+      VERIFY_ARE_EQUAL(resultFloats[j+3], 32.0);
+      break;
+    }
+    VERIFY_ARE_EQUAL(resultFloats[j], expectedResults[j]);
+  } 
+}
+
 TEST_F(ExecutionTest, DynamicResourcesUniformAndNonUniformIndexingTest) {
   //EnableShaderBasedValidation();
   WEX::TestExecution::SetVerifyOutput verifySettings(
@@ -9827,20 +9843,9 @@ TEST_F(ExecutionTest, DynamicResourcesUniformAndNonUniformIndexingTest) {
 
         MappedData resultData;
         test->Test->GetReadBackData("g_result", &resultData);
-        const float *resultFloats = (float *)resultData.data();
+        const float *resultCSFloats = (float *)resultData.data();
 
-        for (unsigned int j = 0; j < expectedResultsSize; j++)
-        {
-          if (j == expectedResultsSize-4 && !non_uniform_bit)
-          {
-            VERIFY_ARE_EQUAL(resultFloats[j],   30.0);
-            VERIFY_ARE_EQUAL(resultFloats[j+1], 30.0);
-            VERIFY_ARE_EQUAL(resultFloats[j+2], 32.0);
-            VERIFY_ARE_EQUAL(resultFloats[j+3], 32.0);
-            break;
-          }
-          VERIFY_ARE_EQUAL(resultFloats[j], expectedResults[j]);
-        }
+        TestReadbackDynamicResourcesUniformAndNonUniformIndexing(non_uniform_bit, resultCSFloats, expectedResults, expectedResultsSize);
       }
 
       // Test Vertex + Pixel shader
@@ -9863,32 +9868,10 @@ TEST_F(ExecutionTest, DynamicResourcesUniformAndNonUniformIndexingTest) {
 
 
         // VS
-        for (unsigned int j = 0; j < expectedResultsSize; j++)
-        {
-          if (j == expectedResultsSize-4 && !non_uniform_bit)
-          {
-            VERIFY_ARE_EQUAL(resultVSFloats[j],   30.0);
-            VERIFY_ARE_EQUAL(resultVSFloats[j+1], 30.0);
-            VERIFY_ARE_EQUAL(resultVSFloats[j+2], 32.0);
-            VERIFY_ARE_EQUAL(resultVSFloats[j+3], 32.0);
-            break;
-          }
-          VERIFY_ARE_EQUAL(resultVSFloats[j], expectedResults[j]);
-        }
+        TestReadbackDynamicResourcesUniformAndNonUniformIndexing(non_uniform_bit, resultVSFloats, expectedResults, expectedResultsSize);
 
         // PS
-        for (unsigned int j = 0; j < expectedResultsSize; j++)
-        {
-          if (j == expectedResultsSize-4 && !non_uniform_bit)
-          {
-            VERIFY_ARE_EQUAL(resultPSFloats[j],   30.0);
-            VERIFY_ARE_EQUAL(resultPSFloats[j+1], 30.0);
-            VERIFY_ARE_EQUAL(resultPSFloats[j+2], 32.0);
-            VERIFY_ARE_EQUAL(resultPSFloats[j+3], 32.0);
-            break;
-          }
-          VERIFY_ARE_EQUAL(resultPSFloats[j], expectedResults[j]);
-        }
+        TestReadbackDynamicResourcesUniformAndNonUniformIndexing(non_uniform_bit, resultPSFloats, expectedResults, expectedResultsSize);
       }
       Skipped = false;
     }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -319,7 +319,7 @@ public:
   TEST_METHOD(HelperLaneTestWave);
   TEST_METHOD(SignatureResourcesTest)
   TEST_METHOD(DynamicResourcesTest)
-  TEST_METHOD(DynamicResourcesUniformIndexingTest)
+  TEST_METHOD(DynamicResourcesUniformAndNonUniformIndexingTest)
 
   TEST_METHOD(QuadReadTest)
   TEST_METHOD(QuadAnyAll);
@@ -9729,7 +9729,7 @@ void EnableShaderBasedValidation() {
   spDebugController1->SetEnableGPUBasedValidation(true);
 }
 
-TEST_F(ExecutionTest, DynamicResourcesUniformIndexingTest) {
+TEST_F(ExecutionTest, DynamicResourcesUniformAndNonUniformIndexingTest) {
   //EnableShaderBasedValidation();
   WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
@@ -9740,12 +9740,23 @@ TEST_F(ExecutionTest, DynamicResourcesUniformIndexingTest) {
       std::make_shared<st::ShaderOpSet>();
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
   st::ShaderOp *pShaderOp =
-      ShaderOpSet->GetShaderOp("DynamicResourcesUniformIndexing");
+      ShaderOpSet->GetShaderOp("DynamicResourcesUniformAndNonUniformIndexing");
 
   bool Skipped = true;
 
   //D3D_SHADER_MODEL TestShaderModels[] = {D3D_SHADER_MODEL_6_0}; // FALLBACK
   D3D_SHADER_MODEL TestShaderModels[] = {D3D_SHADER_MODEL_6_6};
+
+  const int expectedResultsSize = 16;
+  float expectedResults[expectedResultsSize] = {
+    10.0, 10.0, 
+    11.0, 11.0,
+    12.0, 12.0, 
+    23.0, 23.0, 
+    24.0, 24.0,
+    25.0, 25.0, 
+    30.0, 30.0, 
+    31.0, 31.0};
 
   for (unsigned i = 0; i < _countof(TestShaderModels); i++) {
     D3D_SHADER_MODEL sm = TestShaderModels[i];
@@ -9772,21 +9783,17 @@ TEST_F(ExecutionTest, DynamicResourcesUniformIndexingTest) {
     {
       pShaderOp->CS = pShaderOp->GetString("CS66");
       std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
-          pDevice, m_support, "DynamicResourcesUniformIndexing", nullptr,
+          pDevice, m_support, "DynamicResourcesUniformAndNonUniformIndexing", nullptr,
           ShaderOpSet);
 
       MappedData resultData;
       test->Test->GetReadBackData("g_result", &resultData);
       const float *resultFloats = (float *)resultData.data();
 
-      VERIFY_ARE_EQUAL(resultFloats[0], 10.0F);
-      VERIFY_ARE_EQUAL(resultFloats[1], 11.0F);
-      VERIFY_ARE_EQUAL(resultFloats[2], 12.0F);
-      VERIFY_ARE_EQUAL(resultFloats[3], 23.0F);
-      VERIFY_ARE_EQUAL(resultFloats[4], 24.0F);
-      VERIFY_ARE_EQUAL(resultFloats[5], 25.0F);
-      VERIFY_ARE_EQUAL(resultFloats[6], 30.0F);
-      VERIFY_ARE_EQUAL(resultFloats[7], 31.0F);
+      for (unsigned int i = 0; i < expectedResultsSize; i++)
+      {
+        VERIFY_ARE_EQUAL(resultFloats[i], expectedResults[i]);
+      }
     }
 
     // Test Vertex + Pixel shader
@@ -9795,7 +9802,7 @@ TEST_F(ExecutionTest, DynamicResourcesUniformIndexingTest) {
       pShaderOp->VS = pShaderOp->GetString("VS66");
       pShaderOp->PS = pShaderOp->GetString("PS66");
       std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
-          pDevice, m_support, "DynamicResourcesUniformIndexing", nullptr,
+          pDevice, m_support, "DynamicResourcesUniformAndNonUniformIndexing", nullptr,
           ShaderOpSet);
 
       MappedData resultVSData;
@@ -9809,24 +9816,16 @@ TEST_F(ExecutionTest, DynamicResourcesUniformIndexingTest) {
 
 
       // VS
-      VERIFY_ARE_EQUAL(resultVSFloats[0], 10.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[1], 11.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[2], 12.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[3], 23.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[4], 24.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[5], 25.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[6], 30.0F);
-      VERIFY_ARE_EQUAL(resultVSFloats[7], 31.0F);
+      for (unsigned int i = 0; i < expectedResultsSize; i++)
+      {
+        VERIFY_ARE_EQUAL(resultVSFloats[i], expectedResults[i]);
+      }
 
       // PS
-      VERIFY_ARE_EQUAL(resultPSFloats[0], 10.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[1], 11.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[2], 12.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[3], 23.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[4], 24.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[5], 25.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[6], 30.0F);
-      VERIFY_ARE_EQUAL(resultPSFloats[7], 31.0F);
+      for (unsigned int i = 0; i < expectedResultsSize; i++)
+      {
+        VERIFY_ARE_EQUAL(resultPSFloats[i], expectedResults[i]);
+      }
     }
     Skipped = false;
   }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9756,7 +9756,7 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
   st::ShaderOp *pShaderOp =
       ShaderOpSet->GetShaderOp("DynamicResourcesDynamicIndexing");
-  vector<st::ShaderOpRootValue> oldRootValues = pShaderOp->RootValues;
+  vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
   bool Skipped = true;
 
@@ -9813,8 +9813,7 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
     for (unsigned int non_uniform_bit = 0; non_uniform_bit < 2; non_uniform_bit++) {
       float *expectedResults = non_uniform_bit ? expectedResultsNonUniform : expectedResultsUniform;
 
-      LogCommentFmt(L"\r\nnon uniform bit is %1u",
-                  non_uniform_bit);
+      LogCommentFmt(L"Testing %s Resource Indexing.", non_uniform_bit ? L"NonUniform" : L"Uniform");
 
       // Add compile options
       std::string compilerOptions = "";
@@ -9831,13 +9830,13 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
       }
       else
       {
-         pShaderOp->RootValues = oldRootValues;
+         pShaderOp->RootValues = fallbackRootValues;
       }
 
       // Update shader target in xml.
       for (st::ShaderOpShader &S : pShaderOp->Shaders){
         S.Arguments = NULL;
-        if (compilerOptions != ""){
+        if (!compilerOptions.empty()){
           S.Arguments = pShaderOp->GetString(compilerOptions.c_str());
         }        
         // Set the target correctly. Setting here permanently overwrites


### PR DESCRIPTION
Previously, this test failed to test dynamic resources with non-uniform indices.
Now, the test runs with multiple threads, and each thread may use 1 of 2 different indices
to access a resource, depending on pixel location or thread id.
#define NON_UNIFORM 
is used to force the test to enter the Non-uniform path, which (maybe)? is a stricter test than the uniform variant.
Although, the goal is to allow the test suite to define whether or not to run this test in Uniform or NON_uniform mode depending on a define like /DNON_UNIFORM
The default mode is Uniform. 
All resources were duplicated to allow each thread the option to select one or the other duplicate. 
At this point, the Non-Fallback path is passing on NVD hardware. More testing should be done before this gets checked in.