### PR TITLE
Fix leak of DxilContainerWriter in DxbcConverter (#4400)

### DIFF
--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -247,7 +247,7 @@ void DxbcConverter::ConvertImpl(_In_reads_bytes_(DxbcSize) LPCVOID pDxbc,
 
   // Wrap LLVM module in a DXBC container.
   size_t DXILSize = DxilBuffer.size_in_bytes();
-  DxilContainerWriter *pContainerWriter = hlsl::NewDxilContainerWriter();
+  std::unique_ptr<DxilContainerWriter> pContainerWriter(hlsl::NewDxilContainerWriter());
   pContainerWriter->AddPart(DXBC_DXIL, DXILSize, [=](AbstractMemoryStream *pStream) {
     WritePart(pStream, DxilBuffer);
   });


### PR DESCRIPTION
(cherry picked from commit 0c6435124770e9b3edb8dc1e8139d0d0f0e980c9)