### PR TITLE
Teach llvm-dis to read DXIL out of DXBC files

### DIFF
--- a/tools/llvm-dis/CMakeLists.txt
+++ b/tools/llvm-dis/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   BitReader
   Core
+  DxilContainer
   Support
   MSSupport # HLSL Change
   )

--- a/tools/llvm-dis/llvm-dis.cpp
+++ b/tools/llvm-dis/llvm-dis.cpp
@@ -34,6 +34,7 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "dxc/DxilContainer/DxilContainer.h" // HLSL Change
 #include <system_error>
 using namespace llvm;
 
@@ -162,23 +163,37 @@ int __cdecl main(int argc, char **argv) { // HLSL Change - __cdecl
   std::string ErrorMessage;
   std::unique_ptr<Module> M;
 
-  // Use the bitcode streaming interface
-  std::unique_ptr<DataStreamer> Streamer =
-      getDataFileStreamer(InputFilename, &ErrorMessage);
-  if (Streamer) {
-    std::string DisplayFilename;
-    if (InputFilename == "-")
-      DisplayFilename = "<stdin>";
-    else
-      DisplayFilename = InputFilename;
-    ErrorOr<std::unique_ptr<Module>> MOrErr =
-        getStreamedBitcodeModule(DisplayFilename, std::move(Streamer), Context);
-    M = std::move(*MOrErr);
-    M->materializeAllPermanently();
-  } else {
-    errs() << argv[0] << ": " << ErrorMessage << '\n';
+  ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrErr =
+      MemoryBuffer::getFileOrSTDIN(InputFilename);
+  if (std::error_code EC = FileOrErr.getError()) {
+    errs() << argv[0] << ": "
+           << "Could not open file '" << InputFilename << "': " << EC.message()
+           << '\n';
     return 1;
   }
+
+  std::unique_ptr<MemoryBuffer> &Buf = FileOrErr.get();
+  MemoryBufferRef BitcodeData = Buf->getMemBufferRef();
+  if (Buf->getBuffer().startswith("DXBC")) {
+    // move along until I get to the bitcode
+    const hlsl::DxilContainerHeader *Header =
+        reinterpret_cast<const hlsl::DxilContainerHeader *>(Buf->getBufferStart());
+    const hlsl::DxilProgramHeader *DXILHeader =
+        hlsl::GetDxilProgramHeader(Header, hlsl::DFCC_DXIL);
+    StringRef DXILData = StringRef(hlsl::GetDxilBitcodeData(DXILHeader),
+                                   hlsl::GetDxilBitcodeSize(DXILHeader));
+    BitcodeData = MemoryBufferRef(DXILData, "");
+  }
+
+  ErrorOr<std::unique_ptr<Module>> MOrErr =
+      parseBitcodeFile(BitcodeData, Context);
+  if (std::error_code EC = MOrErr.getError()) {
+    errs() << argv[0] << ": "
+           << "Could not load bitcode from file '" << InputFilename
+           << "': " << EC.message() << '\n';
+  }
+  M = std::move(*MOrErr);
+  M->materializeAllPermanently();
 
   // Just use stdout.  We won't actually print anything on it.
   if (DontPrint)

--- a/tools/llvm-dis/llvm-dis.cpp
+++ b/tools/llvm-dis/llvm-dis.cpp
@@ -180,6 +180,11 @@ int __cdecl main(int argc, char **argv) { // HLSL Change - __cdecl
         reinterpret_cast<const hlsl::DxilContainerHeader *>(Buf->getBufferStart());
     const hlsl::DxilProgramHeader *DXILHeader =
         hlsl::GetDxilProgramHeader(Header, hlsl::DFCC_DXIL);
+    if (!DXILHeader) {
+      errs() << argv[0] << ": DXBC file '" << InputFilename
+             << "': Does not contain DXIL part\n";
+      return 1;
+    }
     StringRef DXILData = StringRef(hlsl::GetDxilBitcodeData(DXILHeader),
                                    hlsl::GetDxilBitcodeSize(DXILHeader));
     BitcodeData = MemoryBufferRef(DXILData, "");
@@ -191,6 +196,7 @@ int __cdecl main(int argc, char **argv) { // HLSL Change - __cdecl
     errs() << argv[0] << ": "
            << "Could not load bitcode from file '" << InputFilename
            << "': " << EC.message() << '\n';
+    return 1;
   }
   M = std::move(*MOrErr);
   M->materializeAllPermanently();


### PR DESCRIPTION
This change has no impact on the DXC codebase since we don't use
llvm-dis here, but in LLVM upstream I'm using llvm-dis from DXC to
verify bitcode compatability.

The change here is to intercept the file passed into llvm-dis to detect
DXIL Container files, and read the bitcode out of the DXIL part.