### PR TITLE
Fix use constant corruption from ReplaceUsesForLoweredUDT

### DIFF
--- a/lib/HLSL/HLLowerUDT.cpp
+++ b/lib/HLSL/HLLowerUDT.cpp
@@ -293,7 +293,7 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
               ConstantExpr::getBitCast(cast<Constant>(NewV), CE->getType()));
         }
       } else {
-        DXASSERT(0, "unhandled constant expr for lowered UTD");
+        DXASSERT(0, "unhandled constant expr for lowered UDT");
         // better than infinite loop on release
         CE->replaceAllUsesWith(UndefValue::get(CE->getType()));
       }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/as-groupshared-payload-method.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/as-groupshared-payload-method.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T as_6_5 %s | FileCheck %s
+
+// Ensure groupshared payload still accepted when initialized with method.
+// CHECK: @[[g_payload:.*]] = addrspace(3) global
+// CHECK: store i32 {{.*}} i32 addrspace(3)*
+// CHECK: store i32 {{.*}} i32 addrspace(3)*
+// CHECK: call void @dx.op.dispatchMesh
+// CHECK-SAME: addrspace(3)* nonnull @[[g_payload]]
+
+struct SharedPayload
+{
+  uint2 m_a;
+
+  void Foo( in float3 v3 )
+  {
+    uint3 f16Vec3 = f32tof16(v3);
+    m_a.x = f16Vec3.x | (f16Vec3.y<<16);
+    m_a.y = f16Vec3.z;
+  }
+};
+
+groupshared SharedPayload g_payload;
+
+[numthreads(8, 8, 1)]
+void main()
+{
+  g_payload.Foo( 1.0.xxx );
+  DispatchMesh(1,1,1,g_payload);
+}


### PR DESCRIPTION
ReplaceUsesForLoweredUDT was calling use.set(NewV), or calling dropAllReferences() on constant user.
This results in modification of the constant operand, which is illegal and led to corruption of constants.

Loop in ReplaceUsesForLoweredUDT relies on all uses being eliminated to terminate, so constant or potentially constant users are now handled with legal replacements and removeDeadConstantUsers at the end as needed.

Fixes #4421 