### PR TITLE
Fix broken ternary on matrix return type (#4434)

### DIFF
--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -3732,14 +3732,6 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
     }
   }
 
-  llvm::Instruction *ResultAlloca = nullptr;
-  if (CGF.getLangOpts().HLSL && CGF.getLangOpts().EnableShortCircuit &&
-      hlsl::IsHLSLMatType(E->getType())) {
-    llvm::Type *MatTy = CGF.ConvertTypeForMem(E->getType());
-    ResultAlloca = Builder.CreateAlloca(MatTy);
-    ResultAlloca->moveBefore(hlsl::dxilutil::FindAllocaInsertionPt(
-        Builder.GetInsertBlock()->getParent()));
-  }
   // HLSL Change Ends
 
   // If this is a really simple expression (like x ? 4 : 5), emit this as a
@@ -3759,6 +3751,17 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
     }
     return Builder.CreateSelect(CondV, LHS, RHS, "cond");
   }
+
+  // HLSL Change Begins
+  llvm::Instruction *ResultAlloca = nullptr;
+  if (CGF.getLangOpts().HLSL && CGF.getLangOpts().EnableShortCircuit &&
+      hlsl::IsHLSLMatType(E->getType())) {
+    llvm::Type *MatTy = CGF.ConvertTypeForMem(E->getType());
+    ResultAlloca = CGF.CreateTempAlloca(MatTy);
+    ResultAlloca->moveBefore(hlsl::dxilutil::FindAllocaInsertionPt(
+        Builder.GetInsertBlock()->getParent()));
+  }
+  // HLSL Change Ends
 
   llvm::BasicBlock *LHSBlock = CGF.createBasicBlock("cond.true");
   llvm::BasicBlock *RHSBlock = CGF.createBasicBlock("cond.false");

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -25,6 +25,7 @@
 #include "clang/AST/StmtVisitor.h"
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Frontend/CodeGenOptions.h"
+#include "dxc/DXIL/DxilUtil.h" // HLSL Change
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
@@ -3731,11 +3732,13 @@ VisitAbstractConditionalOperator(const AbstractConditionalOperator *E) {
     }
   }
 
-  llvm::Value *ResultAlloca = nullptr;
+  llvm::Instruction *ResultAlloca = nullptr;
   if (CGF.getLangOpts().HLSL && CGF.getLangOpts().EnableShortCircuit &&
       hlsl::IsHLSLMatType(E->getType())) {
-    llvm::Type *MatTy = CGF.ConvertType(E->getType());
+    llvm::Type *MatTy = CGF.ConvertTypeForMem(E->getType());
     ResultAlloca = Builder.CreateAlloca(MatTy);
+    ResultAlloca->moveBefore(hlsl::dxilutil::FindAllocaInsertionPt(
+        Builder.GetInsertBlock()->getParent()));
   }
   // HLSL Change Ends
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
@@ -12,11 +12,11 @@ float2x2 crashingFunction(bool b) {
 }
 
 // CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction@@YA?AV?$matrix@M$01$01@@_N@Z"
-// CHECK: [[ALLOCA:%[0-9]+]] = alloca %class.matrix.float.2.2
+// CHECK: [[ALLOCA:%[0-9a-z]+]] = alloca %class.matrix.float.2.2
 // CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
 // CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
 // CHECK: preds = {{%[0-9a-z.]+}}, {{%[0-9a-z.]+}}
-// call %class.matrix.float.2.2 @"dx.hl.matldst.colLoad.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*)"(i32 0, %class.matrix.float.2.2* [[ALLOCA]])
+// CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colLoad.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*)"(i32 0, %class.matrix.float.2.2* [[ALLOCA]])
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
@@ -13,10 +13,10 @@ float2x2 crashingFunction(bool b) {
 
 // CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction@@YA?AV?$matrix@M$01$01@@_N@Z"
 // CHECK: [[ALLOCA:%[0-9]+]] = alloca %class.matrix.float.2.2, !dbg !{{[0-9]+}} ; line:6 col:10
-// CHECK: cond.true:
+// CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
-// CHECK: cond.false:
+// CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
-// CHECK: cond.end:
+// CHECK: preds = {{%[0-9a-z.]+}}, {{%[0-9a-z.]+}}
 // call %class.matrix.float.2.2 @"dx.hl.matldst.colLoad.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*)"(i32 0, %class.matrix.float.2.2* [[ALLOCA]])
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
@@ -12,7 +12,7 @@ float2x2 crashingFunction(bool b) {
 }
 
 // CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction@@YA?AV?$matrix@M$01$01@@_N@Z"
-// CHECK: [[ALLOCA:%[0-9]+]] = alloca %class.matrix.float.2.2, !dbg !{{[0-9]+}} ; line:6 col:10
+// CHECK: [[ALLOCA:%[0-9]+]] = alloca %class.matrix.float.2.2
 // CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
 // CHECK: preds = {{%[0-9a-z]+}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T cs_6_0 -E CSMain -HV 2021 %s -fcgl | FileCheck %s
+
+float2x2 crashingFunction(bool b) {
+  float2x2 x = {0.0, 0.0, 0.0, 0.0};
+  float2x2 y = {0.0, 0.0, 0.0, 0.0};
+  return b ? x : y; // <-- this is the issue
+}
+
+[numthreads(1, 1, 1)] void CSMain() {
+  if (crashingFunction(true)[0][0] > 0)
+    return;
+}
+
+// CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction@@YA?AV?$matrix@M$01$01@@_N@Z"
+// CHECK: [[ALLOCA:%[0-9]+]] = alloca %class.matrix.float.2.2, !dbg !{{[0-9]+}} ; line:6 col:10
+// CHECK: cond.true:
+// CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
+// CHECK: cond.false:
+// CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})
+// CHECK: cond.end:
+// call %class.matrix.float.2.2 @"dx.hl.matldst.colLoad.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*)"(i32 0, %class.matrix.float.2.2* [[ALLOCA]])
+


### PR DESCRIPTION
HLSL ternary operators that result in vector or matrix types need
special handling even if the condition is not a vector. This change
allows vector and matrix result types for ternary operators even if
matrix and vector conditions are not allowed.

Preventing matrix and vector conditions is done in Sema, so we should
never be able to reach this code path with a matrix or vector condition
unless the HLSL language version is < 2021.

Fixes #4434