### PR TITLE
Fix lifetime marker detection causing other users to be missed

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -2395,7 +2395,7 @@ static bool ValidateType(Type *Ty, ValidationContext &ValCtx, bool bInner = fals
   }
   if (Ty->isArrayTy()) {
     Type *EltTy = Ty->getArrayElementType();
-    if (!bInner && !ValCtx.isLibProfile && isa<ArrayType>(EltTy)) {
+    if (!bInner && isa<ArrayType>(EltTy)) {
       // Outermost array should be converted to single-dim,
       // but arrays inside struct are allowed to be multi-dim
       ValCtx.EmitTypeError(Ty, ValidationRule::TypesNoMultiDim);

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -2395,7 +2395,7 @@ static bool ValidateType(Type *Ty, ValidationContext &ValCtx, bool bInner = fals
   }
   if (Ty->isArrayTy()) {
     Type *EltTy = Ty->getArrayElementType();
-    if (!bInner && isa<ArrayType>(EltTy)) {
+    if (!bInner && !ValCtx.isLibProfile && isa<ArrayType>(EltTy)) {
       // Outermost array should be converted to single-dim,
       // but arrays inside struct are allowed to be multi-dim
       ValCtx.EmitTypeError(Ty, ValidationRule::TypesNoMultiDim);

--- a/lib/Transforms/Scalar/DxilLoopUnroll.cpp
+++ b/lib/Transforms/Scalar/DxilLoopUnroll.cpp
@@ -574,7 +574,7 @@ static bool BreakUpArrayAllocas(bool AllowOOBIndex, IteratorT ItBegin, IteratorT
       }
 
       // Ignore uses that are only used by lifetime intrinsics.
-      if (onlyUsedByLifetimeMarkers(U))
+      if (isa<BitCastInst>(U) && onlyUsedByLifetimeMarkers(U))
         continue;
 
       // We've found something that prevents us from safely replacing this alloca.

--- a/lib/Transforms/Scalar/HoistConstantArray.cpp
+++ b/lib/Transforms/Scalar/HoistConstantArray.cpp
@@ -215,7 +215,7 @@ void CandidateArray::GetArrayStores(GEPOperator *gep,
 bool CandidateArray::AllArrayUsersAreGEPOrLifetime(std::vector<GEPOperator *> &geps) {
   for (User *U : m_Alloca->users()) {
     // Allow users that are only used by lifetime intrinsics.
-    if (onlyUsedByLifetimeMarkers(U))
+    if (isa<BitCastInst>(U) && onlyUsedByLifetimeMarkers(U))
       continue;
 
     GEPOperator *gep = dyn_cast<GEPOperator>(U);

--- a/lib/Transforms/Scalar/LowerTypePasses.cpp
+++ b/lib/Transforms/Scalar/LowerTypePasses.cpp
@@ -540,15 +540,15 @@ protected:
 // Recurse users, looking for any direct users of array or sub-array type,
 // other than lifetime markers:
 bool MultiDimArrayToOneDimArray::isSafeToLowerArray(Value *V) {
-  if (isa<BitCastOperator>(V))
-    if (!onlyUsedByLifetimeMarkers(V))
-      return false;
   if (!V->getType()->getPointerElementType()->isArrayTy())
     return true;
   for (auto it = V->user_begin(); it != V->user_end();) {
     User *U = *it++;
-    if (isa<GEPOperator>(U) || isa<BitCastOperator>(V) ||
-        isa<AddrSpaceCastInst>(U) || isa<ConstantExpr>(U)) {
+    if (isa<BitCastOperator>(U)) {
+      // Bitcast is ok because source type can be changed.
+      continue;
+    } else if (isa<GEPOperator>(U) || isa<AddrSpaceCastInst>(U) ||
+               isa<ConstantExpr>(U)) {
       if (!isSafeToLowerArray(U))
         return false;
     } else {

--- a/lib/Transforms/Scalar/LowerTypePasses.cpp
+++ b/lib/Transforms/Scalar/LowerTypePasses.cpp
@@ -543,7 +543,7 @@ bool MultiDimArrayToOneDimArray::isSafeToLowerArray(Value *V) {
   if (isa<BitCastOperator>(V))
     if (!onlyUsedByLifetimeMarkers(V))
       return false;
-  if (!V->getType()->isArrayTy())
+  if (!V->getType()->getPointerElementType()->isArrayTy())
     return true;
   for (auto it = V->user_begin(); it != V->user_end();) {
     User *U = *it++;

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
@@ -1,0 +1,53 @@
+// RUN: %dxc -T lib_6_x %s | FileCheck %s
+
+// Ensure 2d array is supported.
+
+// Ensure BreakUpArrayAllocas doesn't misfire and ignore the function call
+// users, causing everything but the calls to be moved to separate scalar
+// arrays, then all that code, being dead, getting deleted, leaving just the
+// passing of uninitialized arrays to the function calls.
+
+// CHECK-DAG: %[[h0:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
+// CHECK-DAG: %[[h1:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
+// CHECK-DAG: %[[h2:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
+// CHECK-DAG: %[[h3:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
+// CHECK-DAG: %[[gep0:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 0, i32 0
+// CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]], align 8
+// CHECK-DAG: %[[gep1:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 0, i32 1
+// CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]], align 8
+// CHECK-DAG: %[[gep2:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 1, i32 0
+// CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]], align 8
+// CHECK-DAG: %[[gep3:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 1, i32 1
+// CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]], align 8
+// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
+// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
+// CHECK: %[[h10:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]], align 8
+// CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]], align 8
+// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
+// CHECK: %[[h01:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]], align 8
+// CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]], align 8
+// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
+
+void useArray(RWStructuredBuffer<float4> buffers[2][2]);
+
+RWStructuredBuffer<float4> buf0;
+RWStructuredBuffer<float4> buf1;
+RWStructuredBuffer<float4> buf2;
+RWStructuredBuffer<float4> buf3;
+uint g_cond;
+
+[shader("pixel")]
+float main() : SV_Target {
+
+  RWStructuredBuffer<float4> buffers[2][2] = { buf0, buf1, buf2, buf3, };
+
+  [unroll]
+  for (uint j = 0; j < 4; j++) {
+    useArray(buffers);
+    if (g_cond == j) {
+      buffers[j/2][j%2] = buffers[j%2][j/2];
+    }
+  }
+
+  return 0;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
@@ -7,26 +7,27 @@
 // arrays, then all that code, being dead, getting deleted, leaving just the
 // passing of uninitialized arrays to the function calls.
 
-// CHECK-DAG: %[[h0:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
-// CHECK-DAG: %[[h1:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
-// CHECK-DAG: %[[h2:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
-// CHECK-DAG: %[[h3:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
-// CHECK-DAG: %[[gep0:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 0, i32 0
+// CHECK-DAG: %[[h0:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
+// CHECK-DAG: %[[h1:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
+// CHECK-DAG: %[[h2:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
+// CHECK-DAG: %[[h3:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
+// CHECK: %[[buffers:.+]] = alloca [2 x [2 x %dx.types.Handle]]
+// CHECK-DAG: %[[gep0:.+]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %[[buffers]], i32 0, i32 0, i32 0
 // CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]], align 8
-// CHECK-DAG: %[[gep1:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 0, i32 1
+// CHECK-DAG: %[[gep1:.+]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %[[buffers]], i32 0, i32 0, i32 1
 // CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]], align 8
-// CHECK-DAG: %[[gep2:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 1, i32 0
+// CHECK-DAG: %[[gep2:.+]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %[[buffers]], i32 0, i32 1, i32 0
 // CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]], align 8
-// CHECK-DAG: %[[gep3:.*]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %buffers, i32 0, i32 1, i32 1
+// CHECK-DAG: %[[gep3:.+]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %[[buffers]], i32 0, i32 1, i32 1
 // CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]], align 8
-// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
-// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
-// CHECK: %[[h10:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]], align 8
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
+// CHECK: %[[h10:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]], align 8
 // CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]], align 8
-// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
-// CHECK: %[[h01:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]], align 8
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
+// CHECK: %[[h01:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]], align 8
 // CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]], align 8
-// CHECK: call void @"\01?useArray@@YAXY111V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x [2 x %dx.types.Handle]]* nonnull %buffers)
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
 
 void useArray(RWStructuredBuffer<float4> buffers[2][2]);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
@@ -1,0 +1,51 @@
+// RUN: %dxc -T lib_6_x %s | FileCheck %s
+
+// Ensure 2d array is broken down into 2 1d arrays, properly initialized,
+// modified, and passed to function calls
+
+// CHECK-DAG: %[[h0:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
+// CHECK-DAG: %[[h1:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
+// CHECK-DAG: %[[h2:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
+// CHECK-DAG: %[[h3:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
+// CHECK: %[[a1:.*]] = alloca [2 x %dx.types.Handle]
+// CHECK: %[[a0:.*]] = alloca [2 x %dx.types.Handle]
+// CHECK-DAG: %[[gep0:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 0
+// CHECK-DAG: %[[gep1:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 1
+// CHECK-DAG: %[[gep2:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 0
+// CHECK-DAG: %[[gep3:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 1
+// CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]]
+// CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]]
+// CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]]
+// CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]]
+// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a1]])
+// CHECK: %[[h10:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]]
+// CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]]
+// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: %[[h01:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]]
+// CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]]
+// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a1]])
+
+void useArray(RWStructuredBuffer<float4> buffers[2]);
+
+RWStructuredBuffer<float4> buf0;
+RWStructuredBuffer<float4> buf1;
+RWStructuredBuffer<float4> buf2;
+RWStructuredBuffer<float4> buf3;
+uint g_cond;
+
+[shader("pixel")]
+float main() : SV_Target {
+
+  RWStructuredBuffer<float4> buffers[2][2] = { buf0, buf1, buf2, buf3, };
+
+  [unroll]
+  for (uint j = 0; j < 4; j++) {
+    useArray(buffers[j%2]);
+    if (g_cond == j) {
+      buffers[j/2][j%2] = buffers[j%2][j/2];
+    }
+  }
+
+  return 0;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
@@ -3,28 +3,28 @@
 // Ensure 2d array is broken down into 2 1d arrays, properly initialized,
 // modified, and passed to function calls
 
-// CHECK-DAG: %[[h0:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
-// CHECK-DAG: %[[h1:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
-// CHECK-DAG: %[[h2:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
-// CHECK-DAG: %[[h3:.*]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
-// CHECK: %[[a1:.*]] = alloca [2 x %dx.types.Handle]
-// CHECK: %[[a0:.*]] = alloca [2 x %dx.types.Handle]
-// CHECK-DAG: %[[gep0:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 0
-// CHECK-DAG: %[[gep1:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 1
-// CHECK-DAG: %[[gep2:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 0
-// CHECK-DAG: %[[gep3:.*]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 1
+// CHECK-DAG: %[[h0:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf0
+// CHECK-DAG: %[[h1:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
+// CHECK-DAG: %[[h2:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
+// CHECK-DAG: %[[h3:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
+// CHECK: %[[a1:.+]] = alloca [2 x %dx.types.Handle]
+// CHECK: %[[a0:.+]] = alloca [2 x %dx.types.Handle]
+// CHECK-DAG: %[[gep0:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 0
+// CHECK-DAG: %[[gep1:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 1
+// CHECK-DAG: %[[gep2:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 0
+// CHECK-DAG: %[[gep3:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 1
 // CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]]
 // CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]]
 // CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]]
 // CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]]
-// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a0]])
-// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a1]])
-// CHECK: %[[h10:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]]
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
+// CHECK: %[[h10:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]]
 // CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]]
-// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a0]])
-// CHECK: %[[h01:.*]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]]
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: %[[h01:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]]
 // CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]]
-// CHECK: call void @"\01?useArray@@YAXY01V?$RWStructuredBuffer@V?$vector@M$03@@@@@Z"([2 x %dx.types.Handle]* nonnull %[[a1]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
 
 void useArray(RWStructuredBuffer<float4> buffers[2]);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/return_type/array/lib_function_call.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/return_type/array/lib_function_call.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck %s
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s
+
+// Tests that we don't drop an array result when calling an external function returning an array.
+
+// CHECK: call void
+// CHECK-SAME: getA
+// CHECK-SAME: ([2 x i32]* nonnull sret %[[tmp:.*]])
+// CHECK: %[[arrayidx:.*]] = getelementptr inbounds [2 x i32], [2 x i32]* %[[tmp]], i32 0, i32 0
+// CHECK: %[[val:.*]] = load i32, i32* %[[arrayidx]]
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 %[[val]])
+
+export int getA() [2];
+
+[shader("vertex")]
+int main() : OUT {
+  return getA()[0];
+}


### PR DESCRIPTION
The codepath to detect lifetime-marker only uses (bitcast -> lifetime intrinsic), failed to check the instruction itself, which could be a user function call directly using the alloca ptr instead of the expected bitcast for the lifetime marker scenario.
If that user function call was unused (for instance, if it returns void), then it will improperly assume that the instruction is inconsequential and only used by lifetime markers, or is unused, thus doesn't matter.

The fix is to only check onlyUsedByLifetimeMarkers if the instruction is a bitcast, since that's the pattern for lifetime marker use on the alloca.  If the bitcast is unused, that's also safe to continue, since it does nothing on its own.

BreakUpArrayAllocas during DxilLoopUnroll had the same issue.  Targeting and testing this led to several issues (crashes) around multi-dimensional arrays and library paths.  For now, there is no simple way to pass multi-dimensional arrays directly to function calls across library boundaries, without either relaxing validation or lowering function parameter types.  However, it's legal to use the offline-linking target with these, and that scenario shouldn't crash or generate bad code.

Tests have been added for multi-dim resource array passing and passing of a sub-array type to a user function, which both used to crash or assert.