### PR TITLE
change filter comparison type for samplers, update test name

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3579,10 +3579,10 @@ void MSMain(uint GID : SV_GroupIndex,
     </DescriptorHeap>
 
     <DescriptorHeap Name="SamplerDescriptorHeap" Type="SAMPLER">
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="30.0" />
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="31.0" />
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="32.0" ComparisonFunc="EQUAL" Filter="COMPARISON_ANISOTROPIC"/>
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="33.0" ComparisonFunc="EQUAL" Filter="COMPARISON_ANISOTROPIC"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="30.0" Filter="MIN_MAG_MIP_POINT"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="31.0" Filter="MIN_MAG_MIP_POINT" />
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="32.0" ComparisonFunc="EQUAL" Filter="COMPARISON_MIN_MAG_MIP_POINT"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="33.0" ComparisonFunc="EQUAL" Filter="COMPARISON_MIN_MAG_MIP_POINT"/>
     </DescriptorHeap>
     
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3581,8 +3581,8 @@ void MSMain(uint GID : SV_GroupIndex,
     <DescriptorHeap Name="SamplerDescriptorHeap" Type="SAMPLER">
       <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="30.0" />
       <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="31.0" />
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="32.0" ComparisonFunc="EQUAL"/>
-      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="33.0" ComparisonFunc="EQUAL"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="32.0" ComparisonFunc="EQUAL" Filter="COMPARISON_ANISOTROPIC"/>
+      <Descriptor Kind="SAMPLER" AddressU="BORDER" AddressV="BORDER" BorderColorR="33.0" ComparisonFunc="EQUAL" Filter="COMPARISON_ANISOTROPIC"/>
     </DescriptorHeap>
     
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -9878,7 +9878,7 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
   unsigned num_models_to_test = ExecutionTest::IsFallbackPathEnabled() ? 2 : 1;
   for (unsigned i = 0; i < num_models_to_test; i++) {
     D3D_SHADER_MODEL sm = TestShaderModels[i];
-    LogCommentFmt(L"\r\nVerifying Dynamic Resources Uniform Indexing in shader "
+    LogCommentFmt(L"\r\nVerifying Dynamic Resources Dynamic Indexing in shader "
                   L"model 6.%1u",
                   ((UINT)sm & 0x0f));
 


### PR DESCRIPTION
Previously, no filter was specified for the samplers that perform a comparison. So, the filter defaulted to D3D_FILTER_ANISOTROPIC. The filter type should be D3D_FILTER_COMPARISON_ANISOTROPIC instead.