### PR TITLE
Replaced some code in dxil-cond-mem2reg with a dxilutils helper. Fixed a crash.

### DIFF
--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1061,8 +1061,9 @@ bool DeleteDeadAllocas(llvm::Function &F) {
 
   while (1) {
     bool LocalChanged = false;
-    for (auto it = Entry.begin(), end = Entry.end(); it != end;) {
-      AllocaInst *AI = dyn_cast<AllocaInst>(&*(it++));
+    for (Instruction *it = &Entry.back(); it;) {
+      AllocaInst *AI = dyn_cast<AllocaInst>(it);
+      it = it->getPrevNode();
       if (!AI)
         continue;
       LocalChanged |= Deleter.TryDeleteUnusedAlloca(AI);

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1022,6 +1022,12 @@ struct AllocaDeleter {
         for (User *U : V->users())
           Add(U);
       }
+      else if (MemCpyInst *MC = dyn_cast<MemCpyInst>(V)) {
+        // If the memcopy's source is anything we've encountered in the
+        // seen set, then the alloca is being read.
+        if (Seen.count(MC->getSource()))
+          return false;
+      }
       // If it's anything else, we'll assume it's reading the
       // alloca. Give up.
       else {

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas.ll
@@ -1,0 +1,118 @@
+; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
+
+; Regression test for a crash in dxilutil::DeleteDeadAllocas
+
+; CHECK: @main
+; CHECK-NOT: = alloca
+
+; ModuleID = 'F:\test\od_fails_may_2022\simple.hlsl'
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%cb = type { [5 x float] }
+%dx.types.Handle = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+
+@cb = external constant %cb
+
+; Function Attrs: nounwind readnone
+declare %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32, %dx.types.Handle, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32, %cb*, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb) #0
+
+; Function Attrs: convergent
+declare void @dx.noop() #1
+
+; Function Attrs: nounwind
+define void @main(float* noalias) #2 {
+entry:
+  %retval = alloca float, align 4, !dx.temp !3
+  %alloca = alloca [5 x float], align 4
+
+  ; Test is here. There was a crash when a user is immediately after the alloca
+  ; when calling dxilutil::DeleteDeadAllocas, because we deleted instructions
+  ; in the forward order.
+  %my_index = getelementptr inbounds [5 x float], [5 x float]* %alloca, i32 0, i32 0
+  store float %7, float* %my_index, align 4
+
+  %i = alloca i32, align 4
+  %1 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32 0, %cb* @cb, i32 0)
+  %2 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32 11, %dx.types.Handle %1, %dx.types.ResourceProperties { i32 13, i32 68 }, %cb undef)
+  %3 = call %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32 6, %dx.types.Handle %2, i32 0)
+  %4 = getelementptr inbounds %cb, %cb* %3, i32 0, i32 0, i32 0
+  call void @dx.noop(), !dbg !4
+  store i32 0, i32* %i, align 4, !dbg !4
+  %5 = load i32, i32* %i, align 4, !dbg !8
+  %cmp.1 = icmp slt i32 %5, 5, !dbg !9
+  br i1 %cmp.1, label %for.body.lr.ph, label %for.end, !dbg !10
+
+for.body.lr.ph:                                   ; preds = %entry
+  br label %for.body, !dbg !10
+
+for.body:                                         ; preds = %for.body.lr.ph, %for.inc
+  %6 = load i32, i32* %i, align 4, !dbg !11
+  %arrayidx3 = getelementptr inbounds %cb, %cb* %3, i32 0, i32 0, i32 %6, !dbg !12
+  %7 = load float, float* %arrayidx3, align 4, !dbg !12
+  %8 = load i32, i32* %i, align 4, !dbg !13
+  %arrayidx2 = getelementptr inbounds [5 x float], [5 x float]* %alloca, i32 0, i32 %8, !dbg !14
+  call void @dx.noop(), !dbg !15
+  store float %7, float* %arrayidx2, align 4, !dbg !15
+  br label %for.inc, !dbg !16
+
+for.inc:                                          ; preds = %for.body
+  %9 = load i32, i32* %i, align 4, !dbg !17
+  %inc = add nsw i32 %9, 1, !dbg !17
+  call void @dx.noop(), !dbg !17
+  store i32 %inc, i32* %i, align 4, !dbg !17
+  %10 = load i32, i32* %i, align 4, !dbg !8
+  %cmp = icmp slt i32 %10, 5, !dbg !9
+  %tobool = icmp ne i1 %cmp, false, !dbg !9
+  %tobool1 = icmp ne i1 %tobool, false, !dbg !10
+  br i1 %tobool1, label %for.body, label %for.cond.for.end_crit_edge, !dbg !10, !llvm.loop !18
+
+for.cond.for.end_crit_edge:                       ; preds = %for.inc
+  br label %for.end, !dbg !10
+
+for.end:                                          ; preds = %for.cond.for.end_crit_edge, %entry
+  %11 = load float, float* %4, align 4, !dbg !20
+  store float %11, float* %retval, !dbg !21
+  %12 = load float, float* %retval, !dbg !21
+  call void @dx.noop(), !dbg !21
+  store float %12, float* %0, !dbg !21
+  ret void, !dbg !21
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { convergent }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!pauseresume = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{!"hlsl-hlemit", !"hlsl-hlensure"}
+!2 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
+!3 = !{}
+!4 = !DILocation(line: 9, column: 12, scope: !5)
+!5 = !DISubprogram(name: "main", scope: !6, file: !6, line: 6, type: !7, isLocal: false, isDefinition: true, scopeLine: 6, flags: DIFlagPrototyped, isOptimized: false, function: void (float*)* @main)
+!6 = !DIFile(filename: "F:\5Ctest\5Cod_fails_may_2022\5Csimple.hlsl", directory: "")
+!7 = !DISubroutineType(types: !3)
+!8 = !DILocation(line: 9, column: 19, scope: !5)
+!9 = !DILocation(line: 9, column: 21, scope: !5)
+!10 = !DILocation(line: 9, column: 3, scope: !5)
+!11 = !DILocation(line: 10, column: 21, scope: !5)
+!12 = !DILocation(line: 10, column: 17, scope: !5)
+!13 = !DILocation(line: 10, column: 12, scope: !5)
+!14 = !DILocation(line: 10, column: 5, scope: !5)
+!15 = !DILocation(line: 10, column: 15, scope: !5)
+!16 = !DILocation(line: 11, column: 3, scope: !5)
+!17 = !DILocation(line: 9, column: 27, scope: !5)
+!18 = distinct !{!18, !19}
+!19 = !{!"llvm.loop.unroll.disable"}
+!20 = !DILocation(line: 13, column: 10, scope: !5)
+!21 = !DILocation(line: 13, column: 3, scope: !5)

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas.ll
@@ -5,7 +5,6 @@
 ; CHECK: @main
 ; CHECK-NOT: = alloca
 
-; ModuleID = 'F:\test\od_fails_may_2022\simple.hlsl'
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas_memcpy.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas_memcpy.ll
@@ -1,0 +1,121 @@
+; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
+
+; Make sure that dxilutil::DeleteDeadAllocas handles memcpy's
+
+; CHECK: @main
+; CHECK-NOT: = alloca %struct.Data
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Data = type { [5 x float] }
+%ConstantBuffer = type opaque
+%cb = type { %struct.Data, %struct.Data }
+%dx.types.Handle = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+
+@"\01?foo@cb@@3UData@@B" = external global %struct.Data, align 4
+@"\01?bar@cb@@3UData@@B" = external global %struct.Data, align 4
+@"$Globals" = external constant %ConstantBuffer
+@cb = external constant %cb
+
+; Function Attrs: nounwind
+define float @main() #0 {
+entry:
+  %0 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32 0, %cb* @cb, i32 0)
+  %1 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32 11, %dx.types.Handle %0, %dx.types.ResourceProperties { i32 13, i32 148 }, %cb undef)
+  %2 = call %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32 6, %dx.types.Handle %1, i32 0)
+  %3 = getelementptr inbounds %cb, %cb* %2, i32 0, i32 0
+  %4 = getelementptr inbounds %cb, %cb* %2, i32 0, i32 1, i32 0, i32 0
+  %retval = alloca float, align 4, !dx.temp !3
+  %alloca = alloca %struct.Data, align 4
+  %i = alloca i32, align 4
+  %5 = bitcast %struct.Data* %alloca to i8*, !dbg !4
+  %6 = bitcast %struct.Data* %3 to i8*, !dbg !4
+  call void @dx.noop(), !dbg !4
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %5, i8* %6, i64 20, i32 1, i1 false), !dbg !4
+  call void @dx.noop(), !dbg !8
+  store i32 0, i32* %i, align 4, !dbg !8
+  br label %for.cond, !dbg !9
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %7 = load i32, i32* %i, align 4, !dbg !10
+  %cmp = icmp slt i32 %7, 5, !dbg !11
+  %tobool = icmp ne i1 %cmp, false, !dbg !11
+  %tobool1 = icmp ne i1 %tobool, false, !dbg !12
+  br i1 %tobool1, label %for.body, label %for.end, !dbg !12
+
+for.body:                                         ; preds = %for.cond
+  %8 = load i32, i32* %i, align 4, !dbg !13
+  %arrayidx3 = getelementptr inbounds %cb, %cb* %2, i32 0, i32 1, i32 0, i32 %8, !dbg !14
+  %9 = load float, float* %arrayidx3, align 4, !dbg !14
+  %10 = load i32, i32* %i, align 4, !dbg !15
+  %member = getelementptr inbounds %struct.Data, %struct.Data* %alloca, i32 0, i32 0, !dbg !16
+  %arrayidx2 = getelementptr inbounds [5 x float], [5 x float]* %member, i32 0, i32 %10, !dbg !17
+  call void @dx.noop(), !dbg !18
+  store float %9, float* %arrayidx2, align 4, !dbg !18
+  br label %for.inc, !dbg !19
+
+for.inc:                                          ; preds = %for.body
+  %11 = load i32, i32* %i, align 4, !dbg !20
+  %inc = add nsw i32 %11, 1, !dbg !20
+  call void @dx.noop(), !dbg !20
+  store i32 %inc, i32* %i, align 4, !dbg !20
+  br label %for.cond, !dbg !12, !llvm.loop !21
+
+for.end:                                          ; preds = %for.cond
+  %12 = load float, float* %4, align 4, !dbg !23
+  store float %12, float* %retval, !dbg !24
+  %13 = load float, float* %retval, !dbg !24
+  call void @dx.noop(), !dbg !24
+  ret float %13, !dbg !24
+}
+
+; Function Attrs: nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture readonly, i64, i32, i1) #0
+
+; Function Attrs: nounwind readnone
+declare %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32, %dx.types.Handle, i32) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32, %cb*, i32) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb) #1
+
+; Function Attrs: convergent
+declare void @dx.noop() #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+attributes #2 = { convergent }
+
+!llvm.module.flags = !{!0}
+!pauseresume = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{!"hlsl-hlemit", !"hlsl-hlensure"}
+!2 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
+!3 = !{}
+!4 = !DILocation(line: 12, column: 17, scope: !5)
+!5 = !DISubprogram(name: "main", scope: !6, file: !6, line: 11, type: !7, isLocal: false, isDefinition: true, scopeLine: 11, flags: DIFlagPrototyped, isOptimized: false, function: float ()* @main)
+!6 = !DIFile(filename: "F:\5Ctest\5Cod_fails_may_2022\5Cmemcpy.hlsl", directory: "")
+!7 = !DISubroutineType(types: !3)
+!8 = !DILocation(line: 14, column: 12, scope: !5)
+!9 = !DILocation(line: 14, column: 8, scope: !5)
+!10 = !DILocation(line: 14, column: 19, scope: !5)
+!11 = !DILocation(line: 14, column: 21, scope: !5)
+!12 = !DILocation(line: 14, column: 3, scope: !5)
+!13 = !DILocation(line: 15, column: 35, scope: !5)
+!14 = !DILocation(line: 15, column: 24, scope: !5)
+!15 = !DILocation(line: 15, column: 19, scope: !5)
+!16 = !DILocation(line: 15, column: 12, scope: !5)
+!17 = !DILocation(line: 15, column: 5, scope: !5)
+!18 = !DILocation(line: 15, column: 22, scope: !5)
+!19 = !DILocation(line: 16, column: 3, scope: !5)
+!20 = !DILocation(line: 14, column: 27, scope: !5)
+!21 = distinct !{!21, !22}
+!22 = !{!"llvm.loop.unroll.disable"}
+!23 = !DILocation(line: 18, column: 10, scope: !5)
+!24 = !DILocation(line: 18, column: 3, scope: !5)

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas_memcpy2.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/dxil_remove_dead_pass/delete_dead_allocas_memcpy2.ll
@@ -1,0 +1,130 @@
+; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
+
+; Make sure that dxilutil::DeleteDeadAllocas doesn't delete allocas
+; with memcpy that read from it.
+
+; CHECK: @main
+; CHECK:  = alloca %struct.Data
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Data = type { [5 x float] }
+%ConstantBuffer = type opaque
+%cb = type { %struct.Data, %struct.Data }
+%dx.types.Handle = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+
+@"\01?foo@cb@@3UData@@B" = external global %struct.Data, align 4
+@"\01?bar@cb@@3UData@@B" = external global %struct.Data, align 4
+@"$Globals" = external constant %ConstantBuffer
+@cb = external constant %cb
+
+; Function Attrs: nounwind
+define float @main() #0 {
+entry:
+  %0 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32 0, %cb* @cb, i32 0)
+  %1 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32 11, %dx.types.Handle %0, %dx.types.ResourceProperties { i32 13, i32 148 }, %cb undef)
+  %2 = call %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32 6, %dx.types.Handle %1, i32 0)
+  %3 = getelementptr inbounds %cb, %cb* %2, i32 0, i32 0
+  %retval = alloca float, align 4, !dx.temp !3
+  %alloca = alloca %struct.Data, align 4
+  %i = alloca i32, align 4
+  %ret = alloca %struct.Data, align 4
+  %4 = bitcast %struct.Data* %alloca to i8*, !dbg !4
+  %5 = bitcast %struct.Data* %3 to i8*, !dbg !4
+  call void @dx.noop(), !dbg !4
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %4, i8* %5, i64 20, i32 1, i1 false), !dbg !4
+  call void @dx.noop(), !dbg !8
+  store i32 0, i32* %i, align 4, !dbg !8
+  br label %for.cond, !dbg !9
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %6 = load i32, i32* %i, align 4, !dbg !10
+  %cmp = icmp slt i32 %6, 5, !dbg !11
+  %tobool = icmp ne i1 %cmp, false, !dbg !11
+  %tobool1 = icmp ne i1 %tobool, false, !dbg !12
+  br i1 %tobool1, label %for.body, label %for.end, !dbg !12
+
+for.body:                                         ; preds = %for.cond
+  %7 = load i32, i32* %i, align 4, !dbg !13
+  %arrayidx5 = getelementptr inbounds %cb, %cb* %2, i32 0, i32 1, i32 0, i32 %7, !dbg !14
+  %8 = load float, float* %arrayidx5, align 4, !dbg !14
+  %9 = load i32, i32* %i, align 4, !dbg !15
+  %member = getelementptr inbounds %struct.Data, %struct.Data* %alloca, i32 0, i32 0, !dbg !16
+  %arrayidx2 = getelementptr inbounds [5 x float], [5 x float]* %member, i32 0, i32 %9, !dbg !17
+  call void @dx.noop(), !dbg !18
+  store float %8, float* %arrayidx2, align 4, !dbg !18
+  br label %for.inc, !dbg !19
+
+for.inc:                                          ; preds = %for.body
+  %10 = load i32, i32* %i, align 4, !dbg !20
+  %inc = add nsw i32 %10, 1, !dbg !20
+  call void @dx.noop(), !dbg !20
+  store i32 %inc, i32* %i, align 4, !dbg !20
+  br label %for.cond, !dbg !12, !llvm.loop !21
+
+for.end:                                          ; preds = %for.cond
+  %11 = bitcast %struct.Data* %ret to i8*, !dbg !23
+  %12 = bitcast %struct.Data* %alloca to i8*, !dbg !23
+  call void @dx.noop(), !dbg !23
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %11, i8* %12, i64 20, i32 1, i1 false), !dbg !23
+  %member3 = getelementptr inbounds %struct.Data, %struct.Data* %ret, i32 0, i32 0, !dbg !24
+  %arrayidx4 = getelementptr inbounds [5 x float], [5 x float]* %member3, i32 0, i32 0, !dbg !25
+  %13 = load float, float* %arrayidx4, align 4, !dbg !25
+  store float %13, float* %retval, !dbg !26
+  %14 = load float, float* %retval, !dbg !26
+  call void @dx.noop(), !dbg !26
+  ret float %14, !dbg !26
+}
+
+; Function Attrs: nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture readonly, i64, i32, i1) #0
+
+; Function Attrs: nounwind readnone
+declare %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32, %dx.types.Handle, i32) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32, %cb*, i32) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb) #1
+
+; Function Attrs: convergent
+declare void @dx.noop() #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+attributes #2 = { convergent }
+
+!llvm.module.flags = !{!0}
+!pauseresume = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{!"hlsl-hlemit", !"hlsl-hlensure"}
+!2 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
+!3 = !{}
+!4 = !DILocation(line: 12, column: 17, scope: !5)
+!5 = !DISubprogram(name: "main", scope: !6, file: !6, line: 11, type: !7, isLocal: false, isDefinition: true, scopeLine: 11, flags: DIFlagPrototyped, isOptimized: false, function: float ()* @main)
+!6 = !DIFile(filename: "F:\5Ctest\5Cod_fails_may_2022\5Cmemcpy2.hlsl", directory: "")
+!7 = !DISubroutineType(types: !3)
+!8 = !DILocation(line: 14, column: 12, scope: !5)
+!9 = !DILocation(line: 14, column: 8, scope: !5)
+!10 = !DILocation(line: 14, column: 19, scope: !5)
+!11 = !DILocation(line: 14, column: 21, scope: !5)
+!12 = !DILocation(line: 14, column: 3, scope: !5)
+!13 = !DILocation(line: 15, column: 35, scope: !5)
+!14 = !DILocation(line: 15, column: 24, scope: !5)
+!15 = !DILocation(line: 15, column: 19, scope: !5)
+!16 = !DILocation(line: 15, column: 12, scope: !5)
+!17 = !DILocation(line: 15, column: 5, scope: !5)
+!18 = !DILocation(line: 15, column: 22, scope: !5)
+!19 = !DILocation(line: 16, column: 3, scope: !5)
+!20 = !DILocation(line: 14, column: 27, scope: !5)
+!21 = distinct !{!21, !22}
+!22 = !{!"llvm.loop.unroll.disable"}
+!23 = !DILocation(line: 18, column: 14, scope: !5)
+!24 = !DILocation(line: 19, column: 14, scope: !5)
+!25 = !DILocation(line: 19, column: 10, scope: !5)
+!26 = !DILocation(line: 19, column: 3, scope: !5)


### PR DESCRIPTION
  - Replaced the code to delete unread allocas in dxil-cond-mem2reg with calling the helper in dxilutils.
  - Fixed a crash in the helper caused by walking the entry in forward order, which could invalidate next iterator.
  - Added handling of memcpy's in the helper.
  - Added tests that actually exercise the memcpy path.