### PR TITLE
Fix build break with new CopyDesc0ToDesc1

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -910,7 +910,7 @@ public:
 
 #if defined(NTDDI_WIN10_CU) && WDK_NTDDI_VERSION >= NTDDI_WIN10_CU
   // Copy common fields from desc0 to desc1 and zero out the new one
-  void CopyDesc0ToDesc1(D3D12_RESOURCE_DESC1 &desc1, const D3D12_RESOURCE_DESC1 &desc0) {
+  void CopyDesc0ToDesc1(D3D12_RESOURCE_DESC1 &desc1, const D3D12_RESOURCE_DESC &desc0) {
     desc1.Dimension = desc0.Dimension;
     desc1.Alignment = desc0.Alignment;
     desc1.Width = desc0.Width;
@@ -956,7 +956,7 @@ public:
       CComPtr<ID3D12Device10> pDevice10;
       // Copy resDesc0 to resDesc1 zeroing anything new
       D3D12_RESOURCE_DESC1 resDesc1 = {0};
-      CopyDesc0ToDesc1(resDesc1, resDesc) {
+      CopyDesc0ToDesc1(resDesc1, resDesc);
       VERIFY_SUCCEEDED(pDevice->QueryInterface(IID_PPV_ARGS(&pDevice10)));
       VERIFY_SUCCEEDED(pDevice10->CreateCommittedResource3(
         &defaultHeapProperties,


### PR DESCRIPTION
Second argument should be D3D12_RESOURCE_DESC for the old version.

Function call needs a semicolon and no open curly brace.