### PR TITLE
Fix leak of FixedSizeMemoryStream object from DxilConv

### DIFF
--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -332,7 +332,7 @@ void DxbcConverter::ConvertImpl(_In_reads_bytes_(DxbcSize) LPCVOID pDxbc,
   CComPtr<AbstractMemoryStream> pOutputStream;
   IFT(CreateFixedSizeMemoryStream((LPBYTE)pOutput.m_pData, OutputSize, &pOutputStream));
   pContainerWriter->write(pOutputStream);
-  pOutputStream.Detach();
+  // pOutputStream does not own the buffer; allow CComPtr to clean up the stream object.
 
   *ppDxil = pOutput.Detach();
   *pDxilSize = OutputSize;


### PR DESCRIPTION
Thanks @jenatali for noticing the errant Detach()!  I think it was intended to be `->Detach()`, but was `.Detach()`.  The first would have simply cleared the pointer to the buffer that the stream object didn't own, the second tells CComPtr not to clean up the object itself, so nobody was cleaning it up.

However, `->Detach()` is also unnecessary because the stream can't and won't free the buffer that we want to keep anyway.