### PR TITLE
Fix leak of FixedSizeMemoryStream object from DxilConv (#4483)

### DIFF
--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -327,7 +327,7 @@ void DxbcConverter::ConvertImpl(_In_reads_bytes_(DxbcSize) LPCVOID pDxbc,
   CComPtr<AbstractMemoryStream> pOutputStream;
   IFT(CreateFixedSizeMemoryStream((LPBYTE)pOutput.m_pData, OutputSize, &pOutputStream));
   pContainerWriter->write(pOutputStream);
-  pOutputStream.Detach();
+  // pOutputStream does not own the buffer; allow CComPtr to clean up the stream object.
 
   *ppDxil = pOutput.Detach();
   *pDxilSize = OutputSize;


### PR DESCRIPTION
(cherry picked from commit 07bf1ae857b86777ca209baa58a96e1b597496c8)