### PR TITLE
Fix the SAL of IDxcResult::GetOutput

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -777,7 +777,7 @@ struct IDxcResult : public IDxcOperationResult {
   virtual HRESULT STDMETHODCALLTYPE
   GetOutput(_In_ DXC_OUT_KIND dxcOutKind, _In_ REFIID iid,
             _COM_Outptr_opt_result_maybenull_ void **ppvObject,
-            _COM_Outptr_ IDxcBlobWide **ppOutputName) = 0;
+            _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputName) = 0;
 
   /// \brief Retrieves the number of outputs available in this result.
   virtual UINT32 GetNumOutputs() = 0;


### PR DESCRIPTION
The ppOutputName parameter can be nullptr and can return nullptr. Change its SAL to _COM_Outptr_opt_result_maybenull_.

Related to #4149 .