### PR TITLE
Validate no gaps in UAV store writemask

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3079,7 +3079,7 @@ INSTR.TGSMRACECOND                        Race condition writing to shared memor
 INSTR.UNDEFINEDVALUEFORUAVSTORE           Assignment of undefined values to UAV.
 INSTR.UNDEFRESULTFORGETDIMENSION          GetDimensions used undef dimension %0 on %1.
 INSTR.WRITEMASKFORTYPEDUAVSTORE           store on typed uav must write to all four components of the UAV.
-INSTR.WRITEMASKGAPFORUAV                  uav write mask must be continuous and not contain gaps.
+INSTR.WRITEMASKGAPFORUAV                  UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.
 INSTR.WRITEMASKMATCHVALUEFORUAVSTORE      uav store write mask must match store value mask, write mask is %0 and store value mask is %1.
 META.BARYCENTRICSFLOAT3                   only 'float3' type is allowed for SV_Barycentrics.
 META.BARYCENTRICSINTERPOLATION            SV_Barycentrics cannot be used with 'nointerpolation' type.

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3079,7 +3079,7 @@ INSTR.TGSMRACECOND                        Race condition writing to shared memor
 INSTR.UNDEFINEDVALUEFORUAVSTORE           Assignment of undefined values to UAV.
 INSTR.UNDEFRESULTFORGETDIMENSION          GetDimensions used undef dimension %0 on %1.
 INSTR.WRITEMASKFORTYPEDUAVSTORE           store on typed uav must write to all four components of the UAV.
-INSTR.WRITEMASKGAPFORUAV                  UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.
+INSTR.WRITEMASKGAPFORUAV                  UAV write mask must be contiguous, starting at x: .x, .xy, .xyz, or .xyzw.
 INSTR.WRITEMASKMATCHVALUEFORUAVSTORE      uav store write mask must match store value mask, write mask is %0 and store value mask is %1.
 META.BARYCENTRICSFLOAT3                   only 'float3' type is allowed for SV_Barycentrics.
 META.BARYCENTRICSINTERPOLATION            SV_Barycentrics cannot be used with 'nointerpolation' type.

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3079,6 +3079,7 @@ INSTR.TGSMRACECOND                        Race condition writing to shared memor
 INSTR.UNDEFINEDVALUEFORUAVSTORE           Assignment of undefined values to UAV.
 INSTR.UNDEFRESULTFORGETDIMENSION          GetDimensions used undef dimension %0 on %1.
 INSTR.WRITEMASKFORTYPEDUAVSTORE           store on typed uav must write to all four components of the UAV.
+INSTR.WRITEMASKGAPFORUAV                  uav write mask must be continuous and not contain gaps.
 INSTR.WRITEMASKMATCHVALUEFORUAVSTORE      uav store write mask must match store value mask, write mask is %0 and store value mask is %1.
 META.BARYCENTRICSFLOAT3                   only 'float3' type is allowed for SV_Barycentrics.
 META.BARYCENTRICSINTERPOLATION            SV_Barycentrics cannot be used with 'nointerpolation' type.

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1466,6 +1466,10 @@ static bool ValidateStorageMasks(Instruction *I, DXIL::OpCode opcode, ConstantIn
     ValCtx.EmitInstrError(I, ValidationRule::InstrWriteMaskForTypedUAVStore);
   }
 
+  if (!((uMask == 0xf) || (uMask == 0x7) || (uMask == 0x3) || (uMask == 0x1))) {
+    ValCtx.EmitInstrError(I, ValidationRule::InstrWriteMaskGapForUAV);
+  }
+
   // If a bit is set in the uMask (expected values) that isn't set in stValMask (user provided values)
   // then the user failed to define some of the output values.
   if (uMask & ~stValMask)

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1466,6 +1466,7 @@ static bool ValidateStorageMasks(Instruction *I, DXIL::OpCode opcode, ConstantIn
     ValCtx.EmitInstrError(I, ValidationRule::InstrWriteMaskForTypedUAVStore);
   }
 
+  // write mask must be contiguous (.x .xy .xyz or .xyzw)
   if (!((uMask == 0xf) || (uMask == 0x7) || (uMask == 0x3) || (uMask == 0x1))) {
     ValCtx.EmitInstrError(I, ValidationRule::InstrWriteMaskGapForUAV);
   }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1199,11 +1199,13 @@ TEST_F(ValidationTest, UAVStoreMaskMatch) {
 }
 
 TEST_F(ValidationTest, UAVStoreMaskGap) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
   RewriteAssemblyCheckMsg(
       L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
       "i32 2, i32 2, i32 2, i32 2, i8 15)",
       "i32 undef, i32 2, i32 undef, i32 2, i8 10)",
-      "uav write mask must be continuous and not contain gaps.");
+      "UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.");
 }
 
 TEST_F(ValidationTest, Recursive) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -72,6 +72,7 @@ public:
   TEST_METHOD(TypedUAVStoreFullMask0)
   TEST_METHOD(TypedUAVStoreFullMask1)
   TEST_METHOD(UAVStoreMaskMatch)
+  TEST_METHOD(UAVStoreMaskGap)
   TEST_METHOD(Recursive)
   TEST_METHOD(Recursive2)
   TEST_METHOD(Recursive3)
@@ -1195,6 +1196,14 @@ TEST_F(ValidationTest, UAVStoreMaskMatch) {
       "i32 2, i8 15)",
       "i32 2, i8 7)",
       "uav store write mask must match store value mask, write mask is 7 and store value mask is 15.");
+}
+
+TEST_F(ValidationTest, UAVStoreMaskGap) {
+  RewriteAssemblyCheckMsg(
+      L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
+      "i32 2, i32 2, i32 2, i32 2, i8 15)",
+      "i32 undef, i32 2, i32 undef, i32 2, i8 10)",
+      "uav write mask must be continuous and not contain gaps.");
 }
 
 TEST_F(ValidationTest, Recursive) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -73,6 +73,8 @@ public:
   TEST_METHOD(TypedUAVStoreFullMask1)
   TEST_METHOD(UAVStoreMaskMatch)
   TEST_METHOD(UAVStoreMaskGap)
+  TEST_METHOD(UAVStoreMaskGap2)
+  TEST_METHOD(UAVStoreMaskGap3)
   TEST_METHOD(Recursive)
   TEST_METHOD(Recursive2)
   TEST_METHOD(Recursive3)
@@ -1205,7 +1207,27 @@ TEST_F(ValidationTest, UAVStoreMaskGap) {
       L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
       "i32 2, i32 2, i32 2, i32 2, i8 15)",
       "i32 undef, i32 2, i32 undef, i32 2, i8 10)",
-      "UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.");
+      "UAV write mask must be contiguous, starting at x: .x, .xy, .xyz, or .xyzw.");
+}
+
+TEST_F(ValidationTest, UAVStoreMaskGap2) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+  RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
+                          "i32 2, i32 2, i32 2, i32 2, i8 15)",
+                          "i32 undef, i32 2, i32 2, i32 2, i8 14)",
+                          "UAV write mask must be contiguous, starting at x: "
+                          ".x, .xy, .xyz, or .xyzw.");
+}
+
+TEST_F(ValidationTest, UAVStoreMaskGap3) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+  RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
+                          "i32 2, i32 2, i32 2, i32 2, i8 15)",
+                          "i32 undef, i32 undef, i32 undef, i32 2, i8 8)",
+                          "UAV write mask must be contiguous, starting at x: "
+                          ".x, .xy, .xyz, or .xyzw.");
 }
 
 TEST_F(ValidationTest, Recursive) {

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -177,7 +177,7 @@ FileRunCommandResult FileRunCommandPart::RunFileChecker(const FileRunCommandResu
   auto args = strtok(Arguments);
   for (const std::string& arg : args) {
     if (arg == "%s") hasInputFilename = true;
-    else if (arg == "-input-file=stderr") { //add an edit here that would concatinate standard err and standard in, follow up with chris, also add multiple run lines
+    else if (arg == "-input-file=stderr") {
       t.InputForStdin = Prior->StdErr;
       t.AllowEmptyInput = true;
     } else if (strstartswith(arg, checkPrefixStr))

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -177,7 +177,7 @@ FileRunCommandResult FileRunCommandPart::RunFileChecker(const FileRunCommandResu
   auto args = strtok(Arguments);
   for (const std::string& arg : args) {
     if (arg == "%s") hasInputFilename = true;
-    else if (arg == "-input-file=stderr") {
+    else if (arg == "-input-file=stderr") { //add an edit here that would concatinate standard err and standard in, follow up with chris, also add multiple run lines
       t.InputForStdin = Prior->StdErr;
       t.AllowEmptyInput = true;
     } else if (strstartswith(arg, checkPrefixStr))

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2582,6 +2582,7 @@ class db_dxil(object):
         self.add_valrule("Instr.BarrierModeNoMemory", "sync must include some form of memory barrier - _u (UAV) and/or _g (Thread Group Shared Memory).  Only _t (thread group sync) is optional.")
         self.add_valrule("Instr.BarrierModeForNonCS", "sync in a non-Compute/Amplification/Mesh Shader must only sync UAV (sync_uglobal).")
         self.add_valrule("Instr.WriteMaskForTypedUAVStore", "store on typed uav must write to all four components of the UAV.")
+        self.add_valrule("Instr.WriteMaskGapForUAV", "uav write mask must be continuous and not contain gaps.")
         self.add_valrule("Instr.ResourceKindForCalcLOD","lod requires resource declared as texture1D/2D/3D/Cube/CubeArray/1DArray/2DArray.")
         self.add_valrule("Instr.ResourceKindForSample", "sample/_l/_d requires resource declared as texture1D/2D/3D/Cube/1DArray/2DArray/CubeArray.")
         self.add_valrule("Instr.ResourceKindForSampleC", "samplec requires resource declared as texture1D/2D/Cube/1DArray/2DArray/CubeArray.")

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2582,7 +2582,7 @@ class db_dxil(object):
         self.add_valrule("Instr.BarrierModeNoMemory", "sync must include some form of memory barrier - _u (UAV) and/or _g (Thread Group Shared Memory).  Only _t (thread group sync) is optional.")
         self.add_valrule("Instr.BarrierModeForNonCS", "sync in a non-Compute/Amplification/Mesh Shader must only sync UAV (sync_uglobal).")
         self.add_valrule("Instr.WriteMaskForTypedUAVStore", "store on typed uav must write to all four components of the UAV.")
-        self.add_valrule("Instr.WriteMaskGapForUAV", "uav write mask must be continuous and not contain gaps.")
+        self.add_valrule("Instr.WriteMaskGapForUAV", "UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.")
         self.add_valrule("Instr.ResourceKindForCalcLOD","lod requires resource declared as texture1D/2D/3D/Cube/CubeArray/1DArray/2DArray.")
         self.add_valrule("Instr.ResourceKindForSample", "sample/_l/_d requires resource declared as texture1D/2D/3D/Cube/1DArray/2DArray/CubeArray.")
         self.add_valrule("Instr.ResourceKindForSampleC", "samplec requires resource declared as texture1D/2D/Cube/1DArray/2DArray/CubeArray.")

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2582,7 +2582,7 @@ class db_dxil(object):
         self.add_valrule("Instr.BarrierModeNoMemory", "sync must include some form of memory barrier - _u (UAV) and/or _g (Thread Group Shared Memory).  Only _t (thread group sync) is optional.")
         self.add_valrule("Instr.BarrierModeForNonCS", "sync in a non-Compute/Amplification/Mesh Shader must only sync UAV (sync_uglobal).")
         self.add_valrule("Instr.WriteMaskForTypedUAVStore", "store on typed uav must write to all four components of the UAV.")
-        self.add_valrule("Instr.WriteMaskGapForUAV", "UAV write mask must be contiguous and without gaps: .x, .xy, .xyz, or .xyzw.")
+        self.add_valrule("Instr.WriteMaskGapForUAV", "UAV write mask must be contiguous, starting at x: .x, .xy, .xyz, or .xyzw.")
         self.add_valrule("Instr.ResourceKindForCalcLOD","lod requires resource declared as texture1D/2D/3D/Cube/CubeArray/1DArray/2DArray.")
         self.add_valrule("Instr.ResourceKindForSample", "sample/_l/_d requires resource declared as texture1D/2D/3D/Cube/1DArray/2DArray/CubeArray.")
         self.add_valrule("Instr.ResourceKindForSampleC", "samplec requires resource declared as texture1D/2D/Cube/1DArray/2DArray/CubeArray.")


### PR DESCRIPTION
This change adds a validation rule for the inherited D3D11 requirement that a UAV store write mask must not contain gaps and therefore be one of the following: .x, .xy, .xyz, .xyzw.

Fixes #4161 