### PR TITLE
Isnormal hlktest

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -179,15 +179,22 @@ std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgra
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
+                           _Outptr_ IDxcBlob **pBlob, bool bRegex, std::string& disassembly, dxc::DxcDllSupport &dllSupport);
+IDxcOperationResult * CompileAndRewriteAssemblyToText(dxc::DxcDllSupport &dllSupport, LPCSTR pText, 
+                            LPWSTR pTargetProfile, LPCWSTR pArgs,  _Outptr_ IDxcBlob **ppResult,
+                            llvm::ArrayRef<LPCSTR> pLookFors,
+                            llvm::ArrayRef<LPCSTR> pReplacements,
+                            bool bRegex = false);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);
 void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlob **ppBlob);
 void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlobEncoding **ppBlob);
-void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, LPCWSTR pArgs,
                      _Outptr_ IDxcBlob **ppResult);
-void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, std::vector<LPCWSTR> &args,
                      _Outptr_ IDxcBlob **ppResult);
 

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -179,7 +179,7 @@ std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgra
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
-void ReplaceText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
                             bool bRegex, std::string& disassembly);
 void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
                            _Outptr_ IDxcBlob **pBlob, bool bRegex, std::string& disassembly, dxc::DxcDllSupport &dllSupport);

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -188,10 +188,10 @@ void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);
 void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlob **ppBlob);
 void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val, _Outptr_ IDxcBlobEncoding **ppBlob);
-IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, LPCWSTR pArgs,
                      _Outptr_ IDxcBlob **ppResult);
-IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, std::vector<LPCWSTR> &args,
                      _Outptr_ IDxcBlob **ppResult);
 

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -179,13 +179,10 @@ std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgra
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
+void ReplaceText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
+                            bool bRegex, std::string& disassembly);
 void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
                            _Outptr_ IDxcBlob **pBlob, bool bRegex, std::string& disassembly, dxc::DxcDllSupport &dllSupport);
-IDxcOperationResult * CompileAndRewriteAssemblyToText(dxc::DxcDllSupport &dllSupport, LPCSTR pText, 
-                            LPWSTR pTargetProfile, LPCWSTR pArgs,  _Outptr_ IDxcBlob **ppResult,
-                            llvm::ArrayRef<LPCSTR> pLookFors,
-                            llvm::ArrayRef<LPCSTR> pReplacements,
-                            bool bRegex = false);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3727,35 +3727,26 @@ void MSMain(uint GID : SV_GroupIndex,
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="IsNormal" CS="CS66">
+  <ShaderOp Name="IsNormal" CS="CS60">
     <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="g_result_floats"   NumElements="12" Kind="UAV"  StructureByteStride="4"/>
       <Descriptor Name="g_result_doubles"  NumElements="12" Kind="UAV"  StructureByteStride="4"/>
     </DescriptorHeap>
+    <RootValues>
+      <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
+    </RootValues>
     
-    <Shader Name="CS66" Target="cs_6_6" EntryPoint="main" Text="@MAIN"/> 
-    <Shader Name="MAIN" Target="cs_6_6" EntryPoint="main">
+    <Shader Name="CS60" Target="cs_6_0" EntryPoint="main" Text="@MAIN"/> 
+    <Shader Name="MAIN" Target="cs_6_0" EntryPoint="main">
       <![CDATA[
         
-      #ifdef FALLBACK
-
       #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=2))")]
     
       // Result buffers
       RWStructuredBuffer <int> g_result_floats    : register(u0);
       RWStructuredBuffer <int> g_result_doubles   : register(u1);
-
-    
-      #else // NO FALLBACK
-      #define ROOT_SIG [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)")]
-
-      // Result buffers
-      static RWStructuredBuffer<int> g_result_floats    = ResourceDescriptorHeap[0];
-      static RWStructuredBuffer<int> g_result_doubles   = ResourceDescriptorHeap[1];
-    
-      #endif // FALLBACK
    
       void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3728,8 +3728,8 @@ void MSMain(uint GID : SV_GroupIndex,
   </ShaderOp>
 
   <ShaderOp Name="IsNormal" CS="CS60">
-    <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
-    <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="g_result_floats"   NumElements="12" Kind="UAV"  StructureByteStride="4"/>
       <Descriptor Name="g_result_doubles"  NumElements="12" Kind="UAV"  StructureByteStride="4"/>
@@ -3747,6 +3747,11 @@ void MSMain(uint GID : SV_GroupIndex,
       // Result buffers
       RWStructuredBuffer <int> g_result_floats    : register(u0);
       RWStructuredBuffer <int> g_result_doubles   : register(u1);
+      
+      int FLOAT_SIGN_MASK  = -2147483648;
+      int FLOAT_EXP_MASK   = 2139095040;
+      int DOUBLE_SIGN_MASK = -2147483648;
+      int DOUBLE_EXP_MASK  = 2146435072;
    
       void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
@@ -3784,6 +3789,18 @@ void MSMain(uint GID : SV_GroupIndex,
           float FPositiveInf      = asfloat(2139095040);  //  01111111100000000000000000000000  (all ones exp, zero mantissa)
           float FNegativeNaN      = asfloat(-8388607);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
           float FPositiveNaN      = asfloat(2139095041);  //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
+          
+          /*
+          //fails compilation?
+          float FNegativeZero     = asfloat(FLOAT_SIGN_MASK);                         //  10000000000000000000000000000000
+          float FPositiveZero     = asfloat(0);                                       //  00000000000000000000000000000000
+          float FNegativeDenormal = asfloat(FLOAT_SIGN_MASK | 1);                     //  10000000000000000000000000000001  (zero exp, non-zero mantissa)
+          float FPositiveDenormal = asfloat(1);                                       //  00000000000000000000000000000001  (zero exp, non-zero mantissa)
+          float FNegativeInf      = asfloat(FLOAT_SIGN_MASK | FLOAT_EXP_MASK);        //  11111111100000000000000000000000  (all ones exp, zero mantissa)
+          float FPositiveInf      = asfloat(FLOAT_EXP_MASK);                          //  01111111100000000000000000000000  (all ones exp, zero mantissa)
+          float FNegativeNaN      = asfloat(FLOAT_SIGN_MASK | FLOAT_EXP_MASK | 1);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
+          float FPositiveNaN      = asfloat(FLOAT_EXP_MASK | 1);                      //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
+          */
           
           float FNonNormalNumbers[8] = {FNegativeZero, FPositiveZero, FNegativeDenormal, FPositiveDenormal, FNegativeInf, FPositiveInf, FNegativeNaN, FPositiveNaN};
           float FNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3748,10 +3748,10 @@ void MSMain(uint GID : SV_GroupIndex,
       RWStructuredBuffer <int> g_result_floats    : register(u0);
       RWStructuredBuffer <int> g_result_doubles   : register(u1);
       
-      int FLOAT_SIGN_MASK  = -2147483648;
-      int FLOAT_EXP_MASK   = 2139095040;
-      int DOUBLE_SIGN_MASK = -2147483648;
-      int DOUBLE_EXP_MASK  = 2146435072;
+      static int FLOAT_SIGN_MASK  = -2147483648;
+      static int FLOAT_EXP_MASK   = 2139095040;
+	    static int DOUBLE_SIGN_MASK = -2147483648;
+      static int DOUBLE_EXP_MASK  = 2146435072;
    
       void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
@@ -3778,20 +3778,11 @@ void MSMain(uint GID : SV_GroupIndex,
       ROOT_SIG
       [NumThreads(1, 1, 1)]
       void main(uint ix : SV_GroupIndex) { //decimal numbers are expressed in signed 2's complement form
-                                                   //        sign exp        mantissa
-                                                   //         | ___|__  ________|____________
-                                                   //         ||      ||                     |
-          float FNegativeZero     = asfloat(-2147483648); //  10000000000000000000000000000000
-          float FPositiveZero     = asfloat(0);           //  00000000000000000000000000000000
-          float FNegativeDenormal = asfloat(-2147483647); //  10000000000000000000000000000001  (zero exp, non-zero mantissa)
-          float FPositiveDenormal = asfloat(1);           //  00000000000000000000000000000001  (zero exp, non-zero mantissa)
-          float FNegativeInf      = asfloat(-8388608);    //  11111111100000000000000000000000  (all ones exp, zero mantissa)
-          float FPositiveInf      = asfloat(2139095040);  //  01111111100000000000000000000000  (all ones exp, zero mantissa)
-          float FNegativeNaN      = asfloat(-8388607);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
-          float FPositiveNaN      = asfloat(2139095041);  //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
+      
           
-          /*
-          //fails compilation?
+                                                                                      // sign exp        mantissa
+                                                                                      //  | ___|__  ________|____________
+                                                                                      //  ||      ||                     | 
           float FNegativeZero     = asfloat(FLOAT_SIGN_MASK);                         //  10000000000000000000000000000000
           float FPositiveZero     = asfloat(0);                                       //  00000000000000000000000000000000
           float FNegativeDenormal = asfloat(FLOAT_SIGN_MASK | 1);                     //  10000000000000000000000000000001  (zero exp, non-zero mantissa)
@@ -3800,7 +3791,7 @@ void MSMain(uint GID : SV_GroupIndex,
           float FPositiveInf      = asfloat(FLOAT_EXP_MASK);                          //  01111111100000000000000000000000  (all ones exp, zero mantissa)
           float FNegativeNaN      = asfloat(FLOAT_SIGN_MASK | FLOAT_EXP_MASK | 1);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
           float FPositiveNaN      = asfloat(FLOAT_EXP_MASK | 1);                      //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
-          */
+          
           
           float FNonNormalNumbers[8] = {FNegativeZero, FPositiveZero, FNegativeDenormal, FPositiveDenormal, FNegativeInf, FPositiveInf, FNegativeNaN, FPositiveNaN};
           float FNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
@@ -3808,17 +3799,17 @@ void MSMain(uint GID : SV_GroupIndex,
           
           //Test Doubles now
           
-                                                                 // sign   exp                   mantissa
-                                                                 //  | _____|___  ___________________|______________________________
-                                                                 //  ||         ||                                                  |
-          double DNegativeZero     = asdouble(0, -2147483648);   //  1000000000000000000000000000000000000000000000000000000000000000
-          double DPositiveZero     = asdouble(0, 0);             //  0000000000000000000000000000000000000000000000000000000000000000
-          double DNegativeDenormal = asdouble(1, -2147483648);   //  1000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)
-          double DPositiveDenormal = asdouble(1, 0);             //  0000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)          
-          double DNegativeInf      = asdouble(0, -1048576);      //  1111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
-          double DPositiveInf      = asdouble(0, 2146435072);    //  0111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
-          double DNegativeNaN      = asdouble(1, -1048576);      //  1111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
-          double DPositiveNaN      = asdouble(1, 2146435072);    //  0111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
+                                                                                               // sign   exp                   mantissa
+                                                                                               //  | _____|___  ___________________|______________________________
+                                                                                               //  ||         ||                                                  |
+          double DNegativeZero     = asdouble(0, DOUBLE_SIGN_MASK);                            //  1000000000000000000000000000000000000000000000000000000000000000
+          double DPositiveZero     = asdouble(0, 0);                                           //  0000000000000000000000000000000000000000000000000000000000000000
+          double DNegativeDenormal = asdouble(1, DOUBLE_SIGN_MASK);                            //  1000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)
+          double DPositiveDenormal = asdouble(1, 0);                                           //  0000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)          
+          double DNegativeInf      = asdouble(0, DOUBLE_SIGN_MASK | DOUBLE_EXP_MASK);          //  1111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
+          double DPositiveInf      = asdouble(0, DOUBLE_EXP_MASK);                             //  0111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
+          double DNegativeNaN      = asdouble(1, DOUBLE_SIGN_MASK | DOUBLE_EXP_MASK | 1);      //  1111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
+          double DPositiveNaN      = asdouble(1, DOUBLE_EXP_MASK | 1);                         //  0111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
           
           double DNonNormalNumbers[8] = {DNegativeZero, DPositiveZero, DNegativeDenormal, DPositiveDenormal, DNegativeInf, DPositiveInf, DNegativeNaN, DPositiveNaN};
           double DNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3738,7 +3738,7 @@ void MSMain(uint GID : SV_GroupIndex,
       <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
     </RootValues>
     
-    <Shader Name="CS60" Target="cs_6_0" EntryPoint="main" Text="@MAIN"/> 
+    <Shader Name="CS60" Target="cs_6_0" EntryPoint="main" Text="@MAIN" Callback="True"/> 
     <Shader Name="MAIN" Target="cs_6_0" EntryPoint="main">
       <![CDATA[
         

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3726,4 +3726,99 @@ void MSMain(uint GID : SV_GroupIndex,
   ]]>
     </Shader>
   </ShaderOp>
+
+  <ShaderOp Name="IsNormal" CS="CS66">
+    <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name="g_result_floats"   NumElements="12" Kind="UAV"  StructureByteStride="4"/>
+      <Descriptor Name="g_result_doubles"  NumElements="12" Kind="UAV"  StructureByteStride="4"/>
+    </DescriptorHeap>
+    
+    <Shader Name="CS66" Target="cs_6_6" EntryPoint="main" Text="@MAIN"/> 
+    <Shader Name="MAIN" Target="cs_6_6" EntryPoint="main">
+      <![CDATA[
+        
+      #ifdef FALLBACK
+
+      #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=2))")]
+    
+      // Result buffers
+      RWStructuredBuffer <int> g_result_floats    : register(u0);
+      RWStructuredBuffer <int> g_result_doubles   : register(u1);
+
+    
+      #else // NO FALLBACK
+      #define ROOT_SIG [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)")]
+
+      // Result buffers
+      static RWStructuredBuffer<int> g_result_floats    = ResourceDescriptorHeap[0];
+      static RWStructuredBuffer<int> g_result_doubles   = ResourceDescriptorHeap[1];
+    
+      #endif // FALLBACK
+   
+      void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
+        for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
+        {
+           result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
+        }
+        for (unsigned int j = 0; j < NormalNumbersSize; j++)
+        {
+           result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;
+        }
+      }
+      void TestDoubleNumbers(RWStructuredBuffer<int> result, double NonNormalNumbers[8], uint NonNormalNumbersSize, double NormalNumbers[4], uint NormalNumbersSize) {
+        for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
+        {
+           result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
+        }
+        for (unsigned int j = 0; j < NormalNumbersSize; j++)
+        {
+           result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;
+        }
+      }
+      
+   
+      ROOT_SIG
+      [NumThreads(1, 1, 1)]
+      void main(uint ix : SV_GroupIndex) { //decimal numbers are expressed in signed 2's complement form
+                                                   //        sign exp        mantissa
+                                                   //         | ___|__  ________|____________
+                                                   //         ||      ||                     |
+          float FNegativeZero     = asfloat(-2147483648); //  10000000000000000000000000000000
+          float FPositiveZero     = asfloat(0);           //  00000000000000000000000000000000
+          float FNegativeDenormal = asfloat(-2147483647); //  10000000000000000000000000000001  (zero exp, non-zero mantissa)
+          float FPositiveDenormal = asfloat(1);           //  00000000000000000000000000000001  (zero exp, non-zero mantissa)
+          float FNegativeInf      = asfloat(-8388608);    //  11111111100000000000000000000000  (all ones exp, zero mantissa)
+          float FPositiveInf      = asfloat(2139095040);  //  01111111100000000000000000000000  (all ones exp, zero mantissa)
+          float FNegativeNaN      = asfloat(-8388607);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
+          float FPositiveNaN      = asfloat(2139095041);  //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
+          
+          float FNonNormalNumbers[8] = {FNegativeZero, FPositiveZero, FNegativeDenormal, FPositiveDenormal, FNegativeInf, FPositiveInf, FNegativeNaN, FPositiveNaN};
+          float FNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
+          TestFloatNumbers(g_result_floats, FNonNormalNumbers, 8u, FNormalNumbers, 4u);
+          
+          //Test Doubles now
+          
+                                                                 // sign   exp                   mantissa
+                                                                 //  | _____|___  ___________________|______________________________
+                                                                 //  ||         ||                                                  |
+          double DNegativeZero     = asdouble(0, -2147483648);   //  1000000000000000000000000000000000000000000000000000000000000000
+          double DPositiveZero     = asdouble(0, 0);             //  0000000000000000000000000000000000000000000000000000000000000000
+          double DNegativeDenormal = asdouble(1, -2147483648);   //  1000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)
+          double DPositiveDenormal = asdouble(1, 0);             //  0000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)          
+          double DNegativeInf      = asdouble(0, -1048576);      //  1111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
+          double DPositiveInf      = asdouble(0, 2146435072);    //  0111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
+          double DNegativeNaN      = asdouble(1, -1048576);      //  1111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
+          double DPositiveNaN      = asdouble(1, 2146435072);    //  0111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
+          
+          double DNonNormalNumbers[8] = {DNegativeZero, DPositiveZero, DNegativeDenormal, DPositiveDenormal, DNegativeInf, DPositiveInf, DNegativeNaN, DPositiveNaN};
+          double DNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
+          TestDoubleNumbers(g_result_doubles, DNonNormalNumbers, 8u, DNormalNumbers, 4u);
+      }
+    
+    ]]>
+    </Shader>
+  </ShaderOp>
+
 </ShaderOpSet>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3730,9 +3730,12 @@ void MSMain(uint GID : SV_GroupIndex,
   <ShaderOp Name="IsNormal" CS="CS60">
     <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+    <Resource Name="g_SUnaryFPOp"         Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ByName"    Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS" />
+
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="g_result_floats"   NumElements="12" Kind="UAV"  StructureByteStride="4"/>
       <Descriptor Name="g_result_doubles"  NumElements="12" Kind="UAV"  StructureByteStride="4"/>
+      <Descriptor Name="g_SUnaryFPOp"      NumElements="12" Kind="UAV"  StructureByteStride="8"/>
     </DescriptorHeap>
     <RootValues>
       <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
@@ -3742,29 +3745,31 @@ void MSMain(uint GID : SV_GroupIndex,
     <Shader Name="MAIN" Target="cs_6_0" EntryPoint="main">
       <![CDATA[
         
-      #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=2))")]
+      #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=3))")]
+    
+      struct InOut{
+        float input;
+        float output;
+      };
     
       // Result buffers
       RWStructuredBuffer <int> g_result_floats    : register(u0);
       RWStructuredBuffer <int> g_result_doubles   : register(u1);
+      RWStructuredBuffer <InOut> g_SUnaryFPOp     : register(u2);
+      static int g_InputSize = 12;
       
       static int FLOAT_SIGN_MASK  = -2147483648;
       static int FLOAT_EXP_MASK   = 2139095040;
 	    static int DOUBLE_SIGN_MASK = -2147483648;
       static int DOUBLE_EXP_MASK  = 2146435072;
    
-      void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
-        [loop]
-        for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
+      void TestFloatNumbers(RWStructuredBuffer<InOut> TestData, unsigned int InputSize) {
+        for (unsigned int i = 0; i < InputSize; i++)
         {
-           result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
-        }
-        [loop]
-        for (unsigned int j = 0; j < NormalNumbersSize; j++)
-        {
-           result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;
+           TestData[i].output = isnan(TestData[i].input) ? 1.0 : 0.0;
         }
       }
+      
       void TestDoubleNumbers(RWStructuredBuffer<int> result, double NonNormalNumbers[8], uint NonNormalNumbersSize, double NormalNumbers[4], uint NormalNumbersSize) {
         [loop]
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
@@ -3799,7 +3804,7 @@ void MSMain(uint GID : SV_GroupIndex,
           
           float FNonNormalNumbers[8] = {FNegativeZero, FPositiveZero, FNegativeDenormal, FPositiveDenormal, FNegativeInf, FPositiveInf, FNegativeNaN, FPositiveNaN};
           float FNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
-          TestFloatNumbers(g_result_floats, FNonNormalNumbers, 8u, FNormalNumbers, 4u);
+          TestFloatNumbers(g_SUnaryFPOp, g_InputSize);
           
           //Test Doubles now
           /* This block needs to be uncommented whenever IsSpecialFloat supports doubles

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3754,20 +3754,24 @@ void MSMain(uint GID : SV_GroupIndex,
       static int DOUBLE_EXP_MASK  = 2146435072;
    
       void TestFloatNumbers(RWStructuredBuffer<int> result, float NonNormalNumbers[8], uint NonNormalNumbersSize, float NormalNumbers[4], uint NormalNumbersSize) {
+        [loop]
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
         {
            result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
         }
+        [loop]
         for (unsigned int j = 0; j < NormalNumbersSize; j++)
         {
            result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;
         }
       }
       void TestDoubleNumbers(RWStructuredBuffer<int> result, double NonNormalNumbers[8], uint NonNormalNumbersSize, double NormalNumbers[4], uint NormalNumbersSize) {
+        [loop]
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
         {
            result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
         }
+        [loop]
         for (unsigned int j = 0; j < NormalNumbersSize; j++)
         {
            result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3769,12 +3769,12 @@ void MSMain(uint GID : SV_GroupIndex,
         [loop]
         for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
         {
-           result[i] = isnan(NonNormalNumbers[i]) ? 1 : 0;
+           result[i] = isinf(NonNormalNumbers[i]) ? 1 : 0;
         }
         [loop]
         for (unsigned int j = 0; j < NormalNumbersSize; j++)
         {
-           result[NonNormalNumbersSize + j] = isnan(NormalNumbers[j]) ? 1 : 0;
+           result[NonNormalNumbersSize + j] = isinf(NormalNumbers[j]) ? 1 : 0;
         }
       }
       
@@ -3802,6 +3802,7 @@ void MSMain(uint GID : SV_GroupIndex,
           TestFloatNumbers(g_result_floats, FNonNormalNumbers, 8u, FNormalNumbers, 4u);
           
           //Test Doubles now
+          /* This block needs to be uncommented whenever IsSpecialFloat supports doubles
           
                                                                                                // sign   exp                   mantissa
                                                                                                //  | _____|___  ___________________|______________________________
@@ -3818,6 +3819,7 @@ void MSMain(uint GID : SV_GroupIndex,
           double DNonNormalNumbers[8] = {DNegativeZero, DPositiveZero, DNegativeDenormal, DPositiveDenormal, DNegativeInf, DPositiveInf, DNegativeNaN, DPositiveNaN};
           double DNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
           TestDoubleNumbers(g_result_doubles, DNonNormalNumbers, 8u, DNormalNumbers, 4u);
+          */
       }
     
     ]]>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3745,7 +3745,7 @@ void MSMain(uint GID : SV_GroupIndex,
     
       struct InOut{
         float input;
-        unsigned int output;
+        uint output;
       };
     
       // Result buffers

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3749,7 +3749,7 @@ void MSMain(uint GID : SV_GroupIndex,
     
       struct InOut{
         float input;
-        float output;
+        unsigned int output;
       };
     
       // Result buffers
@@ -3766,7 +3766,7 @@ void MSMain(uint GID : SV_GroupIndex,
       void TestFloatNumbers(RWStructuredBuffer<InOut> TestData, unsigned int InputSize) {
         for (unsigned int i = 0; i < InputSize; i++)
         {
-           TestData[i].output = isnan(TestData[i].input) ? 1.0 : 0.0;
+           TestData[i].output = isnan(TestData[i].input) ? 1u : 0u;
         }
       }
       

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3750,20 +3750,12 @@ void MSMain(uint GID : SV_GroupIndex,
     
       // Result buffers
       RWStructuredBuffer <InOut> g_SUnaryFPOp     : register(u0);
-      static int g_InputSize = 12;
-   
-      void TestFloatNumbers(RWStructuredBuffer<InOut> TestData, unsigned int InputSize) {
-        for (unsigned int i = 0; i < InputSize; i++)
-        {
-           TestData[i].output = isnan(TestData[i].input) ? 1u : 0u;
-        }
-      }
    
       ROOT_SIG
-      [NumThreads(1, 1, 1)]
-      void main(uint ix : SV_GroupIndex) 
+      [NumThreads(12, 1, 1)]
+      void main(uint ix : SV_GroupIndex)
       {
-          TestFloatNumbers(g_SUnaryFPOp, g_InputSize);
+        g_SUnaryFPOp[ix].output = isnan(g_SUnaryFPOp[ix].input);
       }
     
     ]]>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3728,13 +3728,9 @@ void MSMain(uint GID : SV_GroupIndex,
   </ShaderOp>
 
   <ShaderOp Name="IsNormal" CS="CS60">
-    <Resource Name="g_result_floats"      Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
-    <Resource Name="g_result_doubles"     Dimension="BUFFER"     Width="48"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
     <Resource Name="g_SUnaryFPOp"         Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ByName"    Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS" />
 
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
-      <Descriptor Name="g_result_floats"   NumElements="12" Kind="UAV"  StructureByteStride="4"/>
-      <Descriptor Name="g_result_doubles"  NumElements="12" Kind="UAV"  StructureByteStride="4"/>
       <Descriptor Name="g_SUnaryFPOp"      NumElements="12" Kind="UAV"  StructureByteStride="8"/>
     </DescriptorHeap>
     <RootValues>
@@ -3745,7 +3741,7 @@ void MSMain(uint GID : SV_GroupIndex,
     <Shader Name="MAIN" Target="cs_6_0" EntryPoint="main">
       <![CDATA[
         
-      #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=3))")]
+      #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=1))")]
     
       struct InOut{
         float input;
@@ -3753,15 +3749,8 @@ void MSMain(uint GID : SV_GroupIndex,
       };
     
       // Result buffers
-      RWStructuredBuffer <int> g_result_floats    : register(u0);
-      RWStructuredBuffer <int> g_result_doubles   : register(u1);
-      RWStructuredBuffer <InOut> g_SUnaryFPOp     : register(u2);
+      RWStructuredBuffer <InOut> g_SUnaryFPOp     : register(u0);
       static int g_InputSize = 12;
-      
-      static int FLOAT_SIGN_MASK  = -2147483648;
-      static int FLOAT_EXP_MASK   = 2139095040;
-	    static int DOUBLE_SIGN_MASK = -2147483648;
-      static int DOUBLE_EXP_MASK  = 2146435072;
    
       void TestFloatNumbers(RWStructuredBuffer<InOut> TestData, unsigned int InputSize) {
         for (unsigned int i = 0; i < InputSize; i++)
@@ -3769,62 +3758,12 @@ void MSMain(uint GID : SV_GroupIndex,
            TestData[i].output = isnan(TestData[i].input) ? 1u : 0u;
         }
       }
-      
-      void TestDoubleNumbers(RWStructuredBuffer<int> result, double NonNormalNumbers[8], uint NonNormalNumbersSize, double NormalNumbers[4], uint NormalNumbersSize) {
-        [loop]
-        for (unsigned int i = 0; i < NonNormalNumbersSize; i++)
-        {
-           result[i] = isinf(NonNormalNumbers[i]) ? 1 : 0;
-        }
-        [loop]
-        for (unsigned int j = 0; j < NormalNumbersSize; j++)
-        {
-           result[NonNormalNumbersSize + j] = isinf(NormalNumbers[j]) ? 1 : 0;
-        }
-      }
-      
    
       ROOT_SIG
       [NumThreads(1, 1, 1)]
-      void main(uint ix : SV_GroupIndex) { //decimal numbers are expressed in signed 2's complement form
-      
-          
-                                                                                      // sign exp        mantissa
-                                                                                      //  | ___|__  ________|____________
-                                                                                      //  ||      ||                     | 
-          float FNegativeZero     = asfloat(FLOAT_SIGN_MASK);                         //  10000000000000000000000000000000
-          float FPositiveZero     = asfloat(0);                                       //  00000000000000000000000000000000
-          float FNegativeDenormal = asfloat(FLOAT_SIGN_MASK | 1);                     //  10000000000000000000000000000001  (zero exp, non-zero mantissa)
-          float FPositiveDenormal = asfloat(1);                                       //  00000000000000000000000000000001  (zero exp, non-zero mantissa)
-          float FNegativeInf      = asfloat(FLOAT_SIGN_MASK | FLOAT_EXP_MASK);        //  11111111100000000000000000000000  (all ones exp, zero mantissa)
-          float FPositiveInf      = asfloat(FLOAT_EXP_MASK);                          //  01111111100000000000000000000000  (all ones exp, zero mantissa)
-          float FNegativeNaN      = asfloat(FLOAT_SIGN_MASK | FLOAT_EXP_MASK | 1);    //  11111111100000000000000000000001  (all ones exp, non-zero mantissa)
-          float FPositiveNaN      = asfloat(FLOAT_EXP_MASK | 1);                      //  01111111100000000000000000000001  (all ones exp, non-zero mantissa)
-          
-          
-          float FNonNormalNumbers[8] = {FNegativeZero, FPositiveZero, FNegativeDenormal, FPositiveDenormal, FNegativeInf, FPositiveInf, FNegativeNaN, FPositiveNaN};
-          float FNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
+      void main(uint ix : SV_GroupIndex) 
+      {
           TestFloatNumbers(g_SUnaryFPOp, g_InputSize);
-          
-          //Test Doubles now
-          /* This block needs to be uncommented whenever IsSpecialFloat supports doubles
-          
-                                                                                               // sign   exp                   mantissa
-                                                                                               //  | _____|___  ___________________|______________________________
-                                                                                               //  ||         ||                                                  |
-          double DNegativeZero     = asdouble(0, DOUBLE_SIGN_MASK);                            //  1000000000000000000000000000000000000000000000000000000000000000
-          double DPositiveZero     = asdouble(0, 0);                                           //  0000000000000000000000000000000000000000000000000000000000000000
-          double DNegativeDenormal = asdouble(1, DOUBLE_SIGN_MASK);                            //  1000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)
-          double DPositiveDenormal = asdouble(1, 0);                                           //  0000000000000000000000000000000000000000000000000000000000000001  (zero exp, non-zero mantissa)          
-          double DNegativeInf      = asdouble(0, DOUBLE_SIGN_MASK | DOUBLE_EXP_MASK);          //  1111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
-          double DPositiveInf      = asdouble(0, DOUBLE_EXP_MASK);                             //  0111111111110000000000000000000000000000000000000000000000000000  (all ones exp, zero mantissa)
-          double DNegativeNaN      = asdouble(1, DOUBLE_SIGN_MASK | DOUBLE_EXP_MASK | 1);      //  1111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
-          double DPositiveNaN      = asdouble(1, DOUBLE_EXP_MASK | 1);                         //  0111111111110000000000000000000000000000000000000000000000000001  (all ones exp, non-zero mantissa)
-          
-          double DNonNormalNumbers[8] = {DNegativeZero, DPositiveZero, DNegativeDenormal, DPositiveDenormal, DNegativeInf, DPositiveInf, DNegativeNaN, DPositiveNaN};
-          double DNormalNumbers[4] = {530.99, -530.99, 122.101, -.122101};
-          TestDoubleNumbers(g_result_doubles, DNonNormalNumbers, 8u, DNormalNumbers, 4u);
-          */
       }
     
     ]]>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3728,10 +3728,10 @@ void MSMain(uint GID : SV_GroupIndex,
   </ShaderOp>
 
   <ShaderOp Name="IsNormal" CS="CS60">
-    <Resource Name="g_SUnaryFPOp"         Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ByName"    Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS" />
+    <Resource Name="g_TestData"         Dimension="BUFFER"     Width="96"            InitialResourceState="COPY_DEST" Init="ByName"    Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS" />
 
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
-      <Descriptor Name="g_SUnaryFPOp"      NumElements="12" Kind="UAV"  StructureByteStride="8"/>
+      <Descriptor Name="g_TestData"      NumElements="12" Kind="UAV"  StructureByteStride="8"/>
     </DescriptorHeap>
     <RootValues>
       <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
@@ -3743,19 +3743,19 @@ void MSMain(uint GID : SV_GroupIndex,
         
       #define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( UAV(u0, numDescriptors=1))")]
     
-      struct InOut{
+      struct TestPoint{
         float input;
         uint output;
       };
     
       // Result buffers
-      RWStructuredBuffer <InOut> g_SUnaryFPOp     : register(u0);
+      RWStructuredBuffer <TestPoint> g_TestData     : register(u0);
    
       ROOT_SIG
       [NumThreads(12, 1, 1)]
       void main(uint ix : SV_GroupIndex)
       {
-        g_SUnaryFPOp[ix].output = isnan(g_SUnaryFPOp[ix].input);
+        g_TestData[ix].output = isnan(g_TestData[ix].input);
       }
     
     ]]>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3733,6 +3733,7 @@ void MSMain(uint GID : SV_GroupIndex,
     <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
       <Descriptor Name="g_TestData"      NumElements="12" Kind="UAV"  StructureByteStride="8"/>
     </DescriptorHeap>
+    
     <RootValues>
       <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
     </RootValues>

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11344,7 +11344,7 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 }
 
 TEST_F(ExecutionTest, IsNormalTest) {
-  //EnableShaderBasedValidation();
+  EnableShaderBasedValidation();
     WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11352,7 +11352,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
   // are "fallback". If TestShaderModels has length y, and a test loops through all shader models, a convention
   // to test based on whether fallback is enabled or not is to limit the loop like this:
   // unsigned num_models_to_test = ExecutionTest::IsFallbackPathEnabled() ? y : x;
-  D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_6;
+  D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
   LogCommentFmt(L"\r\nVerifying isNormal in shader "
                 L"model 6.%1u",
                 ((UINT)sm & 0x0f));
@@ -11373,7 +11373,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
 
   // Test Compute shader
   {
-    pShaderOp->CS = pShaderOp->GetString("CS66");
+    pShaderOp->CS = pShaderOp->GetString("CS60");
     std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
         pDevice, m_support, "IsNormal", nullptr,
         ShaderOpSet);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11344,6 +11344,7 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 }
 
 TEST_F(ExecutionTest, IsNormalTest) {
+  //EnableShaderBasedValidation();
     WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
@@ -11358,7 +11359,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
 
   const int expectedResultsSize = 12;
   // false represents 0, true represents a non-zero value
-  int expectedResults[expectedResultsSize] = {0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0};
+  int expectedResults[expectedResultsSize] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
     
   // TestShaderModels will be an array, where the first x models are "non-fallback", and the rest of the models
   // are "fallback". If TestShaderModels has length y, and a test loops through all shader models, a convention
@@ -11386,10 +11387,12 @@ TEST_F(ExecutionTest, IsNormalTest) {
     CComPtr<IDxcBlob> rewrittenDisassembly = nullptr;
     IDxcOperationResult * pOpResult = CompileAndRewriteAssemblyToText(m_support, pText, L"cs_6_0", L"", &rewrittenDisassembly, 
       {
-          "IsNaN",
+          "@dx.op.isSpecialFloat.f32(i32 8,",
+          //"IsNaN",
       },
       {
-          "IsSpecialFloat",
+          "@dx.op.isSpecialFloat.f32(i32 11,",
+          //"IsNaN",
       },
       false
     );

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11461,7 +11461,11 @@ TEST_F(ExecutionTest, IsNormalTest) {
   vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
   const int expectedResultsSize = 12;
-  // false represents 0, true represents a non-zero value
+  
+  // Checks result of IsNormal for a set of 8 floats that should NOT be Normal:
+  // FNegativeZero FPositiveZero FNegativeDenormal FPositiveDenormal FNegativeInf FPositiveInf FNegativeNaN FPositiveNaN
+  // And then a set of 4 floats that should be Normal:
+  // 530.99, -530.99, 122.101, -.122101
   int expectedResults[expectedResultsSize] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
     
   // TestShaderModels will be an array, where the first x models are "non-fallback", and the rest of the models

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11344,7 +11344,6 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 }
 
 TEST_F(ExecutionTest, IsNormalTest) {
-  EnableShaderBasedValidation();
     WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11729,7 +11729,6 @@ extern "C" {
     return hr;
   }
 }
-
 #endif
 // MARKER: ExecutionTest/DxilConf Shared Implementation End
 // Do not remove the line above - it is used by TranslateExecutionTest.py

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11418,7 +11418,6 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     // the Root Signature will be retained by ShaderOpTest, and won't be 
     // permanently lost when assembling the container
     // Otherwise, it's necessary to add the root signature back into the assembled dxil container
-   
     if (!bRootSigInXML) 
     {
       // Find root signature part in container
@@ -11455,12 +11454,12 @@ struct TestData
   };
 
 TEST_F(ExecutionTest, IsNormalTest) {
-  EnableShaderBasedValidation();
+    // EnableShaderBasedValidation();
     // In order, the input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 Normal float numbers.
+    // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
     std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.101f, -.122101f};
     std::vector<float> *Validation_Input = &Validation_Input_Vec;
 
-    //std::vector<float> Validation_Expected_Vec = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f};
     std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};
     std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
 
@@ -11478,12 +11477,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
 
   const int expectedResultsSize = 12;
   
-  // Checks result of IsNormal for a set of 8 floats that should NOT be Normal:
-  // FNegativeZero FPositiveZero FNegativeDenormal FPositiveDenormal FNegativeInf FPositiveInf FNegativeNaN FPositiveNaN
-  // And then a set of 4 floats that should be Normal:
-  // 530.99, -530.99, 122.101, -.122101
-  // int expectedResults[expectedResultsSize] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1};
-
   D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
   LogCommentFmt(L"\r\nVerifying isNormal in shader "
                 L"model 6.%1u",
@@ -11501,9 +11494,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
     WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
     return;
   }
-
-  //LPCWSTR Validation_Type = handler.GetTableParamByName(L"Validation.Type")->m_str;
-  //double Validation_Tolerance = handler.GetTableParamByName(L"Validation.Tolerance")->m_double;
 
   size_t count = Validation_Input->size();
 
@@ -11555,28 +11545,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
         VERIFY_ARE_EQUAL(p->output, val);
         
     }
-
-    /*
-    MappedData resultDataFloats;
-    test->Test->GetReadBackData("g_result_floats", &resultDataFloats);
-    const int *resultCSFloats = (int *)resultDataFloats.data();
-
-    for (unsigned int i = 0; i < expectedResultsSize; i++)
-    {
-      VERIFY_ARE_EQUAL(resultCSFloats[i], expectedResults[i]);
-    }
-    */
-
-    /* This block needs to be uncommented whenever IsSpecialFloat supports doubles
-    MappedData resultDataDoubles;
-    test->Test->GetReadBackData("g_result_doubles", &resultDataDoubles);
-    const int *resultCSDoubles = (int *)resultDataDoubles.data();
-
-    for (unsigned int i = 0; i < expectedResultsSize; i++)
-    {
-      VERIFY_ARE_EQUAL(resultCSDoubles[i], expectedResults[i]);
-    }
-    */
   }
 
 }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -24,6 +24,7 @@
 #include <iomanip>
 #include "dxc/Test/CompilationResult.h"
 #include "dxc/Test/HLSLTestData.h"
+#include "dxc/DxilContainer/DxilContainer.h"
 #include <Shlwapi.h>
 #include <atlcoll.h>
 #include <locale>
@@ -11404,13 +11405,13 @@ TEST_F(ExecutionTest, IsNormalTest) {
     // c_str() guarantees null termination; passing size + 1 to include it will create an IDxcBlobUtf8 without copying.
     CComPtr<IDxcBlobEncoding> rewrittenDisassembly;
     VERIFY_SUCCEEDED(pUtils->CreateBlobFromPinned(
-      disassembly.c_str(), disassembly.size() + 1, DXC_CP_UTF8, &rewrittenDisassembly));
+      disassembly.c_str(), (UINT32) disassembly.size() + 1, DXC_CP_UTF8, &rewrittenDisassembly));
     // Assemble to container
     CComPtr<IDxcBlob> assembledShader;
     AssembleToContainer(m_support, rewrittenDisassembly, &assembledShader);
     // Find root signature part in container
-    hlsl::DxilContainerHeader *pContainerHeader = hlsl::IsDxilContainerLike(assembledShader->GetBufferPointer(), assembledShader->GetBufferSize());
-    VERIFY_SUCCEEDED(hlsl::IsValidDxilContainer(pContainerHeader, assembledShader->GetBufferSize()));
+    hlsl::DxilContainerHeader *pContainerHeader = hlsl::IsDxilContainerLike(compiledShader->GetBufferPointer(), compiledShader->GetBufferSize());
+    VERIFY_SUCCEEDED(hlsl::IsValidDxilContainer(pContainerHeader, compiledShader->GetBufferSize()));
     hlsl::DxilPartHeader *pPartHeader = hlsl::GetDxilPartByType(
         pContainerHeader, hlsl::DxilFourCC::DFCC_RootSignature);
     VERIFY_IS_NOT_NULL(pPartHeader);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11393,9 +11393,12 @@ TEST_F(ExecutionTest, IsNormalTest) {
     VerifyCompileOK(m_support, pText, L"cs_6_0", args, &compiledShader);
     std::string disassembly = DisassembleProgram(m_support, compiledShader);
     // Replace op
-    ReplaceText(
-      { "@dx.op.isSpecialFloat.f32(i32 8," },
-      { "@dx.op.isSpecialFloat.f32(i32 11," },
+    ReplaceDisassemblyText(
+      { "@dx.op.isSpecialFloat.f32(i32 8,"},
+      { "@dx.op.isSpecialFloat.f32(i32 11,"},
+      // Replace the above with what's below when IsSpecialFloat supports doubles
+      //{ "@dx.op.isSpecialFloat.f32(i32 8,",  "@dx.op.isSpecialFloat.f32(i32 9," },
+      //{ "@dx.op.isSpecialFloat.f32(i32 11,", "@dx.op.isSpecialFloat.f64(i32 11," },
       /*bRegex*/false,
       disassembly
     );
@@ -11448,6 +11451,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
       VERIFY_ARE_EQUAL(resultCSFloats[i], expectedResults[i]);
     }
 
+    /* This block needs to be uncommented whenever IsSpecialFloat supports doubles
     MappedData resultDataDoubles;
     test->Test->GetReadBackData("g_result_doubles", &resultDataDoubles);
     const int *resultCSDoubles = (int *)resultDataDoubles.data();
@@ -11456,6 +11460,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
     {
       VERIFY_ARE_EQUAL(resultCSDoubles[i], expectedResults[i]);
     }
+    */
   }
 
 }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11451,7 +11451,7 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
 struct TestData
   {
     float input;
-    float output;
+    unsigned int output;
   };
 
 TEST_F(ExecutionTest, IsNormalTest) {
@@ -11460,8 +11460,9 @@ TEST_F(ExecutionTest, IsNormalTest) {
     std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.101f, -.122101f};
     std::vector<float> *Validation_Input = &Validation_Input_Vec;
 
-    std::vector<float> Validation_Expected_Vec = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f};
-    std::vector<float> *Validation_Expected = &Validation_Expected_Vec;
+    //std::vector<float> Validation_Expected_Vec = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};
+    std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
 
     WEX::TestExecution::SetVerifyOutput verifySettings(
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
@@ -11547,9 +11548,9 @@ TEST_F(ExecutionTest, IsNormalTest) {
     WEX::TestExecution::DisableVerifyExceptions dve;
     for (unsigned i = 0; i < count; ++i) {
         TestData *p = &pPrimitives[i];
-        float val = (*Validation_Expected)[i % Validation_Expected->size()];
+        unsigned int val = (*Validation_Expected)[i % Validation_Expected->size()];
         LogCommentFmt(
-            L"element #%u, input = %6.8f, output = %6.8f, expected = %6.8f", i,
+            L"element #%u, input = %6.8f, output = %6.8f, expected = %d", i,
             p->input, p->output, val);
         VERIFY_ARE_EQUAL(p->output, val);
         

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -793,7 +793,9 @@ void ShaderOpTest::CreateShaders() {
          ShaderOpLogFmt(L"Callback required for shader, but not provided: %S\r\n", S.Name);
          CHECK_HR(E_FAIL);
        }
-       m_ShaderCallbackFn(S.Name, pText, &pCode, m_pShaderOp);
+       CComPtr<IDxcBlob> pCode2;
+       m_ShaderCallbackFn(S.Name, pText, &pCode2, m_pShaderOp);
+       pCode = (ID3DBlob *) pCode2.Detach();
  
     } else if (S.Compiled) {
       int textLen = (int)strlen(pText);

--- a/tools/clang/unittests/HLSL/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.cpp
@@ -793,11 +793,9 @@ void ShaderOpTest::CreateShaders() {
          ShaderOpLogFmt(L"Callback required for shader, but not provided: %S\r\n", S.Name);
          CHECK_HR(E_FAIL);
        }
-       CComPtr<IDxcBlob> pCode2;
-       m_ShaderCallbackFn(S.Name, pText, &pCode2, m_pShaderOp);
-       pCode = (ID3DBlob *) pCode2.Detach();
- 
-    } else if (S.Compiled) {
+       m_ShaderCallbackFn(S.Name, pText, (IDxcBlob **) &pCode, m_pShaderOp); 
+    }
+    else if (S.Compiled) {
       int textLen = (int)strlen(pText);
       int decodedLen = Base64DecodeGetRequiredLength(textLen);
       // Length is an approximation, so we can't creat the final blob yet.

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -161,6 +161,7 @@ public:
   LPCSTR  Arguments;  // Command line Arguments.
   LPCSTR  Defines;    // HLSL Defines.
   BOOL    Compiled;   // Whether text is a base64-encoded value.
+  BOOL    Callback;    // Whether a function exists to modify the shader's disassembly.
 };
 
 // Use this class to represent a value in the root signature.
@@ -252,6 +253,7 @@ struct CommandListRefs {
 class ShaderOpTest {
 public:
   typedef std::function<void(LPCSTR Name, std::vector<BYTE> &Data, ShaderOp *pShaderOp)> TInitCallbackFn;
+  typedef std::function<void(LPCSTR Name, LPCSTR pText, ID3DBlob **ppShaderBlob, ShaderOp *pShaderOp)> TShaderCallbackFn;
   void GetPipelineStats(D3D12_QUERY_DATA_PIPELINE_STATISTICS *pStats);
   void GetReadBackData(LPCSTR pResourceName, MappedData *pData);
   void RunShaderOp(ShaderOp *pShaderOp);
@@ -259,6 +261,7 @@ public:
   void SetDevice(ID3D12Device* pDevice);
   void SetDxcSupport(dxc::DxcDllSupport *pDxcSupport);
   void SetInitCallback(TInitCallbackFn InitCallbackFn);
+  void SetShaderCallback(TShaderCallbackFn ShaderCallbackFn);
   void SetupRenderTarget(ShaderOp *pShaderOp, ID3D12Device *pDevice,
                          ID3D12CommandQueue *pCommandQueue,
                          ID3D12Resource *pRenderTarget);
@@ -296,6 +299,7 @@ private:
   std::vector<ID3D12DescriptorHeap *> m_DescriptorHeaps;
   std::shared_ptr<ShaderOp> m_OrigShaderOp;
   TInitCallbackFn m_InitCallbackFn = nullptr;
+  TShaderCallbackFn m_ShaderCallbackFn = nullptr;
   void CopyBackResources();
   void CreateCommandList();
   void CreateDescriptorHeaps();

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -253,7 +253,7 @@ struct CommandListRefs {
 class ShaderOpTest {
 public:
   typedef std::function<void(LPCSTR Name, std::vector<BYTE> &Data, ShaderOp *pShaderOp)> TInitCallbackFn;
-  typedef std::function<void(LPCSTR Name, LPCSTR pText, ID3DBlob **ppShaderBlob, ShaderOp *pShaderOp)> TShaderCallbackFn;
+  typedef std::function<void(LPCSTR Name, LPCSTR pText, IDxcBlob **ppShaderBlob, ShaderOp *pShaderOp)> TShaderCallbackFn;
   void GetPipelineStats(D3D12_QUERY_DATA_PIPELINE_STATISTICS *pStats);
   void GetReadBackData(LPCSTR pResourceName, MappedData *pData);
   void RunShaderOp(ShaderOp *pShaderOp);

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -250,8 +250,6 @@ struct CommandListRefs {
   void CreateForDevice(ID3D12Device *pDevice, bool compute);
 };
 
-
-
 // Use this class to run the operation described in a ShaderOp object.
 class ShaderOpTest {
 public:

--- a/tools/clang/unittests/HLSL/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSL/ShaderOpTest.h
@@ -35,6 +35,7 @@ class DxcDllSupport;
 }
 struct IStream;
 struct IXmlReader;
+struct IDxcBlob;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Useful helper functions.
@@ -248,6 +249,8 @@ struct CommandListRefs {
 
   void CreateForDevice(ID3D12Device *pDevice, bool compute);
 };
+
+
 
 // Use this class to run the operation described in a ShaderOp object.
 class ShaderOpTest {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -405,7 +405,7 @@ public:
     llvm::ArrayRef<LPCSTR> pErrorMsgs,
     bool bRegex = false) {
     CComPtr<IDxcBlob> pText;
-    if (!RewriteAssemblyToText(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, pLookFors, pReplacements, &pText, bRegex))
+    if (!CompileAndRewriteAssemblyToText(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, pLookFors, pReplacements, &pText, bRegex))
       return false;
     CComPtr<IDxcAssembler> pAssembler;
     CComPtr<IDxcOperationResult> pAssembleResult;
@@ -469,7 +469,7 @@ public:
       pLookFors, pReplacements, pErrorMsgs, bRegex);
   }
 
-  bool RewriteAssemblyToText(IDxcBlobEncoding *pSource, LPCSTR pShaderModel,
+  bool CompileAndRewriteAssemblyToText(IDxcBlobEncoding *pSource, LPCSTR pShaderModel,
                              LPCWSTR *pArguments, UINT32 argCount,
                              const DxcDefine *pDefines, UINT32 defineCount,
                              llvm::ArrayRef<LPCSTR> pLookFors,
@@ -480,64 +480,8 @@ public:
     if (!CompileSource(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, &pProgram))
       return false;
     DisassembleProgram(pProgram, &disassembly);
-    for (unsigned i = 0; i < pLookFors.size(); ++i) {
-      LPCSTR pLookFor = pLookFors[i];
-      bool bOptional = false;
-      if (pLookFor[0] == '?') {
-        bOptional = true;
-        pLookFor++;
-      }
-      LPCSTR pReplacement = pReplacements[i];
-      if (pLookFor && *pLookFor) {
-        if (bRegex) {
-          llvm::Regex RE(pLookFor);
-          std::string reErrors;
-          if (!RE.isValid(reErrors)) {
-            WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                L"Regex errors:\r\n%.*S\r\nWhile compiling expression '%S'",
-                (unsigned)reErrors.size(), reErrors.data(),
-                pLookFor));
-          }
-          VERIFY_IS_TRUE(RE.isValid(reErrors));
-          std::string replaced = RE.sub(pReplacement, disassembly, &reErrors);
-          if (!bOptional) {
-            if (!reErrors.empty()) {
-              WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                  L"Regex errors:\r\n%.*S\r\nWhile searching for '%S' in text:\r\n%.*S",
-                  (unsigned)reErrors.size(), reErrors.data(),
-                  pLookFor,
-                  (unsigned)disassembly.size(), disassembly.data()));
-            }
-            VERIFY_ARE_NOT_EQUAL(disassembly, replaced);
-            VERIFY_IS_TRUE(reErrors.empty());
-          }
-          disassembly = std::move(replaced);
-        } else {
-          bool found = false;
-          size_t pos = 0;
-          size_t lookForLen = strlen(pLookFor);
-          size_t replaceLen = strlen(pReplacement);
-          for (;;) {
-            pos = disassembly.find(pLookFor, pos);
-            if (pos == std::string::npos)
-              break;
-            found = true; // at least once
-            disassembly.replace(pos, lookForLen, pReplacement);
-            pos += replaceLen;
-          }
-          if (!bOptional) {
-            if (!found) {
-              WEX::Logging::Log::Comment(WEX::Common::String().Format(
-                  L"String not found: '%S' in text:\r\n%.*S",
-                  pLookFor,
-                  (unsigned)disassembly.size(), disassembly.data()));
-            }
-            VERIFY_IS_TRUE(found);
-          }
-        }
-      }
-    }
-    Utf8ToBlob(m_dllSupport, disassembly.c_str(), pBlob);
+
+    ReplaceDisassemblyText(pLookFors, pReplacements, pBlob, bRegex, disassembly, m_dllSupport);
     return true;
   }
 

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -405,19 +405,17 @@ public:
     llvm::ArrayRef<LPCSTR> pErrorMsgs,
     bool bRegex = false) {
     CComPtr<IDxcBlob> pText;
-    bool CompilationAndRewriteSucc = true;
 
     CComPtr<IDxcBlob> pProgram;
     std::string disassembly;
     if (!CompileSource(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, &pProgram))
-      CompilationAndRewriteSucc = false;
+      return false;
+
     DisassembleProgram(pProgram, &disassembly);
 
     ReplaceDisassemblyText(pLookFors, pReplacements, bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);
-
-    if (CompilationAndRewriteSucc)
-      return false;
+    
     CComPtr<IDxcAssembler> pAssembler;
     CComPtr<IDxcOperationResult> pAssembleResult;
     VERIFY_SUCCEEDED(

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -209,10 +209,8 @@ IDxcOperationResult * CompileAndRewriteAssemblyToText(dxc::DxcDllSupport &dllSup
   VERIFY_SUCCEEDED(pOpResult->GetResult(&pFirstCompiledBlob));
   std::string disassembly = DisassembleProgram(dllSupport, pFirstCompiledBlob);
 
-  ppResult = nullptr;
-  IDxcBlob *tempResult = nullptr;
-  ReplaceDisassemblyText(pLookFors, pReplacements, &tempResult, bRegex, disassembly, dllSupport);
-  *ppResult = tempResult;
+  *ppResult = nullptr;
+  ReplaceDisassemblyText(pLookFors, pReplacements, ppResult, bRegex, disassembly, dllSupport);
   return pOpResult;
 }
 
@@ -220,7 +218,7 @@ void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
                 llvm::ArrayRef<LPCSTR> pReplacements,
                 _Outptr_ IDxcBlob **pBlob, bool bRegex,
                 std::string& disassembly, dxc::DxcDllSupport &dllSupport){
-  assert(pBlob == nullptr);
+  assert(*pBlob == nullptr);
   for (unsigned i = 0; i < pLookFors.size(); ++i) {
     LPCSTR pLookFor = pLookFors[i];
     bool bOptional = false;

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -261,7 +261,6 @@ void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
                 llvm::ArrayRef<LPCSTR> pReplacements,
                 _Outptr_ IDxcBlob **pBlob, bool bRegex,
                 std::string& disassembly, dxc::DxcDllSupport &dllSupport){
-  assert(pBlob == nullptr);
   ReplaceText(pLookFors, pReplacements, bRegex, disassembly);
   Utf8ToBlob(dllSupport, disassembly.c_str(), pBlob);
 }

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -195,7 +195,7 @@ void AssembleToContainer(dxc::DxcDllSupport &dllSupport, IDxcBlob *pModule,
   CheckOperationSucceeded(pResult, pContainer);
 }
 
-void ReplaceText(llvm::ArrayRef<LPCSTR> pLookFors,
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
                 llvm::ArrayRef<LPCSTR> pReplacements,
                 bool bRegex, std::string& disassembly) {
   for (unsigned i = 0; i < pLookFors.size(); ++i) {
@@ -255,14 +255,6 @@ void ReplaceText(llvm::ArrayRef<LPCSTR> pLookFors,
       }
     }
   }
-}
-
-void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
-                llvm::ArrayRef<LPCSTR> pReplacements,
-                _Outptr_ IDxcBlob **pBlob, bool bRegex,
-                std::string& disassembly, dxc::DxcDllSupport &dllSupport){
-  ReplaceText(pLookFors, pReplacements, bRegex, disassembly);
-  Utf8ToBlob(dllSupport, disassembly.c_str(), pBlob);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -195,30 +195,9 @@ void AssembleToContainer(dxc::DxcDllSupport &dllSupport, IDxcBlob *pModule,
   CheckOperationSucceeded(pResult, pContainer);
 }
 
-IDxcOperationResult * CompileAndRewriteAssemblyToText(dxc::DxcDllSupport &dllSupport, LPCSTR pText, 
-                            LPWSTR pTargetProfile, LPCWSTR pArgs,  _Outptr_ IDxcBlob **ppResult,
-                            llvm::ArrayRef<LPCSTR> pLookFors,
-                            llvm::ArrayRef<LPCSTR> pReplacements,
-                            bool bRegex) {
-
-  IDxcBlob * pFirstCompiledBlob;
-  IDxcOperationResult * pOpResult = VerifyCompileOK(dllSupport, pText,
-                    pTargetProfile, pArgs,
-                    &pFirstCompiledBlob);
-
-  VERIFY_SUCCEEDED(pOpResult->GetResult(&pFirstCompiledBlob));
-  std::string disassembly = DisassembleProgram(dllSupport, pFirstCompiledBlob);
-
-  *ppResult = nullptr;
-  ReplaceDisassemblyText(pLookFors, pReplacements, ppResult, bRegex, disassembly, dllSupport);
-  return pOpResult;
-}
-
-void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
+void ReplaceText(llvm::ArrayRef<LPCSTR> pLookFors,
                 llvm::ArrayRef<LPCSTR> pReplacements,
-                _Outptr_ IDxcBlob **pBlob, bool bRegex,
-                std::string& disassembly, dxc::DxcDllSupport &dllSupport){
-  assert(*pBlob == nullptr);
+                bool bRegex, std::string& disassembly) {
   for (unsigned i = 0; i < pLookFors.size(); ++i) {
     LPCSTR pLookFor = pLookFors[i];
     bool bOptional = false;
@@ -276,6 +255,14 @@ void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
       }
     }
   }
+}
+
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
+                llvm::ArrayRef<LPCSTR> pReplacements,
+                _Outptr_ IDxcBlob **pBlob, bool bRegex,
+                std::string& disassembly, dxc::DxcDllSupport &dllSupport){
+  assert(pBlob == nullptr);
+  ReplaceText(pLookFors, pReplacements, bRegex, disassembly);
   Utf8ToBlob(dllSupport, disassembly.c_str(), pBlob);
 }
 

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -414,7 +414,7 @@ void WideToBlob(dxc::DxcDllSupport &dllSupport, const std::wstring &val,
   WideToBlob(dllSupport, val, (IDxcBlobEncoding **)ppBlob);
 }
 
-IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, LPCWSTR pArgs,
                      _Outptr_ IDxcBlob **ppResult) {
   std::vector<std::wstring> argsW;
@@ -426,10 +426,10 @@ IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pTe
     transform(argsW.begin(), argsW.end(), back_inserter(args),
               [](const wstring &w) { return w.data(); });
   }
-  return VerifyCompileOK(dllSupport, pText, pTargetProfile, args, ppResult);
+  VerifyCompileOK(dllSupport, pText, pTargetProfile, args, ppResult);
 }
 
-IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
+void VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pText,
                      LPWSTR pTargetProfile, std::vector<LPCWSTR> &args,
                      _Outptr_ IDxcBlob **ppResult) {
   CComPtr<IDxcCompiler> pCompiler;
@@ -444,8 +444,7 @@ IDxcOperationResult * VerifyCompileOK(dxc::DxcDllSupport &dllSupport, LPCSTR pTe
                                       nullptr, 0, nullptr, &pResult));
   VERIFY_SUCCEEDED(pResult->GetStatus(&hrCompile));
   VERIFY_SUCCEEDED(hrCompile);
-  return (IDxcOperationResult *)pResult.Detach();
-  //VERIFY_SUCCEEDED(pResult->GetResult(ppResult));
+  VERIFY_SUCCEEDED(pResult->GetResult(ppResult));
 }
 
 HRESULT GetVersion(dxc::DxcDllSupport& DllSupport, REFCLSID clsid, unsigned &Major, unsigned &Minor) {


### PR DESCRIPTION
This change adds an hlktest to test the isSpecialFloat dxil call. This test facilitated by the implementation of a new feature for the shader op test framework: shader call back functions. This specific test was implemented by taking the dxil generated from an isnan call in the source, and replacing it with the "isSpecialFloat" dxil call using various disassembly replacement functions. 