### PR TITLE
Add support for separate ARM64 and ARM64EC testing

### DIFF
--- a/tools/opt/CMakeLists.txt
+++ b/tools/opt/CMakeLists.txt
@@ -39,12 +39,13 @@ add_llvm_tool(opt
 )
 
 if(WIN32 AND HLSL_BUILD_DXILCONV)
-  set_source_files_properties(opt.cpp PROPERTIES
-                                      COMPILE_DEFINITIONS "HAS_DXILCONV")
+  add_compile_definitions(HAS_DXILCONV)
+  
+#  set_source_files_properties(opt.cpp PROPERTIES
+#                                      COMPILE_DEFINITIONS "HAS_DXILCONV")
 
-  target_link_libraries(opt DxilConvPasses
-)
-add_dependencies(opt DxilConvPasses)
+  target_link_libraries(opt DxilConvPasses)
+  add_dependencies(opt DxilConvPasses)
 endif(WIN32 AND HLSL_BUILD_DXILCONV)
 
 export_executable_symbols(opt)

--- a/tools/opt/CMakeLists.txt
+++ b/tools/opt/CMakeLists.txt
@@ -40,10 +40,6 @@ add_llvm_tool(opt
 
 if(WIN32 AND HLSL_BUILD_DXILCONV)
   add_compile_definitions(HAS_DXILCONV)
-  
-#  set_source_files_properties(opt.cpp PROPERTIES
-#                                      COMPILE_DEFINITIONS "HAS_DXILCONV")
-
   target_link_libraries(opt DxilConvPasses)
   add_dependencies(opt DxilConvPasses)
 endif(WIN32 AND HLSL_BUILD_DXILCONV)

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -149,7 +149,7 @@ if "%HLSL_TAEF_MINTE%"=="" (
 echo Found TAEF at %HLSL_TAEF_MINTE%
 set HLSL_TAEF_DIR=%HLSL_BLD_DIR%\TAEF
 echo Copying to %HLSL_TAEF_DIR% for use with AgilitySDK
-mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%"" 1>nul 2>nul
+mkdir "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%" 1>nul 2>nul
 robocopy /NP /NJH /NJS /S "%HLSL_TAEF_MINTE%" "%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%" *
 set path=%path%;%HLSL_TAEF_DIR%\%BUILD_ARCH:Win32=x86%
 goto:eof
@@ -205,7 +205,7 @@ for /F "tokens=1,2*" %%A in ('%REG_QUERY% /v InstallationFolder') do (
   )
 )
 if ""=="%kit_root%" (
-    set kit_root=%WIN10_SDK_PATH%
+    set "kit_root=%WIN10_SDK_PATH%"
 )
 if ""=="%kit_root%" (
   echo Did not find a Windows 10 SDK installation.


### PR DESCRIPTION
If tests are built as ARM64X, the test dll contains two versions of each test - the native ARM64 code and the emulation-ready x64 code (== ARM64EC). By default, TAEF will run both versions of the tests. The tests have the same name, so if one is failing, it is not clear if it is the ARM64 or ARM64EC version. 

It is preferable to run the tests for each platform separately. This PR adds @Architecture parameter to the TAEF tests invocation, which enables exactly that. The hcttest.cmd script has a new argument -arm64ec for running ARM64EC-only tests, and similarly the -arm64 will run only the native ARM64 tests.

Also includes couple of fixes in hctstart.cmd.