### PR TITLE
[spirv] Translate HLSL round to RoundEven

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -2364,7 +2364,7 @@ HLSL Intrinsic Function   GLSL Extended Instruction
 ``pow``                 ``Pow``
 ``reflect``             ``Reflect``
 ``refract``             ``Refract``
-``round``               ``Round``
+``round``               ``RoundEven``
 ``rsqrt``               ``InverseSqrt``
 ``saturate``            ``FClamp``
 ``sign``                ``SSign``/``FSign``

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8109,7 +8109,7 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     INTRINSIC_SPIRV_OP_CASE(fmod, FRem, true);
     INTRINSIC_SPIRV_OP_CASE(fwidth, Fwidth, true);
     INTRINSIC_SPIRV_OP_CASE(reversebits, BitReverse, false);
-    INTRINSIC_OP_CASE(round, Round, true);
+    INTRINSIC_OP_CASE(round, RoundEven, true);
     INTRINSIC_OP_CASE(uabs, SAbs, true);
     INTRINSIC_OP_CASE_INT_FLOAT(abs, SAbs, FAbs, true);
     INTRINSIC_OP_CASE(acos, Acos, true);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.round.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.round.hlsl
@@ -2,6 +2,7 @@
 
 // According to HLSL reference:
 // The 'round' function can only operate on float, vector of float, and matrix of float.
+// Rounds the specified value to the nearest integer. Halfway cases are rounded to the nearest even.
 
 // CHECK:      [[glsl:%\d+]] = OpExtInstImport "GLSL.std.450"
 
@@ -13,48 +14,48 @@ void main() {
   float3x2 result3x2;
 
 // CHECK:      [[a:%\d+]] = OpLoad %float %a
-// CHECK-NEXT: [[round_a:%\d+]] = OpExtInst %float [[glsl]] Round [[a]]
+// CHECK-NEXT: [[round_a:%\d+]] = OpExtInst %float [[glsl]] RoundEven [[a]]
 // CHECK-NEXT: OpStore %result [[round_a]]
   float a;
   result = round(a);
 
 // CHECK-NEXT: [[b:%\d+]] = OpLoad %float %b
-// CHECK-NEXT: [[round_b:%\d+]] = OpExtInst %float [[glsl]] Round [[b]]
+// CHECK-NEXT: [[round_b:%\d+]] = OpExtInst %float [[glsl]] RoundEven [[b]]
 // CHECK-NEXT: OpStore %result [[round_b]]
   float1 b;
   result = round(b);
 
 // CHECK-NEXT: [[c:%\d+]] = OpLoad %v3float %c
-// CHECK-NEXT: [[round_c:%\d+]] = OpExtInst %v3float [[glsl]] Round [[c]]
+// CHECK-NEXT: [[round_c:%\d+]] = OpExtInst %v3float [[glsl]] RoundEven [[c]]
 // CHECK-NEXT: OpStore %result3 [[round_c]]
   float3 c;
   result3 = round(c);
 
 // CHECK-NEXT: [[d:%\d+]] = OpLoad %float %d
-// CHECK-NEXT: [[round_d:%\d+]] = OpExtInst %float [[glsl]] Round [[d]]
+// CHECK-NEXT: [[round_d:%\d+]] = OpExtInst %float [[glsl]] RoundEven [[d]]
 // CHECK-NEXT: OpStore %result [[round_d]]
   float1x1 d;
   result = round(d);
 
 // CHECK-NEXT: [[e:%\d+]] = OpLoad %v2float %e
-// CHECK-NEXT: [[round_e:%\d+]] = OpExtInst %v2float [[glsl]] Round [[e]]
+// CHECK-NEXT: [[round_e:%\d+]] = OpExtInst %v2float [[glsl]] RoundEven [[e]]
 // CHECK-NEXT: OpStore %result2 [[round_e]]
   float1x2 e;
   result2 = round(e);
 
 // CHECK-NEXT: [[f:%\d+]] = OpLoad %v4float %f
-// CHECK-NEXT: [[round_f:%\d+]] = OpExtInst %v4float [[glsl]] Round [[f]]
+// CHECK-NEXT: [[round_f:%\d+]] = OpExtInst %v4float [[glsl]] RoundEven [[f]]
 // CHECK-NEXT: OpStore %result4 [[round_f]]
   float4x1 f;
   result4 = round(f);
 
 // CHECK-NEXT: [[g:%\d+]] = OpLoad %mat3v2float %g
 // CHECK-NEXT: [[g_row0:%\d+]] = OpCompositeExtract %v2float [[g]] 0
-// CHECK-NEXT: [[round_g_row0:%\d+]] = OpExtInst %v2float [[glsl]] Round [[g_row0]]
+// CHECK-NEXT: [[round_g_row0:%\d+]] = OpExtInst %v2float [[glsl]] RoundEven [[g_row0]]
 // CHECK-NEXT: [[g_row1:%\d+]] = OpCompositeExtract %v2float [[g]] 1
-// CHECK-NEXT: [[round_g_row1:%\d+]] = OpExtInst %v2float [[glsl]] Round [[g_row1]]
+// CHECK-NEXT: [[round_g_row1:%\d+]] = OpExtInst %v2float [[glsl]] RoundEven [[g_row1]]
 // CHECK-NEXT: [[g_row2:%\d+]] = OpCompositeExtract %v2float [[g]] 2
-// CHECK-NEXT: [[round_g_row2:%\d+]] = OpExtInst %v2float [[glsl]] Round [[g_row2]]
+// CHECK-NEXT: [[round_g_row2:%\d+]] = OpExtInst %v2float [[glsl]] RoundEven [[g_row2]]
 // CHECK-NEXT: [[round_matrix:%\d+]] = OpCompositeConstruct %mat3v2float [[round_g_row0]] [[round_g_row1]] [[round_g_row2]]
 // CHECK-NEXT: OpStore %result3x2 [[round_matrix]]
   float3x2 g;


### PR DESCRIPTION
The specification for the HLSL round intrinsic function states "Rounds
the specified value to the nearest integer. Halfway cases are rounded to
the nearest even.", so translate it to RoundEven SPIR-V extended
instruction rather than Round.

Fixes #4368