### PR TITLE
[spirv] Fail when unsupported options are used

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1071,6 +1071,21 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.entrypointName =
       Args.getLastArgValue(OPT_fspv_entrypoint_name_EQ);
 
+  // Options not currently implemented in the SPIR-V backend.
+  // The options checked here are non-exhaustive. A thorough audit of available
+  // options and their current compatibility is needed to generate a complete
+  // list.
+  if (Args.hasFlag(OPT_spirv, OPT_INVALID, false)) {
+    if (!Args.getLastArgValue(OPT_Fd).empty()) {
+      errors << "-Fd is not currently supported with -spirv";
+      return 1;
+    }
+    if (!Args.getLastArgValue(OPT_Fre).empty()) {
+      errors << "-Fre is not currently supported with -spirv";
+      return 1;
+    }
+  }
+
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false) ||

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.fd.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.fd.hlsl
@@ -2,4 +2,4 @@
 
 void main() {}
 
-// CHECK: -Fd is not currently supported with -spirv
+// CHECK: -Fd is not supported with -spirv

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.fd.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.fd.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -Fd file.ext
+
+void main() {}
+
+// CHECK: -Fd is not currently supported with -spirv

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.fre.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.fre.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -Fre file.ext
+
+void main() {}
+
+// CHECK: -Fre is not currently supported with -spirv

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.fre.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.fre.hlsl
@@ -2,4 +2,4 @@
 
 void main() {}
 
-// CHECK: -Fre is not currently supported with -spirv
+// CHECK: -Fre is not supported with -spirv

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.qstripreflect.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.qstripreflect.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -Qstrip_reflect
+
+void main() {}
+
+// CHECK: -Qstrip_reflect is not supported with -spirv

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3131,4 +3131,12 @@ TEST_F(FileTest, RenameEntrypoint) { runFileTest("fspv-entrypoint-name.hlsl"); }
 
 TEST_F(FileTest, PrintAll) { runFileTest("fspv-print-all.hlsl"); }
 
+TEST_F(FileTest, SpirvOptFd) {
+  runFileTest("spirv.opt.fd.hlsl", Expect::Failure);
+}
+
+TEST_F(FileTest, SpirvOptFre) {
+  runFileTest("spirv.opt.fre.hlsl", Expect::Failure);
+}
+
 } // namespace

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3134,9 +3134,11 @@ TEST_F(FileTest, PrintAll) { runFileTest("fspv-print-all.hlsl"); }
 TEST_F(FileTest, SpirvOptFd) {
   runFileTest("spirv.opt.fd.hlsl", Expect::Failure);
 }
-
 TEST_F(FileTest, SpirvOptFre) {
   runFileTest("spirv.opt.fre.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, SpirvOptQStripReflect) {
+  runFileTest("spirv.opt.qstripreflect.hlsl", Expect::Failure);
 }
 
 } // namespace


### PR DESCRIPTION
Some DXC options are not supported in combination with the SPIR-V
backend. Rather than silently ignore them, we should emit a clear error
message. This change adds appropriate error messages for a couple
options that have been mentioned in issues #3111 and #4496, but more
should be added in future.