### PR TITLE
[spirv] Clarify error when Globals binding missing

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -3937,7 +3937,8 @@ codegen for Vulkan:
   option cannot be used together with other binding assignment options.
   It requires all source code resources have ``:register()`` attribute and
   all registers have corresponding Vulkan descriptors specified using this
-  option.
+  option. If the ``$Globals`` cbuffer resource is used, it must also be bound
+  with ``-fvk-bind-globals``.
 - ``-fvk-bind-globals N M``: Places the ``$Globals`` cbuffer at
   descriptor set #M and binding #N. See `HLSL global variables and Vulkan binding`_
   for explanation and examples.

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2222,7 +2222,14 @@ bool DeclResultIdMapper::decorateResourceBindings() {
           }
           spvBuilder.decorateDSetBinding(var.getSpirvInstr(), setNo, bindNo);
         }
-      } else if (bindGlobals && var.isGlobalsBuffer()) {
+      } else if (var.isGlobalsBuffer()) {
+        if (!bindGlobals) {
+          emitError("-fvk-bind-register requires Globals buffer to be bound "
+                    "with -fvk-bind-globals",
+                    var.getSourceLocation());
+          return false;
+        }
+
         spvBuilder.decorateDSetBinding(var.getSpirvInstr(), globalsSetNo,
                                        globalsBindNo);
       } else {

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.register.missing-bind-globals.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.register.missing-bind-globals.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T ps_6_0 -E main -fvk-bind-register t5 0 1 2 -vkbr s3 1 3 4
+
+Texture2D MyTexture    : register(t5);
+SamplerState MySampler : register(s3, space1);
+
+int globalInteger;
+float4 globalFloat4;
+
+float4 main() : SV_Target {
+  return MyTexture.Sample(MySampler, float2(0.1, 0.2));
+}
+
+// CHECK: error: -fvk-bind-register requires Globals buffer to be bound with -fvk-bind-globals

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2015,6 +2015,10 @@ TEST_F(FileTest, VulkanRegisterBinding1to1MappingInvalidBindNo) {
 TEST_F(FileTest, VulkanRegisterBinding1to1MappingMissingAttr) {
   runFileTest("vk.binding.cl.register.missing-attr.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, VulkanRegisterBinding1to1MappingMissingBindGlobals) {
+  runFileTest("vk.binding.cl.register.missing-bind-globals.hlsl",
+              Expect::Failure);
+}
 TEST_F(FileTest, VulkanRegisterBinding1to1MappingMissingCLOption) {
   runFileTest("vk.binding.cl.register.missing-cl.hlsl", Expect::Failure);
 }


### PR DESCRIPTION
When -fvk-bind-register is used, all resource must have corresponding
register bindings set, including the Globals cbuffer. This change
clarifies the error message when the latter is the cause of failure and
directs the user to specify -fvk-bind-globals.

Fixes #3781