### PR TITLE
More conforming to C++ standards

### DIFF
--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -98,7 +98,7 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
   try {
     m_symsMgr.Init(this);
   } catch (const hlsl::Exception &) {
-    m_symsMgr = std::move(dxil_dia::SymbolManager());
+    m_symsMgr = dxil_dia::SymbolManager();
   }
 }
 

--- a/projects/dxilconv/include/DxilConvPasses/ScopeNest.h
+++ b/projects/dxilconv/include/DxilConvPasses/ScopeNest.h
@@ -76,7 +76,7 @@ struct ScopeNestEvent {
     return ScopeNestEvent(nullptr, Type::Invalid);
   }
 
-  const bool IsBeginScope() const {
+  bool IsBeginScope() const {
     switch (ElementType) {
     case Type::TopLevel_Begin:
       return "TopLevel_Begin";
@@ -91,7 +91,7 @@ struct ScopeNestEvent {
     return false;
   }
 
-  const bool IsEndScope() const {
+  bool IsEndScope() const {
     switch (ElementType) {
     case Type::If_End:
     case Type::Switch_End:

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -567,11 +567,11 @@ void DxbcConverter::ExtractSignatureFromDXBC(
       memcpy(&P, pParamBase + iElement * uElemSize, uElemSize);
       break;
     case sizeof(D3D10_INTERNALSHADER_PARAMETER):
-      static_assert(sizeof(D3D11_INTERNALSHADER_PARAMETER_FOR_GS) ==
-                        sizeof(D3D10_INTERNALSHADER_PARAMETER) +
-                            FIELD_OFFSET(D3D11_INTERNALSHADER_PARAMETER_FOR_GS,
-                                         SemanticName),
-                    "Incorrect assumptions about field offset");
+      static_assert(
+          sizeof(D3D11_INTERNALSHADER_PARAMETER_FOR_GS) ==
+              sizeof(D3D10_INTERNALSHADER_PARAMETER) +
+                  offsetof(D3D11_INTERNALSHADER_PARAMETER_FOR_GS, SemanticName),
+          "Incorrect assumptions about field offset");
       memcpy(&P.SemanticName, pParamBase + iElement * uElemSize, uElemSize);
       break;
     default:

--- a/projects/dxilconv/unittests/DxilConvTests.cpp
+++ b/projects/dxilconv/unittests/DxilConvTests.cpp
@@ -140,7 +140,7 @@ private:
       return false;
     }
     std::string str = std::string(buffer, size);
-    DWORD pos;
+    size_t pos;
     if ((pos = str.find_last_of("\\")) != std::string::npos) {
       str = str.substr(0, pos + 1);
     }

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -5477,7 +5477,7 @@ void ExecutionTest::RunBasicShaderModelTest(D3D_SHADER_MODEL shaderModel) {
     return;
   }
 
-  char *pShaderModelStr;
+  const char *pShaderModelStr;
   if (shaderModel == D3D_SHADER_MODEL_6_1) {
     pShaderModelStr = "cs_6_1";
   } else if (shaderModel == D3D_SHADER_MODEL_6_3) {
@@ -5499,7 +5499,7 @@ void ExecutionTest::RunBasicShaderModelTest(D3D_SHADER_MODEL shaderModel) {
   char shader[sizeof(shaderTemplate) + 50];
 
   // Run simple shader with float data types
-  char *sTy = "float";
+  const char *sTy = "float";
   float inputFloatPairs[] = {1.5f, -2.8f, 3.23e-5f, 6.0f, 181.621f, 14.978f};
   VERIFY_IS_TRUE(sprintf(shader, shaderTemplate, sTy, sTy, sTy) > 0);
   WEX::Logging::Log::Comment(L"BasicShaderModel float");

--- a/tools/clang/unittests/HLSLHost/HLSLHost.cpp
+++ b/tools/clang/unittests/HLSLHost/HLSLHost.cpp
@@ -172,7 +172,7 @@ struct HhResultReply {
 };
 
 // Logging and tracing.
-static void HhTrace(LPWSTR pMessage) { wprintf(L"%s\n", pMessage); }
+static void HhTrace(LPCWSTR pMessage) { wprintf(L"%s\n", pMessage); }
 
 template <typename TInterface, typename TObject>
 HRESULT DoBasicQueryInterfaceWithRemote(TObject *self, REFIID iid,

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -767,9 +767,6 @@ private:
 
 int DxcBatchContext::BatchCompile(bool bMultiThread, bool bLibLink) {
   int retVal = 0;
-  DxcOpts tmp_Opts;
-  // tmp_Opts = m_Opts;
-  m_Opts.InputFile;
   SmallString<128> path(m_Opts.InputFile.begin(), m_Opts.InputFile.end());
   llvm::sys::path::remove_filename(path);
 

--- a/tools/dxexp/dxexp.cpp
+++ b/tools/dxexp/dxexp.cpp
@@ -187,7 +187,7 @@ static const char *ShaderModelToStr(D3D_SHADER_MODEL SM) {
   }
 }
 
-static char *ViewInstancingTierToStr(D3D12_VIEW_INSTANCING_TIER Tier) {
+static const char *ViewInstancingTierToStr(D3D12_VIEW_INSTANCING_TIER Tier) {
   switch (Tier) {
   case D3D12_VIEW_INSTANCING_TIER_NOT_SUPPORTED:
     return "NO";
@@ -202,7 +202,7 @@ static char *ViewInstancingTierToStr(D3D12_VIEW_INSTANCING_TIER Tier) {
   }
 }
 
-static char *RaytracingTierToStr(D3D12_RAYTRACING_TIER Tier) {
+static const char *RaytracingTierToStr(D3D12_RAYTRACING_TIER Tier) {
   switch (Tier) {
   case D3D12_RAYTRACING_TIER_NOT_SUPPORTED:
     return "NO";
@@ -296,7 +296,7 @@ static HRESULT PrintAdapters() {
     hr = e.m_hr;
     json_printf("%c { \"err\": \"unable to print information for adapters - "
                 "0x%08x\" }\n",
-                comma, hr);
+                comma, (unsigned int)hr);
     text_printf("%s", "Unable to print information for adapters.\n");
   }
   json_printf("  ] }\n");
@@ -336,7 +336,8 @@ int main(int argc, const char *argv[]) {
   hRuntime = LoadLibraryW(L"d3d12.dll");
   if (hRuntime == NULL) {
     err = GetLastError();
-    printf("Failed to load library d3d12.dll - Win32 error %u\n", err);
+    printf("Failed to load library d3d12.dll - Win32 error %u\n",
+           (unsigned int)err);
     return 1;
   }
 
@@ -356,7 +357,8 @@ int main(int argc, const char *argv[]) {
   hRuntime = LoadLibraryW(L"d3d12.dll");
   if (hRuntime == NULL) {
     err = GetLastError();
-    printf("Failed to load library d3d12.dll - Win32 error %u\n", err);
+    printf("Failed to load library d3d12.dll - Win32 error %u\n",
+           (unsigned int)err);
     return 1;
   }
 
@@ -367,7 +369,7 @@ int main(int argc, const char *argv[]) {
     err = GetLastError();
     printf("Failed to find export 'D3D12EnableExperimentalFeatures' in "
            "d3d12.dll - Win32 error %u%s\n",
-           err,
+           (unsigned int)err,
            err == ERROR_PROC_NOT_FOUND
                ? " (The specified procedure could not be found.)"
                : "");
@@ -411,7 +413,7 @@ int main(int argc, const char *argv[]) {
   } else {
     text_printf("Experimental shader model feature failed with unexpected "
                 "HRESULT 0x%08x.\n",
-                hr);
+                (unsigned int)hr);
     json_printf("{ \"err\": \"0x%08x\" }", hr);
     json_printf("\n}\n");
     return 4;


### PR DESCRIPTION
1. Can't mix char* and const char*
2. Remove redundant const and std::move
3. Use standard types and macros to replace platform dependent ones