### PR TITLE
Fix version skip for UAVStoreMaskGap to exclude v1.6

### DIFF
--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1201,7 +1201,7 @@ TEST_F(ValidationTest, UAVStoreMaskMatch) {
 }
 
 TEST_F(ValidationTest, UAVStoreMaskGap) {
-  if (m_ver.SkipDxilVersion(1, 6))
+  if (m_ver.SkipDxilVersion(1, 7))
     return;
   RewriteAssemblyCheckMsg(
       L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
@@ -1211,7 +1211,7 @@ TEST_F(ValidationTest, UAVStoreMaskGap) {
 }
 
 TEST_F(ValidationTest, UAVStoreMaskGap2) {
-  if (m_ver.SkipDxilVersion(1, 6))
+  if (m_ver.SkipDxilVersion(1, 7))
     return;
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
                           "i32 2, i32 2, i32 2, i32 2, i8 15)",
@@ -1221,7 +1221,7 @@ TEST_F(ValidationTest, UAVStoreMaskGap2) {
 }
 
 TEST_F(ValidationTest, UAVStoreMaskGap3) {
-  if (m_ver.SkipDxilVersion(1, 6))
+  if (m_ver.SkipDxilVersion(1, 7))
     return;
   RewriteAssemblyCheckMsg(L"..\\CodeGenHLSL\\uav_store.hlsl", "ps_6_0",
                           "i32 2, i32 2, i32 2, i32 2, i8 15)",


### PR DESCRIPTION
SkipDxilVersion skips test if the either the DXIL version (DxCompiler) or
Validator version (DXIL.dll if external) is less than the specified version.
This message is being added in version 1.7, so the skip value needs to be
1.7 to skip unless it's version 1.7 or higher.

Without this fix, these tests fail when run with DXIL.dll version 1.6.