### PR TITLE
[SPIR-V] Error when -Gis is used with -spirv

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -329,7 +329,7 @@ static bool hasUnsupportedSpirvOption(const InputArgList &args,
   // available options and their current compatibility is needed to generate a
   // complete list.
   std::vector<OptSpecifier> unsupportedOpts = {OPT_Fd, OPT_Fre,
-                                               OPT_Qstrip_reflect};
+                                               OPT_Qstrip_reflect, OPT_Gis};
 
   for (const auto &id : unsupportedOpts) {
     if (Arg *arg = args.getLastArg(id)) {

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.gis.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.gis.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -Gis
+
+void main() {}
+
+// CHECK: -Gis is not supported with -spirv


### PR DESCRIPTION
Though we may support -Gis with the SPIR-V backend in future, it is
currently not supported, so this change makes that explicit to the user
with an error message when it is used.

Related to #3331