### PR TITLE
Pass parameters to CMake in a correct way

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,7 +109,7 @@ stages:
     - bash: |
         mkdir build
         cd build
-        cmake -G Ninja $BUILD_SOURCESDIRECTORY -C $BUILD_SOURCESDIRECTORY/cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=${configuration} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_CXX_FLAGS=${CXX_FLAGS}
+        cmake -G Ninja $BUILD_SOURCESDIRECTORY -C $BUILD_SOURCESDIRECTORY/cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$(configuration) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) -DCMAKE_CXX_FLAGS=$(CXX_FLAGS)
       displayName: 'Running Cmake'
     - bash: |
         cd build


### PR DESCRIPTION
According to Azure pipeline's document, the `$(...)` is used in bash to reference a variable. The original `${...}` doesn't really do it. `CC`, `CXX`, `CXX_FLAGS` are fine because they are also environment variables. But the `configuration` doesn't pass into CMAKE_BUILD_TYPE. The CI is actually build Debug build twice, not a Debug and a Release.