### PR TITLE
[spirv] Fix crash on some ternary ops

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3381,6 +3381,15 @@ SpirvEmitter::doConditionalOperator(const ConditionalOperator *expr) {
     return value;
   }
 
+  // Usually integer conditional types in HLSL will be wrapped in an
+  // ImplicitCastExpr<IntegralToBoolean> in the Clang AST. However, some
+  // combinations of result types can result in a bare integer (literal or
+  // reference) as a condition, which still needs to be cast to bool.
+  if (cond->getType()->isIntegerType()) {
+    condition =
+        castToBool(condition, cond->getType(), astContext.BoolTy, loc, range);
+  }
+
   // If we can't use OpSelect, we need to create if-else control flow.
   auto *tempVar = spvBuilder.addFnVar(type, loc, "temp.var.ternary");
   auto *thenBB = spvBuilder.createBasicBlock("if.true");


### PR DESCRIPTION
Sometimes the Clang AST does not include an implicit cast wrapper around
an integer-type condition in the ternary operator, which causes a crash
when the SPIR-V generated has a non-bool type for the
OpBranchConditional. This change checks for this case and casts the
condition to bool.

Example ASTs:
```
// | `-ConditionalOperator 0x24022c82d48 <col:10, col:19> 'bool'
// |   |-ImplicitCastExpr 0x24022c82d00 <col:10> 'bool' <IntegralToBoolean>
// |   | `-IntegerLiteral 0x24022c82c58 <col:10> 'literal int' 1

bool b1, b2;
bool b = 1 ? b1 : b2;

// | `-ConditionalOperator 0x1ede5137380 <col:18, col:27> 'SamplerState'
// |   |-IntegerLiteral 0x1ede5137308 <col:18> 'literal int' 1

SamplerState s1, s2;
SamplerState s = 1 ? s1 : s2;
```

Fixes #3831