### PR TITLE
Splitting simple array during mem2reg.

### DIFF
--- a/lib/Transforms/Scalar/DxilConditionalMem2Reg.cpp
+++ b/lib/Transforms/Scalar/DxilConditionalMem2Reg.cpp
@@ -110,6 +110,134 @@ public:
     AU.setPreservesCFG();
   }
 
+  // Replace simple array allocas with individual scalar allocas.
+  // Only handle if:
+  // - All the alloca's users are geps
+  // - The geps all have only constant indices
+  // - The geps are indexing to just the scalar elements
+  //
+  bool SplitSimpleAllocas(llvm::Function &F) {
+    llvm::SmallVector<AllocaInst *, 10> ScalarAllocas;
+
+    if (F.empty()) return false;
+    BasicBlock *Entry = &F.getEntryBlock();
+
+    bool Changed = false;
+
+    LLVMContext &Ctx = F.getContext();
+    Module *M = F.getParent();
+    IRBuilder<> Builder(Ctx);
+    DIBuilder DIB(*M);
+    const DataLayout &DL = F.getParent()->getDataLayout();
+
+    for (Instruction *it = &Entry->back(); it != nullptr;) {
+      Instruction *I = it;
+      it = (it == &Entry->front()) ? nullptr : it->getPrevNode();
+
+      AllocaInst *AI = dyn_cast<AllocaInst>(I);
+      if (!AI) continue;
+      Type *AllocType = AI->getAllocatedType();
+      if (!AllocType->isArrayTy())
+        continue;
+      Type *ArrayElemType = AllocType->getArrayElementType();
+      if (!ArrayElemType->isSingleValueType())
+        continue;
+
+      unsigned MaxSize = 0;
+      bool Giveup = false;
+      for (User *U : AI->users()) {
+        GEPOperator *Gep = dyn_cast<GEPOperator>(U);
+        if (!Gep) {
+          Giveup = true;
+          break;
+        }
+        if (!Gep->hasAllConstantIndices()) {
+          Giveup = true;
+          break;
+        }
+        if (Gep->getNumIndices() != 2 || cast<ConstantInt>(Gep->getOperand(1))->getLimitedValue() != 0) {
+          Giveup = true;
+          break;
+        }
+        unsigned RequiredSize = 1 + cast<ConstantInt>(Gep->getOperand(2))->getLimitedValue();
+        if (RequiredSize > MaxSize)
+          MaxSize = RequiredSize;
+      }
+
+      if (Giveup)
+        continue;
+
+      // Generate a scalar allocas for the corresponding GEPs.
+      ScalarAllocas.clear();
+      ScalarAllocas.resize(MaxSize);
+      for (auto it = AI->user_begin(); it != AI->user_end();) {
+        User *U = *(it++);
+        GetElementPtrInst *Gep = cast<GetElementPtrInst>(U);
+        unsigned Index = cast<ConstantInt>(Gep->getOperand(2))->getLimitedValue();
+
+        AllocaInst *ScalarAlloca = ScalarAllocas[Index];
+        if (!ScalarAlloca) {
+          Builder.SetInsertPoint(AI);
+          ScalarAlloca = Builder.CreateAlloca(ArrayElemType);
+          ScalarAlloca->setDebugLoc(AI->getDebugLoc());
+          hlsl::DxilMDHelper::CopyMetadata(*ScalarAlloca, *AI); // Propagate precise attributes, if any
+          ScalarAllocas[Index] = ScalarAlloca;
+        }
+
+        Gep->replaceAllUsesWith(ScalarAlloca);
+        Gep->eraseFromParent();
+      }
+
+      // Rewrite any debug info insts.
+      for (auto mdit = dxilutil::mdv_users_begin(AI); mdit != dxilutil::mdv_users_end(AI);) {
+        User *U = *(mdit++);
+        DbgDeclareInst *DI = dyn_cast<DbgDeclareInst>(U);
+        if (!DI)
+          continue;
+
+        DIExpression *Expr = DI->getExpression();
+
+        unsigned ArrayLayoutOffsetInBits = 0;
+        std::vector<DxilDIArrayDim> ArrayDims;
+        const bool HasStrides = DxilMDHelper::GetVariableDebugLayout(DI, ArrayLayoutOffsetInBits, ArrayDims);
+
+        const bool IsBitpiece = Expr->isBitPiece();
+        const uint64_t BaseBitpieceOffSet = IsBitpiece ? Expr->getBitPieceOffset() : 0;
+
+        for (unsigned i = 0; i < ScalarAllocas.size(); i++) {
+          AllocaInst *ScalarAlloca = ScalarAllocas[i];
+          if (!ScalarAlloca) {
+            continue;
+          }
+
+          uint64_t BitpieceOffsetInBits = 0;
+          const uint64_t BitpieceSizeInBits = DL.getTypeStoreSizeInBits(ArrayElemType);
+          if (HasStrides) {
+            BitpieceOffsetInBits = ArrayLayoutOffsetInBits;
+            unsigned FragmentIndex = i;
+            for (DxilDIArrayDim &ArrayDim : ArrayDims) {
+              unsigned IndexIntoArray = FragmentIndex % ArrayDim.NumElements;
+              BitpieceOffsetInBits += IndexIntoArray * ArrayDim.StrideInBits;
+              FragmentIndex /= ArrayDim.NumElements;
+            }
+          }
+          else {
+            BitpieceOffsetInBits = BaseBitpieceOffSet + i * BitpieceSizeInBits;
+          }
+
+          uint64_t Operands[3] = {dwarf::DW_OP_bit_piece, BitpieceOffsetInBits, BitpieceSizeInBits};
+          DIB.insertDeclare(ScalarAlloca, DI->getVariable(), DIExpression::get(Ctx, Operands), DI->getDebugLoc(), DI);
+        } // For each scalar alloca
+        DI->eraseFromParent();
+      } // For each metadat user
+
+      AI->eraseFromParent();
+      Changed = true;
+    } // For each inst in the entry block
+
+    return Changed;
+  }
+
   //
   // Turns all allocas of vector types that are marked with 'dx.precise'
   // and turn them into scalars. For example:
@@ -356,6 +484,7 @@ public:
 
     Changed |= RewriteOutputArgsDebugInfo(F);
     Changed |= dxilutil::DeleteDeadAllocas(F);
+    Changed |= SplitSimpleAllocas(F);
     Changed |= ScalarizePreciseVectorAlloca(F);
     Changed |= Mem2Reg(F, *DT, *AC);
 

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_call.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/new_noops_call.hlsl
@@ -3,6 +3,10 @@
 typedef float4 MyCoolFloat4; 
 static float4 myStaticGlobalVar = float4(1.0, 1.0, 1.0, 1.0);
 
+cbuffer cb : register(b0) {
+  uint indices[4];
+}
+
 // Local var with same name as outer scope
 float4 localScopeVar_func(float4 val)
 {
@@ -25,7 +29,7 @@ float4 array_func(float4 val)
     result[1] = val.y;
     result[2] = val.z;
     result[3] = val.w;
-    return float4(result[0], result[1], result[2], result[3]);
+    return float4(result[indices[0]], result[indices[1]], result[indices[2]], result[indices[3]]);
 }
 
 // Typedef
@@ -60,7 +64,7 @@ float4 depth2(float4 val)
     return val;
 }
 
-[RootSignature("")]
+[RootSignature("CBV(b0)")]
 float4 main( float4 unused : SV_POSITION, float4 color : COLOR ) : SV_Target
 {
     // xHECK: %[[p_load:[0-9]+]] = load i32, i32*

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold_vec_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/no_fold_vec_array.hlsl
@@ -29,6 +29,6 @@ float2 main(int index : INDEX) : SV_Target {
   // CHECK: load
   // CHECK: load
 
-  return values[3];
+  return values[index];
 }
 

--- a/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split.ll
@@ -1,0 +1,182 @@
+; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
+
+; CHECK: @main
+; CHECK-NOT: alloca [2 x float]
+
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 0, 32)
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 32, 32)
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%cb = type { [10 x float] }
+%dx.types.Handle = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+
+@cb = external constant %cb
+
+; Function Attrs: nounwind readnone
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+; Function Attrs: nounwind readnone
+declare %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32, %dx.types.Handle, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32, %cb*, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb) #0
+
+; Function Attrs: convergent
+declare void @dx.noop() #1
+
+; Function Attrs: nounwind
+define void @main(float* noalias, i32, i32) #2 {
+entry:
+  %tmp2.0 = alloca float
+  %tmp.0 = alloca float
+  %arr.0 = alloca [2 x float]
+  %number.addr.i.11 = alloca i32, align 4, !dx.temp !2
+  %number.addr.i = alloca i32, align 4, !dx.temp !2
+  %retval = alloca float, align 4, !dx.temp !2
+  %j.addr = alloca i32, align 4, !dx.temp !2
+  %i.addr = alloca i32, align 4, !dx.temp !2
+  %3 = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %cb*, i32)"(i32 0, %cb* @cb, i32 0)
+  %4 = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %cb)"(i32 11, %dx.types.Handle %3, %dx.types.ResourceProperties { i32 13, i32 148 }, %cb undef)
+  %5 = call %cb* @"dx.hl.subscript.cb.%cb* (i32, %dx.types.Handle, i32)"(i32 6, %dx.types.Handle %4, i32 0)
+  store i32 %2, i32* %j.addr, align 4
+  call void @llvm.dbg.declare(metadata i32* %j.addr, metadata !30, metadata !31), !dbg !32
+  store i32 %1, i32* %i.addr, align 4
+  call void @llvm.dbg.declare(metadata i32* %i.addr, metadata !33, metadata !31), !dbg !34
+  call void @llvm.dbg.declare(metadata [2 x float]* %arr.0, metadata !35, metadata !31), !dbg !39
+  %6 = load i32, i32* %i.addr, align 4, !dbg !40
+  call void @dx.noop(), !dbg !41
+  store i32 %6, i32* %number.addr.i, align 4, !dbg !41, !noalias !42
+  call void @llvm.dbg.declare(metadata float* %tmp.0, metadata !45, metadata !31), !dbg !46
+  %7 = load i32, i32* %number.addr.i, align 4, !dbg !48, !noalias !42
+  %conv.i = sitofp i32 %7 to float, !dbg !48
+  call void @dx.noop() #2, !dbg !49, !noalias !42
+  store float %conv.i, float* %tmp.0, align 4, !dbg !49, !alias.scope !42
+  call void @dx.noop() #2, !dbg !50, !noalias !42
+  call void @dx.noop(), !dbg !41
+  %8 = getelementptr inbounds [2 x float], [2 x float]* %arr.0, i32 0, i32 0, !dbg !41
+  %9 = load float, float* %tmp.0, !dbg !41
+  store float %9, float* %8, !dbg !41
+  %10 = load i32, i32* %j.addr, align 4, !dbg !51
+  call void @dx.noop(), !dbg !52
+  store i32 %10, i32* %number.addr.i.11, align 4, !dbg !52, !noalias !53
+  call void @llvm.dbg.declare(metadata float* %tmp2.0, metadata !45, metadata !31), !dbg !56
+  %11 = load i32, i32* %number.addr.i.11, align 4, !dbg !58, !noalias !53
+  %conv.i.12 = sitofp i32 %11 to float, !dbg !58
+  call void @dx.noop() #2, !dbg !59, !noalias !53
+  store float %conv.i.12, float* %tmp2.0, align 4, !dbg !59, !alias.scope !53
+  call void @dx.noop() #2, !dbg !60, !noalias !53
+  call void @dx.noop(), !dbg !52
+  %12 = getelementptr inbounds [2 x float], [2 x float]* %arr.0, i32 0, i32 1, !dbg !52
+  %13 = load float, float* %tmp2.0, !dbg !52
+  store float %13, float* %12, !dbg !52
+  %member2 = getelementptr inbounds [2 x float], [2 x float]* %arr.0, i32 0, i32 0, !dbg !61
+  %14 = load float, float* %member2, align 4, !dbg !61
+  %conv = fptoui float %14 to i32, !dbg !62
+  %arrayidx49 = getelementptr inbounds %cb, %cb* %5, i32 0, i32 0, i32 %conv, !dbg !63
+  %15 = load float, float* %arrayidx49, align 4, !dbg !63
+  %member61 = getelementptr inbounds [2 x float], [2 x float]* %arr.0, i32 0, i32 1, !dbg !64
+  %16 = load float, float* %member61, align 4, !dbg !64
+  %conv7 = fptoui float %16 to i32, !dbg !65
+  %arrayidx810 = getelementptr inbounds %cb, %cb* %5, i32 0, i32 0, i32 %conv7, !dbg !66
+  %17 = load float, float* %arrayidx810, align 4, !dbg !66
+  %add = fadd float %15, %17, !dbg !67
+  store float %add, float* %retval, !dbg !68
+  %18 = load float, float* %retval, !dbg !68
+  call void @dx.noop(), !dbg !68
+  call void @llvm.dbg.declare(metadata i32* %number.addr.i, metadata !69, metadata !31), !dbg !70
+  call void @llvm.dbg.declare(metadata i32* %number.addr.i.11, metadata !69, metadata !31), !dbg !71
+  store float %18, float* %0, !dbg !68
+  ret void, !dbg !68
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { convergent }
+attributes #2 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!23, !24}
+!pauseresume = !{!25}
+!llvm.ident = !{!26}
+!dx.source.contents = !{!27}
+!dx.source.defines = !{!2}
+!dx.source.mainFileName = !{!28}
+!dx.source.args = !{!29}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 3.7 (tags/RELEASE_370/final)", isOptimized: false, runtimeVersion: 0, emissionKind: 1, enums: !2, subprograms: !3, globals: !17)
+!1 = !DIFile(filename: "F:\5Ctest\5Cepic_od\5Cminimal.hlsl", directory: "")
+!2 = !{}
+!3 = !{!4, !10}
+!4 = !DISubprogram(name: "main", scope: !1, file: !1, line: 17, type: !5, isLocal: false, isDefinition: true, scopeLine: 17, flags: DIFlagPrototyped, isOptimized: false, function: void (float*, i32, i32)* @main)
+!5 = !DISubroutineType(types: !6)
+!6 = !{!7, !8, !8}
+!7 = !DIBasicType(name: "float", size: 32, align: 32, encoding: DW_ATE_float)
+!8 = !DIDerivedType(tag: DW_TAG_typedef, name: "uint", file: !1, line: 13, baseType: !9)
+!9 = !DIBasicType(name: "unsigned int", size: 32, align: 32, encoding: DW_ATE_unsigned)
+!10 = !DISubprogram(name: "make_struct", linkageName: "\01?make_struct@@YA?AUMyStruct@@H@Z", scope: !1, file: !1, line: 6, type: !11, isLocal: false, isDefinition: true, scopeLine: 6, flags: DIFlagPrototyped, isOptimized: false)
+!11 = !DISubroutineType(types: !12)
+!12 = !{!13, !16}
+!13 = !DICompositeType(tag: DW_TAG_structure_type, name: "MyStruct", file: !1, line: 2, size: 32, align: 32, elements: !14)
+!14 = !{!15}
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "member", scope: !13, file: !1, line: 3, baseType: !7, size: 32, align: 32)
+!16 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
+!17 = !{!18}
+!18 = !DIGlobalVariable(name: "foo", linkageName: "\01?foo@cb@@3QBMB", scope: !0, file: !1, line: 13, type: !19, isLocal: false, isDefinition: true)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 320, align: 32, elements: !21)
+!20 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+!21 = !{!22}
+!22 = !DISubrange(count: 10)
+!23 = !{i32 2, !"Dwarf Version", i32 4}
+!24 = !{i32 2, !"Debug Info Version", i32 3}
+!25 = !{!"hlsl-hlemit", !"hlsl-hlensure"}
+!26 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
+!27 = !{!"F:\5Ctest\5Cepic_od\5Cminimal.hlsl", !""} ; NOTE: Manually deleted this content for the test.
+!28 = !{!"F:\5Ctest\5Cepic_od\5Cminimal.hlsl"}
+!29 = !{!"-E", !"main", !"-T", !"ps_6_0", !"/Od", !"/Zi", !"-Qembed_debug"}
+!30 = !DILocalVariable(tag: DW_TAG_arg_variable, name: "j", arg: 2, scope: !4, file: !1, line: 17, type: !8)
+!31 = !DIExpression()
+!32 = !DILocation(line: 17, column: 29, scope: !4)
+!33 = !DILocalVariable(tag: DW_TAG_arg_variable, name: "i", arg: 1, scope: !4, file: !1, line: 17, type: !8)
+!34 = !DILocation(line: 17, column: 17, scope: !4)
+!35 = !DILocalVariable(tag: DW_TAG_auto_variable, name: "arr", scope: !4, file: !1, line: 18, type: !36)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !13, size: 64, align: 32, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 2)
+!39 = !DILocation(line: 18, column: 12, scope: !4)
+!40 = !DILocation(line: 19, column: 24, scope: !4)
+!41 = !DILocation(line: 19, column: 12, scope: !4)
+!42 = !{!43}
+!43 = distinct !{!43, !44, !"\01?make_struct@@YA?AUMyStruct@@H@Z: %agg.result"}
+!44 = distinct !{!44, !"\01?make_struct@@YA?AUMyStruct@@H@Z"}
+!45 = !DILocalVariable(tag: DW_TAG_arg_variable, name: "ret", arg: 0, scope: !10, file: !1, line: 7, type: !13)
+!46 = !DILocation(line: 7, column: 12, scope: !10, inlinedAt: !47)
+!47 = distinct !DILocation(line: 19, column: 12, scope: !4)
+!48 = !DILocation(line: 8, column: 16, scope: !10, inlinedAt: !47)
+!49 = !DILocation(line: 8, column: 14, scope: !10, inlinedAt: !47)
+!50 = !DILocation(line: 9, column: 3, scope: !10, inlinedAt: !47)
+!51 = !DILocation(line: 20, column: 24, scope: !4)
+!52 = !DILocation(line: 20, column: 12, scope: !4)
+!53 = !{!54}
+!54 = distinct !{!54, !55, !"\01?make_struct@@YA?AUMyStruct@@H@Z: %agg.result"}
+!55 = distinct !{!55, !"\01?make_struct@@YA?AUMyStruct@@H@Z"}
+!56 = !DILocation(line: 7, column: 12, scope: !10, inlinedAt: !57)
+!57 = distinct !DILocation(line: 20, column: 12, scope: !4)
+!58 = !DILocation(line: 8, column: 16, scope: !10, inlinedAt: !57)
+!59 = !DILocation(line: 8, column: 14, scope: !10, inlinedAt: !57)
+!60 = !DILocation(line: 9, column: 3, scope: !10, inlinedAt: !57)
+!61 = !DILocation(line: 22, column: 21, scope: !4)
+!62 = !DILocation(line: 22, column: 14, scope: !4)
+!63 = !DILocation(line: 22, column: 10, scope: !4)
+!64 = !DILocation(line: 22, column: 42, scope: !4)
+!65 = !DILocation(line: 22, column: 35, scope: !4)
+!66 = !DILocation(line: 22, column: 31, scope: !4)
+!67 = !DILocation(line: 22, column: 29, scope: !4)
+!68 = !DILocation(line: 22, column: 3, scope: !4)
+!69 = !DILocalVariable(tag: DW_TAG_arg_variable, name: "number", arg: 1, scope: !10, file: !1, line: 6, type: !16)
+!70 = !DILocation(line: 6, column: 26, scope: !10, inlinedAt: !47)
+!71 = !DILocation(line: 6, column: 26, scope: !10, inlinedAt: !57)

--- a/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split.ll
@@ -1,7 +1,11 @@
 ; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
 
 ; CHECK: @main
-; CHECK-NOT: alloca [2 x float]
+
+; CHECK-NOT: alloca
+; CHECK-NOT: getelementptr
+; CHECK-NOT: store
+; CHECK-NOT: load
 
 ; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 0, 32)
 ; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 32, 32)

--- a/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split_varlayout.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/mem2reg_hlsl/mem2reg_simple_split_varlayout.ll
@@ -1,0 +1,111 @@
+; RUN: %opt %s -dxil-cond-mem2reg -S | FileCheck %s
+
+; CHECK: @main
+; CHECK-NOT: alloca [4 x float]
+; CHECK-NOT: !dx.dbg.varlayout
+
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 0, 32)
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 32, 32)
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 64, 32)
+; CHECK-DAG: !DIExpression(DW_OP_bit_piece, 96, 32)
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+; Function Attrs: nounwind readnone
+declare void @llvm.dbg.declare(metadata, metadata, metadata) #0
+
+; Function Attrs: convergent
+declare void @dx.noop() #1
+
+; Function Attrs: nounwind
+define void @main(<2 x float>* noalias, i32) #2 {
+entry:
+  %values.0 = alloca [4 x float]
+  %values.1 = alloca [4 x float]
+  %retval = alloca <2 x float>, align 4, !dx.temp !2
+  call void @llvm.dbg.declare(metadata [4 x float]* %values.0, metadata !25, metadata !29), !dbg !30, !dx.dbg.varlayout !31
+  call void @llvm.dbg.declare(metadata [4 x float]* %values.1, metadata !25, metadata !32), !dbg !30, !dx.dbg.varlayout !33
+  %2 = getelementptr [4 x float], [4 x float]* %values.0, i32 0, i32 0, !dbg !34
+  %3 = getelementptr [4 x float], [4 x float]* %values.1, i32 0, i32 0, !dbg !34
+  call void @dx.noop(), !dbg !34
+  store float 1.000000e+00, float* %2, !dbg !34
+  store float 2.000000e+00, float* %3, !dbg !34
+  %4 = getelementptr [4 x float], [4 x float]* %values.0, i32 0, i32 1, !dbg !34
+  %5 = getelementptr [4 x float], [4 x float]* %values.1, i32 0, i32 1, !dbg !34
+  call void @dx.noop(), !dbg !34
+  store float 3.000000e+00, float* %4, !dbg !34
+  store float 4.000000e+00, float* %5, !dbg !34
+  %6 = getelementptr [4 x float], [4 x float]* %values.0, i32 0, i32 2, !dbg !34
+  %7 = getelementptr [4 x float], [4 x float]* %values.1, i32 0, i32 2, !dbg !34
+  call void @dx.noop(), !dbg !34
+  store float 5.000000e+00, float* %6, !dbg !34
+  store float 6.000000e+00, float* %7, !dbg !34
+  %8 = getelementptr [4 x float], [4 x float]* %values.0, i32 0, i32 3, !dbg !34
+  %9 = getelementptr [4 x float], [4 x float]* %values.1, i32 0, i32 3, !dbg !34
+  call void @dx.noop(), !dbg !34
+  store float 7.000000e+00, float* %8, !dbg !34
+  store float 8.000000e+00, float* %9, !dbg !34
+  %10 = getelementptr [4 x float], [4 x float]* %values.0, i32 0, i32 3, !dbg !35
+  %11 = getelementptr [4 x float], [4 x float]* %values.1, i32 0, i32 3, !dbg !35
+  %load = load float, float* %10, !dbg !35
+  %insert = insertelement <2 x float> undef, float %load, i64 0, !dbg !35
+  %load6 = load float, float* %11, !dbg !35
+  %insert7 = insertelement <2 x float> %insert, float %load6, i64 1, !dbg !35
+  store <2 x float> %insert7, <2 x float>* %retval, !dbg !36
+  %12 = load <2 x float>, <2 x float>* %retval, !dbg !36
+  call void @dx.noop(), !dbg !36
+  store <2 x float> %12, <2 x float>* %0, !dbg !36
+  ret void, !dbg !36
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { convergent }
+attributes #2 = { nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!18, !19}
+!pauseresume = !{!20}
+!llvm.ident = !{!21}
+!dx.source.contents = !{!22}
+!dx.source.defines = !{!2}
+!dx.source.mainFileName = !{!23}
+!dx.source.args = !{!24}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "clang version 3.7 (tags/RELEASE_370/final)", isOptimized: false, runtimeVersion: 0, emissionKind: 1, enums: !2, retainedTypes: !3, subprograms: !14)
+!1 = !DIFile(filename: "F:\5Cdxc\5Ctools\5Cclang\5Ctest\5CHLSLFileCheck\5Cdxil\5Cdebug\5Cno_fold_vec_array.hlsl", directory: "")
+!2 = !{}
+!3 = !{!4}
+!4 = !DIDerivedType(tag: DW_TAG_typedef, name: "float2", file: !1, baseType: !5)
+!5 = !DICompositeType(tag: DW_TAG_class_type, name: "vector<float, 2>", file: !1, size: 64, align: 32, elements: !6, templateParams: !10)
+!6 = !{!7, !9}
+!7 = !DIDerivedType(tag: DW_TAG_member, name: "x", scope: !5, file: !1, baseType: !8, size: 32, align: 32, flags: DIFlagPublic)
+!8 = !DIBasicType(name: "float", size: 32, align: 32, encoding: DW_ATE_float)
+!9 = !DIDerivedType(tag: DW_TAG_member, name: "y", scope: !5, file: !1, baseType: !8, size: 32, align: 32, offset: 32, flags: DIFlagPublic)
+!10 = !{!11, !12}
+!11 = !DITemplateTypeParameter(name: "element", type: !8)
+!12 = !DITemplateValueParameter(name: "element_count", type: !13, value: i32 2)
+!13 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
+!14 = !{!15}
+!15 = !DISubprogram(name: "main", scope: !1, file: !1, line: 7, type: !16, isLocal: false, isDefinition: true, scopeLine: 7, flags: DIFlagPrototyped, isOptimized: false, function: void (<2 x float>*, i32)* @main)
+!16 = !DISubroutineType(types: !17)
+!17 = !{!4, !13}
+!18 = !{i32 2, !"Dwarf Version", i32 4}
+!19 = !{i32 2, !"Debug Info Version", i32 3}
+!20 = !{!"hlsl-hlemit", !"hlsl-hlensure"}
+!21 = !{!"clang version 3.7 (tags/RELEASE_370/final)"}
+!22 = !{!"F:\5Cdxc\5Ctools\5Cclang\5Ctest\5CHLSLFileCheck\5Cdxil\5Cdebug\5Cno_fold_vec_array.hlsl", !"// RUN: %dxc -E main -T ps_6_0 %s -Od | FileCheck %s\0D\0A\0D\0A// Check that arrays of vectors still work with -Od\0D\0A// without all the inst-simplify\0D\0A\0D\0A[RootSignature(\22\22)]\0D\0Afloat2 main(int index : INDEX) : SV_Target {\0D\0A\0D\0A  float2 values[4] = {\0D\0A    float2(1,2),\0D\0A    float2(3,4),\0D\0A    float2(5,6),\0D\0A    float2(7,8),\0D\0A  };\0D\0A\0D\0A  // CHECK: alloca [4 x float]\0D\0A  // CHECK: alloca [4 x float]\0D\0A\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A  // CHECK: store\0D\0A\0D\0A  // CHECK: load\0D\0A  // CHECK: load\0D\0A\0D\0A  return values[3];\0D\0A}\0D\0A\0D\0A"}
+!23 = !{!"F:\5Cdxc\5Ctools\5Cclang\5Ctest\5CHLSLFileCheck\5Cdxil\5Cdebug\5Cno_fold_vec_array.hlsl"}
+!24 = !{!"-E", !"main", !"-T", !"ps_6_0", !"-Od", !"-Zi", !"-Qembed_debug"}
+!25 = !DILocalVariable(tag: DW_TAG_auto_variable, name: "values", scope: !15, file: !1, line: 9, type: !26)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 256, align: 32, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 4)
+!29 = !DIExpression(DW_OP_bit_piece, 0, 32)
+!30 = !DILocation(line: 9, column: 10, scope: !15)
+!31 = !{i32 0, i32 64, i32 4}
+!32 = !DIExpression(DW_OP_bit_piece, 32, 32)
+!33 = !{i32 32, i32 64, i32 4}
+!34 = !DILocation(line: 9, column: 22, scope: !15)
+!35 = !DILocation(line: 32, column: 10, scope: !15)
+!36 = !DILocation(line: 32, column: 3, scope: !15)


### PR DESCRIPTION
Added a simple transformation before mem2reg to change all allocas of scalar arrays to individual scalar allocas. This could make value deduction easier in Od compilation.