### PR TITLE
Add checks to advanced tex ops exectests

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -4086,6 +4086,10 @@ TEST_F(ExecutionTest, ATOProgOffset) {
                     ((UINT)sm & 0x0f));
       break;
     }
+    if (sm >= D3D_SHADER_MODEL_6_7 && !DoesDeviceSupportAdvancedTexOps(pDevice)) {
+      LogCommentFmt(L"Device does not support Advanced Texture Ops");
+      break;
+    }
 
     bool bSupportMSASDeriv = DoesDeviceSupportMeshAmpDerivatives(pDevice);
 
@@ -4180,6 +4184,12 @@ TEST_F(ExecutionTest, ATOSampleCmpLevelTest) {
   CComPtr<ID3D12Device> pDevice;
   if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_7))
       return;
+
+  if (!DoesDeviceSupportAdvancedTexOps(pDevice)) {
+    WEX::Logging::Log::Comment(L"Device does not support Advanced Texture Operations.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
 
   std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
     std::make_shared<st::ShaderOpSet>();


### PR DESCRIPTION
Two of the Advanced Texture Ops feature tests were missing the check for
the feature in addition to the check for 6.7 support. This adds those
checks

Merge of #4551 to release-1.7.2207