### PR TITLE
param validation for uniform / resources in entry point functions

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -134,6 +134,7 @@ namespace dxilutil {
   std::pair<bool, DxilResourceProperties> GetHLSLResourceProperties(llvm::Type *Ty);
   bool IsHLSLResourceType(llvm::Type *Ty);
   bool IsHLSLObjectType(llvm::Type *Ty);
+  bool IsHLSLObjectStreamType(llvm::Type *Ty);
   bool IsHLSLRayQueryType(llvm::Type *Ty);
   bool IsHLSLResourceDescType(llvm::Type *Ty);
   bool IsResourceSingleComponent(llvm::Type *Ty);

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -491,6 +491,27 @@ std::pair<bool, DxilResourceProperties> GetHLSLResourceProperties(llvm::Type *Ty
   return FalseRet;
 }
 
+bool IsHLSLObjectStreamType(llvm::Type *Ty) {
+  if (llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty)) {
+    if (!ST->hasName()) {
+      return false;
+    }
+
+    StringRef name = ST->getName();
+
+    ConsumePrefix(name, "class.");
+    ConsumePrefix(name, "struct.");
+
+    if (name.startswith("TriangleStream<"))
+      return true;
+    if (name.startswith("PointStream<"))
+      return true;
+    if (name.startswith("LineStream<"))
+      return true;
+  }
+  return false;
+}
+
 bool IsHLSLObjectType(llvm::Type *Ty) {
   if (llvm::StructType *ST = dyn_cast<llvm::StructType>(Ty)) {
     if (!ST->hasName()) {
@@ -511,15 +532,7 @@ bool IsHLSLObjectType(llvm::Type *Ty) {
     if (IsHLSLResourceType(Ty))
       return true;
 
-    ConsumePrefix(name, "class.");
-    ConsumePrefix(name, "struct.");
-
-    if (name.startswith("TriangleStream<"))
-      return true;
-    if (name.startswith("PointStream<"))
-      return true;
-    if (name.startswith("LineStream<"))
-      return true;
+    return IsHLSLObjectStreamType(Ty);
   }
   return false;
 }

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -197,7 +197,7 @@ static Function *StripFunctionParameter(Function *F, DxilModule &DM,
   FunctionType *FT = FunctionType::get(VoidTy, false);
   for (auto &arg : F->args()) {
     if (!arg.user_empty())
-      return nullptr;
+      return nullptr; // If this would return here, we really should produce an error somewhere.
     DbgDeclareInst *DDI = llvm::FindAllocaDbgDeclare(&arg);
     if (DDI) {
       DDI->eraseFromParent();

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -1145,10 +1145,12 @@ void HLSignatureLower::GenerateDxilInputsOutputs(DXIL::SignatureKind SK) {
       bI1Cast = true;
       Ty = i32Ty;
     }
-    if (!hlslOP->IsOverloadLegal(opcode, Ty)) {
+    if (!Ty || !hlslOP->IsOverloadLegal(opcode, Ty)) {
       std::string O;
       raw_string_ostream OSS(O);
-      Ty->print(OSS);
+      if (Ty)
+        Ty->print(OSS);
+
       OSS << "(type for " << SE->GetName() << ")";
       OSS << " cannot be used as shader inputs or outputs.";
       OSS.flush();

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -4391,11 +4391,11 @@ static DxilFieldAnnotation &GetEltAnnotation(Type *Ty, unsigned idx, DxilFieldAn
 // Need to get 0 from s[0].m and s[1].m, get 1 from s[0].m2 and s[1].m2.
 
 
-// Allocate the argments with same semantic string from type where the
+// Allocate the arguments with same semantic string from type where the
 // semantic starts( S2 for s2.m[2] and s2.m2[2]).
 // Iterate each elements of the type, save the semantic index and update it.
 // The map from element to the arg ( s[0].m2 -> s.m2[2]) is done by argIdx.
-// ArgIdx only inc by 1 when finish a struct field.
+// ArgIdx only inc by 1 when finishing a struct field.
 static unsigned AllocateSemanticIndex(
     Type *Ty, unsigned &semIndex, unsigned argIdx, unsigned endArgIdx,
     std::vector<DxilParameterAnnotation> &FlatAnnotationList) {

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2341,7 +2341,24 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
     }
 
     paramAnnotation.SetParamInputQual(dxilInputQ);
+    // Entry-point-specific parameter validation
     if (isEntry) {
+      
+      if (const HLSLUniformAttr *Attr = parmDecl->getAttr<HLSLUniformAttr>()) {
+        unsigned DiagID =
+            Diags.getCustomDiagID(DiagnosticsEngine::Error,
+                                  "attribute uniform only valid for non-entry-point functions.");
+        Diags.Report(Attr->getLocation(), DiagID);
+        return;
+      }
+
+      if (IsHLSLResourceType(parmDecl->getType())){
+        unsigned DiagID =
+            Diags.getCustomDiagID(DiagnosticsEngine::Error,
+                                  "Resource types only valid for non-entry-point functions.");
+        Diags.Report(parmDecl->getLocation(), DiagID);
+        return;
+      }
       if (CGM.getLangOpts().EnableDX9CompatMode && paramAnnotation.HasSemanticString()) {
         RemapObsoleteSemantic(paramAnnotation, /*isPatchConstantFunction*/ false);
       }

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/resource_in_entry_point_ps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/resource_in_entry_point_ps.hlsl
@@ -1,0 +1,34 @@
+// RUN: %dxc /E main -T ps_6_0 %s | FileCheck %s
+// CHECK: warning: effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs. [-Weffects-syntax]
+// CHECK: error: Resource types only valid for non-entry-point functions.
+
+
+#define ROOT_SIG [RootSignature("RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable( SRV(t0)) ")]
+
+SamplerState PointSampler { Filter = MIN_MAG_MIP_POINT; AddressU = Clamp; AddressV = Clamp; };
+
+Texture2D<float> g_fallback_tex              : register(t0);
+
+void main_vertex
+(
+	float4 position	: POSITION,
+	float4 color	: COLOR,
+	float2 texCoord : TEXCOORD0,
+
+	uniform float4x4 modelViewProj,
+
+	out float4 oPosition : POSITION,
+	out float4 oColor    : COLOR,
+	out float2 otexCoord : TEXCOORD
+)
+{
+	oPosition = mul(modelViewProj, position);
+	oColor = color;
+	otexCoord = texCoord;
+}
+
+ROOT_SIG
+int main(float2 texCoord : TEXCOORD0, Texture2D<float> g_fallback_tex  : TEXUNIT0) : SV_Target
+{
+	return 3;
+}  

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/uniform_in_entry_point_ps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/uniform_in_entry_point_ps.hlsl
@@ -1,0 +1,43 @@
+// RUN: %dxc -D PARAMTYPE=Tex2D /E main_fragment -T ps_6_0 %s | FileCheck %s -check-prefix=CHECK1
+// CHECK1: warning: effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs. [-Weffects-syntax]
+// CHECK1: attribute uniform only valid for non-entry-point functions.
+
+// RUN: %dxc -D PARAMTYPE=RW /E main_fragment -T ps_6_0 %s | FileCheck %s -check-prefix=CHECK2
+// CHECK2: warning: effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs. [-Weffects-syntax]
+// CHECK2: attribute uniform only valid for non-entry-point functions.
+
+
+// RUN: %dxc -D PARAMTYPE=SamplerState /E main_fragment -T ps_6_0 %s | FileCheck %s -check-prefix=CHECK3
+// CHECK3: warning: effect state block ignored - effect syntax is deprecated. To use braces as an initializer use them with equal signs. [-Weffects-syntax]
+// CHECK3: attribute uniform only valid for non-entry-point functions.
+
+
+
+#define Tex2D Texture2D<float4>
+#define RW RWStructuredBuffer<float4>
+
+SamplerState PointSampler { Filter = MIN_MAG_MIP_POINT; AddressU = Clamp; AddressV = Clamp; };
+
+
+void main_vertex
+(
+	float4 position	: POSITION,
+	float4 color	: COLOR,
+	float2 texCoord : TEXCOORD0,
+
+	uniform float4x4 modelViewProj,
+
+	out float4 oPosition : POSITION,
+	out float4 oColor    : COLOR,
+	out float2 otexCoord : TEXCOORD
+)
+{
+	oPosition = mul(modelViewProj, position);
+	oColor = color;
+	otexCoord = texCoord;
+}
+
+int main_fragment(float2 texCoord : TEXCOORD0, uniform PARAMTYPE decal : TEXUNIT0) : SV_Target
+{
+	return 3;
+}  


### PR DESCRIPTION
There was some lacking parameter validation for arguments to entry point functions that either had the uniform attribute, or were HLSL resource types. This was causing AV problems as described in #3377.
Now, when each parameter is processed, checking for the uniform attribute and that the parameter type is not a resource takes place, to prevent implicit assumptions from being incorrect. Additionally, some extra nullptr checking to prevent the underlying AV problem.