### PR TITLE
Barycentric check ordering

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1543,7 +1543,7 @@
         return result;
       }
     
-      float4 PSMain(PSInput input, float3 bary : SV_Barycentrics, uint vid : VertexID) : SV_Target {
+      float4 PSMain(PSInput input, float3 bary : SV_Barycentrics) : SV_Target {
         float4 pos = input.position;
         // check to make sure that the pixel shader will see the barycentric weight associated
         // with the first vertex in the x component of the SV_Barycentric vector, and likewise for subsequent vertices

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1491,7 +1491,7 @@
     </Shader>
   </ShaderOp>
 
-  <ShaderOp Name="Barycentrics" PS="PS" VS="VS">
+  <ShaderOp Name="Barycentrics" PS="PS61" VS="VS61">
     <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)</RootSignature>
     <Resource Name="VBuffer" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
         { {   0.0f,  1.0f , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
@@ -1509,32 +1509,54 @@
     <RenderTargets>
       <RenderTarget Name="RTarget" />
     </RenderTargets>
-    <Shader Name="VS" Target="vs_6_1">
+
+
+    <Shader Name="PS61" Target="ps_6_1" EntryPoint="PSMain" Text="@MAIN"/>
+    <Shader Name="VS61" Target="vs_6_1" EntryPoint="VSMain" Text="@MAIN"/>
+
+
+    <Shader Name="MAIN" Target="vs_6_1" EntryPoint="VSMain">
       <![CDATA[
       struct PSInput {
         float4 position : SV_POSITION;
         nointerpolation float4 color : COLOR;
       };
-      PSInput main(float4 position : POSITION, float4 color : COLOR) {
+      
+      PSInput VSMain(float4 position : POSITION, float4 color : COLOR, uint vid : SV_VertexID) {
         PSInput result;
         result.position = position;
         result.color = color;
+        int x = vid;
         return result;
       }
-      ]]>
-    </Shader>
-    <Shader Name="PS" Target="ps_6_1">
-      <![CDATA[
-      struct PSInput {
-        float4 position : SV_POSITION;
-        nointerpolation float4 color : COLOR;
-      };
-      float4 main(PSInput input, float3 bary : SV_Barycentrics) : SV_Target {
+    
+      float4 PSMain(PSInput input, float3 bary : SV_Barycentrics) : SV_Target {
+        float4 pos = input.position;
+        // check to make sure that the pixel shader will see the barycentric weight associated
+        // with the first vertex in the x component of the SV_Barycentric vector, and likewise for subsequent vertices
+        if (pos.x == 0.0f && pos.y == 1.0f && pos.z == 0.0f)
+        {
+          if (abs(bary.x - 1.0f) > .001 || abs(bary.y - 0.0f) > .001 || abs(bary.z - 0.0f) > .001)
+            return 0.5f;
+        }
+        if (pos.x == 1.0f && pos.y == -1.0f && pos.z == 0.0f)
+        {
+          if (abs(bary.x - 0.0f) > .001 || abs(bary.y - 1.0f) > .001 || abs(bary.z - 0.0f) > .001)
+            return 0.5f;
+        }
+        if (pos.x == -1.0f && pos.y == -1.0f && pos.z == 0.0f)
+        {
+          if (abs(bary.x - 0.0f) > .001 || abs(bary.y - 0.0f) > .001 || abs(bary.z - 1.0f) > .001)
+            return 0.5f;
+        }
+        
         float4 vColor0 = GetAttributeAtVertex(input.color, 0);
         float4 vColor1 = GetAttributeAtVertex(input.color, 1);
         float4 vColor2 = GetAttributeAtVertex(input.color, 2);
+        
         return bary.x * vColor0 + bary.y * vColor1 + bary.z * vColor2;
       }
+      
       ]]>
     </Shader>
   </ShaderOp>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1493,11 +1493,12 @@
 
   <ShaderOp Name="Barycentrics" PS="PS61" VS="VS61">
     <RootSignature>RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable(UAV(u0,numDescriptors=1))</RootSignature>
-    <Resource Name="VBuffer" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
-        { {   0.0f,  1.0f , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
-        { {   1.0f, -1.0f , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
-        { {  -1.0f, -1.0f , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
-      </Resource>
+    <Resource Name="VBuffer" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" Init="ByName" ReadBack="true">
+      <!--
+      { {   0.0f,  1.0f , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } }
+      { {   1.0f, -1.0f , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } }
+      { {  -1.0f, -1.0f , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } } !-->
+    </Resource>
     <Resource Name="RTarget" Dimension="TEXTURE2D" Width="1280" Height="2400" Format="R32G32B32A32_FLOAT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
     <Resource Name="g_result"      Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
 

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1494,10 +1494,6 @@
   <ShaderOp Name="Barycentrics" PS="PS61" VS="VS61">
     <RootSignature>RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable(UAV(u0,numDescriptors=1))</RootSignature>
     <Resource Name="VBuffer" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" Init="ByName" ReadBack="true">
-      <!--
-      { {   0.0f,  1.0f , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } }
-      { {   1.0f, -1.0f , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } }
-      { {  -1.0f, -1.0f , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } } !-->
     </Resource>
     <Resource Name="RTarget" Dimension="TEXTURE2D" Width="1280" Height="2400" Format="R32G32B32A32_FLOAT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
     <Resource Name="g_result"      Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>

--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -1492,16 +1492,21 @@
   </ShaderOp>
 
   <ShaderOp Name="Barycentrics" PS="PS61" VS="VS61">
-    <RootSignature>RootFlags(ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT)</RootSignature>
+    <RootSignature>RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT), DescriptorTable(UAV(u0,numDescriptors=1))</RootSignature>
     <Resource Name="VBuffer" Dimension="BUFFER" Width="1024" Flags="ALLOW_UNORDERED_ACCESS" InitialResourceState="COPY_DEST" Init="FromBytes" ReadBack="true">
         { {   0.0f,  1.0f , 0.0f }, { 1.0f, 0.0f, 0.0f, 1.0f } },
         { {   1.0f, -1.0f , 0.0f }, { 0.0f, 1.0f, 0.0f, 1.0f } },
         { {  -1.0f, -1.0f , 0.0f }, { 0.0f, 0.0f, 1.0f, 1.0f } }
       </Resource>
     <Resource Name="RTarget" Dimension="TEXTURE2D" Width="1280" Height="2400" Format="R32G32B32A32_FLOAT" Flags="ALLOW_RENDER_TARGET" InitialResourceState="COPY_DEST" ReadBack="true" />
+    <Resource Name="g_result"      Dimension="BUFFER"     Width="64"            InitialResourceState="COPY_DEST" Init="ZERO"      Flags="ALLOW_UNORDERED_ACCESS" ReadBack="true"  TransitionTo="UNORDERED_ACCESS"/>
+
     <DescriptorHeap Name="RtvHeap" NumDescriptors="1" Type="RTV">
       <Descriptor Name="RTarget" Kind="RTV"/>
     </DescriptorHeap>
+    <DescriptorHeap Name="ResourceDescriptorHeap" Type="CBV_SRV_UAV">
+      <Descriptor Name="g_result"   NumElements="3" Kind="UAV"  StructureByteStride="4"/>
+    </DescriptorHeap>  
     <InputElements>
       <InputElement SemanticName="POSITION" Format="R32G32B32_FLOAT" AlignedByteOffset="0" />
       <InputElement SemanticName="COLOR" Format="R32G32B32A32_FLOAT" AlignedByteOffset="12" />
@@ -1510,7 +1515,10 @@
       <RenderTarget Name="RTarget" />
     </RenderTargets>
 
-
+    <RootValues>
+      <RootValue HeapName="ResourceDescriptorHeap" Index="0" />
+    </RootValues>
+    
     <Shader Name="PS61" Target="ps_6_1" EntryPoint="PSMain" Text="@MAIN"/>
     <Shader Name="VS61" Target="vs_6_1" EntryPoint="VSMain" Text="@MAIN"/>
 
@@ -1520,35 +1528,30 @@
       struct PSInput {
         float4 position : SV_POSITION;
         nointerpolation float4 color : COLOR;
+        uint svid : SVertexID;
       };
       
-      PSInput VSMain(float4 position : POSITION, float4 color : COLOR, uint vid : SV_VertexID) {
+      
+      RWStructuredBuffer <uint> g_result   : register(u0);
+      
+      PSInput VSMain(float4 position : POSITION, float4 color : COLOR, uint svid : SV_VertexID) {
         PSInput result;
         result.position = position;
         result.color = color;
-        int x = vid;
+        result.svid = svid;
+         
         return result;
       }
     
-      float4 PSMain(PSInput input, float3 bary : SV_Barycentrics) : SV_Target {
+      float4 PSMain(PSInput input, float3 bary : SV_Barycentrics, uint vid : VertexID) : SV_Target {
         float4 pos = input.position;
         // check to make sure that the pixel shader will see the barycentric weight associated
         // with the first vertex in the x component of the SV_Barycentric vector, and likewise for subsequent vertices
-        if (pos.x == 0.0f && pos.y == 1.0f && pos.z == 0.0f)
-        {
-          if (abs(bary.x - 1.0f) > .001 || abs(bary.y - 0.0f) > .001 || abs(bary.z - 0.0f) > .001)
-            return 0.5f;
-        }
-        if (pos.x == 1.0f && pos.y == -1.0f && pos.z == 0.0f)
-        {
-          if (abs(bary.x - 0.0f) > .001 || abs(bary.y - 1.0f) > .001 || abs(bary.z - 0.0f) > .001)
-            return 0.5f;
-        }
-        if (pos.x == -1.0f && pos.y == -1.0f && pos.z == 0.0f)
-        {
-          if (abs(bary.x - 0.0f) > .001 || abs(bary.y - 0.0f) > .001 || abs(bary.z - 1.0f) > .001)
-            return 0.5f;
-        }
+        float4 color = input.color;
+     
+        g_result[0] = GetAttributeAtVertex(input.svid, 0);
+        g_result[1] = GetAttributeAtVertex(input.svid, 1);
+        g_result[2] = GetAttributeAtVertex(input.svid, 2);
         
         float4 vColor0 = GetAttributeAtVertex(input.color, 0);
         float4 vColor1 = GetAttributeAtVertex(input.color, 1);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -8977,7 +8977,7 @@ TEST_F(ExecutionTest, BarycentricsTest) {
       WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
       return;
     }
-
+    
     std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(pDevice, m_support, pStream, "Barycentrics", nullptr);
     MappedData data;
     D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -8963,6 +8963,8 @@ TEST_F(ExecutionTest, CBufferTestHalf) {
   }
 }
 
+//$(TargetPath) /inproc /p:"HlslDataDir=D:\DirectXShaderCompiler\tools\clang\unittests\HLSL\..\..\test\HLSL"  /name:ExecutionTest::Barycentric*
+              ///inproc /p:"HlslDataDir=C:\git\dxc\master\tools\clang\unittests\HLSL\..\..\test\HLSL" /runIgnoredTests /p:"ExperimentalShaders=*" /name: ExecutionTest::QuadAnyAll /p:"Adapter=NVIDIA*" /p:D3D12SDKVersion=700 /p:"D3D12SDKPath=.\D3D12\"
 TEST_F(ExecutionTest, BarycentricsTest) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
     CComPtr<IStream> pStream;
@@ -8978,61 +8980,92 @@ TEST_F(ExecutionTest, BarycentricsTest) {
       return;
     }
  
-    std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(pDevice, m_support, pStream, "Barycentrics", nullptr);
-    MappedData data;
-    D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;
-    UINT width = (UINT)D.Width;
-    UINT height = D.Height;
-    UINT pixelSize = GetByteSizeForFormat(D.Format);
+    DXASSERT_NOMSG(pStream != nullptr);
+    std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+          std::make_shared<st::ShaderOpSet>();
+    st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+    
+    for(int test_iteration = 0; test_iteration < 3; test_iteration++)
+    {
+      auto ResourceCallbackFn = 
+          [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+            std::vector<float> bary = {0.0f,  1.0f , 0.0f,   1.0f, 0.0f, 0.0f, 1.0f, 
+                                       1.0f, -1.0f , 0.0f,   0.0f, 1.0f, 0.0f, 1.0f,
+                                      -1.0f, -1.0f , 0.0f,   0.0f, 0.0f, 1.0f, 1.0f}; 
+            const int barysize = 21;
+         
+            UNREFERENCED_PARAMETER(pShaderOp);
+            VERIFY_IS_TRUE(0 == _stricmp(Name, "VBuffer"));
+            size_t size = sizeof(float)*barysize;
+            Data.resize(size);
+            float *vb = (float *)Data.data();
+            for (size_t i = 0; i < barysize; ++i) {
+              float *p = &vb[i];
+              float tempfloat = bary[(i+(7*test_iteration))%barysize];
+              *p = tempfloat;
+            }
+          };
 
-    test->Test->GetReadBackData("RTarget", &data);
-    //const uint8_t *pPixels = (uint8_t *)data.data();
-    const float *pPixels = (float *)data.data();
-    // Get the vertex of barycentric coordinate using VBuffer
-    MappedData triangleData;
-    test->Test->GetReadBackData("VBuffer", &triangleData);
-    const float *pTriangleData = (float*)triangleData.data();
+      std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "Barycentrics", ResourceCallbackFn, ShaderOpSet);
 
-    // Get the vertex of barycentric coordinate using VBuffer
-    MappedData vIDData;
-    test->Test->GetReadBackData("g_result", &vIDData);
-    const unsigned int *pvIDData = (unsigned int*)vIDData.data();
-    // make sure the barycentric ordering constraint gets tested.
-    VERIFY_IS_TRUE(pvIDData[0] == 0);
-    VERIFY_IS_TRUE(pvIDData[1] == 1);
-    VERIFY_IS_TRUE(pvIDData[2] == 2);
+      MappedData data;
+      D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;
+      UINT width = (UINT)D.Width;
+      UINT height = D.Height;
+      UINT pixelSize = GetByteSizeForFormat(D.Format);
 
-    // get the size of the input data
-    unsigned triangleVertexSizeInFloat = 0;
-    for (auto element : test->ShaderOp->InputElements)
-        triangleVertexSizeInFloat += GetByteSizeForFormat(element.Format) / 4;
+      test->Test->GetReadBackData("RTarget", &data);
+      //const uint8_t *pPixels = (uint8_t *)data.data();
+      const float *pPixels = (float *)data.data();
+      // Get the vertex of barycentric coordinate using VBuffer
+      MappedData triangleData;
+      test->Test->GetReadBackData("VBuffer", &triangleData);
+      const float *pTriangleData = (float*)triangleData.data();
 
-    XMFLOAT2 p0(pTriangleData[0], pTriangleData[1]);
-    XMFLOAT2 p1(pTriangleData[triangleVertexSizeInFloat], pTriangleData[triangleVertexSizeInFloat + 1]);
-    XMFLOAT2 p2(pTriangleData[triangleVertexSizeInFloat * 2], pTriangleData[triangleVertexSizeInFloat * 2 + 1]);
+      // Get the vertex of barycentric coordinate using VBuffer
+      MappedData vIDData;
+      test->Test->GetReadBackData("g_result", &vIDData);
+      const unsigned int *pvIDData = (unsigned int*)vIDData.data();
+      // make sure the barycentric ordering constraint gets tested.
+      VERIFY_IS_TRUE(pvIDData[0] == 0);
+      VERIFY_IS_TRUE(pvIDData[1] == 1);
+      VERIFY_IS_TRUE(pvIDData[2] == 2);
 
-    XMFLOAT3 barycentricWeights[4] = {
-        XMFLOAT3(0.3333f, 0.3333f, 0.3333f),
-        XMFLOAT3(0.5f, 0.25f, 0.25f),
-        XMFLOAT3(0.25f, 0.5f, 0.25f),
-        XMFLOAT3(0.25f, 0.25f, 0.50f)
-    };
+      // get the size of the input data
+      unsigned triangleVertexSizeInFloat = 0;
+      for (auto element : test->ShaderOp->InputElements)
+          triangleVertexSizeInFloat += GetByteSizeForFormat(element.Format) / 4;
 
-    float tolerance = 0.001f;
-    for (unsigned i = 0; i < sizeof(barycentricWeights) / sizeof(XMFLOAT3); ++i) {
-        float w0 = barycentricWeights[i].x;
-        float w1 = barycentricWeights[i].y;
-        float w2 = barycentricWeights[i].z;
-        float x1 = w0 * p0.x + w1 * p1.x + w2 * p2.x;
-        float y1 = w0 * p0.y + w1 * p1.y + w2 * p2.y;
-        // map from x1 y1 to rtv pixels
-        int pixelX = (int)((x1 + 1) * (width - 1) / 2);
-        int pixelY = (int)((1 - y1) * (height - 1) / 2);
-        int offset = pixelSize * (pixelX + pixelY * width) / sizeof(pPixels[0]);
-        LogCommentFmt(L"location  %u %u, value %f, %f, %f", pixelX, pixelY, pPixels[offset], pPixels[offset + 1], pPixels[offset + 2]);
-        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset], w0, tolerance));
-        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 1], w1, tolerance));
-        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 2], w2, tolerance));
+      XMFLOAT2 p0(pTriangleData[0], pTriangleData[1]);
+      XMFLOAT2 p1(pTriangleData[triangleVertexSizeInFloat], pTriangleData[triangleVertexSizeInFloat + 1]);
+      XMFLOAT2 p2(pTriangleData[triangleVertexSizeInFloat * 2], pTriangleData[triangleVertexSizeInFloat * 2 + 1]);
+
+      XMFLOAT3 barycentricWeights[4] = {
+          XMFLOAT3(0.3333f, 0.3333f, 0.3333f),
+          XMFLOAT3(0.5f, 0.25f, 0.25f),
+          XMFLOAT3(0.25f, 0.5f, 0.25f),
+          XMFLOAT3(0.25f, 0.25f, 0.50f)
+      };
+
+      float tolerance = 0.001f;
+      for (unsigned i = 0; i < sizeof(barycentricWeights) / sizeof(XMFLOAT3); ++i) {
+          float w0 = barycentricWeights[i].x;
+          float w1 = barycentricWeights[i].y;
+          float w2 = barycentricWeights[i].z;
+          vector<float> weights = {w0, w1, w2};
+          float x1 = w0 * p0.x + w1 * p1.x + w2 * p2.x;
+          float y1 = w0 * p0.y + w1 * p1.y + w2 * p2.y;
+          // map from x1 y1 to rtv pixels
+          int pixelX = (int)((x1 + 1) * (width - 1) / 2);
+          int pixelY = (int)((1 - y1) * (height - 1) / 2);
+          int offset = pixelSize * (pixelX + pixelY * width) / sizeof(pPixels[0]);
+          LogCommentFmt(L"location  %u %u, value %f, %f, %f", pixelX, pixelY, pPixels[offset], pPixels[offset + 1], pPixels[offset + 2]);
+          size_t ws = weights.size();
+          // different weights are used per test_iteration since the order of the vertices changes at each iteration.
+          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset],    weights[(0 - test_iteration + ws) % ws], tolerance));
+          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 1],weights[(1 - test_iteration + ws) % ws], tolerance));
+          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 2],weights[(2 - test_iteration + ws) % ws], tolerance));
+      }
     }
     //SavePixelsToFile(pPixels, DXGI_FORMAT_R32G32B32A32_FLOAT, width, height, L"barycentric.bmp");
 }

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -8963,111 +8963,109 @@ TEST_F(ExecutionTest, CBufferTestHalf) {
   }
 }
 
-//$(TargetPath) /inproc /p:"HlslDataDir=D:\DirectXShaderCompiler\tools\clang\unittests\HLSL\..\..\test\HLSL"  /name:ExecutionTest::Barycentric*
-              ///inproc /p:"HlslDataDir=C:\git\dxc\master\tools\clang\unittests\HLSL\..\..\test\HLSL" /runIgnoredTests /p:"ExperimentalShaders=*" /name: ExecutionTest::QuadAnyAll /p:"Adapter=NVIDIA*" /p:D3D12SDKVersion=700 /p:"D3D12SDKPath=.\D3D12\"
 TEST_F(ExecutionTest, BarycentricsTest) {
-    WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-    CComPtr<IStream> pStream;
-    ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
+  WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+  CComPtr<IStream> pStream;
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
-    CComPtr<ID3D12Device> pDevice;
-    if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_1))
-        return;
-
-    if (!DoesDeviceSupportBarycentrics(pDevice)) {
-      WEX::Logging::Log::Comment(L"Device does not support barycentrics.");
-      WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+  CComPtr<ID3D12Device> pDevice;
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_1))
       return;
-    }
+
+  if (!DoesDeviceSupportBarycentrics(pDevice)) {
+    WEX::Logging::Log::Comment(L"Device does not support barycentrics.");
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
  
-    DXASSERT_NOMSG(pStream != nullptr);
-    std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
-          std::make_shared<st::ShaderOpSet>();
-    st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+  DXASSERT_NOMSG(pStream != nullptr);
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+        std::make_shared<st::ShaderOpSet>();
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
     
-    for(int test_iteration = 0; test_iteration < 3; test_iteration++)
-    {
-      auto ResourceCallbackFn = 
-          [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
-            std::vector<float> bary = {0.0f,  1.0f , 0.0f,   1.0f, 0.0f, 0.0f, 1.0f, 
-                                       1.0f, -1.0f , 0.0f,   0.0f, 1.0f, 0.0f, 1.0f,
-                                      -1.0f, -1.0f , 0.0f,   0.0f, 0.0f, 1.0f, 1.0f}; 
-            const int barysize = 21;
+  for(int test_iteration = 0; test_iteration < 3; test_iteration++)
+  {
+    auto ResourceCallbackFn = 
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+        std::vector<float> bary = {0.0f,  1.0f , 0.0f,   1.0f, 0.0f, 0.0f, 1.0f, 
+                                    1.0f, -1.0f , 0.0f,   0.0f, 1.0f, 0.0f, 1.0f,
+                                  -1.0f, -1.0f , 0.0f,   0.0f, 0.0f, 1.0f, 1.0f}; 
+        const int barysize = 21;
          
-            UNREFERENCED_PARAMETER(pShaderOp);
-            VERIFY_IS_TRUE(0 == _stricmp(Name, "VBuffer"));
-            size_t size = sizeof(float)*barysize;
-            Data.resize(size);
-            float *vb = (float *)Data.data();
-            for (size_t i = 0; i < barysize; ++i) {
-              float *p = &vb[i];
-              float tempfloat = bary[(i+(7*test_iteration))%barysize];
-              *p = tempfloat;
-            }
-          };
-
-      std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "Barycentrics", ResourceCallbackFn, ShaderOpSet);
-
-      MappedData data;
-      D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;
-      UINT width = (UINT)D.Width;
-      UINT height = D.Height;
-      UINT pixelSize = GetByteSizeForFormat(D.Format);
-
-      test->Test->GetReadBackData("RTarget", &data);
-      //const uint8_t *pPixels = (uint8_t *)data.data();
-      const float *pPixels = (float *)data.data();
-      // Get the vertex of barycentric coordinate using VBuffer
-      MappedData triangleData;
-      test->Test->GetReadBackData("VBuffer", &triangleData);
-      const float *pTriangleData = (float*)triangleData.data();
-
-      // Get the vertex of barycentric coordinate using VBuffer
-      MappedData vIDData;
-      test->Test->GetReadBackData("g_result", &vIDData);
-      const unsigned int *pvIDData = (unsigned int*)vIDData.data();
-      // make sure the barycentric ordering constraint gets tested.
-      VERIFY_IS_TRUE(pvIDData[0] == 0);
-      VERIFY_IS_TRUE(pvIDData[1] == 1);
-      VERIFY_IS_TRUE(pvIDData[2] == 2);
-
-      // get the size of the input data
-      unsigned triangleVertexSizeInFloat = 0;
-      for (auto element : test->ShaderOp->InputElements)
-          triangleVertexSizeInFloat += GetByteSizeForFormat(element.Format) / 4;
-
-      XMFLOAT2 p0(pTriangleData[0], pTriangleData[1]);
-      XMFLOAT2 p1(pTriangleData[triangleVertexSizeInFloat], pTriangleData[triangleVertexSizeInFloat + 1]);
-      XMFLOAT2 p2(pTriangleData[triangleVertexSizeInFloat * 2], pTriangleData[triangleVertexSizeInFloat * 2 + 1]);
-
-      XMFLOAT3 barycentricWeights[4] = {
-          XMFLOAT3(0.3333f, 0.3333f, 0.3333f),
-          XMFLOAT3(0.5f, 0.25f, 0.25f),
-          XMFLOAT3(0.25f, 0.5f, 0.25f),
-          XMFLOAT3(0.25f, 0.25f, 0.50f)
+        UNREFERENCED_PARAMETER(pShaderOp);
+        VERIFY_IS_TRUE(0 == _stricmp(Name, "VBuffer"));
+        size_t size = sizeof(float)*barysize;
+        Data.resize(size);
+        float *vb = (float *)Data.data();
+        for (size_t i = 0; i < barysize; ++i) {
+          float *p = &vb[i];
+          float tempfloat = bary[(i+(7*test_iteration))%barysize];
+          *p = tempfloat;
+        }
       };
 
-      float tolerance = 0.001f;
-      for (unsigned i = 0; i < sizeof(barycentricWeights) / sizeof(XMFLOAT3); ++i) {
-          float w0 = barycentricWeights[i].x;
-          float w1 = barycentricWeights[i].y;
-          float w2 = barycentricWeights[i].z;
-          vector<float> weights = {w0, w1, w2};
-          float x1 = w0 * p0.x + w1 * p1.x + w2 * p2.x;
-          float y1 = w0 * p0.y + w1 * p1.y + w2 * p2.y;
-          // map from x1 y1 to rtv pixels
-          int pixelX = (int)((x1 + 1) * (width - 1) / 2);
-          int pixelY = (int)((1 - y1) * (height - 1) / 2);
-          int offset = pixelSize * (pixelX + pixelY * width) / sizeof(pPixels[0]);
-          LogCommentFmt(L"location  %u %u, value %f, %f, %f", pixelX, pixelY, pPixels[offset], pPixels[offset + 1], pPixels[offset + 2]);
-          size_t ws = weights.size();
-          // different weights are used per test_iteration since the order of the vertices changes at each iteration.
-          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset],    weights[(0 - test_iteration + ws) % ws], tolerance));
-          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 1],weights[(1 - test_iteration + ws) % ws], tolerance));
-          VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 2],weights[(2 - test_iteration + ws) % ws], tolerance));
-      }
+    std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(pDevice, m_support, "Barycentrics", ResourceCallbackFn, ShaderOpSet);
+
+    MappedData data;
+    D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;
+    UINT width = (UINT)D.Width;
+    UINT height = D.Height;
+    UINT pixelSize = GetByteSizeForFormat(D.Format);
+
+    test->Test->GetReadBackData("RTarget", &data);
+    //const uint8_t *pPixels = (uint8_t *)data.data();
+    const float *pPixels = (float *)data.data();
+    // Get the vertex of barycentric coordinate using VBuffer
+    MappedData triangleData;
+    test->Test->GetReadBackData("VBuffer", &triangleData);
+    const float *pTriangleData = (float*)triangleData.data();
+
+    // Get the vertex of barycentric coordinate using VBuffer
+    MappedData vIDData;
+    test->Test->GetReadBackData("g_result", &vIDData);
+    const unsigned int *pvIDData = (unsigned int*)vIDData.data();
+    // make sure the barycentric ordering constraint gets tested.
+    VERIFY_IS_TRUE(pvIDData[0] == 0);
+    VERIFY_IS_TRUE(pvIDData[1] == 1);
+    VERIFY_IS_TRUE(pvIDData[2] == 2);
+
+    // get the size of the input data
+    unsigned triangleVertexSizeInFloat = 0;
+    for (auto element : test->ShaderOp->InputElements)
+        triangleVertexSizeInFloat += GetByteSizeForFormat(element.Format) / 4;
+
+    XMFLOAT2 p0(pTriangleData[0], pTriangleData[1]);
+    XMFLOAT2 p1(pTriangleData[triangleVertexSizeInFloat], pTriangleData[triangleVertexSizeInFloat + 1]);
+    XMFLOAT2 p2(pTriangleData[triangleVertexSizeInFloat * 2], pTriangleData[triangleVertexSizeInFloat * 2 + 1]);
+
+    XMFLOAT3 barycentricWeights[4] = {
+        XMFLOAT3(0.3333f, 0.3333f, 0.3333f),
+        XMFLOAT3(0.5f, 0.25f, 0.25f),
+        XMFLOAT3(0.25f, 0.5f, 0.25f),
+        XMFLOAT3(0.25f, 0.25f, 0.50f)
+    };
+
+    float tolerance = 0.001f;
+    for (unsigned i = 0; i < sizeof(barycentricWeights) / sizeof(XMFLOAT3); ++i) {
+        float w0 = barycentricWeights[i].x;
+        float w1 = barycentricWeights[i].y;
+        float w2 = barycentricWeights[i].z;
+        vector<float> weights = {w0, w1, w2};
+        float x1 = w0 * p0.x + w1 * p1.x + w2 * p2.x;
+        float y1 = w0 * p0.y + w1 * p1.y + w2 * p2.y;
+        // map from x1 y1 to rtv pixels
+        int pixelX = (int)((x1 + 1) * (width - 1) / 2);
+        int pixelY = (int)((1 - y1) * (height - 1) / 2);
+        int offset = pixelSize * (pixelX + pixelY * width) / sizeof(pPixels[0]);
+        LogCommentFmt(L"location  %u %u, value %f, %f, %f", pixelX, pixelY, pPixels[offset], pPixels[offset + 1], pPixels[offset + 2]);
+        size_t ws = weights.size();
+        // different weights are used per test_iteration since the order of the vertices changes at each iteration.
+        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset],    weights[(0 - test_iteration + ws) % ws], tolerance));
+        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 1],weights[(1 - test_iteration + ws) % ws], tolerance));
+        VERIFY_IS_TRUE(CompareFloatEpsilon(pPixels[offset + 2],weights[(2 - test_iteration + ws) % ws], tolerance));
     }
-    //SavePixelsToFile(pPixels, DXGI_FORMAT_R32G32B32A32_FLOAT, width, height, L"barycentric.bmp");
+  }
+  //SavePixelsToFile(pPixels, DXGI_FORMAT_R32G32B32A32_FLOAT, width, height, L"barycentric.bmp");
 }
 
 static const char RawBufferTestShaderDeclarations[] =

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -8977,7 +8977,7 @@ TEST_F(ExecutionTest, BarycentricsTest) {
       WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
       return;
     }
-    
+ 
     std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTest(pDevice, m_support, pStream, "Barycentrics", nullptr);
     MappedData data;
     D3D12_RESOURCE_DESC &D = test->ShaderOp->GetResourceByName("RTarget")->Desc;
@@ -8992,6 +8992,16 @@ TEST_F(ExecutionTest, BarycentricsTest) {
     MappedData triangleData;
     test->Test->GetReadBackData("VBuffer", &triangleData);
     const float *pTriangleData = (float*)triangleData.data();
+
+    // Get the vertex of barycentric coordinate using VBuffer
+    MappedData vIDData;
+    test->Test->GetReadBackData("g_result", &vIDData);
+    const unsigned int *pvIDData = (unsigned int*)vIDData.data();
+    // make sure the barycentric ordering constraint gets tested.
+    VERIFY_IS_TRUE(pvIDData[0] == 0);
+    VERIFY_IS_TRUE(pvIDData[1] == 1);
+    VERIFY_IS_TRUE(pvIDData[2] == 2);
+
     // get the size of the input data
     unsigned triangleVertexSizeInFloat = 0;
     for (auto element : test->ShaderOp->InputElements)


### PR DESCRIPTION
Add additional check to pre-existing barycentric HLK test to ensure that GetAttributeAtVertex returns 0 for whichever vertex is first in the vertex buffer.