### PR TITLE
NFC. Ensure that the output directory exists

### DIFF
--- a/utils/hct/hctgen.py
+++ b/utils/hct/hctgen.py
@@ -52,6 +52,9 @@ def writeCodeTag(args):
   return 0
   
 def openOutput(args):
+  outputDir = os.path.dirname(os.path.realpath(args.output))
+  if not os.path.exists(outputDir):
+    os.makedirs(outputDir)
   return open(args.output, 'w', newline=getNewline(args))
 
 def printHeader(out, filename):


### PR DESCRIPTION
Depending on build ordering the output directory may not be created
before the output file is written. This resolves the issue by forcing
the creation.

Resolves #4570.