### PR TITLE
Replace -fcolor-diagnostics by -fdiagnostics-color

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -541,7 +541,7 @@ add_llvm_definitions( -D__STDC_LIMIT_MACROS )
 if (UNIX AND
     CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
     CMAKE_GENERATOR STREQUAL "Ninja")
-  append("-fcolor-diagnostics" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+  append("-fdiagnostics-color" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 endif()
 
 # HLSL Change Starts


### PR DESCRIPTION
Replace this option with a similar one more compatible with different
compiler versions.

Fixes #3730
Signed-off-by: Nathan Gauër <brioche@google.com>