### PR TITLE
[SPIRV] Add support for vk::RawBufferStore

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -3885,7 +3885,7 @@ support setting the memory layout for the data. Since these intrinsics are suppo
 "arbitrary" data to or from a random device address, we assume that the program loads/stores some "bytes of data",
 but that its format or layout is unknown. Therefore, keep in mind that these intrinsics
 load or store ``sizeof(T)`` bytes of data, and that loading/storing data with a struct
-with a custom memory alignment may yeild undefined behavior due to the missing custom memory layout support.
+with a custom memory alignment may yield undefined behavior due to the missing custom memory layout support.
 Loading data with customized memory layouts is future work.
 
 Using either of these intrinsics adds ``PhysicalStorageBufferAddresses`` capability and

--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -3856,38 +3856,39 @@ For example:
 
   uint64_t clock = vk::ReadClock(vk::SubgroupScope);
 
-RawBufferLoad
-~~~~~~~~~~~~~
-Vulkan extension `VK_KHR_buffer_device_address <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_buffer_device_address.html>`_
+RawBufferLoad and RawBufferStore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Vulkan extension `VK_KHR_buffer_device_address <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_buffer_device_address.html>`_
 supports getting the 64-bit address of a buffer and passing it to SPIR-V as a
-Uniform buffer. SPIR-V can use the address to load the data without descriptor.
-We add the following intrinsic funcion to expose a subset of the
+Uniform buffer. SPIR-V can use the address to load and store data without a descriptor.
+We add the following intrinsic functions to expose a subset of the
 `VK_KHR_buffer_device_address <https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_buffer_device_address.html>`_
 and `SPV_KHR_physical_storage_buffer <https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_physical_storage_buffer.asciidoc>`_
 functionality to HLSL:
 
 .. code:: hlsl
 
-  // It uses 'uint' for the default template argument. The default alignment
-  // is 4. Note that 'alignment' must be a constant integer.
+  // RawBufferLoad and RawBufferStore use 'uint' for the default template argument. 
+  // The default alignment is 4. Note that 'alignment' must be a constant integer.
   T RawBufferLoad<T = uint>(in uint64_t deviceAddress, in uint alignment = 4);
+  void RawBufferStore<T = uint>(in uint64_t deviceAddress, in T value, in uint alignment = 4);
 
 
-It allows the shader program to load a single value with type T from a GPU
-accessible memory at given address, similar to ``ByteAddressBuffer.Load()``.
-The intrinsic allows us to set the alignment. It uses 'uint' when the template
-argument is missing and it uses 4 for the default alignment. The alignment
-argument must be a constant integer if it is given.
+These intrinsics allow the shader program to load and store a single value with type T (int, float2, struct, etc...) 
+from GPU accessible memory at given address, similar to ``ByteAddressBuffer.Load()``.
+Additionally, these intrinsics allow users to set the memory alignment for the underlying data. 
+We assume a 'uint' type when the template argument is missing, and we use a value of '4' for the default alignment. 
+Note that the alignment argument must be a constant integer if it is given.
 
-Note that we support the aligned data load, but we do not support setting
-memory layout for the data. Since it is supposed to load "arbitrary" data
-from a random device address, we assume that it loads some "bytes of data"
-but its format or layout is unknown. Therefore, keep it in mind that it
-loads ``sizeof(T)`` bytes of data, but loading data with a complicated struct
-type ``T`` is a undefined behavior because of the missing memory layout support.
-Loading data with a memory layout is a future work.
+Though we do support setting the `alignment` of the data load and store, we do not currently 
+support setting the memory layout for the data. Since these intrinsics are supposed to load 
+"arbitrary" data to or from a random device address, we assume that the program loads/stores some "bytes of data",
+but that its format or layout is unknown. Therefore, keep in mind that these intrinsics
+load or store ``sizeof(T)`` bytes of data, and that loading/storing data with a struct
+with a custom memory alignment may yeild undefined behavior due to the missing custom memory layout support.
+Loading data with customized memory layouts is future work.
 
-Using the intrinsic adds ``PhysicalStorageBufferAddresses`` capability and
+Using either of these intrinsics adds ``PhysicalStorageBufferAddresses`` capability and
 ``SPV_KHR_physical_storage_buffer`` extension requirements as well as changing
 the addressing model to ``PhysicalStorageBuffer64``.
 
@@ -3896,10 +3897,12 @@ Example:
 .. code:: hlsl
 
   uint64_t address;
-  float4 main() : SV_Target0 {
+  [numthreads(32, 1, 1)]
+  void main(uint3 tid : SV_DispatchThreadID) {
     double foo = vk::RawBufferLoad<double>(address, 8);
     uint bar = vk::RawBufferLoad(address + 8);
     ...
+    vk::RawBufferStore<uint>(address + tid.x, bar + tid.x);
   }
 
 Inline SPIR-V (HLSL version of GL_EXT_spirv_intrinsics)

--- a/include/dxc/HlslIntrinsicOp.h
+++ b/include/dxc/HlslIntrinsicOp.h
@@ -227,6 +227,9 @@ enum class IntrinsicOp {  IOP_AcceptHitAndEndSearch,
   IOP_VkRawBufferLoad,
 #endif // ENABLE_SPIRV_CODEGEN
 #ifdef ENABLE_SPIRV_CODEGEN
+  IOP_VkRawBufferStore,
+#endif // ENABLE_SPIRV_CODEGEN
+#ifdef ENABLE_SPIRV_CODEGEN
   IOP_VkReadClock,
 #endif // ENABLE_SPIRV_CODEGEN
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -5765,6 +5765,7 @@ IntrinsicLower gLowerTable[] = {
     {IntrinsicOp::IOP_unpack_u8u32, TranslateUnpack, DXIL::OpCode::Unpack4x8},
 #ifdef ENABLE_SPIRV_CODEGEN
     { IntrinsicOp::IOP_VkRawBufferLoad, UnsupportedVulkanIntrinsic, DXIL::OpCode::NumOpCodes },
+    { IntrinsicOp::IOP_VkRawBufferStore, UnsupportedVulkanIntrinsic, DXIL::OpCode::NumOpCodes },
     { IntrinsicOp::IOP_VkReadClock, UnsupportedVulkanIntrinsic, DXIL::OpCode::NumOpCodes },
     { IntrinsicOp::IOP_Vkext_execution_mode, UnsupportedVulkanIntrinsic, DXIL::OpCode::NumOpCodes },
     { IntrinsicOp::IOP_Vkext_execution_mode_id, UnsupportedVulkanIntrinsic, DXIL::OpCode::NumOpCodes },

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -187,8 +187,8 @@ public:
                                     SpirvInstruction *pointer, SourceLocation);
 
   /// \brief Creates a store instruction storing the given value into the given
-  /// address.
-  void createStore(SpirvInstruction *address, SpirvInstruction *value,
+  /// address. Returns the instruction pointer for the store instruction.
+  SpirvStore *createStore(SpirvInstruction *address, SpirvInstruction *value,
                    SourceLocation loc, SourceRange range = {});
 
   /// \brief Creates a function call instruction and returns the instruction

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1842,10 +1842,15 @@ public:
     return memoryAccess.getValue();
   }
 
+  void setAlignment(uint32_t alignment);
+  bool hasAlignment() const { return memoryAlignment.hasValue(); }
+  uint32_t getAlignment() const { return memoryAlignment.getValue(); }
+
 private:
   SpirvInstruction *pointer;
   SpirvInstruction *object;
   llvm::Optional<spv::MemoryAccessMask> memoryAccess;
+  llvm::Optional<uint32_t> memoryAlignment;
 };
 
 /// \brief Represents SPIR-V unary operation instructions.

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1317,8 +1317,15 @@ bool EmitVisitor::visit(SpirvStore *inst) {
   initInstruction(inst);
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getPointer()));
   curInst.push_back(getOrAssignResultId<SpirvInstruction>(inst->getObject()));
-  if (inst->hasMemoryAccessSemantics())
-    curInst.push_back(static_cast<uint32_t>(inst->getMemoryAccess()));
+  if (inst->hasMemoryAccessSemantics()) {
+    spv::MemoryAccessMask memoryAccess = inst->getMemoryAccess();
+    curInst.push_back(static_cast<uint32_t>(memoryAccess));
+    if (inst->hasAlignment()) {
+      assert(static_cast<uint32_t>(memoryAccess) &
+             static_cast<uint32_t>(spv::MemoryAccessMask::Aligned));
+      curInst.push_back(inst->getAlignment());
+    }
+  }
   finalizeInstruction(&mainBinary);
   return true;
 }

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -257,12 +257,13 @@ SpirvLoad *SpirvBuilder::createLoad(const SpirvType *resultType,
   return instruction;
 }
 
-void SpirvBuilder::createStore(SpirvInstruction *address,
+SpirvStore *SpirvBuilder::createStore(SpirvInstruction *address,
                                SpirvInstruction *value, SourceLocation loc,
                                SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context) SpirvStore(loc, address, value, llvm::None, range);
   insertPoint->addInstruction(instruction);
+  return instruction;
 }
 
 SpirvFunctionCall *

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -634,8 +634,20 @@ private:
                                            uint32_t alignment,
                                            SourceLocation loc);
 
+  /// Process `void vk::RawBufferStore<T>(in uint64_t address, in T value
+  /// [, in uint alignment])` that stores data to a given device address.
+  SpirvInstruction *processRawBufferStore(const CallExpr *callExpr);
+  SpirvInstruction *storeDataToRawAddress(SpirvInstruction *addressInUInt64,
+                                          SpirvInstruction *value,
+                                           QualType bufferType,
+                                           uint32_t alignment,
+                                           SourceLocation loc);
+
   /// Returns the alignment of `vk::RawBufferLoad()`.
   uint32_t getAlignmentForRawBufferLoad(const CallExpr *callExpr);
+
+  /// Returns the alignment of `vk::RawBufferStore()`.
+  uint32_t getAlignmentForRawBufferStore(const CallExpr *callExpr);
 
   /// Process vk::ext_execution_mode intrinsic
   SpirvInstruction *processIntrinsicExecutionMode(const CallExpr *expr,

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -833,6 +833,18 @@ SpirvStore::SpirvStore(SourceLocation loc, SpirvInstruction *pointerInst,
     : SpirvInstruction(IK_Store, spv::Op::OpStore, QualType(), loc, range),
       pointer(pointerInst), object(objectInst), memoryAccess(mask) {}
 
+void SpirvStore::setAlignment(uint32_t alignment) {
+  assert(alignment != 0);
+  assert(llvm::isPowerOf2_32(alignment));
+  if (!memoryAccess.hasValue()) {
+    memoryAccess = spv::MemoryAccessMask::Aligned;
+  } else {
+    memoryAccess.getValue() =
+        memoryAccess.getValue() | spv::MemoryAccessMask::Aligned;
+  }
+  memoryAlignment = alignment;
+}
+
 SpirvUnaryOp::SpirvUnaryOp(spv::Op opcode, QualType resultType,
                            SourceLocation loc, SpirvInstruction *op,
                            SourceRange range)

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -1,17 +1,30 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T cs_6_0 -E main
 
 // CHECK: OpCapability PhysicalStorageBufferAddresses
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
 
 uint64_t Address;
-float4 main() : SV_Target0 {
-  // CHECK: OpTypePointer PhysicalStorageBuffer %uint
-  // CHECK: [[addr:%\d+]] = OpLoad %ulong {{%\d+}}
-  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint [[addr]]
-  // CHECK-NEXT: [[ac:%\d+]] = OpAccessChain %_ptr_PhysicalStorageBuffer_uint [[buf]]
-  // CHECK-NEXT: OpLoad %uint [[ac]] Aligned 4
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  // CHECK: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] %float Aligned 4
+  float x = 42.f;
+  vk::RawBufferStore<float>(Address, x);
 
-  uint32_t test = 42;
-  vk::RawBufferStore<uint32_t>(Address, test);
+  // CHECK: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] %double Aligned 8
+  double y = 42.0;
+  vk::RawBufferStore<double>(Address, y, 8);
+
+  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
+  // CHECK-NEXT: [[z:%\d+]] = OpINotEqual %bool [[load]] %uint_0
+  // CHECK-NEXT: OpStore [[buf]] %bool Aligned 4   OpStore %z [[z]]
+  bool z = true;
+  vk::RawBufferStore<bool>(Address, true);
+
+  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_v2float
+  // CHECK-NEXT: OpStore [[buf]] %v2float Aligned 8
+  float2 w = float2(42.f, 1337.f);
+  vk::RawBufferStore<float2>(Address, w, 8);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -4,27 +4,58 @@
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
 
+struct XYZW {
+  int x;
+  int y;
+  int z;
+  int w;
+};
+
 uint64_t Address;
 [numthreads(1, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {
-  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float
-  // CHECK-NEXT: OpStore [[buf]] %float_42 Aligned 4
-  float x = 42.f;
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[xval:%\d+]] = OpLoad %float %x
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] [[xval]] Aligned 4
+  float x = 78.f;
   vk::RawBufferStore<float>(Address, x);
 
-  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double
-  // CHECK-NEXT: OpStore [[buf]] %double_42 Aligned 8
-  double y = 42.0;
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[yval:%\d+]] = OpLoad %double %y
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] [[yval]] Aligned 8
+  double y = 65.0;
   vk::RawBufferStore<double>(Address, y, 8);
 
-  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
-  // CHECK-NEXT: OpStore [[buf]] %uint_1 Aligned 4
-  bool z = true;
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[zval:%\d+]] = OpINotEqual %bool
+  // CHECK-NEXT: OpStore
+  // CHECK-NEXT: [[tmp:%\d+]] = OpAccessChain
+  // CHECK-NEXT: [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[zval:%\d+]] = OpLoad %bool %z
+  // CHECK-NEXT: [[zsel:%\d+]] = OpSelect %uint [[zval]]
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
+  // CHECK-NEXT: OpStore [[buf]] [[zsel]] Aligned 4
+  // Note, using address here for bool z to prevent bool from being optimized away
+  bool z = Address;
   vk::RawBufferStore<bool>(Address, z);
 
-  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_v2float
-  // CHECK-NEXT: OpStore [[buf]] [[val]] Aligned 8
-  float2 w = float2(42.f, 1337.f);
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[wval:%\d+]] = OpLoad %v2float %w
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_v2float [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] [[wval]] Aligned 8
+  float2 w = float2(84.f, 69.f);
   vk::RawBufferStore<float2>(Address, w, 8);
 
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[xyzwval:%\d+]] = OpLoad %XYZW %xyzw
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_XYZW [[addr]]
+  // CHECK-NEXT: OpStore [[buf]] [[xyzwval]] Aligned 4
+  XYZW xyzw;
+  xyzw.x = 78;
+  xyzw.y = 65;
+  xyzw.z = 84;
+  xyzw.w = 69;
+  vk::RawBufferStore<XYZW>(Address, xyzw);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+// CHECK: OpCapability PhysicalStorageBufferAddresses
+// CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
+// CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
+
+uint64_t Address;
+float4 main() : SV_Target0 {
+  // CHECK: OpTypePointer PhysicalStorageBuffer %uint
+  // CHECK: [[addr:%\d+]] = OpLoad %ulong {{%\d+}}
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint [[addr]]
+  // CHECK-NEXT: [[ac:%\d+]] = OpAccessChain %_ptr_PhysicalStorageBuffer_uint [[buf]]
+  // CHECK-NEXT: OpLoad %uint [[ac]] Aligned 4
+  vk::RawBufferStore(Address, 42);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -11,5 +11,7 @@ float4 main() : SV_Target0 {
   // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint [[addr]]
   // CHECK-NEXT: [[ac:%\d+]] = OpAccessChain %_ptr_PhysicalStorageBuffer_uint [[buf]]
   // CHECK-NEXT: OpLoad %uint [[ac]] Aligned 4
-  vk::RawBufferStore(Address, 42);
+
+  uint32_t test = 42;
+  vk::RawBufferStore<uint32_t>(Address, test);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -9,23 +9,22 @@ uint64_t Address;
 void main(uint3 tid : SV_DispatchThreadID) {
   // CHECK:      [[addr:%\d+]] = OpLoad %ulong
   // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
-  // CHECK-NEXT: OpStore [[buf]] %float Aligned 4
+  // CHECK-NEXT: OpStore [[buf]] %float_42 Aligned 4
   float x = 42.f;
   vk::RawBufferStore<float>(Address, x);
 
-  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
-  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double [[addr]]
-  // CHECK-NEXT: OpStore [[buf]] %double Aligned 8
+  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double
+  // CHECK-NEXT: OpStore [[buf]] %double_42 Aligned 8
   double y = 42.0;
   vk::RawBufferStore<double>(Address, y, 8);
 
   // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
-  // CHECK-NEXT: OpStore [[buf]] %bool Aligned 4
+  // CHECK-NEXT: OpStore [[buf]] %uint_1 Aligned 4
   bool z = true;
   vk::RawBufferStore<bool>(Address, z);
 
   // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_v2float
-  // CHECK-NEXT: OpStore [[buf]] %v2float Aligned 8
+  // CHECK-NEXT: OpStore [[buf]] [[val]] Aligned 8
   float2 w = float2(42.f, 1337.f);
   vk::RawBufferStore<float2>(Address, w, 8);
 

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -7,8 +7,7 @@
 uint64_t Address;
 [numthreads(1, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {
-  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
-  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float
   // CHECK-NEXT: OpStore [[buf]] %float_42 Aligned 4
   float x = 42.f;
   vk::RawBufferStore<float>(Address, x);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -7,24 +7,26 @@
 uint64_t Address;
 [numthreads(1, 1, 1)]
 void main(uint3 tid : SV_DispatchThreadID) {
-  // CHECK: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
   // CHECK-NEXT: OpStore [[buf]] %float Aligned 4
   float x = 42.f;
   vk::RawBufferStore<float>(Address, x);
 
-  // CHECK: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double [[addr]]
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_double [[addr]]
   // CHECK-NEXT: OpStore [[buf]] %double Aligned 8
   double y = 42.0;
   vk::RawBufferStore<double>(Address, y, 8);
 
   // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
-  // CHECK-NEXT: [[z:%\d+]] = OpINotEqual %bool [[load]] %uint_0
-  // CHECK-NEXT: OpStore [[buf]] %bool Aligned 4   OpStore %z [[z]]
+  // CHECK-NEXT: OpStore [[buf]] %bool Aligned 4
   bool z = true;
-  vk::RawBufferStore<bool>(Address, true);
+  vk::RawBufferStore<bool>(Address, z);
 
   // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_v2float
   // CHECK-NEXT: OpStore [[buf]] %v2float Aligned 8
   float2 w = float2(42.f, 1337.f);
   vk::RawBufferStore<float2>(Address, w, 8);
+
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1381,6 +1381,9 @@ TEST_F(FileTest, IntrinsicsVkReadClock) {
 TEST_F(FileTest, IntrinsicsVkRawBufferLoad) {
   runFileTest("intrinsics.vkrawbufferload.hlsl");
 }
+TEST_F(FileTest, IntrinsicsVkRawBufferStore) {
+  runFileTest("intrinsics.vkrawbufferstore.hlsl");
+}
 // Intrinsics added in SM 6.6
 TEST_F(FileTest, IntrinsicsSM66PackU8S8) {
   runFileTest("intrinsics.sm6_6.pack_s8u8.hlsl");

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -382,6 +382,7 @@ namespace VkIntrinsics {
 u64 [[]] ReadClock(in uint scope);
 $funcT [[ro]] RawBufferLoad(in u64 addr);
 $funcT [[ro]] RawBufferLoad(in u64 addr, in uint alignment);
+void [[]] RawBufferStore(in u64 addr, in $funcT value);
 void [[]] ext_execution_mode(in uint mode, ...);
 void [[]] ext_execution_mode_id(in uint mode, ...);
 

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -383,6 +383,7 @@ u64 [[]] ReadClock(in uint scope);
 $funcT [[ro]] RawBufferLoad(in u64 addr);
 $funcT [[ro]] RawBufferLoad(in u64 addr, in uint alignment);
 void [[]] RawBufferStore(in u64 addr, in $funcT value);
+void [[]] RawBufferStore(in u64 addr, in $funcT value, in uint alignment);
 void [[]] ext_execution_mode(in uint mode, ...);
 void [[]] ext_execution_mode_id(in uint mode, ...);
 


### PR DESCRIPTION
Previously, dxc only supported vk::RawBufferLoad for vulkan physical device addressing. 

This pull request introduces vk::RawBufferStore, following in the footsteps of the vk::RawBufferLoad feature. 

Fixes #4568 