### PR TITLE
Support extension KHR_fragment_shading_barycentric

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -300,6 +300,7 @@ Supported extensions
 * SPV_GOOGLE_hlsl_functionality1
 * SPV_GOOGLE_user_type
 * SPV_NV_mesh_shader
+* SPV_KHR_fragment_shading_barycentric
 
 Vulkan specific attributes
 --------------------------
@@ -1541,7 +1542,9 @@ some system-value (SV) semantic strings will be translated into SPIR-V
 +---------------------------+-------------+----------------------------------------+-----------------------+-----------------------------+
 | SV_StencilRef             | PSOut       | ``FragStencilRefEXT``                  | N/A                   | ``StencilExportEXT``        |
 +---------------------------+-------------+----------------------------------------+-----------------------+-----------------------------+
-| SV_Barycentrics           | PSIn        | ``BaryCoord*AMD``                      | N/A                   | ``Shader``                  |
+| SV_Barycentrics           | PSIn        | ``BaryCoord*AMD`` or                   | N/A                   | ``FragmentBarycentricKHR``  |
+|                           |             | ``BaryCoord*KHR`` when                 |                       |                             |
+|                           |             |   turn on extension                    |                       |                             |
 +---------------------------+-------------+----------------------------------------+-----------------------+-----------------------------+
 |                           | GSOut       | ``Layer``                              | N/A                   | ``Geometry``                |
 |                           +-------------+----------------------------------------+-----------------------+-----------------------------+

--- a/tools/clang/include/clang/AST/ASTContext.h
+++ b/tools/clang/include/clang/AST/ASTContext.h
@@ -365,6 +365,8 @@ private:
 
   llvm::DenseMap<FieldDecl *, FieldDecl *> InstantiatedFromUnnamedFieldDecl;
 
+  llvm::SmallVector<SourceLocation, 8> GetAttribAtVertCallInputLoc; // HLSL change
+
   /// \brief Mapping that stores the methods overridden by a given C++
   /// member function.
   ///
@@ -909,6 +911,10 @@ public:
   // HLSL Change Starts
   /// \brief Retrieve the declaration for HLSL string type.
   TypedefDecl *getHLSLStringTypedef() const;
+  /// \brief Record usage of input in GetAttributeAtVertex for lately
+  /// modification to spv variable decl.
+  bool validateBaryCoordInputLoc(SourceLocation srcLoc);
+  void recordBaryCoordInputLoc(SourceLocation srcLoc);
   // HSLS CHange Ends
 
   //===--------------------------------------------------------------------===//

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -55,6 +55,7 @@ enum class Extension {
   EXT_shader_image_int64,
   KHR_physical_storage_buffer,
   KHR_vulkan_memory_model,
+  KHR_fragment_shader_barycentric,
   Unknown,
 };
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -687,6 +687,9 @@ public:
   void decoratePerTaskNV(SpirvInstruction *target, uint32_t offset,
                          SourceLocation);
 
+  /// \brief Decorates the given target with PerVertexKHR
+  void decoratePerVertexKHR(SpirvInstruction *target, SourceLocation);
+
   /// \brief Decorates the given target with Coherent
   void decorateCoherent(SpirvInstruction *target, SourceLocation);
 

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -4074,7 +4074,8 @@ public:
   void ActOnStartHLSLBufferView();
   bool IsOnHLSLBufferView();
   Decl *ActOnHLSLBufferView(Scope *bufferScope, SourceLocation KwLoc,
-                        DeclGroupPtrTy &dcl, bool iscbuf);
+                            DeclGroupPtrTy &dcl, bool iscbuf);
+  void ActOnBaryCentricsInputUsage(ExprResult LHS, Token firstParamTok);
   // HLSL Change Ends
 
   //===---------------------------- C++ Features --------------------------===//

--- a/tools/clang/lib/AST/ASTContext.cpp
+++ b/tools/clang/lib/AST/ASTContext.cpp
@@ -1208,6 +1208,28 @@ ASTContext::getInstantiatedFromUsingDecl(UsingDecl *UUD) {
   return Pos->second;
 }
 
+// HLSL change start
+bool
+ASTContext::validateBaryCoordInputLoc(SourceLocation srcLoc) {
+  for (int i = 0; i < GetAttribAtVertCallInputLoc.size(); i++) {
+    if (GetAttribAtVertCallInputLoc[i] == srcLoc) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void
+ASTContext::recordBaryCoordInputLoc(SourceLocation srcLoc) {
+  for (int i = 0; i < GetAttribAtVertCallInputLoc.size(); i++) {
+    if (GetAttribAtVertCallInputLoc[i] == srcLoc) {
+      return;
+    }
+  }
+  GetAttribAtVertCallInputLoc.push_back(srcLoc);
+}
+// HLSL change end
+
 void
 ASTContext::setInstantiatedFromUsingDecl(UsingDecl *Inst, NamedDecl *Pattern) {
   assert((isa<UsingDecl>(Pattern) ||

--- a/tools/clang/lib/Parse/ParseExpr.cpp
+++ b/tools/clang/lib/Parse/ParseExpr.cpp
@@ -1614,6 +1614,7 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
 
       ExprVector ArgExprs;
       CommaLocsTy CommaLocs;
+      Token firstParamTok = Tok;
       
       if (Tok.is(tok::code_completion)) {
         Actions.CodeCompleteCall(getCurScope(), LHS.get(), None);
@@ -1660,6 +1661,8 @@ Parser::ParsePostfixExpressionSuffix(ExprResult LHS) {
         LHS = Actions.ActOnCallExpr(getCurScope(), LHS.get(), Loc,
                                     ArgExprs, Tok.getLocation(),
                                     ExecConfig);
+        Actions.ActOnBaryCentricsInputUsage(LHS, firstParamTok);
+
         PT.consumeClose();
       }
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -358,6 +358,13 @@ bool CapabilityVisitor::visit(SpirvDecoration *decor) {
                    "SV_Barycentrics", loc);
       break;
     }
+    case spv::BuiltIn::BaryCoordKHR:
+    case spv::BuiltIn::BaryCoordNoPerspKHR: {
+      addExtension(Extension::KHR_fragment_shader_barycentric,
+                   "SV_Barycentrics", loc);
+      addCapability(spv::Capability::FragmentBarycentricKHR);
+      break;
+    }
     case spv::BuiltIn::ShadingRateKHR:
     case spv::BuiltIn::PrimitiveShadingRateKHR: {
       addExtension(Extension::KHR_fragment_shading_rate, "SV_ShadingRate", loc);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -489,6 +489,7 @@ public:
   /// \brief Decorates resource variables with Coherent decoration if they
   /// are declared as globallycoherent.
   bool decorateResourceCoherent();
+  bool decoratePerVertexKHR(const NamedDecl *ArgInst, int index);
 
   /// \brief Returns whether the SPIR-V module requires SPIR-V legalization
   /// passes run to make it legal.

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -166,6 +166,7 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_KHR_physical_storage_buffer",
             Extension::KHR_physical_storage_buffer)
       .Case("SPV_KHR_vulkan_memory_model", Extension::KHR_vulkan_memory_model)
+      .Case("SPV_KHR_fragment_shader_barycentric", Extension::KHR_fragment_shader_barycentric)
       .Default(Extension::Unknown);
 }
 
@@ -225,6 +226,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_KHR_physical_storage_buffer";
   case Extension::KHR_vulkan_memory_model:
     return "SPV_KHR_vulkan_memory_model";
+  case Extension::KHR_fragment_shader_barycentric:
+    return "SPV_KHR_fragment_shader_barycentric";
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -98,10 +98,10 @@ SpirvVariable *SpirvBuilder::addFnVar(QualType valueType, SourceLocation loc,
         context.getPointerType(valueType, spv::StorageClass::UniformConstant),
         loc, spv::StorageClass::Function, isPrecise, init);
   } else {
-    if (astContext->validateBaryCoordInputLoc(loc)) {
+    if (astContext.validateBaryCoordInputLoc(loc)) {
       if (!valueType->isArrayType())
       {
-        QualType qtype = astContext->getConstantArrayType(
+        QualType qtype = astContext.getConstantArrayType(
             valueType, llvm::APInt(32, 3), clang::ArrayType::Normal, 0);
         var = new (context) SpirvVariable(
               qtype, loc, spv::StorageClass::Function, isPrecise, init);
@@ -1265,10 +1265,10 @@ SpirvVariable *SpirvBuilder::addStageIOVar(QualType type,
                                            SourceLocation loc) {
   // Note: We store the underlying type in the variable, *not* the pointer type.
   SpirvVariable *var;
-  if (astContext->validateBaryCoordInputLoc(loc)) {
+  if (astContext.validateBaryCoordInputLoc(loc)) {
     if (!type->isArrayType())
     {
-      QualType qtype = astContext->getConstantArrayType(
+      QualType qtype = astContext.getConstantArrayType(
           type, llvm::APInt(32, 3), clang::ArrayType::Normal, 0);
     spv::StorageClass sc = spv::StorageClass::Input;
     var = new (context) SpirvVariable(qtype, loc, sc, isPrecise);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -98,8 +98,21 @@ SpirvVariable *SpirvBuilder::addFnVar(QualType valueType, SourceLocation loc,
         context.getPointerType(valueType, spv::StorageClass::UniformConstant),
         loc, spv::StorageClass::Function, isPrecise, init);
   } else {
-    var = new (context) SpirvVariable(
-        valueType, loc, spv::StorageClass::Function, isPrecise, init);
+    if (astContext->validateBaryCoordInputLoc(loc)) {
+      if (!valueType->isArrayType())
+      {
+        QualType qtype = astContext->getConstantArrayType(
+            valueType, llvm::APInt(32, 3), clang::ArrayType::Normal, 0);
+        var = new (context) SpirvVariable(
+              qtype, loc, spv::StorageClass::Function, isPrecise, init);
+      }
+      else
+        var = new (context) SpirvVariable(
+            valueType, loc, spv::StorageClass::Function, isPrecise, init);
+    }
+    else
+      var = new (context) SpirvVariable(
+          valueType, loc, spv::StorageClass::Function, isPrecise, init);
   }
   var->setDebugName(name);
   function->addVariable(var);
@@ -1251,7 +1264,20 @@ SpirvVariable *SpirvBuilder::addStageIOVar(QualType type,
                                            llvm::StringRef name, bool isPrecise,
                                            SourceLocation loc) {
   // Note: We store the underlying type in the variable, *not* the pointer type.
-  auto *var = new (context) SpirvVariable(type, loc, storageClass, isPrecise);
+  SpirvVariable *var;
+  if (astContext->validateBaryCoordInputLoc(loc)) {
+    if (!type->isArrayType())
+    {
+      QualType qtype = astContext->getConstantArrayType(
+          type, llvm::APInt(32, 3), clang::ArrayType::Normal, 0);
+    spv::StorageClass sc = spv::StorageClass::Input;
+    var = new (context) SpirvVariable(qtype, loc, sc, isPrecise);
+    }
+    else
+      var = new (context) SpirvVariable(type, loc, storageClass, isPrecise);
+  }
+  else
+    var = new (context) SpirvVariable(type, loc, storageClass, isPrecise);
   var->setDebugName(name);
   mod->addVariable(var);
   return var;
@@ -1481,6 +1507,13 @@ void SpirvBuilder::decoratePerTaskNV(SpirvInstruction *target, uint32_t offset,
   mod->addDecoration(decor);
   decor = new (context)
       SpirvDecoration(srcLoc, target, spv::Decoration::Offset, {offset});
+  mod->addDecoration(decor);
+}
+
+void SpirvBuilder::decoratePerVertexKHR(SpirvInstruction *target,
+                                          SourceLocation srcLoc) {
+  auto *decor = new (context)
+      SpirvDecoration(srcLoc, target, spv::Decoration::PerVertexKHR);
   mod->addDecoration(decor);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -607,6 +607,9 @@ private:
   /// Process mesh shader intrinsics.
   void processMeshOutputCounts(const CallExpr *callExpr);
 
+  /// Process GetAttributeAtVertex for barycentrics.
+  SpirvInstruction* processGetAttributeAtVertex(const CallExpr *expr);
+
   /// Process ray query traceinline intrinsics.
   SpirvInstruction *processTraceRayInline(const CXXMemberCallExpr *expr);
 

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1338,7 +1338,7 @@ TEST_F(FileTest, IntrinsicsMultiPrefix) {
   runFileTest("intrinsics.multiprefix.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, IntrinsicsGetAttributeAtVertex) {
-  runFileTest("intrinsics.get-attribute-at-vertex.hlsl", Expect::Failure);
+  runFileTest("intrinsics.get-attribute-at-vertex.hlsl");
 }
 TEST_F(FileTest, IntrinsicsDot4Add) {
   runFileTest("intrinsics.dot4add.hlsl", Expect::Failure);


### PR DESCRIPTION
Add SPV support in DXC to support extension SPV_KHR_fragment_shading_barycentric.

Including new built-ins and built-in function.

Ref:
https://github.com/microsoft/DirectXShaderCompiler/wiki/SV_Barycentrics