### PR TITLE
[SPIRV] Fix crash when returning void

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2275,7 +2275,8 @@ void SpirvEmitter::doIfStmt(const IfStmt *ifStmt,
 void SpirvEmitter::doReturnStmt(const ReturnStmt *stmt) {
   const auto *retVal = stmt->getRetValue();
   bool returnsVoid = curFunction->getReturnType().getTypePtr()->isVoidType();
-  if (!returnsVoid && retVal) {
+  if (!returnsVoid) {
+    assert(retVal);
     // Update counter variable associated with function returns
     tryToAssignCounterVar(curFunction, retVal);
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2273,7 +2273,9 @@ void SpirvEmitter::doIfStmt(const IfStmt *ifStmt,
 }
 
 void SpirvEmitter::doReturnStmt(const ReturnStmt *stmt) {
-  if (const auto *retVal = stmt->getRetValue()) {
+  const auto *retVal = stmt->getRetValue();
+  bool returnsVoid = curFunction->getReturnType().getTypePtr()->isVoidType();
+  if (!returnsVoid && retVal) {
     // Update counter variable associated with function returns
     tryToAssignCounterVar(curFunction, retVal);
 

--- a/tools/clang/test/CodeGenSPIRV/cf.return.void.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.return.void.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+void A() {
+}
+
+void main() {
+  // CHECK: OpReturn
+  return A();
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -582,6 +582,7 @@ TEST_F(FileTest, ReturnFromDifferentStorageClass) {
 TEST_F(FileTest, ReturnFromDifferentMemoryLayout) {
   runFileTest("cf.return.memory-layout.hlsl");
 }
+TEST_F(FileTest, VoidReturn) { runFileTest("cf.return.void.hlsl"); }
 
 // For control flows
 TEST_F(FileTest, ControlFlowNestedIfForStmt) { runFileTest("cf.if.for.hlsl"); }


### PR DESCRIPTION
This fixes a bug where invalid SPIR-V would be emitted when returning a void value from a void function. According to the spec, the `Value` of `OpReturnValue` must not have type `OpTypeVoid`; therefore, `OpReturn` will now be emitted instead.

Fixes #3596