### PR TITLE
Add vs2022 support to hctstart

### DIFF
--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -115,20 +115,18 @@ echo.
 goto :eof
 
 :findcmake 
-for %%v in (2022 2019 2017) do (
-  for %%e in (Community Professional Enterprise) do (
-    if "%%v"=="2022" (
-      if exist "%programfiles%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
-        set "PATH=%PATH%;%programfiles%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-        echo Path adjusted to include cmake from Visual Studio %%v %%e.
-        exit /b 0
-      )
-    ) else (
-      if exist "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
-        set "PATH=%PATH%;%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-        echo Path adjusted to include cmake from Visual Studio %%v %%e.
-        exit /b 0
-      )
+for %%e in (Community Professional Enterprise) do (
+  rem check 2022 in programfiles first
+  if exist "%programfiles%\Microsoft Visual Studio\2022\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
+    set "PATH=%PATH%;%programfiles%\Microsoft Visual Studio\2022\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+    echo Path adjusted to include cmake from Visual Studio 2022 %%e.
+    exit /b 0
+  )
+  for %%v in (2019 2017) do (
+    if exist "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
+      set "PATH=%PATH%;%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+      echo Path adjusted to include cmake from Visual Studio %%v %%e.
+      exit /b 0
     )
   )
 )

--- a/utils/hct/hctstart.cmd
+++ b/utils/hct/hctstart.cmd
@@ -115,12 +115,20 @@ echo.
 goto :eof
 
 :findcmake 
-for %%v in (2019 2017) do (
+for %%v in (2022 2019 2017) do (
   for %%e in (Community Professional Enterprise) do (
-    if exist "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
-      set "PATH=%PATH%;%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
-      echo Path adjusted to include cmake from Visual Studio %%v %%e.
-      exit /b 0
+    if "%%v"=="2022" (
+      if exist "%programfiles%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
+        set "PATH=%PATH%;%programfiles%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+        echo Path adjusted to include cmake from Visual Studio %%v %%e.
+        exit /b 0
+      )
+    ) else (
+      if exist "%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin" (
+        set "PATH=%PATH%;%programfiles(x86)%\Microsoft Visual Studio\%%v\%%e\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
+        echo Path adjusted to include cmake from Visual Studio %%v %%e.
+        exit /b 0
+      )
     )
   )
 )


### PR DESCRIPTION
vs2022 installs in a different location, so finding cmake requires a
slightly different path. Variable assignment in batch files is ugly.
Duplication of code slightly less ugly.

Mostly done by @tex3d