### PR TITLE
[SPIRV] Do not create counter for RWStructuredBuffer by default

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -213,6 +213,13 @@ bool isAppendStructuredBuffer(QualType type);
 /// \brief Returns true if the given type is a ConsumeStructuredBuffer type.
 bool isConsumeStructuredBuffer(QualType type);
 
+/// \brief Returns true if the given type is a RWStructuredBuffer type.
+bool isRWStructuredBuffer(QualType type);
+
+/// \brief Returns true if the given type is a Append/Consume
+/// StructuredBuffer type.
+bool isAppendConsumeSBuffer(QualType type);
+
 /// \brief Returns true if the given type is a RW/Append/Consume
 /// StructuredBuffer type.
 bool isRWAppendConsumeSBuffer(QualType type);

--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -216,10 +216,6 @@ bool isConsumeStructuredBuffer(QualType type);
 /// \brief Returns true if the given type is a RWStructuredBuffer type.
 bool isRWStructuredBuffer(QualType type);
 
-/// \brief Returns true if the given type is a Append/Consume
-/// StructuredBuffer type.
-bool isAppendConsumeSBuffer(QualType type);
-
 /// \brief Returns true if the given type is a RW/Append/Consume
 /// StructuredBuffer type.
 bool isRWAppendConsumeSBuffer(QualType type);

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -968,14 +968,6 @@ bool isRWStructuredBuffer(QualType type) {
   return false;
 }
 
-bool isAppendConsumeSBuffer(QualType type) {
-  if (const RecordType *recordType = type->getAs<RecordType>()) {
-    StringRef name = recordType->getDecl()->getName();
-    return name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer";
-  }
-  return false;
-}
-
 bool isRWAppendConsumeSBuffer(QualType type) {
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -960,6 +960,22 @@ bool isConsumeStructuredBuffer(QualType type) {
   return name == "ConsumeStructuredBuffer";
 }
 
+bool isRWStructuredBuffer(QualType type) {
+  if (const RecordType *recordType = type->getAs<RecordType>()) {
+    StringRef name = recordType->getDecl()->getName();
+    return name == "RWStructuredBuffer";
+  }
+  return false;
+}
+
+bool isAppendConsumeSBuffer(QualType type) {
+  if (const RecordType *recordType = type->getAs<RecordType>()) {
+    StringRef name = recordType->getDecl()->getName();
+    return name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer";
+  }
+  return false;
+}
+
 bool isRWAppendConsumeSBuffer(QualType type) {
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1037,7 +1037,8 @@ DeclResultIdMapper::createFileVar(const VarDecl *var,
 SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
   const auto type = var->getType();
   const bool isGroupShared = var->hasAttr<HLSLGroupSharedAttr>();
-  const bool isACRWSBuffer = isRWAppendConsumeSBuffer(type);
+  const bool isACSBuffer = isAppendConsumeSBuffer(type);
+  const bool isRWSBuffer = isRWStructuredBuffer(type);
   const auto storageClass = getStorageClassForExternVar(type, isGroupShared);
   const auto rule = getLayoutRuleForExternVar(type, spirvOptions);
   const auto loc = var->getLocation();
@@ -1134,10 +1135,12 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
     spvBuilder.decorateInputAttachmentIndex(varInstr,
                                             inputAttachment->getIndex(), loc);
 
-  if (isACRWSBuffer) {
-    // For {Append|Consume|RW}StructuredBuffer, we need to always create another
+  if (isACSBuffer) {
+    // For {Append|Consume}StructuredBuffer, we need to always create another
     // variable for its associated counter.
     createCounterVar(var, varInstr, /*isAlias=*/false);
+  } else if (isRWSBuffer) {
+    declInstrs[var] = varInstr;
   }
 
   return varInstr;
@@ -1589,8 +1592,17 @@ const CounterIdAliasPair *DeclResultIdMapper::getCounterIdAliasPair(
     if (counter != fieldCounterVars.end())
       return counter->second.get(*indices);
   } else {
-    // No indices. Check the stand-alone entities.
-    const auto counter = counterVars.find(decl);
+    // No indices. Check the stand-alone entities. If not found,
+	// likely a deferred RWStructuredBuffer counter, so try
+	// creating it now.
+    auto counter = counterVars.find(decl);
+    if (counter == counterVars.end()) {
+      auto declInstr = declInstrs[decl];
+      if (declInstr) {
+        createCounterVar(decl, declInstr, /*isAlias*/ false);
+        counter = counterVars.find(decl);
+	  }
+    }
     if (counter != counterVars.end())
       return &counter->second;
   }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -812,6 +812,11 @@ private:
   llvm::DenseMap<const DeclaratorDecl *, CounterIdAliasPair> counterVars;
   llvm::DenseMap<const DeclaratorDecl *, CounterVarFields> fieldCounterVars;
 
+  /// Mapping from clang declarator to SPIR-V declaration instruction.
+  /// This is used to defer creation of counter for RWStructuredBuffer
+  /// until a Increment/DecrementCounter method is called on it.
+  llvm::DenseMap<const DeclaratorDecl *, SpirvInstruction *> declInstrs;
+
   /// Mapping from cbuffer/tbuffer/ConstantBuffer/TextureBufer/push-constant
   /// to the SPIR-V type.
   llvm::DenseMap<const DeclContext *, const SpirvType *> ctBufferPCTypes;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -426,6 +426,12 @@ public:
       const DeclaratorDecl *decl,
       const llvm::SmallVector<uint32_t, 4> *indices = nullptr);
 
+  /// \brief Returns the associated counter's (instr-ptr, is-alias-or-not)
+  /// pair for the given {RW|Append|Consume}StructuredBuffer variable. Creates
+  /// counter for RW buffer if not already created.
+  const CounterIdAliasPair *createOrGetCounterIdAliasPair(
+      const DeclaratorDecl *decl);
+
   /// \brief Returns all the associated counters for the given decl. The decl is
   /// expected to be a struct containing alias RW/Append/Consume structured
   /// buffers. Returns nullptr if it does not.
@@ -815,7 +821,7 @@ private:
   /// Mapping from clang declarator to SPIR-V declaration instruction.
   /// This is used to defer creation of counter for RWStructuredBuffer
   /// until a Increment/DecrementCounter method is called on it.
-  llvm::DenseMap<const DeclaratorDecl *, SpirvInstruction *> declInstrs;
+  llvm::DenseMap<const DeclaratorDecl *, SpirvInstruction *> declRWSBuffers;
 
   /// Mapping from cbuffer/tbuffer/ConstantBuffer/TextureBufer/push-constant
   /// to the SPIR-V type.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4197,7 +4197,8 @@ bool SpirvEmitter::tryToAssignCounterVar(const DeclaratorDecl *dstDecl,
     declIdMapper.createFnParamCounterVar(thisObject);
 
   // Handle AssocCounter#1 (see CounterVarFields comment)
-  if (const auto *dstPair = declIdMapper.getCounterIdAliasPair(dstDecl)) {
+  if (const auto *dstPair =
+          declIdMapper.createOrGetCounterIdAliasPair(dstDecl)) {
     const auto *srcPair = getFinalACSBufferCounter(srcExpr);
     if (!srcPair) {
       emitFatalError("cannot find the associated counter variable",
@@ -4268,7 +4269,7 @@ const CounterIdAliasPair *
 SpirvEmitter::getFinalACSBufferCounter(const Expr *expr) {
   // AssocCounter#1: referencing some stand-alone variable
   if (const auto *decl = getReferencedDef(expr))
-    return declIdMapper.getCounterIdAliasPair(decl);
+    return declIdMapper.createOrGetCounterIdAliasPair(decl);
 
   // AssocCounter#2: referencing some non-struct field
   llvm::SmallVector<uint32_t, 4> rawIndices;

--- a/tools/clang/test/CodeGenSPIRV/method.rw-structured-buffer.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.rw-structured-buffer.counter.hlsl
@@ -13,7 +13,6 @@ struct S {
 // CHECK: %counter_var_wCounter2 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S> wCounter1;
 RWStructuredBuffer<S> wCounter2;
-// CHECK: %counter_var_woCounter = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S> woCounter;
 
 float4 main() : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/namespace.resources.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/namespace.resources.hlsl
@@ -2,16 +2,10 @@
 
 // CHECK: OpDecorate %rw1 DescriptorSet 0
 // CHECK: OpDecorate %rw1 Binding 0
-// CHECK: OpDecorate %counter_var_rw1 DescriptorSet 0
-// CHECK: OpDecorate %counter_var_rw1 Binding 1
 // CHECK: OpDecorate %rw2 DescriptorSet 0
-// CHECK: OpDecorate %rw2 Binding 2
-// CHECK: OpDecorate %counter_var_rw2 DescriptorSet 0
-// CHECK: OpDecorate %counter_var_rw2 Binding 3
+// CHECK: OpDecorate %rw2 Binding 1
 // CHECK: OpDecorate %rw3 DescriptorSet 0
-// CHECK: OpDecorate %rw3 Binding 4
-// CHECK: OpDecorate %counter_var_rw3 DescriptorSet 0
-// CHECK: OpDecorate %counter_var_rw3 Binding 5
+// CHECK: OpDecorate %rw3 Binding 2
 
 // CHECK: OpMemberDecorate %type_RWStructuredBuffer_v4float 0 Offset 0
 // CHECK: OpDecorate %type_RWStructuredBuffer_v4float BufferBlock

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.counter.nested-struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.counter.nested-struct.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T vs_6_0 -E main
 
-// CHECK: %counter_var_rw = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 // CHECK: %counter_var_t_1_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_rw = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 // CHECK: %counter_var_s_0 = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
   
 RWStructuredBuffer<uint> rw : register(u0); 

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.hlsl
@@ -26,7 +26,6 @@ RWStructuredBuffer<S1>      selectRWSBuffer(RWStructuredBuffer<S1>    paramRWSBu
 AppendStructuredBuffer<S2>  selectASBuffer(AppendStructuredBuffer<S2>  paramASBuffer,  bool selector);
 ConsumeStructuredBuffer<S3> selectCSBuffer(ConsumeStructuredBuffer<S3> paramCSBuffer,  bool selector);
 
-// CHECK: %counter_var_globalRWSBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S1>      globalRWSBuffer;
 // CHECK: %counter_var_globalASBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 AppendStructuredBuffer<S2>  globalASBuffer;
@@ -39,6 +38,7 @@ static RWStructuredBuffer<S1>      staticgRWSBuffer = globalRWSBuffer;
 // CHECK: %counter_var_staticgASBuffer = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
 static AppendStructuredBuffer<S2>  staticgASBuffer  = globalASBuffer;
 // CHECK: %counter_var_staticgCSBuffer = OpVariable %_ptr_Private__ptr_Uniform_type_ACSBuffer_counter Private
+// CHECK: %counter_var_globalRWSBuffer = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 static ConsumeStructuredBuffer<S3> staticgCSBuffer  = globalCSBuffer;
 
 // Counter variables for function returns, function parameters, and local variables have an extra level of pointer.

--- a/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.structured-buffer.hlsl
@@ -8,8 +8,8 @@
 // CHECK: OpName %type_RWStructuredBuffer_S "type.RWStructuredBuffer.S"
 // CHECK: OpName %type_RWStructuredBuffer_T "type.RWStructuredBuffer.T"
 
-// CHECK: OpDecorateId %mySBuffer3 CounterBuffer %counter_var_mySBuffer3
-// CHECK: OpDecorateId %mySBuffer4 CounterBuffer %counter_var_mySBuffer4
+// CHECK-NOT: OpDecorateId %mySBuffer3 CounterBuffer %counter_var_mySBuffer3
+// CHECK-NOT: OpDecorateId %mySBuffer4 CounterBuffer %counter_var_mySBuffer4
 
 // CHECK: %S = OpTypeStruct %float %v3float %mat2v3float
 // CHECK: %_runtimearr_S = OpTypeRuntimeArray %S
@@ -29,9 +29,6 @@ struct S {
 // CHECK: %type_RWStructuredBuffer_S = OpTypeStruct %_runtimearr_S
 // CHECK: %_ptr_Uniform_type_RWStructuredBuffer_S = OpTypePointer Uniform %type_RWStructuredBuffer_S
 
-// CHECK: %type_ACSBuffer_counter = OpTypeStruct %int
-// CHECK: %_ptr_Uniform_type_ACSBuffer_counter = OpTypePointer Uniform %type_ACSBuffer_counter
-
 // CHECK: %type_RWStructuredBuffer_T = OpTypeStruct %_runtimearr_T
 // CHECK: %_ptr_Uniform_type_RWStructuredBuffer_T = OpTypePointer Uniform %type_RWStructuredBuffer_T
 struct T {
@@ -47,10 +44,8 @@ StructuredBuffer<S> mySBuffer1 : register(t1);
 StructuredBuffer<T> mySBuffer2 : register(t2);
 
 // CHECK: %mySBuffer3 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_S Uniform
-// CHECK: %counter_var_mySBuffer3 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<S> mySBuffer3 : register(u3);
 // CHECK: %mySBuffer4 = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_T Uniform
-// CHECK: %counter_var_mySBuffer4 = OpVariable %_ptr_Uniform_type_ACSBuffer_counter Uniform
 RWStructuredBuffer<T> mySBuffer4 : register(u4);
 
 float4 main() : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/vk.1p2.remove.bufferblock.ptr-to-ptr.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.1p2.remove.bufferblock.ptr-to-ptr.hlsl
@@ -14,7 +14,6 @@
 
 // CHECK: OpDecorate %type_StructuredBuffer_float Block
 // CHECK: OpDecorate %type_RWStructuredBuffer_float Block
-// CHECK: OpDecorate %type_ACSBuffer_counter Block
 
 // CHECK: [[fn-type:%\d+]] = OpTypeFunction %_ptr_StorageBuffer_type_StructuredBuffer_float %_ptr_Function__ptr_StorageBuffer_type_StructuredBuffer_float
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.cl.register.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.cl.register.counter.hlsl
@@ -4,6 +4,7 @@ struct S { float4 val; };
 RWStructuredBuffer<S>  MyBuffer : register(u10, space2);
 
 float4 main() : SV_Target {
+  MyBuffer.IncrementCounter();
   return MyBuffer[0].val;
 }
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.counter.hlsl
@@ -7,8 +7,6 @@ struct S {
 // vk::binding + vk::counter_binding
 [[vk::binding(5, 3), vk::counter_binding(10)]]
 RWStructuredBuffer<S> mySBuffer1;
-// CHECK:      OpDecorate %counter_var_mySBuffer1 DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_mySBuffer1 Binding 10
 
 // :register(xX, spaceY) + vk::counter_binding
 [[vk::counter_binding(20)]]
@@ -19,8 +17,6 @@ AppendStructuredBuffer<S> myASBuffer1 : register(u1, space1);
 // :register(spaceY) + vk::counter_binding
 [[vk::counter_binding(15)]]
 RWStructuredBuffer<S> mySBuffer3 : register(space3);
-// CHECK:      OpDecorate %counter_var_mySBuffer3 DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_mySBuffer3 Binding 15
 
 // none + vk::counter_binding
 [[vk::counter_binding(2)]]
@@ -28,11 +24,12 @@ ConsumeStructuredBuffer<S> myCSBuffer1;
 // CHECK:      OpDecorate %counter_var_myCSBuffer1 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_myCSBuffer1 Binding 2
 
+// CHECK:      OpDecorate %counter_var_mySBuffer1 DescriptorSet 3
+// CHECK-NEXT: OpDecorate %counter_var_mySBuffer1 Binding 10
+
 // vk::binding + none
 [[vk::binding(1)]]
 RWStructuredBuffer<S> mySBuffer2;
-// CHECK:      OpDecorate %counter_var_mySBuffer2 DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 Binding 3
 
 // :register(xX, spaceY) + none
 AppendStructuredBuffer<S> myASBuffer2 : register(u3, space2);
@@ -47,7 +44,10 @@ ConsumeStructuredBuffer<S> myCSBuffer3 : register(space2);
 // none + none
 ConsumeStructuredBuffer<S> myCSBuffer2;
 // CHECK:      OpDecorate %counter_var_myCSBuffer2 DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_myCSBuffer2 Binding 5
+// CHECK-NEXT: OpDecorate %counter_var_myCSBuffer2 Binding 4
+
+// CHECK:      OpDecorate %counter_var_mySBuffer2 DescriptorSet 0
+// CHECK-NEXT: OpDecorate %counter_var_mySBuffer2 Binding 5
 
 float4 main() : SV_Target {
     uint a = mySBuffer1.IncrementCounter();

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.default-space.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.default-space.implicit.hlsl
@@ -43,20 +43,18 @@ ConstantBuffer<S> myCbuffer2;
   StructuredBuffer<S> sbuffer1;
 // CHECK:      OpDecorate %sbuffer2 DescriptorSet 77
 // CHECK-NEXT: OpDecorate %sbuffer2 Binding 9
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 DescriptorSet 77
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 10
 RWStructuredBuffer<S> sbuffer2;
 
 // CHECK:      OpDecorate %abuffer DescriptorSet 77
-// CHECK-NEXT: OpDecorate %abuffer Binding 11
+// CHECK-NEXT: OpDecorate %abuffer Binding 10
 // CHECK-NEXT: OpDecorate %counter_var_abuffer DescriptorSet 77
-// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 12
+// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 11
 AppendStructuredBuffer<S> abuffer;
 
 // CHECK:      OpDecorate %csbuffer DescriptorSet 77
-// CHECK-NEXT: OpDecorate %csbuffer Binding 13
+// CHECK-NEXT: OpDecorate %csbuffer Binding 12
 // CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 77
-// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 14
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 13
 ConsumeStructuredBuffer<S> csbuffer;
 
 float4 main() : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.explicit.hlsl
@@ -59,8 +59,6 @@ RWStructuredBuffer<S> sbuffer2 : register(u6);
 // CHECK-NEXT: OpDecorate %asbuffer Binding 1
 // CHECK-NEXT: OpDecorate %csbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %csbuffer Binding 21
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 DescriptorSet 3
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 0
 // CHECK-NEXT: OpDecorate %counter_var_asbuffer DescriptorSet 1
 // CHECK-NEXT: OpDecorate %counter_var_asbuffer Binding 0
 // CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 1

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.implicit.hlsl
@@ -43,20 +43,18 @@ ConstantBuffer<S> myCbuffer2;
   StructuredBuffer<S> sbuffer1;
 // CHECK:      OpDecorate %sbuffer2 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %sbuffer2 Binding 9
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 10
 RWStructuredBuffer<S> sbuffer2;
 
 // CHECK:      OpDecorate %abuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %abuffer Binding 11
+// CHECK-NEXT: OpDecorate %abuffer Binding 10
 // CHECK-NEXT: OpDecorate %counter_var_abuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 12
+// CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 11
 AppendStructuredBuffer<S> abuffer;
 
 // CHECK:      OpDecorate %csbuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %csbuffer Binding 13
+// CHECK-NEXT: OpDecorate %csbuffer Binding 12
 // CHECK-NEXT: OpDecorate %counter_var_csbuffer DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 14
+// CHECK-NEXT: OpDecorate %counter_var_csbuffer Binding 13
 ConsumeStructuredBuffer<S> csbuffer;
 
 float4 main() : SV_Target {

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.precedence.hlsl
@@ -34,19 +34,15 @@ cbuffer impBindVsReg2 : register(space1) {
 // CHECK-NEXT: OpDecorate %impBindVsReg2 Binding 9
 
 // explicit set vk::binding + explict counter > :register
-[[vk::binding(4,1), vk::counter_binding(5)]]
+[[vk::binding(4,1)]]
 RWStructuredBuffer<S> exBindVsRegExCt : register(u4, space9);
 // CHECK:      OpDecorate %exBindVsRegExCt DescriptorSet 1
 // CHECK-NEXT: OpDecorate %exBindVsRegExCt Binding 4
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegExCt DescriptorSet 1
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegExCt Binding 5
 
-[[vk::binding(6,1), vk::counter_binding(7)]]
+[[vk::binding(6,1)]]
 RWStructuredBuffer<S> exBindVsRegExCt2 : register(space9);
 // CHECK:      OpDecorate %exBindVsRegExCt2 DescriptorSet 1
 // CHECK-NEXT: OpDecorate %exBindVsRegExCt2 Binding 6
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegExCt2 DescriptorSet 1
-// CHECK-NEXT: OpDecorate %counter_var_exBindVsRegExCt2 Binding 7
 
 // implicit set vk::binding + explict counter > :register
 [[vk::binding(2), vk::counter_binding(5)]]
@@ -91,13 +87,6 @@ RWStructuredBuffer<S> impBindVsRegImpCt2 : register(u2, space4);
 
 // CHECK:      OpDecorate %counter_var_exBindVsRegImpCt2 DescriptorSet 3
 // CHECK-NEXT: OpDecorate %counter_var_exBindVsRegImpCt2 Binding 1
-
-// implicit set vk::binding > :register implicit counter (counter part)
-// CHECK:      OpDecorate %counter_var_impBindVsRegImpCt DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_impBindVsRegImpCt Binding 0
-
-// CHECK:      OpDecorate %counter_var_impBindVsRegImpCt2 DescriptorSet 0
-// CHECK-NEXT: OpDecorate %counter_var_impBindVsRegImpCt2 Binding 1
 
 float4 main() : SV_Target {
     return 1.0;

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.hlsl
@@ -71,9 +71,6 @@ ConsumeStructuredBuffer<S> csbuffer : register(u7);
 // CHECK:      OpDecorate %sampler4 DescriptorSet 0
 // CHECK-NEXT: OpDecorate %sampler4 Binding 2
 
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 DescriptorSet 1
-// CHECK-NEXT: OpDecorate %counter_var_sbuffer2 Binding 0
-
 // CHECK-NEXT: OpDecorate %counter_var_abuffer DescriptorSet 0
 // CHECK-NEXT: OpDecorate %counter_var_abuffer Binding 4
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.register.space-only.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.register.space-only.hlsl
@@ -61,7 +61,7 @@ RWStructuredBuffer<S> sbuffer2 : register(space3);
 AppendStructuredBuffer<S> abuffer : register(space2);
 
 // CHECK:      OpDecorate %csbuffer DescriptorSet 3
-// CHECK-NEXT: OpDecorate %csbuffer Binding 4
+// CHECK-NEXT: OpDecorate %csbuffer Binding 3
 ConsumeStructuredBuffer<S> csbuffer : register(space3);
 
 float4 main() : SV_Target {


### PR DESCRIPTION
Defer creating counter for RWSBuffer until Inc/DecrementCounter method
is invoked.

Fixes #4569