### PR TITLE
allow array sizes defined by min ops to not be treated as variable length

### DIFF
--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -9301,7 +9301,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::CXXConstCastExprClass:
   case Expr::ObjCBridgedCastExprClass: {
     const Expr *SubExpr = cast<CastExpr>(E)->getSubExpr();
-    if (isa<ExplicitCastExpr>(E) || isa<ImplicitCastExpr>(E)) {
+    if (isa<ExplicitCastExpr>(E)) {
       if (const FloatingLiteral *FL
             = dyn_cast<FloatingLiteral>(SubExpr->IgnoreParenImpCasts())) {
         unsigned DestWidth = Ctx.getIntWidth(E->getType());

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -9318,7 +9318,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
         return NoDiag();
       }
     }
-    const CastExpr *CE = (CastExpr*)(E);
+    const CastExpr *CE = (const CastExpr*)(E);
     switch (CE->getCastKind()) {
     case CK_LValueToRValue:
     case CK_AtomicToNonAtomic:

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -3811,6 +3811,23 @@ static bool HandleIntrinsicCall(SourceLocation CallLoc, unsigned opcode,
       return false;
     }
     return true;
+  case hlsl::IntrinsicOp::IOP_min:
+    assert(Args.size() == 2 && "else call should be invalid");
+    assert(ArgValues[0].getKind() == ArgValues[1].getKind() && "else call is invalid");
+    if (ArgValues[0].isInt()) {
+      Result = ArgValues[0].getInt() < ArgValues[1].getInt() ? ArgValues[0] : ArgValues[1];
+    }
+    else if (ArgValues[0].isFloat()) {
+      // TODO: handle NaNs properly
+      APFloat::cmpResult r = ArgValues[0].getFloat().compare(ArgValues[1].getFloat());
+      Result = (r == APFloat::cmpLessThan) ? ArgValues[0] : ArgValues[1];
+    }
+    else {
+      // TODO: consider a better error message here
+      Info.Diag(CallLoc, diag::note_invalid_subexpr_in_const_expr);
+      return false;
+    }
+    return true;
   default:
     Info.Diag(CallLoc, diag::note_invalid_subexpr_in_const_expr);
     return false;
@@ -9284,7 +9301,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
   case Expr::CXXConstCastExprClass:
   case Expr::ObjCBridgedCastExprClass: {
     const Expr *SubExpr = cast<CastExpr>(E)->getSubExpr();
-    if (isa<ExplicitCastExpr>(E)) {
+    if (isa<ExplicitCastExpr>(E) || isa<ImplicitCastExpr>(E)) {
       if (const FloatingLiteral *FL
             = dyn_cast<FloatingLiteral>(SubExpr->IgnoreParenImpCasts())) {
         unsigned DestWidth = Ctx.getIntWidth(E->getType());
@@ -9301,7 +9318,8 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
         return NoDiag();
       }
     }
-    switch (cast<CastExpr>(E)->getCastKind()) {
+    CastExpr *CE = (CastExpr*)(E);
+    switch (CE->getCastKind()) {
     case CK_LValueToRValue:
     case CK_AtomicToNonAtomic:
     case CK_NonAtomicToAtomic:

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -9318,7 +9318,7 @@ static ICEDiag CheckICE(const Expr* E, const ASTContext &Ctx) {
         return NoDiag();
       }
     }
-    CastExpr *CE = (CastExpr*)(E);
+    const CastExpr *CE = (CastExpr*)(E);
     switch (CE->getCastKind()) {
     case CK_LValueToRValue:
     case CK_AtomicToNonAtomic:

--- a/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
@@ -1,13 +1,13 @@
 // RUN: %dxc -E PSMain -T ps_6_0 %s | FileCheck %s
 
-// CHECK: define void @PSMain()
+// CHECK: %"$Globals" = type { [2 x <4 x float>], [3 x <4 x float>] }
 
 // fix me: float4 BrokenTestArray0[int(.3)*12]; 
-float4 BrokenTestArray1[min(2, 3)];
-float4 WorkingTestArray0[max(2, 3)];
+float4 WorkingTestArray0[min(2, 3)];
+float4 WorkingTestArray1[max(2, 3)];
 
 float4 PSMain(float4 color : COLOR) : SV_TARGET
 {
-    return BrokenTestArray1[int(color.y)] +
-           WorkingTestArray0[int(color.z)];
+    return WorkingTestArray0[int(color.y)] +
+           WorkingTestArray1[int(color.z)];
 }

--- a/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
@@ -1,15 +1,13 @@
 // RUN: %dxc -E PSMain -T ps_6_0 %s | FileCheck %s
 
-// CHECK: error: variable length arrays are not supported in HLSL
-// CHECK-NEXT: float4 BrokenTestArray0[int(.3)*12];
+// CHECK: define void @PSMain()
 
-float4 BrokenTestArray0[int(.3)*12];
+// fix me: float4 BrokenTestArray0[int(.3)*12]; 
 float4 BrokenTestArray1[min(2, 3)];
 float4 WorkingTestArray0[max(2, 3)];
 
 float4 PSMain(float4 color : COLOR) : SV_TARGET
 {
-    return BrokenTestArray0[int(color.x)] +
-           BrokenTestArray1[int(color.y)] +
+    return BrokenTestArray1[int(color.y)] +
            WorkingTestArray0[int(color.z)];
 }

--- a/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
@@ -1,6 +1,7 @@
-// RUN: %dxc -T ps_6_0 -E PSMain %s | FileCheck %s
+// RUN: %dxc -E PSMain -T ps_6_0 %s | FileCheck %s
 
-// CHECK: ; Input signature:
+// CHECK: error: variable length arrays are not supported in HLSL
+// CHECK-NEXT: float4 BrokenTestArray0[int(.3)*12];
 
 float4 BrokenTestArray0[int(.3)*12];
 float4 BrokenTestArray1[min(2, 3)];

--- a/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/NonVLAArrays.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_0 -E PSMain %s | FileCheck %s
+
+// CHECK: ; Input signature:
+
+float4 BrokenTestArray0[int(.3)*12];
+float4 BrokenTestArray1[min(2, 3)];
+float4 WorkingTestArray0[max(2, 3)];
+
+float4 PSMain(float4 color : COLOR) : SV_TARGET
+{
+    return BrokenTestArray0[int(color.x)] +
+           BrokenTestArray1[int(color.y)] +
+           WorkingTestArray0[int(color.z)];
+}


### PR DESCRIPTION
added an extra case to use the comparison function for "min" when handling intrinsics that define the size of an array.
This PR should partially address #3355