### PR TITLE
Fix Layer & ViewportIndex ext in 1.2+ 

### DIFF
--- a/lib/Support/MemoryBuffer.cpp
+++ b/lib/Support/MemoryBuffer.cpp
@@ -86,6 +86,11 @@ public:
     init(InputData.begin(), InputData.end(), RequiresNullTerminator);
   }
 
+  // Disable sized deallocation for MemoryByfferMem, because it has
+  // tail-allocated data.
+  // (See llvm commit 21c303e9eadfbd2d685665176159f5f4738169b1)
+  void operator delete(void *p) { ::operator delete(p); }
+
   const char *getBufferIdentifier() const override {
      // The name is stored after the class itself.
     return reinterpret_cast<const char*>(this + 1);
@@ -211,6 +216,11 @@ public:
       init(Start, Start + Len, RequiresNullTerminator);
     }
   }
+
+  // Disable sized deallocation for MemoryByfferMem, because it has
+  // tail-allocated data.
+  // (See llvm commit 21c303e9eadfbd2d685665176159f5f4738169b1)
+  void operator delete(void *p) { ::operator delete(p); }
 
   const char *getBufferIdentifier() const override {
     // The name is stored after the class itself.

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -20,6 +20,7 @@
 #include "dxc/Support/SPIRVOptions.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/SourceLocation.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -123,6 +124,19 @@ public:
   /// Returns true if the target environment is Vulkan 1.3 or above.
   /// Returns false otherwise.
   bool isTargetEnvVulkan1p3OrAbove();
+
+  /// Returns the spv_target_env matching the input string if possible.
+  /// This functions matches the spv_target_env with the command-line version
+  /// of the name ('vulkan1.1', not 'Vulkan 1.1').
+  /// Returns an empty Optional if no matching env is found.
+  static llvm::Optional<spv_target_env>
+  stringToSpvEnvironment(const std::string &target_env);
+
+  /// Returns the equivalent to spv_target_env in pretty, human readable form.
+  /// (SPV_ENV_VULKAN_1_0 -> "Vulkan 1.0").
+  /// Returns an empty Optional if the name cannot be matched.
+  static llvm::Optional<std::string>
+  spvEnvironmentToPrettyName(spv_target_env target_env);
 
 private:
   /// Returns whether codegen should allow usage of this extension by default.

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -314,9 +314,14 @@ bool CapabilityVisitor::visit(SpirvDecoration *decor) {
       if (shaderModel == spv::ExecutionModel::Vertex ||
           shaderModel == spv::ExecutionModel::TessellationControl ||
           shaderModel == spv::ExecutionModel::TessellationEvaluation) {
-        addExtension(Extension::EXT_shader_viewport_index_layer,
-                     "SV_RenderTargetArrayIndex", loc);
-        addCapability(spv::Capability::ShaderViewportIndexLayerEXT);
+
+        if (featureManager.isTargetEnvVulkan1p2OrAbove()) {
+          addCapability(spv::Capability::ShaderLayer);
+        } else {
+          addExtension(Extension::EXT_shader_viewport_index_layer,
+                       "SV_RenderTargetArrayIndex", loc);
+          addCapability(spv::Capability::ShaderViewportIndexLayerEXT);
+        }
       } else if (shaderModel == spv::ExecutionModel::Fragment ||
                  shaderModel == spv::ExecutionModel::MeshNV) {
         // SV_RenderTargetArrayIndex can be used as PSIn or MSPOut.
@@ -328,9 +333,13 @@ bool CapabilityVisitor::visit(SpirvDecoration *decor) {
       if (shaderModel == spv::ExecutionModel::Vertex ||
           shaderModel == spv::ExecutionModel::TessellationControl ||
           shaderModel == spv::ExecutionModel::TessellationEvaluation) {
-        addExtension(Extension::EXT_shader_viewport_index_layer,
-                     "SV_ViewPortArrayIndex", loc);
-        addCapability(spv::Capability::ShaderViewportIndexLayerEXT);
+        if (featureManager.isTargetEnvVulkan1p2OrAbove()) {
+          addCapability(spv::Capability::ShaderViewportIndex);
+        } else {
+          addExtension(Extension::EXT_shader_viewport_index_layer,
+                       "SV_ViewPortArrayIndex", loc);
+          addCapability(spv::Capability::ShaderViewportIndexLayerEXT);
+        }
       } else if (shaderModel == spv::ExecutionModel::Fragment ||
                  shaderModel == spv::ExecutionModel::Geometry ||
                  shaderModel == spv::ExecutionModel::MeshNV) {

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -8,27 +8,56 @@
 
 #include "clang/SPIRV/FeatureManager.h"
 
+#include <array>
 #include <sstream>
 
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringSwitch.h"
 
 namespace clang {
 namespace spirv {
 namespace {
 
-const char *spvEnvironmentAsString(spv_target_env spvEnv) {
-  if (spvEnv > SPV_ENV_VULKAN_1_2)
-    return "Vulkan 1.3";
-  if (spvEnv == SPV_ENV_VULKAN_1_1_SPIRV_1_4)
-    return "Vulkan 1.1 with SPIR-V 1.4";
-  if (spvEnv > SPV_ENV_VULKAN_1_1)
-    return "Vulkan 1.2";
-  if (spvEnv > SPV_ENV_VULKAN_1_0)
-    return "Vulkan 1.1";
-  return "Vulkan 1.0";
-}
+constexpr std::array<std::pair<const char*, spv_target_env>, 6> kKnownTargetEnv = {{
+    {"vulkan1.0", SPV_ENV_VULKAN_1_0},
+    {"vulkan1.1", SPV_ENV_VULKAN_1_1},
+    {"vulkan1.1spirv1.4", SPV_ENV_VULKAN_1_1_SPIRV_1_4},
+    {"vulkan1.2", SPV_ENV_VULKAN_1_2},
+    {"vulkan1.3", SPV_ENV_VULKAN_1_3},
+    {"universal1.5", SPV_ENV_UNIVERSAL_1_5}}};
+
+constexpr std::array<std::pair<spv_target_env, const char*>, 6> kHumanReadableTargetEnv = {{
+    {SPV_ENV_VULKAN_1_0, "Vulkan 1.0"},
+    {SPV_ENV_VULKAN_1_1, "Vulkan 1.1"},
+    {SPV_ENV_VULKAN_1_1_SPIRV_1_4, "Vulkan 1.1 with SPIR-V 1.4"},
+    {SPV_ENV_VULKAN_1_2, "Vulkan 1.2"},
+    {SPV_ENV_VULKAN_1_3, "Vulkan 1.3"},
+    {SPV_ENV_UNIVERSAL_1_5, "SPIR-V 1.5"}}};
+
+static_assert(kKnownTargetEnv.size() == kHumanReadableTargetEnv.size(),
+    "kKnownTargetEnv and kHumanReadableTargetEnv should remain in sync.");
 
 } // end namespace
+
+llvm::Optional<spv_target_env>
+FeatureManager::stringToSpvEnvironment(const std::string &target_env) {
+  auto it =
+      std::find_if(kKnownTargetEnv.cbegin(), kKnownTargetEnv.cend(),
+                   [&](const auto &pair) { return pair.first == target_env; });
+
+  return it == kKnownTargetEnv.end()
+             ? llvm::None
+             : llvm::Optional<spv_target_env>(it->second);
+}
+
+llvm::Optional<std::string>
+FeatureManager::spvEnvironmentToPrettyName(spv_target_env target_env) {
+  auto it =
+      std::find_if(kHumanReadableTargetEnv.cbegin(), kHumanReadableTargetEnv.cend(),
+                   [&](const auto &pair) { return pair.first == target_env; });
+  return it == kHumanReadableTargetEnv.end() ? llvm::None
+                                     : llvm::Optional<std::string>(it->second);
+}
 
 FeatureManager::FeatureManager(DiagnosticsEngine &de,
                                const SpirvCodeGenOptions &opts)
@@ -46,24 +75,15 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
 
   targetEnvStr = opts.targetEnv;
 
-  if (opts.targetEnv == "vulkan1.0")
-    targetEnv = SPV_ENV_VULKAN_1_0;
-  else if (opts.targetEnv == "vulkan1.1")
-    targetEnv = SPV_ENV_VULKAN_1_1;
-  else if (opts.targetEnv == "vulkan1.1spirv1.4")
-    targetEnv = SPV_ENV_VULKAN_1_1_SPIRV_1_4;
-  else if (opts.targetEnv == "vulkan1.2")
-    targetEnv = SPV_ENV_VULKAN_1_2;
-  else if (opts.targetEnv == "vulkan1.3")
-    targetEnv = SPV_ENV_VULKAN_1_3;
-  else if(opts.targetEnv == "universal1.5")
-    targetEnv = SPV_ENV_UNIVERSAL_1_5;
-  else {
+  llvm::Optional<spv_target_env> targetEnvOpt =
+      stringToSpvEnvironment(opts.targetEnv);
+  if (!targetEnvOpt) {
     emitError("unknown SPIR-V target environment '%0'", {}) << opts.targetEnv;
     emitNote("allowed options are:\n vulkan1.0\n vulkan1.1\n "
              "vulkan1.1spirv1.4\n vulkan1.2\n vulkan1.3\n universal1.5",
              {});
   }
+  targetEnv = *targetEnvOpt;
 }
 
 bool FeatureManager::allowExtension(llvm::StringRef name) {
@@ -115,8 +135,9 @@ bool FeatureManager::requestTargetEnv(spv_target_env requestedEnv,
                                       llvm::StringRef target,
                                       SourceLocation srcLoc) {
   if (targetEnv < requestedEnv) {
+    auto envName = spvEnvironmentToPrettyName(requestedEnv);
     emitError("%0 is required for %1 but not permitted to use", srcLoc)
-        << spvEnvironmentAsString(requestedEnv) << target;
+        << envName.getValueOr("unknown") << target;
     emitNote("please specify your target environment via command line option "
              "-fspv-target-env=",
              {});

--- a/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index-core.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.render-target-array-index-core.vs.hlsl
@@ -1,7 +1,7 @@
-// RUN: %dxc -T vs_6_0 -E main
+// RUN: %dxc -E main -T vs_6_0 -spirv -fspv-target-env=vulkan1.2
 
-// CHECK:      OpCapability ShaderViewportIndexLayerEXT
-// CHECK:      OpExtension "SPV_EXT_shader_viewport_index_layer"
+// CHECK:      OpCapability ShaderLayer
+// CHECK-NOT:  OpExtension "SPV_EXT_shader_viewport_index_layer"
 
 // CHECK:      OpEntryPoint Vertex %main "main"
 // CHECK-SAME: %in_var_SV_RenderTargetArrayIndex

--- a/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index-core.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index-core.vs.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -E main -T vs_6_0 -spirv -fspv-target-env=vulkan1.2
+
+// CHECK:      OpCapability ShaderViewportIndex
+// CHECK-NOT:  OpExtension "SPV_EXT_shader_viewport_index_layer"
+
+// CHECK:      OpEntryPoint Vertex %main "main"
+// CHECK-SAME: %in_var_SV_ViewportArrayIndex
+// CHECK-SAME: %gl_ViewportIndex
+
+// CHECK:      OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
+// CHECK:      OpDecorate %in_var_SV_ViewportArrayIndex Location 0
+
+// CHECK:      %in_var_SV_ViewportArrayIndex = OpVariable %_ptr_Input_uint Input
+// CHECK:      %gl_ViewportIndex = OpVariable %_ptr_Output_uint Output
+
+uint main(uint input: SV_ViewportArrayIndex) : SV_ViewportArrayIndex {
+    return input;
+}

--- a/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.intrinsicInstruction.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T vs_6_0 -E main
+// RUN: %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: OpCapability ShaderClockKHR
 // CHECK: {{%\d+}} = OpExtInstImport "GLSL.std.450"

--- a/tools/clang/tools/dxclib/CMakeLists.txt
+++ b/tools/clang/tools/dxclib/CMakeLists.txt
@@ -22,6 +22,7 @@ add_clang_library(dxclib
 
 if(ENABLE_SPIRV_CODEGEN)
   target_link_libraries(dxclib PRIVATE SPIRV-Tools)
+  target_link_libraries(dxclib PRIVATE clangSPIRV)
 endif()
 
 if (WIN32)
@@ -30,5 +31,5 @@ endif (WIN32)
 
 target_compile_definitions(dxclib
     PRIVATE VERSION_STRING_SUFFIX=" for ${CMAKE_SYSTEM_NAME}")
-    
+
 add_dependencies(dxclib TablegenHLSLOptions dxcompiler)

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -863,6 +863,9 @@ TEST_F(FileTest, SemanticRenderTargetArrayIndexGS) {
 TEST_F(FileTest, SemanticRenderTargetArrayIndexPS) {
   runFileTest("semantic.render-target-array-index.ps.hlsl");
 }
+TEST_F(FileTest, SemanticRenderTargetArrayIndexCoreVS) {
+  runFileTest("semantic.render-target-array-index-core.vs.hlsl");
+}
 TEST_F(FileTest, SemanticViewportArrayIndexVS) {
   runFileTest("semantic.viewport-array-index.vs.hlsl");
 }
@@ -877,6 +880,9 @@ TEST_F(FileTest, SemanticViewportArrayIndexGS) {
 }
 TEST_F(FileTest, SemanticViewportArrayIndexPS) {
   runFileTest("semantic.viewport-array-index.ps.hlsl");
+}
+TEST_F(FileTest, SemanticViewportArrayIndexCoreVS) {
+  runFileTest("semantic.viewport-array-index-core.vs.hlsl");
 }
 TEST_F(FileTest, SemanticBarycentricsSmoothPS) {
   runFileTest("semantic.barycentrics.ps.s.hlsl");

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -110,8 +110,9 @@ void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
     ASSERT_TRUE(compileOk);
 
     // Disassemble the generated SPIR-V binary.
-    ASSERT_TRUE(utils::disassembleSpirvBinary(
-        generatedBinary, &generatedSpirvAsm, true /* generateHeader */));
+    ASSERT_TRUE(
+        utils::disassembleSpirvBinary(generatedBinary, &generatedSpirvAsm,
+                                      true /* generateHeader */, targetEnv));
 
     auto options = effcee::Options()
                        .SetChecksName(filename.str())

--- a/tools/clang/unittests/SPIRV/FileTestUtils.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.cpp
@@ -22,9 +22,9 @@ namespace spirv {
 namespace utils {
 
 bool disassembleSpirvBinary(std::vector<uint32_t> &binary,
-                            std::string *generatedSpirvAsm,
-                            bool generateHeader) {
-  spvtools::SpirvTools spirvTools(SPV_ENV_VULKAN_1_1);
+                            std::string *generatedSpirvAsm, bool generateHeader,
+                            spv_target_env target_env) {
+  spvtools::SpirvTools spirvTools(target_env);
   spirvTools.SetMessageConsumer(
       [](spv_message_level_t, const char *, const spv_position_t &,
          const char *message) { fprintf(stdout, "%s\n", message); });

--- a/tools/clang/unittests/SPIRV/FileTestUtils.h
+++ b/tools/clang/unittests/SPIRV/FileTestUtils.h
@@ -28,7 +28,8 @@ namespace utils {
 /// Returns true on success, and false on failure.
 bool disassembleSpirvBinary(std::vector<uint32_t> &binary,
                             std::string *generatedSpirvAsm,
-                            bool generateHeader = false);
+                            bool generateHeader = false,
+                            spv_target_env = SPV_ENV_VULKAN_1_1);
 
 /// \brief Runs the SPIR-V Tools validation on the given SPIR-V binary.
 /// Returns true if validation is successful; false otherwise.

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.cpp
@@ -102,7 +102,7 @@ void WholeFileTest::runWholeFileTest(llvm::StringRef filename,
 
   // Disassemble the generated SPIR-V binary.
   ASSERT_TRUE(utils::disassembleSpirvBinary(generatedBinary, &generatedSpirvAsm,
-                                            generateHeader));
+                                            generateHeader, targetEnv));
 
   // Compare the expected and the generted SPIR-V code.
   EXPECT_EQ(expectedSpirvAsm, generatedSpirvAsm);


### PR DESCRIPTION
Back in Vulkan1.1, ShaderViewportIndexLayer was required to use SV_RenderTargetArrayIndex. This was promoted in VK1.2:
https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_shader_viewport_index_layer.html
Sadly, DXC didn't checked the target SPV environment, and always requested the extension. This commit addresses this.

Additionally, when DXC finishes generating SPIR-V, the binary is disassembled and printed to stdout.
The target env was hardcoded to Vulkan1.1, meaning disassembly would fail if we tried disassembling Vulkan1.2+ SPIR-V.