### PR TITLE
Add diagnostic tests

### DIFF
--- a/lib/HLSL/DxilCondenseResources.cpp
+++ b/lib/HLSL/DxilCondenseResources.cpp
@@ -659,11 +659,6 @@ public:
     // we encountered an unexpted value type
     UnexpectedValuesFromStorePointer,
 
-    // When remapping values to be replaced, we add them to RemappedValues
-    // so we don't use dead values stored in other sets/maps.  Circular
-    // remaps that should not happen are aadded to RemappingCyclesDetected.
-    RemappingCyclesDetected,
-
     // Without SUPPORT_SELECT_ON_ALLOCA, phi/select on alloca based
     // pointer is disallowed, since this scenario is still untested.
     // This error also covers any other unknown alloca pointer uses.
@@ -690,7 +685,6 @@ public:
     "static global resource use is disallowed for library functions.",
     "exported library functions cannot have resource parameters or return value.",
     "internal error: unexpected instruction type when looking for alloca from store.",
-    "internal error: cycles detected in value remapping.",
     "phi/select disallowed on pointers to local resources.",
     "mismatch handle annotation",
     "possible mixing dynamic resource and binding resource",
@@ -906,8 +900,11 @@ public:
     while (it != RemappedValues.end()) {
       // Cycles should not happen, but are bad if they do.
       if (visited.count(it->second)) {
+        // When remapping values to be replaced, we add them to RemappedValues
+        // so we don't use dead values stored in other sets/maps. Circular
+        // remaps that should not happen
         DXASSERT(false, "otherwise, circular remapping");
-        m_Errors.ReportError(ResourceUseErrors::RemappingCyclesDetected, V);
+        llvm_unreachable("cycles detected in value remapping");
         break;
       }
       V = it->second;

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -210,7 +210,7 @@ public:
     if (!SM->IsLib()) {
       Function *EntryFn = m_pHLModule->GetEntryFunction();
       if (!m_pHLModule->HasDxilFunctionProps(EntryFn)) {
-        llvm_unreachable("Entry function doesn't have property.");
+        llvm_unreachable("Entry function doesn't have any properties.");
         return false;
       }
       DxilFunctionProps &props = m_pHLModule->GetDxilFunctionProps(EntryFn);

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -210,7 +210,7 @@ public:
     if (!SM->IsLib()) {
       Function *EntryFn = m_pHLModule->GetEntryFunction();
       if (!m_pHLModule->HasDxilFunctionProps(EntryFn)) {
-        dxilutil::EmitErrorOnFunction(M.getContext(), EntryFn, "Entry function don't have property.");
+        llvm_unreachable("Entry function doesn't have property.");
         return false;
       }
       DxilFunctionProps &props = m_pHLModule->GetDxilFunctionProps(EntryFn);
@@ -264,7 +264,7 @@ public:
           if (F.user_empty()) {
             F.eraseFromParent();
           } else {
-            dxilutil::EmitErrorOnFunction(M.getContext(), &F, "Fail to lower createHandle.");
+            llvm_unreachable("Fail to lower createHandle.");
           }
         }
       }

--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -124,7 +124,10 @@ bool DxilPromoteLocalResources::PromoteLocalResource(Function &F) {
     // No update.
     // Report error and break.
     if (allocaSize == Allocas.size()) {
-      llvm_unreachable(
+      //  TODO: Add test for this instance of the error: "local resource not
+      //  guaranteed to map to unique global resource." No test currently exists.
+      dxilutil::EmitErrorOnContext(
+          F.getContext(),
           "local resource not guaranteed to map to unique global resource.");
       break;
     }
@@ -220,7 +223,11 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
       Insts.clear();
     }
     if (!bUpdated) {
-      llvm_unreachable(
+      //  TODO: Add test for this instance of the error: "local resource not
+      //  guaranteed to map to unique global resource." No test currently
+      //  exists.
+      dxilutil::EmitErrorOnContext(
+          M.getContext(),
           "local resource not guaranteed to map to unique global resource.");
       break;
     }

--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -124,7 +124,8 @@ bool DxilPromoteLocalResources::PromoteLocalResource(Function &F) {
     // No update.
     // Report error and break.
     if (allocaSize == Allocas.size()) {
-      F.getContext().emitError(dxilutil::kResourceMapErrorMsg);
+      llvm_unreachable(
+          "local resource not guaranteed to map to unique global resource.");
       break;
     }
     allocaSize = Allocas.size();
@@ -219,7 +220,8 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
       Insts.clear();
     }
     if (!bUpdated) {
-      M.getContext().emitError(dxilutil::kResourceMapErrorMsg);
+      llvm_unreachable(
+          "local resource not guaranteed to map to unique global resource.");
       break;
     }
     bModified = true;

--- a/lib/HLSL/DxilPromoteResourcePasses.cpp
+++ b/lib/HLSL/DxilPromoteResourcePasses.cpp
@@ -128,7 +128,7 @@ bool DxilPromoteLocalResources::PromoteLocalResource(Function &F) {
       //  guaranteed to map to unique global resource." No test currently exists.
       dxilutil::EmitErrorOnContext(
           F.getContext(),
-          "local resource not guaranteed to map to unique global resource.");
+          dxilutil::kResourceMapErrorMsg);
       break;
     }
     allocaSize = Allocas.size();
@@ -228,7 +228,7 @@ bool DxilPromoteStaticResources::PromoteStaticGlobalResources(
       //  exists.
       dxilutil::EmitErrorOnContext(
           M.getContext(),
-          "local resource not guaranteed to map to unique global resource.");
+          dxilutil::kResourceMapErrorMsg);
       break;
     }
     bModified = true;

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -209,7 +209,8 @@ private:
         return HandleMetaMap[Handle];
       }
     }
-    Handle->getContext().emitError("cannot map resource to handle");
+    dxilutil::EmitErrorOnContext(Handle->getContext(),
+                                 "cannot map resource to handle.");
 
     return HandleMetaMap[Handle];
   }
@@ -636,7 +637,7 @@ Value *TranslateD3DColorToUByte4(CallInst *CI, IntrinsicOp IOP,
       std::vector<int> mask { 2, 1, 0, 3 };
       val = Builder.CreateShuffleVector(val, val, mask);
     } else {
-      dxilutil::EmitErrorOnInstruction(CI, "Unsupported input type for intrinsic D3DColorToUByte4.");
+      llvm_unreachable("Unsupported input type for intrinsic D3DColorToUByte4.");
       return UndefValue::get(CI->getType());
     }
   }
@@ -2387,7 +2388,7 @@ Value *TranslatePrintf(CallInst *CI, IntrinsicOp IOP, DXIL::OpCode opcode,
                        HLObjectOperationLowerHelper *pObjHelper,
                        bool &Translated) {
   Translated = false;
-  CI->getContext().emitError(CI, "use of undeclared identifier 'printf'");
+  dxilutil::EmitErrorOnInstruction(CI, "use of undeclared identifier 'printf'");
   return nullptr;
 }
 

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -2388,7 +2388,7 @@ Value *TranslatePrintf(CallInst *CI, IntrinsicOp IOP, DXIL::OpCode opcode,
                        HLObjectOperationLowerHelper *pObjHelper,
                        bool &Translated) {
   Translated = false;
-  dxilutil::EmitErrorOnInstruction(CI, "use of undeclared identifier 'printf'");
+  dxilutil::EmitErrorOnInstruction(CI, "use of unsupported identifier 'printf'");
   return nullptr;
 }
 

--- a/lib/HLSL/HLSignatureLower.cpp
+++ b/lib/HLSL/HLSignatureLower.cpp
@@ -61,7 +61,7 @@ unsigned UpdateSemanticAndInterpMode(StringRef &semName,
     case InterpolationMode::Kind::Constant:
     case InterpolationMode::Kind::Undefined:
     case InterpolationMode::Kind::Invalid: {
-      Context.emitError("invalid interpolation mode for SV_Position");
+      llvm_unreachable("invalid interpolation mode for SV_Position");
     } break;
     case InterpolationMode::Kind::LinearNoperspective:
     case InterpolationMode::Kind::LinearNoperspectiveCentroid:
@@ -470,8 +470,7 @@ void HLSignatureLower::CreateDxilSignatures() {
   if (props.shaderKind == DXIL::ShaderKind::Hull) {
     Function *patchConstantFunc = props.ShaderProps.HS.patchConstantFunc;
     if (patchConstantFunc == nullptr) {
-      dxilutil::EmitErrorOnFunction(HLM.GetModule()->getContext(), Entry,
-          "Patch constant function is not specified.");
+      llvm_unreachable("Patch constant function is not specified.");
     }
 
     DxilFunctionAnnotation *patchFuncAnnotation =
@@ -499,15 +498,13 @@ void HLSignatureLower::AllocateDxilInputOutputs() {
 
   hlsl::PackDxilSignature(EntrySig.InputSignature, packing);
   if (!EntrySig.InputSignature.IsFullyAllocated()) {
-    dxilutil::EmitErrorOnFunction(HLM.GetModule()->getContext(), Entry,
-        "Failed to allocate all input signature elements in available space.");
+    llvm_unreachable("Failed to allocate all input signature elements in available space.");
   }
 
   if (props.shaderKind != DXIL::ShaderKind::Amplification) {
     hlsl::PackDxilSignature(EntrySig.OutputSignature, packing);
     if (!EntrySig.OutputSignature.IsFullyAllocated()) {
-      dxilutil::EmitErrorOnFunction(HLM.GetModule()->getContext(), Entry,
-          "Failed to allocate all output signature elements in available space.");
+      llvm_unreachable("Failed to allocate all output signature elements in available space.");
     }
   }
 
@@ -516,8 +513,7 @@ void HLSignatureLower::AllocateDxilInputOutputs() {
       props.shaderKind == DXIL::ShaderKind::Mesh) {
     hlsl::PackDxilSignature(EntrySig.PatchConstOrPrimSignature, packing);
     if (!EntrySig.PatchConstOrPrimSignature.IsFullyAllocated()) {
-      dxilutil::EmitErrorOnFunction(HLM.GetModule()->getContext(), Entry,
-                             "Failed to allocate all patch constant signature "
+      llvm_unreachable("Failed to allocate all patch constant signature "
                              "elements in available space.");
     }
   }

--- a/tools/clang/test/CodeGenHLSL/printf.hlsl
+++ b/tools/clang/test/CodeGenHLSL/printf.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
 
-// CHECK: use of undeclared identifier 'printf'
+// CHECK: use of unsupported identifier 'printf'
 
 float4 main(float4 p: Position) : SV_Position {
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/swizzle/swizzleAtomic2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/swizzle/swizzleAtomic2.hlsl
@@ -7,6 +7,9 @@
 RWBuffer<uint4> bufA;
 RWTexture1D<uint4> texA;
 
+ // CHECK: error: Invalid operation on typed buffer.
+// CHECK: error: Invalid operation on typed buffer.
+
 [numthreads(8,8,1)]
 void main( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/unbound_overlap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/unbound_overlap.hlsl
@@ -2,10 +2,15 @@
 
 
 // CHECK: error: more than one unbounded resource (Tex1 and Tex2) in space 0
+// CHECK: error: more than one unbounded resource (Tex3 and Tex4) in space 1
 
 
-Texture2D<float4> Tex1[] : register(t5);  // unbounded
-Texture2D<float4> Tex2[] : register(t6);  // unbounded
+Texture2D<float4> Tex1[] : register(t3);  // unbounded, overlap in space0
+Texture2D<float4> Tex2[] : register(t4);  // unbounded, overlap in space0
+Texture2D<float4> Tex3[] : register(t5, space1);  // unbounded, overlap in space1
+Texture2D<float4> Tex4[] : register(t6, space1);  // unbounded, overlap in space1
+Texture2D<float4> Tex5[] : register(t7, space2);  // unbounded, no overlap
+Texture2D<float4> Tex6[] : register(t8, space3);  // unbounded, no overlap
 
 SamplerState Samp : register(s0);
 
@@ -15,5 +20,9 @@ float4 main(int4 a : A, float4 coord : TEXCOORD) : SV_TARGET
   return (float4)1.0
   * Tex1[0].Sample(Samp, coord.xy)
   * Tex2[0].Sample(Samp, coord.xy)
+  * Tex3[0].Sample(Samp, coord.xy)
+  * Tex4[0].Sample(Samp, coord.xy)
+  * Tex5[0].Sample(Samp, coord.xy)
+  * Tex6[0].Sample(Samp, coord.xy)
   ;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/unbound_overlap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/unbound_overlap.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -E main -T ps_6_0 %s  | FileCheck -input-file=stderr %s
+
+
+// CHECK: error: more than one unbounded resource (Tex1 and Tex2) in space 0
+
+
+Texture2D<float4> Tex1[] : register(t5);  // unbounded
+Texture2D<float4> Tex2[] : register(t6);  // unbounded
+
+SamplerState Samp : register(s0);
+
+
+float4 main(int4 a : A, float4 coord : TEXCOORD) : SV_TARGET
+{
+  return (float4)1.0
+  * Tex1[0].Sample(Samp, coord.xy)
+  * Tex2[0].Sample(Samp, coord.xy)
+  ;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_1.hlsl
@@ -1,8 +1,12 @@
-// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck -check-prefix=OUT %s
 
-// CHECK: SV_Position              0   xyzw        0      POS   float
-// CHECK: SV_Target                1   xyzw        1   TARGET   float   xyzw
-// CHECK: SV_Depth                 0    N/A   oDepth    DEPTH   float    YES
+// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck -input-file=stderr -check-prefix=ERROR %s
+
+// OUT: SV_Position              0   xyzw        0      POS   float
+// OUT: SV_Target                1   xyzw        1   TARGET   float   xyzw
+// OUT: SV_Depth                 0    N/A   oDepth    DEPTH   float    YES
+
+// ERROR: warning: DX9-style semantic "VPOS" mapped to DX10 system semantic "SV_Position" due to -Gec flag. This functionality is deprecated in newer language versions.
 
 struct PSIn
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/legacy/obsolete_semantics_ps_2.hlsl
@@ -1,9 +1,13 @@
-// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck -check-prefix=OUT %s
 
-// CHECK: COLOR                    0   xyzw        0     NONE   float
-// CHECK: TEXCOORD                 0   xy          1     NONE   float
-// CHECK: SV_Position              0   xyzw        2      POS   float
-// CHECK: SV_Target                1   xyzw        1   TARGET   float   xyzw
+// RUN: %dxc -E main -T ps_6_0 %s -Gec | FileCheck -input-file=stderr -check-prefix=ERROR %s
+
+// OUT: COLOR                    0   xyzw        0     NONE   float
+// OUT: TEXCOORD                 0   xy          1     NONE   float
+// OUT: SV_Position              0   xyzw        2      POS   float
+// OUT: SV_Target                1   xyzw        1   TARGET   float   xyzw
+
+//ERROR: warning: DX9-style semantic "CoLoR" mapped to DX10 system semantic "SV_Target" due to -Gec flag. This functionality is deprecated in newer language versions.
 
 struct VOut
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_clipdistance/clip_planes_output_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_clipdistance/clip_planes_output_error.hlsl
@@ -1,0 +1,46 @@
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+
+// CHECK: error: Cannot use clipplanes attribute without specifying a 4-component SV_Position output
+
+struct C0 {
+
+       float4 clipPlane2;
+       float4 clipPlane3;
+};
+
+struct C {
+       float4 clipPlane1;
+       C0 c0;
+};
+
+cbuffer ClipPlaneConstantBuffer 
+{
+    C c;
+    
+       float4 clipPlane4;
+};
+
+struct VS_INPUT
+{
+	float3 vPosition	: POSITION;
+	float3 vNormal		: NORMAL;
+ 	float2 vTexcoord	: TEXCOORD0;
+};
+
+struct VS_OUTPUT
+{
+	float3 vNormal		: NORMAL;
+	float2 vTexcoord	: TEXCOORD0;
+};
+
+[clipplanes(c.clipPlane1, c.c0.clipPlane2, clipPlane4)]
+VS_OUTPUT main(VS_INPUT Input)
+{
+
+	VS_OUTPUT Output;
+	
+	Output.vNormal = Input.vNormal;
+	Output.vTexcoord = Input.vTexcoord;
+ 
+       return Output;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_global_lib_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_global_lib_error.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T lib_6_3 %s | FileCheck -input-file=stderr %s
+
+// CHECK:error: static global resource use is disallowed for library functions. Value: global_texture
+// CHECK:error: static global resource use is disallowed for library functions. Value: global_ss
+
+SamplerState ss;
+Texture2D<float4> t;
+
+static SamplerState global_ss = ss;
+static Texture2D<float4> global_texture = t;
+
+export float4 test() {
+  return global_texture.Sample(global_ss, 0.);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_global_lib_error.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/static/static_global_lib_error.hlsl
@@ -1,7 +1,10 @@
 // RUN: %dxc -T lib_6_3 %s | FileCheck -input-file=stderr %s
+// RUN: %dxc -T lib_6_3 -exports test %s | FileCheck -input-file=stderr %s -check-prefix=EXPORT
 
 // CHECK:error: static global resource use is disallowed for library functions. Value: global_texture
 // CHECK:error: static global resource use is disallowed for library functions. Value: global_ss
+
+// EXPORT:error: non const static global resource use is disallowed in library exports.
 
 SamplerState ss;
 Texture2D<float4> t;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/mesh_invalid_interpolation_modes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/mesh_invalid_interpolation_modes.hlsl
@@ -1,0 +1,71 @@
+// RUN: %dxc -E main -T ms_6_5 %s | FileCheck %s
+
+#define MAX_VERT 32
+#define MAX_PRIM 16
+#define NUM_THREADS 32
+struct MeshPerVertex {
+    float4 position : SV_Position;
+    float4 color : COLOR;
+};
+
+struct MeshPerPrimitive {
+// CHECK: error: Mesh shader's primitive outputs' interpolation mode must be constant or undefined.
+  linear float normal : NORMAL;
+// CHECK: error: Mesh shader's primitive outputs' interpolation mode must be constant or undefined.
+  centroid float malnor : MALNOR;
+// CHECK: error: Mesh shader's primitive outputs' interpolation mode must be constant or undefined.
+    sample float alnorm : ALNORM;
+    float ormaln : ORMALN;
+    int layer[6] : LAYER;
+    bool cullPrimitive : SV_CullPrimitive;
+};
+
+struct MeshPayload {
+    float normal;
+    float malnor;
+    float alnorm;
+    float ormaln;
+    int layer[6];
+};
+
+groupshared float gsMem[MAX_PRIM];
+
+[numthreads(NUM_THREADS, 1, 1)]
+[outputtopology("triangle")]
+void main(
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in payload MeshPayload mpl,
+            in uint tig : SV_GroupIndex,
+            in uint vid : SV_ViewID
+         )
+{
+    SetMeshOutputCounts(MAX_VERT, MAX_PRIM);
+    MeshPerVertex ov;
+    if (vid % 2) {
+        ov.position = float4(4.0,5.0,6.0,7.0);
+        ov.color = float4(4.0, 5.0, 6.0, 7.0);
+    } else {
+        ov.position = float4(14.0,15.0,16.0,17.0);
+        ov.color = float4(14.0, 15.0, 16.0, 17.0);
+    }
+    if (tig % 3) {
+      primIndices[tig / 3] = uint3(tig, tig + 1, tig + 2);
+      MeshPerPrimitive op;
+      op.normal = mpl.normal;
+      op.malnor = gsMem[tig / 3 + 1];
+      op.alnorm = mpl.alnorm;
+      op.ormaln = mpl.ormaln;
+      op.layer[0] = mpl.layer[0];
+      op.layer[1] = mpl.layer[1];
+      op.layer[2] = mpl.layer[2];
+      op.layer[3] = mpl.layer[3];
+      op.layer[4] = mpl.layer[4];
+      op.layer[5] = mpl.layer[5];
+      op.cullPrimitive = false;
+      gsMem[tig / 3] = op.normal;
+      prims[tig / 3] = op;
+    }
+    verts[tig] = ov;
+}


### PR DESCRIPTION
This change cleans up the diagnostics emitted in the /lib/HLSL and /lib/DXIL. This started as an exploration of moving post codegen and pre validation diagnostics earlier in compilation. Most of the functional change here is to add testing for untested errors and change unreachable errors to internal compiler errors. For each diagnostic: 

1. Changed to the updated dxilutil error emitting functions
2. Added a test if untested
3. Changed to an internal compiler error if unreachable 