### PR TITLE
Fix unroller crash in library targets

### DIFF
--- a/lib/Transforms/Scalar/DxilLoopUnroll.cpp
+++ b/lib/Transforms/Scalar/DxilLoopUnroll.cpp
@@ -108,7 +108,6 @@ public:
   static char ID;
 
   std::set<Loop *> LoopsThatFailed;
-  std::unordered_set<Function *> CleanedUpAlloca;
   unsigned MaxIterationAttempt = 0;
   bool OnlyWarnOnFail = false;
   bool StructurizeLoopExits = false;
@@ -1212,7 +1211,11 @@ bool DxilLoopUnroll::doFinalization() {
           Twine(Msg) + Twine(" Use '-HV 2016' to treat this as warning."));
       }
     }
+
+    // This pass instance can be reused. Clear this so it doesn't blow up on the subsequent runs.
+    LoopsThatFailed.clear();
   }
+
   return false;
 }
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pass_reuse_regression.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pass_reuse_regression.hlsl
@@ -1,4 +1,9 @@
-// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Od -E main -T lib_6_x %s | FileCheck %s
+
+// Regression test for when there are multiple functions with loops that can't
+// be unrolled at the point of doing [unroll], the unroll pass crashes because
+// it didn't clean up memory between runs.
+
 // CHECK: pass_reuse_regression.hlsl:{{[0-9]+}}:{{[0-9]+}}: error: Could not unroll loop
 // CHECK: pass_reuse_regression.hlsl:{{[0-9]+}}:{{[0-9]+}}: error: Could not unroll loop
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pass_reuse_regression.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/pass_reuse_regression.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// CHECK: pass_reuse_regression.hlsl:{{[0-9]+}}:{{[0-9]+}}: error: Could not unroll loop
+// CHECK: pass_reuse_regression.hlsl:{{[0-9]+}}:{{[0-9]+}}: error: Could not unroll loop
+
+AppendStructuredBuffer<float4> buf0;
+uint g_cond;
+
+struct Params {
+  int foo;
+};
+
+float f(Params p) {
+  [unroll]
+  for (uint j = 0; j < p.foo; j++) {
+    buf0.Append(1);
+  }
+  return 0;
+}
+
+float g(Params p) {
+  [unroll]
+  for (uint j = 0; j < p.foo; j++) {
+    buf0.Append(1);
+  }
+  return 0;
+}
+
+float main() : SV_Target {
+  Params p;
+  p.foo = g_cond;
+  return f(p) + g(p);
+}
+


### PR DESCRIPTION
Fixed when there are multiple functions with loops that can't be unrolled at
the point of doing [unroll], the unroll pass crashes because it didn't clean up
memory between runs.