### PR TITLE
Accept all ROV types as resources

### DIFF
--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -530,7 +530,9 @@ bool IsHLSLResourceType(clang::QualType type) {
     if (name == "FeedbackTexture2D" || name == "FeedbackTexture2DArray")
       return true;
 
-    if (name == "RasterizerOrderedTexture2D")
+    if (name == "RasterizerOrderedTexture1D" || name == "RasterizerOrderedTexture2D" || name == "RasterizerOrderedTexture3D" ||
+        name == "RasterizerOrderedTexture1DArray" || name == "RasterizerOrderedTexture2DArray" ||
+        name == "RasterizerOrderedBuffer" || name == "RasterizerOrderedByteAddressBuffer" || name == "RasterizerOrderedStructuredBuffer")
       return true;
 
     if (name == "ByteAddressBuffer" || name == "RWByteAddressBuffer")

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/RasterizerOrderedBuffer/rovtype.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/RasterizerOrderedBuffer/rovtype.hlsl
@@ -7,7 +7,7 @@
 // RUN: %dxc -DResType=RasterizerOrderedStructuredBuffer<uint> -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
 
 // BABs can't be indexed so they require special casing
-// RUN: %dxc -DBAB -DResType=RasterizerOrderedByteAddressBuffer -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
+// RUN: %dxc -DBAB -DResType=RasterizerOrderedByteAddressBuffer -DPosType=uint -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
 
 // Verify that the ROV texture type is correctly identified
 // such that a struct member of that type can be assigned
@@ -26,7 +26,6 @@ const static struct {
 
 const static ROVThings thing2 = {GlobalResource[1]};
 
-#ifndef BAB
 void main(in PosType pos : P, out float4 Out : SV_Target0)
 {
         // CHECK: %[[t3:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 2
@@ -46,6 +45,7 @@ void main(in PosType pos : P, out float4 Out : SV_Target0)
 
 	Out = 0.0;
 
+#ifndef BAB
         // CHECK: %[[t1:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0
         // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t1]]
         // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t1]]
@@ -83,32 +83,15 @@ void main(in PosType pos : P, out float4 Out : SV_Target0)
         // CHECK: add i32
         // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t6]]
 	thing6.Resource[pos] += 1;
-}
 #else
-// ByteAddressBuffers are too weird to play with the others
-
-void main(in uint pos : P, out float4 Out : SV_Target0)
-{
+        // ByteAddressBuffers are too weird to play with the others
         // Note that all the CHECKS this needs are included
         // in the corresponding locations of the BUFCHK variant above
-        const struct {
-          ResType Resource;
-        } thing3 = {GlobalResource[2]};
-        struct {
-          ResType Resource;
-        } thing4 = {GlobalResource[3]};
-
-        ROVThings thing5 = {GlobalResource[4]};
-        const ROVThings thing6 = {GlobalResource[5]};
-
-
-	Out = 0.0;
-
 	thing1.Resource.Store(pos, thing1.Resource.Load(pos) + 1);
 	thing2.Resource.Store(pos, thing2.Resource.Load(pos) + 1);
 	thing3.Resource.Store(pos, thing3.Resource.Load(pos) + 1);
 	thing4.Resource.Store(pos, thing4.Resource.Load(pos) + 1);
 	thing5.Resource.Store(pos, thing5.Resource.Load(pos) + 1);
 	thing6.Resource.Store(pos, thing6.Resource.Load(pos) + 1);
-}
 #endif
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/RasterizerOrderedBuffer/rovtype.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/RasterizerOrderedBuffer/rovtype.hlsl
@@ -1,66 +1,114 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -DResType=RasterizerOrderedTexture1D<uint> -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=TXTCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedTexture2D<uint> -DPosType=uint2 -T ps_6_0 %s | FileCheck %s -check-prefixes=TXTCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedTexture3D<uint> -DPosType=uint3 -T ps_6_0 %s | FileCheck %s -check-prefixes=TXTCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedTexture1DArray<uint> -DPosType=uint2 -T ps_6_0 %s | FileCheck %s -check-prefixes=TXTCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedTexture2DArray<uint> -DPosType=uint3 -T ps_6_0 %s | FileCheck %s -check-prefixes=TXTCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedBuffer<uint> -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
+// RUN: %dxc -DResType=RasterizerOrderedStructuredBuffer<uint> -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
+
+// BABs can't be indexed so they require special casing
+// RUN: %dxc -DBAB -DResType=RasterizerOrderedByteAddressBuffer -DPosType=uint1 -T ps_6_0 %s | FileCheck %s -check-prefixes=BUFCHK,CHECK
 
 // Verify that the ROV texture type is correctly identified
 // such that a struct member of that type can be assigned
 
-RasterizerOrderedTexture2D<uint> GlobalTexture[6] : register(u0);
+ResType GlobalResource[6] : register(u0);
 
 // Use a few different storage and declaration ways
 
 struct ROVThings {
-  RasterizerOrderedTexture2D<uint> Texture;
+  ResType Resource;
 };
 
-
 const static struct {
-  RasterizerOrderedTexture2D<uint> Texture;
-} thing1 = {GlobalTexture[0]};
+  ResType Resource;
+} thing1 = {GlobalResource[0]};
 
-const static ROVThings thing2 = {GlobalTexture[1]};
+const static ROVThings thing2 = {GlobalResource[1]};
 
-void main(in float4 SvPosition : SV_Position, out float4 Out : SV_Target0)
+#ifndef BAB
+void main(in PosType pos : P, out float4 Out : SV_Target0)
 {
         // CHECK: %[[t3:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 2
         const struct {
-          RasterizerOrderedTexture2D<uint> Texture;
-        } thing3 = {GlobalTexture[2]};
+          ResType Resource;
+        } thing3 = {GlobalResource[2]};
         // CHECK: %[[t4:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 3
         struct {
-          RasterizerOrderedTexture2D<uint> Texture;
-        } thing4 = {GlobalTexture[3]};
+          ResType Resource;
+        } thing4 = {GlobalResource[3]};
 
         // CHECK: %[[t5:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 4
-        ROVThings thing5 = {GlobalTexture[4]};
+        ROVThings thing5 = {GlobalResource[4]};
         // CHECK: %[[t6:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 5
-        const ROVThings thing6 = {GlobalTexture[5]};
+        const ROVThings thing6 = {GlobalResource[5]};
 
 
 	Out = 0.0;
 
         // CHECK: %[[t1:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t1]]
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t1]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t1]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t1]]
-	thing1.Texture[uint2(SvPosition.xy)] += 1;
+        // TXTCHK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t1]]
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t1]]
+	thing1.Resource[pos] += 1;
         // CHECK: %[[t2:[0-9a-zA-Z_]*]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 1
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t2]]
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t2]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t2]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t2]]
-	thing2.Texture[uint2(SvPosition.xy)] += 1;
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t3]]
+        // TXTCHK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t2]]
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t2]]
+	thing2.Resource[pos] += 1;
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t3]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t3]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t3]]
-	thing3.Texture[uint2(SvPosition.xy)] += 1;
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t4]]
+        // TXTCHK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t3]]
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t3]]
+	thing3.Resource[pos] += 1;
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t4]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t4]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t4]]
-	thing4.Texture[uint2(SvPosition.xy)] += 1;
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t5]]
+        // TXTCHK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t4]]
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t4]]
+	thing4.Resource[pos] += 1;
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t5]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t5]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t5]]
-	thing5.Texture[uint2(SvPosition.xy)] += 1;
-        // CHECK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t6]]
+        // TXTCHK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t5]]
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t5]]
+	thing5.Resource[pos] += 1;
+        // TXTCHK: call %dx.types.ResRet.i32 @dx.op.textureLoad.i32(i32 66, %dx.types.Handle %[[t6]]
+        // BUFCHK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[t6]]
         // CHECK: add i32
-        // CHECK: call void @dx.op.textureStore.i32(i32 67, %dx.types.Handle %[[t6]]
-	thing6.Texture[uint2(SvPosition.xy)] += 1;
+        // BUFCHK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %[[t6]]
+	thing6.Resource[pos] += 1;
 }
+#else
+// ByteAddressBuffers are too weird to play with the others
+
+void main(in uint pos : P, out float4 Out : SV_Target0)
+{
+        // Note that all the CHECKS this needs are included
+        // in the corresponding locations of the BUFCHK variant above
+        const struct {
+          ResType Resource;
+        } thing3 = {GlobalResource[2]};
+        struct {
+          ResType Resource;
+        } thing4 = {GlobalResource[3]};
+
+        ROVThings thing5 = {GlobalResource[4]};
+        const ROVThings thing6 = {GlobalResource[5]};
+
+
+	Out = 0.0;
+
+	thing1.Resource.Store(pos, thing1.Resource.Load(pos) + 1);
+	thing2.Resource.Store(pos, thing2.Resource.Load(pos) + 1);
+	thing3.Resource.Store(pos, thing3.Resource.Load(pos) + 1);
+	thing4.Resource.Store(pos, thing4.Resource.Load(pos) + 1);
+	thing5.Resource.Store(pos, thing5.Resource.Load(pos) + 1);
+	thing6.Resource.Store(pos, thing6.Resource.Load(pos) + 1);
+}
+#endif


### PR DESCRIPTION
Includes all the Raster Order Views types in the check for UAVs and add
a test that exercises all of them, verifying they can be assigned
properly.

Followon to fix #4581 for bug #4578