### PR TITLE
Initialize all DxilModule members

### DIFF
--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -344,8 +344,8 @@ private:
   llvm::Module *m_pModule = nullptr;
   llvm::Function *m_pEntryFunc = nullptr;
   std::string m_EntryName = "";
-  std::unique_ptr<DxilMDHelper> m_pMDHelper = nullptr;
-  std::unique_ptr<llvm::DebugInfoFinder> m_pDebugInfoFinder = nullptr;
+  std::unique_ptr<DxilMDHelper> m_pMDHelper;
+  std::unique_ptr<llvm::DebugInfoFinder> m_pDebugInfoFinder;
   const ShaderModel *m_pSM = nullptr;
   unsigned m_DxilMajor = DXIL::kDxilMajor;
   unsigned m_DxilMinor = DXIL::kDxilMinor;
@@ -381,7 +381,7 @@ private:
   uint32_t m_IntermediateFlags = 0;
   uint32_t m_AutoBindingSpace = UINT_MAX;
 
-  std::unique_ptr<DxilSubobjects> m_pSubobjects = nullptr;
+  std::unique_ptr<DxilSubobjects> m_pSubobjects;
 
   // m_bMetadataErrors is true if non-fatal metadata errors were encountered.
   // Validator will fail in this case, but should not block module load.

--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -333,30 +333,28 @@ private:
   std::vector<std::unique_ptr<DxilSampler> > m_Samplers;
 
   // Geometry shader.
-  DXIL::PrimitiveTopology m_StreamPrimitiveTopology;
-  unsigned m_ActiveStreamMask;
+  DXIL::PrimitiveTopology m_StreamPrimitiveTopology = DXIL::PrimitiveTopology::Undefined;
+  unsigned m_ActiveStreamMask = 0;
 
-private:
   enum IntermediateFlags : uint32_t {
     LegacyResourceReservation = 1 << 0,
   };
 
-private:
   llvm::LLVMContext &m_Ctx;
-  llvm::Module *m_pModule;
-  llvm::Function *m_pEntryFunc;
-  std::string m_EntryName;
-  std::unique_ptr<DxilMDHelper> m_pMDHelper;
-  std::unique_ptr<llvm::DebugInfoFinder> m_pDebugInfoFinder;
-  const ShaderModel *m_pSM;
-  unsigned m_DxilMajor;
-  unsigned m_DxilMinor;
-  unsigned m_ValMajor;
-  unsigned m_ValMinor;
-  bool m_ForceZeroStoreLifetimes;
+  llvm::Module *m_pModule = nullptr;
+  llvm::Function *m_pEntryFunc = nullptr;
+  std::string m_EntryName = "";
+  std::unique_ptr<DxilMDHelper> m_pMDHelper = nullptr;
+  std::unique_ptr<llvm::DebugInfoFinder> m_pDebugInfoFinder = nullptr;
+  const ShaderModel *m_pSM = nullptr;
+  unsigned m_DxilMajor = DXIL::kDxilMajor;
+  unsigned m_DxilMinor = DXIL::kDxilMinor;
+  unsigned m_ValMajor = 1;
+  unsigned m_ValMinor = 0;
+  bool m_ForceZeroStoreLifetimes = false;
 
   std::unique_ptr<OP> m_pOP;
-  size_t m_pUnused;
+  size_t m_pUnused = 0;
 
   // LLVM used.
   std::vector<llvm::GlobalVariable*> m_LLVMUsed;
@@ -377,28 +375,26 @@ private:
   llvm::MDTuple *EmitDxilResources();
   void LoadDxilResources(const llvm::MDOperand &MDO);
 
+  // properties from HLModule preserved as ShaderFlags
+  bool m_bDisableOptimizations = false;
+  bool m_bUseMinPrecision = true; // use min precision by default;
+  bool m_bAllResourcesBound = false;
+  bool m_bResMayAlias = false;
+
+  // properties from HLModule that should not make it to the final DXIL
+  uint32_t m_IntermediateFlags = 0;
+  uint32_t m_AutoBindingSpace = UINT_MAX;
+
+  std::unique_ptr<DxilSubobjects> m_pSubobjects = nullptr;
+
+  // m_bMetadataErrors is true if non-fatal metadata errors were encountered.
+  // Validator will fail in this case, but should not block module load.
+  bool m_bMetadataErrors = false;
+
   // Helpers.
   template<typename T> unsigned AddResource(std::vector<std::unique_ptr<T> > &Vec, std::unique_ptr<T> pRes);
   void LoadDxilSignature(const llvm::MDTuple *pSigTuple, DxilSignature &Sig, bool bInput);
 
-  // properties from HLModule preserved as ShaderFlags
-  bool m_bDisableOptimizations;
-  bool m_bUseMinPrecision;
-  bool m_bAllResourcesBound;
-  bool m_bResMayAlias;
-
-  // properties from HLModule that should not make it to the final DXIL
-  uint32_t m_IntermediateFlags;
-  uint32_t m_AutoBindingSpace;
-
-  // porperties infered from the DXILTypeSystem
-  bool m_bHasPayloadQualifiers;
-
-  std::unique_ptr<DxilSubobjects> m_pSubobjects;
-
-  // m_bMetadataErrors is true if non-fatal metadata errors were encountered.
-  // Validator will fail in this case, but should not block module load.
-  bool m_bMetadataErrors;
 };
 
 } // namespace hlsl

--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -371,10 +371,6 @@ private:
   // Serialized ViewId state.
   std::vector<unsigned> m_SerializedState;
 
-  // DXIL metadata serialization/deserialization.
-  llvm::MDTuple *EmitDxilResources();
-  void LoadDxilResources(const llvm::MDOperand &MDO);
-
   // properties from HLModule preserved as ShaderFlags
   bool m_bDisableOptimizations = false;
   bool m_bUseMinPrecision = true; // use min precision by default;
@@ -390,6 +386,10 @@ private:
   // m_bMetadataErrors is true if non-fatal metadata errors were encountered.
   // Validator will fail in this case, but should not block module load.
   bool m_bMetadataErrors = false;
+
+  // DXIL metadata serialization/deserialization.
+  llvm::MDTuple *EmitDxilResources();
+  void LoadDxilResources(const llvm::MDOperand &MDO);
 
   // Helpers.
   template<typename T> unsigned AddResource(std::vector<std::unique_ptr<T> > &Vec, std::unique_ptr<T> pRes);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -99,10 +99,8 @@ DxilModule::DxilModule(Module *pModule)
 : m_Ctx(pModule->getContext())
 , m_pModule(pModule)
 , m_pMDHelper(make_unique<DxilMDHelper>(pModule, make_unique<DxilExtraPropertyHelper>(pModule)))
-, m_pDebugInfoFinder(nullptr)
 , m_pOP(make_unique<OP>(pModule->getContext(), pModule))
 , m_pTypeSystem(make_unique<DxilTypeSystem>(pModule))
-, m_pSubobjects(nullptr)
 {
 
   DXASSERT_NOMSG(m_pModule != nullptr);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -96,29 +96,11 @@ void ClearDxilHook(Module &M);
 //  DxilModule methods.
 //
 DxilModule::DxilModule(Module *pModule)
-: m_StreamPrimitiveTopology(DXIL::PrimitiveTopology::Undefined)
-, m_ActiveStreamMask(0)
-, m_Ctx(pModule->getContext())
+: m_Ctx(pModule->getContext())
 , m_pModule(pModule)
-, m_pEntryFunc(nullptr)
-, m_EntryName("")
 , m_pMDHelper(make_unique<DxilMDHelper>(pModule, make_unique<DxilExtraPropertyHelper>(pModule)))
-, m_pDebugInfoFinder(nullptr)
-, m_pSM(nullptr)
-, m_DxilMajor(DXIL::kDxilMajor)
-, m_DxilMinor(DXIL::kDxilMinor)
-, m_ValMajor(1)
-, m_ValMinor(0)
-, m_ForceZeroStoreLifetimes(false)
 , m_pOP(make_unique<OP>(pModule->getContext(), pModule))
 , m_pTypeSystem(make_unique<DxilTypeSystem>(pModule))
-, m_bDisableOptimizations(false)
-, m_bUseMinPrecision(true) // use min precision by default
-, m_bAllResourcesBound(false)
-, m_IntermediateFlags(0)
-, m_AutoBindingSpace(UINT_MAX)
-, m_pSubobjects(nullptr)
-, m_bMetadataErrors(false)
 {
 
   DXASSERT_NOMSG(m_pModule != nullptr);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -99,8 +99,10 @@ DxilModule::DxilModule(Module *pModule)
 : m_Ctx(pModule->getContext())
 , m_pModule(pModule)
 , m_pMDHelper(make_unique<DxilMDHelper>(pModule, make_unique<DxilExtraPropertyHelper>(pModule)))
+, m_pDebugInfoFinder(nullptr)
 , m_pOP(make_unique<OP>(pModule->getContext(), pModule))
 , m_pTypeSystem(make_unique<DxilTypeSystem>(pModule))
+, m_pSubobjects(nullptr)
 {
 
   DXASSERT_NOMSG(m_pModule != nullptr);


### PR DESCRIPTION
m_bResMayAlias was not initialized, leading to intermittent failures
when it was not explicitly set. The only functional change here is
setting that variable to eliminate that volatility. The other changes
are to move the setting of these simple typed variables to the header to
make it less likely that future added members will suffer the same fate.

Also in the process, I couldn't resist removing an unused variable added
along with the Payload Access Qualifiers in error, removing redundant
private regions, and moving the private methods out of the middle of
all the variable members.

Fixes #4616