### PR TITLE
[SPIR-V] Generate Shader.DebugInfo DebugFunctionDefinition in the wrapper function

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -780,7 +780,8 @@ private:
   /// The wrapper function is also responsible for initializing global static
   /// variables for some cases.
   bool emitEntryFunctionWrapper(const FunctionDecl *entryFunction,
-                                SpirvFunction *entryFuncId);
+                                SpirvFunction *entryFuncId,
+                                SpirvDebugFunction *debugFunction);
 
   /// \brief Emits a wrapper function for the entry functions for raytracing
   /// stages and returns true on success.
@@ -790,7 +791,8 @@ private:
   /// The wrapper function is also responsible for initializing global static
   /// variables for some cases.
   bool emitEntryFunctionWrapperForRayTracing(const FunctionDecl *entryFunction,
-                                             SpirvFunction *entryFuncId);
+                                             SpirvFunction *entryFuncId,
+                                             SpirvDebugFunction *debugFunction);
 
   /// \brief Performs the following operations for the Hull shader:
   /// * Creates an output variable which is an Array containing results for all

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.function.hlsl
@@ -16,11 +16,19 @@
 
 // Check DebugFunction instructions
 //
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] %uint_25 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_26
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[fooName]] [[fooFnType]] [[source]] %uint_33 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_34
 
 // CHECK: [[float4:%\d+]] = OpExtInst %void [[set]] DebugTypeVector [[float]] %uint_4
 // CHECK: [[mainFnType:%\d+]] = OpExtInst %void [[set]] DebugTypeFunction %uint_3 [[float4]] [[float4]]
-// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] %uint_30 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_31 
+// CHECK: [[mainDbgFn:%\d+]] = OpExtInst %void [[set]] DebugFunction [[mainName]] [[mainFnType]] [[source]] %uint_38 %uint_1 [[compilationUnit]] [[emptyStr]] %uint_3 %uint_39 
+
+// Check DebugFunctionDefintion is in main
+//
+// CHECK: %main = OpFunction %void None {{%\d+}}
+// CHECK: {{%\d+}} = OpExtInst %void [[set]] DebugFunctionDefinition [[mainDbgFn]] %main
+// CHECK: OpFunctionEnd
+// CHECK: OpFunctionEnd
+// CHECK: OpFunctionEnd
 
 void foo(int x, float y)
 {


### PR DESCRIPTION
The DebugFunctionDefintion in the user's entry function called
by the wrapper is omitted. All other DebugFunctionDefinition
instructions are still generated.

This is done because inlining during legalization omits
inlining the DebugFunctionDefintion because its function
no longer exists. This results in all DebugFunctionDefinitions
being eliminated for HLSL because every function is inlined into
the wrapper function.

The solution is to generate the entry point function's
DebugFunctionDefinition in the wrapper to start with.