### PR TITLE
[SPIR-V] Don't deduce literal int type with new type if sign doesn't match.

### DIFF
--- a/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
@@ -56,7 +56,8 @@ bool LiteralTypeVisitor::canDeduceTypeFromLitType(QualType litType,
   if (litType->isFloatingType() && newType->isFloatingType())
     return true;
   if ((litType->isIntegerType() && !litType->isBooleanType()) &&
-      (newType->isIntegerType() && !newType->isBooleanType()))
+      (newType->isIntegerType() && !newType->isBooleanType()) &&
+      litType->isSignedIntegerType() == newType->isSignedIntegerType())
     return true;
 
   {


### PR DESCRIPTION
This PR fixes an issue with implicit vector truncation that only causes a warning for DXIL, but results in invalid SPIR-V:
```hlsl
cbuffer Input {
  float3 Threshold;
  float4 Colors[2];
}
float4 PSMain() : SV_Target {
  // Error caused by int literals instead of uint literals 0 and 1
  uint Index = ((Threshold >= 0.5) ? 0 : 1);
  return Colors[Index];
}
```
Using the ternary operator expression `? 0u : 1u` would fix the issue, but this is still valid HLSL.

The issue arises during AST to SPIR-V type conversion inside `LiteralTypeVisitor::canDeduceTypeFromLitType`: A literal int type is erroneously deduced with a new int type even if the sign does not match, hence causing an `int` to be replaced with a `uint` in the above example. In SPIR-V, this looks as follows:

First, this SPIR-V is generated:
```
%37 = OpSelect %v3int %36 %10 %12
%38 = OpCompositeExtract %int %37 0
```
and then erroneously replaced with this:
```
%37 = OpSelect %v3int %36 %10 %12
%38 = OpCompositeExtract %uint %37 0
```
Register `%37` is of type `v3int`, so `OpCompositeExtract` must have a result type of `int`, not `uint`. Causing SPIR-V validation to fail.