### PR TITLE
Insert cast when types are identical to HLSL but not to clang

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4317,7 +4317,7 @@ public:
     if (kind == AR_TOBJ_MATRIX || kind == AR_TOBJ_VECTOR) {
       type = GetMatrixOrVectorElementType(type);
     } else if (kind == AR_TOBJ_STRING) {
-      type = type;
+      // return original type even if it's an array (string literal)
     } else if (type->isArrayType()) {
       const ArrayType* arrayType = type->getAsArrayTypeUnsafe();
       type = GetTypeElementType(arrayType->getElementType());

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/implicit-cast-almost-identical.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/implicit-cast-almost-identical.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T vs_6_0 -ast-dump %s | FileCheck %s
+// RUN: %dxc -T vs_6_0 %s | FileCheck -check-prefix=CHECKIR %s
+
+// sizeof() results in unsigned long, while various HLSL intrinsics take unsigned int.
+// These types are identical in HLSL (uint), but not in clang.
+// A conversion step is still necessary to prevent this case from causing
+// assert when checking function arguments during codegen.
+
+// CHECK: CallExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-SAME: IntegralCast
+// CHECK-NEXT: UnaryExprOrTypeTraitExpr
+
+// CHECKIR: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 4)
+
+uint main() : OUT {
+  return abs(sizeof(float));
+}


### PR DESCRIPTION
It's possible to get a value of a type `unsigned long` in HLSL, such as
the result of sizeof(), while the uint type is `unsigned int` instead.
This leads to the situation where no cast is inserted because the types
look identical when translated down to ArBasicKind, which can lead to an
assert during codegen, such as when passing sizeof() result to a function
call parameter.

This change preserves the original canonical type ptr from clang and
sets the conversion type when these differ, even when ArBasicKind is
identical.