### PR TITLE
Skip test when using BDA, move check logic up as high as possible

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11453,9 +11453,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
     WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);  
 
   D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
-  LogCommentFmt(L"\r\nVerifying isNormal in shader "
-                L"model 6.%1u",
-                ((UINT)sm & 0x0f));
   
   CComPtr<ID3D12Device> pDevice;
   VERIFY_IS_TRUE(CreateDevice(&pDevice, sm, false /* skipUnsupported */));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11481,8 +11481,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
   st::ShaderOp *pShaderOp =
       ShaderOpSet->GetShaderOp("IsNormal");
   vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
-
-  const int expectedResultsSize = 12;
  
   size_t count = Validation_Input->size();
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11446,17 +11446,32 @@ struct FloatInputUintOutput
 };
 
 TEST_F(ExecutionTest, IsNormalTest) {
-    // EnableShaderBasedValidation();
-    // In order, the input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 Normal float numbers.
-    // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
-    std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.101f, -.122101f};
-    std::vector<float> *Validation_Input = &Validation_Input_Vec;
+  // EnableShaderBasedValidation();
+  // In order, the input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 Normal float numbers.
+  // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
+    
+  D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
+  LogCommentFmt(L"\r\nVerifying isNormal in shader "
+                L"model 6.%1u",
+                ((UINT)sm & 0x0f));
+  
+  CComPtr<ID3D12Device> pDevice;
+  VERIFY_IS_TRUE(CreateDevice(&pDevice, sm, false /* skipUnsupported */));
 
-    std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};
-    std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
+  if (GetTestParamUseWARP(UseWarpByDefault()) || IsDeviceBasicAdapter(pDevice)) {
+      WEX::Logging::Log::Comment(L"WARP has a known issue with IsNormalTest.");
+      WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+      return;
+  }
 
-    WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+  std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.101f, -.122101f};
+  std::vector<float> *Validation_Input = &Validation_Input_Vec;
+
+  std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};
+  std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
+
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+    WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 
@@ -11468,14 +11483,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
   vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
   const int expectedResultsSize = 12;
-  
-  D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
-  LogCommentFmt(L"\r\nVerifying isNormal in shader "
-                L"model 6.%1u",
-                ((UINT)sm & 0x0f));
-
-  CComPtr<ID3D12Device> pDevice;
-  VERIFY_IS_TRUE(CreateDevice(&pDevice, sm, false /* skipUnsupported */));
  
   size_t count = Validation_Input->size();
 

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11449,7 +11449,9 @@ TEST_F(ExecutionTest, IsNormalTest) {
   // EnableShaderBasedValidation();
   // In order, the input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 Normal float numbers.
   // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
-    
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+    WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);  
+
   D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
   LogCommentFmt(L"\r\nVerifying isNormal in shader "
                 L"model 6.%1u",
@@ -11470,8 +11472,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
   std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};
   std::vector<unsigned int> *Validation_Expected = &Validation_Expected_Vec;
 
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-    WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
   CComPtr<IStream> pStream;
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
 


### PR DESCRIPTION
Windows Basic Render Driver on Windows 11 is a separate version than in Windows Server 2022. IsNormal passes on the Win11 version, but not on Win Server 2022. This PR will make the Wintools build pipeline skip the IsNormal HLK test to avoid the known failure that is encountered when running the test in the lab environment. It also pushes this driver detection logic to the top of the test function to avoid doing potentially unnecessary work.