### PR TITLE
Remove unused line in ExecutionTests.cpp

### DIFF
--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11467,8 +11467,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
       ShaderOpSet->GetShaderOp("IsNormal");
   vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
-  const int expectedResultsSize = 12;
-  
   D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
   LogCommentFmt(L"\r\nVerifying isNormal in shader "
                 L"model 6.%1u",


### PR DESCRIPTION
Triggers a C4189 warning (treated as error) in VS2022