### PR TITLE
Add option to force disabling debug info

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -205,6 +205,7 @@ public:
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
   bool ForceZeroStoreLifetimes = false; // OPT_force_zero_store_lifetimes
   bool EnableLifetimeMarkers = false; // OPT_enable_lifetime_markers
+  bool ForceDisableDebugInfo = false; // OPT_fdisable_debug_info
   bool EnableTemplates = false; // OPT_enable_templates
   bool EnableOperatorOverloading = false; // OPT_enable_operator_overloading
   bool StrictUDTCasting = false; // OPT_strict_udt_casting

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -205,7 +205,7 @@ public:
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
   bool ForceZeroStoreLifetimes = false; // OPT_force_zero_store_lifetimes
   bool EnableLifetimeMarkers = false; // OPT_enable_lifetime_markers
-  bool ForceDisableDebugInfo = false; // OPT_fdisable_debug_info
+  bool ForceDisableLocTracking = false; // OPT_fdisable_loc_tracking
   bool EnableTemplates = false; // OPT_enable_templates
   bool EnableOperatorOverloading = false; // OPT_enable_operator_overloading
   bool StrictUDTCasting = false; // OPT_strict_udt_casting

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -168,6 +168,10 @@ def opt_enable : Separate<["-", "/"], "opt-enable">, Group<hlsloptz_Group>, Flag
 def opt_select : MultiArg<["-", "/"], "opt-select", 2>, MetaVarName<"<opt> <variant>">, Group<hlsloptz_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Select this optimization variant.">;
 
+def fdisable_debug_info : Flag<["-"], "fdisable-debug-info">,
+  Group<hlslcomp_Group>, Flags<[CoreOption]>,
+  HelpText<"Force disabling all debug info. This will break diagnostic generation for late validation.">;
+
 /*
 def fno_caret_diagnostics : Flag<["-"], "fno-caret-diagnostics">, Group<hlslcomp_Group>,
  Flags<[CoreOption]>;

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -168,9 +168,9 @@ def opt_enable : Separate<["-", "/"], "opt-enable">, Group<hlsloptz_Group>, Flag
 def opt_select : MultiArg<["-", "/"], "opt-select", 2>, MetaVarName<"<opt> <variant>">, Group<hlsloptz_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,
   HelpText<"Select this optimization variant.">;
 
-def fdisable_debug_info : Flag<["-"], "fdisable-debug-info">,
+def fdisable_loc_tracking : Flag<["-"], "fdisable-loc-tracking">,
   Group<hlslcomp_Group>, Flags<[CoreOption]>,
-  HelpText<"Force disabling all debug info. This will break diagnostic generation for late validation.">;
+  HelpText<"Disable source location tracking in IR. This will break diagnostic generation for late validation. (Ignored if /Zi is passed)">;
 
 /*
 def fno_caret_diagnostics : Flag<["-"], "fno-caret-diagnostics">, Group<hlslcomp_Group>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -828,6 +828,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.EnableLifetimeMarkers = Args.hasFlag(OPT_enable_lifetime_markers, OPT_INVALID,
                                             DXIL::CompareVersions(Major, Minor, 6, 6) >= 0) &&
                               !Args.hasFlag(OPT_disable_lifetime_markers, OPT_INVALID, false);
+  opts.ForceDisableDebugInfo =
+      Args.hasFlag(OPT_fdisable_debug_info, OPT_INVALID, false);
   opts.EnablePayloadQualifiers = Args.hasFlag(OPT_enable_payload_qualifiers, OPT_INVALID,
                                             DXIL::CompareVersions(Major, Minor, 6, 7) >= 0); 
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -828,8 +828,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.EnableLifetimeMarkers = Args.hasFlag(OPT_enable_lifetime_markers, OPT_INVALID,
                                             DXIL::CompareVersions(Major, Minor, 6, 6) >= 0) &&
                               !Args.hasFlag(OPT_disable_lifetime_markers, OPT_INVALID, false);
-  opts.ForceDisableDebugInfo =
-      Args.hasFlag(OPT_fdisable_debug_info, OPT_INVALID, false);
+  opts.ForceDisableLocTracking =
+      Args.hasFlag(OPT_fdisable_loc_tracking, OPT_INVALID, false);
   opts.EnablePayloadQualifiers = Args.hasFlag(OPT_enable_payload_qualifiers, OPT_INVALID,
                                             DXIL::CompareVersions(Major, Minor, 6, 7) >= 0); 
 

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -561,6 +561,13 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
     auto *func = D.getFunction();
     if (DiagClient && func)
       DiagClient->setPrefix("Function: " + func->getName().str());
+    
+    // Clang will de-duplicate this so that it only emits once.
+    Diags.Report(
+        Diags.getCustomDiagID(DiagnosticsEngine::Note,
+                              "Debug information is disabled which may impact "
+                              "diagnostic location accuracy. Re-run without "
+                              "-fdisable-debug-info to improve accuracy.\n"));
   }
   Diags.Report(Loc, DiagID).AddString(Message);
 

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -567,7 +567,7 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
         Diags.getCustomDiagID(DiagnosticsEngine::Note,
                               "Debug information is disabled which may impact "
                               "diagnostic location accuracy. Re-run without "
-                              "-fdisable-debug-info to improve accuracy.\n"));
+                              "-fdisable-loc-tracking to improve accuracy.\n"));
   }
   Diags.Report(Loc, DiagID).AddString(Message);
 

--- a/tools/clang/test/HLSLFileCheck/validation/ResourceResolvingNoDI.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/ResourceResolvingNoDI.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T cs_6_0 -fdisable-debug-info %s 2>&1 | FileCheck %s
+
+// CHECK: Function: main: note: Debug information is disabled which may impact diagnostic location accuracy. Re-run without -fdisable-debug-info to improve accuracy.
+// CHECK-NOT: note: Debug information is disabled
+
+RWBuffer<int> Buf[2];
+RWBuffer<int> Out;
+
+int getVal(bool B, int Idx) {
+  RWBuffer<int> Local;
+  if (B) Local = Buf[Idx];
+  return Local[Idx];
+}
+
+int getValASecondTime(bool B, int Idx) {
+  RWBuffer<int> Local;
+  if (B) Local = Buf[Idx];
+  return Local[Idx];
+}
+
+[numthreads(1,1,1)]
+void main(uint GI : SV_GroupIndex) {
+  Out[GI] = getVal(false, GI);
+  Out[GI+1] = getValASecondTime(false, GI);
+}

--- a/tools/clang/test/HLSLFileCheck/validation/ResourceResolvingNoDI.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/ResourceResolvingNoDI.hlsl
@@ -1,6 +1,6 @@
-// RUN: %dxc -T cs_6_0 -fdisable-debug-info %s 2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_0 -fdisable-loc-tracking %s 2>&1 | FileCheck %s
 
-// CHECK: Function: main: note: Debug information is disabled which may impact diagnostic location accuracy. Re-run without -fdisable-debug-info to improve accuracy.
+// CHECK: Function: main: note: Debug information is disabled which may impact diagnostic location accuracy. Re-run without -fdisable-loc-tracking to improve accuracy.
 // CHECK-NOT: note: Debug information is disabled
 
 RWBuffer<int> Buf[2];

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1417,7 +1417,7 @@ public:
       // TODO: consider
       // DebugPass, DebugCompilationDir, DwarfDebugFlags, SplitDwarfFile
     }
-    else {
+    else if (!Opts.ForceDisableDebugInfo) {
       CodeGenOptions &CGOpts = compiler.getCodeGenOpts();
       CGOpts.setDebugInfo(CodeGenOptions::LocTrackingOnly);
       CGOpts.DebugColumnInfo = 1;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1417,7 +1417,7 @@ public:
       // TODO: consider
       // DebugPass, DebugCompilationDir, DwarfDebugFlags, SplitDwarfFile
     }
-    else if (!Opts.ForceDisableDebugInfo) {
+    else if (!Opts.ForceDisableLocTracking) {
       CodeGenOptions &CGOpts = compiler.getCodeGenOpts();
       CGOpts.setDebugInfo(CodeGenOptions::LocTrackingOnly);
       CGOpts.DebugColumnInfo = 1;


### PR DESCRIPTION
This is (admittedly) a little hacky. DXC spends a lot of compile time updating debug information because we always generate it so that we can generate diagnostics for late-running validation.

This flag disables that validation resulting in about a 15% compile time improvement on a pessimistic inliner test.