### PR TITLE
Add option to enable LTO/LTCG

### DIFF
--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -607,7 +607,6 @@ if (LLVM_ENABLE_LTO)
   endif()
 endif()
 # HLSL Change End
-endif()
 
 # Plugin support
 # FIXME: Make this configurable.

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -593,6 +593,21 @@ if(LLVM_ENABLE_EH AND NOT LLVM_ENABLE_RTTI)
   message(FATAL_ERROR "Exception handling requires RTTI. You must set LLVM_ENABLE_RTTI to ON")
 endif()
 
+option(LLVM_ENABLE_LTO "Enable building with LTO" OFF)
+if (LLVM_ENABLE_LTO)
+  if(MSVC)
+    if (CMAKE_CONFIGURATION_TYPES)
+      set(_PREFIX "$<$<CONFIG:Release>:")
+      set(_SUFFIX ">")
+    endif()
+    append("$_PREFIX/GL$_SUFFIX" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    append("$_PREFIX/LTCG$_SUFFIX" CMAKE_MODULE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
+  else()
+    append("-flto" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    append("-flto" CMAKE_MODULE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
+  endif()
+endif()
+
 # Plugin support
 # FIXME: Make this configurable.
 if(WIN32 OR CYGWIN)

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -593,19 +593,20 @@ if(LLVM_ENABLE_EH AND NOT LLVM_ENABLE_RTTI)
   message(FATAL_ERROR "Exception handling requires RTTI. You must set LLVM_ENABLE_RTTI to ON")
 endif()
 
-option(LLVM_ENABLE_LTO "Enable building with LTO" OFF)
+# HLSL Change Begin
+option(LLVM_ENABLE_LTO "Enable building with LTO" ${HLSL_OFFICIAL_BUILD})
 if (LLVM_ENABLE_LTO)
   if(MSVC)
     if (CMAKE_CONFIGURATION_TYPES)
-      set(_PREFIX "$<$<CONFIG:Release>:")
-      set(_SUFFIX ">")
+      set(_SUFFIX _RELEASE)
     endif()
-    append("$_PREFIX/GL$_SUFFIX" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    append("$_PREFIX/LTCG$_SUFFIX" CMAKE_MODULE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
+    append("/GL" CMAKE_C_FLAGS${_SUFFIX} CMAKE_CXX_FLAGS${_SUFFIX})
+    append("/LTCG" CMAKE_MODULE_LINKER_FLAGS${_SUFFIX} CMAKE_MODULE_LINKER_FLAGS${_SUFFIX} CMAKE_EXE_LINKER_FLAGS${_SUFFIX})
   else()
-    append("-flto" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
-    append("-flto" CMAKE_MODULE_LINKER_FLAGS CMAKE_MODULE_LINKER_FLAGS CMAKE_EXE_LINKER_FLAGS)
+    add_flag_if_supported("-flto" SUPPORST_FLTO)
   endif()
+endif()
+# HLSL Change End
 endif()
 
 # Plugin support

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -217,6 +217,10 @@ if "%1"=="-update-generated-sources" (
   set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_COPY_GENERATED_SOURCES=1
   shift /1 & goto :parse_args
 )
+if "%1"=="-lto" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_ENABLE_LTO=On
+  shift /1 & goto :parse_args
+)
 if "%1" NEQ "" ( 
     echo Unrecognized argument: %1
     exit /b 1


### PR DESCRIPTION
This adds a new option to the build to enable link-time optimzied builds of DXC. On Windows with MSVC this seems to give about a 4% runtime performance boost on my one locally run test case... and on Linux I'm seeing about 6% on that same locally run test case.

It's free performance so yay :D