### PR TITLE
build: fix include in header files.

### DIFF
--- a/include/dxc/DXIL/DxilFunctionProps.h
+++ b/include/dxc/DXIL/DxilFunctionProps.h
@@ -13,6 +13,7 @@
 
 // for memset dependency:
 #include <cstring>
+#include <vector>
 
 #include "dxc/DXIL/DxilConstants.h"
 

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -12,11 +12,11 @@
 
 #pragma once
 
+#include "dxc/DXIL/DxilOperations.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 
-// TODO: add correct include directives
 // TODO: add accessors with values
 // TODO: add validation support code, including calling into right fn
 // TODO: add type hierarchy

--- a/include/dxc/DXIL/DxilShaderFlags.h
+++ b/include/dxc/DXIL/DxilShaderFlags.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 namespace hlsl {
   class DxilModule;
 }

--- a/include/dxc/DxilContainer/DxilPipelineStateValidation.h
+++ b/include/dxc/DxilContainer/DxilPipelineStateValidation.h
@@ -13,7 +13,8 @@
 #define __DXIL_PIPELINE_STATE_VALIDATION__H__
 
 #include <stdint.h>
-#include <string.h>
+#include <cstring>
+#include "dxc/Support/WinAdapter.h"
 
 // Don't include assert.h here.
 // Since this header is included from multiple environments,

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -10,7 +10,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+
 #include "dxc/DXIL/DxilConstants.h"
+#include "dxc/Support/WinAdapter.h"
 
 #define RDAT_NULL_REF ((uint32_t)0xFFFFFFFF)
 

--- a/include/dxc/DxilRootSignature/DxilRootSignature.h
+++ b/include/dxc/DxilRootSignature/DxilRootSignature.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 
 #include "dxc/Support/WinAdapter.h"
+#include "dxc/DXIL/DxilConstants.h"
 
 struct IDxcBlob;
 struct IDxcBlobEncoding;

--- a/include/dxc/HLSL/DxilExportMap.h
+++ b/include/dxc/HLSL/DxilExportMap.h
@@ -13,14 +13,16 @@
 // llvm/Function part so first part may be have shared use without llvm
 
 #pragma once
-#include <vector>
-#include <set>
-#include <unordered_set>
-#include <string>
+
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/MapVector.h"
+
+#include <vector>
+#include <set>
+#include <unordered_set>
+#include <string>
 
 namespace llvm {
 class Function;

--- a/include/dxc/HLSL/DxilFallbackLayerPass.h
+++ b/include/dxc/HLSL/DxilFallbackLayerPass.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "llvm/Pass.h"
+
 namespace llvm {
     ModulePass *createDxilUpdateMetadataPass();
     ModulePass *createDxilPatchShaderRecordBindingsPass();

--- a/include/dxc/HLSL/DxilLinker.h
+++ b/include/dxc/HLSL/DxilLinker.h
@@ -11,13 +11,14 @@
 
 #pragma once
 
+#include "dxc/HLSL/DxilExportMap.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorOr.h"
+
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
-#include "llvm/ADT/StringRef.h"
-#include "llvm/ADT/StringMap.h"
-#include <memory>
-#include "llvm/Support/ErrorOr.h"
-#include "dxc/HLSL/DxilExportMap.h"
 
 namespace llvm {
 class Function;

--- a/include/dxc/HLSL/DxilPackSignatureElement.h
+++ b/include/dxc/HLSL/DxilPackSignatureElement.h
@@ -11,14 +11,16 @@
 
 #pragma once
 
-#include "llvm/ADT/StringRef.h"
-#include "dxc/DXIL/DxilSemantic.h"
-#include "dxc/DXIL/DxilInterpolationMode.h"
 #include "dxc/DXIL/DxilCompType.h"
+#include "dxc/DXIL/DxilInterpolationMode.h"
+#include "dxc/DXIL/DxilSemantic.h"
+#include "dxc/DXIL/DxilSignatureElement.h"
 #include "dxc/HLSL/DxilSignatureAllocator.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <limits.h>
 #include <string>
 #include <vector>
-#include <limits.h>
 
 namespace hlsl {
 

--- a/include/dxc/HLSL/DxilSignatureAllocator.h
+++ b/include/dxc/HLSL/DxilSignatureAllocator.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "dxc/DXIL/DxilConstants.h"
+
 #include <vector>
 
 namespace hlsl {

--- a/include/dxc/HLSL/DxilValidation.h
+++ b/include/dxc/HLSL/DxilValidation.h
@@ -11,10 +11,10 @@
 
 #pragma once
 
-#include <memory>
 #include "dxc/Support/Global.h"
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/Support/WinAdapter.h"
+#include <memory>
 
 namespace llvm {
 class Module;

--- a/include/dxc/HLSL/HLOperationLowerExtension.h
+++ b/include/dxc/HLSL/HLOperationLowerExtension.h
@@ -27,7 +27,7 @@ namespace llvm {
 namespace hlsl {
   class OP;
 
-  struct HLResourceLookup 
+  struct HLResourceLookup
   {
       // Lookup resource kind based on handle. Return true on success.
       virtual bool GetResourceKindName(llvm::Value *HLHandle, const char **ppName) = 0;

--- a/include/dxc/HLSL/HLResource.h
+++ b/include/dxc/HLSL/HLResource.h
@@ -22,7 +22,7 @@ public:
   //QQQ
   // TODO: this does not belong here. QQQ
   //static Kind KeywordToKind(const std::string &keyword);
-  
+
   HLResource();
 };
 

--- a/include/dxc/Support/DxcLangExtensionsCommonHelper.h
+++ b/include/dxc/Support/DxcLangExtensionsCommonHelper.h
@@ -11,9 +11,11 @@
 
 #pragma once
 
-#include "dxc/Support/Unicode.h"
 #include "dxc/Support/FileIOHelper.h"
+#include "dxc/Support/Unicode.h"
 #include "dxc/dxcapi.internal.h"
+#include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallVector.h"
 #include <vector>
 
 namespace llvm {

--- a/include/dxc/Support/DxcLangExtensionsHelper.h
+++ b/include/dxc/Support/DxcLangExtensionsHelper.h
@@ -12,9 +12,14 @@
 #ifndef __DXCLANGEXTENSIONSHELPER_H__
 #define __DXCLANGEXTENSIONSHELPER_H__
 
-#include "dxc/Support/Unicode.h"
-#include "dxc/Support/FileIOHelper.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/AST/Decl.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Sema/Sema.h"
+#include "clang/Sema/SemaHLSL.h"
 #include "dxc/Support/DxcLangExtensionsCommonHelper.h"
+#include "dxc/Support/FileIOHelper.h"
+#include "dxc/Support/Unicode.h"
 #include <vector>
 
 namespace llvm {
@@ -51,7 +56,7 @@ public:
   DxcLangExtensionsHelper *GetDxcLangExtensionsHelper() override {
     return this;
   }
- 
+
   DxcLangExtensionsHelper() {}
 };
 

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -9,8 +9,12 @@
 
 #pragma once
 
-//#define PIX_DEBUG_DUMP_HELPER
+#include "dxc/DXIL/DxilModule.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
 
+//#define PIX_DEBUG_DUMP_HELPER
 #ifdef PIX_DEBUG_DUMP_HELPER
 #include "dxc/Support/Global.h"
 #endif

--- a/lib/DxilRootSignature/DxilRootSignatureHelper.h
+++ b/lib/DxilRootSignature/DxilRootSignatureHelper.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
+#include "dxc/DxilRootSignature/DxilRootSignature.h"
 #include "dxc/Support/Global.h"
+#include "dxc/Support/WinIncludes.h"
 
 namespace hlsl {
 

--- a/lib/HLSL/DxilPatchShaderRecordBindingsShared.h
+++ b/lib/HLSL/DxilPatchShaderRecordBindingsShared.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #define FallbackLayerRegisterSpace 214743647
 
 // SRVs

--- a/lib/Support/regcclass.h
+++ b/lib/Support/regcclass.h
@@ -40,6 +40,8 @@
 #ifndef LLVM_SUPPORT_REGCCLASS_H
 #define LLVM_SUPPORT_REGCCLASS_H
 
+#include <stddef.h>
+
 /* character-class table */
 static struct cclass {
 	const char *name;

--- a/lib/Support/regcname.h
+++ b/lib/Support/regcname.h
@@ -38,6 +38,8 @@
 #ifndef LLVM_SUPPORT_REGCNAME_H
 #define LLVM_SUPPORT_REGCNAME_H
 
+#include <stddef.h>
+
 /* character-name table */
 static struct cname {
 	const char *name;

--- a/lib/Support/regex2.h
+++ b/lib/Support/regex2.h
@@ -38,6 +38,9 @@
 #ifndef LLVM_SUPPORT_REGEX2_H
 #define LLVM_SUPPORT_REGEX2_H
 
+#include "regutils.h"
+#include <stddef.h>
+
 /*
  * internals of regex_t
  */

--- a/lib/Transforms/ObjCARC/DependencyAnalysis.h
+++ b/lib/Transforms/ObjCARC/DependencyAnalysis.h
@@ -23,6 +23,7 @@
 #ifndef LLVM_LIB_TRANSFORMS_OBJCARC_DEPENDENCYANALYSIS_H
 #define LLVM_LIB_TRANSFORMS_OBJCARC_DEPENDENCYANALYSIS_H
 
+#include "ARCInstKind.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace llvm {

--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -3,11 +3,12 @@
 #pragma once
 
 #include "clang/Basic/SourceLocation.h"
-
-#include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/MapVector.h"
-
 #include "dxc/DXIL/DxilCBuffer.h"
+#include "dxc/Support/HLSLVersion.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Instructions.h"
 
 #include <memory>
 #include <vector>

--- a/tools/clang/lib/SPIRV/StageVar.h
+++ b/tools/clang/lib/SPIRV/StageVar.h
@@ -10,11 +10,12 @@
 #ifndef LLVM_CLANG_LIB_SPIRV_STAGEVAR_H
 #define LLVM_CLANG_LIB_SPIRV_STAGEVAR_H
 
-#include <string>
-
+#include "clang/AST/Attr.h"
+#include "clang/SPIRV/SpirvInstruction.h"
 #include "dxc/DXIL/DxilSemantic.h"
 #include "dxc/DXIL/DxilSigPoint.h"
-#include "clang/AST/Attr.h"
+
+#include <string>
 
 namespace clang {
 namespace spirv {

--- a/tools/clang/lib/Sema/VkConstantsTables.h
+++ b/tools/clang/lib/Sema/VkConstantsTables.h
@@ -15,6 +15,10 @@
 #ifndef LLVM_CLANG_LIB_SEMA_VKCONSTANTSTABLES_H
 #define LLVM_CLANG_LIB_SEMA_VKCONSTANTSTABLES_H
 
+#include <string>
+#include <utility>
+#include <vector>
+
 std::vector<std::pair<std::string, uint32_t>> GetVkIntegerConstants() {
   return {
       {"CrossDeviceScope", 0u},

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -11,10 +11,12 @@
 
 #pragma once
 
-#include "dxc/dxcapi.h"
+#include "dxc/DXIL/DxilModule.h"
 #include "dxc/Support/microcom.h"
-#include <memory>
+#include "dxc/dxcapi.h"
 #include "llvm/ADT/StringRef.h"
+
+#include <memory>
 
 namespace clang {
 class DiagnosticsEngine;

--- a/tools/clang/tools/libclang/dxcisenseimpl.h
+++ b/tools/clang/tools/libclang/dxcisenseimpl.h
@@ -13,10 +13,13 @@
 #define __DXC_ISENSEIMPL__
 
 #include "clang-c/Index.h"
-#include "dxc/dxcisense.h"
-#include "dxc/dxcapi.internal.h"
-#include "dxc/Support/microcom.h"
+#include "clang/AST/Decl.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "dxc/Support/DxcLangExtensionsCommonHelper.h"
 #include "dxc/Support/DxcLangExtensionsHelper.h"
+#include "dxc/Support/microcom.h"
+#include "dxc/dxcapi.internal.h"
+#include "dxc/dxcisense.h"
 
 // Forward declarations.
 class DxcCursor;

--- a/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/WholeFileTestFixture.h
@@ -10,8 +10,9 @@
 #ifndef LLVM_CLANG_UNITTESTS_SPIRV_WHOLEFILETESTFIXTURE_H
 #define LLVM_CLANG_UNITTESTS_SPIRV_WHOLEFILETESTFIXTURE_H
 
-#include "llvm/ADT/StringRef.h"
 #include "gtest/gtest.h"
+#include "llvm/ADT/StringRef.h"
+#include "spirv-tools/libspirv.h"
 
 namespace clang {
 namespace spirv {

--- a/utils/TableGen/X86DisassemblerShared.h
+++ b/utils/TableGen/X86DisassemblerShared.h
@@ -10,10 +10,11 @@
 #ifndef LLVM_UTILS_TABLEGEN_X86DISASSEMBLERSHARED_H
 #define LLVM_UTILS_TABLEGEN_X86DISASSEMBLERSHARED_H
 
+#include "llvm/Support/X86DisassemblerDecoderCommon.h"
+#include "../../lib/Target/X86/Disassembler/X86DisassemblerDecoderCommon.h"
+
 #include <cstring>
 #include <string>
-
-#include "../../lib/Target/X86/Disassembler/X86DisassemblerDecoderCommon.h"
 
 struct InstructionSpecifier {
   llvm::X86Disassembler::OperandSpecifier

--- a/utils/hct/hctgen.py
+++ b/utils/hct/hctgen.py
@@ -50,7 +50,7 @@ def writeCodeTag(args):
   argsList = [args.input, args.output]
   result = CodeTags.main(argsList, getNewline(args))
   return 0
-  
+
 def openOutput(args):
   outputDir = os.path.dirname(os.path.realpath(args.output))
   if not os.path.exists(outputDir):


### PR DESCRIPTION
Building DXC with another build system revealed that some includes were dependent on headers only available by chance. Adding missing headers.

Signed-off-by: Nathan Gauër <brioche@google.com>