### PR TITLE
move entry point default code

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -495,11 +495,6 @@ private:
           AddArgPair(std::move(newPair));
         }
 
-        // Entry point might have been omitted. Set it to main by default.
-        if (m_EntryPoint.empty()) {
-          m_EntryPoint = L"main";
-        }
-
         // Sources
         for (unsigned i = 0; i < reader.GetSourcesCount(); i++) {
           hlsl::SourceInfoReader::Source source_data = reader.GetSource(i);
@@ -546,6 +541,12 @@ private:
       } break; // hlsl::DFCC_ShaderDebugInfoDXIL
       } // switch (four_cc)
     } // For each part
+    
+    // Entry point might have been omitted. Set it to main by default.
+    // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
+    if (m_EntryPoint.empty()) {
+      m_EntryPoint = L"main";
+    }
 
     return S_OK;
   }

--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -542,8 +542,6 @@ private:
       } // switch (four_cc)
     } // For each part
     
-    SetEntryPointToDefaultIfEmpty();
-
     return S_OK;
   }
 
@@ -668,6 +666,8 @@ public:
         IFR(pProgramHeaderBlob.QueryInterface(&m_pDebugProgramBlob));
         IFR(PopulateSourcesFromProgramHeaderOrBitcode(m_pDebugProgramBlob));
       }
+
+      SetEntryPointToDefaultIfEmpty();
     }
     catch (std::bad_alloc) {
       Reset();
@@ -751,8 +751,9 @@ public:
 
   virtual void STDMETHODCALLTYPE SetEntryPointToDefaultIfEmpty() {
     // Entry point might have been omitted. Set it to main by default.
+    // Don't set entry point if this instance is non-debug DXIL and has no arguments at all.
     // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
-    if (m_EntryPoint.empty()) {
+    if (m_EntryPoint.empty() && !m_ArgPairs.empty()) {
       m_EntryPoint = L"main";
     }
   }
@@ -810,6 +811,8 @@ public:
 
       // Clear the cached compile result
       m_pCachedRecompileResult = nullptr;
+
+      SetEntryPointToDefaultIfEmpty();
     }
     CATCH_CPP_RETURN_HRESULT()
 

--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -542,11 +542,7 @@ private:
       } // switch (four_cc)
     } // For each part
     
-    // Entry point might have been omitted. Set it to main by default.
-    // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
-    if (m_EntryPoint.empty()) {
-      m_EntryPoint = L"main";
-    }
+    SetEntryPointToDefaultIfEmpty();
 
     return S_OK;
   }
@@ -753,6 +749,14 @@ public:
     return m_pDebugProgramBlob != nullptr;
   }
 
+  virtual void STDMETHODCALLTYPE SetEntryPointToDefaultIfEmpty() {
+    // Entry point might have been omitted. Set it to main by default.
+    // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
+    if (m_EntryPoint.empty()) {
+      m_EntryPoint = L"main";
+    }
+  }
+
   virtual HRESULT STDMETHODCALLTYPE OverrideArgs(_In_ DxcArgPair *pArgPairs, UINT32 uNumArgPairs) override {
     try {
       DxcThreadMalloc TM(m_pMalloc);
@@ -770,6 +774,8 @@ public:
       m_pCachedRecompileResult = nullptr;
     }
     CATCH_CPP_RETURN_HRESULT()
+
+    SetEntryPointToDefaultIfEmpty();
 
     return S_OK;
   }


### PR DESCRIPTION
The entry point member variable is currently only set if the dxilcontainer contains a DFCC_ShaderSourceInfo header.
This change will set the entry point default to main regardless of which headers can be found in the container.