### PR TITLE
[SPIR-V] Handle debugInfo for composite types across source files

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/shader.debug.file.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.file.composite.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -E MainPs -T ps_6_0 -fspv-target-env=vulkan1.1 -fspv-debug=vulkan-with-source
+
+// Just check that compilation completes
+// CHECK: %MainPs = OpFunction %void None
+
+#line 43 "lpv_debug.fxc"
+struct PS_INPUT
+{
+
+    float3 vPositionWithOffsetWs : TEXCOORD0 ;
+
+} ;
+
+#line 430 "csgo_common_ps_code.fxc"
+struct PS_OUTPUT
+{
+    float4 vColor : SV_Target0 ;
+} ;
+
+#line 135 "lpv_debug_grid.vfx"
+PS_OUTPUT MainPs ( PS_INPUT i )
+{
+    float3 v = i . vPositionWithOffsetWs ;
+
+    PS_OUTPUT o ;
+    o . vColor . rgba = float4 ( 0.0 , 0.0 , 0.0 , 0.0 ) ;
+    return o ;
+
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3129,6 +3129,9 @@ TEST_F(FileTest, ShaderDebugInfoLineBranch) {
 TEST_F(FileTest, ShaderDebugInfoLineComposite) {
   runFileTest("shader.debug.line.composite.hlsl");
 }
+TEST_F(FileTest, ShaderDebugInfoFileComposite) {
+  runFileTest("shader.debug.file.composite.hlsl");
+}
 TEST_F(FileTest, ShaderDebugInfoLineInclude) {
   runFileTest("shader.debug.line.include.hlsl");
 }


### PR DESCRIPTION
This fixes a crash when generating source debugInfo for composite types across multiple source files.