### PR TITLE
Fix error on shutdown when using custom memory allocator

### DIFF
--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -12,7 +12,7 @@
 #include "dxc/DXIL/DxilShaderModel.h"
 #include "dxc/DXIL/DxilSemantic.h"
 #include "dxc/Support/Global.h"
-#include <unordered_map>
+#include <algorithm>
 
 
 namespace hlsl {
@@ -83,7 +83,7 @@ bool ShaderModel::IsValidForModule() const {
 const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_shader_model_get()</py>*/
   // VALRULE-TEXT:BEGIN
-  const static std::unordered_map<unsigned, unsigned> hashToIdxMap = {
+  const static std::pair<unsigned, unsigned> hashToIdxMap[] = {
   {1024,0}, //ps_4_0
   {1025,1}, //ps_4_1
   {1280,2}, //ps_5_0
@@ -169,8 +169,9 @@ const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
   {919047,81}, //as_6_7
   };
   unsigned hash = (unsigned)Kind << 16 | Major << 8 | Minor;
-  auto it = hashToIdxMap.find(hash);
-  if (it == hashToIdxMap.end())
+  auto pred = [](const std::pair<unsigned, unsigned>& elem, unsigned val){ return elem.first < val;};
+  auto it = std::lower_bound(std::begin(hashToIdxMap), std::end(hashToIdxMap), hash, pred);
+  if (it == std::end(hashToIdxMap))
     return GetInvalid();
   return &ms_ShaderModels[it->second];
   // VALRULE-TEXT:END

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -1293,7 +1293,7 @@ def get_num_shader_models():
 
 def build_shader_model_hash_idx_map():
     #must match get_shader_models.
-    result = "const static std::unordered_map<unsigned, unsigned> hashToIdxMap = {\n"
+    result = "const static std::pair<unsigned, unsigned> hashToIdxMap[] = {\n"
     count = 0
     for profile in shader_profiles:
         min_sm = profile.start_sm
@@ -1386,11 +1386,12 @@ def get_dxil_version():
     return result
 
 def get_shader_model_get():
-    # const static std::unordered_map<unsigned, unsigned> hashToIdxMap = {};
+    # const static std::pair<unsigned, unsigned> hashToIdxMap[] = {};
     result = build_shader_model_hash_idx_map()
     result += "unsigned hash = (unsigned)Kind << 16 | Major << 8 | Minor;\n"
-    result += "auto it = hashToIdxMap.find(hash);\n"
-    result += "if (it == hashToIdxMap.end())\n"
+    result += "auto pred = [](const std::pair<unsigned, unsigned>& elem, unsigned val){ return elem.first < val;};\n"
+    result += "auto it = std::lower_bound(std::begin(hashToIdxMap), std::end(hashToIdxMap), hash, pred);\n"
+    result += "if (it == std::end(hashToIdxMap))\n"
     result += "  return GetInvalid();\n"
     result += "return &ms_ShaderModels[it->second];"
     return result


### PR DESCRIPTION
ShaderModel::Get() used a static std::unordered_map which is torn down when custom allocator may no longer be active.

Resolves #4655.