### PR TITLE
[SPIR-V] Add short-circuiting logical operators for HLSL 2021

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/binary-op.short-circuited-logical-and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.short-circuited-logical-and.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T ps_6_0 -E main -HV 2021
+
+void main() {
+  // CHECK-LABEL: %bb_entry = OpLabel
+
+  bool a, b, c;
+  // CHECK:      [[t:%temp_[a-z_]+]] = OpVariable %_ptr_Function_bool Function
+  // CHECK-NEXT: [[a:%\d+]] = OpLoad %bool %a
+  // CHECK-NEXT: OpStore [[t]] %false
+  // CHECK-NEXT: OpSelectionMerge %logical_merge None
+  // CHECK-NEXT: OpBranchConditional [[a]] %logical_lhs_cond %logical_merge
+  // CHECK-NEXT: %logical_lhs_cond = OpLabel
+  // CHECK-NEXT: [[b:%\d+]] = OpLoad %bool %b
+  // CHECK-NEXT: OpStore [[t]] [[b]]
+  // CHECK-NEXT: OpBranch %logical_merge
+  // CHECK-NEXT: %logical_merge = OpLabel
+  // CHECK-NEXT: [[result:%\d+]] = OpLoad %bool [[t]]
+  // CHECK-NEXT: OpStore %c [[result]]
+  c = a && b;
+}

--- a/tools/clang/test/CodeGenSPIRV/binary-op.short-circuited-logical-or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.short-circuited-logical-or.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T ps_6_0 -E main -HV 2021
+
+void main() {
+  // CHECK-LABEL: %bb_entry = OpLabel
+
+  bool a, b, c;
+  // Plain assignment.
+  // CHECK:      [[t:%temp_[a-z_]+]] = OpVariable %_ptr_Function_bool Function
+  // CHECK-NEXT: [[a:%\d+]] = OpLoad %bool %a
+  // CHECK-NEXT: OpStore [[t]] %true
+  // CHECK-NEXT: [[cond:%\d+]] = OpLogicalNot %bool [[a]]
+  // CHECK-NEXT: OpSelectionMerge %logical_merge None
+  // CHECK-NEXT: OpBranchConditional [[cond]] %logical_lhs_cond %logical_merge
+  // CHECK-NEXT: %logical_lhs_cond = OpLabel
+  // CHECK-NEXT: [[b:%\d+]] = OpLoad %bool %b
+  // CHECK-NEXT: OpStore [[t]] [[b]]
+  // CHECK-NEXT: OpBranch %logical_merge
+  // CHECK-NEXT: %logical_merge = OpLabel
+  // CHECK-NEXT: [[result:%\d+]] = OpLoad %bool [[t]]
+  // CHECK-NEXT: OpStore %c [[result]]
+  c = a || b;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -382,6 +382,14 @@ TEST_F(FileTest, BinaryOpLogicalOr) {
   runFileTest("binary-op.logical-or.hlsl");
 }
 
+// For short-circuited logical binary operators (HLSL 2021)
+TEST_F(FileTest, BinaryOpShortCircuitedLogicalAnd) {
+  runFileTest("binary-op.short-circuited-logical-and.hlsl");
+}
+TEST_F(FileTest, BinaryOpShortCircuitedLogicalOr) {
+  runFileTest("binary-op.short-circuited-logical-or.hlsl");
+}
+
 // For ternary operators
 TEST_F(FileTest, TernaryOpConditionalOp) {
   runFileTest("ternary-op.cond-op.hlsl");


### PR DESCRIPTION
This implements logical AND and logical OR short-circuiting, which was added with HLSL 2021.

Note: the ternary operator is also short-circuited since HLSL 2021. I will implement that in a follow-up PR.

Issue: #4141