### PR TITLE
[SPIR-V] Support arrays of RWStructuredBuffers

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -1171,6 +1171,10 @@ will be translated into
   ; Variable
   %myCbuffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_T Uniform
 
+You may create arrays of ``RWStructuredBuffer<T>``, but no associated counter
+variables will be created, and you may not use ``.IncrementCounter()`` or
+``.DecrementCounter()`` on the generated array's elements.
+
 ``AppendStructuredBuffer`` and ``ConsumeStructuredBuffer``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1679,6 +1679,17 @@ void DeclResultIdMapper::registerSpecConstant(const VarDecl *decl,
 void DeclResultIdMapper::createCounterVar(
     const DeclaratorDecl *decl, SpirvInstruction *declInstr, bool isAlias,
     const llvm::SmallVector<uint32_t, 4> *indices) {
+
+  if (const auto *varDecl = dyn_cast<VarDecl>(decl)) {
+    if (const Expr *init = varDecl->getInit()) {
+      init = init->IgnoreParenCasts();
+      if (dyn_cast<ArraySubscriptExpr>(init)) {
+        // do not create counter from array subscript
+        return;
+      }
+    }
+  }
+
   std::string counterName = "counter.var." + decl->getName().str();
   if (indices) {
     // Append field indices to the name

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1695,7 +1695,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
               loc);
   }
 
-  // Reject arrays of RW/append/consume structured buffers. They have assoicated
+  // Reject arrays of append or consume structured buffers. They have associated
   // counters, which are quite nasty to handle.
   if (decl->getType()->isArrayType()) {
     auto type = decl->getType();
@@ -1703,8 +1703,8 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
       type = type->getAsArrayTypeUnsafe()->getElementType();
     } while (type->isArrayType());
 
-    if (isRWAppendConsumeSBuffer(type)) {
-      emitError("arrays of RW/append/consume structured buffers unsupported",
+    if (isAppendStructuredBuffer(type) || isConsumeStructuredBuffer(type)) {
+      emitError("arrays of append or consume structured buffers unsupported",
                 loc);
       return;
     }
@@ -4472,7 +4472,7 @@ bool SpirvEmitter::tryToAssignCounterVar(const DeclaratorDecl *dstDecl,
           declIdMapper.createOrGetCounterIdAliasPair(dstDecl)) {
     const auto *srcPair = getFinalACSBufferCounter(srcExpr);
     if (!srcPair) {
-      emitFatalError("cannot find the associated counter variable",
+      emitWarning("cannot find the associated counter variable",
                      srcExpr->getExprLoc());
       return false;
     }

--- a/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.error.hlsl
@@ -9,4 +9,4 @@ AppendStructuredBuffer<T> myAppendStructuredBuffer[];
 
 void main() {}
 
-// CHECK: :8:27: error: arrays of RW/append/consume structured buffers unsupported
+// CHECK: :8:27: error: arrays of append or consume structured buffers unsupported

--- a/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.error.hlsl
@@ -9,4 +9,4 @@ ConsumeStructuredBuffer<T> myConsumeStructuredBuffer[2];
 
 void main() {}
 
-// CHECK: :8:28: error: arrays of RW/append/consume structured buffers unsupported
+// CHECK: :8:28: error: arrays of append or consume structured buffers unsupported

--- a/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.error.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+struct T {
+  float  a;
+  float3 b;
+};
+
+RWStructuredBuffer<T> myRWStructuredBuffer[4];
+
+void main() {
+  myRWStructuredBuffer[0].IncrementCounter();
+}
+
+// CHECK: :11:3: fatal error: cannot find the associated counter variable

--- a/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+// CHECK: %_runtimearr_v4float = OpTypeRuntimeArray %v4float
+
+// CHECK: %type_RWStructuredBuffer_v4float = OpTypeStruct %_runtimearr_v4float
+// CHECK: %_arr_type_RWStructuredBuffer_v4float_uint_8 = OpTypeArray %type_RWStructuredBuffer_v4float %uint_8
+
+// CHECK:    %MyRWSBuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_v4float_uint_8 Uniform
+RWStructuredBuffer<float4>   MyRWSBuffer[8];
+
+float4 main(uint index : INDEX) : SV_Target {
+// CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_type_RWStructuredBuffer_v4float %MyRWSBuffer {{%\d+}}
+// CHECK:                OpStore %localSBuffer [[ptr]]
+    RWStructuredBuffer<float4>   localSBuffer = MyRWSBuffer[index];
+
+// CHECK: [[ptr:%\d+]] = OpLoad %_ptr_Uniform_type_RWStructuredBuffer_v4float %localSBuffer
+// CHECK:                OpAccessChain %_ptr_Uniform_v4float [[ptr]] %int_0 {{%\d+}}
+    return localSBuffer[index];
+}

--- a/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.local.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rw-structured-buffer.array.local.error.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+struct T {
+  float  a;
+  float3 b;
+};
+
+RWStructuredBuffer<T> myRWStructuredBuffer[4];
+
+void main() {
+  RWStructuredBuffer<T> localSBuffer = myRWStructuredBuffer[0];
+  localSBuffer.IncrementCounter();
+}
+
+// CHECK: :12:3: fatal error: cannot find the associated counter variable

--- a/tools/clang/test/CodeGenSPIRV/type.structured-buffer.array.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.structured-buffer.array.error.hlsl
@@ -5,8 +5,8 @@ struct T {
   float3 b;
 };
 
-RWStructuredBuffer<T> myRWStructuredBuffer[4];
+AppendStructuredBuffer<T> myAppendStructuredBuffer[4];
 
 void main() {}
 
-// CHECK: :8:23: error: arrays of RW/append/consume structured buffers unsupported
+// CHECK: :8:27: error: arrays of append or consume structured buffers unsupported

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -135,6 +135,13 @@ TEST_F(FileTest, StructuredByteBufferArray) {
 TEST_F(FileTest, StructuredBufferArrayError) {
   runFileTest("type.structured-buffer.array.error.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, RWStructuredBufferArray) {
+  setBeforeHLSLLegalization();
+  runFileTest("type.rw-structured-buffer.array.hlsl");
+}
+TEST_F(FileTest, RWStructuredBufferArrayError) {
+  runFileTest("type.rw-structured-buffer.array.error.hlsl", Expect::Failure);
+}
 TEST_F(FileTest, AppendStructuredBufferArrayError) {
   runFileTest("type.append-structured-buffer.array.error.hlsl",
               Expect::Failure);

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -142,6 +142,10 @@ TEST_F(FileTest, RWStructuredBufferArray) {
 TEST_F(FileTest, RWStructuredBufferArrayError) {
   runFileTest("type.rw-structured-buffer.array.error.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, RWStructuredBufferArrayLocalError) {
+  runFileTest("type.rw-structured-buffer.array.local.error.hlsl",
+              Expect::Failure);
+}
 TEST_F(FileTest, AppendStructuredBufferArrayError) {
   runFileTest("type.append-structured-buffer.array.error.hlsl",
               Expect::Failure);


### PR DESCRIPTION
I'm not confident this generates the correct code in all cases, so I'd appreciate it if there are any suggestions.

Fixes #3281