### PR TITLE
Add `LLVM_OPTIMZIE_SANITIZED_BUILDS` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ endif( LLVM_USE_OPROFILE )
 
 set(LLVM_USE_SANITIZER "" CACHE STRING
   "Define the sanitizer used to build binaries and tests.")
+option(LLVM_OPTIMIZE_SANITIZED_BUILDS "Enable -O1 on sanitized builds" On)
 
 option(LLVM_USE_SPLIT_DWARF
   "Use -gsplit-dwarf when compiling llvm." OFF)

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -488,7 +488,7 @@ macro(append_common_sanitizer_flags)
     add_flag_if_supported("-gline-tables-only" GLINE_TABLES_ONLY)
   endif()
   # Use -O1 even in debug mode, otherwise sanitizers slowdown is too large.
-  if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+  if (uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" AND LLVM_OPTIMIZE_SANITIZED_BUILDS)
     add_flag_if_supported("-O1" O1)
   endif()
 endmacro()


### PR DESCRIPTION
I added this upstream a few years ago so that you can control passing `-O1` to the compiler when building debug sanitized builds. Without being able to disable optimizing sanitizer builds it is really tricky to debug sanitizer failures, but without optimizing the build ASan builds take _forever_ to run tests which makes them difficult to use.