### PR TITLE
Fix issue in HelperLaneTestWave ExecutionTest caused by assume last lane has VertexID 2.

### DIFF
--- a/tools/clang/test/HLSL/ShaderOpArith.xml
+++ b/tools/clang/test/HLSL/ShaderOpArith.xml
@@ -3261,7 +3261,12 @@
         
         PSInput VSMain(float3 pos : POSITION, uint vid:SV_VertexID) {
             HelperLaneWaveTestResult60 tr60 = RunHelperLaneWaveTests60();
-            if ( vid == 2 ) { // last lane writes results, assume only 3 vertices.
+            uint laneID = WaveGetLaneIndex();
+            uint maxLaneID = WaveActiveMax( laneID );
+            // Note: lane with vid == 2 doesn't mean it is the last lane.
+            bool hasVID2 = WaveActiveAnyTrue(vid == 2);
+            // Last lane in the wave with vid 2 writes results, assume only 3 vertices.
+            if ( hasVID2 && laneID == maxLaneID ) {
                 g_TestResults[VS_INDEX].sm60_wave = tr60;
             }
             PSInput r;
@@ -3272,7 +3277,12 @@
         PSInput VSMain65(float3 pos : POSITION, uint vid:SV_VertexID) {
             HelperLaneWaveTestResult60 tr60 = RunHelperLaneWaveTests60();
             HelperLaneWaveTestResult65 tr65 = RunHelperLaneWaveTests65();
-            if ( vid == 2 ) { // last lane writes results, assume only 3 vertices.
+            uint laneID = WaveGetLaneIndex();
+            uint maxLaneID = WaveActiveMax( laneID );
+            // Note: lane with vid == 2 doesn't mean it is the last lane.
+            bool hasVID2 = WaveActiveAnyTrue(vid == 2);
+            // Last lane in the wave with vid 2 writes results, assume only 3 vertices.
+            if ( hasVID2 && laneID == maxLaneID ) {
                 g_TestResults[VS_INDEX].sm60_wave = tr60;
                 g_TestResults[VS_INDEX].sm65_wave = tr65;
             }


### PR DESCRIPTION

Use the last lane in the wave with VertexID 2 instead of the lane with VertexID 2 when writes results.