### PR TITLE
Remove ResourceAttribute metadata node from DxilFieldAnnotation

### DIFF
--- a/include/dxc/DXIL/DxilMetadataHelper.h
+++ b/include/dxc/DXIL/DxilMetadataHelper.h
@@ -226,6 +226,7 @@ public:
   static const unsigned kDxilFieldAnnotationCompTypeTag           = 7;
   static const unsigned kDxilFieldAnnotationPreciseTag            = 8;
   static const unsigned kDxilFieldAnnotationCBUsedTag             = 9;
+  static const unsigned kDxilFieldAnnotationResPropTag            = 10;
 
   // DXR Payload Annotations
   static const unsigned kDxilPayloadAnnotationStructTag           = 0;
@@ -240,12 +241,6 @@ public:
 
   // Control flow hint.
   static const char kDxilControlFlowHintMDName[];
-
-  // Resource attribute.
-  static const char kHLDxilResourceAttributeMDName[];
-  static const unsigned kHLDxilResourceAttributeNumFields = 2;
-  static const unsigned kHLDxilResourceAttributeClass = 0;
-  static const unsigned kHLDxilResourceAttributeMeta = 1;
 
   // Precise attribute.
   static const char kDxilPreciseAttributeMDName[];
@@ -411,9 +406,6 @@ public:
   llvm::MDTuple *EmitDxilSampler(const DxilSampler &S);
   void LoadDxilSampler(const llvm::MDOperand &MDO, DxilSampler &S);
   const llvm::MDOperand &GetResourceClass(llvm::MDNode *MD, DXIL::ResourceClass &RC);
-  void LoadDxilResourceBaseFromMDNode(llvm::MDNode *MD, DxilResourceBase &R);
-  void LoadDxilResourceFromMDNode(llvm::MDNode *MD, DxilResource &R);
-  void LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S);
 
   // Type system.
   void EmitDxilTypeSystem(DxilTypeSystem &TypeSystem, std::vector<llvm::GlobalVariable *> &LLVMUsed);

--- a/include/dxc/DXIL/DxilModule.h
+++ b/include/dxc/DXIL/DxilModule.h
@@ -109,10 +109,6 @@ public:
   const DxilResource &GetUAV(unsigned idx) const;
   const std::vector<std::unique_ptr<DxilResource> > &GetUAVs() const;
 
-  void LoadDxilResourceBaseFromMDNode(llvm::MDNode *MD, DxilResourceBase &R);
-  void LoadDxilResourceFromMDNode(llvm::MDNode *MD, DxilResource &R);
-  void LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S);
-
   void RemoveUnusedResources();
   void RemoveResourcesWithUnusedSymbols();
   void RemoveFunction(llvm::Function *F);

--- a/include/dxc/DXIL/DxilTypeSystem.h
+++ b/include/dxc/DXIL/DxilTypeSystem.h
@@ -15,6 +15,7 @@
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/DXIL/DxilCompType.h"
 #include "dxc/DXIL/DxilInterpolationMode.h"
+#include "dxc/DXIL/DxilResourceProperties.h"
 
 #include <memory>
 #include <string>
@@ -54,9 +55,12 @@ public:
   const DxilMatrixAnnotation &GetMatrixAnnotation() const;
   void SetMatrixAnnotation(const DxilMatrixAnnotation &MA);
 
-  bool HasResourceAttribute() const;
-  llvm::MDNode *GetResourceAttribute() const;
-  void SetResourceAttribute(llvm::MDNode *MD);
+  // Currently, ResourceProperties is only used to capture resource type
+  // information during CodeGen for the annotate handle generated during
+  // AddOpcodeParamForIntrinsic.
+  bool HasResourceProperties() const;
+  const DxilResourceProperties &GetResourceProperties() const;
+  void SetResourceProperties(const DxilResourceProperties &RP);
 
   bool HasCBufferOffset() const;
   unsigned GetCBufferOffset() const;
@@ -86,7 +90,7 @@ private:
   bool m_bPrecise;
   CompType m_CompType;
   DxilMatrixAnnotation m_Matrix;
-  llvm::MDNode *m_ResourceAttribute;
+  DxilResourceProperties m_ResourceProps;
   unsigned m_CBufferOffset;
   std::string m_Semantic;
   InterpolationMode m_InterpMode;

--- a/include/dxc/HLSL/HLModule.h
+++ b/include/dxc/HLSL/HLModule.h
@@ -176,14 +176,7 @@ public:
   void LoadHLMetadata();
   /// Delete any HLDXIR from the specified module.
   static void ClearHLMetadata(llvm::Module &M);
-  /// Create Metadata from a resource.
-  llvm::MDNode *DxilSamplerToMDNode(const DxilSampler &S);
-  llvm::MDNode *DxilSRVToMDNode(const DxilResource &SRV);
-  llvm::MDNode *DxilUAVToMDNode(const DxilResource &UAV);
-  llvm::MDNode *DxilCBufferToMDNode(const DxilCBuffer &CB);
-  void LoadDxilResourceBaseFromMDNode(llvm::MDNode *MD, DxilResourceBase &R);
-  void LoadDxilResourceFromMDNode(llvm::MDNode *MD, DxilResource &R);
-  void LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S);
+
   DxilResourceBase *
   AddResourceWithGlobalVariableAndProps(llvm::Constant *GV,
                                         DxilResourceProperties &RP);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -916,16 +916,6 @@ const vector<unique_ptr<DxilResource> > &DxilModule::GetUAVs() const {
   return m_UAVs;
 }
 
-void DxilModule::LoadDxilResourceBaseFromMDNode(MDNode *MD, DxilResourceBase &R) {
-  return m_pMDHelper->LoadDxilResourceBaseFromMDNode(MD, R);
-}
-void DxilModule::LoadDxilResourceFromMDNode(llvm::MDNode *MD, DxilResource &R) {
-  return m_pMDHelper->LoadDxilResourceFromMDNode(MD, R);
-}
-void DxilModule::LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S) {
-  return m_pMDHelper->LoadDxilSamplerFromMDNode(MD, S);
-}
-
 template <typename TResource>
 static void RemoveResources(std::vector<std::unique_ptr<TResource>> &vec,
                     std::unordered_set<unsigned> &immResID) {

--- a/lib/DXIL/DxilTypeSystem.cpp
+++ b/lib/DXIL/DxilTypeSystem.cpp
@@ -43,7 +43,6 @@ DxilMatrixAnnotation::DxilMatrixAnnotation()
 //
 DxilFieldAnnotation::DxilFieldAnnotation()
 : m_bPrecise(false)
-, m_ResourceAttribute(nullptr)
 , m_CBufferOffset(UINT_MAX)
 , m_bCBufferVarUsed(false)
 {}
@@ -53,14 +52,14 @@ void DxilFieldAnnotation::SetPrecise(bool b) { m_bPrecise = b; }
 bool DxilFieldAnnotation::HasMatrixAnnotation() const { return m_Matrix.Cols != 0; }
 const DxilMatrixAnnotation &DxilFieldAnnotation::GetMatrixAnnotation() const { return m_Matrix; }
 void DxilFieldAnnotation::SetMatrixAnnotation(const DxilMatrixAnnotation &MA) { m_Matrix = MA; }
-bool DxilFieldAnnotation::HasResourceAttribute() const {
-  return m_ResourceAttribute;
+bool DxilFieldAnnotation::HasResourceProperties() const {
+  return m_ResourceProps.isValid();
 }
-llvm::MDNode *DxilFieldAnnotation::GetResourceAttribute() const {
-  return m_ResourceAttribute;
+const DxilResourceProperties &DxilFieldAnnotation::GetResourceProperties() const {
+  return m_ResourceProps;
 }
-void DxilFieldAnnotation::SetResourceAttribute(llvm::MDNode *MD) {
-  m_ResourceAttribute = MD;
+void DxilFieldAnnotation::SetResourceProperties(const DxilResourceProperties &RP) {
+  m_ResourceProps = RP;
 }
 bool DxilFieldAnnotation::HasCBufferOffset() const { return m_CBufferOffset != UINT_MAX; }
 unsigned DxilFieldAnnotation::GetCBufferOffset() const { return m_CBufferOffset; }

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -664,45 +664,6 @@ void HLModule::LoadHLShaderProperties(const MDOperand &MDO) {
   return;
 }
 
-MDNode *HLModule::DxilSamplerToMDNode(const DxilSampler &S) {
-  MDNode *MD = m_pMDHelper->EmitDxilSampler(S);
-  ValueAsMetadata *ResClass =
-      m_pMDHelper->Uint32ToConstMD((unsigned)DXIL::ResourceClass::Sampler);
-
-  return MDNode::get(m_Ctx, {ResClass, MD});
-}
-MDNode *HLModule::DxilSRVToMDNode(const DxilResource &SRV) {
-  MDNode *MD = m_pMDHelper->EmitDxilSRV(SRV);
-  ValueAsMetadata *ResClass =
-      m_pMDHelper->Uint32ToConstMD((unsigned)DXIL::ResourceClass::SRV);
-
-  return MDNode::get(m_Ctx, {ResClass, MD});
-}
-MDNode *HLModule::DxilUAVToMDNode(const DxilResource &UAV) {
-  MDNode *MD = m_pMDHelper->EmitDxilUAV(UAV);
-  ValueAsMetadata *ResClass =
-      m_pMDHelper->Uint32ToConstMD((unsigned)DXIL::ResourceClass::UAV);
-
-  return MDNode::get(m_Ctx, {ResClass, MD});
-}
-MDNode *HLModule::DxilCBufferToMDNode(const DxilCBuffer &CB) {
-  MDNode *MD = m_pMDHelper->EmitDxilCBuffer(CB);
-  ValueAsMetadata *ResClass =
-      m_pMDHelper->Uint32ToConstMD((unsigned)DXIL::ResourceClass::CBuffer);
-
-  return MDNode::get(m_Ctx, {ResClass, MD});
-}
-
-void HLModule::LoadDxilResourceBaseFromMDNode(MDNode *MD, DxilResourceBase &R) {
-  return m_pMDHelper->LoadDxilResourceBaseFromMDNode(MD, R);
-}
-void HLModule::LoadDxilResourceFromMDNode(llvm::MDNode *MD, DxilResource &R) {
-  return m_pMDHelper->LoadDxilResourceFromMDNode(MD, R);
-}
-void HLModule::LoadDxilSamplerFromMDNode(llvm::MDNode *MD, DxilSampler &S) {
-  return m_pMDHelper->LoadDxilSamplerFromMDNode(MD, S);
-}
-
 DxilResourceBase *
 HLModule::AddResourceWithGlobalVariableAndProps(llvm::Constant *GV,
                                                  DxilResourceProperties &RP) {

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -5268,7 +5268,7 @@ void SROA_Parameter_HLSL::flattenArgument(
       flatParamAnnotation.SetCompType(annotation.GetCompType().GetKind());
       flatParamAnnotation.SetMatrixAnnotation(annotation.GetMatrixAnnotation());
       flatParamAnnotation.SetPrecise(annotation.IsPrecise());
-      flatParamAnnotation.SetResourceAttribute(annotation.GetResourceAttribute());
+      flatParamAnnotation.SetResourceProperties(annotation.GetResourceProperties());
 
       // Add debug info.
       if (DDIs.size() && V != Arg) {

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -648,26 +648,8 @@ DxilResourceProperties GetResourcePropsFromIntrinsicObjectArg(
           cast<ConstantInt>(gepIt.getOperand())->getLimitedValue();
 
       DxilFieldAnnotation &fieldAnno = Anno->GetFieldAnnotation(Index);
-      if (fieldAnno.HasResourceAttribute()) {
-        MDNode *resAttrib = fieldAnno.GetResourceAttribute();
-        DxilResourceBase R(DXIL::ResourceClass::Invalid);
-        HLM.LoadDxilResourceBaseFromMDNode(resAttrib, R);
-        switch (R.GetClass()) {
-        case DXIL::ResourceClass::SRV:
-        case DXIL::ResourceClass::UAV: {
-          DxilResource Res;
-          HLM.LoadDxilResourceFromMDNode(resAttrib, Res);
-          RP = resource_helper::loadPropsFromResourceBase(&Res);
-        } break;
-        case DXIL::ResourceClass::Sampler: {
-          DxilSampler Sampler;
-          HLM.LoadDxilSamplerFromMDNode(resAttrib, Sampler);
-          RP = resource_helper::loadPropsFromResourceBase(&Sampler);
-        } break;
-        default:
-          DXASSERT(0, "invalid resource attribute in filed annotation");
-          break;
-        }
+      if (fieldAnno.HasResourceProperties()) {
+        RP = fieldAnno.GetResourceProperties();
         break;
       }
     }

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource-in-struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource-in-struct.hlsl
@@ -1,5 +1,5 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
-// RUN: %dxc -T lib_6_7 %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKNORP
+// RUN: %dxc -T lib_6_7 -validator-version 1.7 %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKNORP
 // RUN: %dxc -T lib_6_8 %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKRP
 // RUN: %dxc -T lib_6_x %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKRP
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource-in-struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource-in-struct.hlsl
@@ -1,6 +1,19 @@
 // RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
+// RUN: %dxc -T lib_6_7 %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKNORP
+// RUN: %dxc -T lib_6_8 %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKRP
+// RUN: %dxc -T lib_6_x %s  | FileCheck %s -check-prefixes=CHECKTYPE,CHECKRP
 
 // CHECK: res.Tex1
+
+// Make sure ResourceProperties are emitted.
+// CHECKTYPE: !dx.typeAnnotations = !{![[TyAnn:[0-9]+]]
+// CHECKTYPE: ![[TyAnn]] =
+// CHECKTYPE-SAME: %struct.Resources undef, ![[Resources_Ann:[0-9]+]],
+// CHECKTYPE: ![[Resources_Ann]] = !{i32 16, ![[Tex1_Ann:[0-9]+]],
+// CHECKRP: ![[Tex1_Ann]] = !{i32 6, !"Tex1",
+// CHECKRP-SAME: i32 10, %dx.types.ResourceProperties { i32 2, i32 1033 }
+// CHECKNORP: ![[Tex1_Ann]] = !{i32 6, !"Tex1",
+// CHECKNORP-NOT: %dx.types.ResourceProperties
 
 SamplerState Samp;
 struct Resources


### PR DESCRIPTION
Currently, ResourceAttribute is only used to capture resource type information during CodeGen for the annotate handle generated during AddOpcodeParamForIntrinsic.

Going through a metadata node is totally unnecessary, just adding code and complexity.

This change just stores the DxilResourceProperties instead, renaming `*ResourceAttribute` methods to `*ResourceProperties`.
This change also emits the resource properties to new field annotaion metadata in validator version 1.8+ to preserve through serialization.