### PR TITLE
Fix ShaderModel::Get() when entry does not exist in hashToIdxMap

### DIFF
--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -171,7 +171,7 @@ const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
   unsigned hash = (unsigned)Kind << 16 | Major << 8 | Minor;
   auto pred = [](const std::pair<unsigned, unsigned>& elem, unsigned val){ return elem.first < val;};
   auto it = std::lower_bound(std::begin(hashToIdxMap), std::end(hashToIdxMap), hash, pred);
-  if (it == std::end(hashToIdxMap))
+  if (it == std::end(hashToIdxMap) || it->first != hash)
     return GetInvalid();
   return &ms_ShaderModels[it->second];
   // VALRULE-TEXT:END

--- a/utils/hct/hctdb_instrhelp.py
+++ b/utils/hct/hctdb_instrhelp.py
@@ -1391,7 +1391,7 @@ def get_shader_model_get():
     result += "unsigned hash = (unsigned)Kind << 16 | Major << 8 | Minor;\n"
     result += "auto pred = [](const std::pair<unsigned, unsigned>& elem, unsigned val){ return elem.first < val;};\n"
     result += "auto it = std::lower_bound(std::begin(hashToIdxMap), std::end(hashToIdxMap), hash, pred);\n"
-    result += "if (it == std::end(hashToIdxMap))\n"
+    result += "if (it == std::end(hashToIdxMap) || it->first != hash)\n"
     result += "  return GetInvalid();\n"
     result += "return &ms_ShaderModels[it->second];"
     return result


### PR DESCRIPTION
Fixes a bug introduced in commit 8b8956f82be592ed774ee8c59980d6336a67bff0 (cc @pow2clk)