### PR TITLE
Add RDAT::RecordTraits::MaxRecordSize to default to newest version

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -268,6 +268,8 @@ public:
   }
   // RecordSize() is defined in order to allow for use of forward decl type in RecordRef
   static constexpr size_t RecordSize() { /*static_assert(false, "");*/ return sizeof(_T); }
+  static constexpr size_t MaxRecordSize() { return RecordTraits<_T>::DerivedRecordSize(); }
+  static constexpr size_t DerivedRecordSize() { return sizeof(_T); }
 };
 
 ///////////////////////////////////////

--- a/include/dxc/DxilContainer/RDAT_Macros.inl
+++ b/include/dxc/DxilContainer/RDAT_Macros.inl
@@ -220,7 +220,8 @@
   #define RDAT_STRUCT_TABLE_DERIVED(type, base, table) \
     RDAT_STRUCT_DERIVED(type, base) \
     template<> constexpr RecordTableIndex RecordTraits<type>::TableIndex() { return RecordTableIndex::table; } \
-    template<> constexpr RuntimeDataPartType RecordTraits<type>::PartType() { return RuntimeDataPartType::table; }
+    template<> constexpr RuntimeDataPartType RecordTraits<type>::PartType() { return RuntimeDataPartType::table; } \
+    template<> constexpr size_t RecordTraits<base>::DerivedRecordSize() { return RecordTraits<type>::MaxRecordSize(); }
 #endif // DEF_RDAT_TYPES cases
 
 // Define any undefined macros to defaults

--- a/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
+++ b/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
@@ -47,7 +47,7 @@ public:
     if (!*tablePtr) {
       m_Parts.emplace_back(llvm::make_unique<RDATTable>());
       *tablePtr = reinterpret_cast<RDATTable *>(m_Parts.back().get());
-      (*tablePtr)->SetRecordStride(sizeof(T));
+      (*tablePtr)->SetRecordStride(RecordTraits<T>::MaxRecordSize());
       (*tablePtr)->SetType(RDAT::RecordTraits<T>::PartType());
       (*tablePtr)->SetDeduplication(m_bRecordDeduplicationEnabled);
     }

--- a/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
+++ b/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
@@ -47,7 +47,7 @@ public:
     if (!*tablePtr) {
       m_Parts.emplace_back(llvm::make_unique<RDATTable>());
       *tablePtr = reinterpret_cast<RDATTable *>(m_Parts.back().get());
-      (*tablePtr)->SetRecordStride(RecordTraits<T>::MaxRecordSize());
+      (*tablePtr)->SetRecordStride(RDAT::RecordTraits<T>::MaxRecordSize());
       (*tablePtr)->SetType(RDAT::RecordTraits<T>::PartType());
       (*tablePtr)->SetDeduplication(m_bRecordDeduplicationEnabled);
     }


### PR DESCRIPTION
Added MaxRecordSize calling DerivedRecordSize that gets specialized for each base in RDAT_STRUCT_TABLE_DERIVED macro to call the derived MaxRecordStride.  The most-derived version of DerivedRecordSize will use the default implementation, which is the size of that type.