### PR TITLE
RDAT: Revert default to MaxRecordSize for tables

### DIFF
--- a/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
+++ b/include/dxc/DxilRDATBuilder/DxilRDATBuilder.h
@@ -47,7 +47,7 @@ public:
     if (!*tablePtr) {
       m_Parts.emplace_back(llvm::make_unique<RDATTable>());
       *tablePtr = reinterpret_cast<RDATTable *>(m_Parts.back().get());
-      (*tablePtr)->SetRecordStride(RDAT::RecordTraits<T>::MaxRecordSize());
+      (*tablePtr)->SetRecordStride(sizeof(T));
       (*tablePtr)->SetType(RDAT::RecordTraits<T>::PartType());
       (*tablePtr)->SetDeduplication(m_bRecordDeduplicationEnabled);
     }


### PR DESCRIPTION
On second thought, it's safer to default to the initial version, letting code that writes to RDAT set strides for newer record versions it actually uses, rather than breaking RDAT writing code at runtime when versioned updates are added to the structures.