### PR TITLE
Remove arbitrary run line length limit

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -216,22 +216,15 @@ inline std::vector<std::string> GetRunLines(const LPCWSTR name) {
 
   std::vector<std::string> runlines;
   std::string line;
-  constexpr size_t runlinesize = 300;
   while (std::getline(infile, line)) {
     if (!HasRunLine(line))
       continue;
-    char runline[runlinesize];
-    memset(runline, 0, runlinesize);
-    memcpy(runline, line.c_str(), min(runlinesize, line.size()));
-    runlines.emplace_back(runline);
+    runlines.emplace_back(line);
   }
   return runlines;
 }
 
 inline std::string GetFirstLine(LPCWSTR name) {
-  char firstLine[300];
-  memset(firstLine, 0, sizeof(firstLine));
-
   const std::wstring path = PathLooksAbsolute(name)
                                 ? std::wstring(name)
                                 : hlsl_test::GetPathToHlslDataFile(name);
@@ -247,8 +240,9 @@ inline std::string GetFirstLine(LPCWSTR name) {
     VERIFY_FAIL();
   }
 
-  infile.getline(firstLine, _countof(firstLine));
-  return firstLine;
+  std::string line;
+  std::getline(infile, line);
+  return line;
 }
 
 inline HANDLE CreateFileForReading(LPCWSTR path) {


### PR DESCRIPTION
A very strange sequence of copying the run line to a stack char array of size 300, where it would not even null-terminate the line if it hit the limit, seems totally unnecessary, since it's dealing with std::strings in the first place.
This would truncate and pick up garbage from the stack in the stored run line when length >= 300 characters - causing the test to fail, of course. Perhaps some of this is an artifact of some older version of the code.

In any case, this change removes the extra copying step and simply uses the entire std::string result from std::getline() instead.