### PR TITLE
Pull ReplaceDisassemblyText out of DXCTestUtils.cpp

### DIFF
--- a/include/dxc/DxilContainer/DxilContainer.h
+++ b/include/dxc/DxilContainer/DxilContainer.h
@@ -20,7 +20,6 @@
 #include "dxc/Support/WinAdapter.h"
 
 struct IDxcContainerReflection;
-// namespace llvm { class Module; }
 
 namespace hlsl {
 

--- a/include/dxc/DxilContainer/DxilContainer.h
+++ b/include/dxc/DxilContainer/DxilContainer.h
@@ -20,7 +20,7 @@
 #include "dxc/Support/WinAdapter.h"
 
 struct IDxcContainerReflection;
-namespace llvm { class Module; }
+// namespace llvm { class Module; }
 
 namespace hlsl {
 

--- a/include/dxc/DxilContainer/DxilContainer.h
+++ b/include/dxc/DxilContainer/DxilContainer.h
@@ -23,10 +23,6 @@ struct IDxcContainerReflection;
 
 namespace hlsl {
 
-class AbstractMemoryStream;
-class RootSignatureHandle;
-class DxilModule;
-
 #pragma pack(push, 1)
 
 static const size_t DxilContainerHashSize = 16;

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -175,6 +175,17 @@ std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgra
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
+                            llvm::ArrayRef<LPCSTR> pReplacements, bool bRegex,
+                            std::string &disassembly);
+void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
+                            llvm::ArrayRef<LPCSTR> pReplacements,
+                            _Outptr_ IDxcBlob **pBlob, bool bRegex,
+                            std::string &disassembly,
+                            dxc::DxcDllSupport &dllSupport);
+void ReplaceDisassemblyTextWithRegex(llvm::ArrayRef<LPCSTR> pLookFors,
+                                     llvm::ArrayRef<LPCSTR> pReplacements,
+                                     std::string &disassembly);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);

--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -175,10 +175,6 @@ std::string DisassembleProgram(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgra
 void SplitPassList(LPWSTR pPassesBuffer, std::vector<LPCWSTR> &passes);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlob **ppBlob);
 void MultiByteStringToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, UINT32 codePoint, _Outptr_ IDxcBlobEncoding **ppBlob);
-void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
-                            bool bRegex, std::string& disassembly);
-void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors, llvm::ArrayRef<LPCSTR> pReplacements,
-                           _Outptr_ IDxcBlob **pBlob, bool bRegex, std::string& disassembly, dxc::DxcDllSupport &dllSupport);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlob **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const std::string &val, _Outptr_ IDxcBlobEncoding **ppBlob);
 void Utf8ToBlob(dxc::DxcDllSupport &dllSupport, const char *pVal, _Outptr_ IDxcBlobEncoding **ppBlob);

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -12,7 +12,6 @@
 #include <sstream>
 #include <fstream>
 #include <atomic>
-#include <regex>
 #include <cmath>
 #include <vector>
 #include <algorithm>

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -519,8 +519,8 @@ inline bool CompareHalfEpsilon(const uint16_t &fsrc, const uint16_t &fref, float
 }
 
 
-inline void ReplaceDisassemblyTextWithoutRegex(std::vector<std::string> pLookFors,
-                            std::vector<std::string> pReplacements,
+inline void ReplaceDisassemblyTextWithoutRegex(std::vector<std::string> &pLookFors,
+                            std::vector<std::string> &pReplacements,
                             std::string &disassembly) {
   for (unsigned i = 0; i < pLookFors.size(); ++i) {
     LPCSTR pLookFor = pLookFors[i].data();

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11356,7 +11356,7 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     dxc::DxcDllSupport &dllSupport) {
   
   auto ShaderInitFn = 
-      [dxcArgs, &lookFors, &replacements, &dllSupport]
+      [dxcArgs, lookFors, replacements, &dllSupport]
       (LPCSTR Name, LPCSTR pText, IDxcBlob **ppShaderBlob, st::ShaderOp *pShaderOp) {
     
     UNREFERENCED_PARAMETER(pShaderOp);

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11351,9 +11351,8 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 
 // Copies input strings to local storage, so it doesn't rely on lifetime of input string pointers.
 st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
-    llvm::ArrayRef<LPCWSTR> dxcArgs,
-    llvm::ArrayRef<LPCSTR> LookFors,
-    llvm::ArrayRef<LPCSTR> Replacements,
+    std::vector<std::wstring> dxcArgs, std::vector<std::string> LookFors,
+    std::vector<std::string> Replacements,
     dxc::DxcDllSupport &dllSupport) {
   // place ArrayRef arguments in std::vector locals, and copy them by value into the callback function lambda
   std::vector<std::wstring> ArgsStorage(dxcArgs.size());
@@ -11389,10 +11388,9 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     VerifyCompileOK(dllSupport, pText, L"cs_6_0", Args, &compiledShader);
     std::string disassembly = DisassembleProgram(dllSupport, compiledShader);
     // Replace op
-    ReplaceDisassemblyText(
+    ReplaceDisassemblyTextWithoutRegex(
       LookFors,
-      Replacements,
-      /*bRegex*/false,
+      Replacements,      
       disassembly
     );
     // Wrap text in UTF8 blob

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11354,32 +11354,17 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     std::vector<std::wstring> dxcArgs, std::vector<std::string> LookFors,
     std::vector<std::string> Replacements,
     dxc::DxcDllSupport &dllSupport) {
-  // place ArrayRef arguments in std::vector locals, and copy them by value into the callback function lambda
-  std::vector<std::wstring> ArgsStorage(dxcArgs.size());
-    for (unsigned i = 0; i < dxcArgs.size(); ++i)
-      ArgsStorage[i] = dxcArgs[i];
-  std::vector<std::string> LookForsStorage(LookFors.size());
-    for (unsigned i = 0; i < LookFors.size(); ++i)
-      LookForsStorage[i] = LookFors[i];
-  std::vector<std::string> ReplacementsStorage(Replacements.size());
-    for (unsigned i = 0; i < Replacements.size(); ++i)
-      ReplacementsStorage[i] = Replacements[i];
+  
   auto ShaderInitFn = 
-      [ArgsStorage, LookForsStorage, ReplacementsStorage, &dllSupport]
+      [dxcArgs, &LookFors, &Replacements, &dllSupport]
       (LPCSTR Name, LPCSTR pText, IDxcBlob **ppShaderBlob, st::ShaderOp *pShaderOp) {
     
     UNREFERENCED_PARAMETER(pShaderOp);
     UNREFERENCED_PARAMETER(Name);
     // Create pointer vectors from local storage to supply API needs
-    std::vector<LPCWSTR> Args(ArgsStorage.size());
-    for (unsigned i = 0; i < ArgsStorage.size(); ++i)
-      Args[i] = ArgsStorage[i].c_str();
-    std::vector<std::string> LookFors(LookForsStorage.size());
-    for (unsigned i = 0; i < LookForsStorage.size(); ++i)
-      LookFors[i] = LookForsStorage[i];
-    std::vector<std::string> Replacements(ReplacementsStorage.size());
-    for (unsigned i = 0; i < ReplacementsStorage.size(); ++i)
-      Replacements[i] = ReplacementsStorage[i];
+    std::vector<LPCWSTR> Args(dxcArgs.size());
+    for (unsigned i = 0; i < dxcArgs.size(); ++i)
+      Args[i] = dxcArgs[i].c_str();    
 
     CComPtr<IDxcUtils> pUtils;
     VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcUtils, &pUtils));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11375,12 +11375,12 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     std::vector<LPCWSTR> Args(ArgsStorage.size());
     for (unsigned i = 0; i < ArgsStorage.size(); ++i)
       Args[i] = ArgsStorage[i].c_str();
-    std::vector<LPCSTR> LookFors(LookForsStorage.size());
+    std::vector<std::string> LookFors(LookForsStorage.size());
     for (unsigned i = 0; i < LookForsStorage.size(); ++i)
-      LookFors[i] = LookForsStorage[i].c_str();
-    std::vector<LPCSTR> Replacements(ReplacementsStorage.size());
+      LookFors[i] = LookForsStorage[i];
+    std::vector<std::string> Replacements(ReplacementsStorage.size());
     for (unsigned i = 0; i < ReplacementsStorage.size(); ++i)
-      Replacements[i] = ReplacementsStorage[i].c_str();
+      Replacements[i] = ReplacementsStorage[i];
 
     CComPtr<IDxcUtils> pUtils;
     VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcUtils, &pUtils));

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11351,12 +11351,12 @@ TEST_F(ExecutionTest, QuadAnyAll) {
 
 // Copies input strings to local storage, so it doesn't rely on lifetime of input string pointers.
 st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
-    std::vector<std::wstring> dxcArgs, std::vector<std::string> LookFors,
-    std::vector<std::string> Replacements,
+    std::vector<std::wstring> dxcArgs, std::vector<std::string> lookFors,
+    std::vector<std::string> replacements,
     dxc::DxcDllSupport &dllSupport) {
   
   auto ShaderInitFn = 
-      [dxcArgs, &LookFors, &Replacements, &dllSupport]
+      [dxcArgs, &lookFors, &replacements, &dllSupport]
       (LPCSTR Name, LPCSTR pText, IDxcBlob **ppShaderBlob, st::ShaderOp *pShaderOp) {
     
     UNREFERENCED_PARAMETER(pShaderOp);
@@ -11373,9 +11373,7 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     VerifyCompileOK(dllSupport, pText, L"cs_6_0", Args, &compiledShader);
     std::string disassembly = DisassembleProgram(dllSupport, compiledShader);
     // Replace op
-    ReplaceDisassemblyTextWithoutRegex(
-      LookFors,
-      Replacements,      
+    ReplaceDisassemblyTextWithoutRegex(lookFors, replacements,      
       disassembly
     );
     // Wrap text in UTF8 blob

--- a/tools/clang/unittests/HLSL/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExecutionTest.cpp
@@ -11376,6 +11376,7 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     ReplaceDisassemblyTextWithoutRegex(lookFors, replacements,      
       disassembly
     );
+
     // Wrap text in UTF8 blob
     // No need to copy, disassembly won't be changed again and will live as long as rewrittenDisassembly.
     // c_str() guarantees null termination; passing size + 1 to include it will create an IDxcBlobUtf8 without copying.

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -414,9 +414,9 @@ public:
     if (!CompileSource(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, &pProgram))
       return false;
 
-    DisassembleProgram(pProgram, &disassembly);  
-    ReplaceDisassemblyText(pLookFors, pReplacements,
-                           bRegex, disassembly);
+    DisassembleProgram(pProgram, &disassembly);
+
+    ReplaceDisassemblyText(pLookFors, pReplacements, bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);
     
     CComPtr<IDxcAssembler> pAssembler;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -415,7 +415,6 @@ public:
       return false;
 
     DisassembleProgram(pProgram, &disassembly);  
-
     ReplaceDisassemblyText(pLookFors, pReplacements,
                            bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -400,16 +400,6 @@ public:
     *text = ::DisassembleProgram(m_dllSupport, pProgram);
   }
 
-  std::vector<std::string> ConvertLLVMStringArrayToStringVector(llvm::ArrayRef<LPCSTR> a) {
-    std::vector<std::string> ret;
-    for (int i = 0; i < a.size(); i++) {
-      const char *pStr = a[i];
-      std::string s(pStr);
-      ret.push_back(s);
-    }
-    return ret;
-  }
-
   bool RewriteAssemblyCheckMsg(IDxcBlobEncoding *pSource, LPCSTR pShaderModel,
     LPCWSTR *pArguments, UINT32 argCount,
     const DxcDefine *pDefines, UINT32 defineCount,
@@ -424,13 +414,9 @@ public:
     if (!CompileSource(pSource, pShaderModel, pArguments, argCount, pDefines, defineCount, &pProgram))
       return false;
 
-    DisassembleProgram(pProgram, &disassembly);
-    std::vector<std::string> pLookForStrs =
-        ConvertLLVMStringArrayToStringVector(pLookFors);
-    std::vector<std::string> pReplacementsStrs =
-        ConvertLLVMStringArrayToStringVector(pReplacements);    
+    DisassembleProgram(pProgram, &disassembly);  
 
-    ReplaceDisassemblyText(pLookForStrs, pReplacementsStrs,
+    ReplaceDisassemblyText(pLookFors, pReplacements,
                            bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);
     
@@ -1107,8 +1093,8 @@ TEST_F(ValidationTest, SignatureDataWidth) {
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\signature_packing_by_width.hlsl", "ps_6_2",
       pArguments.data(), 3, nullptr, 0,
-      {"i8 8, i8 0, (![0-9]+), i8 2, i32 1, i8 2, i32 0, i8 0, null\\}"},
-      {"i8 9, i8 0, $1, i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
+      {"i8 8, i8 0, (![0-9]+), i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
+      {"i8 9, i8 0, \\1, i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
       "signature element F at location \\(0, 2\\) size \\(1, 2\\) has data "
       "width that differs from another element packed into the same row.",
       true);

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -400,6 +400,16 @@ public:
     *text = ::DisassembleProgram(m_dllSupport, pProgram);
   }
 
+  std::vector<std::string> ConvertLLVMStringArrayToStringVector(llvm::ArrayRef<LPCSTR> a) {
+    std::vector<std::string> ret;
+    for (int i = 0; i < a.size(); i++) {
+      const char *pStr = a[i];
+      std::string s(pStr);
+      ret.push_back(s);
+    }
+    return ret;
+  }
+
   bool RewriteAssemblyCheckMsg(IDxcBlobEncoding *pSource, LPCSTR pShaderModel,
     LPCWSTR *pArguments, UINT32 argCount,
     const DxcDefine *pDefines, UINT32 defineCount,
@@ -415,8 +425,13 @@ public:
       return false;
 
     DisassembleProgram(pProgram, &disassembly);
+    std::vector<std::string> pLookForStrs =
+        ConvertLLVMStringArrayToStringVector(pLookFors);
+    std::vector<std::string> pReplacementsStrs =
+        ConvertLLVMStringArrayToStringVector(pReplacements);    
 
-    ReplaceDisassemblyText(pLookFors, pReplacements, bRegex, disassembly);
+    ReplaceDisassemblyText(pLookForStrs, pReplacementsStrs,
+                           bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);
     
     CComPtr<IDxcAssembler> pAssembler;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -415,6 +415,7 @@ public:
       return false;
 
     DisassembleProgram(pProgram, &disassembly);  
+
     ReplaceDisassemblyText(pLookFors, pReplacements,
                            bRegex, disassembly);
     Utf8ToBlob(m_dllSupport, disassembly.c_str(), &pText);

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1107,8 +1107,8 @@ TEST_F(ValidationTest, SignatureDataWidth) {
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\signature_packing_by_width.hlsl", "ps_6_2",
       pArguments.data(), 3, nullptr, 0,
-      {"i8 8, i8 0, (![0-9]+), i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
-      {"i8 9, i8 0, \\1, i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
+      {"i8 8, i8 0, (![0-9]+), i8 2, i32 1, i8 2, i32 0, i8 0, null\\}"},
+      {"i8 9, i8 0, $1, i8 2, i32 1, i8 2, i32 0, i8 0, null}"},
       "signature element F at location \\(0, 2\\) size \\(1, 2\\) has data "
       "width that differs from another element packed into the same row.",
       true);

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -233,14 +233,13 @@ void ReplaceDisassemblyTextWithRegex(llvm::ArrayRef<LPCSTR> pLookFors,
   }
 }
 
-std::vector<std::string> ConvertLLVMStringArrayToStringVector(llvm::ArrayRef<LPCSTR> a) {
-  std::vector<std::string> ret;
+void ConvertLLVMStringArrayToStringVector(llvm::ArrayRef<LPCSTR> a,
+                                          std::vector<std::string> &ret) {
+  ret.clear();
+  ret.reserve(a.size());
   for (int i = 0; i < a.size(); i++) {
-    const char *pStr = a[i];
-    std::string s(pStr);
-    ret.push_back(s);
+    ret.emplace_back(a[i]);
   }
-  return ret;
 }
 
 void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
@@ -250,10 +249,10 @@ void ReplaceDisassemblyText(llvm::ArrayRef<LPCSTR> pLookFors,
     ReplaceDisassemblyTextWithRegex(pLookFors, pReplacements, disassembly);
   } 
   else {
-    std::vector<std::string> pLookForStrs =
-        ConvertLLVMStringArrayToStringVector(pLookFors);
-    std::vector<std::string> pReplacementsStrs =
-        ConvertLLVMStringArrayToStringVector(pReplacements); 
+    std::vector<std::string> pLookForStrs;
+    ConvertLLVMStringArrayToStringVector(pLookFors, pLookForStrs);
+    std::vector<std::string> pReplacementsStrs;
+    ConvertLLVMStringArrayToStringVector(pReplacements, pReplacementsStrs); 
     ReplaceDisassemblyTextWithoutRegex(pLookForStrs, pReplacementsStrs,
                                        disassembly);
   }

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -237,7 +237,7 @@ void ConvertLLVMStringArrayToStringVector(llvm::ArrayRef<LPCSTR> a,
                                           std::vector<std::string> &ret) {
   ret.clear();
   ret.reserve(a.size());
-  for (int i = 0; i < a.size(); i++) {
+  for (unsigned int i = 0; i < a.size(); i++) {
     ret.emplace_back(a[i]);
   }
 }


### PR DESCRIPTION
The IsNormal HLK test depends on a function called ReplaceShaderText.cpp.
As it is currently defined, the function takes a dependency on llvm for regex usage.
This dependency prevents successful builds when copied over to another repo.
IsNormal depends on other functions with bad dependencies, so this is the first of several PRs to get IsNormal 
to a state in which it only depends on what is available in the other repo. 
This PR divides ReplaceDisassemblyText  (RDT) into 3 functions, RDT, RDTWithoutRegex, and RDTWithRegex.
RDT will call the other 2 functions depending on whether the caller specified that any of the LookFor strings contain a regex, with the boolean parameter passed to RDT.
Because RDTWithoutRegex will be defined in HLSLTestUtils.h, it will be available in the other repo without any llvm dependencies.
RDTWithRegex will still use the llvm regex library, and this should eventually be switched to use std::regex.
