### PR TITLE
[HLSL2021] Disallow bitfields and annotations

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7457,6 +7457,8 @@ def err_hlsl_attribute_valid_on_function_only: Error<
   "attribute is valid only on functions">;
 def err_hlsl_bitfields: Error<
   "bitfields are not supported in HLSL">;
+def err_hlsl_bitfields_with_annotation: Error<
+  "bitfields are not allowed with HLSL annotations">;
 def err_hlsl_cannot_convert: Error<
   "cannot %select{implicitly |}0convert %select{|output parameter }1from %2 to %3">;
 def err_hlsl_half_load_store: Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -13359,9 +13359,15 @@ bool Sema::DiagnoseHLSLDecl(Declarator &D, DeclContext *DC, Expr *BitWidth,
   // SPIRV change ends
 
   // Disallow bitfields where not enabled explicitly or by HV
-  if (BitWidth && !getLangOpts().EnableBitfields) {
-    Diag(BitWidth->getExprLoc(), diag::err_hlsl_bitfields);
-    result = false;
+  if (BitWidth) {
+    if (!getLangOpts().EnableBitfields) {
+      Diag(BitWidth->getExprLoc(), diag::err_hlsl_bitfields);
+      result = false;
+    } else if (!D.UnusualAnnotations.empty()) {
+      Diag(BitWidth->getExprLoc(),
+           diag::err_hlsl_bitfields_with_annotation);
+      result = false;
+    }
   }
 
   // Validate unusual annotations.

--- a/tools/clang/test/HLSL/bitfields-and-annotations.hlsl
+++ b/tools/clang/test/HLSL/bitfields-and-annotations.hlsl
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -fsyntax-only -HV 2021 -verify %s
+
+struct [raypayload] Payload {
+    int a : 1            : write(caller) : read(anyhit); // expected-error {{bitfields are not allowed with HLSL annotations}}
+    int b : 17           : write(miss)   : read(caller); // expected-error {{bitfields are not allowed with HLSL annotations}}
+    int c  : write(miss) : 13            : read(caller); // expected-error {{bitfields are not allowed with HLSL annotations}}
+    int d  : write(miss) : read(caller);
+};
+
+struct Inputs {
+    int a : 16 : SV_GroupIndex; // expected-error {{bitfields are not allowed with HLSL annotations}}
+    int b : SV_Position : 16;  // expected-error {{bitfields are not allowed with HLSL annotations}}
+};

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -100,6 +100,7 @@ public:
   TEST_METHOD(RunWriteConstArrays)
   TEST_METHOD(RunAtomicsOnBitfields)
   TEST_METHOD(RunUnboundedResourceArrays)
+  TEST_METHOD(RunBitFieldAnnotations)
   void CheckVerifies(const wchar_t* path) {
     WEX::TestExecution::SetVerifyOutput verifySettings(WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
     const char startMarker[] = "%clang_cc1";

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -433,3 +433,7 @@ TEST_F(VerifierTest, RunAtomicsOnBitfields) {
 TEST_F(VerifierTest, RunUnboundedResourceArrays) {
   CheckVerifiesHLSL(L"invalid-unbounded-resource-arrays.hlsl");
 }
+
+TEST_F(VerifierTest, RunBitFieldAnnotations) {
+  CheckVerifiesHLSL(L"bitfields-and-annotations.hlsl");
+}


### PR DESCRIPTION
This change makes mixing bitfields and HLSL annotations an error. Since the syntax for HLSL annotations and bitfields are ambiguous, this change works around some issues with the ambiguity by disallowing mixing the two on the same declaration.

Fixes #4686