### PR TITLE
PIX: Access tracking for libs, switch to raw IO

### DIFF
--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -759,10 +759,10 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
     addDebugEntryValue(BC, AsFloat);
   } else {
     Function *StoreValue =
-        BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore,
+        BC.HlslOP->GetOpFunc(OP::OpCode::RawBufferStore,
                              TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
     Constant *StoreValueOpcode =
-        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::RawBufferStore);
     UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
     UndefValue *UndefArg = nullptr;
     if (TheValueTypeID == Type::TypeID::IntegerTyID) {
@@ -774,6 +774,7 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
       assert(false);
     }
     Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
+    Constant *Alignment = BC.HlslOP->GetI32Const(4);
     (void)BC.Builder.CreateCall(
         StoreValue, {StoreValueOpcode, // i32 opcode
                      m_HandleForUAV,   // %dx.types.Handle, ; resource handle
@@ -783,7 +784,8 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
                      UndefArg, // unused values
                      UndefArg, // unused values
                      UndefArg, // unused values
-                     WriteMask_X});
+                     WriteMask_X,
+                     Alignment});
 
     m_RemainingReservedSpaceInBytes -= 4;
     assert(m_RemainingReservedSpaceInBytes < 1024); // check for underflow

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -144,11 +144,12 @@ Value *DxilPIXMeshShaderOutputInstrumentation::writeDwordAndReturnNewOffset(
 {
 
   Function *StoreValue =
-      BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(BC.Ctx));
+      BC.HlslOP->GetOpFunc(OP::OpCode::RawBufferStore, Type::getInt32Ty(BC.Ctx));
   Constant *StoreValueOpcode =
-      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::RawBufferStore);
   UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
   Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
+  Constant *Alignment = BC.HlslOP->GetI32Const(4);
 
   (void)BC.Builder.CreateCall(
       StoreValue,
@@ -160,7 +161,8 @@ Value *DxilPIXMeshShaderOutputInstrumentation::writeDwordAndReturnNewOffset(
        Undef32Arg, // unused values
        Undef32Arg, // unused values
        Undef32Arg, // unused values
-       WriteMask_X});
+       WriteMask_X, 
+       Alignment});
 
   m_RemainingReservedSpaceInBytes -= sizeof(uint32_t);
   assert(m_RemainingReservedSpaceInBytes >=

--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -13,6 +13,7 @@
 #include "dxc/DXIL/DxilOperations.h"
 
 #include "dxc/DXIL/DxilConstants.h"
+#include "dxc/DXIL/DxilFunctionProps.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilResourceBinding.h"
@@ -346,11 +347,12 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
   UndefValue *UndefIntArg = UndefValue::get(Type::getInt32Ty(Ctx));
   Constant *LiteralOne = HlslOP->GetU32Const(1);
   Constant *ElementMask = HlslOP->GetI8Const(1);
+  Constant *Alignment = HlslOP->GetI32Const(4);
 
   Function *StoreFunc =
-      HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(Ctx));
+      HlslOP->GetOpFunc(OP::OpCode::RawBufferStore, Type::getInt32Ty(Ctx));
   Constant *StoreOpcode =
-      HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
+      HlslOP->GetU32Const((unsigned)OP::OpCode::RawBufferStore);
   (void)Builder.CreateCall(
       StoreFunc,
       {
@@ -364,7 +366,8 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
           UndefIntArg,            // i32, ; value v1
           UndefIntArg,            // i32, ; value v2
           UndefIntArg,            // i32, ; value v3
-          ElementMask             // i8 ; just the first value is used
+          ElementMask,            // i8 ; just the first value is used
+          Alignment
       });
 }
 
@@ -544,10 +547,11 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
             CombinedFlagOrInstructionValue = EncodedFlags;
           }
           Constant *ElementMask = HlslOP->GetI8Const(1);
-          Function *StoreFunc =
-              HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(Ctx));
+          Constant *Alignment = HlslOP->GetI32Const(4);
+          Function *StoreFunc = HlslOP->GetOpFunc(OP::OpCode::RawBufferStore,
+                                                  Type::getInt32Ty(Ctx));
           Constant *StoreOpcode =
-              HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
+              HlslOP->GetU32Const((unsigned)OP::OpCode::RawBufferStore);
           UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(Ctx));
           (void)Builder.CreateCall(
               StoreFunc,
@@ -562,13 +566,99 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
                   UndefArg,                     // i32, ; value v1
                   UndefArg,                     // i32, ; value v2
                   UndefArg,                     // i32, ; value v3
-                  ElementMask                   // i8 ; just the first value is used
+                  ElementMask,                  // i8 ; just the first value is used
+                  Alignment
               });
           return true; // did modify
       }
   }
 
   return false; // did not modify
+}
+
+
+DxilResourceAndClass DetermineAccessForHandleForLib(
+    CallInst *handleCreation,
+    DxilResourceAndClass &initializedRnC, DxilModule &DM) {
+
+  DxilResourceAndClass ret = initializedRnC;
+
+  DxilInst_CreateHandleForLib createHandleForLib(handleCreation);
+  auto *res = createHandleForLib.get_Resource();
+
+  auto *loadInstruction = llvm::cast<llvm::LoadInst>(res);
+  auto *ptr = loadInstruction->getOperand(0);
+
+  GlobalVariable *global = nullptr;
+  if (llvm::isa<GetElementPtrInst>(ptr)) {
+    auto *GEP = llvm::cast<GetElementPtrInst>(ptr);
+    // GEPs can have complex nested pointer dereferences, so make sure
+    // it's the kind we expect for an indexed global lookup:
+    auto *FirstGEPIndex = GEP->getOperand(1);
+    if (llvm::isa<ConstantInt>(FirstGEPIndex) &&
+        llvm::cast<ConstantInt>(FirstGEPIndex)->getLimitedValue() == 0) {
+      global = llvm::cast_or_null<GlobalVariable>(GEP->getPointerOperand());
+      ret.index = GEP->getOperand(2);
+    }
+  } else if (GlobalVariable *Global = llvm::cast_or_null<GlobalVariable>(ptr)) {
+    //  If the load instruction points straight at a global, it's not an indexed
+    //  load, so we can ignore it.
+    global = Global;
+  }
+
+  if (global != nullptr) {
+    hlsl::DxilResourceBinding binding{};
+
+    ret.registerType = RegisterType::Invalid;
+
+    auto const &CBuffers = DM.GetCBuffers();
+    for (auto &CBuffer : CBuffers) {
+      if (global->getName() == CBuffer->GetGlobalSymbol()->getName()) {
+        binding =
+            hlsl::resource_helper::loadBindingFromResourceBase(CBuffer.get());
+        ret.registerType = RegisterType::CBV;
+        if (ret.index == nullptr) {
+          ret.index = DM.GetOP()->GetU32Const(binding.rangeLowerBound);
+        }
+        break;
+      }
+    }
+    if (ret.registerType == RegisterType::Invalid) {
+      auto const &SRVs = DM.GetSRVs();
+      for (auto &SRV : SRVs) {
+        if (global->getName() == SRV->GetGlobalSymbol()->getName()) {
+          binding =
+              hlsl::resource_helper::loadBindingFromResourceBase(SRV.get());
+          ret.registerType = RegisterType::SRV;
+          if (ret.index == nullptr) {
+            ret.index = DM.GetOP()->GetU32Const(binding.rangeLowerBound);
+          }
+          break;
+        }
+      }
+    }
+    if (ret.registerType == RegisterType::Invalid) {
+      auto const &UAVs = DM.GetUAVs();
+      for (auto &UAV : UAVs) {
+        if (global->getName() == UAV->GetGlobalSymbol()->getName()) {
+          binding =
+              hlsl::resource_helper::loadBindingFromResourceBase(UAV.get());
+          ret.registerType = RegisterType::UAV;
+          if (ret.index == nullptr) {
+            ret.index = DM.GetOP()->GetU32Const(binding.rangeLowerBound);
+          }
+          break;
+        }
+      }
+    }
+    if (ret.registerType != RegisterType::Invalid) {
+      ret.accessStyle = AccessStyle::FromRootSig;
+      ret.RegisterID = binding.rangeLowerBound;
+      ret.RegisterSpace = binding.spaceID;
+    }
+  }
+
+  return ret;
 }
 
 DxilResourceAndClass
@@ -586,6 +676,10 @@ DxilShaderAccessTracking::GetResourceFromHandle(Value *resHandle,
   Constant *C = dyn_cast<Constant>(resHandle);
   if (C && C->isZeroValue()) {
     return ret;
+  }
+
+  if (!isa<CallInst>(resHandle)) {
+    return ret; //todo
   }
 
   CallInst *handle = cast<CallInst>(resHandle);
@@ -666,13 +760,100 @@ DxilShaderAccessTracking::GetResourceFromHandle(Value *resHandle,
             m_dynamicResourceBindings.emplace_back(std::move(drb));
   
             return ret;
+        } else if (hlsl::OP::IsDxilOpFuncCallInst(
+                       handleCreation, hlsl::OP::OpCode::CreateHandleForLib)) {
+          ret = DetermineAccessForHandleForLib(handleCreation, ret, DM);
         } else {
             DXASSERT_NOMSG(false);
         }
       }
+  } else if (hlsl::OP::IsDxilOpFuncCallInst(
+                 handle, hlsl::OP::OpCode::CreateHandleForLib)) {
+    ret = DetermineAccessForHandleForLib(handle, ret, DM);
   }
 
   return ret;
+}
+
+
+static bool CheckForDynamicIndexing(OP *HlslOP, LLVMContext &Ctx, DxilModule &DM) {
+  bool FoundDynamicIndexing = false;
+
+  for (llvm::Function &F : DM.GetModule()->functions()) {
+    if (F.isDeclaration() && !F.use_empty() && OP::IsDxilOpFunc(&F)) {
+      if (F.hasName()) {
+        if (F.getName().find("createHandleForLib") != StringRef::npos) {
+          auto FunctionUses = F.uses();
+          for (auto FI = FunctionUses.begin(); FI != FunctionUses.end();) {
+            auto &FunctionUse = *FI++;
+            auto FunctionUser = FunctionUse.getUser();
+            auto instruction = cast<Instruction>(FunctionUser);
+            Value *resourceLoad =
+                instruction->getOperand(kCreateHandleForLibResOpIdx);
+            if (auto *load = cast<LoadInst>(resourceLoad)) {
+              auto *resOrGep = load->getOperand(0);
+              if (isa<GetElementPtrInst>(resOrGep)) {
+                FoundDynamicIndexing = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+    if (FoundDynamicIndexing) {
+      break;
+    }
+  }
+
+  if (!FoundDynamicIndexing) {
+    auto CreateHandleFn =
+        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
+    for (auto FI = CreateHandleFn->user_begin();
+         FI != CreateHandleFn->user_end();) {
+      auto *FunctionUser = *FI++;
+      auto instruction = cast<Instruction>(FunctionUser);
+      Value *index = instruction->getOperand(kCreateHandleResIndexOpIdx);
+      if (!isa<Constant>(index)) {
+        FoundDynamicIndexing = true;
+        break;
+      }
+    }
+  }
+
+  if (!FoundDynamicIndexing) {
+    auto CreateHandleFromBindingFn = HlslOP->GetOpFunc(
+        DXIL::OpCode::CreateHandleFromBinding, Type::getVoidTy(Ctx));
+    for (auto FI = CreateHandleFromBindingFn->user_begin();
+         FI != CreateHandleFromBindingFn->user_end();) {
+      auto *FunctionUser = *FI++;
+      auto instruction = cast<Instruction>(FunctionUser);
+      Value *index =
+          instruction->getOperand(kCreateHandleFromBindingResIndexOpIdx);
+      if (!isa<Constant>(index)) {
+        FoundDynamicIndexing = true;
+        break;
+      }
+    }
+  }
+
+  if (!FoundDynamicIndexing) {
+    auto CreateHandleFromHeapFn = HlslOP->GetOpFunc(
+        DXIL::OpCode::CreateHandleFromHeap, Type::getVoidTy(Ctx));
+    for (auto FI = CreateHandleFromHeapFn->user_begin();
+         FI != CreateHandleFromHeapFn->user_end();) {
+      auto *FunctionUser = *FI++;
+      auto instruction = cast<Instruction>(FunctionUser);
+      Value *index =
+          instruction->getOperand(kCreateHandleFromHeapHeapIndexOpIdx);
+      if (!isa<Constant>(index)) {
+        FoundDynamicIndexing = true;
+        break;
+      }
+    }
+  }
+
+  return FoundDynamicIndexing;
 }
 
 bool DxilShaderAccessTracking::runOnModule(Module &M) {
@@ -686,44 +867,8 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
 
   if (m_CheckForDynamicIndexing) {
 
-    bool FoundDynamicIndexing = false;
-
-    auto CreateHandleFn =
-        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandle, Type::getVoidTy(Ctx));
-    for (auto FI = CreateHandleFn->user_begin(); FI != CreateHandleFn->user_end();) {
-      auto *FunctionUser = *FI++;
-      auto instruction = cast<Instruction>(FunctionUser);
-      Value *index = instruction->getOperand(kCreateHandleResIndexOpIdx);
-      if (!isa<Constant>(index)) {
-        FoundDynamicIndexing = true;
-        break;
-      }
-    }
-
-    auto CreateHandleFromBindingFn =
-        HlslOP->GetOpFunc(DXIL::OpCode::CreateHandleFromBinding, Type::getVoidTy(Ctx));
-    for (auto FI = CreateHandleFromBindingFn->user_begin(); FI != CreateHandleFromBindingFn->user_end();) {
-      auto * FunctionUser = *FI++;
-      auto instruction = cast<Instruction>(FunctionUser);
-      Value *index = instruction->getOperand(kCreateHandleFromBindingResIndexOpIdx);
-      if (!isa<Constant>(index)) {
-        FoundDynamicIndexing = true;
-        break;
-      }
-    }
-
-    auto CreateHandleFromHeapFn = HlslOP->GetOpFunc(
-        DXIL::OpCode::CreateHandleFromHeap, Type::getVoidTy(Ctx));
-    for (auto FI = CreateHandleFromHeapFn->user_begin();
-         FI != CreateHandleFromHeapFn->user_end();) {
-      auto *FunctionUser = *FI++;
-      auto instruction = cast<Instruction>(FunctionUser);
-      Value *index = instruction->getOperand(kCreateHandleFromHeapHeapIndexOpIdx);
-      if (!isa<Constant>(index)) {
-        FoundDynamicIndexing = true;
-        break;
-      }
-    }
+    bool FoundDynamicIndexing =
+        CheckForDynamicIndexing(HlslOP, Ctx, DM);
 
     if (FoundDynamicIndexing) {
       if (OSOverride != nullptr) {
@@ -732,35 +877,44 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
       }
     }
   } else {
-    {
-      if (DM.m_ShaderFlags.GetForceEarlyDepthStencil()) {
-        if (OSOverride != nullptr) {
-          formatted_raw_ostream FOS(*OSOverride);
-          FOS << "ShouldAssumeDsvAccess";
-        }
+    if (DM.m_ShaderFlags.GetForceEarlyDepthStencil()) {
+      if (OSOverride != nullptr) {
+        formatted_raw_ostream FOS(*OSOverride);
+        FOS << "ShouldAssumeDsvAccess";
       }
-      int uavRegId = 0;
-      for (llvm::Function &F : M.functions()) {
-        if (!F.getBasicBlockList().empty()) {
-          IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
-
-          m_FunctionToUAVHandle[&F] = PIXPassHelpers::CreateUAV(DM, Builder, uavRegId++, "PIX_CountUAV_Handle");
-          auto const* shaderModel = DM.GetShaderModel();
-          auto shaderKind = shaderModel->GetKind();
-          OP *HlslOP = DM.GetOP();
-          for (int accessStyle = static_cast<int>(ResourceAccessStyle::None);
-              accessStyle < static_cast<int>(ResourceAccessStyle::EndOfEnum);
-              ++accessStyle)
-          {
-              ResourceAccessStyle style = static_cast<ResourceAccessStyle>(accessStyle);
-              m_FunctionToEncodedAccess[&F][style] =
-                  HlslOP->GetU32Const(EncodeShaderModel(shaderKind) |
-                      EncodeAccess(style));
-          }
-        }
-      }
-      DM.ReEmitDxilResources();
     }
+    int uavRegId = 0;
+    for (llvm::Function &F : M.functions()) {
+      if (!F.getBasicBlockList().empty()) {
+
+        DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
+        if (!DM.HasDxilFunctionProps(&F)) {
+          auto ShaderModel = DM.GetShaderModel();
+          shaderKind = ShaderModel->GetKind();
+          if (shaderKind == DXIL::ShaderKind::Library) {
+            continue;
+          }
+        } else {
+          hlsl::DxilFunctionProps const &props = DM.GetDxilFunctionProps(&F);
+          shaderKind = props.shaderKind;
+        }
+
+        IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
+
+        m_FunctionToUAVHandle[&F] = PIXPassHelpers::CreateUAV(
+            DM, Builder, uavRegId++, "PIX_CountUAV_Handle");
+        OP *HlslOP = DM.GetOP();
+        for (int accessStyle = static_cast<int>(ResourceAccessStyle::None);
+             accessStyle < static_cast<int>(ResourceAccessStyle::EndOfEnum);
+             ++accessStyle) {
+          ResourceAccessStyle style =
+              static_cast<ResourceAccessStyle>(accessStyle);
+          m_FunctionToEncodedAccess[&F][style] = HlslOP->GetU32Const(
+              EncodeShaderModel(shaderKind) | EncodeAccess(style));
+        }
+      }
+    }
+    DM.ReEmitDxilResources();
 
     for (llvm::Function &F : M.functions()) {
       // Only used DXIL intrinsics:
@@ -785,85 +939,99 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
         auto &FunctionUse = *FI++;
         auto FunctionUser = FunctionUse.getUser();
         auto Call = cast<CallInst>(FunctionUser);
-        auto opCode = OP::GetDxilOpFuncCallInst(Call);
 
-        // Base Read/Write on function attribute - should match for all normal
-        // resource operations
-        ShaderAccessFlags readWrite = ShaderAccessFlags::Write;
-        if (OP::GetMemAccessAttr(opCode) == llvm::Attribute::AttrKind::ReadOnly)
-          readWrite = ShaderAccessFlags::Read;
-
-        // Special cases
-        switch (opCode) {
-        case DXIL::OpCode::GetDimensions:
-          // readWrite = ShaderAccessFlags::DescriptorRead;  // TODO: Support
-          // GetDimensions
-          continue;
-        case DXIL::OpCode::BufferUpdateCounter:
-          readWrite = ShaderAccessFlags::Counter;
-          break;
-        case DXIL::OpCode::TraceRay:
-          // Read of AccelerationStructure; doesn't match function attribute
-          // readWrite = ShaderAccessFlags::Read;  // TODO: Support
-          continue;
-        case DXIL::OpCode::RayQuery_TraceRayInline: {
-          // Read of AccelerationStructure; doesn't match function attribute
-          auto res = GetResourceFromHandle(Call->getArgOperand(2), DM);
-          if (EmitResourceAccess(
-            DM,
-            res, 
-            Call, 
-            HlslOP, 
-            Ctx,
-            ShaderAccessFlags::Read)) 
-          {
-            Modified = true;
+        auto *CallerParent = Call->getParent();
+        if (llvm::isa<llvm::BasicBlock>(CallerParent)) {
+          auto *BlockParent =
+              llvm::cast<llvm::BasicBlock>(CallerParent)->getParent();
+          DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
+          if (!DM.HasDxilFunctionProps(BlockParent)) {
+            auto ShaderModel = DM.GetShaderModel();
+            shaderKind = ShaderModel->GetKind();
+          } else {
+            hlsl::DxilFunctionProps const &props =
+                DM.GetDxilFunctionProps(BlockParent);
+            shaderKind = props.shaderKind;
           }
-        }
-          continue;
-        default:
-          break;
-        }
 
-        for (unsigned iParam : handleParams) {
-          auto res = GetResourceFromHandle(Call->getArgOperand(iParam), DM);
-          if (res.accessStyle == AccessStyle::None) {
+          auto opCode = OP::GetDxilOpFuncCallInst(Call);
+
+          // Base Read/Write on function attribute - should match for all normal
+          // resource operations
+          ShaderAccessFlags readWrite = ShaderAccessFlags::Write;
+          if (OP::GetMemAccessAttr(opCode) ==
+              llvm::Attribute::AttrKind::ReadOnly)
+            readWrite = ShaderAccessFlags::Read;
+
+          // Special cases
+          switch (opCode) {
+          case DXIL::OpCode::GetDimensions:
+            // readWrite = ShaderAccessFlags::DescriptorRead;  // TODO: Support
+            // GetDimensions
             continue;
+          case DXIL::OpCode::BufferUpdateCounter:
+            readWrite = ShaderAccessFlags::Counter;
+            break;
+          case DXIL::OpCode::TraceRay:
+            // Read of AccelerationStructure; doesn't match function attribute
+            // readWrite = ShaderAccessFlags::Read;  // TODO: Support
+            continue;
+          case DXIL::OpCode::RayQuery_TraceRayInline: {
+            // Read of AccelerationStructure; doesn't match function attribute
+            auto res = GetResourceFromHandle(Call->getArgOperand(2), DM);
+            if (res.accessStyle == AccessStyle::None) {
+              continue;
+            }
+            if (EmitResourceAccess(DM, res, Call, HlslOP, Ctx,
+                                   ShaderAccessFlags::Read)) {
+              Modified = true;
+            }
           }
-          // Don't instrument the accesses to the UAV that we just added
-          if (res.RegisterSpace  == -2) {
+            continue;
+          default:
             break;
           }
-          if (EmitResourceAccess(DM, res, Call, HlslOP, Ctx, readWrite)) {
-            Modified = true;
+
+          for (unsigned iParam : handleParams) {
+            auto res = GetResourceFromHandle(Call->getArgOperand(iParam), DM);
+            if (res.accessStyle == AccessStyle::None) {
+              continue;
+            }
+            // Don't instrument the accesses to the UAV that we just added
+            if (res.RegisterSpace == -2) {
+              break;
+            }
+            if (EmitResourceAccess(DM, res, Call, HlslOP, Ctx, readWrite)) {
+              Modified = true;
+            }
+            // Remaining resources are DescriptorRead.
+            readWrite = ShaderAccessFlags::DescriptorRead;
           }
-          // Remaining resources are DescriptorRead.
-          readWrite = ShaderAccessFlags::DescriptorRead;
         }
       }
-    }
 
-    if (OSOverride != nullptr) {
-      formatted_raw_ostream FOS(*OSOverride);
-      FOS << "DynamicallyIndexedBindPoints=";
-      for (auto const &bp : m_DynamicallyIndexedBindPoints) {
-        FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index
-            << ';';
-      }
-      FOS << ".";
+      if (OSOverride != nullptr) {
+        formatted_raw_ostream FOS(*OSOverride);
+        FOS << "DynamicallyIndexedBindPoints=";
+        for (auto const &bp : m_DynamicallyIndexedBindPoints) {
+          FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index
+              << ';';
+        }
+        FOS << ".";
 
-      // todo: this will reflect dynamic resource names when the metadata exists
-      FOS << "DynamicallyBoundResources=";
-      for (auto const &drb : m_dynamicResourceBindings) {
-        FOS << (drb.HeapIsSampler ? 'S' : 'R') << drb.HeapIndex << ';';
+        // todo: this will reflect dynamic resource names when the metadata
+        // exists
+        FOS << "DynamicallyBoundResources=";
+        for (auto const &drb : m_dynamicResourceBindings) {
+          FOS << (drb.HeapIsSampler ? 'S' : 'R') << drb.HeapIndex << ';';
+        }
+        FOS << ".";
       }
-      FOS << ".";
     }
   }
 
   return Modified;
 }
-
 char DxilShaderAccessTracking::ID = 0;
 
 ModulePass *llvm::createDxilShaderAccessTrackingPass() {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -164,7 +164,7 @@ llvm::CallInst *CreateUAV(DxilModule &DM, IRBuilder<> &Builder,
                           unsigned int registerId, const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
-  constexpr char * PIXStructTypeName = "struct.RWByteAddressBuffer";
+  char * PIXStructTypeName = "struct.RWByteAddressBuffer";
   llvm::StructType *UAVStructTy =
       DM.GetModule()->getTypeByName(PIXStructTypeName);
   if (UAVStructTy == nullptr) {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -164,7 +164,7 @@ llvm::CallInst *CreateUAV(DxilModule &DM, IRBuilder<> &Builder,
                           unsigned int registerId, const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
-  char * PIXStructTypeName = "struct.RWByteAddressBuffer";
+  const char * PIXStructTypeName = "struct.RWByteAddressBuffer";
   llvm::StructType *UAVStructTy =
       DM.GetModule()->getTypeByName(PIXStructTypeName);
   if (UAVStructTy == nullptr) {

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -59,6 +59,10 @@ static bool IsDynamicResourceShaderModel(DxilModule &DM) {
   return DM.GetShaderModel()->IsSMAtLeast(6, 6);
 }
 
+static bool ShaderModelRequiresAnnotateHandle(DxilModule &DM) {
+  return DM.GetShaderModel()->IsSMAtLeast(6, 6);
+}
+
 llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
                                         llvm::IRBuilder<> &Builder,
                                         hlsl::DxilResourceBase *resource,
@@ -77,14 +81,30 @@ llvm::CallInst *CreateHandleForResource(hlsl::DxilModule &DM,
   {
     llvm::Constant *object = resource->GetGlobalSymbol();
     auto * load = Builder.CreateLoad(object);
-    Function *CreateHandleFromBindingOpFunc = HlslOP->GetOpFunc(
+    Function *CreateHandleForLibOpFunc = HlslOP->GetOpFunc(
         DXIL::OpCode::CreateHandleForLib, resource->GetHLSLType()->getVectorElementType());
-    Constant *CreateHandleFromBindingOpcodeArg =
+    Constant *CreateHandleForLibOpcodeArg =
         HlslOP->GetU32Const((unsigned)DXIL::OpCode::CreateHandleForLib);
     auto *handle =
-        Builder.CreateCall(CreateHandleFromBindingOpFunc,
-        {CreateHandleFromBindingOpcodeArg, load });
-    return handle;
+        Builder.CreateCall(CreateHandleForLibOpFunc,
+        {CreateHandleForLibOpcodeArg, load });
+
+    if (ShaderModelRequiresAnnotateHandle(DM)) {
+      Function *annotHandleFn =
+          HlslOP->GetOpFunc(DXIL::OpCode::AnnotateHandle, Type::getVoidTy(Ctx));
+      Value *annotHandleArg =
+          HlslOP->GetI32Const((unsigned)DXIL::OpCode::AnnotateHandle);
+      DxilResourceProperties RP =
+          resource_helper::loadPropsFromResourceBase(resource);
+      Type *resPropertyTy = HlslOP->GetResourcePropertiesType();
+      Value *propertiesV = resource_helper::getAsConstant(RP, resPropertyTy,
+                                                          *DM.GetShaderModel());
+
+      return Builder.CreateCall(annotHandleFn,
+                                {annotHandleArg, handle, propertiesV});
+    } else {
+      return handle;
+    }
   }
   else if (IsDynamicResourceShaderModel(DM)) {
     Function *CreateHandleFromBindingOpFunc = HlslOP->GetOpFunc(
@@ -144,19 +164,24 @@ llvm::CallInst *CreateUAV(DxilModule &DM, IRBuilder<> &Builder,
                           unsigned int registerId, const char *name) {
   LLVMContext &Ctx = DM.GetModule()->getContext();
 
-  SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(Ctx)};
+  constexpr char * PIXStructTypeName = "struct.RWByteAddressBuffer";
   llvm::StructType *UAVStructTy =
-      llvm::StructType::create(Elements, "class.PIXRWStructuredBuffer");
+      DM.GetModule()->getTypeByName(PIXStructTypeName);
+  if (UAVStructTy == nullptr) {
+    SmallVector<llvm::Type *, 1> Elements{Type::getInt32Ty(Ctx)};
+    UAVStructTy = llvm::StructType::create(Elements, PIXStructTypeName);
+  }
 
   std::unique_ptr<DxilResource> pUAV = llvm::make_unique<DxilResource>();
 
   auto const *shaderModel = DM.GetShaderModel();
   if (shaderModel->IsLib()) {
-    GlobalVariable *NewGV = cast<GlobalVariable>(
-        DM.GetModule()->getOrInsertGlobal("PIXUAV", UAVStructTy));
-    NewGV->setConstant(false);
+    auto *Global = DM.GetModule()->getOrInsertGlobal("PIXUAV", UAVStructTy);
+    GlobalVariable *NewGV = cast<GlobalVariable>(Global);
+    NewGV->setConstant(true);
     NewGV->setLinkage(GlobalValue::ExternalLinkage);
     NewGV->setThreadLocal(false);
+    NewGV->setAlignment(4);
     pUAV->SetGlobalSymbol(NewGV);
   }
   else {

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
@@ -12,7 +12,7 @@
 // CHECK: slotIndex = mul i32
 
 // Check for udpate of UAV:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 
 
 ByteAddressBuffer inBuffer : register(t0);

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
@@ -4,13 +4,13 @@
 // CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
 
 // Feedback UAV:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
 
 // Texture:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
 
 // Sampler:
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
 
 Texture2D texture : register(t0);
 SamplerState samplerState : register(s0);

--- a/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToMSPayload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToMSPayload.hlsl
@@ -3,7 +3,7 @@
 // CHECK: getelementptr %PIX_AS2MS_Expanded_Type
 
 // Validate that instrumentation appeared before a store-output
-// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: call void @dx.op.rawBufferStore.i32
 // CHECK: call void @dx.op.storeVertexOutput
 
 struct PSInput

--- a/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
@@ -20,7 +20,7 @@
 // CHECK: %MaskedForUAVLimit = and i32 %UAVIncResult, 983039
 // CHECK: %MultipliedForInterest = mul i32 %MaskedForUAVLimit, %OffsetMultiplicand
 // CHECK: %AddedForInterest = add i32 %MultipliedForInterest, %OffsetAddend
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest
 
 
 [RootSignature("")]

--- a/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
@@ -10,7 +10,7 @@
 
 // CHECK:  %AddedForInterest5 = add i32 %MultipliedForInterest4, %OffsetAddend
 
-// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5
+// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5
 
 
 struct VS_OUTPUT_ENV {

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicResourceAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicResourceAccessTracking.hlsl
@@ -12,7 +12,7 @@ void Main()
 // CHECK: call %dx.types.Handle @dx.op.createHandleFromBinding
 
 // Check we wrote to the PIX UAV:
-// CHECK: call void @dx.op.bufferStore.i32
+// CHECK: call void @dx.op.rawBufferStore.i32
 
 // Offset for buffer Load should be 256 + 8 (skip out-of-bounds record) + 8 (it's the 1th resource) + 4 (offset to the "read" field) = 276
 // The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) for this access

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerAccessTracking.hlsl
@@ -18,9 +18,9 @@ float4 Main() : SV_Target
 
 // Check we wrote sampler data to the PIX UAV. We told the pass to output starting at offset 512.
 // Add 8 to skip the "out of bounds" record. Add 4 to point to the "read" field within the next entry = 524
-// CHECK: call void @dx.op.bufferStore.i32(
+// CHECK: call void @dx.op.rawBufferStore.i32(
 // CHECK:i32 524, i32 undef, i32 16777216
 
 // twice: 512 + 8 + 8*3+4 = 548
-// CHECK: call void @dx.op.bufferStore.i32(
+// CHECK: call void @dx.op.rawBufferStore.i32(
 // CHECK:i32 548, i32 undef, i32 16777216

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
@@ -20,5 +20,5 @@ float4 Main() : SV_Target
 // There are therefore no expected in-bounds references to samplers, so any such reference should go to the out-of-bounds offset at 512:
 
 // Out of bounds sampler access should be at offset 512
-// CHECK: call void @dx.op.bufferStore.i32(
+// CHECK: call void @dx.op.rawBufferStore.i32(
 // CHECK:i32 512, i32 undef, i32 16777216

--- a/tools/clang/test/HLSLFileCheck/pix/LibAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/LibAccessTracking.hlsl
@@ -1,0 +1,31 @@
+// RUN: %dxc -EClosestHit -Tlib_6_5 %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=U0:0:10i0;U0:1:2i0;.0;0;0. | %FileCheck %s
+
+// Check we added the UAV:
+// CHECK: @PIXUAV = external constant %struct.RWByteAddressBuffer, align 4
+// CHECK: load %struct.RWByteAddressBuffer, %struct.RWByteAddressBuffer* @PIXUAV
+// CHECK: call %dx.types.Handle @dx.op.createHandleForLib.struct.RWByteAddressBuffer
+// 
+// check for an attempt to write to the PIX UAV before the load from TerrainTextures:
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
+// CHECK: call %dx.types.ResRet.f32 @dx.op.textureLoad
+// 
+// And a write for the store to RenderTarget:
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
+// CHECK: void @dx.op.textureStore
+
+
+RWTexture2D<float4> RenderTarget : register(u0);
+RWTexture3D<float4> TerrainTextures[2] : register(u1);
+
+struct RayPayload 
+{
+  float4 color;
+};
+
+typedef BuiltInTriangleIntersectionAttributes MyAttributes;
+
+[shader("closesthit")]
+void ClosestHit(inout RayPayload payload, in MyAttributes attr) 
+{
+    RenderTarget[uint2(3,5)] = TerrainTextures[1].Load(uint3(2,2,2));
+}

--- a/tools/clang/test/HLSLFileCheck/pix/TraceRayInline.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/TraceRayInline.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T vs_6_5 -E main %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=S0:1:1i1;U0:2:10i0;.0;0;0. | FileCheck %s
 
 // CHECK: call void @dx.op.rayQuery_TraceRayInline
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
 
 RaytracingAccelerationStructure RTAS;
 

--- a/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
@@ -2,24 +2,24 @@
 
 // Check that the expected PIX UAV read-tracking is emitted (the atomicBinOp "|= 1") followed by the expected raw read:
 
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 24, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16
 
 // Now the writes with atomicBinOp "|=2":
 
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i32
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f16
-// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28, i32 undef, i32 1, i32 undef, i32 undef, i32 undef, i8 1)
+// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i16
 
 struct S


### PR DESCRIPTION
Three interconnected things:
-Fix up the access tracking pass to cope with CreateHandleForLib
-Switch to RawBufferStore to match what the PIX engine does on the API side.
-Cope with GetElementPtrOperand as the argument to the load that designates a global for CreateHandleForLib

