### PR TITLE
Fix build warning in dxcapi.impl.h (Linux build)

### DIFF
--- a/include/dxc/Support/dxcapi.impl.h
+++ b/include/dxc/Support/dxcapi.impl.h
@@ -98,8 +98,9 @@ inline DxcOutputType DxcGetOutputType(DXC_OUT_KIND kind) {
   case DXC_OUT_TEXT:
   case DXC_OUT_REMARKS:
     return DxcOutputType_Text;
+  default:
+    return DxcOutputType_None;
   }
-  return DxcOutputType_None;
 }
 
 // Update when new results are allowed


### PR DESCRIPTION
This is the warning threated as error: 

```
/home/vsts/work/1/s/DXC/include/dxc/Support/dxcapi.impl.h:88:11: error: enumeration values 'DXC_OUT_NONE', 'DXC_OUT_EXTRA_OUTPUTS', and 'DXC_OUT_FORCE_DWORD' not handled in switch [-Werror,-Wswitch]
  switch (kind) {
          ^
```
