### PR TITLE
PIX: Fix shader-access-tracking pass' reportage of dynamic indexing

### DIFF
--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -1018,24 +1018,23 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
           }
         }
       }
-
-      if (OSOverride != nullptr) {
-        formatted_raw_ostream FOS(*OSOverride);
-        FOS << "DynamicallyIndexedBindPoints=";
-        for (auto const &bp : m_DynamicallyIndexedBindPoints) {
-          FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index
-              << ';';
-        }
-        FOS << ".";
-
-        // todo: this will reflect dynamic resource names when the metadata
-        // exists
-        FOS << "DynamicallyBoundResources=";
-        for (auto const &drb : m_dynamicResourceBindings) {
-          FOS << (drb.HeapIsSampler ? 'S' : 'R') << drb.HeapIndex << ';';
-        }
-        FOS << ".";
+    }
+    if (OSOverride != nullptr) {
+      formatted_raw_ostream FOS(*OSOverride);
+      FOS << "DynamicallyIndexedBindPoints=";
+      for (auto const &bp : m_DynamicallyIndexedBindPoints) {
+        FOS << EncodeRegisterType(bp.Type) << bp.Space << ':' << bp.Index
+            << ';';
       }
+      FOS << ".";
+
+      // todo: this will reflect dynamic resource names when the metadata
+      // exists
+      FOS << "DynamicallyBoundResources=";
+      for (auto const &drb : m_dynamicResourceBindings) {
+        FOS << (drb.HeapIsSampler ? 'S' : 'R') << drb.HeapIndex << ';';
+      }
+      FOS << ".";
     }
   }
 


### PR DESCRIPTION
During a refactor this chunk of code was left inside the for loop over functions, which means that many "DynamicallyIndexedBindPoints" were reported, and PIX just assumed there was one and took the first one. The first one is typically a dx.op and so was quite incorrect.