### PR TITLE
Always LValue cast operands in hlsl CheckVectorConditional for now

### DIFF
--- a/tools/clang/include/clang/Sema/SemaHLSL.h
+++ b/tools/clang/include/clang/Sema/SemaHLSL.h
@@ -264,6 +264,8 @@ clang::QualType CheckVectorConditional(
   _In_ clang::ExprResult &Cond,
   _In_ clang::ExprResult &LHS,
   _In_ clang::ExprResult &RHS,
+  _In_ clang::ExprValueKind &VK,
+  _In_ clang::ExprObjectKind &OK,
   _In_ clang::SourceLocation QuestionLoc);
 
 }

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -6346,7 +6346,7 @@ QualType Sema::CheckConditionalOperands(ExprResult &Cond, ExprResult &LHS,
   // HLSL Change Starts: HLSL supports a vector condition and is
   // sufficiently different to merit its own checker.
   if (getLangOpts().HLSL)
-    return hlsl::CheckVectorConditional(this, Cond, LHS, RHS, QuestionLoc);
+    return hlsl::CheckVectorConditional(this, Cond, LHS, RHS, VK, OK, QuestionLoc);
   // HLSL Change Ends
 
   // C++ is sufficiently different to merit its own checker.

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5038,6 +5038,8 @@ public:
     _In_ ExprResult &Cond,
     _In_ ExprResult &LHS,
     _In_ ExprResult &RHS,
+    _In_ ExprValueKind &VK,
+    _In_ ExprObjectKind &OK,
     _In_ SourceLocation QuestionLoc);
 
   clang::QualType ApplyTypeSpecSignToParsedType(
@@ -9736,6 +9738,8 @@ clang::QualType HLSLExternalSource::CheckVectorConditional(
   _In_ ExprResult &Cond,
   _In_ ExprResult &LHS,
   _In_ ExprResult &RHS,
+  _In_ ExprValueKind &VK,
+  _In_ ExprObjectKind &OK,
   _In_ SourceLocation QuestionLoc)
 {
 
@@ -9747,6 +9751,22 @@ clang::QualType HLSLExternalSource::CheckVectorConditional(
   if (Cond.isInvalid() || LHS.isInvalid() || RHS.isInvalid()) {
     return QualType();
   }
+
+  // TBD: Handle LValues instead of always doing RValue cast.
+  VK = VK_RValue;
+  // TBD: Use OK_BitField and OK_VectorComponent when appropriate?
+  OK = OK_Ordinary;
+
+  // Cast condition to RValue
+  if (Cond.get()->isLValue())
+    Cond.set(CreateLValueToRValueCast(Cond.get()));
+
+  // TODO: Is this correct?  Does fxc support lvalue return here?
+  // Cast LHS/RHS to RValue
+  if (LHS.get()->isLValue())
+    LHS.set(CreateLValueToRValueCast(LHS.get()));
+  if (RHS.get()->isLValue())
+    RHS.set(CreateLValueToRValueCast(RHS.get()));
 
   // Gather type info
   QualType condType = GetStructuralForm(Cond.get()->getType());
@@ -9858,10 +9878,6 @@ clang::QualType HLSLExternalSource::CheckVectorConditional(
   // Here, element kind is combined with dimensions for result type.
   ResultTy = NewSimpleAggregateType(AR_TOBJ_INVALID, resultElementKind, 0, rowCount, colCount)->getCanonicalTypeInternal();
 
-  // Cast condition to RValue
-  if (Cond.get()->isLValue())
-    Cond.set(CreateLValueToRValueCast(Cond.get()));
-
   // Convert condition component type to bool, using result component dimensions
   QualType boolType;
   // If short-circuiting, condition must be scalar.
@@ -9880,13 +9896,6 @@ clang::QualType HLSLExternalSource::CheckVectorConditional(
       return QualType();
     }
   }
-
-  // TODO: Is this correct?  Does fxc support lvalue return here?
-  // Cast LHS/RHS to RValue
-  if (LHS.get()->isLValue())
-    LHS.set(CreateLValueToRValueCast(LHS.get()));
-  if (RHS.get()->isLValue())
-    RHS.set(CreateLValueToRValueCast(RHS.get()));
 
   if (leftType != ResultTy) {
     StandardConversionSequence standard;
@@ -14069,9 +14078,11 @@ clang::QualType hlsl::CheckVectorConditional(
   _In_ clang::ExprResult &Cond,
   _In_ clang::ExprResult &LHS,
   _In_ clang::ExprResult &RHS,
+  _In_ clang::ExprValueKind &VK,
+  _In_ clang::ExprObjectKind &OK,
   _In_ clang::SourceLocation QuestionLoc)
 {
-  return HLSLExternalSource::FromSema(self)->CheckVectorConditional(Cond, LHS, RHS, QuestionLoc);
+  return HLSLExternalSource::FromSema(self)->CheckVectorConditional(Cond, LHS, RHS, VK, OK, QuestionLoc);
 }
 
 bool IsTypeNumeric(_In_ clang::Sema* self, _In_ clang::QualType &type) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-object-lvalue.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-object-lvalue.hlsl
@@ -1,0 +1,44 @@
+// RUN: %dxc -T vs_6_0 -E main %s -ast-dump | FileCheck %s -check-prefix=CHECKAST
+// RUN: %dxc -T vs_6_0 -E main -HV 2021 %s -ast-dump | FileCheck %s -check-prefix=CHECKAST
+// RUN: %dxc -T vs_6_0 -E main %s -fcgl | FileCheck %s -check-prefix=CHECKHL
+// RUN: %dxc -T vs_6_0 -E main -HV 2021 %s -fcgl | FileCheck %s -check-prefix=CHECKHL
+// RUN: %dxc -T vs_6_0 -E main %s | FileCheck %s -check-prefixes=CHECK
+// RUN: %dxc -T vs_6_0 -E main -HV 2021 %s | FileCheck %s -check-prefixes=CHECK
+
+// CHECKAST: ConditionalOperator
+// CHECKAST-SAME: 'RWStructuredBuffer<Foo>'
+// CHECKAST-NEXT: ImplicitCastExpr
+// CHECKAST-SAME: 'bool' <LValueToRValue>
+// CHECKAST-NEXT: DeclRefExpr
+// CHECKAST-SAME: 'b' 'bool'
+// CHECKAST-NEXT: ImplicitCastExpr
+// CHECKAST-SAME: 'RWStructuredBuffer<Foo>':'RWStructuredBuffer<Foo>' <LValueToRValue>
+// CHECKAST-NEXT: DeclRefExpr
+// CHECKAST-SAME: 'BufA' 'RWStructuredBuffer<Foo>':'RWStructuredBuffer<Foo>'
+// CHECKAST-NEXT: ImplicitCastExpr
+// CHECKAST-SAME: 'RWStructuredBuffer<Foo>':'RWStructuredBuffer<Foo>' <LValueToRValue>
+// CHECKAST-NEXT: DeclRefExpr
+// CHECKAST-SAME: 'BufB' 'RWStructuredBuffer<Foo>':'RWStructuredBuffer<Foo>'
+
+// CHECKHL: %[[tmp:[^ ]+]] = alloca %"class.RWStructuredBuffer<Foo>"
+// CHECKHL: %[[ld:[^ ]+]] = load %"class.RWStructuredBuffer<Foo>", %"class.RWStructuredBuffer<Foo>"* %[[tmp]]
+// CHECKHL: %[[ch:[^ ]+]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %\22class.RWStructuredBuffer<Foo>\22)"(i32 0, %"class.RWStructuredBuffer<Foo>" %[[ld]])
+// CHECKHL: %[[ah:[^ ]+]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %\22class.RWStructuredBuffer<Foo>\22)"(i32 11, %dx.types.Handle %[[ch]], %dx.types.ResourceProperties { i32 4620, i32 4 }, %"class.RWStructuredBuffer<Foo>" undef)
+// CHECKHL: call %struct.Foo* @"dx.hl.subscript.[].%struct.Foo* (i32, %dx.types.Handle, i32)"(i32 0, %dx.types.Handle %[[ah]], i32 42)
+
+// CHECK: %[[ch:[^ ]+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+// CHECK: call %dx.types.ResRet.i32 @dx.op.bufferLoad.i32(i32 68, %dx.types.Handle %[[ch]], i32 42, i32 0)  ; BufferLoad(srv,index,wot)
+
+struct Foo {
+  uint u;
+};
+
+RWStructuredBuffer<Foo> BufA, BufB;
+
+void Inc(bool b) {
+  (b ? BufA : BufB)[42].u += 1;
+}
+
+void main(bool b : IN) {
+  Inc(true);
+}


### PR DESCRIPTION
CheckVectorConditional does not handle setting ExprValueKind or ExprObjectKind, but should be updated to handle this in the future. Normally the function would cast operands to LValues, but these happened late, so that some return paths skipped this LValue cast. When skipped, this would lead to asserts later in clang code.

This change adds arguments for ExprValueKind and ExprObjectKind so that they may be set properly in the future, and moves the LValue casting earlier, so it's never skipped.

RValue is not preserved in this change due to other assumptions which will be broken, leading to crashes. Supporting RValue expression result will require some other code changes.