### PR TITLE
[SPIR-V] Use KHR_fragment_shader_barycentric for SV_Barycentric semantic

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -33,6 +33,7 @@ enum class Extension {
   KHR_16bit_storage,
   KHR_device_group,
   KHR_fragment_shading_rate,
+  KHR_fragment_shader_barycentric,
   KHR_non_semantic_info,
   KHR_multiview,
   KHR_shader_draw_parameters,

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -368,6 +368,13 @@ bool CapabilityVisitor::visit(SpirvDecoration *decor) {
                    "SV_Barycentrics", loc);
       break;
     }
+    case spv::BuiltIn::BaryCoordNoPerspKHR:
+    case spv::BuiltIn::BaryCoordKHR: {
+      addExtension(Extension::KHR_fragment_shader_barycentric,
+                   "SV_Barycentrics", loc);
+      addCapability(spv::Capability::FragmentBarycentricKHR);
+      break;
+    }
     case spv::BuiltIn::ShadingRateKHR:
     case spv::BuiltIn::PrimitiveShadingRateKHR: {
       addExtension(Extension::KHR_fragment_shading_rate, "SV_ShadingRate", loc);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -429,8 +429,8 @@ public:
   /// \brief Returns the associated counter's (instr-ptr, is-alias-or-not)
   /// pair for the given {RW|Append|Consume}StructuredBuffer variable. Creates
   /// counter for RW buffer if not already created.
-  const CounterIdAliasPair *createOrGetCounterIdAliasPair(
-      const DeclaratorDecl *decl);
+  const CounterIdAliasPair *
+  createOrGetCounterIdAliasPair(const DeclaratorDecl *decl);
 
   /// \brief Returns all the associated counters for the given decl. The decl is
   /// expected to be a struct containing alias RW/Append/Consume structured
@@ -714,7 +714,8 @@ private:
   /// Decorates varInstr of the given asType with proper interpolation modes
   /// considering the attributes on the given decl.
   void decorateInterpolationMode(const NamedDecl *decl, QualType asType,
-                                 SpirvVariable *varInstr);
+                                 SpirvVariable *varInstr,
+                                 hlsl::Semantic::Kind semanticKind);
 
   /// Returns the proper SPIR-V storage class (Input or Output) for the given
   /// SigPoint.

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -183,6 +183,8 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_KHR_ray_query", Extension::KHR_ray_query)
       .Case("SPV_KHR_fragment_shading_rate",
             Extension::KHR_fragment_shading_rate)
+      .Case("SPV_KHR_fragment_shader_barycentric",
+            Extension::KHR_fragment_shader_barycentric)
       .Case("SPV_EXT_shader_image_int64", Extension::EXT_shader_image_int64)
       .Case("SPV_KHR_physical_storage_buffer",
             Extension::KHR_physical_storage_buffer)
@@ -246,6 +248,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_KHR_physical_storage_buffer";
   case Extension::KHR_vulkan_memory_model:
     return "SPV_KHR_vulkan_memory_model";
+  case Extension::KHR_fragment_shader_barycentric:
+    return "SPV_KHR_fragment_shader_barycentric";
   default:
     break;
   }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np-c.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np-c.hlsl
@@ -1,22 +1,18 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspCentroidAMD
-
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspKHR
+// CHECK:      OpDecorate [[bary]] Centroid
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
 float4 main(noperspective centroid float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
 }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np-s.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np-s.hlsl
@@ -1,22 +1,18 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspSampleAMD
-
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspKHR
+// CHECK:      OpDecorate [[bary]] Sample
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
 float4 main(noperspective sample float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
 }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.np.hlsl
@@ -1,22 +1,19 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspAMD
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordNoPerspKHR
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
 
 float4 main(noperspective float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
+
 }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s-c.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s-c.hlsl
@@ -1,22 +1,18 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordSmoothCentroidAMD
-
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordKHR
+// CHECK:      OpDecorate [[bary]] Centroid
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
 float4 main(centroid float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
 }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s-s.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s-s.hlsl
@@ -1,22 +1,18 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordSmoothSampleAMD
-
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordKHR
+// CHECK:      OpDecorate [[bary]] Sample
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
 float4 main(sample float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
 }

--- a/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.barycentrics.ps.s.hlsl
@@ -1,22 +1,17 @@
 // RUN: %dxc -T ps_6_1 -E main
 
-// CHECK:      OpExtension "SPV_AMD_shader_explicit_vertex_parameter"
+// CHECK:      OpCapability FragmentBarycentricKHR
+// CHECK:      OpExtension "SPV_KHR_fragment_shader_barycentric"
 
 // CHECK:      OpEntryPoint Fragment
 // CHECK-SAME: [[bary:%\d+]]
 
-// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordSmoothAMD
-
-// CHECK:      [[bary]] = OpVariable %_ptr_Input_v2float Input
+// CHECK:      OpDecorate [[bary]] BuiltIn BaryCoordKHR
+// CHECK:      [[bary]] = OpVariable %_ptr_Input_v3float Input
 
 float4 main(float3 bary : SV_Barycentrics) : SV_Target {
     return float4(bary, 1.0);
 // CHECK:      %param_var_bary = OpVariable %_ptr_Function_v3float Function
-// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v2float [[bary]]
-// CHECK-NEXT:      [[x:%\d+]] = OpCompositeExtract %float [[c2]] 0
-// CHECK-NEXT:      [[y:%\d+]] = OpCompositeExtract %float [[c2]] 1
-// CHECK-NEXT:     [[xy:%\d+]] = OpFAdd %float [[x]] [[y]]
-// CHECK-NEXT:      [[z:%\d+]] = OpFSub %float %float_1 [[xy]]
-// CHECK-NEXT:     [[c3:%\d+]] = OpCompositeConstruct %v3float [[x]] [[y]] [[z]]
-// CHECK-NEXT:                   OpStore %param_var_bary [[c3]]
+// CHECK-NEXT:     [[c2:%\d+]] = OpLoad %v3float [[bary]]
+// CHECK-NEXT:     OpStore %param_var_bary [[c2]]
 }


### PR DESCRIPTION
Use KHR_fragment_shader_barycentric instead of AMD_shader_explicit_vertex_parameter for SV_barycentric for cross-vendor compatibility.
Fixes #644 