### PR TITLE
Update Windows build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Visit the [DirectX Landing Page](https://devblogs.microsoft.com/directx/landing-
 You can download the latest successful build's artifacts (built by Appveyor) for the main branch:
 | Downloads |        |
 |-----------|--------|
-| Windows   | [⬇](https://ci.appveyor.com/api/projects/dnovillo/directxshadercompiler/artifacts/build%2FRelease%2Fdxc-artifacts.zip?branch=main&pr=false&job=image%3A%20Visual%20Studio%202019) |
+| Windows   | [⬇](https://ci.appveyor.com/api/projects/dnovillo/directxshadercompiler/artifacts/build%2FRelease%2Fdxc-artifacts.zip?branch=main&pr=false&job=image%3A%20Visual%20Studio%202022) |
 | Ubuntu    | [⬇](https://ci.appveyor.com/api/projects/dnovillo/directxshadercompiler/artifacts/build%2Fdxc-artifacts.tar.gz?branch=main&pr=false&job=image%3A%20Ubuntu) |
 
 ## Features and Goals


### PR DESCRIPTION
Windows builds are now done with Visual Studio 2022 rather than 2019; update the link to the builds to reflect that.

Fixes #4746