### PR TITLE
[SPIR-V] Run clang-format

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -429,8 +429,8 @@ public:
   /// \brief Returns the associated counter's (instr-ptr, is-alias-or-not)
   /// pair for the given {RW|Append|Consume}StructuredBuffer variable. Creates
   /// counter for RW buffer if not already created.
-  const CounterIdAliasPair *createOrGetCounterIdAliasPair(
-      const DeclaratorDecl *decl);
+  const CounterIdAliasPair *
+  createOrGetCounterIdAliasPair(const DeclaratorDecl *decl);
 
   /// \brief Returns all the associated counters for the given decl. The decl is
   /// expected to be a struct containing alias RW/Append/Consume structured

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -32,7 +32,7 @@ static const uint32_t kMaximumCharOpSource = 0xFFFA;
 static const uint32_t kMaximumCharOpSourceContinued = 0xFFFD;
 
 // Since OpSource does not have a result id, this is used to mark it was emitted
-static const uint32_t kEmittedSourceForOpSource = 1; 
+static const uint32_t kEmittedSourceForOpSource = 1;
 
 /// Chops the given original string into multiple smaller ones to make sure they
 /// can be encoded in a sequence of OpSourceContinued instructions following an
@@ -1434,7 +1434,8 @@ void EmitVisitor::generateDebugSourceContinued(uint32_t textId,
   finalizeInstruction(&richDebugInfo);
 }
 
-void EmitVisitor::generateChoppedSource(uint32_t fileId, SpirvDebugSource *inst) {
+void EmitVisitor::generateChoppedSource(uint32_t fileId,
+                                        SpirvDebugSource *inst) {
   // Chop up the source into multiple segments if it is too long.
   llvm::SmallVector<std::string, 2> choppedSrcCode;
   uint32_t textId = 0;
@@ -2077,9 +2078,9 @@ uint32_t EmitTypeHandler::getOrCreateConstantFloat(SpirvConstantFloat *inst) {
   if (valueBitwidth != typeBitwidth) {
     bool losesInfo = false;
     const llvm::fltSemantics &targetSemantics =
-        typeBitwidth == 16 ? llvm::APFloat::IEEEhalf
-                           : typeBitwidth == 32 ? llvm::APFloat::IEEEsingle
-                                                : llvm::APFloat::IEEEdouble;
+        typeBitwidth == 16   ? llvm::APFloat::IEEEhalf
+        : typeBitwidth == 32 ? llvm::APFloat::IEEEsingle
+                             : llvm::APFloat::IEEEdouble;
     const auto status = valueToUse.convert(
         targetSemantics, llvm::APFloat::roundingMode::rmTowardZero, &losesInfo);
     if (status != llvm::APFloat::opStatus::opOK &&

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -200,7 +200,8 @@ public:
 public:
   EmitVisitor(ASTContext &astCtx, SpirvContext &spvCtx,
               const SpirvCodeGenOptions &opts, FeatureManager &featureMgr)
-      : Visitor(opts, spvCtx), astContext(astCtx), featureManager(featureMgr), id(0),
+      : Visitor(opts, spvCtx), astContext(astCtx), featureManager(featureMgr),
+        id(0),
         typeHandler(astCtx, spvCtx, opts, featureMgr, &debugVariableBinary,
                     &annotationsBinary, &typeConstantBinary,
                     [this]() -> uint32_t { return takeNextId(); }),

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -18,23 +18,25 @@ namespace clang {
 namespace spirv {
 namespace {
 
-constexpr std::array<std::pair<const char*, spv_target_env>, 6> kKnownTargetEnv = {{
-    {"vulkan1.0", SPV_ENV_VULKAN_1_0},
-    {"vulkan1.1", SPV_ENV_VULKAN_1_1},
-    {"vulkan1.1spirv1.4", SPV_ENV_VULKAN_1_1_SPIRV_1_4},
-    {"vulkan1.2", SPV_ENV_VULKAN_1_2},
-    {"vulkan1.3", SPV_ENV_VULKAN_1_3},
-    {"universal1.5", SPV_ENV_UNIVERSAL_1_5}}};
+constexpr std::array<std::pair<const char *, spv_target_env>, 6>
+    kKnownTargetEnv = {{{"vulkan1.0", SPV_ENV_VULKAN_1_0},
+                        {"vulkan1.1", SPV_ENV_VULKAN_1_1},
+                        {"vulkan1.1spirv1.4", SPV_ENV_VULKAN_1_1_SPIRV_1_4},
+                        {"vulkan1.2", SPV_ENV_VULKAN_1_2},
+                        {"vulkan1.3", SPV_ENV_VULKAN_1_3},
+                        {"universal1.5", SPV_ENV_UNIVERSAL_1_5}}};
 
-constexpr std::array<std::pair<spv_target_env, const char*>, 6> kHumanReadableTargetEnv = {{
-    {SPV_ENV_VULKAN_1_0, "Vulkan 1.0"},
-    {SPV_ENV_VULKAN_1_1, "Vulkan 1.1"},
-    {SPV_ENV_VULKAN_1_1_SPIRV_1_4, "Vulkan 1.1 with SPIR-V 1.4"},
-    {SPV_ENV_VULKAN_1_2, "Vulkan 1.2"},
-    {SPV_ENV_VULKAN_1_3, "Vulkan 1.3"},
-    {SPV_ENV_UNIVERSAL_1_5, "SPIR-V 1.5"}}};
+constexpr std::array<std::pair<spv_target_env, const char *>, 6>
+    kHumanReadableTargetEnv = {
+        {{SPV_ENV_VULKAN_1_0, "Vulkan 1.0"},
+         {SPV_ENV_VULKAN_1_1, "Vulkan 1.1"},
+         {SPV_ENV_VULKAN_1_1_SPIRV_1_4, "Vulkan 1.1 with SPIR-V 1.4"},
+         {SPV_ENV_VULKAN_1_2, "Vulkan 1.2"},
+         {SPV_ENV_VULKAN_1_3, "Vulkan 1.3"},
+         {SPV_ENV_UNIVERSAL_1_5, "SPIR-V 1.5"}}};
 
-static_assert(kKnownTargetEnv.size() == kHumanReadableTargetEnv.size(),
+static_assert(
+    kKnownTargetEnv.size() == kHumanReadableTargetEnv.size(),
     "kKnownTargetEnv and kHumanReadableTargetEnv should remain in sync.");
 
 } // end namespace
@@ -52,11 +54,12 @@ FeatureManager::stringToSpvEnvironment(const std::string &target_env) {
 
 llvm::Optional<std::string>
 FeatureManager::spvEnvironmentToPrettyName(spv_target_env target_env) {
-  auto it =
-      std::find_if(kHumanReadableTargetEnv.cbegin(), kHumanReadableTargetEnv.cend(),
-                   [&](const auto &pair) { return pair.first == target_env; });
-  return it == kHumanReadableTargetEnv.end() ? llvm::None
-                                     : llvm::Optional<std::string>(it->second);
+  auto it = std::find_if(
+      kHumanReadableTargetEnv.cbegin(), kHumanReadableTargetEnv.cend(),
+      [&](const auto &pair) { return pair.first == target_env; });
+  return it == kHumanReadableTargetEnv.end()
+             ? llvm::None
+             : llvm::Optional<std::string>(it->second);
 }
 
 FeatureManager::FeatureManager(DiagnosticsEngine &de,

--- a/tools/clang/lib/SPIRV/GlPerVertex.cpp
+++ b/tools/clang/lib/SPIRV/GlPerVertex.cpp
@@ -583,7 +583,8 @@ bool GlPerVertex::tryToAccess(hlsl::SigPoint::Kind sigPointKind,
   return false;
 }
 
-SpirvInstruction *GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
+SpirvInstruction *
+GlPerVertex::readClipCullArrayAsType(bool isClip, uint32_t offset,
                                      QualType asType, SourceLocation loc,
                                      SourceRange range) const {
   SpirvVariable *clipCullVar = isClip ? inClipVar : inCullVar;
@@ -747,8 +748,9 @@ bool GlPerVertex::writeField(hlsl::Semantic::Kind semanticKind,
       assert(false && "expected vector type");
     }
     type = elemType;
-    offset = spvBuilder.createBinaryOp(
-        spv::Op::OpIAdd, astContext.UnsignedIntTy, vecComponent, offset, loc, range);
+    offset =
+        spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+                                  vecComponent, offset, loc, range);
   }
   writeClipCullArrayFromType(invocationId, isClip, offset, type, *value, loc,
                              range);

--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -309,10 +309,8 @@ InitListHandler::createInitForVectorType(QualType elemType, uint32_t count,
   return spvBuilder.createCompositeConstruct(vecType, elements, srcLoc, range);
 }
 
-SpirvInstruction *
-InitListHandler::createInitForMatrixType(QualType matrixType,
-                                         SourceLocation srcLoc,
-	                                     SourceRange range) {
+SpirvInstruction *InitListHandler::createInitForMatrixType(
+    QualType matrixType, SourceLocation srcLoc, SourceRange range) {
   uint32_t rowCount = 0, colCount = 0;
   hlsl::GetHLSLMatRowColCount(matrixType, rowCount, colCount);
   const QualType elemType = hlsl::GetHLSLMatElementType(matrixType);

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -572,7 +572,8 @@ const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
         (dim = spv::Dim::Cube, isArray = true, name == "TextureCubeArray")) {
       const bool isMS = (name == "Texture2DMS" || name == "Texture2DMSArray");
       const auto sampledType = hlsl::GetHLSLResourceResultType(type);
-      auto loweredType = lowerType(getElementType(astContext, sampledType), rule,
+      auto loweredType =
+          lowerType(getElementType(astContext, sampledType), rule,
                     /*isRowMajor*/ llvm::None, srcLoc);
       // Treat bool textures as uint for compatibility with OpTypeImage.
       if (loweredType == spvContext.getBoolType()) {
@@ -767,21 +768,21 @@ LowerTypeVisitor::translateSampledTypeToImageFormat(QualType sampledType,
       case BuiltinType::Int:
       case BuiltinType::Min12Int:
       case BuiltinType::Min16Int:
-        return elemCount == 1 ? spv::ImageFormat::R32i
-                              : elemCount == 2 ? spv::ImageFormat::Rg32i
-                                               : spv::ImageFormat::Rgba32i;
+        return elemCount == 1   ? spv::ImageFormat::R32i
+               : elemCount == 2 ? spv::ImageFormat::Rg32i
+                                : spv::ImageFormat::Rgba32i;
       case BuiltinType::UInt:
       case BuiltinType::Min16UInt:
-        return elemCount == 1 ? spv::ImageFormat::R32ui
-                              : elemCount == 2 ? spv::ImageFormat::Rg32ui
-                                               : spv::ImageFormat::Rgba32ui;
+        return elemCount == 1   ? spv::ImageFormat::R32ui
+               : elemCount == 2 ? spv::ImageFormat::Rg32ui
+                                : spv::ImageFormat::Rgba32ui;
       case BuiltinType::Float:
       case BuiltinType::HalfFloat:
       case BuiltinType::Min10Float:
       case BuiltinType::Min16Float:
-        return elemCount == 1 ? spv::ImageFormat::R32f
-                              : elemCount == 2 ? spv::ImageFormat::Rg32f
-                                               : spv::ImageFormat::Rgba32f;
+        return elemCount == 1   ? spv::ImageFormat::R32f
+               : elemCount == 2 ? spv::ImageFormat::Rg32f
+                                : spv::ImageFormat::Rgba32f;
       case BuiltinType::LongLong:
         if (elemCount == 1)
           return spv::ImageFormat::R64i;

--- a/tools/clang/lib/SPIRV/NonUniformVisitor.cpp
+++ b/tools/clang/lib/SPIRV/NonUniformVisitor.cpp
@@ -13,7 +13,7 @@ namespace clang {
 namespace spirv {
 
 bool NonUniformVisitor::visit(SpirvLoad *instr) {
-  if(instr->getPointer()->isNonUniform())
+  if (instr->getPointer()->isNonUniform())
     instr->setNonUniform();
   return true;
 }

--- a/tools/clang/lib/SPIRV/NonUniformVisitor.h
+++ b/tools/clang/lib/SPIRV/NonUniformVisitor.h
@@ -31,7 +31,6 @@ public:
   NonUniformVisitor(SpirvContext &spvCtx, const SpirvCodeGenOptions &opts)
       : Visitor(opts, spvCtx) {}
 
-
   bool visit(SpirvLoad *) override;
   bool visit(SpirvAccessChain *) override;
   bool visit(SpirvUnaryOp *) override;

--- a/tools/clang/lib/SPIRV/RawBufferMethods.cpp
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.cpp
@@ -57,7 +57,8 @@ SpirvInstruction *RawBufferHandler::load16BitsAtBitOffset0(
   result = spvBuilder.createLoad(astContext.UnsignedIntTy, loadPtr, loc, range);
   // Only need to mask the lowest 16 bits of the loaded 32-bit uint.
   // OpUConvert can perform truncation in this case.
-  result = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedShortTy, result, loc, range);
+  result = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedShortTy, result, loc, range);
   result = bitCastToNumericalOrBool(result, astContext.UnsignedShortTy,
                                     target16BitType, loc, range);
   result->setRValue();
@@ -125,8 +126,10 @@ SpirvInstruction *RawBufferHandler::load64BitsAtBitOffset0(
       spvBuilder.createLoad(astContext.UnsignedIntTy, ptr, loc, range);
 
   // Convert both word0 and word1 to 64-bit uints.
-  word0 = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedLongLongTy, word0, loc, range);
-  word1 = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedLongLongTy, word1, loc, range);
+  word0 = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedLongLongTy, word0, loc, range);
+  word1 = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedLongLongTy, word1, loc, range);
 
   // Shift word1 to the left by 32 bits.
   word1 = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
@@ -171,7 +174,8 @@ SpirvInstruction *RawBufferHandler::load16BitsAtBitOffset16(
   result = spvBuilder.createBinaryOp(spv::Op::OpShiftRightLogical,
                                      astContext.UnsignedIntTy, result,
                                      constUint16, loc, range);
-  result = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedShortTy, result, loc, range);
+  result = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedShortTy, result, loc, range);
   result = bitCastToNumericalOrBool(result, astContext.UnsignedShortTy,
                                     target16BitType, loc, range);
   result->setRValue();
@@ -424,13 +428,14 @@ void RawBufferHandler::store16BitsAtBitOffset0(SpirvInstruction *value,
                                            {constUint0, index}, loc, range);
   result = bitCastToNumericalOrBool(value, valueType,
                                     astContext.UnsignedShortTy, loc, range);
-  result = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedIntTy, result, loc, range);
+  result = spvBuilder.createUnaryOp(
+      spv::Op::OpUConvert, astContext.UnsignedIntTy, result, loc, range);
   spvBuilder.createStore(ptr, result, loc, range);
 }
 
 void RawBufferHandler::store16BitsAtBitOffset16(SpirvInstruction *value,
-                                               SpirvInstruction *buffer,
-                                               SpirvInstruction *&index,
+                                                SpirvInstruction *buffer,
+                                                SpirvInstruction *&index,
                                                 const QualType valueType,
                                                 SourceRange range) {
   const auto loc = buffer->getSourceLocation();
@@ -557,12 +562,14 @@ void RawBufferHandler::storeArrayOfScalars(
       word = bitCastToNumericalOrBool(values[elemIndex], valueType,
                                       astContext.UnsignedShortTy, loc, range);
       // Zero-extend to 32 bits.
-      word = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedIntTy, word, loc, range);
+      word = spvBuilder.createUnaryOp(
+          spv::Op::OpUConvert, astContext.UnsignedIntTy, word, loc, range);
       if (elemIndex + 1 < elemCount) {
         SpirvInstruction *msb = nullptr;
         msb = bitCastToNumericalOrBool(values[elemIndex + 1], valueType,
                                        astContext.UnsignedShortTy, loc, range);
-        msb = spvBuilder.createUnaryOp(spv::Op::OpUConvert, astContext.UnsignedIntTy, msb, loc, range);
+        msb = spvBuilder.createUnaryOp(
+            spv::Op::OpUConvert, astContext.UnsignedIntTy, msb, loc, range);
         msb = spvBuilder.createBinaryOp(spv::Op::OpShiftLeftLogical,
                                         astContext.UnsignedIntTy, msb,
                                         constUint16, loc, range);
@@ -579,7 +586,8 @@ void RawBufferHandler::storeArrayOfScalars(
       auto *ptr = spvBuilder.createAccessChain(astContext.UnsignedIntTy, buffer,
                                                {constUint0, index}, loc, range);
       spvBuilder.createStore(ptr, word, loc, range);
-      index = spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
+      index =
+          spvBuilder.createBinaryOp(spv::Op::OpIAdd, astContext.UnsignedIntTy,
                                     index, constUint1, loc, range);
     }
   } else if (storeWidth == 32u || storeWidth == 64u) {
@@ -725,7 +733,8 @@ void RawBufferHandler::processTemplatedStoreToBuffer(
     auto serializedType =
         serializeToScalarsOrStruct(&elems, valueType, loc, range);
     if (isScalarType(serializedType)) {
-      storeArrayOfScalars(elems, buffer, index, serializedType, bitOffset, loc, range);
+      storeArrayOfScalars(elems, buffer, index, serializedType, bitOffset, loc,
+                          range);
     } else if (const auto *structType = serializedType->getAs<RecordType>()) {
       for (auto elem : elems)
         processTemplatedStoreToBuffer(elem, buffer, index, serializedType,

--- a/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
+++ b/tools/clang/lib/SPIRV/RemoveBufferBlockVisitor.cpp
@@ -19,9 +19,9 @@ bool RemoveBufferBlockVisitor::isBufferBlockDecorationAvailable() {
 }
 
 bool RemoveBufferBlockVisitor::visit(SpirvModule *mod, Phase phase) {
-  // The BufferBlock decoration requires SPIR-V version 1.3 or earlier. It should be
-  // removed from the module on newer versions.
-  // Otherwise, no action is needed by this IMR visitor.
+  // The BufferBlock decoration requires SPIR-V version 1.3 or earlier. It
+  // should be removed from the module on newer versions. Otherwise, no action
+  // is needed by this IMR visitor.
   if (phase == Visitor::Phase::Init)
     if (isBufferBlockDecorationAvailable())
       return false;

--- a/tools/clang/lib/SPIRV/SignaturePackingUtil.cpp
+++ b/tools/clang/lib/SPIRV/SignaturePackingUtil.cpp
@@ -71,8 +71,8 @@ private:
           firstUnusedComponent = kNumComponentsInFullyUsedLocation;
           break;
         }
-        firstUnusedComponent = std::max(firstUnusedComponent,
-                                        nextUnusedComponent[startLoc + i]);
+        firstUnusedComponent =
+            std::max(firstUnusedComponent, nextUnusedComponent[startLoc + i]);
       }
       if (firstUnusedComponent != kNumComponentsInFullyUsedLocation) {
         // Based on Vulkan spec "15.1.5. Component Assignment", a scalar or

--- a/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBasicBlock.cpp
@@ -98,7 +98,7 @@ bool SpirvBasicBlock::invokeVisitor(
     if (functionScope && !visitor->visit(functionScope))
       return false;
     if (!debugDeclares.empty()) {
-      for (auto *decl : debugDeclares ) {
+      for (auto *decl : debugDeclares) {
         if (!decl->invokeVisitor(visitor))
           return false;
       }

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -148,9 +148,8 @@ SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
     QualType resultType, llvm::ArrayRef<SpirvInstruction *> constituents,
     SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvCompositeConstruct(resultType, loc, constituents,
-                                            range);
+  auto *instruction = new (context)
+      SpirvCompositeConstruct(resultType, loc, constituents, range);
   insertPoint->addInstruction(instruction);
   if (!constituents.empty()) {
     instruction->setLayoutRule(constituents[0]->getLayoutRule());
@@ -160,12 +159,10 @@ SpirvCompositeConstruct *SpirvBuilder::createCompositeConstruct(
 
 SpirvCompositeExtract *SpirvBuilder::createCompositeExtract(
     QualType resultType, SpirvInstruction *composite,
-    llvm::ArrayRef<uint32_t> indexes, SourceLocation loc,
-    SourceRange range) {
+    llvm::ArrayRef<uint32_t> indexes, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *instruction =
-      new (context) SpirvCompositeExtract(resultType, loc, composite, indexes,
-                                          range);
+  auto *instruction = new (context)
+      SpirvCompositeExtract(resultType, loc, composite, indexes, range);
   instruction->setRValue();
   insertPoint->addInstruction(instruction);
   return instruction;
@@ -184,8 +181,7 @@ SpirvCompositeInsert *SpirvBuilder::createCompositeInsert(
 
 SpirvVectorShuffle *SpirvBuilder::createVectorShuffle(
     QualType resultType, SpirvInstruction *vector1, SpirvInstruction *vector2,
-    llvm::ArrayRef<uint32_t> selectors, SourceLocation loc,
-    SourceRange range) {
+    llvm::ArrayRef<uint32_t> selectors, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context)
       SpirvVectorShuffle(resultType, loc, vector1, vector2, selectors, range);
@@ -196,8 +192,7 @@ SpirvVectorShuffle *SpirvBuilder::createVectorShuffle(
 
 SpirvLoad *SpirvBuilder::createLoad(QualType resultType,
                                     SpirvInstruction *pointer,
-                                    SourceLocation loc,
-                                    SourceRange range) {
+                                    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction = new (context) SpirvLoad(resultType, loc, pointer, range);
   instruction->setStorageClass(pointer->getStorageClass());
@@ -233,8 +228,7 @@ SpirvCopyObject *SpirvBuilder::createCopyObject(QualType resultType,
 
 SpirvLoad *SpirvBuilder::createLoad(const SpirvType *resultType,
                                     SpirvInstruction *pointer,
-                                    SourceLocation loc,
-                                    SourceRange range) {
+                                    SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *instruction =
       new (context) SpirvLoad(/*QualType*/ {}, loc, pointer, range);
@@ -258,10 +252,11 @@ SpirvLoad *SpirvBuilder::createLoad(const SpirvType *resultType,
 }
 
 SpirvStore *SpirvBuilder::createStore(SpirvInstruction *address,
-                               SpirvInstruction *value, SourceLocation loc,
-                               SourceRange range) {
+                                      SpirvInstruction *value,
+                                      SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *instruction = new (context) SpirvStore(loc, address, value, llvm::None, range);
+  auto *instruction =
+      new (context) SpirvStore(loc, address, value, llvm::None, range);
   insertPoint->addInstruction(instruction);
   return instruction;
 }
@@ -527,23 +522,22 @@ SpirvInstruction *SpirvBuilder::createImageSample(
   assert(lod == nullptr || minLod == nullptr);
 
   // An OpSampledImage is required to do the image sampling.
-  auto *sampledImage = createSampledImage(imageType, image, sampler, loc, range);
+  auto *sampledImage =
+      createSampledImage(imageType, image, sampler, loc, range);
 
   const auto mask = composeImageOperandsMask(
       bias, lod, grad, constOffset, varOffset, constOffsets, sample, minLod);
 
-  auto *imageSampleInst = new (context)
-      SpirvImageOp(op, texelType, loc, sampledImage, coordinate, mask,
-                   compareVal, bias, lod, grad.first, grad.second, constOffset,
-                   varOffset, constOffsets, sample, minLod, nullptr, nullptr,
-                   range);
+  auto *imageSampleInst = new (context) SpirvImageOp(
+      op, texelType, loc, sampledImage, coordinate, mask, compareVal, bias, lod,
+      grad.first, grad.second, constOffset, varOffset, constOffsets, sample,
+      minLod, nullptr, nullptr, range);
   insertPoint->addInstruction(imageSampleInst);
 
   if (isSparse) {
     // Write the Residency Code
-    const auto status = createCompositeExtract(astContext.UnsignedIntTy,
-                                               imageSampleInst, {0}, loc,
-		                                       range);
+    const auto status = createCompositeExtract(
+        astContext.UnsignedIntTy, imageSampleInst, {0}, loc, range);
     createStore(residencyCode, status, loc, range);
     // Extract the real result from the struct
     return createCompositeExtract(texelType, imageSampleInst, {1}, loc, range);
@@ -572,11 +566,11 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
           ? (isSparse ? spv::Op::OpImageSparseFetch : spv::Op::OpImageFetch)
           : (isSparse ? spv::Op::OpImageSparseRead : spv::Op::OpImageRead);
 
-  auto *fetchOrReadInst = new (context) SpirvImageOp(
-      op, texelType, loc, image, coordinate, mask,
-      /*dref*/ nullptr, /*bias*/ nullptr, lod, /*gradDx*/ nullptr,
-      /*gradDy*/ nullptr, constOffset, varOffset, constOffsets, sample,
-      nullptr, nullptr, nullptr, range);
+  auto *fetchOrReadInst = new (context)
+      SpirvImageOp(op, texelType, loc, image, coordinate, mask,
+                   /*dref*/ nullptr, /*bias*/ nullptr, lod, /*gradDx*/ nullptr,
+                   /*gradDy*/ nullptr, constOffset, varOffset, constOffsets,
+                   sample, nullptr, nullptr, nullptr, range);
   insertPoint->addInstruction(fetchOrReadInst);
 
   if (isSparse) {
@@ -593,8 +587,8 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
 
 void SpirvBuilder::createImageWrite(QualType imageType, SpirvInstruction *image,
                                     SpirvInstruction *coord,
-                                    SpirvInstruction *texel,
-                                    SourceLocation loc, SourceRange range) {
+                                    SpirvInstruction *texel, SourceLocation loc,
+                                    SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *writeInst = new (context) SpirvImageOp(
       spv::Op::OpImageWrite, imageType, loc, image, coord,
@@ -612,12 +606,12 @@ SpirvInstruction *SpirvBuilder::createImageGather(
     SpirvInstruction *component, SpirvInstruction *compareVal,
     SpirvInstruction *constOffset, SpirvInstruction *varOffset,
     SpirvInstruction *constOffsets, SpirvInstruction *sample,
-    SpirvInstruction *residencyCode, SourceLocation loc,
-    SourceRange range) {
+    SpirvInstruction *residencyCode, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
 
   // An OpSampledImage is required to do the image sampling.
-  auto *sampledImage = createSampledImage(imageType, image, sampler, loc, range);
+  auto *sampledImage =
+      createSampledImage(imageType, image, sampler, loc, range);
 
   // TODO: Update ImageGather to accept minLod if necessary.
   const auto mask = composeImageOperandsMask(
@@ -656,9 +650,8 @@ SpirvInstruction *SpirvBuilder::createImageGather(
 SpirvImageSparseTexelsResident *SpirvBuilder::createImageSparseTexelsResident(
     SpirvInstruction *residentCode, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *inst = new (context)
-      SpirvImageSparseTexelsResident(astContext.BoolTy, loc, residentCode,
-		                             range);
+  auto *inst = new (context) SpirvImageSparseTexelsResident(
+      astContext.BoolTy, loc, residentCode, range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -724,8 +717,8 @@ void SpirvBuilder::createBranch(SpirvBasicBlock *targetLabel,
   assert(insertPoint && "null insert point");
 
   if (mergeBB && continueBB) {
-    auto *loopMerge =
-        new (context) SpirvLoopMerge(loc, mergeBB, continueBB, loopControl, range);
+    auto *loopMerge = new (context)
+        SpirvLoopMerge(loc, mergeBB, continueBB, loopControl, range);
     insertPoint->addInstruction(loopMerge);
   }
 
@@ -758,15 +751,13 @@ void SpirvBuilder::createConditionalBranch(
   insertPoint->addInstruction(branchConditional);
 }
 
-void SpirvBuilder::createReturn(SourceLocation loc,
-                                SourceRange range) {
+void SpirvBuilder::createReturn(SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   insertPoint->addInstruction(new (context) SpirvReturn(loc, nullptr, range));
 }
 
 void SpirvBuilder::createReturnValue(SpirvInstruction *value,
-                                     SourceLocation loc,
-                                     SourceRange range) {
+                                     SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   insertPoint->addInstruction(new (context) SpirvReturn(loc, value, range));
 }
@@ -789,7 +780,7 @@ SpirvBuilder::createGLSLExtInst(const SpirvType *resultType, GLSLstd450 inst,
   assert(insertPoint && "null insert point");
   auto *extInst = new (context) SpirvExtInst(
       /*QualType*/ {}, loc, getExtInstSet("GLSL.std.450"), inst, operands,
-	  range);
+      range);
   extInst->setResultType(resultType);
   insertPoint->addInstruction(extInst);
   return extInst;
@@ -811,8 +802,8 @@ void SpirvBuilder::createBarrier(spv::Scope memoryScope,
                                  llvm::Optional<spv::Scope> exec,
                                  SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
-  SpirvBarrier *barrier =
-      new (context) SpirvBarrier(loc, memoryScope, memorySemantics, exec, range);
+  SpirvBarrier *barrier = new (context)
+      SpirvBarrier(loc, memoryScope, memorySemantics, exec, range);
   insertPoint->addInstruction(barrier);
 }
 
@@ -854,9 +845,8 @@ SpirvArrayLength *SpirvBuilder::createArrayLength(QualType resultType,
                                                   uint32_t arrayMember,
                                                   SourceRange range) {
   assert(insertPoint && "null insert point");
-  auto *inst =
-      new (context) SpirvArrayLength(resultType, loc, structure, arrayMember,
-                                     range);
+  auto *inst = new (context)
+      SpirvArrayLength(resultType, loc, structure, arrayMember, range);
   insertPoint->addInstruction(inst);
   return inst;
 }
@@ -969,7 +959,7 @@ SpirvDebugDeclare *SpirvBuilder::createDebugDeclare(
       SpirvDebugDeclare(dbgVar, var,
                         dbgExpr.hasValue() ? dbgExpr.getValue()
                                            : getOrCreateNullDebugExpression(),
-						loc, range);
+                        loc, range);
   if (isa<SpirvFunctionParameter>(var)) {
     assert(function && "found detached parameter");
     function->addParameterDebugDeclare(decl);
@@ -1001,11 +991,9 @@ SpirvBuilder::createDebugFunctionDef(SpirvDebugFunction *function,
   return inst;
 }
 
-SpirvInstruction *
-SpirvBuilder::createRayQueryOpsKHR(spv::Op opcode, QualType resultType,
-                                   ArrayRef<SpirvInstruction *> operands,
-                                   bool cullFlags, SourceLocation loc,
-                                   SourceRange range) {
+SpirvInstruction *SpirvBuilder::createRayQueryOpsKHR(
+    spv::Op opcode, QualType resultType, ArrayRef<SpirvInstruction *> operands,
+    bool cullFlags, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
   auto *inst = new (context)
       SpirvRayQueryOpKHR(resultType, opcode, operands, cullFlags, loc, range);
@@ -1032,7 +1020,7 @@ SpirvInstruction *SpirvBuilder::createSpirvIntrInstExt(
 
   SpirvExtInstImport *set =
       (instSet.size() == 0) ? nullptr : getExtInstSet(instSet);
-      
+
   if (retType != QualType() && retType->isVoidType()) {
     retType = QualType();
   }

--- a/tools/clang/lib/SPIRV/SpirvContext.cpp
+++ b/tools/clang/lib/SPIRV/SpirvContext.cpp
@@ -544,9 +544,9 @@ const SpirvIntrinsicType *SpirvContext::getSpirvIntrinsicType(
 
 SpirvIntrinsicType *
 SpirvContext::getCreatedSpirvIntrinsicType(unsigned typeId) {
-  if (spirvIntrinsicTypes.find(typeId) == spirvIntrinsicTypes.end()){
+  if (spirvIntrinsicTypes.find(typeId) == spirvIntrinsicTypes.end()) {
     return nullptr;
-  }  
+  }
   return spirvIntrinsicTypes[typeId];
 }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -122,10 +122,8 @@ private:
                                SourceRange rangeOverride = {});
   SpirvInstruction *doCompoundAssignOperator(const CompoundAssignOperator *);
   SpirvInstruction *doConditionalOperator(const ConditionalOperator *expr);
-  SpirvInstruction *doConditional(const Expr *expr,
-                                  const Expr *cond,
-                                  const Expr *falseExpr,
-                                  const Expr *trueExpr);
+  SpirvInstruction *doConditional(const Expr *expr, const Expr *cond,
+                                  const Expr *falseExpr, const Expr *trueExpr);
   SpirvInstruction *
   doShortCircuitedConditionalOperator(const ConditionalOperator *expr);
   SpirvInstruction *doCXXMemberCallExpr(const CXXMemberCallExpr *expr);
@@ -292,14 +290,14 @@ private:
   /// are generated.
   SpirvInstruction *tryToAssignToVectorElements(const Expr *lhs,
                                                 SpirvInstruction *rhs,
-	                                            SourceRange range = {});
+                                                SourceRange range = {});
 
   /// Tries to emit instructions for assigning to the given matrix element
   /// accessing expression. Returns 0 if the trial fails and no instructions
   /// are generated.
   SpirvInstruction *tryToAssignToMatrixElements(const Expr *lhs,
                                                 SpirvInstruction *rhs,
-	                                            SourceRange range = {});
+                                                SourceRange range = {});
 
   /// Tries to emit instructions for assigning to the given RWBuffer/RWTexture
   /// object. Returns 0 if the trial fails and no instructions are generated.
@@ -645,9 +643,9 @@ private:
   SpirvInstruction *processRawBufferStore(const CallExpr *callExpr);
   SpirvInstruction *storeDataToRawAddress(SpirvInstruction *addressInUInt64,
                                           SpirvInstruction *value,
-                                           QualType bufferType,
-                                           uint32_t alignment,
-                                           SourceLocation loc);
+                                          QualType bufferType,
+                                          uint32_t alignment,
+                                          SourceLocation loc);
 
   /// Returns the alignment of `vk::RawBufferLoad()`.
   uint32_t getAlignmentForRawBufferLoad(const CallExpr *callExpr);

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -253,8 +253,8 @@ SpirvDecoration::SpirvDecoration(SourceLocation loc,
                                  llvm::ArrayRef<SpirvInstruction *> ids)
     : SpirvInstruction(IK_Decoration, spv::Op::OpDecorateId,
                        /*type*/ {}, loc),
-      target(targetInst), targetFunction(nullptr), decoration(decor), index(llvm::None), params(),
-      idParams(ids.begin(), ids.end()) {}
+      target(targetInst), targetFunction(nullptr), decoration(decor),
+      index(llvm::None), params(), idParams(ids.begin(), ids.end()) {}
 
 SpirvDecoration::SpirvDecoration(SourceLocation loc, SpirvFunction *targetFunc,
                                  spv::Decoration decor,
@@ -403,7 +403,8 @@ SpirvAccessChain::SpirvAccessChain(QualType resultType, SourceLocation loc,
                                    SpirvInstruction *baseInst,
                                    llvm::ArrayRef<SpirvInstruction *> indexVec,
                                    SourceRange range)
-    : SpirvInstruction(IK_AccessChain, spv::Op::OpAccessChain, resultType, loc, range),
+    : SpirvInstruction(IK_AccessChain, spv::Op::OpAccessChain, resultType, loc,
+                       range),
       base(baseInst), indices(indexVec.begin(), indexVec.end()) {}
 
 SpirvAtomic::SpirvAtomic(spv::Op op, QualType resultType, SourceLocation loc,
@@ -411,8 +412,7 @@ SpirvAtomic::SpirvAtomic(spv::Op op, QualType resultType, SourceLocation loc,
                          spv::MemorySemanticsMask mask,
                          SpirvInstruction *valueInst, SourceRange range)
     : SpirvInstruction(IK_Atomic, op, resultType, loc, range),
-      pointer(pointerInst),
-      scope(s), memorySemantic(mask),
+      pointer(pointerInst), scope(s), memorySemantic(mask),
       memorySemanticUnequal(spv::MemorySemanticsMask::MaskNone),
       value(valueInst), comparator(nullptr) {
   assert(
@@ -433,8 +433,7 @@ SpirvAtomic::SpirvAtomic(spv::Op op, QualType resultType, SourceLocation loc,
                          SpirvInstruction *valueInst,
                          SpirvInstruction *comparatorInst, SourceRange range)
     : SpirvInstruction(IK_Atomic, op, resultType, loc, range),
-      pointer(pointerInst),
-      scope(s), memorySemantic(semanticsEqual),
+      pointer(pointerInst), scope(s), memorySemantic(semanticsEqual),
       memorySemanticUnequal(semanticsUnequal), value(valueInst),
       comparator(comparatorInst) {
   assert(op == spv::Op::OpAtomicCompareExchange);
@@ -455,7 +454,7 @@ SpirvBinaryOp::SpirvBinaryOp(spv::Op opcode, QualType resultType,
                              SourceLocation loc, SpirvInstruction *op1,
                              SpirvInstruction *op2, SourceRange range)
     : SpirvInstruction(IK_BinaryOp, opcode, resultType, loc, range),
-	  operand1(op1), operand2(op2) {}
+      operand1(op1), operand2(op2) {}
 
 SpirvBitField::SpirvBitField(Kind kind, spv::Op op, QualType resultType,
                              SourceLocation loc, SpirvInstruction *baseInst,
@@ -484,8 +483,7 @@ SpirvBitFieldInsert::SpirvBitFieldInsert(QualType resultType,
 
 SpirvCompositeConstruct::SpirvCompositeConstruct(
     QualType resultType, SourceLocation loc,
-    llvm::ArrayRef<SpirvInstruction *> constituentsVec,
-    SourceRange range)
+    llvm::ArrayRef<SpirvInstruction *> constituentsVec, SourceRange range)
     : SpirvInstruction(IK_CompositeConstruct, spv::Op::OpCompositeConstruct,
                        resultType, loc, range),
       consituents(constituentsVec.begin(), constituentsVec.end()) {}
@@ -592,7 +590,8 @@ SpirvCompositeInsert::SpirvCompositeInsert(QualType resultType,
       indices(indexVec.begin(), indexVec.end()) {}
 
 SpirvEmitVertex::SpirvEmitVertex(SourceLocation loc, SourceRange range)
-    : SpirvInstruction(IK_EmitVertex, spv::Op::OpEmitVertex, QualType(), loc, range) {}
+    : SpirvInstruction(IK_EmitVertex, spv::Op::OpEmitVertex, QualType(), loc,
+                       range) {}
 
 SpirvEndPrimitive::SpirvEndPrimitive(SourceLocation loc, SourceRange range)
     : SpirvInstruction(IK_EndPrimitive, spv::Op::OpEndPrimitive, QualType(),
@@ -689,9 +688,9 @@ SpirvImageOp::SpirvImageOp(
       image(imageInst), coordinate(coordinateInst), dref(drefInst),
       bias(biasInst), lod(lodInst), gradDx(gradDxInst), gradDy(gradDyInst),
       constOffset(constOffsetInst), offset(offsetInst),
-      constOffsets(constOffsetsInst), sample(sampleInst),
-      minLod(minLodInst), component(componentInst),
-      texelToWrite(texelToWriteInst), operandsMask(mask) {
+      constOffsets(constOffsetsInst), sample(sampleInst), minLod(minLodInst),
+      component(componentInst), texelToWrite(texelToWriteInst),
+      operandsMask(mask) {
   assert(op == spv::Op::OpImageSampleImplicitLod ||
          op == spv::Op::OpImageSampleExplicitLod ||
          op == spv::Op::OpImageSampleDrefImplicitLod ||
@@ -992,8 +991,7 @@ SpirvDebugExpression::SpirvDebugExpression(
 SpirvDebugDeclare::SpirvDebugDeclare(SpirvDebugLocalVariable *debugVar_,
                                      SpirvInstruction *var_,
                                      SpirvDebugExpression *expr,
-	                                 SourceLocation loc,
-	                                 SourceRange range)
+                                     SourceLocation loc, SourceRange range)
     : SpirvDebugInstruction(IK_DebugDeclare, /*opcode*/ 28u),
       debugVar(debugVar_), var(var_), expression(expr) {
   srcLoc = loc;

--- a/tools/clang/lib/SPIRV/SpirvType.cpp
+++ b/tools/clang/lib/SPIRV/SpirvType.cpp
@@ -178,8 +178,8 @@ StructType::StructType(llvm::ArrayRef<StructType::FieldInfo> fieldsVec,
     : SpirvType(TK_Struct, name), fields(fieldsVec.begin(), fieldsVec.end()),
       readOnly(isReadOnly), interfaceType(iface) {}
 
-bool StructType::FieldInfo::
-operator==(const StructType::FieldInfo &that) const {
+bool StructType::FieldInfo::operator==(
+    const StructType::FieldInfo &that) const {
   return type == that.type && offset.hasValue() == that.offset.hasValue() &&
          matrixStride.hasValue() == that.matrixStride.hasValue() &&
          isRowMajor.hasValue() == that.isRowMajor.hasValue() &&

--- a/tools/clang/lib/SPIRV/StageVar.h
+++ b/tools/clang/lib/SPIRV/StageVar.h
@@ -10,10 +10,10 @@
 #ifndef LLVM_CLANG_LIB_SPIRV_STAGEVAR_H
 #define LLVM_CLANG_LIB_SPIRV_STAGEVAR_H
 
-#include "clang/AST/Attr.h"
-#include "clang/SPIRV/SpirvInstruction.h"
 #include "dxc/DXIL/DxilSemantic.h"
 #include "dxc/DXIL/DxilSigPoint.h"
+#include "clang/AST/Attr.h"
+#include "clang/SPIRV/SpirvInstruction.h"
 
 #include <string>
 


### PR DESCRIPTION
Ideally we can add this as a presubmit, but at least this will allow me to use a code formatter in VS Code without changing large swathes of files