### PR TITLE
Added constant folding for some DXIL operations with non-finite operands

### DIFF
--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_ceil.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_ceil.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 28
+// ceil(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// ceil(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// ceil(-inf) -> -inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0xFFF0000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(ceil(GetNan()), ceil(GetInf()), ceil(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_cos.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_cos.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 12
+// cos(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// cos(inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF8000000000000)
+// cos(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(cos(GetNan()), cos(GetInf()), cos(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot2.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.dot2.f32(i32 54
+// CHECK: @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  return dot(float2(1,1), float2(GetNan(),1));
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot3.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.dot3.f32(i32 55
+// CHECK: @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  return dot(float3(1,1,1), float3(GetNan(),1,1));
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_dot4.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.dot4.f32(i32 56
+// CHECK: @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  return dot(float4(1,1,1,1), float4(GetNan(),1,1,1));
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_exp.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_exp.hlsl
@@ -7,7 +7,7 @@
 // exp(inf) -> inf
 // CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
 // exp(-inf) -> 0
-// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.0)
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.0
 
 float GetValue(float a, float b) {
   return a / b;

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_exp.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_exp.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 21
+// exp(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000
+// exp(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// exp(-inf) -> 0
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.0)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(exp(GetNan()), exp(GetInf()), exp(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_floor.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_floor.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 27
+// floor(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// floor(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// floor(-inf) -> -inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0xFFF0000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(floor(GetNan()), floor(GetInf()), floor(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_fma.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_fma.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: @dx.op.tertiary.f64(i32 47
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  return fma(1.0, 2.0, double(GetNan()));
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_frc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_frc.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 22
+// frac(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// frac(inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF8000000000000)
+// frac(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(frac(GetNan()), frac(GetInf()), frac(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_log.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_log.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 23
+// log(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// log(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// log(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(log(GetNan()), log(GetInf()), log(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_mad.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_mad.hlsl
@@ -1,0 +1,23 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: @dx.op.tertiary.f32(i32 46
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float main() : SV_Target {
+  return mad(1, 2, GetNan());
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_round.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_round.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 26
+// round(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// round(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// round(-inf) -> -inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0xFFF0000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(round(GetNan()), round(GetInf()), round(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_rsqrt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_rsqrt.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 25
+// rsqrt(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// rsqrt(inf) -> 0
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.0
+// rsqrt(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(rsqrt(GetNan()), rsqrt(GetInf()), rsqrt(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_sin.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_sin.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 13
+// sin(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// sin(inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF8000000000000)
+// sin(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(sin(GetNan()), sin(GetInf()), sin(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_sqrt.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_sqrt.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 24
+// sqrt(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// sqrt(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// sqrt(-inf) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0x7FF8000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(sqrt(GetNan()), sqrt(GetInf()), sqrt(GetNegInf()), 0);
+}

--- a/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_trunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/constant_folding/nan_trunc.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_6 -Od %s | FileCheck %s
+
+// CHECK: void @main
+// CHECK-NOT: dx.op.unary.f32(i32 29
+// trunc(NaN) -> NaN
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x7FF8000000000000)
+// trunc(inf) -> inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0x7FF0000000000000)
+// trunc(-inf) -> -inf
+// CHECK-DAG: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0xFFF0000000000000)
+
+float GetValue(float a, float b) {
+  return a / b;
+}
+float GetNan() {
+  return GetValue(0, 0);
+}
+float GetInf() {
+  return GetValue(1, 0);
+}
+float GetNegInf() {
+  return -GetInf();
+}
+
+[RootSignature("")]
+float4 main() : SV_Target {
+  return float4(trunc(GetNan()), trunc(GetInf()), trunc(GetNegInf()), 0);
+}


### PR DESCRIPTION
Constant folder for DXIL operations with non-finite operands (inf, -inf, NaN) was intentionally left undone. This change adds constant folding for some of the missing cases based on the D3D spec. This change does not include all the operations. Some of them will be added later.