### PR TITLE
Bring in code coverage tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,21 @@ if(CMAKE_CROSSCOMPILING OR (LLVM_OPTIMIZED_TABLEGEN AND LLVM_ENABLE_ASSERTIONS))
   set(LLVM_USE_HOST_TOOLS ON)
 endif()
 
+if (LLVM_BUILD_INSTRUMENTED OR LLVM_BUILD_INSTRUMENTED_COVERAGE)
+  if(NOT LLVM_PROFILE_MERGE_POOL_SIZE)
+    # A pool size of 1-2 is probably sufficient on a SSD. 3-4 should be fine
+    # for spining disks. Anything higher may only help on slower mediums.
+    set(LLVM_PROFILE_MERGE_POOL_SIZE "4")
+  endif()
+  if(NOT LLVM_PROFILE_FILE_PATTERN)
+    if(NOT LLVM_PROFILE_DATA_DIR)
+      set(LLVM_PROFILE_FILE_PATTERN "%${LLVM_PROFILE_MERGE_POOL_SIZE}m.profraw")
+    else()
+      file(TO_NATIVE_PATH "${LLVM_PROFILE_DATA_DIR}/%${LLVM_PROFILE_MERGE_POOL_SIZE}m.profraw" LLVM_PROFILE_FILE_PATTERN)
+    endif()
+  endif()
+endif()
+
 # All options referred to from HandleLLVMOptions have to be specified
 # BEFORE this include, otherwise options will not be correctly set on
 # first cmake run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,6 +783,8 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
   endif()
 endif()
 
+include(CoverageReport)
+
 # Disable regeneration target for official builds as they always fun a full clean build.
 # This should eliminate the race-condition issue with "Cannot restore timestamp".
 if (HLSL_OFFICIAL_BUILD)

--- a/cmake/modules/CoverageReport.cmake
+++ b/cmake/modules/CoverageReport.cmake
@@ -1,0 +1,64 @@
+# if coverage reports are not enabled, skip all of this
+if(NOT LLVM_BUILD_INSTRUMENTED_COVERAGE)
+  return()
+endif()
+
+file(TO_NATIVE_PATH
+     "${LLVM_SOURCE_DIR}/utils/prepare-code-coverage-artifact.py"
+     PREPARE_CODE_COV_ARTIFACT)
+
+# llvm-cov and llvm-profdata need to match the host compiler. They can either be
+# explicitly provided by the user, or we will look them up based on the install
+# location of the C++ compiler.
+get_filename_component(COMPILER_DIRECTORY ${CMAKE_CXX_COMPILER} DIRECTORY)
+find_program(LLVM_COV "llvm-cov" ${COMPILER_DIRECTORY} NO_DEFAULT_PATH)
+find_program(LLVM_PROFDATA "llvm-profdata" ${COMPILER_DIRECTORY} NO_DEFAULT_PATH)
+
+if(NOT LLVM_COV OR NOT LLVM_PROFDATA)
+  message(WARNING "Could not find code coverage tools, skipping generating targets. You may explicitly specify LLVM_COV and LLVM_PROFDATA to work around this warning.")
+  return()
+endif()
+
+set(LLVM_CODE_COVERAGE_TARGETS "" CACHE STRING "Targets to run code coverage on (defaults to all exported targets if empty)")
+mark_as_advanced(LLVM_CODE_COVERAGE_TARGETS)
+
+if(NOT LLVM_CODE_COVERAGE_TARGETS)
+  # by default run the coverage report across all the exports provided
+  get_property(COV_TARGETS GLOBAL PROPERTY LLVM_EXPORTS)
+endif()
+
+file(TO_NATIVE_PATH
+     "${CMAKE_BINARY_DIR}/report/"
+     REPORT_DIR)
+
+foreach(target ${LLVM_CODE_COVERAGE_TARGETS} ${COV_TARGETS})
+  get_target_property(target_type ${target} TYPE)
+  if("${target_type}" STREQUAL "SHARED_LIBRARY" OR "${target_type}" STREQUAL "EXECUTABLE")
+    list(APPEND coverage_binaries $<TARGET_FILE:${target}>)
+  endif()
+endforeach()
+
+set(LLVM_COVERAGE_SOURCE_DIRS "" CACHE STRING "Source directories to restrict coverage reports to.")
+mark_as_advanced(LLVM_COVERAGE_SOURCE_DIRS)
+
+foreach(dir ${LLVM_COVERAGE_SOURCE_DIRS})
+  list(APPEND restrict_flags -restrict ${dir})
+endforeach()
+
+# Utility target to clear out profile data.
+# This isn't connected to any dependencies because it is a bit finacky to get
+# working exactly how a user might want.
+add_custom_target(clear-profile-data
+                  COMMAND ${CMAKE_COMMAND} -E
+                          remove_directory ${LLVM_PROFILE_DATA_DIR})
+
+# This currently only works for LLVM, but could be expanded to work for all
+# sub-projects. The current limitation is based on not having a good way to
+# automaticall plumb through the targets that we want to run coverage against.
+add_custom_target(generate-coverage-report
+                  COMMAND ${Python3_EXECUTABLE} ${PREPARE_CODE_COV_ARTIFACT}
+                          ${LLVM_PROFDATA} ${LLVM_COV} ${LLVM_PROFILE_DATA_DIR}
+                          ${REPORT_DIR} ${coverage_binaries}
+                          --unified-report ${restrict_flags}
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                  DEPENDS check-llvm) # Run tests

--- a/cmake/modules/CoverageReport.cmake
+++ b/cmake/modules/CoverageReport.cmake
@@ -22,6 +22,15 @@ endif()
 set(LLVM_CODE_COVERAGE_TARGETS "" CACHE STRING "Targets to run code coverage on (defaults to all exported targets if empty)")
 mark_as_advanced(LLVM_CODE_COVERAGE_TARGETS)
 
+# HLSL Change Begin - This is probably worth upstreaming...
+set(LLVM_CODE_COVERAGE_TEST_TARGETS "" CACHE STRING "Targets to run to generate coverage profiles.")
+mark_as_advanced(LLVM_CODE_COVERAGE_TEST_TARGETS)
+
+if (LLVM_CODE_COVERAGE_TEST_TARGETS)
+  set(COV_DEPENDS DEPENDS ${LLVM_CODE_COVERAGE_TEST_TARGETS})
+endif()
+# HLSL Change End
+
 if(NOT LLVM_CODE_COVERAGE_TARGETS)
   # by default run the coverage report across all the exports provided
   get_property(COV_TARGETS GLOBAL PROPERTY LLVM_EXPORTS)
@@ -61,4 +70,4 @@ add_custom_target(generate-coverage-report
                           ${REPORT_DIR} ${coverage_binaries}
                           --unified-report ${restrict_flags}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-                  DEPENDS check-llvm) # Run tests
+                  ${COV_DEPENDS}) # Run tests

--- a/cmake/modules/CoverageReport.cmake
+++ b/cmake/modules/CoverageReport.cmake
@@ -19,7 +19,7 @@ if(NOT LLVM_COV OR NOT LLVM_PROFDATA)
   return()
 endif()
 
-set(LLVM_CODE_COVERAGE_TARGETS "" CACHE STRING "Targets to run code coverage on (defaults to all exported targets if empty)")
+set(LLVM_CODE_COVERAGE_TARGETS "" CACHE STRING "Targets to generate coverage reports against (defaults to all exported targets if empty)")
 mark_as_advanced(LLVM_CODE_COVERAGE_TARGETS)
 
 # HLSL Change Begin - This is probably worth upstreaming...
@@ -55,7 +55,7 @@ foreach(dir ${LLVM_COVERAGE_SOURCE_DIRS})
 endforeach()
 
 # Utility target to clear out profile data.
-# This isn't connected to any dependencies because it is a bit finacky to get
+# This isn't connected to any dependencies because it is a bit finicky to get
 # working exactly how a user might want.
 add_custom_target(clear-profile-data
                   COMMAND ${CMAKE_COMMAND} -E

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -622,7 +622,15 @@ endif()
 
 option(LLVM_BUILD_INSTRUMENTED "Build LLVM and tools with PGO instrumentation (experimental)" Off)
 mark_as_advanced(LLVM_BUILD_INSTRUMENTED)
-append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate"
+append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate='${LLVM_PROFILE_FILE_PATTERN}'"
+  CMAKE_CXX_FLAGS
+  CMAKE_C_FLAGS
+  CMAKE_EXE_LINKER_FLAGS
+  CMAKE_SHARED_LINKER_FLAGS)
+
+option(LLVM_BUILD_INSTRUMENTED_COVERAGE "Build LLVM and tools with Code Coverage instrumentation (experimental)" Off)
+mark_as_advanced(LLVM_BUILD_INSTRUMENTED_COVERAGE)
+append_if(LLVM_BUILD_INSTRUMENTED_COVERAGE "-fprofile-instr-generate='${LLVM_PROFILE_FILE_PATTERN}' -fcoverage-mapping"
   CMAKE_CXX_FLAGS
   CMAKE_C_FLAGS
   CMAKE_EXE_LINKER_FLAGS

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -620,6 +620,14 @@ if (LLVM_ENABLE_LTO)
 endif()
 # HLSL Change End
 
+option(LLVM_BUILD_INSTRUMENTED "Build LLVM and tools with PGO instrumentation (experimental)" Off)
+mark_as_advanced(LLVM_BUILD_INSTRUMENTED)
+append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate"
+  CMAKE_CXX_FLAGS
+  CMAKE_C_FLAGS
+  CMAKE_EXE_LINKER_FLAGS
+  CMAKE_SHARED_LINKER_FLAGS)
+
 # Plugin support
 # FIXME: Make this configurable.
 if(WIN32 OR CYGWIN)

--- a/utils/prepare-code-coverage-artifact.py
+++ b/utils/prepare-code-coverage-artifact.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+'''Prepare a code coverage artifact.
+
+- Collate raw profiles into one indexed profile.
+- Delete the raw profiles.
+- Copy the coverage mappings in the binaries directory.
+'''
+
+import argparse
+import glob
+import os
+import subprocess
+import sys
+
+def merge_raw_profiles(host_llvm_profdata, profile_data_dir):
+    print ':: Merging raw profiles...',
+    sys.stdout.flush()
+    raw_profiles = glob.glob(os.path.join(profile_data_dir, '*.profraw'))
+    manifest_path = os.path.join(profile_data_dir, 'profiles.manifest')
+    profdata_path = os.path.join(profile_data_dir, 'Coverage.profdata')
+    with open(manifest_path, 'w') as manifest:
+        manifest.write('\n'.join(raw_profiles))
+    subprocess.check_call([host_llvm_profdata, 'merge', '-sparse', '-f',
+                           manifest_path, '-o', profdata_path])
+    for raw_profile in raw_profiles:
+        os.remove(raw_profile)
+    print 'Done!'
+
+def extract_covmappings(host_llvm_cov, profile_data_dir, llvm_bin_dir):
+    print ':: Extracting covmappings...',
+    sys.stdout.flush()
+    for prog in os.listdir(llvm_bin_dir):
+        if prog == 'llvm-lit':
+            continue
+        covmapping_path = os.path.join(profile_data_dir,
+                                       os.path.basename(prog) + '.covmapping')
+        subprocess.check_call([host_llvm_cov, 'convert-for-testing',
+                               os.path.join(llvm_bin_dir, prog), '-o',
+                               covmapping_path])
+    print 'Done!'
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('host_llvm_profdata', help='Path to llvm-profdata')
+    parser.add_argument('host_llvm_cov', help='Path to llvm-cov')
+    parser.add_argument('profile_data_dir',
+                       help='Path to the directory containing the raw profiles')
+    parser.add_argument('llvm_bin_dir',
+                       help='Path to the directory containing llvm binaries')
+    args = parser.parse_args()
+
+    merge_raw_profiles(args.host_llvm_profdata, args.profile_data_dir)
+    extract_covmappings(args.host_llvm_cov, args.profile_data_dir,
+                        args.llvm_bin_dir)

--- a/utils/prepare-code-coverage-artifact.py
+++ b/utils/prepare-code-coverage-artifact.py
@@ -1,10 +1,14 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
+from __future__ import print_function
 
 '''Prepare a code coverage artifact.
 
 - Collate raw profiles into one indexed profile.
-- Delete the raw profiles.
-- Copy the coverage mappings in the binaries directory.
+- Generate html reports for the given binaries.
+
+Caution: The positional arguments to this script must be specified before any 
+optional arguments, such as --restrict.
 '''
 
 import argparse
@@ -13,8 +17,8 @@ import os
 import subprocess
 import sys
 
-def merge_raw_profiles(host_llvm_profdata, profile_data_dir):
-    print ':: Merging raw profiles...',
+def merge_raw_profiles(host_llvm_profdata, profile_data_dir, preserve_profiles):
+    print(':: Merging raw profiles...', end='')
     sys.stdout.flush()
     raw_profiles = glob.glob(os.path.join(profile_data_dir, '*.profraw'))
     manifest_path = os.path.join(profile_data_dir, 'profiles.manifest')
@@ -23,22 +27,47 @@ def merge_raw_profiles(host_llvm_profdata, profile_data_dir):
         manifest.write('\n'.join(raw_profiles))
     subprocess.check_call([host_llvm_profdata, 'merge', '-sparse', '-f',
                            manifest_path, '-o', profdata_path])
-    for raw_profile in raw_profiles:
-        os.remove(raw_profile)
-    print 'Done!'
+    if not preserve_profiles:
+        for raw_profile in raw_profiles:
+            os.remove(raw_profile)
+    os.remove(manifest_path)
+    print('Done!')
+    return profdata_path
 
-def extract_covmappings(host_llvm_cov, profile_data_dir, llvm_bin_dir):
-    print ':: Extracting covmappings...',
+def prepare_html_report(host_llvm_cov, profile, report_dir, binaries,
+                        restricted_dirs, compilation_dir):
+    print(':: Preparing html report for {0}...'.format(binaries), end='')
     sys.stdout.flush()
-    for prog in os.listdir(llvm_bin_dir):
-        if prog == 'llvm-lit':
-            continue
-        covmapping_path = os.path.join(profile_data_dir,
-                                       os.path.basename(prog) + '.covmapping')
-        subprocess.check_call([host_llvm_cov, 'convert-for-testing',
-                               os.path.join(llvm_bin_dir, prog), '-o',
-                               covmapping_path])
-    print 'Done!'
+    objects = []
+    for i, binary in enumerate(binaries):
+        if i == 0:
+            objects.append(binary)
+        else:
+            objects.extend(('-object', binary))
+    invocation = [host_llvm_cov, 'show'] + objects + ['-format', 'html',
+                  '-instr-profile', profile, '-o', report_dir,
+                  '-show-line-counts-or-regions', '-Xdemangler', 'c++filt',
+                  '-Xdemangler', '-n'] + restricted_dirs
+    if compilation_dir:
+        invocation += ['-compilation-dir=' + compilation_dir]
+    subprocess.check_call(invocation)
+    with open(os.path.join(report_dir, 'summary.txt'), 'wb') as Summary:
+        subprocess.check_call([host_llvm_cov, 'report'] + objects +
+                               ['-instr-profile', profile] + restricted_dirs,
+                               stdout=Summary)
+    print('Done!')
+
+def prepare_html_reports(host_llvm_cov, profdata_path, report_dir, binaries,
+                         unified_report, restricted_dirs, compilation_dir):
+    if unified_report:
+        prepare_html_report(host_llvm_cov, profdata_path, report_dir, binaries,
+                            restricted_dirs, compilation_dir)
+    else:
+        for binary in binaries:
+            binary_report_dir = os.path.join(report_dir,
+                                             os.path.basename(binary))
+            prepare_html_report(host_llvm_cov, profdata_path, binary_report_dir,
+                                [binary], restricted_dirs, compilation_dir)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
@@ -46,10 +75,43 @@ if __name__ == '__main__':
     parser.add_argument('host_llvm_cov', help='Path to llvm-cov')
     parser.add_argument('profile_data_dir',
                        help='Path to the directory containing the raw profiles')
-    parser.add_argument('llvm_bin_dir',
-                       help='Path to the directory containing llvm binaries')
+    parser.add_argument('report_dir',
+                       help='Path to the output directory for html reports')
+    parser.add_argument('binaries', metavar='B', type=str, nargs='*',
+                       help='Path to an instrumented binary')
+    parser.add_argument('--only-merge', action='store_true',
+                        help='Only merge raw profiles together, skip report '
+                             'generation')
+    parser.add_argument('--preserve-profiles',
+                       help='Do not delete raw profiles', action='store_true')
+    parser.add_argument('--use-existing-profdata',
+                       help='Specify an existing indexed profile to use')
+    parser.add_argument('--unified-report', action='store_true',
+                       help='Emit a unified report for all binaries')
+    parser.add_argument('--restrict', metavar='R', type=str, nargs='*',
+                       default=[],
+                       help='Restrict the reporting to the given source paths'
+                   ' (must be specified after all other positional arguments)')
+    parser.add_argument('-C', '--compilation-dir', type=str, default="",
+                       help='The compilation directory of the binary')
     args = parser.parse_args()
 
-    merge_raw_profiles(args.host_llvm_profdata, args.profile_data_dir)
-    extract_covmappings(args.host_llvm_cov, args.profile_data_dir,
-                        args.llvm_bin_dir)
+    if args.use_existing_profdata and args.only_merge:
+        print('--use-existing-profdata and --only-merge are incompatible')
+        exit(1)
+
+    if args.use_existing_profdata:
+        profdata_path = args.use_existing_profdata
+    else:
+        profdata_path = merge_raw_profiles(args.host_llvm_profdata,
+                                           args.profile_data_dir,
+                                           args.preserve_profiles)
+
+    if not len(args.binaries):
+        print('No binaries specified, no work to do!')
+        exit(1)
+
+    if not args.only_merge:
+        prepare_html_reports(args.host_llvm_cov, profdata_path, args.report_dir,
+                             args.binaries, args.unified_report, args.restrict, 
+                             args.compilation_dir)


### PR DESCRIPTION
This cherry-picks a few changes from upstream LLVM, and has one small DXC-specific change on top.

The goal here is to just bring in the basic code coverage tooling so that we can generate coverage reports. With this PR coverage reports on Unix work, but coverage reports on Windows are still WIP.

Looping in @dnovillo and @bogner since they both worked on LLVM's code coverage infrastructure in past lives 😁 