### PR TITLE
PIX: Switch back to non-raw buffer stores

### DIFF
--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -759,10 +759,10 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
     addDebugEntryValue(BC, AsFloat);
   } else {
     Function *StoreValue =
-        BC.HlslOP->GetOpFunc(OP::OpCode::RawBufferStore,
+        BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore,
                              TheValue->getType()); // Type::getInt32Ty(BC.Ctx));
     Constant *StoreValueOpcode =
-        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::RawBufferStore);
+        BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
     UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
     UndefValue *UndefArg = nullptr;
     if (TheValueTypeID == Type::TypeID::IntegerTyID) {
@@ -774,7 +774,6 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
       assert(false);
     }
     Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
-    Constant *Alignment = BC.HlslOP->GetI32Const(4);
     (void)BC.Builder.CreateCall(
         StoreValue, {StoreValueOpcode, // i32 opcode
                      m_HandleForUAV,   // %dx.types.Handle, ; resource handle
@@ -784,8 +783,7 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
                      UndefArg, // unused values
                      UndefArg, // unused values
                      UndefArg, // unused values
-                     WriteMask_X,
-                     Alignment});
+                     WriteMask_X});
 
     m_RemainingReservedSpaceInBytes -= 4;
     assert(m_RemainingReservedSpaceInBytes < 1024); // check for underflow

--- a/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilPIXMeshShaderOutputInstrumentation.cpp
@@ -144,12 +144,11 @@ Value *DxilPIXMeshShaderOutputInstrumentation::writeDwordAndReturnNewOffset(
 {
 
   Function *StoreValue =
-      BC.HlslOP->GetOpFunc(OP::OpCode::RawBufferStore, Type::getInt32Ty(BC.Ctx));
+      BC.HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(BC.Ctx));
   Constant *StoreValueOpcode =
-      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::RawBufferStore);
+      BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::BufferStore);
   UndefValue *Undef32Arg = UndefValue::get(Type::getInt32Ty(BC.Ctx));
   Constant *WriteMask_X = BC.HlslOP->GetI8Const(1);
-  Constant *Alignment = BC.HlslOP->GetI32Const(4);
 
   (void)BC.Builder.CreateCall(
       StoreValue,
@@ -161,8 +160,7 @@ Value *DxilPIXMeshShaderOutputInstrumentation::writeDwordAndReturnNewOffset(
        Undef32Arg, // unused values
        Undef32Arg, // unused values
        Undef32Arg, // unused values
-       WriteMask_X, 
-       Alignment});
+       WriteMask_X});
 
   m_RemainingReservedSpaceInBytes -= sizeof(uint32_t);
   assert(m_RemainingReservedSpaceInBytes >=

--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -353,12 +353,11 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
   UndefValue *UndefIntArg = UndefValue::get(Type::getInt32Ty(Ctx));
   Constant *LiteralOne = HlslOP->GetU32Const(1);
   Constant *ElementMask = HlslOP->GetI8Const(1);
-  Constant *Alignment = HlslOP->GetI32Const(4);
 
   Function *StoreFunc =
-      HlslOP->GetOpFunc(OP::OpCode::RawBufferStore, Type::getInt32Ty(Ctx));
+      HlslOP->GetOpFunc(OP::OpCode::BufferStore, Type::getInt32Ty(Ctx));
   Constant *StoreOpcode =
-      HlslOP->GetU32Const((unsigned)OP::OpCode::RawBufferStore);
+      HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
   (void)Builder.CreateCall(
       StoreFunc,
       {
@@ -372,8 +371,7 @@ void DxilShaderAccessTracking::EmitAccess(LLVMContext &Ctx, OP *HlslOP,
           UndefIntArg,            // i32, ; value v1
           UndefIntArg,            // i32, ; value v2
           UndefIntArg,            // i32, ; value v3
-          ElementMask,            // i8 ; just the first value is used
-          Alignment
+          ElementMask             // i8 ; just the first value is used
       });
 }
 
@@ -559,11 +557,10 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
             CombinedFlagOrInstructionValue = EncodedFlags;
           }
           Constant *ElementMask = HlslOP->GetI8Const(1);
-          Constant *Alignment = HlslOP->GetI32Const(4);
-          Function *StoreFunc = HlslOP->GetOpFunc(OP::OpCode::RawBufferStore,
+          Function *StoreFunc = HlslOP->GetOpFunc(OP::OpCode::BufferStore,
                                                   Type::getInt32Ty(Ctx));
           Constant *StoreOpcode =
-              HlslOP->GetU32Const((unsigned)OP::OpCode::RawBufferStore);
+              HlslOP->GetU32Const((unsigned)OP::OpCode::BufferStore);
           UndefValue *UndefArg = UndefValue::get(Type::getInt32Ty(Ctx));
           (void)Builder.CreateCall(
               StoreFunc,
@@ -578,8 +575,7 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
                   UndefArg,                     // i32, ; value v1
                   UndefArg,                     // i32, ; value v2
                   UndefArg,                     // i32, ; value v3
-                  ElementMask,                  // i8 ; just the first value is used
-                  Alignment
+                  ElementMask                   // i8 ; just the first value is used
               });
           return true; // did modify
       }

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTracking.hlsl
@@ -12,7 +12,7 @@
 // CHECK: slotIndex = mul i32
 
 // Check for udpate of UAV:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 
 
 ByteAddressBuffer inBuffer : register(t0);

--- a/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AccessTrackingForSamplerFeedback.hlsl
@@ -4,13 +4,13 @@
 // CHECK:  %PIX_CountUAV_Handle = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 0, i1 false)
 
 // Feedback UAV:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 28
 
 // Texture:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 12
 
 // Sampler:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle, i32 0
 
 Texture2D texture : register(t0);
 SamplerState samplerState : register(s0);

--- a/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToMSPayload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToMSPayload.hlsl
@@ -3,7 +3,7 @@
 // CHECK: getelementptr %PIX_AS2MS_Expanded_Type
 
 // Validate that instrumentation appeared before a store-output
-// CHECK: call void @dx.op.rawBufferStore.i32
+// CHECK: call void @dx.op.bufferStore.i32
 // CHECK: call void @dx.op.storeVertexOutput
 
 struct PSInput

--- a/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugBasic.hlsl
@@ -20,7 +20,7 @@
 // CHECK: %MaskedForUAVLimit = and i32 %UAVIncResult, 983039
 // CHECK: %MultipliedForInterest = mul i32 %MaskedForUAVLimit, %OffsetMultiplicand
 // CHECK: %AddedForInterest = add i32 %MultipliedForInterest, %OffsetAddend
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest
 
 
 [RootSignature("")]

--- a/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugFlowControl.hlsl
@@ -10,7 +10,7 @@
 
 // CHECK:  %AddedForInterest5 = add i32 %MultipliedForInterest4, %OffsetAddend
 
-// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5
+// CHECK:  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 %AddedForInterest5
 
 
 struct VS_OUTPUT_ENV {

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicResourceAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicResourceAccessTracking.hlsl
@@ -12,7 +12,7 @@ void Main()
 // CHECK: call %dx.types.Handle @dx.op.createHandleFromBinding
 
 // Check we wrote to the PIX UAV:
-// CHECK: call void @dx.op.rawBufferStore.i32
+// CHECK: call void @dx.op.bufferStore.i32
 
 // Offset for buffer Load should be 256 + 8 (skip out-of-bounds record) + 8 (it's the 1th resource) + 4 (offset to the "read" field) = 276
 // The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) for this access

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerAccessTracking.hlsl
@@ -18,9 +18,9 @@ float4 Main() : SV_Target
 
 // Check we wrote sampler data to the PIX UAV. We told the pass to output starting at offset 512.
 // Add 8 to skip the "out of bounds" record. Add 4 to point to the "read" field within the next entry = 524
-// CHECK: call void @dx.op.rawBufferStore.i32(
+// CHECK: call void @dx.op.bufferStore.i32(
 // CHECK:i32 524, i32 undef, i32 16777216
 
 // twice: 512 + 8 + 8*3+4 = 548
-// CHECK: call void @dx.op.rawBufferStore.i32(
+// CHECK: call void @dx.op.bufferStore.i32(
 // CHECK:i32 548, i32 undef, i32 16777216

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
@@ -20,5 +20,5 @@ float4 Main() : SV_Target
 // There are therefore no expected in-bounds references to samplers, so any such reference should go to the out-of-bounds offset at 512:
 
 // Out of bounds sampler access should be at offset 512
-// CHECK: call void @dx.op.rawBufferStore.i32(
+// CHECK: call void @dx.op.bufferStore.i32(
 // CHECK:i32 512, i32 undef, i32 16777216

--- a/tools/clang/test/HLSLFileCheck/pix/LibAccessTracking.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/LibAccessTracking.hlsl
@@ -6,11 +6,11 @@
 // CHECK: call %dx.types.Handle @dx.op.createHandleForLib.struct.RWByteAddressBuffer
 // 
 // check for an attempt to write to the PIX UAV before the load from TerrainTextures:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle
 // CHECK: call %dx.types.ResRet.f32 @dx.op.textureLoad
 // 
 // And a write for the store to RenderTarget:
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle
 // CHECK: void @dx.op.textureStore
 
 

--- a/tools/clang/test/HLSLFileCheck/pix/TraceRayInline.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/TraceRayInline.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T vs_6_5 -E main %s | %opt -S -hlsl-dxil-pix-shader-access-instrumentation,config=S0:1:1i1;U0:2:10i0;.0;0;0. | FileCheck %s
 
 // CHECK: call void @dx.op.rayQuery_TraceRayInline
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle
 
 RaytracingAccelerationStructure RTAS;
 

--- a/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/rawBufferStore.hlsl
@@ -2,24 +2,24 @@
 
 // Check that the expected PIX UAV read-tracking is emitted (the atomicBinOp "|= 1") followed by the expected raw read:
 
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.i32 @dx.op.rawBufferLoad.i32
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call %dx.types.ResRet.i16 @dx.op.rawBufferLoad.i16
 
 // Now the writes with atomicBinOp "|=2":
 
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f32
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i32
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.f16
-// CHECK: call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %PIX_CountUAV_Handle
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_CountUAV_Handle
 // CHECK: call void @dx.op.rawBufferStore.i16
 
 struct S


### PR DESCRIPTION
A recent change switched to RawBufferStore, because it's a raw UAV at the API. Some GPUs' drivers were upset by this form of store. Spent quite some time trying to modify parameters to please the driver, but to no avail. Since it doesn't really matter which store operand is used, I switched back to BufferStore, and now all (known) drivers are happy.