### PR TITLE
Remove > %s  in FileCheck tests

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/alloca-non-entry-basic-block.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/alloca-non-entry-basic-block.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/enable-partial-unroll-test01.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/enable-partial-unroll-test01.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tcs_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tcs_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/enable-partial-unroll-test02.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/loops/enable-partial-unroll-test02.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tcs_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tcs_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/misc/function-param-typedef-test.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/misc/function-param-typedef-test.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_floats.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_floats.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+}} = call half @dx.op.loadInput.f16(i32 4, i32 3, i32 0, i8 0, i32 undef)
 // CHECK: %{{[a-z0-9]+}} = call half @dx.op.loadInput.f16(i32 4, i32 2, i32 0, i8 0, i32 undef)

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_floats_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_floats_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -enable-16bit-types /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc -enable-16bit-types /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+}} = call half @dx.op.loadInput.f16(i32 4, i32 3, i32 0, i8 0, i32 undef)
 // CHECK: %{{[a-z0-9]+}} = call half @dx.op.loadInput.f16(i32 4, i32 2, i32 0, i8 0, i32 undef)

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_ints.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_ints.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+}} = call i16 @dx.op.loadInput.i16(i32 4, i32 4, i32 0, i8 0, i32 undef)
 // CHECK: %{{[a-z0-9]+}} = call i16 @dx.op.loadInput.i16(i32 4, i32 3, i32 0, i8 0, i32 undef)

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_float.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_float.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = frem fast float %{{[a-z0-9]+.*[a-z0-9]*}}, 1.000000e+01
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fdiv fast float %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_float_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_float_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = frem fast float %{{[a-z0-9]+.*[a-z0-9]*}}, 1.000000e+01
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fdiv fast float %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_half.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_half.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fmul fast float %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_half_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_half_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fmul fast half %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_int.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_int.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = sdiv i32 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_int_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_int_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = sdiv i32 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min10float.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min10float.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fsub fast half %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min10float_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min10float_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fsub fast half %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min12int.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min12int.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = sub nsw i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min12int_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min12int_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = sub nsw i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16float.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16float.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fadd fast half %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16float_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16float_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = fadd fast half %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16int.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16int.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = add nsw i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16int_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16int_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = add nsw i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16uint.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16uint.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = shl i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16uint_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_min16uint_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = shl i16 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_uint.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_uint.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = mul i32 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_uint_16bitflag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/overloading/function_overload_selection_uint_16bitflag.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_2 -enable-16bit-types /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+.*[a-z0-9]*}} = mul i32 %{{[a-z0-9]+.*[a-z0-9]*}}, %{{[a-z0-9]+.*[a-z0-9]*}}
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_signed_unsigned.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/atomic/atomic_signed_unsigned.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tcs_6_2 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tcs_6_2 /Emain  %s | FileCheck %s
 
 // Make sure choose correct signed unsigned.
 // CHECK:atomicrmw max

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/compound/check-modf.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/compound/check-modf.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_0 /Eps_main > %s | FileCheck %s
+// RUN: %dxc /Tps_6_0 /Eps_main  %s | FileCheck %s
 // CHECK: define void @ps_main()
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0x3FFB333340000000)
 // CHECK: entry

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/line_directive/line_directive.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/line_directive/line_directive.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 2> %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0  %s | FileCheck %s
 
 // #line directive should be honored
 // CHECK: renamed.hlsl:42

--- a/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/line_directive/line_directive_ignored.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/preprocessor/line_directive/line_directive_ignored.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -ignore-line-directives 2> %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -ignore-line-directives  %s | FileCheck %s
 
 // #line directive should be ignored due to -ignore-line-directives
 // CHECK-NOT: renamed.hlsl:42

--- a/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_cleanup.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/resource_binding/resource_cleanup.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /O3 /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /O3 /Tps_6_0 /Emain  %s | FileCheck %s
 
 // Make sure only one cbuffer is emitted for the final
 // dxil.

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_idx_with_expr_test01.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_idx_with_expr_test01.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 > %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0  %s | FileCheck %s
 
 // CHECK: define void @main()
 // CHECK: %{{[a-z0-9]+}} = shl i32 %{{[a-z0-9]+}}, 2

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/array_cast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/array_cast.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 > %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0  %s | FileCheck %s
 
 // Make sure cast to nest struct works.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test01.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test01.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 /Gec -HV 2016 > %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 /Gec -HV 2016  %s | FileCheck %s
 
 // Writing to globals only supported with HV <= 2016
 // CHECK: define void @main

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test02.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test02.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 /Gec -HV 2016 2> %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 /Gec -HV 2016  %s | FileCheck %s
 
 // Modifying local const should fail even with HV <= 2016
 // CHECK: warning: /Gec flag is a deprecated functionality.

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test04.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test04.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -fcgl -T ps_6_0 /Gec -HV 2016 > %s | FileCheck %s
+// RUN: %dxc -E main -fcgl -T ps_6_0 /Gec -HV 2016 %s | FileCheck %s
 
 // Writing to globals only supported with HV <= 2016
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test05.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/global-var-write-test05.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 /Gec -HV 2016 > %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 /Gec -HV 2016 %s | FileCheck %s
 
 // CHECK: define void @main()
 // CHECK: ret void

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/no_initialization.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/global/no_initialization.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 > %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
 
 // Test that no variable initializers are emitted, especially for cbuffers globals.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/pragma_granularity.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/pragma_granularity.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T vs_6_0 /E main > %s | FileCheck %s
+// RUN: %dxc /T vs_6_0 /E main  %s | FileCheck %s
 
 // Tests the exact place at which #pragma pack_matrix takes effect.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/pragma_granularity_template_syntax.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/pragma_granularity_template_syntax.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T vs_6_0 /E main > %s | FileCheck %s
+// RUN: %dxc /T vs_6_0 /E main  %s | FileCheck %s
 
 #pragma pack_matrix(column_major)
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tvs_6_0 /Evs_main > %s | FileCheck %s
+// RUN: %dxc /Tvs_6_0 /Evs_main  %s | FileCheck %s
 
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_multiple_calls.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_multiple_calls.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tvs_6_0 /Evs_main > %s | FileCheck %s
+// RUN: %dxc /Tvs_6_0 /Evs_main  %s | FileCheck %s
 
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 2.000000e+00)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 4.000000e+00)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_with_branches.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_with_branches.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tvs_6_0 /Evs_main > %s | FileCheck %s
+// RUN: %dxc /Tvs_6_0 /Evs_main  %s | FileCheck %s
 
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.000000e+00)
 // CHECK: call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 2.000000e+00)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_with_branches_ast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/return_type_with_branches_ast.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -ast-dump /Tvs_6_0 /Evs_main > %s | FileCheck %s
+// RUN: %dxc -ast-dump /Tvs_6_0 /Evs_main  %s | FileCheck %s
 
 // CHECK: GetMatrix 'row_major float2x2 (int)'
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/transpose_in_function.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/matrix_packing/transpose_in_function.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T vs_6_0 /E main > %s | FileCheck %s
+// RUN: %dxc /T vs_6_0 /E main  %s | FileCheck %s
 
 // Regression test for a bug where the transpose isn't performed,
 // or is performed twice, when wrapped in its own function.

--- a/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/legalize-offset-higher-opts.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/legalize-offset-higher-opts.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /Tps_6_0 /Emain  %s | FileCheck %s
 
 // Make sure that the sample offsets get legalized even when loop is not unrolled
 // for higher optimizations.

--- a/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test01.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test01.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /O0 /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /O0 /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 Texture2D g_Tex;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test02.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test02.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /O0 /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /O0 /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 Texture2D g_Tex;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test03.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test03.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /O0 /Od /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /O0 /Od /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 Texture2D g_Tex;

--- a/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test04.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/hl/legalize_sample_offset/sample-offset-imm-test04.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /O0 /Od /Tps_6_0 /Emain > %s | FileCheck %s
+// RUN: %dxc /O0 /Od /Tps_6_0 /Emain  %s | FileCheck %s
 // CHECK: define void @main()
 // CHECK: entry
 Texture2D g_Tex;


### PR DESCRIPTION
Things like RUN: %dxc /Tps_6_0 /Eps_main > %s will overwrite the test when running with lit.