### PR TITLE
bitfields: refactorize struct offset computation

### DIFF
--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -36,7 +36,7 @@ namespace spirv {
 
 void AlignmentSizeCalculator::alignUsingHLSLRelaxedLayout(
     QualType fieldType, uint32_t fieldSize, uint32_t fieldAlignment,
-    uint32_t *currentOffset) {
+    uint32_t *currentOffset) const {
   QualType vecElemType = {};
   const bool fieldIsVecType = isVectorType(fieldType, &vecElemType);
 
@@ -64,7 +64,7 @@ void AlignmentSizeCalculator::alignUsingHLSLRelaxedLayout(
 
 std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
     QualType type, SpirvLayoutRule rule, llvm::Optional<bool> isRowMajor,
-    uint32_t *stride) {
+    uint32_t *stride) const {
   // std140 layout rules:
 
   // 1. If the member is a scalar consuming N basic machine units, the base

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.h
@@ -38,7 +38,7 @@ public:
   /// size contains post-paddings required by the given type.
   std::pair<uint32_t, uint32_t>
   getAlignmentAndSize(QualType type, SpirvLayoutRule rule,
-                      llvm::Optional<bool> isRowMajor, uint32_t *stride);
+                      llvm::Optional<bool> isRowMajor, uint32_t *stride) const;
 
   /// \brief Aligns currentOffset properly to allow packing vectors in the HLSL
   /// way: using the element type's alignment as the vector alignment, as long
@@ -47,11 +47,12 @@ public:
   /// calculated without considering the HLSL vector relaxed rule.
   void alignUsingHLSLRelaxedLayout(QualType fieldType, uint32_t fieldSize,
                                    uint32_t fieldAlignment,
-                                   uint32_t *currentOffset);
+                                   uint32_t *currentOffset) const;
 
   /// \brief Returns true if we use row-major matrix for type. Otherwise,
   /// returns false.
-  bool useRowMajor(llvm::Optional<bool> isRowMajor, clang::QualType type) {
+  bool useRowMajor(llvm::Optional<bool> isRowMajor,
+                   clang::QualType type) const {
     return isRowMajor.hasValue() ? isRowMajor.getValue()
                                  : isRowMajorMatrix(spvOptions, type);
   }
@@ -60,7 +61,7 @@ private:
   /// Emits error to the diagnostic engine associated with this visitor.
   template <unsigned N>
   DiagnosticBuilder emitError(const char (&message)[N],
-                              SourceLocation srcLoc = {}) {
+                              SourceLocation srcLoc = {}) const {
     const auto diagId = astContext.getDiagnostics().getCustomDiagID(
         clang::DiagnosticsEngine::Error, message);
     return astContext.getDiagnostics().Report(srcLoc, diagId);

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -90,6 +90,12 @@ private:
   populateLayoutInformation(llvm::ArrayRef<HybridStructType::FieldInfo> fields,
                             SpirvLayoutRule rule);
 
+  /// Create a clang::StructType::FieldInfo from HybridStructType::FieldInfo.
+  /// This function only considers the field as standalone.
+  /// Offset and layout constraint from the parent struct are not considered.
+  StructType::FieldInfo lowerField(const HybridStructType::FieldInfo *field,
+                                   SpirvLayoutRule rule);
+
 private:
   ASTContext &astContext;                /// AST context
   SpirvContext &spvContext;              /// SPIR-V context


### PR DESCRIPTION
This is some preliminary work to bitfield addition into the SPIR-V backend. This commit should not change the behavior of our backend.

The next steps of the bitfield feature can be seen here : https://github.com/Keenuts/DirectXShaderCompiler/tree/bitfields
(state of this branch not guaranteed, as it's my working branch)