### PR TITLE
MergeGepUse improvements

### DIFF
--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -61,7 +61,13 @@ namespace dxilutil {
                                    llvm::Type *Ty, DxilTypeSystem &typeSys);
   llvm::Type *GetArrayEltTy(llvm::Type *Ty);
   bool HasDynamicIndexing(llvm::Value *V);
-  void MergeGepUse(llvm::Value *V);
+
+  // Cleans up unnecessary chains of GEPs and bitcasts left over from certain
+  // optimizations. This function is NOT safe to call while iterating
+  // instructions either forward or backward. If V happens to be a GEP or
+  // bitcast, the function may delete V, instructions preceding V it, and
+  // instructions following V.
+  bool MergeGepUse(llvm::Value *V);
 
   // Find alloca insertion point, given instruction
   llvm::Instruction *FindAllocaInsertionPt(llvm::Instruction* I); // Considers entire parent function


### PR DESCRIPTION
- Added a comment warning  about using MergeGepUse while iterating.
- Changed MergeGepUse to return bool for whether anything actually changed.
- Adding GEP's user to worklist, even when GEP and GEP's source pointer GEP cannot be merged.