### PR TITLE
Import Optional from LLVM @644aa882359a

### DIFF
--- a/include/llvm/ADT/Optional.h
+++ b/include/llvm/ADT/Optional.h
@@ -1,4 +1,4 @@
-//===-- Optional.h - Simple variant for passing optional values ---*- C++ -*-=//
+//===- Optional.h - Simple variant for passing optional values --*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -19,67 +19,52 @@
 #include "llvm/ADT/None.h"
 #include "llvm/Support/AlignOf.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/type_traits.h"
+#include <algorithm>
 #include <cassert>
 #include <new>
 #include <utility>
 
 namespace llvm {
 
-template<typename T>
-class Optional {
+namespace optional_detail {
+/// Storage for any type.
+template <typename T, bool = isPodLike<T>::value> struct OptionalStorage {
   AlignedCharArrayUnion<T> storage;
-  bool hasVal;
-public:
-  typedef T value_type;
+  bool hasVal = false;
 
-  Optional(NoneType) : hasVal(false) {}
-  explicit Optional() : hasVal(false) {}
-  Optional(const T &y) : hasVal(true) {
-    new (storage.buffer) T(y);
-  }
-  Optional(const Optional &O) : hasVal(O.hasVal) {
+  OptionalStorage() = default;
+
+  OptionalStorage(const T &y) : hasVal(true) { new (storage.buffer) T(y); }
+  OptionalStorage(const OptionalStorage &O) : hasVal(O.hasVal) {
     if (hasVal)
-      new (storage.buffer) T(*O);
+      new (storage.buffer) T(*O.getPointer());
   }
-
-  Optional(T &&y) : hasVal(true) {
+  OptionalStorage(T &&y) : hasVal(true) {
     new (storage.buffer) T(std::forward<T>(y));
   }
-  Optional(Optional<T> &&O) : hasVal(O) {
-    if (O) {
-      new (storage.buffer) T(std::move(*O));
-      O.reset();
+  OptionalStorage(OptionalStorage &&O) : hasVal(O.hasVal) {
+    if (O.hasVal) {
+      new (storage.buffer) T(std::move(*O.getPointer()));
     }
   }
-  Optional &operator=(T &&y) {
+
+  OptionalStorage &operator=(T &&y) {
     if (hasVal)
-      **this = std::move(y);
+      *getPointer() = std::move(y);
     else {
       new (storage.buffer) T(std::move(y));
       hasVal = true;
     }
     return *this;
   }
-  Optional &operator=(Optional &&O) {
-    if (!O)
+  OptionalStorage &operator=(OptionalStorage &&O) {
+    if (!O.hasVal)
       reset();
     else {
-      *this = std::move(*O);
-      O.reset();
+      *this = std::move(*O.getPointer());
     }
     return *this;
-  }
-
-  /// Create a new object by constructing it in place with the given arguments.
-  template<typename ...ArgTypes>
-  void emplace(ArgTypes &&...Args) {
-    reset();
-    hasVal = true;
-    new (storage.buffer) T(std::forward<ArgTypes>(Args)...);
-  }
-
-  static inline Optional create(const T* y) {
-    return y ? Optional(*y) : Optional();
   }
 
   // FIXME: these assignments (& the equivalent const T&/const Optional& ctors)
@@ -87,55 +72,110 @@ public:
   // with the rvalue versions above - but this could place a different set of
   // requirements (notably: the existence of a default ctor) when implemented
   // in that way. Careful SFINAE to avoid such pitfalls would be required.
-  Optional &operator=(const T &y) {
+  OptionalStorage &operator=(const T &y) {
     if (hasVal)
-      **this = y;
+      *getPointer() = y;
     else {
       new (storage.buffer) T(y);
       hasVal = true;
     }
     return *this;
   }
-
-  Optional &operator=(const Optional &O) {
-    if (!O)
+  OptionalStorage &operator=(const OptionalStorage &O) {
+    if (!O.hasVal)
       reset();
     else
-      *this = *O;
+      *this = *O.getPointer();
     return *this;
   }
 
+  ~OptionalStorage() { reset(); }
+
   void reset() {
     if (hasVal) {
-      (**this).~T();
+      (*getPointer()).~T();
       hasVal = false;
     }
   }
 
-  ~Optional() {
+  T *getPointer() {
+    assert(hasVal);
+    return reinterpret_cast<T *>(storage.buffer);
+  }
+  const T *getPointer() const {
+    assert(hasVal);
+    return reinterpret_cast<const T *>(storage.buffer);
+  }
+};
+
+} // namespace optional_detail
+
+template <typename T> class Optional {
+  optional_detail::OptionalStorage<T> Storage;
+
+public:
+  using value_type = T;
+
+  constexpr Optional() {}
+  constexpr Optional(NoneType) {}
+
+  Optional(const T &y) : Storage(y) {}
+  Optional(const Optional &O) = default;
+
+  Optional(T &&y) : Storage(std::forward<T>(y)) {}
+  Optional(Optional &&O) = default;
+
+  Optional &operator=(T &&y) {
+    Storage = std::move(y);
+    return *this;
+  }
+  Optional &operator=(Optional &&O) = default;
+
+  /// Create a new object by constructing it in place with the given arguments.
+  template <typename... ArgTypes> void emplace(ArgTypes &&... Args) {
     reset();
+    Storage.hasVal = true;
+    new (getPointer()) T(std::forward<ArgTypes>(Args)...);
   }
 
-  const T* getPointer() const { assert(hasVal); return reinterpret_cast<const T*>(storage.buffer); }
-  T* getPointer() { assert(hasVal); return reinterpret_cast<T*>(storage.buffer); }
-  const T& getValue() const LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
-  T& getValue() LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
+  static inline Optional create(const T *y) {
+    return y ? Optional(*y) : Optional();
+  }
 
-  explicit operator bool() const { return hasVal; }
-  bool hasValue() const { return hasVal; }
-  const T* operator->() const { return getPointer(); }
-  T* operator->() { return getPointer(); }
-  const T& operator*() const LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
-  T& operator*() LLVM_LVALUE_FUNCTION { assert(hasVal); return *getPointer(); }
+  Optional &operator=(const T &y) {
+    Storage = y;
+    return *this;
+  }
+  Optional &operator=(const Optional &O) = default;
+
+  void reset() { Storage.reset(); }
+
+  const T *getPointer() const {
+    assert(Storage.hasVal);
+    return reinterpret_cast<const T *>(Storage.storage.buffer);
+  }
+  T *getPointer() {
+    assert(Storage.hasVal);
+    return reinterpret_cast<T *>(Storage.storage.buffer);
+  }
+  const T &getValue() const LLVM_LVALUE_FUNCTION { return *getPointer(); }
+  T &getValue() LLVM_LVALUE_FUNCTION { return *getPointer(); }
+
+  explicit operator bool() const { return Storage.hasVal; }
+  bool hasValue() const { return Storage.hasVal; }
+  const T *operator->() const { return getPointer(); }
+  T *operator->() { return getPointer(); }
+  const T &operator*() const LLVM_LVALUE_FUNCTION { return *getPointer(); }
+  T &operator*() LLVM_LVALUE_FUNCTION { return *getPointer(); }
 
   template <typename U>
-  LLVM_CONSTEXPR T getValueOr(U &&value) const LLVM_LVALUE_FUNCTION {
+  constexpr T getValueOr(U &&value) const LLVM_LVALUE_FUNCTION {
     return hasValue() ? getValue() : std::forward<U>(value);
   }
 
 #if LLVM_HAS_RVALUE_REFERENCE_THIS
-  T&& getValue() && { assert(hasVal); return std::move(*getPointer()); }
-  T&& operator*() && { assert(hasVal); return std::move(*getPointer()); }
+  T &&getValue() && { return std::move(*getPointer()); }
+  T &&operator*() && { return std::move(*getPointer()); }
 
   template <typename U>
   T getValueOr(U &&value) && {
@@ -144,66 +184,145 @@ public:
 #endif
 };
 
-template <typename T> struct isPodLike;
-template <typename T> struct isPodLike<Optional<T> > {
+template <typename T> struct isPodLike<Optional<T>> {
   // An Optional<T> is pod-like if T is.
   static const bool value = isPodLike<T>::value;
 };
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator==(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator==(const Optional<T> &X, const Optional<U> &Y) {
+  if (X && Y)
+    return *X == *Y;
+  return X.hasValue() == Y.hasValue();
+}
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator!=(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator!=(const Optional<T> &X, const Optional<U> &Y) {
+  return !(X == Y);
+}
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator<(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator<(const Optional<T> &X, const Optional<U> &Y) {
+  if (X && Y)
+    return *X < *Y;
+  return X.hasValue() < Y.hasValue();
+}
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator<=(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator<=(const Optional<T> &X, const Optional<U> &Y) {
+  return !(Y < X);
+}
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator>=(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator>(const Optional<T> &X, const Optional<U> &Y) {
+  return Y < X;
+}
 
-/// \brief Poison comparison between two \c Optional objects. Clients needs to
-/// explicitly compare the underlying values and account for empty \c Optional
-/// objects.
-///
-/// This routine will never be defined. It returns \c void to help diagnose
-/// errors at compile time.
-template<typename T, typename U>
-void operator>(const Optional<T> &X, const Optional<U> &Y);
+template <typename T, typename U>
+bool operator>=(const Optional<T> &X, const Optional<U> &Y) {
+  return !(X < Y);
+}
 
-} // end llvm namespace
+template<typename T>
+bool operator==(const Optional<T> &X, NoneType) {
+  return !X;
+}
 
-#endif
+template<typename T>
+bool operator==(NoneType, const Optional<T> &X) {
+  return X == None;
+}
+
+template<typename T>
+bool operator!=(const Optional<T> &X, NoneType) {
+  return !(X == None);
+}
+
+template<typename T>
+bool operator!=(NoneType, const Optional<T> &X) {
+  return X != None;
+}
+
+template <typename T> bool operator<(const Optional<T> &X, NoneType) {
+  return false;
+}
+
+template <typename T> bool operator<(NoneType, const Optional<T> &X) {
+  return X.hasValue();
+}
+
+template <typename T> bool operator<=(const Optional<T> &X, NoneType) {
+  return !(None < X);
+}
+
+template <typename T> bool operator<=(NoneType, const Optional<T> &X) {
+  return !(X < None);
+}
+
+template <typename T> bool operator>(const Optional<T> &X, NoneType) {
+  return None < X;
+}
+
+template <typename T> bool operator>(NoneType, const Optional<T> &X) {
+  return X < None;
+}
+
+template <typename T> bool operator>=(const Optional<T> &X, NoneType) {
+  return None <= X;
+}
+
+template <typename T> bool operator>=(NoneType, const Optional<T> &X) {
+  return X <= None;
+}
+
+template <typename T> bool operator==(const Optional<T> &X, const T &Y) {
+  return X && *X == Y;
+}
+
+template <typename T> bool operator==(const T &X, const Optional<T> &Y) {
+  return Y && X == *Y;
+}
+
+template <typename T> bool operator!=(const Optional<T> &X, const T &Y) {
+  return !(X == Y);
+}
+
+template <typename T> bool operator!=(const T &X, const Optional<T> &Y) {
+  return !(X == Y);
+}
+
+template <typename T> bool operator<(const Optional<T> &X, const T &Y) {
+  return !X || *X < Y;
+}
+
+template <typename T> bool operator<(const T &X, const Optional<T> &Y) {
+  return Y && X < *Y;
+}
+
+template <typename T> bool operator<=(const Optional<T> &X, const T &Y) {
+  return !(Y < X);
+}
+
+template <typename T> bool operator<=(const T &X, const Optional<T> &Y) {
+  return !(Y < X);
+}
+
+template <typename T> bool operator>(const Optional<T> &X, const T &Y) {
+  return Y < X;
+}
+
+template <typename T> bool operator>(const T &X, const Optional<T> &Y) {
+  return Y < X;
+}
+
+template <typename T> bool operator>=(const Optional<T> &X, const T &Y) {
+  return !(X < Y);
+}
+
+template <typename T> bool operator>=(const T &X, const Optional<T> &Y) {
+  return !(X < Y);
+}
+
+} // end namespace llvm
+
+#endif // LLVM_ADT_OPTIONAL_H

--- a/unittests/ADT/OptionalTest.cpp
+++ b/unittests/ADT/OptionalTest.cpp
@@ -7,8 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "gtest/gtest.h"
 #include "llvm/ADT/Optional.h"
+#include "gtest/gtest.h"
+
 using namespace llvm;
 
 namespace {
@@ -267,12 +268,12 @@ TEST_F(OptionalTest, MoveOnlyMoveConstruction) {
   Optional<MoveOnly> A(MoveOnly(3));
   MoveOnly::ResetCounts();
   Optional<MoveOnly> B(std::move(A));
-  EXPECT_FALSE((bool)A);
+  EXPECT_TRUE((bool)A);
   EXPECT_TRUE((bool)B);
   EXPECT_EQ(3, B->val);
   EXPECT_EQ(1u, MoveOnly::MoveConstructions);
   EXPECT_EQ(0u, MoveOnly::MoveAssignments);
-  EXPECT_EQ(1u, MoveOnly::Destructions);
+  EXPECT_EQ(0u, MoveOnly::Destructions);
 }
 
 TEST_F(OptionalTest, MoveOnlyAssignment) {
@@ -291,12 +292,12 @@ TEST_F(OptionalTest, MoveOnlyInitializingAssignment) {
   Optional<MoveOnly> B;
   MoveOnly::ResetCounts();
   B = std::move(A);
-  EXPECT_FALSE((bool)A);
+  EXPECT_TRUE((bool)A);
   EXPECT_TRUE((bool)B);
   EXPECT_EQ(3, B->val);
   EXPECT_EQ(1u, MoveOnly::MoveConstructions);
   EXPECT_EQ(0u, MoveOnly::MoveAssignments);
-  EXPECT_EQ(1u, MoveOnly::Destructions);
+  EXPECT_EQ(0u, MoveOnly::Destructions);
 }
 
 TEST_F(OptionalTest, MoveOnlyNullingAssignment) {
@@ -316,12 +317,12 @@ TEST_F(OptionalTest, MoveOnlyAssigningAssignment) {
   Optional<MoveOnly> B(MoveOnly(4));
   MoveOnly::ResetCounts();
   B = std::move(A);
-  EXPECT_FALSE((bool)A);
+  EXPECT_TRUE((bool)A);
   EXPECT_TRUE((bool)B);
   EXPECT_EQ(3, B->val);
   EXPECT_EQ(0u, MoveOnly::MoveConstructions);
   EXPECT_EQ(1u, MoveOnly::MoveAssignments);
-  EXPECT_EQ(1u, MoveOnly::Destructions);
+  EXPECT_EQ(0u, MoveOnly::Destructions);
 }
 
 struct Immovable {
@@ -376,6 +377,146 @@ TEST_F(OptionalTest, MoveGetValueOr) {
 }
 
 #endif // LLVM_HAS_RVALUE_REFERENCE_THIS
+
+struct EqualTo {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X == Y;
+  }
+};
+
+struct NotEqualTo {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X != Y;
+  }
+};
+
+struct Less {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X < Y;
+  }
+};
+
+struct Greater {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X > Y;
+  }
+};
+
+struct LessEqual {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X <= Y;
+  }
+};
+
+struct GreaterEqual {
+  template <typename T, typename U> static bool apply(const T &X, const U &Y) {
+    return X >= Y;
+  }
+};
+
+template <typename OperatorT, typename T>
+void CheckRelation(const Optional<T> &Lhs, const Optional<T> &Rhs,
+                   bool Expected) {
+  EXPECT_EQ(Expected, OperatorT::apply(Lhs, Rhs));
+
+  if (Lhs)
+    EXPECT_EQ(Expected, OperatorT::apply(*Lhs, Rhs));
+  else
+    EXPECT_EQ(Expected, OperatorT::apply(None, Rhs));
+
+  if (Rhs)
+    EXPECT_EQ(Expected, OperatorT::apply(Lhs, *Rhs));
+  else
+    EXPECT_EQ(Expected, OperatorT::apply(Lhs, None));
+}
+
+struct EqualityMock {};
+const Optional<EqualityMock> NoneEq, EqualityLhs((EqualityMock())),
+    EqualityRhs((EqualityMock()));
+bool IsEqual;
+
+bool operator==(const EqualityMock &Lhs, const EqualityMock &Rhs) {
+  EXPECT_EQ(&*EqualityLhs, &Lhs);
+  EXPECT_EQ(&*EqualityRhs, &Rhs);
+  return IsEqual;
+}
+
+TEST_F(OptionalTest, OperatorEqual) {
+  CheckRelation<EqualTo>(NoneEq, NoneEq, true);
+  CheckRelation<EqualTo>(NoneEq, EqualityRhs, false);
+  CheckRelation<EqualTo>(EqualityLhs, NoneEq, false);
+
+  IsEqual = false;
+  CheckRelation<EqualTo>(EqualityLhs, EqualityRhs, IsEqual);
+  IsEqual = true;
+  CheckRelation<EqualTo>(EqualityLhs, EqualityRhs, IsEqual);
+}
+
+TEST_F(OptionalTest, OperatorNotEqual) {
+  CheckRelation<NotEqualTo>(NoneEq, NoneEq, false);
+  CheckRelation<NotEqualTo>(NoneEq, EqualityRhs, true);
+  CheckRelation<NotEqualTo>(EqualityLhs, NoneEq, true);
+
+  IsEqual = false;
+  CheckRelation<NotEqualTo>(EqualityLhs, EqualityRhs, !IsEqual);
+  IsEqual = true;
+  CheckRelation<NotEqualTo>(EqualityLhs, EqualityRhs, !IsEqual);
+}
+
+struct InequalityMock {};
+const Optional<InequalityMock> NoneIneq, InequalityLhs((InequalityMock())),
+    InequalityRhs((InequalityMock()));
+bool IsLess;
+
+bool operator<(const InequalityMock &Lhs, const InequalityMock &Rhs) {
+  EXPECT_EQ(&*InequalityLhs, &Lhs);
+  EXPECT_EQ(&*InequalityRhs, &Rhs);
+  return IsLess;
+}
+
+TEST_F(OptionalTest, OperatorLess) {
+  CheckRelation<Less>(NoneIneq, NoneIneq, false);
+  CheckRelation<Less>(NoneIneq, InequalityRhs, true);
+  CheckRelation<Less>(InequalityLhs, NoneIneq, false);
+
+  IsLess = false;
+  CheckRelation<Less>(InequalityLhs, InequalityRhs, IsLess);
+  IsLess = true;
+  CheckRelation<Less>(InequalityLhs, InequalityRhs, IsLess);
+}
+
+TEST_F(OptionalTest, OperatorGreater) {
+  CheckRelation<Greater>(NoneIneq, NoneIneq, false);
+  CheckRelation<Greater>(NoneIneq, InequalityRhs, false);
+  CheckRelation<Greater>(InequalityLhs, NoneIneq, true);
+
+  IsLess = false;
+  CheckRelation<Greater>(InequalityRhs, InequalityLhs, IsLess);
+  IsLess = true;
+  CheckRelation<Greater>(InequalityRhs, InequalityLhs, IsLess);
+}
+
+TEST_F(OptionalTest, OperatorLessEqual) {
+  CheckRelation<LessEqual>(NoneIneq, NoneIneq, true);
+  CheckRelation<LessEqual>(NoneIneq, InequalityRhs, true);
+  CheckRelation<LessEqual>(InequalityLhs, NoneIneq, false);
+
+  IsLess = false;
+  CheckRelation<LessEqual>(InequalityRhs, InequalityLhs, !IsLess);
+  IsLess = true;
+  CheckRelation<LessEqual>(InequalityRhs, InequalityLhs, !IsLess);
+}
+
+TEST_F(OptionalTest, OperatorGreaterEqual) {
+  CheckRelation<GreaterEqual>(NoneIneq, NoneIneq, true);
+  CheckRelation<GreaterEqual>(NoneIneq, InequalityRhs, false);
+  CheckRelation<GreaterEqual>(InequalityLhs, NoneIneq, true);
+
+  IsLess = false;
+  CheckRelation<GreaterEqual>(InequalityLhs, InequalityRhs, !IsLess);
+  IsLess = true;
+  CheckRelation<GreaterEqual>(InequalityLhs, InequalityRhs, !IsLess);
+}
 
 } // end anonymous namespace
 


### PR DESCRIPTION
Importing this version bring a few improvement, like the ability to store StructDecl types in an Optional.
Importing the last revision is not possible without outside additions, so picked the most recent commit, showing no revert/fix in the recent history, which is standalone.

Signed-off-by: Nathan Gauër <brioche@google.com>