### PR TITLE
TAEF Tests only work on Windows

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -99,11 +99,13 @@ add_lit_target("check-clang-unit" "Running lit suite clang-unit"
 # HLSL Change End - Add a separate target for clang unit tests
 
 # HLSL Change Begin - Add taef tests
-add_lit_target("check-hlsl" "Running lit suite hlsl"
-          ${CMAKE_CURRENT_SOURCE_DIR}/clang-hlsl
-          PARAMS ${CLANG_TEST_PARAMS}
-                 clang_hlsl_site_config=${CMAKE_CURRENT_BINARY_DIR}/clang-hlsl/lit.site.cfg
-          DEPENDS clang-hlsl-tests
-          ARGS ${CLANG_TEST_EXTRA_ARGS}
-        )
+if (WIN32)
+  add_lit_target("check-hlsl" "Running lit suite hlsl"
+            ${CMAKE_CURRENT_SOURCE_DIR}/clang-hlsl
+            PARAMS ${CLANG_TEST_PARAMS}
+                  clang_hlsl_site_config=${CMAKE_CURRENT_BINARY_DIR}/clang-hlsl/lit.site.cfg
+            DEPENDS clang-hlsl-tests
+            ARGS ${CLANG_TEST_EXTRA_ARGS}
+          )
+endif()
 # HLSL Change End

--- a/tools/clang/test/clang-hlsl/lit.cfg
+++ b/tools/clang/test/clang-hlsl/lit.cfg
@@ -35,3 +35,6 @@ test_dir = os.path.join(config.llvm_obj_root, config.build_mode, 'test')
 #projects\dxilconv\test
 config.test_format = lit.formats.TaefTest(te, test_dll, hlsl_data_dir, test_dir)
 
+# TAEF only runs on Windows
+if platform.system() != 'Windows':
+  config.unsupported = True


### PR DESCRIPTION
Disable the TAEF lit suite on non-Windows platforms.