### PR TITLE
Fix failing LLVM ArrayRef unit test

### DIFF
--- a/unittests/ADT/ArrayRefTest.cpp
+++ b/unittests/ADT/ArrayRefTest.cpp
@@ -99,7 +99,8 @@ static void ArgTest12(ArrayRef<int> A) {
 }
 
 TEST(ArrayRefTest, InitializerList) {
-  ArrayRef<int> A = { 0, 1, 2, 3, 4 };
+  std::initializer_list<int> InitList = { 0, 1, 2, 3, 4 };
+  ArrayRef<int> A = InitList;
   for (int i = 0; i < 5; ++i)
     EXPECT_EQ(i, A[i]);
 


### PR DESCRIPTION
The initializer list goes out of scope after the expression it is used in, so the ArrayRef points to invalid memory. This change keeps the initialization list around so that the array ref remains valid through the test.