### PR TITLE
Extend add_lit_testsuites to cover more cases

### DIFF
--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -943,26 +943,39 @@ endfunction()
 
 function(add_lit_testsuites project directory)
   if (NOT CMAKE_CONFIGURATION_TYPES)
-    cmake_parse_arguments(ARG "" "" "PARAMS;DEPENDS;ARGS" ${ARGN})
-    file(GLOB_RECURSE litCfg ${directory}/lit*.cfg)
-    set(lit_suites)
-    foreach(f ${litCfg})
-      get_filename_component(dir ${f} DIRECTORY)
-      set(lit_suites ${lit_suites} ${dir})
-    endforeach()
-    list(REMOVE_DUPLICATES lit_suites)
-    foreach(dir ${lit_suites})
-      string(REPLACE ${directory} "" name_slash ${dir})
+    cmake_parse_arguments(ARG "EXCLUDE_FROM_CHECK_ALL" "FOLDER" "PARAMS;DEPENDS;ARGS" ${ARGN})
+
+    if (NOT ARG_FOLDER)
+      set(ARG_FOLDER "Test Subdirectories")
+    endif()
+
+    # Search recursively for test directories by assuming anything not
+    # in a directory called Inputs contains tests.
+    file(GLOB_RECURSE to_process LIST_DIRECTORIES true ${directory}/*)
+    foreach(lit_suite ${to_process})
+      if(NOT IS_DIRECTORY ${lit_suite})
+        continue()
+      endif()
+      string(FIND ${lit_suite} Inputs is_inputs)
+      string(FIND ${lit_suite} Output is_output)
+      if (NOT (is_inputs EQUAL -1 AND is_output EQUAL -1))
+        continue()
+      endif()
+
+      # Create a check- target for the directory.
+      string(REPLACE ${directory} "" name_slash ${lit_suite})
       if (name_slash)
         string(REPLACE "/" "-" name_slash ${name_slash})
         string(REPLACE "\\" "-" name_dashes ${name_slash})
         string(TOLOWER "${project}${name_dashes}" name_var)
-        add_lit_target("check-${name_var}" "Running lit suite ${dir}"
-          ${dir}
+        add_lit_target("check-${name_var}" "Running lit suite ${lit_suite}"
+          ${lit_suite}
+          ${EXCLUDE_FROM_CHECK_ALL}
           PARAMS ${ARG_PARAMS}
           DEPENDS ${ARG_DEPENDS}
           ARGS ${ARG_ARGS}
         )
+        set_target_properties(check-${name_var} PROPERTIES FOLDER ${ARG_FOLDER})
       endif()
     endforeach()
   endif()


### PR DESCRIPTION
This pulls in a couple upstream commits by myself and @bogner.

commit 3adaa8cf4a6df45430b47a62c649c7cb54bb1626
Author: Justin Bogner <mail@justinbogner.com>
Date:   Wed Jun 8 22:36:37 2016 +0000

    cmake: Simplify add_lit_testsuites

    cmake 3.4 introduced LIST_DIRECTORIES to glob recurse, which can be
    used to simplify this code greatly.

    llvm-svn: 272217

commit 25ef9e34c9de7b1edc327189b78200459337f7e5
Author: Justin Bogner <mail@justinbogner.com>
Date:   Mon Jul 25 18:07:14 2016 +0000

    cmake: When adding lit testsuites, ignore Output directories

    With in-tree builds we can get Output directories scattered among
our
    tests. Recursing into those to find tests doesn't make sense.

    Thanks to nlewycky for noticing this!

    llvm-svn: 276667

commit a44ef999fb5e9243df9c4459df1b17b66aa3fd23
Author: Chris Bieneman <chris.bieneman@me.com>
Date:   Mon Jan 3 11:52:44 2022 -0600

    [NFC][CMake] Add FOLDER to utility targets

    As Visual Studio's CMake support is getting better and better the
line
    between IDE generator and non-IDE generators is blurring. Visual
Studio
    2019 and later have a very useful UI that can handle all of the
various
    targets we create, but if they are unsorted it is wildly unwieldy.

    This change sorts the lit testsuite targets and per-component
install
    targets into folders, which are not generated for IDE generators but
    are generated by default under Visual Studio's CMake + Ninja
    integration.