### PR TITLE
Enable SPIR-V tests to run without arguments

### DIFF
--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -44,6 +44,12 @@ target_include_directories(clang-spirv-tests
 set_output_directory(clang-spirv-tests
   ${LLVM_RUNTIME_OUTPUT_INTDIR} ${LLVM_LIBRARY_OUTPUT_INTDIR})
 
+set(SPIRV_TEST_DATA_DIR ${LLVM_SOURCE_DIR}/tools/clang/test/CodeGenSPIRV/)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/SpirvTestOptions.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/SpirvTestOptions.h
+    )
+
 if(WIN32)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # otherwise will hit fatal error C1128 on windows x64
 endif(WIN32)

--- a/tools/clang/unittests/SPIRV/SpirvTestOptions.cpp
+++ b/tools/clang/unittests/SPIRV/SpirvTestOptions.cpp
@@ -18,7 +18,7 @@ namespace clang {
 namespace spirv {
 namespace testOptions {
 
-std::string inputDataDir = "";
+std::string inputDataDir = DEFAULT_TEST_DIR;
 
 } // namespace testOptions
 } // namespace spirv

--- a/tools/clang/unittests/SPIRV/SpirvTestOptions.h.in
+++ b/tools/clang/unittests/SPIRV/SpirvTestOptions.h.in
@@ -16,6 +16,8 @@
 #ifndef LLVM_CLANG_UNITTESTS_SPIRV_TEST_OPTIONS_H
 #define LLVM_CLANG_UNITTESTS_SPIRV_TEST_OPTIONS_H
 
+#define DEFAULT_TEST_DIR "@SPIRV_TEST_DATA_DIR@"
+
 #include <string>
 
 namespace clang {

--- a/tools/clang/unittests/SPIRV/TestMain.cpp
+++ b/tools/clang/unittests/SPIRV/TestMain.cpp
@@ -103,9 +103,6 @@ int main(int argc, char **argv) {
       // Allow the user set the root directory for test input files.
       if (i + 1 < argc) {
         clang::spirv::testOptions::inputDataDir = argv[++i];
-      } else {
-        fprintf(stderr, "Error: --spirv-test-root requires an argument\n");
-        return 1;
       }
     }
   }


### PR DESCRIPTION
This specifies a default value for the --spirv-test-root flag based on the source directory at configuration time. This simplifies the command line for running the tests manually, but does not alter the ability to override the test directory explicitly.