### PR TITLE
Don't emit built-in 'vk' namespace in DeclPrinter

### DIFF
--- a/tools/clang/lib/AST/DeclPrinter.cpp
+++ b/tools/clang/lib/AST/DeclPrinter.cpp
@@ -852,6 +852,13 @@ void DeclPrinter::VisitStaticAssertDecl(StaticAssertDecl *D) {
 // C++ declarations
 //----------------------------------------------------------------------------
 void DeclPrinter::VisitNamespaceDecl(NamespaceDecl *D) {
+  // HLSL Change Begin - Don't emit built-in "vk" namespace, it's implicitly
+  // declared when compiling to SPIR-V and would otherwise cause parsing errors
+  // due to unsupported HLSL 2021 features.
+  if (D->getNameAsString() == "vk")
+    return;
+  // HLSL Change End
+
   if (D->isInline())
     Out << "inline ";
   Out << "namespace " << *D << " {\n";

--- a/tools/clang/test/HLSL/rewriter/spirv.hlsl
+++ b/tools/clang/test/HLSL/rewriter/spirv.hlsl
@@ -1,0 +1,16 @@
+
+struct S
+{
+	int4 a;
+	int4 b;
+};
+
+RWStructuredBuffer<S> structuredUAV : register(u0);
+
+RWBuffer<int4> outBufferUAV : register(u1);
+
+[RootSignature("UAV(u0, numDescriptors=2, space=0, offset=DESCRIPTOR_RANGE_OFFSET_APPEND)")]
+[numthreads(1, 1, 1)]
+void main(uint id : SV_DispatchThreadID) {
+	outBufferUAV[id] = structuredUAV[id].a + structuredUAV[id].b;
+}


### PR DESCRIPTION
The rewriter emits the internal `namespace vk` in `DeclPrinter` when `-spirv` is specified and `RewriterOpts::RemoveUnusedGlobals` is enabled.
This results in HLSL parse errors because `long` and `extern` are reserved keywords amongst other follow-up errors:
```
input.hlsl:4:33: error: 'long' is a reserved keyword in HLSL
	extern T RawBufferLoad(unsigned long long addr);
	                                ^
input.hlsl:3:19: warning: default template arguments for a function template are a C++11 extension
	  template <class T = unsigned int>
	                  ^   ~~~~~~~~
input.hlsl:6:1: error: 'extern' is not a valid modifier for a function
	extern T RawBufferLoad(unsigned long long addr, unsigned int alignment);
	^
```
This PR just quits the `DeclPrinter::VisitNamespaceDecl` visitor when the namespace declaration's name is `"vk"` as this is a known built-in name for the SPIR-V backend and there's no need to print implicit namespaces in the rewriter.