### PR TITLE
Add option for building with clang-cl and ninja

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -206,6 +206,11 @@ if "%1"=="-spirvtest" (
 rem End SPIRV change
 if "%1"=="-ninja" (
   set BUILD_GENERATOR=Ninja
+  set PARALLEL_OPT=
+  shift /1 & goto :parse_args
+)
+if "%1"=="-clang" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
   shift /1 & goto :parse_args
 )
 if "%1"=="-update-generated-sources" (


### PR DESCRIPTION
This change adds a new `-clang` flag to hctbuild. It also fixes an issue where ninja builds were getting passed the MSBuild parallelization option.

Note: The clang-cl build does not compile successfully at this time. This change is just a required building block to get there.