### PR TITLE
Workarounds for arm64ec build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if ( HLSL_SUPPORT_QUERY_GIT_COMMIT_INFO )
 endif()
 
 # adjust link option to enable debugging from kernel mode; not compatible with incremental linking
-if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND WIN32)
+if(NOT CMAKE_VERSION VERSION_LESS "3.13" AND WIN32 AND NOT CMAKE_C_COMPILER_ARCHITECTURE_ID STREQUAL "ARM64EC")
   add_link_options(/DEBUGTYPE:CV,FIXUP,PDATA /INCREMENTAL:NO)
 endif()
 

--- a/tools/clang/lib/Sema/CMakeLists.txt
+++ b/tools/clang/lib/Sema/CMakeLists.txt
@@ -66,3 +66,11 @@ add_clang_library(clangSema
   clangEdit
   clangLex
   )
+
+# HLSL Change Begin
+# Sema got too big for debug builds on arm64ec, which means it will hit
+# other targets too eventually.
+if(WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+endif(WIN32)
+# HLSL Change End


### PR DESCRIPTION
I encountered two issues building arm64ec. First CMake and/or link.exe seem to have a disagreement about flag ordering and how to handle `/INCREMENTAL`. This change results in disabling kernel-mode debugging on arm64ec builds, but it means we can build... so that's a win.

The other issue is that libClangSema has some files that have gotten too big, so we need `/bigobj` for Sema.