### PR TITLE
Update macos/linux builds to *-latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,8 @@ stages:
     timeoutInMinutes: 90
 
     variables:
-      macOS: macOS-11
-      linux: Ubuntu-18.04
+      macOS: macOS-latest
+      linux: Ubuntu-latest
 
     strategy:
       matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,14 +64,14 @@ stages:
         Linux_Gcc_Release:
           image: ${{ variables.linux }}
           configuration: Release
-          CC: gcc-7
-          CXX: g++-7
+          CC: gcc-9
+          CXX: g++-9
           CXX_FLAGS:
         Linux_Gcc_Debug:
           image: ${{ variables.linux }}
           configuration: Debug
-          CC: gcc-7
-          CXX: g++-7
+          CC: gcc-9
+          CXX: g++-9
           CXX_FLAGS:
         MacOS_Clang_Release:
           image: ${{ variables.macOS }}


### PR DESCRIPTION
This updates the ADO yaml to select the latest version of the OS. In the case of MacOS, this will still be 11 for now. For Ubuntu, it will silence the warnings that we are using a deprecated version and save us the headache of having to do this again.

The risk is that a new version of either OS will cause the build to break without our intervention, but the real motivation for explicit versions was an earlier impulse to support the minimal build system that is no longer a priority. As for the risk, I feel it is minimal and we can respond in a timely fashion if it should occur.