### PR TITLE
PIX: Fix instrumentation of libraries; instruction numbering reports

### DIFF
--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -14,6 +14,7 @@
 #include <memory>
 
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/DxilPIXPasses/DxilPIXVirtualRegisters.h"
 #include "dxc/Support/Global.h"
@@ -70,6 +71,7 @@ public:
   DxilAnnotateWithVirtualRegister() : llvm::ModulePass(ID) {}
 
   bool runOnModule(llvm::Module &M) override;
+  void applyOptions(llvm::PassOptions O) override;
 
 private:
   void AnnotateValues(llvm::Instruction *pI);
@@ -86,6 +88,8 @@ private:
   hlsl::DxilModule* m_DM;
   std::uint32_t m_uVReg;
   std::unique_ptr<llvm::ModuleSlotTracker> m_MST;
+  int m_StartInstruction = 0;
+
   void Init(llvm::Module &M) {
     m_DM = &M.GetOrCreateDxilModule();
     m_uVReg = 0;
@@ -96,6 +100,10 @@ private:
     }
   }
 };
+
+void DxilAnnotateWithVirtualRegister::applyOptions(llvm::PassOptions O) {
+  GetPassOptionInt(O, "startInstruction", &m_StartInstruction, 0);
+}
 
 char DxilAnnotateWithVirtualRegister::ID = 0;
 
@@ -111,37 +119,55 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
     m_DM->SetValidatorVersion(1, 4);
   }
 
-  std::uint32_t InstNum = 0;
-  auto blocks = PIXPassHelpers::GetAllBlocks(*m_DM);
-  for(auto * block : blocks) {
-    for (llvm::Instruction& I : block->getInstList()) {
-      if (!llvm::isa<llvm::DbgDeclareInst>(&I)) {
-        pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, InstNum++);
+  std::uint32_t InstNum = m_StartInstruction;
+  std::map<llvm::StringRef, std::pair<int, int>> InstructionRangeByFunctionName;
+
+  auto instrumentableFunctions = PIXPassHelpers::GetAllInstrumentableFunctions(*m_DM);
+
+  for (auto * F : instrumentableFunctions) {
+    auto &EndInstruction = InstructionRangeByFunctionName[F->getName()];
+    EndInstruction.first = InstNum;
+    for (auto &block : F->getBasicBlockList()) {
+      for (llvm::Instruction &I : block.getInstList()) {
+        if (!llvm::isa<llvm::DbgDeclareInst>(&I)) {
+          pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, InstNum++);
+          EndInstruction.second = InstNum;
+        }
       }
     }
   }
 
   if (OSOverride != nullptr) {
+    // Print a set of strings of the exemplary form "InstructionCount: <n> <fnName>"
     *OSOverride << "\nInstructionCount:" << InstNum << "\n";
-  }
+    for (auto const &fn : InstructionRangeByFunctionName) {
+      *OSOverride << "InstructionRange: ";
+      int skipOverLeadingUnprintableCharacters = 0;
+      if (fn.first.size() > 2 && fn.first[0] == '\1' && fn.first[1] == '?') {
+        skipOverLeadingUnprintableCharacters = 2;
+      }
+      *OSOverride << fn.second.first << " " << fn.second.second << " "
+                  << (fn.first.str().c_str() +
+                      skipOverLeadingUnprintableCharacters)
+                  << "\n";
+    }
 
-  if (OSOverride != nullptr) {
-    *OSOverride << "\nEnd - instruction ID to line\n";
-  }
-
-  if (OSOverride != nullptr) {
     *OSOverride << "\nBegin - dxil values to virtual register mapping\n";
   }
 
-  for (auto* block : blocks) {
-    for (llvm::Instruction& I : block->getInstList()) {
-      AnnotateValues(&I);
+  for (auto * F : instrumentableFunctions) {
+    for (auto &block : F->getBasicBlockList()) {
+      for (llvm::Instruction &I : block.getInstList()) {
+        AnnotateValues(&I);
+      }
     }
   }
 
-  for (auto* block : blocks) {
-    for (llvm::Instruction& I : block->getInstList()) {
-      AnnotateStore(&I);
+  for (auto * F : instrumentableFunctions) {
+    for (auto &block : F->getBasicBlockList()) {
+      for (llvm::Instruction &I : block.getInstList()) {
+        AnnotateStore(&I);
+      }
     }
   }
 

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -952,19 +952,12 @@ void DxilDebugInstrumentation::addStepDebugEntryValue(
 bool DxilDebugInstrumentation::runOnModule(Module &M) {
   DxilModule &DM = M.GetOrCreateDxilModule();
 
-  auto ShaderModel = DM.GetShaderModel();
-  auto shaderKind = ShaderModel->GetKind();
+  auto instrumentableFunctions =
+      PIXPassHelpers::GetAllInstrumentableFunctions(DM);
 
   bool modified = false;
-  if (shaderKind == DXIL::ShaderKind::Library) {
-    for (llvm::Function& F : M.functions()) {
-      modified = modified | RunOnFunction(M, DM, &F); 
-      return modified;
-    }
-  }
-  else {
-    llvm::Function *entryFunction = PIXPassHelpers::GetEntryFunction(DM);
-    modified = RunOnFunction(M, DM, entryFunction);
+  for (auto * F : instrumentableFunctions) {
+    modified = modified | RunOnFunction(M, DM, F);
   }
   return modified;
 }

--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -898,6 +898,10 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
       }
     }
   } else {
+
+    auto instrumentableFunctions =
+        PIXPassHelpers::GetAllInstrumentableFunctions(DM);
+
     if (DM.m_ShaderFlags.GetForceEarlyDepthStencil()) {
       if (OSOverride != nullptr) {
         formatted_raw_ostream FOS(*OSOverride);
@@ -905,44 +909,38 @@ bool DxilShaderAccessTracking::runOnModule(Module &M) {
       }
     }
     int uavRegId = 0;
-    for (llvm::Function &F : M.functions()) {
-      if (!F.getBasicBlockList().empty()) {
-
-        DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
-        if (!DM.HasDxilFunctionProps(&F)) {
-          auto ShaderModel = DM.GetShaderModel();
-          shaderKind = ShaderModel->GetKind();
-          if (shaderKind == DXIL::ShaderKind::Library) {
-            continue;
-          }
-        } else {
-          hlsl::DxilFunctionProps const &props = DM.GetDxilFunctionProps(&F);
-          shaderKind = props.shaderKind;
+    for (auto * F : instrumentableFunctions) {
+      DXIL::ShaderKind shaderKind = DXIL::ShaderKind::Invalid;
+      if (!DM.HasDxilFunctionProps(F)) {
+        auto ShaderModel = DM.GetShaderModel();
+        shaderKind = ShaderModel->GetKind();
+        if (shaderKind == DXIL::ShaderKind::Library) {
+          continue;
         }
+      } else {
+        hlsl::DxilFunctionProps const &props = DM.GetDxilFunctionProps(F);
+        shaderKind = props.shaderKind;
+      }
 
-        IRBuilder<> Builder(F.getEntryBlock().getFirstInsertionPt());
+      IRBuilder<> Builder(F->getEntryBlock().getFirstInsertionPt());
 
-        m_FunctionToUAVHandle[&F] = PIXPassHelpers::CreateUAV(
-            DM, Builder, uavRegId++, "PIX_CountUAV_Handle");
-        OP *HlslOP = DM.GetOP();
-        for (int accessStyle = static_cast<int>(ResourceAccessStyle::None);
-             accessStyle < static_cast<int>(ResourceAccessStyle::EndOfEnum);
-             ++accessStyle) {
-          ResourceAccessStyle style =
-              static_cast<ResourceAccessStyle>(accessStyle);
-          m_FunctionToEncodedAccess[&F][style] = HlslOP->GetU32Const(
-              EncodeShaderModel(shaderKind) | EncodeAccess(style));
-        }
+      m_FunctionToUAVHandle[F] = PIXPassHelpers::CreateUAV(
+          DM, Builder, uavRegId++, "PIX_CountUAV_Handle");
+      OP *HlslOP = DM.GetOP();
+      for (int accessStyle = static_cast<int>(ResourceAccessStyle::None);
+           accessStyle < static_cast<int>(ResourceAccessStyle::EndOfEnum);
+           ++accessStyle) {
+        ResourceAccessStyle style =
+            static_cast<ResourceAccessStyle>(accessStyle);
+        m_FunctionToEncodedAccess[F][style] = HlslOP->GetU32Const(
+            EncodeShaderModel(shaderKind) | EncodeAccess(style));
       }
     }
     DM.ReEmitDxilResources();
 
     for (llvm::Function &F : M.functions()) {
-      // Only used DXIL intrinsics:
-      if (!F.isDeclaration() || F.isIntrinsic() || F.use_empty() ||
-          !OP::IsDxilOpFunc(&F))
+      if (!F.isDeclaration() || F.isIntrinsic() || !OP::IsDxilOpFunc(&F))
         continue;
-
       // Gather handle parameter indices, if any
       FunctionType *fnTy =
           cast<FunctionType>(F.getType()->getPointerElementType());

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -224,6 +224,27 @@ llvm::Function* GetEntryFunction(hlsl::DxilModule& DM) {
     return DM.GetPatchConstantFunction();
 }
 
+std::vector<llvm::Function *>
+GetAllInstrumentableFunctions(hlsl::DxilModule &DM) {
+
+  std::vector<llvm::Function *> ret;
+
+  for (llvm::Function &F : DM.GetModule()->functions()) {
+    if (F.isDeclaration() || F.isIntrinsic() || hlsl::OP::IsDxilOpFunc(&F))
+      continue;
+    if (F.getBasicBlockList().empty())
+      continue;
+    ret.push_back(&F);
+  }
+
+  auto patchConstant = DM.GetPatchConstantFunction();
+  if (patchConstant != nullptr) {
+    ret.push_back(patchConstant);
+  }
+
+  return ret;
+}
+
 std::vector<llvm::BasicBlock*> GetAllBlocks(hlsl::DxilModule& DM) {
     std::vector<llvm::BasicBlock*> ret;
     auto entryPoints = DM.GetExportedFunctions();

--- a/lib/DxilPIXPasses/PixPassHelpers.cpp
+++ b/lib/DxilPIXPasses/PixPassHelpers.cpp
@@ -237,11 +237,6 @@ GetAllInstrumentableFunctions(hlsl::DxilModule &DM) {
     ret.push_back(&F);
   }
 
-  auto patchConstant = DM.GetPatchConstantFunction();
-  if (patchConstant != nullptr) {
-    ret.push_back(patchConstant);
-  }
-
   return ret;
 }
 

--- a/lib/DxilPIXPasses/PixPassHelpers.h
+++ b/lib/DxilPIXPasses/PixPassHelpers.h
@@ -29,6 +29,7 @@ namespace PIXPassHelpers
         const char* name);
     llvm::Function* GetEntryFunction(hlsl::DxilModule& DM);
     std::vector<llvm::BasicBlock*> GetAllBlocks(hlsl::DxilModule& DM);
+    std::vector<llvm::Function*> GetAllInstrumentableFunctions(hlsl::DxilModule& DM);
 #ifdef PIX_DEBUG_DUMP_HELPER
     void Log(const char* format, ...);
     void LogPartialLine(const char* format, ...);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2135,7 +2135,8 @@ class db_dxil(object):
             {'n':'parameter0','t':'int','c':1},
             {'n':'parameter1','t':'int','c':1},
             {'n':'parameter2','t':'int','c':1}])
-        add_pass('dxil-annotate-with-virtual-regs', 'DxilAnnotateWithVirtualRegister', 'Annotates each instruction in the DXIL module with a virtual register number', [])
+        add_pass('dxil-annotate-with-virtual-regs', 'DxilAnnotateWithVirtualRegister', 'Annotates each instruction in the DXIL module with a virtual register number', [
+            {'n':'startInstruction','t':'int','c':1}])
         add_pass('dxil-dbg-value-to-dbg-declare', 'DxilDbgValueToDbgDeclare', 'Converts llvm.dbg.value uses to llvm.dbg.declare.', [])
         add_pass('hlsl-dxil-reduce-msaa-to-single', 'DxilReduceMSAAToSingleSample', 'HLSL DXIL Reduce all MSAA reads to single-sample reads', [])
         add_pass('hlsl-dxil-PIX-add-tid-to-as-payload', 'DxilPIXAddTidToAmplificationShaderPayload', 'HLSL DXIL Add flat thread id to payload from AS to MS', [


### PR DESCRIPTION
This PR does a few things to fix PIX's operation on lib targets:
-Remove the check for "use_empty" on a function. Lib entry functions have no uses! This was done by centralizing the discovery of interesting (to PIX) functions in a new helper in PixPassHelpers.cpp
-In DxilDebugInstrumentation.cpp, remove the early "return" inside runOnModule. There are more functions left to instrument!
-Add reporting from the virtual register pass that reveals the start and end instruction ordinal for interesting functions. PIX can use these values to disambiguate different functions within a module for e.g. shader debugging output.