### PR TITLE
Don't cancel in-progress coverage builds

### DIFF
--- a/.github/workflows/coverage-gh-pages.yml
+++ b/.github/workflows/coverage-gh-pages.yml
@@ -17,7 +17,6 @@ permissions:
 # Allow one concurrent deployment
 concurrency:
   group: "pages"
-  cancel-in-progress: true
 
 jobs:
   # Build job


### PR DESCRIPTION
The coverage builds take a _long_ time to run on the standard GitHub action bots. I initially thought cancelling and restarting was a good idea and have since reconsidered...