### PR TITLE
Disable Clang LIT shtest suites

### DIFF
--- a/tools/clang/test/CXX/lit.local.cfg
+++ b/tools/clang/test/CXX/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/CodeCompletion/lit.local.cfg
+++ b/tools/clang/test/CodeCompletion/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/CodeGenCUDA/lit.local.cfg
+++ b/tools/clang/test/CodeGenCUDA/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/CodeGenHLSL/lit.local.cfg
+++ b/tools/clang/test/CodeGenHLSL/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/CodeGenSPIRV/lit.local.cfg
+++ b/tools/clang/test/CodeGenSPIRV/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Coverage/lit.local.cfg
+++ b/tools/clang/test/Coverage/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/CoverageMapping/lit.local.cfg
+++ b/tools/clang/test/CoverageMapping/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/DXILValidation/lit.local.cfg
+++ b/tools/clang/test/DXILValidation/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/FixIt/lit.local.cfg
+++ b/tools/clang/test/FixIt/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Format/lit.local.cfg
+++ b/tools/clang/test/Format/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/HLSL/lit.local.cfg
+++ b/tools/clang/test/HLSL/lit.local.cfg
@@ -1,4 +1,6 @@
 import os
 
+config.unsupported = True # HLSL Change - Disable lit suites.
+
 # Add .hlsl as a test extension.
 config.suffixes.add('.hlsl')

--- a/tools/clang/test/HLSLDisabled/lit.local.cfg
+++ b/tools/clang/test/HLSLDisabled/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/HLSLFileCheck/lit.local.cfg
+++ b/tools/clang/test/HLSLFileCheck/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Headers/lit.local.cfg
+++ b/tools/clang/test/Headers/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Index/lit.local.cfg
+++ b/tools/clang/test/Index/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Integration/lit.local.cfg
+++ b/tools/clang/test/Integration/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Layout/lit.local.cfg
+++ b/tools/clang/test/Layout/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Lexer/lit.local.cfg
+++ b/tools/clang/test/Lexer/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Misc/lit.local.cfg
+++ b/tools/clang/test/Misc/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/PCH/lit.local.cfg
+++ b/tools/clang/test/PCH/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Parser/lit.local.cfg
+++ b/tools/clang/test/Parser/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Preprocessor/lit.local.cfg
+++ b/tools/clang/test/Preprocessor/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Profile/lit.local.cfg
+++ b/tools/clang/test/Profile/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Sema/lit.local.cfg
+++ b/tools/clang/test/Sema/lit.local.cfg
@@ -1,3 +1,4 @@
+config.unsupported = True # HLSL Change - Disable lit suites.
 config.substitutions = list(config.substitutions)
 config.substitutions.insert(0,
     (r'%clang\b',

--- a/tools/clang/test/SemaCUDA/lit.local.cfg
+++ b/tools/clang/test/SemaCUDA/lit.local.cfg
@@ -1,3 +1,4 @@
+config.unsupported = True # HLSL Change - Disable lit suites.
 config.substitutions = list(config.substitutions)
 config.substitutions.insert(0,
     (r'%clang\b',

--- a/tools/clang/test/SemaCXX/lit.local.cfg
+++ b/tools/clang/test/SemaCXX/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/SemaTemplate/lit.local.cfg
+++ b/tools/clang/test/SemaTemplate/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/Tooling/lit.local.cfg
+++ b/tools/clang/test/Tooling/lit.local.cfg
@@ -1,2 +1,3 @@
+config.unsupported = True # HLSL Change - Disable lit suites.
 if config.root.clang_staticanalyzer == 0:
     config.unsupported = True

--- a/tools/clang/test/VFS/lit.local.cfg
+++ b/tools/clang/test/VFS/lit.local.cfg
@@ -1,2 +1,1 @@
 config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']


### PR DESCRIPTION
This disables all the existing clang lit shell test suites.

Basically all of these suites will fail outright anyways because DXC doesn't function as a C/C++/OpenCL/CUDA compiler anymore. Disabling them gets us one step closer to having a starting point where `check-clang` will pass in the repo, which is a step towards getting `check-all` working.