### PR TITLE
Fix or disable last LLVM tests on Windows

### DIFF
--- a/test/YAMLParser/spec-09-02.test
+++ b/test/YAMLParser/spec-09-02.test
@@ -11,4 +11,4 @@
 # FIXME: The string below should actually be
 #   "as space trimmed\nspecific\nescaped\tnone", but the parser currently has
 #   a bug when parsing multiline quoted strings.
-# CHECK: !!str "as space\n trimmed\n specific\n escaped\t none"
+# CHECK: !!str "as space{{(\\n)+}} trimmed{{(\\n)+}} specific{{(\\n)+}} escaped\t none"

--- a/unittests/Support/MemoryBufferTest.cpp
+++ b/unittests/Support/MemoryBufferTest.cpp
@@ -161,7 +161,15 @@ void MemoryBufferTest::testGetOpenFileSlice(bool Reopen) {
   EXPECT_EQ(BufData[9], '9');
 }
 
+// HLSL Change Begin
+// The MS filesystem breaks loading file slices on Windows unless you are
+// reopening the file, so we disable this test case.
+#if LLVM_ON_WIN32
+TEST_F(MemoryBufferTest, DISABLED_getOpenFileNoReopen) {
+#else
 TEST_F(MemoryBufferTest, getOpenFileNoReopen) {
+#endif
+// HLSL Change End
   testGetOpenFileSlice(false);
 }
 

--- a/utils/unittest/googletest/include/gtest/internal/gtest-port.h
+++ b/utils/unittest/googletest/include/gtest/internal/gtest-port.h
@@ -793,7 +793,7 @@ using ::std::tuple_size;
 // pops up a dialog window that cannot be suppressed programmatically.
 #if (GTEST_OS_LINUX || GTEST_OS_CYGWIN || GTEST_OS_SOLARIS || \
      (GTEST_OS_MAC && !GTEST_OS_IOS) || \
-     (GTEST_OS_WINDOWS_DESKTOP && _MSC_VER >= 1400) || \
+     (!GTEST_OS_WINDOWS_DESKTOP /*HLSL Change - Disable death on Windows.*/) || \
      GTEST_OS_WINDOWS_MINGW || GTEST_OS_AIX || GTEST_OS_HPUX || \
      GTEST_OS_OPENBSD || GTEST_OS_QNX || GTEST_OS_FREEBSD)
 # define GTEST_HAS_DEATH_TEST 1


### PR DESCRIPTION
This handles a few last Windows fixes for LLVM tests.

* The YAML praser convertes \r to \n, resulting in repeated newlines in YAML tests on Windows.
* The MS filesystem changes on Windows cause one of the MemoryBuffer tests to fail. I've disabled that test on Windows.
* Because we convert many crash cases to exceptions on Windows the GoogleTest DEATH tests fail to die on Windows.

This change addresses the same issue #4794 solves, but restricts the change to Windows only. I'm only merging this since @python3kgae is out and I don't really want to wait until he returns.

utils/unittest/googletest/include/gtest/internal/gtest-port.h