### PR TITLE
Tweaks and fixes to clang build and test configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -739,6 +739,7 @@ if( LLVM_INCLUDE_TESTS )
     DEPENDS ${LLVM_LIT_DEPENDS}
     ARGS ${LLVM_LIT_EXTRA_ARGS}
     )
+  add_custom_target(test-depends DEPENDS ${LLVM_LIT_DEPENDS}) # HLSL Change
 endif()
 
 if (LLVM_INCLUDE_DOCS)

--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -69,7 +69,9 @@ endif()
 
 # HLSL Change Begin
 # Explicitly overriding check-clang dependencies for HLSL
-set(CLANG_TEST_DEPS clang opt FileCheck count not)
+set(CLANG_TEST_DEPS dxc dxcompiler clang-tblgen llvm-config opt FileCheck count not ClangUnitTests)
+add_custom_target(clang-test-depends DEPENDS ${CLANG_TEST_DEPS})
+set_target_properties(clang-test-depends PROPERTIES FILDER "Clang tests")
 # HLSL Change End
 
 

--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -71,7 +71,7 @@ endif()
 # Explicitly overriding check-clang dependencies for HLSL
 set(CLANG_TEST_DEPS dxc dxcompiler clang-tblgen llvm-config opt FileCheck count not ClangUnitTests)
 add_custom_target(clang-test-depends DEPENDS ${CLANG_TEST_DEPS})
-set_target_properties(clang-test-depends PROPERTIES FILDER "Clang tests")
+set_target_properties(clang-test-depends PROPERTIES FOLDER "Clang tests")
 # HLSL Change End
 
 

--- a/tools/clang/test/Unit/lit.site.cfg.in
+++ b/tools/clang/test/Unit/lit.site.cfg.in
@@ -19,6 +19,7 @@ try:
     config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
     config.llvm_libs_dir = config.llvm_libs_dir % lit_config.params
     config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+    config.shlibdir = config.shlibdir % lit_config.params
 except KeyError:
     e = sys.exc_info()[1]
     key, = e.args

--- a/tools/clang/test/taef/lit.cfg
+++ b/tools/clang/test/taef/lit.cfg
@@ -25,17 +25,15 @@ if llvm_obj_root is None:
         lit_config.load_config(config, site_cfg)
         raise SystemExit
 
-
-te = os.path.join(config.llvm_obj_root, "TAEF", config.arch, 'te.exe')
-
-test_dll = os.path.join(config.llvm_obj_root, config.build_mode, 'bin', 'ClangHLSLTests.dll')
-
-hlsl_data_dir = os.path.join(config.llvm_src_root, 'tools', 'clang', 'test', 'hlsl')
-
-test_dir = os.path.join(config.llvm_obj_root, config.build_mode, 'test')
-#projects\dxilconv\test
-config.test_format = lit.formats.TaefTest(te, test_dll, hlsl_data_dir, test_dir)
-
 # TAEF only runs on Windows
 if platform.system() != 'Windows':
   config.unsupported = True
+else:
+  te = os.path.join(config.llvm_obj_root, "TAEF", config.arch, 'te.exe')
+
+  test_dll = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'bin', 'ClangHLSLTests.dll')
+
+  hlsl_data_dir = os.path.join(config.llvm_src_root, 'tools', 'clang', 'test', 'HLSL')
+
+  test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
+  config.test_format = lit.formats.TaefTest(te, test_dll, hlsl_data_dir, test_dir)

--- a/tools/clang/test/taef/lit.site.cfg.in
+++ b/tools/clang/test/taef/lit.site.cfg.in
@@ -4,8 +4,18 @@ import sys
 # Do not edit!
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
-config.build_mode = lit_config.params["build_mode"]
-config.arch = "@DXC_BUILD_ARCH@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.arch = "@CMAKE_C_COMPILER_ARCHITECTURE_ID@"
+
+# Support substitution of the tools_dir, libs_dirs, and build_mode with user
+# parameters. This is used when we can't determine the tool dir at
+# configuration time.
+try:
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
 
 # Let the main config do the real work.
 lit_config.load_config(config, "@CLANG_SOURCE_DIR@/test/taef/lit.cfg")

--- a/tools/clang/unittests/CMakeLists.txt
+++ b/tools/clang/unittests/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_custom_target(ClangUnitTests)
 set_target_properties(ClangUnitTests PROPERTIES FOLDER "Clang tests")
 
+# HLSL Change - rpath
+# Add LLVM_LIBRARY_OUTPUT_INTDIR to install rpath for unit tests. This allows
+# unit test binaries on Unix to be run directly even if they dlopen or
+# dynamically link against dxcompiler.
+set(CMAKE_INSTALL_RPATH "${LLVM_LIBRARY_OUTPUT_INTDIR};${CMAKE_INSTALL_RPATH}")
+# HLSL Change End - rpath
+
 # add_clang_unittest(test_dirname file1.cpp file2.cpp)
 #
 # Will compile the list of files together and link against the clang

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -51,6 +51,8 @@ add_clang_library(ClangHLSLTests SHARED
   VerifierTest.cpp
   clang-hlsl-tests.rc
   )
+
+  add_dependencies(ClangUnitTests ClangHLSLTests)
 else (WIN32)
 set(HLSL_IGNORE_SOURCES
   ExecutionTest.cpp

--- a/utils/lit/lit/formats/taef.py
+++ b/utils/lit/lit/formats/taef.py
@@ -42,7 +42,7 @@ class TaefTest(TestFormat):
             lines = lines.replace('\r', '')
             lines = lines.split('\n')
         except:
-            litConfig.error("unable to discover taef in %r" % path)
+            litConfig.error("unable to discover taef in %r" % dll_path)
             raise StopIteration
 
         for ln in lines:


### PR DESCRIPTION
* Setup dependencies for check-clang.
* Proprely adjust shlibdir for multi-configuraiton builds.
* Move TAEF platform verification earlier to avoid issues on Linux.
* Adjust TAEF suite config to handle build_mode specialization.
* Remove another DXC_BUILD_ARCH that snuck in.
* Add the intermediate library path as an rpath for unit tests.
* Make ClangUnitTests depend on ClangHLSLTests so taef tests build.
* Add clang-test-depends and test-depends targets.