### PR TITLE
PIX: Add private API to copy container parts

### DIFF
--- a/include/dxc/DxilContainer/DxcContainerBuilder.h
+++ b/include/dxc/DxilContainer/DxcContainerBuilder.h
@@ -42,6 +42,9 @@ public:
     m_HasPrivateData = false;
   }
 
+  HRESULT AddPartWithoutRestrictions(_In_ UINT32 fourCC,
+                                     _In_ IDxcBlob *pSource);
+
 protected:
   DXC_MICROCOM_TM_REF_FIELDS()
 

--- a/include/dxc/dxcpix.h
+++ b/include/dxc/dxcpix.h
@@ -207,6 +207,13 @@ IDxcPixDxilDebugInfoFactory : public IUnknown
       _COM_Outptr_ IDxcPixCompilationInfo **ppCompilationInfo) = 0;
 };
 
+struct __declspec(uuid("cab55c12-8933-4b0e-a702-a6470eb4c2e3"))
+IDxcPixContainerOperations : public IUnknown 
+{
+  virtual STDMETHODIMP AddPart(_In_ IDxcContainerBuilder *container,
+                               _In_ UINT32 fourCC, _In_ IDxcBlob *pSource) = 0;
+};
+
 #ifndef CLSID_SCOPE
 #ifdef _MSC_VER
 #define CLSID_SCOPE __declspec(selectany) extern

--- a/lib/DxilContainer/DxcContainerBuilder.cpp
+++ b/lib/DxilContainer/DxcContainerBuilder.cpp
@@ -220,3 +220,19 @@ void DxcContainerBuilder::AddPart(DxilPart&& part) {
     m_HasPrivateData = true;
   }
 }
+
+HRESULT DxcContainerBuilder::AddPartWithoutRestrictions(_In_ UINT32 fourCC,
+                                                _In_ IDxcBlob *pSource) {
+  DxcThreadMalloc TM(m_pMalloc);
+  try {
+    PartList::iterator it =
+        std::find_if(m_parts.begin(), m_parts.end(),
+                     [&](DxilPart part) { return part.m_fourCC == fourCC; });
+    if (it != m_parts.end()) {
+      m_parts.erase(it);
+    }
+    AddPart(DxilPart(fourCC, pSource));
+    return S_OK;
+  }
+  CATCH_CPP_RETURN_HRESULT();
+}


### PR DESCRIPTION
Due to the public container assembler API explicitly disabling the adding of an RDAT part, PIX can't modify DXIL and then produce a new container with the original, still-valid, RDAT in it. This precludes PIX from operating with applications that use DXIL-defined root sigs, suboject associations, etc.
