### PR TITLE
Restore impl of DerivedRecordSize in RDAT

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -249,7 +249,7 @@ public:
   // RecordSize() is defined in order to allow for use of forward decl type in RecordRef
   static constexpr size_t RecordSize() { return sizeof(_T); }
   static constexpr size_t MaxRecordSize() { return RecordTraits<_T>::DerivedRecordSize(); }
-  static constexpr size_t DerivedRecordSize();
+  static constexpr size_t DerivedRecordSize() { return sizeof(_T); }
 };
 
 ///////////////////////////////////////


### PR DESCRIPTION
This default method implementation is necessary for the base->derived size version mechanism to work. This is only specialized when a base has a derived, and it relies on the newest version to use the default implementation (no specialization).

The implementation was removed in commit 8ee6ed19f3adfe993e91708a24f96efb0f3a00bc.