### PR TITLE
Remove use of `dynamic_cast`

### DIFF
--- a/tools/clang/include/clang/Basic/Diagnostic.h
+++ b/tools/clang/include/clang/Basic/Diagnostic.h
@@ -1395,6 +1395,12 @@ public:
   /// warnings and errors.
   virtual void HandleDiagnostic(DiagnosticsEngine::Level DiagLevel,
                                 const Diagnostic &Info);
+  
+  // HLSL Change - begin
+  // Add setPrefix method to DiagnosticConsumer to avoid needing to dynamic cast
+  // in order to call it.
+  virtual void setPrefix(std::string) {}
+  // HLSL Change - end 
 };
 
 /// \brief A diagnostic client that ignores all diagnostics.

--- a/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
+++ b/tools/clang/include/clang/Frontend/TextDiagnosticPrinter.h
@@ -45,7 +45,8 @@ public:
   /// setPrefix - Set the diagnostic printer prefix string, which will be
   /// printed at the start of any diagnostics. If empty, no prefix string is
   /// used.
-  void setPrefix(std::string Value) { Prefix = Value; }
+  // HLSL Change - Made this virtual
+  void setPrefix(std::string Value) override { Prefix = Value; }
 
   void BeginSourceFile(const LangOptions &LO, const Preprocessor *PP) override;
   void EndSourceFile() override;

--- a/tools/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenAction.cpp
@@ -557,7 +557,7 @@ BackendConsumer::DxilDiagHandler(const llvm::DiagnosticInfoDxil &D) {
 
   // If no location information is available, add function name
   if (Loc.isInvalid()) {
-    auto *DiagClient = dynamic_cast<TextDiagnosticPrinter*>(Diags.getClient());
+    auto *DiagClient = Diags.getClient();
     auto *func = D.getFunction();
     if (DiagClient && func)
       DiagClient->setPrefix("Function: " + func->getName().str());


### PR DESCRIPTION
This is the only instance of a C++ dynamic_cast in the codebase and it can be avoided by just making an interface virtual.