### PR TITLE
Fix dxcisense.h includes

### DIFF
--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -12,8 +12,10 @@
 #ifndef __DXC_ISENSE__
 #define __DXC_ISENSE__
 
-#include "dxc/dxcapi.h"
-#include "dxc/Support/WinAdapter.h"
+#include "dxcapi.h"
+#ifndef _WIN32
+#include "Support/WinAdapter.h"
+#endif
 
 typedef enum DxcGlobalOptions
 {


### PR DESCRIPTION
- dxcapi.h is in the same directory and the dxc directory does not exist in shipped packages
- WinAdapter.h not needed on Windows