### PR TITLE
Fix dxcisense.h includes (#4852)

### DIFF
--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -12,8 +12,10 @@
 #ifndef __DXC_ISENSE__
 #define __DXC_ISENSE__
 
-#include "dxc/dxcapi.h"
-#include "dxc/Support/WinAdapter.h"
+#include "dxcapi.h"
+#ifndef _WIN32
+#include "Support/WinAdapter.h"
+#endif
 
 typedef enum DxcGlobalOptions
 {


### PR DESCRIPTION
- dxcapi.h is in the same directory
- WinAdapter.h not needed on Windows

(cherry picked from commit 12515e884bda1eb35f05d14bd862091373ce5824)