### PR TITLE
Fix enum scope used inside template function.

### DIFF
--- a/tools/clang/lib/Sema/TreeTransform.h
+++ b/tools/clang/lib/Sema/TreeTransform.h
@@ -3276,7 +3276,7 @@ TreeTransform<Derived>::TransformNestedNameSpecifierLoc(
         return NestedNameSpecifierLoc();
 
       if (TL.getType()->isDependentType() || TL.getType()->isRecordType() ||
-          (SemaRef.getLangOpts().CPlusPlus11 &&
+          ((SemaRef.getLangOpts().CPlusPlus11 || SemaRef.getLangOpts().HLSL) &&
            TL.getType()->isEnumeralType())) {
         assert(!TL.getType().hasLocalQualifiers() &&
                "Can't get cv-qualifiers here");

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/enum-scope-in-template-func.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/enum-scope-in-template-func.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T vs_6_0 -HV 2021 -ast-dump %s | FileCheck %s
+
+// CHECK-NOT: error
+
+// CHECK: FunctionDecl {{.*}} used genericDoStuff 'void (Foo)'
+// CHECK-NEXT: TemplateArgument
+// CHECK-NEXT: ParmVarDecl
+// CHECK-NEXT: CompoundStmt
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK-NEXT: DeclRefExpr
+// CHECK-SAME: 'Food' EnumConstant
+// CHECK-SAME: 'Pizza' 'Food'
+
+enum class Food { Pizza };
+
+void write(Food f, uint val) {}
+
+template <typename Generic>
+void genericDoStuff(Generic g)
+{
+    write(Food::Pizza, g.get());
+}
+
+class Foo {
+    uint get() { return 0; }
+};
+
+void main() {
+    Foo foo;
+    genericDoStuff(foo);
+}


### PR DESCRIPTION
While enums were introduced in HLSL 2017, this code should only be reached on HLSL if we are HLSL 2021 or greater, so an additional language version check does not appear necessary here.