### PR TITLE
Fixing a [[nodiscard]] error in DXC

### DIFF
--- a/tools/clang/include/clang/Serialization/ContinuousRangeMap.h
+++ b/tools/clang/include/clang/Serialization/ContinuousRangeMap.h
@@ -117,14 +117,17 @@ public:
     
     ~Builder() {
       std::sort(Self.Rep.begin(), Self.Rep.end(), Compare());
-      std::unique(Self.Rep.begin(), Self.Rep.end(),
-                  [](const_reference A, const_reference B) {
-        // FIXME: we should not allow any duplicate keys, but there are a lot of
-        // duplicate 0 -> 0 mappings to remove first.
-        assert((A == B || A.first != B.first) &&
-               "ContinuousRangeMap::Builder given non-unique keys");
-        return A == B;
-      });
+      Self.Rep.erase(
+          std::unique(
+              Self.Rep.begin(), Self.Rep.end(),
+              [](const_reference A, const_reference B) {
+                // FIXME: we should not allow any duplicate keys, but there are
+                // a lot of duplicate 0 -> 0 mappings to remove first.
+                assert((A == B || A.first != B.first) &&
+                       "ContinuousRangeMap::Builder given non-unique keys");
+                return A == B;
+              }),
+          Self.Rep.end());
     }
     
     void insert(const value_type &Val) {


### PR DESCRIPTION
This was found while moving to c++20 by an anonymous internal contributor. Integrating the finding to mainline.

std::unique iterates on elements of the container, and removes all but the first element matching the predicate, but does not resize the container. This means the following code doesn't assert.

```cpp
    std::vector<int> v = { 1, 1, 2, 2, 3, 3 };
    assert(v.size() == 6);
    std::unique(v.begin(), v.end());
    assert(v.size() == 6);
```

The function returns a past-end iterator, and all the undefined elements are at the end of the container, meaning we can safely erase them, and fix the container size.

Signed-off-by: Nathan Gauër <brioche@google.com>