### PR TITLE
spirv: keep image format to unknown if it is.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/op.buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.buffer.access.hlsl
@@ -1,16 +1,30 @@
 // RUN: %dxc -T ps_6_0 -E main
 
 // CHECK: OpCapability ImageBuffer
+// CHECK: OpCapability StorageImageReadWithoutFormat
 
+
+// CHECK: %type_buffer_image = OpTypeImage %int Buffer 2 0 0 1 R32i
+// CHECK: %type_buffer_image_0 = OpTypeImage %uint Buffer 2 0 0 1 R32ui
+// CHECK: %type_buffer_image_1 = OpTypeImage %float Buffer 2 0 0 1 R32f
 Buffer<int> intbuf;
 Buffer<uint> uintbuf;
 Buffer<float> floatbuf;
+// CHECK: %type_buffer_image_2 = OpTypeImage %int Buffer 2 0 0 2 Rg32i
+// CHECK: %type_buffer_image_3 = OpTypeImage %uint Buffer 2 0 0 2 Rg32ui
+// CHECK: %type_buffer_image_4 = OpTypeImage %float Buffer 2 0 0 2 Rg32f
 RWBuffer<int2> int2buf;
 RWBuffer<uint2> uint2buf;
 RWBuffer<float2> float2buf;
+// CHECK: %type_buffer_image_5 = OpTypeImage %int Buffer 2 0 0 1 Unknown
+// CHECK: %type_buffer_image_6 = OpTypeImage %uint Buffer 2 0 0 1 Unknown
+// CHECK: %type_buffer_image_7 = OpTypeImage %float Buffer 2 0 0 1 Unknown
 Buffer<int3> int3buf;
 Buffer<uint3> uint3buf;
 Buffer<float3> float3buf;
+// CHECK: %type_buffer_image_8 = OpTypeImage %int Buffer 2 0 0 2 Rgba32i
+// CHECK: %type_buffer_image_9 = OpTypeImage %uint Buffer 2 0 0 2 Rgba32ui
+// CHECK: %type_buffer_image_10 = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
 RWBuffer<int4> int4buf;
 RWBuffer<uint4> uint4buf;
 RWBuffer<float4> float4buf;
@@ -21,7 +35,8 @@ struct S {
   float1 c;
 };
 
-  Buffer<S> sBuf;
+// CHECK: %type_buffer_image_11 = OpTypeImage %float Buffer 2 0 0 1 Rgba32f
+Buffer<S> sBuf;
 
 void main() {
   int address;
@@ -111,7 +126,7 @@ void main() {
 // CHECK-NEXT:                  OpStore %b [[b]]
   float b = float4buf[address][2];
 
-// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_7 %sBuf
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_11 %sBuf
 // CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] %uint_0 None
 // CHECK-NEXT:   [[s_a:%\d+]] = OpCompositeExtract %float [[fetch]] 0
 // CHECK-NEXT:   [[s_b:%\d+]] = OpVectorShuffle %v2float [[fetch]] [[fetch]] 1 2
@@ -123,7 +138,7 @@ void main() {
 // CHECK-NEXT:                  OpStore %c [[c]]
   float c = sBuf[0].a;
 
-// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_7 %sBuf
+// CHECK:        [[img:%\d+]] = OpLoad %type_buffer_image_11 %sBuf
 // CHECK-NEXT: [[fetch:%\d+]] = OpImageFetch %v4float [[img]] %uint_1 None
 // CHECK-NEXT:   [[s_a:%\d+]] = OpCompositeExtract %float [[fetch]] 0
 // CHECK-NEXT:   [[s_b:%\d+]] = OpVectorShuffle %v2float [[fetch]] [[fetch]] 1 2

--- a/tools/clang/test/CodeGenSPIRV/type.buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.buffer.hlsl
@@ -43,29 +43,41 @@ RWBuffer<uint2> uint2rwbuf;
 // CHECK: %_ptr_UniformConstant_type_buffer_image_10 = OpTypePointer UniformConstant %type_buffer_image_10
 RWBuffer<float2> float2rwbuf;
 
-// CHECK: %type_buffer_image_11 = OpTypeImage %int Buffer 2 0 0 1 Rgba32i
+// CHECK: %type_buffer_image_11 = OpTypeImage %int Buffer 2 0 0 1 Unknown
 // CHECK: %_ptr_UniformConstant_type_buffer_image_11 = OpTypePointer UniformConstant %type_buffer_image_11
+// CHECK: %type_buffer_image_12 = OpTypeImage %int Buffer 2 0 0 1 Rgba32i
+// CHECK: %_ptr_UniformConstant_type_buffer_image_12 = OpTypePointer UniformConstant %type_buffer_image_12
 Buffer<int3> int3buf;
 Buffer<int4> int4buf;
-// CHECK: %type_buffer_image_12 = OpTypeImage %uint Buffer 2 0 0 1 Rgba32ui
-// CHECK: %_ptr_UniformConstant_type_buffer_image_12 = OpTypePointer UniformConstant %type_buffer_image_12
+// CHECK: %type_buffer_image_13 = OpTypeImage %uint Buffer 2 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_13 = OpTypePointer UniformConstant %type_buffer_image_13
+// CHECK: %type_buffer_image_14 = OpTypeImage %uint Buffer 2 0 0 1 Rgba32ui
+// CHECK: %_ptr_UniformConstant_type_buffer_image_14 = OpTypePointer UniformConstant %type_buffer_image_14
 Buffer<uint3> uint3buf;
 Buffer<uint4> uint4buf;
-// CHECK: %type_buffer_image_13 = OpTypeImage %float Buffer 2 0 0 1 Rgba32f
-// CHECK: %_ptr_UniformConstant_type_buffer_image_13 = OpTypePointer UniformConstant %type_buffer_image_13
+// CHECK: %type_buffer_image_15 = OpTypeImage %float Buffer 2 0 0 1 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_15 = OpTypePointer UniformConstant %type_buffer_image_15
+// CHECK: %type_buffer_image_16 = OpTypeImage %float Buffer 2 0 0 1 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_buffer_image_16 = OpTypePointer UniformConstant %type_buffer_image_16
 Buffer<float3> float3buf;
 Buffer<float4> float4buf;
 
-// CHECK: %type_buffer_image_14 = OpTypeImage %int Buffer 2 0 0 2 Rgba32i
-// CHECK: %_ptr_UniformConstant_type_buffer_image_14 = OpTypePointer UniformConstant %type_buffer_image_14
+// CHECK: %type_buffer_image_17 = OpTypeImage %int Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_17 = OpTypePointer UniformConstant %type_buffer_image_17
+// CHECK: %type_buffer_image_18 = OpTypeImage %int Buffer 2 0 0 2 Rgba32i
+// CHECK: %_ptr_UniformConstant_type_buffer_image_18 = OpTypePointer UniformConstant %type_buffer_image_18
 RWBuffer<int3> int3rwbuf;
 RWBuffer<int4> int4rwbuf;
-// CHECK: %type_buffer_image_15 = OpTypeImage %uint Buffer 2 0 0 2 Rgba32ui
-// CHECK: %_ptr_UniformConstant_type_buffer_image_15 = OpTypePointer UniformConstant %type_buffer_image_15
+// CHECK: %type_buffer_image_19 = OpTypeImage %uint Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_19 = OpTypePointer UniformConstant %type_buffer_image_19
+// CHECK: %type_buffer_image_20 = OpTypeImage %uint Buffer 2 0 0 2 Rgba32ui
+// CHECK: %_ptr_UniformConstant_type_buffer_image_20 = OpTypePointer UniformConstant %type_buffer_image_20
 RWBuffer<uint3> uint3rwbuf;
 RWBuffer<uint4> uint4rwbuf;
-// CHECK: %type_buffer_image_16 = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
-// CHECK: %_ptr_UniformConstant_type_buffer_image_16 = OpTypePointer UniformConstant %type_buffer_image_16
+// CHECK: %type_buffer_image_21 = OpTypeImage %float Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_21 = OpTypePointer UniformConstant %type_buffer_image_21
+// CHECK: %type_buffer_image_22 = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_buffer_image_22 = OpTypePointer UniformConstant %type_buffer_image_22
 RWBuffer<float3> float3rwbuf;
 RWBuffer<float4> float4rwbuf;
 
@@ -79,9 +91,9 @@ struct T {
     float2 b;
 };
 
-  Buffer<S> sBuf;
+Buffer<S> sBuf;
 
-  Buffer<T> tBuf;
+Buffer<T> tBuf;
 
 // CHECK: %intbuf = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
 // CHECK: %uintbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_0 UniformConstant
@@ -96,18 +108,18 @@ struct T {
 // CHECK: %uint2rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_9 UniformConstant
 // CHECK: %float2rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_10 UniformConstant
 // CHECK: %int3buf = OpVariable %_ptr_UniformConstant_type_buffer_image_11 UniformConstant
-// CHECK: %int4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_11 UniformConstant
-// CHECK: %uint3buf = OpVariable %_ptr_UniformConstant_type_buffer_image_12 UniformConstant
-// CHECK: %uint4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_12 UniformConstant
-// CHECK: %float3buf = OpVariable %_ptr_UniformConstant_type_buffer_image_13 UniformConstant
-// CHECK: %float4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_13 UniformConstant
-// CHECK: %int3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_14 UniformConstant
-// CHECK: %int4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_14 UniformConstant
-// CHECK: %uint3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_15 UniformConstant
-// CHECK: %uint4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_15 UniformConstant
-// CHECK: %float3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_16 UniformConstant
-// CHECK: %float4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_16 UniformConstant
+// CHECK: %int4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_12 UniformConstant
+// CHECK: %uint3buf = OpVariable %_ptr_UniformConstant_type_buffer_image_13 UniformConstant
+// CHECK: %uint4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_14 UniformConstant
+// CHECK: %float3buf = OpVariable %_ptr_UniformConstant_type_buffer_image_15 UniformConstant
+// CHECK: %float4buf = OpVariable %_ptr_UniformConstant_type_buffer_image_16 UniformConstant
+// CHECK: %int3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_17 UniformConstant
+// CHECK: %int4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_18 UniformConstant
+// CHECK: %uint3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_19 UniformConstant
+// CHECK: %uint4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_20 UniformConstant
+// CHECK: %float3rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_21 UniformConstant
+// CHECK: %float4rwbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_22 UniformConstant
 // CHECK:   %sBuf = OpVariable %_ptr_UniformConstant_type_buffer_image_7 UniformConstant
-// CHECK:   %tBuf = OpVariable %_ptr_UniformConstant_type_buffer_image_13 UniformConstant
+// CHECK:   %tBuf = OpVariable %_ptr_UniformConstant_type_buffer_image_15 UniformConstant
 
 void main() {}

--- a/tools/clang/test/CodeGenSPIRV/type.rwbuffer.half.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwbuffer.half.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -T cs_6_0 -E main
 
-// CHECK: %type_buffer_image = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+// CHECK: %type_buffer_image = OpTypeImage %float Buffer 2 0 0 2 Rgba16f
 // CHECK: %_ptr_UniformConstant_type_buffer_image = OpTypePointer UniformConstant %type_buffer_image
 // CHECK: %HalfBuffer = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
 

--- a/tools/clang/test/CodeGenSPIRV/type.rwtexture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwtexture.hlsl
@@ -6,8 +6,10 @@
 // CHECK: %_ptr_UniformConstant_type_1d_image = OpTypePointer UniformConstant %type_1d_image
 // CHECK: %type_2d_image = OpTypeImage %uint 2D 2 0 0 2 Rg32ui
 // CHECK: %_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
-// CHECK: %type_3d_image = OpTypeImage %float 3D 2 0 0 2 Rgba32f
+// CHECK: %type_3d_image = OpTypeImage %int 3D 2 0 0 2 R32i
 // CHECK: %_ptr_UniformConstant_type_3d_image = OpTypePointer UniformConstant %type_3d_image
+// CHECK: %type_3d_image_0 = OpTypeImage %float 3D 2 0 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_3d_image_0 = OpTypePointer UniformConstant %type_3d_image_0
 // CHECK: %type_1d_image_array = OpTypeImage %int 1D 2 1 0 2 R32i
 // CHECK: %_ptr_UniformConstant_type_1d_image_array = OpTypePointer UniformConstant %type_1d_image_array
 // CHECK: %type_2d_image_array = OpTypeImage %uint 2D 2 1 0 2 Rg32ui
@@ -25,21 +27,25 @@ RWTexture1D   <int>    t1 ;
 RWTexture2D   <uint2>  t2 ;
 
 // CHECK: %t3 = OpVariable %_ptr_UniformConstant_type_3d_image UniformConstant
-RWTexture3D   <float3> t3 ;
+RWTexture3D   <int>    t3 ;
 
-// CHECK: %t4 = OpVariable %_ptr_UniformConstant_type_3d_image UniformConstant
-RWTexture3D   <float4> t4 ;
+// CHECK: %t4 = OpVariable %_ptr_UniformConstant_type_3d_image_0 UniformConstant
+[[vk::image_format("rgba32f")]]
+RWTexture3D   <float3> t4 ;
 
-// CHECK: %t5 = OpVariable %_ptr_UniformConstant_type_1d_image_array UniformConstant
-RWTexture1DArray<int>    t5;
+// CHECK: %t5 = OpVariable %_ptr_UniformConstant_type_3d_image_0 UniformConstant
+RWTexture3D   <float4> t5 ;
 
-// CHECK: %t6 = OpVariable %_ptr_UniformConstant_type_2d_image_array UniformConstant
-RWTexture2DArray<uint2>  t6;
+// CHECK: %t6 = OpVariable %_ptr_UniformConstant_type_1d_image_array UniformConstant
+RWTexture1DArray<int>    t6;
 
-// CHECK: %t7 = OpVariable %_ptr_UniformConstant_type_1d_image_array_0 UniformConstant
-RWTexture1DArray<float3> t7;
+// CHECK: %t7 = OpVariable %_ptr_UniformConstant_type_2d_image_array UniformConstant
+RWTexture2DArray<uint2>  t7;
 
-// CHECK: %t8 = OpVariable %_ptr_UniformConstant_type_2d_image_array_0 UniformConstant
-RWTexture2DArray<float4> t8;
+// CHECK: %t8 = OpVariable %_ptr_UniformConstant_type_1d_image_array_0 UniformConstant
+RWTexture1DArray<float4> t8;
+
+// CHECK: %t9 = OpVariable %_ptr_UniformConstant_type_2d_image_array_0 UniformConstant
+RWTexture2DArray<float4> t9;
 
 void main() {}

--- a/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.64bit.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.64bit.scalar.hlsl
@@ -6,7 +6,7 @@
 // CHECK: %type_2d_image_0 = OpTypeImage %long 2D 2 0 0 2 R64i
 // CHECK: %_ptr_UniformConstant_type_2d_image_0 = OpTypePointer UniformConstant %type_2d_image_0
 
-// CHECK: %type_2d_image_1 = OpTypeImage %int 2D 2 0 0 2 Rgba32i
+// CHECK: %type_2d_image_1 = OpTypeImage %int 2D 2 0 0 2 Rgba16i
 // CHECK: %_ptr_UniformConstant_type_2d_image_1 = OpTypePointer UniformConstant %type_2d_image_1
 
 // CHECK: %tex_ui = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant

--- a/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.min.precision.scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwtexture.with.min.precision.scalar.hlsl
@@ -1,12 +1,12 @@
 // RUN: %dxc -T cs_6_0 -E main
 
-// CHECK: %type_2d_image = OpTypeImage %float 2D 2 0 0 2 Rgba32f
+// CHECK: %type_2d_image = OpTypeImage %float 2D 2 0 0 2 Rgba16f
 // CHECK: %_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
 
-// CHECK: %type_2d_image_0 = OpTypeImage %uint 2D 2 0 0 2 Rgba32ui
+// CHECK: %type_2d_image_0 = OpTypeImage %uint 2D 2 0 0 2 Rgba16ui
 // CHECK: %_ptr_UniformConstant_type_2d_image_0 = OpTypePointer UniformConstant %type_2d_image_0
 
-// CHECK: %type_2d_image_1 = OpTypeImage %int 2D 2 0 0 2 Rgba32i
+// CHECK: %type_2d_image_1 = OpTypeImage %int 2D 2 0 0 2 Rgba16i
 // CHECK: %_ptr_UniformConstant_type_2d_image_1 = OpTypePointer UniformConstant %type_2d_image_1
 
 // CHECK:    %tex = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant


### PR DESCRIPTION
This commit aim to fix #4773. In SPIR-V, image type must be specified, and GLSL has the syntax for it. In HLSL, we don't, until #3395. When this attribute is not specified, we decided to guess the type, not using Unknown anymore.
But the type guessing was a bit too optimistic, and thus allowed a 3 component layout to be upgraded to 4 component layout.

Changing the guessing function to either give a close type, or return Unknown, adding the capability on load/store to the variable.