### PR TITLE
[SPIR-V] Fix invalid HLSL in test

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
@@ -48,10 +48,18 @@ struct Wrapper {
     RWStructuredBuffer<float> getRWSBuffer() { return b.b2.rw; }
 };
 
+ConsumeStructuredBuffer<float> globalCSBuffer;
+AppendStructuredBuffer<float> globalASBuffer;
+RWStructuredBuffer<float> globalRWSBuffer;
+
 // CHECK-LABLE: %src_main = OpFunction
 float main() : VVV {
     TwoBundle localBundle;
     Wrapper   localWrapper;
+
+    localBundle.b1.consume = globalCSBuffer;
+    localWrapper.b.b1.append = globalASBuffer;
+    localWrapper.b.b2.rw = globalRWSBuffer;
 
 // CHECK:      [[counter:%\d+]] = OpLoad %_ptr_Uniform_type_ACSBuffer_counter %counter_var_localBundle_0_0
 // CHECK-NEXT:                    OpStore %counter_var_getCSBuffer_this_0_0 [[counter]]


### PR DESCRIPTION
Previously, the test spirv.legal.sbuffer.counter.method.hlsl would cause errors if compiled with the DXIL backend:

```
../DirectXShaderCompiler/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl:72:19: error: cannot map resource to handle.
    float value = localBundle.getCSBuffer().Consume();
                  ^
../DirectXShaderCompiler/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl:87:5: error: cannot map resource to handle.
    localWrapper.getASBuffer().Append(4.2);
    ^
../DirectXShaderCompiler/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl:72:19: error: local resource not guaranteed to map to unique global resource.
    float value = localBundle.getCSBuffer().Consume();
                  ^
../DirectXShaderCompiler/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl:87:5: error: local resource not guaranteed to map to unique global resource.
    localWrapper.getASBuffer().Append(4.2);
    ^
../DirectXShaderCompiler/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl:104:12: error: local resource not guaranteed to map to unique global resource.
    return localRWSBuffer[5];
           ^
```

Fix these errors by assigning global resources to each local variable.