### PR TITLE
Unbuffer raw_string_stream

### DIFF
--- a/include/llvm/Support/raw_ostream.h
+++ b/include/llvm/Support/raw_ostream.h
@@ -516,7 +516,7 @@ class raw_string_ostream : public raw_ostream {
   /// currently in the buffer.
   uint64_t current_pos() const override { return OS.size(); }
 public:
-  explicit raw_string_ostream(std::string &O) : OS(O) {}
+  explicit raw_string_ostream(std::string &O) : OS(O) { SetUnbuffered(); }
   ~raw_string_ostream() override;
 
   /// Flushes the stream contents to the target string and returns  the string's

--- a/tools/clang/test/DXC/show-includes.hlsl
+++ b/tools/clang/test/DXC/show-includes.hlsl
@@ -1,0 +1,4 @@
+// RUN: %dxc -E main -T lib_6_3 %s -H | FileCheck %s
+#include "Inputs/empty.h"
+
+// CHECK: ; Opening file [{{.*}}/Inputs/empty.h], stack top [0]

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -453,8 +453,8 @@ mkdir inc       2>nul
 copy "%testfiles%\include-declarations.h" inc  >nul
 call :run dxc.exe -Tps_6_0 -Vi -I inc "%testfiles%\include-main.hlsl"
 if %Failed% neq 0 goto :failed
-call :check-file log find "; Opening file ["
-call :check-file log find "inc\include-declarations.h], stack top [0]"
+call :check_file log find "; Opening file ["
+call :check_file log find "inc\include-declarations.h], stack top [0]"
 if %Failed% neq 0 goto :failed
 
 set testname=Test Version macro

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -454,7 +454,7 @@ copy "%testfiles%\include-declarations.h" inc  >nul
 call :run dxc.exe -Tps_6_0 -Vi -I inc "%testfiles%\include-main.hlsl"
 if %Failed% neq 0 goto :failed
 call :check_file log find "; Opening file ["
-call :check_file log find "inc\include-declarations.h], stack top [0]"
+call :check_file log find "include-declarations.h], stack top [0]"
 if %Failed% neq 0 goto :failed
 
 set testname=Test Version macro


### PR DESCRIPTION
Double buffering a string stream writing in memory is silly. Upstream LLVM made this change a few years ago based on analysis that most string implementations are sane:

https://github.com/llvm/llvm-project/commit/65b1361