### PR TITLE
Update all the HLSL tests that rely on HLSL 2018 (#4878)

### DIFF
--- a/tools/clang/test/CodeGenHLSL/Samples/D12/d12_multithreading_ps.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/D12/d12_multithreading_ps.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Sqrt
 // CHECK: dot3

--- a/tools/clang/test/CodeGenHLSL/Samples/D12/d12_multithreading_vs.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/D12/d12_multithreading_vs.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // The constant buffer should be allocated with ID zero and referenced as such.
 

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HDecode.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HDecode.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: groupId
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_EncodeBlockCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_EncodeBlockCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_TryModeG10CS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_TryModeG10CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_TryModeLE10CS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/BC6HEncode_TryModeLE10CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/ContactHardeningShadows11_PS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/ContactHardeningShadows11_PS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Round_ni
 // CHECK: textureGather

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/DecalTessellation11_DS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/DecalTessellation11_DS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ds_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ds_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: domainLocation
 // CHECK: domainLocation

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_NumVerticesIndicesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_NumVerticesIndicesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_TessellateVerticesCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/DX11/TessellatorCS40_TessellateVerticesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ApplyBloomCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ApplyBloomCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: dot3

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicHorizontalUpsamplePS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicHorizontalUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicUpsampleGammaPS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicUpsampleGammaPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicUpsamplePS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicVerticalUpsamplePS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BicubicVerticalUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: IMax
 // CHECK: UMin

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BilinearUpsamplePS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BilinearUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: Log

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BloomExtractAndDownsampleHdrCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BloomExtractAndDownsampleHdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: FMax

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BloomExtractAndDownsampleLdrCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/BloomExtractAndDownsampleLdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: dot3

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ConvertLDRToDisplayAltPS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ConvertLDRToDisplayAltPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: textureLoad
 // CHECK: Log

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ConvertLDRToDisplayPS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ConvertLDRToDisplayPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: textureLoad
 // CHECK: Log

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/DebugLuminanceHdrCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/DebugLuminanceHdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/DebugLuminanceLdrCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/DebugLuminanceLdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ExtractLumaCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ExtractLumaCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: sampleLevel

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddXCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddXCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddYCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsGammaOddYCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddXCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddXCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddYCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/GenerateMipsLinearOddYCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/MagnifyPixelsPS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/MagnifyPixelsPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/SharpeningUpsampleGammaPS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/SharpeningUpsampleGammaPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: Log

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/SharpeningUpsamplePS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/SharpeningUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: sampleLevel

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/TemporalBlendCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/TemporalBlendCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ToneMap2CS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ToneMap2CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ToneMapCS.hlsl
+++ b/tools/clang/test/CodeGenHLSL/Samples/MiniEngine/ToneMapCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 

--- a/tools/clang/test/CodeGenSPIRV/binary-op.comma.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.comma.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 void foo() { int x = 1; }
 

--- a/tools/clang/test/CodeGenSPIRV/binary-op.logical-and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.logical-and.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel

--- a/tools/clang/test/CodeGenSPIRV/binary-op.logical-or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.logical-or.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel

--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.struct-to-struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.struct-to-struct.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -E main
+// RUN: %dxc -T cs_6_0 -HV 2018 -E main
 
 // Processing FlatConversion when source and destination
 // are both structures with identical members.

--- a/tools/clang/test/CodeGenSPIRV/cast.literal-type.ternary.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.literal-type.ternary.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // The 'out' argument in the function should be handled correctly when deducing
 // the literal type.

--- a/tools/clang/test/CodeGenSPIRV/cf.cond-op.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.cond-op.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // TODO: write to global variable
 bool fn() { return true; }

--- a/tools/clang/test/CodeGenSPIRV/cf.logical-and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.logical-and.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // TODO: write to global variable
 bool fn() { return true; }

--- a/tools/clang/test/CodeGenSPIRV/cf.logical-or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.logical-or.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // TODO: write to global variable
 bool fn() { return true; }

--- a/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.relaxed-precision.bool.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -E main
+// RUN: %dxc -T cs_6_0 -HV 2018 -E main
 
 // According to the SPIR-V spec (2.14. Relaxed Precision):
 // The RelaxedPrecision decoration can be applied to:

--- a/tools/clang/test/CodeGenSPIRV/literal.constant-composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/literal.constant-composite.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 float func(float3 i) { return i.x; }
 

--- a/tools/clang/test/CodeGenSPIRV/literal.vec-times-scalar.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/literal.vec-times-scalar.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 float func(float3 i) { return i.x; }
 

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.branch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.branch.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main -fspv-debug=vulkan
 
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK:      [[dbgsrc:%\d+]] = OpExtInst %void %1 DebugSource [[file]]

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.line.operators.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.line.operators.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan -no-warnings
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main -fspv-debug=vulkan -no-warnings
 
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK:      [[src:%\d+]] = OpExtInst %void %1 DebugSource [[file]]

--- a/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-diagonal.vulkan1.2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.quad-read-across-diagonal.vulkan1.2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.2
+// RUN: %dxc -T cs_6_0 -E main -HV 2018 -fspv-target-env=vulkan1.2
 
 // CHECK: ; Version: 1.5
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1
+// RUN: %dxc -T cs_6_0 -HV 2018 -E main -fspv-target-env=vulkan1.1
 
 // CHECK: ; Version: 1.3
 

--- a/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.vulkan1.2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/sm6.wave-active-all-equal.vulkan1.2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.2
+// RUN: %dxc -T cs_6_0 -E main -HV 2018 -fspv-target-env=vulkan1.2
 
 // CHECK: ; Version: 1.5
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.branch.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.branch.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main -Zi
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main -Zi
 
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.branch.hlsl

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.operators.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.operators.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main -Zi
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main -Zi
 
 // CHECK:      [[file:%\d+]] = OpString
 // CHECK-SAME: spirv.debug.opline.operators.hlsl

--- a/tools/clang/test/CodeGenSPIRV/ternary-op.cond-op.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/ternary-op.cond-op.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // CHECK: [[v3i0:%\d+]] = OpConstantComposite %v3int %int_0 %int_0 %int_0
 SamplerState gSS1;

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.boolean.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.boolean.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // CHECK: OpDecorate %_arr_v3uint_uint_2 ArrayStride 16
 // CHECK: OpMemberDecorate %FrameConstants 0 Offset 0

--- a/tools/clang/test/CodeGenSPIRV/vk.spec-constant.reuse.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.spec-constant.reuse.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ps_6_0 -E main
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
 // CHECK: OpDecorate %y SpecId 0
 [[vk::constant_id(0)]] const bool y = false;

--- a/tools/clang/test/HLSL/attributes.hlsl
+++ b/tools/clang/test/HLSL/attributes.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -HV 2018 -verify %s
 
 // To test with the classic compiler, run
 // %sdxroot%\tools\x86\fxc.exe /T ps_5_1 attributes.hlsl

--- a/tools/clang/test/HLSL/conversions-between-type-shapes.hlsl
+++ b/tools/clang/test/HLSL/conversions-between-type-shapes.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -verify -verify-ignore-unexpected=note %s
+// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -verify -verify-ignore-unexpected=note -HV 2018 %s
 
 // Tests all implicit conversions and explicit casts between type shapes
 // (scalars, vectors, matrices, arrays and structs).

--- a/tools/clang/test/HLSL/cpp-errors.hlsl
+++ b/tools/clang/test/HLSL/cpp-errors.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -HV 2018 -verify %s
 
 float f_arr_empty_init[] = { 1, 2, 3 };
 float f_arr_empty_pack[] = { 1, 2 ... }; // expected-error {{expansion is unsupported in HLSL}}

--- a/tools/clang/test/HLSL/functions.hlsl
+++ b/tools/clang/test/HLSL/functions.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -verify %s
+// RUN: %clang_cc1 -fsyntax-only -Wno-unused-value -ffreestanding -HV 2018 -verify %s
 
 // __decltype is the GCC way of saying 'decltype', but doesn't require C++11
 // _Static_assert is the C11 way of saying 'static_assert', but doesn't require C++11

--- a/tools/clang/test/HLSL/implicit-casts.hlsl
+++ b/tools/clang/test/HLSL/implicit-casts.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -HV 2018 -verify %s
 
 // To test with the classic compiler, run
 // %sdxroot%\tools\x86\fxc.exe /T ps_5_1 implicit-casts.hlsl

--- a/tools/clang/test/HLSL/vector-conditional.hlsl
+++ b/tools/clang/test/HLSL/vector-conditional.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify %s
+// RUN: %clang_cc1 -fsyntax-only -ffreestanding -verify -HV 2018 %s
 
 // Disable validation on fxc (/Vd) because
 // non-literal ternary with objects results in bad code.

--- a/tools/clang/test/HLSLFileCheck/hlsl/classes/mismatch_class_implicit_cast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/classes/mismatch_class_implicit_cast.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 // RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck %s -check-prefix=ERROR
 
 // CHECK: define void @main()

--- a/tools/clang/test/HLSLFileCheck/hlsl/compile_options/enable_templates.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/compile_options/enable_templates.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck -check-prefix=DISABLED %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck -check-prefix=DISABLED %s
 // RUN: %dxc -E main -T ps_6_0 -HV 2021 %s | FileCheck -check-prefix=ENABLED %s
 
 // DISABLED: error: 'template' is a reserved keyword in HLSL

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/big_step_non_trivial.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/big_step_non_trivial.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Od -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 // CHECK: @main
 
 // CHECK: @dx.op.unary.f32(i32 13

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/partial_cond.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/partial_cond.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -Od -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -Od -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: call float @dx.op.dot3
 // CHECK: call float @dx.op.dot3

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/if8.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/if8.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECKNOT: bitcast
 // CHECKNOT: i64 2

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/logical_no_short_circuiting.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/logical_no_short_circuiting.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // HLSL's logical operators are not short-circuiting.
 // Test that the right-hand side is always executed.

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/ternary_conditional_to_select.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/ternary_conditional_to_select.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_2 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_2 -HV 2018 %s | FileCheck %s
 
 // Make sure no branch.
 // CHECK-NOT:br i1

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/vector_comparison.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/vector_comparison.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: fcmp
 // CHECK: fcmp

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/using.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/using.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T ps_6_0 %s -HV 2021  | FileCheck -check-prefix=HV2021 %s
 
-// RUN: %dxc -E main -T ps_6_0 %s  | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -HV 2018 | FileCheck %s
 
 // CHECK:using.hlsl:14:5: warning: keyword 'using' is a HLSL 2021 feature, and is available in older versions as a non-portable extension.
 // CHECK:using.hlsl:21:1: warning: keyword 'using' is a HLSL 2021 feature, and is available in older versions as a non-portable extension.

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/outputArray.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: switch
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/boolean/all_lit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/boolean/all_lit.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: @main
 uint4 a;

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/reduction/WaveBreakAndUnrollCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T cs_6_0 -Od %s | FileCheck %s
+// RUN: %dxc -T cs_6_0 -Od -HV 2018 %s | FileCheck %s
 // A test of explicit loop unrolling on a loop that uses a wave op in a break block
 
 // CHECK: void @main

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/arithmetic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/arithmetic.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // Tests the implementation of unary and binary matrix operators
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/vector_arithmetic.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/vector_arithmetic.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // Tests the implementation of unary and binary matrix operators
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/select/sel_vec1_mixed.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/select/sel_vec1_mixed.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // Make sure 1-component vector in conditional compiles
 // CHECK: = select i1

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/boolean/const_init_list_no_crash.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/boolean/const_init_list_no_crash.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // Regression test for bools in constant initialization lists crashing
 // due to a mismatch between register and memory representations (GitHub #1880, #1881)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/StructCast.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: SV_RenderTargetArrayIndex or SV_ViewportArrayIndex from any shader feeding rasterizer
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/bool_cast_initializer_syntax_test.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/bool_cast_initializer_syntax_test.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /T ps_6_0 /E main %s | FileCheck %s
+// RUN: %dxc /T ps_6_0 /E main -HV 2018 %s | FileCheck %s
 
 // Ensure that when casting to bool, we never use fptoui or fptosi instruction
 // CHECK-NOT: fptoui

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/explicit_cast_as_out_param.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tvs_6_0 /Emain %s | FileCheck %s
+// RUN: %dxc /Tvs_6_0 /Emain -HV 2018 %s | FileCheck %s
 // Test explicit cast between structs of identical layout where
 // the destination struct is marked as out param.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_func_param_user_scenario.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 // github issue #1725
 // Test implicit cast scenario between structs of identical layout
 // which would crash as reported by a user.

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/cast/identical_layout_structs/implicit_cast_as_streamout_append.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc /Tgs_6_0 /Emain %s | FileCheck %s
+// RUN: %dxc /Tgs_6_0 /Emain -HV 2018 %s | FileCheck %s
 // github issue #1560
 
 // CHECK: main

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/between_type_shapes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/between_type_shapes.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 -no-warnings %s | FileCheck -check-prefix=DXC %s
+// RUN: %dxc -E main -T vs_6_0 -no-warnings -HV 2018 %s | FileCheck -check-prefix=DXC %s
 
 // Tests all implicit conversions and explicit casts between type shapes
 // (scalars, vectors, matrices, arrays and structs).

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/functions_Mod.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/functions_Mod.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/implicit-casts_Mod.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/implicit-casts_Mod.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: @main
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/selMat.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/selMat.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: fcmp fast olt
 // CHECK: 3.000000e+00

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/anonymous.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // Tests declarations and uses of anonymous structs.
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/struct/structArray.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: @main
 struct Vertex

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ApplyBloomCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ApplyBloomCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: dot3

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicHorizontalUpsamplePS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicHorizontalUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicUpsampleGammaPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicUpsampleGammaPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicUpsamplePS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Frc
 // CHECK: IMax

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicVerticalUpsamplePS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BicubicVerticalUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: IMax
 // CHECK: UMin

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BilinearUpsamplePS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BilinearUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: Log

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BloomExtractAndDownsampleHdrCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BloomExtractAndDownsampleHdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: FMax

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BloomExtractAndDownsampleLdrCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/BloomExtractAndDownsampleLdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: dot3

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ConvertLDRToDisplayAltPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ConvertLDRToDisplayAltPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: textureLoad
 // CHECK: Log

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ConvertLDRToDisplayPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ConvertLDRToDisplayPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: textureLoad
 // CHECK: Log

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/DebugLuminanceHdrCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/DebugLuminanceHdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/DebugLuminanceLdrCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/DebugLuminanceLdrCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ExtractLumaCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ExtractLumaCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: sampleLevel

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddXCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddXCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddYCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsGammaOddYCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddXCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddXCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddYCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/GenerateMipsLinearOddYCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: flattenedThreadIdInGroup
 // CHECK: threadId

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MagnifyPixelsPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/MagnifyPixelsPS.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
-// RUN: %dxc -E main -T ps_6_0 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
 
 // CHECK: sampleLevel
 

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/SharpeningUpsampleGammaPS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/SharpeningUpsampleGammaPS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: Log

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/SharpeningUpsamplePS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/SharpeningUpsamplePS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: sampleLevel
 // CHECK: sampleLevel

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/TemporalBlendCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/TemporalBlendCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ToneMap2CS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ToneMap2CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: textureLoad

--- a/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ToneMapCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/MiniEngine/ToneMapCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HDecode.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HDecode.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: groupId
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_EncodeBlockCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_EncodeBlockCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_TryModeG10CS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_TryModeG10CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_TryModeLE10CS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/BC6HEncode_TryModeLE10CS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -HV 2018 %s | FileCheck %s
 
 // check input.
 // CHECK: flattenedThreadIdInGroup

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/ContactHardeningShadows11_PS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/ContactHardeningShadows11_PS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Round_ni
 // CHECK: textureGather

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_NumVerticesIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_NumVerticesIndicesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateIndicesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateVerticesCS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d11/TessellatorCS40_TessellateVerticesCS.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T cs_6_0 -O0 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_0 -O0 -HV 2018 %s | FileCheck %s
 
 // CHECK: threadId
 // CHECK: bufferLoad

--- a/tools/clang/test/HLSLFileCheck/samples/d3d12/d12_multithreading_ps.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d12/d12_multithreading_ps.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 -HV 2018 %s | FileCheck %s
 
 // CHECK: Sqrt
 // CHECK: dot3

--- a/tools/clang/test/HLSLFileCheck/samples/d3d12/d12_multithreading_vs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/d3d12/d12_multithreading_vs.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T vs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 -HV 2018 %s | FileCheck %s
 
 // The constant buffer should be allocated with ID zero and referenced as such.
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_input_before_output_different_structs.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T gs_6_0 -HV 2018 %s | FileCheck %s
 
 // Regression test for an SROA bug where the flattening the output stream argument
 // would not handle the case where its input had already been SROA'd.

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/streamoutputs/streamout_output_before_input_different_structs.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
+// RUN: %dxc -E main -T gs_6_0 %s -HV 2018 | FileCheck %s
 
 // Regression test for an SROA bug where the flattening the output stream argument
 // would not handle the case where its input had already been SROA'd.

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/inout_struct_mismatch.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_x -default-linkage external %s | FileCheck %s
+// RUN: %dxc -T lib_6_x -default-linkage external -HV 2018 %s | FileCheck %s
 
 // CHECK: define <4 x float>
 // CHECK-SAME: main

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -866,8 +866,8 @@ TEST_F(LinkerTest, LinkSm63ToSm66) {
 
 TEST_F(LinkerTest, RunLinkWithRootSig) {
   CComPtr<IDxcBlob> pLib0;
-  CompileLib(L"..\\CodeGenHLSL\\linker\\link_with_root_sig.hlsl", &pLib0, {},
-             L"lib_6_x");
+  CompileLib(L"..\\CodeGenHLSL\\linker\\link_with_root_sig.hlsl", &pLib0,
+            {L"-HV", L"2018"}, L"lib_6_x");
 
   CComPtr<IDxcLinker> pLinker;
   CreateLinker(&pLinker);
@@ -888,8 +888,8 @@ TEST_F(LinkerTest, RunLinkWithRootSig) {
   VERIFY_IS_TRUE(pLinkedProgram);
 
   CComPtr<IDxcBlob> pProgram;
-  Compile(L"..\\CodeGenHLSL\\linker\\link_with_root_sig.hlsl", &pProgram, {},
-          pEntryName, pShaderModel);
+  Compile(L"..\\CodeGenHLSL\\linker\\link_with_root_sig.hlsl", &pProgram,
+          {L"-HV", L"2018"}, pEntryName, pShaderModel);
   VERIFY_IS_TRUE(pProgram);
 
   const DxilContainerHeader *pLinkedContainer = IsDxilContainerLike(

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -2057,7 +2057,8 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(
     const wchar_t * optimizationLevel,
     bool validateCoverage,
     const wchar_t *profile) {
-  CComPtr<IDxcBlob> pBlob = Compile(hlsl, profile, {optimizationLevel});
+  CComPtr<IDxcBlob> pBlob = Compile(hlsl, profile,
+                                    {optimizationLevel, L"-HV", L"2018"});
 
   CComPtr<IDxcBlob> pDxil = FindModule(DFCC_ShaderDebugInfoDXIL, pBlob);
 


### PR DESCRIPTION
This updates all the tests cases that rely on HLSL 2018 behaviors that will break if the default HLSL version updates to 2021.

These tests are updated to be passed the HLSL 2018 version so they continue testing and working under the same behaviors.