### PR TITLE
Include TestConfig.h only if DEFAULT_TEST_DIR is not already defined

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -26,8 +26,11 @@
 #include "WEXAdapter.h"
 #endif
 #include "dxc/Support/Unicode.h"
-#include "dxc/Test/TestConfig.h"
 #include "dxc/DXIL/DxilConstants.h" // DenormMode
+
+#ifndef DEFAULT_TEST_DIR
+#include "dxc/Test/TestConfig.h"
+#endif
 
 using namespace std;
 


### PR DESCRIPTION
TestConfig.h is not available in HLK test build. This change enables skipping of the include.