### PR TITLE
Enable 2021 operator intrinsics in older modes (#4882)

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4783,18 +4783,6 @@ public:
         pIntrinsic->uNumArgs <= g_MaxIntrinsicParamCount + 1,
         "otherwise g_MaxIntrinsicParamCount needs to be updated for wider signatures");
 
-      // Some intrinsics only optionally exist in later language versions.
-      // To prevent collisions with existing functions or templates, exclude
-      // intrinsics when they aren't enabled.
-      if (IsBuiltinTable(tableName) &&
-          m_sema->getLangOpts().HLSLVersion < hlsl::LangStd::v2021) {
-        if (pIntrinsic->Op == (UINT)IntrinsicOp::IOP_and ||
-            pIntrinsic->Op == (UINT)IntrinsicOp::IOP_or ||
-            pIntrinsic->Op == (UINT)IntrinsicOp::IOP_select) {
-          continue;
-        }
-      }
-
       std::vector<QualType> functionArgTypes;
       size_t badArgIdx;
       bool argsMatch = MatchArguments(cursor, QualType(), QualType(), Args, &functionArgTypes, badArgIdx);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.and.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.and.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T ps_6_0 -E main -HV 2021
+// RUN: %dxc -T ps_6_0 -E main -HV 2018
 
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.or.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.or.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T ps_6_0 -E main -HV 2021
+// RUN: %dxc -T ps_6_0 -E main -HV 2018
 
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.select.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.select.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T ps_6_0 -E main -HV 2021
+// RUN: %dxc -T ps_6_0 -E main -HV 2018
 
 // CHECK: [[v3i0:%\d+]] = OpConstantComposite %v3int %int_0 %int_0 %int_0
 


### PR DESCRIPTION
This enables the `select`, `and`, and `or` intrinsics in older HLSL language modes to ease transitioning to HLSL 2021.