### PR TITLE
Do not include TestConfig.h for all HLK build

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -28,7 +28,9 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/DXIL/DxilConstants.h" // DenormMode
 
-#ifndef DEFAULT_TEST_DIR
+#ifdef _HLK_CONF
+#define DEFAULT_TEST_DIR ""
+#else
 #include "dxc/Test/TestConfig.h"
 #endif
 


### PR DESCRIPTION
TestConfig.h is not available in HLK test build.
The test library uses _HLK_CONF define to distinguish between Exec tests-only and HLK-only code.