### PR TITLE
add test to handle preprocessing an already preprocessed file.

### DIFF
--- a/tools/clang/lib/Frontend/PrintPreprocessedOutput.cpp
+++ b/tools/clang/lib/Frontend/PrintPreprocessedOutput.cpp
@@ -280,7 +280,6 @@ void PrintPPOutputPPCallbacks::FileChanged(SourceLocation Loc,
   }
   if (PP.getLangOpts().HLSL) {
     if (0 == strcmp(UserLoc.getFilename(), "<built-in>")) {
-      assert(NewLine == 1 && "else built-in is generating preprocessor output");
       return;
     }
   }

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3976,7 +3976,6 @@ TEST_F(CompilerTest, PreprocessCheckBuiltinIsOk) {
   
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
   CreateBlobFromText(
-    " \r\n\t \r\n\r\n"
     "#line 1 \"<built-in>\"\r\n"
     "int x;", &pSource);
   VERIFY_SUCCEEDED(pCompiler->Preprocess(pSource, L"file.hlsl", nullptr, 0,


### PR DESCRIPTION
There are some captures that cause problems when preprocessing the extracted source. It appears like some of the source files have already been preprocessed. This change prevents the preprocessor from blowing up when receiving a preprocessed file as input Two tests should be added to test this behavior.
1. Make sure that when the preprocessor receives a preprocessed file, it doesn't blow up.
(this is checked by the new test, PreprocessCheckBuiltinIsOk).
2. Make sure that the preprocessor itself doesn't produce files with the line '#line 1 "<built-in>"' at the top.
(this is already satisfied by PreprocessWhenValidThenOK)