### PR TITLE
Fix assert when bool field in nested struct during init list casting

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -4041,7 +4041,9 @@ static Value* ConvertScalarOrVector(CGBuilderTy& Builder, CodeGenTypes &Types,
   llvm::Type *SrcTy = Val->getType();
   llvm::Type *DstTy = Types.ConvertType(DstQualTy);
 
-  DXASSERT(Val->getType() == Types.ConvertType(SrcQualTy), "QualType/Value mismatch!");
+  DXASSERT(Val->getType() == Types.ConvertType(SrcQualTy) ||
+               Val->getType() == Types.ConvertTypeForMem(SrcQualTy),
+           "QualType/Value mismatch!");
   DXASSERT((SrcTy->isIntOrIntVectorTy() || SrcTy->isFPOrFPVectorTy())
     && (DstTy->isIntOrIntVectorTy() || DstTy->isFPOrFPVectorTy()),
     "EmitNumericConversion can only be used with int/float scalars/vectors.");

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/boolean/bool_codegen_cast_init_list.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/boolean/bool_codegen_cast_init_list.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -T vs_6_0 %s | FileCheck %s
+
+// Previously, this would trigger an assert.  The scenario:
+// - Empty struct field in MyStruct2 causes init list cast path in CodeGen
+// - DXASSERT that the value type matches the ConvertType for the bool
+// - value type is i32 based on field in MyStruct from RecordLayout
+// - ConvertType for bool is i1, while ConvertTypeForMem will be i32.
+// The assert should instead check both ConvertType and ConvertTypeForMem.
+
+// CHECK: call void @dx.op.storeOutput.i32(i32 5, i32 0, i32 0, i8 0, i32 1)
+
+struct Empty {
+};
+struct MyStruct {
+  bool b;
+};
+struct MyStruct2 {
+  MyStruct s;
+  Empty e;
+};
+
+bool main() : OUT {
+  MyStruct s = { true };
+  MyStruct2 s2 = { s };
+  return s2.s.b;
+}


### PR DESCRIPTION
The scenario:
- Empty struct field in MyStruct2 causes init list cast path in CodeGen
- DXASSERT that the value type matches the ConvertType for the bool
- value type is i32 based on field in MyStruct from RecordLayout
- ConvertType for bool is i1, while ConvertTypeForMem will be i32.

The assert should instead check both ConvertType and ConvertTypeForMem.