### PR TITLE
Add HlslDataDir parameter back to execution tests

### DIFF
--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -369,7 +369,7 @@ if "%TEST_EXEC%"=="1" (
   call :copyagility
 )
 
-set EXEC_COMMON_ARGS= /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK%
+set EXEC_COMMON_ARGS=/p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\unittests\HLSLExec" /runIgnoredTests /p:"ExperimentalShaders=*" %TEST_ADAPTER% %USE_AGILITY_SDK%
 if "%TEST_EXEC%"=="1" (
   echo Sniffing for D3D12 configuration ...
   call :runte exec-hlsl-tests.dll /select:"@Name='ExecutionTest::BasicTriangleTest' AND @Architecture='%TEST_ARCH%'" %EXEC_COMMON_ARGS% 


### PR DESCRIPTION
This parameter was removed when the execution tests were split into a separate dll from clang-hlsl-tests.dll. When the tests are run on the same machine that they were built on this parameter is not needed. However, for ARM64 the tests are running on a different machine and the infrastructure is using hct scripts and HLSL environment variables, so the build machine defaults do not work here.
