### PR TITLE
PIX: dxcpdbutils: Don't set default entry name in lib case

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -958,10 +958,13 @@ public:
   HRESULT SetEntryPointToDefaultIfEmpty() {
     // Entry point might have been omitted. Set it to main by default.
     // Don't set entry point if this instance is non-debug DXIL and has no arguments at all.
-    // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
     if ((!m_EntryPoint || m_EntryPoint->GetStringLength() == 0) && !m_ArgPairs.empty()) {
-      m_EntryPoint = nullptr;
-      IFR(Utf8ToBlobWide("main", &m_EntryPoint));
+      // Don't set the name if the target is a lib
+      if (m_TargetProfile->GetStringLength() < 3 ||
+          0 != wcsncmp(m_TargetProfile->GetStringPointer(), L"lib", 3)) {
+        m_EntryPoint = nullptr;
+        IFR(Utf8ToBlobWide("main", &m_EntryPoint));
+      }
     }
     return S_OK;
   }

--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -960,6 +960,7 @@ public:
     // Don't set entry point if this instance is non-debug DXIL and has no arguments at all.
     // TODO: Check to see that this DxilContainer is not a library before setting the entry point.
     if ((!m_EntryPoint || m_EntryPoint->GetStringLength() == 0) && !m_ArgPairs.empty()) {
+      m_EntryPoint = nullptr;
       IFR(Utf8ToBlobWide("main", &m_EntryPoint));
     }
     return S_OK;

--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -960,7 +960,8 @@ public:
     // Don't set entry point if this instance is non-debug DXIL and has no arguments at all.
     if ((!m_EntryPoint || m_EntryPoint->GetStringLength() == 0) && !m_ArgPairs.empty()) {
       // Don't set the name if the target is a lib
-      if (m_TargetProfile->GetStringLength() < 3 ||
+      if (!m_TargetProfile || 
+          m_TargetProfile->GetStringLength() < 3 ||
           0 != wcsncmp(m_TargetProfile->GetStringPointer(), L"lib", 3)) {
         m_EntryPoint = nullptr;
         IFR(Utf8ToBlobWide("main", &m_EntryPoint));


### PR DESCRIPTION
In the lib case, m_EntryPoint will be non-null but empty, but shouldn't be set anyway. 
(Also, not clearing m_EntryPoint first can result in an assert in CComPtr that the poiner is non-null, and then the pointer is overwritten, resulting in a small memory leak.)