### PR TITLE
PIX: Educate type system about samplers and resources, base classes

### DIFF
--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -1558,10 +1558,6 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
     return S_OK;
   };
 
-      if (CT->getTag() == llvm::dwarf::DW_TAG_structure_type &&
-      CT->getName() == "SamplerState") {
-    CT->getName();
-  }
   IFR(AddType<symbol_factory::UDT>(dwParentID, CT, pNewTypeID, CT->getAlignInBits(), CT, LazyName));
 
   TypeInfo *udtTI;

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -1571,15 +1571,12 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
     for (llvm::DINode *N : CT->getElements()) {
       if (auto *Field = llvm::dyn_cast<llvm::DIType>(N)) {
         DWORD dwUnusedFieldID;
-        if (Field->getName() == "MaterialTextureBilinearWrapedSampler") {
-          Field->getName();
-        }
         IFR(CreateType(Field, &dwUnusedFieldID));
         if (Field->getTag() == llvm::dwarf::DW_TAG_inheritance) {
           // The base class is a type of its own, so will have contributed to
           // its own TypeInfo. But we still need to remember the size that it
           // contributed to this type:
-          auto *DerivedType = llvm::dyn_cast<llvm::DIDerivedType>(Field);
+          auto *DerivedType = llvm::cast<llvm::DIDerivedType>(Field);
           const llvm::DITypeIdentifierMap EmptyMap;
           llvm::DIType *BaseType = DerivedType->getBaseType().resolve(EmptyMap);
           udtTI->AppendSize(getBaseClassSize(BaseType));

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -365,7 +365,8 @@ static OffsetInBits SplitValue(
   else
   {
     assert(VTy->isFloatTy() || VTy->isDoubleTy() || VTy->isHalfTy() ||
-           VTy->isIntegerTy(32) || VTy->isIntegerTy(64) || VTy->isIntegerTy(16));
+           VTy->isIntegerTy(32) || VTy->isIntegerTy(64) || VTy->isIntegerTy(16) ||
+           VTy->isPointerTy());
     Values->emplace_back(ValueAndOffset{V, CurrentOffset});
     CurrentOffset += VTy->getScalarSizeInBits();
   }


### PR DESCRIPTION
These fixes were the result of a single shader from a well-known game engine, all of which resulted in mismatched offsets between PIX's offsets-into-fake-allocas and the offsets into aggregates for dbg.value statements.
-Base class sizes weren't being added to derived classes
-Samplers+Resources weren't being given any size at all
-Raygen payloads (referred to by pointer) were triggering an assert
Added a new set of tests for the type system to exercise these.
