### PR TITLE
Import "Make headers self-contained." commit.

### DIFF
--- a/tools/clang/include/clang/Lex/HeaderMap.h
+++ b/tools/clang/include/clang/Lex/HeaderMap.h
@@ -16,11 +16,9 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include <memory>
 
-namespace llvm {
-  class MemoryBuffer;
-}
 namespace clang {
   class FileEntry;
   class FileManager;

--- a/tools/clang/include/clang/Lex/MacroArgs.h
+++ b/tools/clang/include/clang/Lex/MacroArgs.h
@@ -15,13 +15,13 @@
 #define LLVM_CLANG_LEX_MACROARGS_H
 
 #include "clang/Basic/LLVM.h"
+#include "clang/Lex/Token.h"
 #include "llvm/ADT/ArrayRef.h"
 #include <vector>
 
 namespace clang {
   class MacroInfo;
   class Preprocessor;
-  class Token;
   class SourceLocation;
 
 /// MacroArgs - An instance of this class captures information about

--- a/tools/clang/lib/Analysis/BodyFarm.h
+++ b/tools/clang/lib/Analysis/BodyFarm.h
@@ -15,6 +15,7 @@
 #ifndef LLVM_CLANG_LIB_ANALYSIS_BODYFARM_H
 #define LLVM_CLANG_LIB_ANALYSIS_BODYFARM_H
 
+#include "clang/AST/DeclBase.h"
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
@@ -22,7 +23,6 @@
 namespace clang {
 
 class ASTContext;
-class Decl;
 class FunctionDecl;
 class ObjCMethodDecl;
 class ObjCPropertyDecl;


### PR DESCRIPTION
Importing fa5113893229876b156d80469b1930adc3221225 from upstream LLVM. This fixes a compilation issue for cpp20.