### PR TITLE
PIX: Account for alignment when computing member offset (#4903)

### DIFF
--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -28,6 +28,7 @@
 #include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/MathExtras.h"
 
 #include "DxilDiaSession.h"
 #include "DxilDiaTableSymbols.h"
@@ -596,10 +597,11 @@ public:
     TypeInfo(const TypeInfo &) = delete;
     TypeInfo(TypeInfo &&) = default;
 
-    explicit TypeInfo(DWORD dwTypeID) : m_dwTypeID(dwTypeID) {}
+    TypeInfo(DWORD dwTypeID, uint64_t alignInBits) : m_dwTypeID(dwTypeID), m_alignInBytes(alignInBits / 8) {}
 
     DWORD GetTypeID() const { return m_dwTypeID; }
     DWORD GetCurrentSizeInBytes() const { return m_dwCurrentSizeInBytes; }
+    uint64_t GetAlignmentInBytes() const { return m_alignInBytes; }
     const std::vector<llvm::DIType *> &GetLayout() const { return m_Layout; }
 
     void Embed(const TypeInfo &TI);
@@ -610,6 +612,7 @@ public:
     DWORD m_dwTypeID;
     std::vector<llvm::DIType *> m_Layout;
     DWORD m_dwCurrentSizeInBytes = 0;
+    uint64_t m_alignInBytes;
   };
   using TypeToInfoMap = llvm::DenseMap<llvm::DIType *, std::unique_ptr<TypeInfo> >;
 
@@ -662,9 +665,9 @@ private:
   HRESULT GetTypeInfo(llvm::DIType *T, TypeInfo **TI);
 
   template<typename Factory, typename... Args>
-  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID, Args&&... args) {
+  HRESULT AddType(DWORD dwParentID, llvm::DIType *T, DWORD *pNewSymID, uint64_t alignment, Args&&... args) {
       IFR(AddSymbol<Factory>(dwParentID, pNewSymID, std::forward<Args>(args)...));
-      if (!m_TypeToInfo.insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID))).second) {
+      if (!m_TypeToInfo.insert(std::make_pair(T, llvm::make_unique<TypeInfo>(*pNewSymID, alignment))).second) {
           return E_FAIL;
       }
       return S_OK;
@@ -1140,6 +1143,11 @@ void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::Embed(const TypeInfo &
   for (const auto &E : TI.GetLayout()) {
     m_Layout.emplace_back(E);
   }
+  uint64_t alignmentInBytes = TI.GetAlignmentInBytes();
+  if (alignmentInBytes != 0) {
+    m_dwCurrentSizeInBytes =
+        llvm::RoundUpToAlignment(m_dwCurrentSizeInBytes, alignmentInBytes);
+  }
   m_dwCurrentSizeInBytes += TI.m_dwCurrentSizeInBytes;
 }
 
@@ -1147,6 +1155,10 @@ void dxil_dia::hlsl_symbols::SymbolManagerInit::TypeInfo::AddBasicType(llvm::DIB
   m_Layout.emplace_back(BT);
 
   static constexpr DWORD kNumBitsPerByte = 8;
+  uint64_t alignmentInBytes = BT->getAlignInBits() / kNumBitsPerByte;
+  if (alignmentInBytes != 0) {
+    m_dwCurrentSizeInBytes = llvm::RoundUpToAlignment(m_dwCurrentSizeInBytes, alignmentInBytes);
+  }
   m_dwCurrentSizeInBytes += BT->getSizeInBits() / kNumBitsPerByte;
 }
 
@@ -1402,7 +1414,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(DWORD dw
     };
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID, SymTagFunctionType, ST, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, ST, pNewTypeID, 0 /*alignment*/, SymTagFunctionType, ST, LazyName));
 
   return S_OK;
 }
@@ -1418,7 +1430,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateBasicType(DWORD dwParen
     return S_OK;
   };
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, SymTagBaseType, BT, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, BT, pNewTypeID, BT->getAlignInBits(), SymTagBaseType, BT, LazyName));
 
   TypeInfo *TI;
   IFR(GetTypeInfo(BT, &TI));
@@ -1477,7 +1489,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
       return S_OK;
     };
 
-    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID, SymTagArrayType, CT, LazyName));
+    IFR(AddType<symbol_factory::Type>(dwParentID, CT, pNewTypeID, BaseType->getAlignInBits(), SymTagArrayType, CT, LazyName));
     TypeInfo *ctTI;
     IFR(GetTypeInfo(CT, &ctTI));
     TypeInfo *baseTI;
@@ -1512,7 +1524,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
     return S_OK;
   };
 
-  IFR(AddType<symbol_factory::UDT>(dwParentID, CT, pNewTypeID, CT, LazyName));
+  IFR(AddType<symbol_factory::UDT>(dwParentID, CT, pNewTypeID, CT->getAlignInBits(), CT, LazyName));
 
   TypeInfo *udtTI;
   IFR(GetTypeInfo(CT, &udtTI));
@@ -1612,7 +1624,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateHLSLVectorType(llvm::DI
   }
 
   const DWORD dwParentID = HlslProgramId;
-  IFR(AddType<symbol_factory::VectorType>(dwParentID, T, pNewTypeID, T, dwElemTyID, ElemCnt->getLimitedValue()));
+  IFR(AddType<symbol_factory::VectorType>(dwParentID, T, pNewTypeID, T->getAlignInBits(), T, dwElemTyID, ElemCnt->getLimitedValue()));
 
   TypeInfo *vecTI;
   IFR(GetTypeInfo(T, &vecTI));
@@ -1676,7 +1688,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
       return E_FAIL;
     }
 
-    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, DT, dwBaseTypeID));
+    IFR(AddType<symbol_factory::TypedefType>(dwParentID, DT, pNewTypeID, BaseTy->getAlignInBits(), DT, dwBaseTypeID));
 
     TypeInfo *dtTI;
     IFR(GetTypeInfo(DT, &dtTI));
@@ -1715,7 +1727,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(DWORD dwPar
   }
   }
 
-  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, st, DT, LazyName));
+  IFR(AddType<symbol_factory::Type>(dwParentID, DT, pNewTypeID, DT->getAlignInBits(), st, DT, LazyName));
 
   if (DT->getTag() == llvm::dwarf::DW_TAG_const_type) {
     TypeInfo *dtTI;
@@ -1788,13 +1800,16 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateUDTField(DWORD dwParent
   DWORD dwLVTypeID;
   IFR(CreateType(FieldTy, &dwLVTypeID));
   if (m_pCurUDT != nullptr) {
-    const DWORD dwOffsetInBytes = CurrentUDTInfo().GetCurrentSizeInBytes();
+    TypeInfo *lvTI;
+    IFR(GetTypeInfo(FieldTy, &lvTI));
+    const DWORD dwOffsetInBytes =
+        (lvTI->GetAlignmentInBytes() == 0)
+        ? CurrentUDTInfo().GetCurrentSizeInBytes()
+        : llvm::RoundUpToAlignment(CurrentUDTInfo().GetCurrentSizeInBytes(), lvTI->GetAlignmentInBytes());
     DXASSERT_ARGS(dwOffsetInBytes == Field->getOffsetInBits() / 8,
       "%d vs %d",
       dwOffsetInBytes,
       Field->getOffsetInBits() / 8);
-    TypeInfo *lvTI;
-    IFR(GetTypeInfo(FieldTy, &lvTI));
     CurrentUDTInfo().Embed(*lvTI);
   }
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -227,6 +227,8 @@ public:
   TEST_METHOD(RootSignatureUpgrade_SubObjects)
   TEST_METHOD(RootSignatureUpgrade_Annotation)
 
+  TEST_METHOD(SymbolManager_Embedded2DArray)
+
   dxc::DxcDllSupport m_dllSupport;
   VersionSupportInfo m_ver;
 
@@ -3601,6 +3603,110 @@ float4 main(int i : A, float j : B) : SV_TARGET
   }
 
   VERIFY_IS_TRUE(foundGlobalRS);
+}
+
+static CComPtr<IDxcBlob> GetDebugPart(dxc::DxcDllSupport &dllSupport,
+                                      IDxcBlob *container) {
+
+  CComPtr<IDxcLibrary> pLib;
+  VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcLibrary, &pLib));
+  CComPtr<IDxcContainerReflection> pReflection;
+
+  VERIFY_SUCCEEDED(
+      dllSupport.CreateInstance(CLSID_DxcContainerReflection, &pReflection));
+  VERIFY_SUCCEEDED(pReflection->Load(container));
+
+  UINT32 index;
+  VERIFY_SUCCEEDED(
+      pReflection->FindFirstPartKind(hlsl::DFCC_ShaderDebugInfoDXIL, &index));
+
+  CComPtr<IDxcBlob> debugPart;
+  VERIFY_SUCCEEDED(pReflection->GetPartContent(index, &debugPart));
+
+  return debugPart;
+}
+
+
+TEST_F(PixTest, SymbolManager_Embedded2DArray) {
+  const char *code = R"x(
+struct EmbeddedStruct
+{
+    uint32_t TwoDArray[2][2];
+};
+
+struct smallPayload
+{
+    uint32_t OneInt;
+    EmbeddedStruct embeddedStruct;
+    uint64_t bigOne;
+};
+
+[numthreads(1, 1, 1)]
+void ASMain()
+{
+    smallPayload p;
+    p.OneInt = -137;
+    p.embeddedStruct.TwoDArray[0][0] = 252;
+    p.embeddedStruct.TwoDArray[0][1] = 253;
+    p.embeddedStruct.TwoDArray[1][0] = 254;
+    p.embeddedStruct.TwoDArray[1][1] = 255;
+    p.bigOne = 123456789;
+
+    DispatchMesh(2, 1, 1, p);
+}
+
+)x";
+
+  auto compiled = Compile(code, L"as_6_5", {}, L"ASMain");
+
+  auto debugPart = GetDebugPart(m_dllSupport, compiled);
+
+  CComPtr<IDxcLibrary> library;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &library));
+
+  CComPtr<IStream> programStream;
+  VERIFY_SUCCEEDED(
+      library->CreateStreamFromBlobReadOnly(debugPart, &programStream));
+
+  CComPtr<IDiaDataSource> diaDataSource;
+  VERIFY_SUCCEEDED(
+      m_dllSupport.CreateInstance(CLSID_DxcDiaDataSource, &diaDataSource));
+
+  VERIFY_SUCCEEDED(diaDataSource->loadDataFromIStream(programStream));
+
+  CComPtr<IDiaSession> session;
+  VERIFY_SUCCEEDED(diaDataSource->openSession(&session));
+
+  CComPtr<IDxcPixDxilDebugInfoFactory> Factory;
+  VERIFY_SUCCEEDED(session->QueryInterface(&Factory));
+  CComPtr<IDxcPixDxilDebugInfo> dxilDebugger;
+  VERIFY_SUCCEEDED(Factory->NewDxcPixDxilDebugInfo(&dxilDebugger));
+  CComPtr<IDxcPixDxilLiveVariables> liveVariables;
+  VERIFY_SUCCEEDED(dxilDebugger->GetLiveVariablesAt(43, &liveVariables));
+  CComPtr<IDxcPixVariable> variable;
+  VERIFY_SUCCEEDED(liveVariables->GetVariableByIndex(0, &variable));
+  CComBSTR name;
+  variable->GetName(&name);
+  VERIFY_ARE_EQUAL_WSTR(name, L"p");
+  CComPtr<IDxcPixType> type;
+  VERIFY_SUCCEEDED(variable->GetType(&type));
+  CComPtr<IDxcPixStructType> structType;
+  VERIFY_SUCCEEDED(type->QueryInterface(IID_PPV_ARGS(&structType)));
+  auto ValidateStructMember = [&structType](DWORD index, const wchar_t *name,
+                                            uint64_t offset) {
+    CComPtr<IDxcPixStructField> member;
+    VERIFY_SUCCEEDED(structType->GetFieldByIndex(index, &member));
+    CComBSTR actualName;
+    VERIFY_SUCCEEDED(member->GetName(&actualName));
+    VERIFY_ARE_EQUAL_WSTR(actualName, name);
+    DWORD actualOffset= 0;
+    VERIFY_SUCCEEDED(member->GetOffsetInBits(&actualOffset));
+    VERIFY_ARE_EQUAL(actualOffset, offset);
+  };
+
+  ValidateStructMember(0, L"OneInt", 0);
+  ValidateStructMember(1, L"embeddedStruct", 4*8);
+  ValidateStructMember(2, L"bigOne", 24*8);
 }
 
 #endif


### PR DESCRIPTION
* Account for alignment

* Use llvm::RoundUpToAlignment