### PR TITLE
Disable code coverage action on forks

### DIFF
--- a/.github/workflows/coverage-gh-pages.yml
+++ b/.github/workflows/coverage-gh-pages.yml
@@ -22,6 +22,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/DirectXShaderCompiler'
     timeout-minutes: 240
     steps:
       - name: Checkout
@@ -52,6 +53,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: github.repository == 'microsoft/DirectXShaderCompiler'
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
This job requires repository settings that most forks won't set up.