### PR TITLE
[bug] Fix memory leak in dxil validator

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -5563,7 +5563,7 @@ static void VerifyRDATMatches(_In_ ValidationContext &ValCtx,
   VerifyBlobPartMatches(ValCtx, PartName, pWriter.get(), pRDATData, RDATSize);
 
   // Verify no errors when runtime reflection from RDAT:
-  RDAT::DxilRuntimeReflection *pReflection = RDAT::CreateDxilRuntimeReflection();
+  unique_ptr<RDAT::DxilRuntimeReflection> pReflection(RDAT::CreateDxilRuntimeReflection());
   if (!pReflection->InitFromRDAT(pRDATData, RDATSize)) {
     ValCtx.EmitFormatError(ValidationRule::ContainerPartMatches, { PartName });
     return;


### PR DESCRIPTION
We would create the dxil runtime reflection object but never free it.
Using a unique_ptr here does the job.

Found by running external tests with appverifier enabled.