### PR TITLE
[bug] Fix possible leak when creating empty blobs

### DIFF
--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -612,6 +612,15 @@ HRESULT DxcCreateBlob(
 
   // Handle empty blob
   if (emptyString) {
+    // Free the passed in pointer if we are supposed to be taking
+    // ownership of it. It is a bit strange to have allocated a zero-sized
+    // buffer, but the IMalloc docs explicitly allow it:
+    //
+    // "If cb is zero, Alloc allocates a zero-length item and returns a valid pointer to that item"
+    //
+    if (!bPinned && !bCopy && pPtr)
+      pMalloc->Free((LPVOID)pPtr);
+
     if (encodingKnown && TryCreateEmptyBlobUtf(codePage, pMalloc, ppBlobEncoding))
       return S_OK;
     InternalDxcBlobEncoding *pInternalEncoding;


### PR DESCRIPTION
In DxcCreateBlob we check to see if the wrapped buffer is empty and throw away the passed in pointer to use nullptr instead.

This is fine except that the passed pointer could have been allocated through IMalloc interface that needs to free the original pointer. The IMalloc docs allow allocating 0 bytes and specify that the returned pointer should be non-null.

This PR updates DxcCreateBlob to free the passed pointer in cases where the resulting blob should take ownership of the passed in buffer.