### PR TITLE
Add a github action to verify PR descriptions

### DIFF
--- a/.github/workflows/pr-description-checker.yml
+++ b/.github/workflows/pr-description-checker.yml
@@ -1,0 +1,18 @@
+name: 'PR description checker'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - unlabeled
+jobs:
+  check-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jadrol/pr-description-checker-action@v1.0.0
+        id: description-checker
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action just verifies that PRs contain descriptions. Our policy requires PR descriptions, but we don't have consistent application of the policy. This should help correct that.