### PR TITLE
Explicitly use n* version of vsnprintf (#4957)

### DIFF
--- a/include/dxc/Support/Global.h
+++ b/include/dxc/Support/Global.h
@@ -167,7 +167,7 @@ inline void OutputDebugFormatA(_In_ _Printf_format_string_ _Null_terminated_ con
 
   va_list argList;
   va_start(argList, pszFormat);
-  int count = vsprintf_s(buffer, _countof(buffer), pszFormat, argList);
+  int count = vsnprintf_s(buffer, _countof(buffer), pszFormat, argList);
   va_end(argList);
 
   OutputDebugStringA(buffer);

--- a/include/dxc/Support/WinAdapter.h
+++ b/include/dxc/Support/WinAdapter.h
@@ -183,7 +183,7 @@
 #define _strdup strdup
 #define _strnicmp strnicmp
 
-#define vsprintf_s vsprintf
+#define vsnprintf_s vsnprintf
 #define strcat_s strcat
 #define strcpy_s(dst, n, src) strncpy(dst, src, n)
 #define _vscwprintf vwprintf

--- a/tools/clang/lib/Parse/HLSLRootSignature.cpp
+++ b/tools/clang/lib/Parse/HLSLRootSignature.cpp
@@ -530,7 +530,7 @@ HRESULT RootSignatureParser::Error(uint32_t uErrorNum, LPCSTR pError, ...)
     va_list Args;
     char msg[512];
     va_start(Args, pError);
-    vsprintf_s(msg, pError, Args);
+    vsnprintf_s(msg, _countof(msg), pError, Args);
     va_end(Args);
     try {
       m_OS << msg;


### PR DESCRIPTION
Newest clang makes use of older version a warning, which we get as an error

(cherry picked from commit 79efe5342e2ae15e8b9ebcdf5680098bf3204dd8)