### PR TITLE
Fix hcttest file-check mode with /runIgnoredTests

### DIFF
--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -420,7 +420,7 @@ if exist "%HCT_EXTRAS%\hcttest-after.cmd" (
 )
 
 if "%TEST_MANUAL_FILE_CHECK%"=="1" (
-  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:CompilerTest::ManualFileCheckTest /p:"InputPath=%MANUAL_FILE_CHECK_PATH%"
+  call :runte clang-hlsl-tests.dll /p:"HlslDataDir=%HLSL_SRC_DIR%\tools\clang\test\HLSL" /name:CompilerTest::ManualFileCheckTest /runIgnoredTests /p:"InputPath=%MANUAL_FILE_CHECK_PATH%"
   set RES_EXEC=!ERRORLEVEL!
 )
 


### PR DESCRIPTION
`hcttest.cmd file-check` runs the `CompilerTest::ManualFileCheckTest` test which is normally Ignored because it's only there to run a custom manual filecheck path. A prior change removed the /runIgnoredTests argument, breaking the testing mode.  This change just adds it back.

This was broken by PR #4963.