### PR TITLE
Fix lower type crash on vector array parameter.

### DIFF
--- a/lib/Transforms/Scalar/LowerTypePasses.cpp
+++ b/lib/Transforms/Scalar/LowerTypePasses.cpp
@@ -440,6 +440,10 @@ void DynamicIndexingVectorToArray::ReplaceVectorArrayWithArray(Value *VA, Value 
       ReplaceVecArrayGEP(GEPOp, idxList, A, Builder);
     } else if (BitCastInst *BCI = dyn_cast<BitCastInst>(User)) {
       BCI->setOperand(0, A);
+    } else if (auto *CI = dyn_cast<CallInst>(User)) {
+      IRBuilder<> B(CI);
+      auto *Cast = B.CreateBitCast(A, VA->getType());
+      CI->replaceUsesOfWith(VA, Cast);
     } else {
       DXASSERT(0, "Array pointer should only used by GEP");
     }

--- a/lib/Transforms/Scalar/Scalar.cpp
+++ b/lib/Transforms/Scalar/Scalar.cpp
@@ -36,6 +36,7 @@ void llvm::initializeScalarOpts(PassRegistry &Registry) {
   initializeCorrelatedValuePropagationPass(Registry);
   initializeDCEPass(Registry);
   initializeDeadInstEliminationPass(Registry);
+  initializeDynamicIndexingVectorToArrayPass(Registry); // HLSL Change
   initializeScalarizerPass(Registry);
   initializeDSEPass(Registry);
   initializeGVNPass(Registry);

--- a/tools/clang/test/HLSLFileCheck/passes/dxil/lower_type/vec_array_param.ll
+++ b/tools/clang/test/HLSLFileCheck/passes/dxil/lower_type/vec_array_param.ll
@@ -1,0 +1,33 @@
+; RUN: %opt %s -dynamic-vector-to-array -S | FileCheck %s
+
+; Make sure argument is cast before call.
+; CHECK:%[[Cast:.+]] = bitcast [3 x [3 x float]]* %0 to [3 x <3 x float>]*
+; CHECK:%call = call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %[[Cast]])
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+; Function Attrs: nounwind
+define float @"\01?bar@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %a) #0 {
+entry:
+  %0 = alloca [3 x <3 x float>]
+  %1 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %0, i32 0, i32 0
+  %2 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %a, i32 0, i32 0
+  %3 = load <3 x float>, <3 x float>* %2
+  store <3 x float> %3, <3 x float>* %1
+  %4 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %0, i32 0, i32 1
+  %5 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %a, i32 0, i32 1
+  %6 = load <3 x float>, <3 x float>* %5
+  store <3 x float> %6, <3 x float>* %4
+  %7 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %0, i32 0, i32 2
+  %8 = getelementptr inbounds [3 x <3 x float>], [3 x <3 x float>]* %a, i32 0, i32 2
+  %9 = load <3 x float>, <3 x float>* %8
+  store <3 x float> %9, <3 x float>* %7
+  %call = call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %0)
+  ret float %call
+}
+
+declare float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]*)
+
+attributes #0 = { nounwind }
+

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_6 %s | FileCheck %s
 
 // Make sure vector array param works.
-// CHECK:%[[Cast:.+]] = bitcast [3 x [3 x float]]* %0 to [3 x <3 x float>]*
+// CHECK:%[[Cast:.+]] = bitcast [9 x float]* %{{.+}} to [3 x <3 x float>]*
 // CHECK:call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %[[Cast]]
 
 float foo(float3 a[3]);

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s
+
+// Make sure vector array param works.
+// CHECK:call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %{{.+}})
+
+float foo(float3 a[3]);
+
+export
+float bar(float3 a[3]) {
+  return foo(a);
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
@@ -1,7 +1,8 @@
 // RUN: %dxc -T lib_6_6 %s | FileCheck %s
 
 // Make sure vector array param works.
-// CHECK:call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %{{.+}})
+// CHECK:%[[Cast:.+]] = bitcast [3 x [3 x float]]* %0 to [3 x <3 x float>]*
+// CHECK:call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %[[Cast]]
 
 float foo(float3 a[3]);
 


### PR DESCRIPTION
To allow vector array parameter for extern functions.

When the parameter used as argument for call.
Just bitcast it to the argument type.