### PR TITLE
Introduce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report an issue with DXC
+title: ''
+labels: ['bug']
+assignees: ''
+
+---
+
+**Description**
+<!--- Please provide a few sentences describing the issue you encountered. --->
+
+**Steps to Reproduce**
+<!--- Provide a description of how to reproduce the error. If possible please 
+provide source and tool command line options. If the issue reproduces on
+Compiler Explorer (https://godbolt.org/) or Shader Playground
+(https://shader-playground.timjones.io/) please provide a link. --->
+
+
+**Actual Behavior**
+<!--- Please provide error output or a description of the observed issue. --->
+
+**Environment**
+- DXC version <!-- replace with the output of 'dxc --version' -->
+- Host Operating System <!--- Host operating system and version --->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,9 @@ assignees: ''
 <!--- Provide a description of how to reproduce the error. If possible please 
 provide source and tool command line options. If the issue reproduces on
 Compiler Explorer (https://godbolt.org/) or Shader Playground
-(https://shader-playground.timjones.io/) please provide a link. --->
+(https://shader-playground.timjones.io/) please provide a link. If the source is
+split across multiple files, please preprocess into a single file using DXC's 
+command line `-P -Fi <path>`. --->
 
 
 **Actual Behavior**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug Report
 about: Report an issue with DXC
 title: ''
-labels: ['bug']
+labels: ['bug', 'needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_spirv.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_spirv.md
@@ -1,0 +1,25 @@
+---
+name: SPIR-V Bug Report
+about: Report an issue with DXC SPIR-V generation
+title: '[SPIR-V]'
+labels: ['bug', 'spirv']
+assignees: ''
+
+---
+
+**Description**
+<!--- Please provide a few sentences describing the issue you encountered. --->
+
+**Steps to Reproduce**
+<!--- Provide a description of how to reproduce the error. If possible please 
+provide source and tool command line options. If the issue reproduces on
+Compiler Explorer (https://godbolt.org/) or Shader Playground
+(https://shader-playground.timjones.io/) please provide a link. --->
+
+
+**Actual Behavior**
+<!--- Please provide error output or a description of the observed issue. --->
+
+**Environment**
+- DXC version <!-- replace with the output of 'dxc --version' -->
+- Host Operating System <!--- Host operating system and version --->

--- a/.github/ISSUE_TEMPLATE/bug_report_spirv.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_spirv.md
@@ -2,7 +2,7 @@
 name: SPIR-V Bug Report
 about: Report an issue with DXC SPIR-V generation
 title: '[SPIR-V]'
-labels: ['bug', 'spirv']
+labels: ['bug', 'spirv', 'needs-triage']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report_spirv.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_spirv.md
@@ -14,7 +14,9 @@ assignees: ''
 <!--- Provide a description of how to reproduce the error. If possible please 
 provide source and tool command line options. If the issue reproduces on
 Compiler Explorer (https://godbolt.org/) or Shader Playground
-(https://shader-playground.timjones.io/) please provide a link. --->
+(https://shader-playground.timjones.io/) please provide a link. If the source is
+split across multiple files, please preprocess into a single file using DXC's 
+command line `-P -Fi <path>`. --->
 
 
 **Actual Behavior**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: '[Feature Request]'
+labels: ['enhancement']
+assignees: ''
+
+---
+
+<!--- If this is a language feature request please file the issue against the
+hlsl-specs repository: https://github.com/microsoft/hlsl-specs/issues/new --->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,7 +11,7 @@ assignees: ''
 hlsl-specs repository: https://github.com/microsoft/hlsl-specs/issues/new --->
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Describe the problem that led you to request this feature in as much detail as you can.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: '[Feature Request]'
-labels: ['enhancement']
+labels: ['enhancement', 'needs-triage']
 assignees: ''
 
 ---


### PR DESCRIPTION
This change introduces three new issue templates for DXC. The three issue templates are:

* feature_request - Issues filed with this template will get automatically tagged with the `enhancement` label
* bug_report - Issues filed with this template will get automatically get tagged with the `bug` label
* bug_report_spirv - Issues filed with this template will get automatically tagged with the `bug` and `spirv` labels

The bug_report and bug_report_spirv templates are otherwise identical, but could diverge to better meet the needs of the supporting teams.

Fixes #4975.