### PR TITLE
Fix two issues found in our internal build

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -26,10 +26,10 @@ namespace spirv {
 struct StringMapInfo {
   static inline std::string getEmptyKey() { return ""; }
   static inline std::string getTombstoneKey() { return ""; }
-  static unsigned getHashValue(const std::string Val) {
+  static unsigned getHashValue(const std::string& Val) {
     return llvm::hash_combine(Val);
   }
-  static bool isEqual(const std::string LHS, const std::string RHS) {
+  static bool isEqual(const std::string& LHS, const std::string& RHS) {
     // Either both are null, or both should have the same underlying type.
     return LHS == RHS;
   }
@@ -851,7 +851,7 @@ private:
   // kept track of separately. This is because the empty string is used
   // as the EmptyKey and TombstoneKey for the map, prohibiting insertion
   // of the empty string as a contained value.
-  llvm::DenseMap<llvm::StringRef, SpirvString *, StringMapInfo> stringLiterals;
+  llvm::DenseMap<std::string, SpirvString *, StringMapInfo> stringLiterals;
   SpirvString *emptyString;
 
   /// Mapping of CTBuffers including matrix 1xN with FXC memory layout to their

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2095,7 +2095,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
   // If alphabetical ordering was requested, sort by semantic string.
   if (spirvOptions.stageIoOrder == "alpha") {
     // Sort stage input/output variables alphabetically
-    std::sort(vars.begin(), vars.end(),
+    std::stable_sort(vars.begin(), vars.end(),
               [](const StageVar *a, const StageVar *b) {
                 return a->getSemanticStr() < b->getSemanticStr();
               });
@@ -2117,7 +2117,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
   // alphabetical ordering.
   if ((!forInput && spvContext.isHS()) || (forInput && spvContext.isDS())) {
     // Sort stage input/output variables alphabetically
-    std::sort(vars.begin(), vars.end(),
+    std::stable_sort(vars.begin(), vars.end(),
               [](const StageVar *a, const StageVar *b) {
                 return a->getSemanticStr() < b->getSemanticStr();
               });


### PR DESCRIPTION
1. The StringRef in the `stringLiterals` in the `SpirvBuilder` can have a
dangling reference causing undefined behaviour.
2. Two symbols can have the same name, so when we sort a vector of symbols by
name, we want to use std::stable_sort to make sure we get deterministic
behaviour.
