### PR TITLE
Correct WinAdapter path assumptions in public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,6 +608,7 @@ endif()
 
 include_directories( ${LLVM_INCLUDE_DIR} ${LLVM_MAIN_INCLUDE_DIR})
 
+include_directories( ${LLVM_MAIN_INCLUDE_DIR}/dxc/Support) # HLSL Change
 include_directories( ${LLVM_INCLUDE_DIR}/dxc/Tracing) # HLSL Change
 
 # when crosscompiling import the executable targets from a file

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -34,7 +34,7 @@
 #else
 
 #include <dlfcn.h>
-#include "dxc/Support/WinAdapter.h"
+#include "WinAdapter.h"
 #endif
 
 struct IMalloc;

--- a/include/dxc/dxcisense.h
+++ b/include/dxc/dxcisense.h
@@ -14,7 +14,7 @@
 
 #include "dxcapi.h"
 #ifndef _WIN32
-#include "Support/WinAdapter.h"
+#include "WinAdapter.h"
 #endif
 
 typedef enum DxcGlobalOptions


### PR DESCRIPTION
dxcapi.h and dxcisense.h had inconsistent and unhelpful for release
include paths to find WinAdapter.h. By adding the necessary -I flag,
the include can be found without including the paths

Fixes #4918