### PR TITLE
Silence cmake endif mismatch warning

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -43,7 +43,7 @@ if (${ENABLE_SPIRV_CODEGEN})
       # This add_compile_options() will only affect the current directory and its subdirectories.
       if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         add_compile_options(-Wno-implicit-fallthrough)
-      endif(NOT WIN32)
+      endif()
       # We only need the library from SPIRV-Tools.
       set(SPIRV_SKIP_EXECUTABLES ON CACHE BOOL "Skip building SPIRV-Tools executables")
       if (NOT HLSL_ENABLE_DEBUG_ITERATORS)


### PR DESCRIPTION
A careless endif in cmake to enable catching a particular compiler warning introduced an irritating cmake warning. The corrects the mismatched endif