### PR TITLE
Just load dxcompiler on non-win platforms

### DIFF
--- a/tools/clang/tools/dxa/CMakeLists.txt
+++ b/tools/clang/tools/dxa/CMakeLists.txt
@@ -21,10 +21,16 @@ add_clang_executable(dxa
   dxa.cpp
   )
 
+if (WIN32)
 target_link_libraries(dxa
   dxcompiler
   HLSLTestLib
   )
+else(WIN32)
+target_link_libraries(dxa
+  HLSLTestLib
+  )
+endif(WIN32)
 
 set_target_properties(dxa PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 

--- a/tools/clang/tools/dxc/CMakeLists.txt
+++ b/tools/clang/tools/dxc/CMakeLists.txt
@@ -21,11 +21,16 @@ add_clang_executable(dxc
 #  dxr.rc
   )
 
+if (WIN32)
 target_link_libraries(dxc
   dxclib
   dxcompiler
+  )
+else (WIN32)
+target_link_libraries(dxc
   dxclib
   )
+endif (WIN32)
 
 if(ENABLE_SPIRV_CODEGEN)
   target_link_libraries(dxc SPIRV-Tools)

--- a/tools/clang/tools/dxl/CMakeLists.txt
+++ b/tools/clang/tools/dxl/CMakeLists.txt
@@ -19,10 +19,16 @@ add_clang_executable(dxl
   dxl.cpp
   )
 
+if (WIN32)
 target_link_libraries(dxl
   dxclib
   dxcompiler
   )
+else (WIN32)
+target_link_libraries(dxl
+  dxclib
+  )
+endif (WIN32)
 
 set_target_properties(dxl PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 

--- a/tools/clang/tools/dxopt/CMakeLists.txt
+++ b/tools/clang/tools/dxopt/CMakeLists.txt
@@ -12,9 +12,11 @@ add_clang_executable(dxopt
   dxopt.cpp
   )
 
+if (WIN32)
 target_link_libraries(dxopt
   dxcompiler
   )
+endif (WIN32)
 
 set_target_properties(dxopt PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 

--- a/tools/clang/tools/dxr/CMakeLists.txt
+++ b/tools/clang/tools/dxr/CMakeLists.txt
@@ -14,10 +14,18 @@ add_clang_executable(dxr
 #  dxr.rc
   )
 
+
+if (WIN32)
 target_link_libraries(dxr
   dxclib
   dxcompiler
   )
+else(WIN32)
+target_link_libraries(dxr
+  dxclib
+  )
+endif(WIN32)
+
 
 set_target_properties(dxr PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 # set_target_properties(dxr PROPERTIES ENABLE_EXPORTS 1)

--- a/tools/clang/tools/dxv/CMakeLists.txt
+++ b/tools/clang/tools/dxv/CMakeLists.txt
@@ -14,9 +14,11 @@ add_clang_executable(dxv
   dxv.cpp
   )
 
+if (WIN32)
 target_link_libraries(dxv
   dxcompiler
   )
+endif (WIN32)
 
 set_target_properties(dxv PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -86,16 +86,11 @@ if (WIN32)
 target_link_libraries(ClangHLSLTests PRIVATE
   dxcompiler
   HLSLTestLib
-  LLVMDxilContainer
   LLVMDxilDia
   ${TAEF_LIBRARIES}
-  ${DIASDK_LIBRARIES}
-  ${D3D12_LIBRARIES}
-  shlwapi
   )
 else(WIN32)
 target_link_libraries(ClangHLSLTests
-  dxcompiler
   HLSLTestLib
   )
 endif(WIN32)
@@ -104,8 +99,6 @@ if(WIN32)
 # Add includes for platform helpers and dxc API.
 include_directories(${TAEF_INCLUDE_DIRS})
 include_directories(${DIASDK_INCLUDE_DIRS})
-include_directories(${D3D12_INCLUDE_DIRS})
-include_directories(${LLVM_MAIN_INCLUDE_DIR}/dxc/Test)
 endif(WIN32)
 
 # Add includes to directly reference intrinsic tables.

--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -21,6 +21,7 @@ add_clang_unittest(ClangSPIRVTests
   WholeFileTestFixture.cpp
   )
 
+if (WIN32)
 target_link_libraries(ClangSPIRVTests
   clangAST
   clangBasic
@@ -32,6 +33,18 @@ target_link_libraries(ClangSPIRVTests
   effcee
   SPIRV-Tools
   )
+else (WIN32)
+target_link_libraries(ClangSPIRVTests
+  clangAST
+  clangBasic
+  clangCodeGen
+  clangFrontend
+  clangSPIRV
+  clangTooling
+  effcee
+  SPIRV-Tools
+  )
+endif (WIN32)
 
 # This is necessary so that the linked dxcompiler is loaded into memory space
 # first, and in case dxcompiler.so is loaded via 'dlopen', it resolves to the


### PR DESCRIPTION
There is thought to be a benefit to both dynamically linking and loading the dxcompiler library on Windows. However no such benefit is expected for other platforms and it just makes us ship two forms of the library.

By only linking on Windows, we can ship just the unversioned named library for non-win platforms and still function correctly.