### PR TITLE
Simplify header/link dependencies for unittests

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -86,16 +86,11 @@ if (WIN32)
 target_link_libraries(ClangHLSLTests PRIVATE
   dxcompiler
   HLSLTestLib
-  LLVMDxilContainer
   LLVMDxilDia
   ${TAEF_LIBRARIES}
-  ${DIASDK_LIBRARIES}
-  ${D3D12_LIBRARIES}
-  shlwapi
   )
 else(WIN32)
 target_link_libraries(ClangHLSLTests
-  dxcompiler
   HLSLTestLib
   )
 endif(WIN32)
@@ -104,8 +99,6 @@ if(WIN32)
 # Add includes for platform helpers and dxc API.
 include_directories(${TAEF_INCLUDE_DIRS})
 include_directories(${DIASDK_INCLUDE_DIRS})
-include_directories(${D3D12_INCLUDE_DIRS})
-include_directories(${LLVM_MAIN_INCLUDE_DIR}/dxc/Test)
 endif(WIN32)
 
 # Add includes to directly reference intrinsic tables.


### PR DESCRIPTION
After execution tests moved into their own place, a lot of the libraries and headers that unittests required weren't necessary anymore. This pares those requirements down as far as possible