### PR TITLE
Fix hcttest fail caused by cannot find clang.

### DIFF
--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -190,7 +190,6 @@ def inferClang(PATH):
 
     return clang
 
-
 if False: # HLSL Change - skip commands using clang.
     config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
     if not lit_config.quiet:

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -190,11 +190,11 @@ def inferClang(PATH):
 
     return clang
 
-# HLSL Change Begin - disable clang related which is not build.
-#config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
-#if not lit_config.quiet:
-#    lit_config.note('using clang: %r' % config.clang)
-# HLSL Change End.
+
+if False: # HLSL Change - skip commands using clang.
+    config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
+    if not lit_config.quiet:
+        lit_config.note('using clang: %r' % config.clang)
 
 # Plugins (loadable modules)
 # TODO: This should be supplied by Makefile or autoconf.
@@ -256,18 +256,18 @@ def makeMSABITriple(triple):
     return 'i686-pc-win32'
 
 # HLSL Change Begin - skip clang related command because clang is not build.
-#config.substitutions.append( ('%clang_cc1',
-#                              '%s -cc1 -internal-isystem %s -nostdsysteminc'
-#                              % (config.clang,
-#                                 getClangBuiltinIncludeDir(config.clang))) )
-#config.substitutions.append( ('%clang_cpp', ' ' + config.clang +
-#                              ' --driver-mode=cpp '))
-#config.substitutions.append( ('%clang_cl', ' ' + config.clang +
-#                              ' --driver-mode=cl '))
-#config.substitutions.append( ('%clangxx', ' ' + config.clang +
-#                              ' --driver-mode=g++ '))
-#config.substitutions.append( ('%clang', ' ' + config.clang + ' ') )
-# HLSL Change End.
+if False: # HLSL Change - skip commands using clang.
+    config.substitutions.append( ('%clang_cc1',
+                                  '%s -cc1 -internal-isystem %s -nostdsysteminc'
+                                  % (config.clang,
+                                     getClangBuiltinIncludeDir(config.clang))) )
+    config.substitutions.append( ('%clang_cpp', ' ' + config.clang +
+                                  ' --driver-mode=cpp '))
+    config.substitutions.append( ('%clang_cl', ' ' + config.clang +
+                                  ' --driver-mode=cl '))
+    config.substitutions.append( ('%clangxx', ' ' + config.clang +
+                                  ' --driver-mode=g++ '))
+    config.substitutions.append( ('%clang', ' ' + config.clang + ' ') )
 
 config.substitutions.append( ('%test_debuginfo', ' ' + config.llvm_src_root + '/utils/test_debuginfo.pl ') )
 config.substitutions.append( ('%itanium_abi_triple', makeItaniumABITriple(config.target_triple)) )

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -190,9 +190,11 @@ def inferClang(PATH):
 
     return clang
 
-config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
-if not lit_config.quiet:
-    lit_config.note('using clang: %r' % config.clang)
+# HLSL Change Begin - disable clang related which is not build.
+#config.clang = inferClang(config.environment['PATH']).replace('\\', '/')
+#if not lit_config.quiet:
+#    lit_config.note('using clang: %r' % config.clang)
+# HLSL Change End.
 
 # Plugins (loadable modules)
 # TODO: This should be supplied by Makefile or autoconf.
@@ -253,17 +255,20 @@ def makeMSABITriple(triple):
     # -win32 is not supported for non-x86 targets; use a default.
     return 'i686-pc-win32'
 
-config.substitutions.append( ('%clang_cc1',
-                              '%s -cc1 -internal-isystem %s -nostdsysteminc'
-                              % (config.clang,
-                                 getClangBuiltinIncludeDir(config.clang))) )
-config.substitutions.append( ('%clang_cpp', ' ' + config.clang +
-                              ' --driver-mode=cpp '))
-config.substitutions.append( ('%clang_cl', ' ' + config.clang +
-                              ' --driver-mode=cl '))
-config.substitutions.append( ('%clangxx', ' ' + config.clang +
-                              ' --driver-mode=g++ '))
-config.substitutions.append( ('%clang', ' ' + config.clang + ' ') )
+# HLSL Change Begin - skip clang related command because clang is not build.
+#config.substitutions.append( ('%clang_cc1',
+#                              '%s -cc1 -internal-isystem %s -nostdsysteminc'
+#                              % (config.clang,
+#                                 getClangBuiltinIncludeDir(config.clang))) )
+#config.substitutions.append( ('%clang_cpp', ' ' + config.clang +
+#                              ' --driver-mode=cpp '))
+#config.substitutions.append( ('%clang_cl', ' ' + config.clang +
+#                              ' --driver-mode=cl '))
+#config.substitutions.append( ('%clangxx', ' ' + config.clang +
+#                              ' --driver-mode=g++ '))
+#config.substitutions.append( ('%clang', ' ' + config.clang + ' ') )
+# HLSL Change End.
+
 config.substitutions.append( ('%test_debuginfo', ' ' + config.llvm_src_root + '/utils/test_debuginfo.pl ') )
 config.substitutions.append( ('%itanium_abi_triple', makeItaniumABITriple(config.target_triple)) )
 config.substitutions.append( ('%ms_abi_triple', makeMSABITriple(config.target_triple)) )

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -255,7 +255,6 @@ def makeMSABITriple(triple):
     # -win32 is not supported for non-x86 targets; use a default.
     return 'i686-pc-win32'
 
-# HLSL Change Begin - skip clang related command because clang is not build.
 if False: # HLSL Change - skip commands using clang.
     config.substitutions.append( ('%clang_cc1',
                                   '%s -cc1 -internal-isystem %s -nostdsysteminc'


### PR DESCRIPTION
All clang related commands are disabled.
Once clang is build, we can reenable these commands.