### PR TITLE
[SPIR-V] Fix composites with empty struct fields.

### DIFF
--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -366,13 +366,15 @@ InitListHandler::createInitForStructType(QualType type, SourceLocation srcLoc,
     while (tryToSplitConstantArray())
       ;
 
-    auto init = initializers.back();
-    // We can only avoid decomposing and reconstructing when the type is
-    // exactly the same.
-    if (type.getCanonicalType() ==
-        init->getAstResultType().getCanonicalType()) {
-      initializers.pop_back();
-      return init;
+    if (!initializers.empty()) {
+      auto init = initializers.back();
+      // We can only avoid decomposing and reconstructing when the type is
+      // exactly the same.
+      if (type.getCanonicalType() ==
+          init->getAstResultType().getCanonicalType()) {
+        initializers.pop_back();
+        return init;
+      }
     }
 
     // Otherwise, if the next initializer is a struct, it is not of the same

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -556,7 +556,7 @@ uint32_t getFieldIndexInStruct(const StructType *spirvStructType,
       getNumBaseClasses(astStructType) + fieldDecl->getFieldIndex();
 
   const auto &fields = spirvStructType->getFields();
-  assert(indexAST <= fields.size());
+  assert(indexAST < fields.size());
   return fields[indexAST].fieldIndex;
 }
 

--- a/tools/clang/test/CodeGenSPIRV/type.template.function.empty-struct-argument.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.template.function.empty-struct-argument.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_0 -E main -HV 2021
+
+struct A {};
+
+template <typename T0, typename T1 = A>
+struct B {
+  T0 m0;
+  T1 m1;
+};
+
+float4 main() : SV_Target {
+  // CHECK: %12 = OpConstantComposite %v4float %float_1 %float_2 %float_3 %float_4
+  B<float4> b = { float4(1, 2, 3, 4) };
+  return b.m0;
+}


### PR DESCRIPTION
`indexAST` must be in the half-open range [0, N) instead of [0, N]. This caused a crash while I was fixing other issues with empty structs. I will file separate PRs for these fixes.