### PR TITLE
[SPIR-V] Forward replacement expression for SubstNonTypeTemplateParmExpr

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1129,6 +1129,9 @@ SpirvInstruction *SpirvEmitter::doExpr(const Expr *expr,
       result = curThis;
   } else if (const auto *unaryExpr = dyn_cast<UnaryExprOrTypeTraitExpr>(expr)) {
     result = doUnaryExprOrTypeTraitExpr(unaryExpr);
+  } else if (const auto *tmplParamExpr =
+                 dyn_cast<SubstNonTypeTemplateParmExpr>(expr)) {
+    result = doExpr(tmplParamExpr->getReplacement());
   } else {
     emitError("expression class '%0' unimplemented", expr->getExprLoc())
         << expr->getStmtClassName() << expr->getSourceRange();

--- a/tools/clang/test/CodeGenSPIRV/fn.template.arg.substitute.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.template.arg.substitute.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T ps_6_0 -E main -HV 2021
+
+template <bool B1>
+bool fnTemplate(bool B2) {
+  return !B1 && B2;
+}
+
+// CHECK:  %10 = OpConstantComposite %v4float %float_1 %float_1 %float_1 %float_1
+// CHECK:  %12 = OpConstantComposite %v4float %float_0 %float_0 %float_0 %float_0
+// CHECK: %main = OpFunction %void None %17
+float4 main(int val : A) : SV_Target {
+  return fnTemplate<false>(val != 0) ? (float4)1 : (float4)0;
+}


### PR DESCRIPTION
`SubstNonTypeTemplateParmExpr` was missing in `doExpr` of the SpirvEmitter. I boiled down the repro example to a simple function template with an input parameter that cannot be constant-folded.