### PR TITLE
Fix AppVeyor Linux tests failing loading dxil.so

### DIFF
--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -32,14 +32,10 @@ protected:
 #ifdef _WIN32
     m_dll = LoadLibraryA(dllName);
     if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
+    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
 #else
     m_dll = ::dlopen(dllName, RTLD_LAZY);
     if (m_dll == nullptr) return E_FAIL;
-#endif
-
-#ifdef _WIN32
-    m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
-#else
     m_createFn = (DxcCreateInstanceProc)::dlsym(m_dll, fnName);
 #endif
 

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -33,22 +33,24 @@ protected:
     m_dll = LoadLibraryA(dllName);
     if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
     m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);
+    
+    if (m_createFn == nullptr) {
+      HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
+      FreeLibrary(m_dll);
+      m_dll = nullptr;
+      return hr;
+    }
 #else
     m_dll = ::dlopen(dllName, RTLD_LAZY);
     if (m_dll == nullptr) return E_FAIL;
     m_createFn = (DxcCreateInstanceProc)::dlsym(m_dll, fnName);
-#endif
-
+    
     if (m_createFn == nullptr) {
-      HRESULT hr = HRESULT_FROM_WIN32(GetLastError());
-#ifdef _WIN32
-      FreeLibrary(m_dll);
-#else
       ::dlclose(m_dll);
-#endif
       m_dll = nullptr;
-      return hr;
+      return E_FAIL;
     }
+#endif
 
     // Only basic functions used to avoid requiring additional headers.
     m_createFn2 = nullptr;

--- a/include/dxc/Support/dxcapi.use.h
+++ b/include/dxc/Support/dxcapi.use.h
@@ -31,11 +31,11 @@ protected:
 
 #ifdef _WIN32
     m_dll = LoadLibraryA(dllName);
+    if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
 #else
     m_dll = ::dlopen(dllName, RTLD_LAZY);
+    if (m_dll == nullptr) return E_FAIL;
 #endif
-
-    if (m_dll == nullptr) return HRESULT_FROM_WIN32(GetLastError());
 
 #ifdef _WIN32
     m_createFn = (DxcCreateInstanceProc)GetProcAddress(m_dll, fnName);

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -810,10 +810,10 @@ TEST_F(DxilContainerTest, CompileWhenOKThenIncludesSignatures) {
       "; COLOR                    0   xyzw        1     NONE   float   xyzw\n"; // should read '1' in register
     if (hlsl::DXIL::CompareVersions(m_ver.m_ValMajor, m_ver.m_ValMinor, 1, 5) < 0) {
       std::string start(s.c_str(), strlen(expected_1_4));
-      VERIFY_ARE_EQUAL_STR(expected_1_4, start.c_str());
+      EXPECT_STREQ(expected_1_4, start.c_str());
     } else {
       std::string start(s.c_str(), strlen(expected));
-      VERIFY_ARE_EQUAL_STR(expected, start.c_str());
+      EXPECT_STREQ(expected, start.c_str());
     }
   }
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -810,10 +810,10 @@ TEST_F(DxilContainerTest, CompileWhenOKThenIncludesSignatures) {
       "; COLOR                    0   xyzw        1     NONE   float   xyzw\n"; // should read '1' in register
     if (hlsl::DXIL::CompareVersions(m_ver.m_ValMajor, m_ver.m_ValMinor, 1, 5) < 0) {
       std::string start(s.c_str(), strlen(expected_1_4));
-      EXPECT_STREQ(expected_1_4, start.c_str());
+      VERIFY_ARE_EQUAL_STR(expected_1_4, start.c_str());
     } else {
       std::string start(s.c_str(), strlen(expected));
-      EXPECT_STREQ(expected, start.c_str());
+      VERIFY_ARE_EQUAL_STR(expected, start.c_str());
     }
   }
 


### PR DESCRIPTION
This patch resolves an issue where dxil.so was failing to load but the error status was not being propagated, which caused repeated load attempts and eventually incorrect error propagation in a test case.

A bunch of this code is fairly gnarly, but the general gist is that `dlopen` is not required to set `errno`, so we were returning back success on failure cases unless there happened to be a previous failure value in `errno`.

Resolving this issue should get AppVeyor back on the rails.

There's a related PR that tries to handle the errors correctly (#4713), and we should adopt something similar.