### PR TITLE
Revert "Simplify header/link dependencies for unittests"

### DIFF
--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -86,11 +86,16 @@ if (WIN32)
 target_link_libraries(ClangHLSLTests PRIVATE
   dxcompiler
   HLSLTestLib
+  LLVMDxilContainer
   LLVMDxilDia
   ${TAEF_LIBRARIES}
+  ${DIASDK_LIBRARIES}
+  ${D3D12_LIBRARIES}
+  shlwapi
   )
 else(WIN32)
 target_link_libraries(ClangHLSLTests
+  dxcompiler
   HLSLTestLib
   )
 endif(WIN32)
@@ -99,6 +104,8 @@ if(WIN32)
 # Add includes for platform helpers and dxc API.
 include_directories(${TAEF_INCLUDE_DIRS})
 include_directories(${DIASDK_INCLUDE_DIRS})
+include_directories(${D3D12_INCLUDE_DIRS})
+include_directories(${LLVM_MAIN_INCLUDE_DIR}/dxc/Test)
 endif(WIN32)
 
 # Add includes to directly reference intrinsic tables.


### PR DESCRIPTION
Reverts microsoft/DirectXShaderCompiler#5009

I came upon this change through experimentation on my own system. I'm not sure why it worked there and in the automated tests, but the headers and libraries involved are used by these tests for the most part, so I'm restoring them here.