### PR TITLE
Enable Additional Security Checks (/sdl) and fix errors that surfaced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,11 @@ add_compile_options(/guard:cf)
 add_link_options(/guard:cf)
 endif(WIN32)
 
+# enable additional security checks
+if(WIN32)
+add_compile_options(/sdl)
+endif(WIN32)
+
 # HLSL Change Ends
 
 # HLSL Change Starts - set flag for Appveyor CI

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -288,7 +288,6 @@ if( MSVC )
 
   set(msvc_warning_flags
     # Disabled warnings.
-    -wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
     -wd4180 # Suppress 'qualifier applied to function type has no meaning; ignored'
     -wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
     -wd4258 # Suppress ''var' : definition from the for loop is ignored; the definition from the enclosing scope is used'
@@ -316,7 +315,6 @@ if( MSVC )
     -wd4706 # Suppress 'assignment within conditional expression'
     -wd4310 # Suppress 'cast truncates constant value'
     -wd4701 # Suppress 'potentially uninitialized local variable'
-    -wd4703 # Suppress 'potentially uninitialized local pointer variable'
     -wd4389 # Suppress 'signed/unsigned mismatch'
     -wd4611 # Suppress 'interaction between '_setjmp' and C++ object destruction is non-portable'
     -wd4805 # Suppress 'unsafe mix of type <type> and type <type> in operation'

--- a/include/llvm/ADT/IntervalMap.h
+++ b/include/llvm/ADT/IntervalMap.h
@@ -317,7 +317,7 @@ public:
       // We want to shrink, copy to sib.
       unsigned Count = std::min(std::min(unsigned(-Add), Size), N - SSize);
       transferToLeftSib(Size, Sib, SSize, Count);
-      return -Count;
+      return -(signed)Count;
     }
   }
 };

--- a/include/llvm/ADT/StringExtras.h
+++ b/include/llvm/ADT/StringExtras.h
@@ -41,7 +41,7 @@ static inline unsigned hexDigitValue(char C) {
   if (C >= '0' && C <= '9') return C-'0';
   if (C >= 'a' && C <= 'f') return C-'a'+10U;
   if (C >= 'A' && C <= 'F') return C-'A'+10U;
-  return -1U;
+  return UINT_MAX;
 }
 
 /// utohex_buffer - Emit the specified number into the buffer specified by

--- a/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -191,12 +191,12 @@ public:
 template<> struct DenseMapInfo<SDValue> {
   static inline SDValue getEmptyKey() {
     SDValue V;
-    V.ResNo = -1U;
+    V.ResNo = UINT_MAX;
     return V;
   }
   static inline SDValue getTombstoneKey() {
     SDValue V;
-    V.ResNo = -2U;
+    V.ResNo = UINT_MAX-1; // -2U
     return V;
   }
   static unsigned getHashValue(const SDValue &Val) {
@@ -879,7 +879,7 @@ inline SDValue::SDValue(SDNode *node, unsigned resno)
     : Node(node), ResNo(resno) {
   assert((!Node || ResNo < Node->getNumValues()) &&
          "Invalid result number for the given node!");
-  assert(ResNo < -2U && "Cannot use result numbers reserved for DenseMaps.");
+  assert(ResNo < (UINT_MAX-1) /* -2U */ && "Cannot use result numbers reserved for DenseMaps.");
 }
 
 inline unsigned SDValue::getOpcode() const {

--- a/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFDebugAranges.h
@@ -32,12 +32,12 @@ private:
   void construct();
 
   struct Range {
-    explicit Range(uint64_t LowPC = -1ULL, uint64_t HighPC = -1ULL,
-                   uint32_t CUOffset = -1U)
+    explicit Range(uint64_t LowPC = UINT64_MAX, uint64_t HighPC = UINT64_MAX,
+                   uint32_t CUOffset = UINT_MAX)
       : LowPC(LowPC), Length(HighPC - LowPC), CUOffset(CUOffset) {}
 
     void setHighPC(uint64_t HighPC) {
-      if (HighPC == -1ULL || HighPC <= LowPC)
+      if (HighPC == UINT64_MAX || HighPC <= LowPC)
         Length = 0;
       else
         Length = HighPC - LowPC;
@@ -45,7 +45,7 @@ private:
     uint64_t HighPC() const {
       if (Length)
         return LowPC + Length;
-      return -1ULL;
+      return UINT64_MAX;
     }
 
     bool containsAddress(uint64_t Address) const {

--- a/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
+++ b/include/llvm/DebugInfo/DWARF/DWARFDebugRangeList.h
@@ -49,9 +49,9 @@ public:
     bool isBaseAddressSelectionEntry(uint8_t AddressSize) const {
       assert(AddressSize == 4 || AddressSize == 8);
       if (AddressSize == 4)
-        return StartAddress == -1U;
+        return StartAddress == UINT_MAX;
       else
-        return StartAddress == -1ULL;
+        return StartAddress == UINT64_MAX;
     }
   };
 

--- a/include/llvm/Support/BlockFrequency.h
+++ b/include/llvm/Support/BlockFrequency.h
@@ -29,7 +29,7 @@ public:
   BlockFrequency(uint64_t Freq = 0) : Frequency(Freq) { }
 
   /// \brief Returns the maximum possible frequency, the saturation value.
-  static uint64_t getMaxFrequency() { return -1ULL; }
+  static uint64_t getMaxFrequency() { return UINT64_MAX; }
 
   /// \brief Returns the frequency as a fixpoint number scaled by the entry
   /// frequency.

--- a/include/llvm/Support/LEB128.h
+++ b/include/llvm/Support/LEB128.h
@@ -103,7 +103,7 @@ inline int64_t decodeSLEB128(const uint8_t *p, unsigned *n = nullptr) {
   } while (Byte >= 128);
   // Sign extend negative numbers.
   if (Byte & 0x40)
-    Value |= (-1ULL) << Shift;
+    Value |= UINT64_MAX << Shift;
   if (n)
     *n = (unsigned)(p - orig_p);
   return Value;

--- a/include/llvm/Support/MathExtras.h
+++ b/include/llvm/Support/MathExtras.h
@@ -644,6 +644,8 @@ inline int64_t SignExtend64(uint64_t X, unsigned B) {
 
 extern const float huge_valf;
 
+/// \brief Negate number while avoiding undefined behavior of negating
+/// min signed int value (result of -INT_MIN is undefined)
 template <typename T> inline T SafeNegate(T value) {
   return (value == std::numeric_limits<T>::min()) ? std::numeric_limits<T>::min() : -value;
 }

--- a/include/llvm/Support/MathExtras.h
+++ b/include/llvm/Support/MathExtras.h
@@ -643,6 +643,11 @@ inline int64_t SignExtend64(uint64_t X, unsigned B) {
 }
 
 extern const float huge_valf;
+
+template <typename T> inline T SafeNegate(T value) {
+  return (value == std::numeric_limits<T>::min()) ? std::numeric_limits<T>::min() : -value;
+}
+
 } // End llvm namespace
 
 #endif

--- a/lib/Analysis/BasicAliasAnalysis.cpp
+++ b/lib/Analysis/BasicAliasAnalysis.cpp
@@ -1117,7 +1117,7 @@ AliasResult BasicAliasAnalysis::aliasGEP(
       // stripped a gep with negative index ('gep <ptr>, -1, ...).
       if (V1Size != MemoryLocation::UnknownSize &&
           V2Size != MemoryLocation::UnknownSize) {
-        if (-(uint64_t)GEP1BaseOffset < V1Size)
+        if ((uint64_t)SafeNegate<int64_t>(GEP1BaseOffset) < V1Size)
           return PartialAlias;
         return NoAlias;
       }

--- a/lib/Analysis/ConstantFolding.cpp
+++ b/lib/Analysis/ConstantFolding.cpp
@@ -187,7 +187,7 @@ static Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
         // Shift it to the right place, depending on endianness.
         Src = ConstantExpr::getShl(Src,
                                    ConstantInt::get(Src->getType(), ShiftAmt));
-        ShiftAmt += isLittleEndian ? SrcBitSize : -SrcBitSize;
+        ShiftAmt += isLittleEndian ? SrcBitSize : -(signed)SrcBitSize;
 
         // Mix it in.
         Elt = ConstantExpr::getOr(Elt, Src);
@@ -213,7 +213,7 @@ static Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
       // endianness.
       Constant *Elt = ConstantExpr::getLShr(Src,
                                   ConstantInt::get(Src->getType(), ShiftAmt));
-      ShiftAmt += isLittleEndian ? DstBitSize : -DstBitSize;
+      ShiftAmt += isLittleEndian ? DstBitSize : -(signed)DstBitSize;
 
       // Truncate the element to an integer with the same pointer size and
       // convert the element back to a pointer using a inttoptr.

--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -791,7 +791,7 @@ void DependenceAnalysis::collectCommonLoops(const SCEV *Expression,
 void DependenceAnalysis::unifySubscriptType(ArrayRef<Subscript *> Pairs) {
 
   unsigned widestWidthSeen = 0;
-  Type *widestType;
+  Type *widestType = nullptr;
 
   // Go through each pair and find the widest bit to which we need
   // to extend all of them.

--- a/lib/Analysis/InstructionSimplify.cpp
+++ b/lib/Analysis/InstructionSimplify.cpp
@@ -1868,7 +1868,7 @@ static Value *SimplifyOrInst(Value *Op0, Value *Op1, const Query &Q,
       // If we have: ((V + N) & C1) | (V & C2)
       // .. and C2 = ~C1 and C2 is 0+1+ and (N & C2) == 0
       // replace with V+N.
-      Value *V1, *V2;
+      Value* V1 = nullptr, *V2 = nullptr;
       if ((C2->getValue() & (C2->getValue() + 1)) == 0 && // C2 == 0+1+
           match(A, m_Add(m_Value(V1), m_Value(V2)))) {
         // Add commutes, try both ways.
@@ -3348,8 +3348,8 @@ static Value *SimplifySelectInst(Value *CondVal, Value *TrueVal,
     Value *CmpLHS = ICI->getOperand(0);
     Value *CmpRHS = ICI->getOperand(1);
     APInt MinSignedValue = APInt::getSignBit(BitWidth);
-    Value *X;
-    const APInt *Y;
+    Value *X = nullptr;
+    const APInt *Y = nullptr;
     bool TrueWhenUnset;
     bool IsBitTest = false;
     if (ICmpInst::isEquality(Pred) &&
@@ -4109,7 +4109,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
         // Shift it to the right place, depending on endianness.
         Src = ConstantExpr::getShl(Src,
                                    ConstantInt::get(Src->getType(), ShiftAmt));
-        ShiftAmt += isLittleEndian ? SrcBitSize : -SrcBitSize;
+        ShiftAmt += isLittleEndian ? SrcBitSize : -(signed)SrcBitSize;
 
         // Mix it in.
         Elt = ConstantExpr::getOr(Elt, Src);
@@ -4146,7 +4146,7 @@ Constant *FoldBitCast(Constant *C, Type *DestTy, const DataLayout &DL) {
       // endianness.
       Constant *Elt = ConstantExpr::getLShr(Src,
                                   ConstantInt::get(Src->getType(), ShiftAmt));
-      ShiftAmt += isLittleEndian ? DstBitSize : -DstBitSize;
+      ShiftAmt += isLittleEndian ? DstBitSize : -(signed)DstBitSize;
 
       // Truncate the element to an integer with the same pointer size and
       // convert the element back to a pointer using a inttoptr.

--- a/lib/Analysis/LoopAccessAnalysis.cpp
+++ b/lib/Analysis/LoopAccessAnalysis.cpp
@@ -1179,7 +1179,7 @@ bool MemoryDepChecker::areDepsSafe(DepCandidates &AccessSets,
                                    MemAccessInfoSet &CheckDeps,
                                    const ValueToValueMap &Strides) {
 
-  MaxSafeDepDistBytes = -1U;
+  MaxSafeDepDistBytes = UINT_MAX;
   while (!CheckDeps.empty()) {
     MemAccessInfo CurAccess = *CheckDeps.begin();
 
@@ -1677,7 +1677,7 @@ LoopAccessInfo::LoopAccessInfo(Loop *L, ScalarEvolution *SE,
                                const ValueToValueMap &Strides)
     : PtrRtChecking(SE), DepChecker(SE, L), TheLoop(L), SE(SE), DL(DL),
       TLI(TLI), AA(AA), DT(DT), LI(LI), NumLoads(0), NumStores(0),
-      MaxSafeDepDistBytes(-1U), CanVecMem(false),
+      MaxSafeDepDistBytes(UINT_MAX), CanVecMem(false),
       StoreToLoopInvariantAddress(false) {
   if (canAnalyzeLoop())
     analyzeLoop(Strides);

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -2842,7 +2842,7 @@ bool LLParser::ParseValID(ValID &ID, PerFunctionState *PFS) {
     unsigned Opc = Lex.getUIntVal();
     SmallVector<Constant*, 16> Elts;
     bool InBounds = false;
-    Type *Ty;
+    Type *Ty = nullptr;
     Lex.Lex();
 
     if (Opc == Instruction::GetElementPtr)

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2393,7 +2393,7 @@ uint64_t BitcodeReader::decodeSignRotatedValue(uint64_t V) {
   if ((V & 1) == 0)
     return V >> 1;
   if (V != 1)
-    return -(V >> 1);
+    return -(int64_t)(V >> 1);
   // There is no such thing as -0 with integers.  "-0" really means MININT.
   return 1ULL << 63;
 }

--- a/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -1360,7 +1360,7 @@ static void emitSignedInt64(SmallVectorImpl<uint64_t> &Vals, uint64_t V) {
   if ((int64_t)V >= 0)
     Vals.push_back(V << 1);
   else
-    Vals.push_back((-V << 1) | 1);
+    Vals.push_back(((-(int64_t)V) << 1) | 1);
 }
 
 static void WriteConstants(unsigned FirstVal, unsigned LastVal,
@@ -1437,7 +1437,7 @@ static void WriteConstants(unsigned FirstVal, unsigned LastVal,
       continue;
     }
     const Constant *C = cast<Constant>(V);
-    unsigned Code = -1U;
+    unsigned Code = UINT_MAX;
     unsigned AbbrevToUse = 0;
     if (C->isNullValue()) {
       Code = bitc::CST_CODE_NULL;

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -178,11 +178,11 @@ void PrintUnescapedString(StringRef Name, raw_ostream &Out) {
     if (C == '\\') {
       C = Name[++i];
       unsigned value = hexDigitValue(C);
-      if (value != -1U) {
+      if (value != UINT_MAX) {
         C = (unsigned char)value;
         unsigned value2 = hexDigitValue(Name[i+1]);
-        assert(value2 != -1U && "otherwise, not a two digit hex escape");
-        if (value2 != -1U) {
+        assert(value2 != UINT_MAX && "otherwise, not a two digit hex escape");
+        if (value2 != UINT_MAX) {
           C = (C << 4) + (unsigned char)value2;
           ++i;
         }

--- a/lib/HLSL/DxilPatchShaderRecordBindings.cpp
+++ b/lib/HLSL/DxilPatchShaderRecordBindings.cpp
@@ -252,7 +252,7 @@ unsigned int DxilPatchShaderRecordBindings::AddHandle(Module &M, unsigned int ba
   std::unique_ptr<DxilResource> pHandle;
   std::unique_ptr<DxilCBuffer> pCBuf;
   std::unique_ptr<DxilSampler> pSampler;
-  DxilResourceBase *pBaseHandle;
+  DxilResourceBase *pBaseHandle = nullptr;
   switch (resClass) {
   case DXIL::ResourceClass::SRV:
     resourceHandle = static_cast<unsigned int>(DM.GetSRVs().size());

--- a/lib/Support/APFloat.cpp
+++ b/lib/Support/APFloat.cpp
@@ -331,7 +331,7 @@ trailingHexadecimalFraction(StringRef::iterator p, StringRef::iterator end,
 
   /* If we ran off the end it is exactly zero or one-half, otherwise
      a little more.  */
-  if (hexDigit == -1U)
+  if (hexDigit == UINT_MAX)
     return digitValue == 0 ? lfExactlyZero: lfExactlyHalf;
   else
     return digitValue == 0 ? lfLessThanHalf: lfMoreThanHalf;
@@ -446,7 +446,7 @@ ulpsFromBoundary(const integerPart *parts, unsigned int bits, bool isNearest)
       if (~parts[count])
         return ~(integerPart) 0; /* A lot.  */
 
-    return -parts[0];
+    return -(int64_t)parts[0];
   }
 
   return ~(integerPart) 0; /* A lot.  */
@@ -2368,7 +2368,7 @@ APFloat::convertFromHexadecimalString(StringRef s, roundingMode rounding_mode)
     }
 
     hex_value = hexDigitValue(*p);
-    if (hex_value == -1U)
+    if (hex_value == UINT_MAX)
       break;
 
     p++;

--- a/lib/Support/APInt.cpp
+++ b/lib/Support/APInt.cpp
@@ -70,7 +70,7 @@ inline static unsigned getDigit(char cdigit, uint8_t radix) {
   if (r < radix)
     return r;
 
-  return -1U;
+  return UINT_MAX;
 }
 
 
@@ -79,7 +79,7 @@ void APInt::initSlowCase(unsigned numBits, uint64_t val, bool isSigned) {
   pVal[0] = val;
   if (isSigned && int64_t(val) < 0)
     for (unsigned i = 1; i < getNumWords(); ++i)
-      pVal[i] = -1ULL;
+      pVal[i] = UINT64_MAX;
 }
 
 void APInt::initSlowCase(const APInt& that) {
@@ -735,7 +735,7 @@ unsigned APInt::countLeadingOnes() const {
   unsigned Count = llvm::countLeadingOnes(pVal[i] << shift);
   if (Count == highWordBits) {
     for (i--; i >= 0; --i) {
-      if (pVal[i] == -1ULL)
+      if (pVal[i] == UINT64_MAX)
         Count += APINT_BITS_PER_WORD;
       else {
         Count += llvm::countLeadingOnes(pVal[i]);
@@ -761,7 +761,7 @@ unsigned APInt::countTrailingZeros() const {
 unsigned APInt::countTrailingOnesSlowCase() const {
   unsigned Count = 0;
   unsigned i = 0;
-  for (; i < getNumWords() && pVal[i] == -1ULL; ++i)
+  for (; i < getNumWords() && pVal[i] == UINT64_MAX; ++i)
     Count += APINT_BITS_PER_WORD;
   if (i < getNumWords())
     Count += llvm::countTrailingOnes(pVal[i]);
@@ -1070,7 +1070,7 @@ APInt APInt::ashr(unsigned shiftAmt) const {
   // issues in the algorithm below.
   if (shiftAmt == BitWidth) {
     if (isNegative())
-      return APInt(BitWidth, -1ULL, true);
+      return APInt(BitWidth, UINT64_MAX, true);
     else
       return APInt(BitWidth, 0);
   }
@@ -1123,7 +1123,7 @@ APInt APInt::ashr(unsigned shiftAmt) const {
   }
 
   // Remaining words are 0 or -1, just assign them.
-  uint64_t fillValue = (isNegative() ? -1ULL : 0);
+  uint64_t fillValue = (isNegative() ? UINT64_MAX : 0);
   for (unsigned i = breakWord+1; i < getNumWords(); ++i)
     val[i] = fillValue;
   APInt Result(val, BitWidth);
@@ -2192,7 +2192,7 @@ void APInt::toString(SmallVectorImpl<char> &Str, unsigned Radix,
         N = I;
       } else {
         Str.push_back('-');
-        N = -(uint64_t)I;
+        N = SafeNegate<int64_t>(I);
       }
     }
 
@@ -2408,7 +2408,7 @@ APInt::tcLSB(const integerPart *parts, unsigned int n)
       }
   }
 
-  return -1U;
+  return UINT_MAX;
 }
 
 /* Returns the bit number of the most significant set bit of a number.
@@ -2428,7 +2428,7 @@ APInt::tcMSB(const integerPart *parts, unsigned int n)
     }
   } while (n);
 
-  return -1U;
+  return UINT_MAX;
 }
 
 /* Copy the bit vector of width srcBITS from SRC, starting at bit

--- a/lib/Support/DataExtractor.cpp
+++ b/lib/Support/DataExtractor.cpp
@@ -168,7 +168,7 @@ int64_t DataExtractor::getSLEB128(uint32_t *offset_ptr) const {
 
   // Sign bit of byte is 2nd high order bit (0x40)
   if (shift < 64 && (byte & 0x40))
-    result |= -(1ULL << shift);
+    result |= -(int64_t)(1ULL << shift);
 
   *offset_ptr = offset;
   return result;

--- a/lib/Support/StringRef.cpp
+++ b/lib/Support/StringRef.cpp
@@ -394,12 +394,11 @@ bool llvm::getAsSignedInteger(StringRef Str, unsigned Radix,
   // Get the positive part of the value.
   if (getAsUnsignedInteger(Str.substr(1), Radix, ULLVal) ||
       // Reject values so large they'd overflow as negative signed, but allow
-      // "-0".  This negates the unsigned so that the negative isn't undefined
-      // on signed overflow.
-      (long long)-ULLVal > 0)
+      // "-0".
+      SafeNegate<long long>(ULLVal) > 0)
     return true;
 
-  Result = -ULLVal;
+  Result = SafeNegate<long long>(ULLVal);
   return false;
 }
 

--- a/lib/Support/TimeValue.cpp
+++ b/lib/Support/TimeValue.cpp
@@ -20,7 +20,7 @@ using namespace sys;
 const TimeValue::SecondsType
   TimeValue::PosixZeroTimeSeconds = -946684800;
 const TimeValue::SecondsType
-  TimeValue::Win32ZeroTimeSeconds = -12591158400ULL;
+  TimeValue::Win32ZeroTimeSeconds = -12591158400LL;
 
 void
 TimeValue::normalize( void ) {

--- a/lib/Support/YAMLParser.cpp
+++ b/lib/Support/YAMLParser.cpp
@@ -1510,7 +1510,7 @@ bool Scanner::findBlockScalarIndent(unsigned &BlockIndent,
                                     unsigned BlockExitIndent,
                                     unsigned &LineBreaks, bool &IsDone) {
   unsigned MaxAllSpaceLineCharacters = 0;
-  StringRef::iterator LongestAllSpaceLine;
+  StringRef::iterator LongestAllSpaceLine("");
 
   while (true) {
     advanceWhile(&Scanner::skip_s_space);

--- a/lib/Support/raw_ostream.cpp
+++ b/lib/Support/raw_ostream.cpp
@@ -135,8 +135,7 @@ raw_ostream &raw_ostream::operator<<(unsigned long N) {
 raw_ostream &raw_ostream::operator<<(long N) {
   if (N < 0 && writeBase == 10) {
     *this << '-';
-    // Avoid undefined behavior on LONG_MIN with a cast.
-    N = -(unsigned long)N;
+    N = SafeNegate<long>(N);
   }
 
   return this->operator<<(static_cast<unsigned long>(N));
@@ -170,8 +169,8 @@ raw_ostream &raw_ostream::operator<<(unsigned long long N) {
 raw_ostream &raw_ostream::operator<<(long long N) {
   if (N < 0 && writeBase == 10) {
     *this << '-';
-    // Avoid undefined behavior on INT64_MIN with a cast.
-    N = -(unsigned long long)N;
+    // Avoid undefined behavior of -LLONG_MIN
+    N = SafeNegate<long long>(N);
   }
 
   return this->operator<<(static_cast<unsigned long long>(N));
@@ -469,7 +468,7 @@ raw_ostream &raw_ostream::operator<<(const FormattedNumber &FN) {
     char *EndPtr = NumberBuffer+sizeof(NumberBuffer);
     char *CurPtr = EndPtr;
     bool Neg = (FN.DecValue < 0);
-    uint64_t N = Neg ? -static_cast<uint64_t>(FN.DecValue) : FN.DecValue;
+    uint64_t N = Neg ? SafeNegate<int64_t>(FN.DecValue) : FN.DecValue;
     while (N) {
       *--CurPtr = '0' + char(N % 10);
       N /= 10;

--- a/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -146,7 +146,7 @@ namespace {
   private:
     Liveness MarkIfNotLive(RetOrArg Use, UseVector &MaybeLiveUses);
     Liveness SurveyUse(const Use *U, UseVector &MaybeLiveUses,
-                       unsigned RetValNum = -1U);
+                       unsigned RetValNum = UINT_MAX);
     Liveness SurveyUses(const Value *V, UseVector &MaybeLiveUses);
 
     void SurveyFunction(const Function &F);
@@ -442,7 +442,7 @@ DAE::Liveness DAE::SurveyUse(const Use *U,
       // that U is really a use of an insertvalue instruction that uses the
       // original Use.
       const Function *F = RI->getParent()->getParent();
-      if (RetValNum != -1U) {
+      if (RetValNum != UINT_MAX) {
         RetOrArg Use = CreateRet(F, RetValNum);
         // We might be live, depending on the liveness of Use.
         return MarkIfNotLive(Use, MaybeLiveUses);

--- a/lib/Transforms/InstCombine/InstCombineAddSub.cpp
+++ b/lib/Transforms/InstCombine/InstCombineAddSub.cpp
@@ -1171,8 +1171,8 @@ Instruction *InstCombiner::visitAdd(BinaryOperator &I) {
 
   if (ConstantInt *CRHS = dyn_cast<ConstantInt>(RHS)) {
     // (X & FF00) + xx00  -> (X+xx00) & FF00
-    Value *X;
-    ConstantInt *C2;
+    Value *X = nullptr;
+    ConstantInt *C2 = nullptr;
     if (LHS->hasOneUse() &&
         match(LHS, m_And(m_Value(X), m_ConstantInt(C2))) &&
         CRHS->getValue() == (CRHS->getValue() & C2->getValue())) {
@@ -1390,12 +1390,12 @@ Instruction *InstCombiner::visitFAdd(BinaryOperator &I) {
 
   // select C, 0, B + select C, A, 0 -> select C, A, B
   {
-    Value *A1, *B1, *C1, *A2, *B2, *C2;
+    Value *A1 = nullptr, *B1 = nullptr, *C1 = nullptr, *A2 = nullptr, *B2 = nullptr, *C2 = nullptr;
     if (match(LHS, m_Select(m_Value(C1), m_Value(A1), m_Value(B1))) &&
         match(RHS, m_Select(m_Value(C2), m_Value(A2), m_Value(B2)))) {
       if (C1 == C2) {
         Constant *Z1=nullptr, *Z2=nullptr;
-        Value *A, *B, *C=C1;
+        Value *A = nullptr, *B = nullptr, *C = C1;
         if (match(A1, m_AnyZero()) && match(B2, m_AnyZero())) {
             Z1 = dyn_cast<Constant>(A1); A = A2;
             Z2 = dyn_cast<Constant>(B2); B = B1;

--- a/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -937,7 +937,7 @@ Value *InstCombiner::FoldAndOfICmps(ICmpInst *LHS, ICmpInst *RHS) {
   if (LHSCC == ICmpInst::ICMP_EQ && LHSCC == RHSCC &&
       LHS->hasOneUse() && RHS->hasOneUse()) {
     Value *V;
-    ConstantInt *AndCst, *SmallCst = nullptr, *BigCst = nullptr;
+    ConstantInt *AndCst = nullptr, *SmallCst = nullptr, *BigCst = nullptr;
 
     // (trunc x) == C1 & (and x, CA) == C2
     // (and x, CA) == C2 & (trunc x) == C1

--- a/lib/Transforms/InstCombine/InstCombineSelect.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSelect.cpp
@@ -541,8 +541,8 @@ Instruction *InstCombiner::visitSelectInstWithICmp(SelectInst &SI,
   {
     unsigned BitWidth = DL.getTypeSizeInBits(TrueVal->getType());
     APInt MinSignedValue = APInt::getSignBit(BitWidth);
-    Value *X;
-    const APInt *Y, *C;
+    Value *X = nullptr;
+    const APInt *Y = nullptr, *C;
     bool TrueWhenUnset;
     bool IsBitTest = false;
     if (ICmpInst::isEquality(Pred) &&

--- a/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -998,7 +998,7 @@ Value *InstCombiner::SimplifyDemandedVectorElts(Value *V, APInt DemandedElts,
     for (unsigned i = 0; i < VWidth; i++) {
       if (DemandedElts[i]) {
         unsigned MaskVal = Shuffle->getMaskValue(i);
-        if (MaskVal != -1u) {
+        if (MaskVal != UINT_MAX) {
           assert(MaskVal < LHSVWidth * 2 &&
                  "shufflevector mask index out of range!");
           if (MaskVal < LHSVWidth)
@@ -1022,7 +1022,7 @@ Value *InstCombiner::SimplifyDemandedVectorElts(Value *V, APInt DemandedElts,
     bool NewUndefElts = false;
     for (unsigned i = 0; i < VWidth; i++) {
       unsigned MaskVal = Shuffle->getMaskValue(i);
-      if (MaskVal == -1u) {
+      if (MaskVal == UINT_MAX) {
         UndefElts.setBit(i);
       } else if (!DemandedElts[i]) {
         NewUndefElts = true;

--- a/lib/Transforms/InstCombine/InstructionCombining.cpp
+++ b/lib/Transforms/InstCombine/InstructionCombining.cpp
@@ -1937,7 +1937,7 @@ Instruction *InstCombiner::visitAllocSite(Instruction &MI) {
       } else if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(I)) {
         if (II->getIntrinsicID() == Intrinsic::objectsize) {
           ConstantInt *CI = cast<ConstantInt>(II->getArgOperand(1));
-          uint64_t DontKnow = CI->isZero() ? -1ULL : 0;
+          uint64_t DontKnow = CI->isZero() ? UINT64_MAX : 0;
           ReplaceInstUsesWith(*I, ConstantInt::get(I->getType(), DontKnow));
         }
       }

--- a/lib/Transforms/Scalar/LoadCombine.cpp
+++ b/lib/Transforms/Scalar/LoadCombine.cpp
@@ -131,10 +131,10 @@ bool LoadCombine::aggregateLoads(SmallVectorImpl<LoadPOPPair> &Loads) {
   LoadInst *BaseLoad = nullptr;
   SmallVector<LoadPOPPair, 8> AggregateLoads;
   bool Combined = false;
-  uint64_t PrevOffset = -1ull;
+  uint64_t PrevOffset = UINT64_MAX;
   uint64_t PrevSize = 0;
   for (auto &L : Loads) {
-    if (PrevOffset == -1ull) {
+    if (PrevOffset == UINT64_MAX) {
       BaseLoad = L.Load;
       PrevOffset = L.POP.Offset;
       PrevSize = L.Load->getModule()->getDataLayout().getTypeStoreSize(
@@ -186,7 +186,7 @@ bool LoadCombine::combineLoads(SmallVectorImpl<LoadPOPPair> &Loads) {
 
   // Find first load. This is where we put the new load.
   LoadPOPPair FirstLP;
-  FirstLP.InsertOrder = -1u;
+  FirstLP.InsertOrder = UINT_MAX;
   for (const auto &L : Loads)
     if (L.InsertOrder < FirstLP.InsertOrder)
       FirstLP = L;

--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -1397,7 +1397,6 @@ static bool isAMCompletelyFolded(const TargetTransformInfo &TTI,
       if (Scale == 0)
         // Avoid undefined behavior of -INT64_MIN
         BaseOffset = SafeNegate<int64_t>(BaseOffset);
-
       return TTI.isLegalICmpImmediate(BaseOffset);
     }
 

--- a/lib/Transforms/Scalar/LoopStrengthReduce.cpp
+++ b/lib/Transforms/Scalar/LoopStrengthReduce.cpp
@@ -1395,8 +1395,9 @@ static bool isAMCompletelyFolded(const TargetTransformInfo &TTI,
       // ICmpZero -1*ScaleReg + BaseOffset => ICmp ScaleReg, BaseOffset
       // Offs is the ICmp immediate.
       if (Scale == 0)
-        // The cast does the right thing with INT64_MIN.
-        BaseOffset = -(uint64_t)BaseOffset;
+        // Avoid undefined behavior of -INT64_MIN
+        BaseOffset = SafeNegate<int64_t>(BaseOffset);
+
       return TTI.isLegalICmpImmediate(BaseOffset);
     }
 
@@ -3007,7 +3008,7 @@ void LSRInstance::CollectFixupsAndInitialFormulae() {
         // of -1) are now also interesting.
         for (size_t i = 0, e = Factors.size(); i != e; ++i)
           if (Factors[i] != -1)
-            Factors.insert(-(uint64_t)Factors[i]);
+            Factors.insert(SafeNegate<int64_t>(Factors[i]));
         Factors.insert(-1);
       }
 
@@ -3746,7 +3747,7 @@ void LSRInstance::GenerateCrossUseConstantOffsets() {
     const SCEV *OrigReg = WI.OrigReg;
 
     Type *IntTy = SE.getEffectiveSCEVType(OrigReg->getType());
-    const SCEV *NegImmS = SE.getSCEV(ConstantInt::get(IntTy, -(uint64_t)Imm));
+    const SCEV *NegImmS = SE.getSCEV(ConstantInt::get(IntTy, SafeNegate<int64_t>(Imm)));
     unsigned BitWidth = SE.getTypeSizeInBits(IntTy);
 
     // TODO: Use a more targeted data structure.
@@ -3762,7 +3763,7 @@ void LSRInstance::GenerateCrossUseConstantOffsets() {
         int64_t Offset = (uint64_t)F.BaseOffset + Imm * (uint64_t)F.Scale;
         // Don't create 50 + reg(-50).
         if (F.referencesReg(SE.getSCEV(
-                   ConstantInt::get(IntTy, -(uint64_t)Offset))))
+                   ConstantInt::get(IntTy, SafeNegate<int64_t>(Offset)))))
           continue;
         Formula NewF = F;
         NewF.BaseOffset = Offset;
@@ -4565,7 +4566,7 @@ Value *LSRInstance::Expand(const LSRFixup &LF,
       // The other interesting way of "folding" with an ICmpZero is to use a
       // negated immediate.
       if (!ICmpScaledV)
-        ICmpScaledV = ConstantInt::get(IntTy, -(uint64_t)Offset);
+        ICmpScaledV = ConstantInt::get(IntTy, SafeNegate<int64_t>(Offset));
       else {
         Ops.push_back(SE.getUnknown(ICmpScaledV));
         ICmpScaledV = ConstantInt::get(IntTy, Offset);
@@ -4618,7 +4619,7 @@ Value *LSRInstance::Expand(const LSRFixup &LF,
              "ICmp does not support folding a global value and "
              "a scale at the same time!");
       Constant *C = ConstantInt::getSigned(SE.getEffectiveSCEVType(OpTy),
-                                           -(uint64_t)Offset);
+                                           SafeNegate<int64_t>(Offset));
       if (C->getType() != OpTy)
         C = ConstantExpr::getCast(CastInst::getCastOpcode(C, false,
                                                           OpTy, false),

--- a/lib/Transforms/Scalar/SROA.cpp
+++ b/lib/Transforms/Scalar/SROA.cpp
@@ -1780,7 +1780,7 @@ static Value *getAdjustedPtr(IRBuilderTy &IRB, const DataLayout &DL, Value *Ptr,
   // never are able to compute one directly that has the correct type, we'll
   // fall back to it, so keep it and the base it was computed from around here.
   Value *OffsetPtr = nullptr;
-  Value *OffsetBasePtr;
+  Value *OffsetBasePtr = nullptr;
 
   // Remember any i8 pointer we come across to re-use if we need to do a raw
   // byte offset.

--- a/lib/Transforms/Utils/CodeExtractor.cpp
+++ b/lib/Transforms/Utils/CodeExtractor.cpp
@@ -332,7 +332,7 @@ Function *CodeExtractor::constructFunction(const ValueSet &inputs,
     DEBUG(dbgs() << **i << ", ");
   DEBUG(dbgs() << ")\n");
 
-  StructType *StructTy;
+  StructType *StructTy = nullptr;
   if (AggregateArgs && (inputs.size() + outputs.size() > 0)) {
     StructTy = StructType::get(M->getContext(), paramTy);
     paramTy.clear();

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -5924,8 +5924,8 @@ void DxbcConverter::LoadOperand(OperandValue &SrcVal,
   case D3D11_SB_OPERAND_TYPE_INPUT_CONTROL_POINT: {
     OP::OpCode OpCode = OP::OpCode::LoadInput;
     unsigned Register;        // Starting index of the register range.
-    Value *pUnitIndexValue;   // Vertex/point index expression.
-    Value *pRowIndexValue;    // Row index expression.
+    Value *pUnitIndexValue = nullptr;   // Vertex/point index expression.
+    Value *pRowIndexValue = nullptr;    // Row index expression.
 
     switch (O.m_IndexDimension) {
     case D3D10_SB_OPERAND_INDEX_1D:

--- a/tools/clang/include/clang/AST/Expr.h
+++ b/tools/clang/include/clang/AST/Expr.h
@@ -4510,7 +4510,7 @@ public:
   Expr *getControllingExpr() { return cast<Expr>(SubExprs[CONTROLLING]); }
 
   /// Whether this generic selection is result-dependent.
-  bool isResultDependent() const { return ResultIndex == -1U; }
+  bool isResultDependent() const { return ResultIndex == UINT_MAX; }
 
   /// The zero-based index of the result expression's generic association in
   /// the generic selection's association list.  Defined only if the

--- a/tools/clang/lib/AST/Expr.cpp
+++ b/tools/clang/lib/AST/Expr.cpp
@@ -3896,7 +3896,7 @@ GenericSelectionExpr::GenericSelectionExpr(const ASTContext &Context,
          ContainsUnexpandedParameterPack),
     AssocTypes(new (Context) TypeSourceInfo*[AssocTypes.size()]),
     SubExprs(new (Context) Stmt*[END_EXPR+AssocExprs.size()]),
-    NumAssocs(AssocExprs.size()), ResultIndex(-1U), GenericLoc(GenericLoc),
+    NumAssocs(AssocExprs.size()), ResultIndex(UINT_MAX), GenericLoc(GenericLoc),
     DefaultLoc(DefaultLoc), RParenLoc(RParenLoc) {
   SubExprs[CONTROLLING] = ControllingExpr;
   assert(AssocTypes.size() == AssocExprs.size());

--- a/tools/clang/lib/AST/ExprConstant.cpp
+++ b/tools/clang/lib/AST/ExprConstant.cpp
@@ -6555,7 +6555,7 @@ bool IntExprEvaluator::VisitCallExpr(const CallExpr *E) {
     // handle all cases where the expression has side-effects.
     if (E->getArg(0)->HasSideEffects(Info.Ctx)) {
       if (E->getArg(1)->EvaluateKnownConstInt(Info.Ctx).getZExtValue() <= 1)
-        return Success(-1ULL, E);
+        return Success(UINT64_MAX, E);
       return Success(0, E);
     }
 
@@ -6570,7 +6570,7 @@ bool IntExprEvaluator::VisitCallExpr(const CallExpr *E) {
       return Error(E);
     case EvalInfo::EM_ConstantExpressionUnevaluated:
     case EvalInfo::EM_PotentialConstantExpressionUnevaluated:
-      return Success(-1ULL, E);
+      return Success(UINT64_MAX, E);
     }
     llvm_unreachable("Invalid EvalMode!");
   }

--- a/tools/clang/lib/AST/MicrosoftMangle.cpp
+++ b/tools/clang/lib/AST/MicrosoftMangle.cpp
@@ -633,7 +633,7 @@ void MicrosoftCXXNameMangler::mangleNumber(int64_t Number) {
 
   uint64_t Value = static_cast<uint64_t>(Number);
   if (Number < 0) {
-    Value = -Value;
+    Value = -(int64_t)Value;
     Out << '?';
   }
 
@@ -2308,7 +2308,7 @@ static void mangleThunkThisAdjustment(const CXXMethodDecl *MD,
       Out << AccessSpec;
       Mangler.mangleNumber(
           static_cast<uint32_t>(Adjustment.Virtual.Microsoft.VtordispOffset));
-      Mangler.mangleNumber(-static_cast<uint32_t>(Adjustment.NonVirtual));
+      Mangler.mangleNumber(llvm::SafeNegate<int32_t>(Adjustment.NonVirtual));
     }
   } else if (Adjustment.NonVirtual != 0) {
     switch (MD->getAccess()) {
@@ -2323,7 +2323,7 @@ static void mangleThunkThisAdjustment(const CXXMethodDecl *MD,
     case AS_public:
       Out << 'W';
     }
-    Mangler.mangleNumber(-static_cast<uint32_t>(Adjustment.NonVirtual));
+    Mangler.mangleNumber(llvm::SafeNegate<int32_t>((Adjustment.NonVirtual)));
   } else {
     switch (MD->getAccess()) {
     case AS_none:

--- a/tools/clang/lib/AST/SelectorLocationsKind.cpp
+++ b/tools/clang/lib/AST/SelectorLocationsKind.cpp
@@ -29,7 +29,7 @@ static SourceLocation getStandardSelLoc(unsigned Index,
       return SourceLocation();
     IdentifierInfo *II = Sel.getIdentifierInfoForSlot(0);
     unsigned Len = II ? II->getLength() : 0;
-    return EndLoc.getLocWithOffset(-Len);
+    return EndLoc.getLocWithOffset(-(signed)Len);
   }
 
   assert(Index < NumSelArgs);
@@ -39,7 +39,7 @@ static SourceLocation getStandardSelLoc(unsigned Index,
   unsigned Len = /* selector id */ (II ? II->getLength() : 0) + /* ':' */ 1;
   if (WithArgSpace)
     ++Len;
-  return ArgLoc.getLocWithOffset(-Len);
+  return ArgLoc.getLocWithOffset(-(signed)Len);
 }
 
 namespace {

--- a/tools/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/tools/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2559,7 +2559,7 @@ void ScalarExprEmitter::EmitUndefinedBehaviorIntegerDivAndRemCheck(
 
     llvm::Value *IntMin =
       Builder.getInt(llvm::APInt::getSignedMinValue(Ty->getBitWidth()));
-    llvm::Value *NegOne = llvm::ConstantInt::get(Ty, -1ULL);
+    llvm::Value *NegOne = llvm::ConstantInt::get(Ty, UINT64_MAX);
 
     llvm::Value *LHSCmp = Builder.CreateICmpNE(Ops.LHS, IntMin);
     llvm::Value *RHSCmp = Builder.CreateICmpNE(Ops.RHS, NegOne);
@@ -3334,7 +3334,7 @@ Value *ScalarExprEmitter::EmitCompare(const BinaryOperator *E,unsigned UICmpOpc,
 Value *ScalarExprEmitter::VisitBinAssign(const BinaryOperator *E) {
   bool Ignore = TestAndClearIgnoreResultAssign();
 
-  Value *RHS;
+  Value *RHS = nullptr;
   LValue LHS;
 
   switch (E->getLHS()->getType().getObjCLifetime()) {

--- a/tools/clang/lib/CodeGen/CGStmt.cpp
+++ b/tools/clang/lib/CodeGen/CGStmt.cpp
@@ -666,7 +666,7 @@ void CodeGenFunction::EmitCondBrHints(llvm::LLVMContext &Context,
 
     LoopHintAttr::OptionType Option = LH->getOption();
     LoopHintAttr::LoopHintState State = LH->getState();
-    const char *MetadataName;
+    const char *MetadataName = nullptr;
     switch (Option) {
     case LoopHintAttr::Vectorize:
     case LoopHintAttr::VectorizeWidth:
@@ -694,8 +694,8 @@ void CodeGenFunction::EmitCondBrHints(llvm::LLVMContext &Context,
       ValueInt = static_cast<int>(ValueAPS.getSExtValue());
     }
 
-    llvm::Constant *Value;
-    llvm::MDString *Name;
+    llvm::Constant *Value = nullptr;
+    llvm::MDString *Name = nullptr;
     switch (Option) {
     case LoopHintAttr::Vectorize:
     case LoopHintAttr::Interleave:

--- a/tools/clang/lib/CodeGen/CoverageMappingGen.cpp
+++ b/tools/clang/lib/CodeGen/CoverageMappingGen.cpp
@@ -116,7 +116,7 @@ public:
   /// \brief Return the start location of an included file or expanded macro.
   SourceLocation getStartOfFileOrMacro(SourceLocation Loc) {
     if (Loc.isMacroID())
-      return Loc.getLocWithOffset(-SM.getFileOffset(Loc));
+      return Loc.getLocWithOffset(-(signed)SM.getFileOffset(Loc));
     return SM.getLocForStartOfFile(SM.getFileID(Loc));
   }
 

--- a/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/tools/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -640,7 +640,7 @@ ItaniumCXXABI::EmitNullMemberPointer(const MemberPointerType *MPT) {
   // Itanium C++ ABI 2.3:
   //   A NULL pointer is represented as -1.
   if (MPT->isMemberDataPointer()) 
-    return llvm::ConstantInt::get(CGM.PtrDiffTy, -1ULL, /*isSigned=*/true);
+    return llvm::ConstantInt::get(CGM.PtrDiffTy, UINT64_MAX, /*isSigned=*/true);
 
   llvm::Constant *Zero = llvm::ConstantInt::get(CGM.PtrDiffTy, 0);
   llvm::Constant *Values[2] = { Zero, Zero };
@@ -1023,7 +1023,7 @@ static CharUnits computeOffsetHint(ASTContext &Context,
   // If Dst is not derived from Src we can skip the whole computation below and
   // return that Src is not a public base of Dst.  Record all inheritance paths.
   if (!Dst->isDerivedFrom(Src, Paths))
-    return CharUnits::fromQuantity(-2ULL);
+    return CharUnits::fromQuantity(UINT64_MAX-1 /* -2UL */); 
 
   unsigned NumPublicPaths = 0;
   CharUnits Offset;
@@ -1040,7 +1040,7 @@ static CharUnits computeOffsetHint(ASTContext &Context,
       // If the path contains a virtual base class we can't give any hint.
       // -1: no hint.
       if (J->Base->isVirtual())
-        return CharUnits::fromQuantity(-1ULL);
+        return CharUnits::fromQuantity(UINT64_MAX);
 
       if (NumPublicPaths > 1) // Won't use offsets, skip computation.
         continue;
@@ -1053,11 +1053,11 @@ static CharUnits computeOffsetHint(ASTContext &Context,
 
   // -2: Src is not a public base of Dst.
   if (NumPublicPaths == 0)
-    return CharUnits::fromQuantity(-2ULL);
+    return CharUnits::fromQuantity(UINT64_MAX-1 /* -2ULL */);
 
   // -3: Src is a multiple public base type but never a virtual base type.
   if (NumPublicPaths > 1)
-    return CharUnits::fromQuantity(-3ULL);
+    return CharUnits::fromQuantity(UINT64_MAX-2 /* -3ULL */);
 
   // Otherwise, the Src type is a unique public nonvirtual base type of Dst.
   // Return the offset of Src from the origin of Dst.
@@ -1090,7 +1090,7 @@ llvm::Value *ItaniumCXXABI::EmitTypeid(CodeGenFunction &CGF,
       CGF.GetVTablePtr(ThisPtr, StdTypeInfoPtrTy->getPointerTo());
 
   // Load the type info.
-  Value = CGF.Builder.CreateConstInBoundsGEP1_64(Value, -1ULL);
+  Value = CGF.Builder.CreateConstInBoundsGEP1_64(Value, UINT64_MAX);
   return CGF.Builder.CreateLoad(Value);
 }
 
@@ -1154,7 +1154,7 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF,
 
   // Get the offset-to-top from the vtable.
   llvm::Value *OffsetToTop =
-      CGF.Builder.CreateConstInBoundsGEP1_64(VTable, -2ULL);
+      CGF.Builder.CreateConstInBoundsGEP1_64(VTable, UINT64_MAX-1 /* -2ULL */);
   OffsetToTop = CGF.Builder.CreateLoad(OffsetToTop, "offset.to.top");
 
   // Finally, add the offset to the pointer.

--- a/tools/clang/lib/CodeGen/TargetInfo.cpp
+++ b/tools/clang/lib/CodeGen/TargetInfo.cpp
@@ -1283,7 +1283,7 @@ llvm::Value *X86_32ABIInfo::EmitVAArg(llvm::Value *VAListAddr, QualType Ty,
     Addr = CGF.Builder.CreateGEP(Addr, Offset);
     llvm::Value *AsInt = CGF.Builder.CreatePtrToInt(Addr,
                                                     CGF.Int32Ty);
-    llvm::Value *Mask = llvm::ConstantInt::get(CGF.Int32Ty, -Align);
+    llvm::Value *Mask = llvm::ConstantInt::get(CGF.Int32Ty, -(int64_t)Align);
     Addr = CGF.Builder.CreateIntToPtr(CGF.Builder.CreateAnd(AsInt, Mask),
                                       Addr->getType(),
                                       "ap.cur.aligned");
@@ -2849,7 +2849,7 @@ static llvm::Value *EmitVAArgFromMemory(llvm::Value *VAListAddr,
     overflow_arg_area = CGF.Builder.CreateGEP(overflow_arg_area, Offset);
     llvm::Value *AsInt = CGF.Builder.CreatePtrToInt(overflow_arg_area,
                                                     CGF.Int64Ty);
-    llvm::Value *Mask = llvm::ConstantInt::get(CGF.Int64Ty, -(uint64_t)Align);
+    llvm::Value *Mask = llvm::ConstantInt::get(CGF.Int64Ty, llvm::SafeNegate<int64_t>(Align));
     overflow_arg_area =
       CGF.Builder.CreateIntToPtr(CGF.Builder.CreateAnd(AsInt, Mask),
                                  overflow_arg_area->getType(),

--- a/tools/clang/lib/Format/Format.cpp
+++ b/tools/clang/lib/Format/Format.cpp
@@ -1049,7 +1049,7 @@ private:
     FormatTok = new (Allocator.Allocate()) FormatToken;
     readRawToken(*FormatTok);
     SourceLocation WhitespaceStart =
-        FormatTok->Tok.getLocation().getLocWithOffset(-TrailingWhitespace);
+        FormatTok->Tok.getLocation().getLocWithOffset(-(signed)TrailingWhitespace);
     FormatTok->IsFirst = IsFirstToken;
     IsFirstToken = false;
 

--- a/tools/clang/lib/Lex/Lexer.cpp
+++ b/tools/clang/lib/Lex/Lexer.cpp
@@ -480,7 +480,7 @@ static SourceLocation getBeginningOfFileToken(SourceLocation Loc,
   }
   
   // Create a lexer starting at the beginning of this token.
-  SourceLocation LexerStartLoc = Loc.getLocWithOffset(-LocInfo.second);
+  SourceLocation LexerStartLoc = Loc.getLocWithOffset(-(signed)LocInfo.second);
   Lexer TheLexer(LexerStartLoc, LangOpts, BufStart, LexStart, Buffer.end());
   TheLexer.SetCommentRetentionState(true);
   
@@ -2737,7 +2737,7 @@ uint32_t Lexer::tryReadUCN(const char *&StartPtr, const char *SlashLoc,
     char C = getCharAndSize(CurPtr, CharSize);
 
     unsigned Value = llvm::hexDigitValue(C);
-    if (Value == -1U) {
+    if (Value == UINT_MAX) {
       if (Result && !isLexingRawMode()) {
         if (i == 0) {
           Diag(BufferPtr, diag::warn_ucn_escape_no_digits)

--- a/tools/clang/lib/Lex/LiteralSupport.cpp
+++ b/tools/clang/lib/Lex/LiteralSupport.cpp
@@ -245,7 +245,7 @@ void clang::expandUCNs(SmallVectorImpl<char> &Buf, StringRef Input) {
     uint32_t CodePoint = 0;
     for (++I; NumHexDigits != 0; ++I, --NumHexDigits) {
       unsigned Value = llvm::hexDigitValue(*I);
-      assert(Value != -1U);
+      assert(Value != UINT_MAX);
 
       CodePoint <<= 4;
       CodePoint += Value;

--- a/tools/clang/lib/Rewrite/Rewriter.cpp
+++ b/tools/clang/lib/Rewrite/Rewriter.cpp
@@ -60,7 +60,7 @@ void RewriteBuffer::RemoveText(unsigned OrigOffset, unsigned Size,
   Buffer.erase(RealOffset, Size);
 
   // Add a delta so that future changes are offset correctly.
-  AddReplaceDelta(OrigOffset, -Size);
+  AddReplaceDelta(OrigOffset, -(signed)Size);
 
   if (removeLineIfEmpty) {
     // Find the line that the remove occurred and if it is completely empty
@@ -86,7 +86,7 @@ void RewriteBuffer::RemoveText(unsigned OrigOffset, unsigned Size,
     }
     if (posI != end() && *posI == '\n') {
       Buffer.erase(curLineStartOffs, lineSize + 1/* + '\n'*/);
-      AddReplaceDelta(curLineStartOffs, -(lineSize + 1/* + '\n'*/));
+      AddReplaceDelta(curLineStartOffs, -(signed)(lineSize + 1/* + '\n'*/));
     }
   }
 }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2763,7 +2763,7 @@ SpirvInstruction *SpirvEmitter::processCall(const CallExpr *callExpr) {
   bool isOperatorOverloading = false;
   QualType objectType = {};             // Type of the object (if exists)
   SpirvInstruction *objInstr = nullptr; // EvalInfo for the object (if exists)
-  const Expr *object;
+  const Expr *object = nullptr;
 
   llvm::SmallVector<SpirvInstruction *, 4> vars; // Variables for function call
   llvm::SmallVector<bool, 4> isTempVar;          // Temporary variable or not

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -5328,7 +5328,7 @@ bool Sema::inferObjCARCLifetime(ValueDecl *decl) {
   Qualifiers::ObjCLifetime lifetime = type.getObjCLifetime();
   if (lifetime == Qualifiers::OCL_Autoreleasing) {
     // Various kinds of declaration aren't allowed to be __autoreleasing.
-    unsigned kind = -1U;
+    unsigned kind = UINT_MAX;
     if (VarDecl *var = dyn_cast<VarDecl>(decl)) {
       if (var->hasAttr<BlocksAttr>())
         kind = 0; // __block
@@ -5340,7 +5340,7 @@ bool Sema::inferObjCARCLifetime(ValueDecl *decl) {
       kind = 2; // field
     }
 
-    if (kind != -1U) {
+    if (kind != UINT_MAX) {
       Diag(decl->getLocation(), diag::err_arc_autoreleasing_var)
         << kind;
     }

--- a/tools/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/tools/clang/lib/Sema/SemaDeclCXX.cpp
@@ -6066,7 +6066,7 @@ static bool checkTrivialSubobjectCall(Sema &S, SourceLocation SubobjLoc,
   if (!SubRD)
     return true;
 
-  CXXMethodDecl *Selected;
+  CXXMethodDecl *Selected = nullptr;
   if (findTrivialSpecialMember(S, SubRD, CSM, SubType.getCVRQualifiers(),
                                ConstRHS, Diagnose ? &Selected : nullptr))
     return true;

--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -1466,7 +1466,7 @@ Sema::CreateGenericSelectionExpr(SourceLocation KeyLoc,
         ContainsUnexpandedParameterPack);
 
   SmallVector<unsigned, 1> CompatIndices;
-  unsigned DefaultIndex = -1U;
+  unsigned DefaultIndex = UINT_MAX;
   for (unsigned i = 0; i < NumAssocs; ++i) {
     if (!Types[i])
       DefaultIndex = i;
@@ -1498,7 +1498,7 @@ Sema::CreateGenericSelectionExpr(SourceLocation KeyLoc,
   // C11 6.5.1.1p2 "If a generic selection has no default generic association,
   // its controlling expression shall have type compatible with exactly one of
   // the types named in its generic association list."
-  if (DefaultIndex == -1U && CompatIndices.size() == 0) {
+  if (DefaultIndex == UINT_MAX && CompatIndices.size() == 0) {
     // We strip parens here because the controlling expression is typically
     // parenthesized in macro definitions.
     ControllingExpr = ControllingExpr->IgnoreParens();

--- a/tools/clang/lib/Sema/SemaInit.cpp
+++ b/tools/clang/lib/Sema/SemaInit.cpp
@@ -3476,7 +3476,7 @@ static void TryConstructorInitialization(Sema &S,
   DeclContext::lookup_result Ctors = S.LookupConstructors(DestRecordDecl);
 
   OverloadingResult Result = OR_No_Viable_Function;
-  OverloadCandidateSet::iterator Best;
+  OverloadCandidateSet::iterator Best = nullptr;
   bool AsInitializerList = false;
 
   // C++11 [over.match.list]p1, per DR1467:

--- a/tools/clang/lib/Sema/SemaType.cpp
+++ b/tools/clang/lib/Sema/SemaType.cpp
@@ -462,7 +462,7 @@ distributeObjCPointerTypeAttrFromDeclarator(TypeProcessingState &state,
 
   // objc_gc goes on the innermost pointer to something that's not a
   // pointer.
-  unsigned innermost = -1U;
+  unsigned innermost = UINT_MAX;
   bool considerDeclSpec = true;
   for (unsigned i = 0, e = declarator.getNumTypeObjects(); i != e; ++i) {
     DeclaratorChunk &chunk = declarator.getTypeObject(i);
@@ -501,7 +501,7 @@ distributeObjCPointerTypeAttrFromDeclarator(TypeProcessingState &state,
 
   // Otherwise, if we found an appropriate chunk, splice the attribute
   // into it.
-  if (innermost != -1U) {
+  if (innermost != UINT_MAX) {
     moveAttrFromListToList(attr, declarator.getAttrListRef(),
                        declarator.getTypeObject(innermost).getAttrListRef());
     return;

--- a/tools/clang/unittests/HLSL/SystemValueTest.cpp
+++ b/tools/clang/unittests/HLSL/SystemValueTest.cpp
@@ -101,7 +101,7 @@ public:
       IFT(library->CreateBlobFromFile(path.c_str(), nullptr, &m_pSource));
     }
 
-    LPCWSTR entry, profile;
+    LPCWSTR entry = nullptr, profile = nullptr;
     wchar_t profile_buf[] = L"vs_6_1";
     switch(shaderKind) {
       case DXIL::ShaderKind::Vertex:    entry = L"VSMain"; profile = L"vs_6_1"; break;

--- a/unittests/ADT/APIntTest.cpp
+++ b/unittests/ADT/APIntTest.cpp
@@ -753,7 +753,7 @@ TEST(APIntTest, StringDeath) {
 #endif
 
 TEST(APIntTest, mul_clear) {
-  APInt ValA(65, -1ULL);
+  APInt ValA(65, UINT64_MAX);
   APInt ValB(65, 4);
   APInt ValC(65, 0);
   ValC = ValA * ValB;

--- a/unittests/ADT/BitVectorTest.cpp
+++ b/unittests/ADT/BitVectorTest.cpp
@@ -73,7 +73,7 @@ TYPED_TEST(BitVectorTest, TrivialOperation) {
   Vec.resize(33, true);
   Vec.resize(57, false);
   unsigned Count = 0;
-  for (unsigned i = Vec.find_first(); i != -1u; i = Vec.find_next(i)) {
+  for (unsigned i = Vec.find_first(); i != UINT_MAX; i = Vec.find_next(i)) {
     ++Count;
     EXPECT_TRUE(Vec[i]);
     EXPECT_TRUE(Vec.test(i));
@@ -103,7 +103,7 @@ TYPED_TEST(BitVectorTest, TrivialOperation) {
   Vec.resize(91, true);
   Vec.resize(130, false);
   Count = 0;
-  for (unsigned i = Vec.find_first(); i != -1u; i = Vec.find_next(i)) {
+  for (unsigned i = Vec.find_first(); i != UINT_MAX; i = Vec.find_next(i)) {
     ++Count;
     EXPECT_TRUE(Vec[i]);
     EXPECT_TRUE(Vec.test(i));

--- a/unittests/Support/DataExtractorTest.cpp
+++ b/unittests/Support/DataExtractorTest.cpp
@@ -20,7 +20,7 @@ const char bigleb128data[] = "\xAA\xA9\xFF\xAA\xFF\xAA\xFF\x4A";
 
 TEST(DataExtractorTest, OffsetOverflow) {
   DataExtractor DE(StringRef(numberData, sizeof(numberData)-1), false, 8);
-  EXPECT_FALSE(DE.isValidOffsetForDataOfSize(-2U, 5));
+  EXPECT_FALSE(DE.isValidOffsetForDataOfSize(UINT_MAX-1 /* -2U */, 5));
 }
 
 TEST(DataExtractorTest, UnsignedNumbers) {

--- a/utils/TableGen/FixedLenDecoderEmitter.cpp
+++ b/utils/TableGen/FixedLenDecoderEmitter.cpp
@@ -548,7 +548,7 @@ void Filter::recurse() {
     // Delegates to an inferior filter chooser for further processing on this
     // group of instructions whose segment values are variable.
     FilterChooserMap.insert(
-        std::make_pair(-1U, llvm::make_unique<FilterChooser>(
+        std::make_pair(UINT_MAX, llvm::make_unique<FilterChooser>(
                                 Owner->AllInstructions, VariableInstructions,
                                 Owner->Operands, BitValueArray, *Owner)));
   }


### PR DESCRIPTION
Enables Additional Security Checks (/sdl compiler flag). These checks change security-relevant warnings into errors and set additional secure code-generation features.

Fix errors that surfaced by adding /sdl. The errors found were in these two categories:
- C4146: unary minus operator applied to unsigned type, result still unsigned
- C4703: potentially uninitialized local pointer variable
