### PR TITLE
Don't skip copy-in copy-out when the callee is noinline or user define need external function.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -6007,7 +6007,12 @@ void CGMSHLSLRuntime::EmitHLSLOutParamConversionInit(
       if (argLV.isSimple())
         argAddr = argLV.getAddress();
 
-      bool mustCopy = bAnnotResource;
+      // Always copy for external user function or noinline function, so the
+      // argument will be always be alloca for noinline functions.
+      // This will avoid to add more code path to support case argument is
+      // input/output signature or static globals.
+      bool mustCopy = bAnnotResource || FD->hasAttr<NoInlineAttr>() ||
+                      (!FD->hasBody() && !FD->hasAttr<HLSLIntrinsicAttr>());
 
       // If matrix orientation changes, we must copy here
       // TODO: A high level intrinsic for matrix array copy with orientation

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
@@ -25,7 +25,7 @@
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
 
 // CHECK: %[[CMP1:.+]] = icmp eq i32 %{{.+}}, 1
-// CHECK: %[[h10_SEL:.+]] = select i1 %[[CMP1]], %dx.types.Handle %[[h1]], %dx.types.Handle %[[h2]]
+// CHECK: %[[h10_SEL:.+]] = select i1 %[[CMP1]], %dx.types.Handle %[[h2]], %dx.types.Handle %[[h1]]
 // CHECK: store %dx.types.Handle %[[h10_SEL]], %dx.types.Handle* %[[gep1]], align 8
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export.hlsl
@@ -20,13 +20,18 @@
 // CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]], align 8
 // CHECK-DAG: %[[gep3:.+]] = getelementptr inbounds [2 x [2 x %dx.types.Handle]], [2 x [2 x %dx.types.Handle]]* %[[buffers]], i32 0, i32 1, i32 1
 // CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]], align 8
+
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
-// CHECK: %[[h10:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]], align 8
-// CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]], align 8
+
+// CHECK: %[[CMP1:.+]] = icmp eq i32 %{{.+}}, 1
+// CHECK: %[[h10_SEL:.+]] = select i1 %[[CMP1]], %dx.types.Handle %[[h1]], %dx.types.Handle %[[h2]]
+// CHECK: store %dx.types.Handle %[[h10_SEL]], %dx.types.Handle* %[[gep1]], align 8
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
-// CHECK: %[[h01:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]], align 8
-// CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]], align 8
+
+// CHECK: %[[CMP2:.+]] = icmp eq i32 %{{.+}}, 2
+// CHECK: %[[h01_SEL:.+]] = select i1 %[[CMP2]], %dx.types.Handle %[[h10_SEL]], %dx.types.Handle %[[h2]]
+// CHECK: store %dx.types.Handle %[[h01_SEL]], %dx.types.Handle* %[[gep2]], align 8
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x [2 x %dx.types.Handle]]* nonnull %[[buffers]])
 
 void useArray(RWStructuredBuffer<float4> buffers[2][2]);

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_x %s | FileCheck %s
+ // RUN: %dxc -T lib_6_x %s | FileCheck %s
 
 // Ensure 2d array is broken down into 2 1d arrays, properly initialized,
 // modified, and passed to function calls
@@ -7,23 +7,27 @@
 // CHECK-DAG: %[[h1:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf1
 // CHECK-DAG: %[[h2:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
 // CHECK-DAG: %[[h3:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
-// CHECK: %[[a1:.+]] = alloca [2 x %dx.types.Handle]
-// CHECK: %[[a0:.+]] = alloca [2 x %dx.types.Handle]
-// CHECK-DAG: %[[gep0:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 0
-// CHECK-DAG: %[[gep1:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a0]], i32 0, i32 1
-// CHECK-DAG: %[[gep2:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 0
-// CHECK-DAG: %[[gep3:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a1]], i32 0, i32 1
+// CHECK: %[[a:.+]] = alloca [2 x %dx.types.Handle]
+// CHECK-DAG: %[[gep0:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 0
+// CHECK-DAG: %[[gep1:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 1
 // CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]]
 // CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]]
+
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+
 // CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]]
 // CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]]
-// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
-// CHECK: %[[h10:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep2]]
-// CHECK: store %dx.types.Handle %[[h10]], %dx.types.Handle* %[[gep1]]
+
+// CHECK: %[[CMP1:.+]] = icmp eq i32 %{{.+}}, 1
+// CHECK: %[[h10_SEL:.+]] = select i1 %[[CMP1]], %dx.types.Handle %[[h2]], %dx.types.Handle %[[h1]]
+// CHECK: store %dx.types.Handle %[[h10_SEL]], %dx.types.Handle* %[[gep1]], align 8
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
-// CHECK: %[[h01:.+]] = load %dx.types.Handle, %dx.types.Handle* %[[gep1]]
-// CHECK: store %dx.types.Handle %[[h01]], %dx.types.Handle* %[[gep2]]
+
+// CHECK: %[[CMP2:.+]] = icmp eq i32 %{{.+}}, 2
+// CHECK: %[[h01_SEL:.+]] = select i1 %[[CMP2]], %dx.types.Handle %[[h10_SEL]], %dx.types.Handle %[[h2]]
+// CHECK: store %dx.types.Handle %[[h01_SEL]], %dx.types.Handle* %[[gep2]], align 8
 // CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
 
 void useArray(RWStructuredBuffer<float4> buffers[2]);

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/attributes/unroll/lib_2d_array_call_export_subarray.hlsl
@@ -1,4 +1,4 @@
- // RUN: %dxc -T lib_6_x %s | FileCheck %s
+// RUN: %dxc -T lib_6_x %s | FileCheck %s
 
 // Ensure 2d array is broken down into 2 1d arrays, properly initialized,
 // modified, and passed to function calls
@@ -8,27 +8,27 @@
 // CHECK-DAG: %[[h2:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf2
 // CHECK-DAG: %[[h3:.+]] = load %dx.types.Handle, %dx.types.Handle* @{{.*}}buf3
 // CHECK: %[[a:.+]] = alloca [2 x %dx.types.Handle]
-// CHECK-DAG: %[[gep0:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 0
-// CHECK-DAG: %[[gep1:.+]] = getelementptr [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 1
+// CHECK-DAG: %[[gep0:.+]] = getelementptr inbounds [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 0
 // CHECK: store %dx.types.Handle %[[h0]], %dx.types.Handle* %[[gep0]]
+// CHECK-DAG: %[[gep1:.+]] = getelementptr inbounds [2 x %dx.types.Handle], [2 x %dx.types.Handle]* %[[a]], i32 0, i32 1
 // CHECK: store %dx.types.Handle %[[h1]], %dx.types.Handle* %[[gep1]]
 
-// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a]])
 
-// CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep2]]
-// CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep3]]
+// CHECK: store %dx.types.Handle %[[h2]], %dx.types.Handle* %[[gep0]]
+// CHECK: store %dx.types.Handle %[[h3]], %dx.types.Handle* %[[gep1]]
 
-// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a]])
 
 // CHECK: %[[CMP1:.+]] = icmp eq i32 %{{.+}}, 1
 // CHECK: %[[h10_SEL:.+]] = select i1 %[[CMP1]], %dx.types.Handle %[[h2]], %dx.types.Handle %[[h1]]
 // CHECK: store %dx.types.Handle %[[h10_SEL]], %dx.types.Handle* %[[gep1]], align 8
-// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a0]])
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a]])
 
 // CHECK: %[[CMP2:.+]] = icmp eq i32 %{{.+}}, 2
 // CHECK: %[[h01_SEL:.+]] = select i1 %[[CMP2]], %dx.types.Handle %[[h10_SEL]], %dx.types.Handle %[[h2]]
-// CHECK: store %dx.types.Handle %[[h01_SEL]], %dx.types.Handle* %[[gep2]], align 8
-// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a1]])
+// CHECK: store %dx.types.Handle %[[h01_SEL]], %dx.types.Handle* %[[gep0]], align 8
+// CHECK: call void @{{.*}}useArray{{.*}}([2 x %dx.types.Handle]* nonnull %[[a]])
 
 void useArray(RWStructuredBuffer<float4> buffers[2]);
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
@@ -8,10 +8,12 @@
 // CHECK:%[[A4:.*]] = alloca i32
 // CHECK:%[[A5:.*]] = alloca i32
 // CHECK:%[[A6:.*]] = alloca i32
+// CHECK:%[[A7:.*]] = alloca i32
+// CHECK:%[[A8:.*]] = alloca i32
 
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A0]], i32* nonnull dereferenceable(4) %[[A5]], i32* nonnull dereferenceable(4) %[[A6]])
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A4]], i32* nonnull dereferenceable(4) %[[A3]], i32* nonnull dereferenceable(4) %[[A6]])
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A2]], i32* nonnull dereferenceable(4) %[[A1]], i32* nonnull dereferenceable(4) %[[A6]])
+// CHECK-DAG:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A2]], i32* nonnull dereferenceable(4) %[[A1]], i32* nonnull dereferenceable(4) %[[A0]])
+// CHECK-DAG:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A5]], i32* nonnull dereferenceable(4) %[[A4]], i32* nonnull dereferenceable(4) %[[A3]])
+// CHECK-DAG:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A8]], i32* nonnull dereferenceable(4) %[[A7]], i32* nonnull dereferenceable(4) %[[A6]])
 
 struct DimStruct {
   uint2 Dims;

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/functions/external_function/always_copy_in_out.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/functions/external_function/always_copy_in_out.hlsl
@@ -1,0 +1,16 @@
+// RUN: dxc -Tlib_6_3 %s -fcgl | FileCheck %s
+
+// Make sure noinline argument is copy-in/copy-out.
+// CHECK-LABEL: define float @main
+// CHECK:%[[TMP:.+]] = alloca float
+// CHECK-NEXT:  %call = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
+// CHECK-NEXT: %[[RESULT:.+]] = load float, float* %[[TMP]]
+// CHECK-NEXT: store float %[[RESULT]], float* %depth, align 4
+// CHECK-NEXT: ret float %call
+
+float foo(out float depth);
+
+[shader("pixel")]
+float main(out float depth: SV_Depth) : SV_Target {
+  return foo(depth);
+}

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/functions/external_function/always_copy_in_out.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/functions/external_function/always_copy_in_out.hlsl
@@ -3,10 +3,10 @@
 // Make sure noinline argument is copy-in/copy-out.
 // CHECK-LABEL: define float @main
 // CHECK:%[[TMP:.+]] = alloca float
-// CHECK-NEXT:  %call = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
+// CHECK-NEXT:  %[[call:.+]] = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
 // CHECK-NEXT: %[[RESULT:.+]] = load float, float* %[[TMP]]
 // CHECK-NEXT: store float %[[RESULT]], float* %depth, align 4
-// CHECK-NEXT: ret float %call
+// CHECK-NEXT: ret float %[[call]]
 
 float foo(out float depth);
 

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/functions/noinline/input_param_as_arg.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/functions/noinline/input_param_as_arg.hlsl
@@ -1,0 +1,21 @@
+// RUN: dxc -Tps_6_0 %s -fcgl | FileCheck %s
+
+// Make sure noinline argument is copy-in/copy-out.
+// CHECK-LABEL: define float @main
+// CHECK:%[[TMP:.+]] = alloca float
+// CHECK-NEXT:  %call = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
+// CHECK-NEXT: %[[RESULT:.+]] = load float, float* %[[TMP]]
+// CHECK-NEXT: store float %[[RESULT]], float* %depth, align 4
+// CHECK-NEXT: ret float %call
+
+float d;
+
+[noinline]
+float foo(out float depth) {
+  depth = d;
+  return d;
+}
+
+float main(out float depth: SV_Depth) : SV_Target {
+  return foo(depth);
+}

--- a/tools/clang/test/HLSLFileCheckLit/hlsl/functions/noinline/input_param_as_arg.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/hlsl/functions/noinline/input_param_as_arg.hlsl
@@ -3,10 +3,10 @@
 // Make sure noinline argument is copy-in/copy-out.
 // CHECK-LABEL: define float @main
 // CHECK:%[[TMP:.+]] = alloca float
-// CHECK-NEXT:  %call = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
+// CHECK-NEXT:  %[[call:.+]] = call float @"\01?foo@@YAMAIAM@Z"(float* dereferenceable(4) %[[TMP]])
 // CHECK-NEXT: %[[RESULT:.+]] = load float, float* %[[TMP]]
 // CHECK-NEXT: store float %[[RESULT]], float* %depth, align 4
-// CHECK-NEXT: ret float %call
+// CHECK-NEXT: ret float %[[call]]
 
 float d;
 

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4035,15 +4035,23 @@ TEST_F(ValidationTest, AtomicsInvalidDests) {
   std::vector<LPCWSTR> pArguments = { L"-HV", L"2021", L"-Zi" };
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\atomics.hlsl", "lib_6_3",
     pArguments.data(), 2, nullptr, 0,
-    {"atomicrmw add i32 addrspace(3)* @\"\\01?gs_var@@3IA\""},
-    {"atomicrmw add i32* %res"},
+    {
+    "%([a-zA-Z0-9]+) = atomicrmw add i32 addrspace\\(3\\)\\* @\"\\\\01\\?gs_var@@3IA\""
+    },
+    {
+      "%non_groupshared = alloca i32, align 4\n%\\1 = atomicrmw add i32* %non_groupshared"
+    },
     "Non-groupshared destination to atomic operation.",
-    false);
+    true);
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\atomics.hlsl", "lib_6_3",
     pArguments.data(), 2, nullptr, 0,
-    {"cmpxchg i32 addrspace(3)* @\"\\01?gs_var@@3IA\""},
-    {"cmpxchg i32* %res"},
+    {
+      "%([a-zA-Z0-9]+) = cmpxchg i32 addrspace\\(3\\)\\* @\"\\\\01\\?gs_var@@3IA\""
+    },
+    {
+      "%non_groupshared = alloca i32, align 4\n%\\1 = cmpxchg i32* %non_groupshared"
+    },
     "Non-groupshared destination to atomic operation.",
-    false);
+    true);
 
 }


### PR DESCRIPTION

This is for better noinline support.
Doing it early can avoid doing the copy-in copy-out later in pipeline
 for things like Input/Output Signature and static global variables.