### PR TITLE
remove uninitialized assign to an unused variable

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -11584,7 +11584,6 @@ TEST_F(ExecutionTest, IsNormalTest) {
   std::shared_ptr<st::ShaderOpSet> ShaderOpSet = std::make_shared<st::ShaderOpSet>();
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
   st::ShaderOp *pShaderOp = ShaderOpSet->GetShaderOp("IsNormal");
-  vector<st::ShaderOpRootValue> fallbackRootValues = pShaderOp->RootValues;
 
   D3D_SHADER_MODEL sm = D3D_SHADER_MODEL_6_0;
   LogCommentFmt(L"\r\nVerifying isNormal in shader "


### PR DESCRIPTION
HLK tests are failing for IsNormal and BarycentricsChecKOrdering.
This fix repairs the IsNormal test. 
The Barycentrics test seems to be a driver problem, since the output of the shader differs at the lowest level, when compared against a different IHV's driver.