### PR TITLE
[NFC] Remove custom StringCchCopyEx

### DIFF
--- a/include/dxc/Support/WinFunctions.h
+++ b/include/dxc/Support/WinFunctions.h
@@ -19,8 +19,6 @@
 
 #ifndef _WIN32
 
-HRESULT StringCchCopyEx(LPSTR pszDest, size_t cchDest, LPCSTR pszSrc,
-                        LPSTR *ppszDestEnd, size_t *pcchRemaining, DWORD dwFlags);
 HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format, ...);
 HRESULT UIntAdd(UINT uAugend, UINT uAddend, UINT *puResult);
 HRESULT IntToUInt(int in, UINT *out);

--- a/lib/DxcSupport/WinFunctions.cpp
+++ b/lib/DxcSupport/WinFunctions.cpp
@@ -22,22 +22,6 @@
 #include "dxc/Support/WinFunctions.h"
 #include "dxc/Support/microcom.h"
 
-HRESULT StringCchCopyEx(LPSTR pszDest, size_t cchDest, LPCSTR pszSrc,
-                        LPSTR *ppszDestEnd, size_t *pcchRemaining, DWORD dwFlags) {
-  assert(dwFlags == 0 && "dwFlag values not supported in StringCchCopyEx");
-  char *zPtr = 0;
-
-  zPtr = stpncpy(pszDest, pszSrc, cchDest);
-
-  if (ppszDestEnd)
-    *ppszDestEnd = zPtr;
-
-  if (pcchRemaining)
-    *pcchRemaining = cchDest - (zPtr - pszDest);
-
-  return S_OK;
-}
-
 
 HRESULT StringCchPrintfA(char *dst, size_t dstSize, const char *format, ...) {
   va_list args;

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -99,6 +99,7 @@ protected:
   TEST_METHOD(CursorWhenOverloadedResolvedThenDirectSymbol)
   TEST_METHOD(CursorWhenReferenceThenDefinitionAvailable)
   TEST_METHOD(CursorWhenTypeOfVariableDeclThenNamesHaveType)
+  TEST_METHOD(CursorTypeUsedNamespace)
   TEST_METHOD(CursorWhenVariableRefThenSimpleNames)
   TEST_METHOD(CursorWhenVariableUsedThenDeclarationAvailable)
 
@@ -538,6 +539,16 @@ TEST_F(DXIntellisenseTest, CursorWhenTypeOfVariableDeclThenNamesHaveType) {
   
   ExpectQualifiedName(result.TU, 3, 6, L"Ns::TheClass");
   ExpectDeclarationText(result.TU, 3, 6, L"class Ns::TheClass");
+}
+
+TEST_F(DXIntellisenseTest, CursorTypeUsedNamespace) {
+  char program[] =
+    "namespace Ns { class TheClass {\n"
+    "}; }\n"
+    "using namespace Ns;\n"
+    "TheClass C;";
+  CompilationResult result(CompilationResult::CreateForProgram(program, _countof(program)));
+  ExpectQualifiedName(result.TU, 4, 4, L"Ns::TheClass");
 }
 
 TEST_F(DXIntellisenseTest, CursorWhenVariableRefThenSimpleNames) {


### PR DESCRIPTION
This patch got a bit away from me. It started as me trying to remove one of the Windows system functions we have a custom implementation of (StringCchCopyEx). It didn't really make sense to me that we needed a custom override of a function where we could have just used `strncpy` or other LLVM utilities to provide the functionality.

After I rewrote the code calling `StringCchCopyEx`, I wanted to make sure it was tested, which led me to discover that it was never called in our existing tests (see:
https://microsoft.github.io/DirectXShaderCompiler/coverage/home/runner/w ork/DirectXShaderCompiler/DirectXShaderCompiler/lib/DxcSupport/WinFuncti ons.cpp.html#L27).

I then looked into the behavior of
`clang_getCursorSpellingWithFormatting`, which it turns out _does_ return fully qualified names. As a result the parent traversal we were attempting always terminated immediately with one name segment found.

I wrote an additional test where the cursor name is _not_ fully qualified in source to verify that the API works as expected in all cases then started deleting code.

This patch deletes two functions (`StringCchCopyEx` & `ConcatPartsReversed`), and simplifies the code in `GetCursorQualifiedName`. It also adds the additional non-fully-qualified name test case.