### PR TITLE
[Support] Add the 'Error' class for structured error handling.

### DIFF
--- a/docs/ProgrammersManual.rst
+++ b/docs/ProgrammersManual.rst
@@ -342,9 +342,12 @@ that inherits from the ErrorInfo utility:
   public:
     MyError(std::string Msg) : Msg(Msg) {}
     void log(OStream &OS) const override { OS << "MyError - " << Msg; }
+    static char ID;
   private:
     std::string Msg;
   };
+
+  char MyError::ID = 0; // In MyError.cpp
 
   Error bar() {
     if (checkErrorCondition)

--- a/include/llvm/Support/Compiler.h
+++ b/include/llvm/Support/Compiler.h
@@ -122,10 +122,24 @@
 #define LLVM_ATTRIBUTE_USED
 #endif
 
+/// LLVM_ATTRIBUTE_UNUSED_RESULT - Deprecated. Use LLVM_NODISCARD instead.
 #if __has_attribute(warn_unused_result) || LLVM_GNUC_PREREQ(3, 4, 0)
 #define LLVM_ATTRIBUTE_UNUSED_RESULT __attribute__((__warn_unused_result__))
 #else
 #define LLVM_ATTRIBUTE_UNUSED_RESULT
+#endif
+
+/// LLVM_NODISCARD - Warn if a type or return value is discarded.
+#if __cplusplus > 201402L && __has_cpp_attribute(nodiscard)
+#define LLVM_NODISCARD [[nodiscard]]
+#elif !__cplusplus
+// Workaround for llvm.org/PR23435, since clang 3.6 and below emit a spurious
+// error when __has_cpp_attribute is given a scoped attribute in C mode.
+#define LLVM_NODISCARD
+#elif __has_cpp_attribute(clang::warn_unused_result)
+#define LLVM_NODISCARD [[clang::warn_unused_result]]
+#else
+#define LLVM_NODISCARD
 #endif
 
 // Some compilers warn about unused functions. When a function is sometimes

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -345,7 +345,8 @@ private:
     if (E1.isA<ErrorList>()) {
       auto &E1List = static_cast<ErrorList &>(*E1.getPtr());
       if (E2.isA<ErrorList>()) {
-        auto &E2List = static_cast<ErrorList &>(*E2.getPtr());
+        auto E2Payload = E2.takePayload();
+        auto &E2List = static_cast<ErrorList &>(*E2Payload);
         for (auto &Payload : E2List.Payloads)
           E1List.Payloads.push_back(std::move(Payload));
       } else

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -627,7 +627,7 @@ public:
         Checked(false)
 #endif
   {
-    new (getStorage()) storage_type(std::move(Val));
+    new (getStorage()) storage_type(std::forward<OtherT>(Val));
   }
 
   /// Move construct an Expected<T> value.
@@ -886,11 +886,18 @@ public:
   /// Check Err. If it's in a failure state log the error(s) and exit.
   void operator()(Error Err) const { checkError(std::move(Err)); }
 
-  /// Check E. If it's in a success state return the contained value. If it's
-  /// in a failure state log the error(s) and exit.
+  /// Check E. If it's in a success state then return the contained value. If
+  /// it's in a failure state log the error(s) and exit.
   template <typename T> T operator()(Expected<T> &&E) const {
     checkError(E.takeError());
     return std::move(*E);
+  }
+
+  /// Check E. If it's in a success state then return the contained reference. If
+  /// it's in a failure state log the error(s) and exit.
+  template <typename T> T& operator()(Expected<T&> &&E) const {
+    checkError(E.takeError());
+    return *E;
   }
 
 private:

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -41,7 +41,7 @@ public:
     std::string Msg;
     raw_string_ostream OS(Msg);
     log(OS);
-    return Msg;
+    return OS.str();
   }
 
   /// Convert this error to a std::error_code.

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -1,0 +1,747 @@
+//===----- llvm/Support/Error.h - Recoverable error handling ----*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines an API used to report recoverable errors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_ERROR_H
+#define LLVM_SUPPORT_ERROR_H
+
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/raw_ostream.h"
+#include <vector>
+
+namespace llvm {
+
+class Error;
+class ErrorList;
+
+/// Base class for error info classes. Do not extend this directly: Extend
+/// the ErrorInfo template subclass instead.
+class ErrorInfoBase {
+public:
+  virtual ~ErrorInfoBase() {}
+
+  /// Print an error message to an output stream.
+  virtual void log(raw_ostream &OS) const = 0;
+
+  // Check whether this instance is a subclass of the class identified by
+  // ClassID.
+  virtual bool isA(const void *const ClassID) const {
+    return ClassID == classID();
+  }
+
+  // Check whether this instance is a subclass of ErrorInfoT.
+  template <typename ErrorInfoT> bool isA() const {
+    return isA(ErrorInfoT::classID());
+  }
+
+  // Returns the class ID for this type.
+  static const void *classID() { return &ID; }
+
+private:
+  virtual void anchor();
+  static char ID;
+};
+
+/// Lightweight error class with error context and mandatory checking.
+///
+/// Instances of this class wrap a ErrorInfoBase pointer. Failure states
+/// are represented by setting the pointer to a ErrorInfoBase subclass
+/// instance containing information describing the failure. Success is
+/// represented by a null pointer value.
+///
+/// Instances of Error also contains a 'Checked' flag, which must be set
+/// before the destructor is called, otherwise the destructor will trigger a
+/// runtime error. This enforces at runtime the requirement that all Error
+/// instances be checked or returned to the caller.
+///
+/// There are two ways to set the checked flag, depending on what state the
+/// Error instance is in. For Error instances indicating success, it
+/// is sufficient to invoke the boolean conversion operator. E.g.:
+///
+///   Error foo(<...>);
+///
+///   if (auto E = foo(<...>))
+///     return E; // <- Return E if it is in the error state.
+///   // We have verified that E was in the success state. It can now be safely
+///   // destroyed.
+///
+/// A success value *can not* be dropped. For example, just calling 'foo(<...>)'
+/// without testing the return value will raise a runtime error, even if foo
+/// returns success.
+///
+/// For Error instances representing failure, you must use the either the
+/// handleErrors or handleAllErrors function with a typed handler. E.g.:
+///
+///   class MyErrorInfo : public ErrorInfo<MyErrorInfo> {
+///     // Custom error info.
+///   };
+///
+///   Error foo(<...>) { return make_error<MyErrorInfo>(...); }
+///
+///   auto E = foo(<...>); // <- foo returns failure with MyErrorInfo.
+///   auto NewE =
+///     checkErrors(E,
+///       [](const MyErrorInfo &M) {
+///         // Deal with the error.
+///       },
+///       [](std::unique_ptr<OtherError> M) -> Error {
+///         if (canHandle(*M)) {
+///           // handle error.
+///           return Error::success();
+///         }
+///         // Couldn't handle this error instance. Pass it up the stack.
+///         return Error(std::move(M));
+///       );
+///   // Note - we must check or return NewE in case any of the handlers
+///   // returned a new error.
+///
+/// The handleAllErrors function is identical to handleErrors, except
+/// that it has a void return type, and requires all errors to be handled and
+/// no new errors be returned. It prevents errors (assuming they can all be
+/// handled) from having to be bubbled all the way to the top-level.
+///
+/// *All* Error instances must be checked before destruction, even if
+/// they're moved-assigned or constructed from Success values that have already
+/// been checked. This enforces checking through all levels of the call stack.
+class Error {
+
+  // ErrorList needs to be able to yank ErrorInfoBase pointers out of this
+  // class to add to the error list.
+  friend class ErrorList;
+
+  // handleErrors needs to be able to set the Checked flag.
+  template <typename... HandlerTs>
+  friend Error handleErrors(Error E, HandlerTs &&... Handlers);
+
+public:
+  /// Create a success value. Prefer using 'Error::success()' for readability
+  /// where possible.
+  Error() {
+    setPtr(nullptr);
+    setChecked(false);
+  }
+
+  /// Create a success value. This is equivalent to calling the default
+  /// constructor, but should be preferred for readability where possible.
+  static Error success() { return Error(); }
+
+  // Errors are not copy-constructable.
+  Error(const Error &Other) = delete;
+
+  /// Move-construct an error value. The newly constructed error is considered
+  /// unchecked, even if the source error had been checked. The original error
+  /// becomes a checked Success value, regardless of its original state.
+  Error(Error &&Other) {
+    setChecked(true);
+    *this = std::move(Other);
+  }
+
+  /// Create an error value. Prefer using the 'make_error' function, but
+  /// this constructor can be useful when "re-throwing" errors from handlers.
+  Error(std::unique_ptr<ErrorInfoBase> Payload) {
+    setPtr(Payload.release());
+    setChecked(false);
+  }
+
+  // Errors are not copy-assignable.
+  Error &operator=(const Error &Other) = delete;
+
+  /// Move-assign an error value. The current error must represent success, you
+  /// you cannot overwrite an unhandled error. The current error is then
+  /// considered unchecked. The source error becomes a checked success value,
+  /// regardless of its original state.
+  Error &operator=(Error &&Other) {
+    // Move assignment shouldn't drop an existing error, but we won't complain
+    // about overwriting success.
+    assertIsChecked();
+    setPtr(Other.getPtr());
+
+    // This Error is unchecked, even if the source error was checked.
+    setChecked(false);
+
+    // Null out Other's payload and set its checked bit.
+    Other.setPtr(nullptr);
+    Other.setChecked(true);
+
+    return *this;
+  }
+
+  /// Destroy a Error. Fails with a call to abort() if the error is
+  /// unchecked.
+  ~Error() {
+    assertIsChecked();
+    delete getPtr();
+  }
+
+  /// Bool conversion. Returns true if this Error is in a failure state,
+  /// and false if it is in an accept state. If the error is in a Success state
+  /// it will be considered checked.
+  explicit operator bool() {
+    setChecked(getPtr() == nullptr);
+    return getPtr() != nullptr;
+  }
+
+  /// Check whether one error is a subclass of another.
+  template <typename ErrT> bool isA() const {
+    return getPtr()->isA(ErrT::classID());
+  }
+
+private:
+  void assertIsChecked() {
+#ifndef NDEBUG
+    if (!getChecked() || getPtr()) {
+      dbgs() << "Program aborted due to an unhandled Error:\n";
+      if (getPtr())
+        getPtr()->log(dbgs());
+      else
+        dbgs()
+            << "Error value was Success. (Note: Success values must still be "
+               "checked prior to being destroyed).\n";
+      abort();
+    }
+#endif
+  }
+
+  ErrorInfoBase *getPtr() const {
+#ifndef NDEBUG
+    return PayloadAndCheckedBit.getPointer();
+#else
+    return Payload;
+#endif
+  }
+
+  void setPtr(ErrorInfoBase *EI) {
+#ifndef NDEBUG
+    PayloadAndCheckedBit.setPointer(EI);
+#else
+    Payload = EI;
+#endif
+  }
+
+  bool getChecked() const {
+#ifndef NDEBUG
+    return PayloadAndCheckedBit.getInt();
+#else
+    return true;
+#endif
+  }
+
+  void setChecked(bool V) {
+#ifndef NDEBUG
+    PayloadAndCheckedBit.setInt(V);
+#endif
+  }
+
+  std::unique_ptr<ErrorInfoBase> takePayload() {
+    std::unique_ptr<ErrorInfoBase> Tmp(getPtr());
+    setPtr(nullptr);
+    setChecked(true);
+    return Tmp;
+  }
+
+#ifndef NDEBUG
+  PointerIntPair<ErrorInfoBase *, 1> PayloadAndCheckedBit;
+#else
+  ErrorInfoBase *Payload;
+#endif
+};
+
+/// Make a Error instance representing failure using the given error info
+/// type.
+template <typename ErrT, typename... ArgTs> Error make_error(ArgTs &&... Args) {
+  return Error(llvm::make_unique<ErrT>(std::forward<ArgTs>(Args)...));
+}
+
+/// Base class for user error types. Users should declare their error types
+/// like:
+///
+/// class MyError : public ErrorInfo<MyError> {
+///   ....
+/// };
+///
+/// This class provides an implementation of the ErrorInfoBase::kind
+/// method, which is used by the Error RTTI system.
+template <typename ThisErrT, typename ParentErrT = ErrorInfoBase>
+class ErrorInfo : public ParentErrT {
+public:
+  bool isA(const void *const ClassID) const override {
+    return ClassID == classID() || ParentErrT::isA(ClassID);
+  }
+
+  static const void *classID() { return &ID; }
+
+private:
+  static char ID;
+};
+
+template <typename MyErrT, typename ParentErrT>
+char ErrorInfo<MyErrT, ParentErrT>::ID = 0;
+
+/// Special ErrorInfo subclass representing a list of ErrorInfos.
+/// Instances of this class are constructed by joinError.
+class ErrorList final : public ErrorInfo<ErrorList> {
+
+  // handleErrors needs to be able to iterate the payload list of an
+  // ErrorList.
+  template <typename... HandlerTs>
+  friend Error handleErrors(Error E, HandlerTs &&... Handlers);
+
+  // joinErrors is implemented in terms of join.
+  friend Error joinErrors(Error, Error);
+
+public:
+  void log(raw_ostream &OS) const override {
+    OS << "Multiple errors:\n";
+    for (auto &ErrPayload : Payloads) {
+      ErrPayload->log(OS);
+      OS << "\n";
+    }
+  }
+
+private:
+  ErrorList(std::unique_ptr<ErrorInfoBase> Payload1,
+            std::unique_ptr<ErrorInfoBase> Payload2) {
+    assert(!Payload1->isA<ErrorList>() && !Payload2->isA<ErrorList>() &&
+           "ErrorList constructor payloads should be singleton errors");
+    Payloads.push_back(std::move(Payload1));
+    Payloads.push_back(std::move(Payload2));
+  }
+
+  static Error join(Error E1, Error E2) {
+    if (!E1)
+      return E2;
+    if (!E2)
+      return E1;
+    if (E1.isA<ErrorList>()) {
+      auto &E1List = static_cast<ErrorList &>(*E1.getPtr());
+      if (E2.isA<ErrorList>()) {
+        auto &E2List = static_cast<ErrorList &>(*E2.getPtr());
+        for (auto &Payload : E2List.Payloads)
+          E1List.Payloads.push_back(std::move(Payload));
+      } else
+        E1List.Payloads.push_back(E2.takePayload());
+
+      return E1;
+    }
+    if (E2.isA<ErrorList>()) {
+      auto &E2List = static_cast<ErrorList &>(*E2.getPtr());
+      E2List.Payloads.insert(E2List.Payloads.begin(), E1.takePayload());
+      return E2;
+    }
+    return Error(std::unique_ptr<ErrorList>(
+        new ErrorList(E1.takePayload(), E2.takePayload())));
+  }
+
+  std::vector<std::unique_ptr<ErrorInfoBase>> Payloads;
+};
+
+/// Concatenate errors. The resulting Error is unchecked, and contains the
+/// ErrorInfo(s), if any, contained in E1, followed by the
+/// ErrorInfo(s), if any, contained in E2.
+inline Error joinErrors(Error E1, Error E2) {
+  return ErrorList::join(std::move(E1), std::move(E2));
+}
+
+/// Helper for testing applicability of, and applying, handlers for
+/// ErrorInfo types.
+template <typename HandlerT>
+class ErrorHandlerTraits
+    : public ErrorHandlerTraits<decltype(
+          &std::remove_reference<HandlerT>::type::operator())> {};
+
+// Specialization functions of the form 'Error (const ErrT&)'.
+template <typename ErrT> class ErrorHandlerTraits<Error (&)(ErrT &)> {
+public:
+  static bool appliesTo(const ErrorInfoBase &E) {
+    return E.template isA<ErrT>();
+  }
+
+  template <typename HandlerT>
+  static Error apply(HandlerT &&H, std::unique_ptr<ErrorInfoBase> E) {
+    assert(appliesTo(*E) && "Applying incorrect handler");
+    return H(static_cast<ErrT &>(*E));
+  }
+};
+
+// Specialization functions of the form 'void (const ErrT&)'.
+template <typename ErrT> class ErrorHandlerTraits<void (&)(ErrT &)> {
+public:
+  static bool appliesTo(const ErrorInfoBase &E) {
+    return E.template isA<ErrT>();
+  }
+
+  template <typename HandlerT>
+  static Error apply(HandlerT &&H, std::unique_ptr<ErrorInfoBase> E) {
+    assert(appliesTo(*E) && "Applying incorrect handler");
+    H(static_cast<ErrT &>(*E));
+    return Error::success();
+  }
+};
+
+/// Specialization for functions of the form 'Error (std::unique_ptr<ErrT>)'.
+template <typename ErrT>
+class ErrorHandlerTraits<Error (&)(std::unique_ptr<ErrT>)> {
+public:
+  static bool appliesTo(const ErrorInfoBase &E) {
+    return E.template isA<ErrT>();
+  }
+
+  template <typename HandlerT>
+  static Error apply(HandlerT &&H, std::unique_ptr<ErrorInfoBase> E) {
+    assert(appliesTo(*E) && "Applying incorrect handler");
+    std::unique_ptr<ErrT> SubE(static_cast<ErrT *>(E.release()));
+    return H(std::move(SubE));
+  }
+};
+
+/// Specialization for functions of the form 'Error (std::unique_ptr<ErrT>)'.
+template <typename ErrT>
+class ErrorHandlerTraits<void (&)(std::unique_ptr<ErrT>)> {
+public:
+  static bool appliesTo(const ErrorInfoBase &E) {
+    return E.template isA<ErrT>();
+  }
+
+  template <typename HandlerT>
+  static Error apply(HandlerT &&H, std::unique_ptr<ErrorInfoBase> E) {
+    assert(appliesTo(*E) && "Applying incorrect handler");
+    std::unique_ptr<ErrT> SubE(static_cast<ErrT *>(E.release()));
+    H(std::move(SubE));
+    return Error::success();
+  }
+};
+
+// Specialization for member functions of the form 'RetT (const ErrT&)'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(ErrT &)>
+    : public ErrorHandlerTraits<RetT (&)(ErrT &)> {};
+
+// Specialization for member functions of the form 'RetT (const ErrT&) const'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(ErrT &) const>
+    : public ErrorHandlerTraits<RetT (&)(ErrT &)> {};
+
+// Specialization for member functions of the form 'RetT (const ErrT&)'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(const ErrT &)>
+    : public ErrorHandlerTraits<RetT (&)(ErrT &)> {};
+
+// Specialization for member functions of the form 'RetT (const ErrT&) const'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(const ErrT &) const>
+    : public ErrorHandlerTraits<RetT (&)(ErrT &)> {};
+
+/// Specialization for member functions of the form
+/// 'RetT (std::unique_ptr<ErrT>) const'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(std::unique_ptr<ErrT>)>
+    : public ErrorHandlerTraits<RetT (&)(std::unique_ptr<ErrT>)> {};
+
+/// Specialization for member functions of the form
+/// 'RetT (std::unique_ptr<ErrT>) const'.
+template <typename C, typename RetT, typename ErrT>
+class ErrorHandlerTraits<RetT (C::*)(std::unique_ptr<ErrT>) const>
+    : public ErrorHandlerTraits<RetT (&)(std::unique_ptr<ErrT>)> {};
+
+inline Error handleErrorImpl(std::unique_ptr<ErrorInfoBase> Payload) {
+  return Error(std::move(Payload));
+}
+
+template <typename HandlerT, typename... HandlerTs>
+Error handleErrorImpl(std::unique_ptr<ErrorInfoBase> Payload,
+                      HandlerT &&Handler, HandlerTs &&... Handlers) {
+  if (ErrorHandlerTraits<HandlerT>::appliesTo(*Payload))
+    return ErrorHandlerTraits<HandlerT>::apply(std::forward<HandlerT>(Handler),
+                                               std::move(Payload));
+  return handleErrorImpl(std::move(Payload),
+                         std::forward<HandlerTs>(Handlers)...);
+}
+
+/// Pass the ErrorInfo(s) contained in E to their respective handlers. Any
+/// unhandled errors (or Errors returned by handlers) are re-concatenated and
+/// returned.
+/// Because this function returns an error, its result must also be checked
+/// or returned. If you intend to handle all errors use handleAllErrors
+/// (which returns void, and will abort() on unhandled errors) instead.
+template <typename... HandlerTs>
+Error handleErrors(Error E, HandlerTs &&... Hs) {
+  if (!E)
+    return Error::success();
+
+  std::unique_ptr<ErrorInfoBase> Payload = E.takePayload();
+
+  if (Payload->isA<ErrorList>()) {
+    ErrorList &List = static_cast<ErrorList &>(*Payload);
+    Error R;
+    for (auto &P : List.Payloads)
+      R = ErrorList::join(
+          std::move(R),
+          handleErrorImpl(std::move(P), std::forward<HandlerTs>(Hs)...));
+    return R;
+  }
+
+  return handleErrorImpl(std::move(Payload), std::forward<HandlerTs>(Hs)...);
+}
+
+/// Behaves the same as handleErrors, except that it requires that all
+/// errors be handled by the given handlers. If any unhandled error remains
+/// after the handlers have run, abort() will be called.
+template <typename... HandlerTs>
+void handleAllErrors(Error E, HandlerTs &&... Handlers) {
+  auto F = handleErrors(std::move(E), std::forward<HandlerTs>(Handlers)...);
+  // Cast 'F' to bool to set the 'Checked' flag if it's a success value:
+  (void)!F;
+}
+
+/// Check that E is a non-error, then drop it.
+inline void handleAllErrors(Error E) {
+  // Cast 'E' to a bool to set the 'Checked' flag if it's a success value:
+  (void)!E;
+}
+
+/// Log all errors (if any) in E to OS. If there are any errors, ErrorBanner
+/// will be printed before the first one is logged. A newline will be printed
+/// after each error.
+///
+/// This is useful in the base level of your program to allow clean termination
+/// (allowing clean deallocation of resources, etc.), while reporting error
+/// information to the user.
+template <typename... HandlerTs>
+void logAllUnhandledErrors(Error E, raw_ostream &OS, std::string ErrorBanner) {
+  if (!E)
+    return;
+  OS << ErrorBanner;
+  handleAllErrors(std::move(E), [&](const ErrorInfoBase &EI) {
+    EI.log(OS);
+    OS << "\n";
+  });
+}
+
+/// Consume a Error without doing anything. This method should be used
+/// only where an error can be considered a reasonable and expected return
+/// value.
+///
+/// Uses of this method are potentially indicative of design problems: If it's
+/// legitimate to do nothing while processing an "error", the error-producer
+/// might be more clearly refactored to return an Optional<T>.
+inline void consumeError(Error Err) {
+  handleAllErrors(std::move(Err), [](const ErrorInfoBase &) {});
+}
+
+/// Tagged union holding either a T or a Error.
+///
+/// This class parallels ErrorOr, but replaces error_code with Error. Since
+/// Error cannot be copied, this class replaces getError() with
+/// takeError(). It also adds an bool errorIsA<ErrT>() method for testing the
+/// error class type.
+template <class T> class Expected {
+  template <class OtherT> friend class Expected;
+  static const bool isRef = std::is_reference<T>::value;
+  typedef ReferenceStorage<typename std::remove_reference<T>::type> wrap;
+
+public:
+  typedef typename std::conditional<isRef, wrap, T>::type storage_type;
+
+private:
+  typedef typename std::remove_reference<T>::type &reference;
+  typedef const typename std::remove_reference<T>::type &const_reference;
+  typedef typename std::remove_reference<T>::type *pointer;
+  typedef const typename std::remove_reference<T>::type *const_pointer;
+
+public:
+  /// Create an Expected<T> error value from the given Error.
+  Expected(Error Err) : HasError(true) {
+    assert(Err && "Cannot create Expected from Error success value.");
+    new (getErrorStorage()) Error(std::move(Err));
+  }
+
+  /// Create an Expected<T> success value from the given OtherT value, which
+  /// must be convertible to T.
+  template <typename OtherT>
+  Expected(OtherT &&Val,
+           typename std::enable_if<std::is_convertible<OtherT, T>::value>::type
+               * = nullptr)
+      : HasError(false) {
+    new (getStorage()) storage_type(std::move(Val));
+  }
+
+  /// Move construct an Expected<T> value.
+  Expected(Expected &&Other) { moveConstruct(std::move(Other)); }
+
+  /// Move construct an Expected<T> value from an Expected<OtherT>, where OtherT
+  /// must be convertible to T.
+  template <class OtherT>
+  Expected(Expected<OtherT> &&Other,
+           typename std::enable_if<std::is_convertible<OtherT, T>::value>::type
+               * = nullptr) {
+    moveConstruct(std::move(Other));
+  }
+
+  /// Move construct an Expected<T> value from an Expected<OtherT>, where OtherT
+  /// isn't convertible to T.
+  template <class OtherT>
+  explicit Expected(
+      Expected<OtherT> &&Other,
+      typename std::enable_if<!std::is_convertible<OtherT, T>::value>::type * =
+          nullptr) {
+    moveConstruct(std::move(Other));
+  }
+
+  /// Move-assign from another Expected<T>.
+  Expected &operator=(Expected &&Other) {
+    moveAssign(std::move(Other));
+    return *this;
+  }
+
+  /// Destroy an Expected<T>.
+  ~Expected() {
+    if (!HasError)
+      getStorage()->~storage_type();
+    else
+      getErrorStorage()->~Error();
+  }
+
+  /// \brief Return false if there is an error.
+  explicit operator bool() const { return !HasError; }
+
+  /// \brief Returns a reference to the stored T value.
+  reference get() { return *getStorage(); }
+
+  /// \brief Returns a const reference to the stored T value.
+  const_reference get() const { return const_cast<Expected<T> *>(this)->get(); }
+
+  /// \brief Check that this Expected<T> is an error of type ErrT.
+  template <typename ErrT> bool errorIsA() const {
+    return HasError && getErrorStorage()->template isA<ErrT>();
+  }
+
+  /// \brief Take ownership of the stored error.
+  /// After calling this the Expected<T> is in an indeterminate state that can
+  /// only be safely destructed. No further calls (beside the destructor) should
+  /// be made on the Expected<T> vaule.
+  Error takeError() {
+    return HasError ? std::move(*getErrorStorage()) : Error();
+  }
+
+  /// \brief Returns a pointer to the stored T value.
+  pointer operator->() { return toPointer(getStorage()); }
+
+  /// \brief Returns a const pointer to the stored T value.
+  const_pointer operator->() const { return toPointer(getStorage()); }
+
+  /// \brief Returns a reference to the stored T value.
+  reference operator*() { return *getStorage(); }
+
+  /// \brief Returns a const reference to the stored T value.
+  const_reference operator*() const { return *getStorage(); }
+
+private:
+  template <class T1>
+  static bool compareThisIfSameType(const T1 &a, const T1 &b) {
+    return &a == &b;
+  }
+
+  template <class T1, class T2>
+  static bool compareThisIfSameType(const T1 &a, const T2 &b) {
+    return false;
+  }
+
+  template <class OtherT> void moveConstruct(Expected<OtherT> &&Other) {
+    if (!Other.HasError) {
+      // Get the other value.
+      HasError = false;
+      new (getStorage()) storage_type(std::move(*Other.getStorage()));
+    } else {
+      // Get other's error.
+      HasError = true;
+      new (getErrorStorage()) Error(Other.takeError());
+    }
+  }
+
+  template <class OtherT> void moveAssign(Expected<OtherT> &&Other) {
+    if (compareThisIfSameType(*this, Other))
+      return;
+
+    this->~Expected();
+    new (this) Expected(std::move(Other));
+  }
+
+  pointer toPointer(pointer Val) { return Val; }
+
+  const_pointer toPointer(const_pointer Val) const { return Val; }
+
+  pointer toPointer(wrap *Val) { return &Val->get(); }
+
+  const_pointer toPointer(const wrap *Val) const { return &Val->get(); }
+
+  storage_type *getStorage() {
+    assert(!HasError && "Cannot get value when an error exists!");
+    return reinterpret_cast<storage_type *>(TStorage.buffer);
+  }
+
+  const storage_type *getStorage() const {
+    assert(!HasError && "Cannot get value when an error exists!");
+    return reinterpret_cast<const storage_type *>(TStorage.buffer);
+  }
+
+  Error *getErrorStorage() {
+    assert(HasError && "Cannot get error when a value exists!");
+    return reinterpret_cast<Error *>(ErrorStorage.buffer);
+  }
+
+  union {
+    AlignedCharArrayUnion<storage_type> TStorage;
+    AlignedCharArrayUnion<Error> ErrorStorage;
+  };
+  bool HasError : 1;
+};
+
+/// This class wraps a std::error_code in a Error.
+///
+/// This is useful if you're writing an interface that returns a Error
+/// (or Expected) and you want to call code that still returns
+/// std::error_codes.
+class ECError : public ErrorInfo<ECError> {
+public:
+  ECError() = default;
+  ECError(std::error_code EC) : EC(EC) {}
+  std::error_code getErrorCode() const { return EC; }
+  void log(raw_ostream &OS) const override { OS << EC.message(); }
+
+protected:
+  std::error_code EC;
+};
+
+/// Helper for converting an std::error_code to a Error.
+inline Error errorCodeToError(std::error_code EC) {
+  if (!EC)
+    return Error::success();
+  return make_error<ECError>(EC);
+}
+
+/// Helper for converting an ECError to a std::error_code.
+///
+/// This method requires that Err be Error() or an ECError, otherwise it
+/// will trigger a call to abort().
+inline std::error_code errorToErrorCode(Error Err) {
+  std::error_code EC;
+  handleAllErrors(std::move(Err),
+                  [&](const ECError &ECE) { EC = ECE.getErrorCode(); });
+  return EC;
+}
+
+} // namespace llvm
+
+#endif // LLVM_SUPPORT_ERROR_H

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -163,8 +163,7 @@ public:
   /// considered unchecked. The source error becomes a checked success value,
   /// regardless of its original state.
   Error &operator=(Error &&Other) {
-    // Move assignment shouldn't drop an existing error, but we won't complain
-    // about overwriting success.
+    // Don't allow overwriting of unchecked values.
     assertIsChecked();
     setPtr(Other.getPtr());
 

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -195,7 +195,7 @@ public:
 
   /// Check whether one error is a subclass of another.
   template <typename ErrT> bool isA() const {
-    return getPtr()->isA(ErrT::classID());
+    return getPtr() && getPtr()->isA(ErrT::classID());
   }
 
 private:

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -143,6 +143,13 @@ public:
   /// constructor, but should be preferred for readability where possible.
   static Error success() { return Error(); }
 
+  /// Create a 'pre-checked' success value suitable for use as an out-parameter.
+  static Error errorForOutParameter() {
+    Error Err;
+    (void)!!Err;
+    return Err;
+  }
+
   // Errors are not copy-constructable.
   Error(const Error &Other) = delete;
 

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -291,9 +291,6 @@ private:
   static char ID;
 };
 
-template <typename MyErrT, typename ParentErrT>
-char ErrorInfo<MyErrT, ParentErrT>::ID = 0;
-
 /// Special ErrorInfo subclass representing a list of ErrorInfos.
 /// Instances of this class are constructed by joinError.
 class ErrorList final : public ErrorInfo<ErrorList> {

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -285,14 +285,8 @@ public:
     return ClassID == classID() || ParentErrT::isA(ClassID);
   }
 
-  static const void *classID() { return &ID; }
-
-private:
-  static char ID;
+  static const void *classID() { return &ThisErrT::ID; }
 };
-
-template <typename ThisErrT, typename ParentErrT>
-char ErrorInfo<ThisErrT, ParentErrT>::ID = 0;
 
 /// Special ErrorInfo subclass representing a list of ErrorInfos.
 /// Instances of this class are constructed by joinError.
@@ -316,6 +310,9 @@ public:
   }
 
   std::error_code convertToErrorCode() const override;
+
+  // Used by ErrorInfo::classID.
+  static char ID;
 
 private:
   ErrorList(std::unique_ptr<ErrorInfoBase> Payload1,
@@ -728,6 +725,9 @@ public:
   void setErrorCode(std::error_code EC) { this->EC = EC; }
   std::error_code convertToErrorCode() const override { return EC; }
   void log(raw_ostream &OS) const override { OS << EC.message(); }
+
+  // Used by ErrorInfo::classID.
+  static char ID;
 
 protected:
   std::error_code EC;

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -752,17 +752,17 @@ public:
 
   /// Create an error on exit helper.
   ExitOnError(std::string Banner = "", int DefaultErrorExitCode = 1)
-    : Banner(Banner),
+    : Banner(std::move(Banner)),
       GetExitCode([=](const Error&) { return DefaultErrorExitCode; }) {}
 
   /// Set the banner string for any errors caught by operator().
   void setBanner(std::string Banner) {
-    this->Banner = Banner;
+    this->Banner = std::move(Banner);
   }
 
   /// Set the exit-code mapper function.
   void setExitCodeMapper(std::function<int(const Error&)> GetExitCode) {
-    this->GetExitCode = GetExitCode;
+    this->GetExitCode = std::move(GetExitCode);
   }
 
   /// Check Err. If it's in a failure state log the error(s) and exit.
@@ -773,7 +773,7 @@ public:
   /// Check E. If it's in a success state return the contained value. If it's
   /// in a failure state log the error(s) and exit.
   template <typename T>
-  T operator()(Expected<T> E) const {
+  T operator()(Expected<T> &&E) const {
     checkError(E.takeError());
     return std::move(*E);
   }

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -753,6 +753,22 @@ inline std::error_code errorToErrorCode(Error Err) {
   return EC;
 }
 
+/// Convert an ErrorOr<T> to an Expected<T>.
+template <typename T>
+Expected<T> errorOrToExpected(ErrorOr<T> &&EO) {
+  if (auto EC = EO.getError())
+    return errorCodeToError(EC);
+  return std::move(*EO);
+}
+
+/// Convert an Expected<T> to an ErrorOr<T>.
+template <typename T>
+ErrorOr<T> expectedToErrorOr(Expected<T> &&E) {
+  if (auto Err = E.takeError())
+    return errorToErrorCode(std::move(Err));
+  return std::move(*E);
+}
+
 /// Helper for check-and-exit error handling.
 ///
 /// For tool use only. NOT FOR USE IN LIBRARY CODE.

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -143,13 +143,6 @@ public:
   /// constructor, but should be preferred for readability where possible.
   static Error success() { return Error(); }
 
-  /// Create a 'pre-checked' success value suitable for use as an out-parameter.
-  static Error errorForOutParameter() {
-    Error Err;
-    (void)!!Err;
-    return Err;
-  }
-
   // Errors are not copy-constructable.
   Error(const Error &Other) = delete;
 
@@ -551,6 +544,36 @@ void logAllUnhandledErrors(Error E, raw_ostream &OS,
 inline void consumeError(Error Err) {
   handleAllErrors(std::move(Err), [](const ErrorInfoBase &) {});
 }
+
+/// Helper for Errors used as out-parameters.
+///
+/// This helper is for use with the Error-as-out-parameter idiom, where an error
+/// is passed to a function or method by reference, rather than being returned.
+/// In such cases it is helpful to set the checked bit on entry to the function
+/// so that the error can be written to (unchecked Errors abort on assignment)
+/// and clear the checked bit on exit so that clients cannot accidentally forget
+/// to check the result. This helper performs these actions automatically using
+/// RAII:
+///
+/// Result foo(Error &Err) {
+///   ErrorAsOutParameter ErrAsOutParam(Err); // 'Checked' flag set
+///   // <body of foo>
+///   // <- 'Checked' flag auto-cleared when ErrAsOutParam is destructed.
+/// }
+class ErrorAsOutParameter {
+public:
+  ErrorAsOutParameter(Error &Err) : Err(Err) {
+    // Raise the checked bit if Err is success.
+    (void)!!Err;
+  }
+  ~ErrorAsOutParameter() {
+    // Clear the checked bit.
+    if (!Err)
+      Err = Error::success();
+  }
+private:
+  Error &Err;
+};
 
 /// Tagged union holding either a T or a Error.
 ///

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -291,6 +291,9 @@ private:
   static char ID;
 };
 
+template <typename ThisErrT, typename ParentErrT>
+char ErrorInfo<ThisErrT, ParentErrT>::ID = 0;
+
 /// Special ErrorInfo subclass representing a list of ErrorInfos.
 /// Instances of this class are constructed by joinError.
 class ErrorList final : public ErrorInfo<ErrorList> {

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -17,6 +17,7 @@
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/raw_ostream.h"
@@ -26,7 +27,6 @@ namespace llvm {
 
 class Error;
 class ErrorList;
-class Twine;
 
 /// Base class for error info classes. Do not extend this directly: Extend
 /// the ErrorInfo template subclass instead.
@@ -537,17 +537,7 @@ inline void handleAllErrors(Error E) {
 /// This is useful in the base level of your program to allow clean termination
 /// (allowing clean deallocation of resources, etc.), while reporting error
 /// information to the user.
-template <typename... HandlerTs>
-void logAllUnhandledErrors(Error E, raw_ostream &OS,
-                           const std::string &ErrorBanner) {
-  if (!E)
-    return;
-  OS << ErrorBanner;
-  handleAllErrors(std::move(E), [&](const ErrorInfoBase &EI) {
-    EI.log(OS);
-    OS << "\n";
-  });
-}
+void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner);
 
 /// Write all error messages (if any) in E to a string. The newline character
 /// is used to separate error messages.

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -858,7 +858,7 @@ protected:
 /// sensible conversion to std::error_code is available, as attempts to convert
 /// to/from this error will result in a fatal error. (i.e. it is a programmatic
 ///error to try to convert such a value).
-std::error_code unconvertibleErrorCode();
+std::error_code inconvertibleErrorCode();
 
 /// Helper for converting an std::error_code to a Error.
 Error errorCodeToError(std::error_code EC);

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -836,9 +836,8 @@ private:
 /// (or Expected) and you want to call code that still returns
 /// std::error_codes.
 class ECError : public ErrorInfo<ECError> {
+  friend Error errorCodeToError(std::error_code);
 public:
-  ECError() = default;
-  ECError(std::error_code EC) : EC(EC) {}
   void setErrorCode(std::error_code EC) { this->EC = EC; }
   std::error_code convertToErrorCode() const override { return EC; }
   void log(raw_ostream &OS) const override { OS << EC.message(); }
@@ -847,6 +846,8 @@ public:
   static char ID;
 
 protected:
+  ECError() = default;
+  ECError(std::error_code EC) : EC(EC) {}
   std::error_code EC;
 };
 
@@ -854,7 +855,7 @@ protected:
 inline Error errorCodeToError(std::error_code EC) {
   if (!EC)
     return Error::success();
-  return make_error<ECError>(EC);
+  return Error(llvm::make_unique<ECError>(ECError(EC)));
 }
 
 /// Helper for converting an ECError to a std::error_code.

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -145,14 +145,14 @@ class LLVM_NODISCARD Error {
   // error.
   template <typename T> friend class Expected;
 
-public:
+protected:
   /// Create a success value. Prefer using 'Error::success()' for readability
-  /// where possible.
   Error() : Payload(nullptr) {
     setPtr(nullptr);
     setChecked(false);
   }
 
+public:
   /// Create a success value. This is equivalent to calling the default
   /// constructor, but should be preferred for readability where possible.
   static Error success() { return Error(); }

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -143,7 +143,7 @@ class LLVM_NODISCARD Error {
 
   // Expected<T> needs to be able to steal the payload when constructed from an
   // error.
-  template <typename T> class Expected;
+  template <typename T> friend class Expected;
 
 public:
   /// Create a success value. Prefer using 'Error::success()' for readability
@@ -635,7 +635,7 @@ public:
 
   {
     assert(Err && "Cannot create Expected<T> from Error success value.");
-    new (getErrorStorage()) Error(std::move(Err));
+    new (getErrorStorage()) error_type(Err.takePayload());
   }
 
   /// Create an Expected<T> success value from the given OtherT value, which

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -16,6 +16,7 @@
 
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorOr.h"
 #include "llvm/Support/raw_ostream.h"
@@ -34,6 +35,14 @@ public:
 
   /// Print an error message to an output stream.
   virtual void log(raw_ostream &OS) const = 0;
+
+  /// Return the error message as a string.
+  virtual std::string message() const {
+    std::string Msg;
+    raw_string_ostream OS(Msg);
+    log(OS);
+    return Msg;
+  }
 
   /// Convert this error to a std::error_code.
   ///
@@ -536,6 +545,16 @@ void logAllUnhandledErrors(Error E, raw_ostream &OS,
     EI.log(OS);
     OS << "\n";
   });
+}
+
+/// Write all error messages (if any) in E to a string. The newline character
+/// is used to separate error messages.
+inline std::string toString(Error E) {
+  SmallVector<std::string, 2> Errors;
+  handleAllErrors(std::move(E), [&Errors](const ErrorInfoBase &EI) {
+    Errors.push_back(EI.message());
+  });
+  return join(Errors.begin(), Errors.end(), "\n");
 }
 
 /// Consume a Error without doing anything. This method should be used

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -131,7 +131,7 @@ private:
 /// *All* Error instances must be checked before destruction, even if
 /// they're moved-assigned or constructed from Success values that have already
 /// been checked. This enforces checking through all levels of the call stack.
-class Error {
+class LLVM_NODISCARD Error {
 
   // ErrorList needs to be able to yank ErrorInfoBase pointers out of this
   // class to add to the error list.
@@ -605,7 +605,7 @@ private:
 /// Error cannot be copied, this class replaces getError() with
 /// takeError(). It also adds an bool errorIsA<ErrT>() method for testing the
 /// error class type.
-template <class T> class Expected {
+template <class T> class LLVM_NODISCARD Expected {
   template <class OtherT> friend class Expected;
   static const bool isRef = std::is_reference<T>::value;
   typedef ReferenceStorage<typename std::remove_reference<T>::type> wrap;

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -26,6 +26,7 @@ namespace llvm {
 
 class Error;
 class ErrorList;
+class Twine;
 
 /// Base class for error info classes. Do not extend this directly: Extend
 /// the ErrorInfo template subclass instead.
@@ -851,24 +852,22 @@ protected:
   std::error_code EC;
 };
 
+/// The value returned by this function can be returned from convertToErrorCode
+/// for Error values where no sensible translation to std::error_code exists.
+/// It should only be used in this situation, and should never be used where a
+/// sensible conversion to std::error_code is available, as attempts to convert
+/// to/from this error will result in a fatal error. (i.e. it is a programmatic
+///error to try to convert such a value).
+std::error_code unconvertibleErrorCode();
+
 /// Helper for converting an std::error_code to a Error.
-inline Error errorCodeToError(std::error_code EC) {
-  if (!EC)
-    return Error::success();
-  return Error(llvm::make_unique<ECError>(ECError(EC)));
-}
+Error errorCodeToError(std::error_code EC);
 
 /// Helper for converting an ECError to a std::error_code.
 ///
 /// This method requires that Err be Error() or an ECError, otherwise it
 /// will trigger a call to abort().
-inline std::error_code errorToErrorCode(Error Err) {
-  std::error_code EC;
-  handleAllErrors(std::move(Err), [&](const ErrorInfoBase &EI) {
-    EC = EI.convertToErrorCode();
-  });
-  return EC;
-}
+std::error_code errorToErrorCode(Error Err);
 
 /// Convert an ErrorOr<T> to an Expected<T>.
 template <typename T> Expected<T> errorOrToExpected(ErrorOr<T> &&EO) {
@@ -883,6 +882,23 @@ template <typename T> ErrorOr<T> expectedToErrorOr(Expected<T> &&E) {
     return errorToErrorCode(std::move(Err));
   return std::move(*E);
 }
+
+/// This class wraps a string in an Error.
+///
+/// StringError is useful in cases where the client is not expected to be able
+/// to consume the specific error message programmatically (for example, if the
+/// error message is to be presented to the user). It cannot be converted to a
+/// std::error_code.
+class StringError : public ErrorInfo<StringError> {
+public:
+  static char ID;
+  StringError(const Twine &S, std::error_code EC);
+  void log(raw_ostream &OS) const override;
+  std::error_code convertToErrorCode() const override;
+private:
+  std::string Msg;
+  std::error_code EC;
+};
 
 /// Helper for check-and-exit error handling.
 ///

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -887,8 +887,7 @@ template <typename T> ErrorOr<T> expectedToErrorOr(Expected<T> &&E) {
 ///
 /// StringError is useful in cases where the client is not expected to be able
 /// to consume the specific error message programmatically (for example, if the
-/// error message is to be presented to the user). It cannot be converted to a
-/// std::error_code.
+/// error message is to be presented to the user).
 class StringError : public ErrorInfo<StringError> {
 public:
   static char ID;

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -148,7 +148,7 @@ class LLVM_NODISCARD Error {
 public:
   /// Create a success value. Prefer using 'Error::success()' for readability
   /// where possible.
-  Error() {
+  Error() : Payload(nullptr) {
     setPtr(nullptr);
     setChecked(false);
   }
@@ -163,7 +163,7 @@ public:
   /// Move-construct an error value. The newly constructed error is considered
   /// unchecked, even if the source error had been checked. The original error
   /// becomes a checked Success value, regardless of its original state.
-  Error(Error &&Other) {
+  Error(Error &&Other) : Payload(nullptr) {
     setChecked(true);
     *this = std::move(Other);
   }
@@ -234,16 +234,17 @@ private:
   }
 
   ErrorInfoBase *getPtr() const {
-#ifndef NDEBUG
-    return PayloadAndCheckedBit.getPointer();
-#else
-    return Payload;
-#endif
+    return reinterpret_cast<ErrorInfoBase*>(
+             reinterpret_cast<uintptr_t>(Payload) &
+             ~static_cast<uintptr_t>(0x1));
   }
 
   void setPtr(ErrorInfoBase *EI) {
 #ifndef NDEBUG
-    PayloadAndCheckedBit.setPointer(EI);
+    Payload = reinterpret_cast<ErrorInfoBase*>(
+                (reinterpret_cast<uintptr_t>(EI) &
+                 ~static_cast<uintptr_t>(0x1)) |
+                (reinterpret_cast<uintptr_t>(Payload) & 0x1));
 #else
     Payload = EI;
 #endif
@@ -251,16 +252,17 @@ private:
 
   bool getChecked() const {
 #ifndef NDEBUG
-    return PayloadAndCheckedBit.getInt();
+    return (reinterpret_cast<uintptr_t>(Payload) & 0x1) == 0;
 #else
     return true;
 #endif
   }
 
   void setChecked(bool V) {
-#ifndef NDEBUG
-    PayloadAndCheckedBit.setInt(V);
-#endif
+    Payload = reinterpret_cast<ErrorInfoBase*>(
+                (reinterpret_cast<uintptr_t>(Payload) &
+                  ~static_cast<uintptr_t>(0x1)) |
+                  (V ? 0 : 1));
   }
 
   std::unique_ptr<ErrorInfoBase> takePayload() {
@@ -270,11 +272,7 @@ private:
     return Tmp;
   }
 
-#ifndef NDEBUG
-  PointerIntPair<ErrorInfoBase *, 1> PayloadAndCheckedBit;
-#else
   ErrorInfoBase *Payload;
-#endif
 };
 
 /// Make a Error instance representing failure using the given error info
@@ -624,11 +622,17 @@ private:
 public:
   /// Create an Expected<T> error value from the given Error.
   Expected(Error Err)
-      : HasError(true)
+      : HasError(true),
 #ifndef NDEBUG
-        ,
-        Checked(false)
+        // Expected is unchecked upon construction in Debug builds.
+        Unchecked(true)
+#else
+        // Expected's unchecked flag is set to false in Release builds. This
+        // allows Expected values constructed in a Release build library to be
+        // consumed by a Debug build application.
+        Unchecked(false)
 #endif
+
   {
     assert(Err && "Cannot create Expected<T> from Error success value.");
     new (getErrorStorage()) Error(std::move(Err));
@@ -640,10 +644,15 @@ public:
   Expected(OtherT &&Val,
            typename std::enable_if<std::is_convertible<OtherT, T>::value>::type
                * = nullptr)
-      : HasError(false)
+      : HasError(false),
 #ifndef NDEBUG
-        ,
-        Checked(false)
+        // Expected is unchecked upon construction in Debug builds.
+        Unchecked(true)
+#else
+        // Expected's 'unchecked' flag is set to false in Release builds. This
+        // allows Expected values constructed in a Release build library to be
+        // consumed by a Debug build application.
+        Unchecked(false)
 #endif
   {
     new (getStorage()) storage_type(std::forward<OtherT>(Val));
@@ -689,7 +698,7 @@ public:
   /// \brief Return false if there is an error.
   explicit operator bool() {
 #ifndef NDEBUG
-    Checked = !HasError;
+    Unchecked = HasError;
 #endif
     return !HasError;
   }
@@ -717,7 +726,7 @@ public:
   /// be made on the Expected<T> vaule.
   Error takeError() {
 #ifndef NDEBUG
-    Checked = true;
+    Unchecked = false;
 #endif
     return HasError ? Error(std::move(*getErrorStorage())) : Error::success();
   }
@@ -759,11 +768,8 @@ private:
 
   template <class OtherT> void moveConstruct(Expected<OtherT> &&Other) {
     HasError = Other.HasError;
-
-#ifndef NDEBUG
-    Checked = false;
-    Other.Checked = true;
-#endif
+    Unchecked = true;
+    Other.Unchecked = false;
 
     if (!HasError)
       new (getStorage()) storage_type(std::move(*Other.getStorage()));
@@ -806,7 +812,7 @@ private:
 
   void assertIsChecked() {
 #ifndef NDEBUG
-    if (!Checked) {
+    if (Unchecked) {
       dbgs() << "Expected<T> must be checked before access or destruction.\n";
       if (HasError) {
         dbgs() << "Unchecked Expected<T> contained error:\n";
@@ -825,9 +831,7 @@ private:
     AlignedCharArrayUnion<error_type> ErrorStorage;
   };
   bool HasError : 1;
-#ifndef NDEBUG
-  bool Checked : 1;
-#endif
+  bool Unchecked : 1;
 };
 
 /// This class wraps a std::error_code in a Error.

--- a/include/llvm/Support/Error.h
+++ b/include/llvm/Support/Error.h
@@ -27,6 +27,7 @@ namespace llvm {
 
 class Error;
 class ErrorList;
+class ErrorSuccess;
 
 /// Base class for error info classes. Do not extend this directly: Extend
 /// the ErrorInfo template subclass instead.
@@ -153,9 +154,8 @@ protected:
   }
 
 public:
-  /// Create a success value. This is equivalent to calling the default
-  /// constructor, but should be preferred for readability where possible.
-  static Error success() { return Error(); }
+  /// Create a success value.
+  static ErrorSuccess success();
 
   // Errors are not copy-constructable.
   Error(const Error &Other) = delete;
@@ -274,6 +274,13 @@ private:
 
   ErrorInfoBase *Payload;
 };
+
+/// Subclass of Error for the sole purpose of identifying the success path in
+/// the type system. This allows to catch invalid conversion to Expected<T> at
+/// compile time.
+class ErrorSuccess : public Error {};
+
+inline ErrorSuccess Error::success() { return ErrorSuccess(); }
 
 /// Make a Error instance representing failure using the given error info
 /// type.
@@ -637,6 +644,11 @@ public:
     assert(Err && "Cannot create Expected<T> from Error success value.");
     new (getErrorStorage()) error_type(Err.takePayload());
   }
+
+  /// Forbid to convert from Error::success() implicitly, this avoids having
+  /// Expected<T> foo() { return Error::success(); } which compiles otherwise
+  /// but triggers the assertion above.
+  Expected(ErrorSuccess) = delete;
 
   /// Create an Expected<T> success value from the given OtherT value, which
   /// must be convertible to T.

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -59,6 +59,7 @@ add_llvm_library(LLVMSupport
   DeltaAlgorithm.cpp
   DAGDeltaAlgorithm.cpp
   Dwarf.cpp
+  Error.cpp
   ErrorHandling.cpp
   FileUtilities.cpp
   FileOutputBuffer.cpp

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -1,0 +1,45 @@
+//===----- lib/Support/Error.cpp - Error and associated utilities ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/ManagedStatic.h"
+
+using namespace llvm;
+
+namespace {
+
+  enum class ErrorErrorCode {
+    MultipleErrors
+  };
+
+  class ErrorErrorCategory : public std::error_category {
+  public:
+    const char *name() const LLVM_NOEXCEPT override { return "Error"; }
+
+    std::string message(int condition) const override {
+      switch (static_cast<ErrorErrorCode>(condition)) {
+      case ErrorErrorCode::MultipleErrors:
+        return "Multiple errors";
+      };
+      llvm_unreachable("Unhandled error code");
+    }
+  };
+
+};
+
+void ErrorInfoBase::anchor() {}
+char ErrorInfoBase::ID = 0;
+
+static ManagedStatic<ErrorErrorCategory> ErrorErrorCat;
+
+std::error_code ErrorList::convertToErrorCode() const {
+  return std::error_code(static_cast<int>(ErrorErrorCode::MultipleErrors),
+                         *ErrorErrorCat);
+}

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -36,9 +36,8 @@ namespace {
 
 void ErrorInfoBase::anchor() {}
 char ErrorInfoBase::ID = 0;
-
-template <> char ErrorInfo<ErrorList>::ID = 0;
-template <> char ErrorInfo<ECError>::ID = 0;
+char ErrorList::ID = 0;
+char ECError::ID = 0;
 
 static ManagedStatic<ErrorErrorCategory> ErrorErrorCat;
 

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -37,6 +37,9 @@ namespace {
 void ErrorInfoBase::anchor() {}
 char ErrorInfoBase::ID = 0;
 
+template <> char ErrorInfo<ErrorList>::ID = 0;
+template <> char ErrorInfo<ECError>::ID = 0;
+
 static ManagedStatic<ErrorErrorCategory> ErrorErrorCat;
 
 std::error_code ErrorList::convertToErrorCode() const {

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -20,7 +20,7 @@ namespace {
 
   enum class ErrorErrorCode : int {
     MultipleErrors = 1,
-    UnconvertibleError
+    InconvertibleError
   };
 
   class ErrorErrorCategory : public std::error_category {
@@ -31,8 +31,8 @@ namespace {
       switch (static_cast<ErrorErrorCode>(condition)) {
       case ErrorErrorCode::MultipleErrors:
         return "Multiple errors";
-      case ErrorErrorCode::UnconvertibleError:
-        return "Unconvertible error value. An error has occurred that could "
+      case ErrorErrorCode::InconvertibleError:
+        return "Inconvertible error value. An error has occurred that could "
                "not be converted to a known std::error_code. Please file a "
                "bug.";
       }
@@ -58,8 +58,8 @@ std::error_code ErrorList::convertToErrorCode() const {
                          *ErrorErrorCat);
 }
 
-std::error_code unconvertibleErrorCode() {
-  return std::error_code(static_cast<int>(ErrorErrorCode::UnconvertibleError),
+std::error_code inconvertibleErrorCode() {
+  return std::error_code(static_cast<int>(ErrorErrorCode::InconvertibleError),
                          *ErrorErrorCat);
 }
 
@@ -74,7 +74,7 @@ std::error_code errorToErrorCode(Error Err) {
   handleAllErrors(std::move(Err), [&](const ErrorInfoBase &EI) {
     EC = EI.convertToErrorCode();
   });
-  if (EC == unconvertibleErrorCode())
+  if (EC == inconvertibleErrorCode())
     report_fatal_error(EC.message());
   return EC;
 }

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -52,6 +52,15 @@ char ErrorList::ID = 0;
 char ECError::ID = 0;
 char StringError::ID = 0;
 
+void logAllUnhandledErrors(Error E, raw_ostream &OS, Twine ErrorBanner) {
+  if (!E)
+    return;
+  OS << ErrorBanner;
+  handleAllErrors(std::move(E), [&](const ErrorInfoBase &EI) {
+    EI.log(OS);
+    OS << "\n";
+  });
+}
 
 std::error_code ErrorList::convertToErrorCode() const {
   return std::error_code(static_cast<int>(ErrorErrorCode::MultipleErrors),

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -8,15 +8,19 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Error.h"
+
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ManagedStatic.h"
+
 
 using namespace llvm;
 
 namespace {
 
-  enum class ErrorErrorCode {
-    MultipleErrors
+  enum class ErrorErrorCode : int {
+    MultipleErrors = 1,
+    UnconvertibleError
   };
 
   class ErrorErrorCategory : public std::error_category {
@@ -27,21 +31,61 @@ namespace {
       switch (static_cast<ErrorErrorCode>(condition)) {
       case ErrorErrorCode::MultipleErrors:
         return "Multiple errors";
-      };
+      case ErrorErrorCode::UnconvertibleError:
+        return "Unconvertible error value. An error has occurred that could "
+               "not be converted to a known std::error_code. Please file a "
+               "bug.";
+      }
       llvm_unreachable("Unhandled error code");
     }
   };
 
 };
 
+static ManagedStatic<ErrorErrorCategory> ErrorErrorCat;
+
+namespace llvm {
+
 void ErrorInfoBase::anchor() {}
 char ErrorInfoBase::ID = 0;
 char ErrorList::ID = 0;
 char ECError::ID = 0;
+char StringError::ID = 0;
 
-static ManagedStatic<ErrorErrorCategory> ErrorErrorCat;
 
 std::error_code ErrorList::convertToErrorCode() const {
   return std::error_code(static_cast<int>(ErrorErrorCode::MultipleErrors),
                          *ErrorErrorCat);
+}
+
+std::error_code unconvertibleErrorCode() {
+  return std::error_code(static_cast<int>(ErrorErrorCode::UnconvertibleError),
+                         *ErrorErrorCat);
+}
+
+Error errorCodeToError(std::error_code EC) {
+  if (!EC)
+    return Error::success();
+  return Error(llvm::make_unique<ECError>(ECError(EC)));
+}
+
+std::error_code errorToErrorCode(Error Err) {
+  std::error_code EC;
+  handleAllErrors(std::move(Err), [&](const ErrorInfoBase &EI) {
+    EC = EI.convertToErrorCode();
+  });
+  if (EC == unconvertibleErrorCode())
+    report_fatal_error(EC.message());
+  return EC;
+}
+
+StringError::StringError(const Twine &S, std::error_code EC)
+    : Msg(S.str()), EC(EC) {}
+
+void StringError::log(raw_ostream &OS) const { OS << Msg; }
+
+std::error_code StringError::convertToErrorCode() const {
+  return EC;
+}
+
 }

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -161,9 +161,6 @@ void LLVMResetFatalErrorHandler() {
   remove_fatal_error_handler();
 }
 
-void ErrorInfoBase::anchor() {}
-char ErrorInfoBase::ID = 0;
-
 #ifdef LLVM_ON_WIN32
 
 #include <winerror.h>

--- a/lib/Support/ErrorHandling.cpp
+++ b/lib/Support/ErrorHandling.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Config/config.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/MutexGuard.h"
@@ -159,6 +160,9 @@ void LLVMInstallFatalErrorHandler(LLVMFatalErrorHandler Handler) {
 void LLVMResetFatalErrorHandler() {
   remove_fatal_error_handler();
 }
+
+void ErrorInfoBase::anchor() {}
+char ErrorInfoBase::ID = 0;
 
 #ifdef LLVM_ON_WIN32
 

--- a/unittests/Support/CMakeLists.txt
+++ b/unittests/Support/CMakeLists.txt
@@ -32,6 +32,7 @@ add_llvm_unittest(SupportTests
   DwarfTest.cpp
   EndianStreamTest.cpp
   EndianTest.cpp
+  ErrorTest.cpp
   ErrorOrTest.cpp
   #FileOutputBufferTest.cpp # HLSL Change
   IteratorTest.cpp

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -1,0 +1,458 @@
+//===----- unittests/ErrorTest.cpp - Error.h tests ------------------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/Errc.h"
+#include "gtest/gtest.h"
+#include <memory>
+
+using namespace llvm;
+
+namespace {
+
+// Test:
+//
+// Constructing success.
+//   - Silent acceptance of tested success.
+//   - Programmatic error on untested success.
+//
+// Custom error class.
+//   - Creation of a custom error class with a default base class.
+//   - Handling of a custom error class with a default base class.
+//   - Handler type deduction.
+//   - Failure to handle a custom error class.
+//   - Isa testing of a custom error class.
+//
+//   - Creation of a custom error class with a custom base class.
+//   - Handling of a custom error class with a default base class.
+//   - Correct shadowing of handlers.
+//
+// Utility functions:
+//   - join_errors to defer errors.
+//   - consume_error to consume a "safe" error without any output.
+//   - handleAllUnhandledErrors to assert that all errors are handled.
+//   - logAllUnhandledErrors to log errors to a stream.
+//
+// Expected tests:
+//   - Expected<T> with T.
+//   - Expected<T> with Error.
+//   - Failure to handle an Expected<T> in failure mode.
+//   - Error extraction (Expected -> Error).
+//
+// std::error_code:
+//   - std::error_code to Error in success mode.
+//   - std::error_code to Error (ECError) in failure mode.
+//   - Error to std::error_code in success mode.
+//   - Error (ECError) to std::error_code in failure mode.
+
+// Custom error class with a default base class and some random 'info' attached.
+class CustomError : public ErrorInfo<CustomError> {
+public:
+  // Create an error with some info attached.
+  CustomError(int Info) : Info(Info) {}
+
+  // Get the info attached to this error.
+  int getInfo() const { return Info; }
+
+  // Log this error to a stream.
+  void log(raw_ostream &OS) const override {
+    OS << "CustomError { " << getInfo() << "}";
+  }
+
+protected:
+  // This error is subclassed below, but we can't use inheriting constructors
+  // yet, so we can't propagate the constructors through ErrorInfo. Instead
+  // we have to have a default constructor and have the subclass initialize all
+  // fields.
+  CustomError() : Info(0) {}
+
+  int Info;
+};
+
+// Custom error class with a custom base class and some additional random
+// 'info'.
+class CustomSubError : public ErrorInfo<CustomSubError, CustomError> {
+public:
+  // Create a sub-error with some info attached.
+  CustomSubError(int Info, int ExtraInfo) : ExtraInfo(ExtraInfo) {
+    this->Info = Info;
+  }
+
+  // Get the extra info attached to this error.
+  int getExtraInfo() const { return ExtraInfo; }
+
+  // Log this error to a stream.
+  void log(raw_ostream &OS) const override {
+    OS << "CustomSubError { " << getInfo() << ", " << getExtraInfo() << "}";
+  }
+
+protected:
+  int ExtraInfo;
+};
+
+// Verify that success values that are checked (i.e. cast to 'bool') are
+// destructed without error, and that unchecked success values cause an
+// abort.
+TEST(Error, CheckSuccess) {
+  // Test checked success.
+  {
+    Error E;
+    EXPECT_FALSE(E) << "Unexpected error while testing Error 'Success'";
+  }
+
+// Test unchecked success.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  {
+    auto DropUncheckedSuccess = []() { Error E; };
+    EXPECT_DEATH(DropUncheckedSuccess(),
+                 "Program aborted due to an unhandled Error:")
+        << "Unchecked Error Succes value did not cause abort()";
+  }
+#endif
+}
+
+static Error handleCustomError(const CustomError &CE) { return Error(); }
+
+static void handleCustomErrorVoid(const CustomError &CE) {}
+
+static Error handleCustomErrorUP(std::unique_ptr<CustomError> CE) {
+  return Error();
+}
+
+static void handleCustomErrorUPVoid(std::unique_ptr<CustomError> CE) {}
+
+// Verify creation and handling of custom error classes.
+TEST(Error, CheckCustomErrors) {
+// Check that we abort on unhandled failure cases. (Force conversion to bool
+// to make sure that we don't accidentally treat checked errors as handled).
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  {
+    auto DropUnhandledError = []() {
+      Error E = make_error<CustomError>(42);
+      (void)!E;
+    };
+    EXPECT_DEATH(DropUnhandledError(),
+                 "Program aborted due to an unhandled Error:")
+        << "Unhandled Error failure value did not cause abort()";
+  }
+#endif
+
+  // Check 'isA' handling.
+  {
+    Error E = make_error<CustomError>(1);
+    Error F = make_error<CustomSubError>(1, 2);
+
+    EXPECT_TRUE(E.isA<CustomError>());
+    EXPECT_FALSE(E.isA<CustomSubError>());
+    EXPECT_TRUE(F.isA<CustomError>());
+    EXPECT_TRUE(F.isA<CustomSubError>());
+
+    consumeError(std::move(E));
+    consumeError(std::move(F));
+  }
+
+  // Check that we can handle a custom error.
+  {
+    int CaughtErrorInfo = 0;
+    handleAllErrors(make_error<CustomError>(42), [&](const CustomError &CE) {
+      CaughtErrorInfo = CE.getInfo();
+    });
+
+    EXPECT_TRUE(CaughtErrorInfo == 42)
+        << "Wrong result from CustomError handler";
+  }
+
+  // Check that handler type deduction also works for handlers
+  // of the following types:
+  // void (const Err&)
+  // Error (const Err&) mutable
+  // void (const Err&) mutable
+  // Error (Err&)
+  // void (Err&)
+  // Error (Err&) mutable
+  // void (Err&) mutable
+  // Error (unique_ptr<Err>)
+  // void (unique_ptr<Err>)
+  // Error (unique_ptr<Err>) mutable
+  // void (unique_ptr<Err>) mutable
+
+  handleAllErrors(make_error<CustomError>(42), [](const CustomError &CE) {});
+
+  handleAllErrors(
+      make_error<CustomError>(42),
+      [](const CustomError &CE) mutable { return Error::success(); });
+
+  handleAllErrors(make_error<CustomError>(42),
+                  [](const CustomError &CE) mutable {});
+
+  handleAllErrors(make_error<CustomError>(42),
+                  [](CustomError &CE) { return Error::success(); });
+
+  handleAllErrors(make_error<CustomError>(42), [](CustomError &CE) {});
+
+  handleAllErrors(make_error<CustomError>(42),
+                  [](CustomError &CE) mutable { return Error::success(); });
+
+  handleAllErrors(make_error<CustomError>(42), [](CustomError &CE) mutable {});
+
+  handleAllErrors(
+      make_error<CustomError>(42),
+      [](std::unique_ptr<CustomError> CE) { return Error::success(); });
+
+  handleAllErrors(make_error<CustomError>(42),
+                  [](std::unique_ptr<CustomError> CE) {});
+
+  handleAllErrors(
+      make_error<CustomError>(42),
+      [](std::unique_ptr<CustomError> CE) mutable { return Error::success(); });
+
+  handleAllErrors(make_error<CustomError>(42),
+                  [](std::unique_ptr<CustomError> CE) mutable {});
+
+  // Check that named handlers of type 'Error (const Err&)' work.
+  handleAllErrors(make_error<CustomError>(42), handleCustomError);
+
+  // Check that named handlers of type 'void (const Err&)' work.
+  handleAllErrors(make_error<CustomError>(42), handleCustomErrorVoid);
+
+  // Check that named handlers of type 'Error (std::unique_ptr<Err>)' work.
+  handleAllErrors(make_error<CustomError>(42), handleCustomErrorUP);
+
+  // Check that named handlers of type 'Error (std::unique_ptr<Err>)' work.
+  handleAllErrors(make_error<CustomError>(42), handleCustomErrorUPVoid);
+
+  // Check that we can handle a custom error with a custom base class.
+  {
+    int CaughtErrorInfo = 0;
+    int CaughtErrorExtraInfo = 0;
+    handleAllErrors(make_error<CustomSubError>(42, 7),
+                    [&](const CustomSubError &SE) {
+                      CaughtErrorInfo = SE.getInfo();
+                      CaughtErrorExtraInfo = SE.getExtraInfo();
+                    });
+
+    EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7)
+        << "Wrong result from CustomSubError handler";
+  }
+
+  // Check that we trigger only the first handler that applies.
+  {
+    int DummyInfo = 0;
+    int CaughtErrorInfo = 0;
+    int CaughtErrorExtraInfo = 0;
+
+    handleAllErrors(make_error<CustomSubError>(42, 7),
+                    [&](const CustomSubError &SE) {
+                      CaughtErrorInfo = SE.getInfo();
+                      CaughtErrorExtraInfo = SE.getExtraInfo();
+                    },
+                    [&](const CustomError &CE) { DummyInfo = CE.getInfo(); });
+
+    EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7 &&
+                DummyInfo == 0)
+        << "Activated the wrong Error handler(s)";
+  }
+
+  // Check that general handlers shadow specific ones.
+  {
+    int CaughtErrorInfo = 0;
+    int DummyInfo = 0;
+    int DummyExtraInfo = 0;
+
+    handleAllErrors(
+        make_error<CustomSubError>(42, 7),
+        [&](const CustomError &CE) { CaughtErrorInfo = CE.getInfo(); },
+        [&](const CustomSubError &SE) {
+          DummyInfo = SE.getInfo();
+          DummyExtraInfo = SE.getExtraInfo();
+        });
+
+    EXPECT_TRUE(CaughtErrorInfo = 42 && DummyInfo == 0 && DummyExtraInfo == 0)
+        << "General Error handler did not shadow specific handler";
+  }
+}
+
+// Test utility functions.
+TEST(Error, CheckErrorUtilities) {
+
+  // Test joinErrors
+  {
+    int CustomErrorInfo1 = 0;
+    int CustomErrorInfo2 = 0;
+    int CustomErrorExtraInfo = 0;
+    Error E = joinErrors(make_error<CustomError>(7),
+                         make_error<CustomSubError>(42, 7));
+
+    handleAllErrors(std::move(E),
+                    [&](const CustomSubError &SE) {
+                      CustomErrorInfo2 = SE.getInfo();
+                      CustomErrorExtraInfo = SE.getExtraInfo();
+                    },
+                    [&](const CustomError &CE) {
+                      // Assert that the CustomError instance above is handled
+                      // before the
+                      // CustomSubError - joinErrors should preserve error
+                      // ordering.
+                      EXPECT_EQ(CustomErrorInfo2, 0)
+                          << "CustomErrorInfo2 should be 0 here. "
+                             "joinErrors failed to preserve ordering.\n";
+                      CustomErrorInfo1 = CE.getInfo();
+                    });
+
+    EXPECT_TRUE(CustomErrorInfo1 == 7 && CustomErrorInfo2 == 42 &&
+                CustomErrorExtraInfo == 7)
+        << "Failed handling compound Error.";
+  }
+
+  // Test consumeError for both success and error cases.
+  {
+    Error E;
+    consumeError(std::move(E));
+  }
+  {
+    Error E = make_error<CustomError>(7);
+    consumeError(std::move(E));
+  }
+
+// Test that handleAllUnhandledErrors crashes if an error is not caught.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  {
+    auto FailToHandle = []() {
+      handleAllErrors(make_error<CustomError>(7),
+                      [&](const CustomSubError &SE) {
+                        errs() << "This should never be called";
+                        exit(1);
+                      });
+    };
+
+    EXPECT_DEATH(FailToHandle(), "Program aborted due to an unhandled Error:")
+        << "Unhandled Error in handleAllErrors call did not cause an "
+           "abort()";
+  }
+#endif
+
+// Test that handleAllUnhandledErrors crashes if an error is returned from a
+// handler.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  {
+    auto ReturnErrorFromHandler = []() {
+      handleAllErrors(make_error<CustomError>(7),
+                      [&](std::unique_ptr<CustomSubError> SE) {
+                        return Error(std::move(SE));
+                      });
+    };
+
+    EXPECT_DEATH(ReturnErrorFromHandler(),
+                 "Program aborted due to an unhandled Error:")
+        << " Error returned from handler in handleAllErrors call did not "
+           "cause abort()";
+  }
+#endif
+
+  // Test that we can return values from handleErrors.
+  {
+    int ErrorInfo = 0;
+
+    Error E = handleErrors(
+        make_error<CustomError>(7),
+        [&](std::unique_ptr<CustomError> CE) { return Error(std::move(CE)); });
+
+    handleAllErrors(std::move(E),
+                    [&](const CustomError &CE) { ErrorInfo = CE.getInfo(); });
+
+    EXPECT_EQ(ErrorInfo, 7)
+        << "Failed to handle Error returned from handleErrors.";
+  }
+}
+
+// Test Expected behavior.
+TEST(Error, CheckExpected) {
+
+  // Check that non-errors convert to 'true'.
+  {
+    Expected<int> A = 7;
+    EXPECT_TRUE(!!A)
+        << "Expected with non-error value doesn't convert to 'true'";
+  }
+
+  // Check that non-error values are accessible via operator*.
+  {
+    Expected<int> A = 7;
+    EXPECT_EQ(*A, 7) << "Incorrect Expected non-error value";
+  }
+
+  // Check that errors convert to 'false'.
+  {
+    Expected<int> A = make_error<CustomError>(42);
+    EXPECT_FALSE(!!A) << "Expected with error value doesn't convert to 'false'";
+    consumeError(A.takeError());
+  }
+
+  // Check that error values are accessible via takeError().
+  {
+    Expected<int> A = make_error<CustomError>(42);
+    Error E = A.takeError();
+    EXPECT_TRUE(E.isA<CustomError>()) << "Incorrect Expected error value";
+    consumeError(std::move(E));
+  }
+
+// Check that an Expected instance with an error value doesn't allow access to
+// operator*.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  {
+    Expected<int> A = make_error<CustomError>(42);
+    EXPECT_DEATH(*A, "\\(!HasError && \"Cannot get value "
+                     "when an error exists!\"\\)")
+        << "Incorrect Expected error value";
+    consumeError(A.takeError());
+  }
+#endif
+
+// Check that an Expected instance with an error triggers an abort if
+// unhandled.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+  EXPECT_DEATH({ Expected<int> A = make_error<CustomError>(42); },
+               "Program aborted due to an unhandled Error:")
+      << "Unchecked Expected<T> failure value did not cause an abort()";
+#endif
+
+  // Test covariance of Expected.
+  {
+    class B {};
+    class D : public B {};
+
+    Expected<B *> A1(Expected<D *>(nullptr));
+    A1 = Expected<D *>(nullptr);
+
+    Expected<std::unique_ptr<B>> A2(Expected<std::unique_ptr<D>>(nullptr));
+    A2 = Expected<std::unique_ptr<D>>(nullptr);
+  }
+}
+
+TEST(Error, ECError) {
+
+  // Round-trip a success value to check that it converts correctly.
+  EXPECT_EQ(errorToErrorCode(errorCodeToError(std::error_code())),
+            std::error_code())
+      << "std::error_code() should round-trip via Error conversions";
+
+  // Round-trip an error value to check that it converts correctly.
+  EXPECT_EQ(errorToErrorCode(errorCodeToError(errc::invalid_argument)),
+            errc::invalid_argument)
+      << "std::error_code error value should round-trip via Error "
+         "conversions";
+}
+
+} // end anon namespace

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -45,6 +45,8 @@ protected:
   int Info;
 };
 
+template <> char ErrorInfo<CustomError>::ID = 0;
+
 // Custom error class with a custom base class and some additional random
 // 'info'.
 class CustomSubError : public ErrorInfo<CustomSubError, CustomError> {
@@ -69,6 +71,8 @@ public:
 protected:
   int ExtraInfo;
 };
+
+template <> char ErrorInfo<CustomSubError, CustomError>::ID = 0;
 
 static Error handleCustomError(const CustomError &CE) { return Error(); }
 

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -9,6 +9,7 @@
 
 #include "llvm/Support/Error.h"
 #include "llvm/Support/Errc.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "gtest/gtest.h"
 #include <memory>
 
@@ -28,6 +29,10 @@ public:
   // Log this error to a stream.
   void log(raw_ostream &OS) const override {
     OS << "CustomError { " << getInfo() << "}";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    llvm_unreachable("CustomError doesn't support ECError conversion");
   }
 
 protected:
@@ -55,6 +60,10 @@ public:
   // Log this error to a stream.
   void log(raw_ostream &OS) const override {
     OS << "CustomSubError { " << getInfo() << ", " << getExtraInfo() << "}";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    llvm_unreachable("CustomSubError doesn't support ECError conversion");
   }
 
 protected:

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -441,6 +441,7 @@ TEST(Error, StringError) {
 }
 
 // Test that the ExitOnError utility works as expected.
+#ifdef GTEST_HAS_DEATH_TEST // HLSL Change - Death tests
 TEST(Error, ExitOnError) {
   ExitOnError ExitOnErr;
   ExitOnErr.setBanner("Error in tool:");
@@ -468,6 +469,7 @@ TEST(Error, ExitOnError) {
               ::testing::ExitedWithCode(2), "Error in tool:")
       << "exitOnError returned an unexpected error result";
 }
+#endif // HLSL Change - Death tests
 
 // Test Checked Expected<T> in success mode.
 TEST(Error, CheckedExpectedInSuccessMode) {

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -121,14 +121,15 @@ static void handleCustomErrorUPVoid(std::unique_ptr<CustomError> CE) {}
 // Test that success values implicitly convert to false, and don't cause crashes
 // once they've been implicitly converted.
 TEST(Error, CheckedSuccess) {
-  Error E;
+  Error E = Error::success();
   EXPECT_FALSE(E) << "Unexpected error while testing Error 'Success'";
 }
 
 // Test that unchecked succes values cause an abort.
 #ifndef NDEBUG
 TEST(Error, UncheckedSuccess) {
-  EXPECT_DEATH({ Error E; }, "Program aborted due to an unhandled Error:")
+  EXPECT_DEATH({ Error E = Error::success(); },
+               "Program aborted due to an unhandled Error:")
       << "Unchecked Error Succes value did not cause abort()";
 }
 #endif
@@ -145,7 +146,7 @@ void errAsOutParamHelper(Error &Err) {
 
 // Test that ErrorAsOutParameter sets the checked flag on construction.
 TEST(Error, ErrorAsOutParameterChecked) {
-  Error E;
+  Error E = Error::success();
   errAsOutParamHelper(E);
   (void)!!E;
 }
@@ -153,7 +154,7 @@ TEST(Error, ErrorAsOutParameterChecked) {
 // Test that ErrorAsOutParameter clears the checked flag on destruction.
 #ifndef NDEBUG
 TEST(Error, ErrorAsOutParameterUnchecked) {
-  EXPECT_DEATH({ Error E; errAsOutParamHelper(E); },
+  EXPECT_DEATH({ Error E = Error::success(); errAsOutParamHelper(E); },
                "Program aborted due to an unhandled Error:")
       << "ErrorAsOutParameter did not clear the checked flag on destruction.";
 }
@@ -223,31 +224,31 @@ TEST(Error, HandlerTypeDeduction) {
 
   handleAllErrors(
       make_error<CustomError>(42),
-      [](const CustomError &CE) mutable { return Error::success(); });
+      [](const CustomError &CE) mutable  -> Error { return Error::success(); });
 
   handleAllErrors(make_error<CustomError>(42),
                   [](const CustomError &CE) mutable {});
 
   handleAllErrors(make_error<CustomError>(42),
-                  [](CustomError &CE) { return Error::success(); });
+                  [](CustomError &CE) -> Error { return Error::success(); });
 
   handleAllErrors(make_error<CustomError>(42), [](CustomError &CE) {});
 
   handleAllErrors(make_error<CustomError>(42),
-                  [](CustomError &CE) mutable { return Error::success(); });
+                  [](CustomError &CE) mutable -> Error { return Error::success(); });
 
   handleAllErrors(make_error<CustomError>(42), [](CustomError &CE) mutable {});
 
   handleAllErrors(
       make_error<CustomError>(42),
-      [](std::unique_ptr<CustomError> CE) { return Error::success(); });
+      [](std::unique_ptr<CustomError> CE) -> Error { return Error::success(); });
 
   handleAllErrors(make_error<CustomError>(42),
                   [](std::unique_ptr<CustomError> CE) {});
 
   handleAllErrors(
       make_error<CustomError>(42),
-      [](std::unique_ptr<CustomError> CE) mutable { return Error::success(); });
+      [](std::unique_ptr<CustomError> CE) mutable -> Error { return Error::success(); });
 
   handleAllErrors(make_error<CustomError>(42),
                   [](std::unique_ptr<CustomError> CE) mutable {});
@@ -391,7 +392,7 @@ TEST(Error, CheckJoinErrors) {
 
 // Test that we can consume success values.
 TEST(Error, ConsumeSuccess) {
-  Error E;
+  Error E = Error::success();
   consumeError(std::move(E));
 }
 

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -133,7 +133,7 @@ TEST(Error, UncheckedSuccess) {
 
 // ErrorAsOutParameter tester.
 void errAsOutParamHelper(Error &Err) {
-  ErrorAsOutParameter ErrAsOutParam(Err);
+  ErrorAsOutParameter ErrAsOutParam(&Err);
   // Verify that checked flag is raised - assignment should not crash.
   Err = Error::success();
   // Raise the checked bit manually - caller should still have to test the

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -431,12 +431,46 @@ TEST(Error, ExitOnError) {
       << "exitOnError returned an unexpected error result";
 }
 
-// Test Expected<T> in success mode.
-TEST(Error, ExpectedInSuccessMode) {
+// Test Checked Expected<T> in success mode.
+TEST(Error, CheckedExpectedInSuccessMode) {
   Expected<int> A = 7;
   EXPECT_TRUE(!!A) << "Expected with non-error value doesn't convert to 'true'";
+  // Access is safe in second test, since we checked the error in the first.
   EXPECT_EQ(*A, 7) << "Incorrect Expected non-error value";
 }
+
+// Test Unchecked Expected<T> in success mode.
+// We expect this to blow up the same way Error would.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+TEST(Error, UncheckedExpectedInSuccessModeDestruction) {
+  EXPECT_DEATH({ Expected<int> A = 7; },
+               "Expected<T> must be checked before access or destruction.")
+    << "Unchecekd Expected<T> success value did not cause an abort().";
+}
+#endif
+
+// Test Unchecked Expected<T> in success mode.
+// We expect this to blow up the same way Error would.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+TEST(Error, UncheckedExpectedInSuccessModeAccess) {
+  EXPECT_DEATH({ Expected<int> A = 7; *A; },
+               "Expected<T> must be checked before access or destruction.")
+    << "Unchecekd Expected<T> success value did not cause an abort().";
+}
+#endif
+
+// Test Unchecked Expected<T> in success mode.
+// We expect this to blow up the same way Error would.
+// Test runs in debug mode only.
+#ifndef NDEBUG
+TEST(Error, UncheckedExpectedInSuccessModeAssignment) {
+  EXPECT_DEATH({ Expected<int> A = 7; A = 7; },
+               "Expected<T> must be checked before access or destruction.")
+    << "Unchecekd Expected<T> success value did not cause an abort().";
+}
+#endif
 
 // Test Expected<T> in failure mode.
 TEST(Error, ExpectedInFailureMode) {
@@ -454,7 +488,7 @@ TEST(Error, ExpectedInFailureMode) {
 #ifndef NDEBUG
 TEST(Error, AccessExpectedInFailureMode) {
   Expected<int> A = make_error<CustomError>(42);
-  EXPECT_DEATH(*A, "!HasError && \"Cannot get value when an error exists!\"")
+  EXPECT_DEATH(*A, "Expected<T> must be checked before access or destruction.")
       << "Incorrect Expected error value";
   consumeError(A.takeError());
 }
@@ -468,7 +502,7 @@ TEST(Error, AccessExpectedInFailureMode) {
 #ifndef NDEBUG
 TEST(Error, UnhandledExpectedInFailureMode) {
   EXPECT_DEATH({ Expected<int> A = make_error<CustomError>(42); },
-               "Program aborted due to an unhandled Error:")
+               "Expected<T> must be checked before access or destruction.")
       << "Unchecked Expected<T> failure value did not cause an abort()";
 }
 #endif
@@ -480,10 +514,18 @@ TEST(Error, ExpectedCovariance) {
   class D : public B {};
 
   Expected<B *> A1(Expected<D *>(nullptr));
+  // Check A1 by converting to bool before assigning to it.
+  (void)!!A1;
   A1 = Expected<D *>(nullptr);
+  // Check A1 again before destruction.
+  (void)!!A1;
 
   Expected<std::unique_ptr<B>> A2(Expected<std::unique_ptr<D>>(nullptr));
+  // Check A2 by converting to bool before assigning to it.
+  (void)!!A2;
   A2 = Expected<std::unique_ptr<D>>(nullptr);
+  // Check A2 again before destruction.
+  (void)!!A2;
 }
 
 TEST(Error, ErrorCodeConversions) {

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -8,6 +8,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/Support/Error.h"
+
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Errc.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "gtest/gtest.h"
@@ -404,6 +406,20 @@ TEST(Error, CatchErrorFromHandler) {
 
   EXPECT_EQ(ErrorInfo, 7)
       << "Failed to handle Error returned from handleErrors.";
+}
+
+TEST(Error, StringError) {
+  std::string Msg;
+  raw_string_ostream S(Msg);
+  logAllUnhandledErrors(make_error<StringError>("foo" + Twine(42),
+                                                unconvertibleErrorCode()),
+                        S, "");
+  EXPECT_EQ(S.str(), "foo42\n") << "Unexpected StringError log result";
+
+  auto EC =
+    errorToErrorCode(make_error<StringError>("", errc::invalid_argument));
+  EXPECT_EQ(EC, errc::invalid_argument)
+    << "Failed to convert StringError to error_code.";
 }
 
 // Test that the ExitOnError utility works as expected.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -16,43 +16,6 @@ using namespace llvm;
 
 namespace {
 
-// Test:
-//
-// Constructing success.
-//   - Silent acceptance of tested success.
-//   - Programmatic error on untested success.
-//
-// Custom error class.
-//   - Creation of a custom error class with a default base class.
-//   - Handling of a custom error class with a default base class.
-//   - Handler type deduction.
-//   - Failure to handle a custom error class.
-//   - Isa testing of a custom error class.
-//
-//   - Creation of a custom error class with a custom base class.
-//   - Handling of a custom error class with a default base class.
-//   - Correct shadowing of handlers.
-//
-// Utility functions:
-//   - join_errors to defer errors.
-//   - consume_error to consume a "safe" error without any output.
-//   - handleAllUnhandledErrors to assert that all errors are handled.
-//   - logAllUnhandledErrors to log errors to a stream.
-//   - ExitOnError tests.
-//
-// Expected tests:
-//   - Expected<T> with T.
-//   - Expected<T> with Error.
-//   - Failure to handle an Expected<T> in failure mode.
-//   - Error extraction (Expected -> Error).
-//
-// std::error_code:
-//   - std::error_code to Error in success mode.
-//   - std::error_code to Error (ECError) in failure mode.
-//   - Error to std::error_code in success mode.
-//   - Error (ECError) to std::error_code in failure mode.
-//
-
 // Custom error class with a default base class and some random 'info' attached.
 class CustomError : public ErrorInfo<CustomError> {
 public:
@@ -98,30 +61,6 @@ protected:
   int ExtraInfo;
 };
 
-// Verify that success values that are checked (i.e. cast to 'bool') are
-// destructed without error, and that unchecked success values cause an
-// abort.
-TEST(Error, CheckSuccess) {
-  // Test checked success.
-  {
-    Error E;
-    EXPECT_FALSE(E) << "Unexpected error while testing Error 'Success'";
-  }
-
-// Test unchecked success.
-// Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
-  {
-    auto DropUncheckedSuccess = []() { Error E; };
-    EXPECT_DEATH(DropUncheckedSuccess(),
-                 "Program aborted due to an unhandled Error:")
-        << "Unchecked Error Succes value did not cause abort()";
-  }
-#endif
-#endif
-}
-
 static Error handleCustomError(const CustomError &CE) { return Error(); }
 
 static void handleCustomErrorVoid(const CustomError &CE) {}
@@ -132,66 +71,80 @@ static Error handleCustomErrorUP(std::unique_ptr<CustomError> CE) {
 
 static void handleCustomErrorUPVoid(std::unique_ptr<CustomError> CE) {}
 
-// Verify creation and handling of custom error classes.
-TEST(Error, CheckCustomErrors) {
+// Test that success values implicitly convert to false, and don't cause crashes
+// once they've been implicitly converted.
+TEST(Error, CheckedSuccess) {
+  Error E;
+  EXPECT_FALSE(E) << "Unexpected error while testing Error 'Success'";
+}
+
+// Test that unchecked succes values cause an abort.
+#ifndef NDEBUG
+TEST(Error, UncheckedSuccess) {
+  EXPECT_DEATH({ Error E; }, "Program aborted due to an unhandled Error:")
+      << "Unchecked Error Succes value did not cause abort()";
+}
+#endif
+
 // Check that we abort on unhandled failure cases. (Force conversion to bool
 // to make sure that we don't accidentally treat checked errors as handled).
 // Test runs in debug mode only.
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
-  {
-    auto DropUnhandledError = []() {
-      Error E = make_error<CustomError>(42);
-      (void)!E;
-    };
-    EXPECT_DEATH(DropUnhandledError(),
-                 "Program aborted due to an unhandled Error:")
-        << "Unhandled Error failure value did not cause abort()";
-  }
+TEST(Error, UncheckedError) {
+  auto DropUnhandledError = []() {
+    Error E = make_error<CustomError>(42);
+    (void)!E;
+  };
+  EXPECT_DEATH(DropUnhandledError(),
+               "Program aborted due to an unhandled Error:")
+      << "Unhandled Error failure value did not cause abort()";
+}
 #endif
 #endif
 
+// Check 'Error::isA<T>' method handling.
+TEST(Error, IsAHandling) {
   // Check 'isA' handling.
-  {
-    Error E = make_error<CustomError>(1);
-    Error F = make_error<CustomSubError>(1, 2);
-    Error G = Error::success();
+  Error E = make_error<CustomError>(1);
+  Error F = make_error<CustomSubError>(1, 2);
+  Error G = Error::success();
 
-    EXPECT_TRUE(E.isA<CustomError>());
-    EXPECT_FALSE(E.isA<CustomSubError>());
-    EXPECT_TRUE(F.isA<CustomError>());
-    EXPECT_TRUE(F.isA<CustomSubError>());
-    EXPECT_FALSE(G.isA<CustomError>());
+  EXPECT_TRUE(E.isA<CustomError>());
+  EXPECT_FALSE(E.isA<CustomSubError>());
+  EXPECT_TRUE(F.isA<CustomError>());
+  EXPECT_TRUE(F.isA<CustomSubError>());
+  EXPECT_FALSE(G.isA<CustomError>());
 
-    consumeError(std::move(E));
-    consumeError(std::move(F));
-    consumeError(std::move(G));
-  }
+  consumeError(std::move(E));
+  consumeError(std::move(F));
+  consumeError(std::move(G));
+}
 
-  // Check that we can handle a custom error.
-  {
-    int CaughtErrorInfo = 0;
-    handleAllErrors(make_error<CustomError>(42), [&](const CustomError &CE) {
-      CaughtErrorInfo = CE.getInfo();
-    });
+// Check that we can handle a custom error.
+TEST(Error, HandleCustomError) {
+  int CaughtErrorInfo = 0;
+  handleAllErrors(make_error<CustomError>(42), [&](const CustomError &CE) {
+    CaughtErrorInfo = CE.getInfo();
+  });
 
-    EXPECT_TRUE(CaughtErrorInfo == 42)
-        << "Wrong result from CustomError handler";
-  }
+  EXPECT_TRUE(CaughtErrorInfo == 42) << "Wrong result from CustomError handler";
+}
 
-  // Check that handler type deduction also works for handlers
-  // of the following types:
-  // void (const Err&)
-  // Error (const Err&) mutable
-  // void (const Err&) mutable
-  // Error (Err&)
-  // void (Err&)
-  // Error (Err&) mutable
-  // void (Err&) mutable
-  // Error (unique_ptr<Err>)
-  // void (unique_ptr<Err>)
-  // Error (unique_ptr<Err>) mutable
-  // void (unique_ptr<Err>) mutable
+// Check that handler type deduction also works for handlers
+// of the following types:
+// void (const Err&)
+// Error (const Err&) mutable
+// void (const Err&) mutable
+// Error (Err&)
+// void (Err&)
+// Error (Err&) mutable
+// void (Err&) mutable
+// Error (unique_ptr<Err>)
+// void (unique_ptr<Err>)
+// Error (unique_ptr<Err>) mutable
+// void (unique_ptr<Err>) mutable
+TEST(Error, HandlerTypeDeduction) {
 
   handleAllErrors(make_error<CustomError>(42), [](const CustomError &CE) {});
 
@@ -237,117 +190,114 @@ TEST(Error, CheckCustomErrors) {
 
   // Check that named handlers of type 'Error (std::unique_ptr<Err>)' work.
   handleAllErrors(make_error<CustomError>(42), handleCustomErrorUPVoid);
-
-  // Check that we can handle a custom error with a custom base class.
-  {
-    int CaughtErrorInfo = 0;
-    int CaughtErrorExtraInfo = 0;
-    handleAllErrors(make_error<CustomSubError>(42, 7),
-                    [&](const CustomSubError &SE) {
-                      CaughtErrorInfo = SE.getInfo();
-                      CaughtErrorExtraInfo = SE.getExtraInfo();
-                    });
-
-    EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7)
-        << "Wrong result from CustomSubError handler";
-  }
-
-  // Check that we trigger only the first handler that applies.
-  {
-    int DummyInfo = 0;
-    int CaughtErrorInfo = 0;
-    int CaughtErrorExtraInfo = 0;
-
-    handleAllErrors(make_error<CustomSubError>(42, 7),
-                    [&](const CustomSubError &SE) {
-                      CaughtErrorInfo = SE.getInfo();
-                      CaughtErrorExtraInfo = SE.getExtraInfo();
-                    },
-                    [&](const CustomError &CE) { DummyInfo = CE.getInfo(); });
-
-    EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7 &&
-                DummyInfo == 0)
-        << "Activated the wrong Error handler(s)";
-  }
-
-  // Check that general handlers shadow specific ones.
-  {
-    int CaughtErrorInfo = 0;
-    int DummyInfo = 0;
-    int DummyExtraInfo = 0;
-
-    handleAllErrors(
-        make_error<CustomSubError>(42, 7),
-        [&](const CustomError &CE) { CaughtErrorInfo = CE.getInfo(); },
-        [&](const CustomSubError &SE) {
-          DummyInfo = SE.getInfo();
-          DummyExtraInfo = SE.getExtraInfo();
-        });
-
-    EXPECT_TRUE(CaughtErrorInfo = 42 && DummyInfo == 0 && DummyExtraInfo == 0)
-        << "General Error handler did not shadow specific handler";
-  }
 }
 
-// Test utility functions.
-TEST(Error, CheckErrorUtilities) {
+// Test that we can handle errors with custom base classes.
+TEST(Error, HandleCustomErrorWithCustomBaseClass) {
+  int CaughtErrorInfo = 0;
+  int CaughtErrorExtraInfo = 0;
+  handleAllErrors(make_error<CustomSubError>(42, 7),
+                  [&](const CustomSubError &SE) {
+                    CaughtErrorInfo = SE.getInfo();
+                    CaughtErrorExtraInfo = SE.getExtraInfo();
+                  });
 
-  // Test joinErrors
-  {
-    int CustomErrorInfo1 = 0;
-    int CustomErrorInfo2 = 0;
-    int CustomErrorExtraInfo = 0;
-    Error E = joinErrors(make_error<CustomError>(7),
-                         make_error<CustomSubError>(42, 7));
+  EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7)
+      << "Wrong result from CustomSubError handler";
+}
 
-    handleAllErrors(std::move(E),
-                    [&](const CustomSubError &SE) {
-                      CustomErrorInfo2 = SE.getInfo();
-                      CustomErrorExtraInfo = SE.getExtraInfo();
-                    },
-                    [&](const CustomError &CE) {
-                      // Assert that the CustomError instance above is handled
-                      // before the
-                      // CustomSubError - joinErrors should preserve error
-                      // ordering.
-                      EXPECT_EQ(CustomErrorInfo2, 0)
-                          << "CustomErrorInfo2 should be 0 here. "
-                             "joinErrors failed to preserve ordering.\n";
-                      CustomErrorInfo1 = CE.getInfo();
-                    });
+// Check that we trigger only the first handler that applies.
+TEST(Error, FirstHandlerOnly) {
+  int DummyInfo = 0;
+  int CaughtErrorInfo = 0;
+  int CaughtErrorExtraInfo = 0;
 
-    EXPECT_TRUE(CustomErrorInfo1 == 7 && CustomErrorInfo2 == 42 &&
-                CustomErrorExtraInfo == 7)
-        << "Failed handling compound Error.";
-  }
+  handleAllErrors(make_error<CustomSubError>(42, 7),
+                  [&](const CustomSubError &SE) {
+                    CaughtErrorInfo = SE.getInfo();
+                    CaughtErrorExtraInfo = SE.getExtraInfo();
+                  },
+                  [&](const CustomError &CE) { DummyInfo = CE.getInfo(); });
 
-  // Test consumeError for both success and error cases.
-  {
-    Error E;
-    consumeError(std::move(E));
-  }
-  {
-    Error E = make_error<CustomError>(7);
-    consumeError(std::move(E));
-  }
+  EXPECT_TRUE(CaughtErrorInfo == 42 && CaughtErrorExtraInfo == 7 &&
+              DummyInfo == 0)
+      << "Activated the wrong Error handler(s)";
+}
+
+// Check that general handlers shadow specific ones.
+TEST(Error, HandlerShadowing) {
+  int CaughtErrorInfo = 0;
+  int DummyInfo = 0;
+  int DummyExtraInfo = 0;
+
+  handleAllErrors(
+      make_error<CustomSubError>(42, 7),
+      [&](const CustomError &CE) { CaughtErrorInfo = CE.getInfo(); },
+      [&](const CustomSubError &SE) {
+        DummyInfo = SE.getInfo();
+        DummyExtraInfo = SE.getExtraInfo();
+      });
+
+  EXPECT_TRUE(CaughtErrorInfo = 42 && DummyInfo == 0 && DummyExtraInfo == 0)
+      << "General Error handler did not shadow specific handler";
+}
+
+// Test joinErrors.
+TEST(Error, CheckJoinErrors) {
+  int CustomErrorInfo1 = 0;
+  int CustomErrorInfo2 = 0;
+  int CustomErrorExtraInfo = 0;
+  Error E =
+      joinErrors(make_error<CustomError>(7), make_error<CustomSubError>(42, 7));
+
+  handleAllErrors(std::move(E),
+                  [&](const CustomSubError &SE) {
+                    CustomErrorInfo2 = SE.getInfo();
+                    CustomErrorExtraInfo = SE.getExtraInfo();
+                  },
+                  [&](const CustomError &CE) {
+                    // Assert that the CustomError instance above is handled
+                    // before the
+                    // CustomSubError - joinErrors should preserve error
+                    // ordering.
+                    EXPECT_EQ(CustomErrorInfo2, 0)
+                        << "CustomErrorInfo2 should be 0 here. "
+                           "joinErrors failed to preserve ordering.\n";
+                    CustomErrorInfo1 = CE.getInfo();
+                  });
+
+  EXPECT_TRUE(CustomErrorInfo1 == 7 && CustomErrorInfo2 == 42 &&
+              CustomErrorExtraInfo == 7)
+      << "Failed handling compound Error.";
+}
+
+// Test that we can consume success values.
+TEST(Error, ConsumeSuccess) {
+  Error E;
+  consumeError(std::move(E));
+}
+
+TEST(Error, ConsumeError) {
+  Error E = make_error<CustomError>(7);
+  consumeError(std::move(E));
+}
 
 // Test that handleAllUnhandledErrors crashes if an error is not caught.
 // Test runs in debug mode only.
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
-  {
-    auto FailToHandle = []() {
-      handleAllErrors(make_error<CustomError>(7),
-                      [&](const CustomSubError &SE) {
-                        errs() << "This should never be called";
-                        exit(1);
-                      });
-    };
+TEST(Error, FailureToHandle) {
+  auto FailToHandle = []() {
+    handleAllErrors(make_error<CustomError>(7), [&](const CustomSubError &SE) {
+      errs() << "This should never be called";
+      exit(1);
+    });
+  };
 
-    EXPECT_DEATH(FailToHandle(), "Program aborted due to an unhandled Error:")
-        << "Unhandled Error in handleAllErrors call did not cause an "
-           "abort()";
-  }
+  EXPECT_DEATH(FailToHandle(), "Program aborted due to an unhandled Error:")
+      << "Unhandled Error in handleAllErrors call did not cause an "
+         "abort()";
+}
 #endif
 #endif
 
@@ -356,107 +306,89 @@ TEST(Error, CheckErrorUtilities) {
 // Test runs in debug mode only.
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
-  {
-    auto ReturnErrorFromHandler = []() {
-      handleAllErrors(make_error<CustomError>(7),
-                      [&](std::unique_ptr<CustomSubError> SE) {
-                        return Error(std::move(SE));
-                      });
-    };
+TEST(Error, FailureFromHandler) {
+  auto ReturnErrorFromHandler = []() {
+    handleAllErrors(make_error<CustomError>(7),
+                    [&](std::unique_ptr<CustomSubError> SE) {
+                      return Error(std::move(SE));
+                    });
+  };
 
-    EXPECT_DEATH(ReturnErrorFromHandler(),
-                 "Program aborted due to an unhandled Error:")
-        << " Error returned from handler in handleAllErrors call did not "
-           "cause abort()";
-  }
+  EXPECT_DEATH(ReturnErrorFromHandler(),
+               "Program aborted due to an unhandled Error:")
+      << " Error returned from handler in handleAllErrors call did not "
+         "cause abort()";
+}
 #endif
 #endif
 
-  // Test that we can return values from handleErrors.
-  {
-    int ErrorInfo = 0;
+// Test that we can return values from handleErrors.
+TEST(Error, CatchErrorFromHandler) {
+  int ErrorInfo = 0;
 
-    Error E = handleErrors(
-        make_error<CustomError>(7),
-        [&](std::unique_ptr<CustomError> CE) { return Error(std::move(CE)); });
+  Error E = handleErrors(
+      make_error<CustomError>(7),
+      [&](std::unique_ptr<CustomError> CE) { return Error(std::move(CE)); });
 
-    handleAllErrors(std::move(E),
-                    [&](const CustomError &CE) { ErrorInfo = CE.getInfo(); });
+  handleAllErrors(std::move(E),
+                  [&](const CustomError &CE) { ErrorInfo = CE.getInfo(); });
 
-    EXPECT_EQ(ErrorInfo, 7)
-        << "Failed to handle Error returned from handleErrors.";
-  }
-
-  // Test ExitOnError
-  {
-    ExitOnError ExitOnErr;
-    ExitOnErr.setBanner("Error in tool:");
-    ExitOnErr.setExitCodeMapper(
-      [](const Error &E) {
-        if (E.isA<CustomSubError>())
-          return 2;
-        return 1;
-      });
-
-    // Make sure we don't bail on success.
-    ExitOnErr(Error::success());
-    EXPECT_EQ(ExitOnErr(Expected<int>(7)), 7)
-      << "exitOnError returned an invalid value for Expected";
-
-    // Exit tests.
-    EXPECT_EXIT(ExitOnErr(make_error<CustomError>(7)),
-                ::testing::ExitedWithCode(1), "Error in tool:")
-      << "exitOnError returned an unexpected error result";
-
-    EXPECT_EXIT(ExitOnErr(Expected<int>(make_error<CustomSubError>(0, 0))),
-                ::testing::ExitedWithCode(2), "Error in tool:")
-      << "exitOnError returned an unexpected error result";
-  }
+  EXPECT_EQ(ErrorInfo, 7)
+      << "Failed to handle Error returned from handleErrors.";
 }
 
-// Test Expected behavior.
-TEST(Error, CheckExpected) {
+// Test that the ExitOnError utility works as expected.
+TEST(Error, ExitOnError) {
+  ExitOnError ExitOnErr;
+  ExitOnErr.setBanner("Error in tool:");
+  ExitOnErr.setExitCodeMapper([](const Error &E) {
+    if (E.isA<CustomSubError>())
+      return 2;
+    return 1;
+  });
 
-  // Check that non-errors convert to 'true'.
-  {
-    Expected<int> A = 7;
-    EXPECT_TRUE(!!A)
-        << "Expected with non-error value doesn't convert to 'true'";
-  }
+  // Make sure we don't bail on success.
+  ExitOnErr(Error::success());
+  EXPECT_EQ(ExitOnErr(Expected<int>(7)), 7)
+      << "exitOnError returned an invalid value for Expected";
 
-  // Check that non-error values are accessible via operator*.
-  {
-    Expected<int> A = 7;
-    EXPECT_EQ(*A, 7) << "Incorrect Expected non-error value";
-  }
+  // Exit tests.
+  EXPECT_EXIT(ExitOnErr(make_error<CustomError>(7)),
+              ::testing::ExitedWithCode(1), "Error in tool:")
+      << "exitOnError returned an unexpected error result";
 
-  // Check that errors convert to 'false'.
-  {
-    Expected<int> A = make_error<CustomError>(42);
-    EXPECT_FALSE(!!A) << "Expected with error value doesn't convert to 'false'";
-    consumeError(A.takeError());
-  }
+  EXPECT_EXIT(ExitOnErr(Expected<int>(make_error<CustomSubError>(0, 0))),
+              ::testing::ExitedWithCode(2), "Error in tool:")
+      << "exitOnError returned an unexpected error result";
+}
 
-  // Check that error values are accessible via takeError().
-  {
-    Expected<int> A = make_error<CustomError>(42);
-    Error E = A.takeError();
-    EXPECT_TRUE(E.isA<CustomError>()) << "Incorrect Expected error value";
-    consumeError(std::move(E));
-  }
+// Test Expected<T> in success mode.
+TEST(Error, ExpectedInSuccessMode) {
+  Expected<int> A = 7;
+  EXPECT_TRUE(!!A) << "Expected with non-error value doesn't convert to 'true'";
+  EXPECT_EQ(*A, 7) << "Incorrect Expected non-error value";
+}
+
+// Test Expected<T> in failure mode.
+TEST(Error, ExpectedInFailureMode) {
+  Expected<int> A = make_error<CustomError>(42);
+  EXPECT_FALSE(!!A) << "Expected with error value doesn't convert to 'false'";
+  Error E = A.takeError();
+  EXPECT_TRUE(E.isA<CustomError>()) << "Incorrect Expected error value";
+  consumeError(std::move(E));
+}
 
 // Check that an Expected instance with an error value doesn't allow access to
 // operator*.
 // Test runs in debug mode only.
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
-  {
-    Expected<int> A = make_error<CustomError>(42);
-    EXPECT_DEATH(*A, "\\(!HasError && \"Cannot get value "
-                     "when an error exists!\"\\)")
-        << "Incorrect Expected error value";
-    consumeError(A.takeError());
-  }
+TEST(Error, AccessExpectedInFailureMode) {
+  Expected<int> A = make_error<CustomError>(42);
+  EXPECT_DEATH(*A, "!HasError && \"Cannot get value when an error exists!\"")
+      << "Incorrect Expected error value";
+  consumeError(A.takeError());
+}
 #endif
 #endif
 
@@ -465,27 +397,27 @@ TEST(Error, CheckExpected) {
 // Test runs in debug mode only.
 #ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
+TEST(Error, UnhandledExpectedInFailureMode) {
   EXPECT_DEATH({ Expected<int> A = make_error<CustomError>(42); },
                "Program aborted due to an unhandled Error:")
       << "Unchecked Expected<T> failure value did not cause an abort()";
+}
 #endif
 #endif
 
-  // Test covariance of Expected.
-  {
-    class B {};
-    class D : public B {};
+// Test covariance of Expected.
+TEST(Error, ExpectedCovariance) {
+  class B {};
+  class D : public B {};
 
-    Expected<B *> A1(Expected<D *>(nullptr));
-    A1 = Expected<D *>(nullptr);
+  Expected<B *> A1(Expected<D *>(nullptr));
+  A1 = Expected<D *>(nullptr);
 
-    Expected<std::unique_ptr<B>> A2(Expected<std::unique_ptr<D>>(nullptr));
-    A2 = Expected<std::unique_ptr<D>>(nullptr);
-  }
+  Expected<std::unique_ptr<B>> A2(Expected<std::unique_ptr<D>>(nullptr));
+  A2 = Expected<std::unique_ptr<D>>(nullptr);
 }
 
 TEST(Error, ECError) {
-
   // Round-trip a success value to check that it converts correctly.
   EXPECT_EQ(errorToErrorCode(errorCodeToError(std::error_code())),
             std::error_code())

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -153,14 +153,17 @@ TEST(Error, CheckCustomErrors) {
   {
     Error E = make_error<CustomError>(1);
     Error F = make_error<CustomSubError>(1, 2);
+    Error G = Error::success();
 
     EXPECT_TRUE(E.isA<CustomError>());
     EXPECT_FALSE(E.isA<CustomSubError>());
     EXPECT_TRUE(F.isA<CustomError>());
     EXPECT_TRUE(F.isA<CustomSubError>());
+    EXPECT_FALSE(G.isA<CustomError>());
 
     consumeError(std::move(E));
     consumeError(std::move(F));
+    consumeError(std::move(G));
   }
 
   // Check that we can handle a custom error.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -106,12 +106,14 @@ TEST(Error, CheckSuccess) {
 
 char CustomSubError::ID = 0;
 
-static Error handleCustomError(const CustomError &CE) { return Error(); }
+static Error handleCustomError(const CustomError &CE) {
+  return Error::success();
+}
 
 static void handleCustomErrorVoid(const CustomError &CE) {}
 
 static Error handleCustomErrorUP(std::unique_ptr<CustomError> CE) {
-  return Error();
+  return Error::success();
 }
 
 static void handleCustomErrorUPVoid(std::unique_ptr<CustomError> CE) {}

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -80,30 +80,6 @@ protected:
   int ExtraInfo;
 };
 
-// Verify that success values that are checked (i.e. cast to 'bool') are
-// destructed without error, and that unchecked success values cause an
-// abort.
-TEST(Error, CheckSuccess) {
-  // Test checked success.
-  {
-    Error E;
-    EXPECT_FALSE(E) << "Unexpected error while testing Error 'Success'";
-  }
-
-// Test unchecked success.
-// Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
-  {
-    auto DropUncheckedSuccess = []() { Error E; };
-    EXPECT_DEATH(DropUncheckedSuccess(),
-                 "Program aborted due to an unhandled Error:")
-        << "Unchecked Error Succes value did not cause abort()";
-  }
-#endif
-#endif
-}
-
 char CustomSubError::ID = 0;
 
 static Error handleCustomError(const CustomError &CE) {
@@ -126,7 +102,7 @@ TEST(Error, CheckedSuccess) {
 }
 
 // Test that unchecked succes values cause an abort.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UncheckedSuccess) {
   EXPECT_DEATH({ Error E = Error::success(); },
                "Program aborted due to an unhandled Error:")
@@ -152,7 +128,7 @@ TEST(Error, ErrorAsOutParameterChecked) {
 }
 
 // Test that ErrorAsOutParameter clears the checked flag on destruction.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, ErrorAsOutParameterUnchecked) {
   EXPECT_DEATH({ Error E = Error::success(); errAsOutParamHelper(E); },
                "Program aborted due to an unhandled Error:")
@@ -163,8 +139,7 @@ TEST(Error, ErrorAsOutParameterUnchecked) {
 // Check that we abort on unhandled failure cases. (Force conversion to bool
 // to make sure that we don't accidentally treat checked errors as handled).
 // Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UncheckedError) {
   auto DropUnhandledError = []() {
     Error E = make_error<CustomError>(42);
@@ -174,7 +149,6 @@ TEST(Error, UncheckedError) {
                "Program aborted due to an unhandled Error:")
       << "Unhandled Error failure value did not cause abort()";
 }
-#endif
 #endif
 
 // Check 'Error::isA<T>' method handling.
@@ -312,7 +286,7 @@ TEST(Error, HandlerShadowing) {
         DummyExtraInfo = SE.getExtraInfo();
       });
 
-  EXPECT_TRUE(CaughtErrorInfo = 42 && DummyInfo == 0 && DummyExtraInfo == 0)
+  EXPECT_TRUE(CaughtErrorInfo == 42 && DummyInfo == 0 && DummyExtraInfo == 0)
       << "General Error handler did not shadow specific handler";
 }
 
@@ -403,8 +377,7 @@ TEST(Error, ConsumeError) {
 
 // Test that handleAllUnhandledErrors crashes if an error is not caught.
 // Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, FailureToHandle) {
   auto FailToHandle = []() {
     handleAllErrors(make_error<CustomError>(7), [&](const CustomSubError &SE) {
@@ -418,13 +391,11 @@ TEST(Error, FailureToHandle) {
          "abort()";
 }
 #endif
-#endif
 
 // Test that handleAllUnhandledErrors crashes if an error is returned from a
 // handler.
 // Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, FailureFromHandler) {
   auto ReturnErrorFromHandler = []() {
     handleAllErrors(make_error<CustomError>(7),
@@ -438,7 +409,6 @@ TEST(Error, FailureFromHandler) {
       << " Error returned from handler in handleAllErrors call did not "
          "cause abort()";
 }
-#endif
 #endif
 
 // Test that we can return values from handleErrors.
@@ -520,7 +490,7 @@ TEST(Error, ExpectedWithReferenceType) {
 // Test Unchecked Expected<T> in success mode.
 // We expect this to blow up the same way Error would.
 // Test runs in debug mode only.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UncheckedExpectedInSuccessModeDestruction) {
   EXPECT_DEATH({ Expected<int> A = 7; },
                "Expected<T> must be checked before access or destruction.")
@@ -531,7 +501,7 @@ TEST(Error, UncheckedExpectedInSuccessModeDestruction) {
 // Test Unchecked Expected<T> in success mode.
 // We expect this to blow up the same way Error would.
 // Test runs in debug mode only.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UncheckedExpectedInSuccessModeAccess) {
   EXPECT_DEATH({ Expected<int> A = 7; *A; },
                "Expected<T> must be checked before access or destruction.")
@@ -542,7 +512,7 @@ TEST(Error, UncheckedExpectedInSuccessModeAccess) {
 // Test Unchecked Expected<T> in success mode.
 // We expect this to blow up the same way Error would.
 // Test runs in debug mode only.
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UncheckedExpectedInSuccessModeAssignment) {
   EXPECT_DEATH({ Expected<int> A = 7; A = 7; },
                "Expected<T> must be checked before access or destruction.")
@@ -562,8 +532,7 @@ TEST(Error, ExpectedInFailureMode) {
 // Check that an Expected instance with an error value doesn't allow access to
 // operator*.
 // Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, AccessExpectedInFailureMode) {
   Expected<int> A = make_error<CustomError>(42);
   EXPECT_DEATH(*A, "Expected<T> must be checked before access or destruction.")
@@ -571,19 +540,16 @@ TEST(Error, AccessExpectedInFailureMode) {
   consumeError(A.takeError());
 }
 #endif
-#endif
 
 // Check that an Expected instance with an error triggers an abort if
 // unhandled.
 // Test runs in debug mode only.
-#ifdef GTEST_HAS_DEATH_TEST
-#ifndef NDEBUG
+#if !defined(NDEBUG) && defined(GTEST_HAS_DEATH_TEST) // HLSL Change
 TEST(Error, UnhandledExpectedInFailureMode) {
   EXPECT_DEATH({ Expected<int> A = make_error<CustomError>(42); },
                "Expected<T> must be checked before access or destruction.")
       << "Unchecked Expected<T> failure value did not cause an abort()";
 }
-#endif
 #endif
 
 // Test covariance of Expected.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -340,6 +340,51 @@ TEST(Error, CheckJoinErrors) {
   EXPECT_TRUE(CustomErrorInfo1 == 7 && CustomErrorInfo2 == 42 &&
               CustomErrorExtraInfo == 7)
       << "Failed handling compound Error.";
+
+  // Test appending a single item to a list.
+  {
+    int Sum = 0;
+    handleAllErrors(
+        joinErrors(
+            joinErrors(make_error<CustomError>(7),
+                       make_error<CustomError>(7)),
+            make_error<CustomError>(7)),
+        [&](const CustomError &CE) {
+          Sum += CE.getInfo();
+        });
+    EXPECT_EQ(Sum, 21) << "Failed to correctly append error to error list.";
+  }
+
+  // Test prepending a single item to a list.
+  {
+    int Sum = 0;
+    handleAllErrors(
+        joinErrors(
+            make_error<CustomError>(7),
+            joinErrors(make_error<CustomError>(7),
+                       make_error<CustomError>(7))),
+        [&](const CustomError &CE) {
+          Sum += CE.getInfo();
+        });
+    EXPECT_EQ(Sum, 21) << "Failed to correctly prepend error to error list.";
+  }
+
+  // Test concatenating two error lists.
+  {
+    int Sum = 0;
+    handleAllErrors(
+        joinErrors(
+            joinErrors(
+                make_error<CustomError>(7),
+                make_error<CustomError>(7)),
+            joinErrors(
+                make_error<CustomError>(7),
+                make_error<CustomError>(7))),
+        [&](const CustomError &CE) {
+          Sum += CE.getInfo();
+        });
+    EXPECT_EQ(Sum, 28) << "Failed to correctly concatenate erorr lists.";
+  }
 }
 
 // Test that we can consume success values.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -108,6 +108,7 @@ TEST(Error, CheckSuccess) {
 
 // Test unchecked success.
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   {
     auto DropUncheckedSuccess = []() { Error E; };
@@ -115,6 +116,7 @@ TEST(Error, CheckSuccess) {
                  "Program aborted due to an unhandled Error:")
         << "Unchecked Error Succes value did not cause abort()";
   }
+#endif
 #endif
 }
 
@@ -133,6 +135,7 @@ TEST(Error, CheckCustomErrors) {
 // Check that we abort on unhandled failure cases. (Force conversion to bool
 // to make sure that we don't accidentally treat checked errors as handled).
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   {
     auto DropUnhandledError = []() {
@@ -143,6 +146,7 @@ TEST(Error, CheckCustomErrors) {
                  "Program aborted due to an unhandled Error:")
         << "Unhandled Error failure value did not cause abort()";
   }
+#endif
 #endif
 
   // Check 'isA' handling.
@@ -324,6 +328,7 @@ TEST(Error, CheckErrorUtilities) {
 
 // Test that handleAllUnhandledErrors crashes if an error is not caught.
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   {
     auto FailToHandle = []() {
@@ -339,10 +344,12 @@ TEST(Error, CheckErrorUtilities) {
            "abort()";
   }
 #endif
+#endif
 
 // Test that handleAllUnhandledErrors crashes if an error is returned from a
 // handler.
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   {
     auto ReturnErrorFromHandler = []() {
@@ -357,6 +364,7 @@ TEST(Error, CheckErrorUtilities) {
         << " Error returned from handler in handleAllErrors call did not "
            "cause abort()";
   }
+#endif
 #endif
 
   // Test that we can return values from handleErrors.
@@ -409,6 +417,7 @@ TEST(Error, CheckExpected) {
 // Check that an Expected instance with an error value doesn't allow access to
 // operator*.
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   {
     Expected<int> A = make_error<CustomError>(42);
@@ -418,14 +427,17 @@ TEST(Error, CheckExpected) {
     consumeError(A.takeError());
   }
 #endif
+#endif
 
 // Check that an Expected instance with an error triggers an abort if
 // unhandled.
 // Test runs in debug mode only.
+#ifdef GTEST_HAS_DEATH_TEST
 #ifndef NDEBUG
   EXPECT_DEATH({ Expected<int> A = make_error<CustomError>(42); },
                "Program aborted due to an unhandled Error:")
       << "Unchecked Expected<T> failure value did not cause an abort()";
+#endif
 #endif
 
   // Test covariance of Expected.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -38,6 +38,7 @@ namespace {
 //   - consume_error to consume a "safe" error without any output.
 //   - handleAllUnhandledErrors to assert that all errors are handled.
 //   - logAllUnhandledErrors to log errors to a stream.
+//   - ExitOnError tests.
 //
 // Expected tests:
 //   - Expected<T> with T.
@@ -50,6 +51,7 @@ namespace {
 //   - std::error_code to Error (ECError) in failure mode.
 //   - Error to std::error_code in success mode.
 //   - Error (ECError) to std::error_code in failure mode.
+//
 
 // Custom error class with a default base class and some random 'info' attached.
 class CustomError : public ErrorInfo<CustomError> {
@@ -383,6 +385,32 @@ TEST(Error, CheckErrorUtilities) {
 
     EXPECT_EQ(ErrorInfo, 7)
         << "Failed to handle Error returned from handleErrors.";
+  }
+
+  // Test ExitOnError
+  {
+    ExitOnError ExitOnErr;
+    ExitOnErr.setBanner("Error in tool:");
+    ExitOnErr.setExitCodeMapper(
+      [](const Error &E) {
+        if (E.isA<CustomSubError>())
+          return 2;
+        return 1;
+      });
+
+    // Make sure we don't bail on success.
+    ExitOnErr(Error::success());
+    EXPECT_EQ(ExitOnErr(Expected<int>(7)), 7)
+      << "exitOnError returned an invalid value for Expected";
+
+    // Exit tests.
+    EXPECT_EXIT(ExitOnErr(make_error<CustomError>(7)),
+                ::testing::ExitedWithCode(1), "Error in tool:")
+      << "exitOnError returned an unexpected error result";
+
+    EXPECT_EXIT(ExitOnErr(Expected<int>(make_error<CustomSubError>(0, 0))),
+                ::testing::ExitedWithCode(2), "Error in tool:")
+      << "exitOnError returned an unexpected error result";
   }
 }
 

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -129,6 +129,12 @@ TEST(Error, UncheckedSuccess) {
 }
 #endif
 
+// Test that errors to be used as out parameters are implicitly checked (
+// and thus destruct quietly).
+TEST(Error, ErrorAsOutParameter) {
+  Error E = Error::errorForOutParameter();
+}
+
 // Check that we abort on unhandled failure cases. (Force conversion to bool
 // to make sure that we don't accidentally treat checked errors as handled).
 // Test runs in debug mode only.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -426,7 +426,7 @@ TEST(Error, ExpectedCovariance) {
   A2 = Expected<std::unique_ptr<D>>(nullptr);
 }
 
-TEST(Error, ECError) {
+TEST(Error, ErrorCodeConversions) {
   // Round-trip a success value to check that it converts correctly.
   EXPECT_EQ(errorToErrorCode(errorCodeToError(std::error_code())),
             std::error_code())
@@ -437,6 +437,29 @@ TEST(Error, ECError) {
             errc::invalid_argument)
       << "std::error_code error value should round-trip via Error "
          "conversions";
+
+  // Round-trip a success value through ErrorOr/Expected to check that it
+  // converts correctly.
+  {
+    auto Orig = ErrorOr<int>(42);
+    auto RoundTripped =
+      expectedToErrorOr(errorOrToExpected(ErrorOr<int>(42)));
+    EXPECT_EQ(*Orig, *RoundTripped)
+      << "ErrorOr<T> success value should round-trip via Expected<T> "
+         "conversions.";
+  }
+
+  // Round-trip a failure value through ErrorOr/Expected to check that it
+  // converts correctly.
+  {
+    auto Orig = ErrorOr<int>(errc::invalid_argument);
+    auto RoundTripped =
+      expectedToErrorOr(
+          errorOrToExpected(ErrorOr<int>(errc::invalid_argument)));
+    EXPECT_EQ(Orig.getError(), RoundTripped.getError())
+      << "ErrorOr<T> failure value should round-trip via Expected<T> "
+         "conversions.";
+  }
 }
 
 } // end anon namespace

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -412,7 +412,7 @@ TEST(Error, StringError) {
   std::string Msg;
   raw_string_ostream S(Msg);
   logAllUnhandledErrors(make_error<StringError>("foo" + Twine(42),
-                                                unconvertibleErrorCode()),
+                                                inconvertibleErrorCode()),
                         S, "");
   EXPECT_EQ(S.str(), "foo42\n") << "Unexpected StringError log result";
 

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -421,6 +421,10 @@ TEST(Error, ExitOnError) {
   EXPECT_EQ(ExitOnErr(Expected<int>(7)), 7)
       << "exitOnError returned an invalid value for Expected";
 
+  int A = 7;
+  int &B = ExitOnErr(Expected<int&>(A));
+  EXPECT_EQ(&A, &B) << "ExitOnError failed to propagate reference";
+
   // Exit tests.
   EXPECT_EXIT(ExitOnErr(make_error<CustomError>(7)),
               ::testing::ExitedWithCode(1), "Error in tool:")
@@ -437,6 +441,16 @@ TEST(Error, CheckedExpectedInSuccessMode) {
   EXPECT_TRUE(!!A) << "Expected with non-error value doesn't convert to 'true'";
   // Access is safe in second test, since we checked the error in the first.
   EXPECT_EQ(*A, 7) << "Incorrect Expected non-error value";
+}
+
+// Test Expected with reference type.
+TEST(Error, ExpectedWithReferenceType) {
+  int A = 7;
+  Expected<int&> B = A;
+  // 'Check' B.
+  (void)!!B;
+  int &C = *B;
+  EXPECT_EQ(&A, &C) << "Expected failed to propagate reference";
 }
 
 // Test Unchecked Expected<T> in success mode.

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -578,4 +578,23 @@ TEST(Error, ErrorCodeConversions) {
   }
 }
 
+// Test that error messages work.
+TEST(Error, ErrorMessage) {
+  EXPECT_EQ(toString(Error::success()).compare(""), 0);
+
+  Error E1 = make_error<CustomError>(0);
+  EXPECT_EQ(toString(std::move(E1)).compare("CustomError { 0}"), 0);
+
+  Error E2 = make_error<CustomError>(0);
+  handleAllErrors(std::move(E2), [](const CustomError &CE) {
+    EXPECT_EQ(CE.message().compare("CustomError { 0}"), 0);
+  });
+
+  Error E3 = joinErrors(make_error<CustomError>(0), make_error<CustomError>(1));
+  EXPECT_EQ(toString(std::move(E3))
+                .compare("CustomError { 0}\n"
+                         "CustomError { 1}"),
+            0);
+}
+
 } // end anon namespace

--- a/unittests/Support/ErrorTest.cpp
+++ b/unittests/Support/ErrorTest.cpp
@@ -129,11 +129,31 @@ TEST(Error, UncheckedSuccess) {
 }
 #endif
 
-// Test that errors to be used as out parameters are implicitly checked (
-// and thus destruct quietly).
-TEST(Error, ErrorAsOutParameter) {
-  Error E = Error::errorForOutParameter();
+// ErrorAsOutParameter tester.
+void errAsOutParamHelper(Error &Err) {
+  ErrorAsOutParameter ErrAsOutParam(Err);
+  // Verify that checked flag is raised - assignment should not crash.
+  Err = Error::success();
+  // Raise the checked bit manually - caller should still have to test the
+  // error.
+  (void)!!Err;
 }
+
+// Test that ErrorAsOutParameter sets the checked flag on construction.
+TEST(Error, ErrorAsOutParameterChecked) {
+  Error E;
+  errAsOutParamHelper(E);
+  (void)!!E;
+}
+
+// Test that ErrorAsOutParameter clears the checked flag on destruction.
+#ifndef NDEBUG
+TEST(Error, ErrorAsOutParameterUnchecked) {
+  EXPECT_DEATH({ Error E; errAsOutParamHelper(E); },
+               "Program aborted due to an unhandled Error:")
+      << "ErrorAsOutParameter did not clear the checked flag on destruction.";
+}
+#endif
 
 // Check that we abort on unhandled failure cases. (Force conversion to bool
 // to make sure that we don't accidentally treat checked errors as handled).


### PR DESCRIPTION
This patch introduces the Error classs for lightweight, structured, recoverable error handling. It includes utilities for creating, manipulating
and handling errors. The scheme is similar to exceptions, in that errors are
described with user-defined types. Unlike exceptions however, errors are represented as ordinary return types in the API (similar to the way std::error_code is used).

For usage notes see the LLVM programmer's manual, and the Error.h header.
Usage examples can be found in unittests/Support/ErrorTest.cpp.

Many thanks to David Blaikie, Mehdi Amini, Kevin Enderby and others on the
llvm-dev and llvm-commits lists for lots of discussion and review.

llvm-svn: 263609

Original commit information:
From f7f6d3e93f739077dc280532d906ca523489b01f Mon Sep 17 00:00:00 2001
From: Lang Hames <@lhames>
Date: Wed, 16 Mar 2016 01:02:46 +0000
Subject: [PATCH] [Support] Add the 'Error' class for structured error
 handling.