### PR TITLE
PIX: Preserve shader-access-tracking flag for descriptor-heap-indexed…

### DIFF
--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -552,10 +552,6 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
           auto* MultipliedOutOfBoundsValue = Builder.CreateMul(OneIfOutOfBounds, HlslOP->GetU32Const(EncodedInstructionNumber));
           auto* CombinedFlagOrInstructionValue = Builder.CreateAdd(MultipliedEncodedFlags, MultipliedOutOfBoundsValue);
 
-          // If we failed to find an instruction value, just return the access flags:
-          if (InstructionNumber == 0) {
-            CombinedFlagOrInstructionValue = EncodedFlags;
-          }
           Constant *ElementMask = HlslOP->GetI8Const(1);
           Function *StoreFunc = HlslOP->GetOpFunc(OP::OpCode::BufferStore,
                                                   Type::getInt32Ty(Ctx));

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicResourceOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicResourceOutOfBounds.hlsl
@@ -14,6 +14,7 @@ void Main()
 // The start of resource records has been passed in as 256. The limit of resource records is 272. 272-256 = 16.
 // 8 bytes per record means we have one record for out-of-bounds (that comes first), and one record for resource index 0.
 // The above HLSL references resource descriptor 1, so is out-of-bounds. Offset for out-of-bounds should thus be 256:
-// The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) for this access
-// CHECK:i32 256, i32 undef, i32 1375731712
+// The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) 
+// for this access plus 0x80000000 to indicate descriptor-heap indexing.
+// CHECK:i32 256, i32 undef, i32 1476395008
 // CHECK:rawBufferLoad

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
@@ -21,4 +21,4 @@ float4 Main() : SV_Target
 
 // Out of bounds sampler access should be at offset 512
 // CHECK: call void @dx.op.bufferStore.i32(
-// CHECK:i32 512, i32 undef, i32 16777216
+// CHECK:i32 512, i32 undef, i32 134217728


### PR DESCRIPTION
PIX recently changed to stop running the instruction-numbering pass before running the pass that's being changed here. This meant that no instructions had an instruction ordinal, so we were always hitting the deleted code. The trouble with that is that the "InstructionOrdinalndicator" flag has a secondary task of denoting an access of a descriptor-heap-indexed resource, and the lack of this flag is breaking some PIX functionality. It's ok to delete this- it was only ever a "just in case" kind of check.