### PR TITLE
Break test dependencies on mangling (Part 1)

### DIFF
--- a/tools/clang/test/CodeGenHLSL/lib_no_alias.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_no_alias.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure out param has no-alias.
-// CHECK: float @"\01?test@@YAMMUT@@AIAV?$matrix@M$01$01@@M@Z"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
+// CHECK: float @"\01?test{{[@$?.A-Za-z0-9_]+}}"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
 
 struct T {
   float a;

--- a/tools/clang/test/CodeGenHLSL/lib_resource.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_resource.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure globals for resource exist.
-// CHECK: @"\01?g_txDiffuse@@3V?$Texture2D@V?$vector@M$03@@@@A" = external constant %"class.Texture2D<vector<float, 4> >", align 4
-// CHECK: @"\01?g_samLinear@@3USamplerState@@A" = external constant %struct.SamplerState, align 4
+// CHECK: @"\01?g_txDiffuse{{[@$?.A-Za-z0-9_]+}}" = external constant %"class.Texture2D<vector<float, 4> >", align 4
+// CHECK: @"\01?g_samLinear{{[@$?.A-Za-z0-9_]+}}" = external constant %struct.SamplerState, align 4
 
 Texture2D    g_txDiffuse;
 SamplerState    g_samLinear;

--- a/tools/clang/test/CodeGenHLSL/linker/lib_mat_entry.hlsl
+++ b/tools/clang/test/CodeGenHLSL/linker/lib_mat_entry.hlsl
@@ -11,7 +11,7 @@
 
 
 // CHECK: [[BCI:%.*]] = bitcast [24 x float]* {{.*}} to [2 x %class.matrix.float.4.3]*
-// CHECK: call float @"\01?mat_array_test@@YAMV?$vector@M$03@@0Y01V?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
+// CHECK: call float @"\01?mat_array_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
 
 float mat_array_test(in float4 inGBuffer0,
                                   in float4 inGBuffer1,

--- a/tools/clang/test/CodeGenHLSL/linker/lib_mat_entry2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/linker/lib_mat_entry2.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3  %s | FileCheck %s
 
 // CHECK: [[BCI:%.*]] = bitcast <12 x float>* {{.*}} to %class.matrix.float.4.3*
-// CHECK:call <3 x float> @"\01?mat_test@@YA?AV?$vector@M$02@@V?$vector@M$03@@0AIAV?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
+// CHECK:call <3 x float> @"\01?mat_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
 
 float3 mat_test(in float4 in0,
                                   in float4 in1,

--- a/tools/clang/test/CodeGenHLSL/linker/lib_unresolved_func1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/linker/lib_unresolved_func1.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib1_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn1@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib2@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib2_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn1
 
 float external_fn();

--- a/tools/clang/test/CodeGenHLSL/linker/lib_unresolved_func2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/linker/lib_unresolved_func2.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib2_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn2@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib1@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib1_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn2
 
 float external_fn();

--- a/tools/clang/test/DXILValidation/lib_no_alias.hlsl
+++ b/tools/clang/test/DXILValidation/lib_no_alias.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure out param has no-alias.
-// CHECK: float @"\01?test@@YAMMUT@@AIAV?$matrix@M$01$01@@M@Z"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
+// CHECK: float @"\01?test{{[@$?.A-Za-z0-9_]+}}"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
 
 struct T {
   float a;

--- a/tools/clang/test/DXILValidation/lib_resource.hlsl
+++ b/tools/clang/test/DXILValidation/lib_resource.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure globals for resource exist.
-// CHECK: @"\01?g_txDiffuse@@3V?$Texture2D@V?$vector@M$03@@@@A" = external constant %"class.Texture2D<vector<float, 4> >", align 4
-// CHECK: @"\01?g_samLinear@@3USamplerState@@A" = external constant %struct.SamplerState, align 4
+// CHECK: @"\01?g_txDiffuse{{[@$?.A-Za-z0-9_]+}}" = external constant %"class.Texture2D<vector<float, 4> >", align 4
+// CHECK: @"\01?g_samLinear{{[@$?.A-Za-z0-9_]+}}" = external constant %struct.SamplerState, align 4
 
 Texture2D    g_txDiffuse;
 SamplerState    g_samLinear;

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
@@ -43,7 +43,7 @@
 // CHECK:   }
 // CHECK:   RecordTable (stride = 44 bytes) FunctionTable[2] = {
 // CHECK:     <0:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?foo@@YAMXZ"
+// CHECK:       Name: "\01?foo{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "foo"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
 // CHECK:         [0]: <1:RuntimeDataResourceInfo>

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_cb_matrix_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_cb_matrix_array.hlsl
@@ -25,7 +25,7 @@ void RayGenShader()
 // CHECK: ID3D12LibraryReflection:
 // CHECK:     FunctionCount: 1
 // CHECK-NEXT:   ID3D12FunctionReflection:
-// CHECK-NEXT:     D3D12_FUNCTION_DESC: Name: \01?RayGenShader@@YAXXZ
+// CHECK-NEXT:     D3D12_FUNCTION_DESC: Name: \01?RayGenShader{{[@$?.A-Za-z0-9_]+}}
 // CHECK-NEXT:       Shader Version: RayGeneration
 // CHECK:       ConstantBuffers: 1
 // CHECK-NEXT:       BoundResources: 2

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
@@ -59,7 +59,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   }
 // CHECK:   RecordTable (stride = 44 bytes) FunctionTable[3] = {
 // CHECK:     <0:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?VS_RENAMED@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z"
+// CHECK:       Name: "\01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "VS_RENAMED"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
 // CHECK:         [0]: <1:RuntimeDataResourceInfo>
@@ -74,7 +74,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       MinShaderTarget: 393312
 // CHECK:     }
 // CHECK:     <1:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?PS_RENAMED@@YA?AV?$vector@M$03@@H@Z"
+// CHECK:       Name: "\01?PS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PS_RENAMED"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
 // CHECK:         [0]: <0:RuntimeDataResourceInfo>
@@ -111,7 +111,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 3
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PS_RENAMED@@YA?AV?$vector@M$03@@H@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PS_RENAMED{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
@@ -136,7 +136,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         NumSamples (or stride): 8
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
@@ -54,7 +54,7 @@ void RayGen() {
 // CHECK:   }
 // CHECK:   RecordTable (stride = 44 bytes) FunctionTable[4] = {
 // CHECK:     <0:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?RayGen1@@YAXXZ"
+// CHECK:       Name: "\01?RayGen1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "RayGen1"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
 // CHECK:         [0]: <1:RuntimeDataResourceInfo>
@@ -69,7 +69,7 @@ void RayGen() {
 // CHECK:       MinShaderTarget: 458851
 // CHECK:     }
 // CHECK:     <1:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?VS_RENAMED@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z"
+// CHECK:       Name: "\01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "VS_RENAMED"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
 // CHECK:         [0]: <0:RuntimeDataResourceInfo>
@@ -84,7 +84,7 @@ void RayGen() {
 // CHECK:       MinShaderTarget: 393312
 // CHECK:     }
 // CHECK:     <2:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?RayGen2@@YAXXZ"
+// CHECK:       Name: "\01?RayGen2{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "RayGen2"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
 // CHECK:         [0]: <1:RuntimeDataResourceInfo>
@@ -119,7 +119,7 @@ void RayGen() {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 4
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen1@@YAXXZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
@@ -134,7 +134,7 @@ void RayGen() {
 // CHECK:         NumSamples (or stride): 0
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen2@@YAXXZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGen2{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
@@ -149,7 +149,7 @@ void RayGen() {
 // CHECK:         NumSamples (or stride): 0
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
@@ -45,7 +45,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   }
 // CHECK:   RecordTable (stride = 44 bytes) FunctionTable[6] = {
 // CHECK:     <0:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?PSMain@@YA?AV?$vector@M$03@@H@Z"
+// CHECK:       Name: "\01?PSMain{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
 // CHECK:         [0]: <0:RuntimeDataResourceInfo>
@@ -61,7 +61,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       MinShaderTarget: 393312
 // CHECK:     }
 // CHECK:     <1:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?PSMain_Clone1@@YA?AV?$vector@M$03@@H@Z"
+// CHECK:       Name: "\01?PSMain_Clone1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain_Clone1"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
 // CHECK:         [0]: <0:RuntimeDataResourceInfo>
@@ -77,7 +77,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       MinShaderTarget: 393312
 // CHECK:     }
 // CHECK:     <2:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?PSMain_Clone2@@YA?AV?$vector@M$03@@H@Z"
+// CHECK:       Name: "\01?PSMain_Clone2{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain_Clone2"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
 // CHECK:         [0]: <0:RuntimeDataResourceInfo>
@@ -146,7 +146,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 6
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain@@YA?AV?$vector@M$03@@H@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
@@ -171,7 +171,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         NumSamples (or stride): 8
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone1@@YA?AV?$vector@M$03@@H@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:
@@ -196,7 +196,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         NumSamples (or stride): 8
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone2@@YA?AV?$vector@M$03@@H@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain_Clone2{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports4.hlsl
@@ -22,7 +22,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 4
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?PSMain{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
@@ -37,7 +37,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VSMain@@YA?AV?$vector@M$03@@H@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?VSMain{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 2
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports_nocollision.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports_nocollision.hlsl
@@ -36,7 +36,7 @@ void RayGen() {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 4
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?Foo@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?Foo{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
@@ -51,7 +51,7 @@ void RayGen() {
 // CHECK:         NumSamples (or stride): 4294967295
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?Foo@@YAXXZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?Foo{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:
@@ -66,7 +66,7 @@ void RayGen() {
 // CHECK:         NumSamples (or stride): 0
 // CHECK:         uFlags: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?fn1@@YAXXZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?fn1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export1.hlsl
@@ -2,7 +2,7 @@
 
 // This version of HSPerPatchFunc1 should not be exported
 // CHECK: ID3D12FunctionReflection:
-// CHECK-NOT: D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@V?$InputPatch@UPSSceneIn@@$0BA@@@@Z
+// CHECK-NOT: D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+InputPatch[@$?.A-Za-z0-9_]+}}
 // CHECK-NOT: D3D_SRV_DIMENSION_BUFFER
 
 Buffer<float> T_unused;

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
@@ -96,7 +96,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:   RawBytes (size = 0 bytes)
 // CHECK:   RecordTable (stride = 44 bytes) FunctionTable[5] = {
 // CHECK:     <0:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?HSMain1@@YAXIV?$InputPatch@UPSSceneIn@@$02@@@Z"
+// CHECK:       Name: "\01?HSMain1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSMain1"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
 // CHECK:       FunctionDependencies: <string[0]> = {}
@@ -109,7 +109,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       MinShaderTarget: 393312
 // CHECK:     }
 // CHECK:     <1:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?HSMain3@@YAXIV?$InputPatch@UPSSceneIn@@$02@@@Z"
+// CHECK:       Name: "\01?HSMain3{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSMain3"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
 // CHECK:       FunctionDependencies: <string[0]> = {}
@@ -148,7 +148,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       MinShaderTarget: 196704
 // CHECK:     }
 // CHECK:     <4:RuntimeDataFunctionInfo> = {
-// CHECK:       Name: "\01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@XZ"
+// CHECK:       Name: "\01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSPerPatchFunc1"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
 // CHECK:       FunctionDependencies: <string[0]> = {}
@@ -166,20 +166,20 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 5
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain1@@YAXIV?$InputPatch@UPSSceneIn@@$02@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSMain2@@YAXIV?$InputPatch@UPSSceneIn@@$03@@@Z
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain3@@YAXIV?$InputPatch@UPSSceneIn@@$02@@@Z
+// CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSMain2{{[@$?.A-Za-z0-9_]+}}
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSMain3{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@XZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 0
 // CHECK:   ID3D12FunctionReflection:
-// CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc2@@YA?AUHSPerPatchData@@V?$InputPatch@UPSSceneIn@@$03@@@Z
+// CHECK-NOT:     D3D12_FUNCTION_DESC: Name: \01?HSPerPatchFunc2{{[@$?.A-Za-z0-9_]+}}
 // CHECK:     D3D12_FUNCTION_DESC: Name: HSMain1
 // CHECK:       Shader Version: Hull 6.3
 // CHECK:       BoundResources: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_requires_flags.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_requires_flags.hlsl
@@ -18,7 +18,7 @@ float4 PSMain(float4 In : IN, out float Depth : SV_Depth) : SV_Target {
 
 // CHECK: ID3D12LibraryReflection:
 // CHECK:     FunctionCount: 3
-// CHECK-LABEL:     D3D12_FUNCTION_DESC: Name: \01?DoubleMAD@@YAMMMM@Z
+// CHECK-LABEL:     D3D12_FUNCTION_DESC: Name: \01?DoubleMAD{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       RequiredFeatureFlags: 0x1
 // CHECK-LABEL:     D3D12_FUNCTION_DESC: Name: PSMain
 // CHECK:       RequiredFeatureFlags: 0x2

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray.hlsl
@@ -29,7 +29,7 @@ float4 emit(inout float2 f2, RayDesc Ray:R, inout Payload p )  {
 // CHECK:     Flags: 0
 // CHECK:     FunctionCount: 1
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?emit@@YA?AV?$vector@M$03@@AIAV?$vector@M$01@@URayDesc@@UPayload@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?emit{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       Flags: 0
 // CHECK:       ConstantBuffers: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray_readback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/raytracing_traceray_readback.hlsl
@@ -37,7 +37,7 @@ void RayGenTestMain()
 // CHECK:     Flags: 0
 // CHECK:     FunctionCount: 1
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGenTestMain@@YAXXZ
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?RayGenTestMain{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: RayGeneration 6.3
 // CHECK:       Flags: 0
 // CHECK:       ConstantBuffers: 1

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/reflect-lib-1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/reflect-lib-1.hlsl
@@ -19,7 +19,7 @@ float4 function2(float4 x : POSITION) : SV_Position { return x + cbval1 + cbval3
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 3
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?function0@@YAM$min16f@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?function0{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library
 // CHECK:       ConstantBuffers: 1
 // CHECK:       BoundResources: 2
@@ -69,7 +69,7 @@ float4 function2(float4 x : POSITION) : SV_Position { return x + cbval1 + cbval3
 // CHECK:         Dimension: D3D_SRV_DIMENSION_TEXTURE1D
 // CHECK:         uFlags: (D3D_SIF_TEXTURE_COMPONENT_0 | D3D_SIF_TEXTURE_COMPONENT_1)
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?function1@@YAMM$min12i@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?function1{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library
 // CHECK:       ConstantBuffers: 1
 // CHECK:       BoundResources: 4

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_getdim_stride.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/structured_buffer_getdim_stride.hlsl
@@ -16,7 +16,7 @@ uint UseBuf(int2 idx) {
 // CHECK:   D3D12_LIBRARY_DESC:
 // CHECK:     FunctionCount: 1
 // CHECK:   ID3D12FunctionReflection:
-// CHECK:     D3D12_FUNCTION_DESC: Name: \01?UseBuf@@YAIV?$vector@H$01@@@Z
+// CHECK:     D3D12_FUNCTION_DESC: Name: \01?UseBuf{{[@$?.A-Za-z0-9_]+}}
 // CHECK:       Shader Version: Library 6.3
 // CHECK:       BoundResources: 1
 // CHECK:     Bound Resources:

--- a/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_cs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_cs.hlsl
@@ -9,7 +9,7 @@ void main() {
 }
 
 // CHECK: define void @main() [[MainAttr:#[0-9]+]]
-// CHECK: define internal void @"\01?fn1@@YAXXZ"() [[FnAttr:#[0-9]+]]
+// CHECK: define internal void @"\01?fn1{{[@$?.A-Za-z0-9_]+}}"() [[FnAttr:#[0-9]+]]
 
 // CHECK: attributes [[MainAttr]] = { nounwind }
 // CHECK: attributes [[FnAttr]] = { alwaysinline nounwind }

--- a/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_lib.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -fcgl %s | FileCheck %s -check-prefixes=ALWAYS,CHECK
 // RUN: %dxc -T lib_6_3 -fnew-inlining-behavior -fcgl %s | FileCheck %s -check-prefixes=NORMAL,CHECK
 
-// CHECK: define internal void @"\01?fn1@@YAXXZ"() [[Fn1:#[0-9]+]]
+// CHECK: define internal void @"\01?fn1{{[@$?.A-Za-z0-9_]+}}"() [[Fn1:#[0-9]+]]
 void fn1() {}
 
-// CHECK: define internal void @"\01?fn2@@YAXXZ"() [[Fn2:#[0-9]+]]
+// CHECK: define internal void @"\01?fn2{{[@$?.A-Za-z0-9_]+}}"() [[Fn2:#[0-9]+]]
 void fn2() {
   fn1();
 }

--- a/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_lib_optimized.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/function_attrs/alwaysinline_lib_optimized.hlsl
@@ -9,8 +9,8 @@ RWBuffer<int> Out;
 
 // CHECK: target datalayout
 
-// NOINLINE: define internal {{.*}} i32 @"\01?add@@YAHHH@Z"(i32 %X, i32 %Y) [[Attr:#[0-9]+]]
-// NORMAL-NOT: define {{.*}} i32 @"\01?add@@YAHHH@Z"(i32 %X, i32 %Y)
+// NOINLINE: define internal {{.*}} i32 @"\01?add{{[@$?.A-Za-z0-9_]+}}"(i32 %X, i32 %Y) [[Attr:#[0-9]+]]
+// NORMAL-NOT: define {{.*}} i32 @"\01?add{{[@$?.A-Za-z0-9_]+}}"(i32 %X, i32 %Y)
 #ifdef NOINLINE
 [noinline]
 #endif
@@ -19,8 +19,8 @@ int add(int X, int Y) {
 }
 
 // CHECK: define void @CSMain()
-// NOINLINE: call {{.*}}i32 @"\01?add@@YAHHH@Z"(i32 
-// NORMAL-NOT: call {{.*}}i32 @"\01?add@@YAHHH@Z"(i32
+// NOINLINE: call {{.*}}i32 @"\01?add{{[@$?.A-Za-z0-9_]+}}"(i32 
+// NORMAL-NOT: call {{.*}}i32 @"\01?add{{[@$?.A-Za-z0-9_]+}}"(i32
 [shader("compute")]
 [numthreads(1,1,1)]
 void CSMain(uint GI : SV_GroupIndex) {

--- a/tools/clang/test/HLSLFileCheck/dxil/linker/lib_mat_entry.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/linker/lib_mat_entry.hlsl
@@ -11,7 +11,7 @@
 
 
 // CHECK: [[BCI:%.*]] = bitcast [24 x float]* {{.*}} to [2 x %class.matrix.float.4.3]*
-// CHECK: call float @"\01?mat_array_test@@YAMV?$vector@M$03@@0Y01V?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
+// CHECK: call float @"\01?mat_array_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
 
 float mat_array_test(in float4 inGBuffer0,
                                   in float4 inGBuffer1,

--- a/tools/clang/test/HLSLFileCheck/dxil/linker/lib_mat_entry2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/linker/lib_mat_entry2.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3  %s | FileCheck %s
 
 // CHECK: [[BCI:%.*]] = bitcast <12 x float>* {{.*}} to %class.matrix.float.4.3*
-// CHECK:call <3 x float> @"\01?mat_test@@YA?AV?$vector@M$02@@V?$vector@M$03@@0AIAV?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
+// CHECK:call <3 x float> @"\01?mat_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
 
 float3 mat_test(in float4 in0,
                                   in float4 in1,

--- a/tools/clang/test/HLSLFileCheck/dxil/linker/lib_unresolved_func1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/linker/lib_unresolved_func1.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib1_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn1@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib2@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib2_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn1
 
 float external_fn();

--- a/tools/clang/test/HLSLFileCheck/dxil/linker/lib_unresolved_func2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/linker/lib_unresolved_func2.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib2_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn2@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib1@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib1_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn2
 
 float external_fn();

--- a/tools/clang/test/HLSLFileCheck/hlsl/classes/this_cast_to_base_class.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/classes/this_cast_to_base_class.hlsl
@@ -1,15 +1,15 @@
 // RUN: %dxc -T lib_6_6 -HV 2021 -disable-lifetime-markers -fcgl %s | FileCheck %s
 
-// CHECK-LABLE: define linkonce_odr void @"\01?foo@Child@@QAAXXZ"(%class.Child* %this)
+// CHECK-LABLE: define linkonce_odr void @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(%class.Child* %this)
 // CHECK: %[[OutArg:.+]] = alloca %class.Parent
 // CHECK: %[[OutThisPtr:.+]] = getelementptr inbounds %class.Child, %class.Child* %this, i32 0, i32 0
-// CHECK: call void @"\01?lib_func2@@YAXVParent@@@Z"(%class.Parent* %[[OutArg]])
+// CHECK: call void @"\01?lib_func2{{[@$?.A-Za-z0-9_]+}}"(%class.Parent* %[[OutArg]])
 // Make sure copy-out.
 // CHECK: %[[OutThisCpyPtr:.+]] = bitcast %class.Parent* %[[OutThisPtr]] to i8*
 // CHECK: %[[OutArgCpyPtr:.+]] = bitcast %class.Parent* %[[OutArg]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[OutThisCpyPtr]], i8* %[[OutArgCpyPtr]], i64 8, i32 1, i1 false)
 
-// CHECK-LABLE: define linkonce_odr void @"\01?bar@Child@@QAAXXZ"(%class.Child* %this)
+// CHECK-LABLE: define linkonce_odr void @"\01?bar{{[@$?.A-Za-z0-9_]+}}"(%class.Child* %this)
 // CHECK: %[[InOutArg:.+]] = alloca %class.Parent
 // CHECK: %[[InOutThisPtr:.+]] = getelementptr inbounds %class.Child, %class.Child* %this, i32 0, i32 0
 
@@ -19,7 +19,7 @@
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[InOutArgCpyPtr]], i8* %[[InOutThisCpyPtr]], i64 8, i32 1, i1 false)
 
 // The call.
-// CHECK: call void @"\01?lib_func3@@YAXVParent@@@Z"(%class.Parent* %[[InOutArg]])
+// CHECK: call void @"\01?lib_func3{{[@$?.A-Za-z0-9_]+}}"(%class.Parent* %[[InOutArg]])
 
 // Make sure copy-out.
 // CHECK: %[[InOutThisCpyOutPtr:.+]] = bitcast %class.Parent* %[[InOutThisPtr]] to i8*
@@ -27,7 +27,7 @@
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[InOutThisCpyOutPtr]], i8* %[[InOutArgCpyOutPtr]], i64 8, i32 1, i1 false)
 
 
-// CHECK-LABLE: define linkonce_odr i32 @"\01?foo@Child@@QAAHHH@Z"(%class.Child* %this, i32 %a, i32 %b)
+// CHECK-LABLE: define linkonce_odr i32 @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(%class.Child* %this, i32 %a, i32 %b)
 // CHECK: %[[Arg:.+]] = alloca %class.Parent
 // CHECK: %[[Tmp:.+]] = alloca %class.Parent, align 4
 
@@ -47,7 +47,7 @@
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[ArgPtr]], i8* %[[TmpPtr]], i64 8, i32 1, i1 false)
 
 // Use Arg to call lib_func.
-// CHECK: call i32 @"\01?lib_func@@YAHVParent@@HH@Z"(%class.Parent* %[[Arg]], i32 %{{.*}}, i32 %{{.*}})
+// CHECK: call i32 @"\01?lib_func{{[@$?.A-Za-z0-9_]+}}"(%class.Parent* %[[Arg]], i32 %{{.*}}, i32 %{{.*}})
 
 class Parent
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/basic_blocks/cbuf_memcpy_replace.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/basic_blocks/cbuf_memcpy_replace.hlsl
@@ -12,7 +12,7 @@ cbuffer cbuf : register(b1)
 {
   Istruct istructs[1];
 }
-//CHECK: define i32 @"\01?loop_with_break1@@YAHH@Z"
+//CHECK: define i32 @"\01?loop_with_break1{{[@$?.A-Za-z0-9_]+}}"
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: icmp eq i32
@@ -37,7 +37,7 @@ int loop_with_break1(int i)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?loop_with_break2@@YAHH@Z"
+//CHECK: define i32 @"\01?loop_with_break2{{[@$?.A-Za-z0-9_]+}}"
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: icmp eq i32
@@ -60,7 +60,7 @@ int loop_with_break2(int i)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?uncond_loop_with_break@@YAHI@Z"
+//CHECK: define i32 @"\01?uncond_loop_with_break{{[@$?.A-Za-z0-9_]+}}"
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: icmp eq i32
@@ -80,7 +80,7 @@ int uncond_loop_with_break(uint i)
   return istruct.ival;
 }
 
-//CHECK define i32 @"\01?uncond_init_loop@@YAHH@Z"
+//CHECK define i32 @"\01?uncond_init_loop{{[@$?.A-Za-z0-9_]+}}"
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: phi i32
@@ -96,7 +96,7 @@ int init_loop(int ct)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?cond_if@@YAHH@Z"(i32 %i)
+//CHECK: define i32 @"\01?cond_if{{[@$?.A-Za-z0-9_]+}}"(i32 %i)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: phi i32
@@ -112,7 +112,7 @@ int cond_if(int i)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?uncond_if@@YAHI@Z"(i32 %i)
+//CHECK: define i32 @"\01?uncond_if{{[@$?.A-Za-z0-9_]+}}"(i32 %i)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: ret i32
@@ -129,7 +129,7 @@ int uncond_if(uint i)
 }
 
 
-//CHECK: define i32 @"\01?cond_if_else@@YAHHH@Z"(i32 %i, i32 %j)
+//CHECK: define i32 @"\01?cond_if_else{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
@@ -150,7 +150,7 @@ int cond_if_else(int i, int j)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?uncond_if_else@@YAHIH@Z"(i32 %i, i32 %j)
+//CHECK: define i32 @"\01?uncond_if_else{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: ret i32
@@ -167,7 +167,7 @@ int uncond_if_else(uint i, int j)
   return istruct.ival;
 }
 
-//CHECK: define i32 @"\01?entry_memcpy@@YAHHH@Z"(i32 %i, i32 %ct)
+//CHECK: define i32 @"\01?entry_memcpy{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %ct)
 //CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32
 //CHECK: extractvalue %dx.types.CBufRet.i32
 //CHECK: phi i32

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/EntryFunctionDisableNVRO.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/return/EntryFunctionDisableNVRO.hlsl
@@ -102,7 +102,7 @@ MyReturn main() {
 
 #elif defined(HS)
 
-// HS-LABEL: @"\01?patch_const@@YA?AUMyPatchConstantReturn@@XZ"
+// HS-LABEL: @"\01?patch_const{{[@$?.A-Za-z0-9_]+}}"
 // HS: call void @dx.op.storePatchConstant
 // HS: call void @dx.op.storePatchConstant
 // HS: call void @dx.op.storePatchConstant

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout-operators.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout-operators.hlsl
@@ -17,7 +17,7 @@ void fn() {
   D(X, Y, X);
 }
 
-// CHECK: define internal void @"\01?fn@@YAXXZ"()
+// CHECK: define internal void @"\01?fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK: [[Tmp1:%[0-9A-Z]+]] = alloca float
 // CHECK: [[X:%[0-9A-Z]+]] = alloca float, align 4
 // CHECK: [[Z:%[0-9A-Z]+]] = alloca float, align 4
@@ -25,13 +25,13 @@ void fn() {
 // CHECK: [[D:%[0-9A-Z]+]] = alloca %struct.Doggo
 
 // First call has no copy-in/copy out parameters since all parameters are unique.
-// CHECK: call void @"\01??RDoggo@@QAAXAIAMAIAH0@Z"(%struct.Doggo* [[D]], float* dereferenceable(4) [[X]], i32* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Z]])
+// CHECK: call void @"\01??RDoggo{{[@$?.A-Za-z0-9_]+}}"(%struct.Doggo* [[D]], float* dereferenceable(4) [[X]], i32* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Z]])
 
 // The second call copies X for the third parameter.
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[X]], align 4
 // CHECK: store float [[TmpX]], float* [[Tmp1]]
 
-// CHECK: call void @"\01??RDoggo@@QAAXAIAMAIAH0@Z"(%struct.Doggo* [[D]], float* dereferenceable(4) [[X]], i32* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Tmp1]])
+// CHECK: call void @"\01??RDoggo{{[@$?.A-Za-z0-9_]+}}"(%struct.Doggo* [[D]], float* dereferenceable(4) [[X]], i32* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Tmp1]])
 
 // The third call stores parameter 3 to X after the call.
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[Tmp1]]

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout-struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout-struct.hlsl
@@ -22,11 +22,11 @@ void fn() {
 
 // CHECK: [[X:%[0-9A-Z]+]] = alloca float, align 4
 // CHECK: [[P:%[0-9A-Z]+]] = alloca %struct.Pup, align 4
-// CHECK: call void @"\01?CalledFunction@@YAXAIAMUPup@@@Z"(float* dereferenceable(4) [[X]], %struct.Pup* [[P]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[X]], %struct.Pup* [[P]])
 
 // CHECK: [[TmpPPtr:%[0-9A-Z]+]] = bitcast %struct.Pup* [[TmpP]] to i8*
 // CHECK: [[PPtr:%[0-9A-Z]+]] = bitcast %struct.Pup* [[P]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[TmpPPtr]], i8* [[PPtr]], i64 4, i32 1, i1 false)
 
 // CHECK: [[PDotX:%[0-9A-Z]+]] = getelementptr inbounds %struct.Pup, %struct.Pup* [[P]], i32 0, i32 0
-// CHECK: call void @"\01?CalledFunction@@YAXAIAMUPup@@@Z"(float* dereferenceable(4) [[PDotX]], %struct.Pup* [[TmpP]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[PDotX]], %struct.Pup* [[TmpP]])

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/copyin-copyout.hlsl
@@ -15,7 +15,7 @@ void fn() {
   CalledFunction(X, Y, X);
 }
 
-// CHECK: define internal void @"\01?fn@@YAXXZ"()
+// CHECK: define internal void @"\01?fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK: [[Tmp1:%[0-9A-Z]+]] = alloca float
 // CHECK: [[Tmp2:%[0-9A-Z]+]] = alloca float
 // CHECK: [[X:%[0-9A-Z]+]] = alloca float, align 4
@@ -23,13 +23,13 @@ void fn() {
 // CHECK: [[Z:%[0-9A-Z]+]] = alloca float, align 4
 
 // First call has no copy-in/copy out parameters since all parameters are unique.
-// CHECK: call void @"\01?CalledFunction@@YAXAIAM00@Z"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Z]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Z]])
 
 // Second call, copies X for parameter 2.
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[X]], align 4
 // CHECK: store float [[TmpX]], float* [[Tmp2]]
 
-// CHECK: call void @"\01?CalledFunction@@YAXAIAM00@Z"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Tmp2]], float* dereferenceable(4) [[Z]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Tmp2]], float* dereferenceable(4) [[Z]])
 
 // Second call, saves parameter 2 to X after the call.
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[Tmp2]]
@@ -39,7 +39,7 @@ void fn() {
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[X]], align 4
 // CHECK: store float [[TmpX]], float* [[Tmp1]]
 
-// CHECK: call void @"\01?CalledFunction@@YAXAIAM00@Z"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Tmp1]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Y]], float* dereferenceable(4) [[Tmp1]])
 
 // The third call stores parameter 3 to X after the call.
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[Tmp1]]
@@ -60,7 +60,7 @@ void fn2() {
 // CHECK: [[TmpX:%[0-9A-Z]+]] = load float, float* [[X]], align 4
 // CHECK: store float [[TmpX]], float* [[Tmp1]]
 
-// CHECK: call void @"\01?CalledFunction@@YAXAIAM00@Z"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Tmp2]], float* dereferenceable(4) [[Tmp1]])
+// CHECK: call void @"\01?CalledFunction{{[@$?.A-Za-z0-9_]+}}"(float* dereferenceable(4) [[X]], float* dereferenceable(4) [[Tmp2]], float* dereferenceable(4) [[Tmp1]])
 
 // X gets restored from parameter 2 _then_ parameter 3, so the last paramter is
 // the final value of X.

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/gep_arg_nocopy.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/gep_arg_nocopy.hlsl
@@ -27,12 +27,12 @@ float4 main() : SV_Target {
 // CHECK: [[TmpaPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[Tmpa]] to i8*
 // CHECK: [[aPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[a]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[TmpaPtr]], i8* [[aPtr]], i64 512, i32 1, i1 false)
-// CHECK: call <4 x float> @"\01?bar@@YA?AV?$vector@M$03@@Y0CA@V1@@Z"([32 x <4 x float>]* [[Tmpa]])
+// CHECK: call <4 x float> @"\01?bar{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[Tmpa]])
 
 // Bug: Because a isn't marked noalias, we are generating copies for it.
-// CHECK: define internal <4 x float> @"\01?bar@@YA?AV?$vector@M$03@@Y0CA@V1@@Z"([32 x <4 x float>]* [[a:%[0-9a]+]]) #1 {
+// CHECK: define internal <4 x float> @"\01?bar{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[a:%[0-9a]+]]) #1 {
 // CHECK: [[Tmpa:%[0-9A-Z]+]] = alloca [32 x <4 x float>]
 // CHECK: [[TmpaPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[Tmpa]] to i8*
 // CHECK: [[aPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[a]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[TmpaPtr]], i8* [[aPtr]], i64 512, i32 1, i1 false)
-// CHECK: call <4 x float> @"\01?foo@@YA?AV?$vector@M$03@@Y0CA@V1@H@Z"([32 x <4 x float>]* [[Tmpa]], i32 {{%[0-9A-Z]+}})
+// CHECK: call <4 x float> @"\01?foo{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[Tmpa]], i32 {{%[0-9A-Z]+}})

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/global_constant_const.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/arguments/global_constant_const.hlsl
@@ -23,12 +23,12 @@ float4 main() : SV_Target {
 // bar should be called with a copy of st.a.
 // CHECK: define <4 x float> @main()
 // CHECK: [[a:%[0-9A-Z]+]] = getelementptr inbounds %"$Globals", %"$Globals"* {{%[0-9A-Z]+}}, i32 0, i32 0, i32 0
-// CHECK: call <4 x float> @"\01?bar@@YA?AV?$vector@M$03@@Y0CA@$$CBV1@@Z"([32 x <4 x float>]* [[a]])
+// CHECK: call <4 x float> @"\01?bar{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[a]])
 
 // Bug: Because a isn't marked noalias, we are generating copies for it.
-// CHECK: define internal <4 x float> @"\01?bar@@YA?AV?$vector@M$03@@Y0CA@$$CBV1@@Z"([32 x <4 x float>]* [[a:%[0-9a]+]]) #1 {
+// CHECK: define internal <4 x float> @"\01?bar{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[a:%[0-9a]+]]) #1 {
 // CHECK: [[Tmpa:%[0-9A-Z]+]] = alloca [32 x <4 x float>]
 // CHECK: [[TmpaPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[Tmpa]] to i8*
 // CHECK: [[aPtr:%[0-9A-Z]+]] = bitcast [32 x <4 x float>]* [[a]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* [[TmpaPtr]], i8* [[aPtr]], i64 512, i32 1, i1 false)
-// CHECK: call <4 x float> @"\01?foo@@YA?AV?$vector@M$03@@Y0CA@$$CBV1@H@Z"([32 x <4 x float>]* [[Tmpa]], i32 {{%[0-9A-Z]+}})
+// CHECK: call <4 x float> @"\01?foo{{[@$?.A-Za-z0-9_]+}}"([32 x <4 x float>]* [[Tmpa]], i32 {{%[0-9A-Z]+}})

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/fn_attr_experimental.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/fn_attr_experimental.hlsl
@@ -2,7 +2,7 @@
 
 // CHECK: define <4 x float>
 // CHECK: fn1
-// @"\01?fn1@@YA?AV?$vector@M$03@@V1@@Z"
+// @"\01?fn1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: #0
 // CHECK: attributes #0
 // CHECK: "exp-foo"="bar"

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes.hlsl
@@ -6,7 +6,7 @@
 //
 // Non-SSA arrays should have lifetimes within the correct scope.
 //
-// CHECK: define i32 @"\01?if_scoped_array@@YAHHH@Z"
+// CHECK: define i32 @"\01?if_scoped_array{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: alloca
 // CHECK: icmp
 // CHECK: br i1
@@ -43,13 +43,13 @@ int if_scoped_array(int n, int c)
 //
 // Escaping structs should have lifetimes within the correct scope.
 //
-// CHECK: define void @"\01?loop_scoped_escaping_struct@@YAXH@Z"(i32 %n)
+// CHECK: define void @"\01?loop_scoped_escaping_struct{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: %[[alloca:.*]] = alloca %struct.MyStruct
 // CHECK: ret
 // CHECK: phi i32
 // CHECK-NEXT: bitcast
 // CHECK-NEXT: call void @llvm.lifetime.start
-// CHECK-NEXT: call float @"\01?func@@YAMUMyStruct@@@Z"(%struct.MyStruct* nonnull %[[alloca]])
+// CHECK-NEXT: call float @"\01?func{{[@$?.A-Za-z0-9_]+}}"(%struct.MyStruct* nonnull %[[alloca]])
 // CHECK-NEXT: call void @llvm.lifetime.end
 // CHECK: br i1
 struct MyStruct {
@@ -72,7 +72,7 @@ void loop_scoped_escaping_struct(int n)
 // within the correct scope and should not produce values live across multiple
 // loop iterations (=no loop phi nodes).
 //
-// CHECK: define i32 @"\01?loop_scoped_escaping_struct_write@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?loop_scoped_escaping_struct_write{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: %[[alloca:.*]] = alloca %struct.MyStruct
 // CHECK: br i1
 // CHECK: phi i32
@@ -83,7 +83,7 @@ void loop_scoped_escaping_struct(int n)
 // CHECK-NEXT: bitcast
 // CHECK-NEXT: call void @llvm.lifetime.start
 // CHECK-NOT: store
-// CHECK-NEXT: call void @"\01?func2@@YAXUMyStruct@@@Z"(%struct.MyStruct* nonnull %[[alloca]])
+// CHECK-NEXT: call void @"\01?func2{{[@$?.A-Za-z0-9_]+}}"(%struct.MyStruct* nonnull %[[alloca]])
 // CHECK-NEXT: getelementptr
 // CHECK-NEXT: load
 // CHECK: call void @llvm.lifetime.end
@@ -107,7 +107,7 @@ int loop_scoped_escaping_struct_write(int n)
 // values considered live across multiple loop iterations (= no loop phi nodes).
 //
 // Make sure there is only one loop phi node, which is the induction var.
-// CHECK: define i32 @"\01?loop_scoped_struct_conditional_init@@YAHHH@Z"(i32 %n, i32 %c1)
+// CHECK: define i32 @"\01?loop_scoped_struct_conditional_init{{[@$?.A-Za-z0-9_]+}}"(i32 %n, i32 %c1)
 // CHECK-NOT: alloca
 // CHECK: phi i32
 // CHECK-NEXT: ret i32
@@ -154,7 +154,7 @@ int loop_scoped_struct_conditional_init(int n, int c1)
 // Both the consume and produce calls must be inlined, otherwise the alloca
 // can't be promoted.
 //
-// CHECK: define i32 @"\01?loop_scoped_struct_conditional_assign_from_func_output@@YAHHH@Z"(i32 %n, i32 %c1)
+// CHECK: define i32 @"\01?loop_scoped_struct_conditional_assign_from_func_output{{[@$?.A-Za-z0-9_]+}}"(i32 %n, i32 %c1)
 // CHECK-NOT: alloca
 // CHECK: phi i32
 // CHECK-NOT: phi i32
@@ -193,7 +193,7 @@ int loop_scoped_struct_conditional_assign_from_func_output(int n, int c1)
 // Global constants should have lifetimes.
 // The constant array should be hoisted to a constant global.
 //
-// CHECK: define i32 @"\01?global_constant@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?global_constant{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: call void @llvm.lifetime.start
 // CHECK: load i32
 // CHECK: call void @llvm.lifetime.end
@@ -215,7 +215,7 @@ int global_constant(int n)
 // The constant array should be hoisted to a constant global with lifetime
 // only inside the loop.
 //
-// CHECK: define i32 @"\01?global_constant2@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?global_constant2{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: phi i32
 // CHECK: phi i32
 // CHECK: call void @llvm.lifetime.start

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_force_zero_flag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_force_zero_flag.hlsl
@@ -4,7 +4,7 @@
 // Same test as in lifetimes.hlsl, but expecting zeroinitializer store
 // instead of lifetime intrinsics due to flag -force-zero-store-lifetimes.
 //
-// CHECK: define i32 @"\01?if_scoped_array@@YAHHH@Z"
+// CHECK: define i32 @"\01?if_scoped_array{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: alloca
 // CHECK: icmp
 // CHECK: br i1

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_lib_6_3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_lib_6_3.hlsl
@@ -7,7 +7,7 @@
 //
 // Non-SSA arrays should have lifetimes within the correct scope.
 //
-// CHECK: define i32 @"\01?if_scoped_array@@YAHHH@Z"
+// CHECK: define i32 @"\01?if_scoped_array{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: alloca
 // CHECK: icmp
 // CHECK: br i1
@@ -44,12 +44,12 @@ int if_scoped_array(int n, int c)
 //
 // Escaping structs should have lifetimes within the correct scope.
 //
-// CHECK: define void @"\01?loop_scoped_escaping_struct@@YAXH@Z"(i32 %n)
+// CHECK: define void @"\01?loop_scoped_escaping_struct{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: %[[alloca:.*]] = alloca %struct.MyStruct
 // CHECK: ret
 // CHECK: phi i32
 // CHECK-NEXT: store %struct.MyStruct undef
-// CHECK-NEXT: call float @"\01?func@@YAMUMyStruct@@@Z"(%struct.MyStruct* nonnull %[[alloca]])
+// CHECK-NEXT: call float @"\01?func{{[@$?.A-Za-z0-9_]+}}"(%struct.MyStruct* nonnull %[[alloca]])
 // CHECK-NEXT: store %struct.MyStruct undef
 // CHECK: br i1
 struct MyStruct {
@@ -72,7 +72,7 @@ void loop_scoped_escaping_struct(int n)
 // within the correct scope and should not produce values live across multiple
 // loop iterations (=no loop phi nodes).
 //
-// CHECK: define i32 @"\01?loop_scoped_escaping_struct_write@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?loop_scoped_escaping_struct_write{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: %[[alloca:.*]] = alloca %struct.MyStruct
 // CHECK: br i1
 // CHECK: phi i32
@@ -82,7 +82,7 @@ void loop_scoped_escaping_struct(int n)
 // CHECK-NOT: phi float
 // CHECK-NEXT: store %struct.MyStruct undef
 // CHECK-NOT: store
-// CHECK-NEXT: call void @"\01?func2@@YAXUMyStruct@@@Z"(%struct.MyStruct* nonnull %[[alloca]])
+// CHECK-NEXT: call void @"\01?func2{{[@$?.A-Za-z0-9_]+}}"(%struct.MyStruct* nonnull %[[alloca]])
 // CHECK-NEXT: getelementptr
 // CHECK-NEXT: load
 // CHECK: store %struct.MyStruct undef
@@ -106,7 +106,7 @@ int loop_scoped_escaping_struct_write(int n)
 // values considered live across multiple loop iterations (= no loop phi nodes).
 //
 // Make sure there is only one loop phi node, which is the induction var.
-// CHECK: define i32 @"\01?loop_scoped_struct_conditional_init@@YAHHH@Z"(i32 %n, i32 %c1)
+// CHECK: define i32 @"\01?loop_scoped_struct_conditional_init{{[@$?.A-Za-z0-9_]+}}"(i32 %n, i32 %c1)
 // CHECK-NOT: alloca
 // CHECK: phi i32
 // CHECK-NEXT: ret i32
@@ -153,7 +153,7 @@ int loop_scoped_struct_conditional_init(int n, int c1)
 // Both the consume and produce calls must be inlined, otherwise the alloca
 // can't be promoted.
 //
-// CHECK: define i32 @"\01?loop_scoped_struct_conditional_assign_from_func_output@@YAHHH@Z"(i32 %n, i32 %c1)
+// CHECK: define i32 @"\01?loop_scoped_struct_conditional_assign_from_func_output{{[@$?.A-Za-z0-9_]+}}"(i32 %n, i32 %c1)
 // CHECK-NOT: alloca
 // CHECK: phi i32
 // CHECK-NOT: phi i32
@@ -193,7 +193,7 @@ int loop_scoped_struct_conditional_assign_from_func_output(int n, int c1)
 // There should be no store of undef or 0 that would overwrite
 // the initializer.
 //
-// CHECK: define i32 @"\01?global_constant@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?global_constant{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK-NOT: store [8 x i32] undef
 // CHECK: load i32
 // CHECK-NOT: store [8 x i32] undef
@@ -216,7 +216,7 @@ int global_constant(int n)
 // There should be no store of undef or 0 that would overwrite
 // the initializer.
 //
-// CHECK: define i32 @"\01?global_constant2@@YAHH@Z"(i32 %n)
+// CHECK: define i32 @"\01?global_constant2{{[@$?.A-Za-z0-9_]+}}"(i32 %n)
 // CHECK: phi i32
 // CHECK: phi i32
 // CHECK-NOT: store [8 x i32] undef

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_loop_live_vals.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_loop_live_vals.hlsl
@@ -6,7 +6,7 @@
 // LLVM: The code is converted easily to standard C++.
 
 //------------------------------------------------------------------------------
-// CHECK: define void @"\01?test@@YAXHAIAM@Z"
+// CHECK: define void @"\01?test{{[@$?.A-Za-z0-9_]+}}"
 // CHECK-NOT: undef
 bool done(int);
 float loop_code();
@@ -32,7 +32,7 @@ void test(in int loopCount, out float res) {
 }
 
 //------------------------------------------------------------------------------
-// CHECK: define void @"\01?fn2@@YAXHAIAM@Z"
+// CHECK: define void @"\01?fn2{{[@$?.A-Za-z0-9_]+}}"
 // CHECK-NOT: undef
 export
 void fn2(in int loopCount, out float res) {
@@ -63,7 +63,7 @@ void test2(in int loopCount, out float res) {
 // There can be 'undef' in the metadata, so we limit the check until metadata
 // starts.
 
-// CHECK: define void @"\01?main@@YAXAIAM@Z"
+// CHECK: define void @"\01?main{{[@$?.A-Za-z0-9_]+}}"
 // CHECK-NOT: undef
 // CHECK: !dx.version
 int loopCountGlobal;

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_replacememcpy.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes_replacememcpy.hlsl
@@ -8,7 +8,7 @@
 //
 
 // CHECK: @[[constname:.*]] = internal unnamed_addr constant [2 x float] [float 1.000000e+00, float 3.000000e+00]
-// CHECK: define float @"\01?memcpy_replace@@YAMH@Z"(i32 %i)
+// CHECK: define float @"\01?memcpy_replace{{[@$?.A-Za-z0-9_]+}}"(i32 %i)
 // CHECK: getelementptr inbounds [2 x float], [2 x float]* @[[constname]], i32 0, i32 %i
 // CHECK: load float
 // CHECK: ret float

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/buf_index.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/buf_index.hlsl
@@ -28,7 +28,7 @@ float4 main(uint i:I) : SV_Target {
 // multiple checks on the same line of text.
 
 // FCGL: [[Buffer:%.+]] = load %"class.Buffer<vector<float, 4> >",
-// FCGL-SAME: %"class.Buffer<vector<float, 4> >"* @"\01?buf@@3V?$Buffer@V?$vector@M$03@@@@A"
+// FCGL-SAME: %"class.Buffer<vector<float, 4> >"* @"\01?buf{{[@$?.A-Za-z0-9_]+}}"
 
 // FCGL: [[Handle:%.+]] = call %dx.types.Handle
 // FCGL-SAME: @"dx.hl.createhandle..%dx.types.Handle (i32, %\22class.Buffer<vector<float, 4> >\22)"

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/res_select5_x.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Buffer/res_select5_x.hlsl
@@ -3,7 +3,7 @@
 // lib_6_x allows phi/select of resource in lib.
 // phi/select of handle should not be produced in this case, but would be allowed if it were.
 
-// CHECK: define <4 x float> @"\01?test@@YA?AV?$vector@M$03@@HHH@Z"(i32 %i, i32 %j, i32 %m)
+// CHECK: define <4 x float> @"\01?test{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j, i32 %m)
 
 // CHECK: phi %dx.types.Handle
 // CHECK: phi %dx.types.Handle

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select3.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure no phi/select of handle in lib.
-// CHECK: define i32 @"\01?test@@YAIHHH@Z"(i32 %i, i32 %j, i32 %m)
+// CHECK: define i32 @"\01?test{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j, i32 %m)
 // CHECK-NOT: phi %"class.
 // CHECK-NOT: phi %dx.types.Handle
 // CHECK-NOT: select i1 %{{[^,]+}}, %"class.

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select3_x.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select3_x.hlsl
@@ -3,7 +3,7 @@
 // lib_6_x allows phi/select of resource in lib.
 // phi/select of handle should not be produced in this case, but would be allowed if it were.
 
-// CHECK: define i32 @"\01?test@@YAIHHH@Z"(i32 %i, i32 %j, i32 %m)
+// CHECK: define i32 @"\01?test{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j, i32 %m)
 
 // CHECK: phi %dx.types.Handle
 // CHECK: select i1 %{{[^,]+}}, %dx.types.Handle

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select4_x.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/StructuredBuffer/res_select4_x.hlsl
@@ -3,7 +3,7 @@
 // lib_6_x allows phi/select of resource in lib.
 // phi/select of handle should not be produced in this case, but would be allowed if it were.
 
-// CHECK: define i32 @"\01?test@@YAIHHH@Z"(i32 %i, i32 %j, i32 %m)
+// CHECK: define i32 @"\01?test{{[@$?.A-Za-z0-9_]+}}"(i32 %i, i32 %j, i32 %m)
 // CHECK: phi %dx.types.Handle
 // CHECK: phi %dx.types.Handle
 // CHECK: select i1 %{{[^,]+}}, %dx.types.Handle

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/shift-mask.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/binary/shift-mask.hlsl
@@ -28,6 +28,6 @@ int64_t shr64(int64_t V, int64_t S) {
   return V >> S;
 }
 
-// CHECK: define internal i64 @"\01?shr64@@YA_J_J0@Z"(i64 %V, i64 %S) #0 {
+// CHECK: define internal i64 @"\01?shr64{{[@$?.A-Za-z0-9_]+}}"(i64 %V, i64 %S) #0 {
 // CHECK-DAG:  %[[Masked:.*]] = and i64 %{{.*}}, 63
 // CHECK-DAG:  %{{.*}} = ashr i64 %{{.*}}, %[[Masked]]

--- a/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/operators/ternary-return-matrix.hlsl
@@ -11,7 +11,7 @@ float2x2 crashingFunction(bool b) {
     return;
 }
 
-// CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction@@YA?AV?$matrix@M$01$01@@_N@Z"
+// CHECK: define internal %class.matrix.float.2.2 @"\01?crashingFunction{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: [[ALLOCA:%[0-9a-z]+]] = alloca %class.matrix.float.2.2
 // CHECK: preds = {{%[0-9a-z]+}}
 // CHECK: call %class.matrix.float.2.2 @"dx.hl.matldst.colStore.%class.matrix.float.2.2 (i32, %class.matrix.float.2.2*, %class.matrix.float.2.2)"(i32 1, %class.matrix.float.2.2* [[ALLOCA]], %class.matrix.float.2.2 %{{[0-9]+}})

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/array/incomp_array.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/array/incomp_array.hlsl
@@ -23,7 +23,7 @@ static const Special s_special = { { 1, 2, 3, 4}, { 5, 6, 7 } };
 
 // CHECK: define <4 x float>
 // CHECK: fn1
-// @"\01?fn1@@YA?AV?$vector@M$03@@USpecial@@@Z"
+// @"\01?fn1{{[@$?.A-Za-z0-9_]+}}"
 float4 fn1(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
   // CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(
   // CHECK: i32 0)
@@ -38,7 +38,7 @@ float4 fn1(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
 
 // CHECK: define <4 x float>
 // CHECK: fn2
-// @"\01?fn2@@YA?AV?$vector@M$03@@USpecial@@@Z"
+// @"\01?fn2{{[@$?.A-Za-z0-9_]+}}"
 float4 fn2(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
   // CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(
   // CHECK: i32 0)
@@ -53,7 +53,7 @@ float4 fn2(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
 
 // CHECK: define <4 x float>
 // CHECK: fn3
-// @"\01?fn3@@YA?AV?$vector@M$03@@USpecial@@@Z"
+// @"\01?fn3{{[@$?.A-Za-z0-9_]+}}"
 float4 fn3(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
   // CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(
   // CHECK: i32 0)
@@ -68,7 +68,7 @@ float4 fn3(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
 
 // CHECK: define <4 x float>
 // CHECK: fn4
-// @"\01?fn4@@YA?AV?$vector@M$03@@USpecial@@@Z"
+// @"\01?fn4{{[@$?.A-Za-z0-9_]+}}"
 float4 fn4(in Special in1: SEMANTIC_IN) : SEMANTIC_OUT {
   // CHECK: call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(
   // CHECK: i32 0)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/hs_static_mat.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/hs_static_mat.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T hs_6_0 %s | FileCheck %s
 
 // Make sure not crash.
-// CHECK:define void @"\01?patchConstantF@@YA?AUPatchConstantOutput@@V?$OutputPatch@UHsOutput@@$02@@@Z"()
+// CHECK:define void @"\01?patchConstantF{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK:define void @main()
 struct ST
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/groupshared/share_mem_arg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/modifiers/groupshared/share_mem_arg.hlsl
@@ -2,8 +2,8 @@
 
 // Make sure different address space arg works.
 
-// CHECK: @"\01?sT@@3PAUT@@A.0" = addrspace(3) global [8 x float]
-// CHECK: @"\01?sT@@3PAUT@@A.1" = addrspace(3) global [8 x i32]
+// CHECK: @"\01?sT{{[@$?.A-Za-z0-9_]+}}" = addrspace(3) global [8 x float]
+// CHECK: @"\01?sT{{[@$?.A-Za-z0-9_]+}}" = addrspace(3) global [8 x i32]
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
@@ -9,9 +9,9 @@
 // CHECK:%[[A5:.*]] = alloca i32
 // CHECK:%[[A6:.*]] = alloca i32
 
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A0]], i32* nonnull dereferenceable(4) %[[A5]], i32* nonnull dereferenceable(4) %[[A6]])
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A4]], i32* nonnull dereferenceable(4) %[[A3]], i32* nonnull dereferenceable(4) %[[A6]])
-// CHECK:call void @"\01?foo@@YAXIAIAI00@Z"(i32 0, i32* nonnull dereferenceable(4) %[[A2]], i32* nonnull dereferenceable(4) %[[A1]], i32* nonnull dereferenceable(4) %[[A6]])
+// CHECK:call void @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(i32 0, i32* nonnull dereferenceable(4) %[[A0]], i32* nonnull dereferenceable(4) %[[A5]], i32* nonnull dereferenceable(4) %[[A6]])
+// CHECK:call void @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(i32 0, i32* nonnull dereferenceable(4) %[[A4]], i32* nonnull dereferenceable(4) %[[A3]], i32* nonnull dereferenceable(4) %[[A6]])
+// CHECK:call void @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(i32 0, i32* nonnull dereferenceable(4) %[[A2]], i32* nonnull dereferenceable(4) %[[A1]], i32* nonnull dereferenceable(4) %[[A6]])
 
 struct DimStruct {
   uint2 Dims;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/hull/NoInputPatchHs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/hull/NoInputPatchHs.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T hs_6_0  %s 2>&1 | FileCheck %s
 
 // Make sure input control point is not 0.
-// CHECK: !{void ()* @"\01?HSPerPatchFunc@@YA?AUHSPerPatchData@@XZ", i32 1
+// CHECK: !{void ()* @"\01?HSPerPatchFunc{{[@$?.A-Za-z0-9_]+}}", i32 1
 
 
 struct HSPerPatchData

--- a/tools/clang/test/HLSLFileCheck/shader_targets/hull/static_res_in_patch_constant_func2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/hull/static_res_in_patch_constant_func2.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T hs_6_0  %s 2>&1 | FileCheck %s
 
 // Make sure @sf is restored to original value 3.0 in patch constant function.
-// CHECK:define void @"\01?HSPerPatchFunc@@YA?AUHSPerPatchData@@XZ"() {
+// CHECK:define void @"\01?HSPerPatchFunc{{[@$?.A-Za-z0-9_]+}}"() {
 
 // CHECK:call void @dx.op.storePatchConstant.f32
 // CHECK-NEXT:call void @dx.op.storePatchConstant.f32

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib-copy-vec.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib-copy-vec.hlsl
@@ -10,7 +10,7 @@
 // RUN: %dxc -T lib_6_3 -D INIT=agg -D ACCUM=agg.array[0]+agg.array[1] -D ARRAY %s | FileCheck %s -check-prefixes=CHECK,AGG
 // RUN: %dxc -T lib_6_3 -D INIT=s_agg -D ACCUM=s_agg.array[0]+s_agg.array[1] -D ARRAY %s | FileCheck %s -check-prefixes=CHECK,AGG
 
-// CHECK: define <3 x float> @"\01?main@@YA?AV?$vector@M$02@@XZ"()
+// CHECK: define <3 x float> @"\01?main{{[@$?.A-Za-z0-9_]+}}"()
 // VEC: alloca <3 x float>
 // VEC: alloca <3 x float>
 // AGG: alloca %struct.Agg

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure function call on external function has correct type.
-// CHECK: call float @"\01?test_extern@@YAMUT@@Y01U1@U1@AIAV?$matrix@M$01$01@@@Z"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* {{.*}}, %class.matrix.float.2.2* dereferenceable(16) {{.*}})
+// CHECK: call float @"\01?test_extern{{[@$?.A-Za-z0-9_]+}}"(%struct.T* {{.*}}, [2 x %struct.T]* {{.*}}, %struct.T* {{.*}}, %class.matrix.float.2.2* dereferenceable(16) {{.*}})
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten3.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure function call on external function has correct type.
 
-// CHECK: call float @"\01?test_extern@@YAMUT@@@Z"(%struct.T* nonnull {{.*}})
+// CHECK: call float @"\01?test_extern{{[@$?.A-Za-z0-9_]+}}"(%struct.T* nonnull {{.*}})
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten4.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_arg_flatten4.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure function call on external function has correct type.
 
-// CHECK: call float @"\01?test_extern@@YAMUFoo@@@Z"(%struct.Foo* {{.*}})
+// CHECK: call float @"\01?test_extern{{[@$?.A-Za-z0-9_]+}}"(%struct.Foo* {{.*}})
 
 struct Foo {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_empty_struct_arg.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_empty_struct_arg.hlsl
@@ -2,11 +2,11 @@
 
 // Make sure calls with empty struct params are well-behaved
 
-// CHECK: define float @"\01?test2@@YAMUT@@@Z"(%struct.T* nocapture readnone %t)
+// CHECK: define float @"\01?test2{{[@$?.A-Za-z0-9_]+}}"(%struct.T* nocapture readnone %t)
 // CHECK-NOT:memcpy
 // CHECK-NOT:load
 // CHECK-NOT:store
-// CHECK-DAG: call float @"\01?test@@YAMUT@@@Z"(%struct.T*
+// CHECK-DAG: call float @"\01?test{{[@$?.A-Za-z0-9_]+}}"(%struct.T*
 
 
 struct T {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_ret_struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_arg_flatten/lib_ret_struct.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure struct param used as out arg works.
 
-// CHECK: call void @"\01?getT@@YA?AUT@@XZ"
+// CHECK: call void @"\01?getT{{[@$?.A-Za-z0-9_]+}}"
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_exports_collision1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_exports_collision1.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -auto-binding-space 13 -exports Foo=VSMain;Foo=VSMainDup;Foo=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;Foo=\01?VSMainDup@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;RayGen;RayGen=fn -T lib_6_3 %s | FileCheck %s
 
 // Verify export collision errors
-// CHECK: error: Export name collides with another export: \01?Foo@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z
-// CHECK: error: Export name collides with another export: \01?RayGen@@YAXXZ
+// CHECK: error: Export name collides with another export: \01?Foo{{[@$?.A-Za-z0-9_]+}}
+// CHECK: error: Export name collides with another export: \01?RayGen{{[@$?.A-Za-z0-9_]+}}
 // CHECK: error: Export name collides with another export: Foo
 
 Buffer<int> T0;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_hs_shaders_only.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_hs_shaders_only.hlsl
@@ -1,12 +1,12 @@
 // RUN: %dxc -auto-binding-space 13 -T lib_6_3 -export-shaders-only %s | FileCheck %s
 
 // CHECK-NOT: unused
-// CHECK-NOT: @"\01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@V?$InputPatch@UPSSceneIn@@$0BA@@@@Z"
+// CHECK-NOT: @"\01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK: define void @"\01?HSPerPatchFunc2
 // CHECK: define void @HSMain1()
 // CHECK: define void @HSMain2()
 // CHECK: define void @HSMain3()
-// CHECK: define void @"\01?HSPerPatchFunc1@@YA?AUHSPerPatchData@@XZ"
+// CHECK: define void @"\01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}"
 
 Buffer<float> T_unused;
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_entry.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_entry.hlsl
@@ -11,7 +11,7 @@
 
 
 // CHECK: [[BCI:%.*]] = bitcast [24 x float]* {{.*}} to [2 x %class.matrix.float.4.3]*
-// CHECK: call float @"\01?mat_array_test@@YAMV?$vector@M$03@@0Y01V?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
+// CHECK: call float @"\01?mat_array_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, [2 x %class.matrix.float.4.3]* [[BCI]]
 
 float mat_array_test(in float4 inGBuffer0,
                                   in float4 inGBuffer1,

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_entry2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_mat_entry2.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3  %s | FileCheck %s
 
 // CHECK: [[BCI:%.*]] = bitcast <12 x float>* {{.*}} to %class.matrix.float.4.3*
-// CHECK:call <3 x float> @"\01?mat_test@@YA?AV?$vector@M$02@@V?$vector@M$03@@0AIAV?$matrix@M$03$02@@@Z"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
+// CHECK:call <3 x float> @"\01?mat_test{{[@$?.A-Za-z0-9_]+}}"(<4 x float> {{.*}}, <4 x float> {{.*}}, %class.matrix.float.4.3* {{.*}}[[BCI]])
 
 float3 mat_test(in float4 in0,
                                   in float4 in1,

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_alias.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_alias.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure out param has no-alias.
-// CHECK: float @"\01?test@@YAMMUT@@AIAV?$matrix@M$01$01@@M@Z"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
+// CHECK: float @"\01?test{{[@$?.A-Za-z0-9_]+}}"(float %a, %struct.T* noalias nocapture %t, %class.matrix.float.2.2* noalias nocapture dereferenceable(16) %m, float %b)
 
 struct T {
   float a;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_flat_extern_func.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_flat_extern_func.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure extern function don't need to flat is called.
-// CHECK: call void @"\01?test@@YAXMAIAM@Z"
+// CHECK: call void @"\01?test{{[@$?.A-Za-z0-9_]+}}"
 
 void test(float a, out float b);
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_vanilla_fn_attributes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_no_vanilla_fn_attributes.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure a bunch of vanilla function attributes are not added to the functions which are not inlined. 
 
-// CHECK: define float @"\01?foo@@YAMM@Z"(float %a)
+// CHECK: define float @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(float %a)
 // CHECK: nounwind
 // CHECK: readnone
 // CHECK-NOT: disable-tail-calls

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_remove_res.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_remove_res.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Ensure UnusedBuffer is removed:
-// CHECK-NOT: @"\01?UnusedBuffer@@3UByteAddressBuffer@@A"
+// CHECK-NOT: @"\01?UnusedBuffer{{[@$?.A-Za-z0-9_]+}}"
 
 // Ensure resource ID is 0 for ReadBuffer1 after UnusedBuffer global is removed.
-// CHECK: !{i32 0, %struct.ByteAddressBuffer* @"\01?ReadBuffer1@@3UByteAddressBuffer@@A", !"ReadBuffer1",
+// CHECK: !{i32 0, %struct.ByteAddressBuffer* @"\01?ReadBuffer1{{[@$?.A-Za-z0-9_]+}}", !"ReadBuffer1",
 
 RWByteAddressBuffer outputBuffer : register(u0);
 ByteAddressBuffer UnusedBuffer : register(t0);

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param_x.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param_x.hlsl
@@ -3,14 +3,14 @@
 // resources in return/params allowed for lib_6_x
 // CHECK: alloca %struct.T.hdl
 // CHECK: store %dx.types.Handle
-// CHECK: call void @"\01?resStruct@@YA?AUT2@@UT@@V?$vector@I$01@@@Z"(%struct.T2.hdl
+// CHECK: call void @"\01?resStruct{{[@$?.A-Za-z0-9_]+}}"(%struct.T2.hdl
 // CHECK: %[[ptr:[^, ]+]] = getelementptr inbounds %struct.T2.hdl
 // CHECK: %[[val:[^, ]+]] = load %dx.types.Handle, %dx.types.Handle* %[[ptr]]
 // CHECK: call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %[[val]])
 
 // Make sure save bitcast for global symbol and HLSL type.
-// CHECK:i32 0, %struct.RWByteAddressBuffer* bitcast (%dx.types.Handle* @"\01?outputBuffer@@3URWByteAddressBuffer@@A" to %struct.RWByteAddressBuffer*), !"outputBuffer"
-// CHECK:i32 1, %struct.RWByteAddressBuffer* bitcast (%dx.types.Handle* @"\01?outputBuffer2@@3URWByteAddressBuffer@@A" to %struct.RWByteAddressBuffer*), !"outputBuffer2"
+// CHECK:i32 0, %struct.RWByteAddressBuffer* bitcast (%dx.types.Handle* @"\01?outputBuffer{{[@$?.A-Za-z0-9_]+}}" to %struct.RWByteAddressBuffer*), !"outputBuffer"
+// CHECK:i32 1, %struct.RWByteAddressBuffer* bitcast (%dx.types.Handle* @"\01?outputBuffer2{{[@$?.A-Za-z0-9_]+}}" to %struct.RWByteAddressBuffer*), !"outputBuffer2"
 
 
 struct T {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_resource.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_resource.hlsl
@@ -1,8 +1,8 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
 // Make sure globals for resource exist.
-// CHECK: @"\01?g_txDiffuse@@3V?$Texture2D@V?$vector@M$03@@@@A" = external constant %"class.Texture2D<vector<float, 4> >", align 4
-// CHECK: @"\01?g_samLinear@@3USamplerState@@A" = external constant %struct.SamplerState, align 4
+// CHECK: @"\01?g_txDiffuse{{[@$?.A-Za-z0-9_]+}}" = external constant %"class.Texture2D<vector<float, 4> >", align 4
+// CHECK: @"\01?g_samLinear{{[@$?.A-Za-z0-9_]+}}" = external constant %struct.SamplerState, align 4
 
 Texture2D    g_txDiffuse;
 SamplerState    g_samLinear;

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_unresolved_func1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_unresolved_func1.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib1_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn1@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib2@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib2_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn1
 
 float external_fn();

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_unresolved_func2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_unresolved_func2.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -default-linkage external %s | FileCheck %s
 
-// CHECK-DAG: define float @"\01?lib2_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?external_fn2@@YAMXZ"()
-// CHECK-DAG: define float @"\01?call_lib1@@YAMXZ"()
-// CHECK-DAG: declare float @"\01?lib1_fn@@YAMXZ"()
+// CHECK-DAG: define float @"\01?lib2_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?external_fn2{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: define float @"\01?call_lib1{{[@$?.A-Za-z0-9_]+}}"()
+// CHECK-DAG: declare float @"\01?lib1_fn{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: @"\01?unused_fn2
 
 float external_fn();

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/vec_array_param.hlsl
@@ -2,7 +2,7 @@
 
 // Make sure vector array param works.
 // CHECK:%[[Cast:.+]] = bitcast [9 x float]* %{{.+}} to [3 x <3 x float>]*
-// CHECK:call float @"\01?foo@@YAMY02V?$vector@M$02@@@Z"([3 x <3 x float>]* %[[Cast]]
+// CHECK:call float @"\01?foo{{[@$?.A-Za-z0-9_]+}}"([3 x <3 x float>]* %[[Cast]]
 
 float foo(float3 a[3]);
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/no-phi-on-res.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/no-phi-on-res.hlsl
@@ -2,7 +2,7 @@
 
 // Verify no phi on resource, handle, or anything
 
-// CHECK: define void @"\01?main@@YAXXZ"()
+// CHECK: define void @"\01?main{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK-NOT: phi
 // CHECK: ret void
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_callable.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_callable.hlsl
@@ -3,12 +3,12 @@
 // CHECK: ; S                                 sampler      NA          NA      S0             s1     1
 // CHECK: ; T                                 texture     f32          2d      T0             t1     1
 
-// CHECK:@"\01?T@@3V?$Texture2D@V?$vector@M$03@@@@A" = external constant %"class.Texture2D<vector<float, 4> >", align 4
-// CHECK:@"\01?S@@3USamplerState@@A" = external constant %struct.SamplerState, align 4
+// CHECK:@"\01?T{{[@$?.A-Za-z0-9_]+}}" = external constant %"class.Texture2D<vector<float, 4> >", align 4
+// CHECK:@"\01?S{{[@$?.A-Za-z0-9_]+}}" = external constant %struct.SamplerState, align 4
 
 // CHECK: define void [[callable1:@"\\01\?callable1@[^\"]+"]](%struct.MyParam* noalias nocapture %param) #0 {
-// CHECK:   %[[i_0:[0-9]+]] = load %struct.SamplerState, %struct.SamplerState* @"\01?S@@3USamplerState@@A", align 4
-// CHECK:   %[[i_1:[0-9]+]] = load %"class.Texture2D<vector<float, 4> >", %"class.Texture2D<vector<float, 4> >"* @"\01?T@@3V?$Texture2D@V?$vector@M$03@@@@A", align 4
+// CHECK:   %[[i_0:[0-9]+]] = load %struct.SamplerState, %struct.SamplerState* @"\01?S{{[@$?.A-Za-z0-9_]+}}", align 4
+// CHECK:   %[[i_1:[0-9]+]] = load %"class.Texture2D<vector<float, 4> >", %"class.Texture2D<vector<float, 4> >"* @"\01?T{{[@$?.A-Za-z0-9_]+}}", align 4
 // CHECK:   %[[i_3:[0-9]+]] = call %dx.types.Handle @"dx.op.createHandleForLib.class.Texture2D<vector<float, 4> >"(i32 160, %"class.Texture2D<vector<float, 4> >" %[[i_1]])
 // CHECK:   %[[i_4:[0-9]+]] = call %dx.types.Handle @dx.op.createHandleForLib.struct.SamplerState(i32 160, %struct.SamplerState %[[i_0]])
 // CHECK:   %[[i_7:[0-9]+]] = call %dx.types.ResRet.f32 @dx.op.sampleLevel.f32(i32 62, %dx.types.Handle %[[i_3]], %dx.types.Handle %[[i_4]], float %[[i_5:[0-9]+]], float %[[i_6:[0-9]+]], float undef, float undef, i32 0, i32 0, i32 undef, float 0.000000e+00)

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_raygeneration.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_raygeneration.hlsl
@@ -2,10 +2,10 @@
 
 // CHECK: ; RTAS                              texture     i32         ras      T0             t5     1
 
-// CHECK:@"\01?RTAS@@3URaytracingAccelerationStructure@@A" = external constant %struct.RaytracingAccelerationStructure, align 4
+// CHECK:@"\01?RTAS{{[@$?.A-Za-z0-9_]+}}" = external constant %struct.RaytracingAccelerationStructure, align 4
 
 // CHECK: define void [[raygen1:@"\\01\?raygen1@[^\"]+"]]() #0 {
-// CHECK:   %[[i_0:[0-9]+]] = load %struct.RaytracingAccelerationStructure, %struct.RaytracingAccelerationStructure* @"\01?RTAS@@3URaytracingAccelerationStructure@@A", align 4
+// CHECK:   %[[i_0:[0-9]+]] = load %struct.RaytracingAccelerationStructure, %struct.RaytracingAccelerationStructure* @"\01?RTAS{{[@$?.A-Za-z0-9_]+}}", align 4
 // CHECK:   call i32 @dx.op.dispatchRaysIndex.i32(i32 145, i8 0)
 // CHECK:   call i32 @dx.op.dispatchRaysIndex.i32(i32 145, i8 1)
 // CHECK:   call i32 @dx.op.dispatchRaysDimensions.i32(i32 146, i8 0)

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_traceray_readback.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_traceray_readback.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 %s | FileCheck %s
 
 // Make sure we don't store the initial value (must load from payload after TraceRay)
-// CHECK: define void @"\01?RayGenTestMain@@YAXXZ"()
+// CHECK: define void @"\01?RayGenTestMain{{[@$?.A-Za-z0-9_]+}}"()
 // CHECK: call void @dx.op.textureStore.f32(i32 67,
 // CHECK-NOT: float 0.000000e+00, float 1.000000e+00, float 0.000000e+00, float 1.000000e+00
 // CHECK: , i8 15)

--- a/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_udt_sizes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/raytracing/raytracing_udt_sizes.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T lib_6_3 -auto-binding-space 11 -enable-16bit-types %s | FileCheck %s
 
 ///////////////////////////////////////
-// CHECK: !{void (%struct.Payload_20*, %struct.BuiltInTriangleIntersectionAttributes*)* @"\01?anyhit1@@YAXUPayload_20@@UBuiltInTriangleIntersectionAttributes@@@Z",
+// CHECK: !{void (%struct.Payload_20*, %struct.BuiltInTriangleIntersectionAttributes*)* @"\01?anyhit1{{[@$?.A-Za-z0-9_]+}}",
 // CHECK: !{i32 8, i32 9, i32 6, i32 20, i32 7, i32 8,
 
 struct Payload_20 {
@@ -17,7 +17,7 @@ void anyhit1( inout Payload_20 payload,
 }
 
 ///////////////////////////////////////
-// CHECK: !{void (%struct.Params_16*)* @"\01?callable4@@YAXUParams_16@@@Z",
+// CHECK: !{void (%struct.Params_16*)* @"\01?callable4{{[@$?.A-Za-z0-9_]+}}",
 // CHECK: !{i32 8, i32 12, i32 6, i32 16
 
 struct Params_16 {
@@ -32,7 +32,7 @@ void callable4( inout Params_16 params )
 }
 
 ///////////////////////////////////////
-// CHECK: !{void (%struct.Payload_16*, %struct.Attributes_12*)* @"\01?closesthit2@@YAXUPayload_16@@UAttributes_12@@@Z",
+// CHECK: !{void (%struct.Payload_16*, %struct.Attributes_12*)* @"\01?closesthit2{{[@$?.A-Za-z0-9_]+}}",
 // CHECK: !{i32 8, i32 10, i32 6, i32 16, i32 7, i32 12
 
 struct Payload_16 {
@@ -60,7 +60,7 @@ void closesthit2( inout Payload_16 payload,
 }
 
 ///////////////////////////////////////
-// CHECK: !{void (%struct.Payload_10*, %struct.Attributes_40*)* @"\01?closesthit3@@YAXUPayload_10@@UAttributes_40@@@Z",
+// CHECK: !{void (%struct.Payload_10*, %struct.Attributes_40*)* @"\01?closesthit3{{[@$?.A-Za-z0-9_]+}}",
 // CHECK: !{i32 8, i32 10, i32 6, i32 10, i32 7, i32 40
 
 struct Payload_10 {
@@ -87,7 +87,7 @@ void closesthit3( inout Payload_10 payload,
 }
 
 ///////////////////////////////////////
-// CHECK: !{void (%struct.Payload_8*)* @"\01?miss4@@YAXUPayload_8@@@Z",
+// CHECK: !{void (%struct.Payload_8*)* @"\01?miss4{{[@$?.A-Za-z0-9_]+}}",
 // CHECK: !{i32 8, i32 11, i32 6, i32 8
 
 struct Payload_8 {

--- a/tools/clang/test/HLSLFileCheckLit/passes/dxil/compute_view_id_state/multiple_entry_call.hlsl
+++ b/tools/clang/test/HLSLFileCheckLit/passes/dxil/compute_view_id_state/multiple_entry_call.hlsl
@@ -2,8 +2,8 @@
 
 // Just make sure it not crash.
 // CHECK: define void @main()
-// CHECK: call fastcc float @"\01?foo@@YAMM@Z"(float %{{.+}})
-// CHECK: call fastcc float @"\01?foo@@YAMM@Z"(float %{{.+}})
+// CHECK: call fastcc float @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(float %{{.+}})
+// CHECK: call fastcc float @"\01?foo{{[@$?.A-Za-z0-9_]+}}"(float %{{.+}})
 
 [noinline]
 float foo(float a) {


### PR DESCRIPTION
This is the simplest update, changing FileCheck-based tests to use a regular expression for matching symbol names rather than explicitly matching mangled symbols. The regex cases here are _extremely_ flexible skipping calling convention, parameter, and target-specific mangled information.