### PR TITLE
Cherry-pick of PIX: Preserve shader-access-tracking flag for descriptor-heap-indexed…

### DIFF
--- a/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
+++ b/lib/DxilPIXPasses/DxilShaderAccessTracking.cpp
@@ -552,10 +552,6 @@ bool DxilShaderAccessTracking::EmitResourceAccess(DxilModule &DM,
           auto* MultipliedOutOfBoundsValue = Builder.CreateMul(OneIfOutOfBounds, HlslOP->GetU32Const(EncodedInstructionNumber));
           auto* CombinedFlagOrInstructionValue = Builder.CreateAdd(MultipliedEncodedFlags, MultipliedOutOfBoundsValue);
 
-          // If we failed to find an instruction value, just return the access flags:
-          if (InstructionNumber == 0) {
-            CombinedFlagOrInstructionValue = EncodedFlags;
-          }
           Constant *ElementMask = HlslOP->GetI8Const(1);
           Function *StoreFunc = HlslOP->GetOpFunc(OP::OpCode::BufferStore,
                                                   Type::getInt32Ty(Ctx));

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicResourceOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicResourceOutOfBounds.hlsl
@@ -14,6 +14,7 @@ void Main()
 // The start of resource records has been passed in as 256. The limit of resource records is 272. 272-256 = 16.
 // 8 bytes per record means we have one record for out-of-bounds (that comes first), and one record for resource index 0.
 // The above HLSL references resource descriptor 1, so is out-of-bounds. Offset for out-of-bounds should thus be 256:
-// The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) for this access
-// CHECK:i32 256, i32 undef, i32 1375731712
+// The large integer is encoded flags for the ResourceAccessStyle (an enumerated type in lib\DxilPIXPasses\DxilShaderAccessTracking.cpp) 
+// for this access plus 0x80000000 to indicate descriptor-heap indexing.
+// CHECK:i32 256, i32 undef, i32 1476395008
 // CHECK:rawBufferLoad

--- a/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DynamicSamplerOutOfBounds.hlsl
@@ -21,4 +21,4 @@ float4 Main() : SV_Target
 
 // Out of bounds sampler access should be at offset 512
 // CHECK: call void @dx.op.bufferStore.i32(
-// CHECK:i32 512, i32 undef, i32 16777216
+// CHECK:i32 512, i32 undef, i32 134217728


### PR DESCRIPTION
… resources (#5053)

(cherry picked from commit c89ac13f0951805124c9d5e59720f0a49acf5740)