### PR TITLE
Add separate target for spirv unit test.

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -111,6 +111,19 @@ add_lit_target("check-clang-unit" "Running lit suite clang-unit"
         )
 # HLSL Change End - Add a separate target for clang unit tests
 
+# HLSL Change Begin - Add a separate target for spirv unit tests
+if (SPIRV_BUILD_TESTS)
+add_lit_target("check-spirv-unit" "Running lit suite spirv-unit"
+          ${CMAKE_CURRENT_SOURCE_DIR}/Unit
+          PARAMS ${CLANG_TEST_PARAMS}
+                 clang_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
+                 spirv_only=True
+          DEPENDS ClangUnitTests
+          ARGS ${CLANG_TEST_EXTRA_ARGS}
+        )
+endif (SPIRV_BUILD_TESTS)
+# HLSL Change End - Add a separate target for spirv unit tests
+
 # HLSL Change Begin - Add taef tests
 if (WIN32)
   add_lit_target("check-clang-taef" "Running lit suite hlsl"

--- a/tools/clang/test/Unit/lit.cfg
+++ b/tools/clang/test/Unit/lit.cfg
@@ -19,6 +19,11 @@ config.suffixes = []
 clang_obj_root = getattr(config, 'clang_obj_root', None)
 if clang_obj_root is not None:
     config.test_exec_root = os.path.join(clang_obj_root, 'unittests')
+
+    spirv_only = lit_config.params.get('spirv_only', False)
+    if spirv_only:
+        config.test_exec_root = os.path.join(config.test_exec_root, 'SPIRV')
+
     config.test_source_root = config.test_exec_root
 
 # testFormat: The test format to use to interpret tests.


### PR DESCRIPTION
This is to help enable lit by default.

Allow running spirv unit test separately.