### PR TITLE
Generate SharedLibAffix.h into the include directory

### DIFF
--- a/lib/DxcSupport/CMakeLists.txt
+++ b/lib/DxcSupport/CMakeLists.txt
@@ -14,9 +14,9 @@ add_llvm_library(LLVMDxcSupport
 #generate header with platform-specific library name
 configure_file(
 ${LLVM_MAIN_SRC_DIR}/lib/DxcSupport/SharedLibAffix.inc
-SharedLibAffix.h
+${LLVM_INCLUDE_DIR}/dxc/Support/SharedLibAffix.h
 )
 
-include_directories( ${LLVM_INCLUDE_DIR}/DxcSupport) #needed to find the generated header
+include_directories( ${LLVM_INCLUDE_DIR}/dxc/Support) #needed to find the generated header
 
 add_dependencies(LLVMDxcSupport TablegenHLSLOptions)


### PR DESCRIPTION
It is currently generated into lib\DxcSupport build output directory. Since it is a header, it should go into include/dxc/Support build output directory with other generated .h and .inc files. 