### PR TITLE
[NFC] Fix typo in FileCheck line.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
@@ -7,7 +7,7 @@ struct S {
     float g[4]; // nested array
 };
 
-// CHECK-LABLE: %src_main
+// CHECK-LABEL: %src_main
 float main(float val: A, uint index: B) : C {
     float r;
 

--- a/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.viewport-array-index.vs.hlsl
@@ -5,7 +5,7 @@
 
 // CHECK:      OpEntryPoint Vertex %main "main"
 // CHECK-SAME: %in_var_SV_ViewportArrayIndex
-// CHECK-SMAE: %gl_ViewportIndex
+// CHECK-SAME: %gl_ViewportIndex
 
 // CHECK:      OpDecorate %gl_ViewportIndex BuiltIn ViewportIndex
 // CHECK:      OpDecorate %in_var_SV_ViewportArrayIndex Location 0

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.counter.method.hlsl
@@ -52,7 +52,7 @@ ConsumeStructuredBuffer<float> globalCSBuffer;
 AppendStructuredBuffer<float> globalASBuffer;
 RWStructuredBuffer<float> globalRWSBuffer;
 
-// CHECK-LABLE: %src_main = OpFunction
+// CHECK-LABEL: %src_main = OpFunction
 float main() : VVV {
     TwoBundle localBundle;
     Wrapper   localWrapper;

--- a/tools/clang/test/HLSLFileCheck/hlsl/classes/this_cast_to_base_class.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/classes/this_cast_to_base_class.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -T lib_6_6 -HV 2021 -disable-lifetime-markers -fcgl %s | FileCheck %s
 
-// CHECK-LABLE: define linkonce_odr void @"\01?foo@Child@@QAAXXZ"(%class.Child* %this)
+// CHECK-LABEL: define linkonce_odr void @"\01?foo@Child@@QAAXXZ"(%class.Child* %this)
 // CHECK: %[[OutArg:.+]] = alloca %class.Parent
 // CHECK: %[[OutThisPtr:.+]] = getelementptr inbounds %class.Child, %class.Child* %this, i32 0, i32 0
 // CHECK: call void @"\01?lib_func2@@YAXVParent@@@Z"(%class.Parent* %[[OutArg]])
@@ -9,7 +9,7 @@
 // CHECK: %[[OutArgCpyPtr:.+]] = bitcast %class.Parent* %[[OutArg]] to i8*
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[OutThisCpyPtr]], i8* %[[OutArgCpyPtr]], i64 8, i32 1, i1 false)
 
-// CHECK-LABLE: define linkonce_odr void @"\01?bar@Child@@QAAXXZ"(%class.Child* %this)
+// CHECK-LABEL: define linkonce_odr void @"\01?bar@Child@@QAAXXZ"(%class.Child* %this)
 // CHECK: %[[InOutArg:.+]] = alloca %class.Parent
 // CHECK: %[[InOutThisPtr:.+]] = getelementptr inbounds %class.Child, %class.Child* %this, i32 0, i32 0
 
@@ -27,7 +27,7 @@
 // CHECK: call void @llvm.memcpy.p0i8.p0i8.i64(i8* %[[InOutThisCpyOutPtr]], i8* %[[InOutArgCpyOutPtr]], i64 8, i32 1, i1 false)
 
 
-// CHECK-LABLE: define linkonce_odr i32 @"\01?foo@Child@@QAAHHH@Z"(%class.Child* %this, i32 %a, i32 %b)
+// CHECK-LABEL: define linkonce_odr i32 @"\01?foo@Child@@QAAHHH@Z"(%class.Child* %this, i32 %a, i32 %b)
 // CHECK: %[[Arg:.+]] = alloca %class.Parent
 // CHECK: %[[Tmp:.+]] = alloca %class.Parent, align 4
 


### PR DESCRIPTION

FileCheck will skip typo lines like CHECK-LABLE.
Fix the typo so we got things tested.