### PR TITLE
Break test dependencies on mangling (Part 2)

### DIFF
--- a/tools/clang/test/HLSLFileCheck/validation/CallableParamIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/CallableParamIsStruct.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; CHECK: Function: BadCallable: error: Argument 'f' must be a struct type for callable shader function 'BadCallable'.
 
@@ -25,7 +25,7 @@ attributes #0 = { nounwind }
 !dx.entryPoints = !{!3, !4}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (float*)* @BadCallable, !"BadCallable", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/CallableParamIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/CallableParamIsStruct.ll
@@ -1,0 +1,33 @@
+; RUN: %dxv %s | FileCheck %s
+
+; CHECK: Function: BadCallable: error: Argument 'f' must be a struct type for callable shader function 'BadCallable'.
+
+; Test based on IR generated from the following HLSL:
+; struct Param { float f; };
+; [shader("callable")]
+; void CallableProto(inout Param p) { p.f += 1.0; }
+;
+; export void BadCallable(inout float f) { f += 1.0; }
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+; Function Attrs: nounwind
+define void @BadCallable(float* noalias nocapture dereferenceable(4) %f) #0 {
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (float*)* @BadCallable, !"BadCallable", null, null, !5}
+!5 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !6}
+!6 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/RayAttrIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayAttrIsStruct.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload {
@@ -50,7 +50,7 @@ attributes #0 = { nounwind }
 !dx.entryPoints = !{!3, !4, !7}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (%struct.Payload*, float)* @BadAnyHit, !"BadAnyHit", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/RayAttrIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayAttrIsStruct.ll
@@ -1,0 +1,61 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload {
+;   float f;
+; };
+; 
+; struct Attributes {
+;   float2 b;
+; };
+; 
+; [shader("anyhit")] void AnyHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.x;
+; }
+; 
+; export void BadAnyHit(inout Payload p, in float a) {
+;   p.f += a;
+; }
+; 
+; [shader("closesthit")] void ClosestHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; export void BadClosestHit(inout Payload p, in float a) {
+;   p.f += a;
+; }
+
+; CHECK: Argument 'a' must be a struct type for attributes in shader function 'BadAnyHit'
+; CHECK: Argument 'a' must be a struct type for attributes in shader function 'BadClosest'
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Payload = type { float }
+
+; Function Attrs: nounwind
+define void @BadAnyHit(%struct.Payload* noalias nocapture %p, float %a) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadClosest(%struct.Payload* noalias nocapture %p, float %a) #0 {
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (%struct.Payload*, float)* @BadAnyHit, !"BadAnyHit", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{void (%struct.Payload*, float)* @BadClosest, !"BadClosest", null, null, !8}
+!8 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+

--- a/tools/clang/test/HLSLFileCheck/validation/RayPayloadIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayPayloadIsStruct.ll
@@ -1,0 +1,77 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload {
+;   float f;
+; };
+; 
+; struct Attributes {
+;   float2 b;
+; };
+; 
+; [shader("anyhit")] void AnyHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.x;
+; }
+; 
+; export void BadAnyHit(inout float f, in Attributes a) {
+;   f += a.b.x;
+; }
+; 
+; [shader("closesthit")] void ClosestHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; export void BadClosestHit(inout float f, in Attributes a) {
+;   f += a.b.y;
+; }
+; 
+; [shader("miss")] void MissProto(inout Payload p) { p.f += 1.0; }
+; 
+; export void BadMiss(inout float f) {
+;   f += 1.0;
+; }
+
+; CHECK: Argument 'f' must be a struct type for payload in shader function 'BadAny'
+; CHECK: Argument 'f' must be a struct type for payload in shader function 'BadClosest'
+; CHECK: Argument 'f' must be a struct type for payload in shader function 'BadMiss'
+
+
+; ModuleID = '<stdin>'
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Attributes = type { <2 x float> }
+
+; Function Attrs: nounwind
+define void @BadAny(float* noalias nocapture dereferenceable(4) %f, %struct.Attributes* nocapture readonly %a) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadClosest(float* noalias nocapture dereferenceable(4) %f, %struct.Attributes* nocapture readonly %a) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadMiss(float* noalias nocapture dereferenceable(4) %f) #0 {
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7, !9}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (float*, %struct.Attributes*)* @BadAny, !"BadAny", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{void (float*, %struct.Attributes*)* @BadClosest, !"BadClosest", null, null, !8}
+!8 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!9 = !{void (float*)* @BadMiss, !"BadMiss", null, null, !10}
+!10 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !6}

--- a/tools/clang/test/HLSLFileCheck/validation/RayPayloadIsStruct.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayPayloadIsStruct.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload {
@@ -65,7 +65,7 @@ attributes #0 = { nounwind }
 !dx.entryPoints = !{!3, !4, !7, !9}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (float*, %struct.Attributes*)* @BadAny, !"BadAny", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/RayShaderExtraArg.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayShaderExtraArg.ll
@@ -1,0 +1,92 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload {
+;   float f;
+; };
+; 
+; struct Attributes {
+;   float2 b;
+; };
+; 
+; struct Param {
+;   float f;
+; };
+; 
+; [shader("anyhit")] void AnyHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.x;
+; }
+; 
+; [shader("closesthit")]
+; void ClosestHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; [shader("miss")] void MissProto(inout Payload p) { p.f += 1.0; }
+; 
+;     [shader("callable")] void CallableProto(inout Param p) {
+;   p.f += 1.0;
+; }
+; 
+; export void BadAnyHit(inout Payload p, in Attributes a, float f) { p.f += f; }
+; 
+; export void BadClosestHit(inout Payload p, in Attributes a, float f) {
+;   p.f += f;
+; }
+; 
+; export void BadMiss(inout Payload p, float f) { p.f += f; }
+; 
+; export void BadCallable(inout Param p, float f) { p.f += f; }
+
+; CHECK: Extra argument 'f' not allowed for shader function 'BadAnyHit'
+; CHECK: Extra argument 'f' not allowed for shader function 'BadClosestHit'
+; CHECK: Extra argument 'f' not allowed for shader function 'BadMiss'
+; CHECK: Extra argument 'f' not allowed for shader function 'BadCallable'
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Payload = type { float }
+%struct.Attributes = type { <2 x float> }
+%struct.Param = type { float }
+
+; Function Attrs: nounwind
+define void @BadAnyHit(%struct.Payload* noalias nocapture %p, %struct.Attributes* nocapture readnone %a, float %f) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadClosestHit(%struct.Payload* noalias nocapture %p, %struct.Attributes* nocapture readnone %a, float %f) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadMiss(%struct.Payload* noalias nocapture %p, float %f) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @BadCallable(%struct.Param* noalias nocapture %p, float %f) #0 {
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7, !9, !11}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (%struct.Payload*, %struct.Attributes*, float)* @BadAnyHit, !"BadAnyHit", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{void (%struct.Param*, float)* @BadCallable, !"BadCallable", null, null, !8}
+!8 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !6}
+!9 = !{void (%struct.Payload*, %struct.Attributes*, float)* @BadClosestHit, !"BadClosestHit", null, null, !10}
+!10 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!11 = !{void (%struct.Payload*, float)* @BadMiss, !"BadMiss", null, null, !12}
+!12 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !6}

--- a/tools/clang/test/HLSLFileCheck/validation/RayShaderExtraArg.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayShaderExtraArg.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload {
@@ -78,7 +78,7 @@ attributes #0 = { nounwind }
 !dx.entryPoints = !{!3, !4, !7, !9, !11}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (%struct.Payload*, %struct.Attributes*, float)* @BadAnyHit, !"BadAnyHit", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/RayShaderWithSignaturesFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayShaderWithSignaturesFail.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload { float f; };
@@ -84,7 +84,7 @@ attributes #1 = { nounwind }
 !dx.entryPoints = !{!3, !4, !10, !12, !14, !16, !18}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (%struct.Payload*, %struct.Attributes*)* @AnyHit, !"AnyHit", !5, null, !9}

--- a/tools/clang/test/HLSLFileCheck/validation/RayShaderWithSignaturesFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/RayShaderWithSignaturesFail.ll
@@ -1,0 +1,105 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload { float f; };
+; 
+; struct Attributes { float2 b; };
+; 
+; struct Param { float f; };
+; 
+; [shader("raygeneration")] void RayGenProto() { return; }
+; 
+; [shader("intersection")] void IntersectionProto() { return; }
+; 
+; [shader("anyhit")] void AnyHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.x;
+; }
+; 
+; [shader("closesthit")]
+; void ClosestHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; [shader("miss")] void MissProto(inout Payload p) { p.f += 1.0; }
+; 
+; [shader("callable")] void CallableProto(inout Param p) { p.f += 1.0; }
+; 
+; [shader("vertex")] float VSOutOnly() : OUTPUT { return 1; }
+; 
+; [shader("vertex")] void VSInOnly(float f : INPUT) : OUTPUT {}
+; 
+; [shader("vertex")] float VSInOut(float f : INPUT) : OUTPUT { return f; }
+
+; CHECK: Ray tracing shader 'RayGen' should not have any shader signatures
+; CHECK: Ray tracing shader 'Intersection' should not have any shader signatures
+; CHECK: Ray tracing shader 'AnyHit' should not have any shader signatures
+; CHECK: Ray tracing shader 'ClosestHit' should not have any shader signatures
+; CHECK: Ray tracing shader 'Miss' should not have any shader signatures
+; CHECK: Ray tracing shader 'Callable' should not have any shader signatures
+
+; ModuleID = '<stdin>'
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Payload = type { float }
+%struct.Attributes = type { <2 x float> }
+%struct.Param = type { float }
+
+; Function Attrs: nounwind readnone
+define void @RayGen() #0 {
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+define void @Intersection() #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @AnyHit(%struct.Payload* noalias nocapture %p, %struct.Attributes* nocapture readonly %a) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @ClosestHit(%struct.Payload* noalias nocapture %p, %struct.Attributes* nocapture readonly %a) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @Miss(%struct.Payload* noalias nocapture %p) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @Callable(%struct.Param* noalias nocapture %p) #1 {
+  ret void
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !10, !12, !14, !16, !18}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (%struct.Payload*, %struct.Attributes*)* @AnyHit, !"AnyHit", !5, null, !9}
+!5 = !{!6, null, null}
+!6 = !{!7}
+!7 = !{i32 0, !"INPUT", i8 9, i8 0, !8, i8 0, i32 1, i8 1, i32 0, i8 0, null}
+!8 = !{i32 0}
+!9 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !8}
+!10 = !{void (%struct.Param*)* @Callable, !"Callable", !5, null, !11}
+!11 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !8}
+!12 = !{void (%struct.Payload*, %struct.Attributes*)* @ClosestHit, !"ClosestHit", !5, null, !13}
+!13 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !8}
+!14 = !{void ()* @Intersection, !"Intersection", !5, null, !15}
+!15 = !{i32 8, i32 8, i32 5, !8}
+!16 = !{void (%struct.Payload*)* @Miss, !"Miss", !5, null, !17}
+!17 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !8}
+!18 = !{void ()* @RayGen, !"RayGen", !5, null, !19}
+!19 = !{i32 8, i32 7, i32 5, !8}

--- a/tools/clang/test/HLSLFileCheck/validation/ShaderFunctionReturnTypeVoid.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/ShaderFunctionReturnTypeVoid.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload {
@@ -89,7 +89,7 @@ attributes #1 = { nounwind readonly }
 !dx.entryPoints = !{!3, !4, !7, !9, !11, !13}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{float (%struct.Payload*, %struct.Attributes*)* @AnyHit, !"AnyHit", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/ShaderFunctionReturnTypeVoid.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/ShaderFunctionReturnTypeVoid.ll
@@ -1,0 +1,105 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload {
+;   float f;
+; };
+; 
+; struct Attributes {
+;   float2 b;
+; };
+; 
+; struct Param {
+;   float f;
+; };
+; 
+; [shader("raygeneration")] void RayGenProto() { return; }
+; 
+; [shader("anyhit")] void AnyHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.x;
+; }
+; 
+; [shader("closesthit")] void ClosestHitProto(inout Payload p, in Attributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; [shader("miss")] void MissProto(inout Payload p) {
+;   p.f += 1.0;
+; }
+; 
+; [shader("callable")] void CallableProto(inout Param p) { p.f += 1.0; }
+; 
+; export float BadRayGen() {
+;   return 1;
+; }
+; 
+; export float BadAnyHit(inout Payload p, in Attributes a) { return p.f; }
+; 
+; export float BadClosestHit(inout Payload p, in Attributes a) { return p.f; }
+; 
+; export float BadMiss(inout Payload p) { return p.f; }
+; 
+; export float BadCallable(inout Param p) { return p.f; }
+
+; CHECK: Shader function 'RayGen' must have void return type
+; CHECK: Shader function 'AnyHit' must have void return type
+; CHECK: Shader function 'ClosestHit' must have void return type
+; CHECK: Shader function 'Miss' must have void return type
+; CHECK: Shader function 'Callable' must have void return type
+
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Payload = type { float }
+%struct.Attributes = type { <2 x float> }
+%struct.Param = type { float }
+
+; Function Attrs: nounwind readnone
+define float @RayGen() #0 {
+  ret float 1.000000e+00
+}
+
+; Function Attrs: nounwind readonly
+define float @AnyHit(%struct.Payload* noalias nocapture readonly %p, %struct.Attributes* nocapture readnone %a) #1 {
+  ret float 1.000000e+00
+}
+
+; Function Attrs: nounwind readonly
+define float @ClosestHit(%struct.Payload* noalias nocapture readonly %p, %struct.Attributes* nocapture readnone %a) #1 {
+  ret float 1.000000e+00
+}
+
+; Function Attrs: nounwind readonly
+define float @Miss(%struct.Payload* noalias nocapture readonly %p) #1 {
+  ret float 1.000000e+00
+}
+
+; Function Attrs: nounwind readonly
+define float @Callable(%struct.Param* noalias nocapture readonly %p) #1 {
+  ret float 1.000000e+00
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind readonly }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7, !9, !11, !13}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{float (%struct.Payload*, %struct.Attributes*)* @AnyHit, !"AnyHit", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{float (%struct.Param*)* @Callable, !"Callable", null, null, !8}
+!8 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !6}
+!9 = !{float (%struct.Payload*, %struct.Attributes*)* @ClosestHit, !"ClosestHit", null, null, !10}
+!10 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!11 = !{float (%struct.Payload*)* @Miss, !"Miss", null, null, !12}
+!12 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !6}
+!13 = !{float ()* @RayGen, !"RayGen", null, null, !14}
+!14 = !{i32 8, i32 7, i32 5, !6}

--- a/tools/clang/test/HLSLFileCheck/validation/WhenMissingPayloadThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenMissingPayloadThenFail.ll
@@ -1,0 +1,82 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload { float f; };
+; 
+; struct Attributes { float2 b; };
+; 
+; struct Param { float f; };
+; 
+; [shader("anyhit")]
+; void AnyHitProto(inout Payload p, in Attributes a) { p.f += a.b.x; }
+; 
+; [shader("closesthit")]
+; void ClosestHitProto(inout Payload p, in Attributes a) { p.f += a.b.y; }
+; 
+; [shader("miss")]
+; void MissProto(inout Payload p) { p.f += 1.0; }
+; 
+; [shader("callable")]
+; void CallableProto(inout Param p) { p.f += 1.0; }
+; 
+; export void BadAnyHit(inout Payload p) { p.f += 1.0; }
+; 
+; export void BadClosestHit() {}
+; 
+; export void BadMiss() {}
+; 
+; export void BadCallable() {}
+
+; CHECK: anyhit shader 'AnyHit' missing required attributes parameter
+; CHECK: closesthit shader 'Closest' missing required payload parameter
+; CHECK: closesthit shader 'Closest' missing required attributes parameter
+; CHECK: miss shader 'Miss' missing required payload parameter
+; CHECK: callable shader 'Callable' missing required params parameter
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.Payload = type { float }
+
+; Function Attrs: nounwind
+define void @AnyHit(%struct.Payload* noalias nocapture %p) #0 {
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+define void @Closest() #1 {
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+define void @Miss() #1 {
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+define void @Callable() #1 {
+  ret void
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7, !9, !11}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (%struct.Payload*)* @AnyHit, !"AnyHit", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{void ()* @Callable, !"Callable", null, null, !8}
+!8 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !6}
+!9 = !{void ()* @Closest, !"Closest", null, null, !10}
+!10 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!11 = !{void ()* @Miss, !"Miss", null, null, !12}
+!12 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !6}
+

--- a/tools/clang/test/HLSLFileCheck/validation/WhenMissingPayloadThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenMissingPayloadThenFail.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload { float f; };
@@ -67,7 +67,7 @@ attributes #1 = { nounwind readnone }
 !dx.entryPoints = !{!3, !4, !7, !9, !11}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (%struct.Payload*)* @AnyHit, !"AnyHit", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/WhenPayloadSizeTooSmallThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenPayloadSizeTooSmallThenFail.ll
@@ -1,0 +1,112 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the following HLSL:
+; struct Payload { float f; };
+; 
+; struct Attributes { float2 b; };
+; 
+; struct Param { float f; };
+; 
+; [shader("raygeneration")] void RayGenProto() { return; }
+; 
+; [shader("intersection")] void IntersectionProto() { return; }
+; 
+; [shader("anyhit")]
+; void AnyHitProto(inout Payload p, in Attributes a) { p.f += a.b.x; }
+; 
+; [shader("closesthit")]
+; void ClosestHitProto(inout Payload p, in Attributes a) { p.f += a.b.y; }
+; 
+; [shader("miss")] void MissProto(inout Payload p) { p.f += 1.0; }
+; 
+; [shader("callable")] void CallableProto(inout Param p) { p.f += 1.0; }
+; 
+; struct BadPayload { float2 f; };
+; 
+; struct BadAttributes { float3 b; };
+; 
+; struct BadParam { float2 f; };
+; 
+; export void BadRayGen() { return; }
+; 
+; export void BadIntersection() { return; }
+; 
+; export void BadAnyHit(inout BadPayload p, in BadAttributes a) { p.f += a.b.x; }
+; 
+; export void BadClosestHit(inout BadPayload p, in BadAttributes a) {
+;   p.f += a.b.y;
+; }
+; 
+; export void BadMiss(inout BadPayload p) { p.f += 1.0; }
+; 
+; export void BadCallable(inout BadParam p) { p.f += 1.0; }
+
+; CHECK: For shader 'AnyHit', payload size is smaller than argument's allocation size
+; CHECK: For shader 'AnyHit', attribute size is smaller than argument's allocation size
+; CHECK: For shader 'ClosestHit', payload size is smaller than argument's allocation size
+; CHECK: For shader 'ClosestHit', attribute size is smaller than argument's allocation size
+; CHECK: For shader 'Miss', payload size is smaller than argument's allocation size
+; CHECK: For shader 'Callable', params size is smaller than argument's allocation size
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%struct.BadPayload = type { <2 x float> }
+%struct.BadAttributes = type { <3 x float> }
+%struct.BadParam = type { <2 x float> }
+
+; Function Attrs: nounwind readnone
+define void @RayGen() #0 {
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+define void @Intersection() #0 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @AnyHit(%struct.BadPayload* noalias nocapture %p, %struct.BadAttributes* nocapture readonly %a) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @ClosestHit(%struct.BadPayload* noalias nocapture %p, %struct.BadAttributes* nocapture readonly %a) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @Miss(%struct.BadPayload* noalias nocapture %p) #1 {
+  ret void
+}
+
+; Function Attrs: nounwind
+define void @Callable(%struct.BadParam* noalias nocapture %p) #1 {
+  ret void
+}
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind }
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.entryPoints = !{!3, !4, !7, !9, !11, !13, !15}
+
+!0 = !{i32 1, i32 3}
+!1 = !{i32 1, i32 7}
+!2 = !{!"lib", i32 6, i32 3}
+!3 = !{null, !"", null, null, null}
+!4 = !{void (%struct.BadPayload*, %struct.BadAttributes*)* @AnyHit, !"AnyHit", null, null, !5}
+!5 = !{i32 8, i32 9, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!6 = !{i32 0}
+!7 = !{void (%struct.BadParam*)* @Callable, !"Callable", null, null, !8}
+!8 = !{i32 8, i32 12, i32 6, i32 4, i32 5, !6}
+!9 = !{void (%struct.BadPayload*, %struct.BadAttributes*)* @ClosestHit, !"ClosestHit", null, null, !10}
+!10 = !{i32 8, i32 10, i32 6, i32 4, i32 7, i32 8, i32 5, !6}
+!11 = !{void ()* @Intersection, !"Intersection", null, null, !12}
+!12 = !{i32 8, i32 8, i32 5, !6}
+!13 = !{void (%struct.BadPayload*)* @Miss, !"Miss", null, null, !14}
+!14 = !{i32 8, i32 11, i32 6, i32 4, i32 5, !6}
+!15 = !{void ()* @RayGen, !"RayGen", null, null, !16}
+!16 = !{i32 8, i32 7, i32 5, !6}

--- a/tools/clang/test/HLSLFileCheck/validation/WhenPayloadSizeTooSmallThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenPayloadSizeTooSmallThenFail.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.3 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the following HLSL:
 ; struct Payload { float f; };
@@ -94,7 +94,7 @@ attributes #1 = { nounwind }
 !dx.entryPoints = !{!3, !4, !7, !9, !11, !13, !15}
 
 !0 = !{i32 1, i32 3}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 3}
 !2 = !{!"lib", i32 6, i32 3}
 !3 = !{null, !"", null, null, null}
 !4 = !{void (%struct.BadPayload*, %struct.BadAttributes*)* @AnyHit, !"AnyHit", null, null, !5}

--- a/tools/clang/test/HLSLFileCheck/validation/WhenZeroInputPatchCountWithInputThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenZeroInputPatchCountWithInputThenFail.ll
@@ -1,0 +1,44 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test based on IR generated from the DXILValidation/SimpleHs1.hlsl test file.
+; CHECK: When HS input control point count is 0, no input signature should exist
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @PatchFunc() {
+  ret void
+}
+
+define void @main() {
+  ret void
+}
+
+!dx.version = !{!0}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.viewIdState = !{!3}
+!dx.entryPoints = !{!4}
+
+!0 = !{i32 1, i32 0}
+!1 = !{i32 1, i32 7}
+!2 = !{!"hs", i32 6, i32 0}
+!3 = !{[29 x i32] [i32 13, i32 13, i32 1, i32 2, i32 4, i32 8, i32 16, i32 32, i32 0, i32 0, i32 256, i32 512, i32 1024, i32 0, i32 4096, i32 13, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]}
+!4 = !{void ()* @main, !"main", !5, null, !20}
+!5 = !{!6, !6, !16}
+!6 = !{!7, !10, !12, !14}
+!7 = !{i32 0, !"SV_Position", i8 9, i8 3, !8, i8 4, i32 1, i8 4, i32 0, i8 0, !9}
+!8 = !{i32 0}
+!9 = !{i32 3, i32 15}
+!10 = !{i32 1, !"TEXCOORD", i8 9, i8 0, !8, i8 2, i32 1, i8 2, i32 1, i8 0, !11}
+!11 = !{i32 3, i32 3}
+!12 = !{i32 2, !"NORMAL", i8 9, i8 0, !8, i8 2, i32 1, i8 3, i32 2, i8 0, !13}
+!13 = !{i32 3, i32 7}
+!14 = !{i32 3, !"SV_RenderTargetArrayIndex", i8 5, i8 4, !8, i8 1, i32 1, i8 1, i32 3, i8 0, !15}
+!15 = !{i32 3, i32 1}
+!16 = !{!17, !19}
+!17 = !{i32 0, !"SV_TessFactor", i8 9, i8 25, !18, i8 0, i32 3, i8 1, i32 0, i8 3, !15}
+!18 = !{i32 0, i32 1, i32 2}
+!19 = !{i32 1, !"SV_InsideTessFactor", i8 9, i8 26, !8, i8 0, i32 1, i8 1, i32 3, i8 0, !15}
+!20 = !{i32 0, i64 512, i32 3, !21}
+!21 = !{void ()* @PatchFunc, i32 0, i32 3, i32 2, i32 3, i32 3, float 6.400000e+01}

--- a/tools/clang/test/HLSLFileCheck/validation/WhenZeroInputPatchCountWithInputThenFail.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/WhenZeroInputPatchCountWithInputThenFail.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.0 | %dxv %s | FileCheck %s
 
 ; Test based on IR generated from the DXILValidation/SimpleHs1.hlsl test file.
 ; CHECK: When HS input control point count is 0, no input signature should exist
@@ -21,7 +21,7 @@ define void @main() {
 !dx.entryPoints = !{!4}
 
 !0 = !{i32 1, i32 0}
-!1 = !{i32 1, i32 7}
+!1 = !{i32 1, i32 0}
 !2 = !{!"hs", i32 6, i32 0}
 !3 = !{[29 x i32] [i32 13, i32 13, i32 1, i32 2, i32 4, i32 8, i32 16, i32 32, i32 0, i32 0, i32 256, i32 512, i32 1024, i32 0, i32 4096, i32 13, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0]}
 !4 = !{void ()* @main, !"main", !5, null, !20}

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -1378,8 +1378,8 @@ TEST_F(DxilContainerTest, CompileWhenOkThenCheckReflection1) {
         ID3D12FunctionReflection *pFunctionReflection = pLibraryReflection->GetFunctionByIndex(iFn);
         D3D12_FUNCTION_DESC FnDesc;
         pFunctionReflection->GetDesc(&FnDesc);
-        std::string Name = FnDesc.Name;
-        if (Name.compare("\01?function0@@YAM$min16f@@Z") == 0) {
+        llvm::StringRef Name = FnDesc.Name;
+        if (Name.startswith("\01?function0@")) {
           VERIFY_ARE_EQUAL(FnDesc.Version, EncodedVersion_lib_6_3);
           VERIFY_ARE_EQUAL(FnDesc.ConstantBuffers, 1U);
           VERIFY_ARE_EQUAL(FnDesc.BoundResources, 2U);
@@ -1410,7 +1410,7 @@ TEST_F(DxilContainerTest, CompileWhenOkThenCheckReflection1) {
               VERIFY_FAIL(L"Unexpected resource used");
             }
           }
-        } else if (Name.compare("\01?function1@@YAMM$min12i@@Z") == 0) {
+        } else if (Name.startswith("\01?function1@")) {
           VERIFY_ARE_EQUAL(FnDesc.Version, EncodedVersion_lib_6_3);
           VERIFY_ARE_EQUAL(FnDesc.ConstantBuffers, 1U);
           VERIFY_ARE_EQUAL(FnDesc.BoundResources, 4U);


### PR DESCRIPTION
This is the second part of my changes to break test dependencies on symbol mangling.

This change rewrites a handful of the tests in ValidationTest.cpp that rely on rewriting IR from compiled shaders to be invalid. The new versions of the tests use simplified IR as the source instead of HLSL. Each test has the HLSL source it was derived from captured in code comments.