### PR TITLE
Change SharedLibAffix.h include path to eliminate the need to change he build setting

### DIFF
--- a/lib/DxcSupport/CMakeLists.txt
+++ b/lib/DxcSupport/CMakeLists.txt
@@ -17,6 +17,4 @@ ${LLVM_MAIN_SRC_DIR}/lib/DxcSupport/SharedLibAffix.inc
 ${LLVM_INCLUDE_DIR}/dxc/Support/SharedLibAffix.h
 )
 
-include_directories( ${LLVM_INCLUDE_DIR}/dxc/Support) #needed to find the generated header
-
 add_dependencies(LLVMDxcSupport TablegenHLSLOptions)

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -15,7 +15,7 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/FileIOHelper.h"
 #include "dxc/Support/WinFunctions.h"
-#include "SharedLibAffix.h"
+#include "dxc/Support/SharedLibAffix.h" // header generated during DXC build
 
 namespace dxc {
 


### PR DESCRIPTION
The file dxcapi.use.cpp is used in other projects and would require build changes if the #include did not change.