### PR TITLE
Don't try to validate invalid decls

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -4944,6 +4944,8 @@ public:
         case AR_TOBJ_COMPOUND:
           {
             const RecordDecl* recordDecl = recordType->getDecl();
+            if (recordDecl->isInvalidDecl())
+              return false;
             RecordDecl::field_iterator begin = recordDecl->field_begin();
             RecordDecl::field_iterator end = recordDecl->field_end();
             bool result = true;

--- a/tools/clang/test/HLSL/invalid-decl-template-arg.hlsl
+++ b/tools/clang/test/HLSL/invalid-decl-template-arg.hlsl
@@ -1,0 +1,9 @@
+// RUN: %clang_cc1 -fsyntax-only -verify %s
+
+struct FOOO_A_B { // expected-note{{'FOOO_A_B' declared here}} expected-note{{definition of 'FOOO_A_B' is not complete until the closing '}'}}
+  FOOO_A v0; // expected-error{{unknown type name 'FOOO_A'; did you mean 'FOOO_A_B'}} expected-error{{field has incomplete type 'FOOO_A_B}}
+};
+
+RWStructuredBuffer<FOOO_A_B> Input;
+
+void main() {}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -54,6 +54,7 @@ public:
   TEST_METHOD(RunIncompleteType)
   TEST_METHOD(RunIndexingOperator)
   TEST_METHOD(RunIntrinsicExamples)
+  TEST_METHOD(RunInvalidDeclTemplateArg)
   TEST_METHOD(RunMatrixAssignments)
   TEST_METHOD(RunMatrixSyntax)
   TEST_METHOD(RunMatrixSyntaxExactPrecision)
@@ -254,6 +255,10 @@ TEST_F(VerifierTest, RunIndexingOperator) {
 
 TEST_F(VerifierTest, RunIntrinsicExamples) {
   CheckVerifiesHLSL(L"intrinsic-examples.hlsl");
+}
+
+TEST_F(VerifierTest, RunInvalidDeclTemplateArg) {
+  CheckVerifiesHLSL(L"invalid-decl-template-arg.hlsl");
 }
 
 TEST_F(VerifierTest, RunMatrixAssignments) {


### PR DESCRIPTION
We should not try to validate template arguments for invalid decls. Doing so seems to result in infinte recursion that eventually kills the compiler... so let's not do that.

Fixes #3455