### PR TITLE
Add -include flag to force pre-included header

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -136,8 +136,9 @@ public:
   llvm::StringRef DefaultLinkage; // OPT_default_linkage
   llvm::StringRef ImportBindingTable;    // OPT_import_binding_table
   llvm::StringRef BindingTableDefine; // OPT_binding_table_define
-  unsigned DefaultTextCodePage = DXC_CP_UTF8; // OPT_encoding
+  std::vector<std::string> PreIncludeFiles; // OPT_include
 
+  unsigned DefaultTextCodePage = DXC_CP_UTF8; // OPT_encoding
   bool AllResourcesBound = false; // OPT_all_resources_bound
   bool IgnoreOptSemDefs = false; // OPT_ignore_opt_semdefs
   bool AstDump = false; // OPT_ast_dump

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -217,11 +217,11 @@ def fno_reroll_loops : Flag<["-"], "fno-reroll-loops">, Group<hlsloptz_Group>,
 */
 def help : Flag<["-", "--", "/"], "help">, Flags<[DriverOption]>, Group<hlslcore_Group>,
   HelpText<"Display available options">;
+def include_ : JoinedOrSeparate<["-", "--"], "include">, Group<hlslcomp_Group>, EnumName<"include">,
+    MetaVarName<"<file>">, HelpText<"Include file before parsing">, Flags<[CoreOption]>;
 /*
 def imacros : JoinedOrSeparate<["-", "--"], "imacros">, Group<clang_i_Group>, Flags<[CoreOption]>,
   HelpText<"Include macros from file before parsing">, MetaVarName<"<file>">;
-def include_ : JoinedOrSeparate<["-", "--"], "include">, Group<clang_i_Group>, EnumName<"include">,
-    MetaVarName<"<file>">, HelpText<"Include file before parsing">, Flags<[CoreOption]>;
 def mllvm : Separate<["-"], "mllvm">, Flags<[CoreOption]>,
   HelpText<"Additional arguments to forward to LLVM's option processing">;
 def mms_bitfields : Flag<["-"], "mms-bitfields">, Group<m_Group>, Flags<[CoreOption]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -680,6 +680,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
 
   opts.Exports = Args.getAllArgValues(OPT_exports);
 
+  opts.PreIncludeFiles = Args.getAllArgValues(OPT_include);
+
   opts.DefaultLinkage = Args.getLastArgValue(OPT_default_linkage);
   if (!opts.DefaultLinkage.empty()) {
     if (!(opts.DefaultLinkage.equals_lower("internal") ||

--- a/tools/clang/test/DXC/Inputs/smoke.hlsl
+++ b/tools/clang/test/DXC/Inputs/smoke.hlsl
@@ -1,5 +1,7 @@
 // Verify that we can successfully process an include
+#ifndef NO_INCLUDE
 #include "include/inc1.hlsli"
+#endif
 
 int g;
 static int g_unused;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1457,6 +1457,8 @@ public:
       PPOpts.addMacroDef(defines[i]);
     }
 
+    PPOpts.Includes = Opts.PreIncludeFiles;
+
     PPOpts.IgnoreLineDirectives = Opts.IgnoreLineDirectives;
     // fxc compatibility: pre-expand operands before performing token-pasting
     PPOpts.ExpandTokPastingArg = Opts.LegacyMacroExpansion;

--- a/utils/hct/hcttestcmds.cmd
+++ b/utils/hct/hcttestcmds.cmd
@@ -33,6 +33,11 @@ call :run dxc.exe /T ps_6_0 "%testfiles%\Inputs\smoke.hlsl" /Fc smoke.hlsl.h
 call :check_file smoke.hlsl.h find "define void @main()" del
 if %Failed% neq 0 goto :failed
 
+set testname=Command-line preincluded header
+call :run dxc.exe "%testfiles%\Inputs\smoke.hlsl" /D "NO_INCLUDE=1" -include "%testfiles%\Inputs\include\inc1.hlsli" /T ps_6_0 /Fc smoke.hlsl.h
+call :check_file smoke.hlsl.h find "define void @main()" del
+if %Failed% neq 0 goto :failed
+
 set testname=Test extra DXC outputs together
 call :run dxc.exe /T ps_6_0 "%testfiles%\Inputs\smoke.hlsl" /DDX12 /Dcheck_warning /Fh smoke.hlsl.h /Vn g_myvar /Fc smoke.ll /Fo smoke.cso /Fre smoke.reflection /Frs smoke.rootsig /Fe smoke.err
 call :check_file smoke.hlsl.h find g_myvar find "0x44, 0x58" find "define void @main()" del


### PR DESCRIPTION
Use the existing mechanisms in clang to allow specifying one or more preincluded headers for a shader using the -include <file> flag