### PR TITLE
WIP: [SPIR-V] Add support for vk::buffer_ref attribute

### DIFF
--- a/tools/clang/include/clang/AST/ASTContext.h
+++ b/tools/clang/include/clang/AST/ASTContext.h
@@ -16,6 +16,7 @@
 #define LLVM_CLANG_AST_ASTCONTEXT_H
 
 #include "clang/AST/ASTTypeTraits.h"
+#include "clang/AST/Attr.h"
 #include "clang/AST/CanonicalType.h"
 #include "clang/AST/CommentCommandTraits.h"
 #include "clang/AST/Decl.h"
@@ -2490,6 +2491,17 @@ public:
   };
 
   llvm::StringMap<SectionInfo> SectionInfos;
+
+  // Buffer Reference Utilities
+public:
+  bool IsBufferRef(const ValueDecl *D) const;
+  bool IsBufferRefDecl(const Decl *D) const;
+  bool IsBufferRefTypeDef(QualType T) const;
+  clang::VKBufferRefAttr *GetBufferRefAttr(const Expr *base) const;
+  clang::VKBufferRefAttr *GetBufferRefAttr(const ValueDecl *decl) const;
+  uint32_t BufferRefByteSize() const;
+  uint32_t BufferRefByteAlign() const;
+  clang::CanQualType BufferRefProxyType() const;
 };
 
 /// \brief Utility function for constructing a nullary selector.

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1012,6 +1012,14 @@ def VKLocation : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKBufferRef : InheritableAttr {
+  let Spellings = [CXX11<"vk", "buffer_ref">];
+  let Subjects = SubjectList<[Function, Var, ParmVar, Field, TypedefName], ErrorDiag>;
+  let Args = [IntArgument<"Number">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 def VKIndex : InheritableAttr {
   let Spellings = [CXX11<"vk", "index">];
   let Subjects = SubjectList<[Function, ParmVar, Field], ErrorDiag>;

--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -233,7 +233,8 @@ bool isAKindOfStructuredOrByteBuffer(QualType type);
 /// \brief Returns true if the given type is the HLSL (RW)StructuredBuffer,
 /// (RW)ByteAddressBuffer, {Append|Consume}StructuredBuffer, or a struct
 /// containing one of the above.
-bool isOrContainsAKindOfStructuredOrByteBuffer(QualType type);
+bool isOrContainsAKindOfStructuredOrByteBuffer(const ASTContext &astContext,
+                                               QualType type);
 
 /// \brief Returns true if the given type is the HLSL Buffer type.
 bool isBuffer(QualType type);
@@ -285,7 +286,7 @@ bool isOpaqueArrayType(QualType type);
 /// (in a recursive away).
 ///
 /// Note: legalization specific code
-bool isOpaqueStructType(QualType type);
+bool isOpaqueStructType(const ASTContext &astContext, QualType type);
 
 /// \brief Returns true if the given type can use relaxed precision
 /// decoration. Integer and float types with lower than 32 bits can be

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -95,7 +95,7 @@ public:
   /// this method for the variable itself.
   SpirvVariable *addFnVar(QualType valueType, SourceLocation,
                           llvm::StringRef name = "", bool isPrecise = false,
-                          SpirvInstruction *init = nullptr);
+                          SpirvInstruction *init = nullptr, bool isRef = false);
 
   /// \brief Ends building of the current function. All basic blocks constructed
   /// from the beginning or after ending the previous function will be collected
@@ -208,7 +208,8 @@ public:
   SpirvAccessChain *
   createAccessChain(QualType resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
-                    SourceLocation loc, SourceRange range = {});
+                    SourceLocation loc, SourceRange range = {},
+                    uint32_t bufRefAlign = 0);
   SpirvAccessChain *
   createAccessChain(const SpirvType *resultType, SpirvInstruction *base,
                     llvm::ArrayRef<SpirvInstruction *> indexes,
@@ -689,6 +690,9 @@ public:
 
   /// \brief Decorates the given target with noperspective
   void decorateNoPerspective(SpirvInstruction *target, SourceLocation);
+
+  /// \brief Decorates the given target with aliased pointer
+  void decorateAliasedPointer(SpirvInstruction *target, SourceLocation);
 
   /// \brief Decorates the given target with sample
   void decorateSample(SpirvInstruction *target, SourceLocation);

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -848,7 +848,8 @@ public:
   SpirvAccessChain(QualType resultType, SourceLocation loc,
                    SpirvInstruction *base,
                    llvm::ArrayRef<SpirvInstruction *> indexVec,
-                   SourceRange range = {});
+                   SourceRange range = {},
+                   uint32_t bufRefAlign = 0);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvAccessChain)
 
@@ -861,10 +862,12 @@ public:
 
   SpirvInstruction *getBase() const { return base; }
   llvm::ArrayRef<SpirvInstruction *> getIndexes() const { return indices; }
+  uint32_t getBufferRefAlign() const { return bufferRefAlign; }
 
 private:
   SpirvInstruction *base;
   llvm::SmallVector<SpirvInstruction *, 4> indices;
+  uint32_t bufferRefAlign;
 };
 
 /// \brief Atomic instructions.

--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -1923,6 +1923,8 @@ public:
                                    AccessSpecifier AS,
                                    AttributeList *MSPropertyAttr);
 
+  bool IsBufferRefDecltr(Declarator *D);
+
   FieldDecl *CheckFieldDecl(DeclarationName Name, QualType T,
                             TypeSourceInfo *TInfo,
                             RecordDecl *Record, SourceLocation Loc,

--- a/tools/clang/lib/AST/RecordLayoutBuilder.cpp
+++ b/tools/clang/lib/AST/RecordLayoutBuilder.cpp
@@ -2312,6 +2312,11 @@ MicrosoftRecordLayoutBuilder::getAdjustedElementInfo(
   // Get the alignment of the field type's natural alignment, ignore any
   // alignment attributes.
   ElementInfo Info;
+  if (Context.IsBufferRef(FD)) {
+    std::tie(Info.Size, Info.Alignment) = Context.getTypeInfoInChars(
+        Context.BufferRefProxyType());
+    return Info;
+  }
   std::tie(Info.Size, Info.Alignment) =
       Context.getTypeInfoInChars(FD->getType()->getUnqualifiedDesugaredType());
   // Respect align attributes on the field.

--- a/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
+++ b/tools/clang/lib/SPIRV/AlignmentSizeCalculator.cpp
@@ -305,8 +305,14 @@ std::pair<uint32_t, uint32_t> AlignmentSizeCalculator::getAlignmentAndSize(
 
     for (const auto *field : structType->getDecl()->fields()) {
       uint32_t memberAlignment = 0, memberSize = 0;
-      std::tie(memberAlignment, memberSize) =
-          getAlignmentAndSize(field->getType(), rule, isRowMajor, stride);
+      // Check for buffer ref
+      if (astContext.IsBufferRef(field)) {
+        memberAlignment = astContext.BufferRefByteAlign();
+        memberSize = astContext.BufferRefByteSize();
+      } else {
+        std::tie(memberAlignment, memberSize) =
+            getAlignmentAndSize(field->getType(), rule, isRowMajor, stride);
+      }
 
       if (rule == SpirvLayoutRule::RelaxedGLSLStd140 ||
           rule == SpirvLayoutRule::RelaxedGLSLStd430 ||

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -189,8 +189,18 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
   }
   // Pointer type
   else if (const auto *ptrType = dyn_cast<SpirvPointerType>(type)) {
-    addCapabilityForType(ptrType->getPointeeType(), loc, sc);
+    addCapabilityForType(ptrType->getPointeeType(), loc,
+                         ptrType->getStorageClass());
     if (sc == spv::StorageClass::PhysicalStorageBuffer) {
+      addExtension(Extension::KHR_physical_storage_buffer,
+                   "SPV_KHR_physical_storage_buffer", loc);
+      addCapability(spv::Capability::PhysicalStorageBufferAddresses);
+    }
+  }
+  // Forward Pointer type
+  else if (const auto *ptrType = dyn_cast<SpirvFwdPointerType>(type)) {
+    if (ptrType->getStorageClass() ==
+        spv::StorageClass::PhysicalStorageBuffer) {
       addExtension(Extension::KHR_physical_storage_buffer,
                    "SPV_KHR_physical_storage_buffer", loc);
       addCapability(spv::Capability::PhysicalStorageBufferAddresses);

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -57,7 +57,7 @@ public:
         typeConstantBinary(typesVec), takeNextIdFunction(takeNextIdFn),
         emittedConstantInts({}), emittedConstantFloats({}),
         emittedConstantComposites({}), emittedConstantNulls({}),
-        emittedConstantBools() {
+        emittedConstantBools(), emittedFwdPtrs() {
     assert(decVec);
     assert(typesVec);
   }
@@ -176,6 +176,10 @@ private:
   // emittedTypes is a map that caches the result-id of types in order to avoid
   // emitting an identical type multiple times.
   llvm::DenseMap<const SpirvType *, uint32_t> emittedTypes;
+
+  // emittedFwdPtrs is a vector that keeps track of forward pointers that have
+  // been emitted for later generation of the true pointers.
+  std::vector<const SpirvFwdPointerType *> emittedFwdPtrs;
 };
 
 /// \breif The visitor class that emits the SPIR-V words from the in-memory

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -46,7 +46,8 @@ public:
   /// The lowering is recursive; all the types that the target type depends
   /// on will be created in SpirvContext.
   const SpirvType *lowerType(QualType type, SpirvLayoutRule,
-                             llvm::Optional<bool> isRowMajor, SourceLocation);
+                             llvm::Optional<bool> isRowMajor, SourceLocation,
+                             bool isRef = false);
 
   bool useSpvArrayForHlslMat1xN() { return useArrayForMat1xN; }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -186,7 +186,7 @@ private:
   /// reference to adjust the CodeGen if not nullptr.
   void storeValue(SpirvInstruction *lhsPtr, SpirvInstruction *rhsVal,
                   QualType lhsValType, SourceLocation loc,
-                  SourceRange range = {});
+                  SourceRange range = {}, bool isRef = false);
 
   /// Decomposes and reconstructs the given srcVal of the given valType to meet
   /// the requirements of the dstLR layout rule.
@@ -363,11 +363,14 @@ private:
   /// CXXOperatorCallExprs. Also special handles all mesh shader out attributes
   /// to return the entire expression in order for caller to extract the member
   /// expression.
-  const Expr *
-  collectArrayStructIndices(const Expr *expr, bool rawIndex,
-                            llvm::SmallVectorImpl<uint32_t> *rawIndices,
-                            llvm::SmallVectorImpl<SpirvInstruction *> *indices,
-                            bool *isMSOutAttribute = nullptr);
+  const Expr *collectArrayStructIndices(
+      const Expr *expr, bool rawIndex,
+      llvm::SmallVectorImpl<uint32_t> *rawIndices,
+      llvm::SmallVectorImpl<SpirvInstruction *> *indices,
+      bool *isMSOutAttribute = nullptr,
+      llvm::SmallVectorImpl<bool> *isRef = nullptr,
+      llvm::SmallVectorImpl<QualType> *refTypes = nullptr,
+      llvm::SmallVectorImpl<uint32_t> *refAligns = nullptr);
 
   /// For L-values, creates an access chain to index into the given SPIR-V
   /// evaluation result and returns the new SPIR-V evaluation result.
@@ -376,7 +379,11 @@ private:
   SpirvInstruction *derefOrCreatePointerToValue(
       QualType baseType, SpirvInstruction *base, QualType elemType,
       const llvm::SmallVector<SpirvInstruction *, 4> &indices,
-      SourceLocation loc, SourceRange range = {});
+      SourceLocation loc, SourceRange range = {},
+      const llvm::SmallVector<bool, 4> *isRef = nullptr,
+      const llvm::SmallVector<QualType, 4> *refTypes = nullptr,
+      const llvm::SmallVector<uint32_t, 4> *refAligns = nullptr,
+      uint32_t baseAlign = 0);
 
   SpirvVariable *turnIntoLValue(QualType type, SpirvInstruction *source,
                                 SourceLocation loc);

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -404,10 +404,11 @@ SpirvUnreachable::SpirvUnreachable(SourceLocation loc)
 SpirvAccessChain::SpirvAccessChain(QualType resultType, SourceLocation loc,
                                    SpirvInstruction *baseInst,
                                    llvm::ArrayRef<SpirvInstruction *> indexVec,
-                                   SourceRange range)
+                                   SourceRange range, uint32_t bufRefAlign)
     : SpirvInstruction(IK_AccessChain, spv::Op::OpAccessChain, resultType, loc,
                        range),
-      base(baseInst), indices(indexVec.begin(), indexVec.end()) {}
+      base(baseInst), indices(indexVec.begin(), indexVec.end()),
+      bufferRefAlign(bufRefAlign) {}
 
 SpirvAtomic::SpirvAtomic(spv::Op op, QualType resultType, SourceLocation loc,
                          SpirvInstruction *pointerInst, spv::Scope s,


### PR DESCRIPTION
vk::buffer_ref(X) when prepended to a struct typedef indicates the typedef is actually a reference to the struct, similar to C++ references, that is, syntactically treated like a struct, but implemented with a pointer with byte alignment X. vk::buffer_ref can alternately be prepended to member and local variable declarations of struct type with similar semantics.

@Keenuts @cassiebeckley This is a WIP as I still need to add tests, but the implementation is otherwise complete, so if you could start reviewing the code, that would be great.

I will presently be adding additional high-level description of the feature to this PR.