### PR TITLE
build: add exception header

### DIFF
--- a/lib/IR/Value.cpp
+++ b/lib/IR/Value.cpp
@@ -33,6 +33,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/raw_ostream.h"
+#include <exception> // HLSL Change - add header.
 #include <algorithm>
 using namespace llvm;
 


### PR DESCRIPTION
This file uses std::current_exception, so it should include <exception>