### PR TITLE
Make matrix with different orientation different types.

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -32,6 +32,7 @@ namespace clang {
   class CXXMethodDecl;
   class CXXRecordDecl;
   class ClassTemplateDecl;
+  class TypeAliasTemplateDecl;
   class ExtVectorType;
   class FunctionDecl;
   class FunctionTemplateDecl;
@@ -78,6 +79,11 @@ enum HLSLScalarType {
   HLSLScalarType_float64,
   HLSLScalarType_int8_4packed,
   HLSLScalarType_uint8_4packed
+};
+
+enum HLSLMatrixOrientation {
+  ColumnMajor = 0,
+  RowMajor,
 };
 
 HLSLScalarType MakeUnsigned(HLSLScalarType T);
@@ -307,7 +313,10 @@ ParamModFromAttributeList(_In_opt_ clang::AttributeList *pAttributes);
 void AddHLSLMatrixTemplate(
   clang::ASTContext& context,
   _In_ clang::ClassTemplateDecl* vectorTemplateDecl,
-  _Outptr_ clang::ClassTemplateDecl** matrixTemplateDecl);
+  _Outptr_ clang::ClassTemplateDecl** matrixTemplateDecl,
+  _Outptr_ clang::TypeAliasTemplateDecl **defaultMatrixAliasDecl,
+  _Outptr_ clang::TypeAliasTemplateDecl **rowMajorMatrixAliasDecl,
+  _Outptr_ clang::TypeAliasTemplateDecl **columnMajorMatrixAliasDecl);
 
 void AddHLSLVectorTemplate(
   clang::ASTContext& context, 
@@ -414,6 +423,10 @@ clang::QualType GetHLSLInputPatchElementType(clang::QualType type);
 unsigned GetHLSLInputPatchCount(clang::QualType type);
 clang::QualType GetHLSLOutputPatchElementType(clang::QualType type);
 unsigned GetHLSLOutputPatchCount(clang::QualType type);
+clang::QualType GetHLSLMatrixTypeWithMajor(clang::QualType matType,
+                                           bool isRowMajor, clang::Sema &sema);
+bool IsRowMajorMatrixTemplate(clang::QualType matType);
+bool IsDefaultMajorMatrixTemplate(clang::QualType matType);
 
 bool IsHLSLSubobjectType(clang::QualType type);
 bool GetHLSLSubobjectKind(clang::QualType type, DXIL::SubobjectKind &subobjectKind, 

--- a/tools/clang/include/clang/AST/OperationKinds.h
+++ b/tools/clang/include/clang/AST/OperationKinds.h
@@ -314,6 +314,8 @@ enum CastKind {
   CK_HLSLVectorToMatrixCast,
   CK_HLSLMatrixToVectorCast,
   CK_HLSLDerivedToBase,
+  CK_HLSLRowMajorToColMajor,
+  CK_HLSLColMajorToRowMajor,
   // HLSL ComponentConversion (HLSLCC) Casts:
   CK_HLSLCC_IntegralCast,
   CK_HLSLCC_IntegralToBoolean,

--- a/tools/clang/include/clang/Sema/Overload.h
+++ b/tools/clang/include/clang/Sema/Overload.h
@@ -97,6 +97,8 @@ namespace clang {
     ICK_HLSLVector_Splat,      ///< HLSLVector/Matrix splat
     ICK_HLSLVector_Truncation, ///< HLSLVector/Matrix truncation
     ICK_HLSL_Derived_To_Base,  ///< HLSL Derived-to-base
+    ICK_HLSLRowMajorToColMajor,///< HLSL row major to column major
+    ICK_HLSLColMajorToRowMajor,///< HLSL column major to row major
     // HLSL Change Ends
 
     ICK_Num_Conversion_Kinds   ///< The number of conversion kinds
@@ -160,6 +162,9 @@ namespace clang {
     /// vector or matrix type.  If used, Second must be one of the 
     /// ICK_HLSLVector_* implicit conversion kinds.
     ImplicitConversionKind ComponentConversion : 8;
+    /// ComponentConversion - If this is not ICK_Identity, this describes
+    /// the type of conversion to apply to matrix major.
+    ImplicitConversionKind MatrixMajorConversion : 8;
     // HLSL Change Ends
 
     /// Third - The third conversion can be a qualification conversion.

--- a/tools/clang/lib/AST/Expr.cpp
+++ b/tools/clang/lib/AST/Expr.cpp
@@ -1716,6 +1716,10 @@ const char *CastExpr::getCastKindName() const {
     return "HLSLCC_FloatingToBoolean";
   case CK_HLSLCC_FloatingCast:
     return "HLSLCC_FloatingCast";
+  case CK_HLSLRowMajorToColMajor:
+    return "HLSLRowMajorToColMajor";
+  case CK_HLSLColMajorToRowMajor:
+    return "HLSLColMajorToRowMajor";
   // HLSL Change Ends
   }
 

--- a/tools/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/tools/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -41,14 +41,17 @@ CodeGenTypes::CodeGenTypes(CodeGenModule &cgm)
 }
 
 CodeGenTypes::~CodeGenTypes() {
+  for (auto *Key : dupMatTys) {
+    RecordDeclTypes.erase(Key);
+    CGRecordLayouts.erase(Key);
+  }
   llvm::DeleteContainerSeconds(CGRecordLayouts);
-
   for (llvm::FoldingSet<CGFunctionInfo>::iterator
        I = FunctionInfos.begin(), E = FunctionInfos.end(); I != E; )
     delete &*I++;
 }
 
-void CodeGenTypes::addRecordTypeName(const RecordDecl *RD,
+bool CodeGenTypes::addRecordTypeName(const RecordDecl *RD,
                                      llvm::StructType *Ty,
                                      StringRef suffix) {
   SmallString<256> TypeName;
@@ -91,6 +94,12 @@ void CodeGenTypes::addRecordTypeName(const RecordDecl *RD,
     OS  << ".";   CompType.print(OS, policy);
     OS  << "." << templateDecl->getTemplateArgs().get(1).getAsIntegral().toString(10)
         << "." << templateDecl->getTemplateArgs().get(2).getAsIntegral().toString(10);
+        //;
+        //<< "."
+        //<< ((templateDecl->getTemplateArgs()
+        //        .get(3)
+        //        .getAsIntegral()
+        //        .getLimitedValue() == 0) ? "Col" : "Row");
   } else if (const ClassTemplateSpecializationDecl *Spec = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
     const TemplateArgumentList &TemplateArgs = Spec->getTemplateArgs();
     TemplateSpecializationType::PrintTemplateArgumentList(OS,
@@ -102,6 +111,7 @@ void CodeGenTypes::addRecordTypeName(const RecordDecl *RD,
   // HLSL Change Ends
 
   Ty->setName(OS.str());
+  return Ty->getName() != OS.str();
 }
 
 /// ConvertTypeForMem - Convert type T into a llvm::Type.  This differs from
@@ -722,10 +732,29 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
 
   llvm::StructType *&Entry = RecordDeclTypes[Key];
 
+  bool bNameConflict = false;
   // If we don't have a StructType at all yet, create the forward declaration.
   if (!Entry) {
     Entry = llvm::StructType::create(getLLVMContext());
-    addRecordTypeName(RD, Entry, "");
+    bNameConflict = addRecordTypeName(RD, Entry, "");
+  }
+  bool isMatrix =
+      RD->getIdentifier() == &(getContext().Idents.get(StringRef("matrix")));
+  // Hack: force matrix with different major generate same IR type.
+  if (isMatrix && bNameConflict) {
+    StringRef Name = Entry->getName();
+    Name = Name.substr(0, Name.find_last_of('.'));
+    llvm::StructType *MatST = TheModule.getTypeByName(Name);
+    CGRecordLayout *Layout = nullptr;
+    for (auto &It : RecordDeclTypes) {
+      if (It.second == MatST) {
+        Layout = CGRecordLayouts[It.first];
+        break;
+      }
+    }
+    dupMatTys.insert(Key);
+    CGRecordLayouts[Key] = Layout;
+    Entry = MatST;
   }
   llvm::StructType *Ty = Entry;
 

--- a/tools/clang/lib/CodeGen/CodeGenTypes.h
+++ b/tools/clang/lib/CodeGen/CodeGenTypes.h
@@ -138,7 +138,7 @@ class CodeGenTypes {
 
   /// Maps clang struct type with corresponding record layout info.
   llvm::DenseMap<const Type*, CGRecordLayout *> CGRecordLayouts;
-
+  llvm::DenseSet<const Type *> dupMatTys;
   /// Contains the LLVM IR type for any converted RecordDecl.
   llvm::DenseMap<const Type*, llvm::StructType *> RecordDeclTypes;
   
@@ -289,7 +289,8 @@ public:
 
   /// addRecordTypeName - Compute a name from the given record decl with an
   /// optional suffix and name the given LLVM type using it.
-  void addRecordTypeName(const RecordDecl *RD, llvm::StructType *Ty,
+  /// HLSL Change - return true when name conflict.
+  bool addRecordTypeName(const RecordDecl *RD, llvm::StructType *Ty,
                          StringRef suffix);
   
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3341,6 +3341,11 @@ SpirvInstruction *SpirvEmitter::doCastExpr(const CastExpr *expr,
       return 0;
     }
   }
+  case CastKind::CK_HLSLColMajorToRowMajor:
+  case CastKind::CK_HLSLRowMajorToColMajor: {
+    // FIXME: support major cast.
+    return doExpr(subExpr, range);
+  }
   default:
     emitError("implicit cast kind '%0' unimplemented", expr->getExprLoc())
         << expr->getCastKindName() << expr->getSourceRange();

--- a/tools/clang/lib/Sema/SemaExprCXX.cpp
+++ b/tools/clang/lib/Sema/SemaExprCXX.cpp
@@ -3453,6 +3453,8 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
   case ICK_HLSLVector_Scalar:
   case ICK_HLSLVector_Truncation:
   case ICK_HLSLVector_Conversion:
+  case ICK_HLSLColMajorToRowMajor:
+  case ICK_HLSLRowMajorToColMajor:
     From = hlsl::PerformHLSLConversion(this, From, ToType.getUnqualifiedType(), SCS, CCK).get();
     break;
   // HLSL Change Ends
@@ -3511,6 +3513,23 @@ Sema::PerformImplicitConversion(Expr *From, QualType ToType,
   default:
     llvm_unreachable("Improper third standard conversion");
   }
+
+  // HLSL Change Starts
+  switch (SCS.MatrixMajorConversion) {
+  default:
+    break;
+  case ICK_HLSLColMajorToRowMajor: {
+    From = ImpCastExprToType(From, ToType, CK_HLSLColMajorToRowMajor,
+                             From->getValueKind())
+               .get();
+  } break;
+  case ICK_HLSLRowMajorToColMajor: {
+    From = ImpCastExprToType(From, ToType, CK_HLSLRowMajorToColMajor,
+                             From->getValueKind())
+               .get();
+  } break;
+  }
+  // HLSL Change Ends
 
   // If this conversion sequence involved a scalar -> atomic conversion, perform
   // that conversion now.

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -714,6 +714,7 @@ struct ArTypeInfo {
   UINT uRows;
   UINT uCols;
   UINT uTotalElts;
+  bool bIsRowMajor;
 };
 
 using namespace clang;
@@ -801,14 +802,14 @@ QualType GetOrCreateTemplateSpecialization(
 }
 
 /// <summary>Instantiates a new matrix type specialization or gets an existing one from the AST.</summary>
-static
-QualType GetOrCreateMatrixSpecialization(ASTContext& context, Sema* sema,
-  _In_ ClassTemplateDecl* matrixTemplateDecl,
-  QualType elementType, uint64_t rowCount, uint64_t colCount)
-{
+static QualType
+GetOrCreateMatrixSpecialization(ASTContext &context, Sema *sema,
+                                _In_ ClassTemplateDecl *matrixTemplateDecl,
+                                QualType elementType, uint64_t rowCount,
+                                uint64_t colCount, bool isRowMajor) {
   DXASSERT_NOMSG(sema);
 
-  TemplateArgument templateArgs[3] = {
+  TemplateArgument templateArgs[4] = {
       TemplateArgument(elementType),
       TemplateArgument(
           context,
@@ -819,7 +820,13 @@ QualType GetOrCreateMatrixSpecialization(ASTContext& context, Sema* sema,
           context,
           llvm::APSInt(
               llvm::APInt(context.getIntWidth(context.IntTy), colCount), false),
-          context.IntTy)};
+          context.IntTy),
+      TemplateArgument(
+          context,
+          llvm::APSInt(
+              llvm::APInt(context.getIntWidth(context.IntTy), isRowMajor?1:0), false),
+          context.IntTy),
+  };
 
   QualType matrixSpecializationType = GetOrCreateTemplateSpecialization(context, *sema, matrixTemplateDecl, ArrayRef<TemplateArgument>(templateArgs));
 
@@ -3068,6 +3075,10 @@ private:
 
   // Declaration for matrix and vector templates.
   ClassTemplateDecl* m_matrixTemplateDecl;
+  TypeAliasTemplateDecl *m_rowMajorMatDecl;
+  TypeAliasTemplateDecl *m_columnMajorMatDecl;
+  TypeAliasTemplateDecl *m_defaultMatDecl;
+
   ClassTemplateDecl* m_vectorTemplateDecl;
   // Namespace decl for hlsl intrinsic functions
   NamespaceDecl*     m_hlslNSDecl;
@@ -3091,10 +3102,13 @@ private:
   TypedefDecl* m_scalarTypeDefs[HLSLScalarTypeCount];
 
   // Matrix types already built indexed by type, row-count, col-count. Should probably move to a sparse map. Instrument to figure out best initial size.
-  QualType m_matrixTypes[HLSLScalarTypeCount][4][4];
+  QualType m_matrixTypes[HLSLScalarTypeCount][4][4][2];
 
   // Matrix types already built, in shorthand form.
-  TypedefDecl* m_matrixShorthandTypes[HLSLScalarTypeCount][4][4];
+  // The last dimension is for orientation, default is 0, column is 1, row is 2.
+  // m_matrixShorthandTypes types are alias so it need to save default orientation for check after attributed types removed.
+  // m_matrixTypes is the final template specialization, it only save column/row major, no default orientation.
+  TypedefDecl* m_matrixShorthandTypes[HLSLScalarTypeCount][4][4][3];
 
   // Vector types already built.
   QualType m_vectorTypes[HLSLScalarTypeCount][4];
@@ -3881,20 +3895,6 @@ private:
                             ImplicitConversionKind &convKind = ImplicitConversionKindUnused,
                             TYPE_CONVERSION_REMARKS &Remarks = RemarksUnused);
 
-  clang::TypedefDecl *LookupMatrixShorthandType(HLSLScalarType scalarType, UINT rowCount, UINT colCount) {
-    DXASSERT_NOMSG(scalarType != HLSLScalarType::HLSLScalarType_unknown &&
-                   rowCount <= 4 && colCount <= 4);
-    TypedefDecl *qts =
-        m_matrixShorthandTypes[scalarType][rowCount - 1][colCount - 1];
-    if (qts == nullptr) {
-      QualType type = LookupMatrixType(scalarType, rowCount, colCount);
-      qts = CreateMatrixSpecializationShorthand(*m_context, type, scalarType,
-                                                rowCount, colCount);
-      m_matrixShorthandTypes[scalarType][rowCount - 1][colCount - 1] = qts;
-    }
-    return qts;
-  }
-
   clang::TypedefDecl *LookupVectorShorthandType(HLSLScalarType scalarType, UINT colCount) {
     DXASSERT_NOMSG(scalarType != HLSLScalarType::HLSLScalarType_unknown &&
                    colCount <= 4);
@@ -3993,18 +3993,91 @@ public:
     return m_scalarTypeDefs[scalarType];
   }
 
-  QualType LookupMatrixType(HLSLScalarType scalarType, unsigned int rowCount, unsigned int colCount)
+  QualType LookupScalarType(HLSLScalarType scalarType) {
+    // lazy initialization of scalar types
+    if (m_scalarTypes[scalarType].isNull()) {
+      LookupScalarTypeDef(scalarType);
+    }
+    return m_scalarTypes[scalarType];
+  }
+
+  QualType CreateAliasMatrixType(QualType rawMatTy, QualType eltTy,
+                                 UINT rowCount, UINT colCount, bool isRowMajor,
+                                 bool isDefault) {
+    auto *matDecl = m_defaultMatDecl;
+    if (!isDefault)
+      matDecl = isRowMajor ? m_rowMajorMatDecl : m_columnMajorMatDecl;
+    auto &context = *m_context;
+    TemplateArgument templateArgs[3] = {
+        TemplateArgument(eltTy),
+        TemplateArgument(
+            context,
+            llvm::APSInt(
+                llvm::APInt(m_context->getIntWidth(m_context->IntTy), rowCount),
+                false),
+            context.IntTy),
+        TemplateArgument(
+            context,
+            llvm::APSInt(
+                llvm::APInt(m_context->getIntWidth(context.IntTy), colCount),
+                false),
+            context.IntTy),
+    };
+    return m_context->getTemplateSpecializationType(TemplateName(matDecl),
+                                                    templateArgs, 3, rawMatTy);
+  }
+
+  clang::TypedefDecl *LookupMatrixShorthandType(HLSLScalarType scalarType,
+                                                UINT rowCount, UINT colCount,
+                                                bool isRowMajor, bool isDefault) {
+    DXASSERT_NOMSG(scalarType != HLSLScalarType::HLSLScalarType_unknown &&
+                   rowCount <= 4 && colCount <= 4);
+    auto *matDecl = m_defaultMatDecl;
+    int orientation = 0;
+    if (!isDefault) {
+      matDecl = isRowMajor ? m_rowMajorMatDecl : m_columnMajorMatDecl;
+      orientation = isRowMajor ? 2 : 1;
+    }
+
+    TypedefDecl *qts = m_matrixShorthandTypes[scalarType][rowCount - 1]
+                                             [colCount - 1][orientation];
+    if (qts == nullptr) {
+      QualType type =
+          LookupMatrixType(scalarType, rowCount, colCount, isRowMajor);
+      type = CreateAliasMatrixType(type, LookupScalarType(scalarType), rowCount,
+                                   colCount,
+                                   isRowMajor, isDefault);
+      qts = CreateMatrixSpecializationShorthand(*m_context, type, scalarType,
+                                                rowCount, colCount);
+      m_matrixShorthandTypes[scalarType][rowCount - 1][colCount - 1]
+                            [orientation] = qts;
+    }
+    return qts;
+  }
+
+  QualType LookupMatrixType(HLSLScalarType scalarType, unsigned int rowCount, unsigned int colCount, bool isRowMajor)
   {
-    QualType qt = m_matrixTypes[scalarType][rowCount - 1][colCount - 1];
+    QualType qt = m_matrixTypes[scalarType][rowCount - 1][colCount - 1][isRowMajor?1:0];
     if (qt.isNull()) {
       // lazy initialization of scalar types 
       if (m_scalarTypes[scalarType].isNull()) {
         LookupScalarTypeDef(scalarType);
       }
-      qt = GetOrCreateMatrixSpecialization(*m_context, m_sema, m_matrixTemplateDecl, m_scalarTypes[scalarType], rowCount, colCount);
-      m_matrixTypes[scalarType][rowCount - 1][colCount - 1] = qt;
+      qt = ::GetOrCreateMatrixSpecialization(
+          *m_context, m_sema, m_matrixTemplateDecl, m_scalarTypes[scalarType],
+          rowCount, colCount, isRowMajor);
+      m_matrixTypes[scalarType][rowCount - 1][colCount - 1]
+                   [isRowMajor ? 1 : 0] = qt;
     }
     return qt;
+  }
+
+  QualType GetOrCreateMatrixSpecialization(QualType elementType,
+                                           uint64_t rowCount, uint64_t colCount,
+                                           bool isRowMajor) {
+    return ::GetOrCreateMatrixSpecialization(*m_context, m_sema,
+                                             m_matrixTemplateDecl, elementType,
+                                             rowCount, colCount, isRowMajor);
   }
 
   QualType LookupVectorType(HLSLScalarType scalarType, unsigned int colCount)
@@ -4132,7 +4205,6 @@ public:
     HLSLScalarType parsedType;
     int rowCount;
     int colCount;
-
     // Try parsing hlsl scalar types that is not initialized at AST time.
     if (TryParseAny(nameIdentifier.data(), nameIdentifier.size(), &parsedType, &rowCount, &colCount, getSema()->getLangOpts())) {
       assert(parsedType != HLSLScalarType_unknown && "otherwise, TryParseHLSLScalarType should not have succeeded.");
@@ -4147,7 +4219,9 @@ public:
         TypedefDecl *qts = LookupVectorShorthandType(parsedType, colCount);
         R.addDecl(qts);
       } else { // matrix
-        TypedefDecl* qts = LookupMatrixShorthandType(parsedType, rowCount, colCount);
+        TypedefDecl *qts = LookupMatrixShorthandType(
+            parsedType, rowCount, colCount,
+            getSema()->getLangOpts().HLSLDefaultRowMajor, true);
         R.addDecl(qts);
       }
       return true;
@@ -4178,6 +4252,13 @@ public:
       else if (!decl->isImplicit())
         return AR_TOBJ_COMPOUND;
       return AR_TOBJ_OBJECT;
+    } else if (auto *TAT = dyn_cast<TypeAliasTemplateDecl>(typeRecordDecl)) {
+      if (TAT->getCanonicalDecl() ==
+                          m_defaultMatDecl->getCanonicalDecl() ||
+          TAT->getCanonicalDecl() ==
+                          m_rowMajorMatDecl->getCanonicalDecl() ||
+          TAT->getCanonicalDecl() == m_columnMajorMatDecl->getCanonicalDecl())
+        return AR_TOBJ_MATRIX;
     }
 
     if (typeRecordDecl && typeRecordDecl->isImplicit()) {
@@ -4265,6 +4346,11 @@ public:
         DXASSERT(decl->isImplicit(),
                  "otherwise object template decl is not set to implicit");
         return AR_TOBJ_OBJECT;
+      } else if (auto *TAT = dyn_cast<TypeAliasTemplateDecl>(typeRecordDecl)) {
+        if (TAT->getCanonicalDecl() == +m_defaultMatDecl->getCanonicalDecl() ||
+            TAT->getCanonicalDecl() == +m_rowMajorMatDecl->getCanonicalDecl() ||
+            TAT->getCanonicalDecl() == m_columnMajorMatDecl->getCanonicalDecl())
+          return AR_TOBJ_MATRIX;
       }
 
       if (typeRecordDecl && typeRecordDecl->isImplicit()) {
@@ -4290,6 +4376,7 @@ public:
 
     const CXXRecordDecl* typeRecordDecl = type->getAsCXXRecordDecl();
     DXASSERT_NOMSG(typeRecordDecl);
+
     const ClassTemplateSpecializationDecl* templateSpecializationDecl = dyn_cast<ClassTemplateSpecializationDecl>(typeRecordDecl);
     DXASSERT_NOMSG(templateSpecializationDecl);
     DXASSERT_NOMSG(templateSpecializationDecl->getSpecializedTemplate() == m_matrixTemplateDecl ||
@@ -4650,7 +4737,8 @@ public:
       }
       else
       {
-        pType = LookupMatrixType(scalarType, uRows, uCols);
+        bool isRowMajor = (qwQual & AR_QUAL_ROWMAJOR);
+        pType = LookupMatrixType(scalarType, uRows, uCols, isRowMajor);
       }
 
       // TODO: handle colmajor/rowmajor
@@ -4849,7 +4937,9 @@ public:
 
     AddHLSLVectorTemplate(*m_context, &m_vectorTemplateDecl);
     DXASSERT(m_vectorTemplateDecl != nullptr, "AddHLSLVectorTypes failed to return the vector template declaration");
-    AddHLSLMatrixTemplate(*m_context, m_vectorTemplateDecl, &m_matrixTemplateDecl);
+    AddHLSLMatrixTemplate(*m_context, m_vectorTemplateDecl,
+                          &m_matrixTemplateDecl, &m_defaultMatDecl,
+                          &m_rowMajorMatDecl, &m_columnMajorMatDecl);
     DXASSERT(m_matrixTemplateDecl != nullptr, "AddHLSLMatrixTypes failed to return the matrix template declaration");
 
     // Initializing built in integers for ray tracing
@@ -5107,8 +5197,13 @@ public:
       return false;
     }
 
-    bool isMatrix = Template->getCanonicalDecl() ==
-                    m_matrixTemplateDecl->getCanonicalDecl();
+    bool isMatrix =
+        Template->getCanonicalDecl() ==
+            m_matrixTemplateDecl->getCanonicalDecl() ||
+        Template->getCanonicalDecl() == m_defaultMatDecl->getCanonicalDecl() ||
+        Template->getCanonicalDecl() == m_rowMajorMatDecl->getCanonicalDecl() ||
+        Template->getCanonicalDecl() ==
+            m_columnMajorMatDecl->getCanonicalDecl();
     bool isVector = Template->getCanonicalDecl() ==
                     m_vectorTemplateDecl->getCanonicalDecl();
     bool requireScalar = isMatrix || isVector;
@@ -5131,7 +5226,7 @@ public:
           Expr *expr = arg.getAsExpr();
           llvm::APSInt constantResult;
           if (expr != nullptr &&
-              expr->isIntegerConstantExpr(constantResult, *m_context)) {
+              expr->isIntegerConstantExpr(constantResult, *m_context) && i < 3) {
             if (CheckRangedTemplateArgument(argSrcLoc, constantResult)) {
               return true;
             }
@@ -6800,6 +6895,7 @@ void HLSLExternalSource::CollectInfo(QualType type, ArTypeInfo* pTypeInfo)
   pTypeInfo->ShapeKind = GetTypeObjectKind(type);
   GetRowsAndColsForAny(type, pTypeInfo->uRows, pTypeInfo->uCols);
   pTypeInfo->uTotalElts = pTypeInfo->uRows * pTypeInfo->uCols;
+  pTypeInfo->bIsRowMajor = hlsl::IsRowMajorMatrixTemplate(type);
 }
 
 // Highest possible score (i.e., worst possible score).
@@ -8554,6 +8650,20 @@ clang::ExprResult HLSLExternalSource::PerformHLSLConversion(
       }
       break;
     }
+    case ICK_HLSLColMajorToRowMajor: {
+      From = m_sema
+                 ->ImpCastExprToType(From, targetType,
+                                     clang::CK_HLSLColMajorToRowMajor,
+                                     From->getValueKind(), /*BasePath=*/0, CCK)
+                 .get();
+    } break;
+    case ICK_HLSLRowMajorToColMajor: {
+      From = m_sema
+                 ->ImpCastExprToType(From, targetType,
+                                     clang::CK_HLSLRowMajorToColMajor,
+                                     From->getValueKind(), /*BasePath=*/0, CCK)
+                 .get();
+    } break;
     case ICK_Identity:
       // Nothing to do.
       break;
@@ -8934,6 +9044,23 @@ static bool ConvertComponent(ArTypeInfo TargetInfo, ArTypeInfo SourceInfo,
   return true;
 }
 
+static bool ConvertMatrixMajor(ArTypeInfo TargetInfo, ArTypeInfo SourceInfo,
+                             ImplicitConversionKind &MatrixMajorConversion) {
+  if (TargetInfo.bIsRowMajor == SourceInfo.bIsRowMajor)
+    return true;
+  // Conversion to/from mismatched size not supported.
+  if (TargetInfo.uRows != SourceInfo.uRows ||
+      TargetInfo.uCols != SourceInfo.uCols)
+    return true;
+
+  MatrixMajorConversion =
+      SourceInfo.bIsRowMajor
+          ? ImplicitConversionKind::ICK_HLSLRowMajorToColMajor
+          : ImplicitConversionKind::ICK_HLSLColMajorToRowMajor;
+  return true;
+}
+
+
 _Use_decl_annotations_
 bool HLSLExternalSource::CanConvert(
   SourceLocation loc,
@@ -8983,6 +9110,7 @@ bool HLSLExternalSource::CanConvert(
   // Temporary conversion kind tracking which will be used/fixed up at the end
   ImplicitConversionKind Second = ICK_Identity;
   ImplicitConversionKind ComponentConversion = ICK_Identity;
+  ImplicitConversionKind MatrixMajorConversion = ICK_Identity;
 
   // Identical types require no conversion.
   if (source == target) {
@@ -9137,6 +9265,9 @@ bool HLSLExternalSource::CanConvert(
   if (!ConvertComponent(TargetInfo, SourceInfo, ComponentConversion, Remarks))
     return false;
 
+  if (!ConvertMatrixMajor(TargetInfo, SourceInfo, MatrixMajorConversion))
+    return false;
+
 lSuccess:
   if (standard)
   {
@@ -9203,7 +9334,10 @@ lSuccess:
       }
     }
 
+    standard->MatrixMajorConversion = MatrixMajorConversion;
+
     standard->Second = Second;
+
     standard->ComponentConversion = ComponentConversion;
 
     // For conversion which change to RValue but targeting reference type
@@ -9211,6 +9345,13 @@ lSuccess:
     if (targetRef && standard->First == ICK_Lvalue_To_Rvalue) {
       standard->First = ICK_Identity;
       standard->Second = ICK_Identity;
+    }
+    // When there's only matrix major cast, set it to be second cast so implicit
+    // conversion can be called.
+    if (standard->First == ICK_Identity && standard->Second == ICK_Identity &&
+        MatrixMajorConversion != ICK_Identity) {
+      standard->MatrixMajorConversion = ICK_Identity;
+      standard->Second = MatrixMajorConversion;
     }
   }
 
@@ -9604,7 +9745,9 @@ void HLSLExternalSource::CheckBinOpForHLSL(
     } else if (IsMatrixType(m_sema, ResultTy)) {
       UINT rowCount, colCount;
       GetRowsAndColsForAny(ResultTy, rowCount, colCount);
-      ResultTy = LookupMatrixType(HLSLScalarType::HLSLScalarType_bool, rowCount, colCount);
+      bool isRowMajor = hlsl::IsRowMajorMatrixTemplate(ResultTy);
+      ResultTy = LookupMatrixType(HLSLScalarType::HLSLScalarType_bool, rowCount,
+                                  colCount, isRowMajor);
     } else
       ResultTy = m_context->BoolTy.withConst();
   }
@@ -9952,7 +10095,10 @@ clang::QualType HLSLExternalSource::ApplyTypeSpecSignToParsedType(
     } else if (objKind == AR_TOBJ_MATRIX) {
       UINT rowCount, colCount;
       GetRowsAndCols(type, rowCount, colCount);
-      TypedefDecl *qts = LookupMatrixShorthandType(newScalarType, rowCount, colCount);
+      bool isRowMajor = hlsl::IsRowMajorMatrixTemplate(type);
+      bool isDefault = hlsl::IsDefaultMajorMatrixTemplate(type);
+      TypedefDecl *qts =
+          LookupMatrixShorthandType(newScalarType, rowCount, colCount, isRowMajor, isDefault);
       return m_context->getTypeDeclType(qts);
     } else {
       DXASSERT_NOMSG(objKind == AR_TOBJ_BASIC || objKind == AR_TOBJ_ARRAY);
@@ -14082,4 +14228,72 @@ QualType Sema::getHLSLDefaultSpecialization(TemplateDecl *Decl) {
                                Decl->getSourceRange().getEnd(), EmptyArgs);
   }
   return QualType();
+}
+
+QualType hlsl::GetHLSLMatrixTypeWithMajor(QualType matType, bool isRowMajor,
+                                          clang::Sema &sema) {
+  bool isDefault = hlsl::IsDefaultMajorMatrixTemplate(matType);
+  // Default major has correct major set, only check major match is not enough.
+  if (!isDefault && hlsl::IsRowMajorMatrixTemplate(matType) == isRowMajor)
+    return matType;
+
+  llvm::Optional<AttributedType::Kind> Attr;
+
+  if (const AttributedType *AT = matType->getAs<AttributedType>()) {
+    while (AT) {
+          AttributedType::Kind kind = AT->getAttrKind();
+          switch (kind) {
+          case AttributedType::attr_hlsl_snorm:
+          case AttributedType::attr_hlsl_unorm:
+              Attr = kind;
+          }
+          matType = AT->getModifiedType();
+          AT = AT->getLocallyUnqualifiedSingleStepDesugaredType()
+                   ->getAs<AttributedType>();
+
+    }
+  }
+
+  unsigned int row = 0;
+  unsigned int col = 0;
+  hlsl::GetHLSLMatRowColCount(matType, row, col);
+  QualType eltType = hlsl::GetHLSLMatElementType(matType);
+
+  HLSLExternalSource *HLSLSrc = HLSLExternalSource::FromSema(&sema);
+
+  HLSLScalarType scalarType =
+      HLSLSrc->ScalarTypeForBasic(HLSLSrc->GetTypeElementKind(eltType));
+  bool isShortHandTy = false;
+  bool isTypedef = false;
+  if (const TypedefType *TD = matType->getAs<TypedefType>()) {
+    isShortHandTy = TD->getDecl()->isImplicit();
+    isTypedef = true;
+  }
+
+  auto *TST = matType->getAs<TemplateSpecializationType>();
+  QualType OriginEltTy = eltType;
+  if (TST->getNumArgs())
+    OriginEltTy = TST->getArg(0).getAsType();
+
+  ASTContext &context = sema.getASTContext();
+  QualType Result;
+  if (isShortHandTy) {
+    Result =
+        sema.getASTContext().getTypeDeclType(HLSLSrc->LookupMatrixShorthandType(
+            scalarType, row, col, isRowMajor, false));
+  } else if (isTypedef || OriginEltTy != eltType) {
+    QualType NewMatTy = HLSLSrc->GetOrCreateMatrixSpecialization(
+        OriginEltTy, row, col, isRowMajor);
+    Result = HLSLSrc->CreateAliasMatrixType(NewMatTy, OriginEltTy, row, col,
+                                            isRowMajor, false);
+  } else {
+    Result = HLSLSrc->LookupMatrixType(scalarType, row, col, isRowMajor);
+
+    Result = HLSLSrc->CreateAliasMatrixType(Result, eltType, row, col,
+                                            isRowMajor, false);
+  }
+
+  if (Attr)
+    Result = context.getAttributedType(Attr.getValue(), Result, Result);
+  return Result;
 }

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -142,6 +142,8 @@ ImplicitConversionRank clang::GetConversionRank(ImplicitConversionKind Kind) {
     ICR_Conversion,
     ICR_Conversion,
     ICR_Conversion,
+    ICR_Conversion,
+    ICR_Conversion,
     // HLSL Change Ends
   };
   static_assert(_countof(Rank) == ICK_Num_Conversion_Kinds,
@@ -187,6 +189,9 @@ static const char* GetImplicitConversionName(ImplicitConversionKind Kind) {
     "HLSLVector/Matrix splat",
     "HLSLVector/Matrix truncation",
     "HLSL derived to base",
+    "HLSL row major to column major",
+    "HLSL column major to row major",
+
     // HLSL Change Ends
   };
   static_assert(_countof(Name) == ICK_Num_Conversion_Kinds,
@@ -223,6 +228,8 @@ ImplicitConversionRank StandardConversionSequence::getRank() const {
     Rank = GetConversionRank(Second);
   if  (GetConversionRank(ComponentConversion) > Rank) // HLSL Change
     Rank = GetConversionRank(ComponentConversion);
+  if (GetConversionRank(MatrixMajorConversion) > Rank) // HLSL Change
+    Rank = GetConversionRank(MatrixMajorConversion);
   if  (GetConversionRank(Third) > Rank)
     Rank = GetConversionRank(Third);
   return Rank;
@@ -484,6 +491,13 @@ void StandardConversionSequence::dump() const {
       OS << " -> ";
     }
     OS << GetImplicitConversionName(ComponentConversion);
+    PrintedSomething = true;
+  }
+  if (MatrixMajorConversion != ICK_Identity) {
+    if (PrintedSomething) {
+      OS << " -> ";
+    }
+    OS << GetImplicitConversionName(MatrixMajorConversion);
     PrintedSomething = true;
   }
   // HLSL Change Ends
@@ -4940,6 +4954,7 @@ TryObjectArgumentInitialization(Sema &S, QualType FromType,
   ICS.Standard.BindsImplicitObjectArgumentWithoutRefQualifier
     = (Method->getRefQualifier() == RQ_None);
   ICS.Standard.ComponentConversion = ICK_Identity;
+  ICS.Standard.MatrixMajorConversion = ICK_Identity;
   return ICS;
 }
 

--- a/tools/clang/test/HLSL/implicit-casts.hlsl
+++ b/tools/clang/test/HLSL/implicit-casts.hlsl
@@ -573,7 +573,7 @@ float4 test(): SV_Target {
           `-ImplicitCastExpr <col:17> 'min16float':'min16float' <LValueToRValue>
             `-DeclRefExpr <col:17> 'min16float':'min16float' lvalue Var 'm16f' 'min16float':'min16float'
   */
-  m16f4x4 = i4x4 * (m16f + 1);                  /* expected-warning {{conversion from larger type 'int4x4' to smaller type 'matrix<min16float, 4, 4>', possible loss of data}} fxc-warning {{X3205: conversion from larger type to smaller, possible loss of data}} */
+  m16f4x4 = i4x4 * (m16f + 1);                  /* expected-warning {{conversion from larger type 'int4x4' to smaller type 'matrix<min16float, 4, 4, 0>', possible loss of data}} fxc-warning {{X3205: conversion from larger type to smaller, possible loss of data}} */
   /*verify-ast
     BinaryOperator <col:3, col:29> 'min16float4x4':'matrix<min16float, 4, 4>' '='
     |-DeclRefExpr <col:3> 'min16float4x4':'matrix<min16float, 4, 4>' lvalue Var 'm16f4x4' 'min16float4x4':'matrix<min16float, 4, 4>'
@@ -636,7 +636,7 @@ float4 test(): SV_Target {
               `-DeclRefExpr <col:30> 'float4':'vector<float, 4>' lvalue Var 'f4' 'float4':'vector<float, 4>'
   */
 
-  f4 = i3x1 * f4;                               /* expected-error {{cannot convert from 'matrix<float, 3, 1>' to 'float4'}} expected-warning {{implicit truncation of vector type}} fxc-error {{X3017: cannot implicitly convert from 'const float3x1' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
+  f4 = i3x1 * f4;                               /* expected-error {{cannot convert from 'matrix<float, 3, 1, 0>' to 'float4'}} expected-warning {{implicit truncation of vector type}} fxc-error {{X3017: cannot implicitly convert from 'const float3x1' to 'float4'}} fxc-warning {{X3206: implicit truncation of vector type}} */
   f3 = i3x1 * f4;                               /* expected-warning {{implicit truncation of vector type}} fxc-warning {{X3206: implicit truncation of vector type}} */
   /*verify-ast
     BinaryOperator <col:3, col:15> 'float3':'vector<float, 3>' '='

--- a/tools/clang/test/HLSL/typemods-syntax.hlsl
+++ b/tools/clang/test/HLSL/typemods-syntax.hlsl
@@ -572,23 +572,23 @@ float3 foo_col_missing_in_def(column_major float2x3 val);
 float3 foo_col_missing_in_def(float2x3 val) {
     return val[0];
 }
-float3 foo_col_in_decl_row_in_def(column_major float2x3 val);
-float3 foo_col_in_decl_row_in_def(row_major float2x3 val) {
+float3 foo_col_in_decl_row_in_def(column_major float2x3 val); /* expected-note {{candidate function}} */ /* expected-note {{candidate function}} */ /* expected-note {{candidate function}} */
+float3 foo_col_in_decl_row_in_def(row_major float2x3 val) { /* expected-note {{candidate function}} */ /* expected-note {{candidate function}} */ /* expected-note {{candidate function}} */
     return val[0];
 }
 float3 use_conflicting_column_row(float2x3 val, column_major float2x3 val_column, row_major float2x3 val_row) {
     float3 res = (float3) 0;
     res += foo_col_missing_in_decl(val);                 /* fxc-error {{X3067: 'foo_col_missing_in_decl': ambiguous function call}} */
     res += foo_col_missing_in_def(val);                  /* fxc-error {{X3067: 'foo_col_missing_in_def': ambiguous function call}} */
-    res += foo_col_in_decl_row_in_def(val);              /* fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
+    res += foo_col_in_decl_row_in_def(val);              /* expected-error {{call to 'foo_col_in_decl_row_in_def' is ambiguous}} fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
     res += foo_col(val);
     res += foo_col_missing_in_decl(val_column);          /* fxc-error {{X3067: 'foo_col_missing_in_decl': ambiguous function call}} */
     res += foo_col_missing_in_def(val_column);           /* fxc-error {{X3067: 'foo_col_missing_in_def': ambiguous function call}} */
-    res += foo_col_in_decl_row_in_def(val_column);       /* fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
+    res += foo_col_in_decl_row_in_def(val_column);       /* expected-error {{call to 'foo_col_in_decl_row_in_def' is ambiguous}} fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
     res += foo_col(val_column);
     res += foo_col_missing_in_decl(val_row);             /* fxc-error {{X3067: 'foo_col_missing_in_decl': ambiguous function call}} */
     res += foo_col_missing_in_def(val_row);              /* fxc-error {{X3067: 'foo_col_missing_in_def': ambiguous function call}} */
-    res += foo_col_in_decl_row_in_def(val_row);          /* fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
+    res += foo_col_in_decl_row_in_def(val_row);          /* expected-error {{call to 'foo_col_in_decl_row_in_def' is ambiguous}} fxc-error {{X3067: 'foo_col_in_decl_row_in_def': ambiguous function call}} */
     res += foo_col(val_row);
     return res;
 }

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/types/matrix_members.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/types/matrix_members.hlsl
@@ -3,7 +3,7 @@
 // Test that the debug info for HLSL matrices exposes per-component fields.
 
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int2x2"
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "matrix<int, 2, 2>", {{.*}}, size: 128, align: 32
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "matrix<int, 2, 2, 0>", {{.*}}, size: 128, align: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_11", {{.*}}, size: 32, align: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_12", {{.*}}, size: 32, align: 32, offset: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_21", {{.*}}, size: 32, align: 32, offset: 64

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/types/matrix_members_bool.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/types/matrix_members_bool.hlsl
@@ -4,7 +4,7 @@
 // in the memory representation of matrices (32-bits)
 
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "bool2x2"
-// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "matrix<bool, 2, 2>", {{.*}}, size: 128, align: 32
+// CHECK-DAG: !DICompositeType(tag: DW_TAG_class_type, name: "matrix<bool, 2, 2, 0>", {{.*}}, size: 128, align: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_11", {{.*}}, size: 32, align: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_12", {{.*}}, size: 32, align: 32, offset: 32
 // CHECK-DAG: !DIDerivedType(tag: DW_TAG_member, name: "_21", {{.*}}, size: 32, align: 32, offset: 64

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/default-matrix-in-template.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/default-matrix-in-template.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -E main -T cs_6_0 -fcgl %s  | FileCheck %s
 
 // Check unlowered type
-// CHECK: %"class.StructuredBuffer<matrix<float, 4, 4> >" = type { %class.matrix.float.4.4 }
+// CHECK: %"class.StructuredBuffer<matrix.internal::matrix<float, 4, 4, 0> >" = type { %"class.matrix.internal::matrix.float.4.4" }
 
 StructuredBuffer<matrix> buf1;
 // Should be equivalent to:

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix-ast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix-ast.hlsl
@@ -1,5 +1,8 @@
 // RUN: %dxc -T lib_6_x -ast-dump-implicit %s | FileCheck %s
 
+// Verify the internal matrix template
+// CHECK:NamespaceDecl 0x{{[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix.internal
+
 // Verify the matrix template formtaion: matrix< T = float, rows = 4, cols = 4>
 // CHECK: ClassTemplateDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix
 // CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class element
@@ -10,6 +13,7 @@
 // CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' col_count
 // CHECK-NEXT: TemplateArgument expr
 // CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' orientation
 
 // Verify the record with the final attribute and the matrix field as an
 // ext_vector array.
@@ -27,3 +31,41 @@
 // CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'vector<element, col_count> &const (unsigned int) const'
 // CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> index 'unsigned int'
 // CHECK-NEXT: HLSLCXXOverloadAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit
+
+// Verify namespace row.major { template<typename T=float, int row_count=4, int col_count=4> using matrix = matrix.internal::matrix<T, row_count, col_count, 1>; }
+// CHECK: NamespaceDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit row.major
+// CHECK-NEXT: TypeAliasTemplateDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix
+// CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class element
+// CHECK-NEXT: TemplateArgument type 'float'
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' row_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' col_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: TypeAliasDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix 'matrix<element, row_count, col_count, 1>':'matrix<element, row_count, col_count, orientation>'
+
+// Verify namespace column.major { template<typename T=float, int row_count=4, int col_count=4> using matrix = matrix.internal::matrix<T, row_count, col_count, 0>; }
+// CHECK: NamespaceDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit column.major
+// CHECK-NEXT: TypeAliasTemplateDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix
+// CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class element
+// CHECK-NEXT: TemplateArgument type 'float'
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' row_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' col_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: TypeAliasDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix 'matrix<element, row_count, col_count, 0>':'matrix<element, row_count, col_count, orientation>'
+
+// Verify template<typename T=float, int row_count=4, int col_count=4> using matrix = matrix.internal::matrix<T, row_count, col_count, 0>;
+// CHECK: TypeAliasTemplateDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix
+// CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class element
+// CHECK-NEXT: TemplateArgument type 'float'
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' row_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: NonTypeTemplateParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> 'int' col_count
+// CHECK-NEXT: TemplateArgument expr
+// CHECK-NEXT: IntegerLiteral {{0x[0-9a-fA-F]+}} <<invalid sloc>> 'int' 4
+// CHECK-NEXT: TypeAliasDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit matrix 'matrix<element, row_count, col_count, 0>':'matrix<element, row_count, col_count, orientation>'

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_attr.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/matrix/matrix_attr.hlsl
@@ -4,30 +4,31 @@
 
 struct Mat
 {
-// CHECK:-FieldDecl {{.*}}, col:22> col:22 referenced m 'row_major float2x2':'matrix<float, 2, 2>'
+// CHECK:-FieldDecl {{.*}}, col:22> col:22 referenced m 'row_major float2x2':'matrix<float, 2, 2, 1>'
 // CHECK-NOT: |-HLSLRowMajorAttr 0x{{.*}} <col:3>
   row_major float2x2 m;
 };
 
 Mat m;
-// CHECK:|-VarDecl {{.*}}, col:10> col:10 used t 'const float3x2':'const matrix<float, 3, 2>'
+// CHECK:|-VarDecl {{.*}}, col:10> col:10 used t 'const float3x2':'const matrix<float, 3, 2, 0>'
 float3x2 t;
 
-// CHECK:|-VarDecl {{.*}}, col:10> col:10 used tt 'const float3x3':'const matrix<float, 3, 3>'
+// CHECK:|-VarDecl {{.*}}, col:10> col:10 used tt 'const float3x3':'const matrix<float, 3, 3, 0>'
 float3x3 tt;
 
 // CHECK:|-FunctionDecl 0x{{.*}}:20 used foo 'row_major float3x3 ()'
 // CHECK-NEXT:CompoundStmt 0x{{.*}} <col:26,
 // CHECK-NEXT:| `-ReturnStmt 0x{{.*}}, col:10>
-// CHECK-NEXT:|   `-ImplicitCastExpr 0x{{.*}} <col:10> 'float3x3':'matrix<float, 3, 3>' <LValueToRValue>
-// CHECK-NEXT:|     `-DeclRefExpr 0x{{.*}} <col:10> 'const float3x3':'const matrix<float, 3, 3>' lvalue Var 0x{{.*}} 'tt' 'const float3x3':'const matrix<float, 3, 3>'
+// CHECK-NEXT:ImplicitCastExpr 0x{{.*}} <col:10> 'row_major float3x3':'matrix<float, 3, 3, 1>' <HLSLColMajorToRowMajor>
+// CHECK-NEXT:|   `-ImplicitCastExpr 0x{{.*}} <col:10> 'float3x3':'matrix<float, 3, 3, 0>' <LValueToRValue>
+// CHECK-NEXT:|     `-DeclRefExpr 0x{{.*}} <col:10> 'const float3x3':'const matrix<float, 3, 3, 0>' lvalue Var 0x{{.*}} 'tt' 'const float3x3':'const matrix<float, 3, 3, 0>'
 // CHECK-NOT:|-HLSLRowMajorAttr
 row_major float3x3 foo() {
   return tt;
 }
 
 // CHECK:-FunctionDecl 0x{{.*}} main 'float4 (column_major float4x4)'
-// CHECK-NEXT:|-ParmVarDecl 0x{{.*}} <col:13, col:35> col:35 used m2 'column_major float4x4':'matrix<float, 4, 4>'
+// CHECK-NEXT:|-ParmVarDecl 0x{{.*}} <col:13, col:35> col:35 used m2 'column_major float4x4':'matrix<float, 4, 4, 0>'
 // CHECK-NOT:|-HLSLColumnMajorAttr
 float4 main(column_major float4x4 m2 : M) :SV_Target {
     Mat lm = m;

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -503,7 +503,7 @@ TEST_F(LinkerTest, RunLinkToLibExport) {
   Link(L"", L"lib_6_3", pLinker, {libName, libName2},
     { "@\"\\01?renamed_test@@","@\"\\01?cloned_test@@","@main" },
     { "@\"\\01?mat_test", "@renamed_test", "@cloned_test" },
-    {L"-exports", L"renamed_test,cloned_test=\\01?mat_test@@YA?AV?$vector@M$02@@V?$vector@M$03@@0AIAV?$matrix@M$03$02@@@Z;main"});
+    {L"-exports", L"renamed_test,cloned_test=\\01?mat_test@@YA?AV?$vector@M$02@@V?$vector@M$03@@0AIAV?$matrix@M$03$02$0A@@@@Z;main"});
 }
 
 TEST_F(LinkerTest, RunLinkToLibExportShadersOnly) {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -744,17 +744,17 @@ TEST_F(ValidationTest, BarrierFail) {
       {"dx.op.barrier(i32 80, i32 8)",
         "dx.op.barrier(i32 80, i32 9)",
         "dx.op.barrier(i32 80, i32 11)",
-        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { [2 x <2 x float>] }\n",
+        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2, 0> >\" = type { [2 x <2 x float>] }\n",
         "call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)",
       },
       {"dx.op.barrier(i32 80, i32 15)",
         "dx.op.barrier(i32 80, i32 0)",
         "dx.op.barrier(i32 80, i32 %rem)",
-        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" = type { [2 x <2 x float>] }\n"
-        "@dx.typevar.8 = external addrspace(1) constant %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\"\n"
+        "%\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2, 0> >\" = type { [2 x <2 x float>] }\n"
+        "@dx.typevar.8 = external addrspace(1) constant %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2, 0> >\"\n"
         "@\"internalGV\" = internal global [64 x <4 x float>] undef\n",
         "call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)\n"
-        "%load = load %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\", %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2> >\" addrspace(1)* @dx.typevar.8",
+        "%load = load %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2, 0> >\", %\"hostlayout.class.RWStructuredBuffer<matrix<float, 2, 2, 0> >\" addrspace(1)* @dx.typevar.8",
       },
       {"Internal declaration 'internalGV' is unused",
        "External declaration 'dx.typevar.8' is unused",


### PR DESCRIPTION
Change hlsl matrix type into

namespace matrix.internal {
template
struct matrix {
vector<T, colCount> h[row_count];

  vector<T, colCount> operator[] (int i);
  vector<T, colCount> operator[] (int i) const;

};
}
namespace row.major { template using matrix = matrix.internal::matrix<T, row_count, col_count, 1>; } namespace column.major { template using matrix = matrix.internal::matrix<T, row_count, col_count, 0>; }

template using matrix = matrix.internal::matrix<T, row_count, col_count, 0>;

This is to allow orientation information saved in template.

TODO:
1. remove attributed type for matrix major.
2. generate different IR type for row major and column major matrix.