### PR TITLE
spirv: fix GL semantic in inherited classes

### DIFF
--- a/tools/clang/lib/SPIRV/GlPerVertex.h
+++ b/tools/clang/lib/SPIRV/GlPerVertex.h
@@ -129,8 +129,7 @@ private:
                   SourceLocation loc, SourceRange range = {});
 
   /// Internal implementation for recordClipCullDistanceDecl().
-  bool doGlPerVertexFacts(const DeclaratorDecl *decl, QualType type,
-                          bool asInput);
+  bool doGlPerVertexFacts(const NamedDecl *decl, QualType type, bool asInput);
 
   /// Returns whether the type is a scalar, vector, or array that contains
   /// only scalars with float type.

--- a/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.inheritance.sv_clipdistance.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interface.ps.inheritance.sv_clipdistance.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_0 -E main
+
+struct Parent {
+  float clipDistance : SV_ClipDistance;
+};
+
+struct PSInput : Parent
+{ };
+
+float main(PSInput input) : SV_TARGET
+{
+// CHECK:  [[ptr0:%\d+]] = OpAccessChain %_ptr_Input_float %gl_ClipDistance %uint_0
+// CHECK: [[load0:%\d+]] = OpLoad %float [[ptr0]]
+
+// CHECK: [[parent:%\d+]] = OpCompositeConstruct %Parent [[load0]]
+// CHECK:  [[input:%\d+]] = OpCompositeConstruct %PSInput [[parent]]
+
+
+// CHECK: [[access0:%\d+]] = OpAccessChain %_ptr_Function_Parent %input %uint_0
+// CHECK: [[access1:%\d+]] = OpAccessChain %_ptr_Function_float [[access0]] %int_0
+// CHECK:   [[load1:%\d+]] = OpLoad %float [[access1]]
+    return input.clipDistance;
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1734,6 +1734,9 @@ TEST_F(FileTest, SpirvStageIOInterfaceVSClipDistanceInvalidType) {
   runFileTest("spirv.interface.vs.clip_distance.type.error.hlsl",
               Expect::Failure);
 }
+TEST_F(FileTest, SpirvStageIOInterfacePSInheritanceSVClipDistance) {
+  runFileTest("spirv.interface.ps.inheritance.sv_clipdistance.hlsl");
+}
 
 TEST_F(FileTest, SpirvStageIOAliasBuiltIn) {
   runFileTest("spirv.interface.alias-builtin.hlsl");


### PR DESCRIPTION
When a semantic was in an inherited class, it was missed and caused issues later down the pipe. This was because we assumed semantic fields would only be present at the top-level struct, ignoring inheritance.

This commit also changes the parameter type from `DeclaratorDecl` to `NamedDecl` as it only requires methods up to `NamedDecl`. Loosening this requirement allowed me to pass a CXXRecordDecl.