### PR TITLE
Update VerifierHelper.py and existing tests for fxc and ast changes

### DIFF
--- a/tools/clang/test/HLSL/attributes.hlsl
+++ b/tools/clang/test/HLSL/attributes.hlsl
@@ -401,7 +401,7 @@ HSFoo HSMain( InputPatch<HSFoo, 16> p,
   | `-SemanticDecl <col:30> "SV_PrimitiveID"
   |-CompoundStmt <line:462:1, line:468:1>
   | |-DeclStmt <line:463:5, col:17>
-  | | `-VarDecl <col:5, col:11> col:11 used output 'HSFoo'
+  | | `-VarDecl <col:5, col:11> col:11 used output 'HSFoo' nrvo
   | |-DeclStmt <line:464:5, col:41>
   | | `-VarDecl <col:5, col:40> col:12 used r 'float4':'vector<float, 4>' cinit
   | |   `-CXXFunctionalCastExpr <col:16, col:40> 'float4':'vector<float, 4>' functional cast to float4 <NoOp>
@@ -563,7 +563,7 @@ void clipplanes_bad_scalar_swizzle();
 /*verify-ast
   HLSLClipPlanesAttr <col:2, line:582:3>
   |-DeclRefExpr <line:579:3> 'const float4':'const vector<float, 4>' lvalue Var 'f4' 'const float4':'const vector<float, 4>'
-  |-ArraySubscriptExpr <line:580:3, col:8> 'float4':'vector<float, 4>' lvalue
+  |-ArraySubscriptExpr <line:580:3, col:8> 'const float4':'const vector<float, 4>' lvalue
   | |-ImplicitCastExpr <col:3> 'const float4 [2]' <LValueToRValue>
   | | `-DeclRefExpr <col:3> 'const float4 [2]' lvalue Var 'cp4' 'const float4 [2]'
   | `-IntegerLiteral <col:7> 'literal int' 0
@@ -588,7 +588,7 @@ float4 clipplanes_good();
   HLSLClipPlanesAttr <col:2, line:616:3>
   |-ParenExpr <line:612:3, col:6> 'const float4':'const vector<float, 4>' lvalue
   | `-DeclRefExpr <col:4> 'const float4':'const vector<float, 4>' lvalue Var 'f4' 'const float4':'const vector<float, 4>'
-  |-ArraySubscriptExpr <line:613:3, col:10> 'float4':'vector<float, 4>' lvalue
+  |-ArraySubscriptExpr <line:613:3, col:10> 'const float4':'const vector<float, 4>' lvalue
   | |-ImplicitCastExpr <col:3> 'const float4 [2]' <LValueToRValue>
   | | `-DeclRefExpr <col:3> 'const float4 [2]' lvalue Var 'cp4' 'const float4 [2]'
   | `-ParenExpr <col:7, col:9> 'literal int'

--- a/tools/clang/test/HLSL/const-default.hlsl
+++ b/tools/clang/test/HLSL/const-default.hlsl
@@ -29,17 +29,17 @@ class MyClass {
     int3x4 my_int3x4;
 };
 
-ConstantBuffer<MyClass> g_const_buffer2;
-TextureBuffer<MyClass> g_texture_buffer2;
+ConstantBuffer<MyClass> g_const_buffer2;                    /* fxc-error {{X3594: D3D12 constant/texture buffer template element can only be a struct}} */
+TextureBuffer<MyClass> g_texture_buffer2;                   /* fxc-error {{X3594: D3D12 constant/texture buffer template element can only be a struct}} */
 
-struct FWDDeclStruct;
-class FWDDeclClass;
+struct FWDDeclStruct;                                       /* fxc-error {{X3000: syntax error: unexpected token ';'}} */
+class FWDDeclClass;                                         /* fxc-error {{X3000: syntax error: unexpected token ';'}} */
 
 // Ensure forward declared struct/class fails as expected
-ConstantBuffer<FWDDeclStruct> g_const_buffer3;              /* expected-error {{variable has incomplete type 'FWDDeclStruct'}} */
-TextureBuffer<FWDDeclStruct> g_texture_buffer3;             /* expected-error {{variable has incomplete type 'FWDDeclStruct'}} */
-ConstantBuffer<FWDDeclClass> g_const_buffer4;               /* expected-error {{variable has incomplete type 'FWDDeclClass'}} */
-TextureBuffer<FWDDeclClass> g_texture_buffer4;              /* expected-error {{variable has incomplete type 'FWDDeclClass'}} */
+ConstantBuffer<FWDDeclStruct> g_const_buffer3;              /* expected-error {{variable has incomplete type 'FWDDeclStruct'}} fxc-error {{X3000: syntax error: unexpected token 'FWDDeclStruct'}} */
+TextureBuffer<FWDDeclStruct> g_texture_buffer3;             /* expected-error {{variable has incomplete type 'FWDDeclStruct'}} fxc-error {{X3000: syntax error: unexpected token 'FWDDeclStruct'}} */
+ConstantBuffer<FWDDeclClass> g_const_buffer4;               /* expected-error {{variable has incomplete type 'FWDDeclClass'}} fxc-error {{X3000: syntax error: unexpected token 'FWDDeclClass'}} */
+TextureBuffer<FWDDeclClass> g_texture_buffer4;              /* expected-error {{variable has incomplete type 'FWDDeclClass'}} fxc-error {{X3000: syntax error: unexpected token 'FWDDeclClass'}} */
 
 float4 main() : SV_TARGET
 {
@@ -61,10 +61,10 @@ float4 main() : SV_TARGET
     g_texture_buffer.my_float3.y += 2.0;                      /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
     g_texture_buffer.my_int3x4._14 = 3;                     /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
 
-    g_const_buffer2.my_float3.x = 1.5;                      /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
-    g_const_buffer2.my_int3x4._21 -= 2;                     /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
-    g_texture_buffer2.my_float3.y += 2.0;                     /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
-    g_texture_buffer2.my_int3x4._14 = 3;                    /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
+    g_const_buffer2.my_float3.x = 1.5;                      /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'g_const_buffer2'}} */
+    g_const_buffer2.my_int3x4._21 -= 2;                     /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'g_const_buffer2'}} */
+    g_texture_buffer2.my_float3.y += 2.0;                     /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'g_texture_buffer2'}} */
+    g_texture_buffer2.my_int3x4._14 = 3;                    /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'g_texture_buffer2'}} */
 
     return (float4)g_float1;
 }

--- a/tools/clang/test/HLSL/const-expr.hlsl
+++ b/tools/clang/test/HLSL/const-expr.hlsl
@@ -59,7 +59,7 @@ float fn_f_f(float r)
         | |-ImplicitCastExpr <col:17> 'vector<float, 2> (*)(vector<float, 2>, matrix<float, 2, 2>)' <FunctionToPointerDecay>
         | | `-DeclRefExpr <col:17> 'vector<float, 2> (vector<float, 2>, matrix<float, 2, 2>)' lvalue Function 'mul' 'vector<float, 2> (vector<float, 2>, matrix<float, 2, 2>)'
         | |-ImplicitCastExpr <col:21, col:33> 'float2':'vector<float, 2>' <LValueToRValue>
-        | | `-ArraySubscriptExpr <col:21, col:33> 'float2':'vector<float, 2>' lvalue
+        | | `-ArraySubscriptExpr <col:21, col:33> 'const float2':'const vector<float, 2>' lvalue
         | |   |-ImplicitCastExpr <col:21> 'const float2 [8]' <LValueToRValue>
         | |   | `-DeclRefExpr <col:21> 'const float2 [8]' lvalue Var 'g_f2_arr' 'const float2 [8]'
         | |   `-ImplicitCastExpr <col:30> 'int' <LValueToRValue>

--- a/tools/clang/test/HLSL/globallycoherent-errors.hlsl
+++ b/tools/clang/test/HLSL/globallycoherent-errors.hlsl
@@ -2,8 +2,8 @@
 
 globallycoherent RWTexture1D<float4> uav1 : register(u3);
 RWBuffer<float4> uav2;
-globallycoherent Buffer<float4> srv; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}}
-globallycoherent float m; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}}
+globallycoherent Buffer<float4> srv; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}} fxc-error {{X3679: globallycoherent can only be used with Unordered Access View buffers}}
+globallycoherent float m; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}} fxc-error {{X3679: globallycoherent can only be used with Unordered Access View buffers}}
 
 globallycoherent RWTexture2D<float> tex[12];
 globallycoherent RWTexture2D<float> texMD[12][12];
@@ -11,8 +11,8 @@ globallycoherent RWTexture2D<float> texMD[12][12];
  float4 main(uint2 a : A, uint2 b : B) : SV_Target
 {
   globallycoherent  RWTexture1D<float4> uav3 = uav1;
-  globallycoherent float x = 3; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}}
-  uav3[0] = srv[0];
+  globallycoherent float x = 3; // expected-error {{'globallycoherent' is not a valid modifier for a non-UAV type}} fxc-pass {{}}
+  uav3[0] = srv[0];             /* fxc-error {{X3004: undeclared identifier 'srv'}} */
   uav1[0] = 2;
   uav2[1] = 3;
   return 0;

--- a/tools/clang/test/HLSL/invalid-decl-template-arg.hlsl
+++ b/tools/clang/test/HLSL/invalid-decl-template-arg.hlsl
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
-struct FOOO_A_B { // expected-note{{'FOOO_A_B' declared here}} expected-note{{definition of 'FOOO_A_B' is not complete until the closing '}'}}
-  FOOO_A v0; // expected-error{{unknown type name 'FOOO_A'; did you mean 'FOOO_A_B'}} expected-error{{field has incomplete type 'FOOO_A_B}}
+struct FOOO_A_B { // expected-note {{'FOOO_A_B' declared here}} expected-note {{definition of 'FOOO_A_B' is not complete until the closing '}'}} fxc-pass {{}}
+  FOOO_A v0; // expected-error {{field has incomplete type 'FOOO_A_B}} expected-error {{unknown type name 'FOOO_A'; did you mean 'FOOO_A_B'}} fxc-error {{X3000: unrecognized identifier 'FOOO_A'}}
 };
 
-RWStructuredBuffer<FOOO_A_B> Input;
+RWStructuredBuffer<FOOO_A_B> Input;                         /* fxc-error {{X3037: object's templated type must have at least one element}} */
 
 void main() {}

--- a/tools/clang/test/HLSL/mintypes-promotion-warnings.hlsl
+++ b/tools/clang/test/HLSL/mintypes-promotion-warnings.hlsl
@@ -6,4 +6,4 @@ void main(
   min10float in_f10, // expected-warning {{'min10float' is promoted to 'min16float'}} fxc-pass {{}}
   min12int in_i12, // expected-warning {{'min12int' is promoted to 'min16int'}} fxc-pass {{}}
   out min10float out_f10, // expected-warning {{'min10float' is promoted to 'min16float'}} fxc-pass {{}}
-  out min12int out_i12) {} // expected-warning {{'min12int' is promoted to 'min16int'}} fxc-pass {{}} expected-warning{{parameter 'out_f10' is uninitialized when used here}} expected-warning{{parameter 'out_i12' is uninitialized when used here}}
+  out min12int out_i12) {} // expected-warning {{'min12int' is promoted to 'min16int'}} expected-warning {{parameter 'out_f10' is uninitialized when used here}} expected-warning {{parameter 'out_i12' is uninitialized when used here}} fxc-pass {{}}

--- a/tools/clang/test/HLSL/more-operators.hlsl
+++ b/tools/clang/test/HLSL/more-operators.hlsl
@@ -190,9 +190,9 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<float, __decltype(-float_l)>::value, "");
     _Static_assert(std::is_same<double, __decltype(-double_l)>::value, "");
     _Static_assert(std::is_same<min16float, __decltype(-min16float_l)>::value, "");
-    _Static_assert(std::is_same<min10float, __decltype(-min10float_l)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min10float, __decltype(-min10float_l)>::value, "");
     _Static_assert(std::is_same<min16int, __decltype(-min16int_l)>::value, "");
-    _Static_assert(std::is_same<min12int, __decltype(-min12int_l)>::value, "");    // fxc-pass {{}}
+    _Static_assert(std::is_same<min12int, __decltype(-min12int_l)>::value, "");
     _Static_assert(std::is_same<min16uint, __decltype(-min16uint_l)>::value, "");
     (-SamplerState_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3022: scalar, vector, or matrix expected}}
     (-f3_s_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3022: scalar, vector, or matrix expected}}
@@ -201,7 +201,7 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<int2, __decltype(-bool2_l)>::value, "");
     _Static_assert(std::is_same<float3, __decltype(-float3_l)>::value, "");
     _Static_assert(std::is_same<double4, __decltype(-double4_l)>::value, "");
-    _Static_assert(std::is_same<min10float1x2, __decltype(-min10float1x2_l)>::value, "");      /* fxc-pass {{}} */
+    _Static_assert(std::is_same<min10float1x2, __decltype(-min10float1x2_l)>::value, "");
     _Static_assert(std::is_same<uint2x3, __decltype(-uint2x3_l)>::value, "");
     _Static_assert(std::is_same<min16uint4x4, __decltype(-min16uint4x4_l)>::value, "");
     _Static_assert(std::is_same<int3x2, __decltype(-int3x2_l)>::value, "");
@@ -212,9 +212,9 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<float, __decltype(+float_l)>::value, "");
     _Static_assert(std::is_same<double, __decltype(+double_l)>::value, "");
     _Static_assert(std::is_same<min16float, __decltype(+min16float_l)>::value, "");
-    _Static_assert(std::is_same<min10float, __decltype(+min10float_l)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min10float, __decltype(+min10float_l)>::value, "");
     _Static_assert(std::is_same<min16int, __decltype(+min16int_l)>::value, "");
-    _Static_assert(std::is_same<min12int, __decltype(+min12int_l)>::value, "");    // fxc-pass {{}}
+    _Static_assert(std::is_same<min12int, __decltype(+min12int_l)>::value, "");
     _Static_assert(std::is_same<min16uint, __decltype(+min16uint_l)>::value, "");
     (+SamplerState_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3022: scalar, vector, or matrix expected}}
     (+f3_s_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3022: scalar, vector, or matrix expected}}
@@ -223,7 +223,7 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<int2, __decltype(+bool2_l)>::value, "");
     _Static_assert(std::is_same<float3, __decltype(+float3_l)>::value, "");
     _Static_assert(std::is_same<double4, __decltype(+double4_l)>::value, "");
-    _Static_assert(std::is_same<min10float1x2, __decltype(+min10float1x2_l)>::value, "");      /* fxc-pass {{}} */
+    _Static_assert(std::is_same<min10float1x2, __decltype(+min10float1x2_l)>::value, "");
     _Static_assert(std::is_same<uint2x3, __decltype(+uint2x3_l)>::value, "");
     _Static_assert(std::is_same<min16uint4x4, __decltype(+min16uint4x4_l)>::value, "");
     _Static_assert(std::is_same<int3x2, __decltype(+int3x2_l)>::value, "");
@@ -236,7 +236,7 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     (~min16float_l); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
     (~min10float_l); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
     _Static_assert(std::is_same<min16int, __decltype(~min16int_l)>::value, "");
-    _Static_assert(std::is_same<min12int, __decltype(~min12int_l)>::value, "");    // fxc-pass {{}}
+    _Static_assert(std::is_same<min12int, __decltype(~min12int_l)>::value, "");
     _Static_assert(std::is_same<min16uint, __decltype(~min16uint_l)>::value, "");
     (~SamplerState_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3082: int or unsigned int type required}}
     (~f3_s_l); // expected-error {{scalar, vector, or matrix expected}} fxc-error {{X3082: int or unsigned int type required}}
@@ -288,11 +288,11 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<min16float&, __decltype(--min16float_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16float, __decltype(min16float_l--)>::value, "");
     _Static_assert(std::is_same<min10float&, __decltype(--min10float_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min10float, __decltype(min10float_l--)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min10float, __decltype(min10float_l--)>::value, "");
     _Static_assert(std::is_same<min16int&, __decltype(--min16int_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16int, __decltype(min16int_l--)>::value, "");
     _Static_assert(std::is_same<min12int&, __decltype(--min12int_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min12int, __decltype(min12int_l--)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min12int, __decltype(min12int_l--)>::value, "");
     _Static_assert(std::is_same<min16uint&, __decltype(--min16uint_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16uint, __decltype(min16uint_l--)>::value, "");
     (--SamplerState_l); // expected-error {{scalar, vector, or matrix expected}} fxc-pass {{}}
@@ -310,7 +310,7 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<double4&, __decltype(--double4_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<double4, __decltype(double4_l--)>::value, "");
     _Static_assert(std::is_same<min10float1x2&, __decltype(--min10float1x2_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min10float1x2, __decltype(min10float1x2_l--)>::value, "");      /* fxc-pass {{}} */
+    _Static_assert(std::is_same<min10float1x2, __decltype(min10float1x2_l--)>::value, "");
     _Static_assert(std::is_same<uint2x3&, __decltype(--uint2x3_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<uint2x3, __decltype(uint2x3_l--)>::value, "");
     _Static_assert(std::is_same<min16uint4x4&, __decltype(--min16uint4x4_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
@@ -332,11 +332,11 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<min16float&, __decltype(++min16float_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16float, __decltype(min16float_l++)>::value, "");
     _Static_assert(std::is_same<min10float&, __decltype(++min10float_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min10float, __decltype(min10float_l++)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min10float, __decltype(min10float_l++)>::value, "");
     _Static_assert(std::is_same<min16int&, __decltype(++min16int_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16int, __decltype(min16int_l++)>::value, "");
     _Static_assert(std::is_same<min12int&, __decltype(++min12int_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min12int, __decltype(min12int_l++)>::value, "");  // fxc-pass {{}}
+    _Static_assert(std::is_same<min12int, __decltype(min12int_l++)>::value, "");
     _Static_assert(std::is_same<min16uint&, __decltype(++min16uint_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<min16uint, __decltype(min16uint_l++)>::value, "");
     (++SamplerState_l); // expected-error {{scalar, vector, or matrix expected}} fxc-pass {{}}
@@ -354,7 +354,7 @@ float4 plain(float4 param4 /* : FOO */) /*: FOO */{
     _Static_assert(std::is_same<double4&, __decltype(++double4_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<double4, __decltype(double4_l++)>::value, "");
     _Static_assert(std::is_same<min10float1x2&, __decltype(++min10float1x2_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
-    _Static_assert(std::is_same<min10float1x2, __decltype(min10float1x2_l++)>::value, "");  /* fxc-pass {{}} */
+    _Static_assert(std::is_same<min10float1x2, __decltype(min10float1x2_l++)>::value, "");
     _Static_assert(std::is_same<uint2x3&, __decltype(++uint2x3_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}
     _Static_assert(std::is_same<uint2x3, __decltype(uint2x3_l++)>::value, "");
     _Static_assert(std::is_same<min16uint4x4&, __decltype(++min16uint4x4_l)>::value, ""); // expected-error {{pointers are unsupported in HLSL}} fxc-pass {{}}

--- a/tools/clang/test/HLSL/out-param-diagnostics.hlsl
+++ b/tools/clang/test/HLSL/out-param-diagnostics.hlsl
@@ -1,22 +1,22 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 
-void UnusedEmpty(out int Val) {} // expected-warning{{parameter 'Val' is uninitialized when used here}} expected-note{{variable 'Val' is declared here}}
+void UnusedEmpty(out int Val) {} // expected-note {{variable 'Val' is declared here}} expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
 
 // Neither of these should warn
 void UnusedInAndOut(in out int Val) {}
 void UnusedInOut(inout int Val) {}
 
 
-int Returned(out int Val) { // expected-note{{variable 'Val' is declared here}}
-  return Val; // expected-warning{{parameter 'Val' is uninitialized when used here}}
+int Returned(out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
+  return Val; // expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
 }
 
-int ReturnedPassthrough(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+int ReturnedPassthrough(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   if (Cond % 3)
     return Returned(Val);
   else if (Cond % 2)
     return Returned(Val);
-  return Val; // expected-warning{{parameter 'Val' is uninitialized when used here}}
+  return Val; // expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
 }
 
 // No disagnostic expected here because all paths to the exit return, and they
@@ -42,31 +42,31 @@ void AllPathsReturnSwitch(int Cond, out int Val) {
   }
 }
 
-int ReturnedMaybePassthrough(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+int ReturnedMaybePassthrough(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   if (Cond % 3)
     UnusedEmpty(Val);
-  else if (Cond % 2) // expected-warning{{parameter 'Val' is used uninitialized whenever 'if' condition is false}} expected-note{{remove the 'if' if its condition is always true}}
+  else if (Cond % 2) // expected-note {{remove the 'if' if its condition is always true}} expected-warning {{parameter 'Val' is used uninitialized whenever 'if' condition is false}} fxc-pass {{}}
     UnusedEmpty(Val);
-  return Val; // expected-note{{uninitialized use occurs here}}
+  return Val; // expected-note {{uninitialized use occurs here}} fxc-pass {{}}
 }
 
-void SomePathsReturnSwitch(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+void SomePathsReturnSwitch(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   switch(Cond) {
     case 0:
       Val = 0;
       return;
-    default: // expected-warning{{parameter 'Val' is used uninitialized whenever switch default is taken}}
+    default: // expected-warning {{parameter 'Val' is used uninitialized whenever switch default is taken}} fxc-pass {{}}
       break;
   }
-}  // expected-note{{uninitialized use occurs here}}
+}  // expected-note {{uninitialized use occurs here}} fxc-pass {{}}
 
-void SomePathsReturnSwitch2(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+void SomePathsReturnSwitch2(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   switch(Cond) {
     case 0:
       Val = 0;
       return;
     case 1:
-      return; // expected-warning{{parameter 'Val' is uninitialized when used here}}
+      return; // expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
     default:
       Val = 0;
       break;
@@ -77,8 +77,8 @@ int Dbl(int V) {
   return V + V;
 }
 
-int UsedAsIn(out int Num) { // expected-note{{variable 'Num' is declared here}}
-  return Dbl(Num); // expected-warning{{parameter 'Num' is uninitialized when used here}}
+int UsedAsIn(out int Num) { // expected-note {{variable 'Num' is declared here}} fxc-pass {{}}
+  return Dbl(Num); // expected-warning {{parameter 'Num' is uninitialized when used here}} fxc-pass {{}}
 }
 
 // No diagnostic for this one either!
@@ -96,16 +96,16 @@ void DblInPlace2(inout int V) {
   V += V;
 }
 
-void MaybePassthrough(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+void MaybePassthrough(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   if (Cond % 3)
     UnusedEmpty(Val);
-  else if (Cond % 2) // expected-warning{{parameter 'Val' is used uninitialized whenever 'if' condition is false}} expected-note{{remove the 'if' if its condition is always true}}
+  else if (Cond % 2) // expected-note {{remove the 'if' if its condition is always true}} expected-warning {{parameter 'Val' is used uninitialized whenever 'if' condition is false}} fxc-pass {{}}
     UnusedEmpty(Val);
-} // expected-note{{uninitialized use occurs here}}
+} // expected-note {{uninitialized use occurs here}} fxc-pass {{}}
 
-void EarlyOut(int Cond, out int Val) { // expected-note{{variable 'Val' is declared here}}
+void EarlyOut(int Cond, out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-pass {{}}
   if (Cond % 11)
-    return; // expected-warning {{parameter 'Val' is uninitialized when used here}}
+    return; // expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
   Val = 1;
 }
 
@@ -128,8 +128,8 @@ void SomethingCalledInAndOut(in out int V) {
   V = 1;
 }
 
-int Something2(out int Num) { // expected-note {{variable 'Num' is declared here}}
-  SomethingCalledInAndOut(Num); // expected-warning {{parameter 'Num' is uninitialized when used here}}
+int Something2(out int Num) { // expected-note {{variable 'Num' is declared here}} fxc-pass {{}}
+  SomethingCalledInAndOut(Num); // expected-warning {{parameter 'Num' is uninitialized when used here}} fxc-pass {{}}
   return Num;
 }
 
@@ -137,8 +137,8 @@ void SomethingCalledInOut(inout int V) {
   V = 1;
 }
 
-int Something3(out int Num) { // expected-note {{variable 'Num' is declared here}}
-  SomethingCalledInOut(Num); // expected-warning {{parameter 'Num' is uninitialized when used here}}
+int Something3(out int Num) { // expected-note {{variable 'Num' is declared here}} fxc-pass {{}}
+  SomethingCalledInOut(Num); // expected-warning {{parameter 'Num' is uninitialized when used here}} fxc-pass {{}}
   return Num;
 }
 
@@ -156,24 +156,24 @@ void UnusedObjectOut(out SomeObj V) {}
 // errors. As a result that test doesn't produce these diagnostics.
 void fn_uint_oload3(uint u) { }
 void fn_uint_oload3(inout uint u) { }
-void fn_uint_oload3(out uint u) { } // expected-warning {{parameter 'u' is uninitialized when used here}} expected-note{{variable 'u' is declared here}}
+void fn_uint_oload3(out uint u) { } // expected-note {{variable 'u' is declared here}} expected-warning {{parameter 'u' is uninitialized when used here}} fxc-pass {{}}
 
 // Verify attribute annotation to opt out of uninitialized parameter analysis.
-void UnusedOutput([maybe_unused] out int Val) {}
+void UnusedOutput([maybe_unused] out int Val) {}            /* fxc-error {{X3000: syntax error: unexpected token '['}} */
 
-void UsedMaybeOutput([maybe_unused] out int Val) { // expected-note{{variable 'Val' is declared here}}
-  Val += Val; // expected-warning{{parameter 'Val' is uninitialized when used here}}
+void UsedMaybeOutput([maybe_unused] out int Val) { // expected-note {{variable 'Val' is declared here}} fxc-error {{X3000: syntax error: unexpected token '['}}
+  Val += Val; // expected-warning {{parameter 'Val' is uninitialized when used here}} fxc-pass {{}}
 }
 
-void MaybeUsedMaybeUnused([maybe_unused] out int Val, int Cnt) { // expected-note{{variable 'Val' is declared here}}
-  if (Cnt % 2) // expected-warning{{parameter 'Val' is used uninitialized whenever 'if' condition is fals}} expected-note{{remove the 'if' if its condition is always true}}
+void MaybeUsedMaybeUnused([maybe_unused] out int Val, int Cnt) { // expected-note {{variable 'Val' is declared here}} fxc-error {{X3000: syntax error: unexpected token '['}}
+  if (Cnt % 2) // expected-note {{remove the 'if' if its condition is always true}} expected-warning {{parameter 'Val' is used uninitialized whenever 'if' condition is fals}} fxc-pass {{}}
     Val = 1;
-} // expected-note{{uninitialized use occurs here}}
+} // expected-note {{uninitialized use occurs here}} fxc-pass {{}}
 
 void Use(int V) {}
 
-void NoAnnotationIsUse(out int V) { // expected-note{{variable 'V' is declared here}}
-  Use(V); // expected-warning{{parameter 'V' is uninitialized when used here}}
+void NoAnnotationIsUse(out int V) { // expected-note {{variable 'V' is declared here}} fxc-pass {{}}
+  Use(V); // expected-warning {{parameter 'V' is uninitialized when used here}} fxc-pass {{}}
 }
 
 RWByteAddressBuffer buffer;
@@ -187,7 +187,7 @@ void interlockWrapper(out uint original) {
 
 // Neither of these will warn because we don't support element-based tracking.
 void UnusedSizedArray(out uint u[2]) { }
-void UnusedUnsizedArray(out uint u[]) { }
+void UnusedUnsizedArray(out uint u[]) { }                   /* fxc-error {{X3072: 'u': array dimensions of function parameters must be explicit}} */
 
 // Warnings for struct types are not supported yet.
 struct S { uint a; uint b; };

--- a/tools/clang/test/HLSL/scalar-operators.hlsl
+++ b/tools/clang/test/HLSL/scalar-operators.hlsl
@@ -73,9 +73,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<float, __decltype(bools + floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(bools + doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(bools + min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(bools + min10floats)>::value, ""); // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(bools + min10floats)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(bools + min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(bools + min12ints)>::value, "");     /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(bools + min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(bools + min16uints)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints + bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints + ints)>::value, "");
@@ -143,14 +143,14 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min16floats + min16ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats + min12ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats + min16uints)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats + bools)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats + bools)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats + ints)>::value, "");   // expected-warning {{conversion from larger type 'int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats + uints)>::value, "");  // expected-warning {{conversion from larger type 'uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<float, __decltype(min10floats + halfs)>::value, "");
   _Static_assert(std::is_same<float, __decltype(min10floats + floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(min10floats + doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min10floats + min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats + min10floats)>::value, ""); // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats + min10floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats + min16ints)>::value, "");  // expected-warning {{conversion from larger type 'min16int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats + min12ints)>::value, "");  // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats + min16uints)>::value, ""); // expected-warning {{conversion from larger type 'min16uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
@@ -165,7 +165,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints + min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints + min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16ints + min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints + bools)>::value, "");          /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(min12ints + bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(min12ints + ints)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min12ints + uints)>::value, "");
   _Static_assert(std::is_same<float, __decltype(min12ints + halfs)>::value, "");
@@ -174,7 +174,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min12ints + min16floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min12ints + min10floats)>::value, "");  // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min16int, __decltype(min12ints + min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints + min12ints)>::value, "");    // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints + min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min12ints + min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints + bools)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min16uints + ints)>::value, "");
@@ -194,9 +194,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<float, __decltype(bools - floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(bools - doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(bools - min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(bools - min10floats)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(bools - min10floats)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(bools - min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(bools - min12ints)>::value, "");      /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(bools - min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(bools - min16uints)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints - bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints - ints)>::value, "");
@@ -264,14 +264,14 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min16floats - min16ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats - min12ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats - min16uints)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats - bools)>::value, "");   // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats - bools)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats - ints)>::value, "");    // expected-warning {{conversion from larger type 'int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats - uints)>::value, "");   // expected-warning {{conversion from larger type 'uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<float, __decltype(min10floats - halfs)>::value, "");
   _Static_assert(std::is_same<float, __decltype(min10floats - floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(min10floats - doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min10floats - min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats - min10floats)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats - min10floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats - min16ints)>::value, "");    // expected-warning {{conversion from larger type 'min16int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats - min12ints)>::value, "");    // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats - min16uints)>::value, "");   // expected-warning {{conversion from larger type 'min16uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
@@ -286,7 +286,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints - min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints - min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16ints - min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints - bools)>::value, "");           /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(min12ints - bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(min12ints - ints)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min12ints - uints)>::value, "");
   _Static_assert(std::is_same<float, __decltype(min12ints - halfs)>::value, "");
@@ -295,7 +295,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min12ints - min16floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min12ints - min10floats)>::value, "");   // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min16int, __decltype(min12ints - min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints - min12ints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints - min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min12ints - min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints - bools)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min16uints - ints)>::value, "");
@@ -315,7 +315,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<float, __decltype(bools / floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(bools / doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(bools / min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(bools / min10floats)>::value, "");   // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(bools / min10floats)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(bools / min16ints)>::value, "");       /* expected-error {{signed integer division is not supported on minimum-precision types, cast to int to use 32-bit division}} fxc-pass {{}} */
   _Static_assert(std::is_same<min12int, __decltype(bools / min12ints)>::value, "");       /* expected-error {{signed integer division is not supported on minimum-precision types, cast to int to use 32-bit division}} fxc-pass {{}} */
   _Static_assert(std::is_same<min16uint, __decltype(bools / min16uints)>::value, "");
@@ -385,14 +385,14 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min16floats / min16ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats / min12ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats / min16uints)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats / bools)>::value, "");   // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats / bools)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats / ints)>::value, "");    // expected-warning {{conversion from larger type 'int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats / uints)>::value, "");   // expected-warning {{conversion from larger type 'uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<float, __decltype(min10floats / halfs)>::value, "");
   _Static_assert(std::is_same<float, __decltype(min10floats / floats)>::value, "");
   _Static_assert(std::is_same<double, __decltype(min10floats / doubles)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min10floats / min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats / min10floats)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats / min10floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats / min16ints)>::value, "");    // expected-warning {{conversion from larger type 'min16int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats / min12ints)>::value, "");    // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats / min16uints)>::value, "");   // expected-warning {{conversion from larger type 'min16uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
@@ -449,7 +449,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-50): error X3684: modulo cannot be used with doubles, cast to float first;compilation failed; no code produced;
   bools = (bools % doubles); // expected-error {{modulo cannot be used with doubles, cast to float first}} fxc-error {{X3684: modulo cannot be used with doubles, cast to float first}}
   _Static_assert(std::is_same<min16float, __decltype(bools % min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(bools % min10floats)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(bools % min10floats)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(bools % min16ints)>::value, "");      /* expected-error {{signed integer division is not supported on minimum-precision types, cast to int to use 32-bit division}} fxc-pass {{}} */
   _Static_assert(std::is_same<min12int, __decltype(bools % min12ints)>::value, "");      /* expected-error {{signed integer division is not supported on minimum-precision types, cast to int to use 32-bit division}} fxc-pass {{}} */
   _Static_assert(std::is_same<min16uint, __decltype(bools % min16uints)>::value, "");
@@ -535,7 +535,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16float, __decltype(min16floats % min16ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats % min12ints)>::value, "");
   _Static_assert(std::is_same<min16float, __decltype(min16floats % min16uints)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats % bools)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats % bools)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats % ints)>::value, "");  // expected-warning {{conversion from larger type 'int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats % uints)>::value, "");  // expected-warning {{conversion from larger type 'uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<float, __decltype(min10floats % halfs)>::value, "");
@@ -543,7 +543,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-56): error X3684: modulo cannot be used with doubles, cast to float first;compilation failed; no code produced;
   min10floats = (min10floats % doubles); // expected-error {{modulo cannot be used with doubles, cast to float first}} expected-warning {{conversion from larger type 'double' to smaller type 'min10float', possible loss of data}} fxc-error {{X3684: modulo cannot be used with doubles, cast to float first}} fxc-warning {{X3205: conversion from larger type to smaller, possible loss of data}}
   _Static_assert(std::is_same<min16float, __decltype(min10floats % min16floats)>::value, "");
-  _Static_assert(std::is_same<min10float, __decltype(min10floats % min10floats)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min10float, __decltype(min10floats % min10floats)>::value, "");
   _Static_assert(std::is_same<min10float, __decltype(min10floats % min16ints)>::value, "");  // expected-warning {{conversion from larger type 'min16int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats % min12ints)>::value, "");  // expected-warning {{conversion from larger type 'min12int' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
   _Static_assert(std::is_same<min10float, __decltype(min10floats % min16uints)>::value, "");  // expected-warning {{conversion from larger type 'min16uint' to smaller type 'min10float', possible loss of data}} fxc-pass {{}}
@@ -1495,9 +1495,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints << min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints << min12ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints << min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << bools)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << uints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << bools)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << uints)>::value, "");
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-53): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-54): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints << halfs); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-54): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-55): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
@@ -1508,9 +1508,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   min12ints = (min12ints << min16floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-59): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-60): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints << min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << min16ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << min12ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints << min16uints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << min16ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << min12ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints << min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints << bools)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints << ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints << uints)>::value, "");
@@ -1701,9 +1701,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints >> min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints >> min12ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints >> min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> bools)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> uints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> bools)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> uints)>::value, "");
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-53): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-54): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints >> halfs); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-54): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-55): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
@@ -1714,9 +1714,9 @@ float4 plain(float4 param4 : FOO) : FOO {
   min12ints = (min12ints >> min16floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-59): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-60): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints >> min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min16ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min12ints)>::value, "");  // fxc-pass {{}}
-  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min16uints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min16ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min12ints)>::value, "");
+  _Static_assert(std::is_same<min12int, __decltype(min12ints >> min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints >> bools)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints >> ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints >> uints)>::value, "");
@@ -1747,7 +1747,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-54): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-55): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   bools = (bools & min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(bools & min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(bools & min12ints)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(bools & min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(bools & min16uints)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints & bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints & ints)>::value, "");
@@ -1907,7 +1907,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints & min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints & min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16ints & min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints & bools)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(min12ints & bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(min12ints & ints)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min12ints & uints)>::value, "");
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-52): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-53): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
@@ -1921,7 +1921,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-58): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-59): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints & min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(min12ints & min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints & min12ints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints & min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min12ints & min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints & bools)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min16uints & ints)>::value, "");
@@ -1953,7 +1953,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-54): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-55): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   bools = (bools | min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(bools | min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(bools | min12ints)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(bools | min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(bools | min16uints)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints | bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints | ints)>::value, "");
@@ -2113,7 +2113,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints | min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints | min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16ints | min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints | bools)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(min12ints | bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(min12ints | ints)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min12ints | uints)>::value, "");
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-52): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-53): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
@@ -2127,7 +2127,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-58): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-59): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints | min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(min12ints | min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints | min12ints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints | min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min12ints | min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints | bools)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min16uints | ints)>::value, "");
@@ -2159,7 +2159,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-54): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-55): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   bools = (bools ^ min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(bools ^ min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(bools ^ min12ints)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(bools ^ min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(bools ^ min16uints)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints ^ bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(ints ^ ints)>::value, "");
@@ -2319,7 +2319,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   _Static_assert(std::is_same<min16int, __decltype(min16ints ^ min16ints)>::value, "");
   _Static_assert(std::is_same<min16int, __decltype(min16ints ^ min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16ints ^ min16uints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints ^ bools)>::value, "");    /* fxc-pass {{}} */
+  _Static_assert(std::is_same<min12int, __decltype(min12ints ^ bools)>::value, "");
   _Static_assert(std::is_same<int, __decltype(min12ints ^ ints)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min12ints ^ uints)>::value, "");
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-52): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-53): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
@@ -2333,7 +2333,7 @@ float4 plain(float4 param4 : FOO) : FOO {
   // X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,22-58): error X3082: int or unsigned int type required;X:\temp\Sfbl_grfx_dev_p\x86\chk\operators.js.hlsl(16,12-59): error X3013: 'get_value': no matching 1 parameter function;compilation failed; no code produced
   min12ints = (min12ints ^ min10floats); // expected-error {{int or unsigned int type required}} fxc-error {{X3082: int or unsigned int type required}}
   _Static_assert(std::is_same<min16int, __decltype(min12ints ^ min16ints)>::value, "");
-  _Static_assert(std::is_same<min12int, __decltype(min12ints ^ min12ints)>::value, "");  // fxc-pass {{}}
+  _Static_assert(std::is_same<min12int, __decltype(min12ints ^ min12ints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min12ints ^ min16uints)>::value, "");
   _Static_assert(std::is_same<min16uint, __decltype(min16uints ^ bools)>::value, "");
   _Static_assert(std::is_same<uint, __decltype(min16uints ^ ints)>::value, "");

--- a/tools/clang/test/HLSL/write-const-arrays.hlsl
+++ b/tools/clang/test/HLSL/write-const-arrays.hlsl
@@ -13,38 +13,38 @@ StructuredBuffer<uint> g_robuf;
 Texture1D<uint> g_tex;
 uint g_cbuf[4];
 
-const groupshared uint gs_val[4];
+const groupshared uint gs_val[4];                           /* fxc-error {{X3012: 'gs_val': missing initial value}} */
 
 [NumThreads(1, 1, 1)]
 void main() {
-  const uint local[4];
+  const uint local[4];                                      /* fxc-error {{X3012: 'local': missing initial value}} */
 
   // Assigning using assignment operator
-  local[0] = 0;                                             /* expected-error {{read-only variable is not assignable}} */
-  gs_val[0] = 0;                                            /* expected-error {{read-only variable is not assignable}} */
-  g_cbuf[0] = 0;                                            /* expected-error {{read-only variable is not assignable}} */
-  g_robuf[0] = 0;                                           /* expected-error {{cannot assign to return value because function 'operator[]<const unsigned int &>' returns a const value}} */
+  local[0] = 0;                                             /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'local'}} */
+  gs_val[0] = 0;                                            /* expected-error {{read-only variable is not assignable}} fxc-error {{X3004: undeclared identifier 'gs_val'}} */
+  g_cbuf[0] = 0;                                            /* expected-error {{read-only variable is not assignable}} fxc-error {{X3025: global variables are implicitly constant, enable compatibility mode to allow modification}} */
+  g_robuf[0] = 0;                                           /* expected-error {{cannot assign to return value because function 'operator[]<const unsigned int &>' returns a const value}} fxc-error {{X3025: l-value specifies const object}} */
 
   // Assigning using out param of builtin function
   double d = 1.0;
-  asuint(d, local[0], local[1]);                          /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} */
-  asuint(d, gs_val[0], gs_val[1]);                        /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} */
-  asuint(d, g_cbuf[0], g_cbuf[1]);                        /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} */
-  asuint(d, g_robuf[0], g_robuf[1]);                      /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const unsigned int') would lose const qualifier}} */
+  asuint(d, local[0], local[1]);                          /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} fxc-error {{X3004: undeclared identifier 'local'}} */
+  asuint(d, gs_val[0], gs_val[1]);                        /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} fxc-error {{X3004: undeclared identifier 'gs_val'}} */
+  asuint(d, g_cbuf[0], g_cbuf[1]);                        /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const uint') would lose const qualifier}} fxc-error {{X3013:     asuint(double, out uint x, out uint y)}} fxc-error {{X3013:     asuint(float|half|int|uint)}} fxc-error {{X3013: 'asuint': no matching 3 parameter intrinsic function}} fxc-error {{X3013: Possible intrinsic functions are:}} */
+  asuint(d, g_robuf[0], g_robuf[1]);                      /* expected-error {{no matching function for call to 'asuint'}} expected-note {{candidate function not viable: 2nd argument ('const unsigned int') would lose const qualifier}} fxc-error {{X3013:     asuint(double, out uint x, out uint y)}} fxc-error {{X3013:     asuint(float|half|int|uint)}} fxc-error {{X3013: 'asuint': no matching 3 parameter intrinsic function}} fxc-error {{X3013: Possible intrinsic functions are:}} */
 
 
   // Assigning using out param of method
-  g_tex.GetDimensions(local[0]);                            /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} */
-  g_tex.GetDimensions(gs_val[0]);                           /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} */
-  g_tex.GetDimensions(g_cbuf[0]);                           /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} */
-  g_tex.GetDimensions(g_robuf[0]);                          /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} */
+  g_tex.GetDimensions(local[0]);                            /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} fxc-error {{X3004: undeclared identifier 'local'}} */
+  g_tex.GetDimensions(gs_val[0]);                           /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} fxc-error {{X3004: undeclared identifier 'gs_val'}} */
+  g_tex.GetDimensions(g_cbuf[0]);                           /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(out float|half|min10float|min16float width)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(out uint width)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(uint, out float|half|min10float|min16float width, out float|half|min10float|min16float levels)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(uint, out uint width, out uint levels)}} fxc-error {{X3013: 'GetDimensions': no matching 1 parameter intrinsic method}} fxc-error {{X3013: Possible intrinsic methods are:}} */
+  g_tex.GetDimensions(g_robuf[0]);                          /* expected-error {{no matching member function for call to 'GetDimensions'}} expected-note {{candidate function template not viable: requires 3 arguments, but 1 was provided}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(out float|half|min10float|min16float width)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(out uint width)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(uint, out float|half|min10float|min16float width, out float|half|min10float|min16float levels)}} fxc-error {{X3013:     Texture1D<uint>.GetDimensions(uint, out uint width, out uint levels)}} fxc-error {{X3013: 'GetDimensions': no matching 1 parameter intrinsic method}} fxc-error {{X3013: Possible intrinsic methods are:}} */
 
 
   // Assigning using dest param of atomics
   // Distinct because of special handling of atomics dest param
-  InterlockedAdd(local[0], 1);                              /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long &' for 1st argument}} */
-  InterlockedAdd(gs_val[0], 1);                             /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long' for 1st argument}} */
-  InterlockedAdd(g_cbuf[0], 1);                             /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long' for 1st argument}} */
-  InterlockedAdd(g_robuf[0], 1);                            /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const unsigned int') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const unsigned int' to 'unsigned long long' for 1st argument}} */
+  InterlockedAdd(local[0], 1);                              /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long &' for 1st argument}} fxc-error {{X3004: undeclared identifier 'local'}} */
+  InterlockedAdd(gs_val[0], 1);                             /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long' for 1st argument}} fxc-error {{X3004: undeclared identifier 'gs_val'}} */
+  InterlockedAdd(g_cbuf[0], 1);                             /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const uint') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const uint' to 'unsigned long long' for 1st argument}} fxc-pass {{}} */
+  InterlockedAdd(g_robuf[0], 1);                            /* expected-error {{no matching function for call to 'InterlockedAdd'}} expected-note {{candidate function not viable: 1st argument ('const unsigned int') would lose const qualifier}} expected-note {{candidate function not viable: no known conversion from 'const unsigned int' to 'unsigned long long' for 1st argument}} fxc-pass {{}} */
 
 }

--- a/utils/hct/VerifierHelper.py
+++ b/utils/hct/VerifierHelper.py
@@ -49,12 +49,16 @@ HlslVerifierTestCpp = os.path.expandvars(r'${HLSL_SRC_DIR}\tools\clang\unittests
 HlslDataDir = os.path.expandvars(r'${HLSL_SRC_DIR}\tools\clang\test\HLSL')
 HlslBinDir = os.path.expandvars(r'${HLSL_BLD_DIR}\Debug\bin')
 VerifierTests = {
+    'GloballyCoherentErrors':                    'globallycoherent-errors.hlsl',
+    'GloballyCoherentTemplateErrors':            'globallycoherent-template-errors.hlsl',
     'RunArrayConstAssign':                       'array-const-assign.hlsl',
     'RunArrayIndexOutOfBounds':                  'array-index-out-of-bounds-HV-2016.hlsl',
     'RunArrayLength':                            'array-length.hlsl',
+    'RunAtomicsOnBitfields':                     'atomics-on-bitfields.hlsl',
     'RunAttributes':                             'attributes.hlsl',
     'RunBadInclude':                             'bad-include.hlsl',
     'RunBinopDims':                              'binop-dims.hlsl',
+    'RunBitFieldAnnotations':                    'bitfields-and-annotations.hlsl',
     'RunBitfields':                              'bitfields.hlsl',
     'RunBuiltinTypesNoInheritance':              'builtin-types-no-inheritance.hlsl',
     'RunCXX11Attributes':                        'cxx11-attributes.hlsl',
@@ -76,6 +80,7 @@ VerifierTests = {
     'RunIndexingOperator':                       'indexing-operator.hlsl',
     'RunInputPatchConst':                        'InputPatch-const.hlsl',
     'RunIntrinsicExamples':                      'intrinsic-examples.hlsl',
+    'RunInvalidDeclTemplateArg':                 'invalid-decl-template-arg.hlsl',
     'RunLiterals':                               'literals.hlsl',
     'RunMatrixAssignments':                      'matrix-assignments.hlsl',
     'RunMatrixSyntax':                           'matrix-syntax.hlsl',
@@ -85,7 +90,9 @@ VerifierTests = {
     'RunObjectOperators':                        'object-operators.hlsl',
     'RunOperatorOverloadingForNewDelete':        'overloading-new-delete-errors.hlsl',
     'RunOperatorOverloadingNotDefinedBinaryOp':  'use-undefined-overloaded-operator.hlsl',
+    'RunOutParamDiags':                          'out-param-diagnostics.hlsl',
     'RunPackReg':                                'packreg.hlsl',
+    'RunPragmaRegion':                           'pragma-region.hlsl',
     'RunRayTracings':                            'raytracings.hlsl',
     'RunScalarAssignments':                      'scalar-assignments.hlsl',
     'RunScalarAssignmentsExactPrecision':        'scalar-assignments-exact-precision.hlsl',
@@ -101,7 +108,9 @@ VerifierTests = {
     'RunTemplateChecks':                         'template-checks.hlsl',
     'RunTemplateLiteralSubstitutionFailure':     'template-literal-substitution-failure.hlsl',
     'RunTypemodsSyntax':                         'typemods-syntax.hlsl',
+    'RunUDTByteAddressBufferLoad':               'template-udt-load.hlsl',
     'RunUint4Add3':                              'uint4_add3.hlsl',
+    'RunUnboundedResourceArrays':                'invalid-unbounded-resource-arrays.hlsl',
     'RunVarmodsSyntax':                          'varmods-syntax.hlsl',
     'RunVectorAnd':                              'vector-and.hlsl',
     'RunVectorAssignments':                      'vector-assignments.hlsl',
@@ -113,14 +122,14 @@ VerifierTests = {
     'RunVectorSyntaxMix':                        'vector-syntax-mix.hlsl',
     'RunWave':                                   'wave.hlsl',
     'RunWriteConstArrays':                       'write-const-arrays.hlsl',
-    'RunAtomicsOnBitfields':                     'atomics-on-bitfields.hlsl',
-    'RunUnboundedResourceArrays':                'invalid-unbounded-resource-arrays.hlsl',
 }
 
 # The following test(s) do not work in fxc mode:
 fxcExcludedTests = [
+    'GloballyCoherentTemplateErrors',
     'RunArrayLength',
     'RunBitfields',
+    'RunBitFieldAnnotations',
     'RunCppErrors',
     'RunCppErrorsHV2015',
     'RunCXX11Attributes',
@@ -131,6 +140,7 @@ fxcExcludedTests = [
     'RunMatrixSyntaxExactPrecision',
     'RunOperatorOverloadingForNewDelete',
     'RunOperatorOverloadingNotDefinedBinaryOp',
+    'RunPragmaRegion',
     'RunRayTracings',
     'RunScalarAssignmentsExactPrecision',
     'RunScalarOperatorsAssignExactPrecision',
@@ -142,6 +152,7 @@ fxcExcludedTests = [
     'RunVectorSyntaxExactPrecision',
     'RunWave',
     'RunAtomicsOnBitfields',
+    'RunUDTByteAddressBufferLoad',
 ]
 
 # rxRUN = re.compile(r'[ RUN      ] VerifierTest.(\w+)')	# gtest syntax
@@ -540,6 +551,9 @@ class File(object):
                 if line[-1] == '\n':
                     line = line[:-1]
                 inlines.append(line)
+        # Remove extra lines at end, we will ensure we have exactly one newline on last line.
+        while inlines and not inlines[-1].strip():
+            del inlines[-1]
         verify_arguments = None
         for line in inlines:
             m = rxVerifyArguments.search(line)
@@ -616,6 +630,7 @@ class File(object):
 
         with open(result_filename, 'wt') as f:
             f.write('\n'.join(map((lambda res: res[0]), result)))
+            f.write('\n')
 
     def TryAst(self, result_filename=None):
         temp_filename = os.path.expandvars(r'${TEMP}\%s' % os.path.split(self.filename)[1])
@@ -646,6 +661,9 @@ class File(object):
                 if line[-1] == '\n':
                     line = line[:-1]
                 inlines.append(line)
+        # Remove extra lines at end, we will ensure we have exactly one newline on last line.
+        while inlines and not inlines[-1].strip():
+            del inlines[-1]
         outlines = []
         i = 0
         while i < len(inlines):
@@ -668,6 +686,7 @@ class File(object):
 
         with open(result_filename, 'wt') as f:
             f.write('\n'.join(outlines))
+            f.write('\n')
 
 def ProcessVerifierOutput(lines):
     files = {}


### PR DESCRIPTION
This change updates VerifierHelper.py and verifier tests that were out of date for fxc and ast modes, so now the tests can be cleanly run through VerifierHelper.py.

Changes to VerifierHelper.py:
- update test list with ones in `VerifierTest.cpp` and add fxc exclusions for HLSL 2021 features
- canonicalize ending newlines to one (it could add/remove newlines depending on mode before)

Changes to tests:
- Update/remove fxc results (fxc-pass only used when we emit something and fxc does not)
- Updates to some ast blocks: `const` additions and `nrvo` added in one place for HS return value in `attributes.hlsl`.
- Error sorting and whitespace changes from VerifierHelper.py canonical output.  In many cases, this was sorting `expected-note` before `expected-warning`.

Moved this change out of #5140.