### PR TITLE
ci: add GCP pipeline files to replace AppVeyor

### DIFF
--- a/gcp-pipelines/x86_64-linux-clang.yml
+++ b/gcp-pipelines/x86_64-linux-clang.yml
@@ -1,4 +1,6 @@
 steps:
+  - name: gcr.io/cloud-builders/git
+    args: ['fetch', '--unshallow']
   - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
     args:
       - git
@@ -11,12 +13,14 @@ steps:
       - '-Bbuild'
       - '-GNinja'
       - '-DCMAKE_BUILD_TYPE=Release'
-      - '-C'
-      - cmake/caches/PredefinedParams.cmake
-      - '-DSPIRV_BUILD_TESTS=ON'
-      - '-DCMAKE_C_COMPILER=clang'
       - '-DCMAKE_CXX_COMPILER=clang++'
+      - '-DCMAKE_C_COMPILER=clang'
+      - '-DCMAKE_INSTALL_PREFIX=artifacts'
+      - '-DDXC_USE_LIT=ON'
       - '-DENABLE_SPIRV_CODEGEN=ON'
+      - '-DSPIRV_BUILD_TESTS=ON'
+      - '-C'
+      - 'cmake/caches/PredefinedParams.cmake'
   - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
     args:
       - ninja
@@ -28,14 +32,23 @@ steps:
       - '-C'
       - build
       - check-all
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    args:
+      - ninja
+      - '-C'
+      - build
+      - install-distribution
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    script: |
+      #!/usr/bin/env bash
+      zip -r dxc-artifacts.zip /workspace/artifacts/*
 logsBucket: 'gs://public-github-building-logs'
 options:
   logging: LEGACY
   pool:
-    name: projects/shaderc-build/locations/europe-west1/workerPools/dxc
+    name: projects/shaderc-build/locations/us-central1/workerPools/dxc
 artifacts:
   objects:
     location: 'gs://public-directx-shader-compiler/$COMMIT_SHA'
     paths:
-      - build/bin/dxc-*
-      - build/lib/libdxcompiler.so.*
+      - artifacts.zip

--- a/gcp-pipelines/x86_64-linux-clang.yml
+++ b/gcp-pipelines/x86_64-linux-clang.yml
@@ -1,0 +1,41 @@
+steps:
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    args:
+      - git
+      - submodule
+      - update
+      - '--init'
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    args:
+      - cmake
+      - '-Bbuild'
+      - '-GNinja'
+      - '-DCMAKE_BUILD_TYPE=Release'
+      - '-C'
+      - cmake/caches/PredefinedParams.cmake
+      - '-DSPIRV_BUILD_TESTS=ON'
+      - '-DCMAKE_C_COMPILER=clang'
+      - '-DCMAKE_CXX_COMPILER=clang++'
+      - '-DENABLE_SPIRV_CODEGEN=ON'
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    args:
+      - ninja
+      - '-C'
+      - build
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:kokoro-dxc-builder'
+    args:
+      - ninja
+      - '-C'
+      - build
+      - check-all
+logsBucket: 'gs://public-github-building-logs'
+options:
+  logging: LEGACY
+  pool:
+    name: projects/shaderc-build/locations/europe-west1/workerPools/dxc
+artifacts:
+  objects:
+    location: 'gs://public-directx-shader-compiler/$COMMIT_SHA'
+    paths:
+      - build/bin/dxc-*
+      - build/lib/libdxcompiler.so.*

--- a/gcp-pipelines/x86_64-linux-clang.yml
+++ b/gcp-pipelines/x86_64-linux-clang.yml
@@ -51,4 +51,4 @@ artifacts:
   objects:
     location: 'gs://public-directx-shader-compiler/$COMMIT_SHA'
     paths:
-      - artifacts.zip
+      - dxc-artifacts.zip

--- a/gcp-pipelines/x86_64-windows-msvc.yml
+++ b/gcp-pipelines/x86_64-windows-msvc.yml
@@ -1,0 +1,16 @@
+steps:
+  - name: 'gcr.io/shaderc-build/shader-compiler-team:dxc-win-builder'
+    env:
+      - BUILD_ID=$BUILD_ID
+      - SOURCE_IMAGE=dxc-windows-vs22
+logsBucket: 'gs://public-github-building-logs'
+options:
+  logging: LEGACY
+  pool:
+    name: projects/shaderc-build/locations/europe-west1/workerPools/dxc
+artifacts:
+  objects:
+    location: 'gs://public-directx-shader-compiler/$COMMIT_SHA'
+    paths:
+      - bin/dxc.exe
+      - bin/dxcompiler.dll

--- a/gcp-pipelines/x86_64-windows-msvc.yml
+++ b/gcp-pipelines/x86_64-windows-msvc.yml
@@ -2,15 +2,15 @@ steps:
   - name: 'gcr.io/shaderc-build/shader-compiler-team:dxc-win-builder'
     env:
       - BUILD_ID=$BUILD_ID
-      - SOURCE_IMAGE=dxc-windows-vs22
+      - SOURCE_IMAGE=dxc-builder-windows-vs22
+      - COMMIT_SHA=$COMMIT_SHA
 logsBucket: 'gs://public-github-building-logs'
 options:
   logging: LEGACY
   pool:
-    name: projects/shaderc-build/locations/europe-west1/workerPools/dxc
+    name: projects/shaderc-build/locations/us-central1/workerPools/dxc
 artifacts:
   objects:
     location: 'gs://public-directx-shader-compiler/$COMMIT_SHA'
     paths:
-      - bin/dxc.exe
-      - bin/dxcompiler.dll
+      - dxc-artifacts.zip


### PR DESCRIPTION
Those files are the required to drive the new GCP pipeline aimed to replace AppVeyor. As-is, those file have no effect on the repo. What's needed to add the CI is to setup some repository permissions, and only then CI will be able to run.

This CI will build x86_64 versions of DXC on both Linux and Windows, run tests, and allow retrieving build artifacts (same as Appveyor).