### PR TITLE
Setup `install-distribution` target for DXC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,23 @@ endif()
 
 include(CoverageReport)
 
+# This must be at the end of the LLVM root CMakeLists file because it must run
+# after all targets are created.
+if(LLVM_DISTRIBUTION_COMPONENTS)
+  if(CMAKE_CONFIGURATION_TYPES)
+    message(FATAL_ERROR "LLVM_DISTRIBUTION_COMPONENTS cannot be specified with multi-configuration generators (i.e. Xcode or Visual Studio)")
+  endif()
+  
+  add_custom_target(install-distribution)
+  foreach(target ${LLVM_DISTRIBUTION_COMPONENTS})
+    if(TARGET install-${target})
+      add_dependencies(install-distribution install-${target})
+    else()
+      message(FATAL_ERROR "Specified distribution component '${target}' doesn't have an install target")
+    endif()
+  endforeach()
+endif()
+
 # Disable regeneration target for official builds as they always fun a full clean build.
 # This should eliminate the race-condition issue with "Cannot restore timestamp".
 if (HLSL_OFFICIAL_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,6 +788,12 @@ endif()
 
 include(CoverageReport)
 
+# HLSL Change begin - Set default distribution value.
+if (NOT CMAKE_CONFIGURATION_TYPES)
+  set(LLVM_DISTRIBUTION_COMPONENTS "dxc;dxcompiler;dxc-headers" CACHE STRING "")
+endif ()
+# HLSL Change end - Set default distribution value.
+
 # This must be at the end of the LLVM root CMakeLists file because it must run
 # after all targets are created.
 if(LLVM_DISTRIBUTION_COMPONENTS)

--- a/include/dxc/CMakeLists.txt
+++ b/include/dxc/CMakeLists.txt
@@ -15,3 +15,29 @@ add_subdirectory(DxilContainer)
 add_subdirectory(HLSL)
 add_subdirectory(Support)
 add_subdirectory(Tracing)
+
+set(DXC_PUBLIC_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/dxcapi.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/dxcerrors.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/dxcisense.h)
+
+if (NOT WIN32)
+  set(DXC_PLATFORM_PUBLIC_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/WinAdapter.h)
+endif()
+
+# This target just needs to exist for the distribuiton build, it doesn't need to
+# actually build anything since the headers are static.
+add_custom_target(dxc-headers)
+
+install(FILES 
+    ${DXC_PUBLIC_HEADERS}
+    ${DXC_PLATFORM_PUBLIC_HEADERS}
+    DESTINATION include/dxc
+    COMPONENT dxc-headers
+    )
+
+add_custom_target(install-dxc-headers
+    DEPENDS dxc-headers
+    COMMAND "${CMAKE_COMMAND}"
+            -DCMAKE_INSTALL_COMPONENT=dxc-headers
+            -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")

--- a/tools/clang/tools/dxc/CMakeLists.txt
+++ b/tools/clang/tools/dxc/CMakeLists.txt
@@ -51,5 +51,12 @@ else()
 endif()
 
 install(TARGETS dxc
-  RUNTIME DESTINATION bin)
+  RUNTIME DESTINATION bin
+  COMPONENT dxc)
+
+add_custom_target(install-dxc
+  DEPENDS dxc
+  COMMAND "${CMAKE_COMMAND}"
+          -DCMAKE_INSTALL_COMPONENT=dxc
+          -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")
 

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -141,3 +141,14 @@ set_target_properties(dxcompiler
   OUTPUT_NAME "dxcompiler"
   VERSION ${LIBCLANG_LIBRARY_VERSION}
   DEFINE_SYMBOL _CINDEX_LIB_)
+
+install(TARGETS dxcompiler
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
+  COMPONENT dxcompiler)
+
+add_custom_target(install-dxcompiler
+  DEPENDS dxcompiler
+  COMMAND "${CMAKE_COMMAND}"
+          -DCMAKE_INSTALL_COMPONENT=dxcompiler
+          -P "${CMAKE_BINARY_DIR}/cmake_install.cmake")


### PR DESCRIPTION
This cherry-picks a change I made in LLVM 3.8 (SVN revision 261681, https://github.com/llvm/llvm-project/commit/c90e12fe9fd7eb9fd7b342e7ac0cec971dd3e4db), and provides updates to DXC-specific build logic to enable the change.

This only works with single-configuration generators (Ninja, Makefiles), but could probably be extended to work with Visual Studio as well.

With this change the `install-distribution` target will build and install the DXC components and headers into the `CMAKE_INSTALL_PREFIX` directory.