### PR TITLE
[NFC] Update tests that depend on 2018 behavior

### DIFF
--- a/tools/clang/test/HLSLFileCheck/passes/llvm/instcombine/nosink.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/llvm/instcombine/nosink.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc %s /T ps_6_0 -opt-disable sink | FileCheck %s
+// RUN: %dxc %s /T ps_6_0 -opt-disable sink -HV 2018 | FileCheck %s
 
 // Make sure the selects are NOT sunk into a single block
 

--- a/tools/clang/test/HLSLFileCheck/passes/llvm/instcombine/sink.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/llvm/instcombine/sink.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc %s /T ps_6_0 -opt-enable sink | FileCheck %s
-// RUN: %dxc %s /T ps_6_0                  | FileCheck %s
+// RUN: %dxc %s /T ps_6_0 -opt-enable sink -HV 2018 | FileCheck %s
+// RUN: %dxc %s /T ps_6_0 -HV 2018 | FileCheck %s
 
 // Make sure the selects are sunk into a single block
 


### PR DESCRIPTION
Under HLSL 2021 short circuiting ternary operators result in _very_ different control flow in these tests, so they aren't really portable. Changing these tests to being HV 2018 keeps them working with minimal changes.