### PR TITLE
Update inline API reference docs for dxcapi.h

### DIFF
--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -41,12 +41,20 @@ struct IMalloc;
 
 struct IDxcIncludeHandler;
 
+/// \brief Typedef for DxcCreateInstance function pointer.
+///
+/// This can be used with GetProcAddress to get the DxcCreateInstance function.
+/// </remarks>
 typedef HRESULT (__stdcall *DxcCreateInstanceProc)(
     _In_ REFCLSID   rclsid,
     _In_ REFIID     riid,
     _Out_ LPVOID*   ppv
 );
 
+/// \brief Typedef for DxcCreateInstance2 function pointer.
+///
+/// This can be used with GetProcAddress to get the DxcCreateInstance2 function.
+/// </remarks>
 typedef HRESULT(__stdcall *DxcCreateInstance2Proc)(
   _In_ IMalloc    *pMalloc,
   _In_ REFCLSID   rclsid,
@@ -79,6 +87,12 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
   _Out_ LPVOID*   ppv
   );
 
+/// <summary>
+/// Version of DxcCreateInstance that takes an IMalloc interface.
+/// </summary>
+/// <remarks>
+/// This can be used to create an instance of the compiler with a custom memory allocator.
+/// </remarks>
 extern "C"
 DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
   _In_ IMalloc    *pMalloc,
@@ -94,19 +108,21 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
 // Use DXC_CP_ACP for: Binary;  ANSI Text;  Autodetect UTF with BOM
 #define DXC_CP_ACP 0
 
+/// Codepage for "wide" characters - UTF16 on Windows, UTF32 on other platforms
 #ifdef _WIN32
 #define DXC_CP_WIDE DXC_CP_UTF16
 #else
 #define DXC_CP_WIDE DXC_CP_UTF32
 #endif
 
-// This flag indicates that the shader hash was computed taking into account source information (-Zss)
-#define DXC_HASHFLAG_INCLUDES_SOURCE  1
+/// Indicates that the shader hash was computed taking into account source
+/// information (-Zss)
+#define DXC_HASHFLAG_INCLUDES_SOURCE 1
 
-// Hash digest type for ShaderHash
+/// Hash digest type for ShaderHash
 typedef struct DxcShaderHash {
-  UINT32 Flags; // DXC_HASHFLAG_*
-  BYTE HashDigest[16];
+  UINT32 Flags;        ///< DXC_HASHFLAG_*
+  BYTE HashDigest[16]; ///< The hash digest
 } DxcShaderHash;
 
 #define DXC_FOURCC(ch0, ch1, ch2, ch3) (                     \
@@ -124,7 +140,8 @@ typedef struct DxcShaderHash {
 #define DXC_PART_OUTPUT_SIGNATURE         DXC_FOURCC('O', 'S', 'G', '1')
 #define DXC_PART_PATCH_CONSTANT_SIGNATURE DXC_FOURCC('P', 'S', 'G', '1')
 
-// Some option arguments are defined here for continuity with D3DCompile interface
+// Some option arguments are defined here for continuity with D3DCompile
+// interface
 #define DXC_ARG_DEBUG L"-Zi"
 #define DXC_ARG_SKIP_VALIDATION L"-Vd"
 #define DXC_ARG_SKIP_OPTIMIZATIONS L"-Od"
@@ -145,87 +162,159 @@ typedef struct DxcShaderHash {
 #define DXC_ARG_DEBUG_NAME_FOR_SOURCE L"-Zss"
 #define DXC_ARG_DEBUG_NAME_FOR_BINARY L"-Zsb"
 
-// IDxcBlob is an alias of ID3D10Blob and ID3DBlob
 CROSS_PLATFORM_UUIDOF(IDxcBlob, "8BA5FB08-5195-40e2-AC58-0D989C3A0102")
+/// \brief A sized buffer that can be passed in and out of DXC APIs
+///
+/// This is an alias of ID3D10Blob and ID3DBlob.
 struct IDxcBlob : public IUnknown {
 public:
+  /// \brief Retrieves a pointer to the blob's data.
   virtual LPVOID STDMETHODCALLTYPE GetBufferPointer(void) = 0;
+
+  /// \brief Retrieves the size, in bytes, of the blob's data.
   virtual SIZE_T STDMETHODCALLTYPE GetBufferSize(void) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcBlobEncoding, "7241d424-2646-4191-97c0-98e96e42fc68")
+/// \brief A blob that might have a known encoding
 struct IDxcBlobEncoding : public IDxcBlob {
 public:
+  /// \brief Retrieve the encoding for this blob.
+  ///
+  /// \param pKnown Pointer to a variable that will be set to TRUE if the
+  /// encoding is known.
+  ///
+  /// \param pCodePage Pointer to variable that will be set to the encoding used
+  /// for this blog.
+  ///
+  /// If the encoding is not known then pCodePage will be set to CP_ACP.
   virtual HRESULT STDMETHODCALLTYPE GetEncoding(_Out_ BOOL *pKnown,
                                                 _Out_ UINT32 *pCodePage) = 0;
 };
 
-// Notes on IDxcBlobWide and IDxcBlobUtf8
-// These guarantee null-terminated text and eithre utf8 or the native wide char encoding.
-// GetBufferSize() will return the size in bytes, including null-terminator
-// GetStringLength() will return the length in characters, excluding the null-terminator
-// Name strings will use IDxcBlobWide, while other string output blobs,
-// such as errors/warnings, preprocessed HLSL, or other text will be based
-// on the -encoding option.
-
-// The API will use this interface for output name strings
 CROSS_PLATFORM_UUIDOF(IDxcBlobWide, "A3F84EAB-0FAA-497E-A39C-EE6ED60B2D84")
+/// \brief A blob containing a null-terminated wide string
+///
+/// This uses the native wide character encoding (utf16 on Windows, utf32 on
+/// Linux).
+///
+/// The value returned by GetBufferSize() is the size of the buffer, in bytes,
+/// including the null-terminator.
+///
+/// This interface is used to return output name strings DXC.  Other string
+/// output blobs, such as errors/warnings, preprocessed HLSL, or other text are
+/// returned using encodings based on the -encoding option passed to the
+/// compiler.
 struct IDxcBlobWide : public IDxcBlobEncoding {
 public:
+  /// \brief Retrieves a pointer to the string stored in this blob.
   virtual LPCWSTR STDMETHODCALLTYPE GetStringPointer(void) = 0;
-  virtual SIZE_T STDMETHODCALLTYPE GetStringLength(void) = 0;
-};
-CROSS_PLATFORM_UUIDOF(IDxcBlobUtf8, "3DA636C9-BA71-4024-A301-30CBF125305B")
-struct IDxcBlobUtf8 : public IDxcBlobEncoding {
-public:
-  virtual LPCSTR STDMETHODCALLTYPE GetStringPointer(void) = 0;
+
+  /// \brief Retrieves the length of the string stored in this blob, in
+  /// characters, excluding the null-terminator.
   virtual SIZE_T STDMETHODCALLTYPE GetStringLength(void) = 0;
 };
 
-// Define legacy name IDxcBlobUtf16 as IDxcBlobWide for Win32
+CROSS_PLATFORM_UUIDOF(IDxcBlobUtf8, "3DA636C9-BA71-4024-A301-30CBF125305B")
+/// \brief A blob containing a UTF-8 encoded string
+///
+/// The value returned by GetBufferSize() is the size of the buffer, in bytes,
+/// including the null-terminator.
+///
+/// Depending on the -encoding option passed to the compiler, this interface is
+/// used to return string output blobs, such as errors/warnings, preprocessed
+/// HLSL, or other text. Output name strings always use IDxcBlobWide.
+struct IDxcBlobUtf8 : public IDxcBlobEncoding {
+public:
+  /// \brief Retrieves a pointer to the string stored in this blob.
+  virtual LPCSTR STDMETHODCALLTYPE GetStringPointer(void) = 0;
+
+  /// \brief Retrieves the length of the string stored in this blob, in
+  /// characters, excluding the null-terminator.
+  virtual SIZE_T STDMETHODCALLTYPE GetStringLength(void) = 0;
+};
+
 #ifdef _WIN32
+/// IDxcBlobUtf16 is a legacy alias for IDxcBlobWide on Win32
 typedef IDxcBlobWide IDxcBlobUtf16;
 #endif
 
 CROSS_PLATFORM_UUIDOF(IDxcIncludeHandler, "7f61fc7d-950d-467f-b3e3-3c02fb49187c")
+/// \brief Interface for handling include directives
+///
+/// This interface can be implemented to customize handling of include
+/// directives.
+///
+/// Use IDxcUtils::CreateDefaultIncludeHandler to create a default
+/// implementation that reads include files from the filesystem..
+///
 struct IDxcIncludeHandler : public IUnknown {
+  /// \brief Load a source file to be included by the compiler.
+  ///
+  /// \param pFilename candidate filename.
+  ///
+  /// \param ppIncludeSource Resultant source object for included file, nullptr
+  /// if not found.
   virtual HRESULT STDMETHODCALLTYPE LoadSource(
-    _In_z_ LPCWSTR pFilename,                                 // Candidate filename.
-    _COM_Outptr_result_maybenull_ IDxcBlob **ppIncludeSource  // Resultant source object for included file, nullptr if not found.
+      _In_z_ LPCWSTR pFilename,
+      _COM_Outptr_result_maybenull_ IDxcBlob **ppIncludeSource 
     ) = 0;
 };
 
-// Structure for supplying bytes or text input to Dxc APIs.
-// Use Encoding = 0 for non-text bytes, ANSI text, or unknown with BOM.
+/// \brief Structure for supplying bytes or text input to Dxc APIs.
 typedef struct DxcBuffer {
+  /// \brief pointer to the start of the buffer
   LPCVOID Ptr;
+
+  /// \brief size of the buffer, in bytes
   SIZE_T Size;
+
+  /// \brief encoding of the buffer.
+  ///
+  /// Use Encoding = 0 for non-text bytes, ANSI text, or unknown with BOM.
   UINT Encoding;
 } DxcText;
 
+/// \brief Structure for supplying defines to Dxc APIs
 struct DxcDefine {
-  LPCWSTR Name;
-  _Maybenull_ LPCWSTR Value;
+  LPCWSTR Name;              ///< the define name
+  _Maybenull_ LPCWSTR Value; ///< optional value for the define
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompilerArgs, "73EFFE2A-70DC-45F8-9690-EFF64C02429D")
+/// \brief Interface for managing arguments passed to DXC
+///
+/// Use IDxcUtils::BuildArguments to create an instance of this interface.
 struct IDxcCompilerArgs : public IUnknown {
-  // Pass GetArguments() and GetCount() to Compile
+  /// \brief Retrieve the array of arguments.
+  ///
+  /// This can be passed directly to the pArguments parameter of the Compile()
+  /// method.
   virtual LPCWSTR* STDMETHODCALLTYPE GetArguments() = 0;
+
+  /// \brief Retrieve the number of arguments.
+  ///
+  /// This can be passed directly to the argCount parameter of the Compile()
+  /// method.
   virtual UINT32 STDMETHODCALLTYPE GetCount() = 0;
 
-  // Add additional arguments or defines here, if desired.
+  /// \brief Add additional arguments to this list of compiler arguments.
   virtual HRESULT STDMETHODCALLTYPE AddArguments(
-    _In_opt_count_(argCount) LPCWSTR *pArguments,       // Array of pointers to arguments to add
-    _In_ UINT32 argCount                                // Number of arguments to add
+    _In_opt_count_(argCount) LPCWSTR *pArguments,       ///< Array of pointers to arguments to add
+    _In_ UINT32 argCount                                ///< Number of arguments to add
   ) = 0;
+
+  /// \brief Add additional UTF-8 encoded arguments to this list of compiler
+  /// arguments.
   virtual HRESULT STDMETHODCALLTYPE AddArgumentsUTF8(
-    _In_opt_count_(argCount)LPCSTR *pArguments,         // Array of pointers to UTF-8 arguments to add
-    _In_ UINT32 argCount                                // Number of arguments to add
+    _In_opt_count_(argCount)LPCSTR *pArguments,         ///< Array of pointers to UTF-8 arguments to add
+    _In_ UINT32 argCount                                ///< Number of arguments to add
   ) = 0;
+
+  /// \brief Add additional defines to this list of compiler arguments.
   virtual HRESULT STDMETHODCALLTYPE AddDefines(
-      _In_count_(defineCount) const DxcDefine *pDefines, // Array of defines
-      _In_ UINT32 defineCount                            // Number of defines
+      _In_count_(defineCount) const DxcDefine *pDefines, ///< Array of defines
+      _In_ UINT32 defineCount                            ///< Number of defines
   ) = 0;
 };
 
@@ -233,37 +322,56 @@ struct IDxcCompilerArgs : public IUnknown {
 // Legacy Interfaces
 /////////////////////////
 
-// NOTE: IDxcUtils replaces IDxcLibrary
 CROSS_PLATFORM_UUIDOF(IDxcLibrary, "e5204dc7-d18c-4c3c-bdfb-851673980fe7")
+/// \deprecated IDxcUtils replaces IDxcLibrary; please use IDxcUtils insted.
 struct IDxcLibrary : public IUnknown {
+  /// \deprecated
   virtual HRESULT STDMETHODCALLTYPE SetMalloc(_In_opt_ IMalloc *pMalloc) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateBlobFromBlob(
     _In_ IDxcBlob *pBlob, UINT32 offset, UINT32 length, _COM_Outptr_ IDxcBlob **ppResult) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateBlobFromFile(
     _In_z_ LPCWSTR pFileName, _In_opt_ UINT32* codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingFromPinned(
     _In_bytecount_(size) LPCVOID pText, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingOnHeapCopy(
     _In_bytecount_(size) LPCVOID pText, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateBlobWithEncodingOnMalloc(
     _In_bytecount_(size) LPCVOID pText, IMalloc *pIMalloc, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateIncludeHandler(
     _COM_Outptr_ IDxcIncludeHandler **ppResult) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE CreateStreamFromBlobReadOnly(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IStream **ppStream) = 0;
+
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
 
   // Renamed from GetBlobAsUtf16 to GetBlobAsWide
+  /// \deprecated 
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
 
 #ifdef _WIN32
   // Alias to GetBlobAsWide on Win32
+  /// \deprecated 
   inline HRESULT GetBlobAsUtf16(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) {
     return this->GetBlobAsWide(pBlob, pBlobEncoding);
@@ -271,27 +379,36 @@ struct IDxcLibrary : public IUnknown {
 #endif
 };
 
-// NOTE: IDxcResult replaces IDxcOperationResult
 CROSS_PLATFORM_UUIDOF(IDxcOperationResult, "CEDB484A-D4E9-445A-B991-CA21CA157DC2")
+/// \brief The results of a DXC operation.
+///
+/// Note: IDxcResult replaces IDxcOperationResult and should be used wherever
+/// possible.
 struct IDxcOperationResult : public IUnknown {
+  /// \brief Retrieve the overall status of the operation.
   virtual HRESULT STDMETHODCALLTYPE GetStatus(_Out_ HRESULT *pStatus) = 0;
 
-  // GetResult returns the main result of the operation.
-  // This corresponds to:
-  // DXC_OUT_OBJECT - Compile() with shader or library target
-  // DXC_OUT_DISASSEMBLY - Disassemble()
-  // DXC_OUT_HLSL - Compile() with -P
-  // DXC_OUT_ROOT_SIGNATURE - Compile() with rootsig_* target
+  /// \brief Retrieve the primary output of the operation.
+  ///
+  /// This corresponds to:
+  /// * DXC_OUT_OBJECT - Compile() with shader or library target
+  /// * DXC_OUT_DISASSEMBLY - Disassemble()
+  /// * DXC_OUT_HLSL - Compile() with -P
+  /// * DXC_OUT_ROOT_SIGNATURE - Compile() with rootsig_* target
   virtual HRESULT STDMETHODCALLTYPE GetResult(_COM_Outptr_result_maybenull_ IDxcBlob **ppResult) = 0;
 
-  // GetErrorBuffer Corresponds to DXC_OUT_ERRORS.
+  /// \brief Retrieves the error buffer from the operation, if there is one.
+  ///
+  // This corresponds to calling IDxcResult::GetOutput() with DXC_OUT_ERRORS.
   virtual HRESULT STDMETHODCALLTYPE GetErrorBuffer(_COM_Outptr_result_maybenull_ IDxcBlobEncoding **ppErrors) = 0;
 };
 
-// NOTE: IDxcCompiler3 replaces IDxcCompiler and IDxcCompiler2
 CROSS_PLATFORM_UUIDOF(IDxcCompiler, "8c210bf3-011f-4422-8d70-6f9acb8db617")
+/// \deprecated Please use IDxcCompiler3 instead.
 struct IDxcCompiler : public IUnknown {
-  // Compile a single entry point to the target shader model
+  /// \brief Compile a single entry point to the target shader model
+  ///
+  /// \deprecated Please use IDxcCompiler3::Compile() instead.
   virtual HRESULT STDMETHODCALLTYPE Compile(
     _In_ IDxcBlob *pSource,                       // Source text to compile
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
@@ -306,7 +423,9 @@ struct IDxcCompiler : public IUnknown {
     _COM_Outptr_ IDxcOperationResult **ppResult   // Compiler output status, buffer, and errors
   ) = 0;
 
-  // Preprocess source text
+  /// \brief Preprocess source text
+  ///
+  /// \todo Is IDxcCompiler::Preprocess() deprecated too?
   virtual HRESULT STDMETHODCALLTYPE Preprocess(
     _In_ IDxcBlob *pSource,                       // Source text to preprocess
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
@@ -319,17 +438,21 @@ struct IDxcCompiler : public IUnknown {
     _COM_Outptr_ IDxcOperationResult **ppResult   // Preprocessor output status, buffer, and errors
   ) = 0;
 
-  // Disassemble a program.
+  /// \brief Disassemble a program.
+  ///
+  /// \deprecated Please use IDxcCompiler3::Disassemble() instead.
   virtual HRESULT STDMETHODCALLTYPE Disassemble(
     _In_ IDxcBlob *pSource,                         // Program to disassemble.
     _COM_Outptr_ IDxcBlobEncoding **ppDisassembly   // Disassembly text.
     ) = 0;
 };
 
-// NOTE: IDxcCompiler3 replaces IDxcCompiler and IDxcCompiler2
 CROSS_PLATFORM_UUIDOF(IDxcCompiler2, "A005A9D9-B8BB-4594-B5C9-0E633BEC4D37")
+/// \deprecated Please use IDxcCompiler3 instead
 struct IDxcCompiler2 : public IDxcCompiler {
-  // Compile a single entry point to the target shader model with debug information.
+  /// \brief Compile a single entry point to the target shader model with debug information.
+  ///
+  /// \deprecated Please use IDxcCompiler3::Compile() instead.
   virtual HRESULT STDMETHODCALLTYPE CompileWithDebug(
     _In_ IDxcBlob *pSource,                       // Source text to compile
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
@@ -348,26 +471,30 @@ struct IDxcCompiler2 : public IDxcCompiler {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcLinker, "F1B5BE2A-62DD-4327-A1C2-42AC1E1E78E6")
+/// \brief DXC linker interface.
+///
+/// Use DxcCreateInstance with CLSID_DxcLinker to obtain an instance of this
+/// interface.
 struct IDxcLinker : public IUnknown {
 public:
-  // Register a library with name to ref it later.
+  /// \brief Register a library with name to reference it later.
   virtual HRESULT RegisterLibrary(
-    _In_opt_ LPCWSTR pLibName,          // Name of the library.
-    _In_ IDxcBlob *pLib                 // Library blob.
+    _In_opt_ LPCWSTR pLibName,          ///< Name of the library.
+    _In_ IDxcBlob *pLib                 ///< Library blob.
   ) = 0;
 
-  // Links the shader and produces a shader blob that the Direct3D runtime can
-  // use.
+  /// \brief Links the shader and produces a shader blob that the Direct3D
+  /// runtime can use.
   virtual HRESULT STDMETHODCALLTYPE Link(
-    _In_opt_ LPCWSTR pEntryName,        // Entry point name
-    _In_ LPCWSTR pTargetProfile,        // shader profile to link
+    _In_opt_ LPCWSTR pEntryName,        ///< Entry point name
+    _In_ LPCWSTR pTargetProfile,        ///< shader profile to link
     _In_count_(libCount)
-        const LPCWSTR *pLibNames,       // Array of library names to link
-    _In_ UINT32 libCount,               // Number of libraries to link
-    _In_opt_count_(argCount) const LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,               // Number of arguments
+        const LPCWSTR *pLibNames,       ///< Array of library names to link
+    _In_ UINT32 libCount,               ///< Number of libraries to link
+    _In_opt_count_(argCount) const LPCWSTR *pArguments, ///< Array of pointers to arguments
+    _In_ UINT32 argCount,               ///< Number of arguments
     _COM_Outptr_
-        IDxcOperationResult **ppResult  // Linker output status, buffer, and errors
+        IDxcOperationResult **ppResult  ///< Linker output status, buffer, and errors
   ) = 0;
 };
 
@@ -375,112 +502,234 @@ public:
 // Latest interfaces. Please use these
 ////////////////////////
 
-// NOTE: IDxcUtils replaces IDxcLibrary
 CROSS_PLATFORM_UUIDOF(IDxcUtils, "4605C4CB-2019-492A-ADA4-65F20BB7D67F")
+/// \brief Various utility functions for DXC.
+///
+/// Use DxcCreateInstance with CLSID_DxcUtils to obtain an instance of this
+/// interface.
+///
+/// IDxcUtils replaces IDxcLibrary.  
 struct IDxcUtils : public IUnknown {
-  // Create a sub-blob that holds a reference to the outer blob and points to its memory.
+  /// \brief Create a sub-blob that holds a reference to the outer blob and
+  /// points to its memory.
+  ///
+  /// \param pBlob The outer blob
+  ///
+  /// \param offset The offset inside the outer blob
+  ///
+  /// \param length The size, in bytes, of the buffer to reference from the
+  /// output blob.
+  ///
+  /// \param ppResult Address of the pointer that receives a pointer to the
+  /// newly created blob.
   virtual HRESULT STDMETHODCALLTYPE CreateBlobFromBlob(
     _In_ IDxcBlob *pBlob, UINT32 offset, UINT32 length, _COM_Outptr_ IDxcBlob **ppResult) = 0;
 
   // For codePage, use 0 (or DXC_CP_ACP) for raw binary or ANSI code page
 
-  // Creates a blob referencing existing memory, with no copy.
-  // User must manage the memory lifetime separately.
-  // (was: CreateBlobWithEncodingFromPinned)
+  /// \brief Create a blob referencing existing memory, with no copy.
+  ///
+  /// \param pData Pointer to buffer containing the contents of the new blob.
+  ///
+  /// \param size The size of the pData buffer, in bytes.
+  ///
+  /// \param codePage The code page to use if the blob contains text.  Use
+  /// DXC_CP_ACP for binary or ANSI code page.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
+  ///
+  /// The user must manage the memory lifetime separately.
+  ///
+  /// This replaces IDxcLibrary::CreateBlobWithEncodingFromPinned.
   virtual HRESULT STDMETHODCALLTYPE CreateBlobFromPinned(
     _In_bytecount_(size) LPCVOID pData, UINT32 size, UINT32 codePage,
-    _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+    _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) = 0;
 
-  // Create blob, taking ownership of memory allocated with supplied allocator.
-  // (was: CreateBlobWithEncodingOnMalloc)
+  /// \brief Create a blob, taking ownership of memory allocated with the
+  /// supplied allocator.
+  ///
+  /// \param pData Pointer to buffer containing the contents of the new blob.
+  ///
+  /// \param pIMalloc The memory allocator to use.
+  ///
+  /// \param size The size of thee pData buffer, in bytes.
+  ///
+  /// \param codePage The code page to use if the blob contains text. Use
+  /// DXC_CP_ACP for binary or ANSI code page.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
+  ///
+  /// This replaces IDxcLibrary::CreateBlobWithEncodingOnMalloc
   virtual HRESULT STDMETHODCALLTYPE MoveToBlob(
     _In_bytecount_(size) LPCVOID pData, IMalloc *pIMalloc, UINT32 size, UINT32 codePage,
-    _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+    _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) = 0;
 
-  ////
-  // New blobs and copied contents are allocated with the current allocator
-
-  // Copy blob contents to memory owned by the new blob.
-  // (was: CreateBlobWithEncodingOnHeapCopy)
+  /// \brief Create a blob containing a copy of the existing data.
+  ///
+  /// \param pData Pointer to buffer containing the contents of the new blob.
+  ///
+  /// \param size The size of thee pData buffer, in bytes.
+  ///
+  /// \param codePage The code page to use if the blob contains text.  Use
+  /// DXC_CP_ACP for binary or ANSI code page.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
+  ///
+  /// The new blob and its contents are allocated with the current allocator.
+  /// This replaces IDxcLibrary::CreateBlobWithEncodingOnHeapCopy.
   virtual HRESULT STDMETHODCALLTYPE CreateBlob(
     _In_bytecount_(size) LPCVOID pData, UINT32 size, UINT32 codePage,
-    _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+    _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) = 0;
 
-  // (was: CreateBlobFromFile)
+  /// \brief Create a blob with data loaded from a file.
+  ///
+  /// \param pFileName The name of the file to load from.
+  ///
+  /// \param pCodePage Optional code page to use if the blob contains text. Pass
+  /// NULL for binary data.</param>
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.</param>
+  ///
+  /// The new blob and its contents are allocated with the current allocator.
+  /// This replaces IDxcLibrary::CreateBlobFromFile.
   virtual HRESULT STDMETHODCALLTYPE LoadFile(
     _In_z_ LPCWSTR pFileName, _In_opt_ UINT32* pCodePage,
-    _COM_Outptr_ IDxcBlobEncoding **pBlobEncoding) = 0;
+    _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) = 0;
 
+  /// \brief Create a stream that reads data from a blob.
+  ///
+  /// \param pBlob The blob to read from.
+  ///
+  /// \param ppStream Address of the pointer that receives a pointer to the
+  /// newly created stream.
   virtual HRESULT STDMETHODCALLTYPE CreateReadOnlyStreamFromBlob(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IStream **ppStream) = 0;
 
-  // Create default file-based include handler
+  /// \brief Create default file-based include handler
+  ///
+  /// \param ppResult Address of the pointer that receives a pointer to the
+  /// newly created include handler.
   virtual HRESULT STDMETHODCALLTYPE CreateDefaultIncludeHandler(
     _COM_Outptr_ IDxcIncludeHandler **ppResult) = 0;
 
-  // Convert or return matching encoded text blobs
+  /// \brief Convert or return matching encoded text blob as UTF-8.
+  ///
+  /// \param pBlob The blob to convert.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsUtf8(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf8 **pBlobEncoding) = 0;
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobUtf8 **ppBlobEncoding) = 0;
 
-  // Renamed from GetBlobAsUtf16 to GetBlobAsWide
+  /// \brief Convert or return matching encoded text blob as UTF-16.
+  ///
+  /// \param pBlob The blob to convert.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
   virtual HRESULT STDMETHODCALLTYPE GetBlobAsWide(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) = 0;
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **ppBlobEncoding) = 0;
 
 #ifdef _WIN32
-  // Alias to GetBlobAsWide on Win32
+  /// \brief Convert or return matching encoded text blob as UTF-16.
+  ///
+  /// \param pBlob The blob to convert.
+  ///
+  /// \param ppBlobEncoding Address of the pointer that receives a pointer to
+  /// the newly created blob.
+  ///
+  /// Alias to GetBlobAsWide on Win32.
   inline HRESULT GetBlobAsUtf16(
-    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **pBlobEncoding) {
-    return this->GetBlobAsWide(pBlob, pBlobEncoding);
+    _In_ IDxcBlob *pBlob, _COM_Outptr_ IDxcBlobWide **ppBlobEncoding) {
+    return this->GetBlobAsWide(pBlob, ppBlobEncoding);
   }
 #endif
 
+  /// \brief Retrieve a single part from a DXIL container
+  ///
+  /// \param pShader The shader to retrieve the part from.
+  ///
+  /// \param DxcPart The part to retrieve (eg DXC_PART_ROOT_SIGNATURE).
+  ///
+  /// \param ppPartData Address of the pointer that receives a pointer to the
+  /// part.
+  ///
+  /// \param pPartSizeInBytes Address of the pointer that receives the size of
+  /// the part.
+  ///
+  /// The returned pointer points inside the buffer passed in pShader.
   virtual HRESULT STDMETHODCALLTYPE GetDxilContainerPart(
     _In_ const DxcBuffer *pShader,
     _In_ UINT32 DxcPart,
     _Outptr_result_nullonfailure_ void **ppPartData,
     _Out_ UINT32 *pPartSizeInBytes) = 0;
 
-  // Create reflection interface from serialized Dxil container, or DXC_PART_REFLECTION_DATA.
-  // TBD: Require part header for RDAT?  (leaning towards yes)
+  /// \brief Create reflection interface from serialized DXIL container or the
+  /// DXC_OUT_REFLECTION blob contents.
+  ///
+  /// \param pData The source data.
+  ///
+  /// \param iid The interface ID of the reflection interface to create.
+  ///
+  /// \param ppvReflection Address of the pointer that receives a pointer to the
+  /// newly created reflection interface.
+  ///
+  /// Use this with interfaces such as ID3D12ShaderReflection.
   virtual HRESULT STDMETHODCALLTYPE CreateReflection(
     _In_ const DxcBuffer *pData, REFIID iid, void **ppvReflection) = 0;
 
+  /// \brief Build arguments that can be passed to the Compile method.
   virtual HRESULT STDMETHODCALLTYPE BuildArguments(
-    _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
-    _In_opt_z_ LPCWSTR pEntryPoint,               // Entry point name. (-E)
-    _In_z_ LPCWSTR pTargetProfile,                // Shader profile to compile. (-T)
-    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,                         // Number of arguments
+    _In_opt_z_ LPCWSTR pSourceName,               ///< Optional file name for pSource. Used in errors and include handlers.
+    _In_opt_z_ LPCWSTR pEntryPoint,               ///< Entry point name. (-E)
+    _In_z_ LPCWSTR pTargetProfile,                ///< Shader profile to compile. (-T)
+    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments
+    _In_ UINT32 argCount,                         ///< Number of arguments
     _In_count_(defineCount)
-      const DxcDefine *pDefines,                  // Array of defines
-    _In_ UINT32 defineCount,                      // Number of defines
-    _COM_Outptr_ IDxcCompilerArgs **ppArgs        // Arguments you can use with Compile() method
+      const DxcDefine *pDefines,                  ///< Array of defines
+    _In_ UINT32 defineCount,                      ///< Number of defines
+    _COM_Outptr_ IDxcCompilerArgs **ppArgs        ///< Arguments you can use with Compile() method
   ) = 0;
 
-  // Takes the shader PDB and returns the hash and the container inside it
+  /// \brief Retrieve the hash and contents of a shader PDB.
+  ///
+  /// \param pPDBBlob The blob containing the PDB.
+  ///
+  /// \param ppHash Address of the pointer that receives a pointer to the hash
+  /// blob.
+  ///
+  /// \param ppContainer Address of the pointer that receives a pointer to the
+  /// bloc containing the contents of the PDB.
+  ///
   virtual HRESULT STDMETHODCALLTYPE GetPDBContents(
     _In_ IDxcBlob *pPDBBlob, _COM_Outptr_ IDxcBlob **ppHash, _COM_Outptr_ IDxcBlob **ppContainer) = 0;
 };
 
-// For use with IDxcResult::[Has|Get]Output dxcOutKind argument
-// Note: text outputs returned from version 2 APIs are UTF-8 or UTF-16 based on -encoding option
+/// \brief Specifies the kind of output to retrieve from a IDxcResult
+///
+/// Note: text outputs returned from version 2 APIs are UTF-8 or UTF-16 based on
+/// the -encoding option passed to the compiler.
 typedef enum DXC_OUT_KIND {
-  DXC_OUT_NONE = 0,
-  DXC_OUT_OBJECT = 1,         // IDxcBlob - Shader or library object
-  DXC_OUT_ERRORS = 2,         // IDxcBlobUtf8 or IDxcBlobWide
-  DXC_OUT_PDB = 3,            // IDxcBlob
-  DXC_OUT_SHADER_HASH = 4,    // IDxcBlob - DxcShaderHash of shader or shader with source info (-Zsb/-Zss)
-  DXC_OUT_DISASSEMBLY = 5,    // IDxcBlobUtf8 or IDxcBlobWide - from Disassemble
-  DXC_OUT_HLSL = 6,           // IDxcBlobUtf8 or IDxcBlobWide - from Preprocessor or Rewriter
-  DXC_OUT_TEXT = 7,           // IDxcBlobUtf8 or IDxcBlobWide - other text, such as -ast-dump or -Odump
-  DXC_OUT_REFLECTION = 8,     // IDxcBlob - RDAT part with reflection data
-  DXC_OUT_ROOT_SIGNATURE = 9, // IDxcBlob - Serialized root signature output
-  DXC_OUT_EXTRA_OUTPUTS  = 10,// IDxcExtraResults - Extra outputs
-  DXC_OUT_REMARKS = 11,       // IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
-  DXC_OUT_TIME_REPORT = 12,   // IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
-  DXC_OUT_TIME_TRACE = 13,   // IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
+  DXC_OUT_NONE = 0,           ///< No output
+  DXC_OUT_OBJECT = 1,         ///< IDxcBlob - Shader or library object
+  DXC_OUT_ERRORS = 2,         ///< IDxcBlobUtf8 or IDxcBlobWide
+  DXC_OUT_PDB = 3,            ///< IDxcBlob
+  DXC_OUT_SHADER_HASH = 4,    ///< IDxcBlob - DxcShaderHash of shader or shader with source info (-Zsb/-Zss)
+  DXC_OUT_DISASSEMBLY = 5,    ///< IDxcBlobUtf8 or IDxcBlobWide - from Disassemble
+  DXC_OUT_HLSL = 6,           ///< IDxcBlobUtf8 or IDxcBlobWide - from Preprocessor or Rewriter
+  DXC_OUT_TEXT = 7,           ///< IDxcBlobUtf8 or IDxcBlobWide - other text, such as -ast-dump or -Odump
+  DXC_OUT_REFLECTION = 8,     ///< IDxcBlob - RDAT part with reflection data
+  DXC_OUT_ROOT_SIGNATURE = 9, ///< IDxcBlob - Serialized root signature output
+  DXC_OUT_EXTRA_OUTPUTS  = 10,///< IDxcExtraOutputs - Extra outputs
+  DXC_OUT_REMARKS = 11,       ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
+  DXC_OUT_TIME_REPORT = 12,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
+  DXC_OUT_TIME_TRACE = 13,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
 
-  DXC_OUT_LAST = DXC_OUT_TIME_TRACE, // Last value for a counter
+  DXC_OUT_LAST = DXC_OUT_TIME_TRACE, ///< Last value for a counter
 
   DXC_OUT_NUM_ENUMS,
   DXC_OUT_FORCE_DWORD = 0xFFFFFFFF
@@ -490,14 +739,41 @@ static_assert(DXC_OUT_NUM_ENUMS == DXC_OUT_LAST + 1,
               "DXC_OUT_* Enum added and last value not updated.");
 
 CROSS_PLATFORM_UUIDOF(IDxcResult, "58346CDA-DDE7-4497-9461-6F87AF5E0659")
+/// \brief Result of a DXC operation
+///
+/// DXC operations may have multiple outputs, such as a shader object and
+/// errors. This interface provides access to the outputs.
 struct IDxcResult : public IDxcOperationResult {
+  /// \brief Determines whether or not this result has the specified output.
+  ///
+  /// \param dxcOutKind The kind of output to check for.
   virtual BOOL STDMETHODCALLTYPE HasOutput(_In_ DXC_OUT_KIND dxcOutKind) = 0;
+
+  /// \brief Retrieves the specified output
+  ///
+  /// \param dxcOutKind The kind of output to retrieve
+  ///
+  /// \param iid The interface ID of the output interface
+  ///
+  /// \param ppvObject Address of the pointer that receives a pointer to the
+  /// output.
+  ///
+  /// \param ppOutputName Optional address of a pointer to receive the name
+  /// blob, if there is one.
   virtual HRESULT STDMETHODCALLTYPE GetOutput(_In_ DXC_OUT_KIND dxcOutKind,
     _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
     _COM_Outptr_ IDxcBlobWide **ppOutputName) = 0;
 
+  /// \brief Retrieves the number of outputs available in this result.
   virtual UINT32 GetNumOutputs() = 0;
+
+  /// \brief Retrieves the output kind at the specified index.
   virtual DXC_OUT_KIND GetOutputByIndex(UINT32 Index) = 0;
+
+  /// \brief Retrieves the primary output kind for this result.
+  ///
+  /// See IDxcOperationResult::GetResult() for more information on the primary
+  /// output kinds.
   virtual DXC_OUT_KIND PrimaryOutput() = 0;
 };
 
@@ -506,9 +782,28 @@ struct IDxcResult : public IDxcOperationResult {
 #define DXC_EXTRA_OUTPUT_NAME_STDERR L"*stderr*"
 
 CROSS_PLATFORM_UUIDOF(IDxcExtraOutputs, "319b37a2-a5c2-494a-a5de-4801b2faf989")
+/// \brief Additional outputs from a DXC operation
+///
+/// This can be used to obtain outputs that don't have an explicit DXC_OUT_KIND.
+/// Use DXC_OUT_EXTRA_OUTPUTS to obtain instances of this.
 struct IDxcExtraOutputs : public IUnknown {
-
+  /// \brief Retrieves the number of outputs available
   virtual UINT32 STDMETHODCALLTYPE GetOutputCount() = 0;
+
+  /// \brief Retrieves the specified output
+  ///
+  /// \param uIndex The index of the output to retrieve
+  ///
+  /// \param iid The interface ID of the output interface
+  ///
+  /// \param ppvObject Optional address of the pointer that receives a pointer
+  /// to the output if there is one.
+  ///
+  /// \param ppOutputType Optional address of the pointer that receives the
+  /// output type name blob if there is one.
+  ///
+  /// \param ppOutputName Optional address of the pointer that receives the
+  /// output name blob if there is one.
   virtual HRESULT STDMETHODCALLTYPE GetOutput(_In_ UINT32 uIndex,
     _In_ REFIID iid, _COM_Outptr_opt_result_maybenull_ void **ppvObject,
     _COM_Outptr_opt_result_maybenull_ IDxcBlobWide **ppOutputType,
@@ -516,23 +811,36 @@ struct IDxcExtraOutputs : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompiler3, "228B4687-5A6A-4730-900C-9702B2203F54")
+/// \brief Interface to the DirectX Shader Compiler
+///
+/// Use DxcCreateInstance with CLSID_DxcCompiler to obtain an instance of this
+/// interface.
 struct IDxcCompiler3 : public IUnknown {
-  // Compile a single entry point to the target shader model,
-  // Compile a library to a library target (-T lib_*),
-  // Compile a root signature (-T rootsig_*), or
-  // Preprocess HLSL source (-P)
+  /// \brief Compile a shader
+  ///
+  /// IDxcUtils::BuildArguments can be used to assist building the pArguments
+  /// and argCount parameters.
+  ///
+  /// Depending on the arguments, this method can be used to:
+  ///
+  /// * Compile a single entry point to the target shader model, 
+  /// * Compile a library to a library target (-T lib_*)
+  /// * Compile a root signature (-T rootsig_*),
+  /// * Preprocess HLSL source (-P)
   virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_ const DxcBuffer *pSource,                // Source text to compile
-    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,                         // Number of arguments
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional)
-    _In_ REFIID riid, _Out_ LPVOID *ppResult      // IDxcResult: status, buffer, and errors
+    _In_ const DxcBuffer *pSource,                ///< Source text to compile
+    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments
+    _In_ UINT32 argCount,                         ///< Number of arguments
+    _In_opt_ IDxcIncludeHandler *pIncludeHandler, ///< user-provided interface to handle include directives (optional)
+    _In_ REFIID riid,                             ///< Interface ID for the result
+    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, buffer, and errors
   ) = 0;
 
-  // Disassemble a program.
+  /// \brief Disassemble a program.
   virtual HRESULT STDMETHODCALLTYPE Disassemble(
-    _In_ const DxcBuffer *pObject,                // Program to disassemble: dxil container or bitcode.
-    _In_ REFIID riid, _Out_ LPVOID *ppResult      // IDxcResult: status, disassembly text, and errors
+    _In_ const DxcBuffer *pObject,                ///< Program to disassemble: dxil container or bitcode.
+    _In_ REFIID riid,                             ///< Interface ID for the result
+    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, disassembly text, and errors
     ) = 0;
 };
 
@@ -543,54 +851,147 @@ static const UINT32 DxcValidatorFlags_ModuleOnly = 4;
 static const UINT32 DxcValidatorFlags_ValidMask = 0x7;
 
 CROSS_PLATFORM_UUIDOF(IDxcValidator, "A6E82BD2-1FD7-4826-9811-2857E797F49A")
+/// \brief Interface to DXC shader validator
+///
+/// Use DxcCreateInstance with CLSID_DxcValidator to obtain an instance of this.
 struct IDxcValidator : public IUnknown {
-  // Validate a shader.
+  /// \brief Validate a shader.
   virtual HRESULT STDMETHODCALLTYPE Validate(
-    _In_ IDxcBlob *pShader,                       // Shader to validate.
-    _In_ UINT32 Flags,                            // Validation flags.
-    _COM_Outptr_ IDxcOperationResult **ppResult   // Validation output status, buffer, and errors
+    _In_ IDxcBlob *pShader,                       ///< Shader to validate.
+    _In_ UINT32 Flags,                            ///< Validation flags.
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcValidator2, "458e1fd1-b1b2-4750-a6e1-9c10f03bed92")
+/// \brief Interface to DXC shader validator
+///
+/// Use DxcCreateInstance with CLSID_DxcValidator to obtain an instance of this.
 struct IDxcValidator2 : public IDxcValidator {
-  // Validate a shader.
+  /// \brief Validate a shader with optional debug bitcode.
   virtual HRESULT STDMETHODCALLTYPE ValidateWithDebug(
-    _In_ IDxcBlob *pShader,                       // Shader to validate.
-    _In_ UINT32 Flags,                            // Validation flags.
-    _In_opt_ DxcBuffer *pOptDebugBitcode,         // Optional debug module bitcode to provide line numbers
-    _COM_Outptr_ IDxcOperationResult **ppResult   // Validation output status, buffer, and errors
+    _In_ IDxcBlob *pShader,                       ///< Shader to validate.
+    _In_ UINT32 Flags,                            ///< Validation flags.
+    _In_opt_ DxcBuffer *pOptDebugBitcode,         ///< Optional debug module bitcode to provide line numbers
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder, "334b1f50-2292-4b35-99a1-25588d8c17fe")
+/// \brief Interface to DXC container builder
+///
+/// Use DxcCreateInstance with CLSID_DxcContainerBuilder to obtain an instance of this.
 struct IDxcContainerBuilder : public IUnknown {
-  virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader) = 0;                // Loads DxilContainer to the builder
-  virtual HRESULT STDMETHODCALLTYPE AddPart(_In_ UINT32 fourCC, _In_ IDxcBlob *pSource) = 0;      // Part to add to the container
-  virtual HRESULT STDMETHODCALLTYPE RemovePart(_In_ UINT32 fourCC) = 0;                           // Remove the part with fourCC
-  virtual HRESULT STDMETHODCALLTYPE SerializeContainer(_Out_ IDxcOperationResult **ppResult) = 0; // Builds a container of the given container builder state
+  /// \brief Load a DxilContainer to the builder
+  virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader) = 0;
+
+  /// \brief Add a part to the container
+  ///
+  /// \param fourCC The part identifier (eg DXC_PART_PDB)
+  ///
+  /// \param pSource The source blob
+  virtual HRESULT STDMETHODCALLTYPE AddPart(_In_ UINT32 fourCC, _In_ IDxcBlob *pSource) = 0;
+
+  /// \brief Remove a part from the container
+  ///
+  /// \param fourCC The part identifier (eg DXC_PART_PDB)
+  ///
+  /// \return S_OK on success, DXC_E_MISSING_PART if the part was not found, or
+  /// other standard HRESULT error code.
+  virtual HRESULT STDMETHODCALLTYPE RemovePart(_In_ UINT32 fourCC) = 0;
+
+  /// \brief Build the container
+  ///
+  /// \param ppResult Pointer to variable to receive the result
+  virtual HRESULT STDMETHODCALLTYPE SerializeContainer(_Out_ IDxcOperationResult **ppResult) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcAssembler, "091f7a26-1c1f-4948-904b-e6e3a8a771d5")
+/// \brief Interface to DxcAssembler
+///
+/// Use DxcCreateInstance with CLSID_DxcAssembler to obtain an instance of this.
 struct IDxcAssembler : public IUnknown {
-  // Assemble dxil in ll or llvm bitcode to DXIL container.
+  /// \brief Assemble DXIL in LL or LLVM bitcode to DXIL container.
   virtual HRESULT STDMETHODCALLTYPE AssembleToContainer(
-    _In_ IDxcBlob *pShader,                       // Shader to assemble.
-    _COM_Outptr_ IDxcOperationResult **ppResult   // Assembly output status, buffer, and errors
+    _In_ IDxcBlob *pShader,                       ///< Shader to assemble.
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Assembly output status, buffer, and errors
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcContainerReflection, "d2c21b26-8350-4bdc-976a-331ce6f4c54c")
+/// \\brief Interface to DxcContainerReflection
+///
+/// Use DxcCreateInstance with CLSID_DxcContainerReflection to obtain an
+/// instance of this.
 struct IDxcContainerReflection : public IUnknown {
-  virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pContainer) = 0; // Container to load.
+  /// \brief Choose the container to perform reflection on
+  ///
+  /// \param pContainer The container to load.  If null is passed then this
+  /// instance will release any held resources.
+  virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pContainer) = 0;
+
+  /// \brief Retrieves the number of parts in the container.
+  ///
+  /// \param pResult Pointer to variable to receive the result.
+  ///
+  /// \return S_OK on success, E_NOT_VALID_STATE if a container has not been
+  /// loaded using Load(), or other standard HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartCount(_Out_ UINT32 *pResult) = 0;
+
+  /// \brief Retrieve the kind of a specified part.
+  ///
+  /// \param idx The index of the part to retrieve the kind of.
+  ///
+  /// \param pResult Pointer to variable to receive the result.
+  ///
+  /// \return S_OK on success, E_NOT_VALID_STATE if a container has not been
+  /// loaded using Load(), E_BOUND if idx is out of bounds, or other standard
+  /// HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartKind(UINT32 idx, _Out_ UINT32 *pResult) = 0;
+
+  /// \brief Retrieve the content of a specified part
+  ///
+  /// \param idx The index of the part to retrieve.
+  ///
+  /// \param ppResult Pointer to variable to receive the result.
+  ///
+  /// \return S_OK on success, E_NOT_VALID_STATE if a container has not been
+  /// loaded using Load(), E_BOUND if idx is out of bounds, or other standard
+  /// HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartContent(UINT32 idx, _COM_Outptr_ IDxcBlob **ppResult) = 0;
+
+  /// \brief Retrieve the index of the first part with the specified kind
+  ///
+  /// \param kind The kind to search for.
+  ///
+  /// \param pResult Pointer to variable to receive the index of the matching
+  /// part.
+  ///
+  /// \return S_OK on success, E_NOT_VALID_STATE if a container has not been
+  /// loaded using Load(), HRESULT_FROM_WIN32(ERROR_NOT_FOUND) if there is no
+  /// part with the specified kind, or other standard HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE FindFirstPartKind(UINT32 kind, _Out_ UINT32 *pResult) = 0;
+
+  /// \brief Retrieve the reflection interface for a specified part
+  ///
+  /// \param idx The index of the part to retrieve the reflection interface of.
+  ///
+  /// \param iid The IID of the interface to retrieve.
+  ///
+  /// \param ppvObject Pointer to variable to receive the result. 
+  ///
+  /// Use this with interfaces such as ID3D12ShaderReflection.
+  ///
+  /// \return S_OK on success, E_NOT_VALID_STATE if a container has not been
+  /// loaded using Load(), E_BOUND if idx is out of bounds, or other standard
+  /// HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartReflection(UINT32 idx, REFIID iid, void **ppvObject) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcOptimizerPass, "AE2CD79F-CC22-453F-9B6B-B124E7A5204C")
+/// \brief An optimizer pass
+///
+/// Instances of this can be obtained via IDxcOptimizer::GetAvailablePass.
 struct IDxcOptimizerPass : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetOptionName(_COM_Outptr_ LPWSTR *ppResult) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetDescription(_COM_Outptr_ LPWSTR *ppResult) = 0;
@@ -600,6 +1001,9 @@ struct IDxcOptimizerPass : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcOptimizer, "25740E2E-9CBA-401B-9119-4FB42F39F270")
+/// \brief Interface to DxcOptimizer
+///
+/// Use DxcCreateInstance with CLSID_DxcOptimizer to obtain an instance of this.
 struct IDxcOptimizer : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetAvailablePassCount(_Out_ UINT32 *pCount) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetAvailablePass(UINT32 index, _COM_Outptr_ IDxcOptimizerPass** ppResult) = 0;
@@ -614,23 +1018,34 @@ static const UINT32 DxcVersionInfoFlags_Debug = 1; // Matches VS_FF_DEBUG
 static const UINT32 DxcVersionInfoFlags_Internal = 2; // Internal Validator (non-signing)
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo, "b04f5b50-2059-4f12-a8ff-a1e0cde1cc7e")
+/// \brief PDB Version information
+///
+/// Use IDxcPdbUtils2::GetVersionInfo to obtain an instance of this.
 struct IDxcVersionInfo : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetVersion(_Out_ UINT32 *pMajor, _Out_ UINT32 *pMinor) = 0;
   virtual HRESULT STDMETHODCALLTYPE GetFlags(_Out_ UINT32 *pFlags) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo2, "fb6904c4-42f0-4b62-9c46-983af7da7c83")
+/// \brief PDB Version Information
+///
+/// Use IDxcPdbUtils2::GetVersionInfo to obtain a IDxcVersionInfo interface, and
+/// then use QueryInterface to obtain an instance of this interface from it.
 struct IDxcVersionInfo2 : public IDxcVersionInfo {
   virtual HRESULT STDMETHODCALLTYPE GetCommitInfo(
-    _Out_ UINT32 *pCommitCount,           // The total number commits.
-    _Outptr_result_z_ char **pCommitHash  // The SHA of the latest commit. (Must be CoTaskMemFree()'d!)
+    _Out_ UINT32 *pCommitCount,           ///< The total number commits.
+    _Outptr_result_z_ char **pCommitHash  ///< The SHA of the latest commit. (Must be CoTaskMemFree()'d!)
   ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo3, "5e13e843-9d25-473c-9ad2-03b2d0b44b1e")
+/// \brief PDB Version Information
+///
+/// Use IDxcPdbUtils2::GetVersionInfo to obtain a IDxcVersionInfo interface, and
+/// then use QueryInterface to obtain an instance of this interface from it.
 struct IDxcVersionInfo3 : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetCustomVersionString(
-    _Outptr_result_z_ char **pVersionString // Custom version string for compiler. (Must be CoTaskMemFree()'d!)
+    _Outptr_result_z_ char **pVersionString ///< Custom version string for compiler. (Must be CoTaskMemFree()'d!)
   ) = 0;
 };
 
@@ -640,6 +1055,7 @@ struct DxcArgPair {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcPdbUtils, "E6C9647E-9D6A-4C3B-B94C-524B5A6C343D")
+/// \deprecated Please use IDxcPdbUtils2 instead.
 struct IDxcPdbUtils : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pPdbOrDxil) = 0;
 
@@ -678,6 +1094,9 @@ struct IDxcPdbUtils : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcPdbUtils2, "4315D938-F369-4F93-95A2-252017CC3807")
+/// \brief DxcPdbUtils interface.
+///
+/// Use DxcCreateInstance with CLSID_DxcPdbUtils to create an instance of this.
 struct IDxcPdbUtils2 : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pPdbOrDxil) = 0;
 

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -417,7 +417,7 @@ struct IDxcCompiler : public IUnknown {
 
   /// \brief Preprocess source text
   ///
-  /// \todo Is IDxcCompiler::Preprocess() deprecated too?
+  /// \deprecated Please use IDxcCompiler3::Compile() with the "-P" argument instead.
   virtual HRESULT STDMETHODCALLTYPE Preprocess(
     _In_ IDxcBlob *pSource,                       // Source text to preprocess
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -44,7 +44,6 @@ struct IDxcIncludeHandler;
 /// \brief Typedef for DxcCreateInstance function pointer.
 ///
 /// This can be used with GetProcAddress to get the DxcCreateInstance function.
-/// </remarks>
 typedef HRESULT (__stdcall *DxcCreateInstanceProc)(
     _In_ REFCLSID   rclsid,
     _In_ REFIID     riid,
@@ -54,7 +53,6 @@ typedef HRESULT (__stdcall *DxcCreateInstanceProc)(
 /// \brief Typedef for DxcCreateInstance2 function pointer.
 ///
 /// This can be used with GetProcAddress to get the DxcCreateInstance2 function.
-/// </remarks>
 typedef HRESULT(__stdcall *DxcCreateInstance2Proc)(
   _In_ IMalloc    *pMalloc,
   _In_ REFCLSID   rclsid,
@@ -62,24 +60,21 @@ typedef HRESULT(__stdcall *DxcCreateInstance2Proc)(
   _Out_ LPVOID*   ppv
   );
 
-/// <summary>
-/// Creates a single uninitialized object of the class associated with a specified CLSID.
-/// </summary>
-/// <param name="rclsid">
-/// The CLSID associated with the data and code that will be used to create the object.
-/// </param>
-/// <param name="riid">
-/// A reference to the identifier of the interface to be used to communicate
-/// with the object.
-/// </param>
-/// <param name="ppv">
-/// Address of pointer variable that receives the interface pointer requested
-/// in riid. Upon successful return, *ppv contains the requested interface
-/// pointer. Upon failure, *ppv contains NULL.</param>
-/// <remarks>
-/// While this function is similar to CoCreateInstance, there is no COM involvement.
-/// </remarks>
-
+/// \brief Creates a single uninitialized object of the class associated with a
+/// specified CLSID.
+///
+/// \param rclsid The CLSID associated with the data and code that will be used
+/// to create the object.
+///
+/// \param riid A reference to the identifier of the interface to be used to
+/// communicate with the object.
+///
+/// \param ppv Address of pointer variable that receives the interface pointer
+/// requested in riid.  Upon successful return, *ppv contains the requested
+/// interface pointer. Upon failure, *ppv contains NULL.
+///
+/// While this function is similar to CoCreateInstance, there is no COM
+/// involvement.
 extern "C"
 DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
   _In_ REFCLSID   rclsid,
@@ -87,12 +82,9 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance(
   _Out_ LPVOID*   ppv
   );
 
-/// <summary>
-/// Version of DxcCreateInstance that takes an IMalloc interface.
-/// </summary>
-/// <remarks>
+/// \brief Version of DxcCreateInstance that takes an IMalloc interface.
+///
 /// This can be used to create an instance of the compiler with a custom memory allocator.
-/// </remarks>
 extern "C"
 DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
   _In_ IMalloc    *pMalloc,
@@ -589,10 +581,10 @@ struct IDxcUtils : public IUnknown {
   /// \param pFileName The name of the file to load from.
   ///
   /// \param pCodePage Optional code page to use if the blob contains text. Pass
-  /// NULL for binary data.</param>
+  /// NULL for binary data.
   ///
   /// \param ppBlobEncoding Address of the pointer that receives a pointer to
-  /// the newly created blob.</param>
+  /// the newly created blob.
   ///
   /// The new blob and its contents are allocated with the current allocator.
   /// This replaces IDxcLibrary::CreateBlobFromFile.

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -100,7 +100,7 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
 // Use DXC_CP_ACP for: Binary;  ANSI Text;  Autodetect UTF with BOM
 #define DXC_CP_ACP 0
 
-/// Codepage for "wide" characters - UTF16 on Windows, UTF32 on other platforms
+/// Codepage for "wide" characters - UTF16 on Windows, UTF32 on other platforms.
 #ifdef _WIN32
 #define DXC_CP_WIDE DXC_CP_UTF16
 #else
@@ -108,10 +108,10 @@ DXC_API_IMPORT HRESULT __stdcall DxcCreateInstance2(
 #endif
 
 /// Indicates that the shader hash was computed taking into account source
-/// information (-Zss)
+/// information (-Zss).
 #define DXC_HASHFLAG_INCLUDES_SOURCE 1
 
-/// Hash digest type for ShaderHash
+/// Hash digest type for ShaderHash.
 typedef struct DxcShaderHash {
   UINT32 Flags;        ///< DXC_HASHFLAG_*
   BYTE HashDigest[16]; ///< The hash digest
@@ -133,7 +133,7 @@ typedef struct DxcShaderHash {
 #define DXC_PART_PATCH_CONSTANT_SIGNATURE DXC_FOURCC('P', 'S', 'G', '1')
 
 // Some option arguments are defined here for continuity with D3DCompile
-// interface
+// interface.
 #define DXC_ARG_DEBUG L"-Zi"
 #define DXC_ARG_SKIP_VALIDATION L"-Vd"
 #define DXC_ARG_SKIP_OPTIMIZATIONS L"-Od"
@@ -155,7 +155,7 @@ typedef struct DxcShaderHash {
 #define DXC_ARG_DEBUG_NAME_FOR_BINARY L"-Zsb"
 
 CROSS_PLATFORM_UUIDOF(IDxcBlob, "8BA5FB08-5195-40e2-AC58-0D989C3A0102")
-/// \brief A sized buffer that can be passed in and out of DXC APIs
+/// \brief A sized buffer that can be passed in and out of DXC APIs.
 ///
 /// This is an alias of ID3D10Blob and ID3DBlob.
 struct IDxcBlob : public IUnknown {
@@ -168,7 +168,7 @@ public:
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcBlobEncoding, "7241d424-2646-4191-97c0-98e96e42fc68")
-/// \brief A blob that might have a known encoding
+/// \brief A blob that might have a known encoding.
 struct IDxcBlobEncoding : public IDxcBlob {
 public:
   /// \brief Retrieve the encoding for this blob.
@@ -398,7 +398,7 @@ struct IDxcOperationResult : public IUnknown {
 CROSS_PLATFORM_UUIDOF(IDxcCompiler, "8c210bf3-011f-4422-8d70-6f9acb8db617")
 /// \deprecated Please use IDxcCompiler3 instead.
 struct IDxcCompiler : public IUnknown {
-  /// \brief Compile a single entry point to the target shader model
+  /// \brief Compile a single entry point to the target shader model.
   ///
   /// \deprecated Please use IDxcCompiler3::Compile() instead.
   virtual HRESULT STDMETHODCALLTYPE Compile(

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -185,7 +185,7 @@ public:
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcBlobWide, "A3F84EAB-0FAA-497E-A39C-EE6ED60B2D84")
-/// \brief A blob containing a null-terminated wide string
+/// \brief A blob containing a null-terminated wide string.
 ///
 /// This uses the native wide character encoding (utf16 on Windows, utf32 on
 /// Linux).
@@ -208,7 +208,7 @@ public:
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcBlobUtf8, "3DA636C9-BA71-4024-A301-30CBF125305B")
-/// \brief A blob containing a UTF-8 encoded string
+/// \brief A blob containing a UTF-8 encoded string.
 ///
 /// The value returned by GetBufferSize() is the size of the buffer, in bytes,
 /// including the null-terminator.
@@ -227,23 +227,23 @@ public:
 };
 
 #ifdef _WIN32
-/// IDxcBlobUtf16 is a legacy alias for IDxcBlobWide on Win32
+/// IDxcBlobUtf16 is a legacy alias for IDxcBlobWide on Win32.
 typedef IDxcBlobWide IDxcBlobUtf16;
 #endif
 
 CROSS_PLATFORM_UUIDOF(IDxcIncludeHandler, "7f61fc7d-950d-467f-b3e3-3c02fb49187c")
-/// \brief Interface for handling include directives
+/// \brief Interface for handling include directives.
 ///
 /// This interface can be implemented to customize handling of include
 /// directives.
 ///
 /// Use IDxcUtils::CreateDefaultIncludeHandler to create a default
-/// implementation that reads include files from the filesystem..
+/// implementation that reads include files from the filesystem.
 ///
 struct IDxcIncludeHandler : public IUnknown {
   /// \brief Load a source file to be included by the compiler.
   ///
-  /// \param pFilename candidate filename.
+  /// \param pFilename Candidate filename.
   ///
   /// \param ppIncludeSource Resultant source object for included file, nullptr
   /// if not found.
@@ -255,26 +255,26 @@ struct IDxcIncludeHandler : public IUnknown {
 
 /// \brief Structure for supplying bytes or text input to Dxc APIs.
 typedef struct DxcBuffer {
-  /// \brief pointer to the start of the buffer
+  /// \brief Pointer to the start of the buffer.
   LPCVOID Ptr;
 
-  /// \brief size of the buffer, in bytes
+  /// \brief Size of the buffer in bytes.
   SIZE_T Size;
 
-  /// \brief encoding of the buffer.
+  /// \brief Encoding of the buffer.
   ///
   /// Use Encoding = 0 for non-text bytes, ANSI text, or unknown with BOM.
   UINT Encoding;
 } DxcText;
 
-/// \brief Structure for supplying defines to Dxc APIs
+/// \brief Structure for supplying defines to Dxc APIs.
 struct DxcDefine {
-  LPCWSTR Name;              ///< the define name
-  _Maybenull_ LPCWSTR Value; ///< optional value for the define
+  LPCWSTR Name;              ///< The define name.
+  _Maybenull_ LPCWSTR Value; ///< Optional value for the define.
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompilerArgs, "73EFFE2A-70DC-45F8-9690-EFF64C02429D")
-/// \brief Interface for managing arguments passed to DXC
+/// \brief Interface for managing arguments passed to DXC.
 ///
 /// Use IDxcUtils::BuildArguments to create an instance of this interface.
 struct IDxcCompilerArgs : public IUnknown {
@@ -292,21 +292,21 @@ struct IDxcCompilerArgs : public IUnknown {
 
   /// \brief Add additional arguments to this list of compiler arguments.
   virtual HRESULT STDMETHODCALLTYPE AddArguments(
-    _In_opt_count_(argCount) LPCWSTR *pArguments,       ///< Array of pointers to arguments to add
-    _In_ UINT32 argCount                                ///< Number of arguments to add
+    _In_opt_count_(argCount) LPCWSTR *pArguments,       ///< Array of pointers to arguments to add.
+    _In_ UINT32 argCount                                ///< Number of arguments to add.
   ) = 0;
 
   /// \brief Add additional UTF-8 encoded arguments to this list of compiler
   /// arguments.
   virtual HRESULT STDMETHODCALLTYPE AddArgumentsUTF8(
-    _In_opt_count_(argCount)LPCSTR *pArguments,         ///< Array of pointers to UTF-8 arguments to add
-    _In_ UINT32 argCount                                ///< Number of arguments to add
+    _In_opt_count_(argCount)LPCSTR *pArguments,         ///< Array of pointers to UTF-8 arguments to add.
+    _In_ UINT32 argCount                                ///< Number of arguments to add.
   ) = 0;
 
   /// \brief Add additional defines to this list of compiler arguments.
   virtual HRESULT STDMETHODCALLTYPE AddDefines(
-      _In_count_(defineCount) const DxcDefine *pDefines, ///< Array of defines
-      _In_ UINT32 defineCount                            ///< Number of defines
+      _In_count_(defineCount) const DxcDefine *pDefines, ///< Array of defines.
+      _In_ UINT32 defineCount                            ///< Number of defines.
   ) = 0;
 };
 
@@ -402,32 +402,32 @@ struct IDxcCompiler : public IUnknown {
   ///
   /// \deprecated Please use IDxcCompiler3::Compile() instead.
   virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_ IDxcBlob *pSource,                       // Source text to compile
+    _In_ IDxcBlob *pSource,                       // Source text to compile.
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
-    _In_opt_z_ LPCWSTR pEntryPoint,               // entry point name
-    _In_z_ LPCWSTR pTargetProfile,                // shader profile to compile
-    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,                         // Number of arguments
+    _In_opt_z_ LPCWSTR pEntryPoint,               // Entry point name.
+    _In_z_ LPCWSTR pTargetProfile,                // Shader profile to compile.
+    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments.
+    _In_ UINT32 argCount,                         // Number of arguments.
     _In_count_(defineCount)
-      const DxcDefine *pDefines,                  // Array of defines
-    _In_ UINT32 defineCount,                      // Number of defines
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional)
-    _COM_Outptr_ IDxcOperationResult **ppResult   // Compiler output status, buffer, and errors
+      const DxcDefine *pDefines,                  // Array of defines.
+    _In_ UINT32 defineCount,                      // Number of defines.
+    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // User-provided interface to handle #include directives (optional).
+    _COM_Outptr_ IDxcOperationResult **ppResult   // Compiler output status, buffer, and errors.
   ) = 0;
 
-  /// \brief Preprocess source text
+  /// \brief Preprocess source text.
   ///
   /// \deprecated Please use IDxcCompiler3::Compile() with the "-P" argument instead.
   virtual HRESULT STDMETHODCALLTYPE Preprocess(
-    _In_ IDxcBlob *pSource,                       // Source text to preprocess
+    _In_ IDxcBlob *pSource,                       // Source text to preprocess.
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
-    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,                         // Number of arguments
+    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments.
+    _In_ UINT32 argCount,                         // Number of arguments.
     _In_count_(defineCount)
-      const DxcDefine *pDefines,                  // Array of defines
-    _In_ UINT32 defineCount,                      // Number of defines
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional)
-    _COM_Outptr_ IDxcOperationResult **ppResult   // Preprocessor output status, buffer, and errors
+      const DxcDefine *pDefines,                  // Array of defines.
+    _In_ UINT32 defineCount,                      // Number of defines.
+    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional).
+    _COM_Outptr_ IDxcOperationResult **ppResult   // Preprocessor output status, buffer, and errors.
   ) = 0;
 
   /// \brief Disassemble a program.
@@ -446,19 +446,19 @@ struct IDxcCompiler2 : public IDxcCompiler {
   ///
   /// \deprecated Please use IDxcCompiler3::Compile() instead.
   virtual HRESULT STDMETHODCALLTYPE CompileWithDebug(
-    _In_ IDxcBlob *pSource,                       // Source text to compile
+    _In_ IDxcBlob *pSource,                       // Source text to compile.
     _In_opt_z_ LPCWSTR pSourceName,               // Optional file name for pSource. Used in errors and include handlers.
-    _In_opt_z_ LPCWSTR pEntryPoint,               // Entry point name
-    _In_z_ LPCWSTR pTargetProfile,                // Shader profile to compile
-    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments
-    _In_ UINT32 argCount,                         // Number of arguments
+    _In_opt_z_ LPCWSTR pEntryPoint,               // Entry point name.
+    _In_z_ LPCWSTR pTargetProfile,                // Shader profile to compile.
+    _In_opt_count_(argCount) LPCWSTR *pArguments, // Array of pointers to arguments.
+    _In_ UINT32 argCount,                         // Number of arguments.
     _In_count_(defineCount)
-      const DxcDefine *pDefines,                  // Array of defines
-    _In_ UINT32 defineCount,                      // Number of defines
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional)
-    _COM_Outptr_ IDxcOperationResult **ppResult,  // Compiler output status, buffer, and errors
-    _Outptr_opt_result_z_ LPWSTR *ppDebugBlobName,// Suggested file name for debug blob. (Must be CoTaskMemFree()'d!)
-    _COM_Outptr_opt_ IDxcBlob **ppDebugBlob       // Debug blob
+      const DxcDefine *pDefines,                  // Array of defines.
+    _In_ UINT32 defineCount,                      // Number of defines.
+    _In_opt_ IDxcIncludeHandler *pIncludeHandler, // user-provided interface to handle #include directives (optional).
+    _COM_Outptr_ IDxcOperationResult **ppResult,  // Compiler output status, buffer, and errors.
+    _Outptr_opt_result_z_ LPWSTR *ppDebugBlobName,// Suggested file name for debug blob. Must be CoTaskMemFree()'d.
+    _COM_Outptr_opt_ IDxcBlob **ppDebugBlob       // Debug blob.
   ) = 0;
 };
 
@@ -478,20 +478,20 @@ public:
   /// \brief Links the shader and produces a shader blob that the Direct3D
   /// runtime can use.
   virtual HRESULT STDMETHODCALLTYPE Link(
-    _In_opt_ LPCWSTR pEntryName,        ///< Entry point name
-    _In_ LPCWSTR pTargetProfile,        ///< shader profile to link
+    _In_opt_ LPCWSTR pEntryName,        ///< Entry point name.
+    _In_ LPCWSTR pTargetProfile,        ///< shader profile to link.
     _In_count_(libCount)
-        const LPCWSTR *pLibNames,       ///< Array of library names to link
-    _In_ UINT32 libCount,               ///< Number of libraries to link
-    _In_opt_count_(argCount) const LPCWSTR *pArguments, ///< Array of pointers to arguments
-    _In_ UINT32 argCount,               ///< Number of arguments
+        const LPCWSTR *pLibNames,       ///< Array of library names to link.
+    _In_ UINT32 libCount,               ///< Number of libraries to link.
+    _In_opt_count_(argCount) const LPCWSTR *pArguments, ///< Array of pointers to arguments.
+    _In_ UINT32 argCount,               ///< Number of arguments.
     _COM_Outptr_
-        IDxcOperationResult **ppResult  ///< Linker output status, buffer, and errors
+        IDxcOperationResult **ppResult  ///< Linker output status, buffer, and errors.
   ) = 0;
 };
 
 /////////////////////////
-// Latest interfaces. Please use these
+// Latest interfaces. Please use these.
 ////////////////////////
 
 CROSS_PLATFORM_UUIDOF(IDxcUtils, "4605C4CB-2019-492A-ADA4-65F20BB7D67F")
@@ -505,9 +505,9 @@ struct IDxcUtils : public IUnknown {
   /// \brief Create a sub-blob that holds a reference to the outer blob and
   /// points to its memory.
   ///
-  /// \param pBlob The outer blob
+  /// \param pBlob The outer blob.
   ///
-  /// \param offset The offset inside the outer blob
+  /// \param offset The offset inside the outer blob.
   ///
   /// \param length The size, in bytes, of the buffer to reference from the
   /// output blob.
@@ -517,7 +517,7 @@ struct IDxcUtils : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE CreateBlobFromBlob(
     _In_ IDxcBlob *pBlob, UINT32 offset, UINT32 length, _COM_Outptr_ IDxcBlob **ppResult) = 0;
 
-  // For codePage, use 0 (or DXC_CP_ACP) for raw binary or ANSI code page
+  // For codePage, use 0 (or DXC_CP_ACP) for raw binary or ANSI code page.
 
   /// \brief Create a blob referencing existing memory, with no copy.
   ///
@@ -553,7 +553,7 @@ struct IDxcUtils : public IUnknown {
   /// \param ppBlobEncoding Address of the pointer that receives a pointer to
   /// the newly created blob.
   ///
-  /// This replaces IDxcLibrary::CreateBlobWithEncodingOnMalloc
+  /// This replaces IDxcLibrary::CreateBlobWithEncodingOnMalloc.
   virtual HRESULT STDMETHODCALLTYPE MoveToBlob(
     _In_bytecount_(size) LPCVOID pData, IMalloc *pIMalloc, UINT32 size, UINT32 codePage,
     _COM_Outptr_ IDxcBlobEncoding **ppBlobEncoding) = 0;
@@ -601,7 +601,7 @@ struct IDxcUtils : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE CreateReadOnlyStreamFromBlob(
     _In_ IDxcBlob *pBlob, _COM_Outptr_ IStream **ppStream) = 0;
 
-  /// \brief Create default file-based include handler
+  /// \brief Create default file-based include handler.
   ///
   /// \param ppResult Address of the pointer that receives a pointer to the
   /// newly created include handler.
@@ -641,7 +641,7 @@ struct IDxcUtils : public IUnknown {
   }
 #endif
 
-  /// \brief Retrieve a single part from a DXIL container
+  /// \brief Retrieve a single part from a DXIL container.
   ///
   /// \param pShader The shader to retrieve the part from.
   ///
@@ -677,14 +677,14 @@ struct IDxcUtils : public IUnknown {
   /// \brief Build arguments that can be passed to the Compile method.
   virtual HRESULT STDMETHODCALLTYPE BuildArguments(
     _In_opt_z_ LPCWSTR pSourceName,               ///< Optional file name for pSource. Used in errors and include handlers.
-    _In_opt_z_ LPCWSTR pEntryPoint,               ///< Entry point name. (-E)
-    _In_z_ LPCWSTR pTargetProfile,                ///< Shader profile to compile. (-T)
-    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments
-    _In_ UINT32 argCount,                         ///< Number of arguments
+    _In_opt_z_ LPCWSTR pEntryPoint,               ///< Entry point name (-E).
+    _In_z_ LPCWSTR pTargetProfile,                ///< Shader profile to compile (-T).
+    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments.
+    _In_ UINT32 argCount,                         ///< Number of arguments.
     _In_count_(defineCount)
-      const DxcDefine *pDefines,                  ///< Array of defines
-    _In_ UINT32 defineCount,                      ///< Number of defines
-    _COM_Outptr_ IDxcCompilerArgs **ppArgs        ///< Arguments you can use with Compile() method
+      const DxcDefine *pDefines,                  ///< Array of defines.
+    _In_ UINT32 defineCount,                      ///< Number of defines.
+    _COM_Outptr_ IDxcCompilerArgs **ppArgs        ///< Arguments you can use with Compile() method.
   ) = 0;
 
   /// \brief Retrieve the hash and contents of a shader PDB.
@@ -701,27 +701,27 @@ struct IDxcUtils : public IUnknown {
     _In_ IDxcBlob *pPDBBlob, _COM_Outptr_ IDxcBlob **ppHash, _COM_Outptr_ IDxcBlob **ppContainer) = 0;
 };
 
-/// \brief Specifies the kind of output to retrieve from a IDxcResult
+/// \brief Specifies the kind of output to retrieve from a IDxcResult.
 ///
 /// Note: text outputs returned from version 2 APIs are UTF-8 or UTF-16 based on
 /// the -encoding option passed to the compiler.
 typedef enum DXC_OUT_KIND {
-  DXC_OUT_NONE = 0,           ///< No output
-  DXC_OUT_OBJECT = 1,         ///< IDxcBlob - Shader or library object
-  DXC_OUT_ERRORS = 2,         ///< IDxcBlobUtf8 or IDxcBlobWide
-  DXC_OUT_PDB = 3,            ///< IDxcBlob
-  DXC_OUT_SHADER_HASH = 4,    ///< IDxcBlob - DxcShaderHash of shader or shader with source info (-Zsb/-Zss)
-  DXC_OUT_DISASSEMBLY = 5,    ///< IDxcBlobUtf8 or IDxcBlobWide - from Disassemble
-  DXC_OUT_HLSL = 6,           ///< IDxcBlobUtf8 or IDxcBlobWide - from Preprocessor or Rewriter
-  DXC_OUT_TEXT = 7,           ///< IDxcBlobUtf8 or IDxcBlobWide - other text, such as -ast-dump or -Odump
-  DXC_OUT_REFLECTION = 8,     ///< IDxcBlob - RDAT part with reflection data
-  DXC_OUT_ROOT_SIGNATURE = 9, ///< IDxcBlob - Serialized root signature output
-  DXC_OUT_EXTRA_OUTPUTS  = 10,///< IDxcExtraOutputs - Extra outputs
-  DXC_OUT_REMARKS = 11,       ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
-  DXC_OUT_TIME_REPORT = 12,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
-  DXC_OUT_TIME_TRACE = 13,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout
+  DXC_OUT_NONE = 0,           ///< No output.
+  DXC_OUT_OBJECT = 1,         ///< IDxcBlob - Shader or library object.
+  DXC_OUT_ERRORS = 2,         ///< IDxcBlobUtf8 or IDxcBlobWide.
+  DXC_OUT_PDB = 3,            ///< IDxcBlob.
+  DXC_OUT_SHADER_HASH = 4,    ///< IDxcBlob - DxcShaderHash of shader or shader with source info (-Zsb/-Zss).
+  DXC_OUT_DISASSEMBLY = 5,    ///< IDxcBlobUtf8 or IDxcBlobWide - from Disassemble.
+  DXC_OUT_HLSL = 6,           ///< IDxcBlobUtf8 or IDxcBlobWide - from Preprocessor or Rewriter.
+  DXC_OUT_TEXT = 7,           ///< IDxcBlobUtf8 or IDxcBlobWide - other text, such as -ast-dump or -Odump.
+  DXC_OUT_REFLECTION = 8,     ///< IDxcBlob - RDAT part with reflection data.
+  DXC_OUT_ROOT_SIGNATURE = 9, ///< IDxcBlob - Serialized root signature output.
+  DXC_OUT_EXTRA_OUTPUTS  = 10,///< IDxcExtraOutputs - Extra outputs.
+  DXC_OUT_REMARKS = 11,       ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
+  DXC_OUT_TIME_REPORT = 12,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
+  DXC_OUT_TIME_TRACE = 13,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
 
-  DXC_OUT_LAST = DXC_OUT_TIME_TRACE, ///< Last value for a counter
+  DXC_OUT_LAST = DXC_OUT_TIME_TRACE, ///< Last value for a counter.
 
   DXC_OUT_NUM_ENUMS,
   DXC_OUT_FORCE_DWORD = 0xFFFFFFFF
@@ -731,7 +731,7 @@ static_assert(DXC_OUT_NUM_ENUMS == DXC_OUT_LAST + 1,
               "DXC_OUT_* Enum added and last value not updated.");
 
 CROSS_PLATFORM_UUIDOF(IDxcResult, "58346CDA-DDE7-4497-9461-6F87AF5E0659")
-/// \brief Result of a DXC operation
+/// \brief Result of a DXC operation.
 ///
 /// DXC operations may have multiple outputs, such as a shader object and
 /// errors. This interface provides access to the outputs.
@@ -741,11 +741,11 @@ struct IDxcResult : public IDxcOperationResult {
   /// \param dxcOutKind The kind of output to check for.
   virtual BOOL STDMETHODCALLTYPE HasOutput(_In_ DXC_OUT_KIND dxcOutKind) = 0;
 
-  /// \brief Retrieves the specified output
+  /// \brief Retrieves the specified output.
   ///
-  /// \param dxcOutKind The kind of output to retrieve
+  /// \param dxcOutKind The kind of output to retrieve.
   ///
-  /// \param iid The interface ID of the output interface
+  /// \param iid The interface ID of the output interface.
   ///
   /// \param ppvObject Address of the pointer that receives a pointer to the
   /// output.
@@ -769,12 +769,12 @@ struct IDxcResult : public IDxcOperationResult {
   virtual DXC_OUT_KIND PrimaryOutput() = 0;
 };
 
-// Special names for extra output that should get written to specific streams
+// Special names for extra output that should get written to specific streams.
 #define DXC_EXTRA_OUTPUT_NAME_STDOUT L"*stdout*"
 #define DXC_EXTRA_OUTPUT_NAME_STDERR L"*stderr*"
 
 CROSS_PLATFORM_UUIDOF(IDxcExtraOutputs, "319b37a2-a5c2-494a-a5de-4801b2faf989")
-/// \brief Additional outputs from a DXC operation
+/// \brief Additional outputs from a DXC operation.
 ///
 /// This can be used to obtain outputs that don't have an explicit DXC_OUT_KIND.
 /// Use DXC_OUT_EXTRA_OUTPUTS to obtain instances of this.
@@ -782,11 +782,11 @@ struct IDxcExtraOutputs : public IUnknown {
   /// \brief Retrieves the number of outputs available
   virtual UINT32 STDMETHODCALLTYPE GetOutputCount() = 0;
 
-  /// \brief Retrieves the specified output
+  /// \brief Retrieves the specified output.
   ///
-  /// \param uIndex The index of the output to retrieve
+  /// \param uIndex The index of the output to retrieve.
   ///
-  /// \param iid The interface ID of the output interface
+  /// \param iid The interface ID of the output interface.
   ///
   /// \param ppvObject Optional address of the pointer that receives a pointer
   /// to the output if there is one.
@@ -803,12 +803,12 @@ struct IDxcExtraOutputs : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompiler3, "228B4687-5A6A-4730-900C-9702B2203F54")
-/// \brief Interface to the DirectX Shader Compiler
+/// \brief Interface to the DirectX Shader Compiler.
 ///
 /// Use DxcCreateInstance with CLSID_DxcCompiler to obtain an instance of this
 /// interface.
 struct IDxcCompiler3 : public IUnknown {
-  /// \brief Compile a shader
+  /// \brief Compile a shader.
   ///
   /// IDxcUtils::BuildArguments can be used to assist building the pArguments
   /// and argCount parameters.
@@ -818,21 +818,21 @@ struct IDxcCompiler3 : public IUnknown {
   /// * Compile a single entry point to the target shader model, 
   /// * Compile a library to a library target (-T lib_*)
   /// * Compile a root signature (-T rootsig_*),
-  /// * Preprocess HLSL source (-P)
+  /// * Preprocess HLSL source (-P).
   virtual HRESULT STDMETHODCALLTYPE Compile(
-    _In_ const DxcBuffer *pSource,                ///< Source text to compile
-    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments
-    _In_ UINT32 argCount,                         ///< Number of arguments
-    _In_opt_ IDxcIncludeHandler *pIncludeHandler, ///< user-provided interface to handle include directives (optional)
-    _In_ REFIID riid,                             ///< Interface ID for the result
-    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, buffer, and errors
+    _In_ const DxcBuffer *pSource,                ///< Source text to compile.
+    _In_opt_count_(argCount) LPCWSTR *pArguments, ///< Array of pointers to arguments.
+    _In_ UINT32 argCount,                         ///< Number of arguments.
+    _In_opt_ IDxcIncludeHandler *pIncludeHandler, ///< user-provided interface to handle include directives (optional).
+    _In_ REFIID riid,                             ///< Interface ID for the result.
+    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, buffer, and errors.
   ) = 0;
 
   /// \brief Disassemble a program.
   virtual HRESULT STDMETHODCALLTYPE Disassemble(
     _In_ const DxcBuffer *pObject,                ///< Program to disassemble: dxil container or bitcode.
-    _In_ REFIID riid,                             ///< Interface ID for the result
-    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, disassembly text, and errors
+    _In_ REFIID riid,                             ///< Interface ID for the result.
+    _Out_ LPVOID *ppResult                        ///< IDxcResult: status, disassembly text, and errors.
     ) = 0;
 };
 
@@ -851,12 +851,12 @@ struct IDxcValidator : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE Validate(
     _In_ IDxcBlob *pShader,                       ///< Shader to validate.
     _In_ UINT32 Flags,                            ///< Validation flags.
-    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors.
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcValidator2, "458e1fd1-b1b2-4750-a6e1-9c10f03bed92")
-/// \brief Interface to DXC shader validator
+/// \brief Interface to DXC shader validator.
 ///
 /// Use DxcCreateInstance with CLSID_DxcValidator to obtain an instance of this.
 struct IDxcValidator2 : public IDxcValidator {
@@ -864,37 +864,37 @@ struct IDxcValidator2 : public IDxcValidator {
   virtual HRESULT STDMETHODCALLTYPE ValidateWithDebug(
     _In_ IDxcBlob *pShader,                       ///< Shader to validate.
     _In_ UINT32 Flags,                            ///< Validation flags.
-    _In_opt_ DxcBuffer *pOptDebugBitcode,         ///< Optional debug module bitcode to provide line numbers
-    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors
+    _In_opt_ DxcBuffer *pOptDebugBitcode,         ///< Optional debug module bitcode to provide line numbers.
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Validation output status, buffer, and errors.
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcContainerBuilder, "334b1f50-2292-4b35-99a1-25588d8c17fe")
-/// \brief Interface to DXC container builder
+/// \brief Interface to DXC container builder.
 ///
 /// Use DxcCreateInstance with CLSID_DxcContainerBuilder to obtain an instance of this.
 struct IDxcContainerBuilder : public IUnknown {
-  /// \brief Load a DxilContainer to the builder
+  /// \brief Load a DxilContainer to the builder.
   virtual HRESULT STDMETHODCALLTYPE Load(_In_ IDxcBlob *pDxilContainerHeader) = 0;
 
-  /// \brief Add a part to the container
+  /// \brief Add a part to the container.
   ///
-  /// \param fourCC The part identifier (eg DXC_PART_PDB)
+  /// \param fourCC The part identifier (eg DXC_PART_PDB).
   ///
-  /// \param pSource The source blob
+  /// \param pSource The source blob.
   virtual HRESULT STDMETHODCALLTYPE AddPart(_In_ UINT32 fourCC, _In_ IDxcBlob *pSource) = 0;
 
-  /// \brief Remove a part from the container
+  /// \brief Remove a part from the container.
   ///
-  /// \param fourCC The part identifier (eg DXC_PART_PDB)
+  /// \param fourCC The part identifier (eg DXC_PART_PDB).
   ///
   /// \return S_OK on success, DXC_E_MISSING_PART if the part was not found, or
   /// other standard HRESULT error code.
   virtual HRESULT STDMETHODCALLTYPE RemovePart(_In_ UINT32 fourCC) = 0;
 
-  /// \brief Build the container
+  /// \brief Build the container.
   ///
-  /// \param ppResult Pointer to variable to receive the result
+  /// \param ppResult Pointer to variable to receive the result.
   virtual HRESULT STDMETHODCALLTYPE SerializeContainer(_Out_ IDxcOperationResult **ppResult) = 0;
 };
 
@@ -906,12 +906,12 @@ struct IDxcAssembler : public IUnknown {
   /// \brief Assemble DXIL in LL or LLVM bitcode to DXIL container.
   virtual HRESULT STDMETHODCALLTYPE AssembleToContainer(
     _In_ IDxcBlob *pShader,                       ///< Shader to assemble.
-    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Assembly output status, buffer, and errors
+    _COM_Outptr_ IDxcOperationResult **ppResult   ///< Assembly output status, buffer, and errors.
     ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcContainerReflection, "d2c21b26-8350-4bdc-976a-331ce6f4c54c")
-/// \\brief Interface to DxcContainerReflection
+/// \brief Interface to DxcContainerReflection.
 ///
 /// Use DxcCreateInstance with CLSID_DxcContainerReflection to obtain an
 /// instance of this.
@@ -941,7 +941,7 @@ struct IDxcContainerReflection : public IUnknown {
   /// HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartKind(UINT32 idx, _Out_ UINT32 *pResult) = 0;
 
-  /// \brief Retrieve the content of a specified part
+  /// \brief Retrieve the content of a specified part.
   ///
   /// \param idx The index of the part to retrieve.
   ///
@@ -952,7 +952,7 @@ struct IDxcContainerReflection : public IUnknown {
   /// HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE GetPartContent(UINT32 idx, _COM_Outptr_ IDxcBlob **ppResult) = 0;
 
-  /// \brief Retrieve the index of the first part with the specified kind
+  /// \brief Retrieve the index of the first part with the specified kind.
   ///
   /// \param kind The kind to search for.
   ///
@@ -964,7 +964,7 @@ struct IDxcContainerReflection : public IUnknown {
   /// part with the specified kind, or other standard HRESULT error codes.
   virtual HRESULT STDMETHODCALLTYPE FindFirstPartKind(UINT32 kind, _Out_ UINT32 *pResult) = 0;
 
-  /// \brief Retrieve the reflection interface for a specified part
+  /// \brief Retrieve the reflection interface for a specified part.
   ///
   /// \param idx The index of the part to retrieve the reflection interface of.
   ///
@@ -981,7 +981,7 @@ struct IDxcContainerReflection : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcOptimizerPass, "AE2CD79F-CC22-453F-9B6B-B124E7A5204C")
-/// \brief An optimizer pass
+/// \brief An optimizer pass.
 ///
 /// Instances of this can be obtained via IDxcOptimizer::GetAvailablePass.
 struct IDxcOptimizerPass : public IUnknown {
@@ -993,7 +993,7 @@ struct IDxcOptimizerPass : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcOptimizer, "25740E2E-9CBA-401B-9119-4FB42F39F270")
-/// \brief Interface to DxcOptimizer
+/// \brief Interface to DxcOptimizer.
 ///
 /// Use DxcCreateInstance with CLSID_DxcOptimizer to obtain an instance of this.
 struct IDxcOptimizer : public IUnknown {
@@ -1010,7 +1010,7 @@ static const UINT32 DxcVersionInfoFlags_Debug = 1; // Matches VS_FF_DEBUG
 static const UINT32 DxcVersionInfoFlags_Internal = 2; // Internal Validator (non-signing)
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo, "b04f5b50-2059-4f12-a8ff-a1e0cde1cc7e")
-/// \brief PDB Version information
+/// \brief PDB Version information.
 ///
 /// Use IDxcPdbUtils2::GetVersionInfo to obtain an instance of this.
 struct IDxcVersionInfo : public IUnknown {
@@ -1019,25 +1019,25 @@ struct IDxcVersionInfo : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo2, "fb6904c4-42f0-4b62-9c46-983af7da7c83")
-/// \brief PDB Version Information
+/// \brief PDB Version Information.
 ///
 /// Use IDxcPdbUtils2::GetVersionInfo to obtain a IDxcVersionInfo interface, and
 /// then use QueryInterface to obtain an instance of this interface from it.
 struct IDxcVersionInfo2 : public IDxcVersionInfo {
   virtual HRESULT STDMETHODCALLTYPE GetCommitInfo(
     _Out_ UINT32 *pCommitCount,           ///< The total number commits.
-    _Outptr_result_z_ char **pCommitHash  ///< The SHA of the latest commit. (Must be CoTaskMemFree()'d!)
+    _Outptr_result_z_ char **pCommitHash  ///< The SHA of the latest commit. Must be CoTaskMemFree()'d.
   ) = 0;
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcVersionInfo3, "5e13e843-9d25-473c-9ad2-03b2d0b44b1e")
-/// \brief PDB Version Information
+/// \brief PDB Version Information.
 ///
 /// Use IDxcPdbUtils2::GetVersionInfo to obtain a IDxcVersionInfo interface, and
 /// then use QueryInterface to obtain an instance of this interface from it.
 struct IDxcVersionInfo3 : public IUnknown {
   virtual HRESULT STDMETHODCALLTYPE GetCustomVersionString(
-    _Outptr_result_z_ char **pVersionString ///< Custom version string for compiler. (Must be CoTaskMemFree()'d!)
+    _Outptr_result_z_ char **pVersionString ///< Custom version string for compiler. Must be CoTaskMemFree()'d.
   ) = 0;
 };
 

--- a/include/dxc/dxcapi.h
+++ b/include/dxc/dxcapi.h
@@ -440,7 +440,7 @@ struct IDxcCompiler : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcCompiler2, "A005A9D9-B8BB-4594-B5C9-0E633BEC4D37")
-/// \deprecated Please use IDxcCompiler3 instead
+/// \deprecated Please use IDxcCompiler3 instead.
 struct IDxcCompiler2 : public IDxcCompiler {
   /// \brief Compile a single entry point to the target shader model with debug information.
   ///
@@ -719,7 +719,7 @@ typedef enum DXC_OUT_KIND {
   DXC_OUT_EXTRA_OUTPUTS  = 10,///< IDxcExtraOutputs - Extra outputs.
   DXC_OUT_REMARKS = 11,       ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
   DXC_OUT_TIME_REPORT = 12,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
-  DXC_OUT_TIME_TRACE = 13,   ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
+  DXC_OUT_TIME_TRACE = 13,    ///< IDxcBlobUtf8 or IDxcBlobWide - text directed at stdout.
 
   DXC_OUT_LAST = DXC_OUT_TIME_TRACE, ///< Last value for a counter.
 
@@ -843,7 +843,7 @@ static const UINT32 DxcValidatorFlags_ModuleOnly = 4;
 static const UINT32 DxcValidatorFlags_ValidMask = 0x7;
 
 CROSS_PLATFORM_UUIDOF(IDxcValidator, "A6E82BD2-1FD7-4826-9811-2857E797F49A")
-/// \brief Interface to DXC shader validator
+/// \brief Interface to DXC shader validator.
 ///
 /// Use DxcCreateInstance with CLSID_DxcValidator to obtain an instance of this.
 struct IDxcValidator : public IUnknown {
@@ -899,7 +899,7 @@ struct IDxcContainerBuilder : public IUnknown {
 };
 
 CROSS_PLATFORM_UUIDOF(IDxcAssembler, "091f7a26-1c1f-4948-904b-e6e3a8a771d5")
-/// \brief Interface to DxcAssembler
+/// \brief Interface to DxcAssembler.
 ///
 /// Use DxcCreateInstance with CLSID_DxcAssembler to obtain an instance of this.
 struct IDxcAssembler : public IUnknown {


### PR DESCRIPTION
[doc] Update inline API reference docs for dxcapi.h

Documentation comments are now formatted using Doxygen-style markup.  Although there's no automated processes in place to generate documentation from this markup, aligning around this style allows for comments that are more readable than xmldoc when viewed as text.