### PR TITLE
Fix build error for deprecated function in UCRT.

### DIFF
--- a/utils/unittest/googletest/src/gtest-all.cc
+++ b/utils/unittest/googletest/src/gtest-all.cc
@@ -38,6 +38,14 @@
 // when it's fused.
 #include "gtest/gtest.h"
 
+// Alias deprecated functions for UCRT.
+#ifdef _UCRT
+#define close _close
+#define creat _creat
+#define dup2  _dup2
+#define dup   _dup
+#endif
+
 // The following lines pull in the real gtest *.cc files.
 #include "src/gtest.cc"
 #include "src/gtest-death-test.cc"

--- a/utils/unittest/googletest/src/gtest-all.cc
+++ b/utils/unittest/googletest/src/gtest-all.cc
@@ -38,7 +38,8 @@
 // when it's fused.
 #include "gtest/gtest.h"
 
-// Alias deprecated functions for UCRT.
+// Alias deprecated functions for UCRT due to these obsolete function have been
+// removed in the newer UCRT libraries.
 #ifdef _UCRT
 #define close _close
 #define creat _creat

--- a/utils/unittest/googletest/src/gtest-all.cc
+++ b/utils/unittest/googletest/src/gtest-all.cc
@@ -38,6 +38,7 @@
 // when it's fused.
 #include "gtest/gtest.h"
 
+// HLSL Change Begin.
 // Alias deprecated functions for UCRT due to these obsolete function have been
 // removed in the newer UCRT libraries.
 #ifdef _UCRT
@@ -46,6 +47,7 @@
 #define dup2  _dup2
 #define dup   _dup
 #endif
+// HLSL Change End.
 
 // The following lines pull in the real gtest *.cc files.
 #include "src/gtest.cc"


### PR DESCRIPTION
This is for enable-lit by default.
gtest got link error for missing dup/dup2/close/creat.