### PR TITLE
[enable-lit] use !TEST_CLANG! to get updated result.

### DIFF
--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -285,7 +285,7 @@ if "%TEST_USE_LIT%"=="1" (
       cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-dxilconv
       set RES_DXILCONV=!ERRORLEVEL!
     )
-    if "%TEST_CLANG%"=="1" (
+    if "!TEST_CLANG!"=="1" (
       cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang
       set RES_CLANG=!ERRORLEVEL!
       set RES_EXEC=%RES_CLANG%


### PR DESCRIPTION
This is for enable lit by default.
It fix issue when running single test instead of all test under lit. %TEST_CLANG% will not get update until out of the if.