### PR TITLE
Relax validation of sampler mode for CalculateLOD

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3068,7 +3068,7 @@ INSTR.RESOURCEOFFSETTOOMANY               out of bound offset must be undef.
 INSTR.RESOURCEUSER                        Resource should only be used by Load/GEP/Call.
 INSTR.SAMPLECOMPTYPE                      sample_* instructions require resource to be declared to return UNORM, SNORM or FLOAT.
 INSTR.SAMPLEINDEXFORLOAD2DMS              load on Texture2DMS/2DMSArray require sampleIndex.
-INSTR.SAMPLERMODEFORLOD                   lod instruction requires sampler declared in default mode.
+INSTR.SAMPLERMODEFORLOD                   lod instruction requires valid sampler handle.
 INSTR.SAMPLERMODEFORSAMPLE                sample/_l/_d/_cl_s/gather instruction requires sampler declared in default mode.
 INSTR.SAMPLERMODEFORSAMPLEC               sample_c_*/gather_c instructions require sampler declared in comparison mode.
 INSTR.SIGNATUREOPERATIONNOTINENTRY        Dxil operation for input output signature must be in entryPoints.

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1577,7 +1577,7 @@ static void ValidateResourceDxilOp(CallInst *CI, DXIL::OpCode opcode,
   case DXIL::OpCode::CalculateLOD: {
     DxilInst_CalculateLOD lod(CI);
     Value *samplerHandle = lod.get_sampler();
-    if (GetSamplerKind(samplerHandle, ValCtx) != DXIL::SamplerKind::Default) {
+    if (GetSamplerKind(samplerHandle, ValCtx) == DXIL::SamplerKind::Invalid) {
       ValCtx.EmitInstrError(CI, ValidationRule::InstrSamplerModeForLOD);
     }
     Value *handle = lod.get_handle();

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2580,7 +2580,7 @@ class db_dxil(object):
         self.add_valrule("Instr.ResourceOffsetMiss", "offset uninitialized.")
         self.add_valrule("Instr.ResourceOffsetTooMany", "out of bound offset must be undef.")
         self.add_valrule("Instr.UndefResultForGetDimension", "GetDimensions used undef dimension %0 on %1.")
-        self.add_valrule("Instr.SamplerModeForLOD", "lod instruction requires sampler declared in default mode.")
+        self.add_valrule("Instr.SamplerModeForLOD", "lod instruction requires valid sampler handle.")
         self.add_valrule("Instr.SamplerModeForSample", "sample/_l/_d/_cl_s/gather instruction requires sampler declared in default mode.")
         self.add_valrule("Instr.SamplerModeForSampleC", "sample_c_*/gather_c instructions require sampler declared in comparison mode.")
         self.add_valrule("Instr.SampleCompType", "sample_* instructions require resource to be declared to return UNORM, SNORM or FLOAT.")


### PR DESCRIPTION
Related: https://github.com/microsoft/hlsl-specs/issues/30

By turning on D3D12 experimental shader models, I've tried running `calculateLOD` instructions on shaders declared as comparison sampling on 4/5 vendors in our ecosystem (not tried Qualcomm yet), and all of them handle it just fine. This makes sense, because `calculateLOD` would only look at the sampler LOD biases/clamps, while the filter and comparison modes are irrelevant.

This validation is overly strict and is inhibiting our ability to produce a conformant VulkanOn12 implementation. In an ideal world, we'd have actual comparison bias/gradient instructions, but in a world without these, being able to compute an LOD is needed.

We could tie this to a new shader model, or a new DXIL version, but... we could also just relax this validation given that it works on existing drivers. Thoughts?