### PR TITLE
[NFC] fix typo in GetPointerInfo.

### DIFF
--- a/lib/DXIL/DxilCounters.cpp
+++ b/lib/DXIL/DxilCounters.cpp
@@ -70,7 +70,7 @@ PointerInfo GetPointerInfo(Value* V, PointerInfoMap &ptrInfoMap) {
     ptrInfoMap[V] = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
   } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(V)) {
     if (CE->getOpcode() == LLVMAddrSpaceCast)
-      ptrInfoMap[V] = GetPointerInfo(AC->getOperand(0), ptrInfoMap);
+      ptrInfoMap[V] = GetPointerInfo(CE->getOperand(0), ptrInfoMap);
   //} else if (PHINode *PN = dyn_cast<PHINode>(V)) {
   //  for (auto it = PN->value_op_begin(), e = PN->value_op_end(); it != e; ++it) {
   //    PI = GetPointerInfo(*it, ptrInfoMap);


### PR DESCRIPTION
    Use CE instead AC which must be nullptr.