### PR TITLE
CleanupPerThreadFileSystem after llvm shutdown to avoid assert.

### DIFF
--- a/tools/clang/tools/dxcompiler/DXCompiler.cpp
+++ b/tools/clang/tools/dxcompiler/DXCompiler.cpp
@@ -106,8 +106,8 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD Reason, LPVOID reserved) {
     DxcEtw_DXCompilerShutdown_Start();
     DxcSetThreadMallocToDefault();
     ::hlsl::options::cleanupHlslOptTable();
-    ::llvm::sys::fs::CleanupPerThreadFileSystem();
     ::llvm::llvm_shutdown();
+    ::llvm::sys::fs::CleanupPerThreadFileSystem();
     if (reserved == NULL) { // FreeLibrary has been called or the DLL load failed
       DxilLibCleanup(DxilLibCleanUpType::UnloadLibrary);
     }


### PR DESCRIPTION
When remove timer in llvm shutdown, CreateInfoOutputFile will be called. It will hit assert for TLS not intialized if CleanupPerThreadFileSystem is already executed.