### PR TITLE
Cherry-pick of 2 changes related to SharedLibAffix.h

### DIFF
--- a/lib/DxcSupport/CMakeLists.txt
+++ b/lib/DxcSupport/CMakeLists.txt
@@ -14,9 +14,9 @@ add_llvm_library(LLVMDxcSupport
 #generate header with platform-specific library name
 configure_file(
 ${LLVM_MAIN_SRC_DIR}/lib/DxcSupport/SharedLibAffix.inc
-SharedLibAffix.h
+${LLVM_INCLUDE_DIR}/dxc/Support/SharedLibAffix.h
 )
 
-include_directories( ${LLVM_INCLUDE_DIR}/DxcSupport) #needed to find the generated header
+include_directories( ${LLVM_INCLUDE_DIR}/dxc/Support) #needed to find the generated header
 
 add_dependencies(LLVMDxcSupport TablegenHLSLOptions)

--- a/lib/DxcSupport/CMakeLists.txt
+++ b/lib/DxcSupport/CMakeLists.txt
@@ -17,6 +17,4 @@ ${LLVM_MAIN_SRC_DIR}/lib/DxcSupport/SharedLibAffix.inc
 ${LLVM_INCLUDE_DIR}/dxc/Support/SharedLibAffix.h
 )
 
-include_directories( ${LLVM_INCLUDE_DIR}/dxc/Support) #needed to find the generated header
-
 add_dependencies(LLVMDxcSupport TablegenHLSLOptions)

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -15,7 +15,7 @@
 #include "dxc/Support/Unicode.h"
 #include "dxc/Support/FileIOHelper.h"
 #include "dxc/Support/WinFunctions.h"
-#include "SharedLibAffix.h"
+#include "dxc/Support/SharedLibAffix.h" // header generated during DXC build
 
 namespace dxc {
 


### PR DESCRIPTION
- Generate SharedLibAffix.h into the include directory (#5058)
- Change SharedLibAffix.h include path to eliminate the need to change build setting (#5085)
