### PR TITLE
PIX: Don't run PIX prep passes during variable evaluation (PIX already did that)

### DIFF
--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -41,13 +41,6 @@ void dxil_dia::Session::Init(
   m_finder = finder;
   m_dxilModule = llvm::make_unique<hlsl::DxilModule>(mod.get());
 
-  llvm::legacy::PassManager PM;
-  llvm::initializeDxilDbgValueToDbgDeclarePass(*llvm::PassRegistry::getPassRegistry());
-  llvm::initializeDxilAnnotateWithVirtualRegisterPass(*llvm::PassRegistry::getPassRegistry());
-  PM.add(llvm::createDxilDbgValueToDbgDeclarePass());
-  PM.add(llvm::createDxilAnnotateWithVirtualRegisterPass());
-  PM.run(*m_module);
-
   // Extract HLSL metadata.
   m_dxilModule->LoadDxilMetadata();
 

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -11,7 +11,6 @@
 
 #include "DxilDiaSession.h"
 
-#include "dxc/DxilPIXPasses/DxilPIXPasses.h"
 #include "dxc/DxilPIXPasses/DxilPIXVirtualRegisters.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/Function.h"
@@ -20,8 +19,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/LegacyPassManager.h"
-#include "llvm/PassRegistry.h"
 
 #include "DxilDia.h"
 #include "DxilDiaEnumTables.h"

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -601,13 +601,15 @@ public:
       //WEX::Logging::Log::Comment(disTextW);
     }
 
+    auto annotated = WrapInNewContainer(RunAnnotationPasses(pProgram).blob);
+
     // CONSIDER: have the dia data source look for the part if passed a whole container.
     CComPtr<IDiaDataSource> pDiaSource;
     CComPtr<IStream> pProgramStream;
     CComPtr<IDxcLibrary> pLib;
     VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &pLib));
     const hlsl::DxilContainerHeader *pContainer = hlsl::IsDxilContainerLike(
-        pProgram->GetBufferPointer(), pProgram->GetBufferSize());
+        annotated->GetBufferPointer(), annotated->GetBufferSize());
     VERIFY_IS_NOT_NULL(pContainer);
     hlsl::DxilPartIterator partIter =
         std::find_if(hlsl::begin(pContainer), hlsl::end(pContainer),
@@ -619,7 +621,8 @@ public:
     CComPtr<IDxcBlob> pProgramPdb;
     hlsl::GetDxilProgramBitcode(pProgramHeader, &pBitcode, &bitcodeLength);
     VERIFY_SUCCEEDED(pLib->CreateBlobFromBlob(
-        pProgram, pBitcode - (char *)pProgram->GetBufferPointer(), bitcodeLength,
+        annotated, pBitcode - (char *)annotated->GetBufferPointer(),
+        bitcodeLength,
         &pProgramPdb));
 
     // Disassemble the program with debug information.
@@ -1146,6 +1149,9 @@ static std::string ToString(std::wstring from)
   void CompileAndRunAnnotationAndLoadDiaSource(dxc::DxcDllSupport &dllSupport,
                                    const char *source, wchar_t *profile,
                                    IDiaDataSource **ppDataSource);
+
+private:
+  CComPtr<IDxcBlob> WrapInNewContainer(IDxcBlob * part);
 };
 
 
@@ -1846,26 +1852,7 @@ void PixTest::CompileAndRunAnnotationAndGetDebugPart(
 
   auto annotated = RunAnnotationPasses(pContainer);
 
-  CComPtr<IDxcBlob> pNewContainer;
-  {
-    CComPtr<IDxcAssembler> pAssembler;
-    IFT(m_dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
-
-    CComPtr<IDxcOperationResult> pAssembleResult;
-    VERIFY_SUCCEEDED(
-        pAssembler->AssembleToContainer(annotated.blob, &pAssembleResult));
-
-    CComPtr<IDxcBlobEncoding> pAssembleErrors;
-    VERIFY_SUCCEEDED(pAssembleResult->GetErrorBuffer(&pAssembleErrors));
-
-    if (pAssembleErrors && pAssembleErrors->GetBufferSize() != 0) {
-      OutputDebugStringA(
-          static_cast<LPCSTR>(pAssembleErrors->GetBufferPointer()));
-      VERIFY_SUCCEEDED(E_FAIL);
-    }
-
-    VERIFY_SUCCEEDED(pAssembleResult->GetResult(&pNewContainer));
-  }
+  CComPtr<IDxcBlob> pNewContainer = WrapInNewContainer(annotated.blob);
 
   VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcLibrary, &pLib));
   VERIFY_SUCCEEDED(
@@ -1894,6 +1881,28 @@ void PixTest::CompileAndRunAnnotationAndLoadDiaSource(
   if (ppDataSource) {
     *ppDataSource = pDiaSource.Detach();
   }
+}
+
+CComPtr<IDxcBlob> PixTest::WrapInNewContainer(IDxcBlob *part) {
+  CComPtr<IDxcAssembler> pAssembler;
+  IFT(m_dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
+
+  CComPtr<IDxcOperationResult> pAssembleResult;
+  VERIFY_SUCCEEDED(pAssembler->AssembleToContainer(part, &pAssembleResult));
+
+  CComPtr<IDxcBlobEncoding> pAssembleErrors;
+  VERIFY_SUCCEEDED(pAssembleResult->GetErrorBuffer(&pAssembleErrors));
+
+  if (pAssembleErrors && pAssembleErrors->GetBufferSize() != 0) {
+    OutputDebugStringA(
+        static_cast<LPCSTR>(pAssembleErrors->GetBufferPointer()));
+    VERIFY_SUCCEEDED(E_FAIL);
+  }
+
+  CComPtr<IDxcBlob> pNewContainer;
+  VERIFY_SUCCEEDED(pAssembleResult->GetResult(&pNewContainer));
+
+  return pNewContainer;
 }
 
 TEST_F(PixTest, PixTypeManager_InheritancePointerStruct) {
@@ -4440,7 +4449,7 @@ void ASMain()
 
   auto compiled = Compile(code, L"as_6_5", {}, L"ASMain");
 
-  auto debugPart = GetDebugPart(m_dllSupport, compiled);
+  auto debugPart = GetDebugPart(m_dllSupport, WrapInNewContainer(RunAnnotationPasses(compiled).blob));
 
   CComPtr<IDxcLibrary> library;
   VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcLibrary, &library));
@@ -4462,8 +4471,22 @@ void ASMain()
   VERIFY_SUCCEEDED(session->QueryInterface(&Factory));
   CComPtr<IDxcPixDxilDebugInfo> dxilDebugger;
   VERIFY_SUCCEEDED(Factory->NewDxcPixDxilDebugInfo(&dxilDebugger));
+
+  auto lines = SplitAndPreserveEmptyLines(code, '\n');
+  auto DispatchMeshLineFind =
+      std::find_if(lines.begin(), lines.end(), [](std::string const &line) {
+        return line.find("DispatchMesh") != std::string::npos;
+      });
+  auto DispatchMeshLine =
+      static_cast<DWORD>(DispatchMeshLineFind - lines.begin()) + 2;
+
+  CComPtr<IDxcPixDxilInstructionOffsets> instructionOffsets;
+  VERIFY_SUCCEEDED(dxilDebugger->InstructionOffsetsFromSourceLocation(
+      L"source.hlsl", DispatchMeshLine, 0, &instructionOffsets));
+  VERIFY_IS_TRUE(instructionOffsets->GetCount() > 0);
+  DWORD InstructionOrdinal = instructionOffsets->GetOffsetByIndex(0);
   CComPtr<IDxcPixDxilLiveVariables> liveVariables;
-  VERIFY_SUCCEEDED(dxilDebugger->GetLiveVariablesAt(43, &liveVariables));
+  VERIFY_SUCCEEDED(dxilDebugger->GetLiveVariablesAt(InstructionOrdinal, &liveVariables));
   CComPtr<IDxcPixVariable> variable;
   VERIFY_SUCCEEDED(liveVariables->GetVariableByIndex(0, &variable));
   CComBSTR name;


### PR DESCRIPTION
These passes have already been run by PIX at this point, and running them twice is both a waste and a source of issues: the annotate-with-virtual-registers pass might thereby change virtual register ordinals, which will cause PIX's view of HLSL variables to degrade as the user steps further into a long function.