### PR TITLE
[SPIR-V] Add fspv-preserve-bindings option to preserve decoration bin…

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -392,6 +392,8 @@ def fspv_print_all: Flag<["-"], "fspv-print-all">, Group<spirv_Group>, Flags<[Co
   HelpText<"Print the SPIR-V module before each pass and after the last one. Useful for debugging SPIR-V legalization and optimization passes.">;
 def Oconfig : CommaJoined<["-"], "Oconfig=">, Group<spirv_Group>, Flags<[CoreOption]>,
   HelpText<"Specify a comma-separated list of SPIRV-Tools passes to customize optimization configuration (see http://khr.io/hlsl2spirv#optimization)">;
+def fspv_preserve_bindings : Flag<["-"], "fspv-preserve-bindings">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Preserves all bindings declared within the module, even when those bindings are unused">;
 // SPIRV Change Ends
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -55,6 +55,7 @@ struct SpirvCodeGenOptions {
   bool invertW; // Multiplicative inverse
   bool noWarnEmulatedFeatures;
   bool noWarnIgnoredFeatures;
+  bool preserveBindings;
   bool useDxLayout;
   bool useGlLayout;
   bool useLegacyBufferMatrixOrder;

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -985,6 +985,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.SpirvOptions.autoShiftBindings = Args.hasFlag(OPT_fvk_auto_shift_bindings, OPT_INVALID, false);
   opts.SpirvOptions.finiteMathOnly =
       Args.hasFlag(OPT_ffinite_math_only, OPT_fno_finite_math_only, false);
+  opts.SpirvOptions.preserveBindings =
+      Args.hasFlag(OPT_fspv_preserve_bindings, OPT_INVALID, false);
 
   if (!handleVkShiftArgs(Args, OPT_fvk_b_shift, "b", &opts.SpirvOptions.bShift, errors) ||
       !handleVkShiftArgs(Args, OPT_fvk_t_shift, "t", &opts.SpirvOptions.tShift, errors) ||

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13775,6 +13775,7 @@ bool SpirvEmitter::spirvToolsOptimize(std::vector<uint32_t> *mod,
 
   spvtools::OptimizerOptions options;
   options.set_run_validator(false);
+  options.set_preserve_bindings(spirvOptions.preserveBindings);
 
   if (spirvOptions.optConfig.empty()) {
     // Add performance passes.

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13816,6 +13816,7 @@ bool SpirvEmitter::spirvToolsLegalize(std::vector<uint32_t> *mod,
 
   spvtools::OptimizerOptions options;
   options.set_run_validator(false);
+  options.set_preserve_bindings(spirvOptions.preserveBindings);
   // Add interface variable SROA if the signature packing is enabled.
   if (spirvOptions.signaturePacking) {
     optimizer.RegisterPass(


### PR DESCRIPTION
…dings even when unused

This change adds a new spirv backend specific option `fspv-preserve-bindings`. By default it will be disabled.

spirv-opt has a flag to stop dead-code elimination pass from removing the decoration bindings when those bindings are unused. There are cases where the user may need this information to process the generated spirv. 

In my case I need this information while converting the spirv to msl using spirv-cross. 


