### PR TITLE
Resolve crash when retrieving diagnostic location

### DIFF
--- a/tools/clang/tools/libclang/dxcisenseimpl.cpp
+++ b/tools/clang/tools/libclang/dxcisenseimpl.cpp
@@ -832,6 +832,8 @@ HRESULT DxcDiagnostic::GetSeverity(_Out_ DxcDiagnosticSeverity* pResult)
 _Use_decl_annotations_
 HRESULT DxcDiagnostic::GetLocation(IDxcSourceLocation** pResult)
 {
+  if (pResult == nullptr) return E_POINTER;
+  DxcThreadMalloc TM(m_pMalloc);
   return DxcSourceLocation::Create(clang_getDiagnosticLocation(m_diagnostic), pResult);
 }
 


### PR DESCRIPTION
The implementation of IDxcDiagnostic::GetLocation was missing a local instance of DxcThreadMalloc. Later, in DxcSourceLocation::Create, this could result in a crash in various multithreaded uses due to the TLS allocator being unset.