### PR TITLE
Add Option to Force loading external dxil lib for validation test

### DIFF
--- a/include/dxc/Test/DxcTestUtils.h
+++ b/include/dxc/Test/DxcTestUtils.h
@@ -199,8 +199,9 @@ public:
   unsigned m_ValMajor, m_ValMinor;
 
   VersionSupportInfo();
-  // Initialize version info structure.  TODO: add device shader model support
-  void Initialize(dxc::DxcDllSupport &dllSupport);
+  // Initialize version info structure(s).  TODO: add device shader model support
+  void Initialize(dxc::DxcDllSupport &dxcompiler);
+  void Initialize(dxc::DxcDllSupport &dxcompiler, dxc::DxcDllSupport &validator);
   // Return true if IR sensitive test should be skipped, and log comment
   bool SkipIRSensitiveTest();
   // Return true if test requiring DXIL of given version should be skipped, and log comment

--- a/include/dxc/Test/WEXAdapter.h
+++ b/include/dxc/Test/WEXAdapter.h
@@ -164,6 +164,7 @@ public:
 };
 namespace RuntimeParameters {
 HRESULT TryGetValue(const wchar_t *param, Common::String &retStr);
+HRESULT TryGetValue(const wchar_t *param, UINT &retUint);
 } // namespace RuntimeParameters
 } // namespace TestExecution
 namespace Logging {

--- a/tools/clang/unittests/HLSL/HLSLTestOptions.cpp
+++ b/tools/clang/unittests/HLSL/HLSLTestOptions.cpp
@@ -42,6 +42,13 @@ HRESULT TryGetValue(const wchar_t *param, WEX::Common::String &retStr) {
   ARG_LIST(RETURN_ARG)
   return E_NOTIMPL;
 }
+HRESULT TryGetValue(const wchar_t *param, UINT &retUint) {
+  WEX::Common::String retStr;
+  HRESULT hr = TryGetValue(param, retStr);
+  if (SUCCEEDED(hr))
+    retUint = UINT(std::stoi(retStr));
+  return hr;
+}
 } // namespace RuntimeParameters
 } // namespace TestExecution
 } // namespace WEX

--- a/tools/clang/unittests/HLSL/HLSLTestOptions.h
+++ b/tools/clang/unittests/HLSL/HLSLTestOptions.h
@@ -37,7 +37,8 @@ namespace testOptions {
     ARGOP(ExperimentalShaders)\
     ARGOP(DebugLayer)\
     ARGOP(SuitePath)\
-    ARGOP(InputPath)
+    ARGOP(InputPath)\
+    ARGOP(LoadExternalDxil)
 
 ARG_LIST(ARG_DECLARE)
 

--- a/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
+++ b/tools/clang/unittests/HLSLTestLib/DxcTestUtils.cpp
@@ -412,7 +412,12 @@ VersionSupportInfo::VersionSupportInfo()
       m_DxilMinor(0), m_ValMajor(0), m_ValMinor(0) {}
 
 void VersionSupportInfo::Initialize(dxc::DxcDllSupport &dllSupport) {
-  VERIFY_IS_TRUE(dllSupport.IsEnabled());
+  Initialize(dllSupport, dllSupport);
+}
+
+void VersionSupportInfo::Initialize(dxc::DxcDllSupport &compiler, dxc::DxcDllSupport &validator) {
+  VERIFY_IS_TRUE(compiler.IsEnabled());
+  VERIFY_IS_TRUE(validator.IsEnabled());
 
   // Default to Dxil 1.0 and internal Val 1.0
   m_DxilMajor = m_ValMajor = 1;
@@ -422,7 +427,7 @@ void VersionSupportInfo::Initialize(dxc::DxcDllSupport &dllSupport) {
   UINT32 VersionFlags = 0;
 
   // If the following fails, we have Dxil 1.0 compiler
-  if (SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcCompiler, &pVersionInfo))) {
+  if (SUCCEEDED(compiler.CreateInstance(CLSID_DxcCompiler, &pVersionInfo))) {
     VERIFY_SUCCEEDED(pVersionInfo->GetVersion(&m_DxilMajor, &m_DxilMinor));
     VERIFY_SUCCEEDED(pVersionInfo->GetFlags(&VersionFlags));
     m_CompilerIsDebugBuild =
@@ -430,7 +435,7 @@ void VersionSupportInfo::Initialize(dxc::DxcDllSupport &dllSupport) {
     pVersionInfo.Release();
   }
 
-  if (SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcValidator, &pVersionInfo))) {
+  if (SUCCEEDED(validator.CreateInstance(CLSID_DxcValidator, &pVersionInfo))) {
     VERIFY_SUCCEEDED(pVersionInfo->GetVersion(&m_ValMajor, &m_ValMinor));
     VERIFY_SUCCEEDED(pVersionInfo->GetFlags(&VersionFlags));
     if (m_ValMinor > 0) {

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -187,6 +187,8 @@ if "%1"=="-clean" (
 ) else if "%1"=="-dxil-loc" (
   set DXIL_DLL_LOC=%~2
   shift /1
+) else if "%1"=="-load-external-dxil" (
+  set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% /p:"LoadExternalDxil=1"
 ) else if "%1"=="--" (
   shift /1
   goto :done_opt


### PR DESCRIPTION
Adds a parameter that will force loading of the external dxil validation library using the usual search name and locations for the given platform. When this parameter is provided, the dxil library is loaded independently of the compiler library, which would try to load it if there. Unlike the usual behavior, which will fallback to the builtin validator if the external library isn't found, when the parameter is provided, If the external library isn't found, the validation test will fail with an informative message.

Fixes #5394