### PR TITLE
[opt] initialize HLSL passes with SetupRegistryPassForHLSL

### DIFF
--- a/tools/opt/CMakeLists.txt
+++ b/tools/opt/CMakeLists.txt
@@ -7,6 +7,8 @@ set(LLVM_LINK_COMPONENTS
   DXIL # HLSL Change
   DxcBindingTable # HLSL Change
   HLSL # HLSL Change
+  DxilContainer #  HLSL Change for DxcOptimizerPass
+  DxilRootSignature #  HLSL Change for DxcOptimizerPass
   IPA
   IPO
   IRReader

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -345,7 +345,6 @@ int __cdecl main(int argc, char **argv) {
   PassRegistry &Registry = *PassRegistry::getPassRegistry();
   initializeCore(Registry);
   initializeScalarOpts(Registry);
-  initializeReducibilityAnalysisPass(Registry); // HLSL Change: add ReducibilityAnalysis pass
   // initializeObjCARCOpts(Registry);    // HLSL Change: remove ObjC ARC passes
   // initializeVectorization(Registry);  // HLSL Change: remove vectorization passes
   initializeIPO(Registry);

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -364,9 +364,6 @@ int __cdecl main(int argc, char **argv) {
   //initializeDwarfEHPreparePass(Registry); // HLSL Change: remove EH passes
   //initializeSjLjEHPreparePass(Registry);  // HLSL Change: remove EH passes
   // HLSL Change Starts
-  initializeReducibilityAnalysisPass(Registry);
-  initializeComputeViewIdStatePass(Registry);
-  initializeDxilFinalizeModulePass(Registry);
   initializeDxilModuleInitPass(Registry);
   hlsl::SetupRegistryPassForHLSL();
 #ifdef HAS_DXILCONV

--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -305,6 +305,9 @@ void initializePollyPasses(llvm::PassRegistry &Registry);
 #ifdef HAS_DXILCONV
 void __cdecl initializeDxilConvPasses(llvm::PassRegistry &);
 #endif
+namespace hlsl {
+HRESULT SetupRegistryPassForHLSL();
+} // namespace hlsl
 // HLSL Change End
 
 //===----------------------------------------------------------------------===//
@@ -365,6 +368,7 @@ int __cdecl main(int argc, char **argv) {
   initializeComputeViewIdStatePass(Registry);
   initializeDxilFinalizeModulePass(Registry);
   initializeDxilModuleInitPass(Registry);
+  hlsl::SetupRegistryPassForHLSL();
 #ifdef HAS_DXILCONV
   initializeDxilConvPasses(Registry);
 #endif


### PR DESCRIPTION
call hlsl::SetupRegistryPassForHLSL in opt to initialize all HLSL/DXIL passes.

This is for FileCheck test which use opt to test HLSL/DXIL passes.