### PR TITLE
Limit multi-stream GS tests to dxilver 1.7 due to fix in PSV0

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_viewid/viewid12.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/sv_viewid/viewid12.hlsl
@@ -1,4 +1,7 @@
-// RUN: %dxilver 1.1 | %dxc -E main -T gs_6_1 %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T gs_6_1 %s | FileCheck %s
+
+// dxilver 1.7 because PSV0 data was incorrectly filled in before this point,
+// making this test fail if running against prior validator versions.
 
 // CHECK: Number of inputs: 12, outputs per stream: { 4, 4, 0, 0 }
 // CHECK: Outputs for Stream 0 dependent on ViewId: { 1, 2, 3 }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/multiStreamGS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/multiStreamGS.hlsl
@@ -1,7 +1,7 @@
-// RUN: %dxilver 1.8 | %dxc -E main -T gs_6_0 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E main -T gs_6_0 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
+// RUN: %dxilver 1.7 | %dxc -E main -T gs_6_0 %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T gs_6_0 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
 
-// dxilver 1.8 because PSV0 data was incorrectly filled in before this point,
+// dxilver 1.7 because PSV0 data was incorrectly filled in before this point,
 // making this test fail if running against prior validator versions.
 
 // CHECK:; Output signature:

--- a/tools/clang/test/HLSLFileCheck/shader_targets/geometry/multiStreamGS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/geometry/multiStreamGS.hlsl
@@ -1,5 +1,8 @@
-// RUN: %dxc -E main -T gs_6_0 %s | FileCheck %s
-// RUN: %dxc -E main -T gs_6_0 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
+// RUN: %dxilver 1.8 | %dxc -E main -T gs_6_0 %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -E main -T gs_6_0 %s | %D3DReflect %s | FileCheck -check-prefix=REFL %s
+
+// dxilver 1.8 because PSV0 data was incorrectly filled in before this point,
+// making this test fail if running against prior validator versions.
 
 // CHECK:; Output signature:
 // CHECK:;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -878,6 +878,9 @@ TEST_F(ValidationTest, InvalidSigCompTyFail) {
       "A specifies unrecognized or invalid component type");
 }
 TEST_F(ValidationTest, MultiStream2Fail) {
+  if (m_ver.SkipDxilVersion(1, 7)) return;
+  // dxilver 1.7 because PSV0 data was incorrectly filled in before this point,
+  // making this test fail if running against prior validator versions.
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\multiStreamGS.hlsl", "gs_6_0",
       "i32 1, i32 12, i32 7, i32 1, i32 1",


### PR DESCRIPTION
PSV0 ViewID dependency data was not filled in correctly for prior releases. This was recently fixed.  This adds dxilver 1.7 requirement to prevent these tests from being run against older vaildator releases, where they will fail validation because the compiler-generated PSV0 won't match the validator's expected PSV0 data.