### PR TITLE
spirv: fix forward reference order for composite

### DIFF
--- a/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
+++ b/tools/clang/lib/SPIRV/SortDebugInfoVisitor.cpp
@@ -120,20 +120,6 @@ void SortDebugInfoVisitor::whileEachOperandOfDebugInstruction(
       break;
     if (!visitor(inst->getDebugInfoNone()))
       break;
-
-    // Note that in OpenCL.DebugInfo.100 DebugTypeComposite always has forward
-    // references to members. Therefore, the edge direction in DAG must be from
-    // DebugTypeMember to DebugTypeComposite. DO NOT visit members here.
-    //
-    // By comparison, NonSemantic.Shader.DebugInfo.100 bans forward references,
-    // leaving only the reference from composite to members and not the
-    // back-reference from member to composite parent. That means we DO want to
-    // visit members here.
-    if (spvOptions.debugInfoVulkan) {
-      for (auto *member : inst->getMembers())
-        if (!visitor(member))
-          break;
-    }
   } break;
   case SpirvInstruction::IK_DebugTypeMember: {
     SpirvDebugTypeMember *inst = dyn_cast<SpirvDebugTypeMember>(di);

--- a/tools/clang/test/CodeGenSPIRV/shader.debug.forwardreferences.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/shader.debug.forwardreferences.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T ps_6_0 -E main -fspv-debug=vulkan
+
+// CHECK:        [[objectName:%\d+]] = OpString "Object"
+// CHECK:      [[functionName:%\d+]] = OpString "Object.method"
+// CHECK:            [[source:%\d+]] = OpExtInst %void %1 DebugSource {{%\d+}}
+// CHECK:              [[unit:%\d+]] = OpExtInst %void %1 DebugCompilationUnit {{%\w+}} {{%\w+}} [[source]] {{%\w+}}
+// CHECK:         [[composite:%\d+]] = OpExtInst %void %1 DebugTypeComposite [[objectName]] %uint_1 [[source]] {{%\w+}} {{%\w+}} [[unit]] [[objectName]] %uint_0 %uint_3 [[debugFunction:%\d+]]
+// CHECK: [[debugTypeFunction:%\d+]] = OpExtInst %void %1 DebugTypeFunction {{%\w+}} %void [[composite]]
+// CHECK:          [[debugFunction]] = OpExtInst %void %1 DebugFunction [[functionName]] [[debugTypeFunction]] [[source]] {{%\w+}} {{%\w+}} [[composite]] {{%\d+}} {{%\w+}} {{%\w+}}
+
+struct Object
+{
+    void method() { }
+};
+
+float4 main(float4 color : COLOR) : SV_TARGET
+{
+    Object o;
+    o.method();
+    return float(0.f).xxxx;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3221,6 +3221,9 @@ TEST_F(FileTest, ShaderDebugInfoLinePrecedence) {
 TEST_F(FileTest, ShaderDebugInfoLineVariables) {
   runFileTest("shader.debug.line.variables.hlsl");
 }
+TEST_F(FileTest, ShaderDebugInfoForwardReferences) {
+  runFileTest("shader.debug.forwardreferences.hlsl");
+}
 TEST_F(FileTest, RayQueryInitExpr) { runFileTest("rayquery_init_expr.hlsl"); }
 TEST_F(FileTest, RayQueryInitExprError) {
   runFileTest("rayquery_init_expr_error.hlsl", Expect::Failure);


### PR DESCRIPTION
The blanket rule for NonSemantic.Shader.DebugInfo.100 is "no forward references". But there is a type-specific rule: DebugTypeComposite members can be forward references:

```
Members must be the <id>s of DebugTypeMember, DebugFunction, or
DebugTypeInheritance. This could be a forward reference.
```

This is mandatory to correctly support HLSL class methods:
 - the composite has a function as member.
 - the function as the composite as scope. This cycle makes the forward reference mandatory, hence the exception in the spec.

The removed code wrongly implemented the general rule, ignoring this exception.

This change doesn't just solves the cycle issue, but might add forward references that were avoided (since we never visit members). But as far as the spec goes, this is a valid behavior. So I believe there is no need to add any additional logic to avoid forward references.

This PR depends on the validator to correctly validate those forward references (KhronosGroup/SPIRV-Tools#5230).

Fixes: #4911.