### PR TITLE
Allow function template default parameters in HLSL

### DIFF
--- a/tools/clang/lib/Sema/SemaTemplate.cpp
+++ b/tools/clang/lib/Sema/SemaTemplate.cpp
@@ -1203,11 +1203,15 @@ static bool DiagnoseDefaultTemplateArgument(Sema &S,
     //   template-argument, that declaration shall be a definition and shall be
     //   the only declaration of the function template in the translation unit.
     // (C++98/03 doesn't have this wording; see DR226).
-    S.Diag(ParamLoc, S.getLangOpts().CPlusPlus11 ?
+    // HLSL Change Begin - Treat HLSL as C++11 here. This hides the C++11
+    // extension warning, and the C++98 compat warning is disabled unless
+    // explicitly enabled.
+    S.Diag(ParamLoc, S.getLangOpts().CPlusPlus11 || S.getLangOpts().HLSL ?
          diag::warn_cxx98_compat_template_parameter_default_in_function_template
            : diag::ext_template_parameter_default_in_function_template)
       << DefArgRange;
     return false;
+    // HLSL Change End
 
   case Sema::TPC_ClassTemplateMember:
     // C++0x [temp.param]p9:

--- a/tools/clang/test/HLSL/function-template-default.hlsl
+++ b/tools/clang/test/HLSL/function-template-default.hlsl
@@ -1,0 +1,5 @@
+// RUN: %clang_cc1 -fsyntax-only -HV 2021 -verify %s
+
+// expected-no-diagnostics
+template<typename T, int Sz = 4>
+vector<T, Sz> someVec() {}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -50,6 +50,7 @@ public:
   TEST_METHOD(RunOperatorOverloadingNotDefinedBinaryOp)
   TEST_METHOD(RunCXX11Attributes)
   TEST_METHOD(RunEnums)
+  TEST_METHOD(RunFunctionTemplateDefault)
   TEST_METHOD(RunFunctions)
   TEST_METHOD(RunIncompleteType)
   TEST_METHOD(RunIndexingOperator)
@@ -241,6 +242,10 @@ TEST_F(VerifierTest, RunCXX11Attributes) {
 
 TEST_F(VerifierTest, RunEnums) {
   CheckVerifiesHLSL(L"enums.hlsl");
+}
+
+TEST_F(VerifierTest, RunFunctionTemplateDefault) {
+  CheckVerifiesHLSL(L"function-template-default.hlsl");
 }
 
 TEST_F(VerifierTest, RunFunctions) {


### PR DESCRIPTION
Default parameters for function templates is a C++11 feature. Since HLSL is defined as C++03 using default parameters for function templates produces a language extension warning. There is really no need for the warning since the template syntax is disallowed in HLSL 2018 and earlier and we effectively always support this syntax in 2021.

This change suppresses the warning by treating HLSL as C++11 when diagnosing default template arguments. This changes the warning to a C++98 compatability warning, which is only enabled if explicitly requested.

In the future we should consider making future HLSL language versions based on a more modern C++ to avoid issues like this.

Fixes #5221