### PR TITLE
[lit] Use ls -l instead of file -E

### DIFF
--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -1,7 +1,7 @@
 // Embed debug info
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
-// RUN: not ls -l *.pdb
+// RUN: not ls *.pdb && count 0
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -2,8 +2,7 @@
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
 
-// RUN: ls  %T | not grep "\\.pdb$"
-
+// RUN: ls -1 %T | not grep "\\.pdb$"
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -1,7 +1,7 @@
 // Embed debug info
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
-// RUN: not ls *.pdb && count 0
+// RUN: not ls *.pdb | count 0
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -1,7 +1,9 @@
 // Embed debug info
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
-// RUN: not ls *.pdb | count 0
+
+// RUN: ls  %T | not grep "\\.pdb$"
+
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -1,7 +1,7 @@
 // Embed debug info
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
-// RUN: not file -E *.pdb
+// RUN: not ls -l *.pdb
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/fd_zs.test
+++ b/tools/clang/test/DXC/fd_zs.test
@@ -1,6 +1,7 @@
 // /Fd plus /Zs
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zs /Fd %t.pdb /Fo %t.dxo_fd
-// RUN:FileCheck --input-file=%t.pdb %s --check-prefix=PDB
+
+// RUN:FileCheck --input-file=%t.pdb %s --check-prefix=PDB && rm %t.pdb
 // Make sure PDB not empty.
 // PDB:{{.+}}
 // RUN:FileCheck --input-file=%t.dxo_fd %s --check-prefix=FD_FO

--- a/tools/clang/test/DXC/recompile.test
+++ b/tools/clang/test/DXC/recompile.test
@@ -15,7 +15,8 @@
 // RUN: %dxc -dumpbin %t.recompiled.pdb | FileCheck %s --check-prefix=RECOMPILE_PDB
 // RECOMPILE_PDB:DICompileUnit
 // RUN: %dxc %t.recompiled.pdb  /recompile > %t.recompiled.pdb.ll
-// RUN: %dxc %t.recompiled.pdb /recompile /T ps_6_0 /E main
+// RUN: %dxc %t.recompiled.pdb /recompile /T ps_6_0 /E main && rm %t.recompiled.pdb
+
 
 // Command-line Defines, Recompile
 // RUN: %dxc  %S/Inputs/smoke.hlsl  /D "semantic = SV_Position" /T vs_6_0 /Zi /Qembed_debug /DDX12 /Fo %t.define.cso

--- a/tools/clang/test/DXC/root_sig.test
+++ b/tools/clang/test/DXC/root_sig.test
@@ -27,7 +27,7 @@
 // Set root signature when already has one should succeed
 // RUN: %dxc %t.define.cso /dumpbin /setrootsignature %t.rootsig.cso /Fo %t.smoke.rsadded.cso
 // Make sure %t.smoke.rsadded.cso exist.
-// RUN: ls -l %t.smoke.rsadded.cso
+// RUN: ls %t.smoke.rsadded.cso
 
 // Set mismatched root signature when already has one should fail
 // RUN: not %dxc %t.define.cso /dumpbin /setrootsignature %t.NonUniformRootSig.cso /Fo %t.smoke.rsadded.cso

--- a/tools/clang/test/DXC/root_sig.test
+++ b/tools/clang/test/DXC/root_sig.test
@@ -27,7 +27,7 @@
 // Set root signature when already has one should succeed
 // RUN: %dxc %t.define.cso /dumpbin /setrootsignature %t.rootsig.cso /Fo %t.smoke.rsadded.cso
 // Make sure %t.smoke.rsadded.cso exist.
-// RUN: file -E %t.smoke.rsadded.cso
+// RUN: ls -l %t.smoke.rsadded.cso
 
 // Set mismatched root signature when already has one should fail
 // RUN: not %dxc %t.define.cso /dumpbin /setrootsignature %t.NonUniformRootSig.cso /Fo %t.smoke.rsadded.cso

--- a/tools/clang/test/DXC/strip_dbg.test
+++ b/tools/clang/test/DXC/strip_dbg.test
@@ -1,7 +1,7 @@
 // /Fd implies /Qstrip_debug ; path with / produces auto hash-named .pdb file
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd ./ /Fo %t.strip
 // RUN: %dxc -dumpbin %t.strip | FileCheck  %s --check-prefix=STRIP_DBG
-// RUN: ls -l *.pdb && rm *.pdb
+// RUN: ls *.pdb && rm *.pdb
 
 // /Zi with /Qstrip_debug and no output should not embed
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qstrip_debug /Fo %t.strip2

--- a/tools/clang/test/DXC/strip_dbg.test
+++ b/tools/clang/test/DXC/strip_dbg.test
@@ -1,7 +1,7 @@
 // /Fd implies /Qstrip_debug ; path with / produces auto hash-named .pdb file
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd ./ /Fo %t.strip
 // RUN: %dxc -dumpbin %t.strip | FileCheck  %s --check-prefix=STRIP_DBG
-// RUN: file -E *.pdb && rm *.pdb
+// RUN: ls -l *.pdb && rm *.pdb
 
 // /Zi with /Qstrip_debug and no output should not embed
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qstrip_debug /Fo %t.strip2


### PR DESCRIPTION
Avoid use file -E because ls is more available on Windows.
Use ls -1 %T | not grep "\\.pdb$" instead of not ls -1 %T because not ls *.pdb not work on windows.