### PR TITLE
[lit] avoid rm *.pdb

### DIFF
--- a/tools/clang/test/DXC/NonUniform.hlsl
+++ b/tools/clang/test/DXC/NonUniform.hlsl
@@ -11,14 +11,18 @@
 
 // RUN: %dxc %s /T ps_6_0 /DDX12 /Fo %t.NonUniform.cso
 // RUN: %dxc %t.NonUniform.cso /dumpbin /Qstrip_rootsignature /Fo %t.NonUniformNoRootSig.cso
-// RUN: cat %t.NonUniformNoRootSig.cso
+// RUN: FileCheck --input-file=%t.NonUniformNoRootSig.cso %s --check-prefix=NONUNIFORMNOROOTSIG
+// NONUNIFORMNOROOTSIG:{{.+}}
+
 // RUN:%dxa  -listparts %t.NonUniformNoRootSig.cso | FileCheck %s --check-prefix=NO_RS
 
 // NO_RS:Part count
 // NO_RS-NOT:RTS0
 
 // RUN: %dxc  %t.NonUniform.cso /dumpbin /extractrootsignature /Fo %t.NonUniformRootSig.cso
-// RUN: cat  %t.NonUniformRootSig.cso
+// RUN: FileCheck --input-file=%t.NonUniformRootSig.cso %s --check-prefix=NONUNIFORMROOTSIG
+// NONUNIFORMROOTSIG:{{.+}}
+
 // RUN:%dxa  -listparts %t.NonUniformRootSig.cso | FileCheck %s --check-prefix=RS_PART
 
 // RS_PART:Part count: 1

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -2,7 +2,7 @@
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
 
-// RUN: ls -1 %T | FileCheck %s --check-prefix=PDB_NAME
+// RUN: ls -1 | FileCheck %s --check-prefix=PDB_NAME
 // PDB_NAME-NOT:.pdb{{$}}
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -2,7 +2,8 @@
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
 
-// RUN: ls -1 %T | not grep "\\.pdb$"
+// RUN: ls -1 %T | FileCheck %s --check-prefix=PDB_NAME
+// PDB_NAME-NOT:.pdb{{$}}
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/fd_zs.test
+++ b/tools/clang/test/DXC/fd_zs.test
@@ -1,7 +1,7 @@
 // /Fd plus /Zs
-// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zs /Fd %t.pdb /Fo %t.dxo_fd
+// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zs /Fd %t.dbg /Fo %t.dxo_fd
 
-// RUN:FileCheck --input-file=%t.pdb %s --check-prefix=PDB && rm %t.pdb
+// RUN:FileCheck --input-file=%t.dbg %s --check-prefix=PDB
 // Make sure PDB not empty.
 // PDB:{{.+}}
 // RUN:FileCheck --input-file=%t.dxo_fd %s --check-prefix=FD_FO

--- a/tools/clang/test/DXC/ftime-trace.hlsl
+++ b/tools/clang/test/DXC/ftime-trace.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -E main -T vs_6_0 %s -ftime-trace | FileCheck %s
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json
-// RUN: cat %t.json | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json && FileCheck %s --input-file=%t.json
 
 // CHECK: { "traceEvents": [
 

--- a/tools/clang/test/DXC/recompile.test
+++ b/tools/clang/test/DXC/recompile.test
@@ -11,11 +11,11 @@
 // RUN: %dxc  %t.recompile.cc.cso /recompile  /T ps_6_0 /E main
 
 // Strip Debug, Recompile PDB
-// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd %t.recompiled.pdb
-// RUN: %dxc -dumpbin %t.recompiled.pdb | FileCheck %s --check-prefix=RECOMPILE_PDB
+// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd %t.recompiled.dbg
+// RUN: %dxc -dumpbin %t.recompiled.dbg | FileCheck %s --check-prefix=RECOMPILE_PDB
 // RECOMPILE_PDB:DICompileUnit
-// RUN: %dxc %t.recompiled.pdb  /recompile > %t.recompiled.pdb.ll
-// RUN: %dxc %t.recompiled.pdb /recompile /T ps_6_0 /E main && rm %t.recompiled.pdb
+// RUN: %dxc %t.recompiled.dbg  /recompile > %t.recompiled.dbg.ll
+// RUN: %dxc %t.recompiled.dbg /recompile /T ps_6_0 /E main
 
 
 // Command-line Defines, Recompile

--- a/tools/clang/test/DXC/root_sig.test
+++ b/tools/clang/test/DXC/root_sig.test
@@ -26,8 +26,9 @@
 
 // Set root signature when already has one should succeed
 // RUN: %dxc %t.define.cso /dumpbin /setrootsignature %t.rootsig.cso /Fo %t.smoke.rsadded.cso
-// Make sure %t.smoke.rsadded.cso exist.
-// RUN: ls %t.smoke.rsadded.cso
+// Make sure %t.smoke.rsadded.cso not empty.
+// RUN:FileCheck --input-file=%t.define.cso %s --check-prefix=CSO
+// CSO:{{.+}}
 
 // Set mismatched root signature when already has one should fail
 // RUN: not %dxc %t.define.cso /dumpbin /setrootsignature %t.NonUniformRootSig.cso /Fo %t.smoke.rsadded.cso

--- a/tools/clang/test/DXC/root_sig.test
+++ b/tools/clang/test/DXC/root_sig.test
@@ -26,9 +26,8 @@
 
 // Set root signature when already has one should succeed
 // RUN: %dxc %t.define.cso /dumpbin /setrootsignature %t.rootsig.cso /Fo %t.smoke.rsadded.cso
-// Make sure %t.smoke.rsadded.cso not empty.
-// RUN:FileCheck --input-file=%t.define.cso %s --check-prefix=CSO
-// CSO:{{.+}}
+// RUN: %dxa -dumprs %t.smoke.rsadded.cso | FileCheck %s --check-prefix=RS_DUMP
+// RS_DUMP:CBV(b0)
 
 // Set mismatched root signature when already has one should fail
 // RUN: not %dxc %t.define.cso /dumpbin /setrootsignature %t.NonUniformRootSig.cso /Fo %t.smoke.rsadded.cso

--- a/tools/clang/test/DXC/strip_dbg.test
+++ b/tools/clang/test/DXC/strip_dbg.test
@@ -1,9 +1,9 @@
 // /Fd implies /Qstrip_debug ; path with / produces auto hash-named .pdb file
 
-// RUN: mkdir -p %T/pdbdir
-// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd %T/pdbdir/ /Fo %t.strip
+// RUN: mkdir -p %t_pdbdir
+// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd %t_pdbdir/ /Fo %t.strip
 // RUN: %dxc -dumpbin %t.strip | FileCheck  %s --check-prefix=STRIP_DBG
-// RUN: ls -A %T/pdbdir | FileCheck %s --check-prefix=PDB_NAME
+// RUN: ls -A %t_pdbdir | FileCheck %s --check-prefix=PDB_NAME
 // Make sure exist .pdb file.
 // PDB_NAME:{{.+}}.pdb
 

--- a/tools/clang/test/DXC/strip_dbg.test
+++ b/tools/clang/test/DXC/strip_dbg.test
@@ -1,7 +1,11 @@
 // /Fd implies /Qstrip_debug ; path with / produces auto hash-named .pdb file
-// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd ./ /Fo %t.strip
+
+// RUN: mkdir -p %T/pdbdir
+// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Fd %T/pdbdir/ /Fo %t.strip
 // RUN: %dxc -dumpbin %t.strip | FileCheck  %s --check-prefix=STRIP_DBG
-// RUN: ls *.pdb && rm *.pdb
+// RUN: ls -A %T/pdbdir | FileCheck %s --check-prefix=PDB_NAME
+// Make sure exist .pdb file.
+// PDB_NAME:{{.+}}.pdb
 
 // /Zi with /Qstrip_debug and no output should not embed
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qstrip_debug /Fo %t.strip2


### PR DESCRIPTION
Rename .pdb to .dbg and put tmp pdb to tmp directory.

This is to avoid random fail caused by check *.pdb and rm *.pdb in different test.