### PR TITLE
Prevent update_spirv_deps.sh from updating re2 and effcee.

### DIFF
--- a/utils/update_spirv_deps.sh
+++ b/utils/update_spirv_deps.sh
@@ -4,7 +4,16 @@ if [ ! -d external -o ! -d .git -o ! -d azure-pipelines ] ; then
   exit 1
 fi
 
-set -ex
-git submodule foreach 'set -x && git switch main && git pull --ff-only'
+# Ignore effcee and re2 updates.  See the discussion at
+# https://github.com/microsoft/DirectXShaderCompiler/pull/5246
+# for details.
+git submodule foreach '                       \
+  n=$(basename $sm_path);                     \
+  if [ "$n" != "re2" -a "$n" != "effcee" ];   \
+  then git switch main && git pull --ff-only; \
+  else echo "Skipping submodule $n";          \
+  fi;                                         \
+  echo                                        \
+  '
 git add external
 exit 0

--- a/utils/update_spirv_deps.sh
+++ b/utils/update_spirv_deps.sh
@@ -7,13 +7,13 @@ fi
 # Ignore effcee and re2 updates.  See the discussion at
 # https://github.com/microsoft/DirectXShaderCompiler/pull/5246
 # for details.
-git submodule foreach '                       \
-  n=$(basename $sm_path);                     \
-  if [ "$n" != "re2" -a "$n" != "effcee" ];   \
-  then git switch main && git pull --ff-only; \
-  else echo "Skipping submodule $n";          \
-  fi;                                         \
-  echo                                        \
+git submodule foreach '                                                   \
+  n=$(basename $sm_path);                                                 \
+  if [ "$n" != "re2" -a "$n" != "effcee" -a "$n" != "DirectX-Headers" ];  \
+  then git switch main && git pull --ff-only;                             \
+  else echo "Skipping submodule $n";                                      \
+  fi;                                                                     \
+  echo                                                                    \
   '
 git add external
 exit 0

--- a/utils/update_spirv_deps.sh
+++ b/utils/update_spirv_deps.sh
@@ -4,7 +4,7 @@ if [ ! -d external -o ! -d .git -o ! -d azure-pipelines ] ; then
   exit 1
 fi
 
-# Ignore effcee and re2 updates.  See the discussion at
+# Ignore effcee, re2 and DirectX-Headers updates.  See the discussion at
 # https://github.com/microsoft/DirectXShaderCompiler/pull/5246
 # for details.
 git submodule foreach '                                                   \


### PR DESCRIPTION
As per discussion in
https://github.com/microsoft/DirectXShaderCompiler/pull/5246, the repositories re2 and effcee should not be updated when rolling submodules forward.