### PR TITLE
Move the check for Subpass into to uses 

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1480,12 +1480,6 @@ bool SpirvEmitter::validateVKAttributes(const NamedDecl *decl) {
   }
 
   if (decl->getAttr<VKInputAttachmentIndexAttr>()) {
-    if (!spvContext.isPS()) {
-      emitError("SubpassInput(MS) only allowed in pixel shader",
-                decl->getLocation());
-      success = false;
-    }
-
     if (!decl->isExternallyVisible()) {
       emitError("SubpassInput(MS) must be externally visible",
                 decl->getLocation());
@@ -3820,6 +3814,11 @@ SpirvEmitter::processGetSamplePosition(const CXXMemberCallExpr *expr) {
 
 SpirvInstruction *
 SpirvEmitter::processSubpassLoad(const CXXMemberCallExpr *expr) {
+  if (!spvContext.isPS()) {
+    emitError("SubpassInput(MS) only allowed in pixel shader",
+              expr->getExprLoc());
+    return nullptr;
+  }
   const auto *object = expr->getImplicitObjectArgument()->IgnoreParens();
   SpirvInstruction *sample =
       expr->getNumArgs() == 1 ? doExpr(expr->getArg(0)) : nullptr;

--- a/tools/clang/test/CodeGenSPIRV/vk.subpass-input.shader.type.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.subpass-input.shader.type.error.hlsl
@@ -1,0 +1,12 @@
+// Test that an error is emitted when a SubpassInput variable is used in
+// something other than a pixel shader.
+
+// RUN: %dxc -T cs_6_0 -E CsTest
+
+[[vk::input_attachment_index (0)]] SubpassInput<float4> subInput;
+[numthreads (8,1,1)]
+void CsTest() {
+	subInput.SubpassLoad();
+}
+
+// CHECK: :9:2: error: SubpassInput(MS) only allowed in pixel shader

--- a/tools/clang/test/CodeGenSPIRV/vk.subpass-input.unused.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.subpass-input.unused.hlsl
@@ -1,0 +1,23 @@
+// Test that the we can correctly compile the compute shader when the
+// subpass input is used in  PsSubpassTest, but not in the compute shader.
+
+// RUN: %dxc -T cs_6_0 -E CsTest
+
+// The variable is declared, but should not be used.
+// CHECK: %subInput = OpVariable
+// CHECK-NOT: %subInput
+
+[[vk::input_attachment_index (0)]] SubpassInput<float4> subInput;
+
+float4 PsSubpassTest() : SV_TARGET
+{
+	return subInput.SubpassLoad();
+}
+
+float4 f()
+{
+	return subInput.SubpassLoad();
+}
+
+[numthreads (8,1,1)]
+void CsTest() {}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2461,6 +2461,9 @@ TEST_F(FileTest, VulkanLayoutRegisterCError) {
 }
 
 TEST_F(FileTest, VulkanSubpassInput) { runFileTest("vk.subpass-input.hlsl"); }
+TEST_F(FileTest, VulkanSubpassInputUnused) {
+  runFileTest("vk.subpass-input.unused.hlsl");
+}
 TEST_F(FileTest, VulkanSubpassInputBinding) {
   runFileTest("vk.subpass-input.binding.hlsl");
 }
@@ -2472,6 +2475,9 @@ TEST_F(FileTest, VulkanSubpassInputError2) {
 }
 TEST_F(FileTest, VulkanSubpassInputError3) {
   runFileTest("vk.subpass-input.static.error.hlsl", Expect::Failure);
+}
+TEST_F(FileTest, VulkanSubpassInputError4) {
+  runFileTest("vk.subpass-input.shader.type.error.hlsl", Expect::Failure);
 }
 
 TEST_F(FileTest, NonFpColMajorError) {


### PR DESCRIPTION
We currently check if the shader is a pixel shader when we see a
declaration of a SubpassInput type. However, it is possible that there
are multiple shader in the same hlsl file, and that the SubpassInput is
only used in the pixel shader.

So that we do not get an error in this case, I moved the check for the
shader type to the use of the variable. I only has a single member
function, so identifying uses of that member function is a good proxy.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/4704