### PR TITLE
[lit] Check no output pdb by fixed file name.

### DIFF
--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -2,7 +2,13 @@
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fo %t.embedpdb
 // RUN: %dxc -dumpbin %t.embedpdb | FileCheck  %s --check-prefix=EMBED_PDB
 
-// RUN: ls -1 %T | not grep "\\.pdb$"
+// NOTE: dae4b0d5020646ac43cd4e4924f67eca.pdb is the output filename if exist.
+// Make sure the pdb file not exist with /Zi /Qembed_debug.
+// RUN: not ls dae4b0d5020646ac43cd4e4924f67eca.pdb
+
+// Make sure dae4b0d5020646ac43cd4e4924f67eca.pdb is the pdb filename.
+// RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fd %T/ /Fo %t.embedpdb
+// RUN: ls %T/dae4b0d5020646ac43cd4e4924f67eca.pdb && rm %T/dae4b0d5020646ac43cd4e4924f67eca.pdb
 
 // Auto-embed debug info when no debug output, and expect warning signifying that this is the case.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl  /Zi /Fo %t.embedpdb2 /Fe %t.err.embedpdb

--- a/tools/clang/test/DXC/embed_dbg.test
+++ b/tools/clang/test/DXC/embed_dbg.test
@@ -7,6 +7,7 @@
 // RUN: not ls dae4b0d5020646ac43cd4e4924f67eca.pdb
 
 // Make sure dae4b0d5020646ac43cd4e4924f67eca.pdb is the pdb filename.
+// NOTE: Assume the filename is stable because the shader is simple.
 // RUN: %dxc /T ps_6_0 %S/Inputs/smoke.hlsl /Zi /Qembed_debug /Fd %T/ /Fo %t.embedpdb
 // RUN: ls %T/dae4b0d5020646ac43cd4e4924f67eca.pdb && rm %T/dae4b0d5020646ac43cd4e4924f67eca.pdb
 


### PR DESCRIPTION
Avoid check *.pdb by check fixed output pdb name.
This will fix the random failure caused by entangled with pdb output of other tests.

The output filename should be stable because the shader is simple.