### PR TITLE
Remove unneeded assert

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -10264,8 +10264,7 @@ SpirvInstruction *SpirvEmitter::processIntrinsicDot(const CallExpr *callExpr) {
   assert(arg0isScalarOrVec && arg1isScalarOrVec);
   // The result type must be a scalar.
   assert(returnIsScalar);
-  // The element type of each argument and the return type must be the same.
-  assert(returnType == vec1ComponentType);
+  // The element type of each argument must be the same.
   assert(vec0ComponentType == vec1ComponentType);
   // The size of the two arguments must be equal.
   assert(vec0Size == vec1Size);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot.hlsl
@@ -164,4 +164,10 @@ void main() {
     // CHECK-NEXT: OpDot %float
     float3 f3;
     float dotProductByLiteral = dot(f3, float3(1.0.xxx));
+   
+    // A dot product using `half` should get promoted to `float`. 
+    // CHECK:      OpCompositeConstruct %v3float %float_1 %float_1 %float_1
+    // CHECK-NEXT: OpDot %float
+    half3 h3;
+    half dotProductWithHalf = dot(h3, half3(1.0.xxx));
 }


### PR DESCRIPTION
When processing the dot intrinsic, there is an assert that ensure the return type is the same as the componentent type of the operands. This is not true when the types were originally half. At that point, the operands will have been promoted to float, but the return type will be promoted later.

Since the assert is not universally true, I will remove it.

Fixes #5048