### PR TITLE
Remove some warnings from GCC when building DXC

### DIFF
--- a/lib/Analysis/DependenceAnalysis.cpp
+++ b/lib/Analysis/DependenceAnalysis.cpp
@@ -3773,7 +3773,7 @@ DependenceAnalysis::depends(Instruction *Src, Instruction *Dst,
 
   auto Final = make_unique<FullDependence>(Result);
   Result.DV = nullptr;
-  return std::move(Final);
+  return Final;
 }
 
 

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -420,6 +420,11 @@ std::error_code BitcodeReader::error(const Twine &Message) {
 }
 
 // HLSL Change: remove unused function
+#if 0
+std::error_code BitcodeReader::error(BitcodeError E) {
+  return ::error(DiagnosticHandler, make_error_code(E));
+}
+#endif
 
 static DiagnosticHandlerFunction getDiagHandler(DiagnosticHandlerFunction F,
                                                 LLVMContext &C) {
@@ -4816,7 +4821,8 @@ std::error_code BitcodeReader::findFunctionInStream(
 // GVMaterializer implementation
 //===----------------------------------------------------------------------===//
 
-// HLSL Change: remove unused function
+// HLSL Change: remove unused function 
+// void BitcodeReader::releaseBuffer() { Buffer.release(); }
 
 std::error_code BitcodeReader::materialize(GlobalValue *GV) {
   if (std::error_code EC = materializeMetadata())

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -419,9 +419,7 @@ std::error_code BitcodeReader::error(const Twine &Message) {
                  make_error_code(BitcodeError::CorruptedBitcode), Message);
 }
 
-std::error_code BitcodeReader::error(BitcodeError E) {
-  return ::error(DiagnosticHandler, make_error_code(E));
-}
+// HLSL Change: remove unused function
 
 static DiagnosticHandlerFunction getDiagHandler(DiagnosticHandlerFunction F,
                                                 LLVMContext &C) {
@@ -4818,7 +4816,7 @@ std::error_code BitcodeReader::findFunctionInStream(
 // GVMaterializer implementation
 //===----------------------------------------------------------------------===//
 
-void BitcodeReader::releaseBuffer() { Buffer.release(); }
+// HLSL Change: remove unused function
 
 std::error_code BitcodeReader::materialize(GlobalValue *GV) {
   if (std::error_code EC = materializeMetadata())

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -220,7 +220,8 @@ class BitcodeReader : public GVMaterializer {
 
 public:
   std::error_code error(BitcodeError E, const Twine &Message);
-  std::error_code error(BitcodeError E);
+  // HLSL Change: Remove unused function declaration
+  // std::error_code error(BitcodeError E);
   std::error_code error(const Twine &Message);
 
   BitcodeReader(std::unique_ptr<MemoryBuffer> &&Buffer, LLVMContext &Context, // HLSL Change: unique_ptr
@@ -233,7 +234,8 @@ public:
 
   void freeState();
 
-  void releaseBuffer();
+  // HLSL Change: remove unused function declaration
+  // void releaseBuffer();
 
   bool ShouldTrackBitstreamUsage = false; // HLSL Change
   BitstreamUseTracker Tracker; // HLSL Change

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -220,8 +220,7 @@ class BitcodeReader : public GVMaterializer {
 
 public:
   std::error_code error(BitcodeError E, const Twine &Message);
-  // HLSL Change: Remove unused function declaration
-  // std::error_code error(BitcodeError E);
+  std::error_code error(BitcodeError E);
   std::error_code error(const Twine &Message);
 
   BitcodeReader(std::unique_ptr<MemoryBuffer> &&Buffer, LLVMContext &Context, // HLSL Change: unique_ptr
@@ -234,8 +233,7 @@ public:
 
   void freeState();
 
-  // HLSL Change: remove unused function declaration
-  // void releaseBuffer();
+  void releaseBuffer();
 
   bool ShouldTrackBitstreamUsage = false; // HLSL Change
   BitstreamUseTracker Tracker; // HLSL Change
@@ -401,13 +399,12 @@ static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
   return EC;
 }
 
-// HLSL Change: remove unused function
-#if 0
+// HLSL Change: annotate unused function
+[[maybe_unused]]
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              std::error_code EC) {
   return error(DiagnosticHandler, EC, EC.message());
 }
-#endif
 
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              const Twine &Message) {
@@ -424,12 +421,11 @@ std::error_code BitcodeReader::error(const Twine &Message) {
                  make_error_code(BitcodeError::CorruptedBitcode), Message);
 }
 
-// HLSL Change: remove unused function
-#if 0
+// HLSL Change: annotate unused function
+[[maybe_unused]]
 std::error_code BitcodeReader::error(BitcodeError E) {
   return ::error(DiagnosticHandler, make_error_code(E));
 }
-#endif
 
 static DiagnosticHandlerFunction getDiagHandler(DiagnosticHandlerFunction F,
                                                 LLVMContext &C) {
@@ -4826,8 +4822,9 @@ std::error_code BitcodeReader::findFunctionInStream(
 // GVMaterializer implementation
 //===----------------------------------------------------------------------===//
 
-// HLSL Change: remove unused function 
-// void BitcodeReader::releaseBuffer() { Buffer.release(); }
+// HLSL Change: annotate unused function 
+[[maybe_unused]]
+void BitcodeReader::releaseBuffer() { Buffer.release(); }
 
 std::error_code BitcodeReader::materialize(GlobalValue *GV) {
   if (std::error_code EC = materializeMetadata())

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -220,7 +220,8 @@ class BitcodeReader : public GVMaterializer {
 
 public:
   std::error_code error(BitcodeError E, const Twine &Message);
-  std::error_code error(BitcodeError E);
+  // HLSL Change: Remove unused function declaration
+  // std::error_code error(BitcodeError E);
   std::error_code error(const Twine &Message);
 
   BitcodeReader(std::unique_ptr<MemoryBuffer> &&Buffer, LLVMContext &Context, // HLSL Change: unique_ptr
@@ -233,7 +234,8 @@ public:
 
   void freeState();
 
-  void releaseBuffer();
+  // HLSL Change: remove unused function declaration
+  // void releaseBuffer();
 
   bool ShouldTrackBitstreamUsage = false; // HLSL Change
   BitstreamUseTracker Tracker; // HLSL Change
@@ -399,12 +401,13 @@ static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
   return EC;
 }
 
-// HLSL Change: annotate unused function
-[[maybe_unused]]
+// HLSL Change: remove unused function
+#if 0
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              std::error_code EC) {
   return error(DiagnosticHandler, EC, EC.message());
 }
+#endif
 
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              const Twine &Message) {
@@ -421,11 +424,12 @@ std::error_code BitcodeReader::error(const Twine &Message) {
                  make_error_code(BitcodeError::CorruptedBitcode), Message);
 }
 
-// HLSL Change: annotate unused function
-[[maybe_unused]]
+// HLSL Change: remove unused function
+#if 0
 std::error_code BitcodeReader::error(BitcodeError E) {
   return ::error(DiagnosticHandler, make_error_code(E));
 }
+#endif
 
 static DiagnosticHandlerFunction getDiagHandler(DiagnosticHandlerFunction F,
                                                 LLVMContext &C) {
@@ -4822,9 +4826,8 @@ std::error_code BitcodeReader::findFunctionInStream(
 // GVMaterializer implementation
 //===----------------------------------------------------------------------===//
 
-// HLSL Change: annotate unused function 
-[[maybe_unused]]
-void BitcodeReader::releaseBuffer() { Buffer.release(); }
+// HLSL Change: remove unused function 
+// void BitcodeReader::releaseBuffer() { Buffer.release(); }
 
 std::error_code BitcodeReader::materialize(GlobalValue *GV) {
   if (std::error_code EC = materializeMetadata())

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -401,10 +401,13 @@ static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
   return EC;
 }
 
+// HLSL Change: remove unused function
+#if 0
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              std::error_code EC) {
   return error(DiagnosticHandler, EC, EC.message());
 }
+#endif
 
 static std::error_code error(DiagnosticHandlerFunction DiagnosticHandler,
                              const Twine &Message) {

--- a/lib/DXIL/DxilCounters.cpp
+++ b/lib/DXIL/DxilCounters.cpp
@@ -60,7 +60,7 @@ PointerInfo GetPointerInfo(Value* V, PointerInfoMap &ptrInfoMap) {
              GV->getLinkage() == GlobalVariable::LinkageTypes::InternalLinkage &&
              GV->getType()->getPointerAddressSpace() == DXIL::kDefaultAddrSpace)
       ptrInfoMap[V].memType = PointerInfo::MemType::Global_Static;
-  } else if (AllocaInst *AI = dyn_cast<AllocaInst>(V)) {
+  } else if (isa<AllocaInst>(V)) {
       ptrInfoMap[V].memType = PointerInfo::MemType::Alloca;
   } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(V)) {
     ptrInfoMap[V] = GetPointerInfo(GEP->getPointerOperand(), ptrInfoMap);

--- a/lib/DXIL/DxilUtilDbgInfoAndMisc.cpp
+++ b/lib/DXIL/DxilUtilDbgInfoAndMisc.cpp
@@ -124,7 +124,7 @@ bool MergeGepUse(Value *V) {
   addUsersToWorklist(V);
   while (worklist.size()) {
     V = worklist.pop_back_val();
-    if (BitCastOperator *BCO = dyn_cast<BitCastOperator>(V)) {
+    if (isa<BitCastOperator>(V)) {
       if (Value *NewV = dxilutil::TryReplaceBaseCastWithGep(V)) {
         changed = true;
         worklist.push_back(NewV);

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -1455,8 +1455,8 @@ void VariableRegisters::PopulateAllocaMap_StructType(
   }
 }
 
-//HLSL Change: remove unused function
-#if 0
+//HLSL Change: annotate unused function
+[[maybe_unused]]
 llvm::DILocation *VariableRegisters::GetVariableLocation() const
 {
   const unsigned DefaultColumn = 1;
@@ -1466,7 +1466,6 @@ llvm::DILocation *VariableRegisters::GetVariableLocation() const
       DefaultColumn,
       m_Variable->getScope());
 }
-#endif
 
 llvm::Value *VariableRegisters::GetMetadataAsValue(
     llvm::Metadata *M

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -588,8 +588,7 @@ GlobalStorageMap GatherGlobalEmbeddedArrayStorage(llvm::Module &M) {
       llvm::DIType *DIGVType = DIGV->getType().resolve(EmptyMap);
       // We're only interested in aggregates, since only they might have
       // embedded arrays:
-      if (auto *DIGVCompositeType =
-              llvm::dyn_cast<llvm::DICompositeType>(DIGVType)) {
+      if (isa<llvm::DICompositeType>(DIGVType)) {
         auto LocalMirrors = GenerateGlobalToLocalMirrorMap(M, DIGV);
         if (!LocalMirrors.empty()) {
           GlobalStaticVariables.push_back(DIGV);
@@ -789,7 +788,7 @@ static bool SortMembers(
             return false;
         }
         case llvm::dwarf::DW_TAG_subprogram: {
-            if (auto* SubProgram = llvm::dyn_cast<llvm::DISubprogram>(Element)) {
+            if (isa<llvm::DISubprogram>(Element)) {
                 continue;
             }
             assert(!"DISubprogram not understood");
@@ -1456,15 +1455,7 @@ void VariableRegisters::PopulateAllocaMap_StructType(
   }
 }
 
-llvm::DILocation *VariableRegisters::GetVariableLocation() const
-{
-  const unsigned DefaultColumn = 1;
-  return llvm::DILocation::get(
-      m_B.getContext(),
-      m_Variable->getLine(),
-      DefaultColumn,
-      m_Variable->getScope());
-}
+// HLSL Change: remove unused function
 
 llvm::Value *VariableRegisters::GetMetadataAsValue(
     llvm::Metadata *M

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -1455,8 +1455,8 @@ void VariableRegisters::PopulateAllocaMap_StructType(
   }
 }
 
-//HLSL Change: annotate unused function
-[[maybe_unused]]
+//HLSL Change: remove unused function
+#if 0
 llvm::DILocation *VariableRegisters::GetVariableLocation() const
 {
   const unsigned DefaultColumn = 1;
@@ -1466,6 +1466,7 @@ llvm::DILocation *VariableRegisters::GetVariableLocation() const
       DefaultColumn,
       m_Variable->getScope());
 }
+#endif
 
 llvm::Value *VariableRegisters::GetMetadataAsValue(
     llvm::Metadata *M

--- a/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
+++ b/lib/DxilPIXPasses/DxilDbgValueToDbgDeclare.cpp
@@ -1455,7 +1455,18 @@ void VariableRegisters::PopulateAllocaMap_StructType(
   }
 }
 
-// HLSL Change: remove unused function
+//HLSL Change: remove unused function
+#if 0
+llvm::DILocation *VariableRegisters::GetVariableLocation() const
+{
+  const unsigned DefaultColumn = 1;
+  return llvm::DILocation::get(
+      m_B.getContext(),
+      m_Variable->getLine(),
+      DefaultColumn,
+      m_Variable->getScope());
+}
+#endif
 
 llvm::Value *VariableRegisters::GetMetadataAsValue(
     llvm::Metadata *M

--- a/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
@@ -438,7 +438,7 @@ void DeserializeRootSignature(const void *pSrcData,
   const char *pData = (const char *)pSrcData;
   IFTBOOL(pData + sizeof(uint32_t) < pData + SrcDataSizeInBytes, E_FAIL);
 
-  DxilRootSignatureVersion Version = (const DxilRootSignatureVersion)((const uint32_t*)pData)[0];
+  const DxilRootSignatureVersion Version = (const DxilRootSignatureVersion)((const uint32_t*)pData)[0];
 
   pRootSignature = new DxilVersionedRootSignatureDesc();
 

--- a/lib/HLSL/DxilContainerReflection.cpp
+++ b/lib/HLSL/DxilContainerReflection.cpp
@@ -1705,7 +1705,7 @@ void DxilModuleReflection::CreateReflectionObjectForResource(DxilResourceBase *R
 static unsigned GetCBOffset(Value *V) {
   if (ConstantInt *Imm = dyn_cast<ConstantInt>(V))
     return Imm->getLimitedValue();
-  else if (UnaryInstruction *UI = dyn_cast<UnaryInstruction>(V)) {
+  else if (isa<UnaryInstruction>(V)) {
     return 0;
   } else if (BinaryOperator *BO = dyn_cast<BinaryOperator>(V)) {
     switch (BO->getOpcode()) {

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -235,7 +235,7 @@ struct ValidationContext {
       DxilResourceProperties RP = resource_helper::loadPropsFromResourceBase(Res);
       ResPropMap[V] = RP;
       for (User *U : V->users()) {
-        if (GEPOperator *GEP = dyn_cast<GEPOperator>(U)) {
+        if (isa<GEPOperator>(U)) {
           PropagateResMap(U, Res);
         } else if (CallInst *CI = dyn_cast<CallInst>(U)) {
           // Stop propagate on function call.
@@ -245,7 +245,7 @@ struct ValidationContext {
                 resource_helper::loadPropsFromResourceBase(Res);
             ResPropMap[CI] = RP;
           }
-        } else if (LoadInst *LI = dyn_cast<LoadInst>(U)) {
+        } else if (isa<LoadInst>(U)) {
           PropagateResMap(U, Res);
         } else if (isa<BitCastOperator>(U) && U->user_empty()) {
           // For hlsl type.
@@ -3015,13 +3015,13 @@ static void ValidateFunctionBody(Function *F, ValidationContext &ValCtx) {
       for (Value *op : I.operands()) {
         if (isa<UndefValue>(op)) {
           bool legalUndef = isa<PHINode>(&I);
-          if (InsertElementInst *InsertInst = dyn_cast<InsertElementInst>(&I)) {
+          if (isa<InsertElementInst>(&I)) {
             legalUndef = op == I.getOperand(0);
           }
-          if (ShuffleVectorInst *Shuf = dyn_cast<ShuffleVectorInst>(&I)) {
+          if (isa<ShuffleVectorInst>(&I)) {
             legalUndef = op == I.getOperand(1);
           }
-          if (StoreInst *Store = dyn_cast<StoreInst>(&I)) {
+          if (isa<StoreInst>(&I)) {
             legalUndef = op == I.getOperand(0);
           }
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -350,7 +350,7 @@ static unsigned IsPtrUsedByLoweredFn(
       if (IsPtrUsedByLoweredFn(user, CollectedUses))
         bFound = true;
 
-    } else if (isa<AddrSpaceCastInst>(user)) { // HLSL Change: remove unused variable
+    } else if (isa<AddrSpaceCastInst>(user)) {
       if (IsPtrUsedByLoweredFn(user, CollectedUses))
         bFound = true;
 

--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -350,7 +350,7 @@ static unsigned IsPtrUsedByLoweredFn(
       if (IsPtrUsedByLoweredFn(user, CollectedUses))
         bFound = true;
 
-    } else if (AddrSpaceCastInst *AC = dyn_cast<AddrSpaceCastInst>(user)) {
+    } else if (isa<AddrSpaceCastInst>(user)) { // HLSL Change: remove unused variable
       if (IsPtrUsedByLoweredFn(user, CollectedUses))
         bFound = true;
 

--- a/tools/clang/lib/AST/Type.cpp
+++ b/tools/clang/lib/AST/Type.cpp
@@ -3474,8 +3474,8 @@ bool Type::canHaveNullability() const {
   case Type::Builtin:
     switch (cast<BuiltinType>(type.getTypePtr())->getKind()) {
       // Signed, unsigned, and floating-point types cannot have nullability.
-#define SIGNED_TYPE(Id, SingletonId) case BuiltinType::Id:
-#define UNSIGNED_TYPE(Id, SingletonId) case BuiltinType::Id:
+#define SIGNED_TYPE(Id, SingletonId) case BuiltinType::Id: LLVM_C_FALLTHROUGH;
+#define UNSIGNED_TYPE(Id, SingletonId) case BuiltinType::Id: LLVM_C_FALLTHROUGH;
 #define FLOATING_TYPE(Id, SingletonId) case BuiltinType::Id:
 #define BUILTIN_TYPE(Id, SingletonId)
 #include "clang/AST/BuiltinTypes.def"

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1518,7 +1518,7 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
   }
 
   const ShaderModel *SM = m_pHLModule->GetShaderModel();
-  if (auto *Attr = FD->getAttr<HLSLWaveOpsIncludeHelperLanesAttr>()) {
+  if (FD->hasAttr<DXIL::HLSLWaveOpsIncludeHelperLanesAttr>()) {
     if (SM->IsSM67Plus() &&
         (funcProps->shaderKind == DXIL::ShaderKind::Pixel ||
          (isEntry && SM->GetKind() == DXIL::ShaderKind::Pixel)))
@@ -2588,62 +2588,6 @@ hlsl::InterpolationMode CGMSHLSLRuntime::GetInterpMode(const Decl *decl,
       Interp = InterpolationMode::Kind::Constant;
   }
   return Interp;
-}
-
-hlsl::CompType CGMSHLSLRuntime::GetCompType(const BuiltinType *BT) {
-
-  hlsl::CompType ElementType = hlsl::CompType::getInvalid();
-  switch (BT->getKind()) {
-  case BuiltinType::Bool:
-    ElementType = hlsl::CompType::getI1();
-    break;
-  case BuiltinType::Double:
-    ElementType = hlsl::CompType::getF64();
-    break;
-  case BuiltinType::HalfFloat: // HLSL Change
-  case BuiltinType::Float:
-    ElementType = hlsl::CompType::getF32();
-    break;
-  // HLSL Changes begin
-  case BuiltinType::Min10Float:
-  case BuiltinType::Min16Float:
-  // HLSL Changes end
-  case BuiltinType::Half:
-    ElementType = hlsl::CompType::getF16();
-    break;
-  case BuiltinType::Int:
-    ElementType = hlsl::CompType::getI32();
-    break;
-  case BuiltinType::LongLong:
-    ElementType = hlsl::CompType::getI64();
-    break;
-  // HLSL Changes begin
-  case BuiltinType::Min12Int:
-  case BuiltinType::Min16Int:
-  // HLSL Changes end
-  case BuiltinType::Short:
-    ElementType = hlsl::CompType::getI16();
-    break;
-    // HLSL Changes begin
-  case BuiltinType::Int8_4Packed:
-  case BuiltinType::UInt8_4Packed:
-    // HLSL Changes end
-  case BuiltinType::UInt:
-    ElementType = hlsl::CompType::getU32();
-    break;
-  case BuiltinType::ULongLong:
-    ElementType = hlsl::CompType::getU64();
-    break;
-  case BuiltinType::Min16UInt: // HLSL Change
-  case BuiltinType::UShort:
-    ElementType = hlsl::CompType::getU16();
-    break;
-  default:
-    llvm_unreachable("unsupported type");
-    break;
-  }
-
-  return ElementType;
 }
 
 /// Add resource to the program

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1518,7 +1518,7 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
   }
 
   const ShaderModel *SM = m_pHLModule->GetShaderModel();
-  if (FD->hasAttr<DXIL::HLSLWaveOpsIncludeHelperLanesAttr>()) {
+  if (FD->hasAttr<HLSLWaveOpsIncludeHelperLanesAttr>()) {
     if (SM->IsSM67Plus() &&
         (funcProps->shaderKind == DXIL::ShaderKind::Pixel ||
          (isEntry && SM->GetKind() == DXIL::ShaderKind::Pixel)))

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2590,6 +2590,63 @@ hlsl::InterpolationMode CGMSHLSLRuntime::GetInterpMode(const Decl *decl,
   return Interp;
 }
 
+[[maybe_unused]]
+hlsl::CompType CGMSHLSLRuntime::GetCompType(const BuiltinType *BT) {
+
+  hlsl::CompType ElementType = hlsl::CompType::getInvalid();
+  switch (BT->getKind()) {
+  case BuiltinType::Bool:
+    ElementType = hlsl::CompType::getI1();
+    break;
+  case BuiltinType::Double:
+    ElementType = hlsl::CompType::getF64();
+    break;
+  case BuiltinType::HalfFloat: // HLSL Change
+  case BuiltinType::Float:
+    ElementType = hlsl::CompType::getF32();
+    break;
+  // HLSL Changes begin
+  case BuiltinType::Min10Float:
+  case BuiltinType::Min16Float:
+  // HLSL Changes end
+  case BuiltinType::Half:
+    ElementType = hlsl::CompType::getF16();
+    break;
+  case BuiltinType::Int:
+    ElementType = hlsl::CompType::getI32();
+    break;
+  case BuiltinType::LongLong:
+    ElementType = hlsl::CompType::getI64();
+    break;
+  // HLSL Changes begin
+  case BuiltinType::Min12Int:
+  case BuiltinType::Min16Int:
+  // HLSL Changes end
+  case BuiltinType::Short:
+    ElementType = hlsl::CompType::getI16();
+    break;
+    // HLSL Changes begin
+  case BuiltinType::Int8_4Packed:
+  case BuiltinType::UInt8_4Packed:
+    // HLSL Changes end
+  case BuiltinType::UInt:
+    ElementType = hlsl::CompType::getU32();
+    break;
+  case BuiltinType::ULongLong:
+    ElementType = hlsl::CompType::getU64();
+    break;
+  case BuiltinType::Min16UInt: // HLSL Change
+  case BuiltinType::UShort:
+    ElementType = hlsl::CompType::getU16();
+    break;
+  default:
+    llvm_unreachable("unsupported type");
+    break;
+  }
+
+  return ElementType;
+}
+
 /// Add resource to the program
 void CGMSHLSLRuntime::addResource(Decl *D) {
   if (HLSLBufferDecl *BD = dyn_cast<HLSLBufferDecl>(D))

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2590,63 +2590,6 @@ hlsl::InterpolationMode CGMSHLSLRuntime::GetInterpMode(const Decl *decl,
   return Interp;
 }
 
-[[maybe_unused]]
-hlsl::CompType CGMSHLSLRuntime::GetCompType(const BuiltinType *BT) {
-
-  hlsl::CompType ElementType = hlsl::CompType::getInvalid();
-  switch (BT->getKind()) {
-  case BuiltinType::Bool:
-    ElementType = hlsl::CompType::getI1();
-    break;
-  case BuiltinType::Double:
-    ElementType = hlsl::CompType::getF64();
-    break;
-  case BuiltinType::HalfFloat: // HLSL Change
-  case BuiltinType::Float:
-    ElementType = hlsl::CompType::getF32();
-    break;
-  // HLSL Changes begin
-  case BuiltinType::Min10Float:
-  case BuiltinType::Min16Float:
-  // HLSL Changes end
-  case BuiltinType::Half:
-    ElementType = hlsl::CompType::getF16();
-    break;
-  case BuiltinType::Int:
-    ElementType = hlsl::CompType::getI32();
-    break;
-  case BuiltinType::LongLong:
-    ElementType = hlsl::CompType::getI64();
-    break;
-  // HLSL Changes begin
-  case BuiltinType::Min12Int:
-  case BuiltinType::Min16Int:
-  // HLSL Changes end
-  case BuiltinType::Short:
-    ElementType = hlsl::CompType::getI16();
-    break;
-    // HLSL Changes begin
-  case BuiltinType::Int8_4Packed:
-  case BuiltinType::UInt8_4Packed:
-    // HLSL Changes end
-  case BuiltinType::UInt:
-    ElementType = hlsl::CompType::getU32();
-    break;
-  case BuiltinType::ULongLong:
-    ElementType = hlsl::CompType::getU64();
-    break;
-  case BuiltinType::Min16UInt: // HLSL Change
-  case BuiltinType::UShort:
-    ElementType = hlsl::CompType::getU16();
-    break;
-  default:
-    llvm_unreachable("unsupported type");
-    break;
-  }
-
-  return ElementType;
-}
-
 /// Add resource to the program
 void CGMSHLSLRuntime::addResource(Decl *D) {
   if (HLSLBufferDecl *BD = dyn_cast<HLSLBufferDecl>(D))

--- a/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -526,6 +526,8 @@ bool CGRecordLowering::hasOwnStorage(const CXXRecordDecl *Decl,
   return true;
 }
 
+// HLSL Change: Remove unused function
+#if 0
 void CGRecordLowering::calculateZeroInit() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),
                                                MemberEnd = Members.end();
@@ -625,6 +627,7 @@ void CGRecordLowering::insertPadding() {
     Members.push_back(StorageInfo(Pad->first, getByteArrayType(Pad->second)));
   std::stable_sort(Members.begin(), Members.end());
 }
+#endif
 
 void CGRecordLowering::fillOutputFields() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),

--- a/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -526,8 +526,8 @@ bool CGRecordLowering::hasOwnStorage(const CXXRecordDecl *Decl,
   return true;
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
+// HLSL Change: Remove unused function
+#if 0
 void CGRecordLowering::calculateZeroInit() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),
                                                MemberEnd = Members.end();
@@ -547,8 +547,6 @@ void CGRecordLowering::calculateZeroInit() {
   }
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void CGRecordLowering::clipTailPadding() {
   std::vector<MemberInfo>::iterator Prior = Members.begin();
   CharUnits Tail = getSize(Prior->Data);
@@ -570,8 +568,6 @@ void CGRecordLowering::clipTailPadding() {
   }
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void CGRecordLowering::determinePacked(bool NVBaseType) {
   if (Packed)
     return;
@@ -606,8 +602,6 @@ void CGRecordLowering::determinePacked(bool NVBaseType) {
     Members.back().Data = getIntNType(Context.toBits(Alignment));
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void CGRecordLowering::insertPadding() {
   std::vector<std::pair<CharUnits, CharUnits> > Padding;
   CharUnits Size = CharUnits::Zero();
@@ -633,6 +627,7 @@ void CGRecordLowering::insertPadding() {
     Members.push_back(StorageInfo(Pad->first, getByteArrayType(Pad->second)));
   std::stable_sort(Members.begin(), Members.end());
 }
+#endif
 
 void CGRecordLowering::fillOutputFields() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),

--- a/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/tools/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -526,8 +526,8 @@ bool CGRecordLowering::hasOwnStorage(const CXXRecordDecl *Decl,
   return true;
 }
 
-// HLSL Change: Remove unused function
-#if 0
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void CGRecordLowering::calculateZeroInit() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),
                                                MemberEnd = Members.end();
@@ -547,6 +547,8 @@ void CGRecordLowering::calculateZeroInit() {
   }
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void CGRecordLowering::clipTailPadding() {
   std::vector<MemberInfo>::iterator Prior = Members.begin();
   CharUnits Tail = getSize(Prior->Data);
@@ -568,6 +570,8 @@ void CGRecordLowering::clipTailPadding() {
   }
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void CGRecordLowering::determinePacked(bool NVBaseType) {
   if (Packed)
     return;
@@ -602,6 +606,8 @@ void CGRecordLowering::determinePacked(bool NVBaseType) {
     Members.back().Data = getIntNType(Context.toBits(Alignment));
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void CGRecordLowering::insertPadding() {
   std::vector<std::pair<CharUnits, CharUnits> > Padding;
   CharUnits Size = CharUnits::Zero();
@@ -627,7 +633,6 @@ void CGRecordLowering::insertPadding() {
     Members.push_back(StorageInfo(Pad->first, getByteArrayType(Pad->second)));
   std::stable_sort(Members.begin(), Members.end());
 }
-#endif
 
 void CGRecordLowering::fillOutputFields() {
   for (std::vector<MemberInfo>::const_iterator Member = Members.begin(),

--- a/tools/clang/lib/Frontend/InitHeaderSearch.cpp
+++ b/tools/clang/lib/Frontend/InitHeaderSearch.cpp
@@ -184,6 +184,8 @@ void InitHeaderSearch::AddUnmappedPath(const Twine &Path, IncludeDirGroup Group,
 #endif // HLSL Change Ends - simplify mapping based on actual usage
 }
 
+// HLSL Change: Remove unused function;
+#if 0
 void InitHeaderSearch::AddGnuCPlusPlusIncludePaths(StringRef Base,
                                                    StringRef ArchDir,
                                                    StringRef Dir32,
@@ -434,6 +436,7 @@ AddDefaultCPlusPlusIncludePaths(const llvm::Triple &triple, const HeaderSearchOp
   }
 #endif // HLSL Change Ends
 }
+#endif
 
 void InitHeaderSearch::AddDefaultIncludePaths(const LangOptions &Lang,
                                               const llvm::Triple &triple,

--- a/tools/clang/lib/Frontend/InitHeaderSearch.cpp
+++ b/tools/clang/lib/Frontend/InitHeaderSearch.cpp
@@ -184,8 +184,8 @@ void InitHeaderSearch::AddUnmappedPath(const Twine &Path, IncludeDirGroup Group,
 #endif // HLSL Change Ends - simplify mapping based on actual usage
 }
 
-// HLSL Change: Remove unused function;
-#if 0
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void InitHeaderSearch::AddGnuCPlusPlusIncludePaths(StringRef Base,
                                                    StringRef ArchDir,
                                                    StringRef Dir32,
@@ -206,6 +206,8 @@ void InitHeaderSearch::AddGnuCPlusPlusIncludePaths(StringRef Base,
   AddPath(Base + "/backward", CXXSystem, false);
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void InitHeaderSearch::AddMinGWCPlusPlusIncludePaths(StringRef Base,
                                                      StringRef Arch,
                                                      StringRef Version) {
@@ -217,6 +219,8 @@ void InitHeaderSearch::AddMinGWCPlusPlusIncludePaths(StringRef Base,
           CXXSystem, false);
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
                                             const HeaderSearchOptions &HSOpts) {
   // HLSL Change Starts - no standard include files for the HLSL/DXIL
@@ -345,6 +349,8 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
 #endif // HLSL Change Ends
 }
 
+// HLSL Change: Annotate unused function
+[[maybe_unused]]
 void InitHeaderSearch::
 AddDefaultCPlusPlusIncludePaths(const llvm::Triple &triple, const HeaderSearchOptions &HSOpts) {
   // HLSL Change Starts - no standard include files for the HLSL/DXIL
@@ -436,7 +442,6 @@ AddDefaultCPlusPlusIncludePaths(const llvm::Triple &triple, const HeaderSearchOp
   }
 #endif // HLSL Change Ends
 }
-#endif
 
 void InitHeaderSearch::AddDefaultIncludePaths(const LangOptions &Lang,
                                               const llvm::Triple &triple,

--- a/tools/clang/lib/Frontend/InitHeaderSearch.cpp
+++ b/tools/clang/lib/Frontend/InitHeaderSearch.cpp
@@ -184,8 +184,8 @@ void InitHeaderSearch::AddUnmappedPath(const Twine &Path, IncludeDirGroup Group,
 #endif // HLSL Change Ends - simplify mapping based on actual usage
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
+// HLSL Change: Remove unused function;
+#if 0
 void InitHeaderSearch::AddGnuCPlusPlusIncludePaths(StringRef Base,
                                                    StringRef ArchDir,
                                                    StringRef Dir32,
@@ -206,8 +206,6 @@ void InitHeaderSearch::AddGnuCPlusPlusIncludePaths(StringRef Base,
   AddPath(Base + "/backward", CXXSystem, false);
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void InitHeaderSearch::AddMinGWCPlusPlusIncludePaths(StringRef Base,
                                                      StringRef Arch,
                                                      StringRef Version) {
@@ -219,8 +217,6 @@ void InitHeaderSearch::AddMinGWCPlusPlusIncludePaths(StringRef Base,
           CXXSystem, false);
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
                                             const HeaderSearchOptions &HSOpts) {
   // HLSL Change Starts - no standard include files for the HLSL/DXIL
@@ -349,8 +345,6 @@ void InitHeaderSearch::AddDefaultCIncludePaths(const llvm::Triple &triple,
 #endif // HLSL Change Ends
 }
 
-// HLSL Change: Annotate unused function
-[[maybe_unused]]
 void InitHeaderSearch::
 AddDefaultCPlusPlusIncludePaths(const llvm::Triple &triple, const HeaderSearchOptions &HSOpts) {
   // HLSL Change Starts - no standard include files for the HLSL/DXIL
@@ -442,6 +436,7 @@ AddDefaultCPlusPlusIncludePaths(const llvm::Triple &triple, const HeaderSearchOp
   }
 #endif // HLSL Change Ends
 }
+#endif
 
 void InitHeaderSearch::AddDefaultIncludePaths(const LangOptions &Lang,
                                               const llvm::Triple &triple,

--- a/tools/clang/lib/Parse/ParseExpr.cpp
+++ b/tools/clang/lib/Parse/ParseExpr.cpp
@@ -454,16 +454,18 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
 
         LHS = Actions.ActOnBinOp(getCurScope(), OpToken.getLocation(),
                                  OpToken.getKind(), LHS.get(), RHS.get());
-      } else
+      } else {
         LHS = Actions.ActOnConditionalOp(OpToken.getLocation(), ColonLoc,
                                          LHS.get(), TernaryMiddle.get(),
                                          RHS.get());
-    } else
+      }
+    } else {
+      // HLSL Change Begin - Take care TernaryMiddle.
       // Ensure potential typos in the RHS aren't left undiagnosed.
       Actions.CorrectDelayedTyposInExpr(RHS);
-      // HLSL Change Begin - Take care TernaryMiddle.
-      Actions.CorrectDelayedTyposInExpr(TernaryMiddle);
-      // HLSL Change End.
+    }
+    Actions.CorrectDelayedTyposInExpr(TernaryMiddle);
+    // HLSL Change End.
   }
 }
 

--- a/tools/clang/lib/Parse/ParseExpr.cpp
+++ b/tools/clang/lib/Parse/ParseExpr.cpp
@@ -459,8 +459,8 @@ Parser::ParseRHSOfBinaryExpression(ExprResult LHS, prec::Level MinPrec) {
                                          LHS.get(), TernaryMiddle.get(),
                                          RHS.get());
       }
+    // HLSL Change Begin - Take care TernaryMiddle.
     } else {
-      // HLSL Change Begin - Take care TernaryMiddle.
       // Ensure potential typos in the RHS aren't left undiagnosed.
       Actions.CorrectDelayedTyposInExpr(RHS);
     }

--- a/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/DebugTypeVisitor.cpp
@@ -98,7 +98,7 @@ void DebugTypeVisitor::addDebugTypeForMemberVariables(
 
     // Get offset (in bits) of this member within the composite.
     uint32_t offsetInBits = field.offset.hasValue()
-                                ? offsetInBits = *field.offset * 8
+                                ? *field.offset * 8
                                 : compositeSizeInBits;
     // Get size (in bits) of this member within the composite.
     uint32_t sizeInBits = field.sizeInBytes.hasValue()

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -2413,7 +2413,7 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
     finalizeTypeInstruction();
   }
   // Sampler types
-  else if (const auto *samplerType = dyn_cast<SamplerType>(type)) {
+  else if (isa<SamplerType>(type)) {
     initTypeInstruction(spv::Op::OpTypeSampler);
     curTypeInst.push_back(id);
     finalizeTypeInstruction();
@@ -2550,13 +2550,13 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
     finalizeTypeInstruction();
   }
   // Acceleration Structure NV type
-  else if (const auto *accType = dyn_cast<AccelerationStructureTypeNV>(type)) {
+  else if (isa<AccelerationStructureTypeNV>(type)) {
     initTypeInstruction(spv::Op::OpTypeAccelerationStructureNV);
     curTypeInst.push_back(id);
     finalizeTypeInstruction();
   }
   // RayQueryType KHR type
-  else if (const auto *rayQueryType = dyn_cast<RayQueryTypeKHR>(type)) {
+  else if (isa<RayQueryTypeKHR>(type)) {
     initTypeInstruction(spv::Op::OpTypeRayQueryKHR);
     curTypeInst.push_back(id);
     finalizeTypeInstruction();
@@ -2583,7 +2583,7 @@ uint32_t EmitTypeHandler::emitType(const SpirvType *type) {
   // Note: The type lowering pass should lower all types to SpirvTypes.
   // Therefore, if we find a hybrid type when going through the emitting pass,
   // that is clearly a bug.
-  else if (const auto *hybridType = dyn_cast<HybridType>(type)) {
+  else if (isa<HybridType>(type)) {
     llvm_unreachable("found hybrid type when emitting SPIR-V");
   }
   // Unhandled types

--- a/tools/clang/lib/SPIRV/RawBufferMethods.cpp
+++ b/tools/clang/lib/SPIRV/RawBufferMethods.cpp
@@ -680,7 +680,7 @@ QualType RawBufferHandler::serializeToScalarsOrStruct(
   if (isScalarType(valueType))
     return valueType;
 
-  if (const auto *structType = valueType->getAs<RecordType>())
+  if (valueType->getAs<RecordType>())
     return valueType;
 
   llvm_unreachable("unhandled type when serializing an array");
@@ -741,7 +741,7 @@ void RawBufferHandler::processTemplatedStoreToBuffer(
     if (isScalarType(serializedType)) {
       storeArrayOfScalars(elems, buffer, index, serializedType, bitOffset, loc,
                           range);
-    } else if (const auto *structType = serializedType->getAs<RecordType>()) {
+    } else if (serializedType->getAs<RecordType>()) {
       for (auto elem : elems)
         processTemplatedStoreToBuffer(elem, buffer, index, serializedType,
                                       bitOffset, range);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -930,8 +930,7 @@ void SpirvEmitter::doDecl(const Decl *decl) {
   } else if (const auto *classTemplateDecl =
                  dyn_cast<ClassTemplateDecl>(decl)) {
     doClassTemplateDecl(classTemplateDecl);
-  } else if (const auto *functionTemplateDecl =
-                 dyn_cast<FunctionTemplateDecl>(decl)) {
+  } else if (isa<FunctionTemplateDecl>(decl)) {
     // nothing to do.
   } else {
     emitError("decl type %0 unimplemented", decl->getLocation())

--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3063,6 +3063,7 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
       switch (cast<ObjCPropertyImplDecl>(D)->getPropertyImplementation()) {
       case ObjCPropertyImplDecl::Dynamic:
         return CXCursor_ObjCDynamicDecl;
+        LLVM_C_FALLTHROUGH;
           
       case ObjCPropertyImplDecl::Synthesize:
         return CXCursor_ObjCSynthesizeDecl;
@@ -3070,8 +3071,10 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
 
       case Decl::Import:
         return CXCursor_ModuleImportDecl;
+        LLVM_C_FALLTHROUGH;
 
     case Decl::ObjCTypeParam:   return CXCursor_TemplateTypeParameter;
+    LLVM_C_FALLTHROUGH;
 
     default:
       if (const TagDecl *TD = dyn_cast<TagDecl>(D)) {

--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3063,7 +3063,7 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
       switch (cast<ObjCPropertyImplDecl>(D)->getPropertyImplementation()) {
       case ObjCPropertyImplDecl::Dynamic:
         return CXCursor_ObjCDynamicDecl;
-        LLVM_C_FALLTHROUGH;
+        LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
           
       case ObjCPropertyImplDecl::Synthesize:
         return CXCursor_ObjCSynthesizeDecl;
@@ -3071,10 +3071,10 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
 
       case Decl::Import:
         return CXCursor_ModuleImportDecl;
-        LLVM_C_FALLTHROUGH;
+        LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
 
     case Decl::ObjCTypeParam:   return CXCursor_TemplateTypeParameter;
-    LLVM_C_FALLTHROUGH;
+    LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
 
     default:
       if (const TagDecl *TD = dyn_cast<TagDecl>(D)) {

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -129,10 +129,12 @@ void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
     // All checks must have passed.
     ASSERT_EQ(result.status(), effcee::Result::Status::Ok);
 
-    if (runValidation)
+    // HLSL Change: Explicit braces
+    if (runValidation) {
       EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
                                              beforeHLSLLegalization, glLayout,
                                              dxLayout, scalarLayout));
+    }
   } else if (expect == Expect::Warning) {
     ASSERT_TRUE(compileOk);
 
@@ -155,10 +157,12 @@ void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
     // All checks must have passed.
     ASSERT_EQ(result.status(), effcee::Result::Status::Ok);
 
-    if (runValidation)
+    // HLSL Change: explicit braces
+    if (runValidation) {
       EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
                                              beforeHLSLLegalization, glLayout,
                                              dxLayout, scalarLayout));
+    }
   } else if (expect == Expect::Failure) {
     ASSERT_FALSE(compileOk);
 


### PR DESCRIPTION
GCC generates some warnings when building DXC in a WSL environment. This PR is meant to reduce some of the warnings, mainly targeting unused variables / functions, and fallthroughs in switch statements.