### PR TITLE
Unix: Avoid concurrency hazard in signal handler registration

### DIFF
--- a/lib/Support/Unix/Signals.inc
+++ b/lib/Support/Unix/Signals.inc
@@ -112,12 +112,8 @@ static void RegisterHandler(int Signal) {
 }
 
 static void RegisterHandlers() {
-  // We need to dereference the signals mutex during handler registration so
-  // that we force its construction. This is to prevent the first use being
-  // during handling an actual signal because you can't safely call new in a
-  // signal handler.
-  *SignalsMutex;
-  
+  sys::SmartScopedLock<true> Guard(*SignalsMutex);
+
   // If the handlers are already registered, we're done.
   if (NumRegisteredSignals != 0) return;
 
@@ -164,7 +160,7 @@ static void RemoveFilesToRemove() {
     // super-user permissions.
     if (!S_ISREG(buf.st_mode))
       continue;
-  
+
     // Otherwise, remove the file. We ignore any errors here as there is nothing
     // else we can do.
     unlink(path);


### PR DESCRIPTION
Fixes #5271
backported from https://github.com/llvm-mirror/llvm/commit/fa92ec8e9e59d57a1556ec7b2024de94001485ae

Note that this doesn't touch a similar possible race condition for `UnregisterHandlers()`.

---

Several static functions from the signal API can be invoked simultaneously; RemoveFileOnSignal for instance can be called indirectly by multiple parallel loadModule() invocations, which might lead to the assertion:

Assertion failed: (NumRegisteredSignals < array_lengthof(RegisteredSignalInfo) && "Out of space for signal handlers!"),
  function RegisterHandler, file /llvm/lib/Support/Unix/Signals.inc, line 105.

RemoveFileOnSignal calls RegisterHandlers(), which isn't currently mutex protected, leading to the behavior above. This potentially affect a few other users of RegisterHandlers() too.

rdar://problem/30381224

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@298871 91177308-0d34-0410-b5e6-96231b3b80d8