### PR TITLE
Fix special case with vector swizzle

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -5859,10 +5859,14 @@ SpirvEmitter::doHLSLVectorElementExpr(const HLSLVectorElementExpr *expr,
     originalOrder &= selectors[i] == i;
   }
 
-  if (originalOrder)
-    return doExpr(baseExpr, range);
-
   auto *info = loadIfGLValue(baseExpr, range);
+
+  if (originalOrder) {
+    // If the elements are simply the original vector, then return it without a
+    // vector shuffle.
+    return info;
+  }
+
   // Use base for both vectors. But we are only selecting values from the
   // first one.
   return spvBuilder.createVectorShuffle(expr->getType(), info, info, selectors,

--- a/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.vector.swizzle.hlsl
@@ -11,6 +11,9 @@
 // * assignment/compound assignment
 // * continuous selection
 
+SamplerState sampler1 : register(s0);
+Texture2D<float4> texture1 : register(t0);
+
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel
     float4 v4f1, v4f2;
@@ -158,4 +161,13 @@ void main() {
 // CHECK-NEXT: [[ptr:%\d+]] = OpAccessChain %_ptr_Function_float %v4f1 %int_3
 // CHECK-NEXT:                OpStore [[ptr]] %float_5
     ((((v4f1.xwzy).yxz)).x) = 5.0f;
+
+// CHECK-NEXT: [[texture:%\d+]] = OpLoad %type_2d_image %texture1
+// CHECK-NEXT: [[sampler:%\d+]] = OpLoad %type_sampler %sampler1
+// CHECK-NEXT: [[v2:%\d+]] = OpLoad %v2float %v2f
+// CHECK-NEXT: [[sampled_image:%\d+]] = OpSampledImage %type_sampled_image [[texture]] [[sampler]]
+// CHECK-NEXT: [[res:%\w+]] = OpImageSampleExplicitLod %v4float [[sampled_image]] [[v2]] Lod %float_0
+// CHECK-NEXT: OpStore %v4f1 [[res]]
+    v4f1 = texture1.SampleLevel(sampler1, v2f.xyx.xy, 0);
+
 }


### PR DESCRIPTION
When handling the swizzles in the SPIR-V backen, there is a special case when
the final result returns the original vector. It tries to avoid adding the
vector shuffle instruction in spir-v. However, that path calls `doExpr` instead
of `loadIfGLValue` like the other path. This can sometimes cause a load to be
omitted.

This is changed so that `loadIfGLValue` is called for both cases.

Fixes #5275
