### PR TITLE
[Metadata] Limit bitfield annotation to validator version >= 1.7

### DIFF
--- a/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield-combine-to-unsigned.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield-combine-to-unsigned.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
 
 // Make sure bitfiled info is saved.
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield-enum.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield-enum.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_6 -HV 2021 -E main %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -T lib_6_6 -HV 2021 -E main -Vd -validator-version 0.0   %s | %D3DReflect %s | FileCheck %s
 
 // Make sure bit field on enum works.
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_in-structured-buffer.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_in-structured-buffer.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
 
 // Make sure bitfiled info is saved.
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_single_member.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_single_member.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
 
 // Make sure bitfiled info is saved.
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_spill-over.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/bitfield_spill-over.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.7 | %dxc -E main -T ps_6_0 -HV 2021 -Vd -validator-version 0.0  %s | %D3DReflect %s | FileCheck %s
 
 // Make sure bitfiled info is saved.
 // FIXME: check half as 16bit when enable-16bit-types.


### PR DESCRIPTION
Only emit bitfield annotation for validator version >= 1.7
This is to avoid validation error on old validator.