### PR TITLE
[flag] Update the lifetime markers flag to correctly handle multiple …

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -779,9 +779,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.ResMayAlias = Args.hasFlag(OPT_res_may_alias_, OPT_INVALID, opts.ResMayAlias);
   opts.ForceZeroStoreLifetimes = Args.hasFlag(OPT_force_zero_store_lifetimes, OPT_INVALID, false);
   // Lifetime markers on by default in 6.6 unless disabled explicitly
-  opts.EnableLifetimeMarkers = Args.hasFlag(OPT_enable_lifetime_markers, OPT_INVALID,
-                                            DXIL::CompareVersions(Major, Minor, 6, 6) >= 0) &&
-                              !Args.hasFlag(OPT_disable_lifetime_markers, OPT_INVALID, false);
+  opts.EnableLifetimeMarkers = Args.hasFlag(OPT_enable_lifetime_markers, OPT_disable_lifetime_markers,
+                                            DXIL::CompareVersions(Major, Minor, 6, 6) >= 0);
   opts.ForceDisableLocTracking =
       Args.hasFlag(OPT_fdisable_loc_tracking, OPT_INVALID, false);
   opts.NewInlining =

--- a/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes-flag.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/lifetimes/lifetimes-flag.hlsl
@@ -1,0 +1,37 @@
+// This test checks that the lifetime markers flag works correctly when
+// multiple instances are given on the command line.
+//
+// The shader here is not important except that it triggers the insertion
+// of lifetime markers when they are enabled.
+
+// Default value is enabled for 6.6.
+// RUN: %dxc /Tvs_6_6 %s | FileCheck %s -check-prefix=ENABLE
+
+// Explicitly enabling the flag should enable lifetime markers.
+// RUN: %dxc /Tvs_6_6 %s -enable-lifetime-markers | FileCheck %s -check-prefix=ENABLE
+
+// Explicitly disabling the flag should disable lifetime markers.
+// RUN: %dxc /Tvs_6_6 %s -disable-lifetime-markers | FileCheck %s -check-prefix=DISABLE
+
+// When both enable and disable flags are given the last occurence should win.
+// RUN: %dxc /Tvs_6_6 %s -enable-lifetime-markers -disable-lifetime-markers | FileCheck %s -check-prefix=DISABLE
+// RUN: %dxc /Tvs_6_6 %s -disable-lifetime-markers -enable-lifetime-markers | FileCheck %s -check-prefix=ENABLE
+
+// ENABLE: define void @main()
+// ENABLE: call void @llvm.lifetime.start
+
+// DISABLE: define void @main()
+// DISABLE-NOT: call void @llvm.lifetime.start
+
+void foo() {};
+
+[RootSignature("DescriptorTable(UAV(u0, numDescriptors=10))")]
+float main(int N : A, float X : X) : Z {
+    float Arr[64];
+  
+    foo();
+    Arr[N] = 0;
+    foo();
+
+    return Arr[X];
+}


### PR DESCRIPTION
…instances

The current behavior of the lifetime markers flags is to allow the `-disable-lifetime-markers` flag to override the enable flag no matter where it occurs. This means that if you write

    dxc -disable-lifetime-markers ... -enable-lifetime-markers

the lifetime markers will be disabled. This works differently from most clang flags which allow the last version of the enable/disable flag to win.

This PR modifies these flags so that when there are multiple occurences of enable/disable the last one will win. It is not clear if the original behavior was intentional or just a  mis-understanding of the flag API. There were no tests enforcing the original behavior.