### PR TITLE
Fix build when compiling against libc++

### DIFF
--- a/include/llvm/ADT/iterator.h
+++ b/include/llvm/ADT/iterator.h
@@ -152,15 +152,12 @@ protected:
 
   iterator_adaptor_base() = default;
 
-  template <typename U>
-  explicit iterator_adaptor_base(
-      U &&u,
-      typename std::enable_if<
-          !std::is_base_of<typename std::remove_cv<
-                               typename std::remove_reference<U>::type>::type,
-                           DerivedT>::value,
-          int>::type = 0)
-      : I(std::forward<U &&>(u)) {}
+  // HLSL Change Begins: Fix libc++ build
+  explicit iterator_adaptor_base(WrappedIteratorT u) : I(std::move(u)) {
+    static_assert(std::is_base_of<iterator_adaptor_base, DerivedT>::value,
+                  "Must pass the derived type to this template!");
+  }
+  // HLSL Change Ends
 
   const WrappedIteratorT &wrapped() const { return I; }
 


### PR DESCRIPTION
When using libc++, the build fails with errors like:

 error: incomplete type 'clang::DeclContext::udir_iterator' used in type trait expression
    : public integral_constant<bool, __is_base_of(_Bp, _Dp)> {};
                                                          ^
 note: while substituting deduced template arguments into function template 'iterator_adaptor_base' [with U = const llvm::iterator_adaptor_base<clang::DeclContext::udir_iterator, clang::DeclContextLookupResult::iterator, std::random_access_iterator_tag, clang::UsingDirectiveDecl *> &]
class iterator_adaptor_base

This was fixed in upstream LLVM in this CL:
https://github.com/llvm/llvm-project/commit/e78e32a443aaaba63d081faaed7e2cb881424458 (also see original review: https://reviews.llvm.org/D22951#change-zKJSAlLXXy11) Unfortunately, the CL does not explain why this change was made, so I can only assume that it was failing a libc++ build as well.

I also added the static_assert that was later added in this CL: https://github.com/llvm/llvm-project/commit/0aecae34529b70f6ac4b758651bf579f0a464257 This restores the build failure that would occur if U is not a base of DerivedT.