### PR TITLE
Add missing CMake variable  for configure_file

### DIFF
--- a/include/llvm/Config/config.h.cmake
+++ b/include/llvm/Config/config.h.cmake
@@ -303,7 +303,7 @@
 #cmakedefine HAVE_SYS_IOCTL_H ${HAVE_SYS_IOCTL_H}
 
 /* Define to 1 if you have the <sys/mman.h> header file. */
-#cmakedefine HAVE_SYS_MMAN_H ${}
+#cmakedefine HAVE_SYS_MMAN_H ${HAVE_SYS_MMAN_H}
 
 /* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
    */


### PR DESCRIPTION
Although seemingly unnecessary for CMake builds of DXC, for our GN build, we needed to write a script to replicate the behaviour of CMake's "configure_file". Having an variable expansion with no variable ("${}") made the script more complex. Besides, this looks like a bug.