### PR TITLE
Fix clang build depending on delayed template parsing

### DIFF
--- a/lib/DxilDia/DxcPixEntrypoints.cpp
+++ b/lib/DxilDia/DxcPixEntrypoints.cpp
@@ -351,7 +351,7 @@ protected:
   template <typename F, typename... A>
   HRESULT InvokeOnReal(F pFn, A... Args)
   {
-    return ::SetupAndRun(m_pMalloc, std::mem_fn(pFn), m_pReal, Args...);
+    return SetupAndRun(m_pMalloc, std::mem_fn(pFn), m_pReal, Args...);
   }
 
 public:
@@ -359,7 +359,7 @@ public:
 
   HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void** ppvObject) override final
   {
-    return ::SetupAndRun(
+    return SetupAndRun(
         m_pMalloc,
         std::mem_fn(&Entrypoint<IInterface>::QueryInterfaceImpl),
         ThisPtr(this),


### PR DESCRIPTION
Remove scope resolution on call to SetupAndRun. This works on MSVC presumably because of it's former non-conformant two-phase lookup. Clang can be made to emulate this behaviour by enabling
`-fdelayed-template-parsing`, but GCC does not seem to support this flag. It seems easier to just fix the code this way.