### PR TITLE
Add cast after RWByteAddressBuffer atomic compare exchange

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/method.rw-byte-address-buffer.atomic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.rw-byte-address-buffer.atomic.hlsl
@@ -8,6 +8,7 @@ RWByteAddressBuffer myBuffer;
 float4 main() : SV_Target
 {
     uint originalVal;
+    int  originalValAsInt;
 
 // CHECK:      [[offset:%\d+]] = OpShiftRightLogical %uint %uint_16 %uint_2
 // CHECK-NEXT:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %myBuffer %uint_0 [[offset]]
@@ -101,6 +102,13 @@ float4 main() : SV_Target
 // CHECK-NEXT:    [[val:%\d+]] = OpAtomicCompareExchange %uint [[ptr]] %uint_1 %uint_0 %uint_0 %uint_42 %uint_30
 // CHECK-NEXT:                   OpStore %originalVal [[val]]
     myBuffer.InterlockedCompareExchange(/*offset=*/16, /*compare_value=*/30, /*value=*/42, originalVal);
+
+// CHECK:      [[offset:%\d+]] = OpShiftRightLogical %uint %uint_16 %uint_2
+// CHECK-NEXT:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %myBuffer %uint_0 [[offset]]
+// CHECK-NEXT:    [[val:%\d+]] = OpAtomicCompareExchange %uint [[ptr]] %uint_1 %uint_0 %uint_0 %uint_42 %uint_30
+// CHECK-NEXT:   [[cast:%\d+]] = OpBitcast %int [[val]]
+// CHECK-NEXT:                   OpStore %originalValAsInt [[cast]]
+    myBuffer.InterlockedCompareExchange(/*offset=*/16, /*compare_value=*/30, /*value=*/42, originalValAsInt);
 
 // CHECK:      [[offset:%\d+]] = OpShiftRightLogical %uint %uint_16 %uint_2
 // CHECK-NEXT:    [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_uint %myBuffer %uint_0 [[offset]]


### PR DESCRIPTION
The type of the RWByteAddressBuffer is always uint in the SPIR-V
representation. This means that the OpAtomicCompareExchange instruction
must have parameters and a result of type uint. If the original code
used an in for the result, then there is a type mismatch when storing
the value. This is fixed by add a cast when appropriate.

Fixes #4741
