### PR TITLE
Handle size 1 vectors in getTypeWithCustomBitwidth

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -652,6 +652,12 @@ QualType getTypeWithCustomBitwidth(const ASTContext &ctx, QualType type,
     }
   }
 
+  // It could be a vector of size 1, which is treated as a scalar.
+  if (hlsl::IsHLSLVecType(type)) {
+    assert(hlsl::GetHLSLVecSize(type) == 1);
+    type = hlsl::GetHLSLVecElementType(type);
+  }
+
   // Scalar cases.
   assert(!type->isBooleanType());
   assert(type->isIntegerType() || type->isFloatingType());

--- a/tools/clang/test/CodeGenSPIRV/cast.float1.half1.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.float1.half1.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -T cs_6_6 -E CS -enable-16bit-types -spirv
+
+
+
+[numthreads(1, 1, 1)]
+void CS()
+{
+	vector<float, 1> x;
+
+ // CHECK: [[x_val:%\d+]] = OpLoad %float %x
+ // CHECK: [[y_val:%\d+]] = OpFConvert %half [[x_val]]
+ // CHECK: OpStore %y [[y_val]]
+	vector<half, 1> y = (vector<half, 1>)x;
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -288,6 +288,9 @@ TEST_F(FileTest, UnaryOpLogicalNot) {
 // For sizeof()
 TEST_F(FileTest, UnaryOpSizeof) { runFileTest("unary-op.sizeof.hlsl"); }
 
+// For cast of size 1 float vectors
+TEST_F(FileTest, CastSize1Vectors) { runFileTest("cast.float1.half1.hlsl"); }
+
 // For assignments
 TEST_F(FileTest, BinaryOpAssign) { runFileTest("binary-op.assign.hlsl"); }
 TEST_F(FileTest, BinaryOpAssignImage) {


### PR DESCRIPTION
Vectors of 1 element are handled as scalars in the spir-v backend
because the element count of [vectors in
spir-v](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpTypeVector)
must be at least 2.

This case is not handled in getTypeWithCustomBitwidth and is causing an
assert. The fix is to add code to explicitly handle vectors of size one.

Fixes #5130
