### PR TITLE
[SPIR-V] Correctly request RayQueryKHR only when requested

### DIFF
--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -214,16 +214,6 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
     for (auto field : structType->getFields())
       addCapabilityForType(field.type, loc, sc);
   }
-  // AccelerationStructureTypeNV 
-  else if (isa<AccelerationStructureTypeNV>(type)) {
-    if (featureManager.isExtensionEnabled(Extension::NV_ray_tracing)) {
-      addCapability(spv::Capability::RayTracingNV);
-      addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
-    } else {
-      addCapability(spv::Capability::RayTracingKHR);
-      addExtension(Extension::KHR_ray_tracing, "SPV_KHR_ray_tracing", {});
-    }
-  }
   // RayQueryTypeKHR type
   else if (isa<RayQueryTypeKHR>(type)) {
     addCapability(spv::Capability::RayQueryKHR);

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -214,15 +214,18 @@ void CapabilityVisitor::addCapabilityForType(const SpirvType *type,
     for (auto field : structType->getFields())
       addCapabilityForType(field.type, loc, sc);
   }
-  // AccelerationStructureTypeNV and RayQueryTypeKHR type
-  // Note: Because AccelerationStructureType can be provided by both
-  // SPV_KHR_ray_query and SPV_{NV,KHR}_ray_tracing extensions, this logic will
-  // result in SPV_KHR_ray_query being unnecessarily required in some cases. If
-  // this is an issue in future (more devices are identified that support
-  // ray_tracing but not ray_query), then we should consider addressing this
-  // interaction with a spirv-opt pass instead.
-  else if (isa<AccelerationStructureTypeNV>(type) ||
-           isa<RayQueryTypeKHR>(type)) {
+  // AccelerationStructureTypeNV 
+  else if (isa<AccelerationStructureTypeNV>(type)) {
+    if (featureManager.isExtensionEnabled(Extension::NV_ray_tracing)) {
+      addCapability(spv::Capability::RayTracingNV);
+      addExtension(Extension::NV_ray_tracing, "SPV_NV_ray_tracing", {});
+    } else {
+      addCapability(spv::Capability::RayTracingKHR);
+      addExtension(Extension::KHR_ray_tracing, "SPV_KHR_ray_tracing", {});
+    }
+  }
+  // RayQueryTypeKHR type
+  else if (isa<RayQueryTypeKHR>(type)) {
     addCapability(spv::Capability::RayQueryKHR);
     addExtension(Extension::KHR_ray_query, "SPV_KHR_ray_query", {});
   }


### PR DESCRIPTION
This PR fixes a bug where ray query compatibility was required whenever acceleration structure compatibility is requested. 

More specifically, this fixes issue #5306 

In practice, not all GPUs capable of ray tracing supporting support ray queries, and not all support the ray tracing pipeline. Many AMD GPUs support only khr_ray_query, while many NVIDIA cards support only khr_ray_tracing_pipeline. 

Currently, if you own a Pascal card, a Volta, Turing or Ampere cards like the 1660 ti, then the current logic in DXC prevents RT from working on these platforms. At ANL, we have A100s in server systems like Polaris where we want to use Vulkan ray tracing + HLSL, but these also only support khr_ray_tracing_pipeline.

Macs through MoltenVK where we're working to add a translation might also only support the ray tracing pipeline due to Metal RT constraints. I'm not entirely sure here, but it's possible.

On the AMD side of things, its often the case that only khr_ray_query is supported.

This change removes the false assumption that the presence of an acceleration structure type implies ray queries or ray tracing pipeline. Instead, we assume that the user will request either the ray query and/or the ray tracing pipeline extensions during compilation.

Down the road, we could request that spirv-opt add a pass to remove any requested ray query extension if no queries are used, or remove the ray pipeline extension if that's not used, but until that's added to spirv-opt, I'd argue we should accept this PR in favor of adding support for all these NVIDIA cards where RT core acceleration isn't available but software fallbacks in RT core are. 

