### PR TITLE
Add missing dxilver 1.8 to test.

### DIFF
--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = 340 bytes):
 // CHECK:  StringBuffer (size = 32 bytes)


### PR DESCRIPTION
Test relies on validator version 1.8, but doesn't specify this version requirement.  Added requirement.