### PR TITLE
Disambiguate recod type; fix nearby gcc warnings

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -151,7 +151,7 @@ bool DxilRuntimeData::InitFromRDAT(const void *pRDAT, size_t size) {
 #else  // NDEBUG
       return true;
 #endif // NDEBUG
-    } catch(CheckedReader::exception e) {
+    } catch(CheckedReader::exception &e) {
       // TODO: error handling
       //throw hlsl::Exception(DXC_E_MALFORMED_CONTAINER, e.what());
       return false;

--- a/lib/DxilContainer/DxilRDATBuilder.cpp
+++ b/lib/DxilContainer/DxilRDATBuilder.cpp
@@ -217,7 +217,7 @@ StringRef DxilRDATBuilder::FinalizeAndGetData() {
       part->Write(bytes);
     }
   }
-  catch (CheckedWriter::exception e) {
+  catch (CheckedWriter::exception &e) {
     throw hlsl::Exception(DXC_E_GENERAL_INTERNAL_ERROR, e.what());
   }
   return llvm::StringRef(m_RDATBuffer.data(), m_RDATBuffer.size());


### PR DESCRIPTION
Previous disambiguation by adding `struct` works for gcc.  However, there was another case under the `DEF_RDAT_TYPES_BASIC_STRUCT` path that would have needed it as well, but just wasn't hit yet.

I thought that I'd disambiguate with the full scope instead, and cover a bunch more potential locations, since I recall that was necessary in another instance in the past.  This should make the usage of `type` in the macros more robust to potential name collisions.

Along the way, there were a few valid gcc warnings in the area which also I fixed.