### PR TITLE
Made linker preserve nops for Od.

### DIFF
--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -267,6 +267,7 @@ void initializeDxilEliminateVectorPass(PassRegistry&);
 void initializeDxilConditionalMem2RegPass(PassRegistry&);
 void initializeDxilFixConstArrayInitializerPass(PassRegistry&);
 void initializeDxilInsertPreservesPass(PassRegistry&);
+void initializeDxilReinsertNopsPass(PassRegistry&);
 void initializeDxilFinalizePreservesPass(PassRegistry&);
 void initializeDxilPreserveToSelectPass(PassRegistry&);
 void initializeDxilRemoveDeadBlocksPass(PassRegistry&);

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -144,6 +144,9 @@ void initializeDxilInsertPreservesPass(PassRegistry&);
 Pass *createDxilFinalizePreservesPass();
 void initializeDxilFinalizePreservesPass(PassRegistry&);
 
+Pass *createDxilReinsertNopsPass();
+void initializeDxilReinsertNopsPass(PassRegistry&);
+
 Pass *createDxilPreserveToSelectPass();
 void initializeDxilPreserveToSelectPass(PassRegistry&);
 

--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -1237,6 +1237,7 @@ void DxilLinkJob::RunPreparePass(Module &M) {
   const ShaderModel *pSM = DM.GetShaderModel();
 
   legacy::PassManager PM;
+  PM.add(createDxilReinsertNopsPass());
   PM.add(createAlwaysInlinerPass(/*InsertLifeTime*/ false));
 
   // Remove unused functions.
@@ -1276,6 +1277,7 @@ void DxilLinkJob::RunPreparePass(Module &M) {
   PM.add(createDxilDeadFunctionEliminationPass());
   PM.add(createNoPausePassesPass());
   PM.add(createDxilEmitMetadataPass());
+  PM.add(createDxilFinalizePreservesPass());
 
   PM.run(M);
 }

--- a/lib/HLSL/DxilNoops.cpp
+++ b/lib/HLSL/DxilNoops.cpp
@@ -95,6 +95,7 @@
 #include "llvm/Transforms/Utils/Local.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/Support/raw_os_ostream.h"
+#include "llvm/ADT/StringRef.h"
 #include "dxc/DXIL/DxilMetadataHelper.h"
 #include "dxc/DXIL/DxilConstants.h"
 #include "dxc/HLSL/DxilNoops.h"
@@ -581,6 +582,78 @@ Pass *llvm::createDxilRewriteOutputArgDebugInfoPass() {
 }
 
 INITIALIZE_PASS(DxilRewriteOutputArgDebugInfo, "dxil-rewrite-output-arg-debug-info", "Dxil Rewrite Output Arg Debug Info", false, false)
+
+//==========================================================
+// Reader pass
+//
+
+namespace {
+
+class DxilReinsertNops : public ModulePass {
+public:
+  static char ID;
+
+  DxilReinsertNops() : ModulePass(ID) {
+    initializeDxilReinsertNopsPass(*PassRegistry::getPassRegistry());
+  }
+
+  static bool IsLegitimateNothingGlobalVar(StringRef Name) {
+    if (1 != Name.count(hlsl::kNothingName))
+      return false;
+    size_t Loc = Name.find(hlsl::kNothingName);
+    StringRef Prefix = Name.substr(0, Loc);
+    StringRef Suffix = Name.substr(Loc+Name.size());
+    if (!Prefix.empty() && !Prefix.endswith(".")) {
+      return false;
+    }
+    if (!Suffix.empty() && !Suffix.startswith(".")) {
+      return false;
+    }
+    return true;
+  }
+
+  bool runOnModule(Module& M) override {
+    bool Changed = false;
+    for (GlobalVariable &GV : M.globals()) {
+      if (!IsLegitimateNothingGlobalVar(GV.getName()))
+        continue;
+
+      const bool IsValidType = GV.getValueType()->isArrayTy() &&
+                               GV.getValueType()->getArrayElementType() ==
+                                   Type::getInt32Ty(M.getContext()) &&
+                               GV.getValueType()->getArrayNumElements() == 1;
+      if (!IsValidType)
+        return false;
+
+      for (User *GVU : GV.users()) {
+        ConstantExpr *CE = dyn_cast<ConstantExpr>(GVU);
+        if (!CE || CE->getOpcode() != Instruction::GetElementPtr)
+          continue;
+
+        for (auto it = CE->user_begin(), end = CE->user_end(); it != end;) {
+          User *U = *(it++);
+          LoadInst *LI = dyn_cast<LoadInst>(U);
+          if (!LI)
+            continue;
+          InsertNoopAt(LI);
+          LI->eraseFromParent();
+          Changed = true;
+        }
+      }
+    }
+
+    return Changed;
+  }
+  StringRef getPassName() const override { return "Dxil Reinsert Nops"; }
+};
+
+char DxilReinsertNops::ID;
+}
+Pass *llvm::createDxilReinsertNopsPass() {
+  return new DxilReinsertNops();
+}
+
+INITIALIZE_PASS(DxilReinsertNops, "dxil-reinsert-nops", "Dxil Reinsert Nops", false, false)
 
 
 //==========================================================

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -51,6 +51,7 @@ public:
   TEST_METHOD(RunLinkMatParamToLib);
   TEST_METHOD(RunLinkResRet);
   TEST_METHOD(RunLinkToLib);
+  TEST_METHOD(RunLinkToLibOdNops);
   TEST_METHOD(RunLinkToLibExport);
   TEST_METHOD(RunLinkToLibExportShadersOnly);
   TEST_METHOD(RunLinkFailReDefineGlobal);
@@ -482,6 +483,29 @@ TEST_F(LinkerTest, RunLinkToLib) {
   RegisterDxcModule(libName2, pLib, pLinker);
 
   Link(L"", L"lib_6_3", pLinker, {libName, libName2}, {"!llvm.dbg.cu"}, {}, option);
+}
+
+TEST_F(LinkerTest, RunLinkToLibOdNops) {
+  LPCWSTR option[] = {L"-Od"};
+
+  CComPtr<IDxcBlob> pEntryLib;
+  CompileLib(L"..\\CodeGenHLSL\\linker\\lib_mat_entry2.hlsl",
+             &pEntryLib, option);
+  CComPtr<IDxcBlob> pLib;
+  CompileLib(
+      L"..\\CodeGenHLSL\\linker\\lib_mat_cast2.hlsl",
+      &pLib, option);
+
+  CComPtr<IDxcLinker> pLinker;
+  CreateLinker(&pLinker);
+
+  LPCWSTR libName = L"ps_main";
+  RegisterDxcModule(libName, pEntryLib, pLinker);
+
+  LPCWSTR libName2 = L"test";
+  RegisterDxcModule(libName2, pLib, pLinker);
+
+  Link(L"", L"lib_6_3", pLinker, {libName, libName2}, {"load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0"}, {}, option);
 }
 
 TEST_F(LinkerTest, RunLinkToLibExport) {

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2200,6 +2200,7 @@ class db_dxil(object):
         add_pass('dxil-elim-vector', 'DxilEliminateVector', 'Dxil Eliminate Vectors', [])
         add_pass('dxil-rewrite-output-arg-debug-info', 'DxilRewriteOutputArgDebugInfo', 'Dxil Rewrite Output Arg Debug Info', [])
         add_pass('dxil-finalize-preserves', 'DxilFinalizePreserves', 'Dxil Finalize Preserves', [])
+        add_pass('dxil-reinsert-nops', 'DxilReinsertNops', 'Dxil Reinsert Nops', [])
         add_pass('dxil-insert-preserves', 'DxilInsertPreserves', 'Dxil Insert Noops', [
                 {'n':'AllowPreserves', 't':'bool', 'c':1},
             ])


### PR DESCRIPTION
For `-Od`/`-O0` compilations, the compiler generates nop instructions in the form of:

```
@dx.nothing.a = internal constant [1 x i32] zeroinitializer
...
%0 = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0)
```
This instruction is intended to be a complete no-op, and backends that recognizes this pattern can turn it into proper hardware specific no-op instructions for debug purposes.

When linking DXIL libraries, the passes that run end up removing these nops. This change adds a new pass `DxilReinsertNops` to run at the beginning of linking to read the `LoadInst`s representing nops and turn them back into calls of `dx.noop`, before turning back into loads again at the end.