### PR TITLE
PIX: don't report modification from DXRInvocationsLog pass for non-DXR-hit libs

### DIFF
--- a/lib/DxilPIXPasses/DxilPIXDXRInvocationsLog.cpp
+++ b/lib/DxilPIXPasses/DxilPIXDXRInvocationsLog.cpp
@@ -64,6 +64,8 @@ bool DxilPIXDXRInvocationsLog::runOnModule(Module &M) {
   LLVMContext &Ctx = M.getContext();
   OP *HlslOP = DM.GetOP();
 
+  bool Modified = false;
+
   for (auto entryFunction : DM.GetExportedFunctions()) {
     
     DXIL::ShaderKind ShaderKind = GetShaderKind(DM, entryFunction);
@@ -78,6 +80,8 @@ bool DxilPIXDXRInvocationsLog::runOnModule(Module &M) {
     default:
       continue;
     }
+
+    Modified = true;
 
     IRBuilder<> Builder(dxilutil::FirstNonAllocaInsertionPt(entryFunction));
 
@@ -220,7 +224,7 @@ bool DxilPIXDXRInvocationsLog::runOnModule(Module &M) {
         });
   }
 
-  return true;
+  return Modified;
 }
 
 char DxilPIXDXRInvocationsLog::ID = 0;


### PR DESCRIPTION
PIX may well have libs in a state object that have no DXR hit groups.