### PR TITLE
Propagate bitwidth for BitCast in LiteralTypeVisitor

### DIFF
--- a/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
@@ -110,41 +110,46 @@ bool LiteralTypeVisitor::visit(SpirvAtomic *inst) {
 }
 
 bool LiteralTypeVisitor::visit(SpirvUnaryOp *inst) {
-  // Do not try to make conclusions about types for bitwidth conversion
-  // operations.
-  // TODO: We can do more to deduce information in OpBitCast.
   const auto opcode = inst->getopcode();
-  if (opcode == spv::Op::OpUConvert || opcode == spv::Op::OpSConvert ||
-      opcode == spv::Op::OpFConvert || opcode == spv::Op::OpBitcast) {
-    return true;
-  }
-
   const auto resultType = inst->getAstResultType();
   auto *arg = inst->getOperand();
   const auto argType = arg->getAstResultType();
 
-  // OpNot, OpSNegate, and OpConvertXToY operations change the type, but may not
-  // change the bitwidth. So, for these operations, we can use the result type's
-  // bitwidth as a hint for the operand's bitwidth.
-  // --> get signedness and vector size (if any) from operand
-  // --> get bitwidth from result type
-  if (opcode == spv::Op::OpConvertFToU || opcode == spv::Op::OpConvertFToS ||
-      opcode == spv::Op::OpConvertSToF || opcode == spv::Op::OpConvertUToF ||
-      opcode == spv::Op::OpNot || opcode == spv::Op::OpSNegate) {
-    if (isLitTypeOrVecOfLitType(argType) &&
-        !isLitTypeOrVecOfLitType(resultType)) {
-      const uint32_t resultTypeBitwidth = getElementSpirvBitwidth(
-          astContext, resultType, spvOptions.enable16BitTypes);
-      const QualType newType =
-          getTypeWithCustomBitwidth(astContext, argType, resultTypeBitwidth);
-      tryToUpdateInstLitType(arg, newType);
-      return true;
-    }
+  if (!isLitTypeOrVecOfLitType(argType)) {
+    return true;
+  }
+  if (isLitTypeOrVecOfLitType(resultType)) {
+    return true;
   }
 
-  // In all other cases, try to use the result type as a hint.
-  tryToUpdateInstLitType(arg, resultType);
-  return true;
+  switch (opcode) {
+  case spv::Op::OpUConvert:
+  case spv::Op::OpSConvert:
+  case spv::Op::OpFConvert:
+    // The result type gives us no information about the operand type. Do not do
+    // anything.
+    return true;
+  case spv::Op::OpConvertFToU:
+  case spv::Op::OpConvertFToS:
+  case spv::Op::OpConvertSToF:
+  case spv::Op::OpConvertUToF:
+  case spv::Op::OpNot:
+  case spv::Op::OpBitcast:
+  case spv::Op::OpSNegate: {
+    // The cases can change the type, but not the bitwidth. We can use the
+    // result type's bitwidth and the operand's type.
+    const uint32_t resultTypeBitwidth = getElementSpirvBitwidth(
+        astContext, resultType, spvOptions.enable16BitTypes);
+    const QualType newType =
+        getTypeWithCustomBitwidth(astContext, argType, resultTypeBitwidth);
+    tryToUpdateInstLitType(arg, newType);
+    return true;
+  }
+  default:
+    // In all other cases, try to set the operand type to the result type.
+    tryToUpdateInstLitType(arg, resultType);
+    return true;
+  }
 }
 
 bool LiteralTypeVisitor::visit(SpirvBinaryOp *inst) {

--- a/tools/clang/test/CodeGenSPIRV/select.long.lit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/select.long.lit.hlsl
@@ -1,6 +1,7 @@
 // RUN: %dxc -T ps_6_0 -HV 2018 -E main
 
-// the literal type.
+// Check that the literals get a 64-bit type, and the result of the select is
+// then cast to an unsigned 64-bit value.
 void foo(uint x) {
   // CHECK: %foo = OpFunction
   // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64
@@ -9,6 +10,10 @@ void foo(uint x) {
   uint64_t value = x < 64 ? 1 : 0;
 }
 
+// Check that the literals get a 64-bit type, and the result of the select is
+// then cast to an signed 64-bit value. Note that the bitcast is redundant in
+// this case, but we add the bitcast before the type of the literal has been
+// determined, so we add it anyway.
 void bar(uint x) {
   // CHECK: %bar = OpFunction
   // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64

--- a/tools/clang/test/CodeGenSPIRV/select.long.lit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/select.long.lit.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_0 -HV 2018 -E main
+
+// the literal type.
+void foo(uint x) {
+  // CHECK: %foo = OpFunction
+  // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64
+  // CHECK: [[result:%\d+]] = OpSelect %long [[cond]] %long_1 %long_0
+  // CHECK: {{%\d+}} = OpBitcast %ulong [[result]]
+  uint64_t value = x < 64 ? 1 : 0;
+}
+
+void bar(uint x) {
+  // CHECK: %bar = OpFunction
+  // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64
+  // CHECK: [[result:%\d+]] = OpSelect %long [[cond]] %long_1 %long_0
+  // CHECK: {{%\d+}} = OpBitcast %long [[result]]
+  int64_t value = x < 64 ? 1 : 0;
+}
+
+void main() {
+  uint value;
+  foo(2);
+  bar(2);
+}

--- a/tools/clang/test/CodeGenSPIRV/select.short.lit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/select.short.lit.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T ps_6_2 -HV 2018 -E main -enable-16bit-types
+
+// Check that the literals get a 16-bit type, and the result of the select is
+// then cast to an unsigned 16-bit value.
+void foo(uint x) {
+  // CHECK: %foo = OpFunction
+  // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64
+  // CHECK: [[result:%\d+]] = OpSelect %short [[cond]] %short_1 %short_0
+  // CHECK: {{%\d+}} = OpBitcast %ushort [[result]]
+  uint16_t value = x < 64 ? 1 : 0;
+}
+
+// Check that the literals get a 16-bit type, and the result of the select is
+// then cast to an signed 16-bit value. Note that the bitcast is redundant in
+// this case, but we add the bitcast before the type of the literal has been
+// determined, so we add it anyway.
+void bar(uint x) {
+  // CHECK: %bar = OpFunction
+  // CHECK: [[cond:%\d+]] = OpULessThan %bool {{%\d+}} %uint_64
+  // CHECK: [[result:%\d+]] = OpSelect %short [[cond]] %short_1 %short_0
+  // CHECK: {{%\d+}} = OpBitcast %short [[result]]
+  int16_t value = x < 64 ? 1 : 0;
+}
+
+void main() {
+  uint value;
+  foo(2);
+  bar(2);
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -552,6 +552,7 @@ TEST_F(FileTest, CastLiteralTypeForTernary) {
 }
 
 TEST_F(FileTest, SelectLongLit) { runFileTest("select.long.lit.hlsl"); }
+TEST_F(FileTest, SelectShortLit) { runFileTest("select.short.lit.hlsl"); }
 
 TEST_F(FileTest, CastLiteralTypeForTernary2021) {
   runFileTest("cast.literal-type.ternary.2021.hlsl");

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -551,6 +551,8 @@ TEST_F(FileTest, CastLiteralTypeForTernary) {
   runFileTest("cast.literal-type.ternary.hlsl");
 }
 
+TEST_F(FileTest, SelectLongLit) { runFileTest("select.long.lit.hlsl"); }
+
 TEST_F(FileTest, CastLiteralTypeForTernary2021) {
   runFileTest("cast.literal-type.ternary.2021.hlsl");
 }


### PR DESCRIPTION
For a BitCast instruction, the bitwidth of the operand must be the same
as the bitwidth of the result type. That requirement is coded into the
LiteralTypeVisitor, so that we do not get validation errors.

Fixes #5319.
