### PR TITLE
[NFC] Cherry-picking some changes to prepare for ReverseIterator support

### DIFF
--- a/include/llvm/ADT/SmallPtrSet.h
+++ b/include/llvm/ADT/SmallPtrSet.h
@@ -158,6 +158,12 @@ protected:
 
   void CopyFrom(const SmallPtrSetImplBase &RHS);
   void MoveFrom(unsigned SmallSize, SmallPtrSetImplBase &&RHS);
+
+private:
+  /// Code shared by MoveFrom() and move constructor.
+  void MoveHelper(unsigned SmallSize, SmallPtrSetImplBase &&RHS);
+  /// Code shared by CopyFrom() and copy constructor.
+  void CopyHelper(const SmallPtrSetImplBase &RHS);
 };
 
 /// SmallPtrSetIteratorImpl - This is the common base class shared between all

--- a/include/llvm/ADT/SmallPtrSet.h
+++ b/include/llvm/ADT/SmallPtrSet.h
@@ -101,7 +101,23 @@ protected:
   /// insert_imp - This returns true if the pointer was new to the set, false if
   /// it was already in the set.  This is hidden from the client so that the
   /// derived class can check that the right type of pointer is passed in.
-  std::pair<const void *const *, bool> insert_imp(const void *Ptr);
+  std::pair<const void *const *, bool> insert_imp(const void *Ptr) {
+    if (isSmall()) {
+      // Check to see if it is already in the set.
+      for (const void **APtr = SmallArray, **E = SmallArray+NumElements;
+           APtr != E; ++APtr)
+        if (*APtr == Ptr)
+          return std::make_pair(APtr, false);
+
+      // Nope, there isn't.  If we stay small, just 'pushback' now.
+      if (NumElements < CurArraySize) {
+        SmallArray[NumElements++] = Ptr;
+        return std::make_pair(SmallArray + (NumElements - 1), true);
+      }
+      // Otherwise, hit the big set case, which will call grow.
+    }
+    return insert_imp_big(Ptr);
+  }
 
   /// erase_imp - If the set contains the specified pointer, remove it and
   /// return true, otherwise return false.  This is hidden from the client so
@@ -125,6 +141,8 @@ protected:
 
 private:
   bool isSmall() const { return CurArray == SmallArray; }
+
+  std::pair<const void *const *, bool> insert_imp_big(const void *Ptr);
 
   const void * const *FindBucketFor(const void *Ptr) const;
   void shrink_and_clear();

--- a/lib/Support/SmallPtrSet.cpp
+++ b/lib/Support/SmallPtrSet.cpp
@@ -35,22 +35,7 @@ void SmallPtrSetImplBase::shrink_and_clear() {
 }
 
 std::pair<const void *const *, bool>
-SmallPtrSetImplBase::insert_imp(const void *Ptr) {
-  if (isSmall()) {
-    // Check to see if it is already in the set.
-    for (const void **APtr = SmallArray, **E = SmallArray+NumElements;
-         APtr != E; ++APtr)
-      if (*APtr == Ptr)
-        return std::make_pair(APtr, false);
-
-    // Nope, there isn't.  If we stay small, just 'pushback' now.
-    if (NumElements < CurArraySize) {
-      SmallArray[NumElements++] = Ptr;
-      return std::make_pair(SmallArray + (NumElements - 1), true);
-    }
-    // Otherwise, hit the big set case, which will call grow.
-  }
-
+SmallPtrSetImplBase::insert_imp_big(const void *Ptr) {
   if (LLVM_UNLIKELY(NumElements * 4 >= CurArraySize * 3)) {
     // If more than 3/4 of the array is full, grow.
     Grow(CurArraySize < 64 ? 128 : CurArraySize*2);


### PR DESCRIPTION
There are a number of changes required to get ReverseIterator support into DXC. Rather than attempting to do it all as one large PR, it makes more sense to break it up into smaller PRs of 2-3 changes.

These first two are just some small refactoring in the SmallPtrSet classes and should not change any behavior.

There was one small change in the DXC codebase that was necessary to bring forward which deviates from the original cherry-pick slightly (will mark it in a comment).