### PR TITLE
[lit] Pass the USERPROFILE variable through on Windows

### DIFF
--- a/utils/lit/lit/TestingConfig.py
+++ b/utils/lit/lit/TestingConfig.py
@@ -53,6 +53,7 @@ class TestingConfig:
                     'INCLUDE' : os.environ.get('INCLUDE',''),
                     'PATHEXT' : os.environ.get('PATHEXT',''),
                     'PYTHONUNBUFFERED' : '1',
+                    'USERPROFILE' : os.environ.get('USERPROFILE',''),
                     'TEMP' : os.environ.get('TEMP',''),
                     'TMP' : os.environ.get('TMP',''),
                     })


### PR DESCRIPTION
This is to fix the failure when running hcttest inside docker image.

Upstream PR is in
https://github.com/llvm/llvm-project/commit/9de63b2e051cb3e79645cc20b83b4d33d132cba0