### PR TITLE
Fixes to build with C++20

### DIFF
--- a/include/llvm/ADT/ilist.h
+++ b/include/llvm/ADT/ilist.h
@@ -248,20 +248,20 @@ void operator+(ilist_iterator<T>,int) = delete;
 
 // operator!=/operator== - Allow mixed comparisons without dereferencing
 // the iterator, which could very likely be pointing to end().
-template<typename T>
-bool operator!=(const T* LHS, const ilist_iterator<const T> &RHS) {
+template<typename T, typename U>
+bool operator!=(const T* LHS, const ilist_iterator<const U> &RHS) {
   return LHS != RHS.getNodePtrUnchecked();
 }
-template<typename T>
-bool operator==(const T* LHS, const ilist_iterator<const T> &RHS) {
+template<typename T, typename U>
+bool operator==(const T* LHS, const ilist_iterator<const U> &RHS) {
   return LHS == RHS.getNodePtrUnchecked();
 }
-template<typename T>
-bool operator!=(T* LHS, const ilist_iterator<T> &RHS) {
+template<typename T, typename U>
+bool operator!=(T* LHS, const ilist_iterator<U> &RHS) {
   return LHS != RHS.getNodePtrUnchecked();
 }
-template<typename T>
-bool operator==(T* LHS, const ilist_iterator<T> &RHS) {
+template<typename T, typename U>
+bool operator==(T* LHS, const ilist_iterator<U> &RHS) {
   return LHS == RHS.getNodePtrUnchecked();
 }
 

--- a/include/llvm/ADT/ilist.h
+++ b/include/llvm/ADT/ilist.h
@@ -248,6 +248,7 @@ void operator+(ilist_iterator<T>,int) = delete;
 
 // operator!=/operator== - Allow mixed comparisons without dereferencing
 // the iterator, which could very likely be pointing to end().
+// HLSL Change Begin: Support for C++20
 template<typename T, typename U>
 bool operator!=(const T* LHS, const ilist_iterator<const U> &RHS) {
   return LHS != RHS.getNodePtrUnchecked();
@@ -264,6 +265,7 @@ template<typename T, typename U>
 bool operator==(T* LHS, const ilist_iterator<U> &RHS) {
   return LHS == RHS.getNodePtrUnchecked();
 }
+// HLSL Change End
 
 
 // Allow ilist_iterators to convert into pointers to a node automatically when

--- a/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables_FragmentIterator.cpp
@@ -212,8 +212,7 @@ private:
   };
   std::vector<FragmentSizeAndOffset> m_fragmentLocations;
   unsigned m_currentFragment = 0;
-  void CompositeTypeFragmentIterator::DetermineStructMemberSizesAndOffsets(
-    llvm::DIType const*, uint64_t BaseOffset);
+  void DetermineStructMemberSizesAndOffsets(llvm::DIType const*, uint64_t BaseOffset);
 };
 
 unsigned SizeIfBaseType(llvm::DIType const* diType)

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -40,7 +40,7 @@ namespace hlsl_symbols {
 
 // HLSL Symbol Hierarchy
 // ---- ------ ---------
-// 
+//
 //                                  +---------------+
 //                                  | Program (EXE) |                                   Global Scope
 //                                  +------+--------+
@@ -50,14 +50,14 @@ namespace hlsl_symbols {
 //                                +--------+-----------+
 //                                         |
 //      +------------+------------+--------+-------+------------+--------------+
-//      |            |            |        |       |            |              |        
+//      |            |            |        |       |            |              |
 // +----^----+   +---^---+   +----^---+    |   +---^---+   +----^----+   +-----^-----+
 // | Details |   | Flags |   | Target |    |   | Entry |   | Defines |   | Arguments |  Synthetic Symbols
 // +---------+   +-------+   +--------+    |   +-------+   +---------+   +-----------+
 //                                         |
 //                                         |
 //       +---------------+------------+----+-----+-------------+-----------+
-//       |               |            |          |             |           | 
+//       |               |            |          |             |           |
 // +-----^-----+   +-----^-----+   +--^--+   +---^--+      +---^--+     +--^--+
 // | Function0 |   | Function1 |   | ... |   | UDT0 |      | UDT1 |     | ... |         Source Symbols
 // +-----+-----+   +-----+-----+   +-----+   +---+--+      +---+--+     +-----+
@@ -111,14 +111,14 @@ struct TypedSymbol : public DISymbol<N> {
     if (ppRetVal == nullptr) {
       return E_INVALIDARG;
     }
-    *ppRetVal = false;
+    *ppRetVal = nullptr;
 
     if (m_pType == nullptr) {
       return S_FALSE;
     }
 
     Symbol *ret;
-    IFR(m_pSession->SymMgr().GetSymbolByID(m_dwTypeID, &ret));
+    IFR(this->m_pSession->SymMgr().GetSymbolByID(m_dwTypeID, &ret));
 
     *ppRetVal = ret;
     return S_OK;
@@ -975,7 +975,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::VectorTypeSymbol::get_type(
   if (ppRetVal == nullptr) {
     return E_INVALIDARG;
   }
-  *ppRetVal = false;
+  *ppRetVal = nullptr;
 
   Symbol *ret;
   IFR(m_pSession->SymMgr().GetSymbolByID(m_ElemTyID, &ret));
@@ -1570,7 +1570,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(DWORD dwP
   } else {
     for (llvm::DINode *N : CT->getElements()) {
       if (auto *Field = llvm::dyn_cast<llvm::DIType>(N)) {
-        std::unique_ptr<UDTScope> UDTScopeOverride; 
+        std::unique_ptr<UDTScope> UDTScopeOverride;
         if (Field->isStaticMember()) {
           // Static members do not contribute to sizes or offsets.
           UDTScopeOverride.reset(new UDTScope(&m_pCurUDT, nullptr));


### PR DESCRIPTION
Add another template typename for pointer <-> ilist_iterator comparison operators. C++20 considers these ambiguous for the same reasons outlined in https://github.com/godotengine/godot/issues/54058

The rest of the changes are general bug fixes which are now caught by the compiler.