### PR TITLE
Error out if two blobs compiled with different compiler versions are linked

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -229,16 +229,16 @@ public:
 
   std::vector<std::string> Warnings;
 
-  bool IsRootSignatureProfile();
-  bool IsLibraryProfile();
+  bool IsRootSignatureProfile() const;
+  bool IsLibraryProfile() const;
 
   // Helpers to clarify interpretation of flags for behavior in implementation
-  bool GenerateFullDebugInfo(); // Zi
-  bool GeneratePDB();           // Zi or Zs
-  bool EmbedDebugInfo();        // Qembed_debug
-  bool EmbedPDBName();          // Zi or Fd
-  bool DebugFileIsDirectory();  // Fd ends in '\\'
-  llvm::StringRef GetPDBName(); // Fd name
+  bool GenerateFullDebugInfo() const; // Zi
+  bool GeneratePDB() const;           // Zi or Zs
+  bool EmbedDebugInfo() const;        // Qembed_debug
+  bool EmbedPDBName() const;          // Zi or Fd
+  bool DebugFileIsDirectory() const;  // Fd ends in '\\'
+  llvm::StringRef GetPDBName() const; // Fd name
 
   // SPIRV Change Starts
 #ifdef ENABLE_SPIRV_CODEGEN

--- a/include/llvm/ADT/SmallPtrSet.h
+++ b/include/llvm/ADT/SmallPtrSet.h
@@ -57,36 +57,41 @@ protected:
   /// CurArraySize - The allocated size of CurArray, always a power of two.
   unsigned CurArraySize;
 
-  // If small, this is # elts allocated consecutively
-  unsigned NumElements;
+  /// Number of elements in CurArray that contain a value or are a tombstone.
+  /// If small, all these elements are at the beginning of CurArray and the rest
+  /// is uninitialized.
+  unsigned NumNonEmpty;
+  /// Number of tombstones in CurArray.
   unsigned NumTombstones;
 
   // Helpers to copy and move construct a SmallPtrSet.
   SmallPtrSetImplBase(const void **SmallStorage, const SmallPtrSetImplBase &that);
   SmallPtrSetImplBase(const void **SmallStorage, unsigned SmallSize,
-                  SmallPtrSetImplBase &&that);
-  explicit SmallPtrSetImplBase(const void **SmallStorage, unsigned SmallSize) :
-    SmallArray(SmallStorage), CurArray(SmallStorage), CurArraySize(SmallSize) {
+                      SmallPtrSetImplBase &&that);
+  explicit SmallPtrSetImplBase(const void **SmallStorage, unsigned SmallSize)
+      : SmallArray(SmallStorage), CurArray(SmallStorage),
+        CurArraySize(SmallSize), NumNonEmpty(0), NumTombstones(0) {
     assert(SmallSize && (SmallSize & (SmallSize-1)) == 0 &&
            "Initial size must be a power of two!");
-    clear();
   }
   ~SmallPtrSetImplBase();
 
 public:
   typedef unsigned size_type;
   bool LLVM_ATTRIBUTE_UNUSED_RESULT empty() const { return size() == 0; }
-  size_type size() const { return NumElements; }
+  size_type size() const { return NumNonEmpty - NumTombstones; }
 
   void clear() {
     // If the capacity of the array is huge, and the # elements used is small,
     // shrink the array.
-    if (!isSmall() && NumElements*4 < CurArraySize && CurArraySize > 32)
-      return shrink_and_clear();
+    if (!isSmall()) {
+      if (size() * 4 < CurArraySize && CurArraySize > 32)
+        return shrink_and_clear();
+      // Fill the array with empty markers.
+      memset(CurArray, -1, CurArraySize * sizeof(void *));
+    }
 
-    // Fill the array with empty markers.
-    memset(CurArray, -1, CurArraySize*sizeof(void*));
-    NumElements = 0;
+    NumNonEmpty = 0;
     NumTombstones = 0;
   }
 
@@ -98,21 +103,37 @@ protected:
     return reinterpret_cast<void*>(-1);
   }
 
+  const void **EndPointer() const {
+    return isSmall() ? CurArray + NumNonEmpty : CurArray + CurArraySize;
+  }
+
   /// insert_imp - This returns true if the pointer was new to the set, false if
   /// it was already in the set.  This is hidden from the client so that the
   /// derived class can check that the right type of pointer is passed in.
   std::pair<const void *const *, bool> insert_imp(const void *Ptr) {
     if (isSmall()) {
       // Check to see if it is already in the set.
-      for (const void **APtr = SmallArray, **E = SmallArray+NumElements;
-           APtr != E; ++APtr)
-        if (*APtr == Ptr)
+      const void **LastTombstone = nullptr;
+      for (const void **APtr = SmallArray, **E = SmallArray + NumNonEmpty;
+           APtr != E; ++APtr) {
+        const void *Value = *APtr;
+        if (Value == Ptr)
           return std::make_pair(APtr, false);
+        if (Value == getTombstoneMarker())
+          LastTombstone = APtr;
+      }
+
+      // Did we find any tombstone marker?
+      if (LastTombstone != nullptr) {
+        *LastTombstone = Ptr;
+        --NumTombstones;
+        return std::make_pair(LastTombstone, true);
+      }
 
       // Nope, there isn't.  If we stay small, just 'pushback' now.
-      if (NumElements < CurArraySize) {
-        SmallArray[NumElements++] = Ptr;
-        return std::make_pair(SmallArray + (NumElements - 1), true);
+      if (NumNonEmpty < CurArraySize) {
+        SmallArray[NumNonEmpty++] = Ptr;
+        return std::make_pair(SmallArray + (NumNonEmpty - 1), true);
       }
       // Otherwise, hit the big set case, which will call grow.
     }
@@ -129,7 +150,7 @@ protected:
     if (isSmall()) {
       // Linear search for the item.
       for (const void *const *APtr = SmallArray,
-                      *const *E = SmallArray+NumElements; APtr != E; ++APtr)
+                      *const *E = SmallArray + NumNonEmpty; APtr != E; ++APtr)
         if (*APtr == Ptr)
           return true;
       return false;
@@ -287,7 +308,7 @@ public:
   /// the element equal to Ptr.
   std::pair<iterator, bool> insert(PtrType Ptr) {
     auto p = insert_imp(PtrTraits::getAsVoidPointer(Ptr));
-    return std::make_pair(iterator(p.first, CurArray + CurArraySize), p.second);
+    return std::make_pair(iterator(p.first, EndPointer()), p.second);
   }
 
   /// erase - If the set contains the specified pointer, remove it and return
@@ -308,10 +329,11 @@ public:
   }
 
   inline iterator begin() const {
-    return iterator(CurArray, CurArray+CurArraySize);
+    return iterator(CurArray, EndPointer());
   }
   inline iterator end() const {
-    return iterator(CurArray+CurArraySize, CurArray+CurArraySize);
+    const void *const *End = EndPointer();
+    return iterator(End, End);
   }
 };
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -130,36 +130,36 @@ void DxcDefines::BuildDefines() {
   }
 }
 
-bool DxcOpts::IsRootSignatureProfile() {
+bool DxcOpts::IsRootSignatureProfile() const {
   return TargetProfile == "rootsig_1_0" ||
       TargetProfile == "rootsig_1_1";
 }
 
-bool DxcOpts::IsLibraryProfile() {
+bool DxcOpts::IsLibraryProfile() const {
   return TargetProfile.startswith("lib_");
 }
 
-bool DxcOpts::GenerateFullDebugInfo() {
+bool DxcOpts::GenerateFullDebugInfo() const {
   return DebugInfo;
 }
 
-bool DxcOpts::GeneratePDB() {
+bool DxcOpts::GeneratePDB() const {
   return DebugInfo || SourceOnlyDebug;
 }
 
-bool DxcOpts::EmbedDebugInfo() {
+bool DxcOpts::EmbedDebugInfo() const {
   return EmbedDebug;
 }
 
-bool DxcOpts::EmbedPDBName() {
+bool DxcOpts::EmbedPDBName() const {
   return GeneratePDB() || !DebugFile.empty();
 }
 
-bool DxcOpts::DebugFileIsDirectory() {
+bool DxcOpts::DebugFileIsDirectory() const {
   return !DebugFile.empty() && llvm::sys::path::is_separator(DebugFile[DebugFile.size() - 1]);
 }
 
-llvm::StringRef DxcOpts::GetPDBName() {
+llvm::StringRef DxcOpts::GetPDBName() const {
   if (!DebugFileIsDirectory())
     return DebugFile;
   return llvm::StringRef();

--- a/lib/Support/SmallPtrSet.cpp
+++ b/lib/Support/SmallPtrSet.cpp
@@ -25,8 +25,9 @@ void SmallPtrSetImplBase::shrink_and_clear() {
   delete[] CurArray; // HLSL Change: Use overridable operator delete
 
   // Reduce the number of buckets.
-  CurArraySize = NumElements > 16 ? 1 << (Log2_32_Ceil(NumElements) + 1) : 32;
-  NumElements = NumTombstones = 0;
+  unsigned Size = size();
+  CurArraySize = Size > 16 ? 1 << (Log2_32_Ceil(Size) + 1) : 32;
+  NumNonEmpty = NumTombstones = 0;
 
   // Install the new array.  Clear all the buckets to empty.
   CurArray = new const void*[CurArraySize]; // HLSL Change: Use overridable operator new
@@ -36,11 +37,10 @@ void SmallPtrSetImplBase::shrink_and_clear() {
 
 std::pair<const void *const *, bool>
 SmallPtrSetImplBase::insert_imp_big(const void *Ptr) {
-  if (LLVM_UNLIKELY(NumElements * 4 >= CurArraySize * 3)) {
+  if (LLVM_UNLIKELY(size() * 4 >= CurArraySize * 3)) {
     // If more than 3/4 of the array is full, grow.
-    Grow(CurArraySize < 64 ? 128 : CurArraySize*2);
-  } else if (LLVM_UNLIKELY(CurArraySize - (NumElements + NumTombstones) <
-                           CurArraySize / 8)) {
+    Grow(CurArraySize < 64 ? 128 : CurArraySize * 2);
+  } else if (LLVM_UNLIKELY(CurArraySize - NumNonEmpty < CurArraySize / 8)) {
     // If fewer of 1/8 of the array is empty (meaning that many are filled with
     // tombstones), rehash.
     Grow(CurArraySize);
@@ -54,21 +54,21 @@ SmallPtrSetImplBase::insert_imp_big(const void *Ptr) {
   // Otherwise, insert it!
   if (*Bucket == getTombstoneMarker())
     --NumTombstones;
+  else
+    ++NumNonEmpty; // Track density.
   *Bucket = Ptr;
-  ++NumElements;  // Track density.
   return std::make_pair(Bucket, true);
 }
 
 bool SmallPtrSetImplBase::erase_imp(const void * Ptr) {
   if (isSmall()) {
     // Check to see if it is in the set.
-    for (const void **APtr = SmallArray, **E = SmallArray+NumElements;
-         APtr != E; ++APtr)
+    for (const void **APtr = CurArray, **E = CurArray + NumNonEmpty; APtr != E;
+         ++APtr)
       if (*APtr == Ptr) {
         // If it is in the set, replace this element.
-        *APtr = E[-1];
-        E[-1] = getEmptyMarker();
-        --NumElements;
+        *APtr = getTombstoneMarker();
+        ++NumTombstones;
         return true;
       }
     
@@ -81,7 +81,6 @@ bool SmallPtrSetImplBase::erase_imp(const void * Ptr) {
 
   // Set this as a tombstone.
   *Bucket = getTombstoneMarker();
-  --NumElements;
   ++NumTombstones;
   return true;
 }
@@ -116,10 +115,8 @@ const void * const *SmallPtrSetImplBase::FindBucketFor(const void *Ptr) const {
 /// Grow - Allocate a larger backing store for the buckets and move it over.
 ///
 void SmallPtrSetImplBase::Grow(unsigned NewSize) {
-  // Allocate at twice as many buckets, but at least 128.
-  unsigned OldSize = CurArraySize;
-  
   const void **OldBuckets = CurArray;
+  const void **OldEnd = EndPointer();
   bool WasSmall = isSmall();
   
   // Install the new array.  Clear all the buckets to empty.
@@ -127,28 +124,19 @@ void SmallPtrSetImplBase::Grow(unsigned NewSize) {
   assert(CurArray && "Failed to allocate memory?");
   CurArraySize = NewSize;
   memset(CurArray, -1, NewSize*sizeof(void*));
-  
-  // Copy over all the elements.
-  if (WasSmall) {
-    // Small sets store their elements in order.
-    for (const void **BucketPtr = OldBuckets, **E = OldBuckets+NumElements;
-         BucketPtr != E; ++BucketPtr) {
-      const void *Elt = *BucketPtr;
+
+  // Copy over all valid entries.
+  for (const void **BucketPtr = OldBuckets; BucketPtr != OldEnd; ++BucketPtr) {
+    // Copy over the element if it is valid.
+    const void *Elt = *BucketPtr;
+    if (Elt != getTombstoneMarker() && Elt != getEmptyMarker())
       *const_cast<void**>(FindBucketFor(Elt)) = const_cast<void*>(Elt);
-    }
-  } else {
-    // Copy over all valid entries.
-    for (const void **BucketPtr = OldBuckets, **E = OldBuckets+OldSize;
-         BucketPtr != E; ++BucketPtr) {
-      // Copy over the element if it is valid.
-      const void *Elt = *BucketPtr;
-      if (Elt != getTombstoneMarker() && Elt != getEmptyMarker())
-        *const_cast<void**>(FindBucketFor(Elt)) = const_cast<void*>(Elt);
-    }
-    
-    delete[] OldBuckets; // HLSL Change: Use overridable operator delete
-    NumTombstones = 0;
   }
+
+  if (!WasSmall)
+    delete [] OldBuckets;
+  NumNonEmpty -= NumTombstones;
+  NumTombstones = 0;
 }
 
 SmallPtrSetImplBase::SmallPtrSetImplBase(const void **SmallStorage,
@@ -210,9 +198,9 @@ void SmallPtrSetImplBase::CopyHelper(const SmallPtrSetImplBase &RHS) {
   CurArraySize = RHS.CurArraySize;
 
   // Copy over the contents from the other set
-  memcpy(CurArray, RHS.CurArray, sizeof(void*)*CurArraySize);
-  
-  NumElements = RHS.NumElements;
+  std::copy(RHS.CurArray, RHS.EndPointer(), CurArray);
+
+  NumNonEmpty = RHS.NumNonEmpty;
   NumTombstones = RHS.NumTombstones;
 }
 
@@ -230,7 +218,7 @@ void SmallPtrSetImplBase::MoveHelper(unsigned SmallSize,
   if (RHS.isSmall()) {
     // Copy a small RHS rather than moving.
     CurArray = SmallArray;
-    memcpy(CurArray, RHS.CurArray, sizeof(void*)*RHS.CurArraySize);
+    std::copy(RHS.CurArray, RHS.CurArray + RHS.NumNonEmpty, CurArray);
   } else {
     CurArray = RHS.CurArray;
     RHS.CurArray = RHS.SmallArray;
@@ -238,13 +226,13 @@ void SmallPtrSetImplBase::MoveHelper(unsigned SmallSize,
 
   // Copy the rest of the trivial members.
   CurArraySize = RHS.CurArraySize;
-  NumElements = RHS.NumElements;
+  NumNonEmpty = RHS.NumNonEmpty;
   NumTombstones = RHS.NumTombstones;
 
   // Make the RHS small and empty.
   RHS.CurArraySize = SmallSize;
   assert(RHS.CurArray == RHS.SmallArray);
-  RHS.NumElements = 0;
+  RHS.NumNonEmpty = 0;
   RHS.NumTombstones = 0;
 }
 
@@ -255,7 +243,7 @@ void SmallPtrSetImplBase::swap(SmallPtrSetImplBase &RHS) {
   if (!this->isSmall() && !RHS.isSmall()) {
     std::swap(this->CurArray, RHS.CurArray);
     std::swap(this->CurArraySize, RHS.CurArraySize);
-    std::swap(this->NumElements, RHS.NumElements);
+    std::swap(this->NumNonEmpty, RHS.NumNonEmpty);
     std::swap(this->NumTombstones, RHS.NumTombstones);
     return;
   }
@@ -265,37 +253,46 @@ void SmallPtrSetImplBase::swap(SmallPtrSetImplBase &RHS) {
   // If only RHS is small, copy the small elements into LHS and move the pointer
   // from LHS to RHS.
   if (!this->isSmall() && RHS.isSmall()) {
-    std::copy(RHS.SmallArray, RHS.SmallArray+RHS.CurArraySize,
-              this->SmallArray);
-    std::swap(this->NumElements, RHS.NumElements);
-    std::swap(this->CurArraySize, RHS.CurArraySize);
+    assert(RHS.CurArray == RHS.SmallArray);
+    std::copy(RHS.CurArray, RHS.CurArray + RHS.NumNonEmpty, this->SmallArray);
+    std::swap(RHS.CurArraySize, this->CurArraySize);
+    std::swap(this->NumNonEmpty, RHS.NumNonEmpty);
+    std::swap(this->NumTombstones, RHS.NumTombstones);
     RHS.CurArray = this->CurArray;
-    RHS.NumTombstones = this->NumTombstones;
     this->CurArray = this->SmallArray;
-    this->NumTombstones = 0;
     return;
   }
 
   // If only LHS is small, copy the small elements into RHS and move the pointer
   // from RHS to LHS.
   if (this->isSmall() && !RHS.isSmall()) {
-    std::copy(this->SmallArray, this->SmallArray+this->CurArraySize,
+    assert(this->CurArray == this->SmallArray);
+    std::copy(this->CurArray, this->CurArray + this->NumNonEmpty,
               RHS.SmallArray);
-    std::swap(RHS.NumElements, this->NumElements);
     std::swap(RHS.CurArraySize, this->CurArraySize);
+    std::swap(RHS.NumNonEmpty, this->NumNonEmpty);
+    std::swap(RHS.NumTombstones, this->NumTombstones);
     this->CurArray = RHS.CurArray;
-    this->NumTombstones = RHS.NumTombstones;
     RHS.CurArray = RHS.SmallArray;
-    RHS.NumTombstones = 0;
     return;
   }
 
   // Both a small, just swap the small elements.
   assert(this->isSmall() && RHS.isSmall());
-  assert(this->CurArraySize == RHS.CurArraySize);
-  std::swap_ranges(this->SmallArray, this->SmallArray+this->CurArraySize,
+  unsigned MinNonEmpty = std::min(this->NumNonEmpty, RHS.NumNonEmpty);
+  std::swap_ranges(this->SmallArray, this->SmallArray + MinNonEmpty,
                    RHS.SmallArray);
-  std::swap(this->NumElements, RHS.NumElements);
+  if (this->NumNonEmpty > MinNonEmpty) {
+    std::copy(this->SmallArray + MinNonEmpty,
+              this->SmallArray + this->NumNonEmpty,
+              RHS.SmallArray + MinNonEmpty);
+  } else {
+    std::copy(RHS.SmallArray + MinNonEmpty, RHS.SmallArray + RHS.NumNonEmpty,
+              this->SmallArray + MinNonEmpty);
+  }
+  assert(this->CurArraySize == RHS.CurArraySize);
+  std::swap(this->NumNonEmpty, RHS.NumNonEmpty);
+  std::swap(this->NumTombstones, RHS.NumTombstones);
 }
 
 SmallPtrSetImplBase::~SmallPtrSetImplBase() {

--- a/tools/clang/test/CodeGenSPIRV/type.struct.empty-struct.array-stride.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.struct.empty-struct.array-stride.hlsl
@@ -1,4 +1,4 @@
-// Run: %dxc -T ps_6_0 -E main -O0
+// RUN: %dxc -T ps_6_0 -E main -O0
 
 // CHECK: OpDecorate %_arr__struct_12_uint_2 ArrayStride 16
 

--- a/tools/clang/tools/dxcompiler/dxclinker.cpp
+++ b/tools/clang/tools/dxcompiler/dxclinker.cpp
@@ -44,6 +44,48 @@ using namespace llvm;
 // This declaration is used for the locally-linked validator.
 HRESULT CreateDxcValidator(_In_ REFIID riid, _Out_ LPVOID *ppv);
 
+struct DeserializedDxilCompilerVersion {
+  const hlsl::DxilCompilerVersion DCV;
+  std::string commitHashStr;
+  std::string versionStr;
+
+  DeserializedDxilCompilerVersion(const DxilCompilerVersion *pDCV)
+      : DCV(*pDCV) {
+    // Assumes pDCV has been checked for safe parsing
+    if (pDCV->VersionStringListSizeInBytes) {
+      const char *pStr = (const char *)(pDCV + 1);
+      commitHashStr.assign(pStr);
+      if (commitHashStr.size() + 1 < pDCV->VersionStringListSizeInBytes)
+        versionStr.assign(pStr + commitHashStr.size() + 1);
+    }
+  }
+
+  DeserializedDxilCompilerVersion(DeserializedDxilCompilerVersion &&other)
+      : DCV(other.DCV), commitHashStr(std::move(other.commitHashStr)),
+        versionStr(std::move(other.versionStr)) {}
+
+  bool operator<(const DeserializedDxilCompilerVersion &rhs) const {
+    return std::tie(DCV.Major, DCV.Minor, DCV.CommitCount,
+                    DCV.VersionStringListSizeInBytes, commitHashStr,
+                    versionStr) < std::tie(rhs.DCV.Major, rhs.DCV.Minor,
+                                           rhs.DCV.CommitCount,
+                                           rhs.DCV.VersionStringListSizeInBytes,
+                                           rhs.commitHashStr, rhs.versionStr);
+  }
+
+  std::string display() const {
+    std::string ret;
+    ret += "Version(" + std::to_string(DCV.Major) + "." +
+           std::to_string(DCV.Minor) + ") ";
+    ret += "commits(" + std::to_string(DCV.CommitCount) + ") ";
+    ret += "sha(" + commitHashStr + ") ";
+    ret += "version string: \"" + versionStr + "\"";
+    ret += "\n";
+
+    return ret;
+  }
+};
+
 class DxcLinker : public IDxcLinker, public IDxcContainerEvent {
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
@@ -98,6 +140,33 @@ public:
     m_pLinker.reset(DxilLinker::CreateLinker(m_Ctx, valMajor, valMinor));
   }
 
+  bool AddCompilerVersionMapEntry(LPCWSTR libName,
+                                  const hlsl::DxilCompilerVersion *pDCV,
+                                  uint32_t partSize) {
+    // Make sure it's safe to parse pDCV
+    bool valid = pDCV && partSize >= sizeof(hlsl::DxilCompilerVersion) &&
+                 partSize - sizeof(hlsl::DxilCompilerVersion) >=
+                     pDCV->VersionStringListSizeInBytes;
+    if (valid && pDCV->VersionStringListSizeInBytes) {
+        const char *vStr = (const char *)(pDCV + 1);
+        valid = vStr[pDCV->VersionStringListSizeInBytes - 1] == 0;
+    }
+
+    DXASSERT(valid, "DxilCompilerVersion part malformed");
+    if (!valid)
+        return false;
+
+    CW2A pUtf8LibName(libName, CP_UTF8);
+    std::string libNameStr = std::string(pUtf8LibName);
+    m_uniqueCompilerVersions.insert(DeserializedDxilCompilerVersion(pDCV));
+    std::set<DeserializedDxilCompilerVersion>::iterator it =
+        m_uniqueCompilerVersions.find(DeserializedDxilCompilerVersion(pDCV));
+
+    m_libNameToCompilerVersionPart[libNameStr] = &(*it);
+
+    return true;
+  }
+
   ~DxcLinker() {
     // Make sure DxilLinker is released before LLVMContext.
     m_pLinker.reset();
@@ -109,6 +178,8 @@ private:
   std::unique_ptr<DxilLinker> m_pLinker;
   CComPtr<IDxcContainerEventsHandler> m_pDxcContainerEventsHandler;
   std::vector<CComPtr<IDxcBlob>> m_blobs; // Keep blobs live for lazy load.
+  std::map<std::string, const DeserializedDxilCompilerVersion*> m_libNameToCompilerVersionPart;
+  std::set<DeserializedDxilCompilerVersion> m_uniqueCompilerVersions;
 };
 
 HRESULT
@@ -140,6 +211,24 @@ DxcLinker::RegisterLibrary(_In_opt_ LPCWSTR pLibName, // Name of the library.
         pBlob->GetBufferPointer(), pBlob->GetBufferSize(), pModule,
         pDebugModule, m_Ctx, m_Ctx, DiagStream));
 
+
+    // add an entry into the library to compiler version part map
+    const hlsl::DxilContainerHeader *pHeader = hlsl::IsDxilContainerLike(
+        pBlob->GetBufferPointer(), pBlob->GetBufferSize());
+    const DxilPartHeader *pDPH = hlsl::GetDxilPartByType(
+        pHeader, hlsl::DxilFourCC::DFCC_CompilerVersion);
+    if (pDPH) {
+        hlsl::DxilCompilerVersion *pDCV =
+            (hlsl::DxilCompilerVersion *)(pDPH + 1);
+        // If the compiler version string is non-empty, add the struct to the
+        // map
+        bool success =
+            AddCompilerVersionMapEntry(pLibName, pDCV, pDPH->PartSize);
+        if (!success) {
+        return E_INVALIDARG;
+        }
+    }
+    
     if (m_pLinker->RegisterLib(pUtf8LibName.m_psz, std::move(pModule),
                                std::move(pDebugModule))) {
       m_blobs.emplace_back(pBlob);
@@ -229,13 +318,55 @@ HRESULT STDMETHODCALLTYPE DxcLinker::Link(
 
     // Attach libraries.
     bool bSuccess = true;
-    for (unsigned i = 0; i < libCount; i++) {
+    const DeserializedDxilCompilerVersion *cur_version = nullptr;
+    const DeserializedDxilCompilerVersion *first_version = nullptr;
+
+    std::string cur_lib_name;
+    std::string first_lib_name;
+
+    for (UINT32 i = 0; i < libCount; i++) {
       CW2A pUtf8LibName(pLibNames[i], CP_UTF8);
       bSuccess &= m_pLinker->AttachLib(pUtf8LibName.m_psz);
+
+      cur_lib_name = std::string(pUtf8LibName);
+
+      // only libraries with compiler version parts are in the map
+      auto result = m_libNameToCompilerVersionPart.find(cur_lib_name);
+
+      if (result != m_libNameToCompilerVersionPart.end()) {
+        cur_version = ((*result).second);
+      } else {
+        cur_version = nullptr;
+      }
+
+      if (i == 0) {
+        first_lib_name = cur_lib_name;
+        first_version = cur_version;
+      }
+
+      if (cur_version != first_version) {
+
+        std::string errorMsg = "error: Cannot link libraries with "
+                               "conflicting compiler versions.\n";
+
+        std::string firstErrorStr =
+            "note: library \"" + first_lib_name + "\" version: ";
+        firstErrorStr += first_version ? first_version->display()
+                                       : "No version info available";
+
+        std::string secondErrorStr =
+            "note: library \"" + cur_lib_name + "\" version: ";
+        secondErrorStr +=
+            cur_version ? cur_version->display() : "No version info available";
+
+        errorMsg += firstErrorStr + secondErrorStr;
+        DiagStream << errorMsg;
+        bSuccess = false;
+      }
     }
 
     dxilutil::ExportMap exportMap;
-    bSuccess = exportMap.ParseExports(opts.Exports, DiagStream);
+    bSuccess &= exportMap.ParseExports(opts.Exports, DiagStream);
 
     if (opts.ExportShadersOnly)
       exportMap.setExportShadersOnly(true);

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -21,6 +21,7 @@
 #include "WexTestClass.h"
 #include "dxc/Test/HlslTestUtils.h"
 #include "dxc/Test/DxcTestUtils.h"
+#include "dxc/Support/Global.h" // for IFT macro
 #include "dxc/dxcapi.h"
 #include "dxc/DxilContainer/DxilContainer.h"
 
@@ -40,6 +41,7 @@ public:
   TEST_CLASS_SETUP(InitSupport);
 
   TEST_METHOD(RunLinkResource);
+  TEST_METHOD(RunLinkModulesDifferentVersions);
   TEST_METHOD(RunLinkResourceWithBinding);
   TEST_METHOD(RunLinkAllProfiles);
   TEST_METHOD(RunLinkFailNoDefine);
@@ -158,14 +160,14 @@ public:
 
   void LinkCheckMsg(LPCWSTR pEntryName, LPCWSTR pShaderModel, IDxcLinker *pLinker,
             ArrayRef<LPCWSTR> libNames, llvm::ArrayRef<LPCSTR> pErrorMsgs,
-            llvm::ArrayRef<LPCWSTR> pArguments = {}) {
+            llvm::ArrayRef<LPCWSTR> pArguments = {}, bool bRegex=false) {
     CComPtr<IDxcOperationResult> pResult;
     VERIFY_SUCCEEDED(pLinker->Link(pEntryName, pShaderModel,
                                    libNames.data(), libNames.size(),
                                    pArguments.data(), pArguments.size(),
                                    &pResult));
     CheckOperationResultMsgs(pResult, pErrorMsgs.data(), pErrorMsgs.size(),
-                             false, false);
+                             false, bRegex);
   }
 };
 
@@ -272,6 +274,97 @@ TEST_F(LinkerTest, RunLinkAllProfiles) {
   LPCWSTR libResName = L"res";
   RegisterDxcModule(libResName, pResLib, pLinker);
   Link(L"cs_main", L"cs_6_0", pLinker, {libName, libResName}, {},{});
+}
+
+TEST_F(LinkerTest, RunLinkModulesDifferentVersions) {
+  CComPtr<IDxcLinker> pLinker1, pLinker2, pLinker3;
+  CreateLinker(&pLinker1);
+  CreateLinker(&pLinker2);
+  CreateLinker(&pLinker3);
+
+  LPCWSTR libName = L"entry";
+  LPCWSTR option[] = {L"-Zi", L"-Qembed_debug"};
+  CComPtr<IDxcBlob> pEntryLib;
+  CompileLib(L"..\\CodeGenHLSL\\lib_entries2.hlsl", &pEntryLib, option);
+
+  // the 2nd blob is the "good" blob that stays constant
+  CComPtr<IDxcBlob> pResLib;
+  CompileLib(L"..\\CodeGenHLSL\\lib_resource2.hlsl", &pResLib);
+  LPCWSTR libResName = L"res";
+
+  // modify the first compiled blob to force it to have a different compiler
+  // version
+  CComPtr<IDxcContainerReflection> containerReflection;
+  IFT(m_dllSupport.CreateInstance(CLSID_DxcContainerReflection,
+                                  &containerReflection));
+  IFT(containerReflection->Load(pEntryLib));
+  UINT part_index;
+  VERIFY_SUCCEEDED(containerReflection->FindFirstPartKind(
+      hlsl::DFCC_CompilerVersion, &part_index));
+  CComPtr<IDxcBlob> pBlob;
+  IFT(containerReflection->GetPartContent(part_index, &pBlob));
+  void *pBlobPtr = pBlob->GetBufferPointer();
+
+  std::string commonMismatchStr =
+      "error: Cannot link libraries with conflicting compiler versions.";
+
+  hlsl::DxilCompilerVersion *pDCV = (hlsl::DxilCompilerVersion *)pBlobPtr;
+  if (pDCV->VersionStringListSizeInBytes) {
+    // first just get both strings, the compiler version and the commit hash
+    char *pVersionStringListPtr =
+        (char *)pBlobPtr + sizeof(hlsl::DxilCompilerVersion);
+    std::string commitHashStr(pVersionStringListPtr);
+    std::string oldCommitHashStr = commitHashStr;
+    std::string compilerVersionStr(pVersionStringListPtr +
+                                   commitHashStr.size() + 1);
+    std::string oldCompilerVersionStr = compilerVersionStr;
+
+    // flip a character to change the commit hash
+    *pVersionStringListPtr = commitHashStr[0] == 'a' ? 'b' : 'a';
+    // store the modified compiler version part.
+    RegisterDxcModule(libName, pEntryLib, pLinker1);
+    // and the "good" version part
+    RegisterDxcModule(libResName, pResLib, pLinker1);
+    // 2 blobs with different compiler versions should not be linkable
+    LinkCheckMsg(L"hs_main", L"hs_6_1", pLinker1, {libName, libResName},
+                 {commonMismatchStr.c_str()});
+
+    // reset the modified part back to normal
+    *pVersionStringListPtr = oldCommitHashStr[0];
+
+    // flip a character to change the compiler version
+    *(pVersionStringListPtr + commitHashStr.size() + 1) =
+        compilerVersionStr[0] == '1' ? '2' : '1';
+    // store the modified compiler version part.
+    RegisterDxcModule(libName, pEntryLib, pLinker2);
+    // and the "good" version part
+    RegisterDxcModule(libResName, pResLib, pLinker2);
+    // 2 blobs with different compiler versions should not be linkable
+    LinkCheckMsg(L"hs_main", L"hs_6_1", pLinker2, {libName, libResName},
+                 {commonMismatchStr.c_str()});
+
+    // reset the modified part back to normal
+    *(pVersionStringListPtr + commitHashStr.size() + 1) =
+        oldCompilerVersionStr[0];
+  } else {
+    // not sure the blob can be changed by adding data, since the
+    // the data after this header could be a subsequent header.
+    // The test should announce that it can't make any version string
+    // modifications
+    WEX::Logging::Log::Warning(
+        "Cannot modify compiler version string for test");
+  }
+
+  // finally, test that a difference is detected if a member of the struct, say
+  // the major member, is different.
+  pDCV->Major = pDCV->Major == 2 ? 1 : 2;
+  // store the modified compiler version part.
+  RegisterDxcModule(libName, pEntryLib, pLinker3);
+  // and the "good" version part
+  RegisterDxcModule(libResName, pResLib, pLinker3);
+  // 2 blobs with different compiler versions should not be linkable
+  LinkCheckMsg(L"hs_main", L"hs_6_1", pLinker3, {libName, libResName},
+               {commonMismatchStr.c_str()});
 }
 
 TEST_F(LinkerTest, RunLinkFailNoDefine) {

--- a/unittests/ADT/DenseMapTest.cpp
+++ b/unittests/ADT/DenseMapTest.cpp
@@ -422,4 +422,14 @@ TEST(DenseMapCustomTest, SmallDenseMapGrowTest) {
   EXPECT_TRUE(map.find(32) == map.end());
 }
 
+TEST(DenseMapCustomTest, TryEmplaceTest) {
+  DenseMap<int, std::unique_ptr<int>> Map;
+  std::unique_ptr<int> P(new int(2));
+  auto Try1 = Map.try_emplace(0, new int(1));
+  EXPECT_TRUE(Try1.second);
+  auto Try2 = Map.try_emplace(0, std::move(P));
+  EXPECT_FALSE(Try2.second);
+  EXPECT_EQ(Try1.first, Try2.first);
+  EXPECT_NE(nullptr, P);
+}
 }


### PR DESCRIPTION
This PR aims to accomplish the final step of the task to prevent blobs compiled with different compiler versions from being linked together.
The same compiler is used to compile both blobs in the test, but the compilerversion part in the first blob is forcefully changed to conflict with the compilerversion part within the second blob.
The test detects the correct error message, which mentions the names of the two libraries that differ, and what their differing versions are exactly.
The PR aims to resolve this issue:
https://github.com/microsoft/DirectXShaderCompiler/issues/5310