### PR TITLE
Add -lit-xml-output-path option to hctbuild.cmd

### DIFF
--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -199,6 +199,11 @@ if "%1"=="-enable-lit" (
   set ENABLE_LIT=ON
   shift /1 & goto :parse_args
 )
+if "%1"=="-lit-xml-output-path" (
+  set "CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_LIT_ARGS=--xunit-xml-output=%~2"
+  shift /1
+  shift /1 & goto :parse_args
+)
 rem Begin SPIRV change
 if "%1"=="-spirv" (
   echo SPIR-V codegen is enabled.


### PR DESCRIPTION
This is used set a path that lit will use to write out an xml file containing the test results.

I had tried to reuse the existing `-dxc-cmake-extra-args` flag to set the output, but I ran into a lot of problems getting the arg value to parse correctly since it has embedded `=` signs that cmd treats as a command line separator the same as a space (we need to pass a value like `-DLLVM_LIT_ARGS=--xunit-xml-output=log.xml`). No combination of quotes and backslashes could get the arg value passed through correctly, so I opted for the direct route taken in this PR.