### PR TITLE
[lit] allow find git usr bin in path directly.

### DIFF
--- a/utils/lit/lit/TestingConfig.py
+++ b/utils/lit/lit/TestingConfig.py
@@ -64,7 +64,10 @@ class TestingConfig:
         if sys.platform == 'win32':
             required_tools = [
                 'cmp.exe', 'grep.exe', 'sed.exe', 'diff.exe', 'echo.exe', 'ls.exe']
-            path = _find_git_windows_unix_tools(required_tools)
+            path = lit.util.whichTools(required_tools, all_path)
+            if path is None:
+                path = _find_git_windows_unix_tools(required_tools)
+
             all_path = f"{path};{all_path}"
         environment = {
             'PATH' : all_path,


### PR DESCRIPTION
This is for case where git usr bin is not in winreg.