### PR TITLE
Update build artifact permissions

### DIFF
--- a/.github/workflows/coverage-gh-pages.yml
+++ b/.github/workflows/coverage-gh-pages.yml
@@ -41,7 +41,7 @@ jobs:
         run: ninja -C build check-all
       - name: Generate Report
         run: ninja -C build generate-coverage-report
-      - name: Force artificat permissions
+      - name: Force artifact permissions
         run: chmod -c -R +rX ${{github.workspace}}/build/report
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/.github/workflows/coverage-gh-pages.yml
+++ b/.github/workflows/coverage-gh-pages.yml
@@ -41,6 +41,8 @@ jobs:
         run: ninja -C build check-all
       - name: Generate Report
         run: ninja -C build generate-coverage-report
+      - name: Force artificat permissions
+        run: chmod -c -R +rX ${{github.workspace}}/build/report
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
I found other users reporting a similar issue:

https://github.com/actions/deploy-pages/issues/188

The root cause seems to be that the deploy-pages action changed to stop correcting permissions problems in the upload since it was slowing down deployment. The recommended fix is to set the permissions before uploading the artifact.

Let's see if this works.

Fixes #5376