### PR TITLE
Emit Offset decoration for PhysicalStorage structs

### DIFF
--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -32,6 +32,7 @@ enum class SpirvLayoutRule {
   FxcCTBuffer,       // fxc.exe layout rule for cbuffer/tbuffer
   FxcSBuffer,        // fxc.exe layout rule for structured buffers
   Scalar,            // VK_EXT_scalar_block_layout
+  Physical,          // SPV_EXT_physical_storage_buffer
   Max,               // This is an invalid layout rule
 };
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -264,13 +264,8 @@ const SpirvType *LowerTypeVisitor::lowerType(const SpirvType *type,
                                              SourceLocation loc) {
   if (const auto *hybridPointer = dyn_cast<HybridPointerType>(type)) {
     const QualType pointeeType = hybridPointer->getPointeeType();
-    SpirvLayoutRule layoutRule =
-        hybridPointer->getStorageClass() ==
-                spv::StorageClass::PhysicalStorageBuffer
-            ? SpirvLayoutRule::Physical
-            : rule;
     const SpirvType *pointeeSpirvType =
-        lowerType(pointeeType, layoutRule, /*isRowMajor*/ llvm::None, loc);
+        lowerType(pointeeType, rule, /*isRowMajor*/ llvm::None, loc);
     return spvContext.getPointerType(pointeeSpirvType,
                                      hybridPointer->getStorageClass());
   } else if (const auto *hybridSampledImage =

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -264,8 +264,13 @@ const SpirvType *LowerTypeVisitor::lowerType(const SpirvType *type,
                                              SourceLocation loc) {
   if (const auto *hybridPointer = dyn_cast<HybridPointerType>(type)) {
     const QualType pointeeType = hybridPointer->getPointeeType();
+    SpirvLayoutRule layoutRule =
+        hybridPointer->getStorageClass() ==
+                spv::StorageClass::PhysicalStorageBuffer
+            ? SpirvLayoutRule::Physical
+            : rule;
     const SpirvType *pointeeSpirvType =
-        lowerType(pointeeType, rule, /*isRowMajor*/ llvm::None, loc);
+        lowerType(pointeeType, layoutRule, /*isRowMajor*/ llvm::None, loc);
     return spvContext.getPointerType(pointeeSpirvType,
                                      hybridPointer->getStorageClass());
   } else if (const auto *hybridSampledImage =

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -560,7 +560,6 @@ uint32_t getFieldIndexInStruct(const StructType *spirvStructType,
   return fields[indexAST].fieldIndex;
 }
 
-// TOTO: not enough info to determine if offset computation is required here.
 // Takes an AST struct type, and lowers is to the equivalent SPIR-V type.
 const StructType *lowerStructType(const SpirvCodeGenOptions &spirvOptions,
                                   LowerTypeVisitor &lowerTypeVisitor,
@@ -6379,49 +6378,6 @@ void SpirvEmitter::storeValue(SpirvInstruction *lhsPtr,
   }
 
   emitError("storing value of type %0 unimplemented", {}) << lhsValType;
-}
-
-void forEachSpirvField(
-    const RecordType *recordType, const StructType *spirvType,
-    std::function<bool(size_t spirvFieldIndex, const QualType &fieldType,
-                       const StructType::FieldInfo &field)>
-        op) {
-  const auto *cxxDecl = recordType->getAsCXXRecordDecl();
-  const auto *recordDecl = recordType->getDecl();
-
-  uint32_t lastConvertedIndex = 0;
-  size_t fieldIndex = 0;
-  for (const auto &base : cxxDecl->bases()) {
-    const size_t astFieldIndex = fieldIndex++;
-    const uint32_t currentFieldIndex =
-        spirvType->getFields()[astFieldIndex].fieldIndex;
-    if (astFieldIndex > 0 && currentFieldIndex == lastConvertedIndex) {
-      continue;
-    }
-    lastConvertedIndex = currentFieldIndex;
-
-    const auto &type = base.getType();
-    const auto &spirvField = spirvType->getFields()[astFieldIndex];
-    if (!op(currentFieldIndex, type, spirvField)) {
-      return;
-    }
-  }
-
-  for (const auto *field : recordDecl->fields()) {
-    const size_t astFieldIndex = fieldIndex++;
-    const uint32_t currentFieldIndex =
-        spirvType->getFields()[astFieldIndex].fieldIndex;
-    if (astFieldIndex > 0 && currentFieldIndex == lastConvertedIndex) {
-      continue;
-    }
-    lastConvertedIndex = currentFieldIndex;
-
-    const auto &type = field->getType();
-    const auto &spirvField = spirvType->getFields()[astFieldIndex];
-    if (!op(currentFieldIndex, type, spirvField)) {
-      return;
-    }
-  }
 }
 
 SpirvInstruction *SpirvEmitter::reconstructValue(SpirvInstruction *srcVal,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13674,6 +13674,7 @@ SpirvEmitter::loadDataFromRawAddress(SpirvInstruction *addressInUInt64,
   SpirvUnaryOp *address = spvBuilder.createUnaryOp(
       spv::Op::OpBitcast, bufferPtrType, addressInUInt64, loc);
   address->setStorageClass(spv::StorageClass::PhysicalStorageBuffer);
+  address->setLayoutRule(SpirvLayoutRule::Physical);
 
   SpirvLoad *loadInst = dyn_cast<SpirvLoad>(
       spvBuilder.createLoad(bufferType, address, loc));

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -656,7 +656,8 @@ private:
                                           SpirvInstruction *value,
                                           QualType bufferType,
                                           uint32_t alignment,
-                                          SourceLocation loc);
+                                          SourceLocation loc,
+                                          SourceRange range);
 
   /// Returns the alignment of `vk::RawBufferLoad()`.
   uint32_t getAlignmentForRawBufferLoad(const CallExpr *callExpr);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.bitfield.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.bitfield.hlsl
@@ -1,8 +1,26 @@
-// RUN: %dxc -T ps_6_0 -E main -HV 2021
+// RUN: %dxc -T cs_6_0 -E main -HV 2021
 
 // CHECK: OpCapability PhysicalStorageBufferAddresses
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
+// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S 1 Offset 4
+// CHECK-NOT: OpMemberDecorate %S 2 Offset 8
+// CHECK-NOT: OpMemberDecorate %S 3 Offset 12
+// CHECK: OpMemberDecorate %S_0 0 Offset 0
+// CHECK: OpMemberDecorate %S_0 1 Offset 4
+// CHECK: OpMemberDecorate %S_0 2 Offset 8
+// CHECK-NOT: OpMemberDecorate %S_0 3 Offset 12
+
+// CHECK: %S = OpTypeStruct %uint %uint %uint
+// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+// CHECK: %S_0 = OpTypeStruct %uint %uint %uint
+// CHECK: %_ptr_PhysicalStorageBuffer_S_0 = OpTypePointer PhysicalStorageBuffer %S_0
+
+// CHECK: %temp_var_S = OpVariable %_ptr_Function_S Function
+// CHECK: %temp_var_S_0 = OpVariable %_ptr_Function_S Function
+// CHECK: %temp_var_S_1 = OpVariable %_ptr_Function_S Function
+// CHECK: %temp_var_S_2 = OpVariable %_ptr_Function_S Function
 
 struct S {
   uint f1;
@@ -13,29 +31,74 @@ struct S {
 
 uint64_t Address;
 
-// CHECK: OpMemberDecorate %S_0 0 Offset 0
-// CHECK: OpMemberDecorate %S_0 1 Offset 4
-// CHECK: OpMemberDecorate %S_0 2 Offset 8
-// CHECK: %S = OpTypeStruct %uint %uint %uint
-// CHECK: [[ptr_f_S:%\w+]] = OpTypePointer Function %S
-// CHECK: %S_0 = OpTypeStruct %uint %uint %uint
-// CHECK: [[ptr_p_S:%\w+]] = OpTypePointer PhysicalStorageBuffer %S_0
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
 
-void main() : B {
-// CHECK: [[tmp_S:%\w+]] = OpVariable [[ptr_f_S]] Function
-// CHECK: [[value:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
-// CHECK: [[value:%\d+]] = OpLoad %ulong [[value]]
-// CHECK: [[value:%\d+]] = OpBitcast [[ptr_p_S]] [[value]]
-// CHECK: [[value:%\d+]] = OpLoad %S_0 [[value]] Aligned 4
-// CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[value]] 0
-// CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[value]] 1
-// CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[value]] 2
-// CHECK: [[value:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
-// CHECK: OpStore [[tmp_S]] [[value]]
-// CHECK: [[value:%\d+]] = OpAccessChain %_ptr_Function_uint [[tmp_S]] %int_1
-// CHECK: [[value:%\d+]] = OpLoad %uint [[value]]
-// CHECK: [[value:%\d+]] = OpBitFieldUExtract %uint [[value]] %uint_1 %uint_1
-// CHECK: OpStore %tmp [[value]]
-  uint tmp = vk::RawBufferLoad<S>(Address).f3;
+
+  {
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
+    // CHECK: [[tmp:%\d+]] = OpLoad %ulong [[tmp]]
+    // CHECK: [[ptr:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_S_0 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpLoad %S_0 [[ptr]] Aligned 4
+    // CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[tmp]] 0
+    // CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[tmp]] 1
+    // CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[tmp]] 2
+    // CHECK: [[tmp:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
+    // CHECK: OpStore %temp_var_S [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %temp_var_S %int_0
+    // CHECK: [[tmp:%\d+]] = OpLoad %uint [[tmp]]
+    // CHECK: OpStore %tmp1 [[tmp]]
+    uint tmp1 = vk::RawBufferLoad<S>(Address).f1;
+  }
+
+  {
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
+    // CHECK: [[tmp:%\d+]] = OpLoad %ulong [[tmp]]
+    // CHECK: [[ptr:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_S_0 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpLoad %S_0 [[ptr]] Aligned 4
+    // CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[tmp]] 0
+    // CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[tmp]] 1
+    // CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[tmp]] 2
+    // CHECK: [[tmp:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
+    // CHECK: OpStore %temp_var_S_0 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %temp_var_S_0 %int_1
+    // CHECK: [[tmp:%\d+]] = OpLoad %uint [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpBitFieldUExtract %uint [[tmp]] %uint_0 %uint_1
+    // CHECK: OpStore %tmp2 [[tmp]]
+    uint tmp2 = vk::RawBufferLoad<S>(Address).f2;
+  }
+
+  {
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
+    // CHECK: [[tmp:%\d+]] = OpLoad %ulong [[tmp]]
+    // CHECK: [[ptr:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_S_0 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpLoad %S_0 [[ptr]] Aligned 4
+    // CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[tmp]] 0
+    // CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[tmp]] 1
+    // CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[tmp]] 2
+    // CHECK: [[tmp:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
+    // CHECK: OpStore %temp_var_S_1 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %temp_var_S_1 %int_1
+    // CHECK: [[tmp:%\d+]] = OpLoad %uint [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpBitFieldUExtract %uint [[tmp]] %uint_1 %uint_1
+    // CHECK: OpStore %tmp3 [[tmp]]
+    uint tmp3 = vk::RawBufferLoad<S>(Address).f3;
+  }
+
+  {
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
+    // CHECK: [[tmp:%\d+]] = OpLoad %ulong [[tmp]]
+    // CHECK: [[ptr:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_S_0 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpLoad %S_0 [[ptr]] Aligned 4
+    // CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[tmp]] 0
+    // CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[tmp]] 1
+    // CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[tmp]] 2
+    // CHECK: [[tmp:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
+    // CHECK: OpStore %temp_var_S_2 [[tmp]]
+    // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %temp_var_S_2 %int_2
+    // CHECK: [[tmp:%\d+]] = OpLoad %uint [[tmp]]
+    // CHECK: OpStore %tmp4 [[tmp]]
+    uint tmp4 = vk::RawBufferLoad<S>(Address).f4;
+  }
 }
 

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.bitfield.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.bitfield.hlsl
@@ -13,16 +13,24 @@ struct S {
 
 uint64_t Address;
 
-// CHECK: [[type_S:%\w+]] = OpTypeStruct %uint %uint %uint
-// CHECK: [[ptr_f_S:%\w+]] = OpTypePointer Function [[type_S]]
-// CHECK: [[ptr_p_S:%\w+]] = OpTypePointer PhysicalStorageBuffer [[type_S]]
+// CHECK: OpMemberDecorate %S_0 0 Offset 0
+// CHECK: OpMemberDecorate %S_0 1 Offset 4
+// CHECK: OpMemberDecorate %S_0 2 Offset 8
+// CHECK: %S = OpTypeStruct %uint %uint %uint
+// CHECK: [[ptr_f_S:%\w+]] = OpTypePointer Function %S
+// CHECK: %S_0 = OpTypeStruct %uint %uint %uint
+// CHECK: [[ptr_p_S:%\w+]] = OpTypePointer PhysicalStorageBuffer %S_0
 
 void main() : B {
 // CHECK: [[tmp_S:%\w+]] = OpVariable [[ptr_f_S]] Function
 // CHECK: [[value:%\d+]] = OpAccessChain %_ptr_Uniform_ulong %_Globals %int_0
 // CHECK: [[value:%\d+]] = OpLoad %ulong [[value]]
 // CHECK: [[value:%\d+]] = OpBitcast [[ptr_p_S]] [[value]]
-// CHECK: [[value:%\d+]] = OpLoad [[type_S]] [[value]] Aligned 4
+// CHECK: [[value:%\d+]] = OpLoad %S_0 [[value]] Aligned 4
+// CHECK: [[member0:%\d+]] = OpCompositeExtract %uint [[value]] 0
+// CHECK: [[member1:%\d+]] = OpCompositeExtract %uint [[value]] 1
+// CHECK: [[member2:%\d+]] = OpCompositeExtract %uint [[value]] 2
+// CHECK: [[value:%\d+]] = OpCompositeConstruct %S [[member0]] [[member1]] [[member2]]
 // CHECK: OpStore [[tmp_S]] [[value]]
 // CHECK: [[value:%\d+]] = OpAccessChain %_ptr_Function_uint [[tmp_S]] %int_1
 // CHECK: [[value:%\d+]] = OpLoad %uint [[value]]

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.bitfields.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.bitfields.hlsl
@@ -1,0 +1,56 @@
+// RUN: %dxc -T cs_6_0 -E main -HV 2021
+
+// CHECK: OpCapability PhysicalStorageBufferAddresses
+// CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
+// CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
+// CHECK-NOT: OpMemberDecorate %S 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %S 1 Offset 4
+// CHECK-NOT: OpMemberDecorate %S 2 Offset 8
+// CHECK-NOT: OpMemberDecorate %S 3 Offset 12
+// CHECK: OpMemberDecorate %S_0 0 Offset 0
+// CHECK: OpMemberDecorate %S_0 1 Offset 4
+// CHECK: OpMemberDecorate %S_0 2 Offset 8
+// CHECK-NOT: OpMemberDecorate %S_0 3 Offset 12
+
+// CHECK: %S = OpTypeStruct %uint %uint %uint
+// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+// CHECK: %S_0 = OpTypeStruct %uint %uint %uint
+// CHECK: %_ptr_PhysicalStorageBuffer_S_0 = OpTypePointer PhysicalStorageBuffer %S_0
+
+
+struct S {
+  uint f1;
+  uint f2 : 1;
+  uint f3 : 3;
+  uint f4;
+};
+
+uint64_t Address;
+
+[numthreads(1, 1, 1)]
+void main(uint3 tid : SV_DispatchThreadID) {
+  // CHECK: %tmp = OpVariable %_ptr_Function_S Function
+  S tmp;
+
+  // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %tmp %int_0
+  // CHECK: OpStore [[tmp]] %uint_2
+  tmp.f1 = 2;
+
+  // CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Function_uint %tmp %int_1
+  // CHECK: [[tmp:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[tmp:%\d+]] = OpBitFieldInsert %uint [[tmp]] %uint_1 %uint_0 %uint_1
+  // CHECK: OpStore [[ptr]] [[tmp]]
+  tmp.f2 = 1;
+
+  // CHECK: [[ptr:%\d+]] = OpAccessChain %_ptr_Function_uint %tmp %int_1
+  // CHECK: [[tmp:%\d+]] = OpLoad %uint [[ptr]]
+  // CHECK: [[tmp:%\d+]] = OpBitFieldInsert %uint [[tmp]] %uint_0 %uint_1 %uint_3
+  // CHECK: OpStore [[ptr]] [[tmp]]
+  tmp.f3 = 0;
+
+  // CHECK: [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint %tmp %int_2
+  // CHECK: OpStore [[tmp]] %uint_3
+  tmp.f4 = 3;
+  vk::RawBufferStore<S>(Address, tmp);
+}
+

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferstore.hlsl
@@ -3,6 +3,18 @@
 // CHECK: OpCapability PhysicalStorageBufferAddresses
 // CHECK: OpExtension "SPV_KHR_physical_storage_buffer"
 // CHECK: OpMemoryModel PhysicalStorageBuffer64 GLSL450
+// CHECK-NOT: OpMemberDecorate %XYZW 0 Offset 0
+// CHECK-NOT: OpMemberDecorate %XYZW 1 Offset 4
+// CHECK-NOT: OpMemberDecorate %XYZW 2 Offset 8
+// CHECK-NOT: OpMemberDecorate %XYZW 3 Offset 12
+// CHECK: OpMemberDecorate %XYZW_0 0 Offset 0
+// CHECK: OpMemberDecorate %XYZW_0 1 Offset 4
+// CHECK: OpMemberDecorate %XYZW_0 2 Offset 8
+// CHECK: OpMemberDecorate %XYZW_0 3 Offset 12
+// CHECK: %XYZW = OpTypeStruct %int %int %int %int
+// CHECK: %_ptr_Function_XYZW = OpTypePointer Function %XYZW
+// CHECK: %XYZW_0 = OpTypeStruct %int %int %int %int
+// CHECK: %_ptr_PhysicalStorageBuffer_XYZW_0 = OpTypePointer PhysicalStorageBuffer %XYZW_0
 
 struct XYZW {
   int x;
@@ -50,8 +62,13 @@ void main(uint3 tid : SV_DispatchThreadID) {
 
   // CHECK:      [[addr:%\d+]] = OpLoad %ulong
   // CHECK-NEXT: [[xyzwval:%\d+]] = OpLoad %XYZW %xyzw
-  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_XYZW [[addr]]
-  // CHECK-NEXT: OpStore [[buf]] [[xyzwval]] Aligned 4
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_XYZW_0 [[addr]]
+  // CHECK-NEXT: [[member1:%\d+]] = OpCompositeExtract %int [[xyzwval]] 0
+  // CHECK-NEXT: [[member2:%\d+]] = OpCompositeExtract %int [[xyzwval]] 1
+  // CHECK-NEXT: [[member3:%\d+]] = OpCompositeExtract %int [[xyzwval]] 2
+  // CHECK-NEXT: [[member4:%\d+]] = OpCompositeExtract %int [[xyzwval]] 3
+  // CHECK-NEXT: [[p_xyzwval:%\d+]] = OpCompositeConstruct %XYZW_0 [[member1]] [[member2]] [[member3]] [[member4]]
+  // CHECK-NEXT: OpStore [[buf]] [[p_xyzwval]] Aligned 4
   XYZW xyzw;
   xyzw.x = 78;
   xyzw.y = 65;

--- a/tools/clang/test/CodeGenSPIRV/op.structured-buffer.reconstruct.bitfield.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.structured-buffer.reconstruct.bitfield.hlsl
@@ -1,0 +1,60 @@
+// RUN: %dxc -T cs_6_0 -E main -HV 2021
+
+struct Base {
+  uint base;
+};
+
+struct Derived : Base {
+  uint a;
+  uint b : 3;
+  uint c : 3;
+  uint d;
+};
+
+RWStructuredBuffer<Derived> g_probes : register(u0);
+
+[numthreads(64u, 1u, 1u)]
+void main(uint3 dispatchThreadId : SV_DispatchThreadID) {
+
+// CHECK:     [[p:%\w+]] = OpVariable %_ptr_Function_Derived_0 Function
+  Derived p;
+
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_Base_0 [[p]] %uint_0
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint [[tmp]] %int_0
+// CHECK:                  OpStore [[tmp]] %uint_5
+  p.base = 5;
+
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint [[p]] %int_1
+// CHECK:                  OpStore [[tmp]] %uint_1
+  p.a = 1;
+
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint [[p]] %int_2
+// CHECK: [[value:%\d+]] = OpLoad %uint [[tmp]]
+// CHECK: [[value:%\d+]] = OpBitFieldInsert %uint [[value]] %uint_2 %uint_0 %uint_3
+// CHECK:                  OpStore [[tmp]] [[value]]
+  p.b = 2;
+
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint [[p]] %int_2
+// CHECK: [[value:%\d+]] = OpLoad %uint [[tmp]]
+// CHECK: [[value:%\d+]] = OpBitFieldInsert %uint [[value]] %uint_3 %uint_3 %uint_3
+// CHECK:                  OpStore [[tmp]] [[value]]
+  p.c = 3;
+
+// CHECK:   [[tmp:%\d+]] = OpAccessChain %_ptr_Function_uint [[p]] %int_3
+// CHECK:                  OpStore [[tmp]] %uint_4
+  p.d = 4;
+
+
+// CHECK:     [[p:%\d+]] = OpLoad %Derived_0 [[p]]
+// CHECK:   [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_Derived %g_probes %int_0 %uint_0
+// CHECK:   [[tmp:%\d+]] = OpCompositeExtract %Base_0 [[p]] 0
+// CHECK:   [[tmp:%\d+]] = OpCompositeExtract %uint [[tmp]] 0
+// CHECK:  [[base:%\d+]] = OpCompositeConstruct %Base [[tmp]]
+// CHECK:  [[mem1:%\d+]] = OpCompositeExtract %uint [[p]] 1
+// CHECK:  [[mem2:%\d+]] = OpCompositeExtract %uint [[p]] 2
+// CHECK:  [[mem3:%\d+]] = OpCompositeExtract %uint [[p]] 3
+// CHECK:   [[tmp:%\d+]] = OpCompositeConstruct %Derived [[base]] [[mem1]] [[mem2]] [[mem3]]
+// CHECK:                  OpStore [[ptr]] [[tmp]]
+	g_probes[0] = p;
+}
+

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -472,6 +472,9 @@ TEST_F(FileTest, OpStructuredBufferAccess) {
 TEST_F(FileTest, OpStructuredBufferAccessBitfield) {
   runFileTest("op.structured-buffer.access.bitfield.hlsl");
 }
+TEST_F(FileTest, OpStructuredBufferReconstructBitfield) {
+  runFileTest("op.structured-buffer.reconstruct.bitfield.hlsl");
+}
 TEST_F(FileTest, OpRWStructuredBufferAccess) {
   runFileTest("op.rw-structured-buffer.access.hlsl");
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -1461,6 +1461,9 @@ TEST_F(FileTest, IntrinsicsVkRawBufferLoadBitfield) {
 TEST_F(FileTest, IntrinsicsVkRawBufferStore) {
   runFileTest("intrinsics.vkrawbufferstore.hlsl");
 }
+TEST_F(FileTest, IntrinsicsVkRawBufferStoreBitfields) {
+  runFileTest("intrinsics.vkrawbufferstore.bitfields.hlsl");
+}
 // Intrinsics added in SM 6.6
 TEST_F(FileTest, IntrinsicsSM66PackU8S8) {
   runFileTest("intrinsics.sm6_6.pack_s8u8.hlsl");


### PR DESCRIPTION
Depending on the struct layout, the `Offset` decoration is not always required.
When this storage class is setup, the decoration needs to be added.

The tricky part if the mix of AST types and SPIRV types with bitfields:
 - in the AST, bitfields are represented as their own fields.
 - in SPIRV, bitfields are meld into 1 field when possible.

This means we need to lower the type to SPIR-V to compute the correct offset.
This would be fine if we could always generate the Offset decoration, but some types like image samplers are structs, and computing an offset for them is not clean (maybe no legal?).
So we need to do it properly, and only generate offsets when the storage
type is physical.

Fixes #5327