### PR TITLE
[lit] fall back to taef for taef only test options

### DIFF
--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -94,6 +94,7 @@ if "%1"=="-clean" (
   set TEST_ALL=0
   set TEST_CLANG=1
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   set TEST_CLANG_FILTER=%2
   shift /1
 ) else if "%1"=="file-check" (
@@ -105,6 +106,7 @@ if "%1"=="-clean" (
   set TEST_ALL=0
   set TEST_CLANG=1
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   set TEST_CLANG_FILTER=VerifierTest::*
 ) else if "%1"=="cmd" (
   set TEST_ALL=0
@@ -117,6 +119,7 @@ if "%1"=="-clean" (
   set TEST_DXILCONV=1
   set TEST_USE_LIT=0
   set TEST_DXILCONV_FILTER=%2
+  echo Fallback to taef when use taef only options.
   shift /1
 ) else if "%1"=="noexec" (
   set TEST_ALL=0
@@ -133,6 +136,7 @@ if "%1"=="-clean" (
   set TEST_ALL=0
   set TEST_EXEC=1
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   set TEST_EXEC_FILTER=ExecutionTest::%2
   set TEST_EXEC_REQUIRED=1
   shift /1
@@ -140,12 +144,14 @@ if "%1"=="-clean" (
   set TEST_ALL=0
   set TEST_EXEC=1
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   set TEST_EXEC_FUTURE=1
   set TEST_EXEC_REQUIRED=1
 ) else if "%1"=="exec-future-filter" (
   set TEST_ALL=0
   set TEST_EXEC=1
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   set TEST_EXEC_FUTURE=1
   set TEST_EXEC_FILTER=ExecutionTest::%2
   set TEST_EXEC_REQUIRED=1
@@ -192,6 +198,7 @@ if "%1"=="-clean" (
 ) else if "%1"=="-file-check-dump" (
   set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% /p:"FileCheckDumpDir=%~2\HLSL"
   set TEST_USE_LIT=0
+  echo Fallback to taef when use taef only options.
   shift /1
 ) else if "%1"=="-dxil-loc" (
   set DXIL_DLL_LOC=%~2
@@ -213,6 +220,7 @@ set "_NEXT_=%1"
 if not defined _NEXT_ goto :done_args
 set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% %1
 set TEST_USE_LIT=0
+echo Fallback to taef when use taef only options.
 shift /1
 goto :collect_args
 :done_args

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -191,6 +191,7 @@ if "%1"=="-clean" (
   shift /1
 ) else if "%1"=="-file-check-dump" (
   set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% /p:"FileCheckDumpDir=%~2\HLSL"
+  set TEST_USE_LIT=0
   shift /1
 ) else if "%1"=="-dxil-loc" (
   set DXIL_DLL_LOC=%~2
@@ -211,6 +212,7 @@ rem This is the robust way to detect whether %1 is empty:
 set "_NEXT_=%1"
 if not defined _NEXT_ goto :done_args
 set ADDITIONAL_OPTS=%ADDITIONAL_OPTS% %1
+set TEST_USE_LIT=0
 shift /1
 goto :collect_args
 :done_args

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -93,6 +93,7 @@ if "%1"=="-clean" (
 ) else if "%1"=="clang-filter" (
   set TEST_ALL=0
   set TEST_CLANG=1
+  set TEST_USE_LIT=0
   set TEST_CLANG_FILTER=%2
   shift /1
 ) else if "%1"=="file-check" (
@@ -103,6 +104,7 @@ if "%1"=="-clean" (
 ) else if "%1"=="v" (
   set TEST_ALL=0
   set TEST_CLANG=1
+  set TEST_USE_LIT=0
   set TEST_CLANG_FILTER=VerifierTest::*
 ) else if "%1"=="cmd" (
   set TEST_ALL=0
@@ -113,6 +115,7 @@ if "%1"=="-clean" (
 ) else if "%1" == "dxilconv-filter" (
   set TEST_ALL=0
   set TEST_DXILCONV=1
+  set TEST_USE_LIT=0
   set TEST_DXILCONV_FILTER=%2
   shift /1
 ) else if "%1"=="noexec" (
@@ -129,17 +132,20 @@ if "%1"=="-clean" (
 ) else if "%1"=="exec-filter" (
   set TEST_ALL=0
   set TEST_EXEC=1
+  set TEST_USE_LIT=0
   set TEST_EXEC_FILTER=ExecutionTest::%2
   set TEST_EXEC_REQUIRED=1
   shift /1
 ) else if "%1"=="exec-future" (
   set TEST_ALL=0
   set TEST_EXEC=1
+  set TEST_USE_LIT=0
   set TEST_EXEC_FUTURE=1
   set TEST_EXEC_REQUIRED=1
 ) else if "%1"=="exec-future-filter" (
   set TEST_ALL=0
   set TEST_EXEC=1
+  set TEST_USE_LIT=0
   set TEST_EXEC_FUTURE=1
   set TEST_EXEC_FILTER=ExecutionTest::%2
   set TEST_EXEC_REQUIRED=1
@@ -171,6 +177,7 @@ if "%1"=="-clean" (
 ) else if /i "%1"=="-arm64ec" (
   set BUILD_ARCH=ARM64EC
 ) else if "%1"=="-adapter" (
+  set TEST_USE_LIT=0
   set TEST_ADAPTER= /p:"Adapter=%~2"
   shift /1
 ) else if "%1"=="-verbose" (


### PR DESCRIPTION
It is not easy to pass through the quoted /p options thru python. And these options are mainly for local debug filter, not for taef FileCheck tests. Just fall back to taef for these options and treat them like taef helper.

This is help to allow lit FileCheck shell test.