### PR TITLE
Remove 'using namespace std' to fix __noop ambiguity with latest libc++

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -60,7 +60,9 @@
 #include <deque>
 
 using namespace llvm;
-using namespace std;
+using std::unique_ptr;
+using std::unordered_set;
+using std::vector;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Error messages.

--- a/lib/HLSL/WaveSensitivityAnalysis.cpp
+++ b/lib/HLSL/WaveSensitivityAnalysis.cpp
@@ -40,7 +40,7 @@
 #include <unordered_set>
 
 using namespace llvm;
-using namespace std;
+using std::map;
 
 namespace hlsl {
 

--- a/lib/IR/Statepoint.cpp
+++ b/lib/IR/Statepoint.cpp
@@ -16,7 +16,6 @@
 #include "llvm/IR/Statepoint.h"
 #include "llvm/Support/CommandLine.h"
 
-using namespace std;
 using namespace llvm;
 
 bool llvm::isStatepoint(const ImmutableCallSite &CS) {


### PR DESCRIPTION
A recent change to libc++ added a 'struct __noop' to the 'std' namespace. When building with clang-cl using libc++ on Windows, this now introduces an ambiguity between this std::__noop struct, and the MSVC __noop intrinsic, in translation units where 'using namespace std;' is used. This commit replaces these with using clauses for the exact symbols required in the non-test cpp files.