### PR TITLE
Generate counter for arrays of RW, consume, and append structured buffers.

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -946,6 +946,10 @@ bool isRWByteAddressBuffer(QualType type) {
 }
 
 bool isAppendStructuredBuffer(QualType type) {
+  // Strip outer arrayness first
+  while (type->isArrayType())
+    type = type->getAsArrayTypeUnsafe()->getElementType();
+
   const auto *recordType = type->getAs<RecordType>();
   if (!recordType)
     return false;
@@ -954,6 +958,10 @@ bool isAppendStructuredBuffer(QualType type) {
 }
 
 bool isConsumeStructuredBuffer(QualType type) {
+  // Strip outer arrayness first
+  while (type->isArrayType())
+    type = type->getAsArrayTypeUnsafe()->getElementType();
+
   const auto *recordType = type->getAs<RecordType>();
   if (!recordType)
     return false;
@@ -962,6 +970,10 @@ bool isConsumeStructuredBuffer(QualType type) {
 }
 
 bool isRWStructuredBuffer(QualType type) {
+  // Strip outer arrayness first
+  while (type->isArrayType())
+    type = type->getAsArrayTypeUnsafe()->getElementType();
+
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();
     return name == "RWStructuredBuffer";
@@ -970,12 +982,7 @@ bool isRWStructuredBuffer(QualType type) {
 }
 
 bool isRWAppendConsumeSBuffer(QualType type) {
-  if (const RecordType *recordType = type->getAs<RecordType>()) {
-    StringRef name = recordType->getDecl()->getName();
-    return name == "RWStructuredBuffer" || name == "AppendStructuredBuffer" ||
-           name == "ConsumeStructuredBuffer";
-  }
-  return false;
+  return isRWStructuredBuffer(type) || isConsumeStructuredBuffer(type) || isAppendStructuredBuffer(type);
 }
 
 bool isAKindOfStructuredOrByteBuffer(QualType type) {

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1689,7 +1689,8 @@ void DeclResultIdMapper::createCounterVar(
   const SpirvType *counterType = spvContext.getACSBufferCounterType();
   QualType declType = decl->getType();
   if (declType->isArrayType()) {
-    // TODO: Handle multi-dimentional arrays.
+    // TODO(5440): This codes does not handle multi-dimensional arrays. We need
+    // to look at specific example to determine the best way to do it.
     uint32_t arrayStride = 4;
     if (const auto *constArrayType =
             astContext.getAsConstantArrayType(declType)) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -323,6 +323,10 @@ const DeclaratorDecl *getReferencedDef(const Expr *expr) {
     return nullptr;
 
   expr = expr->IgnoreParenCasts();
+  while(const auto *arraySubscriptExpr = dyn_cast<ArraySubscriptExpr>(expr)) {
+    expr = arraySubscriptExpr->getBase();
+    expr = expr->IgnoreParenCasts();
+  }
 
   if (const auto *declRefExpr = dyn_cast<DeclRefExpr>(expr)) {
     return dyn_cast_or_null<DeclaratorDecl>(declRefExpr->getDecl());
@@ -4536,8 +4540,15 @@ SpirvEmitter::incDecRWACSBufferCounter(const CXXMemberCallExpr *expr,
     return nullptr;
   }
 
+  llvm::SmallVector<SpirvInstruction *, 2> indexes;
+  if(const auto *arraySubscriptExpr = dyn_cast<ArraySubscriptExpr>(object)) {
+    //TODO: Handle multi-dimensional arrays.
+    indexes.push_back(doExpr(arraySubscriptExpr->getIdx()));
+  }
+  indexes.push_back(zero);
+
   auto *counterPtr = spvBuilder.createAccessChain(
-      astContext.IntTy, counterPair->get(spvBuilder, spvContext), {zero},
+      astContext.IntTy, counterPair->get(spvBuilder, spvContext), indexes,
       srcLoc, srcRange);
 
   SpirvInstruction *index = nullptr;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4542,9 +4542,12 @@ SpirvEmitter::incDecRWACSBufferCounter(const CXXMemberCallExpr *expr,
 
   llvm::SmallVector<SpirvInstruction *, 2> indexes;
   if(const auto *arraySubscriptExpr = dyn_cast<ArraySubscriptExpr>(object)) {
-    //TODO: Handle multi-dimensional arrays.
+    // TODO(5440): This codes does not handle multi-dimensional arrays. We need
+    // to look at specific example to determine the best way to do it.
     indexes.push_back(doExpr(arraySubscriptExpr->getIdx()));
   }
+
+  // Add an extra 0 because the counter is wrapped in a struct.
   indexes.push_back(zero);
 
   auto *counterPtr = spvBuilder.createAccessChain(

--- a/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.append-structured-buffer.array.hlsl
@@ -5,8 +5,14 @@ struct T {
   float3 b;
 };
 
-// CHECK: %myAppendStructuredBuffer = OpVariable %_ptr_Uniform__runtimearr_type_AppendStructuredBuffer_T Uniform
-AppendStructuredBuffer<T> myAppendStructuredBuffer[];
+// CHECK: OpDecorate %myAppendStructuredBuffer DescriptorSet 0
+// CHECK: OpDecorate %myAppendStructuredBuffer Binding 0
+// CHECK: OpDecorate %counter_var_myAppendStructuredBuffer DescriptorSet 0
+// CHECK: OpDecorate %counter_var_myAppendStructuredBuffer Binding 1
+
+// CHECK: %myAppendStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_AppendStructuredBuffer_T_uint_5 Uniform
+// CHECK: %counter_var_myAppendStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+AppendStructuredBuffer<T> myAppendStructuredBuffer[5];
 
 void main() {}
 

--- a/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.consume-structured-buffer.array.hlsl
@@ -5,8 +5,13 @@ struct T {
   float3 b;
 };
 
+// CHECK: OpDecorate %myConsumeStructuredBuffer DescriptorSet 0
+// CHECK: OpDecorate %myConsumeStructuredBuffer Binding 0
+// CHECK: OpDecorate %counter_var_myConsumeStructuredBuffer DescriptorSet 0
+// CHECK: OpDecorate %counter_var_myConsumeStructuredBuffer Binding 1
 
 // CHECK: %myConsumeStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ConsumeStructuredBuffer_T_uint_2 Uniform
+// CHECK: %counter_var_myConsumeStructuredBuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_2 Uniform
 ConsumeStructuredBuffer<T> myConsumeStructuredBuffer[2];
 
 void main() {}

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.const.index.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.const.index.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T ps_6_6 -E main -fvk-allow-rwstructuredbuffer-arrays
+
+struct PSInput
+{
+	uint idx : COLOR;
+};
+
+// CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
+
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
+// CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
+
+float4 main(PSInput input) : SV_TARGET
+{
+// Correctly increment the counter.
+// CHECK: [[ac:%\d+]] = OpAccessChain %_ptr_Uniform_int %counter_var_g_rwbuffer %int_3 %uint_0
+// CHECK: OpAtomicIAdd %int [[ac]] %uint_1 %uint_0 %int_1
+    g_rwbuffer[3].IncrementCounter();
+
+// Correctly access the buffer.
+// CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform_type_RWStructuredBuffer_uint %g_rwbuffer %int_2
+// CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_uint [[ac1]] %int_0 %uint_0
+// CHECK: OpLoad %uint [[ac2]]
+    return g_rwbuffer[2][0];
+}

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.flatten.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.flatten.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T ps_6_6 -E main -fspv-flatten-resource-arrays -fvk-allow-rwstructuredbuffer-arrays
+
+// TODO: This test should add `-O0` to make sure that the resource arrays are correctly flattened.
+// DXC is currently generating the correct code, but the spirv-tools passes are failing on the counter
+// array.
+
+struct PSInput
+{
+	uint idx : COLOR;
+};
+
+// CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %counter_var_g_rwbuffer Binding 5
+
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
+// CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
+RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
+
+float4 main(PSInput input) : SV_TARGET
+{
+// Correctly increment the counter.
+// CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_int %counter_var_g_rwbuffer {{%\d+}} %uint_0
+// CHECK: OpAtomicIAdd %int [[ac]] %uint_1 %uint_0 %int_1
+    g_rwbuffer[input.idx].IncrementCounter();
+
+// Correctly access the buffer.
+// CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform_type_RWStructuredBuffer_uint %g_rwbuffer {{%\d+}}
+// CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_uint [[ac1]] %int_0 %uint_0
+// CHECK: OpLoad %uint [[ac2]]
+    return g_rwbuffer[input.idx][0];
+}

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.counter.hlsl
@@ -7,13 +7,23 @@ struct PSInput
 
 // CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
 // CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
+
 // CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_RWStructuredBuffer_uint_uint_5 Uniform
+// CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__arr_type_ACSBuffer_counter_uint_5 Uniform
 RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
 
 float4 main(PSInput input) : SV_TARGET
 {
+// Correctly increment the counter.
+// CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_int %counter_var_g_rwbuffer {{%\d+}} %uint_0
+// CHECK: OpAtomicIAdd %int [[ac]] %uint_1 %uint_0 %int_1
+    g_rwbuffer[input.idx].IncrementCounter();
+
+// Correctly access the buffer.
 // CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform_type_RWStructuredBuffer_uint %g_rwbuffer {{%\d+}}
 // CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_uint [[ac1]] %int_0 %uint_0
 // CHECK: OpLoad %uint [[ac2]]
-	return g_rwbuffer[input.idx][0];
+    return g_rwbuffer[input.idx][0];
 }

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.nocounter.flatten.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.array.nocounter.flatten.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T ps_6_6 -E main -fspv-flatten-resource-arrays -O0 -fvk-allow-rwstructuredbuffer-arrays
+
+struct PSInput
+{
+	uint idx : COLOR;
+};
+
+// CHECK: OpDecorate %g_rwbuffer_0_ DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer_0_ Binding 0
+// CHECK: OpDecorate %g_rwbuffer_1_ DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer_1_ Binding 1
+// CHECK: OpDecorate %g_rwbuffer_2_ DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer_2_ Binding 2
+// CHECK: OpDecorate %g_rwbuffer_3_ DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer_3_ Binding 3
+// CHECK: OpDecorate %g_rwbuffer_4_ DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer_4_ Binding 4
+
+// CHECK: %g_rwbuffer_0_ = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_uint Uniform
+// CHECK: %g_rwbuffer_1_ = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_uint Uniform
+// CHECK: %g_rwbuffer_2_ = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_uint Uniform
+// CHECK: %g_rwbuffer_3_ = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_uint Uniform
+// CHECK: %g_rwbuffer_4_ = OpVariable %_ptr_Uniform_type_RWStructuredBuffer_uint Uniform
+RWStructuredBuffer<uint> g_rwbuffer[5] : register(u0, space2);
+
+float4 main(PSInput input) : SV_TARGET
+{
+	return g_rwbuffer[input.idx][0];
+}

--- a/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.unbounded.array.counter.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.rwstructured-buffer.unbounded.array.counter.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T ps_6_6 -E main -fvk-allow-rwstructuredbuffer-arrays
+
+struct PSInput
+{
+	uint idx : COLOR;
+};
+
+// CHECK: OpDecorate %g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %g_rwbuffer Binding 0
+// CHECK: OpDecorate %counter_var_g_rwbuffer DescriptorSet 2
+// CHECK: OpDecorate %counter_var_g_rwbuffer Binding 1
+
+// CHECK: %g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_RWStructuredBuffer_uint Uniform
+// CHECK: %counter_var_g_rwbuffer = OpVariable %_ptr_Uniform__runtimearr_type_ACSBuffer_counter Uniform
+RWStructuredBuffer<uint> g_rwbuffer[] : register(u0, space2);
+
+float4 main(PSInput input) : SV_TARGET
+{
+// Correctly increment the counter.
+// CHECK: [[ac:%\w+]] = OpAccessChain %_ptr_Uniform_int %counter_var_g_rwbuffer {{%\d+}} %uint_0
+// CHECK: OpAtomicIAdd %int [[ac]] %uint_1 %uint_0 %int_1
+    g_rwbuffer[input.idx].IncrementCounter();
+
+// Correctly access the buffer.
+// CHECK: [[ac1:%\w+]] = OpAccessChain %_ptr_Uniform_type_RWStructuredBuffer_uint %g_rwbuffer {{%\d+}}
+// CHECK: [[ac2:%\w+]] = OpAccessChain %_ptr_Uniform_uint [[ac1]] %int_0 %uint_0
+// CHECK: OpLoad %uint [[ac2]]
+    return g_rwbuffer[input.idx][0];
+}

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -146,6 +146,21 @@ TEST_F(FileTest, StructuredBufferArrayError) {
 TEST_F(FileTest, RWStructuredBufferArrayNoCounter) {
   runFileTest("type.rwstructured-buffer.array.nocounter.hlsl");
 }
+TEST_F(FileTest, RWStructuredBufferArrayNoCounterFlattened) {
+  runFileTest("type.rwstructured-buffer.array.nocounter.flatten.hlsl");
+}
+TEST_F(FileTest, RWStructuredBufferArrayCounter) {
+  runFileTest("type.rwstructured-buffer.array.counter.hlsl");
+}
+TEST_F(FileTest, RWStructuredBufferUnboundedArrayCounter) {
+  runFileTest("type.rwstructured-buffer.unbounded.array.counter.hlsl");
+}
+TEST_F(FileTest, RWStructuredBufferArrayCounterConstIndex) {
+  runFileTest("type.rwstructured-buffer.array.counter.const.index.hlsl");
+}
+TEST_F(FileTest, RWStructuredBufferArrayCounterFlattened) {
+  runFileTest("type.rwstructured-buffer.array.counter.flatten.hlsl");
+}
 TEST_F(FileTest, AppendStructuredBufferArrayError) {
   runFileTest("type.append-structured-buffer.array.hlsl");
 }


### PR DESCRIPTION
This commit adds code to generate counters for single dimensional arrays
of RW,consume, and append structured buffers.

After this commit, the counter can be used if the global resource is
used directly.
