### PR TITLE
Update required CMake version to 3.17.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
-cmake_minimum_required(VERSION 3.10) # HLSL Change - Require CMake 3.10.
+cmake_minimum_required(VERSION 3.17.2) # HLSL Change - Require CMake 3.17.2.
 
 if (NOT "${DXC_CMAKE_BEGINS_INCLUDE}" STREQUAL "")
   include(${DXC_CMAKE_BEGINS_INCLUDE})

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Building DXC requires:
 
 * [Git](http://git-scm.com/downloads).
 * [Python](https://www.python.org/downloads/) - version 3.x is required
-* [CMake](https://cmake.org/download/) - version >= 3.10
+* [CMake](https://cmake.org/download/) - version >= 3.17.2
     * The bundled version with Visual Studio works for Windows.
 * The C++ 14 compiler and runtime of your choosing.
     * DXC is known to compile with recent versions of GCC, Clang and MSVC.


### PR DESCRIPTION
The SPIR-V-Tools project requires 3.17.2. To simplify our project dependencies we should just require that everywhere. 3.17.2 was released in May 2020, so it is now over three years old.

Fixes #2616.