### PR TITLE
[Build] cleanup build dependency

### DIFF
--- a/lib/DxrFallback/CMakeLists.txt
+++ b/lib/DxrFallback/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(LLVM_LINK_COMPONENTS
+  passprinters
+)
+
 add_llvm_library(LLVMDxrFallback
   DxrFallbackCompiler.cpp
   FunctionBuilder.h

--- a/lib/HLSL/CMakeLists.txt
+++ b/lib/HLSL/CMakeLists.txt
@@ -1,9 +1,5 @@
 # Copyright (C) Microsoft Corporation. All rights reserved.
 # This file is distributed under the University of Illinois Open Source License. See LICENSE.TXT for details.
-set(LLVM_LINK_COMPONENTS
-  ${LLVM_TARGETS_TO_BUILD}
-  passprinters
-)
 
 add_hlsl_hctgen(DxcOptimizer OUTPUT DxcOptimizer.inc BUILD_DIR)
 add_hlsl_hctgen(DxilValidation OUTPUT DxilValidationImpl.inc BUILD_DIR)

--- a/lib/Transforms/IPO/CMakeLists.txt
+++ b/lib/Transforms/IPO/CMakeLists.txt
@@ -30,4 +30,4 @@ add_llvm_library(LLVMipo
 
 add_dependencies(LLVMipo intrinsics_gen)
 
-target_link_libraries(LLVMipo PUBLIC LLVMDXIL) # HLSL Change
+target_link_libraries(LLVMipo PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -68,4 +68,4 @@ add_llvm_library(LLVMScalarOpts
 
 add_dependencies(LLVMScalarOpts intrinsics_gen)
 
-target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL) # HLSL Change
+target_link_libraries(LLVMScalarOpts PUBLIC LLVMDXIL LLVMHLSL) # HLSL Change

--- a/tools/clang/tools/dxcompiler/CMakeLists.txt
+++ b/tools/clang/tools/dxcompiler/CMakeLists.txt
@@ -43,6 +43,7 @@ set(LLVM_LINK_COMPONENTS
   transformutils
   vectorize
   dxilcompression
+  passprinters
   )
 
 if (WIN32)


### PR DESCRIPTION
Add LLVMHLSL dependency to LLVMIPO and LLVMScalarOpts. Remove passprinters from LLVMHLSL to avoid cycle.

This is to fix link error found when trying to enable clang_cc1.