### PR TITLE
Fix include in DxilNodeProps.h

### DIFF
--- a/include/dxc/DXIL/DxilNodeProps.h
+++ b/include/dxc/DXIL/DxilNodeProps.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #include "DxilConstants.h"
-#include "dxc/Support/Global.h"
+#include <string>
 
 namespace llvm {
 class StringRef;


### PR DESCRIPTION
Globals.h defines things like `IFC` macros that leak into callers. All that was really needed here was a definition of `std::string`.