### PR TITLE
Fixed a crash when linker erases functions that still have users.

### DIFF
--- a/lib/HLSL/DxilLinker.cpp
+++ b/lib/HLSL/DxilLinker.cpp
@@ -959,7 +959,11 @@ DxilLinkJob::LinkToLib(const ShaderModel *pSM) {
       if (!m_exportMap.ProcessFunction(F, true)) {
         // Remove Function not in exportMap.
         DM.RemoveFunction(F);
-        F->eraseFromParent();
+
+        // Only erase function if user is empty. The function can still be
+        // used by @llvm.global_ctors
+        if (F->user_empty())
+          F->eraseFromParent();
       }
     }
 

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_global_ctor_with_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_global_ctor_with_export.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc %s -T lib_6_3 -Fo lib0
+// RUN: %dxl %s -T lib_6_3 lib0 -exports foo | FileCheck %s
+
+// CHECK: @llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @{{.+}}, i8* null }]
+
+// This is a regression test for a crash in the linker where when:
+//   1. There are constructors for global variables
+//   2. There are exports
+//
+// The bug assume
+
+Texture1D<float> t0 : register(t0);
+static float get_val(int i) {
+  return t0[i];
+}
+struct My_Glob {
+  float a, b, c;
+};
+// This constructor has real code that has to run and cannot be removed.
+static My_Glob glob = { get_val(0), get_val(1), get_val(2) };
+
+export float foo() {
+  return (++glob.a) + (++glob.b) + (++glob.c);
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_global_ctor_with_export.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_global_ctor_with_export.hlsl
@@ -7,7 +7,8 @@
 //   1. There are constructors for global variables
 //   2. There are exports
 //
-// The bug assume
+// The bug assumes that functions not on the export list must have no users. This is not the case when
+// the functions are constructors for global variables.
 
 Texture1D<float> t0 : register(t0);
 static float get_val(int i) {


### PR DESCRIPTION
When linking to library with a list of `-exports`, the linker erases functions that are not exported assuming they are no longer used. This assumption is not correct when the function is a constructor for a global variable. This change fixes the crash by first checking whether the function still has uses before erasing.

This change adds a regression test with a non-trivially removable global variable constructor that would crash without this change.