### PR TITLE
[lit] use lit.py directly to allow send parameter to lit from hcttest

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -106,6 +106,7 @@ set(CLANG_TEST_PARAMS
   ${CLANG_TEST_PARAMS}
   clang_unit_site_config=${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
   clang_taef_site_config=${CMAKE_CURRENT_BINARY_DIR}/taef/lit.site.cfg
+  no_priority=True
   clang_taef_exec_site_config=${CMAKE_CURRENT_BINARY_DIR}/taef_exec/lit.site.cfg
   )
 
@@ -135,7 +136,6 @@ if (WIN32)
   add_lit_target("check-clang-taef" "Running lit suite hlsl"
             ${CMAKE_CURRENT_SOURCE_DIR}/taef
             PARAMS ${CLANG_TEST_PARAMS}
-              no_priority=True
             DEPENDS ClangHLSLTests
             ARGS ${CLANG_TEST_EXTRA_ARGS}
           )

--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -135,6 +135,7 @@ if (WIN32)
   add_lit_target("check-clang-taef" "Running lit suite hlsl"
             ${CMAKE_CURRENT_SOURCE_DIR}/taef
             PARAMS ${CLANG_TEST_PARAMS}
+              no_priority=True
             DEPENDS ClangHLSLTests
             ARGS ${CLANG_TEST_EXTRA_ARGS}
           )

--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -139,9 +139,12 @@ if (WIN32)
             DEPENDS ClangHLSLTests
             ARGS ${CLANG_TEST_EXTRA_ARGS}
           )
+  set(TAEF_EXEC_ADAPTER "" CACHE STRING "adapter for taef exec test")
+
   add_lit_target("check-clang-taef-exec" "Running lit suite hlsl execution test"
             ${CMAKE_CURRENT_SOURCE_DIR}/taef_exec
             PARAMS ${CLANG_TEST_PARAMS}
+                adapter=${TAEF_EXEC_ADAPTER}
             DEPENDS ExecHLSLTests dxexp
             ARGS ${CLANG_TEST_EXTRA_ARGS}
           )

--- a/tools/clang/test/taef_exec/lit.cfg
+++ b/tools/clang/test/taef_exec/lit.cfg
@@ -60,7 +60,8 @@ if config.unsupported == False:
 
   adapter = lit_config.params.get('adapter', None)
   if adapter:
-      extra_params.append(str.format('/p:"Adapter={}"', adapter))
+      if adapter != '':
+          extra_params.append(str.format('/p:"Adapter={}"', adapter))
 
   agility_sdk = lit_config.params.get('agility_sdk', None)
   if agility_sdk:

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -45,6 +45,7 @@ set SHOW_CMAKE_LOG=0
 set ENABLE_LIT=ON
 set WINSDK_MIN_VERSION=10.0.17763.0
 set INSTALL_DIR=
+set DEFAULT_EXEC_ADAPTER=-DTAEF_EXEC_ADAPTER=
 
 :parse_args
 if "%1"=="" (
@@ -204,6 +205,11 @@ if "%1"=="-lit-xml-output-path" (
   shift /1
   shift /1 & goto :parse_args
 )
+if "%1"=="-default-adapter" (
+  set DEFAULT_EXEC_ADAPTER=-DTAEF_EXEC_ADAPTER=%~2
+  shift /1
+  shift /1 & goto :parse_args
+)
 rem Begin SPIRV change
 if "%1"=="-spirv" (
   echo SPIR-V codegen is enabled.
@@ -339,6 +345,9 @@ set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_BUILD_EXAMPLES:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_CL:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_SYSTEM_VERSION=%DXC_CMAKE_SYSTEM_VERSION%
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%
+
+rem Setup taef exec adapter.
+set CMAKE_OPTS=%CMAKE_OPTS% %DEFAULT_EXEC_ADAPTER%
 
 rem ARM cross-compile setup
 if %BUILD_ARM_CROSSCOMPILING% == 0 goto :after-cross-compile

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -185,6 +185,7 @@ if "%1"=="-clean" (
 ) else if "%1"=="-adapter" (
   set TEST_USE_LIT=0
   set TEST_ADAPTER= /p:"Adapter=%~2"
+  set EXEC_ADAPTER=--param adapter=%~2
   shift /1
 ) else if "%1"=="-verbose" (
   set LOG_FILTER=
@@ -312,24 +313,25 @@ if "%TEST_USE_LIT%"=="1" (
     set TEST_CLANG=1
   )
   if "%TEST_ALL%"=="1" (
-    rem check all includes clang, dxilconv, and exec
-    cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-all
+    rem check all includes clang, dxilconv
+	py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param dxilconv_site_config=%HLSL_BLD_DIR%/projects/dxilconv/test/taef/lit.site.cfg --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param skip_taef_exec=True  --param no_priority=True --param llvm_site_config=%HLSL_BLD_DIR%/test/lit.site.cfg --param llvm_unit_site_config=G:/repos/DXC/hlsl.bin/test/Unit/lit.site.cfg %HLSL_SRC_DIR%/projects/dxilconv/test/taef %HLSL_BLD_DIR%/tools/clang/test %HLSL_BLD_DIR%/test
     set RES_CLANG=!ERRORLEVEL!
     set RES_DXILCONV=%RES_CLANG%
     set RES_EXEC=%RES_CLANG%
     set RES_CMD=%RES_CLANG%
   ) else (
     if "%TEST_DXILCONV%"=="1" (
-      cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-dxilconv
+	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param dxilconv_site_config=%HLSL_BLD_DIR%/projects/dxilconv/test/taef/lit.site.cfg %HLSL_SRC_DIR%/projects/dxilconv/test/taef
       set RES_DXILCONV=!ERRORLEVEL!
     )
     if "!TEST_CLANG!"=="1" (
-      cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang
+	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param no_priority=True --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param skip_taef_exec=True %HLSL_BLD_DIR%/tools/clang/test
       set RES_CLANG=!ERRORLEVEL!
       set RES_CMD=%RES_CLANG%
     )
     if "!TEST_EXEC!"=="1" (
-      cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang-taef-exec
+      py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_unit_site_config=%HLSL_BLD_DIR%/tools/clang/test/Unit/lit.site.cfg --param clang_taef_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
+
       set RES_EXEC=!ERRORLEVEL!
     )
   )

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -183,7 +183,6 @@ if "%1"=="-clean" (
 ) else if /i "%1"=="-arm64ec" (
   set BUILD_ARCH=ARM64EC
 ) else if "%1"=="-adapter" (
-  set TEST_USE_LIT=0
   set TEST_ADAPTER= /p:"Adapter=%~2"
   set EXEC_ADAPTER=--param adapter=%~2
   shift /1
@@ -305,16 +304,13 @@ if "%TEST_MANUAL_FILE_CHECK%"=="1" (
 )
 
 if "%TEST_USE_LIT%"=="1" (
-  rem LIT does not separate cmd tests from other clang hlsl tests.
-  if "%TEST_CMD%"=="1" (
-    set TEST_CLANG=1
-  )
+  rem LIT does not separate spirv tests from other clang hlsl tests.
   if "%TEST_SPIRV%"=="1" (
     set TEST_CLANG=1
   )
   if "%TEST_ALL%"=="1" (
-    rem check all includes clang, dxilconv
-	py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param dxilconv_site_config=%HLSL_BLD_DIR%/projects/dxilconv/test/taef/lit.site.cfg --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param skip_taef_exec=True  --param no_priority=True --param llvm_site_config=%HLSL_BLD_DIR%/test/lit.site.cfg --param llvm_unit_site_config=G:/repos/DXC/hlsl.bin/test/Unit/lit.site.cfg %HLSL_SRC_DIR%/projects/dxilconv/test/taef %HLSL_BLD_DIR%/tools/clang/test %HLSL_BLD_DIR%/test
+    rem check all except exec.
+    cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-all
     set RES_CLANG=!ERRORLEVEL!
     set RES_DXILCONV=%RES_CLANG%
     set RES_EXEC=%RES_CLANG%
@@ -324,13 +320,16 @@ if "%TEST_USE_LIT%"=="1" (
 	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param dxilconv_site_config=%HLSL_BLD_DIR%/projects/dxilconv/test/taef/lit.site.cfg %HLSL_SRC_DIR%/projects/dxilconv/test/taef
       set RES_DXILCONV=!ERRORLEVEL!
     )
+    if "%TEST_CMD%"=="1" (
+      py %BIN_DIR%\llvm-lit.py %HLSL_SRC_DIR%/tools/clang/test/DXC -v
+      set RES_CMD=!ERRORLEVEL!
+    )
     if "!TEST_CLANG!"=="1" (
 	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param no_priority=True --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param skip_taef_exec=True %HLSL_BLD_DIR%/tools/clang/test
       set RES_CLANG=!ERRORLEVEL!
-      set RES_CMD=%RES_CLANG%
     )
     if "!TEST_EXEC!"=="1" (
-      py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_unit_site_config=%HLSL_BLD_DIR%/tools/clang/test/Unit/lit.site.cfg --param clang_taef_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
+      py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
 
       set RES_EXEC=!ERRORLEVEL!
     )

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -317,7 +317,7 @@ if "%TEST_USE_LIT%"=="1" (
     set RES_CMD=%RES_CLANG%
   ) else (
     if "%TEST_DXILCONV%"=="1" (
-	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param dxilconv_site_config=%HLSL_BLD_DIR%/projects/dxilconv/test/taef/lit.site.cfg %HLSL_SRC_DIR%/projects/dxilconv/test/taef
+      cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-dxilconv
       set RES_DXILCONV=!ERRORLEVEL!
     )
     if "%TEST_CMD%"=="1" (
@@ -325,12 +325,15 @@ if "%TEST_USE_LIT%"=="1" (
       set RES_CMD=!ERRORLEVEL!
     )
     if "!TEST_CLANG!"=="1" (
-	  py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param no_priority=True --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param skip_taef_exec=True %HLSL_BLD_DIR%/tools/clang/test
+      cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang
       set RES_CLANG=!ERRORLEVEL!
     )
     if "!TEST_EXEC!"=="1" (
-      py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
-
+      if defined EXEC_ADAPTER (
+        py %HLSL_SRC_DIR%/utils/lit/lit.py -sv --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
+      ) else (
+        cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang-taef-exec
+	  )
       set RES_EXEC=!ERRORLEVEL!
     )
   )


### PR DESCRIPTION
This is for support adapter option for exec test when using lit. no_priority is enabled for clang test too.

CMake behavior will be the same except not support adapter option.
Also hcttest cmd will only run cmd test for lit.