### PR TITLE
[SPIR-V] Handle non-global ConstantBuffer

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1088,6 +1088,10 @@ std::string getHlslResourceTypeName(QualType type) {
       // Get resource type name with template params. Operation is safe because
       // type has already been null checked.
       return type.getLocalUnqualifiedType().getAsString();
+    } else if (name == "ConstantBuffer") {
+      return "cbuffer";
+    } else if (name == "TextureBuffer") {
+      return "tbuffer";
     }
   }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -304,16 +304,6 @@ public:
   /// standing for the whole buffer.
   SpirvVariable *createCTBuffer(const HLSLBufferDecl *decl);
 
-  /// \brief Creates a cbuffer/tbuffer from the given decl.
-  ///
-  /// In the AST, a variable whose type is ConstantBuffer/TextureBuffer is
-  /// represented as a VarDecl whose DeclContext is a HLSLBufferDecl. These
-  /// VarDecl's type is labelled as the struct upon which ConstantBuffer/
-  /// TextureBuffer is parameterized. For a such VarDecl, we need to create
-  /// a corresponding SPIR-V variable for it. Later referencing of such a
-  /// VarDecl does not need an extra OpAccessChain.
-  SpirvVariable *createCTBuffer(const VarDecl *decl);
-
   /// \brief Creates a PushConstant block from the given decl.
   SpirvVariable *createPushConstant(const VarDecl *decl);
 

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -519,36 +519,7 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
       return spvType;
     }
 
-    // Collect all fields' information.
-    llvm::SmallVector<HybridStructType::FieldInfo, 8> fields;
-
-    // If this struct is derived from some other struct, place an implicit
-    // field at the very beginning for the base struct.
-    if (const auto *cxxDecl = dyn_cast<CXXRecordDecl>(decl)) {
-      for (const auto &base : cxxDecl->bases()) {
-        fields.push_back(HybridStructType::FieldInfo(base.getType()));
-      }
-    }
-
-    // Create fields for all members of this struct
-    for (const auto *field : decl->fields()) {
-      llvm::Optional<BitfieldInfo> bitfieldInfo;
-      if (field->isBitField()) {
-        bitfieldInfo = BitfieldInfo();
-        bitfieldInfo->sizeInBits =
-            field->getBitWidthValue(field->getASTContext());
-      }
-
-      fields.push_back(HybridStructType::FieldInfo(
-          field->getType(), field->getName(),
-          /*vkoffset*/ field->getAttr<VKOffsetAttr>(),
-          /*packoffset*/ getPackOffset(field),
-          /*RegisterAssignment*/ nullptr,
-          /*isPrecise*/ field->hasAttr<HLSLPreciseAttr>(),
-          /*bitfield*/ bitfieldInfo));
-    }
-
-    auto loweredFields = populateLayoutInformation(fields, rule);
+    auto loweredFields = lowerStructFields(decl, rule);
 
     const auto *spvStructType =
         spvContext.getStructType(loweredFields, decl->getName());
@@ -566,7 +537,8 @@ const SpirvType *LowerTypeVisitor::lowerType(QualType type,
     if (rule != SpirvLayoutRule::Void &&
         // We won't have stride information for structured/byte buffers since
         // they contain runtime arrays.
-        !isAKindOfStructuredOrByteBuffer(elemType)) {
+        !isAKindOfStructuredOrByteBuffer(elemType) &&
+        !isConstantTextureBuffer(elemType)) {
       uint32_t stride = 0;
       alignmentCalc.getAlignmentAndSize(type, rule, isRowMajor, &stride);
       arrayStride = stride;
@@ -761,24 +733,41 @@ const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
     return valType;
   }
 
-  if (name == "ConstantBuffer") {
-    // ConstantBuffer<T> is lowered as T
+  if (name == "ConstantBuffer" || name == "TextureBuffer") {
+    // ConstantBuffer<T> and TextureBuffer<T> are lowered as T
+
+    const bool forTBuffer = name == "TextureBuffer";
+
     if (rule == SpirvLayoutRule::Void) {
-      rule = getCodeGenOptions().sBufferLayoutRule;
+      rule = forTBuffer ? getCodeGenOptions().tBufferLayoutRule
+                        : getCodeGenOptions().cBufferLayoutRule;
     }
 
+    const auto *bufferType = type->getAs<RecordType>();
+    assert(bufferType);
+    const auto *bufferDecl = bufferType->getDecl();
+
     // Get the underlying resource type.
-    const auto s = hlsl::GetHLSLResourceResultType(type);
+    const auto underlyingType = hlsl::GetHLSLResourceResultType(type);
 
-    // If the underlying type is a matrix, check majorness.
-    llvm::Optional<bool> isRowMajor = llvm::None;
-    if (isMxNMatrix(s))
-      isRowMajor = isRowMajorMatrix(spvOptions, type);
+    const auto *underlyingStructType = underlyingType->getAs<RecordType>();
+    assert(underlyingStructType &&
+           "T in ConstantBuffer<T> or TextureBuffer<T> must be a struct type");
 
-    // Lower the underlying type.
-    const auto *structType = lowerType(s, rule, isRowMajor, srcLoc);
+    const auto *underlyingStructDecl = underlyingStructType->getDecl();
 
-    return structType;
+    auto loweredFields = lowerStructFields(underlyingStructDecl, rule);
+
+    const std::string structName = "type." + bufferDecl->getName().str() + "." +
+                                   underlyingStructDecl->getName().str();
+
+    const auto *spvStructType = spvContext.getStructType(
+        loweredFields, structName, /*isReadOnly*/ forTBuffer,
+        forTBuffer ? StructInterfaceType::StorageBuffer
+                   : StructInterfaceType::UniformBuffer);
+
+    spvContext.registerStructDeclForSpirvType(spvStructType, bufferDecl);
+    return spvStructType;
   }
 
   // ByteAddressBuffer types.
@@ -860,6 +849,43 @@ const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
   }
 
   return nullptr;
+}
+
+llvm::SmallVector<StructType::FieldInfo, 4>
+LowerTypeVisitor::lowerStructFields(const RecordDecl *decl,
+                                    SpirvLayoutRule rule) {
+  assert(decl);
+
+  // Collect all fields' information.
+  llvm::SmallVector<HybridStructType::FieldInfo, 8> fields;
+
+  // If this struct is derived from some other struct, place an implicit
+  // field at the very beginning for the base struct.
+  if (const auto *cxxDecl = dyn_cast<CXXRecordDecl>(decl)) {
+    for (const auto &base : cxxDecl->bases()) {
+      fields.push_back(HybridStructType::FieldInfo(base.getType()));
+    }
+  }
+
+  // Create fields for all members of this struct
+  for (const auto *field : decl->fields()) {
+    llvm::Optional<BitfieldInfo> bitfieldInfo;
+    if (field->isBitField()) {
+      bitfieldInfo = BitfieldInfo();
+      bitfieldInfo->sizeInBits =
+          field->getBitWidthValue(field->getASTContext());
+    }
+
+    fields.push_back(HybridStructType::FieldInfo(
+        field->getType(), field->getName(),
+        /*vkoffset*/ field->getAttr<VKOffsetAttr>(),
+        /*packoffset*/ getPackOffset(field),
+        /*RegisterAssignment*/ nullptr,
+        /*isPrecise*/ field->hasAttr<HLSLPreciseAttr>(),
+        /*bitfield*/ bitfieldInfo));
+  }
+
+  return populateLayoutInformation(fields, rule);
 }
 
 spv::ImageFormat

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.h
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.h
@@ -71,6 +71,11 @@ private:
   const SpirvType *lowerResourceType(QualType type, SpirvLayoutRule rule,
                                      SourceLocation);
 
+  /// Lowers the fields of a RecordDecl into SPIR-V StructType field
+  /// information.
+  llvm::SmallVector<StructType::FieldInfo, 4>
+  lowerStructFields(const RecordDecl *structType, SpirvLayoutRule rule);
+
   /// Lowers the given type defined in vk namespace into its SPIR-V type.
   const SpirvType *lowerVkTypeInVkNamespace(QualType type, llvm::StringRef name,
                                             SpirvLayoutRule rule,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1793,7 +1793,7 @@ void SpirvEmitter::doVarDecl(const VarDecl *decl) {
     return;
   }
 
-  if (isConstantTextureBuffer(decl->getType())) {
+  if (isConstantTextureBuffer(decl->getType()) && !decl->hasInit()) {
     // This is a VarDecl of ConstantBuffer/TextureBuffer type.
     (void)declIdMapper.createCTBuffer(decl);
     return;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -749,10 +749,6 @@ private:
                                           SourceLocation,
                                           SourceRange range = {});
 
-  /// \brief Updates the AST result type of initInstr as type. If it is a load
-  /// instruction update its pointer as well.
-  void updateInstructionType(SpirvInstruction *initInstr, QualType type);
-
 private:
   /// Translates the given frontend APValue into its SPIR-V equivalent for the
   /// given targetType.

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.cbuffer.hlsl
@@ -52,6 +52,8 @@ float4 main(in float4 pos : SV_Position) : SV_Target
 // CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %myASBuffer %uint_0 {{%\d+}}
 // CHECK-NEXT: [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
 // CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[val]] 0
+// CHECK-NEXT: [[tmp:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
+// CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[tmp]] 0
 // CHECK-NEXT: [[tmp:%\d+]] = OpCompositeConstruct %S [[vec]]
 // CHECK-NEXT:                OpStore [[ptr]] [[tmp]]
     myASBuffer.Append(myCBuffer);
@@ -68,9 +70,7 @@ S retStuff() {
 // Returning a ConstantBuffer<T> as a T is a copy
 // CHECK:      [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %myCBuffer
 // CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[val]] 0
-// CHECK-NEXT: [[tmp:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
-// CHECK-NEXT:                OpStore %temp_var_ret [[tmp]]
-// CHECK-NEXT: [[ret:%\d+]] = OpLoad %S_0 %temp_var_ret
+// CHECK-NEXT: [[ret:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
 // CHECK-NEXT:                OpReturnValue [[ret]]
     return myCBuffer;
 }

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.tbuffer.hlsl
@@ -55,7 +55,11 @@ float4 main(in float4 pos : SV_Position) : SV_Target
 // TODO: The underlying struct type has the same layout but %type_TextureBuffer_S
 // has an additional BufferBlock decoration. So this causes an validation error.
 // CHECK:      [[ptr:%\d+]] = OpAccessChain %_ptr_Uniform_S %myASBuffer %uint_0 {{%\d+}}
-// CHECK-NEXT: [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myTBuffer
+// CHECK-NEXT:  [[tb:%\d+]] = OpLoad %type_TextureBuffer_S %myTBuffer
+// CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[tb]] 0
+// CHECK-NEXT: [[loc:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
+// CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[loc]] 0
+// CHECK-NEXT: [[val:%\d+]] = OpCompositeConstruct %S [[vec]]
 // CHECK-NEXT:                OpStore [[ptr]] [[val]]
     myASBuffer.Append(myTBuffer);
 
@@ -71,9 +75,7 @@ S retStuff() {
 // Returning a TextureBuffer<T> as a T is a copy
 // CHECK:      [[val:%\d+]] = OpLoad %type_TextureBuffer_S %myTBuffer
 // CHECK-NEXT: [[vec:%\d+]] = OpCompositeExtract %v4float [[val]] 0
-// CHECK-NEXT: [[tmp:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
-// CHECK-NEXT:                OpStore %temp_var_ret [[tmp]]
-// CHECK-NEXT: [[ret:%\d+]] = OpLoad %S_0 %temp_var_ret
+// CHECK-NEXT: [[ret:%\d+]] = OpCompositeConstruct %S_0 [[vec]]
 // CHECK-NEXT:                OpReturnValue [[ret]]
     return myTBuffer;
 }

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.assign.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.assign.hlsl
@@ -15,18 +15,17 @@ struct S
 };
 
 // CHECK: %_ptr_Uniform_type_ConstantBuffer_S = OpTypePointer Uniform %type_ConstantBuffer_S
-
-// CHECK: %S = OpTypeStruct %float %float
-// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+// CHECK: %_ptr_Function_type_ConstantBuffer_S = OpTypePointer Function %type_ConstantBuffer_S
 
 // CHECK: %buffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_S Uniform
 ConstantBuffer<S> buffer;
 
 void main()
 {
-// CHECK:           %local = OpVariable %_ptr_Function_S Function
+// CHECK:           %local = OpVariable %_ptr_Function_type_ConstantBuffer_S Function
 
 // CHECK: [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %buffer
 // CHECK:                OpStore %local [[val]]
-  ConstantBuffer<S> local = buffer;
+  ConstantBuffer<S> local;
+  local = buffer;
 }

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.assign.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.assign.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -T vs_6_0 -E main
+
+// CHECK:      OpName %type_ConstantBuffer_S "type.ConstantBuffer.S"
+// CHECK-NEXT: OpMemberName %type_ConstantBuffer_S 0 "someFloat"
+// CHECK-NEXT: OpMemberName %type_ConstantBuffer_S 1 "another"
+
+// CHECK:      OpDecorate %type_ConstantBuffer_S Block
+
+// CHECK: %type_ConstantBuffer_S = OpTypeStruct %float %float
+
+struct S
+{
+    float someFloat;
+    float another;
+};
+
+// CHECK: %_ptr_Uniform_type_ConstantBuffer_S = OpTypePointer Uniform %type_ConstantBuffer_S
+
+// CHECK: %S = OpTypeStruct %float %float
+// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+
+// CHECK: %buffer = OpVariable %_ptr_Uniform_type_ConstantBuffer_S Uniform
+ConstantBuffer<S> buffer;
+
+void main()
+{
+// CHECK:           %local = OpVariable %_ptr_Function_S Function
+
+// CHECK: [[val:%\d+]] = OpLoad %type_ConstantBuffer_S %buffer
+// CHECK:                OpStore %local [[val]]
+  ConstantBuffer<S> local = buffer;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.bindless.array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.bindless.array.hlsl
@@ -1,17 +1,17 @@
 // RUN: %dxc -T vs_6_0 -E main
 
 // Used for ConstantBuffer definition.
-// CHECK: OpTypeStruct %mat4v4float
+// CHECK: [[type_CB_PerDraw:%\w+]] = OpTypeStruct %mat4v4float
 // Used for PerDraw local variable.
-// CHECK: OpTypeStruct %mat4v4float
+// CHECK: [[type_PerDraw:%\w+]] = OpTypeStruct %mat4v4float
 
 struct PerDraw {
   float4x4 Transform;
 };
 
+// CHECK: [[ptr_type_CB_PerDraw:%\w+]] = OpTypePointer Uniform [[type_CB_PerDraw]]
 // Used for ConstantBuffer to PerDraw type cast.
-// CHECK:     [[type_PerDraw:%\w+]] = OpTypeStruct %mat4v4float
-// CHECK: [[ptr_type_PerDraw:%\w+]] = OpTypePointer Uniform [[type_PerDraw]]
+
 
 ConstantBuffer<PerDraw> PerDraws[];
 
@@ -23,8 +23,10 @@ struct VSInput {
 };
 
 float4 main(in VSInput input) : SV_POSITION {
-// CHECK: [[ptr:%\w+]] = OpAccessChain [[ptr_type_PerDraw]] %PerDraws
-// CHECK:                OpLoad [[type_PerDraw]] [[ptr]]
+// CHECK:        [[ptr:%\w+]] = OpAccessChain [[ptr_type_CB_PerDraw]] %PerDraws
+// CHECK: [[cb_PerDraw:%\w+]] = OpLoad [[type_CB_PerDraw]] [[ptr]]
+// CHECK:   [[float4x4:%\w+]] = OpCompositeExtract %mat4v4float [[cb_PerDraw]] 0
+// CHECK:                       OpCompositeConstruct [[type_PerDraw]] [[float4x4]]
   const PerDraw perDraw = PerDraws[input.DrawIdx];
   return mul(float4(input.Position, 1.0f), perDraw.Transform);
 }

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.return.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.return.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -T vs_6_0 -E main
+
+// CHECK:      OpName %type_ConstantBuffer_S "type.ConstantBuffer.S"
+// CHECK-NEXT: OpMemberName %type_ConstantBuffer_S 0 "someFloat"
+// CHECK-NEXT: OpMemberName %type_ConstantBuffer_S 1 "another"
+
+// CHECK:      OpDecorate %type_ConstantBuffer_S Block
+
+// CHECK: %type_ConstantBuffer_S = OpTypeStruct %float %float
+
+struct S
+{
+    float someFloat;
+    float another;
+};
+
+// CHECK: %_runtimearr_type_ConstantBuffer_S = OpTypeRuntimeArray %type_ConstantBuffer_S
+// CHECK: %_ptr_Uniform__runtimearr_type_ConstantBuffer_S = OpTypePointer Uniform %_runtimearr_type_ConstantBuffer_S
+
+// CHECK: %S = OpTypeStruct %float %float
+// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+
+// CHECK: %buffers = OpVariable %_ptr_Uniform__runtimearr_type_ConstantBuffer_S Uniform
+ConstantBuffer<S> buffers[];
+
+ConstantBuffer<S> getBuf(uint indx)
+{
+// CHECK-DAG: %temp_var_ret = OpVariable %_ptr_Function_S Function
+// CHECK-DAG: [[bufPtr:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffers [[indx:%\d+]]
+// CHECK-DAG: [[bufVal:%\d+]] = OpLoad %S [[bufPtr]]
+// CHECK-DAG: OpStore %temp_var_ret [[bufVal]]
+    return buffers[indx];
+};
+
+void main()
+{
+// CHECK-DAG: [[val:%\d+]] = OpFunctionCall %S %getBuf %param_var_indx
+  getBuf(1);
+}

--- a/tools/clang/test/CodeGenSPIRV/type.constant-buffer.return.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.constant-buffer.return.hlsl
@@ -17,23 +17,23 @@ struct S
 // CHECK: %_runtimearr_type_ConstantBuffer_S = OpTypeRuntimeArray %type_ConstantBuffer_S
 // CHECK: %_ptr_Uniform__runtimearr_type_ConstantBuffer_S = OpTypePointer Uniform %_runtimearr_type_ConstantBuffer_S
 
-// CHECK: %S = OpTypeStruct %float %float
-// CHECK: %_ptr_Function_S = OpTypePointer Function %S
+// CHECK: [[fnType:%\d+]] = OpTypeFunction %type_ConstantBuffer_S %_ptr_Function_uint
 
 // CHECK: %buffers = OpVariable %_ptr_Uniform__runtimearr_type_ConstantBuffer_S Uniform
 ConstantBuffer<S> buffers[];
 
+// CHECK-DAG: %getBuf = OpFunction %type_ConstantBuffer_S None [[fnType]]
 ConstantBuffer<S> getBuf(uint indx)
 {
-// CHECK-DAG: %temp_var_ret = OpVariable %_ptr_Function_S Function
-// CHECK-DAG: [[bufPtr:%\d+]] = OpAccessChain %_ptr_Uniform_S %buffers [[indx:%\d+]]
-// CHECK-DAG: [[bufVal:%\d+]] = OpLoad %S [[bufPtr]]
+// CHECK-DAG: %temp_var_ret = OpVariable %_ptr_Function_type_ConstantBuffer_S Function
+// CHECK-DAG: [[bufPtr:%\d+]] = OpAccessChain %_ptr_Uniform_type_ConstantBuffer_S %buffers [[indx:%\d+]]
+// CHECK-DAG: [[bufVal:%\d+]] = OpLoad %type_ConstantBuffer_S [[bufPtr]]
 // CHECK-DAG: OpStore %temp_var_ret [[bufVal]]
     return buffers[indx];
 };
 
 void main()
 {
-// CHECK-DAG: [[val:%\d+]] = OpFunctionCall %S %getBuf %param_var_indx
+// CHECK-DAG: [[val:%\d+]] = OpFunctionCall %type_ConstantBuffer_S %getBuf %param_var_indx
   getBuf(1);
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -101,6 +101,14 @@ TEST_F(FileTest, TypeCBufferIncludingResource) {
 TEST_F(FileTest, ConstantBufferType) {
   runFileTest("type.constant-buffer.hlsl");
 }
+TEST_F(FileTest, ConstantBufferTypeAssign) {
+  runFileTest("type.constant-buffer.assign.hlsl", Expect::Success,
+              /*runValidation*/ false);
+}
+TEST_F(FileTest, ConstantBufferTypeReturn) {
+  runFileTest("type.constant-buffer.return.hlsl", Expect::Success,
+              /*runValidation*/ false);
+}
 TEST_F(FileTest, ConstantBufferTypeMultiDimensionalArray) {
   runFileTest("type.constant-buffer.multiple-dimensions.hlsl");
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -102,19 +102,16 @@ TEST_F(FileTest, ConstantBufferType) {
   runFileTest("type.constant-buffer.hlsl");
 }
 TEST_F(FileTest, ConstantBufferTypeAssign) {
-  runFileTest("type.constant-buffer.assign.hlsl", Expect::Success,
-              /*runValidation*/ false);
+  runFileTest("type.constant-buffer.assign.hlsl");
 }
 TEST_F(FileTest, ConstantBufferTypeReturn) {
-  runFileTest("type.constant-buffer.return.hlsl", Expect::Success,
-              /*runValidation*/ false);
+  runFileTest("type.constant-buffer.return.hlsl");
 }
 TEST_F(FileTest, ConstantBufferTypeMultiDimensionalArray) {
   runFileTest("type.constant-buffer.multiple-dimensions.hlsl");
 }
 TEST_F(FileTest, BindlessConstantBufferArrayType) {
-  runFileTest("type.constant-buffer.bindless.array.hlsl", Expect::Success,
-              /*legalization*/ false);
+  runFileTest("type.constant-buffer.bindless.array.hlsl");
 }
 TEST_F(FileTest, EnumType) { runFileTest("type.enum.hlsl"); }
 TEST_F(FileTest, ClassEnumType) { runFileTest("class.enum.hlsl"); }
@@ -1898,9 +1895,7 @@ TEST_F(FileTest, SpirvLegalizationConstantBuffer) {
   runFileTest("spirv.legal.cbuffer.hlsl");
 }
 TEST_F(FileTest, SpirvLegalizationTextureBuffer) {
-  runFileTest("spirv.legal.tbuffer.hlsl", Expect::Success,
-              // TODO: fix the different type error for OpStore
-              /*runValidation=*/false);
+  runFileTest("spirv.legal.tbuffer.hlsl");
 }
 
 TEST_F(FileTest, SpirvDebugOpSource) {


### PR DESCRIPTION
Previously, `ConstantBuffer<T>` in variable declarations were being lowered in `SpirvEmitter`, and in all other cases in `LowerTypeVisitor`, which was improperly lowering the type. This pull request changes the existing logic so only `ConstantBuffer<T>` declarations without an initializer (ie, global declarations) are lowered in `SpirvEmitter`, and adds logic to lower `ConstantBuffer<T>` as `T` in `LowerTypeVisitor`.

This does result in two separate type declarations for `ConstantBuffer<T>`, but after legalization the output is correct in the cases I've checked.

Fixes #5401 