### PR TITLE
Refactor type lowering for local RWStructuredBuffers

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -754,6 +754,7 @@ public:
                        llvm::ArrayRef<SpirvConstant *> constituents,
                        bool specConst = false);
   SpirvConstant *getConstantNull(QualType);
+  SpirvConstant *getConstantNull(const SpirvType *);
 
   SpirvString *createString(llvm::StringRef str);
   SpirvString *getString(llvm::StringRef str);

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -96,6 +96,15 @@ public:
   SpirvVariable *addFnVar(QualType valueType, SourceLocation,
                           llvm::StringRef name = "", bool isPrecise = false,
                           SpirvInstruction *init = nullptr);
+  
+  /// \brief Creates a local variable of the given type in the current
+  /// function and returns it.
+  ///
+  /// The corresponding pointer type of the given type will be constructed in
+  /// this method for the variable itself.
+  SpirvVariable *addFnVar(const HybridType* valueType, SourceLocation,
+                          llvm::StringRef name = "", bool isPrecise = false,
+                          SpirvInstruction *init = nullptr);
 
   /// \brief Ends building of the current function. All basic blocks constructed
   /// from the beginning or after ending the previous function will be collected

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -1228,6 +1228,7 @@ private:
 class SpirvConstantNull : public SpirvConstant {
 public:
   SpirvConstantNull(QualType type);
+  SpirvConstantNull(const SpirvType *type);
 
   DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvConstantNull)
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1699,6 +1699,13 @@ SpirvConstant *SpirvBuilder::getConstantNull(QualType type) {
   return nullConst;
 }
 
+SpirvConstant *SpirvBuilder::getConstantNull(const SpirvType *type) {
+  // We do not care about making unique constants at this point.
+  auto *nullConst = new (context) SpirvConstantNull(type);
+  mod->addConstant(nullConst);
+  return nullConst;
+}
+
 SpirvString *SpirvBuilder::createString(llvm::StringRef str) {
   // Create a SpirvString instruction
   auto *instr = new (context) SpirvString(/* SourceLocation */ {}, str);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -1501,9 +1501,16 @@ void SpirvEmitter::doFunctionDecl(const FunctionDecl *decl) {
         // If the source code does not provide a proper return value for some
         // control flow path, it's undefined behavior. We just return null
         // value here.
-        SpirvInstruction * nullValue = spvBuilder.getConstantNull(retType);
-        if (isOrContainsAKindOfStructuredOrByteBuffer(retType))
+        SpirvInstruction *nullValue = nullptr;
+        if (isOrContainsAKindOfStructuredOrByteBuffer(retType)) {
+          const auto *hybridType =
+              spvContext.getPointerType(retType, spv::StorageClass::Uniform);
+          nullValue = spvBuilder.getConstantNull(hybridType);
           nullValue->setLayoutRule(spirvOptions.sBufferLayoutRule);
+          nullValue->setStorageClass(spv::StorageClass::Uniform);
+        } else {
+          nullValue = spvBuilder.getConstantNull(retType);
+        }
 
         spvBuilder.createReturnValue(nullValue, returnLoc);
       }

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -566,6 +566,9 @@ SpirvConstantComposite::SpirvConstantComposite(
 SpirvConstantNull::SpirvConstantNull(QualType type)
     : SpirvConstant(IK_ConstantNull, spv::Op::OpConstantNull, type) {}
 
+SpirvConstantNull::SpirvConstantNull(const SpirvType *type)
+    : SpirvConstant(IK_ConstantNull, spv::Op::OpConstantNull, type) {}
+
 bool SpirvConstantNull::operator==(const SpirvConstantNull &that) const {
   return opcode == that.opcode && resultType == that.resultType &&
          astResultType == that.astResultType;


### PR DESCRIPTION
To handle a local RWStructuredBuffers, we treat the local varible like a
pointer to the global variable. This is needed to properly represent the
semantics of these local variables. The difficulty is that this spread
out in a number of places creating special cases are not always
intuiative. It is also causing problems for arrays of
RWStructuredBuffers.

This change will modify the type of the local variable generated by the
spirv emitter to be a pointer instead of waiting for type lowering to
handle it.