### PR TITLE
Cleanup HLSLCheckForModifiableLValue

### DIFF
--- a/tools/clang/lib/Sema/SemaExpr.cpp
+++ b/tools/clang/lib/Sema/SemaExpr.cpp
@@ -9475,63 +9475,43 @@ static bool HLSLCheckForModifiableLValue(
     SourceLocation Loc,
     Sema &S
 ) {
-  if (E->getType().isConstQualified()) {
-    DiagnoseConstAssignment(S, E, Loc);
-    return true;
-  }
-  if (!isa<ImplicitCastExpr>(E) && !E->isLValue()) {
-    S.Diag(Loc, diag::err_typecheck_expression_not_modifiable_lvalue);
-    return true;
-  }
-  if (auto OC = dyn_cast<CXXOperatorCallExpr>(E)) {
-    QualType qt = OC->getArg(0)->getType();
-    if (hlsl::IsMatrixType(&S, qt) || hlsl::IsVectorType(&S, qt))
-      return HLSLCheckForModifiableLValue(OC->getArg(0), Loc, S);
-  }
-  if (auto M = dyn_cast<MemberExpr>(E)) {
-    // If the return type of the expressin is const, we should respect the const
-    // qualification.
-    if (E->getType().isConstQualified()) {
-      DiagnoseConstAssignment(S, E, Loc);
+    assert(isa<CXXOperatorCallExpr>(E));
+    const CXXOperatorCallExpr *expr = cast<CXXOperatorCallExpr>(E);
+    const Expr *LHS = expr->getArg(0);
+    QualType qt = LHS->getType();
+
+    // Check modifying const matrix with double subscript operator calls
+    if (isa<CXXOperatorCallExpr>(expr->getArg(0)))
+        return HLSLCheckForModifiableLValue(const_cast<Expr *>(expr->getArg(0)), Loc, S);
+
+    if (qt.isConstQualified() && (hlsl::IsMatrixType(&S, qt) || hlsl::IsVectorType(&S, qt))) {
+      DiagnoseConstAssignment(S, LHS, Loc);
       return true;
     }
-    if (auto MemberCall = dyn_cast<CXXMemberCallExpr>(M->getBase())) {
-      CXXRecordDecl *RD = MemberCall->getRecordDecl();
-      QualType Ty = QualType(RD->getTypeForDecl(), 0);
-      // NodeInputRecord and NodeInputRecordArray are not modifiable
-      if (hlsl::IsHLSLRONodeInputRecordType(Ty)) {
-        DiagnoseConstAssignment(S, E, Loc);
-        return true;
-      }
+    if (!LHS->isLValue()) {
+      S.Diag(Loc, diag::err_typecheck_expression_not_modifiable_lvalue);
+      return true;
     }
-    return HLSLCheckForModifiableLValue(M->getBase(), Loc, S);
-  }
-  if (auto ICE = dyn_cast<ImplicitCastExpr>(E)) {
-    return HLSLCheckForModifiableLValue(ICE->getSubExpr(), Loc, S);
-  }
-  if (auto AS = dyn_cast<ArraySubscriptExpr>(E)) {
-    return HLSLCheckForModifiableLValue(AS->getBase(), Loc, S);
-  }
-  if (auto SE = dyn_cast<HLSLVectorElementExpr>(E)) {
-    return HLSLCheckForModifiableLValue(SE->getBase(), Loc, S);
-  }
-
-  return false;
+    return false;
 }
 
 /// CheckForModifiableLvalue - Verify that E is a modifiable lvalue.  If not,
 /// emit an error and return true.  If so, return false.
 bool CheckForModifiableLvalue(Expr *E, SourceLocation Loc, Sema &S) { // HLSL Change: export this function
   assert(!E->hasPlaceholderType(BuiltinType::PseudoObject));
-  SourceLocation OrigLoc = Loc;
-  Expr::isModifiableLvalueResult IsLV = E->isModifiableLvalue(S.Context, &Loc);
-
-  // HLSL Change Starts - HLSL has extra constraints to check
-  if (IsLV == Expr::MLV_Valid && S.Context.getLangOpts().HLSL &&
-      HLSLCheckForModifiableLValue(E, Loc, S))
-    return true;
+  // HLSL Change Starts - check const for array subscript operator for HLSL vector/matrix
+  if (S.Context.getLangOpts().HLSL && E->getStmtClass() == Stmt::CXXOperatorCallExprClass) {
+    // check if it's a vector or matrix
+    const CXXOperatorCallExpr *expr = cast<CXXOperatorCallExpr>(E);
+    QualType qt = expr->getArg(0)->getType();
+    if ((hlsl::IsMatrixType(&S, qt) || hlsl::IsVectorType(&S, qt)))
+      return HLSLCheckForModifiableLValue(E, Loc, S);
+  }
   // HLSL Change Ends
 
+  SourceLocation OrigLoc = Loc;
+  Expr::isModifiableLvalueResult IsLV = E->isModifiableLvalue(S.Context,
+                                                              &Loc);
   if (IsLV == Expr::MLV_ClassTemporary && IsReadonlyMessage(E, S))
     IsLV = Expr::MLV_InvalidMessageExpression;
   if (IsLV == Expr::MLV_Valid)

--- a/tools/clang/test/HLSL/workgraph/member_write_diagnostics.hlsl
+++ b/tools/clang/test/HLSL/workgraph/member_write_diagnostics.hlsl
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 // ==================================================================
-// CASE120 (error)
 // Errors are generated for writes to members of read-only records
 // ==================================================================
 
 struct RECORD
 {
+  uint3 a;
   bool b;
 };
 
@@ -14,6 +14,11 @@ struct RECORD
 [NodeLaunch("Broadcasting")]
 void node01(DispatchNodeInputRecord<RECORD> input1)
 {
+  RECORD x;
+  input1.Get() = x; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input1.Get().a = 11; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input1.Get().a[0] = 12; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input1.Get().a.z = 13; //expected-error{{read-only variable is not assignable}}
   input1.Get().b = false; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
 }
 
@@ -22,7 +27,11 @@ void node01(DispatchNodeInputRecord<RECORD> input1)
 [NodeLaunch("Broadcasting")]
 void node02(RWDispatchNodeInputRecord<RECORD> input2)
 {
-  input2.b = true; //expected-error{{no member named 'b' in 'RWDispatchNodeInputRecord<RECORD>'}}
+  RECORD x;
+  input2.Get() = x;
+  input2.Get().a = 21;
+  input2.Get().a[0] = 22;
+  input2.Get().a.z = 23;
   input2.Get().b = true;
 }
 
@@ -31,6 +40,12 @@ void node02(RWDispatchNodeInputRecord<RECORD> input2)
 [NodeLaunch("coalescing")]
 void node03([MaxRecords(3)] GroupNodeInputRecords<RECORD> input3)
 {
+  RECORD x;
+  input3.Get() = x; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input3.Get(0).a = 31; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input3.Get(1).a[2] = 32; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input3.Get(2).a.x = 33; //expected-error{{read-only variable is not assignable}}
+  input3[3].a = 34; //expected-error{{cannot assign to return value because function 'operator[]' returns a const value}}
   input3.Get().b = false; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
   input3[0].b = false; //expected-error{{cannot assign to return value because function 'operator[]' returns a const value}}
 }
@@ -40,18 +55,66 @@ void node03([MaxRecords(3)] GroupNodeInputRecords<RECORD> input3)
 [NodeLaunch("coalescing")]
 void node04([MaxRecords(4)] RWGroupNodeInputRecords<RECORD> input4)
 {
+  RECORD x;
+  input4.Get() = x;
+  input4.Get(1).a = 41;
+  input4.Get(2).a[2] = 42;
+  input4.Get(3).a.x = 43;
+  input4.Get(1).a = 44;
+  input4[0].b = true;
   input4.Get().b = true;
   input4.Get(0).b = true;
   input4[0].b = true;
 }
 
 [Shader("node")]
+[NodeLaunch("thread")]
+void node05(ThreadNodeInputRecord<RECORD> input5)
+{
+  RECORD x;
+  input5.Get() = x; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input5.Get().a = 51; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input5.Get().a[0] = 52; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+  input5.Get().a.z = 53; //expected-error{{read-only variable is not assignable}}
+  input5.Get().b = false; //expected-error{{cannot assign to return value because function 'Get' returns a const value}}
+}
+
+[Shader("node")]
+[NodeLaunch("Thread")]
+void node06(RWThreadNodeInputRecord<RECORD> input6)
+{
+  RECORD x;
+  input6.Get() = x;
+  input6.Get().a = 61;
+  input6.Get().a[0] = 62;
+  input6.Get().a.z = 63;
+  input6.Get().b = true;
+}
+
+[Shader("node")]
 [NumThreads(1024,1,1)]
 [NodeLaunch("Broadcasting")]
-void node05(NodeOutput<RECORD> output5)
+void node07(NodeOutput<RECORD> output7)
 {
-  output5.b = false; //expected-error{{no member named 'b' in 'NodeOutput<RECORD>'}}
-  output5.Get().b = false; //expected-error{{no member named 'Get' in 'NodeOutput<RECORD>'}}
+  RECORD x;
+  output7.Get() = x; //expected-error{{no member named 'Get' in 'NodeOutput<RECORD>'}}
+  output7.a = 71; //expected-error{{no member named 'a' in 'NodeOutput<RECORD>'}}
+  output7[0].b = false; //expected-error{{type 'NodeOutput<RECORD>' does not provide a subscript operator}}
+  output7.Get().a = 72; //expected-error{{no member named 'Get' in 'NodeOutput<RECORD>'}}
+  output7.Get().b = false; //expected-error{{no member named 'Get' in 'NodeOutput<RECORD>'}}
+}
+
+[Shader("node")]
+[NumThreads(1024,1,1)]
+[NodeLaunch("Broadcasting")]
+void node08([MaxRecords(8)] NodeOutputArray<RECORD> output8)
+{
+  RECORD x;
+  output8.Get() = x; //expected-error{{no member named 'Get' in 'NodeOutputArray<RECORD>'}}
+  output8.Get().a = 81; //expected-error{{no member named 'Get' in 'NodeOutputArray<RECORD>'}}
+  output8[0].a = 82; //expected-error{{no member named 'a' in 'NodeOutput<RECORD>'}}
+  output8.b = false; //expected-error{{no member named 'b' in 'NodeOutputArray<RECORD>'}}
+  output8.Get().b = false; //expected-error{{no member named 'Get' in 'NodeOutputArray<RECORD>'}}
 }
 
 // expected-note@? +{{function 'Get' which returns const-qualified type 'const RECORD &' declared here}}


### PR DESCRIPTION
Issue 5372 highlighted obsolete code left over from an earlier version of work graph implementation. After investigation it is confirmed that none of the changes there are currently required, so this change reverts to the previous version of the function, and also updates the related test.

Fixes #5372 