### PR TITLE
Add TransformUtils dependency to DxilContainer for Linux builds

### DIFF
--- a/lib/DxilContainer/LLVMBuild.txt
+++ b/lib/DxilContainer/LLVMBuild.txt
@@ -13,4 +13,4 @@
 type = Library
 name = DxilContainer
 parent = Libraries
-required_libraries = BitReader BitWriter Core DxcSupport IPA Support DXIL
+required_libraries = BitReader BitWriter Core DxcSupport IPA Support DXIL TransformUtils


### PR DESCRIPTION
The dependency is necessary because DxilContainerAssembler.cpp uses llvm::CloneModule.