### PR TITLE
[lit] Only enable spirv lit test when spirv build is enabled.

### DIFF
--- a/tools/clang/test/CodeGenSPIRV_Lit/lit.local.cfg
+++ b/tools/clang/test/CodeGenSPIRV_Lit/lit.local.cfg
@@ -1,0 +1,1 @@
+config.unsupported = not config.spirv


### PR DESCRIPTION
To avoid test fail when spirv build is not enabled.