### PR TITLE
[C++17] Merge Replace uses of std::iterator with explicit using

### DIFF
--- a/include/llvm/ADT/DepthFirstIterator.h
+++ b/include/llvm/ADT/DepthFirstIterator.h
@@ -63,12 +63,16 @@ public:
 template<class GraphT,
 class SetType = llvm::SmallPtrSet<typename GraphTraits<GraphT>::NodeType*, 8>,
          bool ExtStorage = false, class GT = GraphTraits<GraphT> >
-class df_iterator : public std::iterator<std::forward_iterator_tag,
-                                         typename GT::NodeType, ptrdiff_t>,
-                    public df_iterator_storage<SetType, ExtStorage> {
-  typedef std::iterator<std::forward_iterator_tag,
-                        typename GT::NodeType, ptrdiff_t> super;
+class df_iterator : public df_iterator_storage<SetType, ExtStorage> {
 
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = typename GT::NodeType;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
+private:
   typedef typename GT::NodeType          NodeType;
   typedef typename GT::ChildIteratorType ChildItTy;
   typedef PointerIntPair<NodeType*, 1>   PointerIntTy;
@@ -77,7 +81,7 @@ class df_iterator : public std::iterator<std::forward_iterator_tag,
   // First element is node pointer, second is the 'next child' to visit
   // if the int in PointerIntTy is 0, the 'next child' to visit is invalid
   std::vector<std::pair<PointerIntTy, ChildItTy> > VisitStack;
-private:
+
   inline df_iterator(NodeType *Node) {
     this->Visited.insert(Node);
     VisitStack.push_back(std::make_pair(PointerIntTy(Node, 0), 
@@ -127,8 +131,6 @@ private:
   }
 
 public:
-  typedef typename super::pointer pointer;
-
   // Provide static begin and end methods as our public "constructors"
   static df_iterator begin(const GraphT &G) {
     return df_iterator(GT::getEntryNode(G));

--- a/include/llvm/ADT/EquivalenceClasses.h
+++ b/include/llvm/ADT/EquivalenceClasses.h
@@ -237,16 +237,16 @@ public:
     return L1;
   }
 
-  class member_iterator : public std::iterator<std::forward_iterator_tag,
-                                               const ElemTy, ptrdiff_t> {
-    typedef std::iterator<std::forward_iterator_tag,
-                          const ElemTy, ptrdiff_t> super;
+  class member_iterator {
     const ECValue *Node;
     friend class EquivalenceClasses;
   public:
-    typedef size_t size_type;
-    typedef typename super::pointer pointer;
-    typedef typename super::reference reference;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const ElemTy;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
 
     explicit member_iterator() {}
     explicit member_iterator(const ECValue *N) : Node(N) {}

--- a/include/llvm/ADT/ImmutableSet.h
+++ b/include/llvm/ADT/ImmutableSet.h
@@ -645,11 +645,15 @@ public:
 //===----------------------------------------------------------------------===//
 
 template <typename ImutInfo>
-class ImutAVLTreeGenericIterator
-    : public std::iterator<std::bidirectional_iterator_tag,
-                           ImutAVLTree<ImutInfo>> {
+class ImutAVLTreeGenericIterator {
   SmallVector<uintptr_t,20> stack;
 public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = ImutAVLTree<ImutInfo>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   enum VisitFlag { VisitedNone=0x0, VisitedLeft=0x1, VisitedRight=0x3,
                    Flags=0x3 };
 
@@ -756,13 +760,17 @@ public:
 };
 
 template <typename ImutInfo>
-class ImutAVLTreeInOrderIterator
-    : public std::iterator<std::bidirectional_iterator_tag,
-                           ImutAVLTree<ImutInfo>> {
+class ImutAVLTreeInOrderIterator {
   typedef ImutAVLTreeGenericIterator<ImutInfo> InternalIteratorTy;
   InternalIteratorTy InternalItr;
 
 public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = ImutAVLTree<ImutInfo>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   typedef ImutAVLTree<ImutInfo> TreeTy;
 
   ImutAVLTreeInOrderIterator(const TreeTy* Root) : InternalItr(Root) {

--- a/include/llvm/ADT/IntervalMap.h
+++ b/include/llvm/ADT/IntervalMap.h
@@ -64,9 +64,14 @@
 // };
 //
 // template <typename KeyT, typename ValT, unsigned N, typename Traits>
-// class IntervalMap::const_iterator :
-//   public std::iterator<std::bidirectional_iterator_tag, ValT> {
+// class IntervalMap::const_iterator {
 // public:
+//   using iterator_category = std::bidirectional_iterator_tag;
+//   using value_type = ValT;
+//   using difference_type = std::ptrdiff_t;
+//   using pointer = value_type *;
+//   using reference = value_type &;
+//
 //   bool operator==(const const_iterator &) const;
 //   bool operator!=(const const_iterator &) const;
 //   bool valid() const;
@@ -1282,11 +1287,17 @@ clear() {
 //===----------------------------------------------------------------------===//
 
 template <typename KeyT, typename ValT, unsigned N, typename Traits>
-class IntervalMap<KeyT, ValT, N, Traits>::const_iterator :
-  public std::iterator<std::bidirectional_iterator_tag, ValT> {
-protected:
+class IntervalMap<KeyT, ValT, N, Traits>::const_iterator {
   friend class IntervalMap;
 
+public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = ValT;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
+protected:
   // The map referred to.
   IntervalMap *map;
 

--- a/include/llvm/ADT/PostOrderIterator.h
+++ b/include/llvm/ADT/PostOrderIterator.h
@@ -90,11 +90,14 @@ template<class GraphT,
   class SetType = llvm::SmallPtrSet<typename GraphTraits<GraphT>::NodeType*, 8>,
   bool ExtStorage = false,
   class GT = GraphTraits<GraphT> >
-class po_iterator : public std::iterator<std::forward_iterator_tag,
-                                         typename GT::NodeType, ptrdiff_t>,
-                    public po_iterator_storage<SetType, ExtStorage> {
-  typedef std::iterator<std::forward_iterator_tag,
-                        typename GT::NodeType, ptrdiff_t> super;
+class po_iterator : public po_iterator_storage<SetType, ExtStorage> {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = typename GT::NodeType;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   typedef typename GT::NodeType          NodeType;
   typedef typename GT::ChildIteratorType ChildItTy;
 
@@ -131,8 +134,6 @@ class po_iterator : public std::iterator<std::forward_iterator_tag,
       : po_iterator_storage<SetType, ExtStorage>(S) {
   } // End is when stack is empty.
 public:
-  typedef typename super::pointer pointer;
-
   // Provide static "constructors"...
   static po_iterator begin(GraphT G) {
     return po_iterator(GT::getEntryNode(G));

--- a/include/llvm/ADT/SparseMultiSet.h
+++ b/include/llvm/ADT/SparseMultiSet.h
@@ -218,9 +218,17 @@ public:
   /// Our iterators are iterators over the collection of objects that share a
   /// key.
   template<typename SMSPtrTy>
-  class iterator_base : public std::iterator<std::bidirectional_iterator_tag,
-                                             ValueT> {
+  class iterator_base {
     friend class SparseMultiSet;
+
+  public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = ValueT;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
+  private:
     SMSPtrTy SMS;
     unsigned Idx;
     unsigned SparseIdx;
@@ -247,12 +255,6 @@ public:
     void setNext(unsigned N) { SMS->Dense[Idx].Next = N; }
 
   public:
-    typedef std::iterator<std::bidirectional_iterator_tag, ValueT> super;
-    typedef typename super::value_type value_type;
-    typedef typename super::difference_type difference_type;
-    typedef typename super::pointer pointer;
-    typedef typename super::reference reference;
-
     reference operator*() const {
       assert(isKeyed() && SMS->sparseIndex(SMS->Dense[Idx].Data) == SparseIdx &&
              "Dereferencing iterator of invalid key or index");
@@ -410,7 +412,7 @@ public:
   RangePair equal_range(const KeyT &K) {
     iterator B = find(K);
     iterator E = iterator(this, SMSNode::INVALID, B.SparseIdx);
-    return make_pair(B, E);
+    return std::make_pair(B, E);
   }
 
   /// Insert a new element at the tail of the subset list. Returns an iterator

--- a/include/llvm/ADT/ilist.h
+++ b/include/llvm/ADT/ilist.h
@@ -142,18 +142,16 @@ struct ilist_traits<const Ty> : public ilist_traits<Ty> {};
 // ilist_iterator<Node> - Iterator for intrusive list.
 //
 template<typename NodeTy>
-class ilist_iterator
-  : public std::iterator<std::bidirectional_iterator_tag, NodeTy, ptrdiff_t> {
+class ilist_iterator {
 
 public:
-  typedef ilist_traits<NodeTy> Traits;
-  typedef std::iterator<std::bidirectional_iterator_tag,
-                        NodeTy, ptrdiff_t> super;
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = NodeTy;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
 
-  typedef typename super::value_type value_type;
-  typedef typename super::difference_type difference_type;
-  typedef typename super::pointer pointer;
-  typedef typename super::reference reference;
+  typedef ilist_traits<NodeTy> Traits;
 private:
   pointer NodePtr;
 

--- a/include/llvm/ADT/iterator.h
+++ b/include/llvm/ADT/iterator.h
@@ -35,9 +35,14 @@ namespace llvm {
 template <typename DerivedT, typename IteratorCategoryT, typename T,
           typename DifferenceTypeT = std::ptrdiff_t, typename PointerT = T *,
           typename ReferenceT = T &>
-class iterator_facade_base
-    : public std::iterator<IteratorCategoryT, T, DifferenceTypeT, PointerT,
-                           ReferenceT> {
+class iterator_facade_base {
+public:
+  using iterator_category = IteratorCategoryT;
+  using value_type = T;
+  using difference_type = DifferenceTypeT;
+  using pointer = PointerT;
+  using reference = ReferenceT;
+
 protected:
   enum {
     IsRandomAccess =

--- a/include/llvm/Analysis/AliasSetTracker.h
+++ b/include/llvm/Analysis/AliasSetTracker.h
@@ -187,10 +187,15 @@ public:
   void dump() const;
 
   /// Define an iterator for alias sets... this is just a forward iterator.
-  class iterator : public std::iterator<std::forward_iterator_tag,
-                                        PointerRec, ptrdiff_t> {
+  class iterator {
     PointerRec *CurNode;
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = PointerRec;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     explicit iterator(PointerRec *CN = nullptr) : CurNode(CN) {}
 
     bool operator==(const iterator& x) const {

--- a/include/llvm/Analysis/RegionIterator.h
+++ b/include/llvm/Analysis/RegionIterator.h
@@ -31,10 +31,15 @@ namespace llvm {
 /// For a subregion RegionNode there is just one successor. The RegionNode
 /// representing the exit of the subregion.
 template<class NodeType, class BlockT, class RegionT>
-class RNSuccIterator : public std::iterator<std::forward_iterator_tag,
-                                           NodeType, ptrdiff_t> {
-  typedef std::iterator<std::forward_iterator_tag, NodeType, ptrdiff_t> super;
+class RNSuccIterator {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = NodeType;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
 
+private:
   typedef GraphTraits<BlockT*> BlockTraits;
   typedef typename BlockTraits::ChildIteratorType SuccIterTy;
 
@@ -88,8 +93,6 @@ class RNSuccIterator : public std::iterator<std::forward_iterator_tag,
   }
 public:
   typedef RNSuccIterator<NodeType, BlockT, RegionT> Self;
-
-  typedef typename super::pointer pointer;
 
   /// @brief Create begin iterator of a RegionNode.
   inline RNSuccIterator(NodeType* node)
@@ -154,9 +157,7 @@ public:
 /// are contained in the Region and its subregions. This is close to a virtual
 /// control flow graph of the Region.
 template<class NodeType, class BlockT, class RegionT>
-class RNSuccIterator<FlatIt<NodeType>, BlockT, RegionT>
-  : public std::iterator<std::forward_iterator_tag, NodeType, ptrdiff_t> {
-  typedef std::iterator<std::forward_iterator_tag, NodeType, ptrdiff_t> super;
+class RNSuccIterator<FlatIt<NodeType>, BlockT, RegionT> {
   typedef GraphTraits<BlockT*> BlockTraits;
   typedef typename BlockTraits::ChildIteratorType SuccIterTy;
 
@@ -164,8 +165,13 @@ class RNSuccIterator<FlatIt<NodeType>, BlockT, RegionT>
   SuccIterTy Itor;
 
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = NodeType;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   typedef RNSuccIterator<FlatIt<NodeType>, BlockT, RegionT> Self;
-  typedef typename super::pointer pointer;
 
   /// @brief Create the iterator from a RegionNode.
   ///

--- a/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/include/llvm/CodeGen/MachineBasicBlock.h
@@ -141,11 +141,16 @@ public:
   /// bundle_iterator - MachineBasicBlock iterator that automatically skips over
   /// MIs that are inside bundles (i.e. walk top level MIs only).
   template<typename Ty, typename IterTy>
-  class bundle_iterator
-    : public std::iterator<std::bidirectional_iterator_tag, Ty, ptrdiff_t> {
+  class bundle_iterator {
     IterTy MII;
 
   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = Ty *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     bundle_iterator(IterTy mii) : MII(mii) {}
 
     bundle_iterator(Ty &mi) : MII(mi) {

--- a/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/include/llvm/CodeGen/MachineBasicBlock.h
@@ -146,7 +146,7 @@ public:
 
   public:
     using iterator_category = std::bidirectional_iterator_tag;
-    using value_type = Ty *;
+    using value_type = Ty;
     using difference_type = std::ptrdiff_t;
     using pointer = value_type *;
     using reference = value_type &;

--- a/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -807,8 +807,16 @@ public:
   /// when incrementing.
   template<bool ReturnUses, bool ReturnDefs, bool SkipDebug,
            bool ByOperand, bool ByInstr, bool ByBundle>
-  class defusechain_iterator
-    : public std::iterator<std::forward_iterator_tag, MachineInstr, ptrdiff_t> {
+  class defusechain_iterator {
+  
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = MachineOperand;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
+  private:
     MachineOperand *Op;
     explicit defusechain_iterator(MachineOperand *op) : Op(op) {
       // If the first node isn't one we're interested in, advance to one that
@@ -842,11 +850,6 @@ public:
       }
     }
   public:
-    typedef std::iterator<std::forward_iterator_tag,
-                          MachineInstr, ptrdiff_t>::reference reference;
-    typedef std::iterator<std::forward_iterator_tag,
-                          MachineInstr, ptrdiff_t>::pointer pointer;
-
     defusechain_iterator() : Op(nullptr) {}
 
     bool operator==(const defusechain_iterator &x) const {
@@ -909,8 +912,16 @@ public:
   /// when incrementing.
   template<bool ReturnUses, bool ReturnDefs, bool SkipDebug,
            bool ByOperand, bool ByInstr, bool ByBundle>
-  class defusechain_instr_iterator
-    : public std::iterator<std::forward_iterator_tag, MachineInstr, ptrdiff_t> {
+  class defusechain_instr_iterator {
+  
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = MachineInstr;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
+  private:
     MachineOperand *Op;
     explicit defusechain_instr_iterator(MachineOperand *op) : Op(op) {
       // If the first node isn't one we're interested in, advance to one that
@@ -944,11 +955,6 @@ public:
       }
     }
   public:
-    typedef std::iterator<std::forward_iterator_tag,
-                          MachineInstr, ptrdiff_t>::reference reference;
-    typedef std::iterator<std::forward_iterator_tag,
-                          MachineInstr, ptrdiff_t>::pointer pointer;
-
     defusechain_instr_iterator() : Op(nullptr) {}
 
     bool operator==(const defusechain_instr_iterator &x) const {

--- a/include/llvm/CodeGen/MachineRegisterInfo.h
+++ b/include/llvm/CodeGen/MachineRegisterInfo.h
@@ -811,7 +811,7 @@ public:
   
   public:
     using iterator_category = std::forward_iterator_tag;
-    using value_type = MachineOperand;
+    using value_type = MachineInstr;
     using difference_type = std::ptrdiff_t;
     using pointer = value_type *;
     using reference = value_type &;

--- a/include/llvm/CodeGen/ScheduleDAG.h
+++ b/include/llvm/CodeGen/ScheduleDAG.h
@@ -616,13 +616,18 @@ namespace llvm {
     const MCInstrDesc *getNodeDesc(const SDNode *Node) const;
   };
 
-  class SUnitIterator : public std::iterator<std::forward_iterator_tag,
-                                             SUnit, ptrdiff_t> {
+  class SUnitIterator {
     SUnit *Node;
     unsigned Operand;
 
     SUnitIterator(SUnit *N, unsigned Op) : Node(N), Operand(Op) {}
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = SUnit;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     bool operator==(const SUnitIterator& x) const {
       return Operand == x.Operand;
     }

--- a/include/llvm/CodeGen/SelectionDAGNodes.h
+++ b/include/llvm/CodeGen/SelectionDAGNodes.h
@@ -456,17 +456,17 @@ public:
 
   /// This class provides iterator support for SDUse
   /// operands that use a specific SDNode.
-  class use_iterator
-    : public std::iterator<std::forward_iterator_tag, SDUse, ptrdiff_t> {
+  class use_iterator {
     SDUse *Op;
     explicit use_iterator(SDUse *op) : Op(op) {
     }
     friend class SDNode;
   public:
-    typedef std::iterator<std::forward_iterator_tag,
-                          SDUse, ptrdiff_t>::reference reference;
-    typedef std::iterator<std::forward_iterator_tag,
-                          SDUse, ptrdiff_t>::pointer pointer;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = SDUse;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
 
     use_iterator(const use_iterator &I) : Op(I.Op) {}
     use_iterator() : Op(nullptr) {}
@@ -2182,13 +2182,18 @@ public:
   }
 };
 
-class SDNodeIterator : public std::iterator<std::forward_iterator_tag,
-                                            SDNode, ptrdiff_t> {
+class SDNodeIterator {
   const SDNode *Node;
   unsigned Operand;
 
   SDNodeIterator(const SDNode *N, unsigned Op) : Node(N), Operand(Op) {}
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = SDNode;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   bool operator==(const SDNodeIterator& x) const {
     return Operand == x.Operand;
   }

--- a/include/llvm/IR/CFG.h
+++ b/include/llvm/IR/CFG.h
@@ -27,10 +27,15 @@ namespace llvm {
 //===----------------------------------------------------------------------===//
 
 template <class Ptr, class USE_iterator> // Predecessor Iterator
-class PredIterator : public std::iterator<std::forward_iterator_tag,
-                                          Ptr, ptrdiff_t, Ptr*, Ptr*> {
-  typedef std::iterator<std::forward_iterator_tag, Ptr, ptrdiff_t, Ptr*,
-                                                                    Ptr*> super;
+class PredIterator {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Ptr;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Ptr *;
+  using reference = Ptr *;
+
+private:
   typedef PredIterator<Ptr, USE_iterator> Self;
   USE_iterator It;
 
@@ -41,8 +46,6 @@ class PredIterator : public std::iterator<std::forward_iterator_tag,
   }
 
 public:
-  typedef typename super::pointer pointer;
-  typedef typename super::reference reference;
 
   PredIterator() {}
   explicit inline PredIterator(Ptr *bb) : It(bb->user_begin()) {
@@ -112,14 +115,14 @@ inline pred_const_range predecessors(const BasicBlock *BB) {
 ///////////////////////////////////////////////////////////////////////////////
 
 template <class Term_, class BB_>           // Successor Iterator
-class SuccIterator : public std::iterator<std::random_access_iterator_tag, BB_,
-                                          int, BB_ *, BB_ *> {
-  typedef std::iterator<std::random_access_iterator_tag, BB_, int, BB_ *, BB_ *>
-  super;
+class SuccIterator {
 
 public:
-  typedef typename super::pointer pointer;
-  typedef typename super::reference reference;
+  using iterator_category = std::random_access_iterator_tag;
+  using value_type = BB_;
+  using difference_type = int;
+  using pointer = BB_ *;
+  using reference = BB_ *;
 
 private:
   Term_ Term;

--- a/include/llvm/IR/DebugInfoMetadata.h
+++ b/include/llvm/IR/DebugInfoMetadata.h
@@ -110,11 +110,16 @@ public:
   unsigned size() const { return N ? N->getNumOperands() : 0u; }
   DITypeRef operator[](unsigned I) const { return DITypeRef(N->getOperand(I)); }
 
-  class iterator : std::iterator<std::input_iterator_tag, DITypeRef,
-                                 std::ptrdiff_t, void, DITypeRef> {
+  class iterator {
     MDNode::op_iterator I = nullptr;
 
   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = DIType *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = DIType *;
+  
     iterator() = default;
     explicit iterator(MDNode::op_iterator I) : I(I) {}
     DITypeRef operator*() const { return DITypeRef(*I); }
@@ -2086,11 +2091,16 @@ public:
   };
 
   /// \brief An iterator for expression operands.
-  class expr_op_iterator
-      : public std::iterator<std::input_iterator_tag, ExprOperand> {
+  class expr_op_iterator {
     ExprOperand Op;
 
   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = ExprOperand;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     explicit expr_op_iterator(element_iterator I) : Op(I) {}
 
     element_iterator getBase() const { return Op.get(); }

--- a/include/llvm/IR/DebugInfoMetadata.h
+++ b/include/llvm/IR/DebugInfoMetadata.h
@@ -115,10 +115,10 @@ public:
 
   public:
     using iterator_category = std::input_iterator_tag;
-    using value_type = DIType *;
+    using value_type = DITypeRef;
     using difference_type = std::ptrdiff_t;
     using pointer = void;
-    using reference = DIType *;
+    using reference = DITypeRef;
   
     iterator() = default;
     explicit iterator(MDNode::op_iterator I) : I(I) {}

--- a/include/llvm/IR/GetElementPtrTypeIterator.h
+++ b/include/llvm/IR/GetElementPtrTypeIterator.h
@@ -22,16 +22,18 @@
 
 namespace llvm {
   template<typename ItTy = User::const_op_iterator>
-  class generic_gep_type_iterator
-    : public std::iterator<std::forward_iterator_tag, Type *, ptrdiff_t> {
-    typedef std::iterator<std::forward_iterator_tag,
-                          Type *, ptrdiff_t> super;
+  class generic_gep_type_iterator {
 
     ItTy OpIt;
     PointerIntPair<Type *, 1> CurTy;
     unsigned AddrSpace;
     generic_gep_type_iterator() {}
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Type *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
 
     static generic_gep_type_iterator begin(Type *Ty, ItTy It) {
       generic_gep_type_iterator I;

--- a/include/llvm/IR/Metadata.h
+++ b/include/llvm/IR/Metadata.h
@@ -1057,11 +1057,16 @@ void TempMDNodeDeleter::operator()(MDNode *Node) const {
 /// An iterator that transforms an \a MDNode::iterator into an iterator over a
 /// particular Metadata subclass.
 template <class T>
-class TypedMDOperandIterator
-    : std::iterator<std::input_iterator_tag, T *, std::ptrdiff_t, void, T *> {
+class TypedMDOperandIterator {
   MDNode::op_iterator I = nullptr;
 
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = T *;
+  using difference_type = std::ptrdiff_t;
+  using pointer = void;
+  using reference = T *;
+
   TypedMDOperandIterator() = default;
   explicit TypedMDOperandIterator(MDNode::op_iterator I) : I(I) {}
   T *operator*() const { return cast_or_null<T>(*I); }
@@ -1147,8 +1152,7 @@ class NamedMDNode : public ilist_node<NamedMDNode> {
   explicit NamedMDNode(const Twine &N);
 
   template<class T1, class T2>
-  class op_iterator_impl :
-      public std::iterator<std::bidirectional_iterator_tag, T2> {
+  class op_iterator_impl {
     const NamedMDNode *Node;
     unsigned Idx;
     op_iterator_impl(const NamedMDNode *N, unsigned i) : Node(N), Idx(i) { }
@@ -1156,6 +1160,12 @@ class NamedMDNode : public ilist_node<NamedMDNode> {
     friend class NamedMDNode;
 
   public:
+    using iterator_category = std::bidirectional_iterator_tag;
+    using value_type = T2;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     op_iterator_impl() : Node(nullptr), Idx(0) { }
 
     bool operator==(const op_iterator_impl &o) const { return Idx == o.Idx; }

--- a/include/llvm/IR/Value.h
+++ b/include/llvm/IR/Value.h
@@ -114,13 +114,18 @@ protected:
 
 private:
   template <typename UseT> // UseT == 'Use' or 'const Use'
-  class use_iterator_impl
-      : public std::iterator<std::forward_iterator_tag, UseT *> {
+  class use_iterator_impl {
     UseT *U;
     explicit use_iterator_impl(UseT *u) : U(u) {}
     friend class Value;
 
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = UseT *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     use_iterator_impl() : U() {}
 
     bool operator==(const use_iterator_impl &x) const { return U == x.U; }
@@ -150,13 +155,18 @@ private:
   };
 
   template <typename UserTy> // UserTy == 'User' or 'const User'
-  class user_iterator_impl
-      : public std::iterator<std::forward_iterator_tag, UserTy *> {
+  class user_iterator_impl {
     use_iterator_impl<Use> UI;
     explicit user_iterator_impl(Use *U) : UI(U) {}
     friend class Value;
 
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = UserTy *;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+  
     user_iterator_impl() {}
 
     bool operator==(const user_iterator_impl &x) const { return UI == x.UI; }

--- a/include/llvm/IR/ValueMap.h
+++ b/include/llvm/IR/ValueMap.h
@@ -295,14 +295,17 @@ struct DenseMapInfo<ValueMapCallbackVH<KeyT, ValueT, Config> > {
 
 
 template<typename DenseMapT, typename KeyT>
-class ValueMapIterator :
-    public std::iterator<std::forward_iterator_tag,
-                         std::pair<KeyT, typename DenseMapT::mapped_type>,
-                         ptrdiff_t> {
+class ValueMapIterator {
   typedef typename DenseMapT::iterator BaseT;
   typedef typename DenseMapT::mapped_type ValueT;
   BaseT I;
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = std::pair<KeyT, typename DenseMapT::mapped_type>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   ValueMapIterator() : I() {}
 
   ValueMapIterator(BaseT I) : I(I) {}
@@ -344,14 +347,17 @@ public:
 };
 
 template<typename DenseMapT, typename KeyT>
-class ValueMapConstIterator :
-    public std::iterator<std::forward_iterator_tag,
-                         std::pair<KeyT, typename DenseMapT::mapped_type>,
-                         ptrdiff_t> {
+class ValueMapConstIterator {
   typedef typename DenseMapT::const_iterator BaseT;
   typedef typename DenseMapT::mapped_type ValueT;
   BaseT I;
 public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::pair<KeyT, typename DenseMapT::mapped_type>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
   ValueMapConstIterator() : I() {}
   ValueMapConstIterator(BaseT I) : I(I) {}
   ValueMapConstIterator(ValueMapIterator<DenseMapT, KeyT> Other)

--- a/include/llvm/Object/SymbolicFile.h
+++ b/include/llvm/Object/SymbolicFile.h
@@ -46,11 +46,16 @@ inline bool operator<(const DataRefImpl &a, const DataRefImpl &b) {
 }
 
 template <class content_type>
-class content_iterator
-    : public std::iterator<std::forward_iterator_tag, content_type> {
+class content_iterator {
   content_type Current;
 
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = content_type;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   content_iterator(content_type symb) : Current(symb) {}
 
   const content_type *operator->() const { return &Current; }

--- a/include/llvm/ProfileData/CoverageMappingReader.h
+++ b/include/llvm/ProfileData/CoverageMappingReader.h
@@ -40,14 +40,19 @@ struct CoverageMappingRecord {
 };
 
 /// \brief A file format agnostic iterator over coverage mapping data.
-class CoverageMappingIterator
-    : public std::iterator<std::input_iterator_tag, CoverageMappingRecord> {
+class CoverageMappingIterator {
   CoverageMappingReader *Reader;
   CoverageMappingRecord Record;
 
   void increment();
 
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = CoverageMappingRecord;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   CoverageMappingIterator() : Reader(nullptr) {}
   CoverageMappingIterator(CoverageMappingReader *Reader) : Reader(Reader) {
     increment();

--- a/include/llvm/ProfileData/InstrProfReader.h
+++ b/include/llvm/ProfileData/InstrProfReader.h
@@ -30,13 +30,18 @@ namespace llvm {
 class InstrProfReader;
 
 /// A file format agnostic iterator over profiling data.
-class InstrProfIterator : public std::iterator<std::input_iterator_tag,
-                                               InstrProfRecord> {
+class InstrProfIterator {
   InstrProfReader *Reader;
   InstrProfRecord Record;
 
   void Increment();
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = InstrProfRecord;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   InstrProfIterator() : Reader(nullptr) {}
   InstrProfIterator(InstrProfReader *Reader) : Reader(Reader) { Increment(); }
 

--- a/include/llvm/Support/LineIterator.h
+++ b/include/llvm/Support/LineIterator.h
@@ -29,8 +29,7 @@ class MemoryBuffer;
 /// character.
 ///
 /// Note that this iterator requires the buffer to be nul terminated.
-class line_iterator
-    : public std::iterator<std::forward_iterator_tag, StringRef> {
+class line_iterator {
   const MemoryBuffer *Buffer;
   char CommentMarker;
   bool SkipBlanks;
@@ -39,6 +38,12 @@ class line_iterator
   StringRef CurrentLine;
 
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = StringRef;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   /// \brief Default construct an "end" iterator.
   line_iterator() : Buffer(nullptr) {}
 

--- a/include/llvm/Support/TargetRegistry.h
+++ b/include/llvm/Support/TargetRegistry.h
@@ -545,13 +545,18 @@ struct TargetRegistry {
   // function).
   TargetRegistry() = delete;
 
-  class iterator
-      : public std::iterator<std::forward_iterator_tag, Target, ptrdiff_t> {
+  class iterator {
     const Target *Current;
     explicit iterator(Target *T) : Current(T) {}
     friend struct TargetRegistry;
 
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = Target;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     iterator() : Current(nullptr) {}
 
     bool operator==(const iterator &x) const { return Current == x.Current; }

--- a/include/llvm/Support/YAMLParser.h
+++ b/include/llvm/Support/YAMLParser.h
@@ -305,7 +305,7 @@ private:
 template <class BaseT, class ValueT>
 class basic_collection_iterator {
 public:
-  using iterator_category = std::input_iterator_tag;
+  using iterator_category = std::forward_iterator_tag;
   using value_type = ValueT;
   using difference_type = std::ptrdiff_t;
   using pointer = value_type *;

--- a/include/llvm/Support/YAMLParser.h
+++ b/include/llvm/Support/YAMLParser.h
@@ -303,9 +303,14 @@ private:
 /// BaseT must have a ValueT* member named CurrentEntry and a member function
 /// increment() which must set CurrentEntry to 0 to create an end iterator.
 template <class BaseT, class ValueT>
-class basic_collection_iterator
-    : public std::iterator<std::forward_iterator_tag, ValueT> {
+class basic_collection_iterator {
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = ValueT;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   basic_collection_iterator() : Base(nullptr) {}
   basic_collection_iterator(BaseT *B) : Base(B) {}
 

--- a/lib/Analysis/CFLAliasAnalysis.cpp
+++ b/lib/Analysis/CFLAliasAnalysis.cpp
@@ -627,8 +627,12 @@ public:
   // allow modificaiton of the edges using this iterator. Additionally, the
   // iterator becomes invalid if you add edges to or from the node you're
   // getting the edges of.
-  struct EdgeIterator : public std::iterator<std::forward_iterator_tag,
-                                             std::tuple<EdgeTypeT, Node *>> {
+  struct EdgeIterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::tuple<EdgeTypeT, Node *>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
     EdgeIterator(const typename std::vector<Edge>::const_iterator &Iter)
         : Current(Iter) {}
 

--- a/lib/IR/BasicBlock.cpp
+++ b/lib/IR/BasicBlock.cpp
@@ -284,7 +284,7 @@ BasicBlock *BasicBlock::getUniqueSuccessor() {
 void BasicBlock::removePredecessor(BasicBlock *Pred,
                                    bool DontDeleteUselessPHIs) {
   assert((hasNUsesOrMore(16)||// Reduce cost of this assertion for complex CFGs.
-          find(pred_begin(this), pred_end(this), Pred) != pred_end(this)) &&
+          std::find(pred_begin(this), pred_end(this), Pred) != pred_end(this)) &&
          "removePredecessor: BB is not a predecessor!");
 
   if (InstList.empty()) return;

--- a/tools/clang/include/clang/AST/Stmt.h
+++ b/tools/clang/include/clang/AST/Stmt.h
@@ -58,11 +58,16 @@ namespace clang {
   class Stmt;
   class Expr;
 
-  class ExprIterator : public std::iterator<std::forward_iterator_tag,
-                                            Expr *&, ptrdiff_t,
-                                            Expr *&, Expr *&> {
+  class ExprIterator {
     Stmt** I;
   public:
+    using REFERENCE = Expr *&;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = REFERENCE;
+    using difference_type = std::ptrdiff_t;
+    using pointer = REFERENCE;
+    using reference = REFERENCE;
+
     ExprIterator(Stmt** i) : I(i) {}
     ExprIterator() : I(nullptr) {}
     ExprIterator& operator++() { ++I; return *this; }
@@ -79,12 +84,16 @@ namespace clang {
     bool operator>=(const ExprIterator& R) const { return I >= R.I; }
   };
 
-  class ConstExprIterator : public std::iterator<std::forward_iterator_tag,
-                                                 const Expr *&, ptrdiff_t,
-                                                 const Expr *&,
-                                                 const Expr *&> {
+  class ConstExprIterator {
     const Stmt * const *I;
   public:
+    using REFERENCE = Expr *&;
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = REFERENCE;
+    using difference_type = std::ptrdiff_t;
+    using pointer = REFERENCE;
+    using reference = REFERENCE;
+
     ConstExprIterator(const Stmt * const *i) : I(i) {}
     ConstExprIterator() : I(nullptr) {}
     ConstExprIterator& operator++() { ++I; return *this; }

--- a/tools/clang/include/clang/AST/StmtIterator.h
+++ b/tools/clang/include/clang/AST/StmtIterator.h
@@ -74,13 +74,16 @@ protected:
 
 
 template <typename DERIVED, typename REFERENCE>
-class StmtIteratorImpl : public StmtIteratorBase,
-                         public std::iterator<std::forward_iterator_tag,
-                                              REFERENCE, ptrdiff_t,
-                                              REFERENCE, REFERENCE> {
+class StmtIteratorImpl : public StmtIteratorBase {
 protected:
   StmtIteratorImpl(const StmtIteratorBase& RHS) : StmtIteratorBase(RHS) {}
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = REFERENCE;
+  using difference_type = std::ptrdiff_t;
+  using pointer = REFERENCE;
+  using reference = REFERENCE;
+
   StmtIteratorImpl() {}
   StmtIteratorImpl(Stmt **s) : StmtIteratorBase(s) {}
   StmtIteratorImpl(Decl **dgi, Decl **dge) : StmtIteratorBase(dgi, dge) {}

--- a/tools/clang/include/clang/Rewrite/Core/RewriteRope.h
+++ b/tools/clang/include/clang/Rewrite/Core/RewriteRope.h
@@ -85,8 +85,7 @@ namespace clang {
   /// over bytes that are in a RopePieceBTree.  This first iterates over bytes
   /// in a RopePiece, then iterates over RopePiece's in a RopePieceBTreeLeaf,
   /// then iterates over RopePieceBTreeLeaf's in a RopePieceBTree.
-  class RopePieceBTreeIterator :
-      public std::iterator<std::forward_iterator_tag, const char, ptrdiff_t> {
+  class RopePieceBTreeIterator {
     /// CurNode - The current B+Tree node that we are inspecting.
     const void /*RopePieceBTreeLeaf*/ *CurNode;
     /// CurPiece - The current RopePiece in the B+Tree node that we're
@@ -95,6 +94,12 @@ namespace clang {
     /// CurChar - The current byte in the RopePiece we are pointing to.
     unsigned CurChar;
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const char;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type *;
+    using reference = value_type &;
+
     // begin iterator.
     RopePieceBTreeIterator(const void /*RopePieceBTreeNode*/ *N);
     // end iterator

--- a/tools/clang/unittests/HLSL/Objects.cpp
+++ b/tools/clang/unittests/HLSL/Objects.cpp
@@ -49,12 +49,17 @@ ElementType first_or_default(
 }
 
 template <typename TEnumeration>
-class EnumFlagsIterator : public std::iterator<std::input_iterator_tag, TEnumeration>
-{
+class EnumFlagsIterator {
 private:
   unsigned long _value;
 
 public:
+  using iterator_category = std::input_iterator_tag;
+  using value_type = TEnumeration;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type *;
+  using reference = value_type &;
+
   EnumFlagsIterator(TEnumeration value) : _value(value) { }
 
   TEnumeration operator*() const


### PR DESCRIPTION


Merged from https://github.com/llvm/llvm-project/commit/0a92aff721f43406691e38a0965fd0c917121d09

This patch removes all uses of `std::iterator`, which was deprecated in C++17. While this isn't currently an issue while compiling LLVM, it's useful for those using LLVM as a library.

For some reason there're a few places that were seemingly able to use `std` functions unqualified, which no longer works after this patch. I've updated those places, but I'm not really sure why it worked in the first place.