### PR TITLE
Lit TAEF fixes: Use filter when listing tests and fix verbose parameter

### DIFF
--- a/projects/dxilconv/test/taef/lit.cfg
+++ b/projects/dxilconv/test/taef/lit.cfg
@@ -33,8 +33,8 @@ test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
 param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
 extra_params = [param_hlsl_data_dir]
 
-verbose = lit_config.params.get('verbose', None)
-if verbose == None:
+verbose = config.verbose
+if verbose != True:
     extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 
 arch = getattr(config, 'taef_arch', None)

--- a/projects/dxilconv/test/taef/lit.cfg
+++ b/projects/dxilconv/test/taef/lit.cfg
@@ -33,7 +33,7 @@ test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
 param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
 extra_params = [param_hlsl_data_dir]
 
-verbose = config.verbose
+verbose = bool(getattr(config, 'verbose', False))
 if verbose != True:
     extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 

--- a/projects/dxilconv/test/taef/lit.site.cfg.in
+++ b/projects/dxilconv/test/taef/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_build_mode = "@LLVM_BUILD_MODE@"
 config.te = "@TAEF_EXECUTABLE@"
 config.taef_arch = "@TAEF_ARCH@"
+config.verbose = True
 
 # Support substitution of the tools_dir, libs_dirs, and build_mode with user
 # parameters. This is used when we can't determine the tool dir at

--- a/tools/clang/test/taef/lit.cfg
+++ b/tools/clang/test/taef/lit.cfg
@@ -38,7 +38,7 @@ else:
   param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
   extra_params = [param_hlsl_data_dir]
 
-  verbose = config.verbose
+  verbose = bool(getattr(config, 'verbose', False))
   if verbose != True:
       extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 

--- a/tools/clang/test/taef/lit.cfg
+++ b/tools/clang/test/taef/lit.cfg
@@ -38,8 +38,8 @@ else:
   param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
   extra_params = [param_hlsl_data_dir]
 
-  verbose = lit_config.params.get('verbose', None)
-  if verbose == None:
+  verbose = config.verbose
+  if verbose != True:
       extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 
   arch = getattr(config, 'taef_arch', None)

--- a/tools/clang/test/taef/lit.site.cfg.in
+++ b/tools/clang/test/taef/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_build_mode = "@LLVM_BUILD_MODE@"
 config.te = "@TAEF_EXECUTABLE@"
 config.taef_arch = "@TAEF_ARCH@"
+config.verbose = True
 
 # Support substitution of the tools_dir, libs_dirs, and build_mode with user
 # parameters. This is used when we can't determine the tool dir at

--- a/tools/clang/test/taef_exec/lit.cfg
+++ b/tools/clang/test/taef_exec/lit.cfg
@@ -54,8 +54,8 @@ if config.unsupported == False:
 
   extra_params = ['/p:"ExperimentalShaders=*\"', param_hlsl_data_dir]
 
-  verbose = lit_config.params.get('verbose', None)
-  if verbose == None:
+  verbose = config.verbose
+  if verbose != True:
       extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 
   adapter = lit_config.params.get('adapter', None)

--- a/tools/clang/test/taef_exec/lit.cfg
+++ b/tools/clang/test/taef_exec/lit.cfg
@@ -54,7 +54,7 @@ if config.unsupported == False:
 
   extra_params = ['/p:"ExperimentalShaders=*\"', param_hlsl_data_dir]
 
-  verbose = config.verbose
+  verbose = bool(getattr(config, 'verbose', False))
   if verbose != True:
       extra_params.append('/logOutput:"LowWithConsoleBuffering"')
 

--- a/tools/clang/test/taef_exec/lit.site.cfg.in
+++ b/tools/clang/test/taef_exec/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_build_mode = "@LLVM_BUILD_MODE@"
 config.te = "@TAEF_EXECUTABLE@"
 config.taef_arch = "@TAEF_ARCH@"
+config.verbose = True
 
 # Support substitution of the tools_dir, libs_dirs, and build_mode with user
 # parameters. This is used when we can't determine the tool dir at

--- a/utils/lit/lit/formats/taef.py
+++ b/utils/lit/lit/formats/taef.py
@@ -64,10 +64,12 @@ class TaefTest(TestFormat):
 
         if litConfig.debug:
             litConfig.note('searching taef test in %r' % dll_path)
+        
+        select_arg = str.format('/select:"{}"', self.select_filter)
 
+        cmd = [self.te, dll_path, "/list", select_arg]
         try:
-            lines = lit.util.capture([self.te, dll_path, '/list'],
-                                     env=localConfig.environment)
+            lines,_,_ = executeCommandForTaef(cmd)
             # this is for windows
             lines = lines.replace('\r', '')
             lines = lines.split('\n')


### PR DESCRIPTION
Lit TAEF files fixes:
- Use filter parameter when enumerating tests. This enables listing of just the tests that should run, and it also filtering by architecture. This is crucial for isolating ARM64 and ARM64EC versions of tests that are in the same test dll.
- Fix verbose parameter - it was not getting applied

Related to #5489.