### PR TITLE
[Test] Replace size integer literal with regex

### DIFF
--- a/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc  -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
 
 
-// CHECK:DxilRuntimeData (size = 240 bytes):
-// CHECK:  StringBuffer (size = 24 bytes)
-// CHECK:  IndexTable (size = 24 bytes)
-// CHECK:  RawBytes (size = 0 bytes)
+// CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:  IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:  RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:  RecordTable (stride = 32 bytes) ResourceTable[1] = {
 // CHECK:    <0:RuntimeDataResourceInfo> = {
 // CHECK:      Class: SRV

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
@@ -5,10 +5,10 @@
 
 // CHECK-NOT: CBufUnused
 
-// CHECK: DxilRuntimeData (size = 448 bytes):
-// CHECK:   StringBuffer (size = 52 bytes)
-// CHECK:   IndexTable (size = 28 bytes)
-// CHECK:   RawBytes (size = 0 bytes)
+// CHECK: DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:   IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:   RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:   RecordTable (stride = 32 bytes) ResourceTable[3] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: CBuffer

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
@@ -1,9 +1,9 @@
 // RUN: %dxc -T lib_6_5 %s | %D3DReflect %s | FileCheck %s
 
-// CHECK:DxilRuntimeData (size = 276 bytes):
-// CHECK:  StringBuffer (size = 28 bytes)
-// CHECK:  IndexTable (size = 28 bytes)
-// CHECK:  RawBytes (size = 0 bytes)
+// CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:  IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:  RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:  RecordTable (stride = 32 bytes) ResourceTable[2] = {
 // CHECK:    <0:RuntimeDataResourceInfo> = {
 // CHECK:      Class: SRV

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
@@ -1,9 +1,9 @@
 // RUN: %dxc -T lib_6_8  %s | %D3DReflect %s | FileCheck %s
 
-// CHECK:DxilRuntimeData (size = 488 bytes):
-// CHECK:  StringBuffer (size = 56 bytes)
-// CHECK:  IndexTable (size = 92 bytes)
-// CHECK:  RawBytes (size = 0 bytes)
+// CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:  IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:  RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
 // CHECK:    <0:RuntimeDataFunctionInfo3> = {
 // CHECK:      Name: "depth18part0_wg_63_nodes_seed_255"

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
@@ -1,10 +1,10 @@
 // RUN: %dxc -T lib_6_8  %s | %D3DReflect %s | FileCheck %s
 
 
-// CHECK:DxilRuntimeData (size = 472 bytes):
-// CHECK:  StringBuffer (size = 32 bytes)
-// CHECK:  IndexTable (size = 92 bytes)
-// CHECK:  RawBytes (size = 0 bytes)
+// CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:  IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:  RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
 // CHECK:    <0:RuntimeDataFunctionInfo3> = {
 // CHECK:      Name: "Input2Output"

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
@@ -21,10 +21,10 @@ float4 PSMain(int idx : INDEX) : SV_Target {
   return T2[T0.Load(idx)].f;
 }
 
-// CHECK: DxilRuntimeData (size = 584 bytes):
-// CHECK:   StringBuffer (size = 140 bytes)
-// CHECK:   IndexTable (size = 28 bytes)
-// CHECK:   RawBytes (size = 0 bytes)
+// CHECK: DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:   IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:   RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:   RecordTable (stride = 32 bytes) ResourceTable[3] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
@@ -26,10 +26,10 @@ void RayGen() {
   U0.Store(idx.y * dim.x * 4 + idx.x * 4, idx.x ^ idx.y);
 }
 
-// CHECK: DxilRuntimeData (size = 612 bytes):
-// CHECK:   StringBuffer (size = 148 bytes)
-// CHECK:   IndexTable (size = 16 bytes)
-// CHECK:   RawBytes (size = 0 bytes)
+// CHECK: DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:   IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:   RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:   RecordTable (stride = 32 bytes) ResourceTable[2] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
@@ -17,10 +17,10 @@ float4 PSMain(int idx : INDEX) : SV_Target {
   return T2[T0.Load(idx)].f;
 }
 
-// CHECK: DxilRuntimeData (size = 756 bytes):
-// CHECK:   StringBuffer (size = 176 bytes)
-// CHECK:   IndexTable (size = 28 bytes)
-// CHECK:   RawBytes (size = 0 bytes)
+// CHECK: DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:   IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:   RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:   RecordTable (stride = 32 bytes) ResourceTable[2] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
@@ -90,10 +90,10 @@ HSPerPatchData HSPerPatchFunc1()
   return d;
 }
 
-// CHECK: DxilRuntimeData (size = 824 bytes):
-// CHECK:   StringBuffer (size = 236 bytes)
-// CHECK:   IndexTable (size = 40 bytes)
-// CHECK:   RawBytes (size = 0 bytes)
+// CHECK: DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:   IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:   RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:   RecordTable (stride = 56 bytes) FunctionTable[5] = {
 // CHECK:     <0:RuntimeDataFunctionInfo3> = {
 // CHECK:       Name: "\01?HSMain1{{[@$?.A-Za-z0-9_]+}}"

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
@@ -1,9 +1,9 @@
 // RUN: %dxilver 1.8 | %dxc -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
 
-// CHECK:DxilRuntimeData (size = 340 bytes):
-// CHECK:  StringBuffer (size = 32 bytes)
-// CHECK:  IndexTable (size = 64 bytes)
-// CHECK:  RawBytes (size = 0 bytes)
+// CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
+// CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
+// CHECK:  IndexTable (size = {{[0-9]+}} bytes)
+// CHECK:  RawBytes (size = {{[0-9]+}} bytes)
 // CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
 // CHECK:    <0:RuntimeDataFunctionInfo3> = {
 // CHECK:      Name: "main"


### PR DESCRIPTION
Some D3DReflect tests compare size values literally, when the size will change depending on the validator version.
This PR changes the literal integer in the checkline to a regex, so that the size value changing between validators won't break the test. 
Fixes  #5386 
