### PR TITLE
[CMake] Don't add unnecessary compiler flags to llvm-config output

### DIFF
--- a/tools/llvm-config/CMakeLists.txt
+++ b/tools/llvm-config/CMakeLists.txt
@@ -18,12 +18,20 @@ string(REPLACE ";" " " SYSTEM_LIBS "${SYSTEM_LIBS}")
 # Fetch target specific compile options, e.g. RTTI option
 get_property(COMPILE_FLAGS TARGET llvm-config PROPERTY COMPILE_FLAGS)
 
+# The language standard potentially affects the ABI/API of LLVM, so we want
+# to make sure it is reported by llvm-config.
+# NOTE: We don't want to start extracting any random C/CXX flags that the
+# user may add that could affect the ABI.  We only want to extract flags
+# that have been added by the LLVM build system.
+string(REGEX MATCH "-std=[^ ]\+" LLVM_CXX_STD_FLAG ${CMAKE_CXX_FLAGS})
+string(REGEX MATCH "-std=[^ ]\+" LLVM_C_STD_FLAG ${CMAKE_C_FLAGS})
+
 # Use configure_file to create BuildVariables.inc.
 set(LLVM_SRC_ROOT ${LLVM_MAIN_SRC_DIR})
 set(LLVM_OBJ_ROOT ${LLVM_BINARY_DIR})
-set(LLVM_CPPFLAGS "${CMAKE_CPP_FLAGS} ${CMAKE_CPP_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${LLVM_DEFINITIONS}")
-set(LLVM_CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${LLVM_DEFINITIONS}")
-set(LLVM_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${COMPILE_FLAGS} ${LLVM_DEFINITIONS}")
+set(LLVM_CPPFLAGS "${LLVM_DEFINITIONS}")
+set(LLVM_CFLAGS "${LLVM_C_STD_FLAG} ${LLVM_DEFINITIONS}")
+set(LLVM_CXXFLAGS "${LLVM_CXX_STD_FLAG} ${COMPILE_FLAGS} ${LLVM_DEFINITIONS}")
 # Use the C++ link flags, since they should be a superset of C link flags.
 set(LLVM_LDFLAGS "${CMAKE_CXX_LINK_FLAGS}")
 set(LLVM_BUILDMODE ${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
This is for running source coverage on windows.

Merge from
https://github.com/llvm/llvm-project/commit/dda331284db4cb6a43481aa7735dee26e504ff36


Summary:
llvm-config --cxxflags --cflags, should only output the minimal flags required to link against the llvm libraries.  They currently contain all flags used to compile llvm including flags like -g, -pedantic, -Wall, etc, which users may not always want.

This changes the llvm-config output to only include flags that have been explictly added to the COMPILE_FLAGS property of the llvm-config target by the llvm build system.

llvm.org/PR8220

Output from llvm-config when running cmake with:
cmake -G Ninja .. -DCMAKE_CXX_FLAGS=-funroll-loops

Before:

--cppflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include
            -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
--cflags:   -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include
            -fPIC -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings \
            -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough \
            -Wno-comment -fdiagnostics-color -g -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS \
            -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
--cxxflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include\
            -funroll-loops -fPIC -fvisibility-inlines-hidden -Werror=date-time -std=c++11 -Wall \
            -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers \
            -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized \
            -Wno-class-memaccess -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment \
            -fdiagnostics-color -g  -fno-exceptions -fno-rtti -D_GNU_SOURCE -D_DEBUG \
            -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"

After:

--cppflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
            -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
--cflags:   -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
            -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
--cxxflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
             -std=c++11   -fno-exceptions -fno-rtti \
             -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS

Differential Revision: https://reviews.llvm.org/D55391

llvm-svn: 349068
(cherry picked from commit dda331284db4cb6a43481aa7735dee26e504ff36)