### PR TITLE
Fixed incorrect BlockSize in PDB header

### DIFF
--- a/lib/DXIL/DxilPDB.cpp
+++ b/lib/DXIL/DxilPDB.cpp
@@ -94,7 +94,7 @@ struct MSFWriter {
     MSF_SuperBlock SB;
   };
 
-  int m_NumBlocks = 0;
+  int m_NumStreamBlocks = 0;
   SmallVector<Stream, 8> m_Streams;
 
   static uint32_t GetNumBlocks(uint32_t Size) {
@@ -106,7 +106,7 @@ struct MSFWriter {
     Stream S;
     S.Data = Data;
     S.NumBlocks = GetNumBlocks(Data.size());
-    m_NumBlocks += S.NumBlocks;
+    m_NumStreamBlocks += S.NumBlocks;
     m_Streams.push_back(S);
     return ID;
   }
@@ -123,17 +123,6 @@ struct MSFWriter {
       DirectorySizeInBytes += m_Streams[i].NumBlocks * 4;
     }
     return DirectorySizeInBytes;
-  }
-
-  MSF_SuperBlock CalculateSuperblock() {
-    MSF_SuperBlock SB = {};
-    memcpy(SB.MagicBytes, kMsfMagic, sizeof(kMsfMagic));
-    SB.BlockSize = kMsfBlockSize;
-    SB.NumDirectoryBytes = CalculateDirectorySize();
-    SB.NumBlocks = 3 + m_NumBlocks + GetNumBlocks(SB.NumDirectoryBytes);
-    SB.FreeBlockMapBlock = 1;
-    SB.BlockMapAddr = 3;
-    return SB;
   }
 
   struct BlockWriter {
@@ -185,13 +174,26 @@ struct MSFWriter {
   }
 
   void WriteToStream(raw_ostream &OS) {
-    MSF_SuperBlock SB = CalculateSuperblock();
-    const uint32_t NumDirectoryBlocks = GetNumBlocks(SB.NumDirectoryBytes);
-    const uint32_t StreamDirectoryAddr = SB.BlockMapAddr;
-    const uint32_t BlockAddrSize = NumDirectoryBlocks * sizeof(support::ulittle32_t);
-    const uint32_t NumBlockAddrBlocks = GetNumBlocks(BlockAddrSize);
-    const uint32_t StreamDirectoryStart = StreamDirectoryAddr + NumBlockAddrBlocks;
-    const uint32_t StreamStart = StreamDirectoryStart + NumDirectoryBlocks;
+    const uint32_t StreamDirectorySizeInBytes = CalculateDirectorySize();
+    const uint32_t StreamDirectoryNumBlocks = GetNumBlocks(StreamDirectorySizeInBytes);
+
+    const uint32_t BlockAddrSizeInBytes = StreamDirectoryNumBlocks * sizeof(support::ulittle32_t);
+    const uint32_t BlockAddrNumBlocks = GetNumBlocks(BlockAddrSizeInBytes);
+
+    const uint32_t BlockAddrStart = 3;
+    const uint32_t StreamDirectoryStart = BlockAddrStart + BlockAddrNumBlocks;
+    const uint32_t StreamStart = StreamDirectoryStart + StreamDirectoryNumBlocks;
+
+    MSF_SuperBlock SB = {};
+    {
+      memcpy(SB.MagicBytes, kMsfMagic, sizeof(kMsfMagic));
+      SB.BlockSize = kMsfBlockSize;
+      SB.NumDirectoryBytes = StreamDirectorySizeInBytes;
+      SB.NumBlocks = 3 /*super block + FPM1 + FPM2*/ + m_NumStreamBlocks +
+                     StreamDirectoryNumBlocks + BlockAddrNumBlocks;
+      SB.FreeBlockMapBlock = 1;
+      SB.BlockMapAddr = 3;
+    }
 
     BlockWriter Writer(OS);
     Writer.WriteBlocks(1, &SB, sizeof(SB)); // Super Block
@@ -204,13 +206,13 @@ struct MSFWriter {
     {
       SmallVector<support::ulittle32_t, 4> BlockAddr;
       uint32_t Start = StreamDirectoryStart;
-      for (unsigned i = 0; i < NumDirectoryBlocks; i++) {
+      for (unsigned i = 0; i < StreamDirectoryNumBlocks; i++) {
         support::ulittle32_t V;
         V = Start++;
         BlockAddr.push_back(V);
       }
-      assert(BlockAddrSize == sizeof(BlockAddr[0])*BlockAddr.size());
-      Writer.WriteBlocks(NumBlockAddrBlocks, BlockAddr.data(), BlockAddrSize);
+      assert(BlockAddrSizeInBytes == sizeof(BlockAddr[0])*BlockAddr.size());
+      Writer.WriteBlocks(BlockAddrNumBlocks, BlockAddr.data(), BlockAddr.size());
     }
 
     // Stream Directory. Describes where all the streams are
@@ -229,7 +231,7 @@ struct MSFWriter {
           StreamDirectoryData.push_back(MakeUint32LE(Start++));
         }
       }
-      Writer.WriteBlocks(NumDirectoryBlocks, StreamDirectoryData.data(), StreamDirectoryData.size()*sizeof(StreamDirectoryData[0]));
+      Writer.WriteBlocks(StreamDirectoryNumBlocks, StreamDirectoryData.data(), StreamDirectoryData.size()*sizeof(StreamDirectoryData[0]));
     }
 
     // Write the streams.

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -55,6 +55,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/MSFileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
 
@@ -146,6 +147,7 @@ public:
   TEST_METHOD(CompileThenTestPdbUtilsStripped)
   TEST_METHOD(CompileThenTestPdbUtilsEmptyEntry)
   TEST_METHOD(CompileThenTestPdbUtilsRelativePath)
+  TEST_METHOD(CompileThenTestPdbIntegrity)
   TEST_METHOD(CompileSameFilenameAndEntryThenTestPdbUtilsArgs)
   TEST_METHOD(CompileWithRootSignatureThenStripRootSignature)
   TEST_METHOD(CompileThenSetRootSignatureThenValidate)
@@ -1967,6 +1969,89 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsRelativePath) {
 
   VERIFY_SUCCEEDED(pPdbUtils->Load(pPdb));
 }
+
+TEST_F(CompilerTest, CompileThenTestPdbIntegrity) {
+  std::string source_0 = R"x(
+      [RootSignature("CBV(b1)")]
+      float4 main() : SV_Target {
+        return float4(1,0,0,1);
+      }
+  )x";
+  std::string source_1 = R"x(
+      Texture1D<float> t0 : register(t0);
+      [RootSignature("CBV(b1),DescriptorTable(SRV(t0))")]
+      float main() : SV_Target {
+        float ret = 0;
+        [unroll]
+        for (int i = 0; i < 256; i++) {
+          ret += t0.Load(i);
+        }
+        return ret;
+      }
+  )x";
+
+  CComPtr<IDxcCompiler3> pCompiler;
+  VERIFY_SUCCEEDED(m_dllSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
+
+
+  struct Profile {
+    llvm::StringRef src;
+    std::vector<const WCHAR *> args;
+  };
+
+  Profile profiles[] = {
+    { source_0, {L"/Tps_6_0", L"/Zi",}},
+    { source_0, {L"/Tps_6_0", L"/Zs",}},
+    { source_1, {L"/Tps_6_0", L"/Zi", L"Od"}},
+    { source_1, {L"/Tps_6_0", L"/Zs", L"Od"}},
+  };
+
+  for (Profile &p : profiles) {
+    DxcBuffer SourceBuf = {};
+    SourceBuf.Ptr  = p.src.data();
+    SourceBuf.Size = p.src.size();
+    SourceBuf.Encoding = CP_UTF8;
+
+    CComPtr<IDxcResult> pResult;
+    VERIFY_SUCCEEDED(pCompiler->Compile(&SourceBuf, p.args.data(), p.args.size(), nullptr, IID_PPV_ARGS(&pResult)));
+
+    CComPtr<IDxcBlob> pPdb;
+    VERIFY_SUCCEEDED(pResult->GetOutput(DXC_OUT_PDB, IID_PPV_ARGS(&pPdb), nullptr));
+
+    static const char kMsfMagic[] = {'M',  'i',  'c',    'r', 'o', 's',  'o',  'f',
+                                     't',  ' ',  'C',    '/', 'C', '+',  '+',  ' ',
+                                     'M',  'S',  'F',    ' ', '7', '.',  '0',  '0',
+                                     '\r', '\n', '\x1a', 'D', 'S', '\0', '\0', '\0'};
+    struct MSF_SuperBlock {
+      char MagicBytes[sizeof(kMsfMagic)];
+      // The file system is split into a variable number of fixed size elements.
+      // These elements are referred to as blocks.  The size of a block may vary
+      // from system to system.
+      llvm::support::ulittle32_t BlockSize;
+      // The index of the free block map.
+      llvm::support::ulittle32_t FreeBlockMapBlock;
+      // This contains the number of blocks resident in the file system.  In
+      // practice, NumBlocks * BlockSize is equivalent to the size of the MSF
+      // file.
+      llvm::support::ulittle32_t NumBlocks;
+      // This contains the number of bytes which make up the directory.
+      llvm::support::ulittle32_t NumDirectoryBytes;
+      // This field's purpose is not yet known.
+      llvm::support::ulittle32_t Unknown1;
+      // This contains the block # of the block map.
+      llvm::support::ulittle32_t BlockMapAddr;
+    };
+
+    VERIFY_IS_LESS_THAN_OR_EQUAL(sizeof(MSF_SuperBlock), pPdb->GetBufferSize());
+    VERIFY_ARE_EQUAL(0, memcmp(pPdb->GetBufferPointer(), kMsfMagic, sizeof(kMsfMagic)));
+
+    const MSF_SuperBlock *pSuperBlock = (const MSF_SuperBlock *)pPdb->GetBufferPointer();
+
+    VERIFY_ARE_EQUAL(pSuperBlock->BlockSize * pSuperBlock->NumBlocks,
+                     pPdb->GetBufferSize());
+  }
+}
+
 
 TEST_F(CompilerTest, CompileSameFilenameAndEntryThenTestPdbUtilsArgs) {
   // This is a regression test for a bug where if entry point has the same


### PR DESCRIPTION
Fixes #3005.

The PDB writer did not include in `NumBlocks` the blocks in the `BlockAddr` data, which points to the contents of the (not necessarily continguous) StreamDirectory data. With this bug, our PDBs' `NumBlocks` is always at least 1 less than it should be.

The purpose of wrapping shader PDB as a MSF file is to allow them to be stored in symbol servers. Symsrv does not check this property currently, but it's best to fix this in case something changes in the future.