### PR TITLE
Enable testing HLSL 2021 short-circuit tests

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-and.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-and.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc /T ps_6_0 %s -HV 2021 /Zi | FileCheck %s
-// RUN: %dxc /T ps_6_0 %s | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
+// RUN: %dxc /T ps_6_0 %s -HV 2021 -Zi | FileCheck %s
+// RUN: %dxc /T ps_6_0 %s -HV 2018 | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
 
 // Load the two uav handles
 // CHECK-DAG: %[[uav_foo:.+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 128, i1 false)

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-and.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-and.hlsl
@@ -14,7 +14,7 @@
 // CHECK: br i1 %[[foo_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
 
 // For AND, if first operand is TRUE, goes to evaluate the second operand
-// CHECK: [[true_label]]:
+// CHECK: [[true_label]]{{:? *}}; preds =
 
 // Second side effect
 // CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-or.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-or.hlsl
@@ -14,7 +14,7 @@
 // CHECK: br i1 %[[foo_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
 
 // For OR, if first operand is FALSE, goes to evaluate the second operand
-// CHECK: [[false_label]]:
+// CHECK: [[false_label]]{{:? *}}; preds =
 
 // Second side effect
 // CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-or.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-or.hlsl
@@ -1,31 +1,29 @@
-// RUN: %dxc /T ps_6_0 %s -HV 2021 /Zi | FileCheck %s
-// RUN: %dxc /T ps_6_0 %s | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
+// RUN: %dxc /T ps_6_0 %s -HV 2021 -Zi | FileCheck %s
+// RUN: %dxc /T ps_6_0 %s -HV 2018 | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
 
 // Load the two uav handles
 // CHECK-DAG: %[[uav_foo:.+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 128, i1 false)
 // CHECK-DAG: %[[uav_bar:.+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 256, i1 false)
 
-// Cond:
-// CHECK-DAG: %[[tan:.+]] = call float @dx.op.unary.f32(i32 14
-// CHECK: %[[cond_cmp:.+]] = fcmp fast une float %[[tan]], 0.000000e+00
-
-// The actual select
-// CHECK: br i1 %[[cond_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
-
-// CHECK: [[true_label]]:
 // First side effect
 // CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_foo]]
+
+// LHS: sin(...) != 0
 // CHECK-DAG: %[[sin:.+]] = call float @dx.op.unary.f32(i32 13
-// CHECK: br label %[[final_block:.+]],
+// CHECK: %[[foo_cmp:.+]] = fcmp fast une float %[[sin]]
+// CHECK: br i1 %[[foo_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
 
+// For OR, if first operand is FALSE, goes to evaluate the second operand
 // CHECK: [[false_label]]:
-// Second side effect
-// CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]
-// CHECK-DAG: %[[cos:.+]] = call float @dx.op.unary.f32(i32 12
-// CHECK: br label %[[final_block]],
 
-// CHECK: [[final_block]]:
-// CHECK: phi float [ %[[sin]], %[[true_label]] ],  [ %[[cos]], %[[false_label]] ]
+// Second side effect
+// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]
+
+// RHS: cos(...) != 0
+// CHECK-DAG: %[[cos:.+]] = call float @dx.op.unary.f32(i32 12
+// CHECK: %[[bar_cmp:.+]] = fcmp fast une float %[[cos]]
+// CHECK: br i1 %[[bar_cmp]]
+// CHECK-SAME: %[[true_label]]
 
 // Just check there's no branches.
 // NO_SHORT_CIRCUIT-NOT: br i1 %{{.+}}
@@ -38,22 +36,25 @@ cbuffer cb : register(b0) {
   uint write_idx1;
   float foo_val;
   float bar_val;
-  float cond;
   bool a, b;
 }
 
-float foo() {
+bool foo() {
   buf_foo[write_idx0] = foo_val;
-  return sin(foo_val);
+  return sin(foo_val) != 0;
 }
 
-float bar() {
+bool bar() {
   buf_bar[write_idx1] = bar_val;
-  return cos(bar_val);
+  return cos(bar_val) != 0;
 }
 
 [RootSignature("DescriptorTable(SRV(t0,numDescriptors=32)),DescriptorTable(CBV(b0,numDescriptors=32)),DescriptorTable(UAV(u0,numDescriptors=1000))")]
 float main() : SV_Target {
-  return tan(cond) != 0 ? foo() : bar();
+  float ret = 0;
+  if (foo() || bar()) {
+    ret = 1;
+  }
+  return ret;
 }
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
@@ -18,13 +18,13 @@
 // CHECK-DAG: %[[sin:.+]] = call float @dx.op.unary.f32(i32 13
 // CHECK: br label %[[final_block:.+]],
 
-// CHECK: [[false_label]]:
+// CHECK: [[false_label]]{{:? *}}; preds =
 // Second side effect
 // CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]
 // CHECK-DAG: %[[cos:.+]] = call float @dx.op.unary.f32(i32 12
 // CHECK: br label %[[final_block]],
 
-// CHECK: [[final_block]]:
+// CHECK: [[final_block]]{{:? *}}; preds =
 // CHECK: phi float [ %[[sin]], %[[true_label]] ],  [ %[[cos]], %[[false_label]] ]
 
 // Just check there's no branches.

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
@@ -12,7 +12,7 @@
 // The actual select
 // CHECK: br i1 %[[cond_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
 
-// CHECK: [[true_label]]:
+// CHECK: [[true_label]]{{:? *}}; preds =
 // First side effect
 // CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_foo]]
 // CHECK-DAG: %[[sin:.+]] = call float @dx.op.unary.f32(i32 13

--- a/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/control_flow/if_else/short-circuit-select.hlsl
@@ -1,29 +1,31 @@
-// RUN: %dxc /T ps_6_0 %s -HV 2021 /Zi | FileCheck %s
-// RUN: %dxc /T ps_6_0 %s | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
+// RUN: %dxc /T ps_6_0 %s -HV 2021 -Zi | FileCheck %s
+// RUN: %dxc /T ps_6_0 %s -HV 2018 | FileCheck %s -check-prefix=NO_SHORT_CIRCUIT
 
 // Load the two uav handles
 // CHECK-DAG: %[[uav_foo:.+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 0, i32 128, i1 false)
 // CHECK-DAG: %[[uav_bar:.+]] = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 1, i32 1, i32 256, i1 false)
 
+// Cond:
+// CHECK-DAG: %[[tan:.+]] = call float @dx.op.unary.f32(i32 14
+// CHECK: %[[cond_cmp:.+]] = fcmp fast une float %[[tan]], 0.000000e+00
+
+// The actual select
+// CHECK: br i1 %[[cond_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
+
+// CHECK: [[true_label]]:
 // First side effect
 // CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_foo]]
-
-// LHS: sin(...) != 0
 // CHECK-DAG: %[[sin:.+]] = call float @dx.op.unary.f32(i32 13
-// CHECK: %[[foo_cmp:.+]] = fcmp fast une float %[[sin]]
-// CHECK: br i1 %[[foo_cmp]], label %[[true_label:.+]], label %[[false_label:.+]],
+// CHECK: br label %[[final_block:.+]],
 
-// For OR, if first operand is FALSE, goes to evaluate the second operand
 // CHECK: [[false_label]]:
-
 // Second side effect
-// CHECK: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]
-
-// RHS: cos(...) != 0
+// CHECK-DAG: call void @dx.op.bufferStore.f32(i32 69, %dx.types.Handle %[[uav_bar]]
 // CHECK-DAG: %[[cos:.+]] = call float @dx.op.unary.f32(i32 12
-// CHECK: %[[bar_cmp:.+]] = fcmp fast une float %[[cos]]
-// CHECK: br i1 %[[bar_cmp]]
-// CHECK-SAME: %[[true_label]]
+// CHECK: br label %[[final_block]],
+
+// CHECK: [[final_block]]:
+// CHECK: phi float [ %[[sin]], %[[true_label]] ],  [ %[[cos]], %[[false_label]] ]
 
 // Just check there's no branches.
 // NO_SHORT_CIRCUIT-NOT: br i1 %{{.+}}
@@ -36,25 +38,22 @@ cbuffer cb : register(b0) {
   uint write_idx1;
   float foo_val;
   float bar_val;
+  float cond;
   bool a, b;
 }
 
-bool foo() {
+float foo() {
   buf_foo[write_idx0] = foo_val;
-  return sin(foo_val) != 0;
+  return sin(foo_val);
 }
 
-bool bar() {
+float bar() {
   buf_bar[write_idx1] = bar_val;
-  return cos(bar_val) != 0;
+  return cos(bar_val);
 }
 
 [RootSignature("DescriptorTable(SRV(t0,numDescriptors=32)),DescriptorTable(CBV(b0,numDescriptors=32)),DescriptorTable(UAV(u0,numDescriptors=1000))")]
 float main() : SV_Target {
-  float ret = 0;
-  if (foo() || bar()) {
-    ret = 1;
-  }
-  return ret;
+  return tan(cond) != 0 ? foo() : bar();
 }
 


### PR DESCRIPTION
These tests were in the wrong location so they weren't getting run. Moving them to the filecheck location enables their testing

Additionally adds an explicit HLSL 2018 parameter to the legacy behavior since HLSL 2021 has become the default now