### PR TITLE
[CodeCoverage] Fix issues when run code coverage on windows

### DIFF
--- a/cmake/modules/AddLLVM.cmake
+++ b/cmake/modules/AddLLVM.cmake
@@ -889,6 +889,9 @@ function(configure_lit_site_cfg input output)
   set(HOST_CXX "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}")
   set(HOST_LDFLAGS "${CMAKE_EXE_LINKER_FLAGS}")
 
+  # HLSL Change - replace " with \" in HOST_LDFLAGS for -fprofile-instr-generate
+  string(REPLACE "\"" "\\\"" HOST_LDFLAGS "${HOST_LDFLAGS}")
+
   configure_file(${input} ${output} @ONLY)
 endfunction()
 

--- a/cmake/modules/CoverageReport.cmake
+++ b/cmake/modules/CoverageReport.cmake
@@ -73,7 +73,7 @@ add_custom_target(clear-profile-data
 # sub-projects. The current limitation is based on not having a good way to
 # automaticall plumb through the targets that we want to run coverage against.
 add_custom_target(generate-coverage-report
-                  COMMAND ${Python3_EXECUTABLE} ${PREPARE_CODE_COV_ARTIFACT}
+                  COMMAND ${PYTHON_EXECUTABLE} ${PREPARE_CODE_COV_ARTIFACT}
                           ${LLVM_PROFDATA} ${LLVM_COV} ${LLVM_PROFILE_DATA_DIR}
                           ${REPORT_DIR} ${coverage_binaries}
                           --unified-report ${restrict_flags}

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -622,7 +622,7 @@ endif()
 
 option(LLVM_BUILD_INSTRUMENTED "Build LLVM and tools with PGO instrumentation (experimental)" Off)
 mark_as_advanced(LLVM_BUILD_INSTRUMENTED)
-append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate='${LLVM_PROFILE_FILE_PATTERN}'"
+append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate=\"${LLVM_PROFILE_FILE_PATTERN}\""
   CMAKE_CXX_FLAGS
   CMAKE_C_FLAGS
   CMAKE_EXE_LINKER_FLAGS
@@ -630,7 +630,7 @@ append_if(LLVM_BUILD_INSTRUMENTED "-fprofile-instr-generate='${LLVM_PROFILE_FILE
 
 option(LLVM_BUILD_INSTRUMENTED_COVERAGE "Build LLVM and tools with Code Coverage instrumentation (experimental)" Off)
 mark_as_advanced(LLVM_BUILD_INSTRUMENTED_COVERAGE)
-append_if(LLVM_BUILD_INSTRUMENTED_COVERAGE "-fprofile-instr-generate='${LLVM_PROFILE_FILE_PATTERN}' -fcoverage-mapping"
+append_if(LLVM_BUILD_INSTRUMENTED_COVERAGE "-fprofile-instr-generate=\"${LLVM_PROFILE_FILE_PATTERN}\" -fcoverage-mapping"
   CMAKE_CXX_FLAGS
   CMAKE_C_FLAGS
   CMAKE_EXE_LINKER_FLAGS


### PR DESCRIPTION
1. Use PYTHON_EXECUTABLE instead of Python3_EXECUTABLE which not enabled for DXC.
2. Use "" instead of '' for -fprofile-instr-generate=${LLVM_PROFILE_FILE_PATTERN