### PR TITLE
[lit] support dxopt in lit

### DIFF
--- a/tools/clang/test/PIX/DebugAs.hlsl
+++ b/tools/clang/test/PIX/DebugAs.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -Emain -Tas_6_5 %s | %opt -S -hlsl-dxil-debug-instrumentation,parameter0=10,parameter1=20,parameter2=30 | %FileCheck %s
+// RUN: %dxc -Emain -Tas_6_5 %s | %dxopt - -S -hlsl-dxil-debug-instrumentation,parameter0=10,parameter1=20,parameter2=30 | FileCheck %s
 
 // Check that the AS thread IDs are added properly
 

--- a/tools/clang/tools/dxopt/dxopt.cpp
+++ b/tools/clang/tools/dxopt/dxopt.cpp
@@ -69,15 +69,15 @@ static HRESULT ReadStdin(std::string &input) {
     std::getline(std::cin, line);
     if (line.empty()) {
       emptyLine = true;
-      break;
+      continue;
     }
 
     std::copy(line.begin(), line.end(),
               std::back_inserter(input));
+    input.push_back('\n');
   }
 
   DWORD lastError = GetLastError();
-
   // Make sure we reached finished successfully.
   if (std::cin.eof())
     return S_OK;


### PR DESCRIPTION
When input is from stdin, need to add '\n' after each line.

This is for use dxopt to test pix passes.
opt doesn't support passes which has parameters right now. We could switch it to opt once pass parameter is supported.