### PR TITLE
[NFC] Refactor -opt-enable and -opt-disable

### DIFF
--- a/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
+++ b/include/dxc/HLSL/HLSLExtensionsCodegenHelper.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "dxc/DXIL/DxilOperations.h"
+#include "dxc/Support/DxcOptToggles.h"
 #include <vector>
 #include <string>
 
@@ -69,7 +70,7 @@ public:
   virtual void UpdateCodeGenOptions(clang::CodeGenOptions &CGO) = 0;
   // Query the named option enable
   // Needed because semantic defines may have set it since options were copied
-  virtual bool IsOptionEnabled(std::string option) = 0;
+  virtual bool IsOptionEnabled(hlsl::options::Toggle toggle) = 0;
 
   // Get the name to use for the dxil intrinsic function.
   virtual std::string GetIntrinsicName(unsigned opcode) = 0;

--- a/include/dxc/Support/DxcOptToggles.h
+++ b/include/dxc/Support/DxcOptToggles.h
@@ -1,0 +1,72 @@
+///////////////////////////////////////////////////////////////////////////////
+//                                                                           //
+// DxcOptToggles.h                                                           //
+// Copyright (C) Microsoft Corporation. All rights reserved.                 //
+// This file is distributed under the University of Illinois Open Source     //
+// License. See LICENSE.TXT for details.                                     //
+//                                                                           //
+// Helper code for representing -opt-disable, -opt-enable, -opt-select       //
+// options                                                                   //
+//                                                                           //
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef LLVM_HLSL_DXC_OPT_TOGGLES_H
+#define LLVM_HLSL_DXC_OPT_TOGGLES_H
+
+#include "llvm/ADT/StringRef.h"
+#include <map>
+#include <set>
+#include <string>
+
+namespace hlsl {
+
+namespace options {
+
+struct Toggle {
+  llvm::StringRef Name;
+  bool Default = false;
+  Toggle(llvm::StringRef Name, bool Default) : Name(Name), Default(Default) {}
+};
+
+enum {
+  DEFAULT_ON  = 1,
+  DEFAULT_OFF = 0,
+};
+
+static const Toggle TOGGLE_GVN = {"gvn", DEFAULT_ON};
+static const Toggle TOGGLE_LICM = {"licm", DEFAULT_ON};
+static const Toggle TOGGLE_SINK = {"sink", DEFAULT_ON};
+static const Toggle TOGGLE_LIFETIME_MARKERS = {"lifetime-markers", DEFAULT_ON};
+static const Toggle TOGGLE_PARTIAL_LIFETIME_MARKERS = {
+    "partial-lifetime-markers", DEFAULT_OFF};
+static const Toggle TOGGLE_STRUCTURIZE_LOOP_EXITS_FOR_UNROLL = {
+    "structurize-loop-exits-for-unroll", DEFAULT_ON};
+static const Toggle TOGGLE_DEBUG_NOPS = {"debug-nops", DEFAULT_ON};
+static const Toggle TOGGLE_STRUCTURIZE_RETURNS = {"structurize-returns", DEFAULT_OFF};
+
+struct OptimizationToggles {
+  // Optimization pass enables, disables and selects
+  std::map<std::string, bool>        Toggles; // OPT_opt_enable & OPT_opt_disable
+  std::map<std::string, std::string> Selects; // OPT_opt_select
+
+  void Set(Toggle Opt, bool Value) {
+    Toggles[Opt.Name] = Value;
+  }
+  bool IsSet(Toggle Opt) const {
+    return Toggles.find(Opt.Name) != Toggles.end();
+  }
+  bool IsEnabled(Toggle Opt) const {
+    auto It = Toggles.find(Opt.Name);
+    const bool Found = It != Toggles.end();
+    if (Found)
+      return It->second;
+    return Opt.Default;
+  }
+};
+
+} // namespace options
+} // namespace hlsl
+
+#endif

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -20,6 +20,7 @@
 #include "dxc/dxcapi.h"
 #include "dxc/Support/HLSLVersion.h"
 #include "dxc/Support/SPIRVOptions.h"
+#include "dxc/Support/DxcOptToggles.h"
 #include <map>
 #include <set>
 
@@ -213,8 +214,7 @@ public:
   bool VerifyDiagnostics = false; // OPT_verify
 
   // Optimization pass enables, disables and selects
-  std::map<std::string, bool> DxcOptimizationToggles; // OPT_opt_enable & OPT_opt_disable
-  std::map<std::string, std::string> DxcOptimizationSelects; // OPT_opt_select
+  OptimizationToggles OptToggles; // OPT_opt_enable, OPT_opt_disable, OPT_opt_select
 
   std::set<std::string> IgnoreSemDefs; // OPT_ignore_semdef
   std::map<std::string, std::string> OverrideSemDefs; // OPT_override_semdef

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -604,17 +604,17 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     opts.ScanLimit = std::stoul(std::string(limit));
 
   for (std::string opt : Args.getAllArgValues(OPT_opt_disable))
-    opts.DxcOptimizationToggles[llvm::StringRef(opt).lower()] = false;
+    opts.OptToggles.Toggles[llvm::StringRef(opt).lower()] = false;
 
   for (std::string opt : Args.getAllArgValues(OPT_opt_enable)) {
     std::string optimization = llvm::StringRef(opt).lower();
-    if (opts.DxcOptimizationToggles.count(optimization) &&
-        !opts.DxcOptimizationToggles[optimization]) {
+    if (opts.OptToggles.Toggles.count(optimization) &&
+        !opts.OptToggles.Toggles[optimization]) {
       errors << "Contradictory use of -opt-disable and -opt-enable with \""
              << llvm::StringRef(opt).lower() << "\"";
       return 1;
     }
-    opts.DxcOptimizationToggles[optimization] = true;
+    opts.OptToggles.Toggles[optimization] = true;
   }
 
   std::vector<std::string> ignoreSemDefs = Args.getAllArgValues(OPT_ignore_semdef);
@@ -638,13 +638,13 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   for (unsigned i = 0; i + 1 < optSelects.size(); i+=2) {
     std::string optimization = llvm::StringRef(optSelects[i]).lower();
     std::string selection = optSelects[i+1];
-    if (opts.DxcOptimizationSelects.count(optimization) &&
-        selection.compare(opts.DxcOptimizationSelects[optimization])) {
+    if (opts.OptToggles.Selects.count(optimization) &&
+        selection.compare(opts.OptToggles.Selects[optimization])) {
       errors << "Contradictory -opt-selects for \""
              << optimization << "\"";
       return 1;
     }
-    opts.DxcOptimizationSelects[optimization] = selection;
+    opts.OptToggles.Selects[optimization] = selection;
   }
 
   if (!opts.ForceRootSigVer.empty() && opts.ForceRootSigVer != "rootsig_1_0" &&

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -23,8 +23,8 @@
 #include <set>
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h" // HLSL change
 #include "dxc/Support/SPIRVOptions.h" // SPIR-V Change
-#include "dxc/DxcBindingTable/DxcBindingTable.h" // HLSL chanhge
-#include "dxc/Support/DxcOptToggles.h" // HLSL chanhge
+#include "dxc/DxcBindingTable/DxcBindingTable.h" // HLSL change
+#include "dxc/Support/DxcOptToggles.h" // HLSL change
 
 namespace clang {
 

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -24,6 +24,7 @@
 #include "dxc/HLSL/HLSLExtensionsCodegenHelper.h" // HLSL change
 #include "dxc/Support/SPIRVOptions.h" // SPIR-V Change
 #include "dxc/DxcBindingTable/DxcBindingTable.h" // HLSL chanhge
+#include "dxc/Support/DxcOptToggles.h" // HLSL chanhge
 
 namespace clang {
 
@@ -229,9 +230,8 @@ public:
   bool HLSLResMayAlias = false;
   /// Lookback scan limit for memory dependencies
   unsigned ScanLimit = 0;
-  // Optimization pass enables, disables and selects
-  std::map<std::string, bool> HLSLOptimizationToggles;
-  std::map<std::string, std::string> HLSLOptimizationSelects;
+  /// Optimization pass enables, disables and selects
+  hlsl::options::OptimizationToggles HLSLOptimizationToggles;
   /// Debug option to print IR after every pass
   bool HLSLPrintAfterAll = false;
   /// Debug option to print IR after specific pass
@@ -240,8 +240,6 @@ public:
   bool HLSLForceZeroStoreLifetimes = false;
   /// Enable lifetime marker generation
   bool HLSLEnableLifetimeMarkers = false;
-  /// Enable lifetime marker generation only for lifetime.start
-  bool HLSLEnablePartialLifetimeMarkers = false;
   /// Put shader sources and options in the module
   bool HLSLEmbedSourcesInModule = false;
   /// Enable generation of payload access qualifier metadata. 

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -337,26 +337,19 @@ void EmitAssemblyHelper::CreatePasses() {
   PMBuilder.HLSLResMayAlias = CodeGenOpts.HLSLResMayAlias;
   PMBuilder.ScanLimit = CodeGenOpts.ScanLimit;
 
-  PMBuilder.EnableGVN = !CodeGenOpts.HLSLOptimizationToggles.count("gvn") ||
-                        CodeGenOpts.HLSLOptimizationToggles.find("gvn")->second;
-
-  PMBuilder.HLSLNoSink = CodeGenOpts.HLSLOptimizationToggles.count("sink") &&
-                         !CodeGenOpts.HLSLOptimizationToggles.find("sink")->second;
-
-  PMBuilder.StructurizeLoopExitsForUnroll =
-                        !CodeGenOpts.HLSLOptimizationToggles.count("structurize-loop-exits-for-unroll") ||
-                        CodeGenOpts.HLSLOptimizationToggles.find("structurize-loop-exits-for-unroll")->second;
-
-  PMBuilder.HLSLEnableDebugNops =
-                        !CodeGenOpts.HLSLOptimizationToggles.count("debug-nops") ||
-                        CodeGenOpts.HLSLOptimizationToggles.find("debug-nops")->second;
-
+  // Opt toggles
+  const hlsl::options::OptimizationToggles &OptToggles =
+      CodeGenOpts.HLSLOptimizationToggles;
+  PMBuilder.EnableGVN = OptToggles.IsEnabled(hlsl::options::TOGGLE_GVN);
+  PMBuilder.HLSLNoSink = !OptToggles.IsEnabled(hlsl::options::TOGGLE_SINK);
+  PMBuilder.StructurizeLoopExitsForUnroll = OptToggles.IsEnabled(
+      hlsl::options::TOGGLE_STRUCTURIZE_LOOP_EXITS_FOR_UNROLL);
+  PMBuilder.HLSLEnableDebugNops = OptToggles.IsEnabled(hlsl::options::TOGGLE_DEBUG_NOPS);
   PMBuilder.HLSLEnableLifetimeMarkers =
       CodeGenOpts.HLSLEnableLifetimeMarkers &&
-      (!CodeGenOpts.HLSLOptimizationToggles.count("lifetime-markers") ||
-       CodeGenOpts.HLSLOptimizationToggles.find("lifetime-markers")->second);
-
-  PMBuilder.HLSLEnablePartialLifetimeMarkers = CodeGenOpts.HLSLEnablePartialLifetimeMarkers;
+      OptToggles.IsEnabled(hlsl::options::TOGGLE_LIFETIME_MARKERS);
+  PMBuilder.HLSLEnablePartialLifetimeMarkers =
+      OptToggles.IsEnabled(hlsl::options::TOGGLE_PARTIAL_LIFETIME_MARKERS);
   // HLSL Change - end
 
   PMBuilder.DisableUnitAtATime = !CodeGenOpts.UnitAtATime;

--- a/tools/clang/lib/CodeGen/CGDecl.cpp
+++ b/tools/clang/lib/CodeGen/CGDecl.cpp
@@ -891,7 +891,7 @@ llvm::Value *CodeGenFunction::EmitLifetimeStart(uint64_t Size,
   llvm::CallInst *C =
       Builder.CreateCall(CGM.getLLVMLifetimeStartFn(), {SizeV, Addr});
   C->setDoesNotThrow();
-  if (CGM.getCodeGenOpts().HLSLEnablePartialLifetimeMarkers) return nullptr; // HLSL Change - Returning nullptr prevents generating lifetime.end
+  if (CGM.getCodeGenOpts().HLSLOptimizationToggles.IsEnabled(hlsl::options::TOGGLE_PARTIAL_LIFETIME_MARKERS)) return nullptr; // HLSL Change - Returning nullptr prevents generating lifetime.end
   return SizeV;
 }
 

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -3696,15 +3696,10 @@ void StructurizeMultiRet(Module &M, clang::CodeGen::CodeGenModule &CGM,
                          bool bWaveEnabledStage,
                          SmallVector<BranchInst *, 16> &DxBreaks) {
   if (CGM.getCodeGenOpts().HLSLExtensionsCodegen) {
-    if (!CGM.getCodeGenOpts().HLSLExtensionsCodegen->IsOptionEnabled(
-            "structurize-returns"))
+    if (!CGM.getCodeGenOpts().HLSLExtensionsCodegen->IsOptionEnabled(hlsl::options::TOGGLE_STRUCTURIZE_RETURNS))
       return;
   } else {
-    if (!CGM.getCodeGenOpts().HLSLOptimizationToggles.count(
-            "structurize-returns") ||
-        !CGM.getCodeGenOpts()
-             .HLSLOptimizationToggles.find("structurize-returns")
-             ->second)
+    if (!CGM.getCodeGenOpts().HLSLOptimizationToggles.IsEnabled(hlsl::options::TOGGLE_STRUCTURIZE_RETURNS))
       return;
   }
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -277,8 +277,8 @@ private:
     const std::string disableStr("_DISABLE_");
     const std::string selectStr("_SELECT_");
 
-    auto &optToggles = m_CI.getCodeGenOpts().HLSLOptimizationToggles;
-    auto &optSelects = m_CI.getCodeGenOpts().HLSLOptimizationSelects;
+    auto &optToggles = m_CI.getCodeGenOpts().HLSLOptimizationToggles.Toggles;
+    auto &optSelects = m_CI.getCodeGenOpts().HLSLOptimizationToggles.Selects;
 
     const llvm::SmallVector<std::string, 2> &semDefPrefixes =
                              m_langExtensionsHelper.GetSemanticDefines();
@@ -372,12 +372,11 @@ public:
   void UpdateCodeGenOptions(clang::CodeGenOptions &CGO) override {
     auto &CodeGenOpts = m_CI.getCodeGenOpts();
     CGO.HLSLEnableLifetimeMarkers &=
-        (!CodeGenOpts.HLSLOptimizationToggles.count("lifetime-markers") ||
-         CodeGenOpts.HLSLOptimizationToggles.find("lifetime-markers")->second);
+        CodeGenOpts.HLSLOptimizationToggles.IsEnabled(
+            hlsl::options::TOGGLE_LIFETIME_MARKERS);
   }
-  virtual bool IsOptionEnabled(std::string option) override {
-    return m_CI.getCodeGenOpts().HLSLOptimizationToggles.count(option) &&
-      m_CI.getCodeGenOpts().HLSLOptimizationToggles.find(option)->second;
+  virtual bool IsOptionEnabled(hlsl::options::Toggle toggle) override {
+    return m_CI.getCodeGenOpts().HLSLOptimizationToggles.IsEnabled(toggle);
   }
 
   virtual std::string GetIntrinsicName(UINT opcode) override {
@@ -1362,9 +1361,6 @@ public:
     compiler.getLangOpts().HLSLProfile =
           compiler.getCodeGenOpts().HLSLProfile = Opts.TargetProfile;
 
-    compiler.getCodeGenOpts().HLSLEnablePartialLifetimeMarkers =
-      Opts.DxcOptimizationToggles.count("partial-lifetime-markers") && Opts.DxcOptimizationToggles.find("partial-lifetime-markers")->second;
-
     // Enable dumping implicit top level decls either if it was specifically
     // requested or if we are not dumping the ast from the command line. That
     // allows us to dump implicit AST nodes in the debugger.
@@ -1410,8 +1406,7 @@ public:
     compiler.getCodeGenOpts().HLSLOnlyWarnOnUnrollFail = Opts.EnableFXCCompatMode;
     compiler.getCodeGenOpts().HLSLResMayAlias = Opts.ResMayAlias;
     compiler.getCodeGenOpts().ScanLimit = Opts.ScanLimit;
-    compiler.getCodeGenOpts().HLSLOptimizationToggles = Opts.DxcOptimizationToggles;
-    compiler.getCodeGenOpts().HLSLOptimizationSelects = Opts.DxcOptimizationSelects;
+    compiler.getCodeGenOpts().HLSLOptimizationToggles = Opts.OptToggles;
     compiler.getCodeGenOpts().HLSLAllResourcesBound = Opts.AllResourcesBound;
     compiler.getCodeGenOpts().HLSLIgnoreOptSemDefs = Opts.IgnoreOptSemDefs;
     compiler.getCodeGenOpts().HLSLIgnoreSemDefs = Opts.IgnoreSemDefs;


### PR DESCRIPTION
Refactored -opt-enable and -opt-disable.

- Added `hlsl::option::OptimizationToggles` to manage the toggles instead of checking a `std::map`.
- All the options are moved into `hlsl::options::TOGGLE_*` constants, where each constant contains both the option's name and whether it's default on or off.
  + Previously, every check had to be either `toggles.count("my-flag") && toggles.find("my-flag")->second` for default off, and `!toggles.count("my-flag") || toggles.map.find("my-flag")->second` for default on.
  + Now, a check is simply `toggles.IsEnabled(TOGGLE_MY_FLAG)`.