### PR TITLE
[C++17] Force C++17 when build DXC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 cmake_minimum_required(VERSION 3.17.2) # HLSL Change - Require CMake 3.17.2.
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if (NOT "${DXC_CMAKE_BEGINS_INCLUDE}" STREQUAL "")
   include(${DXC_CMAKE_BEGINS_INCLUDE})
 endif()

--- a/lib/Support/MSFileSystemBasic.cpp
+++ b/lib/Support/MSFileSystemBasic.cpp
@@ -45,7 +45,8 @@ static
 DWORD WIN32_FROM_HRESULT(HRESULT hr)
 {
   if (SUCCEEDED(hr)) return ERROR_SUCCESS;
-  if ((hr & 0xFFFF0000) == MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIN32, 0))
+  if ((HRESULT)(hr & 0xFFFF0000) ==
+      MAKE_HRESULT(SEVERITY_ERROR, FACILITY_WIN32, 0))
   {
     // Could have come from many values, but we choose this one
     return HRESULT_CODE(hr);
@@ -88,11 +89,6 @@ void ClearStatStg(_Inout_ STATSTG* statStg)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // IDxcSystemAccess-based MSFileSystem implementation.
 
-static const int FirstAllocFD = 10;
-static const int LastAllocFD = 8 * 1024;
-static const HANDLE FirstAllocHandle = (HANDLE)(uintptr_t)FirstAllocFD;
-static const HANDLE LastAllocHandle = (HANDLE)(uintptr_t)LastAllocFD;
-
 struct MSFileSystemHandle
 {
   enum MSFileSystemHandleKind
@@ -109,27 +105,28 @@ struct MSFileSystemHandle
   int fd;                   // For a file handle, its file descriptor.
 
   MSFileSystemHandle(int knownFD)
-    : fd(knownFD)
-    , kind(MSFileSystemHandleKind_FileHandle)
+      : kind(MSFileSystemHandleKind_FileHandle),
+      fd(knownFD)
   {
   }
 
   MSFileSystemHandle(IUnknown* pMapping)
-    : storage(pMapping)
-    , kind(MSFileSystemHandleKind_FileMappingHandle)
+      : kind(MSFileSystemHandleKind_FileMappingHandle)
+    , storage(pMapping)
     , fd(0)
   {
   }
 
   MSFileSystemHandle(IUnknown* pStorage, IStream* pStream)
-    : storage(pStorage)
+      : kind(MSFileSystemHandleKind_FileHandle) ,
+      storage(pStorage)
     , stream(pStream)
-    , kind(MSFileSystemHandleKind_FileHandle)
     , fd(0)
   {
   }
 
-  MSFileSystemHandle(IEnumSTATSTG* pEnumSTATG) : storage(pEnumSTATG), kind(MSFileSystemHandleKind_FindHandle)
+  MSFileSystemHandle(IEnumSTATSTG *pEnumSTATG)
+      : kind(MSFileSystemHandleKind_FindHandle) ,storage(pEnumSTATG)
   {
   }
 
@@ -445,7 +442,6 @@ BOOL MSFileSystemForIface::FindNextFileW(HANDLE hFindFile, LPWIN32_FIND_DATAW lp
 {
   HRESULT hr = S_OK;
   CComPtr<IEnumSTATSTG> enumStatStg;
-  BOOL resultValue = FALSE;
   STATSTG elt;
   ULONG fetched;
 
@@ -462,7 +458,6 @@ BOOL MSFileSystemForIface::FindNextFileW(HANDLE hFindFile, LPWIN32_FIND_DATAW lp
   else
   {
     IFC(CopyStatStg(&elt, lpFindFileData));
-    resultValue = TRUE;
   }
 
 Cleanup:

--- a/lib/Support/Process.cpp
+++ b/lib/Support/Process.cpp
@@ -68,6 +68,7 @@ Optional<std::string> Process::FindInEnvPath(const std::string& EnvName,
     COLOR(FGBG, "7", BOLD)\
   }
 
+[[maybe_unused]]
 static const char colorcodes[2][2][8][10] = {
  { ALLCOLORS("3",""), ALLCOLORS("3","1;") },
  { ALLCOLORS("4",""), ALLCOLORS("4","1;") }

--- a/lib/Support/Windows/MSFileSystem.inc.cpp
+++ b/lib/Support/Windows/MSFileSystem.inc.cpp
@@ -236,25 +236,6 @@ static bool is_separator(const wchar_t value) {
   }
 }
 
-// TODO: consider erasing this
-namespace {
-  [[maybe_unused]]
-  error_code TempDir(_In_ MSFileSystemRef fsr, SmallVectorImpl<wchar_t> &result) {
-  retry_temp_dir:
-    DWORD len = fsr->GetTempPathW(result.capacity(), result.begin());
-
-    if (len == 0)
-      return mapWindowsError(::GetLastError());
-
-    if (len > result.capacity()) {
-      result.reserve(len);
-      goto retry_temp_dir;
-    }
-
-    result.set_size(len);
-    return error_code();
-  }
-}
 
 namespace llvm {
 namespace sys  {

--- a/lib/Support/Windows/MSFileSystem.inc.cpp
+++ b/lib/Support/Windows/MSFileSystem.inc.cpp
@@ -238,6 +238,7 @@ static bool is_separator(const wchar_t value) {
 
 // TODO: consider erasing this
 namespace {
+  [[maybe_unused]]
   error_code TempDir(_In_ MSFileSystemRef fsr, SmallVectorImpl<wchar_t> &result) {
   retry_temp_dir:
     DWORD len = fsr->GetTempPathW(result.capacity(), result.begin());

--- a/lib/Support/Windows/Mutex.inc
+++ b/lib/Support/Windows/Mutex.inc
@@ -24,7 +24,8 @@ using namespace sys;
 
 MutexImpl::MutexImpl(bool /*recursive*/)
 {
-  static_assert(sizeof(data_) == sizeof(CRITICAL_SECTION), "");
+  static_assert(sizeof(data_) == sizeof(CRITICAL_SECTION),
+    "CRITICAL_SECTION size mismatch");
   // data_ = new CRITICAL_SECTION; // HLSL Change
   InitializeCriticalSection((LPCRITICAL_SECTION)data_);
 }

--- a/lib/Support/Windows/Mutex.inc
+++ b/lib/Support/Windows/Mutex.inc
@@ -24,7 +24,7 @@ using namespace sys;
 
 MutexImpl::MutexImpl(bool /*recursive*/)
 {
-  C_ASSERT(sizeof(data_) == sizeof(CRITICAL_SECTION));
+  static_assert(sizeof(data_) == sizeof(CRITICAL_SECTION), "");
   // data_ = new CRITICAL_SECTION; // HLSL Change
   InitializeCriticalSection((LPCRITICAL_SECTION)data_);
 }

--- a/lib/Support/Windows/Process.inc
+++ b/lib/Support/Windows/Process.inc
@@ -178,6 +178,7 @@ ConvertAndPushArg(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
 
 /// \brief Perform wildcard expansion of Arg, or just push it into Args if it
 /// doesn't have wildcards or doesn't match any files.
+[[maybe_unused]]
 static std::error_code
 WildcardExpand(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
                SpecificBumpPtrAllocator<char> &Allocator) {

--- a/lib/Support/Windows/Process.inc
+++ b/lib/Support/Windows/Process.inc
@@ -176,9 +176,9 @@ ConvertAndPushArg(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
   return std::error_code();
 }
 
+#if 0 // HLSL Change - comment out unused function.
 /// \brief Perform wildcard expansion of Arg, or just push it into Args if it
 /// doesn't have wildcards or doesn't match any files.
-[[maybe_unused]]
 static std::error_code
 WildcardExpand(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
                SpecificBumpPtrAllocator<char> &Allocator) {
@@ -223,6 +223,7 @@ WildcardExpand(const wchar_t *Arg, SmallVectorImpl<const char *> &Args,
   FindClose(FindHandle);
   return ec;
 }
+#endif
 
 std::error_code
 Process::GetArgumentVector(SmallVectorImpl<const char *> &Args,

--- a/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
+++ b/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
@@ -127,8 +127,9 @@ public:
     // I cannot delete these constructors, because vector depends on them, even if I never trigger them.
     // So assert if they are hit instead.
     LiveRange(const LiveRange &other)
-      : id(other.id), numI(other.numI), numF(other.numF), numU(other.numU), pNewType(other.pNewType),
-      defs(other.defs), bitcastMap(other.bitcastMap)
+        : id(other.id), defs(other.defs),
+          bitcastMap(other.bitcastMap) ,numI(other.numI), numF(other.numF),
+          numU(other.numU), pNewType(other.pNewType)
     { DXASSERT_NOMSG(false); }
     LiveRange(LiveRange &&other)
       : id(other.id), numI(other.numI), numF(other.numF), numU(other.numU), pNewType(other.pNewType),
@@ -1265,6 +1266,7 @@ Value *DxilCleanup::CastValue(Value *pValue, Type *pToType, Instruction *pOrigIn
     ArgTypes[2] = Type::getInt64Ty(*m_pCtx);
   } else {
     IFT(DXC_E_OPTIMIZATION_FAILED);
+    OpCode = DXIL::OpCode::NumOpCodes;
   }
 
   // Get function.
@@ -1307,6 +1309,8 @@ bool DxilCleanup::IsDxilBitcast(Value *pValue) {
       case OP::OpCode::BitcastI32toF32:
       case OP::OpCode::BitcastI64toF64:
         return true;
+      default:
+        break;
       }
     }
   }

--- a/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
+++ b/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
@@ -1227,7 +1227,7 @@ Value *DxilCleanup::CastValue(Value *pValue, Type *pToType, Instruction *pOrigIn
 
   const unsigned kNumTypeArgs = 3;
   Type *ArgTypes[kNumTypeArgs];
-  DXIL::OpCode OpCode;
+  DXIL::OpCode OpCode = DXIL::OpCode::NumOpCodes;
   if (pType == Type::getFloatTy(*m_pCtx)) {
     IFTBOOL(pToType == Type::getInt32Ty(*m_pCtx), DXC_E_OPTIMIZATION_FAILED);
     OpCode = DXIL::OpCode::BitcastF32toI32;
@@ -1266,7 +1266,6 @@ Value *DxilCleanup::CastValue(Value *pValue, Type *pToType, Instruction *pOrigIn
     ArgTypes[2] = Type::getInt64Ty(*m_pCtx);
   } else {
     IFT(DXC_E_OPTIMIZATION_FAILED);
-    OpCode = DXIL::OpCode::NumOpCodes;
   }
 
   // Get function.

--- a/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
+++ b/projects/dxilconv/lib/DxilConvPasses/DxilCleanup.cpp
@@ -1309,7 +1309,7 @@ bool DxilCleanup::IsDxilBitcast(Value *pValue) {
       case OP::OpCode::BitcastI64toF64:
         return true;
       default:
-        break;
+        return false;
       }
     }
   }

--- a/tools/clang/lib/Parse/ParseStmt.cpp
+++ b/tools/clang/lib/Parse/ParseStmt.cpp
@@ -189,11 +189,11 @@ Retry:
     // punctuator, then we are using them as identifers. Need to change
     // the token type to tok::identifier and fall through to the next case.
     // E.g., center = <RHS>.
-    if (tok::isPunctuator(NextToken().getKind())) {
+    if (!tok::isPunctuator(NextToken().getKind())) {
+      goto tok_default_case;
+    } else {
       Tok.setKind(tok::identifier);
       LLVM_FALLTHROUGH;
-    } else {
-      goto tok_default_case;
     }
   }
     // HLSL Change Ends

--- a/tools/clang/unittests/HLSLHost/CMakeLists.txt
+++ b/tools/clang/unittests/HLSLHost/CMakeLists.txt
@@ -11,15 +11,9 @@ add_clang_executable(HLSLHost
   HLSLHost.cpp
   )
 
-target_link_libraries(HLSLHost
-  ClangHLSLTests
-  )
-
 set_target_properties(HLSLHost PROPERTIES VERSION ${CLANG_EXECUTABLE_VERSION})
 
 include_directories(AFTER ${DIASDK_INCLUDE_DIRS})
-
-add_dependencies(HLSLHost ClangHLSLTests)
 
 if(UNIX)
   set(CLANGXX_LINK_OR_COPY create_symlink)

--- a/utils/unittest/googletest/include/gtest/gtest-printers.h
+++ b/utils/unittest/googletest/include/gtest/gtest-printers.h
@@ -683,6 +683,10 @@ void PrintTo(const ::std::pair<T1, T2>& value, ::std::ostream* os) {
   *os << ')';
 }
 
+#if GTEST_LANG_CXX11
+inline void PrintTo(std::nullptr_t, ::std::ostream* os) { *os << "(nullptr)"; }
+#endif  // GTEST_LANG_CXX11
+
 // Implements printing a non-reference type T by letting the compiler
 // pick the right overload of PrintTo() for T.
 template <typename T>


### PR DESCRIPTION
This is for enable clang-cl build on windows.

The gtest fix is merging from
 https://github.com/google/googletest/pull/1620/commits/f66ab00704cd47e4e63ef6d425ca14b9192aaebb
to work around 'operator <<' is ambiguous on DefaultPrintNonContainerTo.