### PR TITLE
[spirv] Emit error message when -Gec flag is used

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -328,8 +328,8 @@ static bool hasUnsupportedSpirvOption(const InputArgList &args,
   // Note: The options checked here are non-exhaustive. A thorough audit of
   // available options and their current compatibility is needed to generate a
   // complete list.
-  std::vector<OptSpecifier> unsupportedOpts = {OPT_Fd, OPT_Fre,
-                                               OPT_Qstrip_reflect, OPT_Gis};
+  std::vector<OptSpecifier> unsupportedOpts = {OPT_Fd, OPT_Fre, OPT_Gec,
+                                               OPT_Gis, OPT_Qstrip_reflect};
 
   for (const auto &id : unsupportedOpts) {
     if (Arg *arg = args.getLastArg(id)) {

--- a/tools/clang/test/CodeGenSPIRV/spirv.opt.gec.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.opt.gec.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -Gec
+
+void main() {}
+
+// CHECK: -Gec is not supported with -spirv

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -3243,5 +3243,8 @@ TEST_F(FileTest, SpirvOptFre) {
 TEST_F(FileTest, SpirvOptQStripReflect) {
   runFileTest("spirv.opt.qstripreflect.hlsl", Expect::Failure);
 }
+TEST_F(FileTest, SpirvOptGec) {
+  runFileTest("spirv.opt.gec.hlsl", Expect::Failure);
+}
 
 } // namespace


### PR DESCRIPTION
The -Gec option is not supported by the SPIR-V backend so emit an explicit error when it is used in combination with -spirv.

Closes #3890