### PR TITLE
Update node compute compatibility tests

### DIFF
--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -1,36 +1,84 @@
-// RUN: %dxc -T lib_6_8 %s 
 // ==================================================================
-// Check that validation errors are generated when both compute and
-// node are specified and node input or outputs are also present.
-// The validation test will add compute to each of the following
-// shaders in turn, and check for the expected error message.
-// We also check that only Broadcasting nodes may be used with
-// compute.
+// Errors are expected for shaders with both "node" and "compute"
+// specified when:
+// - the launch type is not Broadcasting
+// - a broadcasting node has an input record and/or output records
+// This test operates by changing the [Shader(node)] metadata entry
+// to [Shader(compute)] as if both had been specified in the HLSL,
+// for each shader in turn.
 // ==================================================================
 
-struct RECORD {
- uint a;
+struct RECORD
+{
+  uint a;
 };
 
+//[Shader("compute")]
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
-[NodeDispatchGrid(1, 1, 1)]
-[NumThreads(1,1,1)]
-void node01(DispatchNodeInputRecord<RECORD> input) { }
-
-[Shader("node")]
-[NodeLaunch("Broadcasting")]
-[NodeDispatchGrid(2, 1, 1)]
-[NumThreads(1,1,1)]
-void node02(RWDispatchNodeInputRecord<RECORD> input) { }
-
-[Shader("node")]
-[NodeLaunch("Broadcasting")]
-[NodeDispatchGrid(3, 1, 1)]
-[NumThreads(1,1,1)]
-void node03(NodeOutput<RECORD> output) { }
-
-[Shader("node")]
+[NumThreads(128,1,1)]
 [NodeLaunch("Coalescing")]
+void node01() { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]
+void node02(GroupNodeInputRecords<RECORD> input) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]
+void node03(RWGroupNodeInputRecords<RECORD> input) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]
+void node04(EmptyNodeInput input) { }
+
+//[Shader("compute")]
+[Shader("node")]
 [NumThreads(1,1,1)]
-void node04() { }
+[NodeLaunch("Thread")]
+void node05() { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(1,1,1)]
+[NodeLaunch("Thread")]
+void node06(ThreadNodeInputRecord<RECORD> input) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(1,1,1)]
+[NodeLaunch("Thread")]
+void node07(RWThreadNodeInputRecord<RECORD> input) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(1024,1,1)]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(128,1,1)]
+void node08(DispatchNodeInputRecord<RECORD> input) { }
+
+//[Shader("compute")]
+[NumThreads(1024,1,1)]
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(128,1,1)]
+void node09(RWDispatchNodeInputRecord<RECORD> input) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NumThreads(1024,1,1)]
+[NodeDispatchGrid(128,1,1)]
+void node10(NodeOutput<RECORD> output) { }
+
+//[Shader("compute")]
+[Shader("node")]
+[NumThreads(1024,1,1)]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(128,1,1)]
+void node11(EmptyNodeOutput output) { }

--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -8,8 +8,7 @@
 // for each shader in turn.
 // ==================================================================
 
-struct RECORD
-{
+struct RECORD {
   uint a;
 };
 

--- a/tools/clang/test/HLSL/workgraph/node_compute_compatibility.hlsl
+++ b/tools/clang/test/HLSL/workgraph/node_compute_compatibility.hlsl
@@ -3,7 +3,7 @@
 // Errors are generated for shaders with both "node" and "compute" 
 // specified when:
 // - the launch type is not Broadcasting
-// - the node has an input record and/or output records
+// - a broadcasting node has an input record and/or output records
 // ==================================================================
 
 struct RECORD
@@ -14,6 +14,7 @@ struct RECORD
 [Shader("node")]
 [Shader("compute")]
 [NumThreads(1024,1,1)]
+[NodeDispatchGrid(128,1,1)]
 [NodeLaunch("Broadcasting")]
 void node01()
 { /* compatible */  }
@@ -22,40 +23,79 @@ void node01()
 [Shader("compute")]             // expected-note {{compute defined here}}
 [NumThreads(128,1,1)]
 [NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node02' with coalescing launch type is not compatible with compute}}
-void node02(GroupNodeInputRecords<RECORD> input)
+void node02()
+{ }
+
+[Shader("node")]
+[Shader("compute")]             // expected-note {{compute defined here}}
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node03' with coalescing launch type is not compatible with compute}}
+void node03(GroupNodeInputRecords<RECORD> input)
+{ }
+
+[Shader("node")]
+[Shader("compute")]             // expected-note {{compute defined here}}
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node04' with coalescing launch type is not compatible with compute}}
+void node04(RWGroupNodeInputRecords<RECORD> input)
+{ }
+
+[Shader("node")]
+[Shader("compute")]             // expected-note {{compute defined here}}
+[NumThreads(128,1,1)]
+[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node05' with coalescing launch type is not compatible with compute}}
+void node05(EmptyNodeInput input)
 { }
 
 [Shader("compute")]             // expected-note {{compute defined here}}
 [Shader("node")]
 [NumThreads(1,1,1)]
-[NodeLaunch("Thread")]          // expected-error {{Node shader 'node03' with thread launch type is not compatible with compute}}
-void node03(ThreadNodeInputRecord<RECORD> input)
+[NodeLaunch("Thread")]          // expected-error {{Node shader 'node06' with thread launch type is not compatible with compute}}
+void node06()
+{ }
+
+[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("node")]
+[NumThreads(1,1,1)]
+[NodeLaunch("Thread")]          // expected-error {{Node shader 'node07' with thread launch type is not compatible with compute}}
+void node07(ThreadNodeInputRecord<RECORD> input)
+{ }
+
+[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("node")]
+[NumThreads(1,1,1)]
+[NodeLaunch("Thread")]          // expected-error {{Node shader 'node08' with thread launch type is not compatible with compute}}
+void node08(RWThreadNodeInputRecord<RECORD> input)
 { }
 
 [Shader("node")]
 [NumThreads(1024,1,1)]
 [Shader("compute")]                                // expected-note {{compute defined here}}
 [NodeLaunch("Broadcasting")]
-void node04(DispatchNodeInputRecord<RECORD> input) // expected-error {{Node shader 'node04' with node input/output is not compatible with compute}}
+[NodeDispatchGrid(128,1,1)]
+void node09(DispatchNodeInputRecord<RECORD> input) // expected-error {{Node shader 'node09' with node input/output is not compatible with compute}}
 { }
 
 [Shader("compute")]                                  // expected-note {{compute defined here}}
 [NumThreads(1024,1,1)]
 [Shader("node")]
 [NodeLaunch("Broadcasting")]
-void node05(RWDispatchNodeInputRecord<RECORD> input) // expected-error {{Node shader 'node05' with node input/output is not compatible with compute}}
+[NodeDispatchGrid(128,1,1)]
+void node10(RWDispatchNodeInputRecord<RECORD> input) // expected-error {{Node shader 'node10' with node input/output is not compatible with compute}}
 { }
 
 [NodeLaunch("Broadcasting")]
 [Shader("node")]
 [NumThreads(1024,1,1)]
+[NodeDispatchGrid(128,1,1)]
 [Shader("compute")]                    // expected-note {{compute defined here}}
-void node06(NodeOutput<RECORD> output) // expected-error {{Node shader 'node06' with node input/output is not compatible with compute}}
+void node11(NodeOutput<RECORD> output) // expected-error {{Node shader 'node11' with node input/output is not compatible with compute}}
 { }
 
 [NumThreads(1024,1,1)]
 [NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(128,1,1)]
 [Shader("node")]
 [Shader("compute")]                 // expected-note {{compute defined here}}
-void node07(EmptyNodeOutput output) // expected-error {{Node shader 'node07' with node input/output is not compatible with compute}}
+void node12(EmptyNodeOutput output) // expected-error {{Node shader 'node12' with node input/output is not compatible with compute}}
 { }

--- a/tools/clang/test/HLSL/workgraph/node_compute_compatibility.hlsl
+++ b/tools/clang/test/HLSL/workgraph/node_compute_compatibility.hlsl
@@ -1,13 +1,12 @@
 // RUN: %clang_cc1 -fsyntax-only -verify %s
 // ==================================================================
-// Errors are generated for shaders with both "node" and "compute" 
+// Errors are generated for shaders with both "node" and "compute"
 // specified when:
 // - the launch type is not Broadcasting
 // - a broadcasting node has an input record and/or output records
 // ==================================================================
 
-struct RECORD
-{
+struct RECORD {
   uint a;
 };
 
@@ -20,63 +19,63 @@ void node01()
 { /* compatible */  }
 
 [Shader("node")]
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NumThreads(128,1,1)]
-[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node02' with coalescing launch type is not compatible with compute}}
+[NodeLaunch("Coalescing")] // expected-error {{Node shader 'node02' with coalescing launch type is not compatible with compute}}
 void node02()
 { }
 
 [Shader("node")]
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NumThreads(128,1,1)]
-[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node03' with coalescing launch type is not compatible with compute}}
+[NodeLaunch("Coalescing")] // expected-error {{Node shader 'node03' with coalescing launch type is not compatible with compute}}
 void node03(GroupNodeInputRecords<RECORD> input)
 { }
 
 [Shader("node")]
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NumThreads(128,1,1)]
-[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node04' with coalescing launch type is not compatible with compute}}
+[NodeLaunch("Coalescing")] // expected-error {{Node shader 'node04' with coalescing launch type is not compatible with compute}}
 void node04(RWGroupNodeInputRecords<RECORD> input)
 { }
 
 [Shader("node")]
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NumThreads(128,1,1)]
-[NodeLaunch("Coalescing")]      // expected-error {{Node shader 'node05' with coalescing launch type is not compatible with compute}}
+[NodeLaunch("Coalescing")] // expected-error {{Node shader 'node05' with coalescing launch type is not compatible with compute}}
 void node05(EmptyNodeInput input)
 { }
 
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [Shader("node")]
 [NumThreads(1,1,1)]
-[NodeLaunch("Thread")]          // expected-error {{Node shader 'node06' with thread launch type is not compatible with compute}}
+[NodeLaunch("Thread")] // expected-error {{Node shader 'node06' with thread launch type is not compatible with compute}}
 void node06()
 { }
 
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [Shader("node")]
 [NumThreads(1,1,1)]
-[NodeLaunch("Thread")]          // expected-error {{Node shader 'node07' with thread launch type is not compatible with compute}}
+[NodeLaunch("Thread")] // expected-error {{Node shader 'node07' with thread launch type is not compatible with compute}}
 void node07(ThreadNodeInputRecord<RECORD> input)
 { }
 
-[Shader("compute")]             // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [Shader("node")]
 [NumThreads(1,1,1)]
-[NodeLaunch("Thread")]          // expected-error {{Node shader 'node08' with thread launch type is not compatible with compute}}
+[NodeLaunch("Thread")] // expected-error {{Node shader 'node08' with thread launch type is not compatible with compute}}
 void node08(RWThreadNodeInputRecord<RECORD> input)
 { }
 
 [Shader("node")]
 [NumThreads(1024,1,1)]
-[Shader("compute")]                                // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NodeLaunch("Broadcasting")]
 [NodeDispatchGrid(128,1,1)]
 void node09(DispatchNodeInputRecord<RECORD> input) // expected-error {{Node shader 'node09' with node input/output is not compatible with compute}}
 { }
 
-[Shader("compute")]                                  // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 [NumThreads(1024,1,1)]
 [Shader("node")]
 [NodeLaunch("Broadcasting")]
@@ -88,7 +87,7 @@ void node10(RWDispatchNodeInputRecord<RECORD> input) // expected-error {{Node sh
 [Shader("node")]
 [NumThreads(1024,1,1)]
 [NodeDispatchGrid(128,1,1)]
-[Shader("compute")]                    // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 void node11(NodeOutput<RECORD> output) // expected-error {{Node shader 'node11' with node input/output is not compatible with compute}}
 { }
 
@@ -96,6 +95,6 @@ void node11(NodeOutput<RECORD> output) // expected-error {{Node shader 'node11' 
 [NodeLaunch("Broadcasting")]
 [NodeDispatchGrid(128,1,1)]
 [Shader("node")]
-[Shader("compute")]                 // expected-note {{compute defined here}}
+[Shader("compute")] // expected-note {{compute defined here}}
 void node12(EmptyNodeOutput output) // expected-error {{Node shader 'node12' with node input/output is not compatible with compute}}
 { }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4060,35 +4060,59 @@ TEST_F(ValidationTest, ComputeNodeCompatibility) {
   std::vector<LPCWSTR> pArguments = { L"-HV", L"2021" };
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
     pArguments.data(), 2, nullptr, 0,
-    {"!11 = !{i32 8, i32 15"},
-    {"!11 = !{i32 8, i32 5"},
-    "Node node01 with input/outputs is not compatible with Compute",
-    false);
+    {"!11 = !{i32 8, i32 15"},  // original: node shader
+    {"!11 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node01 Coalescing launch type is not compatible with Compute");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
     pArguments.data(), 2, nullptr, 0,
-    {"!19 = !{i32 8, i32 15"},
-    {"!19 = !{i32 8, i32 5"},
-    "Node node02 with input/outputs is not compatible with Compute",
-    false);
+    {"!18 = !{i32 8, i32 15"},  // original: node shader
+    {"!18 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node02 Coalescing launch type is not compatible with Compute");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
     pArguments.data(), 2, nullptr, 0,
-    {"!25 = !{i32 8, i32 15"},
-    {"!25 = !{i32 8, i32 5"},
-    "Node node03 with input/outputs is not compatible with Compute",
-    false);
+    {"!24 = !{i32 8, i32 15"},  // original: node shader
+    {"!24 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node03 Coalescing launch type is not compatible with Compute");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
     pArguments.data(), 2, nullptr, 0,
-    {"!34 = !{i32 8, i32 15"},
-    {"!34 = !{i32 8, i32 5"},
-    "Node node04 Coalescing launch type is not compatible with Compute",
-    false);
+    {"!29 = !{i32 8, i32 15"},  // original: node shader
+    {"!29 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node04 Coalescing launch type is not compatible with Compute");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
     pArguments.data(), 2, nullptr, 0,
-    {"!34 = !{i32 8, i32 15, i32 13, i32 2"},
-    {"!34 = !{i32 8, i32 5, i32 13, i32 3"},
-    "Node node04 Thread launch type is not compatible with Compute",
-    false);
-
+    {"!32 = !{i32 8, i32 15"},  // original: node shader
+    {"!32 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node05 Thread launch type is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!36 = !{i32 8, i32 15"},  // original: node shader
+    {"!36 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node06 Thread launch type is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!41 = !{i32 8, i32 15"},  // original: node shader
+    {"!41 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node07 Thread launch type is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!46 = !{i32 8, i32 15"},  // original: node shader
+    {"!46 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node08 with input/outputs is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!52 = !{i32 8, i32 15"},  // original: node shader
+    {"!52 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node09 with input/outputs is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!57 = !{i32 8, i32 15"},  // original: node shader
+    {"!57 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node10 with input/outputs is not compatible with Compute");
+  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+    pArguments.data(), 2, nullptr, 0,
+    {"!63 = !{i32 8, i32 15"},  // original: node shader
+    {"!63 = !{i32 8, i32 5"},   // changed to: compute shader
+    "Node node11 with input/outputs is not compatible with Compute");
 }
 
 // Check validation error for incompatible node input record types


### PR DESCRIPTION
Update both the verifier and validator tests for the node and compute compatibility errors.

The front-end error diagnostics and the validator checks for node and compute incompatibilities are already present in the preview branch. This updates both the verifier and validator test cases to make them more comprehensive.

Fixes #5346