### PR TITLE
[Opt.exe] Add -help to opt.exe

### DIFF
--- a/tools/opt/opt.cpp
+++ b/tools/opt/opt.cpp
@@ -125,7 +125,14 @@ DisableOptimizations("disable-opt",
 static cl::opt<bool>
 StandardLinkOpts("std-link-opts",
                  cl::desc("Include the standard link time optimizations"));
-#endif // HLSL Change Ends
+#endif
+
+static cl::opt<bool> ShowHelp("?", cl::desc("Show the help message"));
+
+static cl::alias ShowHelpA("help", cl::desc("Alias for -?"),
+                           cl::aliasopt(ShowHelp));
+
+// HLSL Change Ends
 
 static cl::opt<bool>
 OptLevelO1("O1",
@@ -383,6 +390,12 @@ int __cdecl main(int argc, char **argv) {
   }
 
   SMDiagnostic Err;
+
+  // Handle any help options first
+  if (ShowHelp) {
+    cl::PrintHelpMessage();
+    return 2;
+  }
 
   // Load the input module...
   std::unique_ptr<Module> M = parseIRFile(InputFilename, Err, Context);


### PR DESCRIPTION
opt.exe gave a contradictory message when given the -help argument on the command line.
opt.exe said that "-help" is an invalid command line argument, and recommends using -help.
The problem was that there was no clang opt that explicitly stored any information about the help command line arguments (-help/-?), and the default response that commandline.cpp outputted was to try -help. 
This PR addresses the problem by creating clang opts to store true or false depending on whether these help arguments are parsed from the command line, and adds a step to the main function to check these arguments, and if true, to display a help message.

Fixes #5514