### PR TITLE
Add `-HV 2021` to test that uses templates

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -E main -T ps_6_0 -fcgl %s | FileCheck %s
-// RUN: %dxc -E main -T ps_6_0 -fcgl -Zi -Qembed_debug %s | FileCheck -check-prefixes=CHECK,DI %s
+// RUN: %dxc -HV 2021 -E main -T ps_6_0 -fcgl %s | FileCheck %s
+// RUN: %dxc -HV 2021 -E main -T ps_6_0 -fcgl -Zi -Qembed_debug %s | FileCheck -check-prefixes=CHECK,DI %s
 
 // The goal of this test is to verify the instantiations of `foo` are correctly
 // generated _and_ to verify that the correct debug information is generated for


### PR DESCRIPTION
A recent fix (#5534) modified this test by removing the `-HV 2021` flag. That change was fine because flag is not needed now that 2021 is the default language version.

However, we have a downstream consumer of this repo where we have not yet migrated to 2021 as the default language version. Rather than modifying the test in the downstream repo it was suggested that we add the flag back in the upstream repo to minimize churn.