### PR TITLE
Enable CodeGenHashStability tests by default on all platforms

### DIFF
--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -254,14 +254,20 @@ public:
   TEST_METHOD(BatchValidation)
   TEST_METHOD(BatchPIX)
 
+  TEST_METHOD(CodeGenHashStabilityD3DReflect)
+  TEST_METHOD(CodeGenHashStabilityDisassembler)
+  TEST_METHOD(CodeGenHashStabilityDXIL)
+  TEST_METHOD(CodeGenHashStabilityHLSL)
+  TEST_METHOD(CodeGenHashStabilityInfra)
+  TEST_METHOD(CodeGenHashStabilityPIX)
+  TEST_METHOD(CodeGenHashStabilityRewriter)
+  TEST_METHOD(CodeGenHashStabilitySamples)
+  TEST_METHOD(CodeGenHashStabilityShaderTargets)
+  TEST_METHOD(CodeGenHashStabilityValidation)
+
   TEST_METHOD(SubobjectCodeGenErrors)
   BEGIN_TEST_METHOD(ManualFileCheckTest)
     TEST_METHOD_PROPERTY(L"Ignore", L"true")
-  END_TEST_METHOD()
-
-  // Batch directories
-  BEGIN_TEST_METHOD(CodeGenHashStability)
-      TEST_METHOD_PROPERTY(L"Priority", L"2")
   END_TEST_METHOD()
 
   dxc::DxcDllSupport m_dllSupport;
@@ -2454,7 +2460,6 @@ TEST_F(CompilerTest, CompileWithRootSignatureThenStripRootSignature) {
   VERIFY_IS_NOT_NULL(pPartHeader);
 }
 
-#if _WIN32 // API -setrootsignature requires reflection, which isn't supported on non-win
 TEST_F(CompilerTest, CompileThenSetRootSignatureThenValidate) {
   CComPtr<IDxcCompiler> pCompiler;
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
@@ -2589,7 +2594,7 @@ TEST_F(CompilerTest, CompileThenSetRootSignatureThenValidate) {
                              pRSBlobReplace->GetBufferPointer(),
                              pRSBlob->GetBufferSize()));
 }
-#endif // _WIN32 - API -setrootsignature requires reflection, which isn't supported on non-win
+
 TEST_F(CompilerTest, CompileSetPrivateThenWithStripPrivate) {
   CComPtr<IDxcCompiler> pCompiler;
   CComPtr<IDxcOperationResult> pResult;
@@ -4271,8 +4276,44 @@ TEST_F(CompilerTest, DISABLED_ManualFileCheckTest) {
   }
 }
 
-TEST_F(CompilerTest, CodeGenHashStability) {
-  CodeGenTestCheckBatchHash(L"");
+TEST_F(CompilerTest, CodeGenHashStabilityD3DReflect) {
+  CodeGenTestCheckBatchHash(L"d3dreflect");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityDisassembler) {
+  CodeGenTestCheckBatchHash(L"disassembler");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityDXIL) {
+  CodeGenTestCheckBatchHash(L"dxil");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityHLSL) {
+  CodeGenTestCheckBatchHash(L"hlsl");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityInfra) {
+  CodeGenTestCheckBatchHash(L"infra");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityPIX) {
+  CodeGenTestCheckBatchHash(L"pix");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityRewriter) {
+  CodeGenTestCheckBatchHash(L"rewriter");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilitySamples) {
+  CodeGenTestCheckBatchHash(L"samples");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityShaderTargets) {
+  CodeGenTestCheckBatchHash(L"shader_targets");
+}
+
+TEST_F(CompilerTest, CodeGenHashStabilityValidation) {
+  CodeGenTestCheckBatchHash(L"validation");
 }
 
 TEST_F(CompilerTest, BatchD3DReflect) {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -4271,12 +4271,7 @@ TEST_F(CompilerTest, DISABLED_ManualFileCheckTest) {
   }
 }
 
-
-#ifdef _WIN32
 TEST_F(CompilerTest, CodeGenHashStability) {
-#else
-TEST_F(CompilerTest, DISABLED_CodeGenHashStability) {
-#endif
   CodeGenTestCheckBatchHash(L"");
 }
 


### PR DESCRIPTION
On my local machine the CodeGenHashStability test takes 15 seconds to run. While that is longer than the entire rest of the test suite, it makes the full test suite run only take 17 seconds, which is still reasonable.

This change then goes a step further and breaks up the CodeGenHashStability test into multiple smaller tests. With that refactoring the full test suite drops from 17s to 10s. The end result is that enabling CodeGenHashStability costs only 1s on Release+Aserts builds.

Here is a rough breakdown of the performance impact of this change on test time for the full test suite:

```
┌───────────────┬───────────────┬───────────────┐
│               │Release+Asserts│ Debug+Asserts │
├───────────────┼───────────────┼───────────────┤
│ Before        │      9s       │      57s      │
├───────────────┼───────────────┼───────────────┤
│ After         │     10s       │      88s      │
└───────────────┴───────────────┴───────────────┘
```

We should enable this test case by default and evaluate ways to better parallelize this test so that so that we can run it more efficiently.