### PR TITLE
Enable some tests on non-Windows

### DIFF
--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -604,7 +604,6 @@ bool DxilContainerTest::InitSupport() {
   return true;
 }
 
-#ifdef _WIN32 // - No reflection support
 TEST_F(DxilContainerTest, CompileWhenDebugSourceThenSourceMatters) {
   char program1[] = "float4 main() : SV_Target { return 0; }";
   char program2[] = "  float4 main() : SV_Target { return 0; }  ";
@@ -661,7 +660,6 @@ TEST_F(DxilContainerTest, CompileWhenDebugSourceThenSourceMatters) {
   // Source hash and bin hash should be different
   VERIFY_IS_FALSE(0 == strcmp(binHash1Zss.c_str(), binHash1.c_str()));
 }
-#endif // WIN32 - No reflection support
 
 TEST_F(DxilContainerTest, ContainerBuilder_AddPrivateForceLast) {
   if (m_ver.SkipDxilVersion(1, 7)) return;

--- a/tools/clang/unittests/HLSL/FunctionTest.cpp
+++ b/tools/clang/unittests/HLSL/FunctionTest.cpp
@@ -99,7 +99,6 @@ public:
       CComPtr<IDxcBlob> pContainer;
 
       VERIFY_SUCCEEDED(pResult->GetResult(&pContainer));
-#ifdef _WIN32 // No reflection support
       VERIFY_SUCCEEDED(m_support.CreateInstance(CLSID_DxcContainerReflection, &pReflection));
       VERIFY_SUCCEEDED(pReflection->Load(pContainer));
       UINT count;
@@ -114,7 +113,6 @@ public:
         }
       }
       VERIFY_IS_TRUE(found);
-#endif // _WIN32 - No reflection support
     }
   }
 

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -115,13 +115,7 @@ FileRunCommandResult FileRunCommandPart::Run(dxc::DxcDllSupport &DllSupport, con
     return RunDxr(DllSupport, Prior);
   }
   else if (0 == _stricmp(Command.c_str(), "%dxl")) {
-#ifdef _WIN32 // Linking unsupported
     return RunLink(DllSupport, Prior);
-#else
-    FileRunCommandResult result = FileRunCommandResult::Success("Can't run dxl on non-windows, so just assuming success");
-    result.AbortPipeline = true;
-    return result;
-#endif // WIN32 - Linking unsupported
   }
   else if (pPluginToolsPaths != nullptr) {
     auto it = pPluginToolsPaths->find(Command.c_str());


### PR DESCRIPTION
These tests all build and pass on non-Windows platforms, so we should run them there too.