### PR TITLE
PIX: Educate debug data interface about nested namespaces

### DIFF
--- a/lib/DxilDia/DxcPixDxilDebugInfo.cpp
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.cpp
@@ -229,7 +229,24 @@ dxil_debug_info::DxcPixDxilSourceLocations::DxcPixDxilSourceLocations(
         auto* S = llvm::dyn_cast<llvm::DIScope>(DL.getScope());
         while (S != nullptr && !llvm::isa<llvm::DIFile>(S))
         {
-            S = S->getScope().resolve(EmptyMap);
+            if(auto Namespace = llvm::dyn_cast<llvm::DINamespace>(S))
+            {
+                // DINamespace has a getScope member (that hides DIScope's)
+                // that returns a DIScope directly, but if that namespace
+                // is at file-level scope, it will return nullptr.
+                if (auto * ContainingScope = Namespace->getScope())
+                {
+                    S = ContainingScope;
+                }
+                else 
+                {
+                    S = S->getFile();
+                }
+            } 
+            else 
+            {
+                 S = S->getScope().resolve(EmptyMap);
+            }
         }
 
         if (S != nullptr)

--- a/lib/DxilDia/DxcPixDxilDebugInfo.cpp
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.cpp
@@ -235,18 +235,12 @@ dxil_debug_info::DxcPixDxilSourceLocations::DxcPixDxilSourceLocations(
                 // that returns a DIScope directly, but if that namespace
                 // is at file-level scope, it will return nullptr.
                 if (auto * ContainingScope = Namespace->getScope())
-                {
                     S = ContainingScope;
-                }
                 else 
-                {
                     S = S->getFile();
-                }
             } 
             else 
-            {
                  S = S->getScope().resolve(EmptyMap);
-            }
         }
 
         if (S != nullptr)

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -2331,10 +2331,22 @@ void Raygen()
 
 typedef BuiltInTriangleIntersectionAttributes MyAttributes;
 
+namespace ANameSpace
+{
+    namespace AContainedNamespace
+    {
+        float4 RoundaboutWayToReturnAmbientColor()
+        {
+            return g_sceneCB.lightAmbientColor;
+        }
+    }
+}
+
+
 [shader("closesthit")]
 void InnerClosestHitShader(inout RayPayload payload, in MyAttributes attr)
 {
-    payload.color = float4(0,1,0,0);
+    payload.color = ANameSpace::AContainedNamespace::RoundaboutWayToReturnAmbientColor();
 }
 
 


### PR DESCRIPTION
The comment from the checkin kinda says it all:
                // DINamespace has a getScope member (that hides DIScope's)
                // that returns a DIScope directly, but if that namespace
                // is at file-level scope, it will return nullptr.
(The upshot of this is that you couldn't step into functions within a namespace in WinPIX's shader debugger)