### PR TITLE
Reserve 6.8 samplecmp variant opcodes

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2350,6 +2350,8 @@ ID  Name                                                  Description
 251 AnnotateNodeRecordHandle                              annotate handle with node record properties
 252 NodeOutputIsValid                                     returns true if the specified output node is present in the work graph
 253 GetRemainingRecursionLevels                           returns how many levels of recursion remain
+254 SampleCmpGrad                                         samples a texture using a gradient and compares a single component against the specified comparison value
+255 SampleCmpBias                                         samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
 === ===================================================== =======================================================================================================================================================================================================================
 
 

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -438,6 +438,10 @@ namespace DXIL {
     BitcastI32toF32 = 126, // bitcast between different sizes
     BitcastI64toF64 = 128, // bitcast between different sizes
   
+    // Comparison Samples
+    SampleCmpBias = 255, // samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
+    SampleCmpGrad = 254, // samples a texture using a gradient and compares a single component against the specified comparison value
+  
     // Compute/Mesh/Amplification/Node shader
     FlattenedThreadIdInGroup = 96, // provides a flattened index for a given thread within a given group (SV_GroupIndex)
     GroupId = 94, // reads the group ID (SV_GroupID)
@@ -783,7 +787,7 @@ namespace DXIL {
     NumOpCodes_Dxil_1_6 = 222,
     NumOpCodes_Dxil_1_7 = 226,
   
-    NumOpCodes = 254 // exclusive last value of enumeration
+    NumOpCodes = 256 // exclusive last value of enumeration
   };
   // OPCODE-ENUM:END
 
@@ -814,6 +818,10 @@ namespace DXIL {
     BitcastI16toF16,
     BitcastI32toF32,
     BitcastI64toF64,
+  
+    // Comparison Samples
+    SampleCmpBias,
+    SampleCmpGrad,
   
     // Compute/Mesh/Amplification/Node shader
     FlattenedThreadIdInGroup,
@@ -1087,7 +1095,7 @@ namespace DXIL {
     NumOpClasses_Dxil_1_6 = 149,
     NumOpClasses_Dxil_1_7 = 153,
   
-    NumOpClasses = 179 // exclusive last value of enumeration
+    NumOpClasses = 181 // exclusive last value of enumeration
   };
   // OPCODECLASS-ENUM:END
 

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -8196,5 +8196,136 @@ struct DxilInst_GetRemainingRecursionLevels {
   // Metadata
   bool requiresUniformInputs() const { return false; }
 };
+
+/// This instruction samples a texture using a gradient and compares a single component against the specified comparison value
+struct DxilInst_SampleCmpGrad {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_SampleCmpGrad(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpGrad);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (18 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_srv = 1,
+    arg_sampler = 2,
+    arg_coord0 = 3,
+    arg_coord1 = 4,
+    arg_coord2 = 5,
+    arg_coord3 = 6,
+    arg_offset0 = 7,
+    arg_offset1 = 8,
+    arg_offset2 = 9,
+    arg_compareValue = 10,
+    arg_ddx0 = 11,
+    arg_ddx1 = 12,
+    arg_ddx2 = 13,
+    arg_ddy0 = 14,
+    arg_ddy1 = 15,
+    arg_ddy2 = 16,
+    arg_clamp = 17,
+  };
+  // Accessors
+  llvm::Value *get_srv() const { return Instr->getOperand(1); }
+  void set_srv(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_sampler() const { return Instr->getOperand(2); }
+  void set_sampler(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_coord0() const { return Instr->getOperand(3); }
+  void set_coord0(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_coord1() const { return Instr->getOperand(4); }
+  void set_coord1(llvm::Value *val) { Instr->setOperand(4, val); }
+  llvm::Value *get_coord2() const { return Instr->getOperand(5); }
+  void set_coord2(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_coord3() const { return Instr->getOperand(6); }
+  void set_coord3(llvm::Value *val) { Instr->setOperand(6, val); }
+  llvm::Value *get_offset0() const { return Instr->getOperand(7); }
+  void set_offset0(llvm::Value *val) { Instr->setOperand(7, val); }
+  llvm::Value *get_offset1() const { return Instr->getOperand(8); }
+  void set_offset1(llvm::Value *val) { Instr->setOperand(8, val); }
+  llvm::Value *get_offset2() const { return Instr->getOperand(9); }
+  void set_offset2(llvm::Value *val) { Instr->setOperand(9, val); }
+  llvm::Value *get_compareValue() const { return Instr->getOperand(10); }
+  void set_compareValue(llvm::Value *val) { Instr->setOperand(10, val); }
+  llvm::Value *get_ddx0() const { return Instr->getOperand(11); }
+  void set_ddx0(llvm::Value *val) { Instr->setOperand(11, val); }
+  llvm::Value *get_ddx1() const { return Instr->getOperand(12); }
+  void set_ddx1(llvm::Value *val) { Instr->setOperand(12, val); }
+  llvm::Value *get_ddx2() const { return Instr->getOperand(13); }
+  void set_ddx2(llvm::Value *val) { Instr->setOperand(13, val); }
+  llvm::Value *get_ddy0() const { return Instr->getOperand(14); }
+  void set_ddy0(llvm::Value *val) { Instr->setOperand(14, val); }
+  llvm::Value *get_ddy1() const { return Instr->getOperand(15); }
+  void set_ddy1(llvm::Value *val) { Instr->setOperand(15, val); }
+  llvm::Value *get_ddy2() const { return Instr->getOperand(16); }
+  void set_ddy2(llvm::Value *val) { Instr->setOperand(16, val); }
+  llvm::Value *get_clamp() const { return Instr->getOperand(17); }
+  void set_clamp(llvm::Value *val) { Instr->setOperand(17, val); }
+};
+
+/// This instruction samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
+struct DxilInst_SampleCmpBias {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_SampleCmpBias(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpBias);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (13 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_srv = 1,
+    arg_sampler = 2,
+    arg_coord0 = 3,
+    arg_coord1 = 4,
+    arg_coord2 = 5,
+    arg_coord3 = 6,
+    arg_offset0 = 7,
+    arg_offset1 = 8,
+    arg_offset2 = 9,
+    arg_compareValue = 10,
+    arg_bias = 11,
+    arg_clamp = 12,
+  };
+  // Accessors
+  llvm::Value *get_srv() const { return Instr->getOperand(1); }
+  void set_srv(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_sampler() const { return Instr->getOperand(2); }
+  void set_sampler(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_coord0() const { return Instr->getOperand(3); }
+  void set_coord0(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_coord1() const { return Instr->getOperand(4); }
+  void set_coord1(llvm::Value *val) { Instr->setOperand(4, val); }
+  llvm::Value *get_coord2() const { return Instr->getOperand(5); }
+  void set_coord2(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_coord3() const { return Instr->getOperand(6); }
+  void set_coord3(llvm::Value *val) { Instr->setOperand(6, val); }
+  llvm::Value *get_offset0() const { return Instr->getOperand(7); }
+  void set_offset0(llvm::Value *val) { Instr->setOperand(7, val); }
+  llvm::Value *get_offset1() const { return Instr->getOperand(8); }
+  void set_offset1(llvm::Value *val) { Instr->setOperand(8, val); }
+  llvm::Value *get_offset2() const { return Instr->getOperand(9); }
+  void set_offset2(llvm::Value *val) { Instr->setOperand(9, val); }
+  llvm::Value *get_compareValue() const { return Instr->getOperand(10); }
+  void set_compareValue(llvm::Value *val) { Instr->setOperand(10, val); }
+  llvm::Value *get_bias() const { return Instr->getOperand(11); }
+  void set_bias(llvm::Value *val) { Instr->setOperand(11, val); }
+  llvm::Value *get_clamp() const { return Instr->getOperand(12); }
+  void set_clamp(llvm::Value *val) { Instr->setOperand(12, val); }
+};
 // INSTR-HELPER:END
 } // namespace hlsl

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -757,10 +757,15 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     mask = SFLAG(Library) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Pixel) | SFLAG(Vertex) | SFLAG(Hull) | SFLAG(Domain) | SFLAG(Geometry) | SFLAG(RayGeneration) | SFLAG(Intersection) | SFLAG(AnyHit) | SFLAG(ClosestHit) | SFLAG(Miss) | SFLAG(Callable) | SFLAG(Node);
     return;
   }
-  // Instructions: Sample=60, SampleBias=61, SampleCmp=64, CalculateLOD=81,
-  // DerivCoarseX=83, DerivCoarseY=84, DerivFineX=85, DerivFineY=86
-  if ((60 <= op && op <= 61) || op == 64 || op == 81 || (83 <= op && op <= 86)) {
+  // Instructions: CalculateLOD=81, DerivCoarseX=83, DerivCoarseY=84,
+  // DerivFineX=85, DerivFineY=86
+  if (op == 81 || (83 <= op && op <= 86)) {
     mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh);
+    return;
+  }
+  // Instructions: Sample=60, SampleBias=61, SampleCmp=64
+  if ((60 <= op && op <= 61) || op == 64) {
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: RenderTargetGetSamplePosition=76,
@@ -955,9 +960,15 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     return;
   }
   // Instructions: BarrierByMemoryType=244, BarrierByMemoryHandle=245,
-  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254, SampleCmpBias=255
-  if ((244 <= op && op <= 246) || (254 <= op && op <= 255)) {
+  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254
+  if ((244 <= op && op <= 246) || op == 254) {
     major = 6;  minor = 8;
+    return;
+  }
+  // Instructions: SampleCmpBias=255
+  if (op == 255) {
+    major = 6;  minor = 8;
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: AllocateNodeOutputRecords=238, GetNodeRecordPtr=239,

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -458,6 +458,10 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
   // Work Graph intrinsics                                                                                                   void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
   {  OC::NodeOutputIsValid,       "NodeOutputIsValid",        OCC::NodeOutputIsValid,        "nodeOutputIsValid",         {  true, false, false, false, false, false, false, false, false, false, false}, Attribute::ReadOnly, },
   {  OC::GetRemainingRecursionLevels, "GetRemainingRecursionLevels", OCC::GetRemainingRecursionLevels, "getRemainingRecursionLevels", {  true, false, false, false, false, false, false, false, false, false, false}, Attribute::ReadOnly, },
+
+  // Comparison Samples                                                                                                      void,     h,     f,     d,    i1,    i8,   i16,   i32,   i64,   udt,   obj ,  function attribute
+  {  OC::SampleCmpGrad,           "SampleCmpGrad",            OCC::SampleCmpGrad,            "sampleCmpGrad",             { false,  true,  true, false, false, false, false, false, false, false, false}, Attribute::ReadOnly, },
+  {  OC::SampleCmpBias,           "SampleCmpBias",            OCC::SampleCmpBias,            "sampleCmpBias",             { false,  true,  true, false, false, false, false, false, false, false, false}, Attribute::ReadOnly, },
 };
 // OPCODE-OLOADS:END
 
@@ -951,8 +955,8 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     return;
   }
   // Instructions: BarrierByMemoryType=244, BarrierByMemoryHandle=245,
-  // BarrierByNodeRecordHandle=246
-  if ((244 <= op && op <= 246)) {
+  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254, SampleCmpBias=255
+  if ((244 <= op && op <= 246) || (254 <= op && op <= 255)) {
     major = 6;  minor = 8;
     return;
   }
@@ -1640,6 +1644,10 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     // Work Graph intrinsics
   case OpCode::NodeOutputIsValid:      A(pI1);      A(pI32); A(pNodeHandle);break;
   case OpCode::GetRemainingRecursionLevels:A(pI32);     A(pI32); break;
+
+    // Comparison Samples
+  case OpCode::SampleCmpGrad:          RRT(pETy);   A(pI32); A(pRes); A(pRes); A(pF32); A(pF32); A(pF32); A(pF32); A(pI32); A(pI32); A(pI32); A(pF32); A(pF32); A(pF32); A(pF32); A(pF32); A(pF32); A(pF32); A(pF32); break;
+  case OpCode::SampleCmpBias:          RRT(pETy);   A(pI32); A(pRes); A(pRes); A(pF32); A(pF32); A(pF32); A(pF32); A(pI32); A(pI32); A(pI32); A(pF32); A(pF32); A(pF32); break;
   // OPCODE-OLOAD-FUNCS:END
   default: DXASSERT(false, "otherwise unhandled case"); break;
   }
@@ -1945,6 +1953,8 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::Unpack4x8:
   case OpCode::TextureGatherRaw:
   case OpCode::SampleCmpLevel:
+  case OpCode::SampleCmpGrad:
+  case OpCode::SampleCmpBias:
   {
     StructType *ST = cast<StructType>(Ty);
     return ST->getElementType(0);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -289,8 +289,8 @@ class db_dxil(object):
             self.name_idx[i].category = "Resources"
         for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,SampleCmpBias,SampleCmpGrad,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].category = "Resources - sample"
-        for i in "Sample,SampleBias,SampleCmp".split(","):
-            self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
+        for i in "Sample,SampleBias,SampleCmp,SampleCmpBias".split(","):
+            self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh", "node")
         for i in "RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].shader_stages = ("pixel",)
         for i in "TextureGather,TextureGatherCmp,TextureGatherRaw".split(","):

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -287,7 +287,7 @@ class db_dxil(object):
             self.name_idx[i].category = "Dot"
         for i in "CreateHandle,CBufferLoad,CBufferLoadLegacy,TextureLoad,TextureStore,TextureStoreSample,BufferLoad,BufferStore,BufferUpdateCounter,CheckAccessFullyMapped,GetDimensions,RawBufferLoad,RawBufferStore".split(","):
             self.name_idx[i].category = "Resources"
-        for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
+        for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,SampleCmpBias,SampleCmpGrad,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].category = "Resources - sample"
         for i in "Sample,SampleBias,SampleCmp".split(","):
             self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
@@ -487,6 +487,9 @@ class db_dxil(object):
             self.name_idx[i].shader_model = 6,8
             self.name_idx[i].shader_stages = ("node",)
         for i in "BarrierByMemoryType,BarrierByMemoryHandle,BarrierByNodeRecordHandle".split(","): # included in Synchronization category
+            self.name_idx[i].shader_model = 6,8
+        for i in "SampleCmpBias,SampleCmpGrad".split(","):
+            self.name_idx[i].category = "Comparison Samples"
             self.name_idx[i].shader_model = 6,8
 
     def populate_llvm_instructions(self):
@@ -2137,6 +2140,47 @@ class db_dxil(object):
         self.add_dxil_op("GetRemainingRecursionLevels", next_op_idx, "GetRemainingRecursionLevels", "returns how many levels of recursion remain", "v", "ro", [
             db_dxil_param(0, "i32", "", "number of levels of recursion remaining")])
         next_op_idx += 1
+
+        # Comparison Sampling
+        self.add_dxil_op("SampleCmpGrad", next_op_idx, "SampleCmpGrad", "samples a texture using a gradient and compares a single component against the specified comparison value", "hf", "ro", [
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
+            db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
+            db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
+            db_dxil_param(4, "f", "coord0", "coordinate"),
+            db_dxil_param(5, "f", "coord1", "coordinate, undef for Texture1D"),
+            db_dxil_param(6, "f", "coord2", "coordinate, undef for Texture1D, Texture1DArray or Texture2D"),
+            db_dxil_param(7, "f", "coord3", "coordinate, defined only for TextureCubeArray"),
+            db_dxil_param(8, "i32", "offset0", "optional offset, applicable to Texture1D, Texture1DArray, and as part of offset1"),
+            db_dxil_param(9, "i32", "offset1", "optional offset, applicable to Texture2D, Texture2DArray, and as part of offset2"),
+            db_dxil_param(10, "i32", "offset2", "optional offset, applicable to Texture3D"),
+            db_dxil_param(11, "f", "compareValue", "the value to compare with"),
+            db_dxil_param(12, "f", "ddx0", "rate of change of coordinate c0 in the x direction"),
+            db_dxil_param(13, "f", "ddx1", "rate of change of coordinate c1 in the x direction"),
+            db_dxil_param(14, "f", "ddx2", "rate of change of coordinate c2 in the x direction"),
+            db_dxil_param(15, "f", "ddy0", "rate of change of coordinate c0 in the y direction"),
+            db_dxil_param(16, "f", "ddy1", "rate of change of coordinate c1 in the y direction"),
+            db_dxil_param(17, "f", "ddy2", "rate of change of coordinate c2 in the y direction"),
+            db_dxil_param(18, "f", "clamp", "clamp value")],
+            counters=('tex_cmp',))
+        next_op_idx += 1
+
+        self.add_dxil_op("SampleCmpBias", next_op_idx, "SampleCmpBias", "samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value", "hf", "ro", [
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
+            db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
+            db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
+            db_dxil_param(4, "f", "coord0", "coordinate"),
+            db_dxil_param(5, "f", "coord1", "coordinate, undef for Texture1D"),
+            db_dxil_param(6, "f", "coord2", "coordinate, undef for Texture1D, Texture1DArray or Texture2D"),
+            db_dxil_param(7, "f", "coord3", "coordinate, defined only for TextureCubeArray"),
+            db_dxil_param(8, "i32", "offset0", "optional offset, applicable to Texture1D, Texture1DArray, and as part of offset1"),
+            db_dxil_param(9, "i32", "offset1", "optional offset, applicable to Texture2D, Texture2DArray, and as part of offset2"),
+            db_dxil_param(10, "i32", "offset2", "optional offset, applicable to Texture3D"),
+            db_dxil_param(11, "f", "compareValue", "the value to compare with"),
+            db_dxil_param(12, "f", "bias", "bias value"),
+            db_dxil_param(13, "f", "clamp", "clamp value")],
+            counters=('tex_cmp',))
+        next_op_idx += 1
+
 
 
         # Set interesting properties.


### PR DESCRIPTION
Shader Model 6.8 will include SampleCmpGrad and SampleCmpBias intrinsics. This reserves the opcodes without adding the ability to generate the intrinsics (yet) for collabortive development purposes

contributes to #5560