### PR TITLE
[ExecutionTests] Add validation and signing step to isNormal Test

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -11530,8 +11530,6 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
           assembledShader, DxcValidatorFlags_InPlaceEdit, &pValidationResult));
       VERIFY_SUCCEEDED(pValidationResult->GetStatus(&validationStatus));
       VERIFY_SUCCEEDED(validationStatus);
-
-      pValidator.Release();
     }
 
     // Find root signature part in container
@@ -11588,7 +11586,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
 
   // The input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 normal float numbers.
   // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
-  std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.900f, -.122900f};
+  std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, -122.900f, .122900f};
   std::vector<float> *Validation_Input = &Validation_Input_Vec;
 
   std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};


### PR DESCRIPTION
The IsNormal tests required an addition to the testing framework provided by ShaderOpTest.cpp, known as the MakeShaderReplacementCallback function. This function takes a shader, compiles it to DXIL, disassembles it into a string, replaces anything specified in the function parameters, and reassembles the shader back into a dxil container. The problem with the initial implementation was that after disassembling the shader, the signature applied to the shader on the compile step would be lost.

This PR adds a validation / signing step right after assembling the shader to ensure the new DXIL container has a signature. This will prevent problems with calling CreateComputePipelineState due to a missing signature.
Verified that this fails when disabling experimental mode, and passes only when dxil.dll is available.
Fixes #5337 