### PR TITLE
[NFC] Prepare DXC sources for clang-format

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -172,7 +172,10 @@ namespace DXIL {
     Invalid,
   };
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_enum_decl("SemanticKind", hide_val=True, sort_val=False)</py>*/
+  // clang-format on
   // SemanticKind-ENUM:BEGIN
   // Semantic kind; Arbitrary or specific system value.
   enum class SemanticKind : unsigned {
@@ -211,7 +214,10 @@ namespace DXIL {
   };
   // SemanticKind-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('SigPointKind-ENUM')>hctdb_instrhelp.get_enum_decl("SigPointKind", hide_val=True, sort_val=False)</py>*/
+  // clang-format on
   // SigPointKind-ENUM:BEGIN
   // Signature Point is more specific than shader stage or signature as it is unique in both stage and item dimensionality or frequency.
   enum class SigPointKind : unsigned {
@@ -239,7 +245,10 @@ namespace DXIL {
   };
   // SigPointKind-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('SemanticInterpretationKind-ENUM')>hctdb_instrhelp.get_enum_decl("SemanticInterpretationKind", hide_val=True, sort_val=False)</py>*/
+  // clang-format on
   // SemanticInterpretationKind-ENUM:BEGIN
   // Defines how a semantic is interpreted at a particular SignaturePoint
   enum class SemanticInterpretationKind : unsigned {
@@ -257,7 +266,10 @@ namespace DXIL {
   };
   // SemanticInterpretationKind-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('PackingKind-ENUM')>hctdb_instrhelp.get_enum_decl("PackingKind", hide_val=True, sort_val=False)</py>*/
+  // clang-format on
   // PackingKind-ENUM:BEGIN
   // Kind of signature point
   enum class PackingKind : unsigned {
@@ -270,7 +282,10 @@ namespace DXIL {
   };
   // PackingKind-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('FPDenormMode-ENUM')>hctdb_instrhelp.get_enum_decl("Float32DenormMode", hide_val=False, sort_val=False)</py>*/
+  // clang-format on
   // FPDenormMode-ENUM:BEGIN
   // float32 denorm behavior
   enum class Float32DenormMode : unsigned {
@@ -750,7 +765,10 @@ namespace DXIL {
   };
   // OPCODE-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('OPCODECLASS-ENUM')>hctdb_instrhelp.get_enum_decl("OpCodeClass")</py>*/
+  // clang-format on
   // OPCODECLASS-ENUM:BEGIN
   // Groups for DXIL operations with equivalent function templates
   enum class OpCodeClass : unsigned {
@@ -1315,7 +1333,10 @@ namespace DXIL {
     ReadAcrossDiagonal = 2, // returns the value from the lane across the quad in horizontal and vertical direction
   };
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('WAVEBITOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveBitOpKind")</py>*/
+  // clang-format on
   // WAVEBITOPKIND-ENUM:BEGIN
   // Kind of bitwise cross-lane operation
   enum class WaveBitOpKind : unsigned {
@@ -1325,7 +1346,10 @@ namespace DXIL {
   };
   // WAVEBITOPKIND-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('WAVEOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveOpKind")</py>*/
+  // clang-format on
   // WAVEOPKIND-ENUM:BEGIN
   // Kind of cross-lane operation
   enum class WaveOpKind : unsigned {
@@ -1336,7 +1360,10 @@ namespace DXIL {
   };
   // WAVEOPKIND-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('WAVEMULTIPREFIXOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("WaveMultiPrefixOpKind")</py>*/
+  // clang-format on
   // WAVEMULTIPREFIXOPKIND-ENUM:BEGIN
   // Kind of cross-lane for multi-prefix operation
   enum class WaveMultiPrefixOpKind : unsigned {
@@ -1348,7 +1375,10 @@ namespace DXIL {
   };
   // WAVEMULTIPREFIXOPKIND-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('SIGNEDOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("SignedOpKind")</py>*/
+  // clang-format on
   // SIGNEDOPKIND-ENUM:BEGIN
   // Sign vs. unsigned operands for operation
   enum class SignedOpKind : unsigned {
@@ -1357,7 +1387,10 @@ namespace DXIL {
   };
   // SIGNEDOPKIND-ENUM:END
 
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('QUADVOTEOPKIND-ENUM')>hctdb_instrhelp.get_enum_decl("QuadVoteOpKind")</py>*/
+  // clang-format on
   // QUADVOTEOPKIND-ENUM:BEGIN
   // Kind of cross-quad vote operation
   enum class QuadVoteOpKind : unsigned {

--- a/include/dxc/DXIL/DxilCounters.h
+++ b/include/dxc/DXIL/DxilCounters.h
@@ -21,7 +21,10 @@ namespace llvm {
 namespace hlsl {
 
 struct DxilCounters {
+  // clang-format off
+  // Python lines need to be not formatted.
   // <py::lines('OPCODE-COUNTERS')>['uint32_t %s = 0;' % c for c in hctdb_instrhelp.get_counters()]</py>
+  // clang-format on
   // OPCODE-COUNTERS:BEGIN
   uint32_t array_local_bytes = 0;
   uint32_t array_local_ldst = 0;

--- a/include/dxc/DXIL/DxilShaderModel.h
+++ b/include/dxc/DXIL/DxilShaderModel.h
@@ -31,7 +31,10 @@ public:
   using Kind = DXIL::ShaderKind;
 
   // Major/Minor version of highest shader model
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_highest_shader_model()</py>*/
+  // clang-format on
   // VALRULE-TEXT:BEGIN
   static const unsigned kHighestMajor = 6;
   static const unsigned kHighestMinor = 7;
@@ -62,7 +65,10 @@ public:
   }
   bool IsSM50Plus() const   { return IsSMAtLeast(5, 0); }
   bool IsSM51Plus() const   { return IsSMAtLeast(5, 1); }
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_is_shader_model_plus()</py>*/
+  // clang-format on
   // VALRULE-TEXT:BEGIN
   bool IsSM60Plus() const { return IsSMAtLeast(6, 0); }
   bool IsSM61Plus() const { return IsSMAtLeast(6, 1); }

--- a/include/dxc/DXIL/DxilSigPoint.inl
+++ b/include/dxc/DXIL/DxilSigPoint.inl
@@ -51,7 +51,10 @@ const SigPoint SigPoint::ms_SigPoints[kNumSigPointRecords] = {
 #undef DEF_SIGPOINT
 };
 
+// clang-format off
+// Python lines need to be not formatted.
 // <py::lines('INTERPRETATION-TABLE')>hctdb_instrhelp.get_interpretation_table()</py>
+// clang-format on
 // INTERPRETATION-TABLE:BEGIN
 //   Semantic,               VSIn,         VSOut,    PCIn,         HSIn,         HSCPIn,   HSCPOut,  PCOut,      DSIn,         DSCPIn,   DSOut,    GSVIn,    GSIn,         GSOut,    PSIn,          PSOut,         CSIn,     MSIn,     MSOut,    MSPOut,    ASIn
 #define DO_INTERPRETATION_TABLE(ROW) \

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -91,7 +91,10 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
+  // clang-format onm
   // SemanticKind-ENUM:BEGIN
   RDAT_ENUM_VALUE_NODEF(Arbitrary)
   RDAT_ENUM_VALUE_NODEF(VertexID)

--- a/include/dxc/Support/FileIOHelper.h
+++ b/include/dxc/Support/FileIOHelper.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "Global.h"
+#include "dxc/Support/WinIncludes.h"
 
 #ifndef _ATL_DECLSPEC_ALLOCATOR
 #define _ATL_DECLSPEC_ALLOCATOR

--- a/lib/DXIL/DxilCounters.cpp
+++ b/lib/DXIL/DxilCounters.cpp
@@ -230,7 +230,10 @@ bool CountLlvmOp_uints(unsigned op) {
 // OPCODE-COUNTERS:END
 
 void CountDxilOp(unsigned op, DxilCounters &counters) {
+  // clang-format off
+  // Python lines need to be not formatted.
   // <py::lines('COUNT-DXIL-OPS')>['if (CountDxilOp_%s(op)) ++counters.%s;' % (c,c) for c in hctdb_instrhelp.get_dxil_op_counters()]</py>
+  // clang-format on
   // COUNT-DXIL-OPS:BEGIN
   if (CountDxilOp_atomic(op)) ++counters.atomic;
   if (CountDxilOp_barrier(op)) ++counters.barrier;
@@ -251,7 +254,10 @@ void CountDxilOp(unsigned op, DxilCounters &counters) {
 }
 
 void CountLlvmOp(unsigned op, DxilCounters &counters) {
+  // clang-format off
+  // Python lines need to be not formatted.
   // <py::lines('COUNT-LLVM-OPS')>['if (CountLlvmOp_%s(op)) ++counters.%s;' % (c,c) for c in hctdb_instrhelp.get_llvm_op_counters()]</py>
+  // clang-format on
   // COUNT-LLVM-OPS:BEGIN
   if (CountLlvmOp_atomic(op)) ++counters.atomic;
   if (CountLlvmOp_fence(op)) ++counters.fence;
@@ -334,7 +340,10 @@ struct CounterOffsetByName {
 
 // Must be sorted case-sensitive:
 static const CounterOffsetByName CountersByName[] = {
+  // clang-format off
+  // Python lines need to be not formatted.
   // <py::lines('COUNTER-MEMBER-PTRS')>['{ "%s", &DxilCounters::%s },' % (c,c) for c in hctdb_instrhelp.get_counters()]</py>
+  // clang-format on
   // COUNTER-MEMBER-PTRS:BEGIN
   { "array_local_bytes", &DxilCounters::array_local_bytes },
   { "array_local_ldst", &DxilCounters::array_local_ldst },

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2267,7 +2267,10 @@ void DxilMDHelper::EmitDxilCounters(const DxilCounters &counters) {
     m_pModule->eraseNamedMetadata(pDxilCountersMD);
 
   vector<Metadata*> MDVals;
+  // clang-format off
+  // Python lines need to be not formatted.
   // <py::lines('OPCODE-COUNTERS')>['AddCounterIfNonZero(counters.%s, "%s", MDVals);' % (c,c) for c in hctdb_instrhelp.get_counters()]</py>
+  // clang-format on
   // OPCODE-COUNTERS:BEGIN
   AddCounterIfNonZero(counters.array_local_bytes, "array_local_bytes", MDVals);
   AddCounterIfNonZero(counters.array_local_ldst, "array_local_ldst", MDVals);

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -609,7 +609,10 @@ OP::OpCode OP::GetDxilOpFuncCallInst(const llvm::Instruction *I) {
 
 bool OP::IsDxilOpWave(OpCode C) {
   unsigned op = (unsigned)C;
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('OPCODE-WAVE')>hctdb_instrhelp.get_instrs_pred("op", "is_wave")</py>*/
+  // clang-format on
   // OPCODE-WAVE:BEGIN
   // Instructions: WaveIsFirstLane=110, WaveGetLaneIndex=111,
   // WaveGetLaneCount=112, WaveAnyTrue=113, WaveAllTrue=114,
@@ -624,7 +627,10 @@ bool OP::IsDxilOpWave(OpCode C) {
 
 bool OP::IsDxilOpGradient(OpCode C) {
   unsigned op = (unsigned)C;
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('OPCODE-GRADIENT')>hctdb_instrhelp.get_instrs_pred("op", "is_gradient")</py>*/
+  // clang-format on
   // OPCODE-GRADIENT:BEGIN
   // Instructions: Sample=60, SampleBias=61, SampleCmp=64, CalculateLOD=81,
   // DerivCoarseX=83, DerivCoarseY=84, DerivFineX=85, DerivFineY=86,
@@ -635,7 +641,10 @@ bool OP::IsDxilOpGradient(OpCode C) {
 
 bool OP::IsDxilOpFeedback(OpCode C) {
   unsigned op = (unsigned)C;
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('OPCODE-FEEDBACK')>hctdb_instrhelp.get_instrs_pred("op", "is_feedback")</py>*/
+  // clang-format on
   // OPCODE-FEEDBACK:BEGIN
   // Instructions: WriteSamplerFeedback=174, WriteSamplerFeedbackBias=175,
   // WriteSamplerFeedbackLevel=176, WriteSamplerFeedbackGrad=177
@@ -651,7 +660,10 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
   // Default is 6.0, all stages
   major = 6;  minor = 0;
   mask = ((unsigned)1 << (unsigned)DXIL::ShaderKind::Invalid) - 1;
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('OPCODE-SMMASK')>hctdb_instrhelp.get_min_sm_and_mask_text()</py>*/
+  // clang-format on
   // OPCODE-SMMASK:BEGIN
   // Instructions: ThreadId=93, GroupId=94, ThreadIdInGroup=95,
   // FlattenedThreadIdInGroup=96
@@ -1588,7 +1600,10 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   Type *Ty = F->getReturnType();
   FunctionType *FT = F->getFunctionType();
   LLVMContext &Ctx = F->getContext();
-/* <py::lines('OPCODE-OLOAD-TYPES')>hctdb_instrhelp.get_funcs_oload_type()</py>*/
+  // clang-format off
+  // Python lines need to be not formatted.
+  /* <py::lines('OPCODE-OLOAD-TYPES')>hctdb_instrhelp.get_funcs_oload_type()</py>*/
+  // clang-format on
   switch (opCode) {            // return     OpCode
   // OPCODE-OLOAD-TYPES:BEGIN
   case OpCode::TempRegStore:

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -57,7 +57,10 @@ bool ShaderModel::IsValidForDxil() const {
   switch (m_Major) {
     case 6: {
       switch (m_Minor) {
+      // clang-format off
+      // Python lines need to be not formatted.
       /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_is_valid_for_dxil()</py>*/
+      // clang-format on
       // VALRULE-TEXT:BEGIN
       case 0:
       case 1:
@@ -219,7 +222,10 @@ const ShaderModel *ShaderModel::GetByName(const char *pszName) {
   switch (pszName[Idx++]) {
     case '0': Minor = 0;  break;
     case '1': Minor = 1;  break;
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_shader_model_by_name()</py>*/
+  // clang-format on
   // VALRULE-TEXT:BEGIN
   case '2':
     if (Major == 6) {
@@ -316,7 +322,10 @@ void ShaderModel::GetMinValidatorVersion(unsigned &ValMajor, unsigned &ValMinor)
   DXASSERT(IsValidForDxil(), "invalid shader model");
   ValMajor = 1;
   switch (m_Minor) {
+  // clang-format off
+  // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_min_validator_version()</py>*/
+  // clang-format on
   // VALRULE-TEXT:BEGIN
   case 0:
     ValMinor = 0;

--- a/lib/HLSL/DxilSignatureValidation.cpp
+++ b/lib/HLSL/DxilSignatureValidation.cpp
@@ -18,6 +18,7 @@ using namespace hlsl;
 using namespace llvm;
 
 #include <assert.h> // Needed for DxilPipelineStateValidation.h
-#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include <functional>
+
+#include "dxc/DxilContainer/DxilPipelineStateValidation.h"
 #include "dxc/HLSL/ViewIDPipelineValidation.inl"

--- a/projects/dxilconv/include/Support/DXIncludes.h
+++ b/projects/dxilconv/include/Support/DXIncludes.h
@@ -16,7 +16,8 @@
 
 // This is a platform-specific file.
 // Do not add LLVM/Clang or DXIL files to this file.
-
+// clang-format off
+// Includes on Windows are highly order dependent.
 #define NOMINMAX 1
 #define WIN32_LEAN_AND_MEAN 1
 #define VC_EXTRALEAN 1
@@ -37,3 +38,4 @@
 #endif
 
 #include "ShaderBinary/ShaderBinary.h"
+// clang-format on

--- a/projects/dxilconv/lib/ShaderBinary/ShaderBinaryIncludes.h
+++ b/projects/dxilconv/lib/ShaderBinary/ShaderBinaryIncludes.h
@@ -8,6 +8,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma once
+// clang-format off
+// Includes on Windows are highly order dependent.
 #include "windows.h"
 
 #include <assert.h>
@@ -20,5 +22,6 @@
 #include "dxc/Support/d3dx12.h"
 #include "dxc/Support/D3D12TokenizedProgramFormat.hpp"
 #include "ShaderBinary/ShaderBinary.h"
+// clang-format on
 
 #define ASSUME( _exp ) { assert( _exp ); __analysis_assume( _exp ); __assume( _exp ); }

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -16,6 +16,7 @@
 #ifndef LLVM_CLANG_AST_HLSLTYPES_H
 #define LLVM_CLANG_AST_HLSLTYPES_H
 
+#include "clang/AST/DeclarationName.h"
 #include "clang/AST/Type.h"             // needs QualType
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
@@ -40,7 +41,8 @@ namespace clang {
   class Sema;
   class TypeSourceInfo;
   class TypedefDecl;
-}
+  class VarDecl;
+ }
 
 namespace hlsl {
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -19,7 +19,7 @@
 #endif
 
 // clang-format off
-// Windows include ordering is fragile.
+// Includes on Windows are highly order dependent.
 
 #include <memory>
 #include <vector>

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -18,6 +18,9 @@
 #define _WCHAR_H_CPLUSPLUS_98_CONFORMANCE_
 #endif
 
+// clang-format off
+// Windows include ordering is fragile.
+
 #include <memory>
 #include <vector>
 #include <string>
@@ -62,6 +65,8 @@
 #include <chrono>
 
 #include <codecvt>
+
+// clang-format on
 
 
 using namespace std;


### PR DESCRIPTION
This change prepares DXC sources to be ready to clang-format. This change adds annotations to skip formatting parts of the code that will break if clang-format modifies them due to include ordering or generated C++. It also adds missing include and forward declarations where clang-formatting resulted in moving things around that caused code breakages.