### PR TITLE
Custom extensions to enable lowering for non-resource based functions

### DIFF
--- a/include/dxc/HLSL/HLOperationLowerExtension.h
+++ b/include/dxc/HLSL/HLOperationLowerExtension.h
@@ -45,6 +45,7 @@ namespace hlsl {
       Pack,           // Convert the vector arguments into structs.
       Resource,       // Convert return value to resource return and explode vectors.
       Dxil,           // Convert call to a dxil intrinsic.
+      Custom,         // Custom lowering based on flexible json string.      
     };
 
     // Create the lowering using the given strategy and custom codegen helper.
@@ -86,5 +87,6 @@ namespace hlsl {
     llvm::Value *Resource(llvm::CallInst *CI);
     llvm::Value *Dxil(llvm::CallInst *CI);
     llvm::Value *CustomResource(llvm::CallInst *CI);
+    llvm::Value *Custom(llvm::CallInst *CI);
   };
 }

--- a/lib/HLSL/HLOperationLowerExtension.cpp
+++ b/lib/HLSL/HLOperationLowerExtension.cpp
@@ -993,11 +993,10 @@ private:
                 }
                 else
                 {
-                    // This also disables 'exploding' of vectors
+                    // If the vector isn't exploded, use structs for DXIL Intrinsics
                     if (Arg->getType()->isVectorTy()) {
                       Arg = PackVectorIntoStruct(builder, Arg);
                     }
-                    // If not vector, just leave it alone
                 }
 
                 m_LoweredArgs.push_back(Arg);

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -7,6 +7,7 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "llvm/ADT/STLExtras.h"
 #include "dxc/Test/CompilationResult.h"
 #include "dxc/Test/HlslTestUtils.h"
 #include "dxc/Test/DxcTestUtils.h"
@@ -1344,7 +1345,7 @@ TEST_F(ExtensionTest, ResourceExtensionIntrinsic) {
     "%9 = extractvalue { float, float } %7, 1"
   };
 
-  CheckMsgs(disassembly.c_str(), disassembly.length(), expected, sizeof(expected)/sizeof(LPCSTR), false);
+  CheckMsgs(disassembly.c_str(), disassembly.length(), expected, llvm::array_lengthof(expected), false);
  }
 
 TEST_F(ExtensionTest, NameLoweredWhenNoReplicationNeeded) {

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -1332,7 +1332,7 @@ TEST_F(ExtensionTest, ResourceExtensionIntrinsic) {
   // - input type is 2x struct
   // - function overload handles variable arguments (and replaces them with undefs)
   // - output struct gets converted to vector
-  llvm::ArrayRef<LPCSTR> expected = {
+  LPCSTR expected[] = {
     "%1 = call { float, float } @CustomLoadOp(i32 21, { i32, i32 } { i32 1, i32 2 }, i1 undef, i32 undef, i32 undef)",
     "%2 = extractvalue { float, float } %1, 0",
     "%3 = extractvalue { float, float } %1, 1",
@@ -1343,7 +1343,8 @@ TEST_F(ExtensionTest, ResourceExtensionIntrinsic) {
     "%8 = extractvalue { float, float } %7, 0",
     "%9 = extractvalue { float, float } %7, 1"
   };
-  CheckMsgs(disassembly.c_str(), disassembly.length(), expected.data(), expected.size(), false);
+
+  CheckMsgs(disassembly.c_str(), disassembly.length(), expected, sizeof(expected)/sizeof(LPCSTR), false);
  }
 
 TEST_F(ExtensionTest, NameLoweredWhenNoReplicationNeeded) {

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -110,7 +110,7 @@ static const HLSL_INTRINSIC_ARGUMENT TestCustomLoadOpBool[] = {
   { "val",  AR_QUAL_IN, 2, LITEMPLATE_SCALAR, 2, LICOMPTYPE_BOOL, 1, 1},
 };
 
-// float2 = CustomLoadOp(uint2 addr, bool val, uint lo, uint hi)
+// float2 = CustomLoadOp(uint2 addr, bool val, uint2 subscript)
 static const HLSL_INTRINSIC_ARGUMENT TestCustomLoadOpSubscript[] = {
   { "CustomLoadOp", AR_QUAL_OUT, 0, LITEMPLATE_VECTOR, 0, LICOMPTYPE_FLOAT, 1, 2 },
   { "addr",         AR_QUAL_IN,  1, LITEMPLATE_VECTOR, 1, LICOMPTYPE_UINT, 1, 2},

--- a/tools/clang/unittests/HLSL/ExtensionTest.cpp
+++ b/tools/clang/unittests/HLSL/ExtensionTest.cpp
@@ -208,6 +208,12 @@ Intrinsic Intrinsics[] = {
   {L"test_o_1",     "test_o_1.$o:1",   "r", { 18, false, true, true, -1,  countof(TestOverloadArgs), TestOverloadArgs }},
   {L"test_o_2",     "test_o_2.$o:2",   "r", { 19, false, true, true, -1,  countof(TestOverloadArgs), TestOverloadArgs }},
   {L"test_o_3",     "test_o_3.$o:3",   "r", { 20, false, true, true, -1,  countof(TestOverloadArgs), TestOverloadArgs }},
+  // custom lowering with both optional arguments and vector exploding.
+  // Arg 0 = Opcode
+  // Arg 1 = Pass as is
+  // Arg 2:?i1 = Optional boolean argument
+  // Arg 3.0:?i32 = Optional x component (in i32) of 3rd HLSL arg
+  // Arg 3.1:?i32 = Optional y component (in i32) of 3rd HLSL arg
   {L"CustomLoadOp", "CustomLoadOp",    "c:{\"default\" : \"0,1,2:?i1,3.0:?i32,3.1:?i32\"}", { 21, true,  false, false, -1, countof(TestCustomLoadOp), TestCustomLoadOp}},
   {L"CustomLoadOp", "CustomLoadOp",    "c:{\"default\" : \"0,1,2:?i1,3.0:?i32,3.1:?i32\"}", { 21, true,  false, false, -1, countof(TestCustomLoadOpBool), TestCustomLoadOpBool}},
   {L"CustomLoadOp", "CustomLoadOp",    "c:{\"default\" : \"0,1,2:?i1,3.0:?i32,3.1:?i32\"}", { 21, true,  false, false, -1, countof(TestCustomLoadOpSubscript), TestCustomLoadOpSubscript}},


### PR DESCRIPTION
A downstream consumer requires the use of custom function lowering using a json string as well as methods. For instance, a direct memory load not based on a resource.