### PR TITLE
PIX: CP of "Educate debug data interface about nested namespaces (#5558)"

### DIFF
--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -2331,10 +2331,22 @@ void Raygen()
 
 typedef BuiltInTriangleIntersectionAttributes MyAttributes;
 
+namespace ANameSpace
+{
+    namespace AContainedNamespace
+    {
+        float4 RoundaboutWayToReturnAmbientColor()
+        {
+            return g_sceneCB.lightAmbientColor;
+        }
+    }
+}
+
+
 [shader("closesthit")]
 void InnerClosestHitShader(inout RayPayload payload, in MyAttributes attr)
 {
-    payload.color = float4(0,1,0,0);
+    payload.color = ANameSpace::AContainedNamespace::RoundaboutWayToReturnAmbientColor();
 }
 
 


### PR DESCRIPTION
The comment from the checkin kinda says it all:
// DINamespace has a getScope member (that hides DIScope's) // that returns a DIScope directly, but if that namespace
                // is at file-level scope, it will return nullptr.
(The upshot of this is that you couldn't step into functions within a namespace in WinPIX's shader debugger)

(cherry picked from commit c2233c6c0a528ecaf5d2d008684e08daf722d845)