### PR TITLE
Amend compute node compatibility DXIL validation

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3161,6 +3161,7 @@ META.TARGET                               Target triple must be 'dxil-ms-dx'
 META.TESSELLATOROUTPUTPRIMITIVE           Invalid Tessellator Output Primitive specified. Must be point, line, triangleCW or triangleCCW.
 META.TESSELLATORPARTITION                 Invalid Tessellator Partitioning specified. Must be integer, pow2, fractional_odd or fractional_even.
 META.TEXTURETYPE                          elements of typed buffers and textures must fit in four 32-bit quantities.
+META.UNEXPECTED                           Unexpected metadata detected.
 META.USED                                 All metadata must be used by dxil.
 META.VALIDSAMPLERMODE                     Invalid sampler mode on sampler .
 META.VALUERANGE                           Metadata value must be within range.

--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3025,8 +3025,6 @@ DECL.SHADERMISSINGARG                     payload/params/attributes parameter is
 DECL.SHADERRETURNVOID                     Shader functions must return void
 DECL.USEDEXTERNALFUNCTION                 External function must be used
 DECL.USEDINTERNAL                         Internal declaration must be used
-FLOW.COMPUTENODEIO                        Node with input or outputs is not compatible with Compute
-FLOW.COMPUTENODELAUNCHTYPE                Node launch type is not compatible with Compute
 FLOW.DEADLOOP                             Loop must have break.
 FLOW.FUNCTIONCALL                         Function with parameter is not permitted
 FLOW.NORECUSION                           Recursion is not permitted.
@@ -3125,6 +3123,7 @@ META.BARYCENTRICSTWOPERSPECTIVES          There can only be up to two input attr
 META.BRANCHFLATTEN                        Can't use branch and flatten attributes together.
 META.CLIPCULLMAXCOMPONENTS                Combined elements of SV_ClipDistance and SV_CullDistance must fit in 8 components
 META.CLIPCULLMAXROWS                      Combined elements of SV_ClipDistance and SV_CullDistance must fit in two rows.
+META.COMPUTEWITHNODE                      Compute entry must not have node metadata
 META.CONTROLFLOWHINTNOTONCONTROLFLOW      Control flow hint only works on control flow inst.
 META.DENSERESIDS                          Resource identifiers must be zero-based and dense.
 META.DUPLICATESYSVALUE                    System value may only appear once in signature
@@ -3161,7 +3160,6 @@ META.TARGET                               Target triple must be 'dxil-ms-dx'
 META.TESSELLATOROUTPUTPRIMITIVE           Invalid Tessellator Output Primitive specified. Must be point, line, triangleCW or triangleCCW.
 META.TESSELLATORPARTITION                 Invalid Tessellator Partitioning specified. Must be integer, pow2, fractional_odd or fractional_even.
 META.TEXTURETYPE                          elements of typed buffers and textures must fit in four 32-bit quantities.
-META.UNEXPECTED                           Unexpected metadata detected.
 META.USED                                 All metadata must be used by dxil.
 META.VALIDSAMPLERMODE                     Invalid sampler mode on sampler .
 META.VALUERANGE                           Metadata value must be within range.

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3491,38 +3491,10 @@ static void ValidateFunction(Function &F, ValidationContext &ValCtx) {
         DxilModule &DM = ValCtx.DxilMod;
         if (DM.HasDxilEntryProps(&F)) {
           DxilEntryProps &entryProps = DM.GetDxilEntryProps(&F);
-          // Check compatibility when both compute and node are specified
-          if (entryProps.props.IsNode()) {
-            // Compute is only compatible with Broadcasting launch nodes
-
-            if (entryProps.props.Node.LaunchType !=
-                DXIL::NodeLaunchType::Broadcasting) {
-              ValCtx.EmitFnFormatError(
-                  &F, ValidationRule::FlowComputeNodeLaunchType,
-                  {F.getName(), entryProps.props.Node.LaunchType ==
-                                        DXIL::NodeLaunchType::Coalescing
-                                    ? ShaderModel::GetNodeLaunchTypeName(
-                                          DXIL::NodeLaunchType::Coalescing)
-                                    : ShaderModel::GetNodeLaunchTypeName(
-                                          DXIL::NodeLaunchType::Thread)});
-              break;
-            }
-            // Compute is not compatible with node input (other than an input
-            // added implicitly) or outputs (only produce this error if we
-            // haven't produced the one above) Implicitly added input may only
-            // be an EmptyNodeInput or a record with size of 12 bytes.
-            if (!(entryProps.props.InputNodes.empty() ||
-                  entryProps.props.InputNodes[0]
-                          .GetNodeRecordInfo()
-                          .RecordSize == 12 ||
-                  NodeFlags(entryProps.props.InputNodes[0]
-                                .GetNodeRecordInfo()
-                                .IOFlags)
-                      .IsEmptyInput()) ||
-                !entryProps.props.OutputNodes.empty()) {
-              ValCtx.EmitFnFormatError(&F, ValidationRule::FlowComputeNodeIO,
-                                       {F.getName()});
-            }
+          // Check that compute has no node metadata
+          if (entryProps.props.IsNode()) {             
+              ValCtx.EmitFnFormatError(&F, ValidationRule::MetaUnexpected,
+                                       {F.getName()});           
           }
         }
         break;

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3460,7 +3460,7 @@ static void ValidateNodeInputRecord(Function *F, ValidationContext &ValCtx) {
         break;
       default:
         llvm_unreachable("invalid launch type");
-			}
+      }
       ValCtx.EmitFnFormatError(
           F, ValidationRule::DeclNodeLaunchInputType,
           {ShaderModel::GetNodeLaunchTypeName(props.Node.LaunchType),

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3495,8 +3495,9 @@ static void ValidateFunction(Function &F, ValidationContext &ValCtx) {
           DxilEntryProps &entryProps = DM.GetDxilEntryProps(&F);
           // Check that compute has no node metadata
           if (entryProps.props.IsNode()) {
-            ValCtx.EmitFnFormatError(&F, ValidationRule::MetaUnexpected,
-                                     {F.getName()});                     
+            ValCtx.EmitFnFormatError(&F, ValidationRule::MetaComputeWithNode,
+                                     {F.getName()});
+          }
         }
         break;
       }

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3447,7 +3447,7 @@ static void ValidateNodeInputRecord(Function *F, ValidationContext &ValCtx) {
       if (input.Flags.IsEmptyInput())
         continue;
 
-      LPCSTR validInputs = "";
+      llvm::StringRef validInputs = "";
       switch (props.Node.LaunchType) {
       case DXIL::NodeLaunchType::Broadcasting:
         validInputs = "{RW}DispatchNodeInputRecord";

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -3458,7 +3458,9 @@ static void ValidateNodeInputRecord(Function *F, ValidationContext &ValCtx) {
       case DXIL::NodeLaunchType::Thread:
         validInputs = "{RW}ThreadNodeInputRecord";
         break;
-      }
+      default:
+        llvm_unreachable("invalid launch type");
+			}
       ValCtx.EmitFnFormatError(
           F, ValidationRule::DeclNodeLaunchInputType,
           {ShaderModel::GetNodeLaunchTypeName(props.Node.LaunchType),
@@ -3492,10 +3494,9 @@ static void ValidateFunction(Function &F, ValidationContext &ValCtx) {
         if (DM.HasDxilEntryProps(&F)) {
           DxilEntryProps &entryProps = DM.GetDxilEntryProps(&F);
           // Check that compute has no node metadata
-          if (entryProps.props.IsNode()) {             
-              ValCtx.EmitFnFormatError(&F, ValidationRule::MetaUnexpected,
-                                       {F.getName()});           
-          }
+          if (entryProps.props.IsNode()) {
+            ValCtx.EmitFnFormatError(&F, ValidationRule::MetaUnexpected,
+                                     {F.getName()});                     
         }
         break;
       }

--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -14,24 +14,24 @@ struct RECORD {
 };
 
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 [NodeDispatchGrid(1, 1, 1)]
 [NumThreads(1,1,1)]
 void node01(DispatchNodeInputRecord<RECORD> input) { }
 
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 [NodeDispatchGrid(2, 1, 1)]
 [NumThreads(1,1,1)]
 void node02(RWDispatchNodeInputRecord<RECORD> input) { }
 
 [Shader("node")]
-[NodeLaunch("Broadcasting")]
+[NodeLaunch("broadcasting")]
 [NodeDispatchGrid(3, 1, 1)]
 [NumThreads(1,1,1)]
 void node03(NodeOutput<RECORD> output) { }
 
 [Shader("node")]
-[NodeLaunch("Coalescing")]
+[NodeLaunch("coalescing")]
 [NumThreads(1,1,1)]
 void node04() { }

--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -1,12 +1,12 @@
 // ==================================================================
-// Errors are expected for shaders with both "node" and "compute"
-// specified when:
+// Errors are expected for compute shaders when:
 // - a broadcasting node has an input record and/or output records
 // - the launch type is not broadcasting
-// This test operates by changing the [Shader(node)] metadata entry
-// to [Shader(compute)] as if both had been specified in the HLSL,
-// for each shader in turn.
-// It also changes the coalescing to thread in the final test case.
+// This test operates by changing the [Shader("node")] metadata entry
+// to [Shader("compute")] for each shader in turn.
+// It also changes the coalescing to thread in the final test case,
+// after swapping out the shader kind to compute.
+// The shader is compiled with "-T lib_6_8 -HV 2021"
 // ==================================================================
 
 struct RECORD {
@@ -35,3 +35,9 @@ void node03(NodeOutput<RECORD> output) { }
 [NodeLaunch("coalescing")]
 [NumThreads(1,1,1)]
 void node04() { }
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1,1,1)]
+void node05() { }

--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -1,11 +1,7 @@
 // ==================================================================
-// Errors are expected for compute shaders when:
-// - a broadcasting node has an input record and/or output records
-// - the launch type is not broadcasting
-// This test operates by changing the [Shader("node")] metadata entry
-// to [Shader("compute")] for each shader in turn.
-// It also changes the coalescing to thread in the final test case,
-// after swapping out the shader kind to compute.
+// This HLSL source is used by ValidationTest::ComputeNodeCompatibility,
+// which modifies metadata in this compiled library to verify 
+// validation rules related to node shader entry metadata.
 // The shader is compiled with "-T lib_6_8 -HV 2021"
 // ==================================================================
 

--- a/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
+++ b/tools/clang/test/DXILValidation/compute_node_compatibility.hlsl
@@ -1,83 +1,37 @@
 // ==================================================================
 // Errors are expected for shaders with both "node" and "compute"
 // specified when:
-// - the launch type is not broadcasting
 // - a broadcasting node has an input record and/or output records
+// - the launch type is not broadcasting
 // This test operates by changing the [Shader(node)] metadata entry
 // to [Shader(compute)] as if both had been specified in the HLSL,
 // for each shader in turn.
+// It also changes the coalescing to thread in the final test case.
 // ==================================================================
 
 struct RECORD {
   uint a;
 };
 
-//[Shader("compute")]
 [Shader("node")]
-[NumThreads(128,1,1)]
-[NodeLaunch("coalescing")]
-void node01() { }
-
-//[Shader("compute")]
-[Shader("node")]
-[NumThreads(128,1,1)]
-[NodeLaunch("coalescing")]
-void node02(GroupNodeInputRecords<RECORD> input) { }
-
-//[Shader("compute")]
-[Shader("node")]
-[NumThreads(128,1,1)]
-[NodeLaunch("coalescing")]
-void node03(RWGroupNodeInputRecords<RECORD> input) { }
-
-//[Shader("compute")]
-[Shader("node")]
-[NumThreads(128,1,1)]
-[NodeLaunch("coalescing")]
-void node04(EmptyNodeInput input) { }
-
-//[Shader("compute")]
-[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
 [NumThreads(1,1,1)]
-[NodeLaunch("thread")]
-void node05() { }
+void node01(DispatchNodeInputRecord<RECORD> input) { }
 
-//[Shader("compute")]
 [Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(2, 1, 1)]
 [NumThreads(1,1,1)]
-[NodeLaunch("thread")]
-void node06(ThreadNodeInputRecord<RECORD> input) { }
+void node02(RWDispatchNodeInputRecord<RECORD> input) { }
 
-//[Shader("compute")]
 [Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(3, 1, 1)]
 [NumThreads(1,1,1)]
-[NodeLaunch("thread")]
-void node07(RWThreadNodeInputRecord<RECORD> input) { }
+void node03(NodeOutput<RECORD> output) { }
 
-//[Shader("compute")]
 [Shader("node")]
-[NumThreads(1024,1,1)]
-[NodeLaunch("broadcasting")]
-[NodeDispatchGrid(128,1,1)]
-void node08(DispatchNodeInputRecord<RECORD> input) { }
-
-//[Shader("compute")]
-[NumThreads(1024,1,1)]
-[Shader("node")]
-[NodeLaunch("broadcasting")]
-[NodeDispatchGrid(128,1,1)]
-void node09(RWDispatchNodeInputRecord<RECORD> input) { }
-
-//[Shader("compute")]
-[Shader("node")]
-[NodeLaunch("broadcasting")]
-[NumThreads(1024,1,1)]
-[NodeDispatchGrid(128,1,1)]
-void node10(NodeOutput<RECORD> output) { }
-
-//[Shader("compute")]
-[Shader("node")]
-[NumThreads(1024,1,1)]
-[NodeLaunch("broadcasting")]
-[NodeDispatchGrid(128,1,1)]
-void node11(EmptyNodeOutput output) { }
+[NodeLaunch("Coalescing")]
+[NumThreads(1,1,1)]
+void node04() { }

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4269,7 +4269,13 @@ TEST_F(ValidationTest, AtomicsInvalidDests) {
       "Non-groupshared or node record destination to atomic operation.", false);
 }
 
-// Check validation error for incompatible compute and node combinations
+// Errors are expected for compute shaders when:
+// - a broadcasting node has an input record and/or output records
+// - the launch type is not broadcasting
+// This test operates by changing the [Shader("node")] metadata entry
+// to [Shader("compute")] for each shader in turn.
+// It also changes the coalescing to thread in the 2nd to last test case,
+// after swapping out the shader kind to compute.
 TEST_F(ValidationTest, ComputeNodeCompatibility) {
   if (m_ver.SkipDxilVersion(1, 7))
     return;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4285,34 +4285,34 @@ TEST_F(ValidationTest, ComputeNodeCompatibility) {
       pArguments.data(), 2, nullptr, 0,
       {"!11 = !{i32 8, i32 15"}, // original: node shader
       {"!11 = !{i32 8, i32 5"},  // changed to: compute shader
-      "Node 'node01' with input/outputs is not compatible with compute", false);
+      "Compute entry 'node01' has unexpected node shader metadata", false);
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
       {"!19 = !{i32 8, i32 15"}, // original: node shader
       {"!19 = !{i32 8, i32 5"},  // changed to: compute shader
-      "Node 'node02' with input/outputs is not compatible with compute", false);
+      "Compute entry 'node02' has unexpected node shader metadata", false);
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
       {"!25 = !{i32 8, i32 15"}, // original: node shader
       {"!25 = !{i32 8, i32 5"},  // changed to: compute shader
-      "Node 'node03' with input/outputs is not compatible with compute", false);
+      "Compute entry 'node03' has unexpected node shader metadata", false);
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
-      {"!34 = !{i32 8, i32 15"}, // original: node shader
-      {"!34 = !{i32 8, i32 5"},  // changed to: compute shader
-      "Node 'node04' coalescing launch type is not compatible with compute",
+      {"!32 = !{i32 8, i32 15"}, // original: node shader
+      {"!32 = !{i32 8, i32 5"},  // changed to: compute shader
+      "Compute entry 'node04' has unexpected node shader metadata",
       false);
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
-      {"!34 = !{i32 8, i32 15, i32 13, i32 2"}, // original: node shader,
+      {"!32 = !{i32 8, i32 15, i32 13, i32 2"}, // original: node shader,
                                                 // coalesing launch type
-      {"!34 = !{i32 8, i32 5, i32 13, i32 3"},  // changed to: compute shader,
+      {"!32 = !{i32 8, i32 5, i32 13, i32 3"},  // changed to: compute shader,
                                                 // thread launch type
-      "Node 'node04' thread launch type is not compatible with compute", false);
+      "Compute entry 'node04' has unexpected node shader metadata", false);
 }
 
 // Check validation error for incompatible node input record types

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1052,8 +1052,8 @@ TEST_F(ValidationTest, SimpleHs1Fail) {
           "Constant data",
           // TODO: enable this after support pass thru hull shader.
           //"For pass thru hull shader, input control point count must match
-          //output control point count", "Total number of scalars across all HS
-          //output control points must not exceed",
+          // output control point count", "Total number of scalars across all HS
+          // output control points must not exceed",
       });
 }
 TEST_F(ValidationTest, SimpleHs3Fail) {
@@ -1954,7 +1954,7 @@ float4 main(uint vid : SV_VertexID, uint iid : SV_InstanceID) : SV_Position { \
                           "vs_6_0", "!{i32 1, !\"SV_InstanceID\", i8 5, i8 2,",
                           "!{i32 1, !\"\", i8 5, i8 1,",
                           //"System value SV_VertexID appears more than once in
-                          //the same signature.");
+                          // the same signature.");
                           "Semantic 'SV_VertexID' overlap at 0");
 }
 
@@ -2339,7 +2339,7 @@ Vertex main(uint id : SV_OutputControlPointID, InputPatch< Vertex, 4 > patch) { 
     ",
       "hs_6_0",
       //!{i32 0, !"SV_TessFactor", i8 9, i8 25, !23, i8 0, i32 4, i8 1, i32 0,
-      //!i8 3, null}
+      //! i8 3, null}
       {"!{i32 1, !\"SV_InsideTessFactor\", i8 9, i8 26, !([0-9]+), i8 0, i32 "
        "2, i8 1, i32 4, i8 3, (.*)}",
        "?!dx.viewIdState ="},
@@ -4271,74 +4271,42 @@ TEST_F(ValidationTest, AtomicsInvalidDests) {
 
 // Check validation error for incompatible compute and node combinations
 TEST_F(ValidationTest, ComputeNodeCompatibility) {
-  if (m_ver.SkipDxilVersion(1, 7)) return;
-  std::vector<LPCWSTR> pArguments = { L"-HV", L"2021" };
+  if (m_ver.SkipDxilVersion(1, 7))
+    return;
+  std::vector<LPCWSTR> pArguments = {L"-HV", L"2021"};
   RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node01 Coalescing launch type is not compatible with Compute");
+      L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!11 = !{i32 8, i32 15"}, // original: node shader
+      {"!11 = !{i32 8, i32 5"},  // changed to: compute shader
+      "Node 'node01' with input/outputs is not compatible with compute", false);
   RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node02 Coalescing launch type is not compatible with Compute");
+      L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!19 = !{i32 8, i32 15"}, // original: node shader
+      {"!19 = !{i32 8, i32 5"},  // changed to: compute shader
+      "Node 'node02' with input/outputs is not compatible with compute", false);
   RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node03 Coalescing launch type is not compatible with Compute");
+      L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!25 = !{i32 8, i32 15"}, // original: node shader
+      {"!25 = !{i32 8, i32 5"},  // changed to: compute shader
+      "Node 'node03' with input/outputs is not compatible with compute", false);
   RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node04 Coalescing launch type is not compatible with Compute");
+      L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!34 = !{i32 8, i32 15"}, // original: node shader
+      {"!34 = !{i32 8, i32 5"},  // changed to: compute shader
+      "Node 'node04' coalescing launch type is not compatible with compute",
+      false);
   RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node05 Thread launch type is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node06 Thread launch type is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node07 Thread launch type is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node08 with input/outputs is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node09 with input/outputs is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node10 with input/outputs is not compatible with Compute");
-  RewriteAssemblyCheckMsg(
-    L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
-    pArguments.data(), 2, nullptr, 0,
-    {"!{i32 8, i32 15"},  // original: node shader
-    {"!{i32 8, i32 5"},   // changed to: compute shader
-    "Node node11 with input/outputs is not compatible with Compute");
+      L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!34 = !{i32 8, i32 15, i32 13, i32 2"}, // original: node shader,
+                                                // coalesing launch type
+      {"!34 = !{i32 8, i32 5, i32 13, i32 3"},  // changed to: compute shader,
+                                                // thread launch type
+      "Node 'node04' thread launch type is not compatible with compute", false);
 }
 
 // Check validation error for incompatible node input record types
@@ -4346,86 +4314,93 @@ TEST_F(ValidationTest, NodeInputCompatibility) {
   if (m_ver.SkipDxilVersion(1, 7))
     return;
   std::vector<LPCWSTR> pArguments = {L"-HV", L"2021"};
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          {"!13 = !{i32 1, i32 65"}, // GroupNodeInputRecords
-                          "Broadcasting node shader 'node01' has input record "
-                          "type that is invalid for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          {"!13 = !{i32 1, i32 69"}, // RWGroupNodeInputRecords
-                          "Broadcasting node shader 'node01' has input record "
-                          "type that is invalid for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          {"!13 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
-                          "Broadcasting node shader 'node01' has input record "
-                          "type that is invalid for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          {"!13 = !{i32 1, i32 37"}, // RWThreadNodeInputRecord
-                          "Broadcasting node shader 'node01' has input record "
-                          "type that is invalid for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
-                          {"!20 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          "Coalescing node shader 'node02' has input record "
-                          "type that is invalid for its launch type");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
+      {"!13 = !{i32 1, i32 65"}, // GroupNodeInputRecords
+      "broadcasting node shader 'node01' has incompatible input record type "
+      "(should be {RW}DispatchNodeInputRecord)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
+      {"!13 = !{i32 1, i32 69"}, // RWGroupNodeInputRecords
+      "broadcasting node shader 'node01' has incompatible input record type "
+      "(should be {RW}DispatchNodeInputRecord)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
+      {"!13 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
+      "broadcasting node shader 'node01' has incompatible input record type "
+      "(should be {RW}DispatchNodeInputRecord)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!13 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
+      {"!13 = !{i32 1, i32 37"}, // RWThreadNodeInputRecord
+      "broadcasting node shader 'node01' has incompatible input record type "
+      "(should be {RW}DispatchNodeInputRecord)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
+      {"!20 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
+      "coalescing node shader 'node02' has incompatible input record type "
+      "(should be {RW}GroupNodeInputRecords or EmptyNodeInput)");
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
       {"!20 = !{i32 1, i32 65"},  // GroupNodeInputRecords
       {"!20 = !{i32 1, i32 101"}, // RWDispatchNodeInputRecord
-      "Coalescing node shader 'node02' has input record type that is invalid "
-      "for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
-                          {"!20 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
-                          "Coalescing node shader 'node02' has input record "
-                          "type that is invalid for its launch type");
-  RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
-                          "lib_6_8", pArguments.data(), 2, nullptr, 0,
-                          {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
-                          {"!20 = !{i32 1, i32 37"}, // RWThreadNodeInputRecord
-                          "Coalescing node shader 'node02' has input record "
-                          "type that is invalid for its launch type");
+      "coalescing node shader 'node02' has incompatible input record type "
+      "(should be {RW}GroupNodeInputRecords or EmptyNodeInput)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
+      {"!20 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
+      "coalescing node shader 'node02' has incompatible input record type "
+      "(should be {RW}GroupNodeInputRecords or EmptyNodeInput)");
+  RewriteAssemblyCheckMsg(
+      L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
+      pArguments.data(), 2, nullptr, 0,
+      {"!20 = !{i32 1, i32 65"}, // GroupNodeInputRecords
+      {"!20 = !{i32 1, i32 37"}, // RWThreadNodeInputRecord
+      "coalescing node shader 'node02' has incompatible input record type "
+      "(should be {RW}GroupNodeInputRecords or EmptyNodeInput)");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
                           "lib_6_8", pArguments.data(), 2, nullptr, 0,
                           {"!25 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
                           {"!25 = !{i32 1, i32 97"}, // DispatchNodeInputRecord
-                          "Thread node shader 'node03' has input record type "
-                          "that is invalid for its launch type");
+                          "thread node shader 'node03' has incompatible input "
+                          "record type (should be {RW}ThreadNodeInputRecord)");
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\node_input_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,
       {"!25 = !{i32 1, i32 33"},  // ThreadNodeInputRecord
       {"!25 = !{i32 1, i32 101"}, // RWDispatchNodeInputRecord
-      "Thread node shader 'node03' has input record type that is invalid for "
-      "its launch type");
+      "thread node shader 'node03' has incompatible input record type (should "
+      "be {RW}ThreadNodeInputRecord)");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
                           "lib_6_8", pArguments.data(), 2, nullptr, 0,
                           {"!25 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
                           {"!25 = !{i32 1, i32 65"}, // GroupNodeInputRecords
-                          "Thread node shader 'node03' has input record type "
-                          "that is invalid for its launch type");
+                          "thread node shader 'node03' has incompatible input "
+                          "record type (should be {RW}ThreadNodeInputRecord)");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
                           "lib_6_8", pArguments.data(), 2, nullptr, 0,
                           {"!25 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
                           {"!25 = !{i32 1, i32 69"}, // RWGroupNodeInputRecords
-                          "Thread node shader 'node03' has input record type "
-                          "that is invalid for its launch type");
+                          "thread node shader 'node03' has incompatible input "
+                          "record type (should be {RW}ThreadNodeInputRecord)");
   RewriteAssemblyCheckMsg(L"..\\DXILValidation\\node_input_compatibility.hlsl",
                           "lib_6_8", pArguments.data(), 2, nullptr, 0,
                           {"!25 = !{i32 1, i32 33"}, // ThreadNodeInputRecord
                           {"!25 = !{i32 1, i32 69"}, // RWGroupNodeInputRecords
-                          "Thread node shader 'node03' has input record type "
-                          "that is invalid for its launch type");
+                          "thread node shader 'node03' has incompatible input "
+                          "record type (should be {RW}ThreadNodeInputRecord)");
 }
 
 // Check validation error for multiple input nodes of different types

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -4303,8 +4303,7 @@ TEST_F(ValidationTest, ComputeNodeCompatibility) {
       pArguments.data(), 2, nullptr, 0,
       {"!32 = !{i32 8, i32 15"}, // original: node shader
       {"!32 = !{i32 8, i32 5"},  // changed to: compute shader
-      "Compute entry 'node04' has unexpected node shader metadata",
-      false);
+      "Compute entry 'node04' has unexpected node shader metadata", false);
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\compute_node_compatibility.hlsl", "lib_6_8",
       pArguments.data(), 2, nullptr, 0,

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -131,9 +131,13 @@ void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
 
     // HLSL Change: Explicit braces
     if (runValidation) {
-      EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
-                                             beforeHLSLLegalization, glLayout,
-                                             dxLayout, scalarLayout));
+      bool spirvIsValid = false;
+      if (utils::validateSpirvBinary(targetEnv, generatedBinary,
+                                     beforeHLSLLegalization, glLayout, dxLayout,
+                                     scalarLayout)) {
+        spirvIsValid = true;
+      }
+      EXPECT_TRUE(spirvIsValid);
     }
   } else if (expect == Expect::Warning) {
     ASSERT_TRUE(compileOk);

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -131,13 +131,9 @@ void FileTest::checkTestResult(llvm::StringRef filename, const bool compileOk,
 
     // HLSL Change: Explicit braces
     if (runValidation) {
-      bool spirvIsValid = false;
-      if (utils::validateSpirvBinary(targetEnv, generatedBinary,
-                                     beforeHLSLLegalization, glLayout, dxLayout,
-                                     scalarLayout)) {
-        spirvIsValid = true;
-      }
-      EXPECT_TRUE(spirvIsValid);
+      EXPECT_TRUE(utils::validateSpirvBinary(targetEnv, generatedBinary,
+                                             beforeHLSLLegalization, glLayout,
+                                             dxLayout, scalarLayout));
     }
   } else if (expect == Expect::Warning) {
     ASSERT_TRUE(compileOk);

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2749,6 +2749,7 @@ class db_dxil(object):
         self.add_valrule_msg("Container.RootSignatureIncompatible", "Root Signature in DXIL Container must be compatible with shader", "Root Signature in DXIL container is not compatible with shader.")
 
         self.add_valrule("Meta.Required", "Required metadata missing.")
+        self.add_valrule_msg("Meta.Unexpected", "Unexpected metadata detected.", "Function '%0' has unexpected metadata.")
         self.add_valrule_msg("Meta.Known", "Named metadata should be known", "Named metadata '%0' is unknown.")
         self.add_valrule("Meta.Used", "All metadata must be used by dxil.")
         self.add_valrule_msg("Meta.Target", "Target triple must be 'dxil-ms-dx'", "Unknown target triple '%0'.")

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2749,7 +2749,7 @@ class db_dxil(object):
         self.add_valrule_msg("Container.RootSignatureIncompatible", "Root Signature in DXIL Container must be compatible with shader", "Root Signature in DXIL container is not compatible with shader.")
 
         self.add_valrule("Meta.Required", "Required metadata missing.")
-        self.add_valrule_msg("Meta.Unexpected", "Unexpected metadata detected.", "Function '%0' has unexpected metadata.")
+        self.add_valrule_msg("Meta.ComputeWithNode", "Compute entry must not have node metadata", "Compute entry '%0' has unexpected node shader metadata")
         self.add_valrule_msg("Meta.Known", "Named metadata should be known", "Named metadata '%0' is unknown.")
         self.add_valrule("Meta.Used", "All metadata must be used by dxil.")
         self.add_valrule_msg("Meta.Target", "Target triple must be 'dxil-ms-dx'", "Unknown target triple '%0'.")
@@ -3000,8 +3000,6 @@ class db_dxil(object):
         self.add_valrule("Flow.NoRecusion", "Recursion is not permitted.")
         self.add_valrule("Flow.DeadLoop", "Loop must have break.")
         self.add_valrule_msg("Flow.FunctionCall", "Function with parameter is not permitted", "Function %0 with parameter is not permitted, it should be inlined.")
-        self.add_valrule_msg("Flow.ComputeNodeLaunchType", "Node launch type is not compatible with Compute", "Node '%0' %1 launch type is not compatible with compute")
-        self.add_valrule_msg("Flow.ComputeNodeIO", "Node with input or outputs is not compatible with Compute", "Node '%0' with input/outputs is not compatible with compute")
 
         self.add_valrule_msg("Decl.DxilNsReserved", "The DXIL reserved prefixes must only be used by built-in functions and types", "Declaration '%0' uses a reserved prefix.")
         self.add_valrule_msg("Decl.DxilFnExtern", "External function must be a DXIL function", "External function '%0' is not a DXIL function.")

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2999,8 +2999,8 @@ class db_dxil(object):
         self.add_valrule("Flow.NoRecusion", "Recursion is not permitted.")
         self.add_valrule("Flow.DeadLoop", "Loop must have break.")
         self.add_valrule_msg("Flow.FunctionCall", "Function with parameter is not permitted", "Function %0 with parameter is not permitted, it should be inlined.")
-        self.add_valrule_msg("Flow.ComputeNodeLaunchType", "Node launch type is not compatible with Compute", "Node %0 %1 launch type is not compatible with Compute")
-        self.add_valrule_msg("Flow.ComputeNodeIO", "Node with input or outputs is not compatible with Compute", "Node %0 with input/outputs is not compatible with Compute")
+        self.add_valrule_msg("Flow.ComputeNodeLaunchType", "Node launch type is not compatible with Compute", "Node '%0' %1 launch type is not compatible with compute")
+        self.add_valrule_msg("Flow.ComputeNodeIO", "Node with input or outputs is not compatible with Compute", "Node '%0' with input/outputs is not compatible with compute")
 
         self.add_valrule_msg("Decl.DxilNsReserved", "The DXIL reserved prefixes must only be used by built-in functions and types", "Declaration '%0' uses a reserved prefix.")
         self.add_valrule_msg("Decl.DxilFnExtern", "External function must be a DXIL function", "External function '%0' is not a DXIL function.")
@@ -3019,7 +3019,7 @@ class db_dxil(object):
         self.add_valrule_msg("Decl.ShaderReturnVoid", "Shader functions must return void", "Shader function '%0' must have void return type.")
         self.add_valrule_msg("Decl.ShaderMissingArg", "payload/params/attributes parameter is required for certain shader types", "%0 shader '%1' missing required %2 parameter.")
         self.add_valrule_msg("Decl.MultipleNodeInputs", "A node shader may not have more than one input record", "node shader '%0' may not have more than one input record (%1 are declared)")
-        self.add_valrule_msg("Decl.NodeLaunchInputType", "Invalid input record type for node launch type", "%0 node shader '%1' has input record type that is invalid for its launch type")
+        self.add_valrule_msg("Decl.NodeLaunchInputType", "Invalid input record type for node launch type", "%0 node shader '%1' has incompatible input record type (should be %2)")
 
 
         # Assign sensible category names and build up an enumeration description


### PR DESCRIPTION
Update the DXIL validation for compute node compatibility, and for node input vs launch type compatibility, to make the diagnostics more informative, and update the validation tests accordingly.

Fixes #5348 