### PR TITLE
Add `-print-before` and `-print-before-all` flags

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -219,6 +219,8 @@ public:
   std::set<std::string> IgnoreSemDefs; // OPT_ignore_semdef
   std::map<std::string, std::string> OverrideSemDefs; // OPT_override_semdef
 
+  bool PrintBeforeAll; // OPT_print_before_all
+  std::set<std::string> PrintBefore; // OPT_print_before
   bool PrintAfterAll; // OPT_print_after_all
   std::set<std::string> PrintAfter; // OPT_print_after
   bool EnablePayloadQualifiers = false; // OPT_enable_payload_qualifiers

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -307,6 +307,10 @@ def encoding : Separate<["-", "/"], "encoding">, Group<hlslcomp_Group>, Flags<[C
   HelpText<"Set default encoding for source inputs and text outputs (utf8|utf16(win)|utf32(*nix)|wide) default=utf8">;
 def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Override validator version for module.  Format: <major.minor> ; Default: DXIL.dll version or current internal version.">;
+def print_before_all : Flag<["-", "/"], "print-before-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Print LLVM IR before each pass.">;
+def print_before : Separate<["-", "/"], "print-before">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Print LLVM IR before a specific pass.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR after each pass.">;
 def print_after : Separate<["-", "/"], "print-after">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -310,11 +310,11 @@ def validator_version : Separate<["-", "/"], "validator-version">, Group<hlslcom
 def print_before_all : Flag<["-", "/"], "print-before-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR before each pass.">;
 def print_before : Separate<["-", "/"], "print-before">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
-  HelpText<"Print LLVM IR before a specific pass.">;
+  HelpText<"Print LLVM IR before a specific pass. May be specificied multiple times.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR after each pass.">;
 def print_after : Separate<["-", "/"], "print-after">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
-  HelpText<"Print LLVM IR after a specific pass.">;
+  HelpText<"Print LLVM IR after a specific pass. May be specificied multiple times.">;
 def ignore_opt_semdefs : Flag<["-", "/"], "ignore-opt-semdefs">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Ignore optional semantic defines which are not required to ensure program correctness.">;
 def ignore_semdef : Separate<["-", "/"], "ignore-semdef">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/include/llvm/IR/LegacyPassManager.h
+++ b/include/llvm/IR/LegacyPassManager.h
@@ -36,6 +36,8 @@ class FunctionPassManagerImpl;
 /// it is.
 class PassManagerBase {
 public:
+  bool HLSLPrintBeforeAll = false; // HLSL Change
+  std::set<std::string> HLSLPrintBefore; // HLSL Change
   bool HLSLPrintAfterAll = false; // HLSL Change
   std::set<std::string> HLSLPrintAfter; // HLSL Change
 

--- a/include/llvm/IR/LegacyPassManagers.h
+++ b/include/llvm/IR/LegacyPassManagers.h
@@ -180,6 +180,8 @@ private:
   virtual PassManagerType getTopLevelPassManagerType() = 0;
 
 public:
+  bool HLSLPrintBeforeAll = false; // HLSL Change
+  std::set<std::string> HLSLPrintBefore; // HLSL Change
   bool HLSLPrintAfterAll = false; // HLSL Change
   std::set<std::string> HLSLPrintAfter; // HLSL Change
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -774,6 +774,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.LegacyMacroExpansion = Args.hasFlag(OPT_flegacy_macro_expansion, OPT_INVALID, false);
   opts.LegacyResourceReservation = Args.hasFlag(OPT_flegacy_resource_reservation, OPT_INVALID, false);
   opts.ExportShadersOnly = Args.hasFlag(OPT_export_shaders_only, OPT_INVALID, false);
+  opts.PrintBeforeAll = Args.hasFlag(OPT_print_before_all, OPT_INVALID, false);
   opts.PrintAfterAll = Args.hasFlag(OPT_print_after_all, OPT_INVALID, false);
   opts.ResMayAlias = Args.hasFlag(OPT_res_may_alias, OPT_INVALID, false);
   opts.ResMayAlias = Args.hasFlag(OPT_res_may_alias_, OPT_INVALID, opts.ResMayAlias);
@@ -793,6 +794,9 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.EnablePayloadQualifiers = Args.hasFlag(OPT_enable_payload_qualifiers, OPT_INVALID,
                                             DXIL::CompareVersions(Major, Minor, 6, 7) >= 0); 
 
+  for (const std::string &value : Args.getAllArgValues(OPT_print_before)) {
+    opts.PrintBefore.insert(value);
+  }
   for (const std::string &value : Args.getAllArgValues(OPT_print_after)) {
     opts.PrintAfter.insert(value);
   }

--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -694,7 +694,7 @@ void PMTopLevelManager::schedulePass(Pass *P) {
       [](const PassInfo *PI, bool AllOpt, std::set<std::string> &ByNameOpt) {
         return AllOpt ||
                (ByNameOpt.size() && ByNameOpt.count(PI->getPassArgument()));
-      }
+      };
 
   if (PI && !PI->isAnalysis() &&
       ShouldPrint(PI, this->HLSLPrintBeforeAll, this->HLSLPrintBefore)) {

--- a/lib/IR/LegacyPassManager.cpp
+++ b/lib/IR/LegacyPassManager.cpp
@@ -679,11 +679,36 @@ void PMTopLevelManager::schedulePass(Pass *P) {
     return;
   }
 
+  // HLSL Change - begin
+  class direct_stderr_stream : public raw_ostream {
+    uint64_t current_pos() const override { return 0; }
+    /// See raw_ostream::write_impl.
+    void write_impl(const char *Ptr, size_t Size) override {
+      fwrite(Ptr, Size, 1, stderr);
+    }
+  };
+
+  static direct_stderr_stream stderr_stream;
+  // HLSL Change - end
+
   if (PI && !PI->isAnalysis() && ShouldPrintBeforePass(PI)) {
     Pass *PP = P->createPrinterPass(dbgs(), std::string("*** IR Dump Before ") +
                                          P->getPassName().str() + " ***");
     PP->assignPassManager(activeStack, getTopLevelPassManagerType());
   }
+
+  // HLSL Change - begin
+  if (PI && !PI->isAnalysis() &&
+      (this->HLSLPrintBeforeAll ||
+       (this->HLSLPrintBefore.size() &&
+        this->HLSLPrintBefore.count(PI->getPassArgument())))) {
+    Pass *PP = P->createPrinterPass(stderr_stream,
+                                    std::string("*** IR Dump Before ") +
+                                        P->getPassName().str() + " (" +
+                                        PI->getPassArgument() + ") ***");
+    PP->assignPassManager(activeStack, getTopLevelPassManagerType());
+  }
+  // HLSL Change - end
 
   // Add the requested pass to the best available pass manager.
   PPtr.release(); // HLSL Change - assignPassManager takes ownership
@@ -696,19 +721,14 @@ void PMTopLevelManager::schedulePass(Pass *P) {
   }
 
   // HLSL Change - begin
-  if (PI && !PI->isAnalysis() && (this->HLSLPrintAfterAll || (this->HLSLPrintAfter.size() && this->HLSLPrintAfter.count(PI->getPassArgument())))) {
-    class direct_stderr_stream : public raw_ostream {
-      uint64_t current_pos() const override { return 0; }
-      /// See raw_ostream::write_impl.
-      void write_impl(const char *Ptr, size_t Size) override {
-        fwrite(Ptr, Size, 1, stderr);
-      }
-    };
-
-    static direct_stderr_stream stderr_stream;
-
-    Pass *PP = P->createPrinterPass(
-      stderr_stream, std::string("*** IR Dump After ") + P->getPassName().str() + " (" + PI->getPassArgument() + ") ***");
+  if (PI && !PI->isAnalysis() &&
+      (this->HLSLPrintAfterAll ||
+       (this->HLSLPrintAfter.size() &&
+        this->HLSLPrintAfter.count(PI->getPassArgument())))) {
+    Pass *PP = P->createPrinterPass(stderr_stream,
+                                    std::string("*** IR Dump After ") +
+                                        P->getPassName().str() + " (" +
+                                        PI->getPassArgument() + ") ***");
     PP->assignPassManager(activeStack, getTopLevelPassManagerType());
   }
   // HLSL Change - end
@@ -1420,6 +1440,8 @@ FunctionPassManager::~FunctionPassManager() {
 
 void FunctionPassManager::add(Pass *P) {
   // HLSL Change Starts
+  FPM->HLSLPrintBeforeAll = this->HLSLPrintBeforeAll;
+  FPM->HLSLPrintBefore = this->HLSLPrintBefore;
   FPM->HLSLPrintAfterAll = this->HLSLPrintAfterAll;
   FPM->HLSLPrintAfter = this->HLSLPrintAfter;
   std::unique_ptr<Pass> PPtr(P); // take ownership of P, even on failure paths
@@ -1784,6 +1806,8 @@ PassManager::~PassManager() {
 
 void PassManager::add(Pass *P) {
   // HLSL Change Starts
+  PM->HLSLPrintBeforeAll = this->HLSLPrintBeforeAll;
+  PM->HLSLPrintBefore = this->HLSLPrintBefore;
   PM->HLSLPrintAfterAll = this->HLSLPrintAfterAll;
   PM->HLSLPrintAfter = this->HLSLPrintAfter;
   std::unique_ptr<Pass> PPtr(P); // take ownership of P, even on failure paths

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.h
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.h
@@ -232,6 +232,10 @@ public:
   unsigned ScanLimit = 0;
   /// Optimization pass enables, disables and selects
   hlsl::options::OptimizationToggles HLSLOptimizationToggles;
+  /// Debug option to print IR before every pass
+  bool HLSLPrintBeforeAll = false;
+  /// Debug option to print IR before specific pass
+  std::set<std::string> HLSLPrintBefore;
   /// Debug option to print IR after every pass
   bool HLSLPrintAfterAll = false;
   /// Debug option to print IR after specific pass

--- a/tools/clang/lib/CodeGen/BackendUtil.cpp
+++ b/tools/clang/lib/CodeGen/BackendUtil.cpp
@@ -93,6 +93,9 @@ private:
   legacy::PassManager *getPerModulePasses() const {
     if (!PerModulePasses) {
       PerModulePasses = new legacy::PassManager();
+      PerModulePasses->HLSLPrintBeforeAll =
+          this->CodeGenOpts.HLSLPrintBeforeAll;
+      PerModulePasses->HLSLPrintBefore = this->CodeGenOpts.HLSLPrintBefore;
       PerModulePasses->HLSLPrintAfterAll = this->CodeGenOpts.HLSLPrintAfterAll;
       PerModulePasses->HLSLPrintAfter = this->CodeGenOpts.HLSLPrintAfter;
       PerModulePasses->TrackPassOS = &PerModulePassesConfigOS;
@@ -105,7 +108,11 @@ private:
   legacy::FunctionPassManager *getPerFunctionPasses() const {
     if (!PerFunctionPasses) {
       PerFunctionPasses = new legacy::FunctionPassManager(TheModule);
-      PerFunctionPasses->HLSLPrintAfterAll = this->CodeGenOpts.HLSLPrintAfterAll;
+      PerFunctionPasses->HLSLPrintBeforeAll =
+          this->CodeGenOpts.HLSLPrintBeforeAll;
+      PerFunctionPasses->HLSLPrintBefore = this->CodeGenOpts.HLSLPrintBefore;
+      PerFunctionPasses->HLSLPrintAfterAll =
+          this->CodeGenOpts.HLSLPrintAfterAll;
       PerFunctionPasses->HLSLPrintAfter = this->CodeGenOpts.HLSLPrintAfter;
       PerFunctionPasses->TrackPassOS = &PerFunctionPassesConfigOS;
       PerFunctionPasses->add(

--- a/tools/clang/test/DXC/print-passes.hlsl
+++ b/tools/clang/test/DXC/print-passes.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -E main -T vs_6_0 %s -print-before-all 2>&1 | FileCheck -check-prefix=BEFORE1 --check-prefix=BEFORE2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-after-all 2>&1 | FileCheck -check-prefix=AFTER1 --check-prefix=AFTER2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-before-all -print-after-all 2>&1 | FileCheck -check-prefix=BEFORE1 -check-prefix=BEFORE2 -check-prefix=AFTER1 --check-prefix=AFTER2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-before verify 2>&1 | FileCheck -check-prefix=BEFORE1 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-after hlsl-dxilemit 2>&1 | FileCheck -check-prefix=AFTER2 %s
+
+// BEFORE1: *** IR Dump Before Module Verifier (verify) ***
+// BEFORE1: define void @main
+// AFTER1: *** IR Dump After Module Verifier (verify) ***
+// AFTER1: define void @main
+// BEFORE2: *** IR Dump Before HLSL DXIL Metadata Emit (hlsl-dxilemit) ***
+// BEFORE2: define void @main
+// AFTER2: *** IR Dump After HLSL DXIL Metadata Emit (hlsl-dxilemit) ***
+// AFTER2: define void @main
+
+void main() {}

--- a/tools/clang/test/DXC/print-passes.hlsl
+++ b/tools/clang/test/DXC/print-passes.hlsl
@@ -3,6 +3,9 @@
 // RUN: %dxc -E main -T vs_6_0 %s -print-before-all -print-after-all 2>&1 | FileCheck -check-prefix=BEFORE1 -check-prefix=BEFORE2 -check-prefix=AFTER1 --check-prefix=AFTER2 %s
 // RUN: %dxc -E main -T vs_6_0 %s -print-before verify 2>&1 | FileCheck -check-prefix=BEFORE1 %s
 // RUN: %dxc -E main -T vs_6_0 %s -print-after hlsl-dxilemit 2>&1 | FileCheck -check-prefix=AFTER2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-before verify -print-before hlsl-dxilemit 2>&1 | FileCheck -check-prefix=BEFORE1 -check-prefix=BEFORE2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-after hlsl-dxilemit -print-after verify 2>&1 | FileCheck -check-prefix=AFTER1 -check-prefix=AFTER2 %s
+// RUN: %dxc -E main -T vs_6_0 %s -print-after hlsl-dxilemit -print-before verify 2>&1 | FileCheck -check-prefix=BEFORE1 -check-prefix=AFTER2 %s
 
 // BEFORE1: *** IR Dump Before Module Verifier (verify) ***
 // BEFORE1: define void @main

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1418,6 +1418,8 @@ public:
     compiler.getCodeGenOpts().HLSLDefines = defines;
     compiler.getCodeGenOpts().HLSLPreciseOutputs = Opts.PreciseOutputs;
     compiler.getCodeGenOpts().MainFileName = pMainFile;
+    compiler.getCodeGenOpts().HLSLPrintBeforeAll = Opts.PrintBeforeAll;
+    compiler.getCodeGenOpts().HLSLPrintBefore = Opts.PrintBefore;
     compiler.getCodeGenOpts().HLSLPrintAfterAll = Opts.PrintAfterAll;
     compiler.getCodeGenOpts().HLSLPrintAfter = Opts.PrintAfter;
     compiler.getCodeGenOpts().HLSLForceZeroStoreLifetimes = Opts.ForceZeroStoreLifetimes;


### PR DESCRIPTION
These match `-print-after` and `-print-after-all`, and are needed if we want the opt pipeline view to work in compiler explorer.