### PR TITLE
Fix asserts when compiling node objects with -Od

### DIFF
--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -677,10 +677,6 @@ bool IsHLSLNodeInputRecordType(llvm::Type *Ty) {
   return false;
 }
 
-bool IsHLSLNodeIOType(llvm::Type* Ty) {
-  return IsHLSLNodeInputRecordType(Ty) || IsHLSLNodeOutputType(Ty);
-}
-
 bool IsHLSLNodeEmptyInputRecordType(llvm::Type* Ty) {
   if (llvm::StructType* ST = dyn_cast<llvm::StructType>(Ty)) {
     if (!ST->hasName())
@@ -762,6 +758,11 @@ bool IsHLSLGSNodeOutputRecordType(llvm::Type* Ty) {
 bool IsHLSLNodeRecordType(llvm::Type *Ty) {
   return IsHLSLNodeOutputRecordType(Ty) ||
     IsHLSLNodeInputRecordType(Ty);
+}
+
+bool IsHLSLNodeIOType(llvm::Type* Ty) {
+  return IsHLSLNodeRecordType(Ty) || IsHLSLNodeOutputType(Ty) ||
+         IsHLSLNodeOutputArrayType(Ty);
 }
 
 bool IsIntegerOrFloatingPointType(llvm::Type *Ty) {

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -581,8 +581,7 @@ void TranslateHLCastHandleToRes(Function *F, hlsl::OP &hlslOP, const llvm::DataL
         NodeOutputHandle = CastI->getArgOperand(HLOperandIndex::kHandleOpIdx);
       }
       CI->replaceAllUsesWith(NodeOutputHandle);
-      LLVM_FALLTHROUGH;
-    }
+    } break;
     case HLCastOpcode::NodeRecordToHandleCast: {
       Value *OutputRecordHandle =
           CI->getArgOperand(HLOperandIndex::kHandleOpIdx);
@@ -596,8 +595,7 @@ void TranslateHLCastHandleToRes(Function *F, hlsl::OP &hlslOP, const llvm::DataL
         OutputRecordHandle = CastI->getArgOperand(HLOperandIndex::kHandleOpIdx);
       }
       CI->replaceAllUsesWith(OutputRecordHandle);
-      LLVM_FALLTHROUGH;
-    }
+    } break;
     case HLCastOpcode::HandleToResCast: {
       Value *Handle = CI->getArgOperand(HLOperandIndex::kUnaryOpSrc0Idx);
       for (auto HandleU = CI->user_begin(); HandleU != CI->user_end();) {
@@ -612,10 +610,10 @@ void TranslateHLCastHandleToRes(Function *F, hlsl::OP &hlslOP, const llvm::DataL
           HandleCI->eraseFromParent();
         }
       }
-      if (CI->user_empty()) {
-        CI->eraseFromParent();
-      }
     } break;
+    }
+    if (CI->user_empty()) {
+      CI->eraseFromParent();
     }
   }
 }

--- a/lib/HLSL/HLLowerUDT.cpp
+++ b/lib/HLSL/HLLowerUDT.cpp
@@ -274,6 +274,7 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
       SmallVector<Value*, 4> idxList(GEP->idx_begin(), GEP->idx_end());
       Value *NewGEP = Builder.CreateGEP(NewV, idxList);
       ReplaceUsesForLoweredUDT(GEP, NewGEP);
+      dxilutil::MergeGepUse(NewGEP);
       GEP->eraseFromParent();
 
     } else if (GEPOperator *GEP = dyn_cast<GEPOperator>(user)) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_nodeoutput.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 //
 // Verify that NodeOutput can be passed to a called function and used."
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_record_object.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_record_object.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 //
 // Verify that NodeInputRecord can be passed to a called function and used."
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_record_object.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/called_function_arg_record_object.hlsl
@@ -12,7 +12,7 @@ void loadStressWorker(
     inout DispatchNodeInputRecord<loadStressRecord> inputData,
     GroupNodeOutputRecords<loadStressRecord> outRec)
 {
-    // CHECK: getelementptr %struct.loadStressRecord, %struct.loadStressRecord
+    // CHECK: getelementptr inbounds %struct.loadStressRecord, %struct.loadStressRecord
     uint val =  inputData.Get().data[0]; // problem line
 
     outRec.Get().data[0] = val + 61;

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case085_thread_emptynodeinput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case085_thread_emptynodeinput.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 // ==================================================================
 // CASE085
 // Thread launch node declares EmptyNodeInput<1>
@@ -18,7 +19,7 @@ void node085_thread_emptynodeinput(EmptyNodeInput input)
 }
 
 // CHECK: define void @node085_thread_emptynodeinput() {
-// CHECK: [[LOAD:%[0-9]+]] = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+// CHECK: [[LOAD:%[0-9]+]] = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A"
 // CHECK: [[HANDLE:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 {{[0-9]+}}, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
 // CHECK: [[ANN_HANDLE:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 {{[0-9]+}}, %dx.types.NodeRecordHandle [[HANDLE]], %dx.types.NodeRecordInfo { i32 9, i32 0 })
 // CHECK: [[COUNT:%[0-9]+]] = call i32 @dx.op.getInputRecordCount(i32 {{[0-9]+}}, %dx.types.NodeRecordHandle [[ANN_HANDLE]])  ; GetInputRecordCount(input)

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_atomics.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_atomics.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 // ==================================================================
 // Test using atomics on node record members for cmpxchg and binops
 // ==================================================================

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_matrix_write.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_matrix_write.hlsl
@@ -1,4 +1,5 @@
-// RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 %s | FileCheck %s -check-prefixes=CHECK,CHECKOPT
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s -check-prefixes=CHECK,CHECKOD
 // ==================================================================
 // Test writing to matrix members of node records
 // ==================================================================
@@ -12,126 +13,176 @@ struct RECORD
 
 // CHECK: %[[RECORD:struct\.RECORD.*]] = type { [4 x float], [4 x float], [4 x float] }
 
-// CHECK: define void @node01
+// CHECK-LABEL: define void @node01
 [Shader("node")]
 [NumThreads(1024,1,1)]
 [NodeLaunch("Broadcasting")]
 void node01(RWDispatchNodeInputRecord<RECORD> input1)
 {
-  // CHECK: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]], align 4
-  // CHECK: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]], align 4
-  // CHECK: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]], align 4
-  // CHECK: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]], align 4
+  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
+  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
+  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
+  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
+  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
+  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
+  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
+  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
+  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   input1.Get().m1 = 111;
-  // CHECK: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
-  // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]], align 4
-  // CHECK: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
-  // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]], align 4
-  // CHECK: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
-  // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]], align 4
-  // CHECK: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
-  // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]], align 4
+  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
+  // CHECKOD: %[[p0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0
+  // CHECKOPT: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
+  // CHECKOD: %[[p0_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 0
+  // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]]
+  // CHECKOPT: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
+  // CHECKOD: %[[p0_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 1
+  // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]]
+  // CHECKOPT: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
+  // CHECKOD: %[[p0_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 2
+  // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]]
+  // CHECKOPT: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
+  // CHECKOD: %[[p0_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 3
+  // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]]
   // Note: store transposed.
-  // CHECK: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]], align 4
-  // CHECK: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]], align 4
-  // CHECK: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]], align 4
-  // CHECK: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]], align 4
+  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
+  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]]
+  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
+  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]]
+  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
+  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]]
+  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
+  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]]
   input1.Get().m2 = input1.Get().m0;
 }
 
-// CHECK: define void @node02
+// CHECK-LABEL: define void @node02
 [Shader("node")]
 [NumThreads(1,1,1)]
 [NodeLaunch("coalescing")]
 void node02([MaxRecords(4)] RWGroupNodeInputRecords<RECORD> input2)
 {
-  // CHECK: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]], align 4
-  // CHECK: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]], align 4
-  // CHECK: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]], align 4
-  // CHECK: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]], align 4
+  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
+  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
+  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
+  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
+  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
+  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
+  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
+  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
+  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   input2[0].m1 = 111;
-  // CHECK: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
-  // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]], align 4
-  // CHECK: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
-  // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]], align 4
-  // CHECK: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
-  // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]], align 4
-  // CHECK: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
-  // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]], align 4
+  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
+  // CHECKOD: %[[p0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0
+  // CHECKOPT: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
+  // CHECKOD: %[[p0_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 0
+  // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]]
+  // CHECKOPT: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
+  // CHECKOD: %[[p0_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 1
+  // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]]
+  // CHECKOPT: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
+  // CHECKOD: %[[p0_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 2
+  // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]]
+  // CHECKOPT: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
+  // CHECKOD: %[[p0_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 3
+  // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]]
   // Note: store transposed.
-  // CHECK: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]], align 4
-  // CHECK: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]], align 4
-  // CHECK: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]], align 4
-  // CHECK: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]], align 4
+  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
+  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]]
+  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
+  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]]
+  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
+  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]]
+  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
+  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]]
   input2[1].m2 = input2[1].m0;
 }
 
-// CHECK: define void @node03
+// CHECK-LABEL: define void @node03
 [Shader("node")]
 [NumThreads(1024,1,1)]
 [NodeLaunch("Broadcasting")]
 void node03(NodeOutput<RECORD> output3)
 {
   ThreadNodeOutputRecords<RECORD> outrec = output3.GetThreadNodeOutputRecords(1);
-  // CHECK: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]], align 4
-  // CHECK: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]], align 4
-  // CHECK: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]], align 4
-  // CHECK: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]], align 4
+  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
+  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
+  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
+  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
+  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
+  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
+  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
+  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
+  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   outrec.Get().m1 = 111;
-  // CHECK: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]], align 4
-  // CHECK: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]], align 4
-  // CHECK: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]], align 4
-  // CHECK: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]], align 4
+  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
+  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
+  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]]
+  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
+  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]]
+  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
+  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]]
+  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
+  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]]
   outrec.Get().m2 = 222;
 }
 
-// CHECK: define void @node04
+// CHECK-LABEL: define void @node04
 [Shader("node")]
 [NumThreads(1024,1,1)]
 [NodeLaunch("Coalescing")]
 void node04([MaxOutputRecords(5)] NodeOutput<RECORD> outputs4)
 {
   GroupNodeOutputRecords<RECORD> outrec = outputs4.GetGroupNodeOutputRecords(1);
-  // CHECK: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]], align 4
-  // CHECK: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]], align 4
-  // CHECK: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]], align 4
-  // CHECK: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]], align 4
+  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
+  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
+  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
+  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
+  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
+  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
+  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
+  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
+  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   outrec.Get().m1 = 111;
-  // CHECK: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]], align 4
-  // CHECK: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]], align 4
-  // CHECK: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]], align 4
-  // CHECK: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]], align 4
+  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
+  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
+  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]]
+  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
+  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]]
+  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
+  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]]
+  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
+  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]]
   outrec.Get().m2 = 222;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_matrix_write.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/member_matrix_write.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -T lib_6_8 %s | FileCheck %s -check-prefixes=CHECK,CHECKOPT
-// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s -check-prefixes=CHECK,CHECKOD
+// RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 // ==================================================================
 // Test writing to matrix members of node records
 // ==================================================================
@@ -19,46 +19,31 @@ struct RECORD
 [NodeLaunch("Broadcasting")]
 void node01(RWDispatchNodeInputRecord<RECORD> input1)
 {
-  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
-  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: %[[p1_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
-  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: %[[p1_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
-  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: %[[p1_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
-  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: %[[p1_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   input1.Get().m1 = 111;
-  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
-  // CHECKOD: %[[p0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0
-  // CHECKOPT: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
-  // CHECKOD: %[[p0_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 0
+  // CHECK: %[[p0_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
   // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]]
-  // CHECKOPT: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
-  // CHECKOD: %[[p0_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 1
+  // CHECK: %[[p0_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
   // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]]
-  // CHECKOPT: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
-  // CHECKOD: %[[p0_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 2
+  // CHECK: %[[p0_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
   // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]]
-  // CHECKOPT: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
-  // CHECKOD: %[[p0_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 3
+  // CHECK: %[[p0_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
   // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]]
   // Note: store transposed.
-  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: %[[p2_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
   // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]]
-  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: %[[p2_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
   // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]]
-  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: %[[p2_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
   // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]]
-  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: %[[p2_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
   // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]]
   input1.Get().m2 = input1.Get().m0;
 }
@@ -69,46 +54,31 @@ void node01(RWDispatchNodeInputRecord<RECORD> input1)
 [NodeLaunch("coalescing")]
 void node02([MaxRecords(4)] RWGroupNodeInputRecords<RECORD> input2)
 {
-  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
-  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: %[[p1_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
-  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: %[[p1_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
-  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: %[[p1_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
-  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: %[[p1_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   input2[0].m1 = 111;
-  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
-  // CHECKOD: %[[p0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0
-  // CHECKOPT: %[[p0_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
-  // CHECKOD: %[[p0_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 0
+  // CHECK: %[[p0_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 0
   // CHECK: %[[v0_0:[^ ]+]] = load float, float addrspace(6)* %[[p0_0]]
-  // CHECKOPT: %[[p0_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
-  // CHECKOD: %[[p0_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 1
+  // CHECK: %[[p0_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 1
   // CHECK: %[[v0_1:[^ ]+]] = load float, float addrspace(6)* %[[p0_1]]
-  // CHECKOPT: %[[p0_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
-  // CHECKOD: %[[p0_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 2
+  // CHECK: %[[p0_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 2
   // CHECK: %[[v0_2:[^ ]+]] = load float, float addrspace(6)* %[[p0_2]]
-  // CHECKOPT: %[[p0_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
-  // CHECKOD: %[[p0_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p0]], i32 0, i32 3
+  // CHECK: %[[p0_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 0, i32 3
   // CHECK: %[[v0_3:[^ ]+]] = load float, float addrspace(6)* %[[p0_3]]
   // Note: store transposed.
-  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: %[[p2_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
   // CHECK: store float %[[v0_0]], float addrspace(6)* %[[p2_0]]
-  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: %[[p2_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
   // CHECK: store float %[[v0_2]], float addrspace(6)* %[[p2_1]]
-  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: %[[p2_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
   // CHECK: store float %[[v0_1]], float addrspace(6)* %[[p2_2]]
-  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: %[[p2_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
   // CHECK: store float %[[v0_3]], float addrspace(6)* %[[p2_3]]
   input2[1].m2 = input2[1].m0;
 }
@@ -120,32 +90,22 @@ void node02([MaxRecords(4)] RWGroupNodeInputRecords<RECORD> input2)
 void node03(NodeOutput<RECORD> output3)
 {
   ThreadNodeOutputRecords<RECORD> outrec = output3.GetThreadNodeOutputRecords(1);
-  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
-  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: %[[p1_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
-  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: %[[p1_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
-  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: %[[p1_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
-  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: %[[p1_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   outrec.Get().m1 = 111;
-  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
-  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: %[[p2_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]]
-  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: %[[p2_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]]
-  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: %[[p2_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]]
-  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: %[[p2_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]]
   outrec.Get().m2 = 222;
 }
@@ -157,32 +117,22 @@ void node03(NodeOutput<RECORD> output3)
 void node04([MaxOutputRecords(5)] NodeOutput<RECORD> outputs4)
 {
   GroupNodeOutputRecords<RECORD> outrec = outputs4.GetGroupNodeOutputRecords(1);
-  // CHECKOPT: %[[p1_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
-  // CHECKOD: %[[p1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1
-  // CHECKOD: %[[p1_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 0
+  // CHECK: %[[p1_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 0
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_0]]
-  // CHECKOPT: %[[p1_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
-  // CHECKOD: %[[p1_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 1
+  // CHECK: %[[p1_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 1
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_1]]
-  // CHECKOPT: %[[p1_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
-  // CHECKOD: %[[p1_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 2
+  // CHECK: %[[p1_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 2
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_2]]
-  // CHECKOPT: %[[p1_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
-  // CHECKOD: %[[p1_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p1]], i32 0, i32 3
+  // CHECK: %[[p1_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 1, i32 3
   // CHECK: store float 1.110000e+02, float addrspace(6)* %[[p1_3]]
   outrec.Get().m1 = 111;
-  // CHECKOPT: %[[p2_0:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
-  // CHECKOD: %[[p2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2
-  // CHECKOD: %[[p2_0:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 0
+  // CHECK: %[[p2_0:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 0
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_0]]
-  // CHECKOPT: %[[p2_1:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
-  // CHECKOD: %[[p2_1:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 1
+  // CHECK: %[[p2_1:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 1
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_1]]
-  // CHECKOPT: %[[p2_2:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
-  // CHECKOD: %[[p2_2:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 2
+  // CHECK: %[[p2_2:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 2
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_2]]
-  // CHECKOPT: %[[p2_3:[^ ]+]] = getelementptr %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
-  // CHECKOD: %[[p2_3:[^ ]+]] = getelementptr [4 x float], [4 x float] addrspace(6)* %[[p2]], i32 0, i32 3
+  // CHECK: %[[p2_3:[^ ]+]] = getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* %{{[^,]+}}, i32 0, i32 2, i32 3
   // CHECK: store float 2.220000e+02, float addrspace(6)* %[[p2_3]]
   outrec.Get().m2 = 222;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/multi_dim_array_record.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/multi_dim_array_record.hlsl
@@ -6,6 +6,7 @@
 // Ensure multi-dim array produced by lowering record struct with array of
 // vector has GEP instructions merged to prevent invalid GEP with array type.
 
+// CHECK: [[TID:%[0-9]+]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)
 // CHECK-DAG: [[NOH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32 247, i32 0)
 // CHECK-DAG: [[ANOH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 249, %dx.types.NodeHandle [[NOH]], %dx.types.NodeInfo { i32 6, i32 32768 })
 // CHECK-DAG: [[IRH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)
@@ -13,9 +14,9 @@
 // CHECK-DAG: [[ORH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 238, %dx.types.NodeHandle [[ANOH]], i32 1, i1 false)
 // CHECK-DAG: [[AORH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle [[ORH]], %dx.types.NodeRecordInfo { i32 70, i32 32768 })
 // CHECK-DAG: [[IRP:%[0-9]+]] = call %[[RECORD:struct\.MyRecord[^ ]*]] addrspace(6)* @dx.op.getNodeRecordPtr.[[RECORD]](i32 239, %dx.types.NodeRecordHandle [[AIRH]], i32 0)
-// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[IRP]], i32 0, i32 0, i32 %0, i32 0
+// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[IRP]], i32 0, i32 0, i32 [[TID]], i32 0
 // CHECK-DAG: [[ORP:%[0-9]+]] = call %[[RECORD]] addrspace(6)* @dx.op.getNodeRecordPtr.[[RECORD]](i32 239, %dx.types.NodeRecordHandle [[AORH]], i32 0)
-// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[ORP]], i32 0, i32 0, i32 %0, i32 0
+// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[ORP]], i32 0, i32 0, i32 [[TID]], i32 0
 
 #define THREADGROUP_SIZE 1024
 struct MyRecord {

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/multi_dim_array_record.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/multi_dim_array_record.hlsl
@@ -1,0 +1,45 @@
+// RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -D USE_VECTOR %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -D USE_VECTOR -Od %s | FileCheck %s
+
+// Ensure multi-dim array produced by lowering record struct with array of
+// vector has GEP instructions merged to prevent invalid GEP with array type.
+
+// CHECK-DAG: [[NOH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32 247, i32 0)
+// CHECK-DAG: [[ANOH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 249, %dx.types.NodeHandle [[NOH]], %dx.types.NodeInfo { i32 6, i32 32768 })
+// CHECK-DAG: [[IRH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)
+// CHECK-DAG: [[AIRH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle [[IRH]], %dx.types.NodeRecordInfo { i32 97, i32 32768 })
+// CHECK-DAG: [[ORH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 238, %dx.types.NodeHandle [[ANOH]], i32 1, i1 false)
+// CHECK-DAG: [[AORH:%[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle [[ORH]], %dx.types.NodeRecordInfo { i32 70, i32 32768 })
+// CHECK-DAG: [[IRP:%[0-9]+]] = call %[[RECORD:struct\.MyRecord[^ ]*]] addrspace(6)* @dx.op.getNodeRecordPtr.[[RECORD]](i32 239, %dx.types.NodeRecordHandle [[AIRH]], i32 0)
+// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[IRP]], i32 0, i32 0, i32 %0, i32 0
+// CHECK-DAG: [[ORP:%[0-9]+]] = call %[[RECORD]] addrspace(6)* @dx.op.getNodeRecordPtr.[[RECORD]](i32 239, %dx.types.NodeRecordHandle [[AORH]], i32 0)
+// CHECK-DAG: getelementptr inbounds %[[RECORD]], %[[RECORD]] addrspace(6)* [[ORP]], i32 0, i32 0, i32 %0, i32 0
+
+#define THREADGROUP_SIZE 1024
+struct MyRecord {
+#ifdef USE_VECTOR
+    uint4 data[THREADGROUP_SIZE];
+    uint4 data2[THREADGROUP_SIZE];
+#else
+    uint data[THREADGROUP_SIZE][4];
+    uint data2[THREADGROUP_SIZE][4];
+#endif
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(2, 1, 1)]
+[NumThreads(THREADGROUP_SIZE, 1, 1)]
+void node1(
+    DispatchNodeInputRecord<MyRecord> inputData,
+    [MaxRecords(1)][NodeID("node2")] NodeOutput<MyRecord> child,
+    uint threadInGroup : SV_GroupIndex
+)
+{
+    GroupNodeOutputRecords<MyRecord> outRecs = child.GetGroupNodeOutputRecords(1);
+    outRecs[0].data[threadInGroup] = inputData.Get().data[threadInGroup];
+    outRecs[0].data2[threadInGroup] = inputData.Get().data2[threadInGroup];
+    outRecs.OutputComplete();
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/nodeoutputarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/nodeoutputarray.hlsl
@@ -99,7 +99,7 @@ void node_2_1(
 // CHECK: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)
 // CHECK: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 26, i32 0 })
 // CHECK: call i1 @dx.op.nodeOutputIsValid(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]])
-// CHECKOD-LABEL: if.then:
+// CHECKOD-LABEL: {{if\.then|\<label\>}}:
 // CHECKOD: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)
 // CHECKOD: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 26, i32 0 })
 // CHECK: call void @dx.op.incrementOutputCount(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]], i32 10, i1 false)

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/nodeoutputarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/nodeoutputarray.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s -check-prefixes=CHECK,CHECKOD
 // Tests for NodeOutputArray/EmptyNodeOutputArray/IndexNodeHandle
 struct RECORD1
 {
@@ -15,7 +16,7 @@ void node_1_0(
 )
 {
 }
-// CHECK: define void @node_1_0()
+// CHECK-LABEL: define void @node_1_0()
 // CHECK: ret void
 
 [Shader("node")]
@@ -29,7 +30,7 @@ void node_1_1(
     ThreadNodeOutputRecords<RECORD1> outRec = OutputArray[1].GetThreadNodeOutputRecords(2);
     outRec.OutputComplete();
 }
-// CHECK: define void @node_1_1()
+// CHECK-LABEL: define void @node_1_1()
 // CHECK: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)  ; IndexNodeHandle(NodeOutputHandle,ArrayIndex)
 // CHECK: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 22, i32 8 })
 // CHECK: call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]], i32 2, i1 true)
@@ -45,7 +46,7 @@ void node_1_2(
     GroupNodeOutputRecords<RECORD1> outRec = OutputArray[1].GetGroupNodeOutputRecords(2);
     outRec.OutputComplete();
 }
-// CHECK: define void @node_1_2()
+// CHECK-LABEL: define void @node_1_2()
 // CHECK: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)  ; IndexNodeHandle(NodeOutputHandle,ArrayIndex)
 // CHECK: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 22, i32 8 })
 // CHECK: call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]], i32 2, i1 false)
@@ -64,7 +65,7 @@ void node_1_3(
     	outRec.OutputComplete();
 	}
 }
-// CHECK: define void @node_1_3()
+// CHECK-LABEL: define void @node_1_3()
 // CHECK: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)
 // CHECK: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 22, i32 8 })
 // CHECK: call i1 @dx.op.nodeOutputIsValid(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]])
@@ -78,7 +79,7 @@ void node_2_0(
 )
 {
 }
-// CHECK: define void @node_2_0()
+// CHECK-LABEL: define void @node_2_0()
 // CHECK: ret void
 
 [Shader("node")]
@@ -94,8 +95,11 @@ void node_2_1(
 		EmptyOutputArray[1].GroupIncrementOutputCount(10);
 	}
 }
-// CHECK: define void @node_2_1()
+// CHECK-LABEL: define void @node_2_1()
 // CHECK: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)
 // CHECK: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 26, i32 0 })
 // CHECK: call i1 @dx.op.nodeOutputIsValid(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]])
+// CHECKOD-LABEL: if.then:
+// CHECKOD: [[IDXNH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.indexNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle {{%[0-9]+}}, i32 1)
+// CHECKOD: [[ANH:%[0-9]+]] = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 {{[0-9]+}}, %dx.types.NodeHandle [[IDXNH]], %dx.types.NodeInfo { i32 26, i32 0 })
 // CHECK: call void @dx.op.incrementOutputCount(i32 {{[0-9]+}}, %dx.types.NodeHandle [[ANH]], i32 10, i1 false)

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/test_increment_output_count.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/test_increment_output_count.hlsl
@@ -1,4 +1,5 @@
 // RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s
 
 void loadStressEmptyRecWorker(
 EmptyNodeOutput outputNode)


### PR DESCRIPTION
IsHLSLNodeIOType is supposed to capture all node object types, but was missing output record and output array types.

TranslateHLCastHandleToRes had LLVM_FALLTHROUGH in for two cases where it made no sense to fall through to the next case.

MergeGepUse is needed after lowering GetRecordPtr to collapse GEP chains that could result in intermediate multi-dimension array pointers from GEPs, which is considered an invalid DXIL type.

Updated some tests for -Od compilations.  Added a test for the multi-dim GEP case.

Some CHECKs needed specialization for -Od:
- align 4 added to load/store only with optimizations enabled
- no CSE of index/annotate node handle
- also, use CHECK-LABEL to make failure investigations easier

Fixes #5597