### PR TITLE
[lit] Add hash stability test for lit.

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -15,6 +15,11 @@ configure_lit_site_cfg(
   )
 
 configure_lit_site_cfg(
+  ${CMAKE_CURRENT_SOURCE_DIR}/hash_stability/lit.site.cfg.in
+  ${CMAKE_CURRENT_BINARY_DIR}/hash_stability/lit.site.cfg
+  )
+
+configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.in
   ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg
   )
@@ -90,6 +95,7 @@ add_lit_testsuite(check-clang "Running the Clang regression tests"
   #LIT ${LLVM_LIT}
   PARAMS ${CLANG_TEST_PARAMS}
     skip_taef_exec=True
+    skip_hash_stability=True
   DEPENDS ${CLANG_TEST_DEPS}
   ARGS ${CLANG_TEST_EXTRA_ARGS}
   )
@@ -108,6 +114,7 @@ set(CLANG_TEST_PARAMS
   clang_taef_site_config=${CMAKE_CURRENT_BINARY_DIR}/taef/lit.site.cfg
   no_priority=True
   clang_taef_exec_site_config=${CMAKE_CURRENT_BINARY_DIR}/taef_exec/lit.site.cfg
+  clang_hash_stability_site_config=${CMAKE_CURRENT_BINARY_DIR}/hash_stability/lit.site.cfg
   )
 
 add_lit_testsuites(CLANG ${CMAKE_CURRENT_SOURCE_DIR}
@@ -146,6 +153,13 @@ if (WIN32)
             PARAMS ${CLANG_TEST_PARAMS}
                 adapter=${TAEF_EXEC_ADAPTER}
             DEPENDS ExecHLSLTests dxexp
+            ARGS ${CLANG_TEST_EXTRA_ARGS}
+          )
+
+  add_lit_target("check-clang-hash-stability" "Running lit suite dxc hash stability test"
+            ${CMAKE_CURRENT_SOURCE_DIR}/hash_stability
+            PARAMS ${CLANG_TEST_PARAMS}
+            DEPENDS ${CLANG_TEST_DEPS}
             ARGS ${CLANG_TEST_EXTRA_ARGS}
           )
 endif()

--- a/tools/clang/test/hash_stability/lit.cfg
+++ b/tools/clang/test/hash_stability/lit.cfg
@@ -1,0 +1,47 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import platform
+import subprocess
+
+import lit.formats
+import lit.util
+
+# name: The name of this test suite.
+config.name = 'hash-stability'
+
+skip_hash_stability = lit_config.params.get('skip_hash_stability', None)
+if skip_hash_stability or platform.system() != 'Windows':
+  config.unsupported = True
+
+if config.unsupported == False:
+	llvm_tools_dir = getattr(config, 'llvm_tools_dir', None)
+	if not llvm_tools_dir:
+		# Check for 'clang_hash_stability_site_config' user parameter, and use that if available.
+		site_cfg = lit_config.params.get('clang_hash_stability_site_config', None)
+		if site_cfg and os.path.exists(site_cfg):
+			lit_config.load_config(config, site_cfg)
+			raise SystemExit
+		lit_config.fatal('No LLVM tools dir set!')
+
+	dxc_path = lit.util.which('dxc', llvm_tools_dir)
+	dxa_path = lit.util.which('dxa', llvm_tools_dir)
+	working_dir = config.working_dir
+
+	test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+	tmp_path = os.path.join(working_dir, 'Output')
+	print('tmp_path: ' + tmp_path)
+	# create tmp_path if it doesn't exist
+	if not os.path.exists(tmp_path):
+		try:
+			os.makedirs(tmp_path)
+		except OSError:
+			print("Creation of the directory %s for temp output failed" % tmp_path)
+			raise SystemExit
+	hash_stability_path = lit_config.params.get('hash_stability_path', None)
+	if hash_stability_path:
+		test_path = hash_stability_path
+
+	config.test_format = lit.formats.DxcHashTest(test_path, dxc_path, dxa_path, working_dir)

--- a/tools/clang/test/hash_stability/lit.site.cfg.in
+++ b/tools/clang/test/hash_stability/lit.site.cfg.in
@@ -1,0 +1,18 @@
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.working_dir = os.path.dirname(__file__)
+# Support substitution of the tools_dir, libs_dirs, and build_mode with user
+# parameters. This is used when we can't determine the tool dir at
+# configuration time.
+try:
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@CLANG_SOURCE_DIR@/test/hash_stability/lit.cfg")

--- a/utils/lit/lit/formats/__init__.py
+++ b/utils/lit/lit/formats/__init__.py
@@ -2,4 +2,5 @@ from __future__ import absolute_import
 from lit.formats.base import TestFormat, FileBasedTest, OneCommandPerFileTest
 from lit.formats.googletest import GoogleTest
 from lit.formats.taef import TaefTest
+from lit.formats.dxc_hash import DxcHashTest
 from lit.formats.shtest import ShTest

--- a/utils/lit/lit/formats/dxc_hash.py
+++ b/utils/lit/lit/formats/dxc_hash.py
@@ -1,0 +1,234 @@
+from __future__ import absolute_import
+import os
+import subprocess
+import platform
+import filecmp
+from glob import iglob
+
+import lit.Test
+import lit.TestRunner
+import lit.util
+import lit.ShUtil as ShUtil
+from .base import TestFormat
+
+kIsWindows = platform.system() == 'Windows'
+
+# Don't use close_fds on Windows.
+kUseCloseFDs = not kIsWindows
+
+class ShellEnvironment(object):
+
+    """Mutable shell environment containing things like CWD and env vars.
+
+    Environment variables are not implemented, but cwd tracking is.
+    """
+
+    def __init__(self, cwd, env):
+        self.cwd = cwd
+        self.env = env
+
+class DxcHashTest(TestFormat):
+    def __init__(self, test_path, dxc_path, dxa_path, working_dir):
+        self.test_path = test_path
+        self.dxc_path = dxc_path
+        self.dxa_path = dxa_path
+        self.cwd = working_dir
+
+    def getTestsInDirectory(self, testSuite, path_in_suite,
+                            litConfig, localConfig):
+        if not os.path.isdir(self.test_path):
+            hlsl_list = [self.test_path]
+        else:
+            # Scan all sub directories in self.test_path
+            rootdir = self.test_path.replace('\\','/')
+            rootdir_glob = f"{rootdir}/**/*.hlsl"
+
+            # This will return absolute paths
+            hlsl_list = [f for f in iglob(rootdir_glob, recursive=True) if os.path.isfile(f)]
+
+        # add hlsl files which has first line as %dxc test as tests.
+        for filename in hlsl_list:
+            with open(filename, 'r') as f:
+                first_line = f.readline()
+                if (first_line.find("%dxc") == -1 or first_line.find("RUN:") == -1 or
+                    first_line.find(" not ") != -1 or
+                    first_line.find(" -M ") != -1 or
+                    first_line.find(" -H ") != -1 or
+                    first_line.find(" -Fi ") != -1 or
+                    first_line.find(" -exports ") != -1 or
+                    first_line.find(" -ast-dump-implicit ") != -1 or
+                    first_line.find(" -fcgl ") != -1 or
+                    first_line.find("rootsig_1_") != -1 or
+                    first_line.find(" -verify ") != -1 or
+                    # must have a target profile
+                    first_line.find(" -T") == -1 or
+                    # skip spirv.
+                    first_line.find("spirv") != -1):
+                    continue
+            rel_dir = os.path.relpath(filename, testSuite.source_root)
+
+            yield lit.Test.Test(testSuite, [rel_dir], localConfig, filename)
+
+    def get_run_line(self, test):
+        # Read first line of the test file
+        f = open(test.getFilePath(), 'r')
+        first_line = f.readline().rstrip()
+        f.close()
+        # remove things before RUN: from first line
+        first_line = first_line[first_line.find("RUN:") + 4:]
+
+        sourcepath = test.getFilePath()
+        sourcedir = os.path.dirname(sourcepath)
+        execpath = test.getExecPath()
+        execdir,execbase = os.path.split(execpath)
+        tmpDir = os.path.join(self.cwd, 'Output')
+        tmpBase = os.path.join(tmpDir, execbase)
+        tmpFile = tmpBase + '.tmp'
+        # subsitute %s with sourcepath
+        first_line = first_line.replace("%s", sourcepath)
+        # subsitute %t with tmpDir
+        first_line = first_line.replace("%t", tmpFile)
+        # subsitute %S with sourcedir
+        first_line = first_line.replace("%S", sourcedir)
+        # subsitute %T with execdir
+        first_line = first_line.replace("%T", tmpDir)
+
+        return first_line
+
+    def extract_hash(self, dxa_path, dx_container):
+        # extract hash from dxa_path
+        hash_file = f"{dx_container}.hash"
+        args = [dxa_path, "-extractpart", "HASH", dx_container, "-o", hash_file]
+        stdin, stdout, stderr = 0, subprocess.PIPE, subprocess.PIPE
+
+        proc = subprocess.Popen(args, cwd=self.cwd,
+                                                executable = dxa_path,
+                                        stdin = stdin,
+                                        stdout = stdout,
+                                        stderr = stderr,
+                                                close_fds = kUseCloseFDs)
+        proc.communicate()
+        res = proc.returncode
+        if res != 0:
+            print(f"extract hash failed {args}")
+            # extract hash failed, return fail.
+            return None
+        return hash_file
+
+    def normal_compile(self, args, shenv, test_name, output_file):
+        normal_args = args
+        normal_args.append("-Qstrip_reflect")
+        normal_args.append("-Zsb")
+        normal_args.append("-Fo")
+        normal_args.append(output_file)
+        proc = subprocess.Popen(normal_args, cwd=shenv.cwd,
+                                # don't writ output to stdout
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                env=shenv.env,
+                                close_fds=kUseCloseFDs)
+        proc.communicate()
+        return proc.returncode
+
+    def debug_compile(self, args, shenv, test_name, output_file):
+        debug_args = args
+        debug_args.append("-Zi")
+        debug_args.append("-Qstrip_reflect")
+        debug_args.append("-Zsb")
+        debug_args.append("-Fo")
+        debug_args.append(output_file)
+
+        proc = subprocess.Popen(debug_args, cwd=shenv.cwd,
+                                # don't writ output to stdout
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                env=shenv.env,
+                                close_fds=kUseCloseFDs)
+        proc.communicate()
+        return proc.returncode
+
+    def execute(self, test, litConfig):
+        first_line = self.get_run_line(test)
+        cwd = self.cwd
+        cmds = []
+        try:
+            cmds.append(ShUtil.ShParser(first_line, litConfig.isWindows,
+                                        test.config.pipefail).parse())
+        except ValueError as e:
+            return lit.Test.Result(lit.Test.FAIL, "shell parser error: %s" % e)
+        except Exception as e:
+            return lit.Test.Result(lit.Test.FAIL, "shell parser error: %s" % e)
+        except:
+            return lit.Test.Result(lit.Test.FAIL, "shell parser error on: %r" % first_line)
+
+        shenv = ShellEnvironment(cwd, test.config.environment)
+
+        # get first command
+        cmd = cmds[0]
+        while isinstance(cmd, ShUtil.Seq):
+            cmd = cmd.lhs
+        dxc_cmd = cmd.commands[0]
+
+        if dxc_cmd.args[0] != "%dxc":
+            return lit.Test.Result(lit.Test.PASS)
+        original_args = dxc_cmd.args
+        original_args[0] = self.dxc_path
+        executable = self.dxc_path
+        args = []
+        for i in range(len(original_args)):
+            arg = original_args[i]
+            if arg == "-Fo" or arg == "-validator-version":
+                # remove "-Fo", "-validator-version" and things next to it from args
+                i += 2
+                continue
+            elif arg == "-ast-dump" or arg == "-Zi" or arg == "-verify" or arg == "-M" or arg == "-H":
+                # remove "-ast-dump" and "-Zi" from args
+                i += 1
+                continue
+            args.append(arg)
+
+        # run original compilation
+        proc = subprocess.Popen(args, cwd=shenv.cwd,
+                                executable=executable,
+                                # don't writ output to stdout
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                env=shenv.env,
+                                close_fds=kUseCloseFDs)
+        proc.communicate()
+        res = proc.returncode
+        if res != 0:
+            # original compilation failed, don't run hash test.
+            return lit.Test.Result(lit.Test.PASS, "Original compilation failed.")
+        # get test_name from test path for tmp file name.
+        test_name = test.path_in_suite[0].replace('\\','_').replace('/','_').replace('.','_')
+        # run normal compile
+        normal_out = os.path.join(self.cwd, 'Output', test_name+'.normal.out')
+        res = self.normal_compile(args, shenv, test_name, normal_out)
+        if res != 0:
+            # strip_reflect failed, return fail.
+            return lit.Test.Result(lit.Test.FAIL, "Adding Qstrip_reflect failed compilation.")
+
+        normal_hash = self.extract_hash(self.dxa_path, normal_out)
+        if normal_hash is None:
+            return lit.Test.Result(lit.Test.FAIL, "Fail to get hash for normal compilation.")
+
+
+        # run debug compilation
+        debug_out = os.path.join(self.cwd, 'Output', test_name+'.dbg.out')
+        res = self.debug_compile(args, shenv, test_name, debug_out)
+        if res != 0:
+            # strip_reflect failed, return fail.
+            return lit.Test.Result(lit.Test.FAIL, "Adding Qstrip_reflect and Zi failed compilation.")
+
+        debug_hash = self.extract_hash(self.dxa_path, debug_out)
+        if debug_hash is None:
+            return lit.Test.Result(lit.Test.FAIL, "Fail to get hash for normal compilation.")
+
+        # compare normal_hash and debug_hash.
+        if filecmp.cmp(normal_hash, debug_hash):
+            # hash match, return pass.
+            return lit.Test.Result(lit.Test.PASS)
+        else:
+            # hash mismatch
+            return lit.Test.Result(lit.Test.FAIL, "Hash mismatch.")

--- a/utils/llvm-lit/llvm-lit.in
+++ b/utils/llvm-lit/llvm-lit.in
@@ -24,6 +24,8 @@ clang_obj_root = os.path.join(llvm_obj_root, 'tools', 'clang')
 if os.path.exists(clang_obj_root):
     builtin_parameters['clang_site_config'] = \
         os.path.join(clang_obj_root, 'test', 'lit.site.cfg')
+    builtin_parameters['clang_hash_stability_site_config'] = \
+        os.path.join(clang_obj_root, 'test','hash_stability', 'lit.site.cfg')
     clang_tools_extra_obj_root = os.path.join(clang_obj_root, 'tools', 'extra')
     if os.path.exists(clang_tools_extra_obj_root):
         builtin_parameters['clang_tools_extra_site_config'] = \


### PR DESCRIPTION
A new lit format, DxcHashTest, has been added. This test will scan all HLSL files under tools\clang\test and run a hash stability test on each file. The hash stability test will compile the shader twice, once with the -Zi flag and once without. The hashes of the output containers will then be compared.

The --param hash_stability_path=test_path flag can be used to debug a single file or folder.

The hash stability test is disabled by default for pipeline runs, due to time constraints. To enable it, set the skip_hash_stability flag to False.