### PR TITLE
Fix crash in dominator tree construction used by DiagnoseRaytracingPayloadAccess

### DIFF
--- a/include/llvm/Support/GenericDomTreeConstruction.h
+++ b/include/llvm/Support/GenericDomTreeConstruction.h
@@ -92,6 +92,10 @@ unsigned DFSPass(DominatorTreeBase<typename GraphT::NodeType>& DT,
     // Visit the successor next, if it isn't already visited.
     typename GraphT::NodeType* Succ = *NextSucc;
 
+    // For clang, CFG successors can be optimized-out nullptrs. Skip those.
+    if (!Succ)
+      continue;
+
     typename DominatorTreeBase<typename GraphT::NodeType>::InfoRec &SuccVInfo =
                                                                   DT.Info[Succ];
     if (SuccVInfo.Semi == 0) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/diagnose_raytracing_payload_access_crash.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/warnings/diagnose_raytracing_payload_access_crash.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -E RayGen -T lib_6_7 %s | FileCheck %s
+
+// Regression test for crashing in DiagnoseRaytracingPayloadAccess
+// due to a trivial while(true) loop.
+
+// CHECK: define void @"\01?RayGen@@YAXXZ"()
+[shader("raygeneration")] void RayGen() {
+    while (true) {
+       break;
+    }
+}


### PR DESCRIPTION
Fix crash if a RayGen shader contains a `while(true)` loop, caused by dominator tree construction not ignoring `nullptr` successor AST nodes which occur in this case.

Also add regression test case.

Fixes #5035.