### PR TITLE
select-validator opt to select internal/DXIL.dll

### DIFF
--- a/include/dxc/Support/ErrorCodes.h
+++ b/include/dxc/Support/ErrorCodes.h
@@ -116,3 +116,6 @@
 
 // 0X80AA001D - LLVM Cast Failure
 #define DXC_E_LLVM_CAST_ERROR                         DXC_MAKE_HRESULT(DXC_SEVERITY_ERROR,FACILITY_DXC,(0x001D))
+
+// 0X80AA001E - External validator (DXIL.dll) required, and missing.
+#define DXC_E_VALIDATOR_MISSING                       DXC_MAKE_HRESULT(DXC_SEVERITY_ERROR,FACILITY_DXC,(0x001E))

--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -107,6 +107,12 @@ struct RewriterOpts {
   bool DeclGlobalCB = false;          // OPT_rw_decl_global_cb
 };
 
+enum class ValidatorSelection : int {
+  Auto,       // Try DXIL.dll; fallback to internal validator
+  Internal,   // Force internal validator (even if DXIL.dll is present)
+  External    // Use DXIL.dll, failing compilation if not available
+};
+
 /// Use this class to capture all options.
 class DxcOpts {
 public:
@@ -208,6 +214,7 @@ public:
   bool ExportShadersOnly = false; // OPT_export_shaders_only
   bool ResMayAlias = false; // OPT_res_may_alias
   unsigned long ValVerMajor = UINT_MAX, ValVerMinor = UINT_MAX; // OPT_validator_version
+  ValidatorSelection SelectValidator = ValidatorSelection::Auto; // OPT_select_validator
   unsigned ScanLimit = 0; // OPT_memdep_block_scan_limit
   bool ForceZeroStoreLifetimes = false; // OPT_force_zero_store_lifetimes
   bool EnableLifetimeMarkers = false; // OPT_enable_lifetime_markers

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -311,6 +311,8 @@ def print_before_all : Flag<["-", "/"], "print-before-all">, Group<hlslcomp_Grou
   HelpText<"Print LLVM IR before each pass.">;
 def print_before : Separate<["-", "/"], "print-before">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR before a specific pass. May be specificied multiple times.">;
+def select_validator : Separate<["-", "/"], "select-validator">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
+  HelpText<"Select validator: auto: (default) use DXIL.dll if found, otherwise use internal;  internal: internal non-signing validator;  external: use DXIL.dll if found, otherwise fail compilation.">;
 def print_after_all : Flag<["-", "/"], "print-after-all">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,
   HelpText<"Print LLVM IR after each pass.">;
 def print_after : Separate<["-", "/"], "print-after">, Group<hlslcomp_Group>, Flags<[CoreOption, HelpHidden]>,

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -927,6 +927,21 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     opts.ValVerMinor = (unsigned long)minor64;
   }
 
+  llvm::StringRef valSelectStr = Args.getLastArgValue(OPT_select_validator);
+  if (!valSelectStr.empty()) {
+    if (valSelectStr.equals_lower("auto")) {
+      opts.SelectValidator = ValidatorSelection::Auto;
+    } else if (valSelectStr.equals_lower("internal")) {
+      opts.SelectValidator = ValidatorSelection::Internal;
+    } else if (valSelectStr.equals_lower("external")) {
+      opts.SelectValidator = ValidatorSelection::External;
+    } else {
+      errors << "Unsupported value '" << valSelectStr
+             << "for -select-validator option.";
+      return 1;
+    }
+  }
+
   if (opts.IsLibraryProfile() && Minor == 0xF) {
     if (opts.ValVerMajor != UINT_MAX && opts.ValVerMajor != 0) {
       errors << "Offline library profile cannot be used with non-zero -validator-version.";

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -15,6 +15,7 @@
 #include "dxc/Support/microcom.h"
 #include "dxc/dxcapi.h"
 #include "llvm/ADT/StringRef.h"
+#include "dxc/Support/HLSLOptions.h"
 
 #include <memory>
 
@@ -52,7 +53,9 @@ struct AssembleInputs {
                  hlsl::AbstractMemoryStream *pReflectionOut = nullptr,
                  hlsl::AbstractMemoryStream *pRootSigOut = nullptr,
                  CComPtr<IDxcBlob> pRootSigBlob = nullptr,
-                 CComPtr<IDxcBlob> pPrivateBlob = nullptr);
+                 CComPtr<IDxcBlob> pPrivateBlob = nullptr,
+                 hlsl::options::ValidatorSelection SelectValidator =
+                     hlsl::options::ValidatorSelection::Auto);
   std::unique_ptr<llvm::Module> pM;
   CComPtr<IDxcBlob> &pOutputContainerBlob;
   IDxcVersionInfo *pVersionInfo = nullptr;
@@ -66,12 +69,18 @@ struct AssembleInputs {
   hlsl::AbstractMemoryStream *pRootSigOut = nullptr;
   CComPtr<IDxcBlob> pRootSigBlob = nullptr;
   CComPtr<IDxcBlob> pPrivateBlob = nullptr;
+  hlsl::options::ValidatorSelection SelectValidator =
+      hlsl::options::ValidatorSelection::Auto;
 };
 HRESULT ValidateAndAssembleToContainer(AssembleInputs &inputs);
 HRESULT ValidateRootSignatureInContainer(
-    IDxcBlob *pRootSigContainer, clang::DiagnosticsEngine *pDiag = nullptr);
+    IDxcBlob *pRootSigContainer, clang::DiagnosticsEngine *pDiag = nullptr,
+    hlsl::options::ValidatorSelection SelectValidator =
+        hlsl::options::ValidatorSelection::Auto);
 HRESULT SetRootSignature(hlsl::DxilModule *pModule, CComPtr<IDxcBlob> pSource);
-void GetValidatorVersion(unsigned *pMajor, unsigned *pMinor);
+void GetValidatorVersion(unsigned *pMajor, unsigned *pMinor,
+                         hlsl::options::ValidatorSelection SelectValidator =
+                             hlsl::options::ValidatorSelection::Auto);
 void AssembleToContainer(AssembleInputs &inputs);
 HRESULT Disassemble(IDxcBlob *pProgram, llvm::raw_string_ostream &Stream);
 void ReadOptsAndValidate(hlsl::options::MainArgs &mainArgs,


### PR DESCRIPTION
Add -select-validator option to explicitly select internal or DXIL.dll

New option will fail compilation now if you select 'external' and DXIL.dll is not found.

If you select 'internal', it will use the internal validator, even if DXIL.dll would have been found.  The warning about DXIL.dll not being found will also be suppressed when you use this option.

Default behavior is 'auto', which is to use DXIL.dll if found, otherwise use the internal validator.

Related work items: #msft-internal61

(cherry picked from commit ecc3d35c5d28c7d9cee107efc767481bc88a5062)

Fixes #5362