### PR TITLE
Fix asan container-overflow

### DIFF
--- a/lib/Analysis/LazyValueInfo.cpp
+++ b/lib/Analysis/LazyValueInfo.cpp
@@ -460,7 +460,7 @@ void LazyValueInfoCache::eraseBlock(BasicBlock *BB) {
 
 void LazyValueInfoCache::solve() {
   while (!BlockValueStack.empty()) {
-    std::pair<BasicBlock*, Value*> &e = BlockValueStack.top();
+    std::pair<BasicBlock*, Value*> e = BlockValueStack.top();
     assert(BlockValueSet.count(e) && "Stack value should be in BlockValueSet!");
 
     if (solveBlockValue(e.second, e.first)) {


### PR DESCRIPTION
When the reference 'e' to stack top is popped, the call to erase(e) reads from this now invalid reference. ASAN catches this as a container overflow. We fix this by taking a copy of the stack top instead.

Note that this was similarly fixed in upstream LLVM as well: https://github.com/llvm/llvm-project/commit/9987d983704cb3086b0275043a07c1f599d9eaad