### PR TITLE
[DCE] Move output complete removal code later to DCE

### DIFF
--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -97,6 +97,7 @@ public:
   llvm::Constant *GetFloatConst(float v);
   llvm::Constant *GetDoubleConst(double v);
 
+  static OP::OpCode getOpCode(const llvm::Instruction *I);
   static llvm::Type *GetOverloadType(OpCode OpCode, llvm::Function *F);
   static OpCode GetDxilOpFuncCallInst(const llvm::Instruction *I);
   static const char *GetOpCodeName(OpCode OpCode);

--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -186,7 +186,7 @@ namespace dxilutil {
   /// This can enhance SROA and other transforms that want type-safe pointers,
   /// and enables merging with other getelementptr's.
   llvm::Value *TryReplaceBaseCastWithGep(llvm::Value *V);
-
+  bool DxilOpFunctionHasNoSideEffects(llvm::Instruction *I);
   llvm::Value::user_iterator mdv_users_end(llvm::Value *V);
   llvm::Value::user_iterator mdv_users_begin(llvm::Value *V);
   inline bool mdv_user_empty(llvm::Value *V) {

--- a/include/dxc/DXIL/DxilUtil.h
+++ b/include/dxc/DXIL/DxilUtil.h
@@ -186,7 +186,7 @@ namespace dxilutil {
   /// This can enhance SROA and other transforms that want type-safe pointers,
   /// and enables merging with other getelementptr's.
   llvm::Value *TryReplaceBaseCastWithGep(llvm::Value *V);
-  bool DxilOpFunctionHasNoSideEffects(llvm::Instruction *I);
+  bool FunctionHasNoSideEffects(llvm::Instruction *I);
   llvm::Value::user_iterator mdv_users_end(llvm::Value *V);
   llvm::Value::user_iterator mdv_users_begin(llvm::Value *V);
   inline bool mdv_user_empty(llvm::Value *V) {

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -648,7 +648,7 @@ bool OP::IsDxilOpFuncCallInst(const llvm::Instruction *I) {
 
 bool OP::IsDxilOpFuncCallInst(const llvm::Instruction *I, OpCode opcode) {
   if (!IsDxilOpFuncCallInst(I)) return false;
-  return llvm::cast<llvm::ConstantInt>(I->getOperand(0))->getZExtValue() == (unsigned)opcode;
+  return (unsigned)getOpCode(I) == (unsigned)opcode;
 }
 
 OP::OpCode OP::getOpCode(const llvm::Instruction *I) {

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -651,9 +651,14 @@ bool OP::IsDxilOpFuncCallInst(const llvm::Instruction *I, OpCode opcode) {
   return llvm::cast<llvm::ConstantInt>(I->getOperand(0))->getZExtValue() == (unsigned)opcode;
 }
 
+OP::OpCode OP::getOpCode(const llvm::Instruction *I) {
+  return (OP::OpCode)llvm::cast<llvm::ConstantInt>(I->getOperand(0))
+      ->getZExtValue();
+}
+
 OP::OpCode OP::GetDxilOpFuncCallInst(const llvm::Instruction *I) {
   DXASSERT(IsDxilOpFuncCallInst(I), "else caller didn't call IsDxilOpFuncCallInst to check");
-  return (OP::OpCode)llvm::cast<llvm::ConstantInt>(I->getOperand(0))->getZExtValue();
+  return getOpCode(I);
 }
 
 bool OP::IsDxilOpWave(OpCode C) {

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1223,8 +1223,8 @@ bool DxilOpFunctionHasNoSideEffects(Instruction *I) {
   if (CallInst *CI = dyn_cast<CallInst>(I)) {
     if (CI->onlyReadsMemory()) return false;
 
-    bool isDxilOp = hlsl::OP::IsDxilOpFunc(CI->getCalledFunction());
-    if (!isDxilOp) return false;
+    if (!hlsl::OP::IsDxilOpFunc(CI->getCalledFunction()))
+      return false;
     switch (hlsl::OP::getOpCode(I)) {
     case hlsl::OP::OpCode::OutputComplete: {
       hlsl::DxilInst_OutputComplete OutputComplete(CI);

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1223,8 +1223,7 @@ bool DxilOpFunctionHasNoSideEffects(Instruction *I) {
   if (CallInst *CI = dyn_cast<CallInst>(I)) {
     if (CI->onlyReadsMemory()) return false;
 
-    hlsl::OP op(CI->getContext(), CI->getModule());
-    bool isDxilOp = op.IsDxilOpFunc(CI->getCalledFunction());
+    bool isDxilOp = hlsl::OP::IsDxilOpFunc(CI->getCalledFunction());
     if (!isDxilOp) return false;
     switch (hlsl::OP::getOpCode(I)) {
     case hlsl::OP::OpCode::OutputComplete: {

--- a/lib/DXIL/DxilUtil.cpp
+++ b/lib/DXIL/DxilUtil.cpp
@@ -1233,10 +1233,12 @@ bool DxilOpFunctionHasNoSideEffects(Instruction *I) {
       Constant *C = dyn_cast<Constant>(NodeRecHandle);
       if (C && C->isZeroValue())
         return true;
+      break;
     }
 
     // TODO: Add Wave Ops
-    default: return false;
+    default:
+      return false;
     }
   }
   return false;

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -273,10 +273,7 @@ public:
           }
         }
       }
-    }
-
-    const bool SkipInit = true;
-    hlsl::DxilModule& DxilMod = M.GetOrCreateDxilModule(SkipInit);    
+    }  
 
     // Translate precise on allocas into function call to keep the information after mem2reg.
     // The function calls will be removed after propagate precise attribute.
@@ -287,6 +284,9 @@ public:
     if (!SM->IsLib()) {
       pProps = &EntryPropsMap.begin()->second->props;
     }
+
+    const bool SkipInit = true;
+    hlsl::DxilModule &DxilMod = M.GetOrCreateDxilModule(SkipInit);  
     InitDxilModuleFromHLModule(*m_pHLModule, DxilMod, m_HasDbgInfo);
     DxilMod.ResetEntryPropsMap(std::move(EntryPropsMap));
     if (!SM->IsLib()) {

--- a/lib/HLSL/DxilGenerationPass.cpp
+++ b/lib/HLSL/DxilGenerationPass.cpp
@@ -275,24 +275,8 @@ public:
       }
     }
 
-    // Remove Redundant OutputComplete
-    //call void @dx.op.outputComplete(i32 241, %dx.types.Handle zeroinitializer)
     const bool SkipInit = true;
-    hlsl::DxilModule& DxilMod = M.GetOrCreateDxilModule(SkipInit);
-    hlsl::OP* hlslOP = DxilMod.GetOP();
-    for (auto& it : hlslOP->GetOpFuncList(DXIL::OpCode::OutputComplete)) {
-      Function* F = it.second;
-      if (!F)
-        continue;
-      for (auto itU = F->user_begin(); itU != F->user_end(); ) {
-        User* U = *(itU++);
-        CallInst* CI = cast<CallInst>(U);
-        Value* NodeRecHandle = CI->getArgOperand(HLOperandIndex::kHandleOpIdx);
-        Constant* C = dyn_cast<Constant>(NodeRecHandle);
-        if ( C && C->isZeroValue())
-          CI->eraseFromParent();
-      }
-    }
+    hlsl::DxilModule& DxilMod = M.GetOrCreateDxilModule(SkipInit);    
 
     // Translate precise on allocas into function call to keep the information after mem2reg.
     // The function calls will be removed after propagate precise attribute.

--- a/lib/Transforms/Utils/Local.cpp
+++ b/lib/Transforms/Utils/Local.cpp
@@ -47,7 +47,7 @@
 
 #include "dxc/DXIL/DxilMetadataHelper.h" // HLSL Change - combine dxil metadata.
 #include "dxc/DXIL/DxilUtil.h" // HLSL Change - special handling of convergent marker
-#include "dxc/HLSL/HLOperations.h" // HLSL Change - HLOperandIndex usage
+#include "dxc/DXIL/DxilInstructions.h" // HLSL Change - DxilInst_OutputComplete usage
 #include "dxc/DXIL/DxilOperations.h" // HLSL Change - Get HLSL Opcodes
 
 using namespace llvm;
@@ -340,8 +340,8 @@ bool llvm::isInstructionTriviallyDead(Instruction *I,
   if (CallInst *CI = dyn_cast<CallInst>(I)) {  
     if (hlsl::dxilutil::IsConvergentMarker(CI)) return true;
     if (hlsl::OP::IsDxilOpFuncCallInst(I, hlsl::OP::OpCode::OutputComplete)) {
-      Value *NodeRecHandle =
-          CI->getArgOperand(hlsl::HLOperandIndex::kHandleOpIdx);
+      hlsl::DxilInst_OutputComplete OutputComplete(CI);
+      Value *NodeRecHandle = OutputComplete.get_output();
       Constant *C = dyn_cast<Constant>(NodeRecHandle);
       if (C && C->isZeroValue())
         return true;

--- a/lib/Transforms/Utils/Local.cpp
+++ b/lib/Transforms/Utils/Local.cpp
@@ -335,17 +335,14 @@ bool llvm::isInstructionTriviallyDead(Instruction *I,
     if (Constant *C = dyn_cast<Constant>(CI->getArgOperand(0)))
       return C->isNullValue() || isa<UndefValue>(C);
 
-  // HLSL Change - don't force unused convergenet markers to stay, 
+  // HLSL Change - don't force unused convergent markers to stay, 
   // remove bad OutputCompletes
   if (CallInst *CI = dyn_cast<CallInst>(I)) {  
-    if (hlsl::dxilutil::IsConvergentMarker(CI)) return true;
-    if (hlsl::OP::IsDxilOpFuncCallInst(I, hlsl::OP::OpCode::OutputComplete)) {
-      hlsl::DxilInst_OutputComplete OutputComplete(CI);
-      Value *NodeRecHandle = OutputComplete.get_output();
-      Constant *C = dyn_cast<Constant>(NodeRecHandle);
-      if (C && C->isZeroValue())
-        return true;
-    }
+    if (hlsl::dxilutil::IsConvergentMarker(CI)) 
+      return true;
+
+    if (hlsl::dxilutil::DxilOpFunctionHasNoSideEffects(I)) 
+      return true;
   }
   // HLSL Change End
 

--- a/lib/Transforms/Utils/Local.cpp
+++ b/lib/Transforms/Utils/Local.cpp
@@ -335,15 +335,10 @@ bool llvm::isInstructionTriviallyDead(Instruction *I,
     if (Constant *C = dyn_cast<Constant>(CI->getArgOperand(0)))
       return C->isNullValue() || isa<UndefValue>(C);
 
-  // HLSL Change - don't force unused convergent markers to stay, 
-  // remove bad OutputCompletes
-  if (CallInst *CI = dyn_cast<CallInst>(I)) {  
-    if (hlsl::dxilutil::IsConvergentMarker(CI)) 
-      return true;
-
-    if (hlsl::dxilutil::DxilOpFunctionHasNoSideEffects(I)) 
-      return true;
-  }
+  // HLSL Change - Verify that function has no side effects
+  if (hlsl::dxilutil::FunctionHasNoSideEffects(I)) 
+    return true;
+  
   // HLSL Change End
 
   return false;

--- a/tools/clang/test/HLSLFileCheck/validation/verify_output_complete_dce.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/verify_output_complete_dce.ll
@@ -1,15 +1,6 @@
 ; RUN: %opt %s -hlsl-passes-resume -dce -S | FileCheck %s
 
-; shader hash: 8f77518ca1d616c4259bbb38d029f95c
-;
-; Buffer Definitions:
-;
-;
-; Resource Bindings:
-;
-; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
-; ------------------------------ ---------- ------- ----------- ------- -------------- ------
-;
+
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 
@@ -22,41 +13,23 @@ target triple = "dxil-ms-dx"
 @"\01?loadStressTemp@@3PAIA" = external addrspace(3) global [128 x i32], align 4
 
 define void @loadStress_16() {
-  %1 = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)  ; FlattenedThreadIdInGroup()
-  %2 = call %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32 247, i32 0)  ; CreateNodeOutputHandle(MetadataIdx)
-  %3 = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 249, %dx.types.NodeHandle %2, %dx.types.NodeInfo { i32 6, i32 24 })  ; AnnotateNodeHandle(node,props)
-  %4 = call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 238, %dx.types.NodeHandle %3, i32 1, i1 true)  ; AllocateNodeOutputRecords(output,numRecords,perThread)
-  %5 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %4, %dx.types.NodeRecordInfo { i32 38, i32 24 })  ; AnnotateNodeRecordHandle(noderecord,props)
-  %6 = urem i32 %1, 3
-  %7 = add nuw nsw i32 %6, 1
-  %8 = call %struct.loadStressRecord.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.loadStressRecord.0(i32 239, %dx.types.NodeRecordHandle %5, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
-  %9 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 0
-  store i32 %7, i32 addrspace(6)* %9, align 4
-  %10 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 1
-  store i32 1, i32 addrspace(6)* %10, align 4
-  %11 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 2
-  store i32 1, i32 addrspace(6)* %11, align 4
-  %12 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 0), align 4, !tbaa !22
-  %13 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 0
-  store i32 %12, i32 addrspace(6)* %13, align 4
-  %14 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 1), align 4, !tbaa !22
-  %15 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 1
-  store i32 %14, i32 addrspace(6)* %15, align 4
-  %16 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 2), align 4, !tbaa !22
-  %17 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 2
-  store i32 %16, i32 addrspace(6)* %17, align 4
-  call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %5)  ; OutputComplete(output)
+  %1 = call %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32 247, i32 0)  ; CreateNodeOutputHandle(MetadataIdx)
+  %2 = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 249, %dx.types.NodeHandle %1, %dx.types.NodeInfo { i32 6, i32 24 })  ; AnnotateNodeHandle(node,props)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 238, %dx.types.NodeHandle %2, i32 1, i1 true)  ; AllocateNodeOutputRecords(output,numRecords,perThread)
+  %4 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %3, %dx.types.NodeRecordInfo { i32 38, i32 24 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %5 = call %struct.loadStressRecord.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.loadStressRecord.0(i32 239, %dx.types.NodeRecordHandle %4, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %6 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %5, i32 0, i32 0, i32 0
+  store i32 3, i32 addrspace(6)* %6, align 4
+  
+  call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %4)  ; OutputComplete(output)
   
   ; test that the 2 subsequent output complete calls are removed by DCE
-  ; CHECK: call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %5)
+  ; CHECK: call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %4)
   ; CHECK-NEXT: ret void
   call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle zeroinitializer)  ; OutputComplete(output)
   call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle zeroinitializer)  ; OutputComplete(output)
   ret void
 }
-
-; Function Attrs: nounwind readnone
-declare i32 @dx.op.flattenedThreadIdInGroup.i32(i32) #0
 
 ; Function Attrs: nounwind readnone
 declare %struct.loadStressRecord.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.loadStressRecord.0(i32, %dx.types.NodeRecordHandle, i32) #0
@@ -75,40 +48,3 @@ declare %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32, i32) #0
 
 ; Function Attrs: nounwind readnone
 declare %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32, %dx.types.NodeHandle, %dx.types.NodeInfo) #0
-
-attributes #0 = { nounwind readnone }
-attributes #1 = { nounwind }
-
-!llvm.ident = !{!0}
-!dx.version = !{!1}
-!dx.valver = !{!1}
-!dx.shaderModel = !{!2}
-!dx.typeAnnotations = !{!3}
-!dx.entryPoints = !{!7, !8}
-
-!0 = !{!"dxc(private) 1.8.0.3958 (fixWaveTests, c110270b3-dirty)"}
-!1 = !{i32 1, i32 8}
-!2 = !{!"lib", i32 6, i32 8}
-!3 = !{i32 1, void ()* @loadStress_16, !4}
-!4 = !{!5}
-!5 = !{i32 0, !6, !6}
-!6 = !{}
-!7 = !{null, !"", null, null, null}
-!8 = !{void ()* @loadStress_16, !"loadStress_16", null, null, !9}
-!9 = !{i32 8, i32 15, i32 13, i32 1, i32 15, !10, i32 16, i32 -1, i32 22, !11, i32 20, !12, i32 21, !16, i32 4, !20, i32 5, !21}
-!10 = !{!"loadStress_16", i32 0}
-!11 = !{i32 3, i32 1, i32 1}
-!12 = !{!13}
-!13 = !{i32 1, i32 97, i32 2, !14}
-!14 = !{i32 0, i32 12, i32 1, !15}
-!15 = !{i32 0, i32 5, i32 3}
-!16 = !{!17}
-!17 = !{i32 1, i32 6, i32 2, !18, i32 3, i32 0, i32 0, !19}
-!18 = !{i32 0, i32 24, i32 1, !15}
-!19 = !{!"loadStressChild", i32 0}
-!20 = !{i32 1, i32 1, i32 1}
-!21 = !{i32 0}
-!22 = !{!23, !23, i64 0}
-!23 = !{!"int", !24, i64 0}
-!24 = !{!"omnipotent char", !25, i64 0}
-!25 = !{!"Simple C/C++ TBAA"}

--- a/tools/clang/test/HLSLFileCheck/validation/verify_output_complete_dce.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/verify_output_complete_dce.ll
@@ -1,0 +1,114 @@
+; RUN: %opt %s -hlsl-passes-resume -dce -S | FileCheck %s
+
+; shader hash: 8f77518ca1d616c4259bbb38d029f95c
+;
+; Buffer Definitions:
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.NodeHandle = type { i8* }
+%dx.types.NodeInfo = type { i32, i32 }
+%dx.types.NodeRecordHandle = type { i8* }
+%dx.types.NodeRecordInfo = type { i32, i32 }
+%struct.loadStressRecord.0 = type { [3 x i32], [3 x i32] }
+
+@"\01?loadStressTemp@@3PAIA" = external addrspace(3) global [128 x i32], align 4
+
+define void @loadStress_16() {
+  %1 = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)  ; FlattenedThreadIdInGroup()
+  %2 = call %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32 247, i32 0)  ; CreateNodeOutputHandle(MetadataIdx)
+  %3 = call %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32 249, %dx.types.NodeHandle %2, %dx.types.NodeInfo { i32 6, i32 24 })  ; AnnotateNodeHandle(node,props)
+  %4 = call %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32 238, %dx.types.NodeHandle %3, i32 1, i1 true)  ; AllocateNodeOutputRecords(output,numRecords,perThread)
+  %5 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %4, %dx.types.NodeRecordInfo { i32 38, i32 24 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %6 = urem i32 %1, 3
+  %7 = add nuw nsw i32 %6, 1
+  %8 = call %struct.loadStressRecord.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.loadStressRecord.0(i32 239, %dx.types.NodeRecordHandle %5, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %9 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 0
+  store i32 %7, i32 addrspace(6)* %9, align 4
+  %10 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 1
+  store i32 1, i32 addrspace(6)* %10, align 4
+  %11 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 0, i32 2
+  store i32 1, i32 addrspace(6)* %11, align 4
+  %12 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 0), align 4, !tbaa !22
+  %13 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 0
+  store i32 %12, i32 addrspace(6)* %13, align 4
+  %14 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 1), align 4, !tbaa !22
+  %15 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 1
+  store i32 %14, i32 addrspace(6)* %15, align 4
+  %16 = load i32, i32 addrspace(3)* getelementptr inbounds ([128 x i32], [128 x i32] addrspace(3)* @"\01?loadStressTemp@@3PAIA", i32 0, i32 2), align 4, !tbaa !22
+  %17 = getelementptr inbounds %struct.loadStressRecord.0, %struct.loadStressRecord.0 addrspace(6)* %8, i32 0, i32 1, i32 2
+  store i32 %16, i32 addrspace(6)* %17, align 4
+  call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %5)  ; OutputComplete(output)
+  
+  ; test that the 2 subsequent output complete calls are removed by DCE
+  ; CHECK: call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle %5)
+  ; CHECK-NEXT: ret void
+  call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle zeroinitializer)  ; OutputComplete(output)
+  call void @dx.op.outputComplete(i32 241, %dx.types.NodeRecordHandle zeroinitializer)  ; OutputComplete(output)
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare i32 @dx.op.flattenedThreadIdInGroup.i32(i32) #0
+
+; Function Attrs: nounwind readnone
+declare %struct.loadStressRecord.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.loadStressRecord.0(i32, %dx.types.NodeRecordHandle, i32) #0
+
+; Function Attrs: nounwind
+declare %dx.types.NodeRecordHandle @dx.op.allocateNodeOutputRecords(i32, %dx.types.NodeHandle, i32, i1) #1
+
+; Function Attrs: nounwind
+declare void @dx.op.outputComplete(i32, %dx.types.NodeRecordHandle) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32, %dx.types.NodeRecordHandle, %dx.types.NodeRecordInfo) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.NodeHandle @dx.op.createNodeOutputHandle(i32, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.NodeHandle @dx.op.annotateNodeHandle(i32, %dx.types.NodeHandle, %dx.types.NodeInfo) #0
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.8.0.3958 (fixWaveTests, c110270b3-dirty)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @loadStress_16, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @loadStress_16, !"loadStress_16", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 15, !10, i32 16, i32 -1, i32 22, !11, i32 20, !12, i32 21, !16, i32 4, !20, i32 5, !21}
+!10 = !{!"loadStress_16", i32 0}
+!11 = !{i32 3, i32 1, i32 1}
+!12 = !{!13}
+!13 = !{i32 1, i32 97, i32 2, !14}
+!14 = !{i32 0, i32 12, i32 1, !15}
+!15 = !{i32 0, i32 5, i32 3}
+!16 = !{!17}
+!17 = !{i32 1, i32 6, i32 2, !18, i32 3, i32 0, i32 0, !19}
+!18 = !{i32 0, i32 24, i32 1, !15}
+!19 = !{!"loadStressChild", i32 0}
+!20 = !{i32 1, i32 1, i32 1}
+!21 = !{i32 0}
+!22 = !{!23, !23, i64 0}
+!23 = !{!"int", !24, i64 0}
+!24 = !{!"omnipotent char", !25, i64 0}
+!25 = !{!"Simple C/C++ TBAA"}


### PR DESCRIPTION
Elimination of incorrect output complete calls was located in an awkward spot. The code has been moved over to DCE. 
Fixes #5363