### PR TITLE
[Test][NFC] Add shader stage attribute to test shaders

### DIFF
--- a/tools/clang/test/CodeGenHLSL/lib_cs_entry.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_cs_entry.hlsl
@@ -23,6 +23,7 @@ void StoreOutputMat(float2x2  m, uint gidx);
 float2x2 LoadInputMat(uint x, uint y);
 float2x2 RotateMat(float2x2 m, uint x, uint y);
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/CodeGenHLSL/lib_cs_entry2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_cs_entry2.hlsl
@@ -2,11 +2,13 @@
 
 // CHECK: redefinition of entry
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {
 }
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/CodeGenHLSL/lib_cs_entry3.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_cs_entry3.hlsl
@@ -13,12 +13,13 @@
 // CHECK: [[CS]] = !{i32 8, i32 8, i32 1}
 // CHECK: @entry2, !"entry2", null, null, [[PROPS]]
 
-
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {
 }
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry2( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/CodeGenHLSL/lib_entries.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_entries.hlsl
@@ -59,6 +59,7 @@
 
 void StoreCSOutput(uint2 tid, uint2 gid);
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void cs_main( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/CodeGenHLSL/lib_global2.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_global2.hlsl
@@ -5,6 +5,7 @@ float2x2 MatRotate(float2x2 m, uint x, uint y);
 
 RWStructuredBuffer<float2x2> fA;
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
+++ b/tools/clang/test/CodeGenHLSL/lib_res_bound1.hlsl
@@ -8,6 +8,7 @@ RWByteAddressBuffer b : register(u0);
 
 float Extern(uint dtid);
 
+[shader("compute")]
 [numthreads(31, 1, 1)]
 void main(uint dtid : SV_DispatchThreadId)
 {

--- a/tools/clang/test/DXILValidation/atomics.hlsl
+++ b/tools/clang/test/DXILValidation/atomics.hlsl
@@ -30,6 +30,7 @@ void init(out uint i); // To force an alloca pointer to use with atomic op
 void init(out uint i) {i = 0;}
 #endif
 
+[shader("compute")]
 [numthreads(1,1,1)]
 void main(uint ix : SV_GroupIndex) {
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
@@ -121,6 +121,7 @@ RWBuffer< int > g_Intensities : register(u1);
 
 groupshared Foo sharedData;
 
+[shader("compute")]
 [ numthreads( 64, 2, 2 ) ]
 void main( uint GI : SV_GroupIndex)
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib.hlsl
@@ -22,6 +22,7 @@ static float x = ID + 3;
 // TODO: support array.
 //  static Buffer<float> g_bufs[2] = {ResourceDescriptorHeap[ID+2], ResourceDescriptorHeap[ID+3]};
 
+[shader("compute")]
 [NumThreads(1, 1, 1)]
 [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED), RootConstants(num32BitConstants=1, b0)")]
 void csmain(uint ix : SV_GroupIndex)
@@ -33,6 +34,7 @@ export float foo(uint i) {
   return x + i;
 }
 
+[shader("compute")]
 [NumThreads(1, 1, 1)]
 [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED), RootConstants(num32BitConstants=1, b0)")]
 void csmain2(uint ix : SV_GroupIndex)

--- a/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/createHandleFromHeap/dynamic_res_global_for_lib2.hlsl
@@ -25,6 +25,7 @@ static float x = ID + 3;
 // TODO: support array.
 //  static Buffer<float> g_bufs[2] = {ResourceDescriptorHeap[ID+2], ResourceDescriptorHeap[ID+3]};
 
+[shader("compute")]
 [NumThreads(1, 1, 1)]
 [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED), RootConstants(num32BitConstants=1, b0)")]
 void csmain(uint ix : SV_GroupIndex)
@@ -36,6 +37,7 @@ export float foo(uint i) {
   return x + i;
 }
 
+[shader("compute")]
 [NumThreads(1, 1, 1)]
 [RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED | SAMPLER_HEAP_DIRECTLY_INDEXED), RootConstants(num32BitConstants=1, b0)")]
 void csmain2(uint ix : SV_GroupIndex)

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/vector/VectorIndexingAsArgument.hlsl
@@ -21,7 +21,7 @@ groupshared uint2 gs_Dims;
 
 void foo(uint i, out uint, out uint, out uint);
 
-
+[shader("compute")]
 [numthreads(1,1,1)]
 void main() {
   uint iMips = (uint)(0);

--- a/tools/clang/test/HLSLFileCheck/passes/llvm/mem2reg/undef_phi.hlsl
+++ b/tools/clang/test/HLSLFileCheck/passes/llvm/mem2reg/undef_phi.hlsl
@@ -9,6 +9,7 @@ int c;
 float a;
 
 RWBuffer<float> buf;
+[shader("compute")]
 [numthreads(8,8,1)]
 void main() {
 

--- a/tools/clang/test/HLSLFileCheck/pix/GlobalBackedGlobalStaticEmbeddedArrays_NoDbgValue.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/GlobalBackedGlobalStaticEmbeddedArrays_NoDbgValue.hlsl
@@ -26,6 +26,7 @@ struct GlobalStruct {
 
 static GlobalStruct globalStruct;
 
+[shader("compute")]
 [numthreads(1, 1, 1)] void main() {
   float Accumulator;
   globalStruct.IntArray[0] = floatRWUAV[0];

--- a/tools/clang/test/HLSLFileCheck/pix/GlobalBackedGlobalStaticEmbeddedArrays_WithDbgValue.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/GlobalBackedGlobalStaticEmbeddedArrays_WithDbgValue.hlsl
@@ -26,7 +26,9 @@ struct GlobalStruct {
 
 static GlobalStruct globalStruct;
 
-[numthreads(1, 1, 1)] void main() {
+[shader("compute")]
+[numthreads(1, 1, 1)]
+void main() {
   globalStruct.IntArray[0] = floatRWUAV[0];
   globalStruct.IntArray[1] = floatRWUAV[1];
   globalStruct.FloatArray[0] = floatRWUAV[2];

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry.hlsl
@@ -23,6 +23,7 @@ void StoreOutputMat(float2x2  m, uint gidx);
 float2x2 LoadInputMat(uint x, uint y);
 float2x2 RotateMat(float2x2 m, uint x, uint y);
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry2.hlsl
@@ -2,11 +2,13 @@
 
 // CHECK: redefinition of entry
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {
 }
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_cs_entry3.hlsl
@@ -13,12 +13,13 @@
 // CHECK: [[CS]] = !{i32 8, i32 8, i32 1}
 // CHECK: @entry2, !"entry2", null, null, [[PROPS]]
 
-
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {
 }
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void entry2( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_entries.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_entries.hlsl
@@ -59,6 +59,7 @@
 
 void StoreCSOutput(uint2 tid, uint2 gid);
 
+[shader("compute")]
 [numthreads(8,8,1)]
 void cs_main( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
 {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param.hlsl
@@ -24,6 +24,7 @@ T2 resStruct(T t, uint2 id);
 RWByteAddressBuffer outputBuffer;
 RWByteAddressBuffer outputBuffer2;
 
+[shader("compute")]
 [numthreads(8, 8, 1)]
 void main( uint2 id : SV_DispatchThreadID )
 {

--- a/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param_x.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/library/lib_res_param_x.hlsl
@@ -32,6 +32,7 @@ T2 resStruct(T t, uint2 id);
 RWByteAddressBuffer outputBuffer;
 RWByteAddressBuffer outputBuffer2;
 
+[shader("compute")]
 [numthreads(8, 8, 1)]
 void main( uint2 id : SV_DispatchThreadID )
 {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3931,6 +3931,7 @@ TEST_F(CompilerTest, LibGVStore) {
       RWByteAddressBuffer outputBuffer;
       RWByteAddressBuffer outputBuffer2;
 
+      [shader("compute")]
       [numthreads(8, 8, 1)]
       void main( uint2 id : SV_DispatchThreadID )
       {

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -2664,6 +2664,7 @@ void fn()
     floatRWUAV[0] = Accumulator + globalStruct.IntArray[0] + globalStruct.IntArray[1];
 }
 
+[shader("compute")]
 [numthreads(1, 1, 1)]
 void main()
 {
@@ -2756,6 +2757,7 @@ struct GlobalStruct
 };
 
 static GlobalStruct globalStruct;
+[shader("compute")]
 [numthreads(1, 1, 1)]
 void main()
 {


### PR DESCRIPTION
The team has come to a decision that no inferences should be made on function declarations that have a numthreads attribute (specifically, inferences on whether or not the function represents a shader, or a compute shader, even). 
However, some tests exist that were written with the expectation that they would be treated as a compute shader, and they lack the compute shader attribute. This PR addresses the problem by correctly adding the compute shader attribute to the function declarations in these tests. The PR is necessary so that these tests won't fail when the inference behavior is removed. 
Fixes #5623