### PR TITLE
Require validator ver 1.7 for link without version

### DIFF
--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -934,7 +934,8 @@ TEST_F(LinkerTest, RunLinkWithTempReg) {
   CComPtr<IDxcBlob> pTempRegLib;
   AssembleLib(L"..\\HLSLFileCheck\\dxil\\linker\\TempReg.ll", &pTempRegLib);
   CComPtr<IDxcBlob> pEntryLib;
-  CompileLib(L"..\\HLSLFileCheck\\dxil\\linker\\use-TempReg.hlsl", &pEntryLib, {}, L"lib_6_3");
+  CompileLib(L"..\\HLSLFileCheck\\dxil\\linker\\use-TempReg.hlsl", &pEntryLib,
+             {L"-validator-version", L"1.7"}, L"lib_6_3");
   CComPtr<IDxcLinker> pLinker;
   CreateLinker(&pLinker);
   LPCWSTR libName = L"entry";


### PR DESCRIPTION
The container builder determines whether to include the version in the compiled shader library depending on the validator version. If the version is below 1.8, it won't include it and any linking is allowed. If it is 1.8 or above, the version will prevent linking with a non-versioned compile.

RunLinkWithTempReg assembled one library shader and compiled another. As such, one had a version and the other didn't. By forcing the compile to use an earlier validator version, the link is again allowed

Followup to #5378