### PR TITLE
Make select_sampler handle different opcodes

### DIFF
--- a/tools/clang/test/CodeGenDXIL/operators/select/select_samplers.hlsl
+++ b/tools/clang/test/CodeGenDXIL/operators/select/select_samplers.hlsl
@@ -43,11 +43,11 @@ float4 main(int2 i : I, float4 pos : POS, float cmp :CMP) : SV_Target {
   // CHECK-NOT: br
   // CHECK: [[gSS1B:%[0-9]*]] = load %struct.SamplerState, %struct.SamplerState* @"\01?gSS1@@3USamplerState@@A"
   // CHECK: [[gSS1CHB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerState)"(i32 0, %struct.SamplerState [[gSS1B]])
-  // CHECK: [[gSS1CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 11, %dx.types.Handle [[gSS1CHB]]
+  // CHECK: [[gSS1CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSS1CHB]]
 
   // CHECK: [[gSS2B:%[0-9]*]] = load %struct.SamplerState, %struct.SamplerState* @"\01?gSS2@@3USamplerState@@A"
   // CHECK: [[gSS2CHB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerState)"(i32 0, %struct.SamplerState [[gSS2B]])
-  // CHECK: [[gSS2CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 11, %dx.types.Handle [[gSS2CHB]]
+  // CHECK: [[gSS2CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSS2CHB]]
 
   // CHECK: call %dx.types.Handle @"dx.hl.op..%dx.types.Handle (i32, i1, %dx.types.Handle, %dx.types.Handle)"(i32 {{[0-9]*}}, i1 %{{[0-9a-zA-Z_]*}}, %dx.types.Handle [[gSS1CAB]], %dx.types.Handle [[gSS2CAB]])
 
@@ -55,11 +55,11 @@ float4 main(int2 i : I, float4 pos : POS, float cmp :CMP) : SV_Target {
 
   // CHECK: [[gSCS1B:%[0-9]*]] = load %struct.SamplerComparisonState, %struct.SamplerComparisonState* @"\01?gSCS1@@3USamplerComparisonState@@A"
   // CHECK: [[gSCS1CHB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerComparisonState)"(i32 0, %struct.SamplerComparisonState [[gSCS1B]])
-  // CHECK: [[gSCS1CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 11, %dx.types.Handle [[gSCS1CHB]]
+  // CHECK: [[gSCS1CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSCS1CHB]]
 
   // CHECK: [[gSCS2B:%[0-9]*]] = load %struct.SamplerComparisonState, %struct.SamplerComparisonState* @"\01?gSCS2@@3USamplerComparisonState@@A"
   // CHECK: [[gSCS2CHB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerComparisonState)"(i32 0, %struct.SamplerComparisonState [[gSCS2B]])
-  // CHECK: [[gSCS2CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 11, %dx.types.Handle [[gSCS2CHB]]
+  // CHECK: [[gSCS2CAB:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSCS2CHB]]
 
   // CHECK: call %dx.types.Handle @"dx.hl.op..%dx.types.Handle (i32, i1, %dx.types.Handle, %dx.types.Handle)"(i32 {{[0-9]*}}, i1 %{{[0-9a-zA-Z_]*}}, %dx.types.Handle [[gSCS1CAB]], %dx.types.Handle [[gSCS2CAB]])
 
@@ -91,11 +91,11 @@ float4 main(int2 i : I, float4 pos : POS, float cmp :CMP) : SV_Target {
   // CHECK-NOT: br
   // CHECK: [[gSS2D:%[0-9]*]] = load %struct.SamplerState, %struct.SamplerState* @"\01?gSS2@@3USamplerState@@A"
   // CHECK: [[gSS2CHD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerState)"(i32 0, %struct.SamplerState [[gSS2D]])
-  // CHECK: [[gSS2CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 11, %dx.types.Handle [[gSS2CHD]]
+  // CHECK: [[gSS2CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSS2CHD]]
 
   // CHECK: [[lSS0D:%[0-9]*]] = load %struct.SamplerState, %struct.SamplerState* %lSS1
   // CHECK: [[lSS0CHD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerState)"(i32 0, %struct.SamplerState [[lSS0D]])
-  // CHECK: [[lSS0CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 11, %dx.types.Handle [[lSS0CHD]]
+  // CHECK: [[lSS0CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerState)"(i32 {{[0-9]*}}, %dx.types.Handle [[lSS0CHD]]
 
   // CHECK: call %dx.types.Handle @"dx.hl.op..%dx.types.Handle (i32, i1, %dx.types.Handle, %dx.types.Handle)"(i32 {{[0-9]*}}, i1 %{{[0-9a-zA-Z_]*}}, %dx.types.Handle [[gSS2CAD]], %dx.types.Handle [[lSS0CAD]])
 
@@ -103,11 +103,11 @@ float4 main(int2 i : I, float4 pos : POS, float cmp :CMP) : SV_Target {
 
   // CHECK: [[gSCS2D:%[0-9]*]] = load %struct.SamplerComparisonState, %struct.SamplerComparisonState* @"\01?gSCS2@@3USamplerComparisonState@@A"
   // CHECK: [[gSCS2CHD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerComparisonState)"(i32 0, %struct.SamplerComparisonState [[gSCS2D]])
-  // CHECK: [[gSCS2CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 11, %dx.types.Handle [[gSCS2CHD]]
+  // CHECK: [[gSCS2CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 {{[0-9]*}}, %dx.types.Handle [[gSCS2CHD]]
 
   // CHECK: [[lSCS0D:%[0-9]*]] = load %struct.SamplerComparisonState, %struct.SamplerComparisonState* %lSCS1
   // CHECK: [[lSCS0CHD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %struct.SamplerComparisonState)"(i32 0, %struct.SamplerComparisonState [[lSCS0D]])
-  // CHECK: [[lSCS0CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 11, %dx.types.Handle [[lSCS0CHD]]
+  // CHECK: [[lSCS0CAD:%[0-9]*]] = call %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %struct.SamplerComparisonState)"(i32 {{[0-9]*}}, %dx.types.Handle [[lSCS0CHD]]
 
   // CHECK: call %dx.types.Handle @"dx.hl.op..%dx.types.Handle (i32, i1, %dx.types.Handle, %dx.types.Handle)"(i32 {{[0-9]*}}, i1 %{{[0-9a-zA-Z_]*}}, %dx.types.Handle [[gSCS2CAD]], %dx.types.Handle [[lSCS0CAD]])
   lSCS1 = select(getCond(i.y), gSCS2, lSCS1);


### PR DESCRIPTION
The opcode is variable at this stage, so it shouldn't be explicit. This just replaces the CHECK lines with regex for those integers

Followon to #5525