### PR TITLE
[NFC] Fix most egregious clang-format missteps

### DIFF
--- a/include/dxc/DxilContainer/DxilContainerReader.h
+++ b/include/dxc/DxilContainer/DxilContainerReader.h
@@ -5,7 +5,7 @@
 // This file is distributed under the University of Illinois Open Source     //
 // License. See LICENSE.TXT for details.                                     //
 //                                                                           //
-// Helper class for reading from dxil container.                                  //
+// Helper class for reading from dxil container.                             //
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -22,20 +22,23 @@ namespace hlsl {
 
   struct DxilContainerHeader;
 
-  //=================================================================================================================================
+  //============================================================================
   // DxilContainerReader
   //
   // Parse a DXIL or DXBC Container that you provide as input.
   //
   // Basic usage:
   // (1) Call Load()
-  // (2) Call various Get*() commands to retrieve information about the container such as 
-  //     how many blobs are in it, the hash of the container, the version #, and most importantly
-  //     retrieve all of the Blobs.  You can retrieve blobs by searching for the FourCC, or
-  //     enumerate through all of them.  Multiple blobs can even have the same FourCC, if you choose to 
-  //     create the DXBC that way, and this parser will let you discover all of them.
-  // (3) You can parse a new container by calling Load() again, or just get rid of the class.
-  // 
+  // (2) Call various Get*() commands to retrieve information about the
+  //     container such as how many blobs are in it, the hash of the container,
+  //     the version #, and most importantly retrieve all of the Blobs.  You can
+  //     retrieve blobs by searching for the FourCC, or enumerate through all of
+  //     them.  Multiple blobs can even have the same FourCC, if you choose to
+  //     create the DXBC that way, and this parser will let you discover all of
+  //     them.
+  // (3) You can parse a new container by calling Load() again, or just get rid
+  //     of the class.
+  //
   class DxilContainerReader
   {
   public:

--- a/include/dxc/DxilContainer/RDAT_Macros.inl
+++ b/include/dxc/DxilContainer/RDAT_Macros.inl
@@ -18,19 +18,39 @@
 // and code.
 // While some of associated macros sets are not defined in this file, these
 // definitions allow custom paths in the type definition files in certain cases.
-#define DEF_RDAT_DEFAULTS 1             // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define empty macros for anything not already defined
-#define DEF_RDAT_TYPES_BASIC_STRUCT 2   // DEF_RDAT_TYPES - define structs with basic types, matching RDAT format
-#define DEF_RDAT_TYPES_USE_HELPERS 3    // DEF_RDAT_TYPES - define structs using helpers, matching RDAT format
-#define DEF_RDAT_DUMP_DECL 4            // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump declarations
-#define DEF_RDAT_DUMP_IMPL 5            // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump implementation
-#define DEF_RDAT_TYPES_USE_POINTERS 6   // DEF_RDAT_TYPES - define deserialized version using pointers instead of offsets
-#define DEF_RDAT_ENUM_CLASS 7           // DEF_RDAT_ENUMS - declare enums with enum class
-#define DEF_RDAT_TRAITS 8               // DEF_RDAT_TYPES - define type traits
-#define DEF_RDAT_TYPES_FORWARD_DECL 9   // DEF_RDAT_TYPES - forward declare type struct/class
-#define DEF_RDAT_READER_DECL 10         // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
-#define DEF_RDAT_READER_IMPL 11         // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
-#define DEF_RDAT_STRUCT_VALIDATION 13   // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define structural validation
+
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define empty macros for anything not
+// already defined
+#define DEF_RDAT_DEFAULTS 1
+// DEF_RDAT_TYPES - define structs with basic types, matching RDAT format
+#define DEF_RDAT_TYPES_BASIC_STRUCT 2
+// DEF_RDAT_TYPES - define structs using helpers, matching RDAT format
+#define DEF_RDAT_TYPES_USE_HELPERS 3
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump declarations
+#define DEF_RDAT_DUMP_DECL 4
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write dump implementation
+#define DEF_RDAT_DUMP_IMPL 5
+// DEF_RDAT_TYPES - define deserialized version using pointers instead of
+// offsets
+#define DEF_RDAT_TYPES_USE_POINTERS 6
+// DEF_RDAT_ENUMS - declare enums with enum class
+#define DEF_RDAT_ENUM_CLASS 7
+// DEF_RDAT_TYPES - define type traits
+#define DEF_RDAT_TRAITS 8
+// DEF_RDAT_TYPES - forward declare type struct/class
+#define DEF_RDAT_TYPES_FORWARD_DECL 9
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
+#define DEF_RDAT_READER_DECL 10
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - write reader classes
+#define DEF_RDAT_READER_IMPL 11
+// DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define structural validation
+#define DEF_RDAT_STRUCT_VALIDATION 13
+
 // PRERELEASE-TODO: deeper validation for DxilValidation (limiting enum values and other such things)
+
+// clang-format off
+#define CLOSE_COMPOUND_DECL };
+// clang-format on
 
 #define GLUE2(a, b) a##b
 #define GLUE(a, b) GLUE2(a, b)
@@ -48,9 +68,9 @@
   #define RDAT_STRUCT(type)                   struct type {
   #define RDAT_STRUCT_DERIVED(type, base)     \
     struct type : public base {
-  #define RDAT_STRUCT_END()                   };
+  #define RDAT_STRUCT_END()                   CLOSE_COMPOUND_DECL
   #define RDAT_UNION()                        union {
-  #define RDAT_UNION_END()                    };
+  #define RDAT_UNION_END()                    CLOSE_COMPOUND_DECL
   #define RDAT_RECORD_REF(type, name)         uint32_t name;
   #define RDAT_RECORD_ARRAY_REF(type, name)   uint32_t name;
   #define RDAT_RECORD_VALUE(type, name)       type name;
@@ -67,9 +87,9 @@
 
   #define RDAT_STRUCT(type)                   struct type {
   #define RDAT_STRUCT_DERIVED(type, base)     struct type : public base {
-  #define RDAT_STRUCT_END()                   };
+  #define RDAT_STRUCT_END()                   CLOSE_COMPOUND_DECL
   #define RDAT_UNION()                        union {
-  #define RDAT_UNION_END()                    };
+  #define RDAT_UNION_END()                    CLOSE_COMPOUND_DECL
   #define RDAT_RECORD_REF(type, name)         RecordRef<type> name;
   #define RDAT_RECORD_ARRAY_REF(type, name)   RecordArrayRef<type> name;
   #define RDAT_RECORD_VALUE(type, name)       type name;
@@ -100,7 +120,7 @@
       type##_Reader(); \
       const RecordType *asRecord() const; \
       const RecordType *operator->() const { return asRecord(); }
-  #define RDAT_STRUCT_END() };
+  #define RDAT_STRUCT_END() CLOSE_COMPOUND_DECL
   #define RDAT_UNION_IF(name, expr)           bool has##name() const;
   #define RDAT_UNION_ELIF(name, expr)         RDAT_UNION_IF(name, expr)
   #define RDAT_RECORD_REF(type, name)         type##_Reader get##name() const;
@@ -304,7 +324,7 @@
   #define RDAT_ENUM_VALUE(name, value) name = value,
   #define RDAT_ENUM_VALUE_ALIAS(name, value) name = value,
   #define RDAT_ENUM_VALUE_NODEF(name) name,
-  #define RDAT_ENUM_END() };
+  #define RDAT_ENUM_END() CLOSE_COMPOUND_DECL
 
 #elif DEF_RDAT_ENUMS == DEF_RDAT_DUMP_DECL
 

--- a/include/dxc/HLSL/DxilSignatureAllocator.inl
+++ b/include/dxc/HLSL/DxilSignatureAllocator.inl
@@ -280,25 +280,31 @@ unsigned DxilSignatureAllocator::PackOptimized(std::vector<PackElement*> element
   unsigned rowsUsed = 0;
 
   // Clip/Cull needs special handling due to limitations unique to these.
-  //  Otherwise, packer could easily pack across too many registers in available gaps.
+  //  Otherwise, packer could easily pack across too many registers in available
+  //  gaps.
   // The rules are special/weird:
-  //  - for interpolation mode, clip must be linear or linearCentroid, while cull may be anything
+  //  - for interpolation mode, clip must be linear or linearCentroid, while
+  //    cull may be anything
   //  - both have a maximum of 8 components shared between them
-  //  - you can have a combined maximum of two registers declared with clip or cull SV's
+  //  - you can have a combined maximum of two registers declared with clip or
+  //    cull SV's
   // other SV rules still apply:
   //  - X no indexing allowed X - This rule has been changed to allow indexing
   //  - cannot come before arbitrary values in same register
   // Strategy for dealing with these with rows == 1 for all elements:
   //  - attempt to pack these into a two register allocator
-  //    - if this fails, some constraint is blocking, or declaration order is preventing good packing
-  //      for example: 2, 1, 2, 3 - total 8 components and packable, but if greedily packed, it will fail
-  //      Packing largest to smallest would solve this.
-  //  - track components used for each register and create temp elements for allocation tests
+  //    - if this fails, some constraint is blocking, or declaration order is
+  //      preventing good packing for example: 2, 1, 2, 3 - total 8 components
+  //      and packable, but if greedily packed, it will fail Packing largest to
+  //      smallest would solve this.
+  //  - track components used for each register and create temp elements for
+  //  allocation tests
   //  - iterate rows and look for a viable location for each temp element
   //    When found, allocate original sub-elements associated with temp element.
   // If one or more clip/cull elements have rows > 1:
-  //  - walk through each pair of adjacent rows, initializing a temp two-row allocator
-  //    with existing contents and trying to pack all elements into the remaining space.
+  //  - walk through each pair of adjacent rows, initializing a temp two-row
+  //    allocator with existing contents and trying to pack all elements into
+  //    the remaining space.
   //  - when successful, do real allocation into these rows.
 
   // Packing overview


### PR DESCRIPTION
This change fixes a few of the most awful clang-format missteps in the codebase. I'm not intending to fix all the things clang-format will do something bad with, just a few of the worst ones.

Further formatting fixups can be done after the clang-format change goes in.