### PR TITLE
Give more meaningful filecheck names

### DIFF
--- a/tools/clang/test/CodeGenSPIRV_Lit/binary-op.assign.image.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/binary-op.assign.image.hlsl
@@ -24,13 +24,13 @@ void main() {
 // CHECK:      [[buf_0:%[0-9]+]] = OpLoad %type_buffer_image_0 %MyRWBuffer4
 // CHECK-NEXT: [[old:%[0-9]+]] = OpImageRead %v4uint [[buf_0]] %uint_4 None
 // CHECK-NEXT: [[new:%[0-9]+]] = OpVectorShuffle %v4uint [[old]] [[c25]] 6 1 4 5
-// CHECK-NEXT: [[buf_0_0:%[0-9]+]] = OpLoad %type_buffer_image_0 %MyRWBuffer4
-// CHECK-NEXT:                OpImageWrite [[buf_0_0]] %uint_4 [[new]]
+// CHECK-NEXT: [[buf_1:%[0-9]+]] = OpLoad %type_buffer_image_0 %MyRWBuffer4
+// CHECK-NEXT:                OpImageWrite [[buf_1]] %uint_4 [[new]]
     MyRWBuffer4[4].zwx = 25;
 
     // Swizzling resulting in the original vector
-// CHECK:      [[buf_0_0_0:%[0-9]+]] = OpLoad %type_buffer_image_0 %MyRWBuffer4
-// CHECK-NEXT:                OpImageWrite [[buf_0_0_0]] %uint_4 [[c26]]
+// CHECK:      [[buf_2:%[0-9]+]] = OpLoad %type_buffer_image_0 %MyRWBuffer4
+// CHECK-NEXT:                OpImageWrite [[buf_2]] %uint_4 [[c26]]
     MyRWBuffer4[4].xyzw = 26;
 
     // Selecting one element
@@ -38,32 +38,32 @@ void main() {
 // CHECK-NEXT: [[old_0:%[0-9]+]] = OpImageRead %v4uint [[tex_0]] {{%[0-9]+}} None
 // CHECK-NEXT:  [[v3:%[0-9]+]] = OpVectorShuffle %v3uint [[old_0]] [[old_0]] 0 1 2
 // CHECK-NEXT: [[new_0:%[0-9]+]] = OpCompositeInsert %v3uint %uint_27 [[v3]] 1
-// CHECK-NEXT: [[tex_0_0:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
-// CHECK-NEXT:                OpImageWrite [[tex_0_0]] {{%[0-9]+}} [[new_0]]
+// CHECK-NEXT: [[tex_1:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
+// CHECK-NEXT:                OpImageWrite [[tex_1]] {{%[0-9]+}} [[new_0]]
     MyRWTexture3[uint3(5, 6, 7)].y = 27;
 
     // In-order swizzling
-// CHECK:      [[tex_0_0_0:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
-// CHECK-NEXT: [[old_0_0:%[0-9]+]] = OpImageRead %v4uint [[tex_0_0_0]] {{%[0-9]+}} None
-// CHECK-NEXT:  [[v3_0:%[0-9]+]] = OpVectorShuffle %v3uint [[old_0_0]] [[old_0_0]] 0 1 2
-// CHECK-NEXT: [[new_0_0:%[0-9]+]] = OpVectorShuffle %v3uint [[v3_0]] [[c28]] 3 4 2
-// CHECK-NEXT: [[tex_0_0_0_0:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
-// CHECK-NEXT:                OpImageWrite [[tex_0_0_0_0]] {{%[0-9]+}} [[new_0_0]]
+// CHECK:      [[tex_2:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
+// CHECK-NEXT: [[old_1:%[0-9]+]] = OpImageRead %v4uint [[tex_2]] {{%[0-9]+}} None
+// CHECK-NEXT:  [[v3_0:%[0-9]+]] = OpVectorShuffle %v3uint [[old_1]] [[old_1]] 0 1 2
+// CHECK-NEXT: [[new_1:%[0-9]+]] = OpVectorShuffle %v3uint [[v3_0]] [[c28]] 3 4 2
+// CHECK-NEXT: [[tex_3:%[0-9]+]] = OpLoad %type_3d_image %MyRWTexture3
+// CHECK-NEXT:                OpImageWrite [[tex_3]] {{%[0-9]+}} [[new_1]]
     MyRWTexture3[uint3(8, 9, 10)].xy = 28;
 
-// CHECK:      [[buf_0_0_0_0:%[0-9]+]] = OpLoad %type_buffer_image %MyRWBuffer
-// CHECK-NEXT: [[old_0_0_0:%[0-9]+]] = OpImageRead %v4uint [[buf_0_0_0_0]] %uint_11 None
-// CHECK-NEXT: [[val:%[0-9]+]] = OpCompositeExtract %uint [[old_0_0_0]] 0
+// CHECK:      [[buf_3:%[0-9]+]] = OpLoad %type_buffer_image %MyRWBuffer
+// CHECK-NEXT: [[old_2:%[0-9]+]] = OpImageRead %v4uint [[buf_3]] %uint_11 None
+// CHECK-NEXT: [[val:%[0-9]+]] = OpCompositeExtract %uint [[old_2]] 0
 // CHECK-NEXT: [[add:%[0-9]+]] = OpIAdd %uint [[val]] %uint_30
-// CHECK-NEXT: [[buf_0_0_0_0_0:%[0-9]+]] = OpLoad %type_buffer_image %MyRWBuffer
-// CHECK-NEXT:                OpImageWrite [[buf_0_0_0_0_0]] %uint_11 [[add]]
+// CHECK-NEXT: [[buf_4:%[0-9]+]] = OpLoad %type_buffer_image %MyRWBuffer
+// CHECK-NEXT:                OpImageWrite [[buf_4]] %uint_11 [[add]]
     MyRWBuffer[11] += 30;
 
-// CHECK:      [[tex_0_0_0_0_0:%[0-9]+]] = OpLoad %type_2d_image %MyRWTexture
-// CHECK-NEXT: [[old_0_0_0_0:%[0-9]+]] = OpImageRead %v4int [[tex_0_0_0_0_0]] {{%[0-9]+}} None
-// CHECK-NEXT: [[val_0:%[0-9]+]] = OpCompositeExtract %int [[old_0_0_0_0]] 0
+// CHECK:      [[tex_4:%[0-9]+]] = OpLoad %type_2d_image %MyRWTexture
+// CHECK-NEXT: [[old_3:%[0-9]+]] = OpImageRead %v4int [[tex_4]] {{%[0-9]+}} None
+// CHECK-NEXT: [[val_0:%[0-9]+]] = OpCompositeExtract %int [[old_3]] 0
 // CHECK-NEXT: [[mul:%[0-9]+]] = OpIMul %int [[val_0]] %int_31
-// CHECK-NEXT: [[tex_0_0_0_0_0_0:%[0-9]+]] = OpLoad %type_2d_image %MyRWTexture
-// CHECK-NEXT:                OpImageWrite [[tex_0_0_0_0_0_0]] {{%[0-9]+}} [[mul]]
+// CHECK-NEXT: [[tex_5:%[0-9]+]] = OpLoad %type_2d_image %MyRWTexture
+// CHECK-NEXT:                OpImageWrite [[tex_5]] {{%[0-9]+}} [[mul]]
     MyRWTexture[uint2(12, 13)] *= 31;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise-assign.shift-left.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise-assign.shift-left.hlsl
@@ -24,22 +24,22 @@ void main() {
     d <<= e;
 
 // CHECK:        [[h:%[0-9]+]] = OpLoad %v3long %h
-// CHECK:      [[rhs_0_0:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
-// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%[0-9]+}} [[rhs_0_0]]
+// CHECK:      [[rhs_1:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%[0-9]+}} [[rhs_1]]
     g <<= h;
 
 // CHECK:        [[k:%[0-9]+]] = OpLoad %ulong %k
-// CHECK:      [[rhs_0_0_0:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
-// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%[0-9]+}} [[rhs_0_0_0]]
+// CHECK:      [[rhs_2:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%[0-9]+}} [[rhs_2]]
     j <<= k;
 
 // CHECK:        [[n:%[0-9]+]] = OpLoad %short %n
-// CHECK:      [[rhs_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
-// CHECK-NEXT:                OpShiftLeftLogical %short {{%[0-9]+}} [[rhs_0_0_0_0]]
+// CHECK:      [[rhs_3:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
+// CHECK-NEXT:                OpShiftLeftLogical %short {{%[0-9]+}} [[rhs_3]]
     m <<= n;
 
 // CHECK:        [[q:%[0-9]+]] = OpLoad %v4ushort %q
-// CHECK:      [[rhs_0_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
-// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%[0-9]+}} [[rhs_0_0_0_0_0]]
+// CHECK:      [[rhs_4:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%[0-9]+}} [[rhs_4]]
     p <<= q;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise-assign.shift-right.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise-assign.shift-right.hlsl
@@ -24,22 +24,22 @@ void main() {
     d >>= e;
 
 // CHECK:        [[h:%[0-9]+]] = OpLoad %v3long %h
-// CHECK:      [[rhs_0_0:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
-// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%[0-9]+}} [[rhs_0_0]]
+// CHECK:      [[rhs_1:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%[0-9]+}} [[rhs_1]]
     g >>= h;
 
 // CHECK:        [[k:%[0-9]+]] = OpLoad %ulong %k
-// CHECK:      [[rhs_0_0_0:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
-// CHECK-NEXT:                OpShiftRightLogical %ulong {{%[0-9]+}} [[rhs_0_0_0]]
+// CHECK:      [[rhs_2:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftRightLogical %ulong {{%[0-9]+}} [[rhs_2]]
     j >>= k;
 
 // CHECK:        [[n:%[0-9]+]] = OpLoad %short %n
-// CHECK:      [[rhs_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
-// CHECK-NEXT:                OpShiftRightArithmetic %short {{%[0-9]+}} [[rhs_0_0_0_0]]
+// CHECK:      [[rhs_3:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
+// CHECK-NEXT:                OpShiftRightArithmetic %short {{%[0-9]+}} [[rhs_3]]
     m >>= n;
 
 // CHECK:        [[q:%[0-9]+]] = OpLoad %v4ushort %q
-// CHECK:      [[rhs_0_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
-// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%[0-9]+}} [[rhs_0_0_0_0_0]]
+// CHECK:      [[rhs_4:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%[0-9]+}} [[rhs_4]]
     p >>= q;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise.shift-left.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise.shift-left.hlsl
@@ -24,22 +24,22 @@ void main() {
     f = d << e;
 
 // CHECK:        [[h:%[0-9]+]] = OpLoad %v3long %h
-// CHECK-NEXT: [[rhs_0_0:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
-// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%[0-9]+}} [[rhs_0_0]]
+// CHECK-NEXT: [[rhs_1:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftLeftLogical %v3long {{%[0-9]+}} [[rhs_1]]
     i = g << h;
 
 // CHECK:        [[k:%[0-9]+]] = OpLoad %ulong %k
-// CHECK-NEXT: [[rhs_0_0_0:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
-// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%[0-9]+}} [[rhs_0_0_0]]
+// CHECK-NEXT: [[rhs_2:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftLeftLogical %ulong {{%[0-9]+}} [[rhs_2]]
     l = j << k;
 
 // CHECK:        [[n:%[0-9]+]] = OpLoad %short %n
-// CHECK-NEXT: [[rhs_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
-// CHECK-NEXT:                OpShiftLeftLogical %short {{%[0-9]+}} [[rhs_0_0_0_0]]
+// CHECK-NEXT: [[rhs_3:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
+// CHECK-NEXT:                OpShiftLeftLogical %short {{%[0-9]+}} [[rhs_3]]
     o = m << n;
 
 // CHECK:        [[q:%[0-9]+]] = OpLoad %v4ushort %q
-// CHECK-NEXT: [[rhs_0_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
-// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%[0-9]+}} [[rhs_0_0_0_0_0]]
+// CHECK-NEXT: [[rhs_4:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftLeftLogical %v4ushort {{%[0-9]+}} [[rhs_4]]
     r = p << q;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise.shift-right.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/binary-op.bitwise.shift-right.hlsl
@@ -24,22 +24,22 @@ void main() {
     f = d >> e;
 
 // CHECK:        [[h:%[0-9]+]] = OpLoad %v3long %h
-// CHECK-NEXT: [[rhs_0_0:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
-// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%[0-9]+}} [[rhs_0_0]]
+// CHECK-NEXT: [[rhs_1:%[0-9]+]] = OpBitwiseAnd %v3long [[h]] [[v3c63]]
+// CHECK-NEXT:                OpShiftRightArithmetic %v3long {{%[0-9]+}} [[rhs_1]]
     i = g >> h;
 
 // CHECK:        [[k:%[0-9]+]] = OpLoad %ulong %k
-// CHECK-NEXT: [[rhs_0_0_0:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
-// CHECK-NEXT:                OpShiftRightLogical %ulong {{%[0-9]+}} [[rhs_0_0_0]]
+// CHECK-NEXT: [[rhs_2:%[0-9]+]] = OpBitwiseAnd %ulong [[k]] %ulong_63
+// CHECK-NEXT:                OpShiftRightLogical %ulong {{%[0-9]+}} [[rhs_2]]
     l = j >> k;
 
 // CHECK:        [[n:%[0-9]+]] = OpLoad %short %n
-// CHECK-NEXT: [[rhs_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
-// CHECK-NEXT:                OpShiftRightArithmetic %short {{%[0-9]+}} [[rhs_0_0_0_0]]
+// CHECK-NEXT: [[rhs_3:%[0-9]+]] = OpBitwiseAnd %short [[n]] %short_15
+// CHECK-NEXT:                OpShiftRightArithmetic %short {{%[0-9]+}} [[rhs_3]]
     o = m >> n;
 
 // CHECK:        [[q:%[0-9]+]] = OpLoad %v4ushort %q
-// CHECK-NEXT: [[rhs_0_0_0_0_0:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
-// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%[0-9]+}} [[rhs_0_0_0_0_0]]
+// CHECK-NEXT: [[rhs_4:%[0-9]+]] = OpBitwiseAnd %v4ushort [[q]] [[v4c15]]
+// CHECK-NEXT:                OpShiftRightLogical %v4ushort {{%[0-9]+}} [[rhs_4]]
     r = p >> q;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/rich.debug.scope.after.compound.statement.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/rich.debug.scope.after.compound.statement.hlsl
@@ -33,11 +33,11 @@ VS_OUTPUT main(float4 pos : POSITION,
       x += a + b + c;
     }
 //CHECK:      DebugScope [[bb1]]
-//CHECK-NEXT: OpLine [[file_0_0:%[0-9]+]] 37
+//CHECK-NEXT: OpLine [[file_1:%[0-9]+]] 37
     x += a + b + c;
   }
 //CHECK:      DebugScope [[bb0]]
-//CHECK-NEXT: OpLine [[file_0_0_0:%[0-9]+]] 41
+//CHECK-NEXT: OpLine [[file_2:%[0-9]+]] 41
   x += a + b + c;
 
   VS_OUTPUT vout;

--- a/tools/clang/test/CodeGenSPIRV_Lit/shader.debug.line.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/shader.debug.line.composite.hlsl
@@ -71,8 +71,8 @@ void main() {
 // CHECK:                   DebugLine [[src]] %uint_76 %uint_76 %uint_3 %uint_3
 // CHECK-NEXT: [[z:%[0-9]+]] = OpLoad %type_2d_image %z
 // CHECK-NEXT: [[z_0:%[0-9]+]] = OpImageRead %v4int [[z]] {{%[0-9]+}} None
-// CHECK-NEXT: [[z_0_0:%[0-9]+]] = OpVectorShuffle %v3int [[z_0]] [[z_0]] 0 1 2
-// CHECK:        {{%[0-9]+}} = OpCompositeInsert %v3int %int_16 [[z_0_0]] 0
+// CHECK-NEXT: [[z_1:%[0-9]+]] = OpVectorShuffle %v3int [[z_0]] [[z_0]] 0 1 2
+// CHECK:        {{%[0-9]+}} = OpCompositeInsert %v3int %int_16 [[z_1]] 0
   z[uint2(2, 3)].x = 16;
 
 // CHECK:      DebugLine [[src]] %uint_82 %uint_82 %uint_3 %uint_4

--- a/tools/clang/test/CodeGenSPIRV_Lit/shader.debug.line.intrinsic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/shader.debug.line.intrinsic.hlsl
@@ -82,8 +82,8 @@ void main() {
 // CHECK:                     DebugLine [[src]] %uint_87 %uint_87 %uint_35 %uint_47
 // CHECK-NEXT: [[idx:%[0-9]+]] = OpIAdd %uint
 // CHECK:                     DebugLine [[src]] %uint_87 %uint_87 %uint_3 %uint_48
-// CHECK-NEXT: [[v4i_0_0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %v4i %int_0
-// CHECK-NEXT:                OpStore [[v4i_0_0]] {{%[0-9]+}}
+// CHECK-NEXT: [[v4i_1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %v4i %int_0
+// CHECK-NEXT:                OpStore [[v4i_1]] {{%[0-9]+}}
   v4i.x = NonUniformResourceIndex(v4i.y + v4i.z);
 
 // CHECK:      DebugLine [[src]] %uint_93 %uint_93 %uint_11 %uint_39

--- a/tools/clang/test/CodeGenSPIRV_Lit/spirv.debug.opline.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spirv.debug.opline.composite.hlsl
@@ -71,8 +71,8 @@ void main() {
 // CHECK:                   OpLine [[file]] 76 3
 // CHECK-NEXT: [[z:%[0-9]+]] = OpLoad %type_2d_image %z
 // CHECK-NEXT: [[z_0:%[0-9]+]] = OpImageRead %v4int [[z]] {{%[0-9]+}} None
-// CHECK-NEXT: [[z_0_0:%[0-9]+]] = OpVectorShuffle %v3int [[z_0]] [[z_0]] 0 1 2
-// CHECK-NEXT:   {{%[0-9]+}} = OpCompositeInsert %v3int %int_16 [[z_0_0]] 0
+// CHECK-NEXT: [[z_1:%[0-9]+]] = OpVectorShuffle %v3int [[z_0]] [[z_0]] 0 1 2
+// CHECK-NEXT:   {{%[0-9]+}} = OpCompositeInsert %v3int %int_16 [[z_1]] 0
   z[uint2(2, 3)].x = 16;
 
 // CHECK:      OpLine [[file]] 82 3

--- a/tools/clang/test/CodeGenSPIRV_Lit/spirv.debug.opline.intrinsic.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spirv.debug.opline.intrinsic.hlsl
@@ -82,8 +82,8 @@ void main() {
 // CHECK:                     OpLine [[file]] 87 41
 // CHECK-NEXT: [[idx:%[0-9]+]] = OpIAdd %uint
 // CHECK:                     OpLine [[file]] 87 3
-// CHECK-NEXT: [[v4i_0_0:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %v4i %int_0
-// CHECK-NEXT:                OpStore [[v4i_0_0]] {{%[0-9]+}}
+// CHECK-NEXT: [[v4i_1:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %v4i %int_0
+// CHECK-NEXT:                OpStore [[v4i_1]] {{%[0-9]+}}
   v4i.x = NonUniformResourceIndex(v4i.y + v4i.z);
 
 // CHECK:      OpLine [[file]] 93 11

--- a/tools/clang/test/CodeGenSPIRV_Lit/var.init.matrix.mxn.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/var.init.matrix.mxn.hlsl
@@ -265,29 +265,29 @@ void main() {
     int4x4 imat11 = {imat8, imat9, imat10};
 
     // Boolean matrices
-// CHECK:      [[cc00_0_0:%[0-9]+]] = OpCompositeConstruct %v3bool %false %true %false
-// CHECK-NEXT: [[cc01_0_0:%[0-9]+]] = OpCompositeConstruct %v3bool %true %true %false
-// CHECK-NEXT: [[cc02_0_0:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[cc00_0_0]] [[cc01_0_0]]
-// CHECK-NEXT:                 OpStore %bmat1 [[cc02_0_0]]
+// CHECK:      [[cc00_1:%[0-9]+]] = OpCompositeConstruct %v3bool %false %true %false
+// CHECK-NEXT: [[cc01_1:%[0-9]+]] = OpCompositeConstruct %v3bool %true %true %false
+// CHECK-NEXT: [[cc02_1:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[cc00_1]] [[cc01_1]]
+// CHECK-NEXT:                 OpStore %bmat1 [[cc02_1]]
     bool2x3 bmat1 = bool2x3(false, true, false, true, true, false);
     // All elements in a single {}
-// CHECK-NEXT: [[cc03_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
-// CHECK-NEXT: [[cc04_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
-// CHECK-NEXT: [[cc05_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %true %false
-// CHECK-NEXT: [[cc06_0_0:%[0-9]+]] = OpCompositeConstruct %_arr_v2bool_uint_3 [[cc03_0_0]] [[cc04_0_0]] [[cc05_0_0]]
-// CHECK-NEXT:                 OpStore %bmat2 [[cc06_0_0]]
+// CHECK-NEXT: [[cc03_1:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
+// CHECK-NEXT: [[cc04_1:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
+// CHECK-NEXT: [[cc05_1:%[0-9]+]] = OpCompositeConstruct %v2bool %true %false
+// CHECK-NEXT: [[cc06_1:%[0-9]+]] = OpCompositeConstruct %_arr_v2bool_uint_3 [[cc03_1]] [[cc04_1]] [[cc05_1]]
+// CHECK-NEXT:                 OpStore %bmat2 [[cc06_1]]
     bool3x2 bmat2 = {false, true, false, true, true, false};
     // Each vector has its own {}
-// CHECK-NEXT: [[cc07_0_0:%[0-9]+]] = OpCompositeConstruct %v3bool %false %true %false
-// CHECK-NEXT: [[cc08_0_0:%[0-9]+]] = OpCompositeConstruct %v3bool %true %true %false
-// CHECK-NEXT: [[cc09_0_0:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[cc07_0_0]] [[cc08_0_0]]
-// CHECK-NEXT:                 OpStore %bmat3 [[cc09_0_0]]
+// CHECK-NEXT: [[cc07_1:%[0-9]+]] = OpCompositeConstruct %v3bool %false %true %false
+// CHECK-NEXT: [[cc08_1:%[0-9]+]] = OpCompositeConstruct %v3bool %true %true %false
+// CHECK-NEXT: [[cc09_1:%[0-9]+]] = OpCompositeConstruct %_arr_v3bool_uint_2 [[cc07_1]] [[cc08_1]]
+// CHECK-NEXT:                 OpStore %bmat3 [[cc09_1]]
     bool2x3 bmat3 = {{false, true, false}, {true, true, false}};
     // Wired & complicated {}s
-// CHECK-NEXT: [[cc10_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
-// CHECK-NEXT: [[cc11_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
-// CHECK-NEXT: [[cc12_0_0:%[0-9]+]] = OpCompositeConstruct %v2bool %true %false
-// CHECK-NEXT: [[cc13_0_0:%[0-9]+]] = OpCompositeConstruct %_arr_v2bool_uint_3 [[cc10_0_0]] [[cc11_0_0]] [[cc12_0_0]]
-// CHECK-NEXT:                 OpStore %bmat4 [[cc13_0_0]]
+// CHECK-NEXT: [[cc10_1:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
+// CHECK-NEXT: [[cc11_1:%[0-9]+]] = OpCompositeConstruct %v2bool %false %true
+// CHECK-NEXT: [[cc12_1:%[0-9]+]] = OpCompositeConstruct %v2bool %true %false
+// CHECK-NEXT: [[cc13_1:%[0-9]+]] = OpCompositeConstruct %_arr_v2bool_uint_3 [[cc10_1]] [[cc11_1]] [[cc12_1]]
+// CHECK-NEXT:                 OpStore %bmat4 [[cc13_1]]
     bool3x2 bmat4 = {{false}, {true, false}, true, {{true}, {{false}}}};
 }


### PR DESCRIPTION
Some of the names for the variables in the filecheck tests append a
series of 0s to distinguish them. That is not very readable, so this
commit replaces them with <name>_<number of zeros - 1>. That is `c_0_0`
becomes `c_1` and `p_0_0_0_0` becomes `p_3`.
