### PR TITLE
[SPIR-V] Add fragment interlock extension by default

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -43,6 +43,7 @@ enum class Extension {
   EXT_descriptor_indexing,
   EXT_fragment_fully_covered,
   EXT_fragment_invocation_density,
+  EXT_fragment_shader_interlock,
   EXT_mesh_shader,
   EXT_shader_stencil_export,
   EXT_shader_viewport_index_layer,

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -23,6 +23,17 @@ void CapabilityVisitor::addExtension(Extension ext, llvm::StringRef target,
     spvBuilder.requireExtension(featureManager.getExtensionName(ext), loc);
 }
 
+void CapabilityVisitor::addExtensionAndCapabilitiesIfEnabled(
+    Extension ext, llvm::ArrayRef<spv::Capability> capabilities) {
+  if (featureManager.isExtensionEnabled(ext)) {
+    addExtension(ext, "", {});
+
+    for (auto cap : capabilities) {
+      addCapability(cap);
+    }
+  }
+}
+
 void CapabilityVisitor::addCapability(spv::Capability cap, SourceLocation loc) {
   if (cap != spv::Capability::Max) {
     spvBuilder.requireCapability(cap, loc);
@@ -869,6 +880,14 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
   // supports only some capabilities. This list should be expanded to match the
   // supported capabilities.
   addCapability(spv::Capability::MinLod);
+
+  addExtensionAndCapabilitiesIfEnabled(
+      Extension::EXT_fragment_shader_interlock,
+      {
+          spv::Capability::FragmentShaderSampleInterlockEXT,
+          spv::Capability::FragmentShaderPixelInterlockEXT,
+          spv::Capability::FragmentShaderShadingRateInterlockEXT,
+      });
   return true;
 }
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.h
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.h
@@ -64,6 +64,11 @@ private:
   /// the given extension to the SPIR-V module in memory.
   void addExtension(Extension ext, llvm::StringRef target, SourceLocation loc);
 
+  /// Checks that the given extension is enabled based on command line arguments
+  /// before calling addExtension and addCapability.
+  void addExtensionAndCapabilitiesIfEnabled(
+      Extension ext, llvm::ArrayRef<spv::Capability> capabilities);
+
   /// Checks that the given capability is a valid capability. And if so,
   /// utilizes the SpirvBuilder to add the given capability to the SPIR-V module
   /// in memory.

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -172,6 +172,8 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
             Extension::EXT_fragment_fully_covered)
       .Case("SPV_EXT_fragment_invocation_density",
             Extension::EXT_fragment_invocation_density)
+      .Case("SPV_EXT_fragment_shader_interlock",
+            Extension::EXT_fragment_shader_interlock)
       .Case("SPV_EXT_mesh_shader", Extension::EXT_mesh_shader)
       .Case("SPV_EXT_shader_stencil_export",
             Extension::EXT_shader_stencil_export)
@@ -228,6 +230,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_EXT_fragment_fully_covered";
   case Extension::EXT_fragment_invocation_density:
     return "SPV_EXT_fragment_invocation_density";
+  case Extension::EXT_fragment_shader_interlock:
+    return "SPV_EXT_fragment_shader_interlock";
   case Extension::EXT_mesh_shader:
     return "SPV_EXT_mesh_shader";
   case Extension::EXT_shader_stencil_export:

--- a/tools/clang/test/CodeGenSPIRV_Lit/capability.trimmed.o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/capability.trimmed.o3.hlsl
@@ -5,6 +5,13 @@ SamplerState gSampler : register(s2);
 
 // CHECK-NOT: OpCapability MinLod
 
+// CHECK-NOT: OpExtension "SPV_EXT_fragment_shader_interlock"
+// CHECK-NOT: OpCapability FragmentShaderSampleInterlockEXT
+// CHECK-NOT: OpCapability FragmentShaderPixelInterlockEXT
+// CHECK-NOT: OpCapability FragmentShaderShadingRateInterlockEXT
+
+// CHECK-NOT: OpExtension "SPV_EXT_fragment_shader_interlock"
+
 float4 main(uint clamp : A) : SV_Target {
     if (clamp < 0) {
       return t.Sample(gSampler, 0.5f, 2, float(clamp));

--- a/tools/clang/test/CodeGenSPIRV_Lit/capability.untrimmed.fcgl.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/capability.untrimmed.fcgl.hlsl
@@ -8,5 +8,10 @@
 // event if unused.
 
 // CHECK: OpCapability MinLod
+// CHECK: OpCapability FragmentShaderSampleInterlockEXT
+// CHECK: OpCapability FragmentShaderPixelInterlockEXT
+// CHECK: OpCapability FragmentShaderShadingRateInterlockEXT
+
+// CHECK: OpExtension "SPV_EXT_fragment_shader_interlock"
 [numthreads(1, 1, 1)]
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/capability.untrimmed.o0.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/capability.untrimmed.o0.hlsl
@@ -5,6 +5,13 @@ SamplerState gSampler : register(s2);
 
 // CHECK: OpCapability MinLod
 
+// TODO: add a rasterizer order view and check that these are not trimmed
+//       once ROVs are supported
+// CHECK-NOT: OpCapability FragmentShaderSampleInterlockEXT
+// CHECK-NOT: OpCapability FragmentShaderPixelInterlockEXT
+// CHECK-NOT: OpCapability FragmentShaderShadingRateInterlockEXT
+
+// CHECK-NOT: OpExtension "SPV_EXT_fragment_shader_interlock"
 float4 main(uint clamp : A) : SV_Target {
     if (clamp < 0) {
       return t.Sample(gSampler, 0.5f, 2, float(clamp));


### PR DESCRIPTION
Adds the extension `SPV_EXT_fragment_shader_interlock` and the related capabilities

- `spv::Capability::FragmentShaderSampleInterlockEXT`
- `spv::Capability::FragmentShaderPixelInterlockEXT`
- `spv::Capability::FragmentShaderShadingRateInterlockEXT`

to every shader by default, and let the `spirv-opt` capability trimming pass remove them if unnecessary.