### PR TITLE
Fix Appveyor whole file test test paths

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,9 +47,9 @@ test_script:
 - ps:  utils\appveyor\appveyor_test.ps1
 - cmd: call utils\hct\hcttest -rel clang
 - sh: ./bin/dxc --help
-- sh: ./bin/dxc -T ps_6_0 ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
-- sh: ./bin/dxc -T ps_6_0 -Fo passthru-ps.dxil ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv
-- sh: ./bin/dxc -T ps_6_0 -Fo passthru-ps.spv ../tools/clang/test/CodeGenSPIRV/passthru-ps.hlsl2spv -spirv
+- sh: ./bin/dxc -T ps_6_0 ../tools/clang/test/CodeGenSPIRV_Lit/passthru-ps.hlsl2spv
+- sh: ./bin/dxc -T ps_6_0 -Fo passthru-ps.dxil ../tools/clang/test/CodeGenSPIRV_Lit/passthru-ps.hlsl2spv
+- sh: ./bin/dxc -T ps_6_0 -Fo passthru-ps.spv ../tools/clang/test/CodeGenSPIRV_Lit/passthru-ps.hlsl2spv -spirv
 - sh: ./tools/clang/unittests/SPIRV/ClangSPIRVTests --spirv-test-root ../tools/clang/test/CodeGenSPIRV/
 - sh: ./tools/clang/unittests/HLSL/ClangHLSLTests --HlslDataDir $PWD/../tools/clang/test/HLSL/
 


### PR DESCRIPTION
The whole file passthru tests were moved in #5634, so this change fixes up their paths in the appveyor test script.