### PR TITLE
[lit] Enable exec test by default for hcttest

### DIFF
--- a/tools/clang/test/CMakeLists.txt
+++ b/tools/clang/test/CMakeLists.txt
@@ -89,7 +89,7 @@ add_lit_testsuite(check-clang "Running the Clang regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   #LIT ${LLVM_LIT}
   PARAMS ${CLANG_TEST_PARAMS}
-    skip_taef_exec=True
+    skip_taef_exec=False
   DEPENDS ${CLANG_TEST_DEPS}
   ARGS ${CLANG_TEST_EXTRA_ARGS}
   )

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -313,7 +313,7 @@ if "%TEST_USE_LIT%"=="1" (
     set RES_DXILCONV=!RES_CLANG!
     rem check exec.
     if defined EXEC_ADAPTER (
-        echo The -adapter parameter is supported only when running just execution tests (hcttest.cmd exec)
+        echo "The -adapter parameter is supported only when running just execution tests (hcttest.cmd exec)"
       )
     set RES_EXEC=!ERRORLEVEL!
   ) else (

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -313,7 +313,7 @@ if "%TEST_USE_LIT%"=="1" (
     set RES_DXILCONV=!RES_CLANG!
     rem check exec.
     if defined EXEC_ADAPTER (
-        echo "The -adapter parameter is supported only when running just execution tests (hcttest.cmd exec)"
+        echo The -adapter parameter is supported only when running just execution tests ^(hcttest.cmd exec^)
       )
     set RES_EXEC=!ERRORLEVEL!
   ) else (

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -313,7 +313,7 @@ if "%TEST_USE_LIT%"=="1" (
     set RES_DXILCONV=!RES_CLANG!
     rem check exec.
     if defined EXEC_ADAPTER (
-        echo -adapter is not support when running all tests.
+        echo The -adapter parameter is supported only when running just execution tests (hcttest.cmd exec)
       )
     set RES_EXEC=!ERRORLEVEL!
   ) else (

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -311,6 +311,13 @@ if "%TEST_USE_LIT%"=="1" (
     cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-all
     set RES_CLANG=!ERRORLEVEL!
     set RES_DXILCONV=!RES_CLANG!
+    rem check exec.
+    if defined EXEC_ADAPTER (
+        py %HLSL_SRC_DIR%/utils/lit/lit.py -v --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
+      ) else (
+        cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang-taef-exec
+	  )
+    set RES_EXEC=!ERRORLEVEL!
   ) else (
     if "%TEST_DXILCONV%"=="1" (
       cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-dxilconv

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -314,9 +314,7 @@ if "%TEST_USE_LIT%"=="1" (
     rem check exec.
     if defined EXEC_ADAPTER (
         py %HLSL_SRC_DIR%/utils/lit/lit.py -v --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
-      ) else (
-        cmake --build %HLSL_BLD_DIR% --config %BUILD_CONFIG% --target check-clang-taef-exec
-	  )
+      )
     set RES_EXEC=!ERRORLEVEL!
   ) else (
     if "%TEST_DXILCONV%"=="1" (

--- a/utils/hct/hcttest.cmd
+++ b/utils/hct/hcttest.cmd
@@ -313,7 +313,7 @@ if "%TEST_USE_LIT%"=="1" (
     set RES_DXILCONV=!RES_CLANG!
     rem check exec.
     if defined EXEC_ADAPTER (
-        py %HLSL_SRC_DIR%/utils/lit/lit.py -v --no-progress-bar --param build_mode=%BUILD_CONFIG% --param clang_site_config=%HLSL_BLD_DIR%/tools/clang/test/lit.site.cfg --param clang_taef_exec_site_config=%HLSL_BLD_DIR%/tools/clang/test/taef_exec/lit.site.cfg %EXEC_ADAPTER% %HLSL_SRC_DIR%/tools/clang/test/taef_exec
+        echo -adapter is not support when running all tests.
       )
     set RES_EXEC=!ERRORLEVEL!
   ) else (


### PR DESCRIPTION
Enable exec test for hcttest -all.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/5551