### PR TITLE
[SPIR-V] Evaluate alignment argument for RawBufferLoad

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
@@ -34,5 +34,11 @@ float4 main() : SV_Target0 {
   // CHECK-NEXT: OpStore %v [[load]]
   uint v = vk::RawBufferLoad(Address);
 
+  // CHECK:      [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_uint
+  // CHECK-NEXT: [[load:%\d+]] = OpLoad %uint [[buf]] Aligned 8
+  // CHECK-NEXT: OpStore %c [[load]]
+  const int alignment = 8;
+  uint c = vk::RawBufferLoad(Address, alignment);
+
   return float4(w.x, x, y, z);
 }


### PR DESCRIPTION
This fixes a separate segfault I encountered when looking at #5638.