### PR TITLE
[SPIRV] Evaluate RawBuffer alignment argument

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13747,60 +13747,37 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
                                 /*isInstr*/ true, expr->getExprLoc());
 }
 
-uint32_t SpirvEmitter::getAlignmentForRawBufferLoad(const CallExpr *callExpr) {
-  if (callExpr->getNumArgs() == 1)
-    return 4;
-
-  if (callExpr->getNumArgs() > 2) {
-    emitError("number of arguments for vk::RawBufferLoad() must be 1 or 2",
-              callExpr->getExprLoc());
-    return 0;
-  }
-
-  const Expr *alignmentArgExpr = callExpr->getArg(1);
+uint32_t SpirvEmitter::getRawBufferAlignment(const Expr *expr) {
   if (const auto *templateParmExpr =
-          dyn_cast<SubstNonTypeTemplateParmExpr>(alignmentArgExpr)) {
-    alignmentArgExpr = templateParmExpr->getReplacement();
-  }
-  const auto *intLiteral =
-      dyn_cast<IntegerLiteral>(alignmentArgExpr->IgnoreImplicit());
-  if (intLiteral == nullptr) {
-    emitError("alignment argument of vk::RawBufferLoad() must be a constant "
-              "integer",
-              callExpr->getArg(1)->getExprLoc());
-    return 0;
-  }
-  return static_cast<uint32_t>(intLiteral->getValue().getZExtValue());
-}
-
-uint32_t SpirvEmitter::getAlignmentForRawBufferStore(const CallExpr *callExpr) {
-  if (callExpr->getNumArgs() == 2)
-    return 4;
-
-  if (callExpr->getNumArgs() != 2 && callExpr->getNumArgs() != 3) {
-    emitError("number of arguments for vk::RawBufferStore() must be 2 or 3",
-              callExpr->getExprLoc());
-    return 0;
+          dyn_cast<SubstNonTypeTemplateParmExpr>(expr)) {
+    expr = templateParmExpr->getReplacement();
   }
 
-  const Expr *alignmentArgExpr = callExpr->getArg(2);
-  if (const auto *templateParmExpr =
-          dyn_cast<SubstNonTypeTemplateParmExpr>(alignmentArgExpr)) {
-    alignmentArgExpr = templateParmExpr->getReplacement();
+  const auto *intLiteral = dyn_cast<IntegerLiteral>(expr->IgnoreImplicit());
+  if (intLiteral != nullptr && intLiteral->getValue().isNonNegative())
+    return static_cast<uint32_t>(intLiteral->getValue().getZExtValue());
+
+  llvm::APSInt value;
+  if (expr->EvaluateAsInt(value, astContext) && value.isNonNegative()) {
+    return static_cast<uint32_t>(value.getZExtValue());
   }
-  const auto *intLiteral =
-      dyn_cast<IntegerLiteral>(alignmentArgExpr->IgnoreImplicit());
-  if (intLiteral == nullptr) {
-    emitError("alignment argument of vk::RawBufferStore() must be a constant "
-              "integer",
-              callExpr->getArg(2)->getExprLoc());
-    return 0;
-  }
-  return static_cast<uint32_t>(intLiteral->getValue().getZExtValue());
+
+  // Unable to determine a valid alignment at compile time
+  emitError("alignment argument must be a constant unsigned integer",
+            expr->getExprLoc());
+  return 0;
 }
 
 SpirvInstruction *SpirvEmitter::processRawBufferLoad(const CallExpr *callExpr) {
-  uint32_t alignment = getAlignmentForRawBufferLoad(callExpr);
+  if (callExpr->getNumArgs() > 2) {
+    emitError("number of arguments for vk::RawBufferLoad() must be 1 or 2",
+              callExpr->getExprLoc());
+    return nullptr;
+  }
+
+  uint32_t alignment = callExpr->getNumArgs() == 1
+                           ? 4
+                           : getRawBufferAlignment(callExpr->getArg(1));
   if (alignment == 0)
     return nullptr;
 
@@ -13893,7 +13870,15 @@ SpirvEmitter::storeDataToRawAddress(SpirvInstruction *addressInUInt64,
 
 SpirvInstruction *
 SpirvEmitter::processRawBufferStore(const CallExpr *callExpr) {
-  uint32_t alignment = getAlignmentForRawBufferStore(callExpr);
+  if (callExpr->getNumArgs() != 2 && callExpr->getNumArgs() != 3) {
+    emitError("number of arguments for vk::RawBufferStore() must be 2 or 3",
+              callExpr->getExprLoc());
+    return nullptr;
+  }
+
+  uint32_t alignment = callExpr->getNumArgs() == 2
+                           ? 4
+                           : getRawBufferAlignment(callExpr->getArg(2));
   if (alignment == 0)
     return nullptr;
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13748,15 +13748,6 @@ SpirvEmitter::processSpvIntrinsicCallExpr(const CallExpr *expr) {
 }
 
 uint32_t SpirvEmitter::getRawBufferAlignment(const Expr *expr) {
-  if (const auto *templateParmExpr =
-          dyn_cast<SubstNonTypeTemplateParmExpr>(expr)) {
-    expr = templateParmExpr->getReplacement();
-  }
-
-  const auto *intLiteral = dyn_cast<IntegerLiteral>(expr->IgnoreImplicit());
-  if (intLiteral != nullptr && intLiteral->getValue().isNonNegative())
-    return static_cast<uint32_t>(intLiteral->getValue().getZExtValue());
-
   llvm::APSInt value;
   if (expr->EvaluateAsInt(value, astContext) && value.isNonNegative()) {
     return static_cast<uint32_t>(value.getZExtValue());

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -704,11 +704,9 @@ private:
                                           SourceLocation loc,
                                           SourceRange range);
 
-  /// Returns the alignment of `vk::RawBufferLoad()`.
-  uint32_t getAlignmentForRawBufferLoad(const CallExpr *callExpr);
-
-  /// Returns the alignment of `vk::RawBufferStore()`.
-  uint32_t getAlignmentForRawBufferStore(const CallExpr *callExpr);
+  /// Returns the value of the alignment argument for `vk::RawBufferLoad()` and
+  /// `vk::RawBufferStore()`.
+  uint32_t getRawBufferAlignment(const Expr *expr);
 
   /// Process vk::ext_execution_mode intrinsic
   SpirvInstruction *processIntrinsicExecutionMode(const CallExpr *expr,

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.vkrawbufferload.hlsl
@@ -34,5 +34,12 @@ float4 main() : SV_Target0 {
   // CHECK-NEXT: OpStore %v [[load]]
   uint v = vk::RawBufferLoad(Address);
 
+  // CHECK:      [[addr:%\d+]] = OpLoad %ulong
+  // CHECK-NEXT: [[buf:%\d+]] = OpBitcast %_ptr_PhysicalStorageBuffer_float [[addr]]
+  // CHECK-NEXT: [[load:%\d+]] = OpLoad %float [[buf]] Aligned 4
+  // CHECK-NEXT: OpStore %u [[load]]
+  const uint alignment = 4;
+  float u = vk::RawBufferLoad<float>(Address, alignment);
+
   return float4(w.x, x, y, z);
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.vkrawbufferload.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.vkrawbufferload.error.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T ps_6_0 -E main -fcgl -spirv %s -spirv 2>&1 | FileCheck %s
+
+// CHECK: error: alignment argument must be a constant unsigned integer
+
+uint64_t Address;
+float4 main() : SV_Target0 {
+  float4 x = vk::RawBufferLoad<float4>(Address, -16);
+
+  return x;
+}


### PR DESCRIPTION
Before this change, the alignment argument needed to be an integer literal to be evaluated correctly at compile time. This change now makes a reasonable attempts to evaluate it if it is a constant value.

Fixes #4594