### PR TITLE
DXC Tests: Filter out unsupported test, add verbose option and improve output (#5537)

### DIFF
--- a/test/Analysis/Delinearization/lit.local.cfg
+++ b/test/Analysis/Delinearization/lit.local.cfg
@@ -1,1 +1,2 @@
-config.suffixes = ['.ll']
+# HLSL Change - Hide these lit suites.
+#config.suffixes = ['.ll']

--- a/test/Analysis/Lint/lit.local.cfg
+++ b/test/Analysis/Lint/lit.local.cfg
@@ -1,1 +1,2 @@
-config.suffixes = ['.ll']
+# HLSL Change - Hide these lit suites.
+#config.suffixes = ['.ll']

--- a/test/Bitcode/lit.local.cfg
+++ b/test/Bitcode/lit.local.cfg
@@ -1,4 +1,5 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []
 
 # Failing Tests (3):
 #     LLVM :: Bitcode/highLevelStructure.3.2.ll

--- a/test/MC/Markup/lit.local.cfg
+++ b/test/MC/Markup/lit.local.cfg
@@ -1,2 +1,2 @@
-config.suffixes = ['.mc']
-
+# HLSL Change - Hide these lit suites.
+#config.suffixes = ['.mc']

--- a/test/MC/lit.local.cfg
+++ b/test/MC/lit.local.cfg
@@ -1,1 +1,2 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []

--- a/test/Object/lit.local.cfg
+++ b/test/Object/lit.local.cfg
@@ -1,2 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.test', '.ll', '.s', '.yaml']
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+#config.suffixes = ['.test', '.ll', '.s', '.yaml']
+config.suffixes = []

--- a/test/Other/lit.local.cfg
+++ b/test/Other/lit.local.cfg
@@ -1,5 +1,5 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
-
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []
 # Failing Tests (8):
 #     LLVM :: Other/2007-04-24-eliminate-mostly-empty-blocks.ll
 #     LLVM :: Other/2010-05-06-Printer.ll

--- a/test/Transforms/EarlyCSE/AArch64/lit.local.cfg
+++ b/test/Transforms/EarlyCSE/AArch64/lit.local.cfg
@@ -1,4 +1,5 @@
-config.suffixes = ['.ll']
+# HLSL Change - Hide these lit suites.
+#config.suffixes = ['.ll']
 
 targets = set(config.root.targets_to_build.split())
 if not 'AArch64' in targets:

--- a/test/Transforms/SimplifyCFG/AArch64/lit.local.cfg
+++ b/test/Transforms/SimplifyCFG/AArch64/lit.local.cfg
@@ -1,4 +1,5 @@
-config.suffixes = ['.ll']
+# HLSL Change - Hide these lit suites.
+#config.suffixes = ['.ll']
 
 targets = set(config.root.targets_to_build.split())
 if not 'AArch64' in targets:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -41,7 +41,10 @@ config.test_format = lit.formats.ShTest(execute_external)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.
-config.suffixes = ['.ll', '.c', '.cxx', '.test', '.txt', '.s']
+# HLSL Change Start - use just a subset of LLVM tests
+config.suffixes = ['.txt', '.td', '.test']
+#config.suffixes = ['.ll', '.c', '.cxx', '.test', '.txt', '.s']
+# HLSL Change End - use just a subset of LLVM tests
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent

--- a/test/tools/lit.local.cfg
+++ b/test/tools/lit.local.cfg
@@ -1,0 +1,2 @@
+# HLSL Change - Hide these lit suites (except llvm-lit).
+config.suffixes = []

--- a/test/tools/llvm-cov/lit.local.cfg
+++ b/test/tools/llvm-cov/lit.local.cfg
@@ -1,2 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.test', '.m', '.cpp', '.c']
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []
+#config.suffixes = ['.test', '.m', '.cpp', '.c']

--- a/test/tools/llvm-lit/lit.local.cfg
+++ b/test/tools/llvm-lit/lit.local.cfg
@@ -1,0 +1,2 @@
+# HLSL Change - Enable LIT tool tests
+config.suffixes = ['.c']

--- a/test/tools/llvm-profdata/lit.local.cfg
+++ b/test/tools/llvm-profdata/lit.local.cfg
@@ -1,2 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes.add('.proftext')
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []
+#config.suffixes.add('.proftext')

--- a/tools/clang/test/CodeGenHLSL/lit.local.cfg
+++ b/tools/clang/test/CodeGenHLSL/lit.local.cfg
@@ -1,1 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+# HLSL Change - Hide files in CodeGenHLSL directory - they are tested by existing
+# TAEF tests (CompilerTest, DxilContainerTest, LinkerTest and  ValidationTest)
+config.suffixes = []

--- a/tools/clang/test/CodeGenSPIRV/lit.local.cfg
+++ b/tools/clang/test/CodeGenSPIRV/lit.local.cfg
@@ -1,1 +1,2 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.unsupported = True # HLSL Change - Disable and hide these lit suites.
+config.suffixes = []

--- a/tools/clang/test/DXILValidation/lit.local.cfg
+++ b/tools/clang/test/DXILValidation/lit.local.cfg
@@ -1,1 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+# HLSL Change - Hide files in DxilValidation directory - they are tested by existing
+# TAEF tests (DxilValidation)
+config.suffixes = []

--- a/tools/clang/test/Frontend/lit.local.cfg
+++ b/tools/clang/test/Frontend/lit.local.cfg
@@ -1,2 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']
+# HLSL Change - Hide these lit suites.
+config.suffixes = []
+#config.suffixes = ['.c', '.cpp', '.m', '.mm', '.ll']

--- a/tools/clang/test/HLSL/lit.local.cfg
+++ b/tools/clang/test/HLSL/lit.local.cfg
@@ -1,6 +1,3 @@
-import os
-
-config.unsupported = True # HLSL Change - Disable lit suites.
-
-# Add .hlsl as a test extension.
-config.suffixes.add('.hlsl')
+# HLSL Change - Hide files in HLSL directory - they are tested by existing
+# TAEF tests (RewriterTest, VerifierTest)
+config.suffixes = []

--- a/tools/clang/test/HLSLDisabled/lit.local.cfg
+++ b/tools/clang/test/HLSLDisabled/lit.local.cfg
@@ -1,1 +1,2 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+# HLSL Change - Hide files in HLSLDisabled
+config.suffixes = []

--- a/tools/clang/test/HLSLFileCheck/lit.local.cfg
+++ b/tools/clang/test/HLSLFileCheck/lit.local.cfg
@@ -1,1 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+# HLSL Change - Hide files in CodeGenHLSL directory - they are tested by existing
+# TAEF tests (CompilerTest, DxilContainerTest, LinkerTest)
+config.suffixes = []

--- a/tools/clang/test/Index/lit.local.cfg
+++ b/tools/clang/test/Index/lit.local.cfg
@@ -1,1 +1,2 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+# HLSL Change - Hide these lit suites.
+config.suffixes = []

--- a/tools/clang/test/Index/skip-parsed-bodies/lit.local.cfg
+++ b/tools/clang/test/Index/skip-parsed-bodies/lit.local.cfg
@@ -1,1 +1,3 @@
-config.suffixes = ['.json']
+# HLSL Change - Hide these lit suites.
+config.suffixes = []
+#config.suffixes = ['.json']

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -44,7 +44,10 @@ else:
 config.test_format = lit.formats.ShTest(execute_external)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.c', '.cpp', '.m', '.mm', '.cu', '.ll', '.cl', '.s', '.S', '.modulemap', '.hlsl', '.test']
+# HLSL Change start - look for just .hlsl, .ll and .test files
+config.suffixes = ['.ll', '.hlsl', '.test']
+#config.suffixes = ['.c', '.cpp', '.m', '.mm', '.cu', '.ll', '.cl', '.s', '.S', '.modulemap', '.hlsl', '.test']
+# HLSL Change end - look for just .hlsl, .ll and .test files
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent
@@ -356,7 +359,8 @@ for pattern in [r"\bFileCheck\b",
     tool_path = lit.util.which(tool_name, tool_dirs)
     if not tool_path:
         # Warn, but still provide a substitution.
-        lit_config.note('Did not find ' + tool_name + ' in ' + tool_dirs)
+        if lit_config.debug:
+            lit_config.note('Did not find ' + tool_name + ' in ' + tool_dirs)
         tool_path = clang_tools_dir + '/' + tool_name
     config.substitutions.append((pattern, tool_pipe + tool_path))
 

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -45,6 +45,7 @@ set SHOW_CMAKE_LOG=0
 set WINSDK_MIN_VERSION=10.0.17763.0
 set INSTALL_DIR=
 set DEFAULT_EXEC_ADAPTER=-DTAEF_EXEC_ADAPTER=
+set LIT_ARGS=
 
 :parse_args
 if "%1"=="" (
@@ -190,8 +191,12 @@ if "%1"=="-show-cmake-log" (
   shift /1 & goto :parse_args
 )
 if "%1"=="-lit-xml-output-path" (
-  set "CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_LIT_ARGS=--xunit-xml-output=%~2"
+  set "LIT_ARGS=%LIT_ARGS% --xunit-xml-output=%~2"
   shift /1
+  shift /1 & goto :parse_args
+)
+if "%1"=="-lit-verbose" (
+  set "LIT_ARGS=%LIT_ARGS% -v --no-progress-bar"
   shift /1 & goto :parse_args
 )
 if "%1"=="-default-adapter" (
@@ -333,6 +338,10 @@ set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_BUILD_EXAMPLES:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCLANG_CL:BOOL=OFF
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_SYSTEM_VERSION=%DXC_CMAKE_SYSTEM_VERSION%
 set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR%
+
+if "%LIT_ARGS%" NEQ "" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -DLLVM_LIT_ARGS="%LIT_ARGS%"
+)
 
 rem Setup taef exec adapter.
 set CMAKE_OPTS=%CMAKE_OPTS% %DEFAULT_EXEC_ADAPTER%


### PR DESCRIPTION
Improve output of DXC test runs:
- Add `-lit-verbose` option to `hctbuild` to setup lit test runs with verbose output (`hcttest` will list test names as they run)
- Hide tests that are never supported (there was over 10K of unsupported tests found by LIT discovery)
- Show warnings about non-essential tools only in LIT debug mode
- Skip over file copying and non-LIT part of `hcttest.cmd` if all requested tests have already been run
- CMD tests have been move under clang's lit tests; keep the `hcttest cmd` option for running cmd tests separately

Number of unsupported tests was reduced from 10452 to 1 if spir-v is enabled, 39 if not. The number of tests that run did not change.

(cherry picked from commit b503da7084b4200909d2a3b7dcfc18e8d2944eec)