### PR TITLE
Handle log10 with float16_t parameter

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11179,11 +11179,14 @@ SpirvEmitter::processIntrinsicLog10(const CallExpr *callExpr) {
   // 1 / log2(10) = 0.30103
   auto loc = callExpr->getExprLoc();
   auto range = callExpr->getSourceRange();
+
+  const auto returnType = callExpr->getType();
+  auto scalarType = getElementType(astContext, returnType);
+
   auto *scale =
-      spvBuilder.getConstantFloat(astContext.FloatTy, llvm::APFloat(0.30103f));
+      spvBuilder.getConstantFloat(scalarType, llvm::APFloat(0.30103f));
   auto *log2 = processIntrinsicUsingGLSLInst(
       callExpr, GLSLstd450::GLSLstd450Log2, true, loc, range);
-  const auto returnType = callExpr->getType();
   spv::Op scaleOp = isScalarType(returnType)   ? spv::Op::OpFMul
                     : isVectorType(returnType) ? spv::Op::OpVectorTimesScalar
                                                : spv::Op::OpMatrixTimesScalar;

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.log10.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.log10.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T vs_6_0 -E main
+// RUN: %dxc -T vs_6_2 -E main -enable-16bit-types
 
 // According to HLSL reference:
 // The 'log10' function can only operate on float, vector of float, and matrix of floats.
@@ -7,9 +7,10 @@
 // CHECK: %float_0_30103001 = OpConstant %float 0.30103001
 
 void main() {
-  float    a, log10_a;
-  float4   b, log10_b;
-  float2x3 c, log10_c;
+  float     a, log10_a;
+  float4    b, log10_b;
+  float2x3  c, log10_c;
+  float16_t d, log10_d;
 
 // CHECK:           [[a:%\d+]] = OpLoad %float %a
 // CHECK-NEXT: [[log2_a:%\d+]] = OpExtInst %float [[glsl]] Log2 [[a]]
@@ -32,4 +33,9 @@ void main() {
 // CHECK-NEXT:     [[log10_c:%\d+]] = OpMatrixTimesScalar %mat2v3float [[log2_c]] %float_0_30103
 // CHECK-NEXT:                        OpStore %log10_c [[log10_c]]
   log10_c = log10(c);
+  
+// CHECK:           [[d:%\d+]] = OpLoad %half %d
+// CHECK-NEXT: [[log2_d:%\d+]] = OpExtInst %half [[glsl]] Log2 [[d]]
+// CHECK-NEXT:[[log10_d:%\d+]] = OpFMul %half [[log2_d]] %half_0x1_344pn2
+  log10_d = log10(d);
 }


### PR DESCRIPTION
When the spirv backend sees the log10 intrinsic, it will generate a multiple with a constant. The type of that constant is hard coded to be a float. However, if the type of the parameter is not a float, there is a type mismatch on the multiple instruction.

This commit changes that so the type of the contanst matches the scalar type of the parameter. That is, it will be a type T if the parameter is type T, a vector of type T, or a matrix of type T.

Fixes #5608