### PR TITLE
spirv: validates parameters for InterlockedAddExch

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8875,7 +8875,9 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
                                        uint32_t outputArgIndex) {
     const auto outputArg = callExpr->getArg(outputArgIndex);
     if (dyn_cast<DeclRefExpr>(outputArg) == nullptr) {
-      emitError("InterlockedCompareExchange requires a reference as output parameter", outputArg->getExprLoc());
+      emitError(
+          "InterlockedCompareExchange requires a reference as output parameter",
+          outputArg->getExprLoc());
       return;
     }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8875,7 +8875,7 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
                                        uint32_t outputArgIndex) {
     const auto outputArg = callExpr->getArg(outputArgIndex);
     if (dyn_cast<DeclRefExpr>(outputArg) == nullptr) {
-      emitError("InterlockedCompareExchange requires a reference as output parameter.", outputArg->getExprLoc());
+      emitError("InterlockedCompareExchange requires a reference as output parameter", outputArg->getExprLoc());
       return;
     }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8874,6 +8874,11 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
                                        const CallExpr *callExpr,
                                        uint32_t outputArgIndex) {
     const auto outputArg = callExpr->getArg(outputArgIndex);
+    if (dyn_cast<DeclRefExpr>(outputArg) == nullptr) {
+      emitError("InterlockedCompareExchange requires a reference as output parameter.", outputArg->getExprLoc());
+      return;
+    }
+
     const auto outputArgType = outputArg->getType();
     if (baseType != outputArgType)
       toWrite =

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
@@ -1,0 +1,9 @@
+// RUN: not %dxc -T cs_6_6 -E main -fcgl -spirv %s 2>&1 | FileCheck %s
+
+groupshared uint value;
+
+[numthreads(1, 1, 1)]
+void main() {
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter.
+  InterlockedCompareExchange(value, 1, 2, 3);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
@@ -4,6 +4,6 @@ groupshared uint value;
 
 [numthreads(1, 1, 1)]
 void main() {
-// CHECK: error: InterlockedCompareExchange requires a reference as output parameter.
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
   InterlockedCompareExchange(value, 1, 2, 3);
 }


### PR DESCRIPTION
This function takes a reference as 4th parameter. This was not validated by the backend, meaning we'd generate invalid SPIR-V and fail validation.

This PR adds a check to emit a fatal error if an immediate is used.

Fixes #5647 