### PR TITLE
spirv: correctly choose ray_tracing/ray_query caps

### DIFF
--- a/tools/clang/lib/SPIRV/CapabilityVisitor.h
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.h
@@ -66,7 +66,8 @@ private:
 
   /// Checks that the given extension is enabled based on command line arguments
   /// before calling addExtension and addCapability.
-  void addExtensionAndCapabilitiesIfEnabled(
+  /// Returns `true` if the extension was enabled, `false` otherwise.
+  bool addExtensionAndCapabilitiesIfEnabled(
       Extension ext, llvm::ArrayRef<spv::Capability> capabilities);
 
   /// Checks that the given capability is a valid capability. And if so,

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.acceleration-structure.ray_query.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.acceleration-structure.ray_query.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -E main -T vs_6_5 -fspv-target-env=vulkan1.2 -fspv-extension=SPV_KHR_ray_query %s -spirv | FileCheck %s
+
+// CHECK-NOT: OpCapability RayTracingKHR
+// CHECK: OpCapability RayQueryKHR
+// CHECK: OpCapability Shader
+// CHECK-NEXT: OpExtension "SPV_KHR_ray_query"
+// CHECK-NOT: OpExtension "SPV_KHR_ray_tracing"
+
+RaytracingAccelerationStructure test_bvh;
+
+float main(RayDesc rayDesc : RAYDESC) : OUT {
+  RayQuery<RAY_FLAG_FORCE_OPAQUE|RAY_FLAG_SKIP_PROCEDURAL_PRIMITIVES> rayQuery1;
+  rayQuery1.TraceRayInline(test_bvh, 0, 1, rayDesc);
+  return 0;
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.acceleration-structure.ray_tracing.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.acceleration-structure.ray_tracing.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -E main -T lib_6_6 -fspv-target-env=vulkan1.2 -fspv-extension=SPV_KHR_ray_tracing  %s -spirv | FileCheck %s
+
+// CHECK-NOT: OpCapability RayQueryKHR
+// CHECK: OpCapability RayTracingKHR
+// CHECK-NEXT: OpExtension "SPV_KHR_ray_tracing"
+// CHECK-NOT: OpExtension "SPV_KHR_ray_query"
+
+RaytracingAccelerationStructure rs;
+
+struct Payload { float4 color; };
+struct Attribute { float2 bary; };
+
+[shader("closesthit")]
+void main(inout Payload MyPayload, in Attribute MyAttr) {
+
+  Payload myPayload = { float4(0.0f,0.0f,0.0f,0.0f) };
+  RayDesc rayDesc;
+  rayDesc.Origin = float3(0.0f, 0.0f, 0.0f);
+  rayDesc.Direction = float3(0.0f, 0.0f, -1.0f);
+  rayDesc.TMin = 0.0f;
+  rayDesc.TMax = 1000.0f;
+
+  TraceRay(rs, 0x0, 0xff, 0, 1, 0, rayDesc, myPayload);
+}


### PR DESCRIPTION
Both the ray_query and ray_tracing extensions brings new SPIRV types. But some hardware only support one type.

This decision cannot be taken by the trimming pass as both choices could be valid, instead, we should check what extension the user needed.

What can be removed however is the logic to emit the capability. This commit also does that.

Fixes #4385 