### PR TITLE
Pix: Shader debug speedup

### DIFF
--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -160,8 +160,6 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
         if (auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(&I))
             if (PixAllocaReg::FromInst(Alloca, &unused1, &unused2))
                 continue;
-        if (PixDxilReg::FromInst(&I, &unused1))
-            continue;
         if (!llvm::isa<llvm::DbgDeclareInst>(&I)) {
           pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, InstNum++);
           InstructionRangeEnd = InstNum;

--- a/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
+++ b/lib/DxilPIXPasses/DxilAnnotateWithVirtualRegister.cpp
@@ -133,11 +133,35 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
 
   auto instrumentableFunctions = PIXPassHelpers::GetAllInstrumentableFunctions(*m_DM);
 
-  for (auto * F : instrumentableFunctions) {
+  for (auto *F : instrumentableFunctions) {
+    for (auto &block : F->getBasicBlockList()) {
+      for (llvm::Instruction &I : block.getInstList()) {
+        AnnotateValues(&I);
+      }
+    }
+  }
+
+  for (auto *F : instrumentableFunctions) {
+    for (auto &block : F->getBasicBlockList()) {
+      for (llvm::Instruction &I : block.getInstList()) {
+        AnnotateStore(&I);
+      }
+    }
+  }
+
+  for (auto *F : instrumentableFunctions) {
     int InstructionRangeStart = InstNum;
     int InstructionRangeEnd = InstNum;
     for (auto &block : F->getBasicBlockList()) {
       for (llvm::Instruction &I : block.getInstList()) {
+        // If the instruction is part of the debug value instrumentation added by this pass, 
+        // it doesn't need to be instrumented for the PIX user.
+        uint32_t unused1, unused2;
+        if (auto *Alloca = llvm::dyn_cast<llvm::AllocaInst>(&I))
+            if (PixAllocaReg::FromInst(Alloca, &unused1, &unused2))
+                continue;
+        if (PixDxilReg::FromInst(&I, &unused1))
+            continue;
         if (!llvm::isa<llvm::DbgDeclareInst>(&I)) {
           pix_dxil::PixDxilInstNum::AddMD(M.getContext(), &I, InstNum++);
           InstructionRangeEnd = InstNum;
@@ -161,22 +185,6 @@ bool DxilAnnotateWithVirtualRegister::runOnModule(llvm::Module &M) {
     if (m_DM->GetShaderModel()->GetKind() == hlsl::ShaderModel::Kind::Library)
         *OSOverride << "\nIsLibrary\n";
     *OSOverride << "\nInstructionCount:" << InstNum << "\n";
-  }
-
-  for (auto * F : instrumentableFunctions) {
-    for (auto &block : F->getBasicBlockList()) {
-      for (llvm::Instruction &I : block.getInstList()) {
-        AnnotateValues(&I);
-      }
-    }
-  }
-
-  for (auto * F : instrumentableFunctions) {
-    for (auto &block : F->getBasicBlockList()) {
-      for (llvm::Instruction &I : block.getInstList()) {
-        AnnotateStore(&I);
-      }
-    }
   }
 
   m_DM = nullptr;

--- a/tools/clang/test/HLSLFileCheck/pix/AnnotateVirtualRegs-Raygen.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AnnotateVirtualRegs-Raygen.hlsl
@@ -21,17 +21,13 @@ void ENTRY()
     TraceRay(scene, 0 /*rayFlags*/, 0xFF /*rayMask*/, 0 /*sbtRecordOffset*/, 1 /*sbtRecordStride*/, 0 /*missIndex*/, ray, pld);
 }
 
-// CHECK: {{.*}} = alloca %struct.RayDesc, align 4, !pix-dxil-inst-num {{.*}}, !pix-alloca-reg [[RDAlloca:![0-9]+]]
-// CHECK: {{.*}} = alloca %struct.RayPayload, align 4, !pix-dxil-inst-num {{.*}}, !pix-alloca-reg [[RPAlloca:![0-9]+]]
-// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 0, !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[RDGEP:![0-9]+]]
-// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[NothGEP:![0-9]+]]
-// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 1, !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[RDGEP2:![0-9]+]]
-// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[NothGEP2:![0-9]+]]
-// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 2, !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[RDGEP3:![0-9]+]]
-// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-inst-num {{.*}}, !pix-dxil-reg [[NothGEP3:![0-9]+]]
+// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 0, !pix-dxil-reg [[RDGEP:![0-9]+]], !pix-dxil-inst-num {{.*}}
+// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-reg [[NothGEP:![0-9]+]], !pix-dxil-inst-num {{.*}}
+// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 1, !pix-dxil-reg [[RDGEP2:![0-9]+]], !pix-dxil-inst-num {{.*}}
+// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-reg [[NothGEP2:![0-9]+]], !pix-dxil-inst-num {{.*}}
+// CHECK: {{.*}} = getelementptr inbounds %struct.RayDesc, %struct.RayDesc* {{.*}}, i32 0, i32 2, !pix-dxil-reg [[RDGEP3:![0-9]+]], !pix-dxil-inst-num {{.*}}
+// CHECK: {{.*}} = load i32, i32* getelementptr inbounds ([1 x i32], [1 x i32]* @dx.nothing.a, i32 0, i32 0), !pix-dxil-reg [[NothGEP3:![0-9]+]], !pix-dxil-inst-num {{.*}}
 
-// CHECK-DAG: [[RDAlloca]] = !{i32 1, i32 0, i32 8}
-// CHECK-DAG: [[RPAlloca]] = !{i32 1, i32 8, i32 3}
 // CHECK-DAG: [[RDGEP]] = !{i32 0, i32 0}
 // CHECK-DAG: [[NothGEP]] = !{i32 0, i32 11}
 // CHECK-DAG: [[RDGEP2]] = !{i32 0, i32 3}

--- a/tools/clang/test/HLSLFileCheck/pix/DebugLimitedInstructionOverrides.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugLimitedInstructionOverrides.hlsl
@@ -1,0 +1,79 @@
+// The PIX debug instrumentation pass takes optional arguments that limit the range of instruction numbers that will be instrumented.
+// (This is to cope with extremely large shaders, the instrumentation of which will break, either by out-of-memory or by TDRing when run.)
+
+// RUN: %dxc -EFlowControlPS -Tps_6_0 %s | %opt -S -dxil-annotate-with-virtual-regs -hlsl-dxil-debug-instrumentation,FirstInstruction=6,LastInstruction=9 | %FileCheck %s
+
+// The only instrumented instructions should have instruction numbers in the range [6,9):
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, {{.*}}, i32 undef, i32 6
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, {{.*}}, i32 undef, i32 7
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, {{.*}}, i32 undef, i32 8
+
+// Two more stores to finish off the instrumentation for instruction #8:
+// CHECK: call void @dx.op.bufferStore.f32
+// CHECK: call void @dx.op.bufferStore.i32
+
+// Then no more instrumentation at all:
+// CHECK-NOT: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle
+
+struct VS_OUTPUT_ENV {
+  float4 Pos : SV_Position;
+  float2 Tex : TEXCOORD0;
+};
+
+int i32;
+float f32;
+
+float4 Vectorize(float f) {
+  float4 ret;
+
+  if (f < 1024) // testbreakpoint0
+    ret.x = f;
+  else
+    ret.x = f + 100;
+
+  if (f < 512)
+    ret.y = f;
+  else
+    ret.y = f + 10;
+
+  if (f < 2048)
+    ret.z = f;
+  else
+    ret.z = f + 1000;
+
+  if (f < 4096)
+    ret.w = f + f;
+  else
+    ret.w = f + 1;
+
+  return ret;
+}
+
+float4 FlowControlPS(VS_OUTPUT_ENV input) : SV_Target {
+  float4 ret = {0, 0, 0, 1}; // FirstExecutableLine
+  switch (i32) {
+  case 0:
+    ret = float4(1, 0, 1, 1);
+    break;
+  case 32:
+    ret = Vectorize(f32);
+    break;
+  }
+
+  if (i32 > 10) {
+    ret.r += 0.1f;
+  } else {
+    ret.g += 0.1f;
+  }
+
+  for (uint i = 0; i < 3; ++i) // testbreakpoint1
+  {
+    ret.b += f32 / 1024.f;
+  }
+
+  for (uint j = 0; j < i32 / 8; ++j) {
+    ret.b += f32 / 1000.f;
+  }
+
+  return ret; // LastExecutableLine
+}

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <map>
 #include <unordered_set>
-#include <strstream>
+//#include <strstream>
 #include <iomanip>
 #include "dxc/Test/CompilationResult.h"
 #include "dxc/Test/HLSLTestData.h"

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <map>
 #include <unordered_set>
-//#include <strstream>
+#include <strstream>
 #include <iomanip>
 #include "dxc/Test/CompilationResult.h"
 #include "dxc/Test/HLSLTestData.h"

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -2132,6 +2132,8 @@ class db_dxil(object):
             {'n':'checkForDynamicIndexing','t':'bool','c':1}])
         add_pass('hlsl-dxil-debug-instrumentation', 'DxilDebugInstrumentation', 'HLSL DXIL debug instrumentation for PIX', [
             {'n':'UAVSize','t':'int','c':1},
+            {'n':'FirstInstruction','t':'int','c':1},
+            {'n':'LastInstruction','t':'int','c':1},
             {'n':'parameter0','t':'int','c':1},
             {'n':'parameter1','t':'int','c':1},
             {'n':'parameter2','t':'int','c':1}])


### PR DESCRIPTION
Two related things:
-Move value/store annotations before instruction number annotations so that we can avoid giving instruction numbers to the allocas that the value-to-declare pass adds, since they are only there to implement PIX shader debugging and do not need to be debugged by the PIX end-user. And, otherwise, adding them messes up the instruction numbering for the next part:
-Add parameters that allow PIX to limit instrumentation to a smaller range of instruction numbers. This is a crude way to make instrumentation workable for very large (>100k or so instructions) shaders which otherwise will break the GPU driver either via out of memory or via TDRs when the instrumentation is run.