### PR TITLE
[SPIRV] simplify FileTest.

### DIFF
--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -583,6 +583,7 @@ TEST_F(FileTest, InheritanceLayoutEmptyStruct) {
   runFileTest("oo.inheritance.layout.empty-struct.hlsl");
 }
 TEST_F(FileTest, InheritanceCallMethodOfBase) {
+  setBeforeHLSLLegalization();
   runFileTest("oo.inheritance.call.base.method.hlsl", Expect::Success);
 }
 TEST_F(FileTest, InheritanceBaseWithByteAddressBuffer) {
@@ -1749,7 +1750,8 @@ TEST_F(FileTest, BindingStructureOfResourcesOptimized) {
 }
 
 TEST_F(FileTest, BindingStructureOfResourcesAndNonResourcesError1) {
-  runFileTest("vk.binding.global-struct-of-resource-mix.error.1.hlsl");
+  runFileTest("vk.binding.global-struct-of-resource-mix.error.1.hlsl",
+              Expect::Failure);
 }
 
 TEST_F(FileTest, BindingStructureOfResourcesAndNonResourcesError2) {
@@ -2172,6 +2174,7 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 }
 
 TEST_F(FileTest, UseRValueForMemberExprOfArraySubscriptExpr) {
+  setBeforeHLSLLegalization();
   runFileTest("use.rvalue.for.member-expr.of.array-subscript.hlsl",
               Expect::Success);
 }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -583,8 +583,7 @@ TEST_F(FileTest, InheritanceLayoutEmptyStruct) {
   runFileTest("oo.inheritance.layout.empty-struct.hlsl");
 }
 TEST_F(FileTest, InheritanceCallMethodOfBase) {
-  runFileTest("oo.inheritance.call.base.method.hlsl", Expect::Success,
-              /* runValidation */ false);
+  runFileTest("oo.inheritance.call.base.method.hlsl", Expect::Success);
 }
 TEST_F(FileTest, InheritanceBaseWithByteAddressBuffer) {
   runFileTest("oo.inheritance.base-with-byte-address-buffer.hlsl");
@@ -1746,13 +1745,11 @@ TEST_F(FileTest, AutoShiftBindings) {
 
 TEST_F(FileTest, BindingStructureOfResourcesOptimized) {
   // After optimization is performed, this binary should pass validation.
-  runFileTest("vk.binding.global-struct-of-resources.optimized.hlsl",
-              Expect::Success, /*runValidation*/ true);
+  runFileTest("vk.binding.global-struct-of-resources.optimized.hlsl");
 }
 
 TEST_F(FileTest, BindingStructureOfResourcesAndNonResourcesError1) {
-  runFileTest("vk.binding.global-struct-of-resource-mix.error.1.hlsl",
-              Expect::Failure, /*runValidation*/ false);
+  runFileTest("vk.binding.global-struct-of-resource-mix.error.1.hlsl");
 }
 
 TEST_F(FileTest, BindingStructureOfResourcesAndNonResourcesError2) {
@@ -1767,8 +1764,7 @@ TEST_F(FileTest, BindingStructureOfResourcesContainsBufferError) {
 }
 TEST_F(FileTest, BindingStructureOfResourcesPassLegalization) {
   runFileTest("vk.binding.global-struct-of-resources.pass-legalization.hlsl",
-              Expect::Success,
-              /*runValidation*/ true);
+              Expect::Success);
 }
 
 TEST_F(FileTest, VulkanPushConstant) { runFileTest("vk.push-constant.hlsl"); }
@@ -2156,13 +2152,11 @@ TEST_F(FileTest, MeshShadingNVMeshError14) {
 }
 TEST_F(FileTest, MeshShadingNVAmplification) {
   // TODO: Re-enable spirv-val once issue#3006 is fixed.
-  runFileTest("meshshading.nv.amplification.hlsl", Expect::Success,
-              /* runValidation */ false);
+  runFileTest("meshshading.nv.amplification.hlsl", Expect::Success);
 }
 TEST_F(FileTest, MeshShadingNVAmplificationFunCall) {
   // TODO: Re-enable spirv-val once issue#3006 is fixed.
-  runFileTest("meshshading.nv.fncall.amplification.hlsl", Expect::Success,
-              /* runValidation */ false);
+  runFileTest("meshshading.nv.fncall.amplification.hlsl", Expect::Success);
 }
 TEST_F(FileTest, MeshShadingNVAmplificationError1) {
   runFileTest("meshshading.nv.error1.amplification.hlsl", Expect::Failure);
@@ -2179,8 +2173,7 @@ TEST_F(FileTest, MeshShadingNVAmplificationError4) {
 
 TEST_F(FileTest, UseRValueForMemberExprOfArraySubscriptExpr) {
   runFileTest("use.rvalue.for.member-expr.of.array-subscript.hlsl",
-              Expect::Success,
-              /* runValidation */ false);
+              Expect::Success);
 }
 
 TEST_F(FileTest, ReduceLoadSize) { runFileTest("reduce.load.size.hlsl"); }

--- a/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
+++ b/tools/clang/unittests/SPIRV/CodeGenSpirvTest.cpp
@@ -2153,11 +2153,9 @@ TEST_F(FileTest, MeshShadingNVMeshError14) {
   runFileTest("meshshading.nv.error14.mesh.hlsl", Expect::Failure);
 }
 TEST_F(FileTest, MeshShadingNVAmplification) {
-  // TODO: Re-enable spirv-val once issue#3006 is fixed.
   runFileTest("meshshading.nv.amplification.hlsl", Expect::Success);
 }
 TEST_F(FileTest, MeshShadingNVAmplificationFunCall) {
-  // TODO: Re-enable spirv-val once issue#3006 is fixed.
   runFileTest("meshshading.nv.fncall.amplification.hlsl", Expect::Success);
 }
 TEST_F(FileTest, MeshShadingNVAmplificationError1) {

--- a/tools/clang/unittests/SPIRV/FileTestFixture.cpp
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.cpp
@@ -62,8 +62,8 @@ bool FileTest::parseCommand() {
   return true;
 }
 
-void FileTest::runFileTest(llvm::StringRef filename, Expect expect,
-                           bool runValidation) {
+void FileTest::runFileTest(llvm::StringRef filename, Expect expect) {
+  bool runValidation = true;
   if (beforeHLSLLegalization)
     assert(runValidation);
 

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -31,18 +31,12 @@ public:
       : targetEnv(SPV_ENV_VULKAN_1_0), beforeHLSLLegalization(false),
         glLayout(false), dxLayout(false) {}
 
-  void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
-  void setGlLayout() { glLayout = true; }
-  void setDxLayout() { dxLayout = true; }
-  void setScalarLayout() { scalarLayout = true; }
-
   /// \brief Runs a test with the given input HLSL file.
   ///
   /// The first line of HLSL code must start with "// RUN:" and following DXC
   /// arguments to run the test. Next lines must be proper HLSL code for the
   /// test. It uses file check style output check e.g., "// CHECK: ...".
-  void runFileTest(llvm::StringRef path, Expect expect = Expect::Success,
-                   bool runValidation = true);
+  void runFileTest(llvm::StringRef path, Expect expect = Expect::Success);
 
   /// \brief Runs a test with the given HLSL code.
   ///

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -31,6 +31,8 @@ public:
       : targetEnv(SPV_ENV_VULKAN_1_0), beforeHLSLLegalization(false),
         glLayout(false), dxLayout(false) {}
 
+  void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
+
   /// \brief Runs a test with the given input HLSL file.
   ///
   /// The first line of HLSL code must start with "// RUN:" and following DXC


### PR DESCRIPTION
Remove unused method for runFileTest and enable validation for all tests. This will help code review when convert to lit FileCheck test.