### PR TITLE
Fix build on ARM with non-VS generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,9 @@ add_link_options(/guard:cf)
 endif(WIN32)
 
 # Enable CET Shadow Stack
-if(WIN32 AND NOT (CMAKE_GENERATOR_PLATFORM MATCHES "ARM.*"))
-add_link_options(/CETCOMPAT)
-endif(WIN32 AND NOT (CMAKE_GENERATOR_PLATFORM MATCHES "ARM.*"))
+if(WIN32 AND NOT (CMAKE_C_COMPILER_ARCHITECTURE_ID MATCHES "ARM.*"))
+  add_link_options(/CETCOMPAT)
+endif()
 
 # HLSL Change Ends
 


### PR DESCRIPTION
CMAKE_GENERATOR_PLATFORM is not widely available. For example, Ninja generator doesn't define it. Use CMAKE_C_COMPILER_ARCHITECTURE_ID to avoid this problem.