### PR TITLE
Use the correct header for stringstream

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -24,7 +24,7 @@
 #include <string>
 #include <map>
 #include <unordered_set>
-#include <strstream>
+#include <sstream>
 #include <iomanip>
 #include "dxc/Test/CompilationResult.h"
 #include "dxc/Test/HLSLTestData.h"


### PR DESCRIPTION
stringstream is defined in sstream, not strstream. Include the correct one.