### PR TITLE
[ClangCL] Fix warning for DxilDia

### DIFF
--- a/lib/DxilDia/DxcPixCompilationInfo.cpp
+++ b/lib/DxilDia/DxcPixCompilationInfo.cpp
@@ -76,7 +76,7 @@ public:
 };
 
 CompilationInfo::CompilationInfo(IMalloc *pMalloc, dxil_dia::Session *pSession)
-    : m_pSession(pSession), m_pMalloc(pMalloc) {
+    : m_pMalloc(pMalloc), m_pSession(pSession) {
   auto *Module = m_pSession->DxilModuleRef().GetModule();
   m_contents =
       Module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceContentsMDName);

--- a/lib/DxilDia/DxcPixDxilDebugInfo.h
+++ b/lib/DxilDia/DxcPixDxilDebugInfo.h
@@ -49,7 +49,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilDebugInfo)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilDebugInfo>(this, iid, ppvObject);
   }
 
@@ -94,7 +95,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilInstructionOffsets)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilInstructionOffsets>(this, iid,
                                                                 ppvObject);
   }
@@ -121,7 +123,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilSourceLocations)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilSourceLocations>(this, iid,
                                                              ppvObject);
   }

--- a/lib/DxilDia/DxcPixDxilStorage.h
+++ b/lib/DxilDia/DxcPixDxilStorage.h
@@ -135,7 +135,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilScalarStorage)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilStorage>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxcPixDxilStorage.h
+++ b/lib/DxilDia/DxcPixDxilStorage.h
@@ -59,7 +59,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilArrayStorage)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilStorage>(this, iid, ppvObject);
   }
 
@@ -96,7 +97,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilStructStorage)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilStorage>(this, iid, ppvObject);
   }
 
@@ -133,7 +135,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixDxilScalarStorage)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixDxilStorage>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxcPixTypes.h
+++ b/lib/DxilDia/DxcPixTypes.h
@@ -45,7 +45,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixConstType)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixConstType, IDxcPixType>(this, iid,
                                                                 ppvObject);
   }
@@ -75,7 +76,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixTypedefType)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixTypedefType, IDxcPixType>(this, iid,
                                                                   ppvObject);
   }
@@ -101,7 +103,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixScalarType)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixScalarType, IDxcPixType>(this, iid,
                                                                  ppvObject);
   }
@@ -141,7 +144,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixArrayType)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixArrayType, IDxcPixType>(this, iid,
                                                                 ppvObject);
   }
@@ -181,7 +185,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixStructType)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixStructType2, IDxcPixStructType,
                                  IDxcPixType>(this, iid, ppvObject);
   }
@@ -221,7 +226,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixStructField)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixStructField>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxcPixVariables.cpp
+++ b/lib/DxilDia/DxcPixVariables.cpp
@@ -47,7 +47,8 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixVariable)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixVariable>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxcPixVariables.cpp
+++ b/lib/DxilDia/DxcPixVariables.cpp
@@ -47,7 +47,7 @@ public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_ALLOC(DxcPixVariable)
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDxcPixVariable>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxilDiaDataSource.cpp
+++ b/lib/DxilDia/DxilDiaDataSource.cpp
@@ -61,9 +61,9 @@ getMemBufferFromStream(IStream *pStream, const llvm::Twine &BufferName) {
   size_t size = statstg.cbSize.LowPart;
   std::unique_ptr<llvm::MemoryBuffer> result(
       llvm::MemoryBuffer::getNewUninitMemBuffer(size, BufferName));
-  char *pBuffer = (char *)result.get()->getBufferStart();
+  const char *pBuffer = result.get()->getBufferStart();
   ULONG read;
-  IFT(pStream->Read(pBuffer, size, &read));
+  IFT(pStream->Read(const_cast<char *>(pBuffer), size, &read));
   return result;
 }
 } // namespace dxil_dia
@@ -128,8 +128,8 @@ STDMETHODIMP dxil_dia::DataSource::loadDataFromIStream(IStream *pInputIStream) {
         return DXC_E_MALFORMED_CONTAINER;
       }
 
-      hlsl::DxilProgramHeader *pDxilProgramHeader =
-          (hlsl::DxilProgramHeader *)pBuffer->getBufferStart();
+      const hlsl::DxilProgramHeader *pDxilProgramHeader =
+          (const hlsl::DxilProgramHeader *)pBuffer->getBufferStart();
       if (pDxilProgramHeader->BitcodeHeader.DxilMagic != hlsl::DxilMagicValue) {
         return DXC_E_MALFORMED_CONTAINER;
       }

--- a/lib/DxilDia/DxilDiaDataSource.h
+++ b/lib/DxilDia/DxilDiaDataSource.h
@@ -36,7 +36,7 @@ private:
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
 
-  STDMETHODIMP QueryInterface(REFIID iid, void **ppvObject) {
+  STDMETHODIMP QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDiaDataSource>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxilDiaEnumTables.h
+++ b/lib/DxilDia/DxilDiaEnumTables.h
@@ -37,12 +37,13 @@ protected:
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaEnumTables>(this, iid, ppvObject);
   }
 
   EnumTables(IMalloc *pMalloc, Session *pSession)
-      : m_pMalloc(pMalloc), m_pSession(pSession), m_dwRef(0), m_next(0) {
+      : m_dwRef(0), m_pMalloc(pMalloc), m_pSession(pSession), m_next(0) {
     m_tables.fill(nullptr);
   }
 

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -98,7 +98,7 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
   try {
     m_symsMgr.Init(this);
   } catch (const hlsl::Exception &) {
-    m_symsMgr = std::move(dxil_dia::SymbolManager());
+    m_symsMgr = dxil_dia::SymbolManager();
   }
 }
 
@@ -302,7 +302,7 @@ STDMETHODIMP dxil_dia::Session::findLinesByLinenum(
   std::vector<const llvm::Instruction *> lines;
 
   std::function<bool(DWORD, DWORD)> column_matches =
-      [column](DWORD colStart, DWORD colEnd) -> bool { return true; };
+      [](DWORD colStart, DWORD colEnd) -> bool { return true; };
 
   if (column != 0) {
     column_matches = [column](DWORD colStart, DWORD colEnd) -> bool {

--- a/lib/DxilDia/DxilDiaSession.h
+++ b/lib/DxilDia/DxilDiaSession.h
@@ -75,7 +75,8 @@ public:
 
   HRESULT getSourceFileIdByName(llvm::StringRef fileName, DWORD *pRetVal);
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaSession, IDxcPixDxilDebugInfoFactory>(
         this, iid, ppvObject);
   }

--- a/lib/DxilDia/DxilDiaTable.h
+++ b/lib/DxilDia/DxilDiaTable.h
@@ -75,7 +75,8 @@ protected:
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaTable, T, IEnumUnknown>(this, iid,
                                                              ppvObject);
   }

--- a/lib/DxilDia/DxilDiaTableInjectedSources.h
+++ b/lib/DxilDia/DxilDiaTableInjectedSources.h
@@ -35,7 +35,8 @@ private:
 
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaInjectedSource>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxilDiaTableLineNumbers.h
+++ b/lib/DxilDia/DxilDiaTableLineNumbers.h
@@ -37,7 +37,7 @@ private:
 
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
-  STDMETHODIMP QueryInterface(REFIID iid, void **ppvObject) {
+  STDMETHODIMP QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterface<IDiaLineNumber>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxilDiaTableSourceFiles.h
+++ b/lib/DxilDia/DxilDiaTableSourceFiles.h
@@ -38,7 +38,8 @@ private:
 
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaSourceFile>(this, iid, ppvObject);
   }
 

--- a/lib/DxilDia/DxilDiaTableSymbols.cpp
+++ b/lib/DxilDia/DxilDiaTableSymbols.cpp
@@ -273,7 +273,7 @@ STDMETHODIMP dxil_dia::Symbol::findChildrenEx(
   std::vector<CComPtr<Symbol>> children;
   IFR(GetChildren(&children));
 
-  if (symtag != nsNone) {
+  if (symtag != SymTagNull) {
     std::vector<CComPtr<Symbol>> tmp;
     tmp.reserve(children.size());
     for (const auto &c : children) {

--- a/lib/DxilDia/DxilDiaTableSymbols.h
+++ b/lib/DxilDia/DxilDiaTableSymbols.h
@@ -1281,7 +1281,8 @@ class SymbolChildrenEnumerator : public IDiaEnumSymbols {
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()
   DXC_MICROCOM_TM_CTOR(SymbolChildrenEnumerator)
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDiaEnumSymbols>(this, iid, ppvObject);
   }
 

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -1264,9 +1264,9 @@ TEST_F(PixTest, CompileWhenDebugThenDIPresent) {
 
   // Very basic tests - we have basic symbols, line numbers, and files with
   // sources.
-  VERIFY_IS_NOT_NULL(
-      wcsstr(diaDump.c_str(), L"symIndexId: 5, CompilandEnv, name: hlslTarget, "
-                              L"lexicalParent: id=2, value: ps_6_0"));
+  VERIFY_IS_NOT_NULL(wcsstr(diaDump.c_str(),
+                            L"symIndexId: 5, CompilandEnv, name: hlslTarget, "
+                            L"lexicalParent: id=2, value: ps_6_0"));
   VERIFY_IS_NOT_NULL(wcsstr(diaDump.c_str(), L"lineNumber: 2"));
   VERIFY_IS_NOT_NULL(
       wcsstr(diaDump.c_str(), L"length: 99, filename: source.hlsl"));

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -4994,8 +4994,8 @@ struct RawR10G10B10XRA2Texture : public ExecutionTest::RawGatherTexture {
   virtual DXGI_FORMAT GetFormat() override { return m_format; };
 };
 
-//#define RAWGATHER_FALLBACK // Enable to use pre-6.7 fallback mechanisms to vet
-//raw gather tests
+// #define RAWGATHER_FALLBACK // Enable to use pre-6.7 fallback mechanisms to
+// vet raw gather tests
 
 // Create a single resource of <resFormat> and alias it to a view of
 // <viewFormat> Then execute a shader that uses raw gather to copy the values
@@ -12547,7 +12547,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
       // Replace the above with what's below when IsSpecialFloat supports
       // doubles
       //{ "@dx.op.isSpecialFloat.f32(i32 8,",  "@dx.op.isSpecialFloat.f64(i32
-      //8," }, { "@dx.op.isSpecialFloat.f32(i32 11,",
+      // 8," }, { "@dx.op.isSpecialFloat.f32(i32 11,",
       //"@dx.op.isSpecialFloat.f64(i32 11," },
       {"@dx.op.isSpecialFloat.f32(i32 8,"},
       {"@dx.op.isSpecialFloat.f32(i32 11,"}, m_support);


### PR DESCRIPTION
1. add override for override methods.
2. remove unnecessary std::move
3. remove unused lambda capture
4. use same enum when compare.
5. fix field order in constructor.
6. add const for when cast from a const variable.