### PR TITLE
[ClangCL] fix warning in DxbcConverter

### DIFF
--- a/include/dxc/DxilContainer/DxilContainerReader.h
+++ b/include/dxc/DxilContainer/DxilContainerReader.h
@@ -18,7 +18,7 @@
 
 namespace hlsl {
 
-#define DXIL_CONTAINER_BLOB_NOT_FOUND -1
+const uint32_t DXIL_CONTAINER_BLOB_NOT_FOUND = -1;
 
 struct DxilContainerHeader;
 

--- a/include/dxc/DxilContainer/DxilContainerReader.h
+++ b/include/dxc/DxilContainer/DxilContainerReader.h
@@ -18,7 +18,7 @@
 
 namespace hlsl {
 
-const uint32_t DXIL_CONTAINER_BLOB_NOT_FOUND = -1;
+const uint32_t DXIL_CONTAINER_BLOB_NOT_FOUND = UINT_MAX;
 
 struct DxilContainerHeader;
 

--- a/projects/dxilconv/include/DxilConvPasses/ScopeNestIterator.h
+++ b/projects/dxilconv/include/DxilConvPasses/ScopeNestIterator.h
@@ -265,9 +265,7 @@ private: // ScopeNestIterator Implementation
   public:
     Scope(Type scopeType, Block *startBlock, BranchKind annotation)
         : m_type(scopeType), m_startAnnotation(annotation),
-          m_startBlock(startBlock), m_endBlock(nullptr), m_backedge(nullptr)
-
-    {
+          m_startBlock(startBlock), m_endBlock(nullptr), m_backedge(nullptr) {
       if (m_type == Type::If) {
         DXASSERT_NOMSG(startBlock &&
                        startBlock->getTerminator()->getNumSuccessors() == 2);

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -557,7 +557,7 @@ void DxbcConverter::ExtractSignatureFromDXBC(
 #endif
 
   for (unsigned iElement = 0; iElement < uParamCount; iElement++) {
-    D3D11_INTERNALSHADER_PARAMETER_11_1 P = {0};
+    D3D11_INTERNALSHADER_PARAMETER_11_1 P = {};
     // Properly copy parameters for the serialized form into P.
     switch (uElemSize) {
     case sizeof(D3D11_INTERNALSHADER_PARAMETER_11_1):
@@ -753,7 +753,7 @@ void DxbcConverter::ExtractSignatureFromDDI(
 
       // For PS output, try to disambiguate semantic based on register index.
       if (m_pSM->IsPS() && SigHelper.IsOutput()) {
-        if (P.Register != -1) {
+        if (P.Register != (UINT)-1) {
           // This must be SV_Target.
           E.SemanticName = "SV_Target";
           E.SemanticIndex = P.Register;
@@ -802,7 +802,7 @@ void DxbcConverter::ExtractSignatureFromDDI(
     } else {
       E.SemanticName = string(DXBC::GetD3D10SBName(P.SystemValue));
       E.SemanticIndex = DXBC::GetD3D10SBSemanticIndex(P.SystemValue);
-      if (P.RegisterComponentType != D3D_REGISTER_COMPONENT_UNKNOWN) {
+      if (P.RegisterComponentType != D3D10_SB_REGISTER_COMPONENT_UNKNOWN) {
         E.ComponentType = DXBC::GetCompTypeWithMinPrec(
             (D3D_REGISTER_COMPONENT_TYPE)P.RegisterComponentType,
             (D3D11_SB_OPERAND_MIN_PRECISION)P.MinPrecision);
@@ -1652,7 +1652,7 @@ void DxbcConverter::AnalyzeShader(
         break;
 
       default: {
-        unsigned NumUnits, Row;
+        unsigned NumUnits=0, Row=0;
         switch (Inst.m_Operands[0].m_IndexDimension) {
         case D3D10_SB_OPERAND_INDEX_1D:
           NumUnits = 0;
@@ -2832,7 +2832,6 @@ void DxbcConverter::ConvertInstructions(
         LoadOperand(In, Inst, SrcIdx, WriteMask, CompType::getU32());
 
         OP::OpCode OpCode = OP::OpCode::LegacyF16ToF32;
-        CompType DstType = CompType::getF32();
         Function *F = m_pOP->GetOpFunc(OpCode, Type::getVoidTy(m_Ctx));
 
         for (BYTE c = 0; c < DXBC::kWidth; c++) {
@@ -3755,7 +3754,6 @@ void DxbcConverter::ConvertInstructions(
                       ValueType);
         }
 
-        CompType DstType = CompType::getI32();
         Type *pDstType = Type::getInt32PtrTy(m_Ctx, DXIL::kTGSMAddrSpace);
 
         // Value.
@@ -3776,8 +3774,6 @@ void DxbcConverter::ConvertInstructions(
           pRetVal = m_pBuilder->CreateAtomicCmpXchg(
               pPtr, InCompareValue[0], InValue[0], AtomicOrdering::Monotonic,
               AtomicOrdering::Monotonic);
-          Type *RetTypeFields[2] = {Type::getInt32Ty(m_Ctx),
-                                    Type::getInt1Ty(m_Ctx)};
           pRetVal = m_pBuilder->CreateExtractValue(pRetVal, 0);
         }
 
@@ -6181,10 +6177,6 @@ void DxbcConverter::StoreGetDimensionsOutput(
     R = &m_pPR->GetUAV(m_UAVRangeMap[RangeID]);
   }
 
-  // Return type.
-  CompType RetType = DXBC::GetCompTypeWithMinPrec(
-      CompType::getI32(), Inst.m_Operands[uOpOutput].m_MinPrecision);
-
   // Value type.
   CompType ValueType = CompType::getI32();
   bool bRcp = false;
@@ -8315,7 +8307,7 @@ Value *DxbcConverter::MarkPrecise(Value *pVal, BYTE Comp) {
 void DxbcConverter::SerializeDxil(SmallVectorImpl<char> &DxilBitcode) {
   raw_svector_ostream DxilStream(DxilBitcode);
   // a. Reserve header.
-  DxilProgramHeader Header = {0};
+  DxilProgramHeader Header = {};
   DxilStream.write((char *)&Header, sizeof(Header));
   // b. Bitcode.
   WriteBitcodeToFile(m_pModule.get(), DxilStream);

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -1652,7 +1652,7 @@ void DxbcConverter::AnalyzeShader(
         break;
 
       default: {
-        unsigned NumUnits=0, Row=0;
+        unsigned NumUnits = 0, Row = 0;
         switch (Inst.m_Operands[0].m_IndexDimension) {
         case D3D10_SB_OPERAND_INDEX_1D:
           NumUnits = 0;

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverter.cpp
@@ -753,7 +753,7 @@ void DxbcConverter::ExtractSignatureFromDDI(
 
       // For PS output, try to disambiguate semantic based on register index.
       if (m_pSM->IsPS() && SigHelper.IsOutput()) {
-        if (P.Register != (UINT)-1) {
+        if (P.Register != UINT_MAX) {
           // This must be SV_Target.
           E.SemanticName = "SV_Target";
           E.SemanticIndex = P.Register;

--- a/projects/dxilconv/lib/DxbcConverter/DxbcConverterImpl.h
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcConverterImpl.h
@@ -246,10 +246,10 @@ public:
     DXASSERT(E->IsAllocated(),
              "otherwise signature elements were not set correctly");
     DXASSERT(E->GetStartRow() <= (int)Reg &&
-                 (int)Reg < E->GetStartRow() + E->GetRows(),
+                 Reg < E->GetStartRow() + E->GetRows(),
              "otherwise signature elements were not set correctly");
     DXASSERT(E->GetStartCol() <= (int)Comp &&
-                 (int)Comp < E->GetStartCol() + E->GetCols(),
+                 Comp < E->GetStartCol() + E->GetCols(),
              "otherwise signature elements were not set correctly");
     return E;
   }
@@ -290,7 +290,7 @@ protected:
 public:
   DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL();
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, LPVOID *ppv) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, LPVOID *ppv) override {
     return DoBasicQueryInterface<IDxbcConverter>(this, iid, ppv);
   }
 
@@ -300,18 +300,16 @@ public:
 
   ~DxbcConverter();
 
-  __override HRESULT STDMETHODCALLTYPE Convert(LPCVOID pDxbc, UINT32 DxbcSize,
-                                               LPCWSTR pExtraOptions,
-                                               LPVOID *ppDxil,
-                                               UINT32 *pDxilSize,
-                                               LPWSTR *ppDiag);
+  HRESULT STDMETHODCALLTYPE Convert(LPCVOID pDxbc, UINT32 DxbcSize,
+                                    LPCWSTR pExtraOptions, LPVOID *ppDxil,
+                                    UINT32 *pDxilSize, LPWSTR *ppDiag) override;
 
-  __override HRESULT STDMETHODCALLTYPE ConvertInDriver(
+  HRESULT STDMETHODCALLTYPE ConvertInDriver(
       const UINT32 *pBytecode, LPCVOID pInputSignature,
       UINT32 NumInputSignatureElements, LPCVOID pOutputSignature,
       UINT32 NumOutputSignatureElements, LPCVOID pPatchConstantSignature,
       UINT32 NumPatchConstantSignatureElements, LPCWSTR pExtraOptions,
-      IDxcBlob **ppDxilModule, LPWSTR *ppDiag);
+      IDxcBlob **ppDxilModule, LPWSTR *ppDiag) override;
 
 protected:
   LLVMContext m_Ctx;

--- a/projects/dxilconv/lib/DxbcConverter/DxbcUtil.cpp
+++ b/projects/dxilconv/lib/DxbcConverter/DxbcUtil.cpp
@@ -56,8 +56,6 @@ BYTE CMask::ToByte() const {
   return m_Mask;
 }
 
-static bool IsSet(BYTE Mask, BYTE c) { return CMask(Mask).IsSet(c); }
-
 bool CMask::IsSet(BYTE c) const {
   DXASSERT(c < DXBC::kWidth, "otherwise the caller did not check");
   return (m_Mask & (1 << c)) != 0;
@@ -1353,20 +1351,25 @@ static_assert(D3D10_SB_4_COMPONENT_Y == 1, MSG);
 static_assert(D3D10_SB_4_COMPONENT_Z == 2, MSG);
 static_assert(D3D10_SB_4_COMPONENT_W == 3, MSG);
 
-static_assert(D3D_MIN_PRECISION_DEFAULT ==
-                  D3D11_SB_OPERAND_MIN_PRECISION_DEFAULT,
-              MSG);
-static_assert(D3D_MIN_PRECISION_FLOAT_16 ==
-                  D3D11_SB_OPERAND_MIN_PRECISION_FLOAT_16,
-              MSG);
+static_assert(
+    D3D_MIN_PRECISION_DEFAULT ==
+        static_cast<D3D_MIN_PRECISION>(D3D11_SB_OPERAND_MIN_PRECISION_DEFAULT),
+    MSG);
+static_assert(
+    D3D_MIN_PRECISION_FLOAT_16 ==
+        static_cast<D3D_MIN_PRECISION>(D3D11_SB_OPERAND_MIN_PRECISION_FLOAT_16),
+    MSG);
 static_assert(D3D_MIN_PRECISION_FLOAT_2_8 ==
-                  D3D11_SB_OPERAND_MIN_PRECISION_FLOAT_2_8,
+                  static_cast<D3D_MIN_PRECISION>(
+                      D3D11_SB_OPERAND_MIN_PRECISION_FLOAT_2_8),
               MSG);
-static_assert(D3D_MIN_PRECISION_SINT_16 ==
-                  D3D11_SB_OPERAND_MIN_PRECISION_SINT_16,
-              MSG);
-static_assert(D3D_MIN_PRECISION_UINT_16 ==
-                  D3D11_SB_OPERAND_MIN_PRECISION_UINT_16,
-              MSG);
+static_assert(
+    D3D_MIN_PRECISION_SINT_16 ==
+        static_cast<D3D_MIN_PRECISION>(D3D11_SB_OPERAND_MIN_PRECISION_SINT_16),
+    MSG);
+static_assert(
+    D3D_MIN_PRECISION_UINT_16 ==
+        static_cast<D3D_MIN_PRECISION>(D3D11_SB_OPERAND_MIN_PRECISION_UINT_16),
+    MSG);
 
 } // namespace hlsl

--- a/projects/dxilconv/tools/dxbc2dxil/dxbc2dxil.cpp
+++ b/projects/dxilconv/tools/dxbc2dxil/dxbc2dxil.cpp
@@ -243,7 +243,8 @@ void Converter::Run() {
 
     UINT uDxilBlob;
     IFT(dxilReader.FindFirstPartKind(hlsl::DFCC_DXIL, &uDxilBlob));
-    IFTBOOL(uDxilBlob != hlsl::DXIL_CONTAINER_BLOB_NOT_FOUND, DXC_E_INCORRECT_DXBC);
+    IFTBOOL(uDxilBlob != hlsl::DXIL_CONTAINER_BLOB_NOT_FOUND,
+            DXC_E_INCORRECT_DXBC);
 
     const char *pDxilBlob;
     UINT32 DxilBlobSize;

--- a/projects/dxilconv/tools/dxbc2dxil/dxbc2dxil.cpp
+++ b/projects/dxilconv/tools/dxbc2dxil/dxbc2dxil.cpp
@@ -243,7 +243,7 @@ void Converter::Run() {
 
     UINT uDxilBlob;
     IFT(dxilReader.FindFirstPartKind(hlsl::DFCC_DXIL, &uDxilBlob));
-    IFTBOOL(uDxilBlob != DXIL_CONTAINER_BLOB_NOT_FOUND, DXC_E_INCORRECT_DXBC);
+    IFTBOOL(uDxilBlob != hlsl::DXIL_CONTAINER_BLOB_NOT_FOUND, DXC_E_INCORRECT_DXBC);
 
     const char *pDxilBlob;
     UINT32 DxilBlobSize;

--- a/projects/dxilconv/unittests/DxilConvTests.cpp
+++ b/projects/dxilconv/unittests/DxilConvTests.cpp
@@ -140,8 +140,8 @@ private:
       return false;
     }
     std::string str = std::string(buffer, size);
-    size_t pos;
-    if ((pos = str.find_last_of("\\")) != std::string::npos) {
+    size_t pos = str.find_last_of("\\");
+    if (pos != std::string::npos) {
       str = str.substr(0, pos + 1);
     }
     binDir.assign(str);

--- a/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
+++ b/tools/clang/tools/dxlib-sample/lib_share_compile.cpp
@@ -160,7 +160,7 @@ HRESULT CompileFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
     std::string processedHeader = "";
     std::vector<std::wstring> hashStrList;
     std::vector<LPCWSTR> hashList;
-//#define LIB_SHARE_DBG
+// #define LIB_SHARE_DBG
 #ifdef LIB_SHARE_DBG
     std::vector<std::wstring> defineList;
     defineList.emplace_back(L"");


### PR DESCRIPTION
1. fix order of fields in constructor.
2. fix compare warning for type mismatch by cast to same type.
3. use {} instead of {0} when initialize to all zero.
4. add override for override methods.