### PR TITLE
[NFC] Fix ubsan failure

### DIFF
--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -29,7 +29,7 @@ public:
 
   FileTest()
       : targetEnv(SPV_ENV_VULKAN_1_0), beforeHLSLLegalization(false),
-        glLayout(false), dxLayout(false) {}
+        glLayout(false), dxLayout(false), scalarLayout(true) {}
 
   void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
 

--- a/tools/clang/unittests/SPIRV/FileTestFixture.h
+++ b/tools/clang/unittests/SPIRV/FileTestFixture.h
@@ -29,7 +29,7 @@ public:
 
   FileTest()
       : targetEnv(SPV_ENV_VULKAN_1_0), beforeHLSLLegalization(false),
-        glLayout(false), dxLayout(false), scalarLayout(true) {}
+        glLayout(false), dxLayout(false), scalarLayout(false) {}
 
   void setBeforeHLSLLegalization() { beforeHLSLLegalization = true; }
 


### PR DESCRIPTION
This variable was never initialized so it was always whatever garbage bits were left there. I've defaulted it to `true` because a bunch of tests fail if it is set to `false`, but all tests pass if it is true.

It would be great if someone with more SPIR-V experience could take a look at this.