### PR TITLE
[ClangCL] fix warning for clang unit test.

### DIFF
--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1524,7 +1524,7 @@ static void VerifyPdbUtil(
     D3D12_SHADER_DESC desc = {};
     VERIFY_SUCCEEDED(pRefl->GetDesc(&desc));
 
-    VERIFY_ARE_EQUAL(desc.ConstantBuffers, 1);
+    VERIFY_ARE_EQUAL(desc.ConstantBuffers, 1u);
     ID3D12ShaderReflectionConstantBuffer *pCB =
         pRefl->GetConstantBufferByIndex(0);
 
@@ -1532,7 +1532,7 @@ static void VerifyPdbUtil(
     VERIFY_SUCCEEDED(pCB->GetDesc(&cbDesc));
 
     VERIFY_IS_TRUE(0 == strcmp(cbDesc.Name, "MyCbuffer"));
-    VERIFY_ARE_EQUAL(cbDesc.Variables, 1);
+    VERIFY_ARE_EQUAL(cbDesc.Variables, 1u);
 
     ID3D12ShaderReflectionVariable *pVar = pCB->GetVariableByIndex(0);
     D3D12_SHADER_VARIABLE_DESC varDesc = {};
@@ -1655,7 +1655,7 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsStripped) {
     VERIFY_IS_FALSE(pPdbUtils->IsFullPDB());
     UINT32 uSourceCount = 0;
     VERIFY_SUCCEEDED(pPdbUtils->GetSourceCount(&uSourceCount));
-    VERIFY_ARE_EQUAL(uSourceCount, 0);
+    VERIFY_ARE_EQUAL(uSourceCount, 0u);
   }
 }
 
@@ -1806,21 +1806,21 @@ void CompilerTest::TestPdbUtils(bool bSlim, bool bSourceInDebugModule,
         VERIFY_SUCCEEDED(pPdbUtils_Again.QueryInterface(&pPdbUtils2_Again));
         VERIFY_ARE_EQUAL(pPdbUtils2_Again, pPdbUtils2);
 
-        VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 5);
-        VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 4);
+        VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 5u);
+        VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 4u);
       }
       VERIFY_ARE_EQUAL(pPdbUtils_Again, pPdbUtils);
 
-      VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 4);
-      VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 3);
+      VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 4u);
+      VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 3u);
     }
 
-    VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 3);
-    VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 2);
+    VERIFY_ARE_EQUAL(pPdbUtils2.p->AddRef(), 3u);
+    VERIFY_ARE_EQUAL(pPdbUtils2.p->Release(), 2u);
   }
 
-  VERIFY_ARE_EQUAL(pPdbUtils.p->AddRef(), 2);
-  VERIFY_ARE_EQUAL(pPdbUtils.p->Release(), 1);
+  VERIFY_ARE_EQUAL(pPdbUtils.p->AddRef(), 2u);
+  VERIFY_ARE_EQUAL(pPdbUtils.p->Release(), 1u);
 }
 
 TEST_F(CompilerTest, CompileThenTestPdbUtils) {

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -326,7 +326,7 @@ public:
           D3D12_SHADER_VARIABLE_DESC testConst;
           pTestConst = pTestCB->GetVariableByIndex(vi);
           VERIFY_SUCCEEDED(pTestConst->GetDesc(&testConst));
-          VERIFY_ARE_EQUAL(variableMap.count(testConst.Name), 1);
+          VERIFY_ARE_EQUAL(variableMap.count(testConst.Name), 1u);
           D3D12_SHADER_VARIABLE_DESC baseConst = variableMap[testConst.Name];
           VERIFY_ARE_EQUAL(testConst.uFlags, baseConst.uFlags);
           VERIFY_ARE_EQUAL(testConst.StartOffset, baseConst.StartOffset);
@@ -335,7 +335,7 @@ public:
 
           ID3D12ShaderReflectionType *pTestType = pTestConst->GetType();
           VERIFY_IS_NOT_NULL(pTestType);
-          VERIFY_ARE_EQUAL(variableTypeMap.count(testConst.Name), 1);
+          VERIFY_ARE_EQUAL(variableTypeMap.count(testConst.Name), 1u);
           ID3D12ShaderReflectionType *pBaseType =
               variableTypeMap[testConst.Name];
 

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -465,8 +465,6 @@ TEST_F(RewriterTest, RunPredefines) {
                     L"rewriter\\correct_rewrites\\predefines_gold.hlsl");
 }
 
-static const UINT32 CP_UTF16 = 1200;
-
 TEST_F(RewriterTest, RunWideOneByte) {
   CComPtr<IDxcRewriter> pRewriter;
   VERIFY_SUCCEEDED(CreateRewriter(&pRewriter));

--- a/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
+++ b/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
@@ -4,6 +4,7 @@
 #include "dxc/dxcapi.h"     // Be sure to link with dxcompiler.lib.
 #include <d3d12shader.h>    // Shader reflection.
 // clang-format on
+#include <array>            // for std::size.
 
 // Code from
 // https://github.com/microsoft/DirectXShaderCompiler/wiki/Using-dxc.exe-and-dxcompiler.dll
@@ -184,7 +185,7 @@ int main() {
       pHash != nullptr) {
     wprintf(L"Hash: ");
     DxcShaderHash *pHashBuf = (DxcShaderHash *)pHash->GetBufferPointer();
-    for (int i = 0; i < _countof(pHashBuf->HashDigest); i++)
+    for (unsigned i = 0; i < std::size(pHashBuf->HashDigest); i++)
       wprintf(L"%x", pHashBuf->HashDigest[i]);
     wprintf(L"\n");
   }

--- a/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
+++ b/tools/clang/unittests/HLSLErrors/HLSLErrors.cpp
@@ -4,7 +4,7 @@
 #include "dxc/dxcapi.h"     // Be sure to link with dxcompiler.lib.
 #include <d3d12shader.h>    // Shader reflection.
 // clang-format on
-#include <array>            // for std::size.
+#include <array> // for std::size.
 
 // Code from
 // https://github.com/microsoft/DirectXShaderCompiler/wiki/Using-dxc.exe-and-dxcompiler.dll

--- a/tools/clang/unittests/HLSLHost/HLSLHost.cpp
+++ b/tools/clang/unittests/HLSLHost/HLSLHost.cpp
@@ -121,7 +121,6 @@ public:
 };
 
 // Globals.
-static DWORD g_ProcessLocks;
 static const GUID
     CLSID_HLSLHostServer = // {7FD7A859-6C6B-4352-8F1E-C67BB62E774B}
     {0x7fd7a859,
@@ -139,12 +138,7 @@ static const DWORD ReadLogMsgId = 6;
 static const DWORD SetSizeMsgId = 7;
 static const DWORD SetParentWndMsgId = 8;
 static const DWORD GetPidMsgReplyId = 100 + GetPidMsgId;
-static const DWORD StartRendererMsgReplyId = 100 + StartRendererMsgId;
-static const DWORD StopRendererMsgReplyId = 100 + StopRendererMsgId;
-static const DWORD SetPayloadMsgReplyId = 100 + SetPayloadMsgId;
 static const DWORD ReadLogMsgReplyId = 100 + ReadLogMsgId;
-static const DWORD SetSizeMsgReplyId = 100 + SetSizeMsgId;
-static const DWORD SetParentWndMsgReplyId = 100 + SetParentWndMsgId;
 
 struct HhMessageHeader {
   DWORD Length;
@@ -172,7 +166,7 @@ struct HhResultReply {
 };
 
 // Logging and tracing.
-static void HhTrace(LPWSTR pMessage) { wprintf(L"%s\n", pMessage); }
+static void HhTrace(LPCWSTR pMessage) { wprintf(L"%s\n", pMessage); }
 
 template <typename TInterface, typename TObject>
 HRESULT DoBasicQueryInterfaceWithRemote(TObject *self, REFIID iid,
@@ -502,7 +496,7 @@ public:
       g_ShutdownServerEvent.SetEvent();
     }
   }
-  void SetPayload(LPSTR pText) {
+  void SetPayload(LPCSTR pText) {
     LPSTR textCopy = strdup(pText);
     LPSTR oldText =
         (LPSTR)InterlockedExchangePointer(&m_ShaderOpText, textCopy);
@@ -643,7 +637,7 @@ public:
   DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)
   ServerObj() : m_dwRef(0) {}
   ~ServerObj() {}
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterfaceWithRemote<IStream>(this, iid, ppvObject);
   }
 
@@ -705,9 +699,9 @@ public:
       WriteRequestResultReply(MsgKind, S_OK);
       break;
     case SetPayloadMsgId:
-      LPSTR pText;
+      LPCSTR pText;
       HhTrace(L"SetPayload message received");
-      pText = (LPSTR)(pHeader + 1);
+      pText = (LPCSTR)(pHeader + 1);
       m_renderer.SetPayload(pText);
       WriteRequestResultReply(MsgKind, S_OK);
       break;
@@ -856,11 +850,11 @@ private:
 public:
   DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)
   ServerFactory() : m_dwRef(0) {}
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
     return DoBasicQueryInterfaceWithRemote<IClassFactory>(this, iid, ppvObject);
   }
   HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *pUnk, REFIID riid,
-                                           void **ppvObj) {
+                                           void **ppvObj) override {
     if (pUnk)
       return CLASS_E_NOAGGREGATION;
     CComPtr<ServerObj> obj = new (std::nothrow) ServerObj();
@@ -868,7 +862,7 @@ public:
       return E_OUTOFMEMORY;
     return obj.p->QueryInterface(riid, ppvObj);
   }
-  HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock) {
+  HRESULT STDMETHODCALLTYPE LockServer(BOOL fLock) override {
     // TODO: implement
     return S_OK;
   }

--- a/tools/clang/unittests/HLSLHost/HLSLHost.cpp
+++ b/tools/clang/unittests/HLSLHost/HLSLHost.cpp
@@ -637,7 +637,8 @@ public:
   DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)
   ServerObj() : m_dwRef(0) {}
   ~ServerObj() {}
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterfaceWithRemote<IStream>(this, iid, ppvObject);
   }
 
@@ -850,7 +851,8 @@ private:
 public:
   DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)
   ServerFactory() : m_dwRef(0) {}
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) override {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterfaceWithRemote<IClassFactory>(this, iid, ppvObject);
   }
   HRESULT STDMETHODCALLTYPE CreateInstance(IUnknown *pUnk, REFIID riid,

--- a/tools/clang/unittests/dxc_batch/dxc_batch.cpp
+++ b/tools/clang/unittests/dxc_batch/dxc_batch.cpp
@@ -537,7 +537,8 @@ public:
   DxcIncludeHandlerForInjectedSources() : m_dwRef(0){};
   std::unordered_map<std::wstring, CComPtr<IDxcBlob>> includeFiles;
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIncludeHandler>(this, iid, ppvObject);
   }
 
@@ -769,7 +770,6 @@ int DxcBatchContext::BatchCompile(bool bMultiThread, bool bLibLink) {
   int retVal = 0;
   DxcOpts tmp_Opts;
   // tmp_Opts = m_Opts;
-  m_Opts.InputFile;
   SmallString<128> path(m_Opts.InputFile.begin(), m_Opts.InputFile.end());
   llvm::sys::path::remove_filename(path);
 


### PR DESCRIPTION
1. remove unused variable.
2. use 1u instead 1 to avoid signed unsigned mismatch.
3. use std::size to replace _countof.
4. Use LPCWSTR/LPCSTR instead of LPWSTR/LPSTR.