### PR TITLE
Indicate extra metadata with unknown nodeio tag

### DIFF
--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -2662,7 +2662,7 @@ NodeIOProperties DxilMDHelper::LoadDxilNodeIOState(const llvm::MDOperand &MDO) {
       Node.OutputID.Index = ConstMDToUint32(pNode->getOperand(1));
     } break;
     default:
-      DXASSERT(false, "Unknown NodeIO properties tag");
+      m_bExtraMetadata = true;
       break;
     }
   }

--- a/test/DXILValidation/Metadata/known_nodeio_tags.ll
+++ b/test/DXILValidation/Metadata/known_nodeio_tags.ll
@@ -1,0 +1,84 @@
+; RUN: %dxv %s | FileCheck %s
+
+; Test that all valid node IO tags are accepted
+
+; CHECK: Validation succeeded.
+
+; shader hash: df03be6421edfc5b5480ddc4a4f8b7e3
+;
+; Buffer Definitions:
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4023 (update-dndxc, 15d086f68-dirty)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @main, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @main, !"main", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 14, i1 true, i32 15, !10, i32 16, i32 -1, i32 18, !11, i32 20, !12, i32 21, !15, i32 4, !20, i32 5, !21}
+!10 = !{!"main", i32 0}
+!11 = !{i32 2, i32 3, i32 2}
+!12 = !{!13}
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: DispatchNodeInputRecord (97)
+; Arg #3: NodeRecordType Tag (2)
+; Arg #4: RECORD type
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value of 7
+!13 = !{i32 1, i32 97, i32 2, !14, i32 3, i32 7}
+!14 = !{i32 0, i32 4}
+!15 = !{!16, !18}
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: NodeOutput (6)
+; Arg #3: NodeRecordType Tag (2)
+; Arg #4: Type node
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value of 7
+; Arg #7: NodeOutputArraySize Tag (5)
+; Arg #8: value of 42
+; Arg #9: NodeOutputID Tag (0)
+; Arg #10: output node
+!16 = !{i32 1, i32 6, i32 2, !14, i32 3, i32 7, i32 5, i32 42, i32 0, !17}
+!17 = !{!"myFascinatingNode", i32 0}
+
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: NodeOutputArray (22)
+; Arg #3: NodeRecordType Tag (2)
+; Arg #4: Type node
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value 0 (because shared)
+; Arg #7: NodeOutputArraySize Tag (5)
+; Arg #8: value 63
+; Arg #9: NodeMaxRecordsSharedWith Tag (4)
+; Arg #10: index 0 (myFascinatingNode)
+; Arg #11: NodeAllowSparseNodes Tag (6)
+; Arg #12: value true
+; Arg #13: NodeOutputID Tag (0)
+; Arg #14: output node
+!18 = !{i32 1, i32 22, i32 2, !14, i32 3, i32 0, i32 5, i32 63, i32 4, i32 0, i32 6, i1 true, i32 0, !19}
+!19 = !{!"myMaterials", i32 0}
+!20 = !{i32 1024, i32 1, i32 1}
+!21 = !{i32 0}
+

--- a/test/DXILValidation/Metadata/known_nodeio_tags.ll
+++ b/test/DXILValidation/Metadata/known_nodeio_tags.ll
@@ -4,16 +4,6 @@
 
 ; CHECK: Validation succeeded.
 
-; shader hash: df03be6421edfc5b5480ddc4a4f8b7e3
-;
-; Buffer Definitions:
-;
-;
-; Resource Bindings:
-;
-; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
-; ------------------------------ ---------- ------- ----------- ------- -------------- ------
-;
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 

--- a/test/DXILValidation/Metadata/nodeio_tags.hlsl
+++ b/test/DXILValidation/Metadata/nodeio_tags.hlsl
@@ -1,0 +1,31 @@
+// Source file for unaltered known_nodeio_tags.ll
+// and the altered unknown_nodeio_tags.ll
+// Not intended for indpendent testing
+
+struct MY_INPUT_RECORD {
+  float foo;
+};
+
+struct MY_RECORD {
+  float bar;
+};
+
+struct MY_MATERIAL_RECORD {
+  uint textureIndex;
+};
+
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NodeDispatchGrid(2,3,2)]
+[NumThreads(1024,1,1)]
+[NodeIsProgramEntry]
+void main([MaxRecords(7)] DispatchNodeInputRecord<MY_INPUT_RECORD> myInput,
+              [NodeArraySize(42)]
+              [MaxRecords(7)]
+              NodeOutput<MY_RECORD> myFascinatingNode,
+              [MaxRecordsSharedWith(myFascinatingNode)]
+              [AllowSparseNodes]
+              [NodeArraySize(63)] NodeOutputArray<MY_MATERIAL_RECORD> myMaterials)
+{
+  // Don't really need to do anything
+}

--- a/test/DXILValidation/Metadata/unknown_nodeio_tags.ll
+++ b/test/DXILValidation/Metadata/unknown_nodeio_tags.ll
@@ -1,0 +1,84 @@
+; RUN: not %dxv %s | FileCheck %s
+
+; Test that appropriate errors are produced for unknown node IO Tags
+
+; CHECK: error: Metadata error encountered in non-critical metadata (such as Type Annotations).
+
+; shader hash: df03be6421edfc5b5480ddc4a4f8b7e3
+;
+; Buffer Definitions:
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @main() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4023 (update-dndxc, 15d086f68-dirty)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @main, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @main, !"main", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 14, i1 true, i32 15, !10, i32 16, i32 -1, i32 18, !11, i32 20, !12, i32 21, !15, i32 4, !20, i32 5, !21}
+!10 = !{!"main", i32 0}
+!11 = !{i32 2, i32 3, i32 2}
+!12 = !{!13}
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: DispatchNodeInputRecord (97)
+; Arg #3: INVALID Tag (7)
+; Arg #4: RECORD type
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value of 7
+!13 = !{i32 1, i32 97, i32 7, !14, i32 3, i32 7}
+!14 = !{i32 0, i32 4}
+!15 = !{!16, !18}
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: NodeOutput (6)
+; Arg #3: INVALID Tag (66)
+; Arg #4: Type node
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value of 7
+; Arg #7: NodeOutputArraySize Tag (5)
+; Arg #8: value of 42
+; Arg #9: NodeOutputID Tag (0)
+; Arg #10: output node
+!16 = !{i32 1, i32 6, i32 66, !14, i32 333, i32 7, i32 5, i32 42, i32 0, !17}
+!17 = !{!"myFascinatingNode", i32 0}
+
+; Arg #1: NodeIOFlags Tag (1)
+; Arg #2: NodeOutputArray (22)
+; Arg #3: INVALID Tag (-1)
+; Arg #4: Type node
+; Arg #5: NodeMaxRecords Tag (3)
+; Arg #6: value 0 (because shared)
+; Arg #7: NodeOutputArraySize Tag (5)
+; Arg #8: value 63
+; Arg #9: NodeMaxRecordsSharedWith Tag (4)
+; Arg #10: index 0 (myFascinatingNode)
+; Arg #11: NodeAllowSparseNodes Tag (6)
+; Arg #12: value true
+; Arg #13: NodeOutputID Tag (0)
+; Arg #14: output node
+!18 = !{i32 1, i32 22, i32 -1, !14, i32 3, i32 0, i32 5, i32 63, i32 4, i32 0, i32 6, i1 true, i32 0, !19}
+!19 = !{!"myMaterials", i32 0}
+!20 = !{i32 1024, i32 1, i32 1}
+!21 = !{i32 0}
+

--- a/test/DXILValidation/Metadata/unknown_nodeio_tags.ll
+++ b/test/DXILValidation/Metadata/unknown_nodeio_tags.ll
@@ -4,16 +4,6 @@
 
 ; CHECK: error: Metadata error encountered in non-critical metadata (such as Type Annotations).
 
-; shader hash: df03be6421edfc5b5480ddc4a4f8b7e3
-;
-; Buffer Definitions:
-;
-;
-; Resource Bindings:
-;
-; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
-; ------------------------------ ---------- ------- ----------- ------- -------------- ------
-;
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 

--- a/test/DXILValidation/lit.local.cfg
+++ b/test/DXILValidation/lit.local.cfg
@@ -1,0 +1,3 @@
+# Enable .ll suffixes for this directory
+# They are disabled above to avoid tests unsupported by HLSL
+config.suffixes = ['.txt', '.td', '.test', '.ll']

--- a/test/DXILValidation/lit.local.cfg
+++ b/test/DXILValidation/lit.local.cfg
@@ -1,3 +1,3 @@
 # Enable .ll suffixes for this directory
 # They are disabled above to avoid tests unsupported by HLSL
-config.suffixes = ['.txt', '.td', '.test', '.ll']
+config.suffixes = ['.ll']

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -224,6 +224,9 @@ else:
 # also have a post-assertion to not match a trailing hyphen (foo-).
 NOJUNK = r"(?<!\.|-|\^|/)"
 
+config.substitutions.append( ('%dxv',
+                            lit.util.which('dxv', llvm_tools_dir)) )
+
 # HLSL Change begin - disabling tools we don't build
 for pattern in [#r"\bbugpoint\b(?!-)",
                 #NOJUNK + r"\bllc\b",

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case001_dispatchgrid_shader.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case001_dispatchgrid_shader.hlsl
@@ -65,9 +65,9 @@ void node001_dispatchgrid_shader(DispatchNodeInputRecord<INPUT_NOGRID> input)
 // CHECK: [[DISPATCHGRID]] = !{i32 2, i32 3, i32 2}
 
 // NodeInputs
-// Arg #1: NodeIOKind Tag (1)
-// Arg #2: InputRecord(97)
-// Arg #3: NodeRecordType Tag (3)
+// Arg #1: NodeIOFlags Tag (1)
+// Arg #2: DispatchNodeInputRecord (97)
+// Arg #3: NodeRecordType Tag (2)
 // Arg #4: INPUT_NOGRID type
 // ------------------------------------------------------------------
 // CHECK: [[NODE_IN]] = !{[[INPUT0:![0-9]+]]}

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case014_getrecordcount_nodeinputarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case014_getrecordcount_nodeinputarray.hlsl
@@ -62,9 +62,9 @@ void node014_getrecordcount([MaxRecords(256)] GroupNodeInputRecords<INPUT_RECORD
 // NodeInputs
 // Arg #1: NodeIOKind Tag (1)
 // Arg #2: InputRecord (65)
-// Arg #3: NodeInputMaxArraySize Tag (2)
+// Arg #3: NodeRecordType Tag Tag (2)
 // Arg #4: 256
-// Arg #5: NodeRecordType Tag (3)
+// Arg #5: NodeMaxRecords Tag Tag (3)
 // Arg #6: INPUT_RECORD Type
 // ------------------------------------------------------------------
 // CHECK-DAG: [[NODE_IN]] = !{[[INPUT0:![0-9]+]]}

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case030_outputcomplete_nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case030_outputcomplete_nodeoutput.hlsl
@@ -50,7 +50,7 @@ void node030_outputcomplete_nodeoutput(NodeOutput<OUTPUT_RECORD> output)
 // NodeOutputs
 // Arg #1: NodeIOKind Tag (1)
 // Arg #2: RWOutputRecord (6)
-// Arg #3: NodeRecordType Tag (3)
+// Arg #3: NodeRecordType Tag (2)
 // Arg #4: OUTPUT_RECORD (output metadata)
 // Arg #5: NodeOutputID (0)
 // Arg #6: NodeID (metadata)

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case129_nodeoutputisvalid_nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case129_nodeoutputisvalid_nodeoutput.hlsl
@@ -54,7 +54,7 @@ void node129_nodeoutputisvalid_nodeoutput(NodeOutput<RECORD> output)
 // NodeOutputs
 // Arg #1: NodeIOKind Tag (1)
 // Arg #2: RWOutputRecord (6)
-// Arg #3: NodeRecordType Tag (3)
+// Arg #3: NodeRecordType Tag (2)
 // Arg #4: INPUT_RECORD type
 // Arg #5: NodeMaxOutputRecords Tag (4)
 // Arg #6: value (0) - TODO: shouldn't this be 1?


### PR DESCRIPTION
When unrecognized metadata is encountered, it needs to be recorded so that validation will fail. Additionally, this removes the assert that was there so that the code can be tested. Asserts for code that can be encountered through potential input isn't ideal anyway.

Adds testing for the same which involves introducing dxv testing into the llvm test directory requiring enabling .ll tests for that subdirectory and enabling lit to understand %dxv.

Incidentally fixes some comments in unrelated workgraph tests that had outdated values for some of the metadata that might lead to confusion

Fixes #5609