### PR TITLE
Require validator ver 1.3 for link without version

### DIFF
--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -935,7 +935,7 @@ TEST_F(LinkerTest, RunLinkWithTempReg) {
   AssembleLib(L"..\\HLSLFileCheck\\dxil\\linker\\TempReg.ll", &pTempRegLib);
   CComPtr<IDxcBlob> pEntryLib;
   CompileLib(L"..\\HLSLFileCheck\\dxil\\linker\\use-TempReg.hlsl", &pEntryLib,
-             {L"-validator-version", L"1.7"}, L"lib_6_3");
+             {L"-validator-version", L"1.3"}, L"lib_6_3");
   CComPtr<IDxcLinker> pLinker;
   CreateLinker(&pLinker);
   LPCWSTR libName = L"entry";


### PR DESCRIPTION
Require a lesser validator version for linking without version for RunLinkWithTempReg test in order to allow the test to run on older validators. 1.3 is the lowest version that supports libraries

Another follow up to #5378