### PR TITLE
[NFC] Add missing includes in reflection headers

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -13,6 +13,8 @@
 
 #include "dxc/DXIL/DxilConstants.h"
 
+#include <cstddef>
+
 #define RDAT_NULL_REF ((uint32_t)0xFFFFFFFF)
 
 namespace hlsl {

--- a/include/dxc/Support/D3DReflection.h
+++ b/include/dxc/Support/D3DReflection.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #ifndef _WIN32
+#include "dxc/WinAdapter.h"
 // need to disable this as it is voilated by this header
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnon-virtual-dtor"

--- a/include/dxc/Test/D3DReflectionStrings.h
+++ b/include/dxc/Test/D3DReflectionStrings.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "dxc/Support/WinIncludes.h"
+#include "dxc/WinAdapter.h"
 
 #include "dxc/Support/D3DReflection.h"
 #include "dxc/DxilContainer/DxilRuntimeReflection.h"

--- a/include/dxc/Test/D3DReflectionStrings.h
+++ b/include/dxc/Test/D3DReflectionStrings.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "dxc/Support/WinIncludes.h"
+
 #include "dxc/Support/D3DReflection.h"
 #include "dxc/DxilContainer/DxilRuntimeReflection.h"
 

--- a/tools/clang/tools/dxcompiler/dxcutil.h
+++ b/tools/clang/tools/dxcompiler/dxcutil.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "dxc/DXIL/DxilModule.h"
+#include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/Support/microcom.h"
 #include "dxc/dxcapi.h"
 #include "llvm/ADT/StringRef.h"


### PR DESCRIPTION
`DxilRuntimeReflection.h` uses `size_t`, which is defined by `<cstddef>`.

`dxcutil.h` uses `hlsl::SerializeDxilFlags` by value whcih is declared in `DxilContainer.h`.

`D3DReflectionStrings.h` relies on windows tyoes like `LPCSTR`. It also includes `D3DReflection.h`, which in turn includes `d3d12shader.h` (from DirectXHeaders), which relies on basically the whole `WinAdapter.h`.

I've included `WInAdapter.h` in both `D3DReflectionStrings.h` and `D3DReflection.h` to make both headers indipendently resilient.