### PR TITLE
Add SampleCmpBias and SampleCmpGrad

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -2350,6 +2350,8 @@ ID  Name                                                  Description
 251 AnnotateNodeRecordHandle                              annotate handle with node record properties
 252 NodeOutputIsValid                                     returns true if the specified output node is present in the work graph
 253 GetRemainingRecursionLevels                           returns how many levels of recursion remain
+254 SampleCmpGrad                                         samples a texture using a gradient and compares a single component against the specified comparison value
+255 SampleCmpBias                                         samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
 === ===================================================== =======================================================================================================================================================================================================================
 
 

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -995,6 +995,10 @@ enum class OpCodeClass : unsigned {
   BitcastI32toF32,
   BitcastI64toF64,
 
+  // Comparison Samples
+  SampleCmpBias,
+  SampleCmpGrad,
+
   // Compute/Mesh/Amplification/Node shader
   FlattenedThreadIdInGroup,
   GroupId,
@@ -1267,7 +1271,7 @@ enum class OpCodeClass : unsigned {
   NumOpClasses_Dxil_1_6 = 149,
   NumOpClasses_Dxil_1_7 = 153,
 
-  NumOpClasses = 179 // exclusive last value of enumeration
+  NumOpClasses = 181 // exclusive last value of enumeration
 };
 // OPCODECLASS-ENUM:END
 

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -496,6 +496,14 @@ enum class OpCode : unsigned {
   BitcastI32toF32 = 126, // bitcast between different sizes
   BitcastI64toF64 = 128, // bitcast between different sizes
 
+  // Comparison Samples
+  SampleCmpBias = 255, // samples a texture after applying the input bias to the
+                       // mipmap level and compares a single component against
+                       // the specified comparison value
+  SampleCmpGrad =
+      254, // samples a texture using a gradient and compares a single component
+           // against the specified comparison value
+
   // Compute/Mesh/Amplification/Node shader
   FlattenedThreadIdInGroup = 96, // provides a flattened index for a given
                                  // thread within a given group (SV_GroupIndex)
@@ -952,7 +960,7 @@ enum class OpCode : unsigned {
   NumOpCodes_Dxil_1_6 = 222,
   NumOpCodes_Dxil_1_7 = 226,
 
-  NumOpCodes = 254 // exclusive last value of enumeration
+  NumOpCodes = 256 // exclusive last value of enumeration
 };
 // OPCODE-ENUM:END
 

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -9081,18 +9081,21 @@ struct DxilInst_GetRemainingRecursionLevels {
   bool requiresUniformInputs() const { return false; }
 };
 
-/// This instruction samples a texture using a gradient and compares a single component against the specified comparison value
+/// This instruction samples a texture using a gradient and compares a single
+/// component against the specified comparison value
 struct DxilInst_SampleCmpGrad {
   llvm::Instruction *Instr;
   // Construction and identification
   DxilInst_SampleCmpGrad(llvm::Instruction *pInstr) : Instr(pInstr) {}
   operator bool() const {
-    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpGrad);
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr,
+                                          hlsl::OP::OpCode::SampleCmpGrad);
   }
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (18 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    if (18 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+      return false;
     return true;
   }
   // Metadata
@@ -9154,18 +9157,22 @@ struct DxilInst_SampleCmpGrad {
   void set_clamp(llvm::Value *val) { Instr->setOperand(17, val); }
 };
 
-/// This instruction samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
+/// This instruction samples a texture after applying the input bias to the
+/// mipmap level and compares a single component against the specified
+/// comparison value
 struct DxilInst_SampleCmpBias {
   llvm::Instruction *Instr;
   // Construction and identification
   DxilInst_SampleCmpBias(llvm::Instruction *pInstr) : Instr(pInstr) {}
   operator bool() const {
-    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpBias);
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr,
+                                          hlsl::OP::OpCode::SampleCmpBias);
   }
   // Validation support
   bool isAllowed() const { return true; }
   bool isArgumentListValid() const {
-    if (13 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    if (13 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands())
+      return false;
     return true;
   }
   // Metadata

--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -9080,5 +9080,136 @@ struct DxilInst_GetRemainingRecursionLevels {
   // Metadata
   bool requiresUniformInputs() const { return false; }
 };
+
+/// This instruction samples a texture using a gradient and compares a single component against the specified comparison value
+struct DxilInst_SampleCmpGrad {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_SampleCmpGrad(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpGrad);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (18 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_srv = 1,
+    arg_sampler = 2,
+    arg_coord0 = 3,
+    arg_coord1 = 4,
+    arg_coord2 = 5,
+    arg_coord3 = 6,
+    arg_offset0 = 7,
+    arg_offset1 = 8,
+    arg_offset2 = 9,
+    arg_compareValue = 10,
+    arg_ddx0 = 11,
+    arg_ddx1 = 12,
+    arg_ddx2 = 13,
+    arg_ddy0 = 14,
+    arg_ddy1 = 15,
+    arg_ddy2 = 16,
+    arg_clamp = 17,
+  };
+  // Accessors
+  llvm::Value *get_srv() const { return Instr->getOperand(1); }
+  void set_srv(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_sampler() const { return Instr->getOperand(2); }
+  void set_sampler(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_coord0() const { return Instr->getOperand(3); }
+  void set_coord0(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_coord1() const { return Instr->getOperand(4); }
+  void set_coord1(llvm::Value *val) { Instr->setOperand(4, val); }
+  llvm::Value *get_coord2() const { return Instr->getOperand(5); }
+  void set_coord2(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_coord3() const { return Instr->getOperand(6); }
+  void set_coord3(llvm::Value *val) { Instr->setOperand(6, val); }
+  llvm::Value *get_offset0() const { return Instr->getOperand(7); }
+  void set_offset0(llvm::Value *val) { Instr->setOperand(7, val); }
+  llvm::Value *get_offset1() const { return Instr->getOperand(8); }
+  void set_offset1(llvm::Value *val) { Instr->setOperand(8, val); }
+  llvm::Value *get_offset2() const { return Instr->getOperand(9); }
+  void set_offset2(llvm::Value *val) { Instr->setOperand(9, val); }
+  llvm::Value *get_compareValue() const { return Instr->getOperand(10); }
+  void set_compareValue(llvm::Value *val) { Instr->setOperand(10, val); }
+  llvm::Value *get_ddx0() const { return Instr->getOperand(11); }
+  void set_ddx0(llvm::Value *val) { Instr->setOperand(11, val); }
+  llvm::Value *get_ddx1() const { return Instr->getOperand(12); }
+  void set_ddx1(llvm::Value *val) { Instr->setOperand(12, val); }
+  llvm::Value *get_ddx2() const { return Instr->getOperand(13); }
+  void set_ddx2(llvm::Value *val) { Instr->setOperand(13, val); }
+  llvm::Value *get_ddy0() const { return Instr->getOperand(14); }
+  void set_ddy0(llvm::Value *val) { Instr->setOperand(14, val); }
+  llvm::Value *get_ddy1() const { return Instr->getOperand(15); }
+  void set_ddy1(llvm::Value *val) { Instr->setOperand(15, val); }
+  llvm::Value *get_ddy2() const { return Instr->getOperand(16); }
+  void set_ddy2(llvm::Value *val) { Instr->setOperand(16, val); }
+  llvm::Value *get_clamp() const { return Instr->getOperand(17); }
+  void set_clamp(llvm::Value *val) { Instr->setOperand(17, val); }
+};
+
+/// This instruction samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value
+struct DxilInst_SampleCmpBias {
+  llvm::Instruction *Instr;
+  // Construction and identification
+  DxilInst_SampleCmpBias(llvm::Instruction *pInstr) : Instr(pInstr) {}
+  operator bool() const {
+    return hlsl::OP::IsDxilOpFuncCallInst(Instr, hlsl::OP::OpCode::SampleCmpBias);
+  }
+  // Validation support
+  bool isAllowed() const { return true; }
+  bool isArgumentListValid() const {
+    if (13 != llvm::dyn_cast<llvm::CallInst>(Instr)->getNumArgOperands()) return false;
+    return true;
+  }
+  // Metadata
+  bool requiresUniformInputs() const { return false; }
+  // Operand indexes
+  enum OperandIdx {
+    arg_srv = 1,
+    arg_sampler = 2,
+    arg_coord0 = 3,
+    arg_coord1 = 4,
+    arg_coord2 = 5,
+    arg_coord3 = 6,
+    arg_offset0 = 7,
+    arg_offset1 = 8,
+    arg_offset2 = 9,
+    arg_compareValue = 10,
+    arg_bias = 11,
+    arg_clamp = 12,
+  };
+  // Accessors
+  llvm::Value *get_srv() const { return Instr->getOperand(1); }
+  void set_srv(llvm::Value *val) { Instr->setOperand(1, val); }
+  llvm::Value *get_sampler() const { return Instr->getOperand(2); }
+  void set_sampler(llvm::Value *val) { Instr->setOperand(2, val); }
+  llvm::Value *get_coord0() const { return Instr->getOperand(3); }
+  void set_coord0(llvm::Value *val) { Instr->setOperand(3, val); }
+  llvm::Value *get_coord1() const { return Instr->getOperand(4); }
+  void set_coord1(llvm::Value *val) { Instr->setOperand(4, val); }
+  llvm::Value *get_coord2() const { return Instr->getOperand(5); }
+  void set_coord2(llvm::Value *val) { Instr->setOperand(5, val); }
+  llvm::Value *get_coord3() const { return Instr->getOperand(6); }
+  void set_coord3(llvm::Value *val) { Instr->setOperand(6, val); }
+  llvm::Value *get_offset0() const { return Instr->getOperand(7); }
+  void set_offset0(llvm::Value *val) { Instr->setOperand(7, val); }
+  llvm::Value *get_offset1() const { return Instr->getOperand(8); }
+  void set_offset1(llvm::Value *val) { Instr->setOperand(8, val); }
+  llvm::Value *get_offset2() const { return Instr->getOperand(9); }
+  void set_offset2(llvm::Value *val) { Instr->setOperand(9, val); }
+  llvm::Value *get_compareValue() const { return Instr->getOperand(10); }
+  void set_compareValue(llvm::Value *val) { Instr->setOperand(10, val); }
+  llvm::Value *get_bias() const { return Instr->getOperand(11); }
+  void set_bias(llvm::Value *val) { Instr->setOperand(11, val); }
+  llvm::Value *get_clamp() const { return Instr->getOperand(12); }
+  void set_clamp(llvm::Value *val) { Instr->setOperand(12, val); }
+};
 // INSTR-HELPER:END
 } // namespace hlsl

--- a/include/dxc/HLSL/HLOperations.h
+++ b/include/dxc/HLSL/HLOperations.h
@@ -293,6 +293,22 @@ const unsigned kSampleCmpOffsetArgIndex = 5;
 const unsigned kSampleCmpClampArgIndex = 6;
 const unsigned kSampleCmpStatusArgIndex = 7;
 
+
+// SampleCmpBias.
+const unsigned kSampleCmpBCmpValArgIndex = 4;
+const unsigned kSampleCmpBBiasArgIndex = 5;
+const unsigned kSampleCmpBOffsetArgIndex = 6;
+const unsigned kSampleCmpBClampArgIndex = 7;
+const unsigned kSampleCmpBStatusArgIndex = 8;
+
+// SampleCmpGrad.
+const unsigned kSampleCmpGCmpValArgIndex = 4;
+const unsigned kSampleCmpGDDXArgIndex = 5;
+const unsigned kSampleCmpGDDYArgIndex = 6;
+const unsigned kSampleCmpGOffsetArgIndex = 7;
+const unsigned kSampleCmpGClampArgIndex = 8;
+const unsigned kSampleCmpGStatusArgIndex = 9;
+
 // SampleBias.
 const unsigned kSampleBBiasArgIndex = 4;
 const unsigned kSampleBOffsetArgIndex = 5;

--- a/include/dxc/HlslIntrinsicOp.h
+++ b/include/dxc/HlslIntrinsicOp.h
@@ -252,6 +252,8 @@ enum class IntrinsicOp {
   MOP_Sample,
   MOP_SampleBias,
   MOP_SampleCmp,
+  MOP_SampleCmpBias,
+  MOP_SampleCmpGrad,
   MOP_SampleCmpLevel,
   MOP_SampleCmpLevelZero,
   MOP_SampleGrad,

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -2907,6 +2907,11 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
            SFLAG(Amplification) | SFLAG(Mesh);
     return;
   }
+  // Instructions: Sample=60, SampleBias=61, SampleCmp=64
+  if ((60 <= op && op <= 61) || op == 64) {
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
+    return;
+  }
   // Instructions: RenderTargetGetSamplePosition=76,
   // RenderTargetGetSampleCount=77, Discard=82, EvalSnapped=87,
   // EvalSampleIndex=88, EvalCentroid=89, SampleIndex=90, Coverage=91,
@@ -3143,6 +3148,12 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
   if ((244 <= op && op <= 246) || (254 <= op && op <= 255)) {
     major = 6;
     minor = 8;
+    return;
+  }
+  // Instructions: SampleCmpBias=255
+  if (op == 255) {
+    major = 6;  minor = 8;
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: AllocateNodeOutputRecords=238, GetNodeRecordPtr=239,

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -2561,6 +2561,27 @@ const OP::OpCodeProperty OP::m_OpCodeProps[(unsigned)OP::OpCode::NumOpCodes] = {
          false},
         Attribute::ReadOnly,
     },
+
+    // Comparison Samples void,     h,     f,     d,    i1,    i8,   i16,   i32,
+    // i64,   udt,   obj ,  function attribute
+    {
+        OC::SampleCmpGrad,
+        "SampleCmpGrad",
+        OCC::SampleCmpGrad,
+        "sampleCmpGrad",
+        {false, true, true, false, false, false, false, false, false, false,
+         false},
+        Attribute::ReadOnly,
+    },
+    {
+        OC::SampleCmpBias,
+        "SampleCmpBias",
+        OCC::SampleCmpBias,
+        "sampleCmpBias",
+        {false, true, true, false, false, false, false, false, false, false,
+         false},
+        Attribute::ReadOnly,
+    },
 };
 // OPCODE-OLOADS:END
 
@@ -2899,17 +2920,17 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
            SFLAG(Miss) | SFLAG(Callable) | SFLAG(Node);
     return;
   }
-  // Instructions: Sample=60, SampleBias=61, SampleCmp=64, CalculateLOD=81,
-  // DerivCoarseX=83, DerivCoarseY=84, DerivFineX=85, DerivFineY=86
-  if ((60 <= op && op <= 61) || op == 64 || op == 81 ||
-      (83 <= op && op <= 86)) {
+  // Instructions: CalculateLOD=81, DerivCoarseX=83, DerivCoarseY=84,
+  // DerivFineX=85, DerivFineY=86
+  if (op == 81 || (83 <= op && op <= 86)) {
     mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) |
            SFLAG(Amplification) | SFLAG(Mesh);
     return;
   }
   // Instructions: Sample=60, SampleBias=61, SampleCmp=64
   if ((60 <= op && op <= 61) || op == 64) {
-    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) |
+           SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: RenderTargetGetSamplePosition=76,
@@ -3144,16 +3165,18 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     return;
   }
   // Instructions: BarrierByMemoryType=244, BarrierByMemoryHandle=245,
-  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254, SampleCmpBias=255
-  if ((244 <= op && op <= 246) || (254 <= op && op <= 255)) {
+  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254
+  if ((244 <= op && op <= 246) || op == 254) {
     major = 6;
     minor = 8;
     return;
   }
   // Instructions: SampleCmpBias=255
   if (op == 255) {
-    major = 6;  minor = 8;
-    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) | SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
+    major = 6;
+    minor = 8;
+    mask = SFLAG(Library) | SFLAG(Pixel) | SFLAG(Compute) |
+           SFLAG(Amplification) | SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: AllocateNodeOutputRecords=238, GetNodeRecordPtr=239,
@@ -5629,8 +5652,7 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::TextureGatherRaw:
   case OpCode::SampleCmpLevel:
   case OpCode::SampleCmpGrad:
-  case OpCode::SampleCmpBias:
-  {
+  case OpCode::SampleCmpBias: {
     StructType *ST = cast<StructType>(Ty);
     return ST->getElementType(0);
   }

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -3139,8 +3139,8 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     return;
   }
   // Instructions: BarrierByMemoryType=244, BarrierByMemoryHandle=245,
-  // BarrierByNodeRecordHandle=246
-  if ((244 <= op && op <= 246)) {
+  // BarrierByNodeRecordHandle=246, SampleCmpGrad=254, SampleCmpBias=255
+  if ((244 <= op && op <= 246) || (254 <= op && op <= 255)) {
     major = 6;
     minor = 8;
     return;
@@ -5266,6 +5266,45 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
     A(pI32);
     A(pI32);
     break;
+
+    // Comparison Samples
+  case OpCode::SampleCmpGrad:
+    RRT(pETy);
+    A(pI32);
+    A(pRes);
+    A(pRes);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pI32);
+    A(pI32);
+    A(pI32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    break;
+  case OpCode::SampleCmpBias:
+    RRT(pETy);
+    A(pI32);
+    A(pRes);
+    A(pRes);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    A(pI32);
+    A(pI32);
+    A(pI32);
+    A(pF32);
+    A(pF32);
+    A(pF32);
+    break;
   // OPCODE-OLOAD-FUNCS:END
   default:
     DXASSERT(false, "otherwise unhandled case");
@@ -5577,7 +5616,10 @@ llvm::Type *OP::GetOverloadType(OpCode opCode, llvm::Function *F) {
   case OpCode::RawBufferLoad:
   case OpCode::Unpack4x8:
   case OpCode::TextureGatherRaw:
-  case OpCode::SampleCmpLevel: {
+  case OpCode::SampleCmpLevel:
+  case OpCode::SampleCmpGrad:
+  case OpCode::SampleCmpBias:
+  {
     StructType *ST = cast<StructType>(Ty);
     return ST->getElementType(0);
   }

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -3263,6 +3263,23 @@ SampleHelper::SampleHelper(CallInst *CI, OP::OpCode op,
     SetClamp(CI, HLOperandIndex::kSampleCmpClampArgIndex - cube);
     SetStatus(CI, HLOperandIndex::kSampleCmpStatusArgIndex - cube);
     break;
+  case OP::OpCode::SampleCmpBias:
+    SetBias(CI, HLOperandIndex::kSampleCmpBBiasArgIndex);
+    SetCompareValue(CI, HLOperandIndex::kSampleCmpBCmpValArgIndex);
+    TranslateOffset(CI, cube ? HLOperandIndex::kInvalidIdx
+                             : HLOperandIndex::kSampleCmpBOffsetArgIndex);
+    SetClamp(CI, HLOperandIndex::kSampleCmpBClampArgIndex - cube);
+    SetStatus(CI, HLOperandIndex::kSampleCmpBStatusArgIndex - cube);
+    break;
+  case OP::OpCode::SampleCmpGrad:
+    SetDDX(CI, HLOperandIndex::kSampleCmpGDDXArgIndex);
+    SetDDY(CI, HLOperandIndex::kSampleCmpGDDYArgIndex);
+    SetCompareValue(CI, HLOperandIndex::kSampleCmpGCmpValArgIndex);
+    TranslateOffset(CI, cube ? HLOperandIndex::kInvalidIdx
+                             : HLOperandIndex::kSampleCmpGOffsetArgIndex);
+    SetClamp(CI, HLOperandIndex::kSampleCmpGClampArgIndex - cube);
+    SetStatus(CI, HLOperandIndex::kSampleCmpGStatusArgIndex - cube);
+    break;
   case OP::OpCode::SampleCmpLevel:
     SetCompareValue(CI, HLOperandIndex::kSampleCmpCmpValArgIndex);
     TranslateOffset(CI, cube ? HLOperandIndex::kInvalidIdx
@@ -3439,6 +3456,40 @@ Value *TranslateSample(CallInst *CI, IntrinsicOp IOP, OP::OpCode opcode,
         sampleHelper.offset[0], sampleHelper.offset[1], sampleHelper.offset[2],
         // Bias.
         sampleHelper.bias,
+        // Clamp.
+        sampleHelper.clamp};
+    GenerateDxilSample(CI, F, sampleArgs, sampleHelper.status, hlslOP);
+  } break;
+  case OP::OpCode::SampleCmpBias: {
+    Value *sampleArgs[] = {
+        opArg, sampleHelper.texHandle, sampleHelper.samplerHandle,
+        // Coord.
+        sampleHelper.coord[0], sampleHelper.coord[1], sampleHelper.coord[2],
+        sampleHelper.coord[3],
+        // Offset.
+        sampleHelper.offset[0], sampleHelper.offset[1], sampleHelper.offset[2],
+        // CmpVal.
+        sampleHelper.compareValue,
+        // Bias.
+        sampleHelper.bias,
+        // Clamp.
+        sampleHelper.clamp};
+    GenerateDxilSample(CI, F, sampleArgs, sampleHelper.status, hlslOP);
+  } break;
+  case OP::OpCode::SampleCmpGrad: {
+    Value *sampleArgs[] = {
+        opArg, sampleHelper.texHandle, sampleHelper.samplerHandle,
+        // Coord.
+        sampleHelper.coord[0], sampleHelper.coord[1], sampleHelper.coord[2],
+        sampleHelper.coord[3],
+        // Offset.
+        sampleHelper.offset[0], sampleHelper.offset[1], sampleHelper.offset[2],
+        // CmpVal.
+        sampleHelper.compareValue,
+        // Ddx.
+        sampleHelper.ddx[0], sampleHelper.ddx[1], sampleHelper.ddx[2],
+        // Ddy.
+        sampleHelper.ddy[0], sampleHelper.ddy[1], sampleHelper.ddy[2],
         // Clamp.
         sampleHelper.clamp};
     GenerateDxilSample(CI, F, sampleArgs, sampleHelper.status, hlslOP);
@@ -6710,6 +6761,10 @@ IntrinsicLower gLowerTable[] = {
     {IntrinsicOp::MOP_Sample, TranslateSample, DXIL::OpCode::Sample},
     {IntrinsicOp::MOP_SampleBias, TranslateSample, DXIL::OpCode::SampleBias},
     {IntrinsicOp::MOP_SampleCmp, TranslateSample, DXIL::OpCode::SampleCmp},
+    {IntrinsicOp::MOP_SampleCmpBias, TranslateSample,
+     DXIL::OpCode::SampleCmpBias},
+    {IntrinsicOp::MOP_SampleCmpGrad, TranslateSample,
+     DXIL::OpCode::SampleCmpGrad},
     {IntrinsicOp::MOP_SampleCmpLevel, TranslateSample,
      DXIL::OpCode::SampleCmpLevel},
     {IntrinsicOp::MOP_SampleCmpLevelZero, TranslateSample,

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpBias.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpBias.hlsl
@@ -5,9 +5,9 @@ Texture1D<float4> tex1d;
 Texture1DArray<float4> tex1d_array;
 Texture2D<float4> tex2d;
 
-Texture3D<float4> tex3d;
+TextureCube<float4> texcube;
 
-half cmpVal;
+float cmpVal;
 float bias;
 
 
@@ -15,7 +15,7 @@ float clamp;
 
 // CHECK: define void @main()
 
-// CHECK: %[[T3D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[TCube:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 // CHECK: %[[T2D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 // CHECK: %[[T1DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 0 }, i32 1, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 // CHECK: %[[T1D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
@@ -42,11 +42,11 @@ float main(float4 a
   
   r += tex2d.SampleCmpBias(samp1, a.xy, cmpVal, bias, uint2(-5, 7), clamp);
 
-// CHECK: %[[AnnotT3D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T3D]], %dx.types.ResourceProperties { i32 4, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture3D<4xF32>
-// CHECK: %[[T3DStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotT3D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 4, i32 3, i32 -5, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
-// CHECK: extractvalue %dx.types.ResRet.f32 %[[T3DStatus]], 4
+// CHECK: %[[AnnotTCube:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[TCube]], %dx.types.ResourceProperties { i32 5, i32 1033 })  ; AnnotateHandle(res,props)  resource: TextureCube<4xF32>
+// CHECK: %[[TCubeStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotTCube]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 undef, i32 undef, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
+// CHECK: extractvalue %dx.types.ResRet.f32 %[[TCubeStatus]], 4
 
-  r += tex3d.SampleCmpBias(samp1, a.xyz, cmpVal, bias, uint3(4, 3, -5), clamp, status);
+  r += texcube.SampleCmpBias(samp1, a.xyz, cmpVal, bias, clamp, status);
   r += status;
 
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpBias.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpBias.hlsl
@@ -1,0 +1,55 @@
+// RUN: dxc -Tps_6_8 %s | FileCheck %s
+
+SamplerComparisonState samp1;
+Texture1D<float4> tex1d;
+Texture1DArray<float4> tex1d_array;
+Texture2D<float4> tex2d;
+
+Texture3D<float4> tex3d;
+
+half cmpVal;
+float bias;
+
+
+float clamp;
+
+// CHECK: define void @main()
+
+// CHECK: %[[T3D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T2D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T1DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 0 }, i32 1, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T1D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+
+// CHECK: %[[Sampler:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 3 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+
+float main(float4 a
+  : A) : SV_Target {
+  uint status;
+  float r = 0;
+
+// CHECK: %[[AnnotT1D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T1D]], %dx.types.ResourceProperties { i32 1, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture1D<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotT1D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float undef, float undef, float undef, i32 0, i32 undef, i32 undef, float %{{.*}}, float %{{.*}}, float undef)
+
+  r += tex1d.SampleCmpBias(samp1, a.x, cmpVal, bias);
+
+// CHECK: %[[AnnotT1DArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T1DArray]], %dx.types.ResourceProperties { i32 6, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture1DArray<4xF32>
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotT1DArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float undef, float undef, i32 -5, i32 undef, i32 undef, float %{{.*}}, float %{{.*}}, float undef)  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
+  r += tex1d_array.SampleCmpBias(samp1, a.xy, cmpVal, bias, -5);
+
+// CHECK: %[[AnnotT2D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2D]], %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<4xF32>
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotT2D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float undef, float undef, i32 -5, i32 7, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
+  
+  r += tex2d.SampleCmpBias(samp1, a.xy, cmpVal, bias, uint2(-5, 7), clamp);
+
+// CHECK: %[[AnnotT3D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T3D]], %dx.types.ResourceProperties { i32 4, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture3D<4xF32>
+// CHECK: %[[T3DStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[AnnotT3D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 4, i32 3, i32 -5, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
+// CHECK: extractvalue %dx.types.ResRet.f32 %[[T3DStatus]], 4
+
+  r += tex3d.SampleCmpBias(samp1, a.xyz, cmpVal, bias, uint3(4, 3, -5), clamp, status);
+  r += status;
+
+
+  return r;
+}
+

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpGrad.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpGrad.hlsl
@@ -1,0 +1,66 @@
+// RUN: dxc -Tps_6_8 %s | FileCheck %s
+
+SamplerComparisonState samp1;
+
+Texture2D<float4> tex2d;
+Texture2DArray<float4> tex2d_array;
+Texture3D<float4> tex3d;
+TextureCube<float4> texcube;
+TextureCubeArray<float4> texcube_array;
+
+half cmpVal;
+
+float2 ddx;
+float2 ddy;
+
+float clamp;
+
+// CHECK: define void @main()
+
+// CHECK: %[[CubeArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 4, i32 4, i32 0, i8 0 }, i32 4, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[Cube:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T3D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T2DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 0 }, i32 1, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[T2D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+
+
+// CHECK: %[[Sampler:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 3 }, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+
+float main(float4 a
+  : A) : SV_Target {
+  uint status;
+  float r = 0;
+
+// CHECK: %[[AnnotCube:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Cube]], %dx.types.ResourceProperties { i32 5, i32 1033 })  ; AnnotateHandle(res,props)  resource: TextureCube<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotCube]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 undef, i32 undef, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef)  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+
+  r += texcube.SampleCmpGrad(samp1, a.xyz, cmpVal, ddx.xxy, ddy.yyx);
+
+// CHECK: %[[AnnotCubeArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[CubeArray]], %dx.types.ResourceProperties { i32 9, i32 1033 })  ; AnnotateHandle(res,props)  resource: TextureCubeArray<4xF32>
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotCubeArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, i32 undef, i32 undef, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+
+  r += texcube_array.SampleCmpGrad(samp1, a.xyzw, cmpVal, ddx.xxy, ddy.yyx, clamp);
+
+// CHECK: %[[AnnotT2DArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2DArray]], %dx.types.ResourceProperties { i32 7, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2DArray<4xF32>
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotT2DArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 -4, i32 1, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, float %{{.*}}, float %{{.*}}, float undef, float 5.000000e-01)  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+
+  r += tex2d_array.SampleCmpGrad(samp1, a.xyz, cmpVal, ddx, ddy, uint2(-4, 1), 0.5f);
+
+// CHECK: %[[AnnotT2D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2D]], %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<4xF32>
+// CHECK: %[[T2DStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotT2D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float undef, float undef, i32 -3, i32 2, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, float %{{.*}}, float %{{.*}}, float undef, float 0.000000e+00)  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+// CHECK: extractvalue %dx.types.ResRet.f32 %[[T2DStatus]], 4
+
+  r += tex2d.SampleCmpGrad(samp1, a.xy, cmpVal, ddx, ddy, uint2(-3, 2), 0.f, status);
+  r += status;
+
+// CHECK: %[[AnnotT3D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T3D]], %dx.types.ResourceProperties { i32 4, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture3D<4xF32>
+// CHECK: %[[T3DStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotT3D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 -3, i32 2, i32 -1, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+// CHECK: extractvalue %dx.types.ResRet.f32 %[[T3DStatus]], 4
+
+  r += tex3d.SampleCmpGrad(samp1, a.xyz, cmpVal, ddx.xyx, ddy.yxy, uint3(-3, 2, -1), clamp, status);
+  r += status;
+
+  return r;
+}
+

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpGrad.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/SampleCmpGrad.hlsl
@@ -4,11 +4,10 @@ SamplerComparisonState samp1;
 
 Texture2D<float4> tex2d;
 Texture2DArray<float4> tex2d_array;
-Texture3D<float4> tex3d;
 TextureCube<float4> texcube;
 TextureCubeArray<float4> texcube_array;
 
-half cmpVal;
+float cmpVal;
 
 float2 ddx;
 float2 ddy;
@@ -17,9 +16,8 @@ float clamp;
 
 // CHECK: define void @main()
 
-// CHECK: %[[CubeArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 4, i32 4, i32 0, i8 0 }, i32 4, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
-// CHECK: %[[Cube:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
-// CHECK: %[[T3D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[CubeArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
+// CHECK: %[[Cube:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 // CHECK: %[[T2DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 0 }, i32 1, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 // CHECK: %[[T2D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)  ; CreateHandleFromBinding(bind,index,nonUniformIndex)
 
@@ -52,13 +50,6 @@ float main(float4 a
 // CHECK: extractvalue %dx.types.ResRet.f32 %[[T2DStatus]], 4
 
   r += tex2d.SampleCmpGrad(samp1, a.xy, cmpVal, ddx, ddy, uint2(-3, 2), 0.f, status);
-  r += status;
-
-// CHECK: %[[AnnotT3D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T3D]], %dx.types.ResourceProperties { i32 4, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture3D<4xF32>
-// CHECK: %[[T3DStatus:.+]] = call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[AnnotT3D]], %dx.types.Handle %[[AnnotSampler]], float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, i32 -3, i32 2, i32 -1, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
-// CHECK: extractvalue %dx.types.ResRet.f32 %[[T3DStatus]], 4
-
-  r += tex3d.SampleCmpGrad(samp1, a.xyz, cmpVal, ddx.xyx, ddy.yxy, uint3(-3, 2, -1), clamp, status);
   r += status;
 
   return r;

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/Sample_node.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/Sample_node.hlsl
@@ -1,0 +1,54 @@
+// RUN: %dxc -T lib_6_8  %s | FileCheck %s
+
+// Test SampleCmpBias and SampleCmpGrad for node shader.
+
+// CHECK: define void {{.*}}@BackwardRef
+// CHECK:  %[[Sampler:.+]] = load %dx.types.Handle, %dx.types.Handle* @"\01?s@@3USamplerComparisonState@@A", align 4
+// CHECK:  %[[T2D:.+]] = load %dx.types.Handle, %dx.types.Handle* @"\01?tex2d@@3V?$Texture2D@V?$vector@M$03@@@@A", align 4
+
+// CHECK: %[[T2DH:.+]] = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %[[T2D]])  ; CreateHandleForLib(Resource)
+// CHECK: %[[T2DAnnot:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2DH]], %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<4xF32>
+
+// CHECK: %[[SamplerH:.+]] = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %[[Sampler]])  ; CreateHandleForLib(Resource)
+// CHECK: %[[SamplerAnnot:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[SamplerH]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpBias.f32(i32 255, %dx.types.Handle %[[T2DAnnot]], %dx.types.Handle %[[SamplerAnnot]], float %{{.*}}, float %{{.*}}, float undef, float undef, i32 -5, i32 7, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}})  ; SampleCmpBias(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,bias,clamp)
+
+// CHECK: call %dx.types.ResRet.f32 @dx.op.sampleCmpGrad.f32(i32 254, %dx.types.Handle %[[T2DAnnot]], %dx.types.Handle %[[SamplerAnnot]], float %{{.*}}, float %{{.*}}, float undef, float undef, i32 7, i32 -5, i32 undef, float %{{.*}}, float %{{.*}}, float %{{.*}}, float undef, float %{{.*}}, float %{{.*}}, float undef, float %{{.*}})  ; SampleCmpGrad(srv,sampler,coord0,coord1,coord2,coord3,offset0,offset1,offset2,compareValue,ddx0,ddx1,ddx2,ddy0,ddy1,ddy2,clamp)
+
+struct rec0
+{
+    int i0;
+    float2 f0;
+};
+
+struct rec1
+{
+    float f1;
+    int i1;
+};
+
+Texture2D tex2d;
+SamplerComparisonState s;
+
+float cmpVal;
+float bias;
+float2 ddx;
+float2 ddy;
+bool clamp;
+
+[Shader("node")]
+[NodeLaunch("Thread")]
+void BackwardRef(
+  RWThreadNodeInputRecord<rec0> InputyMcInputFace,
+  [MaxRecords(5)] NodeOutput<rec1> Output1,
+  [MaxRecordsSharedWith(Output1)] NodeOutput<rec1> Output2)
+{
+    float2 coord = InputyMcInputFace.Get().f0;
+    float r;
+    r = tex2d.SampleCmpBias(s, coord, cmpVal, bias, uint2(-5, 7), clamp);
+    r += tex2d.SampleCmpGrad(s, coord, cmpVal, ddx,ddy, uint2(7, -5), clamp);
+
+    GroupNodeOutputRecords<rec1> outrec = Output1.GetGroupNodeOutputRecords(1);
+    InterlockedCompareStoreFloatBitwise(outrec.Get().f1, 0.0, r);
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -443,6 +443,14 @@ $classT [[ro]] SampleBias(in sampler s, in float<1> x, in float bias, in int<1> 
 $classT [[]] SampleBias(in sampler s, in float<1> x, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_bias_o_cl_s;
 $classT [[]] SampleGrad(in sampler s, in float<1> x, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp) : tex1d_t_dd_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<1> x, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_dd_o_cl_s;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias) : tex1d_t_comp_bias;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_o;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_o_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex1d_t_comp_dd;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o) : tex1d_t_comp_dd_o;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace Texture1DArrayMethods {
@@ -481,6 +489,14 @@ $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias, in int<1> 
 $classT [[]] SampleBias(in sampler s, in float<2> x, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_bias_array_o_cl_s;
 $classT [[ro]] SampleGrad(in sampler s, in float<2> x, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp) : tex1d_t_dd_array_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<2> x, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_dd_array_o_cl_s;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex1d_t_comp_bias_array;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_array_o;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_array_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_array_o_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy) : tex1d_t_comp_dd_array;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o) : tex1d_t_comp_dd_array_o;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_array_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_array_o_cl_s;
 } namespace
 
 namespace Texture2DMethods {
@@ -570,6 +586,14 @@ $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<2> x, in fl
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<2> x);
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<2> x, in int<2> o);
 $match<0, -1> void<4> [[]] GatherRaw(in sampler s, in float<2> x, in int<2> o, out uint_only status);
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex2d_t_comp_bias;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_o;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_o_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex2d_t_comp_dd;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o) : tex2d_t_comp_dd_o;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace Texture2DMSMethods {
@@ -668,6 +692,14 @@ $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<3> x, in fl
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<3> x);
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<3> x, in int<2> o);
 $match<0, -1> void<4> [[]] GatherRaw(in sampler s, in float<3> x, in int<2> o, out uint_only status);
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : tex2d_t_comp_bias_array;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_array_o;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_array_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_array_o_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy) : tex2d_t_comp_dd_array;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o) : tex2d_t_comp_dd_array_o;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_array_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_array_o_cl_s;
 } namespace
 
 namespace Texture2DArrayMSMethods {
@@ -678,7 +710,6 @@ float_like<2> [[ro]] GetSamplePosition(in int s) : samplepos;
 $classT [[ro]] Load(in int<3> x, in int s) : texture2darray_ms;
 $classT [[ro]] Load(in int<3> x, in int s, in int<2> o) : texture2darray_ms_o;
 $classT [[]] Load(in int<3> x, in int s, in int<2> o, out uint_only status) : texture2darray_ms_o_s;
-
 } namespace
 
 namespace Texture3DMethods {
@@ -707,6 +738,14 @@ $classT [[ro]] SampleBias(in sampler s, in float<3> x, in float bias, in int<3> 
 $classT [[]] SampleBias(in sampler s, in float<3> x, in float bias, in int<3> o, in float clamp, out uint_only status) : tex3d_t_bias_o_cl_s;
 $classT [[ro]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 ddy, in int<3> o, in float clamp) : tex3d_t_dd_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 ddy, in int<3> o, in float clamp, out uint_only status) : tex3d_t_dd_o_cl_s;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : tex3d_t_comp_bias;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias,in int<3> o) : tex3d_t_comp_bias_o;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<3> o, in float clamp) : tex3d_t_comp_bias_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<3> o, in float clamp, out uint_only status) : tex3d_t_comp_bias_o_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex3d_t_comp_dd;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o) : tex3d_t_comp_dd_o;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o, in float clamp) : tex3d_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o, in float clamp, out uint_only status) : tex3d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace TextureCUBEMethods {
@@ -755,6 +794,12 @@ $match<0, -1> void<4> [[]] GatherCmpRed(in sampler_cmp s, in float<3> x, in floa
 $match<0, -1> void<4> [[]] GatherCmpGreen(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_green_s;
 $match<0, -1> void<4> [[]] GatherCmpBlue(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_blue_s;
 $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_alpha_s;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : texcube_t_comp_bias;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy) : texcube_t_comp_dd;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp) : texcube_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_o_cl_s;
 } namespace
 
 namespace TextureCUBEArrayMethods {
@@ -803,6 +848,13 @@ $match<0, -1> void<4> [[]] GatherCmpRed(in sampler_cmp s, in float<4> x, in floa
 $match<0, -1> void<4> [[]] GatherCmpGreen(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_green_array_s;
 $match<0, -1> void<4> [[]] GatherCmpBlue(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_blue_array_s;
 $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_alpha_array_s;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias) : texcube_t_comp_bias_array;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_array_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_array_cl_s;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy) : texcube_t_comp_dd_array;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp) : texcube_t_comp_dd_array_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_array_cl_s;
+
 } namespace
 
 namespace BufferMethods {

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -424,6 +424,10 @@ $classT [[ro]] SampleBias(in sampler s, in float<1> x, in float bias) : tex1d_t_
 $classT [[ro]] SampleBias(in sampler s, in float<1> x, in float bias, in int<1> o) : tex1d_t_bias_o;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<1> x, in float compareValue) : tex1d_t_comp;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<1> x, in float compareValue, in int<1> o) : tex1d_t_comp_o;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias) : tex1d_t_comp_bias;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_o;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex1d_t_comp_dd;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o) : tex1d_t_comp_dd_o;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<1> x, in float compareValue, in float lod);
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<1> x, in float compareValue, in float lod, in int<1> o);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<1> x, in float compareValue) : tex1d_t_comp_lz;
@@ -436,6 +440,10 @@ $classT [[ro]] Sample(in sampler s, in float<1> x, in int<1> o, in float clamp) 
 $classT [[]] Sample(in sampler s, in float<1> x, in int<1> o, in float clamp, out uint_only status) : tex1d_t_o_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<1> x, in float compareValue, in int<1> o, in float clamp) : tex1d_t_comp_o_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<1> x, in float compareValue, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_o_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_o_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_o_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<1> x, in float compareValue, in float lod, in int<1> o, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<1> x, in float compareValue, in int<1> o, out uint_only status) : tex1d_t_comp_o_s;
 $classT [[]] SampleLevel(in sampler s, in float<1> x, in float lod, in int<1> o, out uint_only status) : tex1d_t_lod_o_s;
@@ -443,14 +451,6 @@ $classT [[ro]] SampleBias(in sampler s, in float<1> x, in float bias, in int<1> 
 $classT [[]] SampleBias(in sampler s, in float<1> x, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_bias_o_cl_s;
 $classT [[]] SampleGrad(in sampler s, in float<1> x, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp) : tex1d_t_dd_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<1> x, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_dd_o_cl_s;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias) : tex1d_t_comp_bias;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_o;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_o_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<1> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_o_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex1d_t_comp_dd;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o) : tex1d_t_comp_dd_o;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<1> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace Texture1DArrayMethods {
@@ -470,6 +470,10 @@ $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias) : tex1d_t_
 $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias, in int<1> o) : tex1d_t_bias_array_o;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue) : tex1d_t_comp_array;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<1> o) : tex1d_t_comp_array_o;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex1d_t_comp_bias_array;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_array_o;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy) : tex1d_t_comp_dd_array;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o) : tex1d_t_comp_dd_array_o;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod);
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod, in int<1> o);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<2> x, in float compareValue) : tex1d_t_comp_lz_array;
@@ -482,6 +486,10 @@ $classT [[ro]] Sample(in sampler s, in float<2> x, in int<1> o, in float clamp) 
 $classT [[]] Sample(in sampler s, in float<2> x, in int<1> o, in float clamp, out uint_only status) : tex1d_t_array_o_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<1> o, in float clamp) : tex1d_t_comp_array_o_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_array_o_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_array_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_array_o_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_array_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_array_o_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod, in int<1> o, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<2> x, in float compareValue, in int<1> o, out uint_only status) : tex1d_t_comp_array_o_s;
 $classT [[]] SampleLevel(in sampler s, in float<2> x, in float lod, in int<1> o, out uint_only status) : tex1d_t_lod_array_o_s;
@@ -489,14 +497,6 @@ $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias, in int<1> 
 $classT [[]] SampleBias(in sampler s, in float<2> x, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_bias_array_o_cl_s;
 $classT [[ro]] SampleGrad(in sampler s, in float<2> x, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp) : tex1d_t_dd_array_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<2> x, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_dd_array_o_cl_s;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex1d_t_comp_bias_array;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o) : tex1d_t_comp_bias_array_o;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp) : tex1d_t_comp_bias_array_o_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_bias_array_o_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy) : tex1d_t_comp_dd_array;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o) : tex1d_t_comp_dd_array_o;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp) : tex1d_t_comp_dd_array_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $match<2, 2> float<1> ddx, in $match<2, 2> float<1> ddy, in int<1> o, in float clamp, out uint_only status) : tex1d_t_comp_dd_array_o_cl_s;
 } namespace
 
 namespace Texture2DMethods {
@@ -544,6 +544,10 @@ $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias) : tex2d_t_
 $classT [[ro]] SampleBias(in sampler s, in float<2> x, in float bias, in int<2> o) : tex2d_t_bias_o;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue) : tex2d_t_comp;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<2> o) : tex2d_t_comp_o;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex2d_t_comp_bias;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_o;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex2d_t_comp_dd;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o) : tex2d_t_comp_dd_o;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod);
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod, in int<2> o);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<2> x, in float compareValue) : tex2d_t_comp_lz;
@@ -556,6 +560,10 @@ $classT [[ro]] Sample(in sampler s, in float<2> x, in int<2> o, in float clamp) 
 $classT [[]] Sample(in sampler s, in float<2> x, in int<2> o, in float clamp, out uint_only status) : tex2d_t_o_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<2> o, in float clamp) : tex2d_t_comp_o_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<2> x, in float compareValue, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_o_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_o_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_o_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<2> x, in float compareValue, in float lod, in int<2> o, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<2> x, in float compareValue, in int<2> o, out uint_only status) : tex2d_t_comp_o_s;
 $classT [[]] SampleLevel(in sampler s, in float<2> x, in float lod, in int<2> o, out uint_only status) : tex2d_t_lod_o_s;
@@ -586,14 +594,6 @@ $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<2> x, in fl
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<2> x);
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<2> x, in int<2> o);
 $match<0, -1> void<4> [[]] GatherRaw(in sampler s, in float<2> x, in int<2> o, out uint_only status);
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias) : tex2d_t_comp_bias;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_o;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_o_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<2> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_o_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex2d_t_comp_dd;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o) : tex2d_t_comp_dd_o;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<2> x, in float compareValue, in $type2 ddx, in $type2 ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace Texture2DMSMethods {
@@ -652,6 +652,10 @@ $classT [[ro]] SampleBias(in sampler s, in float<3> x, in float bias) : tex2d_t_
 $classT [[ro]] SampleBias(in sampler s, in float<3> x, in float bias, in int<2> o) : tex2d_t_bias_array_o;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue) : tex2d_t_comp_array;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue, in int<2> o) : tex2d_t_comp_array_o;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : tex2d_t_comp_bias_array;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_array_o;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy) : tex2d_t_comp_dd_array;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o) : tex2d_t_comp_dd_array_o;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<3> x, in float compareValue, in float lod);
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<3> x, in float compareValue, in float lod, in int<2> o);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<3> x, in float compareValue) : tex2d_t_comp_lz_array;
@@ -664,6 +668,10 @@ $classT [[ro]] Sample(in sampler s, in float<3> x, in int<2> o, in float clamp) 
 $classT [[]] Sample(in sampler s, in float<3> x, in int<2> o, in float clamp, out uint_only status) : tex2d_t_array_o_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue, in int<2> o, in float clamp) : tex2d_t_comp_array_o_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_array_o_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_array_o_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_array_o_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_array_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_array_o_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<3> x, in float compareValue, in float lod, in int<2> o, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<3> x, in float compareValue, in int<2> o, out uint_only status) : tex2d_t_comp_array_o_s;
 $classT [[]] SampleLevel(in sampler s, in float<3> x, in float lod, in int<2> o, out uint_only status) : tex2d_t_lod_array_o_s;
@@ -692,14 +700,6 @@ $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<3> x, in fl
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<3> x);
 $match<0, -1> void<4> [[ro]] GatherRaw(in sampler s, in float<3> x, in int<2> o);
 $match<0, -1> void<4> [[]] GatherRaw(in sampler s, in float<3> x, in int<2> o, out uint_only status);
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : tex2d_t_comp_bias_array;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o) : tex2d_t_comp_bias_array_o;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp) : tex2d_t_comp_bias_array_o_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_bias_array_o_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy) : tex2d_t_comp_dd_array;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o) : tex2d_t_comp_dd_array_o;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp) : tex2d_t_comp_dd_array_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $match<2, 2> float<2> ddx, in $match<2, 2> float<2> ddy, in int<2> o, in float clamp, out uint_only status) : tex2d_t_comp_dd_array_o_cl_s;
 } namespace
 
 namespace Texture2DArrayMSMethods {
@@ -739,14 +739,6 @@ $classT [[ro]] SampleBias(in sampler s, in float<3> x, in float bias, in int<3> 
 $classT [[]] SampleBias(in sampler s, in float<3> x, in float bias, in int<3> o, in float clamp, out uint_only status) : tex3d_t_bias_o_cl_s;
 $classT [[ro]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 ddy, in int<3> o, in float clamp) : tex3d_t_dd_o_cl;
 $classT [[]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 ddy, in int<3> o, in float clamp, out uint_only status) : tex3d_t_dd_o_cl_s;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : tex3d_t_comp_bias;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias,in int<3> o) : tex3d_t_comp_bias_o;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<3> o, in float clamp) : tex3d_t_comp_bias_o_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in int<3> o, in float clamp, out uint_only status) : tex3d_t_comp_bias_o_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy) : tex3d_t_comp_dd;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o) : tex3d_t_comp_dd_o;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o, in float clamp) : tex3d_t_comp_dd_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy,in int<3> o, in float clamp, out uint_only status) : tex3d_t_comp_dd_o_cl_s;
 } namespace
 
 namespace TextureCUBEMethods {
@@ -770,6 +762,8 @@ void [[]] GetDimensions(out float_like width, out $type1 height) : resinfo_o;
 $classT [[ro]] Sample(in sampler s, in float<3> x) : texcube_t;
 $classT [[ro]] SampleBias(in sampler s, in float<3> x, in float bias) : texcube_t_bias;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<3> x, in float c) : texcube_t_comp;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : texcube_t_comp_bias;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy) : texcube_t_comp_dd;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<3> x, in float c, in float lod);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<3> x, in float c) : texcube_t_comp_lz;
 $classT [[ro]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 ddy) : texcube_t_dd;
@@ -778,6 +772,10 @@ $classT [[ro]] Sample(in sampler s, in float<3> x, in float clamp) : texcube_t_c
 $classT [[]] Sample(in sampler s, in float<3> x, in float clamp, out uint_only status) : texcube_t_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue, in float clamp) : texcube_t_comp_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<3> x, in float compareValue, in float clamp, out uint_only status) : texcube_t_comp_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp) : texcube_t_comp_dd_o_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_o_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<3> x, in float compareValue, in float lod, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_comp_s;
 $classT [[]] SampleLevel(in sampler s, in float<3> x, in float lod, out uint_only status) : texcube_t_lod_s;
@@ -795,12 +793,6 @@ $match<0, -1> void<4> [[]] GatherCmpRed(in sampler_cmp s, in float<3> x, in floa
 $match<0, -1> void<4> [[]] GatherCmpGreen(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_green_s;
 $match<0, -1> void<4> [[]] GatherCmpBlue(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_blue_s;
 $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<3> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_alpha_s;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias) : texcube_t_comp_bias;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<3> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy) : texcube_t_comp_dd;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp) : texcube_t_comp_dd_o_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<3> x, in float compareValue, in $type2 ddx, in $type2 ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_o_cl_s;
 } namespace
 
 namespace TextureCUBEArrayMethods {
@@ -824,6 +816,8 @@ void [[]] GetDimensions(out float_like width, out $type1 height, out $type1 elem
 $classT [[ro]] Sample(in sampler s, in float<4> x) : texcube_t_array;
 $classT [[ro]] SampleBias(in sampler s, in float<4> x, in float bias) : texcube_t_bias_array;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<4> x, in float c) : texcube_t_comp_array;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias) : texcube_t_comp_bias_array;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy) : texcube_t_comp_dd_array;
 float_like [[ro]] SampleCmpLevel(in sampler_cmp s, in float<4> x, in float c, in float lod);
 float_like [[ro]] SampleCmpLevelZero(in sampler_cmp s, in float<4> x, in float c) : texcube_t_comp_lz_array;
 $classT [[ro]] SampleGrad(in sampler s, in float<4> x, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy) : texcube_t_dd_array;
@@ -832,6 +826,10 @@ $classT [[ro]] Sample(in sampler s, in float<4> x, in float clamp) : texcube_t_a
 $classT [[]] Sample(in sampler s, in float<4> x, in float clamp, out uint_only status) : texcube_t_array_cl_s;
 float_like [[ro]] SampleCmp(in sampler_cmp s, in float<4> x, in float compareValue, in float clamp) : texcube_t_comp_array_cl;
 float_like [[]] SampleCmp(in sampler_cmp s, in float<4> x, in float compareValue, in float clamp, out uint_only status) : texcube_t_comp_array_cl_s;
+float_like [[ro]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_array_cl;
+float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_array_cl_s;
+float_like [[ro]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp) : texcube_t_comp_dd_array_cl;
+float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_array_cl_s;
 float_like [[]] SampleCmpLevel(in sampler_cmp s, in float<4> x, in float compareValue, in float lod, out uint_only status);
 float_like [[]] SampleCmpLevelZero(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_comp_array_s;
 $classT [[]] SampleLevel(in sampler s, in float<4> x, in float lod, out uint_only status) : texcube_t_lod_array_s;
@@ -849,13 +847,6 @@ $match<0, -1> void<4> [[]] GatherCmpRed(in sampler_cmp s, in float<4> x, in floa
 $match<0, -1> void<4> [[]] GatherCmpGreen(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_green_array_s;
 $match<0, -1> void<4> [[]] GatherCmpBlue(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_blue_array_s;
 $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<4> x, in float compareValue, out uint_only status) : texcube_t_gather_comp_alpha_array_s;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias) : texcube_t_comp_bias_array;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp) : texcube_t_comp_bias_array_cl;
-float_like [[]] SampleCmpBias(in sampler_cmp s, in float<4> x, in float compareValue, in float bias, in float clamp, out uint_only status) : texcube_t_comp_bias_array_cl_s;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy) : texcube_t_comp_dd_array;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp) : texcube_t_comp_dd_array_cl;
-float_like [[]] SampleCmpGrad(in sampler_cmp s, in float<4> x, in float compareValue, in $match<2, 2> float<3> ddx, in $match<2, 2> float<3> ddy, in float clamp, out uint_only status) : texcube_t_comp_dd_array_cl_s;
-
 } namespace
 
 namespace BufferMethods {

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -710,6 +710,7 @@ float_like<2> [[ro]] GetSamplePosition(in int s) : samplepos;
 $classT [[ro]] Load(in int<3> x, in int s) : texture2darray_ms;
 $classT [[ro]] Load(in int<3> x, in int s, in int<2> o) : texture2darray_ms_o;
 $classT [[]] Load(in int<3> x, in int s, in int<2> o, out uint_only status) : texture2darray_ms_o_s;
+
 } namespace
 
 namespace Texture3DMethods {

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -289,8 +289,8 @@ class db_dxil(object):
             self.name_idx[i].category = "Resources"
         for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,SampleCmpBias,SampleCmpGrad,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].category = "Resources - sample"
-        for i in "Sample,SampleBias,SampleCmp".split(","):
-            self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
+        for i in "Sample,SampleBias,SampleCmp,SampleCmpBias".split(","):
+            self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh", "node")
         for i in "RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].shader_stages = ("pixel",)
         for i in "TextureGather,TextureGatherCmp,TextureGatherRaw".split(","):

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -287,7 +287,7 @@ class db_dxil(object):
             self.name_idx[i].category = "Dot"
         for i in "CreateHandle,CBufferLoad,CBufferLoadLegacy,TextureLoad,TextureStore,TextureStoreSample,BufferLoad,BufferStore,BufferUpdateCounter,CheckAccessFullyMapped,GetDimensions,RawBufferLoad,RawBufferStore".split(","):
             self.name_idx[i].category = "Resources"
-        for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
+        for i in "Sample,SampleBias,SampleLevel,SampleGrad,SampleCmp,SampleCmpLevelZero,SampleCmpLevel,SampleCmpBias,SampleCmpGrad,Texture2DMSGetSamplePosition,RenderTargetGetSamplePosition,RenderTargetGetSampleCount".split(","):
             self.name_idx[i].category = "Resources - sample"
         for i in "Sample,SampleBias,SampleCmp".split(","):
             self.name_idx[i].shader_stages = ("library", "pixel", "compute", "amplification", "mesh")
@@ -487,6 +487,9 @@ class db_dxil(object):
             self.name_idx[i].shader_model = 6,8
             self.name_idx[i].shader_stages = ("node",)
         for i in "BarrierByMemoryType,BarrierByMemoryHandle,BarrierByNodeRecordHandle".split(","): # included in Synchronization category
+            self.name_idx[i].shader_model = 6,8
+        for i in "SampleCmpBias,SampleCmpGrad".split(","):
+            self.name_idx[i].category = "Comparison Samples"
             self.name_idx[i].shader_model = 6,8
 
     def populate_llvm_instructions(self):
@@ -2137,6 +2140,47 @@ class db_dxil(object):
         self.add_dxil_op("GetRemainingRecursionLevels", next_op_idx, "GetRemainingRecursionLevels", "returns how many levels of recursion remain", "v", "ro", [
             db_dxil_param(0, "i32", "", "number of levels of recursion remaining")])
         next_op_idx += 1
+
+        # Comparison Sampling
+        self.add_dxil_op("SampleCmpGrad", next_op_idx, "SampleCmpGrad", "samples a texture using a gradient and compares a single component against the specified comparison value", "hf", "ro", [
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
+            db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
+            db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
+            db_dxil_param(4, "f", "coord0", "coordinate"),
+            db_dxil_param(5, "f", "coord1", "coordinate, undef for Texture1D"),
+            db_dxil_param(6, "f", "coord2", "coordinate, undef for Texture1D, Texture1DArray or Texture2D"),
+            db_dxil_param(7, "f", "coord3", "coordinate, defined only for TextureCubeArray"),
+            db_dxil_param(8, "i32", "offset0", "optional offset, applicable to Texture1D, Texture1DArray, and as part of offset1"),
+            db_dxil_param(9, "i32", "offset1", "optional offset, applicable to Texture2D, Texture2DArray, and as part of offset2"),
+            db_dxil_param(10, "i32", "offset2", "optional offset, applicable to Texture3D"),
+            db_dxil_param(11, "f", "compareValue", "the value to compare with"),
+            db_dxil_param(12, "f", "ddx0", "rate of change of coordinate c0 in the x direction"),
+            db_dxil_param(13, "f", "ddx1", "rate of change of coordinate c1 in the x direction"),
+            db_dxil_param(14, "f", "ddx2", "rate of change of coordinate c2 in the x direction"),
+            db_dxil_param(15, "f", "ddy0", "rate of change of coordinate c0 in the y direction"),
+            db_dxil_param(16, "f", "ddy1", "rate of change of coordinate c1 in the y direction"),
+            db_dxil_param(17, "f", "ddy2", "rate of change of coordinate c2 in the y direction"),
+            db_dxil_param(18, "f", "clamp", "clamp value")],
+            counters=('tex_cmp',))
+        next_op_idx += 1
+
+        self.add_dxil_op("SampleCmpBias", next_op_idx, "SampleCmpBias", "samples a texture after applying the input bias to the mipmap level and compares a single component against the specified comparison value", "hf", "ro", [
+            db_dxil_param(0, "$r", "", "the result of the filtered comparisons"),
+            db_dxil_param(2, "res", "srv", "handle of SRV to sample"),
+            db_dxil_param(3, "res", "sampler", "handle of sampler to use"),
+            db_dxil_param(4, "f", "coord0", "coordinate"),
+            db_dxil_param(5, "f", "coord1", "coordinate, undef for Texture1D"),
+            db_dxil_param(6, "f", "coord2", "coordinate, undef for Texture1D, Texture1DArray or Texture2D"),
+            db_dxil_param(7, "f", "coord3", "coordinate, defined only for TextureCubeArray"),
+            db_dxil_param(8, "i32", "offset0", "optional offset, applicable to Texture1D, Texture1DArray, and as part of offset1"),
+            db_dxil_param(9, "i32", "offset1", "optional offset, applicable to Texture2D, Texture2DArray, and as part of offset2"),
+            db_dxil_param(10, "i32", "offset2", "optional offset, applicable to Texture3D"),
+            db_dxil_param(11, "f", "compareValue", "the value to compare with"),
+            db_dxil_param(12, "f", "bias", "bias value"),
+            db_dxil_param(13, "f", "clamp", "clamp value")],
+            counters=('tex_cmp',))
+        next_op_idx += 1
+
 
 
         # Set interesting properties.


### PR DESCRIPTION
1. Add DXIL opcode for SampleCmpBias and SampleCmpGrad.
    Merged from https://github.com/microsoft/DirectXShaderCompiler/pull/5562

2. Add hlsl intrinsic for  SampleCmpBias and SampleCmpGrad.
3. Lower the intrinsic to DXIL.

This is for https://github.com/microsoft/hlsl-specs/issues/30
Fixes #5560 