### PR TITLE
Fix ASAN memory leak in FileChecker

### DIFF
--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -748,6 +748,13 @@ public:
     return *this;
   }
 
+  // NOTE: This conversion constructor is not part of the official CComPtr spec;
+  // however, it is needed to convert CComPtr<Q> to CComPtr<T> where T derives from Q on Clang.
+  // MSVC compiles this conversion as first a call to CComPtr<Q>::operator T*, followed by CComPtr<T>(T*),
+  // but Clang fails to compile with error: no viable conversion from 'CComPtr<Q>' to 'CComPtr<T>'.
+  template <typename Q>
+  CComPtr(const CComPtr<Q> &lp) throw() : CComPtrBase<T>(lp.p) {}
+
   T *operator=(const CComPtr<T> &lp) throw() {
     if (*this != lp) {
       CComPtr(lp).Swap(*this);

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -256,7 +256,7 @@ public:
   }
 };
 
-static IncludeHandlerVFSOverlayForTest *AllocVFSIncludeHandler(IUnknown *pUnkLibrary, const FileMap *pVFS) {
+static CComPtr<IncludeHandlerVFSOverlayForTest> AllocVFSIncludeHandler(IUnknown *pUnkLibrary, const FileMap *pVFS) {
   CComPtr<IncludeHandlerVFSOverlayForTest> pVFSIncludeHandler = IncludeHandlerVFSOverlayForTest::Alloc(DxcGetThreadMallocNoRef());
   IFTBOOL(pVFSIncludeHandler, E_OUTOFMEMORY);
   if (pUnkLibrary) {
@@ -273,7 +273,7 @@ static IncludeHandlerVFSOverlayForTest *AllocVFSIncludeHandler(IUnknown *pUnkLib
     pVFSIncludeHandler->pInnerIncludeHandler = pInnerIncludeHandler;
   }
   pVFSIncludeHandler->pVFS = pVFS;
-  return pVFSIncludeHandler.Detach();
+  return pVFSIncludeHandler;
 }
 
 static void AddOutputsToFileMap(IUnknown *pUnkResult, FileMap *pVFS) {


### PR DESCRIPTION
AllocVFSIncludeHandler was returning it's IUnknown object by Detach()ing from a CComPtr, then assiging to CComPtr. This would result in the object have a ref count of 2, and when the second CComPtr destructed, it would go down to 1, and leak memory.

The fix is to return the object as a CComPtr; however, with Clang, this failed to compile because it finds no conversion from a CComPtr of child class type to a CComPtr of base class type. This compiles fine on MSVC, so I debugged it, and realized that MSVC compiles this as first a conversion to T*, then a constructor call. I suspect MSVC is wrong here. In any case, this change adds a template conversion constructor to CComPtr, very much like the existing template assignment operator.