### PR TITLE
[lit] allow for spaces in taef commands

### DIFF
--- a/projects/dxilconv/test/taef/lit.cfg
+++ b/projects/dxilconv/test/taef/lit.cfg
@@ -30,15 +30,16 @@ hlsl_data_dir = os.path.join(config.llvm_src_root, 'projects', 'dxilconv', 'test
 
 test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
 
-param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
-extra_params = [param_hlsl_data_dir]
+param_hlsl_data_dir = str.format('HlslDataDir={}', hlsl_data_dir)
+extra_params = ['/p:', param_hlsl_data_dir]
 
 verbose = bool(getattr(config, 'verbose', False))
 if verbose != True:
-    extra_params.append('/logOutput:"LowWithConsoleBuffering"')
+    extra_params.append('/logOutput:')
+    extra_params.append('LowWithConsoleBuffering')
 
 arch = getattr(config, 'taef_arch', None)
 select_filter = str.format("@Architecture='{}'", arch)
 
-config.test_format = lit.formats.TaefTest(config.te, test_dll, test_dir, select_filter,extra_params)
+config.test_format = lit.formats.TaefTest(config.te, test_dll, test_dir, select_filter, extra_params)
 

--- a/tools/clang/test/taef/lit.cfg
+++ b/tools/clang/test/taef/lit.cfg
@@ -35,12 +35,13 @@ else:
 
   test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
 
-  param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
-  extra_params = [param_hlsl_data_dir]
+  param_hlsl_data_dir = str.format('HlslDataDir={}', hlsl_data_dir)
+  extra_params = ['/p:', param_hlsl_data_dir]
 
   verbose = bool(getattr(config, 'verbose', False))
   if verbose != True:
-      extra_params.append('/logOutput:"LowWithConsoleBuffering"')
+      extra_params.append('/logOutput:')
+      extra_params.append('LowWithConsoleBuffering')
 
   arch = getattr(config, 'taef_arch', None)
   arch_filter = str.format("@Architecture='{}'", arch)

--- a/tools/clang/test/taef_exec/lit.cfg
+++ b/tools/clang/test/taef_exec/lit.cfg
@@ -50,22 +50,25 @@ if config.unsupported == False:
   hlsl_data_dir = os.path.join(config.llvm_src_root, 'tools', 'clang', 'unittests', 'HLSLExec')
 
   test_dir = os.path.join(config.llvm_obj_root, config.llvm_build_mode, 'test')
-  param_hlsl_data_dir = str.format('/p:"HlslDataDir={}"', hlsl_data_dir)
+  param_hlsl_data_dir = str.format('HlslDataDir={}', hlsl_data_dir)
 
-  extra_params = ['/p:"ExperimentalShaders=*\"', param_hlsl_data_dir]
+  extra_params = ['/p:', 'ExperimentalShaders=*', '/p:', param_hlsl_data_dir]
 
   verbose = bool(getattr(config, 'verbose', False))
   if verbose != True:
-      extra_params.append('/logOutput:"LowWithConsoleBuffering"')
+      extra_params.append('/logOutput:')
+      extra_params.append('LowWithConsoleBuffering')
 
   adapter = lit_config.params.get('adapter', None)
   if adapter:
       if adapter != '':
-          extra_params.append(str.format('/p:"Adapter={}"', adapter))
+          extra_params.append('/p:')
+          extra_params.append(str.format('Adapter={}', adapter))
 
   agility_sdk = lit_config.params.get('agility_sdk', None)
   if agility_sdk:
-    extra_params.append('/p:"D3D12SDKVersion=1"')
+    extra_params.append('/p:')
+    extra_params.append('D3D12SDKVersion=1')
 
   # use ';' to split multiple params.
   taef_extra_params = lit_config.params.get('taef_exec_extra_params', None)

--- a/utils/lit/lit/formats/taef.py
+++ b/utils/lit/lit/formats/taef.py
@@ -13,7 +13,6 @@ from .base import TestFormat
 # because of the way it manually processes quoted arguments in a
 # non-standard way.
 def executeCommandForTaef(command, cwd=None, env=None):
-    command = ' '.join(command)
     p = subprocess.Popen(command, cwd=cwd,
                         shell=True,
                         stdin=subprocess.PIPE,
@@ -65,17 +64,20 @@ class TaefTest(TestFormat):
         if litConfig.debug:
             litConfig.note('searching taef test in %r' % dll_path)
         
-        select_arg = str.format('/select:"{}"', self.select_filter)
+        cmd = [self.te, dll_path, "/list", "/select:", self.select_filter]
 
-        cmd = [self.te, dll_path, "/list", select_arg]
         try:
-            lines,_,_ = executeCommandForTaef(cmd)
+            lines,err,exitCode = executeCommandForTaef(cmd)
             # this is for windows
             lines = lines.replace('\r', '')
             lines = lines.split('\n')
 
         except:
-            litConfig.error("unable to discover taef tests in %r, using %s" % (dll_path, self.te))
+            litConfig.error("unable to discover taef tests in %r, using %s. exeption encountered." % (dll_path, self.te))
+            raise StopIteration
+
+        if exitCode:
+            litConfig.error("unable to discover taef tests in %r, using %s. error: %s." % (dll_path, self.te, err))
             raise StopIteration
 
         for ln in lines:
@@ -123,10 +125,8 @@ class TaefTest(TestFormat):
         if self.select_filter != "":
             select_filter = str.format("{} AND {}", select_filter, self.select_filter)
 
-        select_filter = str.format('/select:"{}"', select_filter)
-
         cmd = [self.te, test_dll, '/inproc',
-                select_filter,
+                '/select:', select_filter,
                 '/miniDumpOnCrash', '/unicodeOutput:false',
                 str.format('/outputFolder:{}', self.test_path)]
         cmd.extend(self.extra_params)


### PR DESCRIPTION
The way taef tests were gathered and executed previously flattened the list of arguments to a string. This allowed the weird /select: flag to work correctly, but if any of the arguments had spaces, they were misinterpretted having lost the implicit quotes around each.

By removing the flattening, putting a space between the flag and the argument for /select: and removing the explicit quotes around that argument, the command executes properly whether there are spaces or not

Additionally added a way to detect when these commands failed since they were silently failing and skipping a large swath of testing when spaces were present.

Fixes #5719