### PR TITLE
Fix memory leak on DxcCreateBlob of empty string

### DIFF
--- a/lib/DxcSupport/FileIOHelper.cpp
+++ b/lib/DxcSupport/FileIOHelper.cpp
@@ -598,6 +598,10 @@ HRESULT DxcCreateBlob(
     InternalDxcBlobEncoding *pInternalEncoding;
     IFR(InternalDxcBlobEncoding::CreateFromMalloc(nullptr, pMalloc, 0, encodingKnown, codePage, &pInternalEncoding));
     *ppBlobEncoding = pInternalEncoding;
+    if (pPtr && !(bCopy || bPinned)) {
+      // Free memory as we're not taking ownership of it
+      pMalloc->Free(const_cast<void*>(pPtr));
+    }
     return S_OK;
   }
 


### PR DESCRIPTION
In the case of an empty string, DxcCreateBlob does not take ownership of the input data object, and ends up leaking it.

Example ASAN error:
```
./bin/dxc -E main -T lib_6_3 /home/amaiorano/src/external/DirectXShaderCompiler/tools/clang/test/DXC/show-includes.hlsl

==524344==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1 byte(s) in 1 object(s) allocated from:
...
```