### PR TITLE
Remove node + compute validation exemption in sema

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15198,24 +15198,20 @@ static bool nodeInputIsCompatible(StringRef& typeName,
 
 void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, HLSLShaderAttr *Attr) {
 
-  SourceLocation ComputeLoc = SourceLocation();
   SourceLocation NodeLoc = SourceLocation();
   SourceLocation NodeLaunchLoc = SourceLocation();
   DXIL::NodeLaunchType NodeLaunchTy = DXIL::NodeLaunchType::Invalid;
   unsigned InputCount = 0;
-
-  // a function may be both compute and work-graph node
-  for (auto *pAttr : FD->specific_attrs<HLSLShaderAttr>()) {
-    DXIL::ShaderKind shaderKind = ShaderModel::KindFromFullName(pAttr->getStage());
-    if (shaderKind == DXIL::ShaderKind::Node) {
-      NodeLoc = pAttr->getLocation();
-    } else if (shaderKind == DXIL::ShaderKind::Compute) {
-      ComputeLoc = pAttr->getLocation();
-    }
+  
+  auto pAttr = FD->getAttr<HLSLShaderAttr>();
+  DXIL::ShaderKind shaderKind =
+      ShaderModel::KindFromFullName(pAttr->getStage());
+  if (shaderKind == DXIL::ShaderKind::Node) {
+    NodeLoc = pAttr->getLocation();
   }
-  // if this isn't a work-graph node we can quit now
-  if (!NodeLoc.isValid())
+  if (NodeLoc.isInvalid()) {
     return;
+  }
 
   // save NodeLaunch type for use later
   if (auto NodeLaunchAttr = FD->getAttr<HLSLNodeLaunchAttr>()) {
@@ -15225,15 +15221,6 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, HLSLShaderAttr *Attr) {
   } else {
     NodeLaunchTy = DXIL::NodeLaunchType::Broadcasting;
     NodeLaunchLoc = SourceLocation();
-  }
-
-  // If this is both a compute shader and work-graph node, it may only have
-  // broadcasting launch mode
-  if (ComputeLoc.isValid() &&
-      NodeLaunchTy != DXIL::NodeLaunchType::Broadcasting) {
-    S.Diags.Report(NodeLaunchLoc, diag::err_hlsl_compute_launch_compatibility)
-      << FD->getName() << ShaderModel::GetNodeLaunchTypeName(NodeLaunchTy);
-    S.Diags.Report(ComputeLoc, diag::note_defined_here) << "compute";
   }
 
   // Check that if a Thread launch node has the NumThreads attribute the
@@ -15306,15 +15293,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, HLSLShaderAttr *Attr) {
 
   // Check parameter constraints
   for (unsigned Idx = 0; Idx < FD->getNumParams(); ++Idx) {
-    ParmVarDecl *Param = FD->getParamDecl(Idx);
-
-    // compute is incompatible with node input/output
-    if (ComputeLoc.isValid() && hlsl::IsHLSLNodeType(Param->getType())) {
-      S.Diags.Report(Param->getLocation(),
-                     diag::err_hlsl_compute_io_compatibility)
-        << FD->getName() << "node input/output" << Param->getSourceRange();
-      S.Diags.Report(ComputeLoc, diag::note_defined_here) << "compute";
-    }
+    ParmVarDecl *Param = FD->getParamDecl(Idx);   
 
     // Check any node input is compatible with the node launch type
     if (hlsl::IsHLSLNodeInputType(Param->getType())) {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12849,10 +12849,7 @@ HLSLShaderAttr* ValidateShaderAttributes(Sema &S, Decl *D,
         ShaderModel::KindFromFullName(Existing->getStage());
     if (Stage == NewStage)
       return nullptr; // don't create, but no error.
-    if ((Stage != DXIL::ShaderKind::Compute &&
-         Stage != DXIL::ShaderKind::Node) ||
-        (NewStage != DXIL::ShaderKind::Compute &&
-         NewStage != DXIL::ShaderKind::Node)) {
+    else {
       S.Diag(A.getLoc(), diag::err_hlsl_conflicting_shader_attribute)
           << ShaderModel::FullNameFromKind(Stage) << ShaderModel::FullNameFromKind(NewStage);
       S.Diag(Existing->getLocation(), diag::note_conflicting_attribute);

--- a/tools/clang/test/HLSL/shader_attribute.hlsl
+++ b/tools/clang/test/HLSL/shader_attribute.hlsl
@@ -20,9 +20,9 @@ void VGMain() {
 void VNMain() {
 }
 
-[shader("compute")] 
-[shader("vertex")]  /* expected-error {{shader attribute type 'vertex' conflicts with shader attribute type 'node'}} */
-[shader("node")]    /* expected-note {{conflicting attribute is here}} */ 
+[shader("compute")] /* expected-error {{shader attribute type 'compute' conflicts with shader attribute type 'node'}} */
+[shader("vertex")]  /* expected-error {{shader attribute type 'vertex' conflicts with shader attribute type 'node'}} */ 
+[shader("node")]    /* expected-note {{conflicting attribute is here}} */ /* expected-note {{conflicting attribute is here}} */ 
 [NodeDispatchGrid(2,1,1)]
 [ numthreads( 64, 2, 2 ) ] 
 void CVNMain() {

--- a/tools/clang/test/HLSL/shader_attribute_no_mismatch.hlsl
+++ b/tools/clang/test/HLSL/shader_attribute_no_mismatch.hlsl
@@ -2,14 +2,6 @@
 
 [shader("compute")] 
 [shader("compute")] 
-[shader("node")] 
-[nodedispatchgrid(4,1,1)]
-[ numthreads( 64, 2, 2 ) ]  /* expected-no-diagnostics */
-void CCNMain() {
-}
-
-[shader("compute")] 
-[shader("compute")] 
 [ numthreads( 64, 2, 2 ) ]  /* expected-no-diagnostics */
 void CCMain() {
 }
@@ -19,21 +11,4 @@ void CCMain() {
 [nodedispatchgrid(8,1,1)]
 [ numthreads( 64, 2, 2 ) ]  /* expected-no-diagnostics */
 void NNMain() {
-}
-
-[shader("compute")]
-[shader("node")]
-[ numthreads( 64, 2, 2 ) ] /* expected-no-diagnostics */
-[nodedispatchgrid(16,1,1)]
-void CNMain() {
-}
-
-
-[shader("compute")] 
-[shader("node")] 
-[shader("compute")] 
-[shader("node")] 
-[nodedispatchgrid(32,1,1)]
-[ numthreads( 64, 2, 2 ) ]  /* expected-no-diagnostics */
-void CNCNMain() {
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/disallow_multiple_attrs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/disallow_multiple_attrs.hlsl
@@ -1,8 +1,7 @@
 // RUN: %dxc -T cs_6_8 -E node_compute %s | FileCheck %s
 
-// CHECK: error: Conflicting shader profile
-// CHECK: note: See conflicting shader attribute
-// CHECK: error: Invalid shader stage attribute combination
+// CHECK: error: shader attribute type 'node' conflicts with shader attribute type 'compute'
+// CHECK: note: conflicting attribute is here
 
 [Shader("node")]
 [Shader("compute")]


### PR DESCRIPTION
#5679 removed some code in the CodeGen pass that allowed node + compute, and some tests were updated. 
In this follow up PR, code is changed in the Sema pass that used to allow validation exemptions for node + compute. The appropriate tests were updated. This is an improvement to #5601

Fixes #5601 