### PR TITLE
Fix memory leaks of debug name in a couple of tests

### DIFF
--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -1280,7 +1280,7 @@ TEST_F(PixTest, CompileDebugDisasmPDB) {
   CComPtr<IDxcBlobEncoding> pSource;
   CComPtr<IDxcBlob> pProgram;
   CComPtr<IDxcBlob> pPdbBlob;
-  WCHAR *pDebugName = nullptr;
+  CComHeapPtr<WCHAR> pDebugName;
 
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
   VERIFY_SUCCEEDED(pCompiler.QueryInterface(&pCompiler2));
@@ -1316,7 +1316,7 @@ TEST_F(PixTest, CompileDebugPDB) {
   CComPtr<IDxcBlobEncoding> pSource;
   CComPtr<IDxcBlob> pProgram;
   CComPtr<IDxcBlob> pPdbBlob;
-  WCHAR *pDebugName = nullptr;
+  CComHeapPtr<WCHAR> pDebugName;
 
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
   VERIFY_SUCCEEDED(pCompiler.QueryInterface(&pCompiler2));

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -303,7 +303,7 @@ static HRESULT CompileForHash(hlsl::options::DxcOpts &opts, LPCWSTR CommandFileN
   CComPtr<IDxcBlob> pCompiledBlob;
   CComPtr<IDxcBlob> pCompiledName;
   CComPtr<IDxcIncludeHandler> pIncludeHandler;
-  WCHAR *pDebugName = nullptr;
+  CComHeapPtr<WCHAR> pDebugName;
   CComPtr<IDxcBlob> pPDBBlob;
 
   std::wstring entry =


### PR DESCRIPTION
A few tests were calling CompileWithDebug, passing in pointer that gets set to the debug name, but was never freed.