### PR TITLE
Fix ASAN alloc-dealloc-mismatch (operator new vs free)

### DIFF
--- a/unittests/ADT/StringMapTest.cpp
+++ b/unittests/ADT/StringMapTest.cpp
@@ -184,15 +184,18 @@ TEST_F(StringMapTest, IterationTest) {
   }
 }
 
+// HLSL Change begin
 // Test StringMapEntry::Create() method.
 TEST_F(StringMapTest, StringMapEntryTest) {
+  MallocAllocator A;
   StringMap<uint32_t>::value_type* entry =
       StringMap<uint32_t>::value_type::Create(
-          StringRef(testKeyFirst, testKeyLength), 1u);
+          StringRef(testKeyFirst, testKeyLength), A, 1u);
   EXPECT_STREQ(testKey, entry->first().data());
   EXPECT_EQ(1u, entry->second);
-  free(entry);
+  entry->Destroy(A);
 }
+// HLSL Change end
 
 // Test insert() method.
 TEST_F(StringMapTest, InsertTest) {


### PR DESCRIPTION
The MallocAllocator originally used malloc and free, but this was changed for DXC to use operator new/delete. The test called free() on the object that is now allocated with new. Fixed the test by passing in the allocator explicitly, and destroying the object using it.