### PR TITLE
Fix ASAN stack-use-after-scope in unit test

### DIFF
--- a/unittests/Support/CommandLineTest.cpp
+++ b/unittests/Support/CommandLineTest.cpp
@@ -72,11 +72,13 @@ public:
 
 cl::OptionCategory TestCategory("Test Options", "Description");
 TEST(CommandLineTest, ModifyExisitingOption) {
-  StackOption<int> TestOption("test-option", cl::desc("old description"));
-
+  // HLSL Change begin
   const char Description[] = "New description";
   const char ArgString[] = "new-test-option";
   const char ValueString[] = "Integer";
+
+  StackOption<int> TestOption("test-option", cl::desc("old description"));
+  // HLSL Change end
 
   StringMap<cl::Option *> &Map = cl::getRegisteredOptions();
 


### PR DESCRIPTION
When StackOption is destructed, it reads the its ArgStr member, which in this test is set to local variable ArgString. Since ArgString was declared after TestOption, it would be destructed first, and thus result in a stack-use-after-scope. Fix this by swapping the declaration order.