### PR TITLE
Remove unneeded Sema equal param special case

### DIFF
--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -9051,14 +9051,6 @@ static void DiagnoseBadConversion(Sema &S, OverloadCandidate *Cand,
       }
   }
 
-  // HLSL Change Starts
-  // With some intrinsics with templated parameters we can end up here
-  // with the To and From types being the same - we'll return early to
-  // avoid a weird diagnostic.
-  if (ToTy == FromTy)
-    return;
-  // HLSL Change Ends
-  
   // Emit the generic diagnostic and, optionally, add the hints to it.
   PartialDiagnostic FDiag = S.PDiag(diag::note_ovl_candidate_bad_conv);
   FDiag << (unsigned) FnKind << FnDesc

--- a/tools/clang/test/HLSL/workgraph/outputcomplete_unsupported_nodeio.hlsl
+++ b/tools/clang/test/HLSL/workgraph/outputcomplete_unsupported_nodeio.hlsl
@@ -11,7 +11,7 @@ struct RECORD {
 [NodeLaunch("Broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(1,1,1)]
-void node127_a(DispatchNodeInputRecord<RECORD> nodeInputRecord)
+void node_dispatchinputrecord(DispatchNodeInputRecord<RECORD> nodeInputRecord)
 {
   nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'DispatchNodeInputRecord<RECORD>'}}
 }
@@ -20,7 +20,7 @@ void node127_a(DispatchNodeInputRecord<RECORD> nodeInputRecord)
 [NodeLaunch("Broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(1,1,1)]
-void node127_c(RWDispatchNodeInputRecord<RECORD> rwNodeInputRecord)
+void node_rwdispatchinputrecord(RWDispatchNodeInputRecord<RECORD> rwNodeInputRecord)
 {
   rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWDispatchNodeInputRecord<RECORD>'}}
 }
@@ -28,7 +28,7 @@ void node127_c(RWDispatchNodeInputRecord<RECORD> rwNodeInputRecord)
 [Shader("node")]
 [NodeLaunch("Coalescing")]
 [NumThreads(1,1,1)]
-void node127_a(GroupNodeInputRecords<RECORD> nodeInputRecord)
+void node_groupinputrecords(GroupNodeInputRecords<RECORD> nodeInputRecord)
 {
   nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'GroupNodeInputRecords<RECORD>'}}
 }
@@ -36,7 +36,7 @@ void node127_a(GroupNodeInputRecords<RECORD> nodeInputRecord)
 [Shader("node")]
 [NodeLaunch("Coalescing")]
 [NumThreads(1,1,1)]
-void node127_c(RWGroupNodeInputRecords<RECORD> rwNodeInputRecord)
+void node_rwgroupinputrecords(RWGroupNodeInputRecords<RECORD> rwNodeInputRecord)
 {
   rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWGroupNodeInputRecords<RECORD>'}}
 }
@@ -44,7 +44,7 @@ void node127_c(RWGroupNodeInputRecords<RECORD> rwNodeInputRecord)
 [Shader("node")]
 [NodeLaunch("Thread")]
 [NumThreads(1,1,1)]
-void node127_a(ThreadNodeInputRecord<RECORD> nodeInputRecord)
+void node_threadinputrecord(ThreadNodeInputRecord<RECORD> nodeInputRecord)
 {
   nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'ThreadNodeInputRecord<RECORD>'}}
 }
@@ -52,16 +52,24 @@ void node127_a(ThreadNodeInputRecord<RECORD> nodeInputRecord)
 [Shader("node")]
 [NodeLaunch("Thread")]
 [NumThreads(1,1,1)]
-void node127_c(RWThreadNodeInputRecord<RECORD> rwNodeInputRecord)
+void node_rwthreadinputrecord(RWThreadNodeInputRecord<RECORD> rwNodeInputRecord)
 {
   rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWThreadNodeInputRecord<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Coalescing")]
+[NumThreads(1,1,1)]
+void node_emptynodeinput([MaxRecords(5)] EmptyNodeInput emptyNodeInput)
+{
+  emptyNodeInput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'EmptyNodeInput'}}
 }
 
 [Shader("node")]
 [NodeLaunch("Broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(1,1,1)]
-void node127_f(NodeOutput<RECORD> nodeOutput)
+void node_nodeoutput(NodeOutput<RECORD> nodeOutput)
 {
   nodeOutput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'NodeOutput<RECORD>'}}
 }
@@ -70,7 +78,7 @@ void node127_f(NodeOutput<RECORD> nodeOutput)
 [NodeLaunch("Broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(1,1,1)]
-void node127_g(EmptyNodeOutput emptyNodeOutput)
+void node127_emptynodeoutput(EmptyNodeOutput emptyNodeOutput)
 {
   emptyNodeOutput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'EmptyNodeOutput'}}
 }

--- a/tools/clang/test/HLSL/workgraph/outputcomplete_unsupported_nodio.hlsl
+++ b/tools/clang/test/HLSL/workgraph/outputcomplete_unsupported_nodio.hlsl
@@ -1,0 +1,76 @@
+// RUN: %clang_cc1 -verify %s
+// ==================================================================
+// OutputComplete() is called with unsupported node i/o types
+// ==================================================================
+
+struct RECORD {
+  int i;
+};
+
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(1,1,1)]
+void node127_a(DispatchNodeInputRecord<RECORD> nodeInputRecord)
+{
+  nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'DispatchNodeInputRecord<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(1,1,1)]
+void node127_c(RWDispatchNodeInputRecord<RECORD> rwNodeInputRecord)
+{
+  rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWDispatchNodeInputRecord<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Coalescing")]
+[NumThreads(1,1,1)]
+void node127_a(GroupNodeInputRecords<RECORD> nodeInputRecord)
+{
+  nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'GroupNodeInputRecords<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Coalescing")]
+[NumThreads(1,1,1)]
+void node127_c(RWGroupNodeInputRecords<RECORD> rwNodeInputRecord)
+{
+  rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWGroupNodeInputRecords<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Thread")]
+[NumThreads(1,1,1)]
+void node127_a(ThreadNodeInputRecord<RECORD> nodeInputRecord)
+{
+  nodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'ThreadNodeInputRecord<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Thread")]
+[NumThreads(1,1,1)]
+void node127_c(RWThreadNodeInputRecord<RECORD> rwNodeInputRecord)
+{
+  rwNodeInputRecord.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'RWThreadNodeInputRecord<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(1,1,1)]
+void node127_f(NodeOutput<RECORD> nodeOutput)
+{
+  nodeOutput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'NodeOutput<RECORD>'}}
+}
+
+[Shader("node")]
+[NodeLaunch("Broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(1,1,1)]
+void node127_g(EmptyNodeOutput emptyNodeOutput)
+{
+  emptyNodeOutput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'EmptyNodeOutput'}}
+}

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -550,5 +550,5 @@ TEST_F(VerifierTest, RunInvalidNodeLaunchDiags) {
   CheckVerifiesHLSL(L"/workgraph/invalid_nodelaunch.hlsl");
 }
 TEST_F(VerifierTest, RunInvalidNodeOutputCompleteDiags) {
-  CheckVerifiesHLSL(L"/workgraph/outputcomplete_unsupported_nodio.hlsl");
+  CheckVerifiesHLSL(L"/workgraph/outputcomplete_unsupported_nodeio.hlsl");
 }

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -120,6 +120,7 @@ public:
   TEST_METHOD(RunNodeZeroSizedRecordDiags)
   TEST_METHOD(RunWorkGraphAttributeDiags)
   TEST_METHOD(RunInvalidNodeLaunchDiags)
+  TEST_METHOD(RunInvalidNodeOutputCompleteDiags)
   TEST_METHOD(RunShaderMismatch)
   TEST_METHOD(RunMaxRecordsAttribute)
 
@@ -547,4 +548,7 @@ TEST_F(VerifierTest, RunWorkGraphAttributeDiags) {
 
 TEST_F(VerifierTest, RunInvalidNodeLaunchDiags) {
   CheckVerifiesHLSL(L"/workgraph/invalid_nodelaunch.hlsl");
+}
+TEST_F(VerifierTest, RunInvalidNodeOutputCompleteDiags) {
+  CheckVerifiesHLSL(L"/workgraph/outputcomplete_unsupported_nodio.hlsl");
 }


### PR DESCRIPTION
This was added to address a special case where OutputComplete was expecting a templated type, but got the wrong one and gave an unhelpful "no matching function" error instead of the error more specific to the requirements of OutputComplete.

Since OutputComplete no longer takes this as a parameter and is instead a method of the object, the hack is not needed.

Also restores testing for this by `node_emptynodeinput` in
tools/clang/test/HLSL/workgraph/outputcomplete_unsupported_nodeio.hlsl
```hlsl
[Shader("node")]
[NodeLaunch("Coalescing")]
void node_emptynodeinput([MaxRecords(5)] EmptyNodeInput emptyNodeInput)
{
  emptyNodeInput.OutputComplete(); // expected-error {{no member named 'OutputComplete' in 'EmptyNodeInput'}}
}
```


part of #5364