### PR TITLE
Execution tests: allow sharing of compile arguments

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -803,6 +803,7 @@ void ShaderOpTest::CreateShaders() {
     CComPtr<ID3DBlob> pCode;
     HRESULT hr = S_OK;
     LPCSTR pText = m_pShaderOp->GetShaderText(&S);
+    LPCSTR pArguments = m_pShaderOp->GetShaderArguments(&S);
     if (S.Callback) {
        if (!m_ShaderCallbackFn) {
          ShaderOpLogFmt(L"Callback required for shader, but not provided: %S\r\n", S.Name);
@@ -832,7 +833,7 @@ void ShaderOpTest::CreateShaders() {
       CA2W nameW(S.Name, CP_UTF8);
       CA2W entryPointW(S.EntryPoint, CP_UTF8);
       CA2W targetW(S.Target, CP_UTF8);
-      CA2W argumentsW(S.Arguments, CP_UTF8);
+      CA2W argumentsW(pArguments, CP_UTF8);
 
       std::vector<LPWSTR> argumentsWList;
       splitWStringIntoVectors(argumentsW, L' ', argumentsWList);

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.h
@@ -218,6 +218,18 @@ public:
     }
     return result;
   }
+  LPCSTR GetShaderArguments(ShaderOpShader *pShader) {
+    if (!pShader || !pShader->Arguments) return nullptr;
+    LPCSTR result = pShader->Arguments;
+    if (result[0] == '@') {
+      for (auto && S : Shaders) {
+        if (S.Name && 0 == strcmp(S.Name, result + 1))
+          return S.Arguments;
+      }
+      result = nullptr;
+    }
+    return result;
+  }
   ShaderOpDescriptorHeap *GetDescriptorHeapByName(LPCSTR pName) {
     for (auto && R : DescriptorHeaps) {
       if (R.Name && 0 == strcmp(R.Name, pName))


### PR DESCRIPTION
Allow sharing of shader compile arguments by referencing Arguments attribute from other shaders like this:

```
      ...
      <Shader Name="PS" Target="ps_6_0" EntryPoint="PSMain" Text="@CS" Arguments="@CS"/>
      <Shader Name="CS" Target="cs_6_0" EntryPoint="CSMain" Arguments="/Od">
        <![CDATA[
      ...
```