### PR TITLE
Fix HelperLaneTest

### DIFF
--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3017,8 +3017,8 @@
         <Viewport Width="2.0" Height="2.0" MaxDepth="1.0"/>
       </RenderTarget>
     </RenderTargets>
-    <Shader Name="VS" Target="vs_6_0" EntryPoint="VSMain" Text="@PS" />
-    <Shader Name="PS" Target="ps_6_0" EntryPoint="PSMain">
+    <Shader Name="VS" Target="vs_6_0" EntryPoint="VSMain" Text="@PS" Arguments="@PS"/>
+    <Shader Name="PS" Target="ps_6_0" EntryPoint="PSMain" Arguments="-opt-disable sink">
         <![CDATA[
 #ifdef ISHELPERLANE_PLACEHOLDER
         bool ph_IsHelperLane(float4 pos, bool first_call) {

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -3017,6 +3017,7 @@
         <Viewport Width="2.0" Height="2.0" MaxDepth="1.0"/>
       </RenderTarget>
     </RenderTargets>
+    <!-- Disable sink optimization to avoid issue #5744 -->
     <Shader Name="VS" Target="vs_6_0" EntryPoint="VSMain" Text="@PS" Arguments="@PS"/>
     <Shader Name="PS" Target="ps_6_0" EntryPoint="PSMain" Arguments="-opt-disable sink">
         <![CDATA[


### PR DESCRIPTION
Add `-opt-disable sink` to HelperLaneTest shader compilation to prevent sinking of `ddx_fine`/`ddy_fine` intrinsics into flow control.

Separate issue has been filed to track down the root of the problem:
#5744: Intrinsics ddx_fine/ddy_fine should not be allowed to sink into flow control