### PR TITLE
Add clang-format checker GitHub action.

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -1,0 +1,38 @@
+name: 'PR clang-format checker'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+jobs:
+  check-pr-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: install clang-format
+        run: sudo apt install -y clang-format
+      - run: |
+            echo Comparing $GITHUB_BASE_REF vs HEAD
+            git diff -U0 --no-color origin/$GITHUB_BASE_REF..HEAD | clang-format-diff -p1 | tee format.diff
+            if [ -s "format.diff" ]
+            then 
+              exit 1
+            fi
+      - if: failure()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'PR contains clang-format violations. See action log for diff.'
+            })

--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -19,7 +19,8 @@ jobs:
           fetch-depth: 0
       - name: install clang-format
         run: sudo apt install -y clang-format
-      - run: |
+      - name: Comparing ${{ env.GITHUB_BASE_REF }} vs HEAD
+        run: |
             echo Comparing $GITHUB_BASE_REF vs HEAD
             git diff -U0 --no-color origin/$GITHUB_BASE_REF..HEAD | clang-format-diff -p1 | tee format.diff
             if [ -s "format.diff" ]
@@ -34,5 +35,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'PR contains clang-format violations. See action log for diff.'
+              body: 'PR contains clang-format violations. See [action log](https://github.com/microsoft/DirectXShaderCompiler/actions/runs/${{ env.GITHUB_RUN_ID }}/job/${{ env.GITHUB_JOB }}) for the full diff.'
             })


### PR DESCRIPTION
This relands #5746.

The initial addition of this action failed due to a permissions issue. The addition of the permissions entry in the workflow should resolve that issue.

This reverts commit d949f78f69c0620fdba7320c2014424f4ecdd14f.