### PR TITLE
Fix cross-compile from non-Windows to Windows

### DIFF
--- a/lib/Support/Atomic.cpp
+++ b/lib/Support/Atomic.cpp
@@ -17,7 +17,7 @@
 using namespace llvm;
 
 #if defined(_MSC_VER)
-#include <Intrin.h>
+#include <intrin.h>
 #include <windows.h>
 #undef MemoryFence
 #endif


### PR DESCRIPTION
When cross-compiling from Linux/MacOS targeting Windows, the #include of "Intrin.h" ends up including the one from the Windows SDK because the host OS is case-sensitive, rather than "intrin.h" from the host standard library. Fix this by renaming the include with the correct case-sensitive name.