### PR TITLE
[NFC] Fix clang-formatting generated sources

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -44,7 +44,7 @@ function(add_hlsl_hctgen mode)
     message(FATAL_ERROR "add_hlsl_hctgen requires OUTPUT argument")
   endif()
  
-  set(temp_output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}.tmp)
+  set(temp_output ${CMAKE_CURRENT_BINARY_DIR}/tmp/${ARG_OUTPUT})
   set(full_output ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_OUTPUT})
   if (ARG_BUILD_DIR)
     set(full_output ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT})

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -7,10 +7,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "dxc/DXIL/DxilMetadataHelper.h"
 #include "dxc/DXIL/DxilCBuffer.h"
 #include "dxc/DXIL/DxilCounters.h"
 #include "dxc/DXIL/DxilFunctionProps.h"
-#include "dxc/DXIL/DxilMetadataHelper.h"
 #include "dxc/DXIL/DxilModule.h"
 #include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilResource.h"

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -9,9 +9,9 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/DXIL/DxilInstructions.h"
 #include "dxc/DXIL/DxilModule.h"
-#include "dxc/DXIL/DxilOperations.h"
 #include "dxc/Support/Global.h"
 
 #include "llvm/ADT/ArrayRef.h"


### PR DESCRIPTION
Clang-format determines if a header is the "main" header by looking at the header name without the last extension and matching it against the source file (with some extra handling for cuda files).

The automation generating temporary files with a `.tmp` suffix tripped this up so it wasn't matching the "main" header when sorting includes.

This corrects the issue by writing temporaries to a tmp directory instead of munging the suffix.