### PR TITLE
Fix apple-clang debug build failing to link llvm_assert

### DIFF
--- a/lib/Support/assert.cpp
+++ b/lib/Support/assert.cpp
@@ -25,7 +25,8 @@ void llvm_assert(const char *_Message, const char *_File, unsigned _Line,
 
 #include <assert.h>
 
-void llvm_assert(const char *message, const char *, unsigned) {
+void llvm_assert(const char *message, const char *, unsigned,
+                 const char *_Function) {
   assert(false && message);
 }
 


### PR DESCRIPTION
When building with apple-clang on MacOS, we get a linker error:

ld64.lld: error: undefined symbol: llvm_assert

Because the llvm_assert implementation is missing the last parameter.