### PR TITLE
[NFC] Use llvm::StringSwitch

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12054,74 +12054,26 @@ SpirvConstant *SpirvEmitter::tryToEvaluateAsConst(const Expr *expr) {
   return nullptr;
 }
 
-hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName) {
-  hlsl::ShaderModel::Kind smk;
-  switch (stageName[0]) {
-  case 'c':
-    switch (stageName[1]) {
-    case 'o':
-      smk = hlsl::ShaderModel::Kind::Compute;
-      break;
-    case 'l':
-      smk = hlsl::ShaderModel::Kind::ClosestHit;
-      break;
-    case 'a':
-      smk = hlsl::ShaderModel::Kind::Callable;
-      break;
-    default:
-      smk = hlsl::ShaderModel::Kind::Invalid;
-      break;
-    }
-    break;
-  case 'v':
-    smk = hlsl::ShaderModel::Kind::Vertex;
-    break;
-  case 'h':
-    smk = hlsl::ShaderModel::Kind::Hull;
-    break;
-  case 'd':
-    smk = hlsl::ShaderModel::Kind::Domain;
-    break;
-  case 'g':
-    smk = hlsl::ShaderModel::Kind::Geometry;
-    break;
-  case 'p':
-    smk = hlsl::ShaderModel::Kind::Pixel;
-    break;
-  case 'r':
-    smk = hlsl::ShaderModel::Kind::RayGeneration;
-    break;
-  case 'i':
-    smk = hlsl::ShaderModel::Kind::Intersection;
-    break;
-  case 'a':
-    switch (stageName[1]) {
-    case 'm':
-      smk = hlsl::ShaderModel::Kind::Amplification;
-      break;
-    case 'n':
-      smk = hlsl::ShaderModel::Kind::AnyHit;
-      break;
-    }
-    break;
-  case 'm':
-    switch (stageName[1]) {
-    case 'e':
-      smk = hlsl::ShaderModel::Kind::Mesh;
-      break;
-    case 'i':
-      smk = hlsl::ShaderModel::Kind::Miss;
-      break;
-    }
-    break;
-  default:
-    smk = hlsl::ShaderModel::Kind::Invalid;
-    break;
-  }
-  if (smk == hlsl::ShaderModel::Kind::Invalid) {
-    llvm_unreachable("unknown stage name");
-  }
-  return smk;
+hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName)
+{
+  hlsl::ShaderModel::Kind SMK = llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
+      .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
+      .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
+      .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
+      .Case("hull", hlsl::ShaderModel::Kind::Hull)
+      .Case("domain", hlsl::ShaderModel::Kind::Domain)
+      .Case("compute", hlsl::ShaderModel::Kind::Compute)
+      .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
+      .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
+      .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
+      .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
+      .Case("miss", hlsl::ShaderModel::Kind::Miss)
+      .Case("callable", hlsl::ShaderModel::Kind::Callable)
+      .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
+      .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
+      .Default(hlsl::ShaderModel::Kind::Invalid);
+  assert(SMK != hlsl::ShaderModel::Kind::Invalid);
+  return SMK;
 }
 
 spv::ExecutionModel

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12054,24 +12054,24 @@ SpirvConstant *SpirvEmitter::tryToEvaluateAsConst(const Expr *expr) {
   return nullptr;
 }
 
-hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName)
-{
-  hlsl::ShaderModel::Kind SMK = llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
-      .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
-      .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
-      .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
-      .Case("hull", hlsl::ShaderModel::Kind::Hull)
-      .Case("domain", hlsl::ShaderModel::Kind::Domain)
-      .Case("compute", hlsl::ShaderModel::Kind::Compute)
-      .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
-      .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
-      .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
-      .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
-      .Case("miss", hlsl::ShaderModel::Kind::Miss)
-      .Case("callable", hlsl::ShaderModel::Kind::Callable)
-      .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
-      .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
-      .Default(hlsl::ShaderModel::Kind::Invalid);
+hlsl::ShaderModel::Kind SpirvEmitter::getShaderModelKind(StringRef stageName) {
+  hlsl::ShaderModel::Kind SMK =
+      llvm::StringSwitch<hlsl::ShaderModel::Kind>(stageName)
+          .Case("pixel", hlsl::ShaderModel::Kind::Pixel)
+          .Case("vertex", hlsl::ShaderModel::Kind::Vertex)
+          .Case("geometry", hlsl::ShaderModel::Kind::Geometry)
+          .Case("hull", hlsl::ShaderModel::Kind::Hull)
+          .Case("domain", hlsl::ShaderModel::Kind::Domain)
+          .Case("compute", hlsl::ShaderModel::Kind::Compute)
+          .Case("raygeneration", hlsl::ShaderModel::Kind::RayGeneration)
+          .Case("intersection", hlsl::ShaderModel::Kind::Intersection)
+          .Case("anyhit", hlsl::ShaderModel::Kind::AnyHit)
+          .Case("closesthit", hlsl::ShaderModel::Kind::ClosestHit)
+          .Case("miss", hlsl::ShaderModel::Kind::Miss)
+          .Case("callable", hlsl::ShaderModel::Kind::Callable)
+          .Case("mesh", hlsl::ShaderModel::Kind::Mesh)
+          .Case("amplification", hlsl::ShaderModel::Kind::Amplification)
+          .Default(hlsl::ShaderModel::Kind::Invalid);
   assert(SMK != hlsl::ShaderModel::Kind::Invalid);
   return SMK;
 }


### PR DESCRIPTION
This replaces a hand-rolled string parser with an
llvm::StringSwitch that matches full strings. This should be more resilient and maintainable.