### PR TITLE
Fix the clang-format workflow

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -17,22 +17,22 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: install clang-format
-        run: sudo apt install -y clang-format
       - name: Comparing PR against target branch
         env:
           PR_NUMBER: ${{ github.event.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-            echo Comparing $GITHUB_BASE_REF vs HEAD
-            git diff -U0 --no-color origin/$GITHUB_BASE_REF..HEAD | clang-format-diff -p1 | tee format.diff
-            if [ -s "format.diff" ]
+            echo Comparing $PR_NUMBER vs target branch
+            git fetch origin refs/pull/$PR_NUMBER/head:pull/$PR_NUMBER
+            git checkout pull/$PR_NUMBER
+            git diff -U0 --no-color $GITHUB_REF..pull/$PR_NUMBER | clang-format-diff-15 -p1 | tee format.diff
+            if [ -s format.diff ]
             then
               echo PR contains clang-format violations. First 50 lines of the diff: >> message.txt
-              echo ``` >> message.txt
+              echo \`\`\`diff >> message.txt
               cat format.diff | head -n 50 >> message.txt
-              echo ``` >> message.txt
-              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/job/$GITHUB_JOB\) for the full diff.  >> message.txt
+              echo \`\`\` >> message.txt
+              echo See [action log]\(https://github.com/microsoft/DirectXShaderCompiler/actions/runs/$GITHUB_RUN_ID/) for the full diff.  >> message.txt
               gh pr comment $PR_NUMBER --body-file message.txt
               exit 1
             fi


### PR DESCRIPTION
There were a few bugs that were difficult to reproduce. The pull request branch ref needs to be fetched and checked out manually in order to get the PR diff to construct. This change also fixes formatting to get a nice diff printed of the PR output.

See an example of the error output this produces here:

https://github.com/llvm-beanz/DirectXShaderCompiler/pull/2