### PR TITLE
Don't string match node type names

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -344,7 +344,7 @@ void AddHLSLVectorTemplate(clang::ASTContext &context,
                            clang::ClassTemplateDecl **vectorTemplateDecl);
 
 void AddHLSLNodeOutputRecordTemplate(
-    clang::ASTContext &context, llvm::StringRef templateName,
+    clang::ASTContext &context, DXIL::NodeIOKind Type,
     _Outptr_ clang::ClassTemplateDecl **outputRecordTemplateDecl,
     bool isCompleteType = true);
 
@@ -394,13 +394,13 @@ clang::CXXRecordDecl *DeclareResourceType(clang::ASTContext &context,
                                           bool bSampler);
 
 clang::CXXRecordDecl *
-DeclareNodeOrRecordType(clang::ASTContext &Ctx, llvm::StringRef TypeName,
+DeclareNodeOrRecordType(clang::ASTContext &Ctx, DXIL::NodeIOKind Type,
                         bool IsRecordTypeTemplate = false, bool IsConst = false,
                         bool HasGetMethods = false, bool IsArray = false,
                         bool IsCompleteType = false);
 
 clang::CXXRecordDecl *DeclareNodeOutputArray(clang::ASTContext &Ctx,
-                                             llvm::StringRef TypeName,
+                                             DXIL::NodeIOKind Type,
                                              clang::CXXRecordDecl *OutputType,
                                              bool IsRecordTypeTemplate,
                                              bool IsCompleteType);
@@ -464,6 +464,8 @@ bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);
 bool IsHLSLRWNodeInputRecordType(clang::QualType type);
 bool IsHLSLRONodeInputRecordType(clang::QualType type);
 bool IsHLSLNodeOutputType(clang::QualType type);
+
+DXIL::NodeIOKind GetNodeIOType(clang::QualType type);
 
 bool IsHLSLStructuredBufferType(clang::QualType type);
 bool IsHLSLNumericOrAggregateOfNumericType(clang::QualType type);

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -984,7 +984,7 @@ def HLSLNodeTrackRWInputSharing : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
-def HLSLNodeRecord : InheritableAttr {
+def HLSLNodeObject : InheritableAttr {
   let Spellings = []; // No spellings!
   let Subjects = SubjectList<[CXXRecord]>;
   let Documentation = [Undocumented];
@@ -1016,6 +1016,83 @@ def HLSLNodeRecord : InheritableAttr {
                            "EmptyNodeOutputArray",
                            "GroupNodeOutputRecords",
                            "ThreadNodeOutputRecords"]>];
+
+  let AdditionalMembers =
+  [{hlsl::DXIL::NodeIOKind getNodeIOType() const {
+      switch (type) {
+      case DispatchNodeInputRecord:
+        return hlsl::DXIL::NodeIOKind::DispatchNodeInputRecord;
+      case RWDispatchNodeInputRecord:
+        return hlsl::DXIL::NodeIOKind::RWDispatchNodeInputRecord;
+      case GroupNodeInputRecords:
+        return hlsl::DXIL::NodeIOKind::GroupNodeInputRecords;
+      case RWGroupNodeInputRecords:
+        return hlsl::DXIL::NodeIOKind::RWGroupNodeInputRecords;
+      case ThreadNodeInputRecord:
+        return hlsl::DXIL::NodeIOKind::ThreadNodeInputRecord;
+      case RWThreadNodeInputRecord:
+        return hlsl::DXIL::NodeIOKind::RWThreadNodeInputRecord;
+      case EmptyNodeInput:
+        return hlsl::DXIL::NodeIOKind::EmptyInput;
+      case NodeOutput:
+        return hlsl::DXIL::NodeIOKind::NodeOutput;
+      case EmptyNodeOutput:
+        return hlsl::DXIL::NodeIOKind::EmptyOutput;
+      case NodeOutputArray:
+        return hlsl::DXIL::NodeIOKind::NodeOutputArray;
+      case EmptyNodeOutputArray:
+        return hlsl::DXIL::NodeIOKind::EmptyOutputArray;
+      case GroupNodeOutputRecords:
+        return hlsl::DXIL::NodeIOKind::GroupNodeOutputRecords;
+      case ThreadNodeOutputRecords:
+        return hlsl::DXIL::NodeIOKind::ThreadNodeOutputRecords;
+      }
+      llvm_unreachable("all cases exhausted");
+      return hlsl::DXIL::NodeIOKind::Invalid;
+    }
+
+    static RecordType toAttrType(hlsl::DXIL::NodeIOKind Type) {
+      switch (Type) {
+      case hlsl::DXIL::NodeIOKind::DispatchNodeInputRecord:
+        return DispatchNodeInputRecord;
+      case hlsl::DXIL::NodeIOKind::RWDispatchNodeInputRecord:
+        return RWDispatchNodeInputRecord;
+      case hlsl::DXIL::NodeIOKind::GroupNodeInputRecords:
+        return GroupNodeInputRecords;
+      case hlsl::DXIL::NodeIOKind::RWGroupNodeInputRecords:
+        return RWGroupNodeInputRecords;
+      case hlsl::DXIL::NodeIOKind::ThreadNodeInputRecord:
+        return ThreadNodeInputRecord;
+      case hlsl::DXIL::NodeIOKind::RWThreadNodeInputRecord:
+        return RWThreadNodeInputRecord;
+      case hlsl::DXIL::NodeIOKind::EmptyInput:
+        return EmptyNodeInput;
+      case hlsl::DXIL::NodeIOKind::NodeOutput:
+        return NodeOutput;
+      case hlsl::DXIL::NodeIOKind::EmptyOutput:
+        return EmptyNodeOutput;
+      case hlsl::DXIL::NodeIOKind::NodeOutputArray:
+        return NodeOutputArray;
+      case hlsl::DXIL::NodeIOKind::EmptyOutputArray:
+        return EmptyNodeOutputArray;
+      case hlsl::DXIL::NodeIOKind::GroupNodeOutputRecords:
+        return GroupNodeOutputRecords;
+      case hlsl::DXIL::NodeIOKind::ThreadNodeOutputRecords:
+        return ThreadNodeOutputRecords;
+      }
+      llvm_unreachable("all cases exhausted");
+    }
+
+    static HLSLNodeObjectAttr *CreateImplicit(ASTContext &Ctx,
+                                              hlsl::DXIL::NodeIOKind Type,
+                                              SourceRange Loc = SourceRange()) {
+      return CreateImplicit(Ctx, toAttrType(Type), Loc);
+    }
+
+    static const char *ConvertRecordTypeToStr(hlsl::DXIL::NodeIOKind Type) {
+      return ConvertRecordTypeToStr(toAttrType(Type));
+    }
+    }];
 }
 
 

--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -984,6 +984,40 @@ def HLSLNodeTrackRWInputSharing : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def HLSLNodeRecord : InheritableAttr {
+  let Spellings = []; // No spellings!
+  let Subjects = SubjectList<[CXXRecord]>;
+  let Documentation = [Undocumented];
+
+  let Args = [EnumArgument<"Type", "RecordType",
+                           ["DispatchNodeInputRecord",
+                           "RWDispatchNodeInputRecord",
+                           "GroupNodeInputRecords",
+                           "RWGroupNodeInputRecords",
+                           "ThreadNodeInputRecord",
+                           "RWThreadNodeInputRecord",
+                           "EmptyNodeInput",
+                           "NodeOutput",
+                           "EmptyNodeOutput",
+                           "NodeOutputArray",
+                           "EmptyNodeOutputArray",
+                           "GroupNodeOutputRecords",
+                           "ThreadNodeOutputRecords"],
+                           ["DispatchNodeInputRecord",
+                           "RWDispatchNodeInputRecord",
+                           "GroupNodeInputRecords",
+                           "RWGroupNodeInputRecords",
+                           "ThreadNodeInputRecord",
+                           "RWThreadNodeInputRecord",
+                           "EmptyNodeInput",
+                           "NodeOutput",
+                           "EmptyNodeOutput",
+                           "NodeOutputArray",
+                           "EmptyNodeOutputArray",
+                           "GroupNodeOutputRecords",
+                           "ThreadNodeOutputRecords"]>];
+}
+
 
 // HLSL Parameter Attributes
 

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -466,38 +466,6 @@ static void AddRecordSubscriptAccess(clang::ASTContext &Ctx,
   AddRecordAccessMethod(Ctx, RD, ReturnTy, false, true, true);
 }
 
-static HLSLNodeRecordAttr::RecordType toAttrType(DXIL::NodeIOKind Type) {
-  switch (Type) {
-  case DXIL::NodeIOKind::DispatchNodeInputRecord:
-    return HLSLNodeRecordAttr::DispatchNodeInputRecord;
-  case DXIL::NodeIOKind::RWDispatchNodeInputRecord:
-    return HLSLNodeRecordAttr::RWDispatchNodeInputRecord;
-  case DXIL::NodeIOKind::GroupNodeInputRecords:
-    return HLSLNodeRecordAttr::GroupNodeInputRecords;
-  case DXIL::NodeIOKind::RWGroupNodeInputRecords:
-    return HLSLNodeRecordAttr::RWGroupNodeInputRecords;
-  case DXIL::NodeIOKind::ThreadNodeInputRecord:
-    return HLSLNodeRecordAttr::ThreadNodeInputRecord;
-  case DXIL::NodeIOKind::RWThreadNodeInputRecord:
-    return HLSLNodeRecordAttr::RWThreadNodeInputRecord;
-  case DXIL::NodeIOKind::EmptyInput:
-    return HLSLNodeRecordAttr::EmptyNodeInput;
-  case DXIL::NodeIOKind::NodeOutput:
-    return HLSLNodeRecordAttr::NodeOutput;
-  case DXIL::NodeIOKind::EmptyOutput:
-    return HLSLNodeRecordAttr::EmptyNodeOutput;
-  case DXIL::NodeIOKind::NodeOutputArray:
-    return HLSLNodeRecordAttr::NodeOutputArray;
-  case DXIL::NodeIOKind::EmptyOutputArray:
-    return HLSLNodeRecordAttr::EmptyNodeOutputArray;
-  case DXIL::NodeIOKind::GroupNodeOutputRecords:
-    return HLSLNodeRecordAttr::GroupNodeOutputRecords;
-  case DXIL::NodeIOKind::ThreadNodeOutputRecords:
-    return HLSLNodeRecordAttr::ThreadNodeOutputRecords;
-  }
-  llvm_unreachable("all cases exhausted");
-}
-
 /// <summary>Adds up-front support for HLSL *NodeOutputRecords template
 /// types.</summary>
 void hlsl::AddHLSLNodeOutputRecordTemplate(
@@ -506,8 +474,7 @@ void hlsl::AddHLSLNodeOutputRecordTemplate(
     bool isCompleteType /*= true*/) {
   DXASSERT_NOMSG(outputRecordTemplateDecl != nullptr);
 
-  HLSLNodeRecordAttr::RecordType RecTy = toAttrType(Type);
-  StringRef templateName = HLSLNodeRecordAttr::ConvertRecordTypeToStr(RecTy);
+  StringRef templateName = HLSLNodeObjectAttr::ConvertRecordTypeToStr(Type);
 
   // Create a *NodeOutputRecords template declaration in translation unit scope.
   BuiltinTypeDeclBuilder typeDeclBuilder(context.getTranslationUnitDecl(),
@@ -522,7 +489,7 @@ void hlsl::AddHLSLNodeOutputRecordTemplate(
   typeDeclBuilder.addField("h", GetHLSLObjectHandleType(context));
 
   typeDeclBuilder.getRecordDecl()->addAttr(
-      HLSLNodeRecordAttr::CreateImplicit(context, RecTy));
+      HLSLNodeObjectAttr::CreateImplicit(context, Type));
 
   QualType elementType = context.getTemplateTypeParmType(
       0, 0, ParameterPackFalse, outputTemplateParamDecl);
@@ -1244,8 +1211,7 @@ CXXRecordDecl *hlsl::DeclareResourceType(ASTContext &context, bool bSampler) {
 CXXRecordDecl *hlsl::DeclareNodeOrRecordType(
     clang::ASTContext &Ctx, DXIL::NodeIOKind Type, bool IsRecordTypeTemplate,
     bool IsConst, bool HasGetMethods, bool IsArray, bool IsCompleteType) {
-  HLSLNodeRecordAttr::RecordType RecTy = toAttrType(Type);
-  StringRef TypeName = HLSLNodeRecordAttr::ConvertRecordTypeToStr(RecTy);
+  StringRef TypeName = HLSLNodeObjectAttr::ConvertRecordTypeToStr(Type);
 
   BuiltinTypeDeclBuilder Builder(Ctx.getTranslationUnitDecl(), TypeName,
                                  TagDecl::TagKind::TTK_Struct);
@@ -1258,7 +1224,7 @@ CXXRecordDecl *hlsl::DeclareNodeOrRecordType(
   Builder.addField("h", GetHLSLObjectHandleType(Ctx));
 
   Builder.getRecordDecl()->addAttr(
-      HLSLNodeRecordAttr::CreateImplicit(Ctx, RecTy));
+      HLSLNodeObjectAttr::CreateImplicit(Ctx, Type));
 
   if (IsRecordTypeTemplate) {
     QualType ParamTy = QualType(TyParamDecl->getTypeForDecl(), 0);
@@ -1282,8 +1248,7 @@ CXXRecordDecl *hlsl::DeclareNodeOutputArray(clang::ASTContext &Ctx,
                                             CXXRecordDecl *OutputType,
                                             bool IsRecordTypeTemplate,
                                             bool IsCompleteType) {
-  HLSLNodeRecordAttr::RecordType RecTy = toAttrType(Type);
-  StringRef TypeName = HLSLNodeRecordAttr::ConvertRecordTypeToStr(RecTy);
+  StringRef TypeName = HLSLNodeObjectAttr::ConvertRecordTypeToStr(Type);
   BuiltinTypeDeclBuilder Builder(Ctx.getTranslationUnitDecl(), TypeName,
                                  TagDecl::TagKind::TTK_Struct);
   TemplateTypeParmDecl *elementTemplateParamDecl = nullptr;
@@ -1295,7 +1260,7 @@ CXXRecordDecl *hlsl::DeclareNodeOutputArray(clang::ASTContext &Ctx,
   Builder.addField("h", GetHLSLObjectHandleType(Ctx));
 
   Builder.getRecordDecl()->addAttr(
-      HLSLNodeRecordAttr::CreateImplicit(Ctx, RecTy));
+      HLSLNodeObjectAttr::CreateImplicit(Ctx, Type));
 
   QualType ResultType;
   if (IsRecordTypeTemplate) {

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -664,28 +664,25 @@ bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type) {
 }
 
 bool IsHLSLRWNodeInputRecordType(clang::QualType type) {
-  if (const HLSLNodeObjectAttr *Attr = getNodeAttr(type))
-    return Attr->getType() == HLSLNodeObjectAttr::RWDispatchNodeInputRecord ||
-           Attr->getType() == HLSLNodeObjectAttr::RWGroupNodeInputRecords ||
-           Attr->getType() == HLSLNodeObjectAttr::RWThreadNodeInputRecord;
-  return false;
+  return (static_cast<uint32_t>(GetNodeIOType(type)) &
+          (static_cast<uint32_t>(DXIL::NodeIOFlags::ReadWrite) |
+           static_cast<uint32_t>(DXIL::NodeIOFlags::Input))) ==
+         (static_cast<uint32_t>(DXIL::NodeIOFlags::ReadWrite) |
+          static_cast<uint32_t>(DXIL::NodeIOFlags::Input));
 }
 
 bool IsHLSLRONodeInputRecordType(clang::QualType type) {
-  if (const HLSLNodeObjectAttr *Attr = getNodeAttr(type))
-    return Attr->getType() == HLSLNodeObjectAttr::DispatchNodeInputRecord ||
-           Attr->getType() == HLSLNodeObjectAttr::GroupNodeInputRecords ||
-           Attr->getType() == HLSLNodeObjectAttr::ThreadNodeInputRecord;
-  return false;
+  return (static_cast<uint32_t>(GetNodeIOType(type)) &
+          (static_cast<uint32_t>(DXIL::NodeIOFlags::ReadWrite) |
+           static_cast<uint32_t>(DXIL::NodeIOFlags::Input))) ==
+         static_cast<uint32_t>(DXIL::NodeIOFlags::Input);
 }
 
 bool IsHLSLNodeOutputType(clang::QualType type) {
-  if (const HLSLNodeObjectAttr *Attr = getNodeAttr(type))
-    return Attr->getType() == HLSLNodeObjectAttr::NodeOutput ||
-           Attr->getType() == HLSLNodeObjectAttr::NodeOutputArray ||
-           Attr->getType() == HLSLNodeObjectAttr::EmptyNodeOutput ||
-           Attr->getType() == HLSLNodeObjectAttr::EmptyNodeOutputArray;
-  return false;
+  return (static_cast<uint32_t>(GetNodeIOType(type)) &
+          (static_cast<uint32_t>(DXIL::NodeIOFlags::Output) |
+           static_cast<uint32_t>(DXIL::NodeIOFlags::RecordGranularityMask))) ==
+         static_cast<uint32_t>(DXIL::NodeIOFlags::Output);
 }
 
 bool IsHLSLStructuredBufferType(clang::QualType type) {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -3878,69 +3878,71 @@ private:
             *m_context, "FeedbackTexture2DArray", "kind");
       } else if (kind == AR_OBJECT_EMPTY_NODE_INPUT) {
         recordDecl = DeclareNodeOrRecordType(
-            *m_context, "EmptyNodeInput",
+            *m_context, DXIL::NodeIOKind::EmptyInput,
             /*IsRecordTypeTemplate*/ false, /*IsConst*/ true,
             /*HasGetMethods*/ false,
             /*IsArray*/ false, /*IsCompleteType*/ false);
       } else if (kind == AR_OBJECT_DISPATCH_NODE_INPUT_RECORD) {
-        recordDecl =
-            DeclareNodeOrRecordType(*m_context, "DispatchNodeInputRecord",
-                                    /*IsRecordTypeTemplate*/ true,
-                                    /*IsConst*/ true, /*HasGetMethods*/ true,
-                                    /*IsArray*/ false, /*IsCompleteType*/ true);
+        recordDecl = DeclareNodeOrRecordType(
+            *m_context, DXIL::NodeIOKind::DispatchNodeInputRecord,
+            /*IsRecordTypeTemplate*/ true,
+            /*IsConst*/ true, /*HasGetMethods*/ true,
+            /*IsArray*/ false, /*IsCompleteType*/ true);
       } else if (kind == AR_OBJECT_RWDISPATCH_NODE_INPUT_RECORD) {
         recordDecl = DeclareNodeOrRecordType(
-            *m_context, "RWDispatchNodeInputRecord",
+            *m_context, DXIL::NodeIOKind::RWDispatchNodeInputRecord,
             /*IsRecordTypeTemplate*/ true, /*IsConst*/ false,
             /*HasGetMethods*/ true,
             /*IsArray*/ false, /*IsCompleteType*/ false);
       } else if (kind == AR_OBJECT_GROUP_NODE_INPUT_RECORDS) {
-        recordDecl =
-            DeclareNodeOrRecordType(*m_context, "GroupNodeInputRecords",
-                                    /*IsRecordTypeTemplate*/ true,
-                                    /*IsConst*/ true, /*HasGetMethods*/ true,
-                                    /*IsArray*/ true, /*IsCompleteType*/ false);
+        recordDecl = DeclareNodeOrRecordType(
+            *m_context, DXIL::NodeIOKind::GroupNodeInputRecords,
+            /*IsRecordTypeTemplate*/ true,
+            /*IsConst*/ true, /*HasGetMethods*/ true,
+            /*IsArray*/ true, /*IsCompleteType*/ false);
       } else if (kind == AR_OBJECT_RWGROUP_NODE_INPUT_RECORDS) {
-        recordDecl =
-            DeclareNodeOrRecordType(*m_context, "RWGroupNodeInputRecords",
-                                    /*IsRecordTypeTemplate*/ true,
-                                    /*IsConst*/ false, /*HasGetMethods*/ true,
-                                    /*IsArray*/ true, /*IsCompleteType*/ false);
+        recordDecl = DeclareNodeOrRecordType(
+            *m_context, DXIL::NodeIOKind::RWGroupNodeInputRecords,
+            /*IsRecordTypeTemplate*/ true,
+            /*IsConst*/ false, /*HasGetMethods*/ true,
+            /*IsArray*/ true, /*IsCompleteType*/ false);
       } else if (kind == AR_OBJECT_THREAD_NODE_INPUT_RECORD) {
-        recordDecl =
-            DeclareNodeOrRecordType(*m_context, "ThreadNodeInputRecord",
-                                    /*IsRecordTypeTemplate*/ true,
-                                    /*IsConst*/ true, /*HasGetMethods*/ true,
-                                    /*IsArray*/ false, /*IsCompleteType*/ true);
+        recordDecl = DeclareNodeOrRecordType(
+            *m_context, DXIL::NodeIOKind::ThreadNodeInputRecord,
+            /*IsRecordTypeTemplate*/ true,
+            /*IsConst*/ true, /*HasGetMethods*/ true,
+            /*IsArray*/ false, /*IsCompleteType*/ true);
       } else if (kind == AR_OBJECT_RWTHREAD_NODE_INPUT_RECORD) {
-        recordDecl =
-            DeclareNodeOrRecordType(*m_context, "RWThreadNodeInputRecord",
-                                    /*IsRecordTypeTemplate*/ true,
-                                    /*IsConst*/ false, /*HasGetMethods*/ true,
-                                    /*IsArray*/ false, /*IsCompleteType*/ true);
+        recordDecl = DeclareNodeOrRecordType(
+            *m_context, DXIL::NodeIOKind::RWThreadNodeInputRecord,
+            /*IsRecordTypeTemplate*/ true,
+            /*IsConst*/ false, /*HasGetMethods*/ true,
+            /*IsArray*/ false, /*IsCompleteType*/ true);
       } else if (kind == AR_OBJECT_NODE_OUTPUT) {
         recordDecl = DeclareNodeOrRecordType(
-            *m_context, "NodeOutput",
+            *m_context, DXIL::NodeIOKind::NodeOutput,
             /*IsRecordTypeTemplate*/ true, /*IsConst*/ true,
             /*HasGetMethods*/ false,
             /*IsArray*/ false, /*IsCompleteType*/ false);
         nodeOutputDecl = recordDecl;
       } else if (kind == AR_OBJECT_EMPTY_NODE_OUTPUT) {
         recordDecl = DeclareNodeOrRecordType(
-            *m_context, "EmptyNodeOutput",
+            *m_context, DXIL::NodeIOKind::EmptyOutput,
             /*IsRecordTypeTemplate*/ false, /*IsConst*/ true,
             /*HasGetMethods*/ false,
             /*IsArray*/ false, /*IsCompleteType*/ false);
         emptyNodeOutputDecl = recordDecl;
       } else if (kind == AR_OBJECT_NODE_OUTPUT_ARRAY) {
         assert(nodeOutputDecl != nullptr);
-        recordDecl = DeclareNodeOutputArray(*m_context, "NodeOutputArray",
+        recordDecl = DeclareNodeOutputArray(*m_context,
+                                            DXIL::NodeIOKind::NodeOutputArray,
                                             /* ItemType */ nodeOutputDecl,
                                             /*IsRecordTypeTemplate*/ true,
                                             /*IsCompleteType*/ true);
       } else if (kind == AR_OBJECT_EMPTY_NODE_OUTPUT_ARRAY) {
         assert(emptyNodeOutputDecl != nullptr);
-        recordDecl = DeclareNodeOutputArray(*m_context, "EmptyNodeOutputArray",
+        recordDecl = DeclareNodeOutputArray(*m_context,
+                                            DXIL::NodeIOKind::EmptyOutputArray,
                                             /* ItemType */ emptyNodeOutputDecl,
                                             /*IsRecordTypeTemplate*/ false,
                                             /*IsCompleteType*/ true);
@@ -5115,10 +5117,12 @@ public:
     AddSamplerFeedbackConstants(*m_context);
     AddBarrierConstants(*m_context);
 
-    AddHLSLNodeOutputRecordTemplate(*m_context, "GroupNodeOutputRecords",
+    AddHLSLNodeOutputRecordTemplate(*m_context,
+                                    DXIL::NodeIOKind::GroupNodeOutputRecords,
                                     &m_GroupNodeOutputRecordsTemplateDecl,
                                     /* isCompleteType */ false);
-    AddHLSLNodeOutputRecordTemplate(*m_context, "ThreadNodeOutputRecords",
+    AddHLSLNodeOutputRecordTemplate(*m_context,
+                                    DXIL::NodeIOKind::ThreadNodeOutputRecords,
                                     &m_ThreadNodeOutputRecordsTemplateDecl,
                                     /* isCompleteType */ false);
 
@@ -5357,16 +5361,7 @@ public:
       }
       return false;
 
-    } else if (templateName == "DispatchNodeInputRecord" ||
-               templateName == "RWDispatchNodeInputRecord" ||
-               templateName == "GroupNodeInputRecords" ||
-               templateName == "RWGroupNodeInputRecords" ||
-               templateName == "ThreadNodeInputRecord" ||
-               templateName == "RWThreadNodeInputRecord" ||
-               templateName == "NodeOutput" ||
-               templateName == "NodeOutputArray" ||
-               templateName == "GroupNodeOutputRecords" ||
-               templateName == "ThreadNodeOutputRecords") {
+    } else if (Template->getTemplatedDecl()->hasAttr<HLSLNodeRecordAttr>()) {
 
       DXASSERT(TemplateArgList.size() == 1,
                "otherwise the template has not been declared properly");
@@ -15101,22 +15096,25 @@ QualType Sema::getHLSLDefaultSpecialization(TemplateDecl *Decl) {
 
 namespace hlsl {
 
-static bool nodeInputIsCompatible(StringRef &typeName,
+static bool nodeInputIsCompatible(DXIL::NodeIOKind IOType,
                                   DXIL::NodeLaunchType launchType) {
-  return llvm::StringSwitch<bool>(typeName)
-      .Case("DispatchNodeInputRecord",
-            launchType == DXIL::NodeLaunchType::Broadcasting)
-      .Case("RWDispatchNodeInputRecord",
-            launchType == DXIL::NodeLaunchType::Broadcasting)
-      .Case("GroupNodeInputRecords",
-            launchType == DXIL::NodeLaunchType::Coalescing)
-      .Case("RWGroupNodeInputRecords",
-            launchType == DXIL::NodeLaunchType::Coalescing)
-      .Case("EmptyNodeInput", launchType == DXIL::NodeLaunchType::Coalescing)
-      .Case("ThreadNodeInputRecord", launchType == DXIL::NodeLaunchType::Thread)
-      .Case("RWThreadNodeInputRecord",
-            launchType == DXIL::NodeLaunchType::Thread)
-      .Default(false);
+  switch (IOType) {
+  case DXIL::NodeIOKind::DispatchNodeInputRecord:
+  case DXIL::NodeIOKind::RWDispatchNodeInputRecord:
+    return launchType == DXIL::NodeLaunchType::Broadcasting;
+
+  case DXIL::NodeIOKind::GroupNodeInputRecords:
+  case DXIL::NodeIOKind::RWGroupNodeInputRecords:
+  case DXIL::NodeIOKind::EmptyInput:
+    return launchType == DXIL::NodeLaunchType::Coalescing;
+
+  case DXIL::NodeIOKind::ThreadNodeInputRecord:
+  case DXIL::NodeIOKind::RWThreadNodeInputRecord:
+    return launchType == DXIL::NodeLaunchType::Thread;
+
+  default:
+    return false;
+  }
 }
 
 void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, HLSLShaderAttr *Attr) {
@@ -15222,12 +15220,13 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, HLSLShaderAttr *Attr) {
     // Check any node input is compatible with the node launch type
     if (hlsl::IsHLSLNodeInputType(Param->getType())) {
       InputCount++;
-      const RecordType *RT = Param->getType()->getAs<RecordType>();
-      StringRef TypeName = RT->getDecl()->getName();
       if (NodeLaunchTy != DXIL::NodeLaunchType::Invalid &&
-          !nodeInputIsCompatible(TypeName, NodeLaunchTy)) {
+          !nodeInputIsCompatible(GetNodeIOType(Param->getType()),
+                                 NodeLaunchTy)) {
+        const RecordType *RT = Param->getType()->getAs<RecordType>();
         S.Diags.Report(Param->getLocation(), diag::err_hlsl_wg_input_kind)
-            << TypeName << ShaderModel::GetNodeLaunchTypeName(NodeLaunchTy)
+            << RT->getDecl()->getName()
+            << ShaderModel::GetNodeLaunchTypeName(NodeLaunchTy)
             << (static_cast<unsigned>(NodeLaunchTy) - 1)
             << Param->getSourceRange();
         if (NodeLaunchLoc.isValid())

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -5361,7 +5361,7 @@ public:
       }
       return false;
 
-    } else if (Template->getTemplatedDecl()->hasAttr<HLSLNodeRecordAttr>()) {
+    } else if (Template->getTemplatedDecl()->hasAttr<HLSLNodeObjectAttr>()) {
 
       DXASSERT(TemplateArgList.size() == 1,
                "otherwise the template has not been declared properly");

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeinput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeinput.hlsl
@@ -17,6 +17,7 @@ void node01(DispatchNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct DispatchNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit DispatchNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &() const'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18
@@ -32,6 +33,7 @@ void node02(GroupNodeInputRecords<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct GroupNodeInputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeInputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &(unsigned int) const'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int' cinit
@@ -60,6 +62,7 @@ void node03(ThreadNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct ThreadNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &() const'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeinput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeinput.hlsl
@@ -17,7 +17,7 @@ void node01(DispatchNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct DispatchNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit DispatchNodeInputRecord
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit DispatchNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &() const'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18
@@ -33,7 +33,7 @@ void node02(GroupNodeInputRecords<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct GroupNodeInputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeInputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeInputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &(unsigned int) const'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int' cinit
@@ -62,7 +62,7 @@ void node03(ThreadNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct ThreadNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeInputRecord
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'const recordtype &() const'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeoutput.hlsl
@@ -22,6 +22,7 @@ void node01(NodeOutput<RECORD> output)
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordType
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct GroupNodeOutputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'recordType &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -52,6 +53,7 @@ void node01(NodeOutput<RECORD> output)
 //CHECK-NEXT: ClassTemplateSpecializationDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> struct GroupNodeOutputRecords definition
 //CHECK-NEXT: TemplateArgument type 'RECORD'
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'RECORD &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -92,6 +94,7 @@ void node02(NodeOutput<RECORD> output)
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordType
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct ThreadNodeOutputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'recordType &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -122,6 +125,7 @@ void node02(NodeOutput<RECORD> output)
 //CHECK-NEXT: ClassTemplateSpecializationDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> struct ThreadNodeOutputRecords definition
 //CHECK-NEXT: TemplateArgument type 'RECORD'
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'RECORD &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-nodeoutput.hlsl
@@ -22,7 +22,7 @@ void node01(NodeOutput<RECORD> output)
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordType
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct GroupNodeOutputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'recordType &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -53,7 +53,7 @@ void node01(NodeOutput<RECORD> output)
 //CHECK-NEXT: ClassTemplateSpecializationDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> struct GroupNodeOutputRecords definition
 //CHECK-NEXT: TemplateArgument type 'RECORD'
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit GroupNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'RECORD &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -94,7 +94,7 @@ void node02(NodeOutput<RECORD> output)
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordType
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct ThreadNodeOutputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'recordType &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'
@@ -125,7 +125,7 @@ void node02(NodeOutput<RECORD> output)
 //CHECK-NEXT: ClassTemplateSpecializationDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> struct ThreadNodeOutputRecords definition
 //CHECK-NEXT: TemplateArgument type 'RECORD'
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit ThreadNodeOutputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> operator[] 'RECORD &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int'

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-rwnodeinput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-rwnodeinput.hlsl
@@ -17,7 +17,7 @@ void node01(RWDispatchNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWDispatchNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWDispatchNodeInputRecord
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWDispatchNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &()'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18
@@ -39,7 +39,7 @@ void node02(RWGroupNodeInputRecords<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWGroupNodeInputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWGroupNodeInputRecords
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWGroupNodeInputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int' cinit
@@ -77,7 +77,7 @@ void node03(RWThreadNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWThreadNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
-//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWThreadNodeInputRecord
+//CHECK-NEXT: HLSLNodeObjectAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWThreadNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &()'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-rwnodeinput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/ast-rwnodeinput.hlsl
@@ -17,6 +17,7 @@ void node01(RWDispatchNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWDispatchNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWDispatchNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &()'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18
@@ -38,6 +39,7 @@ void node02(RWGroupNodeInputRecords<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWGroupNodeInputRecords definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWGroupNodeInputRecords
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &(unsigned int)'
 //CHECK-NEXT: ParmVarDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Index 'unsigned int' cinit
@@ -75,6 +77,7 @@ void node03(RWThreadNodeInputRecord<RECORD> input) {}
 //CHECK-NEXT: TemplateTypeParmDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> class recordtype
 //CHECK-NEXT: CXXRecordDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit struct RWThreadNodeInputRecord definition
 //CHECK-NEXT: FinalAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit final
+//CHECK-NEXT: HLSLNodeRecordAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit RWThreadNodeInputRecord
 //CHECK-NEXT: FieldDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> implicit h 'int'
 //CHECK-NEXT: CXXMethodDecl {{0x[0-9a-fA-F]+}} <<invalid sloc>> <invalid sloc> Get 'recordtype &()'
 //CHECK-NEXT: HLSLIntrinsicAttr {{0x[0-9a-fA-F]+}} <<invalid sloc>> Implicit "op" "ExtractRecordStructFromArray" 18


### PR DESCRIPTION
This change avoids the need to string match type names for node input and output types by using an unspellable AST attribute that translates the node type to an enum (and back to a string if needed).