### PR TITLE
Use GITHUB_SHA instead of GITHUB_REF

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -25,7 +25,7 @@ jobs:
             echo Comparing $PR_NUMBER vs target branch
             git fetch origin refs/pull/$PR_NUMBER/head:pull/$PR_NUMBER
             git checkout pull/$PR_NUMBER
-            git diff -U0 --no-color $GITHUB_REF..pull/$PR_NUMBER | clang-format-diff-15 -p1 | tee format.diff
+            git diff -U0 --no-color $GITHUB_SHA..pull/$PR_NUMBER | clang-format-diff-15 -p1 | tee format.diff
             if [ -s format.diff ]
             then
               echo PR contains clang-format violations. First 50 lines of the diff: >> message.txt


### PR DESCRIPTION
Based on GitHubs docs, I think `GITHUB_SHA` will be the last commit from the target ref that is included in the PR's base ref. That should be the right compare point rather than `GITHUB_REF`, which would be the target branch's head ref.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-w orkflows#pull_request_target