### PR TITLE
Fix HelperLaneTest (release branch version)

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -10897,9 +10897,9 @@ TEST_F(ExecutionTest, HelperLaneTest) {
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
 
 #ifdef ISHELPERLANE_PLACEHOLDER
-  string args = "-DISHELPERLANE_PLACEHOLDER";
+  string args = "-DISHELPERLANE_PLACEHOLDER -opt-disable sink";
 #else 
-  string args = "";
+  string args = "-opt-disable sink";
 #endif
 
   D3D_SHADER_MODEL TestShaderModels[] = { D3D_SHADER_MODEL_6_0, D3D_SHADER_MODEL_6_6 };


### PR DESCRIPTION
Add `-opt-disable sink` to HelperLaneTest shader compilation to prevent sinking of `ddx_fine`/`ddy_fine` intrinsics into flow control.

Separate issue has been filed to track down the root of the problem: #5744: Intrinsics ddx_fine/ddy_fine should not be allowed to sink into flow control