### PR TITLE
Ignore line endings for sources verification

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -93,7 +93,7 @@ function(add_hlsl_hctgen mode)
   if(NOT copy_sources)
     set(output ${temp_output})
     if (CLANG_FORMAT_EXE) # Only verify sources if clang-format is available.
-      set(verification COMMAND ${CMAKE_COMMAND} -E compare_files ${temp_output} ${full_output})
+      set(verification COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${temp_output} ${full_output})
     endif()
   endif()
   if(WIN32 AND NOT HLSL_AUTOCRLF)


### PR DESCRIPTION
The issue arose during builds on specific macOS configurations, where the build would fail due to different line-ending conventions in compared files

```bash
[134/1556] cd /Users/user/.conan2/p/b/dxce4c427e7bc573/b/include/dxc && /usr/local/Cellar/cmake/3.27.6/bin/cmake -E compare_files /Users/user/.conan2/p/b/dxce4c427e7bc573/b/include/dxc/HlslIntrinsicOp.h.tmp /Users/user/.conan2/p/dxcb193344fb9f24/s/source_subfolder/include/dxc/HlslIntrinsicOp.h
FAILED: include/dxc/CMakeFiles/HLSLIntrinsicOp /Users/user/.conan2/p/b/dxce4c427e7bc573/b/include/dxc/CMakeFiles/HLSLIntrinsicOp
```