### PR TITLE
Fixing documentation code tag for BuildingAndTestingDXC.rst 

### DIFF
--- a/docs/BuildingAndTestingDXC.rst
+++ b/docs/BuildingAndTestingDXC.rst
@@ -32,7 +32,8 @@ for the configuration process.
 
 All of the most basic CMake configurations for DXC follow a similar format to:
 
-.. code:: sh
+.. code-block:: sh
+
   cmake <Repository Root> \
     -C <Repository Root>/cmake/caches/PredefinedParams.cmake \
     -DCMAKE_BUILD_TYPE=<Build Type> \
@@ -52,7 +53,8 @@ Generating a Visual Studio Solution
 
 Open a Visual Stuido command prompt and run:
 
-.. code:: sh
+.. code-block:: sh
+
   cmake <Repository Root> \
     -B <Path to Output> \
     -C <Repository Root>/cmake/caches/PredefinedParams.cmake \
@@ -79,7 +81,8 @@ Generating Ninja or Makefiles
 
 In your preferred terminal run:
 
-.. code:: sh
+.. code-block:: sh
+
   cmake <Repository Root> \
     -B <Path to Output> \
     -C <Repository Root>/cmake/caches/PredefinedParams.cmake \


### PR DESCRIPTION
Fixing documentation code tag for BuildingAndTestingDXC.rst doc file, Lack of new line between code and content makes the code dissapear. Removed also new line escape.
Sample sh code is now visible.

Results:
![image](https://github.com/microsoft/DirectXShaderCompiler/assets/789671/1163357c-2e28-4726-a1bc-9b6e6c71294e)
