### PR TITLE
[SPIR-V] Add error for rasterizer ordered view types

### DIFF
--- a/tools/clang/include/clang/SPIRV/AstTypeProbe.h
+++ b/tools/clang/include/clang/SPIRV/AstTypeProbe.h
@@ -292,6 +292,9 @@ bool isOpaqueStructType(QualType type);
 /// operated on with a relaxed precision.
 bool isRelaxedPrecisionType(QualType, const SpirvCodeGenOptions &);
 
+/// Returns true if the given type is a rasterizer ordered view.
+bool isRasterizerOrderedView(QualType type);
+
 /// Returns true if the given type is a bool or vector of bool type.
 bool isBoolOrVecOfBoolType(QualType type);
 

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1187,6 +1187,25 @@ bool isRelaxedPrecisionType(QualType type, const SpirvCodeGenOptions &opts) {
   return false;
 }
 
+bool isRasterizerOrderedView(QualType type) {
+  // Strip outer arrayness first
+  while (type->isArrayType())
+    type = type->getAsArrayTypeUnsafe()->getElementType();
+
+  if (const RecordType *recordType = type->getAs<RecordType>()) {
+    StringRef name = recordType->getDecl()->getName();
+    return name == "RasterizerOrderedBuffer" ||
+           name == "RasterizerOrderedByteAddressBuffer" ||
+           name == "RasterizerOrderedStructuredBuffer" ||
+           name == "RasterizerOrderedTexture1D" ||
+           name == "RasterizerOrderedTexture1DArray" ||
+           name == "RasterizerOrderedTexture2D" ||
+           name == "RasterizerOrderedTexture2DArray" ||
+           name == "RasterizerOrderedTexture3D";
+  }
+  return false;
+}
+
 /// Returns true if the given type is a bool or vector of bool type.
 bool isBoolOrVecOfBoolType(QualType type) {
   QualType elemType = {};

--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -630,6 +630,10 @@ const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
 
   assert(type->isStructureOrClassType());
 
+  if (isRasterizerOrderedView(type)) {
+    emitError("rasterizer ordered views are unimplemented", srcLoc);
+  }
+
   const auto *recordType = type->getAs<RecordType>();
   assert(recordType);
   const llvm::StringRef name = recordType->getDecl()->getName();

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedBuffer<uint> rob;
 
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.unimplemented.hlsl
@@ -1,0 +1,9 @@
+// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
+
+// TODO: Once these are implemented, we will want to add tests checking that
+//       RasterizerOrdered* types have all the functionality of RW* types
+
+// CHECK: error: rasterizer ordered views are unimplemented
+RasterizerOrderedByteAddressBuffer rob;
+
+void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedStructuredBuffer<uint> rob;
 
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d-array.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d-array.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedTexture1DArray<uint> rot;
 
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedTexture1D<uint> rot;
 
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d-array.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d-array.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedTexture2DArray<uint> rot;
 
 void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-3d.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-3d.unimplemented.hlsl
@@ -1,6 +1,6 @@
 // RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
 
 // CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
+RasterizerOrderedTexture3D<uint> rot;
 
 void main() { }


### PR DESCRIPTION
I meant to send this a couple weeks ago. I'll be sending in a PR soon that implements this so up to you if you think it makes sense to merge this first.