### PR TITLE
[SPIR-V] Add methods to record frequency mode for ROVs

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -529,6 +529,11 @@ public:
                                   QualType outputControlPointType,
                                   SpirvInstruction *ptr);
 
+  /// \brief Returns the execution mode to use for rasterizer ordered views.
+  /// \returns PixelInterlockOrderedEXT, SampleInterlockOrderedEXT, or
+  /// ShadingRateInterlockOrderedEXT.
+  spv::ExecutionMode getInterlockExecutionMode();
+
 private:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.
@@ -780,6 +785,12 @@ private:
                                           StageVar *stageVar,
                                           SpirvVariable *varInst);
 
+  /// \brief Set the frequency mode for rasterizer ordered views.
+  /// This should be set to PixelInterlockOrderedEXT (default),
+  /// SampleInterlockOrderedEXT, or ShadingRateInterlockOrderedEXT, based on
+  /// which semantics are present in input variables.
+  void setInterlockExecutionMode(spv::ExecutionMode mode);
+
 private:
   SpirvBuilder &spvBuilder;
   SpirvEmitter &theEmitter;
@@ -821,6 +832,9 @@ private:
   /// Mapping from cbuffer/tbuffer/ConstantBuffer/TextureBufer/push-constant
   /// to the SPIR-V type.
   llvm::DenseMap<const DeclContext *, const SpirvType *> ctBufferPCTypes;
+
+  /// The execution mode to use for rasterizer ordered views.
+  spv::ExecutionMode interlockExecutionMode;
 
   /// The SPIR-V builtin variables accessed by WaveGetLaneCount(),
   /// WaveGetLaneIndex() and ray tracing builtins.


### PR DESCRIPTION
Rasterizer ordered views will need to set an execution mode of either `PixelInterlockOrderedEXT`, `SampleInterlockOrderedEXT`, or `ShadingRateInterlockOrderedEXT`. This PR records which execution mode should be used, based on which semantics are input into the shader.

1. `PixelInterlockOrderedEXT` is the default execution mode
2. `SampleInterlockOrderedEXT` will be chosen if the shader has an input with the `SV_SampleIndex` semantic
3. `ShadingRateInterlockOrderedEXT` will be chosen if the shader has an input with the `SV_ShadingRate` semantic

This PR does not actually add the execution mode to an entry point; that will need to be done only if a rasterizer ordered view is present in the program, and will be done in another PR. As such, this PR has no tests, and its behavior will be tested in the follow-up – I mainly wanted to get your input on whether this looks like a good structure for recording this information.