### PR TITLE
[NFC] Remove unneeded IsComplete parameter

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -402,8 +402,7 @@ DeclareNodeOrRecordType(clang::ASTContext &Ctx, DXIL::NodeIOKind Type,
 clang::CXXRecordDecl *DeclareNodeOutputArray(clang::ASTContext &Ctx,
                                              DXIL::NodeIOKind Type,
                                              clang::CXXRecordDecl *OutputType,
-                                             bool IsRecordTypeTemplate,
-                                             bool IsCompleteType);
+                                             bool IsRecordTypeTemplate);
 
 clang::CXXRecordDecl *
 DeclareRecordTypeWithHandleAndNoMemberFunctions(clang::ASTContext &context,

--- a/tools/clang/lib/AST/ASTContextHLSL.cpp
+++ b/tools/clang/lib/AST/ASTContextHLSL.cpp
@@ -1246,8 +1246,7 @@ CXXRecordDecl *hlsl::DeclareNodeOrRecordType(
 CXXRecordDecl *hlsl::DeclareNodeOutputArray(clang::ASTContext &Ctx,
                                             DXIL::NodeIOKind Type,
                                             CXXRecordDecl *OutputType,
-                                            bool IsRecordTypeTemplate,
-                                            bool IsCompleteType) {
+                                            bool IsRecordTypeTemplate) {
   StringRef TypeName = HLSLNodeObjectAttr::ConvertRecordTypeToStr(Type);
   BuiltinTypeDeclBuilder Builder(Ctx.getTranslationUnitDecl(), TypeName,
                                  TagDecl::TagKind::TTK_Struct);
@@ -1296,10 +1295,7 @@ CXXRecordDecl *hlsl::DeclareNodeOutputArray(clang::ASTContext &Ctx,
       HLSLIntrinsicAttr::CreateImplicit(Ctx, OpcodeGroup, "", Opcode));
   methodDecl->addAttr(HLSLCXXOverloadAttr::CreateImplicit(Ctx));
 
-  if (IsCompleteType)
-    return Builder.completeDefinition();
-
-  return Builder.getRecordDecl();
+  return Builder.completeDefinition();
 }
 
 VarDecl *hlsl::DeclareBuiltinGlobal(llvm::StringRef name, clang::QualType Ty,

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -3937,15 +3937,13 @@ private:
         recordDecl = DeclareNodeOutputArray(*m_context,
                                             DXIL::NodeIOKind::NodeOutputArray,
                                             /* ItemType */ nodeOutputDecl,
-                                            /*IsRecordTypeTemplate*/ true,
-                                            /*IsCompleteType*/ true);
+                                            /*IsRecordTypeTemplate*/ true);
       } else if (kind == AR_OBJECT_EMPTY_NODE_OUTPUT_ARRAY) {
         assert(emptyNodeOutputDecl != nullptr);
         recordDecl = DeclareNodeOutputArray(*m_context,
                                             DXIL::NodeIOKind::EmptyOutputArray,
                                             /* ItemType */ emptyNodeOutputDecl,
-                                            /*IsRecordTypeTemplate*/ false,
-                                            /*IsCompleteType*/ true);
+                                            /*IsRecordTypeTemplate*/ false);
       } else if (kind == AR_OBJECT_GROUP_NODE_OUTPUT_RECORDS) {
         recordDecl = m_GroupNodeOutputRecordsTemplateDecl->getTemplatedDecl();
       } else if (kind == AR_OBJECT_THREAD_NODE_OUTPUT_RECORDS) {


### PR DESCRIPTION
This function is always called with `IsComplete = true`, so there is no need for this parameter.