### PR TITLE
Fix UBSAN error in iterator.h

### DIFF
--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -10936,7 +10936,11 @@ bool Sema::buildOverloadedCallSet(Scope *S, Expr *Fn,
     // We don't perform ADL for implicit declarations of builtins.
     // Verify that this was correctly set up.
     FunctionDecl *F;
-    if (ULE->decls_begin() + 1 == ULE->decls_end() &&
+    if (
+        // HLSL change begin
+        (ULE->getNumDecls() > 0) &&
+        // HLSL change end
+        ULE->decls_begin() + 1 == ULE->decls_end() &&
         (F = dyn_cast<FunctionDecl>(*ULE->decls_begin())) &&
         F->getBuiltinID() && F->isImplicit())
       llvm_unreachable("performing ADL for builtin");


### PR DESCRIPTION
Fixes UBSAN error:
```
include/llvm/ADT/iterator.h:171:7: runtime error: applying non-zero offset 8 to null pointer
```

When ULE has no decls, `decls_begin` returns a null-ptr iterator, and
adding 1 to this pointer is undefined behaviour. We fix this by adding a
check that ULE actually has decls before doing this.

Fixes 332 of these reported from running check-all.