### PR TITLE
Fix UBSAN error in DxilRootSignatureSerializer

### DIFF
--- a/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
@@ -131,7 +131,7 @@ HRESULT SimpleSerializer::ReserveBlock(void **ppData, unsigned cbSize,
 
   *ppData = pClonedData;
   if (pOffset) {
-    *pOffset = pSegment->Offset;
+    memcpy(pOffset, &pSegment->Offset, sizeof(pSegment->Offset));
   }
 
 Cleanup:


### PR DESCRIPTION
Fix UBSAN error:
```
lib/DxilRootSignature/DxilRootSignatureSerializer.cpp:134:5: runtime error: store to misaligned address 0x7fff812daf5f for type 'unsigned int', which requires 4 byte alignment
```

Use memcpy to write to unaligned address.

Fixes 63 of these reported from running check-all.