### PR TITLE
Error when declaring global operator overloads

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7499,8 +7499,8 @@ def err_hlsl_matrix_member_too_many_positions: Error<
   "more than four positions are referenced in '%0'">;
 def err_hlsl_matrix_member_zero_in_one_based: Error<
   "the digit '0' is used in '%0', but the syntax is for one-based rows and columns">;
-def err_hlsl_overloading_new_delete_operator: Error<
-  "overloading %0 is not allowed">;
+def err_hlsl_overloading_operator_disallowed: Error<
+  "overloading %select{|non-member }1%0 is not allowed">;
 def err_hlsl_vector_member_bad_format: Error<
   "invalid format for vector swizzle '%0'">;
 def err_hlsl_vector_member_empty: Error<

--- a/tools/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/tools/clang/lib/Sema/SemaDeclCXX.cpp
@@ -11644,9 +11644,13 @@ bool Sema::CheckOverloadedOperatorDeclaration(FunctionDecl *FnDecl) {
         Op == OO_PlusPlus || Op == OO_MinusMinus || Op == OO_ArrowStar ||
         Op == OO_Arrow) {
       return Diag(FnDecl->getLocation(),
-                  diag::err_hlsl_overloading_new_delete_operator)
-             << FnDecl->getDeclName();
+                  diag::err_hlsl_overloading_operator_disallowed)
+             << FnDecl->getDeclName() << 0;
     }
+    if (!isa<CXXMethodDecl>(FnDecl))
+      return Diag(FnDecl->getLocation(),
+                  diag::err_hlsl_overloading_operator_disallowed)
+             << FnDecl->getDeclName() << 1;
   }
   // HLSL Change Ends
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11175,7 +11175,9 @@ bool hlsl::ShouldSkipNRVO(clang::Sema &sema, clang::QualType returnType,
     // Check if it's an entry function the hard way
     if (!FD->getDeclContext()->isNamespace() && FD->isGlobal()) {
       // Check if this is an entry function by comparing name
-      if (FD->getName() == sema.getLangOpts().HLSLEntryFunction) {
+      // TODO: Remove this once we put HLSLShaderAttr on all entry functions.
+      if (FD->getIdentifier() &&
+          FD->getName() == sema.getLangOpts().HLSLEntryFunction) {
         return true;
       }
 

--- a/tools/clang/test/SemaHLSL/v2021/operators/global-overload-disallowed.hlsl
+++ b/tools/clang/test/SemaHLSL/v2021/operators/global-overload-disallowed.hlsl
@@ -1,0 +1,111 @@
+// RUN: %dxc -T lib_6_6 -HV 2021 %s -verify
+
+// This test verifies that the set of operators that HLSL 2021 allows overriding
+// for correctly generates an error if the override is placed outside a class or
+// struct definition.
+
+struct Test {};
+
+Test operator*(float L, Test R) { // expected-error {{overloading non-member 'operator*' is not allowed}}
+    return R;
+}
+
+Test operator+(float L, Test R) { // expected-error {{overloading non-member 'operator+' is not allowed}}
+    return R;
+}
+
+Test operator-(float L, Test R) { // expected-error {{overloading non-member 'operator-' is not allowed}}
+    return R;
+}
+
+Test operator/(float L, Test R) { // expected-error {{overloading non-member 'operator/' is not allowed}}
+    return R;
+}
+
+Test operator%(float L, Test R) { // expected-error {{overloading non-member 'operator%' is not allowed}}
+    return R;
+}
+
+Test operator&(float L, Test R) { // expected-error {{overloading non-member 'operator&' is not allowed}}
+    return R;
+}
+
+Test operator|(float L, Test R) { // expected-error {{overloading non-member 'operator|' is not allowed}}
+    return R;
+}
+
+Test operator^(float L, Test R) { // expected-error {{overloading non-member 'operator^' is not allowed}}
+    return R;
+}
+
+Test operator<(float L, Test R) { // expected-error {{overloading non-member 'operator<' is not allowed}}
+    return R;
+}
+
+Test operator>(float L, Test R) { // expected-error {{overloading non-member 'operator>' is not allowed}}
+    return R;
+}
+
+Test operator<=(float L, Test R) { // expected-error {{overloading non-member 'operator<=' is not allowed}}
+    return R;
+}
+
+Test operator>=(float L, Test R) { // expected-error {{overloading non-member 'operator>=' is not allowed}}
+    return R;
+}
+
+Test operator==(float L, Test R) { // expected-error {{overloading non-member 'operator==' is not allowed}}
+    return R;
+}
+
+Test operator!=(float L, Test R) { // expected-error {{overloading non-member 'operator!=' is not allowed}}
+    return R;
+}
+
+namespace SomeNamespace {
+
+Test operator*(float L, Test R) { // expected-error {{overloading non-member 'operator*' is not allowed}}
+    return R;
+}
+
+Test operator+(float L, Test R) { // expected-error {{overloading non-member 'operator+' is not allowed}}
+    return R;
+}
+
+Test operator-(float L, Test R) { // expected-error {{overloading non-member 'operator-' is not allowed}}
+    return R;
+}
+
+Test operator/(float L, Test R) { // expected-error {{overloading non-member 'operator/' is not allowed}}
+    return R;
+}
+
+Test operator%(float L, Test R) { // expected-error {{overloading non-member 'operator%' is not allowed}}
+    return R;
+}
+
+Test operator<(float L, Test R) { // expected-error {{overloading non-member 'operator<' is not allowed}}
+    return R;
+}
+
+Test operator>(float L, Test R) { // expected-error {{overloading non-member 'operator>' is not allowed}}
+    return R;
+}
+
+Test operator<=(float L, Test R) { // expected-error {{overloading non-member 'operator<=' is not allowed}}
+    return R;
+}
+
+Test operator>=(float L, Test R) { // expected-error {{overloading non-member 'operator>=' is not allowed}}
+    return R;
+}
+
+Test operator==(float L, Test R) { // expected-error {{overloading non-member 'operator==' is not allowed}}
+    return R;
+}
+
+Test operator!=(float L, Test R) { // expected-error {{overloading non-member 'operator!=' is not allowed}}
+    return R;
+}
+
+}


### PR DESCRIPTION
HLSL 2021 can't resolve calls to global operator overloads and was never intended to support them, but it didn't error on them being declared. This change emits a diagnostic when declaring any operator outside class or struct scope so that users won't instead be greeted by less intuitive errors from overload resolution.

Fixes #5792