### PR TITLE
[ExecutionTests] Add validation and signing step to isNormal Test CherryPick

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -11508,12 +11508,26 @@ st::ShaderOpTest::TShaderCallbackFn MakeShaderReplacementCallback(
     {
       CComPtr<IDxcAssembler> pAssembler;
       CComPtr<IDxcOperationResult> pResult;
-      VERIFY_SUCCEEDED(dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
-      VERIFY_SUCCEEDED(pAssembler->AssembleToContainer(rewrittenDisassembly, &pResult));
+      CComPtr<IDxcOperationResult> pValidationResult;
+      CComPtr<IDxcValidator> pValidator;
+
       HRESULT status;
+      HRESULT validationStatus;
+      VERIFY_SUCCEEDED(
+          dllSupport.CreateInstance(CLSID_DxcAssembler, &pAssembler));
+      VERIFY_SUCCEEDED(pAssembler->AssembleToContainer(rewrittenDisassembly, &pResult));
       VERIFY_SUCCEEDED(pResult->GetStatus(&status));
       VERIFY_SUCCEEDED(status);
       VERIFY_SUCCEEDED(pResult->GetResult(&assembledShader));
+
+      // now validate the rewritten disassembly and sign the shader
+      VERIFY_SUCCEEDED(
+          dllSupport.CreateInstance(CLSID_DxcValidator, &pValidator));
+
+      VERIFY_SUCCEEDED(pValidator->Validate(
+          assembledShader, DxcValidatorFlags_InPlaceEdit, &pValidationResult));
+      VERIFY_SUCCEEDED(pValidationResult->GetStatus(&validationStatus));
+      VERIFY_SUCCEEDED(validationStatus);
     }
 
     // Find root signature part in container
@@ -11570,7 +11584,7 @@ TEST_F(ExecutionTest, IsNormalTest) {
 
   // The input is -Zero, Zero, -Denormal, Denormal, -Infinity, Infinity, -NaN, Nan, and then 4 normal float numbers.
   // Only the last 4 floats are normal, so we expect the first 8 results to be 0, and the last 4 to be 1, as defined by IsNormal.
-  std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, 122.101f, -.122101f};
+  std::vector<float> Validation_Input_Vec = {-0.0, 0.0, -(FLT_MIN / 2), FLT_MIN / 2, -(INFINITY), INFINITY, -(NAN), NAN, 530.99f, -530.99f, -122.900f, .122900f};
   std::vector<float> *Validation_Input = &Validation_Input_Vec;
 
   std::vector<unsigned int> Validation_Expected_Vec = {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 1u, 1u, 1u, 1u};


### PR DESCRIPTION
The IsNormal tests required an addition to the testing framework
provided by ShaderOpTest.cpp, known as the MakeShaderReplacementCallback
function. This function takes a shader, compiles it to DXIL,
disassembles it into a string, replaces anything specified in the
function parameters, and reassembles the shader back into a dxil
container. The problem with the initial implementation was that after
disassembling the shader, the signature applied to the shader on the
compile step would be lost.

This PR adds a validation / signing step right after assembling the
shader to ensure the new DXIL container has a signature. This will
prevent problems with calling CreateComputePipelineState due to a
missing signature.
Verified that this fails when disabling experimental mode, and passes
only when dxil.dll is available.
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/5337

(cherry picked from commit https://github.com/microsoft/DirectXShaderCompiler/commit/3974b57d12cf9c1e30d9da030820020c5a22b111)