### PR TITLE
Enable asan on our Linux Release pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
           configuration: Release
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_ENABLE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On
           OS: Linux
         Linux_Clang_Debug:
           image: ${{ variables.linux }}


### PR DESCRIPTION
Address sanitizer can detect all sorts of memory usage related bugs. Things like overflows, underflows, use-after-free, and (on Linux) leaks. Due to the great work by @amaiorano, DXC is now asan-clean in our test suite. Enabling this in our PR builds will allow us to stay that way.

I've chosen the Linux builds because the Linux runtime hooks capture more errors than on other platforms. It only runs in the Release configuration because asan can have significant runtime overhead so running it in a release configuration will mitigate that substantially. I've also changed the build to use libc++ instead of libstdc++ because the libc++ headers have additional address sanitizer annotations to catch misuses of C++ standard library containers.