### PR TITLE
Allow SamplerComparisonState when CalculateLevelOfDetail

### DIFF
--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1658,7 +1658,9 @@ static void ValidateResourceDxilOp(CallInst *CI, DXIL::OpCode opcode,
   case DXIL::OpCode::CalculateLOD: {
     DxilInst_CalculateLOD lod(CI);
     Value *samplerHandle = lod.get_sampler();
-    if (GetSamplerKind(samplerHandle, ValCtx) != DXIL::SamplerKind::Default) {
+    if ((DXIL::CompareVersions(ValCtx.m_DxilMajor, ValCtx.m_DxilMinor, 1, 8) <
+         0) &&
+        GetSamplerKind(samplerHandle, ValCtx) != DXIL::SamplerKind::Default) {
       ValCtx.EmitInstrError(CI, ValidationRule::InstrSamplerModeForLOD);
     }
     Value *handle = lod.get_handle();

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1658,7 +1658,7 @@ static void ValidateResourceDxilOp(CallInst *CI, DXIL::OpCode opcode,
   case DXIL::OpCode::CalculateLOD: {
     DxilInst_CalculateLOD lod(CI);
     Value *samplerHandle = lod.get_sampler();
-    DXIL::SamplerKind = samplerKind = GetSamplerKind(samplerHandle, ValCtx);
+    DXIL::SamplerKind samplerKind = GetSamplerKind(samplerHandle, ValCtx);
     if (samplerKind != DXIL::SamplerKind::Default) {
       // After SM68, Comparison is supported.
       if (!ValCtx.DxilMod.GetShaderModel()->IsSM68Plus() ||

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1658,10 +1658,12 @@ static void ValidateResourceDxilOp(CallInst *CI, DXIL::OpCode opcode,
   case DXIL::OpCode::CalculateLOD: {
     DxilInst_CalculateLOD lod(CI);
     Value *samplerHandle = lod.get_sampler();
-    if ((DXIL::CompareVersions(ValCtx.m_DxilMajor, ValCtx.m_DxilMinor, 1, 8) <
-         0) &&
-        GetSamplerKind(samplerHandle, ValCtx) != DXIL::SamplerKind::Default) {
-      ValCtx.EmitInstrError(CI, ValidationRule::InstrSamplerModeForLOD);
+    DXIL::SamplerKind = samplerKind = GetSamplerKind(samplerHandle, ValCtx);
+    if (samplerKind != DXIL::SamplerKind::Default) {
+      // After SM68, Comparison is supported.
+      if (!ValCtx.DxilMod.GetShaderModel()->IsSM68Plus() ||
+          samplerKind != DXIL::SamplerKind::Comparison)
+        ValCtx.EmitInstrError(CI, ValidationRule::InstrSamplerModeForLOD);
     }
     Value *handle = lod.get_handle();
     DXIL::ComponentType compTy;

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7766,6 +7766,8 @@ def err_hlsl_unsupported_for_version_lower : Error<
    "%0 is only allowed for HLSL %1 and lower.">;
 def err_hlsl_unsupported_keyword_for_min_precision : Error<
    "%0 is only supported with -enable-16bit-types option">;
+def err_hlsl_intrinsic_overload_in_wrong_shader_model : Error<
+   "overload of intrinsic %0 requires shader model %1 or greater">;
 def err_hlsl_intrinsic_template_arg_unsupported: Error<
    "Explicit template arguments on intrinsic %0 are not supported">;
 def err_hlsl_intrinsic_template_arg_requires_2018: Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11287,6 +11287,22 @@ bool Sema::DiagnoseHLSLMethodCall(const CXXMethodDecl *MD, SourceLocation Loc) {
         Diags.Report(Loc, diag::err_hlsl_wg_nodetrackrwinputsharing_missing);
         return true;
       }
+    } else if (opCode == hlsl::IntrinsicOp::MOP_CalculateLevelOfDetail ||
+               opCode ==
+                   hlsl::IntrinsicOp::MOP_CalculateLevelOfDetailUnclamped) {
+      const auto *shaderModel =
+          hlsl::ShaderModel::GetByName(getLangOpts().HLSLProfile.c_str());
+      if (!shaderModel->IsSM68Plus()) {
+        QualType SamplerComparisonTy =
+            HLSLExternalSource::FromSema(this)->GetBasicKindType(
+                AR_OBJECT_SAMPLERCOMPARISON);
+        if (MD->getParamDecl(0)->getType() == SamplerComparisonTy) {
+          Diags.Report(Loc,
+                       diag::err_hlsl_intrinsic_overload_in_wrong_shader_model)
+              << MD->getNameAsString() << "6.8";
+          return true;
+        }
+      }
     }
   }
   return false;

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/CalcLODWithSamplerComparison.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/texture/CalcLODWithSamplerComparison.hlsl
@@ -1,0 +1,61 @@
+// RUN: dxc -Tps_6_8 %s | FileCheck %s
+
+SamplerComparisonState samp1;
+Texture1D<float4> tex1d;
+Texture1DArray<float4> tex1d_array;
+Texture2D<float4> tex2d;
+Texture2DArray<float4> tex2d_array;
+TextureCube<float4> texcube;
+TextureCubeArray<float4> texcube_array;
+
+// CHECK: define void @main()
+
+// CHECK: %[[TCubeArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 5, i32 5, i32 0, i8 0 }, i32 5, i1 false)
+// CHECK: %[[TCube:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 4, i32 4, i32 0, i8 0 }, i32 4, i1 false)
+// CHECK: %[[T2DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 3, i32 3, i32 0, i8 0 }, i32 3, i1 false)
+// CHECK: %[[T2D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 2, i32 2, i32 0, i8 0 }, i32 2, i1 false)
+// CHECK: %[[T1DArray:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 1, i32 1, i32 0, i8 0 }, i32 1, i1 false)
+// CHECK: %[[T1D:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind zeroinitializer, i32 0, i1 false)
+// CHECK: %[[Sampler:.+]] = call %dx.types.Handle @dx.op.createHandleFromBinding(i32 217, %dx.types.ResBind { i32 0, i32 0, i32 0, i8 3 }, i32 0, i1 false)
+
+float main(float4 a
+  : A) : SV_Target {
+float r = 0;
+// CHECK: %[[AnnotT1D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T1D]], %dx.types.ResourceProperties { i32 1, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture1D<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotT1D]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float undef, float undef, i1 true)
+
+  r += tex1d.CalculateLevelOfDetail(samp1, a.x);
+
+// CHECK: %[[AnnotT1DArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T1DArray]], %dx.types.ResourceProperties { i32 6, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture1DArray<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotT1DArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float undef, float undef, i1 false)
+  r += tex1d_array.CalculateLevelOfDetailUnclamped(samp1, a.x);
+
+// CHECK: %[[AnnotT2D:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2D]], %dx.types.ResourceProperties { i32 2, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2D<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotT2D]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float %{{.+}}, float undef, i1 true)
+
+  r += tex2d.CalculateLevelOfDetail(samp1, a.xy);
+
+// CHECK: %[[AnnotT2DArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[T2DArray]], %dx.types.ResourceProperties { i32 7, i32 1033 })  ; AnnotateHandle(res,props)  resource: Texture2DArray<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotT2DArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float %{{.+}}, float undef, i1 false)
+
+  r += tex2d_array.CalculateLevelOfDetailUnclamped(samp1, a.xy);
+
+// CHECK: %[[AnnotTCube:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[TCube]], %dx.types.ResourceProperties { i32 5, i32 1033 })  ; AnnotateHandle(res,props)  resource: TextureCube<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotTCube]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float %{{.+}}, float %{{.+}}, i1 true)
+
+  r += texcube.CalculateLevelOfDetail(samp1, a.xyz);
+
+// CHECK: %[[AnnotTCubeArray:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[TCubeArray]], %dx.types.ResourceProperties { i32 9, i32 1033 })  ; AnnotateHandle(res,props)  resource: TextureCubeArray<4xF32>
+// CHECK: %[[AnnotSampler:.+]] = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %[[Sampler]], %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
+// CHECK: call float @dx.op.calculateLOD.f32(i32 81, %dx.types.Handle %[[AnnotTCubeArray]], %dx.types.Handle %[[AnnotSampler]], float %{{.+}}, float %{{.+}}, float %{{.+}}, i1 false)
+
+  r += texcube_array.CalculateLevelOfDetailUnclamped(samp1, a.xyz);
+
+  return r;
+}
+

--- a/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState.hlsl
@@ -1,0 +1,9 @@
+// RUN: dxc -Tlib_6_7 %s -verify
+
+SamplerComparisonState s;
+Texture1D t;
+
+float foo(float a) {
+  return t.CalculateLevelOfDetail(s, a) + // expected-error {{overload of intrinsic CalculateLevelOfDetail requires shader model 6.8 or greater}}
+    t.CalculateLevelOfDetailUnclamped(s, a); // expected-error {{overload of intrinsic CalculateLevelOfDetailUnclamped requires shader model 6.8 or greater}}
+}

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -409,10 +409,8 @@ void [[]] RestartStrip() : stream_restart;
 
 namespace Texture1DMethods {
 // Use float for DXIL don't support f16 on CalcLOD.
-float [[ro]] CalculateLevelOfDetail(in sampler1d s, in float<1> x) : tex1d_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<1> x) : tex1d_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped;
 void [[]] GetDimensions(in uint x, out uint_only width, out $type2 levels) : resinfo_uint;
 void [[]] GetDimensions(in uint x, out float_like width, out $type2 levels) : resinfo;
 void [[]] GetDimensions(out uint_only width) : resinfo_o;
@@ -457,10 +455,8 @@ $classT [[]] SampleGrad(in sampler s, in float<1> x, in $type2 ddx, in $type2 dd
 
 namespace Texture1DArrayMethods {
 
-float [[ro]] CalculateLevelOfDetail(in sampler s, in float<1> x) : tex1d_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped_array;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<1> x) : tex1d_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped_array;
 void [[]] GetDimensions(in uint x, out uint_only width, out $type2 elements, out $type2 levels) : resinfo_uint;
 void [[]] GetDimensions(in uint x, out float_like width, out $type2 elements, out $type2 levels) : resinfo;
 void [[]] GetDimensions(out uint_only width, out $type1 elements) : resinfo_uint_o;
@@ -505,10 +501,8 @@ $classT [[]] SampleGrad(in sampler s, in float<2> x, in $match<2, 2> float<1> dd
 
 namespace Texture2DMethods {
 
-float [[ro]] CalculateLevelOfDetail(in sampler s, in float<2> x) : tex2d_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<2> x) : tex2d_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<2> x) : tex2d_t_gather;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<2> x, in int<2> o) : tex2d_t_gather_o;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<2> x) : tex2d_t_gather_alpha;
@@ -615,10 +609,8 @@ $classT [[]] Load(in int<2> x, in int s, in int<2> o, out uint_only status) : te
 
 namespace Texture2DArrayMethods {
 
-float [[ro]] CalculateLevelOfDetail(in sampler s, in float<2> x) : tex2d_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped_array;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<2> x) : tex2d_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x) : tex2d_t_gather_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x, in int<2> o) : tex2d_t_gather_array_o;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<3> x) : tex2d_t_gather_alpha_array;
@@ -751,10 +743,8 @@ $classT [[]] SampleGrad(in sampler s, in float<3> x, in $type2 ddx, in $type2 dd
 
 namespace TextureCUBEMethods {
 
-float [[ro]] CalculateLevelOfDetail(in sampler s, in float<3> x) : texcube_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<3> x) : texcube_t_calc_lod_unclamped;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<3> x) : texcube_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<3> x) : texcube_t_calc_lod_unclamped;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x) : texcube_t_gather;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<3> x) : texcube_t_gather_alpha;
 $match<0, -1> void<4> [[ro]] GatherBlue(in sampler s, in float<3> x) : texcube_t_gather_blue;
@@ -807,10 +797,8 @@ $match<0, -1> void<4> [[]] GatherCmpAlpha(in sampler_cmp s, in float<3> x, in fl
 
 namespace TextureCUBEArrayMethods {
 
-float [[ro]] CalculateLevelOfDetail(in sampler s, in float<3> x) : texcube_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<3> x) : texcube_t_calc_lod_unclamped_array;
-float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_array;
-float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in any_sampler s, in float<3> x) : texcube_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in any_sampler s, in float<3> x) : texcube_t_calc_lod_unclamped_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<4> x) : texcube_t_gather_array;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<4> x) : texcube_t_gather_alpha_array;
 $match<0, -1> void<4> [[ro]] GatherBlue(in sampler s, in float<4> x) : texcube_t_gather_blue_array;

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -411,6 +411,8 @@ namespace Texture1DMethods {
 // Use float for DXIL don't support f16 on CalcLOD.
 float [[ro]] CalculateLevelOfDetail(in sampler1d s, in float<1> x) : tex1d_t_calc_lod;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_unclamped;
 void [[]] GetDimensions(in uint x, out uint_only width, out $type2 levels) : resinfo_uint;
 void [[]] GetDimensions(in uint x, out float_like width, out $type2 levels) : resinfo;
 void [[]] GetDimensions(out uint_only width) : resinfo_o;
@@ -457,6 +459,8 @@ namespace Texture1DArrayMethods {
 
 float [[ro]] CalculateLevelOfDetail(in sampler s, in float<1> x) : tex1d_t_calc_lod_array;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<1> x) : tex1d_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<1> x) : tex1d_t_calc_lod_unclamped_array;
 void [[]] GetDimensions(in uint x, out uint_only width, out $type2 elements, out $type2 levels) : resinfo_uint;
 void [[]] GetDimensions(in uint x, out float_like width, out $type2 elements, out $type2 levels) : resinfo;
 void [[]] GetDimensions(out uint_only width, out $type1 elements) : resinfo_uint_o;
@@ -503,6 +507,8 @@ namespace Texture2DMethods {
 
 float [[ro]] CalculateLevelOfDetail(in sampler s, in float<2> x) : tex2d_t_calc_lod;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_unclamped;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<2> x) : tex2d_t_gather;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<2> x, in int<2> o) : tex2d_t_gather_o;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<2> x) : tex2d_t_gather_alpha;
@@ -611,6 +617,8 @@ namespace Texture2DArrayMethods {
 
 float [[ro]] CalculateLevelOfDetail(in sampler s, in float<2> x) : tex2d_t_calc_lod_array;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<2> x) : tex2d_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<2> x) : tex2d_t_calc_lod_unclamped_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x) : tex2d_t_gather_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x, in int<2> o) : tex2d_t_gather_array_o;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<3> x) : tex2d_t_gather_alpha_array;
@@ -745,6 +753,8 @@ namespace TextureCUBEMethods {
 
 float [[ro]] CalculateLevelOfDetail(in sampler s, in float<3> x) : texcube_t_calc_lod;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<3> x) : texcube_t_calc_lod_unclamped;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_unclamped;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<3> x) : texcube_t_gather;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<3> x) : texcube_t_gather_alpha;
 $match<0, -1> void<4> [[ro]] GatherBlue(in sampler s, in float<3> x) : texcube_t_gather_blue;
@@ -799,6 +809,8 @@ namespace TextureCUBEArrayMethods {
 
 float [[ro]] CalculateLevelOfDetail(in sampler s, in float<3> x) : texcube_t_calc_lod_array;
 float [[ro]] CalculateLevelOfDetailUnclamped(in sampler s, in float<3> x) : texcube_t_calc_lod_unclamped_array;
+float [[ro]] CalculateLevelOfDetail(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_array;
+float [[ro]] CalculateLevelOfDetailUnclamped(in sampler_cmp s, in float<3> x) : texcube_t_calc_lod_unclamped_array;
 $match<0, -1> void<4> [[ro]] Gather(in sampler s, in float<4> x) : texcube_t_gather_array;
 $match<0, -1> void<4> [[ro]] GatherAlpha(in sampler s, in float<4> x) : texcube_t_gather_alpha_array;
 $match<0, -1> void<4> [[ro]] GatherBlue(in sampler s, in float<4> x) : texcube_t_gather_blue_array;


### PR DESCRIPTION
New overloads are added for CalculateLevelOfDetail and CalculateLevelOfDetailUnclamped. Also update validator to allow SamplerComparisonState for shader model higher than 6.7.

Fixes https://github.com/microsoft/DirectXShaderCompiler/pull/5183
