### PR TITLE
[SPIR-V] Implement rasterizer ordered views

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -943,7 +943,7 @@ def CounterStructuredBuffer : SubsetSubject<
        S->getType()->getAs<RecordType>()->getDecl()->getName() == "AppendStructuredBuffer" ||
        S->getType()->getAs<RecordType>()->getDecl()->getName() == "ConsumeStructuredBuffer")}]>;
 
-// Array of StructuredBuffer types that can have associated counters 
+// Array of StructuredBuffer types that can have associated counters
 def ArrayOfCounterStructuredBuffer
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAsArrayTypeUnsafe() &&
@@ -974,7 +974,7 @@ def ConstantTextureBuffer
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "TextureBuffer")}]>;
 
-// Global variable with "RWTexture" type
+// Global variable with "(RW|RasterizerOrdered)Texture" type
 def RWTexture
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
@@ -988,9 +988,19 @@ def RWTexture
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "RWTexture2DArray" ||
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "RWTexture3D")}]>;
+                      "RWTexture3D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture1D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture1DArray" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture2D" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture2DArray" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture3D")}]>;
 
-// Global variable of array of "RWTexture" type
+// Global variable of array of "(RW|RasterizerOrdered)Texture" type
 def ArrayOfRWTexture
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAsArrayTypeUnsafe() &&
@@ -1005,9 +1015,19 @@ def ArrayOfRWTexture
                   S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
                       "RWTexture2DArray" ||
                   S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "RWTexture3D")}]>;
+                      "RWTexture3D" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture1D" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture1DArray" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture2D" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture2DArray" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedTexture3D")}]>;
 
-// Global variable with "[RW]Buffer" type
+// Global variable with "[RW|RasterizerOrdered]Buffer" type
 def Buffer
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
@@ -1015,9 +1035,11 @@ def Buffer
                  (S->getType()->getAs<RecordType>()->getDecl()->getName() ==
                       "Buffer" ||
                   S->getType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "RWBuffer")}]>;
+                      "RWBuffer" ||
+                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedBuffer")}]>;
 
-// Global variable or array of "[RW]Buffer" type
+// Global variable or array of "[RW|RasterizerOrdered]Buffer" type
 def ArrayOfBuffer
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAsArrayTypeUnsafe() &&
@@ -1026,7 +1048,9 @@ def ArrayOfBuffer
                  (S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
                       "Buffer" ||
                   S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "RWBuffer")}]>;
+                      "RWBuffer" ||
+                  S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
+                      "RasterizerOrderedBuffer")}]>;
 
 // Global variable with "Texture" or "SamplerState" type
 def TextureOrSampler

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -201,7 +201,7 @@ def warn_unused_variable : Warning<"unused variable %0">,
 def warn_unused_local_typedef : Warning<
   "unused %select{typedef|type alias}0 %1">,
   InGroup<UnusedLocalTypedef>, DefaultIgnore;
-def warn_unused_property_backing_ivar : 
+def warn_unused_property_backing_ivar :
   Warning<"ivar %0 which backs the property is not "
   "referenced in this property's accessor">,
   InGroup<UnusedPropertyIvar>, DefaultIgnore;
@@ -281,7 +281,7 @@ def err_inline_non_function : Error<
   "'inline' can only appear on functions">;
 def err_noreturn_non_function : Error<
   "'_Noreturn' can only appear on functions">;
-def warn_qual_return_type : Warning< 
+def warn_qual_return_type : Warning<
   "'%0' type qualifier%s1 on return type %plural{1:has|:have}1 no effect">,
   InGroup<IgnoredQualifiers>, DefaultIgnore;
 
@@ -440,8 +440,8 @@ def warn_dyn_class_memaccess : Warning<
 def note_bad_memaccess_silence : Note<
   "explicitly cast the pointer to silence this warning">;
 def warn_sizeof_pointer_expr_memaccess : Warning<
-  "'%0' call operates on objects of type %1 while the size is based on a " 
-  "different type %2">, 
+  "'%0' call operates on objects of type %1 while the size is based on a "
+  "different type %2">,
   InGroup<SizeofPointerMemaccess>;
 def warn_sizeof_pointer_expr_memaccess_note : Note<
   "did you mean to %select{dereference the argument to 'sizeof' (and multiply "
@@ -465,16 +465,16 @@ def note_memsize_comparison_paren : Note<
   "did you mean to compare the result of %0 instead?">;
 def note_memsize_comparison_cast_silence : Note<
   "explicitly cast the argument to size_t to silence this warning">;
-  
+
 def warn_strncat_large_size : Warning<
-  "the value of the size argument in 'strncat' is too large, might lead to a " 
+  "the value of the size argument in 'strncat' is too large, might lead to a "
   "buffer overflow">, InGroup<StrncatSize>;
-def warn_strncat_src_size : Warning<"size argument in 'strncat' call appears " 
+def warn_strncat_src_size : Warning<"size argument in 'strncat' call appears "
   "to be size of the source">, InGroup<StrncatSize>;
 def warn_strncat_wrong_size : Warning<
   "the value of the size argument to 'strncat' is wrong">, InGroup<StrncatSize>;
 def note_strncat_wrong_size : Note<
-  "change the argument to be the free space in the destination buffer minus " 
+  "change the argument to be the free space in the destination buffer minus "
   "the terminating null byte">;
 
 def warn_assume_side_effects : Warning<
@@ -759,15 +759,15 @@ def note_property_attribute : Note<"property %0 is declared "
   "%select{deprecated|unavailable|partial}1 here">;
 def err_setter_type_void : Error<"type of setter must be void">;
 def err_duplicate_method_decl : Error<"duplicate declaration of method %0">;
-def warn_duplicate_method_decl : 
-  Warning<"multiple declarations of method %0 found and ignored">, 
+def warn_duplicate_method_decl :
+  Warning<"multiple declarations of method %0 found and ignored">,
   InGroup<MethodDuplicate>, DefaultIgnore;
 def warn_objc_cdirective_format_string :
   Warning<"using %0 directive in %select{NSString|CFString}1 "
           "which is being passed as a formatting argument to the formatting "
           "%select{method|CFfunction}2">,
   InGroup<ObjCCStringFormat>, DefaultIgnore;
-def err_objc_var_decl_inclass : 
+def err_objc_var_decl_inclass :
     Error<"cannot declare variable inside @interface or @protocol">;
 def error_missing_method_context : Error<
   "missing context for method declaration">;
@@ -973,7 +973,7 @@ def warn_auto_implicit_atomic_property : Warning<
   "property is assumed atomic when auto-synthesizing the property">,
   InGroup<ImplicitAtomic>, DefaultIgnore;
 def warn_unimplemented_selector:  Warning<
-  "no method with selector %0 is implemented in this translation unit">, 
+  "no method with selector %0 is implemented in this translation unit">,
   InGroup<Selector>, DefaultIgnore;
 def warn_unimplemented_protocol_method : Warning<
   "method %0 in protocol %1 not implemented">, InGroup<Protocol>;
@@ -1086,7 +1086,7 @@ def err_capture_default_non_local : Error<
   "non-local lambda expression cannot have a capture-default">;
 
 def err_multiple_final_overriders : Error<
-  "virtual function %q0 has more than one final overrider in %1">; 
+  "virtual function %q0 has more than one final overrider in %1">;
 def note_final_overrider : Note<"final overrider of %q0 in %1">;
 
 def err_type_defined_in_type_specifier : Error<
@@ -1121,7 +1121,7 @@ def warn_weak_template_vtable : Warning<
 
 def ext_using_undefined_std : ExtWarn<
   "using directive refers to implicitly-defined namespace 'std'">;
-  
+
 // C++ exception specifications
 def err_exception_spec_in_typedef : Error<
   "exception specifications are not allowed in %select{typedefs|type aliases}0">;
@@ -1165,7 +1165,7 @@ def ext_ms_using_declaration_inaccessible : ExtWarn<
   "to accessible member '%1') is a Microsoft compatibility extension">,
     AccessControl, InGroup<Microsoft>;
 def err_access_ctor : Error<
-  "calling a %select{private|protected}0 constructor of class %2">, 
+  "calling a %select{private|protected}0 constructor of class %2">,
   AccessControl;
 def ext_rvalue_to_reference_access_ctor : Extension<
   "C++98 requires an accessible copy constructor for class %2 when binding "
@@ -1188,7 +1188,7 @@ def err_access_friend_function : Error<
   AccessControl;
 
 def err_access_dtor : Error<
-  "calling a %select{private|protected}1 destructor of class %0">, 
+  "calling a %select{private|protected}1 destructor of class %0">,
   AccessControl;
 def err_access_dtor_base :
     Error<"base class %0 has %select{private|protected}1 destructor">,
@@ -1230,7 +1230,7 @@ def note_access_protected_restricted_object : Note<
 def warn_cxx98_compat_sfinae_access_control : Warning<
   "substitution failure due to access control is incompatible with C++98">,
   InGroup<CXX98Compat>, DefaultIgnore, NoSFINAE;
-  
+
 // C++ name lookup
 def err_incomplete_nested_name_spec : Error<
   "incomplete type %0 named in nested name specifier">;
@@ -1419,7 +1419,7 @@ def err_covariant_return_type_class_type_more_qualified : Error<
   "return type of virtual function %0 is not covariant with the return type of "
   "the function it overrides (class type %1 is more qualified than class "
   "type %2">;
-  
+
 // C++ constructors
 def err_constructor_cannot_be : Error<"constructor cannot be declared '%0'">;
 def err_invalid_qualified_constructor : Error<
@@ -1660,7 +1660,7 @@ def note_constructor_declared_here : Note<
 // C++11 decltype
 def err_decltype_in_declarator : Error<
     "'decltype' cannot be used to name a declaration">;
-    
+
 // C++11 auto
 def warn_cxx98_compat_auto_type_specifier : Warning<
   "'auto' type specifier is incompatible with C++98">,
@@ -1982,7 +1982,7 @@ def note_private_extern : Note<
 def warn_cxx98_compat_unicode_type : Warning<
   "'%0' type specifier is incompatible with C++98">,
   InGroup<CXX98Compat>, DefaultIgnore;
- 
+
 // Objective-C++
 def err_objc_decls_may_only_appear_in_global_scope : Error<
   "Objective-C declarations may only appear in global scope">;
@@ -2150,7 +2150,7 @@ def warn_objc_literal_comparison : Warning<
 def err_missing_atsign_prefix : Error<
   "string literal must be prefixed by '@' ">;
 def warn_objc_string_literal_comparison : Warning<
-  "direct comparison of a string literal has undefined behavior">, 
+  "direct comparison of a string literal has undefined behavior">,
   InGroup<ObjCStringComparison>;
 def warn_concatenated_nsarray_literal : Warning<
   "concatenated NSString literal for an NSArray expression - "
@@ -2228,7 +2228,7 @@ def warn_cxx11_gnu_attribute_on_type : Warning<
   "attribute %0 ignored, because it cannot be applied to a type">,
   InGroup<IgnoredAttributes>;
 def warn_unhandled_ms_attribute_ignored : Warning<
-  "__declspec attribute %0 is not supported">, 
+  "__declspec attribute %0 is not supported">,
   InGroup<IgnoredAttributes>;
 def err_attribute_invalid_on_stmt : Error<
   "%0 attribute cannot be applied to a statement">;
@@ -2349,7 +2349,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
   "Textures (e.g., Texture2D) and SamplerState|"
-  "RWTextures, Buffers and RWBuffers|"
+  "RWTextures, RasterizerOrderedTextures, Buffers, RWBuffers, and RasterizerOrderedBuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"
   "cbuffer or ConstantBuffer|"
@@ -2421,7 +2421,7 @@ def warn_mismatched_availability: Warning<
   "availability does not match previous declaration">, InGroup<Availability>;
 def warn_mismatched_availability_override : Warning<
   "overriding method %select{introduced after|"
-  "deprecated before|obsoleted before}0 overridden method on %1 (%2 vs. %3)">, 
+  "deprecated before|obsoleted before}0 overridden method on %1 (%2 vs. %3)">,
   InGroup<Availability>;
 def warn_mismatched_availability_override_unavail : Warning<
   "overriding method cannot be unavailable on %0 when its overridden method is "
@@ -2454,7 +2454,7 @@ def err_attribute_argument_out_of_range : Error<
   "1:can only be 1, since there is one parameter|"
   ":must be between 1 and %2}2">;
 
-// Thread Safety Analysis   
+// Thread Safety Analysis
 def warn_unlock_but_no_lock : Warning<"releasing %0 '%1' that was not held">,
   InGroup<ThreadSafetyAnalysis>, DefaultIgnore;
 def warn_unlock_kind_mismatch : Warning<
@@ -2468,7 +2468,7 @@ def warn_no_unlock : Warning<
   InGroup<ThreadSafetyAnalysis>, DefaultIgnore;
 def warn_expecting_locked : Warning<
   "expecting %0 '%1' to be held at the end of function">,
-  InGroup<ThreadSafetyAnalysis>, DefaultIgnore;  
+  InGroup<ThreadSafetyAnalysis>, DefaultIgnore;
 // FIXME: improve the error message about locks not in scope
 def warn_lock_some_predecessors : Warning<
   "%0 '%1' is not held on every path through here">,
@@ -2545,13 +2545,13 @@ def warn_fun_requires_lock_precise :
 def note_found_mutex_near_match : Note<"found near match '%0'">;
 
 // Verbose thread safety warnings
-def warn_thread_safety_verbose : Warning<"Thread safety verbose warning.">, 
+def warn_thread_safety_verbose : Warning<"Thread safety verbose warning.">,
   InGroup<ThreadSafetyVerbose>, DefaultIgnore;
 def note_thread_warning_in_fun : Note<"Thread warning in function '%0'">;
 def note_guarded_by_declared_here : Note<"Guarded_by declared here.">;
 
-// Dummy warning that will trigger "beta" warnings from the analysis if enabled. 
-def warn_thread_safety_beta : Warning<"Thread safety beta warning.">, 
+// Dummy warning that will trigger "beta" warnings from the analysis if enabled.
+def warn_thread_safety_beta : Warning<"Thread safety beta warning.">,
   InGroup<ThreadSafetyBeta>, DefaultIgnore;
 
 // Consumed warnings
@@ -2766,7 +2766,7 @@ def err_attribute_sentinel_not_zero_or_one : Error<
   "'sentinel' parameter 2 not 0 or 1">;
 def warn_cleanup_ext : Warning<
   "GCC does not allow the 'cleanup' attribute argument to be anything other "
-  "than a simple identifier">, 
+  "than a simple identifier">,
   InGroup<GccCompat>;
 def err_attribute_cleanup_arg_not_function : Error<
   "'cleanup' argument %select{|%1 |%1 }0is not a %select{||single }0function">;
@@ -2797,7 +2797,7 @@ def warn_iboutlet_object_type : Warning<
 def warn_iboutletcollection_property_assign : Warning<
   "IBOutletCollection properties should be copy/strong and not assign">,
   InGroup<ObjCInvalidIBOutletProperty>;
-  
+
 def err_attribute_overloadable_missing : Error<
   "%select{overloaded function|redeclaration of}0 %1 must have the "
   "'overloadable' attribute">;
@@ -3013,7 +3013,7 @@ def note_ovl_candidate_non_deduced_mismatch : Note<
 // can handle that case properly.
 def note_ovl_candidate_non_deduced_mismatch_qualified : Note<
     "candidate template ignored: could not match %q0 against %q1">;
-    
+
 // Note that we don't treat templates differently for this diagnostic.
 def note_ovl_candidate_arity : Note<"candidate "
     "%select{function|function|constructor|function|function|constructor|"
@@ -3321,7 +3321,7 @@ def err_template_param_different_kind : Error<
   "%select{|template parameter }0redeclaration">;
 def note_template_param_different_kind : Note<
   "template parameter has a different kind in template argument">;
-  
+
 def err_template_nontype_parm_different_type : Error<
   "template non-type parameter has a different type %0 in template "
   "%select{|template parameter }1redeclaration">;
@@ -3625,7 +3625,7 @@ def err_dependent_typed_non_type_arg_in_partial_spec : Error<
 def err_partial_spec_args_match_primary_template : Error<
     "%select{class|variable}0 template partial specialization does not "
     "specialize any template argument; to %select{declare|define}1 the "
-    "primary template, remove the template argument list">; 
+    "primary template, remove the template argument list">;
 def warn_partial_specs_not_deducible : Warning<
     "%select{class|variable}0 template partial specialization contains "
     "%select{a template parameter|template parameters}1 that cannot be "
@@ -3652,7 +3652,7 @@ def err_var_spec_no_template : Error<
 def err_var_spec_no_template_but_method : Error<
   "no variable template matches specialization; "
   "did you mean to use %0 as function template instead?">;
-  
+
 // C++ Function template specializations
 def err_function_template_spec_no_match : Error<
     "no function template matches function template specialization %0">;
@@ -3703,7 +3703,7 @@ def note_template_type_alias_instantiation_here : Note<
   "in instantiation of template type alias %0 requested here">;
 def note_template_exception_spec_instantiation_here : Note<
   "in instantiation of exception specification for %0 requested here">;
-  
+
 def note_default_arg_instantiation_here : Note<
   "in instantiation of default argument for '%0' required here">;
 def note_default_function_arg_instantiation_here : Note<
@@ -3763,12 +3763,12 @@ def err_explicit_instantiation_out_of_scope : Error<
 def err_explicit_instantiation_must_be_global : Error<
   "explicit instantiation of %0 must occur at global scope">;
 def warn_explicit_instantiation_out_of_scope_0x : Warning<
-  "explicit instantiation of %0 not in a namespace enclosing %1">, 
+  "explicit instantiation of %0 not in a namespace enclosing %1">,
   InGroup<CXX11Compat>, DefaultIgnore;
 def warn_explicit_instantiation_must_be_global_0x : Warning<
-  "explicit instantiation of %0 must occur at global scope">, 
+  "explicit instantiation of %0 must occur at global scope">,
   InGroup<CXX11Compat>, DefaultIgnore;
-  
+
 def err_explicit_instantiation_requires_name : Error<
   "explicit instantiation declaration requires a name">;
 def err_explicit_instantiation_of_typedef : Error<
@@ -3828,7 +3828,7 @@ def err_mismatched_exception_spec_explicit_instantiation : Error<
 def ext_mismatched_exception_spec_explicit_instantiation : ExtWarn<
   "exception specification in explicit instantiation does not match instantiated one">,
   InGroup<Microsoft>;
-  
+
 // C++ typename-specifiers
 def err_typename_nested_not_found : Error<"no type named %0 in %1">;
 def err_typename_nested_not_found_enable_if : Error<
@@ -3899,7 +3899,7 @@ def note_template_parameter_pack_non_pack : Note<
 def note_template_parameter_pack_here : Note<
   "previous %select{template type|non-type template|template template}0 "
   "parameter%select{| pack}1 declared here">;
-  
+
 def err_unexpanded_parameter_pack : Error<
   "%select{expression|base type|declaration type|data member type|bit-field "
   "size|static assertion|fixed underlying type|enumerator value|"
@@ -4009,7 +4009,7 @@ def warn_missing_prototype : Warning<
   "no previous prototype for function %0">,
   InGroup<DiagGroup<"missing-prototypes">>, DefaultIgnore;
 def note_declaration_not_a_prototype : Note<
-  "this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function">; 
+  "this declaration is not a prototype; add 'void' to make it a prototype for a zero-parameter function">;
 def warn_missing_variable_declarations : Warning<
   "no previous extern declaration for non-static variable %0">,
   InGroup<DiagGroup<"missing-variable-declarations">>, DefaultIgnore;
@@ -4166,7 +4166,7 @@ def ext_ms_forward_ref_enum : Extension<
   "forward references to 'enum' types are a Microsoft extension">, InGroup<Microsoft>;
 def ext_forward_ref_enum_def : Extension<
   "redeclaration of already-defined enum %0 is a GNU extension">, InGroup<GNURedeclaredEnum>;
-  
+
 def err_redefinition_of_enumerator : Error<"redefinition of enumerator %0">;
 def err_duplicate_member : Error<"duplicate member %0">;
 def err_misplaced_ivar : Error<
@@ -4185,7 +4185,7 @@ def ext_enumerator_increment_too_large : ExtWarn<
 def warn_flag_enum_constant_out_of_range : Warning<
   "enumeration value %0 is out of range of flags in enumeration type %1">,
   InGroup<FlagEnum>;
-  
+
 def warn_illegal_constant_array_size : Extension<
   "size of static array must be an integer constant expression">;
 def err_vm_decl_in_file_scope : Error<
@@ -4296,7 +4296,7 @@ def err_illegal_initializer : Error<
   "illegal initializer (only variables can be initialized)">;
 def err_illegal_initializer_type : Error<"illegal initializer type %0">;
 def ext_init_list_type_narrowing : ExtWarn<
-  "type %0 cannot be narrowed to %1 in initializer list">, 
+  "type %0 cannot be narrowed to %1 in initializer list">,
   InGroup<CXX11Narrowing>, DefaultError, SFINAEFailure;
 def ext_init_list_variable_narrowing : ExtWarn<
   "non-constant-expression cannot be narrowed from type %0 to %1 in "
@@ -4554,9 +4554,9 @@ def err_arc_illegal_method_def : Error<
 def warn_arc_strong_pointer_objc_pointer : Warning<
   "method parameter of type %0 with no explicit ownership">,
   InGroup<DiagGroup<"explicit-ownership-type">>, DefaultIgnore;
-  
+
 } // end "ARC Restrictions" category
-  
+
 def err_arc_lost_method_convention : Error<
   "method was declared as %select{an 'alloc'|a 'copy'|an 'init'|a 'new'}0 "
   "method, but its implementation doesn't match because %select{"
@@ -4625,7 +4625,7 @@ def warn_receiver_forward_instance : Warning<
   InGroup<ForwardClassReceiver>, DefaultIgnore;
 def err_arc_collection_forward : Error<
   "collection expression type %0 is a forward declaration">;
-def err_arc_multiple_method_decl : Error< 
+def err_arc_multiple_method_decl : Error<
   "multiple methods named %0 found with mismatched result, "
   "parameter type or attributes">;
 def warn_arc_lifetime_result_type : Warning<
@@ -4987,7 +4987,7 @@ def warn_namespace_member_extra_qualification : Warning<
   "extra qualification on member %0">,
   InGroup<DiagGroup<"extra-qualification">>;
 def err_member_qualification : Error<
-  "non-friend class member %0 cannot have a qualified name">;  
+  "non-friend class member %0 cannot have a qualified name">;
 def note_member_def_close_match : Note<"member declaration nearly matches">;
 def note_member_def_close_const_match : Note<
   "member declaration does not match because "
@@ -5085,7 +5085,7 @@ def err_typecheck_invalid_lvalue_addrof_addrof_function : Error<
 def err_typecheck_invalid_lvalue_addrof : Error<
   "cannot take the address of an rvalue of type %0">;
 def ext_typecheck_addrof_temporary : ExtWarn<
-  "taking the address of a temporary object of type %0">, 
+  "taking the address of a temporary object of type %0">,
   InGroup<DiagGroup<"address-of-temporary">>, DefaultError;
 def err_typecheck_addrof_temporary : Error<
   "taking the address of a temporary object of type %0">;
@@ -5169,7 +5169,7 @@ def warn_lunsigned_always_true_comparison : Warning<
   "comparison of unsigned%select{| enum}2 expression %0 is always %1">,
   InGroup<TautologicalCompare>;
 def warn_out_of_range_compare : Warning<
-  "comparison of %select{constant %0|true|false}1 with " 
+  "comparison of %select{constant %0|true|false}1 with "
   "%select{expression of type %2|boolean expression}3 is always "
   "%select{false|true}4">, InGroup<TautologicalOutOfRangeCompare>;
 def warn_runsigned_always_true_comparison : Warning<
@@ -5320,7 +5320,7 @@ def error_no_subobject_property_setting : Error<
   "expression is not assignable">;
 def err_qualified_objc_access : Error<
   "%select{property|instance variable}0 access cannot be qualified with '%1'">;
-  
+
 def ext_freestanding_complex : Extension<
   "complex numbers are an extension in a freestanding C99 implementation">;
 
@@ -5465,13 +5465,13 @@ def warn_cxx98_compat_cast_fn_obj : Warning<
 def err_bad_reinterpret_cast_small_int : Error<
   "cast from pointer to smaller type %2 loses information">;
 def err_bad_cxx_cast_vector_to_scalar_different_size : Error<
-  "%select{||reinterpret_cast||C-style cast|}0 from vector %1 " 
+  "%select{||reinterpret_cast||C-style cast|}0 from vector %1 "
   "to scalar %2 of different size">;
 def err_bad_cxx_cast_scalar_to_vector_different_size : Error<
-  "%select{||reinterpret_cast||C-style cast|}0 from scalar %1 " 
+  "%select{||reinterpret_cast||C-style cast|}0 from scalar %1 "
   "to vector %2 of different size">;
 def err_bad_cxx_cast_vector_to_vector_different_size : Error<
-  "%select{||reinterpret_cast||C-style cast|}0 from vector %1 " 
+  "%select{||reinterpret_cast||C-style cast|}0 from vector %1 "
   "to vector %2 of different size">;
 def err_bad_lvalue_to_rvalue_cast : Error<
   "cannot cast from lvalue of type %1 to rvalue reference type %2; types are "
@@ -5818,7 +5818,7 @@ def err_typecheck_nonviable_condition_incomplete : Error<
 def err_typecheck_deleted_function : Error<
   "conversion function %diff{from $ to $|between types}0,1 "
   "invokes a deleted function">;
-  
+
 def err_expected_class_or_namespace : Error<"%0 is not a class"
   "%select{ or namespace|, namespace, or enumeration}1">;
 def err_invalid_declarator_scope : Error<"cannot define or redeclare %0 here "
@@ -6167,11 +6167,11 @@ def err_typecheck_call_too_many_args_at_most_suggest : Error<
   "too many %select{|||execution configuration }0arguments to "
   "%select{function|block|method|kernel function}0 call, "
   "expected at most %1, have %2; did you mean %3?">;
-  
+
 def err_arc_typecheck_convert_incompatible_pointer : Error<
   "incompatible pointer types passing retainable parameter of type %0"
   "to a CF function expecting %1 type">;
-  
+
 def err_builtin_fn_use : Error<"builtin functions must be directly called">;
 
 def warn_call_wrong_number_of_arguments : Warning<
@@ -6295,7 +6295,7 @@ def warn_cast_pointer_from_sel : Warning<
 def warn_function_def_in_objc_container : Warning<
   "function definition inside an Objective-C container is deprecated">,
   InGroup<FunctionDefInObjCContainer>;
-  
+
 def warn_bad_function_cast : Warning<
   "cast from function call of type %0 to non-matching type %1">,
   InGroup<BadFunctionCast>, DefaultIgnore;
@@ -6354,7 +6354,7 @@ def note_inequality_comparison_to_or_assign : Note<
 
 def err_incomplete_type_used_in_type_trait_expr : Error<
   "incomplete type %0 used in type trait expression">;
-  
+
 def err_dimension_expr_not_constant_integer : Error<
   "dimension expression does not evaluate to a constant unsigned int">;
 
@@ -6562,8 +6562,8 @@ def err_reference_to_local_var_in_enclosing_context : Error<
   "reference to local variable %0 declared in enclosing context">;
 
 def err_static_data_member_not_allowed_in_local_class : Error<
-  "static data member %0 not allowed in local class %1">; 
-  
+  "static data member %0 not allowed in local class %1">;
+
 // C++ derived classes
 def err_base_clause_on_union : Error<"unions cannot have base classes">;
 def err_base_must_be_class : Error<"base specifier must name a class">;
@@ -7189,7 +7189,7 @@ def err_incorrect_num_initializers : Error<
 def err_altivec_empty_initializer : Error<"expected initializer">;
 
 def err_invalid_neon_type_code : Error<
-  "incompatible constant for this __builtin_neon function">; 
+  "incompatible constant for this __builtin_neon function">;
 def err_argument_invalid_range : Error<
   "argument should be a value from %0 to %1">;
 def warn_neon_vector_initializer_non_portable : Warning<
@@ -7224,7 +7224,7 @@ def err_constant_integer_arg_type : Error<
 def ext_mixed_decls_code : Extension<
   "ISO C90 forbids mixing declarations and code">,
   InGroup<DiagGroup<"declaration-after-statement">>;
-  
+
 def err_non_local_variable_decl_in_for : Error<
   "declaration of non-local variable in 'for' loop">;
 def err_non_variable_decl_in_for : Error<
@@ -7291,7 +7291,7 @@ def err_nsconsumed_attribute_mismatch : Error<
 def err_nsreturns_retained_attribute_mismatch : Error<
   "overriding method has mismatched ns_returns_%select{not_retained|retained}0"
   " attributes">;
-  
+
 def note_getter_unavailable : Note<
   "or because setter is declared here, but no getter method %0 is found">;
 def err_invalid_protocol_qualifiers : Error<

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -603,7 +603,9 @@ public:
                                      const std::vector<llvm::StringRef> &name,
                                      llvm::StringRef content = "");
 
-  /// \brief Adds an execution mode to the module under construction.
+  /// \brief Adds an execution mode to the module under construction if it does
+  /// not already exist. Return the newly added instruction or the existing
+  /// instruction, if one already exists.
   inline SpirvInstruction *addExecutionMode(SpirvFunction *entryPoint,
                                             spv::ExecutionMode em,
                                             llvm::ArrayRef<uint32_t> params,
@@ -924,9 +926,17 @@ SpirvInstruction *
 SpirvBuilder::addExecutionMode(SpirvFunction *entryPoint, spv::ExecutionMode em,
                                llvm::ArrayRef<uint32_t> params,
                                SourceLocation loc, bool useIdParams) {
-  auto mode = new (context)
-      SpirvExecutionMode(loc, entryPoint, em, params, useIdParams);
-  mod->addExecutionMode(mode);
+  SpirvExecutionMode *mode = nullptr;
+  SpirvExecutionMode *existingInstruction =
+      mod->findExecutionMode(entryPoint, em);
+
+  if (!existingInstruction) {
+    mode = new (context)
+        SpirvExecutionMode(loc, entryPoint, em, params, useIdParams);
+    mod->addExecutionMode(mode);
+  } else {
+    mode = existingInstruction;
+  }
 
   return mode;
 }

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -556,6 +556,12 @@ public:
       llvm::ArrayRef<llvm::StringRef> extensions, llvm::StringRef instSet,
       llvm::ArrayRef<uint32_t> capablities, SourceLocation loc);
 
+  /// \brief Creates an OpBeginInvocationInterlockEXT instruction.
+  void createBeginInvocationInterlockEXT(SourceLocation loc, SourceRange range);
+
+  /// \brief Creates an OpEndInvocationInterlockEXT instruction.
+  void createEndInvocationInterlockEXT(SourceLocation loc, SourceRange range);
+
   /// \brief Returns a clone SPIR-V variable for CTBuffer with FXC memory layout
   /// and creates copy instructions from the CTBuffer to the clone variable in
   /// module.init if it contains HLSL matrix 1xN. Otherwise, returns nullptr.

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -134,6 +134,8 @@ public:
     IK_VectorShuffle,             // OpVectorShuffle
     IK_SpirvIntrinsicInstruction, // Spirv Intrinsic Instructions
 
+    IK_InvocationInterlockEXT, // Op*InvocationInterlockEXT
+
     // For DebugInfo instructions defined in
     // OpenCL.DebugInfo.100 and NonSemantic.Shader.DebugInfo.100
     IK_DebugInfoNone,
@@ -218,6 +220,9 @@ public:
   void setBitfieldInfo(const BitfieldInfo &info) { bitfieldInfo = info; }
   llvm::Optional<BitfieldInfo> getBitfieldInfo() const { return bitfieldInfo; }
 
+  void setRasterizerOrdered(bool ro = true) { isRasterizerOrdered_ = ro; }
+  bool isRasterizerOrdered() const { return isRasterizerOrdered_; }
+
   /// Legalization-specific code
   ///
   /// Note: the following two functions are currently needed in order to support
@@ -261,6 +266,7 @@ protected:
   bool isNonUniform_;
   bool isPrecise_;
   llvm::Optional<BitfieldInfo> bitfieldInfo;
+  bool isRasterizerOrdered_;
 };
 
 /// \brief OpCapability instruction
@@ -2212,6 +2218,23 @@ public:
 private:
   SpirvInstruction *vertCount;
   SpirvInstruction *primCount;
+};
+
+/// \brief OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT
+/// instructions.
+class SpirvInvocationInterlockEXT : public SpirvInstruction {
+public:
+  SpirvInvocationInterlockEXT(spv::Op opcode, SourceLocation loc,
+                              SourceRange range = {});
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvInvocationInterlockEXT)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_InvocationInterlockEXT;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
 };
 
 class SpirvDebugInfoNone : public SpirvDebugInstruction {

--- a/tools/clang/include/clang/SPIRV/SpirvInstruction.h
+++ b/tools/clang/include/clang/SPIRV/SpirvInstruction.h
@@ -131,10 +131,9 @@ public:
     IK_SpecConstantUnaryOp,       // SpecConstant unary operations
     IK_Store,                     // OpStore
     IK_UnaryOp,                   // Unary operations
+    IK_NullaryOp,                 // Nullary operations
     IK_VectorShuffle,             // OpVectorShuffle
     IK_SpirvIntrinsicInstruction, // Spirv Intrinsic Instructions
-
-    IK_InvocationInterlockEXT, // Op*InvocationInterlockEXT
 
     // For DebugInfo instructions defined in
     // OpenCL.DebugInfo.100 and NonSemantic.Shader.DebugInfo.100
@@ -1869,6 +1868,27 @@ private:
   llvm::Optional<uint32_t> memoryAlignment;
 };
 
+/// \brief Represents SPIR-V nullary operation instructions.
+///
+/// This class includes:
+/// ----------------------------------------------------------------------------
+/// OpBeginInvocationInterlockEXT // FragmentShader*InterlockEXT capability
+/// OpEndInvocationInterlockEXT // FragmentShader*InterlockEXT capability
+/// ----------------------------------------------------------------------------
+class SpirvNullaryOp : public SpirvInstruction {
+public:
+  SpirvNullaryOp(spv::Op opcode, SourceLocation loc, SourceRange range = {});
+
+  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvNullaryOp)
+
+  // For LLVM-style RTTI
+  static bool classof(const SpirvInstruction *inst) {
+    return inst->getKind() == IK_NullaryOp;
+  }
+
+  bool invokeVisitor(Visitor *v) override;
+};
+
 /// \brief Represents SPIR-V unary operation instructions.
 ///
 /// This class includes:
@@ -2218,23 +2238,6 @@ public:
 private:
   SpirvInstruction *vertCount;
   SpirvInstruction *primCount;
-};
-
-/// \brief OpBeginInvocationInterlockEXT and OpEndInvocationInterlockEXT
-/// instructions.
-class SpirvInvocationInterlockEXT : public SpirvInstruction {
-public:
-  SpirvInvocationInterlockEXT(spv::Op opcode, SourceLocation loc,
-                              SourceRange range = {});
-
-  DEFINE_RELEASE_MEMORY_FOR_CLASS(SpirvInvocationInterlockEXT)
-
-  // For LLVM-style RTTI
-  static bool classof(const SpirvInstruction *inst) {
-    return inst->getKind() == IK_InvocationInterlockEXT;
-  }
-
-  bool invokeVisitor(Visitor *v) override;
 };
 
 class SpirvDebugInfoNone : public SpirvDebugInstruction {

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -114,6 +114,11 @@ public:
   // Add an entry point to the module.
   void addEntryPoint(SpirvEntryPoint *);
 
+  // Returns an existing execution mode instruction that is the same as em if it
+  // exists. Return nullptr otherwise.
+  SpirvExecutionMode *findExecutionMode(SpirvFunction *entryPoint,
+                                        spv::ExecutionMode em);
+
   // Adds an execution mode to the module.
   void addExecutionMode(SpirvExecutionMode *);
 

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -146,6 +146,7 @@ public:
 
   DEFINE_VISIT_METHOD(SpirvEmitMeshTasksEXT)
   DEFINE_VISIT_METHOD(SpirvSetMeshOutputsEXT)
+  DEFINE_VISIT_METHOD(SpirvInvocationInterlockEXT)
 #undef DEFINE_VISIT_METHOD
 
   const SpirvCodeGenOptions &getCodeGenOptions() const { return spvOptions; }

--- a/tools/clang/include/clang/SPIRV/SpirvVisitor.h
+++ b/tools/clang/include/clang/SPIRV/SpirvVisitor.h
@@ -110,6 +110,7 @@ public:
   DEFINE_VISIT_METHOD(SpirvSpecConstantBinaryOp)
   DEFINE_VISIT_METHOD(SpirvSpecConstantUnaryOp)
   DEFINE_VISIT_METHOD(SpirvStore)
+  DEFINE_VISIT_METHOD(SpirvNullaryOp)
   DEFINE_VISIT_METHOD(SpirvUnaryOp)
   DEFINE_VISIT_METHOD(SpirvVectorShuffle)
   DEFINE_VISIT_METHOD(SpirvArrayLength)
@@ -146,7 +147,6 @@ public:
 
   DEFINE_VISIT_METHOD(SpirvEmitMeshTasksEXT)
   DEFINE_VISIT_METHOD(SpirvSetMeshOutputsEXT)
-  DEFINE_VISIT_METHOD(SpirvInvocationInterlockEXT)
 #undef DEFINE_VISIT_METHOD
 
   const SpirvCodeGenOptions &getCodeGenOptions() const { return spvOptions; }

--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -864,7 +864,8 @@ bool isStructuredBuffer(QualType type) {
   if (!recordType)
     return false;
   const auto name = recordType->getDecl()->getName();
-  return name == "StructuredBuffer" || name == "RWStructuredBuffer";
+  return name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
+         name == "RasterizerOrderedStructuredBuffer";
 }
 
 bool isNonWritableStructuredBuffer(QualType type) {
@@ -884,7 +885,8 @@ bool isByteAddressBuffer(QualType type) {
 
 bool isRWBuffer(QualType type) {
   if (const auto *rt = type->getAs<RecordType>()) {
-    return rt->getDecl()->getName() == "RWBuffer";
+    const auto name = rt->getDecl()->getName();
+    return name == "RWBuffer" || name == "RasterizerOrderedBuffer";
   }
   return false;
 }
@@ -901,7 +903,11 @@ bool isRWTexture(QualType type) {
     const auto name = rt->getDecl()->getName();
     if (name == "RWTexture1D" || name == "RWTexture1DArray" ||
         name == "RWTexture2D" || name == "RWTexture2DArray" ||
-        name == "RWTexture3D")
+        name == "RWTexture3D" || name == "RasterizerOrderedTexture1D" ||
+        name == "RasterizerOrderedTexture1DArray" ||
+        name == "RasterizerOrderedTexture2D" ||
+        name == "RasterizerOrderedTexture2DArray" ||
+        name == "RasterizerOrderedTexture3D")
       return true;
   }
   return false;
@@ -940,7 +946,9 @@ bool isSampler(QualType type) {
 
 bool isRWByteAddressBuffer(QualType type) {
   if (const auto *rt = type->getAs<RecordType>()) {
-    return rt->getDecl()->getName() == "RWByteAddressBuffer";
+    const auto name = rt->getDecl()->getName();
+    return name == "RWByteAddressBuffer" ||
+           name == "RasterizerOrderedByteAddressBuffer";
   }
   return false;
 }
@@ -976,7 +984,8 @@ bool isRWStructuredBuffer(QualType type) {
 
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();
-    return name == "RWStructuredBuffer";
+    return name == "RWStructuredBuffer" ||
+           name == "RasterizerOrderedStructuredBuffer";
   }
   return false;
 }
@@ -994,7 +1003,9 @@ bool isAKindOfStructuredOrByteBuffer(QualType type) {
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();
     return name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
+           name == "RasterizerOrderedStructuredBuffer" ||
            name == "ByteAddressBuffer" || name == "RWByteAddressBuffer" ||
+           name == "RasterizerOrderedByteAddressBuffer" ||
            name == "AppendStructuredBuffer" ||
            name == "ConsumeStructuredBuffer";
   }
@@ -1008,7 +1019,9 @@ bool isOrContainsAKindOfStructuredOrByteBuffer(QualType type) {
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();
     if (name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
+        name == "RasterizerOrderedStructuredBuffer" ||
         name == "ByteAddressBuffer" || name == "RWByteAddressBuffer" ||
+        name == "RasterizerOrderedByteAddressBuffer" ||
         name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer")
       return true;
 
@@ -1032,27 +1045,33 @@ bool isOpaqueType(QualType type) {
   if (const auto *recordType = type->getAs<RecordType>()) {
     const auto name = recordType->getDecl()->getName();
 
-    if (name == "Texture1D" || name == "RWTexture1D")
+    if (name == "Texture1D" || name == "RWTexture1D" ||
+        name == "RasterizerOrderedTexture1D")
       return true;
-    if (name == "Texture2D" || name == "RWTexture2D")
+    if (name == "Texture2D" || name == "RWTexture2D" ||
+        name == "RasterizerOrderedTexture2D")
       return true;
     if (name == "Texture2DMS" || name == "RWTexture2DMS")
       return true;
-    if (name == "Texture3D" || name == "RWTexture3D")
+    if (name == "Texture3D" || name == "RWTexture3D" ||
+        name == "RasterizerOrderedTexture3D")
       return true;
     if (name == "TextureCube" || name == "RWTextureCube")
       return true;
 
-    if (name == "Texture1DArray" || name == "RWTexture1DArray")
+    if (name == "Texture1DArray" || name == "RWTexture1DArray" ||
+        name == "RasterizerOrderedTexture1DArray")
       return true;
-    if (name == "Texture2DArray" || name == "RWTexture2DArray")
+    if (name == "Texture2DArray" || name == "RWTexture2DArray" ||
+        name == "RasterizerOrderedTexture2DArray")
       return true;
     if (name == "Texture2DMSArray" || name == "RWTexture2DMSArray")
       return true;
     if (name == "TextureCubeArray" || name == "RWTextureCubeArray")
       return true;
 
-    if (name == "Buffer" || name == "RWBuffer")
+    if (name == "Buffer" || name == "RWBuffer" ||
+        name == "RasterizerOrderedBuffer")
       return true;
 
     if (name == "SamplerState" || name == "SamplerComparisonState")
@@ -1078,7 +1097,9 @@ std::string getHlslResourceTypeName(QualType type) {
   if (const RecordType *recordType = type->getAs<RecordType>()) {
     StringRef name = recordType->getDecl()->getName();
     if (name == "StructuredBuffer" || name == "RWStructuredBuffer" ||
+        name == "RasterizerOrderedStructuredBuffer" ||
         name == "ByteAddressBuffer" || name == "RWByteAddressBuffer" ||
+        name == "RasterizerOrderedByteAddressBuffer" ||
         name == "AppendStructuredBuffer" || name == "ConsumeStructuredBuffer" ||
         name == "Texture1D" || name == "Texture2D" || name == "Texture3D" ||
         name == "TextureCube" || name == "Texture1DArray" ||
@@ -1086,7 +1107,12 @@ std::string getHlslResourceTypeName(QualType type) {
         name == "Texture2DMSArray" || name == "TextureCubeArray" ||
         name == "RWTexture1D" || name == "RWTexture2D" ||
         name == "RWTexture3D" || name == "RWTexture1DArray" ||
-        name == "RWTexture2DArray" || name == "Buffer" || name == "RWBuffer" ||
+        name == "RWTexture2DArray" || name == "RasterizerOrderedTexture1D" ||
+        name == "RasterizerOrderedTexture1DArray" ||
+        name == "RasterizerOrderedTexture2D" ||
+        name == "RasterizerOrderedTexture2DArray" ||
+        name == "RasterizerOrderedTexture3D" || name == "Buffer" ||
+        name == "RWBuffer" || name == "RasterizerOrderedBuffer" ||
         name == "SubpassInput" || name == "SubpassInputMS" ||
         name == "InputPatch" || name == "OutputPatch") {
       // Get resource type name with template params. Operation is safe because
@@ -1169,7 +1195,12 @@ bool isRelaxedPrecisionType(QualType type, const SpirvCodeGenOptions &opts) {
         name == "Texture2DMSArray" || name == "TextureCubeArray" ||
         name == "RWTexture1D" || name == "RWTexture2D" ||
         name == "RWTexture3D" || name == "RWTexture1DArray" ||
-        name == "RWTexture2DArray" || name == "Buffer" || name == "RWBuffer" ||
+        name == "RWTexture2DArray" || name == "RasterizerOrderedTexture1D" ||
+        name == "RasterizerOrderedTexture1DArray" ||
+        name == "RasterizerOrderedTexture2D" ||
+        name == "RasterizerOrderedTexture2DArray" ||
+        name == "RasterizerOrderedTexture3D" || name == "Buffer" ||
+        name == "RWBuffer" || name == "RasterizerOrderedBuffer" ||
         name == "SubpassInput" || name == "SubpassInputMS") {
       const auto sampledType = hlsl::GetHLSLResourceResultType(type);
       return isRelaxedPrecisionType(sampledType, opts);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3653,6 +3653,7 @@ SpirvVariable *DeclResultIdMapper::createSpirvStageVar(
   // According to DXIL spec, the SampleIndex SV can only be used by PSIn.
   // According to Vulkan spec, the SampleId BuiltIn can only be used in PSIn.
   case hlsl::Semantic::Kind::SampleIndex: {
+    setInterlockExecutionMode(spv::ExecutionMode::SampleInterlockOrderedEXT);
     stageVar->setIsSpirvBuiltin();
     return spvBuilder.addStageBuiltinVar(type, sc, BuiltIn::SampleId, isPrecise,
                                          srcLoc);
@@ -3776,6 +3777,8 @@ SpirvVariable *DeclResultIdMapper::createSpirvStageVar(
   // VSOut, or PSIn. According to Vulkan spec, the FragSizeEXT BuiltIn can only
   // be used as VSOut, GSOut, MSOut or PSIn.
   case hlsl::Semantic::Kind::ShadingRate: {
+    setInterlockExecutionMode(
+        spv::ExecutionMode::ShadingRateInterlockOrderedEXT);
     switch (sigPointKind) {
     case hlsl::SigPoint::Kind::PSIn:
       stageVar->setIsSpirvBuiltin();
@@ -4202,6 +4205,15 @@ void DeclResultIdMapper::decorateStageVarWithIntrinsicAttrs(
         }
       };
   decorateWithIntrinsicAttrs(decl, varInst, checkBuiltInLocationDecoration);
+}
+
+void DeclResultIdMapper::setInterlockExecutionMode(spv::ExecutionMode mode) {
+  interlockExecutionMode = mode;
+}
+
+spv::ExecutionMode DeclResultIdMapper::getInterlockExecutionMode() {
+  return interlockExecutionMode.getValueOr(
+      spv::ExecutionMode::PixelInterlockOrderedEXT);
 }
 
 void DeclResultIdMapper::copyHullOutStageVarsToOutputPatch(

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -529,6 +529,8 @@ public:
                                   QualType outputControlPointType,
                                   SpirvInstruction *ptr);
 
+  spv::ExecutionMode getInterlockExecutionMode();
+
 private:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.
@@ -780,6 +782,10 @@ private:
                                           StageVar *stageVar,
                                           SpirvVariable *varInst);
 
+  /// \brief Records which execution mode should be used for rasterizer order
+  /// views.
+  void setInterlockExecutionMode(spv::ExecutionMode mode);
+
 private:
   SpirvBuilder &spvBuilder;
   SpirvEmitter &theEmitter;
@@ -821,6 +827,14 @@ private:
   /// Mapping from cbuffer/tbuffer/ConstantBuffer/TextureBufer/push-constant
   /// to the SPIR-V type.
   llvm::DenseMap<const DeclContext *, const SpirvType *> ctBufferPCTypes;
+
+  /// The execution mode to use for rasterizer ordered views. Should be set to
+  /// PixelInterlockOrderedEXT (default), SampleInterlockOrderedEXT, or
+  /// ShadingRateInterlockOrderedEXT. This will be set based on which semantics
+  /// are present in input variables, and will be used to determine which
+  /// execution mode to attach to the entry point if it uses rasterizer ordered
+  /// views.
+  llvm::Optional<spv::ExecutionMode> interlockExecutionMode;
 
   /// The SPIR-V builtin variables accessed by WaveGetLaneCount(),
   /// WaveGetLaneIndex() and ray tracing builtins.

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1332,6 +1332,13 @@ bool EmitVisitor::visit(SpirvStore *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvNullaryOp *inst) {
+  initInstruction(inst);
+
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
 bool EmitVisitor::visit(SpirvUnaryOp *inst) {
   initInstruction(inst);
   curInst.push_back(inst->getResultTypeId());
@@ -1987,13 +1994,6 @@ bool EmitVisitor::visit(SpirvSetMeshOutputsEXT *inst) {
       getOrAssignResultId<SpirvInstruction>(inst->getVertexCount()));
   curInst.push_back(
       getOrAssignResultId<SpirvInstruction>(inst->getPrimitiveCount()));
-
-  finalizeInstruction(&mainBinary);
-  return true;
-}
-
-bool EmitVisitor::visit(SpirvInvocationInterlockEXT *inst) {
-  initInstruction(inst);
 
   finalizeInstruction(&mainBinary);
   return true;

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -1992,6 +1992,13 @@ bool EmitVisitor::visit(SpirvSetMeshOutputsEXT *inst) {
   return true;
 }
 
+bool EmitVisitor::visit(SpirvInvocationInterlockEXT *inst) {
+  initInstruction(inst);
+
+  finalizeInstruction(&mainBinary);
+  return true;
+}
+
 // EmitTypeHandler ------
 
 void EmitTypeHandler::initTypeInstruction(spv::Op op) {

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -269,6 +269,7 @@ public:
   bool visit(SpirvSpecConstantBinaryOp *) override;
   bool visit(SpirvSpecConstantUnaryOp *) override;
   bool visit(SpirvStore *) override;
+  bool visit(SpirvNullaryOp *) override;
   bool visit(SpirvUnaryOp *) override;
   bool visit(SpirvVectorShuffle *) override;
   bool visit(SpirvArrayLength *) override;
@@ -302,7 +303,6 @@ public:
   bool visit(SpirvIntrinsicInstruction *) override;
   bool visit(SpirvEmitMeshTasksEXT *) override;
   bool visit(SpirvSetMeshOutputsEXT *) override;
-  bool visit(SpirvInvocationInterlockEXT *) override;
 
   using Visitor::visit;
 

--- a/tools/clang/lib/SPIRV/EmitVisitor.h
+++ b/tools/clang/lib/SPIRV/EmitVisitor.h
@@ -302,6 +302,7 @@ public:
   bool visit(SpirvIntrinsicInstruction *) override;
   bool visit(SpirvEmitMeshTasksEXT *) override;
   bool visit(SpirvSetMeshOutputsEXT *) override;
+  bool visit(SpirvInvocationInterlockEXT *) override;
 
   using Visitor::visit;
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1121,8 +1121,8 @@ void SpirvBuilder::createBeginInvocationInterlockEXT(SourceLocation loc,
                                                      SourceRange range) {
   assert(insertPoint && "null insert point");
 
-  auto *inst = new (context) SpirvInvocationInterlockEXT(
-      spv::Op::OpBeginInvocationInterlockEXT, loc, range);
+  auto *inst = new (context)
+      SpirvNullaryOp(spv::Op::OpBeginInvocationInterlockEXT, loc, range);
   insertPoint->addInstruction(inst);
 }
 
@@ -1130,8 +1130,8 @@ void SpirvBuilder::createEndInvocationInterlockEXT(SourceLocation loc,
                                                    SourceRange range) {
   assert(insertPoint && "null insert point");
 
-  auto *inst = new (context) SpirvInvocationInterlockEXT(
-      spv::Op::OpEndInvocationInterlockEXT, loc, range);
+  auto *inst = new (context)
+      SpirvNullaryOp(spv::Op::OpEndInvocationInterlockEXT, loc, range);
   insertPoint->addInstruction(inst);
 }
 

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -210,7 +210,15 @@ SpirvInstruction *SpirvBuilder::createLoad(QualType resultType,
     instruction->setContainsAliasComponent(false);
   }
 
+  if (pointer->isRasterizerOrdered()) {
+    createBeginInvocationInterlockEXT(loc, range);
+  }
+
   insertPoint->addInstruction(instruction);
+
+  if (pointer->isRasterizerOrdered()) {
+    createEndInvocationInterlockEXT(loc, range);
+  }
 
   const auto &bitfieldInfo = pointer->getBitfieldInfo();
   if (!bitfieldInfo.hasValue())
@@ -274,6 +282,10 @@ SpirvStore *SpirvBuilder::createStore(SpirvInstruction *address,
   // Safeguard. If this happens, it means we leak non-extracted bitfields.
   assert(false == value->getBitfieldInfo().hasValue());
 
+  if (address->isRasterizerOrdered()) {
+    createBeginInvocationInterlockEXT(loc, range);
+  }
+
   SpirvInstruction *source = value;
   const auto &bitfieldInfo = address->getBitfieldInfo();
   if (bitfieldInfo.hasValue()) {
@@ -300,6 +312,11 @@ SpirvStore *SpirvBuilder::createStore(SpirvInstruction *address,
   auto *instruction =
       new (context) SpirvStore(loc, address, source, llvm::None, range);
   insertPoint->addInstruction(instruction);
+
+  if (address->isRasterizerOrdered()) {
+    createEndInvocationInterlockEXT(loc, range);
+  }
+
   return instruction;
 }
 
@@ -1098,6 +1115,24 @@ SpirvInstruction *SpirvBuilder::createSpirvIntrInstExt(
       retType, opcode, operands, extensions, set, capablities, loc);
   insertPoint->addInstruction(inst);
   return inst;
+}
+
+void SpirvBuilder::createBeginInvocationInterlockEXT(SourceLocation loc,
+                                                     SourceRange range) {
+  assert(insertPoint && "null insert point");
+
+  auto *inst = new (context) SpirvInvocationInterlockEXT(
+      spv::Op::OpBeginInvocationInterlockEXT, loc, range);
+  insertPoint->addInstruction(inst);
+}
+
+void SpirvBuilder::createEndInvocationInterlockEXT(SourceLocation loc,
+                                                   SourceRange range) {
+  assert(insertPoint && "null insert point");
+
+  auto *inst = new (context) SpirvInvocationInterlockEXT(
+      spv::Op::OpEndInvocationInterlockEXT, loc, range);
+  insertPoint->addInstruction(inst);
 }
 
 void SpirvBuilder::createRaytracingTerminateKHR(spv::Op opcode,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -764,6 +764,7 @@ void SpirvEmitter::beginInvocationInterlock(SourceLocation loc,
     interlockModeAdded = true;
   }
   spvBuilder.createBeginInvocationInterlockEXT(loc, range);
+  needsLegalization = true;
 }
 
 llvm::StringRef SpirvEmitter::getEntryPointName(const FunctionInfo *entryInfo) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -623,8 +623,7 @@ SpirvEmitter::SpirvEmitter(CompilerInstance &ci)
                    spirvOptions),
       entryFunction(nullptr), curFunction(nullptr), curThis(nullptr),
       seenPushConstantAt(), isSpecConstantMode(false), needsLegalization(false),
-      beforeHlslLegalization(false), interlockModeAdded(false),
-      mainSourceFile(nullptr) {
+      beforeHlslLegalization(false), mainSourceFile(nullptr) {
 
   // Get ShaderModel from command line hlsl profile option.
   const hlsl::ShaderModel *shaderModel =
@@ -758,11 +757,8 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
 
 void SpirvEmitter::beginInvocationInterlock(SourceLocation loc,
                                             SourceRange range) {
-  if (!interlockModeAdded) {
-    spvBuilder.addExecutionMode(
-        entryFunction, declIdMapper.getInterlockExecutionMode(), {}, loc);
-    interlockModeAdded = true;
-  }
+  spvBuilder.addExecutionMode(
+      entryFunction, declIdMapper.getInterlockExecutionMode(), {}, loc);
   spvBuilder.createBeginInvocationInterlockEXT(loc, range);
   needsLegalization = true;
 }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1395,10 +1395,6 @@ private:
   /// called from the entry point function.
   FunctionDecl *patchConstFunc;
 
-  /// Whether or not an Interlock execution mode has been added to the entry
-  /// function.
-  bool interlockModeAdded;
-
   /// The <result-id> of the OpString containing the main source file's path.
   SpirvString *mainSourceFile;
 };

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1176,6 +1176,10 @@ private:
   std::vector<SpirvVariable *>
   getInterfacesForEntryPoint(SpirvFunction *entryPoint);
 
+  /// \brief Emits OpBeginInvocationInterlockEXT and add the appropriate
+  /// execution mode, if it has not already been added.
+  void beginInvocationInterlock(SourceLocation loc, SourceRange range);
+
 private:
   /// \brief If the given FunctionDecl is not already in the workQueue, creates
   /// a FunctionInfo object for it, and inserts it into the workQueue. It also
@@ -1390,6 +1394,10 @@ private:
   /// This is the Patch Constant Function. This function is not explicitly
   /// called from the entry point function.
   FunctionDecl *patchConstFunc;
+
+  /// Whether or not an Interlock execution mode has been added to the entry
+  /// function.
+  bool interlockModeAdded;
 
   /// The <result-id> of the OpString containing the main source file's path.
   SpirvString *mainSourceFile;

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -78,6 +78,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSelect)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSpecConstantBinaryOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSpecConstantUnaryOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvStore)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvNullaryOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvUnaryOp)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvVectorShuffle)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvArrayLength)
@@ -112,7 +113,6 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvRayTracingTerminateOpKHR)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvIntrinsicInstruction)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvEmitMeshTasksEXT)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSetMeshOutputsEXT)
-DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvInvocationInterlockEXT)
 
 #undef DEFINE_INVOKE_VISITOR_FOR_CLASS
 
@@ -849,6 +849,10 @@ void SpirvStore::setAlignment(uint32_t alignment) {
   memoryAlignment = alignment;
 }
 
+SpirvNullaryOp::SpirvNullaryOp(spv::Op opcode, SourceLocation loc,
+                               SourceRange range)
+    : SpirvInstruction(IK_NullaryOp, opcode, QualType(), loc, range) {}
+
 SpirvUnaryOp::SpirvUnaryOp(spv::Op opcode, QualType resultType,
                            SourceLocation loc, SpirvInstruction *op,
                            SourceRange range)
@@ -1125,12 +1129,6 @@ SpirvSetMeshOutputsEXT::SpirvSetMeshOutputsEXT(SpirvInstruction *vertCount,
     : SpirvInstruction(IK_SetMeshOutputsEXT, spv::Op::OpSetMeshOutputsEXT,
                        QualType(), loc, range),
       vertCount(vertCount), primCount(primCount) {}
-
-SpirvInvocationInterlockEXT::SpirvInvocationInterlockEXT(spv::Op opcode,
-                                                         SourceLocation loc,
-                                                         SourceRange range)
-    : SpirvInstruction(IK_InvocationInterlockEXT, opcode, QualType(), loc,
-                       range) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -112,6 +112,7 @@ DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvRayTracingTerminateOpKHR)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvIntrinsicInstruction)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvEmitMeshTasksEXT)
 DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvSetMeshOutputsEXT)
+DEFINE_INVOKE_VISITOR_FOR_CLASS(SpirvInvocationInterlockEXT)
 
 #undef DEFINE_INVOKE_VISITOR_FOR_CLASS
 
@@ -121,7 +122,8 @@ SpirvInstruction::SpirvInstruction(Kind k, spv::Op op, QualType astType,
       srcRange(range), debugName(), resultType(nullptr), resultTypeId(0),
       layoutRule(SpirvLayoutRule::Void), containsAlias(false),
       storageClass(spv::StorageClass::Function), isRValue_(false),
-      isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false) {}
+      isRelaxedPrecision_(false), isNonUniform_(false), isPrecise_(false),
+      isRasterizerOrdered_(false) {}
 
 bool SpirvInstruction::isArithmeticInstruction() const {
   switch (opcode) {
@@ -1123,6 +1125,12 @@ SpirvSetMeshOutputsEXT::SpirvSetMeshOutputsEXT(SpirvInstruction *vertCount,
     : SpirvInstruction(IK_SetMeshOutputsEXT, spv::Op::OpSetMeshOutputsEXT,
                        QualType(), loc, range),
       vertCount(vertCount), primCount(primCount) {}
+
+SpirvInvocationInterlockEXT::SpirvInvocationInterlockEXT(spv::Op opcode,
+                                                         SourceLocation loc,
+                                                         SourceRange range)
+    : SpirvInstruction(IK_InvocationInterlockEXT, opcode, QualType(), loc,
+                       range) {}
 
 } // namespace spirv
 } // namespace clang

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -277,6 +277,18 @@ void SpirvModule::addEntryPoint(SpirvEntryPoint *ep) {
   entryPoints.push_back(ep);
 }
 
+SpirvExecutionMode *SpirvModule::findExecutionMode(SpirvFunction *entryPoint,
+                                                   spv::ExecutionMode em) {
+  for (SpirvExecutionMode *cem : executionModes) {
+    if (cem->getEntryPoint() != entryPoint)
+      continue;
+    if (cem->getExecutionMode() != em)
+      continue;
+    return cem;
+  }
+  return nullptr;
+}
+
 void SpirvModule::addExecutionMode(SpirvExecutionMode *em) {
   assert(em && "cannot add null execution mode");
   executionModes.push_back(em);

--- a/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.hlsl
@@ -1,0 +1,121 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpExecutionMode %main PixelInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main PixelInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main SampleInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main ShadingRateInterlockOrderedEXT
+
+struct S {
+    float f;
+};
+
+SamplerState gSampler;
+
+RasterizerOrderedBuffer<float> rovBuf;
+RasterizerOrderedByteAddressBuffer rovBABuf;
+RasterizerOrderedStructuredBuffer<S> rovSBuf;
+RasterizerOrderedTexture1D<float> rovTex1D;
+RasterizerOrderedTexture1DArray<float> rovTex1DArray;
+RasterizerOrderedTexture2D<float> rovTex2D;
+RasterizerOrderedTexture2DArray<float> rovTex2DArray;
+RasterizerOrderedTexture3D<float> rovTex3D;
+
+void main() {
+  float val;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovBuf[0];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovBuf[0] = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovBuf[0]++;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpAccessChain
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovBABuf.Load(0);
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK: OpAccessChain
+// CHECK: OpStore
+// CHECK: OpEndInvocationInterlockEXT
+  rovBABuf.Store(0, 123.0);
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovSBuf[0].f;
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpStore
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovSBuf[0].f = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovTex1D[0];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovTex1D[0] = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovTex1DArray[uint2(0,0)];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovTex1DArray[uint2(0,0)] = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovTex2D[uint2(0,0)];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovTex2D[uint2(0,0)] = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovTex2DArray[uint3(0,0,0)];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovTex2DArray[uint3(0,0,0)] = 123.0;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovTex3D[uint3(0,0,0)];
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageWrite
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  rovTex3D[uint3(0,0,0)] = 123.0;
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.sample.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.sample.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpExecutionMode %main SampleInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main PixelInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main SampleInterlockOrrderedEXT
+// CHECK-NOT: OpExecutionMode %main ShadingRateInterlockOrderedEXT
+
+RasterizerOrderedBuffer<float> rovBuf;
+
+void main(uint sind: SV_SampleIndex) {
+  float val;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovBuf[0];
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.shading-rate.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/op.rasterizer-ordered-views.access.shading-rate.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpExecutionMode %main ShadingRateInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main PixelInterlockOrderedEXT
+// CHECK-NOT: OpExecutionMode %main SampleInterlockOrrderedEXT
+// CHECK-NOT: OpExecutionMode %main ShadingRateInterlockOrderedEXT
+
+RasterizerOrderedBuffer<float> rovBuf;
+
+void main(uint rate: SV_ShadingRate) {
+  float val;
+
+// CHECK: OpBeginInvocationInterlockEXT
+// CHECK-NEXT: OpLoad
+// CHECK-NEXT: OpImageRead
+// CHECK-NEXT: OpEndInvocationInterlockEXT
+  val = rovBuf[0];
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.hlsl
@@ -1,0 +1,59 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpCapability SampledBuffer
+// CHECK: OpCapability StorageImageExtendedFormats
+
+// CHECK: %type_buffer_image = OpTypeImage %int Buffer 2 0 0 2 R32i
+// CHECK: %_ptr_UniformConstant_type_buffer_image = OpTypePointer UniformConstant %type_buffer_image
+RasterizerOrderedBuffer<int> introvbuf;
+// CHECK: %type_buffer_image_0 = OpTypeImage %uint Buffer 2 0 0 2 R32ui
+// CHECK: %_ptr_UniformConstant_type_buffer_image_0 = OpTypePointer UniformConstant %type_buffer_image_0
+RasterizerOrderedBuffer<uint> uintrovbuf;
+// CHECK: %type_buffer_image_1 = OpTypeImage %float Buffer 2 0 0 2 R32f
+// CHECK: %_ptr_UniformConstant_type_buffer_image_1 = OpTypePointer UniformConstant %type_buffer_image_1
+RasterizerOrderedBuffer<float> floatrovbuf;
+
+// CHECK: %type_buffer_image_2 = OpTypeImage %int Buffer 2 0 0 2 Rg32i
+// CHECK: %_ptr_UniformConstant_type_buffer_image_2 = OpTypePointer UniformConstant %type_buffer_image_2
+RasterizerOrderedBuffer<int2> int2rovbuf;
+// CHECK: %type_buffer_image_3 = OpTypeImage %uint Buffer 2 0 0 2 Rg32ui
+// CHECK: %_ptr_UniformConstant_type_buffer_image_3 = OpTypePointer UniformConstant %type_buffer_image_3
+RasterizerOrderedBuffer<uint2> uint2rovbuf;
+// CHECK: %type_buffer_image_4 = OpTypeImage %float Buffer 2 0 0 2 Rg32f
+// CHECK: %_ptr_UniformConstant_type_buffer_image_4 = OpTypePointer UniformConstant %type_buffer_image_4
+RasterizerOrderedBuffer<float2> float2rovbuf;
+
+// CHECK: %type_buffer_image_5 = OpTypeImage %int Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_5 = OpTypePointer UniformConstant %type_buffer_image_5
+// CHECK: %type_buffer_image_6 = OpTypeImage %int Buffer 2 0 0 2 Rgba32i
+// CHECK: %_ptr_UniformConstant_type_buffer_image_6 = OpTypePointer UniformConstant %type_buffer_image_6
+RasterizerOrderedBuffer<int3> int3rovbuf;
+RasterizerOrderedBuffer<int4> int4rovbuf;
+// CHECK: %type_buffer_image_7 = OpTypeImage %uint Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_7 = OpTypePointer UniformConstant %type_buffer_image_7
+// CHECK: %type_buffer_image_8 = OpTypeImage %uint Buffer 2 0 0 2 Rgba32ui
+// CHECK: %_ptr_UniformConstant_type_buffer_image_8 = OpTypePointer UniformConstant %type_buffer_image_8
+RasterizerOrderedBuffer<uint3> uint3rovbuf;
+RasterizerOrderedBuffer<uint4> uint4rovbuf;
+// CHECK: %type_buffer_image_9 = OpTypeImage %float Buffer 2 0 0 2 Unknown
+// CHECK: %_ptr_UniformConstant_type_buffer_image_9 = OpTypePointer UniformConstant %type_buffer_image_9
+// CHECK: %type_buffer_image_10 = OpTypeImage %float Buffer 2 0 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_buffer_image_10 = OpTypePointer UniformConstant %type_buffer_image_10
+RasterizerOrderedBuffer<float3> float3rovbuf;
+RasterizerOrderedBuffer<float4> float4rovbuf;
+
+// CHECK: %introvbuf = OpVariable %_ptr_UniformConstant_type_buffer_image UniformConstant
+// CHECK: %uintrovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_0 UniformConstant
+// CHECK: %floatrovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_1 UniformConstant
+// CHECK: %int2rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_2 UniformConstant
+// CHECK: %uint2rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_3 UniformConstant
+// CHECK: %float2rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_4 UniformConstant
+// CHECK: %int3rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_5 UniformConstant
+// CHECK: %int4rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_6 UniformConstant
+// CHECK: %uint3rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_7 UniformConstant
+// CHECK: %uint4rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_8 UniformConstant
+// CHECK: %float3rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_9 UniformConstant
+// CHECK: %float4rovbuf = OpVariable %_ptr_UniformConstant_type_buffer_image_10 UniformConstant
+
+void main() {}
+

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-buffer.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedBuffer<uint> rob;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpName %type_RWByteAddressBuffer "type.RWByteAddressBuffer"
+// CHECK: OpDecorate %_runtimearr_uint ArrayStride 4
+// CHECK: OpMemberDecorate %type_RWByteAddressBuffer 0 Offset 0
+// CHECK: OpDecorate %type_RWByteAddressBuffer BufferBlock
+// CHECK: %_runtimearr_uint = OpTypeRuntimeArray %uint
+// CHECK: %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
+// CHECK: %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
+// CHECK: %buf = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
+RasterizerOrderedByteAddressBuffer buf;
+
+void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-byte-address-buffer.unimplemented.hlsl
@@ -1,9 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// TODO: Once these are implemented, we will want to add tests checking that
-//       RasterizerOrdered* types have all the functionality of RW* types
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedByteAddressBuffer rob;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T ps_6_6 -E main -fspv-reflect -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpExtension "SPV_GOOGLE_hlsl_functionality1"
+
+// CHECK: OpName %type_RasterizerOrderedStructuredBuffer_S "type.RasterizerOrderedStructuredBuffer.S"
+
+// CHECK: %S = OpTypeStruct %float %v3float %mat2v3float
+// CHECK: %_runtimearr_S = OpTypeRuntimeArray %S
+// CHECK: %type_RasterizerOrderedStructuredBuffer_S = OpTypeStruct %_runtimearr_S
+// CHECK: %_ptr_Uniform_type_RasterizerOrderedStructuredBuffer_S = OpTypePointer Uniform %type_RasterizerOrderedStructuredBuffer_S
+struct S {
+    float    a;
+    float3   b;
+    float2x3 c;
+};
+
+// CHECK: %buf = OpVariable %_ptr_Uniform_type_RasterizerOrderedStructuredBuffer_S Uniform
+RasterizerOrderedStructuredBuffer<S> buf : register(u1);
+
+void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-structured-buffer.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedStructuredBuffer<uint> rob;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d-array.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d-array.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture1DArray<uint> rot;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-1d.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture1D<uint> rot;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d-array.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d-array.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2DArray<uint> rot;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-2d.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture2D<uint> rot;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-3d.unimplemented.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture-3d.unimplemented.hlsl
@@ -1,6 +1,0 @@
-// RUN: not %dxc -T ps_6_6 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
-
-// CHECK: error: rasterizer ordered views are unimplemented
-RasterizerOrderedTexture3D<uint> rot;
-
-void main() { }

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rasterizer-ordered-texture.hlsl
@@ -1,0 +1,51 @@
+// RUN: %dxc -T ps_6_6 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpCapability Image1D
+
+// CHECK: %type_1d_image = OpTypeImage %int 1D 2 0 0 2 R32i
+// CHECK: %_ptr_UniformConstant_type_1d_image = OpTypePointer UniformConstant %type_1d_image
+// CHECK: %type_2d_image = OpTypeImage %uint 2D 2 0 0 2 Rg32ui
+// CHECK: %_ptr_UniformConstant_type_2d_image = OpTypePointer UniformConstant %type_2d_image
+// CHECK: %type_3d_image = OpTypeImage %int 3D 2 0 0 2 R32i
+// CHECK: %_ptr_UniformConstant_type_3d_image = OpTypePointer UniformConstant %type_3d_image
+// CHECK: %type_3d_image_0 = OpTypeImage %float 3D 2 0 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_3d_image_0 = OpTypePointer UniformConstant %type_3d_image_0
+// CHECK: %type_1d_image_array = OpTypeImage %int 1D 2 1 0 2 R32i
+// CHECK: %_ptr_UniformConstant_type_1d_image_array = OpTypePointer UniformConstant %type_1d_image_array
+// CHECK: %type_2d_image_array = OpTypeImage %uint 2D 2 1 0 2 Rg32ui
+// CHECK: %_ptr_UniformConstant_type_2d_image_array = OpTypePointer UniformConstant %type_2d_image_array
+// CHECK: %type_1d_image_array_0 = OpTypeImage %float 1D 2 1 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_1d_image_array_0 = OpTypePointer UniformConstant %type_1d_image_array_0
+// CHECK: %type_2d_image_array_0 = OpTypeImage %float 2D 2 1 0 2 Rgba32f
+// CHECK: %_ptr_UniformConstant_type_2d_image_array_0 = OpTypePointer UniformConstant %type_2d_image_array_0
+
+
+// CHECK: %t1 = OpVariable %_ptr_UniformConstant_type_1d_image UniformConstant
+RasterizerOrderedTexture1D   <int>    t1 ;
+
+// CHECK: %t2 = OpVariable %_ptr_UniformConstant_type_2d_image UniformConstant
+RasterizerOrderedTexture2D   <uint2>  t2 ;
+
+// CHECK: %t3 = OpVariable %_ptr_UniformConstant_type_3d_image UniformConstant
+RasterizerOrderedTexture3D   <int>    t3 ;
+
+// CHECK: %t4 = OpVariable %_ptr_UniformConstant_type_3d_image_0 UniformConstant
+[[vk::image_format("rgba32f")]]
+RasterizerOrderedTexture3D   <float3> t4 ;
+
+// CHECK: %t5 = OpVariable %_ptr_UniformConstant_type_3d_image_0 UniformConstant
+RasterizerOrderedTexture3D   <float4> t5 ;
+
+// CHECK: %t6 = OpVariable %_ptr_UniformConstant_type_1d_image_array UniformConstant
+RasterizerOrderedTexture1DArray<int>    t6;
+
+// CHECK: %t7 = OpVariable %_ptr_UniformConstant_type_2d_image_array UniformConstant
+RasterizerOrderedTexture2DArray<uint2>  t7;
+
+// CHECK: %t8 = OpVariable %_ptr_UniformConstant_type_1d_image_array_0 UniformConstant
+RasterizerOrderedTexture1DArray<float4> t8;
+
+// CHECK: %t9 = OpVariable %_ptr_UniformConstant_type_2d_image_array_0 UniformConstant
+RasterizerOrderedTexture2DArray<float4> t9;
+
+void main() {}

--- a/tools/clang/test/CodeGenSPIRV_Lit/type.rwbuffer.struct.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/type.rwbuffer.struct.error.hlsl
@@ -8,6 +8,9 @@ struct S {
 // CHECK: error: cannot instantiate RWBuffer with struct type 'S'
 RWBuffer<S> MyRWBuffer;
 
+// CHECK: error: cannot instantiate RasterizerOrderedBuffer with struct type 'S'
+RasterizerOrderedBuffer<S> MyROVBuffer;
+
 float4 main() : A {
   return 1.0;
 }


### PR DESCRIPTION
Depends on #5819.

Adds support for

- `RasterizerOrderedBuffer`
- `RasterizerOrderedByteAddressBuffer`
- `RasterizerOrderedStructuredBuffer`
- `RasterizerOrderedTexture1D`
- `RasterizerOrderedTexture1DArray`
- `RasterizerOrderedTexture2D`
- `RasterizerOrderedTexture2DArray`
- `RasterizerOrderedTexture3D`

Each of these types is treated and lowered as their corresponding `RW` type, with the addition that loads and stores to values are wrapped with `OpBeginInvocationInterlockEXT` and `OpEndInvocationInterlockEXT`. If loads or stores to an ROV type are present, one of the

- `SampleInterlockOrderedEXT`
- `PixelInterlockOrderedEXT`
- `ShadingRateInterlockOrderedEXT`

execution modes are added to the entry function, based on semantics inputted to the function.

The code emitting the begin and end instructions might be simplified using an RAII-style manager. I avoided that in favor of being explicit with where the end instruction is emitted, but I can add one if you think that would be more readable or cleaner.

