### PR TITLE
[SPIRV] Implement SM6.6 implicit LOD operations in compute shaders

### DIFF
--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -58,6 +58,7 @@ enum class Extension {
   EXT_shader_image_int64,
   KHR_physical_storage_buffer,
   KHR_vulkan_memory_model,
+  NV_compute_shader_derivatives,
   Unknown,
 };
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -597,7 +597,9 @@ public:
                                      const std::vector<llvm::StringRef> &name,
                                      llvm::StringRef content = "");
 
-  /// \brief Adds an execution mode to the module under construction.
+  /// \brief Adds an execution mode to the module under construction if it does
+  /// not already exists. Return the newly added instruction or the existing
+  /// instruction, if one already exists.
   inline SpirvInstruction *addExecutionMode(SpirvFunction *entryPoint,
                                             spv::ExecutionMode em,
                                             llvm::ArrayRef<uint32_t> params,
@@ -918,9 +920,17 @@ SpirvInstruction *
 SpirvBuilder::addExecutionMode(SpirvFunction *entryPoint, spv::ExecutionMode em,
                                llvm::ArrayRef<uint32_t> params,
                                SourceLocation loc, bool useIdParams) {
-  auto mode = new (context)
-      SpirvExecutionMode(loc, entryPoint, em, params, useIdParams);
-  mod->addExecutionMode(mode);
+  SpirvExecutionMode *mode = nullptr;
+  SpirvExecutionMode *existingInstruction =
+      mod->findExecutionMode(entryPoint, em);
+
+  if (!existingInstruction) {
+    mode = new (context)
+        SpirvExecutionMode(loc, entryPoint, em, params, useIdParams);
+    mod->addExecutionMode(mode);
+  } else {
+    mode = existingInstruction;
+  }
 
   return mode;
 }

--- a/tools/clang/include/clang/SPIRV/SpirvModule.h
+++ b/tools/clang/include/clang/SPIRV/SpirvModule.h
@@ -114,6 +114,11 @@ public:
   // Add an entry point to the module.
   void addEntryPoint(SpirvEntryPoint *);
 
+  // Returns an existing execution mode instruction tha is the same as em if it
+  // exists. Return nullptr otherwise.
+  SpirvExecutionMode *findExecutionMode(SpirvFunction *entryPoint,
+                                        spv::ExecutionMode em);
+
   // Adds an execution mode to the module.
   void addExecutionMode(SpirvExecutionMode *);
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -876,6 +876,13 @@ bool CapabilityVisitor::visit(SpirvModule *, Visitor::Phase phase) {
           spv::Capability::FragmentShaderShadingRateInterlockEXT,
       });
 
+  addExtensionAndCapabilitiesIfEnabled(
+      Extension::NV_compute_shader_derivatives,
+      {
+          spv::Capability::ComputeDerivativeGroupQuadsNV,
+          spv::Capability::ComputeDerivativeGroupLinearNV,
+      });
+
   // AccelerationStructureType or RayQueryType can be provided by both
   // ray_tracing and ray_query extension. By default, we select ray_query to
   // provide it. This is an arbitrary decision. If the user wants avoid one

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -199,6 +199,8 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
       .Case("SPV_KHR_physical_storage_buffer",
             Extension::KHR_physical_storage_buffer)
       .Case("SPV_KHR_vulkan_memory_model", Extension::KHR_vulkan_memory_model)
+      .Case("SPV_NV_compute_shader_derivatives",
+            Extension::NV_compute_shader_derivatives)
       .Default(Extension::Unknown);
 }
 
@@ -262,6 +264,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_KHR_physical_storage_buffer";
   case Extension::KHR_vulkan_memory_model:
     return "SPV_KHR_vulkan_memory_model";
+  case Extension::NV_compute_shader_derivatives:
+    return "SPV_NV_compute_shader_derivatives";
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -4076,6 +4076,9 @@ SpirvEmitter::processTextureLevelOfDetail(const CXXMemberCallExpr *expr,
       spvBuilder.createImageQuery(spv::Op::OpImageQueryLod, queryResultType,
                                   expr->getExprLoc(), sampledImage, coordinate);
 
+  if (spvContext.isCS()) {
+    addDerivativeGroupExecutionMode();
+  }
   // The first component of the float2 contains the mipmap array layer.
   // The second component of the float2 represents the unclamped lod.
   return spvBuilder.createCompositeExtract(astContext.FloatTy, query,
@@ -5268,9 +5271,10 @@ SpirvInstruction *SpirvEmitter::createImageSample(
   // Otherwise we use implicit-lod instructions.
   const bool isExplicit = lod || (grad.first && grad.second);
 
-  // Implicit-lod instructions are only allowed in pixel shader.
-  if (!spvContext.isPS() && !isExplicit)
-    emitError("sampling with implicit lod is only allowed in fragment shaders",
+  // Implicit-lod instructions are only allowed in pixel and compute shaders.
+  if (!spvContext.isPS() && !spvContext.isCS() && !isExplicit)
+    emitError("sampling with implicit lod is only allowed in fragment and "
+              "compute shaders",
               loc);
 
   auto *retVal = spvBuilder.createImageSample(
@@ -5347,6 +5351,9 @@ SpirvEmitter::processTextureSampleGather(const CXXMemberCallExpr *expr,
 
   const auto retType = expr->getDirectCallee()->getReturnType();
   if (isSample) {
+    if (spvContext.isCS()) {
+      addDerivativeGroupExecutionMode();
+    }
     return createImageSample(retType, imageType, image, sampler, coordinate,
                              /*compareVal*/ nullptr, /*bias*/ nullptr,
                              /*lod*/ nullptr, std::make_pair(nullptr, nullptr),
@@ -5434,6 +5441,9 @@ SpirvEmitter::processTextureSampleBiasLevel(const CXXMemberCallExpr *expr,
 
   const auto retType = expr->getDirectCallee()->getReturnType();
 
+  if (!lod && spvContext.isCS()) {
+    addDerivativeGroupExecutionMode();
+  }
   return createImageSample(
       retType, imageType, image, sampler, coordinate,
       /*compareVal*/ nullptr, bias, lod, std::make_pair(nullptr, nullptr),
@@ -5582,6 +5592,10 @@ SpirvEmitter::processTextureSampleCmpCmpLevelZero(const CXXMemberCallExpr *expr,
 
   const auto retType = expr->getDirectCallee()->getReturnType();
   const auto imageType = imageExpr->getType();
+
+  if (!lod && spvContext.isCS()) {
+    addDerivativeGroupExecutionMode();
+  }
 
   return createImageSample(
       retType, imageType, image, sampler, coordinate, compareVal,
@@ -14012,6 +14026,33 @@ bool SpirvEmitter::spirvToolsValidate(std::vector<uint32_t> *mod,
   }
 
   return tools.Validate(mod->data(), mod->size(), options);
+}
+
+void SpirvEmitter::addDerivativeGroupExecutionMode() {
+  assert(spvContext.isCS();
+
+  SpirvExecutionMode *numThreadsEm = spvBuilder.getModule()->findExecutionMode(
+      entryFunction, spv::ExecutionMode::LocalSize);
+  auto numThreads = numThreadsEm->getParams();
+
+  // The layout of the quad is determined by the numer of threads in each
+  // dimention. From the HLSL spec
+  // (https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_Derivatives.html):
+  //
+  // Where numthreads has an X value divisible by 4 and Y and Z are both 1, the
+  // quad layouts are determined according to 1D quad rules. Where numthreads X
+  // and Y values are divisible by 2, the quad layouts are determined according
+  // to 2D quad rules. Using derivative operations in any numthreads
+  // configuration not matching either of these is invalid and will produce an
+  // error.
+  spv::ExecutionMode em = spv::ExecutionMode::DerivativeGroupQuadsNV;
+  if (numThreads[0] % 4 == 0 && numThreads[1] == 1 && numThreads[2] == 1) {
+    em = spv::ExecutionMode::DerivativeGroupLinearNV;
+  } else {
+    assert(numThreads[0] % 2 == 0 && numThreads[1] % 2 == 0);
+  }
+
+  spvBuilder.addExecutionMode(entryFunction, em, {}, SourceLocation());
 }
 
 bool SpirvEmitter::spirvToolsTrimCapabilities(std::vector<uint32_t> *mod,

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -1215,6 +1215,13 @@ private:
   /// Returns true on success and false otherwise.
   bool spirvToolsValidate(std::vector<uint32_t> *mod, std::string *messages);
 
+  /// Adds the approparate deritvative group execution mode to the entry point.
+  /// The entry point must already have a LocalSize exectuion mode, which will
+  ///  be used to determine which execution mode (quad or linear) is required.
+  ///  This decision is made according to the rules in 
+  ///  https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_Derivatives.html.
+  void addDerivativeGroupExecutionMode();
+
 public:
   /// \brief Wrapper method to create a fatal error message and report it
   /// in the diagnostic engine associated with this consumer.

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -277,6 +277,18 @@ void SpirvModule::addEntryPoint(SpirvEntryPoint *ep) {
   entryPoints.push_back(ep);
 }
 
+SpirvExecutionMode *SpirvModule::findExecutionMode(SpirvFunction *entryPoint,
+                                                   spv::ExecutionMode em) {
+  for (SpirvExecutionMode *cem : executionModes) {
+    if (cem->getEntryPoint() != entryPoint)
+      continue;
+    if (cem->getExecutionMode() != em)
+      continue;
+    return cem;
+  }
+  return nullptr;
+}
+
 void SpirvModule::addExecutionMode(SpirvExecutionMode *em) {
   assert(em && "cannot add null execution mode");
   executionModes.push_back(em);

--- a/tools/clang/test/CodeGenSPIRV_Lit/single.derivative.execmode.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/single.derivative.execmode.hlsl
@@ -1,0 +1,26 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+// CHECK-NOT: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(2,2,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    uint v = id.x;
+    o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
+    o[1] = t1.CalculateLevelOfDetailUnclamped(ss, 0.5);
+    o[2] = t1.Sample(ss, 1);
+    o[3] = t1.SampleBias(ss, 1, 0.5);
+    o[4] = t1.SampleCmp(scs, 1, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.compute.linear.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupLinearNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupLinearNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(16,1,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    //CHECK:          [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    //CHECK-NEXT:    [[ss1:%[0-9]+]] = OpLoad %type_sampler %ss
+    //CHECK-NEXT:    [[si1:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss1]]
+    //CHECK-NEXT: [[query1:%[0-9]+]] = OpImageQueryLod %v2float [[si1]] %float_0_5
+    //CHECK-NEXT:        {{%[0-9]+}} = OpCompositeExtract %float [[query1]] 0
+    o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.compute.quad.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(8,8,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    //CHECK:          [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    //CHECK-NEXT:    [[ss1:%[0-9]+]] = OpLoad %type_sampler %ss
+    //CHECK-NEXT:    [[si1:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss1]]
+    //CHECK-NEXT: [[query1:%[0-9]+]] = OpImageQueryLod %v2float [[si1]] %float_0_5
+    //CHECK-NEXT:        {{%[0-9]+}} = OpCompositeExtract %float [[query1]] 0
+    o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.unclamped.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.unclamped.compute.linear.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupLinearNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupLinearNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(4,1,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    //CHECK:          [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    //CHECK-NEXT:    [[ss1:%[0-9]+]] = OpLoad %type_sampler %ss
+    //CHECK-NEXT:    [[si1:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss1]]
+    //CHECK-NEXT: [[query1:%[0-9]+]] = OpImageQueryLod %v2float [[si1]] %float_0_5
+    //CHECK-NEXT:        {{%[0-9]+}} = OpCompositeExtract %float [[query1]] 1
+    o[0] = t1.CalculateLevelOfDetailUnclamped(ss, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.unclamped.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.calculate.lod.unclamped.compute.quad.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(4,24,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    //CHECK:          [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    //CHECK-NEXT:    [[ss1:%[0-9]+]] = OpLoad %type_sampler %ss
+    //CHECK-NEXT:    [[si1:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss1]]
+    //CHECK-NEXT: [[query1:%[0-9]+]] = OpImageQueryLod %v2float [[si1]] %float_0_5
+    //CHECK-NEXT:        {{%[0-9]+}} = OpCompositeExtract %float [[query1]] 1
+    o[0] = t1.CalculateLevelOfDetailUnclamped(ss, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.sample-invalid-implicit-lod.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.sample-invalid-implicit-lod.hlsl
@@ -10,20 +10,20 @@ Texture3D   <float4> t3 : register(t3);
 TextureCube <float4> t4 : register(t4);
 
 float4 main(int2 offset: A) : SV_Position {
-// CHECK: sampling with implicit lod is only allowed in fragment shaders
+// CHECK: sampling with implicit lod is only allowed in fragment and compute shaders
     float4 val1 = t1.Sample(gSampler, 0.5);
 
-// CHECK: sampling with implicit lod is only allowed in fragment shaders
+// CHECK: sampling with implicit lod is only allowed in fragment and compute shaders
     float4 val3 = t3.Sample(gSampler, float3(0.5, 0.25, 0.3), 3);
 
-// CHECK: sampling with implicit lod is only allowed in fragment shaders
+// CHECK: sampling with implicit lod is only allowed in fragment and compute shaders
     float4 val4 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3));
 
-// CHECK: sampling with implicit lod is only allowed in fragment shaders
+// CHECK: sampling with implicit lod is only allowed in fragment and compute shaders
     float4 val6 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3), /*clamp*/ 2.0f);
 
     uint status;
-// CHECK: sampling with implicit lod is only allowed in fragment shaders
+// CHECK: sampling with implicit lod is only allowed in fragment and compute shaders
     float4 val8 = t4.Sample(gSampler, float3(0.5, 0.25, 0.3), /*clamp*/ 2.0f, status);
 
     return float4(0.0, 0.0, 0.0, 1.0);

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.sample.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.sample.compute.linear.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupLinearNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupLinearNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(24,1,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[ss:%[0-9]+]] = OpLoad %type_sampler %ss
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_1 None
+    o[0] = t1.Sample(ss, 1);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.sample.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.sample.compute.quad.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(2,2,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[ss:%[0-9]+]] = OpLoad %type_sampler %ss
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_1 None
+    o[0] = t1.Sample(ss, 1);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.samplebias.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.samplebias.compute.linear.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupLinearNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupLinearNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(8,1,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[ss:%[0-9]+]] = OpLoad %type_sampler %ss
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_1 Bias %float_0_5
+    o[0] = t1.SampleBias(ss, 1, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.samplebias.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.samplebias.compute.quad.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(4,4,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[ss:%[0-9]+]] = OpLoad %type_sampler %ss
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[ss]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleImplicitLod %v4float [[sampledImg]] %float_1 Bias %float_0_5
+    o[0] = t1.SampleBias(ss, 1, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.samplecmp.compute.linear.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.samplecmp.compute.linear.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupLinearNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupLinearNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(12,1,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[scs:%[0-9]+]] = OpLoad %type_sampler %scs
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[scs]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleDrefImplicitLod %float [[sampledImg]] %float_1 %float_0_5
+    o[0] = t1.SampleCmp(scs, 1, 0.5);
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/texture.samplecmp.compute.quad.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/texture.samplecmp.compute.quad.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// This test checks tha hte execution mode is not added multiple times. Other
+// tests will verify that the code generation is correct.
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(2,10,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK:              [[t1:%[0-9]+]] = OpLoad %type_1d_image %t1
+    // CHECK-NEXT:   [[scs:%[0-9]+]] = OpLoad %type_sampler %scs
+    // CHECK-NEXT: [[sampledImg:%[0-9]+]] = OpSampledImage %type_sampled_image [[t1]] [[scs]]
+    // CHECK-NEXT:            {{%[0-9]+}} = OpImageSampleDrefImplicitLod %float [[sampledImg]] %float_1 %float_0_5
+    o[0] = t1.SampleCmp(scs, 1, 0.5);
+}


### PR DESCRIPTION
SPIRV has not yet implemented the changes in SM6.6 that allows [derivatives
in compute, mesh, and amplification shaders](https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_Derivatives.html). This is because there is no KHR
extension that enabled that capability in SPIR-V.

However, we have decided to use [SPV_NV_compute_shader_derivatives](https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/NV/SPV_NV_compute_shader_derivatives.asciidoc)
to implement it for compute shader while we wait for a KHR extension.

This change only deals with the texture sample instructions.
The changes involve

1. modifying code that makes sure these only appear in fragment shaders
to allow compute shaders as well.
1. add the extension and capability
1. set the correct execution mode on the function when
the intrinsics are used in compute shaders.
