### PR TITLE
More NodeMaxDispatchGrid diagnostic fixes in Sema

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15179,7 +15179,7 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
   }
 
   // Iterate over fields of the current struct
-  for (FieldDecl* FD : InputRecordDecl->fields()) {
+  for (FieldDecl *FD : InputRecordDecl->fields()) {
     // Check if any of the fields have SV_DispatchGrid annotation
     for (const hlsl::UnusualAnnotation *it : FD->getUnusualAnnotations()) {
       if (it->getKind() == hlsl::UnusualAnnotation::UA_SemanticDecl) {
@@ -15201,12 +15201,13 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
       }
     }
     // Check nested structs
-    const RecordType* FieldTypeAsStruct = FD->getType()->getAsStructureType();
+    const RecordType *FieldTypeAsStruct = FD->getType()->getAsStructureType();
     if (nullptr != FieldTypeAsStruct) {
       CXXRecordDecl *FieldTypeDecl =
           dyn_cast<CXXRecordDecl>(FieldTypeAsStruct->getDecl());
       if (nullptr != FieldTypeDecl) {
-        DiagnoseMustHaveOneDispatchGridSemantics(S, FieldTypeDecl, DispatchGridLoc, Found);
+        DiagnoseMustHaveOneDispatchGridSemantics(S, FieldTypeDecl,
+                                                 DispatchGridLoc, Found);
       }
     }
   }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15163,11 +15163,8 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
                                               bool &Found) {
 
   // Walk up the inheritance chain and check all fields on base classes
-  for (CXXRecordDecl::base_class_iterator B = InputRecordDecl->bases_begin(),
-                                          BEnd = InputRecordDecl->bases_end();
-       B != BEnd; ++B) {
-
-    const RecordType *BaseStructType = B->getType()->getAsStructureType();
+  for (auto &B : InputRecordDecl->bases()) {
+    const RecordType *BaseStructType = B.getType()->getAsStructureType();
     if (nullptr != BaseStructType) {
       CXXRecordDecl *BaseTypeDecl =
           dyn_cast<CXXRecordDecl>(BaseStructType->getDecl());

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15161,11 +15161,27 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
                                               CXXRecordDecl *InputRecordDecl,
                                               SourceLocation &DispatchGridLoc,
                                               bool &Found) {
-  // Iterate over fields of the input record struct
-  for (auto FieldDecl : InputRecordDecl->fields()) {
+
+  // Walk up the inheritance chain and check all fields on base classes
+  for (CXXRecordDecl::base_class_iterator B = InputRecordDecl->bases_begin(),
+                                          BEnd = InputRecordDecl->bases_end();
+       B != BEnd; ++B) {
+
+    const RecordType *BaseStructType = B->getType()->getAsStructureType();
+    if (nullptr != BaseStructType) {
+      CXXRecordDecl *BaseTypeDecl =
+          dyn_cast<CXXRecordDecl>(BaseStructType->getDecl());
+      if (nullptr != BaseTypeDecl) {
+        DiagnoseMustHaveOneDispatchGridSemantics(S, BaseTypeDecl,
+                                                 DispatchGridLoc, Found);
+      }
+    }
+  }
+
+  // Iterate over fields of the current struct
+  for (FieldDecl* FD : InputRecordDecl->fields()) {
     // Check if any of the fields have SV_DispatchGrid annotation
-    for (const hlsl::UnusualAnnotation *it :
-         FieldDecl->getUnusualAnnotations()) {
+    for (const hlsl::UnusualAnnotation *it : FD->getUnusualAnnotations()) {
       if (it->getKind() == hlsl::UnusualAnnotation::UA_SemanticDecl) {
         const hlsl::SemanticDecl *sd = cast<hlsl::SemanticDecl>(it);
         if (sd->SemanticName.equals("SV_DispatchGrid")) {
@@ -15184,20 +15200,13 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
         }
       }
     }
-  }
-
-  // Walk up the inheritance chain and check all fields on base classes
-  for (CXXRecordDecl::base_class_iterator B = InputRecordDecl->bases_begin(),
-                                          BEnd = InputRecordDecl->bases_end();
-       B != BEnd; ++B) {
-
-    const RecordType *BaseStructType = B->getType()->getAsStructureType();
-    if (nullptr != BaseStructType) {
-      CXXRecordDecl *BaseTypeDecl =
-          dyn_cast<CXXRecordDecl>(BaseStructType->getDecl());
-      if (nullptr != BaseTypeDecl) {
-        DiagnoseMustHaveOneDispatchGridSemantics(S, BaseTypeDecl,
-                                                 DispatchGridLoc, Found);
+    // Check nested structs
+    const RecordType* FieldTypeAsStruct = FD->getType()->getAsStructureType();
+    if (nullptr != FieldTypeAsStruct) {
+      CXXRecordDecl *FieldTypeDecl =
+          dyn_cast<CXXRecordDecl>(FieldTypeAsStruct->getDecl());
+      if (nullptr != FieldTypeDecl) {
+        DiagnoseMustHaveOneDispatchGridSemantics(S, FieldTypeDecl, DispatchGridLoc, Found);
       }
     }
   }

--- a/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
+++ b/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
@@ -133,7 +133,7 @@ void node19(DispatchNodeInputRecord<MyStruct3> input)
 
 struct A {
     float a;
-    uint3 grid : SV_DispatchGrid;   // expected-error {{a field with SV_DispatchGrid has already been specified}}
+    uint3 grid : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
 };
 
 struct B : A {
@@ -142,7 +142,7 @@ struct B : A {
 
 struct C : B {
     float b;
-    int3 grid2 : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
+    int3 grid2 : SV_DispatchGrid;   // expected-error {{a field with SV_DispatchGrid has already been specified}}
 };
 
 [Shader("node")]
@@ -150,4 +150,24 @@ struct C : B {
 [NodeMaxDispatchGrid(8, 4, 4)]      
 [NumThreads(32, 1, 1)]
 void node20(DispatchNodeInputRecord<C> input)
+{ }
+
+struct D {
+  uint4 grid1 : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
+};
+
+struct E {
+  D struct_field;
+};
+
+struct F : E {
+  uint4 grid2 : SV_DispatchGrid;   // expected-error {{a field with SV_DispatchGrid has already been specified}}
+  float data;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node21(DispatchNodeInputRecord<F> input)
 { }


### PR DESCRIPTION
- check nested structs for `SV_DispatchGrid` semantics
- check base classes first before iterating through fields to improve error message locations

Related PR: #5806