### PR TITLE
[ClangCL] Cleanup rest clang-cl warnings

### DIFF
--- a/include/dxc/Support/microcom.h
+++ b/include/dxc/Support/microcom.h
@@ -74,7 +74,9 @@ template <typename T> void DxcCallDestructor(T *obj) { obj->T::~T(); }
 #define DXC_MICROCOM_REF_FIELD(m_dwRef)                                        \
   volatile std::atomic<llvm::sys::cas_flag> m_dwRef = {0};
 #define DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                      \
-  ULONG STDMETHODCALLTYPE AddRef() override { return (ULONG)++m_dwRef; }
+  ULONG STDMETHODCALLTYPE AddRef() noexcept override {                         \
+    return (ULONG)++m_dwRef;                                                   \
+  }
 #define DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)                              \
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                            \
   ULONG STDMETHODCALLTYPE Release() override {                                 \
@@ -107,7 +109,7 @@ inline T *CreateOnMalloc(IMalloc *pMalloc, Args &&...args) {
 
 #define DXC_MICROCOM_TM_ADDREF_RELEASE_IMPL()                                  \
   DXC_MICROCOM_ADDREF_IMPL(m_dwRef)                                            \
-  ULONG STDMETHODCALLTYPE Release() override {                                 \
+  ULONG STDMETHODCALLTYPE Release() noexcept override {                        \
     ULONG result = (ULONG)--m_dwRef;                                           \
     if (result == 0) {                                                         \
       CComPtr<IMalloc> pTmp(m_pMalloc);                                        \

--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -19,7 +19,18 @@
 #include <string>
 #include <vector>
 #ifdef _WIN32
+
+// Disable -Wignored-qualifiers for WexTestClass.h.
+// For const size_t GetSize() const; in TestData.h.
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wignored-qualifiers"
+#endif
 #include "WexTestClass.h"
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 #include <dxgiformat.h>
 #else
 #include "WEXAdapter.h"

--- a/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
+++ b/projects/dxilconv/include/ShaderBinary/ShaderBinary.h
@@ -239,6 +239,11 @@ class COperandBase {
 public:
   COperandBase() { Clear(); }
   COperandBase(const COperandBase &Op) { memcpy(this, &Op, sizeof(*this)); }
+  COperandBase &operator=(const COperandBase &Op) {
+    if (this != &Op)
+      memcpy(this, &Op, sizeof(*this));
+    return *this;
+  }
   D3D10_SB_OPERAND_TYPE OperandType() const { return m_Type; }
   const COperandIndex *OperandIndex(UINT Index) const {
     return &m_Index[Index];

--- a/tools/clang/lib/CodeGen/CGBuilder.h
+++ b/tools/clang/lib/CodeGen/CGBuilder.h
@@ -22,9 +22,9 @@ class CodeGenFunction;
 /// instructions.
 template <bool PreserveNames>
 class CGBuilderInserter
-  : protected llvm::IRBuilderDefaultInserter<PreserveNames> {
+    : protected llvm::IRBuilderDefaultInserter<PreserveNames> {
 public:
-  CGBuilderInserter() : CGF(nullptr) {}
+  CGBuilderInserter() = default;
   explicit CGBuilderInserter(CodeGenFunction *CGF) : CGF(CGF) {}
 
 protected:
@@ -32,10 +32,9 @@ protected:
   void InsertHelper(llvm::Instruction *I, const llvm::Twine &Name,
                     llvm::BasicBlock *BB,
                     llvm::BasicBlock::iterator InsertPt) const;
-private:
-  void operator=(const CGBuilderInserter &) = delete;
 
-  CodeGenFunction *CGF;
+private:
+  CodeGenFunction *CGF = nullptr;
 };
 
 // Don't preserve names on values in an optimized build.

--- a/tools/clang/unittests/HLSL/AllocatorTest.cpp
+++ b/tools/clang/unittests/HLSL/AllocatorTest.cpp
@@ -9,9 +9,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "dxc/Support/WinIncludes.h"
-#ifdef _WIN32
-#include "WexTestClass.h"
-#endif
 #include "dxc/Test/HlslTestUtils.h"
 
 #include "dxc/HLSL/DxilSpanAllocator.h"
@@ -104,6 +101,7 @@ bool Align(unsigned &pos, unsigned end, unsigned align) {
 struct Element {
   Element() = default;
   Element(const Element &) = default;
+  Element &operator=(const Element &) = default;
   Element(unsigned id, unsigned start, unsigned end)
       : id(id), start(start), end(end) {}
   bool operator<(const Element &other) { return id < other.id; }

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -13,9 +13,6 @@
 #include "dxc/Test/HLSLTestData.h"
 #include <stdint.h>
 
-#ifdef _WIN32
-#include "WexTestClass.h"
-#endif
 #include "dxc/Support/microcom.h"
 #include "dxc/Test/HlslTestUtils.h"
 

--- a/tools/clang/unittests/HLSL/LinkerTest.cpp
+++ b/tools/clang/unittests/HLSL/LinkerTest.cpp
@@ -18,9 +18,6 @@
 
 #include <fstream>
 
-#ifdef _WIN32
-#include "WexTestClass.h"
-#endif
 #include "dxc/DxilContainer/DxilContainer.h"
 #include "dxc/Support/Global.h" // for IFT macro
 #include "dxc/Test/DxcTestUtils.h"

--- a/tools/clang/unittests/HLSL/Objects.cpp
+++ b/tools/clang/unittests/HLSL/Objects.cpp
@@ -12,9 +12,6 @@
 #include "dxc/Test/HLSLTestData.h"
 #include <stdint.h>
 
-#ifdef _WIN32
-#include "WexTestClass.h"
-#endif
 #include "dxc/Test/HlslTestUtils.h"
 
 #include <exception>

--- a/tools/clang/unittests/HLSL/OptionsTest.cpp
+++ b/tools/clang/unittests/HLSL/OptionsTest.cpp
@@ -23,9 +23,6 @@
 #include <vector>
 
 #include "dxc/Test/HLSLTestData.h"
-#ifdef _WIN32
-#include "WexTestClass.h"
-#endif
 #include "dxc/Test/HlslTestUtils.h"
 
 #include "dxc/DxilContainer/DxilContainer.h"

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -3261,7 +3261,7 @@ void main()
       VERIFY_SUCCEEDED(type->QueryInterface(IID_PPV_ARGS(&structType)));
       DWORD fieldCount = 0;
       VERIFY_SUCCEEDED(structType->GetNumFields(&fieldCount));
-      VERIFY_ARE_EQUAL(fieldCount, 1);
+      VERIFY_ARE_EQUAL(fieldCount, 1u);
       // Just a crash test:
       CComPtr<IDxcPixStructField> structField;
       structType->GetFieldByName(L"", &structField);
@@ -3289,9 +3289,10 @@ public:
   DXC_MICROCOM_ADDREF_RELEASE_IMPL(m_dwRef)
   DxcIncludeHandlerForInjectedSourcesForPix(
       PixTest *pixTest, std::vector<std::pair<std::wstring, std::string>> files)
-      : m_dwRef(0), m_pixTest(pixTest), m_files(files){};
+      : m_dwRef(0), m_files(files), m_pixTest(pixTest){};
 
-  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid, void **ppvObject) {
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID iid,
+                                           void **ppvObject) override {
     return DoBasicQueryInterface<IDxcIncludeHandler>(this, iid, ppvObject);
   }
 
@@ -3913,7 +3914,7 @@ PixTest::TestableResults PixTest::TestStructAnnotationCase(
         for (ValueLocation const &valueLocation :
              passOutput.valueLocations) // For each allocas and dxil values
         {
-          if (CurRegIdx == valueLocation.base &&
+          if (CurRegIdx == (unsigned)valueLocation.base &&
               (unsigned)valueLocation.count == cover.countOfMembers) {
             VERIFY_IS_FALSE(found);
             found = true;
@@ -4335,7 +4336,7 @@ void main()
       VERIFY_ARE_EQUAL(0u, Testables.OffsetAndSizes[0].offset);
       VERIFY_ARE_EQUAL(4u * 32u, Testables.OffsetAndSizes[0].size);
     } else {
-      VERIFY_ARE_EQUAL(4, Testables.OffsetAndSizes.size());
+      VERIFY_ARE_EQUAL(4u, Testables.OffsetAndSizes.size());
       for (unsigned i = 0; i < 4; i++) {
         VERIFY_ARE_EQUAL(1u, Testables.OffsetAndSizes[i].countOfMembers);
         VERIFY_ARE_EQUAL(i * 32u, Testables.OffsetAndSizes[i].offset);
@@ -4381,7 +4382,7 @@ void main()
       VERIFY_ARE_EQUAL(0u, Testables.OffsetAndSizes[0].offset);
       VERIFY_ARE_EQUAL(2u * 32u, Testables.OffsetAndSizes[0].size);
     } else {
-      VERIFY_ARE_EQUAL(2, Testables.OffsetAndSizes.size());
+      VERIFY_ARE_EQUAL(2u, Testables.OffsetAndSizes.size());
       for (unsigned i = 0; i < 2; i++) {
         VERIFY_ARE_EQUAL(1u, Testables.OffsetAndSizes[i].countOfMembers);
         VERIFY_ARE_EQUAL(i * 32u, Testables.OffsetAndSizes[i].offset);
@@ -4491,7 +4492,7 @@ void main()
       VERIFY_ARE_EQUAL(0u, Testables.OffsetAndSizes[0].offset);
       VERIFY_ARE_EQUAL(5u * 32u, Testables.OffsetAndSizes[0].size);
     } else {
-      VERIFY_ARE_EQUAL(5, Testables.OffsetAndSizes.size());
+      VERIFY_ARE_EQUAL(5u, Testables.OffsetAndSizes.size());
       for (unsigned i = 0; i < 5; i++) {
         VERIFY_ARE_EQUAL(1u, Testables.OffsetAndSizes[i].countOfMembers);
         VERIFY_ARE_EQUAL(i * 32u, Testables.OffsetAndSizes[i].offset);
@@ -4650,7 +4651,7 @@ void main()
       VERIFY_ARE_EQUAL(32u * 3u, Testables.OffsetAndSizes[0].size);
     }
 
-    VERIFY_ARE_EQUAL(3, Testables.AllocaWrites.size());
+    VERIFY_ARE_EQUAL(3u, Testables.AllocaWrites.size());
     ValidateAllocaWrite(Testables.AllocaWrites, 0, "i32");
     ValidateAllocaWrite(Testables.AllocaWrites, 1, "e.f2.x");
     ValidateAllocaWrite(Testables.AllocaWrites, 2, "e.f2.y");

--- a/tools/clang/unittests/HLSL/RewriterTest.cpp
+++ b/tools/clang/unittests/HLSL/RewriterTest.cpp
@@ -34,7 +34,6 @@
 #include <atlbase.h>
 #include <atlfile.h>
 
-#include "WexTestClass.h"
 #include "dxc/Test/HLSLTestData.h"
 #include "dxc/Test/HlslTestUtils.h"
 #include "dxc/Test/DxcTestUtils.h"

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -17,7 +17,6 @@
 #include <fstream>
 
 #ifdef _WIN32
-#include "WexTestClass.h"
 #define TEST_CLASS_DERIVATION
 #else
 #define TEST_CLASS_DERIVATION : public ::testing::Test

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -35,7 +35,6 @@
 #include <bitset>
 
 #undef _read
-#include "WexTestClass.h"
 #include "dxc/Test/DxcTestUtils.h"
 #include "dxc/Support/Global.h"
 #include "dxc/Support/WinIncludes.h"
@@ -9870,7 +9869,7 @@ TEST_F(ExecutionTest, ComputeRawBufferLdStHalf) {
       {256.0f, 105.17f, 980.0f},
       {465.1652f, -1.5694e2f, -0.8543e-2f, 1333.5f}};
   RawBufferLdStTestData<uint16_t> halfData;
-  for (int i = 0; i < sizeof(floatData) / sizeof(float); i++) {
+  for (unsigned i = 0; i < sizeof(floatData) / sizeof(float); i++) {
     ((uint16_t *)&halfData)[i] =
         ConvertFloat32ToFloat16(((float *)&floatData)[i]);
   }
@@ -9932,7 +9931,7 @@ TEST_F(ExecutionTest, GraphicsRawBufferLdStHalf) {
       {256.0f, 105.17f, 0.0f},
       {465.1652f, -1.5694e2f, -0.8543e-2f, 1333.5f}};
   RawBufferLdStTestData<uint16_t> halfData;
-  for (int i = 0; i < sizeof(floatData) / sizeof(float); i++) {
+  for (unsigned i = 0; i < sizeof(floatData) / sizeof(float); i++) {
     ((uint16_t *)&halfData)[i] =
         ConvertFloat32ToFloat16(((float *)&floatData)[i]);
   }

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -4415,7 +4415,10 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
 }
 
 // Used to determine how an out of bounds offset should be converted
-#define CLAMPOFFSET(offset) (((int)((unsigned)(offset) << 28)) >> 28)
+constexpr int ClampOffset(int offset) {
+  unsigned shift = ((unsigned)offset) << 28;
+  return ((int)shift) >> 28;
+}
 
 // Determine if the values in pPixels correspond to the expected locations
 // encoded into a uint based on the coordinates and offsets that were provided.
@@ -4425,8 +4428,8 @@ void VerifyProgOffsetResults(unsigned *pPixels, bool bCheckDeriv) {
   int coords[18] = {100, 150, 200, 250, 300, 350, 400, 450, 500,
                     550, 600, 650, 700, 750, 800, 850, 900, 950};
   int offsets[18] = {
-      CLAMPOFFSET(-9), -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,
-      CLAMPOFFSET(8)};
+      ClampOffset(-9), -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7,
+      ClampOffset(8)};
   for (unsigned y = 0; y < _countof(coords); y++) {
     for (unsigned x = 0; x < _countof(coords); x++) {
       unsigned cmp = (coords[y] + offsets[y]) * 1000 + coords[x] + offsets[x];

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -4415,7 +4415,7 @@ TEST_F(ExecutionTest, ATOWriteMSAATest) {
 }
 
 // Used to determine how an out of bounds offset should be converted
-#define CLAMPOFFSET(offset) (((unsigned)(offset) << 28) >> 28)
+#define CLAMPOFFSET(offset) (((int)((unsigned)(offset) << 28)) >> 28)
 
 // Determine if the values in pPixels correspond to the expected locations
 // encoded into a uint based on the coordinates and offsets that were provided.

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -23,7 +23,6 @@
 #include "ShaderOpTest.h"
 
 #include "HlslTestUtils.h"          // LogCommentFmt
-#include "WexTestClass.h"           // TAEF
 #include "dxc/DXIL/DxilConstants.h" // ComponentType
 #include "dxc/Support/Global.h"     // OutputDebugBytes
 #include "dxc/Support/dxcapi.use.h" // DxcDllSupport

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -552,7 +552,7 @@ FileRunCommandPart::RunDxc(dxc::DxcDllSupport &DllSupport,
 
   IFT(DllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
   IFT(pLibrary->CreateBlobFromFile(CommandFileName, nullptr, &pSource));
-  CComPtr<IDxcIncludeHandler> pIncludeHandler =
+  CComPtr<IncludeHandlerVFSOverlayForTest> pIncludeHandler =
       AllocVFSIncludeHandler(pLibrary, pVFS);
   IFT(DllSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));
   IFT(pCompiler->Compile(pSource, CommandFileName, entry.c_str(),
@@ -873,7 +873,7 @@ FileRunCommandPart::RunDxr(dxc::DxcDllSupport &DllSupport,
 
   IFT(DllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
   IFT(pLibrary->CreateBlobFromFile(CommandFileName, nullptr, &pSource));
-  CComPtr<IDxcIncludeHandler> pIncludeHandler =
+  CComPtr<IncludeHandlerVFSOverlayForTest> pIncludeHandler =
       AllocVFSIncludeHandler(pLibrary, pVFS);
   IFT(DllSupport.CreateInstance(CLSID_DxcRewriter, &pRewriter));
   IFT(pRewriter->RewriteWithOptions(pSource, CommandFileName, flags.data(),
@@ -969,7 +969,7 @@ FileRunCommandPart::RunLink(dxc::DxcDllSupport &DllSupport,
   HRESULT resultStatus;
 
   IFT(DllSupport.CreateInstance(CLSID_DxcLibrary, &pLibrary));
-  CComPtr<IDxcIncludeHandler> pIncludeHandler =
+  CComPtr<IncludeHandlerVFSOverlayForTest> pIncludeHandler =
       AllocVFSIncludeHandler(pLibrary, pVFS);
   IFT(DllSupport.CreateInstance(CLSID_DxcLinker, &pLinker));
   IFT(DllSupport.CreateInstance(CLSID_DxcCompiler, &pCompiler));

--- a/tools/dxexp/dxexp.cpp
+++ b/tools/dxexp/dxexp.cpp
@@ -414,7 +414,7 @@ int main(int argc, const char *argv[]) {
     text_printf("Experimental shader model feature failed with unexpected "
                 "HRESULT 0x%08x.\n",
                 (unsigned int)hr);
-    json_printf("{ \"err\": \"0x%08x\" }", hr);
+    json_printf("{ \"err\": \"0x%08x\" }", (unsigned int)hr);
     json_printf("\n}\n");
     return 4;
   }

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -225,6 +225,10 @@ if "%1"=="-clang" (
   set CMAKE_OPTS=%CMAKE_OPTS% -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
   shift /1 & goto :parse_args
 )
+if "%1"=="-clang-cl" (
+  set CMAKE_OPTS=%CMAKE_OPTS% -T ClangCL
+  shift /1 & goto :parse_args
+)
 if "%1"=="-update-generated-sources" (
   set CMAKE_OPTS=%CMAKE_OPTS% -DHLSL_COPY_GENERATED_SOURCES=1
   shift /1 & goto :parse_args


### PR DESCRIPTION
1. printf format mismatch.
2. avoid cast from CComPtr<IncludeHandlerVFSOverlayForTest> to CComPtr<IDxcIncludeHandler>.
3. fix signed unsigned mismatch.
4. fix order of fields in constructor.
5. add override for override methods.
6. port https://github.com/llvm/llvm-project/commit/01f4209631f32ccec686b232039238066a0866d9
7. add copy assignment operator to avoid -Wdeprecated-copy-with-user-provided-copy
8. disable -Wignored-qualifiers for taef header WexTestClass.h.
9. remove unused fields.
10. add -clang-cl for hctbuild.
