### PR TITLE
Direct3D WSL build header changes (#5843)

### DIFF
--- a/include/dxc/Support/WinIncludes.h
+++ b/include/dxc/Support/WinIncludes.h
@@ -66,6 +66,7 @@ template <class T> void swap(CComHeapPtr<T> &a, CComHeapPtr<T> &b) {
 #include "dxc/WinAdapter.h"
 
 #ifdef __cplusplus
+#if !defined(DEFINE_ENUM_FLAG_OPERATORS)
 // Define operator overloads to enable bit operations on enum values that are
 // used to define flags. Use DEFINE_ENUM_FLAG_OPERATORS(YOUR_TYPE) to enable these
 // operators on YOUR_TYPE.
@@ -109,6 +110,7 @@ inline ENUMTYPE operator ~ (ENUMTYPE a) { return ENUMTYPE(~((_ENUM_FLAG_SIZED_IN
 inline ENUMTYPE operator ^ (ENUMTYPE a, ENUMTYPE b) { return ENUMTYPE(((_ENUM_FLAG_SIZED_INTEGER<ENUMTYPE>::type)a) ^ ((_ENUM_FLAG_SIZED_INTEGER<ENUMTYPE>::type)b)); } \
 inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) { return (ENUMTYPE &)(((_ENUM_FLAG_SIZED_INTEGER<ENUMTYPE>::type &)a) ^= ((_ENUM_FLAG_SIZED_INTEGER<ENUMTYPE>::type)b)); } \
 }
+#endif // !defined(DEFINE_ENUM_FLAG_OPERATORS)
 #else
 #define DEFINE_ENUM_FLAG_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
 #endif
@@ -123,15 +125,7 @@ inline ENUMTYPE &operator ^= (ENUMTYPE &a, ENUMTYPE b) { return (ENUMTYPE &)(((_
 #else // defined(_WIN32) && !defined(DXC_DISABLE_ALLOCATOR_OVERRIDES)
 
 #ifndef _WIN32
-CROSS_PLATFORM_UUIDOF(IMalloc, "00000002-0000-0000-C000-000000000046")
-struct IMalloc : public IUnknown {
-  virtual void *Alloc(SIZE_T size) = 0;
-  virtual void *Realloc(void *ptr, SIZE_T size) = 0;
-  virtual void Free(void *ptr) = 0;
-  virtual SIZE_T GetSize(void *pv) = 0;
-  virtual int DidAlloc(void *pv) = 0;
-  virtual void HeapMinimize(void) = 0;
-};
+struct IMalloc;
 #endif
 
 HRESULT DxcCoGetMalloc(DWORD dwMemContext, IMalloc **ppMalloc);

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -642,6 +642,16 @@ struct IUnknown {
 CROSS_PLATFORM_UUIDOF(INoMarshal, "ECC8691B-C1DB-4DC0-855E-65F6C551AF49")
 struct INoMarshal : public IUnknown {};
 
+CROSS_PLATFORM_UUIDOF(IMalloc, "00000002-0000-0000-C000-000000000046")
+struct IMalloc : public IUnknown {
+  virtual void *Alloc(SIZE_T size) = 0;
+  virtual void *Realloc(void *ptr, SIZE_T size) = 0;
+  virtual void Free(void *ptr) = 0;
+  virtual SIZE_T GetSize(void *pv) = 0;
+  virtual int DidAlloc(void *pv) = 0;
+  virtual void HeapMinimize(void) = 0;
+};
+
 CROSS_PLATFORM_UUIDOF(ISequentialStream, "0C733A30-2A1C-11CE-ADE5-00AA0044773D")
 struct ISequentialStream : public IUnknown {
   virtual HRESULT Read(void *pv, ULONG cb, ULONG *pcbRead) = 0;


### PR DESCRIPTION
Header changes to make Direct3D WSL build work:
- Move non-WIN32 IMalloc definition back to `WinAdapter.h` (it was there until commit 44f88339383018d35155ff4f337ce73eefa5cb11)
- Define DEFINE_ENUM_FLAG_OPERATORS only if it was not already defined

(cherry picked from commit f14b0cc8c27e874cb0b49bbc22269e0a4cecb05b)