### PR TITLE
Fix clang diagnostics overflow in SEMA group; add static_assert

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticIDs.h
+++ b/tools/clang/include/clang/Basic/DiagnosticIDs.h
@@ -36,7 +36,8 @@ namespace clang {
       DIAG_START_AST           = DIAG_START_PARSE           +  500,
       DIAG_START_COMMENT       = DIAG_START_AST             +  110,
       DIAG_START_SEMA          = DIAG_START_COMMENT         +  100,
-      DIAG_START_ANALYSIS      = DIAG_START_SEMA            + 3000,
+      // HLSL Change: SEMA group length increased from 3000.
+      DIAG_START_ANALYSIS      = DIAG_START_SEMA            + 3100,
       DIAG_UPPER_LIMIT         = DIAG_START_ANALYSIS        +  100
     };
 

--- a/tools/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/tools/clang/lib/Basic/DiagnosticIDs.cpp
@@ -129,8 +129,8 @@ static const StaticDiagInfoRec *GetDiagInfo(unsigned DiagID) {
   unsigned ID = DiagID - DIAG_START_COMMON - 1;
   // HLSL Change: Added static_asserts to prevent overflow in each category.
 #define CATEGORY(NAME, PREV)                                                   \
-  static_assert(NUM_BUILTIN_##PREV##_DIAGNOSTICS < DIAG_START_##NAME &&        \
-                "otherwise, previous group overflows");                        \
+  static_assert(NUM_BUILTIN_##PREV##_DIAGNOSTICS < DIAG_START_##NAME,          \
+                "otherwise, " #PREV " diagnostic group overflows");            \
   if (DiagID > DIAG_START_##NAME) {                                            \
     Offset += NUM_BUILTIN_##PREV##_DIAGNOSTICS - DIAG_START_##PREV - 1;        \
     ID -= DIAG_START_##NAME - DIAG_START_##PREV;                               \
@@ -145,8 +145,8 @@ static const StaticDiagInfoRec *GetDiagInfo(unsigned DiagID) {
   CATEGORY(SEMA, COMMENT)
   CATEGORY(ANALYSIS, SEMA)
 #undef CATEGORY
-  static_assert(NUM_BUILTIN_ANALYSIS_DIAGNOSTICS < DIAG_UPPER_LIMIT &&
-                "otherwise, ANALYSIS group overflows");
+  static_assert(NUM_BUILTIN_ANALYSIS_DIAGNOSTICS < DIAG_UPPER_LIMIT,
+                "otherwise, ANALYSIS diagnostic group overflows");
 
   // Avoid out of bounds reads.
   if (ID + Offset >= StaticDiagInfoSize)

--- a/tools/clang/lib/Basic/DiagnosticIDs.cpp
+++ b/tools/clang/lib/Basic/DiagnosticIDs.cpp
@@ -127,21 +127,26 @@ static const StaticDiagInfoRec *GetDiagInfo(unsigned DiagID) {
   // memory at all.
   unsigned Offset = 0;
   unsigned ID = DiagID - DIAG_START_COMMON - 1;
-#define CATEGORY(NAME, PREV) \
-  if (DiagID > DIAG_START_##NAME) { \
-    Offset += NUM_BUILTIN_##PREV##_DIAGNOSTICS - DIAG_START_##PREV - 1; \
-    ID -= DIAG_START_##NAME - DIAG_START_##PREV; \
+  // HLSL Change: Added static_asserts to prevent overflow in each category.
+#define CATEGORY(NAME, PREV)                                                   \
+  static_assert(NUM_BUILTIN_##PREV##_DIAGNOSTICS < DIAG_START_##NAME &&        \
+                "otherwise, previous group overflows");                        \
+  if (DiagID > DIAG_START_##NAME) {                                            \
+    Offset += NUM_BUILTIN_##PREV##_DIAGNOSTICS - DIAG_START_##PREV - 1;        \
+    ID -= DIAG_START_##NAME - DIAG_START_##PREV;                               \
   }
-CATEGORY(DRIVER, COMMON)
-CATEGORY(FRONTEND, DRIVER)
-CATEGORY(SERIALIZATION, FRONTEND)
-CATEGORY(LEX, SERIALIZATION)
-CATEGORY(PARSE, LEX)
-CATEGORY(AST, PARSE)
-CATEGORY(COMMENT, AST)
-CATEGORY(SEMA, COMMENT)
-CATEGORY(ANALYSIS, SEMA)
+  CATEGORY(DRIVER, COMMON)
+  CATEGORY(FRONTEND, DRIVER)
+  CATEGORY(SERIALIZATION, FRONTEND)
+  CATEGORY(LEX, SERIALIZATION)
+  CATEGORY(PARSE, LEX)
+  CATEGORY(AST, PARSE)
+  CATEGORY(COMMENT, AST)
+  CATEGORY(SEMA, COMMENT)
+  CATEGORY(ANALYSIS, SEMA)
 #undef CATEGORY
+  static_assert(NUM_BUILTIN_ANALYSIS_DIAGNOSTICS < DIAG_UPPER_LIMIT &&
+                "otherwise, ANALYSIS group overflows");
 
   // Avoid out of bounds reads.
   if (ID + Offset >= StaticDiagInfoSize)
@@ -540,7 +545,10 @@ static bool getDiagnosticsInGroup(diag::Flavor Flavor,
   // Add the members of the option diagnostic set.
   const int16_t *Member = DiagArrays + Group->Members;
   for (; *Member != -1; ++Member) {
-    if (GetDiagInfo(*Member)->getFlavor() == Flavor) {
+    // HLSL Change: Check result of GetDiagInfo
+    const StaticDiagInfoRec *Info = GetDiagInfo(*Member);
+    assert(Info && "otherwise, group contains invalid diag ID");
+    if (Info->getFlavor() == Flavor) {
       NotFound = false;
       Diags.push_back(*Member);
     }

--- a/tools/clang/lib/Frontend/ASTUnit.cpp
+++ b/tools/clang/lib/Frontend/ASTUnit.cpp
@@ -2014,7 +2014,13 @@ ASTUnit *ASTUnit::LoadFromCommandLine(
     // CXXPre1yCompatPedantic is included by CXX98Compat
     // CXX11CompatReservedUserDefinedLiteral
     for (size_t i = 0; i < _countof(groupNames); ++i) {
-      Diags->setSeverityForGroup(diag::Flavor::WarningOrError, StringRef(groupNames[i]), diag::Severity::Ignored);
+      if (Diags->setSeverityForGroup(diag::Flavor::WarningOrError,
+                                     StringRef(groupNames[i]),
+                                     diag::Severity::Ignored)) {
+        assert(false &&
+               "otherwise, there is a problem with diagnostic definitions.");
+        return nullptr;
+      }
     }
     Diags->setExtensionHandlingBehavior(diag::Severity::Ignored);
   }


### PR DESCRIPTION
Overflow of a diagnostic group could lead to a crash, and we just overflowed the diagnostics in the SEMA group.

This change bumps the count for SEMA and adds several checks to catch this in the future:
- static_asserts to prevent overflow of group IDs
- assert to catch invalid ID in group more clearly
- assert to catch failure of setSeverityForGroup in ASTUnit::LoadFromCommandLine
- keep crash on invalid DiagID to prevent late failure with NDEBUG