### PR TITLE
Exec test changes to enable build inside undocked Direct3D repo

### DIFF
--- a/tools/clang/unittests/HLSLExec/CMakeLists.txt
+++ b/tools/clang/unittests/HLSLExec/CMakeLists.txt
@@ -24,6 +24,9 @@ include_directories(${TAEF_INCLUDE_DIRS})
 include_directories(${DIASDK_INCLUDE_DIRS})
 include_directories(${D3D12_INCLUDE_DIRS})
 include_directories(${LLVM_MAIN_INCLUDE_DIR}/dxc/Test)
+# Using include path with subdirectories here to allow '#include "d3dx12.h"'
+# to get use a different (newer) d3dx12.h in when building in Direct3D repo
+include_directories(${LLVM_MAIN_INCLUDE_DIR}/dxc/Support)
 
 add_dependencies(ExecHLSLTests dxcompiler)
 

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -918,7 +918,7 @@ public:
       HRESULT hr = WEX::TestExecution::RuntimeParameters::TryGetValue(
           L"Adapter", AdapterValue);
       if (SUCCEEDED(hr)) {
-        GetHardwareAdapter(factory, AdapterValue, &hardwareAdapter);
+        st::GetHardwareAdapter(factory, AdapterValue, &hardwareAdapter);
       } else {
         WEX::Logging::Log::Comment(
             L"Using default hardware adapter with D3D12 support.");
@@ -9026,6 +9026,8 @@ void LoadStoreMat(int M, int N, bool LEFT, int MEM_TYPE, uint32_t K, uint32_t k,
   }
 }
 
+// define WAVE_MMA types if building with SDK that does not support it yet
+#if !defined(D3D12_SDK_VERSION) || (D3D12_SDK_VERSION < 611)
 typedef enum D3D12_WAVE_MMA_INPUT_DATATYPE {
   D3D12_WAVE_MMA_INPUT_DATATYPE_INVALID = 0,
   D3D12_WAVE_MMA_INPUT_DATATYPE_BYTE =
@@ -9059,6 +9061,7 @@ typedef struct D3D12_FEATURE_DATA_WAVE_MMA {
   UINT RequiredWaveLaneCountMin;
   UINT RequiredWaveLaneCountMax;
 } D3D12_FEATURE_DATA_WAVE_MMA;
+#endif
 
 D3D12_FEATURE_DATA_WAVE_MMA checkWaveMMASupport(CComPtr<ID3D12Device> pDevice,
                                                 std::string &dataTypeInShader,

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -12,7 +12,7 @@
 // We need to keep & fix these warnings to integrate smoothly with HLK
 #pragma warning(error : 4100 4146 4242 4244 4267 4701 4389)
 
-#include "dxc/Support/d3dx12.h"
+#include "d3dx12.h"
 #include <atlbase.h>
 #include <atlenc.h>
 #include <d3d12.h>
@@ -119,46 +119,6 @@ HRESULT LogIfLost(HRESULT hr, ID3D12Resource *pResource) {
   return hr;
 }
 
-bool UseHardwareDevice(const DXGI_ADAPTER_DESC1 &desc, LPCWSTR AdapterName) {
-  if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
-    // Don't select the Basic Render Driver adapter.
-    return false;
-  }
-
-  if (!AdapterName)
-    return true;
-  return hlsl_test::IsStarMatchWide(AdapterName, wcslen(AdapterName),
-                                    desc.Description, wcslen(desc.Description));
-}
-
-void GetHardwareAdapter(IDXGIFactory2 *pFactory, LPCWSTR AdapterName,
-                        IDXGIAdapter1 **ppAdapter) {
-  CComPtr<IDXGIAdapter1> adapter;
-  *ppAdapter = nullptr;
-
-  for (UINT adapterIndex = 0;
-       DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter);
-       ++adapterIndex) {
-    DXGI_ADAPTER_DESC1 desc;
-    adapter->GetDesc1(&desc);
-
-    if (!UseHardwareDevice(desc, AdapterName)) {
-      adapter.Release();
-      continue;
-    }
-
-    // Check to see if the adapter supports Direct3D 12, but don't create the
-    // actual device yet.
-    if (SUCCEEDED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0,
-                                    _uuidof(ID3D12Device), nullptr))) {
-      break;
-    }
-    adapter.Release();
-  }
-
-  *ppAdapter = adapter.Detach();
-}
-
 void RecordTransitionBarrier(ID3D12GraphicsCommandList *pCommandList,
                              ID3D12Resource *pResource,
                              D3D12_RESOURCE_STATES before,
@@ -228,6 +188,46 @@ void MappedData::reset(ID3D12Resource *pResource, UINT32 sizeInBytes) {
 // ShaderOpTest library implementation.
 
 namespace st {
+
+bool UseHardwareDevice(const DXGI_ADAPTER_DESC1 &desc, LPCWSTR AdapterName) {
+  if (desc.Flags & DXGI_ADAPTER_FLAG_SOFTWARE) {
+    // Don't select the Basic Render Driver adapter.
+    return false;
+  }
+
+  if (!AdapterName)
+    return true;
+  return hlsl_test::IsStarMatchWide(AdapterName, wcslen(AdapterName),
+                                    desc.Description, wcslen(desc.Description));
+}
+
+void GetHardwareAdapter(IDXGIFactory2 *pFactory, LPCWSTR AdapterName,
+                        IDXGIAdapter1 **ppAdapter) {
+  CComPtr<IDXGIAdapter1> adapter;
+  *ppAdapter = nullptr;
+
+  for (UINT adapterIndex = 0;
+       DXGI_ERROR_NOT_FOUND != pFactory->EnumAdapters1(adapterIndex, &adapter);
+       ++adapterIndex) {
+    DXGI_ADAPTER_DESC1 desc;
+    adapter->GetDesc1(&desc);
+
+    if (!UseHardwareDevice(desc, AdapterName)) {
+      adapter.Release();
+      continue;
+    }
+
+    // Check to see if the adapter supports Direct3D 12, but don't create the
+    // actual device yet.
+    if (SUCCEEDED(D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_11_0,
+                                    _uuidof(ID3D12Device), nullptr))) {
+      break;
+    }
+    adapter.Release();
+  }
+
+  *ppAdapter = adapter.Detach();
+}
 
 LPCSTR string_table::insert(LPCSTR pValue) {
   std::unordered_set<LPCSTR, HashStr, PredStr>::iterator i =

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.h
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.h
@@ -42,9 +42,6 @@ struct IDxcBlob;
 UINT GetByteSizeForFormat(DXGI_FORMAT value);
 HRESULT LogIfLost(HRESULT hr, ID3D12Device *pDevice);
 HRESULT LogIfLost(HRESULT hr, ID3D12Resource *pResource);
-bool UseHardwareDevice(const DXGI_ADAPTER_DESC1 &desc, LPCWSTR AdapterName);
-void GetHardwareAdapter(IDXGIFactory2 *pFactory, LPCWSTR AdapterName,
-                        IDXGIAdapter1 **ppAdapter);
 void RecordTransitionBarrier(ID3D12GraphicsCommandList *pCommandList,
                              ID3D12Resource *pResource,
                              D3D12_RESOURCE_STATES before,
@@ -83,6 +80,10 @@ namespace st {
 
 typedef void(__stdcall *OutputStringFn)(void *, const wchar_t *);
 void SetOutputFn(void *pCtx, OutputStringFn F);
+
+bool UseHardwareDevice(const DXGI_ADAPTER_DESC1 &desc, LPCWSTR AdapterName);
+void GetHardwareAdapter(IDXGIFactory2 *pFactory, LPCWSTR AdapterName,
+                        IDXGIAdapter1 **ppAdapter);
 
 // String table, used to unique strings.
 class string_table {


### PR DESCRIPTION
- move `GetHardwareAdapter` and `UseHardwareDevice` helper functions into `st` namespace to avoid linking conflicts
- do not define wave matrix data types if using newer `d3d12.h` that already has them
- Use `#include "d3dx12.h"` without subdirs to enable swapping of this header for a newer version in build settings