### PR TITLE
Remove InsertAddrSpaceCastIfRequired which is redundant

### DIFF
--- a/lib/HLSL/HLLowerUDT.cpp
+++ b/lib/HLSL/HLLowerUDT.cpp
@@ -285,11 +285,11 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
         // Replace bitcast argument with new value
         use.set(NewV);
       }
-
     } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(user)) {
       // Constant AddrSpaceCast, or BitCast
       if (CE->getOpcode() == Instruction::AddrSpaceCast) {
-        DXASSERT(CE->getType()->getPointerAddressSpace() != NewAddrSpace &&
+        DXASSERT(
+            CE->getType()->getPointerAddressSpace() != NewAddrSpace &&
                 OriginalAddrSpace == NewAddrSpace,
             "When replace Constant, V and NewV must have same address space");
         Constant *NewAC = ConstantExpr::getAddrSpaceCast(

--- a/lib/HLSL/HLLowerUDT.cpp
+++ b/lib/HLSL/HLLowerUDT.cpp
@@ -178,26 +178,6 @@ hlsl::TranslateInitForLoweredUDT(Constant *Init, Type *NewTy,
   return Init;
 }
 
-static Constant *InsertAddrSpaceCastIfRequired(Constant *C,
-                                               unsigned AddrSpace) {
-  Type *Ty = C->getType();
-  DXASSERT_NOMSG(Ty->isPointerTy());
-  if (AddrSpace != Ty->getPointerAddressSpace())
-    return ConstantExpr::getAddrSpaceCast(
-        C, PointerType::get(Ty->getPointerElementType(), AddrSpace));
-  return C;
-}
-
-static Value *InsertAddrSpaceCastIfRequired(IRBuilder<> &Builder, Value *V,
-                                            unsigned AddrSpace) {
-  Type *Ty = V->getType();
-  DXASSERT_NOMSG(Ty->isPointerTy());
-  if (AddrSpace != Ty->getPointerAddressSpace())
-    return Builder.CreateAddrSpaceCast(
-        V, PointerType::get(Ty->getPointerElementType(), AddrSpace));
-  return V;
-}
-
 void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
   Type *Ty = V->getType();
   Type *NewTy = NewV->getType();
@@ -214,6 +194,10 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
   DXASSERT_NOMSG(Ty->isPointerTy() && NewTy->isPointerTy());
   unsigned OriginalAddrSpace = Ty->getPointerAddressSpace();
   unsigned NewAddrSpace = NewTy->getPointerAddressSpace();
+  DXASSERT((OriginalAddrSpace == NewAddrSpace) ||
+               NewAddrSpace == DXIL::kNodeRecordAddrSpace,
+           "Only DXIL::kNodeRecordAddrSpace are allowed when address space "
+           "mismatch");
   Ty = Ty->getPointerElementType();
   NewTy = NewTy->getPointerElementType();
 
@@ -285,11 +269,10 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
     } else if (AddrSpaceCastInst *AC = dyn_cast<AddrSpaceCastInst>(user)) {
       // Address space cast
       IRBuilder<> Builder(AC);
-      ReplaceUsesForLoweredUDT(
-          user, InsertAddrSpaceCastIfRequired(
-                    Builder, NewV, AC->getType()->getPointerAddressSpace()));
+      Value *NewAC = Builder.CreateAddrSpaceCast(
+          NewV, PointerType::get(Ty, AC->getType()->getPointerAddressSpace()));
+      ReplaceUsesForLoweredUDT(user, NewAC);
       AC->eraseFromParent();
-
     } else if (BitCastInst *BC = dyn_cast<BitCastInst>(user)) {
       IRBuilder<> Builder(BC);
       if (BC->getType()->getPointerElementType() == NewTy) {
@@ -306,10 +289,13 @@ void hlsl::ReplaceUsesForLoweredUDT(Value *V, Value *NewV) {
     } else if (ConstantExpr *CE = dyn_cast<ConstantExpr>(user)) {
       // Constant AddrSpaceCast, or BitCast
       if (CE->getOpcode() == Instruction::AddrSpaceCast) {
-        ReplaceUsesForLoweredUDT(
-            user,
-            InsertAddrSpaceCastIfRequired(
-                cast<Constant>(NewV), CE->getType()->getPointerAddressSpace()));
+        DXASSERT(CE->getType()->getPointerAddressSpace() != NewAddrSpace &&
+                OriginalAddrSpace == NewAddrSpace,
+            "When replace Constant, V and NewV must have same address space");
+        Constant *NewAC = ConstantExpr::getAddrSpaceCast(
+            cast<Constant>(NewV),
+            PointerType::get(Ty, CE->getType()->getPointerAddressSpace()));
+        ReplaceUsesForLoweredUDT(user, NewAC);
       } else if (CE->getOpcode() == Instruction::BitCast) {
         if (CE->getType()->getPointerElementType() == NewTy) {
           // if alreday bitcast to new type, just replace the bitcast

--- a/tools/clang/test/CodeGenDXIL/hlsl/types/modifiers/groupshared/addrspacecast.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/types/modifiers/groupshared/addrspacecast.hlsl
@@ -1,0 +1,40 @@
+// RUN: %dxc  -T as_6_5 %s | FileCheck %s
+// RUN: %dxc  -T as_6_5 %s -fcgl | FileCheck %s --check-prefix=CAST
+
+// Make sure we pass groupshared mesh payload directly
+// in to DispatchMesh, with no alloca involved.
+
+// CHECK: define void @main
+// CHECK-NOT: alloca
+// CHECK-NOT: addrspacecast
+// CHECK-NOT: bitcast
+// CHECK: call void @dx.op.dispatchMesh.struct.MeshPayload{{[^ ]*}}(i32 173, i32 1, i32 1, i32 1, %struct.MeshPayload{{[^ ]*}} addrspace(3)*
+// CHECK-NOT: addrspacecast
+// CHECK: ret void
+
+// Make sure addrspacecast is generated.
+// CAST: @[[GS:.+]] = external addrspace(3) global %struct.GSStruct
+// CAST: define void @main
+// CAST: call void @"dx.hl.op..void (i32, i32, i32, i32, %struct.MeshPayload*)"(i32 12, i32 1, i32 1, i32 1, %struct.MeshPayload* addrspacecast (%struct.MeshPayload addrspace(3)* getelementptr inbounds (%struct.GSStruct, %struct.GSStruct addrspace(3)* @[[GS]], i32 0, i32 1) to %struct.MeshPayload*))
+
+
+struct MeshPayload
+{
+  uint4 data;
+};
+
+struct GSStruct
+{
+  uint i;
+  MeshPayload pld;
+};
+
+groupshared GSStruct gs;
+GSStruct cb_gs;
+
+[numthreads(4,1,1)]
+void main(uint gtid : SV_GroupIndex)
+{
+  gs = cb_gs;
+  DispatchMesh(1,1,1,gs.pld);
+}


### PR DESCRIPTION
For users of hlsl::ReplaceUsesForLoweredUDT, only EmitGetNodeRecordPtrAndUpdateUsers will has V and NewV with different address space. But there will be no addrspacecast for NodeRecordPtr from clangCodeGen, because NodeRecordPtr doesn't have address space before HLLowerOperation.

As a result, when hit addrspacecast in hlsl::ReplaceUsesForLoweredUDT, the address space of V and NewV should match. So InsertAddrSpaceCastIfRequired will always has AddrSpace != Ty->getPointerAddressSpace().

Removed InsertAddrSpaceCastIfRequired and add assert for address space mismatch.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/5695