### PR TITLE
allow [AllowSparseNodes] on non-array outputs

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15541,8 +15541,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
       // If node output is not an array, diagnose array only attributes
       if (((uint32_t)GetNodeIOType(ParamTy) &
            (uint32_t)DXIL::NodeIOFlags::NodeArray) == 0) {
-        Attr *ArrayAttrs[] = {AllowSparseNodesAttr, NodeArraySizeAttr,
-                              UnboundedSparseNodesAttr};
+        Attr *ArrayAttrs[] = {NodeArraySizeAttr, UnboundedSparseNodesAttr};
         for (auto *A : ArrayAttrs) {
           if (A) {
             S.Diags.Report(A->getLocation(),

--- a/tools/clang/test/HLSL/workgraph/attribute_diags.hlsl
+++ b/tools/clang/test/HLSL/workgraph/attribute_diags.hlsl
@@ -171,7 +171,7 @@ void node21(
 [NumThreads(32, 1, 1)]
 void node22(
   [NodeArraySize(15)]         // expected-error {{attribute 'NodeArraySize' may only be used with node output arrays (NodeOutputArray or EmptyNodeOutputArray)}}
-  [AllowSparseNodes]          // expected-error {{attribute 'allowsparsenodes' may only be used with node output arrays (NodeOutputArray or EmptyNodeOutputArray)}}
+  [AllowSparseNodes]
   NodeOutput<SharedRecord> foo)
 { }
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/sparsenodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/sparsenodes.hlsl
@@ -19,6 +19,11 @@
 // AST-NEXT: HLSLMaxRecordsAttr {{.*}} 37
 // AST-NEXT: HLSLUnboundedSparseNodesAttr
 
+// AST: FunctionDecl {{.*}} node_1_2 'void (NodeOutput<RECORD1>)'
+// AST-NEXT: ParmVarDecl {{.*}} used Output_1_2 'NodeOutput<RECORD1>':'NodeOutput<RECORD1>'
+// AST-NEXT: HLSLMaxRecordsAttr {{.*}} 47
+// AST-NEXT: HLSLAllowSparseNodesAttr
+
 // AST: FunctionDecl {{.*}} node_2_0 'void (EmptyNodeOutputArray)'
 // AST-NEXT: ParmVarDecl {{.*}} used OutputArray_2_0 'EmptyNodeOutputArray'
 // AST-NEXT: HLSLMaxRecordsAttr {{.*}} 41
@@ -30,6 +35,11 @@
 // AST-NEXT: HLSLMaxRecordsAttr {{.*}} 43
 // AST-NEXT: HLSLUnboundedSparseNodesAttr
 
+// AST: FunctionDecl {{.*}} node_2_2 'void (EmptyNodeOutput)'
+// AST-NEXT: ParmVarDecl {{.*}} used Output_2_2 'EmptyNodeOutput'
+// AST-NEXT: HLSLMaxRecordsAttr {{.*}} 53
+// AST-NEXT: HLSLAllowSparseNodesAttr
+
 // ==== -fcgl Metadata Checks ====
 
 // Make sure AllowSparseNodes is true
@@ -37,8 +47,10 @@
 // Starting from !"OutputArray_*": OutputID.Name, OutputID.Index, MaxRecords, MaxRecordsSharedWith, OutputArraySize, AllowSparseNodes
 // HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_0, {{.*}} !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true}
 // HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_1, {{.*}} !"OutputArray_1_1", i32 0, i32 37, i32 -1, i32 -1, i1 true}
+// HLCHECK-DAG: = !{void (%"struct.NodeOutput<RECORD1>"*)* @node_1_2, {{.*}} !"Output_1_2", i32 0, i32 47, i32 -1, i32 0, i1 true}
 // HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_0, {{.*}} !"OutputArray_2_0", i32 0, i32 41, i32 -1, i32 131, i1 true}
 // HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_1, {{.*}} !"OutputArray_2_1", i32 0, i32 43, i32 -1, i32 -1, i1 true}
+// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutput*)* @node_2_2, {{.*}} !"Output_2_2", i32 0, i32 53, i32 -1, i32 0, i1 true}
 
 // ==== RDAT Checks ====
 
@@ -62,6 +74,14 @@
 // REFLECT-DAG: AttribKind: AllowSparseNodes
 // REFLECT-NEXT: AllowSparseNodes: 1
 
+// REFLECT-LABEL: UnmangledName: "node_1_2"
+// REFLECT: Outputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
+// REFLECT: IOFlagsAndKind: 6
+// REFLECT-DAG: AttribKind: MaxRecords
+// REFLECT-NEXT: MaxRecords: 47
+// REFLECT-DAG: AttribKind: AllowSparseNodes
+// REFLECT-NEXT: AllowSparseNodes: 1
+
 // REFLECT-LABEL: UnmangledName: "node_2_0"
 // REFLECT: Outputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // REFLECT: IOFlagsAndKind: 26
@@ -82,6 +102,14 @@
 // REFLECT-DAG: AttribKind: AllowSparseNodes
 // REFLECT-NEXT: AllowSparseNodes: 1
 
+// REFLECT-LABEL: UnmangledName: "node_2_2"
+// REFLECT: Outputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
+// REFLECT: IOFlagsAndKind: 10
+// REFLECT-DAG: AttribKind: MaxRecords
+// REFLECT-NEXT: MaxRecords: 53
+// REFLECT-DAG: AttribKind: AllowSparseNodes
+// REFLECT-NEXT: AllowSparseNodes: 1
+
 // ==== DXIL Metadata Checks ====
 
 // CHECK: = !{void ()* @node_1_0, !"node_1_0", null, null, ![[EntryAttrs_1_0:[0-9]+]]}
@@ -98,6 +126,13 @@
 // kDxilNodeMaxRecordsTag(3), 37, kDxilNodeOutputArraySizeTag(5), -1, kDxilNodeAllowSparseNodesTag(6), true,
 // CHECK: ![[NodeInput_1_1]] = !{i32 1, i32 22, {{.*}} i32 3, i32 37, i32 5, i32 -1, i32 6, i1 true,
 
+// CHECK: = !{void ()* @node_1_2, !"node_1_2", null, null, ![[EntryAttrs_1_2:[0-9]+]]}
+// CHECK: ![[EntryAttrs_1_2]] = !{i32 8, i32 15, {{.*}} i32 21, ![[NodeInputs_1_2:[0-9]+]],
+// CHECK: ![[NodeInputs_1_2]] = !{![[NodeInput_1_2:[0-9]+]]}
+// kDxilNodeIOFlagsTag(1), ReadWrite(4) | Output(2), ...
+// kDxilNodeMaxRecordsTag(3), 47, kDxilNodeAllowSparseNodesTag(6), true,
+// CHECK: ![[NodeInput_1_2]] = !{i32 1, i32 6, {{.*}} i32 3, i32 47,{{.*}} i32 6, i1 true,
+
 // CHECK: = !{void ()* @node_2_0, !"node_2_0", null, null, ![[EntryAttrs_2_0:[0-9]+]]}
 // CHECK: ![[EntryAttrs_2_0]] = !{i32 8, i32 15, {{.*}} i32 21, ![[NodeInputs_2_0:[0-9]+]],
 // CHECK: ![[NodeInputs_2_0]] = !{![[NodeInput_2_0:[0-9]+]]}
@@ -111,6 +146,13 @@
 // kDxilNodeIOFlagsTag(1), NodeArray(16) | EmptyRecord(8) | Output(2),
 // kDxilNodeMaxRecordsTag(3), 43, kDxilNodeOutputArraySizeTag(5), -1, kDxilNodeAllowSparseNodesTag(6), true,
 // CHECK: ![[NodeInput_2_1]] = !{i32 1, i32 26, i32 3, i32 43, i32 5, i32 -1, i32 6, i1 true,
+
+// CHECK: = !{void ()* @node_2_2, !"node_2_2", null, null, ![[EntryAttrs_2_2:[0-9]+]]}
+// CHECK: ![[EntryAttrs_2_2]] = !{i32 8, i32 15, {{.*}} i32 21, ![[NodeInputs_2_2:[0-9]+]],
+// CHECK: ![[NodeInputs_2_2]] = !{![[NodeInput_2_2:[0-9]+]]}
+// kDxilNodeIOFlagsTag(1), EmptyRecord(8) | Output(2),
+// kDxilNodeMaxRecordsTag(3), 53, kDxilNodeAllowSparseNodesTag(6), true,
+// CHECK: ![[NodeInput_2_2]] = !{i32 1, i32 10, i32 3, i32 53,{{.*}} i32 6, i1 true,
 
 
 struct RECORD1
@@ -145,6 +187,17 @@ void node_1_1(
 [NodeLaunch("broadcasting")]
 [NodeDispatchGrid(1, 1, 1)]
 [NumThreads(1, 1, 1)]
+void node_1_2(
+    [AllowSparseNodes] [MaxRecords(47)]
+    NodeOutput<RECORD1> Output_1_2) {
+  ThreadNodeOutputRecords<RECORD1> outRec = Output_1_2.GetThreadNodeOutputRecords(2);
+  outRec.OutputComplete();
+}
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1, 1, 1)]
 void node_2_0(
     [AllowSparseNodes] [NodeArraySize(131)] [MaxRecords(41)]
     EmptyNodeOutputArray OutputArray_2_0) {
@@ -159,4 +212,14 @@ void node_2_1(
     [UnboundedSparseNodes] [MaxRecords(43)]
     EmptyNodeOutputArray OutputArray_2_1) {
   OutputArray_2_1[1].GroupIncrementOutputCount(10);
+}
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1, 1, 1)]
+void node_2_2(
+    [AllowSparseNodes] [MaxRecords(53)]
+    EmptyNodeOutput Output_2_2) {
+  Output_2_2.GroupIncrementOutputCount(10);
 }


### PR DESCRIPTION
Recently added checks for legal attributes on node objects were incorrectly disallowing [AllowSparseNodes] on non-array outputs.

This change fixes this regression and updates the tests.

Fixes #5863