### PR TITLE
Remove implicit record to struct cast intrinsic

### DIFF
--- a/include/dxc/HlslIntrinsicOp.h
+++ b/include/dxc/HlslIntrinsicOp.h
@@ -33,7 +33,6 @@ enum class IntrinsicOp {
   IOP_GroupMemoryBarrierWithGroupSync,
   IOP_HitKind,
   IOP_IgnoreHit,
-  IOP_ImplicitRecordToStructCast,
   IOP_InstanceID,
   IOP_InstanceIndex,
   IOP_InterlockedAdd,

--- a/lib/HLSL/HLOperationLower.cpp
+++ b/lib/HLSL/HLOperationLower.cpp
@@ -6462,8 +6462,6 @@ IntrinsicLower gLowerTable[] = {
      DXIL::OpCode::HitKind},
     {IntrinsicOp::IOP_IgnoreHit, TranslateNoArgNoReturnPreserveOutput,
      DXIL::OpCode::IgnoreHit},
-    {IntrinsicOp::IOP_ImplicitRecordToStructCast, EmptyLower,
-     DXIL::OpCode::NumOpCodes},
     {IntrinsicOp::IOP_InstanceID, TrivialNoArgWithRetOperation,
      DXIL::OpCode::InstanceID},
     {IntrinsicOp::IOP_InstanceIndex, TrivialNoArgWithRetOperation,

--- a/utils/hct/gen_intrin_main.txt
+++ b/utils/hct/gen_intrin_main.txt
@@ -380,7 +380,6 @@ void [[]] Barrier(in NodeRecordOrUAV o, in uint SemanticFlags);
 
 uint [[]] GetRemainingRecursionLevels();
 
-$match<0,-2> void [[hidden]] ImplicitRecordToStructCast(in AnyNodeOutputRecord output);
 $match<0,-2> void [[hidden]] ExtractRecordStructFromArray(in AnyNodeOutputRecord output);
 
 } namespace


### PR DESCRIPTION
The ImplicitRecordToStructCast intrinsic is left over dead code that should be removed. This PR removes the intrinsic from existence. Partially addresses https://github.com/microsoft/DirectXShaderCompiler/issues/5351