### PR TITLE
Add nullptr checks to handle undefined arrays

### DIFF
--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -80,7 +80,12 @@ void InitListHandler::flatten(const InitListExpr *expr) {
                    init->IgnoreParenNoopCasts(theEmitter.getASTContext()))) {
       flatten(subInitList);
     } else {
-      initializers.push_back(theEmitter.loadIfGLValue(init));
+      auto *initializer = theEmitter.loadIfGLValue(init);
+      if (!initializer) {
+        initializers.clear();
+        return;
+      }
+      initializers.push_back(initializer);
     }
   }
 }
@@ -252,6 +257,10 @@ InitListHandler::createInitForBuiltinType(QualType type,
   // Keep splitting structs or arrays
   while (tryToSplitStruct() || tryToSplitConstantArray())
     ;
+
+  if (initializers.empty()) {
+    return nullptr;
+  }
 
   auto init = initializers.back();
   initializers.pop_back();

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2688,7 +2688,7 @@ SpirvEmitter::doArraySubscriptExpr(const ArraySubscriptExpr *expr,
   SourceRange range =
       (rangeOverride != SourceRange()) ? rangeOverride : expr->getSourceRange();
 
-  if (indices.empty()) {
+  if (!info || indices.empty()) {
     return info;
   }
 

--- a/tools/clang/test/CodeGenSPIRV_Lit/undefined.static.template.member.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/undefined.static.template.member.hlsl
@@ -1,0 +1,21 @@
+// RUN: not %dxc -T ps_6_7 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
+
+template<uint32_t N, typename T=double>
+struct GaussLegendreValues 
+{
+    const static T wi[N];
+};
+
+static int test_value = 1567;
+
+float main() : SV_Target
+{
+    return float(GaussLegendreValues<2>::wi[test_value]);
+}
+
+// CHECK: :6:20: warning: variable 'GaussLegendreValues<2, double>::wi' has internal linkage but is not defined [-Wundefined-internal]
+// CHECK-NEXT: const static T wi[N];
+// CHECK: :13:42: note: used here
+// CHECK-NEXT: return float(GaussLegendreValues<2>::wi[test_value]);
+// CHECK: :6:20: fatal error: found unregistered decl
+// CHECK-NEXT: const static T wi[N];


### PR DESCRIPTION
When a variable declaration is not found, an error is emitted, and a null value returned. Not all function know what to do with that null value. I fix this by adding a few extra nullptr checks so that the compiler can unwind the stack and return gracefully.

Fixes [SPIR-V] `-Wundefined-internal` SIGSEGVs the compiler when `-spirv` output #5821
