### PR TITLE
Add _FORCE_EXPERIMENTAL_SHADERS define to ExecutionTests

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -1877,7 +1877,11 @@ public:
       return S_OK;
     }
 
+#ifdef _FORCE_EXPERIMENTAL_SHADERS
+    bool bExperimentalShaderModels = true;
+#else
     bool bExperimentalShaderModels = GetTestParamBool(L"ExperimentalShaders");
+#endif // _FORCE_EXPERIMENTAL_SHADERS
 
     HRESULT hr = S_FALSE;
     if (bExperimentalShaderModels) {


### PR DESCRIPTION
If `_FORCE_EXPERIMENTAL_SHADERS` is defined the execution tests will always turn on experimental mode, regardless of the `ExperimentalShaders` runtime TAEF parameter.