### PR TITLE
Fix module loading and validation issues

### DIFF
--- a/include/dxc/DXIL/DxilOperations.h
+++ b/include/dxc/DXIL/DxilOperations.h
@@ -41,8 +41,20 @@ public:
   OP() = delete;
   OP(llvm::LLVMContext &Ctx, llvm::Module *pModule);
 
-  void RefreshCache();
+  // InitWithMinPrecision sets the low-precision mode and calls
+  // FixOverloadNames() and RefreshCache() to set up caches for any existing
+  // DXIL operations and types used in the module.
+  void InitWithMinPrecision(bool bMinPrecision);
+
+  // FixOverloadNames fixes the names of DXIL operation overloads, particularly
+  // when they depend on user defined type names. User defined type names can be
+  // modified by name collisions from multiple modules being loaded into the
+  // same llvm context, such as during module linking.
   void FixOverloadNames();
+
+  // RefreshCache places DXIL types and operation overloads from the module into
+  // caches.
+  void RefreshCache();
 
   llvm::Function *GetOpFunc(OpCode OpCode, llvm::Type *pOverloadType);
   const llvm::SmallMapVector<llvm::Type *, llvm::Function *, 8> &
@@ -73,8 +85,6 @@ public:
 
   // To check if operation uses strict precision types
   bool UseMinPrecision();
-  // Set if operation uses strict precision types or not.
-  void SetMinPrecision(bool bMinPrecision);
 
   // Get the size of the type for a given layout
   uint64_t GetAllocSizeForType(llvm::Type *Ty);

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -123,7 +123,7 @@ void DxilModule::SetShaderModel(const ShaderModel *pSM, bool bUseMinPrecision) {
   m_pSM->GetDxilVersion(m_DxilMajor, m_DxilMinor);
   m_pMDHelper->SetShaderModel(m_pSM);
   m_bUseMinPrecision = bUseMinPrecision;
-  m_pOP->SetMinPrecision(m_bUseMinPrecision);
+  m_pOP->InitWithMinPrecision(m_bUseMinPrecision);
   m_pTypeSystem->SetMinPrecision(m_bUseMinPrecision);
 
   if (!m_pSM->IsLib()) {

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -2980,17 +2980,6 @@ OP::OP(LLVMContext &Ctx, Module *pModule)
                            Type::getInt16Ty(m_Ctx)}; // HiHi, HiLo, LoHi, LoLo
   m_pFourI16Type =
       GetOrCreateStructType(m_Ctx, FourI16Types, "dx.types.fouri16", pModule);
-
-  // When loading a module into an existing context where types are merged,
-  // type names may change.  When this happens, any intrinsics overloaded on
-  // UDT types will no longer have matching overload names.
-  // This causes RefreshCache() to assert.
-  // This fixes the function names to they match the expected types,
-  // preventing RefreshCache() from failing due to this issue.
-  FixOverloadNames();
-
-  // Try to find existing intrinsic function.
-  RefreshCache();
 }
 
 void OP::RefreshCache() {
@@ -3078,16 +3067,6 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   Type *obj = pOverloadType;
   Type *resProperty = GetResourcePropertiesType();
   Type *resBind = GetResourceBindingType();
-
-  std::string funcName;
-  ConstructOverloadName(pOverloadType, opCode, funcName);
-
-  // Try to find exist function with the same name in the module.
-  if (Function *existF = m_pModule->getFunction(funcName)) {
-    F = existF;
-    UpdateCache(opClass, pOverloadType, F);
-    return F;
-  }
 
 #define A(_x) ArgTypes.emplace_back(_x)
 #define RRT(_y) A(GetResRetType(_y))
@@ -4737,6 +4716,21 @@ Function *OP::GetOpFunc(OpCode opCode, Type *pOverloadType) {
   pFT = FunctionType::get(
       ArgTypes[0], ArrayRef<Type *>(&ArgTypes[1], ArgTypes.size() - 1), false);
 
+  std::string funcName;
+  ConstructOverloadName(pOverloadType, opCode, funcName);
+
+  // Try to find existing function with the same name in the module.
+  // This needs to happen after the switch statement that constructs arguments
+  // and return values to ensure that ResRetType is constructed in the
+  // RefreshCache case.
+  if (Function *existF = m_pModule->getFunction(funcName)) {
+    DXASSERT(existF->getFunctionType() == pFT,
+             "existing function must have the expected function type");
+    F = existF;
+    UpdateCache(opClass, pOverloadType, F);
+    return F;
+  }
+
   F = cast<Function>(m_pModule->getOrInsertFunction(funcName, pFT));
 
   UpdateCache(opClass, pOverloadType, F);
@@ -4810,7 +4804,25 @@ void OP::SetMinPrecision(bool bMinPrecision) {
             m_LowPrecisionMode == DXIL::LowPrecisionMode::Undefined),
            "LowPrecisionMode should only be set once.");
 
-  m_LowPrecisionMode = mode;
+  if (mode != m_LowPrecisionMode) {
+    m_LowPrecisionMode = mode;
+
+    // The following FixOverloadNames() and RefreshCache() calls interact with
+    // the type cache, which can only be correctly constructed once we know
+    // the min precision mode.  That's why they are called here, rather than
+    // in the constructor.
+
+    // When loading a module into an existing context where types are merged,
+    // type names may change.  When this happens, any intrinsics overloaded on
+    // UDT types will no longer have matching overload names.
+    // This causes RefreshCache() to assert.
+    // This fixes the function names to they match the expected types,
+    // preventing RefreshCache() from failing due to this issue.
+    FixOverloadNames();
+
+    // Try to find existing intrinsic function.
+    RefreshCache();
+  }
 }
 
 uint64_t OP::GetAllocSizeForType(llvm::Type *Ty) {
@@ -5067,6 +5079,8 @@ Type *OP::GetCBufferRetType(Type *pOverloadType) {
   unsigned TypeSlot = GetTypeSlot(pOverloadType);
 
   if (m_pCBufferRetType[TypeSlot] == nullptr) {
+    DXASSERT(m_LowPrecisionMode != DXIL::LowPrecisionMode::Undefined,
+             "m_LowPrecisionMode must be set before constructing type.");
     string TypeName("dx.types.CBufRet.");
     TypeName += GetOverloadTypeName(TypeSlot);
     Type *i64Ty = Type::getInt64Ty(pOverloadType->getContext());

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -4796,7 +4796,7 @@ bool OP::UseMinPrecision() {
   return m_LowPrecisionMode == DXIL::LowPrecisionMode::UseMinPrecision;
 }
 
-void OP::SetMinPrecision(bool bMinPrecision) {
+void OP::InitWithMinPrecision(bool bMinPrecision) {
   DXIL::LowPrecisionMode mode =
       bMinPrecision ? DXIL::LowPrecisionMode::UseMinPrecision
                     : DXIL::LowPrecisionMode::UseNativeLowPrecision;

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -512,7 +512,7 @@ void HLModule::LoadHLMetadata() {
           DxilMDHelper::ConstMDToUint32(options->getOperand(1)->getOperand(0)));
   }
 
-  m_pOP->SetMinPrecision(m_Options.bUseMinPrecision);
+  m_pOP->InitWithMinPrecision(m_Options.bUseMinPrecision);
 
   m_pMDHelper->LoadRootSignature(m_SerializedRootSignature);
 

--- a/lib/HLSL/HLModule.cpp
+++ b/lib/HLSL/HLModule.cpp
@@ -512,6 +512,8 @@ void HLModule::LoadHLMetadata() {
           DxilMDHelper::ConstMDToUint32(options->getOperand(1)->getOperand(0)));
   }
 
+  m_pOP->SetMinPrecision(m_Options.bUseMinPrecision);
+
   m_pMDHelper->LoadRootSignature(m_SerializedRootSignature);
 
   // Load Subobjects

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -401,7 +401,7 @@ CGMSHLSLRuntime::CGMSHLSLRuntime(CodeGenModule &CGM)
   opts.bFXCCompatMode = CGM.getLangOpts().EnableFXCCompatMode;
 
   m_pHLModule->SetHLOptions(opts);
-  m_pHLModule->GetOP()->SetMinPrecision(opts.bUseMinPrecision);
+  m_pHLModule->GetOP()->InitWithMinPrecision(opts.bUseMinPrecision);
   m_pHLModule->GetTypeSystem().SetMinPrecision(opts.bUseMinPrecision);
 
   m_pHLModule->SetAutoBindingSpace(CGM.getCodeGenOpts().HLSLDefaultSpace);

--- a/tools/clang/test/DXILValidation/val-dx-type-lowprec.ll
+++ b/tools/clang/test/DXILValidation/val-dx-type-lowprec.ll
@@ -1,6 +1,8 @@
 ; RUN: %dxv %s
 
-;
+; Regression test for validator, it should pass validation.
+; See val-dx-type-minprec.hlsl for explanation.
+
 ; Note: shader requires additional functionality:
 ;       Tiled resources
 ;       Use native low precision

--- a/tools/clang/test/DXILValidation/val-dx-type-lowprec.ll
+++ b/tools/clang/test/DXILValidation/val-dx-type-lowprec.ll
@@ -1,0 +1,145 @@
+; RUN: %dxv %s
+
+;
+; Note: shader requires additional functionality:
+;       Tiled resources
+;       Use native low precision
+;
+;
+; Input signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; no parameters
+;
+; Output signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; OUT                      0   x           0     NONE    fp16   x   
+;
+; shader hash: 59565e73b1c4f8f3c2db612c5f639ded
+;
+; Pipeline Runtime Information: 
+;
+; Vertex Shader
+; OutputPositionPresent=0
+;
+;
+; Output signature:
+;
+; Name                 Index             InterpMode DynIdx
+; -------------------- ----- ---------------------- ------
+; OUT                      0                 linear       
+;
+; Buffer Definitions:
+;
+; cbuffer $Globals
+; {
+;
+;   struct $Globals
+;   {
+;
+;       int16_t4 i1;                                  ; Offset:    0
+;       int16_t4 i2;                                  ; Offset:    8
+;   
+;   } $Globals;                                       ; Offset:    0 Size:    16
+;
+; }
+;
+; Resource bind info for SB
+; {
+;
+;   struct struct.MyStruct
+;   {
+;
+;       half f;                                       ; Offset:    0
+;   
+;   } $Element;                                       ; Offset:    0 Size:     2
+;
+; }
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+; $Globals                          cbuffer      NA          NA     CB0            cb0     1
+; SB                                texture  struct         r/o      T0             t0     1
+;
+;
+; ViewId state:
+;
+; Number of inputs: 0, outputs: 1
+; Outputs dependent on ViewId: {  }
+; Inputs contributing to computation of Outputs:
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.CBufRet.i16.8 = type { i16, i16, i16, i16, i16, i16, i16, i16 }
+%dx.types.ResRet.f16 = type { half, half, half, half, i32 }
+%"class.StructuredBuffer<MyStruct>" = type { %struct.MyStruct }
+%struct.MyStruct = type { half }
+%"$Globals" = type { <4 x i16>, <4 x i16> }
+
+; Function Attrs: nounwind readonly
+declare i1 @dx.op.checkAccessFullyMapped.i32(i32, i32) #1
+
+define void @main() {
+  %1 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+  %2 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 2, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+  %3 = call %dx.types.CBufRet.i16.8 @dx.op.cbufferLoadLegacy.i16(i32 59, %dx.types.Handle %2, i32 0)  ; CBufferLoadLegacy(handle,regIndex)
+  %4 = extractvalue %dx.types.CBufRet.i16.8 %3, 5
+  %5 = sext i16 %4 to i32
+  %6 = call %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32 139, %dx.types.Handle %1, i32 %5, i32 0, i8 1, i32 2)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+  %7 = extractvalue %dx.types.ResRet.f16 %6, 0
+  %8 = extractvalue %dx.types.ResRet.f16 %6, 4
+  %9 = call i1 @dx.op.checkAccessFullyMapped.i32(i32 71, i32 %8)  ; CheckAccessFullyMapped(status)
+  %10 = select i1 %9, half %7, half 0xHBC00
+  call void @dx.op.storeOutput.f16(i32 5, i32 0, i32 0, i8 0, half %10)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.storeOutput.f16(i32, i32, i32, i8, half) #0
+
+; Function Attrs: nounwind readonly
+declare %dx.types.ResRet.f16 @dx.op.rawBufferLoad.f16(i32, %dx.types.Handle, i32, i32, i8, i32) #1
+
+; Function Attrs: nounwind readonly
+declare %dx.types.CBufRet.i16.8 @dx.op.cbufferLoadLegacy.i16(i32, %dx.types.Handle, i32) #1
+
+; Function Attrs: nounwind readonly
+declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!2}
+!dx.shaderModel = !{!3}
+!dx.resources = !{!4}
+!dx.viewIdState = !{!10}
+!dx.entryPoints = !{!11}
+
+!0 = !{!"dxc(private) 1.7.0.4154 (dxil-op-cache-init, c8642b4f6-dirty)"}
+!1 = !{i32 1, i32 3}
+!2 = !{i32 1, i32 7}
+!3 = !{!"vs", i32 6, i32 3}
+!4 = !{!5, null, !8, null}
+!5 = !{!6}
+!6 = !{i32 0, %"class.StructuredBuffer<MyStruct>"* undef, !"", i32 0, i32 0, i32 1, i32 12, i32 0, !7}
+!7 = !{i32 1, i32 2}
+!8 = !{!9}
+!9 = !{i32 0, %"$Globals"* undef, !"", i32 0, i32 0, i32 1, i32 16, null}
+!10 = !{[2 x i32] [i32 0, i32 1]}
+!11 = !{void ()* @main, !"main", !12, !4, !17}
+!12 = !{null, !13, null}
+!13 = !{!14}
+!14 = !{i32 0, !"OUT", i8 8, i8 0, !15, i8 2, i32 1, i8 1, i32 0, i8 0, !16}
+!15 = !{i32 0}
+!16 = !{i32 3, i32 1}
+!17 = !{i32 0, i64 8392752}

--- a/tools/clang/test/DXILValidation/val-dx-type-minprec.hlsl
+++ b/tools/clang/test/DXILValidation/val-dx-type-minprec.hlsl
@@ -1,0 +1,60 @@
+// This is intended to be used to help generate validation tests to test fixes
+// for the way DxilOperations gets initialized on an existing llvm module.
+//
+// There are a couple interacting issues:
+// 1. When RefreshCache occurs, it doesn't fill in the m_pResRetType cache.
+//  - This is because in GetOpFunc, if it finds a function matching the
+//    expected name, it simply returns that, skipping function type
+//    construction.
+//  - This causes a validation error if CheckAccessFullyMapped is validated
+//    before a function that calls it.  This depends on the order of
+//    function declarations/definitions in the module.
+//  - The solution is to move the check after type construction, and verify
+//    that the function type matches expectations as well.
+// 2. When RefreshCache() and FixOverloadNames() was called from DxilOperations
+//    constructor, the m_LowPrecisionMode has not yet been set, leading to
+//    incorrect overload types when allowing function type construction to
+//    proceed in GetOpFunc before looking for a matching function by name.
+//  - This leads to an incorrect type for 16-bit CBufRet type being used.
+//  - The solution is to move RefreshCache() and FixOverloadNames() calls
+//    to after we actually know the m_LowPrecisionMode, so that the correct
+//    types may be constructed.
+//
+// So, this test will generate code that uses both CheckAccessFullyMapped and
+// use of min-precision types from a constant buffer, which will be translated
+// to native 16 bit types when -enable-16bit-types is specified.
+//  - The CheckAccessFullyMapped issue is tested by moving the declare of
+//    checkAccessFullyMapped to before the main function in the IR after
+//    compiling this HLSL.
+//  - The incorrect constant buffer type would lead to the wrong return type in
+//    the associated type slot for the intrinsic overload used.
+//  - Both of these issues would be caught by the validator.
+
+// Generated tests:
+//  val-dx-type-minprec.ll
+//  val-dx-type-lowprec.ll
+
+// Instructions for constructing .ll tests:
+// Compile these targets to generate tests:
+//  dxc val-dx-type-minprec.hlsl -T vs_6_3 -enable-16bit-types -Fc val-dx-type-lowprec.ll
+//  dxc val-dx-type-minprec.hlsl -T vs_6_3 -Fc val-dx-type-minprec.ll
+// Move checkAccessFullyMapped declaration before the main function.
+// Add run line with: `%dxv %s' to the top of the modified .ll output.
+
+struct MyStruct {
+  min16float f;
+};
+
+min16int4 i1;
+// Extra credit: using i2 on -enable-16bit-types will extractelement from
+// components above the number of components available in the min-precision
+// equivalent type.
+min16int4 i2;
+
+StructuredBuffer<MyStruct> SB;
+
+min16float main() : OUT {
+  uint status;
+  min16float result = SB.Load(i2.y, status).f;
+  return CheckAccessFullyMapped(status) ? result : -1.0;
+}

--- a/tools/clang/test/DXILValidation/val-dx-type-minprec.ll
+++ b/tools/clang/test/DXILValidation/val-dx-type-minprec.ll
@@ -1,5 +1,8 @@
 ; RUN: %dxv %s
 
+; Regression test for validator, it should pass validation.
+; See val-dx-type-minprec.hlsl for explanation.
+
 ;
 ; Note: shader requires additional functionality:
 ;       Minimum-precision data types

--- a/tools/clang/test/DXILValidation/val-dx-type-minprec.ll
+++ b/tools/clang/test/DXILValidation/val-dx-type-minprec.ll
@@ -1,0 +1,146 @@
+; RUN: %dxv %s
+
+;
+; Note: shader requires additional functionality:
+;       Minimum-precision data types
+;       Tiled resources
+;
+;
+; Input signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; no parameters
+;
+; Output signature:
+;
+; Name                 Index   Mask Register SysValue  Format   Used
+; -------------------- ----- ------ -------- -------- ------- ------
+; OUT                      0   x           0     NONE    fp16   x   
+;
+; shader hash: e44aa74e013b6a207d8d83df4e1743db
+;
+; Pipeline Runtime Information: 
+;
+; Vertex Shader
+; OutputPositionPresent=0
+;
+;
+; Output signature:
+;
+; Name                 Index             InterpMode DynIdx
+; -------------------- ----- ---------------------- ------
+; OUT                      0                 linear       
+;
+; Buffer Definitions:
+;
+; cbuffer $Globals
+; {
+;
+;   struct hostlayout.$Globals
+;   {
+;
+;       min16i4 i1;                                   ; Offset:    0
+;       min16i4 i2;                                   ; Offset:   16
+;   
+;   } $Globals;                                       ; Offset:    0 Size:    32
+;
+; }
+;
+; Resource bind info for SB
+; {
+;
+;   struct hostlayout.struct.MyStruct
+;   {
+;
+;       min16float f;                                 ; Offset:    0
+;   
+;   } $Element;                                       ; Offset:    0 Size:     4
+;
+; }
+;
+;
+; Resource Bindings:
+;
+; Name                                 Type  Format         Dim      ID      HLSL Bind  Count
+; ------------------------------ ---------- ------- ----------- ------- -------------- ------
+; $Globals                          cbuffer      NA          NA     CB0            cb0     1
+; SB                                texture  struct         r/o      T0             t0     1
+;
+;
+; ViewId state:
+;
+; Number of inputs: 0, outputs: 1
+; Outputs dependent on ViewId: {  }
+; Inputs contributing to computation of Outputs:
+;
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.CBufRet.i16 = type { i16, i16, i16, i16 }
+%dx.types.ResRet.f32 = type { float, float, float, float, i32 }
+%"hostlayout.class.StructuredBuffer<MyStruct>" = type { %hostlayout.struct.MyStruct }
+%hostlayout.struct.MyStruct = type { float }
+%"hostlayout.$Globals" = type { <4 x i32>, <4 x i32> }
+
+; Function Attrs: nounwind readonly
+declare i1 @dx.op.checkAccessFullyMapped.i32(i32, i32) #1
+
+define void @main() {
+  %1 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 0, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+  %2 = call %dx.types.Handle @dx.op.createHandle(i32 57, i8 2, i32 0, i32 0, i1 false)  ; CreateHandle(resourceClass,rangeId,index,nonUniformIndex)
+  %3 = call %dx.types.CBufRet.i16 @dx.op.cbufferLoadLegacy.i16(i32 59, %dx.types.Handle %2, i32 1)  ; CBufferLoadLegacy(handle,regIndex)
+  %4 = extractvalue %dx.types.CBufRet.i16 %3, 1
+  %5 = sext i16 %4 to i32
+  %6 = call %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32 139, %dx.types.Handle %1, i32 %5, i32 0, i8 1, i32 4)  ; RawBufferLoad(srv,index,elementOffset,mask,alignment)
+  %7 = extractvalue %dx.types.ResRet.f32 %6, 0
+  %8 = fptrunc float %7 to half
+  %9 = extractvalue %dx.types.ResRet.f32 %6, 4
+  %10 = call i1 @dx.op.checkAccessFullyMapped.i32(i32 71, i32 %9)  ; CheckAccessFullyMapped(status)
+  %11 = select i1 %10, half %8, half 0xHBC00
+  call void @dx.op.storeOutput.f16(i32 5, i32 0, i32 0, i8 0, half %11)  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.storeOutput.f16(i32, i32, i32, i8, half) #0
+
+; Function Attrs: nounwind readonly
+declare %dx.types.CBufRet.i16 @dx.op.cbufferLoadLegacy.i16(i32, %dx.types.Handle, i32) #1
+
+; Function Attrs: nounwind readonly
+declare %dx.types.ResRet.f32 @dx.op.rawBufferLoad.f32(i32, %dx.types.Handle, i32, i32, i8, i32) #1
+
+; Function Attrs: nounwind readonly
+declare %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readonly }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!2}
+!dx.shaderModel = !{!3}
+!dx.resources = !{!4}
+!dx.viewIdState = !{!10}
+!dx.entryPoints = !{!11}
+
+!0 = !{!"dxc(private) 1.7.0.4154 (dxil-op-cache-init, c8642b4f6-dirty)"}
+!1 = !{i32 1, i32 3}
+!2 = !{i32 1, i32 7}
+!3 = !{!"vs", i32 6, i32 3}
+!4 = !{!5, null, !8, null}
+!5 = !{!6}
+!6 = !{i32 0, %"hostlayout.class.StructuredBuffer<MyStruct>"* undef, !"", i32 0, i32 0, i32 1, i32 12, i32 0, !7}
+!7 = !{i32 1, i32 4}
+!8 = !{!9}
+!9 = !{i32 0, %"hostlayout.$Globals"* undef, !"", i32 0, i32 0, i32 1, i32 32, null}
+!10 = !{[2 x i32] [i32 0, i32 1]}
+!11 = !{void ()* @main, !"main", !12, !4, !17}
+!12 = !{null, !13, null}
+!13 = !{!14}
+!14 = !{i32 0, !"OUT", i8 8, i8 0, !15, i8 2, i32 1, i8 1, i32 0, i8 0, !16}
+!15 = !{i32 0}
+!16 = !{i32 3, i32 1}
+!17 = !{i32 0, i64 4144}


### PR DESCRIPTION
Fix module loading and validation issues

There are a couple interacting issues:
1. When RefreshCache occurs, it doesn't fill in the m_pResRetType cache.
  - This is because in GetOpFunc, if it finds a function matching the
    expected name, it simply returns that, skipping function type
    construction.
  - This causes a validation error if CheckAccessFullyMapped is validated
    before a function that calls it.  This depends on the order of
    function declarations/definitions in the module.
  - The solution is to move the check after type construction, and verify
    that the function type matches expectations as well.
2. When RefreshCache() and FixOverloadNames() was called from DxilOperations
    constructor, the m_LowPrecisionMode has not yet been set, leading to
    incorrect overload types when allowing function type construction to
    proceed in GetOpFunc before looking for a matching function by name.
  - This leads to an incorrect type for 16-bit CBufRet type being used.
  - The solution is to move RefreshCache() and FixOverloadNames() calls
    to after we actually know the m_LowPrecisionMode, so that the correct
    types may be constructed.

Rename hlsl::OP::SetMinPrecision to InitWithMinPrecision to make clear what's being done.
Added validation tests to verify the fixes.
Fixed validation test that produced invalid DXIL op function signature.
Fix HLModule not setting min-precision mode when loading from metadata.

Fixes #5879 