### PR TITLE
Make hctbuild cmake gen consistent with asserts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 cmake_minimum_required(VERSION 3.17.2) # HLSL Change - Require CMake 3.17.2.
 
+message(CMAKE_BUILD_TYPE0!!!!!="${CMAKE_BUILD_TYPE}")
+message(CMAKE_CONFIGURATION_TYPES!!!!!="${CMAKE_CONFIGURATION_TYPES}")
+message(CMAKE_CXX_FLAGS_RELEASE!!!!!="${CMAKE_CXX_FLAGS_RELEASE}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -8,10 +11,12 @@ if (NOT "${DXC_CMAKE_BEGINS_INCLUDE}" STREQUAL "")
   include(${DXC_CMAKE_BEGINS_INCLUDE})
 endif()
 
+
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "No build type selected, default to Debug")
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
+message(CMAKE_BUILD_TYPE1!!!!!="${CMAKE_BUILD_TYPE}")
 
 if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW) # automatic when 2.8.12 is required
@@ -315,11 +320,15 @@ option(LLVM_ENABLE_LIBCXXABI "Use libc++abi when using libc++." OFF)
 option(LLVM_ENABLE_PEDANTIC "Compile with pedantic enabled." ON)
 option(LLVM_ENABLE_WERROR "Fail and stop if a warning is triggered." OFF)
 
+message(uppercase_CMAKE_BUILD_TYPE!!!!!="${CMAKE_BUILD_TYPE}")
 if( NOT uppercase_CMAKE_BUILD_TYPE STREQUAL "DEBUG" )
+  message(assertions OFF)
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" OFF)
 else()
+  message(assertions ON)
   option(LLVM_ENABLE_ASSERTIONS "Enable assertions" ON)
 endif()
+message(LLVM_ENABLE_ASSERTIONS!!!!!="${LLVM_ENABLE_ASSERTIONS}")
 
 set(LLVM_ABI_BREAKING_CHECKS "WITH_ASSERTS" CACHE STRING
   "Enable abi-breaking checks.  Can be WITH_ASSERTS, FORCE_ON or FORCE_OFF.")

--- a/cmake/modules/HandleLLVMOptions.cmake
+++ b/cmake/modules/HandleLLVMOptions.cmake
@@ -56,6 +56,7 @@ int main() { return (float)x; }"
 endif()
 
 if( LLVM_ENABLE_ASSERTIONS )
+  message(how did I get here?)
   # MSVC doesn't like _DEBUG on release builds. See PR 4379.
   # HLSL Note: the above comment referrs to llvm.org problem, not pull request: 
   #            https://bugs.llvm.org/show_bug.cgi?id=4379

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -465,10 +465,8 @@ if "%DO_SETUP%"=="1" (
     echo Running "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% > %3\cmake-log.txt
     "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   ) else (
-    rem -DCMAKE_BUILD_TYPE:STRING=%1 is not necessary for multi-config generators like VS
-    rem but need CMAKE_BUILD_TYPE to generate lit cfg.
     echo Running "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1  %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% > %3\cmake-log.txt
-    "%CMAKE_PATH%" %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
+    "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   )
   if %SHOW_CMAKE_LOG%==1 (
     echo ------- Start of %3\cmake-log.txt -------

--- a/utils/hct/hctbuild.cmd
+++ b/utils/hct/hctbuild.cmd
@@ -465,8 +465,10 @@ if "%DO_SETUP%"=="1" (
     echo Running "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% > %3\cmake-log.txt
     "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   ) else (
+    rem BUILD_TYPE is mostly ignored in this path as VS generates multiple targets
+    rem it is still needed to satisfy cmake file expectations
     echo Running "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1  %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% > %3\cmake-log.txt
-    "%CMAKE_PATH%" -DCMAKE_BUILD_TYPE:STRING=%1 %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
+    "%CMAKE_PATH%" %CMAKE_OPTS% -G %4 %5 %HLSL_SRC_DIR% >> %3\cmake-log.txt 2>&1
   )
   if %SHOW_CMAKE_LOG%==1 (
     echo ------- Start of %3\cmake-log.txt -------


### PR DESCRIPTION
A slightly complex series of events causes invocations of hctbuild after the first to enable asserts in release builds. This sets the build type even when it isn't needed to avoid it.

Because the build type was not being set when generating for visual studio in hctbuild, when generating the cmake files using CMakeLists, it would produce an alarming message saying it was defaulting to debug, but, in fact, since it didn't care for the purposes of sln file generation, that wasn't actually a problem, just confusing. It did set a variable to enable asserts, but didn't do this for release variant builds

The real problem occurs if hctbuild is invoked again, at that point, instead of defaulting to Debug, it leaves the build type empty because of another variable set in the cache.

Additionally, since the first invocation enabled asserts, that also comes from the cache and so code that strips NDEBUG from all build variants is invoked because the build type is, in fact, not debug, it's an empty string.