### PR TITLE
[Option] add verify_ignore_unexpected_EQ for verifier test

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -54,6 +54,24 @@ enum HlslFlags {
   RewriteOption = (1 << 17),
 };
 
+/// \brief A bitmask representing the diagnostic levels used by
+/// VerifyDiagnosticConsumer.
+enum class DiagnosticLevelMask : unsigned {
+  None = 0,
+  Note = 1 << 0,
+  Remark = 1 << 1,
+  Warning = 1 << 2,
+  Error = 1 << 3,
+  All = Note | Remark | Warning | Error
+};
+
+inline DiagnosticLevelMask operator|(DiagnosticLevelMask LHS,
+                                     DiagnosticLevelMask RHS) {
+  using UT = std::underlying_type_t<DiagnosticLevelMask>;
+  return static_cast<DiagnosticLevelMask>(static_cast<UT>(LHS) |
+                                          static_cast<UT>(RHS));
+}
+
 enum ID {
   OPT_INVALID = 0, // This is not an option ID.
 #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
@@ -226,6 +244,8 @@ public:
   bool TimeReport = false;              // OPT_ftime_report
   std::string TimeTrace = "";           // OPT_ftime_trace[EQ]
   bool VerifyDiagnostics = false;       // OPT_verify
+  DiagnosticLevelMask DiagMask =
+      DiagnosticLevelMask::None; // OPT_verify_ignore_unexpected_EQ
 
   // Optimization pass enables, disables and selects
   OptimizationToggles

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -187,9 +187,12 @@ def ftime_trace_EQ : Joined<["-"], "ftime-trace=">,
   Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Print hierchial time tracing to file">;
 
-def verify : Joined<["-"], "verify">,
+def verify : Flag<["-"], "verify">,
   Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Verify diagnostic output using comment directives">;
+def verify_ignore_unexpected_EQ : CommaJoined<["-"], "verify-ignore-unexpected=">,
+  Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Ignore unexpected diagnostic messages">;
 
 /*
 def fno_caret_diagnostics : Flag<["-"], "fno-caret-diagnostics">, Group<hlslcomp_Group>,

--- a/tools/clang/test/SemaHLSL/array-index-out-of-bounds-HV-2016.hlsl
+++ b/tools/clang/test/SemaHLSL/array-index-out-of-bounds-HV-2016.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -HV 2016 -verify -verify-ignore-unexpected=note %s
+// RUN: %dxc -Tlib_6_3 -Wno-unused-value -HV 2016 -verify -verify-ignore-unexpected=note %s
 
 void dead()
 {

--- a/tools/clang/test/SemaHLSL/array-index-out-of-bounds.hlsl
+++ b/tools/clang/test/SemaHLSL/array-index-out-of-bounds.hlsl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -Wno-unused-value -fsyntax-only -ffreestanding -verify -verify-ignore-unexpected=note %s
+// RUN: %dxc -Tlib_6_3 -Wno-unused-value -verify -verify-ignore-unexpected=note %s
 
 void main()
 {

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1337,9 +1337,18 @@ public:
     // Make sure clang::DiagnosticLevelMask and
     // hlsl::options::DiagnosticLevelMask match.
     static_assert(
-        std::is_same_v<
-            std::underlying_type_t<clang::DiagnosticLevelMask>,
-            std::underlying_type_t<hlsl::options::DiagnosticLevelMask>>,
+        static_cast<int>(clang::DiagnosticLevelMask::None) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::None) &&
+            static_cast<int>(clang::DiagnosticLevelMask::Note) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::Note) &&
+            static_cast<int>(clang::DiagnosticLevelMask::Remark) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::Remark) &&
+            static_cast<int>(clang::DiagnosticLevelMask::Warning) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::Warning) &&
+            static_cast<int>(clang::DiagnosticLevelMask::Error) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::Error) &&
+            static_cast<int>(clang::DiagnosticLevelMask::All) ==
+                static_cast<int>(hlsl::options::DiagnosticLevelMask::All),
         "clang::DiagnosticLevelMask and DiagnosticLevelMask do not match");
     compiler.getDiagnosticOpts().setVerifyIgnoreUnexpected(
         static_cast<clang::DiagnosticLevelMask>(Opts.DiagMask));

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1334,6 +1334,13 @@ public:
     compiler.getDiagnosticOpts().ShowOptionNames = Opts.ShowOptionNames ? 1 : 0;
     compiler.getDiagnosticOpts().Warnings = std::move(Opts.Warnings);
     compiler.getDiagnosticOpts().VerifyDiagnostics = Opts.VerifyDiagnostics;
+    // Make sure clang::DiagnosticLevelMask and
+    // hlsl::options::DiagnosticLevelMask match.
+    static_assert(
+        std::is_same_v<
+            std::underlying_type_t<clang::DiagnosticLevelMask>,
+            std::underlying_type_t<hlsl::options::DiagnosticLevelMask>>,
+        "clang::DiagnosticLevelMask and DiagnosticLevelMask do not match");
     compiler.getDiagnosticOpts().setVerifyIgnoreUnexpected(
         static_cast<clang::DiagnosticLevelMask>(Opts.DiagMask));
     compiler.createDiagnostics(diagPrinter, false);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1334,6 +1334,8 @@ public:
     compiler.getDiagnosticOpts().ShowOptionNames = Opts.ShowOptionNames ? 1 : 0;
     compiler.getDiagnosticOpts().Warnings = std::move(Opts.Warnings);
     compiler.getDiagnosticOpts().VerifyDiagnostics = Opts.VerifyDiagnostics;
+    compiler.getDiagnosticOpts().setVerifyIgnoreUnexpected(
+        static_cast<clang::DiagnosticLevelMask>(Opts.DiagMask));
     compiler.createDiagnostics(diagPrinter, false);
     // don't output warning to stderr/file if "/no-warnings" is present.
     compiler.getDiagnostics().setIgnoreAllWarnings(!Opts.OutputWarnings);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -461,6 +461,23 @@ static HRESULT ErrorWithString(const std::string &error, REFIID riid,
   return S_OK;
 }
 
+// Make sure clang::DiagnosticLevelMask and
+// hlsl::options::DiagnosticLevelMask match.
+static_assert(
+    static_cast<int>(clang::DiagnosticLevelMask::None) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::None) &&
+        static_cast<int>(clang::DiagnosticLevelMask::Note) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::Note) &&
+        static_cast<int>(clang::DiagnosticLevelMask::Remark) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::Remark) &&
+        static_cast<int>(clang::DiagnosticLevelMask::Warning) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::Warning) &&
+        static_cast<int>(clang::DiagnosticLevelMask::Error) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::Error) &&
+        static_cast<int>(clang::DiagnosticLevelMask::All) ==
+            static_cast<int>(hlsl::options::DiagnosticLevelMask::All),
+    "clang::DiagnosticLevelMask and DiagnosticLevelMask do not match");
+
 class DxcCompiler : public IDxcCompiler3,
                     public IDxcLangExtensions3,
                     public IDxcContainerEvent,
@@ -1334,22 +1351,6 @@ public:
     compiler.getDiagnosticOpts().ShowOptionNames = Opts.ShowOptionNames ? 1 : 0;
     compiler.getDiagnosticOpts().Warnings = std::move(Opts.Warnings);
     compiler.getDiagnosticOpts().VerifyDiagnostics = Opts.VerifyDiagnostics;
-    // Make sure clang::DiagnosticLevelMask and
-    // hlsl::options::DiagnosticLevelMask match.
-    static_assert(
-        static_cast<int>(clang::DiagnosticLevelMask::None) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::None) &&
-            static_cast<int>(clang::DiagnosticLevelMask::Note) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::Note) &&
-            static_cast<int>(clang::DiagnosticLevelMask::Remark) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::Remark) &&
-            static_cast<int>(clang::DiagnosticLevelMask::Warning) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::Warning) &&
-            static_cast<int>(clang::DiagnosticLevelMask::Error) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::Error) &&
-            static_cast<int>(clang::DiagnosticLevelMask::All) ==
-                static_cast<int>(hlsl::options::DiagnosticLevelMask::All),
-        "clang::DiagnosticLevelMask and DiagnosticLevelMask do not match");
     compiler.getDiagnosticOpts().setVerifyIgnoreUnexpected(
         static_cast<clang::DiagnosticLevelMask>(Opts.DiagMask));
     compiler.createDiagnostics(diagPrinter, false);

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -186,11 +186,6 @@ public:
   }
 };
 
-TEST_F(VerifierTest, RunArrayIndexOutOfBounds) {
-  CheckVerifiesHLSL(L"array-index-out-of-bounds.hlsl");
-  CheckVerifiesHLSL(L"array-index-out-of-bounds-HV-2016.hlsl");
-}
-
 TEST_F(VerifierTest, RunArrayLength) {
   CheckVerifiesHLSL(L"array-length.hlsl");
 }

--- a/tools/clang/unittests/HLSL/VerifierTest.cpp
+++ b/tools/clang/unittests/HLSL/VerifierTest.cpp
@@ -33,7 +33,6 @@ public:
   TEST_METHOD_PROPERTY(L"Priority", L"0")
   END_TEST_CLASS()
 
-  TEST_METHOD(RunArrayIndexOutOfBounds)
   TEST_METHOD(RunArrayLength)
   TEST_METHOD(RunAtomicFloatErrors)
   TEST_METHOD(RunAttributes)


### PR DESCRIPTION
Add support -verify-ignore-unexpected= to DxcOpts.
DiagnosticLevelMask is copied to HLSLOptions.h to avoid use clang header in DxcOption.

Also change -verify to Flag to allow adding options after it.

This is for https://github.com/microsoft/DirectXShaderCompiler/issues/5870