### PR TITLE
Enable `.ll` test suffix for LLVM tests

### DIFF
--- a/test/Analysis/lit.local.cfg
+++ b/test/Analysis/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # Failing Tests (26):
 #     LLVM :: Analysis/BasicAA/2008-04-15-Byval.ll

--- a/test/Assembler/lit.local.cfg
+++ b/test/Assembler/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # Failing Tests (5):
 #     LLVM :: Assembler/2007-09-29-GC.ll

--- a/test/CodeGen/lit.local.cfg
+++ b/test/CodeGen/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/Feature/lit.local.cfg
+++ b/test/Feature/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # Failing Tests (6):
 #     LLVM :: Feature/intrinsic-noduplicate.ll

--- a/test/Instrumentation/lit.local.cfg
+++ b/test/Instrumentation/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # Failing Tests (86):
 #     LLVM :: Instrumentation/AddressSanitizer/adaptive_global_redzones.ll

--- a/test/Linker/lit.local.cfg
+++ b/test/Linker/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # Failing Tests (8):
 #     LLVM :: Linker/pr21374.ll

--- a/test/SymbolRewriter/lit.local.cfg
+++ b/test/SymbolRewriter/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/Transforms/lit.local.cfg
+++ b/test/Transforms/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 
 # If these are enabled, a duplicate test was created here which can be deleted:
 #   tools/clang/test/HLSLFileCheck/passes/llvm/globalopt/alias-used.ll

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -42,7 +42,7 @@ config.test_format = lit.formats.ShTest(execute_external)
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.
 # HLSL Change Start - use just a subset of LLVM tests
-config.suffixes = ['.txt', '.td', '.test']
+config.suffixes = ['.ll', '.txt', '.td', '.test']
 #config.suffixes = ['.ll', '.c', '.cxx', '.test', '.txt', '.s']
 # HLSL Change End - use just a subset of LLVM tests
 

--- a/test/tools/dsymutil/lit.local.cfg
+++ b/test/tools/dsymutil/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/llvm-cxxdump/lit.local.cfg
+++ b/test/tools/llvm-cxxdump/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/llvm-mc/lit.local.cfg
+++ b/test/tools/llvm-mc/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/llvm-objdump/lit.local.cfg
+++ b/test/tools/llvm-objdump/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/llvm-symbolizer/lit.local.cfg
+++ b/test/tools/llvm-symbolizer/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/llvm-symbolizer/pdb/lit.local.cfg
+++ b/test/tools/llvm-symbolizer/pdb/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/test/tools/lto/lit.local.cfg
+++ b/test/tools/lto/lit.local.cfg
@@ -1,3 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 if not 'ld64_plugin' in config.available_features:
    config.unsupported = True

--- a/tools/clang/test/CXX/lit.local.cfg
+++ b/tools/clang/test/CXX/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/CodeCompletion/lit.local.cfg
+++ b/tools/clang/test/CodeCompletion/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/CodeGenCUDA/lit.local.cfg
+++ b/tools/clang/test/CodeGenCUDA/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Coverage/lit.local.cfg
+++ b/tools/clang/test/Coverage/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/CoverageMapping/lit.local.cfg
+++ b/tools/clang/test/CoverageMapping/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/FixIt/lit.local.cfg
+++ b/tools/clang/test/FixIt/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Format/lit.local.cfg
+++ b/tools/clang/test/Format/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Headers/lit.local.cfg
+++ b/tools/clang/test/Headers/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Integration/lit.local.cfg
+++ b/tools/clang/test/Integration/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Layout/lit.local.cfg
+++ b/tools/clang/test/Layout/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Lexer/lit.local.cfg
+++ b/tools/clang/test/Lexer/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Misc/lit.local.cfg
+++ b/tools/clang/test/Misc/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/PCH/lit.local.cfg
+++ b/tools/clang/test/PCH/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Parser/lit.local.cfg
+++ b/tools/clang/test/Parser/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Preprocessor/lit.local.cfg
+++ b/tools/clang/test/Preprocessor/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Profile/lit.local.cfg
+++ b/tools/clang/test/Profile/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Sema/lit.local.cfg
+++ b/tools/clang/test/Sema/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 config.substitutions = list(config.substitutions)
 config.substitutions.insert(0,
     (r'%clang\b',

--- a/tools/clang/test/SemaCUDA/lit.local.cfg
+++ b/tools/clang/test/SemaCUDA/lit.local.cfg
@@ -1,4 +1,4 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 config.substitutions = list(config.substitutions)
 config.substitutions.insert(0,
     (r'%clang\b',

--- a/tools/clang/test/SemaCXX/lit.local.cfg
+++ b/tools/clang/test/SemaCXX/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/SemaTemplate/lit.local.cfg
+++ b/tools/clang/test/SemaTemplate/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.

--- a/tools/clang/test/Tooling/lit.local.cfg
+++ b/tools/clang/test/Tooling/lit.local.cfg
@@ -1,3 +1,3 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.
 if config.root.clang_staticanalyzer == 0:
     config.unsupported = True

--- a/tools/clang/test/VFS/lit.local.cfg
+++ b/tools/clang/test/VFS/lit.local.cfg
@@ -1,1 +1,1 @@
-config.unsupported = True # HLSL Change - Disable lit suites.
+config.suffixes = [] # HLSL Change - Disable lit suites.


### PR DESCRIPTION
This enables `.ll` as a default test suffix in the LLVM tests. To preserve the low number of unsupported tests, this changes the way we disable tests from using config.unsupported to setting the suffixes to empty.