### PR TITLE
Make DxilSignatureElement::m_SemanticName canonical for system values

### DIFF
--- a/lib/DXIL/DxilSignatureElement.cpp
+++ b/lib/DXIL/DxilSignatureElement.cpp
@@ -51,6 +51,9 @@ void DxilSignatureElement::Initialize(llvm::StringRef Name,
     m_SemanticStartIndex = IndexVector[0];
   // Find semantic in the table.
   m_pSemantic = Semantic::GetByName(m_SemanticName, m_sigPointKind);
+  // Replace semantic name with canonical name if it's a system value.
+  if (!m_pSemantic->IsInvalid() && !m_pSemantic->IsArbitrary())
+    m_SemanticName = m_pSemantic->GetName();
   SetCompType(ElementType);
   m_InterpMode = InterpMode;
   m_SemanticIndex = IndexVector;

--- a/tools/clang/unittests/HLSL/DxilModuleTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilModuleTest.cpp
@@ -612,7 +612,9 @@ TEST_F(DxilModuleTest, CanonicalSystemValueSemantic) {
   // makes sure the string gets canonicalized when the signature elsement is
   // created.
 
-  std::unique_ptr<hlsl::DxilSignatureElement> newElt = std::make_unique<hlsl::DxilSignatureElement>(hlsl::DXIL::SigPointKind::VSOut);
+  std::unique_ptr<hlsl::DxilSignatureElement> newElt =
+      std::make_unique<hlsl::DxilSignatureElement>(
+          hlsl::DXIL::SigPointKind::VSOut);
   newElt->Initialize("sV_pOsItIoN", hlsl::CompType::getF32(),
                      hlsl::InterpolationMode(
                          hlsl::DXIL::InterpolationMode::LinearNoperspective),

--- a/tools/clang/unittests/HLSL/DxilModuleTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilModuleTest.cpp
@@ -71,6 +71,8 @@ public:
 
   TEST_METHOD(PayloadQualifier)
 
+  TEST_METHOD(CanonicalSystemValueSemantic)
+
   void VerifyValidatorVersionFails(LPCWSTR shaderModel,
                                    const std::vector<LPCWSTR> &arguments,
                                    const std::vector<LPCSTR> &expectedErrors);
@@ -598,4 +600,22 @@ TEST_F(DxilModuleTest, PayloadQualifier) {
                            DXIL::PayloadAccessShaderStage::Anyhit));
     }
   }
+}
+
+TEST_F(DxilModuleTest, CanonicalSystemValueSemantic) {
+  // Verify that the semantic name is canonicalized.
+
+  // This is difficult to do from a FileCheck test because system value
+  // semantics get canonicallized during the metadata emit.  However, having a
+  // non-canonical semantic name at earlier stages can lead to inconsistency
+  // between the strings used earlier and the final canonicalized version.  This
+  // makes sure the string gets canonicalized when the signature elsement is
+  // created.
+
+  std::unique_ptr<hlsl::DxilSignatureElement> newElt = std::make_unique<hlsl::DxilSignatureElement>(hlsl::DXIL::SigPointKind::VSOut);
+  newElt->Initialize("sV_pOsItIoN", hlsl::CompType::getF32(),
+                     hlsl::InterpolationMode(
+                         hlsl::DXIL::InterpolationMode::LinearNoperspective),
+                     1, 4, 0, 0, 0, {0});
+  VERIFY_ARE_EQUAL_STR("SV_Position", newElt->GetSemanticName().data());
 }


### PR DESCRIPTION
When DxilModule metadata is serialized, semantic strings for system values are canonicalized.  If these strings are used anywhere, this can lead to a difference in behavior between an original DxilModule that has not undergone serialization and one that has been deserialized.

This change canonicalizes the string as soon as a DxilSignatureElement is created, thereby removing the possibility of accidentally relying on the non-canonical string for a system value.