### PR TITLE
[CI] Remove redundant SPIRV tests run for Windows pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,10 +34,6 @@ stages:
         call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
         call utils\hct\hcttest.cmd -$(configuration) noexec
       displayName: 'DXIL Tests'
-    - script: |
-        call utils\hct\hctstart.cmd %HLSL_SRC_DIR% %HLSL_BLD_DIR%
-        call utils\hct\hcttest.cmd -$(configuration) spirv_only
-      displayName: 'SPIRV Tests'
 
   - job: Nix
     timeoutInMinutes: 90


### PR DESCRIPTION
hcttest noexec will execute clang tests.
Clang tests include both spirv lit tests and unit tests. So running hcttest spirv_only is redundant.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/5890