### PR TITLE
[SPIR-V] Correctly handle subscript overload in access chain

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -7987,6 +7987,12 @@ const Expr *SpirvEmitter::collectArrayStructIndices(
           indexing->getArg(0)->IgnoreParenNoopCasts(astContext);
 
       const auto thisBaseType = thisBase->getType();
+
+      // If the base type is user defined, return the call expr so that any
+      // user-defined overloads of operator[] are called.
+      if (hlsl::IsUserDefinedRecordType(thisBaseType))
+        return expr;
+
       const Expr *base = collectArrayStructIndices(
           thisBase, rawIndex, rawIndices, indices, isMSOutAttribute);
 

--- a/tools/clang/test/CodeGenSPIRV_Lit/operator.overloading.subscript.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/operator.overloading.subscript.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
+
+struct s
+{
+    float field;
+};
+
+struct subscriptable
+{
+    s operator[](const uint64_t index)
+    {
+        return s(123.0);
+    }
+};
+
+float4 main() : SV_TARGET
+{
+    subscriptable o;
+
+    float f;
+// CHECK: %param_var_index = OpVariable %_ptr_Function_ulong Function
+// CHECK: OpStore %param_var_index %ulong_123
+// CHECK: [[op_result:%[0-9]+]] = OpFunctionCall %s %subscriptable_operator_Subscript %o %param_var_index
+// CHECK: OpStore %temp_var_s [[op_result]]
+// CHECK: {{%[0-9]+}} = OpAccessChain %_ptr_Function_float %temp_var_s %int_0
+    f = o[123].field;
+    return f;
+}


### PR DESCRIPTION
In order to handle types such as `RWStructuredBuffer`, which has the method `operator[]()`, `operator[]` is treated as a special case by our access chain creation code - it's treated similarly to `ArraySubscriptExpr`. This has the unfortunate side effect that user-defined `operator[]` overloads are not called in all cases.

To fix this, this PR adds a check for whether a type is user-defined before handling `operator[]` in `collectArrayStructIndices`.

Part of the fix for #5638.