### PR TITLE
[Instcombine] Disable bswap match for DXIL

### DIFF
--- a/include/llvm/ADT/Triple.h
+++ b/include/llvm/ADT/Triple.h
@@ -508,6 +508,12 @@ public:
     return getVendor() == Triple::SCEI &&
            getOS() == Triple::PS4;
   }
+  
+  // HLSL Change Begin - Add DXIL Triple.
+  bool isDXIL() const {
+    return getArch() == Triple::dxil || getArch() == Triple::dxil64;
+  }
+  // HLSL Change End - Add DXIL Triple.
 
   /// @}
   /// @name Mutators

--- a/include/llvm/ADT/Triple.h
+++ b/include/llvm/ADT/Triple.h
@@ -508,7 +508,7 @@ public:
     return getVendor() == Triple::SCEI &&
            getOS() == Triple::PS4;
   }
-  
+
   // HLSL Change Begin - Add DXIL Triple.
   bool isDXIL() const {
     return getArch() == Triple::dxil || getArch() == Triple::dxil64;

--- a/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
+++ b/lib/Transforms/InstCombine/InstCombineAndOrXor.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "InstCombineInternal.h"
+#include "llvm/ADT/Triple.h" // HLSL Change
 #include "llvm/Analysis/InstructionSimplify.h"
 #include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/Intrinsics.h"
@@ -1634,6 +1635,11 @@ static bool CollectBSwapParts(Value *V, int OverallLeftShift, uint32_t ByteMask,
 /// MatchBSwap - Given an OR instruction, check to see if this is a bswap idiom.
 /// If so, insert the new bswap intrinsic and return it.
 Instruction *InstCombiner::MatchBSwap(BinaryOperator &I) {
+  // HLSL Change begin - Disable bswap matching for DXIL.
+  Triple T(I.getModule()->getTargetTriple());
+  if (T.isDXIL())
+    return nullptr;
+  // HLSL Change end - Disable bswap matching for DXIL.
   IntegerType *ITy = dyn_cast<IntegerType>(I.getType());
   if (!ITy || ITy->getBitWidth() % 16 ||
       // ByteMask only allows up to 32-byte values.

--- a/test/HLSL/passes/instcombine/disable-bswap-match.ll
+++ b/test/HLSL/passes/instcombine/disable-bswap-match.ll
@@ -1,0 +1,89 @@
+; RUN: opt -instcombine -S %s | FileCheck %s
+
+; CHECK-NOT: call i32 @llvm.bswap.i32(i32 %5)
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%Consts = type { i32 }
+%dx.types.Handle = type { i8* }
+%dx.types.ResourceProperties = type { i32, i32 }
+%dx.types.CBufRet.i32 = type { i32, i32, i32, i32 }
+
+@Consts = external constant %Consts
+@llvm.used = appending global [1 x i8*] [i8* bitcast (%Consts* @Consts to i8*)], section "llvm.metadata"
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %Consts*, i32)"(i32, %Consts*, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %Consts)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %Consts) #0
+
+; Function Attrs: nounwind
+define void @main(<4 x float>* noalias) #1 {
+  %2 = load %Consts, %Consts* @Consts, !dbg !3 ; line:16 col:20
+  %Consts = call %dx.types.Handle @dx.op.createHandleForLib.Consts(i32 160, %Consts %2), !dbg !3 ; line:16 col:20
+  %3 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %Consts, %dx.types.ResourceProperties { i32 13, i32 4 }), !dbg !3 ; line:16 col:20
+  %4 = call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(i32 59, %dx.types.Handle %3, i32 0), !dbg !3 ; line:16 col:20
+  %5 = extractvalue %dx.types.CBufRet.i32 %4, 0, !dbg !3 ; line:16 col:20
+  %6 = shl i32 %5, 24, !dbg !8 ; line:8 col:15
+  %7 = and i32 %6, -16777216, !dbg !11 ; line:8 col:22
+  %8 = shl i32 %5, 8, !dbg !12 ; line:9 col:15
+  %9 = and i32 %8, 16711680, !dbg !13 ; line:9 col:22
+  %10 = or i32 %7, %9, !dbg !14 ; line:8 col:36
+  %11 = lshr i32 %5, 8, !dbg !15 ; line:10 col:15
+  %12 = and i32 %11, 65280, !dbg !16 ; line:10 col:22
+  %13 = or i32 %10, %12, !dbg !17 ; line:9 col:36
+  %14 = lshr i32 %5, 24, !dbg !18 ; line:11 col:15
+  %15 = and i32 %14, 255, !dbg !19 ; line:11 col:22
+  %16 = or i32 %13, %15, !dbg !20 ; line:10 col:36
+  %17 = uitofp i32 %16 to float, !dbg !21 ; line:16 col:12
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %17), !dbg !22 ; line:16 col:5
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float %17), !dbg !22 ; line:16 col:5
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float %17), !dbg !22 ; line:16 col:5
+  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float %17), !dbg !22 ; line:16 col:5
+  ret void, !dbg !22 ; line:16 col:5
+}
+
+; Function Attrs: nounwind
+declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #1
+
+; Function Attrs: nounwind readonly
+declare %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(i32, %dx.types.Handle, i32) #2
+
+; Function Attrs: nounwind readonly
+declare %dx.types.Handle @dx.op.createHandleForLib.Consts(i32, %Consts) #2
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #0
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind }
+attributes #2 = { nounwind readonly }
+
+!llvm.module.flags = !{!0}
+!pauseresume = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{!"hlsl-dxilemit", !"hlsl-dxilload"}
+!2 = !{!"dxc(private) 1.7.0.14160 (main, adb2dc70fbd-dirty)"}
+!3 = !DILocation(line: 16, column: 20, scope: !4)
+!4 = !DISubprogram(name: "main", scope: !5, file: !5, line: 14, type: !6, isLocal: false, isDefinition: true, scopeLine: 15, flags: DIFlagPrototyped, isOptimized: false, function: void (<4 x float>*)* @main)
+!5 = !DIFile(filename: "bswap.hlsl", directory: "")
+!6 = !DISubroutineType(types: !7)
+!7 = !{}
+!8 = !DILocation(line: 8, column: 15, scope: !9, inlinedAt: !10)
+!9 = !DISubprogram(name: "bswap32", scope: !5, file: !5, line: 6, type: !6, isLocal: false, isDefinition: true, scopeLine: 6, flags: DIFlagPrototyped, isOptimized: false)
+!10 = distinct !DILocation(line: 16, column: 12, scope: !4)
+!11 = !DILocation(line: 8, column: 22, scope: !9, inlinedAt: !10)
+!12 = !DILocation(line: 9, column: 15, scope: !9, inlinedAt: !10)
+!13 = !DILocation(line: 9, column: 22, scope: !9, inlinedAt: !10)
+!14 = !DILocation(line: 8, column: 36, scope: !9, inlinedAt: !10)
+!15 = !DILocation(line: 10, column: 15, scope: !9, inlinedAt: !10)
+!16 = !DILocation(line: 10, column: 22, scope: !9, inlinedAt: !10)
+!17 = !DILocation(line: 9, column: 36, scope: !9, inlinedAt: !10)
+!18 = !DILocation(line: 11, column: 15, scope: !9, inlinedAt: !10)
+!19 = !DILocation(line: 11, column: 22, scope: !9, inlinedAt: !10)
+!20 = !DILocation(line: 10, column: 36, scope: !9, inlinedAt: !10)
+!21 = !DILocation(line: 16, column: 12, scope: !4)
+!22 = !DILocation(line: 16, column: 5, scope: !4)

--- a/test/HLSL/passes/instcombine/disable-bswap-match.ll
+++ b/test/HLSL/passes/instcombine/disable-bswap-match.ll
@@ -1,64 +1,26 @@
 ; RUN: opt -instcombine -S %s | FileCheck %s
 
-; CHECK-NOT: call i32 @llvm.bswap.i32(i32 %5)
+; CHECK-NOT: call i32 @llvm.bswap.i32
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"
 
-%Consts = type { i32 }
-%dx.types.Handle = type { i8* }
-%dx.types.ResourceProperties = type { i32, i32 }
-%dx.types.CBufRet.i32 = type { i32, i32, i32, i32 }
-
-@Consts = external constant %Consts
-@llvm.used = appending global [1 x i8*] [i8* bitcast (%Consts* @Consts to i8*)], section "llvm.metadata"
-
-; Function Attrs: nounwind readnone
-declare %dx.types.Handle @"dx.hl.createhandle..%dx.types.Handle (i32, %Consts*, i32)"(i32, %Consts*, i32) #0
-
-; Function Attrs: nounwind readnone
-declare %dx.types.Handle @"dx.hl.annotatehandle..%dx.types.Handle (i32, %dx.types.Handle, %dx.types.ResourceProperties, %Consts)"(i32, %dx.types.Handle, %dx.types.ResourceProperties, %Consts) #0
-
 ; Function Attrs: nounwind
-define void @main(<4 x float>* noalias) #1 {
-  %2 = load %Consts, %Consts* @Consts, !dbg !3 ; line:16 col:20
-  %Consts = call %dx.types.Handle @dx.op.createHandleForLib.Consts(i32 160, %Consts %2), !dbg !3 ; line:16 col:20
-  %3 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %Consts, %dx.types.ResourceProperties { i32 13, i32 4 }), !dbg !3 ; line:16 col:20
-  %4 = call %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(i32 59, %dx.types.Handle %3, i32 0), !dbg !3 ; line:16 col:20
-  %5 = extractvalue %dx.types.CBufRet.i32 %4, 0, !dbg !3 ; line:16 col:20
-  %6 = shl i32 %5, 24, !dbg !8 ; line:8 col:15
-  %7 = and i32 %6, -16777216, !dbg !11 ; line:8 col:22
-  %8 = shl i32 %5, 8, !dbg !12 ; line:9 col:15
-  %9 = and i32 %8, 16711680, !dbg !13 ; line:9 col:22
-  %10 = or i32 %7, %9, !dbg !14 ; line:8 col:36
-  %11 = lshr i32 %5, 8, !dbg !15 ; line:10 col:15
-  %12 = and i32 %11, 65280, !dbg !16 ; line:10 col:22
-  %13 = or i32 %10, %12, !dbg !17 ; line:9 col:36
-  %14 = lshr i32 %5, 24, !dbg !18 ; line:11 col:15
-  %15 = and i32 %14, 255, !dbg !19 ; line:11 col:22
-  %16 = or i32 %13, %15, !dbg !20 ; line:10 col:36
-  %17 = uitofp i32 %16 to float, !dbg !21 ; line:16 col:12
-  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float %17), !dbg !22 ; line:16 col:5
-  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float %17), !dbg !22 ; line:16 col:5
-  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float %17), !dbg !22 ; line:16 col:5
-  call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float %17), !dbg !22 ; line:16 col:5
-  ret void, !dbg !22 ; line:16 col:5
+define i32 @main(i32 %input) #0 {
+  %1 = shl i32 %input, 24
+  %2 = and i32 %1, -16777216
+  %3 = shl i32 %input, 8
+  %4 = and i32 %3, 16711680
+  %5 = or i32 %2, %4
+  %6 = lshr i32 %input, 8
+  %7 = and i32 %6, 65280
+  %8 = or i32 %5, %7
+  %9 = lshr i32 %input, 24
+  %10 = and i32 %9, 255
+  %11 = or i32 %8, %10
+  ret i32 %11
 }
 
-; Function Attrs: nounwind
-declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #1
-
-; Function Attrs: nounwind readonly
-declare %dx.types.CBufRet.i32 @dx.op.cbufferLoadLegacy.i32(i32, %dx.types.Handle, i32) #2
-
-; Function Attrs: nounwind readonly
-declare %dx.types.Handle @dx.op.createHandleForLib.Consts(i32, %Consts) #2
-
-; Function Attrs: nounwind readnone
-declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #0
-
-attributes #0 = { nounwind readnone }
-attributes #1 = { nounwind }
-attributes #2 = { nounwind readonly }
+attributes #0 = { nounwind }
 
 !llvm.module.flags = !{!0}
 !pauseresume = !{!1}
@@ -67,23 +29,3 @@ attributes #2 = { nounwind readonly }
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = !{!"hlsl-dxilemit", !"hlsl-dxilload"}
 !2 = !{!"dxc(private) 1.7.0.14160 (main, adb2dc70fbd-dirty)"}
-!3 = !DILocation(line: 16, column: 20, scope: !4)
-!4 = !DISubprogram(name: "main", scope: !5, file: !5, line: 14, type: !6, isLocal: false, isDefinition: true, scopeLine: 15, flags: DIFlagPrototyped, isOptimized: false, function: void (<4 x float>*)* @main)
-!5 = !DIFile(filename: "bswap.hlsl", directory: "")
-!6 = !DISubroutineType(types: !7)
-!7 = !{}
-!8 = !DILocation(line: 8, column: 15, scope: !9, inlinedAt: !10)
-!9 = !DISubprogram(name: "bswap32", scope: !5, file: !5, line: 6, type: !6, isLocal: false, isDefinition: true, scopeLine: 6, flags: DIFlagPrototyped, isOptimized: false)
-!10 = distinct !DILocation(line: 16, column: 12, scope: !4)
-!11 = !DILocation(line: 8, column: 22, scope: !9, inlinedAt: !10)
-!12 = !DILocation(line: 9, column: 15, scope: !9, inlinedAt: !10)
-!13 = !DILocation(line: 9, column: 22, scope: !9, inlinedAt: !10)
-!14 = !DILocation(line: 8, column: 36, scope: !9, inlinedAt: !10)
-!15 = !DILocation(line: 10, column: 15, scope: !9, inlinedAt: !10)
-!16 = !DILocation(line: 10, column: 22, scope: !9, inlinedAt: !10)
-!17 = !DILocation(line: 9, column: 36, scope: !9, inlinedAt: !10)
-!18 = !DILocation(line: 11, column: 15, scope: !9, inlinedAt: !10)
-!19 = !DILocation(line: 11, column: 22, scope: !9, inlinedAt: !10)
-!20 = !DILocation(line: 10, column: 36, scope: !9, inlinedAt: !10)
-!21 = !DILocation(line: 16, column: 12, scope: !4)
-!22 = !DILocation(line: 16, column: 5, scope: !4)


### PR DESCRIPTION
DXIL doesn't support the bswap intrinsic, normally a backend would lower this intrinsic to something else, in this case we don't have a backend so we just end up generating invalid DXIL.

The solution here is to disable bswap matching when targeting DXIL.

Fixes #5104