### PR TITLE
[SPIR-V] Fixup tests failing downstream

### DIFF
--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.stage-vars.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.stage-vars.hlsl
@@ -1,4 +1,6 @@
-// RUN: %dxc -T vs_6_0 -E main -fspv-reflect -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T vs_6_0 -E main -fspv-reflect -fcgl  %s -spirv | FileCheck %s --implicit-check-not "OpDecorate {{%[0-9]+}} NoContraction"
+
+// The --implicit-check-not option above checks that there are no `OpDecorate ... NoContraction` instructions other than those CHECKed below.
 
 // CHECK:      OpDecorate [[aa_1:%[0-9]+]] NoContraction
 // CHECK-NEXT: OpDecorate [[aa_plus_b_1:%[0-9]+]] NoContraction
@@ -18,16 +20,8 @@
 // CHECK-NEXT: OpDecorate [[cxcy_1:%[0-9]+]] NoContraction
 // CHECK-NEXT: OpDecorate [[cxcy_plus_dz_1:%[0-9]+]] NoContraction
 
-// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_2]] NoContraction
-// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_plus_dz_2]] NoContraction
-
-// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_3]] NoContraction
-// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_plus_dz_3]] NoContraction
-
 // CHECK-NEXT: OpDecorate [[aa_3:%[0-9]+]] NoContraction
 // CHECK-NEXT: OpDecorate [[aa_plus_b_3:%[0-9]+]] NoContraction
-
-// CHECK-NOT: OpDecorate {{%[0-9]+}} NoContraction
 
 struct InnerInnerStruct {
   precise float4   position : SV_Position;      // -> BuiltIn Position in gl_Pervertex

--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.stage-vars.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.stage-vars.hlsl
@@ -18,14 +18,16 @@
 // CHECK-NEXT: OpDecorate [[cxcy_1:%[0-9]+]] NoContraction
 // CHECK-NEXT: OpDecorate [[cxcy_plus_dz_1:%[0-9]+]] NoContraction
 
-// CHECK-NOT: OpDecorate [[cxcy_2]] NoContraction
-// CHECK-NOT: OpDecorate [[cxcy_plus_dz_2]] NoContraction
+// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_2]] NoContraction
+// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_plus_dz_2]] NoContraction
 
-// CHECK-NOT: OpDecorate [[cxcy_3]] NoContraction
-// CHECK-NOT: OpDecorate [[cxcy_plus_dz_3]] NoContraction
+// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_3]] NoContraction
+// IMPLICIT-CHECK-NOT: OpDecorate [[cxcy_plus_dz_3]] NoContraction
 
 // CHECK-NEXT: OpDecorate [[aa_3:%[0-9]+]] NoContraction
 // CHECK-NEXT: OpDecorate [[aa_plus_b_3:%[0-9]+]] NoContraction
+
+// CHECK-NOT: OpDecorate {{%[0-9]+}} NoContraction
 
 struct InnerInnerStruct {
   precise float4   position : SV_Position;      // -> BuiltIn Position in gl_Pervertex

--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.struct.hlsl
@@ -17,59 +17,61 @@ struct T {
 };
 
 
-// CHECK:      OpName %w "w"
-// CHECK-NOT:  OpDecorate [[x_mul_x_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[xx_plus_y_1]] NoContraction
-// CHECK-NEXT: OpDecorate [[x_mul_x_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[xx_plus_y_2:%[0-9]+]] NoContraction
+// CHECK:               OpName %w "w"
+// IMPLICIT-CHECK-NOT:  OpDecorate [[x_mul_x_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[xx_plus_y_1]] NoContraction
+// CHECK-NEXT:          OpDecorate [[x_mul_x_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[xx_plus_y_2:%[0-9]+]] NoContraction
 
-// CHECK-NOT:  OpDecorate [[z2_mul_z3_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[z2z3_plus_z4_1]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2_mul_z3_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_2:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[z2_mul_z3_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[z2z3_plus_z4_1]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2_mul_z3_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_2:%[0-9]+]] NoContraction
 
-// CHECK-NOT:  OpDecorate [[uu_row0_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[uu_row1_1]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row1_2:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[uu_row0_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[uu_row1_1]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row1_2:%[0-9]+]] NoContraction
 
-// CHECK-NOT:  OpDecorate [[ww_row0_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[ww_row1_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[ww_row2_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[ww_plus_w_row0_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[ww_plus_w_row1_1]] NoContraction
-// CHECK-NOT:  OpDecorate [[ww_plus_w_row2_1]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row1_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row2_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_2:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_2:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row0_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row1_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row2_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row0_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row1_1]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row2_1]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row1_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row2_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_2:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_2:%[0-9]+]] NoContraction
 
-// CHECK-NEXT: OpDecorate [[x_mul_x_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[xx_plus_y_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[x_mul_x_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[xx_plus_y_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2_mul_z3_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2_mul_z3_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[uu_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row2_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_3:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_row2_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[x_mul_x_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[xx_plus_y_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[x_mul_x_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[xx_plus_y_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2_mul_z3_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2_mul_z3_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[uu_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row2_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_3:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_row2_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_4:%[0-9]+]] NoContraction
+
+// CHECK-NOT:           OpDecorate {{%[0-9]+}} NoContraction
 
 void main() {
   T t;

--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.struct.hlsl
@@ -1,4 +1,6 @@
-// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s  --implicit-check-not "OpDecorate {{%[0-9]+}} NoContraction"
+
+// The --implicit-check-not option above checks that there are no `OpDecorate ... NoContraction` instructions other than those CHECKed below.
 
 struct S {
             float4 a;
@@ -17,61 +19,47 @@ struct T {
 };
 
 
-// CHECK:               OpName %w "w"
-// IMPLICIT-CHECK-NOT:  OpDecorate [[x_mul_x_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[xx_plus_y_1]] NoContraction
-// CHECK-NEXT:          OpDecorate [[x_mul_x_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[xx_plus_y_2:%[0-9]+]] NoContraction
+// CHECK:      OpName %w "w"
+// CHECK-NEXT: OpDecorate [[x_mul_x_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[xx_plus_y_2:%[0-9]+]] NoContraction
 
-// IMPLICIT-CHECK-NOT:  OpDecorate [[z2_mul_z3_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[z2z3_plus_z4_1]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2_mul_z3_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2_mul_z3_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_2:%[0-9]+]] NoContraction
 
-// IMPLICIT-CHECK-NOT:  OpDecorate [[uu_row0_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[uu_row1_1]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row1_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row1_2:%[0-9]+]] NoContraction
 
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row0_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row1_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_row2_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row0_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row1_1]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ww_plus_w_row2_1]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row1_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row2_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_2:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row1_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row2_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_2:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_2:%[0-9]+]] NoContraction
 
-// CHECK-NEXT:          OpDecorate [[x_mul_x_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[xx_plus_y_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[x_mul_x_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[xx_plus_y_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2_mul_z3_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2_mul_z3_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[z2z3_plus_z4_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[uu_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row2_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_3:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_row2_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row0_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row1_4:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[ww_plus_w_row2_4:%[0-9]+]] NoContraction
-
-// CHECK-NOT:           OpDecorate {{%[0-9]+}} NoContraction
+// CHECK-NEXT: OpDecorate [[x_mul_x_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[xx_plus_y_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[x_mul_x_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[xx_plus_y_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2_mul_z3_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2_mul_z3_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[z2z3_plus_z4_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[uu_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row2_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_3:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_row2_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row0_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row1_4:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[ww_plus_w_row2_4:%[0-9]+]] NoContraction
 
 void main() {
   T t;

--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.variable-reuse.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.variable-reuse.hlsl
@@ -1,24 +1,19 @@
-// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s --implicit-check-not "OpDecorate {{%[0-9]+}} NoContraction"
 
 // The purpose of this test is to make sure non-precise computations are *not*
-// decorated with NoContraction.
+// decorated with NoContraction. Note the --implicit-check-not flag above.
 //
 // To this end, we will perform the same computation twice, once when it
 // affects a precise variable, and once when it doesn't.
 
 void foo(float p) { p = p + 1; }
 
-// CHECK:               OpName %bb_entry_0 "bb.entry"
-// CHECK-NEXT:          OpDecorate [[first_b_plus_c:%[0-9]+]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[first_a_mul_b]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[ax_mul_bx]] NoContraction
-// CHECK-NEXT:          OpDecorate [[second_a_mul_b:%[0-9]+]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[second_a_plus_b]] NoContraction
-// CHECK-NEXT:          OpDecorate [[first_d_plus_e:%[0-9]+]] NoContraction
-// CHECK-NEXT:          OpDecorate [[c_mul_d:%[0-9]+]] NoContraction
-// IMPLICIT-CHECK-NOT:  OpDecorate [[second_d_plus_e]] NoContraction
-// CHECK-NEXT:          OpDecorate [[r_plus_s:%[0-9]+]] NoContraction
-// CHECK-NOT:           OpDecorate {{%[0-9]+}} NoContraction
+// CHECK:      OpName %bb_entry_0 "bb.entry"
+// CHECK-NEXT: OpDecorate [[first_b_plus_c:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[second_a_mul_b:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[first_d_plus_e:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[c_mul_d:%[0-9]+]] NoContraction
+// CHECK-NEXT: OpDecorate [[r_plus_s:%[0-9]+]] NoContraction
 
 void main() {
   float4 a, b, c, d, e;

--- a/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.variable-reuse.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/decoration.no-contraction.variable-reuse.hlsl
@@ -8,16 +8,17 @@
 
 void foo(float p) { p = p + 1; }
 
-// CHECK:      OpName %bb_entry_0 "bb.entry"
-// CHECK-NEXT: OpDecorate [[first_b_plus_c:%[0-9]+]] NoContraction
-// CHECK-NOT:  OpDecorate [[first_a_mul_b]] NoContraction
-// CHECK-NOT:  OpDecorate [[ax_mul_bx]] NoContraction
-// CHECK-NEXT: OpDecorate [[second_a_mul_b:%[0-9]+]] NoContraction
-// CHECK-NOT:  OpDecorate [[second_a_plus_b]] NoContraction
-// CHECK-NEXT: OpDecorate [[first_d_plus_e:%[0-9]+]] NoContraction
-// CHECK-NEXT: OpDecorate [[c_mul_d:%[0-9]+]] NoContraction
-// CHECK-NOT:  OpDecorate [[second_d_plus_e]] NoContraction
-// CHECK-NEXT: OpDecorate [[r_plus_s:%[0-9]+]] NoContraction
+// CHECK:               OpName %bb_entry_0 "bb.entry"
+// CHECK-NEXT:          OpDecorate [[first_b_plus_c:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[first_a_mul_b]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[ax_mul_bx]] NoContraction
+// CHECK-NEXT:          OpDecorate [[second_a_mul_b:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[second_a_plus_b]] NoContraction
+// CHECK-NEXT:          OpDecorate [[first_d_plus_e:%[0-9]+]] NoContraction
+// CHECK-NEXT:          OpDecorate [[c_mul_d:%[0-9]+]] NoContraction
+// IMPLICIT-CHECK-NOT:  OpDecorate [[second_d_plus_e]] NoContraction
+// CHECK-NEXT:          OpDecorate [[r_plus_s:%[0-9]+]] NoContraction
+// CHECK-NOT:           OpDecorate {{%[0-9]+}} NoContraction
 
 void main() {
   float4 a, b, c, d, e;


### PR DESCRIPTION
These tests are failing in our downstream builds after migrating to Lit due to CHECK-NOTs referencing variables before they are defined. Those CHECK-NOTs have now been replaced with an `--implicit-check-not` that checks that there are no `OpDecorate ... NoContraction` instructions other than those CHECKed in the test.