### PR TITLE
Do not merge geps when an addrspacecast changes the underlying type.

### DIFF
--- a/test/HLSL/passes/multi_dim_one_dim/fail_to_merge.ll
+++ b/test/HLSL/passes/multi_dim_one_dim/fail_to_merge.ll
@@ -1,0 +1,35 @@
+; RUN: not opt -S -multi-dim-one-dim %s
+
+; We do not handle addrspacecast that changes the shape of the underlying type
+; when merging geps (e.g. array to non-array). Instead of trying to handle some
+; cases we just avoid trying to merge geps in all cases where the underlying
+; type changes shape. This causes the multi-dim-one-dim pass to crash because
+; it expects the geps to be merged. I do not think we can hit this case from
+; hlsl, but it may be possible.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+@ArrayOfArray = addrspace(3) global [256 x [9 x float]] undef, align 4
+
+; This case could be successfully handled by the current code by removing
+; the check for different pointer element types.
+define void @addrspace_cast_new_type_same_shape(i32 %idx0, i32 %idx1) {
+entry:
+  %gep0 = getelementptr inbounds [256 x [9 x float]], [256 x [9 x float]] addrspace(3)* @ArrayOfArray, i32 0, i32 %idx0
+  %asc  = addrspacecast [9 x float] addrspace(3)* %gep0 to [3 x i32]*
+  %gep1 = getelementptr inbounds [3 x i32], [3 x i32]* %asc, i32 0, i32 %idx1
+  %load = load i32, i32* %gep1
+  ret void
+}
+
+; This case could not be successfully handled by the current code because
+; the change in type also changes the shape.
+define void @addrspace_cast_new_type_new_shape(i32 %idx0, i32 %idx1) {
+entry:
+  %gep0 = getelementptr inbounds [256 x [9 x float]], [256 x [9 x float]] addrspace(3)* @ArrayOfArray, i32 0, i32 %idx0
+  %asc  = addrspacecast [9 x float] addrspace(3)* %gep0 to i32*
+  %gep1 = getelementptr inbounds i32, i32* %asc, i32 0
+  %load = load i32, i32* %gep1
+  ret void
+}

--- a/test/HLSL/passes/multi_dim_one_dim/gep_addrspacecast_gep.ll
+++ b/test/HLSL/passes/multi_dim_one_dim/gep_addrspacecast_gep.ll
@@ -177,22 +177,3 @@ entry:
   %load = load float, float addrspace(3)* %gep2
   ret void
 }
-
-; Test that we compute the correct index when the addrspacecast includes both a
-; change in address space and a change in the underlying type. I did not see
-; this pattern in IR generated from hlsl, but we can handle this case so I am
-; adding a test for it anyway.
-; CHECK-LABEL: addrspace_cast_new_type
-; CHECK:  %0 = mul i32 %idx0, 9
-; CHECK:  %1 = add i32 %idx1, %0
-; CHECK:  %2 = getelementptr [2304 x float], [2304 x float] addrspace(3)* @ArrayOfArray.1dim, i32 0, i32 %1
-; CHECK:  %3 = addrspacecast float addrspace(3)* %2 to i32*
-; CHECK:  load i32, i32* %3
-define void @addrspace_cast_new_type(i32 %idx0, i32 %idx1) {
-entry:
-  %gep0 = getelementptr inbounds [256 x [9 x float]], [256 x [9 x float]] addrspace(3)* @ArrayOfArray, i32 0, i32 %idx0
-  %asc  = addrspacecast [9 x float] addrspace(3)* %gep0 to [3 x i32]*
-  %gep1 = getelementptr inbounds [3 x i32], [3 x i32]* %asc, i32 0, i32 %idx1
-  %load = load i32, i32* %gep1
-  ret void
-}


### PR DESCRIPTION
We do not handle an addrspacecast that changes the shape of the underlying type when merging geps (e.g. array to non-array). Instead of trying to handle some cases we just avoid trying to merge geps in all cases where the underlying type changes shape. This causes the multi-dim-one-dim pass to crash because it expects the geps to be merged. I do not think we can hit this case from hlsl, but it may be possible.