### PR TITLE
[SPIR-V] Remove invalid CHECK-COUNTs

### DIFF
--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.khr.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.khr.closesthit.hlsl
@@ -18,6 +18,9 @@
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn RayGeometryIndexKHR
 // CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxNV
 
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
+
 // CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
 struct Payload
 {
@@ -34,7 +37,6 @@ struct Attribute
   float2 bary;
 };
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
 RaytracingAccelerationStructure rs;
 
 [shader("closesthit")]

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.khr.closesthit.vulkan1.1spirv1.4.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.khr.closesthit.vulkan1.1spirv1.4.hlsl
@@ -21,6 +21,9 @@
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn RayGeometryIndexKHR
 // CHECK:  OpDecorate [[n:%[0-9]+]] BuiltIn RayTmaxNV
 
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
+
 // CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
 struct Payload
 {
@@ -37,7 +40,6 @@ struct Attribute
   float2 bary;
 };
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
 RaytracingAccelerationStructure rs;
 
 [shader("closesthit")]

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.anyhit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.anyhit.hlsl
@@ -17,6 +17,9 @@
 // CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn HitTNV
 
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
+
 // CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
 struct Payload
 {
@@ -28,7 +31,6 @@ struct Attribute
   float2 bary;
 };
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
 RaytracingAccelerationStructure rs;
 
 [shader("anyhit")]

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.closesthit.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.closesthit.hlsl
@@ -17,6 +17,9 @@
 // CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
 // CHECK:  OpDecorate [[m:%[0-9]+]] BuiltIn HitTNV
 
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
+
 // CHECK:  OpTypePointer IncomingRayPayloadNV %Payload
 struct Payload
 {
@@ -28,7 +31,6 @@ struct Attribute
   float2 bary;
 };
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
 RaytracingAccelerationStructure rs;
 
 [shader("closesthit")]

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.enum.hlsl
@@ -4,7 +4,8 @@
 // CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
 // CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
 RaytracingAccelerationStructure rs;
 
 struct Payload

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.library.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.library.hlsl
@@ -28,6 +28,8 @@
 // CHECK:  OpDecorate [[k:%[0-9]+]] BuiltIn WorldToObjectNV
 // CHECK:  OpDecorate [[l:%[0-9]+]] BuiltIn HitKindNV
 
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
 
 // CHECK: OpTypePointer CallableDataNV %CallData
 struct CallData
@@ -44,7 +46,6 @@ struct Attribute
 {
   float2 bary;
 };
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
 RaytracingAccelerationStructure rs;
 
 

--- a/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.raygen.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/raytracing.nv.raygen.hlsl
@@ -4,7 +4,8 @@
 // CHECK:  OpDecorate [[a:%[0-9]+]] BuiltIn LaunchIdNV
 // CHECK:  OpDecorate [[b:%[0-9]+]] BuiltIn LaunchSizeNV
 
-// CHECK-COUNT-1: [[rstype:%[0-9]+]] = OpTypeAccelerationStructureNV
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
 RaytracingAccelerationStructure rs;
 
 struct Payload

--- a/tools/clang/test/CodeGenSPIRV_Lit/unsupported/rayquery_init_rgen.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/unsupported/rayquery_init_rgen.hlsl
@@ -4,7 +4,8 @@
 // CHECK:  OpExtension "SPV_KHR_ray_tracing"
 // CHECK:  OpExtension "SPV_KHR_ray_query"
 
-// CHECK-COUNT-1: [[rs:%\d+]] = OpTypeAccelerationStructureNV
+// CHECK: %accelerationStructureNV = OpTypeAccelerationStructureKHR
+// CHECK-NOT: OpTypeAccelerationStructureKHR
 RaytracingAccelerationStructure AccelerationStructure : register(t0);
 RayDesc MakeRayDesc()
 {


### PR DESCRIPTION
CHECK-COUNT-# was not yet implemented in the version of FileCheck used in DXC, so these lines were not checked at all. Switching them to CHECKs caused the tests to fail, so they're now replaced with a combination of a CHECK and CHECK-NOT that pass.

This was caught by the downstream test runner that uses a newer version of FileCheck which does check CHECK-COUNTs.