### PR TITLE
Add missing '-' for pass in ExtractIRForPassTest.py

### DIFF
--- a/utils/hct/ExtractIRForPassTest.py
+++ b/utils/hct/ExtractIRForPassTest.py
@@ -143,7 +143,7 @@ def main(args):
         # 6. Inserts RUN line with -hlsl-passes-resume and desired pass
         with open(args.output_file, "wt") as f:
             f.write(
-                "; RUN: %opt %s -hlsl-passes-resume {} -S | FileCheck %s\n\n".format(
+                "; RUN: %opt %s -hlsl-passes-resume -{} -S | FileCheck %s\n\n".format(
                     args.desired_pass
                 )
             )


### PR DESCRIPTION
The default generated RUN line generated by ExtractIRForPassTest.py adds the desired pass to the options, but forgot to add the '-', so it would fail with difficult to diagnose error in dxopt during argument parsing.

This adds the missing '-' so the RUN line doesn't have to be fixed in this way every time the script is used.