### PR TITLE
NFC: fix dereferencing of past-end iterator

### DIFF
--- a/tools/clang/include/clang/Sema/CXXFieldCollector.h
+++ b/tools/clang/include/clang/Sema/CXXFieldCollector.h
@@ -66,7 +66,7 @@ public:
 
   /// getCurFields - Pointer to array of fields added to the currently parsed
   /// class.
-  FieldDecl **getCurFields() { return &*(Fields.end() - getCurNumFields()); }
+  FieldDecl **getCurFields() { return Fields.end() - getCurNumFields(); }
 
   /// FinishClass - Called by Sema::ActOnFinishCXXClassDef.
   void FinishClass() {


### PR DESCRIPTION
This worked because the value was valid by luck, but this relies on an undefined behavior.
However, it is allowed to convert the iterator to the pointer without dereferencing it.

This change will also get upstreamed in LLVM.