### PR TITLE
[SPIRV][NFC] Fix iterator usage after invalidation

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -206,8 +206,8 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
       if (!var->invokeVisitor(visitor))
         return false;
 
-    for (auto *debugInstruction : debugInstructions)
-      if (!debugInstruction->invokeVisitor(visitor))
+    for (size_t i = 0; i < debugInstruction.size(); i++)
+      if (!debugInstructions[i]->invokeVisitor(visitor))
         return false;
 
     for (auto fn : functions)

--- a/tools/clang/lib/SPIRV/SpirvModule.cpp
+++ b/tools/clang/lib/SPIRV/SpirvModule.cpp
@@ -206,7 +206,7 @@ bool SpirvModule::invokeVisitor(Visitor *visitor, bool reverseOrder) {
       if (!var->invokeVisitor(visitor))
         return false;
 
-    for (size_t i = 0; i < debugInstruction.size(); i++)
+    for (size_t i = 0; i < debugInstructions.size(); i++)
       if (!debugInstructions[i]->invokeVisitor(visitor))
         return false;
 


### PR DESCRIPTION
This is a quick fix to unblock users, but it could hide other issues.

During this iteration, some function down the line push_back to the debugInstructions vector. If the storage gets moved, then we fail.

Fixes #5566
Signed-off-by: Nathan Gauër <brioche@google.com>