### PR TITLE
[SPIR-V] implement vk::spvexecutionmode attribute for inline SPIR-V

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1142,6 +1142,14 @@ def VKExtensionExt : InheritableAttr {
   let Documentation = [Undocumented];
 }
 
+def VKSpvExecutionMode : InheritableAttr {
+  let Spellings = [CXX11<"vk", "spvexecutionmode">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Args = [UnsignedArgument<"ExecutionMode">];
+  let LangOpts = [SPIRV];
+  let Documentation = [Undocumented];
+}
+
 def VKStorageClassExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_storage_class">];
   let Subjects = SubjectList<[Var, ParmVar], ErrorDiag>;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -808,6 +808,9 @@ private:
   static spv::ExecutionModel getSpirvShaderStage(hlsl::ShaderModel::Kind smk,
                                                  bool);
 
+  /// \brief Handle inline SPIR-V attributes for the entry function.
+  void processInlineSpirvAttributes(const FunctionDecl *entryFunction);
+
   /// \brief Adds necessary execution modes for the hull/domain shaders based on
   /// the HLSL attributes of the entry point function.
   /// In the case of hull shaders, also writes the number of output control

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12581,6 +12581,11 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A,
         A.getRange(), S.Context, ValidateAttributeStringArg(S, A, nullptr),
         A.getAttributeSpellingListIndex());
     break;
+  case AttributeList::AT_VKSpvExecutionMode:
+    declAttr = ::new (S.Context) VKSpvExecutionModeAttr(
+        A.getRange(), S.Context, ValidateAttributeIntArg(S, A),
+        A.getAttributeSpellingListIndex());
+    break;
   case AttributeList::AT_VKInstructionExt:
     declAttr = ::new (S.Context) VKInstructionExtAttr(
         A.getRange(), S.Context, ValidateAttributeIntArg(S, A),

--- a/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.executionmode.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.executionmode.hlsl
@@ -1,0 +1,6 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK:      OpExecutionMode %main DepthLess
+// CHECK-NEXT: OpExecutionMode %main PostDepthCoverage
+[[vk::spvexecutionmode(4446),vk::spvexecutionmode(15)]]
+void main() {}

--- a/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.executionmode.undefined.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.executionmode.undefined.hlsl
@@ -1,0 +1,5 @@
+// RUN: not %dxc -T ps_6_0 -E main -fcgl %s -spirv 2>&1 | FileCheck %s
+
+// CHECK: Invalid execution mode operand: 999999
+[[vk::spvexecutionmode(999999)]]
+void main() {}


### PR DESCRIPTION
Implements `vk::spvexecutionmode` from https://github.com/microsoft/hlsl-specs/blob/main/proposals/0011-inline-spirv.md#execution-modes.