### PR TITLE
Add execution mode for derivatives in compute shaders

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11163,7 +11163,12 @@ SpirvInstruction *SpirvEmitter::processIntrinsicUsingSpirvInst(
     const CallExpr *callExpr, spv::Op opcode, bool actPerRowForMatrices) {
   // The derivative opcodes are only allowed in pixel shader, or in compute
   // shaderers when the SPV_NV_compute_shader_derivatives is enabled.
-  if (!spvContext.isPS())
+  if (!spvContext.isPS()) {
+    // For cases where the instructions are known to be invalid, we turn on
+    // legalization expecting the invalid use to be optimized away. For compute
+    // shaders, we add the execution mode to enable the derivatives. We legalize
+    // in this case as well because that is what we did before the extension was
+    // used, and we do not want to change previous behaviour too much.
     switch (opcode) {
     case spv::Op::OpDPdx:
     case spv::Op::OpDPdy:
@@ -11182,6 +11187,7 @@ SpirvInstruction *SpirvEmitter::processIntrinsicUsingSpirvInst(
       // Only the given opcodes need legalization and the execution mode.
       break;
     }
+  }
 
   const auto loc = callExpr->getExprLoc();
   const auto range = callExpr->getSourceRange();

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11173,11 +11173,12 @@ SpirvInstruction *SpirvEmitter::processIntrinsicUsingSpirvInst(
     case spv::Op::OpFwidth:
     case spv::Op::OpFwidthFine:
     case spv::Op::OpFwidthCoarse:
+      if (spvContext.isCS())
+        addDerivativeGroupExecutionMode();
       needsLegalization = true;
       break;
     default:
-      // Only the given opcodes need legalization. Anything else should preserve
-      // previous.
+      // Only the given opcodes need legalization and the execution mode.
       break;
     }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11161,7 +11161,8 @@ SpirvEmitter::processIntrinsicF32ToF16(const CallExpr *callExpr) {
 
 SpirvInstruction *SpirvEmitter::processIntrinsicUsingSpirvInst(
     const CallExpr *callExpr, spv::Op opcode, bool actPerRowForMatrices) {
-  // Certain opcodes are only allowed in pixel shader
+  // The derivative opcodes are only allowed in pixel shader, or in compute
+  // shaderers when the SPV_NV_compute_shader_derivatives is enabled.
   if (!spvContext.isPS())
     switch (opcode) {
     case spv::Op::OpDPdx:

--- a/tools/clang/test/CodeGenSPIRV_Lit/ddx.compute.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/ddx.compute.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T cs_6_6 -E main -fspv-extension=SPV_NV_compute_shader_derivatives -fcgl  %s -spirv  2>&1 | FileCheck %s
+
+// CHECK: OpCapability ComputeDerivativeGroupQuadsNV
+// CHECK: OpExtension "SPV_NV_compute_shader_derivatives"
+// CHECK: OpExecutionMode %main DerivativeGroupQuadsNV
+
+
+SamplerState ss : register(s2);
+SamplerComparisonState scs;
+
+RWStructuredBuffer<uint> o;
+Texture1D        <float>  t1;
+
+[numthreads(2,2,1)]
+void main(uint3 id : SV_GroupThreadID)
+{
+    // CHECK: OpDPdx %float %float_0_5
+    o[0] = ddx(0.5);
+    // CHECK: OpDPdxCoarse %float %float_0_5
+    o[1] = ddx_coarse(0.5);
+    // CHECK: OpDPdy %float %float_0_5
+    o[2] = ddy(0.5);
+    // CHECK: OpDPdyCoarse %float %float_0_5
+    o[3] = ddy_coarse(0.5);
+    // CHECK: OpDPdxFine %float %float_0_5
+    o[4] = ddx_fine(0.5);
+    // CHECK: OpDPdyFine %float %float_0_5
+    o[5] = ddy_fine(0.5);
+}


### PR DESCRIPTION
This commit adds the execution mode to compute shaders when derivatives
are used. I only added a single test because the derivatives are all
handled in one place. The choice of execution mode was tested using the
implicit LOD instructions.
