### PR TITLE
[Linux] Enable PDBUtil test for Linux build

### DIFF
--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -903,6 +903,9 @@ void SysFreeString(BSTR bstrString);
 // Allocate string with length prefix
 BSTR SysAllocStringLen(const OLECHAR *strIn, UINT ui);
 
+//===--------------------------- BSTR Length ------------------------------===//
+unsigned int SysStringLen(const BSTR bstrString);
+
 //===--------------------- UTF-8 Related Types ----------------------------===//
 
 // Code Page
@@ -1000,7 +1003,7 @@ public:
   CComBSTR() : m_str(nullptr){};
   CComBSTR(int nSize, LPCWSTR sz);
   ~CComBSTR() throw() { SysFreeString(m_str); }
-
+  unsigned int Length() const throw() { return SysStringLen(m_str); }
   operator BSTR() const throw() { return m_str; }
 
   bool operator==(const CComBSTR &bstrSrc) const throw();

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -51,7 +51,15 @@ BSTR SysAllocStringLen(const OLECHAR *strIn, UINT ui) {
 
   return strOut;
 }
+//===--------------------------- BSTR Length ------------------------------===//
+unsigned int SysStringLen(const BSTR bstrString) {
+  if (!bstrString)
+    return 0;
 
+  uint32_t *blobIn = (uint32_t *)((uintptr_t)bstrString - sizeof(uint32_t));
+
+  return blobIn[0] / sizeof(OLECHAR);
+}
 //===---------------------- Char converstion ------------------------------===//
 
 const char *CPToLocale(uint32_t CodePage) {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1334,7 +1334,7 @@ static void VerifyPdbUtil(
   {
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetTargetProfile(&str));
-    VERIFY_ARE_EQUAL_WSTR(str.m_str, L"ps_6_0");
+    VERIFY_ARE_EQUAL_WSTR(L"ps_6_0", str.m_str);
   }
 
   // Entry point

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1334,7 +1334,7 @@ static void VerifyPdbUtil(
   {
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetTargetProfile(&str));
-    VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"ps_6_0"));
+    VERIFY_ARE_EQUAL_WSTR(str.m_str, L"ps_6_0");
   }
 
   // Entry point
@@ -1342,9 +1342,9 @@ static void VerifyPdbUtil(
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&str));
     if (TestEntryPoint) {
-      VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"main"));
+      VERIFY_ARE_EQUAL_WSTR(str.m_str, L"main");
     } else {
-      VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"PSMain"));
+      VERIFY_ARE_EQUAL_WSTR(str.m_str, L"PSMain");
     }
   }
 
@@ -1363,7 +1363,7 @@ static void VerifyPdbUtil(
   {
     CComBSTR pPdbMainFileName;
     VERIFY_SUCCEEDED(pPdbUtils->GetMainFileName(&pPdbMainFileName));
-    VERIFY_ARE_EQUAL(0, wcscmp(pPdbMainFileName.m_str, pMainFileName));
+    VERIFY_ARE_EQUAL_WSTR(pPdbMainFileName.m_str, pMainFileName);
   }
 
   // There is hash and hash is not empty
@@ -2198,7 +2198,7 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsEmptyEntry) {
   CComBSTR pEntryName;
   VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&pEntryName));
 
-  VERIFY_ARE_EQUAL(0, wcscmp(pEntryName.m_str, L"main"));
+  VERIFY_ARE_EQUAL_WSTR(pEntryName.m_str, L"main");
 }
 
 TEST_F(CompilerTest, TestPdbUtilsWithEmptyDefine) {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1342,9 +1342,9 @@ static void VerifyPdbUtil(
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&str));
     if (TestEntryPoint) {
-      VERIFY_ARE_EQUAL_WSTR(str.m_str, L"main");
+      VERIFY_ARE_EQUAL_WSTR(L"main", str.m_str);
     } else {
-      VERIFY_ARE_EQUAL_WSTR(str.m_str, L"PSMain");
+      VERIFY_ARE_EQUAL_WSTR(L"PSMain", str.m_str);
     }
   }
 
@@ -1363,7 +1363,7 @@ static void VerifyPdbUtil(
   {
     CComBSTR pPdbMainFileName;
     VERIFY_SUCCEEDED(pPdbUtils->GetMainFileName(&pPdbMainFileName));
-    VERIFY_ARE_EQUAL_WSTR(pPdbMainFileName.m_str, pMainFileName);
+    VERIFY_ARE_EQUAL_WSTR(pMainFileName, pPdbMainFileName.m_str);
   }
 
   // There is hash and hash is not empty
@@ -2198,7 +2198,7 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsEmptyEntry) {
   CComBSTR pEntryName;
   VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&pEntryName));
 
-  VERIFY_ARE_EQUAL_WSTR(pEntryName.m_str, L"main");
+  VERIFY_ARE_EQUAL_WSTR(L"main", pEntryName.m_str);
 }
 
 TEST_F(CompilerTest, TestPdbUtilsWithEmptyDefine) {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2063,20 +2063,11 @@ TEST_F(CompilerTest, CompileSameFilenameAndEntryThenTestPdbUtilsArgs) {
   CComPtr<IDxcCompiler> pCompiler;
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
 
-// Use UTF8 for linux.
-#ifdef _WIN32
-  std::wstring shader = LR"x(
-    [RootSignature("")] float PSMain() : SV_Target {
-      return 0;
-    }
-  )x";
-#else
   std::string shader = R"x(
     [RootSignature("")] float PSMain() : SV_Target  {
       return 0;
     }
   )x";
-#endif
 
   CComPtr<IDxcUtils> pUtils;
   VERIFY_SUCCEEDED(DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&pUtils)));
@@ -2085,14 +2076,10 @@ TEST_F(CompilerTest, CompileSameFilenameAndEntryThenTestPdbUtilsArgs) {
 
   std::wstring EntryPoint = L"PSMain";
   CComPtr<IDxcBlobEncoding> pShaderBlob;
-#ifdef _WIN32
-  UINT32 codePage = DXC_CP_UTF16;
-#else
-  UINT32 codePage = DXC_CP_UTF8;
-#endif
+
   VERIFY_SUCCEEDED(pUtils->CreateBlob(shader.data(),
                                       shader.size() * sizeof(shader[0]),
-                                      codePage, &pShaderBlob));
+                                      DXC_CP_UTF8, &pShaderBlob));
 
   const WCHAR *OtherInputs[] = {
       L"AnotherInput1",

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -1249,7 +1249,6 @@ TEST_F(CompilerTest, CompileThenTestReflectionThreadSizeMS) {
   CompileThenTestReflectionThreadSize(source, L"ms_6_5", 2, 3, 1);
 }
 
-#ifdef _WIN32 // No PDBUtil support
 static void VerifyPdbUtil(
     dxc::DxcDllSupport &dllSupport, IDxcBlob *pBlob, IDxcPdbUtils *pPdbUtils,
     const WCHAR *pMainFileName,
@@ -1335,7 +1334,7 @@ static void VerifyPdbUtil(
   {
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetTargetProfile(&str));
-    VERIFY_ARE_EQUAL(str, L"ps_6_0");
+    VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"ps_6_0"));
   }
 
   // Entry point
@@ -1343,9 +1342,9 @@ static void VerifyPdbUtil(
     CComBSTR str;
     VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&str));
     if (TestEntryPoint) {
-      VERIFY_ARE_EQUAL(str, L"main");
+      VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"main"));
     } else {
-      VERIFY_ARE_EQUAL(str, L"PSMain");
+      VERIFY_ARE_EQUAL(0, wcscmp(str.m_str, L"PSMain"));
     }
   }
 
@@ -1362,9 +1361,9 @@ static void VerifyPdbUtil(
 
   // Main file name
   {
-    CComBSTR pMainFileName;
-    VERIFY_SUCCEEDED(pPdbUtils->GetMainFileName(&pMainFileName));
-    VERIFY_ARE_EQUAL(pMainFileName, pMainFileName);
+    CComBSTR pPdbMainFileName;
+    VERIFY_SUCCEEDED(pPdbUtils->GetMainFileName(&pPdbMainFileName));
+    VERIFY_ARE_EQUAL(0, wcscmp(pPdbMainFileName.m_str, pMainFileName));
   }
 
   // There is hash and hash is not empty
@@ -1550,6 +1549,8 @@ static void VerifyPdbUtil(
     VERIFY_IS_FALSE(pPdbUtils->IsFullPDB());
   }
 
+// Limit dia tests to Windows.
+#ifdef _WIN32
   // Now, test that dia interface doesn't crash (even if it fails).
   {
     CComPtr<IDiaDataSource> pDataSource;
@@ -1594,6 +1595,7 @@ static void VerifyPdbUtil(
       }
     }
   }
+#endif
 }
 
 TEST_F(CompilerTest, CompileThenTestPdbUtilsStripped) {
@@ -2061,11 +2063,20 @@ TEST_F(CompilerTest, CompileSameFilenameAndEntryThenTestPdbUtilsArgs) {
   CComPtr<IDxcCompiler> pCompiler;
   VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
 
+// Use UTF8 for linux.
+#ifdef _WIN32
   std::wstring shader = LR"x(
     [RootSignature("")] float PSMain() : SV_Target {
       return 0;
     }
   )x";
+#else
+  std::string shader = R"x(
+    [RootSignature("")] float PSMain() : SV_Target  {
+      return 0;
+    }
+  )x";
+#endif
 
   CComPtr<IDxcUtils> pUtils;
   VERIFY_SUCCEEDED(DxcCreateInstance(CLSID_DxcUtils, IID_PPV_ARGS(&pUtils)));
@@ -2074,9 +2085,14 @@ TEST_F(CompilerTest, CompileSameFilenameAndEntryThenTestPdbUtilsArgs) {
 
   std::wstring EntryPoint = L"PSMain";
   CComPtr<IDxcBlobEncoding> pShaderBlob;
+#ifdef _WIN32
+  UINT32 codePage = DXC_CP_UTF16;
+#else
+  UINT32 codePage = DXC_CP_UTF8;
+#endif
   VERIFY_SUCCEEDED(pUtils->CreateBlob(shader.data(),
                                       shader.size() * sizeof(shader[0]),
-                                      DXC_CP_UTF16, &pShaderBlob));
+                                      codePage, &pShaderBlob));
 
   const WCHAR *OtherInputs[] = {
       L"AnotherInput1",
@@ -2182,7 +2198,7 @@ TEST_F(CompilerTest, CompileThenTestPdbUtilsEmptyEntry) {
   CComBSTR pEntryName;
   VERIFY_SUCCEEDED(pPdbUtils->GetEntryPoint(&pEntryName));
 
-  VERIFY_ARE_EQUAL(pEntryName, L"main");
+  VERIFY_ARE_EQUAL(0, wcscmp(pEntryName.m_str, L"main"));
 }
 
 TEST_F(CompilerTest, TestPdbUtilsWithEmptyDefine) {
@@ -2206,8 +2222,6 @@ TEST_F(CompilerTest, TestPdbUtilsWithEmptyDefine) {
     VERIFY_SUCCEEDED(pPdbUtils->GetDefine(i, &pDefine));
   }
 }
-
-#endif //  _WIN32 - No PDBUtil support
 
 void CompilerTest::TestResourceBindingImpl(const char *bindingFileContent,
                                            const std::wstring &errors,


### PR DESCRIPTION
Added CComBSTR::Length for WinAdapter.

Use VERIFY_ARE_EQUAL_WSTR to verify CComBSTR.

Use UTF8 for Linux test.

This is for #5877