### PR TITLE
Fix RDAT table versioning for ver 1.8

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -205,6 +205,13 @@ enum class ShaderKind {
   Amplification,
   Node,
   Invalid,
+
+  // Last* values identify the last shader kind recognized by the highest
+  // validator version before additional kinds were added.
+  Last_1_2 = Compute,
+  Last_1_4 = Callable,
+  Last_1_7 = Amplification,
+  LastValid = Node,
 };
 
 // clang-format off

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -62,6 +62,16 @@ enum class RuntimeDataPartType : uint32_t {
   Last_1_4 = SubobjectTable,
 
   // PRERELEASE-TODO: assign values explicitly to all enums before release
+  NodeIDTable = 7,
+  NodeShaderIOAttribTable = 8,
+  NodeShaderFuncAttribTable = 9,
+  IONodeTable = 10,
+  NodeShaderInfoTable = 11,
+
+  Last_1_8 = NodeShaderInfoTable, // PRERELEASE-TODO: change to last
+                                  // necessary 1.8 part before release.
+
+  // Insert experimental here.
   SignatureElementTable,
   VSInfoTable,
   PSInfoTable,
@@ -71,16 +81,6 @@ enum class RuntimeDataPartType : uint32_t {
   CSInfoTable,
   MSInfoTable,
   ASInfoTable,
-
-  NodeIDTable,
-  NodeShaderIOAttribTable,
-  NodeShaderFuncAttribTable,
-  IONodeTable,
-  NodeShaderInfoTable,
-
-  Last_1_8 = NodeShaderInfoTable, // PRERELEASE-TODO: change to last
-                                  // necessary 1.8 part before release.
-  // Insert experimental here.
 
   LastPlus1,
   LastExperimental = LastPlus1 - 1,
@@ -110,15 +110,6 @@ enum class RecordTableIndex : unsigned {
   FunctionTable,
   SubobjectTable,
 
-  SignatureElementTable,
-  VSInfoTable,
-  PSInfoTable,
-  HSInfoTable,
-  DSInfoTable,
-  GSInfoTable,
-  CSInfoTable,
-  MSInfoTable,
-  ASInfoTable,
   NodeIDTable,
   NodeShaderIOAttribTable,
   NodeShaderFuncAttribTable,
@@ -128,6 +119,16 @@ enum class RecordTableIndex : unsigned {
   DxilPdbInfoTable,
   DxilPdbInfoSourceTable,
   DxilPdbInfoLibraryTable,
+
+  SignatureElementTable,
+  VSInfoTable,
+  PSInfoTable,
+  HSInfoTable,
+  DSInfoTable,
+  GSInfoTable,
+  CSInfoTable,
+  MSInfoTable,
+  ASInfoTable,
 
   RecordTableCount
 };

--- a/include/dxc/DxilContainer/DxilRuntimeReflection.h
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.h
@@ -61,15 +61,12 @@ enum class RuntimeDataPartType : uint32_t {
   SubobjectTable = 6,
   Last_1_4 = SubobjectTable,
 
-  // PRERELEASE-TODO: assign values explicitly to all enums before release
   NodeIDTable = 7,
   NodeShaderIOAttribTable = 8,
   NodeShaderFuncAttribTable = 9,
   IONodeTable = 10,
   NodeShaderInfoTable = 11,
-
-  Last_1_8 = NodeShaderInfoTable, // PRERELEASE-TODO: change to last
-                                  // necessary 1.8 part before release.
+  Last_1_8 = NodeShaderInfoTable,
 
   // Insert experimental here.
   SignatureElementTable,

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -24,40 +24,6 @@ RDAT_ENUM_START(DxilResourceFlag, uint32_t)
   RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
 RDAT_ENUM_END()
 
-RDAT_ENUM_START(DxilShaderFlags, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
-  // End of values supported by validator version 1.8
-  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
-  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
-  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
-  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(ID, 1)
-  RDAT_ENUM_VALUE(NumThreads, 2)
-  RDAT_ENUM_VALUE(ShareInputOf, 3)
-  RDAT_ENUM_VALUE(DispatchGrid, 4)
-  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
-  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
-  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(OutputID, 1)
-  RDAT_ENUM_VALUE(MaxRecords, 2)
-  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
-  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
-  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
-  RDAT_ENUM_VALUE(OutputArraySize, 6)
-  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
-RDAT_ENUM_END()
-
 #endif // DEF_RDAT_ENUMS
 
 #ifdef DEF_DXIL_ENUMS
@@ -132,116 +98,6 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
 #endif
 RDAT_ENUM_END()
 
-RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
-  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
-  // SemanticKind-ENUM:BEGIN
-  RDAT_ENUM_VALUE_NODEF(Arbitrary)
-  RDAT_ENUM_VALUE_NODEF(VertexID)
-  RDAT_ENUM_VALUE_NODEF(InstanceID)
-  RDAT_ENUM_VALUE_NODEF(Position)
-  RDAT_ENUM_VALUE_NODEF(RenderTargetArrayIndex)
-  RDAT_ENUM_VALUE_NODEF(ViewPortArrayIndex)
-  RDAT_ENUM_VALUE_NODEF(ClipDistance)
-  RDAT_ENUM_VALUE_NODEF(CullDistance)
-  RDAT_ENUM_VALUE_NODEF(OutputControlPointID)
-  RDAT_ENUM_VALUE_NODEF(DomainLocation)
-  RDAT_ENUM_VALUE_NODEF(PrimitiveID)
-  RDAT_ENUM_VALUE_NODEF(GSInstanceID)
-  RDAT_ENUM_VALUE_NODEF(SampleIndex)
-  RDAT_ENUM_VALUE_NODEF(IsFrontFace)
-  RDAT_ENUM_VALUE_NODEF(Coverage)
-  RDAT_ENUM_VALUE_NODEF(InnerCoverage)
-  RDAT_ENUM_VALUE_NODEF(Target)
-  RDAT_ENUM_VALUE_NODEF(Depth)
-  RDAT_ENUM_VALUE_NODEF(DepthLessEqual)
-  RDAT_ENUM_VALUE_NODEF(DepthGreaterEqual)
-  RDAT_ENUM_VALUE_NODEF(StencilRef)
-  RDAT_ENUM_VALUE_NODEF(DispatchThreadID)
-  RDAT_ENUM_VALUE_NODEF(GroupID)
-  RDAT_ENUM_VALUE_NODEF(GroupIndex)
-  RDAT_ENUM_VALUE_NODEF(GroupThreadID)
-  RDAT_ENUM_VALUE_NODEF(TessFactor)
-  RDAT_ENUM_VALUE_NODEF(InsideTessFactor)
-  RDAT_ENUM_VALUE_NODEF(ViewID)
-  RDAT_ENUM_VALUE_NODEF(Barycentrics)
-  RDAT_ENUM_VALUE_NODEF(ShadingRate)
-  RDAT_ENUM_VALUE_NODEF(CullPrimitive)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  // SemanticKind-ENUM:END
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(I1)
-  RDAT_ENUM_VALUE_NODEF(I16)
-  RDAT_ENUM_VALUE_NODEF(U16)
-  RDAT_ENUM_VALUE_NODEF(I32)
-  RDAT_ENUM_VALUE_NODEF(U32)
-  RDAT_ENUM_VALUE_NODEF(I64)
-  RDAT_ENUM_VALUE_NODEF(U64)
-  RDAT_ENUM_VALUE_NODEF(F16)
-  RDAT_ENUM_VALUE_NODEF(F32)
-  RDAT_ENUM_VALUE_NODEF(F64)
-  RDAT_ENUM_VALUE_NODEF(SNormF16)
-  RDAT_ENUM_VALUE_NODEF(UNormF16)
-  RDAT_ENUM_VALUE_NODEF(SNormF32)
-  RDAT_ENUM_VALUE_NODEF(UNormF32)
-  RDAT_ENUM_VALUE_NODEF(SNormF64)
-  RDAT_ENUM_VALUE_NODEF(UNormF64)
-  RDAT_ENUM_VALUE_NODEF(PackedS8x32)
-  RDAT_ENUM_VALUE_NODEF(PackedU8x32)
-  RDAT_ENUM_VALUE_NODEF(LastEntry)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Undefined)
-  RDAT_ENUM_VALUE_NODEF(Constant)
-  RDAT_ENUM_VALUE_NODEF(Linear)
-  RDAT_ENUM_VALUE_NODEF(LinearCentroid)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspective)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveCentroid)
-  RDAT_ENUM_VALUE_NODEF(LinearSample)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(EmptyInput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
-  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(Broadcasting)
-  RDAT_ENUM_VALUE_NODEF(Coalescing)
-  RDAT_ENUM_VALUE_NODEF(Thread)
-  RDAT_ENUM_VALUE_NODEF(LastEntry)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
 #endif // DEF_DXIL_ENUMS
 
 #ifdef DEF_RDAT_TYPES
@@ -311,144 +167,86 @@ RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-#define RECORD_TYPE SignatureElement
-RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
-  RDAT_STRING(SemanticName)
-  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
-  RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
-  RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
-  RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
-  RDAT_VALUE(
-      uint8_t,
-      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
-  // TODO: use struct with bitfields or accessors for ColsAndStream and
-  // UsageAndDynIndexMasks
-  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
-                                     // (0-3), 4:6 = OutputStream (0-3)
-  RDAT_VALUE(uint8_t,
-             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
-#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
-  uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
-  uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
-  uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
-  uint8_t GetDynamicIndexMask() const {
-    return (UsageAndDynIndexMasks >> 4) & 0xF;
-  }
-  void SetCols(unsigned cols) {
-    ColsAndStream &= ~3;
-    ColsAndStream |= (cols - 1) & 3;
-  }
-  void SetStartCol(unsigned col) {
-    ColsAndStream &= ~(3 << 2);
-    ColsAndStream |= (col & 3) << 2;
-  }
-  void SetOutputStream(unsigned stream) {
-    ColsAndStream &= ~(3 << 4);
-    ColsAndStream |= (stream & 3) << 4;
-  }
-  void SetUsageMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~0xF;
-    UsageAndDynIndexMasks |= mask & 0xF;
-  }
-  void SetDynamicIndexMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~(0xF << 4);
-    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
-  }
+#endif // DEF_RDAT_TYPES
+
+
+//////////////////////////////////////////////////////////////////////
+// The following require validator version 1.8 and above.
+
+// ------------ RuntimeDataFunctionInfo2 dependencies ------------
+
+#ifdef DEF_RDAT_ENUMS
+
+RDAT_ENUM_START(DxilShaderFlags, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+  // End of values supported by validator version 1.8
+  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(ID, 1)
+  RDAT_ENUM_VALUE(NumThreads, 2)
+  RDAT_ENUM_VALUE(ShareInputOf, 3)
+  RDAT_ENUM_VALUE(DispatchGrid, 4)
+  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(OutputID, 1)
+  RDAT_ENUM_VALUE(MaxRecords, 2)
+  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+  RDAT_ENUM_VALUE(OutputArraySize, 6)
+  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+#endif // DEF_RDAT_ENUMS
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(EmptyInput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
+  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Broadcasting)
+  RDAT_ENUM_VALUE_NODEF(Coalescing)
+  RDAT_ENUM_VALUE_NODEF(Thread)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
+RDAT_ENUM_END()
 
-#define RECORD_TYPE VSInfo
-RDAT_STRUCT_TABLE(VSInfo, VSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
+#endif // DEF_DXIL_ENUMS
 
-#define RECORD_TYPE PSInfo
-RDAT_STRUCT_TABLE(PSInfo, PSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE HSInfo
-RDAT_STRUCT_TABLE(HSInfo, HSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(ViewIDPatchConstOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_BYTES(InputToPatchConstOutputMasks)
-  RDAT_VALUE(uint8_t, InputControlPointCount)
-  RDAT_VALUE(uint8_t, OutputControlPointCount)
-  RDAT_VALUE(uint8_t, TessellatorDomain)
-  RDAT_VALUE(uint8_t, TessellatorOutputPrimitive)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE DSInfo
-RDAT_STRUCT_TABLE(DSInfo, DSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstInputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_BYTES(PatchConstInputToOutputMasks)
-  RDAT_VALUE(uint8_t, InputControlPointCount)
-  RDAT_VALUE(uint8_t, TessellatorDomain)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE GSInfo
-RDAT_STRUCT_TABLE(GSInfo, GSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_VALUE(uint8_t, InputPrimitive)
-  RDAT_VALUE(uint8_t, OutputTopology)
-  RDAT_VALUE(uint8_t, MaxVertexCount)
-  RDAT_VALUE(uint8_t, OutputStreamMask)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE CSInfo
-RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE MSInfo
-RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(ViewIDPrimOutputMask)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-  RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
-  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
-  RDAT_VALUE(uint16_t, MaxOutputVertices)
-  RDAT_VALUE(uint16_t, MaxOutputPrimitives)
-  RDAT_VALUE(uint8_t, MeshOutputTopology)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE ASInfo
-RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
+#ifdef DEF_RDAT_TYPES
 
 #define RECORD_TYPE RecordDispatchGrid
 RDAT_STRUCT(RecordDispatchGrid)
@@ -617,6 +415,239 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+
+///////////////////////////////////////////////////////////////////////////////
+// The following are experimental, and are not currently supported on any
+// validator version.
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
+  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
+  // SemanticKind-ENUM:BEGIN
+  RDAT_ENUM_VALUE_NODEF(Arbitrary)
+  RDAT_ENUM_VALUE_NODEF(VertexID)
+  RDAT_ENUM_VALUE_NODEF(InstanceID)
+  RDAT_ENUM_VALUE_NODEF(Position)
+  RDAT_ENUM_VALUE_NODEF(RenderTargetArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ViewPortArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ClipDistance)
+  RDAT_ENUM_VALUE_NODEF(CullDistance)
+  RDAT_ENUM_VALUE_NODEF(OutputControlPointID)
+  RDAT_ENUM_VALUE_NODEF(DomainLocation)
+  RDAT_ENUM_VALUE_NODEF(PrimitiveID)
+  RDAT_ENUM_VALUE_NODEF(GSInstanceID)
+  RDAT_ENUM_VALUE_NODEF(SampleIndex)
+  RDAT_ENUM_VALUE_NODEF(IsFrontFace)
+  RDAT_ENUM_VALUE_NODEF(Coverage)
+  RDAT_ENUM_VALUE_NODEF(InnerCoverage)
+  RDAT_ENUM_VALUE_NODEF(Target)
+  RDAT_ENUM_VALUE_NODEF(Depth)
+  RDAT_ENUM_VALUE_NODEF(DepthLessEqual)
+  RDAT_ENUM_VALUE_NODEF(DepthGreaterEqual)
+  RDAT_ENUM_VALUE_NODEF(StencilRef)
+  RDAT_ENUM_VALUE_NODEF(DispatchThreadID)
+  RDAT_ENUM_VALUE_NODEF(GroupID)
+  RDAT_ENUM_VALUE_NODEF(GroupIndex)
+  RDAT_ENUM_VALUE_NODEF(GroupThreadID)
+  RDAT_ENUM_VALUE_NODEF(TessFactor)
+  RDAT_ENUM_VALUE_NODEF(InsideTessFactor)
+  RDAT_ENUM_VALUE_NODEF(ViewID)
+  RDAT_ENUM_VALUE_NODEF(Barycentrics)
+  RDAT_ENUM_VALUE_NODEF(ShadingRate)
+  RDAT_ENUM_VALUE_NODEF(CullPrimitive)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  // SemanticKind-ENUM:END
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(I1)
+  RDAT_ENUM_VALUE_NODEF(I16)
+  RDAT_ENUM_VALUE_NODEF(U16)
+  RDAT_ENUM_VALUE_NODEF(I32)
+  RDAT_ENUM_VALUE_NODEF(U32)
+  RDAT_ENUM_VALUE_NODEF(I64)
+  RDAT_ENUM_VALUE_NODEF(U64)
+  RDAT_ENUM_VALUE_NODEF(F16)
+  RDAT_ENUM_VALUE_NODEF(F32)
+  RDAT_ENUM_VALUE_NODEF(F64)
+  RDAT_ENUM_VALUE_NODEF(SNormF16)
+  RDAT_ENUM_VALUE_NODEF(UNormF16)
+  RDAT_ENUM_VALUE_NODEF(SNormF32)
+  RDAT_ENUM_VALUE_NODEF(UNormF32)
+  RDAT_ENUM_VALUE_NODEF(SNormF64)
+  RDAT_ENUM_VALUE_NODEF(UNormF64)
+  RDAT_ENUM_VALUE_NODEF(PackedS8x32)
+  RDAT_ENUM_VALUE_NODEF(PackedU8x32)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Undefined)
+  RDAT_ENUM_VALUE_NODEF(Constant)
+  RDAT_ENUM_VALUE_NODEF(Linear)
+  RDAT_ENUM_VALUE_NODEF(LinearCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspective)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearSample)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE SignatureElement
+RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
+  RDAT_STRING(SemanticName)
+  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
+  RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
+  RDAT_VALUE(
+      uint8_t,
+      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and
+  // UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
+                                     // (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t,
+             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
+  uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
+  uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
+  uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
+  uint8_t GetDynamicIndexMask() const {
+    return (UsageAndDynIndexMasks >> 4) & 0xF;
+  }
+  void SetCols(unsigned cols) {
+    ColsAndStream &= ~3;
+    ColsAndStream |= (cols - 1) & 3;
+  }
+  void SetStartCol(unsigned col) {
+    ColsAndStream &= ~(3 << 2);
+    ColsAndStream |= (col & 3) << 2;
+  }
+  void SetOutputStream(unsigned stream) {
+    ColsAndStream &= ~(3 << 4);
+    ColsAndStream |= (stream & 3) << 4;
+  }
+  void SetUsageMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~0xF;
+    UsageAndDynIndexMasks |= mask & 0xF;
+  }
+  void SetDynamicIndexMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~(0xF << 4);
+    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE VSInfo
+RDAT_STRUCT_TABLE(VSInfo, VSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE PSInfo
+RDAT_STRUCT_TABLE(PSInfo, PSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE HSInfo
+RDAT_STRUCT_TABLE(HSInfo, HSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPatchConstOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(InputToPatchConstOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, OutputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+  RDAT_VALUE(uint8_t, TessellatorOutputPrimitive)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE DSInfo
+RDAT_STRUCT_TABLE(DSInfo, DSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstInputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(PatchConstInputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE GSInfo
+RDAT_STRUCT_TABLE(GSInfo, GSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputPrimitive)
+  RDAT_VALUE(uint8_t, OutputTopology)
+  RDAT_VALUE(uint8_t, MaxVertexCount)
+  RDAT_VALUE(uint8_t, OutputStreamMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE CSInfo
+RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE MSInfo
+RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPrimOutputMask)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+  RDAT_VALUE(uint16_t, MaxOutputVertices)
+  RDAT_VALUE(uint16_t, MaxOutputPrimitives)
+  RDAT_VALUE(uint8_t, MeshOutputTopology)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE ASInfo
+RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -115,6 +115,8 @@ RDAT_STRUCT_TABLE(RuntimeDataResourceInfo, ResourceTable)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
+// ------------ RuntimeDataFunctionInfo ------------
+
 #define RECORD_TYPE RuntimeDataFunctionInfo
 RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
   // full function name
@@ -386,7 +388,32 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
   RDAT_VALUE(uint8_t, MaximumExpectedWaveLaneCount) // 0 = none specified
   RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
 
-  RDAT_RECORD_REF(NodeShaderInfo, Node)
+  RDAT_UNION()
+    RDAT_UNION_IF(RawShaderRef,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
+      RDAT_VALUE(uint32_t, RawShaderRef)
+    RDAT_UNION_ELIF(Node, (getShaderKind() == hlsl::DXIL::ShaderKind::Node))
+      RDAT_RECORD_REF(NodeShaderInfo, Node)
+    // End of values supported by validator version 1.8
+    RDAT_UNION_ELIF(VS, (getShaderKind() == hlsl::DXIL::ShaderKind::Vertex))
+      RDAT_RECORD_REF(VSInfo, VS)
+    RDAT_UNION_ELIF(PS, (getShaderKind() == hlsl::DXIL::ShaderKind::Pixel))
+      RDAT_RECORD_REF(PSInfo, PS)
+    RDAT_UNION_ELIF(HS, (getShaderKind() == hlsl::DXIL::ShaderKind::Hull))
+      RDAT_RECORD_REF(HSInfo, HS)
+    RDAT_UNION_ELIF(DS, (getShaderKind() == hlsl::DXIL::ShaderKind::Domain))
+      RDAT_RECORD_REF(DSInfo, DS)
+    RDAT_UNION_ELIF(GS, (getShaderKind() == hlsl::DXIL::ShaderKind::Geometry))
+      RDAT_RECORD_REF(GSInfo, GS)
+    RDAT_UNION_ELIF(CS, (getShaderKind() == hlsl::DXIL::ShaderKind::Compute))
+      RDAT_RECORD_REF(CSInfo, CS)
+    RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
+      RDAT_RECORD_REF(MSInfo, MS)
+    RDAT_UNION_ELIF(AS,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
+      RDAT_RECORD_REF(ASInfo, AS)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
 
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -397,8 +424,6 @@ RDAT_STRUCT_END()
 ///////////////////////////////////////////////////////////////////////////////
 // The following are experimental, and are not currently supported on any
 // validator version.
-
-// ------------ RuntimeDataFunctionInfo3 dependencies ------------
 
 #ifdef DEF_DXIL_ENUMS
 
@@ -623,39 +648,6 @@ RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
                                    // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-// ------------ RuntimeDataFunctionInfo3 ------------
-
-#define RECORD_TYPE RuntimeDataFunctionInfo3
-RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo3, RuntimeDataFunctionInfo2,
-                          FunctionTable)
-
-  RDAT_UNION()
-    RDAT_UNION_IF(VS, (getShaderKind() == hlsl::DXIL::ShaderKind::Vertex))
-      RDAT_RECORD_REF(VSInfo, VS)
-    RDAT_UNION_ELIF(PS, (getShaderKind() == hlsl::DXIL::ShaderKind::Pixel))
-      RDAT_RECORD_REF(PSInfo, PS)
-    RDAT_UNION_ELIF(HS, (getShaderKind() == hlsl::DXIL::ShaderKind::Hull))
-      RDAT_RECORD_REF(HSInfo, HS)
-    RDAT_UNION_ELIF(DS, (getShaderKind() == hlsl::DXIL::ShaderKind::Domain))
-      RDAT_RECORD_REF(DSInfo, DS)
-    RDAT_UNION_ELIF(GS, (getShaderKind() == hlsl::DXIL::ShaderKind::Geometry))
-      RDAT_RECORD_REF(GSInfo, GS)
-    RDAT_UNION_ELIF(CS, (getShaderKind() == hlsl::DXIL::ShaderKind::Compute))
-      RDAT_RECORD_REF(CSInfo, CS)
-    RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
-      RDAT_RECORD_REF(MSInfo, MS)
-    RDAT_UNION_ELIF(AS,
-                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
-      RDAT_RECORD_REF(ASInfo, AS)
-    RDAT_UNION_ELIF(RawShaderRef,
-                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
-      RDAT_VALUE(uint32_t, RawShaderRef)
-    RDAT_UNION_ENDIF()
-  RDAT_UNION_END()
-
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -16,46 +16,46 @@
 #ifdef DEF_RDAT_ENUMS
 
 RDAT_ENUM_START(DxilResourceFlag, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
-  RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
-  RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
-  RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
-  RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
+RDAT_ENUM_VALUE(None, 0)
+RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
+RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
+RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
+RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
+RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(DxilShaderFlags, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
-  // End of values supported by validator version 1.8
-  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
-  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
-  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
-  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+RDAT_ENUM_VALUE(None, 0)
+RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+// End of values supported by validator version 1.8
+RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(ID, 1)
-  RDAT_ENUM_VALUE(NumThreads, 2)
-  RDAT_ENUM_VALUE(ShareInputOf, 3)
-  RDAT_ENUM_VALUE(DispatchGrid, 4)
-  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
-  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
-  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_VALUE(None, 0)
+RDAT_ENUM_VALUE(ID, 1)
+RDAT_ENUM_VALUE(NumThreads, 2)
+RDAT_ENUM_VALUE(ShareInputOf, 3)
+RDAT_ENUM_VALUE(DispatchGrid, 4)
+RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(NodeAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(OutputID, 1)
-  RDAT_ENUM_VALUE(MaxRecords, 2)
-  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
-  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
-  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
-  RDAT_ENUM_VALUE(OutputArraySize, 6)
-  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_VALUE(None, 0)
+RDAT_ENUM_VALUE(OutputID, 1)
+RDAT_ENUM_VALUE(MaxRecords, 2)
+RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+RDAT_ENUM_VALUE(OutputArraySize, 6)
+RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
 #endif // DEF_RDAT_ENUMS
@@ -70,65 +70,65 @@ RDAT_ENUM_END()
 // making sure this definition is updated as well.
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceClass, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(SRV)
-  RDAT_ENUM_VALUE_NODEF(UAV)
-  RDAT_ENUM_VALUE_NODEF(CBuffer)
-  RDAT_ENUM_VALUE_NODEF(Sampler)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_VALUE_NODEF(SRV)
+RDAT_ENUM_VALUE_NODEF(UAV)
+RDAT_ENUM_VALUE_NODEF(CBuffer)
+RDAT_ENUM_VALUE_NODEF(Sampler)
+RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
+              "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceKind, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(Texture1D)
-  RDAT_ENUM_VALUE_NODEF(Texture2D)
-  RDAT_ENUM_VALUE_NODEF(Texture2DMS)
-  RDAT_ENUM_VALUE_NODEF(Texture3D)
-  RDAT_ENUM_VALUE_NODEF(TextureCube)
-  RDAT_ENUM_VALUE_NODEF(Texture1DArray)
-  RDAT_ENUM_VALUE_NODEF(Texture2DArray)
-  RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
-  RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
-  RDAT_ENUM_VALUE_NODEF(TypedBuffer)
-  RDAT_ENUM_VALUE_NODEF(RawBuffer)
-  RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
-  RDAT_ENUM_VALUE_NODEF(CBuffer)
-  RDAT_ENUM_VALUE_NODEF(Sampler)
-  RDAT_ENUM_VALUE_NODEF(TBuffer)
-  RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
-  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
-  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
-  RDAT_ENUM_VALUE_NODEF(NumEntries)
+RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_VALUE_NODEF(Texture1D)
+RDAT_ENUM_VALUE_NODEF(Texture2D)
+RDAT_ENUM_VALUE_NODEF(Texture2DMS)
+RDAT_ENUM_VALUE_NODEF(Texture3D)
+RDAT_ENUM_VALUE_NODEF(TextureCube)
+RDAT_ENUM_VALUE_NODEF(Texture1DArray)
+RDAT_ENUM_VALUE_NODEF(Texture2DArray)
+RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
+RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
+RDAT_ENUM_VALUE_NODEF(TypedBuffer)
+RDAT_ENUM_VALUE_NODEF(RawBuffer)
+RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
+RDAT_ENUM_VALUE_NODEF(CBuffer)
+RDAT_ENUM_VALUE_NODEF(Sampler)
+RDAT_ENUM_VALUE_NODEF(TBuffer)
+RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
+RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
+RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
+RDAT_ENUM_VALUE_NODEF(NumEntries)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
+              "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Pixel)
-  RDAT_ENUM_VALUE_NODEF(Vertex)
-  RDAT_ENUM_VALUE_NODEF(Geometry)
-  RDAT_ENUM_VALUE_NODEF(Hull)
-  RDAT_ENUM_VALUE_NODEF(Domain)
-  RDAT_ENUM_VALUE_NODEF(Compute)
-  RDAT_ENUM_VALUE_NODEF(Library)
-  RDAT_ENUM_VALUE_NODEF(RayGeneration)
-  RDAT_ENUM_VALUE_NODEF(Intersection)
-  RDAT_ENUM_VALUE_NODEF(AnyHit)
-  RDAT_ENUM_VALUE_NODEF(ClosestHit)
-  RDAT_ENUM_VALUE_NODEF(Miss)
-  RDAT_ENUM_VALUE_NODEF(Callable)
-  RDAT_ENUM_VALUE_NODEF(Mesh)
-  RDAT_ENUM_VALUE_NODEF(Amplification)
-  RDAT_ENUM_VALUE_NODEF(Node)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_VALUE_NODEF(Pixel)
+RDAT_ENUM_VALUE_NODEF(Vertex)
+RDAT_ENUM_VALUE_NODEF(Geometry)
+RDAT_ENUM_VALUE_NODEF(Hull)
+RDAT_ENUM_VALUE_NODEF(Domain)
+RDAT_ENUM_VALUE_NODEF(Compute)
+RDAT_ENUM_VALUE_NODEF(Library)
+RDAT_ENUM_VALUE_NODEF(RayGeneration)
+RDAT_ENUM_VALUE_NODEF(Intersection)
+RDAT_ENUM_VALUE_NODEF(AnyHit)
+RDAT_ENUM_VALUE_NODEF(ClosestHit)
+RDAT_ENUM_VALUE_NODEF(Miss)
+RDAT_ENUM_VALUE_NODEF(Callable)
+RDAT_ENUM_VALUE_NODEF(Mesh)
+RDAT_ENUM_VALUE_NODEF(Amplification)
+RDAT_ENUM_VALUE_NODEF(Node)
+RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
+              "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -192,8 +192,7 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(PackedU8x32)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -208,8 +207,7 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
   RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
   RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -237,8 +235,7 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(Thread)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -314,47 +311,25 @@ RDAT_STRUCT_END()
 #define RECORD_TYPE SignatureElement
 RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
   RDAT_STRING(SemanticName)
-  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
+  RDAT_INDEX_ARRAY_REF(SemanticIndices)         // Rows = SemanticIndices.Count()
   RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
   RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
   RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
-  RDAT_VALUE(
-      uint8_t,
-      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
-  // TODO: use struct with bitfields or accessors for ColsAndStream and
-  // UsageAndDynIndexMasks
-  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
-                                     // (0-3), 4:6 = OutputStream (0-3)
-  RDAT_VALUE(uint8_t,
-             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+  RDAT_VALUE(uint8_t, StartRow)                 // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream)            // 0:2 = (Cols-1) (0-3), 2:4 = StartCol (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t, UsageAndDynIndexMasks)    // 0:4 = UsageMask, 4:8 = DynamicIndexMask
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
   uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
   uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
   uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
   uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
-  uint8_t GetDynamicIndexMask() const {
-    return (UsageAndDynIndexMasks >> 4) & 0xF;
-  }
-  void SetCols(unsigned cols) {
-    ColsAndStream &= ~3;
-    ColsAndStream |= (cols - 1) & 3;
-  }
-  void SetStartCol(unsigned col) {
-    ColsAndStream &= ~(3 << 2);
-    ColsAndStream |= (col & 3) << 2;
-  }
-  void SetOutputStream(unsigned stream) {
-    ColsAndStream &= ~(3 << 4);
-    ColsAndStream |= (stream & 3) << 4;
-  }
-  void SetUsageMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~0xF;
-    UsageAndDynIndexMasks |= mask & 0xF;
-  }
-  void SetDynamicIndexMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~(0xF << 4);
-    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
-  }
+  uint8_t GetDynamicIndexMask() const { return (UsageAndDynIndexMasks >> 4) & 0xF; }
+  void SetCols(unsigned cols) { ColsAndStream &= ~3; ColsAndStream |= (cols - 1) & 3; }
+  void SetStartCol(unsigned col) { ColsAndStream &= ~(3 << 2); ColsAndStream |= (col & 3) << 2; }
+  void SetOutputStream(unsigned stream) { ColsAndStream &= ~(3 << 4); ColsAndStream |= (stream & 3) << 4; }
+  void SetUsageMask(unsigned mask) { UsageAndDynIndexMasks &= ~0xF; UsageAndDynIndexMasks |= mask & 0xF; }
+  void SetDynamicIndexMask(unsigned mask) { UsageAndDynIndexMasks &= ~(0xF << 4); UsageAndDynIndexMasks |= (mask & 0xF) << 4; }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -418,8 +393,7 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE CSInfo
 RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -430,8 +404,7 @@ RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
   RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
   RDAT_BYTES(ViewIDOutputMask)
   RDAT_BYTES(ViewIDPrimOutputMask)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
@@ -443,8 +416,7 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE ASInfo
 RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
 RDAT_STRUCT_END()
@@ -453,17 +425,12 @@ RDAT_STRUCT_END()
 #define RECORD_TYPE RecordDispatchGrid
 RDAT_STRUCT(RecordDispatchGrid)
   RDAT_VALUE(uint16_t, ByteOffset)
-  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 =
-                                          // hlsl::DXIL::ComponentType enum
+  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 = hlsl::DXIL::ComponentType enum
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
   uint8_t GetNumComponents() const { return (ComponentNumAndType & 0x3); }
-  hlsl::DXIL::ComponentType GetComponentType() const {
-    return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2);
-  }
+  hlsl::DXIL::ComponentType GetComponentType() const { return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2); }
   void SetNumComponents(uint8_t num) { ComponentNumAndType |= (num & 0x3); }
-  void SetComponentType(hlsl::DXIL::ComponentType type) {
-    ComponentNumAndType |= (((uint16_t)type) << 2);
-  }
+  void SetComponentType(hlsl::DXIL::ComponentType type) { ComponentNumAndType |= (((uint16_t)type) << 2); }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -475,41 +442,30 @@ RDAT_STRUCT_TABLE(NodeID, NodeIDTable)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
+
 #define RECORD_TYPE NodeShaderFuncAttrib
 RDAT_STRUCT_TABLE(NodeShaderFuncAttrib, NodeShaderFuncAttribTable)
   RDAT_ENUM(uint32_t, hlsl::RDAT::NodeFuncAttribKind, AttribKind)
   RDAT_UNION()
     RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ID)
       RDAT_RECORD_REF(NodeID, ID)
-    RDAT_UNION_ELIF(NumThreads, getAttribKind() ==
-                                    hlsl::RDAT::NodeFuncAttribKind::NumThreads)
-      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3
-                                       // elements, default value is 1
-    RDAT_UNION_ELIF(SharedInput,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
+    RDAT_UNION_ELIF(NumThreads, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::NumThreads)
+      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+    RDAT_UNION_ELIF(SharedInput, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
       RDAT_RECORD_REF(NodeID, ShareInputOf)
-    RDAT_UNION_ELIF(DispatchGrid,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
+    RDAT_UNION_ELIF(DispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
       RDAT_INDEX_ARRAY_REF(DispatchGrid)
-    RDAT_UNION_ELIF(MaxRecursionDepth,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
+    RDAT_UNION_ELIF(MaxRecursionDepth, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
       RDAT_VALUE(uint32_t, MaxRecursionDepth)
-    RDAT_UNION_ELIF(
-        LocalRootArgumentsTableIndex,
-        getAttribKind() ==
-            hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
+    RDAT_UNION_ELIF(LocalRootArgumentsTableIndex, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
       RDAT_VALUE(uint32_t, LocalRootArgumentsTableIndex)
-    RDAT_UNION_ELIF(MaxDispatchGrid,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
+    RDAT_UNION_ELIF(MaxDispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
       RDAT_INDEX_ARRAY_REF(MaxDispatchGrid)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
+
 
 #define RECORD_TYPE NodeShaderIOAttrib
 RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
@@ -517,52 +473,36 @@ RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
   RDAT_UNION()
     RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputID)
       RDAT_RECORD_REF(NodeID, OutputID)
-    RDAT_UNION_ELIF(MaxRecords,
-                    getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
+    RDAT_UNION_ELIF(MaxRecords, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
       RDAT_VALUE(uint32_t, MaxRecords)
-    RDAT_UNION_ELIF(MaxRecordsSharedWith,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
+    RDAT_UNION_ELIF(MaxRecordsSharedWith, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
       RDAT_VALUE(uint32_t, MaxRecordsSharedWith)
-    RDAT_UNION_ELIF(RecordSizeInBytes,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
+    RDAT_UNION_ELIF(RecordSizeInBytes, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
       RDAT_VALUE(uint32_t, RecordSizeInBytes)
-    RDAT_UNION_ELIF(RecordDispatchGrid,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
+    RDAT_UNION_ELIF(RecordDispatchGrid, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
       RDAT_RECORD_VALUE(RecordDispatchGrid, RecordDispatchGrid)
-    RDAT_UNION_ELIF(OutputArraySize,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeAttribKind::OutputArraySize)
+    RDAT_UNION_ELIF(OutputArraySize, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputArraySize)
       RDAT_VALUE(uint32_t, OutputArraySize)
-    RDAT_UNION_ELIF(AllowSparseNodes,
-                    getAttribKind() ==
-                        hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
+    RDAT_UNION_ELIF(AllowSparseNodes, getAttribKind() == hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
       RDAT_VALUE(uint32_t, AllowSparseNodes)
-    RDAT_UNION_ENDIF()
+  RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
+
+
 #define RECORD_TYPE IONode
-  RDAT_STRUCT_TABLE(IONode, IONodeTable)
+RDAT_STRUCT_TABLE(IONode, IONodeTable)
   // Required field
   RDAT_VALUE(uint32_t, IOFlagsAndKind)
   // Optional fields
   RDAT_RECORD_ARRAY_REF(NodeShaderIOAttrib, Attribs)
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint32_t GetIOFlags() const {
-    return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask;
-  }
-  hlsl::DXIL::NodeIOKind GetIOKind() const {
-    return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind &
-                                    (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask);
-  }
+  uint32_t GetIOFlags() const { return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask; }
+  hlsl::DXIL::NodeIOKind GetIOKind() const { return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask); }
   void SetIOFlags(uint32_t flags) { IOFlagsAndKind |= flags; }
-  void SetIOKind(hlsl::DXIL::NodeIOKind kind) {
-    IOFlagsAndKind |= (uint32_t)kind;
-  }
+  void SetIOKind(hlsl::DXIL::NodeIOKind kind) { IOFlagsAndKind |= (uint32_t)kind; }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -582,8 +522,7 @@ RDAT_STRUCT_END()
 // ------------ RuntimeDataFunctionInfo2 ------------
 
 #define RECORD_TYPE RuntimeDataFunctionInfo2
-RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
-                          FunctionTable)
+RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, FunctionTable)
 
   // 128 lanes is maximum that could be supported by HLSL
   RDAT_VALUE(uint8_t, MinimumExpectedWaveLaneCount) // 0 = none specified
@@ -591,8 +530,7 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
   RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
 
   RDAT_UNION()
-    RDAT_UNION_IF(RawShaderRef,
-                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
+    RDAT_UNION_IF(RawShaderRef, (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
       RDAT_VALUE(uint32_t, RawShaderRef)
     RDAT_UNION_ELIF(Node, (getShaderKind() == hlsl::DXIL::ShaderKind::Node))
       RDAT_RECORD_REF(NodeShaderInfo, Node)
@@ -611,8 +549,7 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
       RDAT_RECORD_REF(CSInfo, CS)
     RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
       RDAT_RECORD_REF(MSInfo, MS)
-    RDAT_UNION_ELIF(AS,
-                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
+    RDAT_UNION_ELIF(AS, (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
       RDAT_RECORD_REF(ASInfo, AS)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -24,6 +24,40 @@ RDAT_ENUM_START(DxilResourceFlag, uint32_t)
   RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
 RDAT_ENUM_END()
 
+RDAT_ENUM_START(DxilShaderFlags, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+  // End of values supported by validator version 1.8
+  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(ID, 1)
+  RDAT_ENUM_VALUE(NumThreads, 2)
+  RDAT_ENUM_VALUE(ShareInputOf, 3)
+  RDAT_ENUM_VALUE(DispatchGrid, 4)
+  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(OutputID, 1)
+  RDAT_ENUM_VALUE(MaxRecords, 2)
+  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+  RDAT_ENUM_VALUE(OutputArraySize, 6)
+  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
 #endif // DEF_RDAT_ENUMS
 
 #ifdef DEF_DXIL_ENUMS
@@ -98,6 +132,116 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
 #endif
 RDAT_ENUM_END()
 
+RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
+  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
+  // SemanticKind-ENUM:BEGIN
+  RDAT_ENUM_VALUE_NODEF(Arbitrary)
+  RDAT_ENUM_VALUE_NODEF(VertexID)
+  RDAT_ENUM_VALUE_NODEF(InstanceID)
+  RDAT_ENUM_VALUE_NODEF(Position)
+  RDAT_ENUM_VALUE_NODEF(RenderTargetArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ViewPortArrayIndex)
+  RDAT_ENUM_VALUE_NODEF(ClipDistance)
+  RDAT_ENUM_VALUE_NODEF(CullDistance)
+  RDAT_ENUM_VALUE_NODEF(OutputControlPointID)
+  RDAT_ENUM_VALUE_NODEF(DomainLocation)
+  RDAT_ENUM_VALUE_NODEF(PrimitiveID)
+  RDAT_ENUM_VALUE_NODEF(GSInstanceID)
+  RDAT_ENUM_VALUE_NODEF(SampleIndex)
+  RDAT_ENUM_VALUE_NODEF(IsFrontFace)
+  RDAT_ENUM_VALUE_NODEF(Coverage)
+  RDAT_ENUM_VALUE_NODEF(InnerCoverage)
+  RDAT_ENUM_VALUE_NODEF(Target)
+  RDAT_ENUM_VALUE_NODEF(Depth)
+  RDAT_ENUM_VALUE_NODEF(DepthLessEqual)
+  RDAT_ENUM_VALUE_NODEF(DepthGreaterEqual)
+  RDAT_ENUM_VALUE_NODEF(StencilRef)
+  RDAT_ENUM_VALUE_NODEF(DispatchThreadID)
+  RDAT_ENUM_VALUE_NODEF(GroupID)
+  RDAT_ENUM_VALUE_NODEF(GroupIndex)
+  RDAT_ENUM_VALUE_NODEF(GroupThreadID)
+  RDAT_ENUM_VALUE_NODEF(TessFactor)
+  RDAT_ENUM_VALUE_NODEF(InsideTessFactor)
+  RDAT_ENUM_VALUE_NODEF(ViewID)
+  RDAT_ENUM_VALUE_NODEF(Barycentrics)
+  RDAT_ENUM_VALUE_NODEF(ShadingRate)
+  RDAT_ENUM_VALUE_NODEF(CullPrimitive)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  // SemanticKind-ENUM:END
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(I1)
+  RDAT_ENUM_VALUE_NODEF(I16)
+  RDAT_ENUM_VALUE_NODEF(U16)
+  RDAT_ENUM_VALUE_NODEF(I32)
+  RDAT_ENUM_VALUE_NODEF(U32)
+  RDAT_ENUM_VALUE_NODEF(I64)
+  RDAT_ENUM_VALUE_NODEF(U64)
+  RDAT_ENUM_VALUE_NODEF(F16)
+  RDAT_ENUM_VALUE_NODEF(F32)
+  RDAT_ENUM_VALUE_NODEF(F64)
+  RDAT_ENUM_VALUE_NODEF(SNormF16)
+  RDAT_ENUM_VALUE_NODEF(UNormF16)
+  RDAT_ENUM_VALUE_NODEF(SNormF32)
+  RDAT_ENUM_VALUE_NODEF(UNormF32)
+  RDAT_ENUM_VALUE_NODEF(SNormF64)
+  RDAT_ENUM_VALUE_NODEF(UNormF64)
+  RDAT_ENUM_VALUE_NODEF(PackedS8x32)
+  RDAT_ENUM_VALUE_NODEF(PackedU8x32)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Undefined)
+  RDAT_ENUM_VALUE_NODEF(Constant)
+  RDAT_ENUM_VALUE_NODEF(Linear)
+  RDAT_ENUM_VALUE_NODEF(LinearCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspective)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveCentroid)
+  RDAT_ENUM_VALUE_NODEF(LinearSample)
+  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(EmptyInput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
+  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Broadcasting)
+  RDAT_ENUM_VALUE_NODEF(Coalescing)
+  RDAT_ENUM_VALUE_NODEF(Thread)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
 #endif // DEF_DXIL_ENUMS
 
 #ifdef DEF_RDAT_TYPES
@@ -167,86 +311,144 @@ RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-#endif // DEF_RDAT_TYPES
-
-
-//////////////////////////////////////////////////////////////////////
-// The following require validator version 1.8 and above.
-
-// ------------ RuntimeDataFunctionInfo2 dependencies ------------
-
-#ifdef DEF_RDAT_ENUMS
-
-RDAT_ENUM_START(DxilShaderFlags, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
-  // End of values supported by validator version 1.8
-  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
-  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
-  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
-  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(ID, 1)
-  RDAT_ENUM_VALUE(NumThreads, 2)
-  RDAT_ENUM_VALUE(ShareInputOf, 3)
-  RDAT_ENUM_VALUE(DispatchGrid, 4)
-  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
-  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
-  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeAttribKind, uint32_t)
-  RDAT_ENUM_VALUE(None, 0)
-  RDAT_ENUM_VALUE(OutputID, 1)
-  RDAT_ENUM_VALUE(MaxRecords, 2)
-  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
-  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
-  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
-  RDAT_ENUM_VALUE(OutputArraySize, 6)
-  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
-  RDAT_ENUM_VALUE_NODEF(LastValue)
-RDAT_ENUM_END()
-
-#endif // DEF_RDAT_ENUMS
-
-#ifdef DEF_DXIL_ENUMS
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(EmptyInput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
-  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(Broadcasting)
-  RDAT_ENUM_VALUE_NODEF(Coalescing)
-  RDAT_ENUM_VALUE_NODEF(Thread)
-  RDAT_ENUM_VALUE_NODEF(LastEntry)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#define RECORD_TYPE SignatureElement
+RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
+  RDAT_STRING(SemanticName)
+  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
+  RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
+  RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
+  RDAT_VALUE(
+      uint8_t,
+      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and
+  // UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
+                                     // (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t,
+             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
+  uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
+  uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
+  uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
+  uint8_t GetDynamicIndexMask() const {
+    return (UsageAndDynIndexMasks >> 4) & 0xF;
+  }
+  void SetCols(unsigned cols) {
+    ColsAndStream &= ~3;
+    ColsAndStream |= (cols - 1) & 3;
+  }
+  void SetStartCol(unsigned col) {
+    ColsAndStream &= ~(3 << 2);
+    ColsAndStream |= (col & 3) << 2;
+  }
+  void SetOutputStream(unsigned stream) {
+    ColsAndStream &= ~(3 << 4);
+    ColsAndStream |= (stream & 3) << 4;
+  }
+  void SetUsageMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~0xF;
+    UsageAndDynIndexMasks |= mask & 0xF;
+  }
+  void SetDynamicIndexMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~(0xF << 4);
+    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
+  }
 #endif
-RDAT_ENUM_END()
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
 
-#endif // DEF_DXIL_ENUMS
+#define RECORD_TYPE VSInfo
+RDAT_STRUCT_TABLE(VSInfo, VSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
 
-#ifdef DEF_RDAT_TYPES
+#define RECORD_TYPE PSInfo
+RDAT_STRUCT_TABLE(PSInfo, PSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE HSInfo
+RDAT_STRUCT_TABLE(HSInfo, HSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPatchConstOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(InputToPatchConstOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, OutputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+  RDAT_VALUE(uint8_t, TessellatorOutputPrimitive)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE DSInfo
+RDAT_STRUCT_TABLE(DSInfo, DSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstInputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_BYTES(PatchConstInputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputControlPointCount)
+  RDAT_VALUE(uint8_t, TessellatorDomain)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE GSInfo
+RDAT_STRUCT_TABLE(GSInfo, GSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(InputToOutputMasks)
+  RDAT_VALUE(uint8_t, InputPrimitive)
+  RDAT_VALUE(uint8_t, OutputTopology)
+  RDAT_VALUE(uint8_t, MaxVertexCount)
+  RDAT_VALUE(uint8_t, OutputStreamMask)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE CSInfo
+RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE MSInfo
+RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
+  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
+  RDAT_BYTES(ViewIDOutputMask)
+  RDAT_BYTES(ViewIDPrimOutputMask)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+  RDAT_VALUE(uint16_t, MaxOutputVertices)
+  RDAT_VALUE(uint16_t, MaxOutputPrimitives)
+  RDAT_VALUE(uint8_t, MeshOutputTopology)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE ASInfo
+RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
 
 #define RECORD_TYPE RecordDispatchGrid
 RDAT_STRUCT(RecordDispatchGrid)
@@ -415,239 +617,6 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#endif // DEF_RDAT_TYPES
-
-
-///////////////////////////////////////////////////////////////////////////////
-// The following are experimental, and are not currently supported on any
-// validator version.
-
-#ifdef DEF_DXIL_ENUMS
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
-  /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
-  // SemanticKind-ENUM:BEGIN
-  RDAT_ENUM_VALUE_NODEF(Arbitrary)
-  RDAT_ENUM_VALUE_NODEF(VertexID)
-  RDAT_ENUM_VALUE_NODEF(InstanceID)
-  RDAT_ENUM_VALUE_NODEF(Position)
-  RDAT_ENUM_VALUE_NODEF(RenderTargetArrayIndex)
-  RDAT_ENUM_VALUE_NODEF(ViewPortArrayIndex)
-  RDAT_ENUM_VALUE_NODEF(ClipDistance)
-  RDAT_ENUM_VALUE_NODEF(CullDistance)
-  RDAT_ENUM_VALUE_NODEF(OutputControlPointID)
-  RDAT_ENUM_VALUE_NODEF(DomainLocation)
-  RDAT_ENUM_VALUE_NODEF(PrimitiveID)
-  RDAT_ENUM_VALUE_NODEF(GSInstanceID)
-  RDAT_ENUM_VALUE_NODEF(SampleIndex)
-  RDAT_ENUM_VALUE_NODEF(IsFrontFace)
-  RDAT_ENUM_VALUE_NODEF(Coverage)
-  RDAT_ENUM_VALUE_NODEF(InnerCoverage)
-  RDAT_ENUM_VALUE_NODEF(Target)
-  RDAT_ENUM_VALUE_NODEF(Depth)
-  RDAT_ENUM_VALUE_NODEF(DepthLessEqual)
-  RDAT_ENUM_VALUE_NODEF(DepthGreaterEqual)
-  RDAT_ENUM_VALUE_NODEF(StencilRef)
-  RDAT_ENUM_VALUE_NODEF(DispatchThreadID)
-  RDAT_ENUM_VALUE_NODEF(GroupID)
-  RDAT_ENUM_VALUE_NODEF(GroupIndex)
-  RDAT_ENUM_VALUE_NODEF(GroupThreadID)
-  RDAT_ENUM_VALUE_NODEF(TessFactor)
-  RDAT_ENUM_VALUE_NODEF(InsideTessFactor)
-  RDAT_ENUM_VALUE_NODEF(ViewID)
-  RDAT_ENUM_VALUE_NODEF(Barycentrics)
-  RDAT_ENUM_VALUE_NODEF(ShadingRate)
-  RDAT_ENUM_VALUE_NODEF(CullPrimitive)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  // SemanticKind-ENUM:END
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(I1)
-  RDAT_ENUM_VALUE_NODEF(I16)
-  RDAT_ENUM_VALUE_NODEF(U16)
-  RDAT_ENUM_VALUE_NODEF(I32)
-  RDAT_ENUM_VALUE_NODEF(U32)
-  RDAT_ENUM_VALUE_NODEF(I64)
-  RDAT_ENUM_VALUE_NODEF(U64)
-  RDAT_ENUM_VALUE_NODEF(F16)
-  RDAT_ENUM_VALUE_NODEF(F32)
-  RDAT_ENUM_VALUE_NODEF(F64)
-  RDAT_ENUM_VALUE_NODEF(SNormF16)
-  RDAT_ENUM_VALUE_NODEF(UNormF16)
-  RDAT_ENUM_VALUE_NODEF(SNormF32)
-  RDAT_ENUM_VALUE_NODEF(UNormF32)
-  RDAT_ENUM_VALUE_NODEF(SNormF64)
-  RDAT_ENUM_VALUE_NODEF(UNormF64)
-  RDAT_ENUM_VALUE_NODEF(PackedS8x32)
-  RDAT_ENUM_VALUE_NODEF(PackedU8x32)
-  RDAT_ENUM_VALUE_NODEF(LastEntry)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Undefined)
-  RDAT_ENUM_VALUE_NODEF(Constant)
-  RDAT_ENUM_VALUE_NODEF(Linear)
-  RDAT_ENUM_VALUE_NODEF(LinearCentroid)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspective)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveCentroid)
-  RDAT_ENUM_VALUE_NODEF(LinearSample)
-  RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
-                "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
-#endif // DEF_DXIL_ENUMS
-
-#ifdef DEF_RDAT_TYPES
-
-#define RECORD_TYPE SignatureElement
-RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
-  RDAT_STRING(SemanticName)
-  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
-  RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
-  RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
-  RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
-  RDAT_VALUE(
-      uint8_t,
-      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
-  // TODO: use struct with bitfields or accessors for ColsAndStream and
-  // UsageAndDynIndexMasks
-  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
-                                     // (0-3), 4:6 = OutputStream (0-3)
-  RDAT_VALUE(uint8_t,
-             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
-#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
-  uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
-  uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
-  uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
-  uint8_t GetDynamicIndexMask() const {
-    return (UsageAndDynIndexMasks >> 4) & 0xF;
-  }
-  void SetCols(unsigned cols) {
-    ColsAndStream &= ~3;
-    ColsAndStream |= (cols - 1) & 3;
-  }
-  void SetStartCol(unsigned col) {
-    ColsAndStream &= ~(3 << 2);
-    ColsAndStream |= (col & 3) << 2;
-  }
-  void SetOutputStream(unsigned stream) {
-    ColsAndStream &= ~(3 << 4);
-    ColsAndStream |= (stream & 3) << 4;
-  }
-  void SetUsageMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~0xF;
-    UsageAndDynIndexMasks |= mask & 0xF;
-  }
-  void SetDynamicIndexMask(unsigned mask) {
-    UsageAndDynIndexMasks &= ~(0xF << 4);
-    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
-  }
-#endif
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE VSInfo
-RDAT_STRUCT_TABLE(VSInfo, VSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE PSInfo
-RDAT_STRUCT_TABLE(PSInfo, PSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE HSInfo
-RDAT_STRUCT_TABLE(HSInfo, HSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(ViewIDPatchConstOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_BYTES(InputToPatchConstOutputMasks)
-  RDAT_VALUE(uint8_t, InputControlPointCount)
-  RDAT_VALUE(uint8_t, OutputControlPointCount)
-  RDAT_VALUE(uint8_t, TessellatorDomain)
-  RDAT_VALUE(uint8_t, TessellatorOutputPrimitive)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE DSInfo
-RDAT_STRUCT_TABLE(DSInfo, DSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPatchConstInputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_BYTES(PatchConstInputToOutputMasks)
-  RDAT_VALUE(uint8_t, InputControlPointCount)
-  RDAT_VALUE(uint8_t, TessellatorDomain)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE GSInfo
-RDAT_STRUCT_TABLE(GSInfo, GSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigInputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(InputToOutputMasks)
-  RDAT_VALUE(uint8_t, InputPrimitive)
-  RDAT_VALUE(uint8_t, OutputTopology)
-  RDAT_VALUE(uint8_t, MaxVertexCount)
-  RDAT_VALUE(uint8_t, OutputStreamMask)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE CSInfo
-RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE MSInfo
-RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigOutputElements)
-  RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
-  RDAT_BYTES(ViewIDOutputMask)
-  RDAT_BYTES(ViewIDPrimOutputMask)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-  RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
-  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
-  RDAT_VALUE(uint16_t, MaxOutputVertices)
-  RDAT_VALUE(uint16_t, MaxOutputPrimitives)
-  RDAT_VALUE(uint8_t, MeshOutputTopology)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE ASInfo
-RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
-                                   // default value is 1
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -16,46 +16,46 @@
 #ifdef DEF_RDAT_ENUMS
 
 RDAT_ENUM_START(DxilResourceFlag, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
-RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
-RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
-RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
-RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
+  RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
+  RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
+  RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
+  RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(DxilShaderFlags, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
-// End of values supported by validator version 1.8
-RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
-RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
-RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
-RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+  // End of values supported by validator version 1.8
+  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(ID, 1)
-RDAT_ENUM_VALUE(NumThreads, 2)
-RDAT_ENUM_VALUE(ShareInputOf, 3)
-RDAT_ENUM_VALUE(DispatchGrid, 4)
-RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
-RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
-RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
-RDAT_ENUM_VALUE_NODEF(LastValue)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(ID, 1)
+  RDAT_ENUM_VALUE(NumThreads, 2)
+  RDAT_ENUM_VALUE(ShareInputOf, 3)
+  RDAT_ENUM_VALUE(DispatchGrid, 4)
+  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
 RDAT_ENUM_START(NodeAttribKind, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(OutputID, 1)
-RDAT_ENUM_VALUE(MaxRecords, 2)
-RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
-RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
-RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
-RDAT_ENUM_VALUE(OutputArraySize, 6)
-RDAT_ENUM_VALUE(AllowSparseNodes, 7)
-RDAT_ENUM_VALUE_NODEF(LastValue)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(OutputID, 1)
+  RDAT_ENUM_VALUE(MaxRecords, 2)
+  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+  RDAT_ENUM_VALUE(OutputArraySize, 6)
+  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
 #endif // DEF_RDAT_ENUMS
@@ -70,65 +70,65 @@ RDAT_ENUM_END()
 // making sure this definition is updated as well.
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceClass, uint32_t)
-RDAT_ENUM_VALUE_NODEF(SRV)
-RDAT_ENUM_VALUE_NODEF(UAV)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(SRV)
+  RDAT_ENUM_VALUE_NODEF(UAV)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_VALUE_NODEF(Texture1D)
-RDAT_ENUM_VALUE_NODEF(Texture2D)
-RDAT_ENUM_VALUE_NODEF(Texture2DMS)
-RDAT_ENUM_VALUE_NODEF(Texture3D)
-RDAT_ENUM_VALUE_NODEF(TextureCube)
-RDAT_ENUM_VALUE_NODEF(Texture1DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
-RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
-RDAT_ENUM_VALUE_NODEF(TypedBuffer)
-RDAT_ENUM_VALUE_NODEF(RawBuffer)
-RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(TBuffer)
-RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
-RDAT_ENUM_VALUE_NODEF(NumEntries)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Texture1D)
+  RDAT_ENUM_VALUE_NODEF(Texture2D)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMS)
+  RDAT_ENUM_VALUE_NODEF(Texture3D)
+  RDAT_ENUM_VALUE_NODEF(TextureCube)
+  RDAT_ENUM_VALUE_NODEF(Texture1DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
+  RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
+  RDAT_ENUM_VALUE_NODEF(TypedBuffer)
+  RDAT_ENUM_VALUE_NODEF(RawBuffer)
+  RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(TBuffer)
+  RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
+  RDAT_ENUM_VALUE_NODEF(NumEntries)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Pixel)
-RDAT_ENUM_VALUE_NODEF(Vertex)
-RDAT_ENUM_VALUE_NODEF(Geometry)
-RDAT_ENUM_VALUE_NODEF(Hull)
-RDAT_ENUM_VALUE_NODEF(Domain)
-RDAT_ENUM_VALUE_NODEF(Compute)
-RDAT_ENUM_VALUE_NODEF(Library)
-RDAT_ENUM_VALUE_NODEF(RayGeneration)
-RDAT_ENUM_VALUE_NODEF(Intersection)
-RDAT_ENUM_VALUE_NODEF(AnyHit)
-RDAT_ENUM_VALUE_NODEF(ClosestHit)
-RDAT_ENUM_VALUE_NODEF(Miss)
-RDAT_ENUM_VALUE_NODEF(Callable)
-RDAT_ENUM_VALUE_NODEF(Mesh)
-RDAT_ENUM_VALUE_NODEF(Amplification)
-RDAT_ENUM_VALUE_NODEF(Node)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Pixel)
+  RDAT_ENUM_VALUE_NODEF(Vertex)
+  RDAT_ENUM_VALUE_NODEF(Geometry)
+  RDAT_ENUM_VALUE_NODEF(Hull)
+  RDAT_ENUM_VALUE_NODEF(Domain)
+  RDAT_ENUM_VALUE_NODEF(Compute)
+  RDAT_ENUM_VALUE_NODEF(Library)
+  RDAT_ENUM_VALUE_NODEF(RayGeneration)
+  RDAT_ENUM_VALUE_NODEF(Intersection)
+  RDAT_ENUM_VALUE_NODEF(AnyHit)
+  RDAT_ENUM_VALUE_NODEF(ClosestHit)
+  RDAT_ENUM_VALUE_NODEF(Miss)
+  RDAT_ENUM_VALUE_NODEF(Callable)
+  RDAT_ENUM_VALUE_NODEF(Mesh)
+  RDAT_ENUM_VALUE_NODEF(Amplification)
+  RDAT_ENUM_VALUE_NODEF(Node)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -192,7 +192,8 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(PackedU8x32)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19, "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -207,7 +208,8 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
   RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
   RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8, "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -235,7 +237,8 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(Thread)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4, "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -311,25 +314,47 @@ RDAT_STRUCT_END()
 #define RECORD_TYPE SignatureElement
 RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
   RDAT_STRING(SemanticName)
-  RDAT_INDEX_ARRAY_REF(SemanticIndices)         // Rows = SemanticIndices.Count()
+  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
   RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
   RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
   RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
-  RDAT_VALUE(uint8_t, StartRow)                 // Starting row of packed location if allocated, otherwise 0xFF
-  // TODO: use struct with bitfields or accessors for ColsAndStream and UsageAndDynIndexMasks
-  RDAT_VALUE(uint8_t, ColsAndStream)            // 0:2 = (Cols-1) (0-3), 2:4 = StartCol (0-3), 4:6 = OutputStream (0-3)
-  RDAT_VALUE(uint8_t, UsageAndDynIndexMasks)    // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+  RDAT_VALUE(
+      uint8_t,
+      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and
+  // UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
+                                     // (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t,
+             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
   uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
   uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
   uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
   uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
-  uint8_t GetDynamicIndexMask() const { return (UsageAndDynIndexMasks >> 4) & 0xF; }
-  void SetCols(unsigned cols) { ColsAndStream &= ~3; ColsAndStream |= (cols - 1) & 3; }
-  void SetStartCol(unsigned col) { ColsAndStream &= ~(3 << 2); ColsAndStream |= (col & 3) << 2; }
-  void SetOutputStream(unsigned stream) { ColsAndStream &= ~(3 << 4); ColsAndStream |= (stream & 3) << 4; }
-  void SetUsageMask(unsigned mask) { UsageAndDynIndexMasks &= ~0xF; UsageAndDynIndexMasks |= mask & 0xF; }
-  void SetDynamicIndexMask(unsigned mask) { UsageAndDynIndexMasks &= ~(0xF << 4); UsageAndDynIndexMasks |= (mask & 0xF) << 4; }
+  uint8_t GetDynamicIndexMask() const {
+    return (UsageAndDynIndexMasks >> 4) & 0xF;
+  }
+  void SetCols(unsigned cols) {
+    ColsAndStream &= ~3;
+    ColsAndStream |= (cols - 1) & 3;
+  }
+  void SetStartCol(unsigned col) {
+    ColsAndStream &= ~(3 << 2);
+    ColsAndStream |= (col & 3) << 2;
+  }
+  void SetOutputStream(unsigned stream) {
+    ColsAndStream &= ~(3 << 4);
+    ColsAndStream |= (stream & 3) << 4;
+  }
+  void SetUsageMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~0xF;
+    UsageAndDynIndexMasks |= mask & 0xF;
+  }
+  void SetDynamicIndexMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~(0xF << 4);
+    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
+  }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -393,7 +418,8 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE CSInfo
 RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -404,7 +430,8 @@ RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
   RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
   RDAT_BYTES(ViewIDOutputMask)
   RDAT_BYTES(ViewIDPrimOutputMask)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
@@ -416,7 +443,8 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE ASInfo
 RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
 RDAT_STRUCT_END()
@@ -425,12 +453,17 @@ RDAT_STRUCT_END()
 #define RECORD_TYPE RecordDispatchGrid
 RDAT_STRUCT(RecordDispatchGrid)
   RDAT_VALUE(uint16_t, ByteOffset)
-  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 = hlsl::DXIL::ComponentType enum
+  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 =
+                                          // hlsl::DXIL::ComponentType enum
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
   uint8_t GetNumComponents() const { return (ComponentNumAndType & 0x3); }
-  hlsl::DXIL::ComponentType GetComponentType() const { return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2); }
+  hlsl::DXIL::ComponentType GetComponentType() const {
+    return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2);
+  }
   void SetNumComponents(uint8_t num) { ComponentNumAndType |= (num & 0x3); }
-  void SetComponentType(hlsl::DXIL::ComponentType type) { ComponentNumAndType |= (((uint16_t)type) << 2); }
+  void SetComponentType(hlsl::DXIL::ComponentType type) {
+    ComponentNumAndType |= (((uint16_t)type) << 2);
+  }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -442,30 +475,41 @@ RDAT_STRUCT_TABLE(NodeID, NodeIDTable)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-
 #define RECORD_TYPE NodeShaderFuncAttrib
 RDAT_STRUCT_TABLE(NodeShaderFuncAttrib, NodeShaderFuncAttribTable)
   RDAT_ENUM(uint32_t, hlsl::RDAT::NodeFuncAttribKind, AttribKind)
   RDAT_UNION()
     RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ID)
       RDAT_RECORD_REF(NodeID, ID)
-    RDAT_UNION_ELIF(NumThreads, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::NumThreads)
-      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements, default value is 1
-    RDAT_UNION_ELIF(SharedInput, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
+    RDAT_UNION_ELIF(NumThreads, getAttribKind() ==
+                                    hlsl::RDAT::NodeFuncAttribKind::NumThreads)
+      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3
+                                       // elements, default value is 1
+    RDAT_UNION_ELIF(SharedInput,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
       RDAT_RECORD_REF(NodeID, ShareInputOf)
-    RDAT_UNION_ELIF(DispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
+    RDAT_UNION_ELIF(DispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
       RDAT_INDEX_ARRAY_REF(DispatchGrid)
-    RDAT_UNION_ELIF(MaxRecursionDepth, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
+    RDAT_UNION_ELIF(MaxRecursionDepth,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
       RDAT_VALUE(uint32_t, MaxRecursionDepth)
-    RDAT_UNION_ELIF(LocalRootArgumentsTableIndex, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
+    RDAT_UNION_ELIF(
+        LocalRootArgumentsTableIndex,
+        getAttribKind() ==
+            hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
       RDAT_VALUE(uint32_t, LocalRootArgumentsTableIndex)
-    RDAT_UNION_ELIF(MaxDispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
+    RDAT_UNION_ELIF(MaxDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
       RDAT_INDEX_ARRAY_REF(MaxDispatchGrid)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
-
 
 #define RECORD_TYPE NodeShaderIOAttrib
 RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
@@ -473,36 +517,52 @@ RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
   RDAT_UNION()
     RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputID)
       RDAT_RECORD_REF(NodeID, OutputID)
-    RDAT_UNION_ELIF(MaxRecords, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
+    RDAT_UNION_ELIF(MaxRecords,
+                    getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
       RDAT_VALUE(uint32_t, MaxRecords)
-    RDAT_UNION_ELIF(MaxRecordsSharedWith, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
+    RDAT_UNION_ELIF(MaxRecordsSharedWith,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
       RDAT_VALUE(uint32_t, MaxRecordsSharedWith)
-    RDAT_UNION_ELIF(RecordSizeInBytes, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
+    RDAT_UNION_ELIF(RecordSizeInBytes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
       RDAT_VALUE(uint32_t, RecordSizeInBytes)
-    RDAT_UNION_ELIF(RecordDispatchGrid, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
+    RDAT_UNION_ELIF(RecordDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
       RDAT_RECORD_VALUE(RecordDispatchGrid, RecordDispatchGrid)
-    RDAT_UNION_ELIF(OutputArraySize, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputArraySize)
+    RDAT_UNION_ELIF(OutputArraySize,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::OutputArraySize)
       RDAT_VALUE(uint32_t, OutputArraySize)
-    RDAT_UNION_ELIF(AllowSparseNodes, getAttribKind() == hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
+    RDAT_UNION_ELIF(AllowSparseNodes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
       RDAT_VALUE(uint32_t, AllowSparseNodes)
-  RDAT_UNION_ENDIF()
+    RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-
-
 #define RECORD_TYPE IONode
-RDAT_STRUCT_TABLE(IONode, IONodeTable)
+  RDAT_STRUCT_TABLE(IONode, IONodeTable)
   // Required field
   RDAT_VALUE(uint32_t, IOFlagsAndKind)
   // Optional fields
   RDAT_RECORD_ARRAY_REF(NodeShaderIOAttrib, Attribs)
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint32_t GetIOFlags() const { return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask; }
-  hlsl::DXIL::NodeIOKind GetIOKind() const { return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask); }
+  uint32_t GetIOFlags() const {
+    return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask;
+  }
+  hlsl::DXIL::NodeIOKind GetIOKind() const {
+    return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind &
+                                    (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask);
+  }
   void SetIOFlags(uint32_t flags) { IOFlagsAndKind |= flags; }
-  void SetIOKind(hlsl::DXIL::NodeIOKind kind) { IOFlagsAndKind |= (uint32_t)kind; }
+  void SetIOKind(hlsl::DXIL::NodeIOKind kind) {
+    IOFlagsAndKind |= (uint32_t)kind;
+  }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -522,7 +582,8 @@ RDAT_STRUCT_END()
 // ------------ RuntimeDataFunctionInfo2 ------------
 
 #define RECORD_TYPE RuntimeDataFunctionInfo2
-RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, FunctionTable)
+RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
+                          FunctionTable)
 
   // 128 lanes is maximum that could be supported by HLSL
   RDAT_VALUE(uint8_t, MinimumExpectedWaveLaneCount) // 0 = none specified
@@ -530,7 +591,8 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, Fun
   RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
 
   RDAT_UNION()
-    RDAT_UNION_IF(RawShaderRef, (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
+    RDAT_UNION_IF(RawShaderRef,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
       RDAT_VALUE(uint32_t, RawShaderRef)
     RDAT_UNION_ELIF(Node, (getShaderKind() == hlsl::DXIL::ShaderKind::Node))
       RDAT_RECORD_REF(NodeShaderInfo, Node)
@@ -549,7 +611,8 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, Fun
       RDAT_RECORD_REF(CSInfo, CS)
     RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
       RDAT_RECORD_REF(MSInfo, MS)
-    RDAT_UNION_ELIF(AS, (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
+    RDAT_UNION_ELIF(AS,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
       RDAT_RECORD_REF(ASInfo, AS)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -9,48 +9,19 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
 #ifdef DEF_RDAT_ENUMS
 
 RDAT_ENUM_START(DxilResourceFlag, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
-RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
-RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
-RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
-RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(DxilShaderFlags, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 0)
-RDAT_ENUM_VALUE(DepthOutput, 1 << 1)
-RDAT_ENUM_VALUE(SampleFrequency, 1 << 2)
-RDAT_ENUM_VALUE(UsesViewID, 1 << 3)
-RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 4)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(ID, 1)
-RDAT_ENUM_VALUE(NumThreads, 2)
-RDAT_ENUM_VALUE(ShareInputOf, 3)
-RDAT_ENUM_VALUE(DispatchGrid, 4)
-RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
-RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
-RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
-RDAT_ENUM_VALUE_NODEF(LastValue)
-RDAT_ENUM_END()
-
-RDAT_ENUM_START(NodeAttribKind, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(OutputID, 1)
-RDAT_ENUM_VALUE(MaxRecords, 2)
-RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
-RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
-RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
-RDAT_ENUM_VALUE(OutputArraySize, 6)
-RDAT_ENUM_VALUE(AllowSparseNodes, 7)
-RDAT_ENUM_VALUE_NODEF(LastValue)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
+  RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
+  RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
+  RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
+  RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
 RDAT_ENUM_END()
 
 #endif // DEF_RDAT_ENUMS
@@ -65,73 +36,374 @@ RDAT_ENUM_END()
 // making sure this definition is updated as well.
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceClass, uint32_t)
-RDAT_ENUM_VALUE_NODEF(SRV)
-RDAT_ENUM_VALUE_NODEF(UAV)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(SRV)
+  RDAT_ENUM_VALUE_NODEF(UAV)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_VALUE_NODEF(Texture1D)
-RDAT_ENUM_VALUE_NODEF(Texture2D)
-RDAT_ENUM_VALUE_NODEF(Texture2DMS)
-RDAT_ENUM_VALUE_NODEF(Texture3D)
-RDAT_ENUM_VALUE_NODEF(TextureCube)
-RDAT_ENUM_VALUE_NODEF(Texture1DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
-RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
-RDAT_ENUM_VALUE_NODEF(TypedBuffer)
-RDAT_ENUM_VALUE_NODEF(RawBuffer)
-RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(TBuffer)
-RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
-RDAT_ENUM_VALUE_NODEF(NumEntries)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Texture1D)
+  RDAT_ENUM_VALUE_NODEF(Texture2D)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMS)
+  RDAT_ENUM_VALUE_NODEF(Texture3D)
+  RDAT_ENUM_VALUE_NODEF(TextureCube)
+  RDAT_ENUM_VALUE_NODEF(Texture1DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
+  RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
+  RDAT_ENUM_VALUE_NODEF(TypedBuffer)
+  RDAT_ENUM_VALUE_NODEF(RawBuffer)
+  RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(TBuffer)
+  RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
+  RDAT_ENUM_VALUE_NODEF(NumEntries)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Pixel)
-RDAT_ENUM_VALUE_NODEF(Vertex)
-RDAT_ENUM_VALUE_NODEF(Geometry)
-RDAT_ENUM_VALUE_NODEF(Hull)
-RDAT_ENUM_VALUE_NODEF(Domain)
-RDAT_ENUM_VALUE_NODEF(Compute)
-RDAT_ENUM_VALUE_NODEF(Library)
-RDAT_ENUM_VALUE_NODEF(RayGeneration)
-RDAT_ENUM_VALUE_NODEF(Intersection)
-RDAT_ENUM_VALUE_NODEF(AnyHit)
-RDAT_ENUM_VALUE_NODEF(ClosestHit)
-RDAT_ENUM_VALUE_NODEF(Miss)
-RDAT_ENUM_VALUE_NODEF(Callable)
-RDAT_ENUM_VALUE_NODEF(Mesh)
-RDAT_ENUM_VALUE_NODEF(Amplification)
-RDAT_ENUM_VALUE_NODEF(Node)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Pixel)
+  RDAT_ENUM_VALUE_NODEF(Vertex)
+  RDAT_ENUM_VALUE_NODEF(Geometry)
+  RDAT_ENUM_VALUE_NODEF(Hull)
+  RDAT_ENUM_VALUE_NODEF(Domain)
+  RDAT_ENUM_VALUE_NODEF(Compute)
+  RDAT_ENUM_VALUE_NODEF(Library)
+  RDAT_ENUM_VALUE_NODEF(RayGeneration)
+  RDAT_ENUM_VALUE_NODEF(Intersection)
+  RDAT_ENUM_VALUE_NODEF(AnyHit)
+  RDAT_ENUM_VALUE_NODEF(ClosestHit)
+  RDAT_ENUM_VALUE_NODEF(Miss)
+  RDAT_ENUM_VALUE_NODEF(Callable)
+  RDAT_ENUM_VALUE_NODEF(Mesh)
+  RDAT_ENUM_VALUE_NODEF(Amplification)
+  RDAT_ENUM_VALUE_NODEF(Node)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 16,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE RuntimeDataResourceInfo
+RDAT_STRUCT_TABLE(RuntimeDataResourceInfo, ResourceTable)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceClass, Class)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceKind, Kind)
+  RDAT_VALUE(uint32_t, ID)
+  RDAT_VALUE(uint32_t, Space)
+  RDAT_VALUE(uint32_t, LowerBound)
+  RDAT_VALUE(uint32_t, UpperBound)
+  RDAT_STRING(Name)
+  RDAT_FLAGS(uint32_t, DxilResourceFlag, Flags)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE RuntimeDataFunctionInfo
+RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
+  // full function name
+  RDAT_STRING(Name)
+  // unmangled function name
+  RDAT_STRING(UnmangledName)
+  // list of global resources used by this function
+  RDAT_RECORD_ARRAY_REF(RuntimeDataResourceInfo, Resources)
+  // list of external function names this function calls
+  RDAT_STRING_ARRAY_REF(FunctionDependencies)
+  // Shader type, or library function
+  RDAT_ENUM(uint32_t, hlsl::DXIL::ShaderKind, ShaderKind)
+  // Payload Size:
+  // 1) any/closest hit or miss shader: payload size
+  // 2) call shader: parameter size
+  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
+  // attribute size for closest hit and any hit
+  RDAT_VALUE(uint32_t, AttributeSizeInBytes)
+  // first 32 bits of feature flag
+  RDAT_VALUE(uint32_t, FeatureInfo1)
+  // second 32 bits of feature flag
+  RDAT_VALUE(uint32_t, FeatureInfo2)
+  // valid shader stage flag.
+  RDAT_VALUE(uint32_t, ShaderStageFlag)
+  // minimum shader target.
+  RDAT_VALUE(uint32_t, MinShaderTarget)
+
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  // void SetFeatureFlags(uint64_t flags) convenience method
+  void SetFeatureFlags(uint64_t flags) {
+    FeatureInfo1 = flags & 0xffffffff;
+    FeatureInfo2 = (flags >> 32) & 0xffffffff;
+  }
+#endif
+
+#if DEF_RDAT_TYPES == DEF_RDAT_READER_DECL
+  // uint64_t GetFeatureFlags() convenience method
+  uint64_t GetFeatureFlags();
+#elif DEF_RDAT_TYPES == DEF_RDAT_READER_IMPL
+  // uint64_t GetFeatureFlags() convenience method
+  uint64_t RuntimeDataFunctionInfo_Reader::GetFeatureFlags() {
+    return asRecord() ? (((uint64_t)asRecord()->FeatureInfo2 << 32) |
+                         (uint64_t)asRecord()->FeatureInfo1)
+                      : 0;
+  }
+#endif
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+
+//////////////////////////////////////////////////////////////////////
+// The following require validator version 1.8 and above.
+
+// ------------ RuntimeDataFunctionInfo2 dependencies ------------
+
+#ifdef DEF_RDAT_ENUMS
+
+RDAT_ENUM_START(DxilShaderFlags, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(NodeProgramEntry, 1 << 0)
+  // End of values supported by validator version 1.8
+  RDAT_ENUM_VALUE(OutputPositionPresent, 1 << 1)
+  RDAT_ENUM_VALUE(DepthOutput, 1 << 2)
+  RDAT_ENUM_VALUE(SampleFrequency, 1 << 3)
+  RDAT_ENUM_VALUE(UsesViewID, 1 << 4)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeFuncAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(ID, 1)
+  RDAT_ENUM_VALUE(NumThreads, 2)
+  RDAT_ENUM_VALUE(ShareInputOf, 3)
+  RDAT_ENUM_VALUE(DispatchGrid, 4)
+  RDAT_ENUM_VALUE(MaxRecursionDepth, 5)
+  RDAT_ENUM_VALUE(LocalRootArgumentsTableIndex, 6)
+  RDAT_ENUM_VALUE(MaxDispatchGrid, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+RDAT_ENUM_START(NodeAttribKind, uint32_t)
+  RDAT_ENUM_VALUE(None, 0)
+  RDAT_ENUM_VALUE(OutputID, 1)
+  RDAT_ENUM_VALUE(MaxRecords, 2)
+  RDAT_ENUM_VALUE(MaxRecordsSharedWith, 3)
+  RDAT_ENUM_VALUE(RecordSizeInBytes, 4)
+  RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
+  RDAT_ENUM_VALUE(OutputArraySize, 6)
+  RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE_NODEF(LastValue)
+RDAT_ENUM_END()
+
+#endif // DEF_RDAT_ENUMS
+
+#ifdef DEF_DXIL_ENUMS
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(EmptyInput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutput)
+  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
+  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
+  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
+  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+RDAT_ENUM_END()
+
+RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Broadcasting)
+  RDAT_ENUM_VALUE_NODEF(Coalescing)
+  RDAT_ENUM_VALUE_NODEF(Thread)
+  RDAT_ENUM_VALUE_NODEF(LastEntry)
+#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
+  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
+#endif
+RDAT_ENUM_END()
+
+#endif // DEF_DXIL_ENUMS
+
+#ifdef DEF_RDAT_TYPES
+
+#define RECORD_TYPE RecordDispatchGrid
+RDAT_STRUCT(RecordDispatchGrid)
+  RDAT_VALUE(uint16_t, ByteOffset)
+  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 =
+                                          // hlsl::DXIL::ComponentType enum
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint8_t GetNumComponents() const { return (ComponentNumAndType & 0x3); }
+  hlsl::DXIL::ComponentType GetComponentType() const {
+    return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2);
+  }
+  void SetNumComponents(uint8_t num) { ComponentNumAndType |= (num & 0x3); }
+  void SetComponentType(hlsl::DXIL::ComponentType type) {
+    ComponentNumAndType |= (((uint16_t)type) << 2);
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeID
+RDAT_STRUCT_TABLE(NodeID, NodeIDTable)
+  RDAT_STRING(Name)
+  RDAT_VALUE(uint32_t, Index)
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderFuncAttrib
+RDAT_STRUCT_TABLE(NodeShaderFuncAttrib, NodeShaderFuncAttribTable)
+  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeFuncAttribKind, AttribKind)
+  RDAT_UNION()
+    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ID)
+      RDAT_RECORD_REF(NodeID, ID)
+    RDAT_UNION_ELIF(NumThreads, getAttribKind() ==
+                                    hlsl::RDAT::NodeFuncAttribKind::NumThreads)
+      RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3
+                                       // elements, default value is 1
+    RDAT_UNION_ELIF(SharedInput,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
+      RDAT_RECORD_REF(NodeID, ShareInputOf)
+    RDAT_UNION_ELIF(DispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
+      RDAT_INDEX_ARRAY_REF(DispatchGrid)
+    RDAT_UNION_ELIF(MaxRecursionDepth,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
+      RDAT_VALUE(uint32_t, MaxRecursionDepth)
+    RDAT_UNION_ELIF(
+        LocalRootArgumentsTableIndex,
+        getAttribKind() ==
+            hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
+      RDAT_VALUE(uint32_t, LocalRootArgumentsTableIndex)
+    RDAT_UNION_ELIF(MaxDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
+      RDAT_INDEX_ARRAY_REF(MaxDispatchGrid)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderIOAttrib
+RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
+  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeAttribKind, AttribKind)
+  RDAT_UNION()
+    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputID)
+      RDAT_RECORD_REF(NodeID, OutputID)
+    RDAT_UNION_ELIF(MaxRecords,
+                    getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
+      RDAT_VALUE(uint32_t, MaxRecords)
+    RDAT_UNION_ELIF(MaxRecordsSharedWith,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
+      RDAT_VALUE(uint32_t, MaxRecordsSharedWith)
+    RDAT_UNION_ELIF(RecordSizeInBytes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
+      RDAT_VALUE(uint32_t, RecordSizeInBytes)
+    RDAT_UNION_ELIF(RecordDispatchGrid,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
+      RDAT_RECORD_VALUE(RecordDispatchGrid, RecordDispatchGrid)
+    RDAT_UNION_ELIF(OutputArraySize,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::OutputArraySize)
+      RDAT_VALUE(uint32_t, OutputArraySize)
+    RDAT_UNION_ELIF(AllowSparseNodes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
+      RDAT_VALUE(uint32_t, AllowSparseNodes)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE IONode
+  RDAT_STRUCT_TABLE(IONode, IONodeTable)
+  // Required field
+  RDAT_VALUE(uint32_t, IOFlagsAndKind)
+  // Optional fields
+  RDAT_RECORD_ARRAY_REF(NodeShaderIOAttrib, Attribs)
+#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
+  uint32_t GetIOFlags() const {
+    return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask;
+  }
+  hlsl::DXIL::NodeIOKind GetIOKind() const {
+    return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind &
+                                    (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask);
+  }
+  void SetIOFlags(uint32_t flags) { IOFlagsAndKind |= flags; }
+  void SetIOKind(hlsl::DXIL::NodeIOKind kind) {
+    IOFlagsAndKind |= (uint32_t)kind;
+  }
+#endif
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#define RECORD_TYPE NodeShaderInfo
+RDAT_STRUCT_TABLE(NodeShaderInfo, NodeShaderInfoTable)
+  // Function Attributes
+  RDAT_ENUM(uint32_t, hlsl::DXIL::NodeLaunchType, LaunchType)
+  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
+  RDAT_RECORD_ARRAY_REF(NodeShaderFuncAttrib, Attribs)
+  RDAT_RECORD_ARRAY_REF(IONode, Outputs)
+  RDAT_RECORD_ARRAY_REF(IONode, Inputs)
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+// ------------ RuntimeDataFunctionInfo2 ------------
+
+#define RECORD_TYPE RuntimeDataFunctionInfo2
+RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo,
+                          FunctionTable)
+
+  // 128 lanes is maximum that could be supported by HLSL
+  RDAT_VALUE(uint8_t, MinimumExpectedWaveLaneCount) // 0 = none specified
+  RDAT_VALUE(uint8_t, MaximumExpectedWaveLaneCount) // 0 = none specified
+  RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
+
+  RDAT_RECORD_REF(NodeShaderInfo, Node)
+
+RDAT_STRUCT_END()
+#undef RECORD_TYPE
+
+#endif // DEF_RDAT_TYPES
+
+
+///////////////////////////////////////////////////////////////////////////////
+// The following are experimental, and are not currently supported on any
+// validator version.
+
+// ------------ RuntimeDataFunctionInfo3 dependencies ------------
+
+#ifdef DEF_DXIL_ENUMS
+
 RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
-// clang-format off
-  // Python lines need to be not formatted.
   /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
-  // clang-format onm
   // SemanticKind-ENUM:BEGIN
   RDAT_ENUM_VALUE_NODEF(Arbitrary)
   RDAT_ENUM_VALUE_NODEF(VertexID)
@@ -190,7 +462,8 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::ComponentType, uint32_t)
   RDAT_ENUM_VALUE_NODEF(PackedU8x32)
   RDAT_ENUM_VALUE_NODEF(LastEntry)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19, "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ComponentType::LastEntry == 19,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -205,35 +478,8 @@ RDAT_DXIL_ENUM_START(hlsl::DXIL::InterpolationMode, uint32_t)
   RDAT_ENUM_VALUE_NODEF(LinearNoperspectiveSample)
   RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8, "otherwise, RDAT_DXIL_ENUM definition needs updating");
-#endif
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeIOKind, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(EmptyInput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutput)
-  RDAT_ENUM_VALUE_NODEF(NodeOutputArray)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutput)
-  RDAT_ENUM_VALUE_NODEF(EmptyOutputArray)
-  RDAT_ENUM_VALUE_NODEF(DispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWDispatchNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(RWGroupNodeInputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(RWThreadNodeInputRecord)
-  RDAT_ENUM_VALUE_NODEF(GroupNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(ThreadNodeOutputRecords)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_END()
-
-RDAT_DXIL_ENUM_START(hlsl::DXIL::NodeLaunchType, uint32_t)
-  RDAT_ENUM_VALUE_NODEF(Invalid)
-  RDAT_ENUM_VALUE_NODEF(Broadcasting)
-  RDAT_ENUM_VALUE_NODEF(Coalescing)
-  RDAT_ENUM_VALUE_NODEF(Thread)
-  RDAT_ENUM_VALUE_NODEF(LastEntry)
-#if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-  static_assert((unsigned)hlsl::DXIL::NodeLaunchType::LastEntry == 4, "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::InterpolationMode::Invalid == 8,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -241,91 +487,50 @@ RDAT_ENUM_END()
 
 #ifdef DEF_RDAT_TYPES
 
-#define RECORD_TYPE RuntimeDataResourceInfo
-RDAT_STRUCT_TABLE(RuntimeDataResourceInfo, ResourceTable)
-  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceClass, Class)
-  RDAT_ENUM(uint32_t, hlsl::DXIL::ResourceKind, Kind)
-  RDAT_VALUE(uint32_t, ID)
-  RDAT_VALUE(uint32_t, Space)
-  RDAT_VALUE(uint32_t, LowerBound)
-  RDAT_VALUE(uint32_t, UpperBound)
-  RDAT_STRING(Name)
-  RDAT_FLAGS(uint32_t, DxilResourceFlag, Flags)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE RuntimeDataFunctionInfo
-RDAT_STRUCT_TABLE(RuntimeDataFunctionInfo, FunctionTable)
-  // full function name
-  RDAT_STRING(Name)
-  // unmangled function name
-  RDAT_STRING(UnmangledName)
-  // list of global resources used by this function
-  RDAT_RECORD_ARRAY_REF(RuntimeDataResourceInfo, Resources)
-  // list of external function names this function calls
-  RDAT_STRING_ARRAY_REF(FunctionDependencies)
-  // Shader type, or library function
-  RDAT_ENUM(uint32_t, hlsl::DXIL::ShaderKind, ShaderKind)
-  // Payload Size:
-  // 1) any/closest hit or miss shader: payload size
-  // 2) call shader: parameter size 
-  RDAT_VALUE(uint32_t, PayloadSizeInBytes)
-  // attribute size for closest hit and any hit
-  RDAT_VALUE(uint32_t, AttributeSizeInBytes)
-  // first 32 bits of feature flag
-  RDAT_VALUE(uint32_t, FeatureInfo1)
-  // second 32 bits of feature flag
-  RDAT_VALUE(uint32_t, FeatureInfo2)
-  // valid shader stage flag.
-  RDAT_VALUE(uint32_t, ShaderStageFlag)
-  // minimum shader target.
-  RDAT_VALUE(uint32_t, MinShaderTarget)
-
-#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  // void SetFeatureFlags(uint64_t flags) convenience method
-  void SetFeatureFlags(uint64_t flags) {
-    FeatureInfo1 = flags & 0xffffffff;
-    FeatureInfo2 = (flags >> 32) & 0xffffffff;
-  }
-#endif
-
-#if DEF_RDAT_TYPES == DEF_RDAT_READER_DECL
-  // uint64_t GetFeatureFlags() convenience method
-  uint64_t GetFeatureFlags();
-#elif DEF_RDAT_TYPES == DEF_RDAT_READER_IMPL
-  // uint64_t GetFeatureFlags() convenience method
-  uint64_t RuntimeDataFunctionInfo_Reader::GetFeatureFlags() {
-    return asRecord() ? (((uint64_t)asRecord()->FeatureInfo2 << 32) |
-                         (uint64_t)asRecord()->FeatureInfo1)
-                      : 0;
-  }
-#endif
-
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
 #define RECORD_TYPE SignatureElement
 RDAT_STRUCT_TABLE(SignatureElement, SignatureElementTable)
   RDAT_STRING(SemanticName)
-  RDAT_INDEX_ARRAY_REF(SemanticIndices)         // Rows = SemanticIndices.Count()
+  RDAT_INDEX_ARRAY_REF(SemanticIndices) // Rows = SemanticIndices.Count()
   RDAT_ENUM(uint8_t, hlsl::DXIL::SemanticKind, SemanticKind)
   RDAT_ENUM(uint8_t, hlsl::DXIL::ComponentType, ComponentType)
   RDAT_ENUM(uint8_t, hlsl::DXIL::InterpolationMode, InterpolationMode)
-  RDAT_VALUE(uint8_t, StartRow)                 // Starting row of packed location if allocated, otherwise 0xFF
-  // TODO: use struct with bitfields or accessors for ColsAndStream and UsageAndDynIndexMasks
-  RDAT_VALUE(uint8_t, ColsAndStream)            // 0:2 = (Cols-1) (0-3), 2:4 = StartCol (0-3), 4:6 = OutputStream (0-3)
-  RDAT_VALUE(uint8_t, UsageAndDynIndexMasks)    // 0:4 = UsageMask, 4:8 = DynamicIndexMask
+  RDAT_VALUE(
+      uint8_t,
+      StartRow) // Starting row of packed location if allocated, otherwise 0xFF
+  // TODO: use struct with bitfields or accessors for ColsAndStream and
+  // UsageAndDynIndexMasks
+  RDAT_VALUE(uint8_t, ColsAndStream) // 0:2 = (Cols-1) (0-3), 2:4 = StartCol
+                                     // (0-3), 4:6 = OutputStream (0-3)
+  RDAT_VALUE(uint8_t,
+             UsageAndDynIndexMasks) // 0:4 = UsageMask, 4:8 = DynamicIndexMask
 #if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
   uint8_t GetCols() const { return (ColsAndStream & 3) + 1; }
   uint8_t GetStartCol() const { return (ColsAndStream >> 2) & 3; }
   uint8_t GetOutputStream() const { return (ColsAndStream >> 4) & 3; }
   uint8_t GetUsageMask() const { return UsageAndDynIndexMasks & 0xF; }
-  uint8_t GetDynamicIndexMask() const { return (UsageAndDynIndexMasks >> 4) & 0xF; }
-  void SetCols(unsigned cols) { ColsAndStream &= ~3; ColsAndStream |= (cols - 1) & 3; }
-  void SetStartCol(unsigned col) { ColsAndStream &= ~(3 << 2); ColsAndStream |= (col & 3) << 2; }
-  void SetOutputStream(unsigned stream) { ColsAndStream &= ~(3 << 4); ColsAndStream |= (stream & 3) << 4; }
-  void SetUsageMask(unsigned mask) { UsageAndDynIndexMasks &= ~0xF; UsageAndDynIndexMasks |= mask & 0xF; }
-  void SetDynamicIndexMask(unsigned mask) { UsageAndDynIndexMasks &= ~(0xF << 4); UsageAndDynIndexMasks |= (mask & 0xF) << 4; }
+  uint8_t GetDynamicIndexMask() const {
+    return (UsageAndDynIndexMasks >> 4) & 0xF;
+  }
+  void SetCols(unsigned cols) {
+    ColsAndStream &= ~3;
+    ColsAndStream |= (cols - 1) & 3;
+  }
+  void SetStartCol(unsigned col) {
+    ColsAndStream &= ~(3 << 2);
+    ColsAndStream |= (col & 3) << 2;
+  }
+  void SetOutputStream(unsigned stream) {
+    ColsAndStream &= ~(3 << 4);
+    ColsAndStream |= (stream & 3) << 4;
+  }
+  void SetUsageMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~0xF;
+    UsageAndDynIndexMasks |= mask & 0xF;
+  }
+  void SetDynamicIndexMask(unsigned mask) {
+    UsageAndDynIndexMasks &= ~(0xF << 4);
+    UsageAndDynIndexMasks |= (mask & 0xF) << 4;
+  }
 #endif
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -389,7 +594,8 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE CSInfo
 RDAT_STRUCT_TABLE(CSInfo, CSInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
@@ -400,7 +606,8 @@ RDAT_STRUCT_TABLE(MSInfo, MSInfoTable)
   RDAT_RECORD_ARRAY_REF(SignatureElement, SigPrimOutputElements)
   RDAT_BYTES(ViewIDOutputMask)
   RDAT_BYTES(ViewIDPrimOutputMask)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, GroupSharedBytesDependentOnViewID)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
@@ -412,116 +619,18 @@ RDAT_STRUCT_END()
 
 #define RECORD_TYPE ASInfo
 RDAT_STRUCT_TABLE(ASInfo, ASInfoTable)
-  RDAT_INDEX_ARRAY_REF(NumThreads)  // ref to array of X, Y, Z.  If < 3 elements, default value is 1
+  RDAT_INDEX_ARRAY_REF(NumThreads) // ref to array of X, Y, Z.  If < 3 elements,
+                                   // default value is 1
   RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
   RDAT_VALUE(uint32_t, PayloadSizeInBytes)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-#define RECORD_TYPE RecordDispatchGrid
-RDAT_STRUCT(RecordDispatchGrid)
-  RDAT_VALUE(uint16_t, ByteOffset)
-  RDAT_VALUE(uint16_t, ComponentNumAndType) // 0:2 = NumComponents (0-3), 3:15 = hlsl::DXIL::ComponentType enum
-#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint8_t GetNumComponents() const { return (ComponentNumAndType & 0x3); }
-  hlsl::DXIL::ComponentType GetComponentType() const { return (hlsl::DXIL::ComponentType)(ComponentNumAndType >> 2); }
-  void SetNumComponents(uint8_t num) { ComponentNumAndType |= (num & 0x3); }
-  void SetComponentType(hlsl::DXIL::ComponentType type) { ComponentNumAndType |= (((uint16_t)type) << 2); }
-#endif
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
+// ------------ RuntimeDataFunctionInfo3 ------------
 
-#define RECORD_TYPE NodeID
-RDAT_STRUCT_TABLE(NodeID, NodeIDTable)
-  RDAT_STRING(Name)
-  RDAT_VALUE(uint32_t, Index)
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-
-#define RECORD_TYPE NodeShaderFuncAttrib
-RDAT_STRUCT_TABLE(NodeShaderFuncAttrib, NodeShaderFuncAttribTable)
-  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeFuncAttribKind, AttribKind)
-  RDAT_UNION()
-    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ID)
-      RDAT_RECORD_REF(NodeID, ID)
-    RDAT_UNION_ELIF(NumThreads, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::NumThreads)
-      RDAT_INDEX_ARRAY_REF(NumThreads)
-    RDAT_UNION_ELIF(SharedInput, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::ShareInputOf)
-      RDAT_RECORD_REF(NodeID, ShareInputOf)
-    RDAT_UNION_ELIF(DispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::DispatchGrid)
-      RDAT_INDEX_ARRAY_REF(DispatchGrid)
-    RDAT_UNION_ELIF(MaxRecursionDepth, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxRecursionDepth)
-      RDAT_VALUE(uint32_t, MaxRecursionDepth)
-    RDAT_UNION_ELIF(LocalRootArgumentsTableIndex, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::LocalRootArgumentsTableIndex)
-      RDAT_VALUE(uint32_t, LocalRootArgumentsTableIndex)
-    RDAT_UNION_ELIF(MaxDispatchGrid, getAttribKind() == hlsl::RDAT::NodeFuncAttribKind::MaxDispatchGrid)
-      RDAT_INDEX_ARRAY_REF(MaxDispatchGrid)
-    RDAT_UNION_ENDIF()
-  RDAT_UNION_END()
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-
-#define RECORD_TYPE NodeShaderIOAttrib
-RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
-  RDAT_ENUM(uint32_t, hlsl::RDAT::NodeAttribKind, AttribKind)
-  RDAT_UNION()
-    RDAT_UNION_IF(ID, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputID)
-      RDAT_RECORD_REF(NodeID, OutputID)
-    RDAT_UNION_ELIF(MaxRecords, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecords)
-      RDAT_VALUE(uint32_t, MaxRecords)
-    RDAT_UNION_ELIF(MaxRecordsSharedWith, getAttribKind() == hlsl::RDAT::NodeAttribKind::MaxRecordsSharedWith)
-      RDAT_VALUE(uint32_t, MaxRecordsSharedWith)
-    RDAT_UNION_ELIF(RecordSizeInBytes, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordSizeInBytes)
-      RDAT_VALUE(uint32_t, RecordSizeInBytes)
-    RDAT_UNION_ELIF(RecordDispatchGrid, getAttribKind() == hlsl::RDAT::NodeAttribKind::RecordDispatchGrid)
-      RDAT_RECORD_VALUE(RecordDispatchGrid, RecordDispatchGrid)
-    RDAT_UNION_ELIF(OutputArraySize, getAttribKind() == hlsl::RDAT::NodeAttribKind::OutputArraySize)
-      RDAT_VALUE(uint32_t, OutputArraySize)
-    RDAT_UNION_ELIF(AllowSparseNodes, getAttribKind() == hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
-      RDAT_VALUE(uint32_t, AllowSparseNodes)
-  RDAT_UNION_ENDIF()
-  RDAT_UNION_END()
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-
-
-#define RECORD_TYPE IONode
-RDAT_STRUCT_TABLE(IONode, IONodeTable)
-  // Required field
-  RDAT_VALUE(uint32_t, IOFlagsAndKind)
-  // Optional fields
-  RDAT_RECORD_ARRAY_REF(NodeShaderIOAttrib, Attribs)
-#if DEF_RDAT_TYPES == DEF_RDAT_TYPES_USE_HELPERS
-  uint32_t GetIOFlags() const { return IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeFlagsMask; }
-  hlsl::DXIL::NodeIOKind GetIOKind() const { return (hlsl::DXIL::NodeIOKind)(IOFlagsAndKind & (uint32_t)DXIL::NodeIOFlags::NodeIOKindMask); }
-  void SetIOFlags(uint32_t flags) { IOFlagsAndKind |= flags; }
-  void SetIOKind(hlsl::DXIL::NodeIOKind kind) { IOFlagsAndKind |= (uint32_t)kind; }
-#endif
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE NodeShaderInfo
-RDAT_STRUCT_TABLE(NodeShaderInfo, NodeShaderInfoTable)
-  // Function Attributes
-  RDAT_ENUM(uint32_t, hlsl::DXIL::NodeLaunchType, LaunchType)
-  RDAT_VALUE(uint32_t, GroupSharedBytesUsed)
-  RDAT_RECORD_ARRAY_REF(NodeShaderFuncAttrib, Attribs)
-  RDAT_RECORD_ARRAY_REF(IONode, Outputs)
-  RDAT_RECORD_ARRAY_REF(IONode, Inputs)
-
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
-#define RECORD_TYPE RuntimeDataFunctionInfo2
-RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, FunctionTable)
-
-  // 128 lanes is maximum that could be supported by HLSL
-  RDAT_VALUE(uint8_t, MinimumExpectedWaveLaneCount) // 0 = none specified
-  RDAT_VALUE(uint8_t, MaximumExpectedWaveLaneCount) // 0 = none specified
-  RDAT_FLAGS(uint16_t, hlsl::RDAT::DxilShaderFlags, ShaderFlags)
+#define RECORD_TYPE RuntimeDataFunctionInfo3
+RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo3, RuntimeDataFunctionInfo2,
+                          FunctionTable)
 
   RDAT_UNION()
     RDAT_UNION_IF(VS, (getShaderKind() == hlsl::DXIL::ShaderKind::Vertex))
@@ -538,9 +647,11 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, Fun
       RDAT_RECORD_REF(CSInfo, CS)
     RDAT_UNION_ELIF(MS, (getShaderKind() == hlsl::DXIL::ShaderKind::Mesh))
       RDAT_RECORD_REF(MSInfo, MS)
-    RDAT_UNION_ELIF(AS, (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
+    RDAT_UNION_ELIF(AS,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Amplification))
       RDAT_RECORD_REF(ASInfo, AS)
-    RDAT_UNION_ELIF(RawShaderRef, (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
+    RDAT_UNION_ELIF(RawShaderRef,
+                    (getShaderKind() == hlsl::DXIL::ShaderKind::Invalid))
       RDAT_VALUE(uint32_t, RawShaderRef)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
@@ -548,12 +659,6 @@ RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo2, RuntimeDataFunctionInfo, Fun
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
-#define RECORD_TYPE RuntimeDataFunctionInfo3
-RDAT_STRUCT_TABLE_DERIVED(RuntimeDataFunctionInfo3, RuntimeDataFunctionInfo2, FunctionTable)
-
-  RDAT_RECORD_REF(NodeShaderInfo, Node)
-
-RDAT_STRUCT_END()
-#undef RECORD_TYPE
-
 #endif // DEF_RDAT_TYPES
+
+// clang-format on

--- a/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
@@ -9,6 +9,13 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
+//////////////////////////////////////////////////////////////////////
+// The following require validator version 1.4 and above.
+
 #ifdef DEF_RDAT_ENUMS
 
 // Nothing yet
@@ -18,53 +25,54 @@
 #ifdef DEF_DXIL_ENUMS
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::SubobjectKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(StateObjectConfig)
-RDAT_ENUM_VALUE_NODEF(GlobalRootSignature)
-RDAT_ENUM_VALUE_NODEF(LocalRootSignature)
-RDAT_ENUM_VALUE_NODEF(SubobjectToExportsAssociation)
-RDAT_ENUM_VALUE_NODEF(RaytracingShaderConfig)
-RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig)
-RDAT_ENUM_VALUE_NODEF(HitGroup)
-RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig1)
-// No need to define this here
-// RDAT_ENUM_VALUE_NODEF(NumKinds)
+  RDAT_ENUM_VALUE_NODEF(StateObjectConfig)
+  RDAT_ENUM_VALUE_NODEF(GlobalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(LocalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(SubobjectToExportsAssociation)
+  RDAT_ENUM_VALUE_NODEF(RaytracingShaderConfig)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig)
+  RDAT_ENUM_VALUE_NODEF(HitGroup)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig1)
+  // No need to define this here
+  // RDAT_ENUM_VALUE_NODEF(NumKinds)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::SubobjectKind::NumKinds == 13,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::SubobjectKind::NumKinds == 13,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::StateObjectFlags, uint32_t)
-RDAT_ENUM_VALUE_NODEF(AllowLocalDependenciesOnExternalDefinitions)
-RDAT_ENUM_VALUE_NODEF(AllowExternalDependenciesOnLocalDefinitions)
-RDAT_ENUM_VALUE_NODEF(AllowStateObjectAdditions)
-// No need to define these masks here
-// RDAT_ENUM_VALUE_NODEF(ValidMask_1_4)
-// RDAT_ENUM_VALUE_NODEF(ValidMask)
+  RDAT_ENUM_VALUE_NODEF(AllowLocalDependenciesOnExternalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowExternalDependenciesOnLocalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowStateObjectAdditions)
+  // No need to define these masks here
+  // RDAT_ENUM_VALUE_NODEF(ValidMask_1_4)
+  // RDAT_ENUM_VALUE_NODEF(ValidMask)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::StateObjectFlags::ValidMask == 0x7,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::StateObjectFlags::ValidMask == 0x7,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::HitGroupType, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Triangle)
-RDAT_ENUM_VALUE_NODEF(ProceduralPrimitive)
+  RDAT_ENUM_VALUE_NODEF(Triangle)
+  RDAT_ENUM_VALUE_NODEF(ProceduralPrimitive)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::HitGroupType::LastEntry == 2,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::HitGroupType::LastEntry == 2,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::RaytracingPipelineFlags, uint32_t)
-RDAT_ENUM_VALUE_NODEF(None)
-RDAT_ENUM_VALUE_NODEF(SkipTriangles)
-RDAT_ENUM_VALUE_NODEF(SkipProceduralPrimitives)
-// No need to define mask here
-// RDAT_ENUM_VALUE_NODEF(ValidMask)
+  RDAT_ENUM_VALUE_NODEF(None)
+  RDAT_ENUM_VALUE_NODEF(SkipTriangles)
+  RDAT_ENUM_VALUE_NODEF(SkipProceduralPrimitives)
+  // No need to define mask here
+  // RDAT_ENUM_VALUE_NODEF(ValidMask)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::RaytracingPipelineFlags::ValidMask == 0x300,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::RaytracingPipelineFlags::ValidMask ==
+                    0x300,
+                "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -74,99 +82,104 @@ RDAT_ENUM_END()
 
 #define RECORD_TYPE StateObjectConfig_t
 RDAT_STRUCT(StateObjectConfig_t)
-RDAT_FLAGS(uint32_t, hlsl::DXIL::StateObjectFlags, Flags)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::StateObjectFlags, Flags)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RootSignature_t
 RDAT_STRUCT(RootSignature_t)
-RDAT_BYTES(Data)
+  RDAT_BYTES(Data)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE SubobjectToExportsAssociation_t
 RDAT_STRUCT(SubobjectToExportsAssociation_t)
-RDAT_STRING(Subobject)
-RDAT_STRING_ARRAY_REF(Exports)
+  RDAT_STRING(Subobject)
+  RDAT_STRING_ARRAY_REF(Exports)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingShaderConfig_t
 RDAT_STRUCT(RaytracingShaderConfig_t)
-RDAT_VALUE(uint32_t, MaxPayloadSizeInBytes)
-RDAT_VALUE(uint32_t, MaxAttributeSizeInBytes)
+  RDAT_VALUE(uint32_t, MaxPayloadSizeInBytes)
+  RDAT_VALUE(uint32_t, MaxAttributeSizeInBytes)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingPipelineConfig_t
 RDAT_STRUCT(RaytracingPipelineConfig_t)
-RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE HitGroup_t
 RDAT_STRUCT(HitGroup_t)
-RDAT_ENUM(uint32_t, hlsl::DXIL::HitGroupType, Type)
-RDAT_STRING(AnyHit)
-RDAT_STRING(ClosestHit)
-RDAT_STRING(Intersection)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::HitGroupType, Type)
+  RDAT_STRING(AnyHit)
+  RDAT_STRING(ClosestHit)
+  RDAT_STRING(Intersection)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingPipelineConfig1_t
 RDAT_STRUCT(RaytracingPipelineConfig1_t)
-RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
-RDAT_FLAGS(uint32_t, hlsl::DXIL::RaytracingPipelineFlags, Flags)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::RaytracingPipelineFlags, Flags)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RuntimeDataSubobjectInfo
 RDAT_STRUCT_TABLE(RuntimeDataSubobjectInfo, SubobjectTable)
-RDAT_ENUM(uint32_t, hlsl::DXIL::SubobjectKind, Kind)
-RDAT_STRING(Name)
-RDAT_UNION()
-RDAT_UNION_IF(StateObjectConfig,
-              ((uint32_t)pRecord->Kind ==
-               (uint32_t)hlsl::DXIL::SubobjectKind::StateObjectConfig))
-RDAT_RECORD_VALUE(StateObjectConfig_t, StateObjectConfig)
-RDAT_UNION_ELIF(RootSignature,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::GlobalRootSignature) ||
-                    ((uint32_t)pRecord->Kind ==
-                     (uint32_t)hlsl::DXIL::SubobjectKind::LocalRootSignature))
-RDAT_RECORD_VALUE(RootSignature_t, RootSignature)
-RDAT_UNION_ELIF(
-    SubobjectToExportsAssociation,
-    ((uint32_t)pRecord->Kind ==
-     (uint32_t)hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation))
-RDAT_RECORD_VALUE(SubobjectToExportsAssociation_t,
-                  SubobjectToExportsAssociation)
-RDAT_UNION_ELIF(RaytracingShaderConfig,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingShaderConfig))
-RDAT_RECORD_VALUE(RaytracingShaderConfig_t, RaytracingShaderConfig)
-RDAT_UNION_ELIF(RaytracingPipelineConfig,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig))
-RDAT_RECORD_VALUE(RaytracingPipelineConfig_t, RaytracingPipelineConfig)
-RDAT_UNION_ELIF(HitGroup, ((uint32_t)pRecord->Kind ==
-                           (uint32_t)hlsl::DXIL::SubobjectKind::HitGroup))
-RDAT_RECORD_VALUE(HitGroup_t, HitGroup)
-RDAT_UNION_ELIF(
-    RaytracingPipelineConfig1,
-    ((uint32_t)pRecord->Kind ==
-     (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig1))
-RDAT_RECORD_VALUE(RaytracingPipelineConfig1_t, RaytracingPipelineConfig1)
-RDAT_UNION_ENDIF()
-RDAT_UNION_END()
+  RDAT_ENUM(uint32_t, hlsl::DXIL::SubobjectKind, Kind)
+  RDAT_STRING(Name)
+  RDAT_UNION()
+    RDAT_UNION_IF(StateObjectConfig,
+                  ((uint32_t)pRecord->Kind ==
+                   (uint32_t)hlsl::DXIL::SubobjectKind::StateObjectConfig))
+      RDAT_RECORD_VALUE(StateObjectConfig_t, StateObjectConfig)
+    RDAT_UNION_ELIF(
+        RootSignature,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::GlobalRootSignature) ||
+            ((uint32_t)pRecord->Kind ==
+             (uint32_t)hlsl::DXIL::SubobjectKind::LocalRootSignature))
+      RDAT_RECORD_VALUE(RootSignature_t, RootSignature)
+    RDAT_UNION_ELIF(
+        SubobjectToExportsAssociation,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation))
+      RDAT_RECORD_VALUE(SubobjectToExportsAssociation_t,
+                        SubobjectToExportsAssociation)
+    RDAT_UNION_ELIF(
+        RaytracingShaderConfig,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingShaderConfig))
+      RDAT_RECORD_VALUE(RaytracingShaderConfig_t, RaytracingShaderConfig)
+    RDAT_UNION_ELIF(
+        RaytracingPipelineConfig,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig_t, RaytracingPipelineConfig)
+    RDAT_UNION_ELIF(HitGroup, ((uint32_t)pRecord->Kind ==
+                               (uint32_t)hlsl::DXIL::SubobjectKind::HitGroup))
+      RDAT_RECORD_VALUE(HitGroup_t, HitGroup)
+    RDAT_UNION_ELIF(
+        RaytracingPipelineConfig1,
+        ((uint32_t)pRecord->Kind ==
+         (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig1))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig1_t, RaytracingPipelineConfig1)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
 
-// Note: this is how one could inject custom code into one of the definition
-// modes:
+  // Note: this is how one could inject custom code into one of the definition
+  // modes:
 #if DEF_RDAT_TYPES == DEF_RDAT_READER
-// Add custom code here that only gets added to the reader class definition
+  // Add custom code here that only gets added to the reader class definition
 #endif
 
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #endif // DEF_RDAT_TYPES
+
+// clang-format on

--- a/include/dxc/Test/DumpContext.h
+++ b/include/dxc/Test/DumpContext.h
@@ -112,7 +112,7 @@ public:
 
   // Return true if ptr has not yet been visited, prevents recursive dumping
   bool Visit(size_t value) { return m_visited.insert(value).second; }
-  bool Visit(const void *ptr) { return Visit((size_t)ptr); }
+  bool Visit(const void *ptr) { return ptr ? Visit((size_t)ptr) : false; }
   void VisitReset() { m_visited.clear(); }
 };
 

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1682,12 +1682,12 @@ private:
     // We must select the appropriate shader mask for the validator version,
     // so we don't set any bits the validator doesn't recognize.
     unsigned ValidShaderMask =
-        (1 << ((unsigned)DXIL::ShaderKind::Node + 1)) - 1;
+        (1 << ((unsigned)DXIL::ShaderKind::LastValid + 1)) - 1;
     if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 5) < 0) {
-      ValidShaderMask = (1 << ((unsigned)DXIL::ShaderKind::Callable + 1)) - 1;
+      ValidShaderMask = (1 << ((unsigned)DXIL::ShaderKind::Last_1_4 + 1)) - 1;
     } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) < 0) {
       ValidShaderMask =
-          (1 << ((unsigned)DXIL::ShaderKind::Amplification + 1)) - 1;
+          (1 << ((unsigned)DXIL::ShaderKind::Last_1_7 + 1)) - 1;
     }
     for (auto &function : M->getFunctionList()) {
       if (function.isDeclaration() && !function.isIntrinsic() &&
@@ -1782,23 +1782,21 @@ private:
             payloadSizeInBytes = props.ShaderProps.Ray.paramSizeInBytes;
           }
           shaderKind = (uint32_t)props.shaderKind;
-          if (DM.HasDxilEntryProps(&function)) {
+          if (pInfo2 && DM.HasDxilEntryProps(&function)) {
             const auto &entryProps = DM.GetDxilEntryProps(&function);
-            if (pInfo2) {
-              unsigned waveSize = entryProps.props.waveSize;
-              if (waveSize) {
-                pInfo2->MinimumExpectedWaveLaneCount = waveSize;
-                pInfo2->MaximumExpectedWaveLaneCount = waveSize;
-              }
-              pInfo2->ShaderFlags = 0;
-              if (entryProps.props.IsNode()) {
-                shaderInfo = AddShaderNodeInfo(DM, function, entryProps,
-                                               *pInfo2, TGSMInFunc[&function]);
-              } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >
-                         0) {
-                shaderInfo = AddShaderInfo(function, entryProps, *pInfo2, flags,
-                                           TGSMInFunc[&function]);
-              }
+            unsigned waveSize = entryProps.props.waveSize;
+            if (waveSize) {
+              pInfo2->MinimumExpectedWaveLaneCount = waveSize;
+              pInfo2->MaximumExpectedWaveLaneCount = waveSize;
+            }
+            pInfo2->ShaderFlags = 0;
+            if (entryProps.props.IsNode()) {
+              shaderInfo = AddShaderNodeInfo(DM, function, entryProps, *pInfo2,
+                                             TGSMInFunc[&function]);
+            } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >
+                       0) {
+              shaderInfo = AddShaderInfo(function, entryProps, *pInfo2, flags,
+                                         TGSMInFunc[&function]);
             }
           }
         }

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1686,8 +1686,7 @@ private:
     if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 5) < 0) {
       ValidShaderMask = (1 << ((unsigned)DXIL::ShaderKind::Last_1_4 + 1)) - 1;
     } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) < 0) {
-      ValidShaderMask =
-          (1 << ((unsigned)DXIL::ShaderKind::Last_1_7 + 1)) - 1;
+      ValidShaderMask = (1 << ((unsigned)DXIL::ShaderKind::Last_1_7 + 1)) - 1;
     }
     for (auto &function : M->getFunctionList()) {
       if (function.isDeclaration() && !function.isIntrinsic() &&

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1310,10 +1310,11 @@ private:
         info.Flags |=
             static_cast<uint32_t>(RDAT::DxilResourceFlag::UAVGloballyCoherent);
       if (pRes->IsROV())
-        info.Flags |=
-            static_cast<uint32_t>(RDAT::DxilResourceFlag::UAVRasterizerOrderedView);
+        info.Flags |= static_cast<uint32_t>(
+            RDAT::DxilResourceFlag::UAVRasterizerOrderedView);
       if (pRes->HasAtomic64Use())
-        info.Flags |= static_cast<uint32_t>(RDAT::DxilResourceFlag::Atomics64Use);
+        info.Flags |=
+            static_cast<uint32_t>(RDAT::DxilResourceFlag::Atomics64Use);
       // TODO: add dynamic index flag
     }
     m_pResourceTable->Insert(info);
@@ -1791,8 +1792,8 @@ private:
               }
               pInfo2->ShaderFlags = 0;
               if (entryProps.props.IsNode()) {
-                shaderInfo = AddShaderNodeInfo(DM, function, entryProps, *pInfo2,
-                                             TGSMInFunc[&function]);
+                shaderInfo = AddShaderNodeInfo(DM, function, entryProps,
+                                               *pInfo2, TGSMInFunc[&function]);
               } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >
                          0) {
                 shaderInfo = AddShaderInfo(function, entryProps, *pInfo2, flags,

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1467,7 +1467,7 @@ private:
 
   uint32_t AddShaderInfo(llvm::Function &function,
                          const DxilEntryProps &entryProps,
-                         RuntimeDataFunctionInfo3 &funcInfo,
+                         RuntimeDataFunctionInfo2 &funcInfo,
                          const ShaderFlags &flags, uint32_t tgsmSizeInBytes) {
     const DxilFunctionProps &props = entryProps.props;
     const DxilEntrySignature &sig = entryProps.sig;
@@ -1681,9 +1681,12 @@ private:
     // We must select the appropriate shader mask for the validator version,
     // so we don't set any bits the validator doesn't recognize.
     unsigned ValidShaderMask =
-        (1 << ((unsigned)DXIL::ShaderKind::Amplification + 1)) - 1;
+        (1 << ((unsigned)DXIL::ShaderKind::Node + 1)) - 1;
     if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 5) < 0) {
       ValidShaderMask = (1 << ((unsigned)DXIL::ShaderKind::Callable + 1)) - 1;
+    } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) < 0) {
+      ValidShaderMask =
+          (1 << ((unsigned)DXIL::ShaderKind::Amplification + 1)) - 1;
     }
     for (auto &function : M->getFunctionList()) {
       if (function.isDeclaration() && !function.isIntrinsic() &&
@@ -1750,7 +1753,6 @@ private:
         uint32_t attrSizeInBytes = 0;
         uint32_t shaderKind = static_cast<uint32_t>(DXIL::ShaderKind::Library);
         uint32_t shaderInfo = RDAT_NULL_REF;
-        uint32_t nodeInfo = RDAT_NULL_REF;
 
         if (m_FuncToResNameOffset.find(&function) !=
             m_FuncToResNameOffset.end())
@@ -1761,13 +1763,9 @@ private:
           functionDependencies =
               Builder.InsertArray(m_FuncToDependencies[&function].begin(),
                                   m_FuncToDependencies[&function].end());
-        RuntimeDataFunctionInfo3 info_latest = {};
+        RuntimeDataFunctionInfo2 info_latest = {};
         RuntimeDataFunctionInfo &info = info_latest;
         RuntimeDataFunctionInfo2 *pInfo2 = (sizeof(RuntimeDataFunctionInfo2) <=
-                                            m_pFunctionTable->GetRecordStride())
-                                               ? &info_latest
-                                               : nullptr;
-        RuntimeDataFunctionInfo3 *pInfo3 = (sizeof(RuntimeDataFunctionInfo3) <=
                                             m_pFunctionTable->GetRecordStride())
                                                ? &info_latest
                                                : nullptr;
@@ -1793,13 +1791,13 @@ private:
               }
               pInfo2->ShaderFlags = 0;
               if (entryProps.props.IsNode()) {
-                nodeInfo = AddShaderNodeInfo(DM, function, entryProps, *pInfo2,
+                shaderInfo = AddShaderNodeInfo(DM, function, entryProps, *pInfo2,
                                              TGSMInFunc[&function]);
+              } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >
+                         0) {
+                shaderInfo = AddShaderInfo(function, entryProps, *pInfo2, flags,
+                                           TGSMInFunc[&function]);
               }
-            }
-            if (pInfo3) {
-              shaderInfo = AddShaderInfo(function, entryProps, *pInfo3, flags,
-                                         TGSMInFunc[&function]);
             }
           }
         }
@@ -1807,9 +1805,7 @@ private:
         info.UnmangledName = unmangledIndex;
         info.ShaderKind = shaderKind;
         if (pInfo2)
-          pInfo2->Node = nodeInfo;
-        if (pInfo3)
-          pInfo3->RawShaderRef = shaderInfo;
+          pInfo2->RawShaderRef = shaderInfo;
         info.Resources = resourceIndex;
         info.FunctionDependencies = functionDependencies;
         info.PayloadSizeInBytes = payloadSizeInBytes;
@@ -1939,10 +1935,7 @@ public:
     Builder.GetStringBufferPart();
     m_pResourceTable = Builder.GetOrAddTable<RDAT::RuntimeDataResourceInfo>();
     m_pFunctionTable = Builder.GetOrAddTable<RuntimeDataFunctionInfo>();
-    if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) > 0) {
-      // Experimental support only.
-      m_pFunctionTable->SetRecordStride(sizeof(RuntimeDataFunctionInfo3));
-    } else if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) == 0) {
+    if (DXIL::CompareVersions(m_ValMajor, m_ValMinor, 1, 8) >= 0) {
       m_pFunctionTable->SetRecordStride(sizeof(RuntimeDataFunctionInfo2));
     } else {
       m_pFunctionTable->SetRecordStride(sizeof(RuntimeDataFunctionInfo));

--- a/lib/DxilContainer/RDATDumper.cpp
+++ b/lib/DxilContainer/RDATDumper.cpp
@@ -93,7 +93,8 @@ void DumpRecordRef(const hlsl::RDAT::RDATContext &ctx, DumpContext &d,
       d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, ">");
     }
   } else {
-    d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, "> = <nullptr>");
+    d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName,
+              "> = <nullptr>");
   }
 }
 

--- a/lib/DxilContainer/RDATDumper.cpp
+++ b/lib/DxilContainer/RDATDumper.cpp
@@ -84,12 +84,16 @@ void DumpRecordRef(const hlsl::RDAT::RDATContext &ctx, DumpContext &d,
   if (nullptr == storedTypeName)
     storedTypeName = tyName;
   // Unique visit location is based on end of struct so derived are not skipped
-  if (d.Visit(rr.Get(ctx))) {
-    d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, "> = {");
-    rrDumper.Dump(ctx, d);
-    d.WriteLn("}");
+  if (rr.Get(ctx)) {
+    if (d.Visit(rr.Get(ctx))) {
+      d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, "> = {");
+      rrDumper.Dump(ctx, d);
+      d.WriteLn("}");
+    } else {
+      d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, ">");
+    }
   } else {
-    d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, ">");
+    d.WriteLn(memberName, ": <", rr.Index, ":", storedTypeName, "> = <nullptr>");
   }
 }
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/amp-groupshared.hlsl
@@ -1,11 +1,11 @@
-// RUN: %dxc  -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:  IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:  RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:  RecordTable (stride = 32 bytes) ResourceTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[1] = {
 // CHECK:    <0:RuntimeDataResourceInfo> = {
 // CHECK:      Class: SRV
 // CHECK:      Kind: TypedBuffer
@@ -17,8 +17,8 @@
 // CHECK:      Flags: 0 (None)
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo3> = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:      Name: "amplification"
 // CHECK:      UnmangledName: "amplification"
 // CHECK:      Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -51,7 +51,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 12 bytes) ASInfoTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) ASInfoTable[1] = {
 // CHECK:    <0:ASInfo> = {
 // CHECK:      NumThreads: <2:array[3]> = { 4, 1, 1 }
 // CHECK:      GroupSharedBytesUsed: 32

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/cbuf-usage-lib.hlsl
@@ -9,7 +9,7 @@
 // CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:   IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:   RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:   RecordTable (stride = 32 bytes) ResourceTable[3] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[3] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: CBuffer
 // CHECK:       Kind: CBuffer
@@ -41,8 +41,8 @@
 // CHECK:       Flags: 0 (None)
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 56 bytes) FunctionTable[2] = {
-// CHECK:     <0:RuntimeDataFunctionInfo3> = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[2] = {
+// CHECK:     <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?foo{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "foo"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -54,13 +54,13 @@
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <1:RuntimeDataFunctionInfo3> = {
+// CHECK:     <1:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "main"
 // CHECK:       UnmangledName: "main"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -78,40 +78,6 @@
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
-// CHECK:       VS: <0:VSInfo>
-// CHECK:     }
-// CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) SignatureElementTable[2] = {
-// CHECK:     <0:SignatureElement> = {
-// CHECK:       SemanticName: "IDX"
-// CHECK:       SemanticIndices: <5:array[1]> = { 0 }
-// CHECK:       SemanticKind: Arbitrary
-// CHECK:       ComponentType: I32
-// CHECK:       InterpolationMode: Undefined
-// CHECK:       StartRow: 0
-// CHECK:       ColsAndStream: 0
-// CHECK:       UsageAndDynIndexMasks: 0
-// CHECK:     }
-// CHECK:     <1:SignatureElement> = {
-// CHECK:       SemanticName: "OUT"
-// CHECK:       SemanticIndices: <5:array[1]> = { 0 }
-// CHECK:       SemanticKind: Arbitrary
-// CHECK:       ComponentType: F32
-// CHECK:       InterpolationMode: Linear
-// CHECK:       StartRow: 0
-// CHECK:       ColsAndStream: 0
-// CHECK:       UsageAndDynIndexMasks: 0
-// CHECK:     }
-// CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) VSInfoTable[1] = {
-// CHECK:     <0:VSInfo> = {
-// CHECK:       SigInputElements: <5:RecordArrayRef<SignatureElement>[1]>  = {
-// CHECK:         [0]: <0:SignatureElement>
-// CHECK:       }
-// CHECK:       SigOutputElements: <0:RecordArrayRef<SignatureElement>[1]>  = {
-// CHECK:         [0]: <1:SignatureElement>
-// CHECK:       }
-// CHECK:       ViewIDOutputMask: <0:bytes[0]>
 // CHECK:     }
 // CHECK:   }
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/comp-groupshared.hlsl
@@ -1,10 +1,10 @@
-// RUN: %dxc -T lib_6_5 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_5 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:  IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:  RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:  RecordTable (stride = 32 bytes) ResourceTable[2] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[2] = {
 // CHECK:    <0:RuntimeDataResourceInfo> = {
 // CHECK:      Class: SRV
 // CHECK:      Kind: TypedBuffer
@@ -26,8 +26,8 @@
 // CHECK:      Flags: 0 (None)
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo3> = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:      Name: "main"
 // CHECK:      UnmangledName: "main"
 // CHECK:      Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -69,7 +69,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) CSInfoTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) CSInfoTable[1] = {
 // CHECK:    <0:CSInfo> = {
 // CHECK:      NumThreads: <3:array[3]> = { 64, 2, 2 }
 // CHECK:      GroupSharedBytesUsed: 16

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
@@ -4,8 +4,8 @@
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:  IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:  RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo3> = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:      Name: "depth18part0_wg_63_nodes_seed_255"
 // CHECK:      UnmangledName: "depth18part0_wg_63_nodes_seed_255"
 // CHECK:      Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -90,7 +90,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeIDTable[2] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeIDTable[2] = {
 // CHECK:    <0:NodeID> = {
 // CHECK:      Name: "depth18part0_wg_63_nodes_seed_255"
 // CHECK:      Index: 0
@@ -100,7 +100,7 @@
 // CHECK:      Index: 0
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeShaderFuncAttribTable[3] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderFuncAttribTable[3] = {
 // CHECK:    <0:NodeShaderFuncAttrib> = {
 // CHECK:      AttribKind: ID
 // CHECK:      ID: <0:NodeID> = {
@@ -117,7 +117,7 @@
 // CHECK:      DispatchGrid: <4:array[3]> = { 2, 8, 10 }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeShaderIOAttribTable[7] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[7] = {
 // CHECK:    <0:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordSizeInBytes
 // CHECK:      RecordSizeInBytes: 8
@@ -152,7 +152,7 @@
 // CHECK:        ComponentNumAndType: 23
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) IONodeTable[2] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[2] = {
 // CHECK:    <0:IONode> = {
 // CHECK:      IOFlagsAndKind: 97
 // CHECK:      Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
@@ -197,7 +197,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 20 bytes) NodeShaderInfoTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderInfoTable[1] = {
 // CHECK:    <0:NodeShaderInfo> = {
 // CHECK:      LaunchType: Broadcasting
 // CHECK:      GroupSharedBytesUsed: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
@@ -5,8 +5,8 @@
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:  IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:  RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo3> = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:      Name: "Input2Output"
 // CHECK:      UnmangledName: "Input2Output"
 // CHECK:      Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -96,7 +96,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeIDTable[3] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeIDTable[3] = {
 // CHECK:    <0:NodeID> = {
 // CHECK:      Name: "Input2Output"
 // CHECK:      Index: 0
@@ -110,7 +110,7 @@
 // CHECK:      Index: 1
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeShaderFuncAttribTable[3] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderFuncAttribTable[3] = {
 // CHECK:    <0:NodeShaderFuncAttrib> = {
 // CHECK:      AttribKind: ID
 // CHECK:      ID: <0:NodeID> = {
@@ -127,7 +127,7 @@
 // CHECK:      LocalRootArgumentsTableIndex: 2
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) NodeShaderIOAttribTable[6] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[6] = {
 // CHECK:    <0:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordSizeInBytes
 // CHECK:      RecordSizeInBytes: 8
@@ -159,7 +159,7 @@
 // CHECK:      MaxRecords: 5
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 8 bytes) IONodeTable[3] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[3] = {
 // CHECK:    <0:IONode> = {
 // CHECK:      IOFlagsAndKind: 37
 // CHECK:      Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
@@ -218,7 +218,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 20 bytes) NodeShaderInfoTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderInfoTable[1] = {
 // CHECK:    <0:NodeShaderInfo> = {
 // CHECK:      LaunchType: Thread
 // CHECK:      GroupSharedBytesUsed: 0

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports1.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;PS_RENAMED=PSMain -T lib_6_3 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;PS_RENAMED=PSMain -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<float> T_unused;
 
@@ -25,7 +25,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:   IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:   RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:   RecordTable (stride = 32 bytes) ResourceTable[3] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[3] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV
 // CHECK:       Kind: TypedBuffer
@@ -57,8 +57,8 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Flags: 0 (None)
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 56 bytes) FunctionTable[3] = {
-// CHECK:     <0:RuntimeDataFunctionInfo3> = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[3] = {
+// CHECK:     <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "VS_RENAMED"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -70,13 +70,13 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <1:RuntimeDataFunctionInfo3> = {
+// CHECK:     <1:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?PS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PS_RENAMED"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -89,13 +89,13 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <2:RuntimeDataFunctionInfo3> = {
+// CHECK:     <2:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "PS_RENAMED"
 // CHECK:       UnmangledName: "PS_RENAMED"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -116,7 +116,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       PS: <0:PSInfo>
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) SignatureElementTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[2] = {
 // CHECK:     <0:SignatureElement> = {
 // CHECK:       SemanticName: "INDEX"
 // CHECK:       SemanticIndices: <5:array[1]> = { 0 }
@@ -138,7 +138,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       UsageAndDynIndexMasks: 0
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 8 bytes) PSInfoTable[1] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) PSInfoTable[1] = {
 // CHECK:     <0:PSInfo> = {
 // CHECK:       SigInputElements: <5:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:         [0]: <0:SignatureElement>

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports VSMain;VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;RayGen1,RayGen2=RayGen -T lib_6_3 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports VSMain;VS_RENAMED=\01?VSMain@@YA?AV?$vector@M$03@@V?$vector@H$02@@@Z;RayGen1,RayGen2=RayGen -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<int> T0;
 
@@ -30,7 +30,7 @@ void RayGen() {
 // CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:   IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:   RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:   RecordTable (stride = 32 bytes) ResourceTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[2] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV
 // CHECK:       Kind: Texture2D
@@ -52,8 +52,8 @@ void RayGen() {
 // CHECK:       Flags: 0 (None)
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 56 bytes) FunctionTable[4] = {
-// CHECK:     <0:RuntimeDataFunctionInfo3> = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[4] = {
+// CHECK:     <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?RayGen1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "RayGen1"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -71,7 +71,7 @@ void RayGen() {
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <1:RuntimeDataFunctionInfo3> = {
+// CHECK:     <1:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?VS_RENAMED{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "VS_RENAMED"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -83,13 +83,13 @@ void RayGen() {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <2:RuntimeDataFunctionInfo3> = {
+// CHECK:     <2:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?RayGen2{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "RayGen2"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -107,7 +107,7 @@ void RayGen() {
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <3:RuntimeDataFunctionInfo3> = {
+// CHECK:     <3:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "VSMain"
 // CHECK:       UnmangledName: "VSMain"
 // CHECK:       Resources: <2:RecordArrayRef<RuntimeDataResourceInfo>[1]>  = {
@@ -127,7 +127,7 @@ void RayGen() {
 // CHECK:       VS: <0:VSInfo>
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) SignatureElementTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[2] = {
 // CHECK:     <0:SignatureElement> = {
 // CHECK:       SemanticName: "COORD"
 // CHECK:       SemanticIndices: <2:array[1]> = { 0 }
@@ -149,7 +149,7 @@ void RayGen() {
 // CHECK:       UsageAndDynIndexMasks: 0
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) VSInfoTable[1] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) VSInfoTable[1] = {
 // CHECK:     <0:VSInfo> = {
 // CHECK:       SigInputElements: <2:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:         [0]: <0:SignatureElement>

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_exports3.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -exports PSMain,PSMain_Clone1,PSMain_Clone2=PSMain -T lib_6_3 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -exports PSMain,PSMain_Clone1,PSMain_Clone2=PSMain -T lib_6_3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<int> T0;
 
@@ -21,7 +21,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:   IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:   RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:   RecordTable (stride = 32 bytes) ResourceTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) ResourceTable[2] = {
 // CHECK:     <0:RuntimeDataResourceInfo> = {
 // CHECK:       Class: SRV
 // CHECK:       Kind: TypedBuffer
@@ -43,8 +43,8 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       Flags: 0 (None)
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 56 bytes) FunctionTable[6] = {
-// CHECK:     <0:RuntimeDataFunctionInfo3> = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[6] = {
+// CHECK:     <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?PSMain{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -57,13 +57,13 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <1:RuntimeDataFunctionInfo3> = {
+// CHECK:     <1:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?PSMain_Clone1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain_Clone1"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -76,13 +76,13 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <2:RuntimeDataFunctionInfo3> = {
+// CHECK:     <2:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?PSMain_Clone2{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "PSMain_Clone2"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -95,13 +95,13 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <3:RuntimeDataFunctionInfo3> = {
+// CHECK:     <3:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "PSMain"
 // CHECK:       UnmangledName: "PSMain"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -128,7 +128,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:         }
 // CHECK:       }
 // CHECK:     }
-// CHECK:     <4:RuntimeDataFunctionInfo3> = {
+// CHECK:     <4:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "PSMain_Clone1"
 // CHECK:       UnmangledName: "PSMain_Clone1"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -148,7 +148,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:       PS: <0:PSInfo>
 // CHECK:     }
-// CHECK:     <5:RuntimeDataFunctionInfo3> = {
+// CHECK:     <5:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "PSMain_Clone2"
 // CHECK:       UnmangledName: "PSMain_Clone2"
 // CHECK:       Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[2]>  = {
@@ -169,7 +169,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       PS: <0:PSInfo>
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) SignatureElementTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[2] = {
 // CHECK:     <0:SignatureElement> = {
 // CHECK:       SemanticName: "INDEX"
 // CHECK:       SemanticIndices: <3:array[1]> = { 0 }
@@ -191,7 +191,7 @@ float4 PSMain(int idx : INDEX) : SV_Target {
 // CHECK:       UsageAndDynIndexMasks: 0
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 8 bytes) PSInfoTable[1] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) PSInfoTable[1] = {
 // CHECK:     <0:PSInfo> = {
 // CHECK:       SigInputElements: <3:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:         [0]: <0:SignatureElement>

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/lib_hs_export2.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -auto-binding-space 13 -T lib_6_3 -exports HSMain1;HSMain3 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -auto-binding-space 13 -T lib_6_3 -exports HSMain1;HSMain3 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 Buffer<float> T_unused;
 
@@ -94,8 +94,8 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:   StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:   IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:   RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:   RecordTable (stride = 56 bytes) FunctionTable[5] = {
-// CHECK:     <0:RuntimeDataFunctionInfo3> = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[5] = {
+// CHECK:     <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?HSMain1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSMain1"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -105,13 +105,13 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <1:RuntimeDataFunctionInfo3> = {
+// CHECK:     <1:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?HSMain3{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSMain3"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -121,13 +121,13 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       AttributeSizeInBytes: 0
 // CHECK:       FeatureInfo1: 0
 // CHECK:       FeatureInfo2: 0
-// CHECK:       ShaderStageFlag: 32767
+// CHECK:       ShaderStageFlag: 65535
 // CHECK:       MinShaderTarget: 393312
 // CHECK:       MinimumExpectedWaveLaneCount: 0
 // CHECK:       MaximumExpectedWaveLaneCount: 0
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
-// CHECK:     <2:RuntimeDataFunctionInfo3> = {
+// CHECK:     <2:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "HSMain1"
 // CHECK:       UnmangledName: "HSMain1"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -144,7 +144,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:       HS: <0:HSInfo>
 // CHECK:     }
-// CHECK:     <3:RuntimeDataFunctionInfo3> = {
+// CHECK:     <3:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "HSMain3"
 // CHECK:       UnmangledName: "HSMain3"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -161,7 +161,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:       HS: <1:HSInfo>
 // CHECK:     }
-// CHECK:     <4:RuntimeDataFunctionInfo3> = {
+// CHECK:     <4:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:       Name: "\01?HSPerPatchFunc1{{[@$?.A-Za-z0-9_]+}}"
 // CHECK:       UnmangledName: "HSPerPatchFunc1"
 // CHECK:       Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -178,7 +178,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       ShaderFlags: 0 (None)
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 16 bytes) SignatureElementTable[5] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[5] = {
 // CHECK:     <0:SignatureElement> = {
 // CHECK:       SemanticName: "SV_Position"
 // CHECK:       SemanticIndices: <0:array[1]> = { 0 }
@@ -230,7 +230,7 @@ HSPerPatchData HSPerPatchFunc1()
 // CHECK:       UsageAndDynIndexMasks: 0
 // CHECK:     }
 // CHECK:   }
-// CHECK:   RecordTable (stride = 48 bytes) HSInfoTable[2] = {
+// CHECK:   RecordTable (stride = {{[0-9]+}} bytes) HSInfoTable[2] = {
 // CHECK:     <0:HSInfo> = {
 // CHECK:       SigInputElements: <2:RecordArrayRef<SignatureElement>[3]>  = {
 // CHECK:         [0]: <0:SignatureElement>

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxilver 1.8 | %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-groupshared.hlsl
@@ -1,11 +1,11 @@
-// RUN: %dxilver 1.8 | %dxc -T lib_6_7 %s | %D3DReflect %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -T lib_6_7 -Vd -validator-version 0.0 %s | %D3DReflect %s | FileCheck %s
 
 // CHECK:DxilRuntimeData (size = {{[0-9]+}} bytes):
 // CHECK:  StringBuffer (size = {{[0-9]+}} bytes)
 // CHECK:  IndexTable (size = {{[0-9]+}} bytes)
 // CHECK:  RawBytes (size = {{[0-9]+}} bytes)
-// CHECK:  RecordTable (stride = 56 bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo3> = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo{{.*}}> = {
 // CHECK:      Name: "main"
 // CHECK:      UnmangledName: "main"
 // CHECK:      Resources: <RecordArrayRef<RuntimeDataResourceInfo>[0]> = {}
@@ -67,7 +67,7 @@
 // CHECK:      }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 16 bytes) SignatureElementTable[3] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[3] = {
 // CHECK:    <0:SignatureElement> = {
 // CHECK:      SemanticName: "SV_Position"
 // CHECK:      SemanticIndices: <0:array[1]> = { 0 }
@@ -99,7 +99,7 @@
 // CHECK:      UsageAndDynIndexMasks: 0
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = 48 bytes) MSInfoTable[1] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) MSInfoTable[1] = {
 // CHECK:    <0:MSInfo> = {
 // CHECK:      SigOutputElements: <7:RecordArrayRef<SignatureElement>[2]>  = {
 // CHECK:        [0]: <0:SignatureElement> = {


### PR DESCRIPTION
- Reorganize part and table IDs to move shader info after ver 1.8
- Move NodeShaderInfo into RuntimeDataFunctionInfo2 shader info union, since it is mutually exclusive with other shader types
- Remove RuntimeDataFunctionInfo3
- Re-organize RDAT_LibraryTypes into 3 sections by versioning
- Format unformatted section of RDAT_LibraryTypes due to typo
- Add indentation to make definitions easier to read and disable clang-format for RDAT_LibraryTypes.inl and RDAT_SubobjectTypes.inl
- Include Node in ShaderStageFlags for 1.8+
- Added some explicit scopes due to VS IDE thinking they were ambiguous
- RDATDumper: Don't try to visit or print null records
- Fix reflection tests:
    - tests meant to check shader info use: -Vd -validator-version 0.0
    - use regex for record strides for versioning robustness
    - update ShaderStageFlags to include Node
    - use regex for RuntimeDataFunctionInfo name for versioning robustness
    - remove shader info CHECKs for cases not meant to test that

Fixes #5900