### PR TITLE
[Linux] Enable PixTest for Linux

### DIFF
--- a/include/dxc/dxcpix.h
+++ b/include/dxc/dxcpix.h
@@ -13,7 +13,9 @@
 #define __DXC_PIX__
 
 #include "dxc/dxcapi.h"
+#ifdef _WIN32
 #include "objidl.h"
+#endif
 
 struct __declspec(uuid("199d8c13-d312-4197-a2c1-07a532999727")) IDxcPixType
     : public IUnknown {

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -27,9 +27,7 @@ add_subdirectory(DXIL) # HLSL Change
 add_subdirectory(DxilContainer) # HLSL Change
 add_subdirectory(DxilPdbInfo) # HLSL Change
 add_subdirectory(DxilPIXPasses) # HLSL Change
-if(WIN32) # HLSL Change
-  add_subdirectory(DxilDia) # HLSL Change
-endif(WIN32) # HLSL Change
+add_subdirectory(DxilDia) # HLSL Change
 add_subdirectory(DxilRootSignature) # HLSL Change
 add_subdirectory(DxcBindingTable) # HLSL Change
 add_subdirectory(DxrFallback) # HLSL Change

--- a/lib/DxilDia/CMakeLists.txt
+++ b/lib/DxilDia/CMakeLists.txt
@@ -5,33 +5,67 @@ if (WIN32)
   find_package(DiaSDK REQUIRED) # Used for constants and declarations.
 endif (WIN32)
 
-add_llvm_library(LLVMDxilDia
-  DxcPixCompilationInfo.cpp
-  DxcPixDxilDebugInfo.cpp
-  DxcPixDxilStorage.cpp
-  DxcPixEntrypoints.cpp
-  DxcPixLiveVariables.cpp
-  DxcPixLiveVariables_FragmentIterator.cpp
-  DxcPixTypes.cpp
-  DxcPixVariables.cpp
-  DxilDia.cpp
-  DxilDiaDataSource.cpp
-  DxilDiaEnumTables.cpp
-  DxilDiaSession.cpp
-  DxilDiaSymbolManager.cpp
-  DxilDiaTable.cpp
-  DxilDiaTableFrameData.cpp
-  DxilDiaTableInjectedSources.cpp
-  DxilDiaTableInputAssemblyFile.cpp
-  DxilDiaTableLineNumbers.cpp
-  DxilDiaTableSections.cpp
-  DxilDiaTableSegmentMap.cpp
-  DxilDiaTableSourceFiles.cpp
-  DxilDiaTableSymbols.cpp
+if (WIN32)
+  add_llvm_library(LLVMDxilDia
+    DxcPixCompilationInfo.cpp
+    DxcPixDxilDebugInfo.cpp
+    DxcPixDxilStorage.cpp
+    DxcPixEntrypoints.cpp
+    DxcPixLiveVariables.cpp
+    DxcPixLiveVariables_FragmentIterator.cpp
+    DxcPixTypes.cpp
+    DxcPixVariables.cpp
+    DxilDia.cpp
+    DxilDiaDataSource.cpp
+    DxilDiaEnumTables.cpp
+    DxilDiaSession.cpp
+    DxilDiaSymbolManager.cpp
+    DxilDiaTable.cpp
+    DxilDiaTableFrameData.cpp
+    DxilDiaTableInjectedSources.cpp
+    DxilDiaTableInputAssemblyFile.cpp
+    DxilDiaTableLineNumbers.cpp
+    DxilDiaTableSections.cpp
+    DxilDiaTableSegmentMap.cpp
+    DxilDiaTableSourceFiles.cpp
+    DxilDiaTableSymbols.cpp
 
-  ADDITIONAL_HEADER_DIRS
-  ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR
-)
+    ADDITIONAL_HEADER_DIRS
+    ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR
+  )
+else(WIN32)
+  # DxcPixLiveVariables_FragmentIterator is not dependent on dia.
+  # It is used by PixTest.
+  set(HLSL_IGNORE_SOURCES
+    DxcPixCompilationInfo.cpp
+    DxcPixDxilDebugInfo.cpp
+    DxcPixDxilStorage.cpp
+    DxcPixEntrypoints.cpp
+    DxcPixLiveVariables.cpp
+    DxcPixTypes.cpp
+    DxcPixVariables.cpp
+    DxilDia.cpp
+    DxilDiaDataSource.cpp
+    DxilDiaEnumTables.cpp
+    DxilDiaSession.cpp
+    DxilDiaSymbolManager.cpp
+    DxilDiaTable.cpp
+    DxilDiaTableFrameData.cpp
+    DxilDiaTableInjectedSources.cpp
+    DxilDiaTableInputAssemblyFile.cpp
+    DxilDiaTableLineNumbers.cpp
+    DxilDiaTableSections.cpp
+    DxilDiaTableSegmentMap.cpp
+    DxilDiaTableSourceFiles.cpp
+    DxilDiaTableSymbols.cpp
+    )
+  add_llvm_library(LLVMDxilDia
+    DxcPixLiveVariables_FragmentIterator.cpp
+
+    ADDITIONAL_HEADER_DIRS
+    ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR
+  )
+endif(WIN32)
 
 if (WIN32)
   target_link_libraries(LLVMDxilDia PRIVATE ${LIBRARIES} ${DIASDK_LIBRARIES})

--- a/tools/clang/unittests/HLSL/CMakeLists.txt
+++ b/tools/clang/unittests/HLSL/CMakeLists.txt
@@ -56,7 +56,6 @@ else (WIN32)
 set(HLSL_IGNORE_SOURCES
   MSFileSysTest.cpp
   PixDiaTest.cpp
-  PixTest.cpp
   RewriterTest.cpp
   )
 
@@ -74,6 +73,7 @@ add_clang_unittest(ClangHLSLTests
   Objects.cpp
   OptimizerTest.cpp
   OptionsTest.cpp
+  PixTest.cpp
   PixTestUtils.cpp
   SystemValueTest.cpp
   TestMain.cpp
@@ -99,6 +99,7 @@ target_link_libraries(ClangHLSLTests PRIVATE
 else(WIN32)
 target_link_libraries(ClangHLSLTests
   dxcompiler
+  LLVMDxilDia
   HLSLTestLib
   )
 endif(WIN32)

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -9,9 +9,6 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
-// This whole file is win32-only
-#ifdef _WIN32
-
 #ifndef UNICODE
 #define UNICODE
 #endif
@@ -31,7 +28,9 @@
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/dxcapi.h"
 #include "dxc/dxcpix.h"
+#ifdef _WIN32
 #include <atlfile.h>
+#endif
 
 #include "dxc/DXIL/DxilModule.h"
 
@@ -86,7 +85,11 @@ static std::vector<std::string> Tokenize(const std::string &str,
   return tokens;
 }
 
+#ifdef _WIN32
 class PixTest {
+#else
+class PixTest : public ::testing::Test {
+#endif
 public:
   BEGIN_TEST_CLASS(PixTest)
   TEST_CLASS_PROPERTY(L"Parallel", L"true")
@@ -2567,5 +2570,3 @@ void MyMiss(inout MyPayload payload)
   auto compiledLib = Compile(m_dllSupport, source, L"lib_6_6", {});
   RunDxilPIXDXRInvocationsLog(compiledLib);
 }
-
-#endif


### PR DESCRIPTION
DxilDia is enabled for Linux with only DxcPixLiveVariables_FragmentIterator enabled for PixTest.

Enabled PixTest for Linux build.

This is for #5877