### PR TITLE
[Diag] report error when SV_DispatchGrid has illegal type.

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7861,7 +7861,7 @@ def err_hlsl_missing_dispatchgrid_semantic : Error<
 def err_hlsl_dispatchgrid_semantic_already_specified : Error<
    "a field with SV_DispatchGrid has already been specified">;
 def err_hlsl_incompatible_dispatchgrid_semantic_type : Error<
-   "SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not %0">;
+   "SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not %0">;
 def err_hlsl_maxrecursiondepth_exceeded : Error<
    "NodeMaxRecursionDepth may not exceed 32">;
 def err_hlsl_too_many_node_inputs : Error<

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7861,7 +7861,7 @@ def err_hlsl_missing_dispatchgrid_semantic : Error<
 def err_hlsl_dispatchgrid_semantic_already_specified : Error<
    "a field with SV_DispatchGrid has already been specified">;
 def err_hlsl_incompatible_dispatchgrid_semantic_type : Error<
-   "SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements">;
+   "SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not %0">;
 def err_hlsl_maxrecursiondepth_exceeded : Error<
    "NodeMaxRecursionDepth may not exceed 32">;
 def err_hlsl_too_many_node_inputs : Error<

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7860,6 +7860,8 @@ def err_hlsl_missing_dispatchgrid_semantic : Error<
    "Broadcasting node shader '%0' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic">;
 def err_hlsl_dispatchgrid_semantic_already_specified : Error<
    "a field with SV_DispatchGrid has already been specified">;
+def err_hlsl_incompatible_dispatchgrid_semantic_type : Error<
+   "SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements">;
 def err_hlsl_maxrecursiondepth_exceeded : Error<
    "NodeMaxRecursionDepth may not exceed 32">;
 def err_hlsl_too_many_node_inputs : Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15290,7 +15290,8 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
                                ElTy != S.getASTContext().UnsignedShortTy)) {
               S.Diags.Report(
                   it->Loc,
-                  diag::err_hlsl_incompatible_dispatchgrid_semantic_type);
+                  diag::err_hlsl_incompatible_dispatchgrid_semantic_type)
+                  << Ty;
             }
             DispatchGridLoc = it->Loc;
           } else {

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15246,7 +15246,7 @@ static bool nodeInputIsCompatible(DXIL::NodeIOKind IOType,
 // Diagnose input node record to make sure it has exactly one SV_DispatchGrid
 // semantics. Recursivelly walk all fields on the record and all of its base
 // classes/structs
-void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
+void DiagnoseDispatchGridSemantics(Sema &S,
                                               CXXRecordDecl *InputRecordDecl,
                                               SourceLocation &DispatchGridLoc,
                                               bool &Found) {
@@ -15258,7 +15258,7 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
       CXXRecordDecl *BaseTypeDecl =
           dyn_cast<CXXRecordDecl>(BaseStructType->getDecl());
       if (nullptr != BaseTypeDecl) {
-        DiagnoseMustHaveOneDispatchGridSemantics(S, BaseTypeDecl,
+        DiagnoseDispatchGridSemantics(S, BaseTypeDecl,
                                                  DispatchGridLoc, Found);
       }
     }
@@ -15312,18 +15312,18 @@ void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
       CXXRecordDecl *FieldTypeDecl =
           dyn_cast<CXXRecordDecl>(FieldTypeAsStruct->getDecl());
       if (nullptr != FieldTypeDecl) {
-        DiagnoseMustHaveOneDispatchGridSemantics(S, FieldTypeDecl,
+        DiagnoseDispatchGridSemantics(S, FieldTypeDecl,
                                                  DispatchGridLoc, Found);
       }
     }
   }
 }
 
-void DiagnoseMustHaveOneDispatchGridSemantics(Sema &S,
+void DiagnoseDispatchGridSemantics(Sema &S,
                                               CXXRecordDecl *InputRecordStruct,
                                               bool &Found) {
   SourceLocation DispatchGridLoc;
-  DiagnoseMustHaveOneDispatchGridSemantics(S, InputRecordStruct,
+  DiagnoseDispatchGridSemantics(S, InputRecordStruct,
                                            DispatchGridLoc, Found);
 }
 
@@ -15513,7 +15513,8 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
                     dyn_cast<CXXRecordDecl>(NodeInputStructType->getDecl());
                 if (nullptr != NodeInputStructDecl) {
                   // Make sure there is exactly one SV_DispatchGrid semantics
-                  DiagnoseMustHaveOneDispatchGridSemantics(
+                  // and it has correct type.
+                  DiagnoseDispatchGridSemantics(
                       S, NodeInputStructDecl, Found);
                 }
               }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15246,10 +15246,9 @@ static bool nodeInputIsCompatible(DXIL::NodeIOKind IOType,
 // Diagnose input node record to make sure it has exactly one SV_DispatchGrid
 // semantics. Recursivelly walk all fields on the record and all of its base
 // classes/structs
-void DiagnoseDispatchGridSemantics(Sema &S,
-                                              CXXRecordDecl *InputRecordDecl,
-                                              SourceLocation &DispatchGridLoc,
-                                              bool &Found) {
+void DiagnoseDispatchGridSemantics(Sema &S, CXXRecordDecl *InputRecordDecl,
+                                   SourceLocation &DispatchGridLoc,
+                                   bool &Found) {
 
   // Walk up the inheritance chain and check all fields on base classes
   for (auto &B : InputRecordDecl->bases()) {
@@ -15258,8 +15257,7 @@ void DiagnoseDispatchGridSemantics(Sema &S,
       CXXRecordDecl *BaseTypeDecl =
           dyn_cast<CXXRecordDecl>(BaseStructType->getDecl());
       if (nullptr != BaseTypeDecl) {
-        DiagnoseDispatchGridSemantics(S, BaseTypeDecl,
-                                                 DispatchGridLoc, Found);
+        DiagnoseDispatchGridSemantics(S, BaseTypeDecl, DispatchGridLoc, Found);
       }
     }
   }
@@ -15312,19 +15310,16 @@ void DiagnoseDispatchGridSemantics(Sema &S,
       CXXRecordDecl *FieldTypeDecl =
           dyn_cast<CXXRecordDecl>(FieldTypeAsStruct->getDecl());
       if (nullptr != FieldTypeDecl) {
-        DiagnoseDispatchGridSemantics(S, FieldTypeDecl,
-                                                 DispatchGridLoc, Found);
+        DiagnoseDispatchGridSemantics(S, FieldTypeDecl, DispatchGridLoc, Found);
       }
     }
   }
 }
 
-void DiagnoseDispatchGridSemantics(Sema &S,
-                                              CXXRecordDecl *InputRecordStruct,
-                                              bool &Found) {
+void DiagnoseDispatchGridSemantics(Sema &S, CXXRecordDecl *InputRecordStruct,
+                                   bool &Found) {
   SourceLocation DispatchGridLoc;
-  DiagnoseDispatchGridSemantics(S, InputRecordStruct,
-                                           DispatchGridLoc, Found);
+  DiagnoseDispatchGridSemantics(S, InputRecordStruct, DispatchGridLoc, Found);
 }
 
 void DiagnoseAmplificationEntry(Sema &S, FunctionDecl *FD,
@@ -15514,8 +15509,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
                 if (nullptr != NodeInputStructDecl) {
                   // Make sure there is exactly one SV_DispatchGrid semantics
                   // and it has correct type.
-                  DiagnoseDispatchGridSemantics(
-                      S, NodeInputStructDecl, Found);
+                  DiagnoseDispatchGridSemantics(S, NodeInputStructDecl, Found);
                 }
               }
             }

--- a/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
+++ b/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
@@ -153,6 +153,7 @@ void node20(DispatchNodeInputRecord<C> input)
 { }
 
 struct D {
+  // expected-error@+1 {{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
   uint4 grid1 : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
 };
 

--- a/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
+++ b/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
@@ -153,8 +153,7 @@ void node20(DispatchNodeInputRecord<C> input)
 { }
 
 struct D {
-  // expected-error@+1 {{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
-  uint4 grid1 : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
+  uint3 grid1 : SV_DispatchGrid;   // expected-note {{other SV_DispatchGrid defined here}}
 };
 
 struct E {

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
@@ -1,7 +1,7 @@
-// RUN: %dxc -Tlib_6_8 -verify %s
+// RUN: %dxc -Tlib_6_8 -enable-16bit-types -verify %s
 
 struct Record1 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint4'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint4'}}
   uint4 grid : SV_DispatchGrid;
   float data;
 };
@@ -14,7 +14,7 @@ struct Record1 {
 void node1(DispatchNodeInputRecord<Record1> input) {}
 
 struct Record2 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint [4]'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint [4]'}}
   uint grid[4] : SV_DispatchGrid;
   float data;
 };
@@ -28,7 +28,7 @@ void node2(DispatchNodeInputRecord<Record2> input) {}
 
 
 struct Record3 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint2x2'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint2x2'}}
   uint2x2 grid : SV_DispatchGrid;
   float data;
 };
@@ -42,7 +42,7 @@ void node3(DispatchNodeInputRecord<Record3> input) {}
 
 
 struct Record4 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'int3'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int3'}}
   int3 grid : SV_DispatchGrid;
   float data;
 };
@@ -55,7 +55,7 @@ struct Record4 {
 void node4(DispatchNodeInputRecord<Record4> input) {}
 
 struct Record5 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'int [3]'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int [3]'}}
   int grid[3] : SV_DispatchGrid;
   float data;
 };
@@ -71,7 +71,7 @@ struct T {
   float a;
 };
 struct Record6 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'T'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'T'}}
   T grid : SV_DispatchGrid;
   float data;
 };
@@ -87,7 +87,7 @@ struct T2 {
   uint3 a;
 };
 struct Record7 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'T2'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'T2'}}
   T2 grid : SV_DispatchGrid;
   float data;
 };
@@ -101,7 +101,7 @@ void node7(DispatchNodeInputRecord<Record7> input) {}
 
 
 struct Record8 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'float'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
   float grid : SV_DispatchGrid;
   float data;
 };
@@ -114,7 +114,7 @@ void node8(DispatchNodeInputRecord<Record8> input) {}
 
 
 struct Record9 {
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'float3'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float3'}}
   float3 grid : SV_DispatchGrid;
   float data;
 };
@@ -124,3 +124,119 @@ struct Record9 {
 [NodeMaxDispatchGrid(32, 16, 1)]
 [NumThreads(32, 1, 1)]
 void node9(DispatchNodeInputRecord<Record9> input) {}
+
+struct Record10 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
+  half grid : SV_DispatchGrid;
+  float data;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node10(DispatchNodeInputRecord<Record10> input) {}
+
+
+struct Record11 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half3'}}
+  half3 grid : SV_DispatchGrid;
+  float data;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node11(DispatchNodeInputRecord<Record11> input) {}
+
+struct Record12 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t4'}}
+  int16_t4 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node12(DispatchNodeInputRecord<Record12> input) {}
+
+struct Record13 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t [4]'}}
+  int16_t grid[4] : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node13(DispatchNodeInputRecord<Record13> input) {}
+
+
+struct Record14 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t2x2'}}
+  int16_t2x2 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node14(DispatchNodeInputRecord<Record14> input) {}
+
+
+struct Record15 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t3'}}
+  int16_t3 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node15(DispatchNodeInputRecord<Record15> input) {}
+
+struct Record16 {
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t [3]'}}
+  int16_t grid[3] : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node16(DispatchNodeInputRecord<Record16> input) {}
+
+struct Record17 {
+  uint16_t3 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node17(DispatchNodeInputRecord<Record17> input) {}
+
+struct Record18 {
+  uint16_t grid[3] : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node18(DispatchNodeInputRecord<Record18> input) {}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
@@ -1,0 +1,84 @@
+// RUN: %dxc -Tlib_6_8 -verify %s
+
+struct Record1 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  uint4 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node1(DispatchNodeInputRecord<Record1> input) {}
+
+struct Record2 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  uint grid[4] : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node2(DispatchNodeInputRecord<Record2> input) {}
+
+
+struct Record3 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  uint2x2 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node3(DispatchNodeInputRecord<Record3> input) {}
+
+
+struct Record4 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  int3 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node4(DispatchNodeInputRecord<Record4> input) {}
+
+struct Record5 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  int grid[3] : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node5(DispatchNodeInputRecord<Record5> input) {}
+
+struct T {
+  float a;
+};
+struct Record6 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  T grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node3(DispatchNodeInputRecord<Record6> input) {}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
@@ -81,4 +81,46 @@ struct Record6 {
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
 [NumThreads(32, 1, 1)]
-void node3(DispatchNodeInputRecord<Record6> input) {}
+void node6(DispatchNodeInputRecord<Record6> input) {}
+
+struct T2 {
+  uint3 a;
+};
+struct Record7 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  T2 grid : SV_DispatchGrid;
+  float data;
+};
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node7(DispatchNodeInputRecord<Record7> input) {}
+
+
+struct Record8 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  float grid : SV_DispatchGrid;
+  float data;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node8(DispatchNodeInputRecord<Record8> input) {}
+
+
+struct Record9 {
+// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+  float3 grid : SV_DispatchGrid;
+  float data;
+};
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeMaxDispatchGrid(32, 16, 1)]
+[NumThreads(32, 1, 1)]
+void node9(DispatchNodeInputRecord<Record9> input) {}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 
 struct Record1 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint4'}}
   uint4 grid : SV_DispatchGrid;
   float data;
 };
@@ -14,7 +14,7 @@ struct Record1 {
 void node1(DispatchNodeInputRecord<Record1> input) {}
 
 struct Record2 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint [4]'}}
   uint grid[4] : SV_DispatchGrid;
   float data;
 };
@@ -28,7 +28,7 @@ void node2(DispatchNodeInputRecord<Record2> input) {}
 
 
 struct Record3 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'uint2x2'}}
   uint2x2 grid : SV_DispatchGrid;
   float data;
 };
@@ -42,7 +42,7 @@ void node3(DispatchNodeInputRecord<Record3> input) {}
 
 
 struct Record4 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'int3'}}
   int3 grid : SV_DispatchGrid;
   float data;
 };
@@ -55,7 +55,7 @@ struct Record4 {
 void node4(DispatchNodeInputRecord<Record4> input) {}
 
 struct Record5 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'int [3]'}}
   int grid[3] : SV_DispatchGrid;
   float data;
 };
@@ -71,7 +71,7 @@ struct T {
   float a;
 };
 struct Record6 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'T'}}
   T grid : SV_DispatchGrid;
   float data;
 };
@@ -87,7 +87,7 @@ struct T2 {
   uint3 a;
 };
 struct Record7 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'T2'}}
   T2 grid : SV_DispatchGrid;
   float data;
 };
@@ -101,7 +101,7 @@ void node7(DispatchNodeInputRecord<Record7> input) {}
 
 
 struct Record8 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'float'}}
   float grid : SV_DispatchGrid;
   float data;
 };
@@ -114,7 +114,7 @@ void node8(DispatchNodeInputRecord<Record8> input) {}
 
 
 struct Record9 {
-// expected-error@+1{{SV_DispatchGrid should be 32/16 bit uint scalar or vector/array up to 3 elements}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unit/uint16_t scalar, vector, or array up to 3 elements, not 'float3'}}
   float3 grid : SV_DispatchGrid;
   float data;
 };


### PR DESCRIPTION
verify that the input record field with SV_DispatchGrid semantic is a valid type: 32 or 16-bit uint scalar or array/vector with up to 3 components.

Fixes #5845