### PR TITLE
WinPix: variables in subroutines called from multiple functions

### DIFF
--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -27,6 +27,7 @@
 #include "DxilDiaTableLineNumbers.h"
 #include "DxilDiaTableSourceFiles.h"
 #include "DxilDiaTableSymbols.h"
+#include "..\DxilPIXPasses\PixPassHelpers.h"
 
 void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
                              std::shared_ptr<llvm::Module> mod,
@@ -63,7 +64,8 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
 
   // Build up a linear list of instructions. The index will be used as the
   // RVA.
-  for (llvm::Function &fn : m_module->functions()) {
+  std::vector<llvm::Function*> allInstrumentableFunctions = PIXPassHelpers::GetAllInstrumentableFunctions(*m_dxilModule.get());
+  for (auto fn : allInstrumentableFunctions) {
     for (llvm::inst_iterator it = inst_begin(fn), end = inst_end(fn); it != end;
          ++it) {
       llvm::Instruction &i = *it;

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 
+#include "..\DxilPIXPasses\PixPassHelpers.h"
 #include "DxilDia.h"
 #include "DxilDiaEnumTables.h"
 #include "DxilDiaTable.h"
@@ -27,7 +28,6 @@
 #include "DxilDiaTableLineNumbers.h"
 #include "DxilDiaTableSourceFiles.h"
 #include "DxilDiaTableSymbols.h"
-#include "..\DxilPIXPasses\PixPassHelpers.h"
 
 void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
                              std::shared_ptr<llvm::Module> mod,
@@ -64,7 +64,8 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
 
   // Build up a linear list of instructions. The index will be used as the
   // RVA.
-  std::vector<llvm::Function*> allInstrumentableFunctions = PIXPassHelpers::GetAllInstrumentableFunctions(*m_dxilModule.get());
+  std::vector<llvm::Function *> allInstrumentableFunctions =
+      PIXPassHelpers::GetAllInstrumentableFunctions(*m_dxilModule.get());
   for (auto fn : allInstrumentableFunctions) {
     for (llvm::inst_iterator it = inst_begin(fn), end = inst_end(fn); it != end;
          ++it) {

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -2857,10 +2857,9 @@ void ClosestHitShader1(inout RayPayload payload, in BuiltInTriangleIntersectionA
 }
 )";
 
-    CComPtr<DxcIncludeHandlerForInjectedSourcesForPix> pIncludeHandler =
-      new DxcIncludeHandlerForInjectedSourcesForPix(
-          this, {{L"included.h",
-                  R"(
+  CComPtr<DxcIncludeHandlerForInjectedSourcesForPix> pIncludeHandler =
+      new DxcIncludeHandlerForInjectedSourcesForPix(this, {{L"included.h",
+                                                            R"(
 
 namespace StressScopesEvenMore
 {
@@ -2878,9 +2877,8 @@ float4 DeeperInlinedFunction(in BuiltInTriangleIntersectionAttributes attr, int 
 }
 )"}});
 
-
   auto dxilDebugger =
-        CompileAndCreateDxcDebug(hlsl, L"lib_6_6", pIncludeHandler);
+      CompileAndCreateDxcDebug(hlsl, L"lib_6_6", pIncludeHandler);
 
   struct SourceLocations {
     CComBSTR Filename;

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -2761,23 +2761,12 @@ static DWORD AdvanceUntilFunctionEntered(IDxcPixDxilDebugInfo *dxilDebugger,
                                          wchar_t const *fnName) {
   for (;;) {
     CComBSTR FunctioName;
-    if (FAILED(dxilDebugger->GetFunctionName(instructionOffset, &FunctioName)))
+    if (FAILED(
+            dxilDebugger->GetFunctionName(instructionOffset, &FunctioName))) {
+      VERIFY_FAIL(L"Didn't find function");
       return -1;
+    }
     if (FunctioName == fnName)
-      break;
-    instructionOffset++;
-  }
-  return instructionOffset;
-}
-
-static DWORD AdvanceUntilNotInFunction(IDxcPixDxilDebugInfo *dxilDebugger,
-                                       DWORD instructionOffset,
-                                       wchar_t const *fnName) {
-  for (;;) {
-    CComBSTR FunctioName;
-    if (FAILED(dxilDebugger->GetFunctionName(instructionOffset, &FunctioName)))
-      return -1;
-    if (FunctioName != fnName)
       break;
     instructionOffset++;
   }
@@ -2812,6 +2801,7 @@ static DWORD GetRegisterNumberForVariable(IDxcPixDxilDebugInfo *dxilDebugger,
       }
     }
   }
+  VERIFY_FAIL(L"Couldn't find register number");
   return -1;
 }
 

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -2771,8 +2771,8 @@ static DWORD AdvanceUntilFunctionEntered(IDxcPixDxilDebugInfo *dxilDebugger,
 }
 
 static DWORD AdvanceUntilNotInFunction(IDxcPixDxilDebugInfo *dxilDebugger,
-                                         DWORD instructionOffset,
-                                         wchar_t const *fnName) {
+                                       DWORD instructionOffset,
+                                       wchar_t const *fnName) {
   for (;;) {
     CComBSTR FunctioName;
     if (FAILED(dxilDebugger->GetFunctionName(instructionOffset, &FunctioName)))
@@ -2789,8 +2789,8 @@ static DWORD GetRegisterNumberForVariable(IDxcPixDxilDebugInfo *dxilDebugger,
                                           wchar_t const *variableName,
                                           wchar_t const *memberName) {
   CComPtr<IDxcPixDxilLiveVariables> DxcPixDxilLiveVariables;
-  if(SUCCEEDED(dxilDebugger->GetLiveVariablesAt(
-      instructionOffset, &DxcPixDxilLiveVariables))) {
+  if (SUCCEEDED(dxilDebugger->GetLiveVariablesAt(instructionOffset,
+                                                 &DxcPixDxilLiveVariables))) {
     DWORD count = 42;
     VERIFY_SUCCEEDED(DxcPixDxilLiveVariables->GetCount(&count));
     for (DWORD i = 0; i < count; ++i) {
@@ -2848,8 +2848,7 @@ void ClosestHitShader1(inout RayPayload payload, in BuiltInTriangleIntersectionA
 }
 )";
 
-  auto dxilDebugger =
-      CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
 
   struct SourceLocations {
     CComBSTR Filename;
@@ -2858,11 +2857,12 @@ void ClosestHitShader1(inout RayPayload payload, in BuiltInTriangleIntersectionA
   };
 
   std::vector<SourceLocations> sourceLocations;
-  DWORD instructionOffset = AdvanceUntilFunctionEntered(
-      dxilDebugger, 0, L"ClosestHitShader0");
+  DWORD instructionOffset =
+      AdvanceUntilFunctionEntered(dxilDebugger, 0, L"ClosestHitShader0");
   instructionOffset = AdvanceUntilFunctionEntered(
       dxilDebugger, instructionOffset, L"InlinedFunction");
-  DWORD RegisterNumber0 = GetRegisterNumberForVariable(dxilDebugger, instructionOffset, L"color0", L"x");
+  DWORD RegisterNumber0 = GetRegisterNumberForVariable(
+      dxilDebugger, instructionOffset, L"color0", L"x");
   instructionOffset = AdvanceUntilFunctionEntered(
       dxilDebugger, instructionOffset, L"ClosestHitShader1");
   instructionOffset = AdvanceUntilFunctionEntered(


### PR DESCRIPTION
From the comment in one of the changed files:

// If a function is inlined, then the scope of variables within that function
// will be that scope. Since many such callers may inline the function, we
// actually need a "scope" that's unique to each "instance" of that function.
// The caller's scope would be unique, but would have the undesirable
// side-effect of smushing all of the function's variables together with the
// caller's variables, at least from the point of view of PIX. The pair of
// scopes (the function's and the caller's) is both unique to that particular
// inlining, and distinct from the caller's scope by itself.