### PR TITLE
[SPIR-V] Emit error for unsupported HLSL res obj

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -457,6 +457,7 @@ bool IsHLSLStreamOutputType(clang::QualType type);
 bool IsHLSLResourceType(clang::QualType type);
 bool IsHLSLNodeInputType(clang::QualType type);
 bool IsHLSLDynamicResourceType(clang::QualType type);
+bool IsHLSLDynamicSamplerType(clang::QualType type);
 bool IsHLSLNodeType(clang::QualType type);
 bool IsHLSLObjectWithImplicitMemberAccess(clang::QualType type);
 bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -638,6 +638,14 @@ bool IsHLSLDynamicResourceType(clang::QualType type) {
   return false;
 }
 
+bool IsHLSLDynamicSamplerType(clang::QualType type) {
+  if (const RecordType *RT = type->getAs<RecordType>()) {
+    StringRef name = RT->getDecl()->getName();
+    return name == ".Sampler";
+  }
+  return false;
+}
+
 bool IsHLSLNodeType(clang::QualType type) {
   if (const HLSLNodeObjectAttr *Attr = getNodeAttr(type))
     return true;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -956,8 +956,9 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
 SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
                                                       SourceLocation loc,
                                                       SourceRange range) {
-  if (hlsl::IsHLSLDynamicResourceType(decl->getType())) {
-    emitError("HLSL resource %0 not yet supported with -spirv",
+  if (hlsl::IsHLSLDynamicResourceType(decl->getType()) ||
+      hlsl::IsHLSLDynamicSamplerType(decl->getType())) {
+    emitError("HLSL object %0 not yet supported with -spirv",
               decl->getLocation())
         << decl->getName();
     return nullptr;

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -956,6 +956,13 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
 SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
                                                       SourceLocation loc,
                                                       SourceRange range) {
+  if (hlsl::IsHLSLDynamicResourceType(decl->getType())) {
+    emitError("HLSL resource %0 not yet supported with -spirv",
+              decl->getLocation())
+        << decl->getName();
+    return nullptr;
+  }
+
   const DeclSpirvInfo *info = getDeclSpirvInfo(decl);
 
   // If DeclSpirvInfo is not found for this decl, it might be because it is an

--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -136,6 +136,9 @@ bool InitListHandler::tryToSplitStruct() {
     return false;
 
   auto *init = initializers.back();
+  if (!init)
+    return false;
+
   const QualType initType = init->getAstResultType();
   if (!initType->isStructureType() ||
       // Sampler types will pass the above check but we cannot split it.
@@ -171,6 +174,9 @@ bool InitListHandler::tryToSplitConstantArray() {
     return false;
 
   auto *init = initializers.back();
+  if (!init)
+    return false;
+
   const QualType initType = init->getAstResultType();
   if (!initType->isConstantArrayType())
     return false;
@@ -495,6 +501,9 @@ InitListHandler::createInitForBufferOrImageType(QualType type,
 
   auto init = initializers.back();
   initializers.pop_back();
+
+  if (!init)
+    return nullptr;
 
   if (init->getAstResultType().getCanonicalType() != type.getCanonicalType()) {
     emitError("Cannot cast initializer type %0 into variable type %1", srcLoc)

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3407,6 +3407,9 @@ SpirvInstruction *SpirvEmitter::doCastExpr(const CastExpr *expr,
     if (!subExprInstr)
       subExprInstr = loadIfGLValue(subExpr);
 
+    if (!subExprInstr)
+      return nullptr;
+
     auto *val = processFlatConversion(toType, evalType, subExprInstr,
                                       expr->getExprLoc(), range);
     val->setRValue();

--- a/tools/clang/test/CodeGenSPIRV_Lit/sm6_6.objects.descriptorheap.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/sm6_6.objects.descriptorheap.hlsl
@@ -1,0 +1,8 @@
+// RUN: not %dxc -T cs_6_6 -E main -fcgl -spirv %s 2>&1 | FileCheck %s
+
+[numthreads(32, 1, 1)]
+void main(uint3 id: SV_DispatchThreadID) {
+    Texture2D t = ResourceDescriptorHeap[0];
+}
+
+// CHECK: error: HLSL resource ResourceDescriptorHeap not yet supported with -spirv

--- a/tools/clang/test/CodeGenSPIRV_Lit/sm6_6.objects.descriptorheap.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/sm6_6.objects.descriptorheap.hlsl
@@ -1,8 +1,10 @@
 // RUN: not %dxc -T cs_6_6 -E main -fcgl -spirv %s 2>&1 | FileCheck %s
 
 [numthreads(32, 1, 1)]
-void main(uint3 id: SV_DispatchThreadID) {
+void main() {
     Texture2D t = ResourceDescriptorHeap[0];
+    SamplerState s = SamplerDescriptorHeap[0];
 }
 
-// CHECK: error: HLSL resource ResourceDescriptorHeap not yet supported with -spirv
+// CHECK: error: HLSL object ResourceDescriptorHeap not yet supported with -spirv
+// CHECK: error: HLSL object SamplerDescriptorHeap not yet supported with -spirv


### PR DESCRIPTION
Emit an explicit error message when HLSL `ResourceDescriptorHeap` or `SamplerDescriptorHeap` are used with `-spirv` as they are not yet supported.

Fixes #5913