### PR TITLE
[SPIR-V] Add name to unregisterd decl error

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -916,7 +916,7 @@ SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
     }
   }
 
-  emitFatalError("found unregistered decl", decl->getLocation())
+  emitFatalError("found unregistered decl %0", decl->getLocation())
       << decl->getName();
   emitNote("please file a bug report on "
            "https://github.com/Microsoft/DirectXShaderCompiler/issues with "


### PR DESCRIPTION
Parameter was missing from error message so decl name was not being emitted.