### PR TITLE
[SPIRV] Implement dot4add_i8packed and dot4add_u8packed intrinsics

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11384,7 +11384,6 @@ SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
          op == hlsl::IntrinsicOp::IOP_dot4add_u8packed);
 
   // TODO: add comments on what's going on here
-  // TODO: fix/add the tests
   
   const bool isSigned = op == hlsl::IntrinsicOp::IOP_dot4add_i8packed;
   const spv::Op spirvOp = isSigned ? spv::Op::OpSDot : spv::Op::OpUDot;

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11375,9 +11375,8 @@ SpirvEmitter::processIntrinsicLog10(const CallExpr *callExpr) {
                                    range);
 }
 
-SpirvInstruction *
-SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
-                                       hlsl::IntrinsicOp op) {
+SpirvInstruction *SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
+                                                     hlsl::IntrinsicOp op) {
   // Processing the `dot4add_i8packed` and `dot4add_u8packed` intrinsics.
   // There is no direct substitution for them in SPIR-V, but the combination
   // of OpSDot / OpUDot and OpIAdd works.
@@ -11392,7 +11391,7 @@ SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
   //    together each corresponding pair of unsigned 8-bit int bytes in the two
   //    input DWORDs, and sums the results into the 32-bit unsigned integer
   //    accumulator.
-  
+
   auto loc = callExpr->getExprLoc();
   auto range = callExpr->getSourceRange();
   assert(op == hlsl::IntrinsicOp::IOP_dot4add_i8packed ||
@@ -11413,35 +11412,32 @@ SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
   // Prepare the array inputs for createSpirvIntrInstExt below.
   // Need to use this function because the OpSDot/OpUDot operations require
   // two capabilities and an extension to be declared in the module.
-  llvm::SmallVector<SpirvInstruction*, 2> operands;
+  llvm::SmallVector<SpirvInstruction *, 2> operands;
   llvm::SmallVector<uint32_t, 2> capabilities;
   llvm::SmallVector<llvm::StringRef, 1> extensions;
   llvm::StringRef instSet = "";
 
   operands.push_back(arg0Instr);
   operands.push_back(arg1Instr);
-  capabilities.push_back(uint32_t(
-    spv::Capability::DotProduct));
-  capabilities.push_back(uint32_t(
-    spv::Capability::DotProductInput4x8BitPacked));
+  capabilities.push_back(uint32_t(spv::Capability::DotProduct));
+  capabilities.push_back(
+      uint32_t(spv::Capability::DotProductInput4x8BitPacked));
   extensions.push_back("SPV_KHR_integer_dot_product");
 
   // Pick the opcode and return type based on the instruction.
   const bool isSigned = op == hlsl::IntrinsicOp::IOP_dot4add_i8packed;
-  const spv::Op spirvOp = isSigned
-    ? spv::Op::OpSDot
-    : spv::Op::OpUDot;
-  const auto returnType = isSigned
-    ? astContext.IntTy
-    : astContext.UnsignedIntTy;
+  const spv::Op spirvOp = isSigned ? spv::Op::OpSDot : spv::Op::OpUDot;
+  const auto returnType =
+      isSigned ? astContext.IntTy : astContext.UnsignedIntTy;
 
   // Create the dot product instruction.
-  auto *dotResult = spvBuilder.createSpirvIntrInstExt(uint32_t(spirvOp),
-    returnType, operands, extensions, instSet, capabilities, loc);
+  auto *dotResult =
+      spvBuilder.createSpirvIntrInstExt(uint32_t(spirvOp), returnType, operands,
+                                        extensions, instSet, capabilities, loc);
 
   // Create and return the integer addition instruction.
-  return spvBuilder.createBinaryOp(spv::Op::OpIAdd, returnType,
-    dotResult, arg2Instr, loc, range);
+  return spvBuilder.createBinaryOp(spv::Op::OpIAdd, returnType, dotResult,
+                                   arg2Instr, loc, range);
 }
 
 SpirvInstruction *

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -649,6 +649,10 @@ private:
   /// Processes the NonUniformResourceIndex intrinsic function.
   SpirvInstruction *processIntrinsicNonUniformResourceIndex(const CallExpr *);
 
+  /// Processes the SM 6.4 dot4add_{i|u}8packed intrinsic functions.
+  SpirvInstruction *processIntrinsicDP4a(const CallExpr *callExpr,
+                                         hlsl::IntrinsicOp op);
+
   /// Processes the SM 6.6 pack_{s|u}8 and pack_clamp_{s|u}8 intrinsic
   /// functions.
   SpirvInstruction *processIntrinsic8BitPack(const CallExpr *,

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.dot4add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.dot4add.hlsl
@@ -1,23 +1,28 @@
-// RUN: not %dxc -E frag -T ps_6_4 -fspv-target-env=vulkan1.1 -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -E main -T ps_6_4 -fspv-target-env=vulkan1.1 -fcgl  %s -spirv  2>&1 | FileCheck %s
 
-uint frag(float4 vertex
-          : SV_POSITION) : SV_Target {
+float2 f2;
+
+float2 main(uint4 inputs : Inputs0, uint acc0 : Acc0, int acc1 : Acc1) : SV_Target {
+// CHECK-LABEL: %bb_entry = OpLabel
   uint acc = 0;
 
-  // CHECK: 8:14: error: dot4add_u8packed intrinsic function unimplemented
-  acc += 1 + dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y));
+// CHECK:       [[input_x_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_0
+// CHECK-NEXT:  [[input_x_val:%[0-9]+]] = OpLoad %uint [[input_x_ref]]
+// CHECK-NEXT:  [[input_y_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_1
+// CHECK-NEXT:  [[input_y_val:%[0-9]+]] = OpLoad %uint [[input_y_ref]]
+// CHECK-NEXT:  [[a0:%[0-9]+]] = OpLoad %uint %acc0
+// CHECK-NEXT:  [[t0:%[0-9]+]] = OpUDot %uint [[input_x_val]] [[input_y_val]]
+// CHECK-NEXT:  [[t1:%[0-9]+]] = OpIAdd %uint [[t0]] [[a0]]
+  acc += dot4add_u8packed(inputs.x, inputs.y, acc0);
 
-  // CHECK: 11:14: error: dot4add_i8packed intrinsic function unimplemented
-  acc += 2 + dot4add_i8packed(vertex.z, vertex.w, int(vertex.x));
+// CHECK:       [[input_z_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_2
+// CHECK-NEXT:  [[input_z_val:%[0-9]+]] = OpLoad %uint [[input_z_ref]]
+// CHECK-NEXT:  [[input_w_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_3
+// CHECK-NEXT:  [[input_w_val:%[0-9]+]] = OpLoad %uint [[input_w_ref]]
+// CHECK-NEXT:  [[a1:%[0-9]+]] = OpLoad %int %acc1
+// CHECK-NEXT:  [[t2:%[0-9]+]] = OpSDot %int [[input_z_val]] [[input_w_val]]
+// CHECK-NEXT:  [[t3:%[0-9]+]] = OpIAdd %int [[t2]] [[a1]]
+  acc += dot4add_i8packed(inputs.z, inputs.w, acc1);
 
-  // CHECK: 14:10: error: dot4add_u8packed intrinsic function unimplemented
-  acc += dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y)) + 1;
-
-  // CHECK: 17:13: error: dot4add_u8packed intrinsic function unimplemented
-  acc = 1 + dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y));
-
-  // CHECK: 20:9: error: dot4add_u8packed intrinsic function unimplemented
-  acc = dot4add_u8packed(vertex.x, vertex.y, uint(vertex.y)) + 1;
-
-  return acc;
+  return f2 * acc;
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.dot4add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.dot4add.hlsl
@@ -1,9 +1,6 @@
 // RUN: %dxc -E main -T ps_6_4 -fspv-target-env=vulkan1.1 -fcgl  %s -spirv  2>&1 | FileCheck %s
 
-float2 f2;
-
 float2 main(uint4 inputs : Inputs0, uint acc0 : Acc0, int acc1 : Acc1) : SV_Target {
-// CHECK-LABEL: %bb_entry = OpLabel
   uint acc = 0;
 
 // CHECK:       [[input_x_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_0
@@ -24,5 +21,5 @@ float2 main(uint4 inputs : Inputs0, uint acc0 : Acc0, int acc1 : Acc1) : SV_Targ
 // CHECK-NEXT:  [[t3:%[0-9]+]] = OpIAdd %int [[t2]] [[a1]]
   acc += dot4add_i8packed(inputs.z, inputs.w, acc1);
 
-  return f2 * acc;
+  return acc;
 }


### PR DESCRIPTION
This change implements the translation of the two DP4a intrinsics into pairs of operations:
```
dot4add_i8packed -> OpSDot + OpIAdd
dot4add_u8packed -> OpUDot + OpIAdd
```

Note that the `OpSDotAccSat` and `OpUDotAccSat` operations are not matching the HLSL intrinsics as there should not be any saturation.

The SPIR-V test for these intrinsics is also updated by copying and adjusting the corresponding test from the DXIL side.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/4528