### PR TITLE
Add error message for incompatible image format and sampled type.

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -30,6 +30,85 @@ namespace spirv {
 
 namespace {
 
+// Returns true if the image format is compatible with the sampled type. This is
+// determined according to the same at
+// https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+bool areFormatAndTypeCompatible(spv::ImageFormat format, QualType sampledType) {
+  if (format == spv::ImageFormat::Unknown) {
+    return true;
+  }
+
+  if (hlsl::IsHLSLVecType(sampledType)) {
+    // For vectors, we need to check if the element type is compatible. We do
+    // not check the number of elements because it is possible that the number
+    // of elements in the sampled type is different. I could not find in the
+    // spec what should happen in that case.
+    sampledType = hlsl::GetHLSLVecElementType(sampledType);
+  }
+
+  const Type *desugaredType = sampledType->getUnqualifiedDesugaredType();
+  const BuiltinType *builtinType = dyn_cast<BuiltinType>(desugaredType);
+  if (!builtinType) {
+    return false;
+  }
+
+  switch (format) {
+  case spv::ImageFormat::Rgba32f:
+  case spv::ImageFormat::Rg32f:
+  case spv::ImageFormat::R32f:
+  case spv::ImageFormat::Rgba16f:
+  case spv::ImageFormat::Rg16f:
+  case spv::ImageFormat::R16f:
+  case spv::ImageFormat::Rgba16:
+  case spv::ImageFormat::Rg16:
+  case spv::ImageFormat::R16:
+  case spv::ImageFormat::Rgba16Snorm:
+  case spv::ImageFormat::Rg16Snorm:
+  case spv::ImageFormat::R16Snorm:
+  case spv::ImageFormat::Rgb10A2:
+  case spv::ImageFormat::R11fG11fB10f:
+  case spv::ImageFormat::Rgba8:
+  case spv::ImageFormat::Rg8:
+  case spv::ImageFormat::R8:
+  case spv::ImageFormat::Rgba8Snorm:
+  case spv::ImageFormat::Rg8Snorm:
+  case spv::ImageFormat::R8Snorm:
+    // 32-bit float
+    return builtinType->getKind() == BuiltinType::Float;
+  case spv::ImageFormat::Rgba32i:
+  case spv::ImageFormat::Rg32i:
+  case spv::ImageFormat::R32i:
+  case spv::ImageFormat::Rgba16i:
+  case spv::ImageFormat::Rg16i:
+  case spv::ImageFormat::R16i:
+  case spv::ImageFormat::Rgba8i:
+  case spv::ImageFormat::Rg8i:
+  case spv::ImageFormat::R8i:
+    // signed 32-bit int
+    return builtinType->getKind() == BuiltinType::Int;
+  case spv::ImageFormat::Rgba32ui:
+  case spv::ImageFormat::Rg32ui:
+  case spv::ImageFormat::R32ui:
+  case spv::ImageFormat::Rgba16ui:
+  case spv::ImageFormat::Rg16ui:
+  case spv::ImageFormat::R16ui:
+  case spv::ImageFormat::Rgb10a2ui:
+  case spv::ImageFormat::Rgba8ui:
+  case spv::ImageFormat::Rg8ui:
+  case spv::ImageFormat::R8ui:
+    // unsigned 32-bit int
+    return builtinType->getKind() == BuiltinType::UInt;
+  case spv::ImageFormat::R64i:
+    // signed 64-bit int
+    return builtinType->getKind() == BuiltinType::LongLong;
+  case spv::ImageFormat::R64ui:
+    // unsigned 64-bit int
+    return builtinType->getKind() == BuiltinType::ULongLong;
+  }
+
+  return true;
+}
+
 uint32_t getVkBindingAttrSet(const VKBindingAttr *attr, uint32_t defaultSet) {
   // If the [[vk::binding(x)]] attribute is provided without the descriptor set,
   // we should use the default descriptor set.
@@ -1119,6 +1198,18 @@ SpirvVariable *DeclResultIdMapper::createExternVar(const VarDecl *var) {
   if (vkImgFeatures.isCombinedImageSampler ||
       vkImgFeatures.format != spv::ImageFormat::Unknown) {
     spvContext.registerVkImageFeaturesForSpvVariable(varInstr, vkImgFeatures);
+  }
+
+  if (hlsl::IsHLSLResourceType(type)) {
+    if (!areFormatAndTypeCompatible(vkImgFeatures.format,
+                                    hlsl::GetHLSLResourceResultType(type))) {
+      emitError("The image format and the sampled type are not compatible.\n"
+                "For the table of compatible types, see "
+                "https://docs.vulkan.org/spec/latest/appendices/"
+                "spirvenv.html#spirvenv-format-type-matching.",
+                loc);
+      return nullptr;
+    }
   }
 
   astDecls[var] = createDeclSpirvInfo(varInstr);

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.r64i.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.r64i.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("r64i")]]
+RWTexture1D   <uint>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <uint>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.r64ui.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.r64ui.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("r64ui")]]
+RWTexture1D   <uint>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <uint>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32f.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32f.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("rgba32f")]]
+RWTexture1D   <int4>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <int4>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32i.float.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32i.float.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("rgba32i")]]
+RWTexture1D   <float4>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <float4>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32i.uint.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32i.uint.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("rgba32i")]]
+RWTexture1D   <uint4>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <uint4>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32ui.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/image.format.incompat.type.rgba32ui.hlsl
@@ -1,0 +1,10 @@
+// RUN: not %dxc -T vs_6_0 -E main -fspv-target-env=vulkan1.1 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+[[vk::image_format("rgba32ui")]]
+RWTexture1D   <int4>    t1 ;
+
+void main() {}
+
+// CHECK: error: The image format and the sampled type are not compatible.
+// CHECK-NEXT: For the table of compatible types, see https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.
+// CHECK-NEXT: RWTexture1D   <int4>    t1 ;

--- a/tools/clang/test/CodeGenSPIRV_Lit/vk.attribute.image-format.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/vk.attribute.image-format.hlsl
@@ -36,21 +36,29 @@ RWBuffer<float4> Buf_r8;
 [[vk::image_format("rg16snorm")]]
 RWBuffer<float4> Buf_rg16snorm;
 
-//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba32i
+//CHECK: OpTypeImage %int Buffer 2 0 0 2 Rgba32i
 [[vk::image_format("rgba32i")]]
-RWBuffer<float4> Buf_rgba32i;
+RWBuffer<int4> Buf_rgba32i;
 
-//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rg8i
+//CHECK: OpTypeImage %int Buffer 2 0 0 2 Rg8i
 [[vk::image_format("rg8i")]]
-RWBuffer<float4> Buf_rg8i;
+RWBuffer<int2> Buf_rg8i;
 
-//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgba16ui
+//CHECK: OpTypeImage %uint Buffer 2 0 0 2 Rgba16ui
 [[vk::image_format("rgba16ui")]]
-RWBuffer<float4> Buf_rgba16ui;
+RWBuffer<uint4> Buf_rgba16ui;
 
-//CHECK: OpTypeImage %float Buffer 2 0 0 2 Rgb10a2ui
+//CHECK: OpTypeImage %uint Buffer 2 0 0 2 Rgb10a2ui
 [[vk::image_format("rgb10a2ui")]]
-RWBuffer<float4> Buf_rgb10a2ui;
+RWBuffer<uint4> Buf_rgb10a2ui;
+
+//CHECK: OpTypeImage %long Buffer 2 0 0 2 R64i
+[[vk::image_format("r64i")]]
+RWBuffer<int64_t> Buf_r64i;
+
+//CHECK: OpTypeImage %ulong Buffer 2 0 0 2 R64ui
+[[vk::image_format("r64ui")]]
+RWBuffer<uint64_t> Buf_r64ui;
 
 struct S {
     RWBuffer<float4> b;

--- a/tools/clang/test/CodeGenSPIRV_Lit/vk.attribute.image-format.o3.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/vk.attribute.image-format.o3.hlsl
@@ -30,16 +30,22 @@ RWBuffer<float4> Buf_r8;
 RWBuffer<float4> Buf_rg16snorm;
 
 [[vk::image_format("rgba32i")]]
-RWBuffer<float4> Buf_rgba32i;
+RWBuffer<int4> Buf_rgba32i;
 
 [[vk::image_format("rg8i")]]
-RWBuffer<float4> Buf_rg8i;
+RWBuffer<int2> Buf_rg8i;
 
 [[vk::image_format("rgba16ui")]]
-RWBuffer<float4> Buf_rgba16ui;
+RWBuffer<uint4> Buf_rgba16ui;
 
 [[vk::image_format("rgb10a2ui")]]
-RWBuffer<float4> Buf_rgb10a2ui;
+RWBuffer<uint4> Buf_rgb10a2ui;
+
+[[vk::image_format("r64i")]]
+RWBuffer<int64_t> Buf_r64i;
+
+[[vk::image_format("r64ui")]]
+RWBuffer<uint64_t> Buf_r64ui;
 
 struct S {
     RWBuffer<float4> b;


### PR DESCRIPTION
This adds an error when the OpImageType create would violate the
requirements in
https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#spirvenv-format-type-matching.

Fixes #5955
