### PR TITLE
Fix ASAN leak in HLSL/ClangHLSLTests/RewriterTest.RunSpirv

### DIFF
--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -1757,13 +1757,6 @@ public:
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
-      StringRef Data(utf8Source->GetStringPointer(),
-                     utf8Source->GetStringLength());
-      std::unique_ptr<llvm::MemoryBuffer> pBuffer(
-          llvm::MemoryBuffer::getMemBufferCopy(Data, fName));
-      std::unique_ptr<ASTUnit::RemappedFile> pRemap(
-          new ASTUnit::RemappedFile(fName, pBuffer.release()));
-
       hlsl::options::MainArgs mainArgs(argCount, pArguments, 0);
 
       hlsl::options::DxcOpts opts;
@@ -1773,6 +1766,13 @@ public:
         // Looks odd, but this call succeeded enough to allocate a result
         return S_OK;
       }
+
+      StringRef Data(utf8Source->GetStringPointer(),
+                     utf8Source->GetStringLength());
+      std::unique_ptr<llvm::MemoryBuffer> pBuffer(
+          llvm::MemoryBuffer::getMemBufferCopy(Data, fName));
+      std::unique_ptr<ASTUnit::RemappedFile> pRemap(
+          new ASTUnit::RemappedFile(fName, pBuffer.release()));
 
       if (opts.RWOpt.DeclGlobalCB) {
         std::string errors;


### PR DESCRIPTION
Reorder the GetStatus check that earlies out of the function before creating a MemBufferCopy, otherwise it leaks upon early out.

This is a quick fix, but not the ideal one. The unique_ptr<MemoryBuffer> gives the false impression that the buffer will be automatically cleaned up; however, MemoryBuffer is just a pair of string and raw pointer to a buffer, so no cleanup occurs. Indeed, there's no real need for unique_ptr at all here. The ASTUnit::RemappedFile is passed down a chain of functions until SetupCompilerCommon is called, where the buffer is passed to compiler.getPreprocessorOpts().addRemappedFile, where ownership is established. Ideally, a unique_ptr to the buffer would be passed down, safely transferring ownership so that if an error occurs, no memory is leaked. This will be for another day.