### PR TITLE
Fix asan heap overflow pixtests

### DIFF
--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -1757,13 +1757,6 @@ public:
       ::llvm::sys::fs::AutoPerThreadSystem pts(msf.get());
       IFTLLVM(pts.error_code());
 
-      StringRef Data(utf8Source->GetStringPointer(),
-                     utf8Source->GetStringLength());
-      std::unique_ptr<llvm::MemoryBuffer> pBuffer(
-          llvm::MemoryBuffer::getMemBufferCopy(Data, fName));
-      std::unique_ptr<ASTUnit::RemappedFile> pRemap(
-          new ASTUnit::RemappedFile(fName, pBuffer.release()));
-
       hlsl::options::MainArgs mainArgs(argCount, pArguments, 0);
 
       hlsl::options::DxcOpts opts;
@@ -1773,6 +1766,13 @@ public:
         // Looks odd, but this call succeeded enough to allocate a result
         return S_OK;
       }
+
+      StringRef Data(utf8Source->GetStringPointer(),
+                     utf8Source->GetStringLength());
+      std::unique_ptr<llvm::MemoryBuffer> pBuffer(
+          llvm::MemoryBuffer::getMemBufferCopy(Data, fName));
+      std::unique_ptr<ASTUnit::RemappedFile> pRemap(
+          new ASTUnit::RemappedFile(fName, pBuffer.release()));
 
       if (opts.RWOpt.DeclGlobalCB) {
         std::string errors;

--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -258,10 +258,7 @@ PassOutput RunAnnotationPasses(dxc::DxcDllSupport &dllSupport, IDxcBlob *dxil,
   VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
       dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
 
-  std::string outputText;
-  if (pText->GetBufferSize() != 0) {
-    outputText = reinterpret_cast<const char *>(pText->GetBufferPointer());
-  }
+  std::string outputText = BlobToUtf8(pText);
 
   auto disasm = ToString(Disassemble(dllSupport, pOptimizedModule));
 


### PR DESCRIPTION
Fix ASAN heap-buffer-overflow in PixTests

PixStructAnnotation tests were converting an IDxcBlobEncoding to a
std::string, but this isn't valid if the underlying object is an
InternalDxcBlobEncoding_Impl, which holds a buffer that may not be
null-terminated. Fix this by using the BlobToUtf8 helper, which handles
this case gracefully.

Fixes 23 ASAN failures.
