### PR TITLE
Fix ASAN heap-buffer-overflow in PixTests

### DIFF
--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -258,10 +258,7 @@ PassOutput RunAnnotationPasses(dxc::DxcDllSupport &dllSupport, IDxcBlob *dxil,
   VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
       dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
 
-  std::string outputText;
-  if (pText->GetBufferSize() != 0) {
-    outputText = reinterpret_cast<const char *>(pText->GetBufferPointer());
-  }
+  std::string outputText = BlobToUtf8(pText);
 
   auto disasm = ToString(Disassemble(dllSupport, pOptimizedModule));
 


### PR DESCRIPTION
PixStructAnnotation tests were converting an IDxcBlobEncoding to a std::string, but this isn't valid if the underlying object is an InternalDxcBlobEncoding_Impl, which holds a buffer that may not be null-terminated. Fix this by using the BlobToUtf8 helper, which handles this case gracefully.

Fixes 23 ASAN failures.