### PR TITLE
Fix enable asan on pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
           configuration: Release
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_ENABLE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
           OS: Linux
         Linux_Clang_Debug:
           image: ${{ variables.linux }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,7 @@ stages:
           CC: clang
           CXX: clang++
           CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
+          CHECK_ALL_ENV: ASAN_OPTIONS=alloc_dealloc_mismatch=0
           OS: Linux
         Linux_Clang_Debug:
           image: ${{ variables.linux }}
@@ -116,7 +117,7 @@ stages:
         ls -ld $AGENT_BUILDDIRECTORY
         ls -ld $BUILD_SOURCESDIRECTORY
       displayName: 'Smoke tests'
-    - bash: ninja -C build check-all
+    - bash: $(CHECK_ALL_ENV) ninja -C build check-all
       displayName: 'DXC tests'
     - task: PublishTestResults@2
       inputs:


### PR DESCRIPTION
Two commits in this one:

 azure-pipelines: Fix ASAN not being enabled on Linux bot
    
    Unfortunately, the following CL did not correctly spell out the CMake
    variable to enable ASAN properly:
    https://github.com/microsoft/DirectXShaderCompiler/pull/5799
    
    This commit fixes that.


 azure-pipelines: disable ASAN alloc_dealloc_mismatch checks
    
    We are currently hitting false positives because of this. See the issue
    I opened: https://github.com/microsoft/DirectXShaderCompiler/issues/5971
    
    Perhaps a future Linux image will include a build of libc++ that does
    not exhibit this false positive, at which point this workaround can be
    reverted.
