### PR TITLE
Improve pipeline build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,7 @@ stages:
       displayName: 'Installing dependencies'
       condition: eq(variables['image'], variables['macOS'])
     - bash: |
-        cmake -B build -G Ninja $BUILD_SOURCESDIRECTORY -DLLVM_LIT_ARGS=--xunit-xml-output=testresults.xunit.xml -C $BUILD_SOURCESDIRECTORY/cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$(configuration) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) $(CMAKE_OPTS)
+        cmake -B build -G Ninja $BUILD_SOURCESDIRECTORY -DLLVM_LIT_ARGS='-v --xunit-xml-output=testresults.xunit.xml' -C $BUILD_SOURCESDIRECTORY/cmake/caches/PredefinedParams.cmake -DSPIRV_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$(configuration) -DCMAKE_C_COMPILER=$(CC) -DCMAKE_CXX_COMPILER=$(CXX) $(CMAKE_OPTS)
       displayName: 'Running Cmake'
     - bash: |
         ninja -C build test-depends

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,14 +49,14 @@ stages:
           configuration: Release
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_ENABLE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_ENABLE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
           OS: Linux
         Linux_Clang_Debug:
           image: ${{ variables.linux }}
           configuration: Debug
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_LINKER=lld
         Linux_Gcc_Release:
           image: ${{ variables.linux }}
           configuration: Release


### PR DESCRIPTION
Two commits:

    azure-pipelines: Use 'lld' linker for Linux builds
    
    This should speed up the total build time using a faster linker.


   azure-pipelines: Add verbose flag to LLVM_LIT_ARGS
    
    With `--xunit-xml-output` set, stderr is not fed to stdout, so we cannot
    easily see the errors in the build log. The errors only appear in the
    pipeline's "Test" tab. Adding the verbose flag allows it to also output
    stderr to the log.