### PR TITLE
azure-pipelines: Enable UBSAN on Linux_Clang_Release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ stages:
           configuration: Release
           CC: clang
           CXX: clang++
-          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER=Address -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
+          CMAKE_OPTS: -DLLVM_ENABLE_WERROR=On -DLLVM_USE_SANITIZER=Address,Undefined -DLLVM_ENABLE_LIBCXX=On -DLLVM_USE_LINKER=lld
           CHECK_ALL_ENV: ASAN_OPTIONS=alloc_dealloc_mismatch=0
           OS: Linux
         Linux_Clang_Debug:


### PR DESCRIPTION
Now that all UBSAN issues have been fixed, we can enable UBSAN checks on our CI.