### PR TITLE
Only diagnose exported library function declarations

### DIFF
--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -40,8 +40,10 @@ public:
 
 #else
 
-#define LANGOPT(Name, Bits, Default, Description) static const unsigned Name = Default;
-#define LANGOPT_BOOL(Name, Default, Description) static const bool Name = static_cast<bool>( Default );
+#define LANGOPT(Name, Bits, Default, Description)                              \
+  static const unsigned Name = Default;
+#define LANGOPT_BOOL(Name, Default, Description)                               \
+  static const bool Name = static_cast<bool>(Default);
 #define ENUM_LANGOPT(Name, Type, Bits, Default, Description)
 #include "clang/Basic/LangOptions.fixed.def"
 
@@ -52,16 +54,16 @@ protected:
   // have accessors (below).
 #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 #define LANGOPT(Name, Bits, Default, Description)
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
   unsigned Name : Bits;
 #include "clang/Basic/LangOptions.def"
 #endif
 };
 
 // #ifndef MS_SUPPORT_VARIABLE_LANGOPTS
-// #define LANGOPT(Name, Bits, Default, Description) __declspec(selectany) unsigned LangOptionsBase::#Name = Default;
-// #define ENUM_LANGOPT(Name, Type, Bits, Default, Description)
-// #include "clang/Basic/LangOptions.fixed.def"
+// #define LANGOPT(Name, Bits, Default, Description) __declspec(selectany)
+// unsigned LangOptionsBase::#Name = Default; #define ENUM_LANGOPT(Name, Type,
+// Bits, Default, Description) #include "clang/Basic/LangOptions.fixed.def"
 // #endif
 
 /// \brief Keeps track of the various options that can be
@@ -69,14 +71,14 @@ protected:
 class LangOptions : public LangOptionsBase {
 public:
   typedef clang::Visibility Visibility;
-  
+
   enum GCMode { NonGC, GCOnly, HybridGC };
   enum StackProtectorMode { SSPOff, SSPOn, SSPStrong, SSPReq };
-  
+
   enum SignedOverflowBehaviorTy {
-    SOB_Undefined,  // Default C standard behavior.
-    SOB_Defined,    // -fwrapv
-    SOB_Trapping    // -ftrapv
+    SOB_Undefined, // Default C standard behavior.
+    SOB_Defined,   // -fwrapv
+    SOB_Trapping   // -ftrapv
   };
 
   enum PragmaMSPointersToMembersKind {
@@ -106,7 +108,7 @@ public:
   clang::ObjCRuntime ObjCRuntime;
 
   std::string ObjCConstantStringClass;
-  
+
   /// \brief The name of the handler function to be called when -ftrapv is
   /// specified.
   ///
@@ -129,24 +131,24 @@ public:
 
   /// \brief Options for parsing comments.
   CommentOptions CommentOpts;
-  
+
   LangOptions();
 
   // Define accessors/mutators for language options of enumeration type.
 #ifdef MS_SUPPORT_VARIABLE_LANGOPTS
 
-#define LANGOPT(Name, Bits, Default, Description) 
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-  Type get##Name() const { return static_cast<Type>(Name); } \
-  void set##Name(Type Value) { Name = static_cast<unsigned>(Value); }  
+#define LANGOPT(Name, Bits, Default, Description)
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
+  Type get##Name() const { return static_cast<Type>(Name); }                   \
+  void set##Name(Type Value) { Name = static_cast<unsigned>(Value); }
 #include "clang/Basic/LangOptions.def"
-  
+
 #else
 
-#define LANGOPT(Name, Bits, Default, Description) 
-#define ENUM_LANGOPT(Name, Type, Bits, Default, Description) \
-  Type get##Name() const { return static_cast<Type>(Default); } \
-  void set##Name(Type Value) { assert(Value == Default); }  
+#define LANGOPT(Name, Bits, Default, Description)
+#define ENUM_LANGOPT(Name, Type, Bits, Default, Description)                   \
+  Type get##Name() const { return static_cast<Type>(Default); }                \
+  void set##Name(Type Value) { assert(Value == Default); }
 #include "clang/Basic/LangOptions.fixed.def"
 
 #endif
@@ -170,12 +172,12 @@ public:
   bool HLSLDefaultRowMajor = false;
   // HLSL Change Ends
 
-  bool SPIRV = false;  // SPIRV Change
-  
+  bool SPIRV = false; // SPIRV Change
+
   bool isSignedOverflowDefined() const {
     return getSignedOverflowBehavior() == SOB_Defined;
   }
-  
+
   bool isSubscriptPointerArithmetic() const {
     return ObjCRuntime.isSubscriptPointerArithmetic() &&
            !ObjCSubscriptingLegacyRuntime;
@@ -197,18 +199,18 @@ public:
 
   FPOptions() : fp_contract(0) {}
 
-  FPOptions(const LangOptions &LangOpts) :
-    fp_contract(LangOpts.DefaultFPContract) {}
+  FPOptions(const LangOptions &LangOpts)
+      : fp_contract(LangOpts.DefaultFPContract) {}
 };
 
 /// \brief OpenCL volatile options
 class OpenCLOptions {
 public:
-#define OPENCLEXT(nm)  unsigned nm : 1;
+#define OPENCLEXT(nm) unsigned nm : 1;
 #include "clang/Basic/OpenCLExtensions.def"
 
   OpenCLOptions() {
-#define OPENCLEXT(nm)   nm = 0;
+#define OPENCLEXT(nm) nm = 0;
 #include "clang/Basic/OpenCLExtensions.def"
   }
 };
@@ -223,7 +225,7 @@ enum TranslationUnitKind {
   /// \brief The translation unit is a module.
   TU_Module
 };
-  
-}  // end namespace clang
+
+} // end namespace clang
 
 #endif

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -15,12 +15,13 @@
 #ifndef LLVM_CLANG_BASIC_LANGOPTIONS_H
 #define LLVM_CLANG_BASIC_LANGOPTIONS_H
 
+#include "dxc/DXIL/DxilConstants.h" // For DXIL::DefaultLinkage
+#include "dxc/Support/HLSLVersion.h"
 #include "clang/Basic/CommentOptions.h"
 #include "clang/Basic/LLVM.h"
 #include "clang/Basic/ObjCRuntime.h"
 #include "clang/Basic/Sanitizers.h"
 #include "clang/Basic/Visibility.h"
-#include "dxc/Support/HLSLVersion.h"
 #include <string>
 #include <vector>
 
@@ -152,6 +153,7 @@ public:
 
   // HLSL Change Starts
   hlsl::LangStd HLSLVersion = hlsl::LangStd::vLatest;
+  std::vector<std::string> HLSLLibraryExports;
   std::string HLSLEntryFunction;
   std::string HLSLProfile;
   unsigned RootSigMajor = 1;
@@ -162,6 +164,9 @@ public:
   bool EnableFXCCompatMode = false;
   bool EnablePayloadAccessQualifiers = false;
   bool DumpImplicitTopLevelDecls = true;
+  bool ExportShadersOnly = false;
+  hlsl::DXIL::DefaultLinkage DefaultLinkage =
+      hlsl::DXIL::DefaultLinkage::Default;
   /// Whether use row major as default matrix major.
   bool HLSLDefaultRowMajor = false;
   // HLSL Change Ends

--- a/tools/clang/include/clang/Basic/LangOptions.h
+++ b/tools/clang/include/clang/Basic/LangOptions.h
@@ -153,7 +153,6 @@ public:
 
   // HLSL Change Starts
   hlsl::LangStd HLSLVersion = hlsl::LangStd::vLatest;
-  std::vector<std::string> HLSLLibraryExports;
   std::string HLSLEntryFunction;
   std::string HLSLProfile;
   unsigned RootSigMajor = 1;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11464,14 +11464,12 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
 void ValidatePatchConstantFunctionsExist(clang::Sema *self) {
 
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
-    // TODO: improve condition so that only exported functions are checked,
-    // instead of all functions. Issue: #5857
     if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
-      // If there is no patch constant function, then we don't need to validate
-      // anything.
       if (!IsExported(self, FD)) {
         continue;
       }
+      // If there is no patch constant function, then we don't need to validate
+      // anything.
       if (const HLSLPatchConstantFuncAttr *Attr =
               FD->getAttr<HLSLPatchConstantFuncAttr>()) {
         NameLookup NL =
@@ -15859,12 +15857,13 @@ clang::FunctionDecl *ValidateNoRecursion(clang::Sema *self,
   return nullptr;
 }
 
+// There is an assumption being made that this function will only be called
+// on library shader stages.Thus, there is no entry point, only exported
+// functions
 void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
   std::set<FunctionDecl *> FDecls;
   std::vector<FunctionDecl *> FDeclsVec;
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
-    // TODO: improve condition so that only exported functions are checked,
-    // instead of all functions. Issue: #5857
     if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
       // returns the first recursive function declaration detected
       // from this function declaration FD, and determines whether
@@ -15889,7 +15888,7 @@ void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
       continue;
     }
     self->Diag(fdecl->getSourceRange().getBegin(), diag::err_hlsl_no_recursion)
-        << 0 << fdecl->getName();
+        << 1 << fdecl->getName();
 
     FDecls.erase(fdecl);
   }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11400,17 +11400,17 @@ bool hlsl::DiagnoseNodeStructArgument(Sema *self, TemplateArgumentLoc ArgLoc,
   }
 }
 
-bool IsExported(Sema *self, clang::FunctionDecl *FD) {        
+bool IsExported(Sema *self, clang::FunctionDecl *FD) {
   if (FD->hasAttr<HLSLShaderAttr>()) {
-		return true;
-	}
-  
+    return true;
+  }
+
   bool isMarkedStatic = false;
   bool isMarkedExport = false;
 
   if (auto cDecl = dyn_cast<CXXMethodDecl>(FD)) {
     if (cDecl->isStatic()) {
-        isMarkedStatic = true;
+      isMarkedStatic = true;
     }
   }
 
@@ -11419,30 +11419,26 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
   }
 
   if (isMarkedStatic && isMarkedExport) {
-    self->Diag(FD->getLocation(), diag::err_hlsl_varmodifiersna)
-        << "static"
-        << "export"
-        << "function";
-		return false;
-	}
-
+    self->Diag(FD->getLocation(), diag::err_hlsl_varmodifiersna) << "static"
+                                                                 << "export"
+                                                                 << "function";
+    return false;
+  }
 
   Linkage L = FD->getLinkageAndVisibility().getLinkage();
 
-  
   const auto *shaderModel =
       hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
   // case 1 requires special assignments to linkage
   if (L != ExternalLinkage && L != InternalLinkage) {
     if (shaderModel->IsSM60Plus()) {
       L = ExternalLinkage;
-    }
-		else {
+    } else {
       L = InternalLinkage;
     }
-  }   
-  
-  // now case 2 and 3 can apply and we can determine 
+  }
+
+  // now case 2 and 3 can apply and we can determine
   // whether the function is exported.
   if (L == InternalLinkage && isMarkedExport) {
     return true;
@@ -11467,7 +11463,7 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
 // references a patch constant function, there exists a function declaration
 // that could serve as a candidate to that patch constant function.
 void ValidatePatchConstantFunctionsExist(clang::Sema *self) {
-  
+
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
     // TODO: improve condition so that only exported functions are checked,
     // instead of all functions. Issue: #5857

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11405,18 +11405,8 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
     return true;
   }
 
-  bool isMarkedStatic = false;
-  bool isMarkedExport = false;
-
-  if (auto cDecl = dyn_cast<CXXMethodDecl>(FD)) {
-    if (cDecl->isStatic()) {
-      isMarkedStatic = true;
-    }
-  }
-
-  if (FD->hasAttr<HLSLExportAttr>()) {
-    isMarkedExport = true;
-  }
+  const bool isMarkedStatic = FD->getStorageClass() == SC_Static;
+  const bool isMarkedExport = FD->hasAttr<HLSLExportAttr>();
 
   if (isMarkedStatic && isMarkedExport) {
     self->Diag(FD->getLocation(), diag::err_hlsl_varmodifiersna) << "static"
@@ -11429,8 +11419,11 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
 
   // case 1 requires special assignments to linkage
   if (L != ExternalLinkage && L != InternalLinkage) {
-    // the condition below implies the shader stage is lib_6_x
-    if (self->getLangOpts().IsHLSLLibrary) {
+    const hlsl::ShaderModel *SM =
+        hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
+    bool isLib6x =
+        SM->IsLib() && SM->GetMinor() == hlsl::ShaderModel::kOfflineMinor;
+    if (isLib6x) {
       L = ExternalLinkage;
     } else {
       L = InternalLinkage;
@@ -11439,21 +11432,18 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
 
   // now case 2 and 3 can apply and we can determine
   // whether the function is exported.
-  if (L == InternalLinkage && isMarkedExport) {
+  if (L == InternalLinkage && isMarkedExport)
     return true;
-  }
 
-  if (L == ExternalLinkage && isMarkedStatic) {
+  if (L == ExternalLinkage && isMarkedStatic)
     return false;
-  }
 
-  if (L == InternalLinkage) {
+  if (L == InternalLinkage)
     return false;
-  }
 
-  if (L == ExternalLinkage) {
+  if (L == ExternalLinkage)
     return true;
-  }
+
   // unreachable but necessary to prevent warnings
   return true;
 }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2917,6 +2917,7 @@ typedef ::llvm::DenseMap<FunctionDecl *, CallNode> CallNodes;
 typedef ::llvm::SmallPtrSet<Decl *, 8> FnCallStack;
 typedef ::llvm::SmallPtrSet<FunctionDecl *, 128> FunctionSet;
 typedef ::llvm::SmallVector<FunctionDecl *, 32> PendingFunctions;
+typedef ::llvm::DenseMap<FunctionDecl *, FunctionDecl *> FunctionMap;
 
 // Returns the definition of a function.
 // This serves two purposes - ignore built-in functions, and pick
@@ -2991,19 +2992,26 @@ class CallGraphWithRecurseGuard {
 private:
   CallNodes m_callNodes;
   FunctionSet m_visitedFunctions;
+  FunctionMap m_functionsCheckedForRecursion;
 
-  FunctionDecl *CheckRecursion(FnCallStack &CallStack, FunctionDecl *D) const {
+  FunctionDecl *CheckRecursion(FnCallStack &CallStack, FunctionDecl *D) {
+    auto it = m_functionsCheckedForRecursion.find(D);
+    if (it != m_functionsCheckedForRecursion.end())
+      return it->second;
     if (CallStack.insert(D).second == false)
       return D;
     auto node = m_callNodes.find(D);
     if (node != m_callNodes.end()) {
       for (FunctionDecl *Callee : node->second.CalleeFns) {
         FunctionDecl *pResult = CheckRecursion(CallStack, Callee);
-        if (pResult)
+        if (pResult) {
+          m_functionsCheckedForRecursion[D] = pResult;
           return pResult;
+        }
       }
     }
     CallStack.erase(D);
+    m_functionsCheckedForRecursion[D] = nullptr;
     return nullptr;
   }
 
@@ -3038,7 +3046,7 @@ public:
     return false;
   }
 
-  FunctionDecl *CheckRecursion(FunctionDecl *EntryFnDecl) const {
+  FunctionDecl *CheckRecursion(FunctionDecl *EntryFnDecl) {
     FnCallStack CallStack;
     EntryFnDecl = getFunctionWithBody(EntryFnDecl);
     return CheckRecursion(CallStack, EntryFnDecl);
@@ -3148,6 +3156,8 @@ private:
   ObjectTypeDeclMapType m_objectTypeDeclsMap;
 
   UsedIntrinsicStore m_usedIntrinsics;
+
+  CallGraphWithRecurseGuard m_callGraph;
 
   /// <summary>Add all base QualTypes for each hlsl scalar types.</summary>
   void AddBaseTypes();
@@ -4143,6 +4153,14 @@ public:
   void ForgetSema() override { m_sema = nullptr; }
 
   Sema *getSema() { return m_sema; }
+
+  void BuildCallGraphForEntry(FunctionDecl *EntryFnDecl) {
+    m_callGraph.BuildForEntry(EntryFnDecl);
+  }
+
+  FunctionDecl *CheckForCallGraphRecursion(FunctionDecl *EntryFnDecl) {
+    return m_callGraph.CheckRecursion(EntryFnDecl);
+  }
 
   TypedefDecl *LookupScalarTypeDef(HLSLScalarType scalarType) {
     // We shouldn't create Typedef for built in scalar types.
@@ -5792,6 +5810,8 @@ public:
 
     return method;
   }
+
+  CallGraphWithRecurseGuard getCallGraph() { return m_callGraph; }
 
   // Overload support.
   UINT64 ScoreCast(QualType leftType, QualType rightType);
@@ -11400,62 +11420,53 @@ bool hlsl::DiagnoseNodeStructArgument(Sema *self, TemplateArgumentLoc ArgLoc,
   }
 }
 
-bool IsExported(Sema *self, clang::FunctionDecl *FD) {
-  if (FD->hasAttr<HLSLShaderAttr>()) {
-    return true;
-  }
+static bool IsTargetProfileLib6x(Sema &S) {
+  // Remaining functions are exported only if target is 'lib_6_x'.
+  const hlsl::ShaderModel *SM =
+      hlsl::ShaderModel::GetByName(S.getLangOpts().HLSLProfile.c_str());
+  bool isLib6x = SM->IsLib() && SM->GetMajor() == 6u;
+  return isLib6x;
+}
 
-  const bool isMarkedStatic = FD->getStorageClass() == SC_Static;
-  const bool isMarkedExport = FD->hasAttr<HLSLExportAttr>();
-
-  if (isMarkedStatic && isMarkedExport) {
-    self->Diag(FD->getLocation(), diag::err_hlsl_varmodifiersna) << "static"
-                                                                 << "export"
-                                                                 << "function";
-    return false;
-  }
-
-  Linkage L = FD->getLinkageAndVisibility().getLinkage();
-
-  // case 1 requires special assignments to linkage
-  if (L != ExternalLinkage && L != InternalLinkage) {
-    const hlsl::ShaderModel *SM =
-        hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
-    bool isLib6x =
-        SM->IsLib() && SM->GetMinor() == hlsl::ShaderModel::kOfflineMinor;
-    if (isLib6x) {
-      L = ExternalLinkage;
-    } else {
-      L = InternalLinkage;
-    }
-  }
-
-  // now case 2 and 3 can apply and we can determine
-  // whether the function is exported.
-  if (L == InternalLinkage && isMarkedExport)
+bool IsExported(Sema *self, clang::FunctionDecl *FD,
+                bool isDefaultLinkageExternal) {
+  // Entry points are exported.
+  if (FD->hasAttr<HLSLShaderAttr>())
     return true;
 
-  if (L == ExternalLinkage && isMarkedStatic)
+  // Internal linkage functions include functions marked 'static'.
+  if (FD->getLinkageAndVisibility().getLinkage() == InternalLinkage)
     return false;
 
-  if (L == InternalLinkage)
-    return false;
-
-  if (L == ExternalLinkage)
+  // Explicit 'export' functions are exported.
+  if (FD->hasAttr<HLSLExportAttr>())
     return true;
 
-  // unreachable but necessary to prevent warnings
-  return true;
+  return isDefaultLinkageExternal;
+}
+
+bool getDefaultLinkageExternal(clang::Sema *self) {
+  const LangOptions &opts = self->getLangOpts();
+  bool isDefaultLinkageExternal =
+      opts.DefaultLinkage == DXIL::DefaultLinkage::External;
+  if (opts.DefaultLinkage == DXIL::DefaultLinkage::Default &&
+      !opts.ExportShadersOnly && IsTargetProfileLib6x(*self))
+    isDefaultLinkageExternal = true;
+  return isDefaultLinkageExternal;
 }
 
 // validates that for every function in the translation unit, if it
 // references a patch constant function, there exists a function declaration
 // that could serve as a candidate to that patch constant function.
-void ValidatePatchConstantFunctionsExist(clang::Sema *self) {
+// Further, it will validate that if a patch constant function is declared,
+// it isn't recursive, and that it and the hull shader function that references
+// it cannot reach each other in the call graph.
+void ValidatePatchConstantFunctions(clang::Sema *self) {
 
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
     if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
-      if (!IsExported(self, FD)) {
+      if (!FD->hasBody() ||
+          !IsExported(self, FD, getDefaultLinkageExternal(self))) {
         continue;
       }
       // If there is no patch constant function, then we don't need to validate
@@ -11469,6 +11480,42 @@ void ValidatePatchConstantFunctionsExist(clang::Sema *self) {
           self->Diag(Attr->getLocation(),
                      diag::err_hlsl_missing_patch_constant_function)
               << Attr->getFunctionName();
+          continue;
+        }
+        // the patch constant function is NL.Found
+        // now validate that the patch constant function isn't recursive
+        FunctionDecl *pResultPatch = ValidateNoRecursion(self, NL.Found);
+        if (pResultPatch) {
+          self->Diag(pResultPatch->getSourceRange().getBegin(),
+                     diag::err_hlsl_no_recursion)
+              << 2 << pResultPatch->getName();
+        }
+
+        // validate that the hull shader function that references the patch
+        // constant function isn't recursive
+        FunctionDecl *pResultHull = ValidateNoRecursion(self, FD);
+        if (pResultHull) {
+          self->Diag(pResultHull->getSourceRange().getBegin(),
+                     diag::err_hlsl_no_recursion)
+              << 2 << pResultHull->getName();
+        }
+
+        // now validate that the patch constant function and the hull shader
+        // function that references it cannot reach each other in the call graph
+        if (!pResultHull && !pResultPatch) {
+          HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(self);
+          hlslSource->getCallGraph().BuildForEntry(NL.Found);
+          if (hlslSource->getCallGraph().CheckReachability(NL.Found, FD)) {
+            self->Diag(FD->getSourceRange().getBegin(),
+                       diag::err_hlsl_patch_reachability_not_allowed)
+                << 1 << FD->getName() << 0 << NL.Found->getName();
+          }
+          hlslSource->getCallGraph().BuildForEntry(FD);
+          if (hlslSource->getCallGraph().CheckReachability(FD, NL.Found)) {
+            self->Diag(FD->getSourceRange().getBegin(),
+                       diag::err_hlsl_patch_reachability_not_allowed)
+                << 0 << NL.Found->getName() << 1 << FD->getName();
+          }
         }
       }
     }
@@ -11525,7 +11572,7 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
   }
 
   if (self->getLangOpts().IsHLSLLibrary) {
-    ValidatePatchConstantFunctionsExist(self);
+    ValidatePatchConstantFunctions(self);
     ValidateNoRecursionInTranslationUnit(self);
     return;
   }
@@ -15840,9 +15887,9 @@ clang::FunctionDecl *ValidateNoRecursion(clang::Sema *self,
   // on functions that are unreachable (as an early form of dead code
   // elimination).
   if (FD) {
-    hlsl::CallGraphWithRecurseGuard CG;
-    CG.BuildForEntry(FD);
-    return CG.CheckRecursion(FD);
+    HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(self);
+    hlslSource->BuildCallGraphForEntry(FD);
+    return hlslSource->CheckForCallGraphRecursion(FD);
   }
   return nullptr;
 }
@@ -15858,7 +15905,8 @@ void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
       // returns the first recursive function declaration detected
       // from this function declaration FD, and determines whether
       // the recursion was detected in the patch-constant function
-      if (!IsExported(self, FD)) {
+      if (!FD->hasBody() ||
+          !IsExported(self, FD, getDefaultLinkageExternal(self))) {
         continue;
       }
       FunctionDecl *pResult = ValidateNoRecursion(self, FD);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11456,73 +11456,6 @@ bool getDefaultLinkageExternal(clang::Sema *self) {
   return isDefaultLinkageExternal;
 }
 
-// validates that for every function in the translation unit, if it
-// references a patch constant function, there exists a function declaration
-// that could serve as a candidate to that patch constant function.
-// Further, it will validate that if a patch constant function is declared,
-// it isn't recursive, and that it and the hull shader function that references
-// it cannot reach each other in the call graph.
-void ValidatePatchConstantFunctions(clang::Sema *self) {
-
-  for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
-    if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
-      if (!FD->hasBody() ||
-          !IsExported(self, FD, getDefaultLinkageExternal(self))) {
-        continue;
-      }
-      // If there is no patch constant function, then we don't need to validate
-      // anything.
-      if (const HLSLPatchConstantFuncAttr *Attr =
-              FD->getAttr<HLSLPatchConstantFuncAttr>()) {
-        NameLookup NL =
-            GetSingleFunctionDeclByName(self, Attr->getFunctionName(),
-                                        /*checkPatch*/ true);
-        if (!NL.Found || !NL.Found->hasBody()) {
-          self->Diag(Attr->getLocation(),
-                     diag::err_hlsl_missing_patch_constant_function)
-              << Attr->getFunctionName();
-          continue;
-        }
-        // the patch constant function is NL.Found
-        // now validate that the patch constant function isn't recursive
-        FunctionDecl *pResultPatch = ValidateNoRecursion(self, NL.Found);
-        if (pResultPatch) {
-          self->Diag(pResultPatch->getSourceRange().getBegin(),
-                     diag::err_hlsl_no_recursion)
-              << 2 << pResultPatch->getName();
-        }
-
-        // validate that the hull shader function that references the patch
-        // constant function isn't recursive
-        FunctionDecl *pResultHull = ValidateNoRecursion(self, FD);
-        if (pResultHull) {
-          self->Diag(pResultHull->getSourceRange().getBegin(),
-                     diag::err_hlsl_no_recursion)
-              << 0 << pResultHull->getName();
-        }
-
-        // now validate that the patch constant function and the hull shader
-        // function that references it cannot reach each other in the call graph
-        if (!pResultHull && !pResultPatch) {
-          HLSLExternalSource *hlslSource = HLSLExternalSource::FromSema(self);
-          hlslSource->getCallGraph().BuildForEntry(NL.Found);
-          if (hlslSource->getCallGraph().CheckReachability(NL.Found, FD)) {
-            self->Diag(FD->getSourceRange().getBegin(),
-                       diag::err_hlsl_patch_reachability_not_allowed)
-                << 1 << FD->getName() << 0 << NL.Found->getName();
-          }
-          hlslSource->getCallGraph().BuildForEntry(FD);
-          if (hlslSource->getCallGraph().CheckReachability(FD, NL.Found)) {
-            self->Diag(FD->getSourceRange().getBegin(),
-                       diag::err_hlsl_patch_reachability_not_allowed)
-                << 0 << NL.Found->getName() << 1 << FD->getName();
-          }
-        }
-      }
-    }
-  }
-}
-
 // This function diagnoses whether or not all entry-point attributes
 // should exist on this shader stage
 void DiagnoseEntryAttrAllowedOnStage(clang::Sema *self,
@@ -11551,6 +11484,38 @@ void DiagnoseEntryAttrAllowedOnStage(clang::Sema *self,
   }
 }
 
+std::vector<FunctionDecl *> GetAllExportedFDecls(clang::Sema *self) {
+  // Add to the end, process from the beginning, to ensure AllExportedFDecls
+  // will contain functions in decl order.
+  std::vector<FunctionDecl *> AllExportedFDecls;
+
+  std::deque<DeclContext *> Worklist;
+  Worklist.push_back(self->getASTContext().getTranslationUnitDecl());
+  while (Worklist.size()) {
+    DeclContext *DC = Worklist.front();
+    Worklist.pop_front();
+    if (auto *FD = dyn_cast<FunctionDecl>(DC)) {
+      if (!FD->hasBody() ||
+          !IsExported(self, FD, getDefaultLinkageExternal(self))) {
+        continue;
+      }
+      AllExportedFDecls.push_back(FD);
+    } else {
+      for (auto *D : DC->decls()) {
+        if (auto *FD = dyn_cast<FunctionDecl>(D)) {
+          if (FD->hasBody() &&
+              IsExported(self, FD, getDefaultLinkageExternal(self)))
+            Worklist.push_back(FD);
+        } else if (auto *DC2 = dyn_cast<DeclContext>(D)) {
+          Worklist.push_back(DC2);
+        }
+      }
+    }
+  }
+
+  return AllExportedFDecls;
+}
+
 void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
   DXASSERT_NOMSG(self != nullptr);
 
@@ -11572,56 +11537,69 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
     }
   }
 
-  if (self->getLangOpts().IsHLSLLibrary) {
-    ValidatePatchConstantFunctions(self);
-    ValidateNoRecursionInTranslationUnit(self);
-    return;
-  }
+  // Now check for recursion, and check for patch constant function
+  // reachabililty Validation methods differ depending on whether this is a
+  // library shader or not.
 
   // TODO: make these error 'real' errors rather than on-the-fly things
   // Validate that the entry point is available.
   DiagnosticsEngine &Diags = self->getDiagnostics();
   FunctionDecl *pEntryPointDecl = nullptr;
   FunctionDecl *pPatchFnDecl = nullptr;
-  const std::string &EntryPointName = self->getLangOpts().HLSLEntryFunction;
-  if (!EntryPointName.empty()) {
-    NameLookup NL =
-        GetSingleFunctionDeclByName(self, EntryPointName, /*checkPatch*/ false);
-    if (NL.Found && NL.Other) {
-      // NOTE: currently we cannot hit this codepath when CodeGen is enabled,
-      // because CodeGenModule::getMangledName will mangle the entry point name
-      // into the bare string, and so ambiguous points will produce an error
-      // earlier on.
-      unsigned id =
-          Diags.getCustomDiagID(clang::DiagnosticsEngine::Level::Error,
-                                "ambiguous entry point function");
-      Diags.Report(NL.Found->getSourceRange().getBegin(), id);
-      Diags.Report(NL.Other->getLocation(), diag::note_previous_definition);
-      return;
-    }
-    pEntryPointDecl = NL.Found;
-    if (!pEntryPointDecl || !pEntryPointDecl->hasBody()) {
-      unsigned id =
-          Diags.getCustomDiagID(clang::DiagnosticsEngine::Level::Error,
-                                "missing entry point definition");
-      Diags.Report(id);
-      return;
+  std::vector<FunctionDecl *> FDeclsToCheck;
+  if (self->getLangOpts().IsHLSLLibrary) {
+    FDeclsToCheck = GetAllExportedFDecls(self);
+  } else {
+    const std::string &EntryPointName = self->getLangOpts().HLSLEntryFunction;
+    if (!EntryPointName.empty()) {
+      NameLookup NL = GetSingleFunctionDeclByName(self, EntryPointName,
+                                                  /*checkPatch*/ false);
+      if (NL.Found && NL.Other) {
+        // NOTE: currently we cannot hit this codepath when CodeGen is enabled,
+        // because CodeGenModule::getMangledName will mangle the entry point
+        // name into the bare string, and so ambiguous points will produce an
+        // error earlier on.
+        unsigned id =
+            Diags.getCustomDiagID(clang::DiagnosticsEngine::Level::Error,
+                                  "ambiguous entry point function");
+        Diags.Report(NL.Found->getSourceRange().getBegin(), id);
+        Diags.Report(NL.Other->getLocation(), diag::note_previous_definition);
+        return;
+      }
+      pEntryPointDecl = NL.Found;
+      if (!pEntryPointDecl || !pEntryPointDecl->hasBody()) {
+        unsigned id =
+            Diags.getCustomDiagID(clang::DiagnosticsEngine::Level::Error,
+                                  "missing entry point definition");
+        Diags.Report(id);
+        return;
+      }
+      FDeclsToCheck.push_back(NL.Found);
     }
   }
 
-  FunctionDecl *result = ValidateNoRecursion(self, pEntryPointDecl);
+  std::set<FunctionDecl *> DiagnosedDecls;
+  // for each FDecl, check for recursion
+  for (FunctionDecl *FDecl : FDeclsToCheck) {
+    FunctionDecl *result = ValidateNoRecursion(self, FDecl);
 
-  if (result) {
-    self->Diag(result->getSourceRange().getBegin(), diag::err_hlsl_no_recursion)
-        << 0 << result->getName();
-  }
+    if (result) {
+      // don't emit duplicate diagnostics for the same recursive function
+      // if A and B call recursive function C, only emit 1 diagnostic for C.
+      if (DiagnosedDecls.find(result) == DiagnosedDecls.end()) {
+        DiagnosedDecls.insert(result);
+        int errorType = self->getLangOpts().IsHLSLLibrary ? 1 : 0;
+        self->Diag(result->getSourceRange().getBegin(),
+                   diag::err_hlsl_no_recursion)
+            << errorType << result->getName();
+      }
+    }
 
-  const auto *shaderModel =
-      hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
+    const auto *shaderModel =
+        hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
 
-  if (shaderModel->IsHS()) {
     if (const HLSLPatchConstantFuncAttr *attr =
-            pEntryPointDecl->getAttr<HLSLPatchConstantFuncAttr>()) {
+            FDecl->getAttr<HLSLPatchConstantFuncAttr>()) {
       NameLookup NL = GetSingleFunctionDeclByName(self, attr->getFunctionName(),
                                                   /*checkPatch*/ true);
       if (!NL.Found || !NL.Found->hasBody()) {
@@ -11631,34 +11609,35 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
       }
       pPatchFnDecl = NL.Found;
     }
-  }
 
-  if (pPatchFnDecl) {
-    FunctionDecl *patchResult = ValidateNoRecursion(self, pPatchFnDecl);
+    if (pPatchFnDecl) {
+      FunctionDecl *patchResult = ValidateNoRecursion(self, pPatchFnDecl);
 
-    // In this case, recursion was detected in the patch-constant function
-    if (patchResult) {
-      self->Diag(patchResult->getSourceRange().getBegin(),
-                 diag::err_hlsl_no_recursion)
-          << 2 << patchResult->getName();
-    }
-
-    // The patch function decl and the entry function decl should be
-    // disconnected with respect to the call graph.
-    // Only check this if neither function decl is recursive
-    if (!result && !patchResult) {
-      hlsl::CallGraphWithRecurseGuard CG;
-      CG.BuildForEntry(pPatchFnDecl);
-      if (CG.CheckReachability(pPatchFnDecl, pEntryPointDecl)) {
-        self->Diag(pEntryPointDecl->getSourceRange().getBegin(),
-                   diag::err_hlsl_patch_reachability_not_allowed)
-            << 1 << pEntryPointDecl->getName() << 0 << pPatchFnDecl->getName();
+      // In this case, recursion was detected in the patch-constant function
+      if (patchResult) {
+        self->Diag(patchResult->getSourceRange().getBegin(),
+                   diag::err_hlsl_no_recursion)
+            << 2 << patchResult->getName();
       }
-      CG.BuildForEntry(pEntryPointDecl);
-      if (CG.CheckReachability(pEntryPointDecl, pPatchFnDecl)) {
-        self->Diag(pEntryPointDecl->getSourceRange().getBegin(),
-                   diag::err_hlsl_patch_reachability_not_allowed)
-            << 0 << pPatchFnDecl->getName() << 1 << pEntryPointDecl->getName();
+
+      // The patch function decl and the entry function decl should be
+      // disconnected with respect to the call graph.
+      // Only check this if neither function decl is recursive
+      if (!result && !patchResult) {
+        hlsl::CallGraphWithRecurseGuard CG;
+        CG.BuildForEntry(pPatchFnDecl);
+        if (CG.CheckReachability(pPatchFnDecl, FDecl)) {
+          self->Diag(FDecl->getSourceRange().getBegin(),
+                     diag::err_hlsl_patch_reachability_not_allowed)
+              << 1 << FDecl->getName() << 0 << pPatchFnDecl->getName();
+        }
+        CG.BuildForEntry(FDecl);
+        if (CG.CheckReachability(FDecl, pPatchFnDecl)) {
+          self->Diag(FDecl->getSourceRange().getBegin(),
+                     diag::err_hlsl_patch_reachability_not_allowed)
+              << 0 << pPatchFnDecl->getName() << 1
+              << pEntryPointDecl->getName();
+        }
       }
     }
   }
@@ -15893,69 +15872,6 @@ clang::FunctionDecl *ValidateNoRecursion(clang::Sema *self,
     return hlslSource->CheckForCallGraphRecursion(FD);
   }
   return nullptr;
-}
-
-// There is an assumption being made that this function will only be called
-// on library shader stages.Thus, there is no entry point, only exported
-// functions
-void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
-  std::set<FunctionDecl *> FDecls;
-  std::vector<FunctionDecl *> FDeclsVec;
-  std::vector<FunctionDecl *> AllExportedFDecls;
-
-  for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
-    if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
-      if (!FD->hasBody() ||
-          !IsExported(self, FD, getDefaultLinkageExternal(self))) {
-        continue;
-      }
-      AllExportedFDecls.push_back(FD);
-    } else if (DeclContext *declContext = dyn_cast<DeclContext>(decl)) {
-      // Loop through all declarations inside the class or namespace
-      for (DeclContext::decl_iterator j = declContext->decls_begin(),
-                                      e = declContext->decls_end();
-           j != e; ++j) {
-        // Check if the declaration is a function declaration
-        if (FunctionDecl *functionDecl = dyn_cast<FunctionDecl>(*j)) {
-          if (!functionDecl->hasBody() ||
-              !IsExported(self, functionDecl,
-                          getDefaultLinkageExternal(self))) {
-            continue;
-          }
-          AllExportedFDecls.push_back(functionDecl);
-        }
-      }
-    }
-  }
-
-  for (auto FD : AllExportedFDecls) {
-    // returns the first recursive function declaration detected
-    // from this function declaration FD, and determines whether
-    // the recursion was detected in the patch-constant function
-    if (!FD->hasBody() ||
-        !IsExported(self, FD, getDefaultLinkageExternal(self))) {
-      continue;
-    }
-    FunctionDecl *pResult = ValidateNoRecursion(self, FD);
-    // if there is a function that was detected to be recursive,
-    // then make sure it is saved for later to emit a diagnostic
-    if (pResult) {
-      FDecls.insert(pResult);
-      FDeclsVec.push_back(pResult);
-    }
-  }
-
-  // iterate through FDeclsVec to maintain AST order, and delete
-  // from set FDecls as we go.
-  for (FunctionDecl *fdecl : FDeclsVec) {
-    if (FDecls.find(fdecl) == FDecls.end()) {
-      continue;
-    }
-    self->Diag(fdecl->getSourceRange().getBegin(), diag::err_hlsl_no_recursion)
-        << 1 << fdecl->getName();
-
-    FDecls.erase(fdecl);
-  }
 }
 
 // The DiagnoseEntry function does 2 things:

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11424,7 +11424,8 @@ static bool IsTargetProfileLib6x(Sema &S) {
   // Remaining functions are exported only if target is 'lib_6_x'.
   const hlsl::ShaderModel *SM =
       hlsl::ShaderModel::GetByName(S.getLangOpts().HLSLProfile.c_str());
-  bool isLib6x = SM->IsLib() && SM->GetMajor() == 6u;
+  bool isLib6x =
+      SM->IsLib() && SM->GetMinor() == hlsl::ShaderModel::kOfflineMinor;
   return isLib6x;
 }
 
@@ -11497,7 +11498,7 @@ void ValidatePatchConstantFunctions(clang::Sema *self) {
         if (pResultHull) {
           self->Diag(pResultHull->getSourceRange().getBegin(),
                      diag::err_hlsl_no_recursion)
-              << 2 << pResultHull->getName();
+              << 0 << pResultHull->getName();
         }
 
         // now validate that the patch constant function and the hull shader
@@ -15900,22 +15901,47 @@ clang::FunctionDecl *ValidateNoRecursion(clang::Sema *self,
 void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
   std::set<FunctionDecl *> FDecls;
   std::vector<FunctionDecl *> FDeclsVec;
+  std::vector<FunctionDecl *> AllExportedFDecls;
+
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
     if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
-      // returns the first recursive function declaration detected
-      // from this function declaration FD, and determines whether
-      // the recursion was detected in the patch-constant function
       if (!FD->hasBody() ||
           !IsExported(self, FD, getDefaultLinkageExternal(self))) {
         continue;
       }
-      FunctionDecl *pResult = ValidateNoRecursion(self, FD);
-      // if there is a function that was detected to be recursive,
-      // then make sure it is saved for later to emit a diagnostic
-      if (pResult) {
-        FDecls.insert(pResult);
-        FDeclsVec.push_back(pResult);
+      AllExportedFDecls.push_back(FD);
+    } else if (DeclContext *declContext = dyn_cast<DeclContext>(decl)) {
+      // Loop through all declarations inside the class or namespace
+      for (DeclContext::decl_iterator j = declContext->decls_begin(),
+                                      e = declContext->decls_end();
+           j != e; ++j) {
+        // Check if the declaration is a function declaration
+        if (FunctionDecl *functionDecl = dyn_cast<FunctionDecl>(*j)) {
+          if (!functionDecl->hasBody() ||
+              !IsExported(self, functionDecl,
+                          getDefaultLinkageExternal(self))) {
+            continue;
+          }
+          AllExportedFDecls.push_back(functionDecl);
+        }
       }
+    }
+  }
+
+  for (auto FD : AllExportedFDecls) {
+    // returns the first recursive function declaration detected
+    // from this function declaration FD, and determines whether
+    // the recursion was detected in the patch-constant function
+    if (!FD->hasBody() ||
+        !IsExported(self, FD, getDefaultLinkageExternal(self))) {
+      continue;
+    }
+    FunctionDecl *pResult = ValidateNoRecursion(self, FD);
+    // if there is a function that was detected to be recursive,
+    // then make sure it is saved for later to emit a diagnostic
+    if (pResult) {
+      FDecls.insert(pResult);
+      FDeclsVec.push_back(pResult);
     }
   }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11400,16 +11400,83 @@ bool hlsl::DiagnoseNodeStructArgument(Sema *self, TemplateArgumentLoc ArgLoc,
   }
 }
 
+bool IsExported(Sema *self, clang::FunctionDecl *FD) {        
+  if (FD->hasAttr<HLSLShaderAttr>()) {
+		return true;
+	}
+  
+  bool isMarkedStatic = false;
+  bool isMarkedExport = false;
+
+  if (auto cDecl = dyn_cast<CXXMethodDecl>(FD)) {
+    if (cDecl->isStatic()) {
+        isMarkedStatic = true;
+    }
+  }
+
+  if (FD->hasAttr<HLSLExportAttr>()) {
+    isMarkedExport = true;
+  }
+
+  if (isMarkedStatic && isMarkedExport) {
+    self->Diag(FD->getLocation(), diag::err_hlsl_varmodifiersna)
+        << "static"
+        << "export"
+        << "function";
+		return false;
+	}
+
+
+  Linkage L = FD->getLinkageAndVisibility().getLinkage();
+
+  
+  const auto *shaderModel =
+      hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
+  // case 1 requires special assignments to linkage
+  if (L != ExternalLinkage && L != InternalLinkage) {
+    if (shaderModel->IsSM60Plus()) {
+      L = ExternalLinkage;
+    }
+		else {
+      L = InternalLinkage;
+    }
+  }   
+  
+  // now case 2 and 3 can apply and we can determine 
+  // whether the function is exported.
+  if (L == InternalLinkage && isMarkedExport) {
+    return true;
+  }
+
+  if (L == ExternalLinkage && isMarkedStatic) {
+    return false;
+  }
+
+  if (L == InternalLinkage) {
+    return false;
+  }
+
+  if (L == ExternalLinkage) {
+    return true;
+  }
+  // unreachable but necessary to prevent warnings
+  return true;
+}
+
 // validates that for every function in the translation unit, if it
 // references a patch constant function, there exists a function declaration
 // that could serve as a candidate to that patch constant function.
 void ValidatePatchConstantFunctionsExist(clang::Sema *self) {
+  
   for (auto decl : self->getASTContext().getTranslationUnitDecl()->decls()) {
     // TODO: improve condition so that only exported functions are checked,
     // instead of all functions. Issue: #5857
     if (FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
       // If there is no patch constant function, then we don't need to validate
       // anything.
+      if (!IsExported(self, FD)) {
+        continue;
+      }
       if (const HLSLPatchConstantFuncAttr *Attr =
               FD->getAttr<HLSLPatchConstantFuncAttr>()) {
         NameLookup NL =

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11427,11 +11427,10 @@ bool IsExported(Sema *self, clang::FunctionDecl *FD) {
 
   Linkage L = FD->getLinkageAndVisibility().getLinkage();
 
-  const auto *shaderModel =
-      hlsl::ShaderModel::GetByName(self->getLangOpts().HLSLProfile.c_str());
   // case 1 requires special assignments to linkage
   if (L != ExternalLinkage && L != InternalLinkage) {
-    if (shaderModel->IsSM60Plus()) {
+    // the condition below implies the shader stage is lib_6_x
+    if (self->getLangOpts().IsHLSLLibrary) {
       L = ExternalLinkage;
     } else {
       L = InternalLinkage;
@@ -15870,6 +15869,9 @@ void ValidateNoRecursionInTranslationUnit(clang::Sema *self) {
       // returns the first recursive function declaration detected
       // from this function declaration FD, and determines whether
       // the recursion was detected in the patch-constant function
+      if (!IsExported(self, FD)) {
+        continue;
+      }
       FunctionDecl *pResult = ValidateNoRecursion(self, FD);
       // if there is a function that was detected to be recursive,
       // then make sure it is saved for later to emit a diagnostic

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/lib_struct_member_unconditional.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/lib_struct_member_unconditional.hlsl
@@ -6,7 +6,7 @@
 // The SCCP pass replaces the recursive call with an undef value,
 // which is why validation fails with a non-obvious error.
 
-// CHECK: error: recursive functions are not allowed: entry function calls recursive function 'func'
+// CHECK: error: recursive functions are not allowed: export function calls recursive function 'func'
 
 struct S
 {

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/lib_struct_member_unconditional.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/lib_struct_member_unconditional.hlsl
@@ -13,7 +13,7 @@ struct S
   int func() { return func(); }
 };
 
-int main() : OUT
+export int main() : OUT
 {
   S s;
   return s.func();

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/library_hull_recursion.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/library_hull_recursion.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -T lib_6_5 %s | FileCheck %s
 
-// CHECK: error: recursive functions are not allowed: entry function calls recursive function 'recurse2'
+// CHECK: error: recursive functions are not allowed: export function calls recursive function 'recurse2'
 void recurse2(inout float4 f, float a) {
   if (a > 0) {
     recurse2(f, a);
@@ -8,7 +8,7 @@ void recurse2(inout float4 f, float a) {
   f -= abs(f+a);
 }
 
-// CHECK: error: recursive functions are not allowed: entry function calls recursive function 'recurse'
+// CHECK: error: recursive functions are not allowed: export function calls recursive function 'recurse'
 void recurse(inout float4 f, float a)
 {
     if (a > 1) {
@@ -24,7 +24,7 @@ float4 fooey()
   float4 e;
   float4 d;
   d.x = 4;
-  // CHECK: error: recursive functions are not allowed: entry function calls recursive function 'fooey'
+  // CHECK: error: recursive functions are not allowed: export function calls recursive function 'fooey'
   fooey();
   
   return e;

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/library_hull_recursion.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/library_hull_recursion.hlsl
@@ -1,23 +1,5 @@
 // RUN: %dxc -T lib_6_5 %s | FileCheck %s
 
-struct HSPerPatchData
-{
-  float edges[3] : SV_TessFactor;
-  float inside   : SV_InsideTessFactor;
-};
-
-HSPerPatchData HSPerPatchFunc1()
-{
-  HSPerPatchData d;
-
-  d.edges[0] = -5;
-  d.edges[1] = -6;
-  d.edges[2] = -7;
-  d.inside = -8;
-  // CHECK: error: recursive functions are not allowed: patch constant function calls recursive function 'HSPerPatchFunc1'
-  HSPerPatchFunc1();
-  return d;
-}
 
 // no error, because this function isn't exported. 
 // it's reachable from main, but recurse is detected first before recurse2
@@ -36,6 +18,25 @@ void recurse(inout float4 f, float a)
       recurse2(f, a-1);
     }
     f += abs(f+a);
+}
+
+struct HSPerPatchData
+{
+  float edges[3] : SV_TessFactor;
+  float inside   : SV_InsideTessFactor;
+};
+
+HSPerPatchData HSPerPatchFunc1()
+{
+  HSPerPatchData d;
+
+  d.edges[0] = -5;
+  d.edges[1] = -6;
+  d.edges[2] = -7;
+  d.inside = -8;
+  // CHECK: error: recursive functions are not allowed: patch constant function calls recursive function 'HSPerPatchFunc1'
+  HSPerPatchFunc1();
+  return d;
 }
 
 [shader("hull")]

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/patch_constant_func_recursion_in_lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/patch_constant_func_recursion_in_lib.hlsl
@@ -15,7 +15,7 @@ HSPerPatchData fooey()
   d.edges[1] = -6;
   d.edges[2] = -7;
   d.inside = -8;
-  // CHECK: error: recursive functions are not allowed: entry function calls recursive function 'fooey'
+  // CHECK: error: recursive functions are not allowed: export function calls recursive function 'fooey'
   fooey();
   return d;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/patch_constant_func_recursion_in_lib.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/recursion/patch_constant_func_recursion_in_lib.hlsl
@@ -15,7 +15,7 @@ HSPerPatchData fooey()
   d.edges[1] = -6;
   d.edges[2] = -7;
   d.inside = -8;
-  // CHECK: error: recursive functions are not allowed: export function calls recursive function 'fooey'
+  // CHECK: error: recursive functions are not allowed: patch constant function calls recursive function 'fooey'
   fooey();
   return d;
 }

--- a/tools/clang/test/SemaHLSL/recursion/library_6_x_recursion_unexported.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_6_x_recursion_unexported.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -Tlib_6_x -verify %s 
+// functions with unspecified linkage will default to internal, except for when
+// the target library has shader model 6_x.
+// So, we expect an error on unreachable functions
+// that are recursive without export or static keywords. 
+// unreachable_unexported_recurse_external suffices as an example.
+
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'unreachable_unexported_recurse_external'}}
+void unreachable_unexported_recurse_external(inout float4 f, float a) 
+{
+    if (a > 1)
+      unreachable_unexported_recurse_external(f, a-1);
+    f = abs(f+a);
+}

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -Tlib_6_5 -verify %s 
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'recurse'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse'}}
 void recurse(inout float4 f, float a) 
 {
     if (a > 1)

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -Tlib_6_5 -verify %s 
 
 // expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse'}}
-void recurse(inout float4 f, float a) 
+export void recurse(inout float4 f, float a) 
 {
     if (a > 1)
       recurse(f, a-1);

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_2.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_2.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -Tlib_6_5 %s -verify 
 
 // expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse2'}}
-void recurse2(inout float4 f, float a) {
+export void recurse2(inout float4 f, float a) {
   if (a > 0) {
     recurse2(f, a);
   }
@@ -9,7 +9,7 @@ void recurse2(inout float4 f, float a) {
 }
 
 // expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse'}}
-void recurse(inout float4 f, float a)
+export void recurse(inout float4 f, float a)
 {
     if (a > 1) {
       recurse(f, a-1);

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_2.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_2.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -Tlib_6_5 %s -verify 
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'recurse2'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse2'}}
 void recurse2(inout float4 f, float a) {
   if (a > 0) {
     recurse2(f, a);
@@ -8,7 +8,7 @@ void recurse2(inout float4 f, float a) {
   f -= abs(f+a);
 }
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'recurse'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'recurse'}}
 void recurse(inout float4 f, float a)
 {
     if (a > 1) {

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_default_external_in_namespace_or_struct.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_default_external_in_namespace_or_struct.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T lib_6_3 -default-linkage external %s -verify
+
+// This file tests that default-linkage external works, and applies
+// external linkage to decls inside namespaces, structs, or classes
+// It will find such decls, and perform recursion validation on them.
+
+struct S
+{
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'func'}}
+  int func() { return func(); }
+};
+
+namespace something {
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'func2'}}
+  int func2() { return func2(); }
+}
+
+class S2
+{
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'func3'}}
+  int func3() { return func3(); }
+};
+
+export int main() : OUT
+{
+  S s;
+  return s.func();
+}

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
@@ -14,7 +14,7 @@
 // for library shaders, so we expect errors on unreachable functions
 // that are recursive
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'unreachable_unexported_recurse_external'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'unreachable_unexported_recurse_external'}}
 void unreachable_unexported_recurse_external(inout float4 f, float a) 
 {
     if (a > 1)
@@ -29,7 +29,7 @@ static void unreachable_unexported_recurse(inout float4 f, float a)
     f = abs(f+a);
 }
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'unexported_recurse'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'unexported_recurse'}}
 static void unexported_recurse(inout float4 f, float a) 
 {
     if (a > 1)
@@ -37,7 +37,7 @@ static void unexported_recurse(inout float4 f, float a)
     f = abs(f+a);
 }
 
-// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'exported_recurse'}}
+// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'exported_recurse'}}
 export void exported_recurse(inout float4 f, float a) 
 {
     if (a > 1)

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
@@ -1,0 +1,59 @@
+// RUN: %dxc -Tlib_6_5 -verify %s 
+// This file tests several things at once:
+// Firstly, recursive functions with external linkage should be tested
+// and diagnosed for recursion. So, exported_recurse should throw an error
+// since it is recursive. 
+// Secondly, functions with external linkage may not call recursive 
+// functions with internal linkage. exported_recurse_2 calls 
+// unexported_recurse, so we expect an error.
+// Thirdly, unreachable functions with internal linkage should not 
+// be tested for recursion in library shaders. 
+// In this case, unreachable_unexported_recurse is an example, and we 
+// do not expect any compilation errors for that function.
+// Finally, functions with unspecified linkage will default to external
+// for library shaders, so we expect errors on unreachable functions
+// that are recursive
+
+// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'unreachable_unexported_recurse_external'}}
+void unreachable_unexported_recurse_external(inout float4 f, float a) 
+{
+    if (a > 1)
+      unreachable_unexported_recurse_external(f, a-1);
+    f = abs(f+a);
+}
+
+static void unreachable_unexported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      unreachable_unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'unexported_recurse'}}
+static void unexported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+// expected-error@+1{{recursive functions are not allowed: entry function calls recursive function 'exported_recurse'}}
+export void exported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      exported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+export void exported_recurse_2(inout float4 f, float a) 
+{
+    if (a > 1)
+      unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+float4 main(float a : A, float b:B) : SV_TARGET
+{
+  float4 f = b;
+  return f;
+}

--- a/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_recursion_unexported.hlsl
@@ -10,11 +10,11 @@
 // be tested for recursion in library shaders. 
 // In this case, unreachable_unexported_recurse is an example, and we 
 // do not expect any compilation errors for that function.
-// Finally, functions with unspecified linkage will default to external
-// for library shaders, so we expect errors on unreachable functions
-// that are recursive
+// Finally, functions with unspecified linkage will default to internal
+// for library shaders, so we expect no errors on unreachable functions
+// that are recursive without export or static keywords. 
+// unreachable_unexported_recurse_external suffices as an example.
 
-// expected-error@+1{{recursive functions are not allowed: export function calls recursive function 'unreachable_unexported_recurse_external'}}
 void unreachable_unexported_recurse_external(inout float4 f, float a) 
 {
     if (a > 1)

--- a/tools/clang/test/SemaHLSL/recursion/non_library_recursion_unexported.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/non_library_recursion_unexported.hlsl
@@ -1,0 +1,47 @@
+// RUN: %dxc -T ps_6_0 -verify %s 
+// This file tests that functions with unspecified linkage will default to 
+// internal for non-library shaders, so we expect no errors on unreachable 
+// functions that are recursive. Even `export` on non-library shaders will
+// not emit diagnostics on unreachable recursive functions.
+
+// expected-no-diagnostics
+void unreachable_unexported_recurse_external(inout float4 f, float a) 
+{
+    if (a > 1)
+      unreachable_unexported_recurse_external(f, a-1);
+    f = abs(f+a);
+}
+
+static void unreachable_unexported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      unreachable_unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+static void unexported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+export void exported_recurse(inout float4 f, float a) 
+{
+    if (a > 1)
+      exported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+export void exported_recurse_2(inout float4 f, float a) 
+{
+    if (a > 1)
+      unexported_recurse(f, a-1);
+    f = abs(f+a);
+}
+
+float4 main(float a : A, float b:B) : SV_TARGET
+{
+  float4 f = b;
+  return f;
+}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1561,16 +1561,21 @@ public:
 
     // processed export names from -exports option:
     compiler.getCodeGenOpts().HLSLLibraryExports = Opts.Exports;
+    compiler.getLangOpts().HLSLLibraryExports = Opts.Exports;
 
     // only export shader functions for library
     compiler.getCodeGenOpts().ExportShadersOnly = Opts.ExportShadersOnly;
+    compiler.getLangOpts().ExportShadersOnly = Opts.ExportShadersOnly;
 
     if (Opts.DefaultLinkage.empty()) {
       compiler.getCodeGenOpts().DefaultLinkage = DXIL::DefaultLinkage::Default;
+      compiler.getLangOpts().DefaultLinkage = DXIL::DefaultLinkage::Default;
     } else if (Opts.DefaultLinkage.equals_lower("internal")) {
       compiler.getCodeGenOpts().DefaultLinkage = DXIL::DefaultLinkage::Internal;
+      compiler.getLangOpts().DefaultLinkage = DXIL::DefaultLinkage::Internal;
     } else if (Opts.DefaultLinkage.equals_lower("external")) {
       compiler.getCodeGenOpts().DefaultLinkage = DXIL::DefaultLinkage::External;
+      compiler.getLangOpts().DefaultLinkage = DXIL::DefaultLinkage::External;
     }
   }
 

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1561,7 +1561,6 @@ public:
 
     // processed export names from -exports option:
     compiler.getCodeGenOpts().HLSLLibraryExports = Opts.Exports;
-    compiler.getLangOpts().HLSLLibraryExports = Opts.Exports;
 
     // only export shader functions for library
     compiler.getCodeGenOpts().ExportShadersOnly = Opts.ExportShadersOnly;


### PR DESCRIPTION
Previously, diagnosing the translation unit would loop through every function declaration found in a library shader. This behavior is undesired, as there are some functions that are not intended to be exported, and thus shouldn't emit diagnostics (maybe the library compilation target is for a shader model that wouldn't mesh well with some other function declarations in the translation unit). This PR adjusts the diagnostic emission code so that only exported functions are diagnosed.
Fixes #5857 