### PR TITLE
[CI] add workflow to apply clang-format diff

### DIFF
--- a/.github/workflows/clang-format-diff-apply.yml
+++ b/.github/workflows/clang-format-diff-apply.yml
@@ -1,0 +1,61 @@
+name: "Apply code format"
+on:
+  issue_comment:
+    types: edited
+
+permissions:
+  contents: write
+
+jobs:
+  apply_diff:
+    if: ${{ startsWith(github.event.comment.body, '@apply-format<!--LLVM CODE FORMAT COMMENT:') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        id: get-pr
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            } 
+      - name: Fetch LLVM sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+
+      - name: Setup Python env
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'utils/git/requirements_formatting.txt'
+
+      - name: Install python dependencies
+        run: pip install -r utils/git/requirements_formatting.txt
+
+      - name: Apply code diff
+        env:
+          GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: |
+          python utils/git/code-format-diff-apply.py \
+            --token ${{ secrets.GITHUB_TOKEN }} \
+            --issue-number $GITHUB_PR_NUMBER \
+            --comment-id $COMMENT_ID
+      - name: Commit & Push changes
+        uses: actions-js/push@master
+        with:
+          branch: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/utils/git/code-format-diff-apply.py
+++ b/utils/git/code-format-diff-apply.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#
+# ====- code-format-diff-apply, apply diff from comment --*- python -*-------==#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# ==-------------------------------------------------------------------------==#
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from functools import cached_property
+
+import github
+from github import IssueComment, PullRequest
+
+LF = '\n'
+CRLF = '\r\n'
+CR = '\r'
+
+diff_pat = re.compile(r"``````````diff(?P<DIFF>.+)``````````", re.DOTALL)
+
+def get_diff_from_comment(comment: IssueComment.IssueComment) -> str:
+    m = re.search(diff_pat, comment.body)
+    if m is None:
+        raise Exception(f"Could not find diff in comment {comment.id}")
+    diff = m.group("DIFF")
+    # force to linux line endings
+    diff = diff.replace(CRLF, LF).replace(CR, LF)
+    return diff
+
+def run_cmd(cmd: [str]) -> None:
+    print(f"Running: {' '.join(cmd)}")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(proc.stdout)
+        print(proc.stderr)
+        raise Exception(f"Failed to run {' '.join(cmd)}")
+
+def apply_patches(args: argparse.Namespace) -> None:
+    repo = github.Github(args.token).get_repo(args.repo)
+    pr = repo.get_issue(args.issue_number).as_pull_request()
+
+    comment = pr.get_issue_comment(args.comment_id)
+    if comment is None:
+        raise Exception(f"Comment {args.comment_id} does not exist")
+
+    # get the diff from the comment
+    diff = get_diff_from_comment(comment)
+
+    # write diff to temporary file and apply
+    with tempfile.NamedTemporaryFile() as tmp:
+        tmp.write(diff.encode("utf-8"))
+        tmp.flush()
+
+        # run git apply tmp.name
+        apply_cmd = [
+            "git",
+            "apply",
+            tmp.name
+        ]
+        run_cmd(apply_cmd)
+
+    # run git add .
+    add_cmd = [
+        "git",
+        "add",
+        "."
+    ]
+    run_cmd(add_cmd)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--token", type=str, required=True, help="GitHub authentiation token"
+    )
+    parser.add_argument(
+        "--repo",
+        type=str,
+        default=os.getenv("GITHUB_REPOSITORY", "llvm/llvm-project"),
+        help="The GitHub repository that we are working with in the form of <owner>/<repo> (e.g. llvm/llvm-project)",
+    )
+    parser.add_argument("--issue-number", type=int, required=True)
+    parser.add_argument("--comment-id", type=int, required=True)
+
+    args = parser.parse_args()
+
+    apply_patches(args)


### PR DESCRIPTION
When hit clang-format error in a pull request, edit the comment with diff.  
Add @apply-format at the beginning of the comment and Update comment.  
 

New added "Apply code format" workflow will be triggered.  
It will checkout the code from compare branch of the pull request, apply the diff,  
then commit and push it to the compare branch to fix the format issue.  
  
The process should be get clang-format diff comment first.  
Then review the diff in the comment.
If the diff looks good, edit and add @apply-format to apply the diff.