### PR TITLE
Turn off clang formatting for RDAT_LibraryTypes.inl and RDAT_SubobjectTypes.inl

### DIFF
--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -12,12 +12,12 @@
 #ifdef DEF_RDAT_ENUMS
 
 RDAT_ENUM_START(DxilResourceFlag, uint32_t)
-RDAT_ENUM_VALUE(None, 0)
-RDAT_ENUM_VALUE(UAVGloballyCoherent, 1 << 0)
-RDAT_ENUM_VALUE(UAVCounter, 1 << 1)
-RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
-RDAT_ENUM_VALUE(DynamicIndexing, 1 << 3)
-RDAT_ENUM_VALUE(Atomics64Use, 1 << 4)
+  RDAT_ENUM_VALUE(None,                     0)
+  RDAT_ENUM_VALUE(UAVGloballyCoherent,      1 << 0)
+  RDAT_ENUM_VALUE(UAVCounter,               1 << 1)
+  RDAT_ENUM_VALUE(UAVRasterizerOrderedView, 1 << 2)
+  RDAT_ENUM_VALUE(DynamicIndexing,          1 << 3)
+  RDAT_ENUM_VALUE(Atomics64Use,             1 << 4)
 RDAT_ENUM_END()
 
 #endif // DEF_RDAT_ENUMS
@@ -32,72 +32,66 @@ RDAT_ENUM_END()
 // making sure this definition is updated as well.
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceClass, uint32_t)
-RDAT_ENUM_VALUE_NODEF(SRV)
-RDAT_ENUM_VALUE_NODEF(UAV)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(SRV)
+  RDAT_ENUM_VALUE_NODEF(UAV)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceClass::Invalid == 4, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ResourceKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Invalid)
-RDAT_ENUM_VALUE_NODEF(Texture1D)
-RDAT_ENUM_VALUE_NODEF(Texture2D)
-RDAT_ENUM_VALUE_NODEF(Texture2DMS)
-RDAT_ENUM_VALUE_NODEF(Texture3D)
-RDAT_ENUM_VALUE_NODEF(TextureCube)
-RDAT_ENUM_VALUE_NODEF(Texture1DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DArray)
-RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
-RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
-RDAT_ENUM_VALUE_NODEF(TypedBuffer)
-RDAT_ENUM_VALUE_NODEF(RawBuffer)
-RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
-RDAT_ENUM_VALUE_NODEF(CBuffer)
-RDAT_ENUM_VALUE_NODEF(Sampler)
-RDAT_ENUM_VALUE_NODEF(TBuffer)
-RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
-RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
-RDAT_ENUM_VALUE_NODEF(NumEntries)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Texture1D)
+  RDAT_ENUM_VALUE_NODEF(Texture2D)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMS)
+  RDAT_ENUM_VALUE_NODEF(Texture3D)
+  RDAT_ENUM_VALUE_NODEF(TextureCube)
+  RDAT_ENUM_VALUE_NODEF(Texture1DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DArray)
+  RDAT_ENUM_VALUE_NODEF(Texture2DMSArray)
+  RDAT_ENUM_VALUE_NODEF(TextureCubeArray)
+  RDAT_ENUM_VALUE_NODEF(TypedBuffer)
+  RDAT_ENUM_VALUE_NODEF(RawBuffer)
+  RDAT_ENUM_VALUE_NODEF(StructuredBuffer)
+  RDAT_ENUM_VALUE_NODEF(CBuffer)
+  RDAT_ENUM_VALUE_NODEF(Sampler)
+  RDAT_ENUM_VALUE_NODEF(TBuffer)
+  RDAT_ENUM_VALUE_NODEF(RTAccelerationStructure)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2D)
+  RDAT_ENUM_VALUE_NODEF(FeedbackTexture2DArray)
+  RDAT_ENUM_VALUE_NODEF(NumEntries)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ResourceKind::NumEntries == 19, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::ShaderKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Pixel)
-RDAT_ENUM_VALUE_NODEF(Vertex)
-RDAT_ENUM_VALUE_NODEF(Geometry)
-RDAT_ENUM_VALUE_NODEF(Hull)
-RDAT_ENUM_VALUE_NODEF(Domain)
-RDAT_ENUM_VALUE_NODEF(Compute)
-RDAT_ENUM_VALUE_NODEF(Library)
-RDAT_ENUM_VALUE_NODEF(RayGeneration)
-RDAT_ENUM_VALUE_NODEF(Intersection)
-RDAT_ENUM_VALUE_NODEF(AnyHit)
-RDAT_ENUM_VALUE_NODEF(ClosestHit)
-RDAT_ENUM_VALUE_NODEF(Miss)
-RDAT_ENUM_VALUE_NODEF(Callable)
-RDAT_ENUM_VALUE_NODEF(Mesh)
-RDAT_ENUM_VALUE_NODEF(Amplification)
-RDAT_ENUM_VALUE_NODEF(Invalid)
+  RDAT_ENUM_VALUE_NODEF(Pixel)
+  RDAT_ENUM_VALUE_NODEF(Vertex)
+  RDAT_ENUM_VALUE_NODEF(Geometry)
+  RDAT_ENUM_VALUE_NODEF(Hull)
+  RDAT_ENUM_VALUE_NODEF(Domain)
+  RDAT_ENUM_VALUE_NODEF(Compute)
+  RDAT_ENUM_VALUE_NODEF(Library)
+  RDAT_ENUM_VALUE_NODEF(RayGeneration)
+  RDAT_ENUM_VALUE_NODEF(Intersection)
+  RDAT_ENUM_VALUE_NODEF(AnyHit)
+  RDAT_ENUM_VALUE_NODEF(ClosestHit)
+  RDAT_ENUM_VALUE_NODEF(Miss)
+  RDAT_ENUM_VALUE_NODEF(Callable)
+  RDAT_ENUM_VALUE_NODEF(Mesh)
+  RDAT_ENUM_VALUE_NODEF(Amplification)
+  RDAT_ENUM_VALUE_NODEF(Invalid)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 15,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::ShaderKind::Invalid == 15, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::SemanticKind, uint32_t)
-// clang-format off
-  // Python lines need to be not formatted.
   /* <py::lines('SemanticKind-ENUM')>hctdb_instrhelp.get_rdat_enum_decl("SemanticKind", nodef=True)</py>*/
-  // clang-format onm
   // SemanticKind-ENUM:BEGIN
   RDAT_ENUM_VALUE_NODEF(Arbitrary)
   RDAT_ENUM_VALUE_NODEF(VertexID)

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -9,6 +9,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
 #ifdef DEF_RDAT_ENUMS
 
 RDAT_ENUM_START(DxilResourceFlag, uint32_t)

--- a/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
@@ -9,6 +9,10 @@
 //                                                                           //
 ///////////////////////////////////////////////////////////////////////////////
 
+// clang-format off
+// Macro indentation makes this file easier to read, but clang-format flattens
+// everything.  Turn off clang-format for this file.
+
 #ifdef DEF_RDAT_ENUMS
 
 // Nothing yet

--- a/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_SubobjectTypes.inl
@@ -18,53 +18,49 @@
 #ifdef DEF_DXIL_ENUMS
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::SubobjectKind, uint32_t)
-RDAT_ENUM_VALUE_NODEF(StateObjectConfig)
-RDAT_ENUM_VALUE_NODEF(GlobalRootSignature)
-RDAT_ENUM_VALUE_NODEF(LocalRootSignature)
-RDAT_ENUM_VALUE_NODEF(SubobjectToExportsAssociation)
-RDAT_ENUM_VALUE_NODEF(RaytracingShaderConfig)
-RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig)
-RDAT_ENUM_VALUE_NODEF(HitGroup)
-RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig1)
-// No need to define this here
-// RDAT_ENUM_VALUE_NODEF(NumKinds)
+  RDAT_ENUM_VALUE_NODEF(StateObjectConfig)
+  RDAT_ENUM_VALUE_NODEF(GlobalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(LocalRootSignature)
+  RDAT_ENUM_VALUE_NODEF(SubobjectToExportsAssociation)
+  RDAT_ENUM_VALUE_NODEF(RaytracingShaderConfig)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig)
+  RDAT_ENUM_VALUE_NODEF(HitGroup)
+  RDAT_ENUM_VALUE_NODEF(RaytracingPipelineConfig1)
+  // No need to define this here
+  //RDAT_ENUM_VALUE_NODEF(NumKinds)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::SubobjectKind::NumKinds == 13,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::SubobjectKind::NumKinds == 13, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::StateObjectFlags, uint32_t)
-RDAT_ENUM_VALUE_NODEF(AllowLocalDependenciesOnExternalDefinitions)
-RDAT_ENUM_VALUE_NODEF(AllowExternalDependenciesOnLocalDefinitions)
-RDAT_ENUM_VALUE_NODEF(AllowStateObjectAdditions)
-// No need to define these masks here
-// RDAT_ENUM_VALUE_NODEF(ValidMask_1_4)
-// RDAT_ENUM_VALUE_NODEF(ValidMask)
+  RDAT_ENUM_VALUE_NODEF(AllowLocalDependenciesOnExternalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowExternalDependenciesOnLocalDefinitions)
+  RDAT_ENUM_VALUE_NODEF(AllowStateObjectAdditions)
+  // No need to define these masks here
+  //RDAT_ENUM_VALUE_NODEF(ValidMask_1_4)
+  //RDAT_ENUM_VALUE_NODEF(ValidMask)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::StateObjectFlags::ValidMask == 0x7,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::StateObjectFlags::ValidMask == 0x7, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::HitGroupType, uint32_t)
-RDAT_ENUM_VALUE_NODEF(Triangle)
-RDAT_ENUM_VALUE_NODEF(ProceduralPrimitive)
+  RDAT_ENUM_VALUE_NODEF(Triangle)
+  RDAT_ENUM_VALUE_NODEF(ProceduralPrimitive)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::HitGroupType::LastEntry == 2,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::HitGroupType::LastEntry == 2, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
 RDAT_DXIL_ENUM_START(hlsl::DXIL::RaytracingPipelineFlags, uint32_t)
-RDAT_ENUM_VALUE_NODEF(None)
-RDAT_ENUM_VALUE_NODEF(SkipTriangles)
-RDAT_ENUM_VALUE_NODEF(SkipProceduralPrimitives)
-// No need to define mask here
-// RDAT_ENUM_VALUE_NODEF(ValidMask)
+  RDAT_ENUM_VALUE_NODEF(None)
+  RDAT_ENUM_VALUE_NODEF(SkipTriangles)
+  RDAT_ENUM_VALUE_NODEF(SkipProceduralPrimitives)
+  // No need to define mask here
+  //RDAT_ENUM_VALUE_NODEF(ValidMask)
 #if DEF_RDAT_ENUMS == DEF_RDAT_DUMP_IMPL
-static_assert((unsigned)hlsl::DXIL::RaytracingPipelineFlags::ValidMask == 0x300,
-              "otherwise, RDAT_DXIL_ENUM definition needs updating");
+  static_assert((unsigned)hlsl::DXIL::RaytracingPipelineFlags::ValidMask == 0x300, "otherwise, RDAT_DXIL_ENUM definition needs updating");
 #endif
 RDAT_ENUM_END()
 
@@ -74,96 +70,79 @@ RDAT_ENUM_END()
 
 #define RECORD_TYPE StateObjectConfig_t
 RDAT_STRUCT(StateObjectConfig_t)
-RDAT_FLAGS(uint32_t, hlsl::DXIL::StateObjectFlags, Flags)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::StateObjectFlags, Flags)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RootSignature_t
 RDAT_STRUCT(RootSignature_t)
-RDAT_BYTES(Data)
+  RDAT_BYTES(Data)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE SubobjectToExportsAssociation_t
 RDAT_STRUCT(SubobjectToExportsAssociation_t)
-RDAT_STRING(Subobject)
-RDAT_STRING_ARRAY_REF(Exports)
+  RDAT_STRING(Subobject)
+  RDAT_STRING_ARRAY_REF(Exports)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingShaderConfig_t
 RDAT_STRUCT(RaytracingShaderConfig_t)
-RDAT_VALUE(uint32_t, MaxPayloadSizeInBytes)
-RDAT_VALUE(uint32_t, MaxAttributeSizeInBytes)
+  RDAT_VALUE(uint32_t, MaxPayloadSizeInBytes)
+  RDAT_VALUE(uint32_t, MaxAttributeSizeInBytes)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingPipelineConfig_t
 RDAT_STRUCT(RaytracingPipelineConfig_t)
-RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE HitGroup_t
 RDAT_STRUCT(HitGroup_t)
-RDAT_ENUM(uint32_t, hlsl::DXIL::HitGroupType, Type)
-RDAT_STRING(AnyHit)
-RDAT_STRING(ClosestHit)
-RDAT_STRING(Intersection)
+  RDAT_ENUM(uint32_t, hlsl::DXIL::HitGroupType, Type)
+  RDAT_STRING(AnyHit)
+  RDAT_STRING(ClosestHit)
+  RDAT_STRING(Intersection)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RaytracingPipelineConfig1_t
 RDAT_STRUCT(RaytracingPipelineConfig1_t)
-RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
-RDAT_FLAGS(uint32_t, hlsl::DXIL::RaytracingPipelineFlags, Flags)
+  RDAT_VALUE(uint32_t, MaxTraceRecursionDepth)
+  RDAT_FLAGS(uint32_t, hlsl::DXIL::RaytracingPipelineFlags, Flags)
 RDAT_STRUCT_END()
 #undef RECORD_TYPE
 
 #define RECORD_TYPE RuntimeDataSubobjectInfo
 RDAT_STRUCT_TABLE(RuntimeDataSubobjectInfo, SubobjectTable)
-RDAT_ENUM(uint32_t, hlsl::DXIL::SubobjectKind, Kind)
-RDAT_STRING(Name)
-RDAT_UNION()
-RDAT_UNION_IF(StateObjectConfig,
-              ((uint32_t)pRecord->Kind ==
-               (uint32_t)hlsl::DXIL::SubobjectKind::StateObjectConfig))
-RDAT_RECORD_VALUE(StateObjectConfig_t, StateObjectConfig)
-RDAT_UNION_ELIF(RootSignature,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::GlobalRootSignature) ||
-                    ((uint32_t)pRecord->Kind ==
-                     (uint32_t)hlsl::DXIL::SubobjectKind::LocalRootSignature))
-RDAT_RECORD_VALUE(RootSignature_t, RootSignature)
-RDAT_UNION_ELIF(
-    SubobjectToExportsAssociation,
-    ((uint32_t)pRecord->Kind ==
-     (uint32_t)hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation))
-RDAT_RECORD_VALUE(SubobjectToExportsAssociation_t,
-                  SubobjectToExportsAssociation)
-RDAT_UNION_ELIF(RaytracingShaderConfig,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingShaderConfig))
-RDAT_RECORD_VALUE(RaytracingShaderConfig_t, RaytracingShaderConfig)
-RDAT_UNION_ELIF(RaytracingPipelineConfig,
-                ((uint32_t)pRecord->Kind ==
-                 (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig))
-RDAT_RECORD_VALUE(RaytracingPipelineConfig_t, RaytracingPipelineConfig)
-RDAT_UNION_ELIF(HitGroup, ((uint32_t)pRecord->Kind ==
-                           (uint32_t)hlsl::DXIL::SubobjectKind::HitGroup))
-RDAT_RECORD_VALUE(HitGroup_t, HitGroup)
-RDAT_UNION_ELIF(
-    RaytracingPipelineConfig1,
-    ((uint32_t)pRecord->Kind ==
-     (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig1))
-RDAT_RECORD_VALUE(RaytracingPipelineConfig1_t, RaytracingPipelineConfig1)
-RDAT_UNION_ENDIF()
-RDAT_UNION_END()
+  RDAT_ENUM(uint32_t, hlsl::DXIL::SubobjectKind, Kind)
+  RDAT_STRING(Name)
+  RDAT_UNION()
+    RDAT_UNION_IF(StateObjectConfig, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::StateObjectConfig))
+      RDAT_RECORD_VALUE(StateObjectConfig_t, StateObjectConfig)
+    RDAT_UNION_ELIF(RootSignature,
+                    ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::GlobalRootSignature) ||
+                    ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::LocalRootSignature))
+      RDAT_RECORD_VALUE(RootSignature_t, RootSignature)
+    RDAT_UNION_ELIF(SubobjectToExportsAssociation, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::SubobjectToExportsAssociation))
+      RDAT_RECORD_VALUE(SubobjectToExportsAssociation_t, SubobjectToExportsAssociation)
+    RDAT_UNION_ELIF(RaytracingShaderConfig, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingShaderConfig))
+      RDAT_RECORD_VALUE(RaytracingShaderConfig_t, RaytracingShaderConfig)
+    RDAT_UNION_ELIF(RaytracingPipelineConfig, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig_t, RaytracingPipelineConfig)
+    RDAT_UNION_ELIF(HitGroup, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::HitGroup))
+      RDAT_RECORD_VALUE(HitGroup_t, HitGroup)
+    RDAT_UNION_ELIF(RaytracingPipelineConfig1, ((uint32_t)pRecord->Kind == (uint32_t)hlsl::DXIL::SubobjectKind::RaytracingPipelineConfig1))
+      RDAT_RECORD_VALUE(RaytracingPipelineConfig1_t, RaytracingPipelineConfig1)
+    RDAT_UNION_ENDIF()
+  RDAT_UNION_END()
 
-// Note: this is how one could inject custom code into one of the definition
-// modes:
+// Note: this is how one could inject custom code into one of the definition modes:
 #if DEF_RDAT_TYPES == DEF_RDAT_READER
-// Add custom code here that only gets added to the reader class definition
+  // Add custom code here that only gets added to the reader class definition
 #endif
 
 RDAT_STRUCT_END()


### PR DESCRIPTION
Turn off clang formatting for `RDAT_LibraryTypes.inl` and `RDAT_SubobjectTypes.inl`. Macro indentation makes these files easier to read.

This PR was created in 2 steps:
1. `RDAT_LibraryTypes.inl` and `RDAT_SubobjectTypes.inl` were reverted to the version `64348c7e~1` The commit 64348c7eec9d4c966797c7ba73da2f499d0242e8 is the first that started preparing the code base for clang formatting. Except for that there were no functional commits done to these files since then.
2. `//clang-format off` and a comment with explanation was added to the top of these files