### PR TITLE
Fix NodeDispatchGrid diagnostic check

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -13026,7 +13026,7 @@ void Sema::DiagnoseGloballyCoherentMismatch(const Expr *SrcExpr,
 
 void ValidateDispatchGridValues(DiagnosticsEngine &Diags,
                                 const AttributeList &A, Attr *declAttr) {
-  unsigned x = 1, y = 1, z = 1;
+  uint64_t x = 1, y = 1, z = 1;
   if (HLSLNodeDispatchGridAttr *pA =
           dyn_cast<HLSLNodeDispatchGridAttr>(declAttr)) {
     x = pA->getX();

--- a/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
+++ b/tools/clang/test/HLSL/workgraph/dispatchgrid_diags.hlsl
@@ -60,6 +60,20 @@ void node06()
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]
+[NodeDispatchGrid(65535, 65535, 65535)] // expected-error {{'NodeDispatchGrid' X * Y * Z product may not exceed 16,777,215 (2^24-1)}}
+[NumThreads(32, 1, 1)]
+void node07()
+{ }
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(32768, 512, 512)] // expected-error {{'NodeDispatchGrid' X * Y * Z product may not exceed 16,777,215 (2^24-1)}}
+[NumThreads(32, 1, 1)]
+void node08()
+{ }
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(65535, 1, 1)]
 [NumThreads(32, 1, 1)]
 void node11(DispatchNodeInputRecord<MyStruct> input)


### PR DESCRIPTION
The product of the components of the NodeDispatchGrid or NodeMaxDispatchGrid attributes may not exceed 16,777,215 (2^24-1) but this was not diagnosed correctly in cases where the product overflowed 32 bits.
Fixed by increasing the width of the calculation of the product to 64 bits.

Fixes #5988