### PR TITLE
[Build] remove VS_STARTUP_PROJECT to avoid require cmake3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,6 @@ endif()
 
 project(LLVM)
 
-# This requires a more recent version than CMake 3.4 but is a noop in prior versions. # HLSL Change
-set(VS_STARTUP_PROJECT "dndxc" CACHE STRING "VS startup project in solution")         # HLSL Change
-
 # The following only works with the Ninja generator in CMake >= 3.0.
 set(LLVM_PARALLEL_COMPILE_JOBS "" CACHE STRING
   "Define the maximum number of concurrent compilation jobs.")


### PR DESCRIPTION
Since we don't use dndxc as startup project in most cases, just remove the VS_STARTUP_PROJECT so not need cmake3.4 to build on windows.