### PR TITLE
[SM6.8] Diagnostic for output records with SV_DispatchGrid

### DIFF
--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -460,7 +460,6 @@ bool IsHLSLNodeInputType(clang::QualType type);
 bool IsHLSLDynamicResourceType(clang::QualType type);
 bool IsHLSLDynamicSamplerType(clang::QualType type);
 bool IsHLSLNodeType(clang::QualType type);
-clang::CXXRecordDecl *GetHLSLNodeRecordDecl(clang::QualType type);
 
 bool IsHLSLObjectWithImplicitMemberAccess(clang::QualType type);
 bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);

--- a/tools/clang/include/clang/AST/HlslTypes.h
+++ b/tools/clang/include/clang/AST/HlslTypes.h
@@ -460,6 +460,8 @@ bool IsHLSLNodeInputType(clang::QualType type);
 bool IsHLSLDynamicResourceType(clang::QualType type);
 bool IsHLSLDynamicSamplerType(clang::QualType type);
 bool IsHLSLNodeType(clang::QualType type);
+clang::CXXRecordDecl *GetHLSLNodeRecordDecl(clang::QualType type);
+
 bool IsHLSLObjectWithImplicitMemberAccess(clang::QualType type);
 bool IsHLSLObjectWithImplicitROMemberAccess(clang::QualType type);
 bool IsHLSLRWNodeInputRecordType(clang::QualType type);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -975,6 +975,26 @@ QualType GetHLSLResourceTemplateParamType(QualType type) {
 QualType GetHLSLInputPatchElementType(QualType type) {
   return GetHLSLResourceTemplateParamType(type);
 }
+
+CXXRecordDecl *GetHLSLNodeRecordDecl(clang::QualType type) {
+  type = type.getCanonicalType();
+  const RecordType *RT = cast<RecordType>(type);
+  const ClassTemplateSpecializationDecl *templateDecl =
+      dyn_cast<ClassTemplateSpecializationDecl>(RT->getAsCXXRecordDecl());
+  if (!templateDecl)
+    return nullptr;
+  const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
+  DXASSERT_NOMSG(argList.size() >= 1);
+  QualType TemplateParamTy = argList[0].getAsType();
+  if (const RecordType *NodeStructType =
+          TemplateParamTy->getAsStructureType()) {
+    if (CXXRecordDecl *NodeStructDecl =
+            dyn_cast<CXXRecordDecl>(NodeStructType->getDecl()))
+      return NodeStructDecl;
+  }
+  return nullptr;
+}
+
 unsigned GetHLSLInputPatchCount(QualType type) {
   type = type.getCanonicalType();
   const RecordType *RT = cast<RecordType>(type);

--- a/tools/clang/lib/AST/HlslTypes.cpp
+++ b/tools/clang/lib/AST/HlslTypes.cpp
@@ -976,25 +976,6 @@ QualType GetHLSLInputPatchElementType(QualType type) {
   return GetHLSLResourceTemplateParamType(type);
 }
 
-CXXRecordDecl *GetHLSLNodeRecordDecl(clang::QualType type) {
-  type = type.getCanonicalType();
-  const RecordType *RT = cast<RecordType>(type);
-  const ClassTemplateSpecializationDecl *templateDecl =
-      dyn_cast<ClassTemplateSpecializationDecl>(RT->getAsCXXRecordDecl());
-  if (!templateDecl)
-    return nullptr;
-  const TemplateArgumentList &argList = templateDecl->getTemplateArgs();
-  DXASSERT_NOMSG(argList.size() >= 1);
-  QualType TemplateParamTy = argList[0].getAsType();
-  if (const RecordType *NodeStructType =
-          TemplateParamTy->getAsStructureType()) {
-    if (CXXRecordDecl *NodeStructDecl =
-            dyn_cast<CXXRecordDecl>(NodeStructType->getDecl()))
-      return NodeStructDecl;
-  }
-  return nullptr;
-}
-
 unsigned GetHLSLInputPatchCount(QualType type) {
   type = type.getCanonicalType();
   const RecordType *RT = cast<RecordType>(type);

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15683,11 +15683,10 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
             auto &TemplateArgs = templateDecl->getTemplateArgs();
             DXASSERT_NOMSG(TemplateArgs.size() >= 1);
             QualType Arg0Type = TemplateArgs.get(0).getAsType();
-            const RecordType *NodeStructType = Arg0Type->getAsStructureType();
-            if (nullptr != NodeStructType) {
-              CXXRecordDecl *NodeStructDecl =
-                  dyn_cast<CXXRecordDecl>(NodeStructType->getDecl());
-              if (nullptr != NodeStructDecl) {
+            if (const RecordType *NodeStructType =
+                    Arg0Type->getAsStructureType()) {
+              if (CXXRecordDecl *NodeStructDecl =
+                      dyn_cast<CXXRecordDecl>(NodeStructType->getDecl())) {
                 bool OutputFound = false;
                 // Make sure there is exactly one SV_DispatchGrid semantics
                 // and it has correct type.

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -395,8 +395,9 @@ enum ArBasicKind {
 #define IS_BPROP_ENUM(_Props) (((_Props)&BPROP_ENUM) != 0)
 
 #define IS_BPROP_WAVE_MATRIX_INPUT(_Props)                                     \
-  (((_Props)&BPROP_WAVE_MATRIX_INPUT) != 0)
-#define IS_BPROP_WAVE_MATRIX_ACC(_Props) (((_Props)&BPROP_WAVE_MATRIX_ACC) != 0)
+  (((_Props) & BPROP_WAVE_MATRIX_INPUT) != 0)
+#define IS_BPROP_WAVE_MATRIX_ACC(_Props)                                       \
+  (((_Props) & BPROP_WAVE_MATRIX_ACC) != 0)
 
 const UINT g_uBasicKindProps[] = {
     BPROP_PRIMITIVE | BPROP_BOOLEAN | BPROP_INTEGER | BPROP_NUMERIC |

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid.hlsl
@@ -240,3 +240,58 @@ struct Record18 {
 [NodeMaxDispatchGrid(32, 16, 1)]
 [NumThreads(32, 1, 1)]
 void node18(DispatchNodeInputRecord<Record18> input) {}
+
+template<typename T>
+struct OutputRecord {
+// expected-error@+16{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
+// expected-error@+15{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<float, 3>'}}
+// expected-error@+14{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int'}}
+// expected-error@+13{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int, 3>'}}
+// expected-error@+12{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<unsigned int, 4>'}}
+// expected-error@+11{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'unsigned int [4]'}}
+// expected-error@+10{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
+// expected-error@+9{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<half, 3>'}}
+// expected-error@+8{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t'}}
+// expected-error@+7{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 3>'}}
+// expected-error@+6{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<uint16_t, 4>'}}
+// expected-error@+5{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint16_t [4]'}}
+// expected-error@+4{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 4>'}}
+// expected-error@+3{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'matrix<int16_t, 2, 2>'}}
+// expected-error@+2{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<int>'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<float>'}}
+  T grid : SV_DispatchGrid;
+  float data;
+};
+
+#define OUTPUT_NODE_ENTRY(T,N) \
+[Shader("node")] \
+[NodeLaunch("broadcasting")] \
+[NodeDispatchGrid(1,1,1)] \
+[NumThreads(32, 1, 1)] \
+void node_output_N(NodeOutput<OutputRecord< T > > output) {}
+
+
+OUTPUT_NODE_ENTRY(float, 0);
+OUTPUT_NODE_ENTRY(float3, 1);
+OUTPUT_NODE_ENTRY(int, 2);
+OUTPUT_NODE_ENTRY(int3, 3);
+OUTPUT_NODE_ENTRY(uint4, 4);
+OUTPUT_NODE_ENTRY(uint[4], 5);
+OUTPUT_NODE_ENTRY(half, 6);
+OUTPUT_NODE_ENTRY(half3, 7);
+OUTPUT_NODE_ENTRY(int16_t, 8);
+OUTPUT_NODE_ENTRY(int16_t3, 9);
+OUTPUT_NODE_ENTRY(uint16_t4, 10);
+OUTPUT_NODE_ENTRY(uint16_t[4], 11);
+
+OUTPUT_NODE_ENTRY(int16_t4, 12);
+OUTPUT_NODE_ENTRY(int16_t2x2, 13);
+OUTPUT_NODE_ENTRY(uint16_t3 , 14);
+OUTPUT_NODE_ENTRY(uint16_t[3] , 15);
+
+template<typename T>
+struct S {
+  T a;
+};
+OUTPUT_NODE_ENTRY(S<int> , 16);
+OUTPUT_NODE_ENTRY(S<float> , 17);

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid_type_nodeinput.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid_type_nodeinput.hlsl
@@ -6,7 +6,7 @@ struct Record1 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -19,7 +19,7 @@ struct Record2 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -33,7 +33,7 @@ struct Record3 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -47,7 +47,7 @@ struct Record4 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -60,7 +60,7 @@ struct Record5 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -76,7 +76,7 @@ struct Record6 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -92,13 +92,12 @@ struct Record7 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
 [NumThreads(32, 1, 1)]
 void node7(DispatchNodeInputRecord<Record7> input) {}
-
 
 struct Record8 {
 // expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
@@ -106,6 +105,7 @@ struct Record8 {
   float data;
 };
 
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -119,6 +119,7 @@ struct Record9 {
   float data;
 };
 
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -131,6 +132,7 @@ struct Record10 {
   float data;
 };
 
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -144,6 +146,7 @@ struct Record11 {
   float data;
 };
 
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -156,7 +159,7 @@ struct Record12 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -169,7 +172,7 @@ struct Record13 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -183,7 +186,7 @@ struct Record14 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -197,7 +200,7 @@ struct Record15 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -210,7 +213,7 @@ struct Record16 {
   float data;
 };
 
-
+// expected-note@+5{{NodeInput/Output record defined here}}
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(32, 16, 1)]
@@ -240,58 +243,3 @@ struct Record18 {
 [NodeMaxDispatchGrid(32, 16, 1)]
 [NumThreads(32, 1, 1)]
 void node18(DispatchNodeInputRecord<Record18> input) {}
-
-template<typename T>
-struct OutputRecord {
-// expected-error@+16{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
-// expected-error@+15{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<float, 3>'}}
-// expected-error@+14{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int'}}
-// expected-error@+13{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int, 3>'}}
-// expected-error@+12{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<unsigned int, 4>'}}
-// expected-error@+11{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'unsigned int [4]'}}
-// expected-error@+10{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
-// expected-error@+9{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<half, 3>'}}
-// expected-error@+8{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t'}}
-// expected-error@+7{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 3>'}}
-// expected-error@+6{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<uint16_t, 4>'}}
-// expected-error@+5{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint16_t [4]'}}
-// expected-error@+4{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 4>'}}
-// expected-error@+3{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'matrix<int16_t, 2, 2>'}}
-// expected-error@+2{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<int>'}}
-// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<float>'}}
-  T grid : SV_DispatchGrid;
-  float data;
-};
-
-#define OUTPUT_NODE_ENTRY(T,N) \
-[Shader("node")] \
-[NodeLaunch("broadcasting")] \
-[NodeDispatchGrid(1,1,1)] \
-[NumThreads(32, 1, 1)] \
-void node_output_N(NodeOutput<OutputRecord< T > > output) {}
-
-
-OUTPUT_NODE_ENTRY(float, 0);
-OUTPUT_NODE_ENTRY(float3, 1);
-OUTPUT_NODE_ENTRY(int, 2);
-OUTPUT_NODE_ENTRY(int3, 3);
-OUTPUT_NODE_ENTRY(uint4, 4);
-OUTPUT_NODE_ENTRY(uint[4], 5);
-OUTPUT_NODE_ENTRY(half, 6);
-OUTPUT_NODE_ENTRY(half3, 7);
-OUTPUT_NODE_ENTRY(int16_t, 8);
-OUTPUT_NODE_ENTRY(int16_t3, 9);
-OUTPUT_NODE_ENTRY(uint16_t4, 10);
-OUTPUT_NODE_ENTRY(uint16_t[4], 11);
-
-OUTPUT_NODE_ENTRY(int16_t4, 12);
-OUTPUT_NODE_ENTRY(int16_t2x2, 13);
-OUTPUT_NODE_ENTRY(uint16_t3 , 14);
-OUTPUT_NODE_ENTRY(uint16_t[3] , 15);
-
-template<typename T>
-struct S {
-  T a;
-};
-OUTPUT_NODE_ENTRY(S<int> , 16);
-OUTPUT_NODE_ENTRY(S<float> , 17);

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid_type_nodeoutput.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatch_grid_type_nodeoutput.hlsl
@@ -1,0 +1,142 @@
+// RUN: %dxc -Tlib_6_8 -enable-16bit-types -verify %s
+
+template<typename T>
+struct OutputRecord {
+
+// expected-error@+48{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
+// expected-error@+47{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<float, 3>'}}
+// expected-error@+46{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int'}}
+// expected-error@+45{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int, 3>'}}
+// expected-error@+44{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<unsigned int, 4>'}}
+// expected-error@+43{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'unsigned int [4]'}}
+// expected-error@+42{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
+// expected-error@+41{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<half, 3>'}}
+// expected-error@+40{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t'}}
+// expected-error@+39{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 3>'}}
+// expected-error@+38{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<uint16_t, 4>'}}
+// expected-error@+37{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint16_t [4]'}}
+// expected-error@+36{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 4>'}}
+// expected-error@+35{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'matrix<int16_t, 2, 2>'}}
+// expected-error@+34{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<int>'}}
+// expected-error@+33{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<float>'}}
+// expected-error@+32{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
+// expected-error@+31{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<float, 3>'}}
+// expected-error@+30{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int'}}
+// expected-error@+29{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int, 3>'}}
+// expected-error@+28{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<unsigned int, 4>'}}
+// expected-error@+27{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'unsigned int [4]'}}
+// expected-error@+26{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
+// expected-error@+25{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<half, 3>'}}
+// expected-error@+24{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t'}}
+// expected-error@+23{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 3>'}}
+// expected-error@+22{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<uint16_t, 4>'}}
+// expected-error@+21{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint16_t [4]'}}
+// expected-error@+20{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 4>'}}
+// expected-error@+19{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'matrix<int16_t, 2, 2>'}}
+// expected-error@+18{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<int>'}}
+// expected-error@+17{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<float>'}}
+// expected-error@+16{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'float'}}
+// expected-error@+15{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<float, 3>'}}
+// expected-error@+14{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int'}}
+// expected-error@+13{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int, 3>'}}
+// expected-error@+12{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<unsigned int, 4>'}}
+// expected-error@+11{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'unsigned int [4]'}}
+// expected-error@+10{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'half'}}
+// expected-error@+9{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<half, 3>'}}
+// expected-error@+8{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'int16_t'}}
+// expected-error@+7{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 3>'}}
+// expected-error@+6{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<uint16_t, 4>'}}
+// expected-error@+5{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'uint16_t [4]'}}
+// expected-error@+4{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'vector<int16_t, 4>'}}
+// expected-error@+3{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'matrix<int16_t, 2, 2>'}}
+// expected-error@+2{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<int>'}}
+// expected-error@+1{{SV_DispatchGrid can only be applied to a declaration of unsigned 32 or 16-bit integer scalar, vector, or array up to 3 elements, not 'S<float>'}}
+  T grid : SV_DispatchGrid;
+  float data;
+};
+
+#define OUTPUT_NODE_ENTRY(T,N) \
+[Shader("node")] \
+[NodeLaunch("coalescing")] \
+[NumThreads(32, 1, 1)] \
+void node_output_C_N(NodeOutput<OutputRecord< T > > output) {}\
+[Shader("node")] \
+[NodeLaunch("broadcasting")] \
+[NodeDispatchGrid(1,1,1)] \
+[NumThreads(32, 1, 1)] \
+void node_output_B_N(NodeOutput<OutputRecord< T > > output) {}\
+[Shader("node")] \
+[NodeLaunch("thread")] \
+void node_output_T_N(NodeOutput<OutputRecord< T > > output) {}
+
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(float, 0);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(float3, 1);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int, 2);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int3, 3);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(uint4, 4);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(uint[4], 5);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(half, 6);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(half3, 7);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int16_t, 8);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int16_t3, 9);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(uint16_t4, 10);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(uint16_t[4], 11);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int16_t4, 12);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(int16_t2x2, 13);
+OUTPUT_NODE_ENTRY(uint16_t3 , 14);
+OUTPUT_NODE_ENTRY(uint16_t[3] , 15);
+
+template<typename T>
+struct S {
+  T a;
+};
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(S<int> , 16);
+// expected-note@+3{{NodeInput/Output record defined here}}
+// expected-note@+2{{NodeInput/Output record defined here}}
+// expected-note@+1{{NodeInput/Output record defined here}}
+OUTPUT_NODE_ENTRY(S<float> , 17);


### PR DESCRIPTION
Check both Input and Output node type when diagnose Semantic of DispatchGrid.

Fixes #5958