### PR TITLE
[SPIRV] allow location index to be > than 64

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1828,7 +1828,8 @@ public:
     if (loc == nextAvailableLocation[index]) {
       ++nextAvailableLocation[index];
     } else {
-      nextAvailableLocation[index] = std::max(loc + 1, nextAvailableLocation[index]);
+      nextAvailableLocation[index] =
+          std::max(loc + 1, nextAvailableLocation[index]);
     }
   }
 
@@ -1841,9 +1842,11 @@ public:
 
     // Simple case: no hole large enough left, resizing.
     if (res == std::nullopt) {
-      const uint32_t spaceLeft = locations.size() - nextAvailableLocation[index];
+      const uint32_t spaceLeft =
+          locations.size() - nextAvailableLocation[index];
       assert(spaceLeft < count && "There is a bug.");
-      const uint32_t requiredAlloc = count - spaceLeft;;
+      const uint32_t requiredAlloc = count - spaceLeft;
+      ;
       locations.resize(locations.size() + requiredAlloc);
       res = nextAvailableLocation[index];
     }
@@ -1851,7 +1854,8 @@ public:
     for (uint32_t i = res.value(); i < res.value() + count; i++) {
       locations.set(i);
     }
-    nextAvailableLocation[index] = std::max(res.value() + count, nextAvailableLocation[index]);
+    nextAvailableLocation[index] =
+        std::max(res.value() + count, nextAvailableLocation[index]);
     return res.value();
   }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -1805,6 +1805,7 @@ public:
   /// Maximum number of indices supported
   const static uint32_t kMaxIndex = 2;
 
+  // Creates an empty set.
   LocationSet() {
     for (uint32_t i = 0; i < kMaxIndex; ++i) {
       // Default size. 64 should cover most cases without having to resize.
@@ -1814,7 +1815,7 @@ public:
   }
 
   /// Marks a given location as used.
-  void useLoc(uint32_t loc, uint32_t index = 0) {
+  void useLocation(uint32_t loc, uint32_t index = 0) {
     assert(index < kMaxIndex);
 
     auto &set = usedLocations[index];
@@ -1822,22 +1823,15 @@ public:
       set.resize(std::max<size_t>(loc + 1, set.size() * 2));
     }
     set.set(loc);
-
-    // Maybe the bit marked is the next available one.
-    // Otherwise, there is a hole, ignoring.
-    if (loc == nextAvailableLocation[index]) {
-      ++nextAvailableLocation[index];
-    } else {
-      nextAvailableLocation[index] =
-          std::max(loc + 1, nextAvailableLocation[index]);
-    }
+    nextAvailableLocation[index] =
+        std::max(loc + 1, nextAvailableLocation[index]);
   }
 
   // Find the first range of size |count| of unused locations,
   // and marks them as used.
   // Returns the first index of this range.
-  int useNextLocs(uint32_t count, uint32_t index = 0) {
-    auto res = find_unused_range(index, count);
+  int useNextNLocations(uint32_t count, uint32_t index = 0) {
+    auto res = findUnusedRange(index, count);
     auto &locations = usedLocations[index];
 
     // Simple case: no hole large enough left, resizing.
@@ -1845,8 +1839,8 @@ public:
       const uint32_t spaceLeft =
           locations.size() - nextAvailableLocation[index];
       assert(spaceLeft < count && "There is a bug.");
+
       const uint32_t requiredAlloc = count - spaceLeft;
-      ;
       locations.resize(locations.size() + requiredAlloc);
       res = nextAvailableLocation[index];
     }
@@ -1854,13 +1848,14 @@ public:
     for (uint32_t i = res.value(); i < res.value() + count; i++) {
       locations.set(i);
     }
+
     nextAvailableLocation[index] =
         std::max(res.value() + count, nextAvailableLocation[index]);
     return res.value();
   }
 
   /// Returns true if the given location number is already used.
-  bool isLocUsed(uint32_t loc, uint32_t index = 0) {
+  bool isLocationUsed(uint32_t loc, uint32_t index = 0) {
     assert(index < kMaxIndex);
     if (loc >= usedLocations[index].size())
       return false;
@@ -1871,26 +1866,34 @@ private:
   // Find the first unused range of size |size| in the given set.
   // If the set contains such range, returns the first usable index.
   // Otherwise, nullopt is returned.
-  std::optional<uint32_t> find_unused_range(uint32_t index, uint32_t size) {
-    assert(index < kMaxIndex);
-    const auto &locations = usedLocations[index];
-    uint32_t slot_size = 0;
-    for (uint32_t i = nextAvailableLocation[index]; i < locations.size(); i++) {
-      if (locations[i])
-        slot_size = 0;
-      else
-        ++slot_size;
-
-      if (slot_size == size)
-        return i + 1 - slot_size;
+  std::optional<uint32_t> findUnusedRange(uint32_t index, uint32_t size) {
+    if (size == 0) {
+      return 0;
     }
 
-    return std::nullopt;
+    assert(index < kMaxIndex);
+    const auto &locations = usedLocations[index];
+
+    uint32_t required_size = size;
+    uint32_t start = 0;
+    for (uint32_t i = 0; i < locations.size() && required_size > 0; i++) {
+      if (!locations[i]) {
+        --required_size;
+        continue;
+      }
+
+      required_size = size;
+      start = i + 1;
+    }
+
+    return required_size == 0 ? std::optional(start) : std::nullopt;
   }
 
+  // The sets to remember used locations. A set bit means the location is used.
   /// All previously used locations
   llvm::SmallBitVector usedLocations[kMaxIndex];
-  /// Next available location
+
+  // The position of the last bit set in the usedLocation vector.
   uint32_t nextAvailableLocation[kMaxIndex];
 };
 
@@ -2083,7 +2086,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
 
       // Make sure the same location is not assigned more than once
       for (uint32_t l = loc; l < loc + locCount; ++l) {
-        if (locSet.isLocUsed(l, idx)) {
+        if (locSet.isLocationUsed(l, idx)) {
           emitError("stage %select{output|input}0 location #%1 already "
                     "consumed by semantic '%2'",
                     attrLoc)
@@ -2091,7 +2094,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
           noError = false;
         }
 
-        locSet.useLoc(l, idx);
+        locSet.useLocation(l, idx);
       }
 
       spvBuilder.decorateLocation(var.getSpirvInstr(), loc);
@@ -2133,7 +2136,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
     // semantic string index.
     if (semaInfo.isTarget()) {
       spvBuilder.decorateLocation(var.getSpirvInstr(), semaInfo.index);
-      locSet.useLoc(semaInfo.index);
+      locSet.useLocation(semaInfo.index);
 
       if (!isDuplicatedStageVarLocation(&stageVariableLocationInfo, var,
                                         semaInfo.index, 0)) {
@@ -2148,7 +2151,7 @@ bool DeclResultIdMapper::finalizeStageIOLocations(bool forInput) {
     return true;
 
   auto nextLocs = [&locSet](uint32_t locCount) {
-    return locSet.useNextLocs(locCount);
+    return locSet.useNextNLocations(locCount);
   };
 
   // If alphabetical ordering was requested, sort by semantic string.

--- a/tools/clang/test/CodeGenSPIRV_Lit/spirv.interface.holes.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spirv.interface.holes.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+float main(
+  int a[1000] : A,
+// CHECK:  OpDecorate %in_var_A Location 0
+  int b : B,
+// CHECK:  OpDecorate %in_var_B Location 1000
+  int c[500] : C,
+// CHECK:  OpDecorate %in_var_C Location 1001
+  int D : D
+// CHECK:  OpDecorate %in_var_D Location 1501
+  ) : A
+{
+  return 1.0;
+}
+

--- a/tools/clang/test/CodeGenSPIRV_Lit/spirv.interface.hs.large.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spirv.interface.hs.large.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -T hs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+struct ControlPoint {
+  float4 position[1000] : POSITION;
+};
+
+struct HullPatchOut {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+HullPatchOut HullConst () {
+  return (HullPatchOut)0;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+[outputcontrolpoints(3)]
+ControlPoint main(InputPatch<ControlPoint, 1> large_input,
+                  uint id : SV_OutputControlPointID) {
+  return large_input[0];
+}
+
+// CHECK: OpCapability Tessellation
+
+// CHECK: OpEntryPoint TessellationControl %main "main" [[var:%[a-zA-Z0-9_]+]]
+// CHECK: [[array_1:%[a-zA-Z0-9_]+]] = OpTypeArray %v4float %uint_1000
+// CHECK: [[array_2:%[a-zA-Z0-9_]+]] = OpTypeArray [[array_1]] %uint_1
+// CHECK:     [[ptr:%[a-zA-Z0-9_]+]] = OpTypePointer Input [[array_2]]
+// CHECK:                    [[var]] = OpVariable [[ptr]] Input

--- a/tools/clang/test/CodeGenSPIRV_Lit/vk.location.large.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/vk.location.large.hlsl
@@ -1,6 +1,6 @@
-// RUN: not %dxc -T vs_6_0 -E main -fcgl  %s -spirv  2>&1 | FileCheck %s
+// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
 
 [[vk::location(123456)]]
 float main() : A { return 1.0; }
 
-// CHECK: 3:3: error: stage output location #123456 too large
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] Location 123456


### PR DESCRIPTION
There was an arbitrary limit to set the maximum number of locations to 64.
This commit allows the set to be resized, to allow arbitrarily large location indices.

Curiously, one test, vk.location.large.hlsl started to fail. This test assumed 123456 was an invalid location. From the SPIR-V spec, I don't think this is true, as it only days Location should be an arbitraty number.
In addition, it seems like this test was triggering an out-of-bound access, which is now solved. Only drawback: we now end-up with a 123456 sized bitset.
I believe this is OK, as WHY would someone only require this index.

Fixes #3735