### PR TITLE
[SPIR-V] Fix crash with GetAttributeAtVertex

### DIFF
--- a/tools/clang/lib/SPIRV/PervertexInputVisitor.cpp
+++ b/tools/clang/lib/SPIRV/PervertexInputVisitor.cpp
@@ -56,6 +56,11 @@ int PervertexInputVisitor::appendIndexZeroAt(
 ///< treated as nointerpolated too.
 bool PervertexInputVisitor::expandNointerpVarAndParam(
     SpirvInstruction *spvInst) {
+  // If the spirv type has no AST type (hybrid struct for ex), no need to expand
+  // it.
+  if (!spvInst->hasAstResultType())
+    return true;
+
   QualType type = spvInst->getAstResultType();
   bool isExpanded = false;
   auto typePtr = type.getTypePtr();

--- a/tools/clang/test/CodeGenSPIRV_Lit/spirv.interpolation.ps.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spirv.interpolation.ps.struct.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+struct PSInput
+{
+  float4 position : SV_POSITION;
+  nointerpolation float3 color : COLOR;
+};
+
+cbuffer constants : register(b0)
+{
+  float4 g_constants;
+}
+
+float4 main(PSInput input) : SV_TARGET
+{
+  uint cmp = (uint)(g_constants[0]);
+
+  float colorAtV0 = GetAttributeAtVertex(input.color, 0)[cmp];
+  float colorAtV1 = GetAttributeAtVertex(input.color, 1)[cmp];
+  float colorAtV2 = GetAttributeAtVertex(input.color, 2)[cmp];
+
+  return float4(colorAtV0, colorAtV1, colorAtV2, 0);
+}
+
+// CHECK: OpDecorate [[var:%[a-zA-Z0-9_]+]] Flat
+// CHECK: OpDecorate [[var]] PerVertexKHR
+
+// CHECK: [[array:%[a-zA-Z0-9_]+]] = OpTypeArray %v3float %uint_3
+// CHECK:  [[type:%[a-zA-Z0-9_]+]] = OpTypePointer Input [[array]]
+// CHECK:                  [[var]] = OpVariable [[type]] Input


### PR DESCRIPTION
The code assumed all the types we handled had an AST type. But when the struct is created in the SPIR-V backend, there are no AST type left to represent it.
In such case, the lowering step should handle the interpolation attributes, so I think we shouldn't have to do anything.

Fixes #2955 again.