### PR TITLE
[CI] fix issue when apply format

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -6,6 +6,7 @@ on:
     types: edited
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   code_formatter:
@@ -84,23 +85,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          path: main
 
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: 'utils/git/requirements_formatting.txt'
+          cache-dependency-path: 'main/utils/git/requirements_formatting.txt'
 
       - name: Install python dependencies
-        run: pip install -r utils/git/requirements_formatting.txt
+        run: pip install -r main/utils/git/requirements_formatting.txt
 
       - name: Apply code diff
         env:
           GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          python utils/git/code-format-save-diff.py \
+          python main/utils/git/code-format-save-diff.py \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --issue-number $GITHUB_PR_NUMBER \
             --tmp-diff-file $TMP_DIFF_FILE \

--- a/utils/git/code-format-save-diff.py
+++ b/utils/git/code-format-save-diff.py
@@ -58,7 +58,7 @@ def apply_patches(args: argparse.Namespace) -> None:
         os.remove(args.tmp_diff_file)
     
     with open(args.tmp_diff_file, 'w+') as tmp:
-        tmp.write(diff.encode("utf-8"))
+        tmp.write(diff)
         tmp.flush()
         tmp.close()
 


### PR DESCRIPTION
Fix issues hit when apply format.
1. tmp diff file is not opened binary form, don't need to encode.
2. add contents write to "Check code formatting" workflow for commit and push change.
3. put main branch to different path to avoid issue when checkout head branch to same path.