### PR TITLE
Run CI builds only on main and release branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+trigger:
+  - main
+  - release*
+  
 resources:
 - repo: self
 


### PR DESCRIPTION
The CI build is currently running on any new branch in the repo. We should run it only on `main` and `release*` branches.