### PR TITLE
[SPIR-V] Fix interlock output parameter validation

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -1838,15 +1838,23 @@ ParamModsFromIntrinsicArg(const HLSL_INTRINSIC_ARGUMENT *pArg) {
 }
 
 static void InitParamMods(const HLSL_INTRINSIC *pIntrinsic,
-                          SmallVectorImpl<hlsl::ParameterModifier> &paramMods,
-                          size_t uVariadicArgumentCount = 0) {
-  const size_t argumentCount = pIntrinsic->uNumArgs + uVariadicArgumentCount;
-  // The first argument is the return value. Skipping.
-  for (size_t i = 1; i < argumentCount; i++) {
-    if (i < pIntrinsic->uNumArgs && !IsVariadicArgument(pIntrinsic->pArgs[i]))
-      paramMods.push_back(ParamModsFromIntrinsicArg(&pIntrinsic->pArgs[i]));
-    else
-      paramMods.push_back(hlsl::ParameterModifier(hlsl::ParameterModifier::Kind::In));
+                          SmallVectorImpl<hlsl::ParameterModifier> &paramMods) {
+  // The first argument is the return value, which isn't included.
+  UINT i = 1, size = paramMods.size();
+  for (; i < pIntrinsic->uNumArgs; ++i) {
+    // Once we reach varargs we can break out of this loop.
+    if (IsVariadicArgument(pIntrinsic->pArgs[i]))
+      break;
+    paramMods.push_back(ParamModsFromIntrinsicArg(&pIntrinsic->pArgs[i]));
+  }
+
+  // For variadic functions, any argument not explicitly specified will be
+  // considered an input argument.
+  if (IsVariadicIntrinsicFunction(pIntrinsic)) {
+    for (; i < size; ++i) {
+      paramMods.push_back(
+          hlsl::ParameterModifier(hlsl::ParameterModifier::Kind::In));
+    }
   }
 }
 
@@ -1911,7 +1919,14 @@ AddHLSLIntrinsicFunction(ASTContext &context, NamespaceDecl *NS,
            "otherwise g_MaxIntrinsicParamCount should be larger");
 
   SmallVector<hlsl::ParameterModifier, g_MaxIntrinsicParamCount> paramMods;
-  InitParamMods(pIntrinsic, paramMods, functionArgTypeCount - pIntrinsic->uNumArgs);
+
+  if (isVariadic) {
+    // For variadic functions, the number of arguments is larger than the
+    // function declaration signature.
+    paramMods.resize(functionArgTypeCount);
+  }
+
+  InitParamMods(pIntrinsic, paramMods);
 
   for (size_t i = 1; i < functionArgTypeCount; i++) {
     // Change out/inout param to reference type.

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.output.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.output.hlsl
@@ -1,0 +1,69 @@
+// RUN: %dxc -T cs_6_6 -E main -fcgl -spirv %s | FileCheck %s
+
+RWStructuredBuffer<uint> buffer;
+groupshared uint value;
+
+struct S1 {
+  uint m0;
+};
+
+struct S2 {
+  S1 m0[2];
+};
+
+RWStructuredBuffer<uint> returnBuffer() {
+  return buffer;
+}
+
+void passBuffer(RWStructuredBuffer<uint> param) {
+  InterlockedAdd(value, 1, param[0]);
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+  uint result;
+  InterlockedAdd(value, 1, result);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK:                   OpStore %result [[tmp]]
+
+  uint2 value2;
+  InterlockedAdd(value, 1, value2.x);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %value2 %int_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  S1 s1;
+  InterlockedAdd(value, 1, s1.m0);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %s1 %int_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  uint array[2];
+  InterlockedAdd(value, 1, array[0]);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %array %int_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  S2 s2;
+  InterlockedAdd(value, 1, s2.m0[1].m0);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %s2 %int_0 %int_1 %int_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  InterlockedAdd(value, 1, buffer[0]);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %buffer %int_0 %uint_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  InterlockedAdd(value, 1, returnBuffer()[0]);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[buf:%[0-9]+]] = OpFunctionCall %_ptr_Uniform_type_RWStructuredBuffer_uint %returnBuffer
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[buf]] %int_0 %uint_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+
+  passBuffer(buffer);
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[buf:%[0-9]+]] = OpLoad %_ptr_Uniform_type_RWStructuredBuffer_uint %param
+// CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[buf]] %int_0 %uint_0
+// CHECK:                   OpStore [[ptr]] [[tmp]]
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
@@ -2,8 +2,31 @@
 
 groupshared uint value;
 
+uint getValue() {
+  return 0;
+}
+
+uint getVector() {
+  uint2 output;
+  return output;
+}
+
+int getArray()[2] {
+  int array[2];
+  return array;
+}
+
 [numthreads(1, 1, 1)]
 void main() {
-// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
   InterlockedCompareExchange(value, 1, 2, 3);
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
+
+  InterlockedAdd(value, 1, getValue());
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
+
+  InterlockedAdd(value, 1, getVector().x);
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
+
+  InterlockedAdd(value, 1, getArray()[0]);
+// CHECK: error: InterlockedCompareExchange requires a reference as output parameter
 }

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.compareexchange.reference.hlsl
@@ -6,7 +6,7 @@ uint getValue() {
   return 0;
 }
 
-uint getVector() {
+uint2 getVector() {
   uint2 output;
   return output;
 }


### PR DESCRIPTION
Interlock* functions takes output parameters. Because HLSL had no real concept of references, this is allowed:

```
  int value;
  takeAnOutput(value);
```

This weirdness makes using `isLValue()` to validate output parameters a bit tricky. If a function returns a local array, and we take the subscript of this r-value, the r-value is now marked as l-value, but this shouldn't be allowed.

This forces us to walk the expression, and add heuristics to determine if the output parameter is valid or not. Not pretty, but I think this is required until HLSL gets proper references.

Fixes #5772