### PR TITLE
[SM66,SPIRV] Implement InterlockedExchange for floats

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9012,9 +9012,10 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
   const auto srcLoc = expr->getExprLoc();
   const auto baseType = dest->getType()->getCanonicalTypeUnqualified();
 
-  if (!baseType->isIntegerType()) {
-    emitError("can only perform atomic operations on scalar integer values",
-              dest->getLocStart());
+  if (!baseType->isIntegerType() && !baseType->isFloatingType()) {
+    emitError(
+        "can only perform atomic operations on scalar integer or float values",
+        dest->getLocStart());
     return nullptr;
   }
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9013,9 +9013,8 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
   const auto baseType = dest->getType()->getCanonicalTypeUnqualified();
 
   if (!baseType->isIntegerType() && !baseType->isFloatingType()) {
-    emitError(
-        "can only perform atomic operations on scalar integer or float values",
-        dest->getLocStart());
+    llvm_unreachable("Unexpected type for atomic operation. Expecting a scalar "
+                     "integer or float values");
     return nullptr;
   }
 

--- a/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.cs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/intrinsics.interlocked-methods.cs.hlsl
@@ -1,7 +1,8 @@
-// RUN: %dxc -T cs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+// RUN: %dxc -T cs_6_6 -E main -fcgl  %s -spirv | FileCheck %s
 
 groupshared int dest_i;
 groupshared uint dest_u;
+groupshared float dest_f;
 
 RWBuffer<uint> buff;
 RWBuffer<uint> getDest() {
@@ -13,9 +14,11 @@ void main()
 {
   uint original_u_val;
   int original_i_val;
+  float original_f_val;
 
   int   val1;
   int   val2;
+  float val_f1;
 
   //////////////////////////////////////////////////////////////////////////
   ///////      Test all Interlocked* functions on primitive types     //////
@@ -67,4 +70,9 @@ void main()
 // CHECK-NEXT:  [[ace35:%[0-9]+]] = OpAtomicExchange %int %dest_i %uint_1 %uint_0 [[val2_35]]
 // CHECK-NEXT:                   OpStore %original_i_val [[ace35]]
   InterlockedExchange(dest_i, val2, original_i_val);
+
+// CHECK:      [[val_f:%[0-9]+]] = OpLoad %float %val_f1
+// CHECK-NEXT:  [[ace36:%[0-9]+]] = OpAtomicExchange %float %dest_f %uint_1 %uint_0 [[val_f]]
+// CHECK-NEXT:                   OpStore %original_f_val [[ace36]]
+  InterlockedExchange(dest_f, val_f1, original_f_val);
 }


### PR DESCRIPTION
This implements the atomic exchange for floating point values that was
added in SM6.6. See https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_Int64_and_Float_Atomics.html#interlockedexchange.
