### PR TITLE
[CI] use build/main_src instead main when checkout main for save diff

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -85,24 +85,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          path: main
+          path: build/main_src
 
       - name: Setup Python env
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
-          cache-dependency-path: 'main/utils/git/requirements_formatting.txt'
+          cache-dependency-path: 'build/main_src/utils/git/requirements_formatting.txt'
 
       - name: Install python dependencies
-        run: pip install -r main/utils/git/requirements_formatting.txt
+        run: pip install -r build/main_src/utils/git/requirements_formatting.txt
 
       - name: Apply code diff
         env:
           GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
           COMMENT_ID: ${{ github.event.comment.id }}
         run: |
-          python main/utils/git/code-format-save-diff.py \
+          python build/main_src/utils/git/code-format-save-diff.py \
             --token ${{ secrets.GITHUB_TOKEN }} \
             --issue-number $GITHUB_PR_NUMBER \
             --tmp-diff-file $TMP_DIFF_FILE \


### PR DESCRIPTION
This is avoid possible issue when git add . might add main.