### PR TITLE
PIX: CP of clang-format change prepping for subsequent CPs

### DIFF
--- a/lib/DxilDia/DxcPixLiveVariables.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables.cpp
@@ -14,7 +14,7 @@
 
 #include "DxcPixDxilDebugInfo.h"
 #include "DxcPixLiveVariables.h"
-#include "DxcPixLiveVariables_FragmentIterator.h" 
+#include "DxcPixLiveVariables_FragmentIterator.h"
 #include "DxilDiaSession.h"
 
 #include "dxc/Support/Global.h"
@@ -23,8 +23,8 @@
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/Module.h"
 
 #include <unordered_map>
@@ -34,19 +34,16 @@
 // not assigned to a dxil alloca register -- i.e., it
 // tries to find overlapping alloca registers -- which should
 // never happen -- to report the issue.
-void ValidateDbgDeclare(
-    dxil_debug_info::VariableInfo *VarInfo,
-    unsigned FragmentSizeInBits,
-    unsigned FragmentOffsetInBits
-)
-{
-  // #DSLTodo: When operating on libraries, each exported 
-  // function is instrumented separately, resulting in 
+void ValidateDbgDeclare(dxil_debug_info::VariableInfo *VarInfo,
+                        unsigned FragmentSizeInBits,
+                        unsigned FragmentOffsetInBits) {
+  // #DSLTodo: When operating on libraries, each exported
+  // function is instrumented separately, resulting in
   // overlapping variables. This is not a problem for, e.g.
   // raytracing debugging because WinPIX only ever (so far)
   // invokes debugging on one export at a time.
   // With the advent of DSL, this will have to change...
-#if 0 //ndef NDEBUG
+#if 0  // ndef NDEBUG
   for (unsigned i = 0; i < FragmentSizeInBits; ++i)
   {
     const unsigned BitNum = FragmentOffsetInBits + i;
@@ -57,17 +54,14 @@ void ValidateDbgDeclare(
     assert(!VarInfo->m_DbgDeclareValidation[BitNum]);
     VarInfo->m_DbgDeclareValidation[BitNum] = true;
   }
-#endif  // !NDEBUG
+#endif // !NDEBUG
 }
 
-struct dxil_debug_info::LiveVariables::Impl
-{
-  using VariableInfoMap = std::unordered_map<
-      llvm::DIVariable *,
-      std::unique_ptr<VariableInfo>>;
+struct dxil_debug_info::LiveVariables::Impl {
+  using VariableInfoMap =
+      std::unordered_map<llvm::DIVariable *, std::unique_ptr<VariableInfo>>;
 
-  using LiveVarsMap =
-      std::unordered_map<llvm::DIScope*, VariableInfoMap>;
+  using LiveVarsMap = std::unordered_map<llvm::DIScope *, VariableInfoMap>;
 
   IMalloc *m_pMalloc;
   DxcPixDxilDebugInfo *m_pDxilDebugInfo;
@@ -75,79 +69,61 @@ struct dxil_debug_info::LiveVariables::Impl
   LiveVarsMap m_LiveVarsDbgDeclare;
   VariableInfoMap m_LiveGlobalVarsDbgDeclare;
 
-  void Init(
-      IMalloc *pMalloc,
-      DxcPixDxilDebugInfo *pDxilDebugInfo,
-      llvm::Module *pModule);
+  void Init(IMalloc *pMalloc, DxcPixDxilDebugInfo *pDxilDebugInfo,
+            llvm::Module *pModule);
 
   void Init_DbgDeclare(llvm::DbgDeclareInst *DbgDeclare);
 
-  VariableInfo *AssignValueToOffset(
-      VariableInfoMap *VarInfoMap,
-      llvm::DIVariable *Var,
-      llvm::Value *Address,
-      unsigned FragmentIndex,
-      unsigned FragmentOffsetInBits);
+  VariableInfo *AssignValueToOffset(VariableInfoMap *VarInfoMap,
+                                    llvm::DIVariable *Var, llvm::Value *Address,
+                                    unsigned FragmentIndex,
+                                    unsigned FragmentOffsetInBits);
 
-    bool IsVariableLive(const VariableInfoMap::value_type &VarAndInfo,
-                      const llvm::DIScope* S, const llvm::DebugLoc &DL);
+  bool IsVariableLive(const VariableInfoMap::value_type &VarAndInfo,
+                      const llvm::DIScope *S, const llvm::DebugLoc &DL);
 };
 
 void dxil_debug_info::LiveVariables::Impl::Init(
-    IMalloc *pMalloc,
-    DxcPixDxilDebugInfo *pDxilDebugInfo,
-    llvm::Module *pModule)
-{
+    IMalloc *pMalloc, DxcPixDxilDebugInfo *pDxilDebugInfo,
+    llvm::Module *pModule) {
   m_pMalloc = pMalloc;
   m_pDxilDebugInfo = pDxilDebugInfo;
   m_pModule = pModule;
 
-  llvm::Function* DbgDeclareFn = llvm::Intrinsic::getDeclaration(
-      m_pModule,
-      llvm::Intrinsic::dbg_declare);
+  llvm::Function *DbgDeclareFn =
+      llvm::Intrinsic::getDeclaration(m_pModule, llvm::Intrinsic::dbg_declare);
 
-  for (llvm::User* U : DbgDeclareFn->users())
-  {
-    if (auto* DbgDeclare = llvm::dyn_cast<llvm::DbgDeclareInst>(U))
-    {
+  for (llvm::User *U : DbgDeclareFn->users()) {
+    if (auto *DbgDeclare = llvm::dyn_cast<llvm::DbgDeclareInst>(U)) {
       Init_DbgDeclare(DbgDeclare);
     }
   }
 }
 
 void dxil_debug_info::LiveVariables::Impl::Init_DbgDeclare(
-    llvm::DbgDeclareInst *DbgDeclare
-)
-{
+    llvm::DbgDeclareInst *DbgDeclare) {
   llvm::Value *Address = DbgDeclare->getAddress();
   auto *Variable = DbgDeclare->getVariable();
   auto *Expression = DbgDeclare->getExpression();
 
-  if (Address == nullptr || Variable == nullptr || Expression == nullptr)
-  {
+  if (Address == nullptr || Variable == nullptr || Expression == nullptr) {
     return;
   }
 
-  auto* AddressAsAlloca = llvm::dyn_cast<llvm::AllocaInst>(Address);
-  if (AddressAsAlloca == nullptr)
-  {
-      return;
+  auto *AddressAsAlloca = llvm::dyn_cast<llvm::AllocaInst>(Address);
+  if (AddressAsAlloca == nullptr) {
+    return;
   }
 
   auto *S = Variable->getScope();
-  if (S == nullptr)
-  {
+  if (S == nullptr) {
     return;
   }
 
-  auto Iter = CreateMemberIterator(
-      DbgDeclare,
-      m_pModule->getDataLayout(),
-      AddressAsAlloca,
-      Expression);
+  auto Iter = CreateMemberIterator(DbgDeclare, m_pModule->getDataLayout(),
+                                   AddressAsAlloca, Expression);
 
-  if (!Iter)
-  {
+  if (!Iter) {
     // MemberIterator creation failure, this skip this var.
     return;
   }
@@ -158,59 +134,40 @@ void dxil_debug_info::LiveVariables::Impl::Init_DbgDeclare(
   } else {
     LiveVarInfoMap = &m_LiveVarsDbgDeclare[S];
   }
- 
 
   unsigned FragmentIndex;
-  while (Iter->Next(&FragmentIndex))
-  {
-    const unsigned FragmentSizeInBits = 
-      Iter->SizeInBits(FragmentIndex);
-    const unsigned FragmentOffsetInBits =
-        Iter->OffsetInBits(FragmentIndex);
+  while (Iter->Next(&FragmentIndex)) {
+    const unsigned FragmentSizeInBits = Iter->SizeInBits(FragmentIndex);
+    const unsigned FragmentOffsetInBits = Iter->OffsetInBits(FragmentIndex);
 
-    VariableInfo* VarInfo = AssignValueToOffset(
-        LiveVarInfoMap,
-        Variable,
-        Address,
-        FragmentIndex,
-        FragmentOffsetInBits);
+    VariableInfo *VarInfo = AssignValueToOffset(
+        LiveVarInfoMap, Variable, Address, FragmentIndex, FragmentOffsetInBits);
 
     // SROA can split structs so that multiple allocas back the same variable.
     // In this case the expression will be empty
-    if (Expression->getNumElements() != 0)
-    {
-      ValidateDbgDeclare(
-        VarInfo,
-        FragmentSizeInBits,
-        FragmentOffsetInBits);
+    if (Expression->getNumElements() != 0) {
+      ValidateDbgDeclare(VarInfo, FragmentSizeInBits, FragmentOffsetInBits);
     }
   }
 }
 
 dxil_debug_info::VariableInfo *
 dxil_debug_info::LiveVariables::Impl::AssignValueToOffset(
-    VariableInfoMap *VarInfoMap,
-    llvm::DIVariable *Variable,
-    llvm::Value *Address,
-    unsigned FragmentIndex,
-    unsigned FragmentOffsetInBits
-)
-{
+    VariableInfoMap *VarInfoMap, llvm::DIVariable *Variable,
+    llvm::Value *Address, unsigned FragmentIndex,
+    unsigned FragmentOffsetInBits) {
   // FragmentIndex is the index within the alloca'd value
   // FragmentOffsetInBits is the offset within the HLSL variable
   // that maps to Address[FragmentIndex]
   auto it = VarInfoMap->find(Variable);
-  if (it == VarInfoMap->end())
-  {
-    auto InsertIt = VarInfoMap->emplace(
-        Variable,
-        std::make_unique<VariableInfo>(Variable));
+  if (it == VarInfoMap->end()) {
+    auto InsertIt =
+        VarInfoMap->emplace(Variable, std::make_unique<VariableInfo>(Variable));
     assert(InsertIt.second);
     it = InsertIt.first;
   }
   auto *VarInfo = it->second.get();
-  auto &FragmentLocation =
-      VarInfo->m_ValueLocationMap[FragmentOffsetInBits];
+  auto &FragmentLocation = VarInfo->m_ValueLocationMap[FragmentOffsetInBits];
   FragmentLocation.m_V = Address;
   FragmentLocation.m_FragmentIndex = FragmentIndex;
 
@@ -221,9 +178,11 @@ dxil_debug_info::LiveVariables::LiveVariables() = default;
 
 dxil_debug_info::LiveVariables::~LiveVariables() = default;
 
-HRESULT dxil_debug_info::LiveVariables::Init(DxcPixDxilDebugInfo *pDxilDebugInfo) {
+HRESULT
+dxil_debug_info::LiveVariables::Init(DxcPixDxilDebugInfo *pDxilDebugInfo) {
   Clear();
-  m_pImpl->Init(pDxilDebugInfo->GetMallocNoRef(), pDxilDebugInfo, pDxilDebugInfo->GetModuleRef());
+  m_pImpl->Init(pDxilDebugInfo->GetMallocNoRef(), pDxilDebugInfo,
+                pDxilDebugInfo->GetModuleRef());
   return S_OK;
 }
 
@@ -232,8 +191,7 @@ void dxil_debug_info::LiveVariables::Clear() {
 }
 
 HRESULT dxil_debug_info::LiveVariables::GetLiveVariablesAtInstruction(
-  llvm::Instruction *IP,
-  IDxcPixDxilLiveVariables **ppResult) const {
+    llvm::Instruction *IP, IDxcPixDxilLiveVariables **ppResult) const {
   DXASSERT(IP != nullptr, "else IP should not be nullptr");
   DXASSERT(ppResult != nullptr, "else Result should not be nullptr");
 
@@ -242,25 +200,20 @@ HRESULT dxil_debug_info::LiveVariables::GetLiveVariablesAtInstruction(
 
   const llvm::DebugLoc &DL = IP->getDebugLoc();
 
-  if (!DL)
-  {
+  if (!DL) {
     return E_FAIL;
   }
 
   llvm::DIScope *S = DL->getScope();
-  if (S == nullptr)
-  {
+  if (S == nullptr) {
     return E_FAIL;
   }
 
   const llvm::DITypeIdentifierMap EmptyMap;
-  while (S != nullptr)
-  {
+  while (S != nullptr) {
     auto it = m_pImpl->m_LiveVarsDbgDeclare.find(S);
-    if (it != m_pImpl->m_LiveVarsDbgDeclare.end())
-    {
-      for (const auto &VarAndInfo :  it->second)
-      {
+    if (it != m_pImpl->m_LiveVarsDbgDeclare.end()) {
+      for (const auto &VarAndInfo : it->second) {
         auto *Var = VarAndInfo.first;
         llvm::StringRef VarName = Var->getName();
         if (Var->getLine() > DL.getLine()) {
@@ -289,8 +242,6 @@ HRESULT dxil_debug_info::LiveVariables::GetLiveVariablesAtInstruction(
     }
     LiveVars.emplace_back(VarAndInfo.second.get());
   }
-  return CreateDxilLiveVariables(
-      m_pImpl->m_pDxilDebugInfo,
-      std::move(LiveVars),
-      ppResult);
+  return CreateDxilLiveVariables(m_pImpl->m_pDxilDebugInfo, std::move(LiveVars),
+                                 ppResult);
 }

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -28,10 +28,9 @@
 #include "DxilDiaTableSourceFiles.h"
 #include "DxilDiaTableSymbols.h"
 
-void dxil_dia::Session::Init(
-    std::shared_ptr<llvm::LLVMContext> context,
-    std::shared_ptr<llvm::Module> mod,
-    std::shared_ptr<llvm::DebugInfoFinder> finder) {
+void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
+                             std::shared_ptr<llvm::Module> mod,
+                             std::shared_ptr<llvm::DebugInfoFinder> finder) {
   m_pEnumTables = nullptr;
   m_module = mod;
   m_context = context;
@@ -43,40 +42,43 @@ void dxil_dia::Session::Init(
 
   // Get file contents.
   m_contents =
-    m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceContentsMDName);
+      m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceContentsMDName);
   if (!m_contents)
     m_contents = m_module->getNamedMetadata("llvm.dbg.contents");
 
   m_defines =
-    m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceDefinesMDName);
+      m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceDefinesMDName);
   if (!m_defines)
     m_defines = m_module->getNamedMetadata("llvm.dbg.defines");
 
-  m_mainFileName =
-    m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceMainFileNameMDName);
+  m_mainFileName = m_module->getNamedMetadata(
+      hlsl::DxilMDHelper::kDxilSourceMainFileNameMDName);
   if (!m_mainFileName)
     m_mainFileName = m_module->getNamedMetadata("llvm.dbg.mainFileName");
 
   m_arguments =
-    m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceArgsMDName);
+      m_module->getNamedMetadata(hlsl::DxilMDHelper::kDxilSourceArgsMDName);
   if (!m_arguments)
     m_arguments = m_module->getNamedMetadata("llvm.dbg.args");
 
   // Build up a linear list of instructions. The index will be used as the
   // RVA.
   for (llvm::Function &fn : m_module->functions()) {
-    for (llvm::inst_iterator it = inst_begin(fn), end = inst_end(fn); it != end; ++it) {
+    for (llvm::inst_iterator it = inst_begin(fn), end = inst_end(fn); it != end;
+         ++it) {
       llvm::Instruction &i = *it;
       RVA rva;
       if (!pix_dxil::PixDxilInstNum::FromInst(&i, &rva)) {
         continue;
       }
-      m_rvaMap.insert({ &i, rva });
-      m_instructions.insert({ rva, &i});
+      m_rvaMap.insert({&i, rva});
+      m_instructions.insert({rva, &i});
       if (llvm::DebugLoc DL = i.getDebugLoc()) {
-        auto result = m_lineToInfoMap.emplace(DL.getLine(), LineInfo(DL.getCol(), rva, rva + 1));
+        auto result = m_lineToInfoMap.emplace(
+            DL.getLine(), LineInfo(DL.getCol(), rva, rva + 1));
         if (!result.second) {
-          result.first->second.StartCol = std::min(result.first->second.StartCol, DL.getCol());
+          result.first->second.StartCol =
+              std::min(result.first->second.StartCol, DL.getCol());
           result.first->second.Last = rva + 1;
         }
         m_instructionLines.push_back(&i);
@@ -86,26 +88,27 @@ void dxil_dia::Session::Init(
 
   // Sanity check to make sure rva map is same as instruction index.
   for (auto It = m_instructions.begin(); It != m_instructions.end(); ++It) {
-    DXASSERT(m_rvaMap.find(It->second) != m_rvaMap.end(), "instruction not mapped to rva");
-    DXASSERT(m_rvaMap[It->second] == It->first, "instruction mapped to wrong rva");
+    DXASSERT(m_rvaMap.find(It->second) != m_rvaMap.end(),
+             "instruction not mapped to rva");
+    DXASSERT(m_rvaMap[It->second] == It->first,
+             "instruction mapped to wrong rva");
   }
 
   // Initialize symbols
   try {
-      m_symsMgr.Init(this);
+    m_symsMgr.Init(this);
   } catch (const hlsl::Exception &) {
-      m_symsMgr = std::move(dxil_dia::SymbolManager());
+    m_symsMgr = std::move(dxil_dia::SymbolManager());
   }
 }
 
-HRESULT dxil_dia::Session::getSourceFileIdByName(
-    llvm::StringRef fileName,
-    DWORD *pRetVal) {
+HRESULT dxil_dia::Session::getSourceFileIdByName(llvm::StringRef fileName,
+                                                 DWORD *pRetVal) {
   if (Contents() != nullptr) {
     for (unsigned i = 0; i < Contents()->getNumOperands(); ++i) {
-      llvm::StringRef fn =
-        llvm::dyn_cast<llvm::MDString>(Contents()->getOperand(i)->getOperand(0))
-        ->getString();
+      llvm::StringRef fn = llvm::dyn_cast<llvm::MDString>(
+                               Contents()->getOperand(i)->getOperand(0))
+                               ->getString();
       if (fn.equals(fileName)) {
         *pRetVal = i;
         return S_OK;
@@ -123,7 +126,7 @@ STDMETHODIMP dxil_dia::Session::get_loadAddress(
 }
 
 STDMETHODIMP dxil_dia::Session::get_globalScope(
-  /* [retval][out] */ IDiaSymbol **pRetVal) {
+    /* [retval][out] */ IDiaSymbol **pRetVal) {
   DxcThreadMalloc TM(m_pMalloc);
 
   if (pRetVal == nullptr) {
@@ -169,63 +172,59 @@ STDMETHODIMP dxil_dia::Session::findFile(
     /* [in] */ LPCOLESTR name,
     /* [in] */ DWORD compareFlags,
     /* [out] */ IDiaEnumSourceFiles **ppResult) {
-    if (!m_pEnumTables) {
-        return E_INVALIDARG;
+  if (!m_pEnumTables) {
+    return E_INVALIDARG;
+  }
+
+  // TODO: properly support compareFlags.
+  auto namecmp = &_wcsicmp;
+  if (compareFlags & nsCaseSensitive) {
+    namecmp = &wcscmp;
+  }
+
+  DxcThreadMalloc TM(m_pMalloc);
+  CComPtr<IDiaTable> pTable;
+  VARIANT vtIndex;
+  vtIndex.vt = VT_UI4;
+  vtIndex.uintVal = (int)Table::Kind::SourceFiles;
+  IFR(m_pEnumTables->Item(vtIndex, &pTable));
+
+  CComPtr<IDiaEnumSourceFiles> pSourceTable;
+  IFR(pTable->QueryInterface(&pSourceTable));
+  HRESULT hr;
+  CComPtr<IDiaSourceFile> src;
+  ULONG cnt;
+  std::vector<CComPtr<IDiaSourceFile>> sources;
+
+  pSourceTable->Reset();
+  while (SUCCEEDED(hr = pSourceTable->Next(1, &src, &cnt)) && hr == S_OK &&
+         cnt == 1) {
+    CComBSTR currName;
+    IFR(src->get_fileName(&currName));
+    if (namecmp(name, currName) == 0) {
+      sources.emplace_back(src);
     }
-    
-    // TODO: properly support compareFlags.
-    auto namecmp = &_wcsicmp;
-    if (compareFlags & nsCaseSensitive) {
-        namecmp = &wcscmp;
-    }
+    src.Release();
+  }
 
-    DxcThreadMalloc TM(m_pMalloc);
-    CComPtr<IDiaTable> pTable;
-    VARIANT vtIndex;
-    vtIndex.vt = VT_UI4;
-    vtIndex.uintVal = (int)Table::Kind::SourceFiles;
-    IFR(m_pEnumTables->Item(vtIndex, &pTable));
+  *ppResult = CreateOnMalloc<SourceFilesTable>(GetMallocNoRef(), this,
+                                               std::move(sources));
 
-    CComPtr<IDiaEnumSourceFiles> pSourceTable;
-    IFR(pTable->QueryInterface(&pSourceTable));
-    HRESULT hr;
-    CComPtr<IDiaSourceFile> src;
-    ULONG cnt;
-    std::vector<CComPtr<IDiaSourceFile>> sources;
-
-    pSourceTable->Reset();
-    while (SUCCEEDED(hr = pSourceTable->Next(1, &src, &cnt)) && hr == S_OK && cnt == 1) {
-        CComBSTR currName;
-        IFR(src->get_fileName(&currName));
-        if (namecmp(name, currName) == 0) {
-            sources.emplace_back(src);
-        }
-        src.Release();
-    }
-
-    *ppResult = CreateOnMalloc<SourceFilesTable>(
-        GetMallocNoRef(),
-        this,
-        std::move(sources));
-
-    if (*ppResult == nullptr) {
-        return E_OUTOFMEMORY;
-    }
-    (*ppResult)->AddRef();
-    return S_OK;
+  if (*ppResult == nullptr) {
+    return E_OUTOFMEMORY;
+  }
+  (*ppResult)->AddRef();
+  return S_OK;
 }
 
 namespace dxil_dia {
-static HRESULT DxcDiaFindLineNumbersByRVA(
-  Session *pSession,
-  DWORD rva,
-  DWORD length,
-  IDiaEnumLineNumbers **ppResult)
-{
+static HRESULT DxcDiaFindLineNumbersByRVA(Session *pSession, DWORD rva,
+                                          DWORD length,
+                                          IDiaEnumLineNumbers **ppResult) {
   if (!ppResult)
     return E_POINTER;
 
-  std::vector<const llvm::Instruction*> instructions;
+  std::vector<const llvm::Instruction *> instructions;
   auto &allInstructions = pSession->InstructionsRef();
 
   // Gather the list of insructions that map to the given rva range.
@@ -242,115 +241,114 @@ static HRESULT DxcDiaFindLineNumbersByRVA(
 
   // Create line number table from explicit instruction list.
   IMalloc *pMalloc = pSession->GetMallocNoRef();
-  *ppResult = CreateOnMalloc<LineNumbersTable>(pMalloc, pSession, std::move(instructions));
+  *ppResult = CreateOnMalloc<LineNumbersTable>(pMalloc, pSession,
+                                               std::move(instructions));
   if (*ppResult == nullptr)
     return E_OUTOFMEMORY;
   (*ppResult)->AddRef();
   return S_OK;
 }
-}  // namespace dxil_dia
+} // namespace dxil_dia
 
 STDMETHODIMP dxil_dia::Session::findLinesByAddr(
-  /* [in] */ DWORD seg,
-  /* [in] */ DWORD offset,
-  /* [in] */ DWORD length,
-  /* [out] */ IDiaEnumLineNumbers **ppResult) {
+    /* [in] */ DWORD seg,
+    /* [in] */ DWORD offset,
+    /* [in] */ DWORD length,
+    /* [out] */ IDiaEnumLineNumbers **ppResult) {
   DxcThreadMalloc TM(m_pMalloc);
   return DxcDiaFindLineNumbersByRVA(this, offset, length, ppResult);
 }
 
 STDMETHODIMP dxil_dia::Session::findLinesByRVA(
-  /* [in] */ DWORD rva,
-  /* [in] */ DWORD length,
-  /* [out] */ IDiaEnumLineNumbers **ppResult) {
+    /* [in] */ DWORD rva,
+    /* [in] */ DWORD length,
+    /* [out] */ IDiaEnumLineNumbers **ppResult) {
   DxcThreadMalloc TM(m_pMalloc);
   return DxcDiaFindLineNumbersByRVA(this, rva, length, ppResult);
 }
 
 STDMETHODIMP dxil_dia::Session::findInlineeLinesByAddr(
-  /* [in] */ IDiaSymbol *parent,
-  /* [in] */ DWORD isect,
-  /* [in] */ DWORD offset,
-  /* [in] */ DWORD length,
-  /* [out] */ IDiaEnumLineNumbers **ppResult) {
+    /* [in] */ IDiaSymbol *parent,
+    /* [in] */ DWORD isect,
+    /* [in] */ DWORD offset,
+    /* [in] */ DWORD length,
+    /* [out] */ IDiaEnumLineNumbers **ppResult) {
   DxcThreadMalloc TM(m_pMalloc);
   return DxcDiaFindLineNumbersByRVA(this, offset, length, ppResult);
 }
 
 STDMETHODIMP dxil_dia::Session::findLinesByLinenum(
-  /* [in] */ IDiaSymbol *compiland,
-  /* [in] */ IDiaSourceFile *file,
-  /* [in] */ DWORD linenum,
-  /* [in] */ DWORD column,
-  /* [out] */ IDiaEnumLineNumbers **ppResult) {
-    if (!m_pEnumTables) {
-        return E_INVALIDARG;
-    }
-    *ppResult = nullptr;
+    /* [in] */ IDiaSymbol *compiland,
+    /* [in] */ IDiaSourceFile *file,
+    /* [in] */ DWORD linenum,
+    /* [in] */ DWORD column,
+    /* [out] */ IDiaEnumLineNumbers **ppResult) {
+  if (!m_pEnumTables) {
+    return E_INVALIDARG;
+  }
+  *ppResult = nullptr;
 
-    DxcThreadMalloc TM(m_pMalloc);
-    CComPtr<IDiaTable> pTable;
-    VARIANT vtIndex;
-    vtIndex.vt = VT_UI4;
-    vtIndex.uintVal = (int)Table::Kind::LineNumbers;
-    IFR(m_pEnumTables->Item(vtIndex, &pTable));
+  DxcThreadMalloc TM(m_pMalloc);
+  CComPtr<IDiaTable> pTable;
+  VARIANT vtIndex;
+  vtIndex.vt = VT_UI4;
+  vtIndex.uintVal = (int)Table::Kind::LineNumbers;
+  IFR(m_pEnumTables->Item(vtIndex, &pTable));
 
-    CComPtr<IDiaEnumLineNumbers> pLineTable;
-    IFR(pTable->QueryInterface(&pLineTable));
-    HRESULT hr;
-    CComPtr<IDiaLineNumber> line;
-    ULONG cnt;
-    std::vector<const llvm::Instruction *> lines;
+  CComPtr<IDiaEnumLineNumbers> pLineTable;
+  IFR(pTable->QueryInterface(&pLineTable));
+  HRESULT hr;
+  CComPtr<IDiaLineNumber> line;
+  ULONG cnt;
+  std::vector<const llvm::Instruction *> lines;
 
-    std::function<bool(DWORD, DWORD)>column_matches = [column](DWORD colStart, DWORD colEnd) -> bool {
-        return true;
+  std::function<bool(DWORD, DWORD)> column_matches =
+      [column](DWORD colStart, DWORD colEnd) -> bool { return true; };
+
+  if (column != 0) {
+    column_matches = [column](DWORD colStart, DWORD colEnd) -> bool {
+      return colStart < column && column < colEnd;
     };
+  }
 
-    if (column != 0) {
-        column_matches = [column](DWORD colStart, DWORD colEnd) -> bool {
-            return colStart < column && column < colEnd;
-        };
+  pLineTable->Reset();
+  while (SUCCEEDED(hr = pLineTable->Next(1, &line, &cnt)) && hr == S_OK &&
+         cnt == 1) {
+    CComPtr<IDiaSourceFile> f;
+    DWORD ln, lnEnd, cn, cnEnd;
+    IFR(line->get_lineNumber(&ln));
+    IFR(line->get_lineNumberEnd(&lnEnd));
+    IFR(line->get_columnNumber(&cn));
+    IFR(line->get_columnNumberEnd(&cnEnd));
+    IFR(line->get_sourceFile(&f));
+
+    if (file == f && (ln <= linenum && linenum <= lnEnd) &&
+        column_matches(cn, cnEnd)) {
+      lines.emplace_back(reinterpret_cast<LineNumber *>(line.p)->Inst());
     }
+    line.Release();
+  }
 
-    pLineTable->Reset();
-    while (SUCCEEDED(hr = pLineTable->Next(1, &line, &cnt)) && hr == S_OK && cnt == 1) {
-        CComPtr<IDiaSourceFile> f;
-        DWORD ln, lnEnd, cn, cnEnd;
-        IFR(line->get_lineNumber(&ln));
-        IFR(line->get_lineNumberEnd(&lnEnd));
-        IFR(line->get_columnNumber(&cn));
-        IFR(line->get_columnNumberEnd(&cnEnd));
-        IFR(line->get_sourceFile(&f));
-        
-        if (file == f && (ln <= linenum && linenum <= lnEnd) && column_matches(cn, cnEnd)) {
-            lines.emplace_back(reinterpret_cast<LineNumber*>(line.p)->Inst());
-        }
-        line.Release();
-    }
+  HRESULT result = lines.empty() ? S_FALSE : S_OK;
+  *ppResult = CreateOnMalloc<LineNumbersTable>(GetMallocNoRef(), this,
+                                               std::move(lines));
 
-    HRESULT result = lines.empty() ? S_FALSE : S_OK;
-    *ppResult = CreateOnMalloc<LineNumbersTable>(
-        GetMallocNoRef(),
-        this,
-        std::move(lines));
-
-    if (*ppResult == nullptr) {
-        return E_OUTOFMEMORY;
-    }
-    (*ppResult)->AddRef();
-    return result;
+  if (*ppResult == nullptr) {
+    return E_OUTOFMEMORY;
+  }
+  (*ppResult)->AddRef();
+  return result;
 }
 
 STDMETHODIMP dxil_dia::Session::findInjectedSource(
-  /* [in] */ LPCOLESTR srcFile,
-  /* [out] */ IDiaEnumInjectedSources **ppResult) {
+    /* [in] */ LPCOLESTR srcFile,
+    /* [out] */ IDiaEnumInjectedSources **ppResult) {
   if (Contents() != nullptr) {
     CW2A pUtf8FileName(srcFile, CP_UTF8);
     DxcThreadMalloc TM(m_pMalloc);
     IDiaTable *pTable;
     IFT(Table::Create(this, Table::Kind::InjectedSource, &pTable));
-    auto *pInjectedSource =
-      reinterpret_cast<InjectedSourcesTable *>(pTable);
+    auto *pInjectedSource = reinterpret_cast<InjectedSourcesTable *>(pTable);
     pInjectedSource->Init(pUtf8FileName.m_psz);
     *ppResult = pInjectedSource;
     return S_OK;
@@ -360,10 +358,10 @@ STDMETHODIMP dxil_dia::Session::findInjectedSource(
 
 static constexpr DWORD kD3DCodeSection = 1;
 STDMETHODIMP dxil_dia::Session::findInlineFramesByAddr(
-  /* [in] */ IDiaSymbol *parent,
-  /* [in] */ DWORD isect,
-  /* [in] */ DWORD offset,
-  /* [out] */ IDiaEnumSymbols **ppResult) {
+    /* [in] */ IDiaSymbol *parent,
+    /* [in] */ DWORD isect,
+    /* [in] */ DWORD offset,
+    /* [out] */ IDiaEnumSymbols **ppResult) {
   if (parent != nullptr || isect != kD3DCodeSection || ppResult == nullptr) {
     return E_INVALIDARG;
   }

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -95,7 +95,8 @@ using namespace hlsl;
 constexpr uint64_t DebugBufferDumpingGroundSize = 64 * 1024;
 // The actual max size per record is much smaller than this, but it never
 // hurts to be generous.
-constexpr size_t CounterOffsetBeyondUsefulData = DebugBufferDumpingGroundSize / 2;
+constexpr size_t CounterOffsetBeyondUsefulData =
+    DebugBufferDumpingGroundSize / 2;
 
 // These definitions echo those in the debugger application's
 // debugshaderrecord.h file
@@ -216,8 +217,7 @@ private:
   unsigned m_LastInstruction = static_cast<unsigned>(-1);
 
   uint64_t m_UAVSize = 1024 * 1024;
-  struct PerFunctionValues
-  {
+  struct PerFunctionValues {
     CallInst *UAVHandle = nullptr;
     Constant *CounterOffset = nullptr;
     Value *InvocationId = nullptr;
@@ -258,28 +258,27 @@ public:
   void applyOptions(PassOptions O) override;
   bool runOnModule(Module &M) override;
 
-  bool RunOnFunction(Module& M, DxilModule& DM, 
-    llvm::Function *function);
+  bool RunOnFunction(Module &M, DxilModule &DM, llvm::Function *function);
 
 private:
-  SystemValueIndices addRequiredSystemValues(BuilderContext &BC, DXIL::ShaderKind shaderKind);
+  SystemValueIndices addRequiredSystemValues(BuilderContext &BC,
+                                             DXIL::ShaderKind shaderKind);
   void addInvocationSelectionProlog(BuilderContext &BC,
                                     SystemValueIndices SVIndices,
                                     DXIL::ShaderKind shaderKind);
   Value *addPixelShaderProlog(BuilderContext &BC, SystemValueIndices SVIndices);
   Value *addGeometryShaderProlog(BuilderContext &BC);
   Value *addDispatchedShaderProlog(BuilderContext &BC);
-  Value* addRaygenShaderProlog(BuilderContext& BC);
-  Value* addVertexShaderProlog(BuilderContext& BC,
+  Value *addRaygenShaderProlog(BuilderContext &BC);
+  Value *addVertexShaderProlog(BuilderContext &BC,
                                SystemValueIndices SVIndices);
   Value *addHullhaderProlog(BuilderContext &BC);
-  Value *addComparePrimitiveIdProlog(BuilderContext &BC,
-                               unsigned SVIndices);
+  Value *addComparePrimitiveIdProlog(BuilderContext &BC, unsigned SVIndices);
   void addDebugEntryValue(BuilderContext &BC, Value *TheValue);
   void addInvocationStartMarker(BuilderContext &BC);
   void reserveDebugEntrySpace(BuilderContext &BC, uint32_t SpaceInDwords);
   void addStoreStepDebugEntry(BuilderContext &BC, StoreInst *Inst);
-  void addStepDebugEntry(BuilderContext& BC, Instruction* Inst);
+  void addStepDebugEntry(BuilderContext &BC, Instruction *Inst);
   void addStepDebugEntryValue(BuilderContext &BC, std::uint32_t InstNum,
                               Value *V, std::uint32_t ValueOrdinal,
                               Value *ValueOrdinalIndex);
@@ -305,11 +304,9 @@ uint32_t DxilDebugInstrumentation::UAVDumpingGroundOffset() {
   return static_cast<uint32_t>(m_UAVSize - DebugBufferDumpingGroundSize);
 }
 
-static unsigned
-FindOrAddInputSignatureElement(hlsl::DxilSignature &InputSignature,
-    const char * name,
-    DXIL::SigPointKind sigPointKind,
-                               hlsl::DXIL::SemanticKind semanticKind) {
+static unsigned FindOrAddInputSignatureElement(
+    hlsl::DxilSignature &InputSignature, const char *name,
+    DXIL::SigPointKind sigPointKind, hlsl::DXIL::SemanticKind semanticKind) {
 
   auto &InputElements = InputSignature.GetElements();
 
@@ -320,11 +317,9 @@ FindOrAddInputSignatureElement(hlsl::DxilSignature &InputSignature,
                    });
 
   if (ExistingElement == InputElements.end()) {
-    auto AddedElement =
-        llvm::make_unique<DxilSignatureElement>(sigPointKind);
+    auto AddedElement = llvm::make_unique<DxilSignatureElement>(sigPointKind);
     AddedElement->Initialize(name, hlsl::CompType::getF32(),
-                                  hlsl::DXIL::InterpolationMode::Undefined, 1,
-                                  1);
+                             hlsl::DXIL::InterpolationMode::Undefined, 1, 1);
     AddedElement->AppendSemanticIndex(0);
     AddedElement->SetSigPointKind(sigPointKind);
     AddedElement->SetKind(semanticKind);
@@ -337,8 +332,8 @@ FindOrAddInputSignatureElement(hlsl::DxilSignature &InputSignature,
 }
 
 DxilDebugInstrumentation::SystemValueIndices
-  DxilDebugInstrumentation::addRequiredSystemValues(
-      BuilderContext & BC, DXIL::ShaderKind shaderKind) {
+DxilDebugInstrumentation::addRequiredSystemValues(BuilderContext &BC,
+                                                  DXIL::ShaderKind shaderKind) {
   SystemValueIndices SVIndices{};
 
   switch (shaderKind) {
@@ -353,8 +348,8 @@ DxilDebugInstrumentation::SystemValueIndices
     // Dispatch* thread Id is not in the input signature
     break;
   case DXIL::ShaderKind::Vertex: {
-      hlsl::DxilSignature& InputSignature = BC.DM.GetInputSignature();
-      SVIndices.VertexShader.VertexId = FindOrAddInputSignatureElement(
+    hlsl::DxilSignature &InputSignature = BC.DM.GetInputSignature();
+    SVIndices.VertexShader.VertexId = FindOrAddInputSignatureElement(
         InputSignature, "VertexId", DXIL::SigPointKind::VSIn,
         hlsl::DXIL::SemanticKind::VertexID);
     SVIndices.VertexShader.InstanceId = FindOrAddInputSignatureElement(
@@ -364,7 +359,8 @@ DxilDebugInstrumentation::SystemValueIndices
   case DXIL::ShaderKind::Geometry:
   case DXIL::ShaderKind::Hull:
   case DXIL::ShaderKind::Domain:
-    // GS, HS, DS Primitive id, HS control point id, and GS Instance id are not in the input signature
+    // GS, HS, DS Primitive id, HS control point id, and GS Instance id are not
+    // in the input signature
     break;
   case DXIL::ShaderKind::Pixel: {
     hlsl::DxilSignature &InputSignature = BC.DM.GetInputSignature();
@@ -439,16 +435,19 @@ Value *DxilDebugInstrumentation::addDispatchedShaderProlog(BuilderContext &BC) {
 }
 
 Value *DxilDebugInstrumentation::addRaygenShaderProlog(BuilderContext &BC) {
-  auto DispatchRaysIndexOpFunc =
-      BC.HlslOP->GetOpFunc(DXIL::OpCode::DispatchRaysIndex, Type::getInt32Ty(BC.Ctx));
+  auto DispatchRaysIndexOpFunc = BC.HlslOP->GetOpFunc(
+      DXIL::OpCode::DispatchRaysIndex, Type::getInt32Ty(BC.Ctx));
   Constant *DispatchRaysIndexOpcode =
       BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::DispatchRaysIndex);
-  auto RayX =
-      BC.Builder.CreateCall(DispatchRaysIndexOpFunc, {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(0) }, "RayX");
-  auto RayY =
-      BC.Builder.CreateCall(DispatchRaysIndexOpFunc, {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(1) }, "RayY");
-  auto RayZ =
-      BC.Builder.CreateCall(DispatchRaysIndexOpFunc, {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(2) }, "RayZ");
+  auto RayX = BC.Builder.CreateCall(
+      DispatchRaysIndexOpFunc,
+      {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(0)}, "RayX");
+  auto RayY = BC.Builder.CreateCall(
+      DispatchRaysIndexOpFunc,
+      {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(1)}, "RayY");
+  auto RayZ = BC.Builder.CreateCall(
+      DispatchRaysIndexOpFunc,
+      {DispatchRaysIndexOpcode, BC.HlslOP->GetI8Const(2)}, "RayZ");
 
   auto CompareToX = BC.Builder.CreateICmpEQ(
       RayX, BC.HlslOP->GetU32Const(m_Parameters.ComputeShader.ThreadIdX),
@@ -510,15 +509,13 @@ DxilDebugInstrumentation::addVertexShaderProlog(BuilderContext &BC,
   return CompareBoth;
 }
 
-Value * DxilDebugInstrumentation::addHullhaderProlog(BuilderContext &BC) {
+Value *DxilDebugInstrumentation::addHullhaderProlog(BuilderContext &BC) {
   auto LoadControlPointFunction = BC.HlslOP->GetOpFunc(
       DXIL::OpCode::OutputControlPointID, Type::getInt32Ty(BC.Ctx));
   Constant *LoadControlPointOpcode =
       BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::OutputControlPointID);
-  auto ControlPointId =
-      BC.Builder.CreateCall(LoadControlPointFunction,
-                            {LoadControlPointOpcode},
-                            "ControlPointId");
+  auto ControlPointId = BC.Builder.CreateCall(
+      LoadControlPointFunction, {LoadControlPointOpcode}, "ControlPointId");
 
   auto *CompareToPrimId =
       addComparePrimitiveIdProlog(BC, m_Parameters.HullShader.PrimitiveId);
@@ -528,29 +525,26 @@ Value * DxilDebugInstrumentation::addHullhaderProlog(BuilderContext &BC) {
       BC.HlslOP->GetU32Const(m_Parameters.HullShader.ControlPointId),
       "CompareToControlPointId");
 
-  auto CompareBoth =
-      BC.Builder.CreateAnd(CompareToControlPoint, CompareToPrimId, "CompareBoth");
+  auto CompareBoth = BC.Builder.CreateAnd(CompareToControlPoint,
+                                          CompareToPrimId, "CompareBoth");
 
   return CompareBoth;
 }
 
-Value * DxilDebugInstrumentation::addComparePrimitiveIdProlog(BuilderContext &BC,
-                                                unsigned primId) {
+Value *DxilDebugInstrumentation::addComparePrimitiveIdProlog(BuilderContext &BC,
+                                                             unsigned primId) {
   auto PrimitiveIdFunction =
       BC.HlslOP->GetOpFunc(DXIL::OpCode::PrimitiveID, Type::getInt32Ty(BC.Ctx));
   Constant *PrimitiveIdOpcode =
       BC.HlslOP->GetU32Const((unsigned)DXIL::OpCode::PrimitiveID);
   auto PrimId =
-      BC.Builder.CreateCall(PrimitiveIdFunction,
-                            {PrimitiveIdOpcode},
-                            "PrimId");
+      BC.Builder.CreateCall(PrimitiveIdFunction, {PrimitiveIdOpcode}, "PrimId");
 
   return BC.Builder.CreateICmpEQ(PrimId, BC.HlslOP->GetU32Const(primId),
                                  "CompareToPrimId");
 }
 
-Value * DxilDebugInstrumentation::addGeometryShaderProlog(
-    BuilderContext &BC) {
+Value *DxilDebugInstrumentation::addGeometryShaderProlog(BuilderContext &BC) {
   auto CompareToPrim =
       addComparePrimitiveIdProlog(BC, m_Parameters.GeometryShader.PrimitiveId);
 
@@ -622,7 +616,8 @@ DxilDebugInstrumentation::addPixelShaderProlog(BuilderContext &BC,
 }
 
 void DxilDebugInstrumentation::addInvocationSelectionProlog(
-    BuilderContext &BC, SystemValueIndices SVIndices, DXIL::ShaderKind shaderKind) {
+    BuilderContext &BC, SystemValueIndices SVIndices,
+    DXIL::ShaderKind shaderKind) {
   Value *ParameterTestResult = nullptr;
   switch (shaderKind) {
   case DXIL::ShaderKind::RayGeneration:
@@ -647,7 +642,8 @@ void DxilDebugInstrumentation::addInvocationSelectionProlog(
     ParameterTestResult = addHullhaderProlog(BC);
     break;
   case DXIL::ShaderKind::Domain:
-    ParameterTestResult = addComparePrimitiveIdProlog(BC, m_Parameters.DomainShader.PrimitiveId);
+    ParameterTestResult =
+        addComparePrimitiveIdProlog(BC, m_Parameters.DomainShader.PrimitiveId);
     break;
   case DXIL::ShaderKind::Pixel:
     ParameterTestResult = addPixelShaderProlog(BC, SVIndices);
@@ -700,11 +696,11 @@ void DxilDebugInstrumentation::reserveDebugEntrySpace(BuilderContext &BC,
       {
           AtomicBinOpcode,  // i32, ; opcode
           values.UAVHandle, // %dx.types.Handle, ; resource handle
-          AtomicAdd,        // i32, ; binary operation code : EXCHANGE, IADD, AND, OR,
-                            // XOR, IMIN, IMAX, UMIN, UMAX
-          values.CounterOffset,     // i32, ; coordinate c0: index in bytes
-          UndefArg,         // i32, ; coordinate c1 (unused)
-          UndefArg,         // i32, ; coordinate c2 (unused)
+          AtomicAdd, // i32, ; binary operation code : EXCHANGE, IADD, AND, OR,
+                     // XOR, IMIN, IMAX, UMIN, UMAX
+          values.CounterOffset,       // i32, ; coordinate c0: index in bytes
+          UndefArg,                   // i32, ; coordinate c1 (unused)
+          UndefArg,                   // i32, ; coordinate c2 (unused)
           IncrementForThisInvocation, // i32); increment value
       },
       "UAVIncResult");
@@ -713,8 +709,8 @@ void DxilDebugInstrumentation::reserveDebugEntrySpace(BuilderContext &BC,
     values.InvocationId = PreviousValue;
   }
 
-  auto MaskedForLimit =
-      BC.Builder.CreateAnd(PreviousValue, values.OffsetMask, "MaskedForUAVLimit");
+  auto MaskedForLimit = BC.Builder.CreateAnd(PreviousValue, values.OffsetMask,
+                                             "MaskedForUAVLimit");
   // The return value will either end up being itself (multiplied by one and
   // added with zero) or the "dump uninteresting things here" value of (UAVSize
   // - a bit).
@@ -785,10 +781,10 @@ void DxilDebugInstrumentation::addDebugEntryValue(BuilderContext &BC,
     auto &values = m_FunctionToValues[BC.Builder.GetInsertBlock()->getParent()];
 
     (void)BC.Builder.CreateCall(
-        StoreValue, {StoreValueOpcode, // i32 opcode
-                     values.UAVHandle, // %dx.types.Handle, ; resource handle
-                     values.CurrentIndex,   // i32 c0: index in bytes into UAV
-                     Undef32Arg,       // i32 c1: unused
+        StoreValue, {StoreValueOpcode,    // i32 opcode
+                     values.UAVHandle,    // %dx.types.Handle, ; resource handle
+                     values.CurrentIndex, // i32 c0: index in bytes into UAV
+                     Undef32Arg,          // i32 c1: unused
                      TheValue,
                      UndefArg, // unused values
                      UndefArg, // unused values
@@ -852,28 +848,28 @@ void DxilDebugInstrumentation::addStepEntryForType(
   }
 }
 
-void DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext& BC,
-    StoreInst* Inst) {
-    std::uint32_t ValueOrdinalBase;
-    std::uint32_t UnusedValueOrdinalSize;
-    llvm::Value* ValueOrdinalIndex;
-    if (!pix_dxil::PixAllocaRegWrite::FromInst(Inst, &ValueOrdinalBase,
-        &UnusedValueOrdinalSize,
-        &ValueOrdinalIndex)) {
-        return;
-    }
+void DxilDebugInstrumentation::addStoreStepDebugEntry(BuilderContext &BC,
+                                                      StoreInst *Inst) {
+  std::uint32_t ValueOrdinalBase;
+  std::uint32_t UnusedValueOrdinalSize;
+  llvm::Value *ValueOrdinalIndex;
+  if (!pix_dxil::PixAllocaRegWrite::FromInst(Inst, &ValueOrdinalBase,
+                                             &UnusedValueOrdinalSize,
+                                             &ValueOrdinalIndex)) {
+    return;
+  }
 
-    std::uint32_t InstNum;
-    if (!pix_dxil::PixDxilInstNum::FromInst(Inst, &InstNum)) {
-        return;
-    }
+  std::uint32_t InstNum;
+  if (!pix_dxil::PixDxilInstNum::FromInst(Inst, &InstNum)) {
+    return;
+  }
 
-    if (PIXPassHelpers::IsAllocateRayQueryInstruction(Inst->getValueOperand())) {
-        return;
-    }
+  if (PIXPassHelpers::IsAllocateRayQueryInstruction(Inst->getValueOperand())) {
+    return;
+  }
 
-    addStepDebugEntryValue(BC, InstNum, Inst->getValueOperand(), ValueOrdinalBase,
-        ValueOrdinalIndex);
+  addStepDebugEntryValue(BC, InstNum, Inst->getValueOperand(), ValueOrdinalBase,
+                         ValueOrdinalIndex);
 }
 
 void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
@@ -882,7 +878,7 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
     return;
   }
   if (PIXPassHelpers::IsAllocateRayQueryInstruction(Inst)) {
-      return;
+    return;
   }
 
   if (auto *St = llvm::dyn_cast<llvm::StoreInst>(Inst)) {
@@ -976,19 +972,16 @@ bool DxilDebugInstrumentation::runOnModule(Module &M) {
     }
   } else {
     llvm::Function *entryFunction = PIXPassHelpers::GetEntryFunction(DM);
-    modified = RunOnFunction(M, DM, entryFunction);  
+    modified = RunOnFunction(M, DM, entryFunction);
   }
   return modified;
 }
 
-bool DxilDebugInstrumentation::RunOnFunction(
-  Module &M, 
-  DxilModule &DM,
-  llvm::Function * entryFunction) 
-{
+bool DxilDebugInstrumentation::RunOnFunction(Module &M, DxilModule &DM,
+                                             llvm::Function *entryFunction) {
   DXIL::ShaderKind shaderKind =
       PIXPassHelpers::GetFunctionShaderKind(DM, entryFunction);
-  
+
   switch (shaderKind) {
   case DXIL::ShaderKind::Amplification:
   case DXIL::ShaderKind::Mesh:
@@ -1010,8 +1003,7 @@ bool DxilDebugInstrumentation::RunOnFunction(
 
   // First record pointers to all instructions in the function:
   std::vector<Instruction *> AllInstructions;
-  for (inst_iterator I = inst_begin(entryFunction),
-                     E = inst_end(entryFunction);
+  for (inst_iterator I = inst_begin(entryFunction), E = inst_end(entryFunction);
        I != E; ++I) {
     std::uint32_t InstructionNumber;
     if (pix_dxil::PixDxilInstNum::FromInst(&*I, &InstructionNumber)) {
@@ -1046,14 +1038,15 @@ bool DxilDebugInstrumentation::RunOnFunction(
 
   auto &values = m_FunctionToValues[BC.Builder.GetInsertBlock()->getParent()];
 
-  // PIX binds two UAVs when running this instrumentation: one for raygen shaders
-  // and another for the hitgroups and miss shaders. Since PIX invokes this pass
-  // at the library level, which may contain examples of both types, PIX can't really
-  // specify which UAV index to use per-shader. This pass therefore just has to know this:
+  // PIX binds two UAVs when running this instrumentation: one for raygen
+  // shaders and another for the hitgroups and miss shaders. Since PIX invokes
+  // this pass at the library level, which may contain examples of both types,
+  // PIX can't really specify which UAV index to use per-shader. This pass
+  // therefore just has to know this:
   constexpr unsigned int RayGenUAVRegister = 0;
   constexpr unsigned int HitGroupAndMissUAVRegister = 1;
   unsigned int UAVRegisterId = RayGenUAVRegister;
-    switch (shaderKind) {
+  switch (shaderKind) {
   case DXIL::ShaderKind::ClosestHit:
   case DXIL::ShaderKind::Intersection:
   case DXIL::ShaderKind::AnyHit:
@@ -1062,10 +1055,10 @@ bool DxilDebugInstrumentation::RunOnFunction(
     break;
   }
 
-  values.UAVHandle = PIXPassHelpers::CreateUAV(
-      DM, Builder, UAVRegisterId,
-      "PIX_DebugUAV_Handle");
-  values.CounterOffset = BC.HlslOP->GetU32Const(UAVDumpingGroundOffset() + CounterOffsetBeyondUsefulData);
+  values.UAVHandle = PIXPassHelpers::CreateUAV(DM, Builder, UAVRegisterId,
+                                               "PIX_DebugUAV_Handle");
+  values.CounterOffset = BC.HlslOP->GetU32Const(UAVDumpingGroundOffset() +
+                                                CounterOffsetBeyondUsefulData);
 
   auto SystemValues = addRequiredSystemValues(BC, shaderKind);
   addInvocationSelectionProlog(BC, SystemValues, shaderKind);


### PR DESCRIPTION
This is a cherry-pick of the big clang-format change in main, but restricted to just three files for which I intend to CP subsequent changes from main. I generated this PR with the following commands:

git cherry-pick -n https://github.com/microsoft/DirectXShaderCompiler/commit/37ed613864cdc269d8b1fc0e40ecd5aa4a7f2905
git reset -- .
rem variables in subroutines called from multiple functions
git add lib/DxilDia/DxcPixLiveVariables.cpp
git add lib/DxilDia/DxilDiaSession.cpp
rem Instrument ret instructions for shader debugging
git add lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
git restore .
del include\dxc\Support\DxcOptToggles.h