### PR TITLE
PIX: CP of two fixes (vars in inline fns, instrument ret for shader debug)

### DIFF
--- a/lib/DxilDia/DxcPixLiveVariables.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables.cpp
@@ -29,6 +29,58 @@
 
 #include <unordered_map>
 
+// If a function is inlined, then the scope of variables within that function
+// will be that scope. Since many such callers may inline the function, we
+// actually need a "scope" that's unique to each "instance" of that function.
+// The caller's scope would be unique, but would have the undesirable
+// side-effect of smushing all of the function's variables together with the
+// caller's variables, at least from the point of view of PIX. The pair of
+// scopes (the function's and the caller's) is both unique to that particular
+// inlining, and distinct from the caller's scope by itself.
+class UniqueScopeForInlinedFunctions {
+  llvm::DIScope *FunctionScope;
+  llvm::DIScope *InlinedAtScope;
+
+public:
+  bool Valid() const { return FunctionScope != nullptr; }
+  void AscendScopeHierarchy() {
+    // DINamespace has a getScope member (that hides DIScope's)
+    // that returns a DIScope directly, but if that namespace
+    // is at file-level scope, it will return nullptr.
+    if (auto Namespace = llvm::dyn_cast<llvm::DINamespace>(FunctionScope)) {
+      if (auto *ContainingScope = Namespace->getScope()) {
+        FunctionScope = ContainingScope;
+        return;
+      }
+    }
+    const llvm::DITypeIdentifierMap EmptyMap;
+    FunctionScope = FunctionScope->getScope().resolve(EmptyMap);
+  }
+
+  static UniqueScopeForInlinedFunctions Create(llvm::DebugLoc const &DbgLoc,
+                                               llvm::DIScope *FunctionScope) {
+    UniqueScopeForInlinedFunctions ret;
+    ret.FunctionScope = FunctionScope;
+    ret.InlinedAtScope =
+        llvm::dyn_cast_or_null<llvm::DIScope>(DbgLoc.getInlinedAtScope());
+    return ret;
+  }
+
+  bool operator==(const UniqueScopeForInlinedFunctions &o) const {
+    return FunctionScope == o.FunctionScope &&
+           InlinedAtScope == o.InlinedAtScope;
+  }
+
+  std::size_t operator()(const UniqueScopeForInlinedFunctions &k) const {
+    using std::hash;
+    using std::size_t;
+    const uint64_t f = reinterpret_cast<uint64_t>(k.FunctionScope);
+    const uint64_t s = reinterpret_cast<uint64_t>(k.InlinedAtScope);
+    std::hash<uint64_t> h;
+    return (h(f) ^ h(s));
+  }
+};
+
 // ValidateDbgDeclare ensures that all of the bits in
 // [FragmentSizeInBits, FragmentOffsetInBits) are currently
 // not assigned to a dxil alloca register -- i.e., it
@@ -61,7 +113,9 @@ struct dxil_debug_info::LiveVariables::Impl {
   using VariableInfoMap =
       std::unordered_map<llvm::DIVariable *, std::unique_ptr<VariableInfo>>;
 
-  using LiveVarsMap = std::unordered_map<llvm::DIScope *, VariableInfoMap>;
+  using LiveVarsMap =
+      std::unordered_map<UniqueScopeForInlinedFunctions, VariableInfoMap,
+                         UniqueScopeForInlinedFunctions>;
 
   IMalloc *m_pMalloc;
   DxcPixDxilDebugInfo *m_pDxilDebugInfo;
@@ -115,8 +169,9 @@ void dxil_debug_info::LiveVariables::Impl::Init_DbgDeclare(
     return;
   }
 
-  auto *S = Variable->getScope();
-  if (S == nullptr) {
+  auto S = UniqueScopeForInlinedFunctions::Create(DbgDeclare->getDebugLoc(),
+                                                  Variable->getScope());
+  if (!S.Valid()) {
     return;
   }
 
@@ -204,13 +259,12 @@ HRESULT dxil_debug_info::LiveVariables::GetLiveVariablesAtInstruction(
     return E_FAIL;
   }
 
-  llvm::DIScope *S = DL->getScope();
-  if (S == nullptr) {
+  auto S = UniqueScopeForInlinedFunctions::Create(DL, DL->getScope());
+  if (!S.Valid()) {
     return E_FAIL;
   }
 
-  const llvm::DITypeIdentifierMap EmptyMap;
-  while (S != nullptr) {
+  while (S.Valid()) {
     auto it = m_pImpl->m_LiveVarsDbgDeclare.find(S);
     if (it != m_pImpl->m_LiveVarsDbgDeclare.end()) {
       for (const auto &VarAndInfo : it->second) {
@@ -232,7 +286,7 @@ HRESULT dxil_debug_info::LiveVariables::GetLiveVariablesAtInstruction(
         LiveVars.emplace_back(VarAndInfo.second.get());
       }
     }
-    S = S->getScope().resolve(EmptyMap);
+    S.AscendScopeHierarchy();
   }
   for (const auto &VarAndInfo : m_pImpl->m_LiveGlobalVarsDbgDeclare) {
     if (!LiveVarsName.insert(VarAndInfo.first->getName()).second) {

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -20,6 +20,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 
+#include "..\DxilPIXPasses\PixPassHelpers.h"
 #include "DxilDia.h"
 #include "DxilDiaEnumTables.h"
 #include "DxilDiaTable.h"
@@ -63,7 +64,9 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
 
   // Build up a linear list of instructions. The index will be used as the
   // RVA.
-  for (llvm::Function &fn : m_module->functions()) {
+  std::vector<llvm::Function *> allInstrumentableFunctions =
+      PIXPassHelpers::GetAllInstrumentableFunctions(*m_dxilModule.get());
+  for (auto fn : allInstrumentableFunctions) {
     for (llvm::inst_iterator it = inst_begin(fn), end = inst_end(fn); it != end;
          ++it) {
       llvm::Instruction &i = *it;

--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -110,6 +110,7 @@ enum DebugShaderModifierRecordType {
   DebugShaderModifierRecordTypeRegisterRelativeIndex0,
   DebugShaderModifierRecordTypeRegisterRelativeIndex1,
   DebugShaderModifierRecordTypeRegisterRelativeIndex2,
+  DebugShaderModifierRecordTypeDXILStepTerminator = 250,
   DebugShaderModifierRecordTypeDXILStepVoid = 251,
   DebugShaderModifierRecordTypeDXILStepFloat = 252,
   DebugShaderModifierRecordTypeDXILStepUint32 = 253,
@@ -834,7 +835,8 @@ void DxilDebugInstrumentation::addStepEntryForType(
   addDebugEntryValue(BC, values.InvocationId);
   addDebugEntryValue(BC, BC.HlslOP->GetU32Const(InstNum));
 
-  if (RecordType != DebugShaderModifierRecordTypeDXILStepVoid) {
+  if (RecordType != DebugShaderModifierRecordTypeDXILStepVoid &&
+      RecordType != DebugShaderModifierRecordTypeDXILStepTerminator) {
     addDebugEntryValue(BC, V);
 
     IRBuilder<> &B = BC.Builder;
@@ -886,15 +888,18 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
     return;
   }
 
-  std::uint32_t RegNum;
-  if (!pix_dxil::PixDxilReg::FromInst(Inst, &RegNum)) {
-    return;
-  }
-
   std::uint32_t InstNum;
   if (!pix_dxil::PixDxilInstNum::FromInst(Inst, &InstNum)) {
     return;
   }
+
+  std::uint32_t RegNum;
+  if (!pix_dxil::PixDxilReg::FromInst(Inst, &RegNum))
+    if (Inst->getOpcode() == Instruction::Ret) {
+      addStepEntryForType<void>(DebugShaderModifierRecordTypeDXILStepTerminator,
+                                BC, InstNum, nullptr, 0, 0);
+      return;
+    }
 
   addStepDebugEntryValue(BC, InstNum, Inst, RegNum, BC.Builder.getInt32(0));
 }

--- a/tools/clang/test/HLSLFileCheck/pix/DebugInstrumentRet.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DebugInstrumentRet.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_3 %s | %opt -S -S -dxil-annotate-with-virtual-regs -hlsl-dxil-debug-instrumentation,parameter0=10,parameter1=20,parameter2=30 | %FileCheck %s
+
+
+
+
+// The ret's instruction number should be 4 (the last integer on this line):
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %PIX_DebugUAV_Handle, i32 {{.*}}, i32 undef, i32 4
+// But we'll check that instruction number:
+// CHECK: ret void, !pix-dxil-inst-num [[RetInstNum:![0-9]+]]
+// CHECK-DAG: [[RetInstNum]] = !{i32 3, i32 4}
+
+
+float4 main() : SV_Target {
+  return float4(0, 0, 0, 0);
+}


### PR DESCRIPTION
These are two fixes needed for a point release of WinPIX
Original PRs:
https://github.com/microsoft/DirectXShaderCompiler/pull/6033
https://github.com/microsoft/DirectXShaderCompiler/pull/5954

Since PixDiaTest.cpp would require bringing over a whole bunch of changes that were made for the linux build, I elected to remove that file from the CP. These commands were used to generate this PR:
git cherry-pick -n -x 2c19e8121b5290e7310db5bc98242dddf98e9e7b
git rm tools/clang/unittests/HLSL/PixDiaTest.cpp
git commit -am "CP of 2c19e8121b5290e7310db5bc98242dddf98e9e7b without PixDiaTest.cpp"
git cherry-pick -x 5ffdf1452748491d13b77d49702c0cb8b2471bbe
