### PR TITLE
[SPIR-V] disable validation on error

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -865,6 +865,8 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
 
   // Output the constructed module.
   std::vector<uint32_t> m = spvBuilder.takeModule();
+  if (context.getDiagnostics().hasErrorOccurred())
+    return;
 
   // Check the existance of Texture and Sampler with
   // [[vk::combinedImageSampler]] for the same descriptor set and binding.

--- a/tools/clang/test/CodeGenSPIRV_Lit/error.no.validation.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/error.no.validation.hlsl
@@ -1,0 +1,24 @@
+// RUN: not %dxc -T cs_6_6 -E main -enable-16bit-types %s -spirv 2>&1 | FileCheck %s
+
+// This test is to make sure if the SPIR-V code generation returned an
+// error, the compilation fails, but the validation is not run.
+// If the validation runs on incomplete code, the user might get confused
+// as validation error after compilation are considered to be a actual bug.
+
+RWBuffer<half> a;
+
+RWBuffer<half> b;
+
+struct S {
+  float a;
+};
+
+// CHECK: error: cannot instantiate RWBuffer with struct type 'S'
+RWBuffer<S> buff;
+
+[numthreads(1, 1, 1)]
+void main() {
+// CHECK-NOT: fatal error: generated SPIR-V is invalid
+  a[0] = b[0];
+}
+


### PR DESCRIPTION
When the codegen fails, it shows an error, but the SPIR-V validation still runs. Because the generation fails, the generated SPIR-V code could be invalid without it being a compiler bug. But the validation error message could confuse the user as it says this is a DXC bug.