### PR TITLE
build: add missing include file

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
+++ b/tools/clang/lib/CodeGen/CGHLSLMSHelper.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "dxc/DXIL/DxilCBuffer.h"
+#include "dxc/DXIL/DxilNodeProps.h"
 #include "dxc/Support/HLSLVersion.h"
 #include "clang/Basic/SourceLocation.h"
 #include "llvm/ADT/MapVector.h"


### PR DESCRIPTION
NodeInputRecordProps is used in this file, but the corresponding header is not directly included. This breaks out build.