### PR TITLE
[SPIR-V] Enable vk::ext_extension and vk::ext_capability for variables

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1294,7 +1294,7 @@ def VKBinding : InheritableAttr {
 
 def VKCapabilityExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_capability">];
-  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var], ErrorDiag>;
   let Args = [IntArgument<"capability">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];
@@ -1334,7 +1334,7 @@ def VKDecorateStringExt : InheritableAttr {
 
 def VKExtensionExt : InheritableAttr {
   let Spellings = [CXX11<"vk", "ext_extension">];
-  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let Subjects = SubjectList<[Function, Var], ErrorDiag>;
   let Args = [StringArgument<"name">];
   let LangOpts = [SPIRV];
   let Documentation = [Undocumented];

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -956,6 +956,12 @@ DeclResultIdMapper::getDeclSpirvInfo(const ValueDecl *decl) const {
 SpirvInstruction *DeclResultIdMapper::getDeclEvalInfo(const ValueDecl *decl,
                                                       SourceLocation loc,
                                                       SourceRange range) {
+  if (decl->hasAttr<VKExtensionExtAttr>() ||
+      decl->hasAttr<VKCapabilityExtAttr>()) {
+    theEmitter.createSpirvIntrInstExt(decl->getAttrs(), QualType(),
+                                      /* spvArgs */ {}, /* isInst */ false,
+                                      loc);
+  }
   if (hlsl::IsHLSLDynamicResourceType(decl->getType()) ||
       hlsl::IsHLSLDynamicSamplerType(decl->getType())) {
     emitError("HLSL object %0 not yet supported with -spirv",

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -14007,11 +14007,12 @@ SpirvEmitter::processRayQueryIntrinsics(const CXXMemberCallExpr *expr,
   return retVal;
 }
 
-SpirvInstruction *SpirvEmitter::createSpirvIntrInstExt(
-    llvm::ArrayRef<const Attr *> attrs, QualType retType,
-    const llvm::SmallVectorImpl<SpirvInstruction *> &spvArgs, bool isInstr,
-    SourceLocation loc) {
-  llvm::SmallVector<uint32_t, 2> capbilities;
+SpirvInstruction *
+SpirvEmitter::createSpirvIntrInstExt(llvm::ArrayRef<const Attr *> attrs,
+                                     QualType retType,
+                                     llvm::ArrayRef<SpirvInstruction *> spvArgs,
+                                     bool isInstr, SourceLocation loc) {
+  llvm::SmallVector<uint32_t, 2> capabilities;
   llvm::SmallVector<llvm::StringRef, 2> extensions;
   llvm::StringRef instSet = "";
   // For [[vk::ext_type_def]], we use dummy OpNop with no semantic meaning,
@@ -14019,7 +14020,7 @@ SpirvInstruction *SpirvEmitter::createSpirvIntrInstExt(
   uint32_t op = static_cast<unsigned>(spv::Op::OpNop);
   for (auto &attr : attrs) {
     if (auto capAttr = dyn_cast<VKCapabilityExtAttr>(attr)) {
-      capbilities.push_back(capAttr->getCapability());
+      capabilities.push_back(capAttr->getCapability());
     } else if (auto extAttr = dyn_cast<VKExtensionExtAttr>(attr)) {
       extensions.push_back(extAttr->getName());
     }
@@ -14032,7 +14033,7 @@ SpirvInstruction *SpirvEmitter::createSpirvIntrInstExt(
   }
 
   SpirvInstruction *retVal = spvBuilder.createSpirvIntrInstExt(
-      op, retType, spvArgs, extensions, instSet, capbilities, loc);
+      op, retType, spvArgs, extensions, instSet, capabilities, loc);
   if (!retVal)
     return nullptr;
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -106,10 +106,10 @@ public:
 
   /// Create SpirvIntrinsicInstruction for arbitrary SPIR-V instructions
   /// specified by [[vk::ext_instruction(..)]] or [[vk::ext_type_def(..)]]
-  SpirvInstruction *createSpirvIntrInstExt(
-      llvm::ArrayRef<const Attr *> attrs, QualType retType,
-      llvm::ArrayRef<SpirvInstruction *> spvArgs, bool isInstr,
-      SourceLocation loc);
+  SpirvInstruction *
+  createSpirvIntrInstExt(llvm::ArrayRef<const Attr *> attrs, QualType retType,
+                         llvm::ArrayRef<SpirvInstruction *> spvArgs,
+                         bool isInstr, SourceLocation loc);
 
 private:
   void doFunctionDecl(const FunctionDecl *decl);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -104,6 +104,13 @@ public:
                : (var->getAttr<HLSLGroupSharedAttr>() != nullptr);
   }
 
+  /// Create SpirvIntrinsicInstruction for arbitrary SPIR-V instructions
+  /// specified by [[vk::ext_instruction(..)]] or [[vk::ext_type_def(..)]]
+  SpirvInstruction *createSpirvIntrInstExt(
+      llvm::ArrayRef<const Attr *> attrs, QualType retType,
+      llvm::ArrayRef<SpirvInstruction *> spvArgs, bool isInstr,
+      SourceLocation loc);
+
 private:
   void doFunctionDecl(const FunctionDecl *decl);
   void doVarDecl(const VarDecl *decl);
@@ -685,13 +692,6 @@ private:
   /// Process ray query intrinsics
   SpirvInstruction *processRayQueryIntrinsics(const CXXMemberCallExpr *expr,
                                               hlsl::IntrinsicOp opcode);
-
-  /// Create SpirvIntrinsicInstruction for arbitrary SPIR-V instructions
-  /// specified by [[vk::ext_instruction(..)]] or [[vk::ext_type_def(..)]]
-  SpirvInstruction *createSpirvIntrInstExt(
-      llvm::ArrayRef<const Attr *> attrs, QualType retType,
-      const llvm::SmallVectorImpl<SpirvInstruction *> &spvArgs, bool isInstr,
-      SourceLocation loc);
   /// Process spirv intrinsic instruction
   SpirvInstruction *processSpvIntrinsicCallExpr(const CallExpr *expr);
 

--- a/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.capability.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.capability.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl -Vd %s -spirv | FileCheck %s
+
+// CHECK: OpCapability SampleMaskPostDepthCoverage
+
+[[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
+int val;
+
+void main() {
+  int local = val;
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.extension.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.extension.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK: OpExtension "another_extension"
+// CHECK: OpExtension "some_extension"
+
+[[vk::ext_extension("some_extension"), vk::ext_extension("another_extension")]]
+int val;
+
+void main() {
+  int local = val;
+}

--- a/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.extension.unused.hlsl
+++ b/tools/clang/test/CodeGenSPIRV_Lit/spv.inline.extension.unused.hlsl
@@ -1,0 +1,11 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
+
+// CHECK-NOT: OpExtension "some_extension"
+// CHECK-NOT: OpCapability SampleMaskPostDepthCoverage
+
+[[vk::ext_extension("some_extension")]]
+[[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
+int val;
+
+void main() {
+}


### PR DESCRIPTION
`ext_extension` and `ext_capability` can only be added to functions at the moment. This PR enables adding them to variable declarations, so that using the variable results in the extensions and capabilities being added to the module. This is useful for the builtin variable syntax proposed in https://github.com/microsoft/hlsl-specs/pull/129.