### PR TITLE
PIX: CP of shader debugger regression

### DIFF
--- a/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
+++ b/lib/DxilPIXPasses/DxilDebugInstrumentation.cpp
@@ -894,13 +894,12 @@ void DxilDebugInstrumentation::addStepDebugEntry(BuilderContext &BC,
   }
 
   std::uint32_t RegNum;
-  if (!pix_dxil::PixDxilReg::FromInst(Inst, &RegNum))
-    if (Inst->getOpcode() == Instruction::Ret) {
+  if (!pix_dxil::PixDxilReg::FromInst(Inst, &RegNum)) {
+    if (Inst->getOpcode() == Instruction::Ret)
       addStepEntryForType<void>(DebugShaderModifierRecordTypeDXILStepTerminator,
                                 BC, InstNum, nullptr, 0, 0);
-      return;
-    }
-
+    return;
+  }
   addStepDebugEntryValue(BC, InstNum, Inst, RegNum, BC.Builder.getInt32(0));
 }
 

--- a/tools/clang/test/HLSLFileCheck/pix/DontDebugNoRegnum.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/DontDebugNoRegnum.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc -Tlib_6_6 %s | %opt -S -dxil-annotate-with-virtual-regs -hlsl-dxil-debug-instrumentation | %FileCheck %s
+
+// Check that the instrumentation does NOT instrument an instruction that has no dxil-inst-num metadata
+// The load instruction should not be instrumented. If it is, we can expect an "atomicBinOp", emitted
+// by the instrumentation, to be generated before the handle value is used, so assert that there
+// is no such atomicBinOp:
+
+// CHECK: [[HandleNum:%[0-9]+]] = load %dx.types.Handle,
+// CHECK-NOT: call i32 @dx.op.atomicBinOp.i32(i32 78
+// CHECK: @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle [[HandleNum]]
+
+RWByteAddressBuffer buffer : register(u0);
+
+[shader("raygeneration")] 
+void main() {
+  buffer.Store(0, 42);
+}


### PR DESCRIPTION
CP of main PR (#6053), regression caused by main PR https://github.com/microsoft/DirectXShaderCompiler/pull/6033

The misplacement of that "return" in DxilDebugInstrumentation.cpp meant that a thread would continue to the following call to addStepDebugEntryValue, even if pix_dxil::PixDxilReg::FromInst had failed (i.e. returned false), which means that RegNum is not valid (although initialized to 0).

This meant that PIX was instrumenting a bunch of void-return DXIL instructions that it shouldn't have.
Didn't think to test that it WASN'T instrumenting instructions, but herein is added a test to do just that.

(cherry picked from commit 71afbcc7cf5d7c3631a4aef9979762fa120c7c0b)