### PR TITLE
CMake: fix FindD3D12.cmake when using non-VS generators

### DIFF
--- a/cmake/modules/FindD3D12.cmake
+++ b/cmake/modules/FindD3D12.cmake
@@ -1,7 +1,18 @@
 # Find the Win10 SDK path.
 if ("$ENV{WIN10_SDK_PATH}$ENV{WIN10_SDK_VERSION}" STREQUAL "" )
   get_filename_component(WIN10_SDK_PATH "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE CACHE)
-  set (WIN10_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+  if (CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+    set (WIN10_SDK_VERSION ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+  else()
+    # CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION may not be defined if, for example,
+    # the Ninja generator is used instead of Visual Studio. Attempt to retrieve the
+    # most recent SDK version from the list of paths under "${WIN10_SDK_PATH}/Include/".
+    file(GLOB sdk_dirs RELATIVE "${WIN10_SDK_PATH}/Include/" "${WIN10_SDK_PATH}/Include/10.*")
+    if (sdk_dirs)
+      list(POP_BACK sdk_dirs WIN10_SDK_VERSION)
+    endif()
+    unset(sdk_dirs)
+  endif()
 elseif(TRUE)
   set (WIN10_SDK_PATH $ENV{WIN10_SDK_PATH})
   set (WIN10_SDK_VERSION $ENV{WIN10_SDK_VERSION})


### PR DESCRIPTION
FindD3D12.cmake sets WIN10_SDK_VERSION to
CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION; however, this latter variable is only defined when using a Visual Studio CMake generator. When using Ninja instead, for example, this variable will be empty, and WIN10_SDK_VERSION will remain unset.

This change detects when CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION and attempts to retrieve the latest SDK by listing directories under ${WIN10_SDK_PATH}/Include.