### PR TITLE
Refactor create stage vars

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3326,14 +3326,13 @@ bool DeclResultIdMapper::createStageVars(
   }
 
   if (asInput) {
-    *value =
-        createStructInputVar(type, sigPoint, arraySize, namePrefix,
-                                asNoInterp, noWriteBack, semanticToUse, loc);
+    *value = createStructInputVar(type, sigPoint, arraySize, namePrefix,
+                                  asNoInterp, noWriteBack, semanticToUse, loc);
     return (*value) != nullptr;
   } else {
     return createStructOutputVar(type, sigPoint, arraySize, invocationId,
-                                    namePrefix, semanticToUse, noWriteBack,
-                                    asNoInterp, *value, loc);
+                                 namePrefix, semanticToUse, noWriteBack,
+                                 asNoInterp, *value, loc);
   }
 }
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2601,7 +2601,7 @@ bool DeclResultIdMapper::decorateResourceCoherent() {
   return true;
 }
 
-bool DeclResultIdMapper::createStructureOutputVar(
+bool DeclResultIdMapper::createStructOutputVar(
     QualType type, const hlsl::SigPoint *sigPoint, uint32_t arraySize,
     llvm::Optional<SpirvInstruction *> invocationId,
     const llvm::StringRef namePrefix, SemanticInfo *semantic, bool noWriteBack,
@@ -2658,7 +2658,7 @@ bool DeclResultIdMapper::createStructureOutputVar(
   return true;
 }
 
-SpirvInstruction *DeclResultIdMapper::createStructureInputVar(
+SpirvInstruction *DeclResultIdMapper::createStructInputVar(
     QualType type, const hlsl::SigPoint *sigPoint, uint32_t arraySize,
     const llvm::StringRef namePrefix, bool asNoInterp, bool noWriteBack,
     SemanticInfo *semanticToUse, SourceLocation loc) {
@@ -3327,11 +3327,11 @@ bool DeclResultIdMapper::createStageVars(
 
   if (asInput) {
     *value =
-        createStructureInputVar(type, sigPoint, arraySize, namePrefix,
+        createStructInputVar(type, sigPoint, arraySize, namePrefix,
                                 asNoInterp, noWriteBack, semanticToUse, loc);
     return (*value) != nullptr;
   } else {
-    return createStructureOutputVar(type, sigPoint, arraySize, invocationId,
+    return createStructOutputVar(type, sigPoint, arraySize, invocationId,
                                     namePrefix, semanticToUse, noWriteBack,
                                     asNoInterp, *value, loc);
   }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,9 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  SpirvVariable *replaceInstanceIndexWithInstanceId(
+      const NamedDecl *decl, SpirvVariable *instanceIndexVar,
+      SpirvVariable *baseInstanceVar, QualType type);
   SpirvVariable *getBaseInstanceVariable(const NamedDecl *decl,
                                          QualType evalType, QualType type,
                                          SemanticInfo *semanticToUse,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,11 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  QualType getTypeForSpirvStageVariable(QualType type,
+                                        hlsl::Semantic::Kind semanticKind,
+                                        hlsl::SigPoint::Kind sigPointKind,
+                                        const NamedDecl *decl,
+                                        uint32_t arraySize);
   bool validateShaderStageVarType(hlsl::Semantic::Kind semanticKind,
                                   QualType type, clang::SourceLocation loc);
   bool validateShaderStageVar(SemanticInfo *semantic,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,16 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  SpirvVariable *getBaseInstanceVariable(const NamedDecl *decl,
+                                         QualType evalType, QualType type,
+                                         SemanticInfo *semanticToUse,
+                                         const hlsl::SigPoint *sigPoint);
+  SpirvVariable *createSpirvStageVariable(const hlsl::SigPoint *sigPoint,
+                                          SemanticInfo *semanticToUse,
+                                          const NamedDecl *decl,
+                                          QualType evalType, QualType type,
+                                          bool asNoInterp,
+                                          const llvm::StringRef namePrefix);
   QualType getTypeForSpirvStageVariable(QualType type,
                                         hlsl::Semantic::Kind semanticKind,
                                         hlsl::SigPoint::Kind sigPointKind,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -672,12 +672,12 @@ private:
   // interpolated. value: The value to be written to the newly create variable.
   // loc: The location of the variable in the source code.
   bool createStructOutputVar(QualType type, const hlsl::SigPoint *sigPoint,
-                                uint32_t arraySize,
-                                llvm::Optional<SpirvInstruction *> invocationId,
-                                const llvm::StringRef namePrefix,
-                                SemanticInfo *semantic, bool noWriteBack,
-                                bool asNoInterp, SpirvInstruction *value,
-                                SourceLocation loc);
+                             uint32_t arraySize,
+                             llvm::Optional<SpirvInstruction *> invocationId,
+                             const llvm::StringRef namePrefix,
+                             SemanticInfo *semantic, bool noWriteBack,
+                             bool asNoInterp, SpirvInstruction *value,
+                             SourceLocation loc);
 
   // Creates a variable to represent the input variable, which must be a
   // structure. The value is loaded and the instruction with the final value is
@@ -693,9 +693,9 @@ private:
   // loc: The location of the variable in the source code.
   SpirvInstruction *
   createStructInputVar(QualType type, const hlsl::SigPoint *sigPoint,
-                          uint32_t arraySize, const llvm::StringRef namePrefix,
-                          bool asNoInterp, bool noWriteBack,
-                          SemanticInfo *semantic, SourceLocation loc);
+                       uint32_t arraySize, const llvm::StringRef namePrefix,
+                       bool asNoInterp, bool noWriteBack,
+                       SemanticInfo *semantic, SourceLocation loc);
 
   // Store `value` to the shader output variable `varInstr`. Since the type
   // could be different, other data is used to know how to convert `value` into

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,13 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  bool createStructureOutputVar(QualType type, const hlsl::SigPoint *sigPoint,
+                                uint32_t arraySize,
+                                llvm::Optional<SpirvInstruction *> invocationId,
+                                const llvm::StringRef namePrefix,
+                                SemanticInfo *semanticToUse, bool noWriteBack,
+                                bool asNoInterp, SpirvInstruction *value,
+                                SourceLocation loc);
   SpirvInstruction *createStructureInputVar(
       QualType type, const hlsl::SigPoint *sigPoint, uint32_t arraySize,
       llvm::Optional<SpirvInstruction *> invocationId,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -786,16 +786,23 @@ private:
                                         const NamedDecl *decl,
                                         uint32_t arraySize);
 
-  // Returns true if the type and semantic kind are compatible. Issues an error
-  // and returns false otherwise.
-  bool validateShaderStageVarType(hlsl::Semantic::Kind semanticKind,
-                                  QualType type, clang::SourceLocation loc);
-
   // Returns true if all of the information is consistent with a valid shader
   // stage variable. Issues an error and returns false otherwise.
   bool validateShaderStageVar(SemanticInfo *semantic,
                               const hlsl::SigPoint *sigPoint,
                               const NamedDecl *decl, QualType type);
+
+  /// Returns true if all vk:: attributes usages are valid.
+  bool validateVKAttributes(const NamedDecl *decl);
+
+  /// Returns true if all vk::builtin usages are valid.
+  bool validateVKBuiltins(const NamedDecl *decl,
+                          const hlsl::SigPoint *sigPoint);
+
+  // Returns true if the type and semantic kind are compatible. Issues an error
+  // and returns false otherwise.
+  bool validateShaderStageVarType(hlsl::Semantic::Kind semanticKind,
+                                  QualType type, clang::SourceLocation loc);
 
   // Returns true if the semantic can be used with the given signature point.
   // The declaration is used to get the builtin attribute to augment the
@@ -811,13 +818,6 @@ private:
   SpirvVariable *createSpirvStageVar(StageVar *, const NamedDecl *decl,
                                      const llvm::StringRef name,
                                      SourceLocation);
-
-  /// Returns true if all vk:: attributes usages are valid.
-  bool validateVKAttributes(const NamedDecl *decl);
-
-  /// Returns true if all vk::builtin usages are valid.
-  bool validateVKBuiltins(const NamedDecl *decl,
-                          const hlsl::SigPoint *sigPoint);
 
   /// Methods for creating counter variables associated with the given decl.
 

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -622,11 +622,11 @@ private:
       llvm::StringRef typeName, llvm::StringRef varName);
 
   /// Creates all the stage variables mapped from semantics on the given decl.
-  /// Returns true on sucess.
+  /// Returns true on success.
   ///
   /// If decl is of struct type, this means flattening it and create stand-
   /// alone variables for each field. If arraySize is not zero, the created
-  /// stage variables will have an additional arrayness over its original type.
+  /// stage variables will be arrays of the original type and the given size.
   /// This is for supporting HS/DS/GS, which takes in primitives containing
   /// multiple vertices. asType should be the type we are treating decl as;
   /// For HS/DS/GS, the outermost arrayness should be discarded and use
@@ -651,6 +651,15 @@ private:
                        llvm::Optional<SpirvInstruction *> invocationId,
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
+
+  bool validateShaderStageVarType(hlsl::Semantic::Kind semanticKind,
+                                  QualType type, clang::SourceLocation loc);
+  bool validateShaderStageVar(SemanticInfo *semantic,
+                              const hlsl::SigPoint *sigPoint,
+                              const NamedDecl *decl, QualType type);
+  bool isValidSemanticInShaderModel(hlsl::Semantic::Kind semanticKind,
+                                    hlsl::SigPoint::Kind sigPointKind,
+                                    const NamedDecl *decl);
 
   /// Creates the SPIR-V variable instruction for the given StageVar and returns
   /// the instruction. Also sets whether the StageVar is a SPIR-V builtin and

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,11 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  SpirvInstruction *createStructureInputVar(
+      QualType type, const hlsl::SigPoint *sigPoint, uint32_t arraySize,
+      llvm::Optional<SpirvInstruction *> invocationId,
+      const llvm::StringRef namePrefix, bool asNoInterp, bool noWriteBack,
+      SemanticInfo *semanticToUse, SourceLocation loc);
   void storeToShaderInputVariable(
       SpirvVariable *varInstr, hlsl::Semantic::Kind semanticKind, QualType type,
       SpirvInstruction *value, llvm::Optional<SpirvInstruction *> invocationId,

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,52 +652,154 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  // Creates a variable to represent the output variable, which must be a
+  // structure. If `noWriteBack` is false, then `value` will be written to the
+  // new variable. Returns true if successful.
+  //
+  // TODO(s-perron): All of the parameters associated with the HLSL
+  // representation of the variable should be grouped in a struct. This struct
+  // should be used in all of the function below to reduce the number of
+  // parameters.
+  //
+  // type: The type of the variable in the HLSL.
+  // sigPoint: The signature point for the variable.
+  // arraySize: The size of the array when the SPIR-V variable must become an
+  // array of type, 0 otherwise. invocationId: when arraySize is not 0,
+  // invocationId is the index at which `value` should be written. namePrefix: a
+  // prefix to apply to the name of the variable. semantic: the HLSL semantic
+  // for this variable. noWriteBack: A flag to indicate if the variable should
+  // be written or not. asNoInterp: True if the variable is not to be
+  // interpolated. value: The value to be written to the newly create variable.
+  // loc: The location of the variable in the source code.
   bool createStructureOutputVar(QualType type, const hlsl::SigPoint *sigPoint,
                                 uint32_t arraySize,
                                 llvm::Optional<SpirvInstruction *> invocationId,
                                 const llvm::StringRef namePrefix,
-                                SemanticInfo *semanticToUse, bool noWriteBack,
+                                SemanticInfo *semantic, bool noWriteBack,
                                 bool asNoInterp, SpirvInstruction *value,
                                 SourceLocation loc);
-  SpirvInstruction *createStructureInputVar(
-      QualType type, const hlsl::SigPoint *sigPoint, uint32_t arraySize,
-      llvm::Optional<SpirvInstruction *> invocationId,
-      const llvm::StringRef namePrefix, bool asNoInterp, bool noWriteBack,
-      SemanticInfo *semanticToUse, SourceLocation loc);
-  void storeToShaderInputVariable(
+
+  // Creates a variable to represent the input variable, which must be a
+  // structure. The value is loaded and the instruction with the final value is
+  // return.
+  //
+  // type: The type of the variable in the HLSL.
+  // sigPoint: The signature point for the variable.
+  // arraySize: The size of the array when the SPIR-V variable must become an
+  // array of type, 0 otherwise. namePrefix: a prefix to apply to the name of
+  // the variable. asNoInterp: True if the variable is not to be interpolated.
+  // noWriteBack: A flag to indicate if the variable should be written or not.
+  // semantic: the HLSL semantic for this variable.
+  // loc: The location of the variable in the source code.
+  SpirvInstruction *
+  createStructureInputVar(QualType type, const hlsl::SigPoint *sigPoint,
+                          uint32_t arraySize, const llvm::StringRef namePrefix,
+                          bool asNoInterp, bool noWriteBack,
+                          SemanticInfo *semantic, SourceLocation loc);
+
+  // Store `value` to the shader output variable `varInstr`. Since the type
+  // could be different, other data is used to know how to convert `value` into
+  // the correct type for `varInstr`.
+  //
+  // varInstr: the output variable that corresponds to `decl`. It must not be a
+  // struct. semanticKind: the HLSL semantic for this variable. type: The type
+  // of the variable in the HLSL. value: The value to be written to the create
+  // variable. invocationId: when arraySize is not 0, invocationId is the index
+  // at which `value` should be written. sigPointKind: The signature point for
+  // the variable. decl: The original declaration of the variable. loc: The
+  // location of the variable in the source code.
+  void storeToShaderOutputVariable(
       SpirvVariable *varInstr, hlsl::Semantic::Kind semanticKind, QualType type,
       SpirvInstruction *value, llvm::Optional<SpirvInstruction *> invocationId,
       hlsl::SigPoint::Kind sigPointKind, const NamedDecl *decl,
       SourceLocation loc);
+
+  // Loads shader input variable `varInstr`, and modifies it to match `type`.
+  // Other data is used to know how to convert `varInstr` into the correct type.
+  //
+  // varInstr: the input variable that corresponds to `decl`. It must not be a
+  // struct. semanticKind: the HLSL semantic for this variable. sigPointKind:
+  // The signature point for the variable. type: The type of the variable in the
+  // HLSL. decl: The original declaration of the variable. loc: The location of
+  // the variable in the source code.
   SpirvInstruction *loadShaderInputVariable(SpirvVariable *varInstr,
                                             hlsl::Semantic::Kind semanticKind,
                                             hlsl::SigPoint::Kind sigPointKind,
                                             QualType type,
                                             const NamedDecl *decl,
                                             SourceLocation loc);
-  SpirvVariable *replaceInstanceIndexWithInstanceId(
-      const NamedDecl *decl, SpirvVariable *instanceIndexVar,
-      SpirvVariable *baseInstanceVar, QualType type);
-  SpirvVariable *getBaseInstanceVariable(const NamedDecl *decl,
-                                         QualType evalType, QualType type,
-                                         SemanticInfo *semanticToUse,
+
+  // Creates a function scope variable to represent the "SV_InstanceID"
+  // semantic, which it not immediately available in SPIR-V. Its value will be
+  // set by subtracting the values of the given InstanceIndex and base instance
+  // variables.
+  //
+  // instanceIndexVar: The SPIR-V input variable that decorated with
+  // InstanceIndex baseInstanceVar: The SPIR-V input variable that is decorated
+  // with BaseInstance.
+  SpirvVariable *getInstanceIdFromIndexAndBase(SpirvVariable *instanceIndexVar,
+                                               SpirvVariable *baseInstanceVar);
+
+  // Creates and returns a variable that is the BaseInstance builtin input. The
+  // variable is also added to the list of stage variable `this->stageVars`. Its
+  // type will be a 32-bit integer.
+  //
+  // The semantic is a lie. We currently give it the semantic for the
+  // InstanceID. I'm not sure what would happen if we did not use a semantic, or
+  // tried to generate the correct one. I'm guessing there would be some issue
+  // with reflection.
+  //
+  // semantic: the semantic to attach to this variable
+  // sigPoint: the signature point identifying which shader stage the variable
+  // will be used in.
+  SpirvVariable *getBaseInstanceVariable(SemanticInfo *semantic,
                                          const hlsl::SigPoint *sigPoint);
+
+  // Creates and return a new interface variable from the information provided.
+  // The new variable with be add to `this->StageVars`.
+  //
+  //
+  // sigPoint: the signature point identifying which shader stage the variable
+  // will be used in. semantic: the HLSL semantic for the variable. decl: the
+  // declaration of the variable. type: the HLSL type of the variable arraySize:
+  // the size of the array if `type` should be turned into an array. 0 if `type`
+  // should not be turned into and array.
   SpirvVariable *createSpirvInterfaceVariable(const hlsl::SigPoint *sigPoint,
-                                              SemanticInfo *semanticToUse,
+                                              SemanticInfo *semantic,
                                               const NamedDecl *decl,
-                                              QualType evalType, QualType type,
+                                              QualType type, uint32_t arraySize,
                                               bool asNoInterp,
                                               const llvm::StringRef namePrefix);
+
+  // Returns the type that the SPIR-V input or output variable must have to
+  // correspond to a variable with the given information.
+  //
+  // type: The type of the variable in HLSL.
+  // semanticKind: The semantic attached to the variable.
+  // sigPointKind: The signature point (shader, input or output) of the
+  // variable. decl: The declaration of the variable. arraySize: The size of the
+  // array the variable should be converted to. 0 if it should not be turned
+  // into an array.
   QualType getTypeForSpirvStageVariable(QualType type,
                                         hlsl::Semantic::Kind semanticKind,
                                         hlsl::SigPoint::Kind sigPointKind,
                                         const NamedDecl *decl,
                                         uint32_t arraySize);
+
+  // Returns true if the type and semantic kind are compatible. Issues an error
+  // and returns false otherwise.
   bool validateShaderStageVarType(hlsl::Semantic::Kind semanticKind,
                                   QualType type, clang::SourceLocation loc);
+
+  // Returns true if all of the information is consistent with a valid shader
+  // stage variable. Issues an error and returns false otherwise.
   bool validateShaderStageVar(SemanticInfo *semantic,
                               const hlsl::SigPoint *sigPoint,
                               const NamedDecl *decl, QualType type);
+
+  // Returns true if the semantic can be used with the given signature point.
+  // The declaration is used to get the builtin attribute to augment the
+  // semantic.
   bool isValidSemanticInShaderModel(hlsl::Semantic::Kind semanticKind,
                                     hlsl::SigPoint::Kind sigPointKind,
                                     const NamedDecl *decl);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -671,7 +671,7 @@ private:
   // be written or not. asNoInterp: True if the variable is not to be
   // interpolated. value: The value to be written to the newly create variable.
   // loc: The location of the variable in the source code.
-  bool createStructureOutputVar(QualType type, const hlsl::SigPoint *sigPoint,
+  bool createStructOutputVar(QualType type, const hlsl::SigPoint *sigPoint,
                                 uint32_t arraySize,
                                 llvm::Optional<SpirvInstruction *> invocationId,
                                 const llvm::StringRef namePrefix,
@@ -692,7 +692,7 @@ private:
   // semantic: the HLSL semantic for this variable.
   // loc: The location of the variable in the source code.
   SpirvInstruction *
-  createStructureInputVar(QualType type, const hlsl::SigPoint *sigPoint,
+  createStructInputVar(QualType type, const hlsl::SigPoint *sigPoint,
                           uint32_t arraySize, const llvm::StringRef namePrefix,
                           bool asNoInterp, bool noWriteBack,
                           SemanticInfo *semantic, SourceLocation loc);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -652,6 +652,17 @@ private:
                        SpirvInstruction **value, bool noWriteBack,
                        SemanticInfo *inheritSemantic, bool asNoInterp = false);
 
+  void storeToShaderInputVariable(
+      SpirvVariable *varInstr, hlsl::Semantic::Kind semanticKind, QualType type,
+      SpirvInstruction *value, llvm::Optional<SpirvInstruction *> invocationId,
+      hlsl::SigPoint::Kind sigPointKind, const NamedDecl *decl,
+      SourceLocation loc);
+  SpirvInstruction *loadShaderInputVariable(SpirvVariable *varInstr,
+                                            hlsl::Semantic::Kind semanticKind,
+                                            hlsl::SigPoint::Kind sigPointKind,
+                                            QualType type,
+                                            const NamedDecl *decl,
+                                            SourceLocation loc);
   SpirvVariable *replaceInstanceIndexWithInstanceId(
       const NamedDecl *decl, SpirvVariable *instanceIndexVar,
       SpirvVariable *baseInstanceVar, QualType type);
@@ -659,12 +670,12 @@ private:
                                          QualType evalType, QualType type,
                                          SemanticInfo *semanticToUse,
                                          const hlsl::SigPoint *sigPoint);
-  SpirvVariable *createSpirvStageVariable(const hlsl::SigPoint *sigPoint,
-                                          SemanticInfo *semanticToUse,
-                                          const NamedDecl *decl,
-                                          QualType evalType, QualType type,
-                                          bool asNoInterp,
-                                          const llvm::StringRef namePrefix);
+  SpirvVariable *createSpirvInterfaceVariable(const hlsl::SigPoint *sigPoint,
+                                              SemanticInfo *semanticToUse,
+                                              const NamedDecl *decl,
+                                              QualType evalType, QualType type,
+                                              bool asNoInterp,
+                                              const llvm::StringRef namePrefix);
   QualType getTypeForSpirvStageVariable(QualType type,
                                         hlsl::Semantic::Kind semanticKind,
                                         hlsl::SigPoint::Kind sigPointKind,


### PR DESCRIPTION
The `createStageVars` function is very large, and difficult to fix. In support of two bug fixes, I want to refactor the function so try to make the code cleaner.

This change will try to keep the exact same functionality. I believe their could be further simplification after this if needed.