### PR TITLE
Python: fix calls to os.makedirs to avoid existence check races

### DIFF
--- a/utils/hct/hctgen.py
+++ b/utils/hct/hctgen.py
@@ -67,8 +67,7 @@ def writeCodeTag(args):
 
 def openOutput(args):
     outputDir = os.path.dirname(os.path.realpath(args.output))
-    if not os.path.exists(outputDir):
-        os.makedirs(outputDir)
+    os.makedirs(outputDir, exist_ok=True)
     return open(args.output, "w", newline=getNewline(args))
 
 

--- a/utils/hct/hctgettaef.py
+++ b/utils/hct/hctgettaef.py
@@ -10,8 +10,7 @@ zipfile_name = os.path.join(
 src_dir = os.environ["HLSL_SRC_DIR"]
 taef_dir = os.path.join(src_dir, "external", "taef")
 
-if not os.path.isdir(taef_dir):
-    os.makedirs(taef_dir)
+os.makedirs(taef_dir, exist_ok=True)
 
 try:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)


### PR DESCRIPTION
In parallel builds of DXC, hctgen.py in particuilar would sometimes throw an exception from os.makedirs because the directory would already exist. The conditional check for file existence introduces a race when running the script in parallel. Fix this, and all other cases where such conditional checks were done, by using the `exist_ok = True` argument.