### PR TITLE
[CMake] add another hint for DIASDK

### DIFF
--- a/cmake/modules/FindDiaSDK.cmake
+++ b/cmake/modules/FindDiaSDK.cmake
@@ -22,6 +22,7 @@ find_path(DIASDK_INCLUDE_DIR    # Set variable DIASDK_INCLUDE_DIR
           dia2.h                # Find a path with dia2.h
           HINTS "${VS_DIA_INC_PATH}"
           HINTS "${VSWHERE_LATEST}/DIA SDK/include"
+          HINTS "${MSVC_DIA_SDK_DIR}/include"
           DOC "path to DIA SDK header files"
           )
 


### PR DESCRIPTION
Fail to find DIASDK when using VisualStudio "Open a local folder". Both VS_DIA_INC_PATH and VSWHERE_LATEST are empty. But MSVC_DIA_SDK_DIR is set correctly.

Add MSVC_DIA_SDK_DIR/include as hint for DIASDK_INCLUDE_DIR.