### PR TITLE
[SPIRV] Emit OpLine for internally generated SPIR-V wrapper function

### DIFF
--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -262,8 +262,9 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
   // Technically entry function wrappers do not exist in HLSL. They are just
   // created by DXC. We do not want to emit line information for their
   // instructions. To prevent spirv-opt from removing all debug info, we emit
-  // at least a single OpLine to specify the end of the shader.
-  if (inEntryFunctionWrapper && op != spv::Op::OpReturn)
+  // OpLines to specify the beginning and end of the function.
+  if (inEntryFunctionWrapper && 
+      (op != spv::Op::OpReturn && op != spv::Op::OpFunction))
     return;
 
   // Based on SPIR-V spec, OpSelectionMerge must immediately precede either an

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.entry.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.entry.hlsl
@@ -7,6 +7,8 @@ float4 main(float2 a : TEXCOORD0,
             float3 b : NORMAL,
             float4 c : COLOR) : SV_Target {
 // CHECK:                  OpLine [[file]] 6 1
+// CHECK-NEXT: %main = OpFunction %void None
+// CHECK:                  OpLine [[file]] 6 1
 // CHECK-NEXT: %src_main = OpFunction %v4float None
 // CHECK-NEXT:             OpLine [[file]] 6 20
 // CHECK-NEXT:        %a = OpFunctionParameter %_ptr_Function_v2float

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.function.hlsl
@@ -6,7 +6,7 @@
 void foo(in float4 a, out float3 b);
 
 // CHECK:                  OpLine [[file]] 28 1
-// CHECK-NEXT: %src_main = OpFunction %void None
+// CHECK-NEXT: %main = OpFunction %void None
 
 void bar(int a, in float b, inout bool2 c, const float3 d, out uint4 e) {
 }

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
@@ -13,7 +13,9 @@
 // CHECK-SAME: spirv.debug.opline.include-file-3.hlsli
 // CHECK-NEXT: OpSource HLSL 600 [[file3]] "int b;
 
-// CHECK:                  OpLine [[main]] 65 1
+// CHECK:                  OpLine [[main]] 67 1
+// CHECK-NEXT: %main = OpFunction %void None
+// CHECK:                  OpLine [[main]] 67 1
 // CHECK-NEXT: %src_main = OpFunction %void None
 
 #include "spirv.debug.opline.include-file-1.hlsli"
@@ -63,7 +65,7 @@ int callFunction3() {
 }
 
 void main() {
-// CHECK:      OpLine [[main]] 68 3
+// CHECK:      OpLine [[main]] 70 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction1
   callFunction1();
 
@@ -81,11 +83,11 @@ void main() {
   // line
   // in
   // OpSource.
-// CHECK:      OpLine [[main]] 86 3
+// CHECK:      OpLine [[main]] 88 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction2
   callFunction2();
 
-// CHECK:      OpLine [[main]] 90 3
+// CHECK:      OpLine [[main]] 92 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction3
   callFunction3();
 }


### PR DESCRIPTION
This PR improves the experience for profilers and debuggers that consume SPIR-V produced by dxc.  When debugging information is output, additionally note the beginning of the internally generated wrapper function.  This will assign all parameter setup to the entry point declaration, providing context to the user of a shader profiler or debugger.