### PR TITLE
Fixed an OOB that potentially causes a crash

### DIFF
--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -9490,18 +9490,16 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
     return S.NoteOverloadCandidate(Fn);
 
   case ovl_fail_bad_conversion: {
-    unsigned I = (Cand->IgnoreObjectArgument ? 1 : 0);
-    for (unsigned N = Cand->NumConversions; I != N; ++I) {
+    for (unsigned I = (Cand->IgnoreObjectArgument ? 1 : 0),
+                  N = Cand->NumConversions;
+         I != N; ++I) {
       // HLSL Change: check in and out, check out conversions
-      if (Cand->Conversions[I].isInitialized() &&
-          Cand->Conversions[I]
-              .isBad())
+      if (Cand->Conversions[I].isInitialized() && Cand->Conversions[I].isBad())
         return DiagnoseBadConversion(S, Cand, I, Cand->Conversions[I],
                                      OpLoc); // HLSL Change: add OpLoc
       // HLSL Change: check in and out, check out conversions
       if (Cand->OutConversions[I].isInitialized() &&
-          Cand->OutConversions[I]
-              .isBad())
+          Cand->OutConversions[I].isBad())
         return DiagnoseBadConversion(S, Cand, I, Cand->OutConversions[I],
                                      OpLoc); // HLSL Change: add OpLoc
     }

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -9498,6 +9498,7 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
               .isBad())
         return DiagnoseBadConversion(S, Cand, I, Cand->Conversions[I],
                                      OpLoc); // HLSL Change: add OpLoc
+      // HLSL Change: check in and out, check out conversions
       if (Cand->OutConversions[I].isInitialized() &&
           Cand->OutConversions[I]
               .isBad())

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -9492,14 +9492,15 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
   case ovl_fail_bad_conversion: {
     unsigned I = (Cand->IgnoreObjectArgument ? 1 : 0);
     for (unsigned N = Cand->NumConversions; I != N; ++I) {
+      // HLSL Change: check in and out, check out conversions
       if (Cand->Conversions[I].isInitialized() &&
           Cand->Conversions[I]
-              .isBad()) // HLSL Change: check in and out, check out conversions
+              .isBad())
         return DiagnoseBadConversion(S, Cand, I, Cand->Conversions[I],
                                      OpLoc); // HLSL Change: add OpLoc
       if (Cand->OutConversions[I].isInitialized() &&
           Cand->OutConversions[I]
-              .isBad()) // HLSL Change: check in and out, check out conversions
+              .isBad())
         return DiagnoseBadConversion(S, Cand, I, Cand->OutConversions[I],
                                      OpLoc); // HLSL Change: add OpLoc
     }

--- a/tools/clang/lib/Sema/SemaOverload.cpp
+++ b/tools/clang/lib/Sema/SemaOverload.cpp
@@ -9491,12 +9491,18 @@ static void NoteFunctionCandidate(Sema &S, OverloadCandidate *Cand,
 
   case ovl_fail_bad_conversion: {
     unsigned I = (Cand->IgnoreObjectArgument ? 1 : 0);
-    for (unsigned N = Cand->NumConversions; I != N; ++I)
-      if (Cand->Conversions[I].isInitialized() && Cand->Conversions[I].isBad()) // HLSL Change: check in and out, check out conversions
-        return DiagnoseBadConversion(S, Cand, I, Cand->Conversions[I], OpLoc); // HLSL Change: add OpLoc
-    if (Cand->OutConversions[I].isInitialized() && Cand->OutConversions[I].isBad()) // HLSL Change: check in and out, check out conversions
-      return DiagnoseBadConversion(S, Cand, I, Cand->OutConversions[I], OpLoc); // HLSL Change: add OpLoc
-
+    for (unsigned N = Cand->NumConversions; I != N; ++I) {
+      if (Cand->Conversions[I].isInitialized() &&
+          Cand->Conversions[I]
+              .isBad()) // HLSL Change: check in and out, check out conversions
+        return DiagnoseBadConversion(S, Cand, I, Cand->Conversions[I],
+                                     OpLoc); // HLSL Change: add OpLoc
+      if (Cand->OutConversions[I].isInitialized() &&
+          Cand->OutConversions[I]
+              .isBad()) // HLSL Change: check in and out, check out conversions
+        return DiagnoseBadConversion(S, Cand, I, Cand->OutConversions[I],
+                                     OpLoc); // HLSL Change: add OpLoc
+    }
     // FIXME: this currently happens when we're called from SemaInit
     // when user-conversion overload fails.  Figure out how to handle
     // those conditions and diagnose them well.


### PR DESCRIPTION
While emitting diagnostic notes about conversions, the code for checking `OutConversions` was not included in the loop. This caused an OOB when `I >= NumConversions`. Normally, this does not affect anything (other than not emitting the diagnostics for `OutConversions`), since most of the time `OutConversions[I].isBad()` happens to return false. However, in some cases when `OutConversions[I].isBad()` is true, calling `DiagnoseBadConversion()` on the invalid entry will crash.