### PR TITLE
[Diagnostics] Add diagnostics for incompatible combination of System Values and node Launch Types.

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1864,6 +1864,50 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
       funcProps->numThreads[1] = 1;
       funcProps->numThreads[2] = 1;
     }
+
+    // Validate Compute Shader system value inputs per launch mode
+    for (ParmVarDecl *param : FD->parameters()) {
+      for (const hlsl::UnusualAnnotation *it : param->getUnusualAnnotations()) {
+        if (it->getKind() == hlsl::UnusualAnnotation::UA_SemanticDecl) {
+          const hlsl::SemanticDecl *sd = cast<hlsl::SemanticDecl>(it);
+          // if the node launch type is Thread, then there are no system values
+          // allowed
+          if (funcProps->Node.LaunchType == DXIL::NodeLaunchType::Thread) {
+            if (sd->SemanticName.equals("SV_GroupThreadID") ||
+                sd->SemanticName.equals("SV_GroupIndex") ||
+                sd->SemanticName.equals("SV_GroupID") ||
+                sd->SemanticName.equals("SV_DispatchThreadID")) {
+              // emit diagnostic
+              unsigned DiagID = Diags.getCustomDiagID(
+                  DiagnosticsEngine::Error,
+                  "Invalid system value semantic '%0' for launchtype '%1'");
+              Diags.Report(param->getLocation(), DiagID)
+                  << sd->SemanticName << "Thread";
+            }
+          }
+
+          // if the node launch type is Coalescing, then
+          // SV_GroupIndex and SV_GroupThreadID are allowed
+          else if (funcProps->Node.LaunchType ==
+                   DXIL::NodeLaunchType::Coalescing) {
+            if (sd->SemanticName.equals("SV_GroupID") ||
+                sd->SemanticName.equals("SV_DispatchThreadID")) {
+              // emit diagnostic
+              unsigned DiagID = Diags.getCustomDiagID(
+                  DiagnosticsEngine::Error,
+                  "Invalid system value semantic '%0' for launchtype '%1'");
+              Diags.Report(param->getLocation(), DiagID)
+                  << sd->SemanticName << "Coalescing";
+            }
+          }
+          // Broadcasting nodes allow all node shader system value semantics
+          else if (funcProps->Node.LaunchType ==
+                   DXIL::NodeLaunchType::Broadcasting) {
+            continue;
+          }
+        }
+      }
+    }
   }
 
   const unsigned profileAttributes =

--- a/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/launch_types.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/diagnostics/errors/launch_types.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -T lib_6_3 -D e1 %s | FileCheck -check-prefix=CHECK_ENTRY1 %s
+// RUN: %dxc -T lib_6_3 -D e2 %s
+// RUN: %dxc -T lib_6_3 -D e3 %s | FileCheck -check-prefix=CHECK_ENTRY3 %s
+
+
+#ifdef e1
+// CHECK_ENTRY1: error: Invalid system value semantic 'SV_DispatchThreadID' for launchtype 'Thread'
+// CHECK_ENTRY1: error: Invalid system value semantic 'SV_GroupID' for launchtype 'Thread'
+// CHECK_ENTRY1: error: Invalid system value semantic 'SV_GroupThreadID' for launchtype 'Thread'
+// CHECK_ENTRY1: error: Invalid system value semantic 'SV_GroupIndex' for launchtype 'Thread'
+[shader("node")]
+[NodeLaunch("thread")]
+[numthreads(1,1,1)]
+void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}
+#endif
+
+#ifdef e2
+// no expected errors
+[shader("node")]
+[NodeDispatchGrid(1,1,1)]
+[NodeLaunch("broadcasting")]
+[numthreads(1,1,1)]
+void entry2( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}
+#endif
+
+#ifdef e3
+// CHECK_ENTRY3: error: Invalid system value semantic 'SV_DispatchThreadID' for launchtype 'Coalescing'
+// CHECK_ENTRY3: error: Invalid system value semantic 'SV_GroupID' for launchtype 'Coalescing'
+[shader("node")]
+[NodeLaunch("coalescing")]
+[numthreads(1,1,1)]
+void entry3( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}
+#endif


### PR DESCRIPTION
According to this section of the spec:
https://microsoft.github.io/DirectX-Specs/d3d/WorkGraphs.html#node-shader-system-values
There should be diagnostics announcing the unsupported use of certain system value semantics in combination with certain supported launch modes. There were previously no diagnostics for these incompatible combinations. this PR adds the diagnostics into CodeGen. The diagnostics aren't added to Sema (yet) because, according to issue #5827, there is no path for proper flattened signature construction. Parameters won't be flattened at the time that Sema runs, but system values should be accessible by CodeGen.
Fixes #5827 