### PR TITLE
[NFC] Remove misleading function

### DIFF
--- a/include/dxc/DXIL/DxilShaderModel.h
+++ b/include/dxc/DXIL/DxilShaderModel.h
@@ -44,9 +44,6 @@ public:
   bool IsDS() const { return m_Kind == Kind::Domain; }
   bool IsCS() const { return m_Kind == Kind::Compute; }
   bool IsLib() const { return m_Kind == Kind::Library; }
-  bool IsRay() const {
-    return m_Kind >= Kind::RayGeneration && m_Kind <= Kind::Callable;
-  }
   bool IsMS() const { return m_Kind == Kind::Mesh; }
   bool IsAS() const { return m_Kind == Kind::Amplification; }
   bool IsValid() const;

--- a/include/dxc/DXIL/DxilShaderModel.h
+++ b/include/dxc/DXIL/DxilShaderModel.h
@@ -48,7 +48,6 @@ public:
   bool IsAS() const { return m_Kind == Kind::Amplification; }
   bool IsValid() const;
   bool IsValidForDxil() const;
-  bool IsValidForModule() const;
 
   Kind GetKind() const { return m_Kind; }
   unsigned GetMajor() const { return m_Major; }

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -117,8 +117,6 @@ void DxilModule::SetShaderModel(const ShaderModel *pSM, bool bUseMinPrecision) {
            "shader model must not change for the module");
   DXASSERT(pSM != nullptr && pSM->IsValidForDxil(),
            "shader model must be valid");
-  DXASSERT(pSM->IsValidForModule(),
-           "shader model must be valid for top-level module use");
   m_pSM = pSM;
   m_pSM->GetDxilVersion(m_DxilMajor, m_DxilMinor);
   m_pMDHelper->SetShaderModel(m_pSM);

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -76,7 +76,8 @@ bool ShaderModel::IsValidForDxil() const {
 
 bool ShaderModel::IsValidForModule() const {
   // Ray tracing shader model should only be used on functions in a lib
-  return IsValid() && !IsRay();
+  return IsValid() &&
+         !(m_Kind >= Kind::RayGeneration && m_Kind <= Kind::Callable);
 }
 
 const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -74,12 +74,6 @@ bool ShaderModel::IsValidForDxil() const {
   return false;
 }
 
-bool ShaderModel::IsValidForModule() const {
-  // Ray tracing shader model should only be used on functions in a lib
-  return IsValid() &&
-         !(m_Kind >= Kind::RayGeneration && m_Kind <= Kind::Callable);
-}
-
 const ShaderModel *ShaderModel::Get(Kind Kind, unsigned Major, unsigned Minor) {
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_shader_model_get()</py>*/
   // VALRULE-TEXT:BEGIN


### PR DESCRIPTION
The IsRay() function defined in the ShaderModel class can be misleading. It is included in a set of functions that are used to test whether or not the shader in question was targeted to a specific shader stage. However, it is impossible for a shader to be targeted to, say, the "raygeneration" stage, or any other stages associated with the kinds that the IsRay() function checks for. Like the "node" shader kind, a shader can only have these shader kinds if the associated attribute is found on the function declaration. To prevent confusion, and to keep the Is*() functions inside the ShaderModel class restricted to only those targetable shader stages, the IsRay() function can be removed. This PR comes as a response to #6008