### PR TITLE
PIX: Fix scope ascension for variable lookup

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -115,6 +115,7 @@ using namespace std;
 #endif // VERIFY_ARE_EQUAL
 
 static constexpr char whitespaceChars[] = " \t\r\n";
+static constexpr wchar_t wideWhitespaceChars[] = L" \t\r\n";
 
 inline std::string strltrim(const std::string &value) {
   size_t first = value.find_first_not_of(whitespaceChars);
@@ -143,6 +144,25 @@ inline std::vector<std::string>
 strtok(const std::string &value, const char *delimiters = whitespaceChars) {
   size_t searchOffset = 0;
   std::vector<std::string> tokens;
+  while (searchOffset != value.size()) {
+    size_t tokenStartIndex = value.find_first_not_of(delimiters, searchOffset);
+    if (tokenStartIndex == std::string::npos)
+      break;
+    size_t tokenEndIndex = value.find_first_of(delimiters, tokenStartIndex);
+    if (tokenEndIndex == std::string::npos)
+      tokenEndIndex = value.size();
+    tokens.emplace_back(
+        value.substr(tokenStartIndex, tokenEndIndex - tokenStartIndex));
+    searchOffset = tokenEndIndex;
+  }
+  return tokens;
+}
+
+inline std::vector<std::wstring>
+strtok(const std::wstring &value,
+       const wchar_t *delimiters = wideWhitespaceChars) {
+  size_t searchOffset = 0;
+  std::vector<std::wstring> tokens;
   while (searchOffset != value.size()) {
     size_t tokenStartIndex = value.find_first_not_of(delimiters, searchOffset);
     if (tokenStartIndex == std::string::npos)

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -1015,6 +1015,11 @@ public:
     m_str = NULL;
     return s;
   }
+
+  void Empty() throw() {
+    SysFreeString(m_str);
+    m_str = NULL;
+  }
 };
 
 //===--------- Convert argv to wchar ----------------===//

--- a/lib/DxilDia/DxcPixLiveVariables.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables.cpp
@@ -49,12 +49,19 @@ public:
     // is at file-level scope, it will return nullptr.
     if (auto Namespace = llvm::dyn_cast<llvm::DINamespace>(FunctionScope)) {
       if (auto *ContainingScope = Namespace->getScope()) {
-        FunctionScope = ContainingScope;
+        if (FunctionScope == InlinedAtScope)
+          InlinedAtScope = FunctionScope = ContainingScope;
+        else
+          FunctionScope = ContainingScope;
         return;
       }
     }
     const llvm::DITypeIdentifierMap EmptyMap;
-    FunctionScope = FunctionScope->getScope().resolve(EmptyMap);
+    if (FunctionScope == InlinedAtScope)
+      InlinedAtScope = FunctionScope =
+          FunctionScope->getScope().resolve(EmptyMap);
+    else
+      FunctionScope = FunctionScope->getScope().resolve(EmptyMap);
   }
 
   static UniqueScopeForInlinedFunctions Create(llvm::DebugLoc const &DbgLoc,

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -3050,7 +3050,8 @@ TEST_F(PixDiaTest, DxcPixDxilDebugInfo_VariableScopes_ForScopes) {
   DWORD instructionOffset =
       AdvanceUntilFunctionEntered(dxilDebugger, 0, L"CSMain");
 
-  instructionOffset = Labels->FindInstructionOffsetForLabel(L"CheckVariableExistsHere");
+  instructionOffset =
+      Labels->FindInstructionOffsetForLabel(L"CheckVariableExistsHere");
   CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
                                        L"zero");
 
@@ -3195,14 +3196,12 @@ void CSMain()
       Labels->FindInstructionOffsetForLabel(L"inside member fn");
   CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
                                               L"s");
-  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
-                                       L"q");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset, L"q");
 
   instructionOffset = Labels->FindInstructionOffsetForLabel(L"Stop here");
   CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
                                               L"i");
-  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
-      L"j");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset, L"j");
 }
 
 #endif

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -129,6 +129,11 @@ static HRESULT UnAliasType(IDxcPixType *MaybeAlias,
   return S_OK;
 }
 
+struct DebuggerInterfaces {
+  CComPtr<IDxcPixDxilDebugInfo> debugInfo;
+  CComPtr<IDxcPixCompilationInfo> compilationInfo;
+};
+
 class PixDiaTest {
 public:
   BEGIN_TEST_CLASS(PixDiaTest)
@@ -177,8 +182,14 @@ public:
   TEST_METHOD(DxcPixDxilDebugInfo_UnnamedField)
   TEST_METHOD(DxcPixDxilDebugInfo_SubProgramsInNamespaces)
   TEST_METHOD(DxcPixDxilDebugInfo_SubPrograms)
-  TEST_METHOD(DxcPixDxilDebugInfo_InlinedFunctions_TwiceInlinedFunctions)
-  TEST_METHOD(DxcPixDxilDebugInfo_InlinedFunctions_CalledTwiceInSameCaller)
+  TEST_METHOD(
+      DxcPixDxilDebugInfo_VariableScopes_InlinedFunctions_TwiceInlinedFunctions)
+  TEST_METHOD(
+      DxcPixDxilDebugInfo_VariableScopes_InlinedFunctions_CalledTwiceInSameCaller)
+  TEST_METHOD(DxcPixDxilDebugInfo_VariableScopes_ForScopes)
+  TEST_METHOD(DxcPixDxilDebugInfo_VariableScopes_ScopeBraces)
+  TEST_METHOD(DxcPixDxilDebugInfo_VariableScopes_Function)
+  TEST_METHOD(DxcPixDxilDebugInfo_VariableScopes_Member)
 
   dxc::DxcDllSupport m_dllSupport;
   VersionSupportInfo m_ver;
@@ -638,7 +649,8 @@ public:
       const char *hlsl, const wchar_t *profile,
       const char *lineAtWhichToExamineVariables,
       std::vector<VariableComponentInfo> const &ExpectedVariables);
-  CComPtr<IDxcPixDxilDebugInfo>
+
+  DebuggerInterfaces
   CompileAndCreateDxcDebug(const char *hlsl, const wchar_t *profile,
                            IDxcIncludeHandler *includer = nullptr);
 
@@ -769,7 +781,7 @@ void PixDiaTest::CompileAndRunAnnotationAndGetDebugPart(
   *ppDebugPart = GetDebugPart(dllSupport, pNewContainer).Detach();
 }
 
-CComPtr<IDxcPixDxilDebugInfo>
+DebuggerInterfaces
 PixDiaTest::CompileAndCreateDxcDebug(const char *hlsl, const wchar_t *profile,
                                      IDxcIncludeHandler *includer) {
 
@@ -783,9 +795,10 @@ PixDiaTest::CompileAndCreateDxcDebug(const char *hlsl, const wchar_t *profile,
   CComPtr<IDxcPixDxilDebugInfoFactory> Factory;
   VERIFY_SUCCEEDED(session->QueryInterface(IID_PPV_ARGS(&Factory)));
 
-  CComPtr<IDxcPixDxilDebugInfo> dxilDebugger;
-  VERIFY_SUCCEEDED(Factory->NewDxcPixDxilDebugInfo(&dxilDebugger));
-  return dxilDebugger;
+  DebuggerInterfaces ret;
+  VERIFY_SUCCEEDED(Factory->NewDxcPixDxilDebugInfo(&ret.debugInfo));
+  VERIFY_SUCCEEDED(Factory->NewDxcPixCompilationInfo(&ret.compilationInfo));
+  return ret;
 }
 
 CComPtr<IDxcPixDxilLiveVariables>
@@ -845,7 +858,7 @@ void PixDiaTest::TestGlobalStaticCase(
     const char *lineAtWhichToExamineVariables,
     std::vector<VariableComponentInfo> const &ExpectedVariables) {
 
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, profile);
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, profile).debugInfo;
 
   auto liveVariables =
       GetLiveVariablesAt(hlsl, lineAtWhichToExamineVariables, dxilDebugger);
@@ -2239,7 +2252,7 @@ void main()
 }
 
 )";
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6").debugInfo;
 
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
@@ -2300,7 +2313,7 @@ void main()
 }
 
 )";
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6").debugInfo;
 
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
@@ -2358,7 +2371,7 @@ void main()
 }
 
 )";
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6").debugInfo;
 
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
@@ -2418,7 +2431,7 @@ void main()
 }
 
 )";
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_6").debugInfo;
 
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
@@ -2451,7 +2464,7 @@ void PixDiaTest::TestUnnamedTypeCase(const char *hlsl,
                                      const wchar_t *expectedTypeName) {
   if (m_ver.SkipDxilVersion(1, 2))
     return;
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_0");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_0").debugInfo;
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
   DWORD count;
@@ -2562,7 +2575,7 @@ void main()
 
   if (m_ver.SkipDxilVersion(1, 2))
     return;
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_0");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"cs_6_0").debugInfo;
   auto liveVariables =
       GetLiveVariablesAt(hlsl, "InterestingLine", dxilDebugger);
   DWORD count;
@@ -2656,7 +2669,7 @@ float4 fn2( float3 f3, float d, bool sanitize = true )
 )"}});
 
   auto dxilDebugger =
-      CompileAndCreateDxcDebug(hlsl, L"cs_6_0", pIncludeHandler);
+      CompileAndCreateDxcDebug(hlsl, L"cs_6_0", pIncludeHandler).debugInfo;
 
   struct SourceLocations {
     CComBSTR Filename;
@@ -2777,10 +2790,71 @@ static DWORD AdvanceUntilFunctionEntered(IDxcPixDxilDebugInfo *dxilDebugger,
   return instructionOffset;
 }
 
+struct FilenameAndLineNumber {
+  CComBSTR FileName;
+  DWORD LineNumber;
+};
+
+static FilenameAndLineNumber GetFileNameAndLineNumberForInstructionOffset(
+    DebuggerInterfaces &debuggerInterfaces, DWORD instructionOffset) {
+  CComPtr<IDxcPixDxilSourceLocations> SourceLocations;
+  if (FAILED(debuggerInterfaces.debugInfo->SourceLocationsFromInstructionOffset(
+          instructionOffset, &SourceLocations))) {
+    VERIFY_FAIL(L"Didn't find source ");
+    return {};
+  }
+  FilenameAndLineNumber ret{};
+  if (SourceLocations->GetCount() > 0) {
+    if (FAILED(SourceLocations->GetFileNameByIndex(0, &ret.FileName))) {
+      VERIFY_FAIL(L"Couldn't get line number");
+      return {};
+    }
+    ret.LineNumber = SourceLocations->GetLineNumberByIndex(0);
+  }
+  return ret;
+}
+
+static DWORD AdvanceUntilLineContains(DebuggerInterfaces &debuggerInterfaces,
+                                      DWORD instructionOffset,
+                                      wchar_t const *lineContents) {
+  for (;;) {
+    auto CurrentNameAndNumber = GetFileNameAndLineNumberForInstructionOffset(
+        debuggerInterfaces, instructionOffset);
+    if (CurrentNameAndNumber.FileName != nullptr) {
+      DWORD sourceOrdinal = 0;
+      CComBSTR fileName;
+      CComBSTR fileContent;
+      while (SUCCEEDED(debuggerInterfaces.compilationInfo->GetSourceFile(
+          sourceOrdinal++, &fileName, &fileContent))) {
+        if (fileName == CurrentNameAndNumber.FileName) {
+          auto lines = strtok(std::wstring(fileContent), L"\n");
+          // VERIFY_IS_TRUE(CurrentNameAndNumber.LineNumber >= 1);
+          // VERIFY_IS_TRUE(CurrentNameAndNumber.LineNumber - 1 <
+          //               static_cast<DWORD>(lines.size()));
+          std::wostringstream s;
+          s << "Seeking line number " << CurrentNameAndNumber.LineNumber
+            << " at Instruction offsset " << instructionOffset
+            << ": Checking line " << lines[CurrentNameAndNumber.LineNumber - 1]
+            << "\n";
+          OutputDebugStringW(s.str().c_str());
+          if (lines[CurrentNameAndNumber.LineNumber - 1].find(lineContents) !=
+              std::wstring::npos)
+            return instructionOffset;
+        }
+      }
+      fileName = nullptr;
+      fileContent = nullptr;
+    }
+    instructionOffset++;
+  }
+  VERIFY_FAIL(L"Couldn't get line number");
+  return (DWORD)-1;
+}
+
 static DWORD GetRegisterNumberForVariable(IDxcPixDxilDebugInfo *dxilDebugger,
                                           DWORD instructionOffset,
                                           wchar_t const *variableName,
-                                          wchar_t const *memberName) {
+                                          wchar_t const *memberName = nullptr) {
   CComPtr<IDxcPixDxilLiveVariables> DxcPixDxilLiveVariables;
   if (SUCCEEDED(dxilDebugger->GetLiveVariablesAt(instructionOffset,
                                                  &DxcPixDxilLiveVariables))) {
@@ -2795,12 +2869,14 @@ static DWORD GetRegisterNumberForVariable(IDxcPixDxilDebugInfo *dxilDebugger,
       if (Name == variableName) {
         CComPtr<IDxcPixDxilStorage> DxcPixDxilStorage;
         VERIFY_SUCCEEDED(DxcPixVariable->GetStorage(&DxcPixDxilStorage));
-        CComPtr<IDxcPixDxilStorage> DxcPixDxilMemberStorage;
-        VERIFY_SUCCEEDED(DxcPixDxilStorage->AccessField(
-            memberName, &DxcPixDxilMemberStorage));
+        if (memberName != nullptr) {
+          CComPtr<IDxcPixDxilStorage> DxcPixDxilMemberStorage;
+          VERIFY_SUCCEEDED(DxcPixDxilStorage->AccessField(
+              memberName, &DxcPixDxilMemberStorage));
+          DxcPixDxilStorage = DxcPixDxilMemberStorage;
+        }
         DWORD RegisterNumber = 42;
-        VERIFY_SUCCEEDED(
-            DxcPixDxilMemberStorage->GetRegisterNumber(&RegisterNumber));
+        VERIFY_SUCCEEDED(DxcPixDxilStorage->GetRegisterNumber(&RegisterNumber));
         return RegisterNumber;
       }
     }
@@ -2809,7 +2885,37 @@ static DWORD GetRegisterNumberForVariable(IDxcPixDxilDebugInfo *dxilDebugger,
   return -1;
 }
 
-TEST_F(PixDiaTest, DxcPixDxilDebugInfo_InlinedFunctions_TwiceInlinedFunctions) {
+static void
+CheckVariableExistsAtThisInstruction(IDxcPixDxilDebugInfo *dxilDebugger,
+                                     DWORD instructionOffset,
+                                     wchar_t const *variableName) {
+  // It's sufficient to know that there _is_ a register number the var:
+  (void)GetRegisterNumberForVariable(dxilDebugger, instructionOffset,
+                                     variableName);
+}
+
+static void
+CheckVariableDoesNOTExistsAtThisInstruction(IDxcPixDxilDebugInfo *dxilDebugger,
+                                            DWORD instructionOffset,
+                                            wchar_t const *variableName) {
+  CComPtr<IDxcPixDxilLiveVariables> DxcPixDxilLiveVariables;
+  VERIFY_SUCCEEDED(dxilDebugger->GetLiveVariablesAt(instructionOffset,
+                                                    &DxcPixDxilLiveVariables));
+  DWORD count = 42;
+  VERIFY_SUCCEEDED(DxcPixDxilLiveVariables->GetCount(&count));
+  for (DWORD i = 0; i < count; ++i) {
+    CComPtr<IDxcPixVariable> DxcPixVariable;
+    VERIFY_SUCCEEDED(
+        DxcPixDxilLiveVariables->GetVariableByIndex(i, &DxcPixVariable));
+    CComBSTR Name;
+    VERIFY_SUCCEEDED(DxcPixVariable->GetName(&Name));
+    VERIFY_ARE_NOT_EQUAL(Name, variableName);
+  }
+}
+
+TEST_F(
+    PixDiaTest,
+    DxcPixDxilDebugInfo_VariableScopes_InlinedFunctions_TwiceInlinedFunctions) {
   if (m_ver.SkipDxilVersion(1, 6))
     return;
 
@@ -2880,7 +2986,7 @@ float4 DeeperInlinedFunction(in BuiltInTriangleIntersectionAttributes attr, int 
 )"}});
 
   auto dxilDebugger =
-      CompileAndCreateDxcDebug(hlsl, L"lib_6_6", pIncludeHandler);
+      CompileAndCreateDxcDebug(hlsl, L"lib_6_6", pIncludeHandler).debugInfo;
 
   // Case: same functions called from two different top-level callers
   DWORD instructionOffset =
@@ -2923,8 +3029,9 @@ float4 DeeperInlinedFunction(in BuiltInTriangleIntersectionAttributes attr, int 
                        ColorRegisterNumberWhenCalledFromOuterForDeeper);
 }
 
-TEST_F(PixDiaTest,
-       DxcPixDxilDebugInfo_InlinedFunctions_CalledTwiceInSameCaller) {
+TEST_F(
+    PixDiaTest,
+    DxcPixDxilDebugInfo_VariableScopes_InlinedFunctions_CalledTwiceInSameCaller) {
   if (m_ver.SkipDxilVersion(1, 6))
     return;
 
@@ -2953,7 +3060,7 @@ void ClosestHitShader3(inout RayPayload payload, in BuiltInTriangleIntersectionA
 }
 )";
 
-  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"lib_6_6").debugInfo;
 
   // Case: same function called from two places in same top-level function.
   // In this case, we expect the storage for the variable to be in the same
@@ -2974,6 +3081,196 @@ void ClosestHitShader3(inout RayPayload payload, in BuiltInTriangleIntersectionA
   DWORD callsite1 = GetRegisterNumberForVariable(
       dxilDebugger, instructionOffset++, L"ret", L"x");
   VERIFY_ARE_EQUAL(callsite0, callsite1);
+}
+
+TEST_F(PixDiaTest, DxcPixDxilDebugInfo_VariableScopes_ForScopes) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+
+  const char *hlsl =
+      R"(/*01*/RWStructuredBuffer<int> intRWUAV: register(u0);
+/*02*/[shader("compute")]
+/*03*/[numthreads(1,1,1)]
+/*04*/void CSMain()
+/*05*/{
+/*06*/    int zero = intRWUAV.Load(0);
+/*07*/    int two = zero * 2; // CheckVariableExistsHere
+/*08*/    int three = zero * 3;
+/*09*/    for(int i =0; i < two; ++ i)
+/*10*/    {
+/*11*/        int one = intRWUAV.Load(i);
+/*12*/        three += one; // Stop inside loop
+/*13*/    }
+/*14*/    intRWUAV[0] = three; // Stop here
+/*15*/}
+)";
+
+  auto debugInterfaces = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = debugInterfaces.debugInfo;
+
+  // Case: same function called from two places in same top-level function.
+  // In this case, we expect the storage for the variable to be in the same
+  // place for both "instances" of the function: as a thread proceeds through
+  // the caller, it will write new values into the variable's storage during
+  // the second or subsequent invocations of the inlined function.
+  DWORD instructionOffset =
+      AdvanceUntilFunctionEntered(dxilDebugger, 0, L"CSMain");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// CheckVariableExistsHere");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"zero");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop inside loop");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"zero");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop here");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"one");
+}
+
+TEST_F(PixDiaTest, DxcPixDxilDebugInfo_VariableScopes_ScopeBraces) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+
+  const char *hlsl =
+      R"(/*01*/RWStructuredBuffer<int> intRWUAV: register(u0);
+/*02*/[shader("compute")]
+/*03*/[numthreads(1,1,1)]
+/*04*/void CSMain()
+/*05*/{
+/*06*/    int zero = intRWUAV.Load(0);
+/*07*/    int two = zero * 2; // CheckVariableExistsHere
+/*08*/    { 
+/*09*/        int one = intRWUAV.Load(1);
+/*10*/        two += one; // Stop inside loop
+/*11*/    }
+/*12*/    intRWUAV[0] = two; // Stop here
+/*13*/}
+)";
+
+  auto debugInterfaces = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = debugInterfaces.debugInfo;
+
+  // Case: same function called from two places in same top-level function.
+  // In this case, we expect the storage for the variable to be in the same
+  // place for both "instances" of the function: as a thread proceeds through
+  // the caller, it will write new values into the variable's storage during
+  // the second or subsequent invocations of the inlined function.
+  DWORD instructionOffset =
+      AdvanceUntilFunctionEntered(dxilDebugger, 0, L"CSMain");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// CheckVariableExistsHere");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"zero");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop inside loop");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"zero");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop here");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"one");
+}
+
+TEST_F(PixDiaTest, DxcPixDxilDebugInfo_VariableScopes_Function) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+
+  const char *hlsl =
+      R"(/*01*/RWStructuredBuffer<int> intRWUAV: register(u0);
+/*02*/int Square(int i) {
+/*03*/  int i2 = i * i; // Stop in subroutine
+/*04*/  return i2;
+/*05*/}
+/*06*/[shader("compute")]
+/*07*/[numthreads(1,1,1)]
+/*08*/void CSMain()
+/*09*/{
+/*10*/    int zero = intRWUAV.Load(0);
+/*11*/    int two = Square(zero);
+/*12*/    intRWUAV[0] = two; // Stop here
+/*13*/}
+)";
+
+  auto debugInterfaces = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = debugInterfaces.debugInfo;
+
+  // Case: same function called from two places in same top-level function.
+  // In this case, we expect the storage for the variable to be in the same
+  // place for both "instances" of the function: as a thread proceeds through
+  // the caller, it will write new values into the variable's storage during
+  // the second or subsequent invocations of the inlined function.
+  DWORD instructionOffset =
+      AdvanceUntilFunctionEntered(dxilDebugger, 0, L"CSMain");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop in subroutine");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"zero");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop here");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"i2");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"zero");
+}
+
+TEST_F(PixDiaTest, DxcPixDxilDebugInfo_VariableScopes_Member) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+
+  const char *hlsl =
+      R"(/*01*/RWStructuredBuffer<int> intRWUAV: register(u0);
+struct Struct {
+  int i;
+  int Getter() {
+      int q = i;
+      return q; //inside member fn
+  }
+};
+[shader("compute")]
+[numthreads(1,1,1)]
+void CSMain()
+{
+    Struct s;
+    s.i = intRWUAV.Load(0);
+    int j = s.Getter();
+    intRWUAV[0] = j; // Stop here
+}
+)";
+
+  auto debugInterfaces = CompileAndCreateDxcDebug(hlsl, L"lib_6_6");
+  auto dxilDebugger = debugInterfaces.debugInfo;
+
+  // Case: same function called from two places in same top-level function.
+  // In this case, we expect the storage for the variable to be in the same
+  // place for both "instances" of the function: as a thread proceeds through
+  // the caller, it will write new values into the variable's storage during
+  // the second or subsequent invocations of the inlined function.
+  DWORD instructionOffset =
+      AdvanceUntilFunctionEntered(dxilDebugger, 0, L"CSMain");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"inside member fn");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"s");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                       L"q");
+
+  instructionOffset = AdvanceUntilLineContains(
+      debugInterfaces, instructionOffset, L"// Stop here");
+  CheckVariableDoesNOTExistsAtThisInstruction(dxilDebugger, instructionOffset,
+                                              L"i");
+  CheckVariableExistsAtThisInstruction(dxilDebugger, instructionOffset,
+      L"j");
 }
 
 #endif

--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -278,7 +278,7 @@ class InstructionOffsetSeekerImpl : public InstructionOffsetSeeker {
 
   std::map<std::wstring, DWORD> m_labelToInstructionOffset;
 
-  public:
+public:
   InstructionOffsetSeekerImpl(DebuggerInterfaces &debuggerInterfaces) {
     DWORD SourceFileOrdinal = 0;
     CComBSTR fileName;
@@ -291,8 +291,7 @@ class InstructionOffsetSeekerImpl : public InstructionOffsetSeeker {
         auto DebugLocPos = lines[line].find(DebugLocLabel);
         if (DebugLocPos != std::wstring::npos) {
           auto StartLabelPos = DebugLocPos + (_countof(DebugLocLabel) - 1);
-          auto CloseDebugLocPos =
-              lines[line].find(L")", StartLabelPos);
+          auto CloseDebugLocPos = lines[line].find(L")", StartLabelPos);
           VERIFY_ARE_NOT_EQUAL(CloseDebugLocPos, std::string::npos);
           auto Label = lines[line].substr(StartLabelPos,
                                           CloseDebugLocPos - StartLabelPos);
@@ -307,7 +306,7 @@ class InstructionOffsetSeekerImpl : public InstructionOffsetSeeker {
                          m_labelToInstructionOffset.end());
           // Just the last offset is sufficient:
           m_labelToInstructionOffset[Label] =
-              InstructionOffsets->GetOffsetByIndex(InstructionOffsetCount-1);
+              InstructionOffsets->GetOffsetByIndex(InstructionOffsetCount - 1);
         }
       }
       SourceFileOrdinal++;
@@ -316,7 +315,7 @@ class InstructionOffsetSeekerImpl : public InstructionOffsetSeeker {
     }
   }
 
-  virtual DWORD FindInstructionOffsetForLabel(const wchar_t* label) override {
+  virtual DWORD FindInstructionOffsetForLabel(const wchar_t *label) override {
     return m_labelToInstructionOffset[label];
   }
 };

--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -317,8 +317,8 @@ public:
         }
       }
       SourceFileOrdinal++;
-      fileName = nullptr;
-      fileContent = nullptr;
+      fileName.Empty();
+      fileContent.Empty();
     }
   }
 

--- a/tools/clang/unittests/HLSL/PixTestUtils.h
+++ b/tools/clang/unittests/HLSL/PixTestUtils.h
@@ -12,10 +12,11 @@
 #pragma once
 
 #include "dxc/Support/WinIncludes.h"
-#include "dxc/dxcapi.h"
+#include "dxc/dxcpix.h"
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace dxc {
 class DxcDllSupport;
@@ -57,4 +58,19 @@ struct PassOutput {
 
 PassOutput RunAnnotationPasses(dxc::DxcDllSupport &dllSupport, IDxcBlob *dxil,
                                int startingLineNumber = 0);
+
+struct DebuggerInterfaces {
+  CComPtr<IDxcPixDxilDebugInfo> debugInfo;
+  CComPtr<IDxcPixCompilationInfo> compilationInfo;
+};
+
+class InstructionOffsetSeeker {
+public:
+  virtual ~InstructionOffsetSeeker() {}
+  virtual DWORD FindInstructionOffsetForLabel(const wchar_t *label) = 0;
+};
+
+std::unique_ptr<pix_test::InstructionOffsetSeeker>
+GatherDebugLocLabelsFromDxcUtils(DebuggerInterfaces &debuggerInterfaces);
+
 } // namespace pix_test

--- a/tools/clang/unittests/HLSL/PixTestUtils.h
+++ b/tools/clang/unittests/HLSL/PixTestUtils.h
@@ -14,9 +14,9 @@
 #include "dxc/Support/WinIncludes.h"
 #include "dxc/dxcpix.h"
 
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace dxc {
 class DxcDllSupport;


### PR DESCRIPTION
In DxcPixLiveVariables.cpp, UniqueScopeForInlinedFunctions::AscendScopeHierarchy tries to keep track of a variable's scope and the scope at which its containing function was inlined, if any.

This scope duo has to be the same in two places for things to work out: the scopes inferred from dbg.declare, and then again when the scope hierarchy is ascended in order to discover all variables accessible from a given point in the program.

AscendScopeHierarchy was forgetting to update the inlined part of the scope, resulting in, for example, PIX's debugger losing track of variables outside of, for example, a for loop, even though the code can see those variables at that point.

Just setting the inlined scope to be the same as the function scope fixes this problem.

(In addition to these new tests, existing PIX tests exercise this situation happily)
