### PR TITLE
[SPIRV] Generate OpSource for All Includes

### DIFF
--- a/tools/clang/include/clang/Basic/SourceManager.h
+++ b/tools/clang/include/clang/Basic/SourceManager.h
@@ -704,6 +704,9 @@ public:
 
   FileManager &getFileManager() const { return FileMgr; }
 
+  unsigned getNumLineTableFilenames() const;
+  const char * getLineTableFilename(unsigned ID) const;
+
   /// \brief Set true if the SourceManager should report the original file name
   /// for contents of files that were overridden by other files. Defaults to
   /// true.

--- a/tools/clang/lib/Basic/SourceManager.cpp
+++ b/tools/clang/lib/Basic/SourceManager.cpp
@@ -2168,3 +2168,13 @@ size_t SourceManager::getDataStructureSizes() const {
 
   return size;
 }
+
+unsigned SourceManager::getNumLineTableFilenames() const {
+  assert(LineTable);
+  return LineTable->getNumFilenames();
+}
+
+const char * SourceManager::getLineTableFilename(unsigned ID) const {
+  assert(LineTable);
+  return LineTable->getFilename(ID);
+}

--- a/tools/clang/lib/SPIRV/EmitVisitor.cpp
+++ b/tools/clang/lib/SPIRV/EmitVisitor.cpp
@@ -263,7 +263,7 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
   // created by DXC. We do not want to emit line information for their
   // instructions. To prevent spirv-opt from removing all debug info, we emit
   // OpLines to specify the beginning and end of the function.
-  if (inEntryFunctionWrapper && 
+  if (inEntryFunctionWrapper &&
       (op != spv::Op::OpReturn && op != spv::Op::OpFunction))
     return;
 
@@ -377,22 +377,10 @@ void EmitVisitor::emitDebugLine(spv::Op op, const SourceLocation &loc,
     debugColumnEnd = columnEnd;
   }
 
-  if (emittedSource[fileId] == 0) {
-    if (!spvOptions.debugInfoVulkan) {
-      SpirvString *fileNameInst =
-          new (context) SpirvString(/*SourceLocation*/ {}, fileName);
-      visit(fileNameInst);
-      SpirvSource *src = new (context)
-          SpirvSource(/*SourceLocation*/ {}, spv::SourceLanguage::HLSL,
-                      hlslVersion, fileNameInst, "");
-      visit(src);
-      spvInstructions.push_back(src);
-      spvInstructions.push_back(fileNameInst);
-    } else {
-      SpirvDebugSource *src = new (context) SpirvDebugSource(fileName, "");
-      visit(src);
-      spvInstructions.push_back(src);
-    }
+  if ((emittedSource[fileId] == 0) && (spvOptions.debugInfoVulkan)) {
+    SpirvDebugSource *src = new (context) SpirvDebugSource(fileName, "");
+    visit(src);
+    spvInstructions.push_back(src);
   }
 
   curInst.clear();

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -865,6 +865,20 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
   if (!declIdMapper.decorateResourceCoherent())
     return;
 
+  // Add source instruction(s)
+  if ((spirvOptions.debugInfoSource || spirvOptions.debugInfoFile) &&
+      !spirvOptions.debugInfoVulkan) {
+    std::vector<llvm::StringRef> fileNames;
+    fileNames.clear();
+    const auto &sm = context.getSourceManager();
+    // Add each include file from preprocessor output
+    for (unsigned int i = 0; i < sm.getNumLineTableFilenames(); i++) {
+      fileNames.push_back(sm.getLineTableFilename(i));
+    }
+    spvBuilder.setDebugSource(spvContext.getMajorVersion(),
+                              spvContext.getMinorVersion(), fileNames);
+  }
+
   // Output the constructed module.
   std::vector<uint32_t> m = spvBuilder.takeModule();
   if (context.getDiagnostics().hasErrorOccurred())

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.debugsource.multiple.hlsl
@@ -3,11 +3,11 @@
 // CHECK:      [[debugSet:%[0-9]+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 
 // CHECK: rich.debug.debugsource.multiple.hlsl
+// CHECK: spirv.debug.opline.include-file-1.hlsli
+// CHECK: spirv.debug.opline.include-file-2.hlsli
 // CHECK: spirv.debug.opline.include-file-3.hlsli
 // CHECK: [[file3_code:%[0-9]+]] = OpString "int b;
-// CHECK: spirv.debug.opline.include-file-2.hlsli
 // CHECK: [[file2_code:%[0-9]+]] = OpString "static int a;
-// CHECK: spirv.debug.opline.include-file-1.hlsli
 // CHECK: [[file1_code:%[0-9]+]] = OpString "int function1() {
 // CHECK: [[main_code:%[0-9]+]] = OpString "// RUN: %dxc -T ps_6_0 -E main -fspv-debug=rich-with-source -fcgl  %s -spirv | FileCheck %s
 

--- a/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/rich.debug.function.parent.hlsl
@@ -3,11 +3,11 @@
 // CHECK:      [[set:%[0-9]+]] = OpExtInstImport "OpenCL.DebugInfo.100"
 
 // CHECK: rich.debug.function.parent.hlsl
+// CHECK: spirv.debug.opline.include-file-1.hlsli
+// CHECK: spirv.debug.opline.include-file-2.hlsli
 // CHECK: spirv.debug.opline.include-file-3.hlsli
 // CHECK: [[f3:%[0-9]+]] = OpString "function3"
-// CHECK: spirv.debug.opline.include-file-2.hlsli
 // CHECK: [[f2:%[0-9]+]] = OpString "function2"
-// CHECK: spirv.debug.opline.include-file-1.hlsli
 // CHECK: [[f1:%[0-9]+]] = OpString "function1"
 
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opline.include.hlsl
@@ -2,20 +2,19 @@
 
 // CHECK:      [[main:%[0-9]+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include.hlsl
-// CHECK-NEXT: OpSource HLSL 600 [[main]] "// RUN: %dxc -T ps_6_0 -E main -Zi -fcgl  %s -spirv | FileCheck %s
 // CHECK:      [[file1:%[0-9]+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-1.hlsli
-// CHECK-NEXT: OpSource HLSL 600 [[file1]] "int function1() {
 // CHECK:      [[file2:%[0-9]+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-2.hlsli
-// CHECK-NEXT: OpSource HLSL 600 [[file2]] "static int a;
 // CHECK:      [[file3:%[0-9]+]] = OpString
 // CHECK-SAME: spirv.debug.opline.include-file-3.hlsli
-// CHECK-NEXT: OpSource HLSL 600 [[file3]] "int b;
-
-// CHECK:                  OpLine [[main]] 67 1
+// CHECK-NEXT: OpSource HLSL 600 [[main]] "// RUN: %dxc -T ps_6_0 -E main -Zi -fcgl  %s -spirv | FileCheck %s
+// CHECK:      OpSource HLSL 600 [[file1]] "int function1() {
+// CHECK:      OpSource HLSL 600 [[file2]] "static int a;
+// CHECK:      OpSource HLSL 600 [[file3]] "int b;
+// CHECK:      OpLine [[main]] 66 1
 // CHECK-NEXT: %main = OpFunction %void None
-// CHECK:                  OpLine [[main]] 67 1
+// CHECK:      OpLine [[main]] 66 1
 // CHECK-NEXT: %src_main = OpFunction %void None
 
 #include "spirv.debug.opline.include-file-1.hlsli"
@@ -65,7 +64,7 @@ int callFunction3() {
 }
 
 void main() {
-// CHECK:      OpLine [[main]] 70 3
+// CHECK:      OpLine [[main]] 69 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction1
   callFunction1();
 
@@ -83,11 +82,11 @@ void main() {
   // line
   // in
   // OpSource.
-// CHECK:      OpLine [[main]] 88 3
+// CHECK:      OpLine [[main]] 87 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction2
   callFunction2();
 
-// CHECK:      OpLine [[main]] 92 3
+// CHECK:      OpLine [[main]] 91 3
 // CHECK-NEXT: OpFunctionCall %int %callFunction3
   callFunction3();
 }

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.include-file.hlsli
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.include-file.hlsli
@@ -1,0 +1,1 @@
+#define UBER_TYPE(x) x ## Type

--- a/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.include.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.debug.opsource.include.hlsl
@@ -1,0 +1,25 @@
+// RUN: %dxc -T ps_6_0 -E main -Zi %s -spirv | FileCheck %s
+
+// CHECK:      [[main:%[0-9]+]] = OpString
+// CHECK-SAME: spirv.debug.opsource.include.hlsl
+// CHECK:      [[file1:%[0-9]+]] = OpString
+// CHECK-SAME: spirv.debug.opsource.include-file.hlsli
+// CHECK-NEXT: OpSource HLSL 600 [[main]] "// RUN: %dxc -T ps_6_0 -E main -Zi %s -spirv | FileCheck %s
+// CHECK:      OpSource HLSL 600 [[file1]] "#define UBER_TYPE(x) x ## Type
+
+// CHECK:      [[type:%[0-9]+]] = OpTypeFunction %void
+// CHECK:      OpLine [[main]] 22 1
+// CHECK-NEXT: %main = OpFunction %void None [[type]]
+
+#include "spirv.debug.opsource.include-file.hlsli"
+
+struct ColorType
+{
+    float4 position : SV_POSITION;
+    float4 color : COLOR;
+};
+
+float4 main(UBER_TYPE(Color) input) : SV_TARGET
+{
+    return input.color;
+}


### PR DESCRIPTION
The current implementation generates SPIR-V OpSource instructions from within EmitVisitor::emitDebugLine(), part of OpLine processing, improperly tying the two together.  Only files including instructions that generate an OpLine will generate an OpSource, meaning that many include files are missed.  An included file may include nothing more than preprocessor macro definitions, but that should still generate an OpSource.  

The SourceManager already tracks the correct and complete list of files generated by the preprocessor in LineTable.  We therefore propose a new pair of SourceManager api's that expose the LineTable.  SpirvEmitter::HandleTranslationUnit() may now simply and directly create all required OpSource instructions.