### PR TITLE
Revert "Add /bigobj flag on big spirvtest object (#3858)"

### DIFF
--- a/tools/clang/unittests/SPIRV/CMakeLists.txt
+++ b/tools/clang/unittests/SPIRV/CMakeLists.txt
@@ -51,10 +51,6 @@ configure_file(
     ${CMAKE_CURRENT_BINARY_DIR}/SpirvTestOptions.h
     )
 
-if(WIN32)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj") # otherwise will hit fatal error C1128 on windows x64
-endif(WIN32)
-
 if (NOT CLANG_INCLUDE_TESTS)
   add_test(NAME test-spirv-codegen COMMAND $<TARGET_FILE:ClangSPIRVTests>)
 endif()


### PR DESCRIPTION
This reverts commit 36bfa748784966e1406f8c1823e379bb97f4dc81.

CodeGenSpirvTest.cpp has been cut down significantly from its original >10,000 line size, so this flag should no longer be necessary.

Fixes #3867