### PR TITLE
CP of PIX scope ascension fix

### DIFF
--- a/lib/DxilDia/DxcPixLiveVariables.cpp
+++ b/lib/DxilDia/DxcPixLiveVariables.cpp
@@ -49,12 +49,19 @@ public:
     // is at file-level scope, it will return nullptr.
     if (auto Namespace = llvm::dyn_cast<llvm::DINamespace>(FunctionScope)) {
       if (auto *ContainingScope = Namespace->getScope()) {
-        FunctionScope = ContainingScope;
+        if (FunctionScope == InlinedAtScope)
+          InlinedAtScope = FunctionScope = ContainingScope;
+        else
+          FunctionScope = ContainingScope;
         return;
       }
     }
     const llvm::DITypeIdentifierMap EmptyMap;
-    FunctionScope = FunctionScope->getScope().resolve(EmptyMap);
+    if (FunctionScope == InlinedAtScope)
+      InlinedAtScope = FunctionScope =
+          FunctionScope->getScope().resolve(EmptyMap);
+    else
+      FunctionScope = FunctionScope->getScope().resolve(EmptyMap);
   }
 
   static UniqueScopeForInlinedFunctions Create(llvm::DebugLoc const &DbgLoc,


### PR DESCRIPTION
As in my previous PIX CP, I've removed the test changes from the cherry-pick since the test file in question (PixDiaTest.cpp) doesn't even exist in this branch (it was split off from PixTest.cpp in main to deal with linux build issues).