### PR TITLE
[SPIRV] Fix the code generated for dot4add_u8packed and dot4add_i8packed

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -11478,10 +11478,20 @@ SpirvInstruction *SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
   auto *arg1Instr = doExpr(arg1);
   auto *arg2Instr = doExpr(arg2);
 
+  // OpSDot/OpUDot need a Packed Vector Format operand when Vector 1 and
+  // Vector 2 are scalar integer types.
+  SpirvConstant *formatConstant = spvBuilder.getConstantInt(
+      astContext.UnsignedIntTy,
+      llvm::APInt(32,
+                  uint32_t(spv::PackedVectorFormat::PackedVectorFormat4x8Bit)));
+  // Make sure that the format is emitted as a literal constant and not
+  // an instruction reference.
+  formatConstant->setLiteral(true);
+
   // Prepare the array inputs for createSpirvIntrInstExt below.
   // Need to use this function because the OpSDot/OpUDot operations require
   // two capabilities and an extension to be declared in the module.
-  SpirvInstruction *operands[]{arg0Instr, arg1Instr};
+  SpirvInstruction *operands[]{arg0Instr, arg1Instr, formatConstant};
   uint32_t capabilities[]{
       uint32_t(spv::Capability::DotProduct),
       uint32_t(spv::Capability::DotProductInput4x8BitPacked)};

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot4add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot4add.hlsl
@@ -8,7 +8,7 @@ float2 main(uint4 inputs : Inputs0, uint acc0 : Acc0, int acc1 : Acc1) : SV_Targ
 // CHECK-NEXT:  [[input_y_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_1
 // CHECK-NEXT:  [[input_y_val:%[0-9]+]] = OpLoad %uint [[input_y_ref]]
 // CHECK-NEXT:  [[a0:%[0-9]+]] = OpLoad %uint %acc0
-// CHECK-NEXT:  [[t0:%[0-9]+]] = OpUDot %uint [[input_x_val]] [[input_y_val]]
+// CHECK-NEXT:  [[t0:%[0-9]+]] = OpUDot %uint [[input_x_val]] [[input_y_val]] PackedVectorFormat4x8Bit
 // CHECK-NEXT:  [[t1:%[0-9]+]] = OpIAdd %uint [[t0]] [[a0]]
   acc += dot4add_u8packed(inputs.x, inputs.y, acc0);
 
@@ -17,7 +17,7 @@ float2 main(uint4 inputs : Inputs0, uint acc0 : Acc0, int acc1 : Acc1) : SV_Targ
 // CHECK-NEXT:  [[input_w_ref:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %inputs %int_3
 // CHECK-NEXT:  [[input_w_val:%[0-9]+]] = OpLoad %uint [[input_w_ref]]
 // CHECK-NEXT:  [[a1:%[0-9]+]] = OpLoad %int %acc1
-// CHECK-NEXT:  [[t2:%[0-9]+]] = OpSDot %int [[input_z_val]] [[input_w_val]]
+// CHECK-NEXT:  [[t2:%[0-9]+]] = OpSDot %int [[input_z_val]] [[input_w_val]] PackedVectorFormat4x8Bit
 // CHECK-NEXT:  [[t3:%[0-9]+]] = OpIAdd %int [[t2]] [[a1]]
   acc += dot4add_i8packed(inputs.z, inputs.w, acc1);
 


### PR DESCRIPTION
This is a follow-up for https://github.com/microsoft/DirectXShaderCompiler/pull/5959

The SPIR-V spec [requires](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpSDot) that `OpSDot` and `OpUDot` have an extra Packed Vector Format operand when Vector 1 and Vector 2 are scalar integer types. My previous implementation didn't add that operand - sorry about that. The generated code worked on NVIDIA GPUs but produced incorrect ouptut on AMD and resulted in a crash on Intel ARC. This PR fixes the generated code so that it works on all three vendors' GPUs.
