### PR TITLE
spirv: fix build for C++20

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -384,8 +384,6 @@ private:
   /// The struct containing the data needed to create the input and output
   /// variables for the decl.
   struct StageVarDataBundle {
-  public:
-    StageVarDataBundle() = default;
     // The declaration of the variable for which we need to create the stage
     // variables.
     const NamedDecl *decl;


### PR DESCRIPTION
This codebase is using C++17, but to remain compatible with C++20, I need to remove this.
Starting C++20, an aggregate is required to have no user-declared constructors, vs before, no user-provided constructors.

So even if if the only the default constructor is provided, this is enough to prevent us from using this class as an aggregate in c++20.