### PR TITLE
[CMAKE] Cleanup logic for enabling SPIR-V

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,21 +129,24 @@ endif()
 # HLSL Change Ends
 
 # SPIRV change starts
-option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." OFF)
-option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." OFF)
 
 # Enable SPIR-V CodeGen for Linux by default.
-if(NOT WIN32)
-  set(ENABLE_SPIRV_CODEGEN ON)
-endif()
+if (NOT WIN32)
+  set(default_ENABLE_SPIRV_CODEGEN ON)
+else ()
+  set(default_ENABLE_SPIRV_CODEGEN OFF)
+endif ()
 
-if (${SPIRV_BUILD_TESTS})
+option(ENABLE_SPIRV_CODEGEN "Enables SPIR-V code generation." ${default_ENABLE_SPIRV_CODEGEN})
+option(SPIRV_BUILD_TESTS "Build targets for the SPIR-V unit tests." On)
+
+if (SPIRV_BUILD_TESTS AND ENABLE_SPIRV_CODEGEN)
   enable_testing()
-  set(ENABLE_SPIRV_CODEGEN ON)
-endif()
-if (${ENABLE_SPIRV_CODEGEN})
+endif ()
+
+if (ENABLE_SPIRV_CODEGEN)
   add_definitions(-DENABLE_SPIRV_CODEGEN)
-endif()
+endif ()
 # SPIRV change ends
 
 include(VersionFromVCS)


### PR DESCRIPTION
This just cleans up the logic for enabling and disabling building SPIR-V and the SPIR-V tests. It is _extremely_ unusable to ignore a user-defined value that is specified as an option. In the current code if a user enables SPIR-V tests but disables SPIR-V codegen, the user-specified option to enable codegen gets ignored.