### PR TITLE
Allow unsigned int for nonzero base instance

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3218,11 +3218,8 @@ SpirvVariable *DeclResultIdMapper::getInstanceIdFromIndexAndBase(
   return instanceIdVar;
 }
 
-SpirvVariable *
-DeclResultIdMapper::getBaseInstanceVariable(SemanticInfo *semantic,
-                                            const hlsl::SigPoint *sigPoint) {
-
-  QualType type = astContext.IntTy;
+SpirvVariable *DeclResultIdMapper::getBaseInstanceVariable(
+    SemanticInfo *semantic, const hlsl::SigPoint *sigPoint, QualType type) {
   auto *baseInstanceVar = spvBuilder.addStageBuiltinVar(
       type, spv::StorageClass::Input, spv::BuiltIn::BaseInstance, false,
       semantic->loc);
@@ -3319,8 +3316,8 @@ SpirvVariable *DeclResultIdMapper::createSpirvInterfaceVariable(
     // The above call to createSpirvStageVar creates the gl_InstanceIndex.
     // We should now manually create the gl_BaseInstance variable and do the
     // subtraction.
-    auto *baseInstanceVar =
-        getBaseInstanceVariable(stageVarData.semantic, stageVarData.sigPoint);
+    auto *baseInstanceVar = getBaseInstanceVariable(
+        stageVarData.semantic, stageVarData.sigPoint, stageVarData.type);
 
     // SPIR-V code for 'SV_InstanceID = gl_InstanceIndex - gl_BaseInstance'
     varInstr = getInstanceIdFromIndexAndBase(varInstr, baseInstanceVar);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3220,6 +3220,8 @@ SpirvVariable *DeclResultIdMapper::getInstanceIdFromIndexAndBase(
 
 SpirvVariable *DeclResultIdMapper::getBaseInstanceVariable(
     SemanticInfo *semantic, const hlsl::SigPoint *sigPoint, QualType type) {
+  assert(type->isSpecificBuiltinType(BuiltinType::Kind::Int) ||
+         type->isSpecificBuiltinType(BuiltinType::Kind::UInt));
   auto *baseInstanceVar = spvBuilder.addStageBuiltinVar(
       type, spv::StorageClass::Input, spv::BuiltIn::BaseInstance, false,
       semantic->loc);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -761,6 +761,8 @@ private:
   //
   // sigPoint: the signature point identifying which shader stage the variable
   // will be used in.
+  //
+  // type: The type to use for the new variable. Must be int or unsigned int.
   SpirvVariable *getBaseInstanceVariable(SemanticInfo *semantic,
                                          const hlsl::SigPoint *sigPoint,
                                          QualType type);

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -762,7 +762,8 @@ private:
   // sigPoint: the signature point identifying which shader stage the variable
   // will be used in.
   SpirvVariable *getBaseInstanceVariable(SemanticInfo *semantic,
-                                         const hlsl::SigPoint *sigPoint);
+                                         const hlsl::SigPoint *sigPoint,
+                                         QualType type);
 
   // Creates and return a new interface variable from the information provided.
   // The new variable with be add to `this->StageVars`.

--- a/tools/clang/test/CodeGenSPIRV/semantic.unsigned-nonzero-base-instance.vs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.unsigned-nonzero-base-instance.vs.hlsl
@@ -1,0 +1,29 @@
+// RUN: %dxc -T vs_6_0 -E main -fvk-support-nonzero-base-instance -fcgl  %s -spirv | FileCheck %s
+
+// CHECK:                     OpEntryPoint Vertex %main "main"
+// CHECK-SAME:                %gl_InstanceIndex
+// CHECK-SAME:                %gl_BaseInstance
+// CHECK-SAME:                %out_var_SV_InstanceID
+
+// CHECK:                     OpDecorate %gl_InstanceIndex BuiltIn InstanceIndex
+// CHECK:                     OpDecorate %gl_BaseInstance BuiltIn BaseInstance
+// CHECK:                     OpDecorate %out_var_SV_InstanceID Location 0
+
+// CHECK: %gl_InstanceIndex = OpVariable %_ptr_Input_uint Input
+// CHECK:  %gl_BaseInstance = OpVariable %_ptr_Input_uint Input
+// CHECK: %out_var_SV_InstanceID = OpVariable %_ptr_Output_uint Output
+
+// CHECK:                     %main = OpFunction
+// CHECK:            %SV_InstanceID = OpVariable %_ptr_Function_uint Function
+// CHECK: [[gl_InstanceIndex:%[0-9]+]] = OpLoad %uint %gl_InstanceIndex
+// CHECK:  [[gl_BaseInstance:%[0-9]+]] = OpLoad %uint %gl_BaseInstance
+// CHECK:      [[instance_id:%[0-9]+]] = OpISub %uint [[gl_InstanceIndex]] [[gl_BaseInstance]]
+// CHECK:                             OpStore %SV_InstanceID [[instance_id]]
+// CHECK:      [[instance_id_0:%[0-9]+]] = OpLoad %uint %SV_InstanceID
+// CHECK:                             OpStore %param_var_input [[instance_id_0]]
+// CHECK:                  {{%[0-9]+}} = OpFunctionCall %uint %src_main %param_var_input
+
+unsigned int main(unsigned int input: SV_InstanceID) : SV_InstanceID {
+    return input;
+}
+


### PR DESCRIPTION
A regression was introduced by Refactor create stage vars (#6059)
because it created the BaseInstance variable as an int in all cases it
was created for the option vk-support-nonzero-base-instance enabled. In
some cases it was used as an unsigned int.

This comment get the type for BaseInstance from the type of the instance
id variable, and adds a test for unsigned.

Fixes #6118.
