### PR TITLE
Allow node input record to be a class

### DIFF
--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2600,8 +2600,7 @@ void CGMSHLSLRuntime::AddHLSLNodeRecordTypeInfo(
         auto &Rec = TemplateArgs.get(0);
         clang::QualType RecType = Rec.getAsType();
         llvm::Type *Type = CGM.getTypes().ConvertType(RecType);
-        const RecordType *recordtype = RecType->getAsStructureType();
-        RecordDecl *RD = recordtype->getDecl();
+        CXXRecordDecl *RD = RecType->getAsCXXRecordDecl();
 
         // Get the TrackRWInputSharing flag from the record attribute
         if (RD->hasAttr<HLSLNodeTrackRWInputSharingAttr>()) {

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/class_input_record.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/class_input_record.hlsl
@@ -1,0 +1,20 @@
+// RUN: %dxc -T lib_6_8 `%s | FileCheck %s
+// ==================================================================
+// Broadcasting launch node with class input record
+// ==================================================================
+
+class ClassInputRecord
+{
+  uint a;
+};
+
+// CHECK-NOT: error
+// CHECK: define void @node01()
+// CHECK-NOT: error
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(2,3,2)]
+[NumThreads(1024,1,1)]
+void node01(DispatchNodeInputRecord<ClassInputRecord> input)
+{ }

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/class_input_record.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/class_input_record.hlsl
@@ -1,16 +1,14 @@
-// RUN: %dxc -T lib_6_8 `%s | FileCheck %s
+// RUN: %dxc -T lib_6_8 -verify %s
 // ==================================================================
 // Broadcasting launch node with class input record
 // ==================================================================
+
+// expected-no-diagnostics
 
 class ClassInputRecord
 {
   uint a;
 };
-
-// CHECK-NOT: error
-// CHECK: define void @node01()
-// CHECK-NOT: error
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]


### PR DESCRIPTION
Node input records may be a struct or a class, but CodeGen failed to correctly handle the case when a class was used. This change fixes the error, and adds a test case.

Fixes #6119