### PR TITLE
[SPIR-V] Remove dead code and correct Float16 docs

### DIFF
--- a/docs/SPIR-V.rst
+++ b/docs/SPIR-V.rst
@@ -671,21 +671,21 @@ Normal scalar types
 in HLSL are relatively easy to handle and can be mapped directly to SPIR-V
 type instructions:
 
-============================== ======================= ================== =========== =================================
-      HLSL                      Command Line Option           SPIR-V       Capability       Extension
-============================== ======================= ================== =========== =================================
+============================== ======================= ================== ===========
+      HLSL                      Command Line Option           SPIR-V       Capability
+============================== ======================= ================== ===========
 ``bool``                                               ``OpTypeBool``
 ``int``/``int32_t``                                    ``OpTypeInt 32 1``
 ``int16_t``                    ``-enable-16bit-types`` ``OpTypeInt 16 1`` ``Int16``
 ``uint``/``dword``/``uin32_t``                         ``OpTypeInt 32 0``
 ``uint16_t``                   ``-enable-16bit-types`` ``OpTypeInt 16 0`` ``Int16``
 ``half``                                               ``OpTypeFloat 32``
-``half``/``float16_t``         ``-enable-16bit-types`` ``OpTypeFloat 16``             ``SPV_AMD_gpu_shader_half_float``
+``half``/``float16_t``         ``-enable-16bit-types`` ``OpTypeFloat 16`` ``Float16``
 ``float``/``float32_t``                                ``OpTypeFloat 32``
 ``snorm float``                                        ``OpTypeFloat 32``
 ``unorm float``                                        ``OpTypeFloat 32``
 ``double``/``float64_t``                               ``OpTypeFloat 64`` ``Float64``
-============================== ======================= ================== =========== =================================
+============================== ======================= ================== ===========
 
 Please note that ``half`` is translated into 32-bit floating point numbers
 if without ``-enable-16bit-types`` because MSDN says that "this data type
@@ -705,20 +705,20 @@ We use the 16-bit variants if '-enable-16bit-types' command line option is prese
 For more information on these types, please refer to:
 https://github.com/Microsoft/DirectXShaderCompiler/wiki/16-Bit-Scalar-Types
 
-============== ======================= ================== ==================== ============ =================================
-    HLSL        Command Line Option          SPIR-V            Decoration       Capability        Extension
-============== ======================= ================== ==================== ============ =================================
+============== ======================= ================== ==================== ============
+    HLSL        Command Line Option          SPIR-V            Decoration       Capability 
+============== ======================= ================== ==================== ============
 ``min16float``                         ``OpTypeFloat 32`` ``RelaxedPrecision``
 ``min10float``                         ``OpTypeFloat 32`` ``RelaxedPrecision``
 ``min16int``                           ``OpTypeInt 32 1`` ``RelaxedPrecision``
 ``min12int``                           ``OpTypeInt 32 1`` ``RelaxedPrecision``
 ``min16uint``                          ``OpTypeInt 32 0`` ``RelaxedPrecision``
-``min16float`` ``-enable-16bit-types`` ``OpTypeFloat 16``                                   ``SPV_AMD_gpu_shader_half_float``
-``min10float`` ``-enable-16bit-types`` ``OpTypeFloat 16``                                   ``SPV_AMD_gpu_shader_half_float``
+``min16float`` ``-enable-16bit-types`` ``OpTypeFloat 16``                      ``Float16`` 
+``min10float`` ``-enable-16bit-types`` ``OpTypeFloat 16``                      ``Float16`` 
 ``min16int``   ``-enable-16bit-types`` ``OpTypeInt 16 1``                      ``Int16``
 ``min12int``   ``-enable-16bit-types`` ``OpTypeInt 16 1``                      ``Int16``
 ``min16uint``  ``-enable-16bit-types`` ``OpTypeInt 16 0``                      ``Int16``
-============== ======================= ================== ==================== ============ =================================
+============== ======================= ================== ==================== ============
 
 Vectors and matrices
 --------------------

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -736,27 +736,6 @@ bool CapabilityVisitor::visit(SpirvExtInstImport *instr) {
   return true;
 }
 
-bool CapabilityVisitor::visit(SpirvExtInst *instr) {
-  // OpExtInst using the GLSL extended instruction allows only 32-bit types by
-  // default for interpolation instructions. The AMD_gpu_shader_half_float
-  // extension adds support for 16-bit floating-point component types for these
-  // instructions:
-  // InterpolateAtCentroid, InterpolateAtSample, InterpolateAtOffset
-  if (SpirvType::isOrContainsType<FloatType, 16>(instr->getResultType()))
-    switch (instr->getInstruction()) {
-    case GLSLstd450::GLSLstd450InterpolateAtCentroid:
-    case GLSLstd450::GLSLstd450InterpolateAtSample:
-    case GLSLstd450::GLSLstd450InterpolateAtOffset:
-      addExtension(Extension::AMD_gpu_shader_half_float, "16-bit float",
-                   instr->getSourceLocation());
-      break;
-    default:
-      break;
-    }
-
-  return visitInstruction(instr);
-}
-
 bool CapabilityVisitor::visit(SpirvAtomic *instr) {
   if (instr->hasValue() && SpirvType::isOrContainsType<IntegerType, 64>(
                                instr->getValue()->getResultType())) {

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.h
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.h
@@ -36,7 +36,6 @@ public:
   bool visit(SpirvImageOp *) override;
   bool visit(SpirvImageSparseTexelsResident *) override;
   bool visit(SpirvExtInstImport *) override;
-  bool visit(SpirvExtInst *) override;
   bool visit(SpirvAtomic *) override;
   bool visit(SpirvDemoteToHelperInvocation *) override;
   bool visit(SpirvIsHelperInvocationEXT *) override;

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -179,8 +179,6 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
             Extension::EXT_shader_stencil_export)
       .Case("SPV_EXT_shader_viewport_index_layer",
             Extension::EXT_shader_viewport_index_layer)
-      .Case("SPV_AMD_gpu_shader_half_float",
-            Extension::AMD_gpu_shader_half_float)
       .Case("SPV_AMD_shader_early_and_late_fragment_tests",
             Extension::AMD_shader_early_and_late_fragment_tests)
       .Case("SPV_GOOGLE_hlsl_functionality1",
@@ -240,8 +238,6 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_EXT_shader_stencil_export";
   case Extension::EXT_shader_viewport_index_layer:
     return "SPV_EXT_shader_viewport_index_layer";
-  case Extension::AMD_gpu_shader_half_float:
-    return "SPV_AMD_gpu_shader_half_float";
   case Extension::AMD_shader_early_and_late_fragment_tests:
     return "SPV_AMD_shader_early_and_late_fragment_tests";
   case Extension::GOOGLE_hlsl_functionality1:


### PR DESCRIPTION
The docs were out of date stating that the `SPV_AMD_gpu_shader_half_float` extension was added when half types were used. This is now corrected to show that the Float16 capability is added and no extension.

The remaining code that could have added that extension in certain cases has been dead code since #2503 since none of the instructions checked in that list are ones that are emitted by DXC, so it is removed to clean up.

Evidence that this is dead code:
1. `git grep "InterpolateAt"` finds no uses other than those removed here.
2. All tests still pass when it's removed.
3. The comments in #2503 also say they were not able to find a mapping from any HLSL intrinsics to these instructions, which is why no tests were added.

Follow-up from: https://github.com/KhronosGroup/SPIRV-Tools/pull/5519