### PR TITLE
Remove LLVM_C_FALLTHROUGH instances that cause warnings on clang-12

### DIFF
--- a/tools/clang/lib/Sema/SemaCodeComplete.cpp
+++ b/tools/clang/lib/Sema/SemaCodeComplete.cpp
@@ -3063,7 +3063,6 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
       switch (cast<ObjCPropertyImplDecl>(D)->getPropertyImplementation()) {
       case ObjCPropertyImplDecl::Dynamic:
         return CXCursor_ObjCDynamicDecl;
-        LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
           
       case ObjCPropertyImplDecl::Synthesize:
         return CXCursor_ObjCSynthesizeDecl;
@@ -3071,10 +3070,8 @@ CXCursorKind clang::getCursorKindForDecl(const Decl *D) {
 
       case Decl::Import:
         return CXCursor_ModuleImportDecl;
-        LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
 
     case Decl::ObjCTypeParam:   return CXCursor_TemplateTypeParameter;
-    LLVM_C_FALLTHROUGH; //HLSL Change: avoid fallthrough warning
 
     default:
       if (const TagDecl *TD = dyn_cast<TagDecl>(D)) {


### PR DESCRIPTION
The clang-12 warning is:

    error: fallthrough annotation in unreachable code [-Werror,-Wimplicit-fallthrough]

These LLVM_C_FALLTHROUGH were originally added to silence GCC warnings, but the GCC PR validation build is has succeeded, so it looks like they are not needed.