### PR TITLE
[SPIRV] Implement out variables in patch constant functions

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -979,7 +979,6 @@ private:
   /// statement.
   void processSwitchStmtUsingIfStmts(const SwitchStmt *switchStmt);
 
-private:
   /// Handles the offset argument in the given method call at the given argument
   /// index. Panics if the argument at the given index does not exist. Writes
   /// the <result-id> to either *constOffset or *varOffset, depending on the
@@ -1157,7 +1156,6 @@ private:
                                             const CXXMethodDecl *memberFn,
                                             SourceLocation loc);
 
-private:
   /// \brief Takes a vector of size 4, and returns a vector of size 1 or 2 or 3
   /// or 4. Creates a CompositeExtract or VectorShuffle instruction to extract
   /// a scalar or smaller vector from the beginning of the input vector if
@@ -1195,7 +1193,6 @@ private:
   /// execution mode, if it has not already been added.
   void beginInvocationInterlock(SourceLocation loc, SourceRange range);
 
-private:
   /// \brief If the given FunctionDecl is not already in the workQueue, creates
   /// a FunctionInfo object for it, and inserts it into the workQueue. It also
   /// updates the functionInfoMap with the proper mapping.
@@ -1240,6 +1237,16 @@ private:
   ///  This decision is made according to the rules in
   ///  https://microsoft.github.io/DirectX-Specs/d3d/HLSL_SM_6_6_Derivatives.html.
   void addDerivativeGroupExecutionMode();
+
+  /// Creates an input variable for `param` that will be used by the patch
+  /// constant function. The parameter is also added to the patch constant
+  /// function. The wrapper function will copy the input variable to the
+  /// parameter.
+  SpirvVariable *
+  createPCFParmVarAndInitFromStageInputVar(const ParmVarDecl *param);
+
+  /// Returns a function scope parameter with the same type as |param|.
+  SpirvVariable *createFunctionScopeTempFromParameter(const ParmVarDecl *param);
 
 public:
   /// \brief Wrapper method to create a fatal error message and report it

--- a/tools/clang/test/CodeGenSPIRV/hs.const.output-patch.out.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/hs.const.output-patch.out.hlsl
@@ -1,0 +1,39 @@
+// RUN: %dxc -T hs_6_0 -E Hull -fcgl  %s -spirv | FileCheck %s
+
+struct ControlPoint { float4 position : POSITION; };
+
+// CHECK: %param_var_edge = OpVariable %_ptr_Function__arr_float_uint_3 Function
+// CHECK: %param_var_inside = OpVariable %_ptr_Function_float Function
+// CHECK: %param_var_myFloat = OpVariable %_ptr_Function_float Function
+// CHECK: OpFunctionCall %void %HullConst %param_var_edge %param_var_inside %param_var_myFloat 
+// CHECK: [[edges:%[0-9]+]] = OpLoad %_arr_float_uint_3 %param_var_edge 
+// CHECK: [[addr:%[0-9]+]] = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %uint_0 
+// CHECK: [[val:%[0-9]+]] = OpCompositeExtract %float %66 0 
+// CHECK: OpStore [[addr]] [[val]]
+// CHECK: [[addr:%[0-9]+]] = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %uint_1 
+// CHECK: [[val:%[0-9]+]] = OpCompositeExtract %float %66 1 
+// CHECK: OpStore [[addr]] [[val]]
+// CHECK: [[addr:%[0-9]+]] = OpAccessChain %_ptr_Output_float %gl_TessLevelOuter %uint_2 
+// CHECK: [[val:%[0-9]+]] = OpCompositeExtract %float %66 2 
+// CHECK: OpStore [[addr]] [[val]]
+// CHECK: [[val:%[0-9]+]] = OpLoad %float %param_var_inside 
+// CHECK: [[addr:%[0-9]+]] = OpAccessChain %_ptr_Output_float %gl_TessLevelInner %uint_0 
+// CHECK: OpStore [[addr]] [[val]]
+// CHECK: [[val:%[0-9]+]] = OpLoad %float %param_var_myFloat 
+// CHECK: OpStore %out_var_MY_FLOAT [[val]]
+
+void HullConst (out  float edge [3] : SV_TessFactor, out float inside : SV_InsideTessFactor, out float myFloat : MY_FLOAT)
+{
+    edge[0] = 2;
+    edge[1] = 2;
+    edge[2] = 2;
+    inside = 2;
+    myFloat = .2;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_ccw")]
+[patchconstantfunc("HullConst")]
+[outputcontrolpoints(3)]
+ControlPoint Hull (InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) { return v[id]; }


### PR DESCRIPTION
The documentation for the patch constant functions only mention

> The outputs are usually defined by a structure and is
identified by HS_CONSTANT_DATA_OUTPUT in this example; the structure
depends on the domain type and would be different for triangle or
isoline domains.

This is why we did not realize that we needed to implement out variables
as well. This commit implement the alternate method of having an output.

Fixes #3743
