### PR TITLE
Fix YAML formatting for clang-format action

### DIFF
--- a/.github/workflows/clang-format-checker.yml
+++ b/.github/workflows/clang-format-checker.yml
@@ -25,7 +25,8 @@ jobs:
           fetch_depth: 100 # Fetches only the last 10 commits
 
       - name: "Listed files"
-        env: LISTED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        env:
+          LISTED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           echo "Formatting files:"
           echo "$LISTED_FILES"


### PR DESCRIPTION
The YAML formatting for this action became invalid. This should correct the formatting so that it correctly runs.

Fixes #6128