### PR TITLE
[SPIR-V] Handle vk::ext_capability and vk::ext_extension on entry point

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13196,6 +13196,10 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   auto *entryLabel = spvBuilder.createBasicBlock();
   spvBuilder.setInsertPoint(entryLabel);
 
+  // Handle vk::execution_mode, vk::ext_extension and vk::ext_capability
+  // attributes. Uses pseudo-instructions for extensions and capabilities, which
+  // are added to the beginning of the entry basic block, so must be called
+  // after the basic block is created and insert point is set.
   processInlineSpirvAttributes(decl);
 
   // Add DebugFunctionDefinition if we are emitting

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12523,6 +12523,13 @@ void SpirvEmitter::processInlineSpirvAttributes(const FunctionDecl *decl) {
           modeAttr->getLocation());
     }
   }
+
+  // Handle extension and capability attrs
+  if (decl->hasAttr<VKExtensionExtAttr>() ||
+      decl->hasAttr<VKCapabilityExtAttr>()) {
+    createSpirvIntrInstExt(decl->getAttrs(), QualType(), /* spvArgs */ {},
+                           /* isInst */ false, decl->getLocStart());
+  }
 }
 
 bool SpirvEmitter::processGeometryShaderAttributes(const FunctionDecl *decl,
@@ -13112,8 +13119,6 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   assert(entryInfo->isEntryFunction);
   entryInfo->entryFunction = entryFunction;
 
-  processInlineSpirvAttributes(decl);
-
   if (spvContext.isRay()) {
     return emitEntryFunctionWrapperForRayTracing(decl, entryFuncInstr,
                                                  debugFunction);
@@ -13190,6 +13195,8 @@ bool SpirvEmitter::emitEntryFunctionWrapper(const FunctionDecl *decl,
   // The entry basic block.
   auto *entryLabel = spvBuilder.createBasicBlock();
   spvBuilder.setInsertPoint(entryLabel);
+
+  processInlineSpirvAttributes(decl);
 
   // Add DebugFunctionDefinition if we are emitting
   // NonSemantic.Shader.DebugInfo.100 debug info.

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.capability.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.capability.hlsl
@@ -1,10 +1,12 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl -Vd %s -spirv | FileCheck %s
 
+// CHECK: OpCapability Int8
 // CHECK: OpCapability SampleMaskPostDepthCoverage
 
 [[vk::ext_capability(/* SampleMaskPostDepthCoverageCapability */ 4447)]]
 int val;
 
+[[vk::ext_capability(/* Int8 */ 39)]]
 void main() {
   int local = val;
 }

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.extension.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.extension.hlsl
@@ -1,11 +1,13 @@
 // RUN: %dxc -T ps_6_0 -E main -fcgl %s -spirv | FileCheck %s
 
+// CHECK: OpExtension "entry_point_extension"
 // CHECK: OpExtension "another_extension"
 // CHECK: OpExtension "some_extension"
 
 [[vk::ext_extension("some_extension"), vk::ext_extension("another_extension")]]
 int val;
 
+[[vk::ext_extension("entry_point_extension")]]
 void main() {
   int local = val;
 }


### PR DESCRIPTION
`ext_capability` and `ext_extension` were previously only handled when translating a CallExpr. Since the entry point is never called, they were ignored when attached to it.