### PR TITLE
Add ShaderFeatureInfo flags for SM6.8 comparison sampling / extended command info

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1887,8 +1887,10 @@ const uint64_t ShaderFeatureInfo_WriteableMSAATextures = 0x40000000;
 // SM 6.8+
 // WaveMMA slots in between two SM 6.6 feature bits.
 const uint64_t ShaderFeatureInfo_WaveMMA = 0x8000000;
+const uint64_t ShaderFeatureInfo_SampleCmpGradientOrBias = 0x80000000;
+const uint64_t ShaderFeatureInfo_ExtendedCommandInfo = 0x100000000ull;
 
-const unsigned ShaderFeatureInfoCount = 31;
+const unsigned ShaderFeatureInfoCount = 33;
 
 // DxilSubobjectType must match D3D12_STATE_SUBOBJECT_TYPE, with
 // certain values reserved, since they cannot be used from Dxil.

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -347,6 +347,8 @@ PCSTR g_pFeatureInfoNames[] = {
     "64-bit Atomics on Heap Resources",
     "Advanced Texture Ops",
     "Writeable MSAA Textures",
+    "SampleCmp with gradient or bias",
+    "Extended command info",
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount,
               "g_pFeatureInfoNames needs to be updated");


### PR DESCRIPTION
These will be optional in shader model 6.8, so we'll need to detect their usage and set these flags accordingly, so that D3D can validate against driver capabilities. This change simply reserves the bits; the actual detection to set them in the shader still needs to be done.