### PR TITLE
[SPIR-V] Implement type alias, type alias templates, and variable templates

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -982,7 +982,9 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
 }
 
 void SpirvEmitter::doDecl(const Decl *decl) {
-  if (isa<EmptyDecl>(decl) || isa<TypedefDecl>(decl))
+  if (isa<EmptyDecl>(decl) || isa<TypedefDecl>(decl) ||
+      isa<TypeAliasDecl>(decl) || isa<TypeAliasTemplateDecl>(decl) ||
+      isa<VarTemplateDecl>(decl))
     return;
 
   // Implicit decls are lazily created when needed.

--- a/tools/clang/test/CodeGenSPIRV/type.type-alias.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.type-alias.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T vs_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+using myInt = int;
+using myConstUint = const uint;
+using v4f = float4;
+using m2v3f = float2x3;
+
+void main() {
+// CHECK-LABEL: %bb_entry = OpLabel
+
+// CHECK: %v1 = OpVariable %_ptr_Function_int Function
+    myInt v1;
+// CHECK: %v2 = OpVariable %_ptr_Function_uint Function
+    myConstUint v2;
+// CHECK: %v3 = OpVariable %_ptr_Function_v4float Function
+    v4f v3;
+// CHECK: %v4 = OpVariable %_ptr_Function_mat2v3float Function
+    m2v3f v4;
+}

--- a/tools/clang/test/CodeGenSPIRV/type.type-alias.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.type-alias.template.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+template<class T, T val>
+struct integral_constant {
+    static const T value = val;
+};
+
+template <bool val>
+using bool_constant = integral_constant<bool, val>;
+
+bool main(): SV_Target {
+// CHECK: OpStore %value %true
+// CHECK: %tru = OpVariable %_ptr_Function_integral_constant Function
+  bool_constant<true> tru;
+
+// CHECK: [[value:%[0-9]+]] = OpLoad %bool %value
+// CHECK: OpReturnValue [[value]]
+  return tru.value;
+}

--- a/tools/clang/test/CodeGenSPIRV/var.template.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.template.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+// CHECK: OpStore %is_same_v_0 %false
+template <class, class>
+static const bool is_same_v = false;
+
+// CHECK: OpStore %is_same_v_1 %true
+template <class T>
+static const bool is_same_v<T, T> = true;
+
+RWStructuredBuffer<bool> outs;
+
+void main() {
+// CHECK: [[inequal:%[0-9]+]] = OpLoad %bool %is_same_v_0
+// CHECK:  [[outs_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %outs %int_0 %uint_0
+// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint [[inequal]] %uint_1 %uint_0
+// CHECK:                         OpStore [[outs_0]] [[as_uint]]
+  outs[0] = is_same_v<int, bool>;
+// CHECK:   [[equal:%[0-9]+]] = OpLoad %bool %is_same_v_1
+// CHECK:  [[outs_1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %outs %int_0 %uint_1
+// CHECK: [[as_uint:%[0-9]+]] = OpSelect %uint [[equal]] %uint_1 %uint_0
+// CHECK:                         OpStore [[outs_1]] [[as_uint]]
+  outs[1] = is_same_v<int, int>;
+}


### PR DESCRIPTION
Apparently the frontend already provides everything we need for these declarations to work; we just needed to ignore them when handling `Decl`s.

Fixes #5751.