### PR TITLE
Add DXIL 1.8 op code cap and move WaveMatrix intrisics to SM 6.9

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -975,6 +975,7 @@ enum class OpCode : unsigned {
   NumOpCodes_Dxil_1_5 = 216,
   NumOpCodes_Dxil_1_6 = 222,
   NumOpCodes_Dxil_1_7 = 226,
+  NumOpCodes_Dxil_1_8 = 258,
 
   NumOpCodes = 258 // exclusive last value of enumeration
 };
@@ -1290,6 +1291,7 @@ enum class OpCodeClass : unsigned {
   NumOpClasses_Dxil_1_5 = 143,
   NumOpClasses_Dxil_1_6 = 149,
   NumOpClasses_Dxil_1_7 = 153,
+  NumOpClasses_Dxil_1_8 = 183,
 
   NumOpClasses = 183 // exclusive last value of enumeration
 };

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -3160,18 +3160,6 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     minor = 7;
     return;
   }
-  // Instructions: WaveMatrix_Annotate=226, WaveMatrix_Depth=227,
-  // WaveMatrix_Fill=228, WaveMatrix_LoadRawBuf=229,
-  // WaveMatrix_LoadGroupShared=230, WaveMatrix_StoreRawBuf=231,
-  // WaveMatrix_StoreGroupShared=232, WaveMatrix_Multiply=233,
-  // WaveMatrix_MultiplyAccumulate=234, WaveMatrix_ScalarOp=235,
-  // WaveMatrix_SumAccumulate=236, WaveMatrix_Add=237
-  if ((226 <= op && op <= 237)) {
-    major = 6;
-    minor = 7;
-    mask = SFLAG(Library) | SFLAG(Compute);
-    return;
-  }
   // Instructions: QuadVote=222
   if (op == 222) {
     if (bWithTranslation) {
@@ -3217,6 +3205,18 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     major = 6;
     minor = 8;
     mask = SFLAG(Vertex);
+    return;
+  }
+  // Instructions: WaveMatrix_Annotate=226, WaveMatrix_Depth=227,
+  // WaveMatrix_Fill=228, WaveMatrix_LoadRawBuf=229,
+  // WaveMatrix_LoadGroupShared=230, WaveMatrix_StoreRawBuf=231,
+  // WaveMatrix_StoreGroupShared=232, WaveMatrix_Multiply=233,
+  // WaveMatrix_MultiplyAccumulate=234, WaveMatrix_ScalarOp=235,
+  // WaveMatrix_SumAccumulate=236, WaveMatrix_Add=237
+  if ((226 <= op && op <= 237)) {
+    major = 6;
+    minor = 9;
+    mask = SFLAG(Library) | SFLAG(Compute);
     return;
   }
   // OPCODE-SMMASK:END

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Add-limited.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Add-limited.hlsl
@@ -1,9 +1,9 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DADD_TY=WMLC %s | FileCheck %s -DADD_TY=2 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DADD_TY=WMRR %s | FileCheck %s -DADD_TY=3 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DADD_TY=WMA %s | FileCheck %s -DADD_TY=4 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -ast-dump -DADD_TY=WMLC %s | FileCheck %s -DADD_TY=WaveMatrixLeftColAcc -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -ast-dump -DADD_TY=WMRR %s | FileCheck %s -DADD_TY=WaveMatrixRightRowAcc -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -ast-dump -DADD_TY=WMA %s | FileCheck %s -DADD_TY=WaveMatrixAccumulator -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DADD_TY=WMLC %s | FileCheck %s -DADD_TY=2 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DADD_TY=WMRR %s | FileCheck %s -DADD_TY=3 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DADD_TY=WMA %s | FileCheck %s -DADD_TY=4 -DCOMP=9 -DDIMM=16 -DDIMN=16 -check-prefix=CHKIR
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -ast-dump -DADD_TY=WMLC %s | FileCheck %s -DADD_TY=WaveMatrixLeftColAcc -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -ast-dump -DADD_TY=WMRR %s | FileCheck %s -DADD_TY=WaveMatrixRightRowAcc -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -ast-dump -DADD_TY=WMA %s | FileCheck %s -DADD_TY=WaveMatrixAccumulator -DCOMP=float -DDIMM=16 -DDIMN=16 -check-prefix=CHKAST
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Depth.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Depth.hlsl
@@ -1,10 +1,10 @@
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=half -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64
-// RUN: %dxc -E main -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=half -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64
+// RUN: %dxc -E main -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Fill-acc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Fill-acc.hlsl
@@ -1,9 +1,9 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Fill-in.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Fill-in.hlsl
@@ -1,10 +1,10 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_LoadStore-acc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_LoadStore-acc.hlsl
@@ -1,9 +1,9 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_LoadStore-in.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_LoadStore-in.hlsl
@@ -1,10 +1,10 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Multiply-Add-acc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_Multiply-Add-acc.hlsl
@@ -1,11 +1,11 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DCOMP_IN=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DCOMP_IN=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DCOMP_IN=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DCOMP_IN=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_ScalarOps-acc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_ScalarOps-acc.hlsl
@@ -1,9 +1,9 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_SumAccumulate-acc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix_SumAccumulate-acc.hlsl
@@ -1,11 +1,11 @@
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float16_t -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DCOMP_IN=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=int -DCOMP_IN=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
-// RUN: %dxc -enable-16bit-types -T cs_6_8 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float16_t -DCOMP_IN=float16_t -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=8 -DCOMP_IN=8 -DDIMM=16 -DDIMN=16 -DOLOAD=f16
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DCOMP_IN=int8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=17 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=int -DCOMP_IN=uint8_t4_packed -DDIMM=16 -DDIMN=16 %s | FileCheck %s -DCOMP=4 -DCOMP_IN=18 -DDIMM=16 -DDIMN=16 -DOLOAD=i32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=16 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=16 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=16 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=16 -DDIMN=64 -DOLOAD=f32
+// RUN: %dxc -enable-16bit-types -T cs_6_9 -DCOMP=float -DCOMP_IN=float -DDIMM=64 -DDIMN=64 %s | FileCheck %s -DCOMP=9 -DCOMP_IN=9 -DDIMM=64 -DDIMN=64 -DOLOAD=f32
 
 // CHECK: ; Note: shader requires additional functionality:
 // CHECK: ;       Wave level operations

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
@@ -1,2 +1,0 @@
-# HLSL Change - Disable WaveMatrix tests, shader model 6.9 is not enabled yet
-config.unsupported = True

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
@@ -1,2 +1,2 @@
 # HLSL Change - Disable WaveMatrix tests, shader model 6.9 is not enabled yet
-config.unsupported = False
+config.unsupported = True

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/lit.local.cfg
@@ -1,0 +1,2 @@
+# HLSL Change - Disable WaveMatrix tests, shader model 6.9 is not enabled yet
+config.unsupported = False

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -646,7 +646,7 @@ class db_dxil(object):
             + "WaveMatrix_SumAccumulate,WaveMatrix_Add"
         ).split(","):
             self.name_idx[i].category = "WaveMatrix"
-            self.name_idx[i].shader_model = 6, 7
+            self.name_idx[i].shader_model = 6, 9
             self.name_idx[i].shader_stages = (
                 "library",
                 "compute",
@@ -5658,6 +5658,13 @@ class db_dxil(object):
             [db_dxil_param(0, "i32", "", "result")],
         )
         next_op_idx += 1
+
+        # End of DXIL 1.8 opcodes.
+        self.set_op_count_for_version(1, 8, next_op_idx)
+        assert next_op_idx == 258, (
+            "258 is expected next operation index but encountered %d and thus opcodes are broken"
+            % next_op_idx
+        )
 
         # Set interesting properties.
         self.build_indices()


### PR DESCRIPTION
Adds max opcode value for DXIL 1.8 and moves WaveMatrix intrinsics into future shader model 6.9.

Contributes to #6133
Related to #6125