### PR TITLE
[SM68] Add feature flag for SampleCmpBias/Grad and StartInstance/VertexLocation

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1889,8 +1889,9 @@ const uint64_t ShaderFeatureInfo_WriteableMSAATextures = 0x40000000;
 const uint64_t ShaderFeatureInfo_WaveMMA = 0x8000000;
 
 const uint64_t ShaderFeatureInfo_SampleCmpGradientOrBias = 0x80000000;
+const uint64_t ShaderFeatureInfo_ExtendedCommandInfo = 0x100000000;
 
-const unsigned ShaderFeatureInfoCount = 32;
+const unsigned ShaderFeatureInfoCount = 33;
 
 // DxilSubobjectType must match D3D12_STATE_SUBOBJECT_TYPE, with
 // certain values reserved, since they cannot be used from Dxil.

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -1888,7 +1888,9 @@ const uint64_t ShaderFeatureInfo_WriteableMSAATextures = 0x40000000;
 // WaveMMA slots in between two SM 6.6 feature bits.
 const uint64_t ShaderFeatureInfo_WaveMMA = 0x8000000;
 
-const unsigned ShaderFeatureInfoCount = 31;
+const uint64_t ShaderFeatureInfo_SampleCmpGradientOrBias = 0x80000000;
+
+const unsigned ShaderFeatureInfoCount = 32;
 
 // DxilSubobjectType must match D3D12_STATE_SUBOBJECT_TYPE, with
 // certain values reserved, since they cannot be used from Dxil.

--- a/include/dxc/DXIL/DxilShaderFlags.h
+++ b/include/dxc/DXIL/DxilShaderFlags.h
@@ -204,6 +204,9 @@ public:
     return m_bSampleCmpGradientOrBias;
   }
 
+  void SetExtendedCommandInfo(bool flag) { m_bExtendedCommandInfo = flag; }
+  bool GetExtendedCommandInfo() const { return m_bExtendedCommandInfo; }
+
 private:
   unsigned
       m_bDisableOptimizations : 1; // D3D11_1_SB_GLOBAL_FLAG_SKIP_OPTIMIZATION
@@ -284,8 +287,8 @@ private:
   // SM 6.8+
   unsigned m_bWaveMMA : 1; // SHADER_FEATURE_WAVE_MMA
   unsigned m_bSampleCmpGradientOrBias : 1; // SHADER_FEATURE_SAMPLE_CMP_GRADIENT_OR_BIAS
-
-  uint32_t m_align1 : 26; // align to 64 bit.
+  unsigned m_bExtendedCommandInfo : 1; // SHADER_FEATURE_EXTENDED_COMMAND_INFO
+  uint32_t m_align1 : 25; // align to 64 bit.
 };
 
 } // namespace hlsl

--- a/include/dxc/DXIL/DxilShaderFlags.h
+++ b/include/dxc/DXIL/DxilShaderFlags.h
@@ -200,9 +200,7 @@ public:
   void SetSampleCmpGradientOrBias(bool flag) {
     m_bSampleCmpGradientOrBias = flag;
   }
-  bool GetSampleCmpGradientOrBias() const {
-    return m_bSampleCmpGradientOrBias;
-  }
+  bool GetSampleCmpGradientOrBias() const { return m_bSampleCmpGradientOrBias; }
 
   void SetExtendedCommandInfo(bool flag) { m_bExtendedCommandInfo = flag; }
   bool GetExtendedCommandInfo() const { return m_bExtendedCommandInfo; }
@@ -286,9 +284,10 @@ private:
 
   // SM 6.8+
   unsigned m_bWaveMMA : 1; // SHADER_FEATURE_WAVE_MMA
-  unsigned m_bSampleCmpGradientOrBias : 1; // SHADER_FEATURE_SAMPLE_CMP_GRADIENT_OR_BIAS
+  unsigned
+      m_bSampleCmpGradientOrBias : 1; // SHADER_FEATURE_SAMPLE_CMP_GRADIENT_OR_BIAS
   unsigned m_bExtendedCommandInfo : 1; // SHADER_FEATURE_EXTENDED_COMMAND_INFO
-  uint32_t m_align1 : 25; // align to 64 bit.
+  uint32_t m_align1 : 25;              // align to 64 bit.
 };
 
 } // namespace hlsl

--- a/include/dxc/DXIL/DxilShaderFlags.h
+++ b/include/dxc/DXIL/DxilShaderFlags.h
@@ -197,6 +197,13 @@ public:
   void SetWaveMMA(bool flag) { m_bWaveMMA = flag; }
   bool GetWaveMMA() const { return m_bWaveMMA; }
 
+  void SetSampleCmpGradientOrBias(bool flag) {
+    m_bSampleCmpGradientOrBias = flag;
+  }
+  bool GetSampleCmpGradientOrBias() const {
+    return m_bSampleCmpGradientOrBias;
+  }
+
 private:
   unsigned
       m_bDisableOptimizations : 1; // D3D11_1_SB_GLOBAL_FLAG_SKIP_OPTIMIZATION
@@ -276,8 +283,9 @@ private:
 
   // SM 6.8+
   unsigned m_bWaveMMA : 1; // SHADER_FEATURE_WAVE_MMA
+  unsigned m_bSampleCmpGradientOrBias : 1; // SHADER_FEATURE_SAMPLE_CMP_GRADIENT_OR_BIAS
 
-  uint32_t m_align1 : 27; // align to 64 bit.
+  uint32_t m_align1 : 26; // align to 64 bit.
 };
 
 } // namespace hlsl

--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -780,10 +780,10 @@ ShaderFlags ShaderFlags::CollectShaderFlags(const Function *F,
   flag.SetAdvancedTextureOps(hasAdvancedTextureOps);
   flag.SetWriteableMSAATextures(hasWriteableMSAATextures);
   flag.SetWaveMMA(hasWaveMMA);
-  flag.SetSampleCmpGradientOrBias(hasSampleCmpGradientOrBias);
   // Only bother setting the flag when there are UAVs.
   flag.SetResMayNotAlias(canSetResMayNotAlias && hasUAVs &&
                          !M->GetResMayAlias());
+  flag.SetSampleCmpGradientOrBias(hasSampleCmpGradientOrBias);
   flag.SetExtendedCommandInfo(hasExtendedCommandInfo);
 
   return flag;

--- a/lib/DXIL/DxilShaderFlags.cpp
+++ b/lib/DXIL/DxilShaderFlags.cpp
@@ -127,12 +127,12 @@ uint64_t ShaderFlags::GetFeatureInfo() const {
   Flags |= m_bWaveMMA ? hlsl::DXIL::ShaderFeatureInfo_WaveMMA : 0;
 
   Flags |= m_bSampleCmpGradientOrBias
-                 ? hlsl::DXIL::ShaderFeatureInfo_SampleCmpGradientOrBias
-                 : 0;
+               ? hlsl::DXIL::ShaderFeatureInfo_SampleCmpGradientOrBias
+               : 0;
 
   Flags |= m_bExtendedCommandInfo
-                 ? hlsl::DXIL::ShaderFeatureInfo_ExtendedCommandInfo
-                 : 0;
+               ? hlsl::DXIL::ShaderFeatureInfo_ExtendedCommandInfo
+               : 0;
 
   return Flags;
 }

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpBias.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpBias.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -Tps_6_8 %s | FileCheck %s
 
-// CHECK: SampleCmpGradientOrBias
+// CHECK: SampleCmp with gradient or bias
 SamplerComparisonState samp1;
 Texture1D<float4> tex1d;
 Texture1DArray<float4> tex1d_array;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpBias.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpBias.hlsl
@@ -1,5 +1,6 @@
 // RUN: %dxc -Tps_6_8 %s | FileCheck %s
 
+// CHECK: SampleCmpGradientOrBias
 SamplerComparisonState samp1;
 Texture1D<float4> tex1d;
 Texture1DArray<float4> tex1d_array;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpGrad.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpGrad.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -Tps_6_8 %s | FileCheck %s
 
-// CHECK: SampleCmpGradientOrBias
+// CHECK: SampleCmp with gradient or bias
 SamplerComparisonState samp1;
 
 Texture2D<float4> tex2d;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpGrad.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/SampleCmpGrad.hlsl
@@ -1,5 +1,6 @@
 // RUN: %dxc -Tps_6_8 %s | FileCheck %s
 
+// CHECK: SampleCmpGradientOrBias
 SamplerComparisonState samp1;
 
 Texture2D<float4> tex2d;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
@@ -9,7 +9,7 @@
 // From DXC disassembly comment:
 // CHECK: Note: shader requires additional functionality:
 // CHECK-NEXT: Tiled resources
-// CMPBG-NEXT: SampleCmpGradientOrBias
+// CMPBG-NEXT: SampleCmp with gradient or bias
 
 // CHECK:define void @[[name:[a-z_]+]]()
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
@@ -1,28 +1,23 @@
-// RUN: %dxilver 1.8 | %dxc -E test_sample -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
+// RUN: %dxilver 1.8 | %dxc -E test_sample -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
 
 // LOD clamp requires TiledResources feature
 // From DXC disassembly comment:
 // CHECK: Note: shader requires additional functionality:
-// CMPBG: Note: shader requires additional functionality:
 // CHECK-NEXT: Tiled resources
-// CMPBG-NEXT: Tiled resources
 // CMPBG-NEXT: SampleCmpGradientOrBias
 
 // CHECK:define void @[[name:[a-z_]+]]()
-// CMPBG:define void @[[name:[a-z_]+]]()
 
 // CHECK: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
-// CMPBG: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
 // CHECK: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
-// CMPBG: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
 
 // tag 0: ShaderFlags, 4096 = Tiled resources
-// CHECK: ![[extAttr]] = !{i32 0, i64 4096}
+// NRM: ![[extAttr]] = !{i32 0, i64 4096}
 
 // tag 0: ShaderFlags, 137438957568 = Tiled resources and SampleCmpGradientOrBias
 // CMPBG: ![[extAttr]] = !{i32 0, i64 137438957568}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/has_lod_clmap.hlsl
@@ -2,21 +2,30 @@
 // RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
 
 // LOD clamp requires TiledResources feature
 // From DXC disassembly comment:
 // CHECK: Note: shader requires additional functionality:
+// CMPBG: Note: shader requires additional functionality:
 // CHECK-NEXT: Tiled resources
+// CMPBG-NEXT: Tiled resources
+// CMPBG-NEXT: SampleCmpGradientOrBias
 
 // CHECK:define void @[[name:[a-z_]+]]()
+// CMPBG:define void @[[name:[a-z_]+]]()
 
 // CHECK: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
+// CMPBG: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
 // CHECK: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
+// CMPBG: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
 
 // tag 0: ShaderFlags, 4096 = Tiled resources
 // CHECK: ![[extAttr]] = !{i32 0, i64 4096}
+
+// tag 0: ShaderFlags, 137438957568 = Tiled resources and SampleCmpGradientOrBias
+// CMPBG: ![[extAttr]] = !{i32 0, i64 137438957568}
 
 Texture2D T2D;
 SamplerState S;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
@@ -2,26 +2,34 @@
 // RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
 // RUN: %dxilver 1.8 | %dxc -E test_sample_zero -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_sampleb_zero -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_sampleg_zero -T ps_6_8 %s | FileCheck %s
 // RUN: %dxilver 1.8 | %dxc -E test_samplec_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg_zero -T ps_6_8 %s | FileCheck %s
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb_zero -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg_zero -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
 
 // Make sure no tile resources when no lod clamp or clamp is 0.
 
 // CHECK-NOT: Tiled resources
+// CMPBG-NOT: Tiled resources
+// CMPBG: SampleCmpGradientOrBias
 
 // CHECK:define void @[[name:[a-z_]+]]()
+// CMPBG:define void @[[name:[a-z_]+]]()
 
 // CHECK: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
+// CMPBG: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
 // CHECK: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, null}
+// CMPBG: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
 
 // tag 0: ShaderFlags, 4096 = Tiled resources
 // CHECK-NOT:!{i32 0, i64 4096}
+
+// tag 0: ShaderFlags, 137438953472 = SampleCmpGradientOrBias
+// CMPBG: ![[extAttr]] = !{i32 0, i64 137438953472}
 
 Texture2D T2D;
 SamplerState S;

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
@@ -1,32 +1,29 @@
-// RUN: %dxilver 1.8 | %dxc -E test_sample -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
-// RUN: %dxilver 1.8 | %dxc -E test_sample_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleb_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_sampleg_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplec_zero -T ps_6_8 %s | FileCheck %s
-// RUN: %dxilver 1.8 | %dxc -E test_samplecb_zero -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
-// RUN: %dxilver 1.8 | %dxc -E test_samplecg_zero -T ps_6_8 %s | FileCheck %s -check-prefix=CMPBG
+// RUN: %dxilver 1.8 | %dxc -E test_sample -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleb -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleg -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplec -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sample_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleb_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_sampleg_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplec_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=NRM,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecb_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
+// RUN: %dxilver 1.8 | %dxc -E test_samplecg_zero -T ps_6_8 %s | FileCheck %s -check-prefixes=CMPBG,CHECK
 
 // Make sure no tile resources when no lod clamp or clamp is 0.
 
 // CHECK-NOT: Tiled resources
-// CMPBG-NOT: Tiled resources
 // CMPBG: SampleCmpGradientOrBias
 
 // CHECK:define void @[[name:[a-z_]+]]()
-// CMPBG:define void @[[name:[a-z_]+]]()
 
 // CHECK: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
-// CMPBG: !dx.entryPoints = !{![[entryPoints:[0-9]+]]}
-// CHECK: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, null}
+// NRM: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, null}
 // CMPBG: ![[entryPoints]] = !{void ()* @[[name]], !"[[name]]", !{{[0-9]+}}, !{{[0-9]+}}, ![[extAttr:[0-9]+]]}
 
 // tag 0: ShaderFlags, 4096 = Tiled resources
-// CHECK-NOT:!{i32 0, i64 4096}
+// NRM-NOT:!{i32 0, i64 4096}
 
 // tag 0: ShaderFlags, 137438953472 = SampleCmpGradientOrBias
 // CMPBG: ![[extAttr]] = !{i32 0, i64 137438953472}

--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/Texture/no_lod_clmap.hlsl
@@ -14,7 +14,7 @@
 // Make sure no tile resources when no lod clamp or clamp is 0.
 
 // CHECK-NOT: Tiled resources
-// CMPBG: SampleCmpGradientOrBias
+// CMPBG: SampleCmp with gradient or bias
 
 // CHECK:define void @[[name:[a-z_]+]]()
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
@@ -1,14 +1,18 @@
 // RUN: %dxc -E main -T vs_6_8 %s | FileCheck %s
 
+// CHECK: ExtendedCommandInfo
 // CHECK: @main
 
 // CHECK: call i32 @dx.op.startInstanceLocation.i32(i32 257)
 // CHECK: call i32 @dx.op.startVertexLocation.i32(i32 256)
 
 // Make sure no input element is generated for the entry point.
-// CHECK: !{void ()* @main, !"main", ![[SIG:[0-9]+]], null, null}
+// CHECK: !{void ()* @main, !"main", ![[SIG:[0-9]+]], null, ![[extAttr:[0-9]+]]}
 // The input should be null
 // CHECK: ![[SIG]] = !{null,
+
+// tag 0: ShaderFlags, ExtendedCommandInfo = SampleCmpGradientOrBias
+// CHECK: ![[extAttr]] = !{i32 0, i64 ExtendedCommandInfo}
 
 float4 main(int loc : SV_StartVertexLocation
            , uint loc2 : SV_StartInstanceLocation

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T vs_6_8 %s | FileCheck %s
 
-// CHECK: ExtendedCommandInfo
+// CHECK: Extended command info
 // CHECK: @main
 
 // CHECK: call i32 @dx.op.startInstanceLocation.i32(i32 257)

--- a/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/semantics/ExtendedCommandInformation/no_in_sig_input.hlsl
@@ -11,8 +11,8 @@
 // The input should be null
 // CHECK: ![[SIG]] = !{null,
 
-// tag 0: ShaderFlags, ExtendedCommandInfo = SampleCmpGradientOrBias
-// CHECK: ![[extAttr]] = !{i32 0, i64 ExtendedCommandInfo}
+// tag 0: ShaderFlags, 274877906944 = SampleCmpGradientOrBias
+// CHECK: ![[extAttr]] = !{i32 0, i64 274877906944}
 
 float4 main(int loc : SV_StartVertexLocation
            , uint loc2 : SV_StartInstanceLocation

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -347,6 +347,7 @@ PCSTR g_pFeatureInfoNames[] = {
     "64-bit Atomics on Heap Resources",
     "Advanced Texture Ops",
     "Writeable MSAA Textures",
+    "SampleCmpGradientOrBias",
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount,
               "g_pFeatureInfoNames needs to be updated");

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -347,8 +347,8 @@ PCSTR g_pFeatureInfoNames[] = {
     "64-bit Atomics on Heap Resources",
     "Advanced Texture Ops",
     "Writeable MSAA Textures",
-    "SampleCmpGradientOrBias",
-    "ExtendedCommandInfo",
+    "SampleCmp with gradient or bias",
+    "Extended command info",
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount,
               "g_pFeatureInfoNames needs to be updated");

--- a/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
+++ b/tools/clang/tools/dxcompiler/dxcdisassembler.cpp
@@ -348,6 +348,7 @@ PCSTR g_pFeatureInfoNames[] = {
     "Advanced Texture Ops",
     "Writeable MSAA Textures",
     "SampleCmpGradientOrBias",
+    "ExtendedCommandInfo",
 };
 static_assert(_countof(g_pFeatureInfoNames) == ShaderFeatureInfoCount,
               "g_pFeatureInfoNames needs to be updated");


### PR DESCRIPTION
New feature flag ShaderFeatureInfo_SampleCmpGradientOrBias = 0x80000000 and 
ShaderFeatureInfo_ExtendedCommandInfo = 0x100000000 were added. 
 They will be set when SampleCmpBias/Grad startInstance/VertexLocation exists.