### PR TITLE
Remove SPIRV test case from Sema tests related to DS/HS patch size

### DIFF
--- a/tools/clang/test/SemaHLSL/ds-error-outputpatch-size.hlsl
+++ b/tools/clang/test/SemaHLSL/ds-error-outputpatch-size.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -T ds_6_0 -E main -verify %s
-// RUN: %dxc -T ds_6_0 -E main -verify %s -spirv
 
 struct ControlPoint {
   float position : MY_BOOL;

--- a/tools/clang/test/SemaHLSL/hs-error-inputpatch-size.hlsl
+++ b/tools/clang/test/SemaHLSL/hs-error-inputpatch-size.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -T hs_6_0 -E main -verify %s
-// RUN: %dxc -T hs_6_0 -E main -verify %s -spirv
 
 struct ControlPoint {
   float position : MY_BOOL;


### PR DESCRIPTION
The tests are for an error message that originates from Sema HLSL, it is a not a spirv-specific code. The `-spirv` test case does not bring any additional value. And since these tests are not marked spirv-only (as they should not be), they are failing when the compiler is built without SPIRV support.