### PR TITLE
Make clang-format happy

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -117,6 +117,11 @@ function(add_hlsl_hctgen mode)
                       COMMENT "Updating ${ARG_OUTPUT}..."
                       )
   endif()
-  add_custom_target(${mode} ${verification} DEPENDS ${output})
+
+  add_custom_target(${mode}
+                    COMMAND ${verification}
+                    DEPENDS ${output}
+                    COMMENT "Verifying clang-format results...")
+
   add_dependencies(HCTGen ${mode})
 endfunction()

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -256,7 +256,7 @@ const ShaderModel *ShaderModel::GetByName(llvm::StringRef Name) {
   case '1':
     Minor = 1;
     break;
-  // clang-format off
+    // clang-format off
   // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_shader_model_by_name()</py>*/
   // clang-format on
@@ -369,7 +369,7 @@ void ShaderModel::GetMinValidatorVersion(unsigned &ValMajor,
   DXASSERT(IsValidForDxil(), "invalid shader model");
   ValMajor = 1;
   switch (m_Minor) {
-  // clang-format off
+    // clang-format off
   // Python lines need to be not formatted.
   /* <py::lines('VALRULE-TEXT')>hctdb_instrhelp.get_min_validator_version()</py>*/
   // clang-format on


### PR DESCRIPTION
The build is failing due to clang-format modifying these lines. I've changed them to what clang-format wants even though it's a bit odd, and updated the CMake script to make the error message more clear when this type of failure occurs.