### PR TITLE
Defer DiaSession's symbol init (it is unused by WinPix (or anyone?))

### DIFF
--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -99,12 +99,15 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
 }
 
 const dxil_dia::SymbolManager &dxil_dia::Session::SymMgr() {
-  try {
-    m_symsMgr.Init(this);
-  } catch (const hlsl::Exception &) {
-    m_symsMgr = dxil_dia::SymbolManager();
+  if (!m_symsMgr) {
+    try {
+      m_symsMgr.reset(new dxil_dia::SymbolManager());
+      m_symsMgr->Init(this);
+    } catch (const hlsl::Exception &) {
+      m_symsMgr.reset(new dxil_dia::SymbolManager());
+    }
   }
-  return m_symsMgr;
+  return *m_symsMgr;
 }
 
 HRESULT dxil_dia::Session::getSourceFileIdByName(llvm::StringRef fileName,

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -96,13 +96,15 @@ void dxil_dia::Session::Init(std::shared_ptr<llvm::LLVMContext> context,
     DXASSERT(m_rvaMap[It->second] == It->first,
              "instruction mapped to wrong rva");
   }
+}
 
-  // Initialize symbols
+const dxil_dia::SymbolManager &dxil_dia::Session::SymMgr() {
   try {
     m_symsMgr.Init(this);
   } catch (const hlsl::Exception &) {
     m_symsMgr = dxil_dia::SymbolManager();
   }
+  return m_symsMgr;
 }
 
 HRESULT dxil_dia::Session::getSourceFileIdByName(llvm::StringRef fileName,
@@ -138,7 +140,7 @@ STDMETHODIMP dxil_dia::Session::get_globalScope(
   *pRetVal = nullptr;
 
   Symbol *ret;
-  IFR(m_symsMgr.GetGlobalScope(&ret));
+  IFR(SymMgr().GetGlobalScope(&ret));
   *pRetVal = ret;
   return S_OK;
 }
@@ -378,7 +380,7 @@ STDMETHODIMP dxil_dia::Session::findInlineFramesByAddr(
 
   HRESULT hr;
   SymbolChildrenEnumerator *ChildrenEnum;
-  IFR(hr = m_symsMgr.DbgScopeOf(It->second, &ChildrenEnum));
+  IFR(hr = SymMgr().DbgScopeOf(It->second, &ChildrenEnum));
 
   *ppResult = ChildrenEnum;
   return hr;

--- a/lib/DxilDia/DxilDiaSession.h
+++ b/lib/DxilDia/DxilDiaSession.h
@@ -61,7 +61,7 @@ public:
   hlsl::DxilModule &DxilModuleRef() { return *m_dxilModule.get(); }
   llvm::Module &ModuleRef() { return *m_module.get(); }
   llvm::DebugInfoFinder &InfoRef() { return *m_finder.get(); }
-  const SymbolManager &SymMgr() const { return m_symsMgr; }
+  const SymbolManager &SymMgr();
   const RVAMap &InstructionsRef() const { return m_instructions; }
   const std::vector<const llvm::Instruction *> &InstructionLinesRef() const {
     return m_instructionLines;

--- a/lib/DxilDia/DxilDiaSession.h
+++ b/lib/DxilDia/DxilDiaSession.h
@@ -499,7 +499,7 @@ private:
   std::unordered_map<const llvm::Instruction *, RVA>
       m_rvaMap; // Map instruction to its RVA.
   LineToInfoMap m_lineToInfoMap;
-  SymbolManager m_symsMgr;
+  std::unique_ptr<SymbolManager> m_symsMgr;
 
 private:
   CComPtr<IDiaEnumTables> m_pEnumTables;

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -2343,7 +2343,8 @@ dxil_dia::SymbolManager::SymbolManager() = default;
 dxil_dia::SymbolManager::~SymbolManager() { m_pSession = nullptr; }
 
 void dxil_dia::SymbolManager::Init(Session *pSes) {
-  DXASSERT(m_pSession == nullptr, "SymbolManager already initialized");
+  if (m_pSession != nullptr)
+    return; // Already initialized
   m_pSession = pSes;
   m_symbolCtors.clear();
   m_parentToChildren.clear();

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -2343,8 +2343,7 @@ dxil_dia::SymbolManager::SymbolManager() = default;
 dxil_dia::SymbolManager::~SymbolManager() { m_pSession = nullptr; }
 
 void dxil_dia::SymbolManager::Init(Session *pSes) {
-  if (m_pSession != nullptr)
-    return; // Already initialized
+  DXASSERT(m_pSession == nullptr, "SymbolManager already initialized");
   m_pSession = pSes;
   m_symbolCtors.clear();
   m_parentToChildren.clear();


### PR DESCRIPTION
The init of the dia symbol manager presents an unneccessary performance hit for WinPix. It's quite simple to defer the init, so here we are.
(This dia implementation was originally added specifically for WinPix, but was then superseded by a simpler API. It's entirely possible that there are no other clients of the dia interface at all, but it has been published, so we're probably bound to maintain it.)
(Note that there are other deferment opportunities here, but the larger pending work is to disentangle the dia implementation from that of the new "IDxcPix*" API that WinPix uses, which would obviate deferment altogether, but that's way out of scope for me for now.)