### PR TITLE
[SPIR-V] Allow zero outputcontrolpoints

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -2836,7 +2836,8 @@ void DeclResultIdMapper::storeToShaderOutputVariable(
   // element in the per-vertex data array: the one indexed by
   // SV_ControlPointID.
   else if (stageVarData.invocationId.hasValue() &&
-           stageVarData.invocationId.getValue() != nullptr) {
+           stageVarData.invocationId.getValue() != nullptr &&
+           stageVarData.arraySize != 0) {
     // Remove the arrayness to get the element type.
     assert(isa<ConstantArrayType>(varInstr->getAstResultType()));
     const auto elementType =
@@ -3441,7 +3442,7 @@ bool DeclResultIdMapper::createStageVars(StageVarDataBundle &stageVarData,
   assert(value);
   // invocationId should only be used for handling HS per-vertex output.
   if (stageVarData.invocationId.hasValue()) {
-    assert(spvContext.isHS() && stageVarData.arraySize != 0 && !asInput);
+    assert(spvContext.isHS() && !asInput);
   }
 
   assert(stageVarData.semantic);

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -13381,13 +13381,6 @@ bool SpirvEmitter::processHSEntryPointOutputAndPCF(
   auto loc = hullMainFuncDecl->getLocation();
   auto locEnd = hullMainFuncDecl->getLocEnd();
 
-  // For Hull shaders, the real output is an array of size
-  // numOutputControlPoints. The results of the main should be written to the
-  // correct offset in the array (based on InvocationID).
-  if (!numOutputControlPoints) {
-    emitError("number of output control points cannot be zero", loc);
-    return false;
-  }
   // TODO: We should be able to handle cases where the SV_OutputControlPointID
   // is not provided.
   if (!outputControlPointId) {

--- a/tools/clang/test/CodeGenSPIRV/attribute.outputcontrolpoints.unset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/attribute.outputcontrolpoints.unset.hlsl
@@ -1,0 +1,17 @@
+// RUN: %dxc -T hs_6_0 -E Hull -spirv -fcgl  %s | FileCheck %s
+
+struct ControlPoint { float4 position : POSITION; };
+
+struct PatchData {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+PatchData HullConst () { return (PatchData)0; }
+
+// CHECK: OpEntryPoint TessellationControl %Hull "Hull" %in_var_POSITION %gl_InvocationID %out_var_POSITION %gl_TessLevelOuter %gl_TessLevelInner
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+ControlPoint Hull (InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) { return v[id]; }

--- a/tools/clang/test/CodeGenSPIRV/attribute.outputcontrolpoints.zero.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/attribute.outputcontrolpoints.zero.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T hs_6_0 -E Hull -spirv -fcgl  %s | FileCheck %s
+
+struct ControlPoint { float4 position : POSITION; };
+
+struct PatchData {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+PatchData HullConst () { return (PatchData)0; }
+
+// CHECK: OpEntryPoint TessellationControl %Hull "Hull" %in_var_POSITION %gl_InvocationID %out_var_POSITION %gl_TessLevelOuter %gl_TessLevelInner
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+// CHECK: OpExecutionMode %Hull OutputVertices 0
+[outputcontrolpoints(0)]
+ControlPoint Hull (InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) { return v[id]; }


### PR DESCRIPTION
It is valid HLSL for a Hull shader to have zero outputcontrolpoints or have the outputcontrolpoints attribute unset, based on the tests added here passing when compiling for DXIL. This change removes the checks in the SPIR-V backend that required a strictly positive number of control points and adds tests to verify the result.

Fixes #3733