### PR TITLE
Use internal validator for WaveMatrix67.hlsl test

### DIFF
--- a/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix67.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/objects/WaveMatrix/WaveMatrix67.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -E main -T cs_6_7 %s | FileCheck %s 
-// RUN: %dxc -E main -T cs_6_8 %s | FileCheck %s
+// RUN: %dxc -E main -T cs_6_7 -select-validator internal %s | FileCheck %s 
+// RUN: %dxc -E main -T cs_6_8 -select-validator internal %s | FileCheck %s
 
 // CHECK-NOT: define void @main()
 


### PR DESCRIPTION
Published validators do not have consistent error messages.