### PR TITLE
[SPIR-V] Don't always force EXT_mesh_shader override

### DIFF
--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -67,15 +67,6 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
     : diags(de) {
   allowedExtensions.resize(static_cast<unsigned>(Extension::Unknown) + 1);
 
-  if (opts.allowedExtensions.empty()) {
-    // If no explicit extension control from command line, use the default mode:
-    // allowing all extensions that are enabled by default.
-    allowAllKnownExtensions();
-  } else {
-    for (auto ext : opts.allowedExtensions)
-      allowExtension(ext);
-  }
-
   targetEnvStr = opts.targetEnv;
 
   llvm::Optional<spv_target_env> targetEnvOpt =
@@ -89,10 +80,13 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
   }
   targetEnv = *targetEnvOpt;
 
-  // Override the default mesh extension to SPV_EXT_mesh_shader when the
-  // target environment is SPIR-V 1.4 or above
-  if (isTargetEnvSpirv1p4OrAbove()) {
-    allowExtension("SPV_EXT_mesh_shader");
+  if (opts.allowedExtensions.empty()) {
+    // If no explicit extension control from command line, use the default mode:
+    // allowing all extensions that are enabled by default.
+    allowAllKnownExtensions();
+  } else {
+    for (auto ext : opts.allowedExtensions)
+      allowExtension(ext);
   }
 }
 
@@ -349,7 +343,7 @@ bool FeatureManager::enabledByDefault(Extension ext) {
   case Extension::EXT_mesh_shader:
     // Enabling EXT_mesh_shader only when the target environment is SPIR-V 1.4
     // or above
-    return false;
+    return isTargetEnvSpirv1p4OrAbove();
   default:
     return true;
   }

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fcgl %s -spirv | FileCheck %s
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingEXT
 // CHECK:  OpExtension "SPV_EXT_mesh_shader"
 // CHECK:  OpEntryPoint MeshEXT %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]]

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
@@ -1,13 +1,12 @@
 // RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingEXT
 // CHECK:  OpExtension "SPV_EXT_mesh_shader"
-// CHECK:  OpEntryPoint MeshEXT %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]]
+// CHECK:  OpEntryPoint MeshEXT %main "main" {{(%gl_GlobalInvocationID )?}}%gl_Position [[primind:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 64 1 1
 // CHECK:  OpExecutionMode %main OutputTrianglesNV
 // CHECK:  OpExecutionMode %main OutputVertices 81
 // CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
 
-// CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 // CHECK:  OpDecorate %gl_Position BuiltIn Position
 // CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveTriangleIndicesEXT
 

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingEXT
 // CHECK:  OpExtension "SPV_EXT_mesh_shader"
-// CHECK:  OpEntryPoint MeshEXT %main "main" {{(%gl_GlobalInvocationID )?}}%gl_Position [[primind:%[0-9]+]]
+// CHECK:  OpEntryPoint MeshEXT %main "main" %gl_Position [[primind:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 64 1 1
 // CHECK:  OpExecutionMode %main OutputTrianglesNV
 // CHECK:  OpExecutionMode %main OutputVertices 81

--- a/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.ext.no-explicit-exts-spv1.4.mesh.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fcgl %s -spirv | FileCheck %s
+// CHECK:  OpCapability MeshShadingEXT
+// CHECK:  OpExtension "SPV_EXT_mesh_shader"
+// CHECK:  OpEntryPoint MeshEXT %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]]
+// CHECK:  OpExecutionMode %main LocalSize 64 1 1
+// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputVertices 81
+// CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
+
+// CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+// CHECK:  OpDecorate %gl_Position BuiltIn Position
+// CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveTriangleIndicesEXT
+
+// Make sure that when spirv 1.4 or above is supported, and no extensions are explicitly requested, that
+// we output SPIR-V using SPV_EXT_mesh_shader as the default mesh extension
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+};
+
+#define NUM_THREADS 64
+#define MAX_VERT 81
+#define MAX_PRIM 128
+
+[outputtopology("triangle")]
+[numthreads(NUM_THREADS, 1, 1)]
+void main(out vertices MeshPerVertex verts[MAX_VERT],
+          out indices uint3 primitiveInd[MAX_PRIM],
+          in uint tid : SV_DispatchThreadID)
+{
+// CHECK:  OpSetMeshOutputsEXT %uint_81 %uint_128
+    SetMeshOutputCounts(MAX_VERT, MAX_PRIM);
+}

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fspv-extension=SPV_NV_mesh_shader %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingNV
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
-// CHECK:  OpEntryPoint MeshNV %main "main" {{(%gl_GlobalInvocationID )?}}%gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
+// CHECK:  OpEntryPoint MeshNV %main "main" %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 32 1 1
 // CHECK:  OpExecutionMode %main OutputTrianglesNV
 // CHECK:  OpExecutionMode %main OutputVertices 81

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
@@ -1,7 +1,7 @@
 // RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fspv-extension=SPV_NV_mesh_shader %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingNV
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
-// CHECK:  OpEntryPoint MeshNV %main "main" %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
+// CHECK:  OpEntryPoint MeshNV %main "main" {{(%gl_GlobalInvocationID )?}}%gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 32 1 1
 // CHECK:  OpExecutionMode %main OutputTrianglesNV
 // CHECK:  OpExecutionMode %main OutputVertices 81

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
@@ -1,13 +1,12 @@
-// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fspv-extension=SPV_NV_mesh_shader -fcgl %s -spirv | FileCheck %s
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fspv-extension=SPV_NV_mesh_shader %s -spirv | FileCheck %s
 // CHECK:  OpCapability MeshShadingNV
 // CHECK:  OpExtension "SPV_NV_mesh_shader"
-// CHECK:  OpEntryPoint MeshNV %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
+// CHECK:  OpEntryPoint MeshNV %main "main" %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
 // CHECK:  OpExecutionMode %main LocalSize 32 1 1
 // CHECK:  OpExecutionMode %main OutputTrianglesNV
 // CHECK:  OpExecutionMode %main OutputVertices 81
 // CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
 
-// CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
 // CHECK:  OpDecorate %gl_Position BuiltIn Position
 // CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveIndicesNV
 // CHECK:  OpDecorate [[primcount]] BuiltIn PrimitiveCountNV

--- a/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/meshshading.nv.request-nv-with-spv1.4.mesh.hlsl
@@ -1,0 +1,33 @@
+// RUN: %dxc -T ms_6_5 -E main -fspv-target-env=vulkan1.1spirv1.4 -fspv-extension=SPV_NV_mesh_shader -fcgl %s -spirv | FileCheck %s
+// CHECK:  OpCapability MeshShadingNV
+// CHECK:  OpExtension "SPV_NV_mesh_shader"
+// CHECK:  OpEntryPoint MeshNV %main "main" %gl_GlobalInvocationID %gl_Position [[primind:%[0-9]+]] [[primcount:%[0-9]+]]
+// CHECK:  OpExecutionMode %main LocalSize 32 1 1
+// CHECK:  OpExecutionMode %main OutputTrianglesNV
+// CHECK:  OpExecutionMode %main OutputVertices 81
+// CHECK:  OpExecutionMode %main OutputPrimitivesNV 128
+
+// CHECK:  OpDecorate %gl_GlobalInvocationID BuiltIn GlobalInvocationId
+// CHECK:  OpDecorate %gl_Position BuiltIn Position
+// CHECK:  OpDecorate [[primind]] BuiltIn PrimitiveIndicesNV
+// CHECK:  OpDecorate [[primcount]] BuiltIn PrimitiveCountNV
+
+// Make sure that when spirv 1.4 or above is supported, but we explicitly request SPV_NV_mesh_shader through -fpv-extension,
+// that we output SPIR-V using SPV_NV_mesh_shader and don't override using the EXT extension
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+};
+
+#define NUM_THREADS 32
+#define MAX_VERT 81
+#define MAX_PRIM 128
+
+[outputtopology("triangle")]
+[numthreads(NUM_THREADS, 1, 1)]
+void main(out vertices MeshPerVertex verts[MAX_VERT],
+          out indices uint3 primitiveInd[MAX_PRIM],
+          in uint tid : SV_DispatchThreadID)
+{
+    SetMeshOutputCounts(MAX_VERT, MAX_PRIM);
+}


### PR DESCRIPTION

 - This changes the FeatureManager constructor, so that EXT_mesh_shader is still the default choice for mesh shaders when SPIR-V 1.4 or above is supported, but is not forced even when NV_mesh_shader is requested. Before, it was impossible to choose NV_mesh_shader in that case.

Fixes #6193