### PR TITLE
Require valid outputcontrolpoints on Hull shader

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3241,7 +3241,7 @@ SM.NOPSOUTPUTIDX                          Pixel shader output registers are not 
 SM.OPCODE                                 Opcode must be defined in target shader model
 SM.OPCODEININVALIDFUNCTION                Invalid DXIL opcode usage like StorePatchConstant in patch constant function
 SM.OPERAND                                Operand must be defined in target shader model.
-SM.OUTPUTCONTROLPOINTCOUNTRANGE           output control point count must be [0..%0].  %1 specified.
+SM.OUTPUTCONTROLPOINTCOUNTRANGE           output control point count must be [%0..%1].  %2 specified.
 SM.OUTPUTCONTROLPOINTSTOTALSCALARS        Total number of scalars across all HS output control points must not exceed .
 SM.PATCHCONSTANTONLYFORHSDS               patch constant signature only valid in HS and DS.
 SM.PSCONSISTENTINTERP                     Interpolation mode for PS input position must be linear_noperspective_centroid or linear_noperspective_sample when outputting oDepthGE or oDepthLE and not running at sample frequency (which is forced by inputting SV_SampleIndex or declaring an input linear_sample or linear_noperspective_sample).
@@ -3382,4 +3382,3 @@ The following work on this specification is still pending:
 
 * Consider moving some additional tables and lists into hctdb and cross-reference.
 * Complete the extended documentation for instructions.
-

--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -112,6 +112,7 @@ const unsigned kMaxClipOrCullDistanceElementCount = 2;
 const unsigned kMaxClipOrCullDistanceCount = 2 * 4;
 const unsigned kMaxGSOutputVertexCount = 1024;
 const unsigned kMaxGSInstanceCount = 32;
+const unsigned kMinIAPatchControlPointCount = 1;
 const unsigned kMaxIAPatchControlPointCount = 32;
 const float kHSMaxTessFactorLowerBound = 1.0f;
 const float kHSMaxTessFactorUpperBound = 64.0f;

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -5733,10 +5733,12 @@ static void ValidateEntryProps(ValidationContext &ValCtx,
     }
 
     unsigned outputControlPointCount = HS.outputControlPoints;
-    if (outputControlPointCount > DXIL::kMaxIAPatchControlPointCount) {
+    if (outputControlPointCount < DXIL::kMinIAPatchControlPointCount ||
+        outputControlPointCount > DXIL::kMaxIAPatchControlPointCount) {
       ValCtx.EmitFnFormatError(
           F, ValidationRule::SmOutputControlPointCountRange,
-          {std::to_string(DXIL::kMaxIAPatchControlPointCount),
+          {std::to_string(DXIL::kMinIAPatchControlPointCount),
+           std::to_string(DXIL::kMaxIAPatchControlPointCount),
            std::to_string(outputControlPointCount)});
     }
     if (domain == DXIL::TessellatorDomain::Undefined) {

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7913,6 +7913,8 @@ def err_hlsl_inputpatch_size: Error<
 def err_hlsl_outputpatch_size: Error<
    "OutputPatch element count must be greater than 0">;
 def note_hlsl_node_array : Note<"'%0' cannot be used as an array; did you mean '%0Array'?">;
+def err_hlsl_controlpoints_size: Error<
+  "number of control points %0 is outside the valid range of [1..32]">;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -13219,15 +13219,14 @@ void hlsl::HandleDeclAttributeForHLSL(Sema &S, Decl *D, const AttributeList &A,
   case AttributeList::AT_HLSLOutputControlPoints: {
     // Hull shader output must be between 1 and 32 control points.
     int outputControlPoints = ValidateAttributeIntArg(S, A);
-    if (outputControlPoints >= 1 && outputControlPoints <= 32) {
-      declAttr = ::new (S.Context) HLSLOutputControlPointsAttr(
-          A.getRange(), S.Context, outputControlPoints,
-          A.getAttributeSpellingListIndex());
-    } else {
+    if (outputControlPoints < 1 || outputControlPoints > 32) {
       S.Diags.Report(A.getLoc(), diag::err_hlsl_controlpoints_size)
           << outputControlPoints << A.getRange();
       return;
     }
+    declAttr = ::new (S.Context) HLSLOutputControlPointsAttr(
+        A.getRange(), S.Context, outputControlPoints,
+        A.getAttributeSpellingListIndex());
     break;
   }
   case AttributeList::AT_HLSLOutputTopology:

--- a/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/patch_constant_function_missing.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/functions/attribute/patch_constant_function_missing.hlsl
@@ -15,6 +15,7 @@ float4 fooey()
 // CHECK: error: patch constant function 'NotFooey' must be defined
 [patchconstantfunc("NotFooey")]
 [outputtopology("point")]
+[outputcontrolpoints(1)]
 float4 main(float a : A, float b:B) : SV_TARGET
 {
   float4 f = b;

--- a/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/attributes_Mod.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/types/conversions/attributes_Mod.hlsl
@@ -177,9 +177,6 @@ Texture2D<float4> tex1[10] : register( t20, space10 );
   |-RegisterAssignment <col:30> register(t20, space10)
 */
 
-[outputcontrolpoints(-1)] // expected-warning {{attribute 'outputcontrolpoints' must have a uint literal argument}} fxc-pass {{}}
-void all_wrong() { }
-
 [domain("quad")]
 /*verify-ast
   HLSLDomainAttr <col:2, col:15> "quad"

--- a/tools/clang/test/SemaHLSL/attributes.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes.hlsl
@@ -385,6 +385,9 @@ Texture2D<float4> tex1[10] : register( t20, space10 );
 
 void all_wrong() { }
 
+[shader("hull")]
+void hull_wrong() { } // expected-error {{hull entry point must have a valid patchconstantfunc attribute}} expected-error {{hull entry point must have a valid outputtopology attribute}} expected-error {{hull entry point must have a valid outputcontrolpoints attribute}}
+
 [domain("quad")]
 /*verify-ast
   HLSLDomainAttr <col:2, col:15> "quad"

--- a/tools/clang/test/SemaHLSL/attributes.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes.hlsl
@@ -380,7 +380,7 @@ Texture2D<float4> tex1[10] : register( t20, space10 );
 [domain(123)]     // expected-error {{attribute 'domain' must have a string literal argument}} fxc-pass {{}}
 [partitioning()]  // expected-error {{'partitioning' attribute takes one argument}} fxc-error {{X3000: syntax error: unexpected token ')'}}
 [outputtopology("not_triangle_cw")] // expected-error {{attribute 'outputtopology' must have one of these values: point,line,triangle,triangle_cw,triangle_ccw}} fxc-pass {{}}
-[outputcontrolpoints(-1)] // expected-warning {{attribute 'outputcontrolpoints' must have a uint literal argument}} fxc-pass {{}}
+[outputcontrolpoints(-1)] // expected-warning {{attribute 'outputcontrolpoints' must have a uint literal argument}} expected-error {{number of control points -1 is outside the valid range of [1..32]}} fxc-pass {{}}
 [patchconstantfunc("PatchFoo", "ExtraArgument")] // expected-error {{'patchconstantfunc' attribute takes one argument}} fxc-pass {{}}
 
 void all_wrong() { }

--- a/tools/clang/test/SemaHLSL/recursion/library_hull_recursion.hlsl
+++ b/tools/clang/test/SemaHLSL/recursion/library_hull_recursion.hlsl
@@ -42,6 +42,7 @@ HSPerPatchData HSPerPatchFunc1() /* expected-error{{recursive functions are not 
 [shader("hull")]
 [patchconstantfunc("HSPerPatchFunc1")]
 [outputtopology("point")]
+[outputcontrolpoints(1)]
 float4 main(float a : A, float b:B) : SV_TARGET
 {
   float4 f = b;

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -881,7 +881,7 @@ TEST_F(ValidationTest, HsAttributeFail) {
        "Invalid Tessellator Output Primitive specified",
        "Hull Shader MaxTessFactor must be [1.000000..64.000000].  65.000000 "
        "specified",
-       "output control point count must be [0..32].  36 specified"});
+       "output control point count must be [1..32].  36 specified"});
 }
 TEST_F(ValidationTest, InnerCoverageFail) {
   RewriteAssemblyCheckMsg(
@@ -1047,7 +1047,7 @@ TEST_F(ValidationTest, SimpleHs1Fail) {
           "\"InsideTessFactor\", i8 9, i8 0",
       },
       {
-          "output control point count must be [0..32].  3000 specified",
+          "output control point count must be [1..32].  3000 specified",
           "Required TessFactor for domain not found declared anywhere in Patch "
           "Constant data",
           // TODO: enable this after support pass thru hull shader.

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -7829,7 +7829,7 @@ class db_dxil(object):
         )
         self.add_valrule(
             "Sm.OutputControlPointCountRange",
-            "output control point count must be [0..%0].  %1 specified.",
+            "output control point count must be [%0..%1].  %2 specified.",
         )
         self.add_valrule("Sm.GSValidInputPrimitive", "GS input primitive unrecognized.")
         self.add_valrule(


### PR DESCRIPTION
According to the documentation: "A hull shader is implemented with an HLSL function, and has the following properties: [...] The shader output is between 1 and 32 control points".

https://learn.microsoft.com/en-us/windows/win32/direct3d11/direct3d-11-advanced-stages-tessellation#hull-shader-stage

This change adds a check to verify that the outputcontrolpoints attribute is set on Hull shaders and has an argument in the valid range.

Fixes #3733 (by making the error consistent between backends)