### PR TITLE
Ensure dxil validator 1.8 runs for launch type tests

### DIFF
--- a/tools/clang/test/HLSLFileCheck/dxil/intrinsics/launch_types_coalescing.ll
+++ b/tools/clang/test/HLSLFileCheck/dxil/intrinsics/launch_types_coalescing.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"

--- a/tools/clang/test/HLSLFileCheck/dxil/intrinsics/launch_types_thread.ll
+++ b/tools/clang/test/HLSLFileCheck/dxil/intrinsics/launch_types_thread.ll
@@ -1,4 +1,4 @@
-; RUN: %dxv %s | FileCheck %s
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
 
 target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
 target triple = "dxil-ms-dx"


### PR DESCRIPTION
Internal pipeline issues revealed that certain launch type tests that were recently merged were running with older validators.
This PR ensures that the tests run with validator version 1.8. 