### PR TITLE
[SPIR-V] Update SPV_GOOGLE_user_type

### DIFF
--- a/tools/clang/lib/SPIRV/AstTypeProbe.cpp
+++ b/tools/clang/lib/SPIRV/AstTypeProbe.cpp
@@ -1114,14 +1114,12 @@ std::string getHlslResourceTypeName(QualType type) {
         name == "RasterizerOrderedTexture3D" || name == "Buffer" ||
         name == "RWBuffer" || name == "RasterizerOrderedBuffer" ||
         name == "SubpassInput" || name == "SubpassInputMS" ||
-        name == "InputPatch" || name == "OutputPatch") {
+        name == "InputPatch" || name == "OutputPatch" ||
+        name == "ConstantBuffer" || name == "TextureBuffer" ||
+        name == "RaytracingAccelerationStructure") {
       // Get resource type name with template params. Operation is safe because
       // type has already been null checked.
       return type.getLocalUnqualifiedType().getAsString();
-    } else if (name == "ConstantBuffer") {
-      return "cbuffer";
-    } else if (name == "TextureBuffer") {
-      return "tbuffer";
     }
   }
 

--- a/tools/clang/test/CodeGenSPIRV/decoration.user-type.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/decoration.user-type.hlsl
@@ -97,6 +97,20 @@ ByteAddressBuffer bab;
 // CHECK: OpDecorateString %rwbab UserTypeGOOGLE "rwbyteaddressbuffer"
 RWByteAddressBuffer rwbab;
 
+// CHECK: OpDecorateString %rs UserTypeGOOGLE "raytracingaccelerationstructure"
+RaytracingAccelerationStructure rs;
+
+struct S {
+    float  f1;
+    float3 f2;
+};
+
+// CHECK: OpDecorateString %cb UserTypeGOOGLE "constantbuffer:<S>"
+ConstantBuffer<S> cb;
+
+// CHECK: OpDecorateString %tb UserTypeGOOGLE "texturebuffer:<S>"
+TextureBuffer<S> tb;
+
 float4 main() : SV_Target{
     return 0.0.xxxx;
 }


### PR DESCRIPTION
Update implementation of SPV_GOOGLE_user_type following the spec changes in: https://github.com/KhronosGroup/SPIRV-Registry/pull/230