### PR TITLE
[SPIR-V] Fix invalid optional read

### DIFF
--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -85,6 +85,7 @@ FeatureManager::FeatureManager(DiagnosticsEngine &de,
     emitNote("allowed options are:\n vulkan1.0\n vulkan1.1\n "
              "vulkan1.1spirv1.4\n vulkan1.2\n vulkan1.3\n universal1.5",
              {});
+    return;
   }
   targetEnv = *targetEnvOpt;
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.environment.invalid.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.environment.invalid.hlsl
@@ -1,0 +1,6 @@
+// RUN: not %dxc -T cs_6_0 -E main -fspv-target-env=vulkan1.1spirv1.3 %s -spirv 2>&1 | FileCheck %s
+
+[numthreads(1, 1, 1)]
+void main() { }
+
+// CHECK: error: unknown SPIR-V target environment 'vulkan1.1spirv1.3'


### PR DESCRIPTION
When the env isn't valid, we emit an error. But instead of returning, we continued and still tried to load the optional value, which triggered an assert.