### PR TITLE
NFC: Resolve PRERELEASE-TODO cases related to deep RDAT validation

### DIFF
--- a/include/dxc/DxilContainer/DxilRuntimeReflection.inl
+++ b/include/dxc/DxilContainer/DxilRuntimeReflection.inl
@@ -167,9 +167,9 @@ bool DxilRuntimeData::InitFromRDAT(const void *pRDAT, size_t size) {
   return false;
 }
 
-// PRERELEASE-TODO: Incorporate field names and report errors in error stream
+// TODO: Incorporate field names and report errors in error stream
 
-// PRERELEASE-TODO: Low-pri: Check other things like that all the index, string,
+// TODO: Low-pri: Check other things like that all the index, string,
 // and binary buffer space is actually used.
 
 template <typename _RecordType>

--- a/include/dxc/DxilContainer/RDAT_Macros.inl
+++ b/include/dxc/DxilContainer/RDAT_Macros.inl
@@ -46,9 +46,6 @@
 // DEF_RDAT_TYPES and DEF_RDAT_ENUMS - define structural validation
 #define DEF_RDAT_STRUCT_VALIDATION 13
 
-// PRERELEASE-TODO: deeper validation for DxilValidation (limiting enum values
-// and other such things)
-
 // clang-format off
 #define CLOSE_COMPOUND_DECL };
 // clang-format on


### PR DESCRIPTION
These TODOs were intended for if we were to implement deep RDAT validation rather than relying on the exact binary comparison.

This isn't happening for SM 6.8, so these are no longer PRERELEASE-TODOs.

The comment in RDAT_Macros.inl didn't really belong there in the first place, so I removed it.

Fixes #5699.