### PR TITLE
[SPIR-V] Mark array reference to aliased var as unaliased

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -139,8 +139,8 @@ bool isReferencingNonAliasStructuredOrByteBuffer(const Expr *expr) {
   } else if (const auto *callExpr = dyn_cast<CallExpr>(expr)) {
     if (isAKindOfStructuredOrByteBuffer(callExpr->getType()))
       return true;
-  } else if (const auto *arrSubExpr = dyn_cast<ArraySubscriptExpr>(expr)) {
-    return isReferencingNonAliasStructuredOrByteBuffer(arrSubExpr->getBase());
+  } else if (isa<ArraySubscriptExpr>(expr)) {
+    return isAKindOfStructuredOrByteBuffer(expr->getType());
   }
   return false;
 }

--- a/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
@@ -26,7 +26,7 @@ RWByteAddressBuffer BufferOut;
 void main() {
 // CHECK: %LocalArray = OpVariable %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Function
 // CHECK: %Local = OpVariable %_ptr_Function__ptr_Uniform_type_ByteAddressBuffer Function
-  ByteAddressBuffer LocalArary[2];
+  ByteAddressBuffer LocalArray[2];
 
 // CHECK: OpStore %LocalArray %BufferArray
   LocalArray = BufferArray;

--- a/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
@@ -14,25 +14,25 @@
 // CHECK: %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 // CHECK: %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
 // CHECK: %Buffer0 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
-// CHECK: %BufferArary = OpVariable %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Uniform
+// CHECK: %BufferArray = OpVariable %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Uniform
 // CHECK: %BufferOut = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
 
 ByteAddressBuffer Buffer0;
-ByteAddressBuffer BufferArary[2];
+ByteAddressBuffer BufferArray[2];
 RWByteAddressBuffer BufferOut;
 
 // CHECK: %src_main = OpFunction
 [numthreads(1, 1, 1)]
 void main() {
-// CHECK: %LocalArary = OpVariable %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Function
+// CHECK: %LocalArray = OpVariable %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Function
 // CHECK: %Local = OpVariable %_ptr_Function__ptr_Uniform_type_ByteAddressBuffer Function
   ByteAddressBuffer LocalArary[2];
 
-// CHECK: OpStore %LocalArary %BufferArary
-  LocalArary = BufferArary;
+// CHECK: OpStore %LocalArray %BufferArray
+  LocalArray = BufferArray;
 
-// CHECK: [[array:%[0-9]+]] = OpLoad %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 %LocalArary
+// CHECK: [[array:%[0-9]+]] = OpLoad %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 %LocalArray
 // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Uniform_type_ByteAddressBuffer [[array]] %int_0
 // CHECK: OpStore %Local [[ac]]
-  ByteAddressBuffer Local = LocalArary[0];
+  ByteAddressBuffer Local = LocalArray[0];
 }

--- a/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
@@ -14,10 +14,25 @@
 // CHECK: %type_RWByteAddressBuffer = OpTypeStruct %_runtimearr_uint
 // CHECK: %_ptr_Uniform_type_RWByteAddressBuffer = OpTypePointer Uniform %type_RWByteAddressBuffer
 // CHECK: %Buffer0 = OpVariable %_ptr_Uniform_type_ByteAddressBuffer Uniform
+// CHECK: %BufferArary = OpVariable %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Uniform
 // CHECK: %BufferOut = OpVariable %_ptr_Uniform_type_RWByteAddressBuffer Uniform
 
 ByteAddressBuffer Buffer0;
+ByteAddressBuffer BufferArary[2];
 RWByteAddressBuffer BufferOut;
 
+// CHECK: %src_main = OpFunction
 [numthreads(1, 1, 1)]
-void main() {}
+void main() {
+// CHECK: %LocalArary = OpVariable %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Function
+// CHECK: %Local = OpVariable %_ptr_Function__ptr_Uniform_type_ByteAddressBuffer Function
+  ByteAddressBuffer LocalArary[2];
+
+// CHECK: OpStore %LocalArary %BufferArary
+  LocalArary = BufferArary;
+
+// CHECK: [[array:%[0-9]+]] = OpLoad %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 %LocalArary
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Uniform_type_ByteAddressBuffer [[array]] %int_0
+// CHECK: OpStore %Local [[ac]]
+  ByteAddressBuffer Local = LocalArary[0];
+}


### PR DESCRIPTION
An "aliased" variable is on where the compiler has implicitly added an
extra level indirection. So when we access one of these variable, we
have to do an extra load.

When we do an array access on an aliased variable, we do the extra load
before doing the access chain, but we still treat the result of the
access chain as if it is an aliased value. This causes an extra load and
generates invalid spir-v.

The fix is to change `isReferencingNonAliasStructuredOrByteBuffer` so
that we do not distinguish between externally and internally visible
variable if we see an array subscript.

Fixes #6110
