### PR TITLE
Remove early skip of unused GV causing worklist ordering differences

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1746,8 +1746,6 @@ bool SROAGlobalAndAllocas(HLModule &HLM, bool bHasDbgInfo) {
 
   DenseMap<GlobalVariable *, GVDbgOffset> GVDbgOffsetMap;
   for (GlobalVariable &GV : M.globals()) {
-    if (GV.user_empty())
-      continue;
     if (dxilutil::IsStaticGlobal(&GV) || dxilutil::IsSharedMemoryGlobal(&GV)) {
       staticGVs.insert(&GV);
       GVDbgOffset &dbgOffset = GVDbgOffsetMap[&GV];


### PR DESCRIPTION
Early skip of unused GV caused worklist ordering differences, which could result in differently ordered allocas, which is causing optimization regressions in backend.

Reverting this part of prior change (f80b8d6) from PR #5259, since it was not required for the original purpose of removing dead GVs from the staticGVs set.

Unfortunately, it is proving prohibitively difficult to craft a minimal repro for a test case that demonstrates the difference.