### PR TITLE
Recognize 'Microsoft Basic Render Driver' in execution tests

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -448,7 +448,8 @@ inline bool GetTestParamUseWARP(bool defaultVal) {
     return defaultVal;
   }
   if ((defaultVal && AdapterValue.IsEmpty()) ||
-      AdapterValue.CompareNoCase(L"WARP") == 0) {
+      AdapterValue.CompareNoCase(L"WARP") == 0 ||
+      AdapterValue.CompareNoCase(L"Microsoft Basic Render Driver") == 0) {
     return true;
   }
   return false;


### PR DESCRIPTION
Recognize 'Microsoft Basic Render Driver' in execution tests as a valid adapter name equivalent to WARP.