### PR TITLE
[SPIR-V] Fix literal float assertion

### DIFF
--- a/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LiteralTypeVisitor.cpp
@@ -86,7 +86,7 @@ void LiteralTypeVisitor::tryToUpdateInstLitType(SpirvInstruction *inst,
   // Since LiteralTypeVisitor is run before lowering the types, we can simply
   // update the AST result-type of the instruction to the new type. In the case
   // of the instruction being a constant instruction, since we do not have
-  // unique constants at this point, chaing the QualType of the constant
+  // unique constants at this point, changing the QualType of the constant
   // instruction is safe.
   inst->setAstResultType(newType);
 }
@@ -164,7 +164,7 @@ bool LiteralTypeVisitor::visit(SpirvBinaryOp *inst) {
   case spv::Op::OpShiftLeftLogical: {
     // Base (arg1) should have the same type as result type
     tryToUpdateInstLitType(inst->getOperand1(), resultType);
-    // The shitf amount (arg2) cannot be a 64-bit type for a 32-bit base!
+    // The shift amount (arg2) cannot be a 64-bit type for a 32-bit base!
     tryToUpdateInstLitType(inst->getOperand2(), resultType);
     return true;
   }
@@ -227,6 +227,16 @@ bool LiteralTypeVisitor::visit(SpirvBinaryOp *inst) {
                            inst->getOperand1()->getAstResultType());
     return true;
   }
+
+  case spv::Op::OpVectorTimesScalar: {
+    QualType elemType;
+    if (isVectorType(operand1->getAstResultType(), &elemType) &&
+        elemType->isFloatingType()) {
+      tryToUpdateInstLitType(inst->getOperand2(), elemType);
+    }
+    return true;
+  }
+
   default:
     break;
   }

--- a/tools/clang/test/CodeGenSPIRV/binary-op.compound-assign.literal-float.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.compound-assign.literal-float.hlsl
@@ -1,0 +1,21 @@
+// RUN: %dxc -T ps_6_0 -E main -spirv -fspv-target-env=vulkan1.2 %s
+
+struct PS_INPUT 
+{ 
+    bool isFrontFace : SV_IsFrontFace ; 
+} ; 
+
+struct PS_OUTPUT 
+{ 
+    float4 target0 : SV_Target0 ; 
+} ; 
+
+PS_OUTPUT main ( PS_INPUT i ) 
+{ 
+    float4 test = float4(1.0, 1.0, 1.0, 1.0);
+    test *= i.isFrontFace ? -1.0 : 1.0;
+
+    PS_OUTPUT o;
+
+    return o ; 
+}


### PR DESCRIPTION
Fix #6230

The literal type visitor is asserting that the AST result type of an OpLoad should not be literal. The following expression was encountering this assertion.

float_vec_4 *= condition ? -1.0 : 1.0;

This patch visits OpVectorTimesScalar operations to change the AST result type of an instruction from a literal type to a non-literal type where possible.

Also, fix some mispellings I encountered while navigating the code.