### PR TITLE
[CMake] Don't always run compare steps

### DIFF
--- a/cmake/modules/HCT.cmake
+++ b/cmake/modules/HCT.cmake
@@ -118,10 +118,14 @@ function(add_hlsl_hctgen mode)
                       )
   endif()
 
+  add_custom_command(OUTPUT ${temp_output}.stamp
+                     COMMAND ${verification}
+                     COMMAND ${CMAKE_COMMAND} -E touch ${temp_output}.stamp
+                     DEPENDS ${output}
+                     COMMENT "Verifying clang-format results...")
+
   add_custom_target(${mode}
-                    COMMAND ${verification}
-                    DEPENDS ${output}
-                    COMMENT "Verifying clang-format results...")
+                    DEPENDS ${temp_output}.stamp)
 
   add_dependencies(HCTGen ${mode})
 endfunction()


### PR DESCRIPTION
When not updating the in-tree sources, the compare step would always run because the comparison was part of the target. This prevents that by having the comparison be its own custom command that produces an output and the target depends on the "output" of the comparison step.