### PR TITLE
[SPIR-V] Emit error for 16-bit texture types

### DIFF
--- a/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
+++ b/tools/clang/lib/SPIRV/LowerTypeVisitor.cpp
@@ -640,6 +640,26 @@ const SpirvType *LowerTypeVisitor::lowerResourceType(QualType type,
 
   // TODO: avoid string comparison once hlsl::IsHLSLResouceType() does that.
 
+  // Vulkan does not yet support true 16-bit float texture objexts.
+  if (name == "Buffer" || name == "RWBuffer" || name == "Texture1D" ||
+      name == "Texture2D" || name == "Texture3D" || name == "TextureCube" ||
+      name == "Texture1DArray" || name == "Texture2DArray" ||
+      name == "Texture2DMS" || name == "Texture2DMSArray" ||
+      name == "TextureCubeArray" || name == "RWTexture1D" ||
+      name == "RWTexture2D" || name == "RWTexture3D" ||
+      name == "RWTexture1DArray" || name == "RWTexture2DArray") {
+    const auto sampledType = hlsl::GetHLSLResourceResultType(type);
+    const auto loweredType =
+        lowerType(getElementType(astContext, sampledType), rule,
+                  /*isRowMajor*/ llvm::None, srcLoc);
+    if (const auto *floatType = dyn_cast<FloatType>(loweredType)) {
+      if (floatType->getBitwidth() == 16) {
+        emitError("16-bit texture types not yet supported with -spirv", srcLoc);
+        return nullptr;
+      }
+    }
+  }
+
   { // Texture types
     spv::Dim dim = {};
     bool isArray = {};

--- a/tools/clang/test/CodeGenSPIRV/type.buffer.half.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.buffer.half.hlsl
@@ -1,0 +1,6 @@
+// RUN: not %dxc -T ps_6_6 -E main -fcgl  %s -spirv -enable-16bit-types  2>&1 | FileCheck %s
+
+// CHECK: error: 16-bit texture types not yet supported with -spirv
+Buffer<half> MyBuffer;
+
+void main(): SV_Target { }


### PR DESCRIPTION
According to the Vulkan spec:
OpTypeImage must declare a scalar 32-bit float, 64-bit integer, or 32-bit integer type for the “Sampled Type” (RelaxedPrecision can be applied to a sampling instruction and to the variable holding the result of a sampling instruction)

We want to avoid translating a true HLSL 16-bit floating point texture object to a 32-bit texture object with relaxed precision, as this will break backwards compatibility if Vulkan does support 16-bit texture types in the future.

This change adds an error message in cases where the code generated would otherwise fail validation for the above reasons.

Closes #4372