### PR TITLE
[SPIR-V] Add fspv-enable-maximal-reconvergence opt

### DIFF
--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -388,6 +388,8 @@ def fspv_fix_func_call_arguments: Flag<["-"], "fspv-fix-func-call-arguments">, G
   HelpText<"Fix function call arguments which are not memory objects">;
 def fspv_entrypoint_name_EQ : Joined<["-"], "fspv-entrypoint-name=">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Specify the SPIR-V entry point name. Defaults to the HLSL entry point name.">;
+def fspv_enable_maximal_reconvergence: Flag<["-"], "fspv-enable-maximal-reconvergence">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
+  HelpText<"Enables the MaximallyReconvergesKHR execution mode for this module.">;
 def fvk_auto_shift_bindings: Flag<["-"], "fvk-auto-shift-bindings">, Group<spirv_Group>, Flags<[CoreOption, DriverOption]>,
   HelpText<"Apply fvk-*-shift to resources without an explicit register assignment.">;
 def Wno_vk_ignored_features : Joined<["-"], "Wno-vk-ignored-features">, Group<spirv_Group>, Flags<[CoreOption, DriverOption, HelpHidden]>,

--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -67,6 +67,7 @@ struct SpirvCodeGenOptions {
   bool supportNonzeroBaseInstance;
   bool fixFuncCallArguments;
   bool allowRWStructuredBufferArrays;
+  bool enableMaximalReconvergence;
   /// Maximum length in words for the OpString literal containing the shader
   /// source for DebugSource and DebugSourceContinued. If the source code length
   /// is larger than this number, we will use DebugSourceContinued instructions

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1068,6 +1068,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       Args.hasFlag(OPT_fspv_preserve_interface, OPT_INVALID, false);
   opts.SpirvOptions.allowRWStructuredBufferArrays =
       Args.hasFlag(OPT_fvk_allow_rwstructuredbuffer_arrays, OPT_INVALID, false);
+  opts.SpirvOptions.enableMaximalReconvergence =
+      Args.hasFlag(OPT_fspv_enable_maximal_reconvergence, OPT_INVALID, false);
 
   if (!handleVkShiftArgs(Args, OPT_fvk_b_shift, "b", &opts.SpirvOptions.bShift,
                          errors) ||

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -59,6 +59,7 @@ enum class Extension {
   KHR_vulkan_memory_model,
   NV_compute_shader_derivatives,
   KHR_fragment_shader_barycentric,
+  KHR_maximal_reconvergence,
   Unknown,
 };
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -718,6 +718,10 @@ bool CapabilityVisitor::visit(SpirvExecutionMode *execMode) {
     addExtension(Extension::EXT_shader_stencil_export,
                  "[[vk::stencil_ref_less_equal_back]]", execModeSourceLocation);
     break;
+  case spv::ExecutionMode::MaximallyReconvergesKHR:
+    addExtension(Extension::KHR_maximal_reconvergence, "",
+                 execModeSourceLocation);
+    break;
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -194,6 +194,8 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
             Extension::NV_compute_shader_derivatives)
       .Case("SPV_KHR_fragment_shader_barycentric",
             Extension::KHR_fragment_shader_barycentric)
+      .Case("SPV_KHR_maximal_reconvergence",
+            Extension::KHR_maximal_reconvergence)
       .Default(Extension::Unknown);
 }
 
@@ -257,6 +259,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_NV_compute_shader_derivatives";
   case Extension::KHR_fragment_shader_barycentric:
     return "SPV_KHR_fragment_shader_barycentric";
+  case Extension::KHR_maximal_reconvergence:
+    return "SPV_KHR_maximal_reconvergence";
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -890,6 +890,12 @@ void SpirvEmitter::HandleTranslationUnit(ASTContext &context) {
                               spvContext.getMinorVersion(), fileNames);
   }
 
+  if (spirvOptions.enableMaximalReconvergence) {
+    spvBuilder.addExecutionMode(entryFunction,
+                                spv::ExecutionMode::MaximallyReconvergesKHR, {},
+                                SourceLocation());
+  }
+
   // Output the constructed module.
   std::vector<uint32_t> m = spvBuilder.takeModule();
   if (context.getDiagnostics().hasErrorOccurred())

--- a/tools/clang/test/CodeGenSPIRV/spv.default-maximal-reconvergence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.default-maximal-reconvergence.hlsl
@@ -1,9 +1,0 @@
-// RUN: %dxc -T cs_6_0 -E main %s -spirv | FileCheck %s
-
-// CHECK-NOT:       OpExtension "SPV_KHR_maximal_reconvergence"
-// CHECK:           OpEntryPoint GLCompute %main "main"
-// CHECK-NOT:       OpExecutionMode %main MaximallyReconvergesKHR
-[numthreads(1, 1, 1)]
-void main() {}
-
-

--- a/tools/clang/test/CodeGenSPIRV/spv.default-maximal-reconvergence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.default-maximal-reconvergence.hlsl
@@ -1,0 +1,9 @@
+// RUN: %dxc -T cs_6_0 -E main %s -spirv | FileCheck %s
+
+// CHECK-NOT:       OpExtension "SPV_KHR_maximal_reconvergence"
+// CHECK:           OpEntryPoint GLCompute %main "main"
+// CHECK-NOT:       OpExecutionMode %main MaximallyReconvergesKHR
+[numthreads(1, 1, 1)]
+void main() {}
+
+

--- a/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
@@ -1,8 +1,11 @@
-// RUN: %dxc -T cs_6_0 -E main -fspv-enable-maximal-reconvergence %s -spirv | FileCheck %s
+// RUN: %dxc -T cs_6_0 -E main -fspv-enable-maximal-reconvergence %s -spirv | FileCheck %s -check-prefix=CHECK-ENABLED
+// RUN: %dxc -T cs_6_0 -E main %s -spirv | FileCheck %s -check-prefix=CHECK-DISABLED
 
-// CHECK:       OpExtension "SPV_KHR_maximal_reconvergence"
-// CHECK:       OpEntryPoint GLCompute %main "main"
-// CHECK:       OpExecutionMode %main MaximallyReconvergesKHR
+// CHECK-ENABLED:            OpExtension "SPV_KHR_maximal_reconvergence"
+// CHECK-DISABLED-NOT:       OpExtension "SPV_KHR_maximal_reconvergence"
+// CHECK:                    OpEntryPoint GLCompute %main "main"
+// CHECK-ENABLED:            OpExecutionMode %main MaximallyReconvergesKHR
+// CHECK-DISABLED-NOT:       OpExecutionMode %main MaximallyReconvergesKHR
 [numthreads(1, 1, 1)]
 void main() {}
 

--- a/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -T cs_6_0 -E main -fspv-enable-maximal-reconvergence %s -spirv | FileCheck %s -check-prefix=CHECK-ENABLED
-// RUN: %dxc -T cs_6_0 -E main %s -spirv | FileCheck %s -check-prefix=CHECK-DISABLED
+// RUN: %dxc -T cs_6_0 -E main -fspv-enable-maximal-reconvergence %s -spirv | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-ENABLED
+// RUN: %dxc -T cs_6_0 -E main %s -spirv | FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-DISABLED
 
 // CHECK-ENABLED:            OpExtension "SPV_KHR_maximal_reconvergence"
 // CHECK-DISABLED-NOT:       OpExtension "SPV_KHR_maximal_reconvergence"

--- a/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.enable-maximal-reconvergence.hlsl
@@ -1,0 +1,8 @@
+// RUN: %dxc -T cs_6_0 -E main -fspv-enable-maximal-reconvergence %s -spirv | FileCheck %s
+
+// CHECK:       OpExtension "SPV_KHR_maximal_reconvergence"
+// CHECK:       OpEntryPoint GLCompute %main "main"
+// CHECK:       OpExecutionMode %main MaximallyReconvergesKHR
+[numthreads(1, 1, 1)]
+void main() {}
+


### PR DESCRIPTION
This option is not enabled by default. When enabled, this option adds the MaximallyReconvergesKHR execution mode to the module, and the associated extension.

Related to #6222