### PR TITLE
[SPIR-V] Process array subscript individually

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
+++ b/tools/clang/test/CodeGenSPIRV/bezier.hull.hlsl2spv
@@ -172,8 +172,10 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // CHECK-NEXT: %HS_CONSTANT_DATA_OUTPUT = OpTypeStruct %_arr_float_uint_4 %_arr_float_uint_2 %_arr_v3float_uint_4 %_arr_v2float_uint_4 %_arr_v3float_uint_4 %_arr_v3float_uint_4 %v4float
 // CHECK-NEXT:          %98 = OpTypeFunction %HS_CONSTANT_DATA_OUTPUT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint
 // CHECK-NEXT: %_ptr_Function_HS_CONSTANT_DATA_OUTPUT = OpTypePointer Function %HS_CONSTANT_DATA_OUTPUT
+// CHECK-NEXT: %_ptr_Function__arr_float_uint_4 = OpTypePointer Function %_arr_float_uint_4
 // CHECK-NEXT: %_ptr_Function_float = OpTypePointer Function %float
-// CHECK-NEXT:         %112 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
+// CHECK-NEXT: %_ptr_Function__arr_float_uint_2 = OpTypePointer Function %_arr_float_uint_2
+// CHECK-NEXT:         %120 = OpTypeFunction %BEZIER_CONTROL_POINT %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3 %_ptr_Function_uint %_ptr_Function_uint
 // CHECK-NEXT: %_ptr_Function_VS_CONTROL_POINT_OUTPUT = OpTypePointer Function %VS_CONTROL_POINT_OUTPUT
 // CHECK-NEXT: %_ptr_Function_BEZIER_CONTROL_POINT = OpTypePointer Function %BEZIER_CONTROL_POINT
 // CHECK-NEXT: %_ptr_Function_v3float = OpTypePointer Function %v3float
@@ -246,32 +248,38 @@ BEZIER_CONTROL_POINT SubDToBezierHS(InputPatch<VS_CONTROL_POINT_OUTPUT, MAX_POIN
 // CHECK-NEXT:     %PatchID = OpFunctionParameter %_ptr_Function_uint
 // CHECK-NEXT:    %bb_entry = OpLabel
 // CHECK-NEXT:      %Output = OpVariable %_ptr_Function_HS_CONSTANT_DATA_OUTPUT Function
-// CHECK-NEXT:         %105 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_0
-// CHECK-NEXT:                OpStore %105 %float_1
-// CHECK-NEXT:         %106 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_1
-// CHECK-NEXT:                OpStore %106 %float_2
-// CHECK-NEXT:         %107 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_2
-// CHECK-NEXT:                OpStore %107 %float_3
-// CHECK-NEXT:         %108 = OpAccessChain %_ptr_Function_float %Output %int_0 %int_3
-// CHECK-NEXT:                OpStore %108 %float_4
-// CHECK-NEXT:         %109 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_0
-// CHECK-NEXT:                OpStore %109 %float_5
-// CHECK-NEXT:         %110 = OpAccessChain %_ptr_Function_float %Output %int_1 %int_1
-// CHECK-NEXT:                OpStore %110 %float_6
-// CHECK-NEXT:         %111 = OpLoad %HS_CONSTANT_DATA_OUTPUT %Output
-// CHECK-NEXT:                OpReturnValue %111
+// CHECK-NEXT:         %105 = OpAccessChain %_ptr_Function__arr_float_uint_4 %Output %int_0
+// CHECK-NEXT:         %107 = OpAccessChain %_ptr_Function_float %105 %int_0
+// CHECK-NEXT:                OpStore %107 %float_1
+// CHECK-NEXT:         %108 = OpAccessChain %_ptr_Function__arr_float_uint_4 %Output %int_0
+// CHECK-NEXT:         %109 = OpAccessChain %_ptr_Function_float %108 %int_1
+// CHECK-NEXT:                OpStore %109 %float_2
+// CHECK-NEXT:         %110 = OpAccessChain %_ptr_Function__arr_float_uint_4 %Output %int_0
+// CHECK-NEXT:         %111 = OpAccessChain %_ptr_Function_float %110 %int_2
+// CHECK-NEXT:                OpStore %111 %float_3
+// CHECK-NEXT:         %112 = OpAccessChain %_ptr_Function__arr_float_uint_4 %Output %int_0
+// CHECK-NEXT:         %113 = OpAccessChain %_ptr_Function_float %112 %int_3
+// CHECK-NEXT:                OpStore %113 %float_4
+// CHECK-NEXT:         %115 = OpAccessChain %_ptr_Function__arr_float_uint_2 %Output %int_1
+// CHECK-NEXT:         %116 = OpAccessChain %_ptr_Function_float %115 %int_0
+// CHECK-NEXT:                OpStore %116 %float_5
+// CHECK-NEXT:         %117 = OpAccessChain %_ptr_Function__arr_float_uint_2 %Output %int_1
+// CHECK-NEXT:         %118 = OpAccessChain %_ptr_Function_float %117 %int_1
+// CHECK-NEXT:                OpStore %118 %float_6
+// CHECK-NEXT:         %119 = OpLoad %HS_CONSTANT_DATA_OUTPUT %Output
+// CHECK-NEXT:                OpReturnValue %119
 // CHECK-NEXT:                OpFunctionEnd
-// CHECK-NEXT: %src_SubDToBezierHS = OpFunction %BEZIER_CONTROL_POINT None %112
+// CHECK-NEXT: %src_SubDToBezierHS = OpFunction %BEZIER_CONTROL_POINT None %120
 // CHECK-NEXT:        %ip_0 = OpFunctionParameter %_ptr_Function__arr_VS_CONTROL_POINT_OUTPUT_uint_3
 // CHECK-NEXT:        %cpid = OpFunctionParameter %_ptr_Function_uint
 // CHECK-NEXT:   %PatchID_0 = OpFunctionParameter %_ptr_Function_uint
 // CHECK-NEXT:  %bb_entry_0 = OpLabel
 // CHECK-NEXT:    %vsOutput = OpVariable %_ptr_Function_VS_CONTROL_POINT_OUTPUT Function
 // CHECK-NEXT:      %result = OpVariable %_ptr_Function_BEZIER_CONTROL_POINT Function
-// CHECK-NEXT:         %122 = OpAccessChain %_ptr_Function_v3float %vsOutput %int_0
-// CHECK-NEXT:         %123 = OpLoad %v3float %122
-// CHECK-NEXT:         %124 = OpAccessChain %_ptr_Function_v3float %result %int_0
-// CHECK-NEXT:                OpStore %124 %123
-// CHECK-NEXT:         %125 = OpLoad %BEZIER_CONTROL_POINT %result
-// CHECK-NEXT:                OpReturnValue %125
+// CHECK-NEXT:         %130 = OpAccessChain %_ptr_Function_v3float %vsOutput %int_0
+// CHECK-NEXT:         %131 = OpLoad %v3float %130
+// CHECK-NEXT:         %132 = OpAccessChain %_ptr_Function_v3float %result %int_0
+// CHECK-NEXT:                OpStore %132 %131
+// CHECK-NEXT:         %133 = OpLoad %BEZIER_CONTROL_POINT %result
+// CHECK-NEXT:                OpReturnValue %133
 // CHECK-NEXT:                OpFunctionEnd

--- a/tools/clang/test/CodeGenSPIRV/binary-op.assign.composite.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/binary-op.assign.composite.hlsl
@@ -62,7 +62,8 @@ void main(uint index: A) {
     BufferType lbuf;                  // %BufferType_0                   & %SubBuffer_1
     sbuf[5]  = lbuf;             // %BufferType <- %BufferType_0
 
-// CHECK-NEXT: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_SubBuffer_0 %cbuf %int_3 %int_0
+// CHECK-NEXT: [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_SubBuffer_0_uint_1 %cbuf %int_3
+// CHECK-NEXT: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_SubBuffer_0 [[base]] %int_0
 // CHECK-NEXT: [[cbuf_d0:%[0-9]+]] = OpLoad %SubBuffer_0 [[ptr]]
 
     // Reconstruct lbuf.d[0].a

--- a/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/fn.param.unsized-opaque-array.hlsl
@@ -14,8 +14,8 @@ sampler DummySampler;
 // CHECK:                OpStore %param_var_src %bindless
 // CHECK:                OpFunctionCall
 // CHECK:         %src = OpFunctionParameter %_ptr_Function__ptr_UniformConstant__runtimearr_type_2d_image
-// CHECK: [[idx:%[0-9]+]] = OpLoad %uint %index
 // CHECK: [[src:%[0-9]+]] = OpLoad %_ptr_UniformConstant__runtimearr_type_2d_image %src
+// CHECK: [[idx:%[0-9]+]] = OpLoad %uint %index
 // CHECK:                OpAccessChain %_ptr_Function_type_2d_image [[src]] [[idx]]
 
 float4 SampleArray(Texture2D src[], uint index, float2 uv)

--- a/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.array.access.hlsl
@@ -17,13 +17,15 @@ float main(float val: A, uint index: B) : C {
 
 // CHECK:       [[val:%[0-9]+]] = OpLoad %float %val
 // CHECK-NEXT:  [[idx:%[0-9]+]] = OpLoad %uint %index
-// CHECK-NEXT: [[ptr0:%[0-9]+]] = OpAccessChain %_ptr_Function_float %var [[idx]] %int_1 %int_0 %int_2
+// CHECK-NEXT: [[base:%[0-9]+]] = OpAccessChain %_ptr_Function__arr_float_uint_4 %var [[idx]] %int_1 %int_0
+// CHECK-NEXT: [[ptr0:%[0-9]+]] = OpAccessChain %_ptr_Function_float [[base]] %int_2
 // CHECK-NEXT:                 OpStore [[ptr0]] [[val]]
 
     var[index][1].f[2] = val;
 // CHECK-NEXT: [[idx0:%[0-9]+]] = OpLoad %uint %index
-// CHECK-NEXT: [[idx1:%[0-9]+]] = OpLoad %uint %index
-// CHECK:      [[ptr0_0:%[0-9]+]] = OpAccessChain %_ptr_Function_float %var %int_0 [[idx0]] %int_1 [[idx1]]
+// CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Function__arr_float_uint_4 %var %int_0 [[idx0]] %int_1
+// CHECK:      [[idx1:%[0-9]+]] = OpLoad %uint %index
+// CHECK:      [[ptr0_0:%[0-9]+]] = OpAccessChain %_ptr_Function_float [[base]] [[idx1]]
 // CHECK-NEXT: [[load:%[0-9]+]] = OpLoad %float [[ptr0_0]]
 // CHECK-NEXT:                 OpStore %r [[load]]
     r = var[0][index].g[index];

--- a/tools/clang/test/CodeGenSPIRV/op.cbuffer.access.majorness.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.cbuffer.access.majorness.hlsl
@@ -25,7 +25,8 @@ static const SData Data = BufferData;
 static const float3x4 Matrices[2] = BufferData.mat1;
 
 // CHECK: [[ptr_1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_SData %SBufferData %int_0
-// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_Uniform_mat3v4float [[ptr_1]] %int_1 %int_1
+// CHECK:  [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_mat3v4float_uint_2_0 [[ptr_1]] %int_1
+// CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_Uniform_mat3v4float [[base]] %int_1
 static const float3x4 Matrix = BufferData.mat2[1];
 
 RWStructuredBuffer<float4> Out;

--- a/tools/clang/test/CodeGenSPIRV/op.constant-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.constant-buffer.access.hlsl
@@ -30,7 +30,8 @@ float main() : A{
   // CHECK:      [[s:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyCbuffer %int_3 %int_0
   // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[s]]
 
-  // CHECK:      [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyCbuffer %int_4 %int_3
+  // CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyCbuffer %int_4
+  // CHECK:      [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
   // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[t]]
   return MyCbuffer.a + MyCbuffer.b.x + MyCbuffer.c[1][2] + MyCbuffer.s.f + MyCbuffer.t[3] +
   // CHECK:      [[a_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyCbufferArray %int_4 %int_0
@@ -46,7 +47,8 @@ float main() : A{
   // CHECK:      [[s_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyCbufferArray %int_1 %int_3 %int_0
   // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[s_0]]
 
-  // CHECK:      [[t_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyCbufferArray %int_0 %int_4 %int_3
+  // CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyCbufferArray %int_0 %int_4
+  // CHECK:      [[t_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
   // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[t_0]]
          MyCbufferArray[4].a + MyCbufferArray[3].b.x + MyCbufferArray[2].c[1][2] + MyCbufferArray[1].s.f + MyCbufferArray[0].t[3];
 

--- a/tools/clang/test/CodeGenSPIRV/op.rw-structured-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.rw-structured-buffer.access.hlsl
@@ -26,7 +26,8 @@ void main(uint index: A) {
 // CHECK:       [[val:%[0-9]+]] = OpLoad %float %val
 // CHECK-NEXT:  [[index:%[0-9]+]] = OpLoad %uint %index
 
-// CHECK-NEXT:  [[t3:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 [[index]] %int_4 %int_3
+// CHECK-NEXT:  [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MySbuffer %int_0 [[index]] %int_4
+// CHECK-NEXT:  [[t3:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
 // CHECK-NEXT:  OpStore [[t3]] [[val]]
 
 // CHECK:       [[f:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_3 %int_3 %int_0 %int_0
@@ -35,7 +36,8 @@ void main(uint index: A) {
 // CHECK-NEXT:  [[c212:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_2 %int_2 %int_2 %uint_1 %uint_2
 // CHECK-NEXT:  OpStore [[c212]] [[val]]
 
-// CHECK-NEXT:  [[b1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v2float %MySbuffer %int_0 %uint_1 %int_1 %int_1
+// CHECK-NEXT:  [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_v2float_uint_2 %MySbuffer %int_0 %uint_1 %int_1
+// CHECK-NEXT:  [[b1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v2float [[base]] %int_1
 // CHECK-NEXT:  [[x:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[b1]] %int_0
 // CHECK-NEXT:  OpStore [[x]] [[val]]
 

--- a/tools/clang/test/CodeGenSPIRV/op.struct.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.struct.access.hlsl
@@ -91,10 +91,16 @@ float4 main() : SV_Target {
 
 // CHECK:       [[baz:%[0-9]+]] = OpFunctionCall %S %baz
 // CHECK-NEXT:                 OpStore %temp_var_S [[baz]]
-// CHECK-NEXT:                 OpAccessChain %_ptr_Function_v4float %temp_var_S %int_4 %int_0
+// CHECK-NEXT: [[base:%[0-9]+]] = OpAccessChain %_ptr_Function__arr_v4float_uint_1 %temp_var_S %int_4
+// CHECK-NEXT: [[array_value:%[0-9]+]] = OpLoad %_arr_v4float_uint_1 [[base]]
+// CHECK-NEXT:                 OpStore %temp_var_ [[array_value]]
+// CHECK-NEXT:                 OpAccessChain %_ptr_Function_v4float %temp_var_ %int_0
 // CHECK:       [[bar:%[0-9]+]] = OpFunctionCall %S %bar
 // CHECK-NEXT:                 OpStore %temp_var_S_0 [[bar]]
-// CHECK-NEXT:                 OpAccessChain %_ptr_Function_float %temp_var_S_0 %int_5 %int_1
+// CHECK-NEXT: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Function__arr_float_uint_4 %temp_var_S_0 %int_5
+// CHECK-NEXT: [[ld:%[0-9]+]] = OpLoad %_arr_float_uint_4 %111
+// CHECK-NEXT:                 OpStore %temp_var__0 %112
+// CHECK-NEXT:                 OpAccessChain %_ptr_Function_float %temp_var__0 %int_1
     float4 val1 = bar().f[1] * baz().e[0];
 
 // CHECK:        [[ac:%[0-9]+]] = OpAccessChain %_ptr_Function_int %temp_var_S_1 %int_6

--- a/tools/clang/test/CodeGenSPIRV/op.structured-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.structured-buffer.access.hlsl
@@ -19,7 +19,8 @@ float4 main(uint index: A) : SV_Target {
 // CHECK:      [[a:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 %uint_0 %int_0
 // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[a]]
 
-// CHECK:      [[b1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v2float %MySbuffer %int_0 %uint_1 %int_1 %int_1
+// CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_v2float_uint_2 %MySbuffer %int_0 %uint_1 %int_1
+// CHECK:      [[b1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_v2float [[base]] %int_1
 // CHECK-NEXT: [[x:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[b1]] %int_0
 // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[x]]
 
@@ -30,7 +31,8 @@ float4 main(uint index: A) : SV_Target {
 // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[s]]
 
 // CHECK:      [[index:%[0-9]+]] = OpLoad %uint %index
-// CHECK-NEXT: [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MySbuffer %int_0 [[index]] %int_4 %int_3
+// CHECK-NEXT: [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MySbuffer %int_0 [[index]] %int_4
+// CHECK-NEXT: [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
 // CHECK-NEXT: {{%[0-9]+}} = OpLoad %float [[t]]
     return MySbuffer[0].a + MySbuffer[1].b[1].x + MySbuffer[2].c[2][1][2] +
            MySbuffer[3].s[0].f + MySbuffer[index].t[3];

--- a/tools/clang/test/CodeGenSPIRV/op.texture-buffer.access.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.texture-buffer.access.hlsl
@@ -30,7 +30,8 @@ float main() : A {
 // CHECK:      [[s:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyTB %int_3 %int_0
 // CHECK-NEXT:   {{%[0-9]+}} = OpLoad %float [[s]]
 
-// CHECK:      [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyTB %int_4 %int_3
+// CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyTB %int_4
+// CHECK:      [[t:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
 // CHECK-NEXT:   {{%[0-9]+}} = OpLoad %float [[t]]
   return MyTB.a         + MyTB.b.x         + MyTB.c[1][2]         + MyTB.s.f         + MyTB.t[3] +
 // CHECK:      [[a_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyTBArray %int_4 %int_0
@@ -46,7 +47,8 @@ float main() : A {
 // CHECK:      [[s_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyTBArray %int_1 %int_3 %int_0
 // CHECK-NEXT:   {{%[0-9]+}} = OpLoad %float [[s_0]]
 
-// CHECK:      [[t_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float %MyTBArray %int_0 %int_4 %int_3
+// CHECK:      [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_4 %MyTBArray %int_0 %int_4
+// CHECK:      [[t_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_3
 // CHECK-NEXT:   {{%[0-9]+}} = OpLoad %float [[t_0]]
          MyTBArray[4].a + MyTBArray[3].b.x + MyTBArray[2].c[1][2] + MyTBArray[1].s.f + MyTBArray[0].t[3];
 }

--- a/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.usage.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.legal.sbuffer.usage.hlsl
@@ -63,7 +63,8 @@ float4 main(in float4 pos : SV_Position) : SV_Target
 // CHECK-NEXT:      {{%[0-9]+}} = OpLoad %v4float [[ptr2_0]]
         localRWSBuffer[2].f +
 // CHECK:      [[ptr1_1:%[0-9]+]] = OpLoad %_ptr_Uniform_type_RWStructuredBuffer_S %localRWSBuffer
-// CHECK-NEXT: [[ptr2_1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[ptr1_1]] %int_0 %uint_33 %int_1 %int_44
+// CHECK-NEXT: [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_float_uint_128 [[ptr1_1]] %int_0 %uint_33 %int_1
+// CHECK-NEXT: [[ptr2_1:%[0-9]+]] = OpAccessChain %_ptr_Uniform_float [[base]] %int_44
 // CHECK-NEXT:      {{%[0-9]+}} = OpLoad %float [[ptr2_1]]
         localRWSBuffer[33].v[44] +
 // CHECK:      [[ptr1_2:%[0-9]+]] = OpLoad %_ptr_Uniform_type_RWStructuredBuffer_v4float %localv4f32RWSBuffer

--- a/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/type.byte-address-buffer.hlsl
@@ -21,11 +21,17 @@ ByteAddressBuffer Buffer0;
 ByteAddressBuffer BufferArray[2];
 RWByteAddressBuffer BufferOut;
 
+struct MyStruct
+{
+	ByteAddressBuffer myBuffers[2];
+};
+
 // CHECK: %src_main = OpFunction
 [numthreads(1, 1, 1)]
 void main() {
 // CHECK: %LocalArray = OpVariable %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 Function
 // CHECK: %Local = OpVariable %_ptr_Function__ptr_Uniform_type_ByteAddressBuffer Function
+// CHECK: %ms = OpVariable %_ptr_Function_MyStruct Function
   ByteAddressBuffer LocalArray[2];
 
 // CHECK: OpStore %LocalArray %BufferArray
@@ -35,4 +41,15 @@ void main() {
 // CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Uniform_type_ByteAddressBuffer [[array]] %int_0
 // CHECK: OpStore %Local [[ac]]
   ByteAddressBuffer Local = LocalArray[0];
+
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 %ms %int_0
+// CHECK: OpStore [[ac]] %BufferArray
+  MyStruct ms;
+  ms.myBuffers = BufferArray;
+
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Function__ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 %ms %int_0
+// CHECK: [[alias:%[0-9]+]] = OpLoad %_ptr_Uniform__arr_type_ByteAddressBuffer_uint_2 [[ac]]
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Uniform_type_ByteAddressBuffer [[alias]] %int_0
+// CHECK: OpStore %buffer [[ac]]
+	ByteAddressBuffer buffer = ms.myBuffers[0];
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.1p2.block-decoration.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.1p2.block-decoration.hlsl
@@ -28,7 +28,8 @@ RWStructuredBuffer<S> rwsb;
 
 [numthreads(1, 1, 1)]
 void main() {
-// CHECK:   [[vec:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_v4float %rwsb %int_0 %uint_2 %int_0 %int_1
+// CHECK:   [[base:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer__arr_v4float_uint_5 %rwsb %int_0 %uint_2 %int_0
+// CHECK:   [[vec:%[0-9]+]] = OpAccessChain %_ptr_StorageBuffer_v4float [[base]] %int_1
 // CHECK:       {{%[0-9]+}} = OpAccessChain %_ptr_StorageBuffer_float [[vec]] %int_0
   float a = rwsb[2].f[1].x;
 

--- a/tools/clang/test/CodeGenSPIRV/vk.binding.global-struct-of-resources.2.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.binding.global-struct-of-resources.2.hlsl
@@ -45,7 +45,8 @@ Texture2D globalTexture;
 SamplerState globalSamplerState;
 
 float4 main() : SV_Target {
-// CHECK:  [[ptr:%[0-9]+]] = OpAccessChain %_ptr_UniformConstant_S %globalS %int_0 %int_0
+// CHECK:  [[base:%[0-9]+]] = OpAccessChain %_ptr_UniformConstant__arr_S_uint_3 %globalS %int_0
+// CHECK:  [[ptr:%[0-9]+]] = OpAccessChain %_ptr_UniformConstant_S [[base]] %int_0
 // CHECK: [[elem:%[0-9]+]] = OpLoad %S [[ptr]]
 // CHECK:                 OpStore %param_var_x [[elem]]
 // CHECK:                 OpFunctionCall %v4float %tex2D %param_var_x %param_var_v

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.boolean.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.boolean.hlsl
@@ -130,7 +130,8 @@ float4 main(in float4 texcoords : TEXCOORD0) : SV_TARGET
     bool2   k = frameConstants.boolMat._m12_m01;
 
 // CHECK:      [[FrameConstants_9:%[0-9]+]] = OpAccessChain %_ptr_Uniform_FrameConstants %CONSTANTS %int_0
-// CHECK-NEXT:            [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[FrameConstants_9]] %int_3 %int_0 %int_2
+// CHECK-NEXT:            [[base:%[0-9]+]] = OpAccessChain %_ptr_Uniform__arr_uint_uint_1 [[FrameConstants_9]] %int_3 %int_0
+// CHECK-NEXT:            [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[base]] %int_2
 // CHECK-NEXT:           [[uint_3:%[0-9]+]] = OpLoad %uint [[ptr]]
 // CHECK-NEXT:           [[bool_4:%[0-9]+]] = OpINotEqual %bool [[uint_3]] %uint_0
 // CHECK-NEXT:                           OpStore %l [[bool_4]]

--- a/tools/clang/test/CodeGenSPIRV/vk.push-constant.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.push-constant.hlsl
@@ -32,7 +32,8 @@ float main() : A {
         pcs.f2.z +
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_PushConstant_float %pcs %int_2 %uint_1 %uint_2
         pcs.f3[1][2] +
-// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_PushConstant_v2float %pcs %int_3 %int_0 %int_2
+// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_PushConstant__arr_v2float_uint_3 %pcs %int_3 %int_0
+// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_PushConstant_v2float [[base]] %int_2
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_PushConstant_float [[ptr_0]] %int_1
         pcs.f4.val[2].y;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shader-record-ext.hlsl
@@ -39,7 +39,8 @@ void main(inout Payload P)
         srb.f2.z +
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_2 %uint_1 %uint_2
         srb.f3[1][2] +
-// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float %srb %int_3 %int_0 %int_2
+// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV__arr_v2float_uint_3 %srb %int_3 %int_0
+// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float [[base]] %int_2
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr_0]] %int_1
         srb.f4.val[2].y;
 }

--- a/tools/clang/test/CodeGenSPIRV/vk.shader-record-nv.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.shader-record-nv.hlsl
@@ -39,7 +39,8 @@ void main(inout Payload P)
         srb.f2.z +
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float %srb %int_2 %uint_1 %uint_2
         srb.f3[1][2] +
-// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float %srb %int_3 %int_0 %int_2
+// CHECK: [[base:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV__arr_v2float_uint_3 %srb %int_3 %int_0
+// CHECK: [[ptr_0:%[0-9]+]] = OpAccessChain %_ptr_ShaderRecordBufferNV_v2float [[base]] %int_2
 // CHECK:     {{%[0-9]+}} = OpAccessChain %_ptr_ShaderRecordBufferNV_float [[ptr_0]] %int_1
         srb.f4.val[2].y;
 }


### PR DESCRIPTION
In the current implementation, a single OpAccessChain is generated for
all array subscripts and member accesses. This causes a problem if the
member access is an aliased variable, and we need to generate and
OpAccessChains for the member, a load, and then another OpAccessChain
to index into the aliased array.

This change cause an array subscript to be process as a single
OpAccessChian. Note that we still process array sub scripts with the
member access when it is a subnode of the member access. We will
probably need to fix that up later as well, but I want to keep the
change small.

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/6110.