### PR TITLE
[SPIR-V] Apply nointerpolation to mesh output

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3310,10 +3310,11 @@ SpirvVariable *DeclResultIdMapper::createSpirvInterfaceVariable(
     }
   }
 
-  // Decorate with interpolation modes for pixel shader input variables
-  // or vertex shader output variables.
+  // Decorate with interpolation modes for pixel shader input variables, vertex
+  // shader output variables, or mesh shader output variables.
   if ((spvContext.isPS() && stageVarData.sigPoint->IsInput()) ||
-      (spvContext.isVS() && stageVarData.sigPoint->IsOutput()))
+      (spvContext.isVS() && stageVarData.sigPoint->IsOutput()) ||
+      (spvContext.isMS() && stageVarData.sigPoint->IsOutput()))
     decorateInterpolationMode(stageVarData.decl, stageVarData.type, varInstr,
                               *stageVarData.semantic);
 

--- a/tools/clang/test/CodeGenSPIRV/spirv.interpolation.mesh.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spirv.interpolation.mesh.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ms_6_5 -E main -fcgl  %s -spirv | FileCheck %s
+
+struct MeshOutput {
+    float4               PositionCS  : SV_POSITION;
+// CHECK: OpDecorate %out_var_VERTEX_INDEX Flat
+    nointerpolation uint VertexIndex : VERTEX_INDEX;
+};
+
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+void main(
+                 uint       gtid : SV_GroupThreadID,
+                 uint       gid  : SV_GroupID,
+    out indices  uint3      triangles[128],
+    out vertices MeshOutput vertices[64]) {}


### PR DESCRIPTION
Mesh shader output variables may be decorated with the `nointerpolation` attribute, which should be translated to a `Flat` decoration in the SPIR-V backend.

Fixes #6250