### PR TITLE
[SPIRV] Allows variable vertex index for GetAttributeAtVertex

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12114,9 +12114,7 @@ SpirvEmitter::processGetAttributeAtVertex(const CallExpr *expr) {
   const auto exprRange = expr->getSourceRange();
 
   // arg1 : vertexId
-  const auto *arg1BaseExpr = doExpr(expr->getArg(1)->IgnoreParenLValueCasts());
-  const auto *arg1ConstExpr = dyn_cast<SpirvConstantInteger>(arg1BaseExpr);
-  const auto vertexId = arg1ConstExpr->getValue();
+  auto *arg1BaseExpr = doExpr(expr->getArg(1)->IgnoreParenLValueCasts());
 
   // arg0 : <NoInterpolation> decorated input
   // Tip  : for input with boolean type, we need to ignore implicit cast first,
@@ -12133,14 +12131,12 @@ SpirvEmitter::processGetAttributeAtVertex(const CallExpr *expr) {
   }
   // Change to access chain instr
   SpirvInstruction *accessChainPtr = paramDeclInstr;
-  SpirvConstant *vtxId = spvBuilder.getConstantInt(
-      astContext.UnsignedIntTy, llvm::APInt(32, *(vertexId.getRawData())));
   if (isa<SpirvAccessChain>(accessChainPtr)) {
     auto *accessInstr = dyn_cast<SpirvAccessChain>(accessChainPtr);
-    accessInstr->insertIndex(vtxId, accessInstr->getIndexes().size());
+    accessInstr->insertIndex(arg1BaseExpr, accessInstr->getIndexes().size());
   } else
-    accessChainPtr = spvBuilder.createAccessChain(elementType, accessChainPtr,
-                                                  vtxId, exprLoc, exprRange);
+    accessChainPtr = spvBuilder.createAccessChain(
+        elementType, accessChainPtr, arg1BaseExpr, exprLoc, exprRange);
   dyn_cast<SpirvAccessChain>(accessChainPtr)->setNoninterpolated(false);
   auto *loadPtr =
       spvBuilder.createLoad(elementType, accessChainPtr, exprLoc, exprRange);

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.var.idx.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.var.idx.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T ps_6_0 -E main %s -spirv | FileCheck %s
+
+struct PSInput {
+  int idx: INPUT0;
+  nointerpolation      float4 fp_h: FPH;
+};
+
+float4 main(PSInput input) : SV_Target {
+// CHECK: [[idx:%[0-9]+]] = OpLoad %int %in_var_INPUT0
+// CHECK: [[bc:%[0-9]+]] = OpBitcast %uint [[idx]]
+// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Input_v4float %in_var_FPH [[bc]]
+// CHECK: [[ld:%[0-9]+]] = OpLoad %v4float [[ac]]
+// CHECK: OpStore %out_var_SV_Target [[ld]]
+  return GetAttributeAtVertex(input.fp_h, input.idx);
+}


### PR DESCRIPTION
The SPIR-V path currently fails when a variable is passed at the index
to GetAttributeAtVertex. Not only should we not crash, but the variable
does not seem to be a problem for the SPIR-V validator. So we can simply
generate an access chain with a variable idx.
