### PR TITLE
Fixed invalid debug info with templated structs

### DIFF
--- a/lib/HLSL/DxilNoops.cpp
+++ b/lib/HLSL/DxilNoops.cpp
@@ -553,7 +553,8 @@ public:
         DIExpression *Expr = Declare->getExpression();
         if (Expr->getNumElements() == 1 &&
             Expr->getElement(0) == dwarf::DW_OP_deref) {
-          while (Ty && (Ty->getTag() == dwarf::DW_TAG_reference_type ||
+          while (Ty && (Ty->getTag() == dwarf::DW_TAG_pointer_type ||
+                        Ty->getTag() == dwarf::DW_TAG_reference_type ||
                         Ty->getTag() == dwarf::DW_TAG_restrict_type)) {
             Ty = cast<DIDerivedType>(Ty)->getBaseType().resolve(EmptyMap);
           }

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/templated_struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/templated_struct.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T ps_6_0 %s -Zi -O0 | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -Zi -O3 | FileCheck %s
+
+// We check that the broken down elements directly point to the value of the struct S
+
+// CHECK: dbg.value(metadata float %{{.+}}, i64 0, metadata ![[this:.+]], metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"this" !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK: dbg.value(metadata float %{{.+}}, i64 0, metadata ![[this]], metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"this" !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: ![[this]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: !{{[0-9]+}}, type: ![[type:[0-9]+]])
+// CHECK-DAG: ![[type]] = !DICompositeType(tag: DW_TAG_structure_type, name: "S<float>", file: !{{[0-9]+}}, line: {{[0-9]+}}, size: 64, align: 32, elements: !{{[0-9]+}}, templateParams: !{{[0-9]+}})
+
+template<typename T>
+struct S {
+  T a, b;
+  T Get() {
+    return a + b;
+  }
+};
+
+[RootSignature("")]
+float main(float x : X, float y : Y, float z : Z, float w : W) : SV_Target {
+  S<float> s;
+  s.a = x;
+  s.b = y;
+  return s.Get();
+}
+
+


### PR DESCRIPTION
This debug info for the `this` parameter for templated struct is generated like so:

```
define internal float @"\01?Get@?$S@M@@QAAMXZ"(%"struct.S<float>"* %this) #2 comdat align 2 {
    call void @llvm.dbg.declare(metadata %"struct.S<float>"* %this, metadata !27, metadata !29), !dbg !30 ; var:"this" !DIExpression(DW_OP_deref)
    ...
}
...
!27 = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: !8, type: !52, flags: DIFlagArtificial | DIFlagObjectPointer)
!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !9, size: 32, align: 32)
!9 = !DICompositeType(tag: DW_TAG_structure_type, name: "S<float>", file: !1, line: 4, size: 64, align: 32, elements: !10, templateParams: !17)
```

In the pass `DxilRewriteOutputArgDebugInfo`, this pattern of dereferencing a pointer is identified and the indirection is removed; except it was only done for `DW_TAG_reference_type`. This change adds `DW_TAG_pointer_type` to the accepted type tag here.


Fixes #6251 