### PR TITLE
[SPIRV] Do not ignore RValue cast for vertex id in GetAttributeAtVertex

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12133,7 +12133,7 @@ SpirvEmitter::processGetAttributeAtVertex(const CallExpr *expr) {
   const auto exprRange = expr->getSourceRange();
 
   // arg1 : vertexId
-  auto *arg1BaseExpr = doExpr(expr->getArg(1)->IgnoreParenLValueCasts());
+  auto *arg1BaseExpr = doExpr(expr->getArg(1));
 
   // arg0 : <NoInterpolation> decorated input
   // Tip  : for input with boolean type, we need to ignore implicit cast first,

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.var.idx.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.var.idx.hlsl
@@ -2,14 +2,21 @@
 
 struct PSInput {
   int idx: INPUT0;
+  uint uidx: INPUT1;
   nointerpolation      float4 fp_h: FPH;
 };
 
 float4 main(PSInput input) : SV_Target {
-// CHECK: [[idx:%[0-9]+]] = OpLoad %int %in_var_INPUT0
-// CHECK: [[bc:%[0-9]+]] = OpBitcast %uint [[idx]]
-// CHECK: [[ac:%[0-9]+]] = OpAccessChain %_ptr_Input_v4float %in_var_FPH [[bc]]
-// CHECK: [[ld:%[0-9]+]] = OpLoad %v4float [[ac]]
-// CHECK: OpStore %out_var_SV_Target [[ld]]
-  return GetAttributeAtVertex(input.fp_h, input.idx);
+// CHECK:  [[idx:%[0-9]+]] = OpLoad %int %in_var_INPUT0
+// CHECK: [[uidx:%[0-9]+]] = OpLoad %uint %in_var_INPUT1
+// CHECK:   [[bc:%[0-9]+]] = OpBitcast %uint [[idx]]
+// CHECK:   [[ac:%[0-9]+]] = OpAccessChain %_ptr_Input_v4float %in_var_FPH [[bc]]
+// CHECK:    [[a:%[0-9]+]] = OpLoad %v4float [[ac]]
+// CHECK:   [[ac:%[0-9]+]] = OpAccessChain %_ptr_Input_v4float %in_var_FPH %21
+// CHECK:    [[b:%[0-9]+]] = OpLoad %v4float %25
+// CHECK:  [[add:%[0-9]+]] = OpFAdd %v4float [[a]] [[b]]
+// CHECK:                    OpStore %out_var_SV_Target [[add]]
+  float4 a = GetAttributeAtVertex(input.fp_h, input.idx);
+  float4 b = GetAttributeAtVertex(input.fp_h, input.uidx);
+  return a+b;
 }


### PR DESCRIPTION
We are able to pass a variable as the index to GetAttributeAtVertex, but
only if it is signed. If the value is unsigned, no cast is needed, and
the current code will skip the LValueToRValue cast. This causes the
load to be skipped generating invalid code.
