### PR TITLE
[SPIR-V] Remove duplication of raytracing stage vars

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -3938,6 +3938,11 @@ SpirvVariable *DeclResultIdMapper::getBuiltinVar(spv::BuiltIn builtIn,
   return getBuiltinVar(builtIn, type, sc, loc);
 }
 
+SpirvFunction *
+DeclResultIdMapper::getRayTracingStageVarEntryFunction(SpirvVariable *var) {
+  return rayTracingStageVarToEntryPoints[var];
+}
+
 SpirvVariable *DeclResultIdMapper::createSpirvStageVar(
     StageVar *stageVar, const NamedDecl *decl, const llvm::StringRef name,
     SourceLocation srcLoc) {
@@ -4541,6 +4546,8 @@ DeclResultIdMapper::createRayTracingNVStageVar(spv::StorageClass sc,
   default:
     assert(false && "Unsupported SPIR-V storage class for raytracing");
   }
+
+  rayTracingStageVarToEntryPoints[retVal] = entryFunction;
 
   return retVal;
 }

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -205,6 +205,10 @@ public:
   SpirvVariable *getBuiltinVar(spv::BuiltIn builtIn, QualType type,
                                SourceLocation);
 
+  /// \brief If var is a raytracing stage variable, returns its entry point,
+  /// otherwise returns nullptr.
+  SpirvFunction *getRayTracingStageVarEntryFunction(SpirvVariable *var);
+
   /// \brief Creates the stage output variables by parsing the semantics
   /// attached to the given function's parameter or return value and returns
   /// true on success. SPIR-V instructions will also be generated to update the
@@ -969,6 +973,11 @@ private:
   /// using HLSL intrinsic function calls. All other builtin variables are
   /// accessed using stage IO variables.
   llvm::DenseMap<uint32_t, SpirvVariable *> builtinToVarMap;
+
+  /// Maps from a raytracing stage variable to the entry point that variable is
+  /// for.
+  llvm::DenseMap<SpirvVariable *, SpirvFunction *>
+      rayTracingStageVarToEntryPoints;
 
   /// Whether the translated SPIR-V binary needs legalization.
   ///

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -757,6 +757,11 @@ SpirvEmitter::getInterfacesForEntryPoint(SpirvFunction *entryPoint) {
   for (auto *moduleVar : spvBuilder.getModule()->getVariables()) {
     if (moduleVar->getStorageClass() != spv::StorageClass::Input &&
         moduleVar->getStorageClass() != spv::StorageClass::Output) {
+      if (auto *varEntry =
+              declIdMapper.getRayTracingStageVarEntryFunction(moduleVar)) {
+        if (varEntry != entryPoint)
+          continue;
+      }
       interfaces.insert(moduleVar);
     }
   }

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-ext.std430.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.shader-record-ext.std430.hlsl
@@ -1,5 +1,8 @@
 // RUN: %dxc -T lib_6_3 -fspv-target-env=vulkan1.2 -fvk-use-gl-layout -fcgl  %s -spirv | FileCheck %s
 
+// CHECK: OpEntryPoint ClosestHitNV %chs1 "chs1" %cbuf %block %P %A
+// CHECK: OpEntryPoint ClosestHitNV %chs2 "chs2" %cbuf %block %P_0 %A_0
+
 // CHECK: OpDecorate %_arr_v2float_uint_3 ArrayStride 8
 // CHECK: OpDecorate %_arr_mat3v2float_uint_2 ArrayStride 32
 // CHECK: OpDecorate %_arr_v2int_uint_3 ArrayStride 8


### PR DESCRIPTION
Only add raytracing stage var to `OpEntryPoint` interface if it is actually used by that entry point.

Fixes #6265.