### PR TITLE
[DIAG] Limit derivative warning to intrinsic overload added in sm6.8 …

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7778,13 +7778,13 @@ def err_hlsl_unsupported_for_version_lower : Error<
 def err_hlsl_unsupported_keyword_for_min_precision : Error<
    "%0 is only supported with -enable-16bit-types option">;
 def warn_hlsl_derivatives_in_wrong_shader_kind: Warning<
-   "Intrinsic %0 potentially used by %1 requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders.">,
+   "Intrinsic %0 potentially used by '%1' requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders.">,
     DefaultError, InGroup<HLSLAvailability>;
 def warn_hlsl_derivatives_in_wrong_shader_model: Warning<
-   "Intrinsic %0 potentially used by %1 requires derivatives - shader model 6.6 or greater is required for use in compute, amplification, or mesh shaders.">,
+   "Intrinsic %0 potentially used by '%1' requires derivatives - shader model 6.6 or greater is required for use in compute, amplification, or mesh shaders.">,
     DefaultError, InGroup<HLSLAvailability>;
 def warn_hlsl_derivatives_wrong_numthreads : Warning<
-   "Intrinsic %0 potentially used by %1 requires derivatives - when used in compute/amplification/mesh shaders"
+   "Intrinsic %0 potentially used by '%1' requires derivatives - when used in compute/amplification/mesh shaders"
     " or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or"
     " both X and Y must be multiples of 2.">,
     DefaultError, InGroup<HLSLAvailability>;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11156,60 +11156,67 @@ void Sema::DiagnoseReachableHLSLMethodCall(const CXXMethodDecl *MD,
     switch (opCode) {
     case hlsl::IntrinsicOp::MOP_CalculateLevelOfDetail:
     case hlsl::IntrinsicOp::MOP_CalculateLevelOfDetailUnclamped: {
-      if (!SM->IsSM68Plus()) {
-        QualType SamplerComparisonTy =
-            HLSLExternalSource::FromSema(this)->GetBasicKindType(
-                AR_OBJECT_SAMPLERCOMPARISON);
-        if (MD->getParamDecl(0)->getType() == SamplerComparisonTy) {
+      QualType SamplerComparisonTy =
+          HLSLExternalSource::FromSema(this)->GetBasicKindType(
+              AR_OBJECT_SAMPLERCOMPARISON);
+      if (MD->getParamDecl(0)->getType() == SamplerComparisonTy) {
+
+        if (!SM->IsSM68Plus()) {
+
           Diags.Report(Loc,
                        diag::warn_hlsl_intrinsic_overload_in_wrong_shader_model)
               << MD->getNameAsString() + " with SamplerComparisonState"
               << "6.8";
-        }
-      }
-
-      switch (EntrySK) {
-      default: {
-        if (!SM->AllowDerivatives(EntrySK)) {
-          Diags.Report(Loc, diag::warn_hlsl_derivatives_in_wrong_shader_kind)
-              << MD->getNameAsString() << EntryDecl->getNameAsString();
-          Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
-        }
-      } break;
-      case DXIL::ShaderKind::Compute:
-      case DXIL::ShaderKind::Amplification:
-      case DXIL::ShaderKind::Mesh: {
-        if (!SM->IsSM66Plus()) {
-          Diags.Report(Loc, diag::warn_hlsl_derivatives_in_wrong_shader_model)
-              << MD->getNameAsString() << EntryDecl->getNameAsString();
-          Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
-        }
-      } break;
-      case DXIL::ShaderKind::Node: {
-        if (const auto *pAttr = EntryDecl->getAttr<HLSLNodeLaunchAttr>()) {
-          if (pAttr->getLaunchType() != "broadcasting") {
-            Diags.Report(Loc, diag::warn_hlsl_derivatives_in_wrong_shader_kind)
-                << MD->getNameAsString() << EntryDecl->getNameAsString();
-            Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
-          }
-        }
-      } break;
-      }
-      if (const HLSLNumThreadsAttr *Attr =
-              EntryDecl->getAttr<HLSLNumThreadsAttr>()) {
-        bool invalidNumThreads = false;
-        if (Attr->getZ() != 1) {
-          invalidNumThreads = true;
-        } else if (Attr->getY() != 1) {
-          invalidNumThreads =
-              !((Attr->getX() % 2) == 0 && (Attr->getY() % 2) == 0);
         } else {
-          invalidNumThreads = (Attr->getX() % 4) != 0;
-        }
-        if (invalidNumThreads) {
-          Diags.Report(Loc, diag::warn_hlsl_derivatives_wrong_numthreads)
-              << MD->getNameAsString() << EntryDecl->getNameAsString();
-          Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
+
+          switch (EntrySK) {
+          default: {
+            if (!SM->AllowDerivatives(EntrySK)) {
+              Diags.Report(Loc,
+                           diag::warn_hlsl_derivatives_in_wrong_shader_kind)
+                  << MD->getNameAsString() << EntryDecl->getNameAsString();
+              Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
+            }
+          } break;
+          case DXIL::ShaderKind::Compute:
+          case DXIL::ShaderKind::Amplification:
+          case DXIL::ShaderKind::Mesh: {
+            if (!SM->IsSM66Plus()) {
+              Diags.Report(Loc,
+                           diag::warn_hlsl_derivatives_in_wrong_shader_model)
+                  << MD->getNameAsString() << EntryDecl->getNameAsString();
+              Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
+            }
+          } break;
+          case DXIL::ShaderKind::Node: {
+            if (const auto *pAttr = EntryDecl->getAttr<HLSLNodeLaunchAttr>()) {
+              if (pAttr->getLaunchType() != "broadcasting") {
+                Diags.Report(Loc,
+                             diag::warn_hlsl_derivatives_in_wrong_shader_kind)
+                    << MD->getNameAsString() << EntryDecl->getNameAsString();
+                Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
+              }
+            }
+          } break;
+          }
+          if (const HLSLNumThreadsAttr *Attr =
+                  EntryDecl->getAttr<HLSLNumThreadsAttr>()) {
+            bool invalidNumThreads = false;
+            if (Attr->getY() != 1) {
+              // 2D mode requires x and y to be multiple of 2.
+              invalidNumThreads =
+                  !((Attr->getX() % 2) == 0 && (Attr->getY() % 2) == 0);
+            } else {
+              // 1D mode requires x to be multiple of 4 and y and z to be 1.
+              invalidNumThreads =
+                  (Attr->getX() % 4) != 0 || (Attr->getZ() != 1);
+            }
+            if (invalidNumThreads) {
+              Diags.Report(Loc, diag::warn_hlsl_derivatives_wrong_numthreads)
+                  << MD->getNameAsString() << EntryDecl->getNameAsString();
+              Diags.Report(EntryDecl->getLocation(), diag::note_declared_at);
+            }
+          }
         }
       }
     } break;

--- a/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODExtraDiag.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODExtraDiag.hlsl
@@ -2,7 +2,7 @@
 
 // Check cs/as/mesh and node.
 
-SamplerState ss : register(s2);
+SamplerComparisonState ss : register(s2);
 
 RWStructuredBuffer<uint> o;
 Texture1D        <float>  t1;
@@ -12,7 +12,15 @@ Texture1D        <float>  t1;
 [shader("compute")]
 void foo(uint3 id : SV_GroupThreadID)
 {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by foo requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'foo' requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
+}
+
+// Make sure 2d mode ok with z != 1.
+[numthreads(4,2,3)]
+[shader("compute")]
+void foo2(uint3 id : SV_GroupThreadID)
+{
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
 }
 
@@ -21,7 +29,7 @@ void foo(uint3 id : SV_GroupThreadID)
 [shader("compute")]
 void bar(uint3 id : SV_GroupThreadID)
 {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by bar requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'bar' requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
 }
 
@@ -30,7 +38,7 @@ void bar(uint3 id : SV_GroupThreadID)
 [numthreads(3,1,1)]
 [outputtopology("triangle")]
 void mesh(uint ix : SV_GroupIndex, uint3 id : SV_GroupThreadID) {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by mesh requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'mesh' requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
 }
 
@@ -44,7 +52,7 @@ struct Payload {
 [shader("amplification")]
 void ASmain()
 {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by ASmain requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'ASmain' requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
     Payload pld;
     pld.dummy = float2(1.0,2.0);
@@ -61,7 +69,7 @@ struct RECORD {
 [NodeDispatchGrid(1, 1, 1)]
 [NumThreads(1,1,1)]
 void node01(DispatchNodeInputRecord<RECORD> input) {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by node01 requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'node01' requires derivatives - when used in compute/amplification/mesh shaders or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or both X and Y must be multiples of 2}}
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
  }
 
@@ -72,7 +80,28 @@ void node01(DispatchNodeInputRecord<RECORD> input) {
 [NodeIsProgramEntry]
 void node02()
 {
-    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by node02 requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'node02' requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
     o[0] = t1.CalculateLevelOfDetail(ss, 0.5);
 }
 
+// expected-note@+2 {{declared here}}
+[Shader("vertex")]
+float4 vs(float2 a :A) :SV_POSTION {
+  float r = 0;
+  if (1>3)
+    // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'vs' requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
+    r = t1.CalculateLevelOfDetail(ss, 0.5).x;
+  return r;
+}
+
+SamplerComparisonState s;
+Texture1D t;
+// expected-note@+3{{declared here}}
+// expected-note@+2{{declared here}}
+[shader("vertex")]
+float4 vs2(float a:A) : SV_Position {
+  // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by 'vs2' requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
+  return t.CalculateLevelOfDetail(s, a) +
+  // expected-error@+1 {{Intrinsic CalculateLevelOfDetailUnclamped potentially used by 'vs2' requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
+    t.CalculateLevelOfDetailUnclamped(ss, a);
+}

--- a/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODNoWarning.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODNoWarning.hlsl
@@ -1,0 +1,13 @@
+// RUN: %dxc -T lib_6_7 %s -verify
+
+// Make sure no warning for shader model < 6.8
+// expected-no-diagnostics
+
+SamplerState s;
+Texture1D t;
+
+[shader("vertex")]
+float4 vs2(float a:A) : SV_Position {
+  return t.CalculateLevelOfDetail(s, a) +
+    t.CalculateLevelOfDetailUnclamped(s, a);
+}

--- a/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState.hlsl
@@ -35,12 +35,8 @@ float ps(float a:A) : SV_Target {
     t.CalculateLevelOfDetailUnclamped(s, a); // expected-error {{overload of intrinsic CalculateLevelOfDetailUnclamped with SamplerComparisonState requires shader model 6.8 or greater}}
 }
 
-// expected-note@+3{{declared here}}
-// expected-note@+2{{declared here}}
 [shader("vertex")]
 float4 vs(float a:A) : SV_Position {
-  // expected-error@+1 {{Intrinsic CalculateLevelOfDetail potentially used by vs requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
   return t.CalculateLevelOfDetail(s, a) + // expected-error {{overload of intrinsic CalculateLevelOfDetail with SamplerComparisonState requires shader model 6.8 or greater}}
-  // expected-error@+1 {{Intrinsic CalculateLevelOfDetailUnclamped potentially used by vs requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
     t.CalculateLevelOfDetailUnclamped(s, a); // expected-error {{overload of intrinsic CalculateLevelOfDetailUnclamped with SamplerComparisonState requires shader model 6.8 or greater}}
 }

--- a/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState_warning.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/objects/texture/CalculateLODWithSamplerComparisonState_warning.hlsl
@@ -41,12 +41,8 @@ float ps(float a:A) : SV_Target {
     t.CalculateLevelOfDetailUnclamped(s, a); // expected-warning {{overload of intrinsic CalculateLevelOfDetailUnclamped with SamplerComparisonState requires shader model 6.8 or greater}}
 }
 
-// expected-note@+3{{declared here}}
-// expected-note@+2{{declared here}}
 [shader("vertex")]
 float4 vs(float a:A) : SV_Position {
-  // expected-warning@+1 {{Intrinsic CalculateLevelOfDetail potentially used by vs requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
   return t.CalculateLevelOfDetail(s, a) + // expected-warning {{overload of intrinsic CalculateLevelOfDetail with SamplerComparisonState requires shader model 6.8 or greater}}
-  // expected-warning@+1 {{Intrinsic CalculateLevelOfDetailUnclamped potentially used by vs requires derivatives - only available in pixel, compute, amplification, mesh, or broadcast node shaders}}
     t.CalculateLevelOfDetailUnclamped(s, a); // expected-warning {{overload of intrinsic CalculateLevelOfDetailUnclamped with SamplerComparisonState requires shader model 6.8 or greater}}
 }


### PR DESCRIPTION
…(#6244)

This change is made to prevent errors in unused code that might impact existing shaders.

Fixes #6249
Fixes #6235

(cherry picked from commit afedfff5c1b6ad3f87ffbae273a825034c670633)