### PR TITLE
[Sema] Add diagnostics for incompatible combination of System Values …

### DIFF
--- a/tools/clang/include/clang/Sema/Sema.h
+++ b/tools/clang/include/clang/Sema/Sema.h
@@ -3808,6 +3808,8 @@ public:
                                         QualType TargetType,
                                         SourceLocation Loc);
   bool DiagnoseHLSLMethodCall(const CXXMethodDecl *MD, SourceLocation Loc);
+  void DiagnoseSVForLaunchType(const FunctionDecl *FD,
+                               hlsl::DXIL::NodeLaunchType LaunchTy);
   void DiagnoseReachableHLSLMethodCall(const CXXMethodDecl *MD,
                                        SourceLocation Loc,
                                        const hlsl::ShaderModel *SM,

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11144,6 +11144,50 @@ bool Sema::DiagnoseHLSLMethodCall(const CXXMethodDecl *MD, SourceLocation Loc) {
   return false;
 }
 
+// Produce diagnostics for any system values attached to `FD` function
+// that are invalid for the `LaunchTy` launch type
+void Sema::DiagnoseSVForLaunchType(const FunctionDecl *FD,
+                                   DXIL::NodeLaunchType LaunchTy) {
+  // Validate Compute Shader system value inputs per launch mode
+  for (ParmVarDecl *param : FD->parameters()) {
+    for (const hlsl::UnusualAnnotation *it : param->getUnusualAnnotations()) {
+      if (it->getKind() == hlsl::UnusualAnnotation::UA_SemanticDecl) {
+        const hlsl::SemanticDecl *sd = cast<hlsl::SemanticDecl>(it);
+        // if the node launch type is Thread, then there are no system values
+        // allowed
+        if (LaunchTy == DXIL::NodeLaunchType::Thread) {
+          if (sd->SemanticName.startswith("SV_")) {
+            // emit diagnostic
+            unsigned DiagID = Diags.getCustomDiagID(
+                DiagnosticsEngine::Error,
+                "Invalid system value semantic '%0' for launchtype '%1'");
+            Diags.Report(param->getLocation(), DiagID)
+                << sd->SemanticName << "Thread";
+          }
+        }
+
+        // if the node launch type is Coalescing, then only
+        // SV_GroupIndex and SV_GroupThreadID are allowed
+        else if (LaunchTy == DXIL::NodeLaunchType::Coalescing) {
+          if (!(sd->SemanticName.equals("SV_GroupIndex") ||
+                sd->SemanticName.equals("SV_GroupThreadID"))) {
+            // emit diagnostic
+            unsigned DiagID = Diags.getCustomDiagID(
+                DiagnosticsEngine::Error,
+                "Invalid system value semantic '%0' for launchtype '%1'");
+            Diags.Report(param->getLocation(), DiagID)
+                << sd->SemanticName << "Coalescing";
+          }
+        }
+        // Broadcasting nodes allow all node shader system value semantics
+        else if (LaunchTy == DXIL::NodeLaunchType::Broadcasting) {
+          continue;
+        }
+      }
+    }
+  }
+}
+
 // Check HLSL member call constraints for used functions.
 void Sema::DiagnoseReachableHLSLMethodCall(const CXXMethodDecl *MD,
                                            SourceLocation Loc,
@@ -15603,6 +15647,7 @@ void DiagnoseNodeEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName,
           }
         }
       }
+      S.DiagnoseSVForLaunchType(FD, NodeLaunchTy);
     }
   }
   return;

--- a/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
+++ b/tools/clang/lib/Sema/SemaHLSLDiagnoseTU.cpp
@@ -322,6 +322,8 @@ public:
     return true;
   }
 
+  clang::Sema *getSema() { return sema; }
+
 private:
   clang::Sema *sema;
   const hlsl::ShaderModel *SM;
@@ -475,6 +477,18 @@ void hlsl::DiagnoseTranslationUnit(clang::Sema *self) {
       HLSLMethodCallDiagnoseVisitor Visitor(self, shaderModel, EntrySK, FDecl,
                                             DiagnosedCalls);
       Visitor.TraverseDecl(FD);
+
+      // diagnose any node functions that have incompatible launch types with
+      // the present SV semantics on each parameter.
+      if (EntrySK == DXIL::ShaderKind::Node) {
+        if (const auto *NodeLaunchAttr =
+                FDecl->getAttr<clang::HLSLNodeLaunchAttr>()) {
+          llvm::StringRef NodeLaunchTyStr = NodeLaunchAttr->getLaunchType();
+          hlsl::DXIL::NodeLaunchType NodeLaunchTy =
+              ShaderModel::NodeLaunchTypeFromName(NodeLaunchTyStr);
+          Visitor.getSema()->DiagnoseSVForLaunchType(FD, NodeLaunchTy);
+        }
+      }
     }
   }
 }

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_broadcasting.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_broadcasting.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_8 %s -verify
+
+// expected-no-diagnostics
+[shader("node")]
+[NodeDispatchGrid(1,1,1)]
+[NodeLaunch("broadcasting")]
+[numthreads(1,1,1)]
+void entry2( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_coalescing.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_coalescing.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_8 %s -verify
+
+// expected-error@+5{{Invalid system value semantic 'SV_DispatchThreadID' for launchtype 'Coalescing'}}
+// expected-error@+4{{Invalid system value semantic 'SV_GroupID' for launchtype 'Coalescing'}}
+[shader("node")]
+[NodeLaunch("coalescing")]
+[numthreads(1,1,1)]
+void entry3( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_thread.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/launch_type_thread.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T lib_6_8 %s -verify
+
+// expected-error@+7{{Invalid system value semantic 'SV_DispatchThreadID' for launchtype 'Thread'}}
+// expected-error@+6{{Invalid system value semantic 'SV_GroupID' for launchtype 'Thread'}}
+// expected-error@+5{{Invalid system value semantic 'SV_GroupThreadID' for launchtype 'Thread'}}
+// expected-error@+4{{Invalid system value semantic 'SV_GroupIndex' for launchtype 'Thread'}}
+[shader("node")]
+[NodeLaunch("thread")]
+[numthreads(1,1,1)]
+void entry( uint2 tid : SV_DispatchThreadID, uint2 gid : SV_GroupID, uint2 gtid : SV_GroupThreadID, uint gidx : SV_GroupIndex )
+{
+}

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/work-graphs.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/work-graphs.hlsl
@@ -178,6 +178,7 @@ struct R
 void node01(RWGroupNodeInputRecords<R> input,
  uint gidx: SV_GroupIndex,
   uint3 gtid: SV_GroupThreadID,
- uint vid : SV_VertexID ) // TODO: verify error after https://github.com/microsoft/DirectXShaderCompiler/issues/5768 got fixed.
+ uint vid : SV_VertexID ) // expected-error {{Invalid system value semantic 'SV_VertexID' for launchtype 'Coalescing'}}
+ // TODO: verify error after https://github.com/microsoft/DirectXShaderCompiler/issues/5768 got fixed.
 {
 }


### PR DESCRIPTION
…and node Launch Types.  (#6252)

According to this section of the spec:

https://microsoft.github.io/DirectX-Specs/d3d/WorkGraphs.html#node-shader-system-values There should be diagnostics announcing the unsupported use of certain system value semantics in combination with certain supported launch modes. There were previously no diagnostics for these incompatible combinations.
This PR adds the diagnostics into Sema.
According to issue
https://github.com/microsoft/DirectXShaderCompiler/issues/5827, there is no path for proper flattened signature construction. Parameters won't be fully flattened at the time that Sema runs, so the diagnostics in this PR only trigger on simple parameters with low dimensionality. The team has agreed to leave the full implementation (which can address higher-dimensional parameters) to the implementation of a proper parameter parsing infrastructure, which will take place in the modernization effort.
Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/5827

---------

Co-authored-by: Greg Roth <grroth@microsoft.com>
Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
(cherry picked from commit b1eb33e490630a5bb820a2c73690b0cb1c963371)