### PR TITLE
Warn on ignored attributes on library non-entry points (#6243)

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7697,6 +7697,9 @@ def note_field_type_usage : Note<"usage of %0 found in field %1 of type %2">;
 def warn_hlsl_attribute_expects_uint_literal : Warning<
   "attribute %0 must have a uint literal argument">,
   InGroup<HLSLAttributeType>;
+def warn_hlsl_entry_attribute_without_shader_attribute : Warning<
+  "attribute '%0' ignored without accompanying shader attribute">,
+  InGroup<HLSLAttributeType>;
 def err_hlsl_attribute_expects_float_literal : Error<
   "attribute %0 must have a float literal argument">;
 def warn_hlsl_comma_in_init : Warning<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15672,6 +15672,47 @@ void TryAddShaderAttrFromTargetProfile(Sema &S, FunctionDecl *FD,
   return;
 }
 
+// The compiler should emit a warning when an entry-point-only attribute
+// is detected without the presence of a shader attribute,
+// to prevent reliance on deprecated behavior
+// (where the compiler would infer a specific shader kind based on
+// a present entry-point-only attribute).
+void WarnOnEntryAttrWithoutShaderAttr(Sema &S, FunctionDecl *FD) {
+  if (!FD->hasAttrs())
+    return;
+  for (Attr *A : FD->getAttrs()) {
+    switch (A->getKind()) {
+      // Entry-Function-only attributes
+    case clang::attr::HLSLClipPlanes:
+    case clang::attr::HLSLDomain:
+    case clang::attr::HLSLEarlyDepthStencil:
+    case clang::attr::HLSLInstance:
+    case clang::attr::HLSLMaxTessFactor:
+    case clang::attr::HLSLNumThreads:
+    case clang::attr::HLSLRootSignature:
+    case clang::attr::HLSLOutputControlPoints:
+    case clang::attr::HLSLOutputTopology:
+    case clang::attr::HLSLPartitioning:
+    case clang::attr::HLSLPatchConstantFunc:
+    case clang::attr::HLSLMaxVertexCount:
+    case clang::attr::HLSLWaveSize:
+    case clang::attr::HLSLNodeLaunch:
+    case clang::attr::HLSLNodeIsProgramEntry:
+    case clang::attr::HLSLNodeId:
+    case clang::attr::HLSLNodeLocalRootArgumentsTableIndex:
+    case clang::attr::HLSLNodeShareInputOf:
+    case clang::attr::HLSLNodeDispatchGrid:
+    case clang::attr::HLSLNodeMaxDispatchGrid:
+    case clang::attr::HLSLNodeMaxRecursionDepth:
+      S.Diag(A->getLocation(),
+             diag::warn_hlsl_entry_attribute_without_shader_attribute)
+          << A->getSpelling();
+      break;
+    }
+  }
+  return;
+}
+
 // The DiagnoseEntry function does 2 things:
 // 1. Determine whether this function is the current entry point for a
 // non-library compilation, add an implicit shader attribute if so.
@@ -15692,13 +15733,15 @@ void DiagnoseEntry(Sema &S, FunctionDecl *FD) {
     TryAddShaderAttrFromTargetProfile(S, FD, isActiveEntry);
   }
 
-  HLSLShaderAttr *Attr = FD->getAttr<HLSLShaderAttr>();
-  if (!Attr) {
+  HLSLShaderAttr *shaderAttr = FD->getAttr<HLSLShaderAttr>();
+  if (!shaderAttr) {
+    WarnOnEntryAttrWithoutShaderAttr(S, FD);
     return;
   }
 
-  DXIL::ShaderKind Stage = ShaderModel::KindFromFullName(Attr->getStage());
-  llvm::StringRef StageName = Attr->getStage();
+  DXIL::ShaderKind Stage =
+      ShaderModel::KindFromFullName(shaderAttr->getStage());
+  llvm::StringRef StageName = shaderAttr->getStage();
   DiagnoseEntryAttrAllowedOnStage(&S, FD, Stage);
 
   switch (Stage) {

--- a/tools/clang/test/SemaHLSL/IgnoredAttributes.hlsl
+++ b/tools/clang/test/SemaHLSL/IgnoredAttributes.hlsl
@@ -1,0 +1,117 @@
+// RUN: %dxc -T lib_6_8 -verify %s
+// test that clipplanes emits an error when no shader attribute is present,
+// to warn the user that the deprecated behavior of inferring the shader kind
+// is no longer taking place.
+
+cbuffer ClipPlaneConstantBuffer 
+{
+       float4 clipPlane1;
+       float4 clipPlane2;
+};
+
+struct OutputType{
+	float4 f4 : SV_Position;
+};
+
+
+[clipplanes(clipPlane1,clipPlane2)] /* expected-warning{{attribute 'clipplanes' ignored without accompanying shader attribute}} */
+OutputType clipplanesmain()
+{
+	float4 outputData = clipPlane1 + clipPlane2;
+	OutputType output = {outputData};
+	return output;
+}
+
+struct PSSceneIn {
+  float4 pos : SV_Position;
+  float2 tex : TEXCOORD0;
+  float3 norm : NORMAL;
+
+uint   RTIndex      : SV_RenderTargetArrayIndex;
+};
+
+struct HSPerVertexData {
+  // This is just the original vertex verbatim. In many real life cases this would be a
+  // control point instead
+  PSSceneIn v;
+};
+
+struct HSPerPatchData {
+  // We at least have to specify tess factors per patch
+  // As we're tesselating triangles, there will be 4 tess factors
+  // In real life case this might contain face normal, for example
+  float edges[3] : SV_TessFactor;
+  float inside : SV_InsideTessFactor;
+};
+
+HSPerPatchData PatchFoo( const InputPatch< PSSceneIn, 3 > points, OutputPatch<HSPerVertexData, 3> outp)
+{
+    HSPerPatchData d;
+
+    d.edges[ 0 ] = 1;
+    d.edges[ 1 ] = 1;
+    d.edges[ 2 ] = 1;
+    d.inside = 1;
+
+    return d;
+}
+
+[domain("quad")] /* expected-warning{{attribute 'domain' ignored without accompanying shader attribute}} */
+[partitioning("integer")] /* expected-warning{{attribute 'partitioning' ignored without accompanying shader attribute}} */
+[outputtopology("triangle_cw")] /* expected-warning{{attribute 'outputtopology' ignored without accompanying shader attribute}} */
+[outputcontrolpoints(16)] /* expected-warning{{attribute 'outputcontrolpoints' ignored without accompanying shader attribute}} */
+[patchconstantfunc("PatchFoo")] /* expected-warning{{attribute 'patchconstantfunc' ignored without accompanying shader attribute}} */
+void HSMain( 
+              uint i : SV_OutputControlPointID,
+              uint PatchID : SV_PrimitiveID )
+{
+    
+}
+
+[earlydepthstencil] /* expected-warning{{attribute 'earlydepthstencil' ignored without accompanying shader attribute}} */
+float4 EDSmain() : SV_Target0 {
+	float4 x = {2.0,2.0,2.0,2.0};;
+    	return x;
+}
+
+[instance(1)] /* expected-warning{{attribute 'instance' ignored without accompanying shader attribute}} */ 
+int instance_fn() { return 1; } 
+
+[maxtessfactor(1)] /* expected-warning{{attribute 'maxtessfactor' ignored without accompanying shader attribute}} */ 
+int maxtessfactor_fn() { return 1; }
+
+[numthreads(4,4,4)] /* expected-warning{{attribute 'numthreads' ignored without accompanying shader attribute}} */ 
+int numthreads_fn() { return 1; }   
+
+[RootSignature("RootFlags(CBV_SRV_UAV_HEAP_DIRECTLY_INDEXED)")] /* expected-warning{{attribute 'RootSignature' ignored without accompanying shader attribute}} */ 
+void rootsig_fn(){}
+
+[maxvertexcount(12)] /* expected-warning{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */ 
+void maxvertexcount_fn(){}
+
+[wavesize(4,32,16)] /* expected-warning{{attribute 'wavesize' ignored without accompanying shader attribute}} */ 
+void wavesize_fn(){}
+
+[nodelaunch("thread")] /* expected-warning{{attribute 'nodelaunch' ignored without accompanying shader attribute}} */ 
+void nodelaunch_fn(){}
+
+[nodeisprogramentry] /* expected-warning{{attribute 'nodeisprogramentry' ignored without accompanying shader attribute}} */ 
+void nodeisprogramentry_fn(){}
+
+[nodeid("launch")] /* expected-warning{{attribute 'nodeid' ignored without accompanying shader attribute}} */ 
+void nodeid_fn(){}
+
+[NodeLocalRootArgumentsTableIndex(2)] /* expected-warning{{attribute 'nodelocalrootargumentstableindex' ignored without accompanying shader attribute}} */ 
+void NodeLocalRootArgumentsTableIndex_fn(){}
+
+[NodeShareInputOf("launch")] /* expected-warning{{attribute 'nodeshareinputof' ignored without accompanying shader attribute}} */ 
+void NodeShareInputOf_fn(){}
+
+[NodeDispatchGrid(1,2,3)] /* expected-warning{{attribute 'nodedispatchgrid' ignored without accompanying shader attribute}} */ 
+void NodeDispatchGrid_fn(){}
+
+[NodeMaxDispatchGrid(1,2,3)] /* expected-warning{{attribute 'nodemaxdispatchgrid' ignored without accompanying shader attribute}} */ 
+void NodeMaxDispatchGrid_fn(){}
+
+[NodeMaxRecursionDepth(12)] /* expected-warning{{attribute 'nodemaxrecursiondepth' ignored without accompanying shader attribute}} */ 
+void NodeMaxRecursionDepth_fn(){}

--- a/tools/clang/test/SemaHLSL/attributes.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes.hlsl
@@ -352,9 +352,12 @@ int uav() {
 
 [domain] int domain_fn_missing() { return 1; }          // expected-error {{'domain' attribute takes one argument}} fxc-pass {{}}
 [domain()] int domain_fn_empty() { return 1; }          // expected-error {{'domain' attribute takes one argument}} fxc-error {{X3000: syntax error: unexpected token ')'}}
-[domain("blerch")] int domain_fn_bad() { return 1; }    // expected-error {{attribute 'domain' must have one of these values: tri,quad,isoline}} fxc-pass {{}}
-[domain("quad")] int domain_fn() { return 1; }          /* fxc-warning {{X3554: unknown attribute domain, or attribute invalid for this statement}} */
-[domain(1)] int domain_fn_int() { return 1; }           // expected-error {{attribute 'domain' must have a string literal argument}} fxc-pass {{}}
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
+[domain("blerch")]  int domain_fn_bad() { return 1; }    // expected-error {{attribute 'domain' must have one of these values: tri,quad,isoline}} fxc-pass {{}} 
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
+[domain("quad")]  int domain_fn() { return 1; }          /* fxc-warning {{X3554: unknown attribute domain, or attribute invalid for this statement}} */
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
+[domain(1)]  int domain_fn_int() { return 1; }           // expected-error {{attribute 'domain' must have a string literal argument}} fxc-pass {{}}
 [domain("quad","quad")] int domain_fn_mul() { return 1; } // expected-error {{'domain' attribute takes one argument}} fxc-pass {{}}
 [instance] int instance_fn() { return 1; }             // expected-error {{'instance' attribute takes one argument}} fxc-warning {{X3554: unknown attribute instance, or attribute invalid for this statement}}
 [maxtessfactor] int maxtessfactor_fn() { return 1; }   // expected-error {{'maxtessfactor' attribute takes one argument}} fxc-warning {{X3554: unknown attribute maxtessfactor, or attribute invalid for this statement}}
@@ -364,7 +367,8 @@ int uav() {
 [partitioning] int partitioning_fn() { return 1; }     // expected-error {{'partitioning' attribute takes one argument}} fxc-warning {{X3554: unknown attribute partitioning, or attribute invalid for this statement}}
 [patchconstantfunc] int patchconstantfunc_fn() { return 1; } // expected-error {{'patchconstantfunc' attribute takes one argument}} fxc-warning {{X3554: unknown attribute patchconstantfunc, or attribute invalid for this statement}}
 
-[partitioning("fractional_even")] int partitioning_fn_ok() { return 1; }
+/* expected-warning@+1{{attribute 'partitioning' ignored without accompanying shader attribute}} */
+[partitioning("fractional_even")]  int partitioning_fn_ok() { return 1; }
 
 struct HSFoo
 {
@@ -377,21 +381,32 @@ Texture2D<float4> tex1[10] : register( t20, space10 );
   `-RegisterAssignment <col:30> register(t20, space10)
 */
 
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
 [domain(123)]     // expected-error {{attribute 'domain' must have a string literal argument}} fxc-pass {{}}
 [partitioning()]  // expected-error {{'partitioning' attribute takes one argument}} fxc-error {{X3000: syntax error: unexpected token ')'}}
+/* expected-warning@+1{{attribute 'outputtopology' ignored without accompanying shader attribute}} */
 [outputtopology("not_triangle_cw")] // expected-error {{attribute 'outputtopology' must have one of these values: point,line,triangle,triangle_cw,triangle_ccw}} fxc-pass {{}}
+/* expected-warning@+1{{attribute 'outputcontrolpoints' ignored without accompanying shader attribute}} */
 [outputcontrolpoints(-1)] // expected-warning {{attribute 'outputcontrolpoints' must have a uint literal argument}} fxc-pass {{}}
 [patchconstantfunc("PatchFoo", "ExtraArgument")] // expected-error {{'patchconstantfunc' attribute takes one argument}} fxc-pass {{}}
+
 void all_wrong() { }
 
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
 [domain("quad")]
 /*verify-ast
   HLSLDomainAttr <col:2, col:15> "quad"
 */
+
+/* expected-warning@+1{{attribute 'partitioning' ignored without accompanying shader attribute}} */
 [partitioning("integer")]
+/* expected-warning@+1{{attribute 'outputtopology' ignored without accompanying shader attribute}} */
 [outputtopology("triangle_cw")]
+/* expected-warning@+1{{attribute 'outputcontrolpoints' ignored without accompanying shader attribute}} */
 [outputcontrolpoints(16)]
+/* expected-warning@+1{{attribute 'patchconstantfunc' ignored without accompanying shader attribute}} */
 [patchconstantfunc("PatchFoo")]
+
 HSFoo HSMain( InputPatch<HSFoo, 16> p,
 /*verify-ast
   FunctionDecl <col:1, line:468:1> line:394:7 HSMain 'HSFoo (InputPatch<HSFoo, 16>, uint, uint)'
@@ -623,7 +638,9 @@ float4 clipplanes_good_parens();
 // place the errors in comments before the function, but not with the standard
 // fxc error comments on the line.
 struct GSVertex { float4 pos : SV_Position; };
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (12)]
+
 /*verify-ast
   HLSLMaxVertexCountAttr <col:2, col:20> 12
 */
@@ -631,14 +648,17 @@ void maxvertexcount_valid1(triangle GSVertex v[3], inout TriangleStream<GSVertex
 { stream.Append(v[0]); }
 
 static const int sc_count = 12;
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (sc_count)]
+
 /*verify-ast
   HLSLMaxVertexCountAttr <col:2, col:26> 12
 */
 void maxvertexcount_valid2(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
-
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (sc_count + 3)]
+
 /*verify-ast
   HLSLMaxVertexCountAttr <col:2, col:30> 15
 */
@@ -648,7 +668,9 @@ void maxvertexcount_valid3(triangle GSVertex v[3], inout TriangleStream<GSVertex
 static const int4 sc_count4 = int4(3,6,9,12);
 
 // The following passes fxc, but fails clang.
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (sc_count4.w)]          /* expected-error {{'maxvertexcount' attribute requires an integer constant}} fxc-pass {{}} */
+
 /*verify-ast
   HLSLMaxVertexCountAttr <col:2, col:29> 0
 */
@@ -657,7 +679,9 @@ void maxvertexcount_valid4(triangle GSVertex v[3], inout TriangleStream<GSVertex
 
 // fxc:
 // error X3084: cannot match attribute maxvertexcount, non-uint parameters found
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (-12)]                  /* expected-warning {{attribute 'maxvertexcount' must have a uint literal argument}} fxc-pass {{}} */
+
 void negative_maxvertexcount(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
 
@@ -665,7 +689,9 @@ void negative_maxvertexcount(triangle GSVertex v[3], inout TriangleStream<GSVert
 // warning X3554: cannot match attribute maxvertexcount, parameter 1 is expected to be of type int
 // warning X3554: unknown attribute maxvertexcount, or attribute invalid for this statement, valid attributes are: maxvertexcount, MaxVertexCount, instance, RootSignature
 // error X3514: 'float_maxvertexcount1' must have a max vertex count
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (1.5)]                  /* expected-warning {{attribute 'maxvertexcount' must have a uint literal argument}} fxc-pass {{}} */
+
 void float_maxvertexcount1(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
 
@@ -674,7 +700,9 @@ void float_maxvertexcount1(triangle GSVertex v[3], inout TriangleStream<GSVertex
 // warning X3554: unknown attribute maxvertexcount, or attribute invalid for this statement, valid attributes are: maxvertexcount, MaxVertexCount, instance, RootSignature
 // error X3514: 'float_maxvertexcount2' must have a max vertex count
 static const float sc_float = 1.5;
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (sc_float)]             /* expected-error {{'maxvertexcount' attribute requires an integer constant}} fxc-pass {{}} */
+
 void float_maxvertexcount2(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
 
@@ -684,7 +712,9 @@ float f_count;
 // fxc:
 // error X3084: non-literal parameter(s) found for attribute maxvertexcount
 // error X3514: 'uniform_maxvertexcount1' must have a max vertex count
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (i_count)]              /* expected-error {{'maxvertexcount' attribute requires an integer constant}} fxc-pass {{}} */
+
 void uniform_maxvertexcount1(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
 
@@ -692,7 +722,9 @@ void uniform_maxvertexcount1(triangle GSVertex v[3], inout TriangleStream<GSVert
 // warning X3554: cannot match attribute maxvertexcount, parameter 1 is expected to be of type int
 // warning X3554: unknown attribute maxvertexcount, or attribute invalid for this statement, valid attributes are: maxvertexcount, MaxVertexCount, instance, RootSignature
 // error X3514: 'uniform_maxvertexcount2' must have a max vertex count
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [maxvertexcount (f_count)]              /* expected-error {{'maxvertexcount' attribute requires an integer constant}} fxc-pass {{}} */
+
 void uniform_maxvertexcount2(triangle GSVertex v[3], inout TriangleStream<GSVertex> stream)
 { stream.Append(v[0]); }
 
@@ -823,7 +855,9 @@ bool Test_Call() {
 }
 
 // Test EarlyDepthStencil
+/* expected-warning@+1{{attribute 'earlydepthstencil' ignored without accompanying shader attribute}} */
 [EarlyDepthStencil]
+
 bool Test_EarlyDepthStencil() {
   return true;
 }
@@ -854,67 +888,90 @@ bool Test_Loop() {
 
 // Test ClipPlanes
 float4 ClipPlanesVal;
+/* expected-warning@+1{{attribute 'clipplanes' ignored without accompanying shader attribute}} */
 [ClipPlanes(ClipPlanesVal)]
+
 bool Test_ClipPlanes() {
   return true;
 }
 
 // Test Domain
+/* expected-warning@+1{{attribute 'domain' ignored without accompanying shader attribute}} */
 [Domain("tri")]
+
 bool Test_Domain() {
   return true;
 }
 
 // Test Instance
+/* expected-warning@+1{{attribute 'instance' ignored without accompanying shader attribute}} */
 [Instance(1)]
+
 bool Test_Instance() {
   return true;
 }
 
 // Test MaxTessFactor
+/* expected-warning@+1{{attribute 'maxtessfactor' ignored without accompanying shader attribute}} */
 [MaxTessFactor(1)]
+
 bool Test_MaxTessFactor() {
   return true;
 }
 
 // Test MaxVertexCount
+/* expected-warning@+1{{attribute 'maxvertexcount' ignored without accompanying shader attribute}} */
 [MaxVertexCount(1)]
+
 bool Test_MaxVertexCount() {
   return true;
 }
 
 // Test NumThreads
+/* expected-warning@+1{{attribute 'numthreads' ignored without accompanying shader attribute}} */
 [NumThreads(1,2,3)]
+
 bool Test_NumThreads() {
   return true;
 }
 
 // Test OutputControlPoints
+/* expected-warning@+1{{attribute 'outputcontrolpoints' ignored without accompanying shader attribute}} */
 [OutputControlPoints(2)]
+
 bool Test_OutputControlPoints() {
   return true;
 }
 
 // Test OutputTopology
+/* expected-warning@+1{{attribute 'outputtopology' ignored without accompanying shader attribute}} */
 [OutputTopology("line")]
+
 bool Test_OutputTopology() {
   return true;
 }
 
 // Test Partitioning
+/* expected-warning@+1{{attribute 'partitioning' ignored without accompanying shader attribute}} */
 [Partitioning("integer")]
+
 bool Test_Partitioning() {
   return true;
 }
 
 // Test PatchConstantFunc
+/* expected-warning@+1{{attribute 'patchconstantfunc' ignored without accompanying shader attribute}} */
 [PatchConstantFunc("Test_Partitioning")]
+
 bool Test_PatchConstantFunc() {
   return true;
 }
 
 // Test RootSignature
+// strange how RootSignature is the only attribute that is spelled with capitals.
+/* expected-warning@+1{{attribute 'RootSignature' ignored without accompanying shader attribute}} */
 [RootSignature("")]
+
 bool Test_RootSignature() {
   return true;
 }

--- a/tools/clang/test/SemaHLSL/attributes/wavesize_66.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/wavesize_66.hlsl
@@ -7,7 +7,7 @@ void main() {
 }
 
 
-[wavesize(4, 8)] // No diagnostic expected for inactive entry
-[numthreads(1,1,8)]
+[wavesize(4, 8)] /* expected-warning{{attribute 'wavesize' ignored without accompanying shader attribute}} */
+[numthreads(1,1,8)] /* expected-warning{{attribute 'numthreads' ignored without accompanying shader attribute}} */
 void inactive() {
 }

--- a/tools/clang/test/SemaHLSL/overloading-unsupported-operators.hlsl
+++ b/tools/clang/test/SemaHLSL/overloading-unsupported-operators.hlsl
@@ -25,6 +25,3 @@ struct S
     void operator++(S s) {} // expected-error {{overloading 'operator++' is not allowed}}
     void operator--(S s) {} // expected-error {{overloading 'operator--' is not allowed}}
 };
-
-[numthreads(1,1,1)]
-void main() {}

--- a/tools/clang/unittests/HLSL/DXIsenseTest.cpp
+++ b/tools/clang/unittests/HLSL/DXIsenseTest.cpp
@@ -458,6 +458,7 @@ TEST_F(DXIntellisenseTest, TUWhenUnsaveFileThenOK) {
   // works.
   const char fileName[] = "filename.hlsl";
   char program[] = "[numthreads(1, 1, 1)]\r\n"
+                   "[shader(\"compute\")]\r\n"
                    "void main( uint3 DTid : SV_DispatchThreadID )\r\n"
                    "{\r\n"
                    "}";
@@ -516,7 +517,7 @@ TEST_F(DXIntellisenseTest, TUWhenUnsaveFileThenOK) {
     }
     // Format for a location is line:col@offset
     VERIFY_ARE_EQUAL_WSTR(
-        L"main(uint3) - spelling 2:6@28 - extent 2:1@23 .. 4:2@74\n",
+        L"main(uint3) - spelling 3:6@49 - extent 3:1@44 .. 5:2@95\n",
         offsetStream.str().c_str());
   }
 }


### PR DESCRIPTION
For every attribute that is only meaningful on an entry-point, produce a warning indicating that this could be a problem.
The attributes are ignored, so it's harmless, but it still might indicate a mistake on the part of the user.
Previously, some of these would cause the function to be implicitly made a certain kind of entry point.
These warnings will soften the impact of that change.

Fixes #6100

---------

Co-authored-by: Joshua Batista <jbatista@microsoft.com>
Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
(cherry picked from commit 53b2930a1b3ad79cbc060d5db451906a30c2691b)