### PR TITLE
[Sema] Add final touches to wave size range implementation (#6202)

### DIFF
--- a/docs/DXIL.rst
+++ b/docs/DXIL.rst
@@ -3263,12 +3263,16 @@ SM.UNDEFINEDOUTPUT                        Not all elements of output %0 were wri
 SM.VALIDDOMAIN                            Invalid Tessellator Domain specified. Must be isoline, tri or quad.
 SM.VIEWIDNEEDSSLOT                        ViewID requires compatible space in pixel shader input signature
 SM.WAVESIZEALLZEROWHENUNDEFINED           WaveSize Max and Preferred must be 0 when Min is 0
+SM.WAVESIZEEXPECTSONEPARAM                WaveSize tag expects exactly 1 parameter.
 SM.WAVESIZEMAXANDPREFERREDZEROWHENNORANGE WaveSize Max and Preferred must be 0 to encode min==max
 SM.WAVESIZEMAXGREATERTHANMIN              WaveSize Max must greater than Min
-SM.WAVESIZENEEDSDXIL16PLUS                WaveSize is valid only for DXIL version 1.6 and higher.
+SM.WAVESIZENEEDSCONSTANTOPERANDS          WaveSize metadata operands must be constant values.
+SM.WAVESIZENEEDSSM66OR67                  WaveSize is valid only for Shader Model 6.6 and 6.7.
 SM.WAVESIZEONCOMPUTEORNODE                WaveSize only allowed on compute or node shaders
 SM.WAVESIZEPREFERREDINRANGE               WaveSize Preferred must be within Min..Max range
-SM.WAVESIZERANGENEEDSDXIL18PLUS           WaveSize Range is valid only for DXIL version 1.8 and higher.
+SM.WAVESIZERANGEEXPECTSTHREEPARAMS        WaveSize Range tag expects exactly 3 parameters.
+SM.WAVESIZERANGENEEDSSM68PLUS             WaveSize Range is valid only for Shader Model 6.8 and higher.
+SM.WAVESIZETAGDUPLICATE                   WaveSize or WaveSizeRange tag may only appear once per entry point.
 SM.WAVESIZEVALUE                          WaveSize value must be a power of 2 in range [4..128]
 SM.ZEROHSINPUTCONTROLPOINTWITHINPUT       When HS input control point count is 0, no input signature should exist.
 TYPES.DEFINED                             Type must be defined based on DXIL primitives

--- a/include/dxc/DXIL/DxilFunctionProps.h
+++ b/include/dxc/DXIL/DxilFunctionProps.h
@@ -73,11 +73,15 @@ struct DxilWaveSize {
     MaxEqualsMin,
     MaxLessThanMin,
     PreferredOutOfRange,
+    NoRangeOrMin,
   };
   ValidationResult Validate() const {
     if (Min == 0) { // Not defined
       if (Max != 0 || Preferred != 0)
         return ValidationResult::MaxOrPreferredWhenUndefined;
+      else
+        // all 3 parameters are 0
+        return ValidationResult::NoRangeOrMin;
     } else if (!IsValidValue(Min)) {
       return ValidationResult::InvalidMin;
     } else if (Max == 0) { // single WaveSize (SM 6.6/6.7)

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7486,6 +7486,9 @@ def err_hlsl_wavesize_size: Error<
   "WaveSize arguments must be between 4 and 128 and a power of 2">;
 def err_hlsl_wavesize_min_geq_max: Error<
   "Minimum WaveSize value %0 must be less than maximum WaveSize value %1">;
+def warn_hlsl_wavesize_min_eq_max:  Warning<
+  "Wave Size Range minimum and maximum are equal">,
+  InGroup<HLSLAttributeStatement>, DefaultError;
 def err_hlsl_wavesize_pref_size_out_of_range: Error<
   "Preferred WaveSize value %0 must be between %1 and %2">;
 def err_hlsl_wavesize_insufficient_shader_model: Error<

--- a/tools/clang/test/CodeGenDXIL/hlsl/wavesize/wavesize-range-not-int.ll
+++ b/tools/clang/test/CodeGenDXIL/hlsl/wavesize/wavesize-range-not-int.ll
@@ -1,0 +1,46 @@
+; XFAIL:*
+; This test is expected to fail because DxilMetadataHelper.cpp assumes that 
+; all parameters in the wavesize tuple will be integers. This is an assumption we need to remove
+; from DxilMetadatahelper.cpp, and the issue is described here:
+; https://github.com/microsoft/DirectXShaderCompiler/issues/6239
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+; CHECK: Function: node01: error: WaveSize parameter is not an integer.
+!10 = !{i32 16, i32 32, float 2.5}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/CodeGenDXIL/hlsl/wavesize/wavesize-range-not-three-params.ll
+++ b/tools/clang/test/CodeGenDXIL/hlsl/wavesize/wavesize-range-not-three-params.ll
@@ -1,0 +1,46 @@
+; XFAIL:*
+; This test is expected to fail because DxilMetadataHelper.cpp assumes exactly
+; three parameters in the wavesize tuple will be given. This is an assumption we need to remove
+; from DxilMetadatahelper.cpp, and the issue is described here:
+; https://github.com/microsoft/DirectXShaderCompiler/issues/6239
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+; CHECK: Function: node01: error: WaveSize Max (16) and Preferred (16) must be 0 to encode min==max
+!10 = !{i32 16, i32 16}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-ast.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-ast.hlsl
@@ -9,20 +9,6 @@
 // RUN: %dxc -T cs_6_8 -DNODE -DRANGE=,64,32 -ast-dump %s | FileCheck %s -check-prefixes=AST,AST2,ASTNODE,ASTNODE2 -DPREF=32
 // RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64,32 -ast-dump %s | FileCheck %s -check-prefixes=AST,AST2,ASTNODE,ASTNODE2 -DPREF=32
 
-// RUN: %dxc -T cs_6_6 -DNODE %s | FileCheck %s -check-prefixes=META,META1
-// RUN: %dxc -T cs_6_8 -DNODE %s | FileCheck %s -check-prefixes=META,META1
-// RUN: %dxc -T lib_6_6 %s | FileCheck %s -check-prefixes=META,META1
-// RUN: %dxc -T lib_6_8 -DNODE %s | FileCheck %s -check-prefixes=META,META1,METANODE,METANODE1
-
-// RUN: %dxc -T cs_6_8 -DNODE -DRANGE=,64 %s | FileCheck %s -check-prefixes=META,META2 -DPREF=0
-// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64 %s | FileCheck %s -check-prefixes=META,META2,METANODE,METANODE2 -DPREF=0
-
-// RUN: %dxc -T cs_6_8 -DNODE -DRANGE=,64,32 %s | FileCheck %s -check-prefixes=META,META2 -DPREF=32
-// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64,32 %s | FileCheck %s -check-prefixes=META,META2,METANODE,METANODE2 -DPREF=32
-
-// RUN: %dxc -T lib_6_8 -DNODE %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT1
-// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64 %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT2
-// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64,32 %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT2
 
 // Notes on RUN variations:
 //  - Tests cs and lib with SM 6.6 and SM 6.8, with limitations for SM 6.6:
@@ -45,33 +31,6 @@
 // ASTNODE1-SAME: 16 0 0
 // ASTNODE2: -HLSLWaveSizeAttr
 // ASTNODE2-SAME: 16 64 [[PREF]]
-
-// META: @main, !"main", null, null, [[PROPS:![0-9]+]]}
-// META1: [[PROPS]] = !{
-// META1-SAME: i32 11, [[WS:![0-9]+]]
-// META2: [[PROPS]] = !{
-// META2-SAME: i32 23, [[WS:![0-9]+]]
-// META1: [[WS]] = !{i32 16}
-// META2: [[WS]] = !{i32 16, i32 64, i32 [[PREF]]}
-
-// METANODE: @node, !"node", null, null, [[PROPS:![0-9]+]]}
-// METANODE1: [[PROPS]] = !{
-// METANODE1-SAME: i32 11, [[WS]]
-// METANODE2: [[PROPS]] = !{
-// METANODE2-SAME: i32 23, [[WS]]
-
-// RDAT has no min/max wave count until SM 6.8
-// RDAT-LABEL: <0:RuntimeDataFunctionInfo{{.}}> = {
-// RDAT: Name: "main"
-// RDAT: MinimumExpectedWaveLaneCount: 16
-// RDAT1: MaximumExpectedWaveLaneCount: 16
-// RDAT2: MaximumExpectedWaveLaneCount: 64
-
-// RDAT-LABEL: <1:RuntimeDataFunctionInfo{{.}}> = {
-// RDAT: Name: "node"
-// RDAT: MinimumExpectedWaveLaneCount: 16
-// RDAT1: MaximumExpectedWaveLaneCount: 16
-// RDAT2: MaximumExpectedWaveLaneCount: 64
 
 #ifndef RANGE
 #define RANGE

--- a/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-dxil.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-dxil.hlsl
@@ -1,0 +1,47 @@
+// RUN: %dxc -T cs_6_6 -DNODE %s | FileCheck %s -check-prefixes=META,SM66
+// RUN: %dxc -T cs_6_8 -DNODE %s | FileCheck %s -check-prefixes=META,SM68
+// RUN: %dxc -T lib_6_6 %s | FileCheck %s -check-prefixes=META,SM66
+// RUN: %dxc -T lib_6_8 -DNODE %s | FileCheck %s -check-prefixes=META,SM68,METANODE,METANODESM68
+
+// RUN: %dxc -T cs_6_8 -DNODE -DRANGE=,64 %s | FileCheck %s -check-prefixes=META,SM68RANGE -DPREF=0
+// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64 %s | FileCheck %s -check-prefixes=META,SM68RANGE,METANODE,METANODESM68 -DPREF=0
+
+// RUN: %dxc -T cs_6_8 -DNODE -DRANGE=,64,32 %s | FileCheck %s -check-prefixes=META,SM68RANGE -DPREF=32
+// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64,32 %s | FileCheck %s -check-prefixes=META,SM68RANGE,METANODE,METANODESM68 -DPREF=32
+
+// META: @main, !"main", null, null, [[PROPS:![0-9]+]]}
+// SM66: [[PROPS]] = !{
+// SM66-SAME: i32 11, [[WS:![0-9]+]]
+// SM68: [[PROPS]] = !{
+// SM68-SAME: i32 23, [[WS:![0-9]+]]
+// SM68RANGE: [[PROPS]] = !{
+// SM68RANGE-SAME: i32 23, [[WS:![0-9]+]]
+// SM66: [[WS]] = !{i32 16}
+// SM68: [[WS]] = !{i32 16, i32 0, i32 0}
+// SM68RANGE: [[WS]] = !{i32 16, i32 64, i32 [[PREF]]}
+
+// METANODE: @node, !"node", null, null, [[PROPS:![0-9]+]]}
+// METANODESM66: [[PROPS]] = !{
+// METANODESM66-SAME: i32 11, [[WS]]
+// METANODESM68: [[PROPS]] = !{
+// METANODESM68-SAME: i32 23, [[WS]]
+
+
+#ifndef RANGE
+#define RANGE
+#endif
+
+[shader("compute")]
+[wavesize(16 RANGE)]
+[numthreads(1,1,8)]
+void main() {
+}
+
+#ifdef NODE
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,8)]
+[NodeDispatchGrid(1,1,1)]
+[WaveSize(16 RANGE)]
+void node() { }
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-rdat.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/entry/attributes/wavesize-compute-node-rdat.hlsl
@@ -1,0 +1,36 @@
+// RUN: %dxc -T lib_6_8 -DNODE %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT1
+// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64 %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT2
+// RUN: %dxc -T lib_6_8 -DNODE -DRANGE=,64,32 %s | %D3DReflect %s | FileCheck %s -check-prefixes=RDAT,RDAT2
+
+
+// RDAT has no min/max wave count until SM 6.8
+// RDAT-LABEL: <0:RuntimeDataFunctionInfo{{.}}> = {
+// RDAT: Name: "main"
+// RDAT: MinimumExpectedWaveLaneCount: 16
+// RDAT1: MaximumExpectedWaveLaneCount: 16
+// RDAT2: MaximumExpectedWaveLaneCount: 64
+
+// RDAT-LABEL: <1:RuntimeDataFunctionInfo{{.}}> = {
+// RDAT: Name: "node"
+// RDAT: MinimumExpectedWaveLaneCount: 16
+// RDAT1: MaximumExpectedWaveLaneCount: 16
+// RDAT2: MaximumExpectedWaveLaneCount: 64
+
+#ifndef RANGE
+#define RANGE
+#endif
+
+[shader("compute")]
+[wavesize(16 RANGE)]
+[numthreads(1,1,8)]
+void main() {
+}
+
+#ifdef NODE
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,8)]
+[NodeDispatchGrid(1,1,1)]
+[WaveSize(16 RANGE)]
+void node() { }
+#endif

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/wavesize.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/wavesize.hlsl
@@ -17,8 +17,8 @@ struct INPUT_RECORD
 void node01(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 
 // CHECK: !{void ()* @node01, !"node01", null, null, [[NODE01:![0-9]+]]}
-// CHECK: [[NODE01]] = !{i32 8, i32 15, i32 13, i32 1, i32 11, [[NODE01_WS:![0-9]+]]
-// CHECK: [[NODE01_WS]] = !{i32 4}
+// CHECK: [[NODE01]] = !{i32 8, i32 15, i32 13, i32 1, i32 23, [[NODE01_WS:![0-9]+]]
+// CHECK: [[NODE01_WS]] = !{i32 4, i32 0, i32 0}
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]
@@ -28,8 +28,8 @@ void node01(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 void node02(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 
 // CHECK: !{void ()* @node02, !"node02", null, null, [[NODE02:![0-9]+]]}
-// CHECK: [[NODE02]] = !{i32 8, i32 15, i32 13, i32 1, i32 11, [[NODE02_WS:![0-9]+]]
-// CHECK: [[NODE02_WS]] = !{i32 8}
+// CHECK: [[NODE02]] = !{i32 8, i32 15, i32 13, i32 1, i32 23, [[NODE02_WS:![0-9]+]]
+// CHECK: [[NODE02_WS]] = !{i32 8, i32 0, i32 0}
 
 [Shader("node")]
 [NodeLaunch("coalescing")]
@@ -38,8 +38,8 @@ void node02(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 void node03(RWGroupNodeInputRecords<INPUT_RECORD> input) { }
 
 // CHECK: !{void ()* @node03, !"node03", null, null, [[NODE03:![0-9]+]]}
-// CHECK: [[NODE03]] = !{i32 8, i32 15, i32 13, i32 2, i32 11, [[NODE03_WS:![0-9]+]]
-// CHECK: [[NODE03_WS]] = !{i32 16}
+// CHECK: [[NODE03]] = !{i32 8, i32 15, i32 13, i32 2, i32 23, [[NODE03_WS:![0-9]+]]
+// CHECK: [[NODE03_WS]] = !{i32 16, i32 0, i32 0}
 
 [Shader("node")]
 [NodeLaunch("thread")]
@@ -47,5 +47,5 @@ void node03(RWGroupNodeInputRecords<INPUT_RECORD> input) { }
 void node04(ThreadNodeInputRecord<INPUT_RECORD> input) { }
 
 // CHECK: !{void ()* @node04, !"node04", null, null, [[NODE04:![0-9]+]]}
-// CHECK: [[NODE04]] = !{i32 8, i32 15, i32 13, i32 3, i32 11, [[NODE04_WS:![0-9]+]]
-// CHECK: [[NODE04_WS]] = !{i32 32}
+// CHECK: [[NODE04]] = !{i32 8, i32 15, i32 13, i32 3, i32 23, [[NODE04_WS:![0-9]+]]
+// CHECK: [[NODE04_WS]] = !{i32 32, i32 0, i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/outdated-metadata-tag.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/outdated-metadata-tag.ll
@@ -1,0 +1,42 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests that the validator fails when it finds the 
+; wavesize metadata tag as opposed to the wavesize range metadata tag,
+; when the shader model version is 6.8
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 11, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+
+; even with a valid wavesize argument, we do not expect this metadata tag (tag i32 11 -> kDxilWaveSizeTag) 
+; in any dxil for validator version 1.8+
+; CHECK: error: WaveSize is valid only for Shader Model 6.6 and 6.7.
+!10 = !{i32 16}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/too-modern-metadata-tag.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/too-modern-metadata-tag.ll
@@ -1,0 +1,42 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests that the validator fails when it finds the 
+; wavesize range metadata tag as opposed to the wavesize metadata tag,
+; when the shader model version is less than 6.8
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 6}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+
+; even with a valid wavesize range tag, we do not expect this metadata tag (tag i32 23 -> kDxilRangedWaveSizeTag) 
+; in any dxil for shader models less than 6.8
+; CHECK: error: Metadata error encountered in non-critical metadata (such as Type Annotations).
+!10 = !{i32 16, i32 64, i32 32}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-invalid-preferred-value.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-invalid-preferred-value.ll
@@ -1,0 +1,41 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+; CHECK: Function: node01: error: WaveSize Preferred (3) outside valid range [4..128], or not a power of 2.
+!10 = !{i32 4, i32 16, i32 3}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-invalid-range-value.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-invalid-range-value.ll
@@ -29,8 +29,8 @@ define void @node01() {
 !7 = !{null, !"", null, null, null}
 !8 = !{void ()* @node01, !"node01", null, null, !9}
 !9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
-; CHECK: Function: node01: error: WaveSize Max (16) and Preferred (16) must be 0 to encode min==max
-!10 = !{i32 16, i32 16, i32 16}
+; CHECK: Function: node01: error: WaveSize Min (1) outside valid range [4..128], or not a power of 2.
+!10 = !{i32 1, i32 16, i32 16}
 !11 = !{!"node01", i32 0}
 !12 = !{i32 32, i32 1, i32 1}
 !13 = !{!14}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-multiple-legacy-tags.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-multiple-legacy-tags.ll
@@ -1,0 +1,40 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 6}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{void ()* @node01, !"node01", null, null, !8}
+!8 = !{i32 8, i32 15, i32 13, i32 1, i32 11, !9, i32 11, !9, i32 15, !10, i32 16, i32 -1, i32 22, !11, i32 20, !12, i32 4, !16, i32 5, !17}
+; CHECK: error: WaveSize or WaveSizeRange tag may only appear once per entry point.
+!9 = !{i32 4}
+!10 = !{!"node01", i32 0}
+!11 = !{i32 32, i32 1, i32 1}
+!12 = !{!13}
+!13 = !{i32 1, i32 97, i32 2, !14}
+!14 = !{i32 0, i32 12, i32 1, !15}
+!15 = !{i32 0, i32 5, i32 1}
+!16 = !{i32 1, i32 1, i32 1}
+!17 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-multiple-range-tags.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-multiple-range-tags.ll
@@ -1,0 +1,40 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{void ()* @node01, !"node01", null, null, !8}
+!8 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !9, i32 23, !9, i32 15, !10, i32 16, i32 -1, i32 22, !11, i32 20, !12, i32 4, !16, i32 5, !17}
+; CHECK: error: WaveSize or WaveSizeRange tag may only appear once per entry point.
+!9 = !{i32 4, i32 16, i32 8}
+!10 = !{!"node01", i32 0}
+!11 = !{i32 32, i32 1, i32 1}
+!12 = !{!13}
+!13 = !{i32 1, i32 97, i32 2, !14}
+!14 = !{i32 0, i32 12, i32 1, !15}
+!15 = !{i32 0, i32 5, i32 1}
+!16 = !{i32 1, i32 1, i32 1}
+!17 = !{i32 0}

--- a/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-valid-preferred-value-out-of-range.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/wavesize/wavesize-range-valid-preferred-value-out-of-range.ll
@@ -1,0 +1,41 @@
+; RUN: %dxilver 1.8 | %dxv %s | FileCheck %s
+
+; This tests the validator on emitting errors for invalid
+; arguments in the wavesize range attribute for entry point functions.
+; This test tests that when the Minimum wavesize value is equal to the Maximum
+; wavesize value, a diagnostic is emitted.
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+define void @node01() {
+  ret void
+}
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.typeAnnotations = !{!3}
+!dx.entryPoints = !{!7, !8}
+
+!0 = !{!"dxc(private) 1.7.0.4390 (dxil_validation_on_sv_value_node_launch, 6a52940e2258)"}
+!1 = !{i32 1, i32 8}
+!2 = !{!"lib", i32 6, i32 8}
+!3 = !{i32 1, void ()* @node01, !4}
+!4 = !{!5}
+!5 = !{i32 0, !6, !6}
+!6 = !{}
+!7 = !{null, !"", null, null, null}
+!8 = !{void ()* @node01, !"node01", null, null, !9}
+!9 = !{i32 8, i32 15, i32 13, i32 1, i32 23, !10, i32 15, !11, i32 16, i32 -1, i32 22, !12, i32 20, !13, i32 4, !17, i32 5, !18}
+; CHECK: Function: node01: error: WaveSize Preferred (32) outside Min..Max range [4..16]
+!10 = !{i32 4, i32 16, i32 32}
+!11 = !{!"node01", i32 0}
+!12 = !{i32 32, i32 1, i32 1}
+!13 = !{!14}
+!14 = !{i32 1, i32 97, i32 2, !15}
+!15 = !{i32 0, i32 12, i32 1, !16}
+!16 = !{i32 0, i32 5, i32 1}
+!17 = !{i32 1, i32 1, i32 1}
+!18 = !{i32 0}

--- a/tools/clang/test/SemaHLSL/attributes/wavesize_range.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/wavesize_range.hlsl
@@ -22,15 +22,14 @@ void node01(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 [NodeLaunch("broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(32,1,1)]
-/* expected-error@+1{{Minimum WaveSize value 16 must be less than maximum WaveSize value 16}} */
-[WaveSize(16, 16, 32)]
+[WaveSize(16, 16, 32)] /* expected-error{{Wave Size Range minimum and maximum are equal}} */
 void node02(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(32,1,1)]
-[WaveSize(16, 16, 16)] /* expected-error{{Minimum WaveSize value 16 must be less than maximum WaveSize value 16}} */
+[WaveSize(16, 16, 16)] /* expected-error{{Wave Size Range minimum and maximum are equal}} */
 void node03(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 
 // the non-power of 2 diagnostic gets emitted once, regardless of how many arguments aren't powers of 2.
@@ -113,6 +112,107 @@ void node10(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 void node11(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 
 
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+// no expected failure here
+[WaveSize(4, 8, 8)]
+[WaveSize(4, 8, 8)]
+void node12(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{Wave Size Range minimum and maximum are equal}} */
+[WaveSize(4, 4, 4)]
+void node13(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+[WaveSize(0, 0, 0)]
+void node14(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+2{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+/* expected-warning@+1{{attribute 'WaveSize' must have a uint literal argument}} */
+[WaveSize(-2, 16, 8)]
+void node15(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+2{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+/* expected-warning@+1{{attribute 'WaveSize' must have a uint literal argument}} */
+[WaveSize(2, 16, 3.5)]
+void node16(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+// no errors expected
+[WaveSize(4, 16, 3+5)]
+void node17(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+[WaveSize(2, 16, 8)]
+void node18(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+[WaveSize(4, 512, 8)]
+void node19(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{WaveSize arguments must be between 4 and 128 and a power of 2}} */
+[WaveSize(4, 58, 128)]
+void node20(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{'WaveSize' attribute takes at least 1 argument}} */
+[WaveSize]
+void node21(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+1{{'WaveSize' attribute takes no more than 3 arguments}} */
+[WaveSize(32, 32, 32, 32)]
+void node22(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]
@@ -122,4 +222,26 @@ void node11(DispatchNodeInputRecord<INPUT_RECORD> input) { }
 /* expected-note@+2{{conflicting attribute is here}} */
 [WaveSize(4, 8, 4)]
 [WaveSize(4)]
-void node12(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+void node23(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+2{{shader attribute type 'wavesize' conflicts with shader attribute type 'wavesize'}} */
+/* expected-note@+2{{conflicting attribute is here}} */
+[WaveSize(32, 64, 32)]
+[WaveSize(32, 64)]
+void node24(DispatchNodeInputRecord<INPUT_RECORD> input) { }
+
+
+[Shader("node")]
+[NodeLaunch("broadcasting")]
+[NumThreads(1,1,1)]
+[NodeMaxDispatchGrid(32,1,1)]
+/* expected-error@+2{{shader attribute type 'wavesize' conflicts with shader attribute type 'wavesize'}} */
+/* expected-note@+2{{conflicting attribute is here}} */
+[WaveSize(32, 64)]
+[WaveSize(32)]
+void node25(DispatchNodeInputRecord<INPUT_RECORD> input) { }

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -7691,12 +7691,28 @@ class db_dxil(object):
             "WaveSize only allowed on compute or node shaders",
         )
         self.add_valrule(
-            "Sm.WaveSizeNeedsDxil16Plus",
-            "WaveSize is valid only for DXIL version 1.6 and higher.",
+            "Sm.WaveSizeNeedsSM66or67",
+            "WaveSize is valid only for Shader Model 6.6 and 6.7.",
         )
         self.add_valrule(
-            "Sm.WaveSizeRangeNeedsDxil18Plus",
-            "WaveSize Range is valid only for DXIL version 1.8 and higher.",
+            "Sm.WaveSizeRangeNeedsSM68Plus",
+            "WaveSize Range is valid only for Shader Model 6.8 and higher.",
+        )
+        self.add_valrule(
+            "Sm.WaveSizeRangeExpectsThreeParams",
+            "WaveSize Range tag expects exactly 3 parameters.",
+        )
+        self.add_valrule(
+            "Sm.WaveSizeExpectsOneParam",
+            "WaveSize tag expects exactly 1 parameter.",
+        )
+        self.add_valrule(
+            "Sm.WaveSizeTagDuplicate",
+            "WaveSize or WaveSizeRange tag may only appear once per entry point.",
+        )
+        self.add_valrule(
+            "Sm.WaveSizeNeedsConstantOperands",
+            "WaveSize metadata operands must be constant values.",
         )
         self.add_valrule(
             "Sm.ROVOnlyInPS",


### PR DESCRIPTION
Upon further discussion, the team has agreed that in certain degenerate cases, the current diagnostics are insufficient.
In the case that min == max in the wave size range attribute, a defaultError warning should be emitted. Additionally, there should be an explicit way to handle the case where 0,0,0 is passed to the wavesize range attribute.
This PR directly handles and tests both of these cases. Fixes #6161

---------

Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
(cherry picked from commit cadf3bfed1dbfc598fa46d6c9e487d9d37d98a31)