### PR TITLE
[SPIRV] Using 64-bit int literals in flat conversion

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3589,9 +3589,9 @@ SpirvEmitter::processFlatConversion(const QualType type,
     initInstr->setAstResultType(astContext.FloatTy);
   } else if (resultType->isSpecificBuiltinType(BuiltinType::LitInt)) {
     if (resultType->isSignedIntegerType())
-      initInstr->setAstResultType(astContext.IntTy);
+      initInstr->setAstResultType(astContext.LongLongTy);
     else
-      initInstr->setAstResultType(astContext.UnsignedIntTy);
+      initInstr->setAstResultType(astContext.UnsignedLongLongTy);
   }
 
   // Decompose `initInstr`.

--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.literal-initializer-opt.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.literal-initializer-opt.hlsl
@@ -1,0 +1,30 @@
+// RUN: %dxc -T ps_6_0 -E main %s -spirv | FileCheck %s
+
+struct S {
+  float f1;
+  float f2;
+};
+
+struct T {
+  int32_t i;
+  int32_t j;
+};
+
+RWStructuredBuffer<S> float_output;
+RWStructuredBuffer<T> int_output;
+
+// CHECK-NOT: OpCapability Int64
+// CHECK-NOT: OpCapability Float64
+
+// CHECK-DAG: [[s:%[0-9]+]] = OpConstantComposite %S %float_3_40282321e_37 %float_3_40282321e_37
+// CHECK-DAG: [[t:%[0-9]+]] = OpConstantComposite %T %int_1 %int_1
+
+void main() {
+// The literals should initially be interpreted as 64-bits, but fold to 32-bit values.
+// The then 64-bit capabilities should be removed. Spir-v opt does not current fold OpFConvert.
+// This should be updated when it does.
+// CHECK: OpStore {{%[^ ]+}} [[s]]
+  float_output[0] = (S)(3.402823466e+37);
+// CHECK: OpStore {{%[^ ]+}} [[t]]
+  int_output[0] = (T)(0x100000000+1);
+}

--- a/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.literal-initializer.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.flat-conversion.literal-initializer.hlsl
@@ -59,8 +59,8 @@ void main() {
   S s1 = (S)(a);
 
 // TODO(6188): This is wrong because we lose most significant bits in the literal.
-// CHECK: [[lit:%[0-9]+]] = OpIAdd %int %int_0 %int_1
-// CHECK: [[longLit:%[0-9]+]] = OpSConvert %long [[lit]]
+// CHECK: [[longLit:%[0-9]+]] = OpIAdd %long %long_4294967296 %long_1
+// CHECK: [[lit:%[0-9]+]] = OpSConvert %int [[longLit]]
 // CHECK: [[t:%[0-9]+]] = OpCompositeConstruct %T [[lit]] [[longLit]]
 // CHECK: OpStore %t [[t]]
   T t = (T)(0x100000000+1);


### PR DESCRIPTION
During flat convertion, we have to pick the bit width for literals
because they could be used in multiple places as different sizes, and
that breaks the literal visitor.  We currently use 32-bit types because
that is the most common use case, and we don't want to unnecessarily
add a capability.

However, if we pick a 64-bit width, we should be able to fold all of
the operations on literals. If they are only used as 32-bit value, then
ultimatlly fold them to 32-bit constants and remove the 64-bit
capabilities.

This commit updates the spir-v submodule to pull in the 64-bit interger
folding changes, and then starts to use 64-bit integer literal in flat conversion.

Note that the problem still exists for floating point values. Spirv-opt
does not fold OpFConvert yet, we still treat the literals like a float.

Fixes #6188

mend
