### PR TITLE
NFC: Fix switch with missing default case in DxilShaderModel.cpp

### DIFF
--- a/include/dxc/DXIL/DxilConstants.h
+++ b/include/dxc/DXIL/DxilConstants.h
@@ -230,6 +230,9 @@ enum class ShaderKind {
   Last_1_8 = Node,
   LastValid = Last_1_8,
 };
+static_assert((unsigned)DXIL::ShaderKind::LastValid + 1 ==
+                  (unsigned)DXIL::ShaderKind::Invalid,
+              "otherwise, enum needs updating.");
 
 // clang-format off
   // Python lines need to be not formatted.

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -504,8 +504,9 @@ bool ShaderModel::AllowDerivatives(DXIL::ShaderKind sk) const {
   case DXIL::ShaderKind::Amplification:
   case DXIL::ShaderKind::Mesh:
     return IsSM66Plus();
+  default:
+    return false;
   }
-  return false;
 }
 
 typedef ShaderModel SM;

--- a/lib/DXIL/DxilShaderModel.cpp
+++ b/lib/DXIL/DxilShaderModel.cpp
@@ -504,9 +504,22 @@ bool ShaderModel::AllowDerivatives(DXIL::ShaderKind sk) const {
   case DXIL::ShaderKind::Amplification:
   case DXIL::ShaderKind::Mesh:
     return IsSM66Plus();
-  default:
+  case DXIL::ShaderKind::Vertex:
+  case DXIL::ShaderKind::Geometry:
+  case DXIL::ShaderKind::Hull:
+  case DXIL::ShaderKind::Domain:
+  case DXIL::ShaderKind::RayGeneration:
+  case DXIL::ShaderKind::Intersection:
+  case DXIL::ShaderKind::AnyHit:
+  case DXIL::ShaderKind::ClosestHit:
+  case DXIL::ShaderKind::Miss:
+  case DXIL::ShaderKind::Callable:
+  case DXIL::ShaderKind::Invalid:
     return false;
   }
+  static_assert(DXIL::ShaderKind::LastValid == DXIL::ShaderKind::Node,
+                "otherwise, switch needs to be updated.");
+  llvm_unreachable("unknown ShaderKind");
 }
 
 typedef ShaderModel SM;


### PR DESCRIPTION
This missing default case statement would cause build break when compiling with additional warning settings, such as /Wall /WX in VC++.

Fixes #6287.