### PR TITLE
Made the `this` variable in templated struct member functions references

### DIFF
--- a/tools/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/tools/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -1128,16 +1128,9 @@ llvm::DISubroutineType *CGDebugInfo::getOrCreateInstanceMethodType(
   // "this" pointer is always first argument.
   const CXXRecordDecl *RD = ThisPtr->getPointeeCXXRecordDecl();
   if (isa<ClassTemplateSpecializationDecl>(RD)) {
-    // Create pointer type directly in this case.
     // HLSL Change Begin - This is a reference.
-    QualType PointeeTy = ThisPtr->getPointeeType();
-    unsigned AS = CGM.getContext().getTargetAddressSpace(PointeeTy);
-    uint64_t Size = CGM.getTarget().getPointerWidth(AS);
-    uint64_t Align = CGM.getContext().getTypeAlign(ThisPtr.getTypePtr());
+    llvm::DIType *ThisPtrType = getOrCreateType(ThisPtr, Unit);
     // HLSL Change End - This is a reference.
-    llvm::DIType *PointeeType = getOrCreateType(PointeeTy, Unit);
-    llvm::DIType *ThisPtrType =
-        DBuilder.createPointerType(PointeeType, Size, Align);
     TypeCache[ThisPtr.getAsOpaquePtr()].reset(ThisPtrType);
     // TODO: This and the artificial type below are misleading, the
     // types aren't artificial the argument is, but the current

--- a/tools/clang/test/HLSLFileCheck/dxil/debug/templated_struct.hlsl
+++ b/tools/clang/test/HLSLFileCheck/dxil/debug/templated_struct.hlsl
@@ -1,0 +1,27 @@
+// RUN: %dxc -E main -T ps_6_0 %s -Zi -O0 | FileCheck %s
+// RUN: %dxc -E main -T ps_6_0 %s -Zi -O3 | FileCheck %s
+
+// We check that the broken down elements directly point to the value of the struct S
+
+// CHECK: dbg.value(metadata float %{{.+}}, i64 0, metadata ![[this:.+]], metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"this" !DIExpression(DW_OP_bit_piece, 0, 32)
+// CHECK: dbg.value(metadata float %{{.+}}, i64 0, metadata ![[this]], metadata !{{[0-9]+}}), !dbg !{{[0-9]+}} ; var:"this" !DIExpression(DW_OP_bit_piece, 32, 32)
+// CHECK-DAG: ![[this]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: !{{[0-9]+}}, type: ![[type:[0-9]+]])
+// CHECK-DAG: ![[type]] = !DICompositeType(tag: DW_TAG_structure_type, name: "S<float>", file: !{{[0-9]+}}, line: {{[0-9]+}}, size: 64, align: 32, elements: !{{[0-9]+}}, templateParams: !{{[0-9]+}})
+
+template<typename T>
+struct S {
+  T a, b;
+  T Get() {
+    return a + b;
+  }
+};
+
+[RootSignature("")]
+float main(float x : X, float y : Y, float z : Z, float w : W) : SV_Target {
+  S<float> s;
+  s.a = x;
+  s.b = y;
+  return s.Get();
+}
+
+

--- a/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/template/templateStructFunc.hlsl
@@ -67,9 +67,7 @@ float2 main(float4 a:A) : SV_Target {
 // DI-DAG: [[DITestV:![0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Test<vector<float, 2> >", file: [[DIFile]], line: {{[0-9]+}}, size: 64, align: 32
 
 // DI-DAG: [[t1FVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "t1", arg: 2, scope: [[FSub]], file: [[DIFile]], line: {{[0-9]+}}, type: [[DIFloat]])
-// DI-DAG: [[thisFVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: [[FSub]], type: [[thisFPtr:![0-9]+]])
-// DI-DAG: [[thisFPtr]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DITestF]], size: 32, align: 32)
+// DI-DAG: [[thisFVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: [[FSub]], type: [[DITestF]])
 
 // DI-DAG: [[t1VVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "t1", arg: 2, scope: [[VSub]], file: [[DIFile]]
-// DI-DAG: [[thisVVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: [[VSub]], type: [[thisVPtr:![0-9]+]])
-// DI-DAG: [[thisVPtr]] = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: [[DITestV]], size: 32, align: 32)
+// DI-DAG: [[thisVVar]] = !DILocalVariable(tag: DW_TAG_arg_variable, name: "this", arg: 1, scope: [[VSub]], type: [[DITestV]])


### PR DESCRIPTION
Made the debug info type for the `this` argument a reference type. `DxilRewriteOutputArgDebugInfo` then turns the reference type into a value type to preserve the value mapping when the alloca that `this` points to becomes registers.