### PR TITLE
CP: PIX: Deduplicate globals when referenced in multiple library fns (#6305)

### DIFF
--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -168,6 +168,7 @@ public:
       DxcPixDxilDebugInfo_GlobalBackedGlobalStaticEmbeddedArrays_WithDbgValue)
   TEST_METHOD(
       DxcPixDxilDebugInfo_GlobalBackedGlobalStaticEmbeddedArrays_ArrayInValues)
+  TEST_METHOD(DxcPixDxilDebugInfo_DuplicateGlobals)
   TEST_METHOD(DxcPixDxilDebugInfo_StructInheritance)
   TEST_METHOD(DxcPixDxilDebugInfo_StructContainedResource)
   TEST_METHOD(DxcPixDxilDebugInfo_StructStaticInit)
@@ -2225,6 +2226,53 @@ void main()
   Expected.push_back({L"global.globalStruct.FloatArray[0]", L"float"});
   Expected.push_back({L"global.globalStruct.FloatArray[1]", L"float"});
   TestGlobalStaticCase(hlsl, L"lib_6_6", "float Accumulator", Expected);
+}
+
+int CountLiveGlobals(IDxcPixDxilLiveVariables *liveVariables) {
+  int globalCount = 0;
+  DWORD varCount;
+  VERIFY_SUCCEEDED(liveVariables->GetCount(&varCount));
+  for (DWORD i = 0; i < varCount; ++i) {
+    CComPtr<IDxcPixVariable> var;
+    VERIFY_SUCCEEDED(liveVariables->GetVariableByIndex(i, &var));
+    CComBSTR name;
+    VERIFY_SUCCEEDED(var->GetName(&name));
+    if (wcsstr(name, L"global.") != nullptr)
+      globalCount++;
+  }
+  return globalCount;
+}
+
+TEST_F(PixDiaTest, DxcPixDxilDebugInfo_DuplicateGlobals) {
+  if (m_ver.SkipDxilVersion(1, 6))
+    return;
+
+  const char *hlsl = R"(
+static float global = 1.0;
+struct RayPayload
+{
+    float4 color;
+};
+typedef BuiltInTriangleIntersectionAttributes MyAttributes;
+
+[shader("closesthit")]
+void InnerClosestHitShader(inout RayPayload payload, in MyAttributes attr)
+{
+    payload.color = float4(global, 0, 0, 0); // CHLine
+}
+
+[shader("miss")]
+void MyMissShader(inout RayPayload payload)
+{
+    payload.color = float4(0, 1, 0, 0); // MSLine
+})";
+
+  auto dxilDebugger = CompileAndCreateDxcDebug(hlsl, L"lib_6_6").debugInfo;
+
+  auto CHVars = GetLiveVariablesAt(hlsl, "CHLine", dxilDebugger);
+  VERIFY_ARE_EQUAL(1, CountLiveGlobals(CHVars));
+  auto MSVars = GetLiveVariablesAt(hlsl, "MSLine", dxilDebugger);
+  VERIFY_ARE_EQUAL(0, CountLiveGlobals(MSVars));
 }
 
 TEST_F(PixDiaTest, DxcPixDxilDebugInfo_StructInheritance) {


### PR DESCRIPTION
PIX's code for parsing debug data operates at the module level. When the same global is referenced by multiple functions in a module, that variable is referred to by multiple dbg.value/dbg.declare statements, and those are mapped (by the PIX passes) to multiple fake allocas using its usual scheme. This code was written before libraries were a thing, and wasn't expecting this duplication. A little more attention to the variable's scope fixes the issue.
Also, the changed code's original "return false" broke the whole process of discovering variables with the results that PIX's shader debugger locals window was completely empty. Makes more sense to ignore the one variable and keep going.

(cherry picked from commit 64cdb9cfc07ce37a8156c219c04f2b00f5beb547)