### PR TITLE
NFC: Fix DXIL op is_const for Barrier and node create handle ops (#6280)

### DIFF
--- a/include/dxc/DXIL/DxilInstructions.h
+++ b/include/dxc/DXIL/DxilInstructions.h
@@ -8856,6 +8856,15 @@ struct DxilInst_BarrierByNodeRecordHandle {
   void set_object(llvm::Value *val) { Instr->setOperand(1, val); }
   llvm::Value *get_SemanticFlags() const { return Instr->getOperand(2); }
   void set_SemanticFlags(llvm::Value *val) { Instr->setOperand(2, val); }
+  int32_t get_SemanticFlags_val() const {
+    return (int32_t)(llvm::dyn_cast<llvm::ConstantInt>(Instr->getOperand(2))
+                         ->getZExtValue());
+  }
+  void set_SemanticFlags_val(int32_t val) {
+    Instr->setOperand(2, llvm::Constant::getIntegerValue(
+                             llvm::IntegerType::get(Instr->getContext(), 32),
+                             llvm::APInt(32, (uint64_t)val)));
+  }
 };
 
 /// This instruction Creates a handle to a NodeOutput
@@ -8883,6 +8892,15 @@ struct DxilInst_CreateNodeOutputHandle {
   // Accessors
   llvm::Value *get_MetadataIdx() const { return Instr->getOperand(1); }
   void set_MetadataIdx(llvm::Value *val) { Instr->setOperand(1, val); }
+  int32_t get_MetadataIdx_val() const {
+    return (int32_t)(llvm::dyn_cast<llvm::ConstantInt>(Instr->getOperand(1))
+                         ->getZExtValue());
+  }
+  void set_MetadataIdx_val(int32_t val) {
+    Instr->setOperand(1, llvm::Constant::getIntegerValue(
+                             llvm::IntegerType::get(Instr->getContext(), 32),
+                             llvm::APInt(32, (uint64_t)val)));
+  }
 };
 
 /// This instruction returns the handle for the location in the output node
@@ -8972,6 +8990,15 @@ struct DxilInst_CreateNodeInputRecordHandle {
   // Accessors
   llvm::Value *get_MetadataIdx() const { return Instr->getOperand(1); }
   void set_MetadataIdx(llvm::Value *val) { Instr->setOperand(1, val); }
+  int32_t get_MetadataIdx_val() const {
+    return (int32_t)(llvm::dyn_cast<llvm::ConstantInt>(Instr->getOperand(1))
+                         ->getZExtValue());
+  }
+  void set_MetadataIdx_val(int32_t val) {
+    Instr->setOperand(1, llvm::Constant::getIntegerValue(
+                             llvm::IntegerType::get(Instr->getContext(), 32),
+                             llvm::APInt(32, (uint64_t)val)));
+  }
 };
 
 /// This instruction annotate handle with node record properties

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -5396,7 +5396,9 @@ class db_dxil(object):
             [
                 retvoid_param,
                 db_dxil_param(2, "noderecordhandle", "object", "handle of object"),
-                db_dxil_param(3, "i32", "SemanticFlags", "semantic flags"),
+                db_dxil_param(
+                    3, "i32", "SemanticFlags", "semantic flags", is_const=True
+                ),
             ],
         )
         next_op_idx += 1
@@ -5409,7 +5411,7 @@ class db_dxil(object):
             "rn",
             [
                 db_dxil_param(0, "nodehandle", "output", "handle of object"),
-                db_dxil_param(2, "i32", "MetadataIdx", "metadata index"),
+                db_dxil_param(2, "i32", "MetadataIdx", "metadata index", is_const=True),
             ],
         )
         next_op_idx += 1
@@ -5461,7 +5463,7 @@ class db_dxil(object):
             "rn",
             [
                 db_dxil_param(0, "noderecordhandle", "output", "output handle"),
-                db_dxil_param(2, "i32", "MetadataIdx", "metadata index"),
+                db_dxil_param(2, "i32", "MetadataIdx", "metadata index", is_const=True),
             ],
         )
         next_op_idx += 1


### PR DESCRIPTION
DXIL operations should use is_const=True for constant arguments. This allows for convenience methods to retrieve the constant value, and could (should, but currently doesn't) result in validation that the argument is constant.

`BarrierByNodeRecordHandle` SemanticFlags argument must be constant. `MetadataIdx` for both `createNodeOutputHandle` and `CreateNodeInputRecordHandle` must be constant.

(cherry picked from commit df588beb485958a3ece128bfbeda5fb888e2dfce)