### PR TITLE
Fixed PdbUtils not actually normalizing the file paths

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
+++ b/tools/clang/tools/dxcompiler/dxcpdbutils.cpp
@@ -421,7 +421,7 @@ private:
                             &source.Content));
 
     std::string normalizedPath = hlsl::NormalizePath(name);
-    IFR(Utf8ToBlobWide(name, &source.Name));
+    IFR(Utf8ToBlobWide(normalizedPath, &source.Name));
     // First file is the main file
     if (m_SourceFiles.empty()) {
       m_MainFileName = source.Name;

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3016,10 +3016,14 @@ TEST_F(CompilerTest, TestPdbUtilsPathNormalizations) {
     std::string mainPattern = "<MAIN_FILE>";
     std::string includePattern = "<INCLUDE_FILE>";
     while ((findPos = oldPdb.find(mainPattern)) != std::string::npos) {
-      oldPdb.replace(oldPdb.begin()+findPos, oldPdb.begin()+findPos+mainPattern.size(), test.MainName);
+      oldPdb.replace(oldPdb.begin() + findPos,
+                     oldPdb.begin() + findPos + mainPattern.size(),
+                     test.MainName);
     }
     while ((findPos = oldPdb.find(includePattern)) != std::string::npos) {
-      oldPdb.replace(oldPdb.begin()+findPos, oldPdb.begin()+findPos+includePattern.size(), test.IncludeName);
+      oldPdb.replace(oldPdb.begin() + findPos,
+                     oldPdb.begin() + findPos + includePattern.size(),
+                     test.IncludeName);
     }
 
     CComPtr<IDxcAssembler> pAssembler;
@@ -3075,10 +3079,9 @@ TEST_F(CompilerTest, TestPdbUtilsPathNormalizations) {
     CComPtr<IDxcCompiler> pCompiler;
     VERIFY_SUCCEEDED(CreateCompiler(&pCompiler));
     VERIFY_SUCCEEDED(pCompiler->Compile(
-        pMainContentUtf8, pMainName, L"main", L"ps_6_0", args,
-        _countof(args), nullptr, 0, pRecompileInclude, &pRecompileOpResult));
+        pMainContentUtf8, pMainName, L"main", L"ps_6_0", args, _countof(args),
+        nullptr, 0, pRecompileInclude, &pRecompileOpResult));
     VerifyOperationSucceeded(pRecompileOpResult);
-
   }
 }
 

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -2930,68 +2930,7 @@ public:
 };
 
 TEST_F(CompilerTest, TestPdbUtilsPathNormalizations) {
-  llvm::StringRef oldPdbRaw = R"x(
-    target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
-    target triple = "dxil-ms-dx"
-
-    define void @main() {
-    entry:
-      call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00), !dbg !30 ; line:2 col:28  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
-      ret void, !dbg !30 ; line:2 col:28
-    }
-
-    ; Function Attrs: nounwind
-    declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #0
-
-    attributes #0 = { nounwind }
-
-    !llvm.dbg.cu = !{!0}
-    !llvm.module.flags = !{!10, !11}
-    !llvm.ident = !{!12}
-    !dx.source.contents = !{!13, !14}
-    !dx.source.defines = !{!2}
-    !dx.source.mainFileName = !{!15}
-    !dx.source.args = !{!16}
-    !dx.version = !{!17}
-    !dx.valver = !{!18}
-    !dx.shaderModel = !{!19}
-    !dx.typeAnnotations = !{!20}
-    !dx.viewIdState = !{!23}
-    !dx.entryPoints = !{!24}
-
-    !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "dxc(private) 1.7.0.4135 (pdb_header_fix, 24cf4a146)", isOptimized: false, runtimeVersion: 0, emissionKind: 1, enums: !2, subprograms: !3)
-    !1 = !DIFile(filename: "<MAIN_FILE>", directory: "")
-    !2 = !{}
-    !3 = !{!4, !8}
-    !4 = !DISubprogram(name: "main", scope: !1, file: !1, line: 2, type: !5, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: false, function: void ()* @main)
-    !5 = !DISubroutineType(types: !6)
-    !6 = !{!7}
-    !7 = !DIBasicType(name: "float", size: 32, align: 32, encoding: DW_ATE_float)
-    !8 = !DISubprogram(name: "foo", linkageName: "\01?foo@@YAMXZ", scope: !9, file: !9, line: 1, type: !5, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false)
-    !9 = !DIFile(filename: "<INCLUDE_FILE>", directory: "")
-    !10 = !{i32 2, !"Dwarf Version", i32 4}
-    !11 = !{i32 2, !"Debug Info Version", i32 3}
-    !12 = !{!"dxc(private) 1.7.0.4135 (pdb_header_fix, 24cf4a146)"}
-    !13 = !{!"<MAIN_FILE>", !"#include \22include.h\22\0D\0Afloat main() : SV_Target { return foo(); }\0D\0A"}
-    !14 = !{!"<INCLUDE_FILE>", !"float foo() {\0D\0A  return 0;\0D\0A}\0D\0A"}
-    !15 = !{!"<MAIN_FILE>"}
-    !16 = !{!"-E", !"main", !"-T", !"ps_6_0", !"/Zi", !"-Qembed_debug"}
-    !17 = !{i32 1, i32 0}
-    !18 = !{i32 1, i32 8}
-    !19 = !{!"ps", i32 6, i32 0}
-    !20 = !{i32 1, void ()* @main, !21}
-    !21 = !{!22}
-    !22 = !{i32 0, !2, !2}
-    !23 = !{[2 x i32] [i32 0, i32 1]}
-    !24 = !{void ()* @main, !"main", !25, null, null}
-    !25 = !{null, !26, null}
-    !26 = !{!27}
-    !27 = !{i32 0, !"SV_Target", i8 9, i8 16, !28, i8 0, i32 1, i8 1, i32 0, i8 0, !29}
-    !28 = !{i32 0}
-    !29 = !{i32 3, i32 1}
-    !30 = !DILocation(line: 2, column: 28, scope: !4)
-  )x";
-
+#include "TestHeaders/TestPdbUtilsPathNormalizations.h"
   struct TestCase {
     std::string MainName;
     std::string IncludeName;
@@ -3012,8 +2951,7 @@ TEST_F(CompilerTest, TestPdbUtilsPathNormalizations) {
   };
 
   for (TestCase &test : tests) {
-
-    std::string oldPdb = oldPdbRaw;
+    std::string oldPdb = kTestPdbUtilsPathNormalizationsIR;
 
     size_t findPos = std::string::npos;
     std::string mainPattern = "<MAIN_FILE>";

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -3001,11 +3001,14 @@ TEST_F(CompilerTest, TestPdbUtilsPathNormalizations) {
       {R"(main.hlsl)", R"(include.h)"},
       {R"(.\5Cmain.hlsl)", R"(.\5Cinclude.h)"},
       {R"(/path/main.hlsl)", R"(/path/include.h)"},
+      {R"(\5Cpath/main.hlsl)", R"(\5Cpath\5Cinclude.h)"},
       {R"(..\5Cmain.hlsl)", R"(..\5Cinclude.h)"},
       {R"(..\5Cdir\5Cmain.hlsl)", R"(..\5Cdir\5Cinclude.h)"},
       {R"(F:\5C\5Cdir\5Cmain.hlsl)", R"(F:\5C\5Cdir\5Cinclude.h)"},
       {R"(\5C\5Cdir\5Cmain.hlsl)", R"(\5C\5Cdir\5Cinclude.h)"},
       {R"(\5C\5C\5Cdir\5Cmain.hlsl)", R"(\5C\5C\5Cdir\5Cinclude.h)"},
+      {R"(//dir\5Cmain.hlsl)", R"(//dir/include.h)"},
+      {R"(///dir/main.hlsl)", R"(///dir\5Cinclude.h)"},
   };
 
   for (TestCase &test : tests) {

--- a/tools/clang/unittests/HLSL/TestHeaders/TestPdbUtilsPathNormalizations.h
+++ b/tools/clang/unittests/HLSL/TestHeaders/TestPdbUtilsPathNormalizations.h
@@ -1,0 +1,63 @@
+#pragma once
+
+static const llvm::StringRef kTestPdbUtilsPathNormalizationsIR = R"x(
+  target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+  target triple = "dxil-ms-dx"
+
+  define void @main() {
+  entry:
+    call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 0.000000e+00), !dbg !30 ; line:2 col:28  ; StoreOutput(outputSigId,rowIndex,colIndex,value)
+    ret void, !dbg !30 ; line:2 col:28
+  }
+
+  ; Function Attrs: nounwind
+  declare void @dx.op.storeOutput.f32(i32, i32, i32, i8, float) #0
+
+  attributes #0 = { nounwind }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!10, !11}
+  !llvm.ident = !{!12}
+  !dx.source.contents = !{!13, !14}
+  !dx.source.defines = !{!2}
+  !dx.source.mainFileName = !{!15}
+  !dx.source.args = !{!16}
+  !dx.version = !{!17}
+  !dx.valver = !{!18}
+  !dx.shaderModel = !{!19}
+  !dx.typeAnnotations = !{!20}
+  !dx.viewIdState = !{!23}
+  !dx.entryPoints = !{!24}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus, file: !1, producer: "dxc(private) 1.7.0.4135 (pdb_header_fix, 24cf4a146)", isOptimized: false, runtimeVersion: 0, emissionKind: 1, enums: !2, subprograms: !3)
+  !1 = !DIFile(filename: "<MAIN_FILE>", directory: "")
+  !2 = !{}
+  !3 = !{!4, !8}
+  !4 = !DISubprogram(name: "main", scope: !1, file: !1, line: 2, type: !5, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: false, function: void ()* @main)
+  !5 = !DISubroutineType(types: !6)
+  !6 = !{!7}
+  !7 = !DIBasicType(name: "float", size: 32, align: 32, encoding: DW_ATE_float)
+  !8 = !DISubprogram(name: "foo", linkageName: "\01?foo@@YAMXZ", scope: !9, file: !9, line: 1, type: !5, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false)
+  !9 = !DIFile(filename: "<INCLUDE_FILE>", directory: "")
+  !10 = !{i32 2, !"Dwarf Version", i32 4}
+  !11 = !{i32 2, !"Debug Info Version", i32 3}
+  !12 = !{!"dxc(private) 1.7.0.4135 (pdb_header_fix, 24cf4a146)"}
+  !13 = !{!"<MAIN_FILE>", !"#include \22include.h\22\0D\0Afloat main() : SV_Target { return foo(); }\0D\0A"}
+  !14 = !{!"<INCLUDE_FILE>", !"float foo() {\0D\0A  return 0;\0D\0A}\0D\0A"}
+  !15 = !{!"<MAIN_FILE>"}
+  !16 = !{!"-E", !"main", !"-T", !"ps_6_0", !"/Zi", !"-Qembed_debug"}
+  !17 = !{i32 1, i32 0}
+  !18 = !{i32 1, i32 8}
+  !19 = !{!"ps", i32 6, i32 0}
+  !20 = !{i32 1, void ()* @main, !21}
+  !21 = !{!22}
+  !22 = !{i32 0, !2, !2}
+  !23 = !{[2 x i32] [i32 0, i32 1]}
+  !24 = !{void ()* @main, !"main", !25, null, null}
+  !25 = !{null, !26, null}
+  !26 = !{!27}
+  !27 = !{i32 0, !"SV_Target", i8 9, i8 16, !28, i8 0, i32 1, i8 1, i32 0, i8 0, !29}
+  !28 = !{i32 0}
+  !29 = !{i32 3, i32 1}
+  !30 = !DILocation(line: 2, column: 28, scope: !4)
+)x";


### PR DESCRIPTION
There was a typo in dxcpdbutils where the normalized file path wasn't actually being used. This change fixes that and adds thorough testing for the DxcPdbUtils path normalization. Also fixed another case where `/dir/my_file` gets normalized to `.\\dir\my_file`.