### PR TITLE
[Test] Limit NodeObjects test to dxil-1-8

### DIFF
--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/lit.local.cfg
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/lit.local.cfg
@@ -1,0 +1,1 @@
+config.unsupported = 'dxil-1-8' not in config.available_features


### PR DESCRIPTION
Add lit.local.cfg to set unsupported when not dxil-1-8.