### PR TITLE
Fix duplicate output of "globallycoherent" attribute in HLSL rewriter.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -14802,9 +14802,10 @@ void hlsl::CustomPrintHLSLAttr(const clang::Attr *A, llvm::raw_ostream &Out,
     Out << "uniform ";
     break;
 
-  // These four cases are printed in TypePrinter::printAttributedBefore
+  // These three cases are printed in TypePrinter::printAttributedBefore
   case clang::attr::HLSLSnorm:
   case clang::attr::HLSLUnorm:
+  case clang::attr::HLSLGloballyCoherent:
     break;
 
   case clang::attr::HLSLPoint:
@@ -14825,10 +14826,6 @@ void hlsl::CustomPrintHLSLAttr(const clang::Attr *A, llvm::raw_ostream &Out,
 
   case clang::attr::HLSLTriangleAdj:
     Out << "triangleadj ";
-    break;
-
-  case clang::attr::HLSLGloballyCoherent:
-    Out << "globallycoherent ";
     break;
 
   case clang::attr::HLSLIndices:


### PR DESCRIPTION
This attribute is already handled in TypePrinter::printAttributedBefore and must not be emitted hlsl::CustomPrintHLSLAttr prior to that call.