### PR TITLE
[SPIR-V] Allow SamplerComparisonState in combinedImageSampler

### DIFF
--- a/tools/clang/include/clang/Basic/Attr.td
+++ b/tools/clang/include/clang/Basic/Attr.td
@@ -1258,14 +1258,13 @@ def ArrayOfBuffer
                   S->getType()->getAsArrayTypeUnsafe()->getElementType()->getAs<RecordType>()->getDecl()->getName() ==
                       "RasterizerOrderedBuffer")}]>;
 
-// Global variable with "Texture" or "SamplerState" type
+// Global variable with "Texture*" or "Sampler*" type
 def TextureOrSampler
     : SubsetSubject<
           Var, [{S->hasGlobalStorage() && S->getType()->getAs<RecordType>() &&
                  S->getType()->getAs<RecordType>()->getDecl() &&
                  (S->getType()->getAs<RecordType>()->getDecl()->getName().startswith("Texture") ||
-                  S->getType()->getAs<RecordType>()->getDecl()->getName() ==
-                      "SamplerState")}]>;
+                  S->getType()->getAs<RecordType>()->getDecl()->getName().startswith("Sampler"))}]>;
 
 def VKBuiltIn : InheritableAttr {
   let Spellings = [CXX11<"vk", "builtin">];

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -2349,7 +2349,7 @@ def warn_attribute_wrong_decl_type : Warning<
   "global variables of scalar type|"
   "global variables of struct type|"
   "global variables, cbuffers, and tbuffers|"
-  "Textures (e.g., Texture2D) and SamplerState|"
+  "Textures and Samplers|"
   "RWTextures, RasterizerOrderedTextures, Buffers, RWBuffers, and RasterizerOrderedBuffers|"
   "RWStructuredBuffers, AppendStructuredBuffers, and ConsumeStructuredBuffers|"
   "SubpassInput, SubpassInputMS|"

--- a/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.combined-image-sampler.hlsl
@@ -25,6 +25,13 @@ Texture2D<float4> tex2 : register(t2);
 // CHECK: OpDecorate %sam3 Binding 0
 SamplerState sam3 : register(s0);
 
+// CHECK: OpDecorate %tex4 DescriptorSet 0
+// CHECK: OpDecorate %tex4 Binding 4
+[[vk::combinedImageSampler]]
+Texture2D tex4 : register(t4);
+[[vk::combinedImageSampler]]
+SamplerComparisonState sam4 : register(s4);
+
 Texture2D<float4> getTexture(int i) {
   if (i == 0) return tex0;
   if (i == 1) return tex1;
@@ -58,6 +65,10 @@ float4 main(int3 offset: A) : SV_Target {
 // CHECK: [[tex2:%[a-zA-Z0-9_]+]] = OpLoad %type_sampled_image %tex2
 // CHECK: OpImageSampleExplicitLod %v4float [[tex2]]
   ret += sampleLevel(2);
+
+// CHECK: [[tex4:%[a-zA-Z0-9_]+]] = OpLoad %type_sampled_image %tex4
+// CHECK: OpImageSampleDrefImplicitLod %float [[tex4]]
+  ret += tex4.SampleCmp(sam4, float2(1, 2), 10, 2);
 
 // CHECK: [[tex0_0:%[a-zA-Z0-9_]+]] = OpLoad %type_sampled_image %tex0
 // CHECK: [[img_extracted_from_tex0:%[a-zA-Z0-9_]+]] = OpImage %type_2d_image [[tex0_0]]


### PR DESCRIPTION
Previously, only `SamplerState` was allowed to be used as the sampler type with `[[vk::combinedImageSampler]]`, but I don't see any reason that `SamplerComparisonState` shouldn't also be permitted. Since `SamplerComparisonState` is a sampler state plus a comparison state, `SampleCmp` calls are translated to an `OpImageSampleDrefImplicitLod` (sampling with depth-comparison) in Vulkan SPIR-V, which does accept an `OpTypeSampledImage` (combined image sampler) as an operand.

Fixes #4696