### PR TITLE
[lit] support dxil version check in lit test

### DIFF
--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/lit.local.cfg
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/lit.local.cfg
@@ -1,0 +1,1 @@
+config.unsupported = 'dxil-1-8' not in config.available_features

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/node-objects-metdata.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/node-objects-metdata.hlsl
@@ -1,8 +1,22 @@
-// RUN: %dxc -T lib_6_8 %s | FileCheck %s --check-prefixes=MD
-// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s --check-prefixes=MD
-// RUN: %dxc -T lib_6_8 -Zi %s | FileCheck %s --check-prefixes=MD
+// RUN: %if dxil-1-8  \
+// RUN:   %{          \
+// RUN: %dxc -T lib_6_8 %s | FileCheck %s --check-prefixes=MD \
+// RUN:   %}
 
-// RUN: %dxc -T lib_6_8 -fcgl %s | FileCheck %s --check-prefix=FCGLMD
+// RUN: %if dxil-1-8  \
+// RUN:   %{          \
+// RUN: %dxc -T lib_6_8 -Od %s | FileCheck %s --check-prefixes=MD \
+// RUN:   %}
+
+// RUN: %if dxil-1-8  \
+// RUN:   %{          \
+// RUN: %dxc -T lib_6_8 -Zi %s | FileCheck %s --check-prefixes=MD \
+// RUN:   %}
+
+// RUN: %if dxil-1-8  \
+// RUN:   %{          \
+// RUN: %dxc -T lib_6_8 -fcgl %s | FileCheck %s --check-prefix=FCGLMD \
+// RUN:   %}
 
 // Verify correct metadata annotations for different node shader input and outputs.
 

--- a/tools/clang/test/LitDXILValidation/illegalDXILOp.ll
+++ b/tools/clang/test/LitDXILValidation/illegalDXILOp.ll
@@ -39,7 +39,7 @@ define void @main() {
 
   %6 = call %dx.types.Handle @dx.op.annotateHandle2(i32 216, %dx.types.Handle %2, %dx.types.ResourceProperties { i32 32782, i32 0 })  ; AnnotateHandle(res,props)  resource: SamplerComparisonState
 
-; CHECK: error: DXILOpCode must be [0..258].  1999981 specified.
+; CHECK: error: DXILOpCode must be [0..{{[0-9]+}}].  1999981 specified.
 ; CHECK: note: at '%7 = call float @dx.op.calculateLOD.f32(i32 1999981, %dx.types.Handle %5, %dx.types.Handle %6, float %3, float %4, float undef, i1 true)' in block '#0' of function 'main'.
 
   %7 = call float @dx.op.calculateLOD.f32(i32 1999981, %dx.types.Handle %5, %dx.types.Handle %6, float %3, float %4, float undef, i1 true)  ; CalculateLOD(handle,sampler,coord0,coord1,coord2,clamped)

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -507,12 +507,14 @@ if config.spirv:
 def get_dxil_version():
     result = subprocess.run([lit.util.which('dxc', llvm_tools_dir), "--version"], stdout=subprocess.PIPE)
     output = result.stdout.decode("utf-8")
-    pat = re.compile(r"(dxcompiler.dll|libdxcompiler.so|libdxcompiler.dylib): (?P<dxcMajor>[0-9]+)\.(?P<dxcMinor>[0-9]+).*(; (dxil.dll|libdxil.so): (?P<dxilMajor>[0-9]+)\.(?P<dxilMinor>[0-9]+))?")
-    m = pat.search(output)
+    dxcPat = re.compile(r"(dxcompiler.dll|libdxcompiler.so|libdxcompiler.dylib): (?P<dxcMajor>[0-9]+)\.(?P<dxcMinor>[0-9]+).")
+    m = dxcPat.search(output)
     dxcMajor = int(m.group("dxcMajor"))
     dxcMinor = int(m.group("dxcMinor"))
 
-    if None == m.group("dxilMajor"):
+    dxilPat = re.compile(r"; (dxil.dll|libdxil.so): (?P<dxilMajor>[0-9]+)\.(?P<dxilMinor>[0-9]+)")
+    m = dxilPat.search(output)
+    if None == m:
         return dxcMajor, dxcMinor
     dxilMajor = int(m.group("dxilMajor"))
     dxilMinor = int(m.group("dxilMinor"))

--- a/tools/clang/test/lit.cfg
+++ b/tools/clang/test/lit.cfg
@@ -503,6 +503,33 @@ if config.enable_backtrace == "1":
 if config.spirv:
     config.available_features.add("spirv")
 
+# Check supported dxil version
+def get_dxil_version():
+    result = subprocess.run([lit.util.which('dxc', llvm_tools_dir), "--version"], stdout=subprocess.PIPE)
+    output = result.stdout.decode("utf-8")
+    pat = re.compile(r"(dxcompiler.dll|libdxcompiler.so|libdxcompiler.dylib): (?P<dxcMajor>[0-9]+)\.(?P<dxcMinor>[0-9]+).*(; (dxil.dll|libdxil.so): (?P<dxilMajor>[0-9]+)\.(?P<dxilMinor>[0-9]+))?")
+    m = pat.search(output)
+    dxcMajor = int(m.group("dxcMajor"))
+    dxcMinor = int(m.group("dxcMinor"))
+
+    if None == m.group("dxilMajor"):
+        return dxcMajor, dxcMinor
+    dxilMajor = int(m.group("dxilMajor"))
+    dxilMinor = int(m.group("dxilMinor"))
+    if dxcMajor < dxilMajor:
+        return dxcMajor, dxcMinor
+    if dxcMajor > dxilMajor:
+        return dxilMajor, dxilMinor
+    if dxcMinor < dxilMinor:
+        return dxcMajor, dxcMinor
+    return dxilMajor, dxilMinor
+
+dxilMajor, dxilMinor = get_dxil_version()
+if dxilMajor == 1:
+    for i in range(0, dxilMinor + 1):
+        config.available_features.add(f"dxil-1-{i}")
+
+
 # Check if we should run long running tests.
 if lit_config.params.get("run_long_tests", None) == "true":
     config.available_features.add("long_tests")


### PR DESCRIPTION

dxil-1-* will be added as available_features for lit config.

There're 3 ways to use it.
1. Whole file limit use required dxil-1-8
2. Single RUN line with %if dxil-1-8 %{ %}
3. Whole folder with check dxil-1-8 to set config.unsupported in lit.local.cfg 