### PR TITLE
[ExecutionTest] Add Wave Range Size HLK Tests

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13160,7 +13160,7 @@ void RunWaveSizeTest(UINT minWaveSize, UINT maxWaveSize,
       "[numthreads(" stringify(
           MAX_WAVESIZE) "*2,1,1)]\r\n"
                         "void main(uint3 tid : SV_DispatchThreadID ) { \r\n"
-                        "  data[tid.x].count = WaveActiveSum(1); \r\n"
+                        "  data[tid.x].count = WaveGetLaneCount(); \r\n"
                         "}\r\n";
 
   struct WaveSizeTestData {

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13312,7 +13312,7 @@ void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
         // Only allow valid shader wave ranges
         bool AcceptedByRuntime = TestShaderRangeAgainstRequirements(
             minShaderWaveSize, maxShaderWaveSize, minWaveSize, maxWaveSize);
-        if (!AcceptedByRuntime) {          
+        if (!AcceptedByRuntime) {
           continue;
         }
 
@@ -13332,7 +13332,8 @@ void ExecutionTest::WaveSizeTest() {
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
   CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6, /*skipUnsupported*/ false)) {
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6,
+                    /*skipUnsupported*/ false)) {
     return;
   }
 
@@ -13371,7 +13372,8 @@ void ExecutionTest::WaveSizeRangeTest() {
       WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
 
   CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_8, /*skipUnsupported*/ false)) {
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_8,
+                    /*skipUnsupported*/ false)) {
     return;
   }
 

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13306,19 +13306,22 @@ void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
        minShaderWaveSize *= 2) {
     for (UINT maxShaderWaveSize = minShaderWaveSize * 2;
          maxShaderWaveSize <= 128; maxShaderWaveSize *= 2) {
+      // Only allow valid shader wave ranges
+      bool AcceptedByRuntime = TestShaderRangeAgainstRequirements(
+          minShaderWaveSize, maxShaderWaveSize, minWaveSize, maxWaveSize);
+      if (!AcceptedByRuntime) {
+        continue;
+      }
+
+      ExecuteWaveSizeRangeInstance(
+          minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support,
+          minShaderWaveSize, maxShaderWaveSize,
+          /* prefShaderWaveSize won't be used, so set it to minShaderWaveSize*/
+          minShaderWaveSize, false);
+
       for (UINT prefShaderWaveSize = minShaderWaveSize;
            prefShaderWaveSize <= maxShaderWaveSize; prefShaderWaveSize *= 2) {
 
-        // Only allow valid shader wave ranges
-        bool AcceptedByRuntime = TestShaderRangeAgainstRequirements(
-            minShaderWaveSize, maxShaderWaveSize, minWaveSize, maxWaveSize);
-        if (!AcceptedByRuntime) {
-          continue;
-        }
-
-        ExecuteWaveSizeRangeInstance(
-            minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support,
-            minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize, false);
         ExecuteWaveSizeRangeInstance(
             minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support,
             minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize, true);

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13248,7 +13248,7 @@ void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
   for (UINT minShaderWaveSize = 4; minShaderWaveSize <= maxWaveSize;
        minShaderWaveSize *= 2) {
     for (UINT maxShaderWaveSize = minShaderWaveSize * 2;
-         maxShaderWaveSize <= 128; minShaderWaveSize *= 2) {
+         maxShaderWaveSize <= 128; maxShaderWaveSize *= 2) {
       for (UINT prefShaderWaveSize = minShaderWaveSize;
            prefShaderWaveSize <= maxShaderWaveSize; prefShaderWaveSize *= 2) {
         // format compiler args
@@ -13294,17 +13294,20 @@ void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
           pOutData = (WaveSizeTestData *)dataUav.data();
 
           for (unsigned i = 0; i < MAX_WAVESIZE; i++) {
-            if (!VERIFY_IS_TRUE(pOutData[i].count >= minWaveSize &&
-                                pOutData[i].count <= maxWaveSize))
-              break;
+            VERIFY_IS_TRUE(pOutData[i].count >= minWaveSize &&
+                           pOutData[i].count <= maxWaveSize);
+
             if (prefShaderWaveSize >= minWaveSize &&
                 prefShaderWaveSize <= maxWaveSize) {
 
-              if (!VERIFY_ARE_EQUAL(pOutData[i].count, prefShaderWaveSize))
-                break;
+              VERIFY_ARE_EQUAL(pOutData[i].count, prefShaderWaveSize);
             }
           }
         } else {
+          LogCommentFmt(L"Wave size range [%d, %d] not supported by runtime, "
+                        L"which only supports range [%d, %d]",
+                        minShaderWaveSize, maxShaderWaveSize, minWaveSize,
+                        maxWaveSize);
           VERIFY_ARE_EQUAL(0u, dataUav.size());
         }
       }
@@ -13347,6 +13350,7 @@ void ExecutionTest::WaveSizeTest() {
   ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
   st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
 
+  LogCommentFmt(L"Testing WaveSize attribute for shader model 6.6.");
   RunWaveSizeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support);
   pDevice.Release();
   if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_8)) {
@@ -13359,6 +13363,9 @@ void ExecutionTest::WaveSizeTest() {
     WEX::Logging::Log::Comment(L"Device does not support wave operations.");
     return;
   }
+  LogCommentFmt(
+      L"Testing WaveSize attribute with ranges for shader model 6.8.");
+
   RunWaveSizeRangeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice,
                        m_support);
 }

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13171,7 +13171,8 @@ void RunWaveSizeTest(UINT minWaveSize, UINT maxWaveSize,
     // format compiler args
     char compilerOptions[64];
     VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
-                             "-D WAVE_SIZE_ATTR=[wavesize(%d)]", waveSize) != -1);
+                             "-D WAVE_SIZE_ATTR=[wavesize(%d)]",
+                             waveSize) != -1);
 
     // run the shader
     std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
@@ -13237,22 +13238,24 @@ void ExecuteWaveSizeRangeInstance(UINT minWaveSize, UINT maxWaveSize,
         }
       })";
 
-  // format compiler args  
+  // format compiler args
   char compilerOptions[64];
   if (usePreferred) {
     // putting spaces in between the %d's below will cause compilation issues.
     VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
-                  "-D WAVE_SIZE_ATTR=[wavesize(%d,%d,%d)]",
-                  minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize) != -1);    
+                             "-D WAVE_SIZE_ATTR=[wavesize(%d,%d,%d)]",
+                             minShaderWaveSize, maxShaderWaveSize,
+                             prefShaderWaveSize) != -1);
     LogCommentFmt(L"Verifying wave size range test results for (min, max, "
                   L"preferred): (%d, %d, %d)",
                   minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize);
   } else {
     VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
                              "-D WAVE_SIZE_ATTR=[wavesize(%d,%d)]",
-                             minShaderWaveSize, maxShaderWaveSize) != -1);   
-    LogCommentFmt(L"Verifying wave size range test results for (min, max): (%d, %d)",
-                  minShaderWaveSize, maxShaderWaveSize);
+                             minShaderWaveSize, maxShaderWaveSize) != -1);
+    LogCommentFmt(
+        L"Verifying wave size range test results for (min, max): (%d, %d)",
+        minShaderWaveSize, maxShaderWaveSize);
   }
 
   struct WaveSizeTestData {
@@ -13266,7 +13269,7 @@ void ExecuteWaveSizeRangeInstance(UINT minWaveSize, UINT maxWaveSize,
         VERIFY_IS_TRUE((0 == strncmp(Name, "UAVBuffer0", 10)));
         pShaderOp->Shaders.at(0).Arguments = compilerOptions;
         pShaderOp->Shaders.at(0).Text = waveSizeTestShader;
-        pShaderOp->Shaders.at(0).Target = "cs_6_8"; 
+        pShaderOp->Shaders.at(0).Target = "cs_6_8";
 
         VERIFY_IS_TRUE(sizeof(WaveSizeTestData) * MAX_WAVESIZE <= Data.size());
         WaveSizeTestData *pInData = (WaveSizeTestData *)Data.data();

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13141,44 +13141,13 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
 
 #define MAX_WAVESIZE 128
 
-#define strinfigy2(arg) #arg
-#define strinfigy(arg) strinfigy2(arg)
+#define stringify2(arg) #arg
+#define stringify(arg) stringify2(arg)
 
-void ExecutionTest::WaveSizeTest() {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-
-  CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6)) {
-    return;
-  }
-
-  // Check Wave support
-  if (!DoesDeviceSupportWaveOps(pDevice)) {
-    // Optional feature, so it's correct to not support it if declared as such.
-    WEX::Logging::Log::Comment(L"Device does not support wave operations.");
-    return;
-  }
-
-  // Get supported wave sizes
-  D3D12_FEATURE_DATA_D3D12_OPTIONS1 waveOpts;
-  VERIFY_SUCCEEDED(
-      pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS1,
-                                   &waveOpts, sizeof(waveOpts)));
-  UINT minWaveSize = waveOpts.WaveLaneCountMin;
-  UINT maxWaveSize = waveOpts.WaveLaneCountMax;
-
-  DXASSERT_NOMSG(minWaveSize <= maxWaveSize);
-  DXASSERT((minWaveSize & (minWaveSize - 1)) == 0, "must be a power of 2");
-  DXASSERT((maxWaveSize & (maxWaveSize - 1)) == 0, "must be a power of 2");
-
-  // read shader config
-  CComPtr<IStream> pStream;
-  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
-      std::make_shared<st::ShaderOpSet>();
-  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
-  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
-
+void RunWaveSizeTest(UINT minWaveSize, UINT maxWaveSize,
+                     std::shared_ptr<st::ShaderOpSet> ShaderOpSet,
+                     CComPtr<ID3D12Device> pDevice,
+                     dxc::DxcDllSupport &m_support) {
   // format shader source
   const char waveSizeTestShader[] =
       "struct TestData { \r\n"
@@ -13188,7 +13157,7 @@ void ExecutionTest::WaveSizeTest() {
       "\r\n"
       "// Note: WAVESIZE will be defined via compiler option -D\r\n"
       "[wavesize(WAVESIZE)]\r\n"
-      "[numthreads(" strinfigy(
+      "[numthreads(" stringify(
           MAX_WAVESIZE) "*2,1,1)]\r\n"
                         "void main(uint3 tid : SV_DispatchThreadID ) { \r\n"
                         "  data[tid.x].count = WaveActiveSum(1); \r\n"
@@ -13234,6 +13203,163 @@ void ExecutionTest::WaveSizeTest() {
         break;
     }
   }
+}
+
+bool TestShaderRangeAgainstRequirements(UINT shaderminws, UINT shadermaxws,
+                                        UINT minws, UINT maxws) {
+  if (shaderminws > maxws) {
+    return false;
+  }
+  if (shadermaxws < minws) {
+    return false;
+  }
+  return true;
+}
+
+void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
+                          std::shared_ptr<st::ShaderOpSet> ShaderOpSet,
+                          CComPtr<ID3D12Device> pDevice,
+                          dxc::DxcDllSupport &m_support) {
+  // format shader source
+  const char waveSizeTestShader[] =
+      "struct TestData { \r\n"
+      "  uint count; \r\n"
+      "}; \r\n"
+      "RWStructuredBuffer<TestData> data : register(u0); \r\n"
+      "\r\n"
+      "// Note: The 3 WAVESIZE variables below will be defined via compiler "
+      "option -D\r\n"
+      "[wavesize(MINWAVESIZE, MAXWAVESIZE, PREFWAVESIZE)]\r\n"
+      "[numthreads(" stringify(MAX_WAVESIZE) "*2,1,1)]\r\n"
+                                             "void main(uint3 tid : "
+                                             "SV_DispatchThreadID ) { \r\n"
+                                             "  data[tid.x].count = "
+                                             "WaveActiveSum(1); \r\n" // TODO:
+                                                                      // Use
+                                                                      // WaveGetLaneCount()
+                                                                      // instead
+                                             "}\r\n";
+
+  struct WaveSizeTestData {
+    uint32_t count;
+  };
+
+  for (UINT minShaderWaveSize = 4; minShaderWaveSize <= maxWaveSize;
+       minShaderWaveSize *= 2) {
+    for (UINT maxShaderWaveSize = minShaderWaveSize * 2;
+         maxShaderWaveSize <= 128; minShaderWaveSize *= 2) {
+      for (UINT prefShaderWaveSize = minShaderWaveSize;
+           prefShaderWaveSize <= maxShaderWaveSize; prefShaderWaveSize *= 2) {
+        // format compiler args
+        char compilerOptions[64];
+        VERIFY_IS_TRUE(
+            sprintf_s(compilerOptions, sizeof(compilerOptions),
+                      "-D MINWAVESIZE=%d -D MAXWAVESIZE=%d -D PREFWAVESIZE=%d",
+                      minShaderWaveSize, maxShaderWaveSize,
+                      prefShaderWaveSize) != -1);
+
+        // run the shader
+        std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
+            pDevice, m_support, "WaveSizeTest",
+            [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+              VERIFY_IS_TRUE((0 == strncmp(Name, "UAVBuffer0", 10)));
+              pShaderOp->Shaders.at(0).Arguments = compilerOptions;
+              pShaderOp->Shaders.at(0).Text = waveSizeTestShader;
+
+              VERIFY_IS_TRUE(sizeof(WaveSizeTestData) * MAX_WAVESIZE <=
+                             Data.size());
+              WaveSizeTestData *pInData = (WaveSizeTestData *)Data.data();
+              memset(pInData, 0, sizeof(WaveSizeTestData) * MAX_WAVESIZE);
+            },
+            ShaderOpSet);
+
+        // verify expected values
+        MappedData dataUav;
+        WaveSizeTestData *pOutData;
+
+        LogCommentFmt(
+            L"Verifying test result for these shader wave size ranges:");
+        LogCommentFmt(L"Minimum shader wave size: %d", minShaderWaveSize);
+        LogCommentFmt(L"Maximum shader wave size: %d", maxShaderWaveSize);
+        LogCommentFmt(L"Preferred shader wave size: %d", prefShaderWaveSize);
+
+        bool AcceptedByRuntime = TestShaderRangeAgainstRequirements(
+            minShaderWaveSize, maxShaderWaveSize, minWaveSize, maxWaveSize);
+        if (AcceptedByRuntime) {
+
+          test->Test->GetReadBackData("UAVBuffer0", &dataUav);
+          VERIFY_ARE_EQUAL(sizeof(WaveSizeTestData) * MAX_WAVESIZE,
+                           dataUav.size());
+          pOutData = (WaveSizeTestData *)dataUav.data();
+
+          for (unsigned i = 0; i < MAX_WAVESIZE; i++) {
+            if (!VERIFY_IS_TRUE(pOutData[i].count >= minWaveSize &&
+                                pOutData[i].count <= maxWaveSize))
+              break;
+            if (prefShaderWaveSize >= minWaveSize &&
+                prefShaderWaveSize <= maxWaveSize) {
+
+              if (!VERIFY_ARE_EQUAL(pOutData[i].count, prefShaderWaveSize))
+                break;
+            }
+          }
+        } else {
+          VERIFY_ARE_EQUAL(0u, dataUav.size());
+        }
+      }
+    }
+  }
+}
+
+void ExecutionTest::WaveSizeTest() {
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+  CComPtr<ID3D12Device> pDevice;
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6)) {
+    return;
+  }
+
+  // Check Wave support
+  if (!DoesDeviceSupportWaveOps(pDevice)) {
+    // Optional feature, so it's correct to not support it if declared as such.
+    WEX::Logging::Log::Comment(L"Device does not support wave operations.");
+    return;
+  }
+
+  // Get supported wave sizes
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 waveOpts;
+  VERIFY_SUCCEEDED(
+      pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS1,
+                                   &waveOpts, sizeof(waveOpts)));
+  UINT minWaveSize = waveOpts.WaveLaneCountMin;
+  UINT maxWaveSize = waveOpts.WaveLaneCountMax;
+
+  DXASSERT_NOMSG(minWaveSize <= maxWaveSize);
+  DXASSERT((minWaveSize & (minWaveSize - 1)) == 0, "must be a power of 2");
+  DXASSERT((maxWaveSize & (maxWaveSize - 1)) == 0, "must be a power of 2");
+
+  // read shader config
+  CComPtr<IStream> pStream;
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+      std::make_shared<st::ShaderOpSet>();
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+
+  RunWaveSizeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support);
+  pDevice.Release();
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_8)) {
+    return;
+  }
+
+  // Check Wave support
+  if (!DoesDeviceSupportWaveOps(pDevice)) {
+    // Optional feature, so it's correct to not support it if declared as such.
+    WEX::Logging::Log::Comment(L"Device does not support wave operations.");
+    return;
+  }
+  RunWaveSizeRangeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice,
+                       m_support);
 }
 
 // Atomic operation testing

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -13230,15 +13230,16 @@ void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
       "// Note: The 3 WAVESIZE variables below will be defined via compiler "
       "option -D\r\n"
       "[wavesize(MINWAVESIZE, MAXWAVESIZE, PREFWAVESIZE)]\r\n"
-      "[numthreads(" stringify(MAX_WAVESIZE) "*2,1,1)]\r\n"
-                                             "void main(uint3 tid : "
-                                             "SV_DispatchThreadID ) { \r\n"
-                                             "  data[tid.x].count = "
-                                             "WaveActiveSum(1); \r\n" // TODO:
-                                                                      // Use
-                                                                      // WaveGetLaneCount()
-                                                                      // instead
-                                             "}\r\n";
+      "[numthreads(" stringify(
+          MAX_WAVESIZE) "*2,1,1)]\r\n"
+                        "void main(uint3 tid : "
+                        "SV_DispatchThreadID ) { \r\n"
+                        "  data[tid.x].count = "
+                        "WaveActiveSum(1); \r\n" // TODO:
+                                                 // Use
+                                                 // WaveGetLaneCount()
+                                                 // instead
+                        "}\r\n";
 
   struct WaveSizeTestData {
     uint32_t count;

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -2487,7 +2487,7 @@
       </RootValues>
       <Shader Name="CS" Target="cs_6_6">
           <![CDATA[// Shader source code will be set at runtime]]>
-      </Shader>      
+      </Shader>
   </ShaderOp>>
 
   <ShaderOp Name="PackUnpackOp" CS="CS" DispatchX="1" DispatchY="1">

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -2489,17 +2489,6 @@
           <![CDATA[// Shader source code will be set at runtime]]>
       </Shader>      
   </ShaderOp>>
-  
-  <ShaderOp Name="WaveSizeRangeTest" CS="CS">
-      <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
-      <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="512" InitialResourceState="COPY_DEST" Init="ByName" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS" ReadBack="true" Format="R32_TYPELESS" />
-      <RootValues>
-          <RootValue Index="0" ResName="UAVBuffer0" />
-      </RootValues>    
-      <Shader Name="CS" Target="cs_6_8">
-          <![CDATA[// Shader source code will be set at runtime]]>
-      </Shader>
-  </ShaderOp>>
 
   <ShaderOp Name="PackUnpackOp" CS="CS" DispatchX="1" DispatchY="1">
     <RootSignature>RootFlags(0), UAV(u0), UAV(u1), UAV(u2)</RootSignature>

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -2487,6 +2487,17 @@
       </RootValues>
       <Shader Name="CS" Target="cs_6_6">
           <![CDATA[// Shader source code will be set at runtime]]>
+      </Shader>      
+  </ShaderOp>>
+  
+  <ShaderOp Name="WaveSizeRangeTest" CS="CS">
+      <RootSignature>RootFlags(0), UAV(u0)</RootSignature>
+      <Resource Name="UAVBuffer0" Dimension="BUFFER" Width="512" InitialResourceState="COPY_DEST" Init="ByName" Flags="ALLOW_UNORDERED_ACCESS" TransitionTo="UNORDERED_ACCESS" ReadBack="true" Format="R32_TYPELESS" />
+      <RootValues>
+          <RootValue Index="0" ResName="UAVBuffer0" />
+      </RootValues>    
+      <Shader Name="CS" Target="cs_6_8">
+          <![CDATA[// Shader source code will be set at runtime]]>
       </Shader>
   </ShaderOp>>
 


### PR DESCRIPTION
This PR adds execution testing to wave range size attributes, on top of the already existing WaveSizeTest HLK test.
It implements the necessary coverage of the new wave range size attribute, as described in the hlsl-specs here: https://github.com/microsoft/hlsl-specs/blob/main/proposals/0013-wave-size-range.md#execution-testing
Fixes #6347 