### PR TITLE
[Sema] Allow int arguments for attributes to be enum values

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12334,7 +12334,7 @@ static int ValidateAttributeIntArg(Sema &S, const AttributeList &Attr,
     } else {
       if (ArgNum.isInt()) {
         value = ArgNum.getInt().getSExtValue();
-        if (!(E->getType()->isIntegralType(S.Context)) || value < 0) {
+        if (!(E->getType()->isIntegralOrEnumerationType()) || value < 0) {
           S.Diag(Attr.getLoc(), diag::warn_hlsl_attribute_expects_uint_literal)
               << Attr.getName();
         }

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.builtin.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.builtin.enum.hlsl
@@ -1,0 +1,19 @@
+// RUN: %dxc -T cs_6_0 -E main -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+// CHECK-NOT: warning
+// CHECK: OpDecorate %gl_HelperInvocation BuiltIn HelperInvocation
+
+enum class BuiltIn {
+  HelperInvocation = 23
+};
+
+[[vk::ext_builtin_input(BuiltIn::HelperInvocation)]]
+static const bool gl_HelperInvocation;
+
+uint square_x(uint3 v) {
+  return v.x * v.x;
+}
+
+[numthreads(32,1,1)]
+void main() {
+}

--- a/tools/clang/test/CodeGenSPIRV/spv.inline.builtin.enum.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/spv.inline.builtin.enum.hlsl
@@ -1,7 +1,6 @@
-// RUN: %dxc -T cs_6_0 -E main -fcgl  %s -spirv 2>&1 | FileCheck %s
+// RUN: %dxc -T cs_6_0 -E main -fcgl  %s -spirv -verify
 
-// CHECK-NOT: warning
-// CHECK: OpDecorate %gl_HelperInvocation BuiltIn HelperInvocation
+// expected-no-diagnostics
 
 enum class BuiltIn {
   HelperInvocation = 23


### PR DESCRIPTION
The SPIR-V backend uses `ValidateAttributeIntArg` for the `vk::ext_builtin_input` and `vk::ext_builtin_output` attrs, as well as some others. It is convenient for users to be able to pass in an enum value to this attribute, for example:

```
enum class BuiltIn {
  HelperInvocation = 23
};

[[vk::ext_builtin_input(BuiltIn::HelperInvocation)]]
static const bool gl_HelperInvocation;
```

If you think `ValidateAttributeIntArg` *should* warn if a user passes in an enum value, I'll create a separate function for validating `vk::ext_builtin_input` instead.

Fixes #6337