### PR TITLE
[ExecutionTest] Add Wave Range Size HLK Tests (#6348)

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -328,6 +328,7 @@ public:
   TEST_METHOD(WaveIntrinsicsDDITest);
   TEST_METHOD(WaveIntrinsicsInPSTest);
   TEST_METHOD(WaveSizeTest);
+  TEST_METHOD(WaveSizeRangeTest);
   TEST_METHOD(PartialDerivTest);
   TEST_METHOD(DerivativesTest);
   TEST_METHOD(ComputeSampleTest);
@@ -13220,58 +13221,26 @@ TEST_F(ExecutionTest, DynamicResourcesDynamicIndexingTest) {
 
 #define MAX_WAVESIZE 128
 
-#define strinfigy2(arg) #arg
-#define strinfigy(arg) strinfigy2(arg)
+#define stringify2(arg) #arg
+#define stringify(arg) stringify2(arg)
 
-void ExecutionTest::WaveSizeTest() {
-  WEX::TestExecution::SetVerifyOutput verifySettings(
-      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
-
-  CComPtr<ID3D12Device> pDevice;
-  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6)) {
-    return;
-  }
-
-  // Check Wave support
-  if (!DoesDeviceSupportWaveOps(pDevice)) {
-    // Optional feature, so it's correct to not support it if declared as such.
-    WEX::Logging::Log::Comment(L"Device does not support wave operations.");
-    return;
-  }
-
-  // Get supported wave sizes
-  D3D12_FEATURE_DATA_D3D12_OPTIONS1 waveOpts;
-  VERIFY_SUCCEEDED(
-      pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS1,
-                                   &waveOpts, sizeof(waveOpts)));
-  UINT minWaveSize = waveOpts.WaveLaneCountMin;
-  UINT maxWaveSize = waveOpts.WaveLaneCountMax;
-
-  DXASSERT_NOMSG(minWaveSize <= maxWaveSize);
-  DXASSERT((minWaveSize & (minWaveSize - 1)) == 0, "must be a power of 2");
-  DXASSERT((maxWaveSize & (maxWaveSize - 1)) == 0, "must be a power of 2");
-
-  // read shader config
-  CComPtr<IStream> pStream;
-  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
-      std::make_shared<st::ShaderOpSet>();
-  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
-  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
-
+void RunWaveSizeTest(UINT minWaveSize, UINT maxWaveSize,
+                     std::shared_ptr<st::ShaderOpSet> ShaderOpSet,
+                     CComPtr<ID3D12Device> pDevice,
+                     dxc::DxcDllSupport &m_support) {
   // format shader source
   const char waveSizeTestShader[] =
-      "struct TestData { \r\n"
-      "  uint count; \r\n"
-      "}; \r\n"
-      "RWStructuredBuffer<TestData> data : register(u0); \r\n"
-      "\r\n"
-      "// Note: WAVESIZE will be defined via compiler option -D\r\n"
-      "[wavesize(WAVESIZE)]\r\n"
-      "[numthreads(" strinfigy(
-          MAX_WAVESIZE) "*2,1,1)]\r\n"
-                        "void main(uint3 tid : SV_DispatchThreadID ) { \r\n"
-                        "  data[tid.x].count = WaveActiveSum(1); \r\n"
-                        "}\r\n";
+      R"(struct TestData { 
+        uint count; 
+      };
+      RWStructuredBuffer<TestData> data : register(u0); 
+
+      // Note: WAVESIZE will be defined via compiler option -D
+      WAVE_SIZE_ATTR
+      [numthreads()" stringify(MAX_WAVESIZE) R"(*2,1,1)]
+      void main() {
+        data[0].count = WaveGetLaneCount();
+      })";
 
   struct WaveSizeTestData {
     uint32_t count;
@@ -13279,9 +13248,10 @@ void ExecutionTest::WaveSizeTest() {
 
   for (UINT waveSize = minWaveSize; waveSize <= maxWaveSize; waveSize *= 2) {
     // format compiler args
-    char compilerOptions[32];
+    char compilerOptions[64];
     VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
-                             "-D WAVESIZE=%d", waveSize) != -1);
+                             "-D WAVE_SIZE_ATTR=[wavesize(%d)]",
+                             waveSize) != -1);
 
     // run the shader
     std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
@@ -13308,11 +13278,218 @@ void ExecutionTest::WaveSizeTest() {
 
     LogCommentFmt(L"Verifying test result for wave size %d", waveSize);
 
-    for (unsigned i = 0; i < MAX_WAVESIZE; i++) {
-      if (!VERIFY_ARE_EQUAL(pOutData[i].count, waveSize))
-        break;
+    VERIFY_ARE_EQUAL(pOutData[0].count, waveSize);
+  }
+}
+
+bool TestShaderRangeAgainstRequirements(UINT shaderminws, UINT shadermaxws,
+                                        UINT minws, UINT maxws) {
+  if (shaderminws > maxws) {
+    return false;
+  }
+  if (shadermaxws < minws) {
+    return false;
+  }
+  return true;
+}
+
+void ExecuteWaveSizeRangeInstance(UINT minWaveSize, UINT maxWaveSize,
+                                  std::shared_ptr<st::ShaderOpSet> ShaderOpSet,
+                                  CComPtr<ID3D12Device> pDevice,
+                                  dxc::DxcDllSupport &m_support,
+                                  UINT minShaderWaveSize,
+                                  UINT maxShaderWaveSize,
+                                  UINT prefShaderWaveSize, bool usePreferred) {
+
+  // format shader source
+  const char waveSizeTestShader[] =
+      R"(struct TestData { 
+        uint count; 
+      };
+      RWStructuredBuffer<TestData> data : register(u0); 
+
+      // Note: WAVE_SIZE_ATTR will be defined via compiler option -D
+      WAVE_SIZE_ATTR
+      [numthreads()" stringify(MAX_WAVESIZE) R"(*2,1,1)]
+      void main(uint3 tid : SV_DispatchThreadID) {
+        if (tid.x == 0 && tid.y == 0 && tid.z == 0) {
+          data[0].count = WaveGetLaneCount();
+        }
+      })";
+
+  // format compiler args
+  char compilerOptions[64];
+  if (usePreferred) {
+    // putting spaces in between the %d's below will cause compilation issues.
+    VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
+                             "-D WAVE_SIZE_ATTR=[wavesize(%d,%d,%d)]",
+                             minShaderWaveSize, maxShaderWaveSize,
+                             prefShaderWaveSize) != -1);
+    LogCommentFmt(L"Verifying wave size range test results for (min, max, "
+                  L"preferred): (%d, %d, %d)",
+                  minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize);
+  } else {
+    VERIFY_IS_TRUE(sprintf_s(compilerOptions, sizeof(compilerOptions),
+                             "-D WAVE_SIZE_ATTR=[wavesize(%d,%d)]",
+                             minShaderWaveSize, maxShaderWaveSize) != -1);
+    LogCommentFmt(
+        L"Verifying wave size range test results for (min, max): (%d, %d)",
+        minShaderWaveSize, maxShaderWaveSize);
+  }
+
+  struct WaveSizeTestData {
+    uint32_t count;
+  };
+
+  // run the shader
+  std::shared_ptr<ShaderOpTestResult> test = RunShaderOpTestAfterParse(
+      pDevice, m_support, "WaveSizeTest",
+      [&](LPCSTR Name, std::vector<BYTE> &Data, st::ShaderOp *pShaderOp) {
+        VERIFY_IS_TRUE((0 == strncmp(Name, "UAVBuffer0", 10)));
+        pShaderOp->Shaders.at(0).Arguments = compilerOptions;
+        pShaderOp->Shaders.at(0).Text = waveSizeTestShader;
+        pShaderOp->Shaders.at(0).Target = "cs_6_8";
+
+        VERIFY_IS_TRUE(sizeof(WaveSizeTestData) * MAX_WAVESIZE <= Data.size());
+        WaveSizeTestData *pInData = (WaveSizeTestData *)Data.data();
+        memset(pInData, 0, sizeof(WaveSizeTestData) * MAX_WAVESIZE);
+      },
+      ShaderOpSet);
+
+  // verify expected values
+  MappedData dataUav;
+  WaveSizeTestData *pOutData;
+
+  // at this point we assume that the waverange size that
+  // the shader specifies is legal.
+  test->Test->GetReadBackData("UAVBuffer0", &dataUav);
+  VERIFY_ARE_EQUAL(sizeof(WaveSizeTestData) * MAX_WAVESIZE, dataUav.size());
+  pOutData = (WaveSizeTestData *)dataUav.data();
+
+  unsigned count = pOutData[0].count;
+  if (usePreferred && prefShaderWaveSize >= minWaveSize &&
+      prefShaderWaveSize <= maxWaveSize) {
+    VERIFY_ARE_EQUAL(count, prefShaderWaveSize);
+  } else {
+    VERIFY_IS_GREATER_THAN_OR_EQUAL(count, minWaveSize);
+    VERIFY_IS_LESS_THAN_OR_EQUAL(count, maxWaveSize);
+  }
+}
+
+void RunWaveSizeRangeTest(UINT minWaveSize, UINT maxWaveSize,
+                          std::shared_ptr<st::ShaderOpSet> ShaderOpSet,
+                          CComPtr<ID3D12Device> pDevice,
+                          dxc::DxcDllSupport &m_support) {
+
+  for (UINT minShaderWaveSize = 4; minShaderWaveSize <= maxWaveSize;
+       minShaderWaveSize *= 2) {
+    for (UINT maxShaderWaveSize = minShaderWaveSize * 2;
+         maxShaderWaveSize <= 128; maxShaderWaveSize *= 2) {
+      // Only allow valid shader wave ranges
+      bool AcceptedByRuntime = TestShaderRangeAgainstRequirements(
+          minShaderWaveSize, maxShaderWaveSize, minWaveSize, maxWaveSize);
+      if (!AcceptedByRuntime) {
+        continue;
+      }
+
+      ExecuteWaveSizeRangeInstance(
+          minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support,
+          minShaderWaveSize, maxShaderWaveSize,
+          /* prefShaderWaveSize won't be used, so set it to minShaderWaveSize*/
+          minShaderWaveSize, false);
+
+      for (UINT prefShaderWaveSize = minShaderWaveSize;
+           prefShaderWaveSize <= maxShaderWaveSize; prefShaderWaveSize *= 2) {
+
+        ExecuteWaveSizeRangeInstance(
+            minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support,
+            minShaderWaveSize, maxShaderWaveSize, prefShaderWaveSize, true);
+      }
     }
   }
+}
+
+void ExecutionTest::WaveSizeTest() {
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+  CComPtr<ID3D12Device> pDevice;
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_6,
+                    /*skipUnsupported*/ false)) {
+    return;
+  }
+
+  // Check Wave support
+  if (!DoesDeviceSupportWaveOps(pDevice)) {
+    // Optional feature, so it's correct to not support it if declared as such.
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+
+  // Get supported wave sizes
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 waveOpts;
+  VERIFY_SUCCEEDED(
+      pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS1,
+                                   &waveOpts, sizeof(waveOpts)));
+  UINT minWaveSize = waveOpts.WaveLaneCountMin;
+  UINT maxWaveSize = waveOpts.WaveLaneCountMax;
+
+  DXASSERT_NOMSG(minWaveSize <= maxWaveSize);
+  DXASSERT((minWaveSize & (minWaveSize - 1)) == 0, "must be a power of 2");
+  DXASSERT((maxWaveSize & (maxWaveSize - 1)) == 0, "must be a power of 2");
+
+  // read shader config
+  CComPtr<IStream> pStream;
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+      std::make_shared<st::ShaderOpSet>();
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+
+  LogCommentFmt(L"Testing WaveSize attribute for shader model 6.6.");
+  RunWaveSizeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support);
+}
+
+void ExecutionTest::WaveSizeRangeTest() {
+  WEX::TestExecution::SetVerifyOutput verifySettings(
+      WEX::TestExecution::VerifyOutputSettings::LogOnlyFailures);
+
+  CComPtr<ID3D12Device> pDevice;
+  if (!CreateDevice(&pDevice, D3D_SHADER_MODEL_6_8,
+                    /*skipUnsupported*/ false)) {
+    return;
+  }
+
+  // Check Wave support
+  if (!DoesDeviceSupportWaveOps(pDevice)) {
+    // Optional feature, so it's correct to not support it if declared as such.
+    WEX::Logging::Log::Result(WEX::Logging::TestResults::Skipped);
+    return;
+  }
+
+  // Get supported wave sizes
+  D3D12_FEATURE_DATA_D3D12_OPTIONS1 waveOpts;
+  VERIFY_SUCCEEDED(
+      pDevice->CheckFeatureSupport((D3D12_FEATURE)D3D12_FEATURE_D3D12_OPTIONS1,
+                                   &waveOpts, sizeof(waveOpts)));
+  UINT minWaveSize = waveOpts.WaveLaneCountMin;
+  UINT maxWaveSize = waveOpts.WaveLaneCountMax;
+
+  DXASSERT_NOMSG(minWaveSize <= maxWaveSize);
+  DXASSERT((minWaveSize & (minWaveSize - 1)) == 0, "must be a power of 2");
+  DXASSERT((maxWaveSize & (maxWaveSize - 1)) == 0, "must be a power of 2");
+
+  // read shader config
+  CComPtr<IStream> pStream;
+  std::shared_ptr<st::ShaderOpSet> ShaderOpSet =
+      std::make_shared<st::ShaderOpSet>();
+  ReadHlslDataIntoNewStream(L"ShaderOpArith.xml", &pStream);
+  st::ParseShaderOpSetFromStream(pStream, ShaderOpSet.get());
+
+  LogCommentFmt(L"Testing WaveSize Range attribute for shader model 6.8.");
+  RunWaveSizeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice, m_support);
+
+  RunWaveSizeRangeTest(minWaveSize, maxWaveSize, ShaderOpSet, pDevice,
+                       m_support);
 }
 
 // Atomic operation testing


### PR DESCRIPTION
This PR adds execution testing to wave range size attributes, on top of the already existing WaveSizeTest HLK test.
It implements the necessary coverage of the new wave range size attribute, as described in the hlsl-specs here:
https://github.com/microsoft/hlsl-specs/blob/main/proposals/0013-wave-size-range.md#execution-testing Fixes #6347

---------

Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
(cherry picked from commit b6b6b6d903aaae840aebf0779061359969e28a30)