### PR TITLE
sema: check input patch size mismatch earlier.

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7834,6 +7834,8 @@ def err_hlsl_missing_patch_constant_function : Error<
     "patch constant function '%0' must be defined">;
 def err_hlsl_patch_reachability_not_allowed : Error<
     "%select{patch constant|entry}0 function '%1' should not be reachable from %select{patch constant|entry}2 function '%3'">;
+def err_hlsl_patch_input_size_mismatch : Error<
+    "Patch constant function's input patch input should have %0 elements, but has %1.">;
 def warn_hlsl_structurize_exits_lifetime_markers_conflict : Warning <
    "structurize-returns skipped function '%0' due to incompatibility with lifetime markers. Use -disable-lifetime-markers to enable structurize-exits on this function.">,
   InGroup< HLSLStructurizeExitsLifetimeMarkersConflict >;

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -1496,18 +1496,6 @@ void SetPatchConstantFunctionWithAttr(
   if (patchConstantFunctionPropsMap.count(patchConstFunc)) {
     const DxilFunctionProps &patchProps =
         *patchConstantFunctionPropsMap[patchConstFunc];
-    if (patchProps.ShaderProps.HS.inputControlPoints != 0 &&
-        patchProps.ShaderProps.HS.inputControlPoints !=
-            HSProps->ShaderProps.HS.inputControlPoints) {
-      clang::DiagnosticsEngine &Diags = CGM.getDiags();
-      unsigned DiagID =
-          Diags.getCustomDiagID(clang::DiagnosticsEngine::Error,
-                                "Patch constant function's input patch input "
-                                "should have %0 elements, but has %1.");
-      Diags.Report(Entry->second.SL, DiagID)
-          << HSProps->ShaderProps.HS.inputControlPoints
-          << patchProps.ShaderProps.HS.inputControlPoints;
-    }
     if (patchProps.ShaderProps.HS.outputControlPoints != 0 &&
         patchProps.ShaderProps.HS.outputControlPoints !=
             HSProps->ShaderProps.HS.outputControlPoints) {

--- a/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
@@ -1,0 +1,23 @@
+// RUN: not %dxc -T hs_6_0 -E main %s -spirv 2>&1 | FileCheck %s
+
+// CHECK: 12:1: error: Patch constant function's input patch input should have 3 elements, but has 2.
+
+struct ControlPoint { float4 position : POSITION; };
+
+struct HullPatchOut {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+HullPatchOut HullConst (InputPatch<ControlPoint,2> v) {
+  return (HullPatchOut)0;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+[outputcontrolpoints(0)]
+ControlPoint main(InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) {
+  return v[id];
+}

--- a/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
@@ -1,6 +1,5 @@
-// RUN: not %dxc -T hs_6_0 -E main %s -spirv 2>&1 | FileCheck %s
+// RUN: %dxc -T hs_6_0 -E main %s -spirv -verify
 
-// CHECK: 12:1: error: Patch constant function's input patch input should have 3 elements, but has 2.
 
 struct ControlPoint { float4 position : POSITION; };
 
@@ -9,7 +8,7 @@ struct HullPatchOut {
     float inside : SV_InsideTessFactor;
 };
 
-HullPatchOut HullConst (InputPatch<ControlPoint,2> v) {
+HullPatchOut HullConst (InputPatch<ControlPoint,2> v) { /* expected-error{{Patch constant function's input patch input should have 3 elements, but has 2.}} */
   return (HullPatchOut)0;
 }
 

--- a/tools/clang/test/HLSLFileCheck/samples/SimpleHs12.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/SimpleHs12.hlsl
@@ -1,6 +1,7 @@
 // RUN: %dxc -E main -T hs_6_0  %s | FileCheck %s
 
-// CHECK-DAG: Patch constant function's input patch input should have 3 elements, but has 12.
+// CHECK-DAG: Patch Constant function HSPerPatchFunc should not have inout param
+// CHECK-DAG: Patch constant function's output patch input should have 3 elements, but has 5.
 
 //--------------------------------------------------------------------------------------
 // SimpleTessellation.hlsl
@@ -44,7 +45,7 @@ float4 HSPerPatchFunc()
     return 1.8;
 }
 
-HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 12 > points, OutputPatch<HSPerVertexData, 3> outp)
+HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 12 > points, OutputPatch<HSPerVertexData, 5> outp, inout float x)
 {
     HSPerPatchData d;
 
@@ -63,7 +64,7 @@ HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 12 > points, OutputP
 [patchconstantfunc("HSPerPatchFunc")]
 [outputcontrolpoints(3)]
 HSPerVertexData main(const uint id : SV_OutputControlPointID,
-                     const InputPatch< PSSceneIn, 3 > points )
+                      const InputPatch< PSSceneIn, 12 > points )
 {
     HSPerVertexData v;
 
@@ -72,3 +73,4 @@ HSPerVertexData main(const uint id : SV_OutputControlPointID,
 
 	return v;
 }
+


### PR DESCRIPTION
The check was done in the DXIL backend, and not in the SPIR-V backend. This causes the issue to be ignored on the SPIR-V side. Moved the check earlier to SEMA so a single check works for both backends.

I had to split the existing HLSL check as it doesn't support having 2 run lines (AFAIK).

Fixes #3739