### PR TITLE
[SPIR-V] Allow arbitrary exprs in ReportHit

### DIFF
--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.cpp
@@ -4523,14 +4523,19 @@ bool DeclResultIdMapper::getImplicitRegisterType(const ResourceVar &var,
 SpirvVariable *
 DeclResultIdMapper::createRayTracingNVStageVar(spv::StorageClass sc,
                                                const VarDecl *decl) {
-  QualType type = decl->getType();
+  return createRayTracingNVStageVar(sc, decl->getType(), decl->getName().str(),
+                                    decl->hasAttr<HLSLPreciseAttr>(),
+                                    decl->hasAttr<HLSLNoInterpolationAttr>());
+}
+
+SpirvVariable *DeclResultIdMapper::createRayTracingNVStageVar(
+    spv::StorageClass sc, QualType type, std::string name, bool isPrecise,
+    bool isNointerp) {
   SpirvVariable *retVal = nullptr;
 
   // Raytracing interface variables are special since they do not participate
   // in any interface matching and hence do not create StageVar and
   // track them under StageVars vector
-
-  const auto name = decl->getName();
 
   switch (sc) {
   case spv::StorageClass::IncomingRayPayloadNV:
@@ -4538,9 +4543,7 @@ DeclResultIdMapper::createRayTracingNVStageVar(spv::StorageClass sc,
   case spv::StorageClass::HitAttributeNV:
   case spv::StorageClass::RayPayloadNV:
   case spv::StorageClass::CallableDataNV:
-    retVal = spvBuilder.addModuleVar(type, sc, decl->hasAttr<HLSLPreciseAttr>(),
-                                     decl->hasAttr<HLSLNoInterpolationAttr>(),
-                                     name.str());
+    retVal = spvBuilder.addModuleVar(type, sc, isPrecise, isNointerp, name);
     break;
 
   default:

--- a/tools/clang/lib/SPIRV/DeclResultIdMapper.h
+++ b/tools/clang/lib/SPIRV/DeclResultIdMapper.h
@@ -236,6 +236,9 @@ public:
   /// \brief Creates stage variables for raytracing.
   SpirvVariable *createRayTracingNVStageVar(spv::StorageClass sc,
                                             const VarDecl *decl);
+  SpirvVariable *createRayTracingNVStageVar(spv::StorageClass sc, QualType type,
+                                            std::string name, bool isPrecise,
+                                            bool isNointerp);
 
   /// \brief Creates the taskNV stage variables for payload struct variable
   /// and returns true on success. SPIR-V instructions will also be generated

--- a/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/raytracing.nv.intersection.hlsl
@@ -20,6 +20,10 @@ struct Attribute
   float2 bary;
 };
 
+Attribute CreateAttribute() {
+    return Attribute(float2(0.0f,0.0f));
+}
+
 [shader("intersection")]
 void main() {
 
@@ -59,4 +63,8 @@ void main() {
   Attribute myHitAttribute = { float2(0.0f,0.0f) };
 // CHECK: OpReportIntersectionKHR %bool %float_0 %uint_0
   ReportHit(0.0f, 0U, myHitAttribute);
+// CHECK: OpReportIntersectionKHR %bool %float_0 %uint_1
+  ReportHit(0.0f, 1U, CreateAttribute());
+// CHECK: OpReportIntersectionKHR %bool %float_0 %uint_2
+  ReportHit(0.0f, 2U, Attribute(float2(0.0f,0.0f)));
 }


### PR DESCRIPTION
ReportHit was limited to only accepting variable references as the hit attribute in ReportHit calls. This change removes that limitation to allow arbitrary Expr types.

I've also added a TODO follow up for some existing logic that I've kept the same but want to further investigate.

Fixes #5709