### PR TITLE
Fix auto-dxilver logic in FileCheckerTest

### DIFF
--- a/tools/clang/test/HLSLFileCheck/infra/auto-dxilver.hlsl
+++ b/tools/clang/test/HLSLFileCheck/infra/auto-dxilver.hlsl
@@ -1,0 +1,28 @@
+// Make sure each run line either works, or implicitly requires dxilver 1.8.
+// If an implicit dxilver check is missing, we should see one of these errors.
+
+// RUN: %dxc -T vs_6_8 %s | FileCheck %s
+// This should implicitly require dxilver 1.8.
+
+// RUN: %dxc -T vs_6_8 -Vd %s | FileCheck %s
+// Even though this is using -Vd, the validator version is set by the available
+// validator.  If that isn't version 1.8 or above, we'll see an error.
+// The implicit dxilver logic should not skip the check when -Vd is used.
+// CHECK-NOT: error: validator version {{.*}} does not support target profile.
+
+// RUN: %dxc -T vs_6_0 -validator-version 1.8 %s | FileCheck %s
+// Even though target is 6.0, the explicit -validator-version should add an
+// implicit dxilver 1.8 requirement.
+// CHECK-NOT: error: The module cannot be validated by the version of the validator currently attached.
+
+// This error would occur if run against wrong compiler.
+// CHECK-NOT: error: invalid profile
+
+// Catch any other unexpected error cases.
+// CHECK-NOT: error
+
+// RUN: %dxc -T vs_6_8 -select-validator internal %s | FileCheck %s
+// This should always be run, and always succeed.
+// CHECK: define void @main()
+
+void main() {}


### PR DESCRIPTION
In FileCheckerTest.cpp, the -T target of a %dxc part is checked for compatibility. However, if you use -Vd, it skips the version check for the validator. This isn't quite right since the validator version will be set from the attached validator, unless you explicitly set -validator-version or use -select-validator internal. Also, if -validator-version is explicitly set, we should check the validator against that version, not just the one based on shader model.

This change fixes the initial check logic to only skip validator check when using -select-validator internal or -validator-version. It also checks against an explicitly requested -validator-version when an external validator will be used.

Fixes #6367