### PR TITLE
Add dxilver to tests using -Vd to work around auto-dxilver bug (#6369)

### DIFF
--- a/tools/clang/test/HLSLFileCheck/validation/callgraph/barrier-group-in-nested-fn-vs-lib68.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/callgraph/barrier-group-in-nested-fn-vs-lib68.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_8 -Vd %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
+// RUN: %dxilver 1.8 | %dxc -T lib_6_8 -Vd %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
 
 // Verifies that a Barrier requiring a visible group in a noinline function
 // called by a vertex shader is correctly marked as requiring a group in RDAT.

--- a/tools/clang/test/HLSLFileCheck/validation/callgraph/deriv-in-nested-fn-vs-lib68.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/callgraph/deriv-in-nested-fn-vs-lib68.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T lib_6_8 -Vd %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
+// RUN: %dxilver 1.8 | %dxc -T lib_6_8 -Vd %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
 
 // Check that ShaderCompatInfo in RDAT has expected flags for scenario with
 // verttex entry point calling a function using derivatives (through Sample()).


### PR DESCRIPTION
Issue #6367 identifies a problem with the auto-dxilver logic based on -T target option in %dxc part when using FileCheckerTest.cpp.

This change adds a manual %dxilver 1.8 to two tests that run into this problem, as a workaround.

(cherry picked from commit bbcbb2de14a67b5d8f4a0bff9b9db274b27b7fc5)