### PR TITLE
Add alignment to NodeRecordType including DXIL metadata update (#6279)

### DIFF
--- a/include/dxc/DXIL/DxilMetadataHelper.h
+++ b/include/dxc/DXIL/DxilMetadataHelper.h
@@ -332,6 +332,7 @@ public:
   // Node Record Type
   static const unsigned kDxilNodeRecordSizeTag = 0;
   static const unsigned kDxilNodeSVDispatchGridTag = 1;
+  static const unsigned kDxilNodeRecordAlignmentTag = 2;
 
   // GSState.
   static const unsigned kDxilGSStateNumFields = 5;
@@ -624,6 +625,7 @@ private:
                        unsigned &payloadSizeInBytes);
 
   llvm::MDTuple *EmitDxilNodeIOState(const NodeIOProperties &Node);
+  llvm::MDTuple *EmitDxilNodeRecordType(const NodeRecordType &RecordType);
   hlsl::NodeIOProperties LoadDxilNodeIOState(const llvm::MDOperand &MDO);
   hlsl::NodeRecordType LoadDxilNodeRecordType(const llvm::MDOperand &MDO);
 

--- a/include/dxc/DXIL/DxilNodeProps.h
+++ b/include/dxc/DXIL/DxilNodeProps.h
@@ -45,6 +45,7 @@ struct SVDispatchGrid {
 //
 struct NodeRecordType {
   unsigned size;
+  unsigned alignment;
   SVDispatchGrid SV_DispatchGrid;
 };
 

--- a/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
+++ b/include/dxc/DxilContainer/RDAT_LibraryTypes.inl
@@ -277,6 +277,7 @@ RDAT_ENUM_START(NodeAttribKind, uint32_t)
   RDAT_ENUM_VALUE(RecordDispatchGrid, 5)
   RDAT_ENUM_VALUE(OutputArraySize, 6)
   RDAT_ENUM_VALUE(AllowSparseNodes, 7)
+  RDAT_ENUM_VALUE(RecordAlignmentInBytes, 8)
   RDAT_ENUM_VALUE_NODEF(LastValue)
 RDAT_ENUM_END()
 
@@ -407,6 +408,10 @@ RDAT_STRUCT_TABLE(NodeShaderIOAttrib, NodeShaderIOAttribTable)
                     getAttribKind() ==
                         hlsl::RDAT::NodeAttribKind::AllowSparseNodes)
       RDAT_VALUE(uint32_t, AllowSparseNodes)
+    RDAT_UNION_ELIF(RecordAlignmentInBytes,
+                    getAttribKind() ==
+                        hlsl::RDAT::NodeAttribKind::RecordAlignmentInBytes)
+      RDAT_VALUE(uint32_t, RecordAlignmentInBytes)
     RDAT_UNION_ENDIF()
   RDAT_UNION_END()
 RDAT_STRUCT_END()

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -1967,6 +1967,7 @@ void DxilMDHelper::SerializeNodeProps(SmallVectorImpl<llvm::Metadata *> &MDVals,
         nodeinput.RecordType.SV_DispatchGrid.ComponentType)));
     MDVals.push_back(
         Uint32ToConstMD(nodeinput.RecordType.SV_DispatchGrid.NumComponents));
+    MDVals.push_back(Uint32ToConstMD(nodeinput.RecordType.alignment));
   }
   for (auto &nodeoutput : props->OutputNodes) {
     MDVals.push_back(Uint32ToConstMD(nodeoutput.Flags));
@@ -1983,6 +1984,7 @@ void DxilMDHelper::SerializeNodeProps(SmallVectorImpl<llvm::Metadata *> &MDVals,
     MDVals.push_back(Int32ToConstMD(nodeoutput.MaxRecordsSharedWith));
     MDVals.push_back(Uint32ToConstMD(nodeoutput.OutputArraySize));
     MDVals.push_back(BoolToConstMD(nodeoutput.AllowSparseNodes));
+    MDVals.push_back(Uint32ToConstMD(nodeoutput.RecordType.alignment));
   }
 }
 
@@ -2019,6 +2021,10 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
             ConstMDToUint32(pProps->getOperand(idx++)));
     nodeinput.RecordType.SV_DispatchGrid.NumComponents =
         ConstMDToUint32(pProps->getOperand(idx++));
+    if (pProps->getNumOperands() > idx) {
+      nodeinput.RecordType.alignment =
+          ConstMDToUint32(pProps->getOperand(idx++));
+    }
   }
 
   for (auto &nodeoutput : props->OutputNodes) {
@@ -2037,6 +2043,10 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
     nodeoutput.MaxRecordsSharedWith = ConstMDToInt32(pProps->getOperand(idx++));
     nodeoutput.OutputArraySize = ConstMDToUint32(pProps->getOperand(idx++));
     nodeoutput.AllowSparseNodes = ConstMDToBool(pProps->getOperand(idx++));
+    if (pProps->getNumOperands() > idx) {
+      nodeoutput.RecordType.alignment =
+          ConstMDToUint32(pProps->getOperand(idx++));
+    }
   }
 }
 
@@ -2756,6 +2766,32 @@ void DxilMDHelper::EmitDxilNodeState(std::vector<llvm::Metadata *> &MDVals,
 }
 
 llvm::MDTuple *
+DxilMDHelper::EmitDxilNodeRecordType(const NodeRecordType &RecordType) {
+  vector<Metadata *> MDVals;
+  MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeRecordSizeTag));
+  MDVals.emplace_back(Uint32ToConstMD(RecordType.size));
+
+  if (RecordType.SV_DispatchGrid.NumComponents) {
+    MDVals.emplace_back(
+        Uint32ToConstMD(DxilMDHelper::kDxilNodeSVDispatchGridTag));
+    vector<Metadata *> SVDispatchGridVals;
+    SVDispatchGridVals.emplace_back(
+        Uint32ToConstMD(RecordType.SV_DispatchGrid.ByteOffset));
+    SVDispatchGridVals.emplace_back(Uint32ToConstMD(
+        static_cast<unsigned>(RecordType.SV_DispatchGrid.ComponentType)));
+    SVDispatchGridVals.emplace_back(
+        Uint32ToConstMD(RecordType.SV_DispatchGrid.NumComponents));
+    MDVals.emplace_back(MDNode::get(m_Ctx, SVDispatchGridVals));
+  }
+  if (RecordType.alignment) {
+    MDVals.emplace_back(
+        Uint32ToConstMD(DxilMDHelper::kDxilNodeRecordAlignmentTag));
+    MDVals.emplace_back(Uint32ToConstMD(RecordType.alignment));
+  }
+  return MDNode::get(m_Ctx, MDVals);
+}
+
+llvm::MDTuple *
 DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
   vector<Metadata *> MDVals;
   MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeIOFlagsTag));
@@ -2763,24 +2799,7 @@ DxilMDHelper::EmitDxilNodeIOState(const hlsl::NodeIOProperties &Node) {
 
   if (Node.RecordType.size) {
     MDVals.emplace_back(Uint32ToConstMD(DxilMDHelper::kDxilNodeRecordTypeTag));
-    vector<Metadata *> NodeRecordTypeVals;
-    NodeRecordTypeVals.emplace_back(
-        Uint32ToConstMD(DxilMDHelper::kDxilNodeRecordSizeTag));
-    NodeRecordTypeVals.emplace_back(Uint32ToConstMD(Node.RecordType.size));
-    // If the record has a SV_DispatchGrid field
-    if (Node.RecordType.SV_DispatchGrid.NumComponents) {
-      NodeRecordTypeVals.emplace_back(
-          Uint32ToConstMD(DxilMDHelper::kDxilNodeSVDispatchGridTag));
-      vector<Metadata *> SVDispatchGridVals;
-      SVDispatchGridVals.emplace_back(
-          Uint32ToConstMD(Node.RecordType.SV_DispatchGrid.ByteOffset));
-      SVDispatchGridVals.emplace_back(Uint32ToConstMD(static_cast<unsigned>(
-          Node.RecordType.SV_DispatchGrid.ComponentType)));
-      SVDispatchGridVals.emplace_back(
-          Uint32ToConstMD(Node.RecordType.SV_DispatchGrid.NumComponents));
-      NodeRecordTypeVals.emplace_back(MDNode::get(m_Ctx, SVDispatchGridVals));
-    }
-    MDVals.emplace_back(MDNode::get(m_Ctx, NodeRecordTypeVals));
+    MDVals.emplace_back(EmitDxilNodeRecordType(Node.RecordType));
   }
 
   if (Node.Flags.IsOutputNode()) {
@@ -2855,6 +2874,9 @@ DxilMDHelper::LoadDxilNodeRecordType(const llvm::MDOperand &MDO) {
           ConstMDToUint32(pSVDTupleMD->getOperand(1)));
       Record.SV_DispatchGrid.NumComponents =
           ConstMDToUint32(pSVDTupleMD->getOperand(2));
+    } break;
+    case DxilMDHelper::kDxilNodeRecordAlignmentTag: {
+      Record.alignment = ConstMDToUint32(MDO);
     } break;
     default:
       m_bExtraMetadata = true;

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1438,6 +1438,13 @@ private:
               N.RecordType.SV_DispatchGrid.NumComponents);
           nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
         }
+
+        if (N.RecordType.alignment) {
+          nAttrib = {};
+          nAttrib.AttribKind = (uint32_t)NodeAttribKind::RecordAlignmentInBytes;
+          nAttrib.RecordAlignmentInBytes = N.RecordType.alignment;
+          nodeAttribs.push_back(Builder.InsertRecord(nAttrib));
+        }
       }
 
       ioNode.Attribs =

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -2620,8 +2620,10 @@ void CGMSHLSLRuntime::AddHLSLNodeRecordTypeInfo(
         }
 
         // Ex: For DispatchNodeInputRecord<MY_RECORD>, set size =
-        // size(MY_RECORD)
+        // size(MY_RECORD), alignment = alignof(MY_RECORD)
         node.RecordType.size = CGM.getDataLayout().getTypeAllocSize(Type);
+        node.RecordType.alignment =
+            CGM.getDataLayout().getABITypeAlignment(Type);
         // Iterate over fields of the MY_RECORD(example) struct
         for (auto fieldDecl : RD->fields()) {
           // Check if any of the fields have a semantic annotation =

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/array-in-workgraphrecord-1.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/array-in-workgraphrecord-1.hlsl
@@ -8,7 +8,7 @@
 // CHECK: ![[NodeDispatchGrid]] = !{i32 1, i32 1, i32 1}
 // CHECK: ![[NodeInputs]] = !{![[Input0:[0-9]+]]}
 // CHECK: ![[Input0]] = !{i32 1, i32 97, i32 2, ![[NodeRecordType:[0-9]+]]}
-// CHECK: ![[NodeRecordType]] = !{i32 0, i32 68}
+// CHECK: ![[NodeRecordType]] = !{i32 0, i32 68, i32 2, i32 4}
 // CHECK: ![[NumThreads]] = !{i32 32, i32 1, i32 1}
 // CHECK: ![[AutoBindingSpace]] = !{i32 0}
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/array-in-workgraphrecord-2.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/array-in-workgraphrecord-2.hlsl
@@ -8,7 +8,7 @@
 // CHECK: ![[NodeDispatchGrid]] = !{i32 1, i32 1, i32 1}
 // CHECK: ![[NodeInputs]] = !{![[Input0:[0-9]+]]}
 // CHECK: ![[Input0]] = !{i32 1, i32 97, i32 2, ![[NodeRecordType:[0-9]+]]}
-// CHECK: ![[NodeRecordType]] = !{i32 0, i32 68}
+// CHECK: ![[NodeRecordType]] = !{i32 0, i32 68, i32 2, i32 4}
 // CHECK: ![[NumThreads]] = !{i32 32, i32 1, i32 1}
 // CHECK: ![[AutoBindingSpace]] = !{i32 0}
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/node-objects-metdata.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/node-objects-metdata.hlsl
@@ -57,13 +57,13 @@ struct RECORD1
 
 //  DispatchNodeInputRecord
 
-// FCGLMD-DAG:  !{void (%"struct.DispatchNodeInputRecord<RECORD>"*)* @node_DispatchNodeInputRecord, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_DispatchNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 64, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 97, i32 0, i32 16, i32 0, i32 0, i32 0}
+// FCGLMD-DAG:  !{void (%"struct.DispatchNodeInputRecord<RECORD>"*)* @node_DispatchNodeInputRecord, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_DispatchNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 64, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 97, i32 0, i32 16, i32 0, i32 0, i32 0, i32 4}
 
 // MD: !{void ()* @node_DispatchNodeInputRecord, !"node_DispatchNodeInputRecord", null, null, ![[DispatchNodeInput:[0-9]+]]}
 // MD: ![[DispatchNodeInput]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 20, ![[EntryInputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
 // MD: ![[EntryInputs]] = !{![[EntryInputs0:[0-9]+]]}
 // MD: ![[EntryInputs0]] = !{i32 1, i32 97, i32 2, ![[EntryInputs0Record:[0-9]+]]}
-// MD: ![[EntryInputs0Record]] = !{i32 0, i32 16}
+// MD: ![[EntryInputs0Record]] = !{i32 0, i32 16, i32 2, i32 4}
 
 [Shader("node")]
 [NumThreads(1024,1,1)]
@@ -76,7 +76,7 @@ void node_DispatchNodeInputRecord(DispatchNodeInputRecord<RECORD> input)
 
 //  EmptyNodeInput
 
-// FCGLMD-DAG: !{void (%struct.EmptyNodeInput*)* @node_EmptyNodeInput, i32 15, i32 2, i32 1, i32 1, i32 2, i1 true, !"node_EmptyNodeInput", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 9, i32 0, i32 0, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%struct.EmptyNodeInput*)* @node_EmptyNodeInput, i32 15, i32 2, i32 1, i32 1, i32 2, i1 true, !"node_EmptyNodeInput", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 9, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0}
 
 // MD: !{void ()* @node_EmptyNodeInput, !"node_EmptyNodeInput", null, null, ![[EmptyNodeInput:[0-9]+]]}
 // MD: ![[EmptyNodeInput]] = !{i32 8, i32 15, i32 13, i32 2, i32 14, i1 true, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 20, ![[EntryInputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -95,7 +95,7 @@ void node_EmptyNodeInput(EmptyNodeInput input)
 
 //  EmptyNodeOutput
 
-// FCGLMD-DAG: !{void (%struct.EmptyNodeOutput*)* @node_EmptyNodeOutput, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_EmptyNodeOutput", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 10, i32 0, i32 0, i32 0, i32 0, !"loadStressChild", i32 0, i32 0, i32 -1, i32 0, i1 false}
+// FCGLMD-DAG: !{void (%struct.EmptyNodeOutput*)* @node_EmptyNodeOutput, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_EmptyNodeOutput", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 10, i32 0, i32 0, i32 0, i32 0, !"loadStressChild", i32 0, i32 0, i32 -1, i32 0, i1 false, i32 0}
 
 // MD: !{void ()* @node_EmptyNodeOutput, !"node_EmptyNodeOutput", null, null, ![[EmptyNodeOutput:[0-9]+]]}
 // MD: ![[EmptyNodeOutput]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 21, ![[EntryOutputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -121,7 +121,7 @@ void node_EmptyNodeOutput(
 
 //  EmptyNodeOutputArray
 
-// FCGLMD-DAG: !{void (%struct.EmptyNodeOutputArray*)* @node_EmptyNodeOutputArray, i32 15, i32 128, i32 1, i32 1, i32 1, i1 false, !"node_EmptyNodeOutputArray", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 26, i32 0, i32 0, i32 0, i32 0, !"EmptyOutputArray", i32 0, i32 64, i32 -1, i32 128, i1 false}
+// FCGLMD-DAG: !{void (%struct.EmptyNodeOutputArray*)* @node_EmptyNodeOutputArray, i32 15, i32 128, i32 1, i32 1, i32 1, i1 false, !"node_EmptyNodeOutputArray", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 26, i32 0, i32 0, i32 0, i32 0, !"EmptyOutputArray", i32 0, i32 64, i32 -1, i32 128, i1 false, i32 0}
 
 // MD: !{void ()* @node_EmptyNodeOutputArray, !"node_EmptyNodeOutputArray", null, null, ![[EmptyNodeOutputArray:[0-9]+]]}
 // MD: ![[EmptyNodeOutputArray]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 21, ![[EntryOutputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -145,7 +145,7 @@ void node_EmptyNodeOutputArray(
 
 //  GroupNodeInputRecords
 
-// FCGLMD-DAG: !{void (%"struct.GroupNodeInputRecords<RECORD>"*)* @node_GroupNodeInputRecords, i32 15, i32 1024, i32 1, i32 1, i32 2, i1 true, !"node_GroupNodeInputRecords", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 65, i32 256, i32 16, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%"struct.GroupNodeInputRecords<RECORD>"*)* @node_GroupNodeInputRecords, i32 15, i32 1024, i32 1, i32 1, i32 2, i1 true, !"node_GroupNodeInputRecords", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 65, i32 256, i32 16, i32 0, i32 0, i32 0, i32 4}
 
 
 // MD: !{void ()* @node_GroupNodeInputRecords, !"node_GroupNodeInputRecords", null, null, ![[GroupNodeInputRecords:[0-9]+]]}
@@ -166,13 +166,13 @@ void node_GroupNodeInputRecords([MaxRecords(256)] GroupNodeInputRecords<RECORD> 
 
 //  GroupNodeOutputRecords
 
-// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_GroupNodeOutputRecords, i32 15, i32 128, i32 1, i32 1, i32 1, i1 false, !"node_GroupNodeOutputRecords", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray", i32 0, i32 64, i32 -1, i32 128, i1 false}
+// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_GroupNodeOutputRecords, i32 15, i32 128, i32 1, i32 1, i32 1, i1 false, !"node_GroupNodeOutputRecords", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray", i32 0, i32 64, i32 -1, i32 128, i1 false, i32 4}
 
 // MD: !{void ()* @node_GroupNodeOutputRecords, !"node_GroupNodeOutputRecords", null, null, ![[GroupNodeOutputRecords:[0-9]+]]}
 // MD: ![[GroupNodeOutputRecords]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 21, ![[EntryOutputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
 // MD: ![[EntryOutputs]] = !{![[EntryOutputs0:[0-9]+]]}
 // MD: ![[EntryOutputs0]] = !{i32 1, i32 22, i32 2, ![[RecordType1:[0-9]+]], i32 3, i32 64, i32 5, i32 128, i32 0, ![[EntryOutputs0MaxRecords:[0-9]+]]}
-// MD: ![[RecordType1]] = !{i32 0, i32 8}
+// MD: ![[RecordType1]] = !{i32 0, i32 8, i32 2, i32 4}
 // MD: ![[EntryOutputs0MaxRecords]] = !{!"OutputArray", i32 0}
 
 [Shader("node")]
@@ -193,7 +193,7 @@ void node_GroupNodeOutputRecords(
 
 //  NodeOutput
 
-// FCGLMD-DAG: !{void (%"struct.NodeOutput<RECORD>"*)* @node_NodeOutput, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_NodeOutput", i32 0, !"", i32 0, i32 -1, i32 32, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 6, i32 16, i32 0, i32 0, i32 0, !"output3", i32 0, i32 0, i32 -1, i32 0, i1 false}
+// FCGLMD-DAG: !{void (%"struct.NodeOutput<RECORD>"*)* @node_NodeOutput, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_NodeOutput", i32 0, !"", i32 0, i32 -1, i32 32, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 6, i32 16, i32 0, i32 0, i32 0, !"output3", i32 0, i32 0, i32 -1, i32 0, i1 false, i32 4}
 
 // MD: !{void ()* @node_NodeOutput, !"node_NodeOutput", null, null, ![[NodeOutput:[0-9]+]]}
 // MD: ![[NodeOutput]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 21, ![[EntryOutputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -217,7 +217,7 @@ void node_NodeOutput(NodeOutput<RECORD> output3)
 
 //  NodeOutputArray
 
-// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_NodeOutputArray, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_NodeOutputArray", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true}
+// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_NodeOutputArray, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_NodeOutputArray", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true, i32 4}
 
 
 // MD: !{void ()* @node_NodeOutputArray, !"node_NodeOutputArray", null, null, ![[NodeOutputArray:[0-9]+]]}
@@ -240,7 +240,7 @@ void node_NodeOutputArray(
 
 //  RWDispatchNodeInputRecord
 
-// FCGLMD-DAG: !{void (%"struct.RWDispatchNodeInputRecord<RECORD>"*)* @node_RWDispatchNodeInputRecord, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_RWDispatchNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 16, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 101, i32 0, i32 16, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%"struct.RWDispatchNodeInputRecord<RECORD>"*)* @node_RWDispatchNodeInputRecord, i32 15, i32 1024, i32 1, i32 1, i32 1, i1 false, !"node_RWDispatchNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 16, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 101, i32 0, i32 16, i32 0, i32 0, i32 0, i32 4}
 
 
 // MD: !{void ()* @node_RWDispatchNodeInputRecord, !"node_RWDispatchNodeInputRecord", null, null, ![[RWDispatchNodeInputRecord:[0-9]+]]}
@@ -261,14 +261,14 @@ void node_RWDispatchNodeInputRecord(RWDispatchNodeInputRecord<RECORD> input)
 
 //  RWGroupNodeInputRecords
 
-// FCGLMD-DAG: !{void (%"struct.RWGroupNodeInputRecords<RECORD2>"*)* @node_RWGroupNodeInputRecords, i32 15, i32 1, i32 1, i32 1, i32 2, i1 false, !"node_RWGroupNodeInputRecords", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 69, i32 4, i32 48, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%"struct.RWGroupNodeInputRecords<RECORD2>"*)* @node_RWGroupNodeInputRecords, i32 15, i32 1, i32 1, i32 1, i32 2, i1 false, !"node_RWGroupNodeInputRecords", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 69, i32 4, i32 48, i32 0, i32 0, i32 0, i32 4}
 
 
 // MD: !{void ()* @node_RWGroupNodeInputRecords, !"node_RWGroupNodeInputRecords", null, null, ![[RWGroupNodeInputRecords:[0-9]+]]}
 // MD: ![[RWGroupNodeInputRecords]] = !{i32 8, i32 15, i32 13, i32 2, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 20, ![[EntryInputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
 // MD: ![[EntryInputs]] = !{![[EntryInputs0:[0-9]+]]}
 // MD: ![[EntryInputs0]] = !{i32 1, i32 69, i32 2, ![[RecordType2:[0-9]+]], i32 3, i32 4}
-// MD: ![[RecordType2]] = !{i32 0, i32 48}
+// MD: ![[RecordType2]] = !{i32 0, i32 48, i32 2, i32 4}
 
 struct RECORD2
 {
@@ -290,7 +290,7 @@ void node_RWGroupNodeInputRecords([MaxRecords(4)] RWGroupNodeInputRecords<RECORD
 
 //  RWThreadNodeInputRecord
 
-// FCGLMD-DAG: !{void (%"struct.RWThreadNodeInputRecord<RECORD>"*)* @node_RWThreadNodeInputRecord, i32 15, i32 1, i32 1, i32 1, i32 3, i1 false, !"node_RWThreadNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 37, i32 0, i32 16, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%"struct.RWThreadNodeInputRecord<RECORD>"*)* @node_RWThreadNodeInputRecord, i32 15, i32 1, i32 1, i32 1, i32 3, i1 false, !"node_RWThreadNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 37, i32 0, i32 16, i32 0, i32 0, i32 0, i32 4}
 
 // MD: !{void ()* @node_RWThreadNodeInputRecord, !"node_RWThreadNodeInputRecord", null, null, ![[RWThreadNodeInputRecord:[0-9]+]]}
 // MD: ![[RWThreadNodeInputRecord]] = !{i32 8, i32 15, i32 13, i32 3, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 20, ![[EntryInputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -306,7 +306,7 @@ void node_RWThreadNodeInputRecord(RWThreadNodeInputRecord<RECORD> input)
 
 //  ThreadNodeInputRecord
 
-// FCGLMD-DAG: !{void (%"struct.ThreadNodeInputRecord<RECORD>"*)* @node_ThreadNodeInputRecord, i32 15, i32 1, i32 1, i32 1, i32 3, i1 false, !"node_ThreadNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 33, i32 0, i32 16, i32 0, i32 0, i32 0}
+// FCGLMD-DAG: !{void (%"struct.ThreadNodeInputRecord<RECORD>"*)* @node_ThreadNodeInputRecord, i32 15, i32 1, i32 1, i32 1, i32 3, i1 false, !"node_ThreadNodeInputRecord", i32 0, !"", i32 0, i32 -1, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 33, i32 0, i32 16, i32 0, i32 0, i32 0, i32 4}
 
 // MD: !{void ()* @node_ThreadNodeInputRecord, !"node_ThreadNodeInputRecord", null, null, ![[ThreadNodeInputRecord:[0-9]+]]}
 // MD: ![[ThreadNodeInputRecord]] = !{i32 8, i32 15, i32 13, i32 3, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 20, ![[EntryInputs:[0-9]+]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}
@@ -323,7 +323,7 @@ void node_ThreadNodeInputRecord(ThreadNodeInputRecord<RECORD> input)
 
 //  ThreadNodeOutputRecords
 
-// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_ThreadNodeOutputRecords, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_ThreadNodeOutputRecords", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true}
+// FCGLMD-DAG: !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_ThreadNodeOutputRecords, i32 15, i32 1, i32 1, i32 1, i32 1, i1 false, !"node_ThreadNodeOutputRecords", i32 0, !"", i32 0, i32 -1, i32 1, i32 1, i32 1, i32 0, i32 0, i32 0, i32 0, i32 22, i32 8, i32 0, i32 0, i32 0, !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true, i32 4}
 
 // MD: !{void ()* @node_ThreadNodeOutputRecords, !"node_ThreadNodeOutputRecords", null, null, ![[ThreadNodeOutputRecords:[0-9]+]]}
 // MD: ![[ThreadNodeOutputRecords]] = !{i32 8, i32 15, i32 13, i32 1, i32 15, !{{[0-9]+}}, i32 16, i32 -1, i32 18, !{{[0-9]+}}, i32 21, ![[NodeOutputArrayEntryOutputs]], i32 4, !{{[0-9]+}}, i32 5, !{{[0-9]+}}}

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_broadcasting_nodes.hlsl
@@ -40,50 +40,55 @@
 // CHECK:            DispatchGrid: <4:array[3]> = { 2, 8, 10 }
 // CHECK:          }
 // CHECK:        }
-// CHECK:        Outputs: <21:RecordArrayRef<IONode>[1]>  = {
+// CHECK:        Outputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // CHECK:          [0]: <1:IONode> = {
 // CHECK:            IOFlagsAndKind: 22
-// CHECK:            Attribs: <14:RecordArrayRef<NodeShaderIOAttrib>[6]>  = {
-// CHECK:              [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[7]>  = {
+// CHECK:              [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: OutputID
 // CHECK:                OutputID: <1:NodeID> = {
 // CHECK:                  Name: "OutputyMcOutputFace"
 // CHECK:                  Index: 0
 // CHECK:                }
 // CHECK:              }
-// CHECK:              [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:              [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: OutputArraySize
 // CHECK:                OutputArraySize: 2
 // CHECK:              }
-// CHECK:              [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:              [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: MaxRecords
 // CHECK:                MaxRecords: 47
 // CHECK:              }
-// CHECK:              [3]: <4:NodeShaderIOAttrib> = {
+// CHECK:              [3]: <5:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: AllowSparseNodes
 // CHECK:                AllowSparseNodes: 1
 // CHECK:              }
-// CHECK:              [4]: <5:NodeShaderIOAttrib> = {
+// CHECK:              [4]: <6:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: RecordSizeInBytes
 // CHECK:                RecordSizeInBytes: 20
 // CHECK:              }
-// CHECK:              [5]: <6:NodeShaderIOAttrib> = {
+// CHECK:              [5]: <7:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: RecordDispatchGrid
 // CHECK:                RecordDispatchGrid: <RecordDispatchGrid>
 // CHECK:                  ByteOffset: 8
 // CHECK:                  ComponentNumAndType: 23
 // CHECK:              }
+// CHECK:              [6]: <1:NodeShaderIOAttrib> = {
+// CHECK:                AttribKind: RecordAlignmentInBytes
+// CHECK:                RecordAlignmentInBytes: 4
+// CHECK:              }
 // CHECK:            }
 // CHECK:          }
 // CHECK:        }
-// CHECK:        Inputs: <12:RecordArrayRef<IONode>[1]>  = {
+// CHECK:        Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // CHECK:          [0]: <0:IONode> = {
 // CHECK:            IOFlagsAndKind: 97
-// CHECK:            Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:            Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:              [0]: <0:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: RecordSizeInBytes
 // CHECK:                RecordSizeInBytes: 8
 // CHECK:              }
+// CHECK:              [1]: <1:NodeShaderIOAttrib>
 // CHECK:            }
 // CHECK:          }
 // CHECK:        }
@@ -117,35 +122,39 @@
 // CHECK:      DispatchGrid: <4:array[3]> = { 2, 8, 10 }
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[7] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[8] = {
 // CHECK:    <0:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordSizeInBytes
 // CHECK:      RecordSizeInBytes: 8
 // CHECK:    }
 // CHECK:    <1:NodeShaderIOAttrib> = {
+// CHECK:      AttribKind: RecordAlignmentInBytes
+// CHECK:      RecordAlignmentInBytes: 4
+// CHECK:    }
+// CHECK:    <2:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: OutputID
 // CHECK:      OutputID: <1:NodeID> = {
 // CHECK:        Name: "OutputyMcOutputFace"
 // CHECK:        Index: 0
 // CHECK:      }
 // CHECK:    }
-// CHECK:    <2:NodeShaderIOAttrib> = {
+// CHECK:    <3:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: OutputArraySize
 // CHECK:      OutputArraySize: 2
 // CHECK:    }
-// CHECK:    <3:NodeShaderIOAttrib> = {
+// CHECK:    <4:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: MaxRecords
 // CHECK:      MaxRecords: 47
 // CHECK:    }
-// CHECK:    <4:NodeShaderIOAttrib> = {
+// CHECK:    <5:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: AllowSparseNodes
 // CHECK:      AllowSparseNodes: 1
 // CHECK:    }
-// CHECK:    <5:NodeShaderIOAttrib> = {
+// CHECK:    <6:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordSizeInBytes
 // CHECK:      RecordSizeInBytes: 20
 // CHECK:    }
-// CHECK:    <6:NodeShaderIOAttrib> = {
+// CHECK:    <7:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordDispatchGrid
 // CHECK:      RecordDispatchGrid: <RecordDispatchGrid>
 // CHECK:        ByteOffset: 8
@@ -155,44 +164,52 @@
 // CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[2] = {
 // CHECK:    <0:IONode> = {
 // CHECK:      IOFlagsAndKind: 97
-// CHECK:      Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:      Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:        [0]: <0:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: RecordSizeInBytes
 // CHECK:          RecordSizeInBytes: 8
+// CHECK:        }
+// CHECK:        [1]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
 // CHECK:        }
 // CHECK:      }
 // CHECK:    }
 // CHECK:    <1:IONode> = {
 // CHECK:      IOFlagsAndKind: 22
-// CHECK:      Attribs: <14:RecordArrayRef<NodeShaderIOAttrib>[6]>  = {
-// CHECK:        [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:      Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[7]>  = {
+// CHECK:        [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputID
 // CHECK:          OutputID: <1:NodeID> = {
 // CHECK:            Name: "OutputyMcOutputFace"
 // CHECK:            Index: 0
 // CHECK:          }
 // CHECK:        }
-// CHECK:        [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:        [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputArraySize
 // CHECK:          OutputArraySize: 2
 // CHECK:        }
-// CHECK:        [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:        [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: MaxRecords
 // CHECK:          MaxRecords: 47
 // CHECK:        }
-// CHECK:        [3]: <4:NodeShaderIOAttrib> = {
+// CHECK:        [3]: <5:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: AllowSparseNodes
 // CHECK:          AllowSparseNodes: 1
 // CHECK:        }
-// CHECK:        [4]: <5:NodeShaderIOAttrib> = {
+// CHECK:        [4]: <6:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: RecordSizeInBytes
 // CHECK:          RecordSizeInBytes: 20
 // CHECK:        }
-// CHECK:        [5]: <6:NodeShaderIOAttrib> = {
+// CHECK:        [5]: <7:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: RecordDispatchGrid
 // CHECK:          RecordDispatchGrid: <RecordDispatchGrid>
 // CHECK:            ByteOffset: 8
 // CHECK:            ComponentNumAndType: 23
+// CHECK:        }
+// CHECK:        [6]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
 // CHECK:        }
 // CHECK:      }
 // CHECK:    }
@@ -218,50 +235,55 @@
 // CHECK:          DispatchGrid: <4:array[3]> = { 2, 8, 10 }
 // CHECK:        }
 // CHECK:      }
-// CHECK:      Outputs: <21:RecordArrayRef<IONode>[1]>  = {
+// CHECK:      Outputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // CHECK:        [0]: <1:IONode> = {
 // CHECK:          IOFlagsAndKind: 22
-// CHECK:          Attribs: <14:RecordArrayRef<NodeShaderIOAttrib>[6]>  = {
-// CHECK:            [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:          Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[7]>  = {
+// CHECK:            [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: OutputID
 // CHECK:              OutputID: <1:NodeID> = {
 // CHECK:                Name: "OutputyMcOutputFace"
 // CHECK:                Index: 0
 // CHECK:              }
 // CHECK:            }
-// CHECK:            [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:            [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: OutputArraySize
 // CHECK:              OutputArraySize: 2
 // CHECK:            }
-// CHECK:            [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:            [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: MaxRecords
 // CHECK:              MaxRecords: 47
 // CHECK:            }
-// CHECK:            [3]: <4:NodeShaderIOAttrib> = {
+// CHECK:            [3]: <5:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: AllowSparseNodes
 // CHECK:              AllowSparseNodes: 1
 // CHECK:            }
-// CHECK:            [4]: <5:NodeShaderIOAttrib> = {
+// CHECK:            [4]: <6:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: RecordSizeInBytes
 // CHECK:              RecordSizeInBytes: 20
 // CHECK:            }
-// CHECK:            [5]: <6:NodeShaderIOAttrib> = {
+// CHECK:            [5]: <7:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: RecordDispatchGrid
 // CHECK:              RecordDispatchGrid: <RecordDispatchGrid>
 // CHECK:                ByteOffset: 8
 // CHECK:                ComponentNumAndType: 23
 // CHECK:            }
+// CHECK:            [6]: <1:NodeShaderIOAttrib> = {
+// CHECK:              AttribKind: RecordAlignmentInBytes
+// CHECK:              RecordAlignmentInBytes: 4
+// CHECK:            }
 // CHECK:          }
 // CHECK:        }
 // CHECK:      }
-// CHECK:      Inputs: <12:RecordArrayRef<IONode>[1]>  = {
+// CHECK:      Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // CHECK:        [0]: <0:IONode> = {
 // CHECK:          IOFlagsAndKind: 97
-// CHECK:          Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:          Attribs: <12:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:            [0]: <0:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: RecordSizeInBytes
 // CHECK:              RecordSizeInBytes: 8
 // CHECK:            }
+// CHECK:            [1]: <1:NodeShaderIOAttrib>
 // CHECK:          }
 // CHECK:        }
 // CHECK:      }

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/empty_thread_nodes.hlsl
@@ -41,22 +41,22 @@
 // CHECK:            LocalRootArgumentsTableIndex: 2
 // CHECK:          }
 // CHECK:        }
-// CHECK:        Outputs: <20:RecordArrayRef<IONode>[2]>  = {
+// CHECK:        Outputs: <25:RecordArrayRef<IONode>[2]>  = {
 // CHECK:          [0]: <1:IONode> = {
 // CHECK:            IOFlagsAndKind: 262
-// CHECK:            Attribs: <10:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:              [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:              [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: OutputID
 // CHECK:                OutputID: <1:NodeID> = {
 // CHECK:                  Name: "Output1"
 // CHECK:                  Index: 0
 // CHECK:                }
 // CHECK:              }
-// CHECK:              [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:              [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: OutputArraySize
 // CHECK:                OutputArraySize: 0
 // CHECK:              }
-// CHECK:              [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:              [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: MaxRecordsSharedWith
 // CHECK:                MaxRecordsSharedWith: 1
 // CHECK:              }
@@ -64,32 +64,38 @@
 // CHECK:                AttribKind: RecordSizeInBytes
 // CHECK:                RecordSizeInBytes: 8
 // CHECK:              }
+// CHECK:              [4]: <1:NodeShaderIOAttrib> = {
+// CHECK:                AttribKind: RecordAlignmentInBytes
+// CHECK:                RecordAlignmentInBytes: 4
+// CHECK:              }
 // CHECK:            }
 // CHECK:          }
 // CHECK:          [1]: <2:IONode> = {
 // CHECK:            IOFlagsAndKind: 6
-// CHECK:            Attribs: <15:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:              [0]: <4:NodeShaderIOAttrib> = {
+// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:              [0]: <5:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: OutputID
 // CHECK:                OutputID: <2:NodeID> = {
 // CHECK:                  Name: "Output2ID"
 // CHECK:                  Index: 1
 // CHECK:                }
 // CHECK:              }
-// CHECK:              [1]: <2:NodeShaderIOAttrib>
-// CHECK:              [2]: <5:NodeShaderIOAttrib> = {
+// CHECK:              [1]: <3:NodeShaderIOAttrib>
+// CHECK:              [2]: <6:NodeShaderIOAttrib> = {
 // CHECK:                AttribKind: MaxRecords
 // CHECK:                MaxRecords: 5
 // CHECK:              }
 // CHECK:              [3]: <0:NodeShaderIOAttrib>
+// CHECK:              [4]: <1:NodeShaderIOAttrib>
 // CHECK:            }
 // CHECK:          }
 // CHECK:        }
-// CHECK:        Inputs: <8:RecordArrayRef<IONode>[1]>  = {
+// CHECK:        Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
 // CHECK:          [0]: <0:IONode> = {
 // CHECK:            IOFlagsAndKind: 37
-// CHECK:            Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:              [0]: <0:NodeShaderIOAttrib>
+// CHECK:              [1]: <1:NodeShaderIOAttrib>
 // CHECK:            }
 // CHECK:          }
 // CHECK:        }
@@ -127,34 +133,38 @@
 // CHECK:      LocalRootArgumentsTableIndex: 2
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[6] = {
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[7] = {
 // CHECK:    <0:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: RecordSizeInBytes
 // CHECK:      RecordSizeInBytes: 8
 // CHECK:    }
 // CHECK:    <1:NodeShaderIOAttrib> = {
+// CHECK:      AttribKind: RecordAlignmentInBytes
+// CHECK:      RecordAlignmentInBytes: 4
+// CHECK:    }
+// CHECK:    <2:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: OutputID
 // CHECK:      OutputID: <1:NodeID> = {
 // CHECK:        Name: "Output1"
 // CHECK:        Index: 0
 // CHECK:      }
 // CHECK:    }
-// CHECK:    <2:NodeShaderIOAttrib> = {
+// CHECK:    <3:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: OutputArraySize
 // CHECK:      OutputArraySize: 0
 // CHECK:    }
-// CHECK:    <3:NodeShaderIOAttrib> = {
+// CHECK:    <4:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: MaxRecordsSharedWith
 // CHECK:      MaxRecordsSharedWith: 1
 // CHECK:    }
-// CHECK:    <4:NodeShaderIOAttrib> = {
+// CHECK:    <5:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: OutputID
 // CHECK:      OutputID: <2:NodeID> = {
 // CHECK:        Name: "Output2ID"
 // CHECK:        Index: 1
 // CHECK:      }
 // CHECK:    }
-// CHECK:    <5:NodeShaderIOAttrib> = {
+// CHECK:    <6:NodeShaderIOAttrib> = {
 // CHECK:      AttribKind: MaxRecords
 // CHECK:      MaxRecords: 5
 // CHECK:    }
@@ -162,28 +172,32 @@
 // CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[3] = {
 // CHECK:    <0:IONode> = {
 // CHECK:      IOFlagsAndKind: 37
-// CHECK:      Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:      Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:        [0]: <0:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: RecordSizeInBytes
 // CHECK:          RecordSizeInBytes: 8
+// CHECK:        }
+// CHECK:        [1]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
 // CHECK:        }
 // CHECK:      }
 // CHECK:    }
 // CHECK:    <1:IONode> = {
 // CHECK:      IOFlagsAndKind: 262
-// CHECK:      Attribs: <10:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:        [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:      Attribs: <13:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:        [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputID
 // CHECK:          OutputID: <1:NodeID> = {
 // CHECK:            Name: "Output1"
 // CHECK:            Index: 0
 // CHECK:          }
 // CHECK:        }
-// CHECK:        [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:        [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputArraySize
 // CHECK:          OutputArraySize: 0
 // CHECK:        }
-// CHECK:        [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:        [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: MaxRecordsSharedWith
 // CHECK:          MaxRecordsSharedWith: 1
 // CHECK:        }
@@ -191,29 +205,37 @@
 // CHECK:          AttribKind: RecordSizeInBytes
 // CHECK:          RecordSizeInBytes: 8
 // CHECK:        }
+// CHECK:        [4]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
+// CHECK:        }
 // CHECK:      }
 // CHECK:    }
 // CHECK:    <2:IONode> = {
 // CHECK:      IOFlagsAndKind: 6
-// CHECK:      Attribs: <15:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:        [0]: <4:NodeShaderIOAttrib> = {
+// CHECK:      Attribs: <19:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:        [0]: <5:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputID
 // CHECK:          OutputID: <2:NodeID> = {
 // CHECK:            Name: "Output2ID"
 // CHECK:            Index: 1
 // CHECK:          }
 // CHECK:        }
-// CHECK:        [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:        [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: OutputArraySize
 // CHECK:          OutputArraySize: 0
 // CHECK:        }
-// CHECK:        [2]: <5:NodeShaderIOAttrib> = {
+// CHECK:        [2]: <6:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: MaxRecords
 // CHECK:          MaxRecords: 5
 // CHECK:        }
 // CHECK:        [3]: <0:NodeShaderIOAttrib> = {
 // CHECK:          AttribKind: RecordSizeInBytes
 // CHECK:          RecordSizeInBytes: 8
+// CHECK:        }
+// CHECK:        [4]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
 // CHECK:        }
 // CHECK:      }
 // CHECK:    }
@@ -239,22 +261,22 @@
 // CHECK:          LocalRootArgumentsTableIndex: 2
 // CHECK:        }
 // CHECK:      }
-// CHECK:      Outputs: <20:RecordArrayRef<IONode>[2]>  = {
+// CHECK:      Outputs: <25:RecordArrayRef<IONode>[2]>  = {
 // CHECK:        [0]: <1:IONode> = {
 // CHECK:          IOFlagsAndKind: 262
-// CHECK:          Attribs: <10:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:            [0]: <1:NodeShaderIOAttrib> = {
+// CHECK:          Attribs: <13:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:            [0]: <2:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: OutputID
 // CHECK:              OutputID: <1:NodeID> = {
 // CHECK:                Name: "Output1"
 // CHECK:                Index: 0
 // CHECK:              }
 // CHECK:            }
-// CHECK:            [1]: <2:NodeShaderIOAttrib> = {
+// CHECK:            [1]: <3:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: OutputArraySize
 // CHECK:              OutputArraySize: 0
 // CHECK:            }
-// CHECK:            [2]: <3:NodeShaderIOAttrib> = {
+// CHECK:            [2]: <4:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: MaxRecordsSharedWith
 // CHECK:              MaxRecordsSharedWith: 1
 // CHECK:            }
@@ -262,32 +284,38 @@
 // CHECK:              AttribKind: RecordSizeInBytes
 // CHECK:              RecordSizeInBytes: 8
 // CHECK:            }
+// CHECK:            [4]: <1:NodeShaderIOAttrib> = {
+// CHECK:              AttribKind: RecordAlignmentInBytes
+// CHECK:              RecordAlignmentInBytes: 4
+// CHECK:            }
 // CHECK:          }
 // CHECK:        }
 // CHECK:        [1]: <2:IONode> = {
 // CHECK:          IOFlagsAndKind: 6
-// CHECK:          Attribs: <15:RecordArrayRef<NodeShaderIOAttrib>[4]>  = {
-// CHECK:            [0]: <4:NodeShaderIOAttrib> = {
+// CHECK:          Attribs: <19:RecordArrayRef<NodeShaderIOAttrib>[5]>  = {
+// CHECK:            [0]: <5:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: OutputID
 // CHECK:              OutputID: <2:NodeID> = {
 // CHECK:                Name: "Output2ID"
 // CHECK:                Index: 1
 // CHECK:              }
 // CHECK:            }
-// CHECK:            [1]: <2:NodeShaderIOAttrib>
-// CHECK:            [2]: <5:NodeShaderIOAttrib> = {
+// CHECK:            [1]: <3:NodeShaderIOAttrib>
+// CHECK:            [2]: <6:NodeShaderIOAttrib> = {
 // CHECK:              AttribKind: MaxRecords
 // CHECK:              MaxRecords: 5
 // CHECK:            }
 // CHECK:            [3]: <0:NodeShaderIOAttrib>
+// CHECK:            [4]: <1:NodeShaderIOAttrib>
 // CHECK:          }
 // CHECK:        }
 // CHECK:      }
-// CHECK:      Inputs: <8:RecordArrayRef<IONode>[1]>  = {
+// CHECK:      Inputs: <11:RecordArrayRef<IONode>[1]>  = {
 // CHECK:        [0]: <0:IONode> = {
 // CHECK:          IOFlagsAndKind: 37
-// CHECK:          Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[1]>  = {
+// CHECK:          Attribs: <8:RecordArrayRef<NodeShaderIOAttrib>[2]>  = {
 // CHECK:            [0]: <0:NodeShaderIOAttrib>
+// CHECK:            [1]: <1:NodeShaderIOAttrib>
 // CHECK:          }
 // CHECK:        }
 // CHECK:      }

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/node-record-alignment-16bit.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/node-record-alignment-16bit.hlsl
@@ -1,0 +1,44 @@
+// RUN: %dxilver 1.8 | %dxc -T lib_6_8 -enable-16bit-types %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
+
+// Ensure alignment field set correctly in RDAT for various node records
+
+RWByteAddressBuffer BAB : register(u1, space0);
+
+#define GLUE2(x, y) x##y
+#define GLUE(x, y) GLUE2(x, y)
+
+#define TEST_TYPE(EntryName, CompType) \
+  struct GLUE(EntryName, _record) { \
+    vector<CompType, 3> x; \
+  }; \
+  [shader("node")] \
+  [NodeLaunch("broadcasting")] \
+  [NodeDispatchGrid(1, 1, 1)] \
+  [NumThreads(1,1,1)] \
+  void EntryName(DispatchNodeInputRecord<GLUE(EntryName, _record)> Input) { \
+    BAB.Store(0, Input.Get().x.x); \
+  }
+
+// RDAT: FunctionTable[{{.*}}] = {
+
+// RDAT-LABEL: UnmangledName: "node_half"
+// RDAT: RecordAlignmentInBytes: 2
+TEST_TYPE(node_half, half)
+
+// RDAT-LABEL: UnmangledName: "node_float16"
+// RDAT: RecordAlignmentInBytes: 2
+TEST_TYPE(node_float16, float16_t)
+
+// RDAT-LABEL: UnmangledName: "node_int16"
+// RDAT: RecordAlignmentInBytes: 2
+TEST_TYPE(node_int16, int16_t)
+
+// min16 types are converted to native 16-bit types.
+
+// RDAT-LABEL: UnmangledName: "node_min16float"
+// RDAT: RecordAlignmentInBytes: 2
+TEST_TYPE(node_min16float, min16float)
+
+// RDAT-LABEL: UnmangledName: "node_min16int"
+// RDAT: RecordAlignmentInBytes: 2
+TEST_TYPE(node_min16int, min16int)

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/node-record-alignment.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/node-record-alignment.hlsl
@@ -1,0 +1,82 @@
+// RUN: %dxilver 1.8 | %dxc -T lib_6_8 %s | %D3DReflect %s | %FileCheck %s -check-prefixes=RDAT
+
+// Ensure alignment field set correctly in RDAT for various node records
+
+RWByteAddressBuffer BAB : register(u1, space0);
+
+#define GLUE2(x, y) x##y
+#define GLUE(x, y) GLUE2(x, y)
+
+#define TEST_TYPE(EntryName, CompType) \
+  struct GLUE(EntryName, _record) { \
+    vector<CompType, 3> x; \
+  }; \
+  [shader("node")] \
+  [NodeLaunch("broadcasting")] \
+  [NodeDispatchGrid(1, 1, 1)] \
+  [NumThreads(1,1,1)] \
+  void EntryName(DispatchNodeInputRecord<GLUE(EntryName, _record)> Input) { \
+    BAB.Store(0, (uint)Input.Get().x.x); \
+  }
+
+// RDAT: FunctionTable[{{.*}}] = {
+
+// RDAT-LABEL: UnmangledName: "node_half"
+// RDAT: RecordAlignmentInBytes: 4
+TEST_TYPE(node_half, half)
+
+// RDAT-LABEL: UnmangledName: "node_float"
+// RDAT: RecordAlignmentInBytes: 4
+TEST_TYPE(node_float, float)
+
+// RDAT-LABEL: UnmangledName: "node_double"
+// RDAT: RecordAlignmentInBytes: 8
+TEST_TYPE(node_double, double)
+
+// RDAT-LABEL: UnmangledName: "node_int"
+// RDAT: RecordAlignmentInBytes: 4
+TEST_TYPE(node_int, int)
+
+// RDAT-LABEL: UnmangledName: "node_uint64"
+// RDAT: RecordAlignmentInBytes: 8
+TEST_TYPE(node_uint64, uint64_t)
+
+// Min-precision types are still 4 bytes in storage.
+
+// RDAT-LABEL: UnmangledName: "node_min16float"
+// RDAT: RecordAlignmentInBytes: 4
+TEST_TYPE(node_min16float, min16float)
+
+// RDAT-LABEL: UnmangledName: "node_min16int"
+// RDAT: RecordAlignmentInBytes: 4
+TEST_TYPE(node_min16int, min16int)
+
+// Test alignment preserved for unused input record:
+// RDAT-LABEL: UnmangledName: "node_input_unused_double"
+// RDAT: RecordAlignmentInBytes: 8
+struct UnusedDoubleInputRecord {
+  vector<double, 3> x;
+};
+[shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1,1,1)]
+void node_input_unused_double(
+    DispatchNodeInputRecord<UnusedDoubleInputRecord> Input) {
+  BAB.Store(0, 0);
+}
+
+// Test alignment preserved for unused output record:
+// RDAT-LABEL: UnmangledName: "node_output_unused_double"
+// RDAT: RecordAlignmentInBytes: 8
+struct UnusedDoubleOutputRecord {
+  vector<double, 3> x;
+};
+[shader("node")]
+[NodeLaunch("broadcasting")]
+[NodeDispatchGrid(1, 1, 1)]
+[NumThreads(1,1,1)]
+void node_output_unused_double(
+    NodeOutput<UnusedDoubleOutputRecord> Output) {
+  BAB.Store(0, 0);
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case001_dispatchgrid_shader.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case001_dispatchgrid_shader.hlsl
@@ -75,7 +75,7 @@ void node001_dispatchgrid_shader(DispatchNodeInputRecord<INPUT_NOGRID> input)
 // Arg #1: Size Tag (0)
 // Arg #2: 4 bytes
 // ------------------------------------------------------------------
-// CHECK-DAG: [[INPUT_NOGRID]] = !{i32 0, i32 4}
+// CHECK-DAG: [[INPUT_NOGRID]] = !{i32 0, i32 4, i32 2, i32 4}
 
 // NumThreads
 // Arg #1: 1024

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case014_getrecordcount_nodeinputarray.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case014_getrecordcount_nodeinputarray.hlsl
@@ -73,7 +73,7 @@ void node014_getrecordcount([MaxRecords(256)] GroupNodeInputRecords<INPUT_RECORD
 // Arg #1: Size Tag (0)
 // Arg #2: 4 bytes
 // ------------------------------------------------------------------
-// CHECK: [[INPUT_RECORD:![0-9]+]] = !{i32 0, i32 4}
+// CHECK: [[INPUT_RECORD:![0-9]+]] = !{i32 0, i32 4, i32 2, i32 4}
 
 // NumThreads
 // Arg #1: 1024

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case030_outputcomplete_nodeoutput.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case030_outputcomplete_nodeoutput.hlsl
@@ -61,7 +61,7 @@ void node030_outputcomplete_nodeoutput(NodeOutput<OUTPUT_RECORD> output)
 // Arg #1: Size Tag (0)
 // Arg #4: 4 bytes
 // ------------------------------------------------------------------
-// CHECK: [[OUTPUT_RECORD:![0-9]+]] = !{i32 0, i32 4}
+// CHECK: [[OUTPUT_RECORD:![0-9]+]] = !{i32 0, i32 4, i32 2, i32 4}
 
 // NodeID
 // ------------------------------------------------------------------

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case037_finishedcrossgroupsharing.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/case037_finishedcrossgroupsharing.hlsl
@@ -80,7 +80,7 @@ void node037_finishedcrossgroupsharing(RWDispatchNodeInputRecord<INPUT_RECORD> i
 // Arg #1: Size Tag (0)
 // Arg #2: 4 bytes
 // ------------------------------------------------------------------
-// CHECK: [[INPUT_RECORD]] = !{i32 0, i32 4}
+// CHECK: [[INPUT_RECORD]] = !{i32 0, i32 4, i32 2, i32 4}
 
 // NumThreads
 // Arg #1: 1024

--- a/tools/clang/test/HLSLFileCheck/hlsl/workgraph/sparsenodes.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/workgraph/sparsenodes.hlsl
@@ -44,13 +44,13 @@
 
 // Make sure AllowSparseNodes is true
 // Make sure OutputArraySize is -1 for [UnboundedSparseNodes]
-// Starting from !"OutputArray_*": OutputID.Name, OutputID.Index, MaxRecords, MaxRecordsSharedWith, OutputArraySize, AllowSparseNodes
-// HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_0, {{.*}} !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true}
-// HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_1, {{.*}} !"OutputArray_1_1", i32 0, i32 37, i32 -1, i32 -1, i1 true}
-// HLCHECK-DAG: = !{void (%"struct.NodeOutput<RECORD1>"*)* @node_1_2, {{.*}} !"Output_1_2", i32 0, i32 47, i32 -1, i32 0, i1 true}
-// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_0, {{.*}} !"OutputArray_2_0", i32 0, i32 41, i32 -1, i32 131, i1 true}
-// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_1, {{.*}} !"OutputArray_2_1", i32 0, i32 43, i32 -1, i32 -1, i1 true}
-// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutput*)* @node_2_2, {{.*}} !"Output_2_2", i32 0, i32 53, i32 -1, i32 0, i1 true}
+// Starting from !"OutputArray_*": OutputID.Name, OutputID.Index, MaxRecords, MaxRecordsSharedWith, OutputArraySize, AllowSparseNodes, Alignment
+// HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_0, {{.*}} !"OutputArray_1_0", i32 0, i32 31, i32 -1, i32 129, i1 true, i32 4}
+// HLCHECK-DAG: = !{void (%"struct.NodeOutputArray<RECORD1>"*)* @node_1_1, {{.*}} !"OutputArray_1_1", i32 0, i32 37, i32 -1, i32 -1, i1 true, i32 4}
+// HLCHECK-DAG: = !{void (%"struct.NodeOutput<RECORD1>"*)* @node_1_2, {{.*}} !"Output_1_2", i32 0, i32 47, i32 -1, i32 0, i1 true, i32 4}
+// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_0, {{.*}} !"OutputArray_2_0", i32 0, i32 41, i32 -1, i32 131, i1 true, i32 0}
+// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutputArray*)* @node_2_1, {{.*}} !"OutputArray_2_1", i32 0, i32 43, i32 -1, i32 -1, i1 true, i32 0}
+// HLCHECK-DAG: = !{void (%struct.EmptyNodeOutput*)* @node_2_2, {{.*}} !"Output_2_2", i32 0, i32 53, i32 -1, i32 0, i1 true, i32 0}
 
 // ==== RDAT Checks ====
 


### PR DESCRIPTION
This change adds NodeRecordType alignment field to RDAT to make it possible to validate pointer and stride alignment in the runtime.

This includes a change to DXIL metadata to preserve the record alignment without requiring recovery by looking for GetNodeRecordPtr.

Fixes #6270

(cherry picked from commit 66ba5a152964fe4559a1658194cc9ee5aaac8bcb)