### PR TITLE
CP: Use git rev-parse to get last commit sha (#6366)

### DIFF
--- a/utils/version/gen_version.py
+++ b/utils/version/gen_version.py
@@ -35,21 +35,28 @@ def get_output_of(cmd):
     output = subprocess.check_output(cmd, cwd=enlistment_root)
     return output.decode('ASCII').strip()
 
+def is_dirty():
+    diff = get_output_of(["git", "diff", "HEAD", "--shortstat"])
+    return len(diff.strip()) != 0
+
 def get_last_commit_sha():
     try:
-        return get_output_of([ "git", "describe", "--always", "--dirty" ])
+        sha = get_output_of(["git", "rev-parse", "--short", "HEAD"])
+        if is_dirty():
+            sha += "-dirty"
+        return sha
     except subprocess.CalledProcessError:
         return "00000000"
 
 def get_current_branch():
     try:
-        return get_output_of([ "git", "rev-parse", "--abbrev-ref", "HEAD" ])
+        return get_output_of(["git", "rev-parse", "--abbrev-ref", "HEAD"])
     except subprocess.CalledProcessError:
         return "private"
 
 def get_commit_count(sha):
     try:
-        return get_output_of([ "git", "rev-list", "--count", sha ])
+        return get_output_of(["git", "rev-list", "--count", sha])
     except subprocess.CalledProcessError:
         return 0
     


### PR DESCRIPTION
Do not use `git describe`, it is using tags which might be out of date and unrelated to the current build and version.

(cherry picked from commit aaab2a708a7d70006674f52b2f72739d63f98fe2)