### PR TITLE
fix non-portable include path

### DIFF
--- a/lib/Support/MSFileSystemBasic.cpp
+++ b/lib/Support/MSFileSystemBasic.cpp
@@ -16,7 +16,7 @@
 
 #include "dxc/Support/WinIncludes.h"
 
-#include <D3Dcommon.h>
+#include <d3dcommon.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/lib/Support/MSFileSystemBasic.cpp
+++ b/lib/Support/MSFileSystemBasic.cpp
@@ -16,8 +16,8 @@
 
 #include "dxc/Support/WinIncludes.h"
 
-#include <d3dcommon.h>
 #include <assert.h>
+#include <d3dcommon.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <io.h>

--- a/tools/clang/unittests/HLSL/MSFileSysTest.cpp
+++ b/tools/clang/unittests/HLSL/MSFileSysTest.cpp
@@ -18,7 +18,7 @@
 #include "llvm/Support/MSFileSystem.h"
 #include "llvm/Support/Atomic.h"
 
-#include <D3Dcommon.h>
+#include <d3dcommon.h>
 #include "dxc/dxcapi.internal.h"
 
 #include <algorithm>


### PR DESCRIPTION
d3dcommon.h seems to be canonical path name in Win SDK

Windows Kits/10/Include/10.0.22621.0/um/d3dcommon.h

so use d3dcommon.h rather than D3Dcommon.h