### PR TITLE
Implement -ftime-trace-granularity option to set time granularity value for the time profiler

### DIFF
--- a/include/dxc/Support/HLSLOptions.h
+++ b/include/dxc/Support/HLSLOptions.h
@@ -235,6 +235,7 @@ public:
   bool NewInlining = false;             // OPT_fnew_inlining_behavior
   bool TimeReport = false;              // OPT_ftime_report
   std::string TimeTrace = "";           // OPT_ftime_trace[EQ]
+  unsigned TimeTraceGranularity = 500;  // OPT_ftime_trace_granularity_EQ
   bool VerifyDiagnostics = false;       // OPT_verify
 
   // Optimization pass enables, disables and selects

--- a/include/dxc/Support/HLSLOptions.td
+++ b/include/dxc/Support/HLSLOptions.td
@@ -189,6 +189,9 @@ def ftime_trace : Flag<["-"], "ftime-trace">,
 def ftime_trace_EQ : Joined<["-"], "ftime-trace=">,
   Group<hlslcomp_Group>, Flags<[CoreOption]>,
   HelpText<"Print hierchial time tracing to file">;
+def ftime_trace_granularity_EQ : Joined<["-"], "ftime-trace-granularity=">,
+  Group<hlslcomp_Group>, Flags<[CoreOption]>,
+  HelpText<"Minimum time granularity (in microseconds) traced by time profiler">;
 
 def verify : Joined<["-"], "verify">,
   Group<hlslcomp_Group>, Flags<[CoreOption, DriverOption]>,

--- a/include/llvm/Support/TimeProfiler.h
+++ b/include/llvm/Support/TimeProfiler.h
@@ -21,7 +21,7 @@ extern TimeTraceProfiler *TimeTraceProfilerInstance;
 /// Initialize the time trace profiler.
 /// This sets up the global \p TimeTraceProfilerInstance
 /// variable to be the profiler instance.
-void timeTraceProfilerInitialize();
+void timeTraceProfilerInitialize(unsigned TimeTraceGranularity);
 
 /// Cleanup the time trace profiler, if it was initialized.
 void timeTraceProfilerCleanup();
@@ -52,6 +52,13 @@ void timeTraceProfilerEnd();
 /// the section; and when it is destroyed, it stops it. If the time profiler
 /// is not initialized, the overhead is a single branch.
 struct TimeTraceScope {
+
+  TimeTraceScope() = delete;
+  TimeTraceScope(const TimeTraceScope &) = delete;
+  TimeTraceScope &operator=(const TimeTraceScope &) = delete;
+  TimeTraceScope(TimeTraceScope &&) = delete;
+  TimeTraceScope &operator=(TimeTraceScope &&) = delete;
+
   TimeTraceScope(StringRef Name, StringRef Detail) {
     if (TimeTraceProfilerInstance != nullptr)
       timeTraceProfilerBegin(Name, Detail);

--- a/include/llvm/Support/TimeProfiler.h
+++ b/include/llvm/Support/TimeProfiler.h
@@ -52,13 +52,6 @@ void timeTraceProfilerEnd();
 /// the section; and when it is destroyed, it stops it. If the time profiler
 /// is not initialized, the overhead is a single branch.
 struct TimeTraceScope {
-
-  TimeTraceScope() = delete;
-  TimeTraceScope(const TimeTraceScope &) = delete;
-  TimeTraceScope &operator=(const TimeTraceScope &) = delete;
-  TimeTraceScope(TimeTraceScope &&) = delete;
-  TimeTraceScope &operator=(TimeTraceScope &&) = delete;
-
   TimeTraceScope(StringRef Name, StringRef Detail) {
     if (TimeTraceProfilerInstance != nullptr)
       timeTraceProfilerBegin(Name, Detail);

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -825,11 +825,12 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   if (Args.hasArg(OPT_ftime_trace_EQ))
     opts.TimeTrace = Args.getLastArgValue(OPT_ftime_trace_EQ);
   if (Arg *A = Args.getLastArg(OPT_ftime_trace_granularity_EQ)) {
-    if (llvm::StringRef(A->getValue()).getAsInteger(10, opts.TimeTraceGranularity)) {
+    if (llvm::StringRef(A->getValue())
+            .getAsInteger(10, opts.TimeTraceGranularity)) {
       opts.TimeTraceGranularity = 500;
       errors << "Warning: Invalid value for -ftime-trace-granularity option "
-                "specified, defaulting to " << opts.TimeTraceGranularity
-              << " microseconds.";
+                "specified, defaulting to "
+             << opts.TimeTraceGranularity << " microseconds.";
     }
   }
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -824,6 +824,17 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.VerifyDiagnostics = Args.hasFlag(OPT_verify, OPT_INVALID, false);
   if (Args.hasArg(OPT_ftime_trace_EQ))
     opts.TimeTrace = Args.getLastArgValue(OPT_ftime_trace_EQ);
+  if (Args.hasArg(OPT_ftime_trace_granularity_EQ)) {
+    if (Arg *A = Args.getLastArg(OPT_ftime_trace_granularity_EQ)) {
+      if (llvm::StringRef(A->getValue()).getAsInteger(10, opts.TimeTraceGranularity)) {
+        opts.TimeTraceGranularity = 500;
+        errors << "Warning: Invalid value for -ftime-trace-granularity option "
+                  "specified, defaulting to " << opts.TimeTraceGranularity
+               << " microseconds.";
+      }
+    }
+  }
+
   opts.EnablePayloadQualifiers =
       Args.hasFlag(OPT_enable_payload_qualifiers, OPT_INVALID,
                    DXIL::CompareVersions(Major, Minor, 6, 7) >= 0);

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -824,14 +824,12 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   opts.VerifyDiagnostics = Args.hasFlag(OPT_verify, OPT_INVALID, false);
   if (Args.hasArg(OPT_ftime_trace_EQ))
     opts.TimeTrace = Args.getLastArgValue(OPT_ftime_trace_EQ);
-  if (Args.hasArg(OPT_ftime_trace_granularity_EQ)) {
-    if (Arg *A = Args.getLastArg(OPT_ftime_trace_granularity_EQ)) {
-      if (llvm::StringRef(A->getValue()).getAsInteger(10, opts.TimeTraceGranularity)) {
-        opts.TimeTraceGranularity = 500;
-        errors << "Warning: Invalid value for -ftime-trace-granularity option "
-                  "specified, defaulting to " << opts.TimeTraceGranularity
-               << " microseconds.";
-      }
+  if (Arg *A = Args.getLastArg(OPT_ftime_trace_granularity_EQ)) {
+    if (llvm::StringRef(A->getValue()).getAsInteger(10, opts.TimeTraceGranularity)) {
+      opts.TimeTraceGranularity = 500;
+      errors << "Warning: Invalid value for -ftime-trace-granularity option "
+                "specified, defaulting to " << opts.TimeTraceGranularity
+              << " microseconds.";
     }
   }
 

--- a/tools/clang/include/clang/Frontend/CodeGenOptions.def
+++ b/tools/clang/include/clang/Frontend/CodeGenOptions.def
@@ -132,6 +132,8 @@ CODEGENOPT(StrictEnums       , 1, 0) ///< Optimize based on strict enum definiti
 CODEGENOPT(TimePasses        , 1, 0) ///< Set when -ftime-report is enabled.
 CODEGENOPT(TimeTrace         , 1, 0) ///< HLSL Change:
                                      ///< Set when -ftime-trace is enabled.
+VALUE_CODEGENOPT(TimeTraceGranularity, 32, 500) ///< HLSL Change:
+                                          ///< Set when -ftime_trace_granularity is set.
 CODEGENOPT(UnitAtATime       , 1, 1) ///< Unused. For mirroring GCC optimization
                                      ///< selection.
 CODEGENOPT(UnrollLoops       , 1, 0) ///< Control whether loops are unrolled.

--- a/tools/clang/include/clang/Frontend/FrontendOptions.h
+++ b/tools/clang/include/clang/Frontend/FrontendOptions.h
@@ -255,6 +255,10 @@ public:
   /// (in the format produced by -fdump-record-layouts).
   std::string OverrideRecordLayoutsFile;
   
+  /// If given, the minimum time granularity (in microseconds) traced by
+  /// time profiler is set to this value.
+  unsigned TimeTraceGranularity;
+
 public:
   FrontendOptions() :
     DisableFree(false), RelocatablePCH(false), ShowHelp(false),

--- a/tools/clang/include/clang/Frontend/FrontendOptions.h
+++ b/tools/clang/include/clang/Frontend/FrontendOptions.h
@@ -254,7 +254,7 @@ public:
   /// \brief File name of the file that will provide record layouts
   /// (in the format produced by -fdump-record-layouts).
   std::string OverrideRecordLayoutsFile;
-  
+
   /// If given, the minimum time granularity (in microseconds) traced by
   /// time profiler is set to this value.
   unsigned TimeTraceGranularity;

--- a/tools/clang/test/DXC/ftime-trace-granularity.hlsl
+++ b/tools/clang/test/DXC/ftime-trace-granularity.hlsl
@@ -1,0 +1,7 @@
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=0
+// RUN: cat %t.json | FileCheck %s
+
+// CHECK: { "traceEvents": [
+
+void main() {}

--- a/tools/clang/test/DXC/ftime-trace-granularity.hlsl
+++ b/tools/clang/test/DXC/ftime-trace-granularity.hlsl
@@ -2,6 +2,7 @@
 // RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=99999
 // RUN: cat %t.json | FileCheck %s
 
+// This test runs both stdout and file output paths.
 // Validate that we do not output named stats
 // but still continue to output the Totals
 // versions of them which is expected.

--- a/tools/clang/test/DXC/ftime-trace-granularity.hlsl
+++ b/tools/clang/test/DXC/ftime-trace-granularity.hlsl
@@ -1,7 +1,12 @@
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace | FileCheck %s
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=0
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace -ftime-trace-granularity=99999 | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=99999
 // RUN: cat %t.json | FileCheck %s
 
+// Validate that we do not output named stats
+// but still continue to output the Totals
+// versions of them which is expected.
 // CHECK: { "traceEvents": [
+// CHECK-NOT: "name":"Frontend"
+// CHECK: "name":"Total Frontend"
 
 void main() {}

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -1807,7 +1807,7 @@ HRESULT DxcCompilerAdapter::WrapCompile(
     dxcutil::ReadOptsAndValidate(mainArgs, opts, pOutputStream,
                                  &pOperationResult, finished);
     if (!opts.TimeTrace.empty())
-      llvm::timeTraceProfilerInitialize();
+      llvm::timeTraceProfilerInitialize(opts.TimeTraceGranularity);
     if (finished) {
       IFT(pOperationResult->QueryInterface(ppResult));
       return S_OK;


### PR DESCRIPTION
This commit adds a new optional -ftime-trace-granularity option that is already implemented in llvm-project. This change is a surgical port of an existing feature from the upstream llvm-project repo into the DXC codebase.

The following commits in the llvm-project repo were copied and followed for this change. Clean cherry picks were not possible due to the differences in repos like change of file locations and other dependant changes made in the repo.

*** Adds the granularity configuration setting ***
'Time profiler: small fixes and optimizations'
Commit: 26536728591d5fdac373ef535ae122b873f73292

*** Wires up the commandline option -ftime-trace-granularity to the TraceProfiler code ***
'[Support] Fix -ftime-trace-granularity option'
Commit: 4fdcabf259c4ab94654e6cd5d95d0e0313159c70

Fixes #6372