### PR TITLE
[SPIR-V] Evaluate void return expressions

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -2633,6 +2633,9 @@ void SpirvEmitter::doReturnStmt(const ReturnStmt *stmt) {
                                    {stmt->getReturnLoc(), retVal->getLocEnd()});
     }
   } else {
+    if (retVal) {
+      loadIfGLValue(retVal);
+    }
     spvBuilder.createReturn(stmt->getReturnLoc());
   }
 

--- a/tools/clang/test/CodeGenSPIRV/cf.return.void.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cf.return.void.hlsl
@@ -4,6 +4,10 @@ void A() {
 }
 
 void main() {
-  // CHECK: OpReturn
+  // CHECK: [[type:%[0-9]+]] = OpTypeFunction %void
+  // CHECK:        %src_main = OpFunction %void None [[type]]
+  // CHECK:      {{%[0-9]+}} = OpFunctionCall %void %A
+  // CHECK:                    OpReturn
+  // CHECK:                    OpFunctionEnd
   return A();
 }


### PR DESCRIPTION
Even when a function's return type is void, it is still valid to return an void expression, and that expression should be evaluated before the function is terminated to match DXIL behavior.

Although I don't see this explicitly mentioned in HLSL documention, the cpp reference states (abridged):

> `return expression;`
> Evaluates the expression, terminates the current function and returns the result of the expression to the caller, after implicit conversion to the function return type.
> In a function returning void, the return statement with expression can be used, if the expression type is void.

Fixes #5464