### PR TITLE
[SPIR-V] Disallow variable offsets in texture Load

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -322,9 +322,9 @@ public:
       bool doImageFetch, QualType texelType, QualType imageType,
       SpirvInstruction *image, SpirvInstruction *coordinate,
       SpirvInstruction *lod, SpirvInstruction *constOffset,
-      SpirvInstruction *varOffset, SpirvInstruction *constOffsets,
-      SpirvInstruction *sample, SpirvInstruction *residencyCode,
-      SourceLocation loc, SourceRange range = {});
+      SpirvInstruction *constOffsets, SpirvInstruction *sample,
+      SpirvInstruction *residencyCode, SourceLocation loc,
+      SourceRange range = {});
 
   /// \brief Creates SPIR-V instructions for writing to the given image.
   void createImageWrite(QualType imageType, SpirvInstruction *image,

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -622,14 +622,13 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
     bool doImageFetch, QualType texelType, QualType imageType,
     SpirvInstruction *image, SpirvInstruction *coordinate,
     SpirvInstruction *lod, SpirvInstruction *constOffset,
-    SpirvInstruction *varOffset, SpirvInstruction *constOffsets,
-    SpirvInstruction *sample, SpirvInstruction *residencyCode,
-    SourceLocation loc, SourceRange range) {
+    SpirvInstruction *constOffsets, SpirvInstruction *sample,
+    SpirvInstruction *residencyCode, SourceLocation loc, SourceRange range) {
   assert(insertPoint && "null insert point");
 
   const auto mask = composeImageOperandsMask(
       /*bias*/ nullptr, lod, std::make_pair(nullptr, nullptr), constOffset,
-      varOffset, constOffsets, sample, /*minLod*/ nullptr);
+      /*varOffset*/ nullptr, constOffsets, sample, /*minLod*/ nullptr);
 
   const bool isSparse = (residencyCode != nullptr);
 
@@ -641,8 +640,8 @@ SpirvInstruction *SpirvBuilder::createImageFetchOrRead(
   auto *fetchOrReadInst = new (context)
       SpirvImageOp(op, texelType, loc, image, coordinate, mask,
                    /*dref*/ nullptr, /*bias*/ nullptr, lod, /*gradDx*/ nullptr,
-                   /*gradDy*/ nullptr, constOffset, varOffset, constOffsets,
-                   sample, nullptr, nullptr, nullptr, range);
+                   /*gradDy*/ nullptr, constOffset, /*varOffset*/ nullptr,
+                   constOffsets, sample, nullptr, nullptr, nullptr, range);
   insertPoint->addInstruction(fetchOrReadInst);
 
   if (isSparse) {

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3892,7 +3892,7 @@ SpirvEmitter::processSubpassLoad(const CXXMemberCallExpr *expr) {
       astContext.getExtVectorType(astContext.IntTy, 2), {zero, zero});
 
   return processBufferTextureLoad(object, location, /*constOffset*/ 0,
-                                  /*varOffset*/ 0, /*lod*/ sample,
+                                  /*lod*/ sample,
                                   /*residencyCode*/ 0, expr->getExprLoc());
 }
 
@@ -4233,9 +4233,8 @@ SpirvEmitter::processTextureGatherCmp(const CXXMemberCallExpr *expr) {
 
 SpirvInstruction *SpirvEmitter::processBufferTextureLoad(
     const Expr *object, SpirvInstruction *location,
-    SpirvInstruction *constOffset, SpirvInstruction *varOffset,
-    SpirvInstruction *lod, SpirvInstruction *residencyCode, SourceLocation loc,
-    SourceRange range) {
+    SpirvInstruction *constOffset, SpirvInstruction *lod,
+    SpirvInstruction *residencyCode, SourceLocation loc, SourceRange range) {
   // Loading for Buffer and RWBuffer translates to an OpImageFetch.
   // The result type of an OpImageFetch must be a vec4 of float or int.
   const auto type = object->getType();
@@ -4308,8 +4307,7 @@ SpirvInstruction *SpirvEmitter::processBufferTextureLoad(
   const QualType texelType = astContext.getExtVectorType(elemType, 4u);
   auto *texel = spvBuilder.createImageFetchOrRead(
       doFetch, texelType, type, objectInfo, location, lod, constOffset,
-      varOffset, /*constOffsets*/ nullptr, sampleNumber, residencyCode, loc,
-      range);
+      /*constOffsets*/ nullptr, sampleNumber, residencyCode, loc, range);
 
   if (rasterizerOrdered) {
     spvBuilder.createEndInvocationInterlockEXT(loc, range);
@@ -5679,8 +5677,7 @@ SpirvEmitter::processBufferTextureLoad(const CXXMemberCallExpr *expr) {
   auto range = expr->getSourceRange();
   if (isBuffer(objectType) || isRWBuffer(objectType) || isRWTexture(objectType))
     return processBufferTextureLoad(object, doExpr(locationArg),
-                                    /*constOffset*/ nullptr,
-                                    /*varOffset*/ nullptr, /*lod*/ nullptr,
+                                    /*constOffset*/ nullptr, /*lod*/ nullptr,
                                     /*residencyCode*/ status, loc, range);
 
   // Subtract 1 for status (if it exists), and 1 for sampleIndex (if it exists),
@@ -5713,11 +5710,15 @@ SpirvEmitter::processBufferTextureLoad(const CXXMemberCallExpr *expr) {
         handleOffsetInMethodCall(expr, 1, &constOffset, &varOffset);
     }
 
-    if (varOffset)
-      needsLegalization = true;
+    if (varOffset) {
+      emitError(
+          "Offsets to texture access operations must be immediate values.",
+          object->getExprLoc());
+      return nullptr;
+    }
 
-    return processBufferTextureLoad(object, coordinate, constOffset, varOffset,
-                                    lod, status, loc, range);
+    return processBufferTextureLoad(object, coordinate, constOffset, lod,
+                                    status, loc, range);
   }
   emitError("Load() of the given object type unimplemented",
             object->getExprLoc());
@@ -5758,8 +5759,7 @@ SpirvEmitter::doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr,
                                                   llvm::APInt(32, 0))
                       : nullptr;
       return processBufferTextureLoad(baseExpr, doExpr(indexExpr),
-                                      /*constOffset*/ nullptr,
-                                      /*varOffset*/ nullptr, lod,
+                                      /*constOffset*/ nullptr, lod,
                                       /*residencyCode*/ nullptr,
                                       expr->getExprLoc());
     }
@@ -5767,8 +5767,7 @@ SpirvEmitter::doCXXOperatorCallExpr(const CXXOperatorCallExpr *expr,
     if (isTextureMipsSampleIndexing(expr, &baseExpr, &indexExpr, &lodExpr)) {
       auto *lod = doExpr(lodExpr);
       return processBufferTextureLoad(baseExpr, doExpr(indexExpr),
-                                      /*constOffset*/ nullptr,
-                                      /*varOffset*/ nullptr, lod,
+                                      /*constOffset*/ nullptr, lod,
                                       /*residencyCode*/ nullptr,
                                       expr->getExprLoc());
     }

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -962,8 +962,7 @@ private:
   /// resulting residency code will also be emitted.
   SpirvInstruction *
   processBufferTextureLoad(const Expr *object, SpirvInstruction *location,
-                           SpirvInstruction *constOffset,
-                           SpirvInstruction *varOffset, SpirvInstruction *lod,
+                           SpirvInstruction *constOffset, SpirvInstruction *lod,
                            SpirvInstruction *residencyCode, SourceLocation loc,
                            SourceRange range = {});
 

--- a/tools/clang/test/CodeGenSPIRV/method.buffer.load.offset.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/method.buffer.load.offset.error.hlsl
@@ -1,0 +1,7 @@
+// RUN: not %dxc -T ps_6_2 -E main -fcgl -spirv %s 2>&1 | FileCheck %s
+
+Texture2D SourceTexture;
+void main(in float4 SvPosition : SV_Position, out float4 OutColor : SV_Target0) {
+    // CHECK: error: Offsets to texture access operations must be immediate values.
+    OutColor = SourceTexture.Load(SvPosition.x, SvPosition.y);
+}


### PR DESCRIPTION
The `Load` function's optional `Offset` parameter must be an immediate value to match the behavior of the DXIL backend. Further, the existing logic in the SPIR-V backend to evaluate it as a variable offset generated invalid SPIR-V that violated the `VUID-StandaloneSpirv-Offset-04663` rule:
> Image operand Offset must only be used with OpImage*Gather instructions

The logic for processing the argument as a variable value has been removed and replaced with an error message that matches DXIL's.

Note that `handleOffsetInMethodCall` is left unmodified because it is also used to process HLSL `.Gather()` calls, which are lowered to `OpImageGather` SPIR-V instructions and can therefore accept non-const `Offset`s as image operands.

It would be nice to move this error message earlier in execution and share between backends, but I found that to be non-trivial to implement. Since both backends already have all of the logic to identify whether the function call has an offset argument, at which index, and evaluate its const-ness, I think this is the most straightforward implementation at this point. 

Fixes #6149