### PR TITLE
[SPIR-V] Set layout rule when decomposing struct

### DIFF
--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -160,6 +160,7 @@ bool InitListHandler::tryToSplitStruct() {
   for (auto *field : structDecl->fields()) {
     auto *extract =
         spvBuilder.createCompositeExtract(field->getType(), init, {i}, loc);
+    extract->setLayoutRule(init->getLayoutRule());
     fields.push_back(extract);
     ++i;
   }

--- a/tools/clang/test/CodeGenSPIRV/var.init.struct.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/var.init.struct.hlsl
@@ -48,6 +48,16 @@ struct BitFields {
   uint A:8;
 };
 
+struct V
+{
+    float arr[2];
+};
+
+struct U
+{
+    V val;
+};
+
 void main() {
 // CHECK-LABEL: %bb_entry = OpLabel
 
@@ -117,4 +127,17 @@ void main() {
 // CHECK: [[bf:%[0-9]+]] = OpCompositeConstruct %BitFields [[v3]]
 // CHECK:                  OpStore %bf [[bf]]
     BitFields bf = {3, 2, 1, 0};
+
+// CHECK:   [[vals:%[0-9]+]] = OpLoad %_ptr_Uniform_type_StructuredBuffer_V %vals
+// CHECK: [[vals_0:%[0-9]+]] = OpAccessChain %_ptr_Uniform_V [[vals]] %int_0 %uint_0
+// CHECK:      [[V:%[0-9]+]] = OpLoad %V [[vals_0]]
+// CHECK:    [[V_0:%[0-9]+]] = OpCompositeExtract %_arr_float_uint_2 [[V]] 0
+// CHECK:  [[V_0_0:%[0-9]+]] = OpCompositeExtract %float [[V_0]] 0
+// CHECK:  [[V_0_1:%[0-9]+]] = OpCompositeExtract %float [[V_0]] 1
+// CHECK:    [[arr:%[0-9]+]] = OpCompositeConstruct %_arr_float_uint_2_0 [[V_0_0]] [[V_0_1]]
+// CHECK:     [[V2:%[0-9]+]] = OpCompositeConstruct %V_0 [[arr]]
+// CHECK:      [[U:%[0-9]+]] = OpCompositeConstruct %U [[V2]]
+// CHECK:                      OpStore %u [[U]]
+    StructuredBuffer<V> vals;
+    U u = { vals[0] };
 }


### PR DESCRIPTION
Because the layout rule was not propagated from the initializer object to the OpCompositeExtract when decomposing a struct in the InitListHandler, it could result in cases where the result types were mismatched.

Fixes #5625