### PR TITLE
[SPIR-V] Fix null pointer crash in short-circuit ternary op.

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -3608,6 +3608,8 @@ SpirvInstruction *SpirvEmitter::doShortCircuitedConditionalOperator(
   SpirvInstruction *trueVal = loadIfGLValue(trueExpr);
   trueVal = castToType(trueVal, trueExpr->getType(), type,
                        trueExpr->getExprLoc(), range);
+  if (!trueVal)
+    return nullptr;
   spvBuilder.createStore(tempVar, trueVal, trueExpr->getLocStart(), range);
   spvBuilder.createBranch(mergeBB, trueExpr->getLocEnd());
   spvBuilder.addSuccessor(mergeBB);
@@ -3617,6 +3619,8 @@ SpirvInstruction *SpirvEmitter::doShortCircuitedConditionalOperator(
   SpirvInstruction *falseVal = loadIfGLValue(falseExpr);
   falseVal = castToType(falseVal, falseExpr->getType(), type,
                         falseExpr->getExprLoc(), range);
+  if (!falseVal)
+    return nullptr;
   spvBuilder.createStore(tempVar, falseVal, falseExpr->getLocStart(), range);
   spvBuilder.createBranch(mergeBB, falseExpr->getLocEnd());
   spvBuilder.addSuccessor(mergeBB);

--- a/tools/clang/test/CodeGenSPIRV/ternary-op.short-circuited-cond-op.sampler-state.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/ternary-op.short-circuited-cond-op.sampler-state.hlsl
@@ -1,0 +1,11 @@
+// RUN: not %dxc -T ps_6_0 -E main -HV 2021 -fcgl  %s -spirv 2>&1 | FileCheck %s
+
+SamplerState sampler_a;
+SamplerState sampler_b;
+Texture2D tex;
+bool selector;
+
+float4 main() : SV_Target0 {
+// CHECK: error: casting to type 'SamplerState' unimplemente
+  return tex.Sample(selector ? sampler_a : sampler_b, (float2)0);
+}


### PR DESCRIPTION
`castToType` can return null after emitting an error, so `doShortCircuitedConditionalOperator` should exit when true or false branches failed to compile, otherwise it will crash inside `createStore`.

This can be reproduced with in the main branch with a ternary operator selectin a `SamplerState`, which should only emit an error but crashes with a SIGSEGV:
https://godbolt.org/z/j9EGGxWTh

`$ dxc -spirv -E PSMain -T ps_6_0 -HV 2021`
```hlsl
SamplerState SamplerA;
SamplerState SamplerB;
Texture2D Tex;
bool WhichSampler;
float4 SampleTex() {
    return Tex.Sample(WhichSampler ? SamplerA : SamplerB, (float2)0);
}
float4 PSMain() : SV_Target0 {
    return SampleTex();
}
```