### PR TITLE
Sema: warn when POSITION[0] is used intead of SV_Position

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7712,6 +7712,9 @@ def warn_hlsl_incorrect_bind_semantic: Warning< // Is an error in fxc in some ca
   "invalid register specification, expected %0 binding">;
 def err_hlsl_incorrect_bind_semantic: Error< // Is an error in fxc in some cases, but is sometimes ignored
   "invalid register specification, expected %0 binding">;
+def warn_hlsl_semantic_attribute_position_misuse_hint: Warning<
+  "'POSITION' is not considered equal to SV_Position but is treated as a user-defined semantic attribute">,
+  InGroup<DiagGroup<"dx9-deprecation">>;
 def warn_hlsl_unary_negate_unsigned : Warning<
   "unary negate of unsigned value is still unsigned">,
   InGroup<Conversion>, DefaultWarn;

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7713,7 +7713,7 @@ def warn_hlsl_incorrect_bind_semantic: Warning< // Is an error in fxc in some ca
 def err_hlsl_incorrect_bind_semantic: Error< // Is an error in fxc in some cases, but is sometimes ignored
   "invalid register specification, expected %0 binding">;
 def warn_hlsl_semantic_attribute_position_misuse_hint: Warning<
-  "'POSITION' is not considered equal to SV_Position but is treated as a user-defined semantic attribute">,
+  "'%0' is a user-defined semantic; did you mean 'SV_Position'?">,
   InGroup<DiagGroup<"dx9-deprecation">>;
 def warn_hlsl_unary_negate_unsigned : Warning<
   "unary negate of unsigned value is still unsigned">,

--- a/tools/clang/lib/Sema/SemaDecl.cpp
+++ b/tools/clang/lib/Sema/SemaDecl.cpp
@@ -4972,8 +4972,6 @@ NamedDecl *Sema::HandleDeclarator(Scope *S, Declarator &D,
   if (!New)
     return nullptr;
 
-  TransferUnusualAttributes(D, New); // HLSL Change
-
   // If this has an identifier and is not an invalid redeclaration or 
   // function template specialization, add it to the scope stack.
   if (New->getDeclName() && AddToScope &&
@@ -5187,6 +5185,8 @@ Sema::ActOnTypedefDeclarator(Scope* S, Declarator& D, DeclContext* DC,
   bool Redeclaration = D.isRedeclaration();
   NamedDecl *ND = ActOnTypedefNameDecl(S, DC, NewTD, Previous, Redeclaration);
   D.setRedeclaration(Redeclaration);
+
+  TransferUnusualAttributes(D, ND); // HLSL Change
   return ND;
 }
 
@@ -6202,6 +6202,7 @@ Sema::ActOnVariableDeclarator(Scope *S, Declarator &D, DeclContext *DC,
     return NewTemplate;
   }
 
+  TransferUnusualAttributes(D, NewVD); // HLSL Change
   return NewVD;
 }
 
@@ -8108,10 +8109,14 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
     AddToScope = false;
   }
 
+  // HLSL Change Starts
+  TransferUnusualAttributes(D, NewFD);
+
   if (getLangOpts().HLSL && D.isFunctionDefinition() && D.hasName() &&
       NewFD->getDeclContext()->getRedeclContext()->isTranslationUnit()) {
     hlsl::DiagnoseEntry(*this, NewFD);
   }
+  // HLSL Change Ends
 
   return NewFD;
 }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15301,7 +15301,8 @@ void DiagnoseVertexEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName) {
       if (sema->SemanticName.equals_lower("POSITION") ||
           sema->SemanticName.equals_lower("POSITION0")) {
         S.Diags.Report(FD->getLocation(),
-                       diag::warn_hlsl_semantic_attribute_position_misuse_hint);
+                       diag::warn_hlsl_semantic_attribute_position_misuse_hint)
+            << sema->SemanticName;
       }
     }
   }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15295,6 +15295,20 @@ void DiagnoseAmplificationEntry(Sema &S, FunctionDecl *FD,
   return;
 }
 
+void DiagnoseVertexEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName) {
+  for (auto *annotation : FD->getUnusualAnnotations()) {
+    if (auto *sema = dyn_cast<hlsl::SemanticDecl>(annotation)) {
+      if (sema->SemanticName.equals_lower("POSITION") ||
+          sema->SemanticName.equals_lower("POSITION0")) {
+        S.Diags.Report(FD->getLocation(),
+                       diag::warn_hlsl_semantic_attribute_position_misuse_hint);
+      }
+    }
+  }
+
+  return;
+}
+
 void DiagnoseMeshEntry(Sema &S, FunctionDecl *FD, llvm::StringRef StageName) {
 
   if (!(FD->getAttr<HLSLNumThreadsAttr>()))
@@ -15807,8 +15821,9 @@ void DiagnoseEntry(Sema &S, FunctionDecl *FD) {
   DiagnoseEntryAttrAllowedOnStage(&S, FD, Stage);
 
   switch (Stage) {
-  case DXIL::ShaderKind::Pixel:
   case DXIL::ShaderKind::Vertex:
+    return DiagnoseVertexEntry(S, FD, StageName);
+  case DXIL::ShaderKind::Pixel:
   case DXIL::ShaderKind::Library:
   case DXIL::ShaderKind::Invalid:
     return;

--- a/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T vs_6_0 -E main -spirv -verify %s
+
+float4 main(float4 input : SV_Position) : POSITION { /* expected-warning{{'POSITION' is not considered equal to SV_Position but is treated as a user-defined semantic attribute}} */
+  return input;
+}

--- a/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
@@ -1,5 +1,5 @@
 // RUN: %dxc -T vs_6_0 -E main -spirv -verify %s
 
-float4 main(float4 input : SV_Position) : POSITION { /* expected-warning{{'POSITION' is not considered equal to SV_Position but is treated as a user-defined semantic attribute}} */
+float4 main(float4 input : SV_Position) : POSITION { /* expected-warning{{'POSITION' is a user-defined semantic; did you mean 'SV_Position'?}} */
   return input;
 }

--- a/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.nowarn.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.nowarn.hlsl
@@ -1,0 +1,5 @@
+// RUN: %dxc -T vs_6_0 -E main -spirv -Wno-dx9-deprecation -verify %s
+
+float4 main(float4 input : SV_Position) : POSITION { /* expected-no-diagnostics */
+  return input;
+}


### PR DESCRIPTION
Before SM4, POSITION was equivalent to today's SV_Position. However, as HLSL moved to system semantics (SV_), the support for those old semantics has been deprecated.
Some like VFACE are now completely forbidden, but others like POSITION or COLOR have been handled differently by FXC and DXC.

Today, usage of POSITION in place of SV_Position is probably a mistake as POSITION is now considered to be a user-defined semantic.

This commit adds a warning when POSITION is used as an output semantic for a vertex shader, as most cases should be the result of a mistake. If this is expected, the warning can be disabled by using `-Wno-dx9-deprecation`.

Fixes #3742