### PR TITLE
[SPIR-V] Only allow GetAttributeAtVertex in PS

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -1803,11 +1803,13 @@ std::vector<uint32_t> SpirvBuilder::takeModule() {
   RemoveBufferBlockVisitor removeBufferBlockVisitor(
       astContext, context, spirvOptions, featureManager);
   EmitVisitor emitVisitor(astContext, context, spirvOptions, featureManager);
-  PervertexInputVisitor pervertexInputVisitor(*this, astContext, context,
-                                              spirvOptions);
 
   // pervertex inputs refine
-  mod->invokeVisitor(&pervertexInputVisitor);
+  if (context.isPS()) {
+    PervertexInputVisitor pervertexInputVisitor(*this, astContext, context,
+                                                spirvOptions);
+    mod->invokeVisitor(&pervertexInputVisitor);
+  }
 
   mod->invokeVisitor(&literalTypeVisitor, true);
 

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12073,6 +12073,12 @@ void SpirvEmitter::processMeshOutputCounts(const CallExpr *callExpr) {
 
 SpirvInstruction *
 SpirvEmitter::processGetAttributeAtVertex(const CallExpr *expr) {
+  if (!spvContext.isPS()) {
+    emitError("GetAttributeAtVertex only allowed in pixel shader",
+              expr->getExprLoc());
+    return nullptr;
+  }
+
   // Implicit type conversion should bound to two things:
   // 1. Function Parameter, and recursively redecl mapped function called's var
   // types.

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.non-pixel-shader.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.non-pixel-shader.hlsl
@@ -1,0 +1,7 @@
+// RUN: not %dxc -T vs_6_1 -E main -spirv -Od %s 2>&1 | FileCheck %s
+
+float4 main(nointerpolation float4 p : SV_Position) : SV_Position
+{
+// CHECK: 6:12: error: GetAttributeAtVertex only allowed in pixel shader
+    return GetAttributeAtVertex(p, 0);
+}


### PR DESCRIPTION
This builtin should only be called from a pixel shader.