### PR TITLE
[SPIR-V] Allow evaluating enum values to APInt

### DIFF
--- a/tools/clang/lib/SPIRV/ConstEvaluator.cpp
+++ b/tools/clang/lib/SPIRV/ConstEvaluator.cpp
@@ -57,7 +57,7 @@ SpirvConstant *ConstEvaluator::translateAPValue(const APValue &value,
   if (targetType->isBooleanType()) {
     result = spvBuilder.getConstantBool(value.getInt().getBoolValue(),
                                         isSpecConstantMode);
-  } else if (targetType->isIntegerType()) {
+  } else if (targetType->isIntegralOrEnumerationType()) {
     result = translateAPInt(value.getInt(), targetType, isSpecConstantMode);
   } else if (targetType->isFloatingType()) {
     result = translateAPFloat(value.getFloat(), targetType, isSpecConstantMode);

--- a/tools/clang/lib/SPIRV/SpirvInstruction.cpp
+++ b/tools/clang/lib/SPIRV/SpirvInstruction.cpp
@@ -541,7 +541,7 @@ SpirvConstantInteger::SpirvConstantInteger(QualType type, llvm::APInt val,
                     isSpecConst ? spv::Op::OpSpecConstant : spv::Op::OpConstant,
                     type),
       value(val) {
-  assert(type->isIntegerType());
+  assert(type->isIntegralOrEnumerationType());
 }
 
 bool SpirvConstantInteger::operator==(const SpirvConstantInteger &that) const {

--- a/tools/clang/test/CodeGenSPIRV/cast.enum.literal.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/cast.enum.literal.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T ps_6_0 -E main -fcgl  %s -spirv | FileCheck %s
+
+enum class Sample
+{
+    One = 0x0001,
+};
+
+void main()
+{
+    // CHECK: OpStore %s %int_1
+    Sample s = (Sample)0x1u;
+}


### PR DESCRIPTION
Use `isIntegralOrEnumerationType` instead of `isIntegerType` in a couple places so that enum values can be evaluated to `SpirvConstantInteger`

Fixes #6421