### PR TITLE
Fix ubsan failure on uninitialized read of bool param to WideCharToMultiByte

### DIFF
--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -76,7 +76,10 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
                         const wchar_t *lpWideCharStr, int cchWideChar,
                         char *lpMultiByteStr, int cbMultiByte,
                         const char * /*lpDefaultChar*/,
-                        bool * /*lpUsedDefaultChar*/) {
+                        bool *lpUsedDefaultChar) {
+  if (lpUsedDefaultChar) {
+    *lpUsedDefaultChar = FALSE;
+  }
 
   if (cchWideChar == 0) {
     SetLastError(ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
If last arg lpUsedDefaultChar is non-null, the function must set this value to true or false. WideToEncodedString conditionally passes in a pointer to 'usedDefaultChar', which was not getting written to, and causing ubsan to fail on reading an invalid boolean value:
```
.../lib/DxcSupport/Unicode.cpp:156:14: runtime error: load of value 208, which is not a valid value for type 'BOOL' (aka 'bool')
```
