### PR TITLE
Fix asan heap overflow in PixTests (again)

### DIFF
--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -208,10 +208,7 @@ public:
     VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
         dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
 
-    std::string outputText;
-    if (pText->GetBufferSize() != 0) {
-      outputText = reinterpret_cast<const char *>(pText->GetBufferPointer());
-    }
+    std::string outputText = BlobToUtf8(pText);
 
     return {
         std::move(pOptimizedModule), {}, Tokenize(outputText.c_str(), "\n")};


### PR DESCRIPTION
Use BlobToUtf8 which handles the case of InternalDxcBlobEncoding_Impl not having a null-terminated pointer when converting to string.

Effectively a repeat of this PR:
https://github.com/microsoft/DirectXShaderCompiler/pull/5973