### PR TITLE
[SPIR-V] Add support for Denorm Mode

### DIFF
--- a/include/dxc/Support/SPIRVOptions.h
+++ b/include/dxc/Support/SPIRVOptions.h
@@ -92,6 +92,7 @@ struct SpirvCodeGenOptions {
   std::vector<std::string> bindRegister;
   std::vector<std::string> bindGlobals;
   std::string entrypointName;
+  std::string floatDenormalMode; // OPT_denorm
 
   bool signaturePacking; ///< Whether signature packing is enabled or not
 

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -1201,6 +1201,8 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
       hasUnsupportedSpirvOption(Args, errors))
     return 1;
 
+  opts.SpirvOptions.floatDenormalMode = Args.getLastArgValue(OPT_denorm);
+
 #else
   if (Args.hasFlag(OPT_spirv, OPT_INVALID, false) ||
       Args.hasFlag(OPT_fvk_invert_y, OPT_INVALID, false) ||

--- a/tools/clang/include/clang/SPIRV/FeatureManager.h
+++ b/tools/clang/include/clang/SPIRV/FeatureManager.h
@@ -60,6 +60,7 @@ enum class Extension {
   NV_compute_shader_derivatives,
   KHR_fragment_shader_barycentric,
   KHR_maximal_reconvergence,
+  KHR_float_controls,
   Unknown,
 };
 

--- a/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
+++ b/tools/clang/lib/SPIRV/CapabilityVisitor.cpp
@@ -722,6 +722,18 @@ bool CapabilityVisitor::visit(SpirvExecutionMode *execMode) {
     addExtension(Extension::KHR_maximal_reconvergence, "",
                  execModeSourceLocation);
     break;
+  case spv::ExecutionMode::DenormPreserve:
+  case spv::ExecutionMode::DenormFlushToZero:
+    // KHR_float_controls was promoted to core in Vulkan 1.2.
+    if (!featureManager.isTargetEnvVulkan1p2OrAbove()) {
+      addExtension(Extension::KHR_float_controls, "SPV_KHR_float_controls",
+                   execModeSourceLocation);
+    }
+    addCapability(executionMode == spv::ExecutionMode::DenormPreserve
+                      ? spv::Capability::DenormPreserve
+                      : spv::Capability::DenormFlushToZero,
+                  execModeSourceLocation);
+    break;
   default:
     break;
   }

--- a/tools/clang/lib/SPIRV/FeatureManager.cpp
+++ b/tools/clang/lib/SPIRV/FeatureManager.cpp
@@ -196,6 +196,7 @@ Extension FeatureManager::getExtensionSymbol(llvm::StringRef name) {
             Extension::KHR_fragment_shader_barycentric)
       .Case("SPV_KHR_maximal_reconvergence",
             Extension::KHR_maximal_reconvergence)
+      .Case("SPV_KHR_float_controls", Extension::KHR_float_controls)
       .Default(Extension::Unknown);
 }
 
@@ -261,6 +262,8 @@ const char *FeatureManager::getExtensionName(Extension symbol) {
     return "SPV_KHR_fragment_shader_barycentric";
   case Extension::KHR_maximal_reconvergence:
     return "SPV_KHR_maximal_reconvergence";
+  case Extension::KHR_float_controls:
+    return "SPV_KHR_float_controls";
   default:
     break;
   }

--- a/tools/clang/test/CodeGenSPIRV/opt.denorm.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/opt.denorm.error.hlsl
@@ -1,0 +1,7 @@
+// RUN: not %dxc -E main -T ps_6_2 -denorm bad -spirv %s 2>&1 | FileCheck %s
+
+// CHECK: dxc failed : Unsupported value 'bad' for denorm option.
+
+float4 main(float4 col : COL) : SV_Target {
+    return col;
+}

--- a/tools/clang/test/CodeGenSPIRV/opt.denorm.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/opt.denorm.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -E main -T ps_6_2 -denorm preserve -spirv %s | FileCheck --check-prefixes=CHECK-PRE %s
+// RUN: %dxc -E main -T ps_6_2 -denorm preserve -spirv -fspv-target-env=vulkan1.2 %s | FileCheck --check-prefixes=CHECK-PRE-VK12 %s
+// RUN: %dxc -E main -T ps_6_2 -denorm ftz -spirv %s | FileCheck --check-prefixes=CHECK-FTZ %s
+// RUN: %dxc -E main -T ps_6_2 -denorm any -spirv %s | FileCheck --check-prefixes=CHECK-DEFAULT %s
+// RUN: %dxc -E main -T ps_6_2 -spirv %s | FileCheck --check-prefixes=CHECK-DEFAULT %s
+
+// CHECK-PRE: OpCapability DenormPreserve
+// CHECK-PRE: OpExtension "SPV_KHR_float_controls"
+// CHECK-PRE: OpExecutionMode %main DenormPreserve 32
+
+// CHECK-PRE-VK12:     OpCapability DenormPreserve
+// CHECK-PRE-VK12-NOT: OpExtension "SPV_KHR_float_controls"
+// CHECK-PRE-VK12:     OpExecutionMode %main DenormPreserve 32
+
+// CHECK-FTZ: OpCapability DenormFlushToZero
+// CHECK-FTZ: OpExtension "SPV_KHR_float_controls"
+// CHECK-FTZ: OpExecutionMode %main DenormFlushToZero 32
+
+// CHECK-DEFAULT-NOT: OpCapability DenormPreserve
+// CHECK-DEFAULT-NOT: OpExtension "SPV_KHR_float_controls"
+// CHECK-DEFAULT-NOT: OpExecutionMode %main Denorm
+float4 main(float4 col : COL) : SV_Target {
+    return col;
+}


### PR DESCRIPTION
The -denorm option allows the shader to select the desired behavior with respect to denormal values.

Note that this can't take advantage of the SPIRV-Tools capability trimming pass for the same reasons as described in: https://github.com/microsoft/DirectXShaderCompiler/pull/6248#discussion_r1481073348

Fixes #6434