### PR TITLE
[Sema] Check FunctionDecl has identifier before getName.

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15690,7 +15690,7 @@ void TryAddShaderAttrFromTargetProfile(Sema &S, FunctionDecl *FD,
 
   // if this FD isn't the entry point, then we shouldn't add
   // a shader attribute to this decl, so just return
-  if (EntryPointName != FD->getIdentifier()->getName()) {
+  if (FD->getIdentifier() && EntryPointName != FD->getIdentifier()->getName()) {
     return;
   }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15690,7 +15690,8 @@ void TryAddShaderAttrFromTargetProfile(Sema &S, FunctionDecl *FD,
 
   // if this FD isn't the entry point, then we shouldn't add
   // a shader attribute to this decl, so just return
-  if (!FD->getIdentifier() || EntryPointName != FD->getIdentifier()->getName()) {
+  if (!FD->getIdentifier() ||
+      EntryPointName != FD->getIdentifier()->getName()) {
     return;
   }
 

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15690,7 +15690,7 @@ void TryAddShaderAttrFromTargetProfile(Sema &S, FunctionDecl *FD,
 
   // if this FD isn't the entry point, then we shouldn't add
   // a shader attribute to this decl, so just return
-  if (FD->getIdentifier() && EntryPointName != FD->getIdentifier()->getName()) {
+  if (!FD->getIdentifier() || EntryPointName != FD->getIdentifier()->getName()) {
     return;
   }
 

--- a/tools/clang/test/SemaHLSL/operator-overload.hlsl
+++ b/tools/clang/test/SemaHLSL/operator-overload.hlsl
@@ -1,0 +1,32 @@
+// RUN: %dxc -Tps_6_0 -verify %s
+
+// expected-error@+1 {{overloading non-member 'operator==' is not allowed}}
+bool operator==(int lhs, int rhs) {
+    return true;
+}
+
+struct A {
+  float a;
+  int b;
+};
+
+// expected-error@+1 {{overloading non-member 'operator>' is not allowed}}
+bool operator>(A a0, A a1) {
+  return a1.a > a0.a && a1.b > a0.b;
+}
+// expected-error@+1 {{overloading non-member 'operator==' is not allowed}}
+bool operator==(A a0, int i) {
+    return a0.b == i;
+}
+// expected-error@+1 {{overloading non-member 'operator<' is not allowed}}
+bool operator<(A a0, float f) {
+   return a0.a < f;
+}
+// expected-error@+1 {{overloading 'operator++' is not allowed}}
+A operator++(A a0) {
+  a0.a++;
+  a0.b++;
+  return a0;
+}
+
+void main() {}


### PR DESCRIPTION
Use identifier name without check the identifier exists will cause crash.

Fixes #6426