### PR TITLE
[SPIR-V] Implement dot2add intrinsic function

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -8754,6 +8754,10 @@ SpirvEmitter::processIntrinsicCallExpr(const CallExpr *callExpr) {
     retVal = processIntrinsicDP4a(callExpr, hlslOpcode);
     break;
   }
+  case hlsl::IntrinsicOp::IOP_dot2add: {
+    retVal = processIntrinsicDP2a(callExpr);
+    break;
+  }
   case hlsl::IntrinsicOp::IOP_pack_s8:
   case hlsl::IntrinsicOp::IOP_pack_u8:
   case hlsl::IntrinsicOp::IOP_pack_clamp_s8:
@@ -11514,6 +11518,44 @@ SpirvInstruction *SpirvEmitter::processIntrinsicDP4a(const CallExpr *callExpr,
   // Create and return the integer addition instruction.
   return spvBuilder.createBinaryOp(spv::Op::OpIAdd, returnType, dotResult,
                                    arg2Instr, loc, range);
+}
+
+SpirvInstruction *SpirvEmitter::processIntrinsicDP2a(const CallExpr *callExpr) {
+  // Processing the `dot2add` intrinsic.
+  // There is no direct substitution for it in SPIR-V, so it is recreated with a
+  // combination of OpDot and OpFAdd.
+  //
+  // float dot2add( half2 a, half2 b, float acc );
+  //    A 2-dimensional floating point dot product of half2 vectors with add.
+  //    Multiplies the elements of the two half-precision float input vectors
+  //    together and sums the results into the 32-bit float accumulator.
+
+  auto loc = callExpr->getExprLoc();
+  auto range = callExpr->getSourceRange();
+
+  assert(callExpr->getNumArgs() == 3u);
+
+  QualType vecType = callExpr->getArg(0)->getType();
+  QualType componentType = {};
+  uint32_t vecSize = {};
+  bool isVec = isVectorType(vecType, &componentType, &vecSize);
+
+  assert(isVec && vecSize == 2);
+
+  // Create the dot product of the half2 vectors.
+  SpirvInstruction *dotInstr = spvBuilder.createBinaryOp(
+      spv::Op::OpDot, componentType, doExpr(callExpr->getArg(0)),
+      doExpr(callExpr->getArg(1)), loc, range);
+
+  // Convert dot product (half type) to result type (float).
+  QualType resultType = callExpr->getType();
+  SpirvInstruction *floatDotInstr = spvBuilder.createUnaryOp(
+      spv::Op::OpFConvert, resultType, dotInstr, loc, range);
+
+  // Sum the dot product result and accumulator and return.
+  SpirvInstruction *accInstr = doExpr(callExpr->getArg(2));
+  return spvBuilder.createBinaryOp(spv::Op::OpFAdd, resultType, floatDotInstr,
+                                   accInstr, loc, range);
 }
 
 SpirvInstruction *

--- a/tools/clang/lib/SPIRV/SpirvEmitter.h
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.h
@@ -662,6 +662,9 @@ private:
   SpirvInstruction *processIntrinsicDP4a(const CallExpr *callExpr,
                                          hlsl::IntrinsicOp op);
 
+  /// Processes the SM 6.4 dot2add intrinsic function.
+  SpirvInstruction *processIntrinsicDP2a(const CallExpr *callExpr);
+
   /// Processes the SM 6.6 pack_{s|u}8 and pack_clamp_{s|u}8 intrinsic
   /// functions.
   SpirvInstruction *processIntrinsic8BitPack(const CallExpr *,

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
@@ -1,0 +1,14 @@
+// RUN: %dxc -E main -T ps_6_4 -enable-16bit-types -spirv %s | FileCheck %s
+
+float main(half4 inputs : Inputs0, int acc : Acc0) : SV_Target {
+
+// CHECK: [[inputs:%[0-9]+]] = OpLoad %v4half %in_var_Inputs0
+// CHECK: [[acc:%[0-9]+]] = OpLoad %int %in_var_Acc0
+// CHECK: [[b:%[0-9]+]] = OpVectorShuffle %v2half [[inputs]] [[inputs]] 2 3
+// CHECK: [[a:%[0-9]+]] = OpVectorShuffle %v2half [[inputs]] [[inputs]] 0 1
+// CHECK: [[dot:%[0-9]+]] = OpDot %half [[a]] [[b]]
+// CHECK: [[dot2:%[0-9]+]] = OpFConvert %float [[dot]]
+// CHECK: [[acc2:%[0-9]+]] = OpConvertSToF %float [[acc]]
+// CHECK: [[res:%[0-9]+]] = OpFAdd %float [[dot2]] [[acc2]]
+  return dot2add(inputs.xy, inputs.zw, acc);
+}

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
@@ -1,14 +1,53 @@
-// RUN: %dxc -E main -T ps_6_4 -enable-16bit-types -spirv %s | FileCheck %s
+// RUN: %dxc -E main -T ps_6_4 -enable-16bit-types -spirv -O0 %s 2>&1 | FileCheck %s
 
-float main(half4 inputs : Inputs0, int acc : Acc0) : SV_Target {
+float main() : SV_Target {
+// CHECK: warning: conversion from larger type 'float' to smaller type 'vector<half, 2>', possible loss of data
+// CHECK: warning: conversion from larger type 'int4' to smaller type 'vector<half, 2>', possible loss of data
+// CHECK: warning: implicit truncation of vector type
+  float res = 0;
 
-// CHECK: [[inputs:%[0-9]+]] = OpLoad %v4half %in_var_Inputs0
-// CHECK: [[acc:%[0-9]+]] = OpLoad %int %in_var_Acc0
-// CHECK: [[b:%[0-9]+]] = OpVectorShuffle %v2half [[inputs]] [[inputs]] 2 3
-// CHECK: [[a:%[0-9]+]] = OpVectorShuffle %v2half [[inputs]] [[inputs]] 0 1
-// CHECK: [[dot:%[0-9]+]] = OpDot %half [[a]] [[b]]
-// CHECK: [[dot2:%[0-9]+]] = OpFConvert %float [[dot]]
-// CHECK: [[acc2:%[0-9]+]] = OpConvertSToF %float [[acc]]
-// CHECK: [[res:%[0-9]+]] = OpFAdd %float [[dot2]] [[acc2]]
-  return dot2add(inputs.xy, inputs.zw, acc);
+  half2 input1A;
+  half2 input1B;
+  float acc1;
+// CHECK: [[input1B:%[0-9]+]] = OpLoad %v2half %input1B
+// CHECK: [[input1A:%[0-9]+]] = OpLoad %v2half %input1A
+// CHECK: [[dot1_0:%[0-9]+]] = OpDot %half [[input1A]] [[input1B]]
+// CHECK: [[dot1:%[0-9]+]] = OpFConvert %float [[dot1_0]]
+// CHECK: [[acc1:%[0-9]+]] = OpLoad %float %acc1
+// CHECK: [[res1:%[0-9]+]] = OpFAdd %float [[dot1]] [[acc1]]
+  res += dot2add(input1A, input1B, acc1);
+
+  half4 input2;
+  int acc2;
+// CHECK: [[input2:%[0-9]+]] = OpLoad %v4half %input2
+// CHECK: [[input2B:%[0-9]+]] = OpVectorShuffle %v2half [[input2]] [[input2]] 2 3
+// CHECK: [[input2_1:%[0-9]+]] = OpLoad %v4half %input2
+// CHECK: [[input2A:%[0-9]+]] = OpVectorShuffle %v2half [[input2_1]] [[input2_1]] 0 1
+// CHECK: [[dot2_0:%[0-9]+]] = OpDot %half [[input2A]] [[input2B]]
+// CHECK: [[dot2:%[0-9]+]] = OpFConvert %float [[dot2_0]]
+// CHECK: [[acc2_0:%[0-9]+]] = OpLoad %int %acc2
+// CHECK: [[acc2:%[0-9]+]] = OpConvertSToF %float [[acc2_0]]
+// CHECK: [[res2:%[0-9]+]] = OpFAdd %float [[dot2]] [[acc2]]
+  res += dot2add(input2.xy, input2.zw, acc2);
+
+  float input3A;
+  int4 input3B;
+  half acc3;
+// CHECK: [[input3B_1:%[0-9]+]] = OpLoad %v4int %input3B
+// CHECK: [[input3B_2:%[0-9]+]] = OpCompositeExtract %int [[input3B_1]] 0
+// CHECK: [[input3B_3:%[0-9]+]] = OpCompositeExtract %int [[input3B_1]] 1
+// CHECK: [[input3B_4:%[0-9]+]] = OpCompositeConstruct %v2int [[input3B_2]] [[input3B_3]]
+// CHECK: [[input3B_5:%[0-9]+]] = OpSConvert %v2short [[input3B_4]]
+// CHECK: [[input3B:%[0-9]+]] = OpConvertSToF %v2half [[input3B_5]]
+// CHECK: [[input3A_1:%[0-9]+]] = OpLoad %float %input3A
+// CHECK: [[input3A_2:%[0-9]+]] = OpFConvert %half [[input3A_1]]
+// CHECK: [[input3A:%[0-9]+]] = OpCompositeConstruct %v2half [[input3A_2]] [[input3A_2]]
+// CHECK: [[dot3_1:%[0-9]+]] = OpDot %half [[input3A]] [[input3B]]
+// CHECK: [[dot3:%[0-9]+]] = OpFConvert %float [[dot3_1]]
+// CHECK: [[acc3_1:%[0-9]+]] = OpLoad %half %acc3
+// CHECK: [[acc3:%[0-9]+]] = OpFConvert %float [[acc3_1]]
+// CHECK: [[res3:%[0-9]+]] = OpFAdd %float [[dot3]] [[acc3]]
+  res += dot2add(input3A, input3B, acc3);
+
+  return res;
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.dot2add.hlsl
@@ -9,43 +9,43 @@ float main() : SV_Target {
   half2 input1A;
   half2 input1B;
   float acc1;
-// CHECK: [[input1B:%[0-9]+]] = OpLoad %v2half %input1B
 // CHECK: [[input1A:%[0-9]+]] = OpLoad %v2half %input1A
+// CHECK: [[input1B:%[0-9]+]] = OpLoad %v2half %input1B
+// CHECK: [[acc1:%[0-9]+]] = OpLoad %float %acc1
 // CHECK: [[dot1_0:%[0-9]+]] = OpDot %half [[input1A]] [[input1B]]
 // CHECK: [[dot1:%[0-9]+]] = OpFConvert %float [[dot1_0]]
-// CHECK: [[acc1:%[0-9]+]] = OpLoad %float %acc1
 // CHECK: [[res1:%[0-9]+]] = OpFAdd %float [[dot1]] [[acc1]]
   res += dot2add(input1A, input1B, acc1);
 
   half4 input2;
   int acc2;
 // CHECK: [[input2:%[0-9]+]] = OpLoad %v4half %input2
-// CHECK: [[input2B:%[0-9]+]] = OpVectorShuffle %v2half [[input2]] [[input2]] 2 3
+// CHECK: [[input2A:%[0-9]+]] = OpVectorShuffle %v2half [[input2]] [[input2]] 0 1
 // CHECK: [[input2_1:%[0-9]+]] = OpLoad %v4half %input2
-// CHECK: [[input2A:%[0-9]+]] = OpVectorShuffle %v2half [[input2_1]] [[input2_1]] 0 1
-// CHECK: [[dot2_0:%[0-9]+]] = OpDot %half [[input2A]] [[input2B]]
-// CHECK: [[dot2:%[0-9]+]] = OpFConvert %float [[dot2_0]]
+// CHECK: [[input2B:%[0-9]+]] = OpVectorShuffle %v2half [[input2_1]] [[input2_1]] 2 3
 // CHECK: [[acc2_0:%[0-9]+]] = OpLoad %int %acc2
 // CHECK: [[acc2:%[0-9]+]] = OpConvertSToF %float [[acc2_0]]
+// CHECK: [[dot2_0:%[0-9]+]] = OpDot %half [[input2A]] [[input2B]]
+// CHECK: [[dot2:%[0-9]+]] = OpFConvert %float [[dot2_0]]
 // CHECK: [[res2:%[0-9]+]] = OpFAdd %float [[dot2]] [[acc2]]
   res += dot2add(input2.xy, input2.zw, acc2);
 
   float input3A;
   int4 input3B;
   half acc3;
+// CHECK: [[input3A_1:%[0-9]+]] = OpLoad %float %input3A
+// CHECK: [[input3A_2:%[0-9]+]] = OpFConvert %half [[input3A_1]]
+// CHECK: [[input3A:%[0-9]+]] = OpCompositeConstruct %v2half [[input3A_2]] [[input3A_2]]
 // CHECK: [[input3B_1:%[0-9]+]] = OpLoad %v4int %input3B
 // CHECK: [[input3B_2:%[0-9]+]] = OpCompositeExtract %int [[input3B_1]] 0
 // CHECK: [[input3B_3:%[0-9]+]] = OpCompositeExtract %int [[input3B_1]] 1
 // CHECK: [[input3B_4:%[0-9]+]] = OpCompositeConstruct %v2int [[input3B_2]] [[input3B_3]]
 // CHECK: [[input3B_5:%[0-9]+]] = OpSConvert %v2short [[input3B_4]]
 // CHECK: [[input3B:%[0-9]+]] = OpConvertSToF %v2half [[input3B_5]]
-// CHECK: [[input3A_1:%[0-9]+]] = OpLoad %float %input3A
-// CHECK: [[input3A_2:%[0-9]+]] = OpFConvert %half [[input3A_1]]
-// CHECK: [[input3A:%[0-9]+]] = OpCompositeConstruct %v2half [[input3A_2]] [[input3A_2]]
-// CHECK: [[dot3_1:%[0-9]+]] = OpDot %half [[input3A]] [[input3B]]
-// CHECK: [[dot3:%[0-9]+]] = OpFConvert %float [[dot3_1]]
 // CHECK: [[acc3_1:%[0-9]+]] = OpLoad %half %acc3
 // CHECK: [[acc3:%[0-9]+]] = OpFConvert %float [[acc3_1]]
+// CHECK: [[dot3_1:%[0-9]+]] = OpDot %half [[input3A]] [[input3B]]
+// CHECK: [[dot3:%[0-9]+]] = OpFConvert %float [[dot3_1]]
 // CHECK: [[res3:%[0-9]+]] = OpFAdd %float [[dot3]] [[acc3]]
   res += dot2add(input3A, input3B, acc3);
 


### PR DESCRIPTION
Add support for the Shader Model 6.4 intrinsic dot2add which was missing from the SPIR-V backend.

Fixes #6442