### PR TITLE
Disable "downcast of address" UBSAN runtime error

### DIFF
--- a/include/llvm/ADT/SparseBitVector.h
+++ b/include/llvm/ADT/SparseBitVector.h
@@ -248,6 +248,15 @@ struct ilist_traits<SparseBitVectorElement<ElementSize> >
   : public ilist_default_traits<SparseBitVectorElement<ElementSize> > {
   typedef SparseBitVectorElement<ElementSize> Element;
 
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   Element *createSentinel() const { return static_cast<Element *>(&Sentinel); }
   static void destroySentinel(Element *) {}
 

--- a/include/llvm/ADT/SparseBitVector.h
+++ b/include/llvm/ADT/SparseBitVector.h
@@ -254,10 +254,13 @@ struct ilist_traits<SparseBitVectorElement<ElementSize> >
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  Element *createSentinel() const { return static_cast<Element *>(&Sentinel); }
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  Element *
+  createSentinel() const {
+    return static_cast<Element *>(&Sentinel);
+  }
   static void destroySentinel(Element *) {}
 
   Element *provideInitialHead() const { return createSentinel(); }

--- a/include/llvm/Analysis/IVUsers.h
+++ b/include/llvm/Analysis/IVUsers.h
@@ -102,10 +102,11 @@ template<> struct ilist_traits<IVStrideUse>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  IVStrideUse *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  IVStrideUse *
+  createSentinel() const {
     // since i(p)lists always publicly derive from the corresponding
     // traits, placing a data member in this class will augment i(p)list.
     // But since the NodeTy is expected to publicly derive from

--- a/include/llvm/Analysis/IVUsers.h
+++ b/include/llvm/Analysis/IVUsers.h
@@ -96,6 +96,15 @@ template<> struct ilist_traits<IVStrideUse>
   // the list...
   // The sentinel is relative to this instance, so we use a non-static
   // method.
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   IVStrideUse *createSentinel() const {
     // since i(p)lists always publicly derive from the corresponding
     // traits, placing a data member in this class will augment i(p)list.

--- a/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/include/llvm/CodeGen/MachineBasicBlock.h
@@ -46,10 +46,11 @@ public:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  MachineInstr *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  MachineInstr *
+  createSentinel() const {
     return static_cast<MachineInstr*>(&Sentinel);
   }
   void destroySentinel(MachineInstr *) const {}

--- a/include/llvm/CodeGen/MachineBasicBlock.h
+++ b/include/llvm/CodeGen/MachineBasicBlock.h
@@ -40,6 +40,15 @@ private:
   MachineBasicBlock* Parent;
 
 public:
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   MachineInstr *createSentinel() const {
     return static_cast<MachineInstr*>(&Sentinel);
   }

--- a/include/llvm/CodeGen/MachineFunction.h
+++ b/include/llvm/CodeGen/MachineFunction.h
@@ -48,6 +48,15 @@ struct ilist_traits<MachineBasicBlock>
     : public ilist_default_traits<MachineBasicBlock> {
   mutable ilist_half_node<MachineBasicBlock> Sentinel;
 public:
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   MachineBasicBlock *createSentinel() const {
     return static_cast<MachineBasicBlock*>(&Sentinel);
   }

--- a/include/llvm/CodeGen/MachineFunction.h
+++ b/include/llvm/CodeGen/MachineFunction.h
@@ -54,10 +54,11 @@ public:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  MachineBasicBlock *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  MachineBasicBlock *
+  createSentinel() const {
     return static_cast<MachineBasicBlock*>(&Sentinel);
   }
   void destroySentinel(MachineBasicBlock *) const {}

--- a/include/llvm/CodeGen/SelectionDAG.h
+++ b/include/llvm/CodeGen/SelectionDAG.h
@@ -84,6 +84,15 @@ template<> struct ilist_traits<SDNode> : public ilist_default_traits<SDNode> {
 private:
   mutable ilist_half_node<SDNode> Sentinel;
 public:
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   SDNode *createSentinel() const {
     return static_cast<SDNode*>(&Sentinel);
   }

--- a/include/llvm/CodeGen/SelectionDAG.h
+++ b/include/llvm/CodeGen/SelectionDAG.h
@@ -90,10 +90,11 @@ public:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  SDNode *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  SDNode *
+  createSentinel() const {
     return static_cast<SDNode*>(&Sentinel);
   }
   static void destroySentinel(SDNode *) {}

--- a/include/llvm/CodeGen/SlotIndexes.h
+++ b/include/llvm/CodeGen/SlotIndexes.h
@@ -74,6 +74,15 @@ namespace llvm {
   private:
     mutable ilist_half_node<IndexListEntry> Sentinel;
   public:
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
     IndexListEntry *createSentinel() const {
       return static_cast<IndexListEntry*>(&Sentinel);
     }

--- a/include/llvm/CodeGen/SlotIndexes.h
+++ b/include/llvm/CodeGen/SlotIndexes.h
@@ -74,16 +74,17 @@ namespace llvm {
   private:
     mutable ilist_half_node<IndexListEntry> Sentinel;
   public:
-// HLSL Change Starts
-// Temporarily disable "downcast of address" UBSAN runtime error
-// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+  // HLSL Change Starts
+  // Temporarily disable "downcast of address" UBSAN runtime error
+  // https://github.com/microsoft/DirectXShaderCompiler/issues/6446
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
-  __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-    IndexListEntry *createSentinel() const {
+    __attribute__((no_sanitize("undefined")))
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+         // HLSL Change Ends
+    IndexListEntry *
+    createSentinel() const {
       return static_cast<IndexListEntry*>(&Sentinel);
     }
     void destroySentinel(IndexListEntry *) const {}

--- a/include/llvm/IR/BasicBlock.h
+++ b/include/llvm/IR/BasicBlock.h
@@ -347,11 +347,12 @@ private:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
 __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
 // HLSL Change Ends
-inline BasicBlock *ilist_traits<BasicBlock>::createSentinel() const {
-    return static_cast<BasicBlock*>(&Sentinel);
+inline BasicBlock *
+ilist_traits<BasicBlock>::createSentinel() const {
+  return static_cast<BasicBlock *>(&Sentinel);
 }
 
 // Create wrappers for C Binding types (see CBindingWrapping.h).

--- a/include/llvm/IR/BasicBlock.h
+++ b/include/llvm/IR/BasicBlock.h
@@ -341,6 +341,15 @@ private:
 
 // createSentinel is used to get hold of the node that marks the end of the
 // list... (same trick used here as in ilist_traits<Instruction>)
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+__attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
 inline BasicBlock *ilist_traits<BasicBlock>::createSentinel() const {
     return static_cast<BasicBlock*>(&Sentinel);
 }

--- a/include/llvm/IR/Function.h
+++ b/include/llvm/IR/Function.h
@@ -42,10 +42,11 @@ template<> struct ilist_traits<Argument>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  Argument *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  Argument *
+  createSentinel() const {
     return static_cast<Argument*>(&Sentinel);
   }
   static void destroySentinel(Argument*) {}

--- a/include/llvm/IR/Function.h
+++ b/include/llvm/IR/Function.h
@@ -36,6 +36,15 @@ class LLVMContext;
 template<> struct ilist_traits<Argument>
   : public SymbolTableListTraits<Argument, Function> {
 
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   Argument *createSentinel() const {
     return static_cast<Argument*>(&Sentinel);
   }

--- a/include/llvm/IR/Instruction.h
+++ b/include/llvm/IR/Instruction.h
@@ -521,10 +521,11 @@ private:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
 __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
 // HLSL Change Ends
-inline Instruction *ilist_traits<Instruction>::createSentinel() const {
+inline Instruction *
+ilist_traits<Instruction>::createSentinel() const {
   // Since i(p)lists always publicly derive from their corresponding traits,
   // placing a data member in this class will augment the i(p)list.  But since
   // the NodeTy is expected to be publicly derive from ilist_node<NodeTy>,

--- a/include/llvm/IR/Instruction.h
+++ b/include/llvm/IR/Instruction.h
@@ -515,6 +515,15 @@ private:
   Instruction *cloneImpl() const;
 };
 
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+__attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
 inline Instruction *ilist_traits<Instruction>::createSentinel() const {
   // Since i(p)lists always publicly derive from their corresponding traits,
   // placing a data member in this class will augment the i(p)list.  But since

--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -52,10 +52,11 @@ template<> struct ilist_traits<Function>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  Function *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  Function *
+  createSentinel() const {
     return static_cast<Function*>(&Sentinel);
   }
   static void destroySentinel(Function*) {}
@@ -77,10 +78,11 @@ template<> struct ilist_traits<GlobalVariable>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  GlobalVariable *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  GlobalVariable *
+  createSentinel() const {
     return static_cast<GlobalVariable*>(&Sentinel);
   }
   static void destroySentinel(GlobalVariable*) {}
@@ -101,10 +103,11 @@ template<> struct ilist_traits<GlobalAlias>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  GlobalAlias *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  GlobalAlias *
+  createSentinel() const {
     return static_cast<GlobalAlias*>(&Sentinel);
   }
   static void destroySentinel(GlobalAlias*) {}
@@ -126,10 +129,11 @@ template<> struct ilist_traits<NamedMDNode>
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  NamedMDNode *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  NamedMDNode *
+  createSentinel() const {
     return static_cast<NamedMDNode*>(&Sentinel);
   }
   static void destroySentinel(NamedMDNode*) {}

--- a/include/llvm/IR/Module.h
+++ b/include/llvm/IR/Module.h
@@ -46,6 +46,15 @@ template<> struct ilist_traits<Function>
 
   // createSentinel is used to get hold of the node that marks the end of the
   // list... (same trick used here as in ilist_traits<Instruction>)
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   Function *createSentinel() const {
     return static_cast<Function*>(&Sentinel);
   }
@@ -62,6 +71,15 @@ private:
 template<> struct ilist_traits<GlobalVariable>
   : public SymbolTableListTraits<GlobalVariable, Module> {
   // createSentinel is used to create a node that marks the end of the list.
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   GlobalVariable *createSentinel() const {
     return static_cast<GlobalVariable*>(&Sentinel);
   }
@@ -77,6 +95,15 @@ private:
 template<> struct ilist_traits<GlobalAlias>
   : public SymbolTableListTraits<GlobalAlias, Module> {
   // createSentinel is used to create a node that marks the end of the list.
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   GlobalAlias *createSentinel() const {
     return static_cast<GlobalAlias*>(&Sentinel);
   }
@@ -93,6 +120,15 @@ template<> struct ilist_traits<NamedMDNode>
   : public ilist_default_traits<NamedMDNode> {
   // createSentinel is used to get hold of a node that marks the end of
   // the list...
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   NamedMDNode *createSentinel() const {
     return static_cast<NamedMDNode*>(&Sentinel);
   }

--- a/include/llvm/Transforms/Utils/SymbolRewriter.h
+++ b/include/llvm/Transforms/Utils/SymbolRewriter.h
@@ -119,6 +119,15 @@ public:
   // createSentinel is used to get a reference to a node marking the end of
   // the list.  Because the sentinel is relative to this instance, use a
   // non-static method.
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
   SymbolRewriter::RewriteDescriptor *createSentinel() const {
     // since i[p] lists always publicly derive from the corresponding
     // traits, placing a data member in this class will augment the

--- a/include/llvm/Transforms/Utils/SymbolRewriter.h
+++ b/include/llvm/Transforms/Utils/SymbolRewriter.h
@@ -125,10 +125,11 @@ public:
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
   __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-  SymbolRewriter::RewriteDescriptor *createSentinel() const {
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+       // HLSL Change Ends
+  SymbolRewriter::RewriteDescriptor *
+  createSentinel() const {
     // since i[p] lists always publicly derive from the corresponding
     // traits, placing a data member in this class will augment the
     // i[p]list.  Since the NodeTy is expected to publicly derive from

--- a/tools/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
+++ b/tools/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
@@ -317,6 +317,15 @@ public:
 namespace llvm {
   template<> struct ilist_traits<clang::ento::BugReport>
     : public ilist_default_traits<clang::ento::BugReport> {
+// HLSL Change Starts
+// Temporarily disable "downcast of address" UBSAN runtime error
+// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+#ifdef __has_feature
+#if __has_feature(undefined_behavior_sanitizer)
+  __attribute__((no_sanitize("undefined")))
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+// HLSL Change Ends
     clang::ento::BugReport *createSentinel() const {
       return static_cast<clang::ento::BugReport *>(&Sentinel);
     }

--- a/tools/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
+++ b/tools/clang/include/clang/StaticAnalyzer/Core/BugReporter/BugReporter.h
@@ -317,16 +317,17 @@ public:
 namespace llvm {
   template<> struct ilist_traits<clang::ento::BugReport>
     : public ilist_default_traits<clang::ento::BugReport> {
-// HLSL Change Starts
-// Temporarily disable "downcast of address" UBSAN runtime error
-// https://github.com/microsoft/DirectXShaderCompiler/issues/6446
+  // HLSL Change Starts
+  // Temporarily disable "downcast of address" UBSAN runtime error
+  // https://github.com/microsoft/DirectXShaderCompiler/issues/6446
 #ifdef __has_feature
 #if __has_feature(undefined_behavior_sanitizer)
-  __attribute__((no_sanitize("undefined")))
-#endif  // __has_feature(address_sanitizer)
-#endif  // defined(__has_feature)
-// HLSL Change Ends
-    clang::ento::BugReport *createSentinel() const {
+    __attribute__((no_sanitize("undefined")))
+#endif // __has_feature(address_sanitizer)
+#endif // defined(__has_feature)
+         // HLSL Change Ends
+    clang::ento::BugReport *
+    createSentinel() const {
       return static_cast<clang::ento::BugReport *>(&Sentinel);
     }
     void destroySentinel(clang::ento::BugReport *) const {}


### PR DESCRIPTION
This is a temporary workaround until we fix:
https://github.com/microsoft/DirectXShaderCompiler/issues/6446

This should allow us to enable asan/ubsan checks:
https://github.com/microsoft/DirectXShaderCompiler/pull/6428