### PR TITLE
Revert "Fix asan heap overflow in PixTests (again) (#6430)"

### DIFF
--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -208,7 +208,10 @@ public:
     VERIFY_SUCCEEDED(pOptimizer->RunOptimizer(
         dxil, Options.data(), Options.size(), &pOptimizedModule, &pText));
 
-    std::string outputText = BlobToUtf8(pText);
+    std::string outputText;
+    if (pText->GetBufferSize() != 0) {
+      outputText = reinterpret_cast<const char *>(pText->GetBufferPointer());
+    }
 
     return {
         std::move(pOptimizedModule), {}, Tokenize(outputText.c_str(), "\n")};


### PR DESCRIPTION
Test that the pipeline catches this

This reverts commit 4c37fb33c23c81520cfed42c11e7f8beed049444.