### PR TITLE
Revert "Fix UBSAN error in DxilRootSignatureSerializer (#5795)"

### DIFF
--- a/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
+++ b/lib/DxilRootSignature/DxilRootSignatureSerializer.cpp
@@ -131,7 +131,7 @@ HRESULT SimpleSerializer::ReserveBlock(void **ppData, unsigned cbSize,
 
   *ppData = pClonedData;
   if (pOffset) {
-    memcpy(pOffset, &pSegment->Offset, sizeof(pSegment->Offset));
+    *pOffset = pSegment->Offset;
   }
 
 Cleanup:


### PR DESCRIPTION
Test that pipeline fails on this.

This reverts commit 9419b9b1c7ccf6bbc603f962e0cef5c33ea1c5ea.