### PR TITLE
Revert "Fix ubsan failure on uninitialized read of bool param to Wide…

### DIFF
--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -76,10 +76,7 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
                         const wchar_t *lpWideCharStr, int cchWideChar,
                         char *lpMultiByteStr, int cbMultiByte,
                         const char * /*lpDefaultChar*/,
-                        bool *lpUsedDefaultChar) {
-  if (lpUsedDefaultChar) {
-    *lpUsedDefaultChar = FALSE;
-  }
+                        bool * /*lpUsedDefaultChar*/) {
 
   if (cchWideChar == 0) {
     SetLastError(ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
…CharToMultiByte (#6429)"

Test that this fails pipeline check.

This reverts commit 227ea3d488211e1b232f06fc88b7aa870041c969.