### PR TITLE
[SPIR-V] Fix test

### DIFF
--- a/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.hull-input.size-mismatch.hs.hlsl
@@ -16,7 +16,7 @@ HullPatchOut HullConst (InputPatch<ControlPoint,2> v) { /* expected-error{{Patch
 [partitioning("fractional_odd")]
 [outputtopology("triangle_cw")]
 [patchconstantfunc("HullConst")]
-[outputcontrolpoints(0)]
+[outputcontrolpoints(1)]
 ControlPoint main(InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) {
   return v[id];
 }


### PR DESCRIPTION
This test landed after #6196 was created but before it was merged, and had an invalid attribute that is now caught and causing test failues at head.