### PR TITLE
[SPIR-V] Fix crash in GetAttributeAtVertex impl.

### DIFF
--- a/tools/clang/lib/SPIRV/PervertexInputVisitor.cpp
+++ b/tools/clang/lib/SPIRV/PervertexInputVisitor.cpp
@@ -56,6 +56,11 @@ int PervertexInputVisitor::appendIndexZeroAt(
 ///< treated as nointerpolated too.
 bool PervertexInputVisitor::expandNointerpVarAndParam(
     SpirvInstruction *spvInst) {
+  // If there is no AST type, it means the type was already lowered from some
+  // expression/construct. If it required expansion, it should be done already.
+  if (!spvInst->hasAstResultType())
+    return spvInst->isNoninterpolated();
+
   QualType type = spvInst->getAstResultType();
   bool isExpanded = false;
   auto typePtr = type.getTypePtr();

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.cbuf.var.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.get-attribute-at-vertex.cbuf.var.hlsl
@@ -1,0 +1,19 @@
+// RUN: dxc -T ps_6_2 -E main -spirv %s | FileCheck %s
+
+// CHECK:                                       OpDecorate %in_var_A PerVertexKHR
+// CHECK-DAG:                 %type_constants = OpTypeStruct %uint
+// CHECK-DAG:    %_ptr_Uniform_type_constants = OpTypePointer Uniform %type_constants
+// CHECK-DAG:            %_arr_v3float_uint_3 = OpTypeArray %v3float %uint_3
+// CHECK-DAG: %_ptr_Input__arr_v3float_uint_3 = OpTypePointer Input %_arr_v3float_uint_3
+cbuffer constants : register(b0)
+{
+  uint idx;
+}
+
+float4 main(nointerpolation float3 a : A) : SV_Target
+{
+// CHECK-DAG: %constants = OpVariable %_ptr_Uniform_type_constants Uniform
+// CHECK-DAG:  %in_var_A = OpVariable %_ptr_Input__arr_v3float_uint_3 Input
+  float value = GetAttributeAtVertex(a, 0)[idx];
+	return value.xxxx;
+}


### PR DESCRIPTION
Some SPIR-V types are not direct translations of an AST type, hence they don't have an AST type attached to it.
The code didn't checked for this possibility when visiting all variables.

Fixes #2955