### PR TITLE
[Sema] Move outputcontrolpoints check to Sema

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7837,8 +7837,8 @@ def err_hlsl_missing_patch_constant_function : Error<
     "patch constant function '%0' must be defined">;
 def err_hlsl_patch_reachability_not_allowed : Error<
     "%select{patch constant|entry}0 function '%1' should not be reachable from %select{patch constant|entry}2 function '%3'">;
-def err_hlsl_patch_input_size_mismatch : Error<
-    "Patch constant function's input patch input should have %0 elements, but has %1.">;
+def err_hlsl_patch_size_mismatch : Error<
+    "Patch constant function's %0 patch input should have %1 elements, but has %2.">;
 def warn_hlsl_structurize_exits_lifetime_markers_conflict : Warning <
    "structurize-returns skipped function '%0' due to incompatibility with lifetime markers. Use -disable-lifetime-markers to enable structurize-exits on this function.">,
   InGroup< HLSLStructurizeExitsLifetimeMarkersConflict >;

--- a/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMSFinishCodeGen.cpp
@@ -1475,7 +1475,6 @@ void SetPatchConstantFunctionWithAttr(
       HLM.HasDxilFunctionProps(EntryFunc.Func),
       " else AddHLSLFunctionInfo did not save the dxil function props for the "
       "HS entry.");
-  DxilFunctionProps *HSProps = &HLM.GetDxilFunctionProps(EntryFunc.Func);
   HLM.SetPatchConstantFunctionForHS(EntryFunc.Func, patchConstFunc);
   DXASSERT_NOMSG(patchConstantFunctionPropsMap.count(patchConstFunc));
   // Check no inout parameter for patch constant function.
@@ -1489,24 +1488,6 @@ void SetPatchConstantFunctionWithAttr(
           clang::DiagnosticsEngine::Error,
           "Patch Constant function %0 should not have inout param.");
       Diags.Report(Entry->second.SL, DiagID) << funcName;
-    }
-  }
-
-  // Input/Output control point validation.
-  if (patchConstantFunctionPropsMap.count(patchConstFunc)) {
-    const DxilFunctionProps &patchProps =
-        *patchConstantFunctionPropsMap[patchConstFunc];
-    if (patchProps.ShaderProps.HS.outputControlPoints != 0 &&
-        patchProps.ShaderProps.HS.outputControlPoints !=
-            HSProps->ShaderProps.HS.outputControlPoints) {
-      clang::DiagnosticsEngine &Diags = CGM.getDiags();
-      unsigned DiagID =
-          Diags.getCustomDiagID(clang::DiagnosticsEngine::Error,
-                                "Patch constant function's output patch input "
-                                "should have %0 elements, but has %1.");
-      Diags.Report(Entry->second.SL, DiagID)
-          << HSProps->ShaderProps.HS.outputControlPoints
-          << patchProps.ShaderProps.HS.outputControlPoints;
     }
   }
 }

--- a/tools/clang/test/CodeGenDXIL/semantic.hull-output.size-mismatch.hs.hlsl
+++ b/tools/clang/test/CodeGenDXIL/semantic.hull-output.size-mismatch.hs.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T hs_6_0 -E main %s -verify
+
+
+struct ControlPoint { float4 position : POSITION; };
+
+struct HullPatchOut {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+HullPatchOut HullConst (InputPatch<ControlPoint,3> v, OutputPatch<ControlPoint, 2> outpoints) { /* expected-error{{Patch constant function's output patch input should have 5 elements, but has 2.}} */
+  return (HullPatchOut)0;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+[outputcontrolpoints(5)]
+ControlPoint main(InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) {
+  return v[id];
+}

--- a/tools/clang/test/CodeGenSPIRV/semantic.hull-output.size-mismatch.hs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/semantic.hull-output.size-mismatch.hs.hlsl
@@ -1,0 +1,22 @@
+// RUN: %dxc -T hs_6_0 -E main %s -spirv -verify
+
+
+struct ControlPoint { float4 position : POSITION; };
+
+struct HullPatchOut {
+    float edge [3] : SV_TessFactor;
+    float inside : SV_InsideTessFactor;
+};
+
+HullPatchOut HullConst (InputPatch<ControlPoint,3> v, OutputPatch<ControlPoint, 2> outpoints) { /* expected-error{{Patch constant function's output patch input should have 5 elements, but has 2.}} */
+  return (HullPatchOut)0;
+}
+
+[domain("tri")]
+[partitioning("fractional_odd")]
+[outputtopology("triangle_cw")]
+[patchconstantfunc("HullConst")]
+[outputcontrolpoints(5)]
+ControlPoint main(InputPatch<ControlPoint,3> v, uint id : SV_OutputControlPointID) {
+  return v[id];
+}

--- a/tools/clang/test/HLSLFileCheck/samples/SimpleHs12.hlsl
+++ b/tools/clang/test/HLSLFileCheck/samples/SimpleHs12.hlsl
@@ -1,7 +1,6 @@
 // RUN: %dxc -E main -T hs_6_0  %s | FileCheck %s
 
 // CHECK-DAG: Patch Constant function HSPerPatchFunc should not have inout param
-// CHECK-DAG: Patch constant function's output patch input should have 3 elements, but has 5.
 
 //--------------------------------------------------------------------------------------
 // SimpleTessellation.hlsl
@@ -62,7 +61,7 @@ HSPerPatchData HSPerPatchFunc( const InputPatch< PSSceneIn, 12 > points, OutputP
 [partitioning("fractional_odd")]
 [outputtopology("triangle_cw")]
 [patchconstantfunc("HSPerPatchFunc")]
-[outputcontrolpoints(3)]
+[outputcontrolpoints(5)]
 HSPerVertexData main(const uint id : SV_OutputControlPointID,
                       const InputPatch< PSSceneIn, 12 > points )
 {


### PR DESCRIPTION
DXIL had a check in the backend for those values.
Moving it to Sema to share it between DXIL and SPIR-V.

Fixes #6387