### PR TITLE
Fix ASAN use-after-free on unreferenced self-assignment of struct instance

### DIFF
--- a/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
+++ b/lib/Transforms/Scalar/ScalarReplAggregatesHLSL.cpp
@@ -1003,9 +1003,11 @@ void DeleteMemcpy(MemCpyInst *MI) {
     if (op0->user_empty())
       op0->eraseFromParent();
   }
-  if (Instruction *op1 = dyn_cast<Instruction>(Op1)) {
-    if (op1->user_empty())
-      op1->eraseFromParent();
+  if (Op0 != Op1) {
+    if (Instruction *op1 = dyn_cast<Instruction>(Op1)) {
+      if (op1->user_empty())
+        op1->eraseFromParent();
+    }
   }
 }
 

--- a/tools/clang/test/DXC/unreferenced_struct_selft_assignment_crash.hlsl
+++ b/tools/clang/test/DXC/unreferenced_struct_selft_assignment_crash.hlsl
@@ -1,0 +1,24 @@
+// RUN: %dxc -T cs_6_0 %s | FileCheck %s
+
+// Validate that self-assignment of a static struct instance that is not
+// referenced does not crash the compiler. This was resulting in an ASAN
+// use-after-free in ScalarReplAggregatesHLSL because DeleteMemcpy would
+// attempt to delete both source and target, even if both were the same.
+// CHECK: define void @main() {
+// CHECK-NEXT:   ret void
+// CHECK-NEXT: }
+
+struct MyStruct {
+  int m0;
+};
+
+static MyStruct s;
+
+void foo() {
+  s = s;
+}
+
+[numthreads(1, 1, 1)]
+void main() {
+  foo();
+}


### PR DESCRIPTION
When deleting an unused memcpy, ScalarReplAggregatesHLSL was attempting to delete both the target and the source of the memcpy without first checking if they were both same, resulting in a double-delete.
