### PR TITLE
Remove -spirv from new HLSL Sema tests

### DIFF
--- a/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T vs_6_0 -E main -spirv -verify %s
+// RUN: %dxc -T vs_6_0 -E main -verify %s
 
 float4 main(float4 input : SV_Position) : POSITION { /* expected-warning{{'POSITION' is a user-defined semantic; did you mean 'SV_Position'?}} */
   return input;

--- a/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.nowarn.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/semantics/semantic.vertex.position.nowarn.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -T vs_6_0 -E main -spirv -Wno-dx9-deprecation -verify %s
+// RUN: %dxc -T vs_6_0 -E main -Wno-dx9-deprecation -verify %s
 
 float4 main(float4 input : SV_Position) : POSITION { /* expected-no-diagnostics */
   return input;


### PR DESCRIPTION
These are semantic verification tests, the `-spir-v` option is not necessary. 
It also breaks our internal test passes for builds that do include SPIR-V backend. 