### PR TITLE
Allow disabling payload access qualifiers in 6.8+

### DIFF
--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -845,10 +845,9 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
     opts.PrintAfter.insert(value);
   }
 
-  if (DXIL::CompareVersions(Major, Minor, 6, 8) < 0) {
-    opts.EnablePayloadQualifiers &=
-        !Args.hasFlag(OPT_disable_payload_qualifiers, OPT_INVALID, false);
-  }
+  opts.EnablePayloadQualifiers &=
+    !Args.hasFlag(OPT_disable_payload_qualifiers, OPT_INVALID, false);
+
   if (opts.EnablePayloadQualifiers &&
       DXIL::CompareVersions(Major, Minor, 6, 6) < 0) {
     errors << "Invalid target for payload access qualifiers. Only lib_6_6 and "

--- a/lib/DxcSupport/HLSLOptions.cpp
+++ b/lib/DxcSupport/HLSLOptions.cpp
@@ -846,7 +846,7 @@ int ReadDxcOpts(const OptTable *optionTable, unsigned flagsToInclude,
   }
 
   opts.EnablePayloadQualifiers &=
-    !Args.hasFlag(OPT_disable_payload_qualifiers, OPT_INVALID, false);
+      !Args.hasFlag(OPT_disable_payload_qualifiers, OPT_INVALID, false);
 
   if (opts.EnablePayloadQualifiers &&
       DXIL::CompareVersions(Major, Minor, 6, 6) < 0) {

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7628,7 +7628,7 @@ def err_payload_fields_not_qualified : Error<
 def err_payload_fields_is_payload_and_overqualified : Error<
   "payload field '%0' is a payload struct. Payload access qualifiers are not allowed on payload types.">;
 def warn_hlsl_payload_qualifer_dropped : Warning<
-  "payload access qualifieres are only supported for target lib_6_6 and beyond. You can opt-in for lib_6_6 with the -enable-payload-qualifiers flag. Qualifiers will be dropped.">, InGroup<HLSLPayloadAccessQualifer>;
+  "payload access qualifiers ignored. These are only supported for lib_6_7+ targets and lib_6_6 with with the -enable-payload-qualifiers flag.">, InGroup<HLSLPayloadAccessQualifer>;
 def err_hlsl_unsupported_builtin_op: Error<
   "operator cannot be used with built-in type %0">;
 def err_hlsl_unsupported_char_literal : Error<

--- a/tools/clang/test/DXC/disable_paq.hlsl
+++ b/tools/clang/test/DXC/disable_paq.hlsl
@@ -1,0 +1,18 @@
+// RUN: %dxc -T lib_6_7 -disable-payload-qualifiers %s 2>&1 | FileCheck %s
+// RUN: %dxc -T lib_6_8 -disable-payload-qualifiers %s 2>&1 | FileCheck %s
+
+// Ensures that -disable-payload-qualifiers works properly for SM6.6+ versions
+
+
+// CHECK: warning: payload access qualifiers ignored. These are only supported for lib_6_7+ targets and lib_6_6 with with the -enable-payload-qualifiers flag.
+
+// CHECK-NOT: !dx.dxrPayloadAnnotations
+
+struct [raypayload] Payload {
+    int a : read(caller) : write(caller, miss);
+};
+
+[shader("miss")]
+void main( inout Payload payload ) {
+  payload.a = 0.0;
+}

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/access.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/access.hlsl
@@ -10,6 +10,18 @@
 // RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=9 | FileCheck -check-prefix=CHK9 -input-file=stderr  %s
 // RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=10 | FileCheck -check-prefix=CHK10 -input-file=stderr  %s
 // RUN: %dxc -T lib_6_6 main %s -enable-payload-qualifiers -D TEST_NUM=11 | FileCheck -check-prefix=CHK11 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=0 | FileCheck -check-prefix=CHK0 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=1 | FileCheck -check-prefix=CHK1 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=2 | FileCheck -check-prefix=CHK2 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=3 | FileCheck -check-prefix=CHK3 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=4 | FileCheck -check-prefix=CHK4 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=5 | FileCheck -check-prefix=CHK5 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=6 | FileCheck -check-prefix=CHK6 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=7 | FileCheck -check-prefix=CHK7 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=8 | FileCheck -check-prefix=CHK8 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=9 | FileCheck -check-prefix=CHK9 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=10 | FileCheck -check-prefix=CHK10 -input-file=stderr  %s
+// RUN: %dxc -T lib_6_7 main %s -D TEST_NUM=11 | FileCheck -check-prefix=CHK11 -input-file=stderr  %s
 
 // CHK0-NOT: -Wpayload-access-
 

--- a/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
+++ b/tools/clang/test/HLSLFileCheck/hlsl/payload_qualifier/general.hlsl
@@ -5,7 +5,7 @@
 
 // check if we get DXIL and the payload type is there 
 // CHK4: Invalid target for payload access qualifiers. Only lib_6_6 and beyond are supported.
-// CHK5: warning: payload access qualifieres are only supported for target lib_6_6 and beyond. You can opt-in for lib_6_6 with the -enable-payload-qualifiers flag. Qualifiers will be dropped.
+// CHK5: warning: payload access qualifiers ignored. These are only supported for lib_6_7+ targets and lib_6_6 with with the -enable-payload-qualifiers flag.
 // CHK5: struct [raypayload] Payload {
 // CHK5-NOT: struct [raypayload] OtherPayload {
 // CHK6: %struct.Payload = type { i32, i32 }


### PR DESCRIPTION
The original payload access qualifiers change disallowed disabling them on 6.8+ versions. This wasn't an intended feature of 6.8. We'd prefer to maintain the ability to disable these when needed to avoid issues that might crop up.

This change extends respect of the disable-payload-qualifiers flag for all versions. It rewords the warning that is produced when they are encountered when disabled to be more applicable. Tests are also added to verify that the implicit enabling in 6.7+ works in the basic cases and also that disabling in the 6.7+ cases works as well.

Fixes #6462