### PR TITLE
Enable system values for mesh nodes

### DIFF
--- a/lib/DXIL/DxilNodeProps.cpp
+++ b/lib/DXIL/DxilNodeProps.cpp
@@ -72,7 +72,8 @@ bool NodeFlags::RecordTypeMatchesLaunchType(
     DXIL::NodeLaunchType launchType) const {
   DXIL::NodeIOFlags granularity = (DXIL::NodeIOFlags)(
       (uint32_t)m_Flags & (uint32_t)DXIL::NodeIOFlags::RecordGranularityMask);
-  uint32_t writable = ((uint32_t)m_Flags & (uint32_t)DXIL::NodeIOFlags::ReadWrite);
+  uint32_t writable =
+      ((uint32_t)m_Flags & (uint32_t)DXIL::NodeIOFlags::ReadWrite);
   return (launchType == DXIL::NodeLaunchType::Broadcasting &&
           granularity == DXIL::NodeIOFlags::DispatchRecord) ||
          (launchType == DXIL::NodeLaunchType::Coalescing &&
@@ -80,8 +81,7 @@ bool NodeFlags::RecordTypeMatchesLaunchType(
          (launchType == DXIL::NodeLaunchType::Thread &&
           granularity == DXIL::NodeIOFlags::ThreadRecord) ||
          (launchType == DXIL::NodeLaunchType::Mesh &&
-          granularity == DXIL::NodeIOFlags::DispatchRecord &&
-          !writable);
+          granularity == DXIL::NodeIOFlags::DispatchRecord && !writable);
 }
 
 void NodeFlags::SetTrackRWInputSharing() {

--- a/lib/DXIL/DxilNodeProps.cpp
+++ b/lib/DXIL/DxilNodeProps.cpp
@@ -70,14 +70,18 @@ bool NodeFlags::IsValidNodeKind() const {
 
 bool NodeFlags::RecordTypeMatchesLaunchType(
     DXIL::NodeLaunchType launchType) const {
-  DXIL::NodeIOFlags recordLaunchType = (DXIL::NodeIOFlags)(
+  DXIL::NodeIOFlags granularity = (DXIL::NodeIOFlags)(
       (uint32_t)m_Flags & (uint32_t)DXIL::NodeIOFlags::RecordGranularityMask);
+  uint32_t writable = ((uint32_t)m_Flags & (uint32_t)DXIL::NodeIOFlags::ReadWrite);
   return (launchType == DXIL::NodeLaunchType::Broadcasting &&
-          recordLaunchType == DXIL::NodeIOFlags::DispatchRecord) ||
+          granularity == DXIL::NodeIOFlags::DispatchRecord) ||
          (launchType == DXIL::NodeLaunchType::Coalescing &&
-          recordLaunchType == DXIL::NodeIOFlags::GroupRecord) ||
+          granularity == DXIL::NodeIOFlags::GroupRecord) ||
          (launchType == DXIL::NodeLaunchType::Thread &&
-          recordLaunchType == DXIL::NodeIOFlags::ThreadRecord);
+          granularity == DXIL::NodeIOFlags::ThreadRecord) ||
+         (launchType == DXIL::NodeLaunchType::Mesh &&
+          granularity == DXIL::NodeIOFlags::DispatchRecord &&
+          !writable);
 }
 
 void NodeFlags::SetTrackRWInputSharing() {

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -2180,6 +2180,8 @@ std::string GetLaunchTypeStr(DXIL::NodeLaunchType LT) {
     return "Coalescing";
   case DXIL::NodeLaunchType::Thread:
     return "Thread";
+  case DXIL::NodeLaunchType::Mesh:
+    return "Mesh";
   default:
     return "Invalid";
   }
@@ -2423,7 +2425,8 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
       break;
     }
 
-    if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting)
+    if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting ||
+        nodeLaunchType == DXIL::NodeLaunchType::Mesh)
       break;
 
     ValCtx.EmitInstrFormatError(
@@ -2436,7 +2439,8 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
       break;
     }
 
-    if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting)
+    if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting ||
+        nodeLaunchType == DXIL::NodeLaunchType::Mesh)
       break;
 
     ValCtx.EmitInstrFormatError(
@@ -2450,7 +2454,8 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
     }
 
     if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting ||
-        nodeLaunchType == DXIL::NodeLaunchType::Coalescing)
+        nodeLaunchType == DXIL::NodeLaunchType::Coalescing ||
+        nodeLaunchType == DXIL::NodeLaunchType::Mesh)
       break;
 
     ValCtx.EmitInstrFormatError(CI,
@@ -2466,7 +2471,8 @@ static void ValidateDxilOperationCallInProfile(CallInst *CI,
     }
 
     if (nodeLaunchType == DXIL::NodeLaunchType::Broadcasting ||
-        nodeLaunchType == DXIL::NodeLaunchType::Coalescing)
+        nodeLaunchType == DXIL::NodeLaunchType::Coalescing ||
+        nodeLaunchType == DXIL::NodeLaunchType::Mesh)
       break;
 
     ValCtx.EmitInstrFormatError(CI,
@@ -3581,6 +3587,9 @@ static void ValidateNodeInputRecord(Function *F, ValidationContext &ValCtx) {
         break;
       case DXIL::NodeLaunchType::Thread:
         validInputs = "{RW}ThreadNodeInputRecord";
+        break;
+      case DXIL::NodeLaunchType::Mesh:
+        validInputs = "DispatchNodeInputRecord";
         break;
       default:
         llvm_unreachable("invalid launch type");

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7851,7 +7851,7 @@ def err_hlsl_wg_nodetrackrwinputsharing_invalid : Error<
    "NodeTrackRWInputSharing attribute cannot be applied to Input Records that are not RWDispatchNodeInputRecord">;
 def err_hlsl_wg_input_kind : Error<
    "'%0' may not be used with %1 nodes (only %select{DispatchNodeInputRecord or RWDispatchNodeInputRecord|"
-   "GroupNodeInputRecords, RWGroupNodeInputRecords, or EmptyNodeInput|ThreadNodeInputRecord or RWThreadNodeInputRecord}2)">;
+   "GroupNodeInputRecords, RWGroupNodeInputRecords, or EmptyNodeInput|ThreadNodeInputRecord or RWThreadNodeInputRecord|DispatchNodeInputRecord}2)">;
 def err_hlsl_wg_attr_only_on_output : Error<
    "attribute %0 may only be used with output nodes">;
 def err_hlsl_wg_attr_only_on_output_or_input_record : Error<
@@ -7891,9 +7891,9 @@ def err_hlsl_incompatible_node_attr : Error<
 def err_hlsl_missing_node_attr : Error<
    "Node shader '%0' with %1 launch type requires '%2' attribute">;
 def err_hlsl_missing_dispatchgrid_attr : Error<
-   "Broadcasting node shader '%0' must have either the NodeDispatchGrid or NodeMaxDispatchGrid attribute">;
+   "Broadcasting/Mesh node shader '%0' must have either the NodeDispatchGrid or NodeMaxDispatchGrid attribute">;
 def err_hlsl_missing_dispatchgrid_semantic : Error<
-   "Broadcasting node shader '%0' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic">;
+   "Broadcasting/Mesh node shader '%0' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic">;
 def err_hlsl_dispatchgrid_semantic_already_specified : Error<
    "a field with SV_DispatchGrid has already been specified">;
 def err_hlsl_incompatible_dispatchgrid_semantic_type : Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15183,7 +15183,7 @@ static bool nodeInputIsCompatible(DXIL::NodeIOKind IOType,
   switch (IOType) {
   case DXIL::NodeIOKind::DispatchNodeInputRecord:
     return launchType == DXIL::NodeLaunchType::Broadcasting ||
-      launchType == DXIL::NodeLaunchType::Mesh;
+           launchType == DXIL::NodeLaunchType::Mesh;
 
   case DXIL::NodeIOKind::RWDispatchNodeInputRecord:
     return launchType == DXIL::NodeLaunchType::Broadcasting;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -15182,6 +15182,9 @@ static bool nodeInputIsCompatible(DXIL::NodeIOKind IOType,
                                   DXIL::NodeLaunchType launchType) {
   switch (IOType) {
   case DXIL::NodeIOKind::DispatchNodeInputRecord:
+    return launchType == DXIL::NodeLaunchType::Broadcasting ||
+      launchType == DXIL::NodeLaunchType::Mesh;
+
   case DXIL::NodeIOKind::RWDispatchNodeInputRecord:
     return launchType == DXIL::NodeLaunchType::Broadcasting;
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
@@ -1,0 +1,84 @@
+// RUN: %if dxil-1-9 %{ %dxc -T lib_6_9 %s | FileCheck %s %}
+
+// Test all valid mesh node input parameters work
+
+// CHECK: define void @node01()
+// CHECK:  %[[tid_x:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 0)  ; ThreadId(component)
+// CHECK:  %[[tid_y:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 1)  ; ThreadId(component)
+// CHECK:  %[[tid_z:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 2)  ; ThreadId(component)
+
+// CHECK:  %[[ftid:.+]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)  ; FlattenedThreadIdInGroup()
+
+// CHECK:  %[[tid_group_x:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 0)  ; ThreadIdInGroup(component)
+// CHECK:  %[[tid_group_y:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 1)  ; ThreadIdInGroup(component)
+// CHECK:  %[[tid_group_z:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 2)  ; ThreadIdInGroup(component)
+
+// CHECK:  %[[Hdl:.+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+// CHECK:  %[[annotHdl:.+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %[[Hdl]], %dx.types.NodeRecordInfo { i32 97, i32 52 })  ; AnnotateNodeRecordHandle(noderecord,props)
+
+// CHECK:  %[[node_ptr:.+]] = call %struct.RECORD.0 addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD.0(i32 239, %dx.types.NodeRecordHandle %[[annotHdl]], i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 0, i32 0
+// CHECK:  %[[ld1:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 0, i32 1
+// CHECK:  %[[ld2:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 0, i32 2
+// CHECK:  %[[ld3:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %{{[0-9]+}}, i32 1, i32 0, i32 %[[ld1]], i32 %[[ld2]], i32 %[[ld3]], i32 undef, i8 7, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
+
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 1, i32 0
+// CHECK:  %[[ld1:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 1, i32 1
+// CHECK:  %[[ld2:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 1, i32 2
+// CHECK:  %[[ld3:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %{{[0-9]+}}, i32 2, i32 0, i32 %[[ld1]], i32 %[[ld2]], i32 %[[ld3]], i32 undef, i8 7, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
+
+// CHECK:  %[[ptr:.+]] = getelementptr %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 2
+// CHECK:  %[[ld1:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %{{[0-9]+}}, i32 3, i32 0, i32 %[[ld1]], i32 %[[ld1]], i32 %[[ld1]], i32 undef, i8 7, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
+
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 3, i32 0
+// CHECK:  %[[ld1:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 3, i32 1
+// CHECK:  %[[ld2:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  %[[ptr:.+]] = getelementptr inbounds %struct.RECORD.0, %struct.RECORD.0 addrspace(6)* %[[node_ptr]], i32 0, i32 3, i32 2
+// CHECK:  %[[ld3:.+]] = load i32, i32 addrspace(6)* %[[ptr]], align 4
+// CHECK:  call void @dx.op.rawBufferStore.i32(i32 140, %dx.types.Handle %{{[0-9]+}}, i32 4, i32 0, i32 %[[ld1]], i32 %[[ld2]], i32 %[[ld3]], i32 undef, i8 7, i32 4)  ; RawBufferStore(uav,index,elementOffset,value0,value1,value2,value3,mask,alignment)
+// CHECK:  ret void
+
+struct RECORD
+{
+  uint3 dtid;
+  uint3 gid;
+  uint gidx;
+  uint3 gtid;
+  uint3 dg : SV_DispatchGrid;
+};
+
+RWStructuredBuffer<uint3> outbuf;
+
+[Shader("node")]
+[numthreads(4,4,4)]
+[NodeMaxDispatchGrid(4,4,4)]
+[NodeLaunch("mesh")]
+[OutputTopology("line")]
+void node01(DispatchNodeInputRecord<RECORD> input,
+ uint3 DTID : SV_DispatchThreadID,
+ uint3 GID : SV_GroupID,
+ uint GIdx : SV_GroupIndex,
+ uint3 GTID : SV_GroupThreadID )
+{
+  outbuf[0] = input.Get().dg;
+  if (any(DTID) != 0)
+    return;
+  outbuf[1] = input.Get().dtid;
+  if (any(GID) != 0)
+    return;
+  outbuf[2] = input.Get().gid;
+  if (GIdx != 0)
+    return;
+  outbuf[3] = input.Get().gidx;
+  if (any(GTID) != 0)
+    return;
+  outbuf[4] = input.Get().gtid;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
@@ -1,4 +1,6 @@
-// RUN: %if dxil-1-9 %{ %dxc -T lib_6_9 %s | FileCheck %s %}
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// REQUIRES: dxil-1-9
 
 // Test all valid mesh node input parameters work
 

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-input-parameters.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-input-parameters.hlsl
@@ -1,4 +1,6 @@
-// RUN: %if dxil-1-9 %{ %dxc -T lib_6_9 -verify %s | FileCheck %s %}
+// RUN: %dxc -T lib_6_9 -verify %s
+
+// REQUIRES: dxil-1-9
 
 // Test that invalid mesh node input parameters fail with appropriate diagnostics
 
@@ -18,7 +20,7 @@ void node01_rw(RWDispatchNodeInputRecord<RECORD> input, // expected-error {{'RWD
 [Shader("node")]
 [numthreads(4,4,4)]
 [NodeMaxDispatchGrid(4,4,4)]
-[NodeLaunch("mesh")] // expected-note {{Launch type defined here}}
+[NodeLaunch("mesh")]
 void node02_maxdisp(DispatchNodeInputRecord<RECORD> input, // expected-error {{Broadcasting/Mesh node shader 'node02_maxdisp' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
  uint3 GTID : SV_GroupThreadID ) {
 }

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-input-parameters.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-input-parameters.hlsl
@@ -1,0 +1,24 @@
+// RUN: %if dxil-1-9 %{ %dxc -T lib_6_9 -verify %s | FileCheck %s %}
+
+// Test that invalid mesh node input parameters fail with appropriate diagnostics
+
+struct RECORD {
+  uint3 gtid;
+};
+
+[Shader("node")]
+[numthreads(4,4,4)]
+[NodeDispatchGrid(4,4,4)]
+[NodeLaunch("mesh")] // expected-note {{Launch type defined here}}
+void node01_rw(RWDispatchNodeInputRecord<RECORD> input, // expected-error {{'RWDispatchNodeInputRecord' may not be used with mesh nodes (only DispatchNodeInputRecord)}}
+ uint3 GTID : SV_GroupThreadID ) {
+  input.Get().gtid = GTID;
+}
+
+[Shader("node")]
+[numthreads(4,4,4)]
+[NodeMaxDispatchGrid(4,4,4)]
+[NodeLaunch("mesh")] // expected-note {{Launch type defined here}}
+void node02_maxdisp(DispatchNodeInputRecord<RECORD> input, // expected-error {{Broadcasting/Mesh node shader 'node02_maxdisp' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+ uint3 GTID : SV_GroupThreadID ) {
+}

--- a/tools/clang/test/HLSLFileCheck/validation/mesh-node-inputs.hlsl
+++ b/tools/clang/test/HLSLFileCheck/validation/mesh-node-inputs.hlsl
@@ -1,0 +1,50 @@
+// Source file for altered mesh-node-inputs.ll
+// Not intended for indpendent testing
+
+// Run line required in this location, so we'll verify compilation succeeds.
+// RUN: %dxc -T lib_6_8 %s | FileCheck %s
+// CHECK: define void @node_RWDispatchNodeInputRecord()
+// CHECK: define void @node_GroupNodeInputRecords()
+// CHECK: define void @node_RWGroupNodeInputRecords()
+// CHECK: define void @node_ThreadNodeInputRecord()
+// CHECK: define void @node_RWThreadNodeInputRecord()
+
+RWBuffer<uint> buf0;
+
+struct RECORD {
+  uint ival;
+};
+
+[Shader("node")]
+[NumThreads(1024,1,1)]
+[NodeDispatchGrid(64,1,1)]
+[NodeLaunch("broadcasting")]
+void node_RWDispatchNodeInputRecord(RWDispatchNodeInputRecord<RECORD> input) {
+  buf0[0] = input.Get().ival;
+}
+
+[Shader("node")]
+[NodeLaunch("coalescing")]
+[NumThreads(1024,1,1)]
+void node_GroupNodeInputRecords(GroupNodeInputRecords<RECORD> input) {
+  buf0[0] = input.Get().ival;
+}
+
+[Shader("node")]
+[NodeLaunch("coalescing")]
+[NumThreads(1024,1,1)]
+void node_RWGroupNodeInputRecords(RWGroupNodeInputRecords<RECORD> input) {
+  buf0[0] = input.Get().ival;
+}
+
+[Shader("node")]
+[NodeLaunch("thread")]
+void node_ThreadNodeInputRecord(ThreadNodeInputRecord<RECORD> input) {
+  buf0[0] = input.Get().ival;
+}
+
+[Shader("node")]
+[NodeLaunch("thread")]
+void node_RWThreadNodeInputRecord(RWThreadNodeInputRecord<RECORD> input) {
+  buf0[0] = input.Get().ival;
+}

--- a/tools/clang/test/HLSLFileCheck/validation/mesh-node-inputs.ll
+++ b/tools/clang/test/HLSLFileCheck/validation/mesh-node-inputs.ll
@@ -1,0 +1,163 @@
+; RUN: %dxilver 1.9 | %dxv %s | FileCheck %s
+
+; Test that appropriate errors are produced for invalid mesh node input types
+
+; Generated from mesh-node-inputs.hlsl and altered by converting all the nodes to mesh
+
+target datalayout = "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64"
+target triple = "dxil-ms-dx"
+
+%dx.types.Handle = type { i8* }
+%dx.types.NodeRecordHandle = type { i8* }
+%dx.types.NodeRecordInfo = type { i32, i32 }
+%struct.RECORD = type { i32 }
+%dx.types.ResourceProperties = type { i32, i32 }
+%"class.RWBuffer<unsigned int>" = type { i32 }
+
+@"\01?buf0@@3V?$RWBuffer@I@@A" = external constant %dx.types.Handle, align 4
+
+
+; CHECK: mesh node shader 'node_RWDispatchNodeInputRecord' has incompatible input record type (should be DispatchNodeInputRecord)
+define void @node_RWDispatchNodeInputRecord() {
+  %1 = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+  %2 = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %2, %dx.types.NodeRecordInfo { i32 101, i32 4 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %4 = call %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32 239, %dx.types.NodeRecordHandle %3, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %5 = getelementptr %struct.RECORD, %struct.RECORD addrspace(6)* %4, i32 0, i32 0
+  %6 = load i32, i32 addrspace(6)* %5, align 4
+  %7 = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %1)  ; CreateHandleForLib(Resource)
+  %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %7, %dx.types.ResourceProperties { i32 4106, i32 261 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<U32>
+  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %8, i32 0, i32 undef, i32 %6, i32 %6, i32 %6, i32 %6, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ret void
+}
+
+; CHECK: mesh node shader 'node_GroupNodeInputRecords' has incompatible input record type (should be DispatchNodeInputRecord)
+define void @node_GroupNodeInputRecords() {
+  %1 = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+  %2 = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %2, %dx.types.NodeRecordInfo { i32 65, i32 4 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %4 = call %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32 239, %dx.types.NodeRecordHandle %3, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %5 = getelementptr %struct.RECORD, %struct.RECORD addrspace(6)* %4, i32 0, i32 0
+  %6 = load i32, i32 addrspace(6)* %5, align 4
+  %7 = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %1)  ; CreateHandleForLib(Resource)
+  %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %7, %dx.types.ResourceProperties { i32 4106, i32 261 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<U32>
+  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %8, i32 0, i32 undef, i32 %6, i32 %6, i32 %6, i32 %6, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ret void
+}
+
+; CHECK: mesh node shader 'node_RWGroupNodeInputRecords' has incompatible input record type (should be DispatchNodeInputRecord)
+define void @node_RWGroupNodeInputRecords() {
+  %1 = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+  %2 = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %2, %dx.types.NodeRecordInfo { i32 69, i32 4 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %4 = call %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32 239, %dx.types.NodeRecordHandle %3, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %5 = getelementptr %struct.RECORD, %struct.RECORD addrspace(6)* %4, i32 0, i32 0
+  %6 = load i32, i32 addrspace(6)* %5, align 4
+  %7 = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %1)  ; CreateHandleForLib(Resource)
+  %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %7, %dx.types.ResourceProperties { i32 4106, i32 261 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<U32>
+  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %8, i32 0, i32 undef, i32 %6, i32 %6, i32 %6, i32 %6, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ret void
+}
+
+; CHECK: mesh node shader 'node_ThreadNodeInputRecord' has incompatible input record type (should be DispatchNodeInputRecord)
+define void @node_ThreadNodeInputRecord() {
+  %1 = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+  %2 = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %2, %dx.types.NodeRecordInfo { i32 33, i32 4 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %4 = call %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32 239, %dx.types.NodeRecordHandle %3, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %5 = getelementptr %struct.RECORD, %struct.RECORD addrspace(6)* %4, i32 0, i32 0
+  %6 = load i32, i32 addrspace(6)* %5, align 4
+  %7 = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %1)  ; CreateHandleForLib(Resource)
+  %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %7, %dx.types.ResourceProperties { i32 4106, i32 261 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<U32>
+  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %8, i32 0, i32 undef, i32 %6, i32 %6, i32 %6, i32 %6, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ret void
+}
+
+; CHECK: mesh node shader 'node_RWThreadNodeInputRecord' has incompatible input record type (should be DispatchNodeInputRecord)
+define void @node_RWThreadNodeInputRecord() {
+  %1 = load %dx.types.Handle, %dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A", align 4
+  %2 = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
+  %3 = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %2, %dx.types.NodeRecordInfo { i32 37, i32 4 })  ; AnnotateNodeRecordHandle(noderecord,props)
+  %4 = call %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32 239, %dx.types.NodeRecordHandle %3, i32 0)  ; GetNodeRecordPtr(recordhandle,arrayIndex)
+  %5 = getelementptr %struct.RECORD, %struct.RECORD addrspace(6)* %4, i32 0, i32 0
+  %6 = load i32, i32 addrspace(6)* %5, align 4
+  %7 = call %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32 160, %dx.types.Handle %1)  ; CreateHandleForLib(Resource)
+  %8 = call %dx.types.Handle @dx.op.annotateHandle(i32 216, %dx.types.Handle %7, %dx.types.ResourceProperties { i32 4106, i32 261 })  ; AnnotateHandle(res,props)  resource: RWTypedBuffer<U32>
+  call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle %8, i32 0, i32 undef, i32 %6, i32 %6, i32 %6, i32 %6, i8 15)  ; BufferStore(uav,coord0,coord1,value0,value1,value2,value3,mask)
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare %struct.RECORD addrspace(6)* @dx.op.getNodeRecordPtr.struct.RECORD(i32, %dx.types.NodeRecordHandle, i32) #0
+
+; Function Attrs: nounwind
+declare void @dx.op.bufferStore.i32(i32, %dx.types.Handle, i32, i32, i32, i32, i32, i32, i8) #1
+
+; Function Attrs: nounwind readnone
+declare %dx.types.Handle @dx.op.annotateHandle(i32, %dx.types.Handle, %dx.types.ResourceProperties) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32, i32) #0
+
+; Function Attrs: nounwind readnone
+declare %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32, %dx.types.NodeRecordHandle, %dx.types.NodeRecordInfo) #0
+
+; Function Attrs: nounwind readonly
+declare %dx.types.Handle @dx.op.createHandleForLib.dx.types.Handle(i32, %dx.types.Handle) #2
+
+attributes #0 = { nounwind readnone }
+attributes #1 = { nounwind }
+attributes #2 = { nounwind readonly }
+
+!llvm.ident = !{!0}
+!dx.version = !{!1}
+!dx.valver = !{!1}
+!dx.shaderModel = !{!2}
+!dx.resources = !{!3}
+!dx.typeAnnotations = !{!7}
+!dx.entryPoints = !{!11, !13, !21, !27, !32, !38}
+
+!0 = !{!"dxc(private) 1.8.0.4537 (ready-for-6.9, baa5d308a-dirty)"}
+!1 = !{i32 1, i32 9}
+!2 = !{!"lib", i32 6, i32 9}
+!3 = !{null, !4, null, null}
+!4 = !{!5}
+!5 = !{i32 0, %"class.RWBuffer<unsigned int>"* bitcast (%dx.types.Handle* @"\01?buf0@@3V?$RWBuffer@I@@A" to %"class.RWBuffer<unsigned int>"*), !"buf0", i32 -1, i32 -1, i32 1, i32 10, i1 false, i1 false, i1 false, !6}
+!6 = !{i32 0, i32 5}
+!7 = !{i32 1, void ()* @node_RWDispatchNodeInputRecord, !8, void ()* @node_GroupNodeInputRecords, !8, void ()* @node_RWGroupNodeInputRecords, !8, void ()* @node_ThreadNodeInputRecord, !8, void ()* @node_RWThreadNodeInputRecord, !8}
+!8 = !{!9}
+!9 = !{i32 0, !10, !10}
+!10 = !{}
+!11 = !{null, !"", null, !3, !12}
+!12 = !{i32 0, i64 8589934592}
+!13 = !{void ()* @node_GroupNodeInputRecords, !"node_GroupNodeInputRecords", null, null, !14}
+!14 = !{i32 8, i32 15, i32 13, i32 4, i32 15, !15, i32 16, i32 -1, i32 20, !16, i32 4, !19, i32 5, !20}
+!15 = !{!"node_GroupNodeInputRecords", i32 0}
+!16 = !{!17}
+!17 = !{i32 1, i32 65, i32 2, !18}
+!18 = !{i32 0, i32 4, i32 2, i32 4}
+!19 = !{i32 1024, i32 1, i32 1}
+!20 = !{i32 0}
+!21 = !{void ()* @node_RWDispatchNodeInputRecord, !"node_RWDispatchNodeInputRecord", null, null, !22}
+!22 = !{i32 8, i32 15, i32 13, i32 4, i32 15, !23, i32 16, i32 -1, i32 18, !24, i32 20, !25, i32 4, !19, i32 5, !20}
+!23 = !{!"node_RWDispatchNodeInputRecord", i32 0}
+!24 = !{i32 64, i32 1, i32 1}
+!25 = !{!26}
+!26 = !{i32 1, i32 101, i32 2, !18}
+!27 = !{void ()* @node_RWGroupNodeInputRecords, !"node_RWGroupNodeInputRecords", null, null, !28}
+!28 = !{i32 8, i32 15, i32 13, i32 4, i32 15, !29, i32 16, i32 -1, i32 20, !30, i32 4, !19, i32 5, !20}
+!29 = !{!"node_RWGroupNodeInputRecords", i32 0}
+!30 = !{!31}
+!31 = !{i32 1, i32 69, i32 2, !18}
+!32 = !{void ()* @node_RWThreadNodeInputRecord, !"node_RWThreadNodeInputRecord", null, null, !33}
+!33 = !{i32 8, i32 15, i32 13, i32 4, i32 15, !34, i32 16, i32 -1, i32 20, !35, i32 4, !37, i32 5, !20}
+!34 = !{!"node_RWThreadNodeInputRecord", i32 0}
+!35 = !{!36}
+!36 = !{i32 1, i32 37, i32 2, !18}
+!37 = !{i32 1, i32 1, i32 1}
+!38 = !{void ()* @node_ThreadNodeInputRecord, !"node_ThreadNodeInputRecord", null, null, !39}
+!39 = !{i32 8, i32 15, i32 13, i32 4, i32 15, !40, i32 16, i32 -1, i32 20, !41, i32 4, !37, i32 5, !20}
+!40 = !{!"node_ThreadNodeInputRecord", i32 0}
+!41 = !{!42}
+!42 = !{i32 1, i32 33, i32 2, !18}
+

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/attribute_diags.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/attribute_diags.hlsl
@@ -35,7 +35,7 @@ void node04()
 [NodeMaxDispatchGrid(256, 64, 32)]   // expected-error {{Node shader 'node05' may not use both 'nodemaxdispatchgrid' and 'nodedispatchgrid'}}
 [NodeDispatchGrid(32, 1, 1)]         // expected-note  {{nodedispatchgrid defined here}}
 [NumThreads(32, 1, 1)]
-void node05()                        // expected-error {{Broadcasting node shader 'node05' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+void node05()                        // expected-error {{Broadcasting/Mesh node shader 'node05' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 { }
 
 // One of NodeDispatchGrid or NodeMaxDispatchGrid must be specified for a Broadcasting node
@@ -43,7 +43,7 @@ void node05()                        // expected-error {{Broadcasting node shade
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NumThreads(32, 1, 1)]
-void node06()                        // expected-error {{Broadcasting node shader 'node06' must have either the NodeDispatchGrid or NodeMaxDispatchGrid attribute}}
+void node06()                        // expected-error {{Broadcasting/Mesh node shader 'node06' must have either the NodeDispatchGrid or NodeMaxDispatchGrid attribute}}
 { }
 
 // NodeTrackRWInputRecordSharing must appear on the actual input record used if FinishedCrossGroupSharing may be called,

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatchgrid_diags.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/dispatchgrid_diags.hlsl
@@ -104,7 +104,7 @@ void node16(DispatchNodeInputRecord<MyStruct> input)
 [Shader("node")]
 [NodeMaxDispatchGrid(3, 1, 1)]
 [NumThreads(17, 1, 1)]
-void node17()               // expected-error {{Broadcasting node shader 'node17' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+void node17()               // expected-error {{Broadcasting/Mesh node shader 'node17' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 { }
 
 struct MyStruct2 {
@@ -115,7 +115,7 @@ struct MyStruct2 {
 [NodeLaunch("broadcasting")]
 [NodeMaxDispatchGrid(256, 8, 8)]
 [NumThreads(32, 1, 1)]
-void node18(DispatchNodeInputRecord<MyStruct2> input)  // expected-error {{Broadcasting node shader 'node18' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+void node18(DispatchNodeInputRecord<MyStruct2> input)  // expected-error {{Broadcasting/Mesh node shader 'node18' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 { }
 
 struct MyStruct3 {

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/node_input_array.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/node_input_array.hlsl
@@ -10,7 +10,7 @@ struct Record {
 [NodeMaxDispatchGrid(65535, 1, 1)]
 [NodeIsProgramEntry]
 [NumThreads(32, 1, 1)]
-// expected-error@+2 {{Broadcasting node shader 'node01' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+// expected-error@+2 {{Broadcasting/Mesh node shader 'node01' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 // expected-error@+1 {{entry parameter of type 'GroupNodeInputRecords<Record> [9]' may not be an array}}
 void node01(GroupNodeInputRecords<Record> input[9])
 { }
@@ -20,7 +20,7 @@ void node01(GroupNodeInputRecords<Record> input[9])
 [NodeMaxDispatchGrid(65535, 1, 1)]
 [NodeIsProgramEntry]
 [NumThreads(32, 1, 1)]
-// expected-error@+2 {{Broadcasting node shader 'node02' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+// expected-error@+2 {{Broadcasting/Mesh node shader 'node02' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 // expected-error@+1 {{entry parameter of type 'RWGroupNodeInputRecords<Record> [9]' may not be an array}}
 void node02(RWGroupNodeInputRecords<Record> input[9])
 { }

--- a/tools/clang/test/SemaHLSL/hlsl/workgraph/zero_sized_node_record.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/workgraph/zero_sized_node_record.hlsl
@@ -28,14 +28,14 @@ struct EMPTY4 { // expected-note +{{zero sized record defined here}}
 [NodeLaunch("broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(64, 1, 1)]
-void node01(DispatchNodeInputRecord<EMPTY> input) // expected-error {{record used in DispatchNodeInputRecord may not have zero size}} expected-error {{Broadcasting node shader 'node01' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+void node01(DispatchNodeInputRecord<EMPTY> input) // expected-error {{record used in DispatchNodeInputRecord may not have zero size}} expected-error {{Broadcasting/Mesh node shader 'node01' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 {}
 
 [Shader("node")]
 [NodeLaunch("broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(64, 1, 1)]
-void node02(RWDispatchNodeInputRecord<EMPTY> input) // expected-error {{record used in RWDispatchNodeInputRecord may not have zero size}} expected-error {{Broadcasting node shader 'node02' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+void node02(RWDispatchNodeInputRecord<EMPTY> input) // expected-error {{record used in RWDispatchNodeInputRecord may not have zero size}} expected-error {{Broadcasting/Mesh node shader 'node02' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 {}
 
 [Shader("node")]
@@ -73,7 +73,7 @@ void node07(NodeOutput<EMPTY> output) // expected-error {{record used in NodeOut
 [NodeLaunch("broadcasting")]
 [NumThreads(1,1,1)]
 [NodeMaxDispatchGrid(64, 1, 1)]
-// expected-error@+1 {{Broadcasting node shader 'node08' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
+// expected-error@+1 {{Broadcasting/Mesh node shader 'node08' with NodeMaxDispatchGrid attribute must declare an input record containing a field with SV_DispatchGrid semantic}}
 void node08(NodeOutputArray<EMPTY3> output) // expected-error {{record used in NodeOutputArray may not have zero size}}
 {}
 


### PR DESCRIPTION
This allows the intersection of system values shared by mesh shaders and broadcasting nodes to be used by allowing mesh nodes to accept most input values that broadcasting nodes do. The exception is the writable DispatchRecords. It also involved rewording some error messages to account for mesh nodes which required changing some existing tests to just accept the new diagnostic. New tests were added to ensure that all the system values are accepted and treated properly and also that invalid usages were rejected.

Fixes #6470