### PR TITLE
Support SetMeshOutputCounts in mesh nodes

### DIFF
--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -3251,12 +3251,19 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     mask = SFLAG(Library) | SFLAG(Pixel);
     return;
   }
-  // Instructions: SetMeshOutputCounts=168, EmitIndices=169, GetMeshPayload=170,
-  // StoreVertexOutput=171, StorePrimitiveOutput=172
-  if ((168 <= op && op <= 172)) {
+  // Instructions: EmitIndices=169, GetMeshPayload=170, StoreVertexOutput=171,
+  // StorePrimitiveOutput=172
+  if ((169 <= op && op <= 172)) {
     major = 6;
     minor = 5;
     mask = SFLAG(Mesh);
+    return;
+  }
+  // Instructions: SetMeshOutputCounts=168
+  if (op == 168) {
+    major = 6;
+    minor = 5;
+    mask = SFLAG(Mesh) | SFLAG(Node);
     return;
   }
   // Instructions: CreateHandleFromHeap=218, Unpack4x8=219, Pack4x8=220,

--- a/lib/HLSL/DxilValidation.cpp
+++ b/lib/HLSL/DxilValidation.cpp
@@ -1463,8 +1463,8 @@ static void ValidateSignatureDxilOp(CallInst *CI, DXIL::OpCode opcode,
     }
   } break;
   case DXIL::OpCode::SetMeshOutputCounts: {
-    if (!props.IsMS() && (!props.IsNode() ||
-                          props.Node.LaunchType != DXIL::NodeLaunchType::Mesh)) {
+    if (!props.IsMS() && (!props.IsNode() || props.Node.LaunchType !=
+                                                 DXIL::NodeLaunchType::Mesh)) {
       ValCtx.EmitInstrFormatError(CI, ValidationRule::SmOpcodeInInvalidFunction,
                                   {"SetMeshOutputCounts", "Mesh shader"});
     }

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-set-mesh-output-counts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-set-mesh-output-counts.hlsl
@@ -1,0 +1,34 @@
+// RUN: not %dxc -T lib_6_9 %s 2>&1 | FileCheck %s
+
+// REQUIRES: dxil-1-9
+ 
+// Ensure that setMeshOutputCounts will be appropriately rejected by non-mesh nodes
+
+RWBuffer<float> buf0;
+
+// CHECK:  14: error: Function uses features incompatible with the shader stage (node) of the entry function.
+[Shader("node")]
+[NumThreads(1024,1,1)]
+[NodeDispatchGrid(64,1,1)]
+[NodeLaunch("broadcasting")]
+void node_broadcasting() {
+  SetMeshOutputCounts(32, 16);
+  buf0[0] = 1.0;
+}
+
+// CHECK:  23: error: Function uses features incompatible with the shader stage (node) of the entry function.
+[Shader("node")]
+[NodeLaunch("coalescing")]
+[NumThreads(1024,1,1)]
+void node_coalescing() {
+  SetMeshOutputCounts(32, 16);
+  buf0[0] = 2.0;
+}
+
+// CHECK:  31: error: Function uses features incompatible with the shader stage (node) of the entry function.
+[Shader("node")]
+[NodeLaunch("thread")]
+void node_thread() {
+  SetMeshOutputCounts(32, 16);
+  buf0[0] = 4.0;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-set-mesh-output-counts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-set-mesh-output-counts.hlsl
@@ -1,0 +1,28 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// REQUIRES: dxil-1-9
+ 
+// Ensure that setMeshOutputCounts can be correctly lowered in a mesh node
+
+// CHECK: define void @node_setmeshoutputcounts()
+// CHECK: dx.op.setMeshOutputCounts(i32 168, i32 32, i32 16)
+// CHECK: ret void
+
+// CHECK: define void @node_setmeshoutputcounts_call()
+// CHECK: dx.op.setMeshOutputCounts(i32 168, i32 16, i32 32)
+// CHECK: ret void
+
+// CHECK: declare void @dx.op.setMeshOutputCounts(i32, i32, i32) #0
+
+RWBuffer<float> buf0;
+
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void node_setmeshoutputcounts() {
+    SetMeshOutputCounts(32, 16);
+    buf0[0] = 1.0;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-set-mesh-output-counts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-set-mesh-output-counts.hlsl
@@ -8,10 +8,6 @@
 // CHECK: dx.op.setMeshOutputCounts(i32 168, i32 32, i32 16)
 // CHECK: ret void
 
-// CHECK: define void @node_setmeshoutputcounts_call()
-// CHECK: dx.op.setMeshOutputCounts(i32 168, i32 16, i32 32)
-// CHECK: ret void
-
 // CHECK: declare void @dx.op.setMeshOutputCounts(i32, i32, i32) #0
 
 RWBuffer<float> buf0;

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -594,9 +594,14 @@ class db_dxil(object):
         for i in "WaveMatch,WaveMultiPrefixOp,WaveMultiPrefixBitCount".split(","):
             self.name_idx[i].category = "Wave"
             self.name_idx[i].shader_model = 6, 5
-        for (
-            i
-        ) in "SetMeshOutputCounts,EmitIndices,GetMeshPayload,StoreVertexOutput,StorePrimitiveOutput".split(
+        for i in "SetMeshOutputCounts".split(","):
+            self.name_idx[i].category = "Mesh shader instructions"
+            self.name_idx[i].shader_stages = (
+                "mesh",
+                "node",
+            )
+            self.name_idx[i].shader_model = 6, 5
+        for i in "EmitIndices,GetMeshPayload,StoreVertexOutput,StorePrimitiveOutput".split(
             ","
         ):
             self.name_idx[i].category = "Mesh shader instructions"

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -601,7 +601,9 @@ class db_dxil(object):
                 "node",
             )
             self.name_idx[i].shader_model = 6, 5
-        for i in "EmitIndices,GetMeshPayload,StoreVertexOutput,StorePrimitiveOutput".split(
+        for (
+            i
+        ) in "EmitIndices,GetMeshPayload,StoreVertexOutput,StorePrimitiveOutput".split(
             ","
         ):
             self.name_idx[i].category = "Mesh shader instructions"


### PR DESCRIPTION
Allow the usage of SetMeshOutputCounts() in mesh launch node shaders and no other launch type nodes. This requires identifying the op initially as permitted in node shaders, but restraining that permission later on. Given the availability of launch type and opcode information, the locations for doing that were limited. Future implementation might opt to encode the launch type in the stage mask or else at least temporarily use a different opcode for a SetMeshOutputCounts call within a node shader.

Fixes #6473