### PR TITLE
[Test] skip test for older validator which check different value.

### DIFF
--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -1036,6 +1036,8 @@ TEST_F(ValidationTest, SigOverlapFail) {
        "signature element"});
 }
 TEST_F(ValidationTest, SimpleHs1Fail) {
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\SimpleHs1.hlsl", "hs_6_0",
       {
@@ -1059,8 +1061,6 @@ TEST_F(ValidationTest, SimpleHs1Fail) {
       });
 }
 TEST_F(ValidationTest, SimpleHs3Fail) {
-  if (m_ver.SkipDxilVersion(1, 8))
-    return;
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\SimpleHs3.hlsl", "hs_6_0",
       {

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -871,6 +871,8 @@ TEST_F(ValidationTest, GetDimCalcLODFail) {
       /*bRegex*/ true);
 }
 TEST_F(ValidationTest, HsAttributeFail) {
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
   RewriteAssemblyCheckMsg(
       L"..\\CodeGenHLSL\\hsAttribute.hlsl", "hs_6_0",
       {"i32 3, i32 3, i32 2, i32 3, i32 3, float 6.400000e+01"},
@@ -1057,6 +1059,8 @@ TEST_F(ValidationTest, SimpleHs1Fail) {
       });
 }
 TEST_F(ValidationTest, SimpleHs3Fail) {
+  if (m_ver.SkipDxilVersion(1, 8))
+    return;
   RewriteAssemblyCheckMsg(
       L"..\\DXILValidation\\SimpleHs3.hlsl", "hs_6_0",
       {


### PR DESCRIPTION
Error message was updated in #6196 which cause test fail on older validator.

Since this issue is only caused by error message update, the validation itself is still the same.
The compiler didn't generate anything that behaves badly with older validators.

So just limit these tests to sm6.8+ to make it work on older validator.