### PR TITLE
Implement mesh node output params

### DIFF
--- a/include/dxc/DXIL/DxilFunctionProps.h
+++ b/include/dxc/DXIL/DxilFunctionProps.h
@@ -182,9 +182,6 @@ struct DxilFunctionProps {
     unsigned MaxDispatchGrid[3];
     unsigned MaxRecursionDepth;
     // BEGIN experimental mesh node properties
-    DXIL::MeshOutputTopology OutputTopology;
-    unsigned MaxVertexCount;
-    unsigned MaxPrimitiveCount;
     unsigned MaxInputRecordsPerGraphEntryRecord;
     bool MaxInputRecSharedAcrossNodeArray;
     // END experimental mesh node properties
@@ -237,6 +234,10 @@ struct DxilFunctionProps {
   bool IsNode() const {
     return shaderKind == DXIL::ShaderKind::Node ||
            Node.LaunchType != DXIL::NodeLaunchType::Invalid;
+  };
+  bool IsMeshNode() const {
+    return shaderKind == DXIL::ShaderKind::Node &&
+           Node.LaunchType == DXIL::NodeLaunchType::Mesh;
   };
 };
 

--- a/include/dxc/DXIL/DxilSigPoint.inl
+++ b/include/dxc/DXIL/DxilSigPoint.inl
@@ -317,6 +317,8 @@ DXIL::SigPointKind SigPoint::GetKind(DXIL::ShaderKind shaderKind,
     }
     break;
   case DXIL::ShaderKind::Mesh:
+  // Assuming mesh node
+  case DXIL::ShaderKind::Node:
     switch (sigKind) {
     case DXIL::SignatureKind::Input:
       return DXIL::SigPointKind::MSIn;

--- a/lib/DXIL/DxilMetadataHelper.cpp
+++ b/lib/DXIL/DxilMetadataHelper.cpp
@@ -1902,18 +1902,16 @@ void DxilMDHelper::LoadDxilEntryProperties(const MDOperand &MDO,
     } break;
     case DxilMDHelper::kDxilNodeMeshOutputTopologyTag: {
       hasNodeTag = true;
-      auto &Node = props.Node;
-      Node.OutputTopology = (DXIL::MeshOutputTopology)ConstMDToUint32(MDO);
+      props.ShaderProps.MS.outputTopology =
+          (DXIL::MeshOutputTopology)ConstMDToUint32(MDO);
     } break;
     case DxilMDHelper::kDxilNodeMeshMaxVertexCountTag: {
       hasNodeTag = true;
-      auto &Node = props.Node;
-      Node.MaxVertexCount = ConstMDToUint32(MDO);
+      props.ShaderProps.MS.maxVertexCount = ConstMDToUint32(MDO);
     } break;
     case DxilMDHelper::kDxilNodeMeshMaxPrimitiveCountTag: {
       hasNodeTag = true;
-      auto &Node = props.Node;
-      Node.MaxPrimitiveCount = ConstMDToUint32(MDO);
+      props.ShaderProps.MS.maxPrimitiveCount = ConstMDToUint32(MDO);
     } break;
     case DxilMDHelper::kDxilNodeMaxInputRecordsPerGraphEntryRecordTag: {
       hasNodeTag = true;
@@ -1982,9 +1980,11 @@ void DxilMDHelper::SerializeNodeProps(SmallVectorImpl<llvm::Metadata *> &MDVals,
   MDVals.push_back(Uint32ToConstMD(NodeProps.MaxDispatchGrid[2]));
   MDVals.push_back(Uint32ToConstMD(NodeProps.MaxRecursionDepth));
   if (DXIL::CompareVersions(m_MinValMajor, m_MinValMinor, 1, 9) >= 0) {
-    MDVals.emplace_back(Uint32ToConstMD((unsigned)NodeProps.OutputTopology));
-    MDVals.emplace_back(Uint32ToConstMD(NodeProps.MaxVertexCount));
-    MDVals.emplace_back(Uint32ToConstMD(NodeProps.MaxPrimitiveCount));
+    MDVals.emplace_back(
+        Uint32ToConstMD((unsigned)props->ShaderProps.MS.outputTopology));
+    MDVals.emplace_back(Uint32ToConstMD(props->ShaderProps.MS.maxVertexCount));
+    MDVals.emplace_back(
+        Uint32ToConstMD(props->ShaderProps.MS.maxPrimitiveCount));
     MDVals.push_back(
         Uint32ToConstMD(NodeProps.MaxInputRecordsPerGraphEntryRecord));
     MDVals.push_back(BoolToConstMD(NodeProps.MaxInputRecSharedAcrossNodeArray));
@@ -2043,10 +2043,12 @@ void DxilMDHelper::DeserializeNodeProps(const MDTuple *pProps, unsigned &idx,
   NodeProps.MaxDispatchGrid[2] = ConstMDToUint32(pProps->getOperand(idx++));
   NodeProps.MaxRecursionDepth = ConstMDToUint32(pProps->getOperand(idx++));
   if (DXIL::CompareVersions(m_MinValMajor, m_MinValMinor, 1, 9) >= 0) {
-    NodeProps.OutputTopology =
+    props->ShaderProps.MS.outputTopology =
         (DXIL::MeshOutputTopology)ConstMDToUint32(pProps->getOperand(idx++));
-    NodeProps.MaxVertexCount = ConstMDToUint32(pProps->getOperand(idx++));
-    NodeProps.MaxPrimitiveCount = ConstMDToUint32(pProps->getOperand(idx++));
+    props->ShaderProps.MS.maxVertexCount =
+        ConstMDToUint32(pProps->getOperand(idx++));
+    props->ShaderProps.MS.maxPrimitiveCount =
+        ConstMDToUint32(pProps->getOperand(idx++));
     NodeProps.MaxInputRecordsPerGraphEntryRecord =
         ConstMDToUint32(pProps->getOperand(idx++));
     NodeProps.MaxInputRecSharedAcrossNodeArray =
@@ -2791,22 +2793,25 @@ void DxilMDHelper::EmitDxilNodeState(std::vector<llvm::Metadata *> &MDVals,
   }
 
   // Experimental mesh node shader properties
-  if (Node.OutputTopology != DXIL::MeshOutputTopology::Undefined) {
+  if (props.ShaderProps.MS.outputTopology !=
+      DXIL::MeshOutputTopology::Undefined) {
     MDVals.emplace_back(
         Uint32ToConstMD(DxilMDHelper::kDxilNodeMeshOutputTopologyTag));
-    MDVals.emplace_back(Uint32ToConstMD((unsigned)Node.OutputTopology));
+    MDVals.emplace_back(
+        Uint32ToConstMD((unsigned)props.ShaderProps.MS.outputTopology));
   }
 
-  if (Node.MaxVertexCount > 0) {
+  if (props.ShaderProps.MS.maxVertexCount > 0) {
     MDVals.emplace_back(
         Uint32ToConstMD(DxilMDHelper::kDxilNodeMeshMaxVertexCountTag));
-    MDVals.emplace_back(Uint32ToConstMD(Node.MaxVertexCount));
+    MDVals.emplace_back(Uint32ToConstMD(props.ShaderProps.MS.maxVertexCount));
   }
 
-  if (Node.MaxPrimitiveCount > 0) {
+  if (props.ShaderProps.MS.maxPrimitiveCount > 0) {
     MDVals.emplace_back(
         Uint32ToConstMD(DxilMDHelper::kDxilNodeMeshMaxPrimitiveCountTag));
-    MDVals.emplace_back(Uint32ToConstMD(Node.MaxPrimitiveCount));
+    MDVals.emplace_back(
+        Uint32ToConstMD(props.ShaderProps.MS.maxPrimitiveCount));
   }
 
   if (Node.MaxInputRecordsPerGraphEntryRecord) {

--- a/lib/DXIL/DxilModule.cpp
+++ b/lib/DXIL/DxilModule.cpp
@@ -2344,8 +2344,7 @@ void DxilModule::UpdateFunctionToShaderCompat(const llvm::Function *dxilFunc) {
       if (DXIL::OpCode::SetMeshOutputCounts == OP::GetDxilOpFuncCallInst(CI) &&
           HasDxilFunctionProps(F)) {
         const DxilFunctionProps &props = GetDxilFunctionProps(F);
-        if (props.shaderKind != DXIL::ShaderKind::Node ||
-            props.Node.LaunchType != DXIL::NodeLaunchType::Mesh)
+        if (!props.IsMeshNode())
           mask &= ~SFLAG(Node);
       }
       info.mask &= mask;

--- a/lib/DXIL/DxilOperations.cpp
+++ b/lib/DXIL/DxilOperations.cpp
@@ -3251,16 +3251,16 @@ void OP::GetMinShaderModelAndMask(OpCode C, bool bWithTranslation,
     mask = SFLAG(Library) | SFLAG(Pixel);
     return;
   }
-  // Instructions: EmitIndices=169, GetMeshPayload=170, StoreVertexOutput=171,
-  // StorePrimitiveOutput=172
-  if ((169 <= op && op <= 172)) {
+  // Instructions: GetMeshPayload=170
+  if (op == 170) {
     major = 6;
     minor = 5;
     mask = SFLAG(Mesh);
     return;
   }
-  // Instructions: SetMeshOutputCounts=168
-  if (op == 168) {
+  // Instructions: SetMeshOutputCounts=168, EmitIndices=169,
+  // StoreVertexOutput=171, StorePrimitiveOutput=172
+  if ((168 <= op && op <= 169) || (171 <= op && op <= 172)) {
     major = 6;
     minor = 5;
     mask = SFLAG(Mesh) | SFLAG(Node);

--- a/lib/DXIL/DxilTypeSystem.cpp
+++ b/lib/DXIL/DxilTypeSystem.cpp
@@ -782,6 +782,8 @@ DXIL::SigPointKind SigPointFromInputQual(DxilParamInputQual Q,
     }
     break;
   case DXIL::ShaderKind::Mesh:
+  // assuming mesh node, wouldn't be here otherwise
+  case DXIL::ShaderKind::Node:
     switch (Q) {
     case DxilParamInputQual::In:
     case DxilParamInputQual::InPayload:

--- a/lib/DxilContainer/DxilContainerAssembler.cpp
+++ b/lib/DxilContainer/DxilContainerAssembler.cpp
@@ -1656,13 +1656,13 @@ private:
       funcAttribs.push_back(Builder.InsertRecord(nAttrib));
     }
 
-    if (props.Node.OutputTopology != DXIL::MeshOutputTopology::Undefined) {
+    if (props.ShaderProps.MS.outputTopology != DXIL::MeshOutputTopology::Undefined) {
       nAttrib = {};
       nAttrib.AttribKind = (uint32_t)RDAT::NodeFuncAttribKind::MeshShaderInfo;
       RDAT::MSInfo info = {};
-      info.MeshOutputTopology = (uint8_t)props.Node.OutputTopology;
-      info.MaxOutputVertices = (uint16_t)props.Node.MaxVertexCount;
-      info.MaxOutputPrimitives = (uint16_t)props.Node.MaxPrimitiveCount;
+      info.MeshOutputTopology = (uint8_t)props.ShaderProps.MS.outputTopology;
+      info.MaxOutputVertices = (uint16_t)props.ShaderProps.MS.maxVertexCount;
+      info.MaxOutputPrimitives = (uint16_t)props.ShaderProps.MS.maxPrimitiveCount;
       nAttrib.MeshShaderInfo = Builder.InsertRecord(info);
       funcAttribs.push_back(Builder.InsertRecord(nAttrib));
     }

--- a/tools/clang/lib/CodeGen/CGHLSLMS.cpp
+++ b/tools/clang/lib/CodeGen/CGHLSLMS.cpp
@@ -1726,14 +1726,10 @@ void CGMSHLSLRuntime::AddHLSLFunctionInfo(Function *F, const FunctionDecl *FD) {
       DXIL::TessellatorOutputPrimitive primitive =
           StringToTessOutputPrimitive(Attr->getTopology());
       funcProps->ShaderProps.HS.outputPrimitive = primitive;
-    } else if (isMS) {
+    } else if (isMS || isNode) {
       DXIL::MeshOutputTopology topology =
           StringToMeshOutputTopology(Attr->getTopology());
       funcProps->ShaderProps.MS.outputTopology = topology;
-    } else if (isNode) {
-      DXIL::MeshOutputTopology topology =
-          StringToMeshOutputTopology(Attr->getTopology());
-      funcProps->Node.OutputTopology = topology;
     } else if (isEntry && !SM->IsHS() && !SM->IsMS()) {
       unsigned DiagID = Diags.getCustomDiagID(
           DiagnosticsEngine::Warning,

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-input-parameters.hlsl
@@ -5,15 +5,16 @@
 // Test all valid mesh node input parameters work
 
 // CHECK: define void @node01()
-// CHECK:  %[[tid_x:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 0)  ; ThreadId(component)
-// CHECK:  %[[tid_y:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 1)  ; ThreadId(component)
-// CHECK:  %[[tid_z:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 2)  ; ThreadId(component)
-
-// CHECK:  %[[ftid:.+]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)  ; FlattenedThreadIdInGroup()
 
 // CHECK:  %[[tid_group_x:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 0)  ; ThreadIdInGroup(component)
 // CHECK:  %[[tid_group_y:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 1)  ; ThreadIdInGroup(component)
 // CHECK:  %[[tid_group_z:.+]] = call i32 @dx.op.threadIdInGroup.i32(i32 95, i32 2)  ; ThreadIdInGroup(component)
+
+// CHECK:  %[[ftid:.+]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)  ; FlattenedThreadIdInGroup()
+
+// CHECK:  %[[tid_x:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 0)  ; ThreadId(component)
+// CHECK:  %[[tid_y:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 1)  ; ThreadId(component)
+// CHECK:  %[[tid_z:.+]] = call i32 @dx.op.threadId.i32(i32 93, i32 2)  ; ThreadId(component)
 
 // CHECK:  %[[Hdl:.+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)  ; CreateNodeInputRecordHandle(MetadataIdx)
 // CHECK:  %[[annotHdl:.+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %[[Hdl]], %dx.types.NodeRecordInfo { i32 97, i32 52 })  ; AnnotateNodeRecordHandle(noderecord,props)

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-multi-setoutcounts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-multi-setoutcounts.hlsl
@@ -1,0 +1,46 @@
+// RUN: not %dxc -T lib_6_9 %s 2>&1 | FileCheck %s
+
+// REQUIRES: dxil-1-9
+
+// Ensure multiple setMeshOutputCounts produce a validation error
+
+// CHECK:  error: SetMeshOutputCounts cannot be called multiple times
+
+RWBuffer<float> buf0;
+
+#define MAX_VERT 32
+#define MAX_PRIM 16
+#define NUM_THREADS 32
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+};
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+};
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void node_setmeshoutputcounts(
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in uint tig : SV_GroupIndex) {
+
+  SetMeshOutputCounts(32, 16);
+  SetMeshOutputCounts(32, 16);
+  MeshPerVertex ov;
+  ov.position = float4(14.0,15.0,16.0,17.0);
+
+  if (tig % 3) {
+    primIndices[tig / 3] = uint3(tig, tig + 1, tig + 2);
+    MeshPerPrimitive op;
+    op.normal = 1.0;
+    prims[tig / 3] = op;
+  }
+  verts[tig] = ov;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-no-setoutcounts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-no-setoutcounts.hlsl
@@ -1,0 +1,48 @@
+// RUN: not %dxc -T lib_6_9 %s 2>&1 | FileCheck %s
+
+// REQUIRES: dxil-1-9
+
+// Ensure missing setMeshOutputCounts in a shader that writes to the outputs
+// produces a validation error
+
+// One for each out param written to
+// CHECK:  error: Missing SetMeshOutputCounts call
+// CHECK:  error: Missing SetMeshOutputCounts call
+// CHECK:  error: Missing SetMeshOutputCounts call
+
+RWBuffer<float> buf0;
+
+#define MAX_VERT 32
+#define MAX_PRIM 16
+#define NUM_THREADS 32
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+};
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+};
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void node_setmeshoutputcounts(
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in uint tig : SV_GroupIndex) {
+
+  MeshPerVertex ov;
+  ov.position = float4(14.0,15.0,16.0,17.0);
+
+  if (tig % 3) {
+    primIndices[tig / 3] = uint3(tig, tig + 1, tig + 2);
+    MeshPerPrimitive op;
+    op.normal = 1.0;
+    prims[tig / 3] = op;
+  }
+  verts[tig] = ov;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-nondom-setoutcounts.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-nondom-setoutcounts.hlsl
@@ -1,0 +1,45 @@
+// RUN: not %dxc -T lib_6_9 %s 2>&1 | FileCheck %s
+
+// REQUIRES: dxil-1-9
+
+// Ensure non-dominant setMeshOutputCounts produces a validation error
+
+// CHECK:  error: Non-Dominating SetMeshOutputCounts call.
+
+RWBuffer<float> buf0;
+
+#define MAX_VERT 32
+#define MAX_PRIM 16
+#define NUM_THREADS 32
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+};
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+};
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void node_setmeshoutputcounts(
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in uint tig : SV_GroupIndex) {
+
+  MeshPerVertex ov;
+  ov.position = float4(14.0,15.0,16.0,17.0);
+
+  if (tig % 3) {
+    SetMeshOutputCounts(32, 16);
+    primIndices[tig / 3] = uint3(tig, tig + 1, tig + 2);
+    MeshPerPrimitive op;
+    op.normal = 1.0;
+    prims[tig / 3] = op;
+  }
+  verts[tig] = ov;
+}

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node.hlsl
@@ -1,0 +1,130 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// REQUIRES: dxil-1-9
+
+// Test loading of node input and funneling into mesh outputs
+// Essentially an end-to-end mesh node test.
+
+
+RWBuffer<float> buf0;
+
+#define MAX_VERT 32
+#define MAX_PRIM 16
+#define NUM_THREADS 32
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+    float color[4] : COLOR;
+};
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+    float malnor : MALNOR;
+    float alnorm : ALNORM;
+    float ormaln : ORMALN;
+    int layer[6] : LAYER;
+};
+
+struct MeshPayload {
+    float normal;
+    float malnor;
+    float alnorm;
+    float ormaln;
+    int layer[6];
+};
+
+groupshared float gsMem[MAX_PRIM];
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void node_setmeshoutputcounts(DispatchNodeInputRecord<MeshPayload> mpl,
+            out indices uint3 primIndices[MAX_PRIM],
+            out vertices MeshPerVertex verts[MAX_VERT],
+            out primitives MeshPerPrimitive prims[MAX_PRIM],
+            in uint tig : SV_GroupIndex) {
+  // SV_GroupIndex
+  // CHECK: %[[GID:[0-9]+]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)
+
+  // CHECK: call void @dx.op.setMeshOutputCounts(i32 168, i32 32, i32 16)  ; SetMeshOutputCounts(numVertices,numPrimitives)
+  SetMeshOutputCounts(32, 16);
+
+  // create mpl
+  // CHECK: %[[CHDL:[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.createNodeInputRecordHandle(i32 250, i32 0)
+  // CHECK: %[[AHDL:[0-9]+]] = call %dx.types.NodeRecordHandle @dx.op.annotateNodeRecordHandle(i32 251, %dx.types.NodeRecordHandle %[[CHDL]], %dx.types.NodeRecordInfo { i32 97, i32 40 })
+
+  MeshPerVertex ov;
+  ov.position = float4(14.0,15.0,16.0,17.0);
+  ov.color[0] = 14.0;
+  ov.color[1] = 15.0;
+  ov.color[2] = 16.0;
+  ov.color[3] = 17.0;
+
+  if (tig % 3) {
+    // CHECK: %[[GID1:[0-9]+]] = add i32 %[[GID]], 1
+    // CHECK: %[[GID2:[0-9]+]] = add i32 %[[GID]], 2
+    // CHECK: %[[GIDIV:[0-9]+]] = udiv i32 %[[GID]], 3
+    // CHECK: call void @dx.op.emitIndices(i32 169, i32 %[[GIDIV]], i32 %[[GID]], i32 %[[GID1]], i32 %[[GID2]])
+    primIndices[tig / 3] = uint3(tig, tig + 1, tig + 2);
+
+    MeshPerPrimitive op;
+    // CHECK: %[[MPL:[0-9]+]] = call %struct.MeshPayload addrspace(6)* @dx.op.getNodeRecordPtr.struct.MeshPayload(i32 239, %dx.types.NodeRecordHandle %[[AHDL]], i32 0)
+    // CHECK: %[[NRMGEP:[0-9]+]] = getelementptr %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 0
+    // CHECK: %[[NRM:[0-9]+]] = load float, float addrspace(6)* %[[NRMGEP]], align 4
+    op.normal = mpl.Get().normal;
+    // CHECK: %[[GIDIV1:[0-9]+]] = add nuw i32 %[[GIDIV]], 1
+    // CHECK: %[[GSGEP:[0-9]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @"\01?gsMem@@3PAMA", i32 0, i32 %[[GIDIV1]]
+    // CHECK: %[[GS:[0-9]+]] = load float, float addrspace(3)* %[[GSGEP]]
+    op.malnor = gsMem[tig / 3 + 1];
+    // CHECK: %[[AGEP:[0-9]+]] = getelementptr %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 2
+    // CHECK: %[[ANML:[0-9]+]] = load float, float addrspace(6)* %[[AGEP]], align 4
+    op.alnorm = mpl.Get().alnorm;
+    // CHECK: %[[OGEP:[0-9]+]] = getelementptr %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 3
+    // CHECK: %[[ONML:[0-9]+]] = load float, float addrspace(6)* %[[OGEP]], align 4
+    op.ormaln = mpl.Get().ormaln;
+    // CHECK: %[[L0GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 0
+    // CHECK: %[[LAY0:[0-9]+]] = load i32, i32 addrspace(6)* %[[L0GEP]], align 4
+    op.layer[0] = mpl.Get().layer[0];
+    // CHECK: %[[L1GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 1
+    // CHECK: %[[LAY1:[0-9]+]] = load i32, i32 addrspace(6)* %[[L1GEP]], align 4
+    op.layer[1] = mpl.Get().layer[1];
+    // CHECK: %[[L2GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 2
+    // CHECK: %[[LAY2:[0-9]+]] = load i32, i32 addrspace(6)* %[[L2GEP]], align 4
+    op.layer[2] = mpl.Get().layer[2];
+    // CHECK: %[[L3GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 3
+    // CHECK: %[[LAY3:[0-9]+]] = load i32, i32 addrspace(6)* %[[L3GEP]], align 4
+    op.layer[3] = mpl.Get().layer[3];
+    // CHECK: %[[L4GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 4
+    // CHECK: %[[LAY4:[0-9]+]] = load i32, i32 addrspace(6)* %[[L4GEP]], align 4
+    op.layer[4] = mpl.Get().layer[4];
+    // CHECK: %[[L5GEP:[0-9]+]] = getelementptr inbounds %struct.MeshPayload, %struct.MeshPayload addrspace(6)* %[[MPL]], i32 0, i32 4, i32 5
+    // CHECK: %[[LAY5:[0-9]+]] = load i32, i32 addrspace(6)* %[[L5GEP]], align 4
+    op.layer[5] = mpl.Get().layer[5];
+
+    // CHECK: %[[GSGEP2:[0-9]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @"\01?gsMem@@3PAMA", i32 0, i32 %[[GIDIV]]
+    // CHECK: store float %[[NRM]], float addrspace(3)* %[[GSGEP2]], align 4, !tbaa !29
+    gsMem[tig / 3] = op.normal;
+    // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 0, i32 0, i8 0, float %[[NRM]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 1, i32 0, i8 0, float %[[GS]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 2, i32 0, i8 0, float %[[ANML]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 3, i32 0, i8 0, float %[[ONML]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 0, i8 0, i32 %[[LAY0]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 1, i8 0, i32 %[[LAY1]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 2, i8 0, i32 %[[LAY2]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 3, i8 0, i32 %[[LAY3]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 4, i8 0, i32 %[[LAY4]], i32 %[[GIDIV]])
+    // CHECK:  call void @dx.op.storePrimitiveOutput.i32(i32 172, i32 4, i32 5, i8 0, i32 %[[LAY5]], i32 %[[GIDIV]])
+    prims[tig / 3] = op;
+  }
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 0, i32 0, i8 0, float 1.400000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 0, i32 0, i8 1, float 1.500000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 0, i32 0, i8 2, float 1.600000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 0, i32 0, i8 3, float 1.700000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 1, i32 0, i8 0, float 1.400000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 1, i32 1, i8 0, float 1.500000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 1, i32 2, i8 0, float 1.600000e+01, i32 %[[GID]])
+  // CHECK: call void @dx.op.storeVertexOutput.f32(i32 171, i32 1, i32 3, i8 0, float 1.700000e+01, i32 %[[GID]])
+  verts[tig] = ov;
+}

--- a/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T ms_6_5 %s | FileCheck %s
 
-// CHECK: SetMeshOUtputCounts cannot be called multiple times.
+// CHECK: SetMeshOutputCounts cannot be called multiple times.
 
 #define MAX_VERT 32
 #define MAX_PRIM 16

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutIndicesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutIndicesMesh.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: indices output is not an constant-length array
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices uint primIndices) {
+  primIndices = 1;
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutPrimitivesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutPrimitivesMesh.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: primitives output is not an constant-length array
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out primitives uint3 primIndices) {
+  primIndices = 1;
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutVerticesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notArrayOutVerticesMesh.hlsl
@@ -1,0 +1,12 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: vertices output is not an constant-length array
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out vertices uint3 verts) {
+  verts = 1;
+}

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUint2OutIndicesForLinesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUint2OutIndicesForLinesMesh.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: the element of out_indices array in a mesh shader whose output topology is line must be uint2
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices uint3 primIndices[16]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUint3OutIndicesForTrianglesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUint3OutIndicesForTrianglesMesh.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: the element of out_indices array in a mesh shader whose output topology is triangle must be uint3
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("triangle")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices uint2 primIndices[16]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUintOutIndicesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notUintOutIndicesMesh.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: the element of out_indices array must be uint2 for line output or uint3 for triangle output
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices float3 primIndices[16]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notVectorOutIndicesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/notVectorOutIndicesMesh.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: the element of out_indices array must be uint2 for line output or uint3 for triangle output
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices uint primIndices[16]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutIndicesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutIndicesMesh.hlsl
@@ -1,0 +1,10 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: max primitive count should not exceed 256
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out indices uint3 primIndices[257]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutPrimitivesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutPrimitivesMesh.hlsl
@@ -1,0 +1,16 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: max primitive count should not exceed 256
+
+struct MeshPerPrimitive {
+    float normal : NORMAL;
+    float malnor : MALNOR;
+    int layer[4] : LAYER;
+};
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out primitives MeshPerPrimitive prims[257]) { }

--- a/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutVerticesMesh.hlsl
+++ b/tools/clang/test/HLSLFileCheck/shader_targets/mesh/tooManyOutVerticesMesh.hlsl
@@ -1,0 +1,15 @@
+// RUN: %dxc -T lib_6_9 %s | FileCheck %s
+
+// CHECK: error: max vertex count should not exceed 256
+
+struct MeshPerVertex {
+    float4 position : SV_Position;
+    float color[4] : COLOR;
+};
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[outputtopology("line")]
+[numthreads(128, 1, 1)]
+[NodeDispatchGrid(64,1,1)]
+void main(out vertices MeshPerVertex verts[257]) { }

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -603,7 +603,13 @@ class db_dxil(object):
             self.name_idx[i].shader_model = 6, 5
         for (
             i
-        ) in "EmitIndices,GetMeshPayload,StoreVertexOutput,StorePrimitiveOutput".split(
+        ) in "EmitIndices,StoreVertexOutput,StorePrimitiveOutput".split(
+            ","
+        ):
+            self.name_idx[i].category = "Mesh shader instructions"
+            self.name_idx[i].shader_stages = ("mesh","node")
+            self.name_idx[i].shader_model = 6, 5
+        for i in "GetMeshPayload".split(
             ","
         ):
             self.name_idx[i].category = "Mesh shader instructions"
@@ -7559,7 +7565,7 @@ class db_dxil(object):
         )
         self.add_valrule(
             "Instr.MultipleSetMeshOutputCounts",
-            "SetMeshOUtputCounts cannot be called multiple times.",
+            "SetMeshOutputCounts cannot be called multiple times.",
         )
         self.add_valrule(
             "Instr.MissingSetMeshOutputCounts", "Missing SetMeshOutputCounts call."


### PR DESCRIPTION
To enable reuse of the mesh code generation for output parameters, mesh nodes now share the mesh shader function properties instead of having their own copies. This allows us to rely on the same code to detect errors and pass along parameter information. Since nodes don't store their info in the shader info union, there isn't a conflict.

Similar sharing with mesh signature lowering is possible by calling the mesh signature lowering stages for mesh nodes and lightly altering those functions to accomodate for node shaders.

Some changes were made to validation to allow for the new parameters and DXIL intrinsics in node shaders.

Created a convenience method in function properties to identify mesh nodes as I was tired of typing out the conditionals to identify it.

Adds tests for invalid output parameters, misuse of SetMeshOutputCounts, and a thorough end-to-end node record-to-mesh output test.

Fixes #6475

Add a raft of tests for mesh node out param fails

enable signature lowering more tests