### PR TITLE
Update locale setting logic to support UTF-8 only for Apple and Linux distros

### DIFF
--- a/include/dxc/Test/HlslTestUtils.h
+++ b/include/dxc/Test/HlslTestUtils.h
@@ -77,7 +77,7 @@ using namespace std;
     const char *pTmpA = (a);                                                   \
     const char *pTmpB = (b);                                                   \
     if (0 != strcmp(pTmpA, pTmpB)) {                                           \
-      CA2W conv(pTmpB, CP_UTF8);                                               \
+      CA2W conv(pTmpB);                                                        \
       WEX::Logging::Log::Comment(conv);                                        \
       const char *pA = pTmpA;                                                  \
       const char *pB = pTmpB;                                                  \

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -925,7 +925,6 @@ public:
       setlocale(LC_ALL, m_locale);
     }
   }
-  bool IsSupported() { return (m_locale != nullptr); }
 
 private:
   // Sets a locale for the specified Windows codepage
@@ -934,26 +933,16 @@ private:
       assert(false && "Support for Linux only handles UTF8 code pages");
     }
 #ifdef __APPLE__
-    switch (CodePage) {
-    case CP_UTF8:
-      return setlocale(Category, "en_US.UTF-8");
-    default:
-      return nullptr;
-    }
+    return setlocale(Category, "en_US.UTF-8");
 #else
     const char *utf8LocaleOptions[] = {"en_US.UTF-8", "en_US.utf8"};
 
-    switch (CodePage) {
-    case CP_UTF8: {
-      for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
-        const char *locale = setlocale(Category, utf8LocaleOptions[i]);
-        if (locale != nullptr)
-          return locale;
-      }
+    for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
+      const char *locale = setlocale(Category, utf8LocaleOptions[i]);
+      if (locale != nullptr)
+        return locale;
     }
-    default:
-      return nullptr;
-    }
+    return nullptr;
 #endif
   }
 };
@@ -962,14 +951,8 @@ private:
 // used here.
 template <int t_nBufferLength = 128> class CW2AEX {
 public:
-  CW2AEX(LPCWSTR psz, UINT nCodePage = CP_UTF8) {
-    ScopedLocale locale(nCodePage);
-    if (!locale.IsSupported()) {
-      // Current Implementation only supports CP_UTF8, and CP_ACP
-      assert(false && "CW2AEX implementation for Linux only handles "
-                      "UTF8 and ACP code pages");
-      return;
-    }
+  CW2AEX(LPCWSTR psz) {
+    ScopedLocale locale(CP_UTF8);
 
     if (!psz) {
       m_psz = NULL;
@@ -993,14 +976,8 @@ typedef CW2AEX<> CW2A;
 // used here.
 template <int t_nBufferLength = 128> class CA2WEX {
 public:
-  CA2WEX(LPCSTR psz, UINT nCodePage = CP_UTF8) {
-    ScopedLocale locale(nCodePage);
-    if (!locale.IsSupported()) {
-      // Current Implementation only supports CP_UTF8, and CP_ACP
-      assert(false && "CA2WEX implementation for Linux only handles "
-                      "UTF8 and ACP code pages");
-      return;
-    }
+  CA2WEX(LPCSTR psz) {
+    ScopedLocale locale(CP_UTF8);
 
     if (!psz) {
       m_psz = NULL;

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -930,7 +930,9 @@ public:
 private:
   // Sets a locale for the specified Windows codepage
   const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
-    assert(false && "Support for Linux only handles UTF8 code pages");
+    if (CodePage != CP_UTF8) {
+      assert(false && "Support for Linux only handles UTF8 code pages");
+    }
 #ifdef __APPLE__
     switch (CodePage) {
     case CP_UTF8:

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -932,18 +932,7 @@ private:
     if (CodePage != CP_UTF8) {
       assert(false && "Support for Linux only handles UTF8 code pages");
     }
-#ifdef __APPLE__
     return setlocale(Category, "en_US.UTF-8");
-#else
-    const char *utf8LocaleOptions[] = {"en_US.UTF-8", "en_US.utf8"};
-
-    for (size_t i = 0; i < _countof(utf8LocaleOptions); ++i) {
-      const char *locale = setlocale(Category, utf8LocaleOptions[i]);
-      if (locale != nullptr)
-        return locale;
-    }
-    return nullptr;
-#endif
   }
 };
 

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -126,7 +126,7 @@
 // Used by HRESULT <--> WIN32 error code conversion
 #define SEVERITY_ERROR 1
 #define FACILITY_WIN32 7
-#define HRESULT_CODE(hr) ((hr)&0xFFFF)
+#define HRESULT_CODE(hr) ((hr) & 0xFFFF)
 #define MAKE_HRESULT(severity, facility, code)                                 \
   ((HRESULT)(((unsigned long)(severity) << 31) |                               \
              ((unsigned long)(facility) << 16) | ((unsigned long)(code))))
@@ -238,7 +238,7 @@
 
 #define HRESULT_FROM_WIN32(x)                                                  \
   (HRESULT)(x) <= 0 ? (HRESULT)(x)                                             \
-                    : (HRESULT)(((x)&0x0000FFFF) | (7 << 16) | 0x80000000)
+                    : (HRESULT)(((x) & 0x0000FFFF) | (7 << 16) | 0x80000000)
 
 //===----------------------------------------------------------------------===//
 //

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -915,24 +915,19 @@ unsigned int SysStringLen(const BSTR bstrString);
 // RAII style mechanism for setting/unsetting a locale for the specified Windows
 // codepage
 class ScopedLocale {
-  const char *m_locale;
+  const char *m_prevLocale;
 
 public:
   explicit ScopedLocale(uint32_t codePage)
-      : m_locale(SetLocaleForCodePage(LC_ALL, codePage)) {}
-  ~ScopedLocale() {
-    if (m_locale != nullptr) {
-      setlocale(LC_ALL, m_locale);
-    }
+      : m_prevLocale(setlocale(LC_ALL, nullptr)) {
+    assert((codePage == CP_UTF8) &&
+           "Support for Linux only handles UTF8 code pages");
+    setlocale(LC_ALL, "en_US.UTF-8");
   }
-
-private:
-  // Sets a locale for the specified Windows codepage
-  const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
-    if (CodePage != CP_UTF8) {
-      assert(false && "Support for Linux only handles UTF8 code pages");
+  ~ScopedLocale() {
+    if (m_prevLocale != nullptr) {
+      setlocale(LC_ALL, m_prevLocale);
     }
-    return setlocale(Category, "en_US.UTF-8");
   }
 };
 

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -915,19 +915,20 @@ unsigned int SysStringLen(const BSTR bstrString);
 // Sets a locale for the specified Windows codepage
 const char *SetLocaleForCodePage(int Category, uint32_t CodePage);
 
-// RAII style mechanism for setting/unsetting a locale for the specified Windows codepage
+// RAII style mechanism for setting/unsetting a locale for the specified Windows
+// codepage
 class ScopedLocale {
-    const char* m_locale;
+  const char *m_locale;
+
 public:
-    explicit ScopedLocale(uint32_t codePage)
-    : m_locale(SetLocaleForCodePage(LC_ALL, codePage)) {
+  explicit ScopedLocale(uint32_t codePage)
+      : m_locale(SetLocaleForCodePage(LC_ALL, codePage)) {}
+  ~ScopedLocale() {
+    if (m_locale != nullptr) {
+      setlocale(LC_ALL, m_locale);
     }
-    ~ScopedLocale() {
-      if (m_locale != nullptr) {
-        setlocale(LC_ALL, m_locale);
-      }
-    }
-    bool IsSupported() { return (m_locale != nullptr);}
+  }
+  bool IsSupported() { return (m_locale != nullptr); }
 };
 
 // The t_nBufferLength parameter is part of the published interface, but not

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -937,7 +937,7 @@ private:
 #else
     const char *utf8LocaleOptions[] = {"en_US.UTF-8", "en_US.utf8"};
 
-    for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
+    for (size_t i = 0; i < _countof(utf8LocaleOptions); ++i) {
       const char *locale = setlocale(Category, utf8LocaleOptions[i]);
       if (locale != nullptr)
         return locale;

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -930,21 +930,18 @@ public:
 private:
   // Sets a locale for the specified Windows codepage
   const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
+    assert(false && "Support for Linux only handles UTF8 code pages");
 #ifdef __APPLE__
     switch (CodePage) {
-    case CP_ACP:
-      return setlocale(Category, "en_US.ISO8859-1");
     case CP_UTF8:
       return setlocale(Category, "en_US.UTF-8");
     default:
       return nullptr;
     }
 #else
-    const char *utf8LocaleOptions[] = {"en_US.utf8", "en_US.UTF-8"};
+    const char *utf8LocaleOptions[] = {"en_US.UTF-8", "en_US.utf8"};
 
     switch (CodePage) {
-    case CP_ACP:
-      return setlocale(Category, "en_US.iso88591");
     case CP_UTF8: {
       for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
         const char *locale = setlocale(Category, utf8LocaleOptions[i]);

--- a/include/dxc/WinAdapter.h
+++ b/include/dxc/WinAdapter.h
@@ -940,10 +940,7 @@ private:
       return nullptr;
     }
 #else
-    const char *utf8LocaleOptions[] = {
-        "en_US.utf8", // supported on Ubuntu
-        "en_US.UTF-8" // supported on Mariner
-    };
+    const char *utf8LocaleOptions[] = {"en_US.utf8", "en_US.UTF-8"};
 
     switch (CodePage) {
     case CP_ACP:

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -62,7 +62,7 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
   } else {
     rv = mbstowcs(lpWideCharStr, lpMultiByteStr, cchWideChar);
   }
-  
+
   if (rv == (size_t)cbMultiByte)
     return rv;
   return rv + 1; // mbstowcs excludes the terminating character
@@ -114,7 +114,7 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
   } else {
     rv = wcstombs(lpMultiByteStr, lpWideCharStr, cbMultiByte);
   }
-  
+
   if (rv == (size_t)cchWideChar)
     return rv;
   return rv + 1; // mbstowcs excludes the terminating character

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -52,8 +52,7 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *locale = CPToLocale(CodePage);
-  locale = setlocale(LC_ALL, locale);
+  ScopedLocale locale(CodePage);
   if (lpMultiByteStr[cbMultiByte - 1] != '\0') {
     char *srcStr = (char *)malloc((cbMultiByte + 1) * sizeof(char));
     strncpy(srcStr, lpMultiByteStr, cbMultiByte);
@@ -63,7 +62,7 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
   } else {
     rv = mbstowcs(lpWideCharStr, lpMultiByteStr, cchWideChar);
   }
-  setlocale(LC_ALL, locale);
+  
   if (rv == (size_t)cbMultiByte)
     return rv;
   return rv + 1; // mbstowcs excludes the terminating character
@@ -105,8 +104,7 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *locale = CPToLocale(CodePage);
-  locale = setlocale(LC_ALL, locale);
+  ScopedLocale locale(CodePage);
   if (lpWideCharStr[cchWideChar - 1] != L'\0') {
     wchar_t *srcStr = (wchar_t *)malloc((cchWideChar + 1) * sizeof(wchar_t));
     wcsncpy(srcStr, lpWideCharStr, cchWideChar);
@@ -116,7 +114,7 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
   } else {
     rv = wcstombs(lpMultiByteStr, lpWideCharStr, cbMultiByte);
   }
-  setlocale(LC_ALL, locale);
+  
   if (rv == (size_t)cchWideChar)
     return rv;
   return rv + 1; // mbstowcs excludes the terminating character

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -24,7 +24,7 @@
 // MultiByteToWideChar which is a Windows-specific method.
 // This is a very simplistic implementation for non-Windows platforms. This
 // implementation completely ignores CodePage and dwFlags.
-int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
+int MultiByteToWideChar(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
                         const char *lpMultiByteStr, int cbMultiByte,
                         wchar_t *lpWideCharStr, int cchWideChar) {
 
@@ -52,7 +52,7 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  ScopedLocale locale(CodePage);
+  const char *locale = setlocale(LC_ALL, "en_US.UTF-8");
   if (lpMultiByteStr[cbMultiByte - 1] != '\0') {
     char *srcStr = (char *)malloc((cbMultiByte + 1) * sizeof(char));
     strncpy(srcStr, lpMultiByteStr, cbMultiByte);
@@ -63,6 +63,9 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
     rv = mbstowcs(lpWideCharStr, lpMultiByteStr, cchWideChar);
   }
 
+  if (locale)
+    setlocale(LC_ALL, locale);
+
   if (rv == (size_t)cbMultiByte)
     return rv;
   return rv + 1; // mbstowcs excludes the terminating character
@@ -71,7 +74,7 @@ int MultiByteToWideChar(uint32_t CodePage, uint32_t /*dwFlags*/,
 // WideCharToMultiByte is a Windows-specific method.
 // This is a very simplistic implementation for non-Windows platforms. This
 // implementation completely ignores CodePage and dwFlags.
-int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
+int WideCharToMultiByte(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
                         const wchar_t *lpWideCharStr, int cchWideChar,
                         char *lpMultiByteStr, int cbMultiByte,
                         const char * /*lpDefaultChar*/,
@@ -104,7 +107,7 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  ScopedLocale locale(CodePage);
+  const char *locale = setlocale(LC_ALL, "en_US.UTF-8");
   if (lpWideCharStr[cchWideChar - 1] != L'\0') {
     wchar_t *srcStr = (wchar_t *)malloc((cchWideChar + 1) * sizeof(wchar_t));
     wcsncpy(srcStr, lpWideCharStr, cchWideChar);
@@ -114,6 +117,9 @@ int WideCharToMultiByte(uint32_t CodePage, uint32_t /*dwFlags*/,
   } else {
     rv = wcstombs(lpMultiByteStr, lpWideCharStr, cbMultiByte);
   }
+
+  if (locale)
+    setlocale(LC_ALL, locale);
 
   if (rv == (size_t)cchWideChar)
     return rv;

--- a/lib/DxcSupport/Unicode.cpp
+++ b/lib/DxcSupport/Unicode.cpp
@@ -52,7 +52,8 @@ int MultiByteToWideChar(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *locale = setlocale(LC_ALL, "en_US.UTF-8");
+  const char *prevLocale = setlocale(LC_ALL, nullptr);
+  setlocale(LC_ALL, "en_US.UTF-8");
   if (lpMultiByteStr[cbMultiByte - 1] != '\0') {
     char *srcStr = (char *)malloc((cbMultiByte + 1) * sizeof(char));
     strncpy(srcStr, lpMultiByteStr, cbMultiByte);
@@ -63,8 +64,8 @@ int MultiByteToWideChar(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
     rv = mbstowcs(lpWideCharStr, lpMultiByteStr, cchWideChar);
   }
 
-  if (locale)
-    setlocale(LC_ALL, locale);
+  if (prevLocale)
+    setlocale(LC_ALL, prevLocale);
 
   if (rv == (size_t)cbMultiByte)
     return rv;
@@ -107,7 +108,8 @@ int WideCharToMultiByte(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
   }
 
   size_t rv;
-  const char *locale = setlocale(LC_ALL, "en_US.UTF-8");
+  const char *prevLocale = setlocale(LC_ALL, nullptr);
+  setlocale(LC_ALL, "en_US.UTF-8");
   if (lpWideCharStr[cchWideChar - 1] != L'\0') {
     wchar_t *srcStr = (wchar_t *)malloc((cchWideChar + 1) * sizeof(wchar_t));
     wcsncpy(srcStr, lpWideCharStr, cchWideChar);
@@ -118,8 +120,8 @@ int WideCharToMultiByte(uint32_t /*CodePage*/, uint32_t /*dwFlags*/,
     rv = wcstombs(lpMultiByteStr, lpWideCharStr, cbMultiByte);
   }
 
-  if (locale)
-    setlocale(LC_ALL, locale);
+  if (prevLocale)
+    setlocale(LC_ALL, prevLocale);
 
   if (rv == (size_t)cchWideChar)
     return rv;

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -64,37 +64,33 @@ unsigned int SysStringLen(const BSTR bstrString) {
 
 const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
 #ifdef __APPLE__
-    switch(CodePage)
-    {
-      case CP_ACP:
-          return setlocale(Category, "en_US.ISO8859-1");
-      case CP_UTF8:
-          return setlocale(Category, "en_US.UTF-8");
-      default:
-          return nullptr;
-    }
+  switch (CodePage) {
+  case CP_ACP:
+    return setlocale(Category, "en_US.ISO8859-1");
+  case CP_UTF8:
+    return setlocale(Category, "en_US.UTF-8");
+  default:
+    return nullptr;
+  }
 #else
-    const char* utf8LocaleOptions[] = {
+  const char *utf8LocaleOptions[] = {
       "en_US.utf8", // supported on Ubuntu
       "en_US.UTF-8" // supported on Mariner
-    };
+  };
 
-    switch(CodePage)
-      {
-        case CP_ACP:
-            return setlocale(Category, "en_US.iso88591");
-        case CP_UTF8:
-        {
-            for (int i = 0; i < _countof(utf8LocaleOptions); ++i)
-            {
-                const char* locale = setlocale(Category, utf8LocaleOptions[i]);
-                if (locale != nullptr)
-                    return locale;
-            }
-        }
-        default:
-            return nullptr;
-      }
+  switch (CodePage) {
+  case CP_ACP:
+    return setlocale(Category, "en_US.iso88591");
+  case CP_UTF8: {
+    for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
+      const char *locale = setlocale(Category, utf8LocaleOptions[i]);
+      if (locale != nullptr)
+        return locale;
+    }
+  }
+  default:
+    return nullptr;
+  }
 #endif
 }
 

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -62,21 +62,40 @@ unsigned int SysStringLen(const BSTR bstrString) {
 }
 //===---------------------- Char converstion ------------------------------===//
 
-const char *CPToLocale(uint32_t CodePage) {
+const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
 #ifdef __APPLE__
-  static const char *utf8 = "en_US.UTF-8";
-  static const char *iso88591 = "en_US.ISO8859-1";
+    switch(CodePage)
+    {
+      case CP_ACP:
+          return setlocale(Category, "en_US.ISO8859-1");
+      case CP_UTF8:
+          return setlocale(Category, "en_US.UTF-8");
+      default:
+          return nullptr;
+    }
 #else
-  static const char *utf8 = "en_US.utf8";
-  static const char *iso88591 = "en_US.iso88591";
+    const char* utf8LocaleOptions[] = {
+      "en_US.utf8", // supported on Ubuntu
+      "en_US.UTF-8" // supported on Mariner
+    };
+
+    switch(CodePage)
+      {
+        case CP_ACP:
+            return setlocale(Category, "en_US.iso88591");
+        case CP_UTF8:
+        {
+            for (int i = 0; i < _countof(utf8LocaleOptions); ++i)
+            {
+                const char* locale = setlocale(Category, utf8LocaleOptions[i]);
+                if (locale != nullptr)
+                    return locale;
+            }
+        }
+        default:
+            return nullptr;
+      }
 #endif
-  if (CodePage == CP_UTF8) {
-    return utf8;
-  } else if (CodePage == CP_ACP) {
-    // Experimentation suggests that ACP is expected to be ISO-8859-1
-    return iso88591;
-  }
-  return nullptr;
 }
 
 //===--------------------------- CHandle -------------------------------===//

--- a/lib/DxcSupport/WinAdapter.cpp
+++ b/lib/DxcSupport/WinAdapter.cpp
@@ -60,39 +60,6 @@ unsigned int SysStringLen(const BSTR bstrString) {
 
   return blobIn[0] / sizeof(OLECHAR);
 }
-//===---------------------- Char converstion ------------------------------===//
-
-const char *SetLocaleForCodePage(int Category, uint32_t CodePage) {
-#ifdef __APPLE__
-  switch (CodePage) {
-  case CP_ACP:
-    return setlocale(Category, "en_US.ISO8859-1");
-  case CP_UTF8:
-    return setlocale(Category, "en_US.UTF-8");
-  default:
-    return nullptr;
-  }
-#else
-  const char *utf8LocaleOptions[] = {
-      "en_US.utf8", // supported on Ubuntu
-      "en_US.UTF-8" // supported on Mariner
-  };
-
-  switch (CodePage) {
-  case CP_ACP:
-    return setlocale(Category, "en_US.iso88591");
-  case CP_UTF8: {
-    for (int i = 0; i < _countof(utf8LocaleOptions); ++i) {
-      const char *locale = setlocale(Category, utf8LocaleOptions[i]);
-      if (locale != nullptr)
-        return locale;
-    }
-  }
-  default:
-    return nullptr;
-  }
-#endif
-}
 
 //===--------------------------- CHandle -------------------------------===//
 

--- a/lib/DxcSupport/dxcapi.use.cpp
+++ b/lib/DxcSupport/dxcapi.use.cpp
@@ -58,7 +58,7 @@ static std::string GetWin32ErrorMessage(DWORD err) {
 void IFT_Data(HRESULT hr, LPCWSTR data) {
   if (SUCCEEDED(hr))
     return;
-  CW2A pData(data, CP_UTF8);
+  CW2A pData(data);
   std::string errMsg;
   if (HRESULT_IS_WIN32ERR(hr)) {
     DWORD err = HRESULT_AS_WIN32ERR(hr);

--- a/lib/DxilDia/DxcPixCompilationInfo.cpp
+++ b/lib/DxilDia/DxcPixCompilationInfo.cpp
@@ -105,7 +105,7 @@ static void MDStringOperandToBSTR(llvm::MDOperand const &mdOperand,
       llvm::dyn_cast<llvm::MDString>(mdOperand)->getString();
   std::string StringWithTerminator(MetadataAsStringRef.begin(),
                                    MetadataAsStringRef.size());
-  CA2W cv(StringWithTerminator.c_str(), CP_UTF8);
+  CA2W cv(StringWithTerminator.c_str());
   CComBSTR BStr;
   BStr.Append(cv);
   BStr.Append(L"\0", 1);
@@ -168,7 +168,7 @@ STDMETHODIMP CompilationInfo::GetArguments(BSTR *pArguments) {
     }
 
     std::string str(strRef.begin(), strRef.size());
-    CA2W cv(str.c_str(), CP_UTF8);
+    CA2W cv(str.c_str());
     pBSTR.Append(cv);
     pBSTR.Append(L" ", 1);
   }
@@ -201,7 +201,7 @@ STDMETHODIMP CompilationInfo::GetMacroDefinitions(BSTR *pMacroDefinitions) {
       str = name + "=" + definition;
     }
 
-    CA2W cv(str.c_str(), CP_UTF8);
+    CA2W cv(str.c_str());
     pBSTR.Append(L"-D", 2);
     pBSTR.Append(cv);
     pBSTR.Append(L" ", 1);
@@ -218,7 +218,7 @@ CompilationInfo::GetEntryPointFile(BSTR *pEntryPointFile) {
                                ->getString();
   std::string str(strRef.begin(),
                   strRef.size()); // To make sure str is null terminated
-  CA2W cv(str.c_str(), CP_UTF8);
+  CA2W cv(str.c_str());
   CComBSTR pBSTR;
   pBSTR.Append(cv);
   *pEntryPointFile = pBSTR.Detach();
@@ -227,7 +227,7 @@ CompilationInfo::GetEntryPointFile(BSTR *pEntryPointFile) {
 
 STDMETHODIMP
 CompilationInfo::GetHlslTarget(BSTR *pHlslTarget) {
-  CA2W cv(m_pSession->DxilModuleRef().GetShaderModel()->GetName(), CP_UTF8);
+  CA2W cv(m_pSession->DxilModuleRef().GetShaderModel()->GetName());
   CComBSTR pBSTR;
   pBSTR.Append(cv);
   *pHlslTarget = pBSTR.Detach();
@@ -237,7 +237,7 @@ CompilationInfo::GetHlslTarget(BSTR *pHlslTarget) {
 STDMETHODIMP
 CompilationInfo::GetEntryPoint(BSTR *pEntryPoint) {
   auto name = m_pSession->DxilModuleRef().GetEntryFunctionName();
-  CA2W cv(name.c_str(), CP_UTF8);
+  CA2W cv(name.c_str());
   CComBSTR pBSTR;
   pBSTR.Append(cv);
   *pEntryPoint = pBSTR.Detach();

--- a/lib/DxilDia/DxilDiaSession.cpp
+++ b/lib/DxilDia/DxilDiaSession.cpp
@@ -351,7 +351,7 @@ STDMETHODIMP dxil_dia::Session::findInjectedSource(
     /* [in] */ LPCOLESTR srcFile,
     /* [out] */ IDiaEnumInjectedSources **ppResult) {
   if (Contents() != nullptr) {
-    CW2A pUtf8FileName(srcFile, CP_UTF8);
+    CW2A pUtf8FileName(srcFile);
     DxcThreadMalloc TM(m_pMalloc);
     IDiaTable *pTable;
     IFT(Table::Create(this, Table::Kind::InjectedSource, &pTable));

--- a/lib/DxilDia/DxilDiaSymbolManager.cpp
+++ b/lib/DxilDia/DxilDiaSymbolManager.cpp
@@ -296,7 +296,7 @@ public:
     IFR(FunctionSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
                                m_Node->getType(), ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
     return S_OK;
   }
 
@@ -398,7 +398,7 @@ public:
     IFR(TypedefTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
                                   m_BaseTypeID, ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
     return S_OK;
   }
 
@@ -440,7 +440,7 @@ public:
     IFR(VectorTypeSymbol::Create(pMalloc, pSession, m_ParentID, m_ID, m_Node,
                                  m_ElemTyID, m_NumElts, ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
     return S_OK;
   }
 
@@ -506,7 +506,7 @@ public:
     IFR(GlobalVariableSymbol::Create(pMalloc, pSession, m_ID, m_GV, m_TypeID,
                                      m_Type, ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_GV->getName().str().c_str()));
     (*ppRet)->SetIsHLSLData(true);
     return S_OK;
   }
@@ -586,7 +586,7 @@ public:
                                     m_Type, m_VI->GetOffsetInUDT(),
                                     m_VI->GetDxilRegister(), ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
     (*ppRet)->SetDataKind(m_Node->getTag() == llvm::dwarf::DW_TAG_arg_variable
                               ? DataIsParam
                               : DataIsLocal);
@@ -628,7 +628,7 @@ public:
     IFR(UDTFieldSymbol::Create(pMalloc, pSession, m_ID, m_Node, m_TypeID,
                                m_Type, ppRet));
     (*ppRet)->SetLexicalParent(m_ParentID);
-    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str(), CP_UTF8));
+    (*ppRet)->SetName(CA2W(m_Node->getName().str().c_str()));
     (*ppRet)->SetDataKind(m_Node->isStaticMember() ? DataIsStaticLocal
                                                    : DataIsMember);
     return S_OK;
@@ -946,7 +946,7 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateFlags(
     }
 
     std::string str(strRef.begin(), strRef.size());
-    CA2W cv(str.c_str(), CP_UTF8);
+    CA2W cv(str.c_str());
     pBSTR.Append(cv);
     pBSTR.Append(L"\0", 1);
   }
@@ -989,7 +989,7 @@ HRESULT dxil_dia::hlsl_symbols::CompilandEnvSymbol::CreateDefines(
        it != definesNode->op_end(); ++it) {
     llvm::StringRef strRef = llvm::dyn_cast<llvm::MDString>(*it)->getString();
     std::string str(strRef.begin(), strRef.size());
-    CA2W cv(str.c_str(), CP_UTF8);
+    CA2W cv(str.c_str());
     pBSTR.Append(cv);
     pBSTR.Append(L"\0", 1);
   }
@@ -1068,7 +1068,7 @@ STDMETHODIMP dxil_dia::hlsl_symbols::TypeSymbol::get_name(
     DXASSERT(!this->HasName(), "Setting type name multiple times.");
     std::string Name;
     IFR(m_lazySymbolName(m_pSession, &Name));
-    this->SetName(CA2W(Name.c_str(), CP_UTF8));
+    this->SetName(CA2W(Name.c_str()));
     m_lazySymbolName = nullptr;
   }
   return Symbol::get_name(pRetVal);
@@ -1579,7 +1579,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateSubroutineType(
           if (!name) {
             OS << "???";
           } else {
-            OS << CW2A((BSTR)name, CP_UTF8);
+            OS << CW2A((BSTR)name);
           }
         }
         if (first) {
@@ -1678,7 +1678,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::CreateCompositeType(
       if (!name) {
         OS << "???";
       } else {
-        OS << CW2A((BSTR)name, CP_UTF8);
+        OS << CW2A((BSTR)name);
       }
 
       OS << "[";
@@ -1910,7 +1910,7 @@ HRESULT dxil_dia::hlsl_symbols::SymbolManagerInit::HandleDerivedType(
     if (!name) {
       OS << "???";
     } else {
-      OS << CW2A((BSTR)name, CP_UTF8);
+      OS << CW2A((BSTR)name);
     }
     OS << Qualifier;
     return S_OK;

--- a/lib/HLSL/DxcOptimizer.cpp
+++ b/lib/HLSL/DxcOptimizer.cpp
@@ -462,7 +462,7 @@ HRESULT STDMETHODCALLTYPE DxcOptimizer::RunOptimizer(
         continue;
       }
 
-      CW2A optName(ppOptions[i], CP_UTF8);
+      CW2A optName(ppOptions[i]);
       // The option syntax is
       const char ArgDelim = ',';
       // '-' OPTION_NAME (',' ARG_NAME ('=' ARG_VALUE)?)*

--- a/projects/dxilconv/unittests/DxilConvTests.cpp
+++ b/projects/dxilconv/unittests/DxilConvTests.cpp
@@ -74,7 +74,7 @@ private:
     FileRunTestResult t = FileRunTestResult::RunFromFileCommands(
         path, m_dllSupport, &m_TestToolPaths);
     if (t.RunResult != 0) {
-      CA2W commentWide(t.ErrorMessage.c_str(), CP_UTF8);
+      CA2W commentWide(t.ErrorMessage.c_str());
       WEX::Logging::Log::Comment(commentWide);
       WEX::Logging::Log::Error(L"Run result is not zero");
     }
@@ -159,7 +159,7 @@ private:
     if (::PathFileExistsA(loc.c_str())) {
       m_TestToolPaths.emplace(refName, loc);
     } else {
-      CA2W locW(loc.c_str(), CP_UTF8);
+      CA2W locW(loc.c_str());
       hlsl_test::LogErrorFmt(L"Cannot find %s.", locW.m_psz);
       return false;
     }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -2521,8 +2521,8 @@ private:
     _firstChecked = true;
 
     // TODO: review this - this will allocate at least once per string
-    CA2WEX<> typeName(_typeName.str().c_str(), CP_UTF8);
-    CA2WEX<> functionName(_functionName.str().c_str(), CP_UTF8);
+    CA2WEX<> typeName(_typeName.str().c_str());
+    CA2WEX<> functionName(_functionName.str().c_str());
 
     if (FAILED(_tables[_tableIndex]->LookupIntrinsic(
             typeName, functionName, &_tableIntrinsic, &_tableLookupCookie))) {
@@ -4469,7 +4469,7 @@ public:
       const HLSL_INTRINSIC *pIntrinsic = nullptr;
       const HLSL_INTRINSIC *pPrior = nullptr;
       UINT64 lookupCookie = 0;
-      CA2W wideTypeName(typeName, CP_UTF8);
+      CA2W wideTypeName(typeName);
       HRESULT found = table->LookupIntrinsic(wideTypeName, L"*", &pIntrinsic,
                                              &lookupCookie);
       while (pIntrinsic != nullptr && SUCCEEDED(found)) {

--- a/tools/clang/tools/d3dcomp/d3dcomp.cpp
+++ b/tools/clang/tools/d3dcomp/d3dcomp.cpp
@@ -52,8 +52,8 @@ HRESULT CompileFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
   }
 
   try {
-    CA2W pEntrypointW(pEntrypoint, CP_UTF8);
-    CA2W pTargetProfileW(pTarget, CP_UTF8);
+    CA2W pEntrypointW(pEntrypoint);
+    CA2W pTargetProfileW(pTarget);
     std::vector<std::wstring> defineValues;
     std::vector<DxcDefine> defines;
     if (pDefines) {
@@ -61,10 +61,10 @@ HRESULT CompileFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
 
       // Convert to UTF-16.
       while (pCursor->Name) {
-        defineValues.push_back(std::wstring(CA2W(pCursor->Name, CP_UTF8)));
+        defineValues.push_back(std::wstring(CA2W(pCursor->Name)));
         if (pCursor->Definition)
           defineValues.push_back(
-              std::wstring(CA2W(pCursor->Definition, CP_UTF8)));
+              std::wstring(CA2W(pCursor->Definition)));
         else
           defineValues.push_back(std::wstring());
         ++pCursor;
@@ -168,7 +168,7 @@ HRESULT WINAPI BridgeD3DCompile(LPCVOID pSrcData, SIZE_T SrcDataSize,
   }
 
   try {
-    CA2W pFileName(pSourceName, CP_UTF8);
+    CA2W pFileName(pSourceName);
     return CompileFromBlob(source, pFileName, pDefines, includeHandler,
                            pEntrypoint, pTarget, Flags1, Flags2, ppCode,
                            ppErrorMsgs);
@@ -298,10 +298,10 @@ HRESULT PreprocessFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
 
       // Convert to UTF-16.
       while (pCursor->Name) {
-        defineValues.push_back(std::wstring(CA2W(pCursor->Name, CP_UTF8)));
+        defineValues.push_back(std::wstring(CA2W(pCursor->Name)));
         if (pCursor->Definition)
           defineValues.push_back(
-              std::wstring(CA2W(pCursor->Definition, CP_UTF8)));
+              std::wstring(CA2W(pCursor->Definition)));
         else
           defineValues.push_back(std::wstring());
         ++pCursor;
@@ -365,7 +365,7 @@ HRESULT WINAPI BridgeD3DPreprocess(LPCVOID pSrcData, SIZE_T SrcDataSize,
   }
 
   try {
-    CA2W pFileName(pSourceName, CP_UTF8);
+    CA2W pFileName(pSourceName);
     return PreprocessFromBlob(source, pFileName, pDefines, includeHandler,
                               ppCodeText, ppErrorMsgs);
   } catch (const std::bad_alloc &) {

--- a/tools/clang/tools/d3dcomp/d3dcomp.cpp
+++ b/tools/clang/tools/d3dcomp/d3dcomp.cpp
@@ -63,8 +63,7 @@ HRESULT CompileFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
       while (pCursor->Name) {
         defineValues.push_back(std::wstring(CA2W(pCursor->Name)));
         if (pCursor->Definition)
-          defineValues.push_back(
-              std::wstring(CA2W(pCursor->Definition)));
+          defineValues.push_back(std::wstring(CA2W(pCursor->Definition)));
         else
           defineValues.push_back(std::wstring());
         ++pCursor;
@@ -300,8 +299,7 @@ HRESULT PreprocessFromBlob(IDxcBlobEncoding *pSource, LPCWSTR pSourceName,
       while (pCursor->Name) {
         defineValues.push_back(std::wstring(CA2W(pCursor->Name)));
         if (pCursor->Definition)
-          defineValues.push_back(
-              std::wstring(CA2W(pCursor->Definition)));
+          defineValues.push_back(std::wstring(CA2W(pCursor->Definition)));
         else
           defineValues.push_back(std::wstring());
         ++pCursor;

--- a/tools/clang/tools/dxa/dxa.cpp
+++ b/tools/clang/tools/dxa/dxa.cpp
@@ -208,7 +208,7 @@ bool DxaContext::ExtractFile(const char *pName) {
   IFT(pPdbUtils->GetSourceCount(&uNumSources));
   bool printedAny = false;
 
-  CA2W WideName(pName, CP_UTF8);
+  CA2W WideName(pName);
   for (UINT32 i = 0; i < uNumSources; i++) {
     CComBSTR name;
     IFT(pPdbUtils->GetSourceName(i, &name));

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -759,10 +759,9 @@ public:
 
   virtual int Open(const char *lpFileName, int flags,
                    mode_t mode) throw() override {
-    HANDLE H =
-        CreateFileW(CA2W(lpFileName), GENERIC_READ | GENERIC_WRITE,
-                    FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING,
-                    FILE_ATTRIBUTE_NORMAL);
+    HANDLE H = CreateFileW(CA2W(lpFileName), GENERIC_READ | GENERIC_WRITE,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING,
+                           FILE_ATTRIBUTE_NORMAL);
     if (H == INVALID_HANDLE_VALUE)
       return -1;
     int FD = open_osfhandle(intptr_t(H), 0);

--- a/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
+++ b/tools/clang/tools/dxcompiler/dxcfilesystem.cpp
@@ -760,7 +760,7 @@ public:
   virtual int Open(const char *lpFileName, int flags,
                    mode_t mode) throw() override {
     HANDLE H =
-        CreateFileW(CA2W(lpFileName, CP_UTF8), GENERIC_READ | GENERIC_WRITE,
+        CreateFileW(CA2W(lpFileName), GENERIC_READ | GENERIC_WRITE,
                     FILE_SHARE_READ | FILE_SHARE_WRITE, OPEN_EXISTING,
                     FILE_ATTRIBUTE_NORMAL);
     if (H == INVALID_HANDLE_VALUE)
@@ -774,7 +774,7 @@ public:
   // fake my way toward as linux-y a file_status as I can get
   virtual int Stat(const char *lpFileName,
                    struct stat *Status) throw() override {
-    CA2W fileName_wide(lpFileName, CP_UTF8);
+    CA2W fileName_wide(lpFileName);
 
     DWORD attr = GetFileAttributesW(fileName_wide);
     if (attr == INVALID_FILE_ATTRIBUTES)

--- a/tools/clang/tools/dxcompiler/dxclinker.cpp
+++ b/tools/clang/tools/dxcompiler/dxclinker.cpp
@@ -153,7 +153,7 @@ public:
     if (!valid)
       return false;
 
-    CW2A pUtf8LibName(libName, CP_UTF8);
+    CW2A pUtf8LibName(libName);
     std::string libNameStr = std::string(pUtf8LibName);
     auto result =
         m_uniqueCompilerVersions.insert(DeserializedDxilCompilerVersion(pDCV));
@@ -187,7 +187,7 @@ DxcLinker::RegisterLibrary(LPCWSTR pLibName, // Name of the library.
   DXASSERT(m_pLinker.get(), "else Initialize() not called or failed silently");
   DxcThreadMalloc TM(m_pMalloc);
   // Prepare UTF8-encoded versions of API values.
-  CW2A pUtf8LibName(pLibName, CP_UTF8);
+  CW2A pUtf8LibName(pLibName);
   // Already exist lib with same name.
   if (m_pLinker->HasLibNameRegistered(pUtf8LibName.m_psz))
     return E_INVALIDARG;
@@ -246,8 +246,8 @@ HRESULT STDMETHODCALLTYPE DxcLinker::Link(
     return E_INVALIDARG;
   DxcThreadMalloc TM(m_pMalloc);
   // Prepare UTF8-encoded versions of API values.
-  CW2A pUtf8TargetProfile(pTargetProfile, CP_UTF8);
-  CW2A pUtf8EntryPoint(pEntryName, CP_UTF8);
+  CW2A pUtf8TargetProfile(pTargetProfile);
+  CW2A pUtf8EntryPoint(pEntryName);
 
   CComPtr<AbstractMemoryStream> pOutputStream;
 
@@ -267,7 +267,7 @@ HRESULT STDMETHODCALLTYPE DxcLinker::Link(
     hlsl::options::MainArgs mainArgs(argCountInt,
                                      const_cast<LPCWSTR *>(pArguments), 0);
     hlsl::options::DxcOpts opts;
-    CW2A pUtf8TargetProfile(pTargetProfile, CP_UTF8);
+    CW2A pUtf8TargetProfile(pTargetProfile);
     // Set target profile before reading options and validate
     opts.TargetProfile = pUtf8TargetProfile.m_psz;
     bool finished;
@@ -330,7 +330,7 @@ HRESULT STDMETHODCALLTYPE DxcLinker::Link(
     std::string first_lib_name;
 
     for (UINT32 i = 0; i < libCount; i++) {
-      CW2A pUtf8LibName(pLibNames[i], CP_UTF8);
+      CW2A pUtf8LibName(pLibNames[i]);
       bSuccess &= m_pLinker->AttachLib(pUtf8LibName.m_psz);
 
       cur_lib_name = std::string(pUtf8LibName);

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -601,8 +601,8 @@ public:
                                     : opts.OutputObject.empty()
                                         ? ""
                                         : opts.OutputObject.data();
-      CA2W pWideOutputName(
-          isPreprocessing ? opts.Preprocess.data() : pUtf8OutputName, CP_UTF8);
+      CA2W pWideOutputName(isPreprocessing ? opts.Preprocess.data()
+                                           : pUtf8OutputName);
       LPCWSTR pObjectName = (!isPreprocessing && opts.OutputObject.empty())
                                 ? nullptr
                                 : pWideOutputName.m_psz;

--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -442,8 +442,8 @@ static void CreateDefineStrings(const DxcDefine *pDefines, UINT defineCount,
                                 std::vector<std::string> &defines) {
   // Not very efficient but also not very important.
   for (UINT32 i = 0; i < defineCount; i++) {
-    CW2A utf8Name(pDefines[i].Name, CP_UTF8);
-    CW2A utf8Value(pDefines[i].Value, CP_UTF8);
+    CW2A utf8Name(pDefines[i].Name);
+    CW2A utf8Value(pDefines[i].Value);
     std::string val(utf8Name.m_psz);
     val += "=";
     val += (pDefines[i].Value) ? utf8Value.m_psz : "1";
@@ -594,7 +594,7 @@ public:
       const char *pUtf8SourceName =
           opts.InputFile.empty() ? "hlsl.hlsl" : opts.InputFile.data();
 
-      CA2W pWideSourceName(pUtf8SourceName, CP_UTF8);
+      CA2W pWideSourceName(pUtf8SourceName);
       const char *pUtf8EntryPoint =
           opts.EntryPoint.empty() ? "main" : opts.EntryPoint.data();
       const char *pUtf8OutputName = isPreprocessing ? opts.Preprocess.data()

--- a/tools/clang/tools/dxlib-sample/lib_cache_manager.cpp
+++ b/tools/clang/tools/dxlib-sample/lib_cache_manager.cpp
@@ -108,7 +108,7 @@ private:
 };
 
 static hash_code CombineWStr(hash_code hash, LPCWSTR Arg) {
-  CW2A pUtf8Arg(Arg, CP_UTF8);
+  CW2A pUtf8Arg(Arg);
   unsigned length = strlen(pUtf8Arg.m_psz);
   return hash_combine(hash, StringRef(pUtf8Arg.m_psz, length));
 }

--- a/tools/clang/tools/dxopt/dxopt.cpp
+++ b/tools/clang/tools/dxopt/dxopt.cpp
@@ -315,8 +315,8 @@ int main(int argc, const char **argv) {
     }
 
     if (externalLib) {
-      CW2A externalFnA(externalFn, CP_UTF8);
-      CW2A externalLibA(externalLib, CP_UTF8);
+      CW2A externalFnA(externalFn);
+      CW2A externalLibA(externalLib);
       IFT(g_DxcSupport.InitializeForDll(externalLibA, externalFnA));
     } else {
       IFT(g_DxcSupport.Initialize());

--- a/tools/clang/tools/libclang/dxcrewriteunused.cpp
+++ b/tools/clang/tools/libclang/dxcrewriteunused.cpp
@@ -625,8 +625,8 @@ void SetupCompilerForPreprocess(CompilerInstance &compiler,
   if (pDefines) {
     PreprocessorOptions &PPOpts = compiler.getPreprocessorOpts();
     for (size_t i = 0; i < defineCount; ++i) {
-      CW2A utf8Name(pDefines[i].Name, CP_UTF8);
-      CW2A utf8Value(pDefines[i].Value, CP_UTF8);
+      CW2A utf8Name(pDefines[i].Name);
+      CW2A utf8Value(pDefines[i].Value);
       std::string val(utf8Name.m_psz);
       val += "=";
       val += (pDefines[i].Value) ? utf8Value.m_psz : "1";
@@ -638,8 +638,8 @@ void SetupCompilerForPreprocess(CompilerInstance &compiler,
 std::string DefinesToString(DxcDefine *pDefines, UINT32 defineCount) {
   std::string defineStr;
   for (UINT32 i = 0; i < defineCount; i++) {
-    CW2A utf8Name(pDefines[i].Name, CP_UTF8);
-    CW2A utf8Value(pDefines[i].Value, CP_UTF8);
+    CW2A utf8Name(pDefines[i].Name);
+    CW2A utf8Value(pDefines[i].Value);
     defineStr += "#define ";
     defineStr += utf8Name;
     defineStr += " ";
@@ -1589,7 +1589,7 @@ public:
       std::unique_ptr<ASTUnit::RemappedFile> pRemap(
           new ASTUnit::RemappedFile(fakeName, pBuffer.release()));
 
-      CW2A utf8EntryPoint(pEntryPoint, CP_UTF8);
+      CW2A utf8EntryPoint(pEntryPoint);
 
       std::string errors;
       std::string rewrite;
@@ -1678,7 +1678,7 @@ public:
     CComPtr<IDxcBlobUtf8> utf8Source;
     IFR(hlsl::DxcGetBlobAsUtf8(pSource, m_pMalloc, &utf8Source));
 
-    CW2A utf8SourceName(pSourceName, CP_UTF8);
+    CW2A utf8SourceName(pSourceName);
     LPCSTR fName = utf8SourceName.m_psz;
 
     try {
@@ -1746,7 +1746,7 @@ public:
     CComPtr<IDxcBlobUtf8> utf8Source;
     IFR(hlsl::DxcGetBlobAsUtf8(pSource, m_pMalloc, &utf8Source));
 
-    CW2A utf8SourceName(pSourceName, CP_UTF8);
+    CW2A utf8SourceName(pSourceName);
     LPCSTR fName = utf8SourceName.m_psz;
 
     try {

--- a/tools/clang/unittests/HLSL/CompilerTest.cpp
+++ b/tools/clang/unittests/HLSL/CompilerTest.cpp
@@ -381,7 +381,7 @@ public:
       CComPtr<IDxcBlobEncoding> pErr;
       IFT(pResult->GetErrorBuffer(&pErr));
       std::string errString(BlobToUtf8(pErr));
-      CA2W errStringW(errString.c_str(), CP_UTF8);
+      CA2W errStringW(errString.c_str());
       WEX::Logging::Log::Comment(L"Failed to compile - errors follow");
       WEX::Logging::Log::Comment(errStringW);
     }
@@ -403,7 +403,7 @@ public:
     FileRunTestResult t =
         FileRunTestResult::RunHashTestFromFileCommands(fullPath);
     if (t.RunResult != 0) {
-      CA2W commentWide(t.ErrorMessage.c_str(), CP_UTF8);
+      CA2W commentWide(t.ErrorMessage.c_str());
       WEX::Logging::Log::Comment(commentWide);
       WEX::Logging::Log::Error(L"Run result is not zero");
     }
@@ -486,7 +486,7 @@ public:
         fullPath,
         /*pPluginToolsPaths*/ nullptr, dumpPath);
     if (t.RunResult != 0) {
-      CA2W commentWide(t.ErrorMessage.c_str(), CP_UTF8);
+      CA2W commentWide(t.ErrorMessage.c_str());
       WEX::Logging::Log::Comment(commentWide);
       WEX::Logging::Log::Error(L"Run result is not zero");
     }
@@ -610,7 +610,7 @@ public:
     if (FAILED(result)) {
       CComPtr<IDxcBlobEncoding> pErrors;
       VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrors));
-      CA2W errorsWide(BlobToUtf8(pErrors).c_str(), CP_UTF8);
+      CA2W errorsWide(BlobToUtf8(pErrors).c_str());
       WEX::Logging::Log::Comment(errorsWide);
     }
     VERIFY_SUCCEEDED(result);
@@ -649,7 +649,7 @@ public:
       CComPtr<IDxcBlobEncoding> pDisassembly;
       VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDisassembly));
       std::string disText = BlobToUtf8(pDisassembly);
-      CA2W disTextW(disText.c_str(), CP_UTF8);
+      CA2W disTextW(disText.c_str());
       // WEX::Logging::Log::Comment(disTextW);
     }
 
@@ -680,7 +680,7 @@ public:
       CComPtr<IDxcBlobEncoding> pDbgDisassembly;
       VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgramPdb, &pDbgDisassembly));
       std::string disText = BlobToUtf8(pDbgDisassembly);
-      CA2W disTextW(disText.c_str(), CP_UTF8);
+      CA2W disTextW(disText.c_str());
       // WEX::Logging::Log::Comment(disTextW);
     }
 
@@ -881,7 +881,7 @@ TEST_F(CompilerTest, CompileWhenIncorrectThenFails) {
   std::string errorString(BlobToUtf8(pErrorBuffer));
   VERIFY_ARE_NOT_EQUAL(0U, errorString.size());
   // Useful for examining actual error message:
-  // CA2W errorStringW(errorString.c_str(), CP_UTF8);
+  // CA2W errorStringW(errorString.c_str());
   // WEX::Logging::Log::Comment(errorStringW.m_psz);
 }
 
@@ -909,7 +909,7 @@ TEST_F(CompilerTest, CompileWhenWorksThenDisassembleWorks) {
   std::string disassembleString(BlobToUtf8(pDisassembleBlob));
   VERIFY_ARE_NOT_EQUAL(0U, disassembleString.size());
   // Useful for examining disassembly:
-  // CA2W disassembleStringW(disassembleString.c_str(), CP_UTF8);
+  // CA2W disassembleStringW(disassembleString.c_str());
   // WEX::Logging::Log::Comment(disassembleStringW.m_psz);
 }
 

--- a/tools/clang/unittests/HLSL/DxilContainerTest.cpp
+++ b/tools/clang/unittests/HLSL/DxilContainerTest.cpp
@@ -634,7 +634,7 @@ public:
     FileRunTestResult t =
         FileRunTestResult::RunFromFileCommands(fullPath.c_str());
     if (t.RunResult != 0) {
-      CA2W commentWide(t.ErrorMessage.c_str(), CP_UTF8);
+      CA2W commentWide(t.ErrorMessage.c_str());
       WEX::Logging::Log::Comment(commentWide);
       WEX::Logging::Log::Error(L"Run result is not zero");
     }

--- a/tools/clang/unittests/HLSL/FunctionTest.cpp
+++ b/tools/clang/unittests/HLSL/FunctionTest.cpp
@@ -94,7 +94,7 @@ public:
       CComPtr<IDxcBlobEncoding> pErrors;
       pResult->GetErrorBuffer(&pErrors);
       std::string text = BlobToUtf8(pErrors);
-      CA2W textW(text.c_str(), CP_UTF8);
+      CA2W textW(text.c_str());
       WEX::Logging::Log::Comment(textW.m_psz);
     }
     VERIFY_ARE_EQUAL(expected, resultStatus);

--- a/tools/clang/unittests/HLSL/OptimizerTest.cpp
+++ b/tools/clang/unittests/HLSL/OptimizerTest.cpp
@@ -134,7 +134,7 @@ public:
     if (FAILED(result)) {
       CComPtr<IDxcBlobEncoding> pErrors;
       VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrors));
-      CA2W errorsWide(BlobToUtf8(pErrors).c_str(), CP_UTF8);
+      CA2W errorsWide(BlobToUtf8(pErrors).c_str());
       WEX::Logging::Log::Comment(errorsWide);
     }
     VERIFY_SUCCEEDED(result);
@@ -265,7 +265,7 @@ void OptimizerTest::OptimizerWhenSliceNThenOK(int optLevel, LPCSTR pText,
   VERIFY_SUCCEEDED(pResult->GetResult(&pOptDump));
   pResult.Release();
   passes = BlobToUtf8(pOptDump);
-  CA2W passesW(passes.c_str(), CP_UTF8);
+  CA2W passesW(passes.c_str());
 
   // Get the high-level compile of the program.
   highLevelArgs.pop_back(); // Remove /Odump

--- a/tools/clang/unittests/HLSL/PixDiaTest.cpp
+++ b/tools/clang/unittests/HLSL/PixDiaTest.cpp
@@ -587,7 +587,7 @@ public:
       CComPtr<IDxcBlobEncoding> pDisassembly;
       VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDisassembly));
       std::string disText = BlobToUtf8(pDisassembly);
-      CA2W disTextW(disText.c_str(), CP_UTF8);
+      CA2W disTextW(disText.c_str());
       // WEX::Logging::Log::Comment(disTextW);
     }
 
@@ -621,7 +621,7 @@ public:
       CComPtr<IDxcBlobEncoding> pDbgDisassembly;
       VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgramPdb, &pDbgDisassembly));
       std::string disText = BlobToUtf8(pDbgDisassembly);
-      CA2W disTextW(disText.c_str(), CP_UTF8);
+      CA2W disTextW(disText.c_str());
       // WEX::Logging::Log::Comment(disTextW);
     }
 
@@ -940,7 +940,7 @@ TEST_F(PixDiaTest, CompileWhenDebugThenDIPresent) {
   CComPtr<IDxcBlob> pdbBlob;
   VERIFY_SUCCEEDED(pLib->CreateBlobFromFile(path, nullptr, &fxcBlob));
   std::string s = DumpParts(fxcBlob);
-  CA2W sW(s.c_str(), CP_UTF8);
+  CA2W sW(s.c_str());
   WEX::Logging::Log::Comment(sW);
   VERIFY_SUCCEEDED(CreateDiaSourceFromDxbcBlob(pLib, fxcBlob, &pDiaSource));
   WEX::Logging::Log::Comment(GetDebugInfoAsText(pDiaSource).c_str());

--- a/tools/clang/unittests/HLSL/PixTest.cpp
+++ b/tools/clang/unittests/HLSL/PixTest.cpp
@@ -2352,7 +2352,7 @@ static void VerifyOperationSucceeded(IDxcOperationResult *pResult) {
   if (FAILED(result)) {
     CComPtr<IDxcBlobEncoding> pErrors;
     VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrors));
-    CA2W errorsWide(BlobToUtf8(pErrors).c_str(), CP_UTF8);
+    CA2W errorsWide(BlobToUtf8(pErrors).c_str());
     WEX::Logging::Log::Comment(errorsWide);
   }
   VERIFY_SUCCEEDED(result);

--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -173,7 +173,7 @@ std::wstring Disassemble(dxc::DxcDllSupport &dllSupport, IDxcBlob *pProgram) {
   CComPtr<IDxcBlobEncoding> pDbgDisassembly;
   VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgram, &pDbgDisassembly));
   std::string disText = BlobToUtf8(pDbgDisassembly);
-  CA2W disTextW(disText.c_str(), CP_UTF8);
+  CA2W disTextW(disText.c_str());
   return std::wstring(disTextW);
 }
 
@@ -418,7 +418,7 @@ CComPtr<IDxcBlob> Compile(dxc::DxcDllSupport &dllSupport, const char *hlsl,
       CComPtr<IDxcBlobEncoding> pDbgDisassembly;
       VERIFY_SUCCEEDED(pCompiler->Disassemble(pProgramPdb, &pDbgDisassembly));
       std::string disText = BlobToUtf8(pDbgDisassembly);
-      CA2W disTextW(disText.c_str(), CP_UTF8);
+      CA2W disTextW(disText.c_str());
       WEX::Logging::Log::Comment(disTextW);
     }
 #endif

--- a/tools/clang/unittests/HLSL/PixTestUtils.cpp
+++ b/tools/clang/unittests/HLSL/PixTestUtils.cpp
@@ -386,8 +386,7 @@ CComPtr<IDxcBlob> Compile(dxc::DxcDllSupport &dllSupport, const char *hlsl,
   if (FAILED(compilationStatus)) {
     CComPtr<IDxcBlobEncoding> pErrros;
     VERIFY_SUCCEEDED(pResult->GetErrorBuffer(&pErrros));
-    CA2W errorTextW(static_cast<const char *>(pErrros->GetBufferPointer()),
-                    CP_UTF8);
+    CA2W errorTextW(static_cast<const char *>(pErrros->GetBufferPointer()));
     WEX::Logging::Log::Error(errorTextW);
     return {};
   }

--- a/tools/clang/unittests/HLSL/SystemValueTest.cpp
+++ b/tools/clang/unittests/HLSL/SystemValueTest.cpp
@@ -76,7 +76,7 @@ public:
     if (semKind < DXIL::SemanticKind::Invalid && pSemName) {
       if (Semantic::HasSVPrefix(pSemName))
         pSemName += 3;
-      CA2W semNameW(pSemName, CP_UTF8);
+      CA2W semNameW(pSemName);
       sigDefValue = L"Def_";
       sigDefValue += semNameW;
     }
@@ -160,7 +160,7 @@ public:
       profile = profile_buf;
     }
 
-    CA2W sigPointNameW(sigPoint->GetName(), CP_UTF8);
+    CA2W sigPointNameW(sigPoint->GetName());
     // Strip SV_ from semantic name
     std::wstring sigDefName(sigPointNameW);
     sigDefName += L"_Defs";

--- a/tools/clang/unittests/HLSL/ValidationTest.cpp
+++ b/tools/clang/unittests/HLSL/ValidationTest.cpp
@@ -315,7 +315,7 @@ public:
     FileRunTestResult t =
         FileRunTestResult::RunFromFileCommands(fullPath.c_str());
     if (t.RunResult != 0) {
-      CA2W commentWide(t.ErrorMessage.c_str(), CP_UTF8);
+      CA2W commentWide(t.ErrorMessage.c_str());
       WEX::Logging::Log::Comment(commentWide);
       WEX::Logging::Log::Error(L"Run result is not zero");
     }
@@ -368,7 +368,7 @@ public:
     CComPtr<IDxcOperationResult> pResult;
     CComPtr<IDxcBlob> pProgram;
 
-    CA2W shWide(pShaderModel, CP_UTF8);
+    CA2W shWide(pShaderModel);
 
     const wchar_t *pEntryName = L"main";
 

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -152,7 +152,7 @@ static void WriteInfoQueueMessages(void *pStrCtx,
       allMessagesOK = false;
       continue;
     }
-    CA2W msgW(pMessage->pDescription, CP_ACP);
+    CA2W msgW(pMessage->pDescription);
     pOutputStrFn(pStrCtx, msgW.m_psz);
     pOutputStrFn(pStrCtx, L"\r\n");
   }
@@ -1717,8 +1717,8 @@ public:
 #ifndef _HLK_CONF
   void DXBCFromText(LPCSTR pText, LPCWSTR pEntryPoint, LPCWSTR pTargetProfile,
                     ID3DBlob **ppBlob) {
-    CW2A pEntryPointA(pEntryPoint, CP_UTF8);
-    CW2A pTargetProfileA(pTargetProfile, CP_UTF8);
+    CW2A pEntryPointA(pEntryPoint);
+    CW2A pTargetProfileA(pTargetProfile);
     CComPtr<ID3DBlob> pErrors;
     D3D_SHADER_MACRO d3dMacro[2];
     ZeroMemory(d3dMacro, sizeof(d3dMacro));
@@ -1728,7 +1728,7 @@ public:
         D3DCompile(pText, strlen(pText), "hlsl.hlsl", d3dMacro, nullptr,
                    pEntryPointA, pTargetProfileA, 0, 0, ppBlob, &pErrors);
     if (pErrors != nullptr) {
-      CA2W errors((char *)pErrors->GetBufferPointer(), CP_ACP);
+      CA2W errors((char *)pErrors->GetBufferPointer());
       LogCommentFmt(L"Compilation failure: %s", errors.m_szBuffer);
     }
     VERIFY_SUCCEEDED(hr);

--- a/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ShaderOpTest.cpp
@@ -848,10 +848,10 @@ void ShaderOpTest::CreateShaders() {
       CComPtr<IDxcLibrary> pLibrary;
       CComPtr<IDxcBlobEncoding> pTextBlob;
       CComPtr<IDxcOperationResult> pResult;
-      CA2W nameW(S.Name, CP_UTF8);
-      CA2W entryPointW(S.EntryPoint, CP_UTF8);
-      CA2W targetW(S.Target, CP_UTF8);
-      CA2W argumentsW(pArguments, CP_UTF8);
+      CA2W nameW(S.Name);
+      CA2W entryPointW(S.EntryPoint);
+      CA2W targetW(S.Target);
+      CA2W argumentsW(pArguments);
 
       std::vector<LPCWSTR> argumentsWList;
       splitWStringIntoVectors(argumentsW, L' ', argumentsWList);

--- a/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
+++ b/tools/clang/unittests/HLSLTestLib/FileCheckerTest.cpp
@@ -130,7 +130,7 @@ FileRunCommandPart::RunFileChecker(const FileRunCommandResult *Prior,
         "Prior command required to generate stdin");
 
   FileCheckForTest t;
-  t.CheckFilename = CW2A(CommandFileName, CP_UTF8);
+  t.CheckFilename = CW2A(CommandFileName);
   t.InputForStdin = Prior->ExitCode ? Prior->StdErr : Prior->StdOut;
 
   // Parse command arguments
@@ -164,7 +164,7 @@ FileRunCommandPart::RunFileChecker(const FileRunCommandResult *Prior,
 
   if (dumpName) {
     // Dump t.InputForStdin to file for comparison purposes
-    CW2A dumpNameUtf8(dumpName, CP_UTF8);
+    CW2A dumpNameUtf8(dumpName);
     llvm::StringRef dumpPath(dumpNameUtf8.m_psz);
     llvm::sys::fs::create_directories(llvm::sys::path::parent_path(dumpPath),
                                       /*IgnoreExisting*/ true);
@@ -1022,11 +1022,11 @@ FileRunCommandPart::RunTee(const FileRunCommandResult *Prior) {
 
   // Ignore commands for now - simply log out through test framework.
   {
-    CA2W outWide(Prior->StdOut.c_str(), CP_UTF8);
+    CA2W outWide(Prior->StdOut.c_str());
     WEX::Logging::Log::Comment(outWide.m_psz);
   }
   if (!Prior->StdErr.empty()) {
-    CA2W errWide(Prior->StdErr.c_str(), CP_UTF8);
+    CA2W errWide(Prior->StdErr.c_str());
     WEX::Logging::Log::Comment(L"<stderr>");
     WEX::Logging::Log::Comment(errWide.m_psz);
   }


### PR DESCRIPTION
This commit fixes the setlocale( ) logic to include the UTF-8 supported string value for Mariner distros.  

It also introduces a new RAII class `ScopedLocale' which ensure that the locale setting is set/reset during string conversion operations.

Fixes: #6201