### PR TITLE
[SPIR-V] Emulate OpBitFieldInsert for type != i32

### DIFF
--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -444,8 +444,8 @@ public:
   /// \brief Creates an OpBitFieldInsert SPIR-V instruction for the given
   /// arguments.
   SpirvInstruction *createBitFieldInsert(QualType resultType,
-                                         SpirvInstruction *dst,
-                                         SpirvInstruction *src,
+                                         SpirvInstruction *base,
+                                         SpirvInstruction *insert,
                                          unsigned bitOffset, unsigned bitCount,
                                          SourceLocation, SourceRange);
 
@@ -836,7 +836,7 @@ private:
   /// arguments.
   SpirvInstruction *
   createEmulatedBitFieldInsert(QualType resultType, uint32_t baseTypeBitwidth,
-                               SpirvInstruction *dst, SpirvInstruction *src,
+                               SpirvInstruction *base, SpirvInstruction *insert,
                                unsigned bitOffset, unsigned bitCount,
                                SourceLocation, SourceRange);
 

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -443,10 +443,11 @@ public:
 
   /// \brief Creates an OpBitFieldInsert SPIR-V instruction for the given
   /// arguments.
-  SpirvBitFieldInsert *
-  createBitFieldInsert(QualType resultType, SpirvInstruction *base,
-                       SpirvInstruction *insert, SpirvInstruction *offset,
-                       SpirvInstruction *count, SourceLocation);
+  SpirvInstruction *createBitFieldInsert(QualType ResultType,
+                                         SpirvInstruction *Dst,
+                                         SpirvInstruction *Src,
+                                         unsigned BitOffset, unsigned BitCount,
+                                         SourceLocation, SourceRange);
 
   /// \brief Creates an OpBitFieldUExtract or OpBitFieldSExtract SPIR-V
   /// instruction for the given arguments.
@@ -830,6 +831,14 @@ private:
   SpirvVariable *createCloneVarForFxcCTBuffer(QualType astType,
                                               const SpirvType *spvType,
                                               SpirvInstruction *var);
+
+  /// \brief Emulates OpBitFieldInsert SPIR-V instruction for the given
+  /// arguments.
+  SpirvInstruction *
+  createEmulatedBitFieldInsert(QualType ResultType, uint32_t BaseTypeBitwidth,
+                               SpirvInstruction *Dst, SpirvInstruction *Src,
+                               unsigned BitOffset, unsigned BitCount,
+                               SourceLocation loc, SourceRange range);
 
 private:
   ASTContext &astContext;

--- a/tools/clang/include/clang/SPIRV/SpirvBuilder.h
+++ b/tools/clang/include/clang/SPIRV/SpirvBuilder.h
@@ -443,10 +443,10 @@ public:
 
   /// \brief Creates an OpBitFieldInsert SPIR-V instruction for the given
   /// arguments.
-  SpirvInstruction *createBitFieldInsert(QualType ResultType,
-                                         SpirvInstruction *Dst,
-                                         SpirvInstruction *Src,
-                                         unsigned BitOffset, unsigned BitCount,
+  SpirvInstruction *createBitFieldInsert(QualType resultType,
+                                         SpirvInstruction *dst,
+                                         SpirvInstruction *src,
+                                         unsigned bitOffset, unsigned bitCount,
                                          SourceLocation, SourceRange);
 
   /// \brief Creates an OpBitFieldUExtract or OpBitFieldSExtract SPIR-V
@@ -835,10 +835,10 @@ private:
   /// \brief Emulates OpBitFieldInsert SPIR-V instruction for the given
   /// arguments.
   SpirvInstruction *
-  createEmulatedBitFieldInsert(QualType ResultType, uint32_t BaseTypeBitwidth,
-                               SpirvInstruction *Dst, SpirvInstruction *Src,
-                               unsigned BitOffset, unsigned BitCount,
-                               SourceLocation loc, SourceRange range);
+  createEmulatedBitFieldInsert(QualType resultType, uint32_t baseTypeBitwidth,
+                               SpirvInstruction *dst, SpirvInstruction *src,
+                               unsigned bitOffset, unsigned bitCount,
+                               SourceLocation, SourceRange);
 
 private:
   ASTContext &astContext;

--- a/tools/clang/lib/SPIRV/InitListHandler.cpp
+++ b/tools/clang/lib/SPIRV/InitListHandler.cpp
@@ -452,14 +452,9 @@ InitListHandler::createInitForStructType(QualType type, SourceLocation srcLoc,
         // For the remaining bitfields, we need to insert them into the existing
         // container, which is the last element in `fields`.
         assert(fields.size() == fieldInfo.fieldIndex + 1);
-        SpirvInstruction *offset = spvBuilder.getConstantInt(
-            astContext.UnsignedIntTy,
-            llvm::APInt(32, fieldInfo.bitfield->offsetInBits));
-        SpirvInstruction *count = spvBuilder.getConstantInt(
-            astContext.UnsignedIntTy,
-            llvm::APInt(32, fieldInfo.bitfield->sizeInBits));
         fields.back() = spvBuilder.createBitFieldInsert(
-            fieldType, fields.back(), init, offset, count, srcLoc);
+            fieldType, fields.back(), init, fieldInfo.bitfield->offsetInBits,
+            fieldInfo.bitfield->sizeInBits, srcLoc, range);
         return true;
       },
       true);

--- a/tools/clang/lib/SPIRV/SpirvBuilder.cpp
+++ b/tools/clang/lib/SPIRV/SpirvBuilder.cpp
@@ -887,10 +887,12 @@ SpirvInstruction *SpirvBuilder::createEmulatedBitFieldInsert(
   //
   //
 
-  // mask = (1 << bitCount) - 1     // Create a mask matching B's size.
-  // mask = (unsigned dstType)mask  // cast mask to the an unsigned with the
-  // same bitwidth. mask = mask << bitOffset  // Move the mask to B's position
-  // in the raw type.
+  // Create a mask matching B's size.
+  //   mask = (1 << bitCount) - 1
+  // cast mask to the an unsigned with the same bitwidth.
+  //   mask = (unsigned dstType)mask
+  // Move the mask to B's position in the raw type.
+  //   mask = mask << bitOffset
   assert(bitCount <= 64 &&
          "Bitfield insertion emulation can only insert at most 64 bits.");
   auto maskTy =

--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9237,6 +9237,7 @@ SpirvEmitter::processIntrinsicNonUniformResourceIndex(const CallExpr *expr) {
 SpirvInstruction *
 SpirvEmitter::processIntrinsicMsad4(const CallExpr *callExpr) {
   const auto loc = callExpr->getExprLoc();
+  const auto range = callExpr->getSourceRange();
   if (!spirvOptions.noWarnEmulatedFeatures)
     emitWarning("msad4 intrinsic function is emulated using many SPIR-V "
                 "instructions due to lack of direct SPIR-V equivalent",
@@ -9297,18 +9298,15 @@ SpirvEmitter::processIntrinsicMsad4(const CallExpr *callExpr) {
   // Do bfi 3 times. DXIL bfi is equivalent to SPIR-V OpBitFieldInsert.
   auto *v1y = spvBuilder.createCompositeExtract(uintType, source, {1}, loc);
   // Note that t0.x = v1.x, nothing we need to do for that.
-  auto *t0y =
-      spvBuilder.createBitFieldInsert(uintType, /*base*/ v1xS8, /*insert*/ v1y,
-                                      /*offset*/ uint24,
-                                      /*width*/ uint8, loc);
-  auto *t0z =
-      spvBuilder.createBitFieldInsert(uintType, /*base*/ v1xS16, /*insert*/ v1y,
-                                      /*offset*/ uint16,
-                                      /*width*/ uint16, loc);
-  auto *t0w =
-      spvBuilder.createBitFieldInsert(uintType, /*base*/ v1xS24, /*insert*/ v1y,
-                                      /*offset*/ uint8,
-                                      /*width*/ uint24, loc);
+  auto *t0y = spvBuilder.createBitFieldInsert(
+      uintType, /*base*/ v1xS8, /*insert*/ v1y,
+      /* bitOffest */ 24, /* bitCount */ 8, loc, range);
+  auto *t0z = spvBuilder.createBitFieldInsert(
+      uintType, /*base*/ v1xS16, /*insert*/ v1y,
+      /* bitOffest */ 16, /* bitCount */ 16, loc, range);
+  auto *t0w = spvBuilder.createBitFieldInsert(
+      uintType, /*base*/ v1xS24, /*insert*/ v1y,
+      /* bitOffest */ 8, /* bitCount */ 24, loc, range);
 
   // Step 3. MSAD (Masked Sum of Absolute Differences)
 

--- a/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.hlsl
@@ -1,0 +1,148 @@
+// RUN: %dxc -T cs_6_2 -E main -spirv -fcgl -enable-16bit-types %s | FileCheck %s
+
+struct S1 {
+  uint64_t f1 : 32;
+  uint64_t f2 : 1;
+};
+// CHECK-DAG: %S1 = OpTypeStruct %ulong
+
+struct S2 {
+  uint16_t f1 : 4;
+  uint16_t f2 : 5;
+};
+// CHECK-DAG: %S2 = OpTypeStruct %ushort
+
+struct S3 {
+  uint64_t f1 : 45;
+  uint64_t f2 : 10;
+  uint16_t f3 : 7;
+  uint32_t f4 : 5;
+};
+// CHECK-DAG: %S3 = OpTypeStruct %ulong %ushort %uint
+
+struct S4 {
+  int64_t f1 : 32;
+  int64_t f2 : 1;
+};
+// CHECK-DAG: %S4 = OpTypeStruct %long
+
+[numthreads(1, 1, 1)]
+void main() {
+  S1 s1;
+  s1.f1 = 3;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_4294967295 %uint_0
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_3
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s1.f2 = 1;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1 %uint_32
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_1
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_32
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  S2 s2;
+  s2.f1 = 2;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s2 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_15 %uint_0
+// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_2
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s2.f2 = 3;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s2 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_31 %uint_4
+// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_3
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_4
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  S3 s3;
+  s3.f1 = 5;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_35184372088831 %uint_0
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_5
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s3.f2 = 6;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1023 %uint_45
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_6
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_45
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s3.f3 = 7;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s3 %int_1
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_127 %uint_0
+// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_7
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s3.f4 = 8;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %s3 %int_2
+// CHECK:   [[val:%[0-9]+]] = OpLoad %uint [[ptr]]
+// CHECK:   [[tmp:%[0-9]+]] = OpBitFieldInsert %uint [[val]] %uint_8 %uint_0 %uint_5
+// CHECK:                     OpStore [[ptr]] [[tmp]]
+
+  S4 s4;
+  s4.f1 = 3;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_long %s4 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %long [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_4294967295 %uint_0
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %long %long_3
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %long [[val]] %uint_0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %long [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+
+  s4.f2 = 1;
+// CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_long %s4 %int_0
+// CHECK:   [[tmp:%[0-9]+]] = OpLoad %long [[ptr]]
+// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1 %uint_32
+// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[imask]]
+// CHECK:   [[val:%[0-9]+]] = OpBitcast %long %long_1
+// CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %long [[val]] %uint_32
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[mask]]
+// CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %long [[dst]] [[src]]
+// CHECK:                     OpStore [[ptr]] [[mix]]
+}

--- a/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/op.struct.access.bitfield.sized.hlsl
@@ -32,24 +32,24 @@ void main() {
   s1.f1 = 3;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_4294967295 %uint_0
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+//                                                        0xffffffff00000000
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_18446744069414584320
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_3
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_0
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+//                                                        0x00000000ffffffff
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_4294967295
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
   s1.f2 = 1;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s1 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1 %uint_32
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+//                                                        0xfffffffeffffffff
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_18446744069414584319
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_1
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_32
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+//                                                        0x0000000100000000
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_4294967296
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
@@ -57,24 +57,24 @@ void main() {
   s2.f1 = 2;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s2 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_15 %uint_0
-// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+//                                                         0xfff0
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_65520
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_2
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_0
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+//                                                         0x000f
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_15
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
   s2.f2 = 3;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s2 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_31 %uint_4
-// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+//                                                         0xfe0f
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_65039
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_3
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_4
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+//                                                         0x01f0
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_496
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
@@ -82,36 +82,36 @@ void main() {
   s3.f1 = 5;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_35184372088831 %uint_0
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+//                                                        0xffffe00000000000
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_18446708889337462784
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_5
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_0
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+//                                                        0x00001fffffffffff
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_35184372088831
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
   s3.f2 = 6;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ulong %s3 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ulong [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1023 %uint_45
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[imask]]
+//                                                        0xff801fffffffffff
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_18410750461062676479
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ulong %ulong_6
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ulong [[val]] %uint_45
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] [[mask]]
+//                                                        0x007fe00000000000
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ulong [[tmp]] %ulong_35993612646875136
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ulong [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
   s3.f3 = 7;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_ushort %s3 %int_1
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %ushort [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ushort %ushort_127 %uint_0
-// CHECK: [[imask:%[0-9]+]] = OpNot %ushort [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[imask]]
+//                                                         0xff80
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_65408
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %ushort %ushort_7
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %ushort [[val]] %uint_0
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] [[mask]]
+//                                                         0x007f
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %ushort [[tmp]] %ushort_127
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %ushort [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
@@ -125,24 +125,24 @@ void main() {
   s4.f1 = 3;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_long %s4 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %long [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_4294967295 %uint_0
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[imask]]
+//                                                       0xffffffff00000000
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] %ulong_18446744069414584320
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %long %long_3
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %long [[val]] %uint_0
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[mask]]
+//                                                       0x00000000ffffffff
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] %ulong_4294967295
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %long [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 
   s4.f2 = 1;
 // CHECK:   [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_long %s4 %int_0
 // CHECK:   [[tmp:%[0-9]+]] = OpLoad %long [[ptr]]
-// CHECK:  [[mask:%[0-9]+]] = OpShiftLeftLogical %ulong %ulong_1 %uint_32
-// CHECK: [[imask:%[0-9]+]] = OpNot %ulong [[mask]]
-// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[imask]]
+//                                                       0xfffffffeffffffff
+// CHECK:   [[dst:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] %ulong_18446744069414584319
 // CHECK:   [[val:%[0-9]+]] = OpBitcast %long %long_1
 // CHECK:   [[tmp:%[0-9]+]] = OpShiftLeftLogical %long [[val]] %uint_32
-// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] [[mask]]
+//                                                       0x0000000100000000
+// CHECK:   [[src:%[0-9]+]] = OpBitwiseAnd %long [[tmp]] %ulong_4294967296
 // CHECK:   [[mix:%[0-9]+]] = OpBitwiseOr %long [[dst]] [[src]]
 // CHECK:                     OpStore [[ptr]] [[mix]]
 }


### PR DESCRIPTION
SPIR-V supported OpBitFieldInsert on all integer types. But Vulkan requires the operands to be 32bit integers.
This means we need to emulate this instruction for types other then i32.

This PR only adds emulation for OpBitFieldInsert. The next PR will add support for emulating OpBitFieldExtract,

Related to #6327