### PR TITLE
Set supported validator version on DXC/disable_paq.hlsl

### DIFF
--- a/tools/clang/test/DXC/disable_paq.hlsl
+++ b/tools/clang/test/DXC/disable_paq.hlsl
@@ -1,3 +1,4 @@
+// REQUIRES: dxil-1-8
 // RUN: %dxc -T lib_6_7 -disable-payload-qualifiers %s 2>&1 | FileCheck %s
 // RUN: %dxc -T lib_6_8 -disable-payload-qualifiers %s 2>&1 | FileCheck %s
 


### PR DESCRIPTION
This test is failing in the internal validator back-compat suite because the feature is not supported on older validators.