### PR TITLE
Gate experimental mesh test on validator version 1.9

### DIFF
--- a/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
@@ -1,4 +1,4 @@
-// RUN: %dxc -E main -T ms_6_5 %s | FileCheck %s
+// RUN: not %dxc -E main -T ms_6_5 %s 2>&1 | FileCheck %s
 
 // CHECK: SetMeshOutputCounts cannot be called multiple times.
 

--- a/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
+++ b/tools/clang/test/CodeGenHLSL/mesh-val/multipleSetMeshOutputCounts.hlsl
@@ -1,4 +1,4 @@
-// RUN: not %dxc -E main -T ms_6_5 %s 2>&1 | FileCheck %s
+// RUN: %dxilver 1.9 | %dxc -E main -T ms_6_5 %s | FileCheck %s
 
 // CHECK: SetMeshOutputCounts cannot be called multiple times.
 


### PR DESCRIPTION
The multipleSetMeshOutputCounts.hlsl test file needs to be gated on dxil validator version 1.9
