### PR TITLE
DerivativesTest: Remove invalid thread group size test cases 

### DIFF
--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -4021,7 +4021,7 @@ TEST_F(ExecutionTest, DerivativesTest) {
                                           {4, 16, 2}, {4, 16, 2}};
 
   pShaderOp->UseWarpDevice = GetTestParamUseWARP(true);
-  
+
   MappedData data;
 
   for (Dispatch &D : dispatches) {

--- a/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
+++ b/tools/clang/unittests/HLSLExec/ExecutionTest.cpp
@@ -4020,11 +4020,8 @@ TEST_F(ExecutionTest, DerivativesTest) {
                                           {16, 8, 1}, {8, 4, 2},   {10, 10, 1},
                                           {4, 16, 2}, {4, 16, 2}};
 
-  std::vector<Dispatch> badDispatches = {{16, 3, 1}, {2, 16, 1}, {33, 1, 1}};
-
   pShaderOp->UseWarpDevice = GetTestParamUseWARP(true);
-  LPCSTR CS = pShaderOp->CS;
-
+  
   MappedData data;
 
   for (Dispatch &D : dispatches) {
@@ -4066,19 +4063,6 @@ TEST_F(ExecutionTest, DerivativesTest) {
       pPixels = (float *)data.data();
       LogCommentFmt(L"Verifying derivatives in amplification shader results");
       VerifyDerivResults_CS_AS_MS_66(pPixels, offsetCenter);
-    }
-  }
-
-  // Final tests with invalid dispatch size just to make sure they run
-  for (Dispatch &D : badDispatches) {
-    // Test Compute Shader
-    pShaderOp->CS = CS;
-    std::shared_ptr<st::ShaderOpTest> test =
-        RunDispatch(pDevice, m_support, pShaderOp, D);
-
-    if (DoesDeviceSupportMeshAmpDerivatives(pDevice)) {
-      pShaderOp->CS = nullptr;
-      test = RunDispatch(pDevice, m_support, pShaderOp, D);
     }
   }
 }

--- a/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
+++ b/tools/clang/unittests/HLSLExec/ShaderOpArith.xml
@@ -233,7 +233,7 @@
         void CSMain(uint3 id : SV_GroupThreadID, uint ix : SV_GroupIndex) {
           if (DISPATCHY == 1 && DISPATCHZ == 1) {
             g_bufMain[ix] = DerivTest(ix);
-            g_bufDbg[ix] = uint4(ix, ConvertGroupIdx(id), 0);
+            g_bufDbg[ix] = uint4(ix, ConvertGroupIdx(id.x), 0);
            }
           else {
             g_bufMain[convert2Dto1D(id.x, id.y, DISPATCHX)] = DerivTest(id.xy);
@@ -246,7 +246,7 @@
 #undef DISPATCHY
 #undef DISPATCHZ
 
-#define DISPATCHX 1
+#define DISPATCHX 4
 #define DISPATCHY 1
 #define DISPATCHZ 1
 #endif


### PR DESCRIPTION
Invalid thread group size testing is included in the compiler/validator tests (PR #6332, commit 696a13a). It does not belong in the execution tests because is it not verifying the driver execution results. The shaders with invalid thread group sizes fail validation and cannot be executed.

Also fixing compile warning and override defines in the derivatives test HLSL code.

Note that the test is incorrectly using the term `dispatch size` instead of `thread group size`.

Fixes internal bug #49806539. Reported from RITP pass.