### PR TITLE
[ClangCL] fix x86 only warning

### DIFF
--- a/tools/clang/tools/dxa/dxa.cpp
+++ b/tools/clang/tools/dxa/dxa.cpp
@@ -303,7 +303,7 @@ bool DxaContext::ExtractPart(const char *pName) {
 
   WriteBlobToFile(pContent, StringRefWide(OutputFilename),
                   DXC_CP_UTF8); // TODO: Support DefaultTextCodePage
-  printf("%zu bytes written to %s\n", pContent->GetBufferSize(),
+  printf("%zu bytes written to %s\n", (size_t)pContent->GetBufferSize(),
          OutputFilename.c_str());
   return true;
 }


### PR DESCRIPTION
SIZE_T is unsigned long for x86 while size_t is unsigned int for x86. Cast SIZE_T to size_t to avoid integer mismatch warning.