### PR TITLE
Add CODEOWNERS to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @microsoft/hlsl-release


### PR DESCRIPTION
In release branches we've added enforcement of AskMode where approval is required before merging. This just adds the requisite file to the `main` branch so that it will appear in future release branches. It DOES NOT apply the branch protection policy, which is a setting controlled in GitHub.

There is no policy change to contributions to main with this change.