### PR TITLE
Write usage masks for mesh nodes in libraries into RDAT

### DIFF
--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -848,7 +848,7 @@ public:
         const DxilEntryProps &entryProps = DM.GetDxilEntryProps(F);
         MarkUsedSignatureElements(F, entryProps);
         if (entryProps.props.IsHS() && entryProps.props.ShaderProps.HS.patchConstantFunc)
-          MarkUsedSignatureElements(DM.GetPatchConstantFunction(), DM, IsLib);
+          MarkUsedSignatureElements(props.ShaderProps.HS.patchConstantFunc, entryProps);
       } else {
         for (auto &function : M.getFunctionList()) {
           if (!function.isDeclaration()) {

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -847,7 +847,8 @@ public:
         // Assume entry props are available for entry function.
         DxilEntryProps &entryProps = DM.GetDxilEntryProps(F);
         MarkUsedSignatureElements(F, entryProps);
-        if (entryProps.props.IsHS() && entryProps.props.ShaderProps.HS.patchConstantFunc)
+        if (entryProps.props.IsHS() &&
+            entryProps.props.ShaderProps.HS.patchConstantFunc)
           MarkUsedSignatureElements(
               entryProps.props.ShaderProps.HS.patchConstantFunc, entryProps);
       } else {

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -333,8 +333,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(LPC.get_row(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature
-                   : &DM.GetPatchConstOrPrimSignature();
+      pSig = entryProps.sig.PatchConstOrPrimSignature;
     } else if (SVO) {
       if (!GetUnsignedVal(SVO.get_outputSigId(), &sigId))
         continue;

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -317,8 +317,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(SO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.OutputSignature
-                   : &DM.GetOutputSignature();
+      pSig = entryProps.sig.OutputSignature;
     } else if (SPC) {
       if (!GetUnsignedVal(SPC.get_outputSigID(), &sigId))
         continue;

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -309,7 +309,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(LI.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = &DM.GetInputSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.InputSignature;
     } else if (SO) {
       if (!GetUnsignedVal(SO.get_outputSigId(), &sigId))
         continue;
@@ -317,7 +317,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(SO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = &DM.GetOutputSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.OutputSignature;
     } else if (SPC) {
       if (!GetUnsignedVal(SPC.get_outputSigID(), &sigId))
         continue;
@@ -325,7 +325,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(SPC.get_row(), &row))
         bDynIdx = true;
-      pSig = &DM.GetPatchConstOrPrimSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature;
     } else if (LPC) {
       if (!GetUnsignedVal(LPC.get_inputSigId(), &sigId))
         continue;
@@ -333,7 +333,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(LPC.get_row(), &row))
         bDynIdx = true;
-      pSig = &DM.GetPatchConstOrPrimSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature;
     } else if (SVO) {
       if (!GetUnsignedVal(SVO.get_outputSigId(), &sigId))
         continue;
@@ -341,7 +341,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(SVO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = &DM.GetOutputSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.OutputSignature;
     } else if (SPO) {
       if (!GetUnsignedVal(SPO.get_outputSigId(), &sigId))
         continue;
@@ -349,7 +349,7 @@ static void MarkUsedSignatureElements(Function *F, DxilModule &DM) {
         continue;
       if (!GetUnsignedVal(SPO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = &DM.GetPatchConstOrPrimSignature();
+      pSig = &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature;
     } else {
       continue;
     }
@@ -846,6 +846,18 @@ public:
         MarkUsedSignatureElements(DM.GetEntryFunction(), DM);
         if (DM.GetShaderModel()->IsHS())
           MarkUsedSignatureElements(DM.GetPatchConstantFunction(), DM);
+      } else {
+        for (auto &function : M.getFunctionList()) {
+          if (!function.isDeclaration()) {            
+            if (DM.HasDxilEntryProps(&function)) {
+              const auto &entryProps = DM.GetDxilEntryProps(&function);
+              if (entryProps.props.IsNode() && 
+                  entryProps.props.Node.LaunchType == hlsl::DXIL::NodeLaunchType::Mesh) {
+                MarkUsedSignatureElements(&function, DM);
+              }
+            }
+          }          
+        }
       }
 
       // Adding warning for pixel shader with unassigned target

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -855,7 +855,7 @@ public:
             if (DM.HasDxilEntryProps(&function)) {
               const auto &entryProps = DM.GetDxilEntryProps(&function);
               if (entryProps.props.IsMeshNode()) {
-                MarkUsedSignatureElements(&function, DM, IsLib);
+                MarkUsedSignatureElements(&function, entryProps);
               }
             }
           }

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -309,8 +309,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(LI.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.InputSignature
-                   : &DM.GetInputSignature();
+      pSig = entryProps.sig.InputSignature;
     } else if (SO) {
       if (!GetUnsignedVal(SO.get_outputSigId(), &sigId))
         continue;

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -848,15 +848,14 @@ public:
           MarkUsedSignatureElements(DM.GetPatchConstantFunction(), DM);
       } else {
         for (auto &function : M.getFunctionList()) {
-          if (!function.isDeclaration()) {            
+          if (!function.isDeclaration()) {
             if (DM.HasDxilEntryProps(&function)) {
               const auto &entryProps = DM.GetDxilEntryProps(&function);
-              if (entryProps.props.IsNode() && 
-                  entryProps.props.Node.LaunchType == hlsl::DXIL::NodeLaunchType::Mesh) {
+              if (entryProps.props.IsMeshNode()) {
                 MarkUsedSignatureElements(&function, DM);
               }
             }
-          }          
+          }
         }
       }
 

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -341,8 +341,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(SVO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.OutputSignature
-                   : &DM.GetOutputSignature();
+      pSig = entryProps.sig.OutputSignature;
     } else if (SPO) {
       if (!GetUnsignedVal(SPO.get_outputSigId(), &sigId))
         continue;

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -349,8 +349,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(SPO.get_rowIndex(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature
-                   : &DM.GetPatchConstOrPrimSignature();
+      pSig = entryProps.sig.PatchConstOrPrimSignature;
     } else {
       continue;
     }

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -287,7 +287,7 @@ static bool GetUnsignedVal(Value *V, uint32_t *pValue) {
   return true;
 }
 
-static void MarkUsedSignatureElements(Function *F, DxilModule &DM, bool IsLib) {
+static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryProps) {
   DXASSERT_NOMSG(F != nullptr);
   // For every loadInput/storeOutput, update the corresponding ReadWriteMask.
   // F is a pointer to a Function instance

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -843,8 +843,11 @@ public:
 
       if (!IsLib) {
         // Set used masks for signature elements
-        MarkUsedSignatureElements(DM.GetEntryFunction(), DM, IsLib);
-        if (DM.GetShaderModel()->IsHS())
+        Function *F = DM.GetEntryFunction();
+        // Assume entry props are available for entry function.
+        const DxilEntryProps &entryProps = DM.GetDxilEntryProps(F);
+        MarkUsedSignatureElements(F, entryProps);
+        if (entryProps.props.IsHS() && entryProps.props.ShaderProps.HS.patchConstantFunc)
           MarkUsedSignatureElements(DM.GetPatchConstantFunction(), DM, IsLib);
       } else {
         for (auto &function : M.getFunctionList()) {

--- a/lib/HLSL/DxilPreparePasses.cpp
+++ b/lib/HLSL/DxilPreparePasses.cpp
@@ -325,8 +325,7 @@ static void MarkUsedSignatureElements(Function *F, const DxilEntryProps &entryPr
         continue;
       if (!GetUnsignedVal(SPC.get_row(), &row))
         bDynIdx = true;
-      pSig = IsLib ? &DM.GetDxilEntryProps(F).sig.PatchConstOrPrimSignature
-                   : &DM.GetPatchConstOrPrimSignature();
+      pSig = entryProps.sig.PatchConstOrPrimSignature;
     } else if (LPC) {
       if (!GetUnsignedVal(LPC.get_inputSigId(), &sigId))
         continue;

--- a/tools/clang/test/CodeGenDXIL/hlsl/shaders/node/mesh-node.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/shaders/node/mesh-node.hlsl
@@ -104,7 +104,7 @@ void node_setmeshoutputcounts(DispatchNodeInputRecord<MeshPayload> mpl,
     op.layer[5] = mpl.Get().layer[5];
 
     // CHECK: %[[GSGEP2:[0-9]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @"\01?gsMem@@3PAMA", i32 0, i32 %[[GIDIV]]
-    // CHECK: store float %[[NRM]], float addrspace(3)* %[[GSGEP2]], align 4, !tbaa !29
+    // CHECK: store float %[[NRM]], float addrspace(3)* %[[GSGEP2]], align 4, !tbaa !31
     gsMem[tig / 3] = op.normal;
     // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 0, i32 0, i8 0, float %[[NRM]], i32 %[[GIDIV]])
     // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 1, i32 0, i8 0, float %[[GS]], i32 %[[GIDIV]])

--- a/tools/clang/test/CodeGenDXIL/hlsl/shaders/node/mesh-node.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/shaders/node/mesh-node.hlsl
@@ -104,7 +104,7 @@ void node_setmeshoutputcounts(DispatchNodeInputRecord<MeshPayload> mpl,
     op.layer[5] = mpl.Get().layer[5];
 
     // CHECK: %[[GSGEP2:[0-9]+]] = getelementptr [16 x float], [16 x float] addrspace(3)* @"\01?gsMem@@3PAMA", i32 0, i32 %[[GIDIV]]
-    // CHECK: store float %[[NRM]], float addrspace(3)* %[[GSGEP2]], align 4, !tbaa !31
+    // CHECK: store float %[[NRM]], float addrspace(3)* %[[GSGEP2]], align 4
     gsMem[tig / 3] = op.normal;
     // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 0, i32 0, i8 0, float %[[NRM]], i32 %[[GIDIV]])
     // CHECK:  call void @dx.op.storePrimitiveOutput.f32(i32 172, i32 1, i32 0, i8 0, float %[[GS]], i32 %[[GIDIV]])

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
@@ -4,94 +4,7 @@
 // mesh node functions in library shaders.
 
 
-// CHECK:RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
-// CHECK:    <0:RuntimeDataFunctionInfo2> = {
-// CHECK:      Name: "justMeshBinsLeaf"
-// CHECK:      UnmangledName: "justMeshBinsLeaf"
-// CHECK:      Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[5]>  = {
-// CHECK:        [0]: <0:RuntimeDataResourceInfo> = {
-// CHECK:          Class: CBuffer
-// CHECK:          Kind: CBuffer
-// CHECK:          ID: 0
-// CHECK:          Space: 15
-// CHECK:          LowerBound: 0
-// CHECK:          UpperBound: 0
-// CHECK:          Name: "JustMeshBinsNodeConfig"
-// CHECK:          Flags: 0 (None)
-// CHECK:        }
-// CHECK:        [1]: <1:RuntimeDataResourceInfo> = {
-// CHECK:          Class: Sampler
-// CHECK:          Kind: Sampler
-// CHECK:          ID: 0
-// CHECK:          Space: 15
-// CHECK:          LowerBound: 0
-// CHECK:          UpperBound: 0
-// CHECK:          Name: "JustMeshBinsSampler"
-// CHECK:          Flags: 0 (None)
-// CHECK:        }
-// CHECK:        [2]: <2:RuntimeDataResourceInfo> = {
-// CHECK:          Class: SRV
-// CHECK:          Kind: Texture2D
-// CHECK:          ID: 0
-// CHECK:          Space: 15
-// CHECK:          LowerBound: 0
-// CHECK:          UpperBound: 0
-// CHECK:          Name: "JustMeshBinsTexture0"
-// CHECK:          Flags: 0 (None)
-// CHECK:        }
-// CHECK:        [3]: <3:RuntimeDataResourceInfo> = {
-// CHECK:          Class: SRV
-// CHECK:          Kind: Texture2D
-// CHECK:          ID: 1
-// CHECK:          Space: 15
-// CHECK:          LowerBound: 1
-// CHECK:          UpperBound: 1
-// CHECK:          Name: "JustMeshBinsTexture1"
-// CHECK:          Flags: 0 (None)
-// CHECK:        }
-// CHECK:        [4]: <4:RuntimeDataResourceInfo> = {
-// CHECK:          Class: UAV
-// CHECK:          Kind: StructuredBuffer
-// CHECK:          ID: 0
-// CHECK:          Space: 15
-// CHECK:          LowerBound: 0
-// CHECK:          UpperBound: 0
-// CHECK:          Name: "JustMeshBinsUAV"
-// CHECK:          Flags: 0 (None)
-// CHECK:        }
-// CHECK:      }
-// CHECK:      FunctionDependencies: <string[0]> = {}
-// CHECK:      ShaderKind: Node
-// CHECK:      PayloadSizeInBytes: 0
-// CHECK:      AttributeSizeInBytes: 0
-// CHECK:      FeatureInfo1: (NativeLowPrecision)
-// CHECK:      FeatureInfo2: 0
-// CHECK:      ShaderStageFlag: (Node)
-// CHECK:      MinShaderTarget: 0xf0069
-// CHECK:      MinimumExpectedWaveLaneCount: 0
-// CHECK:      MaximumExpectedWaveLaneCount: 0
-// CHECK:      ShaderFlags: (OutputPositionPresent)
-// CHECK:      Node: <0:NodeShaderInfo> = {
-// CHECK:        LaunchType: Mesh
-// CHECK:        GroupSharedBytesUsed: 0
-// CHECK:        Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderFuncAttrib>[4]>  = {
-// CHECK:          [0]: <0:NodeShaderFuncAttrib> = {
-// CHECK:            AttribKind: ID
-// CHECK:            ID: <{{[0-9]+}}:NodeID> = {
-// CHECK:              Name: "justMeshBinsLeaf"
-// CHECK:              Index: 0
-// CHECK:            }
-// CHECK:          }
-// CHECK:          [1]: <1:NodeShaderFuncAttrib> = {
-// CHECK:            AttribKind: NumThreads
-// CHECK:            NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:          }
-// CHECK:          [2]: <2:NodeShaderFuncAttrib> = {
-// CHECK:            AttribKind: MaxDispatchGrid
-// CHECK:            MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
-// CHECK:          }
-// CHECK:          [3]: <3:NodeShaderFuncAttrib> = {
-// CHECK:            AttribKind: MeshShaderInfo
+
 // CHECK:            MeshShaderInfo: <0:MSInfo> = {
 // CHECK:              SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:                [0]: <0:SignatureElement> = {
@@ -127,67 +40,7 @@
 // CHECK:                  UsageAndDynIndexMasks: 1
 // CHECK:                }
 // CHECK:              }
-// CHECK:              ViewIDOutputMask: <0:bytes[0]>
-// CHECK:              ViewIDPrimOutputMask: <0:bytes[0]>
-// CHECK:              NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:              GroupSharedBytesUsed: 0
-// CHECK:              GroupSharedBytesDependentOnViewID: 0
-// CHECK:              PayloadSizeInBytes: 0
-// CHECK:              MaxOutputVertices: 3
-// CHECK:              MaxOutputPrimitives: 1
-// CHECK:              MeshOutputTopology: 2
-// CHECK:            }
-// CHECK:          }
-// CHECK:        }
-// CHECK:        Outputs: <RecordArrayRef<IONode>[0]> = {}
-// CHECK:        Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
-// CHECK:          [0]: <0:IONode> = {
-// CHECK:            IOFlagsAndKind: 97
-// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
-// CHECK:              [0]: <0:NodeShaderIOAttrib> = {
-// CHECK:                AttribKind: RecordSizeInBytes
-// CHECK:                RecordSizeInBytes: 12
-// CHECK:              }
-// CHECK:              [1]: <1:NodeShaderIOAttrib> = {
-// CHECK:                AttribKind: RecordDispatchGrid
-// CHECK:                RecordDispatchGrid: <RecordDispatchGrid>
-// CHECK:                  ByteOffset: 4
-// CHECK:                  ComponentNumAndType: 14
-// CHECK:              }
-// CHECK:              [2]: <2:NodeShaderIOAttrib> = {
-// CHECK:                AttribKind: RecordAlignmentInBytes
-// CHECK:                RecordAlignmentInBytes: 4
-// CHECK:              }
-// CHECK:            }
-// CHECK:          }
-// CHECK:        }
-// CHECK:      }
-// CHECK:    }
-// CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeIDTable[1] = {
-// CHECK:    <0:NodeID> = {
-// CHECK:      Name: "justMeshBinsLeaf"
-// CHECK:      Index: 0
-// CHECK:    }
-// CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderFuncAttribTable[4] = {
-// CHECK:    <0:NodeShaderFuncAttrib> = {
-// CHECK:      AttribKind: ID
-// CHECK:      ID: <{{[0-9]+}}:NodeID> = {
-// CHECK:        Name: "justMeshBinsLeaf"
-// CHECK:        Index: 0
-// CHECK:      }
-// CHECK:    }
-// CHECK:    <1:NodeShaderFuncAttrib> = {
-// CHECK:      AttribKind: NumThreads
-// CHECK:      NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:    }
-// CHECK:    <2:NodeShaderFuncAttrib> = {
-// CHECK:      AttribKind: MaxDispatchGrid
-// CHECK:      MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
-// CHECK:    }
-// CHECK:    <3:NodeShaderFuncAttrib> = {
-// CHECK:      AttribKind: MeshShaderInfo
+
 // CHECK:      MeshShaderInfo: <0:MSInfo> = {
 // CHECK:        SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:          [0]: <0:SignatureElement> = {
@@ -223,77 +76,7 @@
 // CHECK:            UsageAndDynIndexMasks: 1
 // CHECK:          }
 // CHECK:        }
-// CHECK:        ViewIDOutputMask: <0:bytes[0]>
-// CHECK:        ViewIDPrimOutputMask: <0:bytes[0]>
-// CHECK:        NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:        GroupSharedBytesUsed: 0
-// CHECK:        GroupSharedBytesDependentOnViewID: 0
-// CHECK:        PayloadSizeInBytes: 0
-// CHECK:        MaxOutputVertices: 3
-// CHECK:        MaxOutputPrimitives: 1
-// CHECK:        MeshOutputTopology: 2
-// CHECK:      }
-// CHECK:    }
-// CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[3] = {
-// CHECK:    <0:NodeShaderIOAttrib> = {
-// CHECK:      AttribKind: RecordSizeInBytes
-// CHECK:      RecordSizeInBytes: 12
-// CHECK:    }
-// CHECK:    <1:NodeShaderIOAttrib> = {
-// CHECK:      AttribKind: RecordDispatchGrid
-// CHECK:      RecordDispatchGrid: <RecordDispatchGrid>
-// CHECK:        ByteOffset: 4
-// CHECK:        ComponentNumAndType: 14
-// CHECK:    }
-// CHECK:    <2:NodeShaderIOAttrib> = {
-// CHECK:      AttribKind: RecordAlignmentInBytes
-// CHECK:      RecordAlignmentInBytes: 4
-// CHECK:    }
-// CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[1] = {
-// CHECK:    <0:IONode> = {
-// CHECK:      IOFlagsAndKind: 97
-// CHECK:      Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
-// CHECK:        [0]: <0:NodeShaderIOAttrib> = {
-// CHECK:          AttribKind: RecordSizeInBytes
-// CHECK:          RecordSizeInBytes: 12
-// CHECK:        }
-// CHECK:        [1]: <1:NodeShaderIOAttrib> = {
-// CHECK:          AttribKind: RecordDispatchGrid
-// CHECK:          RecordDispatchGrid: <RecordDispatchGrid>
-// CHECK:            ByteOffset: 4
-// CHECK:            ComponentNumAndType: 14
-// CHECK:        }
-// CHECK:        [2]: <2:NodeShaderIOAttrib> = {
-// CHECK:          AttribKind: RecordAlignmentInBytes
-// CHECK:          RecordAlignmentInBytes: 4
-// CHECK:        }
-// CHECK:      }
-// CHECK:    }
-// CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderInfoTable[1] = {
-// CHECK:    <0:NodeShaderInfo> = {
-// CHECK:      LaunchType: Mesh
-// CHECK:      GroupSharedBytesUsed: 0
-// CHECK:      Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderFuncAttrib>[4]>  = {
-// CHECK:        [0]: <0:NodeShaderFuncAttrib> = {
-// CHECK:          AttribKind: ID
-// CHECK:          ID: <{{[0-9]+}}:NodeID> = {
-// CHECK:            Name: "justMeshBinsLeaf"
-// CHECK:            Index: 0
-// CHECK:          }
-// CHECK:        }
-// CHECK:        [1]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
-// CHECK:          AttribKind: NumThreads
-// CHECK:          NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:        }
-// CHECK:        [2]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
-// CHECK:          AttribKind: MaxDispatchGrid
-// CHECK:          MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
-// CHECK:        }
-// CHECK:        [3]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
-// CHECK:          AttribKind: MeshShaderInfo
+
 // CHECK:          MeshShaderInfo: <0:MSInfo> = {
 // CHECK:            SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:              [0]: <0:SignatureElement> = {
@@ -340,31 +123,7 @@
 // CHECK:            MeshOutputTopology: 2
 // CHECK:          }
 // CHECK:        }
-// CHECK:      }
-// CHECK:      Outputs: <RecordArrayRef<IONode>[0]> = {}
-// CHECK:      Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
-// CHECK:        [0]: <0:IONode> = {
-// CHECK:          IOFlagsAndKind: 97
-// CHECK:          Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
-// CHECK:            [0]: <0:NodeShaderIOAttrib> = {
-// CHECK:              AttribKind: RecordSizeInBytes
-// CHECK:              RecordSizeInBytes: 12
-// CHECK:            }
-// CHECK:            [1]: <1:NodeShaderIOAttrib> = {
-// CHECK:              AttribKind: RecordDispatchGrid
-// CHECK:              RecordDispatchGrid: <RecordDispatchGrid>
-// CHECK:                ByteOffset: 4
-// CHECK:                ComponentNumAndType: 14
-// CHECK:            }
-// CHECK:            [2]: <2:NodeShaderIOAttrib> = {
-// CHECK:              AttribKind: RecordAlignmentInBytes
-// CHECK:              RecordAlignmentInBytes: 4
-// CHECK:            }
-// CHECK:          }
-// CHECK:        }
-// CHECK:      }
-// CHECK:    }
-// CHECK:  }
+
 // CHECK:  RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[3] = {
 // CHECK:    <0:SignatureElement> = {
 // CHECK:      SemanticName: "SV_Position"
@@ -397,7 +156,7 @@
 // CHECK:      UsageAndDynIndexMasks: 1
 // CHECK:    }
 // CHECK:  }
-// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) MSInfoTable[1] = {
+
 // CHECK:    <0:MSInfo> = {
 // CHECK:      SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
 // CHECK:        [0]: <0:SignatureElement> = {
@@ -433,19 +192,6 @@
 // CHECK:          UsageAndDynIndexMasks: 1
 // CHECK:        }
 // CHECK:      }
-// CHECK:      ViewIDOutputMask: <0:bytes[0]>
-// CHECK:      ViewIDPrimOutputMask: <0:bytes[0]>
-// CHECK:      NumThreads: <6:array[3]> = { 32, 1, 1 }
-// CHECK:      GroupSharedBytesUsed: 0
-// CHECK:      GroupSharedBytesDependentOnViewID: 0
-// CHECK:      PayloadSizeInBytes: 0
-// CHECK:      MaxOutputVertices: 3
-// CHECK:      MaxOutputPrimitives: 1
-// CHECK:      MeshOutputTopology: 2
-// CHECK:    }
-// CHECK:  }
-
-
 
 
 

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
@@ -1,14 +1,10 @@
-// dxc RDATUsageMaskRepro.hlsl /T lib_6_9 -enable-16bit-types -select-validator internal
-// In the runtime when examining MeshShaderInfo from RDAT and looking at the output signature, 
-// I see that SignatureElement_Reader->GetUsageMask() is returning 0 all the time.
-// This causes the runtime to produce Mesh Node -> Pixel Shader linkage errors because it thinks
-// the pixel shader is always reading an input field that the Mesh Node never writes.
+// RUN: %dxc -Tlib_6_9 -enable-16bit-types -select-validator internal %s | %D3DReflect %s | FileCheck %s
+
 // This test tests that the UsageAndDynIndexMasks flag is set to non-null values for
 // mesh node functions in library shaders.
 
-// RUN: %dxc -Tlib_6_9 -enable-16bit-types -select-validator internal %s | %D3DReflect %s | FileCheck %s
 
-  // CHECK:RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
 // CHECK:    <0:RuntimeDataFunctionInfo2> = {
 // CHECK:      Name: "justMeshBinsLeaf"
 // CHECK:      UnmangledName: "justMeshBinsLeaf"

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/RDATUsageMaskRepro.hlsl
@@ -1,0 +1,598 @@
+// dxc RDATUsageMaskRepro.hlsl /T lib_6_9 -enable-16bit-types -select-validator internal
+// In the runtime when examining MeshShaderInfo from RDAT and looking at the output signature, 
+// I see that SignatureElement_Reader->GetUsageMask() is returning 0 all the time.
+// This causes the runtime to produce Mesh Node -> Pixel Shader linkage errors because it thinks
+// the pixel shader is always reading an input field that the Mesh Node never writes.
+// This test tests that the UsageAndDynIndexMasks flag is set to non-null values for
+// mesh node functions in library shaders.
+
+// RUN: %dxc -Tlib_6_9 -enable-16bit-types -select-validator internal %s | %D3DReflect %s | FileCheck %s
+
+  // CHECK:RecordTable (stride = {{[0-9]+}} bytes) FunctionTable[1] = {
+// CHECK:    <0:RuntimeDataFunctionInfo2> = {
+// CHECK:      Name: "justMeshBinsLeaf"
+// CHECK:      UnmangledName: "justMeshBinsLeaf"
+// CHECK:      Resources: <0:RecordArrayRef<RuntimeDataResourceInfo>[5]>  = {
+// CHECK:        [0]: <0:RuntimeDataResourceInfo> = {
+// CHECK:          Class: CBuffer
+// CHECK:          Kind: CBuffer
+// CHECK:          ID: 0
+// CHECK:          Space: 15
+// CHECK:          LowerBound: 0
+// CHECK:          UpperBound: 0
+// CHECK:          Name: "JustMeshBinsNodeConfig"
+// CHECK:          Flags: 0 (None)
+// CHECK:        }
+// CHECK:        [1]: <1:RuntimeDataResourceInfo> = {
+// CHECK:          Class: Sampler
+// CHECK:          Kind: Sampler
+// CHECK:          ID: 0
+// CHECK:          Space: 15
+// CHECK:          LowerBound: 0
+// CHECK:          UpperBound: 0
+// CHECK:          Name: "JustMeshBinsSampler"
+// CHECK:          Flags: 0 (None)
+// CHECK:        }
+// CHECK:        [2]: <2:RuntimeDataResourceInfo> = {
+// CHECK:          Class: SRV
+// CHECK:          Kind: Texture2D
+// CHECK:          ID: 0
+// CHECK:          Space: 15
+// CHECK:          LowerBound: 0
+// CHECK:          UpperBound: 0
+// CHECK:          Name: "JustMeshBinsTexture0"
+// CHECK:          Flags: 0 (None)
+// CHECK:        }
+// CHECK:        [3]: <3:RuntimeDataResourceInfo> = {
+// CHECK:          Class: SRV
+// CHECK:          Kind: Texture2D
+// CHECK:          ID: 1
+// CHECK:          Space: 15
+// CHECK:          LowerBound: 1
+// CHECK:          UpperBound: 1
+// CHECK:          Name: "JustMeshBinsTexture1"
+// CHECK:          Flags: 0 (None)
+// CHECK:        }
+// CHECK:        [4]: <4:RuntimeDataResourceInfo> = {
+// CHECK:          Class: UAV
+// CHECK:          Kind: StructuredBuffer
+// CHECK:          ID: 0
+// CHECK:          Space: 15
+// CHECK:          LowerBound: 0
+// CHECK:          UpperBound: 0
+// CHECK:          Name: "JustMeshBinsUAV"
+// CHECK:          Flags: 0 (None)
+// CHECK:        }
+// CHECK:      }
+// CHECK:      FunctionDependencies: <string[0]> = {}
+// CHECK:      ShaderKind: Node
+// CHECK:      PayloadSizeInBytes: 0
+// CHECK:      AttributeSizeInBytes: 0
+// CHECK:      FeatureInfo1: (NativeLowPrecision)
+// CHECK:      FeatureInfo2: 0
+// CHECK:      ShaderStageFlag: (Node)
+// CHECK:      MinShaderTarget: 0xf0069
+// CHECK:      MinimumExpectedWaveLaneCount: 0
+// CHECK:      MaximumExpectedWaveLaneCount: 0
+// CHECK:      ShaderFlags: (OutputPositionPresent)
+// CHECK:      Node: <0:NodeShaderInfo> = {
+// CHECK:        LaunchType: Mesh
+// CHECK:        GroupSharedBytesUsed: 0
+// CHECK:        Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderFuncAttrib>[4]>  = {
+// CHECK:          [0]: <0:NodeShaderFuncAttrib> = {
+// CHECK:            AttribKind: ID
+// CHECK:            ID: <{{[0-9]+}}:NodeID> = {
+// CHECK:              Name: "justMeshBinsLeaf"
+// CHECK:              Index: 0
+// CHECK:            }
+// CHECK:          }
+// CHECK:          [1]: <1:NodeShaderFuncAttrib> = {
+// CHECK:            AttribKind: NumThreads
+// CHECK:            NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:          }
+// CHECK:          [2]: <2:NodeShaderFuncAttrib> = {
+// CHECK:            AttribKind: MaxDispatchGrid
+// CHECK:            MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
+// CHECK:          }
+// CHECK:          [3]: <3:NodeShaderFuncAttrib> = {
+// CHECK:            AttribKind: MeshShaderInfo
+// CHECK:            MeshShaderInfo: <0:MSInfo> = {
+// CHECK:              SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
+// CHECK:                [0]: <0:SignatureElement> = {
+// CHECK:                  SemanticName: "SV_Position"
+// CHECK:                  SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                  SemanticKind: Position
+// CHECK:                  ComponentType: F32
+// CHECK:                  InterpolationMode: LinearNoperspective
+// CHECK:                  StartRow: 0
+// CHECK:                  ColsAndStream: 3
+// CHECK:                  UsageAndDynIndexMasks: 15
+// CHECK:                }
+// CHECK:              }
+// CHECK:              SigPrimOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[2]>  = {
+// CHECK:                [0]: <1:SignatureElement> = {
+// CHECK:                  SemanticName: "CLR"
+// CHECK:                  SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                  SemanticKind: Arbitrary
+// CHECK:                  ComponentType: F32
+// CHECK:                  InterpolationMode: Constant
+// CHECK:                  StartRow: 0
+// CHECK:                  ColsAndStream: 3
+// CHECK:                  UsageAndDynIndexMasks: 15
+// CHECK:                }
+// CHECK:                [1]: <2:SignatureElement> = {
+// CHECK:                  SemanticName: "LOG"
+// CHECK:                  SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                  SemanticKind: Arbitrary
+// CHECK:                  ComponentType: U32
+// CHECK:                  InterpolationMode: Constant
+// CHECK:                  StartRow: 1
+// CHECK:                  ColsAndStream: 0
+// CHECK:                  UsageAndDynIndexMasks: 1
+// CHECK:                }
+// CHECK:              }
+// CHECK:              ViewIDOutputMask: <0:bytes[0]>
+// CHECK:              ViewIDPrimOutputMask: <0:bytes[0]>
+// CHECK:              NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:              GroupSharedBytesUsed: 0
+// CHECK:              GroupSharedBytesDependentOnViewID: 0
+// CHECK:              PayloadSizeInBytes: 0
+// CHECK:              MaxOutputVertices: 3
+// CHECK:              MaxOutputPrimitives: 1
+// CHECK:              MeshOutputTopology: 2
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:        Outputs: <RecordArrayRef<IONode>[0]> = {}
+// CHECK:        Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
+// CHECK:          [0]: <0:IONode> = {
+// CHECK:            IOFlagsAndKind: 97
+// CHECK:            Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
+// CHECK:              [0]: <0:NodeShaderIOAttrib> = {
+// CHECK:                AttribKind: RecordSizeInBytes
+// CHECK:                RecordSizeInBytes: 12
+// CHECK:              }
+// CHECK:              [1]: <1:NodeShaderIOAttrib> = {
+// CHECK:                AttribKind: RecordDispatchGrid
+// CHECK:                RecordDispatchGrid: <RecordDispatchGrid>
+// CHECK:                  ByteOffset: 4
+// CHECK:                  ComponentNumAndType: 14
+// CHECK:              }
+// CHECK:              [2]: <2:NodeShaderIOAttrib> = {
+// CHECK:                AttribKind: RecordAlignmentInBytes
+// CHECK:                RecordAlignmentInBytes: 4
+// CHECK:              }
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeIDTable[1] = {
+// CHECK:    <0:NodeID> = {
+// CHECK:      Name: "justMeshBinsLeaf"
+// CHECK:      Index: 0
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderFuncAttribTable[4] = {
+// CHECK:    <0:NodeShaderFuncAttrib> = {
+// CHECK:      AttribKind: ID
+// CHECK:      ID: <{{[0-9]+}}:NodeID> = {
+// CHECK:        Name: "justMeshBinsLeaf"
+// CHECK:        Index: 0
+// CHECK:      }
+// CHECK:    }
+// CHECK:    <1:NodeShaderFuncAttrib> = {
+// CHECK:      AttribKind: NumThreads
+// CHECK:      NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:    }
+// CHECK:    <2:NodeShaderFuncAttrib> = {
+// CHECK:      AttribKind: MaxDispatchGrid
+// CHECK:      MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
+// CHECK:    }
+// CHECK:    <3:NodeShaderFuncAttrib> = {
+// CHECK:      AttribKind: MeshShaderInfo
+// CHECK:      MeshShaderInfo: <0:MSInfo> = {
+// CHECK:        SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
+// CHECK:          [0]: <0:SignatureElement> = {
+// CHECK:            SemanticName: "SV_Position"
+// CHECK:            SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:            SemanticKind: Position
+// CHECK:            ComponentType: F32
+// CHECK:            InterpolationMode: LinearNoperspective
+// CHECK:            StartRow: 0
+// CHECK:            ColsAndStream: 3
+// CHECK:            UsageAndDynIndexMasks: 15
+// CHECK:          }
+// CHECK:        }
+// CHECK:        SigPrimOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[2]>  = {
+// CHECK:          [0]: <1:SignatureElement> = {
+// CHECK:            SemanticName: "CLR"
+// CHECK:            SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:            SemanticKind: Arbitrary
+// CHECK:            ComponentType: F32
+// CHECK:            InterpolationMode: Constant
+// CHECK:            StartRow: 0
+// CHECK:            ColsAndStream: 3
+// CHECK:            UsageAndDynIndexMasks: 15
+// CHECK:          }
+// CHECK:          [1]: <2:SignatureElement> = {
+// CHECK:            SemanticName: "LOG"
+// CHECK:            SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:            SemanticKind: Arbitrary
+// CHECK:            ComponentType: U32
+// CHECK:            InterpolationMode: Constant
+// CHECK:            StartRow: 1
+// CHECK:            ColsAndStream: 0
+// CHECK:            UsageAndDynIndexMasks: 1
+// CHECK:          }
+// CHECK:        }
+// CHECK:        ViewIDOutputMask: <0:bytes[0]>
+// CHECK:        ViewIDPrimOutputMask: <0:bytes[0]>
+// CHECK:        NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:        GroupSharedBytesUsed: 0
+// CHECK:        GroupSharedBytesDependentOnViewID: 0
+// CHECK:        PayloadSizeInBytes: 0
+// CHECK:        MaxOutputVertices: 3
+// CHECK:        MaxOutputPrimitives: 1
+// CHECK:        MeshOutputTopology: 2
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderIOAttribTable[3] = {
+// CHECK:    <0:NodeShaderIOAttrib> = {
+// CHECK:      AttribKind: RecordSizeInBytes
+// CHECK:      RecordSizeInBytes: 12
+// CHECK:    }
+// CHECK:    <1:NodeShaderIOAttrib> = {
+// CHECK:      AttribKind: RecordDispatchGrid
+// CHECK:      RecordDispatchGrid: <RecordDispatchGrid>
+// CHECK:        ByteOffset: 4
+// CHECK:        ComponentNumAndType: 14
+// CHECK:    }
+// CHECK:    <2:NodeShaderIOAttrib> = {
+// CHECK:      AttribKind: RecordAlignmentInBytes
+// CHECK:      RecordAlignmentInBytes: 4
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) IONodeTable[1] = {
+// CHECK:    <0:IONode> = {
+// CHECK:      IOFlagsAndKind: 97
+// CHECK:      Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
+// CHECK:        [0]: <0:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordSizeInBytes
+// CHECK:          RecordSizeInBytes: 12
+// CHECK:        }
+// CHECK:        [1]: <1:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordDispatchGrid
+// CHECK:          RecordDispatchGrid: <RecordDispatchGrid>
+// CHECK:            ByteOffset: 4
+// CHECK:            ComponentNumAndType: 14
+// CHECK:        }
+// CHECK:        [2]: <2:NodeShaderIOAttrib> = {
+// CHECK:          AttribKind: RecordAlignmentInBytes
+// CHECK:          RecordAlignmentInBytes: 4
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) NodeShaderInfoTable[1] = {
+// CHECK:    <0:NodeShaderInfo> = {
+// CHECK:      LaunchType: Mesh
+// CHECK:      GroupSharedBytesUsed: 0
+// CHECK:      Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderFuncAttrib>[4]>  = {
+// CHECK:        [0]: <0:NodeShaderFuncAttrib> = {
+// CHECK:          AttribKind: ID
+// CHECK:          ID: <{{[0-9]+}}:NodeID> = {
+// CHECK:            Name: "justMeshBinsLeaf"
+// CHECK:            Index: 0
+// CHECK:          }
+// CHECK:        }
+// CHECK:        [1]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
+// CHECK:          AttribKind: NumThreads
+// CHECK:          NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:        }
+// CHECK:        [2]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
+// CHECK:          AttribKind: MaxDispatchGrid
+// CHECK:          MaxDispatchGrid: <10:array[3]> = { 512, 512, 1 }
+// CHECK:        }
+// CHECK:        [3]: <{{[0-9]+}}:NodeShaderFuncAttrib> = {
+// CHECK:          AttribKind: MeshShaderInfo
+// CHECK:          MeshShaderInfo: <0:MSInfo> = {
+// CHECK:            SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
+// CHECK:              [0]: <0:SignatureElement> = {
+// CHECK:                SemanticName: "SV_Position"
+// CHECK:                SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                SemanticKind: Position
+// CHECK:                ComponentType: F32
+// CHECK:                InterpolationMode: LinearNoperspective
+// CHECK:                StartRow: 0
+// CHECK:                ColsAndStream: 3
+// CHECK:                UsageAndDynIndexMasks: 15
+// CHECK:              }
+// CHECK:            }
+// CHECK:            SigPrimOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[2]>  = {
+// CHECK:              [0]: <1:SignatureElement> = {
+// CHECK:                SemanticName: "CLR"
+// CHECK:                SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                SemanticKind: Arbitrary
+// CHECK:                ComponentType: F32
+// CHECK:                InterpolationMode: Constant
+// CHECK:                StartRow: 0
+// CHECK:                ColsAndStream: 3
+// CHECK:                UsageAndDynIndexMasks: 15
+// CHECK:              }
+// CHECK:              [1]: <2:SignatureElement> = {
+// CHECK:                SemanticName: "LOG"
+// CHECK:                SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:                SemanticKind: Arbitrary
+// CHECK:                ComponentType: U32
+// CHECK:                InterpolationMode: Constant
+// CHECK:                StartRow: 1
+// CHECK:                ColsAndStream: 0
+// CHECK:                UsageAndDynIndexMasks: 1
+// CHECK:              }
+// CHECK:            }
+// CHECK:            ViewIDOutputMask: <0:bytes[0]>
+// CHECK:            ViewIDPrimOutputMask: <0:bytes[0]>
+// CHECK:            NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:            GroupSharedBytesUsed: 0
+// CHECK:            GroupSharedBytesDependentOnViewID: 0
+// CHECK:            PayloadSizeInBytes: 0
+// CHECK:            MaxOutputVertices: 3
+// CHECK:            MaxOutputPrimitives: 1
+// CHECK:            MeshOutputTopology: 2
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:      Outputs: <RecordArrayRef<IONode>[0]> = {}
+// CHECK:      Inputs: <{{[0-9]+}}:RecordArrayRef<IONode>[1]>  = {
+// CHECK:        [0]: <0:IONode> = {
+// CHECK:          IOFlagsAndKind: 97
+// CHECK:          Attribs: <{{[0-9]+}}:RecordArrayRef<NodeShaderIOAttrib>[3]>  = {
+// CHECK:            [0]: <0:NodeShaderIOAttrib> = {
+// CHECK:              AttribKind: RecordSizeInBytes
+// CHECK:              RecordSizeInBytes: 12
+// CHECK:            }
+// CHECK:            [1]: <1:NodeShaderIOAttrib> = {
+// CHECK:              AttribKind: RecordDispatchGrid
+// CHECK:              RecordDispatchGrid: <RecordDispatchGrid>
+// CHECK:                ByteOffset: 4
+// CHECK:                ComponentNumAndType: 14
+// CHECK:            }
+// CHECK:            [2]: <2:NodeShaderIOAttrib> = {
+// CHECK:              AttribKind: RecordAlignmentInBytes
+// CHECK:              RecordAlignmentInBytes: 4
+// CHECK:            }
+// CHECK:          }
+// CHECK:        }
+// CHECK:      }
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) SignatureElementTable[3] = {
+// CHECK:    <0:SignatureElement> = {
+// CHECK:      SemanticName: "SV_Position"
+// CHECK:      SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:      SemanticKind: Position
+// CHECK:      ComponentType: F32
+// CHECK:      InterpolationMode: LinearNoperspective
+// CHECK:      StartRow: 0
+// CHECK:      ColsAndStream: 3
+// CHECK:      UsageAndDynIndexMasks: 15
+// CHECK:    }
+// CHECK:    <1:SignatureElement> = {
+// CHECK:      SemanticName: "CLR"
+// CHECK:      SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:      SemanticKind: Arbitrary
+// CHECK:      ComponentType: F32
+// CHECK:      InterpolationMode: Constant
+// CHECK:      StartRow: 0
+// CHECK:      ColsAndStream: 3
+// CHECK:      UsageAndDynIndexMasks: 15
+// CHECK:    }
+// CHECK:    <2:SignatureElement> = {
+// CHECK:      SemanticName: "LOG"
+// CHECK:      SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:      SemanticKind: Arbitrary
+// CHECK:      ComponentType: U32
+// CHECK:      InterpolationMode: Constant
+// CHECK:      StartRow: 1
+// CHECK:      ColsAndStream: 0
+// CHECK:      UsageAndDynIndexMasks: 1
+// CHECK:    }
+// CHECK:  }
+// CHECK:  RecordTable (stride = {{[0-9]+}} bytes) MSInfoTable[1] = {
+// CHECK:    <0:MSInfo> = {
+// CHECK:      SigOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
+// CHECK:        [0]: <0:SignatureElement> = {
+// CHECK:          SemanticName: "SV_Position"
+// CHECK:          SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:          SemanticKind: Position
+// CHECK:          ComponentType: F32
+// CHECK:          InterpolationMode: LinearNoperspective
+// CHECK:          StartRow: 0
+// CHECK:          ColsAndStream: 3
+// CHECK:          UsageAndDynIndexMasks: 15
+// CHECK:        }
+// CHECK:      }
+// CHECK:      SigPrimOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[2]>  = {
+// CHECK:        [0]: <1:SignatureElement> = {
+// CHECK:          SemanticName: "CLR"
+// CHECK:          SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:          SemanticKind: Arbitrary
+// CHECK:          ComponentType: F32
+// CHECK:          InterpolationMode: Constant
+// CHECK:          StartRow: 0
+// CHECK:          ColsAndStream: 3
+// CHECK:          UsageAndDynIndexMasks: 15
+// CHECK:        }
+// CHECK:        [1]: <2:SignatureElement> = {
+// CHECK:          SemanticName: "LOG"
+// CHECK:          SemanticIndices: <14:array[1]> = { 0 }
+// CHECK:          SemanticKind: Arbitrary
+// CHECK:          ComponentType: U32
+// CHECK:          InterpolationMode: Constant
+// CHECK:          StartRow: 1
+// CHECK:          ColsAndStream: 0
+// CHECK:          UsageAndDynIndexMasks: 1
+// CHECK:        }
+// CHECK:      }
+// CHECK:      ViewIDOutputMask: <0:bytes[0]>
+// CHECK:      ViewIDPrimOutputMask: <0:bytes[0]>
+// CHECK:      NumThreads: <6:array[3]> = { 32, 1, 1 }
+// CHECK:      GroupSharedBytesUsed: 0
+// CHECK:      GroupSharedBytesDependentOnViewID: 0
+// CHECK:      PayloadSizeInBytes: 0
+// CHECK:      MaxOutputVertices: 3
+// CHECK:      MaxOutputPrimitives: 1
+// CHECK:      MeshOutputTopology: 2
+// CHECK:    }
+// CHECK:  }
+
+
+
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+// Just Mesh Bins
+//---------------------------------------------------------------------------------------------------------------------------------
+#ifndef JUST_MESH_BINS_MS_LOG_OFFSET
+// Compile with different offsets to force generating different shader permutations
+#define JUST_MESH_BINS_MS_LOG_OFFSET 0
+#endif
+
+#define JUST_MESH_BINS_MAX_MEGAPIXELS 8
+#define JUST_MESH_BINS_MAX_PIXELS (JUST_MESH_BINS_MAX_MEGAPIXELS*1048576)
+#define JUST_MESH_BINS_THREAD_GROUP_SIZE 32
+#define JUST_MESH_BINS_MAX_GRID_SIZE_X 512
+#define JUST_MESH_BINS_MAX_GRID_SIZE_Y (JUST_MESH_BINS_MAX_PIXELS/(JUST_MESH_BINS_MAX_GRID_SIZE_X*JUST_MESH_BINS_THREAD_GROUP_SIZE))
+
+GlobalRootSignature JustMeshBinsGlobalRS = {
+    "UAV(u0,space=15)," \
+    "DescriptorTable(SRV(t0, space=15)),"
+    "DescriptorTable(SRV(t1, space=15)),"
+    "StaticSampler(s0, space=15, filter = FILTER_MIN_MAG_MIP_POINT) "
+};
+
+LocalRootSignature JustMeshBinsLocalRS =
+{
+    "RootConstants(num32BitConstants=2,b0,space=15)"
+};
+
+#define JustMeshBinsMSRootSig     "UAV(u0,space=15)," \
+    "DescriptorTable(SRV(t0, space=15))," \
+    "DescriptorTable(SRV(t1, space=15))," \
+    "RootConstants(num32BitConstants=2,b0,space=15), " \
+    "RootConstants(num32BitConstants=3,b1,space=15), " \
+    "StaticSampler(s0, space=15, filter = FILTER_MIN_MAG_MIP_POINT)"
+
+RWStructuredBuffer<uint> JustMeshBinsUAV : register(u0, space15);
+Texture2D<float4> JustMeshBinsTexture0 : register(t0, space15);
+Texture2D<float4> JustMeshBinsTexture1 : register(t1, space15);
+sampler JustMeshBinsSampler : register(s0, space15);
+
+struct JustMeshBinsNodeConstants {
+    uint ALU;
+    uint samples;
+};
+
+// The root signature feeds NodeConstants via local root signature, so the constants are per-node
+ConstantBuffer<JustMeshBinsNodeConstants> JustMeshBinsNodeConfig : register(b0, space15);
+
+uint PlayWithALUJustMeshBins(uint ALUIterations, uint inputVal)
+{
+    uint val = inputVal;
+    for (uint a = 0; a < ALUIterations; a++)
+    {
+        val ^= inputVal + a;
+    }
+    return val;
+}
+
+float PlayWithTexturesJustMeshBins(uint sampleCount, float2 startUV)
+{
+    float2 uv = startUV;
+    float fVal = 1.0f;
+    for (uint s = 0; s < sampleCount; s++)
+    {
+        float4 data0 = JustMeshBinsTexture0.SampleLevel(JustMeshBinsSampler, uv, 0);
+        float4 data1 = JustMeshBinsTexture1.SampleLevel(JustMeshBinsSampler, uv, 0);
+        fVal += data0.x == data1.x ? 0 : 1;
+        fVal += data0.y == data1.y ? 0 : 1;
+        fVal += data0.z == data1.z ? 0 : 1;
+        fVal += data0.w == data1.w ? 0 : 1;
+        uv = float2(data0.x, data1.y);
+    }
+    return fVal;
+}
+
+struct JustMeshBinsRecord
+{
+    uint logOffset;
+    uint16_t2 grid : SV_DispatchGrid;
+    uint16_t2 lastDispatchThreadID;
+};
+
+struct JustMeshBins_MS_OUT_POS
+{
+    float4 pos : SV_POSITION;
+};
+
+struct JustMeshBins_MS_OUT_CLR
+{
+    float4 clr : CLR;
+    uint logOffset : LOG;
+};
+
+struct JustMeshBins_VS_OUT_POS_CLR
+{
+    float4 pos : SV_POSITION;
+    float4 clr : CLR;
+    uint logOffset : LOG;
+};
+
+
+//---------------------------------------------------------------------------------------------------------------------------------
+// JustMeshBinsLeaf:
+// Shader that's repeated into a node array
+// This shader is what gets invoked per "pixel" for the bin it gets sent to.
+[Shader("node")]
+[NodeLaunch("mesh")]
+[NodeMaxDispatchGrid(JUST_MESH_BINS_MAX_GRID_SIZE_X,JUST_MESH_BINS_MAX_GRID_SIZE_Y,1)]
+[NumThreads(JUST_MESH_BINS_THREAD_GROUP_SIZE,1,1)]
+[OutputTopology("triangle")]
+void justMeshBinsLeaf(
+    DispatchNodeInputRecord<JustMeshBinsRecord> inputData,
+    uint2 dispatchThreadID : SV_DispatchThreadID,
+    uint2 groupID : SV_GroupID,
+    uint groupIndex : SV_GroupIndex,
+    out vertices JustMeshBins_MS_OUT_POS verts[3],
+    out primitives JustMeshBins_MS_OUT_CLR prims[1],
+    out indices uint3 idx[1]
+)
+{
+    if( (inputData.Get().lastDispatchThreadID.y < dispatchThreadID.y) || 
+        ((inputData.Get().lastDispatchThreadID.y == dispatchThreadID.y) && (inputData.Get().lastDispatchThreadID.x < dispatchThreadID.x)))
+    {
+        return;
+    }
+
+    uint pixelLocation = (groupID.y*JUST_MESH_BINS_MAX_GRID_SIZE_X + groupID.x)*JUST_MESH_BINS_THREAD_GROUP_SIZE + groupIndex;
+
+    uint val = PlayWithALUJustMeshBins(JustMeshBinsNodeConfig.ALU, pixelLocation);
+    float fVal = val;
+    fVal /= 1000000;
+    fVal = PlayWithTexturesJustMeshBins(JustMeshBinsNodeConfig.samples, float2(fVal,fVal));
+    val = (fVal > 2.0f) ? val : 1;
+
+    uint logOffset = inputData.Get().logOffset;
+    InterlockedAdd(JustMeshBinsUAV[logOffset], val);
+
+    SetMeshOutputCounts(3,1);
+    verts[0].pos = float4(-1, 1, 0, 1);
+    verts[1].pos = float4(1, 1, 0, 1);
+    verts[2].pos = float4(1, -1, 0, 1);
+    prims[0].clr = float4(1,1,1,1);
+    prims[0].logOffset = logOffset;
+    idx[0] = uint3(0,1,2);
+}

--- a/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-node-rdat.hlsl
+++ b/tools/clang/test/HLSLFileCheck/d3dreflect/mesh-node-rdat.hlsl
@@ -52,7 +52,7 @@
 // CHECK:                  InterpolationMode: LinearNoperspective
 // CHECK:                  StartRow: 0
 // CHECK:                  ColsAndStream: 3
-// CHECK:                  UsageAndDynIndexMasks: 0
+// CHECK:                  UsageAndDynIndexMasks: 15
 // CHECK:                }
 // CHECK:              }
 // CHECK:              SigPrimOutputElements: <{{[0-9]+}}:RecordArrayRef<SignatureElement>[1]>  = {
@@ -64,7 +64,7 @@
 // CHECK:                  InterpolationMode: Constant
 // CHECK:                  StartRow: 0
 // CHECK:                  ColsAndStream: 3
-// CHECK:                  UsageAndDynIndexMasks: 0
+// CHECK:                  UsageAndDynIndexMasks: 15
 // CHECK:                }
 // CHECK:              }
 // CHECK:              ViewIDOutputMask: <0:bytes[0]>


### PR DESCRIPTION
Previously, the step that is typically taken to set the usage mask for signature elements was not executed, due to mesh nodes being defined in library shaders. The mask was only written for non-lib shaders. Now that mesh nodes exist in library shaders, we need to allow usage masks to be set for mesh nodes, even though they are in library shaders.

This PR adds an alternative case for mesh nodes. In this case, usage masks are written for all mesh nodes defined in a library shader, by iterating over all functions declared in a library module. An accompanying test was written that shows the RDAT now contains the usage mask, and it is non-null. 

Fixes https://github.com/microsoft/DirectXShaderCompiler/issues/6521