### PR TITLE
[SPIR-V] Scope Atomic ops on Workgroup memory

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -9176,6 +9176,12 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
     ptr = ptrInfo;
   }
 
+  // Atomic operations on memory in the Workgroup storage class should also be
+  // Workgroup scoped. Otherwise, default to Device scope.
+  spv::Scope scope = ptr->getStorageClass() == spv::StorageClass::Workgroup
+                         ? spv::Scope::Workgroup
+                         : spv::Scope::Device;
+
   const bool isCompareExchange =
       opcode == hlsl::IntrinsicOp::IOP_InterlockedCompareExchange;
   const bool isCompareStore =
@@ -9185,7 +9191,7 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
     auto *comparator = doArg(expr, 1);
     auto *valueInstr = doArg(expr, 2);
     auto *originalVal = spvBuilder.createAtomicCompareExchange(
-        baseType, ptr, spv::Scope::Device, spv::MemorySemanticsMask::MaskNone,
+        baseType, ptr, scope, spv::MemorySemanticsMask::MaskNone,
         spv::MemorySemanticsMask::MaskNone, valueInstr, comparator, srcLoc);
     if (isCompareExchange)
       writeToOutputArg(originalVal, expr, 3);
@@ -9207,8 +9213,8 @@ SpirvEmitter::processIntrinsicInterlockedMethod(const CallExpr *expr,
     if (atomicOp == spv::Op::OpAtomicSMin && baseType->isUnsignedIntegerType())
       atomicOp = spv::Op::OpAtomicUMin;
     auto *originalVal = spvBuilder.createAtomicOp(
-        atomicOp, baseType, ptr, spv::Scope::Device,
-        spv::MemorySemanticsMask::MaskNone, value, srcLoc);
+        atomicOp, baseType, ptr, scope, spv::MemorySemanticsMask::MaskNone,
+        value, srcLoc);
     if (expr->getNumArgs() > 2)
       writeToOutputArg(originalVal, expr, 2);
   }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.64bit-interlocked-methods.cs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.64bit-interlocked-methods.cs.hlsl
@@ -27,7 +27,7 @@ void main()
 // CHECK: OpCapability Int64Atomics
 
 // CHECK:        [[val1_i64:%[0-9]+]] = OpLoad %long %val1_i64
-// CHECK-NEXT: [[atomic_add:%[0-9]+]] = OpAtomicIAdd %long %dest_i %uint_1 %uint_0 [[val1_i64]]
+// CHECK-NEXT: [[atomic_add:%[0-9]+]] = OpAtomicIAdd %long %dest_i %uint_2 %uint_0 [[val1_i64]]
 // CHECK-NEXT:                       OpStore %original_i_val [[atomic_add]]
   InterlockedAdd(dest_i, val1_i64, original_i_val);
 
@@ -39,41 +39,41 @@ void main()
   InterlockedAdd(getDest()[0], val3_u64, original_u_val);
 
 // CHECK:        [[val3_u64_0:%[0-9]+]] = OpLoad %ulong %val3_u64
-// CHECK-NEXT: [[atomic_and:%[0-9]+]] = OpAtomicAnd %ulong %dest_u %uint_1 %uint_0 [[val3_u64_0]]
+// CHECK-NEXT: [[atomic_and:%[0-9]+]] = OpAtomicAnd %ulong %dest_u %uint_2 %uint_0 [[val3_u64_0]]
 // CHECK-NEXT:                       OpStore %original_u_val [[atomic_and]]
   InterlockedAnd(dest_u, val3_u64,  original_u_val);
 
 // CHECK:        [[val1_i64_0:%[0-9]+]] = OpLoad %long %val1_i64
-// CHECK-NEXT: [[atomic_max:%[0-9]+]] = OpAtomicSMax %long %dest_i %uint_1 %uint_0 [[val1_i64_0]]
+// CHECK-NEXT: [[atomic_max:%[0-9]+]] = OpAtomicSMax %long %dest_i %uint_2 %uint_0 [[val1_i64_0]]
 // CHECK-NEXT:                       OpStore %original_i_val [[atomic_max]]
   InterlockedMax(dest_i, val1_i64,  original_i_val);
 
 // CHECK:        [[val3_u64_1:%[0-9]+]] = OpLoad %ulong %val3_u64
-// CHECK-NEXT: [[atomic_min:%[0-9]+]] = OpAtomicUMin %ulong %dest_u %uint_1 %uint_0 [[val3_u64_1]]
+// CHECK-NEXT: [[atomic_min:%[0-9]+]] = OpAtomicUMin %ulong %dest_u %uint_2 %uint_0 [[val3_u64_1]]
 // CHECK-NEXT:                       OpStore %original_u_val [[atomic_min]]
   InterlockedMin(dest_u, val3_u64,  original_u_val);
 
 // CHECK:       [[val2_i64:%[0-9]+]] = OpLoad %long %val2_i64
-// CHECK-NEXT: [[atomic_or:%[0-9]+]] = OpAtomicOr %long %dest_i %uint_1 %uint_0 [[val2_i64_0:%[0-9]+]]
+// CHECK-NEXT: [[atomic_or:%[0-9]+]] = OpAtomicOr %long %dest_i %uint_2 %uint_0 [[val2_i64_0:%[0-9]+]]
 // CHECK-NEXT:                      OpStore %original_i_val [[atomic_or]]
   InterlockedOr (dest_i, val2_i64, original_i_val);
 
 // CHECK:        [[val3_u64_2:%[0-9]+]] = OpLoad %ulong %val3_u64
-// CHECK-NEXT: [[atomic_xor:%[0-9]+]] = OpAtomicXor %ulong %dest_u %uint_1 %uint_0 [[val3_u64_2]]
+// CHECK-NEXT: [[atomic_xor:%[0-9]+]] = OpAtomicXor %ulong %dest_u %uint_2 %uint_0 [[val3_u64_2]]
 // CHECK-NEXT:                       OpStore %original_u_val [[atomic_xor]]
   InterlockedXor(dest_u, val3_u64,  original_u_val);
 
 // CHECK:      [[val1_i64_1:%[0-9]+]] = OpLoad %long %val1_i64
 // CHECK-NEXT: [[val2_i64_1:%[0-9]+]] = OpLoad %long %val2_i64
-// CHECK-NEXT:          {{%[0-9]+}} = OpAtomicCompareExchange %long %dest_i %uint_1 %uint_0 %uint_0 [[val2_i64_1]] [[val1_i64_1]]
+// CHECK-NEXT:          {{%[0-9]+}} = OpAtomicCompareExchange %long %dest_i %uint_2 %uint_0 %uint_0 [[val2_i64_1]] [[val1_i64_1]]
   InterlockedCompareStore(dest_i, val1_i64, val2_i64);
 
-// CHECK:      [[ace:%[0-9]+]] = OpAtomicCompareExchange %ulong %dest_u %uint_1 %uint_0 %uint_0 %ulong_20 %ulong_15
+// CHECK:      [[ace:%[0-9]+]] = OpAtomicCompareExchange %ulong %dest_u %uint_2 %uint_0 %uint_0 %ulong_20 %ulong_15
 // CHECK-NEXT:                OpStore %original_u_val [[ace]]
   InterlockedCompareExchange(dest_u, 15u, 20u, original_u_val);
 
 // CHECK:      [[val2_i64_2:%[0-9]+]] = OpLoad %long %val2_i64
-// CHECK-NEXT:       [[ae:%[0-9]+]] = OpAtomicExchange %long %dest_i %uint_1 %uint_0 [[val2_i64_2]]
+// CHECK-NEXT:       [[ae:%[0-9]+]] = OpAtomicExchange %long %dest_i %uint_2 %uint_0 [[val2_i64_2]]
 // CHECK-NEXT:                     OpStore %original_i_val [[ae]]
   InterlockedExchange(dest_i, val2_i64, original_i_val);
 }

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.compareexchange.output.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.compareexchange.output.hlsl
@@ -23,46 +23,46 @@ void passBuffer(RWStructuredBuffer<uint> param) {
 void main() {
   uint result;
   InterlockedAdd(value, 1, result);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK:                   OpStore %result [[tmp]]
 
   uint2 value2;
   InterlockedAdd(value, 1, value2.x);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %value2 %int_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   S1 s1;
   InterlockedAdd(value, 1, s1.m0);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %s1 %int_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   uint array[2];
   InterlockedAdd(value, 1, array[0]);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %array %int_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   S2 s2;
   InterlockedAdd(value, 1, s2.m0[1].m0);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Function_uint %s2 %int_0 %int_1 %int_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   InterlockedAdd(value, 1, buffer[0]);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint %buffer %int_0 %uint_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   InterlockedAdd(value, 1, returnBuffer()[0]);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[buf:%[0-9]+]] = OpFunctionCall %_ptr_Uniform_type_RWStructuredBuffer_uint %returnBuffer
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[buf]] %int_0 %uint_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]
 
   passBuffer(buffer);
-// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_1 %uint_0 %uint_1
+// CHECK: [[tmp:%[0-9]+]] = OpAtomicIAdd %uint %value %uint_2 %uint_0 %uint_1
 // CHECK: [[buf:%[0-9]+]] = OpLoad %_ptr_Uniform_type_RWStructuredBuffer_uint %param
 // CHECK: [[ptr:%[0-9]+]] = OpAccessChain %_ptr_Uniform_uint [[buf]] %int_0 %uint_0
 // CHECK:                   OpStore [[ptr]] [[tmp]]

--- a/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.cs.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/intrinsics.interlocked-methods.cs.hlsl
@@ -26,53 +26,58 @@ void main()
   //////////////////////////////////////////////////////////////////////////
 
 // CHECK:      [[val1_27:%[0-9]+]] = OpLoad %int %val1
-// CHECK-NEXT: [[iadd27:%[0-9]+]] = OpAtomicIAdd %int %dest_i %uint_1 %uint_0 [[val1_27]]
+// CHECK-NEXT: [[iadd27:%[0-9]+]] = OpAtomicIAdd %int %dest_i %uint_2 %uint_0 [[val1_27]]
 // CHECK-NEXT:                   OpStore %original_i_val [[iadd27]]
   InterlockedAdd(dest_i, val1, original_i_val);
 
 // CHECK:      [[buff:%[0-9]+]] = OpFunctionCall %type_buffer_image %getDest
 // CHECK-NEXT: OpStore %temp_var_RWBuffer [[buff]]
-// CHECK-NEXT: OpImageTexelPointer %_ptr_Image_uint %temp_var_RWBuffer %uint_0 %uint_0
+// CHECK-NEXT: [[ptr:%[0-9]+]] = OpImageTexelPointer %_ptr_Image_uint %temp_var_RWBuffer %uint_0 %uint_0
+// CHECK-NEXT: [[load_28:%[0-9]+]] = OpLoad %int %val1
+// CHECK-NEXT: [[val1_28:%[0-9]+]] = OpBitcast %uint [[load_28]]
+// CHECK-NEXT: [[iadd28:%[0-9]+]] = OpAtomicIAdd %uint [[ptr]] %uint_1 %uint_0 [[val1_28]]
+// CHECK-NEXT: [[iadd28_2:%[0-9]+]] = OpBitcast %int [[iadd28]]
+// CHECK-NEXT:       OpStore %original_i_val [[iadd28_2]]
   InterlockedAdd(getDest()[0], val1, original_i_val);
 
-// CHECK:      [[and28:%[0-9]+]] = OpAtomicAnd %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK:      [[and28:%[0-9]+]] = OpAtomicAnd %uint %dest_u %uint_2 %uint_0 %uint_10
 // CHECK-NEXT:                  OpStore %original_u_val [[and28]]
   InterlockedAnd(dest_u, 10,  original_u_val);
 
 // CHECK:       [[uint10:%[0-9]+]] = OpBitcast %int %uint_10
-// CHECK-NEXT: [[asmax29:%[0-9]+]] = OpAtomicSMax %int %dest_i %uint_1 %uint_0 [[uint10]]
+// CHECK-NEXT: [[asmax29:%[0-9]+]] = OpAtomicSMax %int %dest_i %uint_2 %uint_0 [[uint10]]
 // CHECK-NEXT:                    OpStore %original_i_val [[asmax29]]
   InterlockedMax(dest_i, 10,  original_i_val);
 
-// CHECK:      [[umin30:%[0-9]+]] = OpAtomicUMin %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK:      [[umin30:%[0-9]+]] = OpAtomicUMin %uint %dest_u %uint_2 %uint_0 %uint_10
 // CHECK-NEXT:                   OpStore %original_u_val [[umin30]]
   InterlockedMin(dest_u, 10,  original_u_val);
 
 // CHECK:      [[val2_31:%[0-9]+]] = OpLoad %int %val2
-// CHECK-NEXT:   [[or31:%[0-9]+]] = OpAtomicOr %int %dest_i %uint_1 %uint_0 [[val2_31]]
+// CHECK-NEXT:   [[or31:%[0-9]+]] = OpAtomicOr %int %dest_i %uint_2 %uint_0 [[val2_31]]
 // CHECK-NEXT:                   OpStore %original_i_val [[or31]]
   InterlockedOr (dest_i, val2, original_i_val);
 
-// CHECK:      [[xor32:%[0-9]+]] = OpAtomicXor %uint %dest_u %uint_1 %uint_0 %uint_10
+// CHECK:      [[xor32:%[0-9]+]] = OpAtomicXor %uint %dest_u %uint_2 %uint_0 %uint_10
 // CHECK-NEXT:                  OpStore %original_u_val [[xor32]]
   InterlockedXor(dest_u, 10,  original_u_val);
 
 // CHECK:      [[val1_33:%[0-9]+]] = OpLoad %int %val1
 // CHECK-NEXT: [[val2_33:%[0-9]+]] = OpLoad %int %val2
-// CHECK-NEXT:        {{%[0-9]+}} = OpAtomicCompareExchange %int %dest_i %uint_1 %uint_0 %uint_0 [[val2_33]] [[val1_33]]
+// CHECK-NEXT:        {{%[0-9]+}} = OpAtomicCompareExchange %int %dest_i %uint_2 %uint_0 %uint_0 [[val2_33]] [[val1_33]]
   InterlockedCompareStore(dest_i, val1, val2);
 
-// CHECK:      [[ace34:%[0-9]+]] = OpAtomicCompareExchange %uint %dest_u %uint_1 %uint_0 %uint_0 %uint_20 %uint_15
+// CHECK:      [[ace34:%[0-9]+]] = OpAtomicCompareExchange %uint %dest_u %uint_2 %uint_0 %uint_0 %uint_20 %uint_15
 // CHECK-NEXT:                  OpStore %original_u_val [[ace34]]
   InterlockedCompareExchange(dest_u, 15, 20, original_u_val);
 
 // CHECK:      [[val2_35:%[0-9]+]] = OpLoad %int %val2
-// CHECK-NEXT:  [[ace35:%[0-9]+]] = OpAtomicExchange %int %dest_i %uint_1 %uint_0 [[val2_35]]
+// CHECK-NEXT:  [[ace35:%[0-9]+]] = OpAtomicExchange %int %dest_i %uint_2 %uint_0 [[val2_35]]
 // CHECK-NEXT:                   OpStore %original_i_val [[ace35]]
   InterlockedExchange(dest_i, val2, original_i_val);
 
 // CHECK:      [[val_f:%[0-9]+]] = OpLoad %float %val_f1
-// CHECK-NEXT:  [[ace36:%[0-9]+]] = OpAtomicExchange %float %dest_f %uint_1 %uint_0 [[val_f]]
+// CHECK-NEXT:  [[ace36:%[0-9]+]] = OpAtomicExchange %float %dest_f %uint_2 %uint_0 [[val_f]]
 // CHECK-NEXT:                   OpStore %original_f_val [[ace36]]
   InterlockedExchange(dest_f, val_f1, original_f_val);
 }


### PR DESCRIPTION
Set the scope of atomic operation on Workgroup-shared variables to the Workgroup rather than the Device.

Fixes #6508