### PR TITLE
Increase filter time value for failing ftime-trace-granularity test

### DIFF
--- a/tools/clang/test/DXC/ftime-trace-granularity.hlsl
+++ b/tools/clang/test/DXC/ftime-trace-granularity.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace -ftime-trace-granularity=99999 | FileCheck %s
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=99999
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace -ftime-trace-granularity=999999 | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=999999
 // RUN: cat %t.json | FileCheck %s
 
 // This test runs both stdout and file output paths.

--- a/tools/clang/test/DXC/ftime-trace-granularity.hlsl
+++ b/tools/clang/test/DXC/ftime-trace-granularity.hlsl
@@ -1,5 +1,5 @@
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace -ftime-trace-granularity=999999 | FileCheck %s
-// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=999999
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace -ftime-trace-granularity=2147483647 | FileCheck %s
+// RUN: %dxc -E main -T vs_6_0 %s -ftime-trace=%t.json -ftime-trace-granularity=2147483647
 // RUN: cat %t.json | FileCheck %s
 
 // This test runs both stdout and file output paths.


### PR DESCRIPTION
ftime-trace-granularity test was failing in test runs due to the configured time filter value being too small.  The latest test run was recording duration times of 322308 which is larger than the test's specified filter value of 99999 causing timings to not be filtered out.

The test is now updated to have a filter value of 999999, which should properly filter out timings.

Fixes #6528 
