### PR TITLE
[SPIR-V] Warn when wave size is used

### DIFF
--- a/tools/clang/lib/SPIRV/SpirvEmitter.cpp
+++ b/tools/clang/lib/SPIRV/SpirvEmitter.cpp
@@ -12577,6 +12577,19 @@ void SpirvEmitter::processComputeShaderAttributes(const FunctionDecl *decl) {
 
   spvBuilder.addExecutionMode(entryFunction, spv::ExecutionMode::LocalSize,
                               {x, y, z}, decl->getLocation());
+
+  auto *waveSizeAttr = decl->getAttr<HLSLWaveSizeAttr>();
+  if (waveSizeAttr) {
+    // Not supported in Vulkan SPIR-V, warn and ignore.
+
+    // SPIR-V SubgroupSize execution mode would work but it is Kernel only
+    // (requires the SubgroupDispatch capability, which implies the
+    // DeviceEnqueue capability, which is Kernel only). Subgroup sizes can be
+    // specified in Vulkan on the application side via
+    // VK_EXT_subgroup_size_control.
+    emitWarning("Wave size is not supported by SPIR-V",
+                waveSizeAttr->getLocation());
+  }
 }
 
 bool SpirvEmitter::processTessellationShaderAttributes(

--- a/tools/clang/test/CodeGenSPIRV/attribute.wavesize.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/attribute.wavesize.hlsl
@@ -1,0 +1,7 @@
+// RUN: %dxc -T cs_6_6 -E main -fcgl -spirv %s 2>&1 | FileCheck %s
+
+// CHECK: warning: Wave size is not supported by SPIR-V
+
+[WaveSize(32)]
+[numthreads(1, 1, 1)]
+void main() {}


### PR DESCRIPTION
Specifying a wave size is not supported in Vulkan SPIR-V, so warn when it is used in a shader.