### PR TITLE
[Sema] Report warning when mix packoffset with nonpackoffset

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7544,7 +7544,7 @@ def err_hlsl_objectintemplateargument : Error<
   "%0 is an object and cannot be used as a type parameter">;
 def err_hlsl_packoffset_requires_cbuffer : Error<
   "packoffset is only allowed in a constant buffer">;
-def err_hlsl_packoffset_mix : Error<
+def warn_hlsl_packoffset_mix : Warning<
   "cannot mix packoffset elements with nonpackoffset elements in a cbuffer">;
 def err_hlsl_packoffset_overlap : Error<"packoffset overlap between %0, %1">;
 def err_hlsl_register_semantics_conflicting : Error<

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7544,6 +7544,9 @@ def err_hlsl_objectintemplateargument : Error<
   "%0 is an object and cannot be used as a type parameter">;
 def err_hlsl_packoffset_requires_cbuffer : Error<
   "packoffset is only allowed in a constant buffer">;
+def err_hlsl_packoffset_mix : Error<
+  "cannot mix packoffset elements with nonpackoffset elements in a cbuffer">;
+def err_hlsl_packoffset_overlap : Error<"packoffset overlap between %0, %1">;
 def err_hlsl_register_semantics_conflicting : Error<
   "conflicting register semantics">;
 def err_hlsl_register_or_offset_bind_not_valid: Error<

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -14056,7 +14056,7 @@ void Sema::ActOnFinishHLSLBuffer(Decl *Dcl, SourceLocation RBrace) {
   }
 
   if (HasPackOffset && HasNonPackOffset) {
-    Diag(BufDecl->getLocation(), diag::err_hlsl_packoffset_mix);
+    Diag(BufDecl->getLocation(), diag::warn_hlsl_packoffset_mix);
   } else if (HasPackOffset) {
     // Make sure no overlap in packoffset.
     llvm::SmallDenseMap<VarDecl *, std::pair<unsigned, unsigned>>

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.error.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.error.hlsl
@@ -1,7 +1,7 @@
 // RUN: not %dxc -T vs_6_0 -E main -fcgl  %s -spirv  2>&1 | FileCheck %s
 
 cbuffer MyCBuffer {
-    float4 data1;
+    float4 data1 : packoffset(c0);
     float4 data2 : packoffset(c2);
     float  data3 : packoffset(c0);    // error: overlap
     float  data4 : packoffset(c10.z);

--- a/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.hlsl
+++ b/tools/clang/test/CodeGenSPIRV/vk.layout.cbuffer.packoffset.hlsl
@@ -14,11 +14,11 @@ struct S {
 };
 
 cbuffer MyCBuffer {                    // Offset
-    float4   data1;                    //                  0
+    float4   data1 : packoffset(c0);   //                  0
     float4   data2 : packoffset(c2);   // 2 * 16         = 32
     float    data3 : packoffset(c3.y); // 3 * 16 + 1 * 4 = 52
     float    data4 : packoffset(c3.z); // 3 * 16 + 2 * 4 = 56
-    float    data5;                    //                  60
+    float    data5 : packoffset(c3.w); //                  60
     float4   data6 : packoffset(c100); // 100 * 16       = 1600
     float2x3 data7 : packoffset(c110); // 110 * 16       = 1760
     S        data8 : packoffset(c150); // 150 * 16       = 2400

--- a/tools/clang/test/SemaHLSL/attributes/packoffset-invalid.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/packoffset-invalid.hlsl
@@ -1,6 +1,6 @@
 // RUN: %dxc -E main -T lib_6_6 %s -verify
 
-// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+// expected-warning@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer Mix
 {
     float4 M1 : packoffset(c0);
@@ -8,7 +8,7 @@ cbuffer Mix
     float M3 : packoffset(c1.y);
 }
 
-// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+// expected-warning@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer Mix2
 {
     float4 M4;

--- a/tools/clang/test/SemaHLSL/attributes/packoffset-invalid.hlsl
+++ b/tools/clang/test/SemaHLSL/attributes/packoffset-invalid.hlsl
@@ -1,0 +1,57 @@
+// RUN: %dxc -E main -T lib_6_6 %s -verify
+
+// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+cbuffer Mix
+{
+    float4 M1 : packoffset(c0);
+    float M2;
+    float M3 : packoffset(c1.y);
+}
+
+// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+cbuffer Mix2
+{
+    float4 M4;
+    float M5 : packoffset(c1.y);
+    float M6 ;
+}
+
+// expected-error@+1{{packoffset is only allowed in a constant buffer}}
+float4 g : packoffset(c0);
+
+cbuffer IllegalOffset
+{
+    // expected-error@+1{{register type is unsupported - available types are 'b', 'c', 'i', 's', 't', 'u'}}
+    float4 i1 : packoffset(t2);
+    // expected-error@+1{{packoffset component should indicate offset with one of x, y, z, w, r, g, b, or a}}
+    float i2 : packoffset(c1.m);
+}
+
+cbuffer Overlap
+{
+    float4 o1 : packoffset(c0);
+    // expected-error@+1{{packoffset overlap between 'o2', 'o1'}}
+    float2 o2 : packoffset(c0.z);
+}
+
+cbuffer CrossReg
+{
+    // expected-error@+1{{register or offset bind not valid}}
+    float4 c1 : packoffset(c0.y);
+    // expected-error@+1{{register or offset bind not valid}}
+    float2 c2 : packoffset(c1.w);
+}
+
+struct ST {
+  float s;
+};
+
+cbuffer Aggregate
+{
+    // expected-error@+1{{register or offset bind not valid}}
+    ST A1 : packoffset(c0.y);
+    // expected-error@+1{{register or offset bind not valid}}
+    float A2[2] : packoffset(c1.w);
+    // expected-error@+1{{register or offset bind not valid}}
+    float2x1 m2 : packoffset(c12.z);
+}

--- a/tools/clang/test/SemaHLSL/packreg.hlsl
+++ b/tools/clang/test/SemaHLSL/packreg.hlsl
@@ -575,7 +575,7 @@ cbuffer MyBuffer2
 Texture2D<float4> Texture : register(t0);
 Texture2D<float4> Texture_ : register(t0);
 sampler Sampler : register(s0);
-
+// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer Parameters : register(b0)
 {
   float4   DiffuseColor   : packoffset(c0) : register(c0);

--- a/tools/clang/test/SemaHLSL/packreg.hlsl
+++ b/tools/clang/test/SemaHLSL/packreg.hlsl
@@ -575,7 +575,7 @@ cbuffer MyBuffer2
 Texture2D<float4> Texture : register(t0);
 Texture2D<float4> Texture_ : register(t0);
 sampler Sampler : register(s0);
-// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+// expected-warning@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer Parameters : register(b0)
 {
   float4   DiffuseColor   : packoffset(c0) : register(c0);

--- a/tools/clang/test/SemaHLSL/semantics.hlsl
+++ b/tools/clang/test/SemaHLSL/semantics.hlsl
@@ -6,7 +6,7 @@ float g_foo1 : foo;
 float g_foo2 : foo : fubar;
 float g_foo3 : foo : fubar : register(c3);
 float g_foo4 : register(c4) : foo : fubar;
-
+// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer CBInit : register(b2)
 {
     float g2_foo1 : foo;                                    /* fxc-error {{X3530: cannot mix packoffset elements with nonpackoffset elements in a cbuffer}} */

--- a/tools/clang/test/SemaHLSL/semantics.hlsl
+++ b/tools/clang/test/SemaHLSL/semantics.hlsl
@@ -6,7 +6,7 @@ float g_foo1 : foo;
 float g_foo2 : foo : fubar;
 float g_foo3 : foo : fubar : register(c3);
 float g_foo4 : register(c4) : foo : fubar;
-// expected-error@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
+// expected-warning@+1{{cannot mix packoffset elements with nonpackoffset elements in a cbuffer}}
 cbuffer CBInit : register(b2)
 {
     float g2_foo1 : foo;                                    /* fxc-error {{X3530: cannot mix packoffset elements with nonpackoffset elements in a cbuffer}} */


### PR DESCRIPTION
Check  mix packoffset elements with nonpackoffset elements in a cbuffer at Sema::ActOnFinishHLSLBuffer. Also check packoffset for aggregate type.

Fixes #3724