### PR TITLE
Add diag for new Barrier intrinsic on SM < 6.8

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7802,6 +7802,9 @@ def warn_hlsl_derivatives_wrong_numthreads : Warning<
     " or broadcast nodes, numthreads must be either 1D with X as a multiple of 4 or"
     " both X and Y must be multiples of 2.">,
     DefaultError, InGroup<HLSLAvailability>;
+def warn_hlsl_intrinsic_in_wrong_shader_model : Warning<
+   "intrinsic %0 potentially used by '%1' requires shader model %2 or greater">,
+    DefaultError, InGroup<HLSLAvailability>;
 def warn_hlsl_intrinsic_overload_in_wrong_shader_model : Warning<
    "overload of intrinsic %0 requires shader model %1 or greater">, 
     DefaultError, InGroup<HLSLAvailability>;

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -11474,6 +11474,15 @@ static void DiagnoseReachableBarrier(Sema &S, CallExpr *CE,
   FunctionDecl *FD = CE->getDirectCallee();
   DXASSERT(FD->getNumParams() == 2, "otherwise, unknown Barrier overload");
 
+  // First, check shader model constraint.
+  if (!SM->IsSM68Plus()) {
+    Diags.Report(CE->getExprLoc(),
+                 diag::warn_hlsl_intrinsic_in_wrong_shader_model)
+        << FD->getNameAsString() << EntryDecl->getNameAsString() << "6.8";
+    Diags.Report(EntryDecl->getLocation(), diag::note_hlsl_entry_defined_here);
+    return;
+  }
+
   // Does shader have visible group?
   // Allow exported library functions as well.
   bool hasVisibleGroup = ShaderModel::HasVisibleGroup(EntrySK, NodeLaunchTy);

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-errors.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 // RUN: %dxc -Tcs_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test the ordinary compute shader model case with node memory flags.
 

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-local-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-local-errors.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 // RUN: %dxc -Tcs_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test the ordinary compute shader model case with local call-site errors.
 // Since these errors are emitted before we do diagnostics for reachable calls,

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-compat.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-compat.hlsl
@@ -1,0 +1,103 @@
+// RUN: %dxc -Tlib_6_7 -verify %s
+// REQUIRES: dxil-1-8
+
+// Test translatable barriers in compute shader model.
+// These are currently not translated, so we expect errors for now.
+
+struct RECORD { uint a; };
+RWBuffer<uint> buf0;
+static uint i = 7;
+
+// Barriers not requiring visible group, compatible with any shader stage.
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+// expected-note@+2 {{entry function defined here}}
+[noinline] export
+void DeviceBarriers() {
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, DEVICE_SCOPE);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, 2 + 2);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, DEVICE_SCOPE);
+}
+
+// Barriers requiring visible group.
+// expected-note@+13 {{entry function defined here}}
+// expected-note@+12 {{entry function defined here}}
+// expected-note@+11 {{entry function defined here}}
+// expected-note@+10 {{entry function defined here}}
+// expected-note@+9 {{entry function defined here}}
+// expected-note@+8 {{entry function defined here}}
+// expected-note@+7 {{entry function defined here}}
+// expected-note@+6 {{entry function defined here}}
+// expected-note@+5 {{entry function defined here}}
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+// expected-note@+2 {{entry function defined here}}
+[noinline] export
+void GroupBarriers() {
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(0, GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, GROUP_SCOPE);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, 1 + 2 + 4);
+
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, GROUP_SCOPE);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SCOPE);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SCOPE | GROUP_SYNC);
+}
+
+// expected-note@+17 {{entry function defined here}}
+// expected-note@+16 {{entry function defined here}}
+// expected-note@+15 {{entry function defined here}}
+// expected-note@+14 {{entry function defined here}}
+// expected-note@+13 {{entry function defined here}}
+// expected-note@+12 {{entry function defined here}}
+// expected-note@+11 {{entry function defined here}}
+// expected-note@+10 {{entry function defined here}}
+// expected-note@+9 {{entry function defined here}}
+// expected-note@+8 {{entry function defined here}}
+// expected-note@+7 {{entry function defined here}}
+// expected-note@+6 {{entry function defined here}}
+// expected-note@+5 {{entry function defined here}}
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+[Shader("compute")]
+[numthreads(1, 1, 1)]
+void main() {
+  DeviceBarriers();
+  GroupBarriers();
+}

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-compat.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-compat.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -Tlib_6_7 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test translatable barriers in compute shader model.
 // These are currently not translated, so we expect errors for now.

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-errors.hlsl
@@ -1,0 +1,94 @@
+// RUN: %dxc -Tlib_6_7 -verify %s
+// REQUIRES: dxil-1-8
+
+// Test non-translatable barriers in compute shader model.
+
+struct RECORD { uint a; };
+RWBuffer<uint> buf0;
+static uint i = 7;
+
+// Barriers not requiring visible group, compatible with any shader stage.
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+// expected-note@+2 {{entry function defined here}}
+[noinline] export
+void DeviceBarriers() {
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(0, 0);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, 0);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'DeviceBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, 0);
+}
+
+// Barriers requiring visible group.
+// expected-note@+5 {{entry function defined here}}
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+// expected-note@+2 {{entry function defined here}}
+[noinline] export
+void GroupBarriers() {
+  // No scope
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(ALL_MEMORY, GROUP_SYNC);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(UAV_MEMORY, GROUP_SYNC);
+
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(GROUP_SHARED_MEMORY, 0);
+  // expected-error@+2 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'GroupBarriers' requires shader model 6.8 or greater}}
+  Barrier(GROUP_SHARED_MEMORY, GROUP_SYNC);
+}
+
+// expected-note@+14 {{entry function defined here}}
+// expected-note@+13 {{entry function defined here}}
+// expected-note@+12 {{entry function defined here}}
+// expected-note@+11 {{entry function defined here}}
+// expected-note@+10 {{entry function defined here}}
+// expected-note@+9 {{entry function defined here}}
+// expected-note@+8 {{entry function defined here}}
+// expected-note@+7 {{entry function defined here}}
+// expected-note@+6 {{entry function defined here}}
+// expected-note@+5 {{entry function defined here}}
+// expected-note@+4 {{entry function defined here}}
+// expected-note@+3 {{entry function defined here}}
+[Shader("compute")]
+[numthreads(1, 1, 1)]
+void main() {
+  DeviceBarriers();
+  GroupBarriers();
+
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  Barrier(buf0, 0);
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  Barrier(buf0, GROUP_SYNC);
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  Barrier(buf0, GROUP_SCOPE);
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  Barrier(buf0, DEVICE_SCOPE);
+  // expected-error@+1 {{intrinsic Barrier potentially used by 'main' requires shader model 6.8 or greater}}
+  Barrier(buf0, DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+}
+
+// Unused compute entry should not produce any diagnostics, other than the
+// numthreads warning.
+
+// expected-warning@+1 {{attribute 'numthreads' ignored without accompanying shader attribute}}
+[numthreads(1, 1, 1)]
+void main_unused() {
+  DeviceBarriers();
+  GroupBarriers();
+
+  Barrier(buf0, 0);
+  Barrier(buf0, GROUP_SYNC);
+  Barrier(buf0, GROUP_SCOPE);
+  Barrier(buf0, DEVICE_SCOPE);
+  Barrier(buf0, DEVICE_SCOPE | GROUP_SCOPE | GROUP_SYNC);
+}

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs-sm67-errors.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -Tlib_6_7 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test non-translatable barriers in compute shader model.
 

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-cs.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 // RUN: %dxc -Tcs_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test the compute shader model case with visible group.
 // expected-no-diagnostics

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node-errors.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 struct RECORD { uint a; };
 RWBuffer<uint> buf0;

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-node.hlsl
@@ -1,5 +1,4 @@
 // RUN: %dxc -Tlib_6_8 -Wno-unused-value -verify %s
-// REQUIRES: dxil-1-8
 
 // Legal cases, no diagnostics expected for this file.
 // expected-no-diagnostics

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-vs-errors.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-vs-errors.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 // RUN: %dxc -Tvs_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test the ordinary shader model case with no visible group.
 

--- a/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-vs.hlsl
+++ b/tools/clang/test/SemaHLSL/hlsl/intrinsics/barrier/barrier-vs.hlsl
@@ -1,6 +1,5 @@
 // RUN: %dxc -Tlib_6_8 -verify %s
 // RUN: %dxc -Tvs_6_8 -verify %s
-// REQUIRES: dxil-1-8
 
 // Test the ordinary shader model case with no visible group.
 // expected-no-diagnostics


### PR DESCRIPTION
Tests are split between one containing cases that could potentially be translated to legacy barrier op in the future, and a test without translatable barrier ops.

Part of #6538.