### PR TITLE
Escape paths in depfiles.

### DIFF
--- a/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
+++ b/tools/clang/tools/dxcompiler/dxcompilerobj.cpp
@@ -887,16 +887,38 @@ public:
         preprocessAction.Execute();
         preprocessAction.EndSourceFile();
 
-        outStream << (opts.OutputObject.empty() ? opts.InputFile
-                                                : opts.OutputObject);
+        auto writeEscapedPath = [](auto &stream, auto const &path) {
+          for (auto p : path) {
+            switch (p) {
+            case ':':
+            case ' ':
+            case '#':
+            case '[':
+            case ']':
+            case '\\':
+              stream << '\\';
+              break;
+            case '$':
+              stream << '$';
+              break;
+            }
+            stream << p;
+          }
+        };
+
+        writeEscapedPath(outStream, opts.OutputObject.empty()
+                                        ? opts.InputFile
+                                        : opts.OutputObject);
+
         bool firstDependency = true;
         for (auto &dependency : dependencyCollector->getDependencies()) {
           if (firstDependency) {
-            outStream << ": " << dependency;
+            outStream << ": ";
             firstDependency = false;
-            continue;
+          } else {
+            outStream << " \\\n ";
           }
-          outStream << " \\\n " << dependency;
+          writeEscapedPath(outStream, dependency);
         }
         outStream << "\n";
         outStream.flush();


### PR DESCRIPTION
Escape paths in generated depfiles.

Problems especially occur when using depfiles containing absolute paths on windows that include driver letters (e.g. `c:\foo\bar`) as the depfile format requires a colon between the output dependency and its input dependencies (`output: input1 input2 ...`). When Windows drive letters come into play this becomes ambiguous (`c:\output: c:\input1 c:\input2`). Therefore, certain characters should be escaped when generating the depfile (`c\:\\output1: c\:\\input1 c\:\\input2`). This PR adds a method for escaping the relevant characters.