### PR TITLE
Fix bool attribute argument handling

### DIFF
--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12341,7 +12341,6 @@ static int ValidateAttributeIntArg(Sema &S, const AttributeList &Attr,
           // warning.
           value = value ? 1 : 0;
         } else if (!(E->getType()->isIntegralType(S.Context)) || value < 0) {
-          QualType ETy = E->getType();
           S.Diag(Attr.getLoc(), diag::warn_hlsl_attribute_expects_uint_literal)
               << Attr.getName();
         }

--- a/tools/clang/lib/Sema/SemaHLSL.cpp
+++ b/tools/clang/lib/Sema/SemaHLSL.cpp
@@ -12336,7 +12336,12 @@ static int ValidateAttributeIntArg(Sema &S, const AttributeList &Attr,
     } else {
       if (ArgNum.isInt()) {
         value = ArgNum.getInt().getSExtValue();
-        if (!(E->getType()->isIntegralType(S.Context)) || value < 0) {
+        if (E->getType()->isBooleanType()) {
+          // Bool should map to 0 or 1.  Otherwise, we would see -1 and emit a
+          // warning.
+          value = value ? 1 : 0;
+        } else if (!(E->getType()->isIntegralType(S.Context)) || value < 0) {
+          QualType ETy = E->getType();
           S.Diag(Attr.getLoc(), diag::warn_hlsl_attribute_expects_uint_literal)
               << Attr.getName();
         }

--- a/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-attribs.hlsl
+++ b/tools/clang/test/CodeGenDXIL/hlsl/objects/NodeObjects/mesh-node-invalid-attribs.hlsl
@@ -78,3 +78,21 @@ void compute_node_topology() {}
 [OutputTopology("triangle")]
 [NodeMaxInputRecordsPerGraphEntryRecord(7, false)] // expected-error {{attribute nodemaxinputrecordspergraphentryrecord only allowed on node shaders}}
 void compute_node_maxrecs() {}
+
+// Check a few valid cases as well.
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[OutputTopology("triangle")]
+[NumThreads(42,1,1)]
+[NodeDispatchGrid(19,84,1)]
+[NodeMaxInputRecordsPerGraphEntryRecord(11, false)]
+void valid_mesh_max_input_records() {}
+
+[Shader("node")]
+[NodeLaunch("mesh")]
+[NumThreads(122,1,1)]
+[NodeDispatchGrid(17,76,1)]
+[OutputTopology("line")]
+[NodeMaxInputRecordsPerGraphEntryRecord(13, true)]
+void valid_mesh_max_input_records_shared() {}


### PR DESCRIPTION
Bool attribute argument values of true would be interpreted as -1 and generate a warning that it expects a uint literal argument.

This change translates bool expression to either 0 or 1 when translating to int, just as normal expression evaluation would.
