### PR TITLE
[202x] Implement -Whlsl-legacy-literal warnings

### DIFF
--- a/tools/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/tools/clang/include/clang/Basic/DiagnosticGroups.td
@@ -804,4 +804,5 @@ def HLSLStructurizeExitsLifetimeMarkersConflict: DiagGroup<"structurize-exits-li
 def HLSLParameterUsage : DiagGroup<"parameter-usage">;
 def HLSLAvailability: DiagGroup<"hlsl-availability">;
 def HLSLBarrier : DiagGroup<"hlsl-barrier">;
+def HLSLLegacyLiterals : DiagGroup<"hlsl-legacy-literal">;
 // HLSL Change Ends

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7960,7 +7960,7 @@ def warn_hlsl_barrier_no_mem_with_required_device_scope: Warning<
   "DEVICE_SCOPE specified for Barrier operation without applicable memory">,
   InGroup<HLSLBarrier>, DefaultError;
 def warn_hlsl_legacy_integer_literal_signedness: Warning<
-  "literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later">,
+  "literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions">,
   InGroup<HLSLLegacyLiterals>, DefaultIgnore;
 // HLSL Change Ends
 

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7959,6 +7959,7 @@ def warn_hlsl_barrier_no_mem_with_required_group_scope: Warning<
 def warn_hlsl_barrier_no_mem_with_required_device_scope: Warning<
   "DEVICE_SCOPE specified for Barrier operation without applicable memory">,
   InGroup<HLSLBarrier>, DefaultError;
+def warn_hlsl_legacy_integer_literal_signedness: Warning<"literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later">, InGroup<HLSLLegacyLiterals>;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7959,7 +7959,9 @@ def warn_hlsl_barrier_no_mem_with_required_group_scope: Warning<
 def warn_hlsl_barrier_no_mem_with_required_device_scope: Warning<
   "DEVICE_SCOPE specified for Barrier operation without applicable memory">,
   InGroup<HLSLBarrier>, DefaultError;
-def warn_hlsl_legacy_integer_literal_signedness: Warning<"literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later">, InGroup<HLSLLegacyLiterals>;
+def warn_hlsl_legacy_integer_literal_signedness: Warning<
+  "literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later">,
+  InGroup<HLSLLegacyLiterals>;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -7961,7 +7961,7 @@ def warn_hlsl_barrier_no_mem_with_required_device_scope: Warning<
   InGroup<HLSLBarrier>, DefaultError;
 def warn_hlsl_legacy_integer_literal_signedness: Warning<
   "literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later">,
-  InGroup<HLSLLegacyLiterals>;
+  InGroup<HLSLLegacyLiterals>, DefaultIgnore;
 // HLSL Change Ends
 
 // SPIRV Change Starts

--- a/tools/clang/test/SemaHLSL/literals.hlsl
+++ b/tools/clang/test/SemaHLSL/literals.hlsl
@@ -146,7 +146,7 @@ float test() {
 
   // Infinity literals are floats.
   _Static_assert(0x7f800000 == asuint(1.#INF), "inf bit pattern");    /* fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
-  _Static_assert(0xff800000 == asuint(-1.#INF), "-inf bit pattern");    /* expected-warning{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}} fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
+  _Static_assert(0xff800000 == asuint(-1.#INF), "-inf bit pattern");    /* fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
   float3 vec_syn = 1.#INF.xxx; // vector syntax
   float bad_inf_0 = 1#;      /* expected-error {{invalid suffix '#' on integer constant}} fxc-error {{X3000: syntax error: unexpected token '#'}} */
   float bad_inf_1 = 1#INF;   /* expected-error {{invalid suffix '#INF' on integer constant}} fxc-error {{X3000: syntax error: unexpected token '#'}} */

--- a/tools/clang/test/SemaHLSL/literals.hlsl
+++ b/tools/clang/test/SemaHLSL/literals.hlsl
@@ -146,7 +146,7 @@ float test() {
 
   // Infinity literals are floats.
   _Static_assert(0x7f800000 == asuint(1.#INF), "inf bit pattern");    /* fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
-  _Static_assert(0xff800000 == asuint(-1.#INF), "-inf bit pattern");    /* fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
+  _Static_assert(0xff800000 == asuint(-1.#INF), "-inf bit pattern");    /* expected-warning{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}} fxc-error {{X1516: not enough actual parameters for macro '_Static_assert'}} fxc-error {{X3004: undeclared identifier '_Static_assert'}} */
   float3 vec_syn = 1.#INF.xxx; // vector syntax
   float bad_inf_0 = 1#;      /* expected-error {{invalid suffix '#' on integer constant}} fxc-error {{X3000: syntax error: unexpected token '#'}} */
   float bad_inf_1 = 1#INF;   /* expected-error {{invalid suffix '#INF' on integer constant}} fxc-error {{X3000: syntax error: unexpected token '#'}} */

--- a/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
+++ b/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
@@ -3,10 +3,6 @@
 // RUN: %dxc -T lib_6_3 -HV 2021 -verify %s
 // RUN: %dxc -T lib_6_3 -HV 2021 -enable-16bit-types -verify %s
 
-#if __HLSL_VERSION <= 2021
-// expected-no-diagnostics
-#endif
-
 template <typename T, typename U>
 struct is_same {
   static const bool value = false;
@@ -52,9 +48,11 @@ static const uint64_t V = 9223372036854775808;
 
 _Static_assert(is_same<__decltype(0x0), int>::value, "0x0 is int");
 _Static_assert(is_same<__decltype(0x70000000), int>::value, "0x70000000 is int");
+// expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
 _Static_assert(is_same<__decltype(0xF0000000), uint>::value, "0xF0000000 is uint");
 
 _Static_assert(is_same<__decltype(0x7000000000000000), int64_t>::value, "0x7000000000000000 is int64_t");
+// expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
 _Static_assert(is_same<__decltype(0xF000000000000000), uint64_t>::value, "0xF000000000000000 is uint64_t");
 
 #else
@@ -84,6 +82,24 @@ _Static_assert(!is_same<__decltype(1), int>::value, "Literals are not int");
 _Static_assert(!is_same<__decltype(1), uint>::value, "Literals are not uint");
 _Static_assert(!is_same<__decltype(1), int64_t>::value, "Literals are not int64_t");
 _Static_assert(!is_same<__decltype(1), uint64_t>::value, "Literals are not uint64_t");
+
+uint UnsignedBitMask32() {
+  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  return 0xF0000000;
+}
+
+uint64_t UnsignedBitMask64() {
+  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  return 0xF000000000000000;
+}
+
+uint SignedBitMask32() {
+  return 0x70000000; // No warning
+}
+
+uint64_t SignedBitMask64() {
+  return 0x7000000000000000; // No warning
+}
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
+++ b/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
@@ -1,7 +1,7 @@
-// RUN: %dxc -T lib_6_3 -HV 202x -verify %s
-// RUN: %dxc -T lib_6_3 -HV 202x -enable-16bit-types -verify %s
-// RUN: %dxc -T lib_6_3 -HV 2021 -verify %s
-// RUN: %dxc -T lib_6_3 -HV 2021 -enable-16bit-types -verify %s
+// RUN: %dxc -T lib_6_3 -HV 202x -Whlsl-legacy-literal -verify %s
+// RUN: %dxc -T lib_6_3 -HV 202x -Whlsl-legacy-literal -enable-16bit-types -verify %s
+// RUN: %dxc -T lib_6_3 -HV 2021 -Whlsl-legacy-literal -verify %s
+// RUN: %dxc -T lib_6_3 -HV 2021 -Whlsl-legacy-literal -enable-16bit-types -verify %s
 
 template <typename T, typename U>
 struct is_same {
@@ -99,6 +99,24 @@ uint SignedBitMask32() {
 
 uint64_t SignedBitMask64() {
   return 0x7000000000000000; // No warning
+}
+
+uint OctUnsignedBitMask32() {
+  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  return 020000000000;
+}
+
+uint64_t OctUnsignedBitMask64() {
+  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  return 01000000000000000000000;
+}
+
+uint OctSignedBitMask32() {
+  return 010000000000; // No warning
+}
+
+uint64_t OctSignedBitMask64() {
+  return 0400000000000000000000; // No warning
 }
 #endif
 

--- a/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
+++ b/tools/clang/test/SemaHLSL/v202x/conforming-literals/valid-literals.hlsl
@@ -48,11 +48,11 @@ static const uint64_t V = 9223372036854775808;
 
 _Static_assert(is_same<__decltype(0x0), int>::value, "0x0 is int");
 _Static_assert(is_same<__decltype(0x70000000), int>::value, "0x70000000 is int");
-// expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+// expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
 _Static_assert(is_same<__decltype(0xF0000000), uint>::value, "0xF0000000 is uint");
 
 _Static_assert(is_same<__decltype(0x7000000000000000), int64_t>::value, "0x7000000000000000 is int64_t");
-// expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+// expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
 _Static_assert(is_same<__decltype(0xF000000000000000), uint64_t>::value, "0xF000000000000000 is uint64_t");
 
 #else
@@ -84,12 +84,12 @@ _Static_assert(!is_same<__decltype(1), int64_t>::value, "Literals are not int64_
 _Static_assert(!is_same<__decltype(1), uint64_t>::value, "Literals are not uint64_t");
 
 uint UnsignedBitMask32() {
-  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  // expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
   return 0xF0000000;
 }
 
 uint64_t UnsignedBitMask64() {
-  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  // expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
   return 0xF000000000000000;
 }
 
@@ -102,12 +102,12 @@ uint64_t SignedBitMask64() {
 }
 
 uint OctUnsignedBitMask32() {
-  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  // expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
   return 020000000000;
 }
 
 uint64_t OctUnsignedBitMask64() {
-  // expected-warning@+1{{literal value is treated as signed in HLSL before 202x, and unsigned in 202x and later}}
+  // expected-warning@+1{{literal value is treated as signed in HLSL 2021 and earlier, and unsigned in later language versions}}
   return 01000000000000000000000;
 }
 


### PR DESCRIPTION
This adds new literal warnings to identify integer literals that may have breaking behavior changes between HLSL 2021 and 202x as a result of the conforming literals change.

The spec update for this is in: https://github.com/microsoft/hlsl-specs/pull/229

Resolves #6581