### PR TITLE
PIX: Correct the disambiguation of AS+MS threads for mesh shader output

### DIFF
--- a/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToASPayload.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/AddThreadIdToASPayload.hlsl
@@ -1,19 +1,36 @@
 // RUN: %dxc -Emain -Tas_6_6 %s | %opt -S -hlsl-dxil-PIX-add-tid-to-as-payload,dispatchArgY=3,dispatchArgZ=7 | %FileCheck %s
 
-// CHECK: mul i32 %ThreadIdX, 3
-// CHECK: mul i32
-// CHECK: , 7
-// CHECK: @dx.op.dispatchMesh.PIX_AS2MS_Expanded_Type
+// CHECK: [[AppsGroupIdX:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 0)
+// CHECK: [[GROUPIDX:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 0)
+// CHECK: [[GROUPIDY:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 1)
+// CHECK: [[GROUPIDZ:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 2)
 
+// The integer literals here come from the dispatchArg* arguments in the command line above
+// CHECK: [[YTIMES7:%.*]] = mul i32 [[GROUPIDY]], 7
+// CHECK: [[ZPLUSYTIMES7:%.*]] = add i32 [[GROUPIDZ]], [[YTIMES7]]
+// CHECK: [[XTIMES21:%.*]] = mul i32 [[GROUPIDX]], 21
+// CHECK: [[FLATGROUPNUM:%.*]] = add i32 [[XTIMES21]], [[ZPLUSYTIMES7]]
+// This 105 is the thread counts for the shader multiplied together
+// CHECK: [[FLATWITHSPACE:%.*]] = mul i32 [[FLATGROUPNUM]], 105
+// CHECK: [[FLATTENEDTHREADIDINGROUP:%.*]] = call i32 @dx.op.flattenedThreadIdInGroup.i32(i32 96)
+// CHECK: [[FLATID:%.*]] = add i32 [[FLATWITHSPACE]], [[FLATTENEDTHREADIDINGROUP]]
+
+// Check that this flat ID is stored into the expanded payload:
+// CHECKL store i32 [[FLATID]], i32*
+
+// Check that the Y and Z dispatch-mesh counts are emitted to the expanded payload:
+// CHECK: store i32 3, i32*
+// CHECK: store i32 4, i32*
 struct MyPayload
 {
     uint i;
 };
 
-[numthreads(1, 1, 1)]
+[numthreads(3, 5, 7)]
 void main(uint gid : SV_GroupID)
 {
     MyPayload payload;
     payload.i = gid;
-    DispatchMesh(1, 1, 1, payload);
+    DispatchMesh(2, 3, 4, payload);
 }
+    

--- a/tools/clang/test/HLSLFileCheck/pix/MSOutputInstrumentationCoerceValues.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/MSOutputInstrumentationCoerceValues.hlsl
@@ -1,0 +1,61 @@
+// RUN: %dxc -EMSMain -enable-16bit-types -Tms_6_6 %s | %opt -S -hlsl-dxil-pix-meshshader-output-instrumentation,expand-payload=0,dispatchArgY=3,dispatchArgZ=7,UAVSize=8192 | %FileCheck %s
+
+// Check that the instrumentation properly coerces different output types into int32
+
+// CHECK: [[PAYLOAD:%.*]]  = call %struct.MyPayload* @dx.op.getMeshPayload.struct.MyPayload(i32 170)
+
+// FP16 value in 0th member
+// CHECK: [[F16:%.*]] = getelementptr inbounds %struct.MyPayload, %struct.MyPayload* [[PAYLOAD]], i32 0, i32 0
+// CHECK: [[F16LOADED:%.*]] = load half, half* [[F16]]
+// CHECK: [[F16CONV:%.*]] = fpext half [[F16LOADED]] to float
+
+// uint16 value in 1st member
+// CHECK: [[U16:%.*]] = getelementptr inbounds %struct.MyPayload, %struct.MyPayload* [[PAYLOAD]], i32 0, i32 1
+// CHECK: [[U16LOADED:%.*]] = load i16, i16* [[U16]]
+// CHECK: [[U16CONV:%.*]] = uitofp i16 [[U16LOADED]] to float
+
+// int16 value in 2nd member
+// CHECK: [[I16:%.*]] = getelementptr inbounds %struct.MyPayload, %struct.MyPayload* [[PAYLOAD]], i32 0, i32 2
+// CHECK: [[I16LOADED:%.*]] = load i16, i16* [[I16]]
+// CHECK: [[I16CONV:%.*]] = sitofp i16 [[I16LOADED]] to float
+
+// float value in 3rd member
+// CHECK: [[FP:%.*]] = getelementptr inbounds %struct.MyPayload, %struct.MyPayload* [[PAYLOAD]], i32 0, i32 3
+// CHECK: [[FPLOADED:%.*]] = load float, float* [[FP]]
+
+
+// Check that these converted values are written out:
+// CHECK: [[F16COERCED:%.*]] = bitcast float [[F16CONV]] to i32
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[ANYRESOURCE:%.*]], i32 [[ANYOFFSET:%.*]], i32 undef, i32 [[F16COERCED]]
+// CHECK: [[U16COERCED:%.*]] = bitcast float [[U16CONV]] to i32
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[ANYRESOURCE:%.*]], i32 [[ANYOFFSET:%.*]], i32 undef, i32 [[U16COERCED]]
+// CHECK: [[I16COERCED:%.*]] = bitcast float [[I16CONV]] to i32
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[ANYRESOURCE:%.*]], i32 [[ANYOFFSET:%.*]], i32 undef, i32 [[I16COERCED]]
+// CHECK: [[FPCOERCED:%.*]] = bitcast float [[FPLOADED]] to i32
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[ANYRESOURCE:%.*]], i32 [[ANYOFFSET:%.*]], i32 undef, i32 [[FPCOERCED]]
+
+struct PSInput
+{
+    float4 position : SV_POSITION;
+};
+
+struct MyPayload
+{
+  half f16;
+  uint16_t u16;
+  int16_t i16;
+  float f;
+};
+
+[outputtopology("triangle")]
+[numthreads(4, 1, 1)]
+void MSMain(
+    in payload MyPayload small,
+    in uint tid : SV_GroupThreadID,
+    out vertices PSInput verts[4],
+    out indices uint3 triangles[2])
+{
+    SetMeshOutputCounts(4, 2);
+    verts[tid].position = float4(small.f16, small.u16, small.i16, small.f);
+    triangles[tid % 2] = uint3(0, tid + 1, tid + 2);
+}

--- a/tools/clang/test/HLSLFileCheck/pix/MSOutputInstrumentationWithoutAS.hlsl
+++ b/tools/clang/test/HLSLFileCheck/pix/MSOutputInstrumentationWithoutAS.hlsl
@@ -1,0 +1,37 @@
+// RUN: %dxc -EMSMain -Tms_6_6 %s | %opt -S -hlsl-dxil-pix-meshshader-output-instrumentation,expand-payload=0,dispatchArgY=3,dispatchArgZ=7,UAVSize=8192 | %FileCheck %s
+
+// Check that the instrumentation calculates the expected "flat" group ID:
+
+// CHECK: [[GROUPIDX:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 0)
+// CHECK: [[GROUPIDY:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 1)
+// CHECK: [[GROUPIDZ:%.*]] = call i32 @dx.op.groupId.i32(i32 94, i32 2)
+
+// The integer literals here come from the dispatchArg* arguments in the command line above
+// CHECK: [[YTIMES7:%.*]] = mul i32 [[GROUPIDY]], 7
+// CHECK: [[ZPLUSYTIMES7:%.*]] = add i32 [[GROUPIDZ]], [[YTIMES7]]
+// CHECK: [[XTIMES21:%.*]] = mul i32 [[GROUPIDX]], 21
+// CHECK: [[FLATID:%.*]] = add i32 [[XTIMES21]], [[ZPLUSYTIMES7]]
+
+// CHECK: call void @dx.op.bufferStore.i32(i32 69, %dx.types.Handle [[SOMERESOURCEHANDLE:%.*]], i32 [[SOMEOFFSET:%.*]], i32 undef, i32 [[FLATID]],
+struct PSInput
+{
+    float4 position : SV_POSITION;
+};
+
+struct MyPayload
+{
+    uint i;
+};
+
+[outputtopology("triangle")]
+[numthreads(4, 1, 1)]
+void MSMain(
+    in payload MyPayload small,
+    in uint tid : SV_GroupThreadID,
+    out vertices PSInput verts[4],
+    out indices uint3 triangles[2])
+{
+    SetMeshOutputCounts(4, 2);
+    verts[tid].position = float4(small.i, 0, 0, 0);
+    triangles[tid % 2] = uint3(0, tid + 1, tid + 2);
+}

--- a/utils/hct/hctdb.py
+++ b/utils/hct/hctdb.py
@@ -6116,6 +6116,8 @@ class db_dxil(object):
             [
                 {"n": "expand-payload", "t": "int", "c": 1},
                 {"n": "UAVSize", "t": "int", "c": 1},
+                {"n": "dispatchArgY", "t": "int", "c": 1},
+                {"n": "dispatchArgZ", "t": "int", "c": 1},
             ],
         )
         add_pass(


### PR DESCRIPTION
PIX requires that all vertex information generated by these passes be uniquely identified by vertex id and MS thread id.
This change fixes the MS thread id part in two places: the amplification shader and the mesh shader.
To be unique across an entire DispatchMesh call, we must uniquify the AS thread group, the AS thread, the MS thread group and the MS thread. This is a lot of multiplying and adding, and there wasn't quite enough math going on here before.
In the AS case, we now generate a unique "flat" thread id from the flat-thread-id-in-group (the already-available system value) and the "flat group id", which we synthesize by multiplying together the group id components with the DispatchMesh API's thread group counts, and then multiplying that by the number of threads each AS group launches, then add the flat-thread-id-in-group. (This flat id then goes into an expanded version of the AS->MS payload, the code for which was pre-existing.)
The MS will either treat the incoming AS thread id as its unique thread-group-within-the-whole-dispatch id.
If the AS is not active, the instrumentation herein will synthesize a flat id in the same way as the AS did before it passed that id through the payload, again from the DispatchMesh parameters (newly-added params to that pass) and the flat-thread-in-group.

In addition to the new filecheck tests for this, there is also a new filecheck test to cover coercion of non-i32 types to i32 before being written to PIX's output UAV, which I happened to notice wasn't adequately tested.