### PR TITLE
Add test to validate that -Qsource_in_debug_module is present in help…

### DIFF
--- a/tools/clang/test/DXC/help_text.test
+++ b/tools/clang/test/DXC/help_text.test
@@ -1,0 +1,7 @@
+// Test /? and /help option
+// RUN: %dxc /? | FileCheck %s
+// RUN: %dxc /help | FileCheck %s
+
+// Test to ensure the help text for '-Qsource_in_debug_module' is present
+// CHECK:-Qsource_in_debug_module
+// CHECK:Embed source code in PDB


### PR DESCRIPTION
This commit adds a new test that validates the help text output contains the -Qsource_in_debug_module option recently enabled by a previous PR #6597 .

This is a follow up commit for Issue: #6028
